### PR TITLE
docs: update arm64 mac dependencies to include Rosetta 2

### DIFF
--- a/docs/development/build-instructions-macos.md
+++ b/docs/development/build-instructions-macos.md
@@ -13,6 +13,10 @@ Follow the guidelines below for building **Electron itself** on macOS, for the p
 * [node.js](https://nodejs.org) (external)
 * Python >= 3.7
 
+### Arm64-specific prerequisites
+* Rosetta 2
+  * this can be installed by using the softwareupdate command line tool.
+  * `$ softwareupdate --install-rosetta`
 ## Building Electron
 
 See [Build Instructions: GN](build-instructions-gn.md).


### PR DESCRIPTION
#### Description of Change

Not having Rosetta 2 installed on arm64-architecture MacOS laptops can cause `vpython` to fail during `e sync`. 
This bug is documented [here](https://bugs.chromium.org/p/chromium/issues/detail?id=1103275). It was fixed earlier this year, but I ran into this problem regardless, so it may be worth it to add Rosetta 2 into dependencies to tick all the boxes.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
(https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
