### PR TITLE
docs: remove claim that HTTPS authenticates the remote server

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -130,10 +130,8 @@ like `HTTP`. Similarly, we recommend the use of `WSS` over `WS`, `FTPS` over
 
 #### Why?
 
-`HTTPS` has three main benefits:
+`HTTPS` has two main benefits:
 
-1. It authenticates the remote server, ensuring your app connects to the correct
-   host instead of an impersonator.
 1. It ensures data integrity, asserting that the data was not modified while in
    transit between your application and the host.
 1. It encrypts the traffic between your user and the destination host, making it


### PR DESCRIPTION
#### Description of Change

Removed the claim that HTTPS authenticates the remote server. This is not a feature of HTTPS. This would require certificate pinning. It has been in the security docs since https://github.com/electron/electron/commit/2db125890cf901f939ab60b550dee54a091d57a4

Related

https://github.com/electron/electron/issues/3330
https://www.npmjs.com/package/electron-ssl-pinning
https://cheatsheetseries.owasp.org/cheatsheets/Pinning_Cheat_Sheet.html

#### Checklist

- [x] relevant documentation is changed or added

#### Release Notes

Notes: none
