### PR TITLE
docs: fix typescript error in code samples

### DIFF
--- a/docs/fiddles/features/web-serial/main.js
+++ b/docs/fiddles/features/web-serial/main.js
@@ -33,12 +33,16 @@ function createWindow () {
     if (permission === 'serial' && details.securityOrigin === 'file:///') {
       return true
     }
+    
+    return false
   })
 
   mainWindow.webContents.session.setDevicePermissionHandler((details) => {
     if (details.deviceType === 'serial' && details.origin === 'file://') {
       return true
     }
+    
+    return false
   })
   
   mainWindow.loadFile('index.html')


### PR DESCRIPTION
Fixed a typescript warning / error in the example code

- [ x ] relevant documentation is changed or added

Notes: None