### PR TITLE
refactor: use raw_ptr for class fields that are pointers

### DIFF
--- a/shell/app/uv_task_runner.h
+++ b/shell/app/uv_task_runner.h
@@ -42,7 +42,7 @@ class UvTaskRunner : public base::SingleThreadTaskRunner {
   static void OnTimeout(uv_timer_t* timer);
   static void OnClose(uv_handle_t* handle);
 
-  raw_ptr<uv_loop_t> loop_;
+  raw_ptr<uv_loop_t> loop_ = nullptr;
 
   std::map<uv_timer_t*, base::OnceClosure> tasks_;
 };

--- a/shell/app/uv_task_runner.h
+++ b/shell/app/uv_task_runner.h
@@ -8,6 +8,7 @@
 #include <map>
 
 #include "base/callback.h"
+#include "base/memory/raw_ptr.h"
 #include "base/task/single_thread_task_runner.h"
 #include "uv.h"  // NOLINT(build/include_directory)
 
@@ -41,7 +42,7 @@ class UvTaskRunner : public base::SingleThreadTaskRunner {
   static void OnTimeout(uv_timer_t* timer);
   static void OnClose(uv_handle_t* handle);
 
-  uv_loop_t* loop_;
+  raw_ptr<uv_loop_t> loop_;
 
   std::map<uv_timer_t*, base::OnceClosure> tasks_;
 };

--- a/shell/browser/api/electron_api_browser_view.h
+++ b/shell/browser/api/electron_api_browser_view.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "gin/handle.h"
 #include "gin/wrappable.h"
@@ -81,7 +82,7 @@ class BrowserView : public gin::Wrappable<BrowserView>,
   v8::Local<v8::Value> GetWebContents(v8::Isolate*);
 
   v8::Global<v8::Value> web_contents_;
-  class WebContents* api_web_contents_ = nullptr;
+  raw_ptr<class WebContents> api_web_contents_ = nullptr;
 
   std::unique_ptr<NativeBrowserView> view_;
   base::WeakPtr<BaseWindow> owner_window_;

--- a/shell/browser/api/electron_api_cookies.h
+++ b/shell/browser/api/electron_api_cookies.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "base/callback_list.h"
+#include "base/memory/raw_ptr.h"
 #include "base/values.h"
 #include "gin/handle.h"
 #include "net/cookies/canonical_cookie.h"
@@ -61,7 +62,7 @@ class Cookies : public gin::Wrappable<Cookies>,
   base::CallbackListSubscription cookie_change_subscription_;
 
   // Weak reference; ElectronBrowserContext is guaranteed to outlive us.
-  ElectronBrowserContext* browser_context_;
+  raw_ptr<ElectronBrowserContext> browser_context_;
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_debugger.h
+++ b/shell/browser/api/electron_api_debugger.h
@@ -8,6 +8,7 @@
 #include <map>
 
 #include "base/callback.h"
+#include "base/memory/raw_ptr.h"
 #include "base/values.h"
 #include "content/public/browser/devtools_agent_host_client.h"
 #include "content/public/browser/web_contents_observer.h"
@@ -65,7 +66,7 @@ class Debugger : public gin::Wrappable<Debugger>,
   v8::Local<v8::Promise> SendCommand(gin::Arguments* args);
   void ClearPendingRequests();
 
-  content::WebContents* web_contents_;  // Weak Reference.
+  raw_ptr<content::WebContents> web_contents_;  // Weak Reference.
   scoped_refptr<content::DevToolsAgentHost> agent_host_;
 
   PendingRequestMap pending_requests_;

--- a/shell/browser/api/electron_api_download_item.h
+++ b/shell/browser/api/electron_api_download_item.h
@@ -79,9 +79,9 @@ class DownloadItem : public gin::Wrappable<DownloadItem>,
 
   base::FilePath save_path_;
   file_dialog::DialogSettings dialog_options_;
-  raw_ptr<download::DownloadItem> download_item_;
+  raw_ptr<download::DownloadItem> download_item_ = nullptr;
 
-  raw_ptr<v8::Isolate> isolate_;
+  raw_ptr<v8::Isolate> isolate_ = nullptr;
 
   base::WeakPtrFactory<DownloadItem> weak_factory_{this};
 };

--- a/shell/browser/api/electron_api_download_item.h
+++ b/shell/browser/api/electron_api_download_item.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "base/files/file_path.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "components/download/public/common/download_item.h"
 #include "gin/handle.h"
@@ -78,9 +79,9 @@ class DownloadItem : public gin::Wrappable<DownloadItem>,
 
   base::FilePath save_path_;
   file_dialog::DialogSettings dialog_options_;
-  download::DownloadItem* download_item_;
+  raw_ptr<download::DownloadItem> download_item_;
 
-  v8::Isolate* isolate_;
+  raw_ptr<v8::Isolate> isolate_;
 
   base::WeakPtrFactory<DownloadItem> weak_factory_{this};
 };

--- a/shell/browser/api/electron_api_native_theme.h
+++ b/shell/browser/api/electron_api_native_theme.h
@@ -52,8 +52,8 @@ class NativeTheme : public gin::Wrappable<NativeTheme>,
   void OnNativeThemeUpdatedOnUI();
 
  private:
-  raw_ptr<ui::NativeTheme> ui_theme_;
-  raw_ptr<ui::NativeTheme> web_theme_;
+  raw_ptr<ui::NativeTheme> ui_theme_ = nullptr;
+  raw_ptr<ui::NativeTheme> web_theme_ = nullptr;
 };
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_native_theme.h
+++ b/shell/browser/api/electron_api_native_theme.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_API_ELECTRON_API_NATIVE_THEME_H_
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_NATIVE_THEME_H_
 
+#include "base/memory/raw_ptr.h"
 #include "gin/handle.h"
 #include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
@@ -51,8 +52,8 @@ class NativeTheme : public gin::Wrappable<NativeTheme>,
   void OnNativeThemeUpdatedOnUI();
 
  private:
-  ui::NativeTheme* ui_theme_;
-  ui::NativeTheme* web_theme_;
+  raw_ptr<ui::NativeTheme> ui_theme_;
+  raw_ptr<ui::NativeTheme> web_theme_;
 };
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_net_log.h
+++ b/shell/browser/api/electron_api_net_log.h
@@ -7,6 +7,7 @@
 
 #include "base/callback.h"
 #include "base/files/file_path.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/values.h"
 #include "gin/handle.h"
@@ -62,7 +63,7 @@ class NetLog : public gin::Wrappable<NetLog> {
   void NetLogStarted(int32_t error);
 
  private:
-  ElectronBrowserContext* browser_context_;
+  raw_ptr<ElectronBrowserContext> browser_context_;
 
   mojo::Remote<network::mojom::NetLogExporter> net_log_exporter_;
 

--- a/shell/browser/api/electron_api_net_log.h
+++ b/shell/browser/api/electron_api_net_log.h
@@ -63,7 +63,7 @@ class NetLog : public gin::Wrappable<NetLog> {
   void NetLogStarted(int32_t error);
 
  private:
-  raw_ptr<ElectronBrowserContext> browser_context_;
+  raw_ptr<ElectronBrowserContext> browser_context_ = nullptr;
 
   mojo::Remote<network::mojom::NetLogExporter> net_log_exporter_;
 

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -111,7 +111,7 @@ class Notification : public gin::Wrappable<Notification>,
   std::u16string close_button_text_;
   std::u16string toast_xml_;
 
-  raw_ptr<electron::NotificationPresenter> presenter_;
+  raw_ptr<electron::NotificationPresenter> presenter_ = nullptr;
 
   base::WeakPtr<electron::Notification> notification_;
 };

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "base/strings/utf_string_conversions.h"
 #include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
@@ -110,7 +111,7 @@ class Notification : public gin::Wrappable<Notification>,
   std::u16string close_button_text_;
   std::u16string toast_xml_;
 
-  electron::NotificationPresenter* presenter_;
+  raw_ptr<electron::NotificationPresenter> presenter_;
 
   base::WeakPtr<electron::Notification> notification_;
 };

--- a/shell/browser/api/electron_api_protocol.h
+++ b/shell/browser/api/electron_api_protocol.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "content/public/browser/content_browser_client.h"
 #include "gin/handle.h"
 #include "gin/wrappable.h"
@@ -96,7 +97,7 @@ class Protocol : public gin::Wrappable<Protocol> {
 
   // Weak pointer; the lifetime of the ProtocolRegistry is guaranteed to be
   // longer than the lifetime of this JS interface.
-  ProtocolRegistry* protocol_registry_;
+  raw_ptr<ProtocolRegistry> protocol_registry_;
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_protocol.h
+++ b/shell/browser/api/electron_api_protocol.h
@@ -97,7 +97,7 @@ class Protocol : public gin::Wrappable<Protocol> {
 
   // Weak pointer; the lifetime of the ProtocolRegistry is guaranteed to be
   // longer than the lifetime of this JS interface.
-  raw_ptr<ProtocolRegistry> protocol_registry_;
+  raw_ptr<ProtocolRegistry> protocol_registry_ = nullptr;
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_screen.h
+++ b/shell/browser/api/electron_api_screen.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/common/gin_helper/error_thrower.h"
@@ -53,7 +54,7 @@ class Screen : public gin::Wrappable<Screen>,
                                uint32_t changed_metrics) override;
 
  private:
-  display::Screen* screen_;
+  raw_ptr<display::Screen> screen_;
 };
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_screen.h
+++ b/shell/browser/api/electron_api_screen.h
@@ -54,7 +54,7 @@ class Screen : public gin::Wrappable<Screen>,
                                uint32_t changed_metrics) override;
 
  private:
-  raw_ptr<display::Screen> screen_;
+  raw_ptr<display::Screen> screen_ = nullptr;
 };
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_service_worker_context.h
+++ b/shell/browser/api/electron_api_service_worker_context.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_API_ELECTRON_API_SERVICE_WORKER_CONTEXT_H_
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_SERVICE_WORKER_CONTEXT_H_
 
+#include "base/memory/raw_ptr.h"
 #include "content/public/browser/service_worker_context.h"
 #include "content/public/browser/service_worker_context_observer.h"
 #include "gin/handle.h"
@@ -53,7 +54,7 @@ class ServiceWorkerContext
   ~ServiceWorkerContext() override;
 
  private:
-  content::ServiceWorkerContext* service_worker_context_;
+  raw_ptr<content::ServiceWorkerContext> service_worker_context_;
 
   base::WeakPtrFactory<ServiceWorkerContext> weak_ptr_factory_{this};
 };

--- a/shell/browser/api/electron_api_service_worker_context.h
+++ b/shell/browser/api/electron_api_service_worker_context.h
@@ -54,7 +54,7 @@ class ServiceWorkerContext
   ~ServiceWorkerContext() override;
 
  private:
-  raw_ptr<content::ServiceWorkerContext> service_worker_context_;
+  raw_ptr<content::ServiceWorkerContext> service_worker_context_ = nullptr;
 
   base::WeakPtrFactory<ServiceWorkerContext> weak_ptr_factory_{this};
 };

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -190,12 +190,12 @@ class Session : public gin::Wrappable<Session>,
   v8::Global<v8::Value> service_worker_context_;
   v8::Global<v8::Value> web_request_;
 
-  raw_ptr<v8::Isolate> isolate_;
+  raw_ptr<v8::Isolate> isolate_ = nullptr;
 
   // The client id to enable the network throttler.
   base::UnguessableToken network_emulation_token_;
 
-  raw_ptr<ElectronBrowserContext> browser_context_;
+  raw_ptr<ElectronBrowserContext> browser_context_ = nullptr;
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "base/values.h"
 #include "content/public/browser/download_manager.h"
 #include "electron/buildflags/buildflags.h"
@@ -189,12 +190,12 @@ class Session : public gin::Wrappable<Session>,
   v8::Global<v8::Value> service_worker_context_;
   v8::Global<v8::Value> web_request_;
 
-  v8::Isolate* isolate_;
+  raw_ptr<v8::Isolate> isolate_;
 
   // The client id to enable the network throttler.
   base::UnguessableToken network_emulation_token_;
 
-  ElectronBrowserContext* browser_context_;
+  raw_ptr<ElectronBrowserContext> browser_context_;
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "electron/buildflags/buildflags.h"
 #include "gin/handle.h"
 #include "shell/common/gin_helper/wrappable.h"
