### PR TITLE
refactor: migrate from asar to @electron/asar (#36070)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Build cross platform desktop apps with JavaScript, HTML, and CSS",
   "devDependencies": {
     "@azure/storage-blob": "^12.9.0",
+    "@electron/asar": "^3.2.1",
     "@electron/docs-parser": "^0.12.4",
     "@electron/typescript-definitions": "^8.9.5",
     "@octokit/auth-app": "^2.10.0",
@@ -31,7 +32,6 @@
     "@types/webpack-env": "^1.16.3",
     "@typescript-eslint/eslint-plugin": "^4.4.1",
     "@typescript-eslint/parser": "^4.4.1",
-    "asar": "^3.1.0",
     "aws-sdk": "^2.814.0",
     "check-for-leaks": "^1.2.1",
     "colors": "1.4.0",

--- a/script/gn-asar-hash.js
+++ b/script/gn-asar-hash.js
@@ -1,4 +1,4 @@
-const asar = require('asar');
+const asar = require('@electron/asar');
 const crypto = require('crypto');
 const fs = require('fs');
 

--- a/script/gn-asar.js
+++ b/script/gn-asar.js
@@ -1,4 +1,4 @@
-const asar = require('asar');
+const asar = require('@electron/asar');
 const assert = require('assert');
 const fs = require('fs-extra');
 const os = require('os');

--- a/spec/fixtures/test.asar/repack.js
+++ b/spec/fixtures/test.asar/repack.js
@@ -1,7 +1,7 @@
 // Use this script to regenerate these fixture files
 // using a new version of the asar package
 
-const asar = require('asar');
+const asar = require('@electron/asar');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,6 +106,18 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@electron/asar@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@electron/asar/-/asar-3.2.1.tgz#c4143896f3dd43b59a80a9c9068d76f77efb62ea"
+  integrity sha512-hE2cQMZ5+4o7+6T2lUaVbxIzrOjZZfX7dB02xuapyYFJZEAiWTelq6J3mMoxzd0iONDvYLPVKecB5tyjIoVDVA==
+  dependencies:
+    chromium-pickle-js "^0.2.0"
+    commander "^5.0.0"
+    glob "^7.1.6"
+    minimatch "^3.0.4"
+  optionalDependencies:
+    "@types/glob" "^7.1.1"
+
 "@electron/docs-parser@^0.12.4":
   version "0.12.4"
   resolved "https://registry.yarnpkg.com/@electron/docs-parser/-/docs-parser-0.12.4.tgz#cca403c8c2200181339c3115cdd25f3fbfc7dea3"
@@ -1207,18 +1219,6 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
-
-asar@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/asar/-/asar-3.1.0.tgz#70b0509449fe3daccc63beb4d3c7d2e24d3c6473"
-  integrity sha512-vyxPxP5arcAqN4F/ebHd/HhwnAiZtwhglvdmc7BR2f0ywbVNTOpSeyhLDbGXtE/y58hv1oC75TaNIXutnsOZsQ==
-  dependencies:
-    chromium-pickle-js "^0.2.0"
-    commander "^5.0.0"
-    glob "^7.1.6"
-    minimatch "^3.0.4"
-  optionalDependencies:
-    "@types/glob" "^7.1.1"
 
 asn1.js@^4.0.0:
   version "4.10.1"


### PR DESCRIPTION
Backport of #36070 

See that PR for details.

* refactor: migrate from asar to @electron/asar

* fix: update asar require calls

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
