### PR TITLE
build: disable allowJs in tsconfig

### DIFF
--- a/script/run-clang-tidy.ts
+++ b/script/run-clang-tidy.ts
@@ -9,7 +9,7 @@ import * as streamJson from 'stream-json';
 import { ignore as streamJsonIgnore } from 'stream-json/filters/Ignore';
 import { streamArray as streamJsonStreamArray } from 'stream-json/streamers/StreamArray';
 
-import { chunkFilenames } from './lib/utils';
+const { chunkFilenames } = require('./lib/utils');
 
 const SOURCE_ROOT = path.normalize(path.dirname(__dirname));
 const LLVM_BIN = path.resolve(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "experimentalDecorators": true,
     "strict": true,
     "baseUrl": ".",
-    "allowJs": true,
     "noUnusedLocals": true,
     "outDir": "ts-gen",
     "paths": {


### PR DESCRIPTION
Now that `spec` is entirely typescript we can remove the `allowJs` from our tsconfig

Notes: no-notes