### PR TITLE
chore: cherry-pick f1504440487f from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -138,3 +138,4 @@ fsa_pass_file_ownership_to_worker_for_async_fsarfd_file_operations.patch
 merge_to_m100_don_t_use_getoriginalopener_to_get_opener_s_origin_on.patch
 cherry-pick-ec0cce63f47d.patch
 cherry-pick-99c3f3bfd507.patch
+cherry-pick-f1504440487f.patch

--- a/patches/chromium/cherry-pick-f1504440487f.patch
+++ b/patches/chromium/cherry-pick-f1504440487f.patch
@@ -1,7 +1,7 @@
-From f1504440487fc6461b085a472e3c46ed7796dd5b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Justin Novosad <junov@chromium.org>
-Date: Thu, 02 Jun 2022 19:35:57 +0000
-Subject: [PATCH] PaintOpReader: Harden PaintImage deserialization
+Date: Thu, 2 Jun 2022 19:35:57 +0000
+Subject: PaintOpReader: Harden PaintImage deserialization
 
 This fix prevents the deserialization of PaintImage pixel data from
 reading data out of bounds when the block of serialized pixel data isn't
@@ -23,13 +23,12 @@ Auto-Submit: Srinivas Sista <srinivassista@chromium.org>
 Commit-Queue: Srinivas Sista <srinivassista@chromium.org>
 Cr-Commit-Position: refs/branch-heads/5005@{#1093}
 Cr-Branched-From: 5b4d9450fee01f821b6400e947b3839727643a71-refs/heads/main@{#992738}
----
 
 diff --git a/cc/paint/paint_op_reader.cc b/cc/paint/paint_op_reader.cc
-index 006aad39..3958479 100644
+index d71230cfc47944ca538ec8e007f652640e752b63..e34a5fb540dfa2626ab4d0a655e4ba85aa2b8921 100644
 --- a/cc/paint/paint_op_reader.cc
 +++ b/cc/paint/paint_op_reader.cc
-@@ -332,6 +332,10 @@
+@@ -329,6 +329,10 @@ void PaintOpReader::Read(PaintImage* image) {
  
          SkImageInfo image_info =
              SkImageInfo::Make(width, height, color_type, kPremul_SkAlphaType);
@@ -41,10 +40,10 @@ index 006aad39..3958479 100644
          if (!valid_)
            return;
 diff --git a/cc/paint/paint_op_reader.h b/cc/paint/paint_op_reader.h
-index 61ea287..c5b5e6e 100644
+index 201cdfde5eea3a07e31a3d6a50a5119485d5c1fc..af784145a9365ea2f776a1020145c0b83c63f16d 100644
 --- a/cc/paint/paint_op_reader.h
 +++ b/cc/paint/paint_op_reader.h
-@@ -183,8 +183,9 @@
+@@ -180,8 +180,9 @@ class CC_PAINT_EXPORT PaintOpReader {
      kSharedImageProviderNoAccess = 50,
      kSharedImageProviderSkImageCreationFailed = 51,
      kZeroSkColorFilterBytes = 52,
@@ -56,10 +55,10 @@ index 61ea287..c5b5e6e 100644
  
    template <typename T>
 diff --git a/tools/metrics/histograms/enums.xml b/tools/metrics/histograms/enums.xml
-index 0561eb9..d07d4eb 100644
+index 5faaf3cfd3c0231ad34f651023aeec5d74d9c19b..e15f292c099cfc8bf9cb8613f73517f2f241d91f 100644
 --- a/tools/metrics/histograms/enums.xml
 +++ b/tools/metrics/histograms/enums.xml
-@@ -70047,6 +70047,7 @@
+@@ -66406,6 +66406,7 @@ Called by update_net_trust_anchors.py.-->
    <int value="50" label="SharedImageProvider no access"/>
    <int value="51" label="SharedImageProvider SkImage creation failed"/>
    <int value="52" label="Zero SkColorFilter bytes"/>

--- a/patches/chromium/cherry-pick-f1504440487f.patch
+++ b/patches/chromium/cherry-pick-f1504440487f.patch
@@ -1,0 +1,69 @@
+From f1504440487fc6461b085a472e3c46ed7796dd5b Mon Sep 17 00:00:00 2001
+From: Justin Novosad <junov@chromium.org>
+Date: Thu, 02 Jun 2022 19:35:57 +0000
+Subject: [PATCH] PaintOpReader: Harden PaintImage deserialization
+
+This fix prevents the deserialization of PaintImage pixel data from
+reading data out of bounds when the block of serialized pixel data isn't
+large enough to cover the expected amount of data, given the size and
+format of the image.
+
+(cherry picked from commit e89ea1489429a9a9e49e70d5d4e8d018fbafb6ac)
+
+Bug: 1325298
+Change-Id: Icbeb405d2031d7d8ce4537836d7996ce7885f6d1
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3669596
+Commit-Queue: Justin Novosad <junov@chromium.org>
+Reviewed-by: Jonathan Ross <jonross@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1007804}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3687975
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Reviewed-by: Justin Novosad <junov@chromium.org>
+Auto-Submit: Srinivas Sista <srinivassista@chromium.org>
+Commit-Queue: Srinivas Sista <srinivassista@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5005@{#1093}
+Cr-Branched-From: 5b4d9450fee01f821b6400e947b3839727643a71-refs/heads/main@{#992738}
+---
+
+diff --git a/cc/paint/paint_op_reader.cc b/cc/paint/paint_op_reader.cc
+index 006aad39..3958479 100644
+--- a/cc/paint/paint_op_reader.cc
++++ b/cc/paint/paint_op_reader.cc
+@@ -332,6 +332,10 @@
+ 
+         SkImageInfo image_info =
+             SkImageInfo::Make(width, height, color_type, kPremul_SkAlphaType);
++        if (pixel_size < image_info.computeMinByteSize()) {
++          SetInvalid(DeserializationError::kInsufficientPixelData);
++          return;
++        }
+         const volatile void* pixel_data = ExtractReadableMemory(pixel_size);
+         if (!valid_)
+           return;
+diff --git a/cc/paint/paint_op_reader.h b/cc/paint/paint_op_reader.h
+index 61ea287..c5b5e6e 100644
+--- a/cc/paint/paint_op_reader.h
++++ b/cc/paint/paint_op_reader.h
+@@ -183,8 +183,9 @@
+     kSharedImageProviderNoAccess = 50,
+     kSharedImageProviderSkImageCreationFailed = 51,
+     kZeroSkColorFilterBytes = 52,
++    kInsufficientPixelData = 53,
+ 
+-    kMaxValue = kZeroSkColorFilterBytes,
++    kMaxValue = kInsufficientPixelData
+   };
+ 
+   template <typename T>
+diff --git a/tools/metrics/histograms/enums.xml b/tools/metrics/histograms/enums.xml
+index 0561eb9..d07d4eb 100644
+--- a/tools/metrics/histograms/enums.xml
++++ b/tools/metrics/histograms/enums.xml
+@@ -70047,6 +70047,7 @@
+   <int value="50" label="SharedImageProvider no access"/>
+   <int value="51" label="SharedImageProvider SkImage creation failed"/>
+   <int value="52" label="Zero SkColorFilter bytes"/>
++  <int value="53" label="Insufficient Pixel Data"/>
+ </enum>
+ 
+ <enum name="PaletteModeCancelType">


### PR DESCRIPTION
PaintOpReader: Harden PaintImage deserialization

This fix prevents the deserialization of PaintImage pixel data from
reading data out of bounds when the block of serialized pixel data isn't
large enough to cover the expected amount of data, given the size and
format of the image.

(cherry picked from commit e89ea1489429a9a9e49e70d5d4e8d018fbafb6ac)

Bug: 1325298
Change-Id: Icbeb405d2031d7d8ce4537836d7996ce7885f6d1
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3669596
Commit-Queue: Justin Novosad <junov@chromium.org>
Reviewed-by: Jonathan Ross <jonross@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1007804}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3687975
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Reviewed-by: Justin Novosad <junov@chromium.org>
Auto-Submit: Srinivas Sista <srinivassista@chromium.org>
Commit-Queue: Srinivas Sista <srinivassista@chromium.org>
Cr-Commit-Position: refs/branch-heads/5005@{#1093}
Cr-Branched-From: 5b4d9450fee01f821b6400e947b3839727643a71-refs/heads/main@{#992738}


Notes: Backported fix for CVE-2022-2010.