### PR TITLE
chore: cherry-pick 03aa5ae75c29 from angle

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -1,1 +1,2 @@
 cherry-pick-9768648fffc9.patch
+cherry-pick-03aa5ae75c29.patch

--- a/patches/angle/cherry-pick-03aa5ae75c29.patch
+++ b/patches/angle/cherry-pick-03aa5ae75c29.patch
@@ -1,0 +1,74 @@
+From 03aa5ae75c29eef3873ab514e8a882454916b288 Mon Sep 17 00:00:00 2001
+From: Geoff Lang <geofflang@google.com>
+Date: Wed, 01 Jun 2022 11:22:42 -0400
+Subject: [PATCH] M102: Ignore eglBind/ReleaseTexImage calls for lost contexts.
+
+eglBindTexImage and eglReleaseTexImage no-op when no context is
+current. Extend this to lost contexts to match the behaviour of making
+a GL call on a lost context.
+
+This avoids potential unexpected bad accesses in the backends.
+
+Bug: chromium:1316578
+Change-Id: I7b309c297e0c803019720733dee2950abb4c4b5f
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3683869
+Reviewed-by: Jamie Madill <jmadill@chromium.org>
+Reviewed-by: Alexis Hétu <sugoi@google.com>
+Reviewed-by: Alexis Hétu <sugoi@chromium.org>
+Commit-Queue: Geoff Lang <geofflang@chromium.org>
+(cherry picked from commit bfab7e60a15dc6f72e34406d3f2a3996cd8d0be2)
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3691180
+---
+
+diff --git a/src/libANGLE/validationEGL.cpp b/src/libANGLE/validationEGL.cpp
+index 472405d..5b775b4 100644
+--- a/src/libANGLE/validationEGL.cpp
++++ b/src/libANGLE/validationEGL.cpp
+@@ -4874,7 +4874,7 @@
+     }
+ 
+     gl::Context *context = val->eglThread->getContext();
+-    if (context)
++    if (context && !context->isContextLost())
+     {
+         gl::TextureType type = egl_gl::EGLTextureTargetToTextureType(surface->getTextureTarget());
+         gl::Texture *textureObject = context->getTextureByType(type);
+diff --git a/src/libGLESv2/egl_stubs.cpp b/src/libGLESv2/egl_stubs.cpp
+index 0554b7f..645f53b 100644
+--- a/src/libGLESv2/egl_stubs.cpp
++++ b/src/libGLESv2/egl_stubs.cpp
+@@ -61,7 +61,7 @@
+                          GetDisplayIfValid(display), EGL_FALSE);
+ 
+     gl::Context *context = thread->getContext();
+-    if (context)
++    if (context && !context->isContextLost())
+     {
+         gl::TextureType type =
+             egl_gl::EGLTextureTargetToTextureType(eglSurface->getTextureTarget());
+@@ -573,15 +573,18 @@
+ {
+     ANGLE_EGL_TRY_RETURN(thread, display->prepareForCall(), "eglReleaseTexImage",
+                          GetDisplayIfValid(display), EGL_FALSE);
+-    gl::Texture *texture = eglSurface->getBoundTexture();
+-
+-    if (texture)
++    gl::Context *context = thread->getContext();
++    if (context && !context->isContextLost())
+     {
+-        ANGLE_EGL_TRY_RETURN(thread, eglSurface->releaseTexImage(thread->getContext(), buffer),
+-                             "eglReleaseTexImage", GetSurfaceIfValid(display, eglSurface),
+-                             EGL_FALSE);
+-    }
++        gl::Texture *texture = eglSurface->getBoundTexture();
+ 
++        if (texture)
++        {
++            ANGLE_EGL_TRY_RETURN(thread, eglSurface->releaseTexImage(thread->getContext(), buffer),
++                                 "eglReleaseTexImage", GetSurfaceIfValid(display, eglSurface),
++                                 EGL_FALSE);
++        }
++    }
+     thread->setSuccess();
+     return EGL_TRUE;
+ }

