### PR TITLE
fix: prevent `SetLoginItemSettings()` from mounting volumes

### DIFF
--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -318,26 +318,32 @@ Browser::LoginItemSettings Browser::GetLoginItemSettings(
   return settings;
 }
 
+// Some logic here copied from GetLoginItemForApp in base/mac/mac_util.mm
 void RemoveFromLoginItems() {
 #pragma clang diagnostic push  // https://crbug.com/1154377
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  // logic to find the login item copied from GetLoginItemForApp in
-  // base/mac/mac_util.mm
   base::ScopedCFTypeRef<LSSharedFileListRef> login_items(
       LSSharedFileListCreate(NULL, kLSSharedFileListSessionLoginItems, NULL));
   if (!login_items.get()) {
     LOG(ERROR) << "Couldn't get a Login Items list.";
     return;
   }
+
   base::scoped_nsobject<NSArray> login_items_array(
       base::mac::CFToNSCast(LSSharedFileListCopySnapshot(login_items, NULL)));
   NSURL* url = [NSURL fileURLWithPath:[base::mac::MainBundle() bundlePath]];
-  for (NSUInteger i = 0; i < [login_items_array count]; ++i) {
+  for (id login_item in login_items_array.get()) {
     LSSharedFileListItemRef item =
-        reinterpret_cast<LSSharedFileListItemRef>(login_items_array[i]);
+        reinterpret_cast<LSSharedFileListItemRef>(login_item);
+
+    // kLSSharedFileListDoNotMountVolumes is used so that we don't trigger
+    // mounting when it's not expected by a user. Just listing the login
+    // items should not cause any side-effects.
     base::ScopedCFTypeRef<CFErrorRef> error;
-    CFURLRef item_url_ref =
-        LSSharedFileListItemCopyResolvedURL(item, 0, error.InitializeInto());
+    base::ScopedCFTypeRef<CFURLRef> item_url_ref(
+        LSSharedFileListItemCopyResolvedURL(
+            item, kLSSharedFileListDoNotMountVolumes, error.InitializeInto()));
+
     if (!error && item_url_ref) {
       base::ScopedCFTypeRef<CFURLRef> item_url(item_url_ref);
       if (CFEqual(item_url, url)) {


### PR DESCRIPTION
#### Description of Change

Update `SetLoginItemSettings` to include CL:964074. From the CL:

> If a user has a network volumes listed in login items, calling
LSSharedFileListItemCopyResolvedURL() will cause an attempt to mount
those volumes. This is confusing behavior because it is not relevant to
the user's action (which is likely installing PWA or Chrome extension
with a background page). Also the name "GetLoginFileList" doesn't
indicate there is any such side-effect expected. Using kLSSharedFileListDoNotMountVolumes flag will prevent this
behavior.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where calling `SetLoginItemSettings()` could potentially cause network volumes to be incorrectly mounted.
