### PR TITLE
fix: delayed bounds when moving/resizing and preventing default

### DIFF
--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -296,6 +296,7 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
                              &prevent_default);
       if (prevent_default) {
         ::GetWindowRect(hwnd, reinterpret_cast<RECT*>(l_param));
+        pending_bounds_change_.reset();
         return true;  // Tells Windows that the Sizing is handled.
       }
       return false;
@@ -334,6 +335,7 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       NotifyWindowWillMove(dpi_bounds, &prevent_default);
       if (!movable_ || prevent_default) {
         ::GetWindowRect(hwnd, reinterpret_cast<RECT*>(l_param));
+        pending_bounds_change_.reset();
         return true;  // Tells Windows that the Move is handled. If not true,
                       // frameless windows can be moved using
                       // -webkit-app-region: drag elements.


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/33897.
Refs https://github.com/electron/electron/pull/33288.

Fixes an issue where bounds changes were incorrectly delayed in the case where a window was moved or resized and `event.preventDefault` was called in either `will-resize` or `will-move`. We can assume in this case that we should prevent the pending bounds if the user is overridding functionality in either callback.

Tested with https://gist.github.com/ccc3e3fa4f724b5d717d9fc8f9c8dfe2 as well as https://gist.github.com/6b6ea5cdaa1883656a8bd0bf89195283 to ensure no regression of the initial issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where bounds changes were incorrectly delayed in the case where a window was moved or resized and `event.preventDefault` was called in either `will-resize` or `will-move` on Windows.
