### PR TITLE
docs: removes unused import in preload script

### DIFF
--- a/docs/fiddles/features/drag-and-drop/preload.js
+++ b/docs/fiddles/features/drag-and-drop/preload.js
@@ -1,5 +1,4 @@
 const { contextBridge, ipcRenderer } = require('electron')
-const path = require('path')
 
 contextBridge.exposeInMainWorld('electron', {
   startDrag: (fileName) => {

--- a/docs/tutorial/native-file-drag-drop.md
+++ b/docs/tutorial/native-file-drag-drop.md
@@ -22,7 +22,6 @@ In `preload.js` use the [`contextBridge`] to inject a method `window.electron.st
 
 ```js
 const { contextBridge, ipcRenderer } = require('electron')
-const path = require('path')
 
 contextBridge.exposeInMainWorld('electron', {
   startDrag: (fileName) => {


### PR DESCRIPTION
notes: Removes unused import which causes issue in preload script of drag and drop tutorial

It fails to run with the error.
```
VM4 sandbox_bundle:93 Error: module not found: path
    at preloadRequire (VM4 sandbox_bundle:93:1386)
    at <anonymous>:3:14
    at runPreloadScript (VM4 sandbox_bundle:93:2213)
    at Object.<anonymous> (VM4 sandbox_bundle:93:2480)
    at ./lib/sandboxed_renderer/init.ts (VM4 sandbox_bundle:93:2636)
    at __webpack_require__ (VM4 sandbox_bundle:1:170)
    at VM4 sandbox_bundle:1:1242
    at ___electron_webpack_init__ (VM4 sandbox_bundle:1:1320)
    at VM4 sandbox_bundle:160:455
```

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Removes unused import which causes issue in preload script of drag and drop tutorial