### PR TITLE
test: use webContents.setWindowOpenHandler() in specs

### DIFF
--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3265,9 +3265,6 @@ describe('BrowserWindow module', () => {
           action: 'allow',
           overrideBrowserWindowOptions: { show: false, webPreferences: { contextIsolation: false, webviewTag: true, nodeIntegrationInSubFrames: true } }
         }));
-        w.webContents.once('new-window', (event, url, frameName, disposition, options) => {
-          options.show = false;
-        });
 
         const webviewLoaded = emittedOnce(ipcMain, 'webview-loaded');
         w.loadFile(path.join(fixtures, 'api', 'new-window-webview.html'));

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -788,10 +788,10 @@ describe('chromium features', () => {
 
         defer(() => { w.close(); });
 
-        const newWindow = emittedOnce(w.webContents, 'new-window');
+        const promise = emittedOnce(app, 'browser-window-created');
         w.loadFile(path.join(fixturesPath, 'pages', 'window-open.html'));
-        const [,,,, options] = await newWindow;
-        expect(options.show).to.equal(true);
+        const [, newWindow] = await promise;
+        expect(newWindow.isVisible()).to.equal(true);
       });
     }
 

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -900,8 +900,12 @@ describe('chromium features', () => {
       const w = new BrowserWindow({ show: false });
       w.loadURL('about:blank');
       w.webContents.executeJavaScript('{ b = window.open(\'\', \'__proto__\'); null }');
-      const [, , frameName] = await emittedOnce(w.webContents, 'new-window');
-
+      const frameName = await new Promise((resolve) => {
+        w.webContents.setWindowOpenHandler(details => {
+          setImmediate(() => resolve(details.frameName));
+          return { action: 'allow' };
+        });
+      });
       expect(frameName).to.equal('__proto__');
     });
   });

--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -32,9 +32,12 @@ describe('<webview> tag', function () {
   afterEach(closeAllWindows);
 
   function hideChildWindows (e: any, wc: WebContents) {
-    wc.on('new-window', (event, url, frameName, disposition, options) => {
-      options.show = false;
-    });
+    wc.setWindowOpenHandler(() => ({
+      action: 'allow',
+      overrideBrowserWindowOptions: {
+        show: false
+      }
+    }));
   }
 
   before(() => {


### PR DESCRIPTION
#### Description of Change
Follow-up to #34310. This removes the usage of the deprecated `new-window` event from tests unrelated to this event.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes
Notes: none
