### PR TITLE
docs: update the link for Introduction to Node.js

### DIFF
--- a/docs/tutorial/tutorial-1-prerequisites.md
+++ b/docs/tutorial/tutorial-1-prerequisites.md
@@ -123,7 +123,7 @@ the list of versions in the [electron/releases] repository.
 [homebrew]: https://brew.sh/
 [mdn-guide]: https://developer.mozilla.org/en-US/docs/Learn/
 [node]: https://nodejs.org/
-[node-guide]: https://nodejs.dev/learn
+[node-guide]: https://nodejs.dev/en/learn/
 [node-download]: https://nodejs.org/en/download/
 [nvm]: https://github.com/nvm-sh/nvm
 [process-model]: ./process-model.md


### PR DESCRIPTION
#### Description of Change
Updated the link for `Introduction to NodeJs`  that was https://nodejs.dev/learn but the new one is https://nodejs.dev/en/learn/ . 
#### Why this change was needed?
This change was needed because the NodeJs organisation has updated their routes and if you go to that old link then you will get 404 " PAGE NOT FOUND" error.

I changed the file `electron/docs/tutorial/tutorial-prerequisites.md`. Only one link was found and was changed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

#### Release Notes

Notes: none
