### PR TITLE
fix: override `content::ContentMainDelegate::CreateContentClient()`

### DIFF
--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -439,7 +439,6 @@ base::StringPiece ElectronMainDelegate::GetBrowserV8SnapshotFilename() {
 
 content::ContentClient* ElectronMainDelegate::CreateContentClient() {
   content_client_ = std::make_unique<ElectronContentClient>();
-  SetContentClient(content_client_.get());
   return content_client_.get();
 }
 

--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -317,9 +317,6 @@ absl::optional<int> ElectronMainDelegate::BasicStartupComplete() {
       ::switches::kDisableGpuMemoryBufferCompositorResources);
 #endif
 
-  content_client_ = std::make_unique<ElectronContentClient>();
-  SetContentClient(content_client_.get());
-
   return absl::nullopt;
 }
 
@@ -438,6 +435,12 @@ base::StringPiece ElectronMainDelegate::GetBrowserV8SnapshotFilename() {
     return "browser_v8_context_snapshot.bin";
   }
   return ContentMainDelegate::GetBrowserV8SnapshotFilename();
+}
+
+content::ContentClient* ElectronMainDelegate::CreateContentClient() {
+  content_client_ = std::make_unique<ElectronContentClient>();
+  SetContentClient(content_client_.get());
+  return content_client_.get();
 }
 
 content::ContentBrowserClient*

--- a/shell/app/electron_main_delegate.h
+++ b/shell/app/electron_main_delegate.h
@@ -38,6 +38,7 @@ class ElectronMainDelegate : public content::ContentMainDelegate {
   void PreSandboxStartup() override;
   void SandboxInitialized(const std::string& process_type) override;
   absl::optional<int> PreBrowserMain() override;
+  content::ContentClient* CreateContentClient() override;
   content::ContentBrowserClient* CreateContentBrowserClient() override;
   content::ContentGpuClient* CreateContentGpuClient() override;
   content::ContentRendererClient* CreateContentRendererClient() override;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/35916.

Overrides `content::ContentMainDelegate::CreateContentClient()` to prevent duplicate creation. The previous code was added in Electron's infancy, and the override did not become available until 2019, which is why this hasn't yet been changed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a potential memory leak.
