### PR TITLE
build: use npm@7 for npm view command

### DIFF
--- a/script/release/publish-to-npm.js
+++ b/script/release/publish-to-npm.js
@@ -194,7 +194,7 @@ new Promise((resolve, reject) => {
     });
   })
   .then((tarballPath) => {
-    const existingVersionJSON = childProcess.execSync(`npm view electron@${currentElectronVersion} --json`).toString('utf-8');
+    const existingVersionJSON = childProcess.execSync(`npx npm@7 view ${rootPackageJson.name}@${currentElectronVersion} --json`).toString('utf-8');
     // It's possible this is a re-run and we already have published the package, if not we just publish like normal
     if (!existingVersionJSON) {
       childProcess.execSync(`npm publish ${tarballPath} --tag ${npmTag} --otp=${process.env.ELECTRON_NPM_OTP}`);


### PR DESCRIPTION
#### Description of Change

Fixes the beta release - use npm@7 explicitly when publishing

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
