### PR TITLE
test: add missing page-title-updated event spec for webview

### DIFF
--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -554,6 +554,18 @@ describe('<webview> tag', function () {
     });
   });
 
+  describe('page-title-updated event', () => {
+    it('emits when title is set', async () => {
+      loadWebView(webview, {
+        src: `file://${fixtures}/pages/a.html`
+      });
+      const { title, explicitSet } = await waitForEvent(webview, 'page-title-updated');
+
+      expect(title).to.equal('test');
+      expect(explicitSet).to.be.true();
+    });
+  });
+
   describe('page-title-set event', () => {
     it('emits when title is set', async () => {
       loadWebView(webview, {


### PR DESCRIPTION
#### Description of Change
We are only testing the deprecated `page-title-set` event for webview.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes
Notes: none