### PR TITLE
chore: cherry-pick 8b040cb69e96 from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -11,3 +11,4 @@ revert_runtime_dhceck_terminating_exception_in_microtasks.patch
 allow_disabling_of_v8_sandboxed_pointers.patch
 chore_disable_is_execution_terminating_dcheck.patch
 ext-code-space_fix_coderange_allocation_logic.patch
+cherry-pick-8b040cb69e96.patch

--- a/patches/v8/cherry-pick-8b040cb69e96.patch
+++ b/patches/v8/cherry-pick-8b040cb69e96.patch
@@ -1,7 +1,7 @@
-From 8b040cb69e96ab93843b403be29cd8c8daacaef1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jakob Kummerow <jkummerow@chromium.org>
 Date: Fri, 23 Sep 2022 13:13:37 +0200
-Subject: [PATCH] [wasm][liftoff] Fix a register reuse corner case
+Subject: Fix a register reuse corner case
 
 Fixed: chromium:1366399
 (cherry picked from commit 6c214db445827707d65be08d177c9a4257a03a7b)
@@ -12,13 +12,12 @@ Reviewed-by: Matthias Liedtke <mliedtke@chromium.org>
 Cr-Commit-Position: refs/branch-heads/10.6@{#29}
 Cr-Branched-From: 41bc7435693fbce8ef86753cd9239e30550a3e2d-refs/heads/10.6.194@{#1}
 Cr-Branched-From: d5f29b929ce7746409201d77f44048f3e9529b40-refs/heads/main@{#82548}
----
 
 diff --git a/src/wasm/baseline/liftoff-compiler.cc b/src/wasm/baseline/liftoff-compiler.cc
-index 4b51d64..291d171 100644
+index 2b269516dd302c06a3eebc1c9d70f4d36612b942..3f768f8f5adcc1bfd1d64e68c638a5bf2e737051 100644
 --- a/src/wasm/baseline/liftoff-compiler.cc
 +++ b/src/wasm/baseline/liftoff-compiler.cc
-@@ -1451,9 +1451,11 @@
+@@ -1421,9 +1421,11 @@ class LiftoffCompiler {
          __ MergeFullStackWith(c->label_state, *__ cache_state());
          __ emit_jump(c->label.get());
        }
@@ -32,7 +31,7 @@ index 4b51d64..291d171 100644
        __ cache_state()->Steal(c->label_state);
      } else if (c->reachable()) {
        // No merge yet at the end of the if, but we need to create a merge for
-@@ -1465,9 +1467,11 @@
+@@ -1435,9 +1437,11 @@ class LiftoffCompiler {
                                 c->stack_depth + c->num_exceptions);
        __ MergeFullStackWith(c->label_state, *__ cache_state());
        __ emit_jump(c->label.get());

--- a/patches/v8/cherry-pick-8b040cb69e96.patch
+++ b/patches/v8/cherry-pick-8b040cb69e96.patch
@@ -1,0 +1,48 @@
+From 8b040cb69e96ab93843b403be29cd8c8daacaef1 Mon Sep 17 00:00:00 2001
+From: Jakob Kummerow <jkummerow@chromium.org>
+Date: Fri, 23 Sep 2022 13:13:37 +0200
+Subject: [PATCH] [wasm][liftoff] Fix a register reuse corner case
+
+Fixed: chromium:1366399
+(cherry picked from commit 6c214db445827707d65be08d177c9a4257a03a7b)
+
+Change-Id: I72cf30cbd31a21acb44b524a194acfb89d8fecbc
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3925795
+Reviewed-by: Matthias Liedtke <mliedtke@chromium.org>
+Cr-Commit-Position: refs/branch-heads/10.6@{#29}
+Cr-Branched-From: 41bc7435693fbce8ef86753cd9239e30550a3e2d-refs/heads/10.6.194@{#1}
+Cr-Branched-From: d5f29b929ce7746409201d77f44048f3e9529b40-refs/heads/main@{#82548}
+---
+
+diff --git a/src/wasm/baseline/liftoff-compiler.cc b/src/wasm/baseline/liftoff-compiler.cc
+index 4b51d64..291d171 100644
+--- a/src/wasm/baseline/liftoff-compiler.cc
++++ b/src/wasm/baseline/liftoff-compiler.cc
+@@ -1451,9 +1451,11 @@
+         __ MergeFullStackWith(c->label_state, *__ cache_state());
+         __ emit_jump(c->label.get());
+       }
+-      // Merge the else state into the end state.
++      // Merge the else state into the end state. Set this state as the current
++      // state first so helper functions know which registers are in use.
+       __ bind(c->else_state->label.get());
+-      __ MergeFullStackWith(c->label_state, c->else_state->state);
++      __ cache_state()->Steal(c->else_state->state);
++      __ MergeFullStackWith(c->label_state, *__ cache_state());
+       __ cache_state()->Steal(c->label_state);
+     } else if (c->reachable()) {
+       // No merge yet at the end of the if, but we need to create a merge for
+@@ -1465,9 +1467,11 @@
+                                c->stack_depth + c->num_exceptions);
+       __ MergeFullStackWith(c->label_state, *__ cache_state());
+       __ emit_jump(c->label.get());
+-      // Merge the else state into the end state.
++      // Merge the else state into the end state. Set this state as the current
++      // state first so helper functions know which registers are in use.
+       __ bind(c->else_state->label.get());
+-      __ MergeFullStackWith(c->label_state, c->else_state->state);
++      __ cache_state()->Steal(c->else_state->state);
++      __ MergeFullStackWith(c->label_state, *__ cache_state());
+       __ cache_state()->Steal(c->label_state);
+     } else {
+       // No merge needed, just continue with the else state.


### PR DESCRIPTION
[wasm][liftoff] Fix a register reuse corner case

Fixed: chromium:1366399
(cherry picked from commit 6c214db445827707d65be08d177c9a4257a03a7b)

Change-Id: I72cf30cbd31a21acb44b524a194acfb89d8fecbc
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3925795
Reviewed-by: Matthias Liedtke <mliedtke@chromium.org>
Cr-Commit-Position: refs/branch-heads/10.6@{#29}
Cr-Branched-From: 41bc7435693fbce8ef86753cd9239e30550a3e2d-refs/heads/10.6.194@{#1}
Cr-Branched-From: d5f29b929ce7746409201d77f44048f3e9529b40-refs/heads/main@{#82548}


Ref electron/security#225

Notes: Security: backported fix for CVE-2022-3373.