### PR TITLE
chore: use --root instead of --project_root for cpplint

### DIFF
--- a/script/lint.js
+++ b/script/lint.js
@@ -44,7 +44,7 @@ function spawnAndCheckExitCode (cmd, args, opts) {
 }
 
 function cpplint (args) {
-  args.unshift(`--project_root=${SOURCE_ROOT}`);
+  args.unshift(`--root=${SOURCE_ROOT}`);
   const result = childProcess.spawnSync(IS_WINDOWS ? 'cpplint.bat' : 'cpplint.py', args, { encoding: 'utf8', shell: true });
   // cpplint.py writes EVERYTHING to stderr, including status messages
   if (result.stderr) {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Currently when `cpplint` runs on Windows it is complaining a lot about incorrect header guards due to not knowing the correct root, which the `--project_root` flag is supposed tell it. It looks like `--root` and `--project_root` aim to do the same thing, AFAICT, but it doesn't seem like `--project_root` is working as intended. [cpplint/cpplint](https://github.com/cpplint/cpplint) (which is actually a fork and has diverged from 'depot_tools' `cpplint`, eek) has improved handling of `--root` (and doesn't have `--project_root` at all) which I [upstreamed to depot_tools](
https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/3648533), so let's use that.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
