### PR TITLE
fix: update Windows caption buttons to match Win11 style

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -85,6 +85,8 @@ filenames = {
     "shell/browser/ui/message_box_win.cc",
     "shell/browser/ui/tray_icon_win.cc",
     "shell/browser/ui/views/electron_views_delegate_win.cc",
+    "shell/browser/ui/views/win_icon_painter.cc",
+    "shell/browser/ui/views/win_icon_painter.h",
     "shell/browser/ui/views/win_frame_view.cc",
     "shell/browser/ui/views/win_frame_view.h",
     "shell/browser/ui/views/win_caption_button.cc",

--- a/shell/browser/ui/views/win_caption_button.h
+++ b/shell/browser/ui/views/win_caption_button.h
@@ -7,8 +7,11 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_VIEWS_WIN_CAPTION_BUTTON_H_
 #define ELECTRON_SHELL_BROWSER_UI_VIEWS_WIN_CAPTION_BUTTON_H_
 
+#include <memory>
+
 #include "chrome/browser/ui/frame/window_frame_util.h"
 #include "chrome/browser/ui/view_ids.h"
+#include "shell/browser/ui/views/win_icon_painter.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 #include "ui/gfx/canvas.h"
 #include "ui/views/controls/button/button.h"
@@ -23,6 +26,8 @@ class WinCaptionButton : public views::Button {
                    WinFrameView* frame_view,
                    ViewID button_type,
                    const std::u16string& accessible_name);
+  ~WinCaptionButton() override;
+
   WinCaptionButton(const WinCaptionButton&) = delete;
   WinCaptionButton& operator=(const WinCaptionButton&) = delete;
 
@@ -35,6 +40,7 @@ class WinCaptionButton : public views::Button {
   void SetSize(gfx::Size size);
 
  private:
+  std::unique_ptr<WinIconPainter> CreateIconPainter();
   // Returns the amount we should visually reserve on the left (right in RTL)
   // for spacing between buttons. We do this instead of repositioning the
   // buttons to avoid the sliver of deadspace that would result.
@@ -53,6 +59,7 @@ class WinCaptionButton : public views::Button {
   void PaintSymbol(gfx::Canvas* canvas);
 
   WinFrameView* frame_view_;
+  std::unique_ptr<WinIconPainter> icon_painter_;
   ViewID button_type_;
 
   int base_width_ = WindowFrameUtil::kWindows10GlassCaptionButtonWidth;

--- a/shell/browser/ui/views/win_icon_painter.cc
+++ b/shell/browser/ui/views/win_icon_painter.cc
@@ -1,0 +1,135 @@
+// Copyright (c) 2022 Microsoft, Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/ui/views/win_icon_painter.h"
+
+#include "base/numerics/safe_conversions.h"
+#include "ui/gfx/color_utils.h"
+#include "ui/gfx/geometry/rect_conversions.h"
+#include "ui/gfx/geometry/skia_conversions.h"
+#include "ui/gfx/scoped_canvas.h"
+
+namespace {
+
+// Canvas::DrawRect's stroke can bleed out of |rect|'s bounds, so this draws a
+// rectangle inset such that the result is constrained to |rect|'s size.
+void DrawRect(gfx::Canvas* canvas,
+              const gfx::Rect& rect,
+              const cc::PaintFlags& flags) {
+  gfx::RectF rect_f(rect);
+  float stroke_half_width = flags.getStrokeWidth() / 2;
+  rect_f.Inset(stroke_half_width);
+  canvas->DrawRect(rect_f, flags);
+}
+
+void DrawRoundRect(gfx::Canvas* canvas,
+                   const gfx::Rect& rect,
+                   int radius,
+                   const cc::PaintFlags& flags) {
+  gfx::RectF rect_f(rect);
+  float stroke_half_width = flags.getStrokeWidth() / 2;
+  rect_f.Inset(stroke_half_width);
+  canvas->DrawRoundRect(rect_f, radius, flags);
+}
+
+// Draws a path containing the top and right edges of a rounded rectangle.
+void DrawRoundRectEdges(gfx::Canvas* canvas,
+                        const gfx::Rect& rect,
+                        float radius,
+                        const cc::PaintFlags& flags) {
+  gfx::RectF symbol_rect_f(rect);
+  float stroke_half_width = flags.getStrokeWidth() / 2;
+  symbol_rect_f.Inset(stroke_half_width);
+  SkPath path;
+  path.moveTo(symbol_rect_f.x(), symbol_rect_f.y());
+  path.arcTo(symbol_rect_f.right(), symbol_rect_f.y(), symbol_rect_f.right(),
+             symbol_rect_f.y() + radius, radius);
+  path.lineTo(symbol_rect_f.right(), symbol_rect_f.bottom());
+  canvas->DrawPath(path, flags);
+}
+
+}  // namespace
+
+namespace electron {
+
+WinIconPainter::WinIconPainter() = default;
+WinIconPainter::~WinIconPainter() = default;
+
+void WinIconPainter::PaintMinimizeIcon(gfx::Canvas* canvas,
+                                       const gfx::Rect& symbol_rect,
+                                       const cc::PaintFlags& flags) {
+  const int y = symbol_rect.CenterPoint().y();
+  const gfx::Point p1 = gfx::Point(symbol_rect.x(), y);
+  const gfx::Point p2 = gfx::Point(symbol_rect.right(), y);
+  canvas->DrawLine(p1, p2, flags);
+}
+
+void WinIconPainter::PaintMaximizeIcon(gfx::Canvas* canvas,
+                                       const gfx::Rect& symbol_rect,
+                                       const cc::PaintFlags& flags) {
+  DrawRect(canvas, symbol_rect, flags);
+}
+
+void WinIconPainter::PaintRestoreIcon(gfx::Canvas* canvas,
+                                      const gfx::Rect& symbol_rect,
+                                      const cc::PaintFlags& flags) {
+  const int separation = std::floor(2 * canvas->image_scale());
+  symbol_rect.Inset(gfx::Insets::TLBR(separation, 0, 0, separation));
+
+  // Bottom left ("in front") square.
+  DrawRect(canvas, symbol_rect, flags);
+
+  // Top right ("behind") square.
+  canvas->ClipRect(symbol_rect, SkClipOp::kDifference);
+  symbol_rect.Offset(separation, -separation);
+  DrawRect(canvas, symbol_rect, flags);
+}
+
+void WinIconPainter::PaintCloseIcon(gfx::Canvas* canvas,
+                                    const gfx::Rect& symbol_rect,
+                                    const cc::PaintFlags& flags) {
+  // TODO(bsep): This sometimes draws misaligned at fractional device scales
+  // because the button's origin isn't necessarily aligned to pixels.
+  flags.setAntiAlias(true);
+  canvas->ClipRect(symbol_rect);
+  SkPath path;
+  path.moveTo(symbol_rect.x(), symbol_rect.y());
+  path.lineTo(symbol_rect.right(), symbol_rect.bottom());
+  path.moveTo(symbol_rect.right(), symbol_rect.y());
+  path.lineTo(symbol_rect.x(), symbol_rect.bottom());
+  canvas->DrawPath(path, flags);
+}
+
+Win11IconPainter::Win11IconPainter() = default;
+Win11IconPainter::~Win11IconPainter() = default;
+
+void Win11IconPainter::PaintMaximizeIcon(gfx::Canvas* canvas,
+                                         const gfx::Rect& symbol_rect,
+                                         const cc::PaintFlags& flags) {
+  flags.setAntiAlias(true);
+  const float corner_radius = 2 * canvas->image_scale();
+  DrawRoundRect(canvas, symbol_rect, corner_radius, flags);
+}
+
+void Win11IconPainter::PaintRestoreIcon(gfx::Canvas* canvas,
+                                        const gfx::Rect& symbol_rect,
+                                        const cc::PaintFlags& flags) {
+  const int separation = std::floor(2 * canvas->image_scale());
+  symbol_rect.Inset(gfx::Insets::TLBR(separation, 0, 0, separation));
+
+  flags.setAntiAlias(true);
+  // Bottom left ("in front") rounded square.
+  const float bottom_rect_radius = 1 * canvas->image_scale();
+  DrawRoundRect(canvas, symbol_rect, bottom_rect_radius, flags);
+
+  // Top right ("behind") top+right edges of rounded square (2.5x).
+  symbol_rect.Offset(separation, -separation);
+  // Apply inset to left+bottom edges since we don't draw arcs for those edges
+  constexpr int top_rect_inset = 1;
+  symbol_rect.Inset(gfx::Insets::TLBR(0, top_rect_inset, top_rect_inset, 0));
+
+  const float top_rect_radius = 2.5f * canvas->image_scale();
+  DrawRoundRectEdges(canvas, symbol_rect, top_rect_radius, flags);
+}
+}  // namespace electron

--- a/shell/browser/ui/views/win_icon_painter.cc
+++ b/shell/browser/ui/views/win_icon_painter.cc
@@ -75,15 +75,16 @@ void WinIconPainter::PaintRestoreIcon(gfx::Canvas* canvas,
                                       const gfx::Rect& symbol_rect,
                                       const cc::PaintFlags& flags) {
   const int separation = std::floor(2 * canvas->image_scale());
-  symbol_rect.Inset(gfx::Insets::TLBR(separation, 0, 0, separation));
+  gfx::Rect icon_rect = symbol_rect;
+  icon_rect.Inset(gfx::Insets::TLBR(separation, 0, 0, separation));
 
   // Bottom left ("in front") square.
-  DrawRect(canvas, symbol_rect, flags);
+  DrawRect(canvas, icon_rect, flags);
 
   // Top right ("behind") square.
-  canvas->ClipRect(symbol_rect, SkClipOp::kDifference);
-  symbol_rect.Offset(separation, -separation);
-  DrawRect(canvas, symbol_rect, flags);
+  canvas->ClipRect(icon_rect, SkClipOp::kDifference);
+  icon_rect.Offset(separation, -separation);
+  DrawRect(canvas, icon_rect, flags);
 }
 
 void WinIconPainter::PaintCloseIcon(gfx::Canvas* canvas,
@@ -91,7 +92,9 @@ void WinIconPainter::PaintCloseIcon(gfx::Canvas* canvas,
                                     const cc::PaintFlags& flags) {
   // TODO(bsep): This sometimes draws misaligned at fractional device scales
   // because the button's origin isn't necessarily aligned to pixels.
-  flags.setAntiAlias(true);
+  cc::PaintFlags paint_flags = flags;
+  paint_flags.setAntiAlias(true);
+
   canvas->ClipRect(symbol_rect);
   SkPath path;
   path.moveTo(symbol_rect.x(), symbol_rect.y());
@@ -107,7 +110,9 @@ Win11IconPainter::~Win11IconPainter() = default;
 void Win11IconPainter::PaintMaximizeIcon(gfx::Canvas* canvas,
                                          const gfx::Rect& symbol_rect,
                                          const cc::PaintFlags& flags) {
-  flags.setAntiAlias(true);
+  cc::PaintFlags paint_flags = flags;
+  paint_flags.setAntiAlias(true);
+
   const float corner_radius = 2 * canvas->image_scale();
   DrawRoundRect(canvas, symbol_rect, corner_radius, flags);
 }
@@ -116,20 +121,23 @@ void Win11IconPainter::PaintRestoreIcon(gfx::Canvas* canvas,
                                         const gfx::Rect& symbol_rect,
                                         const cc::PaintFlags& flags) {
   const int separation = std::floor(2 * canvas->image_scale());
-  symbol_rect.Inset(gfx::Insets::TLBR(separation, 0, 0, separation));
+  gfx::Rect icon_rect = symbol_rect;
+  icon_rect.Inset(gfx::Insets::TLBR(separation, 0, 0, separation));
 
-  flags.setAntiAlias(true);
+  cc::PaintFlags paint_flags = flags;
+  paint_flags.setAntiAlias(true);
+
   // Bottom left ("in front") rounded square.
   const float bottom_rect_radius = 1 * canvas->image_scale();
-  DrawRoundRect(canvas, symbol_rect, bottom_rect_radius, flags);
+  DrawRoundRect(canvas, icon_rect, bottom_rect_radius, flags);
 
   // Top right ("behind") top+right edges of rounded square (2.5x).
-  symbol_rect.Offset(separation, -separation);
+  icon_rect.Offset(separation, -separation);
   // Apply inset to left+bottom edges since we don't draw arcs for those edges
   constexpr int top_rect_inset = 1;
-  symbol_rect.Inset(gfx::Insets::TLBR(0, top_rect_inset, top_rect_inset, 0));
+  icon_rect.Inset(gfx::Insets::TLBR(0, top_rect_inset, top_rect_inset, 0));
 
   const float top_rect_radius = 2.5f * canvas->image_scale();
-  DrawRoundRectEdges(canvas, symbol_rect, top_rect_radius, flags);
+  DrawRoundRectEdges(canvas, icon_rect, top_rect_radius, flags);
 }
 }  // namespace electron

--- a/shell/browser/ui/views/win_icon_painter.h
+++ b/shell/browser/ui/views/win_icon_painter.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2022 Microsoft, Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_BROWSER_UI_VIEWS_WIN_ICON_PAINTER_H_
+#define ELECTRON_SHELL_BROWSER_UI_VIEWS_WIN_ICON_PAINTER_H_
+
+#include "base/memory/raw_ptr.h"
+#include "ui/gfx/canvas.h"
+
+namespace electron {
+
+class WinIconPainter {
+ public:
+  WinIconPainter();
+  virtual ~WinIconPainter();
+
+  WinIconPainter(const WinIconPainter&) = delete;
+  WinIconPainter& operator=(const WinIconPainter&) = delete;
+
+ public:
+  // Paints the minimize icon for the button
+  virtual void PaintMinimizeIcon(gfx::Canvas* canvas,
+                                 const gfx::Rect& symbol_rect,
+                                 const cc::PaintFlags& flags);
+
+  // Paints the maximize icon for the button
+  virtual void PaintMaximizeIcon(gfx::Canvas* canvas,
+                                 const gfx::Rect& symbol_rect,
+                                 const cc::PaintFlags& flags);
+
+  // Paints the restore icon for the button
+  virtual void PaintRestoreIcon(gfx::Canvas* canvas,
+                                const gfx::Rect& symbol_rect,
+                                const cc::PaintFlags& flags);
+
+  // Paints the close icon for the button
+  virtual void PaintCloseIcon(gfx::Canvas* canvas,
+                              const gfx::Rect& symbol_rect,
+                              const cc::PaintFlags& flags);
+};
+
+class Win11IconPainter : public WinIconPainter {
+ public:
+  Win11IconPainter();
+  ~Win11IconPainter() override;
+
+  Win11IconPainter(const Win11IconPainter&) = delete;
+  Win11IconPainter& operator=(const Win11IconPainter&) = delete;
+
+ public:
+  // Paints the maximize icon for the button
+  void PaintMaximizeIcon(gfx::Canvas* canvas,
+                         const gfx::Rect& symbol_rect,
+                         const cc::PaintFlags& flags) override;
+
+  // Paints the restore icon for the button
+  void PaintRestoreIcon(gfx::Canvas* canvas,
+                        const gfx::Rect& symbol_rect,
+                        const cc::PaintFlags& flags) override;
+};
+}  // namespace electron
+
+#endif  // ELECTRON_SHELL_BROWSER_UI_VIEWS_WIN_ICON_PAINTER_H_


### PR DESCRIPTION
#### Description of Change

Refs CL:3674580

This PR updates WCO restore and maximize buttons to match Windows 11 design. It also refactors out the functionality into its own file, as the above CL does, to make it more maintainable an extensible

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Updated Windows Control Overlay buttons to look and feel more native on Windows 11.
