### PR TITLE
chore: stop using v8::Locker everywhere

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -802,7 +802,6 @@ bool App::CanCreateWindow(
     bool opener_suppressed,
     bool* no_javascript_access) {
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-  v8::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
   content::WebContents* web_contents =
       content::WebContents::FromRenderFrameHost(opener);
@@ -828,7 +827,6 @@ void App::AllowCertificateError(
     base::OnceCallback<void(content::CertificateRequestResultType)> callback) {
   auto adapted_callback = base::AdaptCallbackForRepeating(std::move(callback));
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-  v8::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
   bool prevent_default = Emit(
       "certificate-error", WebContents::FromOrCreate(isolate, web_contents),
@@ -1086,7 +1084,6 @@ std::string App::GetLocaleCountryCode() {
 void App::OnFirstInstanceAck(
     const base::span<const uint8_t>* first_instance_data) {
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-  v8::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
   base::Value data_to_send;
   if (first_instance_data) {
@@ -1120,7 +1117,6 @@ void App::OnSecondInstance(
     const std::vector<uint8_t> additional_data,
     const ProcessSingleton::NotificationAckCallback& ack_callback) {
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-  v8::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Value> data_value =
       DeserializeV8Value(isolate, std::move(additional_data));

--- a/shell/browser/api/electron_api_auto_updater.cc
+++ b/shell/browser/api/electron_api_auto_updater.cc
@@ -32,7 +32,6 @@ AutoUpdater::~AutoUpdater() {
 
 void AutoUpdater::OnError(const std::string& message) {
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-  v8::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Object> wrapper;
   if (GetWrapper(isolate).ToLocal(&wrapper)) {
@@ -49,7 +48,6 @@ void AutoUpdater::OnError(const std::string& message,
                           const int code,
                           const std::string& domain) {
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-  v8::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Object> wrapper;
   if (GetWrapper(isolate).ToLocal(&wrapper)) {

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -209,7 +209,6 @@ void BaseWindow::OnWindowWillResize(const gfx::Rect& new_bounds,
                                     const gfx::ResizeEdge& edge,
                                     bool* prevent_default) {
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-  v8::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
   gin_helper::Dictionary info = gin::Dictionary::CreateEmpty(isolate);
   info.Set("edge", edge);
@@ -309,7 +308,6 @@ void BaseWindow::OnSystemContextMenu(int x, int y, bool* prevent_default) {
 void BaseWindow::OnWindowMessage(UINT message, WPARAM w_param, LPARAM l_param) {
   if (IsWindowMessageHooked(message)) {
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-    v8::Locker locker(isolate);
     v8::HandleScope scope(isolate);
     messages_callback_map_[message].Run(
         ToBuffer(isolate, static_cast<void*>(&w_param), sizeof(WPARAM)),

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -349,7 +349,6 @@ void BrowserWindow::UpdateWindowControlsOverlay(
 
 void BrowserWindow::CloseImmediately() {
   // Close all child windows before closing current window.
-  v8::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
   for (v8::Local<v8::Value> value : child_windows_.Values(isolate())) {
     gin::Handle<BrowserWindow> child;

--- a/shell/browser/api/electron_api_data_pipe_holder.cc
+++ b/shell/browser/api/electron_api_data_pipe_holder.cc
@@ -107,7 +107,6 @@ class DataPipeReader {
     //
     // Note that the lifetime of the native buffer belongs to us, and we will
     // free memory when JS buffer gets garbage collected.
-    v8::Locker locker(promise_.isolate());
     v8::HandleScope handle_scope(promise_.isolate());
     v8::Local<v8::Value> buffer =
         node::Buffer::New(promise_.isolate(), &buffer_.front(), buffer_.size(),

--- a/shell/browser/api/electron_api_debugger.cc
+++ b/shell/browser/api/electron_api_debugger.cc
@@ -43,8 +43,6 @@ void Debugger::DispatchProtocolMessage(DevToolsAgentHost* agent_host,
   DCHECK(agent_host == agent_host_);
 
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-
-  v8::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
 
   base::StringPiece message_str(reinterpret_cast<const char*>(message.data()),

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -155,7 +155,6 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
       if (!webrtc::DxgiDuplicatorController::Instance()->GetDeviceNames(
               &device_names)) {
         v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-        v8::Locker locker(isolate);
         v8::HandleScope scope(isolate);
         gin_helper::CallMethod(this, "_onerror", "Failed to get sources.");
 
@@ -191,7 +190,6 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
 
   if (!capture_window_ && !capture_screen_) {
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-    v8::Locker locker(isolate);
     v8::HandleScope scope(isolate);
     gin_helper::CallMethod(this, "_onfinished", captured_sources_);
 

--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -146,7 +146,6 @@ void Menu::OnMenuWillShow(ui::SimpleMenuModel* source) {
 base::OnceClosure Menu::BindSelfToClosure(base::OnceClosure callback) {
   // return ((callback, ref) => { callback() }).bind(null, callback, this)
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-  v8::Locker locker(isolate);
   v8::HandleScope scope(isolate);
   v8::Local<v8::Object> self;
   if (GetWrapper(isolate).ToLocal(&self)) {

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -372,7 +372,6 @@ void Session::OnDownloadCreated(content::DownloadManager* manager,
   if (item->IsSavePackageDownload())
     return;
 
-  v8::Locker locker(isolate_);
   v8::HandleScope handle_scope(isolate_);
   auto handle = DownloadItem::FromOrCreate(isolate_, item);
   if (item->GetState() == download::DownloadItem::INTERRUPTED)

--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -389,7 +389,6 @@ gfx::Rect Tray::GetBounds() {
 bool Tray::CheckAlive() {
   if (!tray_icon_) {
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-    v8::Locker locker(isolate);
     v8::HandleScope scope(isolate);
     gin_helper::ErrorThrower(isolate).ThrowError("Tray is destroyed");
     return false;

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1041,7 +1041,6 @@ void WebContents::WebContentsCreatedWithFullParams(
   tracker->body = params.body;
 
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-  v8::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
 
   gin_helper::Dictionary dict;
@@ -1073,7 +1072,6 @@ bool WebContents::IsWebContentsCreationOverridden(
 void WebContents::SetNextChildWebPreferences(
     const gin_helper::Dictionary preferences) {
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-  v8::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
   // Store these prefs for when Chrome calls WebContentsCreatedWithFullParams
   // with the new child contents.
@@ -1105,7 +1103,6 @@ void WebContents::AddNewContents(
 
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
 
-  v8::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
   auto api_web_contents =
       CreateAndTake(isolate, std::move(new_contents), Type::kBrowserWindow);
@@ -1392,7 +1389,6 @@ void WebContents::FindReply(content::WebContents* web_contents,
     return;
 
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-  v8::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
   gin_helper::Dictionary result = gin::Dictionary::CreateEmpty(isolate);
   result.Set("requestId", request_id);
@@ -1991,7 +1987,6 @@ void WebContents::DevToolsFocused() {
 
 void WebContents::DevToolsOpened() {
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-  v8::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
   DCHECK(inspectable_web_contents_);
   DCHECK(inspectable_web_contents_->GetDevToolsWebContents());
@@ -2015,7 +2010,6 @@ void WebContents::DevToolsOpened() {
 
 void WebContents::DevToolsClosed() {
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-  v8::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
   devtools_web_contents_.Reset();
 

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -108,7 +108,6 @@ void WebFrameMain::UpdateRenderFrameHost(content::RenderFrameHost* rfh) {
 bool WebFrameMain::CheckRenderFrame() const {
   if (render_frame_disposed_) {
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-    v8::Locker locker(isolate);
     v8::HandleScope scope(isolate);
     gin_helper::ErrorThrower(isolate).ThrowError(
         "Render frame was disposed before WebFrameMain could be accessed");

--- a/shell/browser/event_emitter_mixin.h
+++ b/shell/browser/event_emitter_mixin.h
@@ -29,7 +29,6 @@ class EventEmitterMixin {
   template <typename... Args>
   bool Emit(base::StringPiece name, Args&&... args) {
     v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
-    v8::Locker locker(isolate);
     v8::HandleScope handle_scope(isolate);
     v8::Local<v8::Object> wrapper;
     if (!static_cast<T*>(this)->GetWrapper(isolate).ToLocal(&wrapper))

--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -171,7 +171,6 @@ JavascriptEnvironment::~JavascriptEnvironment() {
   platform_->DrainTasks(isolate_);
 
   {
-    v8::Locker locker(isolate_);
     v8::HandleScope scope(isolate_);
     context_.Get(isolate_)->Exit();
   }
@@ -370,7 +369,6 @@ void JavascriptEnvironment::OnMessageLoopCreated() {
 void JavascriptEnvironment::OnMessageLoopDestroying() {
   DCHECK(microtasks_runner_);
   {
-    v8::Locker locker(isolate_);
     v8::HandleScope scope(isolate_);
     gin_helper::CleanedUpAtExit::DoCleanup();
   }

--- a/shell/browser/net/node_stream_loader.cc
+++ b/shell/browser/net/node_stream_loader.cc
@@ -30,7 +30,6 @@ NodeStreamLoader::NodeStreamLoader(
 }
 
 NodeStreamLoader::~NodeStreamLoader() {
-  v8::Locker locker(isolate_);
   v8::Isolate::Scope isolate_scope(isolate_);
   v8::HandleScope handle_scope(isolate_);
 
@@ -154,7 +153,6 @@ void NodeStreamLoader::DidWrite(MojoResult result) {
 }
 
 void NodeStreamLoader::On(const char* event, EventCallback callback) {
-  v8::Locker locker(isolate_);
   v8::Isolate::Scope isolate_scope(isolate_);
   v8::HandleScope handle_scope(isolate_);
 

--- a/shell/browser/printing/print_preview_message_handler.cc
+++ b/shell/browser/printing/print_preview_message_handler.cc
@@ -24,7 +24,6 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_contents_user_data.h"
 #include "mojo/public/cpp/bindings/callback_helpers.h"
-#include "shell/common/gin_helper/locker.h"
 #include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
 
 #include "shell/common/node_includes.h"
@@ -250,7 +249,6 @@ void PrintPreviewMessageHandler::ResolvePromise(
   gin_helper::Promise<v8::Local<v8::Value>> promise = GetPromise(request_id);
 
   v8::Isolate* isolate = promise.isolate();
-  gin_helper::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
   v8::Context::Scope context_scope(
       v8::Local<v8::Context>::New(isolate, promise.GetContext()));

--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -307,7 +307,6 @@ void ResolvePromiseInNextTick(gin_helper::Promise<v8::Local<v8::Value>> promise,
           [](gin_helper::Promise<v8::Local<v8::Value>> promise,
              v8::Global<v8::Value> global) {
             v8::Isolate* isolate = promise.isolate();
-            v8::Locker locker(isolate);
             v8::HandleScope handle_scope(isolate);
             v8::Local<v8::Value> value = global.Get(isolate);
             promise.Resolve(value);

--- a/shell/browser/ui/file_dialog_win.cc
+++ b/shell/browser/ui/file_dialog_win.cc
@@ -221,7 +221,6 @@ void ShowOpenDialog(const DialogSettings& settings,
                     gin_helper::Promise<gin_helper::Dictionary> promise) {
   auto done = [](gin_helper::Promise<gin_helper::Dictionary> promise,
                  bool success, std::vector<base::FilePath> result) {
-    v8::Locker locker(promise.isolate());
     v8::HandleScope handle_scope(promise.isolate());
     gin::Dictionary dict = gin::Dictionary::CreateEmpty(promise.isolate());
     dict.Set("canceled", !success);
@@ -271,7 +270,6 @@ void ShowSaveDialog(const DialogSettings& settings,
                     gin_helper::Promise<gin_helper::Dictionary> promise) {
   auto done = [](gin_helper::Promise<gin_helper::Dictionary> promise,
                  bool success, base::FilePath result) {
-    v8::Locker locker(promise.isolate());
     v8::HandleScope handle_scope(promise.isolate());
     gin::Dictionary dict = gin::Dictionary::CreateEmpty(promise.isolate());
     dict.Set("canceled", !success);

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -250,7 +250,6 @@ void ElectronBindings::DidReceiveMemoryDump(
     bool success,
     std::unique_ptr<memory_instrumentation::GlobalMemoryDump> global_dump) {
   v8::Isolate* isolate = promise.isolate();
-  gin_helper::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
   gin_helper::MicrotasksScope microtasks_scope(isolate, true);
   v8::Context::Scope context_scope(

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -61,7 +61,6 @@ class EventEmitter : public gin_helper::Wrappable<T> {
   // this.emit(name, new Event(), args...);
   template <typename... Args>
   bool Emit(base::StringPiece name, Args&&... args) {
-    v8::Locker locker(isolate());
     v8::HandleScope handle_scope(isolate());
     v8::Local<v8::Object> wrapper = GetWrapper();
     if (wrapper.IsEmpty())

--- a/shell/common/gin_helper/pinnable.h
+++ b/shell/common/gin_helper/pinnable.h
@@ -14,7 +14,6 @@ class Pinnable {
  protected:
   // Prevent the object from being garbage collected until Unpin() is called.
   void Pin(v8::Isolate* isolate) {
-    v8::Locker locker(isolate);
     v8::HandleScope scope(isolate);
     v8::Local<v8::Value> wrapper;
     if (static_cast<T*>(this)->GetWrapper(isolate).ToLocal(&wrapper)) {

--- a/shell/common/gin_helper/promise.cc
+++ b/shell/common/gin_helper/promise.cc
@@ -24,7 +24,6 @@ PromiseBase::~PromiseBase() = default;
 PromiseBase& PromiseBase::operator=(PromiseBase&&) = default;
 
 v8::Maybe<bool> PromiseBase::Reject() {
-  gin_helper::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
   gin_helper::MicrotasksScope microtasks_scope(isolate());
   v8::Context::Scope context_scope(GetContext());
@@ -33,7 +32,6 @@ v8::Maybe<bool> PromiseBase::Reject() {
 }
 
 v8::Maybe<bool> PromiseBase::Reject(v8::Local<v8::Value> except) {
-  gin_helper::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
   gin_helper::MicrotasksScope microtasks_scope(isolate());
   v8::Context::Scope context_scope(GetContext());
@@ -42,7 +40,6 @@ v8::Maybe<bool> PromiseBase::Reject(v8::Local<v8::Value> except) {
 }
 
 v8::Maybe<bool> PromiseBase::RejectWithErrorMessage(base::StringPiece message) {
-  gin_helper::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
   gin_helper::MicrotasksScope microtasks_scope(isolate());
   v8::Context::Scope context_scope(GetContext());
@@ -85,7 +82,6 @@ v8::Local<v8::Promise> Promise<void>::ResolvedPromise(v8::Isolate* isolate) {
 }
 
 v8::Maybe<bool> Promise<void>::Resolve() {
-  gin_helper::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
   gin_helper::MicrotasksScope microtasks_scope(isolate());
   v8::Context::Scope context_scope(GetContext());

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -628,8 +628,6 @@ void NodeBindings::UvRunOnce() {
   if (!env)
     return;
 
-  // Use Locker in browser process.
-  gin_helper::Locker locker(env->isolate());
   v8::HandleScope handle_scope(env->isolate());
 
   // Enter node context while dealing with uv events.


### PR DESCRIPTION
#### Description of Change
v8::Locker is supposed to coordinate usage of a single v8::Isolate from
multiple threads. However, we don't actually access the isolate from multiple
threads in Electron. To wit, there is a [persistent locker][] in
`JavascriptEnvironment`, that is initialized at boot time and held until
shutdown, meaning that any method that were to attempt to access the Isolate in
another thread would hang forever. That this doesn't happen is evidence that we
do not access the isolate from non-main threads.

[persistent locker]: https://github.com/electron/electron/blob/5b648854d59180cc9d72c6def8849ec59489bba6/shell/browser/javascript_environment.h#L50

As a followup, we should remove the `IsBrowserProcess` method from
`gin_helper::Locker`, where it never really belonged in the first place.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none
