### PR TITLE
test: scope internal test fixtures under `@electron-ci`

### DIFF
--- a/spec-main/fixtures/api/native-window-open-native-addon.html
+++ b/spec-main/fixtures/api/native-window-open-native-addon.html
@@ -7,7 +7,7 @@
   let requireError
 
   try {
-    echo = require('@electron/echo')
+    echo = require('@electron-ci/echo')
   } catch (error) {
     requireError = error
   }

--- a/spec-main/fixtures/api/native-window-open-native-addon.html
+++ b/spec-main/fixtures/api/native-window-open-native-addon.html
@@ -7,7 +7,7 @@
   let requireError
 
   try {
-    echo = require('echo')
+    echo = require('@electron/echo')
   } catch (error) {
     requireError = error
   }

--- a/spec-main/fixtures/module/echo-renamed.js
+++ b/spec-main/fixtures/module/echo-renamed.js
@@ -1,6 +1,6 @@
 let echo;
 try {
-  echo = require('echo');
+  echo = require('@electron/echo');
 } catch (e) {
   process.exit(1);
 }

--- a/spec-main/fixtures/module/echo-renamed.js
+++ b/spec-main/fixtures/module/echo-renamed.js
@@ -1,6 +1,6 @@
 let echo;
 try {
-  echo = require('@electron/echo');
+  echo = require('@electron-ci/echo');
 } catch (e) {
   process.exit(1);
 }

--- a/spec-main/fixtures/module/echo.js
+++ b/spec-main/fixtures/module/echo.js
@@ -2,5 +2,5 @@ process.on('uncaughtException', function (err) {
   process.send(err.message);
 });
 
-const echo = require('echo');
+const echo = require('@electron/echo');
 process.send(echo('ok'));

--- a/spec-main/fixtures/module/echo.js
+++ b/spec-main/fixtures/module/echo.js
@@ -2,5 +2,5 @@ process.on('uncaughtException', function (err) {
   process.send(err.message);
 });
 
-const echo = require('@electron/echo');
+const echo = require('@electron-ci/echo');
 process.send(echo('ok'));

--- a/spec-main/fixtures/module/uv-dlopen.js
+++ b/spec-main/fixtures/module/uv-dlopen.js
@@ -1,1 +1,1 @@
-require('uv-dlopen');
+require('@electron/uv-dlopen');

--- a/spec-main/fixtures/module/uv-dlopen.js
+++ b/spec-main/fixtures/module/uv-dlopen.js
@@ -1,1 +1,1 @@
-require('@electron/uv-dlopen');
+require('@electron-ci/uv-dlopen');

--- a/spec-main/fixtures/native-addon/echo/package.json
+++ b/spec-main/fixtures/native-addon/echo/package.json
@@ -1,6 +1,6 @@
 
 {
   "main": "./lib/echo.js",
-  "name": "echo",
+  "name": "@electron/echo",
   "version": "0.0.1"
 }

--- a/spec-main/fixtures/native-addon/echo/package.json
+++ b/spec-main/fixtures/native-addon/echo/package.json
@@ -1,6 +1,5 @@
-
 {
   "main": "./lib/echo.js",
-  "name": "@electron/echo",
+  "name": "@electron-ci/echo",
   "version": "0.0.1"
 }

--- a/spec-main/fixtures/native-addon/uv-dlopen/package.json
+++ b/spec-main/fixtures/native-addon/uv-dlopen/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "uv-dlopen",
+  "name": "@electron/uv-dlopen",
   "version": "0.0.1",
   "main": "index.js"
 }

--- a/spec-main/fixtures/native-addon/uv-dlopen/package.json
+++ b/spec-main/fixtures/native-addon/uv-dlopen/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@electron/uv-dlopen",
+  "name": "@electron-ci/uv-dlopen",
   "version": "0.0.1",
   "main": "index.js"
 }

