### PR TITLE
chore: cherry-pick f3d01ff794dc from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -139,3 +139,4 @@ merge_to_m100_don_t_use_getoriginalopener_to_get_opener_s_origin_on.patch
 cherry-pick-ec0cce63f47d.patch
 cherry-pick-99c3f3bfd507.patch
 cherry-pick-21139756239b.patch
+cherry-pick-f3d01ff794dc.patch

--- a/patches/chromium/cherry-pick-f3d01ff794dc.patch
+++ b/patches/chromium/cherry-pick-f3d01ff794dc.patch
@@ -1,0 +1,122 @@
+From f3d01ff794dc29fe74ef9893edb768d35ba1b1ab Mon Sep 17 00:00:00 2001
+From: Alvin Ji <alvinji@chromium.org>
+Date: Thu, 28 Apr 2022 00:44:28 +0000
+Subject: [PATCH] [Merge M-102] Introduce isLowEnergyDevice() for safely downward static_cast from BluetoothDeviceMac to BluetoothLowEnergyDeviceMac
+
+device/bluetooth/bluetooth_adapter_mac.mm has two non safely downward static_cast BluetoothDevice to BluetoothLowEnergyDeviceMac
+
+To avoid it, we introduce isLowEnergyDevice() to BluetoothDeviceMac so we could identify LE bluetooth device from classic bluetooth device then safely cast it downward.
+
+(cherry picked from commit 2582158fc555edee390a050a64c1b89994a6b349)
+
+Bug: 1318610
+Change-Id: Iaf082fc2c40270237bbc0b000b80faa7f94b1026
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3601727
+Reviewed-by: Reilly Grant <reillyg@chromium.org>
+Commit-Queue: Alvin Ji <alvinji@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#995419}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3606585
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/5005@{#217}
+Cr-Branched-From: 5b4d9450fee01f821b6400e947b3839727643a71-refs/heads/main@{#992738}
+---
+
+diff --git a/device/bluetooth/bluetooth_adapter_mac.mm b/device/bluetooth/bluetooth_adapter_mac.mm
+index 3f7dce0..d342eb4 100644
+--- a/device/bluetooth/bluetooth_adapter_mac.mm
++++ b/device/bluetooth/bluetooth_adapter_mac.mm
+@@ -766,6 +766,11 @@
+     DVLOG(1)
+         << "Central no longer powered on. Notifying of device disconnection.";
+     for (BluetoothDevice* device : GetDevices()) {
++      // GetDevices() returns instances of BluetoothClassicDeviceMac and
++      // BluetoothLowEnergyDeviceMac. The DidDisconnectPeripheral() method is
++      // only available on BluetoothLowEnergyDeviceMac.
++      if (!static_cast<BluetoothDeviceMac*>(device)->IsLowEnergyDevice())
++        continue;
+       BluetoothLowEnergyDeviceMac* device_mac =
+           static_cast<BluetoothLowEnergyDeviceMac*>(device);
+       if (device_mac->IsGattConnected()) {
+@@ -903,9 +908,16 @@
+       BluetoothLowEnergyDeviceMac::GetPeripheralHashAddress(peripheral);
+   auto iter = devices_.find(device_address);
+   if (iter == devices_.end()) {
+-    return nil;
++    return nullptr;
+   }
+-  return static_cast<BluetoothLowEnergyDeviceMac*>(iter->second.get());
++  // device_mac can be BluetoothClassicDeviceMac* or
++  // BluetoothLowEnergyDeviceMac* To return valid BluetoothLowEnergyDeviceMac*
++  // we need to first check with IsLowEnergyDevice()
++  BluetoothDeviceMac* device_mac =
++      static_cast<BluetoothDeviceMac*>(iter->second.get());
++  return device_mac->IsLowEnergyDevice()
++             ? static_cast<BluetoothLowEnergyDeviceMac*>(device_mac)
++             : nullptr;
+ }
+ 
+ bool BluetoothAdapterMac::DoesCollideWithKnownDevice(
+diff --git a/device/bluetooth/bluetooth_classic_device_mac.h b/device/bluetooth/bluetooth_classic_device_mac.h
+index b11dbbd..a7deb96 100644
+--- a/device/bluetooth/bluetooth_classic_device_mac.h
++++ b/device/bluetooth/bluetooth_classic_device_mac.h
+@@ -82,6 +82,7 @@
+   // Returns the Bluetooth address for the |device|. The returned address has a
+   // normalized format (see below).
+   static std::string GetDeviceAddress(IOBluetoothDevice* device);
++  bool IsLowEnergyDevice() override;
+ 
+  protected:
+   // BluetoothDevice override
+diff --git a/device/bluetooth/bluetooth_classic_device_mac.mm b/device/bluetooth/bluetooth_classic_device_mac.mm
+index 210802ee..ceeeab4 100644
+--- a/device/bluetooth/bluetooth_classic_device_mac.mm
++++ b/device/bluetooth/bluetooth_classic_device_mac.mm
+@@ -305,4 +305,8 @@
+       base::SysNSStringToUTF8([device addressString]));
+ }
+ 
++bool BluetoothClassicDeviceMac::IsLowEnergyDevice() {
++  return false;
++}
++
+ }  // namespace device
+diff --git a/device/bluetooth/bluetooth_device_mac.h b/device/bluetooth/bluetooth_device_mac.h
+index 10245db..0213e20 100644
+--- a/device/bluetooth/bluetooth_device_mac.h
++++ b/device/bluetooth/bluetooth_device_mac.h
+@@ -30,6 +30,7 @@
+       BluetoothGattService::GattErrorCode error_code);
+   static BluetoothGattService::GattErrorCode GetGattErrorCodeFromNSError(
+       NSError* error);
++  virtual bool IsLowEnergyDevice() = 0;
+ 
+  protected:
+   BluetoothDeviceMac(BluetoothAdapterMac* adapter);
+diff --git a/device/bluetooth/bluetooth_low_energy_device_mac.h b/device/bluetooth/bluetooth_low_energy_device_mac.h
+index 6db4f574..1e5ce47 100644
+--- a/device/bluetooth/bluetooth_low_energy_device_mac.h
++++ b/device/bluetooth/bluetooth_low_energy_device_mac.h
+@@ -83,6 +83,7 @@
+       const device::BluetoothUUID& uuid,
+       ConnectToServiceCallback callback,
+       ConnectToServiceErrorCallback error_callback) override;
++  bool IsLowEnergyDevice() override;
+ 
+  protected:
+   // BluetoothDevice override.
+diff --git a/device/bluetooth/bluetooth_low_energy_device_mac.mm b/device/bluetooth/bluetooth_low_energy_device_mac.mm
+index 9a89728..73b1bee 100644
+--- a/device/bluetooth/bluetooth_low_energy_device_mac.mm
++++ b/device/bluetooth/bluetooth_low_energy_device_mac.mm
+@@ -207,6 +207,10 @@
+   NOTIMPLEMENTED();
+ }
+ 
++bool BluetoothLowEnergyDeviceMac::IsLowEnergyDevice() {
++  return true;
++}
++
+ void BluetoothLowEnergyDeviceMac::CreateGattConnectionImpl(
+     absl::optional<BluetoothUUID> serivce_uuid) {
+   if (!IsGattConnected()) {


### PR DESCRIPTION
[Merge M-102] Introduce isLowEnergyDevice() for safely downward static_cast from BluetoothDeviceMac to BluetoothLowEnergyDeviceMac

device/bluetooth/bluetooth_adapter_mac.mm has two non safely downward static_cast BluetoothDevice to BluetoothLowEnergyDeviceMac

To avoid it, we introduce isLowEnergyDevice() to BluetoothDeviceMac so we could identify LE bluetooth device from classic bluetooth device then safely cast it downward.

(cherry picked from commit 2582158fc555edee390a050a64c1b89994a6b349)

Bug: 1318610
Change-Id: Iaf082fc2c40270237bbc0b000b80faa7f94b1026
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3601727
Reviewed-by: Reilly Grant <reillyg@chromium.org>
Commit-Queue: Alvin Ji <alvinji@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#995419}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3606585
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Cr-Commit-Position: refs/branch-heads/5005@{#217}
Cr-Branched-From: 5b4d9450fee01f821b6400e947b3839727643a71-refs/heads/main@{#992738}


Ref electron/security#164

Notes: Security: backported fix for 1318610.