### PR TITLE
fix: prevent brief display of "Ozone X11" in window title on Linux

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -150,3 +150,4 @@ m102_ensure_raw_ptr_t_and_t_are_treated_identically_in_base.patch
 post_media_log_destruction_to_avoid_destruction.patch
 add_stop_method_to_batchingmedialog.patch
 make_gtk_getlibgtk_public.patch
+remove_default_window_title.patch

--- a/patches/chromium/remove_default_window_title.patch
+++ b/patches/chromium/remove_default_window_title.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom Anderson <thomasanderson@chromium.org>
+Date: Fri, 24 Jun 2022 22:27:07 +0000
+Subject: Remove default window title
+
+This is to prevent the enterprise startup dialog from having "Ozone X11"
+in the titlebar.  The intention is for the window to have no title [1]
+
+[1] https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/views/policy/enterprise_startup_dialog_view.cc;drc=855b63f8fe9115f8b38d4736a259f9a96f83fcc6;l=209
+
+R=sky
+
+Change-Id: Iecc200941ad36b6d9feb91e88791b3612e941ea6
+Fixed: 1336343
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3722478
+Reviewed-by: Scott Violet <sky@chromium.org>
+Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1017858}
+
+diff --git a/ui/ozone/platform/x11/ozone_platform_x11.cc b/ui/ozone/platform/x11/ozone_platform_x11.cc
+index 88668a14e38b4391a7951ed16072b4c85a2cb6cb..d5de2dc42f4ae338b92752b591c287dc408879be 100644
+--- a/ui/ozone/platform/x11/ozone_platform_x11.cc
++++ b/ui/ozone/platform/x11/ozone_platform_x11.cc
+@@ -102,7 +102,6 @@ class OzonePlatformX11 : public OzonePlatform,
+       PlatformWindowInitProperties properties) override {
+     auto window = std::make_unique<X11Window>(delegate);
+     window->Initialize(std::move(properties));
+-    window->SetTitle(u"Ozone X11");
+     return std::move(window);
+   }
+ 
+diff --git a/ui/platform_window/x11/x11_window.cc b/ui/platform_window/x11/x11_window.cc
+index 4fa29923943293cec37c7f62bd75b6d6cc57ae31..768f4b6a9c3d60db092761aaa581e2e97ff7f27f 100644
+--- a/ui/platform_window/x11/x11_window.cc
++++ b/ui/platform_window/x11/x11_window.cc
+@@ -362,6 +362,8 @@ void X11Window::Initialize(PlatformWindowInitProperties properties) {
+   if (wm_role_name)
+     SetWindowRole(xwindow_, std::string(wm_role_name));
+ 
++  SetTitle(u"");
++
+   if (properties.remove_standard_frame) {
+     // Setting _GTK_HIDE_TITLEBAR_WHEN_MAXIMIZED tells gnome-shell to not force
+     // fullscreen on the window when it matches the desktop size.
+diff --git a/ui/platform_window/x11/x11_window.h b/ui/platform_window/x11/x11_window.h
+index 6ee76e032cc3e6d880e703366543f2e44eae3d92..25a4a2decfd1e91145c4d1ebd98bd7083f8679f8 100644
+--- a/ui/platform_window/x11/x11_window.h
++++ b/ui/platform_window/x11/x11_window.h
+@@ -363,7 +363,7 @@ class X11_WINDOW_EXPORT X11Window : public PlatformWindow,
+   // Was this window initialized with the override_redirect window attribute?
+   bool override_redirect_ = false;
+ 
+-  std::u16string window_title_;
++  absl::optional<std::u16string> window_title_;
+ 
+   // Whether the window is visible with respect to Aura.
+   bool window_mapped_in_client_ = false;


### PR DESCRIPTION
Backport of #34929

See that PR for details.


Notes: Prevent brief display of "Ozone X11" in window title on Linux.