### PR TITLE
fix: don't set window decoration insets when maximized

### DIFF
--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
@@ -146,9 +146,13 @@ void ElectronDesktopWindowTreeHostLinux::UpdateClientDecorationHints(
   gfx::Insets insets;
   gfx::Insets input_insets;
   if (showing_frame) {
-    insets = view->GetBorderDecorationInsets();
-    if (base::i18n::IsRTL()) {
-      insets.set_left_right(insets.right(), insets.left());
+    const auto window_state = window->GetPlatformWindowState();
+    if (window_state == ui::PlatformWindowState::kUnknown ||
+        window_state == ui::PlatformWindowState::kNormal) {
+      insets = view->GetBorderDecorationInsets();
+      if (base::i18n::IsRTL()) {
+        insets.set_left_right(insets.right(), insets.left());
+      }
     }
 
     input_insets = view->GetInputInsets();


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Don't set window decoration insets while maximized on Linux/Wayland. This causes the window to still have the window shadow padding around it while maximized.

Upstream code reference: https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/views/frame/browser_desktop_window_tree_host_linux.cc;l=171-175;drc=c3d2363d9442969358bc902a14fe68225991e0ab

Fixes #33161 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd (@refi64)
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed empty space around maximized window on Wayland<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
