### PR TITLE
build: fix deps workflow tag comparison

### DIFF
--- a/.github/workflows/release_dependency_versions.yml
+++ b/.github/workflows/release_dependency_versions.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Check Tag
       run: |
-        if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.0\.0$ ]]; then
+        if [[ ${{ github.event.release.tag_name }} =~ ^v[0-9]+\.0\.0$ ]]; then
           echo ::set-output name=should_release::true
         fi
   trigger:


### PR DESCRIPTION
#### Description of Change

Previous error:

```
Run if [[  =~ ^refs/tags/v[0-9]+\.0\.0$ ]]; then
  if [[  =~ ^refs/tags/v[0-9]+\.0\.0$ ]]; then
    echo ::set-output name=should_release::true
  fi
  shell: /usr/bin/bash -e {0}
  env:
    GITHUB_TOKEN: ***
/home/runner/work/_temp/e[1](https://github.com/electron/electron/actions/runs/3131226499/jobs/5082347062#step:3:1)9d80f[2](https://github.com/electron/electron/actions/runs/3131226499/jobs/5082347062#step:3:2)-96d2-479[3](https://github.com/electron/electron/actions/runs/3131226499/jobs/5082347062#step:3:3)-8029-207b2b7[5](https://github.com/electron/electron/actions/runs/3131226499/jobs/5082347062#step:3:5)b8[6](https://github.com/electron/electron/actions/runs/3131226499/jobs/5082347062#step:3:6)d.sh: line 1: conditional binary operator expected
Error: Process completed with exit code 2.
```

happening because `ref` is not a top level prop on `github.event` for releases. fix by using `github.event.release.tag_name`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
