### PR TITLE
feat: add app.getSystemLocale() method

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -715,7 +715,7 @@ To set the locale, you'll want to use a command line switch at app startup, whic
 **Note:** When distributing your packaged app, you have to also ship the
 `locales` folder.
 
-**Note:** On Windows, you have to call it after the `ready` events gets emitted.
+**Note:** On Windows, you have to call it after the `ready` event is emitted.
 
 ### `app.getLocaleCountryCode()`
 
@@ -728,7 +728,7 @@ Returns `string` - User operating system's locale two-letter [ISO 3166](https://
 Returns `string` - The current system locale, fetched using Chromium's `l10n_util` library.
 Possible return values are documented [here](https://source.chromium.org/chromium/chromium/src/+/main:ui/base/l10n/l10n_util.cc).
 
-**Note:** On Windows, you have to call it after the `ready` events gets emitted.
+**Note:** This API must be called after the `ready` event is emitted.
 
 ### `app.addRecentDocument(path)` _macOS_ _Windows_
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -725,8 +725,7 @@ Returns `string` - User operating system's locale two-letter [ISO 3166](https://
 
 ### `app.getSystemLocale()`
 
-Returns `string` - The current system locale, fetched using Chromium's `l10n_util` library.
-Possible return values are documented [here](https://source.chromium.org/chromium/chromium/src/+/main:ui/base/l10n/l10n_util.cc).
+Returns `string` - The current system locale. On Windows and Linux, it is fetched using Chromium's `i18n` library. On macOS, the `NSLocale` object is used instead.
 
 **Note:** This API must be called after the `ready` event is emitted.
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -715,7 +715,7 @@ To set the locale, you'll want to use a command line switch at app startup, whic
 **Note:** When distributing your packaged app, you have to also ship the
 `locales` folder.
 
-**Note:** On Windows, you have to call it after the `ready` event is emitted.
+**Note:** This API must be called after the `ready` event is emitted.
 
 ### `app.getLocaleCountryCode()`
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -723,6 +723,13 @@ Returns `string` - User operating system's locale two-letter [ISO 3166](https://
 
 **Note:** When unable to detect locale country code, it returns empty string.
 
+### `app.getSystemLocale()`
+
+Returns `string` - The current system locale, fetched using Chromium's `l10n_util` library.
+Possible return values are documented [here](https://source.chromium.org/chromium/chromium/src/+/main:ui/base/l10n/l10n_util.cc).
+
+**Note:** On Windows, you have to call it after the `ready` events gets emitted.
+
 ### `app.addRecentDocument(path)` _macOS_ _Windows_
 
 * `path` string

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -140,6 +140,7 @@ auto_filenames = {
     "lib/common/define-properties.ts",
     "lib/common/ipc-messages.ts",
     "lib/common/web-view-methods.ts",
+    "lib/common/webpack-globals-provider.ts",
     "lib/renderer/api/context-bridge.ts",
     "lib/renderer/api/crash-reporter.ts",
     "lib/renderer/api/ipc-renderer.ts",

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -140,7 +140,6 @@ auto_filenames = {
     "lib/common/define-properties.ts",
     "lib/common/ipc-messages.ts",
     "lib/common/web-view-methods.ts",
-    "lib/common/webpack-globals-provider.ts",
     "lib/renderer/api/context-bridge.ts",
     "lib/renderer/api/crash-reporter.ts",
     "lib/renderer/api/ipc-renderer.ts",

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1040,7 +1040,7 @@ std::string App::GetLocale() {
   return g_browser_process->GetApplicationLocale();
 }
 
-std::string App::GetSystemLocale() {
+std::string App::GetSystemLocale() const {
   return static_cast<BrowserProcessImpl*>(g_browser_process)->GetSystemLocale();
 }
 

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1040,7 +1040,13 @@ std::string App::GetLocale() {
   return g_browser_process->GetApplicationLocale();
 }
 
-std::string App::GetSystemLocale() const {
+std::string App::GetSystemLocale(gin_helper::ErrorThrower thrower) const {
+  if (!Browser::Get()->is_ready()) {
+    thrower.ThrowError(
+        "app.getSystemLocale() can only be called "
+        "after app is ready");
+    return std::string();
+  }
   return static_cast<BrowserProcessImpl*>(g_browser_process)->GetSystemLocale();
 }
 

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -47,6 +47,7 @@
 #include "shell/browser/api/electron_api_session.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/api/gpuinfo_manager.h"
+#include "shell/browser/browser_process_impl.h"
 #include "shell/browser/electron_browser_context.h"
 #include "shell/browser/electron_browser_main_parts.h"
 #include "shell/browser/javascript_environment.h"
@@ -1039,6 +1040,10 @@ std::string App::GetLocale() {
   return g_browser_process->GetApplicationLocale();
 }
 
+std::string App::GetSystemLocale() {
+  return static_cast<BrowserProcessImpl*>(g_browser_process)->GetSystemLocale();
+}
+
 std::string App::GetLocaleCountryCode() {
   std::string region;
 #if BUILDFLAG(IS_WIN)
@@ -1785,6 +1790,7 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
       .SetMethod("setAppLogsPath", &App::SetAppLogsPath)
       .SetMethod("setDesktopName", &App::SetDesktopName)
       .SetMethod("getLocale", &App::GetLocale)
+      .SetMethod("getSystemLocale", &App::GetSystemLocale)
       .SetMethod("getLocaleCountryCode", &App::GetLocaleCountryCode)
 #if BUILDFLAG(USE_NSS_CERTS)
       .SetMethod("importCertificate", &App::ImportCertificate)

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -191,7 +191,7 @@ class App : public ElectronBrowserClient::Delegate,
   void SetDesktopName(const std::string& desktop_name);
   std::string GetLocale();
   std::string GetLocaleCountryCode();
-  std::string GetSystemLocale();
+  std::string GetSystemLocale() const;
   void OnSecondInstance(const base::CommandLine& cmd,
                         const base::FilePath& cwd,
                         const std::vector<const uint8_t> additional_data);

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -191,6 +191,7 @@ class App : public ElectronBrowserClient::Delegate,
   void SetDesktopName(const std::string& desktop_name);
   std::string GetLocale();
   std::string GetLocaleCountryCode();
+  std::string GetSystemLocale();
   void OnSecondInstance(const base::CommandLine& cmd,
                         const base::FilePath& cwd,
                         const std::vector<const uint8_t> additional_data);

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -191,7 +191,7 @@ class App : public ElectronBrowserClient::Delegate,
   void SetDesktopName(const std::string& desktop_name);
   std::string GetLocale();
   std::string GetLocaleCountryCode();
-  std::string GetSystemLocale() const;
+  std::string GetSystemLocale(gin_helper::ErrorThrower thrower) const;
   void OnSecondInstance(const base::CommandLine& cmd,
                         const base::FilePath& cwd,
                         const std::vector<const uint8_t> additional_data);

--- a/shell/browser/browser_process_impl.cc
+++ b/shell/browser/browser_process_impl.cc
@@ -305,7 +305,7 @@ const std::string& BrowserProcessImpl::GetApplicationLocale() {
   return locale_;
 }
 
-const std::string& BrowserProcessImpl::GetSystemLocale() {
+const std::string& BrowserProcessImpl::GetSystemLocale() const {
   return system_locale_;
 }
 

--- a/shell/browser/browser_process_impl.cc
+++ b/shell/browser/browser_process_impl.cc
@@ -293,20 +293,20 @@ HidPolicyAllowedDevices* BrowserProcessImpl::hid_policy_allowed_devices() {
   return nullptr;
 }
 
-void BrowserProcessImpl::SetApplicationLocale(const std::string& locale) {
-  locale_ = locale;
-}
-
 void BrowserProcessImpl::SetSystemLocale(const std::string& locale) {
   system_locale_ = locale;
 }
 
-const std::string& BrowserProcessImpl::GetApplicationLocale() {
-  return locale_;
-}
-
 const std::string& BrowserProcessImpl::GetSystemLocale() const {
   return system_locale_;
+}
+
+void BrowserProcessImpl::SetApplicationLocale(const std::string& locale) {
+  locale_ = locale;
+}
+
+const std::string& BrowserProcessImpl::GetApplicationLocale() {
+  return locale_;
 }
 
 printing::PrintJobManager* BrowserProcessImpl::print_job_manager() {

--- a/shell/browser/browser_process_impl.cc
+++ b/shell/browser/browser_process_impl.cc
@@ -297,8 +297,16 @@ void BrowserProcessImpl::SetApplicationLocale(const std::string& locale) {
   locale_ = locale;
 }
 
+void BrowserProcessImpl::SetSystemLocale(const std::string& locale) {
+  system_locale_ = locale;
+}
+
 const std::string& BrowserProcessImpl::GetApplicationLocale() {
   return locale_;
+}
+
+const std::string& BrowserProcessImpl::GetSystemLocale() {
+  return system_locale_;
 }
 
 printing::PrintJobManager* BrowserProcessImpl::print_job_manager() {

--- a/shell/browser/browser_process_impl.h
+++ b/shell/browser/browser_process_impl.h
@@ -102,7 +102,7 @@ class BrowserProcessImpl : public BrowserProcess {
   void SetApplicationLocale(const std::string& locale) override;
   void SetSystemLocale(const std::string& locale);
   const std::string& GetApplicationLocale() override;
-  const std::string& GetSystemLocale();
+  const std::string& GetSystemLocale() const;
   printing::PrintJobManager* print_job_manager() override;
   StartupData* startup_data() override;
 

--- a/shell/browser/browser_process_impl.h
+++ b/shell/browser/browser_process_impl.h
@@ -49,6 +49,9 @@ class BrowserProcessImpl : public BrowserProcess {
   void PostDestroyThreads() {}
   void PostMainMessageLoopRun();
 
+  void SetSystemLocale(const std::string& locale);
+  const std::string& GetSystemLocale() const;
+
   void EndSession() override {}
   void FlushLocalStateAndReply(base::OnceClosure reply) override {}
   bool IsShuttingDown() override;
@@ -100,9 +103,7 @@ class BrowserProcessImpl : public BrowserProcess {
   void StartAutoupdateTimer() override {}
 #endif
   void SetApplicationLocale(const std::string& locale) override;
-  void SetSystemLocale(const std::string& locale);
   const std::string& GetApplicationLocale() override;
-  const std::string& GetSystemLocale() const;
   printing::PrintJobManager* print_job_manager() override;
   StartupData* startup_data() override;
 

--- a/shell/browser/browser_process_impl.h
+++ b/shell/browser/browser_process_impl.h
@@ -100,7 +100,9 @@ class BrowserProcessImpl : public BrowserProcess {
   void StartAutoupdateTimer() override {}
 #endif
   void SetApplicationLocale(const std::string& locale) override;
+  void SetSystemLocale(const std::string& locale);
   const std::string& GetApplicationLocale() override;
+  const std::string& GetSystemLocale();
   printing::PrintJobManager* print_job_manager() override;
   StartupData* startup_data() override;
 
@@ -110,6 +112,7 @@ class BrowserProcessImpl : public BrowserProcess {
 #endif
   std::unique_ptr<PrefService> local_state_;
   std::string locale_;
+  std::string system_locale_;
 };
 
 #endif  // ELECTRON_SHELL_BROWSER_BROWSER_PROCESS_IMPL_H_

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -283,10 +283,11 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
 }
 
 int ElectronBrowserMainParts::PreCreateThreads() {
-  if (!views::LayoutProvider::Get())
+  if (!views::LayoutProvider::Get()) {
     layout_provider_ = std::make_unique<views::LayoutProvider>();
+  }
 
-    // Fetch the system locale for Electron.
+  // Fetch the system locale for Electron.
 #if BUILDFLAG(IS_MAC)
   fake_browser_process_->SetSystemLocale(GetCurrentSystemLocale());
 #else

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -320,7 +320,11 @@ int ElectronBrowserMainParts::PreCreateThreads() {
   }
 #endif
 
-  // Initialize the app locale.
+  // Fetch the system locale for Electron.
+  std::string system_locale = l10n_util::GetApplicationLocale("", false);
+  fake_browser_process_->SetSystemLocale(system_locale);
+
+  // Initialize the app locale for Electron and Chromium.
   std::string app_locale = l10n_util::GetApplicationLocale(loaded_locale);
   ElectronBrowserClient::SetApplicationLocale(app_locale);
   fake_browser_process_->SetApplicationLocale(app_locale);

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -321,8 +321,7 @@ int ElectronBrowserMainParts::PreCreateThreads() {
 #endif
 
   // Fetch the system locale for Electron.
-  std::string system_locale = l10n_util::GetApplicationLocale("", false);
-  fake_browser_process_->SetSystemLocale(system_locale);
+  fake_browser_process_->SetSystemLocale(l10n_util::GetApplicationLocale("", false));
 
   // Initialize the app locale for Electron and Chromium.
   std::string app_locale = l10n_util::GetApplicationLocale(loaded_locale);

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -11,6 +11,7 @@
 #include "base/base_switches.h"
 #include "base/command_line.h"
 #include "base/feature_list.h"
+#include "base/i18n/rtl.h"
 #include "base/metrics/field_trial.h"
 #include "base/path_service.h"
 #include "base/run_loop.h"
@@ -285,6 +286,13 @@ int ElectronBrowserMainParts::PreCreateThreads() {
   if (!views::LayoutProvider::Get())
     layout_provider_ = std::make_unique<views::LayoutProvider>();
 
+    // Fetch the system locale for Electron.
+#if BUILDFLAG(IS_MAC)
+  fake_browser_process_->SetSystemLocale(GetCurrentSystemLocale());
+#else
+  fake_browser_process_->SetSystemLocale(base::i18n::GetConfiguredLocale());
+#endif
+
   auto* command_line = base::CommandLine::ForCurrentProcess();
   std::string locale = command_line->GetSwitchValueASCII(::switches::kLang);
 
@@ -319,10 +327,6 @@ int ElectronBrowserMainParts::PreCreateThreads() {
     screen_ = views::CreateDesktopScreen();
   }
 #endif
-
-  // Fetch the system locale for Electron.
-  fake_browser_process_->SetSystemLocale(
-      l10n_util::GetApplicationLocale("", false));
 
   // Initialize the app locale for Electron and Chromium.
   std::string app_locale = l10n_util::GetApplicationLocale(loaded_locale);

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -321,7 +321,8 @@ int ElectronBrowserMainParts::PreCreateThreads() {
 #endif
 
   // Fetch the system locale for Electron.
-  fake_browser_process_->SetSystemLocale(l10n_util::GetApplicationLocale("", false));
+  fake_browser_process_->SetSystemLocale(
+      l10n_util::GetApplicationLocale("", false));
 
   // Initialize the app locale for Electron and Chromium.
   std::string app_locale = l10n_util::GetApplicationLocale(loaded_locale);

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -130,7 +130,7 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   void FreeAppDelegate();
   void RegisterURLHandler();
   void InitializeMainNib();
-  std::string GetSystemLocale();
+  std::string GetCurrentSystemLocale();
 #endif
 
 #if BUILDFLAG(IS_MAC)

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -130,6 +130,7 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   void FreeAppDelegate();
   void RegisterURLHandler();
   void InitializeMainNib();
+  std::string GetSystemLocale();
 #endif
 
 #if BUILDFLAG(IS_MAC)

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -130,7 +130,7 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   void FreeAppDelegate();
   void RegisterURLHandler();
   void InitializeMainNib();
-  std::string GetCurrentSystemLocale();
+  static std::string GetCurrentSystemLocale();
 #endif
 
 #if BUILDFLAG(IS_MAC)

--- a/shell/browser/electron_browser_main_parts_mac.mm
+++ b/shell/browser/electron_browser_main_parts_mac.mm
@@ -76,7 +76,7 @@ void ElectronBrowserMainParts::InitializeMainNib() {
   [mainNib release];
 }
 
-std::string GetCurrentSystemLocale() {
+std::string ElectronBrowserMainParts::GetCurrentSystemLocale() {
   NSString* systemLocaleIdentifier =
       [[NSLocale currentLocale] localeIdentifier];
 

--- a/shell/browser/electron_browser_main_parts_mac.mm
+++ b/shell/browser/electron_browser_main_parts_mac.mm
@@ -85,13 +85,6 @@ std::string ElectronBrowserMainParts::GetCurrentSystemLocale() {
       stringByReplacingOccurrencesOfString:@"_"
                                 withString:@"-"] UTF8String];
 
-  // On disk the "en-US" resources are just "en" (http://crbug.com/25578), so
-  // the reverse mapping is done here to continue to feed Chrome the same values
-  // in all cases on all platforms.  (l10n_util maps en to en-US if it gets
-  // passed this on the command line)
-  if (locale_value == "en")
-    locale_value = "en-US";
-
   return locale_value;
 }
 

--- a/shell/browser/electron_browser_main_parts_mac.mm
+++ b/shell/browser/electron_browser_main_parts_mac.mm
@@ -4,6 +4,8 @@
 
 #include "shell/browser/electron_browser_main_parts.h"
 
+#include <string>
+
 #include "base/mac/bundle_locations.h"
 #include "base/mac/foundation_util.h"
 #include "base/path_service.h"
@@ -72,6 +74,25 @@ void ElectronBrowserMainParts::InitializeMainNib() {
 
   [mainNib instantiateWithOwner:application topLevelObjects:nil];
   [mainNib release];
+}
+
+std::string GetCurrentSystemLocale() {
+  NSString* systemLocaleIdentifier =
+      [[NSLocale currentLocale] localeIdentifier];
+
+  // Mac OS X uses "_" instead of "-", so swap to get a real locale value.
+  std::string locale_value = [[systemLocaleIdentifier
+      stringByReplacingOccurrencesOfString:@"_"
+                                withString:@"-"] UTF8String];
+
+  // On disk the "en-US" resources are just "en" (http://crbug.com/25578), so
+  // the reverse mapping is done here to continue to feed Chrome the same values
+  // in all cases on all platforms.  (l10n_util maps en to en-US if it gets
+  // passed this on the command line)
+  if (locale_value == "en")
+    locale_value = "en-US";
+
+  return locale_value;
 }
 
 }  // namespace electron

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -118,6 +118,12 @@ describe('app module', () => {
     });
   });
 
+  describe('app.getSystemLocale()', () => {
+    it('should not be empty', () => {
+      expect(app.getSystemLocale()).to.not.equal('');
+    });
+  });
+
   describe('app.getLocaleCountryCode()', () => {
     it('should be empty or have length of two', () => {
       const localeCountryCode = app.getLocaleCountryCode();

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -374,6 +374,7 @@ describe('command line switches', () => {
   });
   describe('--lang switch', () => {
     const currentLocale = app.getLocale();
+    const currentSystemLocale = app.getSystemLocale();
     const testLocale = async (locale: string, result: string, printEnv: boolean = false) => {
       const appPath = path.join(fixturesPath, 'api', 'locale-check');
       const args = [appPath, `--set-lang=${locale}`];
@@ -396,8 +397,9 @@ describe('command line switches', () => {
       expect(output).to.equal(result);
     };
 
-    it('should set the locale', async () => testLocale('fr', 'fr'));
-    it('should not set an invalid locale', async () => testLocale('asdfkl', currentLocale));
+    it('should set the locale', async () => testLocale('fr', `fr|${currentSystemLocale}`));
+    it('should set the locale with country code', async () => testLocale('zh-CN', `zh-CN|${currentSystemLocale}`));
+    it('should not set an invalid locale', async () => testLocale('asdfkl', `${currentLocale}|${currentSystemLocale}`));
 
     const lcAll = String(process.env.LC_ALL);
     ifit(process.platform === 'linux')('current process has a valid LC_ALL env', async () => {

--- a/spec/fixtures/api/locale-check/main.js
+++ b/spec/fixtures/api/locale-check/main.js
@@ -9,7 +9,7 @@ app.whenReady().then(() => {
   if (process.argv[3] === '--print-env') {
     process.stdout.write(String(process.env.LC_ALL));
   } else {
-    process.stdout.write(app.getLocale());
+    process.stdout.write(`${app.getLocale()}|${app.getSystemLocale()}`);
   }
   process.stdout.end();
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

This PR adds a method to fetch the OS locale from Chromium. That way, even when the application is in a certain locale, the program can still know the system locale and make recommendations based off of that.

Downstream: https://github.com/microsoft/vscode/issues/159813 and PR https://github.com/microsoft/vscode/pull/159958.

CC @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `app.getSystemLocale()` method. <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
