### PR TITLE
test: fix nativeModulesEnabled in spec/webview-spec.js

### DIFF
--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -7,7 +7,7 @@ const { emittedOnce, waitForEvent } = require('./events-helpers');
 const { ifdescribe, ifit, delay } = require('./spec-helpers');
 
 const features = process._linkedBinding('electron_common_features');
-const nativeModulesEnabled = process.env.ELECTRON_SKIP_NATIVE_MODULE_TESTS;
+const nativeModulesEnabled = !process.env.ELECTRON_SKIP_NATIVE_MODULE_TESTS;
 
 /* Most of the APIs here don't use standard callbacks */
 /* eslint-disable standard/no-callback-literal */


### PR DESCRIPTION
#### Description of Change
The logic was flipped
https://github.com/electron/electron/blob/7dee5179cb0f4a79056204a243aa3317fbe711a6/spec/webview-spec.js#L10

It needs to be
https://github.com/electron/electron/blob/7dee5179cb0f4a79056204a243aa3317fbe711a6/spec-main/modules-spec.ts#L13
https://github.com/electron/electron/blob/7dee5179cb0f4a79056204a243aa3317fbe711a6/spec/static/main.js#L90

Depends on #34026

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none