### PR TITLE
fix: add missing #include "base/cxx17_backports.h"

### DIFF
--- a/shell/browser/ui/autofill_popup.cc
+++ b/shell/browser/ui/autofill_popup.cc
@@ -6,6 +6,7 @@
 #include <memory>
 #include <vector>
 
+#include "base/cxx17_backports.h"
 #include "base/feature_list.h"
 #include "base/i18n/rtl.h"
 #include "components/autofill/core/common/autofill_features.h"


### PR DESCRIPTION
#### Description of Change
```
FAILED: obj/electron/electron_lib/autofill_popup.obj 
D:\a\_work\1\b\build-tools\third_party\goma\gomacc.exe ..\..\third_party\llvm-build\Release+Asserts\bin\clang-cl.exe /c ../../electron/shell/browser/ui/autofill_popup.cc /Foobj/electron/electron_lib/autofill_popup.obj /nologo /showIncludes:user "-imsvcC:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30133\ATLMFC\include" "-imsvcC:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30133\include" "-imsvcC:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\include\um" "-imsvcC:\Program Files (x86)\Windows Kits\10\include\10.0.20348.0\ucrt" "-imsvcC:\Program Files (x86)\Windows Kits\10\include\10.0.20348.0\shared" "-imsvcC:\Program Files (x86)\Windows Kits\10\include\10.0.20348.0\um" "-imsvcC:\Program Files (x86)\Windows Kits\10\include\10.0.20348.0\winrt" "-imsvcC:\Program Files (x86)\Windows Kits\10\include\10.0.20348.0\cppwinrt" -DV8_DEPRECATION_WARNINGS -DALLOW_RUNTIME_CONFIGURABLE_KEY_STORAGE "-DMICROSOFT_BUILD_VERSION_STRING=\"0\"" -DDCHECK_ALWAYS_ON=1 -DUSE_AURA=1 -D_HAS_NODISCARD -D_CRT_NONSTDC_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS "-DCR_CLANG_REVISION=\"llvmorg-16-init-5189-gbfcd536a-1\"" -D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS -DCR_LIBCXX_REVISION=71619e734caf944bdc576a70c5ca4830e2723830 -D__STD_C -D_CRT_RAND_S -D_CRT_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_DEPRECATE -D_ATL_NO_OPENGL -D_WINDOWS -DCERT_CHAIN_PARA_HAS_EXTRA_FIELDS -DPSAPI_VERSION=2 -DWIN32 -D_SECURE_ATL -DWINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP -DWIN32_LEAN_AND_MEAN -DNOMINMAX -D_UNICODE -DUNICODE -DNTDDI_VERSION=NTDDI_WIN10_FE -D_WIN32_WINNT=0x0A00 -DWINVER=0x0A00 -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DV8_USE_EXTERNAL_STARTUP_DATA -DNODE_WANT_INTERNALS=1 "-DELECTRON_PRODUCT_NAME=\"Electron\"" "-DELECTRON_PROJECT_NAME=\"electron\"" -DENABLE_IPC_FUZZER -DLIBYUV_DISABLE_NEON -DWEBP_EXTERN=extern -DUSE_EGL -DVK_USE_PLATFORM_WIN32_KHR -D_WTL_NO_AUTOMATIC_NAMESPACE -DTOOLKIT_VIEWS=1 -DON_FOCUS_PING_ENABLED -DU_USING_ICU_NAMESPACE=0 -DU_ENABLE_DYLOAD=0 -DUSE_CHROMIUM_ICU=1 -DU_ENABLE_TRACING=1 -DU_ENABLE_RESOURCE_TRACING=0 -DU_STATIC_IMPLEMENTATION -DICU_UTIL_DATA_IMPL=ICU_UTIL_DATA_FILE -DCRASHPAD_ZLIB_SOURCE_EXTERNAL -DGOOGLE_PROTOBUF_NO_RTTI -DGOOGLE_PROTOBUF_NO_STATIC_INITIALIZER -DGOOGLE_PROTOBUF_INTERNAL_DONATE_STEAL_INLINE=0 -DSK_CODEC_DECODES_PNG -DSK_CODEC_DECODES_WEBP -DSK_ENCODE_PNG -DSK_ENCODE_WEBP -DSK_ENABLE_SKSL -DSK_UNTIL_CRBUG_1187654_IS_FIXED "-DSK_USER_CONFIG_HEADER=\"../../skia/config/SkUserConfig.h\"" -DSK_WIN_FONTMGR_NO_SIMULATIONS -DSK_GL -DSK_CODEC_DECODES_JPEG -DSK_ENCODE_JPEG -DSK_HAS_WUFFS_LIBRARY -DSK_VULKAN=1 -DSK_DAWN -DSK_SUPPORT_GPU=1 "-DSK_GPU_WORKAROUNDS_HEADER=\"gpu/config/gpu_driver_bug_workaround_autogen.h\"" -DGR_GL_FUNCTION_TYPE=__stdcall -DUSE_V8_CONTEXT_SNAPSHOT "-DV8_CONTEXT_SNAPSHOT_FILENAME=\"v8_context_snapshot.bin\"" -DWEBRTC_ENABLE_AVX2 -DRTC_ENABLE_WIN_WGC -DWEBRTC_NON_STATIC_TRACE_EVENT_HANDLERS=0 -DWEBRTC_CHROMIUM_BUILD -DWEBRTC_WIN -DABSL_ALLOCATOR_NOTHROW=1 -DWEBRTC_USE_BUILTIN_ISAC_FIX=0 -DWEBRTC_USE_BUILTIN_ISAC_FLOAT=1 -DLOGGING_INSIDE_WEBRTC -DLEVELDB_PLATFORM_CHROMIUM=1 -DV8_COMPRESS_POINTERS -DV8_COMPRESS_POINTERS_IN_SHARED_CAGE -DV8_31BIT_SMIS_ON_64BIT_ARCH -DV8_ENABLE_SANDBOX -DCPPGC_CAGED_HEAP -DCPPGC_YOUNG_GENERATION -DCPPGC_POINTER_COMPRESSION "-DOPENSCREEN_TEST_DATA_DIR=\"third_party/openscreen/src/test/data/\"" -DLIBGAV1_MAX_BITDEPTH=10 -DLIBGAV1_THREADPOOL_USE_STD_MUTEX -DLIBGAV1_ENABLE_LOGGING=0 -DLIBGAV1_PUBLIC= -DHAVE_INSPECTOR=1 -DHAVE_OPENSSL=1 -DNODE_HAVE_I18N_SUPPORT=1 -DNODE_USE_V8_PLATFORM=0 -DFLATBUFFERS_LOCALE_INDEPENDENT=0 -I../../electron -Igen/electron -I../../third_party/blink/renderer -I../.. -Igen -I../../buildtools/third_party/libc++ -I../../third_party/perfetto/include -Igen/third_party/perfetto/build_config -Igen/third_party/perfetto -I../../third_party/libyuv/include -I../../third_party/jsoncpp/source/include -Igen/third_party/dawn/include -I../../third_party/dawn/include -I../../third_party/libwebp/src/src -I../../third_party/khronos -I../../gpu -I../../third_party/vulkan-deps/vulkan-headers/src/include -Igen/third_party/private_membership/src -Igen/third_party/shell-encryption/src -Igen/components/policy/proto -I../../third_party/wtl/include -I../../third_party/abseil-cpp -I../../third_party/boringssl/src/include -I../../third_party/protobuf/src -Igen/protoc_out -I../../third_party/ced/src -I../../third_party/icu/source/common -I../../third_party/icu/source/i18n -I../../third_party/crashpad/crashpad -I../../third_party/crashpad/crashpad/compat/win -I../../third_party/zlib -I../../net/third_party/quiche/overrides -I../../net/third_party/quiche/src/quiche/common/platform/default -I../../net/third_party/quiche/src -Igen/net/third_party/quiche/src -I../../third_party/skia -I../../third_party/wuffs/src/release/c -I../../third_party/vulkan/include -I../../third_party/webrtc_overrides -I../../third_party/webrtc -Igen/third_party/webrtc -I../../third_party/libwebm/source -I../../third_party/mesa_headers -I../../third_party/leveldatabase -I../../third_party/leveldatabase/src -I../../third_party/leveldatabase/src/include -I../../third_party/libaom/source/libaom -I../../v8/include -Igen/v8/include -Igen/third_party/metrics_proto -I../../third_party/re2/src -I../../third_party/openscreen/src -Igen/third_party/openscreen/src -I../../third_party/libgav1/src -I../../third_party/libgav1/src/src -I../../third_party/electron_node/src -I../../third_party/electron_node/deps/uv/include -I../../third_party/flatbuffers/src/include /W4 -Wimplicit-fallthrough -Wextra-semi -Wunreachable-code-aggressive -Wthread-safety /WX -Wno-missing-field-initializers -Wno-unused-parameter -Wloop-analysis -Wno-unneeded-internal-declaration -Wno-nonportable-include-path -Wenum-compare-conditional -Wno-psabi -Wno-ignored-pragma-optimize -Wno-deprecated-builtins -Wno-bitfield-constant-conversion -Wshadow -fno-delete-null-pointer-checks -fno-ident -fcolor-diagnostics -fmerge-all-constants -fcrash-diagnostics-dir=../../tools/clang/crashreports -mllvm -instcombine-lower-dbg-declare=0 /clang:-ffp-contract=off -fcomplete-member-pointers /Gy /FS /bigobj /utf-8 /Zc:twoPhase -ffile-reproducible /Zc:sizedDealloc- /D__WRL_ENABLE_FUNCTION_STATICS__ -fmsc-version=1916 -m64 -msse3 /Brepro -Wno-builtin-macro-redefined -D__DATE__= -D__TIME__= -D__TIMESTAMP__= -ffile-compilation-dir=. -no-canonical-prefixes -ftrivial-auto-var-init=pattern /O1 /Ob2 /Oy- /Zc:inline /Gw /Oi -gcodeview-ghash -gline-tables-only /guard:cf /MT -Xclang -add-plugin -Xclang find-bad-constructs -Xclang -plugin-arg-find-bad-constructs -Xclang raw-ref-template-as-trivial-member -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare -Wno-null-pointer-subtraction -DPROTOBUF_ALLOW_DEPRECATED=1 -Wno-microsoft-include /std:c++17 -Wno-trigraphs /TP /GR- -I../../buildtools/third_party/libc++/trunk/include -Wno-deprecated-declarations /Fd"obj/electron/electron_lib_cc.pdb"
../../electron/shell/browser/ui/autofill_popup.cc(44,7): error: no member named 'clamp' in namespace 'base'; did you mean 'base::ranges::clamp'?
      base::clamp(element_bounds.x() + (element_bounds.size().width() / 2),
      ^~~~~~~~~~~
      base::ranges::clamp
../..\base/ranges/algorithm.h(4797,20): note: 'base::ranges::clamp' declared here
constexpr const T& clamp(const T& v,
                   ^
../../electron/shell/browser/ui/autofill_popup.cc(85,28): error: no member named 'clamp' in namespace 'base'; did you mean 'base::ranges::clamp'?
  int right_growth_start = base::clamp(
                           ^~~~~~~~~~~
                           base::ranges::clamp
../..\base/ranges/algorithm.h(4797,20): note: 'base::ranges::clamp' declared here
constexpr const T& clamp(const T& v,
                   ^
../../electron/shell/browser/ui/autofill_popup.cc(88,7): error: no member named 'clamp' in namespace 'base'; did you mean 'base::ranges::clamp'?
      base::clamp(element_bounds.right(), content_area_bounds.x(),
      ^~~~~~~~~~~
      base::ranges::clamp
../..\base/ranges/algorithm.h(4797,20): note: 'base::ranges::clamp' declared here
constexpr const T& clamp(const T& v,
                   ^
../../electron/shell/browser/ui/autofill_popup.cc(118,24): error: no member named 'clamp' in namespace 'base'; did you mean 'base::ranges::clamp'?
  int top_growth_end = base::clamp(element_bounds.y(), content_area_bounds.y(),
                       ^~~~~~~~~~~
                       base::ranges::clamp
../..\base/ranges/algorithm.h(4797,20): note: 'base::ranges::clamp' declared here
constexpr const T& clamp(const T& v,
                   ^
```

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
