### PR TITLE
build: use smaller resource_class because goma

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -41,9 +41,8 @@ executors:
     parameters:
       size:
         description: "Docker executor size"
-        default: 2xlarge+
         type: enum
-        enum: ["medium", "xlarge", "2xlarge+"]
+        enum: ["medium", "xlarge", "2xlarge"]
     docker:
       - image: ghcr.io/electron/build:e6bebd08a51a0d78ec23e5b3fd7e7c0846412328
     resource_class: << parameters.size >>
@@ -52,12 +51,11 @@ executors:
     parameters:
       size:
         description: "macOS executor size"
-        default: macos.x86.medium.gen2
         type: enum
         enum: ["macos.x86.medium.gen2", "large"]
       xcode:
         description: "xcode version"
-        default: "12.4.0"
+        default: 13.3.0
         type: enum
         enum: ["12.4.0", "13.3.0"]
 
@@ -1622,7 +1620,9 @@ commands:
 jobs:
   # Layer 0: Docs. Standalone.
   ts-compile-doc-change:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: medium
     environment:
       <<: *env-linux-2xlarge
       <<: *env-testing-build
@@ -1645,32 +1645,10 @@ jobs:
           save-git-cache: true
           checkout-to-create-src-cache: true
 
-  linux-checkout-for-native-tests:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_pyyaml=True'
-    steps:
-      - electron-build:
-          persist: false
-          build: false
-          checkout: true
-          persist-checkout: true
-
-  linux-checkout-for-native-tests-with-no-patches:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      GCLIENT_EXTRA_ARGS: '--custom-var=apply_patches=False --custom-var=checkout_pyyaml=True'
-    steps:
-      - electron-build:
-          persist: false
-          build: false
-          checkout: true
-          persist-checkout: true
-
   mac-checkout:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: xlarge
     environment:
       <<: *env-linux-2xlarge
       <<: *env-testing-build
@@ -1703,7 +1681,9 @@ jobs:
 
   # Layer 2: Builds.
   linux-x64-testing:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: xlarge
     environment:
       <<: *env-global
       <<: *env-testing-build
@@ -1717,7 +1697,9 @@ jobs:
           use-out-cache: false
 
   linux-x64-testing-asan:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-global
       <<: *env-testing-build
@@ -1733,7 +1715,9 @@ jobs:
           build-nonproprietary-ffmpeg: false
 
   linux-x64-testing-no-run-as-node:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: xlarge
     environment:
       <<: *env-linux-2xlarge
       <<: *env-testing-build
@@ -1756,21 +1740,10 @@ jobs:
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
     <<: *steps-electron-gn-check
 
-  linux-x64-release:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge-release
-      <<: *env-release-build
-      <<: *env-send-slack-notifications
-      <<: *env-ninja-status
-      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
-    steps:
-      - electron-build:
-          persist: true
-          checkout: true
-
   linux-x64-publish:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-release-build
@@ -1790,7 +1763,9 @@ jobs:
 
 
   linux-arm-testing:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-global
       <<: *env-arm
@@ -1806,22 +1781,10 @@ jobs:
           checkout-and-assume-cache: true
           use-out-cache: false
 
-  linux-arm-release:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge-release
-      <<: *env-arm
-      <<: *env-release-build
-      <<: *env-send-slack-notifications
-      <<: *env-ninja-status
-      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
-    steps:
-      - electron-build:
-          persist: false
-          checkout: true
-
   linux-arm-publish:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-arm
@@ -1843,7 +1806,9 @@ jobs:
                 checkout: true
 
   linux-arm64-testing:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-global
       <<: *env-arm64
@@ -1870,22 +1835,10 @@ jobs:
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
     <<: *steps-electron-gn-check
 
-  linux-arm64-release:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge-release
-      <<: *env-arm64
-      <<: *env-release-build
-      <<: *env-send-slack-notifications
-      <<: *env-ninja-status
-      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
-    steps:
-      - electron-build:
-          persist: false
-          checkout: true
-
   linux-arm64-publish:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-arm64
@@ -1908,7 +1861,7 @@ jobs:
   osx-testing-x64:
     executor:
       name: macos
-      xcode: "13.3.0"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-testing-build
@@ -1925,7 +1878,7 @@ jobs:
   osx-testing-x64-gn-check:
     executor:
       name: macos
