### PR TITLE
fix: `base::DictionaryValue` usage in APNS notifs

### DIFF
--- a/shell/browser/api/electron_api_push_notifications.h
+++ b/shell/browser/api/electron_api_push_notifications.h
@@ -39,7 +39,7 @@ class PushNotifications
   PushNotifications& operator=(const PushNotifications&) = delete;
 
 #if BUILDFLAG(IS_MAC)
-  void OnDidReceiveAPNSNotification(const base::DictionaryValue& user_info);
+  void OnDidReceiveAPNSNotification(const base::Value::Dict& user_info);
   void ResolveAPNSPromiseSetWithToken(const std::string& token_string);
   void RejectAPNSPromiseSetWithError(const std::string& error_message);
 #endif

--- a/shell/browser/api/electron_api_push_notifications_mac.mm
+++ b/shell/browser/api/electron_api_push_notifications_mac.mm
@@ -53,7 +53,7 @@ void PushNotifications::UnregisterForAPNSNotifications() {
 }
 
 void PushNotifications::OnDidReceiveAPNSNotification(
-    const base::DictionaryValue& user_info) {
+    const base::Value::Dict& user_info) {
   Emit("received-apns-notification", user_info);
 }
 

--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -193,7 +193,7 @@ static NSDictionary* UNNotificationResponseToNSDictionary(
       electron::api::PushNotifications::Get();
   if (push_notifications) {
     electron::api::PushNotifications::Get()->OnDidReceiveAPNSNotification(
-        electron::NSDictionaryToDictionaryValue(userInfo));
+        electron::NSDictionaryToValue(userInfo));
   }
 }
 


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/33574.

Hotfixes incorrect `base::DictionaryValue` usage.

Notes: none.