### PR TITLE
fix: crash when creating interface for speculative frame

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1506,7 +1506,7 @@ void WebContents::HandleNewRenderFrame(
 
   auto* web_frame = WebFrameMain::FromRenderFrameHost(render_frame_host);
   if (web_frame)
-    web_frame->Connect();
+    web_frame->MaybeSetupMojoConnection();
 }
 
 void WebContents::OnBackgroundColorChanged() {

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -315,7 +315,7 @@ std::vector<content::RenderFrameHost*> WebFrameMain::FramesInSubtree() const {
 }
 
 void WebFrameMain::Connect() {
-  if (pending_receiver_) {
+  if (pending_receiver_ && render_frame_->IsRenderFrameCreated()) {
     render_frame_->GetRemoteInterfaces()->GetInterface(
         std::move(pending_receiver_));
   }

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -103,6 +103,7 @@ void WebFrameMain::UpdateRenderFrameHost(content::RenderFrameHost* rfh) {
   render_frame_disposed_ = false;
   render_frame_ = rfh;
   renderer_api_.reset();
+  pending_receiver_.reset();
   MaybeSetupMojoConnection();
 }
 
@@ -193,7 +194,7 @@ void WebFrameMain::MaybeSetupMojoConnection() {
         &WebFrameMain::OnRendererConnectionError, weak_factory_.GetWeakPtr()));
   }
   // Wait for RenderFrame to be created in renderer before accessing remote.
-  if (pending_receiver_ && render_frame_->IsRenderFrameCreated()) {
+  if (pending_receiver_ && !render_frame_disposed_ && render_frame_->IsRenderFrameCreated()) {
     render_frame_->GetRemoteInterfaces()->GetInterface(
         std::move(pending_receiver_));
   }

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -83,6 +83,7 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
 
   const mojo::Remote<mojom::ElectronRenderer>& GetRendererApi();
   void MaybeSetupMojoConnection();
+  void TeardownMojoConnection();
   void OnRendererConnectionError();
 
   // WebFrameMain can outlive its RenderFrameHost pointer so we need to check

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -82,6 +82,8 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
   void UpdateRenderFrameHost(content::RenderFrameHost* rfh);
 
   const mojo::Remote<mojom::ElectronRenderer>& GetRendererApi();
+  void MaybeSetupMojoConnection();
+  void OnRendererConnectionError();
 
   // WebFrameMain can outlive its RenderFrameHost pointer so we need to check
   // whether its been disposed of prior to accessing it.
@@ -112,8 +114,6 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
   std::vector<content::RenderFrameHost*> Frames() const;
   std::vector<content::RenderFrameHost*> FramesInSubtree() const;
 
-  void OnRendererConnectionError();
-  void Connect();
   void DOMContentLoaded();
 
   mojo::Remote<mojom::ElectronRenderer> renderer_api_;


### PR DESCRIPTION
#### Description of Change

fixes #33880

Speculative render frames are created with pending cross-origin navigation requests. Their RenderFrameHost is not fully active until the navigation is later committed.

There seems to be a crash with our code to handle new RFHs. I've added a check to make sure the RFH has been notified of the RenderFrame being created prior to connecting the WebFrameMain's Mojo interface.

I wasn't able to reproduce the crash in a test.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed potential crash with WebFrameMain when navigating between cross-origin websites.
