### PR TITLE
fix: include accessibility blink strings

### DIFF
--- a/electron_paks.gni
+++ b/electron_paks.gni
@@ -175,6 +175,7 @@ template("electron_paks") {
     source_patterns = [
       "${root_gen_dir}/chrome/platform_locale_settings_",
       "${root_gen_dir}/components/strings/components_strings_",
+      "${root_gen_dir}/third_party/blink/public/strings/blink_accessibility_strings_",
       "${root_gen_dir}/third_party/blink/public/strings/blink_strings_",
       "${root_gen_dir}/device/bluetooth/strings/bluetooth_strings_",
       "${root_gen_dir}/services/strings/services_strings_",
@@ -188,6 +189,7 @@ template("electron_paks") {
       "//device/bluetooth/strings",
       "//services/strings",
       "//third_party/blink/public/strings",
+      "//third_party/blink/public/strings:accessibility_strings",
       "//ui/strings:app_locale_settings",
       "//ui/strings:ax_strings",
       "//ui/strings:ui_strings",


### PR DESCRIPTION
Backport of #33840

See that PR for details.

Notes: Fixed crash when img without `alt` is shown with accessibility features enabled