### PR TITLE
feat: add WebFrame.windowFeatures property

### DIFF
--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -314,3 +314,8 @@ current renderer process.
 An `Integer` representing the unique frame id in the current renderer process.
 Distinct WebFrame instances that refer to the same underlying frame will have
 the same `routingId`.
+
+### `webFrame.windowFeatures` _Readonly_
+
+A `String` representing the encoded list of window features passed into
+`window.open(url, target, windowFeatures)`.

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -51,6 +51,8 @@
 #include "third_party/blink/public/web/web_view.h"
 #include "third_party/blink/renderer/core/execution_context/execution_context.h"  // nogncheck
 #include "third_party/blink/renderer/core/frame/csp/content_security_policy.h"  // nogncheck
+#include "third_party/blink/renderer/core/frame/local_frame.h"  // nogncheck
+#include "third_party/blink/renderer/core/page/page.h"  // nogncheck
 #include "third_party/blink/renderer/platform/bindings/dom_wrapper_world.h"  // nogncheck
 #include "ui/base/ime/ime_text_span.h"
 #include "url/url_util.h"
@@ -396,7 +398,8 @@ class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
         .SetProperty("top", &WebFrameRenderer::GetTop)
         .SetProperty("firstChild", &WebFrameRenderer::GetFirstChild)
         .SetProperty("nextSibling", &WebFrameRenderer::GetNextSibling)
-        .SetProperty("routingId", &WebFrameRenderer::GetRoutingId);
+        .SetProperty("routingId", &WebFrameRenderer::GetRoutingId)
+        .SetProperty("windowFeatures", &WebFrameRenderer::GetWindowFeatures);
   }
 
   const char* GetTypeName() override { return "WebFrameRenderer"; }
@@ -903,6 +906,16 @@ class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
       return 0;
 
     return render_frame->GetRoutingID();
+  }
+
+  std::string GetWindowFeatures(v8::Isolate* isolate) {
+    content::RenderFrame* render_frame;
+    if (!MaybeGetRenderFrame(isolate, "windowFeatures", &render_frame))
+      return "";
+
+    blink::LocalFrameToken frame_token = render_frame->GetWebFrame()->GetLocalFrameToken();
+    blink::LocalFrame* frame = blink::LocalFrame::FromFrameToken(frame_token);
+    return frame ? frame->GetPage()->GetWindowFeatures().raw_features.Utf8() : "";
   }
 };
 

--- a/spec-main/spec-helpers.ts
+++ b/spec-main/spec-helpers.ts
@@ -145,3 +145,7 @@ export async function repeatedly<T> (
     if (+new Date() - begin > timeLimit) { throw new Error(`repeatedly timed out (limit=${timeLimit})`); }
   }
 }
+
+export function executeJavaScriptInPreloadContext (webContents: Electron.WebContents, code: string, userGesture?: boolean): ReturnType<Electron.WebContents['executeJavaScript']> {
+  return webContents.executeJavaScriptInIsolatedWorld(999, [{ code }], userGesture);
+}

--- a/spec/fixtures/pages/test-preload.js
+++ b/spec/fixtures/pages/test-preload.js
@@ -1,0 +1,3 @@
+// Expose 'require' for use in tests
+// eslint-disable-next-line no-undef
+globalThis.requireForTest = require;


### PR DESCRIPTION
#### Description of Change

Adds a `windowFeatures` property to the renderer's WebFrame API. This exposes the raw string of features passed into `window.open(url, name, features)`.

Electron has a [Chromium patch](https://github.com/electron/electron/blob/954fd725009093660599a03a6926d57717f5a8c4/patches/chromium/can_create_window.patch) which adds the raw feature list string. I'd like to be able to access it from a preload script without needing to hook up an IPC to save and retrieve this data already present in the renderer process.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added WebFrame.windowFeatures API to access features list passed to `window.open(url, name, features)`.
