### PR TITLE
fix(docs): fix a typo in section on debugging with VSCode

### DIFF
--- a/docs/tutorial/tutorial-2-first-app.md
+++ b/docs/tutorial/tutorial-2-first-app.md
@@ -350,7 +350,7 @@ app.whenReady().then(() => {
 
 ## Optional: Debugging from VS Code
 
-If you want to debug your application using VS Code, you have need attach VS Code to
+If you want to debug your application using VS Code, you need to attach VS Code to
 both the main and renderer processes. Here is a sample configuration for you to
 run. Create a launch.json configuration in a new `.vscode` folder in your project:
 


### PR DESCRIPTION
#### Description of Change

I just fixed a small typo in the section on debugging with VSCode

> If you want to debug your application using VS Code, you **have need** attach VS Code to both the main and renderer processes.

to

> If you want to debug your application using VS Code, you **need to** attach VS Code to both the main and renderer processes.

notes: Fixed a typo in the section on debugging with VSCode

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->

notes: Fixed a typo in the section on debugging with VSCode
