### PR TITLE
fix: modify file extension generation on Windows

### DIFF
--- a/shell/browser/electron_download_manager_delegate.cc
+++ b/shell/browser/electron_download_manager_delegate.cc
@@ -79,8 +79,8 @@ base::FilePath CreateDownloadPath(const GURL& url,
 bool GetRegistryDescriptionFromExtension(const std::string& file_ext,
                                          std::string* reg_description) {
   DCHECK(reg_description);
-  base::win::RegKey reg_ext(
-      HKEY_CLASSES_ROOT, base::as_wcstr(base::UTF8ToUTF16(file_ext)), KEY_READ);
+  base::win::RegKey reg_ext(HKEY_CLASSES_ROOT,
+                            base::UTF8ToWide(file_ext).c_str(), KEY_READ);
   std::wstring reg_app;
   if (reg_ext.ReadValue(nullptr, &reg_app) == ERROR_SUCCESS &&
       !reg_app.empty()) {

--- a/shell/browser/electron_download_manager_delegate.cc
+++ b/shell/browser/electron_download_manager_delegate.cc
@@ -10,10 +10,8 @@
 
 #include "base/bind.h"
 #include "base/files/file_util.h"
-#include "base/i18n/case_conversion.h"
 #include "base/task/thread_pool.h"
 #include "base/threading/thread_restrictions.h"
-#include "base/win/registry.h"
 #include "chrome/common/pref_names.h"
 #include "components/download/public/common/download_danger_type.h"
 #include "components/prefs/pref_service.h"
@@ -31,10 +29,15 @@
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/file_path_converter.h"
 #include "shell/common/options_switches.h"
+
+#if BUILDFLAG(IS_WIN)
+#include "base/i18n/case_conversion.h"
+#include "base/win/registry.h"
 #include "ui/base/l10n/l10n_util.h"
 
 #define IDS_APP_SAVEAS_ALL_FILES 35936
 #define IDS_APP_SAVEAS_EXTENSION_FORMAT 35937
+#endif  // BUILDFLAG(IS_WIN)
 
 namespace electron {
 
@@ -99,6 +102,7 @@ void ElectronDownloadManagerDelegate::GetItemSaveDialogOptions(
     *options = download->GetSaveDialogOptions();
 }
 
+#if BUILDFLAG(IS_WIN)
 // Get the file type description from the registry. This will be "Text Document"
 // for .txt files, "JPEG Image" for .jpg files, etc. If the registry doesn't
 // have an entry for the file type, we return false, true if the description was
@@ -204,6 +208,7 @@ ElectronDownloadManagerDelegate::FormatFilterForExtensions(
 
   return result;
 }
+#endif  // BUILDFLAG(IS_WIN)
 
 void ElectronDownloadManagerDelegate::OnDownloadPathGenerated(
     uint32_t download_id,
@@ -242,6 +247,7 @@ void ElectronDownloadManagerDelegate::OnDownloadPathGenerated(
     const bool offscreen = !web_preferences || web_preferences->IsOffscreen();
     settings.force_detached = offscreen;
 
+#if BUILDFLAG(IS_WIN)
     auto extension = settings.default_path.FinalExtension();
     if (!extension.empty() && settings.filters.empty()) {
       extension.erase(extension.begin());
@@ -262,6 +268,7 @@ void ElectronDownloadManagerDelegate::OnDownloadPathGenerated(
       std::vector<std::string> all_files{"*.*"};
       settings.filters.emplace_back(std::make_pair("All Files", all_files));
     }
+#endif  // BUILDFLAG(IS_WIN)
 
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
     v8::HandleScope scope(isolate);

--- a/shell/browser/electron_download_manager_delegate.cc
+++ b/shell/browser/electron_download_manager_delegate.cc
@@ -34,9 +34,7 @@
 #include "base/i18n/case_conversion.h"
 #include "base/win/registry.h"
 #include "ui/base/l10n/l10n_util.h"
-
-#define IDS_APP_SAVEAS_ALL_FILES 35936
-#define IDS_APP_SAVEAS_EXTENSION_FORMAT 35937
+#include "ui/strings/grit/ui_strings.h"
 #endif  // BUILDFLAG(IS_WIN)
 
 namespace electron {

--- a/shell/browser/electron_download_manager_delegate.cc
+++ b/shell/browser/electron_download_manager_delegate.cc
@@ -245,13 +245,11 @@ void ElectronDownloadManagerDelegate::OnDownloadPathGenerated(
     settings.force_detached = offscreen;
 
 #if BUILDFLAG(IS_WIN)
-    std::wstring extension = settings.default_path.FinalExtension();
-    if (!extension.empty() && settings.filters.empty()) {
-      file_dialog::Filters filter_spec = FormatFilterForExtensions(
-          {base::WideToUTF8(extension)}, {""}, true, true);
-
-      for (file_dialog::Filter filter : filter_spec) {
-        settings.filters.emplace_back(filter);
+    if (settings.filters.empty()) {
+      const std::wstring extension = settings.default_path.FinalExtension();
+      if (!extension.empty()) {
+        settings.filters = FormatFilterForExtensions(
+            {base::WideToUTF8(extension)}, {""}, true, true);
       }
     }
 #endif  // BUILDFLAG(IS_WIN)

--- a/shell/browser/electron_download_manager_delegate.cc
+++ b/shell/browser/electron_download_manager_delegate.cc
@@ -10,8 +10,10 @@
 
 #include "base/bind.h"
 #include "base/files/file_util.h"
+#include "base/i18n/case_conversion.h"
 #include "base/task/thread_pool.h"
 #include "base/threading/thread_restrictions.h"
+#include "base/win/registry.h"
 #include "chrome/common/pref_names.h"
 #include "components/download/public/common/download_danger_type.h"
 #include "components/prefs/pref_service.h"
@@ -29,12 +31,10 @@
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/file_path_converter.h"
 #include "shell/common/options_switches.h"
-
-#include "base/win/registry.h"
-#define IDS_APP_SAVEAS_ALL_FILES 35936
 #include "ui/base/l10n/l10n_util.h"
+
+#define IDS_APP_SAVEAS_ALL_FILES 35936
 #define IDS_APP_SAVEAS_EXTENSION_FORMAT 35937
-#include "base/i18n/case_conversion.h"
 
 namespace electron {
 

--- a/shell/browser/electron_download_manager_delegate.cc
+++ b/shell/browser/electron_download_manager_delegate.cc
@@ -31,6 +31,8 @@
 #include "shell/common/options_switches.h"
 
 #if BUILDFLAG(IS_WIN)
+#include <vector>
+
 #include "base/i18n/case_conversion.h"
 #include "base/win/registry.h"
 #include "ui/base/l10n/l10n_util.h"

--- a/shell/browser/electron_download_manager_delegate.h
+++ b/shell/browser/electron_download_manager_delegate.h
@@ -9,7 +9,6 @@
 #include "content/public/browser/download_manager_delegate.h"
 #include "shell/browser/ui/file_dialog.h"
 #include "shell/common/gin_helper/dictionary.h"
-
 #include "ui/shell_dialogs/execute_select_file_win.h"
 
 namespace content {

--- a/shell/browser/electron_download_manager_delegate.h
+++ b/shell/browser/electron_download_manager_delegate.h
@@ -10,6 +10,8 @@
 #include "shell/browser/ui/file_dialog.h"
 #include "shell/common/gin_helper/dictionary.h"
 
+#include "ui/shell_dialogs/execute_select_file_win.h"
+
 namespace content {
 class DownloadManager;
 }
@@ -60,6 +62,15 @@ class ElectronDownloadManagerDelegate
 
   content::DownloadManager* download_manager_;
   base::WeakPtrFactory<ElectronDownloadManagerDelegate> weak_ptr_factory_{this};
+
+  // Copied from ui/shell_dialogs/select_file_dialog_win.h
+  bool GetRegistryDescriptionFromExtension(const std::u16string& file_ext,
+                                           std::u16string* reg_description);
+  std::vector<ui::FileFilterSpec> FormatFilterForExtensions(
+      const std::vector<std::u16string>& file_ext,
+      const std::vector<std::u16string>& ext_desc,
+      bool include_all_files,
+      bool keep_extension_visible);
 };
 
 }  // namespace electron

--- a/shell/browser/electron_download_manager_delegate.h
+++ b/shell/browser/electron_download_manager_delegate.h
@@ -13,9 +13,6 @@
 #include "content/public/browser/download_manager_delegate.h"
 #include "shell/browser/ui/file_dialog.h"
 #include "shell/common/gin_helper/dictionary.h"
-#if BUILDFLAG(IS_WIN)
-#include "ui/shell_dialogs/execute_select_file_win.h"
-#endif  // BUILDFLAG(IS_WIN)
 
 namespace content {
 class DownloadManager;
@@ -67,17 +64,6 @@ class ElectronDownloadManagerDelegate
 
   content::DownloadManager* download_manager_;
   base::WeakPtrFactory<ElectronDownloadManagerDelegate> weak_ptr_factory_{this};
-
-#if BUILDFLAG(IS_WIN)
-  // Copied from ui/shell_dialogs/select_file_dialog_win.h
-  bool GetRegistryDescriptionFromExtension(const std::u16string& file_ext,
-                                           std::u16string* reg_description);
-  std::vector<ui::FileFilterSpec> FormatFilterForExtensions(
-      const std::vector<std::u16string>& file_ext,
-      const std::vector<std::u16string>& ext_desc,
-      bool include_all_files,
-      bool keep_extension_visible);
-#endif  // BUILDFLAG(IS_WIN)
 };
 
 }  // namespace electron

--- a/shell/browser/electron_download_manager_delegate.h
+++ b/shell/browser/electron_download_manager_delegate.h
@@ -5,6 +5,8 @@
 #ifndef ELECTRON_SHELL_BROWSER_ELECTRON_DOWNLOAD_MANAGER_DELEGATE_H_
 #define ELECTRON_SHELL_BROWSER_ELECTRON_DOWNLOAD_MANAGER_DELEGATE_H_
 
+#include <vector>
+
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/download_manager_delegate.h"
 #include "shell/browser/ui/file_dialog.h"

--- a/shell/browser/electron_download_manager_delegate.h
+++ b/shell/browser/electron_download_manager_delegate.h
@@ -5,8 +5,6 @@
 #ifndef ELECTRON_SHELL_BROWSER_ELECTRON_DOWNLOAD_MANAGER_DELEGATE_H_
 #define ELECTRON_SHELL_BROWSER_ELECTRON_DOWNLOAD_MANAGER_DELEGATE_H_
 
-#include <vector>
-
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/download_manager_delegate.h"
 #include "shell/browser/ui/file_dialog.h"

--- a/shell/browser/electron_download_manager_delegate.h
+++ b/shell/browser/electron_download_manager_delegate.h
@@ -5,9 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_ELECTRON_DOWNLOAD_MANAGER_DELEGATE_H_
 #define ELECTRON_SHELL_BROWSER_ELECTRON_DOWNLOAD_MANAGER_DELEGATE_H_
 
-#if BUILDFLAG(IS_WIN)
 #include <vector>
-#endif  // BUILDFLAG(IS_WIN)
 
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/download_manager_delegate.h"

--- a/shell/browser/electron_download_manager_delegate.h
+++ b/shell/browser/electron_download_manager_delegate.h
@@ -11,7 +11,9 @@
 #include "content/public/browser/download_manager_delegate.h"
 #include "shell/browser/ui/file_dialog.h"
 #include "shell/common/gin_helper/dictionary.h"
+#if BUILDFLAG(IS_WIN)
 #include "ui/shell_dialogs/execute_select_file_win.h"
+#endif  // BUILDFLAG(IS_WIN)
 
 namespace content {
 class DownloadManager;
@@ -64,6 +66,7 @@ class ElectronDownloadManagerDelegate
   content::DownloadManager* download_manager_;
   base::WeakPtrFactory<ElectronDownloadManagerDelegate> weak_ptr_factory_{this};
 
+#if BUILDFLAG(IS_WIN)
   // Copied from ui/shell_dialogs/select_file_dialog_win.h
   bool GetRegistryDescriptionFromExtension(const std::u16string& file_ext,
                                            std::u16string* reg_description);
@@ -72,6 +75,7 @@ class ElectronDownloadManagerDelegate
       const std::vector<std::u16string>& ext_desc,
       bool include_all_files,
       bool keep_extension_visible);
+#endif  // BUILDFLAG(IS_WIN)
 };
 
 }  // namespace electron

--- a/shell/browser/electron_download_manager_delegate.h
+++ b/shell/browser/electron_download_manager_delegate.h
@@ -5,7 +5,9 @@
 #ifndef ELECTRON_SHELL_BROWSER_ELECTRON_DOWNLOAD_MANAGER_DELEGATE_H_
 #define ELECTRON_SHELL_BROWSER_ELECTRON_DOWNLOAD_MANAGER_DELEGATE_H_
 
+#if BUILDFLAG(IS_WIN)
 #include <vector>
+#endif  // BUILDFLAG(IS_WIN)
 
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/download_manager_delegate.h"


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Closes #34450

Previously when saving a file on Windows, the file type would not be defined based on the extension of the file. (The linked issue also mentions that the file name should include the extension, but I could not replicate this on non-Electron applications). The file dialog will now properly display the file type and the saved file will include the extension.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->None
