### PR TITLE
fix: safer check for WCO button updates

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -876,7 +876,7 @@ bool NativeWindowViews::IsMovable() {
 void NativeWindowViews::SetMinimizable(bool minimizable) {
 #if BUILDFLAG(IS_WIN)
   FlipWindowStyle(GetAcceleratedWidget(), minimizable, WS_MINIMIZEBOX);
-  if (titlebar_overlay_enabled()) {
+  if (IsWindowControlsOverlayEnabled()) {
     auto* frame_view =
         static_cast<WinFrameView*>(widget()->non_client_view()->frame_view());
     frame_view->caption_button_container()->UpdateButtons();
@@ -896,7 +896,7 @@ bool NativeWindowViews::IsMinimizable() {
 void NativeWindowViews::SetMaximizable(bool maximizable) {
 #if BUILDFLAG(IS_WIN)
   FlipWindowStyle(GetAcceleratedWidget(), maximizable, WS_MAXIMIZEBOX);
-  if (titlebar_overlay_enabled()) {
+  if (IsWindowControlsOverlayEnabled()) {
     auto* frame_view =
         static_cast<WinFrameView*>(widget()->non_client_view()->frame_view());
     frame_view->caption_button_container()->UpdateButtons();
@@ -936,7 +936,7 @@ void NativeWindowViews::SetClosable(bool closable) {
   } else {
     EnableMenuItem(menu, SC_CLOSE, MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
   }
-  if (titlebar_overlay_enabled()) {
+  if (IsWindowControlsOverlayEnabled()) {
     auto* frame_view =
         static_cast<WinFrameView*>(widget()->non_client_view()->frame_view());
     frame_view->caption_button_container()->UpdateButtons();

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -2427,6 +2427,41 @@ describe('BrowserWindow module', () => {
     ifit(process.platform === 'darwin')('sets Window Control Overlay with hidden inset title bar', async () => {
       await testWindowsOverlay('hiddenInset');
     });
+
+    ifdescribe(process.platform === 'win32')('when an invalid titleBarStyle is initially set', () => {
+      let w: BrowserWindow;
+
+      beforeEach(() => {
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            nodeIntegration: true,
+            contextIsolation: false
+          },
+          titleBarOverlay: {
+            color: '#0000f0',
+            symbolColor: '#ffffff'
+          },
+          titleBarStyle: 'hiddenInset'
+        });
+      });
+
+      afterEach(async () => {
+        await closeAllWindows();
+      });
+
+      it('does not crash changing minimizability ', () => {
+        expect(() => {
+          w.setMinimizable(false);
+        }).to.not.throw();
+      });
+
+      it('does not crash changing maximizability', () => {
+        expect(() => {
+          w.setMaximizable(false);
+        }).to.not.throw();
+      });
+    });
   });
 
   ifdescribe(['win32', 'darwin'].includes(process.platform))('"titleBarOverlay" option', () => {


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/34677.

Fixes a potential crash when changing window settings after initializing WCO with an invalid `titleBarStyle`. We need both to ensure that the overlay has been set and _also_ that the `titleBarStyle` is valid for the platform.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash when changing window settings after initializing WCO with an invalid `titleBarStyle`. 