### PR TITLE
build: run CI on Xcode 13.3.0

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -511,6 +511,7 @@ step-install-signing-cert-on-mac: &step-install-signing-cert-on-mac
     name: Import and trust self-signed codesigning cert on MacOS
     command: |
       if  [ "$TARGET_ARCH" != "arm64" ] && [ "`uname`" == "Darwin" ]; then
+        sudo security authorizationdb write com.apple.trust-settings.admin allow
         cd src/electron
         ./script/codesign/generate-identity.sh
       fi
@@ -2044,7 +2045,6 @@ jobs:
   osx-testing-x64-tests:
     executor:
       name: macos
-      xcode: 12.4.0
       size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
@@ -2063,7 +2063,6 @@ jobs:
   mas-testing-x64-tests:
     executor:
       name: macos
-      xcode: 12.4.0
       size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1033,6 +1033,7 @@ steps-tests: &steps-tests
     - *step-setup-linux-for-headless-testing
     - *step-restore-brew-cache
     - *step-fix-known-hosts-linux
+    - install-python2-mac
     - *step-install-signing-cert-on-mac
 
     - run:

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -53,14 +53,8 @@ executors:
         description: "macOS executor size"
         type: enum
         enum: ["macos.x86.medium.gen2", "large"]
-      xcode:
-        description: "xcode version"
-        default: 13.3.0
-        type: enum
-        enum: ["12.4.0", "13.3.0"]
-
     macos:
-      xcode: << parameters.xcode >>
+      xcode: 13.3.0
     resource_class: << parameters.size >>
 
   # Electron Runners

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1132,7 +1132,7 @@ commands:
       - run:
           name: Install python2 on macos
           command: |
-            if [ "`uname`" == "Darwin" ]; then
+            if [ "`uname`" == "Darwin" ] && [ "$TARGET_ARCH" != "arm64" ]; then
               if [ ! -f "python-downloads/python-2.7.18-macosx10.9.pkg" ]; then
                 mkdir python-downloads
                 echo 'Downloading Python 2.7.18'

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -125,6 +125,9 @@ env-apple-silicon: &env-apple-silicon
   USE_PREBUILT_V8_CONTEXT_SNAPSHOT: 1
   npm_config_arch: arm64
 
+env-runner: &env-runner
+  IS_ELECTRON_RUNNER: 1
+
 env-arm64: &env-arm64
   GN_EXTRA_ARGS: 'target_cpu = "arm64" fatal_linker_warnings = false enable_linux_installer = false'
   MKSNAPSHOT_TOOLCHAIN: //build/toolchain/linux:clang_arm64
@@ -1132,7 +1135,7 @@ commands:
       - run:
           name: Install python2 on macos
           command: |
-            if [ "`uname`" == "Darwin" ] && [ "$TARGET_ARCH" != "arm64" ]; then
+            if [ "`uname`" == "Darwin" ] && [ "$IS_ELECTRON_RUNNER" != "1" ]; then
               if [ ! -f "python-downloads/python-2.7.18-macosx10.9.pkg" ]; then
                 mkdir python-downloads
                 echo 'Downloading Python 2.7.18'
@@ -2059,6 +2062,7 @@ jobs:
       <<: *env-mac-large
       <<: *env-stack-dumping
       <<: *env-apple-silicon
+      <<: *env-runner
     <<: *steps-tests
 
   mas-testing-x64-tests:
@@ -2077,6 +2081,7 @@ jobs:
       <<: *env-mac-large
       <<: *env-stack-dumping
       <<: *env-apple-silicon
+      <<: *env-runner
     <<: *steps-tests
 
 # List all workflows


### PR DESCRIPTION
With some arcane `sudo security` commands we can make our code signing tests work 😅 

Notes: no-notes