### PR TITLE
build: use smaller resource_class because goma

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -41,9 +41,8 @@ executors:
     parameters:
       size:
         description: "Docker executor size"
-        default: 2xlarge+
         type: enum
-        enum: ["medium", "xlarge", "2xlarge+"]
+        enum: ["medium", "xlarge", "2xlarge"]
     docker:
       - image: ghcr.io/electron/build:27db4a3e3512bfd2e47f58cea69922da0835f1d9
     resource_class: << parameters.size >>
@@ -52,9 +51,8 @@ executors:
     parameters:
       size:
         description: "macOS executor size"
-        default: large
         type: enum
-        enum: ["medium", "large"]
+        enum: ["macos.x86.medium.gen2", "large"]
     macos:
       xcode: "12.4.0"
     resource_class: << parameters.size >>
@@ -1621,32 +1619,10 @@ jobs:
           save-git-cache: true
           checkout-to-create-src-cache: true
 
-  linux-checkout-for-native-tests:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_pyyaml=True'
-    steps:
-      - electron-build:
-          persist: false
-          build: false
-          checkout: true
-          persist-checkout: true
-
-  linux-checkout-for-native-tests-with-no-patches:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      GCLIENT_EXTRA_ARGS: '--custom-var=apply_patches=False --custom-var=checkout_pyyaml=True'
-    steps:
-      - electron-build:
-          persist: false
-          build: false
-          checkout: true
-          persist-checkout: true
-
   mac-checkout:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: xlarge
     environment:
       <<: *env-linux-2xlarge
       <<: *env-testing-build
@@ -1679,7 +1655,9 @@ jobs:
 
   # Layer 2: Builds.
   linux-x64-testing:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: xlarge
     environment:
       <<: *env-global
       <<: *env-testing-build
@@ -1693,7 +1671,9 @@ jobs:
           use-out-cache: false
 
   linux-x64-testing-asan:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-global
       <<: *env-testing-build
@@ -1709,7 +1689,9 @@ jobs:
           build-nonproprietary-ffmpeg: false
 
   linux-x64-testing-no-run-as-node:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: xlarge
     environment:
       <<: *env-linux-2xlarge
       <<: *env-testing-build
@@ -1732,21 +1714,10 @@ jobs:
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
     <<: *steps-electron-gn-check
 
-  linux-x64-release:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge-release
-      <<: *env-release-build
-      <<: *env-send-slack-notifications
-      <<: *env-ninja-status
-      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
-    steps:
-      - electron-build:
-          persist: true
-          checkout: true
-
   linux-x64-publish:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-release-build
@@ -1765,7 +1736,9 @@ jobs:
                 checkout: true
 
   linux-ia32-testing:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: xlarge
     environment:
       <<: *env-global
       <<: *env-ia32
@@ -1778,22 +1751,10 @@ jobs:
           checkout: true
           use-out-cache: false
 
-  linux-ia32-release:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge-release
-      <<: *env-ia32
-      <<: *env-release-build
-      <<: *env-send-slack-notifications
-      <<: *env-ninja-status
-      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
-    steps:
-      - electron-build:
-          persist: true
-          checkout: true
-
   linux-ia32-publish:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-ia32
@@ -1814,7 +1775,9 @@ jobs:
                 checkout: true
 
   linux-arm-testing:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-global
       <<: *env-arm
@@ -1830,22 +1793,10 @@ jobs:
           checkout-and-assume-cache: true
           use-out-cache: false
 
-  linux-arm-release:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge-release
-      <<: *env-arm
-      <<: *env-release-build
-      <<: *env-send-slack-notifications
-      <<: *env-ninja-status
-      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
-    steps:
-      - electron-build:
-          persist: false
-          checkout: true
-
   linux-arm-publish:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-arm
@@ -1867,7 +1818,9 @@ jobs:
                 checkout: true
 
   linux-arm64-testing:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-global
       <<: *env-arm64
@@ -1894,22 +1847,10 @@ jobs:
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
     <<: *steps-electron-gn-check
 
-  linux-arm64-release:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge-release
-      <<: *env-arm64
-      <<: *env-release-build
-      <<: *env-send-slack-notifications
-      <<: *env-ninja-status
-      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
-    steps:
-      - electron-build:
-          persist: false
-          checkout: true
-
   linux-arm64-publish:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: 2xlarge
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-arm64
@@ -1930,7 +1871,9 @@ jobs:
                 checkout: true
 
   osx-testing-x64:
-    executor: macos
+    executor:
+      name: macos
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-testing-build
@@ -1947,7 +1890,7 @@ jobs:
   osx-testing-x64-gn-check:
     executor:
       name: macos
