### PR TITLE
docs: remove X-Content-Security-Policy header in quick-start.md

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -131,7 +131,6 @@ folder of your project:
     <meta charset="UTF-8">
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'">
-    <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self'">
     <title>Hello World!</title>
   </head>
   <body>
@@ -427,7 +426,6 @@ window.addEventListener('DOMContentLoaded', () => {
     <meta charset="UTF-8">
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'">
-    <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self'">
     <title>Hello World!</title>
   </head>
   <body>


### PR DESCRIPTION
reference: Note: It is known that having both Content-Security-Policy
 and X-Content-Security-Policy or X-Webkit-CSP causes unexpected
 behaviours on certain versions of browsers. Please avoid using deprecated
 X-* headers. https://content-security-policy.com/
also:
https://github.com/electron/electron-quick-start/commit/1ad18486ed9be39612fdfe7b8fe265e602846ab3

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: no-notes