### PR TITLE
build: use smaller resource_class because goma

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -41,9 +41,8 @@ executors:
     parameters:
       size:
         description: "Docker executor size"
-        default: 2xlarge+
         type: enum
-        enum: ["medium", "xlarge", "2xlarge+"]
+        enum: ["medium", "xlarge", "2xlarge"]
     docker:
       - image: ghcr.io/electron/build:e6bebd08a51a0d78ec23e5b3fd7e7c0846412328
     resource_class: << parameters.size >>
@@ -52,12 +51,11 @@ executors:
     parameters:
       size:
         description: "macOS executor size"
-        default: macos.x86.medium.gen2
         type: enum
         enum: ["macos.x86.medium.gen2", "large"]
       xcode:
         description: "xcode version"
-        default: "12.4.0"
+        default: 13.2.1
         type: enum
         enum: ["12.4.0", "13.2.1"]
 
@@ -1630,32 +1628,10 @@ jobs:
           save-git-cache: true
           checkout-to-create-src-cache: true
 
-  linux-checkout-for-native-tests:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_pyyaml=True'
-    steps:
-      - electron-build:
-          persist: false
-          build: false
-          checkout: true
-          persist-checkout: true
-
-  linux-checkout-for-native-tests-with-no-patches:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      GCLIENT_EXTRA_ARGS: '--custom-var=apply_patches=False --custom-var=checkout_pyyaml=True'
-    steps:
-      - electron-build:
-          persist: false
-          build: false
-          checkout: true
-          persist-checkout: true
-
   mac-checkout:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: xlarge
     environment:
       <<: *env-linux-2xlarge
       <<: *env-testing-build
@@ -1688,7 +1664,9 @@ jobs:
 
   # Layer 2: Builds.
   linux-x64-testing:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: xlarge
     environment:
       <<: *env-global
       <<: *env-testing-build
@@ -1702,7 +1680,9 @@ jobs:
           use-out-cache: false
 
   linux-x64-testing-asan:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-global
       <<: *env-testing-build
@@ -1718,7 +1698,9 @@ jobs:
           build-nonproprietary-ffmpeg: false
 
   linux-x64-testing-no-run-as-node:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: xlarge
     environment:
       <<: *env-linux-2xlarge
       <<: *env-testing-build
@@ -1741,21 +1723,10 @@ jobs:
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
     <<: *steps-electron-gn-check
 
-  linux-x64-release:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge-release
-      <<: *env-release-build
-      <<: *env-send-slack-notifications
-      <<: *env-ninja-status
-      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
-    steps:
-      - electron-build:
-          persist: true
-          checkout: true
-
   linux-x64-publish:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-release-build
@@ -1774,7 +1745,9 @@ jobs:
                 checkout: true
 
   linux-ia32-testing:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: xlarge
     environment:
       <<: *env-global
       <<: *env-ia32
@@ -1787,22 +1760,10 @@ jobs:
           checkout: true
           use-out-cache: false
 
-  linux-ia32-release:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge-release
-      <<: *env-ia32
-      <<: *env-release-build
-      <<: *env-send-slack-notifications
-      <<: *env-ninja-status
-      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
-    steps:
-      - electron-build:
-          persist: true
-          checkout: true
-
   linux-ia32-publish:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-ia32
@@ -1823,7 +1784,9 @@ jobs:
                 checkout: true
 
   linux-arm-testing:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-global
       <<: *env-arm
@@ -1839,22 +1802,10 @@ jobs:
           checkout-and-assume-cache: true
           use-out-cache: false
 
-  linux-arm-release:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge-release
-      <<: *env-arm
-      <<: *env-release-build
-      <<: *env-send-slack-notifications
-      <<: *env-ninja-status
-      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
-    steps:
-      - electron-build:
-          persist: false
-          checkout: true
-
   linux-arm-publish:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-arm
@@ -1876,7 +1827,9 @@ jobs:
                 checkout: true
 
   linux-arm64-testing:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-global
       <<: *env-arm64
@@ -1903,22 +1856,10 @@ jobs:
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
     <<: *steps-electron-gn-check
 
-  linux-arm64-release:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge-release
-      <<: *env-arm64
-      <<: *env-release-build
-      <<: *env-send-slack-notifications
-      <<: *env-ninja-status
-      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
-    steps:
-      - electron-build:
-          persist: false
-          checkout: true
-
   linux-arm64-publish:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-arm64
@@ -1941,7 +1882,7 @@ jobs:
   osx-testing-x64:
     executor:
       name: macos
