### PR TITLE
build: fix run-clang-format extension matching

### DIFF
--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -55,8 +55,7 @@ def list_files(files, recursive=False, extensions=None, exclude=None):
                         x for x in fpaths if not fnmatch.fnmatch(x, pattern)
                     ]
                 for fp in fpaths:
-                    ext = os.path.splitext(f)[1][1:]
-                    print(ext)
+                    ext = os.path.splitext(fp)[1][1:]
                     if ext in extensions:
                         out.append(fp)
         else:


### PR DESCRIPTION
#### Description of Change
run-clang-format was excluding all files?

Notes: none
