### PR TITLE
ci: fixup doc-only-change on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,11 +64,11 @@ for:
     build_script:
     - ps: |
         node script/yarn.js install --frozen-lockfile
-        $result = node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH
-        Write-Output $result
-        if ($result.ExitCode -eq 0) {
-          Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
+        node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH
+        if ($LASTEXITCODE -eq 0) {
+          Write-warning "Skipping tests for doc only change"; Exit-AppveyorBuild
         }
+        $global:LASTEXITCODE = 0
     - cd ..
     - ps: Write-Host "Building $env:GN_CONFIG build"
     - git config --global core.longpaths true
@@ -255,11 +255,11 @@ for:
     build_script:
     - ps: |
         node script/yarn.js install --frozen-lockfile
-        $result = node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH
-        Write-Output $result
-        if ($result.ExitCode -eq 0) {
+        node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH
+        if ($LASTEXITCODE -eq 0) {
           Write-warning "Skipping tests for doc only change"; Exit-AppveyorBuild
         }
+        $global:LASTEXITCODE = 0
     - ps: |
         cd ..
         mkdir out\Default


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

The docs only check on Windows was not working properly due to how we were reading the exit code from the check.  This change will allow that check to operate properly.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
