### PR TITLE
fix: `shell.trashItem()` not working in the renderer on Windows

### DIFF
--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -33,6 +33,7 @@
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "shell/common/electron_paths.h"
+#include "ui/base/win/scoped_ole_initializer.h"
 #include "ui/base/win/shell.h"
 #include "url/gurl.h"
 
@@ -351,7 +352,7 @@ void OpenExternal(const GURL& url,
 bool MoveItemToTrashWithError(const base::FilePath& path,
                               bool delete_on_fail,
                               std::string* error) {
-  base::win::ScopedCOMInitializer com_initializer;
+  ui::ScopedOleInitializer ole_initializer;
   if (!com_initializer.Succeeded()) {
     *error = "Failed to initialize COM";
     return false;

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -351,6 +351,11 @@ void OpenExternal(const GURL& url,
 bool MoveItemToTrashWithError(const base::FilePath& path,
                               bool delete_on_fail,
                               std::string* error) {
+  base::win::ScopedCOMInitializer com_initializer;
+  if (!com_initializer.Succeeded()) {
+    *error = "Failed to initialize COM";
+    return false;
+  }
   Microsoft::WRL::ComPtr<IFileOperation> pfo;
   if (FAILED(::CoCreateInstance(CLSID_FileOperation, nullptr, CLSCTX_ALL,
                                 IID_PPV_ARGS(&pfo)))) {

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -353,10 +353,6 @@ bool MoveItemToTrashWithError(const base::FilePath& path,
                               bool delete_on_fail,
                               std::string* error) {
   ui::ScopedOleInitializer ole_initializer;
-  if (!com_initializer.Succeeded()) {
-    *error = "Failed to initialize COM";
-    return false;
-  }
   Microsoft::WRL::ComPtr<IFileOperation> pfo;
   if (FAILED(::CoCreateInstance(CLSID_FileOperation, nullptr, CLSCTX_ALL,
                                 IID_PPV_ARGS(&pfo)))) {

--- a/spec/api-shell-spec.ts
+++ b/spec/api-shell-spec.ts
@@ -2,7 +2,7 @@ import { BrowserWindow, app } from 'electron/main';
 import { shell } from 'electron/common';
 import { closeAllWindows } from './window-helpers';
 import { emittedOnce } from './events-helpers';
-import { ifdescribe, ifit } from './spec-helpers';
+import { ifdescribe } from './spec-helpers';
 import * as http from 'http';
 import * as fs from 'fs-extra';
 import * as os from 'os';
@@ -79,10 +79,10 @@ describe('shell module', () => {
       await expect(shell.trashItem(filename)).to.eventually.be.rejected();
     });
 
-    ifit(!(process.platform === 'win32' && process.arch === 'ia32'))('works in the renderer process', async () => {
+    it('works in the renderer process', async () => {
       const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, contextIsolation: false } });
       w.loadURL('about:blank');
-      await expect(w.webContents.executeJavaScript('require(\'electron\').shell.trashItem(\'does-not-exist\')')).to.be.rejectedWith(/does-not-exist|Failed to move item|Failed to create FileOperation/);
+      await expect(w.webContents.executeJavaScript('require(\'electron\').shell.trashItem(\'does-not-exist\')')).to.be.rejectedWith(/does-not-exist|Failed to move item/);
     });
   });
 


### PR DESCRIPTION
#### Description of Change
Fixes #29598, hopefully.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed shell.trashItem not working when called from the renderer on Windows.
