### PR TITLE
docs: update bluetooth fiddle example event name to trigger correct event

### DIFF
--- a/docs/fiddles/features/web-bluetooth/preload.js
+++ b/docs/fiddles/features/web-bluetooth/preload.js
@@ -2,5 +2,5 @@ const { contextBridge, ipcRenderer } = require('electron')
 
 contextBridge.exposeInMainWorld('electronAPI', {
   bluetoothPairingRequest: (callback) => ipcRenderer.on('bluetooth-pairing-request', callback),
-  bluetoothPairingResponse: (response) => ipcRenderer.send('bluetooth-pairing-respnse', response)
+  bluetoothPairingResponse: (response) => ipcRenderer.send('bluetooth-pairing-response', response)
 })


### PR DESCRIPTION
#### Description of Change
Fix the spelling of the event name in the bluetooth example fiddle `preload.js` file so that the correct event get triggered. 
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] relevant documentation is changed or added
(https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed spelling in bluetooth example documentation