### PR TITLE
chore: cherry-pick a602a068e022 from angle

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -1,3 +1,4 @@
 cherry-pick-d27d9d059b51.patch
 m100_fix_crash_when_pausing_xfb_then_deleting_a_buffer.patch
 cherry-pick-d49484c21e3c.patch
+cherry-pick-a602a068e022.patch

--- a/patches/angle/cherry-pick-a602a068e022.patch
+++ b/patches/angle/cherry-pick-a602a068e022.patch
@@ -1,0 +1,32 @@
+From a602a068e022149691d8642b095b8e68d05feb77 Mon Sep 17 00:00:00 2001
+From: Jamie Madill <jmadill@chromium.org>
+Date: Tue, 19 Apr 2022 17:01:20 -0400
+Subject: [PATCH] [M100] Fix validate state cache after XFB buffer deleted.
+
+Bug: chromium:1317650
+Change-Id: Iec9f1167c3b2957091dd0f4ef3efcfcd7c4bf3c0
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3594250
+Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
+Auto-Submit: Jamie Madill <jmadill@chromium.org>
+Commit-Queue: Jamie Madill <jmadill@chromium.org>
+(cherry picked from commit 4efc4ee6830a8a53a0daf9daa3c7aa835db4220f)
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3621779
+Reviewed-by: Amirali Abdolrashidi <abdolrashidi@google.com>
+---
+
+diff --git a/src/libANGLE/State.cpp b/src/libANGLE/State.cpp
+index 383bf7c..360896c 100644
+--- a/src/libANGLE/State.cpp
++++ b/src/libANGLE/State.cpp
+@@ -2176,10 +2176,7 @@
+     if (curTransformFeedback)
+     {
+         ANGLE_TRY(curTransformFeedback->detachBuffer(context, bufferID));
+-        if (isTransformFeedbackActiveUnpaused())
+-        {
+-            context->getStateCache().onActiveTransformFeedbackChange(context);
+-        }
++        context->getStateCache().onActiveTransformFeedbackChange(context);
+     }
+ 
+     if (getVertexArray()->detachBuffer(context, bufferID))

--- a/patches/angle/cherry-pick-a602a068e022.patch
+++ b/patches/angle/cherry-pick-a602a068e022.patch
@@ -1,7 +1,7 @@
-From a602a068e022149691d8642b095b8e68d05feb77 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jamie Madill <jmadill@chromium.org>
 Date: Tue, 19 Apr 2022 17:01:20 -0400
-Subject: [PATCH] [M100] Fix validate state cache after XFB buffer deleted.
+Subject: Fix validate state cache after XFB buffer deleted.
 
 Bug: chromium:1317650
 Change-Id: Iec9f1167c3b2957091dd0f4ef3efcfcd7c4bf3c0
@@ -12,13 +12,12 @@ Commit-Queue: Jamie Madill <jmadill@chromium.org>
 (cherry picked from commit 4efc4ee6830a8a53a0daf9daa3c7aa835db4220f)
 Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3621779
 Reviewed-by: Amirali Abdolrashidi <abdolrashidi@google.com>
----
 
 diff --git a/src/libANGLE/State.cpp b/src/libANGLE/State.cpp
-index 383bf7c..360896c 100644
+index ae245e4abdf9818d6aec83e4badad9811ed492b3..e9635038a1d4cc0ab5211b94c22d44f353388d64 100644
 --- a/src/libANGLE/State.cpp
 +++ b/src/libANGLE/State.cpp
-@@ -2176,10 +2176,7 @@
+@@ -2174,10 +2174,7 @@ angle::Result State::detachBuffer(Context *context, const Buffer *buffer)
      if (curTransformFeedback)
      {
          ANGLE_TRY(curTransformFeedback->detachBuffer(context, bufferID));


### PR DESCRIPTION
[M100] Fix validate state cache after XFB buffer deleted.

Bug: chromium:1317650
Change-Id: Iec9f1167c3b2957091dd0f4ef3efcfcd7c4bf3c0
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3594250
Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
Auto-Submit: Jamie Madill <jmadill@chromium.org>
Commit-Queue: Jamie Madill <jmadill@chromium.org>
(cherry picked from commit 4efc4ee6830a8a53a0daf9daa3c7aa835db4220f)
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3621779
Reviewed-by: Amirali Abdolrashidi <abdolrashidi@google.com>


Notes: Backported fix for CVE-2022-1639.