### PR TITLE
fix: uv_os_gethostname failing on Windows 7 (libuv patch regression)

### DIFF
--- a/patches/node/fix_crash_caused_by_gethostnamew_on_windows_7.patch
+++ b/patches/node/fix_crash_caused_by_gethostnamew_on_windows_7.patch
@@ -6,7 +6,7 @@ Subject: fix: crash caused by GetHostNameW on Windows 7
 Backported from https://github.com/libuv/libuv/pull/3285.
 
 diff --git a/deps/uv/src/win/util.c b/deps/uv/src/win/util.c
-index 33e874ac442f88b58d2b68c8ec9764f6f664552e..2d4cc0aaa02e61bf359e80eca27527efb49fd85e 100644
+index 33e874ac442f88b58d2b68c8ec9764f6f664552e..37ece5e2867ab836492a8b7faa0aa5e1b8e562f0 100644
 --- a/deps/uv/src/win/util.c
 +++ b/deps/uv/src/win/util.c
 @@ -37,6 +37,7 @@
@@ -166,3 +166,17 @@ index 33e874ac442f88b58d2b68c8ec9764f6f664552e..2d4cc0aaa02e61bf359e80eca27527ef
  int uv_os_gethostname(char* buffer, size_t* size) {
    WCHAR buf[UV_MAXHOSTNAMESIZE];
    size_t len;
+@@ -1674,10 +1803,10 @@ int uv_os_gethostname(char* buffer, size_t* size) {
+ 
+   uv__once_init(); /* Initialize winsock */
+ 
+-  if (pGetHostNameW == NULL)
+-    return UV_ENOSYS;
++  uv_sGetHostNameW gethostnamew =
++      pGetHostNameW == NULL ? uv__gethostnamew_nt60 : pGetHostNameW;
+ 
+-  if (pGetHostNameW(buf, UV_MAXHOSTNAMESIZE) != 0)
++  if (gethostnamew(buf, UV_MAXHOSTNAMESIZE) != 0)
+     return uv_translate_sys_error(WSAGetLastError());
+ 
+   convert_result = uv__convert_utf16_to_utf8(buf, -1, &utf8_str);

--- a/patches/node/fix_suppress_clang_-wdeprecated-declarations_in_libuv.patch
+++ b/patches/node/fix_suppress_clang_-wdeprecated-declarations_in_libuv.patch
@@ -6,7 +6,7 @@ Subject: fix: suppress clang -Wdeprecated-declarations in libuv
 Should be upstreamed.
 
 diff --git a/deps/uv/src/win/util.c b/deps/uv/src/win/util.c
-index 2d4cc0aaa02e61bf359e80eca27527efb49fd85e..aaa16052e2a9c7d1dca82763c41c0890371f1471 100644
+index 37ece5e2867ab836492a8b7faa0aa5e1b8e562f0..d50296728f7e0810064647125a469f3ed714f8ea 100644
 --- a/deps/uv/src/win/util.c
 +++ b/deps/uv/src/win/util.c
 @@ -1950,10 +1950,17 @@ int uv_os_uname(uv_utsname_t* buffer) {


### PR DESCRIPTION
#### Description of Change
Fixes #35219. Regressed in https://github.com/electron/electron/pull/32833/commits/a2e5d1946711299d69d275e4a69f5f75a18304de

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `uv_os_gethostname` failing on Windows 7