### PR TITLE
fix: building node modules with Visual Studio 2017

### DIFF
--- a/patches/v8/fix_build_deprecated_attribute_for_older_msvc_versions.patch
+++ b/patches/v8/fix_build_deprecated_attribute_for_older_msvc_versions.patch
@@ -6,7 +6,7 @@ Subject: fix: usage of c++ [[deprecated]] attribute for older msvc versions
 This attribute can only be used in all contexts in Visual Studio 2019
 
 diff --git a/include/v8config.h b/include/v8config.h
-index 77fd65c6c5b7d8c0a7fe7a37c40e17ce66f49ce6..d203053d41c702733f5f3b950aa31cef74c2ab57 100644
+index 77fd65c6c5b7d8c0a7fe7a37c40e17ce66f49ce6..644f921f970d214b4d93b1e4c384e7475740b485 100644
 --- a/include/v8config.h
 +++ b/include/v8config.h
 @@ -454,10 +454,13 @@ path. Add it with -I<path> to the command line
@@ -25,7 +25,7 @@ index 77fd65c6c5b7d8c0a7fe7a37c40e17ce66f49ce6..d203053d41c702733f5f3b950aa31cef
  #else
  # define V8_DEPRECATED(message)
  #endif
-@@ -465,7 +468,11 @@ path. Add it with -I<path> to the command line
+@@ -465,13 +468,17 @@ path. Add it with -I<path> to the command line
  
  // A macro (V8_DEPRECATE_SOON) to make it easier to see what will be deprecated.
  #if defined(V8_IMMINENT_DEPRECATION_WARNINGS)
@@ -38,3 +38,10 @@ index 77fd65c6c5b7d8c0a7fe7a37c40e17ce66f49ce6..d203053d41c702733f5f3b950aa31cef
  #else
  # define V8_DEPRECATE_SOON(message)
  #endif
+ 
+ 
+-#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 6)
++#if !defined(__clang__) && (defined(__GNUC__) && __GNUC__ < 6) || (defined(_MSC_VER) && _MSC_VER < 1920)
+ # define V8_ENUM_DEPRECATED(message)
+ # define V8_ENUM_DEPRECATE_SOON(message)
+ #else


### PR DESCRIPTION
#### Description of Change
Build error occurs due to this in Visual Studio 2017:
```cpp
/**
 * Weakness type for weak handles.
 */
enum class WeakCallbackType {
  /**
   * Passes a user-defined void* parameter back to the callback.
   */
  kParameter,
  /**
   * Passes the first two internal fields of the object back to the callback.
   */
  kInternalFields,
  /**
   * Passes a user-defined void* parameter back to the callback. Will do so
   * before the object is actually reclaimed, allowing it to be resurrected. In
   * this case it is not possible to set a second-pass callback.
   */
  kFinalizer V8_ENUM_DEPRECATED("Resurrecting finalizers are deprecated "
                                "and will not be supported going forward.")
};
```

In Electron 18, this was previously:
```cpp
enum class WeakCallbackType { kParameter, kInternalFields, kFinalizer };
```

Follow-up to #34109

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed building node modules with Visual Studio 2017