### PR TITLE
fix: potential exception when calling webFrameMainBinding.fromIdOrNull()

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -537,6 +537,14 @@ const addReturnValueToEvent = (event: Electron.IpcMainEvent) => {
   });
 };
 
+const getWebFrameForEvent = (event: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent) => {
+  try {
+    return webFrameMainBinding.fromIdOrNull(event.processId, event.frameId);
+  } catch {
+    return null;
+  }
+};
+
 const commandLine = process._linkedBinding('electron_common_command_line');
 const environment = process._linkedBinding('electron_common_environment');
 
@@ -574,7 +582,7 @@ WebContents.prototype._init = function () {
     } else {
       addReplyToEvent(event);
       this.emit('ipc-message', event, channel, ...args);
-      const maybeWebFrame = webFrameMainBinding.fromIdOrNull(event.processId, event.frameId);
+      const maybeWebFrame = getWebFrameForEvent(event);
       maybeWebFrame && maybeWebFrame.ipc.emit(channel, event, ...args);
       ipc.emit(channel, event, ...args);
       ipcMain.emit(channel, event, ...args);
@@ -588,8 +596,8 @@ WebContents.prototype._init = function () {
       console.error(`Error occurred in handler for '${channel}':`, error);
       event.sendReply({ error: error.toString() });
     };
-    const maybeWebFrame = webFrameMainBinding.fromIdOrNull(event.processId, event.frameId);
-    const targets: (ElectronInternal.IpcMainInternal| undefined)[] = internal ? [ipcMainInternal] : [maybeWebFrame && maybeWebFrame.ipc, ipc, ipcMain];
+    const maybeWebFrame = getWebFrameForEvent(event);
+    const targets: (ElectronInternal.IpcMainInternal| undefined)[] = internal ? [ipcMainInternal] : [maybeWebFrame?.ipc, ipc, ipcMain];
     const target = targets.find(target => target && (target as any)._invokeHandlers.has(channel));
     if (target) {
       (target as any)._invokeHandlers.get(channel)(event, ...args);
@@ -605,7 +613,7 @@ WebContents.prototype._init = function () {
       ipcMainInternal.emit(channel, event, ...args);
     } else {
       addReplyToEvent(event);
-      const maybeWebFrame = webFrameMainBinding.fromIdOrNull(event.processId, event.frameId);
+      const maybeWebFrame = getWebFrameForEvent(event);
       if (this.listenerCount('ipc-message-sync') === 0 && ipc.listenerCount(channel) === 0 && ipcMain.listenerCount(channel) === 0 && (!maybeWebFrame || maybeWebFrame.ipc.listenerCount(channel) === 0)) {
         console.warn(`WebContents #${this.id} called ipcRenderer.sendSync() with '${channel}' channel without listeners.`);
       }
@@ -619,7 +627,7 @@ WebContents.prototype._init = function () {
   this.on('-ipc-ports' as any, function (event: Electron.IpcMainEvent, internal: boolean, channel: string, message: any, ports: any[]) {
     addSenderFrameToEvent(event);
     event.ports = ports.map(p => new MessagePortMain(p));
-    const maybeWebFrame = webFrameMainBinding.fromIdOrNull(event.processId, event.frameId);
+    const maybeWebFrame = getWebFrameForEvent(event);
     maybeWebFrame && maybeWebFrame.ipc.emit(channel, event, message);
     ipc.emit(channel, event, message);
     ipcMain.emit(channel, event, message);

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -538,11 +538,8 @@ const addReturnValueToEvent = (event: Electron.IpcMainEvent) => {
 };
 
 const getWebFrameForEvent = (event: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent) => {
-  try {
-    return webFrameMainBinding.fromIdOrNull(event.processId, event.frameId);
-  } catch {
-    return null;
-  }
+  if (!event.processId || !event.frameId) return null;
+  return webFrameMainBinding.fromIdOrNull(event.processId, event.frameId);
 };
 
 const commandLine = process._linkedBinding('electron_common_command_line');

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -237,7 +237,7 @@ declare namespace NodeJS {
     _linkedBinding(name: 'electron_browser_web_frame_main'): {
       WebFrameMain: typeof Electron.WebFrameMain;
       fromId(processId: number, routingId: number): Electron.WebFrameMain;
-      fromIdOrNull(processId: number, routingId: number): Electron.WebFrameMain;
+      fromIdOrNull(processId: number, routingId: number): Electron.WebFrameMain | null;
     }
     _linkedBinding(name: 'electron_renderer_crash_reporter'): Electron.CrashReporter;
     _linkedBinding(name: 'electron_renderer_ipc'): { ipc: IpcRendererBinding };


### PR DESCRIPTION
#### Description of Change
> TypeError: Error processing argument at index 1, conversion failure from undefined

happens here in the generated `out/release/gen/electron/js2c/browser_init.js`
```ts
this.on("-ipc-message",(function(e,r,n,s){if(addSenderFrameToEvent(e),r)c.ipcMainInternal.emit(n,e,...s);else{addReplyToEvent(e),this.emit("ipc-message",e,n,...s);const r=p.fromIdOrNull(e.processId,e.frameId);r&&r.ipc.emit(n,e,...s),t.emit(n,e,...s),o.ipcMain.emit(n,e,...s)}}))
```
which maps to https://github.com/electron/electron/blob/ad33a5f364c5a630c148fe4866d38c735f905bfe/lib/browser/api/web-contents.ts#L577

Related to #35231

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none