### PR TITLE
chore: cherry-pick 2083e894852c from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -135,3 +135,4 @@ cherry-pick-54a7927b19f9.patch
 cherry-pick-bd9724c9fe63.patch
 cherry-pick-c643d18a078d.patch
 feat_add_set_can_resize_mutator.patch
+cherry-pick-2083e894852c.patch

--- a/patches/chromium/cherry-pick-2083e894852c.patch
+++ b/patches/chromium/cherry-pick-2083e894852c.patch
@@ -1,7 +1,7 @@
-From 2083e894852cfd18bd913a91eea23f59046e6c39 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anton Bikineev <bikineev@chromium.org>
 Date: Sun, 10 Jul 2022 22:17:03 +0000
-Subject: [PATCH] Fix heap-overflow in blink::TableLayoutAlgorithmAuto::InsertSpanCell
+Subject: Fix heap-overflow in blink::TableLayoutAlgorithmAuto::InsertSpanCell
 
 The CL fixes size confusion between Member<> and raw pointers.
 
@@ -13,13 +13,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3751138
 Reviewed-by: Kentaro Hara <haraken@chromium.org>
 Commit-Queue: Anton Bikineev <bikineev@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#1022529}
----
 
 diff --git a/third_party/blink/renderer/core/layout/table_layout_algorithm_auto.cc b/third_party/blink/renderer/core/layout/table_layout_algorithm_auto.cc
-index 1e1575c..1a4a06a 100644
+index 1e1575cf47027584a9d06d7c5f6046fa15990b10..1a4a06a4761c52b8dd9ae9052b7c51b9236694a5 100644
 --- a/third_party/blink/renderer/core/layout/table_layout_algorithm_auto.cc
 +++ b/third_party/blink/renderer/core/layout/table_layout_algorithm_auto.cc
-@@ -673,7 +673,7 @@
+@@ -673,7 +673,7 @@ void TableLayoutAlgorithmAuto::InsertSpanCell(LayoutTableCell* cell) {
           span > span_cells_[pos]->ColSpan())
      pos++;
    memmove(span_cells_.data() + pos + 1, span_cells_.data() + pos,

--- a/patches/chromium/cherry-pick-2083e894852c.patch
+++ b/patches/chromium/cherry-pick-2083e894852c.patch
@@ -1,0 +1,30 @@
+From 2083e894852cfd18bd913a91eea23f59046e6c39 Mon Sep 17 00:00:00 2001
+From: Anton Bikineev <bikineev@chromium.org>
+Date: Sun, 10 Jul 2022 22:17:03 +0000
+Subject: [PATCH] Fix heap-overflow in blink::TableLayoutAlgorithmAuto::InsertSpanCell
+
+The CL fixes size confusion between Member<> and raw pointers.
+
+The bug was found (and the fix was proposed) by m.cooolie@gmail.com.
+
+Bug: 1341539
+Change-Id: I99d524fd65c2d6305693d09ad274c23178271269
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3751138
+Reviewed-by: Kentaro Hara <haraken@chromium.org>
+Commit-Queue: Anton Bikineev <bikineev@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1022529}
+---
+
+diff --git a/third_party/blink/renderer/core/layout/table_layout_algorithm_auto.cc b/third_party/blink/renderer/core/layout/table_layout_algorithm_auto.cc
+index 1e1575c..1a4a06a 100644
+--- a/third_party/blink/renderer/core/layout/table_layout_algorithm_auto.cc
++++ b/third_party/blink/renderer/core/layout/table_layout_algorithm_auto.cc
+@@ -673,7 +673,7 @@
+          span > span_cells_[pos]->ColSpan())
+     pos++;
+   memmove(span_cells_.data() + pos + 1, span_cells_.data() + pos,
+-          (size - pos - 1) * sizeof(LayoutTableCell*));
++          (size - pos - 1) * sizeof(decltype(span_cells_)::value_type));
+   span_cells_[pos] = cell;
+ }
+ 


### PR DESCRIPTION
Fix heap-overflow in blink::TableLayoutAlgorithmAuto::InsertSpanCell

The CL fixes size confusion between Member<> and raw pointers.

The bug was found (and the fix was proposed) by m.cooolie@gmail.com.

Bug: 1341539
Change-Id: I99d524fd65c2d6305693d09ad274c23178271269
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3751138
Reviewed-by: Kentaro Hara <haraken@chromium.org>
Commit-Queue: Anton Bikineev <bikineev@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1022529}


Ref electron/security#208

Notes: Security: backported fix for CVE-2022-3040.