### PR TITLE
fix: don't bypass redirect checks

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1487,9 +1487,6 @@ bool ElectronBrowserClient::WillCreateURLLoaderFactory(
       std::move(proxied_receiver), std::move(target_factory_remote),
       std::move(header_client_receiver), type);
 
-  if (bypass_redirect_checks)
-    *bypass_redirect_checks = true;
-
   return true;
 }
 


### PR DESCRIPTION
#### Description of Change
Remove unneeded bypass of redirect checks when creating URL loader factories.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none