### PR TITLE
fix: `webContents.printToPDF` option plumbing

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -174,13 +174,13 @@ WebContents.prototype.printToPDF = async function (options) {
     headerTemplate: '',
     footerTemplate: '',
     printBackground: false,
-    scale: 1,
+    scale: 1.0,
     paperWidth: 8.5,
-    paperHeight: 11,
-    marginTop: 0,
-    marginBottom: 0,
-    marginLeft: 0,
-    marginRight: 0,
+    paperHeight: 11.0,
+    marginTop: 0.0,
+    marginBottom: 0.0,
+    marginLeft: 0.0,
+    marginRight: 0.0,
     pageRanges: '',
     preferCSSPageSize: false
   };
@@ -210,7 +210,7 @@ WebContents.prototype.printToPDF = async function (options) {
     if (typeof options.scale !== 'number') {
       return Promise.reject(new Error('scale must be a Number'));
     }
-    printSettings.scaleFactor = options.scale;
+    printSettings.scale = options.scale;
   }
 
   const { pageSize } = options;

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2857,12 +2857,12 @@ v8::Local<v8::Promise> WebContents::PrintToPDF(const base::Value& settings) {
       settings.GetDict().FindBool("displayHeaderFooter");
   auto print_background = settings.GetDict().FindBool("shouldPrintBackgrounds");
   auto scale = settings.GetDict().FindDouble("scale");
-  auto paper_width = settings.GetDict().FindInt("paperWidth");
-  auto paper_height = settings.GetDict().FindInt("paperHeight");
-  auto margin_top = settings.GetDict().FindIntByDottedPath("margins.top");
-  auto margin_bottom = settings.GetDict().FindIntByDottedPath("margins.bottom");
-  auto margin_left = settings.GetDict().FindIntByDottedPath("margins.left");
-  auto margin_right = settings.GetDict().FindIntByDottedPath("margins.right");
+  auto paper_width = settings.GetDict().FindDouble("paperWidth");
+  auto paper_height = settings.GetDict().FindDouble("paperHeight");
+  auto margin_top = settings.GetDict().FindDouble("marginTop");
+  auto margin_bottom = settings.GetDict().FindDouble("marginBottom");
+  auto margin_left = settings.GetDict().FindDouble("marginLeft");
+  auto margin_right = settings.GetDict().FindDouble("marginRight");
   auto page_ranges = *settings.GetDict().FindString("pageRanges");
   auto header_template = *settings.GetDict().FindString("headerTemplate");
   auto footer_template = *settings.GetDict().FindString("footerTemplate");


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/35971.

Fixes some incorrect options plumbing in `webContents.printToPDF()`

Tested with https://gist.github.com/lesleyandreza/7699603b20f2459d1fcf3b9480fb22e1

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where some options were incorrectly ignored when using `webContents.printToPDF()`.