--- a/spec-main/modules-spec.ts
+++ b/spec-main/modules-spec.ts
@@ -21,7 +21,11 @@ describe('modules support', () => {
       it('can be required in renderer', async () => {
         const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, contextIsolation: false } });
         w.loadURL('about:blank');
-        await expect(w.webContents.executeJavaScript('{ require(\'echo\'); null }')).to.be.fulfilled();
+        await expect(
+          w.webContents.executeJavaScript(
+            "{ require('@electron-ci/echo'); null }"
+          )
+        ).to.be.fulfilled();
       });
 
       ifit(features.isRunAsNodeEnabled())('can be required in node binary', async function () {
@@ -53,7 +57,7 @@ describe('modules support', () => {
       it('can be required in renderer', async () => {
         const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, contextIsolation: false } });
         w.loadURL('about:blank');
-        await expect(w.webContents.executeJavaScript('{ require(\'uv-dlopen\'); null }')).to.be.fulfilled();
+        await expect(w.webContents.executeJavaScript('{ require(\'@electron-ci/uv-dlopen\'); null }')).to.be.fulfilled();
       });
 
       ifit(features.isRunAsNodeEnabled())('can be required in node binary', async function () {

--- a/spec-main/package.json
+++ b/spec-main/package.json
@@ -4,13 +4,13 @@
   "main": "index.js",
   "version": "0.1.0",
   "devDependencies": {
+    "@electron/echo": "file:./fixtures/native-addon/echo",
+    "@electron/uv-dlopen": "file:./fixtures/native-addon/uv-dlopen/",
     "@types/sinon": "^9.0.4",
     "@types/ws": "^7.2.0",
     "busboy": "^0.3.1",
-    "echo": "file:fixtures/native-addon/echo",
     "q": "^1.5.1",
     "sinon": "^9.0.1",
-    "uv-dlopen": "./fixtures/native-addon/uv-dlopen/",
     "ws": "^7.4.6"
   },
   "dependencies": {

--- a/spec-main/package.json
+++ b/spec-main/package.json
@@ -4,8 +4,8 @@
   "main": "index.js",
   "version": "0.1.0",
   "devDependencies": {
-    "@electron/echo": "file:./fixtures/native-addon/echo",
-    "@electron/uv-dlopen": "file:./fixtures/native-addon/uv-dlopen/",
+    "@electron-ci/echo": "file:./fixtures/native-addon/echo",
+    "@electron-ci/uv-dlopen": "file:./fixtures/native-addon/uv-dlopen/",
     "@types/sinon": "^9.0.4",
     "@types/ws": "^7.2.0",
     "busboy": "^0.3.1",

--- a/spec-main/yarn.lock
+++ b/spec-main/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@electron/echo@file:./fixtures/native-addon/echo":
+  version "0.0.1"
+
+"@electron/uv-dlopen@file:./fixtures/native-addon/uv-dlopen":
+  version "0.0.1"
+
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.7.2":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.0.tgz#c8d68821a854c555bba172f3b06959a0039b236d"
@@ -319,9 +325,6 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
-
-"echo@file:fixtures/native-addon/echo":
-  version "0.0.1"
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -948,9 +951,6 @@ uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uv-dlopen@./fixtures/native-addon/uv-dlopen/:
-  version "0.0.1"
 
 verror@1.10.0:
   version "1.10.0"

--- a/spec-main/yarn.lock
+++ b/spec-main/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@electron/echo@file:./fixtures/native-addon/echo":
+"@electron-ci/echo@file:./fixtures/native-addon/echo":
   version "0.0.1"
 
-"@electron/uv-dlopen@file:./fixtures/native-addon/uv-dlopen":
+"@electron-ci/uv-dlopen@file:./fixtures/native-addon/uv-dlopen":
   version "0.0.1"
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.7.2":


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

This PR scopes the internal test fixtures `echo` and `uv-dlopen` under the `@electron` scope.

I understand that these packages are not published and are only fixtures for the test suite. However, it is always a good practice to use scopes that you own to avoid substitution attacks[^1]. This attack was already attempted with `uv-dlopen` and npmjs.com has a security hold on that package name as a result[^2].

I wish to do the same change for other `package.json` files under `spec/fixtures` as well, but thought I'd start small first.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none

[^1]: https://github.blog/2021-02-12-avoiding-npm-substitution-attacks/
[^2]: https://www.npmjs.com/package/uv-dlopen