### PR TITLE
fix: linker error when enable_ppapi=false

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -676,6 +676,10 @@ source_set("electron_lib") {
       "//ppapi/proxy",
       "//ppapi/shared_impl",
     ]
+    sources += [
+      "shell/renderer/electron_renderer_pepper_host_factory.cc",
+      "shell/renderer/electron_renderer_pepper_host_factory.h",
+    ]
   }
 
   if (enable_run_as_node) {

--- a/filenames.gni
+++ b/filenames.gni
@@ -671,8 +671,6 @@ filenames = {
     "shell/renderer/electron_render_frame_observer.h",
     "shell/renderer/electron_renderer_client.cc",
     "shell/renderer/electron_renderer_client.h",
-    "shell/renderer/electron_renderer_pepper_host_factory.cc",
-    "shell/renderer/electron_renderer_pepper_host_factory.h",
     "shell/renderer/electron_sandboxed_renderer_client.cc",
     "shell/renderer/electron_sandboxed_renderer_client.h",
     "shell/renderer/renderer_client_base.cc",


### PR DESCRIPTION
#### Description of Change
When building electron 21.2.0 on linux with gcc, no LTO and enable_plugins=false enable_ppapi=false, i'm getting a linker error at the very end (missing symbols).
The error does not happen when compiling with LTO, as all the references are in code that is dead when enable_ppapi=false.

This patch fixes the error for me.

#### Release Notes
none