### PR TITLE
build: change upload-to-s3 vars to upload-to-az

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,7 @@ parameters:
     type: boolean
     default: false
   
-  # TODO (vertedinde): migrate this variable to upload-to-az
-  upload-to-s3:
+  upload-to-az:
     type: string
     default: '1'
 

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -5,7 +5,7 @@ parameters:
     type: boolean
     default: false
   
-  upload-to-s3:
+  upload-to-az:
     type: string
     default: '1'
 
@@ -637,9 +637,9 @@ step-electron-publish: &step-electron-publish
       fi
 
       cd src/electron
-      if [ "$UPLOAD_TO_S3" == "1" ]; then
-        echo 'Uploading Electron release distribution to S3'
-        script/release/uploaders/upload.py --verbose --upload_to_s3
+      if [ "$UPLOAD_TO_AZ" == "1" ]; then
+        echo 'Uploading Electron release distribution to Azure'
+        script/release/uploaders/upload.py --verbose --upload_to_az
       else
         echo 'Uploading Electron release distribution to Github releases'
         script/release/uploaders/upload.py --verbose
@@ -1687,7 +1687,7 @@ jobs:
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-release-build
-      UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
+      UPLOAD_TO_AZ: << pipeline.parameters.upload-to-az >>
       <<: *env-ninja-status
     steps:
       - run: echo running
@@ -1731,7 +1731,7 @@ jobs:
       <<: *env-release-build
       <<: *env-32bit-release
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True'
-      UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
+      UPLOAD_TO_AZ: << pipeline.parameters.upload-to-az >>
       <<: *env-ninja-status
     steps:
       - run: echo running
@@ -1784,7 +1784,7 @@ jobs:
       <<: *env-arm64
       <<: *env-release-build
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm64=True'
-      UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
+      UPLOAD_TO_AZ: << pipeline.parameters.upload-to-az >>
       <<: *env-ninja-status
     steps:
       - run: echo running
@@ -1832,7 +1832,7 @@ jobs:
     environment:
       <<: *env-mac-large-release
       <<: *env-release-build
-      UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
+      UPLOAD_TO_AZ: << pipeline.parameters.upload-to-az >>
       <<: *env-ninja-status
     steps:
       - run: echo running
@@ -1854,7 +1854,7 @@ jobs:
       <<: *env-mac-large-release
       <<: *env-release-build
       <<: *env-apple-silicon
-      UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
+      UPLOAD_TO_AZ: << pipeline.parameters.upload-to-az >>
       <<: *env-ninja-status
     steps:
       - run: echo running
@@ -1924,7 +1924,7 @@ jobs:
       <<: *env-mac-large-release
       <<: *env-mas
       <<: *env-release-build
-      UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
+      UPLOAD_TO_AZ: << pipeline.parameters.upload-to-az >>
     steps:
       - run: echo running
       - when:
@@ -1945,7 +1945,7 @@ jobs:
       <<: *env-mac-large-release
       <<: *env-mas-apple-silicon
       <<: *env-release-build
-      UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
+      UPLOAD_TO_AZ: << pipeline.parameters.upload-to-az >>
       <<: *env-ninja-status
     steps:
       - run: echo running

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@
 #  - "TARGET_ARCH" Choose from {'ia32', 'x64', 'arm', 'arm64', 'mips64el'}.
 #      Is used in some publishing scripts, but does NOT affect the Electron binary.
 #      Must match 'target_cpu' passed to "GN_EXTRA_ARGS" and "NPM_CONFIG_ARCH" value.
-#  - "UPLOAD_TO_S3" Set it to '1' upload a release to the S3 bucket.
+#  - "UPLOAD_TO_AZ" Set it to '1' upload a release to the Azure bucket.
 #      Otherwise the release will be uploaded to the Github Releases.
 #      (The value is only checked if "ELECTRON_RELEASE" is defined.)
 #
