### PR TITLE
docs: fix misspelling in fuses

### DIFF
--- a/docs/tutorial/fuses.md
+++ b/docs/tutorial/fuses.md
@@ -52,7 +52,7 @@ For more information on how to use asar integrity validation please read the [As
 **Default:** Disabled
 **@electron/fuses:** `FuseV1Options.OnlyLoadAppFromAsar`
 
-The onlyLoadAppFromAsar fuse changes the search system that Electron uses to locate your app code.  By default Electron will search in the following order `app.asar` -> `app` -> `default_app.asasr`.  When this fuse is enabled the search order becomes a single entry `app.asar` thus ensuring that when combined with the `embeddedAsarIntegrityValidation` fuse it is impossible to load non-validated code.
+The onlyLoadAppFromAsar fuse changes the search system that Electron uses to locate your app code.  By default Electron will search in the following order `app.asar` -> `app` -> `default_app.asar`.  When this fuse is enabled the search order becomes a single entry `app.asar` thus ensuring that when combined with the `embeddedAsarIntegrityValidation` fuse it is impossible to load non-validated code.
 
 ## How do I flip the fuses?
 


### PR DESCRIPTION
#### Description of Change
Fixes misspelling in new Fuses docs (`.asasr` -> `.asar`).

#### Release Notes

Notes: none