### PR TITLE
fix: promise support with webFrameMain.executeJavaScript

### DIFF
--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -151,10 +151,13 @@ v8::Local<v8::Promise> WebFrameMain::ExecuteJavaScript(
                  blink::mojom::JavaScriptExecutionResultType type,
                  base::Value value) {
                 if (type ==
-                    blink::mojom::JavaScriptExecutionResultType::kSuccess)
+                    blink::mojom::JavaScriptExecutionResultType::kSuccess) {
                   promise.Resolve(value);
-                else
-                  promise.Resolve(base::Value());
+                } else {
+                  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+                  v8::HandleScope scope(isolate);
+                  promise.Reject(gin::ConvertToV8(isolate, value));
+                }
               },
               std::move(promise)));
 

--- a/spec/api-web-frame-main-spec.ts
+++ b/spec/api-web-frame-main-spec.ts
@@ -163,6 +163,15 @@ describe('webFrameMain module', () => {
       expect(await getUrl(webFrame.frames[0])).to.equal(fileUrl('frame-with-frame.html'));
       expect(await getUrl(webFrame.frames[0].frames[0])).to.equal(fileUrl('frame.html'));
     });
+
+    it('can resolve promise', async () => {
+      const w = new BrowserWindow({ show: false, webPreferences: { contextIsolation: true } });
+      await w.loadFile(path.join(subframesPath, 'frame.html'));
+      const webFrame = w.webContents.mainFrame;
+      const p = () => webFrame.executeJavaScript('new Promise(resolve => setTimeout(resolve(42), 2000));');
+      const result = await p();
+      expect(result).to.equal(42);
+    });
   });
 
   describe('WebFrame.reload', () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/32756.
Closes https://github.com/electron/electron/issues/32164.

PR changes the backend for `WebFrameMain::ExecuteJavaScript` to use the version that allows resolving promises before returning the result. Not sure why the previous version which does not support promises https://source.chromium.org/chromium/chromium/src/+/main:content/browser/renderer_host/render_frame_host_impl.cc;l=2667-2670 was adopted in https://github.com/electron/electron/commit/704d69a8f96d904afc725f121432d23b7f44bd33 but this aligns the behavior with `WebFrame::ExecuteJavaScript`.

Was identified when writing tests for https://github.com/electron/electron/pull/35281

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix enable promise support with webFrameMain.executeJavaScript