### PR TITLE
chore: cherry-pick 6661eb4900da from angle

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -4,3 +4,4 @@ cherry-pick-d49484c21e3c.patch
 cherry-pick-a602a068e022.patch
 cherry-pick-a4f71e40e571.patch
 cherry-pick-9768648fffc9.patch
+cherry-pick-6661eb4900da.patch

--- a/patches/angle/cherry-pick-6661eb4900da.patch
+++ b/patches/angle/cherry-pick-6661eb4900da.patch
@@ -1,0 +1,28 @@
+From 6661eb4900dae62cbe9af5023f9c1e7105798b50 Mon Sep 17 00:00:00 2001
+From: Jamie Madill <jmadill@chromium.org>
+Date: Mon, 02 May 2022 15:42:23 -0400
+Subject: [PATCH] [M102] Fix validation cache when deleting a Transform Feedback.
+
+Bug: chromium:1320024
+Change-Id: I76ef85a3c65c663c138d8caebd4ef2c0da53cd4f
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3621780
+Commit-Queue: Jamie Madill <jmadill@chromium.org>
+Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
+Commit-Queue: Shahbaz Youssefi <syoussefi@chromium.org>
+(cherry picked from commit 84e42c3b04da9e2c9d93d35bb6f2b1830fef22f4)
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3650697
+Reviewed-by: Geoff Lang <geofflang@chromium.org>
+---
+
+diff --git a/src/libANGLE/Context.cpp b/src/libANGLE/Context.cpp
+index bd9e3cd..75385dd 100644
+--- a/src/libANGLE/Context.cpp
++++ b/src/libANGLE/Context.cpp
+@@ -3115,6 +3115,7 @@
+     if (mState.removeTransformFeedbackBinding(this, transformFeedback))
+     {
+         bindTransformFeedback(GL_TRANSFORM_FEEDBACK, {0});
++        mStateCache.onActiveTransformFeedbackChange(this);
+     }
+ }
+ 


### PR DESCRIPTION
[M102] Fix validation cache when deleting a Transform Feedback.

Bug: chromium:1320024
Change-Id: I76ef85a3c65c663c138d8caebd4ef2c0da53cd4f
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3621780
Commit-Queue: Jamie Madill <jmadill@chromium.org>
Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
Commit-Queue: Shahbaz Youssefi <syoussefi@chromium.org>
(cherry picked from commit 84e42c3b04da9e2c9d93d35bb6f2b1830fef22f4)
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3650697
Reviewed-by: Geoff Lang <geofflang@chromium.org>


Ref electron/security#163

Notes: Security: backported fix for 1320024.