-      xcode: "13.3.0"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-machine-mac
       <<: *env-testing-build
@@ -1935,7 +1888,7 @@ jobs:
   osx-publish-x64-skip-checkout:
     executor:
       name: macos
-      xcode: "13.3.0"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large-release
       <<: *env-release-build
@@ -1956,7 +1909,7 @@ jobs:
   osx-publish-arm64-skip-checkout:
     executor:
       name: macos
-      xcode: "13.3.0"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large-release
       <<: *env-release-build
@@ -1978,7 +1931,7 @@ jobs:
   osx-testing-arm64:
     executor:
       name: macos
-      xcode: "13.3.0"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-testing-build
@@ -1997,7 +1950,7 @@ jobs:
   mas-testing-x64:
     executor:
       name: macos
-      xcode: "13.3.0"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-mas
@@ -2015,7 +1968,7 @@ jobs:
   mas-testing-x64-gn-check:
     executor:
       name: macos
-      xcode: "13.3.0"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-machine-mac
       <<: *env-mas
@@ -2026,7 +1979,7 @@ jobs:
   mas-publish-x64-skip-checkout:
     executor:
       name: macos
-      xcode: "13.3.0"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large-release
       <<: *env-mas
@@ -2047,7 +2000,7 @@ jobs:
   mas-publish-arm64-skip-checkout:
     executor:
       name: macos
-      xcode: "13.3.0"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large-release
       <<: *env-mas-apple-silicon
@@ -2069,7 +2022,7 @@ jobs:
   mas-testing-arm64:
     executor:
       name: macos
-      xcode: "13.3.0"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-testing-build
@@ -2086,41 +2039,6 @@ jobs:
           attach: true
 
   # Layer 3: Tests.
-  linux-x64-unittests:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      <<: *env-unittests
-      <<: *env-headless-testing
-    <<: *steps-native-tests
-
-  linux-x64-disabled-unittests:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      <<: *env-unittests
-      <<: *env-headless-testing
-      TESTS_ARGS: '--only-disabled-tests'
-    <<: *steps-native-tests
-
-  linux-x64-chromium-unittests:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      <<: *env-unittests
-      <<: *env-headless-testing
-      TESTS_ARGS: '--include-disabled-tests'
-    <<: *steps-native-tests
-
-  linux-x64-browsertests:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      <<: *env-browsertests
-      <<: *env-testing-build
-      <<: *env-headless-testing
-    <<: *steps-native-tests
-
   linux-x64-testing-tests:
     executor:
       name: linux-docker
@@ -2156,22 +2074,14 @@ jobs:
     <<: *steps-test-nan
 
   linux-x64-testing-node:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: xlarge
     environment:
       <<: *env-linux-medium
       <<: *env-headless-testing
       <<: *env-stack-dumping
     <<: *steps-test-node
-
-  linux-x64-release-tests:
-    executor:
-      name: linux-docker
-      size: medium
-    environment:
-      <<: *env-linux-medium
-      <<: *env-headless-testing
-      <<: *env-send-slack-notifications
-    <<: *steps-tests
 
   linux-x64-verify-ffmpeg:
     executor:
@@ -2202,7 +2112,10 @@ jobs:
     <<: *steps-tests
 
   osx-testing-x64-tests:
-    executor: macos      
+    executor:
+      name: macos
+      xcode: 12.4.0
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-stack-dumping
@@ -2218,7 +2131,10 @@ jobs:
     <<: *steps-tests
 
   mas-testing-x64-tests:
-    executor: macos
+    executor:
+      name: macos
+      xcode: 12.4.0
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-stack-dumping


### PR DESCRIPTION
As noted in #33904 with Goma and other CI improvements we really don't need to be burning a 20 core machine.  Some super basic testing shows that dropping from the 20 core machine to an 8 core machine _increases_ CI time by ~30-90 seconds, I don't think that is going to be the end of the world for anyone especially when the above mentioned PR speeds CI up by over double that 🤷 

This should drop our linux credit usage by almost ~50% ✨ 🥳 

Changes:
* Testing builds now use 8 core instead of 20 core
* Unused release jobs deleted
* Publish builds now use 16 core instead of 20 core

Notes: no-notes