### PR TITLE
build: trigger mksnapshot/chromedriver releases automatically

### DIFF
--- a/.github/workflows/release_dependency_versions.yml
+++ b/.github/workflows/release_dependency_versions.yml
@@ -1,0 +1,31 @@
+name: Trigger Major Release Dependency Updates
+
+on:
+  release:
+    types: [published]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  check_tag:
+    runs-on: ubuntu-latest
+    id: check_tag
+    - uses: actions/checkout@v3
+    - name: Check Tag
+      run: |
+        if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.0\.0$ ]]; then
+          echo ::set-output name=should_release::true
+        fi
+  trigger:
+    runs-on: ubuntu-latest
+    needs: check_tag
+    if: jobs.check_tag.outputs.should_release == 'true'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Trigger New chromedriver Release
+        run: |
+          gh api /repos/:owner/chromedriver/actions/workflows/release.yml/dispatches --input - <<< '{"ref":"main","inputs":{"version":"${{ github.event.release.tag_name }}"}}'
+      - name: Trigger New mksnapshot Release
+        run: |
+          gh api /repos/:owner/mksnapshot/actions/workflows/release.yml/dispatches --input - <<< '{"ref":"main","inputs":{"version":"${{ github.event.release.tag_name }}"}}'


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/chromedriver/pull/98
Refs https://github.com/electron/mksnapshot/pull/61

This GitHub Action adds automated release for chromedriver and mksnapshot whenever there are new major releases of Electron. 

✅ mksnapshot [test run](https://github.com/electron/mksnapshot/actions/runs/2383109099)
✅ chromedriver [test run](https://github.com/electron/chromedriver/runs/6588071750?check_suite_focus=true)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
