### PR TITLE
chore: use webContents.setWindowOpenHandler() in default-app

### DIFF
--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -66,9 +66,9 @@ async function createWindow (backgroundColor?: string) {
   mainWindow = new BrowserWindow(options);
   mainWindow.on('ready-to-show', () => mainWindow!.show());
 
-  mainWindow.webContents.on('new-window', (event, url) => {
-    event.preventDefault();
-    shell.openExternal(decorateURL(url));
+  mainWindow.webContents.setWindowOpenHandler(details => {
+    shell.openExternal(decorateURL(details.url));
+    return { action: 'deny' };
   });
 
   mainWindow.webContents.session.setPermissionRequestHandler((webContents, permission, done) => {


### PR DESCRIPTION
#### Description of Change
The `new-window` event is [deprecated](https://github.com/electron/electron/blob/main/docs/breaking-changes.md#deprecated-webcontents-new-window-event).

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none