@@ -229,9 +229,9 @@ deploy_script:
   - cd electron
   - ps: >-
       if (Test-Path Env:\ELECTRON_RELEASE) {
-        if (Test-Path Env:\UPLOAD_TO_S3) {
-          Write-Output "Uploading Electron release distribution to s3"
-          & python script\release\uploaders\upload.py --verbose --upload_to_s3
+        if (Test-Path Env:\UPLOAD_TO_AZ) {
+          Write-Output "Uploading Electron release distribution to azure"
+          & python script\release\uploaders\upload.py --verbose --upload_to_az
         } else {
           Write-Output "Uploading Electron release distribution to github releases"
           & python script\release\uploaders\upload.py --verbose

--- a/script/release/ci-release-build.js
+++ b/script/release/ci-release-build.js
@@ -62,9 +62,9 @@ async function circleCIcall (targetBranch, workflowName, options) {
     parameters: {}
   };
   if (options.ghRelease) {
-    buildRequest.parameters['upload-to-s3'] = '0';
+    buildRequest.parameters['upload-to-az'] = '0';
   } else {
-    buildRequest.parameters['upload-to-s3'] = '1';
+    buildRequest.parameters['upload-to-az'] = '1';
   }
   buildRequest.parameters[`run-${workflowName}`] = true;
   if (options.arch) {
@@ -205,7 +205,7 @@ async function callAppVeyor (targetBranch, job, options) {
   };
 
   if (!options.ghRelease) {
-    environmentVariables.UPLOAD_TO_S3 = 1;
+    environmentVariables.UPLOAD_TO_AZ = 1;
   }
 
   const requestOpts = {

--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -47,7 +47,7 @@ def main():
   args = parse_args()
   if args.verbose:
     enable_verbose_mode()
-  if args.upload_to_s3:
+  if args.upload_to_az:
     utcnow = datetime.datetime.utcnow()
     args.upload_timestamp = utcnow.strftime('%Y%m%d')
 
@@ -64,7 +64,7 @@ def main():
   if not release['draft']:
     tag_exists = True
 
-  if not args.upload_to_s3:
+  if not args.upload_to_az:
     assert release['exists'], \
           'Release does not exist; cannot upload to GitHub!'
     assert tag_exists == args.overwrite, \
@@ -148,7 +148,7 @@ def main():
       OUT_DIR, 'hunspell_dictionaries.zip')
     upload_electron(release, hunspell_dictionaries_zip, args)
 
-  if not tag_exists and not args.upload_to_s3:
+  if not tag_exists and not args.upload_to_az:
     # Upload symbols to symbol server.
     run_python_upload_script('upload-symbols.py')
     if PLATFORM == 'win32':
@@ -174,9 +174,9 @@ def parse_args():
   parser.add_argument('-p', '--publish-release',
                       help='Publish the release',
                       action='store_true')
-  parser.add_argument('-s', '--upload_to_s3',
-                      help='Upload assets to s3 bucket',
-                      dest='upload_to_s3',
+  parser.add_argument('-s', '--upload_to_az',
+                      help='Upload assets to azure bucket',
+                      dest='upload_to_az',
                       action='store_true',
                       default=False,
                       required=False)
@@ -342,9 +342,9 @@ def upload_electron(release, file_path, args):
   except NonZipFileError:
     pass
 
-  # if upload_to_s3 is set, skip github upload.
+  # if upload_to_az is set, skip github upload.
   # todo (vertedinde): migrate this variable to upload_to_az
-  if args.upload_to_s3:
+  if args.upload_to_az:
     key_prefix = 'release-builds/{0}_{1}'.format(args.version,
                                                      args.upload_timestamp)
     store_artifact(os.path.dirname(file_path), key_prefix, [file_path])


### PR DESCRIPTION
#### Description of Change

A follow up to #34104, this PR changes all instances of `upload-to-s3` to `upload-to-az`.

Please do not merge until the first PR is merged, and all instances of this variable have been confirmed changed in CircleCI and AppVeyor.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
