### PR TITLE
chore: improve run-clang-tidy.ts behavior when filenames < jobs

### DIFF
--- a/script/run-clang-tidy.ts
+++ b/script/run-clang-tidy.ts
@@ -173,7 +173,7 @@ async function runClangTidy (
   const worker = async () => {
     let filenames = chunkedFilenames.shift();
 
-    while (filenames && filenames.length > 0) {
+    while (filenames?.length) {
       results.push(
         await spawnAsync(cmd, [...args, ...filenames], {}).then((result) => {
           console.log(result.stdout);

--- a/script/run-clang-tidy.ts
+++ b/script/run-clang-tidy.ts
@@ -173,7 +173,7 @@ async function runClangTidy (
   const worker = async () => {
     let filenames = chunkedFilenames.shift();
 
-    while (filenames) {
+    while (filenames && filenames.length > 0) {
       results.push(
         await spawnAsync(cmd, [...args, ...filenames], {}).then((result) => {
           console.log(result.stdout);


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Currently tries to run `clang-tidy` even when there are no filenames to run it on if you set more jobs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
