### PR TITLE
chore: increase timeout for electron-build step

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -549,7 +549,7 @@ step-gn-check: &step-gn-check
 step-electron-build: &step-electron-build
   run:
     name: Electron build
-    no_output_timeout: 30m
+    no_output_timeout: 60m
     command: |
       # On arm platforms we generate a cross-arch ffmpeg that ninja does not seem
       # to realize is not correct / should be rebuilt.  We delete it here so it is


### PR DESCRIPTION
#### Description of Change

Beginning in main/20-x-y, the linking step on Mac is taking over a half hour.

While we figure out why this linking time has increased, this PR increases the output timeout from 30m to 60m so we can keep nightly and alpha releases moving.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