@@ -44,7 +45,7 @@ class View : public gin_helper::Wrappable<View> {
   std::vector<v8::Global<v8::Object>> child_views_;
 
   bool delete_view_ = true;
-  views::View* view_ = nullptr;
+  raw_ptr<views::View> view_ = nullptr;
 };
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -737,7 +737,9 @@ WebContents::WebContents(v8::Isolate* isolate,
 #endif
 
   // Init embedder earlier
-  options.Get("embedder", &embedder_);
+  WebContents* embedder = nullptr;
+  options.Get("embedder", &embedder);
+  embedder_ = embedder;
 
   // Whether to enable DevTools.
   options.Get("devTools", &enable_devtools_);

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -785,7 +785,7 @@ class WebContents : public ExclusiveAccessContext,
 
   std::unique_ptr<DevToolsEyeDropper> eye_dropper_;
 
-  raw_ptr<ElectronBrowserContext> browser_context_;
+  raw_ptr<ElectronBrowserContext> browser_context_ = nullptr;
 
   // The stored InspectableWebContents object.
   // Notice that inspectable_web_contents_ must be placed after

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "base/observer_list_types.h"
@@ -740,13 +741,13 @@ class WebContents : public ExclusiveAccessContext,
 #endif
 
   // The host webcontents that may contain this webcontents.
-  WebContents* embedder_ = nullptr;
+  raw_ptr<WebContents> embedder_ = nullptr;
 
   // Whether the guest view has been attached.
   bool attached_ = false;
 
   // The zoom controller for this webContents.
-  WebContentsZoomController* zoom_controller_ = nullptr;
+  raw_ptr<WebContentsZoomController> zoom_controller_ = nullptr;
 
   // The type of current WebContents.
   Type type_ = Type::kBrowserWindow;
@@ -784,7 +785,7 @@ class WebContents : public ExclusiveAccessContext,
 
   std::unique_ptr<DevToolsEyeDropper> eye_dropper_;
 
-  ElectronBrowserContext* browser_context_;
+  raw_ptr<ElectronBrowserContext> browser_context_;
 
   // The stored InspectableWebContents object.
   // Notice that inspectable_web_contents_ must be placed after
@@ -809,7 +810,7 @@ class WebContents : public ExclusiveAccessContext,
 #endif
 
   // Stores the frame thats currently in fullscreen, nullptr if there is none.
-  content::RenderFrameHost* fullscreen_frame_ = nullptr;
+  raw_ptr<content::RenderFrameHost> fullscreen_frame_ = nullptr;
 
   base::WeakPtrFactory<WebContents> weak_factory_{this};
 };

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -47,7 +47,7 @@ WebContentsView::~WebContentsView() {
 }
 
 gin::Handle<WebContents> WebContentsView::GetWebContents(v8::Isolate* isolate) {
-  return gin::CreateHandle(isolate, api_web_contents_);
+  return gin::CreateHandle(isolate, api_web_contents_.get());
 }
 
 void WebContentsView::WebContentsDestroyed() {

--- a/shell/browser/api/electron_api_web_contents_view.h
+++ b/shell/browser/api/electron_api_web_contents_view.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_API_ELECTRON_API_WEB_CONTENTS_VIEW_H_
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_WEB_CONTENTS_VIEW_H_
 
+#include "base/memory/raw_ptr.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "shell/browser/api/electron_api_view.h"
 
@@ -48,7 +49,7 @@ class WebContentsView : public View, public content::WebContentsObserver {
 
   // Keep a reference to v8 wrapper.
   v8::Global<v8::Value> web_contents_;
-  api::WebContents* api_web_contents_;
+  raw_ptr<api::WebContents> api_web_contents_;
 };
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_web_contents_view.h
+++ b/shell/browser/api/electron_api_web_contents_view.h
@@ -49,7 +49,7 @@ class WebContentsView : public View, public content::WebContentsObserver {
 
   // Keep a reference to v8 wrapper.
   v8::Global<v8::Value> web_contents_;
-  raw_ptr<api::WebContents> api_web_contents_;
+  raw_ptr<api::WebContents> api_web_contents_ = nullptr;
 };
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/process/process.h"
 #include "gin/handle.h"
@@ -124,7 +125,7 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
 
   int frame_tree_node_id_;
 
-  content::RenderFrameHost* render_frame_ = nullptr;
+  raw_ptr<content::RenderFrameHost> render_frame_ = nullptr;
 
   // Whether the RenderFrameHost has been removed and that it should no longer
   // be accessed.

--- a/shell/browser/api/electron_api_web_request.h
+++ b/shell/browser/api/electron_api_web_request.h
@@ -147,7 +147,7 @@ class WebRequest : public gin::Wrappable<WebRequest>, public WebRequestAPI {
   std::map<uint64_t, net::CompletionOnceCallback> callbacks_;
 
   // Weak-ref, it manages us.
-  raw_ptr<content::BrowserContext> browser_context_;
+  raw_ptr<content::BrowserContext> browser_context_ = nullptr;
 };
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_web_request.h
+++ b/shell/browser/api/electron_api_web_request.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <set>
 
+#include "base/memory/raw_ptr.h"
 #include "base/values.h"
 #include "extensions/common/url_pattern.h"
 #include "gin/arguments.h"
@@ -146,7 +147,7 @@ class WebRequest : public gin::Wrappable<WebRequest>, public WebRequestAPI {
   std::map<uint64_t, net::CompletionOnceCallback> callbacks_;
 
   // Weak-ref, it manages us.
-  content::BrowserContext* browser_context_;
+  raw_ptr<content::BrowserContext> browser_context_;
 };
 
 }  // namespace electron::api

--- a/shell/browser/api/frame_subscriber.h
+++ b/shell/browser/api/frame_subscriber.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "base/callback.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "components/viz/host/client_frame_sink_video_capturer.h"
 #include "content/public/browser/web_contents.h"
@@ -70,7 +71,7 @@ class FrameSubscriber : public content::WebContentsObserver,
   FrameCaptureCallback callback_;
   bool only_dirty_;
 
-  content::RenderWidgetHost* host_;
+  raw_ptr<content::RenderWidgetHost> host_;
   std::unique_ptr<viz::ClientFrameSinkVideoCapturer> video_capturer_;
 
   base::WeakPtrFactory<FrameSubscriber> weak_ptr_factory_{this};

--- a/shell/browser/api/frame_subscriber.h
+++ b/shell/browser/api/frame_subscriber.h
@@ -71,7 +71,7 @@ class FrameSubscriber : public content::WebContentsObserver,
   FrameCaptureCallback callback_;
   bool only_dirty_;
 
-  raw_ptr<content::RenderWidgetHost> host_;
+  raw_ptr<content::RenderWidgetHost> host_ = nullptr;
   std::unique_ptr<viz::ClientFrameSinkVideoCapturer> video_capturer_;
 
   base::WeakPtrFactory<FrameSubscriber> weak_ptr_factory_{this};

--- a/shell/browser/api/gpuinfo_manager.h
+++ b/shell/browser/api/gpuinfo_manager.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "content/browser/gpu/gpu_data_manager_impl.h"  // nogncheck
 #include "content/public/browser/gpu_data_manager.h"
 #include "content/public/browser/gpu_data_manager_observer.h"
@@ -42,7 +43,7 @@ class GPUInfoManager : public content::GpuDataManagerObserver {
   // This set maintains all the promises that should be fulfilled
   // once we have the complete information data
   std::vector<gin_helper::Promise<base::Value>> complete_info_promise_set_;
-  content::GpuDataManagerImpl* gpu_data_manager_;
+  raw_ptr<content::GpuDataManagerImpl> gpu_data_manager_;
 };
 
 }  // namespace electron

--- a/shell/browser/api/gpuinfo_manager.h
+++ b/shell/browser/api/gpuinfo_manager.h
@@ -43,7 +43,7 @@ class GPUInfoManager : public content::GpuDataManagerObserver {
   // This set maintains all the promises that should be fulfilled
   // once we have the complete information data
   std::vector<gin_helper::Promise<base::Value>> complete_info_promise_set_;
-  raw_ptr<content::GpuDataManagerImpl> gpu_data_manager_;
+  raw_ptr<content::GpuDataManagerImpl> gpu_data_manager_ = nullptr;
 };
 
 }  // namespace electron

--- a/shell/browser/api/save_page_handler.h
+++ b/shell/browser/api/save_page_handler.h
@@ -43,7 +43,7 @@ class SavePageHandler : public content::DownloadManager::Observer,
   // download::DownloadItem::Observer:
   void OnDownloadUpdated(download::DownloadItem* item) override;
 
-  raw_ptr<content::WebContents> web_contents_;  // weak
+  raw_ptr<content::WebContents> web_contents_ = nullptr;  // weak
   gin_helper::Promise<void> promise_;
 };
 

--- a/shell/browser/api/save_page_handler.h
+++ b/shell/browser/api/save_page_handler.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_API_SAVE_PAGE_HANDLER_H_
 #define ELECTRON_SHELL_BROWSER_API_SAVE_PAGE_HANDLER_H_
 
+#include "base/memory/raw_ptr.h"
 #include "components/download/public/common/download_item.h"
 #include "content/public/browser/download_manager.h"
 #include "content/public/browser/save_page_type.h"
@@ -42,7 +43,7 @@ class SavePageHandler : public content::DownloadManager::Observer,
   // download::DownloadItem::Observer:
   void OnDownloadUpdated(download::DownloadItem* item) override;
 
-  content::WebContents* web_contents_;  // weak
+  raw_ptr<content::WebContents> web_contents_;  // weak
   gin_helper::Promise<void> promise_;
 };
 

--- a/shell/browser/certificate_manager_model.h
+++ b/shell/browser/certificate_manager_model.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "base/callback.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/ref_counted.h"
 #include "net/cert/nss_cert_database.h"
 
