### PR TITLE
ci: use AppVeyor workflows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,19 +48,18 @@ clone_folder: C:\projects\src\electron
 matrix:
   fast_finish: true
 
-# configuration common for all jobs
-init:
-  - ps: >-
-      if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
-        Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
-      }
-
 for:
 
   -
     matrix:
       only:
         - job_name: Build
+
+    init:
+    - ps: >-
+        if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
+          Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
+        }
 
     build_script:
     - ps: |
@@ -249,6 +248,9 @@ for:
     - ps: |
         if ($env:RUN_TESTS -ne 'true') {
           Write-warning "Skipping tests for $env:APPVEYOR_PROJECT_NAME"; Exit-AppveyorBuild
+        }
+        if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
+          Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
         }
     build_script:
     - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,212 +34,276 @@ environment:
   MOCHA_REPORTER: mocha-multi-reporters
   MOCHA_MULTI_REPORTERS: mocha-appveyor-reporter, tap
   GOMA_FALLBACK_ON_AUTH_FAILURE: true
-build_script:
+
+  matrix:
+
+  - job_name: Build
+
+  - job_name: Test
+    job_depends_on: Build
+
+clone_folder: C:\projects\src\electron
+
+# the first failed job cancels other jobs and fails entire build
+matrix:
+  fast_finish: true
+
+# configuration common for all jobs
+init:
   - ps: >-
       if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
         Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
-      } else {
-        node script/yarn.js install --frozen-lockfile
+      }
 
+for:
+
+  -
+    matrix:
+      only:
+        - job_name: Build
+
+    build_script:
+    - ps: |
+        node script/yarn.js install --frozen-lockfile
         $result = node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH
         Write-Output $result
         if ($result.ExitCode -eq 0) {
           Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
         }
