### PR TITLE
build: fix missing patch config dir error

### DIFF
--- a/script/export_all_patches.py
+++ b/script/export_all_patches.py
@@ -2,13 +2,15 @@
 
 import argparse
 import json
+import os
 
 from lib import git
 
 
 def export_patches(dirs, dry_run):
   for patch_dir, repo in dirs.items():
-    git.export_patches(repo=repo, out_dir=patch_dir, dry_run=dry_run)
+    if os.path.exists(repo):
+      git.export_patches(repo=repo, out_dir=patch_dir, dry_run=dry_run)
 
 
 def parse_args():


### PR DESCRIPTION
#### Description of Change

Fixes an error on macOS where editing an existing patch and re-exporting it would cause a Not Found error. This error was happening when editing and re-exporting patches only, as opposed to when applying patches, since `apply_all_patches.py` specifically [ensures the dir exists](https://github.com/electron/electron/blob/97b353a30a0e92a169fb0557ddff641fa0332d7c/script/apply_all_patches.py#L14). The same should be true in `export_all_patches.py` - this PR fixes that.

This came up as of https://github.com/electron/electron/pull/34993 since `third_party/lss`doesn't exist on macOS.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
