### PR TITLE
fix: libappindicator left-click support

### DIFF
--- a/shell/browser/ui/gtk/app_indicator_icon_menu.cc
+++ b/shell/browser/ui/gtk/app_indicator_icon_menu.cc
@@ -51,21 +51,14 @@ void AppIndicatorIconMenu::UpdateClickActionReplacementMenuItem(
   } else {
     click_action_replacement_menu_item_added_ = true;
 
-    // If |menu_model_| is non empty, add a separator to separate the
-    // "click action replacement menu item" from the other menu items.
-    if (menu_model_ && menu_model_->GetItemCount() > 0) {
-      GtkWidget* menu_item = gtk_separator_menu_item_new();
-      gtk_widget_show(menu_item);
-      gtk_menu_shell_prepend(GTK_MENU_SHELL(gtk_menu_), menu_item);
-    }
-
+    // create a hidden menu item that will be activated from libappindicator on
+    // tray icon click
     GtkWidget* menu_item = gtk_menu_item_new_with_mnemonic(label);
     g_object_set_data(G_OBJECT(menu_item), "click-action-item",
                       GINT_TO_POINTER(1));
     g_signal_connect(menu_item, "activate",
                      G_CALLBACK(OnClickActionReplacementMenuItemActivatedThunk),
                      this);
-    gtk_widget_show(menu_item);
     gtk_menu_shell_prepend(GTK_MENU_SHELL(gtk_menu_), menu_item);
   }
 }

--- a/shell/browser/ui/tray_icon_gtk.cc
+++ b/shell/browser/ui/tray_icon_gtk.cc
@@ -62,7 +62,7 @@ void TrayIconGtk::OnClick() {
 }
 
 bool TrayIconGtk::HasClickAction() {
-  return false;
+  return true;
 }
 
 // static


### PR DESCRIPTION
#### Description of Change
There is a long-standing issue of left-click on tray icon not working on Linux when libappindicator is installed
https://github.com/electron/electron/issues/14941

This PR along with a libappindicator patch 
(in progress here https://bugs.launchpad.net/ubuntu/+source/libappindicator/+bug/1910521 )
enables the Activate event of tray icon to be propagated into electron app.

This builds on already implemented solution of creating a replacement menu item in systray menu that will be triggered if the tray icon is clicked. This code was activated and adapted to create the replacement item as hidden.

In libappindicator, the relevant Activate method was implemented and will trigger activation of this replacement menu item.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added support for left-click app activation when using libappindicator based tray icon
