### PR TITLE
build: ensure sync-done file exists during git cache save

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1413,6 +1413,7 @@ commands:
             - *step-checkout-electron
             - *step-run-electron-only-hooks
             - *step-generate-deps-hash-cleanly
+            - *step-touch-sync-done
             - when:
                 condition: << parameters.save-git-cache >>
                 steps:


### PR DESCRIPTION
There's an edge case where this marker file doesn't exist and therefore the git cache push doesn't work because the cachekey can't be calculated

Notes: no-notes