### PR TITLE
docs: removes unused import of path in dnd tutorial

### DIFF
--- a/docs/fiddles/features/drag-and-drop/preload.js
+++ b/docs/fiddles/features/drag-and-drop/preload.js
@@ -1,5 +1,4 @@
 const { contextBridge, ipcRenderer } = require('electron')
-const path = require('path')
 
 contextBridge.exposeInMainWorld('electron', {
   startDrag: (fileName) => {


### PR DESCRIPTION
This import gives out the error in the preload script:

Error: module not found: path
    at preloadRequire

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] relevant documentation is changed or added

