### PR TITLE
fix: set Wayland application ID

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -51,6 +51,7 @@
 #include "shell/browser/ui/views/client_frame_view_linux.h"
 #include "shell/browser/ui/views/frameless_view.h"
 #include "shell/browser/ui/views/native_frame_view.h"
+#include "shell/common/platform_util.h"
 #include "ui/views/widget/desktop_aura/desktop_native_widget_aura.h"
 #include "ui/views/window/native_frame_view.h"
 
@@ -271,6 +272,8 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
   // Set WM_CLASS.
   params.wm_class_name = base::ToLowerASCII(name);
   params.wm_class_class = name;
+  // Set Wayland application ID.
+  params.wayland_app_id = platform_util::GetXdgAppId();
 
   auto* native_widget = new views::DesktopNativeWidgetAura(widget());
   params.native_widget = native_widget;

--- a/shell/browser/notifications/linux/libnotify_notification.cc
+++ b/shell/browser/notifications/linux/libnotify_notification.cc
@@ -9,7 +9,6 @@
 
 #include "base/files/file_enumerator.h"
 #include "base/logging.h"
-#include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "shell/browser/notifications/notification_delegate.h"
 #include "shell/browser/ui/gtk_util.h"
@@ -138,13 +137,8 @@ void LibnotifyNotification::Show(const NotificationOptions& options) {
 
   // Send the desktop name to identify the application
   // The desktop-entry is the part before the .desktop
-  std::string desktop_id;
-  if (platform_util::GetDesktopName(&desktop_id)) {
-    const std::string suffix{".desktop"};
-    if (base::EndsWith(desktop_id, suffix,
-                       base::CompareCase::INSENSITIVE_ASCII)) {
-      desktop_id.resize(desktop_id.size() - suffix.size());
-    }
+  std::string desktop_id = platform_util::GetXdgAppId();
+  if (!desktop_id.empty()) {
     libnotify_loader_.notify_notification_set_hint_string(
         notification_, "desktop-entry", desktop_id.c_str());
   }

--- a/shell/common/platform_util.h
+++ b/shell/common/platform_util.h
@@ -56,6 +56,10 @@ bool SetLoginItemEnabled(bool enabled);
 // Returns a success flag.
 // Unlike libgtkui, does *not* use "chromium-browser.desktop" as a fallback.
 bool GetDesktopName(std::string* setme);
+
+// The XDG application ID must match the name of the desktop entry file without
+// the .desktop extension.
+std::string GetXdgAppId();
 #endif
 
 }  // namespace platform_util

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -20,6 +20,7 @@
 #include "base/posix/eintr_wrapper.h"
 #include "base/process/kill.h"
 #include "base/process/launch.h"
+#include "base/strings/string_util.h"
 #include "base/threading/thread_restrictions.h"
 #include "components/dbus/thread_linux/dbus_thread_linux.h"
 #include "content/public/browser/browser_thread.h"
@@ -401,6 +402,20 @@ void Beep() {
 
 bool GetDesktopName(std::string* setme) {
   return base::Environment::Create()->GetVar("CHROME_DESKTOP", setme);
+}
+
+std::string GetXdgAppId() {
+  std::string desktop_file_name;
+  if (GetDesktopName(&desktop_file_name)) {
+    const std::string kDesktopExtension{".desktop"};
+    if (base::EndsWith(desktop_file_name, kDesktopExtension,
+                       base::CompareCase::INSENSITIVE_ASCII)) {
+      desktop_file_name.resize(desktop_file_name.size() -
+                               kDesktopExtension.size());
+    }
+  }
+
+  return desktop_file_name;
 }
 
 }  // namespace platform_util


### PR DESCRIPTION
#### Description of Change

Electron versions prior to 18.0.0 (`<18.0.0`) were setting the [Wayland application ID](https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id) to the same value as the X11 `WM_CLASS` property. But in recent versions of Electron the Wayland's application ID property is empty (#33578).

Most likely this was caused by [this upstream Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/3347575) which introduced the [`wayland_app_id`](https://source.chromium.org/chromium/chromium/src/+/main:ui/platform_window/platform_window_init_properties.h;l=132-134;drc=f28f4f8f90c4494c9bc9f34a28f5dcc215caa077) property.

This pull-request makes use of the `wayland_app_id` property by setting its value to the *basename of the application's `.desktop` file*.

Fixes #33578
Closes https://github.com/electron/electron/issues/34852

##### Related issues

- #34852 (it *may* be related, but it needs more investigation)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd (@zcbenz @ckerr @deepak1556)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix empty app_id when running under wayland