### PR TITLE
build: make check-symlinks.js aware of BRANDING.json changes

### DIFF
--- a/script/check-symlinks.js
+++ b/script/check-symlinks.js
@@ -2,13 +2,14 @@ const fs = require('fs');
 const path = require('path');
 
 const utils = require('./lib/utils');
+const branding = require('../shell/app/BRANDING.json');
 
 if (process.platform !== 'darwin') {
   console.log('Not checking symlinks on non-darwin platform');
   process.exit(0);
 }
 
-const appPath = path.resolve(__dirname, '..', '..', 'out', utils.getOutDir(), 'Electron.app');
+const appPath = path.resolve(__dirname, '..', '..', 'out', utils.getOutDir(), `${branding.product_name}.app`);
 const visited = new Set();
 const traverse = (p) => {
   if (visited.has(p)) return;


### PR DESCRIPTION
Right now the `check-symlinks.js` assumes that the branding product name
is "Electron". If users change `BRANDING.json` on custom builds, the
script will fail.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

Notes: none
