### PR TITLE
docs: Use inline image link in faq.md

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -135,7 +135,7 @@ is only available in renderer processes.
 
 If [sub-pixel anti-aliasing](https://alienryderflex.com/sub_pixel/) is deactivated, then fonts on LCD screens can look blurry. Example:
 
-![subpixel rendering example]
+![Subpixel rendering example](images/subpixel-rendering-screenshot.gif)
 
 Sub-pixel anti-aliasing needs a non-transparent background of the layer containing the font glyphs. (See [this issue](https://github.com/electron/electron/issues/6344#issuecomment-420371918) for more info).
 
@@ -161,4 +161,3 @@ Notice that just setting the background in the CSS does not have the desired eff
 [indexed-db]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 [message-port]: https://developer.mozilla.org/en-US/docs/Web/API/MessagePort
 [browser-window]: api/browser-window.md
-[subpixel rendering example]: https://github.com/electron/electron/raw/main/docs/images/subpixel-rendering-screenshot.gif

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -161,4 +161,4 @@ Notice that just setting the background in the CSS does not have the desired eff
 [indexed-db]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 [message-port]: https://developer.mozilla.org/en-US/docs/Web/API/MessagePort
 [browser-window]: api/browser-window.md
-[subpixel rendering example]: images/subpixel-rendering-screenshot.gif
+[subpixel rendering example]: https://github.com/electron/electron/raw/main/docs/images/subpixel-rendering-screenshot.gif


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Relative Markdown links are rendered relative to the host domain, which works fine when viewing it on Github, but since you also use the same generated HTML in your doc site, the link is broken. See here: https://www.electronjs.org/docs/latest/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do

Using an absolute URL here should fix the issue on the main site.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed broken image link in `docs/latest/faq`.