### PR TITLE
fix: call loadUrl when opening new windows from links

### DIFF
--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1937,6 +1937,26 @@ describe('BrowserWindow module', () => {
     });
   });
 
+  describe('Opening a BrowserWindow from a link', () => {
+    let appProcess: childProcess.ChildProcessWithoutNullStreams | undefined;
+
+    afterEach(() => {
+      if (appProcess && !appProcess.killed) {
+        appProcess.kill();
+        appProcess = undefined;
+      }
+    });
+
+    it('can properly open and load a new window from a link', async () => {
+      const appPath = path.join(__dirname, 'fixtures', 'apps', 'open-new-window-from-link');
+
+      appProcess = childProcess.spawn(process.execPath, [appPath]);
+
+      const [code] = await emittedOnce(appProcess, 'exit');
+      expect(code).to.equal(0);
+    });
+  });
+
   describe('BrowserWindow.fromWebContents(webContents)', () => {
     afterEach(closeAllWindows);
 

--- a/spec-main/fixtures/apps/open-new-window-from-link/index.html
+++ b/spec-main/fixtures/apps/open-new-window-from-link/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'">
+    <title>Hello World!</title>
+  </head>
+  <body>
+    <a href="./new-window-page.html">Open New Window</a>
+  </body>
+</html>

--- a/spec-main/fixtures/apps/open-new-window-from-link/main.js
+++ b/spec-main/fixtures/apps/open-new-window-from-link/main.js
@@ -1,0 +1,64 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+async function createWindow () {
+  const mainWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+    x: 100,
+    y: 100,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: false,
+      nodeIntegration: true
+    }
+  });
+
+  await mainWindow.loadFile('index.html');
+
+  const rect = await mainWindow.webContents.executeJavaScript('JSON.parse(JSON.stringify(document.querySelector("a").getBoundingClientRect()))');
+  const x = rect.x + rect.width / 2;
+  const y = rect.y + rect.height / 2;
+
+  function click (x, y, options) {
+    x = Math.floor(x);
+    y = Math.floor(y);
+    mainWindow.webContents.sendInputEvent({
+      type: 'mouseDown',
+      button: 'left',
+      x,
+      y,
+      clickCount: 1,
+      ...options
+    });
+
+    mainWindow.webContents.sendInputEvent({
+      type: 'mouseUp',
+      button: 'left',
+      x,
+      y,
+      clickCount: 1,
+      ...options
+    });
+  }
+
+  click(x, y, { modifiers: ['shift'] });
+}
+
+app.whenReady().then(() => {
+  app.on('web-contents-created', (e, wc) => {
+    wc.on('render-process-gone', (e, details) => {
+      console.error(details);
+      process.exit(1);
+    });
+
+    wc.on('did-finish-load', () => {
+      const title = wc.getTitle();
+      if (title === 'Window From Link') {
+        process.exit(0);
+      }
+    });
+  });
+
+  createWindow();
+});

--- a/spec-main/fixtures/apps/open-new-window-from-link/new-window-page.html
+++ b/spec-main/fixtures/apps/open-new-window-from-link/new-window-page.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'">
+    <title>Window From Link</title>
+  </head>
+  <body>
+    I'm a window opened from a link!
+  </body>
+</html>

--- a/spec-main/fixtures/apps/open-new-window-from-link/package.json
+++ b/spec-main/fixtures/apps/open-new-window-from-link/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "electron-test-open-new-window-from-link",
+  "main": "main.js"
+}

--- a/spec-main/fixtures/apps/open-new-window-from-link/preload.js
+++ b/spec-main/fixtures/apps/open-new-window-from-link/preload.js
@@ -1,0 +1,3 @@
+window.addEventListener('click', e => {
+  console.log('click', e);
+});


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/34152.

Fixes an issue where windows opened from new links wouldn't properly load URLs. This happened as a result of cleanup in https://github.com/electron/electron/commit/d44a187d0b226800fe0cb4f7a0d2b36c871b27cd - a section of code was removed which loaded the url for non-guest windows in `openGuestWindow`. It's actually the case that this code is necessary when we're opening new windows from links as well. When we open a new window from a link via `Shift+LeftClick`, this routes through `OpenUrlFromTab`, at which point the browser process is responsible for initiating navigation in the new window. This PR restores that code and updates the comment accordingly.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where some `BrowserWindow`s opened from new links wouldn't properly load URLs. 