### PR TITLE
chore: fix BrowserView painting when origin updated

### DIFF
--- a/shell/browser/native_browser_view_views.cc
+++ b/shell/browser/native_browser_view_views.cc
@@ -128,6 +128,9 @@ void NativeBrowserViewViews::SetBounds(const gfx::Rect& bounds) {
   auto* view = iwc_view->GetView();
   view->SetBoundsRect(bounds);
   ResetAutoResizeProportions();
+
+  view->InvalidateLayout();
+  view->SchedulePaint();
 }
 
 gfx::Rect NativeBrowserViewViews::GetBounds() {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/34580.

Fixes an issue where changes to bounds that changed the origin and not the width or height did not consistently result in repaints.

Tested with https://gist.github.com/de7bb5f18826338729e03441da70e102.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where BrowserViews didn't always visually update after call to `setBounds`
