### PR TITLE
fix: add pinning for timeout never notifications and xml printing for debugging

### DIFF
--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -17,6 +17,7 @@
 #include "shell/common/gin_helper/cleaned_up_at_exit.h"
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/error_thrower.h"
+#include "shell/common/gin_helper/pinnable.h"
 #include "ui/gfx/image/image.h"
 
 namespace gin {
@@ -28,6 +29,7 @@ class Handle;
 namespace electron::api {
 
 class Notification : public gin::Wrappable<Notification>,
+                     public gin_helper::Pinnable<Notification>,
                      public gin_helper::EventEmitterMixin<Notification>,
                      public gin_helper::Constructible<Notification>,
                      public gin_helper::CleanedUpAtExit,

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -15,6 +15,7 @@
 #include "base/logging.h"
 #include "base/strings/string_util_win.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/win/scoped_hstring.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "shell/browser/notifications/notification_delegate.h"
@@ -31,6 +32,7 @@ using ABI::Windows::Data::Xml::Dom::IXmlElement;
 using ABI::Windows::Data::Xml::Dom::IXmlNamedNodeMap;
 using ABI::Windows::Data::Xml::Dom::IXmlNode;
 using ABI::Windows::Data::Xml::Dom::IXmlNodeList;
+using ABI::Windows::Data::Xml::Dom::IXmlNodeSerializer;
 using ABI::Windows::Data::Xml::Dom::IXmlText;
 using Microsoft::WRL::Wrappers::HStringReference;
 
@@ -232,6 +234,18 @@ HRESULT WindowsToastNotification::GetToastXml(
   }
 
   return S_OK;
+}
+
+std::string WindowsToastNotification::XmlStringFromDocument(IXmlDocument* doc) {
+  ComPtr<IXmlNodeSerializer> ser;
+  ComPtr<IXmlElement> doc_elem;
+  doc->get_DocumentElement(&doc_elem);
+  doc_elem.As<IXmlNodeSerializer>(&ser);
+  HSTRING result_xml;
+  ser->GetXml(&result_xml);
+  base::win::ScopedHString result_string(result_xml);
+
+  return result_string.GetAsUTF8();
 }
 
 HRESULT WindowsToastNotification::SetXmlScenarioReminder(IXmlDocument* doc) {

--- a/shell/browser/notifications/win/windows_toast_notification.h
+++ b/shell/browser/notifications/win/windows_toast_notification.h
@@ -88,6 +88,8 @@ class WindowsToastNotification : public Notification {
   HRESULT XmlDocumentFromString(
       const wchar_t* xmlString,
       ABI::Windows::Data::Xml::Dom::IXmlDocument** doc);
+  std::string XmlStringFromDocument(
+      ABI::Windows::Data::Xml::Dom::IXmlDocument* doc);
   HRESULT SetupCallbacks(
       ABI::Windows::UI::Notifications::IToastNotification* toast);
   bool RemoveCallbacks(


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Closes https://github.com/electron/electron/issues/32923

Previously when a notification with `timeoutTyoe='never'` was created, it would be garbage collected after 6 seconds. As a result, though the notification remains on screen, interactions such as clicks would not be registered. With this PR, the notification is pinned until an interaction occurs so that it is not garbage collected.

An additional debugging function was added to print the XML of toast notifications.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> Fixed an issue where Windows notifications with timeoutType 'never' stopped responding to clicks