### PR TITLE
fix: crash on startup due to missing gtk symbol on older distros

### DIFF
--- a/shell/browser/ui/electron_gtk.sigs
+++ b/shell/browser/ui/electron_gtk.sigs
@@ -4,3 +4,4 @@ void gtk_native_dialog_show(GtkNativeDialog* self);
 void gtk_native_dialog_hide(GtkNativeDialog* self);
 gint gtk_native_dialog_run(GtkNativeDialog* self);
 void gtk_native_dialog_destroy(GtkNativeDialog* self);
+GType gtk_native_dialog_get_type(void);


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/34118

Check for availability of `gtk_native_dialog_get_type` which is only available with `>= 3.20` symbol used by the `gtk_native_dialog_*` code path

#### Release Notes

Notes: fix crash on startup due to missing gtk symbol on older distros