### PR TITLE
ci: wait longer for goma to be ready

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -346,7 +346,7 @@ step-wait-for-goma: &step-wait-for-goma
           sleep 5
       done
       echo "Goma ready"
-    no_output_timeout: 2m
+    no_output_timeout: 5m
 
 step-restore-brew-cache: &step-restore-brew-cache
   restore_cache:


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

CircleCI has been timing out frequently on our macOS release jobs, eg:
https://app.circleci.com/pipelines/github/electron/electron/55680/workflows/dca75325-3a54-4600-a06e-0d34ee650ec0.

This PR updates the timeout waiting for goma to 5 minutes.  This should be enough time to accommodate hiccups without waiting too long.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
