### PR TITLE
fix: crash on WebWorker destruction

### DIFF
--- a/patches/node/feat_add_uv_loop_interrupt_on_io_change_option_to_uv_loop_configure.patch
+++ b/patches/node/feat_add_uv_loop_interrupt_on_io_change_option_to_uv_loop_configure.patch
@@ -136,7 +136,7 @@ index 7cd3a2a954ff7d70e6ba7a6f7538648841bc54b2..f89b7158218be60ac10e61484a2d5e5e
  
  
 diff --git a/deps/uv/src/unix/loop.c b/deps/uv/src/unix/loop.c
-index a88e71c339351f2ebcdd6c3f933fc3b1122910ed..353143e5ebecae598425dc036f4458bb7c43bb0b 100644
+index a88e71c339351f2ebcdd6c3f933fc3b1122910ed..46fc03264b6cc1a3a4d8faf5ec5a754fc07c9b6d 100644
 --- a/deps/uv/src/unix/loop.c
 +++ b/deps/uv/src/unix/loop.c
 @@ -217,6 +217,11 @@ int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap) {
@@ -151,7 +151,7 @@ index a88e71c339351f2ebcdd6c3f933fc3b1122910ed..353143e5ebecae598425dc036f4458bb
    if (option != UV_LOOP_BLOCK_SIGNAL)
      return UV_ENOSYS;
  
-@@ -226,3 +231,37 @@ int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap) {
+@@ -226,3 +231,40 @@ int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap) {
    loop->flags |= UV_LOOP_BLOCK_SIGPROF;
    return 0;
  }
@@ -181,6 +181,9 @@ index a88e71c339351f2ebcdd6c3f933fc3b1122910ed..353143e5ebecae598425dc036f4458bb
 +  while (r == -1 && errno == EINTR);
 +
 +  if (r == len)
++    return;
++
++  if (!uv_loop_alive(loop))
 +    return;
 +
 +  if (r == -1)

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -37,6 +37,7 @@
 #include "shell/common/mac/main_application_bundle.h"
 #include "shell/common/node_includes.h"
 #include "third_party/blink/renderer/bindings/core/v8/v8_initializer.h"  // nogncheck
+#include "third_party/electron_node/src/debug_utils.h"
 
 #if !defined(MAS_BUILD)
 #include "shell/common/crash_keys.h"
@@ -136,7 +137,7 @@ void stop_and_close_uv_loop(uv_loop_t* loop) {
       break;
 
   DCHECK_EQ(0, uv_loop_alive(loop));
-  uv_loop_close(loop);
+  node::CheckedUvLoopClose(loop);
 }
 
 bool g_is_initialized = false;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/35384.
Closes https://github.com/electron/electron/issues/35442.

Fixes a potential crash on WebWorker destruction. This was happening as a result of our custom `UV_LOOP_INTERRUPT_ON_IO_CHANGE` code added to libuv, as `uv_loop_close` results in a call to `uv__io_stop`, which then calls `uv__loop_interrupt`. `uv__loop_interrupt` didn't account for the case where the loop was no longer alive, and so would crash. This fixes that.

This PR also switches over from a direct call to `uv_loop_close` to Node's wrapper `CheckedUvLoopClose`, which calls `uv_loop_close` as expected but also aids in future debugging by logging all open handles should they exist. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash on WebWorker destruction. 
