### PR TITLE
fix: pass rfh instances through to the permission helper

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -635,7 +635,7 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
     * `notifications` - Request notification creation and the ability to display them in the user's system tray.
     * `midi` - Request MIDI access in the `webmidi` API.
     * `midiSysex` - Request the use of system exclusive messages in the `webmidi` API.
-    * `pointerLock` - Request to directly interpret mouse movements as an input method. Click [here](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API) to know more.
+    * `pointerLock` - Request to directly interpret mouse movements as an input method. Click [here](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API) to know more. These requests always appear to originate from the main frame.
     * `fullscreen` - Request for the app to enter fullscreen mode.
     * `openExternal` - Request to open links in external applications.
     * `unknown` - An unrecognized permission request

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1312,7 +1312,7 @@ void WebContents::EnterFullscreenModeForTab(
   auto callback =
       base::BindRepeating(&WebContents::OnEnterFullscreenModeForTab,
                           base::Unretained(this), requesting_frame, options);
-  permission_helper->RequestFullscreenPermission(callback);
+  permission_helper->RequestFullscreenPermission(requesting_frame, callback);
 }
 
 void WebContents::OnEnterFullscreenModeForTab(

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1036,8 +1036,13 @@ void HandleExternalProtocolInUI(
     return;
 
   content::RenderFrameHost* rfh = document_ptr.AsRenderFrameHostIfValid();
-  if (!rfh)
-    return;
+  if (!rfh) {
+    // If the render frame host is not valid it means it was a top level
+    // navigation and the frame has already been disposed of.  In this case we
+    // take the current main frame and declare it responsible for the
+    // transition.
+    rfh = web_contents->GetPrimaryMainFrame();
+  }
 
   GURL escaped_url(base::EscapeExternalHandlerValue(url.spec()));
   auto callback = base::BindOnce(&OnOpenExternal, escaped_url);

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1061,7 +1061,9 @@ bool ElectronBrowserClient::HandleExternalProtocol(
   content::GetUIThreadTaskRunner({})->PostTask(
       FROM_HERE,
       base::BindOnce(&HandleExternalProtocolInUI, url,
-                     initiator_document->GetWeakDocumentPtr(),
+                     initiator_document
+                         ? initiator_document->GetWeakDocumentPtr()
+                         : content::WeakDocumentPtr(),
                      std::move(web_contents_getter), has_user_gesture));
   return true;
 }

--- a/shell/browser/web_contents_permission_helper.h
+++ b/shell/browser/web_contents_permission_helper.h
@@ -33,7 +33,8 @@ class WebContentsPermissionHelper
   };
 
   // Asynchronous Requests
-  void RequestFullscreenPermission(base::OnceCallback<void(bool)> callback);
+  void RequestFullscreenPermission(content::RenderFrameHost* requesting_frame,
+                                   base::OnceCallback<void(bool)> callback);
   void RequestMediaAccessPermission(const content::MediaStreamRequest& request,
                                     content::MediaResponseCallback callback);
   void RequestPointerLockPermission(
@@ -42,8 +43,10 @@ class WebContentsPermissionHelper
       base::OnceCallback<void(content::WebContents*, bool, bool, bool)>
           callback);
   void RequestWebNotificationPermission(
+      content::RenderFrameHost* requesting_frame,
       base::OnceCallback<void(bool)> callback);
-  void RequestOpenExternalPermission(base::OnceCallback<void(bool)> callback,
+  void RequestOpenExternalPermission(content::RenderFrameHost* requesting_frame,
+                                     base::OnceCallback<void(bool)> callback,
                                      bool user_gesture,
                                      const GURL& url);
 
@@ -56,7 +59,8 @@ class WebContentsPermissionHelper
   explicit WebContentsPermissionHelper(content::WebContents* web_contents);
   friend class content::WebContentsUserData<WebContentsPermissionHelper>;
 
-  void RequestPermission(blink::PermissionType permission,
+  void RequestPermission(content::RenderFrameHost* requesting_frame,
+                         blink::PermissionType permission,
                          base::OnceCallback<void(bool)> callback,
                          bool user_gesture = false,
                          base::Value::Dict details = {});


### PR DESCRIPTION
Some permission helper methods weren't passing the render frame host through all the way, this fixes it so they do.

Notes: no-notes