### PR TITLE
feat: expose frame and stack trace in the console-message event

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -935,10 +935,17 @@ Emitted when a `<webview>` has been attached to this web contents.
 Returns:
 
 * `event` Event
-* `level` Integer - The log level, from 0 to 3. In order it matches `verbose`, `info`, `warning` and `error`.
-* `message` string - The actual console message
-* `line` Integer - The line number of the source that triggered this console message
-* `sourceId` string
+* `_` never - deprecated parameter
+* `__` never - deprecated parameter
+* `___` never - deprecated parameter
+* `____` never - deprecated parameter
+* `details` Object
+  * `frame` WebFrameMain - The frame that logged the message
+  * `level` Integer - The log level, from 0 to 3. In order it matches `verbose`, `info`, `warning` and `error`.
+  * `message` string - The actual console message
+  * `lineNumber` Integer - The line number of the source that triggered this console message
+  * `sourceId` String - Url the log message came from, can be the empty string
+  * `untrustedStackTrace` String | undefined - Undefined in most cases, optionally present for exceptions that are logged
 
 Emitted when the associated window logs a console message.
 

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -491,11 +491,6 @@ class WebContents : public ExclusiveAccessContext,
 #endif
 
   // content::WebContentsDelegate:
-  bool DidAddMessageToConsole(content::WebContents* source,
-                              blink::mojom::ConsoleMessageLevel level,
-                              const std::u16string& message,
-                              int32_t line_no,
-                              const std::u16string& source_id) override;
   bool IsWebContentsCreationOverridden(
       content::SiteInstance* source_site_instance,
       content::mojom::WindowContainerType window_container_type,
@@ -634,6 +629,13 @@ class WebContents : public ExclusiveAccessContext,
       content::RenderWidgetHost* render_widget_host) override;
   void OnWebContentsLostFocus(
       content::RenderWidgetHost* render_widget_host) override;
+  void OnDidAddMessageToConsole(
+      content::RenderFrameHost* source_frame,
+      blink::mojom::ConsoleMessageLevel log_level,
+      const std::u16string& message,
+      int32_t line_no,
+      const std::u16string& source_id,
+      const absl::optional<std::u16string>& untrusted_stack_trace) override;
 
   // InspectableWebContentsDelegate:
   void DevToolsReloadPage() override;

--- a/shell/common/gin_converters/absl_converter.h
+++ b/shell/common/gin_converters/absl_converter.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 Slack Technologies, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_COMMON_GIN_CONVERTERS_ABSL_CONVERTER_H_
+#define ELECTRON_SHELL_COMMON_GIN_CONVERTERS_ABSL_CONVERTER_H_
+
+#include "gin/converter.h"
+
+namespace ui {
+class Accelerator;
+}
+
+namespace gin {
+
+template <typename T>
+struct Converter<absl::optional<T>> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   absl::optional<T> status) {
+    if (status) {
+      return gin::ConvertToV8(isolate, *status);
+    }
+    return v8::Undefined(isolate);
+  }
+};
+
+}  // namespace gin
+
+#endif  // ELECTRON_SHELL_COMMON_GIN_CONVERTERS_ABSL_CONVERTER_H_


### PR DESCRIPTION
Notes: Added a new `details` object to the `console-message` event that contains frame and stack trace information