### PR TITLE
chore: make macOS spellchecker fns formal no-ops

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -978,7 +978,7 @@ The built in spellchecker does not automatically detect what language a user is 
 spell checker to correctly check their words you must call this API with an array of language codes.  You can
 get the list of supported language codes with the `ses.availableSpellCheckerLanguages` property.
 
-**Note:** On macOS the OS spellchecker is used and will detect your language automatically.  This API will return whichever languages have been configured by the OS.
+**Note:** On macOS the OS spellchecker is used and will detect your language automatically.  This API is a no-op on macOS.
 
 #### `ses.getSpellCheckerLanguages()`
 
@@ -986,7 +986,7 @@ Returns `string[]` - An array of language codes the spellchecker is enabled for.
 will fallback to using `en-US`.  By default on launch if this setting is an empty list Electron will try to populate this
 setting with the current OS locale.  This setting is persisted across restarts.
 
-**Note:** On macOS the OS spellchecker is used and has its own list of languages.  This API is a no-op on macOS.
+**Note:** On macOS the OS spellchecker is used and has its own list of languages. On macOS, this API will return whichever languages have been configured by the OS.
 
 #### `ses.setSpellCheckerDictionaryDownloadURL(url)`
 

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -978,7 +978,7 @@ The built in spellchecker does not automatically detect what language a user is 
 spell checker to correctly check their words you must call this API with an array of language codes.  You can
 get the list of supported language codes with the `ses.availableSpellCheckerLanguages` property.
 
-**Note:** On macOS the OS spellchecker is used and will detect your language automatically.  This API is a no-op on macOS.
+**Note:** On macOS the OS spellchecker is used and will detect your language automatically.  This API will return whichever languages have been configured by the OS.
 
 #### `ses.getSpellCheckerLanguages()`
 

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -1043,6 +1043,7 @@ base::Value Session::GetSpellCheckerLanguages() {
 void Session::SetSpellCheckerLanguages(
     gin_helper::ErrorThrower thrower,
     const std::vector<std::string>& languages) {
+#if !BUILDFLAG(IS_MAC)
   base::Value::List language_codes;
   for (const std::string& lang : languages) {
     std::string code = spellcheck::GetCorrespondingSpellCheckLanguage(lang);
@@ -1058,10 +1059,12 @@ void Session::SetSpellCheckerLanguages(
   // Enable spellcheck if > 0 languages, disable if no languages set
   browser_context_->prefs()->SetBoolean(spellcheck::prefs::kSpellCheckEnable,
                                         !languages.empty());
+#endif
 }
 
 void SetSpellCheckerDictionaryDownloadURL(gin_helper::ErrorThrower thrower,
                                           const GURL& url) {
+#if !BUILDFLAG(IS_MAC)
   if (!url.is_valid()) {
     thrower.ThrowError(
         "The URL you provided to setSpellCheckerDictionaryDownloadURL is not a "
@@ -1069,6 +1072,7 @@ void SetSpellCheckerDictionaryDownloadURL(gin_helper::ErrorThrower thrower,
     return;
   }
   SpellcheckHunspellDictionary::SetBaseDownloadURL(url);
+#endif
 }
 
 v8::Local<v8::Promise> Session::ListWordsInSpellCheckerDictionary() {

--- a/spec/spellchecker-spec.ts
+++ b/spec/spellchecker-spec.ts
@@ -212,6 +212,44 @@ ifdescribe(features.isBuiltinSpellCheckerEnabled())('spellchecker', function () 
           });
         });
 
+        describe('ses.setSpellCheckerLanguages', () => {
+          const isMac = process.platform === 'darwin';
+
+          ifit(isMac)('should be a no-op when setSpellCheckerLanguages is called on macOS', () => {
+            expect(() => {
+              w.webContents.session.setSpellCheckerLanguages(['i-am-a-nonexistent-language']);
+            }).to.not.throw();
+          });
+
+          ifit(!isMac)('should throw when a bad language is passed', () => {
+            expect(() => {
+              w.webContents.session.setSpellCheckerLanguages(['i-am-a-nonexistent-language']);
+            }).to.throw(/Invalid language code provided: "i-am-a-nonexistent-language" is not a valid language code/);
+          });
+
+          ifit(!isMac)('should not throw when a recognized language is passed', () => {
+            expect(() => {
+              w.webContents.session.setSpellCheckerLanguages(['es']);
+            }).to.not.throw();
+          });
+        });
+
+        describe('SetSpellCheckerDictionaryDownloadURL', () => {
+          const isMac = process.platform === 'darwin';
+
+          ifit(isMac)('should be a no-op when a bad url is passed on macOS', () => {
+            expect(() => {
+              w.webContents.session.setSpellCheckerDictionaryDownloadURL('i-am-not-a-valid-url');
+            }).to.not.throw();
+          });
+
+          ifit(!isMac)('should throw when a bad url is passed', () => {
+            expect(() => {
+              w.webContents.session.setSpellCheckerDictionaryDownloadURL('i-am-not-a-valid-url');
+            }).to.throw(/The URL you provided to setSpellCheckerDictionaryDownloadURL is not a valid URL/);
+          });
+        });
+
         describe('ses.removeWordFromSpellCheckerDictionary', () => {
           it('should successfully remove words to custom dictionary', async () => {
             const result1 = ses.addWordToSpellCheckerDictionary('foobar');


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/35508.

Formally make `session.setSpellCheckerLanguages()` and `session.setSpellCheckerDictionaryDownloadURL()` no-ops on macOS. macOS uses system spellchecking functionality so those functions would not have their intended effect, but could still throw errors if called with an unsupported language.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where some spellcheck functionality would incorrectly throw errors on macOS.
