### PR TITLE
fix: draggable regions updating on bounds change

### DIFF
--- a/shell/browser/native_browser_view_views.cc
+++ b/shell/browser/native_browser_view_views.cc
@@ -27,6 +27,9 @@ void NativeBrowserViewViews::SetAutoResizeFlags(uint8_t flags) {
 
 void NativeBrowserViewViews::UpdateDraggableRegions(
     const std::vector<mojom::DraggableRegionPtr>& regions) {
+  if (&draggable_regions_ != &regions)
+    draggable_regions_ = mojo::Clone(regions);
+
   // We need to snap the regions to the bounds of the current BrowserView.
   // For example, if an attached BrowserView is draggable but its bounds are
   // { x: 200,  y: 100, width: 300, height: 300 }
@@ -35,12 +38,10 @@ void NativeBrowserViewViews::UpdateDraggableRegions(
   // assumed that the regions begin in the top left corner as they
   // would for the main client window.
   auto const offset = GetBounds().OffsetFromOrigin();
-  auto snapped_regions = mojo::Clone(regions);
-  for (auto& snapped_region : snapped_regions) {
+  for (auto& snapped_region : draggable_regions_) {
     snapped_region->bounds.Offset(offset);
   }
-
-  draggable_region_ = DraggableRegionsToSkRegion(snapped_regions);
+  draggable_region_ = DraggableRegionsToSkRegion(draggable_regions_);
 }
 
 void NativeBrowserViewViews::SetAutoResizeProportions(
@@ -128,6 +129,9 @@ void NativeBrowserViewViews::SetBounds(const gfx::Rect& bounds) {
   auto* view = iwc_view->GetView();
   view->SetBoundsRect(bounds);
   ResetAutoResizeProportions();
+
+  // Ensure draggable regions are properly updated to reflect new bounds.
+  UpdateDraggableRegions(draggable_regions_);
 }
 
 gfx::Rect NativeBrowserViewViews::GetBounds() {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/34552.

Fixes an issue where draggable regions were not recalculated when BrowserView bounds changed. This was happening because we didn't issue a call to `UpdateDraggableRegions` after bounds changed on Windows, as we do on macOS: https://github.com/electron/electron/blob/abf6f1cf78fa4e88131fe2a77caf350cb3b9fdcb/shell/browser/native_browser_view_mac.mm#L270 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where draggable regions were not recalculated when BrowserView bounds changed on Windows.