### PR TITLE
build: fix error in the `ts-compile-doc-change` step

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -990,7 +990,7 @@ step-ts-compile: &step-ts-compile
       do
         out="${f:29}"
         if [ "$out" != "base.js" ]; then
-          node script/yarn webpack --config $f --output-filename=$out --output-path=./.tmp --env.mode=development
+          node script/yarn webpack --config $f --output-filename=$out --output-path=./.tmp --env mode=development
         fi
       done
 


### PR DESCRIPTION
Fixes the following error: https://app.circleci.com/pipelines/github/electron/electron/56517/workflows/ea0f6548-e0ac-40c6-bacb-e24610cd6670/jobs/1287168?invite=true#step-103-29

```sh
$ webpack --config build/webpack/webpack.config.asar.js --output-filename=asar.js --output-path=./.tmp --env.mode=development
[webpack-cli] Error: Unknown option '--env.mode=development'
[webpack-cli] Run 'webpack --help' to see available commands and options
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

This probably started happening because of the recent webpack upgrade in https://github.com/electron/electron/pull/34990.

Signed-off-by: Darshan Sen <raisinten@gmail.com>

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
