### PR TITLE
chore: upgrade extract-zip for installer

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -70,17 +70,8 @@ function isInstalled () {
 
 // unzips and makes path.txt point at the correct executable
 function extractFile (zipPath) {
-  return new Promise((resolve, reject) => {
-    extract(zipPath, { dir: path.join(__dirname, 'dist') }, err => {
-      if (err) return reject(err);
-
-      fs.writeFile(path.join(__dirname, 'path.txt'), platformPath, err => {
-        if (err) return reject(err);
-
-        resolve();
-      });
-    });
-  });
+  return extract(zipPath, { dir: path.join(__dirname, 'dist') })
+    .then(() => fs.promises.writeFile(path.join(__dirname, 'path.txt'), platformPath));
 }
 
 function getPlatformPath () {

--- a/npm/package.json
+++ b/npm/package.json
@@ -10,9 +10,9 @@
   "dependencies": {
     "@electron/get": "^1.14.1",
     "@types/node": "^16.11.26",
-    "extract-zip": "^1.0.3"
+    "extract-zip": "^2.0.1"
   },
   "engines": {
-    "node": ">= 8.6"
+    "node": ">= 10.17.0"
   }
 }


### PR DESCRIPTION
#### Description of Change

`extract-zip@^1.0.3` indirectly depends on `minimist@0.0.8` which is affected by [CVE-2021-44906](https://nvd.nist.gov/vuln/detail/CVE-2021-44906).

By upgrading this package, it requires updating our minimum version of Node required by the Electron npm installer.

Followup: does CI run tests against the npm package scripts?

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes

#### Release Notes

Notes: Minimum required node version to install the `electron` npm package is now >10