### PR TITLE
fix: IPC emit order in -ipc-ports handler

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -618,9 +618,9 @@ WebContents.prototype._init = function () {
   this.on('-ipc-ports' as any, function (event: Electron.IpcMainEvent, internal: boolean, channel: string, message: any, ports: any[]) {
     addSenderFrameToEvent(event);
     event.ports = ports.map(p => new MessagePortMain(p));
-    ipc.emit(channel, event, message);
     const maybeWebFrame = webFrameMainBinding.fromIdOrNull(event.processId, event.frameId);
     maybeWebFrame && maybeWebFrame.ipc.emit(channel, event, message);
+    ipc.emit(channel, event, message);
     ipcMain.emit(channel, event, message);
   });
 


### PR DESCRIPTION
#### Description of Change
Follow-up to #34959.
The order in this case does not match the documentation: https://github.com/electron/electron/blob/main/docs/api/web-frame-main.md#frameipc-readonly

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
