### PR TITLE
docs: Add missing link to tutorial page

### DIFF
--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -66,6 +66,7 @@ Are you getting stuck anywhere? Here are a few links to places to look:
 
 <!-- Links -->
 
+[tutorial]: tutorial-1-prerequisites.md
 [api documentation]: ../api/app.md
 [chromium]: https://www.chromium.org/
 [discord]: https://discord.gg/electronjs


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

### Why
The introduction page in the official docs has a missing link to the tutorial page
![image](https://user-images.githubusercontent.com/17537040/180583860-771bd495-2345-470b-990e-a640f92e1c2e.png)


### What
Add missing link to tutorial page from `introduction.md`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
