### PR TITLE
chore: fix ambiguous reference gcc compile error

### DIFF
--- a/shell/browser/serial/electron_serial_delegate.cc
+++ b/shell/browser/serial/electron_serial_delegate.cc
@@ -66,16 +66,18 @@ device::mojom::SerialPortManager* ElectronSerialDelegate::GetPortManager(
   return GetChooserContext(frame)->GetPortManager();
 }
 
-void ElectronSerialDelegate::AddObserver(content::RenderFrameHost* frame,
-                                         Observer* observer) {
+void ElectronSerialDelegate::AddObserver(
+    content::RenderFrameHost* frame,
+    content::SerialDelegate::Observer* observer) {
   observer_list_.AddObserver(observer);
   auto* chooser_context = GetChooserContext(frame);
   if (!port_observation_.IsObserving())
     port_observation_.Observe(chooser_context);
 }
 
-void ElectronSerialDelegate::RemoveObserver(content::RenderFrameHost* frame,
-                                            Observer* observer) {
+void ElectronSerialDelegate::RemoveObserver(
+    content::RenderFrameHost* frame,
+    content::SerialDelegate::Observer* observer) {
   observer_list_.RemoveObserver(observer);
 }
 

--- a/shell/browser/serial/electron_serial_delegate.h
+++ b/shell/browser/serial/electron_serial_delegate.h
@@ -38,9 +38,9 @@ class ElectronSerialDelegate : public content::SerialDelegate,
   device::mojom::SerialPortManager* GetPortManager(
       content::RenderFrameHost* frame) override;
   void AddObserver(content::RenderFrameHost* frame,
-                   Observer* observer) override;
+                   content::SerialDelegate::Observer* observer) override;
   void RemoveObserver(content::RenderFrameHost* frame,
-                      Observer* observer) override;
+                      content::SerialDelegate::Observer* observer) override;
   void RevokePortPermissionWebInitiated(
       content::RenderFrameHost* frame,
       const base::UnguessableToken& token) override;


### PR DESCRIPTION
#### Description of Change

When compiling electron 20.1.4 on linux with gcc, the compiler cannot determine what `Observer` refers to. I needed to apply this patch to get it to compile.

#### Release Notes

Notes: none