### PR TITLE
fix: fix FirstPartySetsHandler initialization

### DIFF
--- a/shell/browser/net/system_network_context_manager.cc
+++ b/shell/browser/net/system_network_context_manager.cc
@@ -20,6 +20,7 @@
 #include "components/os_crypt/os_crypt.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/browser_thread.h"
+#include "content/public/browser/first_party_sets_handler.h"
 #include "content/public/browser/network_service_instance.h"
 #include "content/public/common/content_features.h"
 #include "content/public/common/network_service_util.h"
@@ -287,6 +288,11 @@ void SystemNetworkContextManager::OnNetworkServiceCreated(
   content::GetNetworkService()->ConfigureStubHostResolver(
       base::FeatureList::IsEnabled(features::kAsyncDns),
       default_secure_dns_mode, doh_config, additional_dns_query_types_enabled);
+
+  // Initializes first party sets component
+  // CL: https://chromium-review.googlesource.com/c/chromium/src/+/3449280
+  content::FirstPartySetsHandler::GetInstance()->SetPublicFirstPartySets(
+      base::File());
 
   std::string app_name = electron::Browser::Get()->GetName();
 #if BUILDFLAG(IS_MAC)


### PR DESCRIPTION
#### Description of Change

Initialization for FirstPartySets was [removed in a recent Chromium roll](https://github.com/electron/electron/pull/33454/commits/00465d5d62e06e15f84ec42218dbc2c8cbcca691). 

This PR re-adds the FPS initialization, and updates it based on the Chromium updates from that CL.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed the initialization of First Party Sets
