### PR TITLE
chore: Update ICU to ICU 71-1

### DIFF
--- a/patches/config.json
+++ b/patches/config.json
@@ -5,6 +5,8 @@
 
   "src/electron/patches/devtools_frontend": "src/third_party/devtools-frontend/src",
 
+  "src/electron/patches/icu": "src/third_party/icu",
+
   "src/electron/patches/webrtc": "src/third_party/webrtc",
 
   "src/electron/patches/v8":  "src/v8",

--- a/patches/icu/.patches
+++ b/patches/icu/.patches
@@ -1,0 +1,1 @@
+update_icu_to_icu_71-1.patch


### PR DESCRIPTION
#### Description of Change
Backport: 3579992: Update ICU to ICU 71-1 | https://chromium-review.googlesource.com/c/chromium/deps/icu/+/3579992

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Updated ICU timezone data to 2022a.