### PR TITLE
build: fix building with enable_basic_printing false

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -144,6 +144,10 @@
 #include "shell/browser/osr/osr_web_contents_view.h"
 #endif
 
+#if BUILDFLAG(IS_WIN)
+#include "shell/browser/native_window_views.h"
+#endif
+
 #if !BUILDFLAG(IS_MAC)
 #include "ui/aura/window.h"
 #else
@@ -176,9 +180,8 @@
 
 #if BUILDFLAG(IS_WIN)
 #include "printing/backend/win_helper.h"
-#include "shell/browser/native_window_views.h"
 #endif
-#endif
+#endif  // BUILDFLAG(ENABLE_PRINTING)
 
 #if BUILDFLAG(ENABLE_PICTURE_IN_PICTURE)
 #include "chrome/browser/picture_in_picture/picture_in_picture_window_manager.h"


### PR DESCRIPTION
#### Description of Change
Regressed in #35209, cc @codebytere
```
../../electron/shell/browser/api/electron_api_web_contents.cc(2484,27): error: unknown type name 'NativeWindowViews'
  auto* win = static_cast<NativeWindowViews*>(owner_window());
                          ^
../../electron/shell/browser/api/electron_api_web_contents.cc(2487,19): error: no member named 'IsWindowControlsOverlayEnabled' in 'electron::NativeWindow'
  if (win && win->IsWindowControlsOverlayEnabled())
             ~~~  ^
```

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
