### PR TITLE
docs: add dependencies and troubleshooting section to build-instructions

### DIFF
--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -281,9 +281,39 @@ $ cd electron
 $ gclient sync -f
 ```
 
+This may also happen if you have checked out a branch (as opposed to having a detached head) in `electron/src/`
+or some other dependency’s repository. If that is the case, a `git checkout --detach HEAD` in the appropriate repository should do the trick.
+
 ### I'm being asked for a username/password for chromium-internal.googlesource.com
 
 If you see a prompt for `Username for 'https://chrome-internal.googlesource.com':` when running `gclient sync` on Windows, it's probably because the `DEPOT_TOOLS_WIN_TOOLCHAIN` environment variable is not set to 0. Open `Control Panel` → `System and Security` → `System` → `Advanced system settings` and add a system variable
 `DEPOT_TOOLS_WIN_TOOLCHAIN` with value `0`.  This tells `depot_tools` to use
 your locally installed version of Visual Studio (by default, `depot_tools` will
 try to download a Google-internal version that only Googlers have access to).
+
+### `e` Module not found
+
+If `e` is not recognized despite running `npm i -g @electron/build-tools`, ie:
+
+```sh
+Error: Cannot find module '/Users/<user>/.electron_build_tools/src/e'
+```
+
+ensure that Node is installed through [nvm](https://github.com/nvm-sh/nvm), rather than through the [website](https://nodejs.org/en/download/)
+
+### Certificates fail to verify
+
+installing [`certifi`](https://pypi.org/project/certifi/) will fix the following error:
+
+```sh
+________ running 'python3 src/tools/clang/scripts/update.py' in '/Users/<user>/electron'
+Downloading https://commondatastorage.googleapis.com/chromium-browser-clang/Mac_arm64/clang-llvmorg-15-init-15652-g89a99ec9-1.tgz
+<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:997)>
+Retrying in 5 s ...
+Downloading https://commondatastorage.googleapis.com/chromium-browser-clang/Mac_arm64/clang-llvmorg-15-init-15652-g89a99ec9-1.tgz
+<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:997)>
+Retrying in 10 s ...
+Downloading https://commondatastorage.googleapis.com/chromium-browser-clang/Mac_arm64/clang-llvmorg-15-init-15652-g89a99ec9-1.tgz
+<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:997)>
+Retrying in 20 s ...
+```

--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -299,21 +299,4 @@ If `e` is not recognized despite running `npm i -g @electron/build-tools`, ie:
 Error: Cannot find module '/Users/<user>/.electron_build_tools/src/e'
 ```
 
