### PR TITLE
fix: Set background for WCO container

### DIFF
--- a/shell/browser/ui/views/win_caption_button_container.cc
+++ b/shell/browser/ui/views/win_caption_button_container.cc
@@ -14,6 +14,7 @@
 #include "shell/browser/ui/views/win_frame_view.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/strings/grit/ui_strings.h"
+#include "ui/views/background.h"
 #include "ui/views/layout/flex_layout.h"
 #include "ui/views/view_class_properties.h"
 
@@ -128,6 +129,8 @@ void WinCaptionButtonContainer::AddedToWidget() {
   UpdateButtons();
 
   if (frame_view_->window()->IsWindowControlsOverlayEnabled()) {
+    SetBackground(views::CreateSolidBackground(
+        frame_view_->window()->overlay_button_color()));
     SetPaintToLayer();
   }
 }

--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -19,6 +19,7 @@
 #include "ui/display/win/dpi.h"
 #include "ui/display/win/screen_win.h"
 #include "ui/gfx/geometry/dip_util.h"
+#include "ui/views/background.h"
 #include "ui/views/widget/widget.h"
 #include "ui/views/win/hwnd_util.h"
 
@@ -58,6 +59,8 @@ void WinFrameView::InvalidateCaptionButtons() {
   if (!caption_button_container_)
     return;
 
+  caption_button_container_->SetBackground(
+      views::CreateSolidBackground(window()->overlay_button_color()));
   caption_button_container_->InvalidateLayout();
   caption_button_container_->SchedulePaint();
 }


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/35312

Ref https://github.com/electron/electron/issues/35312#issuecomment-1235944004

Chromium was setting a background colour for the windows control overlay container, whereas we weren't. This PR copies the line so that we are also setting a background colour for the WCO container, which should avoid rendering glitches.

I'm currently on an RTL system language to work on another issue, so the WCO in the demo below is mirrored, but it shows that the gaps have been filled in with the overlay button colour.

![WCO with an RTL system language](https://user-images.githubusercontent.com/7199958/188243524-165c25aa-c8b5-466f-a5d9-3882e3b9759b.gif)

CC @deepak1556 

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added a background to the WCO container to avoid rendering glitches. <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