@@ -107,7 +108,7 @@ class CertificateManagerModel {
   static void GetCertDBOnIOThread(content::ResourceContext* context,
                                   CreationCallback callback);
 
-  net::NSSCertDatabase* cert_db_;
+  raw_ptr<net::NSSCertDatabase> cert_db_;
   // Whether the certificate database has a public slot associated with the
   // profile. If not set, importing certificates is not allowed with this model.
   bool is_user_db_available_;

--- a/shell/browser/cookie_change_notifier.h
+++ b/shell/browser/cookie_change_notifier.h
@@ -6,6 +6,7 @@
 #define ELECTRON_SHELL_BROWSER_COOKIE_CHANGE_NOTIFIER_H_
 
 #include "base/callback_list.h"
+#include "base/memory/raw_ptr.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "net/cookies/cookie_change_dispatcher.h"
 #include "services/network/public/mojom/cookie_manager.mojom.h"
@@ -36,7 +37,7 @@ class CookieChangeNotifier : public network::mojom::CookieChangeListener {
   // network::mojom::CookieChangeListener implementation.
   void OnCookieChange(const net::CookieChangeInfo& change) override;
 
-  ElectronBrowserContext* browser_context_;
+  raw_ptr<ElectronBrowserContext> browser_context_;
   base::RepeatingCallbackList<void(const net::CookieChangeInfo& change)>
       cookie_change_sub_list_;
 

--- a/shell/browser/electron_autofill_driver.h
+++ b/shell/browser/electron_autofill_driver.h
@@ -12,6 +12,7 @@
 #include "shell/browser/ui/autofill_popup.h"
 #endif
 
+#include "base/memory/raw_ptr.h"
 #include "mojo/public/cpp/bindings/associated_receiver.h"
 #include "mojo/public/cpp/bindings/pending_associated_receiver.h"
 #include "shell/common/api/api.mojom.h"
@@ -35,7 +36,7 @@ class AutofillDriver : public mojom::ElectronAutofillDriver {
   void HideAutofillPopup() override;
 
  private:
-  content::RenderFrameHost* const render_frame_host_;
+  raw_ptr<content::RenderFrameHost> const render_frame_host_;
 
 #if defined(TOOLKIT_VIEWS)
   std::unique_ptr<AutofillPopup> autofill_popup_;

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -323,7 +323,7 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
   std::unique_ptr<PlatformNotificationService> notification_service_;
   std::unique_ptr<NotificationPresenter> notification_presenter_;
 
-  Delegate* delegate_ = nullptr;
+  raw_ptr<Delegate> delegate_ = nullptr;
 
   std::string user_agent_override_ = "";
 

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "base/files/file_path.h"
+#include "base/memory/raw_ptr.h"
 #include "base/synchronization/lock.h"
 #include "content/public/browser/content_browser_client.h"
 #include "content/public/browser/render_process_host_observer.h"
@@ -337,7 +338,7 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
       web_authentication_delegate_;
 
 #if BUILDFLAG(IS_MAC)
-  ElectronBrowserMainParts* browser_main_parts_ = nullptr;
+  raw_ptr<ElectronBrowserMainParts> browser_main_parts_ = nullptr;
 #endif
 };
 

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "chrome/browser/predictors/preconnect_manager.h"
 #include "content/public/browser/browser_context.h"
@@ -227,7 +228,7 @@ class ElectronBrowserContext : public content::BrowserContext {
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   // Owned by the KeyedService system.
-  extensions::ElectronExtensionSystem* extension_system_;
+  raw_ptr<extensions::ElectronExtensionSystem> extension_system_;
 #endif
 
   // Shared URLLoaderFactory.

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -228,7 +228,7 @@ class ElectronBrowserContext : public content::BrowserContext {
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   // Owned by the KeyedService system.
-  raw_ptr<extensions::ElectronExtensionSystem> extension_system_;
+  raw_ptr<extensions::ElectronExtensionSystem> extension_system_ = nullptr;
 #endif
 
   // Shared URLLoaderFactory.

--- a/shell/browser/electron_download_manager_delegate.h
+++ b/shell/browser/electron_download_manager_delegate.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_ELECTRON_DOWNLOAD_MANAGER_DELEGATE_H_
 #define ELECTRON_SHELL_BROWSER_ELECTRON_DOWNLOAD_MANAGER_DELEGATE_H_
 
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/download_manager_delegate.h"
 #include "shell/browser/ui/file_dialog.h"
@@ -58,7 +59,7 @@ class ElectronDownloadManagerDelegate
 
   base::FilePath last_saved_directory_;
 
-  content::DownloadManager* download_manager_;
+  raw_ptr<content::DownloadManager> download_manager_;
   base::WeakPtrFactory<ElectronDownloadManagerDelegate> weak_ptr_factory_{this};
 };
 

--- a/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.h
+++ b/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.h
@@ -38,7 +38,7 @@ class ElectronRuntimeAPIDelegate : public RuntimeAPIDelegate {
   bool RestartDevice(std::string* error_message) override;
 
  private:
-  raw_ptr<content::BrowserContext> browser_context_;
+  raw_ptr<content::BrowserContext> browser_context_ = nullptr;
 };
 
 }  // namespace extensions

--- a/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.h
+++ b/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.h
@@ -9,6 +9,8 @@
 
 #include "extensions/browser/api/runtime/runtime_api_delegate.h"
 
+#include "base/memory/raw_ptr.h"
+
 namespace content {
 class BrowserContext;
 }
@@ -36,7 +38,7 @@ class ElectronRuntimeAPIDelegate : public RuntimeAPIDelegate {
   bool RestartDevice(std::string* error_message) override;
 
  private:
-  content::BrowserContext* browser_context_;
+  raw_ptr<content::BrowserContext> browser_context_;
 };
 
 }  // namespace extensions

--- a/shell/browser/extensions/api/tabs/tabs_api.h
+++ b/shell/browser/extensions/api/tabs/tabs_api.h
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "base/memory/raw_ptr.h"
 #include "extensions/browser/api/execute_code_function.h"
 #include "extensions/browser/extension_function.h"
 #include "extensions/common/extension_resource.h"
@@ -107,7 +108,7 @@ class TabsUpdateFunction : public ExtensionFunction {
   bool UpdateURL(const std::string& url, int tab_id, std::string* error);
   ResponseValue GetResult();
 
-  content::WebContents* web_contents_;
+  raw_ptr<content::WebContents> web_contents_;
 
  private:
   ResponseAction Run() override;

--- a/shell/browser/extensions/api/tabs/tabs_api.h
+++ b/shell/browser/extensions/api/tabs/tabs_api.h
@@ -108,7 +108,7 @@ class TabsUpdateFunction : public ExtensionFunction {
   bool UpdateURL(const std::string& url, int tab_id, std::string* error);
   ResponseValue GetResult();
 
-  raw_ptr<content::WebContents> web_contents_;
+  raw_ptr<content::WebContents> web_contents_ = nullptr;
 
  private:
   ResponseAction Run() override;

--- a/shell/browser/extensions/electron_extension_message_filter.h
+++ b/shell/browser/extensions/electron_extension_message_filter.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "base/task/sequenced_task_runner_helpers.h"
 #include "content/public/browser/browser_message_filter.h"
 #include "content/public/browser/browser_thread.h"
@@ -63,7 +64,7 @@ class ElectronExtensionMessageFilter : public content::BrowserMessageFilter {
   // be accessed on the UI thread! Furthermore since this class is refcounted it
   // may outlive |browser_context_|, so make sure to NULL check if in doubt;
   // async calls and the like.
-  content::BrowserContext* browser_context_;
+  raw_ptr<content::BrowserContext> browser_context_;
 };
 
 }  // namespace electron

--- a/shell/browser/extensions/electron_extension_message_filter.h
+++ b/shell/browser/extensions/electron_extension_message_filter.h
@@ -64,7 +64,7 @@ class ElectronExtensionMessageFilter : public content::BrowserMessageFilter {
   // be accessed on the UI thread! Furthermore since this class is refcounted it
   // may outlive |browser_context_|, so make sure to NULL check if in doubt;
   // async calls and the like.
-  raw_ptr<content::BrowserContext> browser_context_;
+  raw_ptr<content::BrowserContext> browser_context_ = nullptr;
 };
 
 }  // namespace electron

--- a/shell/browser/extensions/electron_extension_system.h
+++ b/shell/browser/extensions/electron_extension_system.h
@@ -99,7 +99,7 @@ class ElectronExtensionSystem : public ExtensionSystem {
       scoped_refptr<Extension> extension);
   void LoadComponentExtensions();
 
-  raw_ptr<content::BrowserContext> browser_context_;  // Not owned.
+  raw_ptr<content::BrowserContext> browser_context_ = nullptr;  // Not owned.
 
   // Data to be accessed on the IO thread. Must outlive process_manager_.
   scoped_refptr<InfoMap> info_map_;

--- a/shell/browser/extensions/electron_extension_system.h
+++ b/shell/browser/extensions/electron_extension_system.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "base/compiler_specific.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/ref_counted.h"
 #include "base/memory/weak_ptr.h"
 #include "base/one_shot_event.h"
@@ -98,7 +99,7 @@ class ElectronExtensionSystem : public ExtensionSystem {
       scoped_refptr<Extension> extension);
   void LoadComponentExtensions();
 
-  content::BrowserContext* browser_context_;  // Not owned.
+  raw_ptr<content::BrowserContext> browser_context_;  // Not owned.
 
   // Data to be accessed on the IO thread. Must outlive process_manager_.
   scoped_refptr<InfoMap> info_map_;

--- a/shell/browser/file_select_helper.h
+++ b/shell/browser/file_select_helper.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "base/compiler_specific.h"
+#include "base/memory/raw_ptr.h"
 #include "base/scoped_observation.h"
 #include "build/build_config.h"
 #include "content/public/browser/browser_thread.h"
@@ -193,8 +194,8 @@ class FileSelectHelper : public base::RefCountedThreadSafe<
 
   // The RenderFrameHost and WebContents for the page showing a file dialog
   // (may only be one such dialog).
-  content::RenderFrameHost* render_frame_host_;
-  content::WebContents* web_contents_;
+  raw_ptr<content::RenderFrameHost> render_frame_host_;
+  raw_ptr<content::WebContents> web_contents_;
 
   // |listener_| receives the result of the FileSelectHelper.
   scoped_refptr<content::FileSelectListener> listener_;

--- a/shell/browser/hid/hid_chooser_context.h
+++ b/shell/browser/hid/hid_chooser_context.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "base/containers/queue.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "base/unguessable_token.h"
@@ -118,7 +119,7 @@ class HidChooserContext : public KeyedService,
       const url::Origin& origin,
       const device::mojom::HidDeviceInfo& device);
 
-  ElectronBrowserContext* browser_context_;
+  raw_ptr<ElectronBrowserContext> browser_context_;
 
   bool is_initialized_ = false;
   base::queue<device::mojom::HidManager::GetDevicesCallback>

--- a/shell/browser/hid/hid_chooser_context.h
+++ b/shell/browser/hid/hid_chooser_context.h
@@ -119,7 +119,7 @@ class HidChooserContext : public KeyedService,
       const url::Origin& origin,
       const device::mojom::HidDeviceInfo& device);
 
-  raw_ptr<ElectronBrowserContext> browser_context_;
+  raw_ptr<ElectronBrowserContext> browser_context_ = nullptr;
 
   bool is_initialized_ = false;
   base::queue<device::mojom::HidManager::GetDevicesCallback>

