### PR TITLE
chore: cherry-pick 9768648fffc9 from angle

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -1,0 +1,1 @@
+cherry-pick-9768648fffc9.patch

--- a/patches/angle/cherry-pick-9768648fffc9.patch
+++ b/patches/angle/cherry-pick-9768648fffc9.patch
@@ -1,0 +1,27 @@
+From 9768648fffc94a434a7d400a2542ce3706224417 Mon Sep 17 00:00:00 2001
+From: SeongHwan Park <ggabu423@gmail.com>
+Date: Tue, 31 May 2022 02:41:32 +0900
+Subject: [PATCH] [M102] Fix to invalidate cache when binding Transform Feedback.
+
+Bug: chromium:1330379
+Change-Id: I091116286ac511c50f9abcffa4d3cf350be920b4
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3677115
+Commit-Queue: Jamie Madill <jmadill@chromium.org>
+Reviewed-by: Jamie Madill <jmadill@chromium.org>
+(cherry picked from commit d96cee6685099f6bcc392a4d20d28c8ec484673a)
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3691799
+Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
+---
+
+diff --git a/src/libANGLE/Context.cpp b/src/libANGLE/Context.cpp
+index 75385dd..baf881d 100644
+--- a/src/libANGLE/Context.cpp
++++ b/src/libANGLE/Context.cpp
+@@ -1364,6 +1364,7 @@
+     TransformFeedback *transformFeedback =
+         checkTransformFeedbackAllocation(transformFeedbackHandle);
+     mState.setTransformFeedbackBinding(this, transformFeedback);
++    mStateCache.onActiveTransformFeedbackChange(this);
+ }
+ 
+ void Context::bindProgramPipeline(ProgramPipelineID pipelineHandle)

--- a/patches/angle/cherry-pick-9768648fffc9.patch
+++ b/patches/angle/cherry-pick-9768648fffc9.patch
@@ -1,7 +1,7 @@
-From 9768648fffc94a434a7d400a2542ce3706224417 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: SeongHwan Park <ggabu423@gmail.com>
 Date: Tue, 31 May 2022 02:41:32 +0900
-Subject: [PATCH] [M102] Fix to invalidate cache when binding Transform Feedback.
+Subject: Fix to invalidate cache when binding Transform Feedback.
 
 Bug: chromium:1330379
 Change-Id: I091116286ac511c50f9abcffa4d3cf350be920b4
@@ -11,13 +11,12 @@ Reviewed-by: Jamie Madill <jmadill@chromium.org>
 (cherry picked from commit d96cee6685099f6bcc392a4d20d28c8ec484673a)
 Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3691799
 Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
----
 
 diff --git a/src/libANGLE/Context.cpp b/src/libANGLE/Context.cpp
-index 75385dd..baf881d 100644
+index 685b235cc5962c4f55f539e387dda8c7edb023bc..390f7bc6790abe5d84b05f97160966eca46fee05 100755
 --- a/src/libANGLE/Context.cpp
 +++ b/src/libANGLE/Context.cpp
-@@ -1364,6 +1364,7 @@
+@@ -1323,6 +1323,7 @@ void Context::bindTransformFeedback(GLenum target, TransformFeedbackID transform
      TransformFeedback *transformFeedback =
          checkTransformFeedbackAllocation(transformFeedbackHandle);
      mState.setTransformFeedbackBinding(this, transformFeedback);

--- a/patches/config.json
+++ b/patches/config.json
@@ -19,5 +19,7 @@
 
   "src/electron/patches/Mantle": "src/third_party/squirrel.mac/vendor/Mantle",
 
-  "src/electron/patches/ReactiveObjC": "src/third_party/squirrel.mac/vendor/ReactiveObjC"
+  "src/electron/patches/ReactiveObjC": "src/third_party/squirrel.mac/vendor/ReactiveObjC",
+
+  "src/electron/patches/angle": "src/third_party/angle"
 }


### PR DESCRIPTION
[M102] Fix to invalidate cache when binding Transform Feedback.

Bug: chromium:1330379
Change-Id: I091116286ac511c50f9abcffa4d3cf350be920b4
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3677115
Commit-Queue: Jamie Madill <jmadill@chromium.org>
Reviewed-by: Jamie Madill <jmadill@chromium.org>
(cherry picked from commit d96cee6685099f6bcc392a4d20d28c8ec484673a)
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3691799
Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>


Notes: Backported fix for CVE-2022-2011.