### PR TITLE
fix: EventEmitter is missing properties in sandbox preload script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-standard": "^4.0.1",
     "eslint-plugin-typescript": "^0.14.0",
+    "events": "^3.2.0",
     "express": "^4.16.4",
     "folder-hash": "^2.1.1",
     "fs-extra": "^9.0.1",

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -2970,6 +2970,26 @@ describe('BrowserWindow module', () => {
         expect(url).to.equal(expectedUrl);
       });
 
+      it('exposes full EventEmmiter object to preload script', async () => {
+        const w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            sandbox: true,
+            preload: path.join(fixtures, 'module', 'preload-eventemitter.js')
+          }
+        });
+        w.loadURL('about:blank');
+        const [, rendererEventEmitterProperties] = await emittedOnce(ipcMain, 'answer');
+        const { EventEmitter } = require('events');
+        const emitter = new EventEmitter();
+        let browserEventEmitterProperties = '';
+        let currentObj = emitter;
+        do {
+          Object.getOwnPropertyNames(currentObj).map(property => { browserEventEmitterProperties += property + ';'; });
+        } while ((currentObj = Object.getPrototypeOf(currentObj)));
+        expect(rendererEventEmitterProperties).to.equal(browserEventEmitterProperties);
+      });
+
       it('should open windows in same domain with cross-scripting enabled', async () => {
         const w = new BrowserWindow({
           show: true,

--- a/spec/fixtures/module/preload-eventemitter.js
+++ b/spec/fixtures/module/preload-eventemitter.js
@@ -1,0 +1,11 @@
+(function () {
+  const { EventEmitter } = require('events');
+  const emitter = new EventEmitter();
+  let rendererEventEmitterProperties = '';
+  let currentObj = emitter;
+  do {
+    Object.getOwnPropertyNames(currentObj).map(property => { rendererEventEmitterProperties += property + ';'; });
+  } while ((currentObj = Object.getPrototypeOf(currentObj)));
+  const { ipcRenderer } = require('electron');
+  ipcRenderer.send('answer', rendererEventEmitterProperties);
+})();


### PR DESCRIPTION
#### Description of Change
Add EventEmitter to package.json (version is based on webpack 5 requirements).

After update to webpack 5 missing events dependency was causing EventEmitter created in renderer preload script to be missing properties, for example eventNames, getMaxListeners, prependListener, prependOnceListener, etc. Add it so that it can be used properly from electron libs, sandbox renderer init scripts specifically.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
