### PR TITLE
chore: remove undocumented page-title-set webview event

### DIFF
--- a/lib/renderer/web-view/guest-view-internal.ts
+++ b/lib/renderer/web-view/guest-view-internal.ts
@@ -9,10 +9,6 @@ export interface GuestViewDelegate {
   reset(): void;
 }
 
-const DEPRECATED_EVENTS: Record<string, string> = {
-  'page-title-updated': 'page-title-set'
-} as const;
-
 export function registerEvents (viewInstanceId: number, delegate: GuestViewDelegate) {
   ipcRendererInternal.on(`${IPC_MESSAGES.GUEST_VIEW_INTERNAL_DESTROY_GUEST}-${viewInstanceId}`, function () {
     delegate.reset();
@@ -20,10 +16,6 @@ export function registerEvents (viewInstanceId: number, delegate: GuestViewDeleg
   });
 
   ipcRendererInternal.on(`${IPC_MESSAGES.GUEST_VIEW_INTERNAL_DISPATCH_EVENT}-${viewInstanceId}`, function (event, eventName, props) {
-    if (DEPRECATED_EVENTS[eventName] != null) {
-      delegate.dispatchEvent(DEPRECATED_EVENTS[eventName], props);
-    }
-
     delegate.dispatchEvent(eventName, props);
   });
 }

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -566,18 +566,6 @@ describe('<webview> tag', function () {
     });
   });
 
-  describe('page-title-set event', () => {
-    it('emits when title is set', async () => {
-      loadWebView(webview, {
-        src: `file://${fixtures}/pages/a.html`
-      });
-      const { title, explicitSet } = await waitForEvent(webview, 'page-title-set');
-
-      expect(title).to.equal('test');
-      expect(explicitSet).to.be.true();
-    });
-  });
-
   describe('page-favicon-updated event', () => {
     it('emits when favicon urls are received', async () => {
       loadWebView(webview, {


### PR DESCRIPTION
#### Description of Change
This event has been undocumented for ages.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: The undocumented `page-title-set` webview event has been removed.