### PR TITLE
fix: ensure that requestMediaKeySystemAccess resolves

### DIFF
--- a/shell/app/electron_content_client.cc
+++ b/shell/app/electron_content_client.cc
@@ -22,17 +22,18 @@
 #include "ppapi/buildflags/buildflags.h"
 #include "shell/common/electron_paths.h"
 #include "shell/common/options_switches.h"
+#include "third_party/widevine/cdm/buildflags.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "url/url_constants.h"
 // In SHARED_INTERMEDIATE_DIR.
 #include "widevine_cdm_version.h"  // NOLINT(build/include_directory)
 
-#if defined(WIDEVINE_CDM_AVAILABLE)
+#if BUILDFLAG(ENABLE_WIDEVINE)
 #include "base/native_library.h"
 #include "content/public/common/cdm_info.h"
 #include "media/base/video_codecs.h"
-#endif  // defined(WIDEVINE_CDM_AVAILABLE)
+#endif  // BUILDFLAG(ENABLE_WIDEVINE)
 
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
 #include "chrome/common/pdf_util.h"
@@ -58,7 +59,7 @@ enum class WidevineCdmFileCheck {
   kNotFound,
 };
 
-#if defined(WIDEVINE_CDM_AVAILABLE)
+#if BUILDFLAG(ENABLE_WIDEVINE)
 bool IsWidevineAvailable(
     base::FilePath* cdm_path,
     std::vector<media::VideoCodec>* codecs_supported,
@@ -102,7 +103,7 @@ bool IsWidevineAvailable(
 
   return false;
 }
-#endif  // defined(WIDEVINE_CDM_AVAILABLE)
+#endif  // BUILDFLAG(ENABLE_WIDEVINE)
 
 #if BUILDFLAG(ENABLE_PLUGINS)
 void ComputeBuiltInPlugins(std::vector<content::PepperPluginInfo>* plugins) {
@@ -227,7 +228,7 @@ void ElectronContentClient::AddContentDecryptionModules(
     std::vector<content::CdmInfo>* cdms,
     std::vector<media::CdmHostFilePath>* cdm_host_file_paths) {
   if (cdms) {
-#if defined(WIDEVINE_CDM_AVAILABLE)
+#if BUILDFLAG(ENABLE_WIDEVINE)
     base::FilePath cdm_path;
     std::vector<media::VideoCodec> video_codecs_supported;
     base::flat_set<media::CdmSessionType> session_types_supported;
@@ -252,7 +253,7 @@ void ElectronContentClient::AddContentDecryptionModules(
           kWidevineCdmDisplayName, kWidevineCdmGuid, version, cdm_path,
           kWidevineCdmFileSystemId, capability, kWidevineKeySystem, false));
     }
-#endif  // defined(WIDEVINE_CDM_AVAILABLE)
+#endif  // BUILDFLAG(ENABLE_WIDEVINE)
   }
 }
 

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -47,6 +47,7 @@
 #include "third_party/blink/public/web/web_view.h"
 #include "third_party/blink/renderer/platform/media/multi_buffer_data_source.h"  // nogncheck
 #include "third_party/blink/renderer/platform/weborigin/scheme_registry.h"  // nogncheck
+#include "third_party/widevine/cdm/buildflags.h"
 
 #if BUILDFLAG(IS_MAC)
 #include "base/strings/sys_string_conversions.h"
@@ -56,7 +57,7 @@
 #include <shlobj.h>
 #endif
 
-#if defined(WIDEVINE_CDM_AVAILABLE)
+#if BUILDFLAG(ENABLE_WIDEVINE)
 #include "chrome/renderer/media/chrome_key_systems.h"  // nogncheck
 #endif
 
@@ -377,8 +378,10 @@ bool RendererClientBase::OverrideCreatePlugin(
 
 void RendererClientBase::GetSupportedKeySystems(
     media::GetSupportedKeySystemsCB cb) {
-#if defined(WIDEVINE_CDM_AVAILABLE)
+#if BUILDFLAG(ENABLE_WIDEVINE)
   GetChromeKeySystems(std::move(cb));
+#else
+  std::move(cb).Run({});
 #endif
 }
 


### PR DESCRIPTION
When widevine was disabled at the build level we never dealt with the callback passed into GetSupportedKeySystems.  This was ok until requests became marked pending in https://chromium-review.googlesource.com/c/chromium/src/+/3430502 until the callback was called.  This resulted in a promise never resolving / rejecting and certain media websites (E.g. spotify) hanging on load waiting for a signal that would never arrive.

Notes: Ensures that `requestMediaKeySystemAccess` eventually resolves / rejects 