### PR TITLE
fix: WCO pressed background state updates

### DIFF
--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -11,6 +11,7 @@
 #include "shell/browser/browser.h"
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/ui/views/root_view.h"
+#include "shell/browser/ui/views/win_frame_view.h"
 #include "shell/common/electron_constants.h"
 #include "ui/display/display.h"
 #include "ui/display/win/screen_win.h"
@@ -421,7 +422,7 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
       }
       break;
     }
-    case SIZE_RESTORED:
+    case SIZE_RESTORED: {
       switch (last_window_state_) {
         case ui::SHOW_STATE_MAXIMIZED:
           last_window_state_ = ui::SHOW_STATE_NORMAL;
@@ -439,7 +440,15 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
         default:
           break;
       }
+      // If a given window was minimized/maximized and has since been
+      // restored, ensure the WCO buttons are set to normal state.
+      auto* ncv = widget()->non_client_view();
+      if (IsWindowControlsOverlayEnabled() && ncv) {
+        auto* frame_view = static_cast<WinFrameView*>(ncv->frame_view());
+        frame_view->caption_button_container()->ResetWindowControls();
+      }
       break;
+    }
   }
 }
 

--- a/shell/browser/ui/views/win_caption_button_container.h
+++ b/shell/browser/ui/views/win_caption_button_container.h
@@ -46,6 +46,9 @@ class WinCaptionButtonContainer : public views::View,
   // time, and both are disabled in tablet UI mode.
   void UpdateButtons();
 
+  // Reset window button states to STATE_NORMAL.
+  void ResetWindowControls();
+
  private:
   // views::View:
   void AddedToWidget() override;
@@ -54,8 +57,6 @@ class WinCaptionButtonContainer : public views::View,
   // views::WidgetObserver:
   void OnWidgetBoundsChanged(views::Widget* widget,
                              const gfx::Rect& new_bounds) override;
-
-  void ResetWindowControls();
 
   WinFrameView* const frame_view_;
   WinCaptionButton* const minimize_button_;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/34763.

When a window with WCO is restored after the minimize button is clicked, the button was left in the `STATE_HOVERED` state. This meant that when the user restored (unminimized) the window, the button was incorrectly left painted as though the user was still hovered over it, and could only fix this by once again hovering over the button and then moving off of it. This issue is fixed by ensuring that windows controls are reset when the window is restored, since the buttons could neither be pressed or hovered over as that is occurring by the nature of the event taking place.

Tested by adding:

```js
titleBarStyle: 'hidden',
    titleBarOverlay: {
      color: '#2f3241',
      symbolColor: '#74b1be',
      height: 60
    }
```

to the BrowserWindow ctor options of the default Fiddle.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the minimize button with WCO enabled would incorrectly be highlighted in some cases.