### PR TITLE
fix: building with printing disabled

### DIFF
--- a/shell/browser/electron_api_ipc_handler_impl.h
+++ b/shell/browser/electron_api_ipc_handler_impl.h
@@ -12,8 +12,7 @@
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "electron/shell/common/api/api.mojom.h"
-#include "mojo/public/cpp/bindings/pending_receiver.h"
-#include "mojo/public/cpp/bindings/receiver.h"
+#include "mojo/public/cpp/bindings/associated_receiver.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 
 namespace content {

--- a/shell/browser/electron_web_contents_utility_handler_impl.h
+++ b/shell/browser/electron_web_contents_utility_handler_impl.h
@@ -11,6 +11,7 @@
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "electron/shell/common/api/api.mojom.h"
+#include "mojo/public/cpp/bindings/associated_receiver.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 
 namespace content {


### PR DESCRIPTION
Backport #33838

```
In file included from ../../electron/shell/browser/electron_api_ipc_handler_impl.cc:5:
../../electron/shell/browser/electron_api_ipc_handler_impl.h:83:9: error: no template named 'AssociatedReceiver' in namespace 'mojo'; did you mean 'AssociatedRemote'?
  mojo::AssociatedReceiver<mojom::ElectronApiIPC> receiver_{this};
  ~~~~~~^~~~~~~~~~~~~~~~~~
        AssociatedRemote
../../mojo/public/cpp/bindings/associated_remote.h:39:7: note: 'AssociatedRemote' declared here
class AssociatedRemote {
```
```
In file included from ../../electron/shell/browser/electron_web_contents_utility_handler_impl.cc:5:
../../electron/shell/browser/electron_web_contents_utility_handler_impl.h:65:9: error: no template named 'AssociatedReceiver' in namespace 'mojo'; did you mean 'AssociatedRemote'?
  mojo::AssociatedReceiver<mojom::ElectronWebContentsUtility> receiver_{this};
  ~~~~~~^~~~~~~~~~~~~~~~~~
        AssociatedRemote
../../mojo/public/cpp/bindings/associated_remote.h:39:7: note: 'AssociatedRemote' declared here
class AssociatedRemote {
```

Notes: none