### PR TITLE
docs: update build dependencies for Fedora

### DIFF
--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -47,10 +47,10 @@ $ sudo yum install clang dbus-devel gtk3-devel libnotify-devel \
 On Fedora, install the following libraries:
 
 ```sh
-$ sudo dnf install clang dbus-devel gtk3-devel libnotify-devel \
-                   libgnome-keyring-devel xorg-x11-server-utils libcap-devel \
+$ sudo dnf install clang dbus-devel gperf gtk3-devel \
+                   libnotify-devel libgnome-keyring-devel libcap-devel \
                    cups-devel libXtst-devel alsa-lib-devel libXrandr-devel \
-                   nss-devel python-dbusmock openjdk-8-jre
+                   nss-devel python-dbusmock
 ```
 
 On Arch Linux / Manjaro, install the following libraries:


### PR DESCRIPTION
#### Description of Change

This PR slightly updates the required packages needed to build Electron on Fedora, based on a recent debugging session. Two packages are no longer available and have been removed, and one package was needed that wasn't listed (see `.build/install-build-deps.sh` in Chromium src for more information) 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
