### PR TITLE
chore: use semantic-commit-action

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,0 +1,20 @@
+name: "Check Semantic Commit"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: semantic-pull-request
+        uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          validateSingleCommit: true

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -17,4 +17,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          validateSingleCommit: true
+          validateSingleCommit: false


### PR DESCRIPTION
#### Description of Change
The semantic commit checker is
[down](https://github.com/zeke/semantic-pull-requests/issues/183), and not for
the first time. Let's switch to using GitHub Actions.

Notes: none
