### PR TITLE
fix: remove extra dot in extension

### DIFF
--- a/shell/browser/electron_download_manager_delegate.cc
+++ b/shell/browser/electron_download_manager_delegate.cc
@@ -106,7 +106,7 @@ bool GetRegistryDescriptionFromExtension(const std::string& file_ext,
 // If a description is not provided for a file extension, it will be retrieved
 // from the registry. If the file extension does not exist in the registry, a
 // default description will be created (e.g. "qqq" yields "QQQ File").
-// Copied from ui/shell_dialogs/select_file_dialog_win.cc
+// Modified from ui/shell_dialogs/select_file_dialog_win.cc
 file_dialog::Filters FormatFilterForExtensions(
     const std::vector<std::string>& file_ext,
     const std::vector<std::string>& ext_desc,

--- a/shell/browser/electron_download_manager_delegate.cc
+++ b/shell/browser/electron_download_manager_delegate.cc
@@ -99,7 +99,7 @@ bool GetRegistryDescriptionFromExtension(const std::string& file_ext,
 // Set up a filter for a Save/Open dialog, |ext_desc| as the text descriptions
 // of the |file_ext| types (optional), and (optionally) the default 'All Files'
 // view. The purpose of the filter is to show only files of a particular type in
-// a Windows Save/Open dialog box. The resulting filter is returned. The filter
+// a Windows Save/Open dialog box. The resulting filter is returned. The filters
 // created here are:
 //   1. only files that have 'file_ext' as their extension
 //   2. all files (only added if 'include_all_files' is true)
@@ -168,6 +168,10 @@ file_dialog::Filters FormatFilterForExtensions(
       base::ReplaceChars(desc, "*", base::StringPiece(), &desc);
     }
 
+    // Remove the preceeding '.' character from the extension.
+    size_t ext_index = ext.find_first_not_of('.');
+    if (ext_index != std::string::npos)
+      ext = ext.substr(ext_index);
     result.push_back({desc, {ext}});
   }
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Closes https://github.com/electron/electron/issues/35594 https://github.com/electron/electron/issues/35429

Removes an extra period from the extension portion of the dialog filter on Windows. This is not expected in Electron's implementation of filters, but was in place for Chromium's. Updates https://github.com/electron/electron/pull/34723

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> Added support for Windows drop-down dialog extensions
