### PR TITLE
fix: undefined details.requestingUrl from session.setPermissionCheckHandler

### DIFF
--- a/shell/browser/electron_permission_manager.cc
+++ b/shell/browser/electron_permission_manager.cc
@@ -339,9 +339,16 @@ blink::mojom::PermissionStatus
 ElectronPermissionManager::GetPermissionStatusForCurrentDocument(
     blink::PermissionType permission,
     content::RenderFrameHost* render_frame_host) {
-  return GetPermissionStatus(
-      permission, render_frame_host->GetLastCommittedOrigin().GetURL(),
-      content::PermissionUtil::GetLastCommittedOriginAsURL(render_frame_host));
+  base::Value::Dict details;
+  details.Set("embeddingOrigin",
+              content::PermissionUtil::GetLastCommittedOriginAsURL(
+                  render_frame_host->GetMainFrame())
+                  .spec());
+  bool granted = CheckPermissionWithDetails(
+      permission, render_frame_host,
+      render_frame_host->GetLastCommittedOrigin().GetURL(), std::move(details));
+  return granted ? blink::mojom::PermissionStatus::GRANTED
+                 : blink::mojom::PermissionStatus::DENIED;
 }
 
 blink::mojom::PermissionStatus


### PR DESCRIPTION
#### Description of Change

With https://github.com/electron/electron/commit/7e59d784a0b5c922564cbc8c55f95f0e7daf6997, https://chromium-review.googlesource.com/c/chromium/src/+/3495142 deprecates `GetPermissionStatusForFrame` in favor of `GetPermissionStatusForCurrentDocument` and the latter always called into `GetPermissionStatus` which does not have a frame context leading to empty `RenderFrameHost` causing the above issue. 

Depends on https://github.com/electron/electron/pull/35292

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix undefined details.requestingUrl from session.setPermissionCheckHandler