### PR TITLE
fix: fail non-fatally when InitLogging fails

### DIFF
--- a/shell/common/logging.cc
+++ b/shell/common/logging.cc
@@ -141,7 +141,7 @@ void InitElectronLogging(const base::CommandLine& command_line,
           : APPEND_TO_OLD_LOG_FILE;
   bool success = InitLogging(settings);
   if (!success) {
-    PLOG(FATAL) << "Failed to init logging";
+    PLOG(ERROR) << "Failed to init logging";
   }
 
   SetLogItems(true /* pid */, false, true /* timestamp */, false);


### PR DESCRIPTION
Some apps use logging in production to collect data in the wild. However,
there's no way for such apps to recover from a situation in which logging fails
(e.g. if the log file location is not accessible).

Instead of crashing, log (?) an error and continue.

Notes: Do not exit when logging initialization fails.
