### PR TITLE
fix: `screen.getCursorScreenPoint()` crash on Wayland

### DIFF
--- a/shell/browser/api/electron_api_screen.h
+++ b/shell/browser/api/electron_api_screen.h
@@ -40,7 +40,7 @@ class Screen : public gin::Wrappable<Screen>,
   Screen(v8::Isolate* isolate, display::Screen* screen);
   ~Screen() override;
 
-  gfx::Point GetCursorScreenPoint();
+  gfx::Point GetCursorScreenPoint(v8::Isolate* isolate);
   display::Display GetPrimaryDisplay();
   std::vector<display::Display> GetAllDisplays();
   display::Display GetDisplayNearestPoint(const gfx::Point& point);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/35471.

Fixes an issue where `screen.getCursorScreenPoint()` crashed on Wayland when it was called before a `BrowserWindow` had been created. This happened becuase the Wayland implementation [requires it](https://source.chromium.org/chromium/chromium/src/+/main:ui/ozone/platform/wayland/host/wayland_screen.cc;l=325-327;drc=7267e612666ee78e5809dcc48253af2857989a47;bpv=1;bpt=1?q=wayland_scr&ss=chromium%2Fchromium%2Fsrc). To fix this, we throw an error if a user attempts to call it before creating a `BrowserWindow`.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `screen.getCursorScreenPoint()` crashed on Wayland when it was called before a `BrowserWindow` had been created.