### PR TITLE
fix: allow maximizing when window enters tablet mode with WCO

### DIFF
--- a/shell/browser/ui/views/win_caption_button_container.cc
+++ b/shell/browser/ui/views/win_caption_button_container.cc
@@ -159,10 +159,11 @@ void WinCaptionButtonContainer::UpdateButtons() {
   const bool is_touch = ui::TouchUiController::Get()->touch_ui();
   restore_button_->SetEnabled(!is_touch);
 
-  // The maximize button should only be enabled if the window is
-  // maximizable *and* touch mode is disabled.
+  // In touch mode, windows cannot be taken out of fullscreen or tiled mode, so
+  // the maximize/restore button should be disabled, unless the window is not
+  // maximized.
   const bool maximizable = frame_view_->window()->IsMaximizable();
-  maximize_button_->SetEnabled(!is_touch && maximizable);
+  maximize_button_->SetEnabled(!(is_touch && is_maximized) && maximizable);
 
   const bool closable = frame_view_->window()->IsClosable();
   close_button_->SetEnabled(closable);


### PR DESCRIPTION
#### Description of Change
Backport of https://github.com/electron/electron/pull/35617

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Enable WCO maximize button when window enters tablet mode and is not already maximized.
