### PR TITLE
chore: fix nan spec runner on macOS

### DIFF
--- a/script/nan-spec-runner.js
+++ b/script/nan-spec-runner.js
@@ -18,7 +18,8 @@ const args = require('minimist')(process.argv.slice(2), {
 });
 
 async function main () {
-  const nodeDir = path.resolve(BASE, `out/${utils.getOutDir({ shouldLog: true })}/gen/node_headers`);
+  const outDir = utils.getOutDir({ shouldLog: true });
+  const nodeDir = path.resolve(BASE, 'out', outDir, 'gen', 'node_headers');
   const env = Object.assign({}, process.env, {
     npm_config_nodedir: nodeDir,
     npm_config_msvs_version: '2019',
@@ -31,6 +32,25 @@ async function main () {
   const cxx = path.resolve(clangDir, 'clang++');
   const ld = path.resolve(clangDir, 'lld');
 
+  const platformFlags = [];
+  if (process.platform === 'darwin') {
+    const sdkPath = path.resolve(BASE, 'out', outDir, 'sdk', 'xcode_links');
+    const sdks = (await fs.promises.readdir(sdkPath)).filter(fileName => fileName.endsWith('.sdk'));
+    const sdkToUse = sdks[0];
+    if (!sdkToUse) {
+      console.error('Could not find an SDK to use for the NAN tests');
+      process.exit(1);
+    }
+
+    if (sdks.length) {
+      console.warn(`Multiple SDKs found in the xcode_links directory - using ${sdkToUse}`);
+    }
+
+    platformFlags.push(
+      `-isysroot ${path.resolve(sdkPath, sdkToUse)}`
+    );
+  }
+
   // TODO(ckerr) this is cribbed from read obj/electron/electron_app.ninja.
   // Maybe it would be better to have this script literally open up that
   // file and pull cflags_cc from it instead of using bespoke code here?
@@ -41,15 +61,17 @@ async function main () {
     `-isystem"${path.resolve(BASE, 'buildtools', 'third_party', 'libc++')}"`,
     `-isystem"${path.resolve(BASE, 'buildtools', 'third_party', 'libc++', 'trunk', 'include')}"`,
     `-isystem"${path.resolve(BASE, 'buildtools', 'third_party', 'libc++abi', 'trunk', 'include')}"`,
-    '-fPIC'
+    '-fPIC',
+    ...platformFlags
   ].join(' ');
 
   const ldflags = [
     '-stdlib=libc++',
     '-fuse-ld=lld',
-    `-L"${path.resolve(BASE, 'out', `${utils.getOutDir({ shouldLog: true })}`, 'obj', 'buildtools', 'third_party', 'libc++abi')}"`,
-    `-L"${path.resolve(BASE, 'out', `${utils.getOutDir({ shouldLog: true })}`, 'obj', 'buildtools', 'third_party', 'libc++')}"`,
-    '-lc++abi'
+    `-L"${path.resolve(BASE, 'out', outDir, 'obj', 'buildtools', 'third_party', 'libc++abi')}"`,
+    `-L"${path.resolve(BASE, 'out', outDir, 'obj', 'buildtools', 'third_party', 'libc++')}"`,
+    '-lc++abi',
+    ...platformFlags
   ].join(' ');
 
   if (process.platform !== 'win32') {
@@ -66,6 +88,7 @@ async function main () {
     cwd: NAN_DIR,
     stdio: 'inherit'
   });
+
   if (buildStatus !== 0) {
     console.error('Failed to build nan test modules');
     return process.exit(buildStatus);


### PR DESCRIPTION
#### Description of Change

In https://github.com/electron/electron/pull/29281, we modified the nan spec runner to build with `libc++`/`libc++abi`, since Linux uses `libstdc++` by default and there was a mismatch between the two that was causing test failures. However, this change inadvertently caused it to begin failing on macOS since that's not tested as part of the suite.

It transpires that macOS uses `libc++` by default, and so forcing it to use the `libc++` found in `src/buildtools/third_party/libc++` instead of what's found in XCode causes issues. We only need to pass `-std=c++17` as part of `CFLAGS` on macOS, and then the test suite works fully.

We might also consider running the nan tests on macOS as part of our test suite to help catch issues like this in the future 🤔  

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none