### PR TITLE
build: build & release libcxx objects on darwin

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -794,8 +794,8 @@ step-maybe-generate-libcxx: &step-maybe-generate-libcxx
       if [ "`uname`" == "Linux" ]; then
         ninja -C out/Default electron:libcxx_headers_zip -j $NUMBER_OF_NINJA_PROCESSES
         ninja -C out/Default electron:libcxxabi_headers_zip -j $NUMBER_OF_NINJA_PROCESSES
-        ninja -C out/Default electron:libcxx_objects_zip -j $NUMBER_OF_NINJA_PROCESSES
       fi
+      ninja -C out/Default electron:libcxx_objects_zip -j $NUMBER_OF_NINJA_PROCESSES
 
 step-maybe-generate-breakpad-symbols: &step-maybe-generate-breakpad-symbols
   run:

--- a/script/release/release.js
+++ b/script/release/release.js
@@ -146,6 +146,8 @@ function assetsForVersion (version, validatingRelease) {
     `libcxx-objects-${version}-linux-arm64.zip`,
     `libcxx-objects-${version}-linux-armv7l.zip`,
     `libcxx-objects-${version}-linux-x64.zip`,
+    `libcxx-objects-${version}-darwin-x64.zip`,
+    `libcxx-objects-${version}-darwin-arm64.zip`,
     `ffmpeg-${version}-darwin-x64.zip`,
     `ffmpeg-${version}-darwin-arm64.zip`,
     `ffmpeg-${version}-linux-arm64.zip`,

--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -94,7 +94,13 @@ def main():
 
     dsym_snaphot_zip = os.path.join(OUT_DIR, DSYM_SNAPSHOT_NAME)
     shutil.copy2(os.path.join(OUT_DIR, 'dsym-snapshot.zip'), dsym_snaphot_zip)
-    upload_electron(release, dsym_snaphot_zip, args)    
+    upload_electron(release, dsym_snaphot_zip, args)
+
+    libcxx_objects = get_zip_name('libcxx-objects', ELECTRON_VERSION)
+    libcxx_objects_zip = os.path.join(OUT_DIR, libcxx_objects)
+    shutil.copy2(os.path.join(OUT_DIR, 'libcxx_objects.zip'),
+        libcxx_objects_zip)
+    upload_electron(release, libcxx_objects_zip, args)
   elif PLATFORM == 'win32':
     if get_target_arch() != 'ia32':
       pdb_zip = os.path.join(OUT_DIR, PDB_NAME)
@@ -105,7 +111,6 @@ def main():
     shutil.copy2(os.path.join(OUT_DIR, 'debug.zip'), debug_zip)
     upload_electron(release, debug_zip, args)
 
-    # Upload libcxx_objects.zip for linux only
     libcxx_objects = get_zip_name('libcxx-objects', ELECTRON_VERSION)
     libcxx_objects_zip = os.path.join(OUT_DIR, libcxx_objects)
     shutil.copy2(os.path.join(OUT_DIR, 'libcxx_objects.zip'),


### PR DESCRIPTION
#### Description of Change

We previously added libcxx + libcxxabi headers and libcxx object files to release artifacts. The headers are platform agnostic, but the object files are currently exported per platform, and are Linux only. This PR adds additional build and upload steps for exporting those object files on MacOS.

_(Windows will require building libc++ as a static library rather than source set before similar support can be added)_

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Changed release uploads to now upload libcxx objects for MacOS x64 and arm64.
