### PR TITLE
fix: allow setsize to be called within a move or resize for preventDefault

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -719,7 +719,6 @@ void NativeWindowViews::SetBounds(const gfx::Rect& bounds, bool animate) {
 #if BUILDFLAG(IS_WIN)
   if (is_moving_ || is_resizing_) {
     pending_bounds_change_ = bounds;
-    return;
   }
 #endif
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Closes #34599
Refs #33288
Refs #33279

The prior work in #33279 to allow calling SetBounds during a resize or move (defined as time period between receiving a WM_MOVING or WM_SIZING--respectively--and WM_EXITSIZEMOVE WNDPROC message) prevented the ability to call preventDefault() within 'will-resize' or 'will-move' and then call SetBounds to change the size and position of the window immediately.  After the PR, the window does not change bounds until the user ends the resize or move by releasing the mouse button, e.g. This PR simply removes the early-return statement to forward the SetBounds call to the widget, allowing for the bounds to change immediately if the movement or resizing has been cancelled through 'preventDefault' or after it has ended otherwise.

Tested with https://gist.github.com/6b6ea5cdaa1883656a8bd0bf89195283 and https://gist.github.com/meredith-ciq/a7ad120e84bd028a3fbd26b8f61aa45c

This is unfortunately not directly testable via spec, given that it's dependent on user-initiated movement.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue in which calling setBounds() after e.preventDefault in a 'will-move' or 'will-resize' event wouldn't change the window's shape until the mouse button was released.
