### PR TITLE
build: use macos.x86.medium.gen2 for macos publish jobs

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1935,7 +1935,7 @@ jobs:
   osx-publish-x64-skip-checkout:
     executor:
       name: macos
-      size: large
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large-release
       <<: *env-release-build
@@ -1956,7 +1956,7 @@ jobs:
   osx-publish-arm64-skip-checkout:
     executor:
       name: macos
-      size: large
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large-release
       <<: *env-release-build
@@ -2026,7 +2026,7 @@ jobs:
   mas-publish-x64-skip-checkout:
     executor:
       name: macos
-      size: large
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large-release
       <<: *env-mas
@@ -2047,7 +2047,7 @@ jobs:
   mas-publish-arm64-skip-checkout:
     executor:
       name: macos
-      size: large
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large-release
       <<: *env-mas-apple-silicon


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
#34983 updated the version of macOS used to build Electron because CircleCI removed support for that version of macOS.  Unfortunately the new version of macOS has less disk space and caused publish jobs to run out of disk space, eg: https://app.circleci.com/pipelines/github/electron/electron/56260/workflows/3bc90396-6f1a-4436-920e-17400f1a93db/jobs/1281741

This PR changes the mac publish jobs to use `macos.x86.medium.gen2` machines which have a large disk.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
