### PR TITLE
fix: empty result of `webContents.getUserAgent()`

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -675,10 +675,8 @@ WebContents::WebContents(v8::Isolate* isolate,
   auto session = Session::CreateFrom(isolate, GetBrowserContext());
   session_.Reset(isolate, session.ToV8());
 
-  absl::optional<std::string> user_agent_override =
-      GetBrowserContext()->GetUserAgentOverride();
-  if (user_agent_override)
-    SetUserAgent(*user_agent_override);
+  SetUserAgent(GetBrowserContext()->GetUserAgent());
+
   web_contents->SetUserData(kElectronApiWebContentsKey,
                             std::make_unique<UserDataLink>(GetWeakPtr()));
   InitZoomController(web_contents, gin::Dictionary::CreateEmpty(isolate));
@@ -884,10 +882,7 @@ void WebContents::InitWithSessionAndOptions(
 
   AutofillDriverFactory::CreateForWebContents(web_contents());
 
-  absl::optional<std::string> user_agent_override =
-      GetBrowserContext()->GetUserAgentOverride();
-  if (user_agent_override)
-    SetUserAgent(*user_agent_override);
+  SetUserAgent(GetBrowserContext()->GetUserAgent());
 
   if (IsGuest()) {
     NativeWindow* owner_window = nullptr;

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -308,11 +308,6 @@ std::string ElectronBrowserContext::GetUserAgent() const {
   return user_agent_.value_or(ElectronBrowserClient::Get()->GetUserAgent());
 }
 
-absl::optional<std::string> ElectronBrowserContext::GetUserAgentOverride()
-    const {
-  return user_agent_;
-}
-
 predictors::PreconnectManager* ElectronBrowserContext::GetPreconnectManager() {
   if (!preconnect_manager_.get()) {
     preconnect_manager_ =

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -89,7 +89,6 @@ class ElectronBrowserContext : public content::BrowserContext {
 
   void SetUserAgent(const std::string& user_agent);
   std::string GetUserAgent() const;
-  absl::optional<std::string> GetUserAgentOverride() const;
   bool CanUseHttpCache() const;
   int GetMaxCacheSize() const;
   ResolveProxyHelper* GetResolveProxyHelper();

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -902,6 +902,12 @@ describe('webContents module', () => {
   });
 
   describe('userAgent APIs', () => {
+    it('is not empty by default', () => {
+      const w = new BrowserWindow({ show: false });
+      const userAgent = w.webContents.getUserAgent();
+      expect(userAgent).to.be.a('string').that.is.not.empty();
+    });
+
     it('can set the user agent (functions)', () => {
       const w = new BrowserWindow({ show: false });
       const userAgent = w.webContents.getUserAgent();


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/35046.

Refs https://github.com/electron/electron/pull/34481 - this change made it such that we were [no longer initializing the user agent](https://github.com/electron/electron/pull/34481/files#diff-fa823350727ad86e0ac08c18d6f17e24a62d653b43a08242e4608f5a8ee8e5b9L110) and so it would always be empty when calling `webContents.getUserAgent()` unless it had been previously set by `webContents.setUserAgent(agent)`. This fixes that, and incidentally removes the need to have a separate `GetUserAgentOverride`.

Confirmed not to regress https://github.com/electron/electron/issues/30201

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed `webContents.getUserAgent()` incorrectly returning an empty string unless previously set.