### PR TITLE
fix: alwaysOnTop browser window option for X11 Linux

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -495,6 +495,13 @@ void NativeWindowViews::Show() {
   if (global_menu_bar_)
     global_menu_bar_->OnWindowMapped();
 #endif
+
+#if defined(USE_OZONE_PLATFORM_X11)
+  // On X11, setting Z order before showing the window doesn't take effect,
+  // so we have to call it again.
+  if (IsX11())
+    widget()->SetZOrderLevel(widget()->GetZOrderLevel());
+#endif
 }
 
 void NativeWindowViews::ShowInactive() {


### PR DESCRIPTION
#### Description of Change

Fixes #32889

On X11 when alwaysOnTop was set as a browser window preference, it got applied to the window before showing it. While that set the z-index of the window in X11, it didn't take effect, it just behaved as a window without alwaysOnTop.

This was working correctly prior to Electron 16, but not ever since. No idea why it broke, didn't find any trace for it.

#### Checklist

- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix alwaysOnTop BrowserWindow option for X11 Linux