### PR TITLE
build: fix macos release GN gen

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1119,7 +1119,7 @@ if (is_mac) {
     }
 
     extract_symbols("egl_syms") {
-      binary = "$root_out_dir/ibEGL.dylib"
+      binary = "$root_out_dir/libEGL.dylib"
       symbol_dir = "$root_out_dir/breakpad_symbols"
       dsym_file = "$root_out_dir/libEGL.dylib.dSYM/Contents/Resources/DWARF/libEGL.dylib"
       deps = [ "//third_party/angle:libEGL" ]


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
- #33731 broke macOS release GN generation due to a typo.  This PR fixes that issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
