### PR TITLE
fix: remove skip-taskbar feature on Linux.

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1323,7 +1323,7 @@ win.setSheetOffset(toolbarRect.height)
 
 Starts or stops flashing the window to attract user's attention.
 
-#### `win.setSkipTaskbar(skip)`
+#### `win.setSkipTaskbar(skip)` _macOS_ _Windows_
 
 * `skip` boolean
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -300,14 +300,9 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
 
 #if defined(USE_OZONE_PLATFORM_X11)
   if (IsX11()) {
-    // TODO(ckerr): remove in Electron v20.0.0
     // Before the window is mapped the SetWMSpecState can not work, so we have
     // to manually set the _NET_WM_STATE.
     std::vector<x11::Atom> state_atom_list;
-    bool skip_taskbar = false;
-    if (options.Get(options::kSkipTaskbar, &skip_taskbar) && skip_taskbar) {
-      state_atom_list.push_back(x11::GetAtom("_NET_WM_STATE_SKIP_TASKBAR"));
-    }
 
     // Before the window is mapped, there is no SHOW_FULLSCREEN_STATE.
     if (fullscreen) {


### PR DESCRIPTION
#### Description of Change

This doesn't work in Wayland and won't be fixed. The feature couldn't be removed in e19 due to the policy of not removing features that aren't advertised in advance in Breaking Changes, so it was listed in e19 and is being removed now for e20.


See #33226 for more information.

CC @electron/wg-releases 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Removed the skip-taskbar feature on Linux.