### PR TITLE
fix: move FirstPartySets initialization into the browser process

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -25,6 +25,7 @@
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/child_process_security_policy.h"
 #include "content/public/browser/device_service.h"
+#include "content/public/browser/first_party_sets_handler.h"
 #include "content/public/browser/web_ui_controller_factory.h"
 #include "content/public/common/content_features.h"
 #include "content/public/common/content_switches.h"
@@ -415,6 +416,11 @@ int ElectronBrowserMainParts::PreMainMessageLoopRun() {
 
   // url::Add*Scheme are not threadsafe, this helps prevent data races.
   url::LockSchemeRegistries();
+
+  // The First-Party Sets feature always expects to be initialized
+  // CL: https://chromium-review.googlesource.com/c/chromium/src/+/3448551
+  content::FirstPartySetsHandler::GetInstance()->SetPublicFirstPartySets(
+      base::File());
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   extensions_client_ = std::make_unique<ElectronExtensionsClient>();

--- a/shell/browser/net/system_network_context_manager.cc
+++ b/shell/browser/net/system_network_context_manager.cc
@@ -20,7 +20,6 @@
 #include "components/os_crypt/os_crypt.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/browser_thread.h"
-#include "content/public/browser/first_party_sets_handler.h"
 #include "content/public/browser/network_service_instance.h"
 #include "content/public/common/content_features.h"
 #include "content/public/common/network_service_util.h"
@@ -288,11 +287,6 @@ void SystemNetworkContextManager::OnNetworkServiceCreated(
   content::GetNetworkService()->ConfigureStubHostResolver(
       base::FeatureList::IsEnabled(features::kAsyncDns),
       default_secure_dns_mode, doh_config, additional_dns_query_types_enabled);
-
-  // Initializes first party sets component
-  // CL: https://chromium-review.googlesource.com/c/chromium/src/+/3449280
-  content::FirstPartySetsHandler::GetInstance()->SetPublicFirstPartySets(
-      base::File());
 
   std::string app_name = electron::Browser::Get()->GetName();
 #if BUILDFLAG(IS_MAC)


### PR DESCRIPTION
#### Description of Change

In this CL, First Party Sets initialization was moved to the [content layer](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/browser_main_loop.cc;l=987-997): https://chromium-review.googlesource.com/c/chromium/src/+/3448551 . We still need to initialize an empty sets file within Electron's equivalent PreMainMessageLoopRun method. However, our First Party Set initialization is currently in the wrong place.

This PR moves Electron's First Party Sets initialization to the PreMainMessageLoopRun method.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed the initialization of first party sets in the browser process.
