### PR TITLE
chore: cherry-pick ecad352cd614 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -146,3 +146,4 @@ cherry-pick-f1dd785e021e.patch
 cherry-pick-f3d01ff794dc.patch
 cherry-pick-b03797bdb1df.patch
 posix_replace_doubleforkandexec_with_forkandspawn.patch
+cherry-pick-ecad352cd614.patch

--- a/patches/chromium/cherry-pick-ecad352cd614.patch
+++ b/patches/chromium/cherry-pick-ecad352cd614.patch
@@ -1,0 +1,106 @@
+From ecad352cd61420d6bf8c9c39041b5369372ecf94 Mon Sep 17 00:00:00 2001
+From: Ted Meyer <tmathmeyer@chromium.org>
+Date: Wed, 08 Jun 2022 04:33:20 +0000
+Subject: [PATCH] Add Stop method to BatchingMediaLog
+
+Now that ~MediaLog is posted for a later destruction due to garbage
+collector ownership of CodecLogger, it's possible for the
+SendQueuedMediaEvents call from ~BatchingMediaLog to reference
+InspectorMediaEventHandler::inspector_context_ after it has been freed.
+
+This fix forces BatchingMediaLog to shut down it's logging capabilities
+when the destruction call is caused by the garbage collector deletion
+phase
+
+R=​liberato
+
+(cherry picked from commit 1bbfaf23cd8a1e977cb445a82a4caae107632a59)
+
+Bug: 1333333
+Change-Id: I0bdca72a71177c4c5a6a9dc692aad3de4c25f4e2
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3689639
+Commit-Queue: Ted (Chromium) Meyer <tmathmeyer@chromium.org>
+Reviewed-by: Eugene Zemtsov <eugene@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1011247}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3694435
+Auto-Submit: Ted (Chromium) Meyer <tmathmeyer@chromium.org>
+Reviewed-by: Eugene Zemtsov <ezemtsov@google.com>
+Commit-Queue: Eugene Zemtsov <eugene@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5060@{#672}
+Cr-Branched-From: b83393d0f4038aeaf67f970a024d8101df7348d1-refs/heads/main@{#1002911}
+---
+
+diff --git a/content/renderer/media/batching_media_log.cc b/content/renderer/media/batching_media_log.cc
+index 42b6fb6..efd56d9 100644
+--- a/content/renderer/media/batching_media_log.cc
++++ b/content/renderer/media/batching_media_log.cc
+@@ -76,6 +76,11 @@
+     SendQueuedMediaEvents();
+ }
+ 
++void BatchingMediaLog::Stop() {
++  base::AutoLock lock(lock_);
++  event_handlers_.clear();
++}
++
+ void BatchingMediaLog::OnWebMediaPlayerDestroyedLocked() {
+   base::AutoLock lock(lock_);
+   for (const auto& handler : event_handlers_)
+diff --git a/content/renderer/media/batching_media_log.h b/content/renderer/media/batching_media_log.h
+index eb757a4..6c2df68 100644
+--- a/content/renderer/media/batching_media_log.h
++++ b/content/renderer/media/batching_media_log.h
+@@ -45,6 +45,8 @@
+ 
+   ~BatchingMediaLog() override;
+ 
++  void Stop() override;
++
+   // Will reset |last_ipc_send_time_| with the value of NowTicks().
+   void SetTickClockForTesting(const base::TickClock* tick_clock);
+ 
+diff --git a/media/base/media_log.cc b/media/base/media_log.cc
+index 3728433..46887da3 100644
+--- a/media/base/media_log.cc
++++ b/media/base/media_log.cc
+@@ -49,6 +49,9 @@
+   return "";
+ }
+ 
++// Default implementation.
++void MediaLog::Stop() {}
++
+ void MediaLog::AddMessage(MediaLogMessageLevel level, std::string message) {
+   std::unique_ptr<MediaLogRecord> record(
+       CreateRecord(MediaLogRecord::Type::kMessage));
+diff --git a/media/base/media_log.h b/media/base/media_log.h
+index e70a95b..cce6a266 100644
+--- a/media/base/media_log.h
++++ b/media/base/media_log.h
+@@ -131,6 +131,10 @@
+   // even if this occurs, in the "won't crash" sense.
+   virtual std::unique_ptr<MediaLog> Clone();
+ 
++  // Can be used for stopping a MediaLog during a garbage-collected destruction
++  // sequence.
++  virtual void Stop();
++
+  protected:
+   // Ensures only subclasses and factories (e.g. Clone()) can create MediaLog.
+   MediaLog();
+diff --git a/third_party/blink/renderer/modules/webcodecs/codec_logger.h b/third_party/blink/renderer/modules/webcodecs/codec_logger.h
+index 034c448..4dc058c 100644
+--- a/third_party/blink/renderer/modules/webcodecs/codec_logger.h
++++ b/third_party/blink/renderer/modules/webcodecs/codec_logger.h
+@@ -81,7 +81,10 @@
+     // media logs must be posted for destruction, since they can cause the
+     // garbage collector to trigger an immediate cleanup and delete the owning
+     // instance of |CodecLogger|.
+-    task_runner_->DeleteSoon(FROM_HERE, std::move(parent_media_log_));
++    if (parent_media_log_) {
++      parent_media_log_->Stop();
++      task_runner_->DeleteSoon(FROM_HERE, std::move(parent_media_log_));
++    }
+   }
+ 
+   void SendPlayerNameInformation(const ExecutionContext& context,


### PR DESCRIPTION
Add Stop method to BatchingMediaLog

Now that ~MediaLog is posted for a later destruction due to garbage
collector ownership of CodecLogger, it's possible for the
SendQueuedMediaEvents call from ~BatchingMediaLog to reference
InspectorMediaEventHandler::inspector_context_ after it has been freed.

This fix forces BatchingMediaLog to shut down it's logging capabilities
when the destruction call is caused by the garbage collector deletion
phase

R=​liberato

(cherry picked from commit 1bbfaf23cd8a1e977cb445a82a4caae107632a59)

Bug: 1333333
Change-Id: I0bdca72a71177c4c5a6a9dc692aad3de4c25f4e2
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3689639
Commit-Queue: Ted (Chromium) Meyer <tmathmeyer@chromium.org>
Reviewed-by: Eugene Zemtsov <eugene@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1011247}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3694435
Auto-Submit: Ted (Chromium) Meyer <tmathmeyer@chromium.org>
Reviewed-by: Eugene Zemtsov <ezemtsov@google.com>
Commit-Queue: Eugene Zemtsov <eugene@chromium.org>
Cr-Commit-Position: refs/branch-heads/5060@{#672}
Cr-Branched-From: b83393d0f4038aeaf67f970a024d8101df7348d1-refs/heads/main@{#1002911}


Ref electron/security#174

Notes: Security: backported fix for 1333333.