### PR TITLE
chore: cherry-pick 14e51893e5 from icu

### DIFF
--- a/patches/config.json
+++ b/patches/config.json
@@ -19,5 +19,7 @@
 
   "src/electron/patches/angle": "src/third_party/angle",
 
-  "src/electron/patches/skia": "src/third_party/skia"
+  "src/electron/patches/skia": "src/third_party/skia",
+
+  "src/electron/patches/icu": "src/third_party/icu"
 }

--- a/patches/icu/.patches
+++ b/patches/icu/.patches
@@ -1,0 +1,1 @@
+m100_cp_pr_2070_fix_int32_overflow.patch

--- a/patches/icu/m100_cp_pr_2070_fix_int32_overflow.patch
+++ b/patches/icu/m100_cp_pr_2070_fix_int32_overflow.patch
@@ -1,0 +1,1148 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Frank Tang <ftang@chromium.org>
+Date: Fri, 29 Apr 2022 16:50:59 -0700
+Subject: [m100] CP PR 2070 fix int32 overflow
+
+https://github.com/unicode-org/icu/pull/2070
+https://unicode-org.atlassian.net/browse/ICU-22005
+
+Bug: chromium:1316946
+Change-Id: I6cd7d687a55b6cc157b1afa52365908be2992fa6
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/deps/icu/+/3614280
+Reviewed-by: Jungshik Shin <jshin@chromium.org>
+(cherry picked from commit 85814e1af52482199a13d284545623ffbc9eef83)
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/deps/icu/+/3632709
+
+diff --git a/README.chromium b/README.chromium
+index fe29431ee485858aa600c29d30e364362d667178..815d7d57d69d6d0333c0431c0bd37537b5f39392 100644
+--- a/README.chromium
++++ b/README.chromium
+@@ -282,3 +282,7 @@ D. Local Modifications
+   - upstream PR:
+     https://github.com/unicode-org/icu/pull/1762
+ 
++12. Patch i18n/formatted_string_builder to fix int32_t overflow bug
++    patches/formatted_string_builder.patch
++  - https://github.com/unicode-org/icu/pull/2070
++  - https://unicode-org.atlassian.net/browse/ICU-22005
+diff --git a/patches/formatted_string_builder.patch b/patches/formatted_string_builder.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..fc8d8a01b2f2ecf4df4d8dc5535f56d7cc637415
+--- /dev/null
++++ b/patches/formatted_string_builder.patch
+@@ -0,0 +1,191 @@
++diff --git a/source/i18n/formatted_string_builder.cpp b/source/i18n/formatted_string_builder.cpp
++index 73407864..628fbea8 100644
++--- a/source/i18n/formatted_string_builder.cpp
+++++ b/source/i18n/formatted_string_builder.cpp
++@@ -6,6 +6,7 @@
++ #if !UCONFIG_NO_FORMATTING
++ 
++ #include "formatted_string_builder.h"
+++#include "putilimp.h"
++ #include "unicode/ustring.h"
++ #include "unicode/utf16.h"
++ #include "unicode/unum.h" // for UNumberFormatFields literals
++@@ -197,6 +198,9 @@ FormattedStringBuilder::splice(int32_t startThis, int32_t endThis,  const Unicod
++     int32_t thisLength = endThis - startThis;
++     int32_t otherLength = endOther - startOther;
++     int32_t count = otherLength - thisLength;
+++    if (U_FAILURE(status)) {
+++        return count;
+++    }
++     int32_t position;
++     if (count > 0) {
++         // Overall, chars need to be added.
++@@ -221,6 +225,9 @@ int32_t FormattedStringBuilder::append(const FormattedStringBuilder &other, UErr
++ 
++ int32_t
++ FormattedStringBuilder::insert(int32_t index, const FormattedStringBuilder &other, UErrorCode &status) {
+++    if (U_FAILURE(status)) {
+++        return 0;
+++    }
++     if (this == &other) {
++         status = U_ILLEGAL_ARGUMENT_ERROR;
++         return 0;
++@@ -255,12 +262,18 @@ int32_t FormattedStringBuilder::prepareForInsert(int32_t index, int32_t count, U
++     U_ASSERT(index >= 0);
++     U_ASSERT(index <= fLength);
++     U_ASSERT(count >= 0);
+++    U_ASSERT(fZero >= 0);
+++    U_ASSERT(fLength >= 0);
+++    U_ASSERT(getCapacity() - fZero >= fLength);
+++    if (U_FAILURE(status)) {
+++        return count;
+++    }
++     if (index == 0 && fZero - count >= 0) {
++         // Append to start
++         fZero -= count;
++         fLength += count;
++         return fZero;
++-    } else if (index == fLength && fZero + fLength + count < getCapacity()) {
+++    } else if (index == fLength && count <= getCapacity() - fZero - fLength) {
++         // Append to end
++         fLength += count;
++         return fZero + fLength - count;
++@@ -275,18 +288,26 @@ int32_t FormattedStringBuilder::prepareForInsertHelper(int32_t index, int32_t co
++     int32_t oldZero = fZero;
++     char16_t *oldChars = getCharPtr();
++     Field *oldFields = getFieldPtr();
++-    if (fLength + count > oldCapacity) {
++-        if ((fLength + count) > INT32_MAX / 2) {
++-            // If we continue, then newCapacity will overflow int32_t in the next line.
+++    int32_t newLength;
+++    if (uprv_add32_overflow(fLength, count, &newLength)) {
+++        status = U_INPUT_TOO_LONG_ERROR;
+++        return -1;
+++    }
+++    int32_t newZero;
+++    if (newLength > oldCapacity) {
+++        if (newLength > INT32_MAX / 2) {
+++            // We do not support more than 1G char16_t in this code because
+++            // dealing with >2G *bytes* can cause subtle bugs.
++             status = U_INPUT_TOO_LONG_ERROR;
++             return -1;
++         }
++-        int32_t newCapacity = (fLength + count) * 2;
++-        int32_t newZero = newCapacity / 2 - (fLength + count) / 2;
+++        // Keep newCapacity also to at most 1G char16_t.
+++        int32_t newCapacity = newLength * 2;
+++        newZero = (newCapacity - newLength) / 2;
++ 
++         // C++ note: malloc appears in two places: here and in the assignment operator.
++-        auto newChars = static_cast<char16_t *> (uprv_malloc(sizeof(char16_t) * newCapacity));
++-        auto newFields = static_cast<Field *>(uprv_malloc(sizeof(Field) * newCapacity));
+++        auto newChars = static_cast<char16_t *> (uprv_malloc(sizeof(char16_t) * static_cast<size_t>(newCapacity)));
+++        auto newFields = static_cast<Field *>(uprv_malloc(sizeof(Field) * static_cast<size_t>(newCapacity)));
++         if (newChars == nullptr || newFields == nullptr) {
++             uprv_free(newChars);
++             uprv_free(newFields);
++@@ -315,10 +336,8 @@ int32_t FormattedStringBuilder::prepareForInsertHelper(int32_t index, int32_t co
++         fChars.heap.capacity = newCapacity;
++         fFields.heap.ptr = newFields;
++         fFields.heap.capacity = newCapacity;
++-        fZero = newZero;
++-        fLength += count;
++     } else {
++-        int32_t newZero = oldCapacity / 2 - (fLength + count) / 2;
+++        newZero = (oldCapacity - newLength) / 2;
++ 
++         // C++ note: memmove is required because src and dest may overlap.
++         // First copy the entire string to the location of the prefix, and then move the suffix
++@@ -331,18 +350,20 @@ int32_t FormattedStringBuilder::prepareForInsertHelper(int32_t index, int32_t co
++         uprv_memmove2(oldFields + newZero + index + count,
++                 oldFields + newZero + index,
++                 sizeof(Field) * (fLength - index));
++-
++-        fZero = newZero;
++-        fLength += count;
++     }
++-    U_ASSERT((fZero + index) >= 0);
+++    fZero = newZero;
+++    fLength = newLength;
++     return fZero + index;
++ }
++ 
++ int32_t FormattedStringBuilder::remove(int32_t index, int32_t count) {
++-    // TODO: Reset the heap here?  (If the string after removal can fit on stack?)
+++     U_ASSERT(0 <= index);
+++     U_ASSERT(index <= fLength);
+++     U_ASSERT(count <= (fLength - index));
+++     U_ASSERT(index <= getCapacity() - fZero);
+++
++     int32_t position = index + fZero;
++-    U_ASSERT(position >= 0);
+++    // TODO: Reset the heap here?  (If the string after removal can fit on stack?)
++     uprv_memmove2(getCharPtr() + position,
++             getCharPtr() + position + count,
++             sizeof(char16_t) * (fLength - index - count));
++diff --git a/source/test/intltest/formatted_string_builder_test.cpp b/source/test/intltest/formatted_string_builder_test.cpp
++index 45721a32..57294e24 100644
++--- a/source/test/intltest/formatted_string_builder_test.cpp
+++++ b/source/test/intltest/formatted_string_builder_test.cpp
++@@ -22,6 +22,7 @@ class FormattedStringBuilderTest : public IntlTest {
++     void testFields();
++     void testUnlimitedCapacity();
++     void testCodePoints();
+++    void testInsertOverflow();
++ 
++     void runIndexedTest(int32_t index, UBool exec, const char *&name, char *par = 0) override;
++ 
++@@ -50,6 +51,7 @@ void FormattedStringBuilderTest::runIndexedTest(int32_t index, UBool exec, const
++         TESTCASE_AUTO(testFields);
++         TESTCASE_AUTO(testUnlimitedCapacity);
++         TESTCASE_AUTO(testCodePoints);
+++        TESTCASE_AUTO(testInsertOverflow);
++     TESTCASE_AUTO_END;
++ }
++ 
++@@ -308,6 +310,45 @@ void FormattedStringBuilderTest::testCodePoints() {
++     assertEquals("Code point count is 2", 2, nsb.codePointCount());
++ }
++ 
+++void FormattedStringBuilderTest::testInsertOverflow() {
+++    if (quick) return;
+++    // Setup the test fixture in sb, sb2, ustr.
+++    UErrorCode status = U_ZERO_ERROR;
+++    FormattedStringBuilder sb;
+++    int32_t data_length = INT32_MAX / 2;
+++    UnicodeString ustr(data_length, u'a', data_length);
+++    sb.append(ustr, kUndefinedField, status);
+++    assertSuccess("Setup the first FormattedStringBuilder", status);
+++
+++    FormattedStringBuilder sb2;
+++    sb2.append(ustr, kUndefinedField, status);
+++    sb2.insert(0, ustr, 0, data_length / 2, kUndefinedField, status);
+++    sb2.writeTerminator(status);
+++    assertSuccess("Setup the second FormattedStringBuilder", status);
+++
+++    ustr = sb2.toUnicodeString();
+++    // Complete setting up the test fixture in sb, sb2 and ustr.
+++
+++    // Test splice() of the second UnicodeString
+++    sb.splice(0, 1, ustr, 1, ustr.length(),
+++              kUndefinedField, status);
+++    assertEquals(
+++        "splice() long text should not crash but return U_INPUT_TOO_LONG_ERROR",
+++        U_INPUT_TOO_LONG_ERROR, status);
+++
+++    // Test sb.insert() of the first FormattedStringBuilder with the second one.
+++    sb.insert(0, sb2, status);
+++    assertEquals(
+++        "insert() long FormattedStringBuilder should not crash but return "
+++        "U_INPUT_TOO_LONG_ERROR", U_INPUT_TOO_LONG_ERROR, status);
+++
+++    // Test sb.insert() of the first FormattedStringBuilder with UnicodeString.
+++    sb.insert(0, ustr, 0, ustr.length(), kUndefinedField, status);
+++    assertEquals(
+++        "insert() long UnicodeString should not crash but return "
+++        "U_INPUT_TOO_LONG_ERROR", U_INPUT_TOO_LONG_ERROR, status);
+++}
+++
++ void FormattedStringBuilderTest::assertEqualsImpl(const UnicodeString &a, const FormattedStringBuilder &b) {
++     // TODO: Why won't this compile without the IntlTest:: qualifier?
++     IntlTest::assertEquals("Lengths should be the same", a.length(), b.length());
+diff --git a/source/i18n/formatted_string_builder.cpp b/source/i18n/formatted_string_builder.cpp
+index b370f14f2ac4ff0873e5614376ae51fe0232b02d..1726e632a91f44dfff7b2205301c7cd19dccb964 100644
+--- a/source/i18n/formatted_string_builder.cpp
++++ b/source/i18n/formatted_string_builder.cpp
+@@ -1,449 +1,470 @@
+-// © 2017 and later: Unicode, Inc. and others.
+-// License & terms of use: http://www.unicode.org/copyright.html
+-
+-#include "unicode/utypes.h"
+-
+-#if !UCONFIG_NO_FORMATTING
+-
+-#include "formatted_string_builder.h"
+-#include "unicode/ustring.h"
+-#include "unicode/utf16.h"
+-#include "unicode/unum.h" // for UNumberFormatFields literals
+-
+-namespace {
+-
+-// A version of uprv_memcpy that checks for length 0.
+-// By default, uprv_memcpy requires a length of at least 1.
+-inline void uprv_memcpy2(void* dest, const void* src, size_t len) {
+-    if (len > 0) {
+-        uprv_memcpy(dest, src, len);
+-    }
+-}
+-
+-// A version of uprv_memmove that checks for length 0.
+-// By default, uprv_memmove requires a length of at least 1.
+-inline void uprv_memmove2(void* dest, const void* src, size_t len) {
+-    if (len > 0) {
+-        uprv_memmove(dest, src, len);
+-    }
+-}
+-
+-} // namespace
+-
+-
+-U_NAMESPACE_BEGIN
+-
+-FormattedStringBuilder::FormattedStringBuilder() {
+-#if U_DEBUG
+-    // Initializing the memory to non-zero helps catch some bugs that involve
+-    // reading from an improperly terminated string.
+-    for (int32_t i=0; i<getCapacity(); i++) {
+-        getCharPtr()[i] = 1;
+-    }
+-#endif
+-}
+-
+-FormattedStringBuilder::~FormattedStringBuilder() {
+-    if (fUsingHeap) {
+-        uprv_free(fChars.heap.ptr);
+-        uprv_free(fFields.heap.ptr);
+-    }
+-}
+-
+-FormattedStringBuilder::FormattedStringBuilder(const FormattedStringBuilder &other) {
+-    *this = other;
+-}
+-
+-FormattedStringBuilder &FormattedStringBuilder::operator=(const FormattedStringBuilder &other) {
+-    // Check for self-assignment
+-    if (this == &other) {
+-        return *this;
+-    }
+-
+-    // Continue with deallocation and copying
+-    if (fUsingHeap) {
+-        uprv_free(fChars.heap.ptr);
+-        uprv_free(fFields.heap.ptr);
+-        fUsingHeap = false;
+-    }
+-
+-    int32_t capacity = other.getCapacity();
+-    if (capacity > DEFAULT_CAPACITY) {
+-        // FIXME: uprv_malloc
+-        // C++ note: malloc appears in two places: here and in prepareForInsertHelper.
+-        auto newChars = static_cast<char16_t *> (uprv_malloc(sizeof(char16_t) * capacity));
+-        auto newFields = static_cast<Field *>(uprv_malloc(sizeof(Field) * capacity));
+-        if (newChars == nullptr || newFields == nullptr) {
+-            // UErrorCode is not available; fail silently.
+-            uprv_free(newChars);
+-            uprv_free(newFields);
+-            *this = FormattedStringBuilder();  // can't fail
+-            return *this;
+-        }
+-
+-        fUsingHeap = true;
+-        fChars.heap.capacity = capacity;
+-        fChars.heap.ptr = newChars;
+-        fFields.heap.capacity = capacity;
+-        fFields.heap.ptr = newFields;
+-    }
+-
+-    uprv_memcpy2(getCharPtr(), other.getCharPtr(), sizeof(char16_t) * capacity);
+-    uprv_memcpy2(getFieldPtr(), other.getFieldPtr(), sizeof(Field) * capacity);
+-
+-    fZero = other.fZero;
+-    fLength = other.fLength;
+-    return *this;
+-}
+-
+-int32_t FormattedStringBuilder::length() const {
+-    return fLength;
+-}
+-
+-int32_t FormattedStringBuilder::codePointCount() const {
+-    return u_countChar32(getCharPtr() + fZero, fLength);
+-}
+-
+-UChar32 FormattedStringBuilder::getFirstCodePoint() const {
+-    if (fLength == 0) {
+-        return -1;
+-    }
+-    UChar32 cp;
+-    U16_GET(getCharPtr() + fZero, 0, 0, fLength, cp);
+-    return cp;
+-}
+-
+-UChar32 FormattedStringBuilder::getLastCodePoint() const {
+-    if (fLength == 0) {
+-        return -1;
+-    }
+-    int32_t offset = fLength;
+-    U16_BACK_1(getCharPtr() + fZero, 0, offset);
+-    UChar32 cp;
+-    U16_GET(getCharPtr() + fZero, 0, offset, fLength, cp);
+-    return cp;
+-}
+-
+-UChar32 FormattedStringBuilder::codePointAt(int32_t index) const {
+-    UChar32 cp;
+-    U16_GET(getCharPtr() + fZero, 0, index, fLength, cp);
+-    return cp;
+-}
+-
+-UChar32 FormattedStringBuilder::codePointBefore(int32_t index) const {
+-    int32_t offset = index;
+-    U16_BACK_1(getCharPtr() + fZero, 0, offset);
+-    UChar32 cp;
+-    U16_GET(getCharPtr() + fZero, 0, offset, fLength, cp);
+-    return cp;
+-}
+-
+-FormattedStringBuilder &FormattedStringBuilder::clear() {
+-    // TODO: Reset the heap here?
+-    fZero = getCapacity() / 2;
+-    fLength = 0;
+-    return *this;
+-}
+-
+-int32_t
+-FormattedStringBuilder::insertCodePoint(int32_t index, UChar32 codePoint, Field field, UErrorCode &status) {
+-    int32_t count = U16_LENGTH(codePoint);
+-    int32_t position = prepareForInsert(index, count, status);
+-    if (U_FAILURE(status)) {
+-        return count;
+-    }
+-    if (count == 1) {
+-        getCharPtr()[position] = (char16_t) codePoint;
+-        getFieldPtr()[position] = field;
+-    } else {
+-        getCharPtr()[position] = U16_LEAD(codePoint);
+-        getCharPtr()[position + 1] = U16_TRAIL(codePoint);
+-        getFieldPtr()[position] = getFieldPtr()[position + 1] = field;
+-    }
+-    return count;
+-}
+-
+-int32_t FormattedStringBuilder::insert(int32_t index, const UnicodeString &unistr, Field field,
+-                                    UErrorCode &status) {
+-    if (unistr.length() == 0) {
+-        // Nothing to insert.
+-        return 0;
+-    } else if (unistr.length() == 1) {
+-        // Fast path: insert using insertCodePoint.
+-        return insertCodePoint(index, unistr.charAt(0), field, status);
+-    } else {
+-        return insert(index, unistr, 0, unistr.length(), field, status);
+-    }
+-}
+-
+-int32_t
+-FormattedStringBuilder::insert(int32_t index, const UnicodeString &unistr, int32_t start, int32_t end,
+-                            Field field, UErrorCode &status) {
+-    int32_t count = end - start;
+-    int32_t position = prepareForInsert(index, count, status);
+-    if (U_FAILURE(status)) {
+-        return count;
+-    }
+-    for (int32_t i = 0; i < count; i++) {
+-        getCharPtr()[position + i] = unistr.charAt(start + i);
+-        getFieldPtr()[position + i] = field;
+-    }
+-    return count;
+-}
+-
+-int32_t
+-FormattedStringBuilder::splice(int32_t startThis, int32_t endThis,  const UnicodeString &unistr,
+-                            int32_t startOther, int32_t endOther, Field field, UErrorCode& status) {
+-    int32_t thisLength = endThis - startThis;
+-    int32_t otherLength = endOther - startOther;
+-    int32_t count = otherLength - thisLength;
+-    int32_t position;
+-    if (count > 0) {
+-        // Overall, chars need to be added.
+-        position = prepareForInsert(startThis, count, status);
+-    } else {
+-        // Overall, chars need to be removed or kept the same.
+-        position = remove(startThis, -count);
+-    }
+-    if (U_FAILURE(status)) {
+-        return count;
+-    }
+-    for (int32_t i = 0; i < otherLength; i++) {
+-        getCharPtr()[position + i] = unistr.charAt(startOther + i);
+-        getFieldPtr()[position + i] = field;
+-    }
+-    return count;
+-}
+-
+-int32_t FormattedStringBuilder::append(const FormattedStringBuilder &other, UErrorCode &status) {
+-    return insert(fLength, other, status);
+-}
+-
+-int32_t
+-FormattedStringBuilder::insert(int32_t index, const FormattedStringBuilder &other, UErrorCode &status) {
+-    if (this == &other) {
+-        status = U_ILLEGAL_ARGUMENT_ERROR;
+-        return 0;
+-    }
+-    int32_t count = other.fLength;
+-    if (count == 0) {
+-        // Nothing to insert.
+-        return 0;
+-    }
+-    int32_t position = prepareForInsert(index, count, status);
+-    if (U_FAILURE(status)) {
+-        return count;
+-    }
+-    for (int32_t i = 0; i < count; i++) {
+-        getCharPtr()[position + i] = other.charAt(i);
+-        getFieldPtr()[position + i] = other.fieldAt(i);
+-    }
+-    return count;
+-}
+-
+-void FormattedStringBuilder::writeTerminator(UErrorCode& status) {
+-    int32_t position = prepareForInsert(fLength, 1, status);
+-    if (U_FAILURE(status)) {
+-        return;
+-    }
+-    getCharPtr()[position] = 0;
+-    getFieldPtr()[position] = kUndefinedField;
+-    fLength--;
+-}
+-
+-int32_t FormattedStringBuilder::prepareForInsert(int32_t index, int32_t count, UErrorCode &status) {
+-    U_ASSERT(index >= 0);
+-    U_ASSERT(index <= fLength);
+-    U_ASSERT(count >= 0);
+-    if (index == 0 && fZero - count >= 0) {
+-        // Append to start
+-        fZero -= count;
+-        fLength += count;
+-        return fZero;
+-    } else if (index == fLength && fZero + fLength + count < getCapacity()) {
+-        // Append to end
+-        fLength += count;
+-        return fZero + fLength - count;
+-    } else {
+-        // Move chars around and/or allocate more space
+-        return prepareForInsertHelper(index, count, status);
+-    }
+-}
+-
+-int32_t FormattedStringBuilder::prepareForInsertHelper(int32_t index, int32_t count, UErrorCode &status) {
+-    int32_t oldCapacity = getCapacity();
+-    int32_t oldZero = fZero;
+-    char16_t *oldChars = getCharPtr();
+-    Field *oldFields = getFieldPtr();
+-    if (fLength + count > oldCapacity) {
+-        if ((fLength + count) > INT32_MAX / 2) {
+-            // If we continue, then newCapacity will overlow int32_t in the next line.
+-            status = U_INPUT_TOO_LONG_ERROR;
+-            return -1;
+-        }
+-        int32_t newCapacity = (fLength + count) * 2;
+-        int32_t newZero = newCapacity / 2 - (fLength + count) / 2;
+-
+-        // C++ note: malloc appears in two places: here and in the assignment operator.
+-        auto newChars = static_cast<char16_t *> (uprv_malloc(sizeof(char16_t) * newCapacity));
+-        auto newFields = static_cast<Field *>(uprv_malloc(sizeof(Field) * newCapacity));
+-        if (newChars == nullptr || newFields == nullptr) {
+-            uprv_free(newChars);
+-            uprv_free(newFields);
+-            status = U_MEMORY_ALLOCATION_ERROR;
+-            return -1;
+-        }
+-
+-        // First copy the prefix and then the suffix, leaving room for the new chars that the
+-        // caller wants to insert.
+-        // C++ note: memcpy is OK because the src and dest do not overlap.
+-        uprv_memcpy2(newChars + newZero, oldChars + oldZero, sizeof(char16_t) * index);
+-        uprv_memcpy2(newChars + newZero + index + count,
+-                oldChars + oldZero + index,
+-                sizeof(char16_t) * (fLength - index));
+-        uprv_memcpy2(newFields + newZero, oldFields + oldZero, sizeof(Field) * index);
+-        uprv_memcpy2(newFields + newZero + index + count,
+-                oldFields + oldZero + index,
+-                sizeof(Field) * (fLength - index));
+-
+-        if (fUsingHeap) {
+-            uprv_free(oldChars);
+-            uprv_free(oldFields);
+-        }
+-        fUsingHeap = true;
+-        fChars.heap.ptr = newChars;
+-        fChars.heap.capacity = newCapacity;
+-        fFields.heap.ptr = newFields;
+-        fFields.heap.capacity = newCapacity;
+-        fZero = newZero;
+-        fLength += count;
+-    } else {
+-        int32_t newZero = oldCapacity / 2 - (fLength + count) / 2;
+-
+-        // C++ note: memmove is required because src and dest may overlap.
+-        // First copy the entire string to the location of the prefix, and then move the suffix
+-        // to make room for the new chars that the caller wants to insert.
+-        uprv_memmove2(oldChars + newZero, oldChars + oldZero, sizeof(char16_t) * fLength);
+-        uprv_memmove2(oldChars + newZero + index + count,
+-                oldChars + newZero + index,
+-                sizeof(char16_t) * (fLength - index));
+-        uprv_memmove2(oldFields + newZero, oldFields + oldZero, sizeof(Field) * fLength);
+-        uprv_memmove2(oldFields + newZero + index + count,
+-                oldFields + newZero + index,
+-                sizeof(Field) * (fLength - index));
+-
+-        fZero = newZero;
+-        fLength += count;
+-    }
+-    U_ASSERT((fZero + index) >= 0);
+-    return fZero + index;
+-}
+-
+-int32_t FormattedStringBuilder::remove(int32_t index, int32_t count) {
+-    // TODO: Reset the heap here?  (If the string after removal can fit on stack?)
+-    int32_t position = index + fZero;
+-    U_ASSERT(position >= 0);
+-    uprv_memmove2(getCharPtr() + position,
+-            getCharPtr() + position + count,
+-            sizeof(char16_t) * (fLength - index - count));
+-    uprv_memmove2(getFieldPtr() + position,
+-            getFieldPtr() + position + count,
+-            sizeof(Field) * (fLength - index - count));
+-    fLength -= count;
+-    return position;
+-}
+-
+-UnicodeString FormattedStringBuilder::toUnicodeString() const {
+-    return UnicodeString(getCharPtr() + fZero, fLength);
+-}
+-
+-const UnicodeString FormattedStringBuilder::toTempUnicodeString() const {
+-    // Readonly-alias constructor:
+-    return UnicodeString(FALSE, getCharPtr() + fZero, fLength);
+-}
+-
+-UnicodeString FormattedStringBuilder::toDebugString() const {
+-    UnicodeString sb;
+-    sb.append(u"<FormattedStringBuilder [", -1);
+-    sb.append(toUnicodeString());
+-    sb.append(u"] [", -1);
+-    for (int i = 0; i < fLength; i++) {
+-        if (fieldAt(i) == kUndefinedField) {
+-            sb.append(u'n');
+-        } else if (fieldAt(i).getCategory() == UFIELD_CATEGORY_NUMBER) {
+-            char16_t c;
+-            switch (fieldAt(i).getField()) {
+-                case UNUM_SIGN_FIELD:
+-                    c = u'-';
+-                    break;
+-                case UNUM_INTEGER_FIELD:
+-                    c = u'i';
+-                    break;
+-                case UNUM_FRACTION_FIELD:
+-                    c = u'f';
+-                    break;
+-                case UNUM_EXPONENT_FIELD:
+-                    c = u'e';
+-                    break;
+-                case UNUM_EXPONENT_SIGN_FIELD:
+-                    c = u'+';
+-                    break;
+-                case UNUM_EXPONENT_SYMBOL_FIELD:
+-                    c = u'E';
+-                    break;
+-                case UNUM_DECIMAL_SEPARATOR_FIELD:
+-                    c = u'.';
+-                    break;
+-                case UNUM_GROUPING_SEPARATOR_FIELD:
+-                    c = u',';
+-                    break;
+-                case UNUM_PERCENT_FIELD:
+-                    c = u'%';
+-                    break;
+-                case UNUM_PERMILL_FIELD:
+-                    c = u'‰';
+-                    break;
+-                case UNUM_CURRENCY_FIELD:
+-                    c = u'$';
+-                    break;
+-                default:
+-                    c = u'0' + fieldAt(i).getField();
+-                    break;
+-            }
+-            sb.append(c);
+-        } else {
+-            sb.append(u'0' + fieldAt(i).getCategory());
+-        }
+-    }
+-    sb.append(u"]>", -1);
+-    return sb;
+-}
+-
+-const char16_t *FormattedStringBuilder::chars() const {
+-    return getCharPtr() + fZero;
+-}
+-
+-bool FormattedStringBuilder::contentEquals(const FormattedStringBuilder &other) const {
+-    if (fLength != other.fLength) {
+-        return false;
+-    }
+-    for (int32_t i = 0; i < fLength; i++) {
+-        if (charAt(i) != other.charAt(i) || fieldAt(i) != other.fieldAt(i)) {
+-            return false;
+-        }
+-    }
+-    return true;
+-}
+-
+-bool FormattedStringBuilder::containsField(Field field) const {
+-    for (int32_t i = 0; i < fLength; i++) {
+-        if (field == fieldAt(i)) {
+-            return true;
+-        }
+-    }
+-    return false;
+-}
+-
+-U_NAMESPACE_END
+-
+-#endif /* #if !UCONFIG_NO_FORMATTING */
++// © 2017 and later: Unicode, Inc. and others.
++// License & terms of use: http://www.unicode.org/copyright.html
++
++#include "unicode/utypes.h"
++
++#if !UCONFIG_NO_FORMATTING
++
++#include "formatted_string_builder.h"
++#include "putilimp.h"
++#include "unicode/ustring.h"
++#include "unicode/utf16.h"
++#include "unicode/unum.h" // for UNumberFormatFields literals
++
++namespace {
++
++// A version of uprv_memcpy that checks for length 0.
++// By default, uprv_memcpy requires a length of at least 1.
++inline void uprv_memcpy2(void* dest, const void* src, size_t len) {
++    if (len > 0) {
++        uprv_memcpy(dest, src, len);
++    }
++}
++
++// A version of uprv_memmove that checks for length 0.
++// By default, uprv_memmove requires a length of at least 1.
++inline void uprv_memmove2(void* dest, const void* src, size_t len) {
++    if (len > 0) {
++        uprv_memmove(dest, src, len);
++    }
++}
++
++} // namespace
++
++
++U_NAMESPACE_BEGIN
++
++FormattedStringBuilder::FormattedStringBuilder() {
++#if U_DEBUG
++    // Initializing the memory to non-zero helps catch some bugs that involve
++    // reading from an improperly terminated string.
++    for (int32_t i=0; i<getCapacity(); i++) {
++        getCharPtr()[i] = 1;
++    }
++#endif
++}
++
++FormattedStringBuilder::~FormattedStringBuilder() {
++    if (fUsingHeap) {
++        uprv_free(fChars.heap.ptr);
++        uprv_free(fFields.heap.ptr);
++    }
++}
++
++FormattedStringBuilder::FormattedStringBuilder(const FormattedStringBuilder &other) {
++    *this = other;
++}
++
++FormattedStringBuilder &FormattedStringBuilder::operator=(const FormattedStringBuilder &other) {
++    // Check for self-assignment
++    if (this == &other) {
++        return *this;
++    }
++
++    // Continue with deallocation and copying
++    if (fUsingHeap) {
++        uprv_free(fChars.heap.ptr);
++        uprv_free(fFields.heap.ptr);
++        fUsingHeap = false;
++    }
++
++    int32_t capacity = other.getCapacity();
++    if (capacity > DEFAULT_CAPACITY) {
++        // FIXME: uprv_malloc
++        // C++ note: malloc appears in two places: here and in prepareForInsertHelper.
++        auto newChars = static_cast<char16_t *> (uprv_malloc(sizeof(char16_t) * capacity));
++        auto newFields = static_cast<Field *>(uprv_malloc(sizeof(Field) * capacity));
++        if (newChars == nullptr || newFields == nullptr) {
++            // UErrorCode is not available; fail silently.
++            uprv_free(newChars);
++            uprv_free(newFields);
++            *this = FormattedStringBuilder();  // can't fail
++            return *this;
++        }
++
++        fUsingHeap = true;
++        fChars.heap.capacity = capacity;
++        fChars.heap.ptr = newChars;
++        fFields.heap.capacity = capacity;
++        fFields.heap.ptr = newFields;
++    }
++
++    uprv_memcpy2(getCharPtr(), other.getCharPtr(), sizeof(char16_t) * capacity);
++    uprv_memcpy2(getFieldPtr(), other.getFieldPtr(), sizeof(Field) * capacity);
++
++    fZero = other.fZero;
++    fLength = other.fLength;
++    return *this;
++}
++
++int32_t FormattedStringBuilder::length() const {
++    return fLength;
++}
++
++int32_t FormattedStringBuilder::codePointCount() const {
++    return u_countChar32(getCharPtr() + fZero, fLength);
++}
++
++UChar32 FormattedStringBuilder::getFirstCodePoint() const {
++    if (fLength == 0) {
++        return -1;
++    }
++    UChar32 cp;
++    U16_GET(getCharPtr() + fZero, 0, 0, fLength, cp);
++    return cp;
++}
++
++UChar32 FormattedStringBuilder::getLastCodePoint() const {
++    if (fLength == 0) {
++        return -1;
++    }
++    int32_t offset = fLength;
++    U16_BACK_1(getCharPtr() + fZero, 0, offset);
++    UChar32 cp;
++    U16_GET(getCharPtr() + fZero, 0, offset, fLength, cp);
++    return cp;
++}
++
++UChar32 FormattedStringBuilder::codePointAt(int32_t index) const {
++    UChar32 cp;
++    U16_GET(getCharPtr() + fZero, 0, index, fLength, cp);
++    return cp;
++}
++
++UChar32 FormattedStringBuilder::codePointBefore(int32_t index) const {
++    int32_t offset = index;
++    U16_BACK_1(getCharPtr() + fZero, 0, offset);
++    UChar32 cp;
++    U16_GET(getCharPtr() + fZero, 0, offset, fLength, cp);
++    return cp;
++}
++
++FormattedStringBuilder &FormattedStringBuilder::clear() {
++    // TODO: Reset the heap here?
++    fZero = getCapacity() / 2;
++    fLength = 0;
++    return *this;
++}
++
++int32_t
++FormattedStringBuilder::insertCodePoint(int32_t index, UChar32 codePoint, Field field, UErrorCode &status) {
++    int32_t count = U16_LENGTH(codePoint);
++    int32_t position = prepareForInsert(index, count, status);
++    if (U_FAILURE(status)) {
++        return count;
++    }
++    if (count == 1) {
++        getCharPtr()[position] = (char16_t) codePoint;
++        getFieldPtr()[position] = field;
++    } else {
++        getCharPtr()[position] = U16_LEAD(codePoint);
++        getCharPtr()[position + 1] = U16_TRAIL(codePoint);
++        getFieldPtr()[position] = getFieldPtr()[position + 1] = field;
++    }
++    return count;
++}
++
++int32_t FormattedStringBuilder::insert(int32_t index, const UnicodeString &unistr, Field field,
++                                    UErrorCode &status) {
++    if (unistr.length() == 0) {
++        // Nothing to insert.
++        return 0;
++    } else if (unistr.length() == 1) {
++        // Fast path: insert using insertCodePoint.
++        return insertCodePoint(index, unistr.charAt(0), field, status);
++    } else {
++        return insert(index, unistr, 0, unistr.length(), field, status);
++    }
++}
++
++int32_t
++FormattedStringBuilder::insert(int32_t index, const UnicodeString &unistr, int32_t start, int32_t end,
++                            Field field, UErrorCode &status) {
++    int32_t count = end - start;
++    int32_t position = prepareForInsert(index, count, status);
++    if (U_FAILURE(status)) {
++        return count;
++    }
++    for (int32_t i = 0; i < count; i++) {
++        getCharPtr()[position + i] = unistr.charAt(start + i);
++        getFieldPtr()[position + i] = field;
++    }
++    return count;
++}
++
++int32_t
++FormattedStringBuilder::splice(int32_t startThis, int32_t endThis,  const UnicodeString &unistr,
++                            int32_t startOther, int32_t endOther, Field field, UErrorCode& status) {
++    int32_t thisLength = endThis - startThis;
++    int32_t otherLength = endOther - startOther;
++    int32_t count = otherLength - thisLength;
++    if (U_FAILURE(status)) {
++        return count;
++    }
++    int32_t position;
++    if (count > 0) {
++        // Overall, chars need to be added.
++        position = prepareForInsert(startThis, count, status);
++    } else {
++        // Overall, chars need to be removed or kept the same.
++        position = remove(startThis, -count);
++    }
++    if (U_FAILURE(status)) {
++        return count;
++    }
++    for (int32_t i = 0; i < otherLength; i++) {
++        getCharPtr()[position + i] = unistr.charAt(startOther + i);
++        getFieldPtr()[position + i] = field;
++    }
++    return count;
++}
++
++int32_t FormattedStringBuilder::append(const FormattedStringBuilder &other, UErrorCode &status) {
++    return insert(fLength, other, status);
++}
++
++int32_t
++FormattedStringBuilder::insert(int32_t index, const FormattedStringBuilder &other, UErrorCode &status) {
++    if (U_FAILURE(status)) {
++        return 0;
++    }
++    if (this == &other) {
++        status = U_ILLEGAL_ARGUMENT_ERROR;
++        return 0;
++    }
++    int32_t count = other.fLength;
++    if (count == 0) {
++        // Nothing to insert.
++        return 0;
++    }
++    int32_t position = prepareForInsert(index, count, status);
++    if (U_FAILURE(status)) {
++        return count;
++    }
++    for (int32_t i = 0; i < count; i++) {
++        getCharPtr()[position + i] = other.charAt(i);
++        getFieldPtr()[position + i] = other.fieldAt(i);
++    }
++    return count;
++}
++
++void FormattedStringBuilder::writeTerminator(UErrorCode& status) {
++    int32_t position = prepareForInsert(fLength, 1, status);
++    if (U_FAILURE(status)) {
++        return;
++    }
++    getCharPtr()[position] = 0;
++    getFieldPtr()[position] = kUndefinedField;
++    fLength--;
++}
++
++int32_t FormattedStringBuilder::prepareForInsert(int32_t index, int32_t count, UErrorCode &status) {
++    U_ASSERT(index >= 0);
++    U_ASSERT(index <= fLength);
++    U_ASSERT(count >= 0);
++    U_ASSERT(fZero >= 0);
++    U_ASSERT(fLength >= 0);
++    U_ASSERT(getCapacity() - fZero >= fLength);
++    if (U_FAILURE(status)) {
++        return count;
++    }
++    if (index == 0 && fZero - count >= 0) {
++        // Append to start
++        fZero -= count;
++        fLength += count;
++        return fZero;
++    } else if (index == fLength && count <= getCapacity() - fZero - fLength) {
++        // Append to end
++        fLength += count;
++        return fZero + fLength - count;
++    } else {
++        // Move chars around and/or allocate more space
++        return prepareForInsertHelper(index, count, status);
++    }
++}
++
++int32_t FormattedStringBuilder::prepareForInsertHelper(int32_t index, int32_t count, UErrorCode &status) {
++    int32_t oldCapacity = getCapacity();
++    int32_t oldZero = fZero;
++    char16_t *oldChars = getCharPtr();
++    Field *oldFields = getFieldPtr();
++    int32_t newLength;
++    if (uprv_add32_overflow(fLength, count, &newLength)) {
++        status = U_INPUT_TOO_LONG_ERROR;
++        return -1;
++    }
++    int32_t newZero;
++    if (newLength > oldCapacity) {
++        if (newLength > INT32_MAX / 2) {
++            // We do not support more than 1G char16_t in this code because
++            // dealing with >2G *bytes* can cause subtle bugs.
++            status = U_INPUT_TOO_LONG_ERROR;
++            return -1;
++        }
++        // Keep newCapacity also to at most 1G char16_t.
++        int32_t newCapacity = newLength * 2;
++        newZero = (newCapacity - newLength) / 2;
++
++        // C++ note: malloc appears in two places: here and in the assignment operator.
++        auto newChars = static_cast<char16_t *> (uprv_malloc(sizeof(char16_t) * static_cast<size_t>(newCapacity)));
++        auto newFields = static_cast<Field *>(uprv_malloc(sizeof(Field) * static_cast<size_t>(newCapacity)));
++        if (newChars == nullptr || newFields == nullptr) {
++            uprv_free(newChars);
++            uprv_free(newFields);
++            status = U_MEMORY_ALLOCATION_ERROR;
++            return -1;
++        }
++
++        // First copy the prefix and then the suffix, leaving room for the new chars that the
++        // caller wants to insert.
++        // C++ note: memcpy is OK because the src and dest do not overlap.
++        uprv_memcpy2(newChars + newZero, oldChars + oldZero, sizeof(char16_t) * index);
++        uprv_memcpy2(newChars + newZero + index + count,
++                oldChars + oldZero + index,
++                sizeof(char16_t) * (fLength - index));
++        uprv_memcpy2(newFields + newZero, oldFields + oldZero, sizeof(Field) * index);
++        uprv_memcpy2(newFields + newZero + index + count,
++                oldFields + oldZero + index,
++                sizeof(Field) * (fLength - index));
++
++        if (fUsingHeap) {
++            uprv_free(oldChars);
++            uprv_free(oldFields);
++        }
++        fUsingHeap = true;
++        fChars.heap.ptr = newChars;
++        fChars.heap.capacity = newCapacity;
++        fFields.heap.ptr = newFields;
++        fFields.heap.capacity = newCapacity;
++    } else {
++        newZero = (oldCapacity - newLength) / 2;
++
++        // C++ note: memmove is required because src and dest may overlap.
++        // First copy the entire string to the location of the prefix, and then move the suffix
++        // to make room for the new chars that the caller wants to insert.
++        uprv_memmove2(oldChars + newZero, oldChars + oldZero, sizeof(char16_t) * fLength);
++        uprv_memmove2(oldChars + newZero + index + count,
++                oldChars + newZero + index,
++                sizeof(char16_t) * (fLength - index));
++        uprv_memmove2(oldFields + newZero, oldFields + oldZero, sizeof(Field) * fLength);
++        uprv_memmove2(oldFields + newZero + index + count,
++                oldFields + newZero + index,
++                sizeof(Field) * (fLength - index));
++    }
++    fZero = newZero;
++    fLength = newLength;
++    return fZero + index;
++}
++
++int32_t FormattedStringBuilder::remove(int32_t index, int32_t count) {
++     U_ASSERT(0 <= index);
++     U_ASSERT(index <= fLength);
++     U_ASSERT(count <= (fLength - index));
++     U_ASSERT(index <= getCapacity() - fZero);
++
++    int32_t position = index + fZero;
++    // TODO: Reset the heap here?  (If the string after removal can fit on stack?)
++    uprv_memmove2(getCharPtr() + position,
++            getCharPtr() + position + count,
++            sizeof(char16_t) * (fLength - index - count));
++    uprv_memmove2(getFieldPtr() + position,
++            getFieldPtr() + position + count,
++            sizeof(Field) * (fLength - index - count));
++    fLength -= count;
++    return position;
++}
++
++UnicodeString FormattedStringBuilder::toUnicodeString() const {
++    return UnicodeString(getCharPtr() + fZero, fLength);
++}
++
++const UnicodeString FormattedStringBuilder::toTempUnicodeString() const {
++    // Readonly-alias constructor:
++    return UnicodeString(FALSE, getCharPtr() + fZero, fLength);
++}
++
++UnicodeString FormattedStringBuilder::toDebugString() const {
++    UnicodeString sb;
++    sb.append(u"<FormattedStringBuilder [", -1);
++    sb.append(toUnicodeString());
++    sb.append(u"] [", -1);
++    for (int i = 0; i < fLength; i++) {
++        if (fieldAt(i) == kUndefinedField) {
++            sb.append(u'n');
++        } else if (fieldAt(i).getCategory() == UFIELD_CATEGORY_NUMBER) {
++            char16_t c;
++            switch (fieldAt(i).getField()) {
++                case UNUM_SIGN_FIELD:
++                    c = u'-';
++                    break;
++                case UNUM_INTEGER_FIELD:
++                    c = u'i';
++                    break;
++                case UNUM_FRACTION_FIELD:
++                    c = u'f';
++                    break;
++                case UNUM_EXPONENT_FIELD:
++                    c = u'e';
++                    break;
++                case UNUM_EXPONENT_SIGN_FIELD:
++                    c = u'+';
++                    break;
++                case UNUM_EXPONENT_SYMBOL_FIELD:
++                    c = u'E';
++                    break;
++                case UNUM_DECIMAL_SEPARATOR_FIELD:
++                    c = u'.';
++                    break;
++                case UNUM_GROUPING_SEPARATOR_FIELD:
++                    c = u',';
++                    break;
++                case UNUM_PERCENT_FIELD:
++                    c = u'%';
++                    break;
++                case UNUM_PERMILL_FIELD:
++                    c = u'‰';
++                    break;
++                case UNUM_CURRENCY_FIELD:
++                    c = u'$';
++                    break;
++                default:
++                    c = u'0' + fieldAt(i).getField();
++                    break;
++            }
++            sb.append(c);
++        } else {
++            sb.append(u'0' + fieldAt(i).getCategory());
++        }
++    }
++    sb.append(u"]>", -1);
++    return sb;
++}
++
++const char16_t *FormattedStringBuilder::chars() const {
++    return getCharPtr() + fZero;
++}
++
++bool FormattedStringBuilder::contentEquals(const FormattedStringBuilder &other) const {
++    if (fLength != other.fLength) {
++        return false;
++    }
++    for (int32_t i = 0; i < fLength; i++) {
++        if (charAt(i) != other.charAt(i) || fieldAt(i) != other.fieldAt(i)) {
++            return false;
++        }
++    }
++    return true;
++}
++
++bool FormattedStringBuilder::containsField(Field field) const {
++    for (int32_t i = 0; i < fLength; i++) {
++        if (field == fieldAt(i)) {
++            return true;
++        }
++    }
++    return false;
++}
++
++U_NAMESPACE_END
++
++#endif /* #if !UCONFIG_NO_FORMATTING */

--- a/patches/icu/m100_cp_pr_2070_fix_int32_overflow.patch
+++ b/patches/icu/m100_cp_pr_2070_fix_int32_overflow.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Frank Tang <ftang@chromium.org>
 Date: Fri, 29 Apr 2022 16:50:59 -0700
-Subject: [m100] CP PR 2070 fix int32 overflow
+Subject: CP PR 2070 fix int32 overflow
 
 https://github.com/unicode-org/icu/pull/2070
 https://unicode-org.atlassian.net/browse/ICU-22005
@@ -27,7 +27,7 @@ index fe29431ee485858aa600c29d30e364362d667178..815d7d57d69d6d0333c0431c0bd37537
 +  - https://unicode-org.atlassian.net/browse/ICU-22005
 diff --git a/patches/formatted_string_builder.patch b/patches/formatted_string_builder.patch
 new file mode 100644
-index 0000000000000000000000000000000000000000..fc8d8a01b2f2ecf4df4d8dc5535f56d7cc637415
+index 0000000000000000000000000000000000000000..4fad6f18601f7b4097e2d46bfe6660bec2e2882d
 --- /dev/null
 +++ b/patches/formatted_string_builder.patch
 @@ -0,0 +1,191 @@
@@ -37,7 +37,7 @@ index 0000000000000000000000000000000000000000..fc8d8a01b2f2ecf4df4d8dc5535f56d7
 ++++ b/source/i18n/formatted_string_builder.cpp
 +@@ -6,6 +6,7 @@
 + #if !UCONFIG_NO_FORMATTING
-+ 
++
 + #include "formatted_string_builder.h"
 ++#include "putilimp.h"
 + #include "unicode/ustring.h"
@@ -54,7 +54,7 @@ index 0000000000000000000000000000000000000000..fc8d8a01b2f2ecf4df4d8dc5535f56d7
 +     if (count > 0) {
 +         // Overall, chars need to be added.
 +@@ -221,6 +225,9 @@ int32_t FormattedStringBuilder::append(const FormattedStringBuilder &other, UErr
-+ 
++
 + int32_t
 + FormattedStringBuilder::insert(int32_t index, const FormattedStringBuilder &other, UErrorCode &status) {
 ++    if (U_FAILURE(status)) {
@@ -108,7 +108,7 @@ index 0000000000000000000000000000000000000000..fc8d8a01b2f2ecf4df4d8dc5535f56d7
 ++        // Keep newCapacity also to at most 1G char16_t.
 ++        int32_t newCapacity = newLength * 2;
 ++        newZero = (newCapacity - newLength) / 2;
-+ 
++
 +         // C++ note: malloc appears in two places: here and in the assignment operator.
 +-        auto newChars = static_cast<char16_t *> (uprv_malloc(sizeof(char16_t) * newCapacity));
 +-        auto newFields = static_cast<Field *>(uprv_malloc(sizeof(Field) * newCapacity));
@@ -126,7 +126,7 @@ index 0000000000000000000000000000000000000000..fc8d8a01b2f2ecf4df4d8dc5535f56d7
 +     } else {
 +-        int32_t newZero = oldCapacity / 2 - (fLength + count) / 2;
 ++        newZero = (oldCapacity - newLength) / 2;
-+ 
++
 +         // C++ note: memmove is required because src and dest may overlap.
 +         // First copy the entire string to the location of the prefix, and then move the suffix
 +@@ -331,18 +350,20 @@ int32_t FormattedStringBuilder::prepareForInsertHelper(int32_t index, int32_t co
@@ -142,7 +142,7 @@ index 0000000000000000000000000000000000000000..fc8d8a01b2f2ecf4df4d8dc5535f56d7
 ++    fLength = newLength;
 +     return fZero + index;
 + }
-+ 
++
 + int32_t FormattedStringBuilder::remove(int32_t index, int32_t count) {
 +-    // TODO: Reset the heap here?  (If the string after removal can fit on stack?)
 ++     U_ASSERT(0 <= index);
@@ -165,9 +165,9 @@ index 0000000000000000000000000000000000000000..fc8d8a01b2f2ecf4df4d8dc5535f56d7
 +     void testUnlimitedCapacity();
 +     void testCodePoints();
 ++    void testInsertOverflow();
-+ 
++
 +     void runIndexedTest(int32_t index, UBool exec, const char *&name, char *par = 0) override;
-+ 
++
 +@@ -50,6 +51,7 @@ void FormattedStringBuilderTest::runIndexedTest(int32_t index, UBool exec, const
 +         TESTCASE_AUTO(testFields);
 +         TESTCASE_AUTO(testUnlimitedCapacity);
@@ -175,11 +175,11 @@ index 0000000000000000000000000000000000000000..fc8d8a01b2f2ecf4df4d8dc5535f56d7
 ++        TESTCASE_AUTO(testInsertOverflow);
 +     TESTCASE_AUTO_END;
 + }
-+ 
++
 +@@ -308,6 +310,45 @@ void FormattedStringBuilderTest::testCodePoints() {
 +     assertEquals("Code point count is 2", 2, nsb.codePointCount());
 + }
-+ 
++
 ++void FormattedStringBuilderTest::testInsertOverflow() {
 ++    if (quick) return;
 ++    // Setup the test fixture in sb, sb2, ustr.
@@ -223,749 +223,64 @@ index 0000000000000000000000000000000000000000..fc8d8a01b2f2ecf4df4d8dc5535f56d7
 +     // TODO: Why won't this compile without the IntlTest:: qualifier?
 +     IntlTest::assertEquals("Lengths should be the same", a.length(), b.length());
 diff --git a/source/i18n/formatted_string_builder.cpp b/source/i18n/formatted_string_builder.cpp
-index b370f14f2ac4ff0873e5614376ae51fe0232b02d..1726e632a91f44dfff7b2205301c7cd19dccb964 100644
+index b370f14f2ac4ff0873e5614376ae51fe0232b02d..628fbea871167619f60cc6eed0ee4b7776dab7fe 100644
 --- a/source/i18n/formatted_string_builder.cpp
 +++ b/source/i18n/formatted_string_builder.cpp
-@@ -1,449 +1,470 @@
--// © 2017 and later: Unicode, Inc. and others.
--// License & terms of use: http://www.unicode.org/copyright.html
--
--#include "unicode/utypes.h"
--
--#if !UCONFIG_NO_FORMATTING
--
--#include "formatted_string_builder.h"
--#include "unicode/ustring.h"
--#include "unicode/utf16.h"
--#include "unicode/unum.h" // for UNumberFormatFields literals
--
--namespace {
--
--// A version of uprv_memcpy that checks for length 0.
--// By default, uprv_memcpy requires a length of at least 1.
--inline void uprv_memcpy2(void* dest, const void* src, size_t len) {
--    if (len > 0) {
--        uprv_memcpy(dest, src, len);
--    }
--}
--
--// A version of uprv_memmove that checks for length 0.
--// By default, uprv_memmove requires a length of at least 1.
--inline void uprv_memmove2(void* dest, const void* src, size_t len) {
--    if (len > 0) {
--        uprv_memmove(dest, src, len);
--    }
--}
--
--} // namespace
--
--
--U_NAMESPACE_BEGIN
--
--FormattedStringBuilder::FormattedStringBuilder() {
--#if U_DEBUG
--    // Initializing the memory to non-zero helps catch some bugs that involve
--    // reading from an improperly terminated string.
--    for (int32_t i=0; i<getCapacity(); i++) {
--        getCharPtr()[i] = 1;
--    }
--#endif
--}
--
--FormattedStringBuilder::~FormattedStringBuilder() {
--    if (fUsingHeap) {
--        uprv_free(fChars.heap.ptr);
--        uprv_free(fFields.heap.ptr);
--    }
--}
--
--FormattedStringBuilder::FormattedStringBuilder(const FormattedStringBuilder &other) {
--    *this = other;
--}
--
--FormattedStringBuilder &FormattedStringBuilder::operator=(const FormattedStringBuilder &other) {
--    // Check for self-assignment
--    if (this == &other) {
--        return *this;
--    }
--
--    // Continue with deallocation and copying
--    if (fUsingHeap) {
--        uprv_free(fChars.heap.ptr);
--        uprv_free(fFields.heap.ptr);
--        fUsingHeap = false;
--    }
--
--    int32_t capacity = other.getCapacity();
--    if (capacity > DEFAULT_CAPACITY) {
--        // FIXME: uprv_malloc
--        // C++ note: malloc appears in two places: here and in prepareForInsertHelper.
--        auto newChars = static_cast<char16_t *> (uprv_malloc(sizeof(char16_t) * capacity));
--        auto newFields = static_cast<Field *>(uprv_malloc(sizeof(Field) * capacity));
--        if (newChars == nullptr || newFields == nullptr) {
--            // UErrorCode is not available; fail silently.
--            uprv_free(newChars);
--            uprv_free(newFields);
--            *this = FormattedStringBuilder();  // can't fail
--            return *this;
--        }
--
--        fUsingHeap = true;
--        fChars.heap.capacity = capacity;
--        fChars.heap.ptr = newChars;
--        fFields.heap.capacity = capacity;
--        fFields.heap.ptr = newFields;
--    }
--
--    uprv_memcpy2(getCharPtr(), other.getCharPtr(), sizeof(char16_t) * capacity);
--    uprv_memcpy2(getFieldPtr(), other.getFieldPtr(), sizeof(Field) * capacity);
--
--    fZero = other.fZero;
--    fLength = other.fLength;
--    return *this;
--}
--
--int32_t FormattedStringBuilder::length() const {
--    return fLength;
--}
--
--int32_t FormattedStringBuilder::codePointCount() const {
--    return u_countChar32(getCharPtr() + fZero, fLength);
--}
--
--UChar32 FormattedStringBuilder::getFirstCodePoint() const {
--    if (fLength == 0) {
--        return -1;
--    }
--    UChar32 cp;
--    U16_GET(getCharPtr() + fZero, 0, 0, fLength, cp);
--    return cp;
--}
--
--UChar32 FormattedStringBuilder::getLastCodePoint() const {
--    if (fLength == 0) {
--        return -1;
--    }
--    int32_t offset = fLength;
--    U16_BACK_1(getCharPtr() + fZero, 0, offset);
--    UChar32 cp;
--    U16_GET(getCharPtr() + fZero, 0, offset, fLength, cp);
--    return cp;
--}
--
--UChar32 FormattedStringBuilder::codePointAt(int32_t index) const {
--    UChar32 cp;
--    U16_GET(getCharPtr() + fZero, 0, index, fLength, cp);
--    return cp;
--}
--
--UChar32 FormattedStringBuilder::codePointBefore(int32_t index) const {
--    int32_t offset = index;
--    U16_BACK_1(getCharPtr() + fZero, 0, offset);
--    UChar32 cp;
--    U16_GET(getCharPtr() + fZero, 0, offset, fLength, cp);
--    return cp;
--}
--
--FormattedStringBuilder &FormattedStringBuilder::clear() {
--    // TODO: Reset the heap here?
--    fZero = getCapacity() / 2;
--    fLength = 0;
--    return *this;
--}
--
--int32_t
--FormattedStringBuilder::insertCodePoint(int32_t index, UChar32 codePoint, Field field, UErrorCode &status) {
--    int32_t count = U16_LENGTH(codePoint);
--    int32_t position = prepareForInsert(index, count, status);
--    if (U_FAILURE(status)) {
--        return count;
--    }
--    if (count == 1) {
--        getCharPtr()[position] = (char16_t) codePoint;
--        getFieldPtr()[position] = field;
--    } else {
--        getCharPtr()[position] = U16_LEAD(codePoint);
--        getCharPtr()[position + 1] = U16_TRAIL(codePoint);
--        getFieldPtr()[position] = getFieldPtr()[position + 1] = field;
--    }
--    return count;
--}
--
--int32_t FormattedStringBuilder::insert(int32_t index, const UnicodeString &unistr, Field field,
--                                    UErrorCode &status) {
--    if (unistr.length() == 0) {
--        // Nothing to insert.
--        return 0;
--    } else if (unistr.length() == 1) {
--        // Fast path: insert using insertCodePoint.
--        return insertCodePoint(index, unistr.charAt(0), field, status);
--    } else {
--        return insert(index, unistr, 0, unistr.length(), field, status);
--    }
--}
--
--int32_t
--FormattedStringBuilder::insert(int32_t index, const UnicodeString &unistr, int32_t start, int32_t end,
--                            Field field, UErrorCode &status) {
--    int32_t count = end - start;
--    int32_t position = prepareForInsert(index, count, status);
--    if (U_FAILURE(status)) {
--        return count;
--    }
--    for (int32_t i = 0; i < count; i++) {
--        getCharPtr()[position + i] = unistr.charAt(start + i);
--        getFieldPtr()[position + i] = field;
--    }
--    return count;
--}
--
--int32_t
--FormattedStringBuilder::splice(int32_t startThis, int32_t endThis,  const UnicodeString &unistr,
--                            int32_t startOther, int32_t endOther, Field field, UErrorCode& status) {
--    int32_t thisLength = endThis - startThis;
--    int32_t otherLength = endOther - startOther;
--    int32_t count = otherLength - thisLength;
--    int32_t position;
--    if (count > 0) {
--        // Overall, chars need to be added.
--        position = prepareForInsert(startThis, count, status);
--    } else {
--        // Overall, chars need to be removed or kept the same.
--        position = remove(startThis, -count);
--    }
--    if (U_FAILURE(status)) {
--        return count;
--    }
--    for (int32_t i = 0; i < otherLength; i++) {
--        getCharPtr()[position + i] = unistr.charAt(startOther + i);
--        getFieldPtr()[position + i] = field;
--    }
--    return count;
--}
--
--int32_t FormattedStringBuilder::append(const FormattedStringBuilder &other, UErrorCode &status) {
--    return insert(fLength, other, status);
--}
--
--int32_t
--FormattedStringBuilder::insert(int32_t index, const FormattedStringBuilder &other, UErrorCode &status) {
--    if (this == &other) {
--        status = U_ILLEGAL_ARGUMENT_ERROR;
--        return 0;
--    }
--    int32_t count = other.fLength;
--    if (count == 0) {
--        // Nothing to insert.
--        return 0;
--    }
--    int32_t position = prepareForInsert(index, count, status);
--    if (U_FAILURE(status)) {
--        return count;
--    }
--    for (int32_t i = 0; i < count; i++) {
--        getCharPtr()[position + i] = other.charAt(i);
--        getFieldPtr()[position + i] = other.fieldAt(i);
--    }
--    return count;
--}
--
--void FormattedStringBuilder::writeTerminator(UErrorCode& status) {
--    int32_t position = prepareForInsert(fLength, 1, status);
--    if (U_FAILURE(status)) {
--        return;
--    }
--    getCharPtr()[position] = 0;
--    getFieldPtr()[position] = kUndefinedField;
--    fLength--;
--}
--
--int32_t FormattedStringBuilder::prepareForInsert(int32_t index, int32_t count, UErrorCode &status) {
--    U_ASSERT(index >= 0);
--    U_ASSERT(index <= fLength);
--    U_ASSERT(count >= 0);
--    if (index == 0 && fZero - count >= 0) {
--        // Append to start
--        fZero -= count;
--        fLength += count;
--        return fZero;
--    } else if (index == fLength && fZero + fLength + count < getCapacity()) {
--        // Append to end
--        fLength += count;
--        return fZero + fLength - count;
--    } else {
--        // Move chars around and/or allocate more space
--        return prepareForInsertHelper(index, count, status);
--    }
--}
--
--int32_t FormattedStringBuilder::prepareForInsertHelper(int32_t index, int32_t count, UErrorCode &status) {
--    int32_t oldCapacity = getCapacity();
--    int32_t oldZero = fZero;
--    char16_t *oldChars = getCharPtr();
--    Field *oldFields = getFieldPtr();
--    if (fLength + count > oldCapacity) {
--        if ((fLength + count) > INT32_MAX / 2) {
--            // If we continue, then newCapacity will overlow int32_t in the next line.
--            status = U_INPUT_TOO_LONG_ERROR;
--            return -1;
--        }
--        int32_t newCapacity = (fLength + count) * 2;
--        int32_t newZero = newCapacity / 2 - (fLength + count) / 2;
--
--        // C++ note: malloc appears in two places: here and in the assignment operator.
--        auto newChars = static_cast<char16_t *> (uprv_malloc(sizeof(char16_t) * newCapacity));
--        auto newFields = static_cast<Field *>(uprv_malloc(sizeof(Field) * newCapacity));
--        if (newChars == nullptr || newFields == nullptr) {
--            uprv_free(newChars);
--            uprv_free(newFields);
--            status = U_MEMORY_ALLOCATION_ERROR;
--            return -1;
--        }
--
--        // First copy the prefix and then the suffix, leaving room for the new chars that the
--        // caller wants to insert.
--        // C++ note: memcpy is OK because the src and dest do not overlap.
--        uprv_memcpy2(newChars + newZero, oldChars + oldZero, sizeof(char16_t) * index);
--        uprv_memcpy2(newChars + newZero + index + count,
--                oldChars + oldZero + index,
--                sizeof(char16_t) * (fLength - index));
--        uprv_memcpy2(newFields + newZero, oldFields + oldZero, sizeof(Field) * index);
--        uprv_memcpy2(newFields + newZero + index + count,
--                oldFields + oldZero + index,
--                sizeof(Field) * (fLength - index));
--
--        if (fUsingHeap) {
--            uprv_free(oldChars);
--            uprv_free(oldFields);
--        }
--        fUsingHeap = true;
--        fChars.heap.ptr = newChars;
--        fChars.heap.capacity = newCapacity;
--        fFields.heap.ptr = newFields;
--        fFields.heap.capacity = newCapacity;
--        fZero = newZero;
--        fLength += count;
--    } else {
--        int32_t newZero = oldCapacity / 2 - (fLength + count) / 2;
--
--        // C++ note: memmove is required because src and dest may overlap.
--        // First copy the entire string to the location of the prefix, and then move the suffix
--        // to make room for the new chars that the caller wants to insert.
--        uprv_memmove2(oldChars + newZero, oldChars + oldZero, sizeof(char16_t) * fLength);
--        uprv_memmove2(oldChars + newZero + index + count,
--                oldChars + newZero + index,
--                sizeof(char16_t) * (fLength - index));
--        uprv_memmove2(oldFields + newZero, oldFields + oldZero, sizeof(Field) * fLength);
--        uprv_memmove2(oldFields + newZero + index + count,
--                oldFields + newZero + index,
--                sizeof(Field) * (fLength - index));
--
--        fZero = newZero;
--        fLength += count;
--    }
--    U_ASSERT((fZero + index) >= 0);
--    return fZero + index;
--}
--
--int32_t FormattedStringBuilder::remove(int32_t index, int32_t count) {
--    // TODO: Reset the heap here?  (If the string after removal can fit on stack?)
--    int32_t position = index + fZero;
--    U_ASSERT(position >= 0);
--    uprv_memmove2(getCharPtr() + position,
--            getCharPtr() + position + count,
--            sizeof(char16_t) * (fLength - index - count));
--    uprv_memmove2(getFieldPtr() + position,
--            getFieldPtr() + position + count,
--            sizeof(Field) * (fLength - index - count));
--    fLength -= count;
--    return position;
--}
--
--UnicodeString FormattedStringBuilder::toUnicodeString() const {
--    return UnicodeString(getCharPtr() + fZero, fLength);
--}
--
--const UnicodeString FormattedStringBuilder::toTempUnicodeString() const {
--    // Readonly-alias constructor:
--    return UnicodeString(FALSE, getCharPtr() + fZero, fLength);
--}
--
--UnicodeString FormattedStringBuilder::toDebugString() const {
--    UnicodeString sb;
--    sb.append(u"<FormattedStringBuilder [", -1);
--    sb.append(toUnicodeString());
--    sb.append(u"] [", -1);
--    for (int i = 0; i < fLength; i++) {
--        if (fieldAt(i) == kUndefinedField) {
--            sb.append(u'n');
--        } else if (fieldAt(i).getCategory() == UFIELD_CATEGORY_NUMBER) {
--            char16_t c;
--            switch (fieldAt(i).getField()) {
--                case UNUM_SIGN_FIELD:
--                    c = u'-';
--                    break;
--                case UNUM_INTEGER_FIELD:
--                    c = u'i';
--                    break;
--                case UNUM_FRACTION_FIELD:
--                    c = u'f';
--                    break;
--                case UNUM_EXPONENT_FIELD:
--                    c = u'e';
--                    break;
--                case UNUM_EXPONENT_SIGN_FIELD:
--                    c = u'+';
--                    break;
--                case UNUM_EXPONENT_SYMBOL_FIELD:
--                    c = u'E';
--                    break;
--                case UNUM_DECIMAL_SEPARATOR_FIELD:
--                    c = u'.';
--                    break;
--                case UNUM_GROUPING_SEPARATOR_FIELD:
--                    c = u',';
--                    break;
--                case UNUM_PERCENT_FIELD:
--                    c = u'%';
--                    break;
--                case UNUM_PERMILL_FIELD:
--                    c = u'‰';
--                    break;
--                case UNUM_CURRENCY_FIELD:
--                    c = u'$';
--                    break;
--                default:
--                    c = u'0' + fieldAt(i).getField();
--                    break;
--            }
--            sb.append(c);
--        } else {
--            sb.append(u'0' + fieldAt(i).getCategory());
--        }
--    }
--    sb.append(u"]>", -1);
--    return sb;
--}
--
--const char16_t *FormattedStringBuilder::chars() const {
--    return getCharPtr() + fZero;
--}
--
--bool FormattedStringBuilder::contentEquals(const FormattedStringBuilder &other) const {
--    if (fLength != other.fLength) {
--        return false;
--    }
--    for (int32_t i = 0; i < fLength; i++) {
--        if (charAt(i) != other.charAt(i) || fieldAt(i) != other.fieldAt(i)) {
--            return false;
--        }
--    }
--    return true;
--}
--
--bool FormattedStringBuilder::containsField(Field field) const {
--    for (int32_t i = 0; i < fLength; i++) {
--        if (field == fieldAt(i)) {
--            return true;
--        }
--    }
--    return false;
--}
--
--U_NAMESPACE_END
--
--#endif /* #if !UCONFIG_NO_FORMATTING */
-+// © 2017 and later: Unicode, Inc. and others.
-+// License & terms of use: http://www.unicode.org/copyright.html
-+
-+#include "unicode/utypes.h"
-+
-+#if !UCONFIG_NO_FORMATTING
-+
-+#include "formatted_string_builder.h"
+@@ -6,6 +6,7 @@
+ #if !UCONFIG_NO_FORMATTING
+ 
+ #include "formatted_string_builder.h"
 +#include "putilimp.h"
-+#include "unicode/ustring.h"
-+#include "unicode/utf16.h"
-+#include "unicode/unum.h" // for UNumberFormatFields literals
-+
-+namespace {
-+
-+// A version of uprv_memcpy that checks for length 0.
-+// By default, uprv_memcpy requires a length of at least 1.
-+inline void uprv_memcpy2(void* dest, const void* src, size_t len) {
-+    if (len > 0) {
-+        uprv_memcpy(dest, src, len);
-+    }
-+}
-+
-+// A version of uprv_memmove that checks for length 0.
-+// By default, uprv_memmove requires a length of at least 1.
-+inline void uprv_memmove2(void* dest, const void* src, size_t len) {
-+    if (len > 0) {
-+        uprv_memmove(dest, src, len);
-+    }
-+}
-+
-+} // namespace
-+
-+
-+U_NAMESPACE_BEGIN
-+
-+FormattedStringBuilder::FormattedStringBuilder() {
-+#if U_DEBUG
-+    // Initializing the memory to non-zero helps catch some bugs that involve
-+    // reading from an improperly terminated string.
-+    for (int32_t i=0; i<getCapacity(); i++) {
-+        getCharPtr()[i] = 1;
-+    }
-+#endif
-+}
-+
-+FormattedStringBuilder::~FormattedStringBuilder() {
-+    if (fUsingHeap) {
-+        uprv_free(fChars.heap.ptr);
-+        uprv_free(fFields.heap.ptr);
-+    }
-+}
-+
-+FormattedStringBuilder::FormattedStringBuilder(const FormattedStringBuilder &other) {
-+    *this = other;
-+}
-+
-+FormattedStringBuilder &FormattedStringBuilder::operator=(const FormattedStringBuilder &other) {
-+    // Check for self-assignment
-+    if (this == &other) {
-+        return *this;
-+    }
-+
-+    // Continue with deallocation and copying
-+    if (fUsingHeap) {
-+        uprv_free(fChars.heap.ptr);
-+        uprv_free(fFields.heap.ptr);
-+        fUsingHeap = false;
-+    }
-+
-+    int32_t capacity = other.getCapacity();
-+    if (capacity > DEFAULT_CAPACITY) {
-+        // FIXME: uprv_malloc
-+        // C++ note: malloc appears in two places: here and in prepareForInsertHelper.
-+        auto newChars = static_cast<char16_t *> (uprv_malloc(sizeof(char16_t) * capacity));
-+        auto newFields = static_cast<Field *>(uprv_malloc(sizeof(Field) * capacity));
-+        if (newChars == nullptr || newFields == nullptr) {
-+            // UErrorCode is not available; fail silently.
-+            uprv_free(newChars);
-+            uprv_free(newFields);
-+            *this = FormattedStringBuilder();  // can't fail
-+            return *this;
-+        }
-+
-+        fUsingHeap = true;
-+        fChars.heap.capacity = capacity;
-+        fChars.heap.ptr = newChars;
-+        fFields.heap.capacity = capacity;
-+        fFields.heap.ptr = newFields;
-+    }
-+
-+    uprv_memcpy2(getCharPtr(), other.getCharPtr(), sizeof(char16_t) * capacity);
-+    uprv_memcpy2(getFieldPtr(), other.getFieldPtr(), sizeof(Field) * capacity);
-+
-+    fZero = other.fZero;
-+    fLength = other.fLength;
-+    return *this;
-+}
-+
-+int32_t FormattedStringBuilder::length() const {
-+    return fLength;
-+}
-+
-+int32_t FormattedStringBuilder::codePointCount() const {
-+    return u_countChar32(getCharPtr() + fZero, fLength);
-+}
-+
-+UChar32 FormattedStringBuilder::getFirstCodePoint() const {
-+    if (fLength == 0) {
-+        return -1;
-+    }
-+    UChar32 cp;
-+    U16_GET(getCharPtr() + fZero, 0, 0, fLength, cp);
-+    return cp;
-+}
-+
-+UChar32 FormattedStringBuilder::getLastCodePoint() const {
-+    if (fLength == 0) {
-+        return -1;
-+    }
-+    int32_t offset = fLength;
-+    U16_BACK_1(getCharPtr() + fZero, 0, offset);
-+    UChar32 cp;
-+    U16_GET(getCharPtr() + fZero, 0, offset, fLength, cp);
-+    return cp;
-+}
-+
-+UChar32 FormattedStringBuilder::codePointAt(int32_t index) const {
-+    UChar32 cp;
-+    U16_GET(getCharPtr() + fZero, 0, index, fLength, cp);
-+    return cp;
-+}
-+
-+UChar32 FormattedStringBuilder::codePointBefore(int32_t index) const {
-+    int32_t offset = index;
-+    U16_BACK_1(getCharPtr() + fZero, 0, offset);
-+    UChar32 cp;
-+    U16_GET(getCharPtr() + fZero, 0, offset, fLength, cp);
-+    return cp;
-+}
-+
-+FormattedStringBuilder &FormattedStringBuilder::clear() {
-+    // TODO: Reset the heap here?
-+    fZero = getCapacity() / 2;
-+    fLength = 0;
-+    return *this;
-+}
-+
-+int32_t
-+FormattedStringBuilder::insertCodePoint(int32_t index, UChar32 codePoint, Field field, UErrorCode &status) {
-+    int32_t count = U16_LENGTH(codePoint);
-+    int32_t position = prepareForInsert(index, count, status);
+ #include "unicode/ustring.h"
+ #include "unicode/utf16.h"
+ #include "unicode/unum.h" // for UNumberFormatFields literals
+@@ -197,6 +198,9 @@ FormattedStringBuilder::splice(int32_t startThis, int32_t endThis,  const Unicod
+     int32_t thisLength = endThis - startThis;
+     int32_t otherLength = endOther - startOther;
+     int32_t count = otherLength - thisLength;
 +    if (U_FAILURE(status)) {
 +        return count;
 +    }
-+    if (count == 1) {
-+        getCharPtr()[position] = (char16_t) codePoint;
-+        getFieldPtr()[position] = field;
-+    } else {
-+        getCharPtr()[position] = U16_LEAD(codePoint);
-+        getCharPtr()[position + 1] = U16_TRAIL(codePoint);
-+        getFieldPtr()[position] = getFieldPtr()[position + 1] = field;
-+    }
-+    return count;
-+}
-+
-+int32_t FormattedStringBuilder::insert(int32_t index, const UnicodeString &unistr, Field field,
-+                                    UErrorCode &status) {
-+    if (unistr.length() == 0) {
-+        // Nothing to insert.
-+        return 0;
-+    } else if (unistr.length() == 1) {
-+        // Fast path: insert using insertCodePoint.
-+        return insertCodePoint(index, unistr.charAt(0), field, status);
-+    } else {
-+        return insert(index, unistr, 0, unistr.length(), field, status);
-+    }
-+}
-+
-+int32_t
-+FormattedStringBuilder::insert(int32_t index, const UnicodeString &unistr, int32_t start, int32_t end,
-+                            Field field, UErrorCode &status) {
-+    int32_t count = end - start;
-+    int32_t position = prepareForInsert(index, count, status);
-+    if (U_FAILURE(status)) {
-+        return count;
-+    }
-+    for (int32_t i = 0; i < count; i++) {
-+        getCharPtr()[position + i] = unistr.charAt(start + i);
-+        getFieldPtr()[position + i] = field;
-+    }
-+    return count;
-+}
-+
-+int32_t
-+FormattedStringBuilder::splice(int32_t startThis, int32_t endThis,  const UnicodeString &unistr,
-+                            int32_t startOther, int32_t endOther, Field field, UErrorCode& status) {
-+    int32_t thisLength = endThis - startThis;
-+    int32_t otherLength = endOther - startOther;
-+    int32_t count = otherLength - thisLength;
-+    if (U_FAILURE(status)) {
-+        return count;
-+    }
-+    int32_t position;
-+    if (count > 0) {
-+        // Overall, chars need to be added.
-+        position = prepareForInsert(startThis, count, status);
-+    } else {
-+        // Overall, chars need to be removed or kept the same.
-+        position = remove(startThis, -count);
-+    }
-+    if (U_FAILURE(status)) {
-+        return count;
-+    }
-+    for (int32_t i = 0; i < otherLength; i++) {
-+        getCharPtr()[position + i] = unistr.charAt(startOther + i);
-+        getFieldPtr()[position + i] = field;
-+    }
-+    return count;
-+}
-+
-+int32_t FormattedStringBuilder::append(const FormattedStringBuilder &other, UErrorCode &status) {
-+    return insert(fLength, other, status);
-+}
-+
-+int32_t
-+FormattedStringBuilder::insert(int32_t index, const FormattedStringBuilder &other, UErrorCode &status) {
+     int32_t position;
+     if (count > 0) {
+         // Overall, chars need to be added.
+@@ -221,6 +225,9 @@ int32_t FormattedStringBuilder::append(const FormattedStringBuilder &other, UErr
+ 
+ int32_t
+ FormattedStringBuilder::insert(int32_t index, const FormattedStringBuilder &other, UErrorCode &status) {
 +    if (U_FAILURE(status)) {
 +        return 0;
 +    }
-+    if (this == &other) {
-+        status = U_ILLEGAL_ARGUMENT_ERROR;
-+        return 0;
-+    }
-+    int32_t count = other.fLength;
-+    if (count == 0) {
-+        // Nothing to insert.
-+        return 0;
-+    }
-+    int32_t position = prepareForInsert(index, count, status);
-+    if (U_FAILURE(status)) {
-+        return count;
-+    }
-+    for (int32_t i = 0; i < count; i++) {
-+        getCharPtr()[position + i] = other.charAt(i);
-+        getFieldPtr()[position + i] = other.fieldAt(i);
-+    }
-+    return count;
-+}
-+
-+void FormattedStringBuilder::writeTerminator(UErrorCode& status) {
-+    int32_t position = prepareForInsert(fLength, 1, status);
-+    if (U_FAILURE(status)) {
-+        return;
-+    }
-+    getCharPtr()[position] = 0;
-+    getFieldPtr()[position] = kUndefinedField;
-+    fLength--;
-+}
-+
-+int32_t FormattedStringBuilder::prepareForInsert(int32_t index, int32_t count, UErrorCode &status) {
-+    U_ASSERT(index >= 0);
-+    U_ASSERT(index <= fLength);
-+    U_ASSERT(count >= 0);
+     if (this == &other) {
+         status = U_ILLEGAL_ARGUMENT_ERROR;
+         return 0;
+@@ -255,12 +262,18 @@ int32_t FormattedStringBuilder::prepareForInsert(int32_t index, int32_t count, U
+     U_ASSERT(index >= 0);
+     U_ASSERT(index <= fLength);
+     U_ASSERT(count >= 0);
 +    U_ASSERT(fZero >= 0);
 +    U_ASSERT(fLength >= 0);
 +    U_ASSERT(getCapacity() - fZero >= fLength);
 +    if (U_FAILURE(status)) {
 +        return count;
 +    }
-+    if (index == 0 && fZero - count >= 0) {
-+        // Append to start
-+        fZero -= count;
-+        fLength += count;
-+        return fZero;
+     if (index == 0 && fZero - count >= 0) {
+         // Append to start
+         fZero -= count;
+         fLength += count;
+         return fZero;
+-    } else if (index == fLength && fZero + fLength + count < getCapacity()) {
 +    } else if (index == fLength && count <= getCapacity() - fZero - fLength) {
-+        // Append to end
-+        fLength += count;
-+        return fZero + fLength - count;
-+    } else {
-+        // Move chars around and/or allocate more space
-+        return prepareForInsertHelper(index, count, status);
-+    }
-+}
-+
-+int32_t FormattedStringBuilder::prepareForInsertHelper(int32_t index, int32_t count, UErrorCode &status) {
-+    int32_t oldCapacity = getCapacity();
-+    int32_t oldZero = fZero;
-+    char16_t *oldChars = getCharPtr();
-+    Field *oldFields = getFieldPtr();
+         // Append to end
+         fLength += count;
+         return fZero + fLength - count;
+@@ -275,18 +288,26 @@ int32_t FormattedStringBuilder::prepareForInsertHelper(int32_t index, int32_t co
+     int32_t oldZero = fZero;
+     char16_t *oldChars = getCharPtr();
+     Field *oldFields = getFieldPtr();
+-    if (fLength + count > oldCapacity) {
+-        if ((fLength + count) > INT32_MAX / 2) {
+-            // If we continue, then newCapacity will overlow int32_t in the next line.
 +    int32_t newLength;
 +    if (uprv_add32_overflow(fLength, count, &newLength)) {
 +        status = U_INPUT_TOO_LONG_ERROR;
@@ -976,173 +291,59 @@ index b370f14f2ac4ff0873e5614376ae51fe0232b02d..1726e632a91f44dfff7b2205301c7cd1
 +        if (newLength > INT32_MAX / 2) {
 +            // We do not support more than 1G char16_t in this code because
 +            // dealing with >2G *bytes* can cause subtle bugs.
-+            status = U_INPUT_TOO_LONG_ERROR;
-+            return -1;
-+        }
+             status = U_INPUT_TOO_LONG_ERROR;
+             return -1;
+         }
+-        int32_t newCapacity = (fLength + count) * 2;
+-        int32_t newZero = newCapacity / 2 - (fLength + count) / 2;
 +        // Keep newCapacity also to at most 1G char16_t.
 +        int32_t newCapacity = newLength * 2;
 +        newZero = (newCapacity - newLength) / 2;
-+
-+        // C++ note: malloc appears in two places: here and in the assignment operator.
+ 
+         // C++ note: malloc appears in two places: here and in the assignment operator.
+-        auto newChars = static_cast<char16_t *> (uprv_malloc(sizeof(char16_t) * newCapacity));
+-        auto newFields = static_cast<Field *>(uprv_malloc(sizeof(Field) * newCapacity));
 +        auto newChars = static_cast<char16_t *> (uprv_malloc(sizeof(char16_t) * static_cast<size_t>(newCapacity)));
 +        auto newFields = static_cast<Field *>(uprv_malloc(sizeof(Field) * static_cast<size_t>(newCapacity)));
-+        if (newChars == nullptr || newFields == nullptr) {
-+            uprv_free(newChars);
-+            uprv_free(newFields);
-+            status = U_MEMORY_ALLOCATION_ERROR;
-+            return -1;
-+        }
-+
-+        // First copy the prefix and then the suffix, leaving room for the new chars that the
-+        // caller wants to insert.
-+        // C++ note: memcpy is OK because the src and dest do not overlap.
-+        uprv_memcpy2(newChars + newZero, oldChars + oldZero, sizeof(char16_t) * index);
-+        uprv_memcpy2(newChars + newZero + index + count,
-+                oldChars + oldZero + index,
-+                sizeof(char16_t) * (fLength - index));
-+        uprv_memcpy2(newFields + newZero, oldFields + oldZero, sizeof(Field) * index);
-+        uprv_memcpy2(newFields + newZero + index + count,
-+                oldFields + oldZero + index,
-+                sizeof(Field) * (fLength - index));
-+
-+        if (fUsingHeap) {
-+            uprv_free(oldChars);
-+            uprv_free(oldFields);
-+        }
-+        fUsingHeap = true;
-+        fChars.heap.ptr = newChars;
-+        fChars.heap.capacity = newCapacity;
-+        fFields.heap.ptr = newFields;
-+        fFields.heap.capacity = newCapacity;
-+    } else {
+         if (newChars == nullptr || newFields == nullptr) {
+             uprv_free(newChars);
+             uprv_free(newFields);
+@@ -315,10 +336,8 @@ int32_t FormattedStringBuilder::prepareForInsertHelper(int32_t index, int32_t co
+         fChars.heap.capacity = newCapacity;
+         fFields.heap.ptr = newFields;
+         fFields.heap.capacity = newCapacity;
+-        fZero = newZero;
+-        fLength += count;
+     } else {
+-        int32_t newZero = oldCapacity / 2 - (fLength + count) / 2;
 +        newZero = (oldCapacity - newLength) / 2;
-+
-+        // C++ note: memmove is required because src and dest may overlap.
-+        // First copy the entire string to the location of the prefix, and then move the suffix
-+        // to make room for the new chars that the caller wants to insert.
-+        uprv_memmove2(oldChars + newZero, oldChars + oldZero, sizeof(char16_t) * fLength);
-+        uprv_memmove2(oldChars + newZero + index + count,
-+                oldChars + newZero + index,
-+                sizeof(char16_t) * (fLength - index));
-+        uprv_memmove2(oldFields + newZero, oldFields + oldZero, sizeof(Field) * fLength);
-+        uprv_memmove2(oldFields + newZero + index + count,
-+                oldFields + newZero + index,
-+                sizeof(Field) * (fLength - index));
-+    }
+ 
+         // C++ note: memmove is required because src and dest may overlap.
+         // First copy the entire string to the location of the prefix, and then move the suffix
+@@ -331,18 +350,20 @@ int32_t FormattedStringBuilder::prepareForInsertHelper(int32_t index, int32_t co
+         uprv_memmove2(oldFields + newZero + index + count,
+                 oldFields + newZero + index,
+                 sizeof(Field) * (fLength - index));
+-
+-        fZero = newZero;
+-        fLength += count;
+     }
+-    U_ASSERT((fZero + index) >= 0);
 +    fZero = newZero;
 +    fLength = newLength;
-+    return fZero + index;
-+}
-+
-+int32_t FormattedStringBuilder::remove(int32_t index, int32_t count) {
+     return fZero + index;
+ }
+ 
+ int32_t FormattedStringBuilder::remove(int32_t index, int32_t count) {
+-    // TODO: Reset the heap here?  (If the string after removal can fit on stack?)
 +     U_ASSERT(0 <= index);
 +     U_ASSERT(index <= fLength);
 +     U_ASSERT(count <= (fLength - index));
 +     U_ASSERT(index <= getCapacity() - fZero);
 +
-+    int32_t position = index + fZero;
+     int32_t position = index + fZero;
+-    U_ASSERT(position >= 0);
 +    // TODO: Reset the heap here?  (If the string after removal can fit on stack?)
-+    uprv_memmove2(getCharPtr() + position,
-+            getCharPtr() + position + count,
-+            sizeof(char16_t) * (fLength - index - count));
-+    uprv_memmove2(getFieldPtr() + position,
-+            getFieldPtr() + position + count,
-+            sizeof(Field) * (fLength - index - count));
-+    fLength -= count;
-+    return position;
-+}
-+
-+UnicodeString FormattedStringBuilder::toUnicodeString() const {
-+    return UnicodeString(getCharPtr() + fZero, fLength);
-+}
-+
-+const UnicodeString FormattedStringBuilder::toTempUnicodeString() const {
-+    // Readonly-alias constructor:
-+    return UnicodeString(FALSE, getCharPtr() + fZero, fLength);
-+}
-+
-+UnicodeString FormattedStringBuilder::toDebugString() const {
-+    UnicodeString sb;
-+    sb.append(u"<FormattedStringBuilder [", -1);
-+    sb.append(toUnicodeString());
-+    sb.append(u"] [", -1);
-+    for (int i = 0; i < fLength; i++) {
-+        if (fieldAt(i) == kUndefinedField) {
-+            sb.append(u'n');
-+        } else if (fieldAt(i).getCategory() == UFIELD_CATEGORY_NUMBER) {
-+            char16_t c;
-+            switch (fieldAt(i).getField()) {
-+                case UNUM_SIGN_FIELD:
-+                    c = u'-';
-+                    break;
-+                case UNUM_INTEGER_FIELD:
-+                    c = u'i';
-+                    break;
-+                case UNUM_FRACTION_FIELD:
-+                    c = u'f';
-+                    break;
-+                case UNUM_EXPONENT_FIELD:
-+                    c = u'e';
-+                    break;
-+                case UNUM_EXPONENT_SIGN_FIELD:
-+                    c = u'+';
-+                    break;
-+                case UNUM_EXPONENT_SYMBOL_FIELD:
-+                    c = u'E';
-+                    break;
-+                case UNUM_DECIMAL_SEPARATOR_FIELD:
-+                    c = u'.';
-+                    break;
-+                case UNUM_GROUPING_SEPARATOR_FIELD:
-+                    c = u',';
-+                    break;
-+                case UNUM_PERCENT_FIELD:
-+                    c = u'%';
-+                    break;
-+                case UNUM_PERMILL_FIELD:
-+                    c = u'‰';
-+                    break;
-+                case UNUM_CURRENCY_FIELD:
-+                    c = u'$';
-+                    break;
-+                default:
-+                    c = u'0' + fieldAt(i).getField();
-+                    break;
-+            }
-+            sb.append(c);
-+        } else {
-+            sb.append(u'0' + fieldAt(i).getCategory());
-+        }
-+    }
-+    sb.append(u"]>", -1);
-+    return sb;
-+}
-+
-+const char16_t *FormattedStringBuilder::chars() const {
-+    return getCharPtr() + fZero;
-+}
-+
-+bool FormattedStringBuilder::contentEquals(const FormattedStringBuilder &other) const {
-+    if (fLength != other.fLength) {
-+        return false;
-+    }
-+    for (int32_t i = 0; i < fLength; i++) {
-+        if (charAt(i) != other.charAt(i) || fieldAt(i) != other.fieldAt(i)) {
-+            return false;
-+        }
-+    }
-+    return true;
-+}
-+
-+bool FormattedStringBuilder::containsField(Field field) const {
-+    for (int32_t i = 0; i < fLength; i++) {
-+        if (field == fieldAt(i)) {
-+            return true;
-+        }
-+    }
-+    return false;
-+}
-+
-+U_NAMESPACE_END
-+
-+#endif /* #if !UCONFIG_NO_FORMATTING */
+     uprv_memmove2(getCharPtr() + position,
+             getCharPtr() + position + count,
+             sizeof(char16_t) * (fLength - index - count));


### PR DESCRIPTION
[m100] CP PR 2070 fix int32 overflow

https://github.com/unicode-org/icu/pull/2070
https://unicode-org.atlassian.net/browse/ICU-22005

Bug: chromium:1316946
Change-Id: I6cd7d687a55b6cc157b1afa52365908be2992fa6
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/deps/icu/+/3614280
Reviewed-by: Jungshik Shin <jshin@chromium.org>
(cherry picked from commit 85814e1af52482199a13d284545623ffbc9eef83)
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/deps/icu/+/3632709


Notes: Backported fix for CVE-2022-1638.