### PR TITLE
chore: update Discord invite links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI Build Status](https://circleci.com/gh/electron/electron/tree/main.svg?style=shield)](https://circleci.com/gh/electron/electron/tree/main)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/4lggi9dpjc1qob7k/branch/main?svg=true)](https://ci.appveyor.com/project/electron-bot/electron-ljo26/branch/main)
-[![Electron Discord Invite](https://img.shields.io/discord/745037351163527189?color=%237289DA&label=chat&logo=discord&logoColor=white)](https://discord.com/invite/APGC3k5yaH)
+[![Electron Discord Invite](https://img.shields.io/discord/745037351163527189?color=%237289DA&label=chat&logo=discord&logoColor=white)](https://discord.gg/electronjs)
 
 :memo: Available Translations: 🇨🇳 🇧🇷 🇪🇸 🇯🇵 🇷🇺 🇫🇷 🇺🇸 🇩🇪.
 View these docs in other languages at [electron/i18n](https://github.com/electron/i18n/tree/master/content/).

--- a/docs/tutorial/examples.md
+++ b/docs/tutorial/examples.md
@@ -50,7 +50,7 @@ guide!).
 
 You can find the full list of "How to?" in the sidebar. If there is
 something that you would like to do that is not documented, please join
-our [Discord server][] and let us know!
+our [Discord server][discord] and let us know!
 
-[discord server]: https://discord.com/invite/electron
+[discord]: https://discord.gg/electronjs
 [fiddle]: https://www.electronjs.org/fiddle

--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -68,7 +68,7 @@ Are you getting stuck anywhere? Here are a few links to places to look:
 
 [api documentation]: ../api/app.md
 [chromium]: https://www.chromium.org/
-[discord]: https://discord.com/invite/APGC3k5yaH
+[discord]: https://discord.gg/electronjs
 [examples]: examples.md
 [fiddle]: https://electronjs.org/fiddle
 [issue-tracker]: https://github.com/electron/electron/issues

--- a/docs/tutorial/tutorial-4-adding-features.md
+++ b/docs/tutorial/tutorial-4-adding-features.md
@@ -62,7 +62,7 @@ into end users' hands.
 
 <!-- Link labels -->
 
-[discord]: https://discord.com/invite/APGC3k5yaH
+[discord]: https://discord.gg/electronjs
 [github]: https://github.com/electron/electronjs.org-new/issues/new
 [how to]: ./examples.md
 [node-platform]: https://nodejs.org/api/process.html#process_process_platform

--- a/docs/tutorial/tutorial-6-publishing-updating.md
+++ b/docs/tutorial/tutorial-6-publishing-updating.md
@@ -226,7 +226,7 @@ rest of our docs and happy developing! If you have questions, please stop by our
 
 [autoupdater]: ../api/auto-updater.md
 [code-signed]: ./code-signing.md
-[discord server]: https://discord.com/invite/APGC3k5yaH
+[discord server]: https://discord.gg/electronjs
 [electron fiddle]: https://electronjs.org/fiddle
 [fiddle-build]: https://github.com/electron/fiddle/blob/master/.github/workflows/build.yaml
 [fiddle-forge-config]: https://github.com/electron/fiddle/blob/master/forge.config.js

--- a/lib/browser/default-menu.ts
+++ b/lib/browser/default-menu.ts
@@ -31,7 +31,7 @@ export const setDefaultApplicationMenu = () => {
       {
         label: 'Community Discussions',
         click: async () => {
-          await shell.openExternal('https://discord.com/invite/APGC3k5yaH');
+          await shell.openExternal('https://discord.gg/electronjs');
         }
       },
       {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
We continue to be plagued by the wrong Discord links, one slipped in via #34604.

This PR fixes that link, and updates all links to be `https://discord.gg/electronjs` for consistency.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->