### PR TITLE
chore: cherry-pick 801b904aea7d from angle

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -4,3 +4,4 @@ cherry-pick-d49484c21e3c.patch
 cherry-pick-a602a068e022.patch
 cherry-pick-a4f71e40e571.patch
 cherry-pick-9768648fffc9.patch
+cherry-pick-801b904aea7d.patch

--- a/patches/angle/cherry-pick-801b904aea7d.patch
+++ b/patches/angle/cherry-pick-801b904aea7d.patch
@@ -1,0 +1,239 @@
+From 801b904aea7de49234dcd99114e01cb77e21bc52 Mon Sep 17 00:00:00 2001
+From: Jamie Madill <jmadill@chromium.org>
+Date: Fri, 20 May 2022 10:26:15 -0400
+Subject: [PATCH] [M102] D3D: Fix race condition with parallel shader compile.
+
+Bug: chromium:1317673
+Change-Id: I0fb7c9a66248852e41e8700e80c295393ef941e8
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3651153
+Reviewed-by: Jie A Chen <jie.a.chen@intel.com>
+Reviewed-by: Lingfeng Yang <lfy@google.com>
+Commit-Queue: Jamie Madill <jmadill@chromium.org>
+(cherry picked from commit 4a20c9143abbf29c649cf643182735e8952089e3)
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3691050
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+---
+
+diff --git a/src/libANGLE/renderer/d3d/ProgramD3D.cpp b/src/libANGLE/renderer/d3d/ProgramD3D.cpp
+index eb57441..166403e 100644
+--- a/src/libANGLE/renderer/d3d/ProgramD3D.cpp
++++ b/src/libANGLE/renderer/d3d/ProgramD3D.cpp
+@@ -1684,12 +1684,6 @@
+     angle::Result run() override
+     {
+         ANGLE_TRACE_EVENT0("gpu.angle", "ProgramD3D::GetVertexExecutableTask::run");
+-        if (!mProgram->mState.getAttachedShader(gl::ShaderType::Vertex))
+-        {
+-            return angle::Result::Continue;
+-        }
+-
+-        mProgram->updateCachedInputLayoutFromShader();
+ 
+         ANGLE_TRY(mProgram->getVertexExecutableForCachedInputLayout(this, &mExecutable, &mInfoLog));
+ 
+@@ -2166,6 +2160,11 @@
+ 
+         linkResources(resources);
+ 
++        if (mState.getAttachedShader(gl::ShaderType::Vertex))
++        {
++            updateCachedInputLayoutFromShader();
++        }
++
+         return compileProgramExecutables(context, infoLog);
+     }
+ }
+diff --git a/src/tests/gl_tests/ParallelShaderCompileTest.cpp b/src/tests/gl_tests/ParallelShaderCompileTest.cpp
+index bcd88ef..a98aff5 100644
+--- a/src/tests/gl_tests/ParallelShaderCompileTest.cpp
++++ b/src/tests/gl_tests/ParallelShaderCompileTest.cpp
+@@ -58,9 +58,10 @@
+         Task(int id) : mID(id) {}
+         virtual ~Task() {}
+ 
+-        virtual bool compile()                                     = 0;
+-        virtual bool isCompileCompleted()                          = 0;
+-        virtual bool link()                                        = 0;
++        virtual bool compile()            = 0;
++        virtual bool isCompileCompleted() = 0;
++        virtual bool link()               = 0;
++        virtual void postLink() {}
+         virtual void runAndVerify(ParallelShaderCompileTest *test) = 0;
+ 
+         bool isLinkCompleted()
+@@ -71,7 +72,7 @@
+         }
+ 
+       protected:
+-        std::string insertRandomString(const std::string &source)
++        static std::string InsertRandomString(const std::string &source)
+         {
+             RNG rng;
+             std::ostringstream ostream;
+@@ -80,7 +81,7 @@
+             return ostream.str();
+         }
+ 
+-        GLuint CompileShader(GLenum type, const std::string &source)
++        static GLuint CompileShader(GLenum type, const std::string &source)
+         {
+             GLuint shader = glCreateShader(type);
+ 
+@@ -90,7 +91,14 @@
+             return shader;
+         }
+ 
+-        bool checkShader(GLuint shader)
++        static void RecompileShader(GLuint shader, const std::string &source)
++        {
++            const char *sourceArray[1] = {source.c_str()};
++            glShaderSource(shader, 1, sourceArray, nullptr);
++            glCompileShader(shader);
++        }
++
++        static bool CheckShader(GLuint shader)
+         {
+             GLint compileResult;
+             glGetShaderiv(shader, GL_COMPILE_STATUS, &compileResult);
+@@ -129,7 +137,7 @@
+         TaskRunner() {}
+         ~TaskRunner() {}
+ 
+-        void run(ParallelShaderCompileTest *test)
++        void run(ParallelShaderCompileTest *test, unsigned int pollInterval)
+         {
+ 
+             std::vector<std::unique_ptr<T>> compileTasks;
+@@ -151,6 +159,7 @@
+                     if (task->isCompileCompleted())
+                     {
+                         bool isLinking = task->link();
++                        task->postLink();
+                         ASSERT_TRUE(isLinking);
+                         linkTasks.push_back(std::move(task));
+                         compileTasks.erase(compileTasks.begin() + i);
+@@ -158,7 +167,10 @@
+                     }
+                     ++i;
+                 }
+-                angle::Sleep(kPollInterval);
++                if (pollInterval != 0)
++                {
++                    angle::Sleep(pollInterval);
++                }
+             }
+ 
+             while (!linkTasks.empty())
+@@ -173,9 +185,16 @@
+                         linkTasks.erase(linkTasks.begin() + i);
+                         continue;
+                     }
++                    else
++                    {
++                        task->postLink();
++                    }
+                     ++i;
+                 }
+-                angle::Sleep(kPollInterval);
++                if (pollInterval != 0)
++                {
++                    angle::Sleep(pollInterval);
++                }
+             }
+         }
+     };
+@@ -192,9 +211,9 @@
+         bool compile() override
+         {
+             mVertexShader =
+-                CompileShader(GL_VERTEX_SHADER, insertRandomString(essl1_shaders::vs::Simple()));
++                CompileShader(GL_VERTEX_SHADER, InsertRandomString(essl1_shaders::vs::Simple()));
+             mFragmentShader = CompileShader(GL_FRAGMENT_SHADER,
+-                                            insertRandomString(essl1_shaders::fs::UniformColor()));
++                                            InsertRandomString(essl1_shaders::fs::UniformColor()));
+             return (mVertexShader != 0 && mFragmentShader != 0);
+         }
+ 
+@@ -213,7 +232,7 @@
+         bool link() override
+         {
+             mProgram = 0;
+-            if (checkShader(mVertexShader) && checkShader(mFragmentShader))
++            if (CheckShader(mVertexShader) && CheckShader(mFragmentShader))
+             {
+                 mProgram = glCreateProgram();
+                 glAttachShader(mProgram, mVertexShader);
+@@ -244,10 +263,25 @@
+             ASSERT_GL_NO_ERROR();
+         }
+ 
++      protected:
++        void recompile()
++        {
++            RecompileShader(mVertexShader, essl1_shaders::vs::Simple());
++            RecompileShader(mFragmentShader, essl1_shaders::fs::UniformColor());
++        }
++
+       private:
+-        GLColor mColor;
+         GLuint mVertexShader;
+         GLuint mFragmentShader;
++        GLColor mColor;
++    };
++
++    class ClearColorWithDrawRecompile : public ClearColorWithDraw
++    {
++      public:
++        ClearColorWithDrawRecompile(int taskID) : ClearColorWithDraw(taskID) {}
++
++        void postLink() override { recompile(); }
+     };
+ 
+     class ImageLoadStore : public Task
+@@ -268,7 +302,7 @@
+     imageStore(uImage_2, ivec2(gl_LocalInvocationID.xy), value);
+ })";
+ 
+-            mShader = CompileShader(GL_COMPUTE_SHADER, insertRandomString(kCSSource));
++            mShader = CompileShader(GL_COMPUTE_SHADER, InsertRandomString(kCSSource));
+             return mShader != 0;
+         }
+ 
+@@ -282,7 +316,7 @@
+         bool link() override
+         {
+             mProgram = 0;
+-            if (checkShader(mShader))
++            if (CheckShader(mShader))
+             {
+                 mProgram = glCreateProgram();
+                 glAttachShader(mProgram, mShader);
+@@ -370,7 +404,18 @@
+     ANGLE_SKIP_TEST_IF(!ensureParallelShaderCompileExtensionAvailable());
+ 
+     TaskRunner<ClearColorWithDraw> runner;
+-    runner.run(this);
++    runner.run(this, kPollInterval);
++}
++
++// Tests no crash in case that the Shader starts another compile while the Program being attached
++// to is still linking.
++// crbug.com/1317673
++TEST_P(ParallelShaderCompileTest, LinkProgramAndRecompileShader)
++{
++    ANGLE_SKIP_TEST_IF(!ensureParallelShaderCompileExtensionAvailable());
++
++    TaskRunner<ClearColorWithDrawRecompile> runner;
++    runner.run(this, 0);
+ }
+ 
+ class ParallelShaderCompileTestES31 : public ParallelShaderCompileTest
+@@ -389,7 +434,7 @@
+     ANGLE_SKIP_TEST_IF(!ensureParallelShaderCompileExtensionAvailable());
+ 
+     TaskRunner<ImageLoadStore> runner;
+-    runner.run(this);
++    runner.run(this, kPollInterval);
+ }
+ 
+ ANGLE_INSTANTIATE_TEST_ES2(ParallelShaderCompileTest);


### PR DESCRIPTION
[M102] D3D: Fix race condition with parallel shader compile.

Bug: chromium:1317673
Change-Id: I0fb7c9a66248852e41e8700e80c295393ef941e8
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3651153
Reviewed-by: Jie A Chen <jie.a.chen@intel.com>
Reviewed-by: Lingfeng Yang <lfy@google.com>
Commit-Queue: Jamie Madill <jmadill@chromium.org>
(cherry picked from commit 4a20c9143abbf29c649cf643182735e8952089e3)
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3691050
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>


Ref electron/security#170

Notes: Security: backported fix for 1317673.