### PR TITLE
chore: add missing .eslintrc.json files to limit imports properly

### DIFF
--- a/lib/common/.eslintrc.json
+++ b/lib/common/.eslintrc.json
@@ -5,11 +5,13 @@
       {
         "paths": [
           "electron",
+          "electron/main",
           "electron/renderer"
         ],
         "patterns": [
           "./*",
           "../*",
+          "@electron/internal/browser/*",
           "@electron/internal/isolated_renderer/*",
           "@electron/internal/renderer/*",
           "@electron/internal/sandboxed_worker/*",

--- a/lib/common/api/clipboard.ts
+++ b/lib/common/api/clipboard.ts
@@ -1,5 +1,6 @@
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
+// eslint-disable-next-line no-restricted-imports
 import type * as ipcRendererUtilsModule from '@electron/internal/renderer/ipc-renderer-internal-utils';
 
 const clipboard = process._linkedBinding('electron_common_clipboard');

--- a/lib/isolated_renderer/.eslintrc.json
+++ b/lib/isolated_renderer/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "rules": {
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          "electron",
+          "electron/main"
+        ],
+        "patterns": [
+          "./*",
+          "../*",
+          "@electron/internal/browser/*"
+        ]
+      }
+    ]
+  }
+}

--- a/lib/renderer/.eslintrc.json
+++ b/lib/renderer/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "rules": {
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          "electron",
+          "electron/main"
+        ],
+        "patterns": [
+          "./*",
+          "../*",
+          "@electron/internal/browser/*"
+        ]
+      }
+    ]
+  }
+}

--- a/lib/renderer/common-init.ts
+++ b/lib/renderer/common-init.ts
@@ -1,4 +1,4 @@
-import { ipcRenderer } from 'electron';
+import { ipcRenderer } from 'electron/renderer';
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 
 import type * as webViewInitModule from '@electron/internal/renderer/web-view/web-view-init';

--- a/lib/renderer/inspector.ts
+++ b/lib/renderer/inspector.ts
@@ -2,7 +2,7 @@ import { internalContextBridge } from '@electron/internal/renderer/api/context-b
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 import * as ipcRendererUtils from '@electron/internal/renderer/ipc-renderer-internal-utils';
 import { webFrame } from 'electron/renderer';
-import { IPC_MESSAGES } from '../common/ipc-messages';
+import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
 const { contextIsolationEnabled } = internalContextBridge;
 

--- a/lib/renderer/web-frame-init.ts
+++ b/lib/renderer/web-frame-init.ts
@@ -1,4 +1,4 @@
-import { webFrame, WebFrame } from 'electron';
+import { webFrame, WebFrame } from 'electron/renderer';
 import * as ipcRendererUtils from '@electron/internal/renderer/ipc-renderer-internal-utils';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 

--- a/lib/sandboxed_renderer/.eslintrc.json
+++ b/lib/sandboxed_renderer/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "rules": {
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          "electron",
+          "electron/main"
+        ],
+        "patterns": [
+          "./*",
+          "../*",
+          "@electron/internal/browser/*"
+        ]
+      }
+    ]
+  }
+}

--- a/lib/worker/.eslintrc.json
+++ b/lib/worker/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "rules": {
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          "electron",
+          "electron/main"
+        ],
+        "patterns": [
+          "./*",
+          "../*",
+          "@electron/internal/browser/*"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
#### Description of Change
We only had this `.eslintrc.json` in `lib/browser` limiting the imports to `electron/main`.
Do the same for the renderers and common.

Follow-up to #24512

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
