### PR TITLE
fix: ensure history navigations are sandboxed-iframe-aware

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1380,11 +1380,6 @@ bool WebContents::HandleContextMenu(content::RenderFrameHost& render_frame_host,
   return true;
 }
 
-bool WebContents::OnGoToEntryOffset(int offset) {
-  GoToOffset(offset);
-  return false;
-}
-
 void WebContents::FindReply(content::WebContents* web_contents,
                             int request_id,
                             int number_of_matches,

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -534,7 +534,6 @@ class WebContents : public ExclusiveAccessContext,
       content::RenderWidgetHost* render_widget_host) override;
   bool HandleContextMenu(content::RenderFrameHost& render_frame_host,
                          const content::ContextMenuParams& params) override;
-  bool OnGoToEntryOffset(int offset) override;
   void FindReply(content::WebContents* web_contents,
                  int request_id,
                  int number_of_matches,

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -1812,6 +1812,34 @@ describe('chromium features', () => {
         expect((w.webContents as any).length()).to.equal(2);
       });
     });
+
+    describe('window.history.back', () => {
+      it('should not allow sandboxed iframe to modify main frame state', async () => {
+        const w = new BrowserWindow({ show: false });
+        w.loadURL('data:text/html,<iframe sandbox="allow-scripts"></iframe>');
+        await Promise.all([
+          emittedOnce(w.webContents, 'navigation-entry-committed'),
+          emittedOnce(w.webContents, 'did-frame-navigate'),
+          emittedOnce(w.webContents, 'did-navigate')
+        ]);
+
+        w.webContents.executeJavaScript('window.history.pushState(1, "")');
+        await Promise.all([
+          emittedOnce(w.webContents, 'navigation-entry-committed'),
+          emittedOnce(w.webContents, 'did-navigate-in-page')
+        ]);
+
+        (w.webContents as any).once('navigation-entry-committed', () => {
+          expect.fail('Unexpected navigation-entry-committed');
+        });
+        w.webContents.once('did-navigate-in-page', () => {
+          expect.fail('Unexpected did-navigate-in-page');
+        });
+        await w.webContents.mainFrame.frames[0].executeJavaScript('window.history.back()');
+        expect(await w.webContents.executeJavaScript('window.history.state')).to.equal(1);
+        expect((w.webContents as any).getActiveIndex()).to.equal(1);
+      });
+    });
   });
 
   describe('chrome://media-internals', () => {


### PR DESCRIPTION
#### Description of Change

This fixes https://github.com/electron/electron/issues/35391

When a sandboxed iframe calls `history.go()`, the renderer calls into the browser at [RenderFrameHostImpl::GoToEntryAtOffset](https://chromium.googlesource.com/chromium/src.git/+/refs/tags/106.0.5216.0/content/browser/renderer_host/render_frame_host_impl.cc#6153):
```c++
  if (delegate_->IsAllowedToGoToEntryAtOffset(offset)) {
    if (IsSandboxed(network::mojom::WebSandboxFlags::kTopNavigation)) {
      // Keep track of whether this is a session history from a sandboxed iframe
      // with top level navigation disallowed.
      frame_tree_->controller().GoToOffsetInSandboxedFrame(
          offset, GetFrameTreeNodeId());
    } else {
      frame_tree_->controller().GoToOffsetFromRenderer(offset);
    }
  }
```
The call to `delegate_->IsAllowedToGoToEntryAtOffset(offset)` goes to [WebContentsImpl::IsAllowedToGoToEntryAtOffset](https://chromium.googlesource.com/chromium/src.git/+/refs/tags/106.0.5216.0/content/browser/web_contents/web_contents_impl.cc#6260):
```c++
bool WebContentsImpl::IsAllowedToGoToEntryAtOffset(int32_t offset) {
  // TODO(https://crbug.com/1170277): This should probably be renamed to
  // WebContentsDelegate::IsAllowedToGoToEntryAtOffset or
  // ShouldGoToEntryAtOffset
  return !delegate_ || delegate_->OnGoToEntryOffset(offset);
}
```
And Electron's implementation of `delegate_->OnGoToEntryOffset(offset)` in [electron::api::WebContents::OnGoToEntryOffset](https://github.com/electron/electron/blob/97b353a30a0e92a169fb0557ddff641fa0332d7c/shell/browser/api/electron_api_web_contents.cc#L1382) handles the navigation itself, rather than allowing `RenderFrameHostImpl::GoToEntryAtOffset`'s default behavior of navigating in the frame instead of the parent context:
```c++
bool WebContents::OnGoToEntryOffset(int offset) {
  GoToOffset(offset);
  return false;
}
```

This change removes the override of `OnGoToEntryOffset` in `electron::api::WebContents` (the default implementation of `WebContentsDelegate::OnGoToEntryOffset` is just `return true`).

The override was added by @deepak1556 in https://github.com/electron/electron/pull/3875 to fix https://github.com/electron/electron/issues/3734. I think that the calling Chrome code may have changed since then, since it was so long ago (2015) and because of the comment in `WebContentsImpl::IsAllowedToGoToEntryAtOffset` about needing to rename `WebContentsDelegate::OnGoToEntryOffset` to `WebContentsDelegate::IsAllowedToGoToEntryAtOffset or ShouldGoToEntryAtOffset`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed issue with history.back() in sandboxed iframes affecting parent browsing context. <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
