### PR TITLE
build: remove appveyor hook to defunct service

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,16 +34,6 @@ environment:
   MOCHA_REPORTER: mocha-multi-reporters
   MOCHA_MULTI_REPORTERS: mocha-appveyor-reporter, tap
   GOMA_FALLBACK_ON_AUTH_FAILURE: true
-notifications:
-  - provider: Webhook
-    url: https://electron-mission-control.herokuapp.com/rest/appveyor-hook
-    method: POST
-    headers:
-      x-mission-control-secret:
-        secure: 90BLVPcqhJPG7d24v0q/RRray6W3wDQ8uVQlQjOHaBWkw1i8FoA1lsjr2C/v1dVok+tS2Pi6KxDctPUkwIb4T27u4RhvmcPzQhVpfwVJAG9oNtq+yKN7vzHfg7k/pojEzVdJpQLzeJGcSrZu7VY39Q==
-    on_build_success: false
-    on_build_failure: true
-    on_build_status_changed: false
 build_script:
   - ps: >-
       if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {


### PR DESCRIPTION
#### Description of Change

Remove defunct webhook notification from Appveyor config.

See [example failure](https://ci.appveyor.com/project/electron-bot/electron-ia32-testing/builds/44003410):
> Error sending Webhook notification: Error calling webhook https://electron-mission-control.herokuapp.com/rest/appveyor-hook: Response status code does not indicate success: 404 (Not Found).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none