### PR TITLE
feat: sandbox preloads by default

### DIFF
--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -312,9 +312,7 @@ bool WebContentsPreferences::IsSandboxed() const {
   if (sandbox_)
     return *sandbox_;
   bool sandbox_disabled_by_default =
-      node_integration_ || node_integration_in_worker_ || preload_path_ ||
-      !SessionPreferences::GetValidPreloads(web_contents_->GetBrowserContext())
-           .empty();
+      node_integration_ || node_integration_in_worker_;
   return !sandbox_disabled_by_default;
 }
 

--- a/spec-main/fixtures/apps/libuv-hang/main.js
+++ b/spec-main/fixtures/apps/libuv-hang/main.js
@@ -5,7 +5,8 @@ async function createWindow () {
   const mainWindow = new BrowserWindow({
     show: false,
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js')
+      preload: path.join(__dirname, 'preload.js'),
+      sandbox: false
     }
   });
 

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -243,6 +243,7 @@ describe('<webview> tag', function () {
     it('preload script can require modules that still use "process" and "Buffer" when nodeintegration is off', async () => {
       const message = await startLoadingWebViewAndWaitForMessage(webview, {
         preload: `${fixtures}/module/preload-node-off-wrapper.js`,
+        webpreferences: 'sandbox=no',
         src: `file://${fixtures}/api/blank.html`
       });
 
@@ -288,6 +289,7 @@ describe('<webview> tag', function () {
     it('works without script tag in page', async () => {
       const message = await startLoadingWebViewAndWaitForMessage(webview, {
         preload: `${fixtures}/module/preload.js`,
+        webpreferences: 'sandbox=no',
         src: `file://${fixtures}pages/base-page.html`
       });
 
@@ -303,6 +305,7 @@ describe('<webview> tag', function () {
     it('resolves relative URLs', async () => {
       const message = await startLoadingWebViewAndWaitForMessage(webview, {
         preload: '../fixtures/module/preload.js',
+        webpreferences: 'sandbox=no',
         src: `file://${fixtures}/pages/e.html`
       });
 
@@ -390,6 +393,7 @@ describe('<webview> tag', function () {
       const message = await startLoadingWebViewAndWaitForMessage(webview, {
         disablewebsecurity: '',
         preload: `${fixtures}/module/preload.js`,
+        webpreferences: 'sandbox=no',
         src: `file://${fixtures}/pages/e.html`
       });
 


### PR DESCRIPTION
Manual backport of #32869 

See that PR for details.

Notes: Notes: Renderers are now sandboxed by default unless `nodeIntegration: true` or `sandbox: false` is specified.