### PR TITLE
chore: cherry-pick f1504440487f from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -121,3 +121,4 @@ cherry-pick-6b66a45021a0.patch
 fix_xkb_keysym_reverse_look_up_for_lacros.patch
 custom_protocols_plzserviceworker.patch
 pa_support_16kb_pagesize_on_linux_arm64.patch
+cherry-pick-f1504440487f.patch

--- a/patches/chromium/cherry-pick-f1504440487f.patch
+++ b/patches/chromium/cherry-pick-f1504440487f.patch
@@ -1,0 +1,69 @@
+From f1504440487fc6461b085a472e3c46ed7796dd5b Mon Sep 17 00:00:00 2001
+From: Justin Novosad <junov@chromium.org>
+Date: Thu, 02 Jun 2022 19:35:57 +0000
+Subject: [PATCH] PaintOpReader: Harden PaintImage deserialization
+
+This fix prevents the deserialization of PaintImage pixel data from
+reading data out of bounds when the block of serialized pixel data isn't
+large enough to cover the expected amount of data, given the size and
+format of the image.
+
+(cherry picked from commit e89ea1489429a9a9e49e70d5d4e8d018fbafb6ac)
+
+Bug: 1325298
+Change-Id: Icbeb405d2031d7d8ce4537836d7996ce7885f6d1
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3669596
+Commit-Queue: Justin Novosad <junov@chromium.org>
+Reviewed-by: Jonathan Ross <jonross@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1007804}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3687975
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Reviewed-by: Justin Novosad <junov@chromium.org>
+Auto-Submit: Srinivas Sista <srinivassista@chromium.org>
+Commit-Queue: Srinivas Sista <srinivassista@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5005@{#1093}
+Cr-Branched-From: 5b4d9450fee01f821b6400e947b3839727643a71-refs/heads/main@{#992738}
+---
+
+diff --git a/cc/paint/paint_op_reader.cc b/cc/paint/paint_op_reader.cc
+index 006aad39..3958479 100644
+--- a/cc/paint/paint_op_reader.cc
++++ b/cc/paint/paint_op_reader.cc
+@@ -332,6 +332,10 @@
+ 
+         SkImageInfo image_info =
+             SkImageInfo::Make(width, height, color_type, kPremul_SkAlphaType);
++        if (pixel_size < image_info.computeMinByteSize()) {
++          SetInvalid(DeserializationError::kInsufficientPixelData);
++          return;
++        }
+         const volatile void* pixel_data = ExtractReadableMemory(pixel_size);
+         if (!valid_)
+           return;
+diff --git a/cc/paint/paint_op_reader.h b/cc/paint/paint_op_reader.h
+index 61ea287..c5b5e6e 100644
+--- a/cc/paint/paint_op_reader.h
++++ b/cc/paint/paint_op_reader.h
+@@ -183,8 +183,9 @@
+     kSharedImageProviderNoAccess = 50,
+     kSharedImageProviderSkImageCreationFailed = 51,
+     kZeroSkColorFilterBytes = 52,
++    kInsufficientPixelData = 53,
+ 
+-    kMaxValue = kZeroSkColorFilterBytes,
++    kMaxValue = kInsufficientPixelData
+   };
+ 
+   template <typename T>
+diff --git a/tools/metrics/histograms/enums.xml b/tools/metrics/histograms/enums.xml
+index 0561eb9..d07d4eb 100644
+--- a/tools/metrics/histograms/enums.xml
++++ b/tools/metrics/histograms/enums.xml
+@@ -70047,6 +70047,7 @@
+   <int value="50" label="SharedImageProvider no access"/>
+   <int value="51" label="SharedImageProvider SkImage creation failed"/>
+   <int value="52" label="Zero SkColorFilter bytes"/>
++  <int value="53" label="Insufficient Pixel Data"/>
+ </enum>
+ 
+ <enum name="PaletteModeCancelType">


### PR DESCRIPTION
PaintOpReader: Harden PaintImage deserialization

This fix prevents the deserialization of PaintImage pixel data from
reading data out of bounds when the block of serialized pixel data isn't
large enough to cover the expected amount of data, given the size and
format of the image.

(cherry picked from commit e89ea1489429a9a9e49e70d5d4e8d018fbafb6ac)

Bug: 1325298
Change-Id: Icbeb405d2031d7d8ce4537836d7996ce7885f6d1
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3669596
Commit-Queue: Justin Novosad <junov@chromium.org>
Reviewed-by: Jonathan Ross <jonross@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1007804}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3687975
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Reviewed-by: Justin Novosad <junov@chromium.org>
Auto-Submit: Srinivas Sista <srinivassista@chromium.org>
Commit-Queue: Srinivas Sista <srinivassista@chromium.org>
Cr-Commit-Position: refs/branch-heads/5005@{#1093}
Cr-Branched-From: 5b4d9450fee01f821b6400e947b3839727643a71-refs/heads/main@{#992738}


Notes: Backported fix for 1325298.