### PR TITLE
chore: cherry-pick 763d847f1e5a from webrtc

### DIFF
--- a/patches/webrtc/.patches
+++ b/patches/webrtc/.patches
@@ -1,3 +1,4 @@
 add_thread_local_to_x_error_trap_cc.patch
 adding_fuzzer_for_pcm16b_decoder_and_fixing_a_fuzzer_problem.patch
 cherry-pick-a18fddcb53e6.patch
+cherry-pick-763d847f1e5a.patch

--- a/patches/webrtc/cherry-pick-763d847f1e5a.patch
+++ b/patches/webrtc/cherry-pick-763d847f1e5a.patch
@@ -1,0 +1,91 @@
+From 763d847f1e5ac3c5607ace75cc03876e4fc1341b Mon Sep 17 00:00:00 2001
+From: Taylor Brandstetter <deadbeef@webrtc.org>
+Date: Fri, 01 Jul 2022 12:20:05 -0700
+Subject: [PATCH] [M102] Do not allow simulcast to be turned off using SDP munging
+
+This is an error that puts the PC into an inconsistent state, so
+causing a crash is the right thing to do.
+
+(cherry picked from commit 3fe8b0d9a980642ee5ebb1f9e429378b063c1f07)
+TBR=hta@webrtc.org
+
+Bug: chromium:1341043
+Change-Id: Ie1eb89400ad87f0c83634b7073236b07e92ec7ab
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/267281
+Reviewed-by: Mirko Bonadei <mbonadei@webrtc.org>
+Reviewed-by: Henrik Boström <hbos@webrtc.org>
+Commit-Queue: Harald Alvestrand <hta@webrtc.org>
+Cr-Original-Commit-Position: refs/heads/main@{#37391}
+No-Presubmit: true
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/267427
+Commit-Queue: Taylor Brandstetter <deadbeef@webrtc.org>
+Reviewed-by: Guido Urdaneta <guidou@webrtc.org>
+Reviewed-by: Taylor Brandstetter <deadbeef@webrtc.org>
+Cr-Commit-Position: refs/branch-heads/5005@{#9}
+Cr-Branched-From: 8f9b44ba38c134e1c69126196e4d9e566ca5d5e3-refs/heads/main@{#36552}
+---
+
+diff --git a/pc/rtp_sender.cc b/pc/rtp_sender.cc
+index dc53105..58fef40 100644
+--- a/pc/rtp_sender.cc
++++ b/pc/rtp_sender.cc
+@@ -300,8 +300,8 @@
+       // we need to copy.
+       RtpParameters current_parameters =
+           media_channel_->GetRtpSendParameters(ssrc_);
+-      RTC_DCHECK_GE(current_parameters.encodings.size(),
+-                    init_parameters_.encodings.size());
++      RTC_CHECK_GE(current_parameters.encodings.size(),
++                   init_parameters_.encodings.size());
+       for (size_t i = 0; i < init_parameters_.encodings.size(); ++i) {
+         init_parameters_.encodings[i].ssrc =
+             current_parameters.encodings[i].ssrc;
+diff --git a/pc/rtp_sender_receiver_unittest.cc b/pc/rtp_sender_receiver_unittest.cc
+index 20621e4..d9d4b8d 100644
+--- a/pc/rtp_sender_receiver_unittest.cc
++++ b/pc/rtp_sender_receiver_unittest.cc
+@@ -1166,6 +1166,44 @@
+   DestroyVideoRtpSender();
+ }
+ 
++#if GTEST_HAS_DEATH_TEST && !defined(WEBRTC_ANDROID)
++using RtpSenderReceiverDeathTest = RtpSenderReceiverTest;
++
++TEST_F(RtpSenderReceiverDeathTest,
++       VideoSenderManualRemoveSimulcastFailsDeathTest) {
++  AddVideoTrack(false);
++
++  std::unique_ptr<MockSetStreamsObserver> set_streams_observer =
++      std::make_unique<MockSetStreamsObserver>();
++  video_rtp_sender_ = VideoRtpSender::Create(worker_thread_, video_track_->id(),
++                                             set_streams_observer.get());
++  ASSERT_TRUE(video_rtp_sender_->SetTrack(video_track_.get()));
++  EXPECT_CALL(*set_streams_observer, OnSetStreams());
++  video_rtp_sender_->SetStreams({local_stream_->id()});
++
++  std::vector<RtpEncodingParameters> init_encodings(2);
++  init_encodings[0].max_bitrate_bps = 60000;
++  init_encodings[1].max_bitrate_bps = 120000;
++  video_rtp_sender_->set_init_send_encodings(init_encodings);
++
++  RtpParameters params = video_rtp_sender_->GetParameters();
++  ASSERT_EQ(2u, params.encodings.size());
++  EXPECT_EQ(params.encodings[0].max_bitrate_bps, 60000);
++
++  // Simulate the setLocalDescription call as if the user used SDP munging
++  // to disable simulcast.
++  std::vector<uint32_t> ssrcs;
++  ssrcs.reserve(2);
++  for (int i = 0; i < 2; ++i)
++    ssrcs.push_back(kVideoSsrcSimulcast + i);
++  cricket::StreamParams stream_params =
++      cricket::StreamParams::CreateLegacy(kVideoSsrc);
++  video_media_channel_->AddSendStream(stream_params);
++  video_rtp_sender_->SetMediaChannel(video_media_channel_);
++  EXPECT_DEATH(video_rtp_sender_->SetSsrc(kVideoSsrcSimulcast), "");
++}
++#endif
++
+ TEST_F(RtpSenderReceiverTest,
+        VideoSenderMustCallGetParametersBeforeSetParametersBeforeNegotiation) {
+   video_rtp_sender_ =

--- a/patches/webrtc/cherry-pick-763d847f1e5a.patch
+++ b/patches/webrtc/cherry-pick-763d847f1e5a.patch
@@ -1,7 +1,10 @@
-From 763d847f1e5ac3c5607ace75cc03876e4fc1341b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Taylor Brandstetter <deadbeef@webrtc.org>
-Date: Fri, 01 Jul 2022 12:20:05 -0700
-Subject: [PATCH] [M102] Do not allow simulcast to be turned off using SDP munging
+Date: Fri, 1 Jul 2022 12:20:05 -0700
+Subject: Do not allow simulcast to be turned off using SDP munging
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 This is an error that puts the PC into an inconsistent state, so
 causing a crash is the right thing to do.
@@ -23,13 +26,12 @@ Reviewed-by: Guido Urdaneta <guidou@webrtc.org>
 Reviewed-by: Taylor Brandstetter <deadbeef@webrtc.org>
 Cr-Commit-Position: refs/branch-heads/5005@{#9}
 Cr-Branched-From: 8f9b44ba38c134e1c69126196e4d9e566ca5d5e3-refs/heads/main@{#36552}
----
 
 diff --git a/pc/rtp_sender.cc b/pc/rtp_sender.cc
-index dc53105..58fef40 100644
+index d4286371be9513f38ad79b8739a4badf47e2beda..6b4fa3c039d0b3e89993e886eb0fced01be8c22d 100644
 --- a/pc/rtp_sender.cc
 +++ b/pc/rtp_sender.cc
-@@ -300,8 +300,8 @@
+@@ -291,8 +291,8 @@ void RtpSenderBase::SetSsrc(uint32_t ssrc) {
        // we need to copy.
        RtpParameters current_parameters =
            media_channel_->GetRtpSendParameters(ssrc_);
@@ -41,10 +43,10 @@ index dc53105..58fef40 100644
          init_parameters_.encodings[i].ssrc =
              current_parameters.encodings[i].ssrc;
 diff --git a/pc/rtp_sender_receiver_unittest.cc b/pc/rtp_sender_receiver_unittest.cc
-index 20621e4..d9d4b8d 100644
+index f36183366a6944935f98562ed20deff26b33014a..323e0231b66f0fc18854c5b34909e477e742f214 100644
 --- a/pc/rtp_sender_receiver_unittest.cc
 +++ b/pc/rtp_sender_receiver_unittest.cc
-@@ -1166,6 +1166,44 @@
+@@ -1152,6 +1152,44 @@ TEST_F(RtpSenderReceiverTest,
    DestroyVideoRtpSender();
  }
  


### PR DESCRIPTION
[M102] Do not allow simulcast to be turned off using SDP munging

This is an error that puts the PC into an inconsistent state, so
causing a crash is the right thing to do.

(cherry picked from commit 3fe8b0d9a980642ee5ebb1f9e429378b063c1f07)
TBR=hta@webrtc.org

Bug: chromium:1341043
Change-Id: Ie1eb89400ad87f0c83634b7073236b07e92ec7ab
Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/267281
Reviewed-by: Mirko Bonadei <mbonadei@webrtc.org>
Reviewed-by: Henrik Boström <hbos@webrtc.org>
Commit-Queue: Harald Alvestrand <hta@webrtc.org>
Cr-Original-Commit-Position: refs/heads/main@{#37391}
No-Presubmit: true
Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/267427
Commit-Queue: Taylor Brandstetter <deadbeef@webrtc.org>
Reviewed-by: Guido Urdaneta <guidou@webrtc.org>
Reviewed-by: Taylor Brandstetter <deadbeef@webrtc.org>
Cr-Commit-Position: refs/branch-heads/5005@{#9}
Cr-Branched-From: 8f9b44ba38c134e1c69126196e4d9e566ca5d5e3-refs/heads/main@{#36552}


Notes: Backported fix for CVE-2022-2294.