### PR TITLE
test: use webContents.setWindowOpenHandler() in specs

### DIFF
--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -1563,9 +1563,10 @@ describe('webContents module', () => {
       server.listen(0, '127.0.0.1', () => {
         const url = 'http://127.0.0.1:' + (server.address() as AddressInfo).port + '/';
         w.webContents.once('did-finish-load', () => {
-          w.webContents.once('new-window', (event, newUrl, frameName, disposition, options, features, referrer) => {
-            expect(referrer.url).to.equal(url);
-            expect(referrer.policy).to.equal('strict-origin-when-cross-origin');
+          w.webContents.setWindowOpenHandler(details => {
+            expect(details.referrer.url).to.equal(url);
+            expect(details.referrer.policy).to.equal('strict-origin-when-cross-origin');
+            return { action: 'allow' };
           });
           w.webContents.executeJavaScript('a.click()');
         });
@@ -1591,9 +1592,10 @@ describe('webContents module', () => {
       server.listen(0, '127.0.0.1', () => {
         const url = 'http://127.0.0.1:' + (server.address() as AddressInfo).port + '/';
         w.webContents.once('did-finish-load', () => {
-          w.webContents.once('new-window', (event, newUrl, frameName, disposition, options, features, referrer) => {
-            expect(referrer.url).to.equal(url);
-            expect(referrer.policy).to.equal('no-referrer-when-downgrade');
+          w.webContents.setWindowOpenHandler(details => {
+            expect(details.referrer.url).to.equal(url);
+            expect(details.referrer.policy).to.equal('no-referrer-when-downgrade');
+            return { action: 'allow' };
           });
           w.webContents.executeJavaScript('window.open(location.href + "should_have_referrer")');
         });


### PR DESCRIPTION
#### Description of Change
The `new-window` event is [deprecated](https://github.com/electron/electron/blob/main/docs/breaking-changes.md#deprecated-webcontents-new-window-event).

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes
Notes: none