### PR TITLE
fix: crash on startup in X11

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -278,12 +278,6 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
 }
 
 int ElectronBrowserMainParts::PreCreateThreads() {
-#if defined(USE_AURA)
-  if (!display::Screen::GetScreen()) {
-    screen_ = views::CreateDesktopScreen();
-  }
-#endif
-
   if (!views::LayoutProvider::Get())
     layout_provider_ = std::make_unique<views::LayoutProvider>();
 
@@ -313,6 +307,14 @@ int ElectronBrowserMainParts::PreCreateThreads() {
 
   // Load resources bundle according to locale.
   std::string loaded_locale = LoadResourceBundle(locale);
+
+#if defined(USE_AURA)
+  // NB: must be called _after_ locale resource bundle is loaded,
+  // because ui lib makes use of it in X11
+  if (!display::Screen::GetScreen()) {
+    screen_ = views::CreateDesktopScreen();
+  }
+#endif
 
   // Initialize the app locale.
   std::string app_locale = l10n_util::GetApplicationLocale(loaded_locale);


### PR DESCRIPTION
#### Description of Change

Fixes #34996.

This is a regression introduced in 20.0.0-beta.9 caused by `ElectronBrowserMainParts::PreCreateThreads()` creating the main window before loading the locale resource bundle, but `ui::BuildDisplaysFromXRandRInfo()` needed that locale info to be loaded.

CC @electron/wg-releases 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix 20.0.0-beta.8 X11 crash regression.