### PR TITLE
chore: cherry-pick 1a31e2110440 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -142,3 +142,4 @@ cherry-pick-1665a1d16d46.patch
 use-after-free_of_id_and_idref_attributes.patch
 fix_--without-valid_build.patch
 usb_fix_oob_access_with_non-sequential_interfaces.patch
+cherry-pick-1a31e2110440.patch

--- a/patches/chromium/cherry-pick-1a31e2110440.patch
+++ b/patches/chromium/cherry-pick-1a31e2110440.patch
@@ -1,7 +1,7 @@
-From 1a31e2110440a507ff75e50490ae50a47fdd2a6c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anders Hartvoll Ruud <andruud@chromium.org>
-Date: Tue, 05 Apr 2022 20:44:33 +0000
-Subject: [PATCH] [css-typed-om] Disallow CSS-wide keywords for StylePropertyMap.set
+Date: Tue, 5 Apr 2022 20:44:33 +0000
+Subject: Disallow CSS-wide keywords for StylePropertyMap.set
 
 We don't support this properly, and the spec does not handle CSS-keywords
 either. Disallow it until we can add proper support for this.
@@ -21,13 +21,12 @@ Auto-Submit: Srinivas Sista <srinivassista@chromium.org>
 Commit-Queue: Rune Lillesveen <futhark@chromium.org>
 Cr-Commit-Position: refs/branch-heads/4896@{#1041}
 Cr-Branched-From: 1f63ff4bc27570761b35ffbc7f938f6586f7bee8-refs/heads/main@{#972766}
----
 
 diff --git a/third_party/blink/renderer/build/scripts/core/css/templates/cssom_keywords.cc.tmpl b/third_party/blink/renderer/build/scripts/core/css/templates/cssom_keywords.cc.tmpl
-index 925272d..75597ba 100644
+index 925272d4967a33043cc3a53bd7de448ab03ca805..75597baf3aae8e9a1981153353202fb3e35b7850 100644
 --- a/third_party/blink/renderer/build/scripts/core/css/templates/cssom_keywords.cc.tmpl
 +++ b/third_party/blink/renderer/build/scripts/core/css/templates/cssom_keywords.cc.tmpl
-@@ -20,8 +20,10 @@
+@@ -20,8 +20,10 @@ bool CSSOMKeywords::ValidKeywordForProperty(CSSPropertyID id,
      return false;
    }
  
@@ -42,7 +41,7 @@ index 925272d..75597ba 100644
    {% for property in properties if property.keywordIDs and 'Keyword' in property.typedom_types %}
 diff --git a/third_party/blink/web_tests/external/wpt/css/css-typed-om/set-css-wide-in-custom-property-crash.html b/third_party/blink/web_tests/external/wpt/css/css-typed-om/set-css-wide-in-custom-property-crash.html
 new file mode 100644
-index 0000000..bc977c98
+index 0000000000000000000000000000000000000000..bc977c9889889bd8a35eccc48ac28e25871b1ec9
 --- /dev/null
 +++ b/third_party/blink/web_tests/external/wpt/css/css-typed-om/set-css-wide-in-custom-property-crash.html
 @@ -0,0 +1,15 @@

--- a/patches/chromium/cherry-pick-1a31e2110440.patch
+++ b/patches/chromium/cherry-pick-1a31e2110440.patch
@@ -1,0 +1,63 @@
+From 1a31e2110440a507ff75e50490ae50a47fdd2a6c Mon Sep 17 00:00:00 2001
+From: Anders Hartvoll Ruud <andruud@chromium.org>
+Date: Tue, 05 Apr 2022 20:44:33 +0000
+Subject: [PATCH] [css-typed-om] Disallow CSS-wide keywords for StylePropertyMap.set
+
+We don't support this properly, and the spec does not handle CSS-keywords
+either. Disallow it until we can add proper support for this.
+
+(cherry picked from commit 02e4b18febb37de8baea718bc2f62cfb5fe56e23)
+
+Fixed: 1292905
+Bug: 1310761
+Change-Id: Ieb3d20edfea72c2ccb0928536fdfd86d10aad1a9
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3551609
+Reviewed-by: Rune Lillesveen <futhark@chromium.org>
+Commit-Queue: Anders Hartvoll Ruud <andruud@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#986411}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3572186
+Commit-Queue: Srinivas Sista <srinivassista@chromium.org>
+Auto-Submit: Srinivas Sista <srinivassista@chromium.org>
+Commit-Queue: Rune Lillesveen <futhark@chromium.org>
+Cr-Commit-Position: refs/branch-heads/4896@{#1041}
+Cr-Branched-From: 1f63ff4bc27570761b35ffbc7f938f6586f7bee8-refs/heads/main@{#972766}
+---
+
+diff --git a/third_party/blink/renderer/build/scripts/core/css/templates/cssom_keywords.cc.tmpl b/third_party/blink/renderer/build/scripts/core/css/templates/cssom_keywords.cc.tmpl
+index 925272d..75597ba 100644
+--- a/third_party/blink/renderer/build/scripts/core/css/templates/cssom_keywords.cc.tmpl
++++ b/third_party/blink/renderer/build/scripts/core/css/templates/cssom_keywords.cc.tmpl
+@@ -20,8 +20,10 @@
+     return false;
+   }
+ 
+-  if (css_parsing_utils::IsCSSWideKeyword(valueID))
+-    return true;
++  if (css_parsing_utils::IsCSSWideKeyword(valueID)) {
++    // TODO(crbug.com/1310761): Support CSS-wide keywords in custom props.
++    return id != CSSPropertyID::kVariable;
++  }
+ 
+   switch (id) {
+   {% for property in properties if property.keywordIDs and 'Keyword' in property.typedom_types %}
+diff --git a/third_party/blink/web_tests/external/wpt/css/css-typed-om/set-css-wide-in-custom-property-crash.html b/third_party/blink/web_tests/external/wpt/css/css-typed-om/set-css-wide-in-custom-property-crash.html
+new file mode 100644
+index 0000000..bc977c98
+--- /dev/null
++++ b/third_party/blink/web_tests/external/wpt/css/css-typed-om/set-css-wide-in-custom-property-crash.html
+@@ -0,0 +1,15 @@
++<!DOCTYPE html>
++<title>Don't crash when setting a CSS-wide keyword on a custom property</title>
++<link rel="help" href="https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymap-set">
++<link rel="help" href="https://crbug.com/1310761<">
++<div id="target">
++  Don't crash
++</div>
++<script>
++  for (let keyword of ['initial', 'inherit', 'unset', 'revert', 'revert-layer']) {
++    try {
++      target.attributeStyleMap.set('--x', new CSSKeywordValue(keyword));
++    } catch (e) {
++    }
++  }
++</script>


### PR DESCRIPTION
[css-typed-om] Disallow CSS-wide keywords for StylePropertyMap.set

We don't support this properly, and the spec does not handle CSS-keywords
either. Disallow it until we can add proper support for this.

(cherry picked from commit 02e4b18febb37de8baea718bc2f62cfb5fe56e23)

Fixed: 1292905
Bug: 1310761
Change-Id: Ieb3d20edfea72c2ccb0928536fdfd86d10aad1a9
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3551609
Reviewed-by: Rune Lillesveen <futhark@chromium.org>
Commit-Queue: Anders Hartvoll Ruud <andruud@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#986411}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3572186
Commit-Queue: Srinivas Sista <srinivassista@chromium.org>
Auto-Submit: Srinivas Sista <srinivassista@chromium.org>
Commit-Queue: Rune Lillesveen <futhark@chromium.org>
Cr-Commit-Position: refs/branch-heads/4896@{#1041}
Cr-Branched-From: 1f63ff4bc27570761b35ffbc7f938f6586f7bee8-refs/heads/main@{#972766}


Notes: Backported fix for chromium:1310761.