### PR TITLE
chore: cherry-pick d49484c21e3c from angle

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -8,3 +8,4 @@ m99_vulkan_streamvertexdatawithdivisor_write_beyond_buffer_boundary.patch
 cherry-pick-2b75a29bf241.patch
 m96-lts_fix_base_level_changes_not_updating_fbo_completeness_check.patch
 cherry-pick-d27d9d059b51.patch
+cherry-pick-d49484c21e3c.patch

--- a/patches/angle/cherry-pick-d49484c21e3c.patch
+++ b/patches/angle/cherry-pick-d49484c21e3c.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jamie Madill <jmadill@chromium.org>
+Date: Mon, 11 Apr 2022 12:29:00 -0400
+Subject: Add error check on resuming XFB with deleted buffer.
+
+Bug: chromium:1313905
+Change-Id: I22c6f6400b05ca32c922fba9a3b9d4b5841ca8b8
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3578378
+Auto-Submit: Jamie Madill <jmadill@chromium.org>
+Reviewed-by: Geoff Lang <geofflang@chromium.org>
+Commit-Queue: Jamie Madill <jmadill@chromium.org>
+(cherry picked from commit 5c85fd4e11a3835a0719223a7cedb978d309da21)
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3594103
+Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
+
+diff --git a/src/libANGLE/validationES3.cpp b/src/libANGLE/validationES3.cpp
+index f9dac542366b51c2431885e1bf4fb85040234ca9..608524ad4df85e6fa81def3c4395e437702af990 100644
+--- a/src/libANGLE/validationES3.cpp
++++ b/src/libANGLE/validationES3.cpp
+@@ -4309,6 +4309,13 @@ bool ValidateGetActiveUniformBlockName(const Context *context,
+         return false;
+     }
+ 
++    if (!ValidateProgramExecutableXFBBuffersPresent(context,
++                                                    context->getState().getProgramExecutable()))
++    {
++        context->validationError(GL_INVALID_OPERATION, kTransformFeedbackBufferMissing);
++        return false;
++    }
++
+     return true;
+ }
+ 


### PR DESCRIPTION
[M100] Add error check on resuming XFB with deleted buffer.

Bug: chromium:1313905
Change-Id: I22c6f6400b05ca32c922fba9a3b9d4b5841ca8b8
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3578378
Auto-Submit: Jamie Madill <jmadill@chromium.org>
Reviewed-by: Geoff Lang <geofflang@chromium.org>
Commit-Queue: Jamie Madill <jmadill@chromium.org>
(cherry picked from commit 5c85fd4e11a3835a0719223a7cedb978d309da21)
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3594103
Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>


Notes: Backported fix for CVE-2022-1477.