### PR TITLE
chore: remove git.io

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -364,7 +364,7 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
     // Don't show title bar.
     [window_ setTitlebarAppearsTransparent:YES];
     [window_ setTitleVisibility:NSWindowTitleHidden];
-    // Remove non-transparent corners, see http://git.io/vfonD.
+    // Remove non-transparent corners, see https://github.com/electron/electron/issues/517.
     [window_ setOpaque:NO];
     // Show window buttons if titleBarStyle is not "normal".
     if (title_bar_style_ == TitleBarStyle::kNormal) {


### PR DESCRIPTION
#### Description of Change

All links on git.io will stop redirecting after April 29, 2022. So I removed it.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added

#### Release Notes

Notes: none
