### PR TITLE
ci: use larger machine for docs only check

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1562,7 +1562,7 @@ jobs:
   ts-compile-doc-change:
     executor:
       name: linux-docker
-      size: medium
+      size: 2xlarge
     environment:
       <<: *env-linux-2xlarge
       <<: *env-testing-build


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
- #33905 mistakenly reverted #33141 which in turn is causing doc only change PRs from forks to fail, eg https://app.circleci.com/pipelines/github/electron/electron/53769/workflows/0fa43589-8333-4187-97f4-2a13a57391b2/jobs/1229870.

From #33141: Doc only changes coming from forks were failing on gclient sync. Forks do not get access to the source/git caches that branches use, so gclient sync is much slower. Using a larger machine alleviates this problem.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
