### PR TITLE
chore: cleanup undocumented keys from webFrame.getWebPreference()

### DIFF
--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -509,22 +509,8 @@ class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
     } else if (pref_name == options::kHiddenPage) {
       // NOTE: hiddenPage is internal-only.
       return gin::ConvertToV8(isolate, prefs.hidden_page);
-    } else if (pref_name == options::kOffscreen) {
-      return gin::ConvertToV8(isolate, prefs.offscreen);
     } else if (pref_name == options::kNodeIntegration) {
       return gin::ConvertToV8(isolate, prefs.node_integration);
-    } else if (pref_name == options::kNodeIntegrationInWorker) {
-      return gin::ConvertToV8(isolate, prefs.node_integration_in_worker);
-    } else if (pref_name == options::kNodeIntegrationInSubFrames) {
-      return gin::ConvertToV8(isolate, true);
-#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
-    } else if (pref_name == options::kSpellcheck) {
-      return gin::ConvertToV8(isolate, prefs.enable_spellcheck);
-#endif
-    } else if (pref_name == options::kPlugins) {
-      return gin::ConvertToV8(isolate, prefs.enable_plugins);
-    } else if (pref_name == options::kEnableWebSQL) {
-      return gin::ConvertToV8(isolate, prefs.enable_websql);
     } else if (pref_name == options::kWebviewTag) {
       return gin::ConvertToV8(isolate, prefs.webview_tag);
     }


### PR DESCRIPTION
#### Description of Change
`webFrame.getWebPreference()` is an internal API and we have removed unused keys before. We only need to keep these:
https://github.com/electron/electron/blob/bad8d5e08af159371b0dc2875eb6c2281bff59a5/typings/internal-ambient.d.ts#L106-L111

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
