### PR TITLE
refactor: handle uncaught promise error

### DIFF
--- a/lib/renderer/web-view/web-view-attributes.ts
+++ b/lib/renderer/web-view/web-view-attributes.ts
@@ -186,7 +186,10 @@ export class SrcAttribute extends WebViewAttribute {
       opts.userAgent = useragent;
     }
 
-    (this.webViewImpl.webviewNode as Electron.WebviewTag).loadURL(this.getValue(), opts);
+    (this.webViewImpl.webviewNode as Electron.WebviewTag).loadURL(this.getValue(), opts)
+      .catch(err => {
+        console.error('Unexpected error while loading URL', err);
+      });
   }
 }
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

`loadURL` throws uncaught promise error such as `Uncaught (in promise) Error: Error invoking remote method 'GUEST_VIEW_MANAGER_CALL': Error: ERR_FAILED (-2) loading 'http://xxx.com/'
    at t.ipcRendererInternal.invoke` very often.

Issues: #28208, #35240

Actually I do nothing. But I think it's better than uncaught error.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
