### PR TITLE
feat: add webFrameMain.executeJavaScriptInIsolatedWorld()

### DIFF
--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -93,6 +93,17 @@ In the browser window some HTML APIs like `requestFullScreen` can only be
 invoked by a gesture from the user. Setting `userGesture` to `true` will remove
 this limitation.
 
+#### `frame.executeJavaScriptInIsolatedWorld(worldId, code[, userGesture])`
+
+* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electron's `contextIsolation` feature.  You can provide any integer here.
+* `code` string
+* `userGesture` boolean (optional) - Default is `false`.
+
+Returns `Promise<unknown>` - A promise that resolves with the result of the executed
+code or is rejected if execution throws or results in a rejected promise.
+
+Works like `executeJavaScript` but evaluates `scripts` in an isolated context.
+
 #### `frame.reload()`
 
 Returns `boolean` - Whether the reload was initiated successfully. Only results in `false` when the frame has no history.

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -120,6 +120,14 @@ bool WebFrameMain::CheckRenderFrame() const {
 v8::Local<v8::Promise> WebFrameMain::ExecuteJavaScript(
     gin::Arguments* args,
     const std::u16string& code) {
+  return ExecuteJavaScriptInIsolatedWorld(
+      args, content::ISOLATED_WORLD_ID_GLOBAL, code);
+}
+
+v8::Local<v8::Promise> WebFrameMain::ExecuteJavaScriptInIsolatedWorld(
+    gin::Arguments* args,
+    int world_id,
+    const std::u16string& code) {
   gin_helper::Promise<base::Value> promise(args->isolate());
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
@@ -144,8 +152,7 @@ v8::Local<v8::Promise> WebFrameMain::ExecuteJavaScript(
 
   static_cast<content::RenderFrameHostImpl*>(render_frame_)
       ->ExecuteJavaScriptForTests(
-          code, user_gesture, true /* resolve_promises */,
-          content::ISOLATED_WORLD_ID_GLOBAL,
+          code, user_gesture, true /* resolve_promises */, world_id,
           base::BindOnce(
               [](gin_helper::Promise<base::Value> promise,
                  blink::mojom::JavaScriptExecutionResultType type,
@@ -388,6 +395,8 @@ v8::Local<v8::ObjectTemplate> WebFrameMain::FillObjectTemplate(
     v8::Local<v8::ObjectTemplate> templ) {
   return gin_helper::ObjectTemplateBuilder(isolate, templ)
       .SetMethod("executeJavaScript", &WebFrameMain::ExecuteJavaScript)
+      .SetMethod("executeJavaScriptInIsolatedWorld",
+                 &WebFrameMain::ExecuteJavaScriptInIsolatedWorld)
       .SetMethod("reload", &WebFrameMain::Reload)
       .SetMethod("_send", &WebFrameMain::Send)
       .SetMethod("_postMessage", &WebFrameMain::PostMessage)

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -93,6 +93,11 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
 
   v8::Local<v8::Promise> ExecuteJavaScript(gin::Arguments* args,
                                            const std::u16string& code);
+  v8::Local<v8::Promise> ExecuteJavaScriptInIsolatedWorld(
+      gin::Arguments* args,
+      int world_id,
+      const std::u16string& code);
+
   bool Reload();
   void Send(v8::Isolate* isolate,
             bool internal,


### PR DESCRIPTION
#### Description of Change
Re-land #26913

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added missing `webFrameMain.executeJavaScriptInIsolatedWorld()`.