### PR TITLE
fix: focus window when showing via maximize on macOS

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -942,7 +942,7 @@ Returns `boolean` - Whether current window is a modal window.
 
 #### `win.maximize()`
 
-Maximizes the window. This will also show (but not focus) the window if it
+Maximizes the window. This will also show the window if it
 isn't being displayed already.
 
 #### `win.unmaximize()`

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -608,7 +608,7 @@ void NativeWindowMac::Maximize() {
 
   if (IsMaximized()) {
     if (!is_visible)
-      ShowInactive();
+      Show();
     return;
   }
 
@@ -618,7 +618,7 @@ void NativeWindowMac::Maximize() {
   [window_ zoom:nil];
 
   if (!is_visible) {
-    ShowInactive();
+    Show();
     NotifyWindowMaximize();
   }
 }

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -602,6 +602,10 @@ void NativeWindowViews::Maximize() {
   } else {
     widget()->native_widget_private()->Show(ui::SHOW_STATE_MAXIMIZED,
                                             gfx::Rect());
+
+    // explicitly focus the window
+    widget()->Activate();
+
     NotifyWindowShow();
   }
 }

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -183,6 +183,10 @@ void NativeWindowViews::Maximize() {
     } else {
       widget()->native_widget_private()->Show(ui::SHOW_STATE_MAXIMIZED,
                                               gfx::Rect());
+
+      // explicitly focus the window
+      widget()->Activate();
+
       NotifyWindowShow();
     }
   } else {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -4037,14 +4037,18 @@ describe('BrowserWindow module', () => {
     it('should show the window if it is not currently shown', async () => {
       const w = new BrowserWindow({ show: false });
       const hidden = emittedOnce(w, 'hide');
+      const focused = emittedOnce(w, 'focus');
       let shown = emittedOnce(w, 'show');
       const maximize = emittedOnce(w, 'maximize');
       expect(w.isVisible()).to.be.false('visible');
+      expect(w.isFocused()).to.be.false('focused');
       w.maximize();
       await maximize;
       await shown;
+      await focused;
       expect(w.isMaximized()).to.be.true('maximized');
       expect(w.isVisible()).to.be.true('visible');
+      expect(w.isFocused()).to.be.true('focused');
       // Even if the window is already maximized
       w.hide();
       await hidden;

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -4034,11 +4034,16 @@ describe('BrowserWindow module', () => {
   // TODO(dsanders11): Enable once maximize event works on Linux again on CI
   ifdescribe(process.platform !== 'linux')('BrowserWindow.maximize()', () => {
     afterEach(closeAllWindows);
-    it('should show the window if it is not currently shown', async () => {
-      const w = new BrowserWindow({ show: false });
-      const hidden = emittedOnce(w, 'hide');
-      const focused = emittedOnce(w, 'focus');
+
+    const testMaximizeHiddenWindow = async (showInitially: boolean) => {
+      const w = new BrowserWindow({ show: showInitially });
       let shown = emittedOnce(w, 'show');
+      if (showInitially) {
+        await shown;
+        shown = emittedOnce(w, 'show');
+        await emittedOnce(w, 'hide', () => w.hide());
+      }
+      let focused = emittedOnce(w, 'focus');
       const maximize = emittedOnce(w, 'maximize');
       expect(w.isVisible()).to.be.false('visible');
       expect(w.isFocused()).to.be.false('focused');
@@ -4050,13 +4055,21 @@ describe('BrowserWindow module', () => {
       expect(w.isVisible()).to.be.true('visible');
       expect(w.isFocused()).to.be.true('focused');
       // Even if the window is already maximized
-      w.hide();
-      await hidden;
+      await emittedOnce(w, 'hide', () => w.hide());
       expect(w.isVisible()).to.be.false('visible');
+      expect(w.isFocused()).to.be.false('focused');
       shown = emittedOnce(w, 'show');
+      focused = emittedOnce(w, 'focus');
       w.maximize();
       await shown;
+      await focused;
       expect(w.isVisible()).to.be.true('visible');
+      expect(w.isFocused()).to.be.true('focused');
+    };
+
+    it('should show the window if it is not currently shown', async () => {
+      await testMaximizeHiddenWindow(true);
+      await testMaximizeHiddenWindow(false);
     });
   });
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Other platforms focus an unshown window when maximizing it causes it to become visible, and seem to have for a long time. This PR updates macOS to match the other platform behavior and corrects the documentation. See comments on #32949 for more detailed discussion.

Should the docs change be bumped out to a different PR? It gets a bit hidden in here, which isn't ideal.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed focus on macOS when calling BrowserWindow.maximize for not shown windows. <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
