### PR TITLE
docs: new main -> renderers messageChannel example

### DIFF
--- a/docs/tutorial/message-ports.md
+++ b/docs/tutorial/message-ports.md
@@ -90,8 +90,7 @@ In this example, the main process sets up a MessageChannel, then sends each port
 to a different renderer. This allows renderers to send messages to each other
 without needing to use the main process as an in-between.
 
-```js
-// main.js ///////////////////////////////////////////////////////////////////
+```js title='main.js (Main Process)'
 const { BrowserWindow, app, MessageChannelMain } = require('electron')
 
 app.whenReady().then(async () => {

--- a/docs/tutorial/message-ports.md
+++ b/docs/tutorial/message-ports.md
@@ -131,9 +131,9 @@ const { ipcRenderer } = require('electron')
 
 ipcRenderer.on('port', e => {
   // port received, make it globally available.
-  window.messagePort = e.ports[0]
+  window.electronMessagePort = e.ports[0]
 
-  window.messagePort.onmessage = messageEvent => {
+  window.electronMessagePort.onmessage = messageEvent => {
     // handle message
   }
 })
@@ -150,7 +150,7 @@ renderer.
 
 ```js title='renderer.js (Renderer Process)'
 // elsewhere in your code to send a message to the other renderers message handler
-window.messagePort.postmessage('ping')
+window.electronMessagePort.postmessage('ping')
 ```
 
 ### Worker process

--- a/docs/tutorial/message-ports.md
+++ b/docs/tutorial/message-ports.md
@@ -129,7 +129,7 @@ app.whenReady().then(async () => {
 });
 
 ```
-Then, in your preload scripts you recieve the port through IPC and set up the 
+Then, in your preload scripts you receive the port through IPC and set up the 
 listeners. 
 
 ```js

--- a/docs/tutorial/message-ports.md
+++ b/docs/tutorial/message-ports.md
@@ -95,7 +95,7 @@ without needing to use the main process as an in-between.
 const { BrowserWindow, app, MessageChannelMain } = require('electron')
 
 app.whenReady().then(async () => {
-  // create the windows
+  // create the windows.
   const mainWindow = new BrowserWindow({
     show: false,
     webPreferences: { 
@@ -115,10 +115,10 @@ app.whenReady().then(async () => {
   })
 
 
-  // set up the channel
+  // set up the channel.
   const { port1, port2 } = new MessageChannelMain();
   
-  // once the webContents are ready, send a port to each webContents with postMessage
+  // once the webContents are ready, send a port to each webContents with postMessage.
   mainWindow.once('ready-to-show', () => {
     mainWindow.webContents.postMessage('port', null, [port1]);
   });
@@ -137,7 +137,7 @@ listeners.
 const { ipcRenderer } = require('electron');
 
 ipcRenderer.on('port', e => {
-  // we recieved a port, make it available to your app.
+  // port received, make it globally available.
   window.messagePort = e.ports[0];
   
   window.messagePort.onmessage = messageEvent => {

--- a/docs/tutorial/message-ports.md
+++ b/docs/tutorial/message-ports.md
@@ -97,7 +97,6 @@ app.whenReady().then(async () => {
     show: false,
     webPreferences: {
       contextIsolation: false,
-      nodeIntegration: true,
       preload: 'preloadMain.js'
     }
   })
@@ -106,7 +105,6 @@ app.whenReady().then(async () => {
     show: false,
     webPreferences: {
       contextIsolation: false,
-      nodeIntegration: true,
       preload: 'preloadSecondary.js'
     }
   })

--- a/docs/tutorial/message-ports.md
+++ b/docs/tutorial/message-ports.md
@@ -98,52 +98,50 @@ app.whenReady().then(async () => {
   // create the windows.
   const mainWindow = new BrowserWindow({
     show: false,
-    webPreferences: { 
+    webPreferences: {
       contextIsolation: false,
-      nodeIntegration: true ,
-      preload: 'preloadMain.js',
+      nodeIntegration: true,
+      preload: 'preloadMain.js'
     }
   })
 
   const secondaryWindow = BrowserWindow({
     show: false,
-    webPreferences: { 
+    webPreferences: {
       contextIsolation: false,
-      nodeIntegration: true ,
-      preload: 'preloadSecondary.js',
+      nodeIntegration: true,
+      preload: 'preloadSecondary.js'
     }
   })
 
-
   // set up the channel.
-  const { port1, port2 } = new MessageChannelMain();
-  
+  const { port1, port2 } = new MessageChannelMain()
+
   // once the webContents are ready, send a port to each webContents with postMessage.
   mainWindow.once('ready-to-show', () => {
-    mainWindow.webContents.postMessage('port', null, [port1]);
-  });
+    mainWindow.webContents.postMessage('port', null, [port1])
+  })
 
   secondaryWindow.once('ready-to-show', () => {
-    secondaryWindow.webContents.postMessage('port', null, [port2]);
-  });
-});
-
+    secondaryWindow.webContents.postMessage('port', null, [port2])
+  })
+})
 ```
 Then, in your preload scripts you receive the port through IPC and set up the 
 listeners. 
 
 ```js
 // preloadMain.js and preloadSecondary.js
-const { ipcRenderer } = require('electron');
+const { ipcRenderer } = require('electron')
 
 ipcRenderer.on('port', e => {
   // port received, make it globally available.
-  window.messagePort = e.ports[0];
-  
+  window.messagePort = e.ports[0]
+
   window.messagePort.onmessage = messageEvent => {
     // handle message
-  };
-});
+  }
+})
 ```
 In this example messagePort is bound to the `window` object directly. It is better
 to use `contextIsolation` and set up specific contextBridge calls for each of your 
@@ -155,7 +153,7 @@ renderer.
 
 ```js
 // elsewhere in your code to send a message to the other renderers message handler
-window.messagePort.postmessage("ping");
+window.messagePort.postmessage('ping')
 ```
 
 

--- a/docs/tutorial/message-ports.md
+++ b/docs/tutorial/message-ports.md
@@ -8,8 +8,7 @@ your app.
 
 Here is a very brief example of what a MessagePort is and how it works:
 
-```js
-// renderer.js ///////////////////////////////////////////////////////////////
+```js title='renderer.js (Renderer Process)'
 // MessagePorts are created in pairs. A connected pair of message ports is
 // called a channel.
 const channel = new MessageChannel()
@@ -28,8 +27,7 @@ port2.postMessage({ answer: 42 })
 ipcRenderer.postMessage('port', null, [port1])
 ```
 
-```js
-// main.js ///////////////////////////////////////////////////////////////////
+```js title='main.js (Main Process)'
 // In the main process, we receive the port.
 ipcMain.on('port', (event) => {
   // When we receive a MessagePort in the main process, it becomes a
@@ -130,8 +128,7 @@ app.whenReady().then(async () => {
 Then, in your preload scripts you receive the port through IPC and set up the
 listeners.
 
-```js
-// preloadMain.js and preloadSecondary.js
+```js title='preloadMain.js and preloadSecondary.js (Preload scripts)'
 const { ipcRenderer } = require('electron')
 
 ipcRenderer.on('port', e => {
@@ -146,13 +143,14 @@ ipcRenderer.on('port', e => {
 
 In this example messagePort is bound to the `window` object directly. It is better
 to use `contextIsolation` and set up specific contextBridge calls for each of your
-expected messages, but for the simplicity of this example we don't.
+expected messages, but for the simplicity of this example we don't. You can find an
+example of context isolation further down this page at [Communicating directly between the main process and the main world of a context-isolated page](#communicating-directly-between-the-main-process-and-the-main-world-of-a-context-isolated-page)
 
 That means window.messagePort is globally available and you can call
 `postMessage` on it from anywhere in your app to send a message to the other
 renderer.
 
-```js
+```js title='renderer.js (Renderer Process)'
 // elsewhere in your code to send a message to the other renderers message handler
 window.messagePort.postmessage('ping')
 ```
@@ -163,8 +161,7 @@ In this example, your app has a worker process implemented as a hidden window.
 You want the app page to be able to communicate directly with the worker
 process, without the performance overhead of relaying via the main process.
 
-```js
-// main.js ///////////////////////////////////////////////////////////////////
+```js title='main.js (Main Process)'
 const { BrowserWindow, app, ipcMain, MessageChannelMain } = require('electron')
 
 app.whenReady().then(async () => {
@@ -202,8 +199,7 @@ app.whenReady().then(async () => {
 })
 ```
 
-```html
-<!-- worker.html ------------------------------------------------------------>
+```html  title='worker.html'
 <script>
 const { ipcRenderer } = require('electron')
 
@@ -226,8 +222,7 @@ ipcRenderer.on('new-client', (event) => {
 </script>
 ```
 
-```html
-<!-- app.html --------------------------------------------------------------->
+```html  title='app.html'
 <script>
 const { ipcRenderer } = require('electron')
 
@@ -255,9 +250,7 @@ Electron's built-in IPC methods only support two modes: fire-and-forget
 can implement a "response stream", where a single request responds with a
 stream of data.
 
-```js
-// renderer.js ///////////////////////////////////////////////////////////////
-
+```js title='renderer.js (Renderer Process)'
 const makeStreamingRequest = (element, callback) => {
   // MessageChannels are lightweight--it's cheap to create a new one for each
   // request.
@@ -286,9 +279,7 @@ makeStreamingRequest(42, (data) => {
 // We will see "got response data: 42" 10 times.
 ```
 
-```js
-// main.js ///////////////////////////////////////////////////////////////////
-
+```js  title='main.js (Main Process)'
 ipcMain.on('give-me-a-stream', (event, msg) => {
   // The renderer has sent us a MessagePort that it wants us to send our
   // response over.
@@ -315,8 +306,7 @@ the renderer are delivered to the isolated world, rather than to the main
 world. Sometimes you want to deliver messages to the main world directly,
 without having to step through the isolated world.
 
-```js
-// main.js ///////////////////////////////////////////////////////////////////
+```js title='main.js (Main Process)'
 const { BrowserWindow, app, MessageChannelMain } = require('electron')
 const path = require('path')
 
@@ -351,8 +341,7 @@ app.whenReady().then(async () => {
 })
 ```
 
-```js
-// preload.js ////////////////////////////////////////////////////////////////
+```js title='preload.js (Preload Script)'
 const { ipcRenderer } = require('electron')
 
 // We need to wait until the main world is ready to receive the message before
@@ -370,8 +359,7 @@ ipcRenderer.on('main-world-port', async (event) => {
 })
 ```
 
-```html
-<!-- index.html ------------------------------------------------------------->
+```html title='index.html'
 <script>
 window.onmessage = (event) => {
   // event.source === window means the message is coming from the preload

--- a/docs/tutorial/message-ports.md
+++ b/docs/tutorial/message-ports.md
@@ -86,9 +86,9 @@ process, you can listen for the `close` event by calling `port.on('close',
 
 ### Setting up a MessageChannel between two renderers
 
-In this example, the main process sets up a MessageChannel, then sends each port 
-to a different renderer. This allows renderers to send messages to each other 
-without needing to use the main process as an in-between. 
+In this example, the main process sets up a MessageChannel, then sends each port
+to a different renderer. This allows renderers to send messages to each other
+without needing to use the main process as an in-between.
 
 ```js
 // main.js ///////////////////////////////////////////////////////////////////
@@ -127,8 +127,9 @@ app.whenReady().then(async () => {
   })
 })
 ```
-Then, in your preload scripts you receive the port through IPC and set up the 
-listeners. 
+
+Then, in your preload scripts you receive the port through IPC and set up the
+listeners.
 
 ```js
 // preloadMain.js and preloadSecondary.js
@@ -143,20 +144,19 @@ ipcRenderer.on('port', e => {
   }
 })
 ```
+
 In this example messagePort is bound to the `window` object directly. It is better
-to use `contextIsolation` and set up specific contextBridge calls for each of your 
+to use `contextIsolation` and set up specific contextBridge calls for each of your
 expected messages, but for the simplicity of this example we don't.
 
-That means window.messagePort is globally available and you can call 
-`postMessage` on it from anywhere in your app to send a message to the other 
+That means window.messagePort is globally available and you can call
+`postMessage` on it from anywhere in your app to send a message to the other
 renderer.
 
 ```js
 // elsewhere in your code to send a message to the other renderers message handler
 window.messagePort.postmessage('ping')
 ```
-
-
 
 ### Worker process
 


### PR DESCRIPTION
#### Description of Change

Added a code example describing how to set up a `messageChannel` between two renderers from inside of main. 

#### Checklist
- [x] relevant documentation is changed or added

#### Release Notes

Notes: none
