### PR TITLE
fix: consider dock space when showing menu

### DIFF
--- a/shell/browser/api/electron_api_menu_mac.mm
+++ b/shell/browser/api/electron_api_menu_mac.mm
@@ -131,7 +131,7 @@ void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
   if (!item) {
     CGFloat windowBottom = CGRectGetMinY([view window].frame);
     CGFloat lowestMenuPoint = windowBottom + position.y - [menu size].height;
-    CGFloat screenBottom = CGRectGetMinY([view window].screen.frame);
+    CGFloat screenBottom = CGRectGetMinY([view window].screen.visibleFrame);
     CGFloat distanceFromBottom = lowestMenuPoint - screenBottom;
     if (distanceFromBottom < 0)
       position.y = position.y - distanceFromBottom + 4;
@@ -140,7 +140,7 @@ void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
   // Place the menu left of cursor if it is overflowing off right of screen.
   CGFloat windowLeft = CGRectGetMinX([view window].frame);
   CGFloat rightmostMenuPoint = windowLeft + position.x + [menu size].width;
-  CGFloat screenRight = CGRectGetMaxX([view window].screen.frame);
+  CGFloat screenRight = CGRectGetMaxX([view window].screen.visibleFrame);
   if (rightmostMenuPoint > screenRight)
     position.x = position.x - [menu size].width;
 


### PR DESCRIPTION
#### Description of Change

Use `visibleFrame` instead of `frame` when computing edge of screen, the former excludes the dock and menubar from the frame.

Close https://github.com/electron/electron/issues/14261.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix context menu not showing all items on macOS when dock is not hidden.