### PR TITLE
fix: merge crash annotations instead of overwriting

### DIFF
--- a/shell/app/electron_crash_reporter_client.cc
+++ b/shell/app/electron_crash_reporter_client.cc
@@ -190,7 +190,9 @@ bool ElectronCrashReporterClient::GetShouldCompressUploads() {
 
 void ElectronCrashReporterClient::GetProcessSimpleAnnotations(
     std::map<std::string, std::string>* annotations) {
-  *annotations = global_annotations_;
+  for (auto&& pair : global_annotations_) {
+    (*annotations)[pair.first] = pair.second;
+  }
   (*annotations)["prod"] = ELECTRON_PRODUCT_NAME;
   (*annotations)["ver"] = ELECTRON_VERSION_STRING;
 }


### PR DESCRIPTION
ElectronCrashReporterClient::GetProcessSimpleAnnotations() merges
annotations provided as argument with global_annotations_,
preserving useful information.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: more crash annotations preserved
