### PR TITLE
test: re-enable <webview> tag DOM events emits resize event

### DIFF
--- a/spec/webview-spec.ts
+++ b/spec/webview-spec.ts
@@ -309,6 +309,7 @@ describe('<webview> tag', function () {
       const [, { runtimeId, tabId }] = await emittedOnce(ipcMain, 'answer');
       expect(runtimeId).to.match(/^[a-z]{32}$/);
       expect(tabId).to.equal(childWebContentsId);
+      await w.webContents.executeJavaScript('webview.closeDevTools()');
     });
   });
 
@@ -1534,6 +1535,7 @@ describe('<webview> tag', function () {
           webview.openDevTools()
           webview.addEventListener('devtools-opened', () => resolve(), {once: true})
         })`);
+        await w.executeJavaScript('webview.closeDevTools()');
       });
     });
 
@@ -1950,60 +1952,40 @@ describe('<webview> tag', function () {
     });
 
     describe('DOM events', () => {
-      /*
-      let div;
-
-      beforeEach(() => {
-        div = document.createElement('div');
-        div.style.width = '100px';
-        div.style.height = '10px';
-        div.style.overflow = 'hidden';
-        webview.style.height = '100%';
-        webview.style.width = '100%';
-      });
-
-      afterEach(() => {
-        if (div != null) div.remove();
-      });
-      */
-
       for (const [description, sandbox] of [
         ['without sandbox', false] as const,
         ['with sandbox', true] as const
       ]) {
         describe(description, () => {
-        // TODO(nornagon): disabled during chromium roll 2019-06-11 due to a
-        // 'ResizeObserver loop limit exceeded' error on Windows
-        /*
-          xit('emits resize events', async () => {
-            const firstResizeSignal = waitForEvent(webview, 'resize');
-            const domReadySignal = waitForEvent(webview, 'dom-ready');
+          it('emits resize events', async () => {
+            await loadWebViewAndWaitForEvent(w, {
+              src: `file://${fixtures}/pages/a.html`,
+              webpreferences: `sandbox=${sandbox ? 'yes' : 'no'}`
+            }, 'dom-ready');
 
-            webview.src = `file://${fixtures}/pages/a.html`;
-            webview.webpreferences = `sandbox=${sandbox ? 'yes' : 'no'}`;
-            div.appendChild(webview);
-            document.body.appendChild(div);
+            const firstResizeSignal = w.executeJavaScript(`new Promise((resolve, reject) => {
+              webview.addEventListener('resize', (e) => resolve({...e}), {once: true})
+            })`);
+
+            const insertedCSS = await w.insertCSS('webview { width: 100px; height: 10px; }');
 
             const firstResizeEvent = await firstResizeSignal;
-            expect(firstResizeEvent.target).to.equal(webview);
             expect(firstResizeEvent.newWidth).to.equal(100);
             expect(firstResizeEvent.newHeight).to.equal(10);
 
-            await domReadySignal;
+            await w.removeInsertedCSS(insertedCSS);
 
-            const secondResizeSignal = waitForEvent(webview, 'resize');
+            const secondResizeSignal = w.executeJavaScript(`new Promise((resolve, reject) => {
+              webview.addEventListener('resize', (e) => resolve({...e}), {once: true})
+            })`);
 
             const newWidth = 1234;
             const newHeight = 789;
-            div.style.width = `${newWidth}px`;
-            div.style.height = `${newHeight}px`;
-
+            await w.insertCSS(`webview { width: ${newWidth}px; height: ${newHeight}px; }`);
             const secondResizeEvent = await secondResizeSignal;
-            expect(secondResizeEvent.target).to.equal(webview);
             expect(secondResizeEvent.newWidth).to.equal(newWidth);
             expect(secondResizeEvent.newHeight).to.equal(newHeight);
           });
-          */
 
           it('emits focus event', async () => {
             await loadWebViewAndWaitForEvent(w, {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
This PR re-enables the <webview> tag DOM events emits resize event test.

- Resolves #19086

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
