### PR TITLE
chore: drop unresponsive suppressor for menus

### DIFF
--- a/shell/browser/api/electron_api_menu_mac.mm
+++ b/shell/browser/api/electron_api_menu_mac.mm
@@ -14,7 +14,6 @@
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/web_contents.h"
 #include "shell/browser/native_window.h"
-#include "shell/browser/unresponsive_suppressor.h"
 #include "shell/common/keyboard_util.h"
 #include "shell/common/node_includes.h"
 
@@ -156,7 +155,6 @@ void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
   base::mac::ScopedSendingEvent sendingEventScoper;
 
   // Don't emit unresponsive event when showing menu.
-  electron::UnresponsiveSuppressor suppressor;
   [menu popUpMenuPositioningItem:item atLocation:position inView:view];
 }
 

--- a/shell/browser/api/electron_api_menu_views.cc
+++ b/shell/browser/api/electron_api_menu_views.cc
@@ -8,7 +8,6 @@
 #include <utility>
 
 #include "shell/browser/native_window_views.h"
-#include "shell/browser/unresponsive_suppressor.h"
 #include "ui/display/screen.h"
 
 using views::MenuRunner;

--- a/shell/browser/api/electron_api_menu_views.cc
+++ b/shell/browser/api/electron_api_menu_views.cc
@@ -39,9 +39,6 @@ void MenuViews::PopupAt(BaseWindow* window,
 
   int flags = MenuRunner::CONTEXT_MENU | MenuRunner::HAS_MNEMONICS;
 
-  // Don't emit unresponsive event when showing menu.
-  electron::UnresponsiveSuppressor suppressor;
-
   // Make sure the Menu object would not be garbage-collected until the callback
   // has run.
   base::OnceClosure callback_with_ref = BindSelfToClosure(std::move(callback));


### PR DESCRIPTION
#### Description of Change
This no longer seems to be necessary since #20114 moved the menu popup loop off
the UI thread.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none
