### PR TITLE
feat: add more functions for NSApp activation state

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -153,9 +153,23 @@ Returns:
 
 * `event` Event
 
-Emitted when mac application become active. Difference from `activate` event is
-that `did-become-active` is emitted every time the app becomes active, not only
-when Dock icon is clicked or application is re-launched.
+Emitted when the application becomes active (i.e., the macOS title bar is
+showing the name of the app). The difference between this and the `activate`
+event is that `did-become-active` is emitted every time the app becomes active,
+whereas `activate` is only emitted when the Dock icon is clicked or the
+application is re-launched.
+
+See [`-[NSApplicationDelegate applicationDidBecomeActive:]`](https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428577-applicationdidbecomeactive?language=objc)
+
+### Event: 'did-resign-active' _macOS_
+
+Returns:
+
+* `event` Event
+
+Emitted when the application loses active state.
+
+See [`-[NSApplicationDelegate applicationDidResignActive:]`](https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428636-applicationdidresignactive?language=objc)
 
 ### Event: 'continue-activity' _macOS_
 
@@ -1426,6 +1440,28 @@ details.
 
 **Note:** Enable `Secure Keyboard Entry` only when it is needed and disable it when it is no longer needed.
 
+### `app.isActive()` _macOS_
+
+Returns `boolean` - `true` if the app is currently active (i.e., the macOS
+title bar is showing the name of the app).
+
+See [`-[NSApplication active]`](https://developer.apple.com/documentation/appkit/nsapplication/1428493-active?language=objc).
+
+### `app.activate([opts])` _macOS_
+
+* `opts` Object (optional)
+  * `ignoreOtherApps` boolean - If false, the app is activated only if no other
+    app is currently active. If true, the app activates regardless. Defaults to
+    false.
+
+See [`-[NSApplication activateIgnoringOtherApps:]`](https://developer.apple.com/documentation/appkit/nsapplication/1428468-activateignoringotherapps?language=objc).
+
+### `app.deactivate()` _macOS_
+
+Deactivates the app.
+
+See [`-[NSApplication deactivate]`](https://developer.apple.com/documentation/appkit/nsapplication/1428428-deactivate?language=objc).
+
 ## Properties
 
 ### `app.accessibilitySupportEnabled` _macOS_ _Windows_
@@ -1437,6 +1473,13 @@ See [Chromium's accessibility docs](https://www.chromium.org/developers/design-d
 This API must be called after the `ready` event is emitted.
 
 **Note:** Rendering accessibility tree can significantly affect the performance of your app. It should not be enabled by default.
+
+### `app.active` _macOS_ _Readonly_
+
+A `boolean` property, `true` if the app is currently active (i.e., the macOS
+title bar is showing the name of the app).
+
+See [`-[NSApplication active]`](https://developer.apple.com/documentation/appkit/nsapplication/1428493-active?language=objc).
 
 ### `app.applicationMenu`
 

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -782,6 +782,10 @@ void App::OnNewWindowForTab() {
 void App::OnDidBecomeActive() {
   Emit("did-become-active");
 }
+
+void App::OnDidResignActive() {
+  Emit("did-resign-active");
+}
 #endif
 
 bool App::CanCreateWindow(
@@ -1742,6 +1746,9 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
       .SetMethod("moveToApplicationsFolder", &App::MoveToApplicationsFolder)
       .SetMethod("isInApplicationsFolder", &App::IsInApplicationsFolder)
       .SetMethod("setActivationPolicy", &App::SetActivationPolicy)
+      .SetMethod("isActive", &App::IsActive)
+      .SetMethod("activate", &App::Activate)
+      .SetMethod("deactivate", &App::Deactivate)
 #endif
       .SetMethod("setAboutPanelOptions",
                  base::BindRepeating(&Browser::SetAboutPanelOptions, browser))
@@ -1805,6 +1812,7 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
       .SetProperty("dock", &App::GetDockAPI)
       .SetProperty("runningUnderRosettaTranslation",
                    &App::IsRunningUnderRosettaTranslation)
+      .SetProperty("active", &App::IsActive)
 #endif
 #if BUILDFLAG(IS_MAC) || BUILDFLAG(IS_WIN)
       .SetProperty("runningUnderARM64Translation",

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -116,6 +116,7 @@ class App : public ElectronBrowserClient::Delegate,
                                  base::Value::Dict user_info) override;
   void OnNewWindowForTab() override;
   void OnDidBecomeActive() override;
+  void OnDidResignActive() override;
 #endif
 
   // content::ContentBrowserClient:
@@ -227,6 +228,9 @@ class App : public ElectronBrowserClient::Delegate,
   bool IsInApplicationsFolder();
   v8::Local<v8::Value> GetDockAPI(v8::Isolate* isolate);
   bool IsRunningUnderRosettaTranslation() const;
+  bool IsActive() const;
+  void Activate(absl::optional<gin_helper::Dictionary> opts) const;
+  void Deactivate() const;
   v8::Global<v8::Value> dock_;
 #endif
 

--- a/shell/browser/api/electron_api_app_mac.mm
+++ b/shell/browser/api/electron_api_app_mac.mm
@@ -80,4 +80,19 @@ bool App::IsRunningUnderARM64Translation() const {
   return proc_translated == 1;
 }
 
+bool App::IsActive() const {
+  return NSApp.active;
+}
+
+void App::Activate(absl::optional<gin_helper::Dictionary> opts) const {
+  bool ignore_other_apps = false;
+  if (opts)
+    opts->Get("ignoreOtherApps", &ignore_other_apps);
+  [NSApp activateIgnoringOtherApps:ignore_other_apps];
+}
+
+void App::Deactivate() const {
+  [NSApp deactivate];
+}
+
 }  // namespace electron::api

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -285,6 +285,11 @@ void Browser::DidBecomeActive() {
   for (BrowserObserver& observer : observers_)
     observer.OnDidBecomeActive();
 }
+
+void Browser::DidResignActive() {
+  for (BrowserObserver& observer : observers_)
+    observer.OnDidResignActive();
+}
 #endif
 
 }  // namespace electron

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -278,6 +278,8 @@ class Browser : public WindowListObserver {
 
   // Tell the application that application did become active
   void DidBecomeActive();
+
+  void DidResignActive();
 #endif  // BUILDFLAG(IS_MAC)
 
   // Tell the application that application is activated with visible/invisible

--- a/shell/browser/browser_observer.h
+++ b/shell/browser/browser_observer.h
@@ -84,6 +84,8 @@ class BrowserObserver : public base::CheckedObserver {
 
   // Browser did become active.
   virtual void OnDidBecomeActive() {}
+
+  virtual void OnDidResignActive() {}
 #endif
 
  protected:

--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -92,6 +92,10 @@ static NSDictionary* UNNotificationResponseToNSDictionary(
   electron::Browser::Get()->DidBecomeActive();
 }
 
+- (void)applicationDidResignActive:(NSNotification*)notification {
+  electron::Browser::Get()->DidResignActive();
+}
+
 - (NSMenu*)applicationDockMenu:(NSApplication*)sender {
   if (menu_controller_)
     return [menu_controller_ menu];


### PR DESCRIPTION
#### Description of Change
We currently have `app.on('did-become-active')`, but no way to see the current
active state of the app or get an event when the app becomes inactive.

macOS provides these functions, so expose them.

NB that `app.deactivate()` is a confusing and possibly not that useful. But
AppKit exposes it, so we might as well also. It's cheap and easy.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added functions and events for app active state on macOS: `app.active`, `app.activate()`, `app.on('did-resign-active')`.