-ensure that Node is installed through [nvm](https://github.com/nvm-sh/nvm), rather than through the [website](https://nodejs.org/en/download/)
-
-### Certificates fail to verify
-
-installing [`certifi`](https://pypi.org/project/certifi/) will fix the following error:
-
-```sh
-________ running 'python3 src/tools/clang/scripts/update.py' in '/Users/<user>/electron'
-Downloading https://commondatastorage.googleapis.com/chromium-browser-clang/Mac_arm64/clang-llvmorg-15-init-15652-g89a99ec9-1.tgz
-<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:997)>
-Retrying in 5 s ...
-Downloading https://commondatastorage.googleapis.com/chromium-browser-clang/Mac_arm64/clang-llvmorg-15-init-15652-g89a99ec9-1.tgz
-<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:997)>
-Retrying in 10 s ...
-Downloading https://commondatastorage.googleapis.com/chromium-browser-clang/Mac_arm64/clang-llvmorg-15-init-15652-g89a99ec9-1.tgz
-<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:997)>
-Retrying in 20 s ...
-```
+We recommend installing Node through [nvm](https://github.com/nvm-sh/nvm). This allows for easier Node version management, and is often a fix for missing `e` modules.

--- a/docs/development/build-instructions-macos.md
+++ b/docs/development/build-instructions-macos.md
@@ -13,6 +13,45 @@ Follow the guidelines below for building **Electron itself** on macOS, for the p
 * [node.js](https://nodejs.org) (external)
 * Python >= 3.7
 
+### Arm64-specific prerequisites
+
+* Rosetta 2
+  * this can be installed by using the softwareupdate command line tool.
+  * `$ softwareupdate --install-rosetta`
+
 ## Building Electron
 
 See [Build Instructions: GN](build-instructions-gn.md).
+
+## Troubleshooting
+
+### Xcode is complaining about incompatible architecture (MacOS arm64-specific)
+
+If both Xcode and Xcode command line tools are installed (`$ xcode -select --install`, or directly download the correct version [here](https://developer.apple.com/download/all/?q=command%20line%20tools)), but the stack trace says otherwise like so:
+
+```sh
+xcrun: error: unable to load libxcrun
+(dlopen(/Users/<user>/.electron_build_tools/third_party/Xcode/Xcode.app/Contents/Developer/usr/lib/libxcrun.dylib (http://xcode.app/Contents/Developer/usr/lib/libxcrun.dylib), 0x0005):
+ tried: '/Users/<user>/.electron_build_tools/third_party/Xcode/Xcode.app/Contents/Developer/usr/lib/libxcrun.dylib (http://xcode.app/Contents/Developer/usr/lib/libxcrun.dylib)'
+ (mach-o file, but is an incompatible architecture (have (x86_64), need (arm64e))), '/Users/<user>/.electron_build_tools/third_party/Xcode/Xcode-11.1.0.app/Contents/Developer/usr/lib/libxcrun.dylib (http://xcode-11.1.0.app/Contents/Developer/usr/lib/libxcrun.dylib)' (mach-o file, but is an incompatible architecture (have (x86_64), need (arm64e)))).`
+```
+
+If you are on arm64 architecture, the build script may be pointing to the wrong Xcode version (11.x.y doesn't support arm64). Navigate to `/Users/<user>/.electron_build_tools/third_party/Xcode/` and rename `Xcode-13.3.0.app` to `Xcode.app` to ensure the right Xcode version is used.
+
+### I'm running into a vpython error resulting in a failed goroutine
+
+```sh
+Updating depot_tools...
+[E2022-08-08T15:10:18.034202-07:00 18261 0 annotate.go:273] original error: permission denied
+
+goroutine 1:
+#0 go.chromium.org/luci/vpython/venv/venv.go:316 - venv.(*Env).ensure()
+  reason: failed to ensure VirtualEnv
+
+#1 go.chromium.org/luci/vpython/venv/venv.go:160 - venv.With()
+  reason: failed to create empty probe environment
+
+#2 go.chromium.org/luci/vpython/run.go:60 - vpython.Run()
+```
+
+This error can be solved by uninstalling build-tools, running `xcode-select -r`, reinstalling build-tools, and finally clearing your `gcache` with `rm -rf ~/.git_cache`

--- a/docs/development/build-instructions-macos.md
+++ b/docs/development/build-instructions-macos.md
@@ -16,7 +16,7 @@ Follow the guidelines below for building **Electron itself** on macOS, for the p
 ### Arm64-specific prerequisites
 
 * Rosetta 2
-  * this can be installed by using the softwareupdate command line tool.
+  * We recommend installing Rosetta if using dependencies that need to cross-compile on x64 and arm64 machines. Rosetta can be installed by using the softwareupdate command line tool.
   * `$ softwareupdate --install-rosetta`
 
 ## Building Electron
@@ -25,7 +25,7 @@ See [Build Instructions: GN](build-instructions-gn.md).
 
 ## Troubleshooting
 
-### Xcode is complaining about incompatible architecture (MacOS arm64-specific)
+### Xcode "incompatible architecture" errors (MacOS arm64-specific)
 
 If both Xcode and Xcode command line tools are installed (`$ xcode -select --install`, or directly download the correct version [here](https://developer.apple.com/download/all/?q=command%20line%20tools)), but the stack trace says otherwise like so:
 
@@ -38,20 +38,21 @@ xcrun: error: unable to load libxcrun
 
 If you are on arm64 architecture, the build script may be pointing to the wrong Xcode version (11.x.y doesn't support arm64). Navigate to `/Users/<user>/.electron_build_tools/third_party/Xcode/` and rename `Xcode-13.3.0.app` to `Xcode.app` to ensure the right Xcode version is used.
 
-### I'm running into a vpython error resulting in a failed goroutine
+### Certificates fail to verify
+
+installing [`certifi`](https://pypi.org/project/certifi/) will fix the following error:
 
 ```sh
-Updating depot_tools...
-[E2022-08-08T15:10:18.034202-07:00 18261 0 annotate.go:273] original error: permission denied
-
-goroutine 1:
-#0 go.chromium.org/luci/vpython/venv/venv.go:316 - venv.(*Env).ensure()
-  reason: failed to ensure VirtualEnv
-
-#1 go.chromium.org/luci/vpython/venv/venv.go:160 - venv.With()
-  reason: failed to create empty probe environment
-
-#2 go.chromium.org/luci/vpython/run.go:60 - vpython.Run()
+________ running 'python3 src/tools/clang/scripts/update.py' in '/Users/<user>/electron'
+Downloading https://commondatastorage.googleapis.com/chromium-browser-clang/Mac_arm64/clang-llvmorg-15-init-15652-g89a99ec9-1.tgz
+<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:997)>
+Retrying in 5 s ...
+Downloading https://commondatastorage.googleapis.com/chromium-browser-clang/Mac_arm64/clang-llvmorg-15-init-15652-g89a99ec9-1.tgz
+<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:997)>
+Retrying in 10 s ...
+Downloading https://commondatastorage.googleapis.com/chromium-browser-clang/Mac_arm64/clang-llvmorg-15-init-15652-g89a99ec9-1.tgz
+<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:997)>
+Retrying in 20 s ...
 ```
 
-This error can be solved by uninstalling build-tools, running `xcode-select -r`, reinstalling build-tools, and finally clearing your `gcache` with `rm -rf ~/.git_cache`
+This issue has to do with Python 3.6 using its [own](https://github.com/python/cpython/blob/560ea272b01acaa6c531cc7d94331b2ef0854be6/Mac/BuildScript/resources/ReadMe.rtf#L35) copy of OpenSSL in lieu of the deprecated Apple-supplied OpenSSL libraries. `certifi` adds a curated bundle of default root certificates. This issue is documented in the Electron repo [here](https://github.com/electron/build-tools/issues/55). Further information about this issue can be found [here](https://stackoverflow.com/questions/27835619/urllib-and-ssl-certificate-verify-failed-error) and [here](https://stackoverflow.com/questions/40684543/how-to-make-python-use-ca-certificates-from-mac-os-truststore).


### PR DESCRIPTION
#### Description of Change

added some troubleshooting solutions to the section in `docs/development/build-instructions-gn.md`, and created the troubleshooting section for macOS. 

Also added a dependency specifically for M1 MacOS:

Not having Rosetta 2 installed on arm64-architecture MacOS laptops can cause vpython to fail during e sync.
This bug is documented [here](https://bugs.chromium.org/p/chromium/issues/detail?id=1103275). It was fixed earlier this year, but I ran into this problem regardless, so it may be worth it to add Rosetta 2 into dependencies to tick all the boxes.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
