### PR TITLE
ci: explicitly use pylint-1.5 for pylint

### DIFF
--- a/script/lint.js
+++ b/script/lint.js
@@ -103,7 +103,7 @@ const LINTERS = [{
     const rcfile = path.join(DEPOT_TOOLS, 'pylintrc');
     const args = ['--rcfile=' + rcfile, ...filenames];
     const env = Object.assign({ PYTHONPATH: path.join(ELECTRON_ROOT, 'script') }, process.env);
-    spawnAndCheckExitCode('pylint', args, { env });
+    spawnAndCheckExitCode('pylint-1.5', args, { env });
   }
 }, {
   key: 'javascript',


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/3780302 broke lint because we were using `pylint` instead of a specific version.  This PR fixes our linting to explicitly use `pylint-1.5` since that is what the `pylint` alias was pointing to.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
