### PR TITLE
chore: warn when using the deprecated new-window event

### DIFF
--- a/lib/browser/guest-window-manager.ts
+++ b/lib/browser/guest-window-manager.ts
@@ -5,7 +5,7 @@
  * out-of-process (cross-origin) are created here. "Embedder" roughly means
  * "parent."
  */
-import { BrowserWindow } from 'electron/main';
+import { BrowserWindow, deprecate } from 'electron/main';
 import type { BrowserWindowConstructorOptions, Referrer, WebContents, LoadURLOptions } from 'electron/main';
 import { parseFeatures } from '@electron/internal/browser/parse-features-string';
 
@@ -154,6 +154,10 @@ function emitDeprecatedNewWindowEvent ({ event, embedder, guest, windowOpenArgs,
     data: postData,
     ...parseContentTypeFormat(postData)
   } : null;
+
+  if (embedder.listenerCount('new-window') > 0) {
+    deprecate.log('The new-window event is deprecated and will be removed. Please use contents.setWindowOpenHandler() instead.');
+  }
 
   embedder.emit(
     'new-window',


### PR DESCRIPTION
#### Description of Change
Prerequisite for #34526

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added deprecation warning for the `new-window` event.