### PR TITLE
Avoid stringifying the error

### DIFF
--- a/lib/renderer/ipc-renderer-internal.ts
+++ b/lib/renderer/ipc-renderer-internal.ts
@@ -17,7 +17,7 @@ ipcRendererInternal.sendSync = function (channel, ...args) {
 ipcRendererInternal.invoke = async function<T> (channel: string, ...args: any[]) {
   const { error, result } = await ipc.invoke<T>(internal, channel, args);
   if (error) {
-    throw new Error(`Error invoking remote method '${channel}': ${error}`);
+    throw error;
   }
   return result;
 };


### PR DESCRIPTION
Stringifying the error makes it impossible to return a proper error when the handler fails.
So in the UI we can only say "it worked" or "it didn't work", unless we parse the error.

It would be more useful to get the error fully to display understandable error messages in the UI.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
