### PR TITLE
fix: crash on `BrowserWindow.setEnabled()`

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -484,7 +484,8 @@ void NativeWindowMac::Close() {
   // [window_ performClose:nil], the window won't close properly
   // even after the user has ended the sheet.
   // Ensure it's closed before calling [window_ performClose:nil].
-  SetEnabled(true);
+  if ([window_ attachedSheet])
+    [window_ endSheet:[window_ attachedSheet]];
 
   [window_ performClose:nil];
 
@@ -554,7 +555,8 @@ void NativeWindowMac::Hide() {
   // If a sheet is attached to the window when we call [window_ orderOut:nil],
   // the sheet won't be able to show again on the same window.
   // Ensure it's closed before calling [window_ orderOut:nil].
-  SetEnabled(true);
+  if ([window_ attachedSheet])
+    [window_ endSheet:[window_ attachedSheet]];
 
   if (is_modal() && parent()) {
     [window_ orderOut:nil];
@@ -593,9 +595,18 @@ bool NativeWindowMac::IsEnabled() {
 
 void NativeWindowMac::SetEnabled(bool enable) {
   if (!enable) {
-    [window_ beginSheet:window_
+    NSRect frame = [window_ frame];
+    NSWindow* window =
+        [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, frame.size.width,
+                                                         frame.size.height)
+                                    styleMask:NSWindowStyleMaskTitled
+                                      backing:NSBackingStoreBuffered
+                                        defer:NO];
+    [window setAlphaValue:0.5];
+
+    [window_ beginSheet:window
         completionHandler:^(NSModalResponse returnCode) {
-          NSLog(@"modal enabled");
+          NSLog(@"main window disabled");
           return;
         }];
   } else if ([window_ attachedSheet]) {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -4331,6 +4331,14 @@ describe('BrowserWindow module', () => {
         await createTwo();
       });
 
+      ifit(process.platform !== 'darwin')('can disable and enable a window', () => {
+        const w = new BrowserWindow({ show: false });
+        w.setEnabled(false);
+        expect(w.isEnabled()).to.be.false('w.isEnabled()');
+        w.setEnabled(true);
+        expect(w.isEnabled()).to.be.true('!w.isEnabled()');
+      });
+
       ifit(process.platform !== 'darwin')('disables parent window', () => {
         const w = new BrowserWindow({ show: false });
         const c = new BrowserWindow({ show: false, parent: w, modal: true });


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/34707.

Fixes an issue where calling `BrowserWindow.setEnabled(false)` would crash. This was happening because we were attempting to create a sheet modal on the window with itself. Fix this by instead creating a dummy sheet window to disable interaction with the main window.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash when calling `BrowserWindow.setEnabled()`.
