### PR TITLE
chore: cherry-pick d24570fb65 from angle

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -1,0 +1,1 @@
+m100_fix_crash_when_pausing_xfb_then_deleting_a_buffer.patch

--- a/patches/angle/m100_fix_crash_when_pausing_xfb_then_deleting_a_buffer.patch
+++ b/patches/angle/m100_fix_crash_when_pausing_xfb_then_deleting_a_buffer.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jamie Madill <jmadill@chromium.org>
+Date: Mon, 14 Mar 2022 10:37:31 -0400
+Subject: [M100] Fix crash when pausing XFB then deleting a buffer.
+
+Fix is to validate XFB buffer bindings even if we're paused.
+This is undefined behaviour so we can use any non-crashing solution.
+
+Bug: chromium:1305190
+Change-Id: Ib95404cdb13adbde7f34d6cc77473a8b3cbf1de7
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3522283
+Reviewed-by: Geoff Lang <geofflang@chromium.org>
+Commit-Queue: Jamie Madill <jmadill@chromium.org>
+(cherry picked from commit 708ce9cfd63bc8eab7c48987612a2dedce78c69a)
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3594105
+Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
+
+diff --git a/src/libANGLE/validationES.cpp b/src/libANGLE/validationES.cpp
+index e0281742d46d709f5f20a9d472256c5e475b627a..4cd36918f485f51cef2d6532a90bb8583b2861ab 100644
+--- a/src/libANGLE/validationES.cpp
++++ b/src/libANGLE/validationES.cpp
+@@ -4087,7 +4087,7 @@ const char *ValidateDrawStates(const Context *context)
+                 }
+             }
+ 
+-            if (state.isTransformFeedbackActiveUnpaused())
++            if (state.isTransformFeedbackActive())
+             {
+                 if (!ValidateProgramExecutableXFBBuffersPresent(context, executable))
+                 {
+diff --git a/src/tests/gl_tests/TransformFeedbackTest.cpp b/src/tests/gl_tests/TransformFeedbackTest.cpp
+index c93cd02406390471f24005b61c7cf3e4703700a9..d495f8bf7ffe917cc6722a05c92ac2fa71d0376b 100644
+--- a/src/tests/gl_tests/TransformFeedbackTest.cpp
++++ b/src/tests/gl_tests/TransformFeedbackTest.cpp
+@@ -3902,6 +3902,25 @@ void main()
+     EXPECT_GL_NO_ERROR();
+ }
+ 
++// Same as the above, with a paused transform feedback.
++TEST_P(TransformFeedbackTest, DeletePausedTransformFeedbackBuffer)
++{
++    ANGLE_GL_PROGRAM_TRANSFORM_FEEDBACK(testProgram, essl1_shaders::vs::Simple(),
++                                        essl1_shaders::fs::Green(), {"gl_Position"},
++                                        GL_INTERLEAVED_ATTRIBS);
++    glUseProgram(testProgram);
++
++    GLBuffer buffer;
++    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, buffer);
++    glBufferData(GL_PIXEL_UNPACK_BUFFER, 3, nullptr, GL_STATIC_DRAW);
++    glBindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, 0, buffer);
++
++    glBeginTransformFeedback(GL_POINTS);
++    glPauseTransformFeedback();
++    buffer.reset();
++    glDrawArrays(GL_POINTS, 0, 1);
++}
++
+ GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(TransformFeedbackTest);
+ ANGLE_INSTANTIATE_TEST_ES3(TransformFeedbackTest);
+ 

--- a/patches/angle/m100_fix_crash_when_pausing_xfb_then_deleting_a_buffer.patch
+++ b/patches/angle/m100_fix_crash_when_pausing_xfb_then_deleting_a_buffer.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jamie Madill <jmadill@chromium.org>
 Date: Mon, 14 Mar 2022 10:37:31 -0400
-Subject: [M100] Fix crash when pausing XFB then deleting a buffer.
+Subject: Fix crash when pausing XFB then deleting a buffer.
 
 Fix is to validate XFB buffer bindings even if we're paused.
 This is undefined behaviour so we can use any non-crashing solution.

--- a/patches/config.json
+++ b/patches/config.json
@@ -15,5 +15,7 @@
 
   "src/electron/patches/Mantle": "src/third_party/squirrel.mac/vendor/Mantle",
 
-  "src/electron/patches/ReactiveObjC": "src/third_party/squirrel.mac/vendor/ReactiveObjC"
+  "src/electron/patches/ReactiveObjC": "src/third_party/squirrel.mac/vendor/ReactiveObjC",
+
+  "src/electron/patches/angle": "src/third_party/angle"
 }


### PR DESCRIPTION
[M100] Fix crash when pausing XFB then deleting a buffer.

Fix is to validate XFB buffer bindings even if we're paused.
This is undefined behaviour so we can use any non-crashing solution.

Bug: [chromium:1305190](https://bugs.chromium.org/p/chromium/issues/detail?id=1305190)
Change-Id: [Ib95404cdb13adbde7f34d6cc77473a8b3cbf1de7](https://chromium-review.googlesource.com/q/Ib95404cdb13adbde7f34d6cc77473a8b3cbf1de7)
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3522283
Reviewed-by: Geoff Lang <[geofflang@chromium.org](mailto:geofflang@chromium.org)>
Commit-Queue: Jamie Madill <[jmadill@chromium.org](mailto:jmadill@chromium.org)>
(cherry picked from [commit 708ce9cfd63bc8eab7c48987612a2dedce78c69a](https://chromium-review.googlesource.com/q/commit:708ce9cfd63bc8eab7c48987612a2dedce78c69a))
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3594105
Reviewed-by: Shahbaz Youssefi <[syoussefi@chromium.org](mailto:syoussefi@chromium.org)>

Notes: Backported fix for CVE-2022-1479.
