### PR TITLE
docs: note `safeStorage.isEncryptionAvailable()` needs ready event

### DIFF
--- a/docs/api/safe-storage.md
+++ b/docs/api/safe-storage.md
@@ -20,7 +20,7 @@ Returns `Boolean` - Whether encryption is available.
 
 On Linux, returns true if the secret key is
 available. On MacOS, returns true if Keychain is available.
-On Windows, returns true with no other preconditions.
+On Windows, returns true once the app has emitted the `ready` event.
 
 ### `safeStorage.encryptString(plainText)`
 


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/33724.

See that PR for details.

Notes: none.