### PR TITLE
fix: adopt partition alloc early initialization for macOS

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -916,7 +916,10 @@ if (is_mac) {
       assert(defined(invoker.helper_name_suffix))
 
       output_name = electron_helper_name + invoker.helper_name_suffix
-      deps = [ ":electron_framework+link" ]
+      deps = [
+        ":electron_framework+link",
+        "//base/allocator:early_zone_registration_mac",
+      ]
       if (!is_mas_build) {
         deps += [ "//sandbox/mac:seatbelt" ]
       }
@@ -1077,6 +1080,7 @@ if (is_mac) {
       ":electron_app_plist",
       ":electron_app_resources",
       ":electron_fuses",
+      "//base/allocator:early_zone_registration_mac",
       "//electron/buildflags",
     ]
     if (is_mas_build) {

--- a/shell/app/electron_main_mac.cc
+++ b/shell/app/electron_main_mac.cc
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <memory>
 
+#include "base/allocator/early_zone_registration_mac.h"
 #include "electron/buildflags/buildflags.h"
 #include "electron/fuses.h"
 #include "shell/app/electron_library_main.h"
@@ -28,6 +29,7 @@ namespace {
 }  // namespace
 
 int main(int argc, char* argv[]) {
+  partition_alloc::EarlyMallocZoneRegistration();
   FixStdioStreams();
 
 #if BUILDFLAG(ENABLE_RUN_AS_NODE)


### PR DESCRIPTION
#### Description of Change

Refs
https://chromium-review.googlesource.com/c/chromium/src/+/3298858
https://chromium-review.googlesource.com/c/chromium/src/+/3314829

Found when looking into https://bugs.chromium.org/p/chromium/issues/detail?id=1255223

Might address the sqlite crash from https://github.com/electron/electron/issues/32406

#### Release Notes

Notes: fix initialization race when registering partition allocator on macOS