### PR TITLE
Fix clang format

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "generate-version-json": "node script/generate-version-json.js",
     "lint": "node ./script/lint.js && npm run lint:clang-format && npm run lint:docs",
     "lint:js": "node ./script/lint.js --js",
-    "lint:clang-format": "python3 script/run-clang-format.py -r -c shell/ || (echo \"\\nCode not formatted correctly.\" && exit 1)",
+    "lint:clang-format": "python3 script/run-clang-format.py -r shell/ || (echo \"\\nCode not formatted correctly.\" && exit 1)",
     "lint:clang-tidy": "ts-node ./script/run-clang-tidy.ts",
     "lint:cpp": "node ./script/lint.js --cc",
     "lint:objc": "node ./script/lint.js --objc",
@@ -94,6 +94,7 @@
     "gn-typescript-definitions": "npm run create-typescript-definitions && shx cp electron.d.ts",
     "pre-flight": "pre-flight",
     "gn-check": "node ./script/gn-check.js",
+    "gn-format": "python3 script/run-gn-format.py",
     "precommit": "lint-staged",
     "preinstall": "node -e 'process.exit(0)'",
     "prepack": "check-for-leaks",
@@ -117,14 +118,14 @@
       "ts-node script/gen-filenames.ts"
     ],
     "*.{cc,mm,c,h}": [
-      "python3 script/run-clang-format.py -r -c --fix"
+      "python3 script/run-clang-format.py -r -i"
     ],
     "*.md": [
       "npm run lint:docs"
     ],
     "*.{gn,gni}": [
       "npm run gn-check",
-      "python3 script/run-gn-format.py"
+      "npm run gn-format"
     ],
     "*.py": [
       "node script/lint.js --py --fix --only --"

--- a/shell/app/electron_main_mac.cc
+++ b/shell/app/electron_main_mac.cc
@@ -13,6 +13,7 @@
 
 #if defined(HELPER_EXECUTABLE) && !defined(MAS_BUILD)
 #include <mach-o/dyld.h>
+
 #include <cstdio>
 
 #include "sandbox/mac/seatbelt_exec.h"  // nogncheck

--- a/shell/app/electron_main_win.cc
+++ b/shell/app/electron_main_win.cc
@@ -2,12 +2,11 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include <windows.h>  // windows.h must be included first
-
 #include <atlbase.h>  // ensures that ATL statics like `_AtlWinModule` are initialized (it's an issue in static debug build)
 #include <shellapi.h>
 #include <shellscalingapi.h>
 #include <tchar.h>
+#include <windows.h>  // windows.h must be included first
 
 #include <algorithm>
 #include <cstdlib>

--- a/shell/app/uv_stdio_fix.cc
+++ b/shell/app/uv_stdio_fix.cc
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
 #include <cstdio>
 #include <tuple>
 

--- a/shell/app/uv_task_runner.cc
+++ b/shell/app/uv_task_runner.cc
@@ -2,12 +2,13 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include "shell/app/uv_task_runner.h"
+
 #include <utility>
 
 #include "base/location.h"
 #include "base/stl_util.h"
 #include "base/time/time.h"
-#include "shell/app/uv_task_runner.h"
 
 namespace electron {
 

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -79,6 +79,7 @@
 
 #if BUILDFLAG(IS_MAC)
 #include <CoreFoundation/CoreFoundation.h>
+
 #include "shell/browser/ui/cocoa/electron_bundle_mover.h"
 #endif
 

--- a/shell/browser/api/electron_api_browser_window_views.cc
+++ b/shell/browser/api/electron_api_browser_window_views.cc
@@ -2,9 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/browser/api/electron_api_browser_window.h"
-
 #include "content/browser/web_contents/web_contents_impl.h"  // nogncheck
+#include "shell/browser/api/electron_api_browser_window.h"
 #include "shell/browser/native_window_views.h"
 #include "ui/aura/window.h"
 

--- a/shell/browser/api/electron_api_crash_reporter.h
+++ b/shell/browser/api/electron_api_crash_reporter.h
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <string>
+
 #include "base/files/file_path.h"
 
 namespace electron {

--- a/shell/browser/api/electron_api_data_pipe_holder.cc
+++ b/shell/browser/api/electron_api_data_pipe_holder.cc
@@ -15,7 +15,6 @@
 #include "net/base/net_errors.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/key_weak_map.h"
-
 #include "shell/common/node_includes.h"
 
 namespace electron {

--- a/shell/browser/api/electron_api_menu_mac.h
+++ b/shell/browser/api/electron_api_menu_mac.h
@@ -5,10 +5,9 @@
 #ifndef ELECTRON_SHELL_BROWSER_API_ELECTRON_API_MENU_MAC_H_
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_MENU_MAC_H_
 
-#include "shell/browser/api/electron_api_menu.h"
-
 #include <map>
 
+#include "shell/browser/api/electron_api_menu.h"
 #import "shell/browser/ui/cocoa/electron_menu_controller.h"
 
 using base::scoped_nsobject;

--- a/shell/browser/api/electron_api_net.cc
+++ b/shell/browser/api/electron_api_net.cc
@@ -15,7 +15,6 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/object_template_builder.h"
-
 #include "shell/common/node_includes.h"
 
 namespace {

--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -2,14 +2,13 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/browser/api/electron_api_power_monitor.h"
-
 #include <windows.h>
 #include <wtsapi32.h>
 
 #include "base/win/windows_types.h"
 #include "base/win/wrapped_window_proc.h"
 #include "content/public/browser/browser_task_traits.h"
+#include "shell/browser/api/electron_api_power_monitor.h"
 #include "ui/base/win/shell.h"
 #include "ui/gfx/win/hwnd_util.h"
 

--- a/shell/browser/api/electron_api_system_preferences_win.cc
+++ b/shell/browser/api/electron_api_system_preferences_win.cc
@@ -5,13 +5,13 @@
 #include <dwmapi.h>
 #include <windows.devices.enumeration.h>
 #include <wrl/client.h>
-#include <iomanip>
 
-#include "shell/browser/api/electron_api_system_preferences.h"
+#include <iomanip>
 
 #include "base/win/core_winrt_util.h"
 #include "base/win/windows_types.h"
 #include "base/win/wrapped_window_proc.h"
+#include "shell/browser/api/electron_api_system_preferences.h"
 #include "shell/common/color_util.h"
 #include "ui/base/win/shell.h"
 #include "ui/gfx/color_utils.h"

--- a/shell/browser/api/electron_api_web_contents_impl.cc
+++ b/shell/browser/api/electron_api_web_contents_impl.cc
@@ -2,11 +2,10 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/browser/api/electron_api_web_contents.h"
-
 #include "content/browser/renderer_host/frame_tree.h"        // nogncheck
 #include "content/browser/renderer_host/frame_tree_node.h"   // nogncheck
 #include "content/browser/web_contents/web_contents_impl.h"  // nogncheck
+#include "shell/browser/api/electron_api_web_contents.h"
 
 #if BUILDFLAG(ENABLE_OSR)
 #include "shell/browser/osr/osr_render_widget_host_view.h"

--- a/shell/browser/api/process_metric.cc
+++ b/shell/browser/api/process_metric.cc
@@ -10,14 +10,15 @@
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
 #if BUILDFLAG(IS_WIN)
+#include <psapi.h>
 #include <windows.h>
 
-#include <psapi.h>
 #include "base/win/win_util.h"
 #endif
 
 #if BUILDFLAG(IS_MAC)
 #include <mach/mach.h>
+
 #include "base/process/port_provider_mac.h"
 #include "content/public/browser/browser_child_process_host.h"
 

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -20,6 +20,7 @@
 
 #if BUILDFLAG(IS_WIN)
 #include <windows.h>
+
 #include "base/files/file_path.h"
 #include "shell/browser/ui/win/taskbar_host.h"
 #endif

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/browser/browser.h"
-
 #include <fcntl.h>
 #include <stdlib.h>
 
@@ -11,6 +9,7 @@
 #include "base/environment.h"
 #include "base/process/launch.h"
 #include "electron/electron_version.h"
+#include "shell/browser/browser.h"
 #include "shell/browser/native_window.h"
 #include "shell/browser/window_list.h"
 #include "shell/common/application_info.h"

--- a/shell/browser/browser_process_impl.cc
+++ b/shell/browser/browser_process_impl.cc
@@ -5,7 +5,6 @@
 #include "shell/browser/browser_process_impl.h"
 
 #include <memory>
-
 #include <utility>
 
 #include "base/command_line.h"

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -5,13 +5,10 @@
 #include "shell/browser/browser.h"
 
 // must come before other includes. fixes bad #defines from <shlwapi.h>.
-#include "base/win/shlwapi.h"  // NOLINT(build/include_order)
-
-#include <windows.h>  // NOLINT(build/include_order)
-
 #include <atlbase.h>   // NOLINT(build/include_order)
 #include <shlobj.h>    // NOLINT(build/include_order)
 #include <shobjidl.h>  // NOLINT(build/include_order)
+#include <windows.h>   // NOLINT(build/include_order)
 
 #include "base/base_paths.h"
 #include "base/file_version_info.h"
@@ -23,6 +20,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "base/threading/thread_restrictions.h"
 #include "base/win/registry.h"
+#include "base/win/shlwapi.h"  // NOLINT(build/include_order)
 #include "base/win/win_util.h"
 #include "base/win/windows_version.h"
 #include "chrome/browser/icon_manager.h"

--- a/shell/browser/child_web_contents_tracker.cc
+++ b/shell/browser/child_web_contents_tracker.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "shell/browser/child_web_contents_tracker.h"
+
 #include "content/public/browser/web_contents_user_data.h"
 
 namespace electron {

--- a/shell/browser/electron_autofill_driver.cc
+++ b/shell/browser/electron_autofill_driver.cc
@@ -5,7 +5,6 @@
 #include "shell/browser/electron_autofill_driver.h"
 
 #include <memory>
-
 #include <utility>
 
 #include "content/public/browser/render_widget_host_view.h"

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -5,7 +5,6 @@
 #include "shell/browser/electron_browser_context.h"
 
 #include <memory>
-
 #include <utility>
 
 #include "base/barrier_closure.h"

--- a/shell/browser/electron_browser_main_parts_posix.cc
+++ b/shell/browser/electron_browser_main_parts_posix.cc
@@ -4,8 +4,6 @@
 
 // Most code came from: chrome/browser/chrome_browser_main_posix.cc.
 
-#include "shell/browser/electron_browser_main_parts.h"
-
 #include <errno.h>
 #include <limits.h>
 #include <pthread.h>
@@ -19,6 +17,7 @@
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "shell/browser/browser.h"
+#include "shell/browser/electron_browser_main_parts.h"
 
 namespace electron {
 

--- a/shell/browser/extensions/api/cryptotoken_private/cryptotoken_private_api.cc
+++ b/shell/browser/extensions/api/cryptotoken_private/cryptotoken_private_api.cc
@@ -5,6 +5,7 @@
 #include "shell/browser/extensions/api/cryptotoken_private/cryptotoken_private_api.h"
 
 #include <stddef.h>
+
 #include <memory>
 #include <string>
 #include <vector>

--- a/shell/browser/extensions/electron_extension_message_filter.cc
+++ b/shell/browser/extensions/electron_extension_message_filter.cc
@@ -5,6 +5,7 @@
 #include "shell/browser/extensions/electron_extension_message_filter.h"
 
 #include <stdint.h>
+
 #include <memory>
 
 #include "base/bind.h"

--- a/shell/browser/extensions/electron_extension_web_contents_observer.cc
+++ b/shell/browser/extensions/electron_extension_web_contents_observer.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "shell/browser/extensions/electron_extension_web_contents_observer.h"
+
 #include "content/public/browser/web_contents_user_data.h"
 
 namespace extensions {

--- a/shell/browser/extensions/electron_process_manager_delegate.cc
+++ b/shell/browser/extensions/electron_process_manager_delegate.cc
@@ -1,11 +1,10 @@
 // Copyright 2019 Slack Technologies, Inc. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-#include "base/debug/stack_trace.h"
-
 #include "shell/browser/extensions/electron_process_manager_delegate.h"
 
 #include "base/command_line.h"
+#include "base/debug/stack_trace.h"
 #include "base/logging.h"
 #include "base/one_shot_event.h"
 #include "build/build_config.h"

--- a/shell/browser/lib/power_observer_linux.cc
+++ b/shell/browser/lib/power_observer_linux.cc
@@ -5,6 +5,7 @@
 
 #include <unistd.h>
 #include <uv.h>
+
 #include <utility>
 
 #include "base/bind.h"

--- a/shell/browser/native_browser_view_mac.h
+++ b/shell/browser/native_browser_view_mac.h
@@ -6,6 +6,7 @@
 #define ELECTRON_SHELL_BROWSER_NATIVE_BROWSER_VIEW_MAC_H_
 
 #import <Cocoa/Cocoa.h>
+
 #include <vector>
 
 #include "base/mac/scoped_nsobject.h"

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -5,13 +5,12 @@
 #ifndef ELECTRON_SHELL_BROWSER_NATIVE_WINDOW_VIEWS_H_
 #define ELECTRON_SHELL_BROWSER_NATIVE_WINDOW_VIEWS_H_
 
-#include "shell/browser/native_window.h"
-
 #include <memory>
 #include <set>
 #include <string>
 #include <vector>
 
+#include "shell/browser/native_window.h"
 #include "shell/common/api/api.mojom.h"
 #include "third_party/skia/include/core/SkRegion.h"
 #include "ui/views/widget/widget_observer.h"

--- a/shell/browser/net/cert_verifier_client.cc
+++ b/shell/browser/net/cert_verifier_client.cc
@@ -2,9 +2,9 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include <utility>
-
 #include "shell/browser/net/cert_verifier_client.h"
+
+#include <utility>
 
 namespace electron {
 

--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -31,9 +31,8 @@
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_converters/net_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
-#include "third_party/blink/public/mojom/loader/resource_load_info.mojom-shared.h"
-
 #include "shell/common/node_includes.h"
+#include "third_party/blink/public/mojom/loader/resource_load_info.mojom-shared.h"
 
 using content::BrowserThread;
 

--- a/shell/browser/notifications/win/win32_desktop_notifications/desktop_notification_controller.cc
+++ b/shell/browser/notifications/win/win32_desktop_notifications/desktop_notification_controller.cc
@@ -13,6 +13,7 @@
 #include "shell/browser/notifications/win/win32_desktop_notifications/desktop_notification_controller.h"
 
 #include <windowsx.h>
+
 #include <utility>
 
 #include "base/check.h"

--- a/shell/browser/notifications/win/win32_desktop_notifications/desktop_notification_controller.h
+++ b/shell/browser/notifications/win/win32_desktop_notifications/desktop_notification_controller.h
@@ -6,6 +6,7 @@
 #define ELECTRON_SHELL_BROWSER_NOTIFICATIONS_WIN_WIN32_DESKTOP_NOTIFICATIONS_DESKTOP_NOTIFICATION_CONTROLLER_H_
 
 #include <Windows.h>
+
 #include <deque>
 #include <memory>
 #include <string>

--- a/shell/browser/notifications/win/win32_desktop_notifications/toast.cc
+++ b/shell/browser/notifications/win/win32_desktop_notifications/toast.cc
@@ -7,11 +7,11 @@
 #endif
 #include "shell/browser/notifications/win/win32_desktop_notifications/toast.h"
 
-#include <combaseapi.h>
-
 #include <UIAutomation.h>
+#include <combaseapi.h>
 #include <uxtheme.h>
 #include <windowsx.h>
+
 #include <algorithm>
 #include <cmath>
 #include <memory>

--- a/shell/browser/notifications/win/win32_desktop_notifications/toast.h
+++ b/shell/browser/notifications/win/win32_desktop_notifications/toast.h
@@ -7,9 +7,8 @@
 
 #include <memory>
 
-#include "shell/browser/notifications/win/win32_desktop_notifications/desktop_notification_controller.h"
-
 #include "base/check.h"
+#include "shell/browser/notifications/win/win32_desktop_notifications/desktop_notification_controller.h"
 
 namespace electron {
 

--- a/shell/browser/notifications/win/win32_desktop_notifications/toast_uia.h
+++ b/shell/browser/notifications/win/win32_desktop_notifications/toast_uia.h
@@ -5,11 +5,10 @@
 #ifndef ELECTRON_SHELL_BROWSER_NOTIFICATIONS_WIN_WIN32_DESKTOP_NOTIFICATIONS_TOAST_UIA_H_
 #define ELECTRON_SHELL_BROWSER_NOTIFICATIONS_WIN_WIN32_DESKTOP_NOTIFICATIONS_TOAST_UIA_H_
 
-#include "shell/browser/notifications/win/win32_desktop_notifications/toast.h"
-
+#include <UIAutomationCore.h>
 #include <combaseapi.h>
 
-#include <UIAutomationCore.h>
+#include "shell/browser/notifications/win/win32_desktop_notifications/toast.h"
 
 namespace electron {
 

--- a/shell/browser/notifications/win/win32_notification.cc
+++ b/shell/browser/notifications/win/win32_notification.cc
@@ -9,6 +9,7 @@
 #include "shell/browser/notifications/win/win32_notification.h"
 
 #include <windows.h>
+
 #include <utility>
 
 #include "base/strings/utf_string_conversions.h"

--- a/shell/browser/notifications/win/windows_toast_notification.h
+++ b/shell/browser/notifications/win/windows_toast_notification.h
@@ -12,6 +12,7 @@
 #include <windows.h>
 #include <windows.ui.notifications.h>
 #include <wrl/implements.h>
+
 #include <string>
 #include <vector>
 

--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -21,6 +21,7 @@
 #include "base/time/time.h"
 #include "components/viz/common/quads/compositor_frame.h"
 #include "components/viz/common/surfaces/parent_local_surface_id_allocator.h"
+#include "components/viz/host/host_display_client.h"
 #include "content/browser/renderer_host/delegated_frame_host.h"  // nogncheck
 #include "content/browser/renderer_host/input/mouse_wheel_phase_handler.h"  // nogncheck
 #include "content/browser/renderer_host/render_widget_host_impl.h"  // nogncheck
@@ -37,8 +38,6 @@
 #include "ui/compositor/layer_delegate.h"
 #include "ui/compositor/layer_owner.h"
 #include "ui/gfx/geometry/point.h"
-
-#include "components/viz/host/host_display_client.h"
 
 #if BUILDFLAG(IS_WIN)
 #include "ui/gfx/win/window_impl.h"

--- a/shell/browser/osr/osr_web_contents_view.h
+++ b/shell/browser/osr/osr_web_contents_view.h
@@ -5,12 +5,11 @@
 #ifndef ELECTRON_SHELL_BROWSER_OSR_OSR_WEB_CONTENTS_VIEW_H_
 #define ELECTRON_SHELL_BROWSER_OSR_OSR_WEB_CONTENTS_VIEW_H_
 
-#include "shell/browser/native_window.h"
-#include "shell/browser/native_window_observer.h"
-
 #include "content/browser/renderer_host/render_view_host_delegate_view.h"  // nogncheck
 #include "content/browser/web_contents/web_contents_view.h"  // nogncheck
 #include "content/public/browser/web_contents.h"
+#include "shell/browser/native_window.h"
+#include "shell/browser/native_window_observer.h"
 #include "shell/browser/osr/osr_render_widget_host_view.h"
 #include "third_party/blink/public/common/page/drag_mojom_traits.h"
 

--- a/shell/browser/printing/print_preview_message_handler.cc
+++ b/shell/browser/printing/print_preview_message_handler.cc
@@ -23,9 +23,8 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_contents_user_data.h"
 #include "mojo/public/cpp/bindings/callback_helpers.h"
-#include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
-
 #include "shell/common/node_includes.h"
+#include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
 
 using content::BrowserThread;
 

--- a/shell/browser/relauncher_linux.cc
+++ b/shell/browser/relauncher_linux.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/browser/relauncher.h"
-
 #include <fcntl.h>
 #include <signal.h>
 #include <sys/prctl.h>
@@ -14,6 +12,7 @@
 #include "base/logging.h"
 #include "base/process/launch.h"
 #include "base/synchronization/waitable_event.h"
+#include "shell/browser/relauncher.h"
 
 namespace relauncher {
 

--- a/shell/browser/relauncher_mac.cc
+++ b/shell/browser/relauncher_mac.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/browser/relauncher.h"
-
 #include <sys/event.h>
 #include <sys/time.h>
 #include <sys/types.h>
@@ -15,6 +13,7 @@
 #include "base/posix/eintr_wrapper.h"
 #include "base/process/launch.h"
 #include "base/strings/sys_string_conversions.h"
+#include "shell/browser/relauncher.h"
 
 namespace relauncher {
 

--- a/shell/browser/relauncher_win.cc
+++ b/shell/browser/relauncher_win.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/browser/relauncher.h"
-
 #include <windows.h>
 
 #include "base/logging.h"
@@ -12,6 +10,7 @@
 #include "base/win/scoped_handle.h"
 #include "sandbox/win/src/nt_internals.h"
 #include "sandbox/win/src/win_utils.h"
+#include "shell/browser/relauncher.h"
 #include "ui/base/win/shell.h"
 
 namespace relauncher {

--- a/shell/browser/ui/accelerator_util_unittests.cc
+++ b/shell/browser/ui/accelerator_util_unittests.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "shell/browser/ui/accelerator_util.h"
-
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace accelerator_util {

--- a/shell/browser/ui/autofill_popup.cc
+++ b/shell/browser/ui/autofill_popup.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "shell/browser/ui/autofill_popup.h"
+
 #include <algorithm>
 #include <memory>
 #include <vector>
@@ -12,7 +14,6 @@
 #include "electron/buildflags/buildflags.h"
 #include "mojo/public/cpp/bindings/associated_remote.h"
 #include "shell/browser/native_window_views.h"
-#include "shell/browser/ui/autofill_popup.h"
 #include "shell/common/api/api.mojom.h"
 #include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
 #include "ui/color/color_id.h"

--- a/shell/browser/ui/certificate_trust_win.cc
+++ b/shell/browser/ui/certificate_trust_win.cc
@@ -2,15 +2,13 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/browser/ui/certificate_trust.h"
-
-#include <windows.h>  // windows.h must be included first
-
 #include <wincrypt.h>
+#include <windows.h>  // windows.h must be included first
 
 #include "net/cert/cert_database.h"
 #include "net/cert/x509_util_win.h"
 #include "shell/browser/javascript_environment.h"
+#include "shell/browser/ui/certificate_trust.h"
 
 namespace certificate_trust {
 

--- a/shell/browser/ui/cocoa/electron_bundle_mover.mm
+++ b/shell/browser/ui/cocoa/electron_bundle_mover.mm
@@ -291,10 +291,9 @@ bool ElectronBundleMover::AuthorizedInstall(NSString* srcPath,
 
   AuthorizationItem myItems = {kAuthorizationRightExecute, 0, NULL, 0};
   AuthorizationRights myRights = {1, &myItems};
-  AuthorizationFlags myFlags =
-      (AuthorizationFlags)(kAuthorizationFlagInteractionAllowed |
-                           kAuthorizationFlagExtendRights |
-                           kAuthorizationFlagPreAuthorize);
+  AuthorizationFlags myFlags = (AuthorizationFlags)(
+      kAuthorizationFlagInteractionAllowed | kAuthorizationFlagExtendRights |
+      kAuthorizationFlagPreAuthorize);
 
   err = AuthorizationCopyRights(myAuthorizationRef, &myRights, NULL, myFlags,
                                 NULL);

--- a/shell/browser/ui/drag_util_views.cc
+++ b/shell/browser/ui/drag_util_views.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "shell/browser/ui/drag_util.h"
-
 #include "ui/aura/client/drag_drop_client.h"
 #include "ui/aura/window.h"
 #include "ui/base/clipboard/file_info.h"

--- a/shell/browser/ui/file_dialog_win.cc
+++ b/shell/browser/ui/file_dialog_win.cc
@@ -2,15 +2,13 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/browser/ui/file_dialog.h"
-
 #include <windows.h>  // windows.h must be included first
 
 #include "base/win/shlwapi.h"  // NOLINT(build/include_order)
+#include "shell/browser/ui/file_dialog.h"
 
 // atlbase.h for CComPtr
-#include <atlbase.h>  // NOLINT(build/include_order)
-
+#include <atlbase.h>   // NOLINT(build/include_order)
 #include <shlobj.h>    // NOLINT(build/include_order)
 #include <shobjidl.h>  // NOLINT(build/include_order)
 

--- a/shell/browser/ui/message_box_gtk.cc
+++ b/shell/browser/ui/message_box_gtk.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/browser/ui/message_box.h"
-
 #include <map>
 
 #include "base/callback.h"
@@ -15,6 +13,7 @@
 #include "shell/browser/native_window_observer.h"
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/ui/gtk_util.h"
+#include "shell/browser/ui/message_box.h"
 #include "shell/browser/unresponsive_suppressor.h"
 #include "ui/base/glib/glib_signal.h"
 #include "ui/gfx/image/image_skia.h"

--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -2,11 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/browser/ui/message_box.h"
-
-#include <windows.h>  // windows.h must be included first
-
 #include <commctrl.h>
+#include <windows.h>  // windows.h must be included first
 
 #include <map>
 #include <vector>
@@ -19,6 +16,7 @@
 #include "base/win/scoped_gdi_object.h"
 #include "shell/browser/browser.h"
 #include "shell/browser/native_window_views.h"
+#include "shell/browser/ui/message_box.h"
 #include "shell/browser/ui/win/dialog_thread.h"
 #include "shell/browser/unresponsive_suppressor.h"
 #include "ui/gfx/icon_util.h"

--- a/shell/browser/ui/views/autofill_popup_view.h
+++ b/shell/browser/ui/views/autofill_popup_view.h
@@ -7,11 +7,10 @@
 
 #include <memory>
 
-#include "shell/browser/ui/autofill_popup.h"
-
 #include "content/public/browser/native_web_keyboard_event.h"
 #include "content/public/browser/render_widget_host.h"
 #include "electron/buildflags/buildflags.h"
+#include "shell/browser/ui/autofill_popup.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/accessibility/ax_node_data.h"
 #include "ui/views/drag_controller.h"

--- a/shell/browser/ui/views/electron_views_delegate_win.cc
+++ b/shell/browser/ui/views/electron_views_delegate_win.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-CHROMIUM file.
 
-#include "shell/browser/ui/views/electron_views_delegate.h"
-
 #include <dwmapi.h>
 #include <shellapi.h>
 
@@ -11,6 +9,7 @@
 
 #include "base/bind.h"
 #include "base/task/thread_pool.h"
+#include "shell/browser/ui/views/electron_views_delegate.h"
 
 namespace {
 

--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -5,7 +5,6 @@
 #include "shell/browser/ui/views/inspectable_web_contents_view_views.h"
 
 #include <memory>
-
 #include <utility>
 
 #include "base/strings/utf_string_conversions.h"

--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -10,6 +10,7 @@
 #include "shell/browser/ui/views/win_frame_view.h"
 
 #include <dwmapi.h>
+
 #include <memory>
 
 #include "base/win/windows_version.h"

--- a/shell/browser/ui/win/jump_list.h
+++ b/shell/browser/ui/win/jump_list.h
@@ -7,6 +7,7 @@
 
 #include <atlbase.h>
 #include <shobjidl.h>
+
 #include <vector>
 
 #include "base/files/file_path.h"

--- a/shell/browser/ui/win/notify_icon.h
+++ b/shell/browser/ui/win/notify_icon.h
@@ -5,9 +5,8 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_WIN_NOTIFY_ICON_H_
 #define ELECTRON_SHELL_BROWSER_UI_WIN_NOTIFY_ICON_H_
 
-#include <windows.h>  // windows.h must be included first
-
 #include <shellapi.h>
+#include <windows.h>  // windows.h must be included first
 
 #include <memory>
 #include <string>

--- a/shell/browser/ui/win/taskbar_host.cc
+++ b/shell/browser/ui/win/taskbar_host.cc
@@ -5,6 +5,7 @@
 #include "shell/browser/ui/win/taskbar_host.h"
 
 #include <objbase.h>
+
 #include <string>
 
 #include "base/stl_util.h"

--- a/shell/common/api/electron_api_native_image_win.cc
+++ b/shell/common/api/electron_api_native_image_win.cc
@@ -2,14 +2,12 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/common/api/electron_api_native_image.h"
-
-#include <windows.h>
-
 #include <thumbcache.h>
+#include <windows.h>
 #include <wrl/client.h>
 
 #include "base/win/scoped_com_initializer.h"
+#include "shell/common/api/electron_api_native_image.h"
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/skia_util.h"

--- a/shell/common/application_info_linux.cc
+++ b/shell/common/application_info_linux.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/common/application_info.h"
-
 #include <gio/gdesktopappinfo.h>
 #include <gio/gio.h>
 
@@ -12,6 +10,7 @@
 #include "base/environment.h"
 #include "base/logging.h"
 #include "electron/electron_version.h"
+#include "shell/common/application_info.h"
 #include "shell/common/platform_util.h"
 #include "ui/gtk/gtk_util.h"  // nogncheck
 

--- a/shell/common/application_info_win.cc
+++ b/shell/common/application_info_win.cc
@@ -2,13 +2,10 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/common/application_info.h"
-
-#include <windows.h>  // windows.h must be included first
-
 #include <VersionHelpers.h>
 #include <appmodel.h>
 #include <shlobj.h>
+#include <windows.h>  // windows.h must be included first
 
 #include <memory>
 
@@ -19,6 +16,7 @@
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "shell/browser/win/scoped_hstring.h"
+#include "shell/common/application_info.h"
 
 namespace electron {
 

--- a/shell/common/keyboard_util.cc
+++ b/shell/common/keyboard_util.cc
@@ -2,11 +2,12 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include "shell/common/keyboard_util.h"
+
 #include <string>
 
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
-#include "shell/common/keyboard_util.h"
 #include "third_party/blink/public/common/input/web_input_event.h"
 #include "ui/events/event_constants.h"
 

--- a/shell/common/language_util_linux.cc
+++ b/shell/common/language_util_linux.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "shell/common/language_util.h"
-
 #include "ui/base/l10n/l10n_util.h"
 
 namespace electron {

--- a/shell/common/language_util_win.cc
+++ b/shell/common/language_util_win.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/common/language_util.h"
-
 #include <roapi.h>
 #include <windows.system.userprofile.h>
 #include <wrl.h>
@@ -13,6 +11,7 @@
 #include "base/win/i18n.h"
 #include "base/win/win_util.h"
 #include "base/win/windows_version.h"
+#include "shell/common/language_util.h"
 
 namespace electron {
 

--- a/shell/common/mouse_util.cc
+++ b/shell/common/mouse_util.cc
@@ -2,9 +2,10 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include "shell/common/mouse_util.h"
+
 #include <string>
 
-#include "shell/common/mouse_util.h"
 #include "ui/base/cursor/mojom/cursor_type.mojom-shared.h"
 
 using Cursor = ui::mojom::CursorType;

--- a/shell/common/mouse_util.h
+++ b/shell/common/mouse_util.h
@@ -6,6 +6,7 @@
 #define ELECTRON_SHELL_COMMON_MOUSE_UTIL_H_
 
 #include <string>
+
 #include "content/common/cursors/webcursor.h"
 #include "ipc/ipc_message_macros.h"
 

--- a/shell/common/node_includes.h
+++ b/shell/common/node_includes.h
@@ -14,8 +14,8 @@
 #undef debug_string    // This is defined in macOS SDK in AssertMacros.h.
 #undef require_string  // This is defined in macOS SDK in AssertMacros.h.
 
+#include "electron/pop_node_defines.h"
 #include "electron/push_and_undef_node_defines.h"
-
 #include "env-inl.h"
 #include "env.h"
 #include "node.h"
@@ -28,8 +28,6 @@
 #include "node_options.h"
 #include "node_platform.h"
 #include "tracing/agent.h"
-
-#include "electron/pop_node_defines.h"
 
 // Alternative to NODE_MODULE_CONTEXT_AWARE_X.
 // Allows to explicitly register builtin modules instead of using

--- a/shell/common/platform_util_internal.h
+++ b/shell/common/platform_util_internal.h
@@ -5,9 +5,9 @@
 #ifndef ELECTRON_SHELL_COMMON_PLATFORM_UTIL_INTERNAL_H_
 #define ELECTRON_SHELL_COMMON_PLATFORM_UTIL_INTERNAL_H_
 
-#include "shell/common/platform_util.h"
-
 #include <string>
+
+#include "shell/common/platform_util.h"
 
 namespace base {
 class FilePath;

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -2,11 +2,9 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/common/platform_util.h"
-
 #include <fcntl.h>
-
 #include <stdio.h>
+
 #include <string>
 #include <vector>
 
@@ -26,6 +24,7 @@
 #include "dbus/bus.h"
 #include "dbus/message.h"
 #include "dbus/object_proxy.h"
+#include "shell/common/platform_util.h"
 #include "shell/common/platform_util_internal.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/gtk/gtk_util.h"  // nogncheck

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -2,10 +2,6 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/common/platform_util.h"
-
-#include <windows.h>  // windows.h must be included first
-
 #include <atlbase.h>
 #include <comdef.h>
 #include <commdlg.h>
@@ -13,6 +9,7 @@
 #include <objbase.h>
 #include <shellapi.h>
 #include <shlobj.h>
+#include <windows.h>  // windows.h must be included first
 #include <wrl/client.h>
 
 #include "base/bind.h"
@@ -33,6 +30,7 @@
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "shell/common/electron_paths.h"
+#include "shell/common/platform_util.h"
 #include "ui/base/win/shell.h"
 #include "url/gurl.h"
 

--- a/shell/common/skia_util.cc
+++ b/shell/common/skia_util.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include "shell/common/skia_util.h"
+
 #include <string>
 
 #include "base/files/file_path.h"
@@ -12,7 +14,6 @@
 #include "net/base/data_url.h"
 #include "shell/common/asar/asar_util.h"
 #include "shell/common/node_includes.h"
-#include "shell/common/skia_util.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
 #include "third_party/skia/include/core/SkPixelRef.h"


### PR DESCRIPTION
#### Description of Change

Turns out our clang-format script has been broken for....... a while 😅 . This updates it per [`run-clang-format.py`](https://github.com/Sarcasm/run-clang-format/blob/master/run-clang-format.py) and applies changes to `shell/`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none