--- a/shell/browser/javascript_environment.h
+++ b/shell/browser/javascript_environment.h
@@ -44,7 +44,7 @@ class JavascriptEnvironment {
  private:
   v8::Isolate* Initialize(uv_loop_t* event_loop);
   // Leaked on exit.
-  raw_ptr<node::MultiIsolatePlatform> platform_;
+  raw_ptr<node::MultiIsolatePlatform> platform_ = nullptr;
 
   raw_ptr<v8::Isolate> isolate_;
   gin::IsolateHolder isolate_holder_;

--- a/shell/browser/javascript_environment.h
+++ b/shell/browser/javascript_environment.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/memory/raw_ptr.h"
 #include "gin/public/isolate_holder.h"
 #include "uv.h"  // NOLINT(build/include_directory)
 #include "v8/include/v8-locker.h"
@@ -45,7 +46,7 @@ class JavascriptEnvironment {
   // Leaked on exit.
   node::MultiIsolatePlatform* platform_;
 
-  v8::Isolate* isolate_;
+  raw_ptr<v8::Isolate> isolate_;
   gin::IsolateHolder isolate_holder_;
   v8::Locker locker_;
   v8::Global<v8::Context> context_;
@@ -66,7 +67,7 @@ class NodeEnvironment {
   node::Environment* env() { return env_; }
 
  private:
-  node::Environment* env_;
+  raw_ptr<node::Environment> env_;
 };
 
 }  // namespace electron

--- a/shell/browser/javascript_environment.h
+++ b/shell/browser/javascript_environment.h
@@ -44,7 +44,7 @@ class JavascriptEnvironment {
  private:
   v8::Isolate* Initialize(uv_loop_t* event_loop);
   // Leaked on exit.
-  node::MultiIsolatePlatform* platform_;
+  raw_ptr<node::MultiIsolatePlatform> platform_;
 
   raw_ptr<v8::Isolate> isolate_;
   gin::IsolateHolder isolate_holder_;

--- a/shell/browser/lib/bluetooth_chooser.h
+++ b/shell/browser/lib/bluetooth_chooser.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "content/public/browser/bluetooth_chooser.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 
@@ -42,7 +43,7 @@ class BluetoothChooser : public content::BluetoothChooser {
 
  private:
   std::map<std::string, std::u16string> device_map_;
-  api::WebContents* api_web_contents_;
+  raw_ptr<api::WebContents> api_web_contents_;
   EventHandler event_handler_;
   int num_retries_ = 0;
   bool refreshing_ = false;

--- a/shell/browser/lib/bluetooth_chooser.h
+++ b/shell/browser/lib/bluetooth_chooser.h
@@ -43,7 +43,7 @@ class BluetoothChooser : public content::BluetoothChooser {
 
  private:
   std::map<std::string, std::u16string> device_map_;
-  raw_ptr<api::WebContents> api_web_contents_;
+  raw_ptr<api::WebContents> api_web_contents_ = nullptr;
   EventHandler event_handler_;
   int num_retries_ = 0;
   bool refreshing_ = false;

--- a/shell/browser/mac/in_app_purchase_observer.h
+++ b/shell/browser/mac/in_app_purchase_observer.h
@@ -75,7 +75,7 @@ class TransactionObserver {
       const std::vector<Transaction>& transactions) = 0;
 
  private:
-  raw_ptr<InAppTransactionObserver> observer_;
+  raw_ptr<InAppTransactionObserver> observer_ = nullptr;
 
   base::WeakPtrFactory<TransactionObserver> weak_ptr_factory_{this};
 };

--- a/shell/browser/mac/in_app_purchase_observer.h
+++ b/shell/browser/mac/in_app_purchase_observer.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "base/callback.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
@@ -74,7 +75,7 @@ class TransactionObserver {
       const std::vector<Transaction>& transactions) = 0;
 
  private:
-  InAppTransactionObserver* observer_;
+  raw_ptr<InAppTransactionObserver> observer_;
 
   base::WeakPtrFactory<TransactionObserver> weak_ptr_factory_{this};
 };

--- a/shell/browser/microtasks_runner.h
+++ b/shell/browser/microtasks_runner.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_MICROTASKS_RUNNER_H_
 #define ELECTRON_SHELL_BROWSER_MICROTASKS_RUNNER_H_
 
+#include "base/memory/raw_ptr.h"
 #include "base/task/task_observer.h"
 
 namespace v8 {
@@ -29,7 +30,7 @@ class MicrotasksRunner : public base::TaskObserver {
   void DidProcessTask(const base::PendingTask& pending_task) override;
 
  private:
-  v8::Isolate* isolate_;
+  raw_ptr<v8::Isolate> isolate_;
 };
 
 }  // namespace electron

--- a/shell/browser/native_browser_view.h
+++ b/shell/browser/native_browser_view.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "shell/common/api/api.mojom.h"
@@ -66,7 +67,7 @@ class NativeBrowserView : public content::WebContentsObserver {
   // content::WebContentsObserver:
   void WebContentsDestroyed() override;
 
-  InspectableWebContents* inspectable_web_contents_;
+  raw_ptr<InspectableWebContents> inspectable_web_contents_;
   std::vector<mojom::DraggableRegionPtr> draggable_regions_;
 };
 

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "base/supports_user_data.h"
@@ -409,7 +410,7 @@ class NativeWindow : public base::SupportsUserData,
   static int32_t next_id_;
 
   // The content view, weak ref.
-  views::View* content_view_ = nullptr;
+  raw_ptr<views::View> content_view_ = nullptr;
 
   // Whether window has standard frame.
   bool has_frame_ = true;
@@ -442,7 +443,7 @@ class NativeWindow : public base::SupportsUserData,
   gfx::Size aspect_ratio_extraSize_;
 
   // The parent window, it is guaranteed to be valid during this window's life.
-  NativeWindow* parent_ = nullptr;
+  raw_ptr<NativeWindow> parent_ = nullptr;
 
   // Is this a modal window.
   bool is_modal_ = false;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "base/mac/scoped_nsobject.h"
+#include "base/memory/raw_ptr.h"
 #include "shell/browser/native_window.h"
 #include "ui/display/display_observer.h"
 #include "ui/native_theme/native_theme_observer.h"
@@ -222,7 +223,7 @@ class NativeWindowMac : public NativeWindow,
   void InternalSetParentWindow(NativeWindow* parent, bool attach);
   void SetForwardMouseMessages(bool forward);
 
-  ElectronNSWindow* window_;  // Weak ref, managed by widget_.
+  raw_ptr<ElectronNSWindow> window_;  // Weak ref, managed by widget_.
 
   base::scoped_nsobject<ElectronNSWindowDelegate> window_delegate_;
   base::scoped_nsobject<ElectronPreviewItem> preview_item_;

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "shell/common/api/api.mojom.h"
 #include "third_party/skia/include/core/SkRegion.h"
 #include "ui/views/widget/widget_observer.h"
@@ -259,7 +260,7 @@ class NativeWindowViews : public NativeWindow,
   std::unique_ptr<RootView> root_view_;
 
   // The view should be focused by default.
-  views::View* focused_view_ = nullptr;
+  base::raw_ptr<views::View> focused_view_ = nullptr;
 
   // The "resizable" flag on Linux is implemented by setting size constraints,
   // we need to make sure size constraints are restored when window becomes

--- a/shell/browser/net/network_context_service.h
+++ b/shell/browser/net/network_context_service.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_NET_NETWORK_CONTEXT_SERVICE_H_
 #define ELECTRON_SHELL_BROWSER_NET_NETWORK_CONTEXT_SERVICE_H_
 
+#include "base/memory/raw_ptr.h"
 #include "base/files/file_path.h"
 #include "chrome/browser/net/proxy_config_monitor.h"
 #include "components/keyed_service/core/keyed_service.h"
@@ -36,7 +37,7 @@ class NetworkContextService : public KeyedService {
       bool in_memory,
       const base::FilePath& path);
 
-  ElectronBrowserContext* browser_context_;
+  raw_ptr<ElectronBrowserContext> browser_context_;
   ProxyConfigMonitor proxy_config_monitor_;
 };
 

--- a/shell/browser/net/network_context_service.h
+++ b/shell/browser/net/network_context_service.h
@@ -5,8 +5,8 @@
 #ifndef ELECTRON_SHELL_BROWSER_NET_NETWORK_CONTEXT_SERVICE_H_
 #define ELECTRON_SHELL_BROWSER_NET_NETWORK_CONTEXT_SERVICE_H_
 
-#include "base/memory/raw_ptr.h"
 #include "base/files/file_path.h"
+#include "base/memory/raw_ptr.h"
 #include "chrome/browser/net/proxy_config_monitor.h"
 #include "components/keyed_service/core/keyed_service.h"
 #include "mojo/public/cpp/bindings/remote.h"
@@ -37,7 +37,7 @@ class NetworkContextService : public KeyedService {
       bool in_memory,
       const base::FilePath& path);
 
-  raw_ptr<ElectronBrowserContext> browser_context_;
+  raw_ptr<ElectronBrowserContext> browser_context_ = nullptr;
   ProxyConfigMonitor proxy_config_monitor_;
 };
 

--- a/shell/browser/net/node_stream_loader.h
+++ b/shell/browser/net/node_stream_loader.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "mojo/public/cpp/system/data_pipe_producer.h"
@@ -67,7 +68,7 @@ class NodeStreamLoader : public network::mojom::URLLoader {
   mojo::Receiver<network::mojom::URLLoader> url_loader_;
   mojo::Remote<network::mojom::URLLoaderClient> client_;
 
-  v8::Isolate* isolate_;
+  raw_ptr<v8::Isolate> isolate_;
   v8::Global<v8::Object> emitter_;
   v8::Global<v8::Value> buffer_;
 

--- a/shell/browser/net/node_stream_loader.h
+++ b/shell/browser/net/node_stream_loader.h
@@ -68,7 +68,7 @@ class NodeStreamLoader : public network::mojom::URLLoader {
   mojo::Receiver<network::mojom::URLLoader> url_loader_;
   mojo::Remote<network::mojom::URLLoaderClient> client_;
 
-  raw_ptr<v8::Isolate> isolate_;
+  raw_ptr<v8::Isolate> isolate_ = nullptr;
   v8::Global<v8::Object> emitter_;
   v8::Global<v8::Value> buffer_;
 

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -130,7 +130,7 @@ class ProxyingURLLoaderFactory
     void OnRequestError(const network::URLLoaderCompletionStatus& status);
     void HandleBeforeRequestRedirect();
 
-    const raw_ptr<ProxyingURLLoaderFactory> factory_;
+    const raw_ptr<ProxyingURLLoaderFactory> factory_ = nullptr;
     network::ResourceRequest request_;
     const absl::optional<url::Origin> original_initiator_;
     const uint64_t request_id_ = 0;
@@ -246,7 +246,7 @@ class ProxyingURLLoaderFactory
   bool ShouldIgnoreConnectionsLimit(const network::ResourceRequest& request);
 
   // Passed from api::WebRequest.
-  raw_ptr<WebRequestAPI> web_request_api_;
+  raw_ptr<WebRequestAPI> web_request_api_ = nullptr;
 
   // This is passed from api::Protocol.
   //
@@ -259,7 +259,8 @@ class ProxyingURLLoaderFactory
 
   const int render_process_id_;
   const int frame_routing_id_;
-  raw_ptr<uint64_t> request_id_generator_;  // managed by ElectronBrowserClient
+  raw_ptr<uint64_t> request_id_generator_ =
+      nullptr;  // managed by ElectronBrowserClient
   std::unique_ptr<extensions::ExtensionNavigationUIData> navigation_ui_data_;
   absl::optional<int64_t> navigation_id_;
   mojo::ReceiverSet<network::mojom::URLLoaderFactory> proxy_receivers_;

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/content_browser_client.h"
 #include "content/public/browser/render_frame_host.h"
@@ -129,7 +130,7 @@ class ProxyingURLLoaderFactory
     void OnRequestError(const network::URLLoaderCompletionStatus& status);
     void HandleBeforeRequestRedirect();
 
-    ProxyingURLLoaderFactory* const factory_;
+    const raw_ptr<ProxyingURLLoaderFactory> factory_;
     network::ResourceRequest request_;
     const absl::optional<url::Origin> original_initiator_;
     const uint64_t request_id_ = 0;
@@ -245,7 +246,7 @@ class ProxyingURLLoaderFactory
   bool ShouldIgnoreConnectionsLimit(const network::ResourceRequest& request);
 
   // Passed from api::WebRequest.
-  WebRequestAPI* web_request_api_;
+  raw_ptr<WebRequestAPI> web_request_api_;
 
   // This is passed from api::Protocol.
   //
@@ -258,7 +259,7 @@ class ProxyingURLLoaderFactory
 
   const int render_process_id_;
   const int frame_routing_id_;
-  uint64_t* request_id_generator_;  // managed by ElectronBrowserClient
+  raw_ptr<uint64_t> request_id_generator_;  // managed by ElectronBrowserClient
   std::unique_ptr<extensions::ExtensionNavigationUIData> navigation_ui_data_;
   absl::optional<int64_t> navigation_id_;
   mojo::ReceiverSet<network::mojom::URLLoaderFactory> proxy_receivers_;

--- a/shell/browser/net/proxying_websocket.h
+++ b/shell/browser/net/proxying_websocket.h
@@ -138,7 +138,7 @@ class ProxyingWebSocket : public network::mojom::WebSocketHandshakeClient,
   void OnMojoConnectionError();
 
   // Passed from api::WebRequest.
-  raw_ptr<WebRequestAPI> web_request_api_;
+  raw_ptr<WebRequestAPI> web_request_api_ = nullptr;
 
   // Saved to feed the api::WebRequest.
   network::ResourceRequest request_;

--- a/shell/browser/net/proxying_websocket.h
+++ b/shell/browser/net/proxying_websocket.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "content/public/browser/content_browser_client.h"
 #include "extensions/browser/api/web_request/web_request_info.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
@@ -137,7 +138,7 @@ class ProxyingWebSocket : public network::mojom::WebSocketHandshakeClient,
   void OnMojoConnectionError();
 
   // Passed from api::WebRequest.
-  WebRequestAPI* web_request_api_;
+  raw_ptr<WebRequestAPI> web_request_api_;
 
   // Saved to feed the api::WebRequest.
   network::ResourceRequest request_;

--- a/shell/browser/net/resolve_proxy_helper.h
+++ b/shell/browser/net/resolve_proxy_helper.h
@@ -8,6 +8,7 @@
 #include <deque>
 #include <string>
 
+#include "base/memory/raw_ptr.h"
 #include "base/memory/ref_counted.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "services/network/public/mojom/proxy_lookup_client.mojom.h"
@@ -70,7 +71,7 @@ class ResolveProxyHelper
   mojo::Receiver<network::mojom::ProxyLookupClient> receiver_{this};
 
   // Weak Ref
-  ElectronBrowserContext* browser_context_;
+  raw_ptr<ElectronBrowserContext> browser_context_;
 };
 
 }  // namespace electron

--- a/shell/browser/net/resolve_proxy_helper.h
+++ b/shell/browser/net/resolve_proxy_helper.h
@@ -71,7 +71,7 @@ class ResolveProxyHelper
   mojo::Receiver<network::mojom::ProxyLookupClient> receiver_{this};
 
   // Weak Ref
-  raw_ptr<ElectronBrowserContext> browser_context_;
+  raw_ptr<ElectronBrowserContext> browser_context_ = nullptr;
 };
 
 }  // namespace electron

