### PR TITLE
docs: Fix the URL bugs at tutorial-6-publishing-updating.md

### DIFF
--- a/docs/tutorial/tutorial-6-publishing-updating.md
+++ b/docs/tutorial/tutorial-6-publishing-updating.md
@@ -1,5 +1,5 @@
 ---
-title: "Publishing and Updating"
+title: 'Publishing and Updating'
 description: "There are several ways to update an Electron application. The easiest and officially supported one is taking advantage of the built-in Squirrel framework and Electron's autoUpdater module."
 slug: tutorial-publishing-updating
 hide_title: false
@@ -195,7 +195,7 @@ npm install update-electron-app
 Then, import the module and call it immediately in the main process.
 
 ```js title='main.js'
-require("update-electron-app")();
+require('update-electron-app')()
 ```
 
 And that is all it takes! Once your application is packaged, it will update itself for each new

--- a/docs/tutorial/tutorial-6-publishing-updating.md
+++ b/docs/tutorial/tutorial-6-publishing-updating.md
@@ -1,5 +1,5 @@
 ---
-title: 'Publishing and Updating'
+title: "Publishing and Updating"
 description: "There are several ways to update an Electron application. The easiest and officially supported one is taking advantage of the built-in Squirrel framework and Electron's autoUpdater module."
 slug: tutorial-publishing-updating
 hide_title: false
@@ -27,7 +27,7 @@ into your app code.
 ## Using update.electronjs.org
 
 The Electron maintainers provide a free auto-updating service for open-source apps
-at https://update.electronjs.org . Its requirements are:
+at [https://update.electronjs.org](https://update.electronjs.org). Its requirements are:
 
 - Your app runs on macOS or Windows
 - Your app has a public GitHub repository
@@ -195,7 +195,7 @@ npm install update-electron-app
 Then, import the module and call it immediately in the main process.
 
 ```js title='main.js'
-require('update-electron-app')()
+require("update-electron-app")();
 ```
 
 And that is all it takes! Once your application is packaged, it will update itself for each new

--- a/docs/tutorial/tutorial-6-publishing-updating.md
+++ b/docs/tutorial/tutorial-6-publishing-updating.md
@@ -27,7 +27,7 @@ into your app code.
 ## Using update.electronjs.org
 
 The Electron maintainers provide a free auto-updating service for open-source apps
-at https://update.electronjs.org. Its requirements are:
+at https://update.electronjs.org . Its requirements are:
 
 - Your app runs on macOS or Windows
 - Your app has a public GitHub repository


### PR DESCRIPTION
The dot at the end of the URL will depend on the site that cannot open. Because it will open `https://update.electronjs.org./` which does not exist.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
