### PR TITLE
docs: fix return type of setJumpList() in electron.d.ts

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -864,6 +864,8 @@ Returns `Object`:
 
 * `categories` [JumpListCategory[]](structures/jump-list-category.md) | `null` - Array of `JumpListCategory` objects.
 
+Returns `string`
+
 Sets or removes a custom Jump List for the application, and returns one of the
 following strings:
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Before:
```ts
setJumpList(categories: (JumpListCategory[]) | (null)): void;
```

After:
```ts
setJumpList(categories: (JumpListCategory[]) | (null)): ('ok' | 'error' | 'invalidSeparatorError' | 'fileTypeRegistrationError' | 'customCategoryAccessDeniedError');
```

Fixes: https://github.com/electron/electron/issues/33909
Signed-off-by: Darshan Sen <raisinten@gmail.com>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
