### PR TITLE
fix: handle null/undefined options for fs.readdir

### DIFF
--- a/lib/asar/fs-wrapper.ts
+++ b/lib/asar/fs-wrapper.ts
@@ -646,7 +646,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       return;
     }
 
-    if (options && options.withFileTypes) {
+    if (options?.withFileTypes) {
       const dirents = [];
       for (const file of files) {
         const childPath = path.join(filePath, file);

--- a/lib/asar/fs-wrapper.ts
+++ b/lib/asar/fs-wrapper.ts
@@ -623,11 +623,11 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
   };
 
   const { readdir } = fs;
-  fs.readdir = function (pathArgument: string, options: { encoding?: string | null; withFileTypes?: boolean } = {}, callback?: Function) {
+  fs.readdir = function (pathArgument: string, options?: { encoding?: string | null; withFileTypes?: boolean } | null, callback?: Function) {
     const pathInfo = splitPath(pathArgument);
     if (typeof options === 'function') {
       callback = options;
-      options = {};
+      options = undefined;
     }
     if (!pathInfo.isAsar) return readdir.apply(this, arguments);
     const { asarPath, filePath } = pathInfo;
@@ -646,7 +646,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       return;
     }
 
-    if (options.withFileTypes) {
+    if (options && options.withFileTypes) {
       const dirents = [];
       for (const file of files) {
         const childPath = path.join(filePath, file);

--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -965,6 +965,32 @@ describe('asar package', function () {
         const err = await new Promise<any>(resolve => fs.readdir(p, resolve));
         expect(err.code).to.equal('ENOENT');
       });
+
+      it('handles null for options', function (done) {
+        const p = path.join(asarDir, 'a.asar', 'dir1');
+        fs.readdir(p, null, function (err, dirs) {
+          try {
+            expect(err).to.be.null();
+            expect(dirs).to.deep.equal(['file1', 'file2', 'file3', 'link1', 'link2']);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+      });
+
+      it('handles undefined for options', function (done) {
+        const p = path.join(asarDir, 'a.asar', 'dir1');
+        fs.readdir(p, undefined, function (err, dirs) {
+          try {
+            expect(err).to.be.null();
+            expect(dirs).to.deep.equal(['file1', 'file2', 'file3', 'link1', 'link2']);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+      });
     });
 
     describe('fs.promises.readdir', function () {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Fixes https://github.com/isaacs/node-graceful-fs/issues/223 in Electron. I also have a PR on that repo to improve their behavior (which would also fix the issue), so I'm fixing it from all angles.

This moves `fs.readdir` slightly closer to the typings from Node, but there's still other issues (`options` could be a string). I plan on doing a more general improvement PR to fix up behavior in `lib/asar/fs-wrapper.ts`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an error when fs.readdir gets null for options<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
