### PR TITLE
build: bump @electron/get to 2.0.0, node to >= 12+

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -8,11 +8,11 @@
     "postinstall": "node install.js"
   },
   "dependencies": {
-    "@electron/get": "^1.14.1",
+    "@electron/get": "^2.0.0",
     "@types/node": "^16.11.26",
     "extract-zip": "^2.0.1"
   },
   "engines": {
-    "node": ">= 10.17.0"
+    "node": ">= 12.20.55"
   }
 }


### PR DESCRIPTION
#### Description of Change
Aligns our npm package with the newest version of @electron/get, and the new minimum version of Node that is required (see @electron/get PR here: https://github.com/electron/get/pull/225 )

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Bumps the minimum required version of Node.js needed to install Electron to 12.20.55
