### PR TITLE
fix: compensate for title bar height when setting bounds on `BrowserView`

### DIFF
--- a/spec/api-browser-view-spec.ts
+++ b/spec/api-browser-view-spec.ts
@@ -146,7 +146,14 @@ describe('BrowserView module', () => {
   });
 
   describe('BrowserView.getBounds()', () => {
-    it('returns the current bounds', () => {
+    it('returns correct bounds on a framed window', () => {
+      view = new BrowserView();
+      const bounds = { x: 10, y: 20, width: 30, height: 40 };
+      view.setBounds(bounds);
+      expect(view.getBounds()).to.deep.equal(bounds);
+    });
+
+    it('returns correct bounds on a frameless window', () => {
       view = new BrowserView();
       const bounds = { x: 10, y: 20, width: 30, height: 40 };
       view.setBounds(bounds);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/32880.

Fixes an issue where part of the BrowserView could be cut off when calling `setBounds` on some windows. This was happening because we were not taking the titlebar height into account when calling `setBounds` on a framed window, which meant that the y-value for the bounds would end up negative. For example, the following snippet:

<details><summary>main.js</summary>

```js
const {app, BrowserView, BrowserWindow} = require('electron')
const path = require('path')

function createWindow () {
  const mainWindow = new BrowserWindow({
    width: 1200,
    height: 900,
    webPreferences: {
      preload: path.join(__dirname, 'preload.js')
    }
  })
  mainWindow.removeMenu();
  const view = new BrowserView()
  mainWindow.setBrowserView(view)
  view.webContents.loadURL('https:// google.com')
  view.webContents.openDevTools({ mode: "bottom" });
  view.setBounds({
    x : 0,
    y : 100,
    width: 1200,
    height : 800
  });
}

app.whenReady().then(() => {
  createWindow()
  
  app.on('activate', function () {
    if (BrowserWindow.getAllWindows().length === 0) createWindow()
  })
})

app.on('window-all-closed', function () {
  if (process.platform !== 'darwin') app.quit()
})
```

</details>

Would result in the `y` value being calculated to -28, which is the height of the titlebar. Fix the problem by correcting for this extra height when relevant.

Visual Comparison:

<details> <summary>Before</summary>
<img width="1312" alt="Screen Shot 2022-06-23 at 10 50 26 AM" src="https://user-images.githubusercontent.com/2036040/175261745-bbcc831e-d4fd-47d0-b36e-b5938c74b11a.png">
</details>

<details> <summary>After</summary>
<img width="1312" alt="Screen Shot 2022-06-23 at 10 50 13 AM" src="https://user-images.githubusercontent.com/2036040/175261766-fbddc6d2-aa84-46bb-9185-62818d39d08a.png">
</details>

<details> <summary>Frameless Window</summary>
<img width="1312" alt="Screen Shot 2022-06-23 at 10 52 32 AM" src="https://user-images.githubusercontent.com/2036040/175261774-fbab1c6f-c42f-478a-b206-d9f512935322.png">
 Comparison
</details>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where part of the BrowserView could be cut off when calling `setBounds` on some windows.
