### PR TITLE
test: disable failing linux arm/arm64 crash test case

### DIFF
--- a/spec/crash-spec.ts
+++ b/spec/crash-spec.ts
@@ -31,6 +31,22 @@ const runFixtureAndEnsureCleanExit = (args: string[]) => {
   });
 };
 
+const shouldRunCase = (crashCase: string) => {
+  switch (crashCase) {
+    // TODO(jkleinsc) fix this flaky test on Windows 32-bit
+    case 'quit-on-crashed-event': {
+      return (process.platform !== 'win32' || process.arch !== 'ia32');
+    }
+    // TODO(jkleinsc) fix this test on Linux on arm/arm64
+    case 'js-execute-iframe': {
+      return (process.platform !== 'linux' || (process.arch !== 'arm64' && process.arch !== 'arm'));
+    }
+    default: {
+      return true;
+    }
+  }
+};
+
 describe('crash cases', () => {
   afterEach(() => {
     for (const child of children) {
@@ -42,8 +58,7 @@ describe('crash cases', () => {
   const cases = fs.readdirSync(fixturePath);
 
   for (const crashCase of cases) {
-    // TODO(jkleinsc) fix this flaky test on Windows 32-bit
-    ifit(process.platform !== 'win32' || process.arch !== 'ia32' || crashCase !== 'quit-on-crashed-event')(`the "${crashCase}" case should not crash`, () => {
+    ifit(shouldRunCase(crashCase))(`the "${crashCase}" case should not crash`, () => {
       const fixture = path.resolve(fixturePath, crashCase);
       const argsFile = path.resolve(fixture, 'electron.args');
       const args = [fixture];


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
- As stated in #36093, the test crash case "js-execute-iframe" is failing on Linux on arm/arm64.  This appears to be an issue with the CI machines because it is happening across all the branches, so for now we should disable this test until #36093 is resolved.
- 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
