### PR TITLE
build: ensure get-version runs in the electron git checkout

### DIFF
--- a/script/lib/get-version.js
+++ b/script/lib/get-version.js
@@ -1,5 +1,5 @@
 const { spawnSync } = require('child_process');
-const rootPackageJson = require('../../package.json');
+const path = require('path');
 
 module.exports.getElectronVersion = () => {
   // Find the nearest tag to the current HEAD
@@ -11,7 +11,9 @@ module.exports.getElectronVersion = () => {
   // The only difference in the "git describe" technique is that technically a commit can "change" it's version
   // number if a tag is created / removed retroactively.  i.e. the first time a commit is pushed it will be 1.2.3
   // and after the tag is made rebuilding the same commit will result in it being 1.2.4
-  const output = spawnSync('git', ['describe', '--tags', '--abbrev=0']);
+  const output = spawnSync('git', ['describe', '--tags', '--abbrev=0'], {
+    cwd: path.resolve(__dirname, '..', '..')
+  });
   if (output.status !== 0) {
     console.error(output.stderr);
     throw new Error('Failed to get current electron version');


### PR DESCRIPTION
This might fix the nightly release, shot in the dark

Notes: no-notes