### PR TITLE
chore: cherry-pick 80ed4b917477 from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -15,3 +15,4 @@ cherry-pick-8b040cb69e96.patch
 cherry-pick-2f6a2939514f.patch
 cherry-pick-194bcc127f21.patch
 cherry-pick-ec236fef54b8.patch
+cherry-pick-80ed4b917477.patch

--- a/patches/v8/cherry-pick-80ed4b917477.patch
+++ b/patches/v8/cherry-pick-80ed4b917477.patch
@@ -1,7 +1,7 @@
-From 80ed4b9174774d305739ca216a11ba2e88d61976 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Maya Lekova <mslekova@chromium.org>
-Date: Wed, 02 Nov 2022 11:02:24 +0100
-Subject: [PATCH] Merged: [compiler] Fix mutable heap number object reference leak
+Date: Wed, 2 Nov 2022 11:02:24 +0100
+Subject: Merged: [compiler] Fix mutable heap number object reference leak
 
 (cherry picked from commit 64112122374c00a86771b4612d20ca5d88ad5bfb)
 
@@ -16,13 +16,12 @@ Commit-Queue: Maya Lekova <mslekova@chromium.org>
 Cr-Commit-Position: refs/branch-heads/10.6@{#51}
 Cr-Branched-From: 41bc7435693fbce8ef86753cd9239e30550a3e2d-refs/heads/10.6.194@{#1}
 Cr-Branched-From: d5f29b929ce7746409201d77f44048f3e9529b40-refs/heads/main@{#82548}
----
 
 diff --git a/src/compiler/effect-control-linearizer.cc b/src/compiler/effect-control-linearizer.cc
-index a887771..cddd956 100644
+index 5825045052be450516b30e09a2cdf3e55c42c70e..909a6781d60729d7e21d9f8dfe265ff853855ed3 100644
 --- a/src/compiler/effect-control-linearizer.cc
 +++ b/src/compiler/effect-control-linearizer.cc
-@@ -5221,6 +5221,8 @@
+@@ -5380,6 +5380,8 @@ Node* EffectControlLinearizer::LowerLoadFieldByIndex(Node* node) {
  
    auto if_double = __ MakeDeferredLabel();
    auto done = __ MakeLabel(MachineRepresentation::kTagged);
@@ -31,7 +30,7 @@ index a887771..cddd956 100644
  
    // Check if field is a mutable double field.
    __ GotoIfNot(__ IntPtrEqual(__ WordAnd(index, one), zero), &if_double);
-@@ -5237,8 +5239,8 @@
+@@ -5396,8 +5398,8 @@ Node* EffectControlLinearizer::LowerLoadFieldByIndex(Node* node) {
        Node* offset =
            __ IntAdd(__ WordShl(index, __ IntPtrConstant(kTaggedSizeLog2 - 1)),
                      __ IntPtrConstant(JSObject::kHeaderSize - kHeapObjectTag));
@@ -42,7 +41,7 @@ index a887771..cddd956 100644
      }
  
      // The field is located in the properties backing store of {object}.
-@@ -5252,8 +5254,8 @@
+@@ -5411,8 +5413,8 @@ Node* EffectControlLinearizer::LowerLoadFieldByIndex(Node* node) {
                                 __ IntPtrConstant(kTaggedSizeLog2 - 1)),
                      __ IntPtrConstant((FixedArray::kHeaderSize - kTaggedSize) -
                                        kHeapObjectTag));
@@ -53,7 +52,7 @@ index a887771..cddd956 100644
      }
    }
  
-@@ -5261,9 +5263,6 @@
+@@ -5420,9 +5422,6 @@ Node* EffectControlLinearizer::LowerLoadFieldByIndex(Node* node) {
    // architectures, or a mutable HeapNumber.
    __ Bind(&if_double);
    {
@@ -63,7 +62,7 @@ index a887771..cddd956 100644
      index = __ WordSar(index, one);
  
      // Check if field is in-object or out-of-object.
-@@ -5291,27 +5290,27 @@
+@@ -5450,27 +5449,27 @@ Node* EffectControlLinearizer::LowerLoadFieldByIndex(Node* node) {
        Node* field = __ Load(MachineType::AnyTagged(), properties, offset);
        __ Goto(&loaded_field, field);
      }
@@ -79,6 +78,10 @@ index a887771..cddd956 100644
 -      Node* field_map = __ LoadField(AccessBuilder::ForMap(), field);
 -      __ GotoIfNot(__ TaggedEqual(field_map, __ HeapNumberMapConstant()), &done,
 -                   field);
+-
+-      Node* value = __ LoadField(AccessBuilder::ForHeapNumberValue(), field);
+-      __ Goto(&done_double, value);
+-    }
 +  __ Bind(&loaded_field);
 +  {
 +    Node* field = loaded_field.PhiAt(0);
@@ -90,18 +93,15 @@ index a887771..cddd956 100644
 +    __ GotoIfNot(__ TaggedEqual(field_map, __ HeapNumberMapConstant()), &done,
 +                 field);
  
--      Node* value = __ LoadField(AccessBuilder::ForHeapNumberValue(), field);
--      __ Goto(&done_double, value);
--    }
-+    Node* value = __ LoadField(AccessBuilder::ForHeapNumberValue(), field);
-+    __ Goto(&done_double, value);
-+  }
- 
 -    __ Bind(&done_double);
 -    {
 -      Node* result = AllocateHeapNumberWithValue(done_double.PhiAt(0));
 -      __ Goto(&done, result);
 -    }
++    Node* value = __ LoadField(AccessBuilder::ForHeapNumberValue(), field);
++    __ Goto(&done_double, value);
++  }
++
 +  __ Bind(&done_double);
 +  {
 +    Node* result = AllocateHeapNumberWithValue(done_double.PhiAt(0));

--- a/patches/v8/cherry-pick-80ed4b917477.patch
+++ b/patches/v8/cherry-pick-80ed4b917477.patch
@@ -1,0 +1,111 @@
+From 80ed4b9174774d305739ca216a11ba2e88d61976 Mon Sep 17 00:00:00 2001
+From: Maya Lekova <mslekova@chromium.org>
+Date: Wed, 02 Nov 2022 11:02:24 +0100
+Subject: [PATCH] Merged: [compiler] Fix mutable heap number object reference leak
+
+(cherry picked from commit 64112122374c00a86771b4612d20ca5d88ad5bfb)
+
+Bug: chromium:1380063
+No-Try: true
+No-Presubmit: true
+No-Tree-Checks: true
+Change-Id: Ifa1737af7fbc7e14d69a5080cbe0aabf7ef466fa
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4009978
+Reviewed-by: Igor Sheludko <ishell@chromium.org>
+Commit-Queue: Maya Lekova <mslekova@chromium.org>
+Cr-Commit-Position: refs/branch-heads/10.6@{#51}
+Cr-Branched-From: 41bc7435693fbce8ef86753cd9239e30550a3e2d-refs/heads/10.6.194@{#1}
+Cr-Branched-From: d5f29b929ce7746409201d77f44048f3e9529b40-refs/heads/main@{#82548}
+---
+
+diff --git a/src/compiler/effect-control-linearizer.cc b/src/compiler/effect-control-linearizer.cc
+index a887771..cddd956 100644
+--- a/src/compiler/effect-control-linearizer.cc
++++ b/src/compiler/effect-control-linearizer.cc
+@@ -5221,6 +5221,8 @@
+ 
+   auto if_double = __ MakeDeferredLabel();
+   auto done = __ MakeLabel(MachineRepresentation::kTagged);
++  auto loaded_field = __ MakeLabel(MachineRepresentation::kTagged);
++  auto done_double = __ MakeLabel(MachineRepresentation::kFloat64);
+ 
+   // Check if field is a mutable double field.
+   __ GotoIfNot(__ IntPtrEqual(__ WordAnd(index, one), zero), &if_double);
+@@ -5237,8 +5239,8 @@
+       Node* offset =
+           __ IntAdd(__ WordShl(index, __ IntPtrConstant(kTaggedSizeLog2 - 1)),
+                     __ IntPtrConstant(JSObject::kHeaderSize - kHeapObjectTag));
+-      Node* result = __ Load(MachineType::AnyTagged(), object, offset);
+-      __ Goto(&done, result);
++      Node* field = __ Load(MachineType::AnyTagged(), object, offset);
++      __ Goto(&loaded_field, field);
+     }
+ 
+     // The field is located in the properties backing store of {object}.
+@@ -5252,8 +5254,8 @@
+                                __ IntPtrConstant(kTaggedSizeLog2 - 1)),
+                     __ IntPtrConstant((FixedArray::kHeaderSize - kTaggedSize) -
+                                       kHeapObjectTag));
+-      Node* result = __ Load(MachineType::AnyTagged(), properties, offset);
+-      __ Goto(&done, result);
++      Node* field = __ Load(MachineType::AnyTagged(), properties, offset);
++      __ Goto(&loaded_field, field);
+     }
+   }
+ 
+@@ -5261,9 +5263,6 @@
+   // architectures, or a mutable HeapNumber.
+   __ Bind(&if_double);
+   {
+-    auto loaded_field = __ MakeLabel(MachineRepresentation::kTagged);
+-    auto done_double = __ MakeLabel(MachineRepresentation::kFloat64);
+-
+     index = __ WordSar(index, one);
+ 
+     // Check if field is in-object or out-of-object.
+@@ -5291,27 +5290,27 @@
+       Node* field = __ Load(MachineType::AnyTagged(), properties, offset);
+       __ Goto(&loaded_field, field);
+     }
++  }
+ 
+-    __ Bind(&loaded_field);
+-    {
+-      Node* field = loaded_field.PhiAt(0);
+-      // We may have transitioned in-place away from double, so check that
+-      // this is a HeapNumber -- otherwise the load is fine and we don't need
+-      // to copy anything anyway.
+-      __ GotoIf(ObjectIsSmi(field), &done, field);
+-      Node* field_map = __ LoadField(AccessBuilder::ForMap(), field);
+-      __ GotoIfNot(__ TaggedEqual(field_map, __ HeapNumberMapConstant()), &done,
+-                   field);
++  __ Bind(&loaded_field);
++  {
++    Node* field = loaded_field.PhiAt(0);
++    // We may have transitioned in-place away from double, so check that
++    // this is a HeapNumber -- otherwise the load is fine and we don't need
++    // to copy anything anyway.
++    __ GotoIf(ObjectIsSmi(field), &done, field);
++    Node* field_map = __ LoadField(AccessBuilder::ForMap(), field);
++    __ GotoIfNot(__ TaggedEqual(field_map, __ HeapNumberMapConstant()), &done,
++                 field);
+ 
+-      Node* value = __ LoadField(AccessBuilder::ForHeapNumberValue(), field);
+-      __ Goto(&done_double, value);
+-    }
++    Node* value = __ LoadField(AccessBuilder::ForHeapNumberValue(), field);
++    __ Goto(&done_double, value);
++  }
+ 
+-    __ Bind(&done_double);
+-    {
+-      Node* result = AllocateHeapNumberWithValue(done_double.PhiAt(0));
+-      __ Goto(&done, result);
+-    }
++  __ Bind(&done_double);
++  {
++    Node* result = AllocateHeapNumberWithValue(done_double.PhiAt(0));
++    __ Goto(&done, result);
+   }
+ 
+   __ Bind(&done);


### PR DESCRIPTION
Merged: [compiler] Fix mutable heap number object reference leak

(cherry picked from commit 64112122374c00a86771b4612d20ca5d88ad5bfb)

Bug: chromium:1380063
No-Try: true
No-Presubmit: true
No-Tree-Checks: true
Change-Id: Ifa1737af7fbc7e14d69a5080cbe0aabf7ef466fa
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4009978
Reviewed-by: Igor Sheludko <ishell@chromium.org>
Commit-Queue: Maya Lekova <mslekova@chromium.org>
Cr-Commit-Position: refs/branch-heads/10.6@{#51}
Cr-Branched-From: 41bc7435693fbce8ef86753cd9239e30550a3e2d-refs/heads/10.6.194@{#1}
Cr-Branched-From: d5f29b929ce7746409201d77f44048f3e9529b40-refs/heads/main@{#82548}


Ref electron/security#246

Notes: Security: backported fix for CVE-2022-3889.