### PR TITLE
build: actually verify az urls too

### DIFF
--- a/script/release/release.js
+++ b/script/release/release.js
@@ -81,7 +81,7 @@ async function validateReleaseAssets (release, validatingRelease) {
     const s3RemoteFiles = s3RemoteFilesForVersion(release.tag_name);
     await verifyShasumsForRemoteFiles(s3RemoteFiles, true);
     const azRemoteFiles = azRemoteFilesForVersion(release.tag_name);
-    await verifyShasumsForRemoteFiles(s3RemoteFiles, true);
+    await verifyShasumsForRemoteFiles(azRemoteFiles, true);
   }
 }
 


### PR DESCRIPTION
No idea why the linter didn't warn about the unused variable

Notes: no-notes