### PR TITLE
fix: don't locate matching PDB files for electron PDBs

### DIFF
--- a/build/dump_syms.py
+++ b/build/dump_syms.py
@@ -35,6 +35,8 @@ def mkdir_p(path):
 
 def main(dump_syms, binary, out_dir, stamp_file, dsym_file=None):
   args = [dump_syms]
+  if sys.platform in ['win32', 'cygwin', 'msys']:
+    args += ['--pe']
   if dsym_file:
     args += ["-g", dsym_file]
   args += [binary]


### PR DESCRIPTION
#### Description of Change
Windbg in the Windows 11 SDK and the Windows Performance Analyzer v11.0.8.2
don't support PDBs larger than 4GB.
This change avoids loading said PDBs in order to have debug builds with a symbol depth > 1

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
