### PR TITLE
fix: add support for --ozone-platform-hint flag on Linux

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -23,6 +23,7 @@ filenames = {
 
   lib_sources_linux = [
     "shell/browser/browser_linux.cc",
+    "shell/browser/electron_browser_main_parts_linux.cc",
     "shell/browser/lib/power_observer_linux.cc",
     "shell/browser/lib/power_observer_linux.h",
     "shell/browser/linux/unity_service.cc",

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -217,6 +217,7 @@ int ElectronBrowserMainParts::PreEarlyInitialization() {
   HandleSIGCHLD();
 #endif
 #if BUILDFLAG(IS_LINUX)
+  DetectOzonePlatform();
   ui::OzonePlatform::PreEarlyInitialization();
 #endif
 #if BUILDFLAG(IS_MAC)

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -122,6 +122,10 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
       const scoped_refptr<base::SingleThreadTaskRunner>& task_runner);
 #endif
 
+#if BUILDFLAG(IS_LINUX)
+  void DetectOzonePlatform();
+#endif
+
 #if BUILDFLAG(IS_MAC)
   void FreeAppDelegate();
   void RegisterURLHandler();

--- a/shell/browser/electron_browser_main_parts_linux.cc
+++ b/shell/browser/electron_browser_main_parts_linux.cc
@@ -1,0 +1,134 @@
+// Copyright (c) 2022 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/electron_browser_main_parts.h"
+
+#include "base/command_line.h"
+#include "base/environment.h"
+#include "ui/ozone/public/ozone_switches.h"
+
+#if BUILDFLAG(OZONE_PLATFORM_WAYLAND)
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/nix/xdg_util.h"
+#include "base/threading/thread_restrictions.h"
+#endif
+
+#if BUILDFLAG(OZONE_PLATFORM_WAYLAND)
+
+constexpr char kPlatformWayland[] = "wayland";
+
+bool HasWaylandDisplay(base::Environment* env) {
+  std::string wayland_display;
+  const bool has_wayland_display =
+      env->GetVar("WAYLAND_DISPLAY", &wayland_display) &&
+      !wayland_display.empty();
+  if (has_wayland_display)
+    return true;
+
+  std::string xdg_runtime_dir;
+  const bool has_xdg_runtime_dir =
+      env->GetVar("XDG_RUNTIME_DIR", &xdg_runtime_dir) &&
+      !xdg_runtime_dir.empty();
+  if (has_xdg_runtime_dir) {
+    auto wayland_server_pipe =
+        base::FilePath(xdg_runtime_dir).Append("wayland-0");
+    // Normally, this should happen exactly once, at the startup of the main
+    // process.
+    base::ScopedAllowBlocking allow_blocking;
+    return base::PathExists(wayland_server_pipe);
+  }
+
+  return false;
+}
+
+#endif  // BUILDFLAG(OZONE_PLATFORM_WAYLAND)
+
+#if BUILDFLAG(OZONE_PLATFORM_X11)
+constexpr char kPlatformX11[] = "x11";
+#endif
+
+namespace electron {
+
+namespace {
+
+// Evaluates the environment and returns the effective platform name for the
+// given |ozone_platform_hint|.
+// For the "auto" value, returns "wayland" if the XDG session type is "wayland",
+// "x11" otherwise.
+// For the "wayland" value, checks if the Wayland server is available, and
+// returns "x11" if it is not.
+// See https://crbug.com/1246928.
+std::string MaybeFixPlatformName(const std::string& ozone_platform_hint) {
+#if BUILDFLAG(OZONE_PLATFORM_WAYLAND)
+  // Wayland is selected if both conditions below are true:
+  // 1. The user selected either 'wayland' or 'auto'.
+  // 2. The XDG session type is 'wayland', OR the user has selected 'wayland'
+  //    explicitly and a Wayland server is running.
+  // Otherwise, fall back to X11.
+  if (ozone_platform_hint == kPlatformWayland ||
+      ozone_platform_hint == "auto") {
+    auto env(base::Environment::Create());
+
+    std::string xdg_session_type;
+    const bool has_xdg_session_type =
+        env->GetVar(base::nix::kXdgSessionTypeEnvVar, &xdg_session_type) &&
+        !xdg_session_type.empty();
+
+    if ((has_xdg_session_type && xdg_session_type == "wayland") ||
+        (ozone_platform_hint == kPlatformWayland &&
+         HasWaylandDisplay(env.get()))) {
+      return kPlatformWayland;
+    }
+  }
+#endif  // BUILDFLAG(OZONE_PLATFORM_WAYLAND)
+
+#if BUILDFLAG(OZONE_PLATFORM_X11)
+  if (ozone_platform_hint == kPlatformX11) {
+    return kPlatformX11;
+  }
+#if BUILDFLAG(OZONE_PLATFORM_WAYLAND)
+  if (ozone_platform_hint == kPlatformWayland ||
+      ozone_platform_hint == "auto") {
+    // We are here if:
+    // - The binary has both X11 and Wayland backends.
+    // - The user wanted Wayland but that did not work, otherwise it would have
+    //   been returned above.
+    if (ozone_platform_hint == kPlatformWayland) {
+      LOG(WARNING) << "No Wayland server is available. Falling back to X11.";
+    } else {
+      LOG(WARNING) << "This is not a Wayland session.  Falling back to X11. "
+                      "If you need to run Chrome on Wayland using some "
+                      "embedded compositor, e. g., Weston, please specify "
+                      "Wayland as your preferred Ozone platform, or use "
+                      "--ozone-platform=wayland.";
+    }
+    return kPlatformX11;
+  }
+#endif  // BUILDFLAG(OZONE_PLATFORM_WAYLAND)
+#endif  // BUILDFLAG(OZONE_PLATFORM_X11)
+
+  return ozone_platform_hint;
+}
+
+}  // namespace
+
+void ElectronBrowserMainParts::DetectOzonePlatform() {
+  auto* const command_line = base::CommandLine::ForCurrentProcess();
+  if (!command_line->HasSwitch(switches::kOzonePlatform)) {
+    const auto ozone_platform_hint =
+        command_line->GetSwitchValueASCII(switches::kOzonePlatformHint);
+    if (!ozone_platform_hint.empty()) {
+      command_line->AppendSwitchASCII(
+          switches::kOzonePlatform, MaybeFixPlatformName(ozone_platform_hint));
+    }
+  }
+
+  auto env = base::Environment::Create();
+  std::string desktop_startup_id;
+  if (env->GetVar("DESKTOP_STARTUP_ID", &desktop_startup_id))
+    command_line->AppendSwitchASCII("desktop-startup-id", desktop_startup_id);
+}
+
+}  // namespace electron


### PR DESCRIPTION
#### Description of Change

Add support for the `--ozone-platform-hint` flag in order to make it easier for users to switch between the X11 and Wayland platforms (e.g.: by using `--ozone-platform-hint=auto`).

##### Implementation details

~This was implemented by reusing the [same logic from upstream](https://chromium-review.googlesource.com/c/chromium/src/+/3188974), but it required implementing [`chrome::SessionEnding()`](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/lifetime/application_lifetime.h;l=84-85;drc=627a149e7e191267a05b354a2bb697394bf4e1ae) which is a bit hacky. This was necessary due to [this call](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/chrome_browser_main_extra_parts_ozone.cc;l=23;drc=627a149e7e191267a05b354a2bb697394bf4e1ae) from ` ChromeBrowserMainExtraPartsOzone::PostCreateMainMessageLoop()`.~

~Another option would have been to either [patch](https://www.electronjs.org/docs/latest/development/patches) that method or copy the logic from [`ChromeBrowserMainExtraPartsOzone`](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/chrome_browser_main_extra_parts_ozone.cc;drc=627a149e7e191267a05b354a2bb697394bf4e1ae) and [`ChromeBrowserMainExtraPartsLinux`](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/chrome_browser_main_extra_parts_linux.cc;drc=31a79911d78501ef1bcf4673ce59ec5ea9ba1322) inside Electron. If Electron maintainers think that's a more reasonable approach I'll update this pull-request accordingly.~

EDIT: This description is no longer relevant because the implementation has been reworked with feedback from Electron maintainers.


Fixes #33810

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd (@deepak1556 @ckerr @MarshallOfSound)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added support for `--ozone-platform-hint` flag on Linux
