### PR TITLE
fix: only override valid electron module names

### DIFF
--- a/lib/common/reset-search-paths.ts
+++ b/lib/common/reset-search-paths.ts
@@ -52,8 +52,9 @@ if (process.type === 'renderer') {
 }
 
 const originalResolveFilename = Module._resolveFilename;
+const electronModuleNames = new Set(['electron', 'electron/main', 'electron/renderer', 'electron/common']);
 Module._resolveFilename = function (request: string, parent: NodeModule, isMain: boolean, options?: { paths: Array<string>}) {
-  if (request === 'electron' || request.startsWith('electron/')) {
+  if (electronModuleNames.has(request)) {
     return 'electron';
   } else {
     return originalResolveFilename(request, parent, isMain, options);


### PR DESCRIPTION
Fixes #33014

Notes: Doing `require('electron/*')` where `*` is not one of `main`, `common` or `renderer` no longer resolves with the built-in `electron` module
