### PR TITLE
fix: fullscreen windows aren't resizable on macOS

### DIFF
--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -167,6 +167,7 @@ class NativeWindowMac : public NativeWindow,
   void UpdateVibrancyRadii(bool fullscreen);
 
   // Set the attribute of NSWindow while work around a bug of zoom button.
+  bool GetStyleMask(NSUInteger flag) const;
   void SetStyleMask(bool on, NSUInteger flag);
   void SetCollectionBehavior(bool on, NSUInteger flag);
   void SetWindowLevel(int level);

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -167,7 +167,7 @@ class NativeWindowMac : public NativeWindow,
   void UpdateVibrancyRadii(bool fullscreen);
 
   // Set the attribute of NSWindow while work around a bug of zoom button.
-  bool GetStyleMask(NSUInteger flag) const;
+  bool HasStyleMask(NSUInteger flag) const;
   void SetStyleMask(bool on, NSUInteger flag);
   void SetCollectionBehavior(bool on, NSUInteger flag);
   void SetWindowLevel(int level);

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -646,7 +646,7 @@ void NativeWindowMac::Unmaximize() {
 }
 
 bool NativeWindowMac::IsMaximized() {
-  if (GetStyleMask(NSWindowStyleMaskResizable) != 0)
+  if (HasStyleMask(NSWindowStyleMaskResizable) != 0)
     return [window_ isZoomed];
 
   NSRect rectScreen = GetAspectRatio() > 0.0
@@ -729,7 +729,7 @@ void NativeWindowMac::SetFullScreen(bool fullscreen) {
 }
 
 bool NativeWindowMac::IsFullscreen() const {
-  return GetStyleMask(NSWindowStyleMaskFullScreen);
+  return HasStyleMask(NSWindowStyleMaskFullScreen);
 }
 
 void NativeWindowMac::SetBounds(const gfx::Rect& bounds, bool animate) {
@@ -831,7 +831,7 @@ void NativeWindowMac::SetResizable(bool resizable) {
 bool NativeWindowMac::IsResizable() {
   bool in_fs_transition =
       fullscreen_transition_state() != FullScreenTransitionState::NONE;
-  bool has_rs_mask = GetStyleMask(NSWindowStyleMaskResizable);
+  bool has_rs_mask = HasStyleMask(NSWindowStyleMaskResizable);
   return has_rs_mask && !IsFullscreen() && !in_fs_transition;
 }
 
@@ -848,7 +848,7 @@ void NativeWindowMac::SetMinimizable(bool minimizable) {
 }
 
 bool NativeWindowMac::IsMinimizable() {
-  return GetStyleMask(NSMiniaturizableWindowMask);
+  return HasStyleMask(NSMiniaturizableWindowMask);
 }
 
 void NativeWindowMac::SetMaximizable(bool maximizable) {
@@ -878,7 +878,7 @@ void NativeWindowMac::SetClosable(bool closable) {
 }
 
 bool NativeWindowMac::IsClosable() {
-  return GetStyleMask(NSWindowStyleMaskClosable);
+  return HasStyleMask(NSWindowStyleMaskClosable);
 }
 
 void NativeWindowMac::SetAlwaysOnTop(ui::ZOrderLevel z_order,
@@ -1386,7 +1386,7 @@ void NativeWindowMac::UpdateVibrancyRadii(bool fullscreen) {
   NSVisualEffectView* vibrantView = [window_ vibrantView];
 
   if (vibrantView != nil && !vibrancy_type_.empty()) {
-    const bool no_rounded_corner = !GetStyleMask(NSWindowStyleMaskTitled);
+    const bool no_rounded_corner = !HasStyleMask(NSWindowStyleMaskTitled);
     if (!has_frame() && !is_modal() && !no_rounded_corner) {
       CGFloat radius;
       if (fullscreen) {
@@ -1754,7 +1754,7 @@ void NativeWindowMac::OverrideNSWindowContentView() {
   AddContentViewLayers();
 }
 
-bool NativeWindowMac::GetStyleMask(NSUInteger flag) const {
+bool NativeWindowMac::HasStyleMask(NSUInteger flag) const {
   return [window_ styleMask] & flag;
 }
 

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -848,7 +848,7 @@ void NativeWindowMac::SetMinimizable(bool minimizable) {
 }
 
 bool NativeWindowMac::IsMinimizable() {
-  return HasStyleMask(NSMiniaturizableWindowMask);
+  return HasStyleMask(NSWindowStyleMaskMiniaturizable);
 }
 
 void NativeWindowMac::SetMaximizable(bool maximizable) {

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -235,7 +235,7 @@ using FullScreenTransitionState =
 
 - (void)windowWillEnterFullScreen:(NSNotification*)notification {
   // Store resizable mask so it can be restored after exiting fullscreen.
-  is_resizable_ = shell_->GetStyleMask(NSResizableWindowMask);
+  is_resizable_ = shell_->HasStyleMask(NSResizableWindowMask);
 
   shell_->SetFullScreenTransitionState(FullScreenTransitionState::ENTERING);
 

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -234,12 +234,14 @@ using FullScreenTransitionState =
 }
 
 - (void)windowWillEnterFullScreen:(NSNotification*)notification {
+  // Store resizable mask so it can be restored after exiting fullscreen.
+  is_resizable_ = shell_->GetStyleMask(NSResizableWindowMask);
+
   shell_->SetFullScreenTransitionState(FullScreenTransitionState::ENTERING);
 
   shell_->NotifyWindowWillEnterFullScreen();
 
-  // Setting resizable to true before entering fullscreen.
-  is_resizable_ = shell_->IsResizable();
+  // Set resizable to true before entering fullscreen.
   shell_->SetResizable(true);
 }
 

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -235,7 +235,7 @@ using FullScreenTransitionState =
 
 - (void)windowWillEnterFullScreen:(NSNotification*)notification {
   // Store resizable mask so it can be restored after exiting fullscreen.
-  is_resizable_ = shell_->HasStyleMask(NSResizableWindowMask);
+  is_resizable_ = shell_->HasStyleMask(NSWindowStyleMaskResizable);
 
   shell_->SetFullScreenTransitionState(FullScreenTransitionState::ENTERING);
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -4650,18 +4650,34 @@ describe('BrowserWindow module', () => {
     });
 
     ifdescribe(process.platform === 'darwin')('fullscreen state with resizable set', () => {
-      it('resizable flag should be set to true and restored', async () => {
+      it('resizable flag should be set to false and restored', async () => {
         const w = new BrowserWindow({ resizable: false });
+
         const enterFullScreen = emittedOnce(w, 'enter-full-screen');
         w.setFullScreen(true);
         await enterFullScreen;
-        expect(w.resizable).to.be.true('resizable');
+        expect(w.resizable).to.be.false('resizable');
 
         await delay();
         const leaveFullScreen = emittedOnce(w, 'leave-full-screen');
         w.setFullScreen(false);
         await leaveFullScreen;
         expect(w.resizable).to.be.false('resizable');
+      });
+
+      it('default resizable flag should be restored after entering/exiting fullscreen', async () => {
+        const w = new BrowserWindow();
+
+        const enterFullScreen = emittedOnce(w, 'enter-full-screen');
+        w.setFullScreen(true);
+        await enterFullScreen;
+        expect(w.resizable).to.be.false('resizable');
+
+        await delay();
+        const leaveFullScreen = emittedOnce(w, 'leave-full-screen');
+        w.setFullScreen(false);
+        await leaveFullScreen;
+        expect(w.resizable).to.be.true('resizable');
       });
     });
 


### PR DESCRIPTION
#### Description of Change

On macOS, BrowserWindows cannot be resized when in a fullscreen transition or when actively in fullscreen.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where BrowserWindows on macOS were incorrectly marked as resizable.