### PR TITLE
build: fix index upload error on 15-x-y

### DIFF
--- a/script/release/uploaders/upload-index-json.py
+++ b/script/release/uploaders/upload-index-json.py
@@ -4,7 +4,11 @@ from __future__ import print_function
 import json
 import os
 import sys
-import urllib2
+# Python 3 / 2 compat import
+try:
+  from urllib.request import Request, urlopen
+except ImportError:
+  from urllib2 import Request, urlopen
 
 sys.path.append(
   os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + "/../.."))
@@ -28,12 +32,12 @@ def is_json(myjson):
 
 def get_content(retry_count = 5):
   try:
-    request = urllib2.Request(
+    request = Request(
       BASE_URL + version,
       headers={"Authorization" : authToken}
     )
 
-    proposed_content = urllib2.urlopen(
+    proposed_content = urlopen(
       request
     ).read()
 


### PR DESCRIPTION
#### Description of Change

All branches except 15-x-y were migrated to Python 3. However, the last release of 15-x-y failed due to tooling expecting a Python 3 library. This PR adds compatibility for both Python 2 and Python 3 to that file prior to the final 15-x-y release.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
