### PR TITLE
fix: on macOS show BrowserWindow on maximize if not currently shown

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -608,13 +608,23 @@ void NativeWindowMac::SetEnabled(bool enable) {
 }
 
 void NativeWindowMac::Maximize() {
-  if (IsMaximized())
+  const bool is_visible = [window_ isVisible];
+
+  if (IsMaximized()) {
+    if (!is_visible)
+      ShowInactive();
     return;
+  }
 
   // Take note of the current window size
   if (IsNormal())
     original_frame_ = [window_ frame];
   [window_ zoom:nil];
+
+  if (!is_visible) {
+    ShowInactive();
+    NotifyWindowMaximize();
+  }
 }
 
 void NativeWindowMac::Unmaximize() {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3817,22 +3817,24 @@ describe('BrowserWindow module', () => {
   // TODO(dsanders11): Enable once maximize event works on Linux again on CI
   ifdescribe(process.platform !== 'linux')('BrowserWindow.maximize()', () => {
     afterEach(closeAllWindows);
-    // TODO(dsanders11): Disabled on macOS, see https://github.com/electron/electron/issues/32947
-    ifit(process.platform !== 'darwin')('should show the window if it is not currently shown', async () => {
+    it('should show the window if it is not currently shown', async () => {
       const w = new BrowserWindow({ show: false });
       const hidden = emittedOnce(w, 'hide');
-      const shown = emittedOnce(w, 'show');
+      let shown = emittedOnce(w, 'show');
       const maximize = emittedOnce(w, 'maximize');
       expect(w.isVisible()).to.be.false('visible');
       w.maximize();
       await maximize;
+      await shown;
+      expect(w.isMaximized()).to.be.true('maximized');
       expect(w.isVisible()).to.be.true('visible');
       // Even if the window is already maximized
       w.hide();
       await hidden;
       expect(w.isVisible()).to.be.false('visible');
+      shown = emittedOnce(w, 'show');
       w.maximize();
-      await shown; // Ensure a 'show' event happens when it becomes visible
+      await shown;
       expect(w.isVisible()).to.be.true('visible');
     });
   });


### PR DESCRIPTION
Backport of #32949.

See that PR for details.

Notes: Fixed behavior of BrowserWindow.maximize on macOS for not shown windows