### PR TITLE
fix: update normal bounds prior to minimizing

### DIFF
--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -166,6 +166,8 @@ class NativeWindowMac : public NativeWindow,
 
   void UpdateVibrancyRadii(bool fullscreen);
 
+  void UpdateWindowOriginalFrame();
+
   // Set the attribute of NSWindow while work around a bug of zoom button.
   bool HasStyleMask(NSUInteger flag) const;
   void SetStyleMask(bool on, NSUInteger flag);

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -447,7 +447,7 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   SetContentView(new views::View());
   AddContentViewLayers();
 
-  original_frame_ = [window_ frame];
+  UpdateWindowOriginalFrame();
   original_level_ = [window_ level];
 }
 
@@ -614,7 +614,7 @@ void NativeWindowMac::Maximize() {
 
   // Take note of the current window size
   if (IsNormal())
-    original_frame_ = [window_ frame];
+    UpdateWindowOriginalFrame();
   [window_ zoom:nil];
 
   if (!is_visible) {
@@ -658,7 +658,7 @@ void NativeWindowMac::Minimize() {
 
   // Take note of the current window size
   if (IsNormal())
-    original_frame_ = [window_ frame];
+    UpdateWindowOriginalFrame();
   [window_ miniaturize:nil];
 }
 
@@ -711,7 +711,7 @@ void NativeWindowMac::SetFullScreen(bool fullscreen) {
 
   // Take note of the current window size
   if (IsNormal())
-    original_frame_ = [window_ frame];
+    UpdateWindowOriginalFrame();
 
   // This needs to be set here because it can be the case that
   // SetFullScreen is called by a user before windowWillEnterFullScreen
@@ -747,6 +747,7 @@ void NativeWindowMac::SetBounds(const gfx::Rect& bounds, bool animate) {
 
   [window_ setFrame:cocoa_bounds display:YES animate:animate];
   user_set_bounds_maximized_ = IsMaximized() ? true : false;
+  UpdateWindowOriginalFrame();
 }
 
 gfx::Rect NativeWindowMac::GetBounds() {
@@ -1019,7 +1020,7 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
 
     // Take note of the current window size and level
     if (IsNormal()) {
-      original_frame_ = [window_ frame];
+      UpdateWindowOriginalFrame();
       original_level_ = [window_ level];
     }
 
@@ -1414,6 +1415,10 @@ void NativeWindowMac::UpdateVibrancyRadii(bool fullscreen) {
       [window_ setCornerMask:maskImage];
     }
   }
+}
+
+void NativeWindowMac::UpdateWindowOriginalFrame() {
+  original_frame_ = [window_ frame];
 }
 
 void NativeWindowMac::SetVibrancy(const std::string& type) {

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -203,6 +203,7 @@ using FullScreenTransitionState =
   // windowDidDeminiaturize
   level_ = [window level];
   shell_->SetWindowLevel(NSNormalWindowLevel);
+  shell_->UpdateWindowOriginalFrame();
 }
 
 - (void)windowDidMiniaturize:(NSNotification*)notification {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1228,6 +1228,7 @@ describe('BrowserWindow module', () => {
           await resize;
           expectBoundsEqual(w.getNormalBounds(), w.getBounds());
         });
+
         it('checks normal bounds after move', async () => {
           const pos = [10, 10];
           const move = emittedOnce(w, 'move');
@@ -1246,6 +1247,51 @@ describe('BrowserWindow module', () => {
           await maximize;
           expectBoundsEqual(w.getNormalBounds(), bounds);
         });
+
+        it('updates normal bounds after resize and maximize', async () => {
+          const size = [300, 400];
+          const resize = emittedOnce(w, 'resize');
+          w.setSize(size[0], size[1]);
+          await resize;
+          const original = w.getBounds();
+
+          const maximize = emittedOnce(w, 'maximize');
+          w.maximize();
+          await maximize;
+
+          const normal = w.getNormalBounds();
+          const bounds = w.getBounds();
+
+          expect(normal).to.deep.equal(original);
+          expect(normal).to.not.deep.equal(bounds);
+
+          const close = emittedOnce(w, 'close');
+          w.close();
+          await close;
+        });
+
+        it('updates normal bounds after move and maximize', async () => {
+          const pos = [10, 10];
+          const move = emittedOnce(w, 'move');
+          w.setPosition(pos[0], pos[1]);
+          await move;
+          const original = w.getBounds();
+
+          const maximize = emittedOnce(w, 'maximize');
+          w.maximize();
+          await maximize;
+
+          const normal = w.getNormalBounds();
+          const bounds = w.getBounds();
+
+          expect(normal).to.deep.equal(original);
+          expect(normal).to.not.deep.equal(bounds);
+
+          const close = emittedOnce(w, 'close');
+          w.close();
+          await close;
+        });
+
         it('checks normal bounds when unmaximized', async () => {
           const bounds = w.getBounds();
           w.once('maximize', () => {
@@ -1257,6 +1303,7 @@ describe('BrowserWindow module', () => {
           await unmaximize;
           expectBoundsEqual(w.getNormalBounds(), bounds);
         });
+
         it('does not change size for a frameless window with min size', async () => {
           w.destroy();
           w = new BrowserWindow({
@@ -1277,6 +1324,7 @@ describe('BrowserWindow module', () => {
           await unmaximize;
           expectBoundsEqual(w.getNormalBounds(), bounds);
         });
+
         it('correctly checks transparent window maximization state', async () => {
           w.destroy();
           w = new BrowserWindow({
@@ -1296,6 +1344,7 @@ describe('BrowserWindow module', () => {
           await unmaximize;
           expect(w.isMaximized()).to.equal(false);
         });
+
         it('returns the correct value for windows with an aspect ratio', async () => {
           w.destroy();
           w = new BrowserWindow({
@@ -1325,6 +1374,41 @@ describe('BrowserWindow module', () => {
           await minimize;
           expectBoundsEqual(w.getNormalBounds(), bounds);
         });
+
+        it('updates normal bounds after move and minimize', async () => {
+          const pos = [10, 10];
+          const move = emittedOnce(w, 'move');
+          w.setPosition(pos[0], pos[1]);
+          await move;
+          const original = w.getBounds();
+
+          const minimize = emittedOnce(w, 'minimize');
+          w.minimize();
+          await minimize;
+
+          const normal = w.getNormalBounds();
+
+          expect(original).to.deep.equal(normal);
+          expectBoundsEqual(normal, w.getBounds());
+        });
+
+        it('updates normal bounds after resize and minimize', async () => {
+          const size = [300, 400];
+          const resize = emittedOnce(w, 'resize');
+          w.setSize(size[0], size[1]);
+          await resize;
+          const original = w.getBounds();
+
+          const minimize = emittedOnce(w, 'minimize');
+          w.minimize();
+          await minimize;
+
+          const normal = w.getNormalBounds();
+
+          expect(original).to.deep.equal(normal);
+          expectBoundsEqual(normal, w.getBounds());
+        });
+
         it('checks normal bounds when restored', async () => {
           const bounds = w.getBounds();
           w.once('minimize', () => {
@@ -1336,6 +1420,7 @@ describe('BrowserWindow module', () => {
           await restore;
           expectBoundsEqual(w.getNormalBounds(), bounds);
         });
+
         it('does not change size for a frameless window with min size', async () => {
           w.destroy();
           w = new BrowserWindow({
@@ -1381,6 +1466,50 @@ describe('BrowserWindow module', () => {
             expectBoundsEqual(w.getNormalBounds(), bounds);
           });
 
+          it('updates normal bounds after resize and fullscreen', async () => {
+            const size = [300, 400];
+            const resize = emittedOnce(w, 'resize');
+            w.setSize(size[0], size[1]);
+            await resize;
+            const original = w.getBounds();
+
+            const fsc = emittedOnce(w, 'enter-full-screen');
+            w.fullScreen = true;
+            await fsc;
+
+            const normal = w.getNormalBounds();
+            const bounds = w.getBounds();
+
+            expect(normal).to.deep.equal(original);
+            expect(normal).to.not.deep.equal(bounds);
+
+            const close = emittedOnce(w, 'close');
+            w.close();
+            await close;
+          });
+
+          it('updates normal bounds after move and fullscreen', async () => {
+            const pos = [10, 10];
+            const move = emittedOnce(w, 'move');
+            w.setPosition(pos[0], pos[1]);
+            await move;
+            const original = w.getBounds();
+
+            const fsc = emittedOnce(w, 'enter-full-screen');
+            w.fullScreen = true;
+            await fsc;
+
+            const normal = w.getNormalBounds();
+            const bounds = w.getBounds();
+
+            expect(normal).to.deep.equal(original);
+            expect(normal).to.not.deep.equal(bounds);
+
+            const close = emittedOnce(w, 'close');
+            w.close();
+            await close;
+          });
+
           it('checks normal bounds when unfullscreen\'ed', async () => {
             const bounds = w.getBounds();
             w.once('enter-full-screen', () => {
@@ -1416,6 +1545,50 @@ describe('BrowserWindow module', () => {
             await enterFullScreen;
 
             expectBoundsEqual(w.getNormalBounds(), bounds);
+          });
+
+          it('updates normal bounds after resize and fullscreen', async () => {
+            const size = [300, 400];
+            const resize = emittedOnce(w, 'resize');
+            w.setSize(size[0], size[1]);
+            await resize;
+            const original = w.getBounds();
+
+            const fsc = emittedOnce(w, 'enter-full-screen');
+            w.setFullScreen(true);
+            await fsc;
+
+            const normal = w.getNormalBounds();
+            const bounds = w.getBounds();
+
+            expect(normal).to.deep.equal(original);
+            expect(normal).to.not.deep.equal(bounds);
+
+            const close = emittedOnce(w, 'close');
+            w.close();
+            await close;
+          });
+
+          it('updates normal bounds after move and fullscreen', async () => {
+            const pos = [10, 10];
+            const move = emittedOnce(w, 'move');
+            w.setPosition(pos[0], pos[1]);
+            await move;
+            const original = w.getBounds();
+
+            const fsc = emittedOnce(w, 'enter-full-screen');
+            w.setFullScreen(true);
+            await fsc;
+
+            const normal = w.getNormalBounds();
+            const bounds = w.getBounds();
+
+            expect(normal).to.deep.equal(original);
+            expect(normal).to.not.deep.equal(bounds);
+
+            const close = emittedOnce(w, 'close');
+            w.close();
+            await close;
           });
 
           it('checks normal bounds when unfullscreen\'ed', async () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/34401.

Fixes an issue where normal bounds would not be appropriately updated if the user minimized via clicking on the minimize button as opposed to calling `BrowserWindow.minimize()` on macOS. This fixes that by updating the normal bounds value prior to window miniaturization in the NSWindow delegate.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where normal bounds would not be appropriately updated if the user minimized with the minimize button.