### PR TITLE
chore: backport a536de469 from node

### DIFF
--- a/patches/node/.patches
+++ b/patches/node/.patches
@@ -45,3 +45,4 @@ macos_don_t_use_thread-unsafe_strtok_3524.patch
 process_fix_hang_after_note_exit_3521.patch
 worker_thread_add_asar_support.patch
 macos_avoid_posix_spawnp_cwd_bug_3597.patch
+build_disable_v8_pointer_compression_on_32bit_archs.patch

--- a/patches/node/build_disable_v8_pointer_compression_on_32bit_archs.patch
+++ b/patches/node/build_disable_v8_pointer_compression_on_32bit_archs.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Tue, 12 Oct 2021 10:41:55 +0900
+Subject: build: disable v8 pointer compression on 32bit archs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+PR-URL: https://github.com/nodejs/node/pull/40418
+Reviewed-By: Jiawen Geng <technicalcute@gmail.com>
+Reviewed-By: Stewart X Addison <sxa@redhat.com>
+Reviewed-By: Tobias Nießen <tniessen@tnie.de>
+Reviewed-By: Minwoo Jung <nodecorelab@gmail.com>
+Reviewed-By: Michael Dawson <midawson@redhat.com>
+
+diff --git a/common.gypi b/common.gypi
+index 8a85c7c3d0ab0e2906c417f2cc2fc9ca584fd601..f6ea8340b696103d0949df7fb7b75a1d05e90f87 100644
+--- a/common.gypi
++++ b/common.gypi
+@@ -130,6 +130,11 @@
+       ['target_arch == "arm64" or target_arch == "x64"', {
+         'v8_enable_pointer_compression': 1,
+       }],
++      # V8 pointer compression only supports 64bit architectures.
++      ['target_arch in "arm ia32 mips mipsel ppc x32"', {
++        'v8_enable_pointer_compression': 0,
++        'v8_enable_31bit_smis_on_64bit_arch': 0,
++      }],
+       ['target_arch in "ppc64 s390x"', {
+         'v8_enable_backtrace': 1,
+       }],


### PR DESCRIPTION
#### Description of Change

Backports https://github.com/nodejs/node/commit/a536de469564eea56129385c321c42c75f310b05

Fixes 32-bit native module builds with node-gyp@9.0.0 that uses `config.gypi` from bundled custom headers. Also removes redundant patch `enable_31_bit_smis_on_64bit_arch_and_ptr_compression.patch` since we always ship a single copy of `config.gypi` with pointer compression enabled since https://github.com/electron/electron/commit/d1e0b6324a0b380912f3d0dc5fc799ed2447ab1e

#### Release Notes

Notes: Fix 32-bit native module builds with node-gyp >= 9.0.0