### PR TITLE
fix: crash when `setWindowOpenHandler` callback throws

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -483,14 +483,7 @@ WebContents.prototype._callWindowOpenHandler = function (event: Electron.Event, 
     return defaultResponse;
   }
 
-  let response;
-  try {
-    response = this._windowOpenHandler(details);
-  } catch (e: any) {
-    event.preventDefault();
-    console.log(`Error in windowOpenHandler: ${e.message}`);
-    return defaultResponse;
-  }
+  const response = this._windowOpenHandler(details);
 
   if (typeof response !== 'object') {
     event.preventDefault();
@@ -652,7 +645,15 @@ WebContents.prototype._init = function () {
         postBody,
         disposition
       };
-      const result = this._callWindowOpenHandler(event, details);
+
+      let result;
+      try {
+        result = this._callWindowOpenHandler(event, details);
+      } catch (err) {
+        event.preventDefault();
+        throw err;
+      }
+
       const options = result.browserWindowConstructorOptions;
       if (!event.defaultPrevented) {
         openGuestWindow({
@@ -683,7 +684,15 @@ WebContents.prototype._init = function () {
         referrer,
         postBody
       };
-      const result = this._callWindowOpenHandler(event, details);
+
+      let result;
+      try {
+        result = this._callWindowOpenHandler(event, details);
+      } catch (err) {
+        event.preventDefault();
+        throw err;
+      }
+
       windowOpenOutlivesOpenerOption = result.outlivesOpener;
       windowOpenOverriddenOptions = result.browserWindowConstructorOptions;
       if (!event.defaultPrevented) {

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -482,7 +482,15 @@ WebContents.prototype._callWindowOpenHandler = function (event: Electron.Event, 
   if (!this._windowOpenHandler) {
     return defaultResponse;
   }
-  const response = this._windowOpenHandler(details);
+
+  let response;
+  try {
+    response = this._windowOpenHandler(details);
+  } catch (e: any) {
+    event.preventDefault();
+    console.log(`Error in windowOpenHandler: ${e.message}`);
+    return defaultResponse;
+  }
 
   if (typeof response !== 'object') {
     event.preventDefault();

--- a/spec-main/guest-window-manager-spec.ts
+++ b/spec-main/guest-window-manager-spec.ts
@@ -79,6 +79,48 @@ describe('webContents.setWindowOpenHandler', () => {
 
   afterEach(closeAllWindows);
 
+  it('does not fire window creation events if the handler callback throws an error', async () => {
+    const error = new Promise((resolve) => {
+      browserWindow.webContents.setWindowOpenHandler(() => {
+        setTimeout(resolve);
+        throw new Error('oh no');
+      });
+    });
+
+    browserWindow.webContents.on('new-window', () => {
+      assert.fail('new-window should not be called with an overridden window.open');
+    });
+
+    browserWindow.webContents.on('did-create-window', () => {
+      assert.fail('did-create-window should not be called with an overridden window.open');
+    });
+
+    browserWindow.webContents.executeJavaScript("window.open('about:blank', '', 'show=no') && true");
+
+    await error;
+  });
+
+  it('does not fire window creation events if the handler callback returns a bad result', async () => {
+    const bad = new Promise((resolve) => {
+      browserWindow.webContents.setWindowOpenHandler(() => {
+        setTimeout(resolve);
+        return [1, 2, 3] as any;
+      });
+    });
+
+    browserWindow.webContents.on('new-window', () => {
+      assert.fail('new-window should not be called with an overridden window.open');
+    });
+
+    browserWindow.webContents.on('did-create-window', () => {
+      assert.fail('did-create-window should not be called with an overridden window.open');
+    });
+
+    browserWindow.webContents.executeJavaScript("window.open('about:blank', '', 'show=no') && true");
+
+    await bad;
+  });
+
   it('does not fire window creation events if an override returns action: deny', async () => {
     const denied = new Promise((resolve) => {
       browserWindow.webContents.setWindowOpenHandler(() => {
@@ -87,11 +129,11 @@ describe('webContents.setWindowOpenHandler', () => {
       });
     });
     browserWindow.webContents.on('new-window', () => {
-      assert.fail('new-window should not to be called with an overridden window.open');
+      assert.fail('new-window should not be called with an overridden window.open');
     });
 
     browserWindow.webContents.on('did-create-window', () => {
-      assert.fail('did-create-window should not to be called with an overridden window.open');
+      assert.fail('did-create-window should not be called with an overridden window.open');
     });
 
     browserWindow.webContents.executeJavaScript("window.open('about:blank', '', 'show=no') && true");
@@ -107,11 +149,11 @@ describe('webContents.setWindowOpenHandler', () => {
       });
     });
     browserWindow.webContents.on('new-window', () => {
-      assert.fail('new-window should not to be called with an overridden window.open');
+      assert.fail('new-window should not be called with an overridden window.open');
     });
 
     browserWindow.webContents.on('did-create-window', () => {
-      assert.fail('did-create-window should not to be called with an overridden window.open');
+      assert.fail('did-create-window should not be called with an overridden window.open');
     });
 
     await browserWindow.webContents.loadURL('data:text/html,<a target="_blank" href="http://example.com" style="display: block; width: 100%; height: 100%; position: fixed; left: 0; top: 0;">link</a>');
@@ -129,11 +171,11 @@ describe('webContents.setWindowOpenHandler', () => {
       });
     });
     browserWindow.webContents.on('new-window', () => {
-      assert.fail('new-window should not to be called with an overridden window.open');
+      assert.fail('new-window should not be called with an overridden window.open');
     });
 
     browserWindow.webContents.on('did-create-window', () => {
-      assert.fail('did-create-window should not to be called with an overridden window.open');
+      assert.fail('did-create-window should not be called with an overridden window.open');
     });
 
     await browserWindow.webContents.loadURL('data:text/html,<a href="http://example.com" style="display: block; width: 100%; height: 100%; position: fixed; left: 0; top: 0;">link</a>');


### PR DESCRIPTION
#### Description of Change
Closes https://github.com/electron/electron/issues/34508.

Fixes an error where `setWindowOpenHandler()` would crash if the callback threw an error. Fix this issue by wrapping the call in a try/catch and handling appropriately if an error is thrown.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an error where `setWindowOpenHandler()` would crash if the callback threw an error