-      xcode: "13.2.1"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-testing-build
@@ -1958,7 +1899,7 @@ jobs:
   osx-testing-x64-gn-check:
     executor:
       name: macos
-      xcode: "13.2.1"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-machine-mac
       <<: *env-testing-build
@@ -1968,7 +1909,7 @@ jobs:
   osx-publish-x64-skip-checkout:
     executor:
       name: macos
-      xcode: "13.2.1"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large-release
       <<: *env-release-build
@@ -1989,7 +1930,7 @@ jobs:
   osx-publish-arm64-skip-checkout:
     executor:
       name: macos
-      xcode: "13.2.1"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large-release
       <<: *env-release-build
@@ -2011,7 +1952,7 @@ jobs:
   osx-testing-arm64:
     executor:
       name: macos
-      xcode: "13.2.1"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-testing-build
@@ -2030,7 +1971,7 @@ jobs:
   mas-testing-x64:
     executor:
       name: macos
-      xcode: "13.2.1"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-mas
@@ -2048,7 +1989,7 @@ jobs:
   mas-testing-x64-gn-check:
     executor:
       name: macos
-      xcode: "13.2.1"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-machine-mac
       <<: *env-mas
@@ -2059,7 +2000,7 @@ jobs:
   mas-publish-x64-skip-checkout:
     executor:
       name: macos
-      xcode: "13.2.1"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large-release
       <<: *env-mas
@@ -2080,7 +2021,7 @@ jobs:
   mas-publish-arm64-skip-checkout:
     executor:
       name: macos
-      xcode: "13.2.1"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large-release
       <<: *env-mas-apple-silicon
@@ -2102,7 +2043,7 @@ jobs:
   mas-testing-arm64:
     executor:
       name: macos
-      xcode: "13.2.1"
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-testing-build
@@ -2119,41 +2060,6 @@ jobs:
           attach: true
 
   # Layer 3: Tests.
-  linux-x64-unittests:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      <<: *env-unittests
-      <<: *env-headless-testing
-    <<: *steps-native-tests
-
-  linux-x64-disabled-unittests:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      <<: *env-unittests
-      <<: *env-headless-testing
-      TESTS_ARGS: '--only-disabled-tests'
-    <<: *steps-native-tests
-
-  linux-x64-chromium-unittests:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      <<: *env-unittests
-      <<: *env-headless-testing
-      TESTS_ARGS: '--include-disabled-tests'
-    <<: *steps-native-tests
-
-  linux-x64-browsertests:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      <<: *env-browsertests
-      <<: *env-testing-build
-      <<: *env-headless-testing
-    <<: *steps-native-tests
-
   linux-x64-testing-tests:
     executor:
       name: linux-docker
@@ -2189,22 +2095,14 @@ jobs:
     <<: *steps-test-nan
 
   linux-x64-testing-node:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: xlarge
     environment:
       <<: *env-linux-medium
       <<: *env-headless-testing
       <<: *env-stack-dumping
     <<: *steps-test-node
-
-  linux-x64-release-tests:
-    executor:
-      name: linux-docker
-      size: medium
-    environment:
-      <<: *env-linux-medium
-      <<: *env-headless-testing
-      <<: *env-send-slack-notifications
-    <<: *steps-tests
 
   linux-x64-verify-ffmpeg:
     executor:
@@ -2240,24 +2138,15 @@ jobs:
     <<: *steps-test-nan
 
   linux-ia32-testing-node:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: xlarge
     environment:
       <<: *env-linux-medium
       <<: *env-ia32
       <<: *env-headless-testing
       <<: *env-stack-dumping
     <<: *steps-test-node
-
-  linux-ia32-release-tests:
-    executor:
-      name: linux-docker
-      size: medium
-    environment:
-      <<: *env-linux-medium
-      <<: *env-ia32
-      <<: *env-headless-testing
-      <<: *env-send-slack-notifications
-    <<: *steps-tests
 
   linux-ia32-verify-ffmpeg:
     executor:
@@ -2289,7 +2178,10 @@ jobs:
     <<: *steps-tests
 
   osx-testing-x64-tests:
-    executor: macos      
+    executor:
+      name: macos
+      xcode: 12.4.0
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-stack-dumping
@@ -2305,7 +2197,10 @@ jobs:
     <<: *steps-tests
 
   mas-testing-x64-tests:
-    executor: macos
+    executor:
+      name: macos
+      xcode: 12.4.0
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-stack-dumping


### PR DESCRIPTION
Backport of #33905.

See that PR for details.

Notes: no-notes