### PR TITLE
fix: don't require glibc 2.29+ on linux arm64 builds

### DIFF
--- a/script/sysroots.json
+++ b/script/sysroots.json
@@ -10,9 +10,9 @@
         "Tarball": "debian_bullseye_arm_sysroot.tar.xz"
     },
     "bullseye_arm64": {
-        "Sha1Sum": "de38cc85d51a820c3307e1937f3c2d3cedcce988",
-        "SysrootDir": "debian_bullseye_arm64-sysroot",
-        "Tarball": "debian_bullseye_arm64_sysroot.tar.xz"
+        "Sha1Sum": "5a56c1ef714154ea5003bcafb16f21b0f8dde023",
+        "SysrootDir": "debian_sid_arm64-sysroot",
+        "Tarball": "debian_sid_arm64_sysroot.tar.xz"
     },
     "bullseye_armel": {
         "Sha1Sum": "db15aab39af3cfbc55a8ff0386943db1b78a1eab",

--- a/script/sysroots.json
+++ b/script/sysroots.json
@@ -11,7 +11,7 @@
     },
     "bullseye_arm64": {
         "Sha1Sum": "5a56c1ef714154ea5003bcafb16f21b0f8dde023",
-        "SysrootDir": "debian_sid_arm64-sysroot",
+        "SysrootDir": "debian_bullseye_arm64-sysroot",
         "Tarball": "debian_sid_arm64_sysroot.tar.xz"
     },
     "bullseye_armel": {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
When we updated our sysroots in #33557 as part of the Chromium roll to 102.0.4989.0, it introduced a new dependency in linux arm64 builds to use glibc 2.29 or greater.  Since there are supported versions of linux distros (eg Ubuntu 18.04) that do not have access to this version of glibc, Electron no longer works in those versions.

This PR reverts the sysroot for linux arm64 only to the older sysroot as this issue only affects linux arm64 (linux x64 and armv7 are unaffected).

- Fixes #34399

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->Fixed linux arm64 builds to not require glibc 2.29+
