### PR TITLE
feat: add BaseWindow.isClosed

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1869,6 +1869,10 @@ removed in future Electron releases.
 On a Window with Window Controls Overlay already enabled, this method updates
 the style of the title bar overlay.
 
+#### `win.isClosed()`
+
+Returns `boolean` - true if the window has been closed.
+
 [runtime-enabled-features]: https://cs.chromium.org/chromium/src/third_party/blink/renderer/platform/runtime_enabled_features.json5?l=70
 [page-visibility-api]: https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
 [quick-look]: https://en.wikipedia.org/wiki/Quick_Look

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -329,6 +329,10 @@ void BaseWindow::Close() {
   window_->Close();
 }
 
+bool BaseWindow::IsClosed() {
+  return window_->IsClosed();
+}
+
 void BaseWindow::Focus() {
   window_->Focus(true);
 }
@@ -1216,6 +1220,7 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isFullScreenable", &BaseWindow::IsFullScreenable)
       .SetMethod("setClosable", &BaseWindow::SetClosable)
       .SetMethod("isClosable", &BaseWindow::IsClosable)
+      .SetMethod("isClosed", &BaseWindow::IsClosed)
       .SetMethod("setAlwaysOnTop", &BaseWindow::SetAlwaysOnTop)
       .SetMethod("isAlwaysOnTop", &BaseWindow::IsAlwaysOnTop)
       .SetMethod("center", &BaseWindow::Center)

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -90,6 +90,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   // Public APIs of NativeWindow.
   void SetContentView(gin::Handle<View> view);
   void Close();
+  bool IsClosed();
   virtual void CloseImmediately();
   virtual void Focus();
   virtual void Blur();


### PR DESCRIPTION
#### Description of Change
This adds a new method, `win.isClosed()`, to BaseWindow (and thus
BrowserWindow).

This is useful for checking certain things, e.g. whether an app should show a
dialog when some sort of event is received it may be useful to check whether
the window is still open before showing the dialog.

It's currently possible to work around the lack of this by listening to the
`closed` event, but it's clunky.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `win.isClosed()` to BrowserWindow.
