### PR TITLE
fix: use win_clang_x64 binary for x86 extract symbols

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -170,19 +170,16 @@ build_script:
   - python %LOCAL_GOMA_DIR%\goma_ctl.py stat
   - python3 electron/build/profile_toolchain.py --output-json=out/Default/windows_toolchain_profile.json
   - 7z a node_headers.zip out\Default\gen\node_headers
-  # Temporarily disable symbol generation on 32-bit Windows due to failures  
   - ps: >-
-      if ($env:GN_CONFIG -eq 'release' -And $env:TARGET_ARCH -ne 'ia32') {
+      if ($env:GN_CONFIG -eq 'release') {
         # Needed for msdia140.dll on 64-bit windows
         $env:Path += ";$pwd\third_party\llvm-build\Release+Asserts\bin"
         ninja -C out/Default electron:electron_symbols
       }
   - ps: >-
       if ($env:GN_CONFIG -eq 'release') {
-        if ($env:TARGET_ARCH -ne 'ia32') {
-          python electron\script\zip-symbols.py
-          appveyor-retry appveyor PushArtifact out/Default/symbols.zip
-        }
+        python electron\script\zip-symbols.py
+        appveyor-retry appveyor PushArtifact out/Default/symbols.zip
       } else {
         # It's useful to have pdb files when debugging testing builds that are
         # built on CI.

--- a/build/extract_symbols.gni
+++ b/build/extract_symbols.gni
@@ -24,7 +24,11 @@ template("extract_symbols") {
     assert(defined(invoker.binary), "Need binary to dump")
     assert(defined(invoker.symbol_dir), "Need directory for symbol output")
 
-    dump_syms_label = "//third_party/breakpad:dump_syms($host_toolchain)"
+    if (host_os == "win" && target_cpu == "x86") {
+      dump_syms_label = "//third_party/breakpad:dump_syms(//build/toolchain/win:win_clang_x64)"
+    } else {
+      dump_syms_label = "//third_party/breakpad:dump_syms($host_toolchain)"
+    }
     dump_syms_binary = get_label_info(dump_syms_label, "root_out_dir") +
                        "/dump_syms$_host_executable_suffix"
 

--- a/script/release/release.js
+++ b/script/release/release.js
@@ -128,9 +128,8 @@ function assetsForVersion (version, validatingRelease) {
     `electron-${version}-mas-arm64-dsym-snapshot.zip`,
     `electron-${version}-mas-arm64-symbols.zip`,
     `electron-${version}-mas-arm64.zip`,
-    // TODO(vertedinde) Symbol generation on 32-bit Windows is temporarily disabled due to CI failures
-    // `electron-${version}-win32-ia32-pdb.zip`,
-    // `electron-${version}-win32-ia32-symbols.zip`,
+    `electron-${version}-win32-ia32-pdb.zip`,
+    `electron-${version}-win32-ia32-symbols.zip`,
     `electron-${version}-win32-ia32.zip`,
     `electron-${version}-win32-x64-pdb.zip`,
     `electron-${version}-win32-x64-symbols.zip`,

--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -76,10 +76,9 @@ def main():
   shutil.copy2(os.path.join(OUT_DIR, 'dist.zip'), electron_zip)
   upload_electron(release, electron_zip, args)
   if get_target_arch() != 'mips64el':
-    if (get_target_arch() != 'ia32' or PLATFORM != 'win32'):
-      symbols_zip = os.path.join(OUT_DIR, SYMBOLS_NAME)
-      shutil.copy2(os.path.join(OUT_DIR, 'symbols.zip'), symbols_zip)
-      upload_electron(release, symbols_zip, args)
+    symbols_zip = os.path.join(OUT_DIR, SYMBOLS_NAME)
+    shutil.copy2(os.path.join(OUT_DIR, 'symbols.zip'), symbols_zip)
+    upload_electron(release, symbols_zip, args)
   if PLATFORM == 'darwin':
     if get_platform_key() == 'darwin' and get_target_arch() == 'x64':
       api_path = os.path.join(ELECTRON_DIR, 'electron-api.json')
@@ -96,10 +95,9 @@ def main():
     shutil.copy2(os.path.join(OUT_DIR, 'dsym-snapshot.zip'), dsym_snapshot_zip)
     upload_electron(release, dsym_snapshot_zip, args)    
   elif PLATFORM == 'win32':
-    if get_target_arch() != 'ia32':
-      pdb_zip = os.path.join(OUT_DIR, PDB_NAME)
-      shutil.copy2(os.path.join(OUT_DIR, 'pdb.zip'), pdb_zip)
-      upload_electron(release, pdb_zip, args)
+    pdb_zip = os.path.join(OUT_DIR, PDB_NAME)
+    shutil.copy2(os.path.join(OUT_DIR, 'pdb.zip'), pdb_zip)
+    upload_electron(release, pdb_zip, args)
   elif PLATFORM == 'linux':
     debug_zip = os.path.join(OUT_DIR, DEBUG_NAME)
     shutil.copy2(os.path.join(OUT_DIR, 'debug.zip'), debug_zip)


### PR DESCRIPTION
#### Description of Change

Addresses #34413

We're currently experiencing build failures on main, 20-x-y and 18-x-y because the ia32 symbol generation is running out of virtual memory space. This PR uses the win_clang_x64 binary to extract/generate electron symbols for Windows x86.

_Note: This issue isn't currently affecting 19-x-y, but it was introduced into 18-x-y by a backported Chromium roll. Adding this change to 19-x-y will protect us against a potential future breakage in that branch._

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed symbol generation on 32-bit Windows release builds.
