### PR TITLE
fix: override app's desktop name and v8 flags in default-app

### DIFF
--- a/default_app/main.ts
+++ b/default_app/main.ts
@@ -83,7 +83,7 @@ function loadApplicationPackage (packagePath: string) {
   });
 
   try {
-    // Override app name and version.
+    // Override app's package.json data.
     packagePath = path.resolve(packagePath);
     const packageJsonPath = path.join(packagePath, 'package.json');
     let appPath;
@@ -103,6 +103,16 @@ function loadApplicationPackage (packagePath: string) {
         app.name = packageJson.productName;
       } else if (packageJson.name) {
         app.name = packageJson.name;
+      }
+      if (packageJson.desktopName) {
+        app.setDesktopName(packageJson.desktopName);
+      } else {
+        app.setDesktopName(`${app.name}.desktop`);
+      }
+      // Set v8 flags, deliberately lazy load so that apps that do not use this
+      // feature do not pay the price
+      if (packageJson.v8Flags) {
+        require('v8').setFlagsFromString(packageJson.v8Flags);
       }
       appPath = packagePath;
     }


### PR DESCRIPTION
#### Description of Change
Fixes #35967 (and maybe #34801).
Override app's desktop name and v8 flags when launching local app from default-app.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed v8 flags and desktop name in package.json does not hornored when running local app using electron cli.
