### PR TITLE
chore: cherry-pick 06aea31d10f8 from webrtc

### DIFF
--- a/patches/webrtc/.patches
+++ b/patches/webrtc/.patches
@@ -1,1 +1,2 @@
 add_thread_local_to_x_error_trap_cc.patch
+cherry-pick-06aea31d10f8.patch

--- a/patches/webrtc/cherry-pick-06aea31d10f8.patch
+++ b/patches/webrtc/cherry-pick-06aea31d10f8.patch
@@ -1,7 +1,10 @@
-From 06aea31d10f860ae4236e3422252557762d39188 Mon Sep 17 00:00:00 2001
-From: Henrik Boström <hbos@webrtc.org>
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Henrik=20Bostr=C3=B6m?= <hbos@webrtc.org>
 Date: Wed, 13 Jul 2022 11:10:14 +0200
-Subject: [PATCH] [Merge-104] Disallow invalid arguments in RestoreEncodingLayers.
+Subject: Disallow invalid arguments in RestoreEncodingLayers.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 Changing DCHECK into CHECK for good measure.
 
@@ -17,13 +20,12 @@ Cr-Original-Commit-Position: refs/heads/main@{#37511}
 Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/269242
 Cr-Commit-Position: refs/branch-heads/5112@{#8}
 Cr-Branched-From: a976a871159f85f975fbd6f170d0a8f00a4aee49-refs/heads/main@{#37168}
----
 
 diff --git a/pc/rtp_sender.cc b/pc/rtp_sender.cc
-index 3ee9145..86bf644 100644
+index 58fef4041ecfcef3a76fcfb296c923355f68625c..3604d198e8fabf8a689746f073b6783fc827e7c5 100644
 --- a/pc/rtp_sender.cc
 +++ b/pc/rtp_sender.cc
-@@ -75,8 +75,8 @@
+@@ -75,8 +75,8 @@ RtpParameters RestoreEncodingLayers(
      const RtpParameters& parameters,
      const std::vector<std::string>& removed_rids,
      const std::vector<RtpEncodingParameters>& all_layers) {

--- a/patches/webrtc/cherry-pick-06aea31d10f8.patch
+++ b/patches/webrtc/cherry-pick-06aea31d10f8.patch
@@ -1,0 +1,36 @@
+From 06aea31d10f860ae4236e3422252557762d39188 Mon Sep 17 00:00:00 2001
+From: Henrik Boström <hbos@webrtc.org>
+Date: Wed, 13 Jul 2022 11:10:14 +0200
+Subject: [PATCH] [Merge-104] Disallow invalid arguments in RestoreEncodingLayers.
+
+Changing DCHECK into CHECK for good measure.
+
+(cherry picked from commit 2b1f509f3a05035a17917061a71b16114e8c72dc)
+
+No-Try: True
+Bug: chromium:1343889
+Change-Id: I2cede85dc2d2a4238739f73afe25275047f4aa50
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/268460
+Reviewed-by: Ilya Nikolaevskiy <ilnik@webrtc.org>
+Commit-Queue: Henrik Boström <hbos@webrtc.org>
+Cr-Original-Commit-Position: refs/heads/main@{#37511}
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/269242
+Cr-Commit-Position: refs/branch-heads/5112@{#8}
+Cr-Branched-From: a976a871159f85f975fbd6f170d0a8f00a4aee49-refs/heads/main@{#37168}
+---
+
+diff --git a/pc/rtp_sender.cc b/pc/rtp_sender.cc
+index 3ee9145..86bf644 100644
+--- a/pc/rtp_sender.cc
++++ b/pc/rtp_sender.cc
+@@ -75,8 +75,8 @@
+     const RtpParameters& parameters,
+     const std::vector<std::string>& removed_rids,
+     const std::vector<RtpEncodingParameters>& all_layers) {
+-  RTC_DCHECK_EQ(parameters.encodings.size() + removed_rids.size(),
+-                all_layers.size());
++  RTC_CHECK_EQ(parameters.encodings.size() + removed_rids.size(),
++               all_layers.size());
+   RtpParameters result(parameters);
+   result.encodings.clear();
+   size_t index = 0;


### PR DESCRIPTION
[Merge-104] Disallow invalid arguments in RestoreEncodingLayers.

Changing DCHECK into CHECK for good measure.

(cherry picked from commit 2b1f509f3a05035a17917061a71b16114e8c72dc)

No-Try: True
Bug: chromium:1343889
Change-Id: I2cede85dc2d2a4238739f73afe25275047f4aa50
Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/268460
Reviewed-by: Ilya Nikolaevskiy <ilnik@webrtc.org>
Commit-Queue: Henrik Boström <hbos@webrtc.org>
Cr-Original-Commit-Position: refs/heads/main@{#37511}
Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/269242
Cr-Commit-Position: refs/branch-heads/5112@{#8}
Cr-Branched-From: a976a871159f85f975fbd6f170d0a8f00a4aee49-refs/heads/main@{#37168}


Notes: Security: backported fix for chromium:1343889.