### PR TITLE
build: make patches owned by patch-owners (formed by upgrades + security)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # https://git-scm.com/docs/gitignore
 
 # Upgrades WG
-/patches/                               @electron/wg-upgrades @electron/wg-security
+/patches/                               @electron/patch-owners
 DEPS                                    @electron/wg-upgrades
 
 # Releases WG


### PR DESCRIPTION
This ensures that we don't need **both** security and upgrades to sign off on a patch PR, instead a single rep from either team can approve

Notes: no-notes