### PR TITLE
feat: add webFrame.securityOrigin

### DIFF
--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -314,3 +314,12 @@ current renderer process.
 An `Integer` representing the unique frame id in the current renderer process.
 Distinct WebFrame instances that refer to the same underlying frame will have
 the same `routingId`.
+
+### `webFrame.securityOrigin` _Readonly_
+
+A `string` representing the security origin assigned to this frame. A security
+origin can be defined as a URL which is shared across one or more frames
+with same-site synchronous script access. An `<iframe>` or window opened with
+`open()` may share the same security origin if permitted by the browser's
+same-site rules. Isolated resources without any parent frame, such as Data URIs
+or `about:blank`, may return an empty string.


### PR DESCRIPTION
#### Description of Change

Adds `securityOrigin` property to renderer's webFrame module.

Security origin tells a WebFrame which scripting context group it belongs to. A collection of same-site frames created using `<iframe>`, `open(sameSiteUrl)`, or `open('about:blank')` will have the same security origin.

A use case for this feature is to determine whether a preload script in an about:blank popup should run if its security origin is the same as the secure host WebContents.

cc @MarshallOfSound @nornagon

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `webFrame.securityOrigin` to determine the security origin of the frame.
