### PR TITLE
build: use dev-cdn instead of sysroots s3 bucket

### DIFF
--- a/patches/chromium/sysroot.patch
+++ b/patches/chromium/sysroot.patch
@@ -19,8 +19,8 @@ index ada6208644cb22c9f51c571f9509e335c0836163..86b55223fc21adf0e01cb276ebc613f6
  
 -URL_PREFIX = 'https://commondatastorage.googleapis.com'
 -URL_PATH = 'chrome-linux-sysroot/toolchain'
-+URL_PREFIX = 'https://s3.amazonaws.com'
-+URL_PATH = 'electronjs-sysroots/toolchain'
++URL_PREFIX = 'https://dev-cdn.electronjs.org'
++URL_PATH = 'linux-sysroots'
  
  VALID_ARCHS = ('arm', 'arm64', 'i386', 'amd64', 'mips', 'mips64el')
  


### PR DESCRIPTION
Backport of #33922.

See that PR for details.

Notes: no-notes