### PR TITLE
docs: add height option and color transparency info

### DIFF
--- a/docs/tutorial/window-customization.md
+++ b/docs/tutorial/window-customization.md
@@ -115,9 +115,9 @@ const win = new BrowserWindow({
 })
 ```
 
-On Windows, you can also specify the color of the overlay and its symbols by setting
-`titleBarOverlay` to an object with the `color` and `symbolColor` properties. If an option
-is not specified, the color will default to its system color for the window control buttons:
+On Windows, you can also specify additional parameters. The color of the overlay and its symbols can be specified by setting `titleBarOverlay` to an object and using the `color` and `symbolColor` properties respectively. The height of the overlay can also be specified with the `height` property.
+
+If a color option is not specified, the color will default to its system color for the window control buttons. Similarly, if the height option is not specified it will default to the default height:
 
 ```javascript title='main.js'
 // on Windows
@@ -126,7 +126,8 @@ const win = new BrowserWindow({
   titleBarStyle: 'hidden',
   titleBarOverlay: {
     color: '#2f3241',
-    symbolColor: '#74b1be'
+    symbolColor: '#74b1be',
+    height: 60
   }
 })
 ```
@@ -134,6 +135,10 @@ const win = new BrowserWindow({
 > Note: Once your title bar overlay is enabled from the main process, you can access the overlay's
 > color and dimension values from a renderer using a set of readonly
 > [JavaScript APIs][overlay-javascript-apis] and [CSS Environment Variables][overlay-css-env-vars].
+
+### Limitations
+
+* Transparent colors are currently not supported. Progress updates for this feature can be found in PR [#33567](https://github.com/electron/electron/issues/33567).
 
 ## Create transparent windows
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
This PR adds documentation for the WCO height option added by https://github.com/electron/electron/pull/31222 and notifies of the WCO's current limitation using transparent colors notified by https://github.com/electron/electron/issues/33567.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> None
