### PR TITLE
build: GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/electron_woa_testing.yml
+++ b/.github/workflows/electron_woa_testing.yml
@@ -10,6 +10,8 @@ on:
         type: text
         required: true
 
+permissions: {}
+
 jobs:
   electron-woa-init:
     if: ${{ github.event_name == 'push' && github.repository == 'electron/electron' }}
@@ -20,11 +22,13 @@ jobs:
             echo "This job is a needed initialization step for Electron WOA testing.  Another test result will appear once the electron-woa-testing build is done."
 
   electron-woa-testing:    
+
     if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'electron/electron' }}    
     runs-on: [self-hosted, woa]  
     permissions:
-      checks: write
+      checks: write # to create checks (LouisBrunner/checks-action)
       pull-requests: write
+      contents: read # to fetch code (actions/checkout)
     steps:
     - uses: LouisBrunner/checks-action@v1.1.1
       with:

--- a/.github/workflows/electron_woa_testing.yml
+++ b/.github/workflows/electron_woa_testing.yml
@@ -21,14 +21,13 @@ jobs:
           run: |
             echo "This job is a needed initialization step for Electron WOA testing.  Another test result will appear once the electron-woa-testing build is done."
 
-  electron-woa-testing:    
-
+  electron-woa-testing:
     if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'electron/electron' }}    
     runs-on: [self-hosted, woa]  
     permissions:
-      checks: write # to create checks (LouisBrunner/checks-action)
+      checks: write
       pull-requests: write
-      contents: read # to fetch code (actions/checkout)
+      contents: read
     steps:
     - uses: LouisBrunner/checks-action@v1.1.1
       with:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.

notes: no-notes