### PR TITLE
chore: cherry-pick eb4d31309df7 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -140,3 +140,4 @@ cherry-pick-079105b7ebba.patch
 cherry-pick-51daffbf5cd8.patch
 cherry-pick-9b5207569882.patch
 dpwa_enable_window_controls_overlay_by_default.patch
+cherry-pick-eb4d31309df7.patch

--- a/patches/chromium/cherry-pick-eb4d31309df7.patch
+++ b/patches/chromium/cherry-pick-eb4d31309df7.patch
@@ -1,7 +1,7 @@
-From eb4d31309df7e555e928388778fe8a0801b4ede6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Stefan Zager <szager@chromium.org>
-Date: Fri, 09 Sep 2022 01:56:46 +0000
-Subject: [PATCH] Fix for reference to invalid iterator
+Date: Fri, 9 Sep 2022 01:56:46 +0000
+Subject: Fix for reference to invalid iterator
 
 Evidently, LocalFrameView::layout_subtree_root_list_ can be modified
 during LayoutFromRootObject, leaving the loop variable in an invalid
@@ -22,13 +22,12 @@ Auto-Submit: Srinivas Sista <srinivassista@chromium.org>
 Reviewed-by: Stefan Zager <szager@chromium.org>
 Cr-Commit-Position: refs/branch-heads/5112@{#1566}
 Cr-Branched-From: b13d3fe7b3c47a56354ef54b221008afa754412e-refs/heads/main@{#1012729}
----
 
 diff --git a/third_party/blink/renderer/core/frame/local_frame_view.cc b/third_party/blink/renderer/core/frame/local_frame_view.cc
-index 7890e7b..9eefcdd 100644
+index 8a9dabd602b54b4801406bffb26723b4105c5fdc..82963b7edb85da99f4bbf345b22e70d50ac1573c 100644
 --- a/third_party/blink/renderer/core/frame/local_frame_view.cc
 +++ b/third_party/blink/renderer/core/frame/local_frame_view.cc
-@@ -826,6 +826,7 @@
+@@ -821,6 +821,7 @@ void LocalFrameView::PerformLayout() {
        }
        for (auto& root : layout_subtree_root_list_.Ordered()) {
          bool should_rebuild_fragments = false;
@@ -36,7 +35,7 @@ index 7890e7b..9eefcdd 100644
          LayoutBlock* cb = root->ContainingNGBlock();
          if (cb) {
            auto it = fragment_tree_spines.find(cb);
-@@ -845,7 +846,7 @@
+@@ -840,7 +841,7 @@ void LocalFrameView::PerformLayout() {
          // We need to ensure that we mark up all layoutObjects up to the
          // LayoutView for paint invalidation. This simplifies our code as we
          // just always do a full tree walk.

--- a/patches/chromium/cherry-pick-eb4d31309df7.patch
+++ b/patches/chromium/cherry-pick-eb4d31309df7.patch
@@ -1,0 +1,47 @@
+From eb4d31309df7e555e928388778fe8a0801b4ede6 Mon Sep 17 00:00:00 2001
+From: Stefan Zager <szager@chromium.org>
+Date: Fri, 09 Sep 2022 01:56:46 +0000
+Subject: [PATCH] Fix for reference to invalid iterator
+
+Evidently, LocalFrameView::layout_subtree_root_list_ can be modified
+during LayoutFromRootObject, leaving the loop variable in an invalid
+state. I don't know the exact sequence, but the test case crashes for
+me without this patch, and doesn't crash with the patch.
+
+(cherry picked from commit 815aa5ca03ab4ecc619b2d2ad7650531bd3892a8)
+
+Bug: 1355237
+Change-Id: Ib17b1fac5b2ec060eda39be76305db18075802fa
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3864877
+Reviewed-by: Ian Kilpatrick <ikilpatrick@chromium.org>
+Commit-Queue: Stefan Zager <szager@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1041903}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3884238
+Owners-Override: Srinivas Sista <srinivassista@chromium.org>
+Auto-Submit: Srinivas Sista <srinivassista@chromium.org>
+Reviewed-by: Stefan Zager <szager@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5112@{#1566}
+Cr-Branched-From: b13d3fe7b3c47a56354ef54b221008afa754412e-refs/heads/main@{#1012729}
+---
+
+diff --git a/third_party/blink/renderer/core/frame/local_frame_view.cc b/third_party/blink/renderer/core/frame/local_frame_view.cc
+index 7890e7b..9eefcdd 100644
+--- a/third_party/blink/renderer/core/frame/local_frame_view.cc
++++ b/third_party/blink/renderer/core/frame/local_frame_view.cc
+@@ -826,6 +826,7 @@
+       }
+       for (auto& root : layout_subtree_root_list_.Ordered()) {
+         bool should_rebuild_fragments = false;
++        LayoutObject& root_layout_object = *root;
+         LayoutBlock* cb = root->ContainingNGBlock();
+         if (cb) {
+           auto it = fragment_tree_spines.find(cb);
+@@ -845,7 +846,7 @@
+         // We need to ensure that we mark up all layoutObjects up to the
+         // LayoutView for paint invalidation. This simplifies our code as we
+         // just always do a full tree walk.
+-        if (LayoutObject* container = root->Container())
++        if (LayoutObject* container = root_layout_object.Container())
+           container->SetShouldCheckForPaintInvalidation();
+       }
+       layout_subtree_root_list_.Clear();


### PR DESCRIPTION
Fix for reference to invalid iterator

Evidently, LocalFrameView::layout_subtree_root_list_ can be modified
during LayoutFromRootObject, leaving the loop variable in an invalid
state. I don't know the exact sequence, but the test case crashes for
me without this patch, and doesn't crash with the patch.

(cherry picked from commit 815aa5ca03ab4ecc619b2d2ad7650531bd3892a8)

Bug: 1355237
Change-Id: Ib17b1fac5b2ec060eda39be76305db18075802fa
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3864877
Reviewed-by: Ian Kilpatrick <ikilpatrick@chromium.org>
Commit-Queue: Stefan Zager <szager@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1041903}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3884238
Owners-Override: Srinivas Sista <srinivassista@chromium.org>
Auto-Submit: Srinivas Sista <srinivassista@chromium.org>
Reviewed-by: Stefan Zager <szager@chromium.org>
Cr-Commit-Position: refs/branch-heads/5112@{#1566}
Cr-Branched-From: b13d3fe7b3c47a56354ef54b221008afa754412e-refs/heads/main@{#1012729}


Ref electron/security#215

Notes: Security: backported fix for CVE-2022-3199.