### PR TITLE
refactor: simplify Node.js event loop with `SpinEventLoop`

### DIFF
--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -260,37 +260,9 @@ int NodeMain(int argc, char* argv[]) {
     v8::HandleScope scope(isolate);
     node::LoadEnvironment(env, node::StartExecutionCallback{});
 
-    env->set_trace_sync_io(env->options()->trace_sync_io);
-
-    {
-      v8::SealHandleScope seal(isolate);
-      bool more;
-      env->performance_state()->Mark(
-          node::performance::NODE_PERFORMANCE_MILESTONE_LOOP_START);
-      do {
-        uv_run(env->event_loop(), UV_RUN_DEFAULT);
-
-        gin_env.platform()->DrainTasks(isolate);
-
-        more = uv_loop_alive(env->event_loop());
-        if (more && !env->is_stopping())
-          continue;
-
-        if (!uv_loop_alive(env->event_loop())) {
-          EmitBeforeExit(env);
-        }
-
-        // Emit `beforeExit` if the loop became alive either after emitting
-        // event, or after running some callbacks.
-        more = uv_loop_alive(env->event_loop());
-      } while (more && !env->is_stopping());
-      env->performance_state()->Mark(
-          node::performance::NODE_PERFORMANCE_MILESTONE_LOOP_EXIT);
-    }
-
-    env->set_trace_sync_io(false);
-
-    exit_code = node::EmitExit(env);
+    // Potential reasons we get Nothing here may include: the env
+    // is stopping, or the user hooks process.emit('exit').
+    exit_code = node::SpinEventLoop(env).FromMaybe(1);
 
     node::ResetStdio();
 


### PR DESCRIPTION
#### Description of Change

Take advantage of Node.js-provided helper function to spin uv loop found [here](https://github.com/nodejs/node/blob/eaca13ddc9092e831b9b45180c6e0ee1f3292e5e/src/api/embed_helpers.cc#L17-L60). Allows us to remove a chunk of code and maintain tighter parity with upstream.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none