### PR TITLE
chore: used nested namespaces

### DIFF
--- a/build/fuses/build.py
+++ b/build/fuses/build.py
@@ -19,17 +19,13 @@ TEMPLATE_H = """
 #define FUSE_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace electron {
-
-namespace fuses {
+namespace electron::fuses {
 
 extern const volatile char kFuseWire[];
 
 {getters}
 
-}  // namespace fuses
-
-}  // namespace electron
+}  // namespace electron::fuses
 
 #endif  // ELECTRON_FUSES_H_
 """
@@ -37,17 +33,13 @@ extern const volatile char kFuseWire[];
 TEMPLATE_CC = """
 #include "electron/fuses.h"
 
-namespace electron {
-
-namespace fuses {
+namespace electron::fuses {
 
 const volatile char kFuseWire[] = { /* sentinel */ {sentinel}, /* fuse_version */ {fuse_version}, /* fuse_wire_length */ {fuse_wire_length}, /* fuse_wire */ {initial_config}};
 
 {getters}
 
-}
-
-}
+}  // namespace electron:fuses
 """
 
 with open(os.path.join(dir_path, "fuses.json5"), 'r') as f:

--- a/build/js2c.py
+++ b/build/js2c.py
@@ -8,9 +8,7 @@ TEMPLATE = """
 #include "node_native_module.h"
 #include "node_internals.h"
 
-namespace node {{
-
-namespace native_module {{
+namespace node::native_module {{
 
 {definitions}
 
@@ -18,9 +16,7 @@ void NativeModuleLoader::LoadEmbedderJavaScriptSource() {{
   {initializers}
 }}
 
-}}  // namespace native_module
-
-}}  // namespace node
+}}  // namespace node::native_module
 """
 
 def main():

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -453,9 +453,7 @@ struct Converter<net::SecureDnsMode> {
 };
 }  // namespace gin
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 gin::WrapperInfo App::kWrapperInfo = {gin::kEmbedderNativeGin};
 
