### PR TITLE
Clarify `electron-rebuild` usage

### DIFF
--- a/docs/tutorial/using-native-node-modules.md
+++ b/docs/tutorial/using-native-node-modules.md
@@ -40,6 +40,8 @@ npm install --save-dev electron-rebuild
 .\node_modules\.bin\electron-rebuild.cmd
 ```
 
+This will ONLY apply to modules declared in your `dependencies`, not `devDependencies`.
+
 For more information on usage and integration with other tools such as [Electron
 Packager][electron-packager], consult the project's README.
 


### PR DESCRIPTION
#### Description of Change

Clarify that electron-rebuild only applies to "dependencies", not "devDependencies".

#### Checklist

- [X] relevant documentation is changed or added

#### Release Notes

Notes: none
