### PR TITLE
chore: move dark mode activation to main_win.cc

### DIFF
--- a/shell/app/electron_main_win.cc
+++ b/shell/app/electron_main_win.cc
@@ -21,6 +21,7 @@
 #include "base/i18n/icu_util.h"
 #include "base/process/launch.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/win/dark_mode_support.h"
 #include "base/win/windows_version.h"
 #include "components/browser_watcher/exit_code_watcher_win.h"
 #include "components/crash/core/app/crash_switches.h"
@@ -218,6 +219,11 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
     }
     return crashpad_status;
   }
+
+#if BUILDFLAG(IS_WIN)
+  // access ui native theme here to prevent blocking calls later
+  base::win::AllowDarkModeForApp(true);
+#endif
 
 #if defined(ARCH_CPU_32_BITS)
   // Intentionally crash if converting to a fiber failed.

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -83,7 +83,6 @@
 #endif
 
 #if BUILDFLAG(IS_WIN)
-#include "base/win/dark_mode_support.h"
 #include "ui/base/l10n/l10n_util_win.h"
 #include "ui/display/win/dpi.h"
 #include "ui/gfx/system_fonts_win.h"
@@ -442,11 +441,6 @@ int ElectronBrowserMainParts::PreMainMessageLoopRun() {
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   SpellcheckServiceFactory::GetInstance();
-#endif
-
-#if BUILDFLAG(IS_WIN)
-  // access ui native theme here to prevent blocking calls later
-  base::win::AllowDarkModeForApp(true);
 #endif
 
   content::WebUIControllerFactory::RegisterFactory(


### PR DESCRIPTION
#### Description of Change

Follow up to a recent Chrome roll (#34993), this PR moves Windows dark mode activation from electron_browser_main_parts.cc to electron_main_win.cc, to more closely match Chromium.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