--- a/shell/browser/network_hints_handler_impl.h
+++ b/shell/browser/network_hints_handler_impl.h
@@ -7,6 +7,8 @@
 
 #include "components/network_hints/browser/simple_network_hints_handler_impl.h"
 
+#include "base/memory/raw_ptr.h"
+
 namespace content {
 class RenderFrameHost;
 class BrowserContext;
@@ -28,7 +30,7 @@ class NetworkHintsHandlerImpl
  private:
   explicit NetworkHintsHandlerImpl(content::RenderFrameHost*);
 
-  content::BrowserContext* browser_context_ = nullptr;
+  raw_ptr<content::BrowserContext> browser_context_ = nullptr;
 };
 
 #endif  // ELECTRON_SHELL_BROWSER_NETWORK_HINTS_HANDLER_IMPL_H_

--- a/shell/browser/notifications/notification.h
+++ b/shell/browser/notifications/notification.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "url/gurl.h"
@@ -81,8 +82,8 @@ class Notification {
                NotificationPresenter* presenter);
 
  private:
-  NotificationDelegate* delegate_;
-  NotificationPresenter* presenter_;
+  raw_ptr<NotificationDelegate> delegate_;
+  raw_ptr<NotificationPresenter> presenter_;
   std::string notification_id_;
 
   base::WeakPtrFactory<Notification> weak_factory_{this};

--- a/shell/browser/notifications/platform_notification_service.h
+++ b/shell/browser/notifications/platform_notification_service.h
@@ -9,6 +9,8 @@
 
 #include "content/public/browser/platform_notification_service.h"
 
+#include "base/memory/raw_ptr.h"
+
 namespace electron {
 
 class ElectronBrowserClient;
@@ -50,7 +52,7 @@ class PlatformNotificationService
   base::Time ReadNextTriggerTimestamp() override;
 
  private:
-  ElectronBrowserClient* browser_client_;
+  raw_ptr<ElectronBrowserClient> browser_client_;
 };
 
 }  // namespace electron

--- a/shell/browser/osr/osr_video_consumer.h
+++ b/shell/browser/osr/osr_video_consumer.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "base/callback.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "components/viz/host/client_frame_sink_video_capturer.h"
 #include "media/capture/mojom/video_capture_buffer.mojom-forward.h"
@@ -52,7 +53,7 @@ class OffScreenVideoConsumer : public viz::mojom::FrameSinkVideoConsumer {
 
   OnPaintCallback callback_;
 
-  OffScreenRenderWidgetHostView* view_;
+  raw_ptr<OffScreenRenderWidgetHostView> view_;
   std::unique_ptr<viz::ClientFrameSinkVideoCapturer> video_capturer_;
 
   base::WeakPtrFactory<OffScreenVideoConsumer> weak_ptr_factory_{this};

--- a/shell/browser/osr/osr_video_consumer.h
+++ b/shell/browser/osr/osr_video_consumer.h
@@ -53,7 +53,7 @@ class OffScreenVideoConsumer : public viz::mojom::FrameSinkVideoConsumer {
 
   OnPaintCallback callback_;
 
-  raw_ptr<OffScreenRenderWidgetHostView> view_;
+  raw_ptr<OffScreenRenderWidgetHostView> view_ = nullptr;
   std::unique_ptr<viz::ClientFrameSinkVideoCapturer> video_capturer_;
 
   base::WeakPtrFactory<OffScreenVideoConsumer> weak_ptr_factory_{this};

--- a/shell/browser/osr/osr_view_proxy.h
+++ b/shell/browser/osr/osr_view_proxy.h
@@ -42,7 +42,7 @@ class OffscreenViewProxy {
   void ResetView() { view_ = nullptr; }
 
  private:
-  raw_ptr<views::View> view_;
+  raw_ptr<views::View> view_ = nullptr;
 
   gfx::Rect view_bounds_;
   std::unique_ptr<SkBitmap> view_bitmap_;

--- a/shell/browser/osr/osr_view_proxy.h
+++ b/shell/browser/osr/osr_view_proxy.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/memory/raw_ptr.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/events/event.h"
 #include "ui/gfx/geometry/rect.h"
@@ -41,7 +42,7 @@ class OffscreenViewProxy {
   void ResetView() { view_ = nullptr; }
 
  private:
-  views::View* view_;
+  raw_ptr<views::View> view_;
 
   gfx::Rect view_bounds_;
   std::unique_ptr<SkBitmap> view_bitmap_;

--- a/shell/browser/osr/osr_web_contents_view.h
+++ b/shell/browser/osr/osr_web_contents_view.h
@@ -8,6 +8,7 @@
 #include "shell/browser/native_window.h"
 #include "shell/browser/native_window_observer.h"
 
+#include "base/memory/raw_ptr.h"
 #include "content/browser/renderer_host/render_view_host_delegate_view.h"  // nogncheck
 #include "content/browser/web_contents/web_contents_view.h"  // nogncheck
 #include "content/public/browser/web_contents.h"
@@ -91,7 +92,7 @@ class OffScreenWebContentsView : public content::WebContentsView,
 
   OffScreenRenderWidgetHostView* GetView() const;
 
-  NativeWindow* native_window_ = nullptr;
+  raw_ptr<NativeWindow> native_window_ = nullptr;
 
   const bool transparent_;
   bool painting_ = true;
@@ -99,10 +100,10 @@ class OffScreenWebContentsView : public content::WebContentsView,
   OnPaintCallback callback_;
 
   // Weak refs.
-  content::WebContents* web_contents_ = nullptr;
+  raw_ptr<content::WebContents> web_contents_ = nullptr;
 
 #if BUILDFLAG(IS_MAC)
-  OffScreenView* offScreenView_;
+  raw_ptr<OffScreenView> offScreenView_;
 #endif
 };
 

--- a/shell/browser/osr/osr_web_contents_view.h
+++ b/shell/browser/osr/osr_web_contents_view.h
@@ -103,7 +103,7 @@ class OffScreenWebContentsView : public content::WebContentsView,
   raw_ptr<content::WebContents> web_contents_ = nullptr;
 
 #if BUILDFLAG(IS_MAC)
-  raw_ptr<OffScreenView> offScreenView_;
+  raw_ptr<OffScreenView> offScreenView_ = nullptr;
 #endif
 };
 

--- a/shell/browser/serial/serial_chooser_context.h
+++ b/shell/browser/serial/serial_chooser_context.h
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "base/unguessable_token.h"
@@ -107,7 +108,7 @@ class SerialChooserContext : public KeyedService,
   mojo::Receiver<device::mojom::SerialPortManagerClient> client_receiver_{this};
   base::ObserverList<PortObserver> port_observer_list_;
 
-  ElectronBrowserContext* browser_context_;
+  raw_ptr<ElectronBrowserContext> browser_context_;
 
   base::WeakPtrFactory<SerialChooserContext> weak_factory_{this};
 };

--- a/shell/browser/serial/serial_chooser_context.h
+++ b/shell/browser/serial/serial_chooser_context.h
@@ -108,7 +108,7 @@ class SerialChooserContext : public KeyedService,
   mojo::Receiver<device::mojom::SerialPortManagerClient> client_receiver_{this};
   base::ObserverList<PortObserver> port_observer_list_;
 
-  raw_ptr<ElectronBrowserContext> browser_context_;
+  raw_ptr<ElectronBrowserContext> browser_context_ = nullptr;
 
   base::WeakPtrFactory<SerialChooserContext> weak_factory_{this};
 };

--- a/shell/browser/ui/autofill_popup.h
+++ b/shell/browser/ui/autofill_popup.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "content/public/browser/render_frame_host.h"
 #include "shell/browser/ui/views/autofill_popup_view.h"
 #include "ui/color/color_id.h"
@@ -79,13 +80,13 @@ class AutofillPopup : public views::ViewObserver {
 
   // For sending the accepted suggestion to the render frame that
   // asked to open the popup
-  content::RenderFrameHost* frame_host_ = nullptr;
+  raw_ptr<content::RenderFrameHost> frame_host_ = nullptr;
 
   // The popup view. The lifetime is managed by the owning Widget
-  AutofillPopupView* view_ = nullptr;
+  raw_ptr<AutofillPopupView> view_ = nullptr;
 
   // The parent view that the popup view shows on. Weak ref.
-  views::View* parent_ = nullptr;
+  raw_ptr<views::View> parent_ = nullptr;
 };
 
 }  // namespace electron

--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.h
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.h
@@ -9,6 +9,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_ELECTRON_DESKTOP_WINDOW_TREE_HOST_LINUX_H_
 #define ELECTRON_SHELL_BROWSER_UI_ELECTRON_DESKTOP_WINDOW_TREE_HOST_LINUX_H_
 
+#include "base/memory/raw_ptr.h"
 #include "base/scoped_observation.h"
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/ui/views/client_frame_view_linux.h"
@@ -58,7 +59,7 @@ class ElectronDesktopWindowTreeHostLinux
   void UpdateClientDecorationHints(ClientFrameViewLinux* view);
   void UpdateWindowState(ui::PlatformWindowState new_state);
 
-  NativeWindowViews* native_window_view_;  // weak ref
+  raw_ptr<NativeWindowViews> native_window_view_;  // weak ref
 
   base::ScopedObservation<ui::NativeTheme, ui::NativeThemeObserver>
       theme_observation_{this};

--- a/shell/browser/ui/electron_menu_model.h
+++ b/shell/browser/ui/electron_menu_model.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "base/files/file_path.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "base/observer_list_types.h"
@@ -112,7 +113,7 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
   ElectronMenuModel* GetSubmenuModelAt(size_t index);
 
  private:
-  Delegate* delegate_;  // weak ref.
+  raw_ptr<Delegate> delegate_;  // weak ref.
 
 #if BUILDFLAG(IS_MAC)
   absl::optional<SharingItem> sharing_item_;

--- a/shell/browser/ui/gtk/app_indicator_icon_menu.cc
+++ b/shell/browser/ui/gtk/app_indicator_icon_menu.cc
@@ -19,7 +19,7 @@ AppIndicatorIconMenu::AppIndicatorIconMenu(ui::MenuModel* model)
     ANNOTATE_SCOPED_MEMORY_LEAK;  // http://crbug.com/378770
     gtk_menu_ = gtk_menu_new();
   }
