### PR TITLE
fix: add uv_loop_close when object release to fix crash

### DIFF
--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -136,6 +136,7 @@ void stop_and_close_uv_loop(uv_loop_t* loop) {
       break;
 
   DCHECK_EQ(0, uv_loop_alive(loop));
+  uv_loop_close(loop);
 }
 
 bool g_is_initialized = false;


### PR DESCRIPTION
#### Description of Change
stop_and_close_uv_loop add call uv_loop_close.
In the destructor of NodeBindings, stop_and_close_uv_loop is called, but stop_and_close_uv_loop does not call uv_loop_close. After NodeBindings are destructed, libuv still holds the member objects of NodeBindings. When power resume, libuv enumerates all loops, and will accesses a pointer that has been released.
as issue https://github.com/electron/electron/issues/32926

About npm test in checklist.  Before I modified the code, 15 cases could not pass on my computer. After I modified, the failed  cases did not increase, so there should be no problem with npm test.

Resolves #32926
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes


#### Release Notes

Notes: Fixed crash in renderer when resuming system from sleep