### PR TITLE
build: fix building with enable_ppapi = false

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -404,9 +404,6 @@ source_set("electron_lib") {
     "//media/mojo/mojom",
     "//net:extras",
     "//net:net_resources",
-    "//ppapi/host",
-    "//ppapi/proxy",
-    "//ppapi/shared_impl",
     "//printing/buildflags",
     "//services/device/public/cpp/geolocation",
     "//services/device/public/cpp/hid",
@@ -622,6 +619,14 @@ source_set("electron_lib") {
     sources += [
       "shell/renderer/pepper_helper.cc",
       "shell/renderer/pepper_helper.h",
+    ]
+  }
+
+  if (enable_ppapi) {
+    deps += [
+      "//ppapi/host",
+      "//ppapi/proxy",
+      "//ppapi/shared_impl",
     ]
   }
 

--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -6,6 +6,7 @@ import("//build/config/ozone.gni")
 import("//build/config/ui.gni")
 import("//components/spellcheck/spellcheck_build_features.gni")
 import("//electron/buildflags/buildflags.gni")
+import("//ppapi/buildflags/buildflags.gni")
 import("//printing/buildflags/buildflags.gni")
 import("//third_party/widevine/cdm/widevine.gni")
 
@@ -372,15 +373,20 @@ source_set("plugins") {
   deps += [
     "//components/strings",
     "//media:media_buildflags",
-    "//ppapi/buildflags",
-    "//ppapi/host",
-    "//ppapi/proxy",
-    "//ppapi/proxy:ipc",
-    "//ppapi/shared_impl",
     "//services/device/public/mojom",
     "//skia",
     "//storage/browser",
   ]
+
+  if (enable_ppapi) {
+    deps += [
+      "//ppapi/buildflags",
+      "//ppapi/host",
+      "//ppapi/proxy",
+      "//ppapi/proxy:ipc",
+      "//ppapi/shared_impl",
+    ]
+  }
 }
 
 # This source set is just so we don't have to depend on all of //chrome/browser


### PR DESCRIPTION
#### Description of Change
Related to https://chromium-review.googlesource.com/c/chromium/src/+/3750107
Without this change we are getting
```
ERROR at //ppapi/proxy/BUILD.gn:9:1: Assertion failed.
assert(enable_ppapi)
^-----
See //electron/chromium_src/BUILD.gn:377:5: which caused the file to be included.
    "//ppapi/proxy",
    ^--------------
```

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
