### PR TITLE
chore: cherry-pick 30a32e6 from chromium (#35370)

### DIFF
--- a/shell/browser/ui/views/win_caption_button.cc
+++ b/shell/browser/ui/views/win_caption_button.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Modified from chrome/browser/ui/views/frame/windows_10_caption_button.cc
+// Modified from chrome/browser/ui/views/frame/windows_caption_button.cc
 
 #include "shell/browser/ui/views/win_caption_button.h"
 

--- a/shell/browser/ui/views/win_icon_painter.cc
+++ b/shell/browser/ui/views/win_icon_painter.cc
@@ -25,7 +25,7 @@ void DrawRect(gfx::Canvas* canvas,
 
 void DrawRoundRect(gfx::Canvas* canvas,
                    const gfx::Rect& rect,
-                   int radius,
+                   float radius,
                    const cc::PaintFlags& flags) {
   gfx::RectF rect_f(rect);
   float stroke_half_width = flags.getStrokeWidth() / 2;
@@ -74,7 +74,7 @@ void WinIconPainter::PaintMaximizeIcon(gfx::Canvas* canvas,
 void WinIconPainter::PaintRestoreIcon(gfx::Canvas* canvas,
                                       const gfx::Rect& symbol_rect,
                                       const cc::PaintFlags& flags) {
-  const int separation = std::floor(2 * canvas->image_scale());
+  const int separation = base::ClampFloor(2 * canvas->image_scale());
   gfx::Rect icon_rect = symbol_rect;
   icon_rect.Inset(gfx::Insets::TLBR(separation, 0, 0, separation));
 
@@ -113,14 +113,14 @@ void Win11IconPainter::PaintMaximizeIcon(gfx::Canvas* canvas,
   cc::PaintFlags paint_flags = flags;
   paint_flags.setAntiAlias(true);
 
-  const float corner_radius = 2 * canvas->image_scale();
+  const float corner_radius = canvas->image_scale();
   DrawRoundRect(canvas, symbol_rect, corner_radius, flags);
 }
 
 void Win11IconPainter::PaintRestoreIcon(gfx::Canvas* canvas,
                                         const gfx::Rect& symbol_rect,
                                         const cc::PaintFlags& flags) {
-  const int separation = std::floor(2 * canvas->image_scale());
+  const int separation = base::ClampFloor(2 * canvas->image_scale());
   gfx::Rect icon_rect = symbol_rect;
   icon_rect.Inset(gfx::Insets::TLBR(separation, 0, 0, separation));
 
@@ -128,14 +128,11 @@ void Win11IconPainter::PaintRestoreIcon(gfx::Canvas* canvas,
   paint_flags.setAntiAlias(true);
 
   // Bottom left ("in front") rounded square.
-  const float bottom_rect_radius = 1 * canvas->image_scale();
+  const float bottom_rect_radius = canvas->image_scale();
   DrawRoundRect(canvas, icon_rect, bottom_rect_radius, flags);
 
   // Top right ("behind") top+right edges of rounded square (2.5x).
   icon_rect.Offset(separation, -separation);
-  // Apply inset to left+bottom edges since we don't draw arcs for those edges
-  constexpr int top_rect_inset = 1;
-  icon_rect.Inset(gfx::Insets::TLBR(0, top_rect_inset, top_rect_inset, 0));
 
   const float top_rect_radius = 2.5f * canvas->image_scale();
   DrawRoundRectEdges(canvas, icon_rect, top_rect_radius, flags);


### PR DESCRIPTION
#### Description of Change

Resolves #35938
Backport of https://github.com/electron/electron/pull/35370.

CC @deepak1556

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Modified the Windows 11 WCO to match the native look more closely.
