### PR TITLE
build: revert migrate urllib to python3

### DIFF
--- a/script/release/uploaders/upload-index-json.py
+++ b/script/release/uploaders/upload-index-json.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import json
 import os
 import sys
-from urllib.request import Request, urlopen
+import urllib2
 
 sys.path.append(
   os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + "/../.."))
@@ -28,12 +28,12 @@ def is_json(myjson):
 
 def get_content(retry_count = 5):
   try:
-    request = Request(
+    request = urllib2.Request(
       BASE_URL + version,
       headers={"Authorization" : authToken}
     )
 
-    proposed_content = urlopen(
+    proposed_content = urllib2.urlopen(
       request
     ).read()
 


### PR DESCRIPTION
#### Description of Change

After changing our scripts to run on python3 (#33720), we needed to apply a fast follow to urllib to get it working with the new version of python (#33737). However, the python3 migration was only backported through 16-x-y. The urllib fix was backported through 15-x-y. 

This PR reverts the fix (commit a29136950e87a64e69c1e2e8965f7d45acc1a2dc), since 15-x-y is still running python 2 and it does not apply.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
