### PR TITLE
build: remove ending slash upload-index-json

### DIFF
--- a/script/release/uploaders/upload-index-json.py
+++ b/script/release/uploaders/upload-index-json.py
@@ -59,7 +59,7 @@ def main():
     with open(index_json, "wb") as f:
       f.write(new_content)
 
-    store_artifact(OUT_DIR, 'headers/dist/', [index_json])
+    store_artifact(OUT_DIR, 'headers/dist', [index_json])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### Description of Change

Follow up to #34104, corrects the path for headers/dist artifacts in upload-index-json.py ([specific error here](https://github.com/electron/electron/pull/34104/files#diff-9b264d89ea713efb8d1742959114a0364ae01fec94bdda761f2a699aa90b3024R62))

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
