### PR TITLE
chore: cherry-pick 5361d836aeb1 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -129,3 +129,4 @@ skia_renderer_use_rectf_intersect_in_applyscissor.patch
 cherry-pick-1a31e2110440.patch
 cherry-pick-5cb934a23ddf.patch
 use_iserrordocument_to_prevent_bfcacheing_of_interstitials_and.patch
+cherry-pick-5361d836aeb1.patch

--- a/patches/chromium/cherry-pick-5361d836aeb1.patch
+++ b/patches/chromium/cherry-pick-5361d836aeb1.patch
@@ -1,7 +1,7 @@
-From 5361d836aeb1bde7fb3ef333209a65b61e1911fe Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Austin Eng <enga@chromium.org>
 Date: Mon, 25 Apr 2022 21:01:40 +0000
-Subject: [PATCH] [M96-LTS] Add bounds check to WebGPUDecoderImpl::DoRequestDevice
+Subject: Add bounds check to WebGPUDecoderImpl::DoRequestDevice
 
 (cherry picked from commit bee4701c99cbbbb25c0bd6c5c79a40f63f1b1e47)
 
@@ -16,13 +16,12 @@ Owners-Override: Achuith Bhandarkar <achuith@chromium.org>
 Commit-Queue: Roger Felipe Zanoni da Silva <rzanoni@google.com>
 Cr-Commit-Position: refs/branch-heads/4664@{#1603}
 Cr-Branched-From: 24dc4ee75e01a29d390d43c9c264372a169273a7-refs/heads/main@{#929512}
----
 
 diff --git a/gpu/command_buffer/service/webgpu_decoder_impl.cc b/gpu/command_buffer/service/webgpu_decoder_impl.cc
-index 201ac917..6a8d143 100644
+index 39f2652a69e3b0e7494c8de3dee5453c4d447941..6879bddb8354e3f57f1431f05f30801e267940f5 100644
 --- a/gpu/command_buffer/service/webgpu_decoder_impl.cc
 +++ b/gpu/command_buffer/service/webgpu_decoder_impl.cc
-@@ -424,11 +424,12 @@
+@@ -423,11 +423,12 @@ class WebGPUDecoderImpl final : public WebGPUDecoder {
  
    int32_t GetPreferredAdapterIndex(PowerPreference power_preference) const;
  
@@ -40,7 +39,7 @@ index 201ac917..6a8d143 100644
    void OnRequestDeviceCallback(DawnRequestDeviceSerial request_device_serial,
                                 size_t requested_adapter_index,
                                 uint32_t device_id,
-@@ -583,16 +584,16 @@
+@@ -582,16 +583,16 @@ ContextResult WebGPUDecoderImpl::Initialize() {
    return ContextResult::kSuccess;
  }
  
@@ -60,9 +59,9 @@ index 201ac917..6a8d143 100644
 +    return error::kOutOfBounds;
 +  }
  
-   dawn_native::DeviceDescriptor device_descriptor;
+   dawn_native::DawnDeviceDescriptor device_descriptor;
    if (request_device_properties.textureCompressionBC) {
-@@ -661,6 +662,8 @@
+@@ -666,6 +667,8 @@ void WebGPUDecoderImpl::DoRequestDevice(
          std::move(*callback).Run(status, wgpu_device, message);
        },
        new CallbackT(std::move(callback)));
@@ -71,7 +70,7 @@ index 201ac917..6a8d143 100644
  }
  
  void WebGPUDecoderImpl::OnRequestDeviceCallback(
-@@ -1071,9 +1074,8 @@
+@@ -1083,9 +1086,8 @@ error::Error WebGPUDecoderImpl::HandleRequestDevice(
      }
    }
  

--- a/patches/chromium/cherry-pick-5361d836aeb1.patch
+++ b/patches/chromium/cherry-pick-5361d836aeb1.patch
@@ -1,0 +1,85 @@
+From 5361d836aeb1bde7fb3ef333209a65b61e1911fe Mon Sep 17 00:00:00 2001
+From: Austin Eng <enga@chromium.org>
+Date: Mon, 25 Apr 2022 21:01:40 +0000
+Subject: [PATCH] [M96-LTS] Add bounds check to WebGPUDecoderImpl::DoRequestDevice
+
+(cherry picked from commit bee4701c99cbbbb25c0bd6c5c79a40f63f1b1e47)
+
+Fixed: chromium:1314754
+Change-Id: Id23af9cc3df08cca3ce7d627e3761c9a65a2c802
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3580555
+Commit-Queue: Austin Eng <enga@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#991510}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3589810
+Reviewed-by: Achuith Bhandarkar <achuith@chromium.org>
+Owners-Override: Achuith Bhandarkar <achuith@chromium.org>
+Commit-Queue: Roger Felipe Zanoni da Silva <rzanoni@google.com>
+Cr-Commit-Position: refs/branch-heads/4664@{#1603}
+Cr-Branched-From: 24dc4ee75e01a29d390d43c9c264372a169273a7-refs/heads/main@{#929512}
+---
+
+diff --git a/gpu/command_buffer/service/webgpu_decoder_impl.cc b/gpu/command_buffer/service/webgpu_decoder_impl.cc
+index 201ac917..6a8d143 100644
+--- a/gpu/command_buffer/service/webgpu_decoder_impl.cc
++++ b/gpu/command_buffer/service/webgpu_decoder_impl.cc
+@@ -424,11 +424,12 @@
+ 
+   int32_t GetPreferredAdapterIndex(PowerPreference power_preference) const;
+ 
+-  void DoRequestDevice(DawnRequestDeviceSerial request_device_serial,
+-                       int32_t requested_adapter_index,
+-                       uint32_t device_id,
+-                       uint32_t device_generation,
+-                       const WGPUDeviceProperties& requested_device_properties);
++  error::Error DoRequestDevice(
++      DawnRequestDeviceSerial request_device_serial,
++      int32_t requested_adapter_index,
++      uint32_t device_id,
++      uint32_t device_generation,
++      const WGPUDeviceProperties& requested_device_properties);
+   void OnRequestDeviceCallback(DawnRequestDeviceSerial request_device_serial,
+                                size_t requested_adapter_index,
+                                uint32_t device_id,
+@@ -583,16 +584,16 @@
+   return ContextResult::kSuccess;
+ }
+ 
+-void WebGPUDecoderImpl::DoRequestDevice(
++error::Error WebGPUDecoderImpl::DoRequestDevice(
+     DawnRequestDeviceSerial request_device_serial,
+     int32_t requested_adapter_index,
+     uint32_t device_id,
+     uint32_t device_generation,
+     const WGPUDeviceProperties& request_device_properties) {
+-  DCHECK_LE(0, requested_adapter_index);
+-
+-  DCHECK_LT(static_cast<size_t>(requested_adapter_index),
+-            dawn_adapters_.size());
++  if (requested_adapter_index < 0 ||
++      static_cast<uint32_t>(requested_adapter_index) >= dawn_adapters_.size()) {
++    return error::kOutOfBounds;
++  }
+ 
+   dawn_native::DeviceDescriptor device_descriptor;
+   if (request_device_properties.textureCompressionBC) {
+@@ -661,6 +662,8 @@
+         std::move(*callback).Run(status, wgpu_device, message);
+       },
+       new CallbackT(std::move(callback)));
++
++  return error::kNoError;
+ }
+ 
+ void WebGPUDecoderImpl::OnRequestDeviceCallback(
+@@ -1071,9 +1074,8 @@
+     }
+   }
+ 
+-  DoRequestDevice(request_device_serial, adapter_service_id, device_id,
+-                  device_generation, device_properties);
+-  return error::kNoError;
++  return DoRequestDevice(request_device_serial, adapter_service_id, device_id,
++                         device_generation, device_properties);
+ }
+ 
+ error::Error WebGPUDecoderImpl::HandleDawnCommands(


### PR DESCRIPTION
[M96-LTS] Add bounds check to WebGPUDecoderImpl::DoRequestDevice

(cherry picked from commit bee4701c99cbbbb25c0bd6c5c79a40f63f1b1e47)

Fixed: chromium:1314754
Change-Id: Id23af9cc3df08cca3ce7d627e3761c9a65a2c802
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3580555
Commit-Queue: Austin Eng <enga@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#991510}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3589810
Reviewed-by: Achuith Bhandarkar <achuith@chromium.org>
Owners-Override: Achuith Bhandarkar <achuith@chromium.org>
Commit-Queue: Roger Felipe Zanoni da Silva <rzanoni@google.com>
Cr-Commit-Position: refs/branch-heads/4664@{#1603}
Cr-Branched-From: 24dc4ee75e01a29d390d43c9c264372a169273a7-refs/heads/main@{#929512}


Notes: Backported fix for CVE-2022-1483.