### PR TITLE
chore: move main process only accessible API bindings away from common

### DIFF
--- a/lib/browser/api/native-theme.ts
+++ b/lib/browser/api/native-theme.ts
@@ -1,3 +1,3 @@
-const { nativeTheme } = process._linkedBinding('electron_common_native_theme');
+const { nativeTheme } = process._linkedBinding('electron_browser_native_theme');
 
 module.exports = nativeTheme;

--- a/lib/browser/api/notification.ts
+++ b/lib/browser/api/notification.ts
@@ -1,7 +1,7 @@
 const {
   Notification: ElectronNotification,
   isSupported
-} = process._linkedBinding('electron_common_notification');
+} = process._linkedBinding('electron_browser_notification');
 
 ElectronNotification.isSupported = isSupported;
 

--- a/lib/browser/api/screen.ts
+++ b/lib/browser/api/screen.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 
-const { createScreen } = process._linkedBinding('electron_common_screen');
+const { createScreen } = process._linkedBinding('electron_browser_screen');
 
 let _screen: Electron.Screen;
 

--- a/shell/browser/api/electron_api_native_theme.cc
+++ b/shell/browser/api/electron_api_native_theme.cc
@@ -174,4 +174,4 @@ bool Converter<ui::NativeTheme::ThemeSource>::FromV8(
 
 }  // namespace gin
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_common_native_theme, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_native_theme, Initialize)

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -304,4 +304,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_common_notification, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_notification, Initialize)

--- a/shell/browser/api/electron_api_screen.cc
+++ b/shell/browser/api/electron_api_screen.cc
@@ -185,4 +185,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_common_screen, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_screen, Initialize)

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -55,13 +55,16 @@
   V(electron_browser_in_app_purchase)    \
   V(electron_browser_menu)               \
   V(electron_browser_message_port)       \
+  V(electron_browser_native_theme)       \
   V(electron_browser_net)                \
+  V(electron_browser_notification)       \
   V(electron_browser_power_monitor)      \
   V(electron_browser_power_save_blocker) \
   V(electron_browser_protocol)           \
   V(electron_browser_printing)           \
   V(electron_browser_safe_storage)       \
   V(electron_browser_session)            \
+  V(electron_browser_screen)             \
   V(electron_browser_system_preferences) \
   V(electron_browser_base_window)        \
   V(electron_browser_tray)               \
@@ -77,9 +80,6 @@
   V(electron_common_environment)         \
   V(electron_common_features)            \
   V(electron_common_native_image)        \
-  V(electron_common_native_theme)        \
-  V(electron_common_notification)        \
-  V(electron_common_screen)              \
   V(electron_common_shell)               \
   V(electron_common_v8_util)             \
   V(electron_renderer_context_bridge)    \

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -178,12 +178,6 @@ declare namespace NodeJS {
     _linkedBinding(name: 'electron_common_environment'): EnvironmentBinding;
     _linkedBinding(name: 'electron_common_features'): FeaturesBinding;
     _linkedBinding(name: 'electron_common_native_image'): { nativeImage: typeof Electron.NativeImage };
-    _linkedBinding(name: 'electron_common_native_theme'): { nativeTheme: Electron.NativeTheme };
-    _linkedBinding(name: 'electron_common_notification'): {
-      isSupported(): boolean;
-      Notification: typeof Electron.Notification;
-    }
-    _linkedBinding(name: 'electron_common_screen'): { createScreen(): Electron.Screen };
     _linkedBinding(name: 'electron_common_shell'): Electron.Shell;
     _linkedBinding(name: 'electron_common_v8_util'): V8UtilBinding;
     _linkedBinding(name: 'electron_browser_app'): { app: Electron.App, App: Function };
@@ -215,6 +209,7 @@ declare namespace NodeJS {
     _linkedBinding(name: 'electron_browser_message_port'): {
       createPair(): { port1: Electron.MessagePortMain, port2: Electron.MessagePortMain };
     };
+    _linkedBinding(name: 'electron_browser_native_theme'): { nativeTheme: Electron.NativeTheme };
     _linkedBinding(name: 'electron_browser_net'): {
       isOnline(): boolean;
       isValidHeaderName: (headerName: string) => boolean;
@@ -224,10 +219,15 @@ declare namespace NodeJS {
       net: any;
       createURLLoader(options: CreateURLLoaderOptions): URLLoader;
     };
+    _linkedBinding(name: 'electron_browser_notification'): {
+      isSupported(): boolean;
+      Notification: typeof Electron.Notification;
+    }
     _linkedBinding(name: 'electron_browser_power_monitor'): PowerMonitorBinding;
     _linkedBinding(name: 'electron_browser_power_save_blocker'): { powerSaveBlocker: Electron.PowerSaveBlocker };
     _linkedBinding(name: 'electron_browser_safe_storage'): { safeStorage: Electron.SafeStorage };
     _linkedBinding(name: 'electron_browser_session'): typeof Electron.Session;
+    _linkedBinding(name: 'electron_browser_screen'): { createScreen(): Electron.Screen };
     _linkedBinding(name: 'electron_browser_system_preferences'): { systemPreferences: Electron.SystemPreferences };
     _linkedBinding(name: 'electron_browser_tray'): { Tray: Electron.Tray };
     _linkedBinding(name: 'electron_browser_view'): { View: Electron.View };


### PR DESCRIPTION
#### Description of Change
Renames the following:
- `electron_common_native_theme` -> `electron_browser_native_theme`
- `electron_common_notification` -> `electron_browser_notification`
- `electron_common_screen` -> `electron_browser_screen`

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none