### PR TITLE
ci: fix appveyor x64 tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -190,6 +190,7 @@ for:
     - python %LOCAL_GOMA_DIR%\goma_ctl.py stat
     - python3 electron/build/profile_toolchain.py --output-json=out/Default/windows_toolchain_profile.json
     - 7z a node_headers.zip out\Default\gen\node_headers
+    - 7z a builtins-pgo.zip v8\tools\builtins-pgo
     - ps: >-
         if ($env:GN_CONFIG -eq 'release') {
           # Needed for msdia140.dll on 64-bit windows
@@ -234,6 +235,7 @@ for:
       - if exist out\Default\mksnapshot.zip (appveyor-retry appveyor PushArtifact out\Default\mksnapshot.zip)
       - if exist out\Default\hunspell_dictionaries.zip (appveyor-retry appveyor PushArtifact out\Default\hunspell_dictionaries.zip)
       - if exist out\Default\electron.lib (appveyor-retry appveyor PushArtifact out\Default\electron.lib)
+      - if exist builtins-pgo.zip (appveyor-retry appveyor PushArtifact builtins-pgo.zip)
       - ps: >-
           if ((Test-Path "pdb.zip") -And ($env:GN_CONFIG -ne 'release')) {
             appveyor-retry appveyor PushArtifact pdb.zip
@@ -267,7 +269,7 @@ for:
         # Download build artifacts
         $apiUrl = 'https://ci.appveyor.com/api'             
         $build_info = Invoke-RestMethod -Method Get -Uri "$apiUrl/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/builds/$env:APPVEYOR_BUILD_ID"
-        $artifacts_to_download = @('dist.zip','shell_browser_ui_unittests.exe','chromedriver.zip','ffmpeg.zip','node_headers.zip','mksnapshot.zip','electron.lib')
+        $artifacts_to_download = @('dist.zip','shell_browser_ui_unittests.exe','chromedriver.zip','ffmpeg.zip','node_headers.zip','mksnapshot.zip','electron.lib','builtins-pgo.zip')
         foreach ($job in $build_info.build.jobs) {
           if ($job.name -eq "Build") {
             $jobId = $job.jobId
@@ -288,6 +290,7 @@ for:
         }
     - ps: 7z x -y -osrc\out\ffmpeg ffmpeg.zip
     - ps: 7z x -y -osrc node_headers.zip
+    - ps: 7z x -y -osrc\v8\tools\builtins-pgo builtins-pgo.zip
 
     test_script:
       # Workaround for https://github.com/appveyor/ci/issues/2420

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -290,7 +290,7 @@ for:
         }
     - ps: 7z x -y -osrc\out\ffmpeg ffmpeg.zip
     - ps: 7z x -y -osrc node_headers.zip
-    - ps: 7z x -y -osrc\v8\tools\builtins-pgo builtins-pgo.zip
+    - ps: 7z x -y -osrc builtins-pgo.zip
 
     test_script:
       # Workaround for https://github.com/appveyor/ci/issues/2420


### PR DESCRIPTION
#### Description of Change

Seeing several appveyor failures on PRs with unrelated changed (e.g. https://ci.appveyor.com/project/electron-bot/electron-x64-testing/builds/44541167/job/t510wg0a0mprn94c#L3197).

In the latest Chrome roll, we saw similar failures when the `v8\tools\builtins-pgo` folder wasn't persisted for tests. The recent split in "Build" and "Test" workflows resulted in this folder being empty during tests, which likely causes this failure. This PR zips `v8\tools\builtins-pgo` to upload, then re-download for use during the test workflow.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