-      }
-  - echo "Building $env:GN_CONFIG build"
-  - git config --global core.longpaths true
-  - cd ..
-  - mkdir src
-  - update_depot_tools.bat
-  - ps: Move-Item $env:APPVEYOR_BUILD_FOLDER -Destination src\electron
-  - ps: >-
-      if (Test-Path 'env:RAW_GOMA_AUTH') {
-        $env:GOMA_OAUTH2_CONFIG_FILE = "$pwd\.goma_oauth2_config"
-        $env:RAW_GOMA_AUTH | Set-Content $env:GOMA_OAUTH2_CONFIG_FILE
-      }
-  - git clone https://github.com/electron/build-tools.git
-  - cd build-tools
-  - npm install
-  - mkdir third_party
-  - ps: >-
-      node -e "require('./src/utils/goma.js').downloadAndPrepare({ gomaOneForAll: true })"
-  - ps: $env:GN_GOMA_FILE = node -e "console.log(require('./src/utils/goma.js').gnFilePath)"
-  - ps: $env:LOCAL_GOMA_DIR = node -e "console.log(require('./src/utils/goma.js').dir)"
-  - cd ..
-  - ps: .\src\electron\script\start-goma.ps1 -gomaDir $env:LOCAL_GOMA_DIR
-  - ps: >-
-      if (Test-Path 'env:RAW_GOMA_AUTH') {
-        $goma_login = python $env:LOCAL_GOMA_DIR\goma_auth.py info
-        if ($goma_login -eq 'Login as Fermi Planck') {
-          Write-warning "Goma authentication is correct";
-        } else {
-          Write-warning "WARNING!!!!!! Goma authentication is incorrect; please update Goma auth token.";
-          $host.SetShouldExit(1)
+    - cd ..
+    - ps: Write-Host "Building $env:GN_CONFIG build"
+    - git config --global core.longpaths true
+    - update_depot_tools.bat
+    - ps: >-
+        if (Test-Path 'env:RAW_GOMA_AUTH') {
+          $env:GOMA_OAUTH2_CONFIG_FILE = "$pwd\.goma_oauth2_config"
+          $env:RAW_GOMA_AUTH | Set-Content $env:GOMA_OAUTH2_CONFIG_FILE
         }
-      }
-  - ps: $env:CHROMIUM_BUILDTOOLS_PATH="$pwd\src\buildtools"
-  - ps: >-
-      if ($env:GN_CONFIG -ne 'release') {
-        $env:NINJA_STATUS="[%r processes, %f/%t @ %o/s : %es] "
-      }
-  - >-
-      gclient config
-      --name "src\electron"
-      --unmanaged
-      %GCLIENT_EXTRA_ARGS%
-      "https://github.com/electron/electron"
-  - ps: >-
-      if ($env:GN_CONFIG -eq 'release') {
-        $env:RUN_GCLIENT_SYNC="true"
-      } else {
-        cd src\electron
-        node script\generate-deps-hash.js
-        $depshash = Get-Content .\.depshash -Raw 
-        $zipfile = "Z:\$depshash.7z"
-        cd ..\..
-        if (Test-Path -Path $zipfile) {
-          # file exists, unzip and then gclient sync
-          7z x -y $zipfile -mmt=30 -aoa
-          if (-not (Test-Path -Path "src\buildtools")) {
-            # the zip file must be corrupt - resync
+    - git clone https://github.com/electron/build-tools.git
+    - cd build-tools
+    - npm install
+    - mkdir third_party
+    - ps: >-
+        node -e "require('./src/utils/goma.js').downloadAndPrepare({ gomaOneForAll: true })"
+    - ps: $env:GN_GOMA_FILE = node -e "console.log(require('./src/utils/goma.js').gnFilePath)"
+    - ps: $env:LOCAL_GOMA_DIR = node -e "console.log(require('./src/utils/goma.js').dir)"
+    - cd ..\..
+    - ps: .\src\electron\script\start-goma.ps1 -gomaDir $env:LOCAL_GOMA_DIR
+    - ps: >-
+        if (Test-Path 'env:RAW_GOMA_AUTH') {
+          $goma_login = python $env:LOCAL_GOMA_DIR\goma_auth.py info
+          if ($goma_login -eq 'Login as Fermi Planck') {
+            Write-warning "Goma authentication is correct";
+          } else {
+            Write-warning "WARNING!!!!!! Goma authentication is incorrect; please update Goma auth token.";
+            $host.SetShouldExit(1)
+          }
+        }
+    - ps: $env:CHROMIUM_BUILDTOOLS_PATH="$pwd\src\buildtools"
+    - ps: >-
+        if ($env:GN_CONFIG -ne 'release') {
+          $env:NINJA_STATUS="[%r processes, %f/%t @ %o/s : %es] "
+        }
+    - >-
+        gclient config
+        --name "src\electron"
+        --unmanaged
+        %GCLIENT_EXTRA_ARGS%
+        "https://github.com/electron/electron"
+    - ps: >-
+        if ($env:GN_CONFIG -eq 'release') {
+          $env:RUN_GCLIENT_SYNC="true"
+        } else {
+          cd src\electron
+          node script\generate-deps-hash.js
+          $depshash = Get-Content .\.depshash -Raw 
+          $zipfile = "Z:\$depshash.7z"
+          cd ..\..
+          if (Test-Path -Path $zipfile) {
+            # file exists, unzip and then gclient sync
+            7z x -y $zipfile -mmt=14 -aoa
+            if (-not (Test-Path -Path "src\buildtools")) {
+              # the zip file must be corrupt - resync
+              $env:RUN_GCLIENT_SYNC="true"
+              if ($env:TARGET_ARCH -ne 'ia32') {
+                # only save on x64/woa to avoid contention saving
+                $env:SAVE_GCLIENT_SRC="true"
+              }
+            } else {
+              # update angle
+              cd src\third_party\angle
+              git remote set-url origin  https://chromium.googlesource.com/angle/angle.git
+              git fetch
+              cd ..\..\..
+            }
+          } else {    
+            # file does not exist, gclient sync, then zip
             $env:RUN_GCLIENT_SYNC="true"
             if ($env:TARGET_ARCH -ne 'ia32') {
               # only save on x64/woa to avoid contention saving
               $env:SAVE_GCLIENT_SRC="true"
             }
-          } else {
-            # update angle
-            cd src\third_party\angle
-            git remote set-url origin  https://chromium.googlesource.com/angle/angle.git
-            git fetch
-            cd ..\..\..
-          }
-        } else {    
-          # file does not exist, gclient sync, then zip
-          $env:RUN_GCLIENT_SYNC="true"
-          if ($env:TARGET_ARCH -ne 'ia32') {
-            # only save on x64/woa to avoid contention saving
-            $env:SAVE_GCLIENT_SRC="true"
           }
         }
-      }
-  - if "%RUN_GCLIENT_SYNC%"=="true" ( gclient sync )
-  - ps: >-
-      if ($env:SAVE_GCLIENT_SRC -eq 'true') {
-        # archive current source for future use 
-        # only run on x64/woa to avoid contention saving
-        $(7z a $zipfile src -xr!android_webview -xr!electron -xr'!*\.git' -xr!third_party\WebKit\LayoutTests! -xr!third_party\blink\web_tests -xr!third_party\blink\perf_tests -slp -t7z -mmt=30)
-        if ($LASTEXITCODE -ne 0) {
-          Write-warning "Could not save source to shared drive; continuing anyway"
+    - if "%RUN_GCLIENT_SYNC%"=="true" ( gclient sync )
+    - ps: >-
+        if ($env:SAVE_GCLIENT_SRC -eq 'true') {
+          # archive current source for future use 
+          # only run on x64/woa to avoid contention saving
+          $(7z a $zipfile src -xr!android_webview -xr!electron -xr'!*\.git' -xr!third_party\WebKit\LayoutTests! -xr!third_party\blink\web_tests -xr!third_party\blink\perf_tests -slp -t7z -mmt=30)
+          if ($LASTEXITCODE -ne 0) {
+            Write-warning "Could not save source to shared drive; continuing anyway"
+          }
+          # build time generation of file gen/angle/angle_commit.h depends on
+          # third_party/angle/.git
+          # https://chromium-review.googlesource.com/c/angle/angle/+/2074924       
+          $(7z a $zipfile src\third_party\angle\.git)
+          if ($LASTEXITCODE -ne 0) {
+            Write-warning "Failed to add third_party\angle\.git; continuing anyway"
+          }
+          # build time generation of file dawn/common/Version_autogen.h depends on third_party/dawn/.git/HEAD
+          # https://dawn-review.googlesource.com/c/dawn/+/83901        
+          $(7z a $zipfile src\third_party\dawn\.git)
+          if ($LASTEXITCODE -ne 0) {
+            Write-warning "Failed to add third_party\dawn\.git; continuing anyway"
+          }
         }
-        # build time generation of file gen/angle/angle_commit.h depends on
-        # third_party/angle/.git
-        # https://chromium-review.googlesource.com/c/angle/angle/+/2074924       
-        $(7z a $zipfile src\third_party\angle\.git)
-        if ($LASTEXITCODE -ne 0) {
-          Write-warning "Failed to add third_party\angle\.git; continuing anyway"
+    - cd src
+    - set BUILD_CONFIG_PATH=//electron/build/args/%GN_CONFIG%.gn 
+    - gn gen out/Default "--args=import(\"%BUILD_CONFIG_PATH%\") import(\"%GN_GOMA_FILE%\") %GN_EXTRA_ARGS% "
+    - gn check out/Default //electron:electron_lib
+    - gn check out/Default //electron:electron_app
+    - gn check out/Default //electron/shell/common/api:mojo
+    - if DEFINED GN_GOMA_FILE (ninja -j 300 -C out/Default electron:electron_app) else (ninja -C out/Default electron:electron_app)
+    - if "%GN_CONFIG%"=="testing" ( python C:\depot_tools\post_build_ninja_summary.py -C out\Default )
+    - gn gen out/ffmpeg "--args=import(\"//electron/build/args/ffmpeg.gn\") %GN_EXTRA_ARGS%"
+    - ninja -C out/ffmpeg electron:electron_ffmpeg_zip
+    - ninja -C out/Default electron:electron_dist_zip
+    - ninja -C out/Default shell_browser_ui_unittests
+    - gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
+    - ninja -C out/Default electron:electron_mksnapshot_zip
+    - cd out\Default
+    - 7z a mksnapshot.zip mksnapshot_args gen\v8\embedded.S
+    - cd ..\..
+    - ninja -C out/Default electron:hunspell_dictionaries_zip
+    - ninja -C out/Default electron:electron_chromedriver_zip
+    - ninja -C out/Default third_party/electron_node:headers
+    - python %LOCAL_GOMA_DIR%\goma_ctl.py stat
+    - python3 electron/build/profile_toolchain.py --output-json=out/Default/windows_toolchain_profile.json
+    - 7z a node_headers.zip out\Default\gen\node_headers
+    - ps: >-
+        if ($env:GN_CONFIG -eq 'release') {
+          # Needed for msdia140.dll on 64-bit windows
+          $env:Path += ";$pwd\third_party\llvm-build\Release+Asserts\bin"
+          ninja -C out/Default electron:electron_symbols
         }
-        # build time generation of file dawn/common/Version_autogen.h depends on third_party/dawn/.git/HEAD
-        # https://dawn-review.googlesource.com/c/dawn/+/83901        
-        $(7z a $zipfile src\third_party\dawn\.git)
-        if ($LASTEXITCODE -ne 0) {
-          Write-warning "Failed to add third_party\dawn\.git; continuing anyway"
-        }
-      }
-  - cd src
-  - set BUILD_CONFIG_PATH=//electron/build/args/%GN_CONFIG%.gn 
-  - gn gen out/Default "--args=import(\"%BUILD_CONFIG_PATH%\") import(\"%GN_GOMA_FILE%\") %GN_EXTRA_ARGS% "
-  - gn check out/Default //electron:electron_lib
-  - gn check out/Default //electron:electron_app
-  - gn check out/Default //electron/shell/common/api:mojo
-  - if DEFINED GN_GOMA_FILE (ninja -j 300 -C out/Default electron:electron_app) else (ninja -C out/Default electron:electron_app)
-  - if "%GN_CONFIG%"=="testing" ( python C:\depot_tools\post_build_ninja_summary.py -C out\Default )
-  - gn gen out/ffmpeg "--args=import(\"//electron/build/args/ffmpeg.gn\") %GN_EXTRA_ARGS%"
-  - ninja -C out/ffmpeg electron:electron_ffmpeg_zip
-  - ninja -C out/Default electron:electron_dist_zip
-  - ninja -C out/Default shell_browser_ui_unittests
-  - gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
-  - ninja -C out/Default electron:electron_mksnapshot_zip
-  - cd out\Default
-  - 7z a mksnapshot.zip mksnapshot_args gen\v8\embedded.S
-  - cd ..\..
-  - ninja -C out/Default electron:hunspell_dictionaries_zip
-  - ninja -C out/Default electron:electron_chromedriver_zip
-  - ninja -C out/Default third_party/electron_node:headers
-  - python %LOCAL_GOMA_DIR%\goma_ctl.py stat
-  - python3 electron/build/profile_toolchain.py --output-json=out/Default/windows_toolchain_profile.json
-  - 7z a node_headers.zip out\Default\gen\node_headers
-  - ps: >-
-      if ($env:GN_CONFIG -eq 'release') {
-        # Needed for msdia140.dll on 64-bit windows
-        $env:Path += ";$pwd\third_party\llvm-build\Release+Asserts\bin"
-        ninja -C out/Default electron:electron_symbols
-      }
-  - ps: >-
-      if ($env:GN_CONFIG -eq 'release') {
-        python electron\script\zip-symbols.py
-        appveyor-retry appveyor PushArtifact out/Default/symbols.zip
-      } else {
-        # It's useful to have pdb files when debugging testing builds that are
-        # built on CI.
-        7z a pdb.zip out\Default\*.pdb
-      }
-  - python electron/script/zip_manifests/check-zip-manifest.py out/Default/dist.zip electron/script/zip_manifests/dist_zip.win.%TARGET_ARCH%.manifest
-test_script:
-  # Workaround for https://github.com/appveyor/ci/issues/2420
-  - set "PATH=%PATH%;C:\Program Files\Git\mingw64\libexec\git-core"
-  - ps: >-
-      if ((-Not (Test-Path Env:\TEST_WOA)) -And (-Not (Test-Path Env:\ELECTRON_RELEASE)) -And ($env:GN_CONFIG -in "testing", "release")) {
-        $env:RUN_TESTS="true"
-      }
-  - ps: >-
-      if ($env:RUN_TESTS -eq 'true') {
-        New-Item .\out\Default\gen\node_headers\Release -Type directory
-        Copy-Item -path .\out\Default\electron.lib -destination .\out\Default\gen\node_headers\Release\node.lib
-      } else {
-        echo "Skipping tests for $env:GN_CONFIG build"
-      }
-  - cd electron
-  - if "%RUN_TESTS%"=="true" ( echo Running main test suite & node script/yarn test -- --trace-uncaught --runners=main --enable-logging=file --log-file=%cd%\electron.log )
-  - if "%RUN_TESTS%"=="true" ( echo Running native test suite & node script/yarn test -- --trace-uncaught --runners=native --enable-logging=file --log-file=%cd%\electron.log )  
-  - cd ..
-  - if "%RUN_TESTS%"=="true" ( echo Verifying non proprietary ffmpeg & python electron\script\verify-ffmpeg.py --build-dir out\Default --source-root %cd% --ffmpeg-path out\ffmpeg )
-  - echo "About to verify mksnapshot"
-  - if "%RUN_TESTS%"=="true" ( echo Verifying mksnapshot & python electron\script\verify-mksnapshot.py --build-dir out\Default --source-root %cd% )
-  - echo "Done verifying mksnapshot"
-  - if "%RUN_TESTS%"=="true" ( echo Verifying chromedriver & python electron\script\verify-chromedriver.py --build-dir out\Default --source-root %cd% )
-  - echo "Done verifying chromedriver"
-deploy_script:
-  - cd electron
-  - ps: >-
-      if (Test-Path Env:\ELECTRON_RELEASE) {
-        if (Test-Path Env:\UPLOAD_TO_STORAGE) {
-          Write-Output "Uploading Electron release distribution to azure"
-          & python script\release\uploaders\upload.py --verbose --upload_to_storage
+    - ps: >-
+        if ($env:GN_CONFIG -eq 'release') {
+          python electron\script\zip-symbols.py
+          appveyor-retry appveyor PushArtifact out/Default/symbols.zip
         } else {
-          Write-Output "Uploading Electron release distribution to github releases"
-          & python script\release\uploaders\upload.py --verbose
+          # It's useful to have pdb files when debugging testing builds that are
+          # built on CI.
+          7z a pdb.zip out\Default\*.pdb
         }
-      } elseif (Test-Path Env:\TEST_WOA) {
-        node script/release/ci-release-build.js --job=electron-woa-testing --ci=GHA --appveyorJobId=$env:APPVEYOR_JOB_ID $env:APPVEYOR_REPO_BRANCH
-      }
-on_finish:
-  # Uncomment this lines to enable RDP
-  #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-  - cd ..
-  - if exist out\Default\windows_toolchain_profile.json ( appveyor-retry appveyor PushArtifact out\Default\windows_toolchain_profile.json )
-  - if exist out\Default\dist.zip (appveyor-retry appveyor PushArtifact out\Default\dist.zip)
-  - if exist out\Default\shell_browser_ui_unittests.exe (appveyor-retry appveyor PushArtifact out\Default\shell_browser_ui_unittests.exe)
-  - if exist out\Default\chromedriver.zip (appveyor-retry appveyor PushArtifact out\Default\chromedriver.zip)
-  - if exist out\ffmpeg\ffmpeg.zip (appveyor-retry appveyor PushArtifact out\ffmpeg\ffmpeg.zip)
-  - if exist node_headers.zip (appveyor-retry appveyor PushArtifact node_headers.zip)
-  - if exist out\Default\mksnapshot.zip (appveyor-retry appveyor PushArtifact out\Default\mksnapshot.zip)
-  - if exist out\Default\hunspell_dictionaries.zip (appveyor-retry appveyor PushArtifact out\Default\hunspell_dictionaries.zip)
-  - if exist out\Default\electron.lib (appveyor-retry appveyor PushArtifact out\Default\electron.lib)
-  - ps: >-
-      if ((Test-Path "pdb.zip") -And ($env:GN_CONFIG -ne 'release')) {
-        appveyor-retry appveyor PushArtifact pdb.zip
-      }
+    - python electron/script/zip_manifests/check-zip-manifest.py out/Default/dist.zip electron/script/zip_manifests/dist_zip.win.%TARGET_ARCH%.manifest
+   
+    deploy_script:
+      - cd electron
+      - ps: >-
+          if (Test-Path Env:\ELECTRON_RELEASE) {
+            if (Test-Path Env:\UPLOAD_TO_STORAGE) {
+              Write-Output "Uploading Electron release distribution to azure"
+              & python script\release\uploaders\upload.py --verbose --upload_to_storage
+            } else {
+              Write-Output "Uploading Electron release distribution to github releases"
+              & python script\release\uploaders\upload.py --verbose
+            }
+          } elseif (Test-Path Env:\TEST_WOA) {
+            node script/release/ci-release-build.js --job=electron-woa-testing --ci=GHA --appveyorJobId=$env:APPVEYOR_JOB_ID $env:APPVEYOR_REPO_BRANCH
+          }
+    on_finish:
+      # Uncomment this lines to enable RDP
+      #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+      - cd ..
+      - if exist out\Default\windows_toolchain_profile.json ( appveyor-retry appveyor PushArtifact out\Default\windows_toolchain_profile.json )
+      - if exist out\Default\dist.zip (appveyor-retry appveyor PushArtifact out\Default\dist.zip)
+      - if exist out\Default\shell_browser_ui_unittests.exe (appveyor-retry appveyor PushArtifact out\Default\shell_browser_ui_unittests.exe)
+      - if exist out\Default\chromedriver.zip (appveyor-retry appveyor PushArtifact out\Default\chromedriver.zip)
+      - if exist out\ffmpeg\ffmpeg.zip (appveyor-retry appveyor PushArtifact out\ffmpeg\ffmpeg.zip)
+      - if exist node_headers.zip (appveyor-retry appveyor PushArtifact node_headers.zip)
+      - if exist out\Default\mksnapshot.zip (appveyor-retry appveyor PushArtifact out\Default\mksnapshot.zip)
+      - if exist out\Default\hunspell_dictionaries.zip (appveyor-retry appveyor PushArtifact out\Default\hunspell_dictionaries.zip)
+      - if exist out\Default\electron.lib (appveyor-retry appveyor PushArtifact out\Default\electron.lib)
+      - ps: >-
+          if ((Test-Path "pdb.zip") -And ($env:GN_CONFIG -ne 'release')) {
+            appveyor-retry appveyor PushArtifact pdb.zip
+          }        
 
-  - if exist electron\electron.log ( appveyor-retry appveyor PushArtifact electron\electron.log )
+  -
+    matrix:
+      only:
+        - job_name: Test
+
+    init:
+    - ps: |
+        if ($env:RUN_TESTS -ne 'true') {
+          Write-warning "Skipping tests for $env:APPVEYOR_PROJECT_NAME"; Exit-AppveyorBuild
+        }
+    build_script:
+    - ps: |
+        node script/yarn.js install --frozen-lockfile
+        $result = node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH
+        Write-Output $result
+        if ($result.ExitCode -eq 0) {
+          Write-warning "Skipping tests for doc only change"; Exit-AppveyorBuild
+        }
+    - ps: |
+        cd ..
+        mkdir out\Default
+        cd ..
+        # Download build artifacts
+        $apiUrl = 'https://ci.appveyor.com/api'             
+        $build_info = Invoke-RestMethod -Method Get -Uri "$apiUrl/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/builds/$env:APPVEYOR_BUILD_ID"
+        $artifacts_to_download = @('dist.zip','shell_browser_ui_unittests.exe','chromedriver.zip','ffmpeg.zip','node_headers.zip','mksnapshot.zip','electron.lib')
+        foreach ($job in $build_info.build.jobs) {
+          if ($job.name -eq "Build") {
+            $jobId = $job.jobId
+            foreach($artifact_name in $artifacts_to_download) {
+              if ($artifact_name -eq 'shell_browser_ui_unittests.exe' -Or $artifact_name -eq 'electron.lib') {
+                $outfile = "src\out\Default\$artifact_name"
+              } else {
+                $outfile = $artifact_name
+              }
+              Invoke-RestMethod -Method Get -Uri "$apiUrl/buildjobs/$jobId/artifacts/$artifact_name" -OutFile $outfile
+            }
+          }
+        }
+    - ps: |
+        $out_default_zips = @('dist.zip','chromedriver.zip','mksnapshot.zip')
+        foreach($zip_name in $out_default_zips) {
+          7z x -y -osrc\out\Default $zip_name
+        }
+    - ps: 7z x -y -osrc\out\ffmpeg ffmpeg.zip
+    - ps: 7z x -y -osrc node_headers.zip
+
+    test_script:
+      # Workaround for https://github.com/appveyor/ci/issues/2420
+      - set "PATH=%PATH%;C:\Program Files\Git\mingw64\libexec\git-core"
+      - ps: |
+          cd src
+          New-Item .\out\Default\gen\node_headers\Release -Type directory
+          Copy-Item -path .\out\Default\electron.lib -destination .\out\Default\gen\node_headers\Release\node.lib
+      - cd electron
+      - echo Running main test suite & node script/yarn test -- --trace-uncaught --runners=main --enable-logging=file --log-file=%cd%\electron.log
+      - echo Running native test suite & node script/yarn test -- --trace-uncaught --runners=native --enable-logging=file --log-file=%cd%\electron.log
+      - cd ..
+      - echo Verifying non proprietary ffmpeg & python electron\script\verify-ffmpeg.py --build-dir out\Default --source-root %cd% --ffmpeg-path out\ffmpeg
+      - echo "About to verify mksnapshot"
+      - echo Verifying mksnapshot & python electron\script\verify-mksnapshot.py --build-dir out\Default --source-root %cd%
+      - echo "Done verifying mksnapshot"
+      - echo Verifying chromedriver & python electron\script\verify-chromedriver.py --build-dir out\Default --source-root %cd%
+      - echo "Done verifying chromedriver"
+    
+    on_finish:
+      - if exist electron\electron.log ( appveyor-retry appveyor PushArtifact electron\electron.log )


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

This PR splits up our Windows CI into two jobs: build and test.  This means that we can re-run just the tests if needed which is much quicker than re-running the whole build and test.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
