### PR TITLE
test: allow connections to port 2049

### DIFF
--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -28,6 +28,13 @@ v8.setFlagsFromString('--expose_gc');
 app.commandLine.appendSwitch('js-flags', '--expose_gc');
 app.commandLine.appendSwitch('ignore-certificate-errors');
 app.commandLine.appendSwitch('disable-renderer-backgrounding');
+// Some ports are considered to be "unsafe" by Chromium
+// but Windows on Microsoft-hosted agents sometimes assigns one of them
+// to a Node.js server. Chromium refuses to establish a connection
+// and the whole app crashes with the "Error: net::ERR_UNSAFE_PORT" error.
+// Let's allow connections to those ports to avoid test failures.
+// Use a comma-separated list of ports as a flag value, e.g. "666,667,668".
+app.commandLine.appendSwitch('explicitly-allowed-ports', '2049');
 
 // Disable security warnings (the security warnings test will enable them)
 process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = true;


### PR DESCRIPTION
#### Description of Change
Some ports are considered to be "unsafe" by Chromium, but Windows on Microsoft-hosted agents sometimes assigns one of them to a Node.js server. Chromium refuses to establish a connection and the whole app crashes with the "Error: net::ERR_UNSAFE_PORT" error.

Let's allow connections to those ports to avoid test failures.
Use a comma-separated list of ports as a flag value, e.g. "666,667,668".

https://source.chromium.org/chromium/chromium/src/+/main:net/base/port_util.cc

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
