### PR TITLE
chore: cherry-pick 664e0d8b4cfb from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -136,3 +136,4 @@ remove_default_window_title.patch
 cherry-pick-d7a5d6b38ea8.patch
 cherry-pick-22abbad430b6.patch
 cherry-pick-3cbd5973d704.patch
+cherry-pick-664e0d8b4cfb.patch

--- a/patches/chromium/cherry-pick-664e0d8b4cfb.patch
+++ b/patches/chromium/cherry-pick-664e0d8b4cfb.patch
@@ -1,7 +1,7 @@
-From 664e0d8b4cfb328c8425a385d9b958d031013e65 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Etienne Bergeron <etienneb@chromium.org>
 Date: Tue, 19 Jul 2022 16:46:43 +0000
-Subject: [PATCH] [M96-LTS] Fix incorrect text itemization for \r codepoint
+Subject: Fix incorrect text itemization for \r codepoint
 
 M96 merge issues:
   render_text_unittest.cc
@@ -31,13 +31,12 @@ Reviewed-by: Etienne Bergeron <etienneb@chromium.org>
 Commit-Queue: Roger Felipe Zanoni da Silva <rzanoni@google.com>
 Cr-Commit-Position: refs/branch-heads/4664@{#1662}
 Cr-Branched-From: 24dc4ee75e01a29d390d43c9c264372a169273a7-refs/heads/main@{#929512}
----
 
 diff --git a/ui/gfx/render_text_harfbuzz.cc b/ui/gfx/render_text_harfbuzz.cc
-index e378c6c6..9e99256 100644
+index cd19053ad39a8386b348ae89fb2cf59bcfddb01a..cd779904454940f744cd82c5365ece7147633c2b 100644
 --- a/ui/gfx/render_text_harfbuzz.cc
 +++ b/ui/gfx/render_text_harfbuzz.cc
-@@ -200,7 +200,7 @@
+@@ -201,7 +201,7 @@ GraphemeProperties RetrieveGraphemeProperties(const base::StringPiece16& text,
          properties.block = ublock_getCode(codepoint);
      }
  
@@ -47,10 +46,10 @@ index e378c6c6..9e99256 100644
      if (IsBracket(codepoint))
        properties.has_bracket = true;
 diff --git a/ui/gfx/render_text_unittest.cc b/ui/gfx/render_text_unittest.cc
-index 629bb25d..42f346c5 100644
+index 43d03699495c935cd1203e8195d12571fa92b347..e33d25270efb49ee8498108dfa0473b4f760d732 100644
 --- a/ui/gfx/render_text_unittest.cc
 +++ b/ui/gfx/render_text_unittest.cc
-@@ -1573,6 +1573,9 @@
+@@ -1575,6 +1575,9 @@ const RunListCase kBasicsRunListCases[] = {
      {"multiline_newline1", u"\n\n", "[0][1]", true},
      {"multiline_newline2", u"\r\n\r\n", "[0->1][2->3]", true},
      {"multiline_newline3", u"\r\r\n", "[0][1->2]", true},
@@ -60,7 +59,7 @@ index 629bb25d..42f346c5 100644
  };
  
  INSTANTIATE_TEST_SUITE_P(ItemizeTextToRunsBasics,
-@@ -8546,4 +8549,14 @@
+@@ -8561,4 +8564,14 @@ TEST_F(RenderTextTest, StringSizeUpdatedWhenDeviceScaleFactorChanges) {
  }
  #endif
  

--- a/patches/chromium/cherry-pick-664e0d8b4cfb.patch
+++ b/patches/chromium/cherry-pick-664e0d8b4cfb.patch
@@ -1,0 +1,77 @@
+From 664e0d8b4cfb328c8425a385d9b958d031013e65 Mon Sep 17 00:00:00 2001
+From: Etienne Bergeron <etienneb@chromium.org>
+Date: Tue, 19 Jul 2022 16:46:43 +0000
+Subject: [PATCH] [M96-LTS] Fix incorrect text itemization for \r codepoint
+
+M96 merge issues:
+  render_text_unittest.cc
+    Tests Clusterfuzz_Issue_1298286/1299054 aren't present
+    in M96 and caused a merge conflict.
+
+The "\r" codepoint should be split to be rendered in a single
+harfbuzz run (same as "\n").
+
+We do recognize these sequences as newline:
+  \r
+  \n
+  \r\n
+
+Previously, the itemization will leave the "\r" with the previous
+run. This is leading to incorrect multiline lines splitting.
+
+(cherry picked from commit eee0c5ca752ad50df9986c551cb98226ce078893)
+
+Bug: 1287804
+Change-Id: Idfc00a3cf147eb53258d5da9ea105e2d6dc25f05
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3708936
+Commit-Queue: Etienne Bergeron <etienneb@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1014955}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3726349
+Reviewed-by: Etienne Bergeron <etienneb@chromium.org>
+Commit-Queue: Roger Felipe Zanoni da Silva <rzanoni@google.com>
+Cr-Commit-Position: refs/branch-heads/4664@{#1662}
+Cr-Branched-From: 24dc4ee75e01a29d390d43c9c264372a169273a7-refs/heads/main@{#929512}
+---
+
+diff --git a/ui/gfx/render_text_harfbuzz.cc b/ui/gfx/render_text_harfbuzz.cc
+index e378c6c6..9e99256 100644
+--- a/ui/gfx/render_text_harfbuzz.cc
++++ b/ui/gfx/render_text_harfbuzz.cc
+@@ -200,7 +200,7 @@
+         properties.block = ublock_getCode(codepoint);
+     }
+ 
+-    if (codepoint == '\n' || codepoint == ' ')
++    if (codepoint == '\n' || codepoint == '\r' || codepoint == ' ')
+       properties.has_control = true;
+     if (IsBracket(codepoint))
+       properties.has_bracket = true;
+diff --git a/ui/gfx/render_text_unittest.cc b/ui/gfx/render_text_unittest.cc
+index 629bb25d..42f346c5 100644
+--- a/ui/gfx/render_text_unittest.cc
++++ b/ui/gfx/render_text_unittest.cc
+@@ -1573,6 +1573,9 @@
+     {"multiline_newline1", u"\n\n", "[0][1]", true},
+     {"multiline_newline2", u"\r\n\r\n", "[0->1][2->3]", true},
+     {"multiline_newline3", u"\r\r\n", "[0][1->2]", true},
++    {"multiline_newline4", u"x\r\r", "[0][1][2]", true},
++    {"multiline_newline5", u"x\n\r\r", "[0][1][2][3]", true},
++    {"multiline_newline6", u"x\ny\rz\r\n", "[0][1][2][3][4][5->6]", true},
+ };
+ 
+ INSTANTIATE_TEST_SUITE_P(ItemizeTextToRunsBasics,
+@@ -8546,4 +8549,14 @@
+ }
+ #endif
+ 
++TEST_F(RenderTextTest, Clusterfuzz_Issue_1287804) {
++  RenderText* render_text = GetRenderText();
++  render_text->SetMaxLines(1);
++  render_text->SetText(u">\r\r");
++  render_text->SetMultiline(true);
++  render_text->SetDisplayRect(Rect(0, 0, 100, 24));
++  render_text->SetElideBehavior(ELIDE_TAIL);
++  EXPECT_EQ(RangeF(0, 0), render_text->GetCursorSpan(Range(0, 0)));
++}
++
+ }  // namespace gfx


### PR DESCRIPTION
[M96-LTS] Fix incorrect text itemization for \r codepoint

M96 merge issues:
  render_text_unittest.cc
    Tests Clusterfuzz_Issue_1298286/1299054 aren't present
    in M96 and caused a merge conflict.

The "\r" codepoint should be split to be rendered in a single
harfbuzz run (same as "\n").

We do recognize these sequences as newline:
  \r
  \n
  \r\n

Previously, the itemization will leave the "\r" with the previous
run. This is leading to incorrect multiline lines splitting.

(cherry picked from commit eee0c5ca752ad50df9986c551cb98226ce078893)

Bug: 1287804
Change-Id: Idfc00a3cf147eb53258d5da9ea105e2d6dc25f05
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3708936
Commit-Queue: Etienne Bergeron <etienneb@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1014955}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3726349
Reviewed-by: Etienne Bergeron <etienneb@chromium.org>
Commit-Queue: Roger Felipe Zanoni da Silva <rzanoni@google.com>
Cr-Commit-Position: refs/branch-heads/4664@{#1662}
Cr-Branched-From: 24dc4ee75e01a29d390d43c9c264372a169273a7-refs/heads/main@{#929512}


Notes: Security: backported fix for 1287804.