### PR TITLE
chore: remove unused WebContents._sendToFrameInternal

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -124,13 +124,6 @@ WebContents.prototype.sendToFrame = function (frameId, channel, ...args) {
   return true;
 };
 
-WebContents.prototype._sendToFrameInternal = function (frameId, channel, ...args) {
-  const frame = getWebFrame(this, frameId);
-  if (!frame) return false;
-  frame._sendInternal(channel, ...args);
-  return true;
-};
-
 // Following methods are mapped to webFrame.
 const webFrameMethods = [
   'insertCSS',

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -66,7 +66,6 @@ declare namespace Electron {
     _callWindowOpenHandler(event: any, details: Electron.HandlerDetails): {browserWindowConstructorOptions: Electron.BrowserWindowConstructorOptions | null, outlivesOpener: boolean};
     _setNextChildWebPreferences(prefs: Partial<Electron.BrowserWindowConstructorOptions['webPreferences']> & Pick<Electron.BrowserWindowConstructorOptions, 'backgroundColor'>): void;
     _send(internal: boolean, channel: string, args: any): boolean;
-    _sendToFrameInternal(frameId: number | [number, number], channel: string, ...args: any[]): boolean;
     _sendInternal(channel: string, ...args: any[]): void;
     _printToPDF(options: any): Promise<Buffer>;
     _print(options: any, callback?: (success: boolean, failureReason: string) => void): void;


### PR DESCRIPTION
#### Description of Change
This method was once used for the remote module, and is no longer used.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none
