### PR TITLE
docs: document the removal of IA32 Linux support

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -98,7 +98,10 @@ is the origin that is checking for device permission.
 
 ## Planned Breaking API Changes (19.0)
 
-None
+### Removed: IA32 Linux binaries
+
+This is a result of Chromium 102.0.4999.0 dropping support for IA32 Linux.
+This concludes the [removal of support for IA32 Linux](#removed-ia32-linux-support).
 
 ## Planned Breaking API Changes (18.0)
 
@@ -1264,6 +1267,10 @@ the module's `binding.gyp` must be true (which is the default). If this hook is
 not present, then the native module will fail to load on Windows, with an error
 message like `Cannot find module`. See the [native module
 guide](/docs/tutorial/using-native-node-modules.md) for more.
+
+### Removed: IA32 Linux support
+
+See - [Discontinuing support for 32-bit Linux](https://www.electronjs.org/blog/linux-32bit-support).
 
 ## Breaking API Changes (3.0)
 

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -1270,7 +1270,7 @@ guide](/docs/tutorial/using-native-node-modules.md) for more.
 
 ### Removed: IA32 Linux support
 
-See - [Discontinuing support for 32-bit Linux](https://www.electronjs.org/blog/linux-32bit-support).
+Electron 18 will no longer run on 32-bit Linux systems. See [discontinuing support for 32-bit Linux](https://www.electronjs.org/blog/linux-32bit-support) for more information.
 
 ## Breaking API Changes (3.0)
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Chromium had dropped support for IA32 Linux, so the Chromium
102.0.4999.0 upgrade PR, https://github.com/electron/electron/pull/33731, had introduced the commit,
https://github.com/electron/electron/pull/33731/commits/389ef0731efca802db2089486ad6d9a91cc02ba8, to drop support for IA32 Linux but the change landed
without an addition to the documentation for the breaking changes,
so this PR adds that.

Closes: https://github.com/electron/electron/issues/34783
Refs: https://bugs.chromium.org/p/chromium/issues/detail?id=1194538
Signed-off-by: Darshan Sen <raisinten@gmail.com>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
