### PR TITLE
feat: add ignore method to IncomingMessage

### DIFF
--- a/docs/api/incoming-message.md
+++ b/docs/api/incoming-message.md
@@ -102,3 +102,14 @@ duplicates are not merged.
 //   '*/*' ]
 console.log(request.rawHeaders)
 ```
+
+### Methods
+
+Objects received in [ClientRequest](client-request.md) event `response` have the following instance methods:
+
+#### `response.ignore()`
+
+Indicates that response is ignored. Cancels all chunks of data from being downloaded.
+
+**Note:** Please make sure you call this method if response data is not read.
+Otherwise it will lead to memory leaks in browser process ([#34158](https://github.com/electron/electron/issues/34158)).

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -140,6 +140,7 @@ auto_filenames = {
     "lib/common/define-properties.ts",
     "lib/common/ipc-messages.ts",
     "lib/common/web-view-methods.ts",
+    "lib/common/webpack-globals-provider.ts",
     "lib/renderer/api/context-bridge.ts",
     "lib/renderer/api/crash-reporter.ts",
     "lib/renderer/api/ipc-renderer.ts",

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -140,7 +140,6 @@ auto_filenames = {
     "lib/common/define-properties.ts",
     "lib/common/ipc-messages.ts",
     "lib/common/web-view-methods.ts",
-    "lib/common/webpack-globals-provider.ts",
     "lib/renderer/api/context-bridge.ts",
     "lib/renderer/api/crash-reporter.ts",
     "lib/renderer/api/ipc-renderer.ts",

--- a/lib/browser/api/net.ts
+++ b/lib/browser/api/net.ts
@@ -113,6 +113,10 @@ class IncomingMessage extends Readable {
     throw new Error('HTTP trailers are not supported');
   }
 
+  ignore () {
+    this.emit('ignored');
+  }
+
   _storeInternalData (chunk: Buffer | null, resume: (() => void) | null) {
     // save the network callback for use in _pushInternalData
     this._resume = resume;
@@ -438,6 +442,9 @@ export class ClientRequest extends Writable implements Electron.ClientRequest {
     this._urlLoader = createURLLoader(opts);
     this._urlLoader.on('response-started', (event, finalUrl, responseHead) => {
       const response = this._response = new IncomingMessage(responseHead);
+      this._response.on('ignored', () => {
+        this._urlLoader!.cancel();
+      });
       this.emit('response', response);
     });
     this._urlLoader.on('data', (event, data, resume) => {


### PR DESCRIPTION
#### Description of Change

That method makes possible to indicate that response is ignored, and all data chunks should be dropped. Otherwise, response data should be read. If response data is not read and is not ignored, memory leak will happen per each net.request call in browser process.

Fixes #34158
CC: @VerteDinde 

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Method ignore() is added to IncomingMessage in order to prevent memory leaks in browser process when data is not read.