-  g_object_ref_sink(gtk_menu_);
+  g_object_ref_sink(gtk_menu_.get());
   if (menu_model_) {
     BuildSubmenuFromModel(menu_model_, gtk_menu_,
                           G_CALLBACK(OnMenuItemActivatedThunk),
@@ -39,7 +39,7 @@ void AppIndicatorIconMenu::UpdateClickActionReplacementMenuItem(
   click_action_replacement_callback_ = callback;
 
   if (click_action_replacement_menu_item_added_) {
-    GList* children = gtk_container_get_children(GTK_CONTAINER(gtk_menu_));
+    GList* children = gtk_container_get_children(GTK_CONTAINER(gtk_menu_.get()));
     for (GList* child = children; child; child = g_list_next(child)) {
       if (g_object_get_data(G_OBJECT(child->data), "click-action-item") !=
           nullptr) {
@@ -56,7 +56,7 @@ void AppIndicatorIconMenu::UpdateClickActionReplacementMenuItem(
     if (menu_model_ && menu_model_->GetItemCount() > 0) {
       GtkWidget* menu_item = gtk_separator_menu_item_new();
       gtk_widget_show(menu_item);
-      gtk_menu_shell_prepend(GTK_MENU_SHELL(gtk_menu_), menu_item);
+      gtk_menu_shell_prepend(GTK_MENU_SHELL(gtk_menu_.get()), menu_item);
     }
 
     GtkWidget* menu_item = gtk_menu_item_new_with_mnemonic(label);
@@ -66,17 +66,17 @@ void AppIndicatorIconMenu::UpdateClickActionReplacementMenuItem(
                      G_CALLBACK(OnClickActionReplacementMenuItemActivatedThunk),
                      this);
     gtk_widget_show(menu_item);
-    gtk_menu_shell_prepend(GTK_MENU_SHELL(gtk_menu_), menu_item);
+    gtk_menu_shell_prepend(GTK_MENU_SHELL(gtk_menu_.get()), menu_item);
   }
 }
 
 void AppIndicatorIconMenu::Refresh() {
-  gtk_container_foreach(GTK_CONTAINER(gtk_menu_), SetMenuItemInfo,
+  gtk_container_foreach(GTK_CONTAINER(gtk_menu_.get()), SetMenuItemInfo,
                         &block_activation_);
 }
 
 GtkMenu* AppIndicatorIconMenu::GetGtkMenu() {
-  return GTK_MENU(gtk_menu_);
+  return GTK_MENU(gtk_menu_.get());
 }
 
 void AppIndicatorIconMenu::OnClickActionReplacementMenuItemActivated(

--- a/shell/browser/ui/gtk/app_indicator_icon_menu.h
+++ b/shell/browser/ui/gtk/app_indicator_icon_menu.h
@@ -6,6 +6,7 @@
 #define ELECTRON_SHELL_BROWSER_UI_GTK_APP_INDICATOR_ICON_MENU_H_
 
 #include "base/callback.h"
+#include "base/memory/raw_ptr.h"
 #include "ui/base/glib/glib_signal.h"
 
 typedef struct _GtkMenu GtkMenu;
@@ -63,7 +64,7 @@ class AppIndicatorIconMenu {
   // invoked and is assumed to do any necessary processing.
   base::RepeatingClosure click_action_replacement_callback_;
 
-  GtkWidget* gtk_menu_ = nullptr;
+  raw_ptr<GtkWidget> gtk_menu_ = nullptr;
 
   bool block_activation_ = false;
 };

--- a/shell/browser/ui/inspectable_web_contents.h
+++ b/shell/browser/ui/inspectable_web_contents.h
@@ -15,6 +15,7 @@
 
 #include "base/containers/span.h"
 #include "base/containers/unique_ptr_adapters.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "chrome/browser/devtools/devtools_contents_resizing_strategy.h"
 #include "chrome/browser/devtools/devtools_embedder_message_dispatcher.h"
@@ -213,7 +214,7 @@ class InspectableWebContents
 
   InspectableWebContentsDelegate* delegate_ = nullptr;  // weak references.
 
-  PrefService* pref_service_;  // weak reference.
+  raw_ptr<PrefService> pref_service_;  // weak reference.
 
   std::unique_ptr<content::WebContents> web_contents_;
 
@@ -221,7 +222,7 @@ class InspectableWebContents
   // one assigned by SetDevToolsWebContents.
   std::unique_ptr<content::WebContents> managed_devtools_web_contents_;
   // The external devtools assigned by SetDevToolsWebContents.
-  content::WebContents* external_devtools_web_contents_ = nullptr;
+  raw_ptr<content::WebContents> external_devtools_web_contents_ = nullptr;
 
   bool is_guest_;
   std::unique_ptr<InspectableWebContentsView> view_;

--- a/shell/browser/ui/inspectable_web_contents_view.h
+++ b/shell/browser/ui/inspectable_web_contents_view.h
@@ -8,6 +8,7 @@
 
 #include <string>
 
+#include "base/memory/raw_ptr.h"
 #include "ui/gfx/native_widget_types.h"
 
 class DevToolsContentsResizingStrategy;
@@ -55,7 +56,7 @@ class InspectableWebContentsView {
   virtual void SetTitle(const std::u16string& title) = 0;
 
  private:
-  InspectableWebContentsViewDelegate* delegate_ = nullptr;  // weak references.
+  raw_ptr<InspectableWebContentsViewDelegate> delegate_ = nullptr;  // weak references.
 };
 
 }  // namespace electron

--- a/shell/browser/ui/inspectable_web_contents_view_mac.h
+++ b/shell/browser/ui/inspectable_web_contents_view_mac.h
@@ -9,6 +9,7 @@
 #include "shell/browser/ui/inspectable_web_contents_view.h"
 
 #include "base/mac/scoped_nsobject.h"
+#include "base/memory/raw_ptr.h"
 
 @class ElectronInspectableWebContentsView;
 
@@ -41,7 +42,7 @@ class InspectableWebContentsViewMac : public InspectableWebContentsView {
 
  private:
   // Owns us.
-  InspectableWebContents* inspectable_web_contents_;
+  raw_ptr<InspectableWebContents> inspectable_web_contents_;
 
   base::scoped_nsobject<ElectronInspectableWebContentsView> view_;
 };

--- a/shell/browser/ui/tray_icon_gtk.h
+++ b/shell/browser/ui/tray_icon_gtk.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 
+#include "base/memory/raw_ptr.h"
 #include "shell/browser/ui/tray_icon.h"
 #include "ui/linux/status_icon_linux.h"
 
@@ -37,7 +38,7 @@ class TrayIconGtk : public TrayIcon, public ui::StatusIconLinux::Delegate {
   std::unique_ptr<ui::StatusIconLinux> icon_;
   gfx::ImageSkia image_;
   std::u16string tool_tip_;
-  ui::MenuModel* menu_model_;
+  raw_ptr<ui::MenuModel> menu_model_;
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/autofill_popup_view.h
+++ b/shell/browser/ui/views/autofill_popup_view.h
@@ -131,10 +131,10 @@ class AutofillPopupView : public views::WidgetDelegateView,
   void RemoveObserver();
 
   // Controller for this popup. Weak reference.
-  raw_ptr<AutofillPopup> popup_;
+  raw_ptr<AutofillPopup> popup_ = nullptr;
 
   // The widget of the window that triggered this popup. Weak reference.
-  raw_ptr<views::Widget> parent_widget_;
+  raw_ptr<views::Widget> parent_widget_ = nullptr;
 
   // The time when the popup was shown.
   base::Time show_time_;

--- a/shell/browser/ui/views/autofill_popup_view.h
+++ b/shell/browser/ui/views/autofill_popup_view.h
@@ -9,6 +9,7 @@
 
 #include "shell/browser/ui/autofill_popup.h"
 
+#include "base/memory/raw_ptr.h"
 #include "content/public/browser/native_web_keyboard_event.h"
 #include "content/public/browser/render_widget_host.h"
 #include "electron/buildflags/buildflags.h"
@@ -130,10 +131,10 @@ class AutofillPopupView : public views::WidgetDelegateView,
   void RemoveObserver();
 
   // Controller for this popup. Weak reference.
-  AutofillPopup* popup_;
+  raw_ptr<AutofillPopup> popup_;
 
   // The widget of the window that triggered this popup. Weak reference.
-  views::Widget* parent_widget_;
+  raw_ptr<views::Widget> parent_widget_;
 
   // The time when the popup was shown.
   base::Time show_time_;

--- a/shell/browser/ui/views/client_frame_view_linux.cc
+++ b/shell/browser/ui/views/client_frame_view_linux.cc
@@ -99,7 +99,7 @@ ClientFrameViewLinux::ClientFrameViewLinux()
   title_->SetHorizontalAlignment(gfx::ALIGN_CENTER);
   title_->SetVerticalAlignment(gfx::ALIGN_MIDDLE);
   title_->SetTextStyle(views::style::STYLE_TAB_ACTIVE);
-  AddChildView(title_);
+  AddChildView(title_.get());
 
   native_theme_observer_.Observe(theme_);
 

--- a/shell/browser/ui/views/client_frame_view_linux.h
+++ b/shell/browser/ui/views/client_frame_view_linux.h
@@ -114,10 +114,10 @@ class ClientFrameViewLinux : public FramelessView,
 
   gfx::Size SizeWithDecorations(gfx::Size size) const;
 
-  raw_ptr<ui::NativeTheme> theme_;
+  raw_ptr<ui::NativeTheme> theme_ = nullptr;
   ThemeValues theme_values_;
 
-  raw_ptr<views::Label> title_;
+  raw_ptr<views::Label> title_ = nullptr;
 
   std::unique_ptr<ui::NavButtonProvider> nav_button_provider_;
   std::array<NavButton, kNavButtonCount> nav_buttons_;
@@ -127,7 +127,7 @@ class ClientFrameViewLinux : public FramelessView,
 
   bool host_supports_client_frame_shadow_ = false;
 
-  raw_ptr<ui::WindowFrameProvider> frame_provider_;
+  raw_ptr<ui::WindowFrameProvider> frame_provider_ = nullptr;
 
   base::ScopedObservation<ui::NativeTheme, ui::NativeThemeObserver>
       native_theme_observer_{this};

--- a/shell/browser/ui/views/client_frame_view_linux.h
+++ b/shell/browser/ui/views/client_frame_view_linux.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "base/scoped_observation.h"
 #include "shell/browser/ui/views/frameless_view.h"
 #include "ui/linux/linux_ui.h"
@@ -113,10 +114,10 @@ class ClientFrameViewLinux : public FramelessView,
 
   gfx::Size SizeWithDecorations(gfx::Size size) const;
 
-  ui::NativeTheme* theme_;
+  raw_ptr<ui::NativeTheme> theme_;
   ThemeValues theme_values_;
 
-  views::Label* title_;
+  raw_ptr<views::Label> title_;
 
   std::unique_ptr<ui::NavButtonProvider> nav_button_provider_;
   std::array<NavButton, kNavButtonCount> nav_buttons_;
@@ -126,7 +127,7 @@ class ClientFrameViewLinux : public FramelessView,
 
   bool host_supports_client_frame_shadow_ = false;
 
-  ui::WindowFrameProvider* frame_provider_;
+  raw_ptr<ui::WindowFrameProvider> frame_provider_;
 
   base::ScopedObservation<ui::NativeTheme, ui::NativeThemeObserver>
       native_theme_observer_{this};

--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -93,8 +93,8 @@ InspectableWebContentsViewViews::InspectableWebContentsViewViews(
   }
 
   devtools_web_view_->SetVisible(false);
-  AddChildView(devtools_web_view_);
-  AddChildView(contents_web_view_);
+  AddChildView(devtools_web_view_.get());
+  AddChildView(contents_web_view_.get());
 }
 
 InspectableWebContentsViewViews::~InspectableWebContentsViewViews() {

--- a/shell/browser/ui/views/inspectable_web_contents_view_views.h
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "base/compiler_specific.h"
+#include "base/memory/raw_ptr.h"
 #include "chrome/browser/devtools/devtools_contents_resizing_strategy.h"
 #include "shell/browser/ui/inspectable_web_contents_view.h"
 #include "ui/views/view.h"
@@ -55,13 +56,13 @@ class InspectableWebContentsViewViews : public InspectableWebContentsView,
   InspectableWebContents* inspectable_web_contents_;
 
   std::unique_ptr<views::Widget> devtools_window_;
-  views::WebView* devtools_window_web_view_ = nullptr;
-  views::View* contents_web_view_ = nullptr;
-  views::WebView* devtools_web_view_ = nullptr;
+  raw_ptr<views::WebView> devtools_window_web_view_ = nullptr;
+  raw_ptr<views::View> contents_web_view_ = nullptr;
+  raw_ptr<views::WebView> devtools_web_view_ = nullptr;
 
   DevToolsContentsResizingStrategy strategy_;
   bool devtools_visible_ = false;
-  views::WidgetDelegate* devtools_window_delegate_ = nullptr;
+  raw_ptr<views::WidgetDelegate> devtools_window_delegate_ = nullptr;
   std::u16string title_;
 };
 

--- a/shell/browser/ui/views/menu_bar.h
+++ b/shell/browser/ui/views/menu_bar.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_VIEWS_MENU_BAR_H_
 #define ELECTRON_SHELL_BROWSER_UI_VIEWS_MENU_BAR_H_
 
+#include "base/memory/raw_ptr.h"
 #include "shell/browser/native_window_observer.h"
 #include "shell/browser/ui/electron_menu_model.h"
 #include "shell/browser/ui/views/menu_delegate.h"
@@ -84,9 +85,9 @@ class MenuBar : public views::AccessiblePaneView,
   SkColor disabled_color_;
 #endif
 
-  NativeWindow* window_;
-  RootView* root_view_;
-  ElectronMenuModel* menu_model_ = nullptr;
+  raw_ptr<NativeWindow> window_;
+  raw_ptr<RootView> root_view_;
+  raw_ptr<ElectronMenuModel> menu_model_ = nullptr;
   bool accelerator_installed_ = false;
 };
 

--- a/shell/browser/ui/views/menu_bar.h
+++ b/shell/browser/ui/views/menu_bar.h
@@ -85,8 +85,8 @@ class MenuBar : public views::AccessiblePaneView,
   SkColor disabled_color_;
 #endif
 
-  raw_ptr<NativeWindow> window_;
-  raw_ptr<RootView> root_view_;
+  raw_ptr<NativeWindow> window_ = nullptr;
+  raw_ptr<RootView> root_view_ = nullptr;
   raw_ptr<ElectronMenuModel> menu_model_ = nullptr;
   bool accelerator_installed_ = false;
 };

--- a/shell/browser/ui/views/menu_delegate.h
+++ b/shell/browser/ui/views/menu_delegate.h
@@ -67,7 +67,7 @@ class MenuDelegate : public views::MenuDelegate {
                                       views::MenuButton** button) override;
 
  private:
-  raw_ptr<MenuBar> menu_bar_;
+  raw_ptr<MenuBar> menu_bar_ = nullptr;
   int id_ = -1;
   std::unique_ptr<views::MenuDelegate> adapter_;
   std::unique_ptr<views::MenuRunner> menu_runner_;

--- a/shell/browser/ui/views/menu_delegate.h
+++ b/shell/browser/ui/views/menu_delegate.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/memory/raw_ptr.h"
 #include "base/observer_list.h"
 #include "shell/browser/ui/electron_menu_model.h"
 #include "ui/views/controls/menu/menu_delegate.h"
@@ -66,7 +67,7 @@ class MenuDelegate : public views::MenuDelegate {
                                       views::MenuButton** button) override;
 
  private:
-  MenuBar* menu_bar_;
+  raw_ptr<MenuBar> menu_bar_;
   int id_ = -1;
   std::unique_ptr<views::MenuDelegate> adapter_;
   std::unique_ptr<views::MenuRunner> menu_runner_;

--- a/shell/browser/ui/views/menu_model_adapter.h
+++ b/shell/browser/ui/views/menu_model_adapter.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_VIEWS_MENU_MODEL_ADAPTER_H_
 #define ELECTRON_SHELL_BROWSER_UI_VIEWS_MENU_MODEL_ADAPTER_H_
 
+#include "base/memory/raw_ptr.h"
 #include "shell/browser/ui/electron_menu_model.h"
 #include "ui/views/controls/menu/menu_model_adapter.h"
 
@@ -23,7 +24,7 @@ class MenuModelAdapter : public views::MenuModelAdapter {
   bool GetAccelerator(int id, ui::Accelerator* accelerator) const override;
 
  private:
-  ElectronMenuModel* menu_model_;
+  raw_ptr<ElectronMenuModel> menu_model_;
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/menu_model_adapter.h
+++ b/shell/browser/ui/views/menu_model_adapter.h
@@ -24,7 +24,7 @@ class MenuModelAdapter : public views::MenuModelAdapter {
   bool GetAccelerator(int id, ui::Accelerator* accelerator) const override;
 
  private:
-  raw_ptr<ElectronMenuModel> menu_model_;
+  raw_ptr<ElectronMenuModel> menu_model_ = nullptr;
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/native_frame_view.h
+++ b/shell/browser/ui/views/native_frame_view.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_VIEWS_NATIVE_FRAME_VIEW_H_
 #define ELECTRON_SHELL_BROWSER_UI_VIEWS_NATIVE_FRAME_VIEW_H_
 
+#include "base/memory/raw_ptr.h"
 #include "ui/views/window/native_frame_view.h"
 
 namespace electron {
@@ -29,7 +30,7 @@ class NativeFrameView : public views::NativeFrameView {
   const char* GetClassName() const override;
 
  private:
-  NativeWindow* window_;  // weak ref.
+  raw_ptr<NativeWindow> window_;  // weak ref.
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/native_frame_view.h
+++ b/shell/browser/ui/views/native_frame_view.h
@@ -30,7 +30,7 @@ class NativeFrameView : public views::NativeFrameView {
   const char* GetClassName() const override;
 
  private:
-  raw_ptr<NativeWindow> window_;  // weak ref.
+  raw_ptr<NativeWindow> window_ = nullptr;  // weak ref.
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/root_view.h
+++ b/shell/browser/ui/views/root_view.h
@@ -54,7 +54,7 @@ class RootView : public views::View {
 
  private:
   // Parent window, weak ref.
-  raw_ptr<NativeWindow> window_;
+  raw_ptr<NativeWindow> window_ = nullptr;
 
   // Menu bar.
   std::unique_ptr<MenuBar> menu_bar_;

--- a/shell/browser/ui/views/root_view.h
+++ b/shell/browser/ui/views/root_view.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/memory/raw_ptr.h"
 #include "shell/browser/ui/accelerator_util.h"
 #include "ui/gfx/geometry/insets.h"
 #include "ui/views/view.h"
@@ -53,7 +54,7 @@ class RootView : public views::View {
 
  private:
   // Parent window, weak ref.
-  NativeWindow* window_;
+  raw_ptr<NativeWindow> window_;
 
   // Menu bar.
   std::unique_ptr<MenuBar> menu_bar_;

--- a/shell/browser/ui/views/win_caption_button_container.h
+++ b/shell/browser/ui/views/win_caption_button_container.h
@@ -9,6 +9,7 @@
 #define ELECTRON_SHELL_BROWSER_UI_VIEWS_WIN_CAPTION_BUTTON_CONTAINER_H_
 
 #include "base/scoped_observation.h"
+#include "base/memory/raw_ptr.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 #include "ui/base/pointer/touch_ui_controller.h"
 #include "ui/views/controls/button/button.h"
@@ -59,10 +60,10 @@ class WinCaptionButtonContainer : public views::View,
                              const gfx::Rect& new_bounds) override;
 
   WinFrameView* const frame_view_;
-  WinCaptionButton* const minimize_button_;
-  WinCaptionButton* const maximize_button_;
-  WinCaptionButton* const restore_button_;
-  WinCaptionButton* const close_button_;
+  const raw_ptr<WinCaptionButton> minimize_button_;
+  const raw_ptr<WinCaptionButton> maximize_button_;
+  const raw_ptr<WinCaptionButton> restore_button_;
+  const raw_ptr<WinCaptionButton> close_button_;
 
   base::ScopedObservation<views::Widget, views::WidgetObserver>
       widget_observation_{this};

--- a/shell/browser/ui/views/win_frame_view.h
+++ b/shell/browser/ui/views/win_frame_view.h
@@ -10,6 +10,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_VIEWS_WIN_FRAME_VIEW_H_
 #define ELECTRON_SHELL_BROWSER_UI_VIEWS_WIN_FRAME_VIEW_H_
 
+#include "base/memory/raw_ptr.h"
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/ui/views/frameless_view.h"
 #include "shell/browser/ui/views/win_caption_button.h"
@@ -90,7 +91,7 @@ class WinFrameView : public FramelessView {
   // The container holding the caption buttons (minimize, maximize, close, etc.)
   // May be null if the caption button container is destroyed before the frame
   // view. Always check for validity before using!
-  WinCaptionButtonContainer* caption_button_container_;
+  raw_ptr<WinCaptionButtonContainer> caption_button_container_;
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/win_frame_view.h
+++ b/shell/browser/ui/views/win_frame_view.h
@@ -91,7 +91,7 @@ class WinFrameView : public FramelessView {
   // The container holding the caption buttons (minimize, maximize, close, etc.)
   // May be null if the caption button container is destroyed before the frame
   // view. Always check for validity before using!
-  raw_ptr<WinCaptionButtonContainer> caption_button_container_;
+  raw_ptr<WinCaptionButtonContainer> caption_button_container_ = nullptr;
 };
 
 }  // namespace electron

--- a/shell/browser/web_contents_permission_helper.h
+++ b/shell/browser/web_contents_permission_helper.h
@@ -6,6 +6,7 @@
 #define ELECTRON_SHELL_BROWSER_WEB_CONTENTS_PERMISSION_HELPER_H_
 
 #include "base/values.h"
+#include "base/memory/raw_ptr.h"
 #include "content/public/browser/media_stream_request.h"
 #include "content/public/browser/web_contents_user_data.h"
 #include "third_party/blink/public/common/mediastream/media_stream_request.h"
@@ -70,7 +71,7 @@ class WebContentsPermissionHelper
 
   // TODO(clavin): refactor to use the WebContents provided by the
   // WebContentsUserData base class instead of storing a duplicate ref
-  content::WebContents* web_contents_;
+  raw_ptr<content::WebContents> web_contents_;
 
   WEB_CONTENTS_USER_DATA_KEY_DECL();
 };

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "base/values.h"
 #include "content/public/browser/web_contents_user_data.h"
 #include "electron/buildflags/buildflags.h"
@@ -92,7 +93,7 @@ class WebContentsPreferences
 
   // TODO(clavin): refactor to use the WebContents provided by the
   // WebContentsUserData base class instead of storing a duplicate ref
-  content::WebContents* web_contents_;
+  raw_ptr<content::WebContents> web_contents_;
 
   bool plugins_;
   bool experimental_features_;

--- a/shell/browser/web_contents_zoom_controller.h
+++ b/shell/browser/web_contents_zoom_controller.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_WEB_CONTENTS_ZOOM_CONTROLLER_H_
 #define ELECTRON_SHELL_BROWSER_WEB_CONTENTS_ZOOM_CONTROLLER_H_
 
+#include "base/memory/raw_ptr.h"
 #include "base/observer_list.h"
 #include "base/observer_list_types.h"
 #include "content/public/browser/host_zoom_map.h"
@@ -111,11 +112,11 @@ class WebContentsZoomController
   int old_process_id_ = -1;
   int old_view_id_ = -1;
 
-  WebContentsZoomController* embedder_zoom_controller_ = nullptr;
+  raw_ptr<WebContentsZoomController> embedder_zoom_controller_ = nullptr;
 
   base::ObserverList<Observer> observers_;
 
-  content::HostZoomMap* host_zoom_map_;
+  raw_ptr<content::HostZoomMap> host_zoom_map_;
 
   WEB_CONTENTS_USER_DATA_KEY_DECL();
 };

--- a/shell/browser/web_view_guest_delegate.h
+++ b/shell/browser/web_view_guest_delegate.h
@@ -49,11 +49,11 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
   void ResetZoomController();
 
   // The WebContents that attaches this guest view.
-  content::WebContents* embedder_web_contents_ = nullptr;
+  raw_ptr<content::WebContents> embedder_web_contents_ = nullptr;
 
   // The zoom controller of the embedder that is used
   // to subscribe for zoom changes.
-  WebContentsZoomController* embedder_zoom_controller_ = nullptr;
+  raw_ptr<WebContentsZoomController> embedder_zoom_controller_ = nullptr;
 
   raw_ptr<api::WebContents> api_web_contents_ = nullptr;
 };

--- a/shell/browser/web_view_guest_delegate.h
+++ b/shell/browser/web_view_guest_delegate.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/memory/raw_ptr.h"
 #include "content/public/browser/browser_plugin_guest_delegate.h"
 #include "shell/browser/web_contents_zoom_controller.h"
 
@@ -54,7 +55,7 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
   // to subscribe for zoom changes.
   WebContentsZoomController* embedder_zoom_controller_ = nullptr;
 
-  api::WebContents* api_web_contents_ = nullptr;
+  raw_ptr<api::WebContents> api_web_contents_ = nullptr;
 };
 
 }  // namespace electron

--- a/shell/browser/zoom_level_delegate.h
+++ b/shell/browser/zoom_level_delegate.h
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "base/memory/raw_ptr.h"
 #include "base/values.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/host_zoom_map.h"
@@ -52,8 +53,8 @@ class ZoomLevelDelegate : public content::ZoomLevelDelegate {
   // zoom levels (if any) managed by this class (for its associated partition).
   void OnZoomLevelChanged(const content::HostZoomMap::ZoomLevelChange& change);
 
-  PrefService* pref_service_;
-  content::HostZoomMap* host_zoom_map_ = nullptr;
+  raw_ptr<PrefService> pref_service_;
+  raw_ptr<content::HostZoomMap> host_zoom_map_ = nullptr;
   base::CallbackListSubscription zoom_subscription_;
   std::string partition_key_;
 };

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -135,7 +135,7 @@ class NativeImage : public gin::Wrappable<NativeImage> {
 
   gfx::Image image_;
 
-  raw_ptr<v8::Isolate> isolate_;
+  raw_ptr<v8::Isolate> isolate_ = nullptr;
   int32_t memory_usage_ = 0;
 };
 

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "base/values.h"
 #include "gin/handle.h"
 #include "gin/wrappable.h"
@@ -134,7 +135,7 @@ class NativeImage : public gin::Wrappable<NativeImage> {
 
   gfx::Image image_;
 
-  v8::Isolate* isolate_;
+  raw_ptr<v8::Isolate> isolate_;
   int32_t memory_usage_ = 0;
 };
 

--- a/shell/common/gin_helper/error_thrower.h
+++ b/shell/common/gin_helper/error_thrower.h
@@ -30,7 +30,7 @@ class ErrorThrower {
       v8::Local<v8::Value> (*)(v8::Local<v8::String> err_msg);
   void Throw(ErrorGenerator gen, base::StringPiece err_msg) const;
 
-  raw_ptr<v8::Isolate> isolate_;
+  raw_ptr<v8::Isolate> isolate_ = nullptr;
 };
 
 }  // namespace gin_helper

--- a/shell/common/gin_helper/error_thrower.h
+++ b/shell/common/gin_helper/error_thrower.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_COMMON_GIN_HELPER_ERROR_THROWER_H_
 #define ELECTRON_SHELL_COMMON_GIN_HELPER_ERROR_THROWER_H_
 
+#include "base/memory/raw_ptr.h"
 #include "base/strings/string_piece.h"
 #include "v8/include/v8.h"
 
@@ -29,7 +30,7 @@ class ErrorThrower {
       v8::Local<v8::Value> (*)(v8::Local<v8::String> err_msg);
   void Throw(ErrorGenerator gen, base::StringPiece err_msg) const;
 
-  v8::Isolate* isolate_;
+  raw_ptr<v8::Isolate> isolate_;
 };
 
 }  // namespace gin_helper

--- a/shell/common/gin_helper/function_template.h
+++ b/shell/common/gin_helper/function_template.h
@@ -9,6 +9,7 @@
 
 #include "base/bind.h"
 #include "base/callback.h"
+#include "base/memory/raw_ptr.h"
 #include "gin/arguments.h"
 #include "shell/common/gin_helper/arguments.h"
 #include "shell/common/gin_helper/destroyable.h"
@@ -237,7 +238,7 @@ class Invoker<IndicesHolder<indices...>, ArgTypes...>
     return arg1 && And(args...);
   }
 
-  gin::Arguments* args_;
+  raw_ptr<gin::Arguments> args_;
 };
 
 // DispatchToCallback converts all the JavaScript arguments to C++ types and

--- a/shell/common/gin_helper/function_template.h
+++ b/shell/common/gin_helper/function_template.h
@@ -238,7 +238,7 @@ class Invoker<IndicesHolder<indices...>, ArgTypes...>
     return arg1 && And(args...);
   }
 
