### PR TITLE
fix: WCO respects maximizable/closable/minimizable

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -876,6 +876,11 @@ bool NativeWindowViews::IsMovable() {
 void NativeWindowViews::SetMinimizable(bool minimizable) {
 #if BUILDFLAG(IS_WIN)
   FlipWindowStyle(GetAcceleratedWidget(), minimizable, WS_MINIMIZEBOX);
+  if (titlebar_overlay_enabled()) {
+    auto* frame_view =
+        static_cast<WinFrameView*>(widget()->non_client_view()->frame_view());
+    frame_view->caption_button_container()->UpdateButtons();
+  }
 #endif
   minimizable_ = minimizable;
 }
@@ -891,6 +896,11 @@ bool NativeWindowViews::IsMinimizable() {
 void NativeWindowViews::SetMaximizable(bool maximizable) {
 #if BUILDFLAG(IS_WIN)
   FlipWindowStyle(GetAcceleratedWidget(), maximizable, WS_MAXIMIZEBOX);
+  if (titlebar_overlay_enabled()) {
+    auto* frame_view =
+        static_cast<WinFrameView*>(widget()->non_client_view()->frame_view());
+    frame_view->caption_button_container()->UpdateButtons();
+  }
 #endif
   maximizable_ = maximizable;
 }
@@ -925,6 +935,11 @@ void NativeWindowViews::SetClosable(bool closable) {
     EnableMenuItem(menu, SC_CLOSE, MF_BYCOMMAND | MF_ENABLED);
   } else {
     EnableMenuItem(menu, SC_CLOSE, MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
+  }
+  if (titlebar_overlay_enabled()) {
+    auto* frame_view =
+        static_cast<WinFrameView*>(widget()->non_client_view()->frame_view());
+    frame_view->caption_button_container()->UpdateButtons();
   }
 #endif
 }

--- a/shell/browser/ui/views/win_caption_button_container.cc
+++ b/shell/browser/ui/views/win_caption_button_container.cc
@@ -148,11 +148,30 @@ void WinCaptionButtonContainer::UpdateButtons() {
   restore_button_->SetVisible(is_maximized);
   maximize_button_->SetVisible(!is_maximized);
 
+  const bool minimizable = frame_view_->window()->IsMinimizable();
+  minimize_button_->SetEnabled(minimizable);
+
   // In touch mode, windows cannot be taken out of fullscreen or tiled mode, so
   // the maximize/restore button should be disabled.
   const bool is_touch = ui::TouchUiController::Get()->touch_ui();
   restore_button_->SetEnabled(!is_touch);
-  maximize_button_->SetEnabled(!is_touch);
+
+  // The maximize button should only be enabled if the window is
+  // maximizable *and* touch mode is disabled.
+  const bool maximizable = frame_view_->window()->IsMaximizable();
+  maximize_button_->SetEnabled(!is_touch && maximizable);
+
+  const bool closable = frame_view_->window()->IsClosable();
+  close_button_->SetEnabled(closable);
+
+  // If all three of closable, maximizable, and minimizable are disabled,
+  // Windows natively only shows the disabled closable button. Copy that
+  // behavior here.
+  if (!maximizable && !closable && !minimizable) {
+    minimize_button_->SetVisible(false);
+    maximize_button_->SetVisible(false);
+  }
+
   InvalidateLayout();
 }
 }  // namespace electron

--- a/shell/browser/ui/views/win_caption_button_container.h
+++ b/shell/browser/ui/views/win_caption_button_container.h
@@ -41,6 +41,11 @@ class WinCaptionButtonContainer : public views::View,
   gfx::Size GetButtonSize() const;
   void SetButtonSize(gfx::Size size);
 
+  // Sets caption button visibility and enabled state based on window state.
+  // Only one of maximize or restore button should ever be visible at the same
+  // time, and both are disabled in tablet UI mode.
+  void UpdateButtons();
+
  private:
   // views::View:
   void AddedToWidget() override;
@@ -51,11 +56,6 @@ class WinCaptionButtonContainer : public views::View,
                              const gfx::Rect& new_bounds) override;
 
   void ResetWindowControls();
-
-  // Sets caption button visibility and enabled state based on window state.
-  // Only one of maximize or restore button should ever be visible at the same
-  // time, and both are disabled in tablet UI mode.
-  void UpdateButtons();
 
   WinFrameView* const frame_view_;
   WinCaptionButton* const minimize_button_;

--- a/shell/browser/ui/views/win_frame_view.h
+++ b/shell/browser/ui/views/win_frame_view.h
@@ -13,6 +13,7 @@
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/ui/views/frameless_view.h"
 #include "shell/browser/ui/views/win_caption_button.h"
+#include "shell/browser/ui/views/win_caption_button_container.h"
 
 namespace electron {
 
@@ -43,6 +44,9 @@ class WinFrameView : public FramelessView {
 
   NativeWindowViews* window() const { return window_; }
   views::Widget* frame() const { return frame_; }
+  WinCaptionButtonContainer* caption_button_container() {
+    return caption_button_container_;
+  }
 
   bool IsMaximized() const;
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/32285.

Adapts WCO window button container to adapt to and update based on the maximizable, minimizable, and closable states of a given BrowserWindow. It is slightly different UI-wise than native, in that it does not fully grey out when disabled, but it behaves the same.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where Windows Control Overlay buttons did not respect  maximizable/minimizable/closable states of a BrowserWindow.
