### PR TITLE
fix: crashes caused by usage of debugger api

### DIFF
--- a/shell/browser/api/electron_api_debugger.cc
+++ b/shell/browser/api/electron_api_debugger.cc
@@ -92,9 +92,11 @@ void Debugger::DispatchProtocolMessage(DevToolsAgentHost* agent_host,
 void Debugger::RenderFrameHostChanged(content::RenderFrameHost* old_rfh,
                                       content::RenderFrameHost* new_rfh) {
   if (agent_host_) {
-    agent_host_->DisconnectWebContents();
     auto* web_contents = content::WebContents::FromRenderFrameHost(new_rfh);
-    agent_host_->ConnectWebContents(web_contents);
+    if (web_contents != agent_host_->GetWebContents()) {
+      agent_host_->DisconnectWebContents();
+      agent_host_->ConnectWebContents(web_contents);
+    }
   }
 }
 


### PR DESCRIPTION
#### Description of Change

Closes #34696.

Devtools agent host should not reconnect if web_contents not change. 

First time PR, not sure if this is the best way. Works for me though.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

notes: Fixed a crash when `webcontents.debugger` is attached.
