### PR TITLE
fix: allow macOS debug builds to be built

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -92,6 +92,7 @@ static_library("chrome") {
       "//chrome/browser/media/webrtc/system_media_capture_permissions_stats_mac.h",
       "//chrome/browser/media/webrtc/system_media_capture_permissions_stats_mac.mm",
       "//chrome/browser/media/webrtc/window_icon_util_mac.mm",
+      "//chrome/browser/platform_util_mac.mm",
       "//chrome/browser/process_singleton_mac.mm",
       "//chrome/browser/ui/views/eye_dropper/eye_dropper_view_mac.h",
       "//chrome/browser/ui/views/eye_dropper/eye_dropper_view_mac.mm",


### PR DESCRIPTION
Extending the `testing` GN profile with the arguments documented to
allow breakpoint debugging
(https://www.electronjs.org/docs/latest/development/debugging#breakpoint-debugging)
doesn't quite work on macOS:

```sh
is_debug = true
symbol_level = 2
forbid_non_component_debug_builds = false
```

The build eventually fails on both Intel and Apple Silicon with the
following (summarized) error:

```sh
[S:41062 R:1 (41062:41247) (C/s:0.1 O/s:13.6)] SOLINK 'obj/electron/electron_framework_shared_library/Electron Framework' 'obj/electron/electron_framework_shared_library/Electron Framework.TOC'
FAILED: obj/electron/electron_framework_shared_library/Electron Framework obj/electron/electron_framework_shared_library/Electron Framework.TOC
...
Undefined symbols for architecture x86_64:
  "platform_util::GetViewForWindow(gfx::NativeWindow)", referenced from:
      BoundsOverlapWithAnyOpenPrompt(gfx::Rect const&, content::WebContents*) in libchrome.a(autofill_popup_view_utils.o)
  "platform_util::GetParent(gfx::NativeView)", referenced from:
      BoundsOverlapWithAnyOpenPrompt(gfx::Rect const&, content::WebContents*) in libchrome.a(autofill_popup_view_utils.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
...
```

This symbol is defined on a file that is not declared as a dependency of
`libchrome` on the GN definitions. Why the problem is not reproducible
on plain testing or release builds remains a mystery to me. I'm guessing
some non-debug path somewhere in the GN definitions does eventually
require that file.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes

#### Release Notes

Notes: none
