### PR TITLE
fix: `<datalist>` bounds vertical cutoff

### DIFF
--- a/shell/browser/ui/views/autofill_popup_view.cc
+++ b/shell/browser/ui/views/autofill_popup_view.cc
@@ -174,7 +174,7 @@ void AutofillPopupView::DrawAutofillEntry(gfx::Canvas* canvas,
   const int text_align =
       is_rtl ? gfx::Canvas::TEXT_ALIGN_RIGHT : gfx::Canvas::TEXT_ALIGN_LEFT;
   gfx::Rect value_rect = entry_rect;
-  value_rect.Inset(gfx::Insets::VH(kEndPadding, 0));
+  value_rect.Inset(gfx::Insets::VH(0, kEndPadding));
 
   int x_align_left = value_rect.x();
   const int value_width = gfx::GetStringWidth(


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/34750.
Refs CL:3560843

Fixes an issue where DataList bounds had part of the item text cut off vertically. This happened in https://github.com/electron/electron/pull/33556 when we switched from the mult-parameter form of `gfx::Insets`, since the horizontal and vertical parameters switched and we didn't catch it.

Tested with https://gist.github.com/1525a4d39d33bc46eb033af6ebcf51c1.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where DataList bounds had part of the item text cut off vertically. 