-  raw_ptr<gin::Arguments> args_;
+  raw_ptr<gin::Arguments> args_ = nullptr;
 };
 
 // DispatchToCallback converts all the JavaScript arguments to C++ types and

--- a/shell/common/gin_helper/object_template_builder.h
+++ b/shell/common/gin_helper/object_template_builder.h
@@ -67,7 +67,7 @@ class ObjectTemplateBuilder {
       v8::Local<v8::FunctionTemplate> getter,
       v8::Local<v8::FunctionTemplate> setter);
 
-  raw_ptr<v8::Isolate> isolate_;
+  raw_ptr<v8::Isolate> isolate_ = nullptr;
 
   // ObjectTemplateBuilder should only be used on the stack.
   v8::Local<v8::ObjectTemplate> template_;

--- a/shell/common/gin_helper/object_template_builder.h
+++ b/shell/common/gin_helper/object_template_builder.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_COMMON_GIN_HELPER_OBJECT_TEMPLATE_BUILDER_H_
 #define ELECTRON_SHELL_COMMON_GIN_HELPER_OBJECT_TEMPLATE_BUILDER_H_
 
+#include "base/memory/raw_ptr.h"
 #include "shell/common/gin_helper/function_template.h"
 
 namespace gin_helper {
@@ -66,7 +67,7 @@ class ObjectTemplateBuilder {
       v8::Local<v8::FunctionTemplate> getter,
       v8::Local<v8::FunctionTemplate> setter);
 
-  v8::Isolate* isolate_;
+  raw_ptr<v8::Isolate> isolate_;
 
   // ObjectTemplateBuilder should only be used on the stack.
   v8::Local<v8::ObjectTemplate> template_;

--- a/shell/common/gin_helper/promise.h
+++ b/shell/common/gin_helper/promise.h
@@ -76,7 +76,7 @@ class PromiseBase {
   v8::Local<v8::Promise::Resolver> GetInner() const;
 
  private:
-  raw_ptr<v8::Isolate> isolate_;
+  raw_ptr<v8::Isolate> isolate_ = nullptr;
   v8::Global<v8::Context> context_;
   v8::Global<v8::Promise::Resolver> resolver_;
 };

--- a/shell/common/gin_helper/promise.h
+++ b/shell/common/gin_helper/promise.h
@@ -10,6 +10,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "base/memory/raw_ptr.h"
 #include "base/strings/string_piece.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
@@ -75,7 +76,7 @@ class PromiseBase {
   v8::Local<v8::Promise::Resolver> GetInner() const;
 
  private:
-  v8::Isolate* isolate_;
+  raw_ptr<v8::Isolate> isolate_;
   v8::Global<v8::Context> context_;
   v8::Global<v8::Promise::Resolver> resolver_;
 };

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -8,6 +8,7 @@
 #include <type_traits>
 
 #include "base/files/file_path.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "uv.h"  // NOLINT(build/include_directory)
 #include "v8/include/v8.h"
@@ -138,7 +139,7 @@ class NodeBindings {
   scoped_refptr<base::SingleThreadTaskRunner> task_runner_;
 
   // Current thread's libuv loop.
-  uv_loop_t* uv_loop_;
+  raw_ptr<uv_loop_t> uv_loop_;
 
  private:
   // Thread to poll uv events.
@@ -163,10 +164,10 @@ class NodeBindings {
   uv_sem_t embed_sem_;
 
   // Environment that to wrap the uv loop.
-  node::Environment* uv_env_ = nullptr;
+  raw_ptr<node::Environment> uv_env_ = nullptr;
 
   // Isolate data used in creating the environment
-  node::IsolateData* isolate_data_ = nullptr;
+  raw_ptr<node::IsolateData> isolate_data_ = nullptr;
 
   base::WeakPtrFactory<NodeBindings> weak_factory_{this};
 };

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -139,7 +139,7 @@ class NodeBindings {
   scoped_refptr<base::SingleThreadTaskRunner> task_runner_;
 
   // Current thread's libuv loop.
-  raw_ptr<uv_loop_t> uv_loop_;
+  raw_ptr<uv_loop_t> uv_loop_ = nullptr;
 
  private:
   // Thread to poll uv events.

--- a/shell/renderer/api/electron_api_spell_check_client.h
+++ b/shell/renderer/api/electron_api_spell_check_client.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "base/callback.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "components/spellcheck/renderer/spellcheck_worditerator.h"
 #include "third_party/blink/public/platform/web_spell_check_panel_host_client.h"
@@ -101,7 +102,7 @@ class SpellCheckClient : public blink::WebSpellCheckPanelHostClient,
   // requests so we do not have to use vectors.)
   std::unique_ptr<SpellcheckRequest> pending_request_param_;
 
-  v8::Isolate* isolate_;
+  raw_ptr<v8::Isolate> isolate_;
   v8::Global<v8::Context> context_;
   v8::Global<v8::Object> provider_;
   v8::Global<v8::Function> spell_check_;

--- a/shell/renderer/api/electron_api_spell_check_client.h
+++ b/shell/renderer/api/electron_api_spell_check_client.h
@@ -102,7 +102,7 @@ class SpellCheckClient : public blink::WebSpellCheckPanelHostClient,
   // requests so we do not have to use vectors.)
   std::unique_ptr<SpellcheckRequest> pending_request_param_;
 
-  raw_ptr<v8::Isolate> isolate_;
+  raw_ptr<v8::Isolate> isolate_ = nullptr;
   v8::Global<v8::Context> context_;
   v8::Global<v8::Object> provider_;
   v8::Global<v8::Function> spell_check_;

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_frame_observer.h"
@@ -64,7 +65,7 @@ class ElectronApiServiceImpl : public mojom::ElectronRenderer,
   mojo::PendingReceiver<mojom::ElectronRenderer> pending_receiver_;
   mojo::Receiver<mojom::ElectronRenderer> receiver_{this};
 
-  RendererClientBase* renderer_client_;
+  raw_ptr<RendererClientBase> renderer_client_;
   base::WeakPtrFactory<ElectronApiServiceImpl> weak_factory_{this};
 };
 

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -65,7 +65,7 @@ class ElectronApiServiceImpl : public mojom::ElectronRenderer,
   mojo::PendingReceiver<mojom::ElectronRenderer> pending_receiver_;
   mojo::Receiver<mojom::ElectronRenderer> receiver_{this};
 
-  raw_ptr<RendererClientBase> renderer_client_;
+  raw_ptr<RendererClientBase> renderer_client_ = nullptr;
   base::WeakPtrFactory<ElectronApiServiceImpl> weak_factory_{this};
 };
 

--- a/shell/renderer/electron_render_frame_observer.h
+++ b/shell/renderer/electron_render_frame_observer.h
@@ -46,8 +46,8 @@ class ElectronRenderFrameObserver : public content::RenderFrameObserver {
                           const std::string& channel);
 
   bool has_delayed_node_initialization_ = false;
-  raw_ptr<content::RenderFrame> render_frame_;
-  raw_ptr<RendererClientBase> renderer_client_;
+  raw_ptr<content::RenderFrame> render_frame_ = nullptr;
+  raw_ptr<RendererClientBase> renderer_client_ = nullptr;
 };
 
 }  // namespace electron

