### PR TITLE
chore: cherry-pick 99c3f3bfd507 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -180,3 +180,4 @@ m96-lts_add_bounds_check_to_webgpudecoderimpl_dorequestdevice.patch
 cherry-pick-5ff02e4d7368.patch
 cherry-pick-12ba78f3fa7a.patch
 reland_fix_noopener_case_for_user_activation_consumption.patch
+cherry-pick-99c3f3bfd507.patch

--- a/patches/chromium/cherry-pick-99c3f3bfd507.patch
+++ b/patches/chromium/cherry-pick-99c3f3bfd507.patch
@@ -1,7 +1,7 @@
-From 99c3f3bfd507090070bc5ae5f9396528fbe03d0f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Eugene Zemtsov <eugene@chromium.org>
-Date: Fri, 08 Apr 2022 23:28:35 +0000
-Subject: [PATCH] Only destroy successfully created compression session in VT encoder
+Date: Fri, 8 Apr 2022 23:28:35 +0000
+Subject: Only destroy successfully created compression session in VT encoder
 
 This is a defensive change, since we don't have a repro on hand.
 My guess is that VTCompressionSessionCreate() might fail to create a
@@ -17,13 +17,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3575680
 Reviewed-by: Dale Curtis <dalecurtis@chromium.org>
 Commit-Queue: Eugene Zemtsov <eugene@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#990654}
----
 
 diff --git a/media/gpu/mac/vt_video_encode_accelerator_mac.cc b/media/gpu/mac/vt_video_encode_accelerator_mac.cc
-index 8e5df31..6a3a7771 100644
+index 8a49e706890a173a3e09ae16b8e88500aefb0499..39384b426a38f2210040cb3f2cbba85893496a7b 100644
 --- a/media/gpu/mac/vt_video_encode_accelerator_mac.cc
 +++ b/media/gpu/mac/vt_video_encode_accelerator_mac.cc
-@@ -139,13 +139,13 @@
+@@ -120,13 +120,13 @@ VTVideoEncodeAccelerator::GetSupportedProfiles() {
    SupportedProfiles profiles;
    const bool rv = CreateCompressionSession(
        gfx::Size(kDefaultResolutionWidth, kDefaultResolutionHeight));
@@ -38,7 +37,7 @@ index 8e5df31..6a3a7771 100644
    SupportedProfile profile;
    profile.max_framerate_numerator = kMaxFrameRateNumerator;
    profile.max_framerate_denominator = kMaxFrameRateDenominator;
-@@ -578,10 +578,8 @@
+@@ -505,10 +505,8 @@ bool VTVideoEncodeAccelerator::ResetCompressionSession() {
    DestroyCompressionSession();
  
    bool session_rv = CreateCompressionSession(input_visible_size_);
@@ -50,7 +49,7 @@ index 8e5df31..6a3a7771 100644
  
    const bool configure_rv = ConfigureCompressionSession();
    if (configure_rv)
-@@ -625,6 +623,12 @@
+@@ -544,6 +542,12 @@ bool VTVideoEncodeAccelerator::CreateCompressionSession(
        &VTVideoEncodeAccelerator::CompressionCallback,
        reinterpret_cast<void*>(this), compression_session_.InitializeInto());
    if (status != noErr) {

--- a/patches/chromium/cherry-pick-99c3f3bfd507.patch
+++ b/patches/chromium/cherry-pick-99c3f3bfd507.patch
@@ -1,0 +1,65 @@
+From 99c3f3bfd507090070bc5ae5f9396528fbe03d0f Mon Sep 17 00:00:00 2001
+From: Eugene Zemtsov <eugene@chromium.org>
+Date: Fri, 08 Apr 2022 23:28:35 +0000
+Subject: [PATCH] Only destroy successfully created compression session in VT encoder
+
+This is a defensive change, since we don't have a repro on hand.
+My guess is that VTCompressionSessionCreate() might fail to create a
+compression session, but still write a value to compressionSessionOut.
+It makes VTCompressionSessionInvalidate() access uninitialized memory.
+
+That's why this CL makes sure that we only destroy a compression session
+if VTCompressionSessionCreate() reports success.
+
+Bug: 1312563
+Change-Id: I468ce0e10bad251ca0b62b568607dbc5c32ba8bc
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3575680
+Reviewed-by: Dale Curtis <dalecurtis@chromium.org>
+Commit-Queue: Eugene Zemtsov <eugene@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#990654}
+---
+
+diff --git a/media/gpu/mac/vt_video_encode_accelerator_mac.cc b/media/gpu/mac/vt_video_encode_accelerator_mac.cc
+index 8e5df31..6a3a7771 100644
+--- a/media/gpu/mac/vt_video_encode_accelerator_mac.cc
++++ b/media/gpu/mac/vt_video_encode_accelerator_mac.cc
+@@ -139,13 +139,13 @@
+   SupportedProfiles profiles;
+   const bool rv = CreateCompressionSession(
+       gfx::Size(kDefaultResolutionWidth, kDefaultResolutionHeight));
+-  DestroyCompressionSession();
+   if (!rv) {
+     VLOG(1)
+         << "Hardware encode acceleration is not available on this platform.";
+     return profiles;
+   }
+ 
++  DestroyCompressionSession();
+   SupportedProfile profile;
+   profile.max_framerate_numerator = kMaxFrameRateNumerator;
+   profile.max_framerate_denominator = kMaxFrameRateDenominator;
+@@ -578,10 +578,8 @@
+   DestroyCompressionSession();
+ 
+   bool session_rv = CreateCompressionSession(input_visible_size_);
+-  if (!session_rv) {
+-    DestroyCompressionSession();
++  if (!session_rv)
+     return false;
+-  }
+ 
+   const bool configure_rv = ConfigureCompressionSession();
+   if (configure_rv)
+@@ -625,6 +623,12 @@
+       &VTVideoEncodeAccelerator::CompressionCallback,
+       reinterpret_cast<void*>(this), compression_session_.InitializeInto());
+   if (status != noErr) {
++    // IMPORTANT: ScopedCFTypeRef::release() doesn't call CFRelease().
++    // In case of an error VTCompressionSessionCreate() is not supposed to
++    // write a non-null value into compression_session_, but just in case,
++    // we'll clear it without calling CFRelease() because it can be unsafe
++    // to call on a not fully created session.
++    (void)compression_session_.release();
+     DLOG(ERROR) << " VTCompressionSessionCreate failed: " << status;
+     return false;
+   }


### PR DESCRIPTION
Only destroy successfully created compression session in VT encoder

This is a defensive change, since we don't have a repro on hand.
My guess is that VTCompressionSessionCreate() might fail to create a
compression session, but still write a value to compressionSessionOut.
It makes VTCompressionSessionInvalidate() access uninitialized memory.

That's why this CL makes sure that we only destroy a compression session
if VTCompressionSessionCreate() reports success.

Bug: 1312563
Change-Id: I468ce0e10bad251ca0b62b568607dbc5c32ba8bc
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3575680
Reviewed-by: Dale Curtis <dalecurtis@chromium.org>
Commit-Queue: Eugene Zemtsov <eugene@chromium.org>
Cr-Commit-Position: refs/heads/main@{#990654}


Notes: Backported fix for chromium:1312563.