### PR TITLE
test: exit properly when `node-spec-runner` validates specs

### DIFF
--- a/script/node-spec-runner.js
+++ b/script/node-spec-runner.js
@@ -67,6 +67,8 @@ async function main () {
       console.error(`Found ${missing.length} missing disabled specs: \n${missing.join('\n')}`);
       process.exit(1);
     }
+
+    process.exit(0);
   }
 
   const options = args.default ? defaultOptions : getCustomOptions();


### PR DESCRIPTION
#### Description of Change

Exit properly if `node script/node-spec-runner --validateDisabled` finds no missing tests.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none