### PR TITLE
chore: cherry-pick b2d3ef69ef99 from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -15,3 +15,4 @@ cherry-pick-26b7ad6967b1.patch
 cherry-pick-a1427aad7cef.patch
 cherry-pick-f599381978f2.patch
 cherry-pick-f546ac11eec7.patch
+cherry-pick-b2d3ef69ef99.patch

--- a/patches/v8/cherry-pick-b2d3ef69ef99.patch
+++ b/patches/v8/cherry-pick-b2d3ef69ef99.patch
@@ -1,0 +1,80 @@
+From b2d3ef69ef992d2dc2f1733e3c17c361357516dd Mon Sep 17 00:00:00 2001
+From: Tobias Tebbi <tebbi@chromium.org>
+Date: Wed, 13 Apr 2022 16:30:36 +0000
+Subject: [PATCH] [M96-LTS][compiler] mark receiver and function as escaping
+
+(cherry picked from commit 8081a5ffa7ebdb0e5b35cf63aa0490ad3578b940)
+
+Bug: chromium:1315901
+No-Try: true
+No-Presubmit: true
+No-Tree-Checks: true
+Change-Id: Ic44bfcae32aba202ba25c5f59fe579214a444584
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3584117
+Commit-Queue: Tobias Tebbi <tebbi@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#79968}
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3584531
+Reviewed-by: Tobias Tebbi <tebbi@chromium.org>
+Reviewed-by: Nico Hartmann <nicohartmann@chromium.org>
+Commit-Queue: Roger Felipe Zanoni da Silva <rzanoni@google.com>
+Cr-Commit-Position: refs/branch-heads/9.6@{#62}
+Cr-Branched-From: 0b7bda016178bf438f09b3c93da572ae3663a1f7-refs/heads/9.6.180@{#1}
+Cr-Branched-From: 41a5a247d9430b953e38631e88d17790306f7a4c-refs/heads/main@{#77244}
+---
+
+diff --git a/src/compiler/escape-analysis.cc b/src/compiler/escape-analysis.cc
+index bf693c7..fe8126f 100644
+--- a/src/compiler/escape-analysis.cc
++++ b/src/compiler/escape-analysis.cc
+@@ -5,10 +5,12 @@
+ #include "src/compiler/escape-analysis.h"
+ 
+ #include "src/codegen/tick-counter.h"
++#include "src/compiler/frame-states.h"
+ #include "src/compiler/linkage.h"
+ #include "src/compiler/node-matchers.h"
+ #include "src/compiler/operator-properties.h"
+ #include "src/compiler/simplified-operator.h"
++#include "src/compiler/state-values-utils.h"
+ #include "src/handles/handles-inl.h"
+ #include "src/init/bootstrapper.h"
+ #include "src/objects/map-inl.h"
+@@ -224,6 +226,11 @@
+       return tracker_->ResolveReplacement(
+           NodeProperties::GetContextInput(current_node()));
+     }
++    // Accessing the current node is fine for `FrameState nodes.
++    Node* CurrentNode() {
++      DCHECK_EQ(current_node()->opcode(), IrOpcode::kFrameState);
++      return current_node();
++    }
+ 
+     void SetReplacement(Node* replacement) {
+       replacement_ = replacement;
+@@ -799,9 +806,25 @@
+       break;
+     }
+     case IrOpcode::kStateValues:
+-    case IrOpcode::kFrameState:
+       // These uses are always safe.
+       break;
++    case IrOpcode::kFrameState: {
++      // We mark the receiver as escaping due to the non-standard `.getThis`
++      // API.
++      FrameState frame_state{current->CurrentNode()};
++      if (frame_state.frame_state_info().type() !=
++          FrameStateType::kUnoptimizedFunction)
++        break;
++      StateValuesAccess::iterator it =
++          StateValuesAccess(frame_state.parameters()).begin();
++      if (!it.done()) {
++        if (Node* receiver = it.node()) {
++          current->SetEscaped(receiver);
++        }
++        current->SetEscaped(frame_state.function());
++      }
++      break;
++    }
+     default: {
+       // For unknown nodes, treat all value inputs as escaping.
+       int value_input_count = op->ValueInputCount();

--- a/patches/v8/cherry-pick-b2d3ef69ef99.patch
+++ b/patches/v8/cherry-pick-b2d3ef69ef99.patch
@@ -1,7 +1,7 @@
-From b2d3ef69ef992d2dc2f1733e3c17c361357516dd Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tobias Tebbi <tebbi@chromium.org>
 Date: Wed, 13 Apr 2022 16:30:36 +0000
-Subject: [PATCH] [M96-LTS][compiler] mark receiver and function as escaping
+Subject: mark receiver and function as escaping
 
 (cherry picked from commit 8081a5ffa7ebdb0e5b35cf63aa0490ad3578b940)
 
@@ -20,10 +20,9 @@ Commit-Queue: Roger Felipe Zanoni da Silva <rzanoni@google.com>
 Cr-Commit-Position: refs/branch-heads/9.6@{#62}
 Cr-Branched-From: 0b7bda016178bf438f09b3c93da572ae3663a1f7-refs/heads/9.6.180@{#1}
 Cr-Branched-From: 41a5a247d9430b953e38631e88d17790306f7a4c-refs/heads/main@{#77244}
----
 
 diff --git a/src/compiler/escape-analysis.cc b/src/compiler/escape-analysis.cc
-index bf693c7..fe8126f 100644
+index bf693c71dc670fdf290c6c5b84012d9965978c69..fe8126f9638e77ef72ddc56c7ae67822786d3020 100644
 --- a/src/compiler/escape-analysis.cc
 +++ b/src/compiler/escape-analysis.cc
 @@ -5,10 +5,12 @@
@@ -39,7 +38,7 @@ index bf693c7..fe8126f 100644
  #include "src/handles/handles-inl.h"
  #include "src/init/bootstrapper.h"
  #include "src/objects/map-inl.h"
-@@ -224,6 +226,11 @@
+@@ -224,6 +226,11 @@ class EscapeAnalysisTracker : public ZoneObject {
        return tracker_->ResolveReplacement(
            NodeProperties::GetContextInput(current_node()));
      }
@@ -51,7 +50,7 @@ index bf693c7..fe8126f 100644
  
      void SetReplacement(Node* replacement) {
        replacement_ = replacement;
-@@ -799,9 +806,25 @@
+@@ -799,9 +806,25 @@ void ReduceNode(const Operator* op, EscapeAnalysisTracker::Scope* current,
        break;
      }
      case IrOpcode::kStateValues:


### PR DESCRIPTION
[M96-LTS][compiler] mark receiver and function as escaping

(cherry picked from commit 8081a5ffa7ebdb0e5b35cf63aa0490ad3578b940)

Bug: chromium:1315901
No-Try: true
No-Presubmit: true
No-Tree-Checks: true
Change-Id: Ic44bfcae32aba202ba25c5f59fe579214a444584
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3584117
Commit-Queue: Tobias Tebbi <tebbi@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#79968}
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3584531
Reviewed-by: Tobias Tebbi <tebbi@chromium.org>
Reviewed-by: Nico Hartmann <nicohartmann@chromium.org>
Commit-Queue: Roger Felipe Zanoni da Silva <rzanoni@google.com>
Cr-Commit-Position: refs/branch-heads/9.6@{#62}
Cr-Branched-From: 0b7bda016178bf438f09b3c93da572ae3663a1f7-refs/heads/9.6.180@{#1}
Cr-Branched-From: 41a5a247d9430b953e38631e88d17790306f7a4c-refs/heads/main@{#77244}


Notes: Backported fix for CVE-2022-1364.