### PR TITLE
fix: `app.dock.setIcon()` crash before app ready

### DIFF
--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -447,6 +447,13 @@ void Browser::DockSetIcon(v8::Isolate* isolate, v8::Local<v8::Value> icon) {
     image = native_image->image();
   }
 
+  // This is needed when this fn is called before the browser
+  // process is ready, since supported scales are normally set
+  // by ui::ResourceBundle::InitSharedInstance
+  // during browser process startup.
+  if (!is_ready())
+    gfx::ImageSkia::SetSupportedScales({1.0f});
+
   [[AtomApplication sharedApplication]
       setApplicationIconImage:image.AsNSImage()];
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/26604.

Fixes an issue where calling `app.dock.setIcon(/path/t/icon)` would crash when called before the `ready` event on `app`. This would happen because [`SetSupportedScales`](https://source.chromium.org/chromium/chromium/src/+/main:ui/gfx/image/image_skia.cc;l=326;drc=caa1747121ee9f14ba7d4e346ea2dc5e7a2e05c0) had not yet been called, which normally happens in browser process startup in the following call chain:

<details> <summary>Callstack</summary>
```
2   Electron Framework                  0x000000011d1bb094 gfx::ImageSkia::SetSupportedScales(std::Cr::vector<float, std::Cr::allocator<float>> const&) + 36
3   Electron Framework                  0x000000011d3f3a68 ui::SetSupportedResourceScaleFactors(std::Cr::vector<ui::ResourceScaleFactor, std::Cr::allocator<ui::ResourceScaleFactor>> const&) + 276
4   Electron Framework                  0x000000011d3f8cb4 ui::ResourceBundle::InitSharedInstance(ui::ResourceBundle::Delegate*) + 312
5   Electron Framework                  0x000000011d3f8b18 ui::ResourceBundle::InitSharedInstanceWithLocale(std::Cr::basic_string<char, std::Cr::char_traits<char>, std::Cr::allocator<char>> const&, ui::ResourceBundle::Delegate*, ui::ResourceBundle::LoadResources) + 40
6   Electron Framework                  0x0000000118281fd8 electron::LoadResourceBundle(std::Cr::basic_string<char, std::Cr::char_traits<char>, std::Cr::allocator<char>> const&) + 188
7   Electron Framework                  0x00000001182825fc electron::ElectronMainDelegate::PreSandboxStartup() + 648
8   Electron Framework                  0x000000011859aeec content::ContentMainRunnerImpl::Initialize(content::ContentMainParams) + 908
9   Electron Framework                  0x0000000118599cf8 content::RunContentProcess(content::ContentMainParams, content::ContentMainRunner*) + 1432
10  Electron Framework                  0x0000000118599f6c content::ContentMain(content::ContentMainParams) + 92
11  Electron Framework                  0x000000011827ed0c ElectronMain + 128
12  Electron Helper                     0x0000000104344a00 main + 224
13  dyld                                0x00000001043dd08c start + 520
```

</details>

We correct this issue by calling `gfx::ImageSkia::SetSupportedScales` ourselves if the app is not ready.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where calling `app.dock.setIcon(/path/t/icon)` would crash when called before the `ready` event on `app`. 