### PR TITLE
fix: delegate to `PrintViewManagerBase` on failed print

### DIFF
--- a/shell/browser/printing/print_view_manager_electron.cc
+++ b/shell/browser/printing/print_view_manager_electron.cc
@@ -163,12 +163,23 @@ void PrintViewManagerElectron::ScriptedPrint(
 }
 
 void PrintViewManagerElectron::ShowInvalidPrinterSettingsError() {
+  if (headless_jobs_.size() == 0) {
+    PrintViewManagerBase::ShowInvalidPrinterSettingsError();
+    return;
+  }
+
   ReleaseJob(INVALID_PRINTER_SETTINGS);
 }
 
 void PrintViewManagerElectron::PrintingFailed(
     int32_t cookie,
     printing::mojom::PrintFailureReason reason) {
+  auto entry = std::find(headless_jobs_.begin(), headless_jobs_.end(), cookie);
+  if (entry == headless_jobs_.end()) {
+    PrintViewManagerBase::PrintingFailed(cookie, reason);
+    return;
+  }
+
   ReleaseJob(reason == printing::mojom::PrintFailureReason::kInvalidPageRange
                  ? PAGE_COUNT_EXCEEDED
                  : PRINTING_FAILED);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/34813.

Fixes an issue where invalid `pageSize` values would cause a silent hang and eventual crash. This was happening because our `PrintVieeManager` was incorrectly delegating failures back to `PrintViewManagerBase` for non-headless job failures. Correct this issue by delegating when the job is a regular printer job and not a headless PDF job.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where invalid `pageSize` values would cause a silent hang and eventual crash. 