--- a/shell/renderer/electron_render_frame_observer.h
+++ b/shell/renderer/electron_render_frame_observer.h
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "base/memory/raw_ptr.h"
 #include "content/public/renderer/render_frame_observer.h"
 #include "ipc/ipc_platform_file.h"
 #include "third_party/blink/public/web/web_local_frame.h"
@@ -45,8 +46,8 @@ class ElectronRenderFrameObserver : public content::RenderFrameObserver {
                           const std::string& channel);
 
   bool has_delayed_node_initialization_ = false;
-  content::RenderFrame* render_frame_;
-  RendererClientBase* renderer_client_;
+  raw_ptr<content::RenderFrame> render_frame_;
+  raw_ptr<RendererClientBase> renderer_client_;
 };
 
 }  // namespace electron

--- a/shell/renderer/electron_renderer_pepper_host_factory.h
+++ b/shell/renderer/electron_renderer_pepper_host_factory.h
@@ -35,7 +35,7 @@ class ElectronRendererPepperHostFactory : public ppapi::host::HostFactory {
 
  private:
   // Not owned by this object.
-  raw_ptr<content::RendererPpapiHost> host_;
+  raw_ptr<content::RendererPpapiHost> host_ = nullptr;
 };
 
 #endif  // ELECTRON_SHELL_RENDERER_ELECTRON_RENDERER_PEPPER_HOST_FACTORY_H_

--- a/shell/renderer/electron_renderer_pepper_host_factory.h
+++ b/shell/renderer/electron_renderer_pepper_host_factory.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "base/compiler_specific.h"
+#include "base/memory/raw_ptr.h"
 #include "ppapi/host/host_factory.h"
 
 namespace content {
@@ -34,7 +35,7 @@ class ElectronRendererPepperHostFactory : public ppapi::host::HostFactory {
 
  private:
   // Not owned by this object.
-  content::RendererPpapiHost* host_;
+  raw_ptr<content::RendererPpapiHost> host_;
 };
 
 #endif  // ELECTRON_SHELL_RENDERER_ELECTRON_RENDERER_PEPPER_HOST_FACTORY_H_


### PR DESCRIPTION
#### Description of Change

This is a first stab at using upstream's `raw_ptr` mechanism as described in https://chromium.googlesource.com/chromium/src/+/main/base/memory/raw_ptr.md and https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md#non_owning-pointers-in-class-fields.

WfM locally, but I'm interested to see what happens when feeding this into CI. Marking as a draft pending a little CI feedback.

No particular stakeholders, but @electron/wg-releases and @electron/wg-security might be interested

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none