### PR TITLE
fix: `serialPort.open()` failing

### DIFF
--- a/shell/browser/serial/electron_serial_delegate.cc
+++ b/shell/browser/serial/electron_serial_delegate.cc
@@ -56,10 +56,7 @@ bool ElectronSerialDelegate::HasPortPermission(
     content::RenderFrameHost* frame,
     const device::mojom::SerialPortInfo& port) {
   auto* web_contents = content::WebContents::FromRenderFrameHost(frame);
-  auto* browser_context = web_contents->GetBrowserContext();
-  auto* chooser_context =
-      SerialChooserContextFactory::GetForBrowserContext(browser_context);
-  return chooser_context->HasPortPermission(
+  return GetChooserContext(frame)->HasPortPermission(
       web_contents->GetPrimaryMainFrame()->GetLastCommittedOrigin(), port,
       frame);
 }
@@ -91,8 +88,7 @@ void ElectronSerialDelegate::RevokePortPermissionWebInitiated(
 const device::mojom::SerialPortInfo* ElectronSerialDelegate::GetPortInfo(
     content::RenderFrameHost* frame,
     const base::UnguessableToken& token) {
-  // TODO(nornagon/jkleinsc): pass this on to the chooser context
-  return nullptr;
+  return GetChooserContext(frame)->GetPortInfo(token);
 }
 
 SerialChooserController* ElectronSerialDelegate::ControllerForFrame(

--- a/shell/browser/serial/serial_chooser_context.cc
+++ b/shell/browser/serial/serial_chooser_context.cc
@@ -103,6 +103,8 @@ void SerialChooserContext::GrantPortPermission(
     const url::Origin& origin,
     const device::mojom::SerialPortInfo& port,
     content::RenderFrameHost* render_frame_host) {
+  port_info_.insert({port.token, port.Clone()});
+
   auto* permission_manager = static_cast<ElectronPermissionManager*>(
       browser_context_->GetPermissionControllerDelegate());
   return permission_manager->GrantDevicePermission(
@@ -190,6 +192,9 @@ base::WeakPtr<SerialChooserContext> SerialChooserContext::AsWeakPtr() {
 }
 
 void SerialChooserContext::OnPortAdded(device::mojom::SerialPortInfoPtr port) {
+  if (!base::Contains(port_info_, port->token))
+    port_info_.insert({port->token, port->Clone()});
+
   for (auto& observer : port_observer_list_)
     observer.OnPortAdded(*port);
 }
@@ -198,6 +203,8 @@ void SerialChooserContext::OnPortRemoved(
     device::mojom::SerialPortInfoPtr port) {
   for (auto& observer : port_observer_list_)
     observer.OnPortRemoved(*port);
+
+  port_info_.erase(port->token);
 }
 
 void SerialChooserContext::EnsurePortManagerConnection() {
@@ -218,6 +225,15 @@ void SerialChooserContext::SetUpPortManagerConnection(
                      base::Unretained(this)));
 
   port_manager_->SetClient(client_receiver_.BindNewPipeAndPassRemote());
+  port_manager_->GetDevices(base::BindOnce(&SerialChooserContext::OnGetDevices,
+                                           weak_factory_.GetWeakPtr()));
+}
+
+void SerialChooserContext::OnGetDevices(
+    std::vector<device::mojom::SerialPortInfoPtr> ports) {
+  for (auto& port : ports)
+    port_info_.insert({port->token, std::move(port)});
+  is_initialized_ = true;
 }
 
 void SerialChooserContext::OnPortManagerConnectionError() {

--- a/shell/browser/serial/serial_chooser_context.h
+++ b/shell/browser/serial/serial_chooser_context.h
@@ -97,6 +97,7 @@ class SerialChooserContext : public KeyedService,
   void EnsurePortManagerConnection();
   void SetUpPortManagerConnection(
       mojo::PendingRemote<device::mojom::SerialPortManager> manager);
+  void OnGetDevices(std::vector<device::mojom::SerialPortInfoPtr> ports);
   void OnPortManagerConnectionError();
   void RevokeObjectPermissionInternal(const url::Origin& origin,
                                       const base::Value& object,


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/35282.

Fixes an issue where `serialPort.open()` failed with `NetworkError: Failed to open serial port.`.

This was happening because we returned `nullptr` from `ElectronSerialDelegate::GetPortInfo`: https://github.com/electron/electron/blob/648c9934c01c12ea082a18fdf690c37e3112ce12/shell/browser/serial/electron_serial_delegate.cc#L91-L96

and `SerialService::OpenPort` expects that `delegate->GetInfo` [returns non-null](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/serial/serial_service.cc;l=128;drc=06106fa71f3ed1044028f77ccf4d5b9de7028b8b;bpv=1;bpt=1) in order to succeed.

Tested with https://gist.github.com/17afc65be515f3a1aec6256cb69f069d and an Arduino Uno.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `serialPort.open()` failed with `NetworkError: Failed to open serial port.`.