### PR TITLE
test: run node specs with py3

### DIFF
--- a/script/node-spec-runner.js
+++ b/script/node-spec-runner.js
@@ -55,7 +55,7 @@ const getCustomOptions = () => {
 async function main () {
   const options = args.default ? defaultOptions : getCustomOptions();
 
-  const testChild = cp.spawn('python', options, {
+  const testChild = cp.spawn('python3', options, {
     env: {
       ...process.env,
       ELECTRON_RUN_AS_NODE: 'true',


### PR DESCRIPTION
#### Description of Change
node-spec-runner.js was using `python` instead of `python3` to execute tests,
causing failures on macOS Monterey which has no `python` binary.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none
