### PR TITLE
refactor: load webFrame via process._linkedBinding in security-warnings.ts

### DIFF
--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -1,6 +1,7 @@
-import { webFrame } from 'electron';
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
+
+const { mainFrame: webFrame } = process._linkedBinding('electron_renderer_web_frame');
 
 let shouldLog: boolean | null = null;
 


### PR DESCRIPTION
#### Description of Change
Fixes this error (the previous `import` statement leads to delay loading of `webFrame` due to how the TypeScript code is translated to JavaScript)
<img width="912" alt="Screen Shot 2022-06-25 at 2 40 25 AM" src="https://user-images.githubusercontent.com/1281234/175751417-094329dd-6006-4240-9c6e-05b3df19829d.png">
when bindings are removed in the preload script for security reasons (after all the imports)
> delete process.binding;
delete process._linkedBinding;


#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none