### PR TITLE
test: remove duplicate test that is causing hang in Windows

### DIFF
--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -62,14 +62,6 @@ describe('chromium feature', () => {
   });
 
   describe('window.open', () => {
-    it('accepts "nodeIntegration" as feature', async () => {
-      const message = waitForEvent(window, 'message');
-      const b = window.open(`file://${fixtures}/pages/window-opener-node.html`, '', 'nodeIntegration=no,show=no');
-      const event = await message;
-      b.close();
-      expect(event.data.isProcessGlobalUndefined).to.be.true();
-    });
-
     it('inherit options of parent window', async () => {
       const message = waitForEvent(window, 'message');
       const b = window.open(`file://${fixtures}/pages/window-open-size.html`, '', 'show=no');


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Windows CI has been hanging while running `spec/chromium-spec.js`, eg: https://ci.appveyor.com/project/electron-bot/electron-x64-testing/builds/44279018

Investigating this, I found that removing the test `chromium feature window.open accepts "nodeIntegration" as feature` resolves the hang as seen by this test run that runs through that test file 100 times:
https://ci.appveyor.com/project/electron-bot/electron-x64-testing/builds/44276581.

Researching further, we basically have a duplicate test in spec-main: https://github.com/electron/electron/blob/main/spec-main/chromium-spec.ts#L842, so this test is not necessary in `spec/chromium-spec.js` anymore. so I removed it completely.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
