### PR TITLE
fix: missing resource printing DCHECK

### DIFF
--- a/electron_strings.grdp
+++ b/electron_strings.grdp
@@ -24,6 +24,9 @@
   <message name="IDS_DEFAULT_PRINT_DOCUMENT_TITLE" desc="Default title for a print document">
     Untitled Document
   </message>
+  <message name="IDS_UTILITY_PROCESS_PRINT_BACKEND_SERVICE_NAME" desc="The name of the utility process used for backend interactions with printer drivers.">
+    Print Backend Service
+  </message>
 
   <!-- Desktop Capturer API -->
   <message name="IDS_DESKTOP_MEDIA_PICKER_SINGLE_SCREEN_NAME" desc="Name for screens in the desktop media picker UI when there is only one monitor.">

--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -10,6 +10,19 @@ majority of changes originally come from these PRs:
 
 This patch also fixes callback for manual user cancellation and success.
 
+diff --git a/chrome/browser/printing/print_backend_service_manager.cc b/chrome/browser/printing/print_backend_service_manager.cc
+index 7df299afaa8c243b2aa913c8b5daa67efb18ebd2..feacf7ef13ebc1053702d5cb9e56955d397b7da9 100644
+--- a/chrome/browser/printing/print_backend_service_manager.cc
++++ b/chrome/browser/printing/print_backend_service_manager.cc
+@@ -18,7 +18,7 @@
+ #include "base/unguessable_token.h"
+ #include "build/build_config.h"
+ #include "chrome/browser/browser_process.h"
+-#include "chrome/grit/generated_resources.h"
++#include "electron/grit/electron_resources.h"
+ #include "chrome/services/printing/public/mojom/print_backend_service.mojom.h"
+ #include "components/crash/core/common/crash_keys.h"
+ #include "content/public/browser/browser_thread.h"
 diff --git a/chrome/browser/printing/print_job.cc b/chrome/browser/printing/print_job.cc
 index 6408cbee8b5a8e45c4276ed966b57c1e61ad1137..e951c41a1bd92a33e32f6835841d3935a05dde53 100644
 --- a/chrome/browser/printing/print_job.cc

--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -11,7 +11,7 @@ majority of changes originally come from these PRs:
 This patch also fixes callback for manual user cancellation and success.
 
 diff --git a/chrome/browser/printing/print_backend_service_manager.cc b/chrome/browser/printing/print_backend_service_manager.cc
-index 7df299afaa8c243b2aa913c8b5daa67efb18ebd2..feacf7ef13ebc1053702d5cb9e56955d397b7da9 100644
+index 27eb7cf1480e7a56ab6b7d010cdee65c72e62c10..76d265b8de17244ed9d3727f1bebe730a224cd56 100644
 --- a/chrome/browser/printing/print_backend_service_manager.cc
 +++ b/chrome/browser/printing/print_backend_service_manager.cc
 @@ -18,7 +18,7 @@


### PR DESCRIPTION
Closes https://github.com/electron/electron/issues/34358.

Adds missing resource string resultant of [CL:3470185](https://chromium-review.googlesource.com/c/chromium/src/+/3470185)

Notes: Fix printing crash when using `webContents.print()`.