### PR TITLE
fix: touch events not recognized by WCO on windows (#35117)

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -139,3 +139,4 @@ cherry-pick-3cbd5973d704.patch
 cherry-pick-902f0d144a5b.patch
 cherry-pick-664e0d8b4cfb.patch
 chore_add_electron_deps_to_gitignores.patch
+chore_allow_chromium_to_handle_synthetic_mouse_events_for_touch.patch

--- a/patches/chromium/chore_allow_chromium_to_handle_synthetic_mouse_events_for_touch.patch
+++ b/patches/chromium/chore_allow_chromium_to_handle_synthetic_mouse_events_for_touch.patch
@@ -7,7 +7,7 @@ With WCO, allow chromium to handle synthetic mouse events generated for touch
 actions in the non-client caption area.
 
 diff --git a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
-index f6b37bdec2343d45447b419aeadbe2aa19493c3c..bdbf7153f27376bd68459f9cb480bff7485c9e98 100644
+index 65b9f5e5f81e8ef8b591ef2e027e095df11c0d7b..b5d764db353e758e8feefd5fd0a045be27cf09c6 100644
 --- a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
 +++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
 @@ -1169,6 +1169,10 @@ void DesktopWindowTreeHostWin::HandleWindowScaleFactorChanged(
@@ -22,10 +22,10 @@ index f6b37bdec2343d45447b419aeadbe2aa19493c3c..bdbf7153f27376bd68459f9cb480bff7
  DesktopWindowTreeHostWin::GetSingletonDesktopNativeCursorManager() {
    return new DesktopNativeCursorManagerWin();
 diff --git a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h
-index 0aae49ec83b88057434af5bbfb54b10e53469918..058e5dc978e76a71fa02dc9e275592f3c39befea 100644
+index 444581249014a8ce301591f269dbb194f0520732..9377f26b081b717db6b50c13ce3795907cf2fcd2 100644
 --- a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h
 +++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h
-@@ -263,6 +263,7 @@ class VIEWS_EXPORT DesktopWindowTreeHostWin
+@@ -262,6 +262,7 @@ class VIEWS_EXPORT DesktopWindowTreeHostWin
    void HandleWindowSizeChanging() override;
    void HandleWindowSizeUnchanged() override;
    void HandleWindowScaleFactorChanged(float window_scale_factor) override;
@@ -34,10 +34,10 @@ index 0aae49ec83b88057434af5bbfb54b10e53469918..058e5dc978e76a71fa02dc9e275592f3
    Widget* GetWidget();
    const Widget* GetWidget() const;
 diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
-index 3b546cf67089e6677fc668b4d1d6c0863282dff5..c6810f162806b36494885b2f63982a756d4dcd38 100644
+index 86f06d2a2c9588a2210a9f78f47e73f1b7c5e329..f943179d0071ed77fe49f5e4e9cff05eeff665e0 100644
 --- a/ui/views/win/hwnd_message_handler.cc
 +++ b/ui/views/win/hwnd_message_handler.cc
-@@ -3129,15 +3129,19 @@ LRESULT HWNDMessageHandler::HandleMouseEventInternal(UINT message,
+@@ -3049,15 +3049,19 @@ LRESULT HWNDMessageHandler::HandleMouseEventInternal(UINT message,
        SetMsgHandled(FALSE);
      // We must let Windows handle the caption buttons if it's drawing them, or
      // they won't work.

--- a/patches/chromium/chore_allow_chromium_to_handle_synthetic_mouse_events_for_touch.patch
+++ b/patches/chromium/chore_allow_chromium_to_handle_synthetic_mouse_events_for_touch.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: deepak1556 <hop2deep@gmail.com>
+Date: Fri, 29 Jul 2022 00:29:35 +0900
+Subject: chore: allow chromium to handle synthetic mouse events for touch
+
+With WCO, allow chromium to handle synthetic mouse events generated for touch
+actions in the non-client caption area.
+
+diff --git a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
+index f6b37bdec2343d45447b419aeadbe2aa19493c3c..bdbf7153f27376bd68459f9cb480bff7485c9e98 100644
+--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
++++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
+@@ -1169,6 +1169,10 @@ void DesktopWindowTreeHostWin::HandleWindowScaleFactorChanged(
+   }
+ }
+ 
++bool DesktopWindowTreeHostWin::HandleMouseEventForCaption(UINT message) const {
++  return false;
++}
++
+ DesktopNativeCursorManager*
+ DesktopWindowTreeHostWin::GetSingletonDesktopNativeCursorManager() {
+   return new DesktopNativeCursorManagerWin();
+diff --git a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h
+index 0aae49ec83b88057434af5bbfb54b10e53469918..058e5dc978e76a71fa02dc9e275592f3c39befea 100644
+--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h
++++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h
+@@ -263,6 +263,7 @@ class VIEWS_EXPORT DesktopWindowTreeHostWin
+   void HandleWindowSizeChanging() override;
+   void HandleWindowSizeUnchanged() override;
+   void HandleWindowScaleFactorChanged(float window_scale_factor) override;
++  bool HandleMouseEventForCaption(UINT message) const override;
+ 
+   Widget* GetWidget();
+   const Widget* GetWidget() const;
+diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
+index 3b546cf67089e6677fc668b4d1d6c0863282dff5..c6810f162806b36494885b2f63982a756d4dcd38 100644
+--- a/ui/views/win/hwnd_message_handler.cc
++++ b/ui/views/win/hwnd_message_handler.cc
+@@ -3129,15 +3129,19 @@ LRESULT HWNDMessageHandler::HandleMouseEventInternal(UINT message,
+       SetMsgHandled(FALSE);
+     // We must let Windows handle the caption buttons if it's drawing them, or
+     // they won't work.
++    bool simulate_mouse_event_for_caption = false;
+     if (delegate_->GetFrameMode() == FrameMode::SYSTEM_DRAWN &&
+         (hittest == HTCLOSE || hittest == HTMINBUTTON ||
+          hittest == HTMAXBUTTON)) {
+-      SetMsgHandled(FALSE);
++      simulate_mouse_event_for_caption =
++          delegate_->HandleMouseEventForCaption(message);
++      if (!simulate_mouse_event_for_caption)
++        SetMsgHandled(FALSE);
+     }
+     // Let resize events fall through. Ignore everything else, as we're either
+     // letting Windows handle it above or we've already handled the equivalent
+     // touch message.
+-    if (!IsHitTestOnResizeHandle(hittest))
++    if (!IsHitTestOnResizeHandle(hittest) && !simulate_mouse_event_for_caption)
+       return 0;
+   }
+ 
+diff --git a/ui/views/win/hwnd_message_handler_delegate.h b/ui/views/win/hwnd_message_handler_delegate.h
+index 5dbb192d0840ca0ded61397c399b774a8cb05cce..098a9c3140e9e140fdc8f0dc9cf4e8ec84451221 100644
+--- a/ui/views/win/hwnd_message_handler_delegate.h
++++ b/ui/views/win/hwnd_message_handler_delegate.h
+@@ -258,6 +258,10 @@ class VIEWS_EXPORT HWNDMessageHandlerDelegate {
+   // Called when the window scale factor has changed.
+   virtual void HandleWindowScaleFactorChanged(float window_scale_factor) = 0;
+ 
++  // Called when synthetic mouse event is generated for touch event on
++  // caption buttons.
++  virtual bool HandleMouseEventForCaption(UINT message) const = 0;
++
+  protected:
+   virtual ~HWNDMessageHandlerDelegate() = default;
+ };

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
@@ -36,6 +36,7 @@ class ElectronDesktopWindowTreeHostWin
   bool GetDwmFrameInsetsInPixels(gfx::Insets* insets) const override;
   bool GetClientAreaInsets(gfx::Insets* insets,
                            HMONITOR monitor) const override;
+  bool HandleMouseEventForCaption(UINT message) const override;
 
  private:
   NativeWindowViews* native_window_view_;  // weak ref


### PR DESCRIPTION
#### Description of Change

Backport of https://github.com/electron/electron/pull/35117

#### Release Notes

Notes: fix WCO not responding to touch events on windows.
