### PR TITLE
chore: cherry-pick d0882b3dff76 from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -14,3 +14,4 @@ cherry-pick-e42dbcdedb7a.patch
 cherry-pick-b2d3ef69ef99.patch
 cherry-pick-2004594a46c8.patch
 cherry-pick-723ed8a9cfff.patch
+cherry-pick-d0882b3dff76.patch

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -14,5 +14,5 @@ cherry-pick-e42dbcdedb7a.patch
 cherry-pick-b2d3ef69ef99.patch
 cherry-pick-2004594a46c8.patch
 cherry-pick-723ed8a9cfff.patch
-cherry-pick-d0882b3dff76.patch
 cherry-pick-44c4e56fea2c.patch
+version_10_2_154_10_cherry-pick.patch

--- a/patches/v8/cherry-pick-d0882b3dff76.patch
+++ b/patches/v8/cherry-pick-d0882b3dff76.patch
@@ -1,0 +1,64 @@
+From d0882b3dff76a9fc86bbf93381df1585d58f4f57 Mon Sep 17 00:00:00 2001
+From: Tobias Tebbi <tebbi@chromium.org>
+Date: Fri, 10 Jun 2022 12:53:10 +0000
+Subject: [PATCH] Version 10.2.154.10 (cherry-pick)
+
+Merged 85b4b5d719c50ecc8f376ca853c9001d5ac0ed9a
+
+[compiler] only enable MidTierRegisterAllocator for Wasm
+
+Bug: chromium:1335054
+Change-Id: I61ab97d4fbfcbb81319e611a64a6454e050a1d65
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3705397
+Owners-Override: Tobias Tebbi <tebbi@chromium.org>
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/10.2@{#18}
+Cr-Branched-From: 374091f382e88095694c1283cbdc2acddc1b1417-refs/heads/10.2.154@{#1}
+Cr-Branched-From: f0c353f6315eeb2212ba52478983a3b3af07b5b1-refs/heads/main@{#79976}
+---
+
+diff --git a/include/v8-version.h b/include/v8-version.h
+index 20b0eeb..f47ac39 100644
+--- a/include/v8-version.h
++++ b/include/v8-version.h
+@@ -11,7 +11,7 @@
+ #define V8_MAJOR_VERSION 10
+ #define V8_MINOR_VERSION 2
+ #define V8_BUILD_NUMBER 154
+-#define V8_PATCH_LEVEL 9
++#define V8_PATCH_LEVEL 10
+ 
+ // Use 1 for candidates and 0 otherwise.
+ // (Boolean macro values are not supported by all preprocessors.)
+diff --git a/src/compiler/pipeline.cc b/src/compiler/pipeline.cc
+index cd546fe..a71427f 100644
+--- a/src/compiler/pipeline.cc
++++ b/src/compiler/pipeline.cc
+@@ -3486,8 +3486,11 @@
+ 
+   const RegisterConfiguration* config = RegisterConfiguration::Default();
+   std::unique_ptr<const RegisterConfiguration> restricted_config;
++  // The mid-tier register allocator keeps values in stack slots for too long.
++  // This is incompatible with left-trimming, therefore we cannot enable it for
++  // JS functions.
+   bool use_mid_tier_register_allocator =
+-      !CodeKindIsStaticallyCompiled(data->info()->code_kind()) &&
++      data->info()->code_kind() == CodeKind::WASM_FUNCTION &&
+       (FLAG_turbo_force_mid_tier_regalloc ||
+        (FLAG_turbo_use_mid_tier_regalloc_for_huge_functions &&
+         data->sequence()->VirtualRegisterCount() >
+diff --git a/src/objects/code-kind.h b/src/objects/code-kind.h
+index b43affd..32c3b02 100644
+--- a/src/objects/code-kind.h
++++ b/src/objects/code-kind.h
+@@ -57,10 +57,6 @@
+   return kind == CodeKind::BASELINE;
+ }
+ 
+-inline constexpr bool CodeKindIsStaticallyCompiled(CodeKind kind) {
+-  return kind == CodeKind::BYTECODE_HANDLER || kind == CodeKind::BUILTIN;
+-}
+-
+ inline constexpr bool CodeKindIsUnoptimizedJSFunction(CodeKind kind) {
+   STATIC_ASSERT(static_cast<int>(CodeKind::INTERPRETED_FUNCTION) + 1 ==
+                 static_cast<int>(CodeKind::BASELINE));

--- a/patches/v8/version_10_2_154_10_cherry-pick.patch
+++ b/patches/v8/version_10_2_154_10_cherry-pick.patch
@@ -1,7 +1,7 @@
-From d0882b3dff76a9fc86bbf93381df1585d58f4f57 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tobias Tebbi <tebbi@chromium.org>
 Date: Fri, 10 Jun 2022 12:53:10 +0000
-Subject: [PATCH] Version 10.2.154.10 (cherry-pick)
+Subject: Version 10.2.154.10 (cherry-pick)
 
 Merged 85b4b5d719c50ecc8f376ca853c9001d5ac0ed9a
 
@@ -15,26 +15,25 @@ Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
 Cr-Commit-Position: refs/branch-heads/10.2@{#18}
 Cr-Branched-From: 374091f382e88095694c1283cbdc2acddc1b1417-refs/heads/10.2.154@{#1}
 Cr-Branched-From: f0c353f6315eeb2212ba52478983a3b3af07b5b1-refs/heads/main@{#79976}
----
 
 diff --git a/include/v8-version.h b/include/v8-version.h
-index 20b0eeb..f47ac39 100644
+index b6e920c05e5928c707f8e7c0ed56822a6bb33164..3b18fdda0dfb74163bfdc3aad34e0611250efb6c 100644
 --- a/include/v8-version.h
 +++ b/include/v8-version.h
 @@ -11,7 +11,7 @@
- #define V8_MAJOR_VERSION 10
- #define V8_MINOR_VERSION 2
- #define V8_BUILD_NUMBER 154
--#define V8_PATCH_LEVEL 9
-+#define V8_PATCH_LEVEL 10
+ #define V8_MAJOR_VERSION 9
+ #define V8_MINOR_VERSION 8
+ #define V8_BUILD_NUMBER 177
+-#define V8_PATCH_LEVEL 13
++#define V8_PATCH_LEVEL 14
  
  // Use 1 for candidates and 0 otherwise.
  // (Boolean macro values are not supported by all preprocessors.)
 diff --git a/src/compiler/pipeline.cc b/src/compiler/pipeline.cc
-index cd546fe..a71427f 100644
+index ef16b8f304b3d7e40ae5e5e8b1acc989be9b42a0..c84b0789fa1fa3a9f6df3d955a631a7c1ba6d54c 100644
 --- a/src/compiler/pipeline.cc
 +++ b/src/compiler/pipeline.cc
-@@ -3486,8 +3486,11 @@
+@@ -3567,12 +3567,16 @@ bool PipelineImpl::SelectInstructions(Linkage* linkage) {
  
    const RegisterConfiguration* config = RegisterConfiguration::Default();
    std::unique_ptr<const RegisterConfiguration> restricted_config;
@@ -42,23 +41,14 @@ index cd546fe..a71427f 100644
 +  // This is incompatible with left-trimming, therefore we cannot enable it for
 +  // JS functions.
    bool use_mid_tier_register_allocator =
--      !CodeKindIsStaticallyCompiled(data->info()->code_kind()) &&
+-      FLAG_turbo_force_mid_tier_regalloc ||
 +      data->info()->code_kind() == CodeKind::WASM_FUNCTION &&
-       (FLAG_turbo_force_mid_tier_regalloc ||
-        (FLAG_turbo_use_mid_tier_regalloc_for_huge_functions &&
-         data->sequence()->VirtualRegisterCount() >
-diff --git a/src/objects/code-kind.h b/src/objects/code-kind.h
-index b43affd..32c3b02 100644
---- a/src/objects/code-kind.h
-+++ b/src/objects/code-kind.h
-@@ -57,10 +57,6 @@
-   return kind == CodeKind::BASELINE;
- }
++      (FLAG_turbo_force_mid_tier_regalloc ||
+       (FLAG_turboprop_mid_tier_reg_alloc && data->info()->IsTurboprop()) ||
+       (FLAG_turbo_use_mid_tier_regalloc_for_huge_functions &&
+        data->sequence()->VirtualRegisterCount() >
+-           kTopTierVirtualRegistersLimit);
++           kTopTierVirtualRegistersLimit));
  
--inline constexpr bool CodeKindIsStaticallyCompiled(CodeKind kind) {
--  return kind == CodeKind::BYTECODE_HANDLER || kind == CodeKind::BUILTIN;
--}
--
- inline constexpr bool CodeKindIsUnoptimizedJSFunction(CodeKind kind) {
-   STATIC_ASSERT(static_cast<int>(CodeKind::INTERPRETED_FUNCTION) + 1 ==
-                 static_cast<int>(CodeKind::BASELINE));
+   if (call_descriptor->HasRestrictedAllocatableRegisters()) {
+     RegList registers = call_descriptor->AllocatableRegisters();


### PR DESCRIPTION
Version 10.2.154.10 (cherry-pick)

Merged 85b4b5d719c50ecc8f376ca853c9001d5ac0ed9a

[compiler] only enable MidTierRegisterAllocator for Wasm

Bug: chromium:1335054
Change-Id: I61ab97d4fbfcbb81319e611a64a6454e050a1d65
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3705397
Owners-Override: Tobias Tebbi <tebbi@chromium.org>
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Cr-Commit-Position: refs/branch-heads/10.2@{#18}
Cr-Branched-From: 374091f382e88095694c1283cbdc2acddc1b1417-refs/heads/10.2.154@{#1}
Cr-Branched-From: f0c353f6315eeb2212ba52478983a3b3af07b5b1-refs/heads/main@{#79976}


Ref electron/security#173

Notes: Security: backported fix for 1335054.