### PR TITLE
test: add first-party-set chromium tests

### DIFF
--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -495,6 +495,37 @@ describe('chromium features', () => {
     });
   });
 
+  describe('first party sets', () => {
+    const fps = [
+      'https://fps-member1.glitch.me',
+      'https://fps-member2.glitch.me',
+      'https://fps-member3.glitch.me'
+    ];
+
+    it('loads first party sets', async () => {
+      const appPath = path.join(fixturesPath, 'api', 'first-party-sets', 'base');
+      const fpsProcess = ChildProcess.spawn(process.execPath, [appPath]);
+
+      let output = '';
+      fpsProcess.stdout.on('data', data => { output += data; });
+      await emittedOnce(fpsProcess, 'exit');
+
+      expect(output).to.include(fps.join(','));
+    });
+
+    it('loads sets from the command line', async () => {
+      const appPath = path.join(fixturesPath, 'api', 'first-party-sets', 'command-line');
+      const args = [appPath, `--use-first-party-set=${fps}`];
+      const fpsProcess = ChildProcess.spawn(process.execPath, args);
+
+      let output = '';
+      fpsProcess.stdout.on('data', data => { output += data; });
+      await emittedOnce(fpsProcess, 'exit');
+
+      expect(output).to.include(fps.join(','));
+    });
+  });
+
   describe('loading jquery', () => {
     it('does not crash', (done) => {
       const w = new BrowserWindow({ show: false });

--- a/spec/fixtures/api/first-party-sets/base/main.js
+++ b/spec/fixtures/api/first-party-sets/base/main.js
@@ -1,0 +1,20 @@
+const { app } = require('electron');
+
+const sets = [
+  'https://fps-member1.glitch.me',
+  'https://fps-member2.glitch.me',
+  'https://fps-member3.glitch.me'
+];
+
+app.commandLine.appendSwitch('use-first-party-set', sets.join(','));
+
+app.whenReady().then(function () {
+  const hasSwitch = app.commandLine.hasSwitch('use-first-party-set');
+  const value = app.commandLine.getSwitchValue('use-first-party-set');
+  if (hasSwitch) {
+    process.stdout.write(JSON.stringify(value));
+    process.stdout.end();
+  }
+
+  app.quit();
+});

--- a/spec/fixtures/api/first-party-sets/base/package.json
+++ b/spec/fixtures/api/first-party-sets/base/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "electron-test-first-party-sets-base",
+  "main": "main.js"
+}

--- a/spec/fixtures/api/first-party-sets/command-line/main.js
+++ b/spec/fixtures/api/first-party-sets/command-line/main.js
@@ -1,0 +1,12 @@
+const { app } = require('electron');
+
+app.whenReady().then(function () {
+  const hasSwitch = app.commandLine.hasSwitch('use-first-party-set');
+  const value = app.commandLine.getSwitchValue('use-first-party-set');
+  if (hasSwitch) {
+    process.stdout.write(JSON.stringify(value));
+    process.stdout.end();
+  }
+
+  app.quit();
+});

--- a/spec/fixtures/api/first-party-sets/command-line/package.json
+++ b/spec/fixtures/api/first-party-sets/command-line/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "electron-test-first-party-sets-command-line",
+  "main": "main.js"
+}


### PR DESCRIPTION
#### Description of Change

First party sets are now being used by Electron app developers. Although Electron itself does not contain API code for first party sets, it would be helpful to have a few small tests to protect against any upstream changes or breaks (for example, when upgrading a Chromium role).

This PR adds two small tests to test loading FPS within an app and from the command line.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
