### PR TITLE
build: prefix version in uploader script

### DIFF
--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -23,7 +23,7 @@ from lib.util import get_electron_branding, execute, get_electron_version, \
                      SRC_DIR, ELECTRON_DIR, TS_NODE
 
 
-ELECTRON_VERSION = get_electron_version()
+ELECTRON_VERSION = 'v' + get_electron_version()
 
 PROJECT_NAME = get_electron_branding()['project_name']
 PRODUCT_NAME = get_electron_branding()['product_name']


### PR DESCRIPTION
#### Description of Change

In a previous PR, we removed the "v" prefix from Electron version, as there were several areas in the code that weren't expecting it. However, the upload script still expects a prefix. This PR re-adds the prefix to the upload script.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
