### PR TITLE
fix: `TryCatch` scope in node_bindings

### DIFF
--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -492,19 +492,22 @@ node::Environment* NodeBindings::CreateEnvironment(
     flags |= node::EnvironmentFlags::kNoStartDebugSignalHandler;
   }
 
-  v8::TryCatch try_catch(isolate);
-  env = node::CreateEnvironment(
-      isolate_data_, context, args, exec_args,
-      static_cast<node::EnvironmentFlags::Flags>(flags));
+  {
+    v8::TryCatch try_catch(isolate);
+    env = node::CreateEnvironment(
+        isolate_data_, context, args, exec_args,
+        static_cast<node::EnvironmentFlags::Flags>(flags));
 
-  if (try_catch.HasCaught()) {
-    std::string err_msg =
-        "Failed to initialize node environment in process: " + process_type;
-    v8::Local<v8::Message> message = try_catch.Message();
-    std::string msg;
-    if (!message.IsEmpty() && gin::ConvertFromV8(isolate, message->Get(), &msg))
-      err_msg += " , with error: " + msg;
-    LOG(ERROR) << err_msg;
+    if (try_catch.HasCaught()) {
+      std::string err_msg =
+          "Failed to initialize node environment in process: " + process_type;
+      v8::Local<v8::Message> message = try_catch.Message();
+      std::string msg;
+      if (!message.IsEmpty() &&
+          gin::ConvertFromV8(isolate, message->Get(), &msg))
+        err_msg += " , with error: " + msg;
+      LOG(ERROR) << err_msg;
+    }
   }
 
   DCHECK(env);


### PR DESCRIPTION
#### Description of Change

Fixes a scoping issue with `TryCatch` in node_bindings which may have obscured errors farther below where we intended.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none