### PR TITLE
test: re-enable shared worker webview test

### DIFF
--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -281,15 +281,14 @@ describe('chromium feature', () => {
         expect(event.data).to.equal('undefined undefined undefined undefined');
       });
 
-      // FIXME: disabled during chromium update due to crash in content::WorkerScriptFetchInitiator::CreateScriptLoaderOnIO
-      xit('has node integration with nodeIntegrationInWorker', async () => {
+      it('has node integration with nodeIntegrationInWorker', async () => {
         const webview = new WebView();
         webview.addEventListener('console-message', (e) => {
           console.log(e);
         });
         const eventPromise = waitForEvent(webview, 'ipc-message');
         webview.src = `file://${fixtures}/pages/shared_worker.html`;
-        webview.setAttribute('webpreferences', 'nodeIntegration, nodeIntegrationInWorker');
+        webview.setAttribute('webpreferences', 'nodeIntegration, nodeIntegrationInWorker, contextIsolation=no');
         document.body.appendChild(webview);
         const event = await eventPromise;
         webview.remove();


### PR DESCRIPTION
#### Description of Change

The crash no longer occurs locally and it passes as soon as `contextIsolation=no` is set as an attribute.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.
