### PR TITLE
fix: DCHECK entering fullscreen while loading url

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1332,6 +1332,8 @@ void WebContents::OnEnterFullscreenModeForTab(
     return;
   }
 
+  owner_window()->set_fullscreen_transition_type(
+      NativeWindow::FullScreenTransitionType::HTML);
   exclusive_access_manager_->fullscreen_controller()->EnterFullscreenModeForTab(
       requesting_frame, options.display_id);
 
@@ -3542,12 +3544,15 @@ void WebContents::EnumerateDirectory(
 
 bool WebContents::IsFullscreenForTabOrPending(
     const content::WebContents* source) {
-  bool transition_fs = owner_window()
-                           ? owner_window()->fullscreen_transition_state() !=
-                                 NativeWindow::FullScreenTransitionState::NONE
-                           : false;
+  if (!owner_window())
+    return html_fullscreen_;
 
-  return html_fullscreen_ || transition_fs;
+  bool in_transition = owner_window()->fullscreen_transition_state() !=
+                       NativeWindow::FullScreenTransitionState::NONE;
+  bool is_html_transition = owner_window()->fullscreen_transition_type() ==
+                            NativeWindow::FullScreenTransitionType::HTML;
+
+  return html_fullscreen_ || (in_transition && is_html_transition);
 }
 
 bool WebContents::TakeFocus(content::WebContents* source, bool reverse) {

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -718,8 +718,10 @@ std::string NativeWindow::GetAccessibleTitle() {
 }
 
 void NativeWindow::HandlePendingFullscreenTransitions() {
-  if (pending_transitions_.empty())
+  if (pending_transitions_.empty()) {
+    set_fullscreen_transition_type(FullScreenTransitionType::NONE);
     return;
+  }
 
   bool next_transition = pending_transitions_.front();
   pending_transitions_.pop();

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -318,15 +318,25 @@ class NativeWindow : public base::SupportsUserData,
     observers_.RemoveObserver(obs);
   }
 
-  enum class FullScreenTransitionState { ENTERING, EXITING, NONE };
-
   // Handle fullscreen transitions.
   void HandlePendingFullscreenTransitions();
+
+  enum class FullScreenTransitionState { ENTERING, EXITING, NONE };
+
   void set_fullscreen_transition_state(FullScreenTransitionState state) {
     fullscreen_transition_state_ = state;
   }
   FullScreenTransitionState fullscreen_transition_state() const {
     return fullscreen_transition_state_;
+  }
+
+  enum class FullScreenTransitionType { HTML, NATIVE, NONE };
+
+  void set_fullscreen_transition_type(FullScreenTransitionType type) {
+    fullscreen_transition_type_ = type;
+  }
+  FullScreenTransitionType fullscreen_transition_type() const {
+    return fullscreen_transition_type_;
   }
 
   views::Widget* widget() const { return widget_.get(); }
@@ -390,6 +400,8 @@ class NativeWindow : public base::SupportsUserData,
   std::queue<bool> pending_transitions_;
   FullScreenTransitionState fullscreen_transition_state_ =
       FullScreenTransitionState::NONE;
+  FullScreenTransitionType fullscreen_transition_type_ =
+      FullScreenTransitionType::NONE;
 
  private:
   std::unique_ptr<views::Widget> widget_;

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -19,7 +19,7 @@
 
 using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 using FullScreenTransitionState =
-    electron::NativeWindowMac::FullScreenTransitionState;
+    electron::NativeWindow::FullScreenTransitionState;
 
 @implementation ElectronNSWindowDelegate
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -4954,6 +4954,17 @@ describe('BrowserWindow module', () => {
         await leaveFullScreen;
       });
 
+      it('should be able to load a URL while transitioning to fullscreen', async () => {
+        const w = new BrowserWindow({ fullscreen: true });
+        w.loadFile(path.join(fixtures, 'pages', 'c.html'));
+
+        const load = emittedOnce(w.webContents, 'did-finish-load');
+        const enterFS = emittedOnce(w, 'enter-full-screen');
+
+        await Promise.all([enterFS, load]);
+        expect(w.fullScreen).to.be.true();
+      });
+
       it('can be changed with setFullScreen method', async () => {
         const w = new BrowserWindow();
         const enterFullScreen = emittedOnce(w, 'enter-full-screen');

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -4963,6 +4963,12 @@ describe('BrowserWindow module', () => {
 
         await Promise.all([enterFS, load]);
         expect(w.fullScreen).to.be.true();
+
+        await delay();
+
+        const leaveFullScreen = emittedOnce(w, 'leave-full-screen');
+        w.setFullScreen(false);
+        await leaveFullScreen;
       });
 
       it('can be changed with setFullScreen method', async () => {


### PR DESCRIPTION
#### Description of Change

Fixes a DCHECK introduced by https://github.com/electron/electron/pull/32905. This was happening because I adapted `WebContents::IsFullscreenForTabOrPending` to also return true if the window was in a fullscreen transition state, but this only applies in the context of the problem is the window is entering fullscreen _from html_. e.g. with `document.enterFullscreen()`. This change makes it so that html fullscreen and native fullscreen both receive appropriate values.

<details><summary>Stacktrace</summary>

```
88442:0728/112318.332158:FATAL:web_contents_impl.cc(5858)] Check failed: !IsFullscreen(). 
0   Electron Framework                  0x000000012a8a7ec2 base::debug::CollectStackTrace(void**, unsigned long) + 18
1   Electron Framework                  0x000000012a7c5223 base::debug::StackTrace::StackTrace() + 19
2   Electron Framework                  0x000000012a7deda7 logging::LogMessage::~LogMessage() + 183
3   Electron Framework                  0x000000012a7dfc3e logging::LogMessage::~LogMessage() + 14
4   Electron Framework                  0x0000000129b41aad content::WebContentsImpl::DidNavigateMainFramePreCommit(content::FrameTreeNode*, bool) + 237
5   Electron Framework                  0x000000012990de69 content::Navigator::DidNavigate(content::RenderFrameHostImpl*, content::mojom::DidCommitProvisionalLoadParams const&, std::Cr::unique_ptr<content::NavigationRequest, std::Cr::default_delete<content::NavigationRequest>>, bool) + 841
6   Electron Framework                  0x0000000129930f52 content::RenderFrameHostImpl::DidCommitNavigationInternal(std::Cr::unique_ptr<content::NavigationRequest, std::Cr::default_delete<content::NavigationRequest>>, mojo::StructPtr<content::mojom::DidCommitProvisionalLoadParams>, mojo::InlinedStructPtr<content::mojom::DidCommitSameDocumentNavigationParams>) + 5602
7   Electron Framework                  0x000000012992f34f content::RenderFrameHostImpl::DidCommitNavigation(content::NavigationRequest*, mojo::StructPtr<content::mojom::DidCommitProvisionalLoadParams>, mojo::StructPtr<content::mojom::DidCommitProvisionalLoadInterfaceParams>) + 1023
8   Electron Framework                  0x000000012996d002 base::internal::Invoker<base::internal::BindState<void (content::RenderFrameHostImpl::*)(content::NavigationRequest*, mojo::StructPtr<content::mojom::DidCommitProvisionalLoadParams>, mojo::StructPtr<content::mojom::DidCommitProvisionalLoadInterfaceParams>), base::internal::UnretainedWrapper<content::RenderFrameHostImpl>, base::internal::UnretainedWrapper<content::NavigationRequest>>, void (mojo::StructPtr<content::mojom::DidCommitProvisionalLoadParams>, mojo::StructPtr<content::mojom::DidCommitProvisionalLoadInterfaceParams>)>::RunOnce(base::internal::BindStateBase*, mojo::StructPtr<content::mojom::DidCommitProvisionalLoadParams>&&, mojo::StructPtr<content::mojom::DidCommitProvisionalLoadInterfaceParams>&&) + 82
9   Electron Framework                  0x00000001274b7415 content::mojom::NavigationClient_CommitNavigation_ForwardToCallback::Accept(mojo::Message*) + 293
10  Electron Framework                  0x000000012abdda22 mojo::InterfaceEndpointClient::HandleValidatedMessage(mojo::Message*) + 1554
11  Electron Framework                  0x000000012abe3d99 mojo::MessageDispatcher::Accept(mojo::Message*) + 265
12  Electron Framework                  0x000000012abdf55a mojo::InterfaceEndpointClient::HandleIncomingMessage(mojo::Message*) + 154
13  Electron Framework                  0x000000012b02aec1 IPC::(anonymous namespace)::ChannelAssociatedGroupController::AcceptOnEndpointThread(mojo::Message) + 721
14  Electron Framework                  0x000000012b0281cc base::internal::Invoker<base::internal::BindState<void (IPC::(anonymous namespace)::ChannelAssociatedGroupController::*)(mojo::Message), scoped_refptr<IPC::(anonymous namespace)::ChannelAssociatedGroupController>, mojo::Message>, void ()>::RunOnce(base::internal::BindStateBase*) + 140
15  Electron Framework                  0x000000012a83b7a9 base::TaskAnnotator::RunTaskImpl(base::PendingTask&) + 313
16  Electron Framework                  0x000000012a864505 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::sequence_manager::LazyNow*) + 1669
17  Electron Framework                  0x000000012a86399b base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() + 123
18  Electron Framework                  0x000000012a864cf5 non-virtual thunk to base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() + 21
19  Electron Framework                  0x000000012a8bd93b base::MessagePumpCFRunLoopBase::RunWork() + 91
20  Electron Framework                  0x000000012a8bc8b2 base::mac::CallWithEHFrame(void () block_pointer) + 10
21  Electron Framework                  0x000000012a8bce7f base::MessagePumpCFRunLoopBase::RunWorkSource(void*) + 63
22  CoreFoundation                      0x00007ff80289619b __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17
23  CoreFoundation                      0x00007ff802896103 __CFRunLoopDoSource0 + 180
24  CoreFoundation                      0x00007ff802895e7d __CFRunLoopDoSources0 + 242
25  CoreFoundation                      0x00007ff802894898 __CFRunLoopRun + 892
26  CoreFoundation                      0x00007ff802893e5c CFRunLoopRunSpecific + 562
27  HIToolbox                           0x00007ff80b53b5e6 RunCurrentEventLoopInMode + 292
28  HIToolbox                           0x00007ff80b53b34a ReceiveNextEventCommon + 594
29  HIToolbox                           0x00007ff80b53b0e5 _BlockUntilNextEventMatchingListInModeWithFilter + 70
30  AppKit                              0x00007ff8052d31fd _DPSNextEvent + 927
31  AppKit                              0x00007ff8052d18ba -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1394
32  AppKit                              0x00007ff8052c3f69 -[NSApplication run] + 586
33  Electron Framework                  0x000000012a8be36c base::MessagePumpNSApplication::DoRun(base::MessagePump::Delegate*) + 348
34  Electron Framework                  0x000000012a8bc964 base::MessagePumpCFRunLoopBase::Run(base::MessagePump::Delegate*) + 164
35  Electron Framework                  0x000000012a865287 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) + 679
36  Electron Framework                  0x000000012a813fb6 base::RunLoop::Run(base::Location const&) + 726
37  Electron Framework                  0x00000001293da6b3 content::BrowserMainLoop::RunMainMessageLoop() + 243
38  Electron Framework                  0x00000001293dc5f2 content::BrowserMainRunnerImpl::Run() + 82
39  Electron Framework                  0x00000001293d79ce content::BrowserMain(content::MainFunctionParams) + 270
40  Electron Framework                  0x0000000126055852 content::RunBrowserProcessMain(content::MainFunctionParams, content::ContentMainDelegate*) + 258
41  Electron Framework                  0x0000000126056f47 content::ContentMainRunnerImpl::RunBrowser(content::MainFunctionParams, bool) + 1383
42  Electron Framework                  0x0000000126056955 content::ContentMainRunnerImpl::Run() + 1125
43  Electron Framework                  0x0000000126055177 content::RunContentProcess(content::ContentMainParams, content::ContentMainRunner*) + 2679
44  Electron Framework                  0x0000000126055292 content::ContentMain(content::ContentMainParams) + 98
45  Electron Framework                  0x0000000125c0e7fd ElectronMain + 157
46  dyld                                0x000000010ff7851e start + 462
Task trace:
0   Electron Framework                  0x000000012b027290 IPC::(anonymous namespace)::ChannelAssociatedGroupController::Accept(mojo::Message*) + 784
1   Electron Framework                  0x000000012ac078de mojo::SimpleWatcher::Context::Notify(unsigned int, MojoHandleSignalsState, unsigned int) + 430
Crash keys:
  "amfi-status" = "rv=0 status=0x0 allow_everything=0"
  "ui_scheduler_async_stack" = "0x12B027290 0x12AC078DE"
  "io_scheduler_async_stack" = "0x129D6E721 0x129D6DC96"
  "platform" = "darwin"
  "process_type" = "browser"

Electron exited with signal SIGTRAP.
```

</details>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.
