### PR TITLE
fix: handle WCO pressed state when going maximized -> minimized

### DIFF
--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -225,6 +225,7 @@ class NativeWindowViews : public NativeWindow,
 
 #if BUILDFLAG(IS_WIN)
   void HandleSizeEvent(WPARAM w_param, LPARAM l_param);
+  void ResetWindowControls();
   void SetForwardMouseMessages(bool forward);
   static LRESULT CALLBACK SubclassProc(HWND hwnd,
                                        UINT msg,

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -415,6 +415,7 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
           last_window_state_ != ui::SHOW_STATE_MAXIMIZED) {
         last_window_state_ = ui::SHOW_STATE_MAXIMIZED;
         NotifyWindowMaximize();
+        ResetWindowControls();
       } else if (w_param == SIZE_MINIMIZED &&
                  last_window_state_ != ui::SHOW_STATE_MINIMIZED) {
         last_window_state_ = ui::SHOW_STATE_MINIMIZED;
@@ -440,15 +441,20 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
         default:
           break;
       }
-      // If a given window was minimized/maximized and has since been
-      // restored, ensure the WCO buttons are set to normal state.
-      auto* ncv = widget()->non_client_view();
-      if (IsWindowControlsOverlayEnabled() && ncv) {
-        auto* frame_view = static_cast<WinFrameView*>(ncv->frame_view());
-        frame_view->caption_button_container()->ResetWindowControls();
-      }
+      ResetWindowControls();
       break;
     }
+  }
+}
+
+void NativeWindowViews::ResetWindowControls() {
+  // If a given window was minimized and has since been
+  // unminimized (restored/maximized), ensure the WCO buttons
+  // are reset to their default unpressed state.
+  auto* ncv = widget()->non_client_view();
+  if (IsWindowControlsOverlayEnabled() && ncv) {
+    auto* frame_view = static_cast<WinFrameView*>(ncv->frame_view());
+    frame_view->caption_button_container()->ResetWindowControls();
   }
 }
 


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/34763#issuecomment-1195342899 - augments previous solution in https://github.com/electron/electron/pull/34771 to handle the case where a window is unminimized directly back into a maximized state without being restored. The previous solution incorrectly assumed that a window would be restored after being maximized.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a Windows Control Overlay issue where a window taken directly from minimized to maximized state could have incorrect hover state.
