### PR TITLE
docs: update tray docs with info for mac menubar icons

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -25,15 +25,20 @@ app.whenReady().then(() => {
 })
 ```
 
-__Platform limitations:__
+__Platform Considerations__
 
-* On Linux the app indicator will be used if it is supported, otherwise
-  `GtkStatusIcon` will be used instead.
+If you want to keep exact same behaviors on all platforms, you should not
+rely on the `click` event; instead, always attach a context menu to the tray icon.
+
+__Linux__
+
 * On Linux distributions that only have app indicator support, you have to
   install `libappindicator1` to make the tray icon work.
+* The app indicator will be used if it is supported, otherwise
+  `GtkStatusIcon` will be used instead.
 * App indicator will only be shown when it has a context menu.
-* When app indicator is used on Linux, the `click` event is ignored.
-* On Linux in order for changes made to individual `MenuItem`s to take effect,
+* The `click` event is ignored when using the app indicator.
+* In order for changes made to individual `MenuItem`s to take effect,
   you have to call `setContextMenu` again. For example:
 
 ```javascript
@@ -55,10 +60,16 @@ app.whenReady().then(() => {
 })
 ```
 
-* On Windows it is recommended to use `ICO` icons to get best visual effects.
+__MacOS__
 
-If you want to keep exact same behaviors on all platforms, you should not
-rely on the `click` event and always attach a context menu to the tray icon.
+* Icons passed to the Tray constructor should be [Template Images](native-image.md#template-image).
+* To make sure your icon isn't grainy on retina monitors, be sure your `@2x` image is 144dpi.
+* If you are bundling your application (e.g., with webpack for development), be sure that the file names are not being mangled or hashed. The filename needs to end in Template, and the `@2x` image needs to have the same filename as the standard image, or MacOS will not magically invert your image's colors or use the high density image.
+* 16x16 (72dpi) and 32x32@2x (144dpi) work well for most icons.
+
+__Windows__
+
+* It is recommended to use `ICO` icons to get best visual effects.
 
 ### `new Tray(image, [guid])`
 


### PR DESCRIPTION
#### Description of Change
Updates tray documentation to make creating tray icons on macos a bit clearer.

#### Checklist

- [x] relevant documentation is changed or added

#### Release Notes
Notes: none
