### PR TITLE
fix: Make the disable_color_correct_rendering flag work with textured images

### DIFF
--- a/patches/chromium/disable_color_correct_rendering.patch
+++ b/patches/chromium/disable_color_correct_rendering.patch
@@ -260,6 +260,19 @@ index 09f72f1fbd7b782c5bf52245482b358103f0c243..80d9fd40efed1edc90e7bdf1db534acb
      switches::kDisableInProcessStackTraces,
      sandbox::policy::switches::kDisableSeccompFilterSandbox,
      sandbox::policy::switches::kNoSandbox,
+diff --git a/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc b/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
+index 396b2983f403b0684f952a5fbd2d0abf947328f0..35c44065ba8980c06bb35e64aa33cc5b3f290953 100644
+--- a/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
++++ b/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
+@@ -6194,7 +6194,7 @@ void WebGLRenderingContextBase::TexImageHelperImageBitmap(
+                                      : SkColorSpace::MakeSRGB();
+   const bool needs_color_conversion =
+       !SkColorSpace::Equals(unpack_color_space.get(), image_color_space.get());
+-  if (needs_color_conversion) {
++  if (needs_color_conversion && unpack_color_space) {
+     image = image->ConvertToColorSpace(unpack_color_space,
+                                        image->GetSkColorInfo().colorType());
+     if (!image) {
 diff --git a/third_party/blink/renderer/platform/graphics/canvas_color_params.cc b/third_party/blink/renderer/platform/graphics/canvas_color_params.cc
 index 648f25d99884b99f49e26cd9f280a8a6ae63e1c7..e42f8ba89070477b06777c7a0c37d30c8c5e4ed1 100644
 --- a/third_party/blink/renderer/platform/graphics/canvas_color_params.cc


### PR DESCRIPTION
#### Description of Change

This PR updates `disable_color_correct_rendering.patch` to make it work with images in WebGL canvases. Without this change, attempting to render an image inside of a WebGL canvas, with the `disable_color_correct_rendering` flag enabled, will cause a crash in the renderer. This was introduced in https://github.com/electron/electron/pull/35050.

The crash is caused because `unpack_color_space` is null. So this PR adds a check to see that it's not null before sending it to `ConvertToColorSpace`. The reason that it is null in the first place is that `gfx::ColorSpace()` is not a "valid" color space according to Skia. So when we call `gfx::ColorSpace().ToSkColorSpace()` we get null back.

This crash only occurs in Electron 19. The code in Chromium in Electron 20 is rewritten, and does not have the crash on a null `unpack_color_space`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
