### PR TITLE
fix: use system freetype on linux

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -45,3 +45,7 @@ enable_cet_shadow_stack = false
 # V8 in the browser process.
 # Ref: https://source.chromium.org/chromium/chromium/src/+/45fba672185aae233e75d6ddc81ea1e0b30db050:v8/BUILD.gn;l=281
 is_cfi = false
+
+if (is_linux) {
+  use_system_freetype = true
+}


### PR DESCRIPTION
#### Description of Change

By default chromium doesn't use system's freetype, as a result electron ignore freetype config, and fonts doesn't look consistent in the OS

This change make sure the engine will use the system's freetype library and its configurations

Assuming that is the right place for the flag, and it'll propagate to chromium BUILD.gn, i'm not very sure about that

#### Release Notes

chromium engine now uses system's freetype library, and honor system's freetype configuration
