### PR TITLE
fix: properly fire serial-port-added and serial-port-removed events

### DIFF
--- a/shell/browser/serial/electron_serial_delegate.cc
+++ b/shell/browser/serial/electron_serial_delegate.cc
@@ -71,15 +71,15 @@ device::mojom::SerialPortManager* ElectronSerialDelegate::GetPortManager(
 
 void ElectronSerialDelegate::AddObserver(content::RenderFrameHost* frame,
                                          Observer* observer) {
-  return GetChooserContext(frame)->AddPortObserver(observer);
+  observer_list_.AddObserver(observer);
+  auto* chooser_context = GetChooserContext(frame);
+  if (!port_observation_.IsObserving())
+    port_observation_.Observe(chooser_context);
 }
 
 void ElectronSerialDelegate::RemoveObserver(content::RenderFrameHost* frame,
                                             Observer* observer) {
-  SerialChooserContext* serial_chooser_context = GetChooserContext(frame);
-  if (serial_chooser_context) {
-    return serial_chooser_context->RemovePortObserver(observer);
-  }
+  observer_list_.RemoveObserver(observer);
 }
 
 void ElectronSerialDelegate::RevokePortPermissionWebInitiated(
@@ -118,6 +118,29 @@ SerialChooserController* ElectronSerialDelegate::AddControllerForFrame(
 void ElectronSerialDelegate::DeleteControllerForFrame(
     content::RenderFrameHost* render_frame_host) {
   controller_map_.erase(render_frame_host);
+}
+
+// SerialChooserContext::PortObserver:
+void ElectronSerialDelegate::OnPortAdded(
+    const device::mojom::SerialPortInfo& port) {
+  for (auto& observer : observer_list_)
+    observer.OnPortAdded(port);
+}
+
+void ElectronSerialDelegate::OnPortRemoved(
+    const device::mojom::SerialPortInfo& port) {
+  for (auto& observer : observer_list_)
+    observer.OnPortRemoved(port);
+}
+
+void ElectronSerialDelegate::OnPortManagerConnectionError() {
+  port_observation_.Reset();
+  for (auto& observer : observer_list_)
+    observer.OnPortManagerConnectionError();
+}
+
+void ElectronSerialDelegate::OnSerialChooserContextShutdown() {
+  port_observation_.Reset();
 }
 
 }  // namespace electron

--- a/shell/browser/serial/electron_serial_delegate.h
+++ b/shell/browser/serial/electron_serial_delegate.h
@@ -11,13 +11,15 @@
 
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/serial_delegate.h"
+#include "shell/browser/serial/serial_chooser_context.h"
 #include "shell/browser/serial/serial_chooser_controller.h"
 
 namespace electron {
 
 class SerialChooserController;
 
-class ElectronSerialDelegate : public content::SerialDelegate {
+class ElectronSerialDelegate : public content::SerialDelegate,
+                               public SerialChooserContext::PortObserver {
  public:
   ElectronSerialDelegate();
   ~ElectronSerialDelegate() override;
@@ -48,6 +50,13 @@ class ElectronSerialDelegate : public content::SerialDelegate {
 
   void DeleteControllerForFrame(content::RenderFrameHost* render_frame_host);
 
+  // SerialChooserContext::PortObserver:
+  void OnPortAdded(const device::mojom::SerialPortInfo& port) override;
+  void OnPortRemoved(const device::mojom::SerialPortInfo& port) override;
+  void OnPortManagerConnectionError() override;
+  void OnPermissionRevoked(const url::Origin& origin) override {}
+  void OnSerialChooserContextShutdown() override;
+
  private:
   SerialChooserController* ControllerForFrame(
       content::RenderFrameHost* render_frame_host);
@@ -55,6 +64,13 @@ class ElectronSerialDelegate : public content::SerialDelegate {
       content::RenderFrameHost* render_frame_host,
       std::vector<blink::mojom::SerialPortFilterPtr> filters,
       content::SerialChooser::Callback callback);
+
+  base::ScopedObservation<SerialChooserContext,
+                          SerialChooserContext::PortObserver,
+                          &SerialChooserContext::AddPortObserver,
+                          &SerialChooserContext::RemovePortObserver>
+      port_observation_{this};
+  base::ObserverList<content::SerialDelegate::Observer> observer_list_;
 
   std::unordered_map<content::RenderFrameHost*,
                      std::unique_ptr<SerialChooserController>>

--- a/shell/browser/serial/serial_chooser_context.h
+++ b/shell/browser/serial/serial_chooser_context.h
@@ -46,7 +46,12 @@ extern const char kUsbDriverKey[];
 class SerialChooserContext : public KeyedService,
                              public device::mojom::SerialPortManagerClient {
  public:
-  using PortObserver = content::SerialDelegate::Observer;
+  class PortObserver : public content::SerialDelegate::Observer {
+   public:
+    // Called when the SerialChooserContext is shutting down. Observers must
+    // remove themselves before returning.
+    virtual void OnSerialChooserContextShutdown() = 0;
+  };
 
   explicit SerialChooserContext(ElectronBrowserContext* context);
   ~SerialChooserContext() override;
@@ -54,9 +59,6 @@ class SerialChooserContext : public KeyedService,
   // disable copy
   SerialChooserContext(const SerialChooserContext&) = delete;
   SerialChooserContext& operator=(const SerialChooserContext&) = delete;
-
-  // ObjectPermissionContextBase::PermissionObserver:
-  void OnPermissionRevoked(const url::Origin& origin);
 
   // Serial-specific interface for granting and checking permissions.
   void GrantPortPermission(const url::Origin& origin,

--- a/shell/browser/serial/serial_chooser_controller.cc
+++ b/shell/browser/serial/serial_chooser_controller.cc
@@ -77,13 +77,11 @@ SerialChooserController::SerialChooserController(
   DCHECK(chooser_context_);
   chooser_context_->GetPortManager()->GetDevices(base::BindOnce(
       &SerialChooserController::OnGetDevices, weak_factory_.GetWeakPtr()));
+  observation_.Observe(chooser_context_.get());
 }
 
 SerialChooserController::~SerialChooserController() {
   RunCallback(/*port=*/nullptr);
-  if (chooser_context_) {
-    chooser_context_->RemovePortObserver(this);
-  }
 }
 
 api::Session* SerialChooserController::GetSession() {
@@ -117,7 +115,11 @@ void SerialChooserController::OnPortRemoved(
 }
 
 void SerialChooserController::OnPortManagerConnectionError() {
-  // TODO(nornagon/jkleinsc): report event
+  observation_.Reset();
+}
+
+void SerialChooserController::OnSerialChooserContextShutdown() {
+  observation_.Reset();
 }
 
 void SerialChooserController::OnDeviceChosen(const std::string& port_id) {

--- a/shell/browser/serial/serial_chooser_controller.h
+++ b/shell/browser/serial/serial_chooser_controller.h
@@ -48,6 +48,7 @@ class SerialChooserController final : public SerialChooserContext::PortObserver,
   void OnPortRemoved(const device::mojom::SerialPortInfo& port) override;
   void OnPortManagerConnectionError() override;
   void OnPermissionRevoked(const url::Origin& origin) override {}
+  void OnSerialChooserContextShutdown() override;
 
  private:
   api::Session* GetSession();
@@ -61,6 +62,12 @@ class SerialChooserController final : public SerialChooserContext::PortObserver,
   url::Origin origin_;
 
   base::WeakPtr<SerialChooserContext> chooser_context_;
+
+  base::ScopedObservation<SerialChooserContext,
+                          SerialChooserContext::PortObserver,
+                          &SerialChooserContext::AddPortObserver,
+                          &SerialChooserContext::RemovePortObserver>
+      observation_{this};
 
   std::vector<device::mojom::SerialPortInfoPtr> ports_;
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/34887.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->fixed `serial-port-added` and `serial-port-removed` events not firing.
