### PR TITLE
build: make sure depot_tools is up to date

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -244,6 +244,8 @@ step-depot-tools-get: &step-depot-tools-get
       else
         sed -i '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
       fi
+      # Run update_depot_tools to make sure ninja gets downloaded
+      depot_tools/update_depot_tools
 
 step-depot-tools-add-to-path: &step-depot-tools-add-to-path
   run:


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Due to recent depot_tools changes, we need to run depot_tools/update_depot_tools to ensure that ninja is available.  Newer branches of electron already end up running depot_tools/update_depot_tool via https://github.com/electron/electron/blame/main/.circleci/config/base.yml#L493 so this change is not needed there.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
