### PR TITLE
build: add --unique option to release notes script

### DIFF
--- a/script/release/notes/index.js
+++ b/script/release/notes/index.js
@@ -147,7 +147,7 @@ const getPreviousPoint = async (point) => {
   }
 };
 
-async function getReleaseNotes (range, newVersion) {
+async function getReleaseNotes (range, newVersion, unique) {
   const rangeList = range.split('..') || ['HEAD'];
   const to = rangeList.pop();
   const from = rangeList.pop() || (await getPreviousPoint(to));
@@ -158,7 +158,7 @@ async function getReleaseNotes (range, newVersion) {
 
   const notes = await notesGenerator.get(from, to, newVersion);
   const ret = {
-    text: notesGenerator.render(notes)
+    text: notesGenerator.render(notes, unique)
   };
 
   if (notes.unknown.length) {
@@ -170,7 +170,7 @@ async function getReleaseNotes (range, newVersion) {
 
 async function main () {
   const opts = minimist(process.argv.slice(2), {
-    boolean: ['help'],
+    boolean: ['help', 'unique'],
     string: ['version']
   });
   opts.range = opts._.shift();
@@ -179,13 +179,14 @@ async function main () {
     console.log(`
 easy usage: ${name} version
 
-full usage: ${name} [begin..]end [--version version]
+full usage: ${name} [begin..]end [--version version] [--unique]
 
  * 'begin' and 'end' are two git references -- tags, branches, etc --
    from which the release notes are generated.
  * if omitted, 'begin' defaults to the previous tag in end's branch.
  * if omitted, 'version' defaults to 'end'. Specifying a version is
    useful if you're making notes on a new version that isn't tagged yet.
+ * '--unique' omits changes that also landed in other branches.
 
 For example, these invocations are equivalent:
   ${process.argv[1]} v4.0.1
@@ -194,7 +195,7 @@ For example, these invocations are equivalent:
     return 0;
   }
 
-  const notes = await getReleaseNotes(opts.range, opts.version);
+  const notes = await getReleaseNotes(opts.range, opts.version, opts.unique);
   console.log(notes.text);
   if (notes.warning) {
     throw new Error(notes.warning);

--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -596,10 +596,14 @@ function renderDescription (commit) {
 const renderNote = (commit, excludeBranch) =>
   `* ${renderDescription(commit)} ${renderLink(commit)} ${renderTrops(commit, excludeBranch)}\n`;
 
-const renderNotes = (notes) => {
+const renderNotes = (notes, unique = false) => {
   const rendered = [`# Release Notes for ${notes.name}\n\n`];
 
-  const renderSection = (title, commits) => {
+  const renderSection = (title, commits, unique) => {
+    if (unique) {
+      // omit changes that also landed in other branches
+      commits = commits.filter((commit) => renderTrops(commit, notes.toBranch).length === 0);
+    }
     if (commits.length > 0) {
       rendered.push(
         `## ${title}\n\n`,
@@ -608,17 +612,17 @@ const renderNotes = (notes) => {
     }
   };
 
-  renderSection('Breaking Changes', notes.breaking);
-  renderSection('Features', notes.feat);
-  renderSection('Fixes', notes.fix);
-  renderSection('Other Changes', notes.other);
+  renderSection('Breaking Changes', notes.breaking, unique);
+  renderSection('Features', notes.feat, unique);
+  renderSection('Fixes', notes.fix, unique);
+  renderSection('Other Changes', notes.other, unique);
 
   if (notes.docs.length) {
     const docs = notes.docs.map(commit => renderLink(commit)).sort();
     rendered.push('## Documentation\n\n', ` * Documentation changes: ${docs.join(', ')}\n`, '\n');
   }
 
-  renderSection('Unknown', notes.unknown);
+  renderSection('Unknown', notes.unknown, unique);
 
   return rendered.join('');
 };


### PR DESCRIPTION
#### Description of Change

Add a `--unique` command-line parameter to the release notes script (default: `false`).

Not used in the release scripts, but can run manually to see only changes which have not been tropped into other branches. Useful when looking for 'notable changes' for x.0.0 blog posts!

CC @mlaurencin as the Keeper of the Notes and blog post coauthor @VerteDinde 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.