### PR TITLE
fix: potential "Object has been destroyed" error in BrowserWindow.getFocusedWindow

### DIFF
--- a/lib/browser/api/browser-window.ts
+++ b/lib/browser/api/browser-window.ts
@@ -72,9 +72,8 @@ BrowserWindow.getAllWindows = () => {
 
 BrowserWindow.getFocusedWindow = () => {
   for (const window of BrowserWindow.getAllWindows()) {
-    const hasWC = window.webContents && !window.webContents.isDestroyed();
-    if (!window.isDestroyed() && hasWC) {
-      if (window.isFocused() || window.isDevToolsFocused()) return window;
+    if (!window.isDestroyed() && window.webContents && !window.webContents.isDestroyed()) {
+      if (window.isFocused() || window.webContents.isDevToolsFocused()) return window;
     }
   }
   return null;


### PR DESCRIPTION
#### Description of Change
We cannot access the `webContents` property before checking for `!isDestroyed()`

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: none