### PR TITLE
refactor: migrate from asar to @electron/asar

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Build cross platform desktop apps with JavaScript, HTML, and CSS",
   "devDependencies": {
     "@azure/storage-blob": "^12.9.0",
+    "@electron/asar": "^3.2.1",
     "@electron/docs-parser": "^0.12.4",
     "@electron/typescript-definitions": "^8.9.6",
     "@octokit/auth-app": "^2.10.0",
@@ -31,7 +32,6 @@
     "@types/webpack-env": "^1.17.0",
     "@typescript-eslint/eslint-plugin": "^4.4.1",
     "@typescript-eslint/parser": "^4.4.1",
-    "asar": "^3.1.0",
     "aws-sdk": "^2.814.0",
     "buffer": "^6.0.3",
     "check-for-leaks": "^1.2.1",

--- a/script/gn-asar-hash.js
+++ b/script/gn-asar-hash.js
@@ -1,4 +1,4 @@
-const asar = require('asar');
+const asar = require('@electron/asar');
 const crypto = require('crypto');
 const fs = require('fs');
 

--- a/script/gn-asar.js
+++ b/script/gn-asar.js
@@ -1,4 +1,4 @@
-const asar = require('asar');
+const asar = require('@electron/asar');
 const assert = require('assert');
 const fs = require('fs-extra');
 const os = require('os');

--- a/spec/fixtures/test.asar/repack.js
+++ b/spec/fixtures/test.asar/repack.js
@@ -1,7 +1,7 @@
 // Use this script to regenerate these fixture files
 // using a new version of the asar package
 
-const asar = require('asar');
+const asar = require('@electron/asar');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');

--- a/yarn.lock
+++ b/yarn.lock
@@ -111,6 +111,18 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
+"@electron/asar@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@electron/asar/-/asar-3.2.1.tgz#c4143896f3dd43b59a80a9c9068d76f77efb62ea"
+  integrity sha512-hE2cQMZ5+4o7+6T2lUaVbxIzrOjZZfX7dB02xuapyYFJZEAiWTelq6J3mMoxzd0iONDvYLPVKecB5tyjIoVDVA==
+  dependencies:
+    chromium-pickle-js "^0.2.0"
+    commander "^5.0.0"
+    glob "^7.1.6"
+    minimatch "^3.0.4"
+  optionalDependencies:
+    "@types/glob" "^7.1.1"
+
 "@electron/docs-parser@^0.12.4":
   version "0.12.4"
   resolved "https://registry.yarnpkg.com/@electron/docs-parser/-/docs-parser-0.12.4.tgz#cca403c8c2200181339c3115cdd25f3fbfc7dea3"
@@ -1188,18 +1200,6 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
-
-asar@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/asar/-/asar-3.1.0.tgz#70b0509449fe3daccc63beb4d3c7d2e24d3c6473"
-  integrity sha512-vyxPxP5arcAqN4F/ebHd/HhwnAiZtwhglvdmc7BR2f0ywbVNTOpSeyhLDbGXtE/y58hv1oC75TaNIXutnsOZsQ==
-  dependencies:
-    chromium-pickle-js "^0.2.0"
-    commander "^5.0.0"
-    glob "^7.1.6"
-    minimatch "^3.0.4"
-  optionalDependencies:
-    "@types/glob" "^7.1.1"
 
 assertion-error@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This is a cosmetic change, and future updates to the `asar` package will only be published to `@electron/asar`.

Notes: no-notes