### PR TITLE
docs: changed event.data to data under the message.port in docs

### DIFF
--- a/docs/tutorial/message-ports.md
+++ b/docs/tutorial/message-ports.md
@@ -272,7 +272,7 @@ const makeStreamingRequest = (element, callback) => {
 }
 
 makeStreamingRequest(42, (data) => {
-  console.log('got response data:', event.data)
+  console.log('got response data:', data)
 })
 // We will see "got response data: 42" 10 times.
 ```

--- a/docs/tutorial/message-ports.md
+++ b/docs/tutorial/message-ports.md
@@ -101,7 +101,7 @@ app.whenReady().then(async () => {
     }
   })
 
-  const secondaryWindow = BrowserWindow({
+  const secondaryWindow = new BrowserWindow({
     show: false,
     webPreferences: {
       contextIsolation: false,
@@ -144,7 +144,7 @@ to use `contextIsolation` and set up specific contextBridge calls for each of yo
 expected messages, but for the simplicity of this example we don't. You can find an
 example of context isolation further down this page at [Communicating directly between the main process and the main world of a context-isolated page](#communicating-directly-between-the-main-process-and-the-main-world-of-a-context-isolated-page)
 
-That means window.messagePort is globally available and you can call
+That means window.electronMessagePort is globally available and you can call
 `postMessage` on it from anywhere in your app to send a message to the other
 renderer.
 


### PR DESCRIPTION
#### Description of Change   

changed event.data to data under the message.port in docs.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> none
