### PR TITLE
docs: fix link to tutorial in intro docs

### DIFF
--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -66,6 +66,7 @@ Are you getting stuck anywhere? Here are a few links to places to look:
 
 <!-- Links -->
 
+[tutorial]: ./tutorial-1-prerequisites.md
 [api documentation]: ../api/app.md
 [chromium]: https://www.chromium.org/
 [discord]: https://discord.gg/electronjs


### PR DESCRIPTION
#### Description of Change

Fixes a broken link in `/docs`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