--- a/patches/angle/cherry-pick-03aa5ae75c29.patch
+++ b/patches/angle/cherry-pick-03aa5ae75c29.patch
@@ -1,7 +1,10 @@
-From 03aa5ae75c29eef3873ab514e8a882454916b288 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Geoff Lang <geofflang@google.com>
-Date: Wed, 01 Jun 2022 11:22:42 -0400
-Subject: [PATCH] M102: Ignore eglBind/ReleaseTexImage calls for lost contexts.
+Date: Wed, 1 Jun 2022 11:22:42 -0400
+Subject: M102: Ignore eglBind/ReleaseTexImage calls for lost contexts.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 eglBindTexImage and eglReleaseTexImage no-op when no context is
 current. Extend this to lost contexts to match the behaviour of making
@@ -18,13 +21,12 @@ Reviewed-by: Alexis Hétu <sugoi@chromium.org>
 Commit-Queue: Geoff Lang <geofflang@chromium.org>
 (cherry picked from commit bfab7e60a15dc6f72e34406d3f2a3996cd8d0be2)
 Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3691180
----
 
 diff --git a/src/libANGLE/validationEGL.cpp b/src/libANGLE/validationEGL.cpp
-index 472405d..5b775b4 100644
+index 7e4b3adb8db7ea32c98228155e0a702796f0da4c..4309fd84e74fbb4a21edfb9b90bfc1fcda5a9d4a 100644
 --- a/src/libANGLE/validationEGL.cpp
 +++ b/src/libANGLE/validationEGL.cpp
-@@ -4874,7 +4874,7 @@
+@@ -4863,7 +4863,7 @@ bool ValidateBindTexImage(const ValidationContext *val,
      }
  
      gl::Context *context = val->eglThread->getContext();
@@ -34,10 +36,10 @@ index 472405d..5b775b4 100644
          gl::TextureType type = egl_gl::EGLTextureTargetToTextureType(surface->getTextureTarget());
          gl::Texture *textureObject = context->getTextureByType(type);
 diff --git a/src/libGLESv2/egl_stubs.cpp b/src/libGLESv2/egl_stubs.cpp
-index 0554b7f..645f53b 100644
+index 0554b7f40c65d6a2690380fe7483818886e20533..645f53ba038e3a5ad580eead0d9135cd274c57f8 100644
 --- a/src/libGLESv2/egl_stubs.cpp
 +++ b/src/libGLESv2/egl_stubs.cpp
-@@ -61,7 +61,7 @@
+@@ -61,7 +61,7 @@ EGLBoolean BindTexImage(Thread *thread, Display *display, Surface *eglSurface, E
                           GetDisplayIfValid(display), EGL_FALSE);
  
      gl::Context *context = thread->getContext();
@@ -46,7 +48,7 @@ index 0554b7f..645f53b 100644
      {
          gl::TextureType type =
              egl_gl::EGLTextureTargetToTextureType(eglSurface->getTextureTarget());
-@@ -573,15 +573,18 @@
+@@ -573,15 +573,18 @@ EGLBoolean ReleaseTexImage(Thread *thread, Display *display, Surface *eglSurface
  {
      ANGLE_EGL_TRY_RETURN(thread, display->prepareForCall(), "eglReleaseTexImage",
                           GetDisplayIfValid(display), EGL_FALSE);


### PR DESCRIPTION
M102: Ignore eglBind/ReleaseTexImage calls for lost contexts.

eglBindTexImage and eglReleaseTexImage no-op when no context is
current. Extend this to lost contexts to match the behaviour of making
a GL call on a lost context.

This avoids potential unexpected bad accesses in the backends.

Bug: chromium:1316578
Change-Id: I7b309c297e0c803019720733dee2950abb4c4b5f
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3683869
Reviewed-by: Jamie Madill <jmadill@chromium.org>
Reviewed-by: Alexis Hétu <sugoi@google.com>
Reviewed-by: Alexis Hétu <sugoi@chromium.org>
Commit-Queue: Geoff Lang <geofflang@chromium.org>
(cherry picked from commit bfab7e60a15dc6f72e34406d3f2a3996cd8d0be2)
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3691180


Ref electron/security#171

Notes: Security: backported fix for 1316578.