### PR TITLE
docs: Fixed outdated documentation (uploading to App Store)

### DIFF
--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -232,7 +232,7 @@ how to meet the Mac App Store requirements.
 
 ### Upload
 
-The Application Loader should be used to upload the signed app to iTunes
+[Apple Transporter](apple-transporter) should be used to upload the signed app to App Store
 Connect for processing, making sure you have [created a record][create-record]
 before uploading.
 
@@ -345,7 +345,8 @@ Electron uses following cryptographic algorithms:
 [app-sandboxing]: https://developer.apple.com/app-sandboxing/
 [app-notarization]: https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution
 [submitting-your-app]: https://developer.apple.com/library/mac/documentation/IDEs/Conceptual/AppDistributionGuide/SubmittingYourApp/SubmittingYourApp.html
-[create-record]: https://developer.apple.com/library/ios/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Chapters/CreatingiTunesConnectRecord.html
+[create-record]: https://help.apple.com/app-store-connect/#/dev2cd126805
+[apple-transporter]: https://help.apple.com/itc/transporteruserguide/en.lproj/static.html
 [submit-for-review]: https://developer.apple.com/library/ios/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Chapters/SubmittingTheApp.html
 [export-compliance]: https://help.apple.com/app-store-connect/#/devc3f64248f
 [user-selected]: https://developer.apple.com/library/mac/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html#//apple_ref/doc/uid/TP40011195-CH4-SW6

--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -232,7 +232,7 @@ how to meet the Mac App Store requirements.
 
 ### Upload
 
-[Apple Transporter](apple-transporter) should be used to upload the signed app to App Store
+[Apple Transporter][apple-transporter] should be used to upload the signed app to App Store
 Connect for processing, making sure you have [created a record][create-record]
 before uploading.
 


### PR DESCRIPTION
#### Description of Change
- replaced mention of Application Loader with Apple Transporter, its replacement
- replaced mention of iTunes Connect with App Store Connect
- updated link for creating a record

Fixes https://github.com/electron/electron/issues/35115

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
