### PR TITLE
build: fix export patches to work when source directory does not exist

### DIFF
--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -238,6 +238,11 @@ def to_utf8(patch):
 
 
 def export_patches(repo, out_dir, patch_range=None, dry_run=False):
+  if not os.path.exists(repo):
+    sys.stderr.write(
+      "Skipping patches in {} because it does not exist.\n".format(repo)
+    )
+    return
   if patch_range is None:
     patch_range, num_patches = guess_base_commit(repo)
     sys.stderr.write("Exporting {} patches in {} since {}\n".format(


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
#34993 added a patch (f82c240acb13b0a4605306930f28ab2f5d41415a) that only applies to source code that only exists on Linux.  That broke exporting patches on OSes other than Linux.  This PR fixes that issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
