### PR TITLE
chore: use nghttp2's config.h on all platforms

### DIFF
--- a/patches/node/build_add_gn_build_files.patch
+++ b/patches/node/build_add_gn_build_files.patch
@@ -709,10 +709,10 @@ index 0000000000000000000000000000000000000000..fb000f8ee7647c375bc190d1729d67bb
 +}
 diff --git a/deps/nghttp2/BUILD.gn b/deps/nghttp2/BUILD.gn
 new file mode 100644
-index 0000000000000000000000000000000000000000..8bfecba74d4d90e9fbf0e2cd301118e4adc6cba8
+index 0000000000000000000000000000000000000000..9abde472d88923db835b12982b7f2ccb1f260196
 --- /dev/null
 +++ b/deps/nghttp2/BUILD.gn
-@@ -0,0 +1,49 @@
+@@ -0,0 +1,47 @@
 +config("nghttp2_config") {
 +  defines = [ "NGHTTP2_STATICLIB" ]
 +  include_dirs = [ "lib/includes" ]
@@ -723,11 +723,9 @@ index 0000000000000000000000000000000000000000..8bfecba74d4d90e9fbf0e2cd301118e4
 +    "_U_",
 +    "BUILDING_NGHTTP2",
 +    "NGHTTP2_STATICLIB",
++    "HAVE_CONFIG_H",
 +  ]
 +  include_dirs = [ "lib/includes" ]
-+  if (is_win) {
-+    defines += [ "HAVE_CONFIG_H" ]
-+  }
 +
 +  cflags_c = [
 +    "-Wno-implicit-function-declaration",


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/nodejs/node/pull/27283/files.

More closely aligns with nghttp2.gyp.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.