### PR TITLE
ci: cache python install to better deal with download errors.

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -527,13 +527,33 @@ step-install-gnutar-on-mac: &step-install-gnutar-on-mac
         ln -fs /usr/local/bin/gtar /usr/local/bin/tar
       fi
 
+step-restore-python-cache: &step-restore-python-cache
+  restore_cache:
+    keys:
+      - v2.7.18-python-cache-{{ arch }}
+    name: Restore python cache      
+
+step-save-python-cache: &step-save-python-cache
+  save_cache:
+    paths:
+      - python-downloads
+    key: v2.7.18-python-cache-{{ arch }}
+    name: Persisting python cache
+
 step-install-python2-on-mac: &step-install-python2-on-mac
   run:
     name: Install python2 on macos
     command: |
       if [ "`uname`" == "Darwin" ]; then
-        curl -O https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg
-        sudo installer -pkg python-2.7.18-macosx10.9.pkg -target /
+        if [ ! -f "python-downloads/python-2.7.18-macosx10.9.pkg" ]; then
+          mkdir python-downloads
+          echo 'Downloading Python 2.7.18'
+          curl -O https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg
+          mv python-2.7.18-macosx10.9.pkg python-downloads
+        else
+          echo 'Using Python install from cache'
+        fi
+        sudo installer -pkg python-downloads/python-2.7.18-macosx10.9.pkg -target /        
       fi
 
 step-gn-gen-default: &step-gn-gen-default
@@ -1011,7 +1031,9 @@ steps-electron-gn-check: &steps-electron-gn-check
     - *step-checkout-electron
     - *step-depot-tools-get
     - *step-depot-tools-add-to-path
+    - *step-restore-python-cache
     - *step-install-python2-on-mac
+    - *step-save-python-cache
     - *step-setup-env-for-build
     - *step-setup-goma-for-build
     - *step-generate-deps-hash
@@ -1296,7 +1318,9 @@ commands:
             - run: rm -rf src/electron
       - *step-restore-brew-cache
       - *step-install-gnutar-on-mac
+      - *step-restore-python-cache
       - *step-install-python2-on-mac
+      - *step-save-python-cache
       - *step-save-brew-cache
       - when:
           condition: << parameters.build >>
@@ -1488,7 +1512,10 @@ commands:
             - *step-depot-tools-get
       - *step-depot-tools-add-to-path
       - *step-restore-brew-cache
+      - *step-restore-python-cache
       - *step-install-python2-on-mac
+      - *step-save-python-cache
+
       - *step-get-more-space-on-mac
       - when:
           condition: << parameters.checkout >>


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
About 25% of the time the install of python2 on our macOS builds fails, eg:
https://app.circleci.com/pipelines/github/electron/electron/53960/workflows/902b979b-a95c-4b7c-ab67-6a83db73a8bd/jobs/1233894

This PR caches that download so that most of the time we can pull it from cache instead of downloading.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
