### PR TITLE
docs: update VS Code debugger types to remove "pwa-" prefix

### DIFF
--- a/docs/tutorial/tutorial-2-first-app.md
+++ b/docs/tutorial/tutorial-2-first-app.md
@@ -369,12 +369,12 @@ run. Create a launch.json configuration in a new `.vscode` folder in your projec
       "name": "Renderer",
       "port": 9222,
       "request": "attach",
-      "type": "pwa-chrome",
+      "type": "chrome",
       "webRoot": "${workspaceFolder}"
     },
     {
       "name": "Main",
-      "type": "pwa-node",
+      "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}",
       "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
@@ -398,11 +398,11 @@ What we have done in the `launch.json` file is to create 3 configurations:
 - `Main` is used to start the main process and also expose port 9222 for remote debugging
   (`--remote-debugging-port=9222`). This is the port that we will use to attach the debugger
   for the `Renderer`. Because the main process is a Node.js process, the type is set to
-  `pwa-node` (`pwa-` is the prefix that tells VS Code to use the latest JavaScript debugger).
+  `node`.
 - `Renderer` is used to debug the renderer process. Because the main process is the one
   that creates the process, we have to "attach" to it (`"request": "attach"`) instead of
   creating a new one.
-  The renderer process is a web one, so the debugger we have to use is `pwa-chrome`.
+  The renderer process is a web one, so the debugger we have to use is `chrome`.
 - `Main + renderer` is a [compound task] that executes the previous ones simultaneously.
 
 :::caution


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Usage of `pwa-` prefixes on the debugger types are deprecated, VS Code now tells you to drop the prefix.

<img width="309" alt="Screen Shot 2022-10-16 at 1 48 46 PM" src="https://user-images.githubusercontent.com/5820654/196057589-a46cf1fe-ee24-4259-adb2-dd13d74778e4.png">

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
