### PR TITLE
fix: tray icon not highlighting on empty menu

### DIFF
--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -190,9 +190,9 @@
       gfx::ScreenPointFromNSPoint([event locationInWindow]),
       ui::EventFlagsFromModifiers([event modifierFlags]));
 
-  // Pass click to superclass to show menu. Custom mouseUp handler won't be
-  // invoked.
-  if (menuController_) {
+  // Pass click to superclass to show menu if one exists and has a non-zero
+  // number of items. Custom mouseUp handler won't be invoked in this case.
+  if (menuController_ && [[menuController_ menu] numberOfItems] > 0) {
     [self handleClickNotifications:event];
     [super mouseDown:event];
   } else {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/32111.

Ensures that the menu controller not only exists, but has a non-zero number of items before choosing to pass the click item to the superclass. 

Regressed in https://github.com/electron/electron/commit/47a38daee20ef77cc98bc13bb7a7c1d690fd635c.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where tray items wouldn't highlight in some scenarios on macOS.