### PR TITLE
docs: don't wait for ready event to register open-url listener

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -130,6 +130,11 @@ set `NSPrincipalClass` to `AtomApplication`.
 
 You should call `event.preventDefault()` if you want to handle this event.
 
+As with the `open-file`, be sure to register a listener for the 'open-url' event
+early in your application startup to detect if the the application being is
+being opened to handle a URL. If you register the listener in response to a 'ready'
+event, you'll miss it.
+
 ### Event: 'activate' _macOS_
 
 Returns:

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -130,10 +130,10 @@ set `NSPrincipalClass` to `AtomApplication`.
 
 You should call `event.preventDefault()` if you want to handle this event.
 
-As with the `open-file`, be sure to register a listener for the 'open-url' event
-early in your application startup to detect if the the application being is
-being opened to handle a URL. If you register the listener in response to a 'ready'
-event, you'll miss it.
+As with the `open-file` event, be sure to register a listener for the `open-url`
+event early in your application startup to detect if the the application being
+is being opened to handle a URL. If you register the listener in response to a
+`ready` event, you'll miss URLs that trigger the launch of your application.
 
 ### Event: 'activate' _macOS_
 


### PR DESCRIPTION
Add warning about late registration of the `open-url` event, similar to that of `open-file`.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none