### PR TITLE
test: optionally validate disabled Node.js specs

### DIFF
--- a/script/node-disabled-tests.json
+++ b/script/node-disabled-tests.json
@@ -13,7 +13,6 @@
   "parallel/test-crypto-des3-wrap",
   "parallel/test-crypto-dh-stateless",
   "parallel/test-crypto-ecb",
-  "parallel/test-crypto-engine",
   "parallel/test-crypto-fips",
   "parallel/test-crypto-keygen",
   "parallel/test-crypto-keygen-deprecation",
@@ -21,7 +20,7 @@
   "parallel/test-crypto-padding-aes256",
   "parallel/test-crypto-secure-heap",
   "parallel/test-fs-utimes-y2K38",
-  "parallel/test-heapsnapshot-near-heap-limit-worker.js",
+  "parallel/test-heapsnapshot-near-heap-limit-worker",
   "parallel/test-http2-clean-output",
   "parallel/test-https-agent-session-reuse",
   "parallel/test-https-options-boolean-check",
@@ -96,7 +95,6 @@
   "parallel/test-trace-events-fs-sync",
   "parallel/test-trace-events-metadata",
   "parallel/test-trace-events-none",
-  "parallel/test-trace-events-perf",
   "parallel/test-trace-events-process-exit",
   "parallel/test-trace-events-promises",
   "parallel/test-trace-events-v8",
@@ -125,7 +123,7 @@
   "report/test-report-writereport",
   "sequential/test-cpu-prof-kill",
   "sequential/test-diagnostic-dir-cpu-prof",
-  "sequential/test-cpu-prof-drained.js",
+  "sequential/test-cpu-prof-drained",
   "sequential/test-tls-connect",
   "wpt/test-webcrypto"
 ]

--- a/script/node-spec-runner.js
+++ b/script/node-spec-runner.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 
 const args = require('minimist')(process.argv.slice(2), {
-  boolean: ['default'],
+  boolean: ['default', 'validateDisabled'],
   string: ['jUnitDir']
 });
 
@@ -43,8 +43,7 @@ const getCustomOptions = () => {
     customOptions = customOptions.concat(extra);
   }
 
-  // We need this unilaterally or Node.js will try
-  // to run from out/Release/node.
+  // Necessary or Node.js will try to run from out/Release/node.
   customOptions = customOptions.concat([
     '--shell',
     utils.getAbsoluteElectronExec()
@@ -54,6 +53,22 @@ const getCustomOptions = () => {
 };
 
 async function main () {
+  // Optionally validate that all disabled specs still exist.
+  if (args.validateDisabled) {
+    const missing = [];
+    for (const test of DISABLED_TESTS) {
+      const testName = test.endsWith('.js') ? test : `${test}.js`;
+      if (!fs.existsSync(path.join(NODE_DIR, 'test', testName))) {
+        missing.push(test);
+      }
+    }
+
+    if (missing.length > 0) {
+      console.error(`Found ${missing.length} missing disabled specs: \n${missing.join('\n')}`);
+      process.exit(1);
+    }
+  }
+
   const options = args.default ? defaultOptions : getCustomOptions();
 
   const testChild = cp.spawn('python3', options, {


### PR DESCRIPTION
#### Description of Change

Adds the ability to check that all tests currently disabled via `node-disabled-tests.json` still exist. This is especially helpful during Node.js upgrade rolls, to ensure that our skip test file is still up to date.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.
