### PR TITLE
fix: WCO occlusion of DevTools

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1626,6 +1626,8 @@ Opens the devtools.
 When `contents` is a `<webview>` tag, the `mode` would be `detach` by default,
 explicitly passing an empty `mode` can force using last used dock state.
 
+On Windows, if Windows Control Overlay is enabled, Devtools will be opened with `mode: 'detach'`.
+
 #### `contents.closeDevTools()`
 
 Closes the devtools.

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -175,6 +175,7 @@
 
 #if BUILDFLAG(IS_WIN)
 #include "printing/backend/win_helper.h"
+#include "shell/browser/native_window_views.h"
 #endif
 #endif
 
@@ -2418,6 +2419,14 @@ void WebContents::OpenDevTools(gin::Arguments* args) {
       options.Get("activate", &activate);
     }
   }
+
+#if BUILDFLAG(IS_WIN)
+  auto* win = static_cast<NativeWindowViews*>(owner_window());
+  // Force a detached state when WCO is enabled to match Chrome
+  // behavior and prevent occlusion of DevTools.
+  if (win && win->IsWindowControlsOverlayEnabled())
+    state = "detach";
+#endif
 
   DCHECK(inspectable_web_contents_);
   inspectable_web_contents_->SetDockState(state);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/34129.

This change matches Chromium behavior for WCO by opening DevTools in detached mode if WCO is enabled.
This prevents the DevTools from being occluded and becoming semi-unusable.

<details><summary>Before</summary>
<img width="806" alt="Screen Shot 2022-08-03 at 4 21 38 PM" src="https://user-images.githubusercontent.com/2036040/182632344-40fe9f79-fdcf-4383-b35c-c0fd105a2423.png">
</details>

<details><summary>After</summary>
<img width="808" alt="Screen Shot 2022-08-03 at 4 21 52 PM" src="https://user-images.githubusercontent.com/2036040/182632349-e2e126cc-9fcf-4a73-880b-c5af55a79eb4.png">
</details>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where WCO could occlude DevTools opened in any non-detached mode.
