### PR TITLE
chore: remove WebKit leftovers after it was renamed to Blink

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -951,7 +951,6 @@ step-minimize-workspace-size-from-checkout: &step-minimize-workspace-size-from-c
       rm -rf src/ios/chrome
       rm -rf src/third_party/blink/web_tests
       rm -rf src/third_party/blink/perf_tests
-      rm -rf src/third_party/WebKit/LayoutTests
       rm -rf third_party/electron_node/deps/openssl
       rm -rf third_party/electron_node/deps/v8
       rm -rf chrome/test/data/xr/webvr_info

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -149,7 +149,7 @@ for:
         if ($env:SAVE_GCLIENT_SRC -eq 'true') {
           # archive current source for future use 
           # only run on x64/woa to avoid contention saving
-          $(7z a $zipfile src -xr!android_webview -xr!electron -xr'!*\.git' -xr!third_party\WebKit\LayoutTests! -xr!third_party\blink\web_tests -xr!third_party\blink\perf_tests -slp -t7z -mmt=30)
+          $(7z a $zipfile src -xr!android_webview -xr!electron -xr'!*\.git' -xr!third_party\blink\web_tests -xr!third_party\blink\perf_tests -slp -t7z -mmt=30)
           if ($LASTEXITCODE -ne 0) {
             Write-warning "Could not save source to shared drive; continuing anyway"
           }

--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -146,7 +146,7 @@ $ ninja -C out/Release electron
 ```
 
 This will build all of what was previously 'libchromiumcontent' (i.e. the
-`content/` directory of `chromium` and its dependencies, incl. WebKit and V8),
+`content/` directory of `chromium` and its dependencies, incl. Blink and V8),
 so it will take a while.
 
 The built executable will be under `./out/Testing`:

--- a/shell/renderer/api/electron_api_spell_check_client.cc
+++ b/shell/renderer/api/electron_api_spell_check_client.cc
@@ -64,7 +64,7 @@ class SpellCheckClient::SpellcheckRequest {
  private:
   std::u16string text_;          // Text to be checked in this task.
   std::vector<Word> word_list_;  // List of Words found in text
-  // The interface to send the misspelled ranges to WebKit.
+  // The interface to send the misspelled ranges to Blink.
   std::unique_ptr<blink::WebTextCheckingCompletion> completion_;
 };
 

--- a/shell/renderer/api/electron_api_spell_check_client.h
+++ b/shell/renderer/api/electron_api_spell_check_client.h
@@ -89,7 +89,7 @@ class SpellCheckClient : public blink::WebSpellCheckPanelHostClient,
   SpellcheckCharAttribute character_attributes_;
 
   // Represents word iterators used in this spellchecker. The |text_iterator_|
-  // splits text provided by WebKit into words, contractions, or concatenated
+  // splits text provided by Blink into words, contractions, or concatenated
   // words. The |contraction_iterator_| splits a concatenated word extracted by
   // |text_iterator_| into word components so we can treat a concatenated word
   // consisting only of correct words as a correct word.
@@ -97,7 +97,7 @@ class SpellCheckClient : public blink::WebSpellCheckPanelHostClient,
   SpellcheckWordIterator contraction_iterator_;
 
   // The parameters of a pending background-spellchecking request.
-  // (When WebKit sends two or more requests, we cancel the previous
+  // (When Blink sends two or more requests, we cancel the previous
   // requests so we do not have to use vectors.)
   std::unique_ptr<SpellcheckRequest> pending_request_param_;
 

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -341,7 +341,7 @@ describe('node feature', () => {
   describe('Buffer', () => {
     useRemoteContext();
 
-    itremote('can be created from WebKit external string', () => {
+    itremote('can be created from Blink external string', () => {
       const p = document.createElement('p');
       p.innerText = '闲云潭影日悠悠，物换星移几度秋';
       const b = Buffer.from(p.innerText);


### PR DESCRIPTION
#### Description of Change
Also `third_party/WebKit/LayoutTests` no longer exists

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
