### PR TITLE
docs: document that when `invoke` rejects, it gives a different Error

### DIFF
--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -96,14 +96,6 @@ Algorithm][SCA], just like [`window.postMessage`][], so prototype chains will no
 included. Sending Functions, Promises, Symbols, WeakMaps, or WeakSets will
 throw an exception.
 
-> **NOTE:** Sending non-standard JavaScript types such as DOM objects or
-> special Electron objects will throw an exception.
->
-> Since the main process does not have support for DOM objects such as
-> `ImageBitmap`, `File`, `DOMMatrix` and so on, such objects cannot be sent over
-> Electron's IPC to the main process, as the main process would have no way to decode
-> them. Attempting to send such objects over IPC will result in an error.
-
 The main process should listen for `channel` with
 [`ipcMain.handle()`](./ipc-main.md#ipcmainhandlechannel-listener).
 
@@ -125,6 +117,21 @@ ipcMain.handle('some-name', async (event, someArgument) => {
 If you need to transfer a [`MessagePort`][] to the main process, use [`ipcRenderer.postMessage`](#ipcrendererpostmessagechannel-message-transfer).
 
 If you do not need a response to the message, consider using [`ipcRenderer.send`](#ipcrenderersendchannel-args).
+
+> **Note**
+> Sending non-standard JavaScript types such as DOM objects or
+> special Electron objects will throw an exception.
+>
+> Since the main process does not have support for DOM objects such as
+> `ImageBitmap`, `File`, `DOMMatrix` and so on, such objects cannot be sent over
+> Electron's IPC to the main process, as the main process would have no way to decode
+> them. Attempting to send such objects over IPC will result in an error.
+
+> **Note**
+> If the handler in the main process throws an error,
+> the promise returned by `invoke` will reject.
+> However, the `Error` object in the renderer process
+> will not be the same as the one thrown in the main process.
 
 ### `ipcRenderer.sendSync(channel, ...args)`
 


### PR DESCRIPTION
#### Description of Change
Closes #24427.

I don't think we want to change the serialization behavior of `Error` here, but enough people have tripped over this that it deserves a mention in the docs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added

#### Release Notes

Notes: none