### PR TITLE
docs: remove pywin32 mention in Windows build instructions

### DIFF
--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -116,10 +116,6 @@ $ git config --system core.longpaths true
 
 This can happen during build, when Debugging Tools for Windows has been installed with Windows Driver Kit. Uninstall Windows Driver Kit and install Debugging Tools with steps described above.
 
-### ImportError: No module named win32file
-
-Make sure you have installed `pywin32` with `pip install pywin32`.
-
 ### Build Scripts Hang Until Keypress
 
 This bug is a "feature" of Windows' command prompt. It happens when clicking inside the prompt window with


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

`pywin32` was removed from the build instructions in #33402 but this reference in the troubleshooting section was missed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
