### PR TITLE
fix: `setRepresentedFilename` with non-default `titlebarStyle`

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1150,6 +1150,8 @@ double NativeWindowMac::GetOpacity() {
 
 void NativeWindowMac::SetRepresentedFilename(const std::string& filename) {
   [window_ setRepresentedFilename:base::SysUTF8ToNSString(filename)];
+  if (buttons_proxy_)
+    [buttons_proxy_ redraw];
 }
 
 std::string NativeWindowMac::GetRepresentedFilename() {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/34822.

Fixes an issue where calling `BrowserWindow.setRepresentedFilename` on macOS with `titlebarStyle: 'hiddenInset'`  or `titlebarStyle: 'hidden'` inadvertently moves the traffic light location. Fix this by ensuring the traffic lights are redrawn according to the current `titleBarStyle` when `representedFilename` value is changed.

Tested with https://gist.github.com/9ad043673ca425c92bbb4e1f951c455c

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where calling `BrowserWindow.setRepresentedFilename` on macOS with `titlebarStyle: 'hiddenInset'`  or `titlebarStyle: 'hidden'` inadvertently moves the traffic light location.