### PR TITLE
fix: Add port / user information to standard schemes

### DIFF
--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -111,7 +111,7 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
     if (custom_scheme.options.standard) {
       auto* policy = content::ChildProcessSecurityPolicy::GetInstance();
       url::AddStandardScheme(custom_scheme.scheme.c_str(),
-                             url::SCHEME_WITH_HOST);
+                             url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION);
       g_standard_schemes.push_back(custom_scheme.scheme);
       policy->RegisterWebSafeScheme(custom_scheme.scheme);
     }

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -157,7 +157,7 @@ RendererClientBase::RendererClientBase() {
   std::vector<std::string> standard_schemes_list =
       ParseSchemesCLISwitch(command_line, switches::kStandardSchemes);
   for (const std::string& scheme : standard_schemes_list)
-    url::AddStandardScheme(scheme.c_str(), url::SCHEME_WITH_HOST);
+    url::AddStandardScheme(scheme.c_str(), url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION);
   // Parse --cors-schemes=scheme1,scheme2
   std::vector<std::string> cors_schemes_list =
       ParseSchemesCLISwitch(command_line, switches::kCORSSchemes);

--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -743,7 +743,6 @@ describe('protocol module', () => {
       const portScheme = (global as any).portScheme;
       const u = portScheme + '://fake-host:8080/';
       registerStringProtocol(portScheme, (request, callback) => {
-        console.log(request);
         if (request.url === u) {
           callback('<script>function ajax(url) { return fetch(url).then(res => res.text()) }</script>');
         } else {

--- a/spec-main/index.js
+++ b/spec-main/index.js
@@ -36,10 +36,12 @@ app.commandLine.appendSwitch('host-rules', 'MAP localhost2 127.0.0.1');
 
 global.standardScheme = 'app';
 global.zoomScheme = 'zoom';
+global.portScheme = 'port';
 global.serviceWorkerScheme = 'sw';
 protocol.registerSchemesAsPrivileged([
   { scheme: global.standardScheme, privileges: { standard: true, secure: true, stream: false } },
   { scheme: global.zoomScheme, privileges: { standard: true, secure: true } },
+  { scheme: global.portScheme, privileges: { standard: true, secure: true, supportFetchAPI: true } },
   { scheme: global.serviceWorkerScheme, privileges: { allowServiceWorkers: true, standard: true, secure: true } },
   { scheme: 'cors-blob', privileges: { corsEnabled: true, supportFetchAPI: true } },
   { scheme: 'cors', privileges: { corsEnabled: true, supportFetchAPI: true } },


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

This is my second attempt at adding port/user information when registering standard schemes which fixes https://github.com/electron/electron/issues/24725

First attempt here: https://github.com/electron/electron/pull/26803

This issue was breaking `gemini://` URLs with custom ports, and also makes it impossible to pass in user/password info for protocols.

I've added the test case from the initial PR here: https://github.com/electron/electron/pull/26803#issuecomment-762778446

I think the reason it was failing before was that I hadn't added the change to `AddStandardScheme` within `renderer_client_base.cc`.

Hopefully the CI can run without issues this time. 😅

cc @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Custom protocol schemes can now have ports and user information passed to protocol handlers when they are registered as `standard`.