@@ -1822,9 +1820,7 @@ const char* App::GetTypeName() {
   return "App";
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_app_mac.mm
+++ b/shell/browser/api/electron_api_app_mac.mm
@@ -13,9 +13,7 @@
 #import <Cocoa/Cocoa.h>
 #import <sys/sysctl.h>
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 void App::SetAppLogsPath(gin_helper::ErrorThrower thrower,
                          absl::optional<base::FilePath> custom_path) {
@@ -82,6 +80,4 @@ bool App::IsRunningUnderARM64Translation() const {
   return proc_translated == 1;
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_app_mas.mm
+++ b/shell/browser/api/electron_api_app_mas.mm
@@ -10,9 +10,7 @@
 
 #include "base/strings/sys_string_conversions.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 // Callback passed to js which will stop accessing the given bookmark.
 void OnStopAccessingSecurityScopedResource(NSURL* bookmarkUrl) {
@@ -64,6 +62,4 @@ base::RepeatingCallback<void()> App::StartAccessingSecurityScopedResource(
                              bookmarkUrl);
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_auto_updater.cc
+++ b/shell/browser/api/electron_api_auto_updater.cc
@@ -16,9 +16,7 @@
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 gin::WrapperInfo AutoUpdater::kWrapperInfo = {gin::kEmbedderNativeGin};
 
@@ -134,9 +132,7 @@ const char* AutoUpdater::GetTypeName() {
   return "AutoUpdater";
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_auto_updater.h
+++ b/shell/browser/api/electron_api_auto_updater.h
@@ -13,9 +13,7 @@
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/browser/window_list_observer.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class AutoUpdater : public gin::Wrappable<AutoUpdater>,
                     public gin_helper::EventEmitterMixin<AutoUpdater>,
@@ -60,8 +58,6 @@ class AutoUpdater : public gin::Wrappable<AutoUpdater>,
   void QuitAndInstall();
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_AUTO_UPDATER_H_

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -58,9 +58,7 @@ struct Converter<electron::TaskbarHost::ThumbarButton> {
 }  // namespace gin
 #endif
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 namespace {
 
@@ -1323,9 +1321,7 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetProperty("id", &BaseWindow::GetID);
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -19,9 +19,7 @@
 #include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/trackable_object.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class View;
 
@@ -282,8 +280,6 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   base::WeakPtrFactory<BaseWindow> weak_factory_{this};
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_BASE_WINDOW_H_

--- a/shell/browser/api/electron_api_browser_view.cc
+++ b/shell/browser/api/electron_api_browser_view.cc
@@ -67,9 +67,7 @@ int32_t GetNextId() {
 
 }  // namespace
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 gin::WrapperInfo BrowserView::kWrapperInfo = {gin::kEmbedderNativeGin};
 
@@ -200,9 +198,7 @@ v8::Local<v8::ObjectTemplate> BrowserView::FillObjectTemplate(
       .Build();
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_browser_view.h
+++ b/shell/browser/api/electron_api_browser_view.h
@@ -28,9 +28,7 @@ namespace gin_helper {
 class Dictionary;
 }
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class WebContents;
 
@@ -90,8 +88,6 @@ class BrowserView : public gin::Wrappable<BrowserView>,
   int32_t id_;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_BROWSER_VIEW_H_

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -33,9 +33,7 @@
 #include "shell/browser/ui/views/win_frame_view.h"
 #endif
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 BrowserWindow::BrowserWindow(gin::Arguments* args,
                              const gin_helper::Dictionary& options)
@@ -607,9 +605,7 @@ v8::Local<v8::Value> BrowserWindow::From(v8::Isolate* isolate,
     return v8::Null(isolate);
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -14,9 +14,7 @@
 #include "shell/browser/ui/drag_util.h"
 #include "shell/common/gin_helper/error_thrower.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class BrowserWindow : public BaseWindow,
                       public content::RenderWidgetHost::InputEventObserver,
@@ -133,8 +131,6 @@ class BrowserWindow : public BaseWindow,
   base::WeakPtrFactory<BrowserWindow> weak_factory_{this};
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_BROWSER_WINDOW_H_

--- a/shell/browser/api/electron_api_browser_window_mac.mm
+++ b/shell/browser/api/electron_api_browser_window_mac.mm
@@ -15,9 +15,7 @@
 #include "shell/browser/ui/cocoa/electron_inspectable_web_contents_view.h"
 #include "shell/browser/ui/inspectable_web_contents_view.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 void BrowserWindow::OverrideNSWindowContentView(
     InspectableWebContentsView* view) {
@@ -102,6 +100,4 @@ void BrowserWindow::UpdateDraggableRegions(
   [[webView window] setMovableByWindowBackground:YES];
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_browser_window_views.cc
+++ b/shell/browser/api/electron_api_browser_window_views.cc
@@ -8,9 +8,7 @@
 #include "shell/browser/native_window_views.h"
 #include "ui/aura/window.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 void BrowserWindow::UpdateDraggableRegions(
     const std::vector<mojom::DraggableRegionPtr>& regions) {
@@ -36,6 +34,4 @@ void BrowserWindow::UpdateDraggableRegions(
       ->UpdateDraggableRegions(draggable_regions_);
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_cookies.cc
+++ b/shell/browser/api/electron_api_cookies.cc
@@ -91,9 +91,7 @@ struct Converter<net::CookieChangeCause> {
 
 }  // namespace gin
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 namespace {
 
@@ -397,6 +395,4 @@ const char* Cookies::GetTypeName() {
   return "Cookies";
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_crash_reporter.cc
+++ b/shell/browser/api/electron_api_crash_reporter.cc
@@ -64,11 +64,7 @@ bool g_crash_reporter_initialized = false;
 
 }  // namespace
 
-namespace electron {
-
-namespace api {
-
-namespace crash_reporter {
+namespace electron::api::crash_reporter {
 
 #if defined(MAS_BUILD)
 namespace {
@@ -196,11 +192,7 @@ void Start(const std::string& submit_url,
 #endif
 }
 
-}  // namespace crash_reporter
-
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api::crash_reporter
 
 namespace {
 

--- a/shell/browser/api/electron_api_crash_reporter.h
+++ b/shell/browser/api/electron_api_crash_reporter.h
@@ -9,11 +9,7 @@
 #include <string>
 #include "base/files/file_path.h"
 
-namespace electron {
-
-namespace api {
-
-namespace crash_reporter {
+namespace electron::api::crash_reporter {
 
 bool IsCrashReporterEnabled();
 
@@ -32,10 +28,6 @@ void Start(const std::string& submit_url,
            const std::map<std::string, std::string>& extra,
            bool is_node_process);
 
-}  // namespace crash_reporter
-
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api::crash_reporter
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_CRASH_REPORTER_H_

--- a/shell/browser/api/electron_api_data_pipe_holder.cc
+++ b/shell/browser/api/electron_api_data_pipe_holder.cc
@@ -18,9 +18,7 @@
 
 #include "shell/common/node_includes.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 namespace {
 
@@ -201,6 +199,4 @@ gin::Handle<DataPipeHolder> DataPipeHolder::From(v8::Isolate* isolate,
   return gin::Handle<DataPipeHolder>();
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_data_pipe_holder.h
+++ b/shell/browser/api/electron_api_data_pipe_holder.h
@@ -13,9 +13,7 @@
 #include "services/network/public/cpp/data_element.h"
 #include "services/network/public/mojom/data_pipe_getter.mojom.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 // Retains reference to the data pipe.
 class DataPipeHolder : public gin::Wrappable<DataPipeHolder> {
@@ -49,8 +47,6 @@ class DataPipeHolder : public gin::Wrappable<DataPipeHolder> {
   mojo::Remote<network::mojom::DataPipeGetter> data_pipe_;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_DATA_PIPE_HOLDER_H_

--- a/shell/browser/api/electron_api_debugger.cc
+++ b/shell/browser/api/electron_api_debugger.cc
@@ -20,9 +20,7 @@
 
 using content::DevToolsAgentHost;
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 gin::WrapperInfo Debugger::kWrapperInfo = {gin::kEmbedderNativeGin};
 
@@ -206,6 +204,4 @@ const char* Debugger::GetTypeName() {
   return "Debugger";
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_debugger.h
+++ b/shell/browser/api/electron_api_debugger.h
@@ -22,9 +22,7 @@ class DevToolsAgentHost;
 class WebContents;
 }  // namespace content
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class Debugger : public gin::Wrappable<Debugger>,
                  public gin_helper::EventEmitterMixin<Debugger>,
@@ -74,8 +72,6 @@ class Debugger : public gin::Wrappable<Debugger>,
   int previous_request_id_ = 0;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_DEBUGGER_H_

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -59,9 +59,7 @@ struct Converter<electron::api::DesktopCapturer::Source> {
 
 }  // namespace gin
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 gin::WrapperInfo DesktopCapturer::kWrapperInfo = {gin::kEmbedderNativeGin};
 
@@ -217,9 +215,7 @@ const char* DesktopCapturer::GetTypeName() {
   return "DesktopCapturer";
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_desktop_capturer.h
+++ b/shell/browser/api/electron_api_desktop_capturer.h
@@ -15,9 +15,7 @@
 #include "gin/wrappable.h"
 #include "shell/common/gin_helper/pinnable.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
                         public gin_helper::Pinnable<DesktopCapturer>,
@@ -77,8 +75,6 @@ class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
   base::WeakPtrFactory<DesktopCapturer> weak_ptr_factory_{this};
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_DESKTOP_CAPTURER_H_

--- a/shell/browser/api/electron_api_download_item.cc
+++ b/shell/browser/api/electron_api_download_item.cc
@@ -48,9 +48,7 @@ struct Converter<download::DownloadItem::DownloadState> {
 
 }  // namespace gin
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 namespace {
 
@@ -301,6 +299,4 @@ gin::Handle<DownloadItem> DownloadItem::FromOrCreate(
   return handle;
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_download_item.h
+++ b/shell/browser/api/electron_api_download_item.h
@@ -18,9 +18,7 @@
 
 class GURL;
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class DownloadItem : public gin::Wrappable<DownloadItem>,
                      public gin_helper::Pinnable<DownloadItem>,
@@ -87,8 +85,6 @@ class DownloadItem : public gin::Wrappable<DownloadItem>,
   base::WeakPtrFactory<DownloadItem> weak_factory_{this};
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_DOWNLOAD_ITEM_H_

--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -51,9 +51,7 @@ bool MapHasMediaKeys(
 
 }  // namespace
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 gin::WrapperInfo GlobalShortcut::kWrapperInfo = {gin::kEmbedderNativeGin};
 
@@ -182,9 +180,7 @@ const char* GlobalShortcut::GetTypeName() {
   return "GlobalShortcut";
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_global_shortcut.h
+++ b/shell/browser/api/electron_api_global_shortcut.h
@@ -14,9 +14,7 @@
 #include "gin/wrappable.h"
 #include "ui/base/accelerators/accelerator.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class GlobalShortcut : public extensions::GlobalShortcutListener::Observer,
                        public gin::Wrappable<GlobalShortcut> {
@@ -56,8 +54,6 @@ class GlobalShortcut : public extensions::GlobalShortcutListener::Observer,
   AcceleratorCallbackMap accelerator_callback_map_;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_GLOBAL_SHORTCUT_H_

--- a/shell/browser/api/electron_api_in_app_purchase.cc
+++ b/shell/browser/api/electron_api_in_app_purchase.cc
@@ -135,9 +135,7 @@ struct Converter<in_app_purchase::Product> {
 
 }  // namespace gin
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 gin::WrapperInfo InAppPurchase::kWrapperInfo = {gin::kEmbedderNativeGin};
 
@@ -211,9 +209,7 @@ void InAppPurchase::OnTransactionsUpdated(
 }
 #endif
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_in_app_purchase.h
+++ b/shell/browser/api/electron_api_in_app_purchase.h
@@ -16,9 +16,7 @@
 #include "shell/browser/mac/in_app_purchase_product.h"
 #include "v8/include/v8.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class InAppPurchase : public gin::Wrappable<InAppPurchase>,
                       public gin_helper::EventEmitterMixin<InAppPurchase>,
@@ -51,8 +49,6 @@ class InAppPurchase : public gin::Wrappable<InAppPurchase>,
       const std::vector<in_app_purchase::Transaction>& transactions) override;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_IN_APP_PURCHASE_H_

--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -44,9 +44,7 @@ struct Converter<SharingItem> {
 
 #endif
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 gin::WrapperInfo Menu::kWrapperInfo = {gin::kEmbedderNativeGin};
 
@@ -301,9 +299,7 @@ v8::Local<v8::ObjectTemplate> Menu::FillObjectTemplate(
       .Build();
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -16,9 +16,7 @@
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/pinnable.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class Menu : public gin::Wrappable<Menu>,
              public gin_helper::EventEmitterMixin<Menu>,
@@ -123,9 +121,7 @@ class Menu : public gin::Wrappable<Menu>,
   bool WorksWhenHiddenAt(int index) const;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace gin {
 

--- a/shell/browser/api/electron_api_menu_mac.h
+++ b/shell/browser/api/electron_api_menu_mac.h
@@ -13,9 +13,7 @@
 
 using base::scoped_nsobject;
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class MenuMac : public Menu {
  protected:
@@ -50,8 +48,6 @@ class MenuMac : public Menu {
   base::WeakPtrFactory<MenuMac> weak_factory_{this};
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_MENU_MAC_H_

--- a/shell/browser/api/electron_api_menu_mac.mm
+++ b/shell/browser/api/electron_api_menu_mac.mm
@@ -42,9 +42,7 @@ ui::Accelerator GetAcceleratorFromKeyEquivalentAndModifierMask(
 
 }  // namespace
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 MenuMac::MenuMac(gin::Arguments* args) : Menu(args) {}
 
@@ -262,6 +260,4 @@ gin::Handle<Menu> Menu::New(gin::Arguments* args) {
   return handle;
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_menu_views.cc
+++ b/shell/browser/api/electron_api_menu_views.cc
@@ -13,9 +13,7 @@
 
 using views::MenuRunner;
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 MenuViews::MenuViews(gin::Arguments* args) : Menu(args) {}
 
@@ -91,6 +89,4 @@ gin::Handle<Menu> Menu::New(gin::Arguments* args) {
   return handle;
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_menu_views.h
+++ b/shell/browser/api/electron_api_menu_views.h
@@ -13,9 +13,7 @@
 #include "ui/display/screen.h"
 #include "ui/views/controls/menu/menu_runner.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class MenuViews : public Menu {
  public:
@@ -39,8 +37,6 @@ class MenuViews : public Menu {
   base::WeakPtrFactory<MenuViews> weak_factory_{this};
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_MENU_VIEWS_H_

--- a/shell/browser/api/electron_api_native_theme.cc
+++ b/shell/browser/api/electron_api_native_theme.cc
@@ -16,9 +16,7 @@
 #include "ui/gfx/color_utils.h"
 #include "ui/native_theme/native_theme.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 gin::WrapperInfo NativeTheme::kWrapperInfo = {gin::kEmbedderNativeGin};
 
@@ -117,9 +115,7 @@ const char* NativeTheme::GetTypeName() {
   return "NativeTheme";
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_native_theme.h
+++ b/shell/browser/api/electron_api_native_theme.h
@@ -11,9 +11,7 @@
 #include "ui/native_theme/native_theme.h"
 #include "ui/native_theme/native_theme_observer.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class NativeTheme : public gin::Wrappable<NativeTheme>,
                     public gin_helper::EventEmitterMixin<NativeTheme>,
@@ -57,9 +55,7 @@ class NativeTheme : public gin::Wrappable<NativeTheme>,
   ui::NativeTheme* web_theme_;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace gin {
 

--- a/shell/browser/api/electron_api_native_theme_mac.mm
+++ b/shell/browser/api/electron_api_native_theme_mac.mm
@@ -7,9 +7,7 @@
 #include "base/mac/sdk_forward_declarations.h"
 #include "shell/browser/mac/electron_application.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 void NativeTheme::UpdateMacOSAppearanceForOverrideValue(
     ui::NativeTheme::ThemeSource override) {
@@ -32,6 +30,4 @@ void NativeTheme::UpdateMacOSAppearanceForOverrideValue(
   }
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -45,9 +45,7 @@ struct Converter<electron::NotificationAction> {
 
 }  // namespace gin
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 gin::WrapperInfo Notification::kWrapperInfo = {gin::kEmbedderNativeGin};
 
@@ -284,9 +282,7 @@ v8::Local<v8::ObjectTemplate> Notification::FillObjectTemplate(
       .Build();
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -25,9 +25,7 @@ template <typename T>
 class Handle;
 }  // namespace gin
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class Notification : public gin::Wrappable<Notification>,
                      public gin_helper::EventEmitterMixin<Notification>,
@@ -117,8 +115,6 @@ class Notification : public gin::Wrappable<Notification>,
   base::WeakPtr<electron::Notification> notification_;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_NOTIFICATION_H_

--- a/shell/browser/api/electron_api_power_monitor.cc
+++ b/shell/browser/api/electron_api_power_monitor.cc
@@ -35,9 +35,7 @@ struct Converter<ui::IdleState> {
 
 }  // namespace gin
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 gin::WrapperInfo PowerMonitor::kWrapperInfo = {gin::kEmbedderNativeGin};
 
@@ -116,9 +114,7 @@ const char* PowerMonitor::GetTypeName() {
   return "PowerMonitor";
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_power_monitor.h
+++ b/shell/browser/api/electron_api_power_monitor.h
@@ -15,9 +15,7 @@
 #include "shell/browser/lib/power_observer_linux.h"
 #endif
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class PowerMonitor : public gin::Wrappable<PowerMonitor>,
                      public gin_helper::EventEmitterMixin<PowerMonitor>,
@@ -86,8 +84,6 @@ class PowerMonitor : public gin::Wrappable<PowerMonitor>,
 #endif
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_POWER_MONITOR_H_

--- a/shell/browser/api/electron_api_power_monitor_mac.mm
+++ b/shell/browser/api/electron_api_power_monitor_mac.mm
@@ -108,9 +108,7 @@
 
 @end
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 static MacLockMonitor* g_lock_monitor = nil;
 
@@ -120,6 +118,4 @@ void PowerMonitor::InitPlatformSpecificMonitors() {
   [g_lock_monitor addEmitter:this];
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_power_save_blocker.cc
+++ b/shell/browser/api/electron_api_power_save_blocker.cc
@@ -37,9 +37,7 @@ struct Converter<device::mojom::WakeLockType> {
 
 }  // namespace gin
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 gin::WrapperInfo PowerSaveBlocker::kWrapperInfo = {gin::kEmbedderNativeGin};
 
@@ -126,9 +124,7 @@ gin::ObjectTemplateBuilder PowerSaveBlocker::GetObjectTemplateBuilder(
       .SetMethod("isStarted", &PowerSaveBlocker::IsStarted);
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_power_save_blocker.h
+++ b/shell/browser/api/electron_api_power_save_blocker.h
@@ -13,9 +13,7 @@
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/device/public/mojom/wake_lock.mojom.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class PowerSaveBlocker : public gin::Wrappable<PowerSaveBlocker> {
  public:
@@ -56,8 +54,6 @@ class PowerSaveBlocker : public gin::Wrappable<PowerSaveBlocker> {
   mojo::Remote<device::mojom::WakeLock> wake_lock_;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_POWER_SAVE_BLOCKER_H_

--- a/shell/browser/api/electron_api_printing.cc
+++ b/shell/browser/api/electron_api_printing.cc
@@ -38,9 +38,7 @@ struct Converter<printing::PrinterBasicInfo> {
 
 }  // namespace gin
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 #if BUILDFLAG(ENABLE_PRINTING)
 printing::PrinterList GetPrinterList(v8::Isolate* isolate) {
@@ -89,9 +87,7 @@ v8::Local<v8::Promise> GetPrinterListAsync(v8::Isolate* isolate) {
 }
 #endif
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -78,8 +78,7 @@ struct Converter<CustomScheme> {
 
 }  // namespace gin
 
-namespace electron {
-namespace api {
+namespace electron::api {
 
 gin::WrapperInfo Protocol::kWrapperInfo = {gin::kEmbedderNativeGin};
 
@@ -312,8 +311,7 @@ const char* Protocol::GetTypeName() {
   return "Protocol";
 }
 
-}  // namespace api
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_safe_storage.cc
+++ b/shell/browser/api/electron_api_safe_storage.cc
@@ -15,9 +15,7 @@
 #include "shell/common/node_includes.h"
 #include "shell/common/platform_util.h"
 
-namespace electron {
-
-namespace safestorage {
+namespace electron::safestorage {
 
 static const char* kEncryptionVersionPrefixV10 = "v10";
 static const char* kEncryptionVersionPrefixV11 = "v11";
@@ -119,9 +117,7 @@ std::string DecryptString(v8::Isolate* isolate, v8::Local<v8::Value> buffer) {
   return plaintext;
 }
 
-}  // namespace safestorage
-
-}  // namespace electron
+}  // namespace electron::safestorage
 
 void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,

--- a/shell/browser/api/electron_api_safe_storage.h
+++ b/shell/browser/api/electron_api_safe_storage.h
@@ -7,9 +7,7 @@
 
 #include "base/dcheck_is_on.h"
 
-namespace electron {
-
-namespace safestorage {
+namespace electron::safestorage {
 
 // Used in a DCHECK to validate that our assumption that the network context
 // manager has initialized before app ready holds true. Only used in the
@@ -18,8 +16,6 @@ namespace safestorage {
 void SetElectronCryptoReady(bool ready);
 #endif
 
-}  // namespace safestorage
-
-}  // namespace electron
+}  // namespace electron::safestorage
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_SAFE_STORAGE_H_

--- a/shell/browser/api/electron_api_screen.cc
+++ b/shell/browser/api/electron_api_screen.cc
@@ -24,9 +24,7 @@
 #include "ui/display/win/screen_win.h"
 #endif
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 gin::WrapperInfo Screen::kWrapperInfo = {gin::kEmbedderNativeGin};
 
@@ -166,9 +164,7 @@ const char* Screen::GetTypeName() {
   return "Screen";
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_screen.h
+++ b/shell/browser/api/electron_api_screen.h
@@ -19,9 +19,7 @@ class Rect;
 class Screen;
 }  // namespace gfx
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class Screen : public gin::Wrappable<Screen>,
                public gin_helper::EventEmitterMixin<Screen>,
@@ -58,8 +56,6 @@ class Screen : public gin::Wrappable<Screen>,
   display::Screen* screen_;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_SCREEN_H_

--- a/shell/browser/api/electron_api_service_worker_context.cc
+++ b/shell/browser/api/electron_api_service_worker_context.cc
@@ -21,9 +21,7 @@
 #include "shell/common/gin_helper/function_template_extensions.h"
 #include "shell/common/node_includes.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 namespace {
 
@@ -162,6 +160,4 @@ const char* ServiceWorkerContext::GetTypeName() {
   return "ServiceWorkerContext";
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -242,9 +242,7 @@ struct Converter<network::mojom::SSLConfigPtr> {
 
 }  // namespace gin
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 namespace {
 
@@ -1255,9 +1253,7 @@ const char* Session::GetTypeName() {
   return "Session";
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_system_preferences.cc
+++ b/shell/browser/api/electron_api_system_preferences.cc
@@ -13,9 +13,7 @@
 #include "ui/gfx/color_utils.h"
 #include "ui/native_theme/native_theme.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 gin::WrapperInfo SystemPreferences::kWrapperInfo = {gin::kEmbedderNativeGin};
 
@@ -117,9 +115,7 @@ const char* SystemPreferences::GetTypeName() {
   return "SystemPreferences";
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_system_preferences.h
+++ b/shell/browser/api/electron_api_system_preferences.h
@@ -21,9 +21,7 @@
 #include "ui/gfx/sys_color_change_listener.h"
 #endif
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 #if BUILDFLAG(IS_MAC)
 enum class NotificationCenterKind {
@@ -168,8 +166,6 @@ class SystemPreferences
 #endif
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_SYSTEM_PREFERENCES_H_

--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -86,9 +86,7 @@ struct Converter<NSAppearance*> {
 
 }  // namespace gin
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 namespace {
 
@@ -657,6 +655,4 @@ void SystemPreferences::SetAppLevelAppearance(gin::Arguments* args) {
   }
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -56,9 +56,7 @@ struct Converter<electron::TrayIcon::IconType> {
 
 }  // namespace gin
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 gin::WrapperInfo Tray::kWrapperInfo = {gin::kEmbedderNativeGin};
 
@@ -422,9 +420,7 @@ v8::Local<v8::ObjectTemplate> Tray::FillObjectTemplate(
       .Build();
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_tray.h
+++ b/shell/browser/api/electron_api_tray.h
@@ -29,9 +29,7 @@ namespace gin_helper {
 class Dictionary;
 }
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class Menu;
 
@@ -113,8 +111,6 @@ class Tray : public gin::Wrappable<Tray>,
   std::unique_ptr<TrayIcon> tray_icon_;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_TRAY_H_

--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -70,9 +70,7 @@ struct Converter<network::mojom::CredentialsMode> {
 
 }  // namespace gin
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 namespace {
 
@@ -614,6 +612,4 @@ const char* SimpleURLLoaderWrapper::GetTypeName() {
   return "SimpleURLLoaderWrapper";
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_url_loader.h
+++ b/shell/browser/api/electron_api_url_loader.h
@@ -33,9 +33,7 @@ class SimpleURLLoader;
 struct ResourceRequest;
 }  // namespace network
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 /** Wraps a SimpleURLLoader to make it usable from JavaScript */
 class SimpleURLLoaderWrapper
@@ -123,8 +121,6 @@ class SimpleURLLoaderWrapper
   base::WeakPtrFactory<SimpleURLLoaderWrapper> weak_factory_{this};
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_URL_LOADER_H_

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -8,9 +8,7 @@
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 View::View(views::View* view) : view_(view) {
   view_->set_owned_by_client();
@@ -55,9 +53,7 @@ void View::BuildPrototype(v8::Isolate* isolate,
 #endif
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -12,9 +12,7 @@
 #include "shell/common/gin_helper/wrappable.h"
 #include "ui/views/view.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class View : public gin_helper::Wrappable<View> {
  public:
@@ -49,8 +47,6 @@ class View : public gin_helper::Wrappable<View> {
   views::View* view_ = nullptr;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_VIEW_H_

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -372,9 +372,7 @@ struct Converter<scoped_refptr<content::DevToolsAgentHost>> {
 
 }  // namespace gin
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 namespace {
 
@@ -4297,9 +4295,7 @@ WebContents* WebContents::FromID(int32_t id) {
 // static
 gin::WrapperInfo WebContents::kWrapperInfo = {gin::kEmbedderNativeGin};
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_web_contents_impl.cc
+++ b/shell/browser/api/electron_api_web_contents_impl.cc
@@ -17,9 +17,7 @@
 // have to isolate the usage of WebContentsImpl into a clean file to fix it:
 // error C2371: 'ssize_t': redefinition; different basic types
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 void WebContents::DetachFromOuterFrame() {
   // See detach_webview_frame.patch on how to detach.
@@ -55,6 +53,4 @@ OffScreenRenderWidgetHostView* WebContents::GetOffScreenRenderWidgetHostView()
 }
 #endif
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_web_contents_mac.mm
+++ b/shell/browser/api/electron_api_web_contents_mac.mm
@@ -15,9 +15,7 @@
 - (void)redispatchKeyEvent:(NSEvent*)event;
 @end
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 bool WebContents::IsFocused() const {
   auto* view = web_contents()->GetRenderWidgetHostView();
@@ -81,6 +79,4 @@ bool WebContents::PlatformHandleKeyboardEvent(
   return false;
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -19,9 +19,7 @@
 #include "shell/browser/ui/cocoa/delayed_native_view_host.h"
 #endif
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 WebContentsView::WebContentsView(v8::Isolate* isolate,
                                  gin::Handle<WebContents> web_contents)
@@ -105,9 +103,7 @@ void WebContentsView::BuildPrototype(
       .SetProperty("webContents", &WebContentsView::GetWebContents);
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_web_contents_view.h
+++ b/shell/browser/api/electron_api_web_contents_view.h
@@ -12,9 +12,7 @@ namespace gin_helper {
 class Dictionary;
 }
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class WebContents;
 
@@ -53,8 +51,6 @@ class WebContentsView : public View, public content::WebContentsObserver {
   api::WebContents* api_web_contents_;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_WEB_CONTENTS_VIEW_H_

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -52,9 +52,7 @@ struct Converter<blink::mojom::PageVisibilityState> {
 
 }  // namespace gin
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 typedef std::unordered_map<int, WebFrameMain*> WebFrameMainIdMap;
 
@@ -391,9 +389,7 @@ const char* WebFrameMain::GetTypeName() {
   return "WebFrameMain";
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -28,9 +28,7 @@ namespace gin {
 class Arguments;
 }
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class WebContents;
 
@@ -131,8 +129,6 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
   base::WeakPtrFactory<WebFrameMain> weak_factory_{this};
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_WEB_FRAME_MAIN_H_

--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -81,9 +81,7 @@ struct Converter<extensions::WebRequestResourceType> {
 
 }  // namespace gin
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 namespace {
 
@@ -551,6 +549,4 @@ gin::Handle<WebRequest> WebRequest::From(
   return gin::CreateHandle(isolate, user_data->data);
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_web_request.h
+++ b/shell/browser/api/electron_api_web_request.h
@@ -19,9 +19,7 @@ namespace content {
 class BrowserContext;
 }
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class WebRequest : public gin::Wrappable<WebRequest>, public WebRequestAPI {
  public:
@@ -151,8 +149,6 @@ class WebRequest : public gin::Wrappable<WebRequest>, public WebRequestAPI {
   content::BrowserContext* browser_context_;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_ELECTRON_API_WEB_REQUEST_H_

--- a/shell/browser/api/frame_subscriber.cc
+++ b/shell/browser/api/frame_subscriber.cc
@@ -17,9 +17,7 @@
 #include "ui/gfx/image/image.h"
 #include "ui/gfx/skbitmap_operations.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 constexpr static int kMaxFrameRate = 30;
 
@@ -180,6 +178,4 @@ gfx::Size FrameSubscriber::GetRenderViewSize() const {
       gfx::ScaleSize(gfx::SizeF(size), view->GetDeviceScaleFactor()));
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/frame_subscriber.h
+++ b/shell/browser/api/frame_subscriber.h
@@ -22,9 +22,7 @@ class Image;
 class Rect;
 }  // namespace gfx
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class WebContents;
 
@@ -77,8 +75,6 @@ class FrameSubscriber : public content::WebContentsObserver,
   base::WeakPtrFactory<FrameSubscriber> weak_ptr_factory_{this};
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_FRAME_SUBSCRIBER_H_

--- a/shell/browser/api/save_page_handler.cc
+++ b/shell/browser/api/save_page_handler.cc
@@ -11,9 +11,7 @@
 #include "content/public/browser/web_contents.h"
 #include "shell/browser/electron_browser_context.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 SavePageHandler::SavePageHandler(content::WebContents* web_contents,
                                  gin_helper::Promise<void> promise)
@@ -65,6 +63,4 @@ void SavePageHandler::Destroy(download::DownloadItem* item) {
   delete this;
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/save_page_handler.h
+++ b/shell/browser/api/save_page_handler.h
@@ -19,9 +19,7 @@ namespace content {
 class WebContents;
 }
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 // A self-destroyed class for handling save page request.
 class SavePageHandler : public content::DownloadManager::Observer,
@@ -48,8 +46,6 @@ class SavePageHandler : public content::DownloadManager::Observer,
   gin_helper::Promise<void> promise_;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_SAVE_PAGE_HANDLER_H_

--- a/shell/browser/api/ui_event.cc
+++ b/shell/browser/api/ui_event.cc
@@ -9,8 +9,7 @@
 #include "ui/events/event_constants.h"
 #include "v8/include/v8.h"
 
-namespace electron {
-namespace api {
+namespace electron::api {
 
 constexpr int mouse_button_flags =
     (ui::EF_RIGHT_MOUSE_BUTTON | ui::EF_LEFT_MOUSE_BUTTON |
@@ -29,5 +28,4 @@ v8::Local<v8::Object> CreateEventFromFlags(int flags) {
       .Build();
 }
 
-}  // namespace api
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/browser/api/ui_event.h
+++ b/shell/browser/api/ui_event.h
@@ -11,12 +11,10 @@ template <typename T>
 class Local;
 }  // namespace v8
 
-namespace electron {
-namespace api {
+namespace electron::api {
 
 v8::Local<v8::Object> CreateEventFromFlags(int flags);
 
-}  // namespace api
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_UI_EVENT_H_

--- a/shell/browser/api/views/electron_api_image_view.cc
+++ b/shell/browser/api/views/electron_api_image_view.cc
@@ -10,9 +10,7 @@
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 ImageView::ImageView() : View(new views::ImageView()) {
   view()->set_owned_by_client();
@@ -40,9 +38,7 @@ void ImageView::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setImage", &ImageView::SetImage);
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/browser/api/views/electron_api_image_view.h
+++ b/shell/browser/api/views/electron_api_image_view.h
@@ -10,9 +10,7 @@
 #include "ui/gfx/image/image.h"
 #include "ui/views/controls/image_view.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class ImageView : public View {
  public:
@@ -32,8 +30,6 @@ class ImageView : public View {
   }
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_BROWSER_API_VIEWS_ELECTRON_API_IMAGE_VIEW_H_

--- a/shell/browser/event_emitter_mixin.cc
+++ b/shell/browser/event_emitter_mixin.cc
@@ -7,9 +7,7 @@
 #include "gin/public/wrapper_info.h"
 #include "shell/browser/api/electron_api_event_emitter.h"
 
-namespace gin_helper {
-
-namespace internal {
+namespace gin_helper::internal {
 
 gin::WrapperInfo kWrapperInfo = {gin::kEmbedderNativeGin};
 
@@ -40,6 +38,4 @@ v8::Local<v8::FunctionTemplate> GetEventEmitterTemplate(v8::Isolate* isolate) {
   return tmpl;
 }
 
-}  // namespace internal
-
-}  // namespace gin_helper
+}  // namespace gin_helper::internal

--- a/shell/browser/extensions/api/cryptotoken_private/cryptotoken_private_api.cc
+++ b/shell/browser/extensions/api/cryptotoken_private/cryptotoken_private_api.cc
@@ -39,9 +39,7 @@
 #include "device/fido/win/webauthn_api.h"
 #endif  // BUILDFLAG(IS_WIN)
 
-namespace extensions {
-
-namespace api {
+namespace extensions::api {
 
 namespace {
 
@@ -307,5 +305,4 @@ CryptotokenPrivateRecordSignRequestFunction::Run() {
   return RespondNow(NoArguments());
 }
 
-}  // namespace api
-}  // namespace extensions
+}  // namespace extensions::api

--- a/shell/browser/extensions/api/cryptotoken_private/cryptotoken_private_api.h
+++ b/shell/browser/extensions/api/cryptotoken_private/cryptotoken_private_api.h
@@ -14,8 +14,7 @@ class PrefRegistrySyncable;
 
 // Implementations for chrome.cryptotokenPrivate API functions.
 
-namespace extensions {
-namespace api {
+namespace extensions::api {
 
 // void CryptotokenRegisterProfilePrefs(
 //     user_prefs::PrefRegistrySyncable* registry);
@@ -80,7 +79,6 @@ class CryptotokenPrivateRecordSignRequestFunction : public ExtensionFunction {
   ResponseAction Run() override;
 };
 
-}  // namespace api
-}  // namespace extensions
+}  // namespace extensions::api
 
 #endif  // ELECTRON_SHELL_BROWSER_EXTENSIONS_API_CRYPTOTOKEN_PRIVATE_CRYPTOTOKEN_PRIVATE_API_H_

--- a/shell/browser/extensions/electron_browser_context_keyed_service_factories.cc
+++ b/shell/browser/extensions/electron_browser_context_keyed_service_factories.cc
@@ -7,8 +7,7 @@
 #include "extensions/browser/updater/update_service_factory.h"
 #include "shell/browser/extensions/electron_extension_system_factory.h"
 
-namespace extensions {
-namespace electron {
+namespace extensions::electron {
 
 void EnsureBrowserContextKeyedServiceFactoriesBuilt() {
   // TODO(rockot): Remove this once UpdateService is supported across all
@@ -18,5 +17,4 @@ void EnsureBrowserContextKeyedServiceFactoriesBuilt() {
   ElectronExtensionSystemFactory::GetInstance();
 }
 
-}  // namespace electron
-}  // namespace extensions
+}  // namespace extensions::electron

--- a/shell/browser/extensions/electron_browser_context_keyed_service_factories.h
+++ b/shell/browser/extensions/electron_browser_context_keyed_service_factories.h
@@ -5,14 +5,12 @@
 #ifndef ELECTRON_SHELL_BROWSER_EXTENSIONS_ELECTRON_BROWSER_CONTEXT_KEYED_SERVICE_FACTORIES_H_
 #define ELECTRON_SHELL_BROWSER_EXTENSIONS_ELECTRON_BROWSER_CONTEXT_KEYED_SERVICE_FACTORIES_H_
 
-namespace extensions {
-namespace electron {
+namespace extensions::electron {
 
 // Ensures the existence of any BrowserContextKeyedServiceFactory provided by
 // the core extensions code.
 void EnsureBrowserContextKeyedServiceFactoriesBuilt();
 
-}  // namespace electron
-}  // namespace extensions
+}  // namespace extensions::electron
 
 #endif  // ELECTRON_SHELL_BROWSER_EXTENSIONS_ELECTRON_BROWSER_CONTEXT_KEYED_SERVICE_FACTORIES_H_

--- a/shell/browser/relauncher_linux.cc
+++ b/shell/browser/relauncher_linux.cc
@@ -15,9 +15,7 @@
 #include "base/process/launch.h"
 #include "base/synchronization/waitable_event.h"
 
-namespace relauncher {
-
-namespace internal {
+namespace relauncher::internal {
 
 // this is global to be visible to the sa_handler
 base::WaitableEvent parentWaiter;
@@ -68,6 +66,4 @@ int LaunchProgram(const StringVector& relauncher_args,
   return process.IsValid() ? 0 : 1;
 }
 
-}  // namespace internal
-
-}  // namespace relauncher
+}  // namespace relauncher::internal

--- a/shell/browser/relauncher_mac.cc
+++ b/shell/browser/relauncher_mac.cc
@@ -16,9 +16,7 @@
 #include "base/process/launch.h"
 #include "base/strings/sys_string_conversions.h"
 
-namespace relauncher {
-
-namespace internal {
+namespace relauncher::internal {
 
 void RelauncherSynchronizeWithParent() {
   base::ScopedFD relauncher_sync_fd(kRelauncherSyncFD);
@@ -91,6 +89,4 @@ int LaunchProgram(const StringVector& relauncher_args,
   return process.IsValid() ? 0 : 1;
 }
 
-}  // namespace internal
-
-}  // namespace relauncher
+}  // namespace relauncher::internal

--- a/shell/browser/relauncher_win.cc
+++ b/shell/browser/relauncher_win.cc
@@ -14,9 +14,7 @@
 #include "sandbox/win/src/win_utils.h"
 #include "ui/base/win/shell.h"
 
-namespace relauncher {
-
-namespace internal {
+namespace relauncher::internal {
 
 namespace {
 
@@ -125,6 +123,4 @@ int LaunchProgram(const StringVector& relauncher_args,
   return process.IsValid() ? 0 : 1;
 }
 
-}  // namespace internal
-
-}  // namespace relauncher
+}  // namespace relauncher::internal

--- a/shell/browser/ui/gtk/app_indicator_icon.cc
+++ b/shell/browser/ui/gtk/app_indicator_icon.cc
@@ -152,9 +152,7 @@ void DeleteTempDirectory(const base::FilePath& dir_path) {
 
 }  // namespace
 
-namespace electron {
-
-namespace gtkui {
+namespace electron::gtkui {
 
 AppIndicatorIcon::AppIndicatorIcon(std::string id,
                                    const gfx::ImageSkia& image,
@@ -375,6 +373,4 @@ void AppIndicatorIcon::OnClickActionReplacementMenuItemActivated() {
     delegate()->OnClick();
 }
 
-}  // namespace gtkui
-
-}  // namespace electron
+}  // namespace electron::gtkui

--- a/shell/browser/ui/gtk/app_indicator_icon.h
+++ b/shell/browser/ui/gtk/app_indicator_icon.h
@@ -28,9 +28,7 @@ namespace ui {
 class MenuModel;
 }
 
-namespace electron {
-
-namespace gtkui {
+namespace electron::gtkui {
 
 class AppIndicatorIconMenu;
 
@@ -111,8 +109,6 @@ class AppIndicatorIcon : public views::StatusIconLinux {
   base::WeakPtrFactory<AppIndicatorIcon> weak_factory_{this};
 };
 
-}  // namespace gtkui
-
-}  // namespace electron
+}  // namespace electron::gtkui
 
 #endif  // ELECTRON_SHELL_BROWSER_UI_GTK_APP_INDICATOR_ICON_H_

--- a/shell/browser/ui/gtk/app_indicator_icon_menu.cc
+++ b/shell/browser/ui/gtk/app_indicator_icon_menu.cc
@@ -11,9 +11,7 @@
 #include "shell/browser/ui/gtk/menu_util.h"
 #include "ui/base/models/menu_model.h"
 
-namespace electron {
-
-namespace gtkui {
+namespace electron::gtkui {
 
 AppIndicatorIconMenu::AppIndicatorIconMenu(ui::MenuModel* model)
     : menu_model_(model) {
@@ -115,6 +113,4 @@ void AppIndicatorIconMenu::OnMenuItemActivated(GtkWidget* menu_item) {
     ExecuteCommand(model, id);
 }
 
-}  // namespace gtkui
-
-}  // namespace electron
+}  // namespace electron::gtkui

--- a/shell/browser/ui/gtk/app_indicator_icon_menu.h
+++ b/shell/browser/ui/gtk/app_indicator_icon_menu.h
@@ -15,9 +15,7 @@ namespace ui {
 class MenuModel;
 }
 
-namespace electron {
-
-namespace gtkui {
+namespace electron::gtkui {
 
 // The app indicator icon's menu.
 class AppIndicatorIconMenu {
@@ -70,8 +68,6 @@ class AppIndicatorIconMenu {
   bool block_activation_ = false;
 };
 
-}  // namespace gtkui
-
-}  // namespace electron
+}  // namespace electron::gtkui
 
 #endif  // ELECTRON_SHELL_BROWSER_UI_GTK_APP_INDICATOR_ICON_MENU_H_

--- a/shell/browser/ui/gtk/gtk_status_icon.cc
+++ b/shell/browser/ui/gtk/gtk_status_icon.cc
@@ -15,9 +15,7 @@
 
 G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 
-namespace electron {
-
-namespace gtkui {
+namespace electron::gtkui {
 
 GtkStatusIcon::GtkStatusIcon(const gfx::ImageSkia& image,
                              const std::u16string& tool_tip) {
@@ -81,6 +79,4 @@ void GtkStatusIcon::OnContextMenuRequested(GtkStatusIcon* status_icon,
   }
 }
 
-}  // namespace gtkui
-
-}  // namespace electron
+}  // namespace electron::gtkui

--- a/shell/browser/ui/gtk/gtk_status_icon.h
+++ b/shell/browser/ui/gtk/gtk_status_icon.h
@@ -21,9 +21,8 @@ namespace ui {
 class MenuModel;
 }
 
-namespace electron {
+namespace electron::gtkui {
 
-namespace gtkui {
 class AppIndicatorIconMenu;
 
 // Status icon implementation which uses the system tray X11 spec (via
@@ -58,8 +57,6 @@ class GtkStatusIcon : public views::StatusIconLinux {
   std::unique_ptr<AppIndicatorIconMenu> menu_;
 };
 
-}  // namespace gtkui
-
-}  // namespace electron
+}  // namespace electron::gtkui
 
 #endif  // ELECTRON_SHELL_BROWSER_UI_GTK_GTK_STATUS_ICON_H_

--- a/shell/browser/ui/gtk/menu_util.cc
+++ b/shell/browser/ui/gtk/menu_util.cc
@@ -30,9 +30,7 @@
 #include "ui/ozone/public/ozone_platform.h"
 #endif
 
-namespace electron {
-
-namespace gtkui {
+namespace electron::gtkui {
 
 namespace {
 
@@ -330,6 +328,4 @@ void SetMenuItemInfo(GtkWidget* widget, void* block_activation_ptr) {
   }
 }
 
-}  // namespace gtkui
-
-}  // namespace electron
+}  // namespace electron::gtkui

--- a/shell/browser/ui/gtk/menu_util.h
+++ b/shell/browser/ui/gtk/menu_util.h
@@ -15,9 +15,7 @@ namespace ui {
 class MenuModel;
 }
 
-namespace electron {
-
-namespace gtkui {
+namespace electron::gtkui {
 
 // Builds GtkImageMenuItems.
 GtkWidget* BuildMenuItemWithImage(const std::string& label, GtkWidget* image);
@@ -56,8 +54,6 @@ void BuildSubmenuFromModel(ui::MenuModel* model,
 // Sets the check mark, enabled/disabled state and dynamic labels on menu items.
 void SetMenuItemInfo(GtkWidget* widget, void* block_activation_ptr);
 
-}  // namespace gtkui
-
-}  // namespace electron
+}  // namespace electron::gtkui
 
 #endif  // ELECTRON_SHELL_BROWSER_UI_GTK_MENU_UTIL_H_

--- a/shell/browser/ui/gtk/status_icon.cc
+++ b/shell/browser/ui/gtk/status_icon.cc
@@ -16,9 +16,7 @@
 #include "shell/browser/ui/gtk/app_indicator_icon.h"
 #include "shell/browser/ui/gtk/gtk_status_icon.h"
 
-namespace electron {
-
-namespace gtkui {
+namespace electron::gtkui {
 
 namespace {
 
@@ -55,6 +53,4 @@ std::unique_ptr<views::StatusIconLinux> CreateLinuxStatusIcon(
 #endif
 }
 
-}  // namespace gtkui
-
-}  // namespace electron
+}  // namespace electron::gtkui

--- a/shell/browser/ui/gtk/status_icon.h
+++ b/shell/browser/ui/gtk/status_icon.h
@@ -15,9 +15,7 @@
 #include "ui/gfx/image/image_skia.h"
 #include "ui/views/linux_ui/status_icon_linux.h"
 
-namespace electron {
-
-namespace gtkui {
+namespace electron::gtkui {
 
 bool IsStatusIconSupported();
 std::unique_ptr<views::StatusIconLinux> CreateLinuxStatusIcon(
@@ -25,8 +23,6 @@ std::unique_ptr<views::StatusIconLinux> CreateLinuxStatusIcon(
     const std::u16string& tool_tip,
     const char* id_prefix);
 
-}  // namespace gtkui
-
-}  // namespace electron
+}  // namespace electron::gtkui
 
 #endif  // ELECTRON_SHELL_BROWSER_UI_GTK_STATUS_ICON_H_

--- a/shell/browser/win/dark_mode.cc
+++ b/shell/browser/win/dark_mode.cc
@@ -40,9 +40,7 @@ HRESULT TrySetWindowTheme(HWND hWnd, bool dark) {
 
 }  // namespace
 
-namespace electron {
-
-namespace win {
+namespace electron::win {
 
 bool IsDarkModeSupported() {
   auto* os_info = base::win::OSInfo::GetInstance();
@@ -59,6 +57,4 @@ void SetDarkModeForWindow(HWND hWnd) {
   TrySetWindowTheme(hWnd, dark);
 }
 
-}  // namespace win
-
-}  // namespace electron
+}  // namespace electron::win

--- a/shell/browser/win/dark_mode.h
+++ b/shell/browser/win/dark_mode.h
@@ -15,15 +15,11 @@
 
 #include "ui/native_theme/native_theme.h"
 
-namespace electron {
-
-namespace win {
+namespace electron::win {
 
 bool IsDarkModeSupported();
 void SetDarkModeForWindow(HWND hWnd);
 
-}  // namespace win
-
-}  // namespace electron
+}  // namespace electron::win
 
 #endif  // ELECTRON_SHELL_BROWSER_WIN_DARK_MODE_H_

--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -17,9 +17,7 @@
 #include "ui/base/clipboard/scoped_clipboard_writer.h"
 #include "ui/gfx/codec/png_codec.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 ui::ClipboardBuffer Clipboard::GetClipboardBuffer(gin_helper::Arguments* args) {
   std::string type;
@@ -260,9 +258,7 @@ void Clipboard::Clear(gin_helper::Arguments* args) {
   ui::Clipboard::GetForCurrentThread()->Clear(GetClipboardBuffer(args));
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/common/api/electron_api_clipboard.h
+++ b/shell/common/api/electron_api_clipboard.h
@@ -17,9 +17,7 @@ class Arguments;
 class Dictionary;
 }  // namespace gin_helper
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class Clipboard {
  public:
@@ -67,8 +65,6 @@ class Clipboard {
                           gin_helper::Arguments* args);
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_COMMON_API_ELECTRON_API_CLIPBOARD_H_

--- a/shell/common/api/electron_api_clipboard_mac.mm
+++ b/shell/common/api/electron_api_clipboard_mac.mm
@@ -6,9 +6,7 @@
 #include "shell/common/api/electron_api_clipboard.h"
 #include "ui/base/cocoa/find_pasteboard.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 void Clipboard::WriteFindText(const std::u16string& text) {
   NSString* text_ns = base::SysUTF16ToNSString(text);
@@ -19,6 +17,4 @@ std::u16string Clipboard::ReadFindText() {
   return GetFindPboardText();
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/common/api/electron_api_key_weak_map.h
+++ b/shell/common/api/electron_api_key_weak_map.h
@@ -11,9 +11,7 @@
 #include "shell/common/gin_helper/wrappable.h"
 #include "shell/common/key_weak_map.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 template <typename K>
 class KeyWeakMap : public gin_helper::Wrappable<KeyWeakMap<K>> {
@@ -59,8 +57,6 @@ class KeyWeakMap : public gin_helper::Wrappable<KeyWeakMap<K>> {
   electron::KeyWeakMap<K> key_weak_map_;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_COMMON_API_ELECTRON_API_KEY_WEAK_MAP_H_

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -48,9 +48,7 @@
 #include "ui/gfx/icon_util.h"
 #endif
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 namespace {
 
@@ -627,9 +625,7 @@ const char* NativeImage::GetTypeName() {
 // static
 gin::WrapperInfo NativeImage::kWrapperInfo = {gin::kEmbedderNativeGin};
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 namespace {
 

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -40,9 +40,7 @@ namespace gin {
 class Arguments;
 }
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class NativeImage : public gin::Wrappable<NativeImage> {
  public:
@@ -140,8 +138,6 @@ class NativeImage : public gin::Wrappable<NativeImage> {
   int32_t memory_usage_ = 0;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_COMMON_API_ELECTRON_API_NATIVE_IMAGE_H_

--- a/shell/common/api/electron_api_native_image_mac.mm
+++ b/shell/common/api/electron_api_native_image_mac.mm
@@ -23,9 +23,7 @@
 #include "ui/gfx/image/image_skia.h"
 #include "ui/gfx/image/image_skia_operations.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 NSData* bufferFromNSImage(NSImage* image) {
   CGImageRef ref = [image CGImageForProposedRect:nil context:nil hints:nil];
@@ -183,6 +181,4 @@ bool NativeImage::IsTemplateImage() {
   return [image_.AsNSImage() isTemplate];
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/common/api/electron_api_native_image_win.cc
+++ b/shell/common/api/electron_api_native_image_win.cc
@@ -17,9 +17,7 @@
 #include "ui/gfx/icon_util.h"
 #include "ui/gfx/image/image_skia.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 // static
 v8::Local<v8::Promise> NativeImage::CreateThumbnailFromPath(
@@ -102,6 +100,4 @@ v8::Local<v8::Promise> NativeImage::CreateThumbnailFromPath(
   return handle;
 }
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/common/crash_keys.cc
+++ b/shell/common/crash_keys.cc
@@ -23,9 +23,7 @@
 #include "shell/common/process_util.h"
 #include "third_party/crashpad/crashpad/client/annotation.h"
 
-namespace electron {
-
-namespace crash_keys {
+namespace electron::crash_keys {
 
 namespace {
 
@@ -167,6 +165,4 @@ void SetPlatformCrashKey() {
 #endif
 }
 
-}  // namespace crash_keys
-
-}  // namespace electron
+}  // namespace electron::crash_keys

--- a/shell/common/crash_keys.h
+++ b/shell/common/crash_keys.h
@@ -12,9 +12,7 @@ namespace base {
 class CommandLine;
 }
 
-namespace electron {
-
-namespace crash_keys {
+namespace electron::crash_keys {
 
 void SetCrashKey(const std::string& key, const std::string& value);
 void ClearCrashKey(const std::string& key);
@@ -23,8 +21,6 @@ void GetCrashKeys(std::map<std::string, std::string>* keys);
 void SetCrashKeysFromCommandLine(const base::CommandLine& command_line);
 void SetPlatformCrashKey();
 
-}  // namespace crash_keys
-
-}  // namespace electron
+}  // namespace electron::crash_keys
 
 #endif  // ELECTRON_SHELL_COMMON_CRASH_KEYS_H_

--- a/shell/common/gin_helper/event_emitter.cc
+++ b/shell/common/gin_helper/event_emitter.cc
@@ -10,9 +10,7 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 
-namespace gin_helper {
-
-namespace internal {
+namespace gin_helper::internal {
 
 namespace {
 
@@ -75,6 +73,4 @@ v8::Local<v8::Object> CreateNativeEvent(
   return event;
 }
 
-}  // namespace internal
-
-}  // namespace gin_helper
+}  // namespace gin_helper::internal

--- a/shell/common/gin_helper/event_emitter_caller.cc
+++ b/shell/common/gin_helper/event_emitter_caller.cc
@@ -8,9 +8,7 @@
 #include "shell/common/gin_helper/microtasks_scope.h"
 #include "shell/common/node_includes.h"
 
-namespace gin_helper {
-
-namespace internal {
+namespace gin_helper::internal {
 
 v8::Local<v8::Value> CallMethodWithArgs(v8::Isolate* isolate,
                                         v8::Local<v8::Object> obj,
@@ -33,6 +31,4 @@ v8::Local<v8::Value> CallMethodWithArgs(v8::Isolate* isolate,
   return v8::Boolean::New(isolate, false);
 }
 
-}  // namespace internal
-
-}  // namespace gin_helper
+}  // namespace gin_helper::internal

--- a/shell/common/node_util.cc
+++ b/shell/common/node_util.cc
@@ -7,9 +7,7 @@
 #include "base/logging.h"
 #include "shell/common/node_includes.h"
 
-namespace electron {
-
-namespace util {
+namespace electron::util {
 
 v8::MaybeLocal<v8::Value> CompileAndCall(
     v8::Local<v8::Context> context,
@@ -36,6 +34,4 @@ v8::MaybeLocal<v8::Value> CompileAndCall(
   return ret;
 }
 
-}  // namespace util
-
-}  // namespace electron
+}  // namespace electron::util

--- a/shell/common/node_util.h
+++ b/shell/common/node_util.h
@@ -13,9 +13,7 @@ namespace node {
 class Environment;
 }
 
-namespace electron {
-
-namespace util {
+namespace electron::util {
 
 // Run a script with JS source bundled inside the binary as if it's wrapped
 // in a function called with a null receiver and arguments specified in C++.
@@ -29,8 +27,6 @@ v8::MaybeLocal<v8::Value> CompileAndCall(
     std::vector<v8::Local<v8::Value>>* arguments,
     node::Environment* optional_env);
 
-}  // namespace util
-
-}  // namespace electron
+}  // namespace electron::util
 
 #endif  // ELECTRON_SHELL_COMMON_NODE_UTIL_H_

--- a/shell/common/platform_util_internal.h
+++ b/shell/common/platform_util_internal.h
@@ -13,14 +13,12 @@ namespace base {
 class FilePath;
 }
 
-namespace platform_util {
-namespace internal {
+namespace platform_util::internal {
 
 // Called by platform_util.cc on to invoke platform specific logic to move
 // |path| to trash using a suitable handler.
 bool PlatformTrashItem(const base::FilePath& path, std::string* error);
 
-}  // namespace internal
-}  // namespace platform_util
+}  // namespace platform_util::internal
 
 #endif  // ELECTRON_SHELL_COMMON_PLATFORM_UTIL_INTERNAL_H_

--- a/shell/common/skia_util.cc
+++ b/shell/common/skia_util.cc
@@ -28,9 +28,7 @@
 #include "ui/gfx/icon_util.h"
 #endif
 
-namespace electron {
-
-namespace util {
+namespace electron::util {
 
 struct ScaleFactorPair {
   const char* name;
@@ -164,6 +162,4 @@ bool ReadImageSkiaFromICO(gfx::ImageSkia* image, HICON icon) {
 }
 #endif
 
-}  // namespace util
-
-}  // namespace electron
+}  // namespace electron::util

--- a/shell/common/skia_util.h
+++ b/shell/common/skia_util.h
@@ -13,9 +13,7 @@ namespace gfx {
 class ImageSkia;
 }
 
-namespace electron {
-
-namespace util {
+namespace electron::util {
 
 bool PopulateImageSkiaRepsFromPath(gfx::ImageSkia* image,
                                    const base::FilePath& path);
@@ -41,8 +39,6 @@ bool AddImageSkiaRepFromPNG(gfx::ImageSkia* image,
 bool ReadImageSkiaFromICO(gfx::ImageSkia* image, HICON icon);
 #endif
 
-}  // namespace util
-
-}  // namespace electron
+}  // namespace electron::util
 
 #endif  // ELECTRON_SHELL_COMMON_SKIA_UTIL_H_

--- a/shell/renderer/api/context_bridge/object_cache.cc
+++ b/shell/renderer/api/context_bridge/object_cache.cc
@@ -8,11 +8,7 @@
 
 #include "shell/common/api/object_life_monitor.h"
 
-namespace electron {
-
-namespace api {
-
-namespace context_bridge {
+namespace electron::api::context_bridge {
 
 ObjectCache::ObjectCache() = default;
 ObjectCache::~ObjectCache() = default;
@@ -50,8 +46,4 @@ v8::MaybeLocal<v8::Value> ObjectCache::GetCachedProxiedObject(
   return v8::MaybeLocal<v8::Value>();
 }
 
-}  // namespace context_bridge
-
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api::context_bridge

--- a/shell/renderer/api/context_bridge/object_cache.h
+++ b/shell/renderer/api/context_bridge/object_cache.h
@@ -15,11 +15,7 @@
 #include "shell/renderer/electron_render_frame_observer.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 
-namespace electron {
-
-namespace api {
-
-namespace context_bridge {
+namespace electron::api::context_bridge {
 
 using ObjectCachePair = std::pair<v8::Local<v8::Value>, v8::Local<v8::Value>>;
 
@@ -38,10 +34,6 @@ class ObjectCache final {
   std::unordered_map<int, std::forward_list<ObjectCachePair>> proxy_map_;
 };
 
-}  // namespace context_bridge
-
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api::context_bridge
 
 #endif  // ELECTRON_SHELL_RENDERER_API_CONTEXT_BRIDGE_OBJECT_CACHE_H_

--- a/shell/renderer/api/electron_api_context_bridge.h
+++ b/shell/renderer/api/electron_api_context_bridge.h
@@ -12,9 +12,7 @@ namespace gin_helper {
 class Arguments;
 }
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 void ProxyFunctionWrapper(const v8::FunctionCallbackInfo<v8::Value>& info);
 
@@ -51,8 +49,6 @@ v8::MaybeLocal<v8::Object> CreateProxyForAPI(
     bool support_dynamic_properties,
     int recursion_depth);
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_RENDERER_API_ELECTRON_API_CONTEXT_BRIDGE_H_

--- a/shell/renderer/api/electron_api_spell_check_client.cc
+++ b/shell/renderer/api/electron_api_spell_check_client.cc
@@ -22,9 +22,7 @@
 #include "third_party/blink/public/web/web_text_checking_result.h"
 #include "third_party/icu/source/common/unicode/uscript.h"
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 namespace {
 
@@ -275,6 +273,4 @@ SpellCheckClient::SpellCheckScope::SpellCheckScope(
 
 SpellCheckClient::SpellCheckScope::~SpellCheckScope() = default;
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api

--- a/shell/renderer/api/electron_api_spell_check_client.h
+++ b/shell/renderer/api/electron_api_spell_check_client.h
@@ -23,9 +23,7 @@ struct WebTextCheckingResult;
 class WebTextCheckingCompletion;
 }  // namespace blink
 
-namespace electron {
-
-namespace api {
+namespace electron::api {
 
 class SpellCheckClient : public blink::WebSpellCheckPanelHostClient,
                          public blink::WebTextCheckClient,
@@ -109,8 +107,6 @@ class SpellCheckClient : public blink::WebSpellCheckPanelHostClient,
   v8::Global<v8::Function> spell_check_;
 };
 
-}  // namespace api
-
-}  // namespace electron
+}  // namespace electron::api
 
 #endif  // ELECTRON_SHELL_RENDERER_API_ELECTRON_API_SPELL_CHECK_CLIENT_H_


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

C++17 brought nested namespaces, and [the Chromium folks have adopted them](https://groups.google.com/a/chromium.org/g/cxx/c/gLdR3apDSmg/). Let's use them as well.

Pros:
* Fewer boilerplate lines of code in the codebase
* Easier to search namespaces like "namespace electron::api"

Cons:
* You will occasionally have to unnest a namespace if you're going to for example put a forward include for "namespace electron" inside an existing "namespace electron::api"

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
