### PR TITLE
build: re-enable 32-bit Windows symbol generation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -193,19 +193,16 @@ build_script:
   - appveyor PushArtifact out/Default/mksnapshot.zip
   - appveyor PushArtifact out/Default/hunspell_dictionaries.zip
   - appveyor PushArtifact out/Default/electron.lib
-  # Temporarily disable symbol generation on 32-bit Windows due to failures  
   - ps: >-
-      if ($env:GN_CONFIG -eq 'release' -And $env:TARGET_ARCH -ne 'ia32') {
+      if ($env:GN_CONFIG -eq 'release') {
         # Needed for msdia140.dll on 64-bit windows
         $env:Path += ";$pwd\third_party\llvm-build\Release+Asserts\bin"
         ninja -C out/Default electron:electron_symbols
       }
   - ps: >-
       if ($env:GN_CONFIG -eq 'release') {
-        if ($env:TARGET_ARCH -ne 'ia32') {
-          python electron\script\zip-symbols.py
-          appveyor-retry appveyor PushArtifact out/Default/symbols.zip
-        }
+        python electron\script\zip-symbols.py
+        appveyor-retry appveyor PushArtifact out/Default/symbols.zip
       } else {
         # It's useful to have pdb files when debugging testing builds that are
         # built on CI.

--- a/script/release/release.js
+++ b/script/release/release.js
@@ -128,9 +128,8 @@ function assetsForVersion (version, validatingRelease) {
     `electron-${version}-mas-arm64-dsym-snapshot.zip`,
     `electron-${version}-mas-arm64-symbols.zip`,
     `electron-${version}-mas-arm64.zip`,
-    // TODO(jkleinsc) Symbol generation on 32-bit Windows is temporarily disabled due to failures
-    // `electron-${version}-win32-ia32-pdb.zip`,
-    // `electron-${version}-win32-ia32-symbols.zip`,
+    `electron-${version}-win32-ia32-pdb.zip`,
+    `electron-${version}-win32-ia32-symbols.zip`,
     `electron-${version}-win32-ia32.zip`,
     `electron-${version}-win32-x64-pdb.zip`,
     `electron-${version}-win32-x64-symbols.zip`,

--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -76,10 +76,9 @@ def main():
   shutil.copy2(os.path.join(OUT_DIR, 'dist.zip'), electron_zip)
   upload_electron(release, electron_zip, args)
   if get_target_arch() != 'mips64el':
-    if get_target_arch() != 'ia32' or PLATFORM != 'win32':
-      symbols_zip = os.path.join(OUT_DIR, SYMBOLS_NAME)
-      shutil.copy2(os.path.join(OUT_DIR, 'symbols.zip'), symbols_zip)
-      upload_electron(release, symbols_zip, args)
+    symbols_zip = os.path.join(OUT_DIR, SYMBOLS_NAME)
+    shutil.copy2(os.path.join(OUT_DIR, 'symbols.zip'), symbols_zip)
+    upload_electron(release, symbols_zip, args)
   if PLATFORM == 'darwin':
     if get_platform_key() == 'darwin' and get_target_arch() == 'x64':
       api_path = os.path.join(ELECTRON_DIR, 'electron-api.json')
@@ -96,10 +95,9 @@ def main():
     shutil.copy2(os.path.join(OUT_DIR, 'dsym-snapshot.zip'), dsym_snaphot_zip)
     upload_electron(release, dsym_snaphot_zip, args)    
   elif PLATFORM == 'win32':
-    if get_target_arch() != 'ia32':
-      pdb_zip = os.path.join(OUT_DIR, PDB_NAME)
-      shutil.copy2(os.path.join(OUT_DIR, 'pdb.zip'), pdb_zip)
-      upload_electron(release, pdb_zip, args)
+    pdb_zip = os.path.join(OUT_DIR, PDB_NAME)
+    shutil.copy2(os.path.join(OUT_DIR, 'pdb.zip'), pdb_zip)
+    upload_electron(release, pdb_zip, args)
   elif PLATFORM == 'linux':
     debug_zip = os.path.join(OUT_DIR, DEBUG_NAME)
     shutil.copy2(os.path.join(OUT_DIR, 'debug.zip'), debug_zip)


### PR DESCRIPTION
Manual backport of https://github.com/electron/electron/pull/34162

See that PR for details

_Note: Please don't merge unless the electron-ia32-release job is green_

Notes: Re-enabled symbol generation on 32-bit Windows.

