### PR TITLE
test: fix some broken globs for spec-main

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1060,7 +1060,7 @@ steps-tests: &steps-tests
             export LLVM_SYMBOLIZER_PATH=$PWD/third_party/llvm-build/Release+Asserts/bin/llvm-symbolizer
             export MOCHA_TIMEOUT=180000
             echo "Piping output to ASAN_SYMBOLIZE ($ASAN_SYMBOLIZE)"
-            (cd electron && node script/yarn test --runners=main --trace-uncaught --enable-logging --files $(circleci tests glob spec-main/*-spec.ts | circleci tests split --split-by=timings)) 2>&1 | $ASAN_SYMBOLIZE
+            (cd electron && node script/yarn test --runners=main --trace-uncaught --enable-logging --files $(circleci tests glob spec/*-spec.ts | circleci tests split --split-by=timings)) 2>&1 | $ASAN_SYMBOLIZE
           else
             if [ "$TARGET_ARCH" == "arm" ] || [ "$TARGET_ARCH" == "arm64" ]; then
               export ELECTRON_SKIP_NATIVE_MODULE_TESTS=true
@@ -1069,7 +1069,7 @@ steps-tests: &steps-tests
               if [ "$TARGET_ARCH" == "ia32" ]; then
                 npm_config_arch=x64 node electron/node_modules/dugite/script/download-git.js
               fi
-              (cd electron && node script/yarn test --runners=main --trace-uncaught --enable-logging --files $(circleci tests glob spec-main/*-spec.ts | circleci tests split --split-by=timings))
+              (cd electron && node script/yarn test --runners=main --trace-uncaught --enable-logging --files $(circleci tests glob spec/*-spec.ts | circleci tests split --split-by=timings))
             fi
           fi
     - run:

--- a/.gitignore
+++ b/.gitignore
@@ -35,13 +35,13 @@ electron-api.json
 electron.d.ts
 
 # Spec hash calculation
-spec-main/.hash
+spec/.hash
 
 # Eslint Cache
 .eslintcache*
 
 # Generated native addon files
-/spec-main/fixtures/native-addon/echo/build/
+/spec/fixtures/native-addon/echo/build/
 
 # If someone runs tsc this is where stuff will end up
 ts-gen
@@ -53,4 +53,4 @@ ts-gen
 # Used to accelerate builds after sync
 patches/mtime-cache.json
 
-spec-main/fixtures/logo.png
+spec/fixtures/logo.png


### PR DESCRIPTION
Missed these in the rename.

Notes: none
