### PR TITLE
build: fix building with enable_plugins = false

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -665,6 +665,8 @@ source_set("electron_lib") {
     sources += [
       "shell/common/plugin_info.cc",
       "shell/common/plugin_info.h",
+      "shell/renderer/electron_renderer_pepper_host_factory.cc",
+      "shell/renderer/electron_renderer_pepper_host_factory.h",
       "shell/renderer/pepper_helper.cc",
       "shell/renderer/pepper_helper.h",
     ]

--- a/filenames.gni
+++ b/filenames.gni
@@ -671,8 +671,6 @@ filenames = {
     "shell/renderer/electron_render_frame_observer.h",
     "shell/renderer/electron_renderer_client.cc",
     "shell/renderer/electron_renderer_client.h",
-    "shell/renderer/electron_renderer_pepper_host_factory.cc",
-    "shell/renderer/electron_renderer_pepper_host_factory.h",
     "shell/renderer/electron_sandboxed_renderer_client.cc",
     "shell/renderer/electron_sandboxed_renderer_client.h",
     "shell/renderer/renderer_client_base.cc",


### PR DESCRIPTION
#### Description of Change
`electron_renderer_pepper_host_factory.h` is referenced by `pepper_helper.cc` and needs to share the same buildflag.
https://github.com/electron/electron/blob/169cf531ba72247552ade73f7107a38b4362eab4/shell/renderer/pepper_helper.cc#L12
https://github.com/electron/electron/blob/169cf531ba72247552ade73f7107a38b4362eab4/shell/renderer/pepper_helper.cc#L25-L26

Without the fix the build fails with:
```
lld-link: error: undefined symbol: public: __cdecl ppapi::host::ResourceHost::ResourceHost(class ppapi::host::PpapiHost *, int, int)

>>> referenced by .\..\..\electron\shell\renderer\electron_renderer_pepper_host_factory.cc:103
>>>               obj/electron/electron_lib/electron_renderer_pepper_host_factory.obj:(public: virtual class std::Cr::unique_ptr<class ppapi::host::ResourceHost, struct std::Cr::default_delete<class ppapi::host::ResourceHost>> __cdecl ElectronRendererPepperHostFactory::CreateResourceHost(class ppapi::host::PpapiHost *, int, int, class IPC::Message const &))

lld-link: error: undefined symbol: public: virtual __cdecl ppapi::host::ResourceHost::~ResourceHost(void)
>>> referenced by .\..\..\electron\shell\renderer\electron_renderer_pepper_host_factory.cc:28
>>>               obj/electron/electron_lib/electron_renderer_pepper_host_factory.obj:(public: virtual void * __cdecl PepperUMAHost::`scalar deleting dtor'(unsigned int))

lld-link: error: undefined symbol: public: static bool __cdecl IPC::MessageT<struct PpapiHostMsg_UMA_HistogramCustomCounts_Meta, class std::Cr::tuple<class std::Cr::basic_string<char, struct std::Cr::char_traits<char>, class std::Cr::allocator<char>>, int, int, int, unsigned int>, void>::Read(class IPC::Message const *, class std::Cr::tuple<class std::Cr::basic_string<char, struct std::Cr::char_traits<char>, class std::Cr::allocator<char>>, int, int, int, unsigned int> *)
>>> referenced by .\..\..\electron\shell\renderer\electron_renderer_pepper_host_factory.cc:37
>>>               obj/electron/electron_lib/electron_renderer_pepper_host_factory.obj:(public: virtual int __cdecl PepperUMAHost::OnResourceMessageReceived(class IPC::Message const &, struct ppapi::host::HostMessageContext *))

lld-link: error: undefined symbol: public: static bool __cdecl IPC::MessageT<struct PpapiHostMsg_UMA_HistogramCustomTimes_Meta, class std::Cr::tuple<class std::Cr::basic_string<char, struct std::Cr::char_traits<char>, class std::Cr::allocator<char>>, __int64, __int64, __int64, unsigned int>, void>::Read(class IPC::Message const *, class std::Cr::tuple<class std::Cr::basic_string<char, struct std::Cr::char_traits<char>, class std::Cr::allocator<char>>, __int64, __int64, __int64, unsigned int> *)
>>> referenced by .\..\..\electron\shell\renderer\electron_renderer_pepper_host_factory.cc:35
>>>               obj/electron/electron_lib/electron_renderer_pepper_host_factory.obj:(public: virtual int __cdecl PepperUMAHost::OnResourceMessageReceived(class IPC::Message const &, struct ppapi::host::HostMessageContext *))

lld-link: error: undefined symbol: public: static bool __cdecl IPC::MessageT<struct PpapiHostMsg_UMA_HistogramEnumeration_Meta, class std::Cr::tuple<class std::Cr::basic_string<char, struct std::Cr::char_traits<char>, class std::Cr::allocator<char>>, int, int>, void>::Read(class IPC::Message const *, class std::Cr::tuple<class std::Cr::basic_string<char, struct std::Cr::char_traits<char>, class std::Cr::allocator<char>>, int, int> *)
>>> referenced by .\..\..\electron\shell\renderer\electron_renderer_pepper_host_factory.cc:39
>>>               obj/electron/electron_lib/electron_renderer_pepper_host_factory.obj:(public: virtual int __cdecl PepperUMAHost::OnResourceMessageReceived(class IPC::Message const &, struct ppapi::host::HostMessageContext *))

lld-link: error: undefined symbol: public: virtual bool __cdecl ppapi::host::ResourceHost::HandleMessage(class IPC::Message const &, struct ppapi::host::HostMessageContext *)
>>> referenced by obj/electron/electron_lib/electron_renderer_pepper_host_factory.obj:(const PepperUMAHost::`vftable')

lld-link: error: undefined symbol: public: virtual void __cdecl ppapi::host::ResourceHost::SendReply(struct ppapi::host::ReplyMessageContext const &, class IPC::Message const &)
>>> referenced by obj/electron/electron_lib/electron_renderer_pepper_host_factory.obj:(const PepperUMAHost::`vftable')

lld-link: error: undefined symbol: public: virtual bool __cdecl ppapi::host::ResourceHost::IsFileRefHost(void)
>>> referenced by obj/electron/electron_lib/electron_renderer_pepper_host_factory.obj:(const PepperUMAHost::`vftable')

lld-link: error: undefined symbol: public: virtual bool __cdecl ppapi::host::ResourceHost::IsFileSystemHost(void)
>>> referenced by obj/electron/electron_lib/electron_renderer_pepper_host_factory.obj:(const PepperUMAHost::`vftable')

lld-link: error: undefined symbol: public: virtual bool __cdecl ppapi::host::ResourceHost::IsGraphics2DHost(void)
>>> referenced by obj/electron/electron_lib/electron_renderer_pepper_host_factory.obj:(const PepperUMAHost::`vftable')

lld-link: error: undefined symbol: public: virtual bool __cdecl ppapi::host::ResourceHost::IsMediaStreamVideoTrackHost(void)
>>> referenced by obj/electron/electron_lib/electron_renderer_pepper_host_factory.obj:(const PepperUMAHost::`vftable')

ninja: build stopped: cannot make progress due to previous errors.
```

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none