### PR TITLE
fix: crash when RenderFrameHost is nullptr

### DIFF
--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -193,8 +193,12 @@ void WebFrameMain::MaybeSetupMojoConnection() {
     renderer_api_.set_disconnect_handler(base::BindOnce(
         &WebFrameMain::OnRendererConnectionError, weak_factory_.GetWeakPtr()));
   }
+
+  // Render frame should exist when this method is called.
+  DCHECK(render_frame_);
+
   // Wait for RenderFrame to be created in renderer before accessing remote.
-  if (pending_receiver_ && render_frame_->IsRenderFrameCreated()) {
+  if (pending_receiver_ && render_frame_ && render_frame_->IsRenderFrameCreated()) {
     render_frame_->GetRemoteInterfaces()->GetInterface(
         std::move(pending_receiver_));
   }

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -198,7 +198,8 @@ void WebFrameMain::MaybeSetupMojoConnection() {
   DCHECK(render_frame_);
 
   // Wait for RenderFrame to be created in renderer before accessing remote.
-  if (pending_receiver_ && render_frame_ && render_frame_->IsRenderFrameCreated()) {
+  if (pending_receiver_ && render_frame_ &&
+      render_frame_->IsRenderFrameCreated()) {
     render_frame_->GetRemoteInterfaces()->GetInterface(
         std::move(pending_receiver_));
   }


### PR DESCRIPTION
#### Description of Change

Follow up to #33919. A code path involving speculative RenderFrameHosts being created is resulting in a crash when initially setting up the Mojo connection.

More investigation is still needed to determine what leads to this state where `render_frame_` is a nullptr.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed potential crash in WebFrameMain when performing a cross-origin navigation.
