### PR TITLE
chore: cherry-pick 723ed8a9cfff from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -13,3 +13,4 @@ cherry-pick-f546ac11eec7.patch
 cherry-pick-e42dbcdedb7a.patch
 cherry-pick-b2d3ef69ef99.patch
 cherry-pick-2004594a46c8.patch
+cherry-pick-723ed8a9cfff.patch

--- a/patches/v8/cherry-pick-723ed8a9cfff.patch
+++ b/patches/v8/cherry-pick-723ed8a9cfff.patch
@@ -1,7 +1,7 @@
-From 723ed8a9cfffede007ae3d675a961d3cabe67e30 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jakob Kummerow <jkummerow@chromium.org>
-Date: Mon, 02 May 2022 19:52:11 +0200
-Subject: [PATCH] Merged: [wasm] Fix Int64Lowering for tagged stack-passed parameters
+Date: Mon, 2 May 2022 19:52:11 +0200
+Subject: Merged: [wasm] Fix Int64Lowering for tagged stack-passed parameters
 
 When lowering signatures, we must preserve the separation of parameters
 into tagged and untagged sections.
@@ -16,13 +16,12 @@ Reviewed-by: Shu-yu Guo <syg@chromium.org>
 Cr-Commit-Position: refs/branch-heads/10.1@{#28}
 Cr-Branched-From: b003970395b7efcc309eb30b4ca06dd8385acd55-refs/heads/10.1.124@{#1}
 Cr-Branched-From: e62f556862624103ea1da5b9dcef9b216832033b-refs/heads/main@{#79503}
----
 
 diff --git a/src/compiler/wasm-compiler.cc b/src/compiler/wasm-compiler.cc
-index 0afc124..d03f146 100644
+index 07bb41358898fbd9c5968fb8a37dff161e71ed65..5bd325035726d4e91ede2b54076dd0d2cfdce8c0 100644
 --- a/src/compiler/wasm-compiler.cc
 +++ b/src/compiler/wasm-compiler.cc
-@@ -8555,16 +8555,10 @@
+@@ -8233,16 +8233,10 @@ class LinkageLocationAllocator {
    // must be offset to just before the param slots, using this |slot_offset_|.
    int slot_offset_;
  };
@@ -42,7 +41,7 @@ index 0afc124..d03f146 100644
    int extra_params = extra_callable_param ? 2 : 1;
    LocationSignature::Builder locations(zone, fsig->return_count(),
                                         fsig->parameter_count() + extra_params);
-@@ -8607,19 +8601,37 @@
+@@ -8285,19 +8279,37 @@ CallDescriptor* GetWasmCallDescriptor(Zone* zone, const wasm::FunctionSig* fsig,
          kJSFunctionRegister.code(), MachineType::TaggedPointer()));
    }
  
@@ -83,9 +82,9 @@ index 0afc124..d03f146 100644
 +  LocationSignature* location_sig = BuildLocations(
 +      zone, fsig, extra_callable_param, &parameter_slots, &return_slots);
  
-   const RegList kCalleeSaveRegisters;
-   const DoubleRegList kCalleeSaveFPRegisters;
-@@ -8645,7 +8657,7 @@
+   const RegList kCalleeSaveRegisters = 0;
+   const RegList kCalleeSaveFPRegisters = 0;
+@@ -8323,7 +8335,7 @@ CallDescriptor* GetWasmCallDescriptor(Zone* zone, const wasm::FunctionSig* fsig,
        descriptor_kind,                    // kind
        target_type,                        // target MachineType
        target_loc,                         // target location
@@ -94,7 +93,7 @@ index 0afc124..d03f146 100644
        parameter_slots,                    // parameter slot count
        compiler::Operator::kNoProperties,  // properties
        kCalleeSaveRegisters,               // callee-saved registers
-@@ -8696,78 +8708,45 @@
+@@ -8374,78 +8386,45 @@ const wasm::FunctionSig* ReplaceTypeInSig(Zone* zone,
  CallDescriptor* ReplaceTypeInCallDescriptorWith(
      Zone* zone, const CallDescriptor* call_descriptor, size_t num_replacements,
      wasm::ValueType input_type, wasm::ValueType output_type) {
@@ -117,22 +116,21 @@ index 0afc124..d03f146 100644
 +    for (size_t i = 0; i < call_descriptor->ReturnCount(); i++) {
 +      DCHECK_NE(call_descriptor->GetReturnType(i), input_type.machine_type());
      }
--  }
++#endif
++    return const_cast<CallDescriptor*>(call_descriptor);
+   }
 -  if (parameter_count == call_descriptor->ParameterCount() &&
 -      return_count == call_descriptor->ReturnCount()) {
-+#endif
-     return const_cast<CallDescriptor*>(call_descriptor);
-   }
--
--  LocationSignature::Builder locations(zone, return_count, parameter_count);
 +  const wasm::FunctionSig* sig =
 +      ReplaceTypeInSig(zone, call_descriptor->wasm_sig(), input_type,
 +                       output_type, num_replacements);
 +  // If {ReplaceTypeInSig} took the early fast path, there's nothing to do.
 +  if (sig == call_descriptor->wasm_sig()) {
-+    return const_cast<CallDescriptor*>(call_descriptor);
-+  }
+     return const_cast<CallDescriptor*>(call_descriptor);
+   }
  
+-  LocationSignature::Builder locations(zone, return_count, parameter_count);
+-
    // The last parameter may be the special callable parameter. In that case we
    // have to preserve it as the last parameter, i.e. we allocate it in the new
    // location signature again in the same register.
@@ -143,7 +141,7 @@ index 0afc124..d03f146 100644
                                      MachineType::TaggedPointer()));
 -  LinkageLocationAllocator params(
 -      wasm::kGpParamRegisters, wasm::kFpParamRegisters, 0 /* no slot offset */);