-      size: medium
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-machine-mac
       <<: *env-testing-build
@@ -1955,7 +1898,9 @@ jobs:
     <<: *steps-electron-gn-check
 
   osx-publish-x64-skip-checkout:
-    executor: macos
+    executor:
+      name: macos
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large-release
       <<: *env-release-build
@@ -1974,7 +1919,9 @@ jobs:
                 checkout: false
 
   osx-publish-arm64-skip-checkout:
-    executor: macos
+    executor:
+      name: macos
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large-release
       <<: *env-release-build
@@ -1994,7 +1941,9 @@ jobs:
                 checkout: false
 
   osx-testing-arm64:
-    executor: macos
+    executor:
+      name: macos
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-testing-build
@@ -2011,7 +1960,9 @@ jobs:
           attach: true
 
   mas-testing-x64:
-    executor: macos
+    executor:
+      name: macos
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-mas
@@ -2029,7 +1980,7 @@ jobs:
   mas-testing-x64-gn-check:
     executor:
       name: macos
-      size: medium
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-machine-mac
       <<: *env-mas
@@ -2038,7 +1989,9 @@ jobs:
     <<: *steps-electron-gn-check
 
   mas-publish-x64-skip-checkout:
-    executor: macos
+    executor:
+      name: macos
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large-release
       <<: *env-mas
@@ -2057,7 +2010,9 @@ jobs:
                 checkout: false
 
   mas-publish-arm64-skip-checkout:
-    executor: macos
+    executor:
+      name: macos
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large-release
       <<: *env-mas-apple-silicon
@@ -2077,7 +2032,9 @@ jobs:
                 checkout: false
 
   mas-testing-arm64:
-    executor: macos
+    executor:
+      name: macos
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-testing-build
@@ -2094,41 +2051,6 @@ jobs:
           attach: true
 
   # Layer 3: Tests.
-  linux-x64-unittests:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      <<: *env-unittests
-      <<: *env-headless-testing
-    <<: *steps-native-tests
-
-  linux-x64-disabled-unittests:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      <<: *env-unittests
-      <<: *env-headless-testing
-      TESTS_ARGS: '--only-disabled-tests'
-    <<: *steps-native-tests
-
-  linux-x64-chromium-unittests:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      <<: *env-unittests
-      <<: *env-headless-testing
-      TESTS_ARGS: '--include-disabled-tests'
-    <<: *steps-native-tests
-
-  linux-x64-browsertests:
-    executor: linux-docker
-    environment:
-      <<: *env-linux-2xlarge
-      <<: *env-browsertests
-      <<: *env-testing-build
-      <<: *env-headless-testing
-    <<: *steps-native-tests
-
   linux-x64-testing-tests:
     executor:
       name: linux-docker
@@ -2164,22 +2086,14 @@ jobs:
     <<: *steps-test-nan
 
   linux-x64-testing-node:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: xlarge
     environment:
       <<: *env-linux-medium
       <<: *env-headless-testing
       <<: *env-stack-dumping
     <<: *steps-test-node
-
-  linux-x64-release-tests:
-    executor:
-      name: linux-docker
-      size: medium
-    environment:
-      <<: *env-linux-medium
-      <<: *env-headless-testing
-      <<: *env-send-slack-notifications
-    <<: *steps-tests
 
   linux-x64-verify-ffmpeg:
     executor:
@@ -2215,24 +2129,15 @@ jobs:
     <<: *steps-test-nan
 
   linux-ia32-testing-node:
-    executor: linux-docker
+    executor:
+      name: linux-docker
+      size: xlarge
     environment:
       <<: *env-linux-medium
       <<: *env-ia32
       <<: *env-headless-testing
       <<: *env-stack-dumping
     <<: *steps-test-node
-
-  linux-ia32-release-tests:
-    executor:
-      name: linux-docker
-      size: medium
-    environment:
-      <<: *env-linux-medium
-      <<: *env-ia32
-      <<: *env-headless-testing
-      <<: *env-send-slack-notifications
-    <<: *steps-tests
 
   linux-ia32-verify-ffmpeg:
     executor:
@@ -2266,7 +2171,7 @@ jobs:
   osx-testing-x64-tests:
     executor:
       name: macos
-      size: medium
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-stack-dumping
@@ -2284,7 +2189,7 @@ jobs:
   mas-testing-x64-tests:
     executor:
       name: macos
-      size: medium
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-stack-dumping


### PR DESCRIPTION
Backport of #33905.

See that PR for details.

Notes: no-notes