### PR TITLE
fix: fullscreen crashing with `roundedCorners: false`

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -246,7 +246,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `trafficLightPosition` [Point](structures/point.md) (optional) _macOS_ -
     Set a custom position for the traffic light buttons in frameless windows.
   * `roundedCorners` boolean (optional) _macOS_ - Whether frameless window
-    should have rounded corners on macOS. Default is `true`.
+    should have rounded corners on macOS. Default is `true`. Setting this property
+    to `false` will prevent the window from being fullscreenable.
   * `fullscreenWindowTitle` boolean (optional) _macOS_ _Deprecated_ - Shows
     the title in the title bar in full screen mode on macOS for `hiddenInset`
     titleBarStyle. Default is `false`.

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -299,7 +299,7 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   bool rounded_corner = true;
   options.Get(options::kRoundedCorners, &rounded_corner);
   if (!rounded_corner && !has_frame())
-    styleMask = 0;
+    styleMask = NSWindowStyleMaskBorderless;
 
   if (minimizable)
     styleMask |= NSWindowStyleMaskMiniaturizable;
@@ -691,6 +691,9 @@ bool NativeWindowMac::HandleDeferredClose() {
 }
 
 void NativeWindowMac::SetFullScreen(bool fullscreen) {
+  if (!has_frame() && !HasStyleMask(NSWindowStyleMaskTitled))
+    return;
+
   // [NSWindow -toggleFullScreen] is an asynchronous operation, which means
   // that it's possible to call it while a fullscreen transition is currently
   // in process. This can create weird behavior (incl. phantom windows),

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1450,6 +1450,11 @@ describe('BrowserWindow module', () => {
             expect(w.fullScreen).to.be.true();
           });
 
+          it('does not go fullscreen if roundedCorners are enabled', async () => {
+            w = new BrowserWindow({ frame: false, roundedCorners: false, fullscreen: true });
+            expect(w.fullScreen).to.be.false();
+          });
+
           it('can be changed', () => {
             w.fullScreen = false;
             expect(w.fullScreen).to.be.false();


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/35403.
Refs CL:1125099.

Fixes an issue where frameless windows with `roundedCorners: false` cannot enter fullscreen without crashing. This is happening because Chromium uses a custom `NativeWidgetMacNSWindowBorderlessFrame` when the NSWindow has a `NSWindowStyleMaskBorderless` style mask, which is itself a subclass of `NSNextStepFrame`. `NSNextStepFrame` does not implement any of the public or private methods required for fullscreen, and so it would crash with errors like:

```
-[NativeWidgetMacNSWindowBorderlessFrame _surrenderToolbarViewForFullScreenWindow:]: unrecognized selector sent to instance
```

The cleanest solution for this would be to document this case in the `roundedCorners` option, and prevent the window from going fullscreen.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where frameless windows with `roundedCorners: false` couldn't enter fullscreen without crashing.