### PR TITLE
build: use large executors for macos publish on 12.4.0

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1900,7 +1900,7 @@ jobs:
   osx-publish-x64-skip-checkout:
     executor:
       name: macos
-      size: macos.x86.medium.gen2
+      size: large
     environment:
       <<: *env-mac-large-release
       <<: *env-release-build
@@ -1921,7 +1921,7 @@ jobs:
   osx-publish-arm64-skip-checkout:
     executor:
       name: macos
-      size: macos.x86.medium.gen2
+      size: large
     environment:
       <<: *env-mac-large-release
       <<: *env-release-build
@@ -1991,7 +1991,7 @@ jobs:
   mas-publish-x64-skip-checkout:
     executor:
       name: macos
-      size: macos.x86.medium.gen2
+      size: large
     environment:
       <<: *env-mac-large-release
       <<: *env-mas
@@ -2012,7 +2012,7 @@ jobs:
   mas-publish-arm64-skip-checkout:
     executor:
       name: macos
-      size: macos.x86.medium.gen2
+      size: large
     environment:
       <<: *env-mac-large-release
       <<: *env-mas-apple-silicon


### PR DESCRIPTION
#### Description of Change

We recently switched to using the macos.x86.medium.gen2 in CI for MacOS publish jobs. This works well on branches that have a default xcode version of 12.7.0+, as CircleCI can bump all images that use 12.7.0 or higher to ~150 GB. However, for branches that are still using 12.4.0 for publish (like 17-x-y) and only have access to ~80 GB images, this is causing us to run out of diskspace before the publish run can be completed.

This PR bumps us up to the large executor for macos publish jobs only.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