- 
+-
 -  for (size_t i = 0;
 -       i < call_descriptor->ParameterCount() - (has_callable_param ? 1 : 0);
 -       i++) {
@@ -178,7 +176,7 @@ index 0afc124..d03f146 100644
 -  }
 -
 -  int return_slots = rets.NumStackSlots();
--
+ 
 -  auto sig = ReplaceTypeInSig(zone, call_descriptor->wasm_sig(), input_type,
 -                              output_type, num_replacements);
 +  int parameter_slots;

--- a/patches/v8/cherry-pick-723ed8a9cfff.patch
+++ b/patches/v8/cherry-pick-723ed8a9cfff.patch
@@ -1,0 +1,197 @@
+From 723ed8a9cfffede007ae3d675a961d3cabe67e30 Mon Sep 17 00:00:00 2001
+From: Jakob Kummerow <jkummerow@chromium.org>
+Date: Mon, 02 May 2022 19:52:11 +0200
+Subject: [PATCH] Merged: [wasm] Fix Int64Lowering for tagged stack-passed parameters
+
+When lowering signatures, we must preserve the separation of parameters
+into tagged and untagged sections.
+
+Fixed: chromium:1320614
+(cherry picked from commit 8062598f26127d833c237acb3da154c91c1ec7e7)
+
+Change-Id: I2f84535f785ce5c96e9c892994416986965eaa40
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3632515
+Commit-Queue: Jakob Kummerow <jkummerow@chromium.org>
+Reviewed-by: Shu-yu Guo <syg@chromium.org>
+Cr-Commit-Position: refs/branch-heads/10.1@{#28}
+Cr-Branched-From: b003970395b7efcc309eb30b4ca06dd8385acd55-refs/heads/10.1.124@{#1}
+Cr-Branched-From: e62f556862624103ea1da5b9dcef9b216832033b-refs/heads/main@{#79503}
+---
+
+diff --git a/src/compiler/wasm-compiler.cc b/src/compiler/wasm-compiler.cc
+index 0afc124..d03f146 100644
+--- a/src/compiler/wasm-compiler.cc
++++ b/src/compiler/wasm-compiler.cc
+@@ -8555,16 +8555,10 @@
+   // must be offset to just before the param slots, using this |slot_offset_|.
+   int slot_offset_;
+ };
+-}  // namespace
+ 
+-// General code uses the above configuration data.
+-CallDescriptor* GetWasmCallDescriptor(Zone* zone, const wasm::FunctionSig* fsig,
+-                                      WasmCallKind call_kind,
+-                                      bool need_frame_state) {
+-  // The extra here is to accomodate the instance object as first parameter
+-  // and, when specified, the additional callable.
+-  bool extra_callable_param =
+-      call_kind == kWasmImportWrapper || call_kind == kWasmCapiFunction;
++LocationSignature* BuildLocations(Zone* zone, const wasm::FunctionSig* fsig,
++                                  bool extra_callable_param,
++                                  int* parameter_slots, int* return_slots) {
+   int extra_params = extra_callable_param ? 2 : 1;
+   LocationSignature::Builder locations(zone, fsig->return_count(),
+                                        fsig->parameter_count() + extra_params);
+@@ -8607,19 +8601,37 @@
+         kJSFunctionRegister.code(), MachineType::TaggedPointer()));
+   }
+ 
+-  int parameter_slots = AddArgumentPaddingSlots(params.NumStackSlots());
++  *parameter_slots = AddArgumentPaddingSlots(params.NumStackSlots());
+ 
+   // Add return location(s).
+   LinkageLocationAllocator rets(wasm::kGpReturnRegisters,
+-                                wasm::kFpReturnRegisters, parameter_slots);
++                                wasm::kFpReturnRegisters, *parameter_slots);
+ 
+-  const int return_count = static_cast<int>(locations.return_count_);
+-  for (int i = 0; i < return_count; i++) {
++  const size_t return_count = locations.return_count_;
++  for (size_t i = 0; i < return_count; i++) {
+     MachineRepresentation ret = fsig->GetReturn(i).machine_representation();
+     locations.AddReturn(rets.Next(ret));
+   }
+ 
+-  int return_slots = rets.NumStackSlots();
++  *return_slots = rets.NumStackSlots();
++
++  return locations.Build();
++}
++}  // namespace
++
++// General code uses the above configuration data.
++CallDescriptor* GetWasmCallDescriptor(Zone* zone, const wasm::FunctionSig* fsig,
++                                      WasmCallKind call_kind,
++                                      bool need_frame_state) {
++  // The extra here is to accomodate the instance object as first parameter
++  // and, when specified, the additional callable.
++  bool extra_callable_param =
++      call_kind == kWasmImportWrapper || call_kind == kWasmCapiFunction;
++
++  int parameter_slots;
++  int return_slots;
++  LocationSignature* location_sig = BuildLocations(
++      zone, fsig, extra_callable_param, &parameter_slots, &return_slots);
+ 
+   const RegList kCalleeSaveRegisters;
+   const DoubleRegList kCalleeSaveFPRegisters;
+@@ -8645,7 +8657,7 @@
+       descriptor_kind,                    // kind
+       target_type,                        // target MachineType
+       target_loc,                         // target location
+-      locations.Build(),                  // location_sig
++      location_sig,                       // location_sig
+       parameter_slots,                    // parameter slot count
+       compiler::Operator::kNoProperties,  // properties
+       kCalleeSaveRegisters,               // callee-saved registers
+@@ -8696,78 +8708,45 @@
+ CallDescriptor* ReplaceTypeInCallDescriptorWith(
+     Zone* zone, const CallDescriptor* call_descriptor, size_t num_replacements,
+     wasm::ValueType input_type, wasm::ValueType output_type) {
+-  size_t parameter_count = call_descriptor->ParameterCount();
+-  size_t return_count = call_descriptor->ReturnCount();
+-  for (size_t i = 0; i < call_descriptor->ParameterCount(); i++) {
+-    if (call_descriptor->GetParameterType(i) == input_type.machine_type()) {
+-      parameter_count += num_replacements - 1;
++  if (call_descriptor->wasm_sig() == nullptr) {
++    // This happens for builtins calls. They need no replacements anyway.
++#if DEBUG
++    for (size_t i = 0; i < call_descriptor->ParameterCount(); i++) {
++      DCHECK_NE(call_descriptor->GetParameterType(i),
++                input_type.machine_type());
+     }
+-  }
+-  for (size_t i = 0; i < call_descriptor->ReturnCount(); i++) {
+-    if (call_descriptor->GetReturnType(i) == input_type.machine_type()) {
+-      return_count += num_replacements - 1;
++    for (size_t i = 0; i < call_descriptor->ReturnCount(); i++) {
++      DCHECK_NE(call_descriptor->GetReturnType(i), input_type.machine_type());
+     }
+-  }
+-  if (parameter_count == call_descriptor->ParameterCount() &&
+-      return_count == call_descriptor->ReturnCount()) {
++#endif
+     return const_cast<CallDescriptor*>(call_descriptor);
+   }
+-
+-  LocationSignature::Builder locations(zone, return_count, parameter_count);
++  const wasm::FunctionSig* sig =
++      ReplaceTypeInSig(zone, call_descriptor->wasm_sig(), input_type,
++                       output_type, num_replacements);
++  // If {ReplaceTypeInSig} took the early fast path, there's nothing to do.
++  if (sig == call_descriptor->wasm_sig()) {
++    return const_cast<CallDescriptor*>(call_descriptor);
++  }
+ 
+   // The last parameter may be the special callable parameter. In that case we
+   // have to preserve it as the last parameter, i.e. we allocate it in the new
+   // location signature again in the same register.
+-  bool has_callable_param =
++  bool extra_callable_param =
+       (call_descriptor->GetInputLocation(call_descriptor->InputCount() - 1) ==
+        LinkageLocation::ForRegister(kJSFunctionRegister.code(),
+                                     MachineType::TaggedPointer()));
+-  LinkageLocationAllocator params(
+-      wasm::kGpParamRegisters, wasm::kFpParamRegisters, 0 /* no slot offset */);
+ 
+-  for (size_t i = 0;
+-       i < call_descriptor->ParameterCount() - (has_callable_param ? 1 : 0);
+-       i++) {
+-    if (call_descriptor->GetParameterType(i) == input_type.machine_type()) {
+-      for (size_t j = 0; j < num_replacements; j++) {
+-        locations.AddParam(params.Next(output_type.machine_representation()));
+-      }
+-    } else {
+-      locations.AddParam(
+-          params.Next(call_descriptor->GetParameterType(i).representation()));
+-    }
+-  }
+-  if (has_callable_param) {
+-    locations.AddParam(LinkageLocation::ForRegister(
+-        kJSFunctionRegister.code(), MachineType::TaggedPointer()));
+-  }
+-
+-  int parameter_slots = AddArgumentPaddingSlots(params.NumStackSlots());
+-
+-  LinkageLocationAllocator rets(wasm::kGpReturnRegisters,
+-                                wasm::kFpReturnRegisters, parameter_slots);
+-
+-  for (size_t i = 0; i < call_descriptor->ReturnCount(); i++) {
+-    if (call_descriptor->GetReturnType(i) == input_type.machine_type()) {
+-      for (size_t j = 0; j < num_replacements; j++) {
+-        locations.AddReturn(rets.Next(output_type.machine_representation()));
+-      }
+-    } else {
+-      locations.AddReturn(
+-          rets.Next(call_descriptor->GetReturnType(i).representation()));
+-    }
+-  }
+-
+-  int return_slots = rets.NumStackSlots();
+-
+-  auto sig = ReplaceTypeInSig(zone, call_descriptor->wasm_sig(), input_type,
+-                              output_type, num_replacements);
++  int parameter_slots;
++  int return_slots;
++  LocationSignature* location_sig = BuildLocations(
++      zone, sig, extra_callable_param, &parameter_slots, &return_slots);
+ 
+   return zone->New<CallDescriptor>(               // --
+       call_descriptor->kind(),                    // kind
+       call_descriptor->GetInputType(0),           // target MachineType
+       call_descriptor->GetInputLocation(0),       // target location
+-      locations.Build(),                          // location_sig
++      location_sig,                               // location_sig
+       parameter_slots,                            // parameter slot count
+       call_descriptor->properties(),              // properties
+       call_descriptor->CalleeSavedRegisters(),    // callee-saved registers


### PR DESCRIPTION
Merged: [wasm] Fix Int64Lowering for tagged stack-passed parameters

When lowering signatures, we must preserve the separation of parameters
into tagged and untagged sections.

Fixed: chromium:1320614
(cherry picked from commit 8062598f26127d833c237acb3da154c91c1ec7e7)

Change-Id: I2f84535f785ce5c96e9c892994416986965eaa40
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3632515
Commit-Queue: Jakob Kummerow <jkummerow@chromium.org>
Reviewed-by: Shu-yu Guo <syg@chromium.org>
Cr-Commit-Position: refs/branch-heads/10.1@{#28}
Cr-Branched-From: b003970395b7efcc309eb30b4ca06dd8385acd55-refs/heads/10.1.124@{#1}
Cr-Branched-From: e62f556862624103ea1da5b9dcef9b216832033b-refs/heads/main@{#79503}


Notes: Backported fix for chromium:1320614.