### PR TITLE
refactor: change defined(MAS_BUILD) to IS_MAS_BUILD()

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -512,13 +512,14 @@ source_set("electron_lib") {
     ]
   }
 
+  configs += [ "//electron/build/config:mas_build" ]
+
   sources = filenames.lib_sources
   if (is_win) {
     sources += filenames.lib_sources_win
   }
   if (is_mac) {
     sources += filenames.lib_sources_mac
-    configs += [ "//electron/build/config:mas_build" ]
   }
   if (is_posix) {
     sources += filenames.lib_sources_posix

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -518,6 +518,7 @@ source_set("electron_lib") {
   }
   if (is_mac) {
     sources += filenames.lib_sources_mac
+    configs += [ "//electron/build/config:mas_build" ]
   }
   if (is_posix) {
     sources += filenames.lib_sources_posix
@@ -573,7 +574,6 @@ source_set("electron_lib") {
     if (is_mas_build) {
       sources += [ "shell/browser/api/electron_api_app_mas.mm" ]
       sources -= [ "shell/browser/auto_updater_mac.mm" ]
-      defines += [ "MAS_BUILD" ]
       sources -= [
         "shell/app/electron_crash_reporter_client.cc",
         "shell/app/electron_crash_reporter_client.h",
@@ -977,6 +977,11 @@ if (is_mac) {
         deps += [ "//sandbox/mac:seatbelt" ]
       }
       defines = [ "HELPER_EXECUTABLE" ]
+      if (is_mas_build) {
+        defines += [ "IS_MAS_BUILD()=1" ]
+      } else {
+        defines += [ "IS_MAS_BUILD()=0" ]
+      }
       sources = [
         "shell/app/electron_main_mac.cc",
         "shell/app/uv_stdio_fix.cc",
@@ -1147,6 +1152,11 @@ if (is_mac) {
       "-rpath",
       "@executable_path/../Frameworks",
     ]
+    if (is_mas_build) {
+      defines = [ "IS_MAS_BUILD()=1" ]
+    } else {
+      defines = [ "IS_MAS_BUILD()=0" ]
+    }
   }
 
   if (enable_dsyms) {

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -978,11 +978,7 @@ if (is_mac) {
         deps += [ "//sandbox/mac:seatbelt" ]
       }
       defines = [ "HELPER_EXECUTABLE" ]
-      if (is_mas_build) {
-        defines += [ "IS_MAS_BUILD()=1" ]
-      } else {
-        defines += [ "IS_MAS_BUILD()=0" ]
-      }
+      extra_configs = [ "//electron/build/config:mas_build" ]
       sources = [
         "shell/app/electron_main_mac.cc",
         "shell/app/uv_stdio_fix.cc",
@@ -1153,11 +1149,7 @@ if (is_mac) {
       "-rpath",
       "@executable_path/../Frameworks",
     ]
-    if (is_mas_build) {
-      defines = [ "IS_MAS_BUILD()=1" ]
-    } else {
-      defines = [ "IS_MAS_BUILD()=0" ]
-    }
+    extra_configs = [ "//electron/build/config:mas_build" ]
   }
 
   if (enable_dsyms) {

--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -1,6 +1,8 @@
 # For MAS build, we force defining "MAS_BUILD".
 config("mas_build") {
   if (is_mas_build) {
-    defines = [ "MAS_BUILD" ]
+    defines = [ "IS_MAS_BUILD()=1" ]
+  } else {
+    defines = [ "IS_MAS_BUILD()=0" ]
   }
 }

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -123,3 +123,4 @@ fix_remove_caption-removing_style_call.patch
 build_allow_electron_to_use_exec_script.patch
 revert_use_accessibility_pkey_when_setting_page_access.patch
 roll_clang_llvmorg-16-init-8189-g97196a2d-2.patch
+build_only_use_the_mas_build_config_in_the_required_components.patch

--- a/patches/chromium/build_only_use_the_mas_build_config_in_the_required_components.patch
+++ b/patches/chromium/build_only_use_the_mas_build_config_in_the_required_components.patch
@@ -1,0 +1,282 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Samuel Attard <samuel.r.attard@gmail.com>
+Date: Mon, 14 Nov 2022 01:05:20 -0800
+Subject: build: only use the mas build config in the required components
+
+Before landing this patch should be split into the relevant MAS patches, or at least the patch this one partially reverts
+
+diff --git a/base/BUILD.gn b/base/BUILD.gn
+index 98c3dbe91452543c4cbe58f51268633346f3851f..6e06f98e8db59bda3d34307467dc3158fdd097f7 100644
+--- a/base/BUILD.gn
++++ b/base/BUILD.gn
+@@ -1480,6 +1480,7 @@ mixed_component("base") {
+     "//build/config/compiler:prevent_unsafe_narrowing",
+     "//build/config/compiler:wexit_time_destructors",
+     "//build/config/compiler:wglobal_constructors",
++    "//electron/build/config:mas_build",
+   ]
+ 
+   deps = [
+diff --git a/build/config/BUILDCONFIG.gn b/build/config/BUILDCONFIG.gn
+index 091b1ae4b16771a5ec05cdeab6a1f281b2d9ccc5..21841237347178d7720fd0b79f7799d471a3e31f 100644
+--- a/build/config/BUILDCONFIG.gn
++++ b/build/config/BUILDCONFIG.gn
+@@ -355,7 +355,6 @@ default_compiler_configs = [
+   "//build/config/compiler/pgo:default_pgo_flags",
+   "//build/config/coverage:default_coverage",
+   "//build/config/sanitizers:default_sanitizer_flags",
+-  "//electron/build/config:mas_build",
+ ]
+ 
+ if (is_win) {
+diff --git a/components/os_crypt/BUILD.gn b/components/os_crypt/BUILD.gn
+index 8448ff2d912ed8664ba1117397a2407c08e9a578..5f6bb1a87615c474e06209fc8034ff36ee6a5b75 100644
+--- a/components/os_crypt/BUILD.gn
++++ b/components/os_crypt/BUILD.gn
+@@ -65,6 +65,8 @@ component("os_crypt") {
+       "keychain_password_mac.mm",
+       "os_crypt_mac.mm",
+     ]
++
++    configs += ["//electron/build/config:mas_build"]
+   }
+ 
+   if (is_win) {
+diff --git a/components/remote_cocoa/app_shim/BUILD.gn b/components/remote_cocoa/app_shim/BUILD.gn
+index 629172faea91a3384e6115f732a1d0ba272b3835..5970d1cb2ed7d29f653cc1b094cdfa8248e0b48c 100644
+--- a/components/remote_cocoa/app_shim/BUILD.gn
++++ b/components/remote_cocoa/app_shim/BUILD.gn
+@@ -16,6 +16,7 @@ component("app_shim") {
+   assert(is_mac)
+ 
+   configs += [ ":app_shim_warnings" ]
++  configs += ["//electron/build/config:mas_build"]
+   sources = [
+     "alert.h",
+     "alert.mm",
+diff --git a/components/viz/service/BUILD.gn b/components/viz/service/BUILD.gn
+index c2c65f685e760248adf3efcc98e6c7a8f1f7e5fb..34a15cbb10861058c5ba46c9ac111c9de69800f9 100644
+--- a/components/viz/service/BUILD.gn
++++ b/components/viz/service/BUILD.gn
+@@ -305,6 +305,8 @@ viz_component("service") {
+ 
+     deps += [ "//ui/accelerated_widget_mac" ]
+     frameworks = [ "IOSurface.framework" ]
++
++    configs = ["//electron/build/config:mas_build"]
+   }
+ 
+   if (is_android || use_ozone) {
+diff --git a/content/browser/BUILD.gn b/content/browser/BUILD.gn
+index b33864b2d57fb26637bd96edbd8fb917881f5f4c..749949d1b3618a16fce3a47dd2776af3555f64d2 100644
+--- a/content/browser/BUILD.gn
++++ b/content/browser/BUILD.gn
+@@ -52,6 +52,7 @@ source_set("browser") {
+     "//tools/v8_context_snapshot:use_v8_context_snapshot",
+     "//v8:external_startup_data",
+   ]
++  configs += ["//electron/build/config:mas_build"]
+   defines = []
+   libs = []
+   frameworks = []
+diff --git a/content/common/BUILD.gn b/content/common/BUILD.gn
+index bcc0a45f9b9eabb8aa98def58a68a8fcac93eadb..6105cb434bf0de629a9876480ad8bf31ba554d09 100644
+--- a/content/common/BUILD.gn
++++ b/content/common/BUILD.gn
+@@ -177,6 +177,7 @@ source_set("common") {
+     "//content:content_implementation",
+     "//build/config:precompiled_headers",
+   ]
++  configs += ["//electron/build/config:mas_build"]
+ 
+   public_deps = [
+     ":mojo_bindings",
+diff --git a/content/renderer/BUILD.gn b/content/renderer/BUILD.gn
+index ac506972529bec0f2c02dd1d1f7e25cb6709959a..1815ee6dd219c9f90ea052464e73427ae9a68fb7 100644
+--- a/content/renderer/BUILD.gn
++++ b/content/renderer/BUILD.gn
+@@ -214,6 +214,7 @@ target(link_target_type, "renderer") {
+   }
+ 
+   configs += [ "//content:content_implementation" ]
++  configs += ["//electron/build/config:mas_build"]
+   defines = []
+ 
+   public_deps = [
+diff --git a/device/bluetooth/BUILD.gn b/device/bluetooth/BUILD.gn
+index bd08baf779fba569079cfa27726adfca92a27f8e..640975ae8c67892ea99813553cec63addad69339 100644
+--- a/device/bluetooth/BUILD.gn
++++ b/device/bluetooth/BUILD.gn
+@@ -251,6 +251,7 @@ component("bluetooth") {
+       "IOKit.framework",
+       "Foundation.framework",
+     ]
++    configs += ["//electron/build/config:mas_build"]
+   }
+ 
+   if (is_win) {
+diff --git a/gpu/ipc/service/BUILD.gn b/gpu/ipc/service/BUILD.gn
+index c342a9c95b1787c49b88ba62457c6f27151cbb87..6181018d4940569e1feb323587fcbc96bd597ae9 100644
+--- a/gpu/ipc/service/BUILD.gn
++++ b/gpu/ipc/service/BUILD.gn
+@@ -118,6 +118,7 @@ component("service") {
+       "OpenGL.framework",
+       "QuartzCore.framework",
+     ]
++    configs += ["//electron/build/config:mas_build"]
+   }
+   if (is_android) {
+     sources += [
+diff --git a/media/audio/BUILD.gn b/media/audio/BUILD.gn
+index 1e6b91961c3e32aa223383b444d075ada9688b0b..f7b6e6f20b0972d0c1e51d34f9a82f98494f0182 100644
+--- a/media/audio/BUILD.gn
++++ b/media/audio/BUILD.gn
+@@ -192,6 +192,7 @@ source_set("audio") {
+       "CoreAudio.framework",
+       "CoreFoundation.framework",
+     ]
++    configs += ["//electron/build/config:mas_build"]
+   }
+ 
+   if (is_win) {
+diff --git a/net/dns/BUILD.gn b/net/dns/BUILD.gn
+index 9f4efcb2244b9e044c540586e1246c08161a8d6f..0d346b3cf0f2de8d35b2b07a1c789ea292e54ced 100644
+--- a/net/dns/BUILD.gn
++++ b/net/dns/BUILD.gn
+@@ -165,6 +165,8 @@ source_set("dns") {
+     ":host_resolver_manager",
+     ":mdns_client",
+   ]
++
++  configs += ["//electron/build/config:mas_build"]
+ }
+ 
+ # The standard API of net/dns.
+diff --git a/sandbox/mac/BUILD.gn b/sandbox/mac/BUILD.gn
+index 06b7f0310f1bca118cc2c89a9c21d3ebd661ec1e..b5b7432e1d998db003dd33622c750e817c79d7bc 100644
+--- a/sandbox/mac/BUILD.gn
++++ b/sandbox/mac/BUILD.gn
+@@ -33,6 +33,7 @@ component("seatbelt") {
+   ]
+   public_deps = [ "//third_party/protobuf:protobuf_lite" ]
+   defines = [ "SEATBELT_IMPLEMENTATION" ]
++  configs += ["//electron/build/config:mas_build"]
+ }
+ 
+ component("seatbelt_extension") {
+@@ -46,6 +47,7 @@ component("seatbelt_extension") {
+   libs = [ "sandbox" ]
+   public_deps = [ "//base" ]
+   defines = [ "SEATBELT_IMPLEMENTATION" ]
++  configs += ["//electron/build/config:mas_build"]
+ }
+ 
+ component("system_services") {
+@@ -60,6 +62,7 @@ component("system_services") {
+   deps = [ ":seatbelt_export" ]
+   public_deps = [ "//base" ]
+   defines = [ "SEATBELT_IMPLEMENTATION" ]
++  configs += ["//electron/build/config:mas_build"]
+ }
+ 
+ source_set("sandbox_unittests") {
+diff --git a/third_party/blink/renderer/core/BUILD.gn b/third_party/blink/renderer/core/BUILD.gn
+index a42b76b65e9b04f5226c5e4e706fae45464a96b0..c5a8d12a0c6c456d8f8d92d1e9ca06180cde641c 100644
+--- a/third_party/blink/renderer/core/BUILD.gn
++++ b/third_party/blink/renderer/core/BUILD.gn
+@@ -282,6 +282,7 @@ component("core") {
+     "//tools/v8_context_snapshot:use_v8_context_snapshot",
+     "//v8:external_startup_data",
+   ]
++  configs += ["//electron/build/config:mas_build"]
+ 
+   public_deps = [
+     ":core_generated",
+diff --git a/ui/accelerated_widget_mac/BUILD.gn b/ui/accelerated_widget_mac/BUILD.gn
+index 79b5a50e197897ab36253761fddffda25e5e98a4..0bcb5d1ff7b0e97922406a6f758421d9c4b24c75 100644
+--- a/ui/accelerated_widget_mac/BUILD.gn
++++ b/ui/accelerated_widget_mac/BUILD.gn
+@@ -50,6 +50,8 @@ component("accelerated_widget_mac") {
+     "OpenGL.framework",
+     "QuartzCore.framework",
+   ]
++
++  configs += ["//electron/build/config:mas_build"]
+ }
+ 
+ test("accelerated_widget_mac_unittests") {
+diff --git a/ui/accessibility/platform/BUILD.gn b/ui/accessibility/platform/BUILD.gn
+index 8eb556b9fb92ee523417e8dd6298ee0bdedfbb9e..e46fce5152c09138e7765c0743bfbeef011a51cf 100644
+--- a/ui/accessibility/platform/BUILD.gn
++++ b/ui/accessibility/platform/BUILD.gn
+@@ -235,6 +235,7 @@ source_set("platform") {
+         "AppKit.framework",
+         "Foundation.framework",
+       ]
++      configs += ["//electron/build/config:mas_build"]
+     }
+ 
+     if (use_atk) {
+diff --git a/ui/base/BUILD.gn b/ui/base/BUILD.gn
+index c1cc143209fbd60a34ad1d8f92c55c94f780e977..7bc5670489381d38e57de75f8ed4885790266b78 100644
+--- a/ui/base/BUILD.gn
++++ b/ui/base/BUILD.gn
+@@ -347,6 +347,7 @@ component("base") {
+       "l10n/l10n_util_mac.mm",
+       "resource/resource_bundle_mac.mm",
+     ]
++    configs += ["//electron/build/config:mas_build"]
+   }
+ 
+   if (is_chromeos_lacros) {
+diff --git a/ui/display/BUILD.gn b/ui/display/BUILD.gn
+index b379aa35ddfba8a43881a3b936f382dfdb92c9b5..fa965b8f1e7e05b4153f6e5d9ae0ac787dc808d3 100644
+--- a/ui/display/BUILD.gn
++++ b/ui/display/BUILD.gn
+@@ -56,6 +56,10 @@ component("display") {
+       "mac/display_link_mac.h",
+       "mac/screen_mac.mm",
+     ]
++
++    configs += [
++      "//electron/build/config:mas_build"
++    ]
+   }
+ 
+   if (is_win) {
+diff --git a/ui/gfx/BUILD.gn b/ui/gfx/BUILD.gn
+index 77ec78c9fdf6b8acdf15d74dbc2f970cda242d7d..119f688169e5050a17078f6b52043461bc2c1ba2 100644
+--- a/ui/gfx/BUILD.gn
++++ b/ui/gfx/BUILD.gn
+@@ -187,6 +187,7 @@ component("gfx") {
+       "scoped_ns_graphics_context_save_gstate_mac.h",
+       "scoped_ns_graphics_context_save_gstate_mac.mm",
+     ]
++    configs += ["//electron/build/config:mas_build"]
+   }
+   if (is_win) {
+     sources += [
+diff --git a/ui/views/BUILD.gn b/ui/views/BUILD.gn
+index 4aee50aff6d97b9bfac75c943eacce8a552d20a5..44e92a351193ccbbd387d06c13460886dd8b443c 100644
+--- a/ui/views/BUILD.gn
++++ b/ui/views/BUILD.gn
+@@ -657,6 +657,7 @@ component("views") {
+       "IOSurface.framework",
+       "QuartzCore.framework",
+     ]
++    configs += ["//electron/build/config:mas_build"]
+   }
+ 
+   if (is_win) {
+diff --git a/ui/views/controls/webview/BUILD.gn b/ui/views/controls/webview/BUILD.gn
+index f37a5a881ac6ac432a4672c5738b7f49b75b5523..1764117f539c2423ebe8bb4c3fe70afcdd0883e8 100644
+--- a/ui/views/controls/webview/BUILD.gn
++++ b/ui/views/controls/webview/BUILD.gn
+@@ -19,6 +19,7 @@ component("webview") {
+ 
+   if (is_mac) {
+     sources += [ "unhandled_keyboard_event_handler_mac.mm" ]
++    configs += ["//electron/build/config:mas_build"]
+   }
+ 
+   if (is_win) {

--- a/patches/chromium/disable_compositor_recycling.patch
+++ b/patches/chromium/disable_compositor_recycling.patch
@@ -6,7 +6,7 @@ Subject: fix: disabling compositor recycling
 Compositor recycling is useful for Chrome because there can be many tabs and spinning up a compositor for each one would be costly. In practice, Chrome uses the parent compositor code path of browser_compositor_view_mac.mm; the NSView of each tab is detached when it's hidden and attached when it's shown. For Electron, there is no parent compositor, so we're forced into the "own compositor" code path, which seems to be non-optimal and pretty ruthless in terms of the release of resources. Electron has no real concept of multiple tabs per window, so it should be okay to disable this ruthless recycling altogether in Electron.
 
 diff --git a/content/browser/renderer_host/render_widget_host_view_mac.mm b/content/browser/renderer_host/render_widget_host_view_mac.mm
-index a420b3cf9b1c325967318db322d61c4ebc4cf7c6..c5bc07973bba93aff7837cea92895e2ef7dff897 100644
+index cc2836fb66d9cf84fa298f1d75480f2c796b274f..4de5eddfeded8881717832c78725eb57769dcb5b 100644
 --- a/content/browser/renderer_host/render_widget_host_view_mac.mm
 +++ b/content/browser/renderer_host/render_widget_host_view_mac.mm
 @@ -525,7 +525,11 @@

--- a/patches/chromium/feat_ensure_mas_builds_of_the_same_application_can_use_safestorage.patch
+++ b/patches/chromium/feat_ensure_mas_builds_of_the_same_application_can_use_safestorage.patch
@@ -12,14 +12,14 @@ We attempt to migrate the safe storage key from the old account, if that migrati
 Existing apps that aren't built for the app store should be unimpacted, there is one edge case where a user uses BOTH an AppStore and a darwin build of the same app only one will keep it's access to the safestorage key as during the migration we delete the old account.  This is an acceptable edge case as no one should be actively using two versions of the same app.
 
 diff --git a/components/os_crypt/keychain_password_mac.mm b/components/os_crypt/keychain_password_mac.mm
-index 214ae79b9a6de27b99ccfa9cf03327449fd79198..1b740e8dd19eeb34e68db30ba66ebadd1a132a39 100644
+index 214ae79b9a6de27b99ccfa9cf03327449fd79198..fc8e8485706a8725f88e8a37c8d26ca29ec492e8 100644
 --- a/components/os_crypt/keychain_password_mac.mm
 +++ b/components/os_crypt/keychain_password_mac.mm
 @@ -22,6 +22,12 @@
  using KeychainNameContainerType = const base::NoDestructor<std::string>;
  #endif
  
-+#if defined(MAS_BUILD)
++#if IS_MAS_BUILD()
 +const char kAccountNameSuffix[] = " App Store Key";
 +#else
 +const char kAccountNameSuffix[] = " Key";

--- a/patches/chromium/mas-cgdisplayusesforcetogray.patch
+++ b/patches/chromium/mas-cgdisplayusesforcetogray.patch
@@ -6,14 +6,14 @@ Subject: mas: avoid usage of CGDisplayUsesForceToGray
 Removes usage of the CGDisplayUsesForceToGray private API.
 
 diff --git a/ui/display/mac/screen_mac.mm b/ui/display/mac/screen_mac.mm
-index a0c06e539088c6521793ecf9ba8d54311c4a6ff7..562fbe579639b7dd64e897d0f88fd23e492ac058 100644
+index a0c06e539088c6521793ecf9ba8d54311c4a6ff7..90c21bfc045df5c43dfa1d5305df28acb7d1123f 100644
 --- a/ui/display/mac/screen_mac.mm
 +++ b/ui/display/mac/screen_mac.mm
 @@ -269,7 +269,17 @@ DisplayMac BuildDisplayForScreen(NSScreen* screen) {
      display.set_color_depth(Display::kDefaultBitsPerPixel);
      display.set_depth_per_component(Display::kDefaultBitsPerComponent);
    }
-+#ifdef MAS_BUILD
++#if IS_MAS_BUILD()
 +  // This is equivalent to the CGDisplayUsesForceToGray() API as at 2018-08-06,
 +  // but avoids usage of the private API.
 +  CFStringRef app = CFSTR("com.apple.CoreGraphics");

--- a/patches/chromium/mas_avoid_usage_of_private_macos_apis.patch
+++ b/patches/chromium/mas_avoid_usage_of_private_macos_apis.patch
@@ -14,14 +14,14 @@ Disable usage of the following private APIs in MAS builds:
 * AudioDeviceDuck
 
 diff --git a/base/enterprise_util_mac.mm b/base/enterprise_util_mac.mm
-index 91a65a1e700cf1accb8e4541e0ceca4e0a734b16..a41df69515e421b629aa6dc82e296c3a3bb04f8e 100644
+index 91a65a1e700cf1accb8e4541e0ceca4e0a734b16..323b9b48214aa013ad8f7da2f63cca2ee3295d68 100644
 --- a/base/enterprise_util_mac.mm
 +++ b/base/enterprise_util_mac.mm
 @@ -189,6 +189,13 @@ MacDeviceManagementStateNew IsDeviceRegisteredWithManagementNew() {
  DeviceUserDomainJoinState AreDeviceAndUserJoinedToDomain() {
    static DeviceUserDomainJoinState state = [] {
      DeviceUserDomainJoinState state{false, false};
-+#if defined(MAS_BUILD)
++#if IS_MAS_BUILD()
 +    return state;
 +  }();
 +
@@ -76,14 +76,14 @@ index e38a02b3f0eed139653eaa82b6a09167b8658d81..071e699b23b99abd96a8a1ef2acbdca5
    if ([ns_val isKindOfClass:[NSFont class]]) {
      return (CTFontRef)(cf_val);
 diff --git a/base/process/launch_mac.cc b/base/process/launch_mac.cc
-index f860be6fbb6caf166f4808772a490ebba9cd7f08..20cead8c65f109fd74669bf647486132055e9860 100644
+index f860be6fbb6caf166f4808772a490ebba9cd7f08..d1b588346e106b032045b1a33ccc469c479b8f03 100644
 --- a/base/process/launch_mac.cc
 +++ b/base/process/launch_mac.cc
 @@ -19,14 +19,19 @@
  #include "base/threading/scoped_blocking_call.h"
  #include "base/threading/thread_restrictions.h"
  #include "base/trace_event/base_tracing.h"
-+#if defined(MAS_BUILD)
++#if IS_MAS_BUILD()
 +#include <sys/syscall.h>
 +#endif
  
@@ -92,7 +92,7 @@ index f860be6fbb6caf166f4808772a490ebba9cd7f08..20cead8c65f109fd74669bf647486132
  // descriptor. libpthread only exposes a syscall wrapper starting in
  // macOS 10.12, but the system call dates back to macOS 10.5. On older OSes,
  // the syscall is issued directly.
-+#if !defined(MAS_BUILD)
++#if !IS_MAS_BUILD()
  int pthread_chdir_np(const char* dir) API_AVAILABLE(macosx(10.12));
  int pthread_fchdir_np(int fd) API_AVAILABLE(macosx(10.12));
 +#endif
@@ -103,7 +103,7 @@ index f860be6fbb6caf166f4808772a490ebba9cd7f08..20cead8c65f109fd74669bf647486132
  };
  
  int ChangeCurrentThreadDirectory(const char* path) {
-+#if defined(MAS_BUILD)
++#if IS_MAS_BUILD()
 +  #pragma clang diagnostic push
 +  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 +  return syscall(SYS___pthread_chdir, path);
@@ -116,7 +116,7 @@ index f860be6fbb6caf166f4808772a490ebba9cd7f08..20cead8c65f109fd74669bf647486132
  // The recommended way to unset a per-thread cwd is to set a new value to an
  // invalid file descriptor, per libpthread-218.1.3/private/private.h.
  int ResetCurrentThreadDirectory() {
-+#if defined(MAS_BUILD)
++#if IS_MAS_BUILD()
 +  #pragma clang diagnostic push
 +  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 +  return syscall(SYS___pthread_fchdir, -1);
@@ -142,14 +142,14 @@ index f860be6fbb6caf166f4808772a490ebba9cd7f08..20cead8c65f109fd74669bf647486132
    std::vector<char*> argv_cstr;
    argv_cstr.reserve(argv.size() + 1);
 diff --git a/media/audio/mac/audio_low_latency_input_mac.cc b/media/audio/mac/audio_low_latency_input_mac.cc
-index 751b723388f78a314e2af9c0ec0205f3bd4b6d77..248fe5fc47bb94bf18a96700a5aaca0c516c39b8 100644
+index 751b723388f78a314e2af9c0ec0205f3bd4b6d77..ee89452b8af1a372b208403ad5a1d4dadd7f0165 100644
 --- a/media/audio/mac/audio_low_latency_input_mac.cc
 +++ b/media/audio/mac/audio_low_latency_input_mac.cc
 @@ -34,19 +34,23 @@
  
  namespace {
  extern "C" {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  // See:
  // https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/PAL/pal/spi/cf/CoreAudioSPI.h?rev=228264
  OSStatus AudioDeviceDuck(AudioDeviceID inDevice,
@@ -160,7 +160,7 @@ index 751b723388f78a314e2af9c0ec0205f3bd4b6d77..248fe5fc47bb94bf18a96700a5aaca0c
  }
  
  void UndoDucking(AudioDeviceID output_device_id) {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    if (AudioDeviceDuck != nullptr) {
      // Ramp the volume back up over half a second.
      AudioDeviceDuck(output_device_id, 1.0, nullptr, 0.5);
@@ -170,14 +170,14 @@ index 751b723388f78a314e2af9c0ec0205f3bd4b6d77..248fe5fc47bb94bf18a96700a5aaca0c
  
  }  // namespace
 diff --git a/sandbox/mac/sandbox_logging.cc b/sandbox/mac/sandbox_logging.cc
-index f52f1d1da4d431505b1a55df4764f37a70e0b29d..ebc15064d0d0e97dfab7fc82b99254556b050eb2 100644
+index f52f1d1da4d431505b1a55df4764f37a70e0b29d..2406f5d4342dafc0d2c398f03ac23907a55c929f 100644
 --- a/sandbox/mac/sandbox_logging.cc
 +++ b/sandbox/mac/sandbox_logging.cc
 @@ -32,9 +32,11 @@
    }
  #endif
  
-+#if !defined(MAS_BUILD)
++#if !IS_MAS_BUILD()
  extern "C" {
  void abort_report_np(const char*, ...);
  }
@@ -189,7 +189,7 @@ index f52f1d1da4d431505b1a55df4764f37a70e0b29d..ebc15064d0d0e97dfab7fc82b9925455
  
    os_log_with_type(log.get(), os_log_type, "%{public}s", message);
  
-+#if !defined(MAS_BUILD)
++#if !IS_MAS_BUILD()
    if (level == Level::FATAL) {
      abort_report_np(message);
    }
@@ -198,14 +198,14 @@ index f52f1d1da4d431505b1a55df4764f37a70e0b29d..ebc15064d0d0e97dfab7fc82b9925455
  
  // |error| is strerror(errno) when a P* logging function is called. Pass
 diff --git a/sandbox/mac/system_services.cc b/sandbox/mac/system_services.cc
-index 92b84121da46b692b89f70a46e36f5d1991383b8..8e5f05bb012b622e27f41b7c6327f70959dd9731 100644
+index 92b84121da46b692b89f70a46e36f5d1991383b8..8de2556bb59c70f229d35da05fd0718ba81696b5 100644
 --- a/sandbox/mac/system_services.cc
 +++ b/sandbox/mac/system_services.cc
 @@ -9,6 +9,7 @@
  
  #include "base/mac/mac_logging.h"
  
-+#if !defined(MAS_BUILD)
++#if !IS_MAS_BUILD()
  extern "C" {
  OSStatus SetApplicationIsDaemon(Boolean isDaemon);
  void _LSSetApplicationLaunchServicesServerConnectionStatus(
@@ -218,7 +218,7 @@ index 92b84121da46b692b89f70a46e36f5d1991383b8..8e5f05bb012b622e27f41b7c6327f709
  namespace sandbox {
  
  void DisableLaunchServices() {
-+  #if !defined(MAS_BUILD)
++  #if !IS_MAS_BUILD()
    // Allow the process to continue without a LaunchServices ASN. The
    // INIT_Process function in HIServices will abort if it cannot connect to
    // launchservicesd to get an ASN. By setting this flag, HIServices skips
@@ -230,7 +230,7 @@ index 92b84121da46b692b89f70a46e36f5d1991383b8..8e5f05bb012b622e27f41b7c6327f709
  }
  
  void DisableCoreServicesCheckFix() {
-+#if !defined(MAS_BUILD)
++#if !IS_MAS_BUILD()
    if (__builtin_available(macOS 10.15, *)) {
      _CSCheckFixDisable();
    }

--- a/patches/chromium/mas_blink_no_private_api.patch
+++ b/patches/chromium/mas_blink_no_private_api.patch
@@ -7,14 +7,14 @@ Guard usages in chromium code of private Mac APIs by MAS_BUILD, so they can
 be excluded for people who want to submit their apps to the Mac App store.
 
 diff --git a/third_party/blink/renderer/core/editing/kill_ring_mac.mm b/third_party/blink/renderer/core/editing/kill_ring_mac.mm
-index 94afefcee81b87c05bf9b1199d90d3d4b5ea84a6..2ec7f04c71824b47de1ddbf1f0e8625d33e833a8 100644
+index 94afefcee81b87c05bf9b1199d90d3d4b5ea84a6..78e4e0fe20e0fdfeab18b28fe208d5aa38eb0bd1 100644
 --- a/third_party/blink/renderer/core/editing/kill_ring_mac.mm
 +++ b/third_party/blink/renderer/core/editing/kill_ring_mac.mm
 @@ -27,6 +27,7 @@
  
  namespace blink {
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  extern "C" {
  
  // Kill ring calls. Would be better to use NSKillRing.h, but that's not
@@ -28,7 +28,7 @@ index 94afefcee81b87c05bf9b1199d90d3d4b5ea84a6..2ec7f04c71824b47de1ddbf1f0e8625d
    static bool initialized_kill_ring = false;
    if (!initialized_kill_ring) {
      initialized_kill_ring = true;
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
      _NSInitializeKillRing();
 +#endif
    }
@@ -36,21 +36,21 @@ index 94afefcee81b87c05bf9b1199d90d3d4b5ea84a6..2ec7f04c71824b47de1ddbf1f0e8625d
  
  void KillRing::Append(const String& string) {
    InitializeKillRingIfNeeded();
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    _NSAppendToKillRing(string);
 +#endif
  }
  
  void KillRing::Prepend(const String& string) {
    InitializeKillRingIfNeeded();
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    _NSPrependToKillRing(string);
 +#endif
  }
  
  String KillRing::Yank() {
    InitializeKillRingIfNeeded();
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    return _NSYankFromKillRing();
 +#else
 +  return "";
@@ -59,14 +59,14 @@ index 94afefcee81b87c05bf9b1199d90d3d4b5ea84a6..2ec7f04c71824b47de1ddbf1f0e8625d
  
  void KillRing::StartNewSequence() {
    InitializeKillRingIfNeeded();
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    _NSNewKillRingSequence();
 +#endif
  }
  
  void KillRing::SetToYankedState() {
    InitializeKillRingIfNeeded();
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    _NSSetKillRingToYankedState();
 +#endif
  }

--- a/patches/chromium/mas_disable_custom_window_frame.patch
+++ b/patches/chromium/mas_disable_custom_window_frame.patch
@@ -7,14 +7,14 @@ Disable private window frame APIs (NSNextStepFrame and NSThemeFrame) for MAS
 build.
 
 diff --git a/components/remote_cocoa/app_shim/browser_native_widget_window_mac.mm b/components/remote_cocoa/app_shim/browser_native_widget_window_mac.mm
-index 6e116d634c658ff26f6990fae5fcac975285e865..5beceecf8e0d712b69eefeba939c6fa524b7e363 100644
+index 6e116d634c658ff26f6990fae5fcac975285e865..8c034acee912b26c187d0da7e1d9e68fa6abb5b6 100644
 --- a/components/remote_cocoa/app_shim/browser_native_widget_window_mac.mm
 +++ b/components/remote_cocoa/app_shim/browser_native_widget_window_mac.mm
 @@ -9,6 +9,7 @@
  #include "components/remote_cocoa/app_shim/native_widget_ns_window_bridge.h"
  #include "components/remote_cocoa/common/native_widget_ns_window_host.mojom.h"
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  @interface NSWindow (PrivateBrowserNativeWidgetAPI)
  + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle;
  @end
@@ -28,7 +28,7 @@ index 6e116d634c658ff26f6990fae5fcac975285e865..5beceecf8e0d712b69eefeba939c6fa5
  
  // NSWindow (PrivateAPI) overrides.
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle {
    // - NSThemeFrame and its subclasses will be nil if it's missing at runtime.
    if ([BrowserWindowFrame class])
@@ -42,14 +42,14 @@ index 6e116d634c658ff26f6990fae5fcac975285e865..5beceecf8e0d712b69eefeba939c6fa5
  // Keyboard -> Shortcuts -> Keyboard. Usually Ctrl+F5. The argument (|unknown|)
  // tends to just be nil.
 diff --git a/components/remote_cocoa/app_shim/native_widget_mac_frameless_nswindow.mm b/components/remote_cocoa/app_shim/native_widget_mac_frameless_nswindow.mm
-index 3a815ebf505bd95fa7f6b61ba433d98fbfe20225..8584b6b09323a9e100841dcde9a963b48e84b518 100644
+index 3a815ebf505bd95fa7f6b61ba433d98fbfe20225..dbbebbdc1735bc14224dfcde0b7fe3a6fd9f9e40 100644
 --- a/components/remote_cocoa/app_shim/native_widget_mac_frameless_nswindow.mm
 +++ b/components/remote_cocoa/app_shim/native_widget_mac_frameless_nswindow.mm
 @@ -4,6 +4,8 @@
  
  #import "components/remote_cocoa/app_shim/native_widget_mac_frameless_nswindow.h"
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
 +
  @interface NSWindow (PrivateAPI)
  + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle;
@@ -62,7 +62,7 @@ index 3a815ebf505bd95fa7f6b61ba433d98fbfe20225..8584b6b09323a9e100841dcde9a963b4
 +
  @implementation NativeWidgetMacFramelessNSWindow
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
 +
  + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle {
    if ([NativeWidgetMacFramelessNSWindowFrame class]) {
@@ -75,14 +75,14 @@ index 3a815ebf505bd95fa7f6b61ba433d98fbfe20225..8584b6b09323a9e100841dcde9a963b4
 +
  @end
 diff --git a/components/remote_cocoa/app_shim/native_widget_mac_nswindow.h b/components/remote_cocoa/app_shim/native_widget_mac_nswindow.h
-index e7bf48ba670dbe8fa2a8688cf89e74a7d15cc6a3..5596703bbae1977c9c2bcd421373c578ca9780cb 100644
+index e7bf48ba670dbe8fa2a8688cf89e74a7d15cc6a3..f385de06d8b33aafa0eac1858d9fd23347f64594 100644
 --- a/components/remote_cocoa/app_shim/native_widget_mac_nswindow.h
 +++ b/components/remote_cocoa/app_shim/native_widget_mac_nswindow.h
 @@ -17,6 +17,7 @@ class NativeWidgetNSWindowBridge;
  
  @protocol WindowTouchBarDelegate;
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  // Weak lets Chrome launch even if a future macOS doesn't have the below classes
  WEAK_IMPORT_ATTRIBUTE
  @interface NSNextStepFrame : NSView
@@ -95,14 +95,14 @@ index e7bf48ba670dbe8fa2a8688cf89e74a7d15cc6a3..5596703bbae1977c9c2bcd421373c578
  // The NSWindow used by BridgedNativeWidget. Provides hooks into AppKit that
  // can only be accomplished by overriding methods.
 diff --git a/components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm b/components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm
-index 0cf281aff32bd37b3539056ea202aa74ef432000..f65046706dc0e05f7d654ea96901fdeee268a445 100644
+index 0cf281aff32bd37b3539056ea202aa74ef432000..9b070697f5243ae25f50aa9f681cec57128da5cf 100644
 --- a/components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm
 +++ b/components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm
 @@ -97,7 +97,9 @@ void OrderChildWindow(NSWindow* child_window,
  }  // namespace
  
  @interface NSWindow (Private)
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  + (Class)frameViewClassForStyleMask:(NSWindowStyleMask)windowStyle;
 +#endif
  - (BOOL)hasKeyAppearance;
@@ -112,7 +112,7 @@ index 0cf281aff32bd37b3539056ea202aa74ef432000..f65046706dc0e05f7d654ea96901fdee
  }
  @end
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
 +
  @implementation NativeWidgetMacNSWindowTitledFrame
  - (void)mouseDown:(NSEvent*)event {
@@ -130,7 +130,7 @@ index 0cf281aff32bd37b3539056ea202aa74ef432000..f65046706dc0e05f7d654ea96901fdee
  
  // NSWindow overrides.
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
 +
  + (Class)frameViewClassForStyleMask:(NSWindowStyleMask)windowStyle {
    if (windowStyle & NSWindowStyleMaskTitled) {

--- a/patches/chromium/mas_disable_remote_accessibility.patch
+++ b/patches/chromium/mas_disable_remote_accessibility.patch
@@ -11,14 +11,14 @@ needs to think it's coming from the PWA process). I think it can just be chopped
 out -- if there are any side-effects, we should be able to work around them.
 
 diff --git a/components/remote_cocoa/app_shim/application_bridge.mm b/components/remote_cocoa/app_shim/application_bridge.mm
-index 89b9323c08cfed0d3ea3a0ec1beaa0bdfabe343e..d000b7f43f393d297a3715ea4279537bcf3fa813 100644
+index 89b9323c08cfed0d3ea3a0ec1beaa0bdfabe343e..69ae95eb8537bab751d27749d6cf392a8419f317 100644
 --- a/components/remote_cocoa/app_shim/application_bridge.mm
 +++ b/components/remote_cocoa/app_shim/application_bridge.mm
 @@ -51,6 +51,7 @@
  
    // NativeWidgetNSWindowHostHelper:
    id GetNativeViewAccessible() override {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
      if (!remote_accessibility_element_) {
        base::ProcessId browser_pid = base::kNullProcessId;
        std::vector<uint8_t> element_token;
@@ -36,7 +36,7 @@ index 89b9323c08cfed0d3ea3a0ec1beaa0bdfabe343e..d000b7f43f393d297a3715ea4279537b
    mojo::AssociatedRemote<mojom::TextInputHost> text_input_host_remote_;
  
    std::unique_ptr<NativeWidgetNSWindowBridge> bridge_;
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    base::scoped_nsobject<NSAccessibilityRemoteUIElement>
        remote_accessibility_element_;
 +#endif
@@ -44,14 +44,14 @@ index 89b9323c08cfed0d3ea3a0ec1beaa0bdfabe343e..d000b7f43f393d297a3715ea4279537b
  
  }  // namespace
 diff --git a/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm b/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
-index 1b91b71bae8201d7cae5850a8c810bd179a36ab1..7f4bc1ded505067ba83001b389ab5813bad17dc4 100644
+index 1b91b71bae8201d7cae5850a8c810bd179a36ab1..f010b3565f81ecb692269d778822b31f9cbfe585 100644
 --- a/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
 +++ b/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
 @@ -566,10 +566,12 @@ NSUInteger CountBridgedWindows(NSArray* child_windows) {
    // this should be treated as an error and caught early.
    CHECK(bridged_view_);
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    // Send the accessibility tokens for the NSView now that it exists.
    host_->SetRemoteAccessibilityTokens(
        ui::RemoteAccessibility::GetTokenForLocalElement(window_),
@@ -61,14 +61,14 @@ index 1b91b71bae8201d7cae5850a8c810bd179a36ab1..7f4bc1ded505067ba83001b389ab5813
    // Beware: This view was briefly removed (in favor of a bare CALayer) in
    // crrev/c/1236675. The ordering of unassociated layers relative to NSView
 diff --git a/content/app_shim_remote_cocoa/ns_view_bridge_factory_impl.mm b/content/app_shim_remote_cocoa/ns_view_bridge_factory_impl.mm
-index abd19b8613e52a6f4c9404f509ab7ed5a61046a6..35945493a02996e88b0c53caf107c4352450aff7 100644
+index abd19b8613e52a6f4c9404f509ab7ed5a61046a6..8c69b989882084946bb821e1d64d75657f17ab26 100644
 --- a/content/app_shim_remote_cocoa/ns_view_bridge_factory_impl.mm
 +++ b/content/app_shim_remote_cocoa/ns_view_bridge_factory_impl.mm
 @@ -77,6 +77,7 @@ explicit RenderWidgetHostNSViewBridgeOwner(
  
    // RenderWidgetHostNSViewHostHelper implementation.
    id GetAccessibilityElement() override {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
      if (!remote_accessibility_element_) {
        base::ProcessId browser_pid = base::kNullProcessId;
        std::vector<uint8_t> element_token;
@@ -86,7 +86,7 @@ index abd19b8613e52a6f4c9404f509ab7ed5a61046a6..35945493a02996e88b0c53caf107c435
      return nil;
    }
    void SetAccessibilityWindow(NSWindow* window) override {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
      host_->SetRemoteAccessibilityWindowToken(
          ui::RemoteAccessibility::GetTokenForLocalElement(window));
 +#endif
@@ -97,7 +97,7 @@ index abd19b8613e52a6f4c9404f509ab7ed5a61046a6..35945493a02996e88b0c53caf107c435
  
    mojo::AssociatedRemote<mojom::RenderWidgetHostNSViewHost> host_;
    std::unique_ptr<RenderWidgetHostNSViewBridge> bridge_;
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    base::scoped_nsobject<NSAccessibilityRemoteUIElement>
        remote_accessibility_element_;
 +#endif
@@ -105,14 +105,14 @@ index abd19b8613e52a6f4c9404f509ab7ed5a61046a6..35945493a02996e88b0c53caf107c435
  }
  
 diff --git a/content/browser/accessibility/browser_accessibility_manager_mac.mm b/content/browser/accessibility/browser_accessibility_manager_mac.mm
-index 67473b500bc8305bc21ec0324001ea5a64612aee..964acff055c3e192813b7793894b3fde8940facb 100644
+index 67473b500bc8305bc21ec0324001ea5a64612aee..859e45bd6f4f130947e0718e32fea4abe8fe3a8c 100644
 --- a/content/browser/accessibility/browser_accessibility_manager_mac.mm
 +++ b/content/browser/accessibility/browser_accessibility_manager_mac.mm
 @@ -22,7 +22,9 @@
  #include "ui/accelerated_widget_mac/accelerated_widget_mac.h"
  #include "ui/accessibility/ax_role_properties.h"
  #include "ui/accessibility/platform/ax_private_webkit_constants_mac.h"
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  #include "ui/base/cocoa/remote_accessibility_api.h"
 +#endif
  
@@ -122,7 +122,7 @@ index 67473b500bc8305bc21ec0324001ea5a64612aee..964acff055c3e192813b7793894b3fde
    if ([NSApp isActive])
      return window == [NSApp accessibilityFocusedWindow];
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    // TODO(accessibility): We need a solution to the problem described below.
    // If the window is NSAccessibilityRemoteUIElement, there are some challenges:
    // 1. NSApp is the browser which spawned the PWA, and what it considers the
@@ -135,14 +135,14 @@ index 67473b500bc8305bc21ec0324001ea5a64612aee..964acff055c3e192813b7793894b3fde
    return false;
  }
 diff --git a/content/browser/renderer_host/render_widget_host_view_mac.h b/content/browser/renderer_host/render_widget_host_view_mac.h
-index c1f2725cf74fe8845843461518a849f2cbf2c024..897f46a7333eb80c8fe54535f6159dc1350d2d64 100644
+index c1f2725cf74fe8845843461518a849f2cbf2c024..c9f489a8603a63dc2641fbd435c4ab1de9fafbd3 100644
 --- a/content/browser/renderer_host/render_widget_host_view_mac.h
 +++ b/content/browser/renderer_host/render_widget_host_view_mac.h
 @@ -52,7 +52,9 @@ class ScopedPasswordInputEnabler;
  
  @protocol RenderWidgetHostViewMacDelegate;
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  @class NSAccessibilityRemoteUIElement;
 +#endif
  @class RenderWidgetHostViewCocoa;
@@ -152,7 +152,7 @@ index c1f2725cf74fe8845843461518a849f2cbf2c024..897f46a7333eb80c8fe54535f6159dc1
    // EnsureSurfaceSynchronizedForWebTest().
    uint32_t latest_capture_sequence_number_ = 0u;
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    // Remote accessibility objects corresponding to the NSWindow that this is
    // displayed to the user in.
    base::scoped_nsobject<NSAccessibilityRemoteUIElement>
@@ -162,14 +162,14 @@ index c1f2725cf74fe8845843461518a849f2cbf2c024..897f46a7333eb80c8fe54535f6159dc1
    // Used to force the NSApplication's focused accessibility element to be the
    // content::BrowserAccessibilityCocoa accessibility tree when the NSView for
 diff --git a/content/browser/renderer_host/render_widget_host_view_mac.mm b/content/browser/renderer_host/render_widget_host_view_mac.mm
-index f2cd4583734aab9a6760f357eb6fb9ce73d96753..a420b3cf9b1c325967318db322d61c4ebc4cf7c6 100644
+index f2cd4583734aab9a6760f357eb6fb9ce73d96753..cc2836fb66d9cf84fa298f1d75480f2c796b274f 100644
 --- a/content/browser/renderer_host/render_widget_host_view_mac.mm
 +++ b/content/browser/renderer_host/render_widget_host_view_mac.mm
 @@ -260,8 +260,10 @@
  void RenderWidgetHostViewMac::MigrateNSViewBridge(
      remote_cocoa::mojom::Application* remote_cocoa_application,
      uint64_t parent_ns_view_id) {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    // Destroy the previous remote accessibility element.
    remote_window_accessible_.reset();
 +#endif
@@ -180,7 +180,7 @@ index f2cd4583734aab9a6760f357eb6fb9ce73d96753..a420b3cf9b1c325967318db322d61c4e
  
  gfx::NativeViewAccessible
  RenderWidgetHostViewMac::AccessibilityGetNativeViewAccessibleForWindow() {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    if (remote_window_accessible_)
      return remote_window_accessible_.get();
 +#endif
@@ -191,7 +191,7 @@ index f2cd4583734aab9a6760f357eb6fb9ce73d96753..a420b3cf9b1c325967318db322d61c4e
  }
  
  void RenderWidgetHostViewMac::SetAccessibilityWindow(NSWindow* window) {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    // When running in-process, just use the NSView's NSWindow as its own
    // accessibility element.
    remote_window_accessible_.reset();
@@ -203,7 +203,7 @@ index f2cd4583734aab9a6760f357eb6fb9ce73d96753..a420b3cf9b1c325967318db322d61c4e
  void RenderWidgetHostViewMac::GetRenderWidgetAccessibilityToken(
      GetRenderWidgetAccessibilityTokenCallback callback) {
    base::ProcessId pid = getpid();
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    id element_id = GetNativeViewAccessible();
    std::vector<uint8_t> token =
        ui::RemoteAccessibility::GetTokenForLocalElement(element_id);
@@ -215,7 +215,7 @@ index f2cd4583734aab9a6760f357eb6fb9ce73d96753..a420b3cf9b1c325967318db322d61c4e
  
  void RenderWidgetHostViewMac::SetRemoteAccessibilityWindowToken(
      const std::vector<uint8_t>& window_token) {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    if (window_token.empty()) {
      remote_window_accessible_.reset();
    } else {
@@ -245,14 +245,14 @@ index 52f8e4e48b4c54dc39231dc4702dc4ce9089c520..c1cc143209fbd60a34ad1d8f92c55c94
      sources += [
        "device_form_factor_ios.mm",
 diff --git a/ui/base/cocoa/remote_accessibility_api.h b/ui/base/cocoa/remote_accessibility_api.h
-index 4d47115d3f72da17b2ada8866770ac24717c29da..a74c655a6143a3ce9b10c6c23a508b1d306bb980 100644
+index 4d47115d3f72da17b2ada8866770ac24717c29da..506d7847d904478793d992dbe548a61177644d09 100644
 --- a/ui/base/cocoa/remote_accessibility_api.h
 +++ b/ui/base/cocoa/remote_accessibility_api.h
 @@ -11,6 +11,8 @@
  #include "base/component_export.h"
  #include "base/mac/scoped_nsobject.h"
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
 +
  @interface NSAccessibilityRemoteUIElement : NSObject
  + (void)setRemoteUIApp:(BOOL)flag;
@@ -265,14 +265,14 @@ index 4d47115d3f72da17b2ada8866770ac24717c29da..a74c655a6143a3ce9b10c6c23a508b1d
 +
  #endif  // UI_BASE_COCOA_REMOTE_ACCESSIBILITY_API_H_
 diff --git a/ui/views/cocoa/native_widget_mac_ns_window_host.h b/ui/views/cocoa/native_widget_mac_ns_window_host.h
-index f6d8e8847203d705aea9f581bab84c361a6164c9..d8b17d16aaeba9e9aa95bd0e646a143b325ecc64 100644
+index f6d8e8847203d705aea9f581bab84c361a6164c9..4130f1bced39af36f9761613a1d1cbcddf922dd2 100644
 --- a/ui/views/cocoa/native_widget_mac_ns_window_host.h
 +++ b/ui/views/cocoa/native_widget_mac_ns_window_host.h
 @@ -32,7 +32,9 @@
  #include "ui/views/window/dialog_observer.h"
  
  @class NativeWidgetMacNSWindow;
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  @class NSAccessibilityRemoteUIElement;
 +#endif
  @class NSView;
@@ -282,7 +282,7 @@ index f6d8e8847203d705aea9f581bab84c361a6164c9..d8b17d16aaeba9e9aa95bd0e646a143b
    mojo::AssociatedRemote<remote_cocoa::mojom::NativeWidgetNSWindow>
        remote_ns_window_remote_;
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    // Remote accessibility objects corresponding to the NSWindow and its root
    // NSView.
    base::scoped_nsobject<NSAccessibilityRemoteUIElement>
@@ -293,14 +293,14 @@ index f6d8e8847203d705aea9f581bab84c361a6164c9..d8b17d16aaeba9e9aa95bd0e646a143b
    // Used to force the NSApplication's focused accessibility element to be the
    // views::Views accessibility tree when the NSView for this is focused.
 diff --git a/ui/views/cocoa/native_widget_mac_ns_window_host.mm b/ui/views/cocoa/native_widget_mac_ns_window_host.mm
-index 020c952ea07bd67b3acefe33c73e7c1aed598fea..1b67c91b499aa583bd2f7516658f7377cec62566 100644
+index 020c952ea07bd67b3acefe33c73e7c1aed598fea..3bf8849e269b62d9a5a2389b2e45433b3acf8448 100644
 --- a/ui/views/cocoa/native_widget_mac_ns_window_host.mm
 +++ b/ui/views/cocoa/native_widget_mac_ns_window_host.mm
 @@ -336,14 +336,22 @@ void HandleAccelerator(const ui::Accelerator& accelerator,
  NativeWidgetMacNSWindowHost::GetNativeViewAccessibleForNSView() const {
    if (in_process_ns_window_bridge_)
      return in_process_ns_window_bridge_->ns_view();
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    return remote_view_accessible_.get();
 +#else
 +  return nullptr;
@@ -311,7 +311,7 @@ index 020c952ea07bd67b3acefe33c73e7c1aed598fea..1b67c91b499aa583bd2f7516658f7377
  NativeWidgetMacNSWindowHost::GetNativeViewAccessibleForNSWindow() const {
    if (in_process_ns_window_bridge_)
      return in_process_ns_window_bridge_->ns_window();
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    return remote_window_accessible_.get();
 +#else
 +  return nullptr;
@@ -323,7 +323,7 @@ index 020c952ea07bd67b3acefe33c73e7c1aed598fea..1b67c91b499aa583bd2f7516658f7377
  void NativeWidgetMacNSWindowHost::SetRemoteAccessibilityTokens(
      const std::vector<uint8_t>& window_token,
      const std::vector<uint8_t>& view_token) {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    remote_window_accessible_ =
        ui::RemoteAccessibility::GetRemoteElementFromToken(window_token);
    remote_view_accessible_ =
@@ -337,7 +337,7 @@ index 020c952ea07bd67b3acefe33c73e7c1aed598fea..1b67c91b499aa583bd2f7516658f7377
  bool NativeWidgetMacNSWindowHost::GetRootViewAccessibilityToken(
      base::ProcessId* pid,
      std::vector<uint8_t>* token) {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    *pid = getpid();
    id element_id = GetNativeViewAccessible();
    *token = ui::RemoteAccessibility::GetTokenForLocalElement(element_id);

--- a/patches/chromium/mas_disable_remote_layer.patch
+++ b/patches/chromium/mas_disable_remote_layer.patch
@@ -16,14 +16,14 @@ cases where performance improves when disabling remote CoreAnimation (remote
 CoreAnimation is really only about battery usage).
 
 diff --git a/gpu/ipc/service/image_transport_surface_overlay_mac.h b/gpu/ipc/service/image_transport_surface_overlay_mac.h
-index 54df9cd23be7441f9b61e9f94b191b3a6a7ab6fd..1ba6c4804cd98c6aa118fcd4ee74b1368648bde6 100644
+index 54df9cd23be7441f9b61e9f94b191b3a6a7ab6fd..861f6579d9fb93ab7c3741fd39eaaf8bda76ed9d 100644
 --- a/gpu/ipc/service/image_transport_surface_overlay_mac.h
 +++ b/gpu/ipc/service/image_transport_surface_overlay_mac.h
 @@ -21,7 +21,9 @@
  #include "ui/gl/gl_surface_egl.h"
  #endif
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  @class CAContext;
 +#endif
  @class CALayer;
@@ -33,7 +33,7 @@ index 54df9cd23be7441f9b61e9f94b191b3a6a7ab6fd..1ba6c4804cd98c6aa118fcd4ee74b136
    base::WeakPtr<ImageTransportSurfaceDelegate> delegate_;
  
    bool use_remote_layer_api_;
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    base::scoped_nsobject<CAContext> ca_context_;
 +#endif
    std::unique_ptr<ui::CALayerTreeCoordinator> ca_layer_tree_coordinator_;
@@ -43,21 +43,21 @@ index 54df9cd23be7441f9b61e9f94b191b3a6a7ab6fd..1ba6c4804cd98c6aa118fcd4ee74b136
    base::WeakPtr<ImageTransportSurfaceDelegate> delegate_;
  
    bool use_remote_layer_api_;
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    base::scoped_nsobject<CAContext> ca_context_;
 +#endif
    std::unique_ptr<ui::CALayerTreeCoordinator> ca_layer_tree_coordinator_;
  
    gfx::Size pixel_size_;
 diff --git a/gpu/ipc/service/image_transport_surface_overlay_mac.mm b/gpu/ipc/service/image_transport_surface_overlay_mac.mm
-index 6944ef9d099231c04e1b13e8a434ca436637ddd2..f0e64b88d0dcaff5937424c14a41552a554c2be0 100644
+index 6944ef9d099231c04e1b13e8a434ca436637ddd2..57ec91986dad4f7f18263fdc81ec877406fbee69 100644
 --- a/gpu/ipc/service/image_transport_surface_overlay_mac.mm
 +++ b/gpu/ipc/service/image_transport_surface_overlay_mac.mm
 @@ -68,6 +68,7 @@
    ca_layer_tree_coordinator_ = std::make_unique<ui::CALayerTreeCoordinator>(
        use_remote_layer_api_, allow_av_sample_buffer_display_layer);
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    // Create the CAContext to send this to the GPU process, and the layer for
    // the context.
    if (use_remote_layer_api_) {
@@ -73,7 +73,7 @@ index 6944ef9d099231c04e1b13e8a434ca436637ddd2..f0e64b88d0dcaff5937424c14a41552a
                           "GLImpl", static_cast<int>(gl::GetGLImplementation()),
                           "width", pixel_size_.width());
      if (use_remote_layer_api_) {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
        params.ca_context_id = [ca_context_ contextId];
 +#endif
      } else {
@@ -83,7 +83,7 @@ index 6944ef9d099231c04e1b13e8a434ca436637ddd2..f0e64b88d0dcaff5937424c14a41552a
    ca_layer_tree_coordinator_ = std::make_unique<ui::CALayerTreeCoordinator>(
        use_remote_layer_api_, allow_av_sample_buffer_display_layer);
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    // Create the CAContext to send this to the GPU process, and the layer for
    // the context.
    if (use_remote_layer_api_) {
@@ -99,21 +99,21 @@ index 6944ef9d099231c04e1b13e8a434ca436637ddd2..f0e64b88d0dcaff5937424c14a41552a
                           "GLImpl", static_cast<int>(gl::GetGLImplementation()),
                           "width", pixel_size_.width());
      if (use_remote_layer_api_) {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
        params.ca_context_id = [ca_context_ contextId];
 +#endif
      } else {
        IOSurfaceRef io_surface =
            ca_layer_tree_coordinator_->GetIOSurfaceForDisplay();
 diff --git a/ui/accelerated_widget_mac/display_ca_layer_tree.mm b/ui/accelerated_widget_mac/display_ca_layer_tree.mm
-index 2c4821b34f71d30ce814bd1f3cf9a7a76bbaac66..cd7e0eac449bc81d5c9f6f0bed40b0d339712427 100644
+index 2c4821b34f71d30ce814bd1f3cf9a7a76bbaac66..c7dc371c780a405f502a84c77e92251ae08f66e0 100644
 --- a/ui/accelerated_widget_mac/display_ca_layer_tree.mm
 +++ b/ui/accelerated_widget_mac/display_ca_layer_tree.mm
 @@ -99,6 +99,7 @@ - (void)setContentsChanged;
  }
  
  void DisplayCALayerTree::GotCALayerFrame(uint32_t ca_context_id) {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    // Early-out if the remote layer has not changed.
    if ([remote_layer_ contextId] == ca_context_id)
      return;
@@ -128,14 +128,14 @@ index 2c4821b34f71d30ce814bd1f3cf9a7a76bbaac66..cd7e0eac449bc81d5c9f6f0bed40b0d3
  
  void DisplayCALayerTree::GotIOSurfaceFrame(
 diff --git a/ui/base/cocoa/remote_layer_api.h b/ui/base/cocoa/remote_layer_api.h
-index 9b691e2f16c68235dd180a28b6eb2eefc91f8e4c..0ce8048c6a72fe1483d71b2fd5786c28d86ac2bf 100644
+index 9b691e2f16c68235dd180a28b6eb2eefc91f8e4c..9d4a7fb36e671980024b895eaafab2d970ac2818 100644
 --- a/ui/base/cocoa/remote_layer_api.h
 +++ b/ui/base/cocoa/remote_layer_api.h
 @@ -13,6 +13,7 @@
  
  #include "base/component_export.h"
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  // The CGSConnectionID is used to create the CAContext in the process that is
  // going to share the CALayers that it is rendering to another process to
  // display.
@@ -149,14 +149,14 @@ index 9b691e2f16c68235dd180a28b6eb2eefc91f8e4c..0ce8048c6a72fe1483d71b2fd5786c28
  
  // This function will check if all of the interfaces listed above are supported
 diff --git a/ui/base/cocoa/remote_layer_api.mm b/ui/base/cocoa/remote_layer_api.mm
-index e23eb7719a9798afe984c6af6a422167b93d89b5..2fcc48067c2992a2fae950a678269014b7295817 100644
+index e23eb7719a9798afe984c6af6a422167b93d89b5..d448bc09ee54fc77f1ed4d088d1369b96f83a1db 100644
 --- a/ui/base/cocoa/remote_layer_api.mm
 +++ b/ui/base/cocoa/remote_layer_api.mm
 @@ -10,6 +10,7 @@
  
  namespace ui {
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  namespace {
  // Control use of cross-process CALayers to display content directly from the
  // GPU process on Mac.
@@ -167,7 +167,7 @@ index e23eb7719a9798afe984c6af6a422167b93d89b5..2fcc48067c2992a2fae950a678269014
 +#endif
  
  bool RemoteLayerAPISupported() {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    if (!base::FeatureList::IsEnabled(kRemoteCoreAnimationAPI))
      return false;
  

--- a/patches/chromium/mas_no_private_api.patch
+++ b/patches/chromium/mas_no_private_api.patch
@@ -7,14 +7,14 @@ Guard usages in blink of private Mac APIs by MAS_BUILD, so they can be
 excluded for people who want to submit their apps to the Mac App store.
 
 diff --git a/base/process/process_info_mac.cc b/base/process/process_info_mac.cc
-index 6840358c3187522c63dff66b5a85567aaadc5c12..ef94524eab52719c84e176fde2afd88f85223888 100644
+index 6840358c3187522c63dff66b5a85567aaadc5c12..72c57fbc5fbb267f96ff9e21915fb801ed5bf24e 100644
 --- a/base/process/process_info_mac.cc
 +++ b/base/process/process_info_mac.cc
 @@ -9,18 +9,22 @@
  #include <stdlib.h>
  #include <unistd.h>
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  extern "C" {
  pid_t responsibility_get_pid_responsible_for_pid(pid_t)
      API_AVAILABLE(macosx(10.12));
@@ -24,7 +24,7 @@ index 6840358c3187522c63dff66b5a85567aaadc5c12..ef94524eab52719c84e176fde2afd88f
  namespace base {
  
  bool IsProcessSelfResponsible() {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    if (__builtin_available(macOS 10.14, *)) {
      const pid_t pid = getpid();
      return responsibility_get_pid_responsible_for_pid(pid) == pid;
@@ -34,14 +34,14 @@ index 6840358c3187522c63dff66b5a85567aaadc5c12..ef94524eab52719c84e176fde2afd88f
  }
  
 diff --git a/content/common/pseudonymization_salt.cc b/content/common/pseudonymization_salt.cc
-index c7e4ef224e76b4df4fa08bb7fa8dd78605ea8de1..16cb4084ecc5818813022412a00a3b1acc67cc05 100644
+index c7e4ef224e76b4df4fa08bb7fa8dd78605ea8de1..8a15ee3e062e108824c6b2fadc2ffa807ff03ade 100644
 --- a/content/common/pseudonymization_salt.cc
 +++ b/content/common/pseudonymization_salt.cc
 @@ -41,11 +41,13 @@ uint32_t GetPseudonymizationSalt() {
    uint32_t salt = g_salt.load();
  
    if (salt == 0) {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  #if DCHECK_IS_ON()
      // Only the Browser process needs to initialize the `salt` on demand.
      // Other processes (identified via the IsProcessSandboxed heuristic) should
@@ -52,14 +52,14 @@ index c7e4ef224e76b4df4fa08bb7fa8dd78605ea8de1..16cb4084ecc5818813022412a00a3b1a
      salt = InitializeSalt();
    }
 diff --git a/content/renderer/renderer_main_platform_delegate_mac.mm b/content/renderer/renderer_main_platform_delegate_mac.mm
-index add9345fdd076698fc7ec654d7ef1701699639a4..13e615dbbe0fca71acea1f494944262933843f40 100644
+index add9345fdd076698fc7ec654d7ef1701699639a4..ea5287cbe878014e4f0f6124a459bef225b0ca59 100644
 --- a/content/renderer/renderer_main_platform_delegate_mac.mm
 +++ b/content/renderer/renderer_main_platform_delegate_mac.mm
 @@ -10,9 +10,11 @@
  #include "sandbox/mac/seatbelt.h"
  #include "sandbox/mac/system_services.h"
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  extern "C" {
  CGError CGSSetDenyWindowServerConnections(bool);
  }
@@ -71,7 +71,7 @@ index add9345fdd076698fc7ec654d7ef1701699639a4..13e615dbbe0fca71acea1f4949442629
  // verifies there are no existing open connections), and then indicates that
  // Chrome should continue execution without access to launchservicesd.
  void DisableSystemServices() {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    // Tell the WindowServer that we don't want to make any future connections.
    // This will return Success as long as there are no open connections, which
    // is what we want.
@@ -84,7 +84,7 @@ index add9345fdd076698fc7ec654d7ef1701699639a4..13e615dbbe0fca71acea1f4949442629
  
  }  // namespace
 diff --git a/content/renderer/theme_helper_mac.mm b/content/renderer/theme_helper_mac.mm
-index f50448237c40710e25644c2f7d44e8d0bc0789c8..fd351c916993a8950b595c103f3f5a4086d5480b 100644
+index f50448237c40710e25644c2f7d44e8d0bc0789c8..752b575cf341546bdcc46e6dfff28fe4c66325b3 100644
 --- a/content/renderer/theme_helper_mac.mm
 +++ b/content/renderer/theme_helper_mac.mm
 @@ -7,11 +7,11 @@
@@ -92,7 +92,7 @@ index f50448237c40710e25644c2f7d44e8d0bc0789c8..fd351c916993a8950b595c103f3f5a40
  
  #include "base/strings/sys_string_conversions.h"
 -
-+#if !defined(MAS_BUILD)
++#if !IS_MAS_BUILD()
  extern "C" {
  bool CGFontRenderingGetFontSmoothingDisabled(void) API_AVAILABLE(macos(10.14));
  }
@@ -105,7 +105,7 @@ index f50448237c40710e25644c2f7d44e8d0bc0789c8..fd351c916993a8950b595c103f3f5a40
  bool IsSubpixelAntialiasingAvailable() {
    if (__builtin_available(macOS 10.14, *)) {
      // See https://trac.webkit.org/changeset/239306/webkit for more info.
-+#if !defined(MAS_BUILD)
++#if !IS_MAS_BUILD()
      return !CGFontRenderingGetFontSmoothingDisabled();
 +#else
 +    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
@@ -122,14 +122,14 @@ index f50448237c40710e25644c2f7d44e8d0bc0789c8..fd351c916993a8950b595c103f3f5a40
  }
  
 diff --git a/device/bluetooth/bluetooth_adapter_mac.mm b/device/bluetooth/bluetooth_adapter_mac.mm
-index 644990412b4d67789faffc65c4f1114fa96c8f42..085ceafcda3f66b27cec2aedde86ac7ca23fcf8f 100644
+index 644990412b4d67789faffc65c4f1114fa96c8f42..7ecbfbff3ac73157a3eac371c673ea80b55c619b 100644
 --- a/device/bluetooth/bluetooth_adapter_mac.mm
 +++ b/device/bluetooth/bluetooth_adapter_mac.mm
 @@ -43,6 +43,7 @@
  #include "device/bluetooth/bluetooth_socket_mac.h"
  #include "device/bluetooth/public/cpp/bluetooth_address.h"
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  extern "C" {
  // Undocumented IOBluetooth Preference API [1]. Used by `blueutil` [2] and
  // `Karabiner` [3] to programmatically control the Bluetooth state. Calling the
@@ -145,7 +145,7 @@ index 644990412b4d67789faffc65c4f1114fa96c8f42..085ceafcda3f66b27cec2aedde86ac7c
      : controller_state_function_(
            base::BindRepeating(&BluetoothAdapterMac::GetHostControllerState,
                                base::Unretained(this))),
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
        power_state_function_(
            base::BindRepeating(IOBluetoothPreferenceSetControllerPowerState)),
 +#endif
@@ -156,7 +156,7 @@ index 644990412b4d67789faffc65c4f1114fa96c8f42..085ceafcda3f66b27cec2aedde86ac7c
  }
  
  bool BluetoothAdapterMac::SetPoweredImpl(bool powered) {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    power_state_function_.Run(base::strict_cast<int>(powered));
    return true;
 +#else
@@ -196,7 +196,7 @@ index f2e38845218fe585085ca4ad9dc364ce2fdf3546..516bd4ae829d67e9d53b783671a2f603
  }
  
 diff --git a/net/dns/dns_config_service_posix.cc b/net/dns/dns_config_service_posix.cc
-index a8a223d1d9ea6de51a27f148c008ee8be38af29a..7413277bd91e7a08042fc957f89112fcb53d440c 100644
+index a8a223d1d9ea6de51a27f148c008ee8be38af29a..328200858bd7aa4077bf6824bfc1367bda748920 100644
 --- a/net/dns/dns_config_service_posix.cc
 +++ b/net/dns/dns_config_service_posix.cc
 @@ -130,8 +130,8 @@ class DnsConfigServicePosix::Watcher : public DnsConfigService::Watcher {
@@ -205,7 +205,7 @@ index a8a223d1d9ea6de51a27f148c008ee8be38af29a..7413277bd91e7a08042fc957f89112fc
      CheckOnCorrectSequence();
 -
      bool success = true;
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
      if (!config_watcher_.Watch(base::BindRepeating(&Watcher::OnConfigChanged,
                                                     base::Unretained(this)))) {
        LOG(ERROR) << "DNS config watch failed to start.";
@@ -218,14 +218,14 @@ index a8a223d1d9ea6de51a27f148c008ee8be38af29a..7413277bd91e7a08042fc957f89112fc
    }
  
 diff --git a/sandbox/mac/sandbox_compiler.cc b/sandbox/mac/sandbox_compiler.cc
-index 5db411212b62b583ae26e9ecd0a87ad5fc5504e8..d5feedb02900a2a323b8a3961b1de21734ad1b65 100644
+index 5db411212b62b583ae26e9ecd0a87ad5fc5504e8..2778852a1573ca5d573018171caeadf1e89f3b9e 100644
 --- a/sandbox/mac/sandbox_compiler.cc
 +++ b/sandbox/mac/sandbox_compiler.cc
 @@ -28,6 +28,7 @@ bool SandboxCompiler::InsertStringParam(const std::string& key,
  }
  
  bool SandboxCompiler::CompileAndApplyProfile(std::string* error) {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    char* error_internal = nullptr;
    std::vector<const char*> params;
  
@@ -238,14 +238,14 @@ index 5db411212b62b583ae26e9ecd0a87ad5fc5504e8..d5feedb02900a2a323b8a3961b1de217
  }
  
 diff --git a/sandbox/mac/seatbelt.cc b/sandbox/mac/seatbelt.cc
-index 1e75790d60789746073828cc22d3863b35ab6f95..68e68bb1bd0b5c897bf385911ab36f5562563974 100644
+index 1e75790d60789746073828cc22d3863b35ab6f95..08fa6b16d09e2ceb73094639fa81570202123178 100644
 --- a/sandbox/mac/seatbelt.cc
 +++ b/sandbox/mac/seatbelt.cc
 @@ -64,7 +64,11 @@ void Seatbelt::FreeError(char* errorbuf) {
  
  // static
  bool Seatbelt::IsSandboxed() {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    return ::sandbox_check(getpid(), NULL, 0);
 +#else
 +  return true;
@@ -254,14 +254,14 @@ index 1e75790d60789746073828cc22d3863b35ab6f95..68e68bb1bd0b5c897bf385911ab36f55
  
  }  // namespace sandbox
 diff --git a/sandbox/mac/seatbelt_extension.cc b/sandbox/mac/seatbelt_extension.cc
-index 18479382a277cb2b25626ec8d31442bfd1377ee6..b048bb27eee1001c2bc34092220150d312ca61c6 100644
+index 18479382a277cb2b25626ec8d31442bfd1377ee6..7d80d7fa8337523c3a70f317f883f0cc26c6f40b 100644
 --- a/sandbox/mac/seatbelt_extension.cc
 +++ b/sandbox/mac/seatbelt_extension.cc
 @@ -11,6 +11,7 @@
  #include "base/notreached.h"
  #include "sandbox/mac/seatbelt_extension_token.h"
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  // libsandbox private API.
  extern "C" {
  extern const char* APP_SANDBOX_READ;
@@ -277,7 +277,7 @@ index 18479382a277cb2b25626ec8d31442bfd1377ee6..b048bb27eee1001c2bc34092220150d3
  
  bool SeatbeltExtension::Consume() {
    DCHECK(!token_.empty());
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    handle_ = sandbox_extension_consume(token_.c_str());
 +#else
 +  handle_ = -1;
@@ -289,7 +289,7 @@ index 18479382a277cb2b25626ec8d31442bfd1377ee6..b048bb27eee1001c2bc34092220150d3
  }
  
  bool SeatbeltExtension::Revoke() {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    int rv = sandbox_extension_release(handle_);
 +#else
 +  int rv = -1;
@@ -301,7 +301,7 @@ index 18479382a277cb2b25626ec8d31442bfd1377ee6..b048bb27eee1001c2bc34092220150d3
  char* SeatbeltExtension::IssueToken(SeatbeltExtension::Type type,
                                      const std::string& resource) {
    switch (type) {
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
      case FILE_READ:
        return sandbox_extension_issue_file(APP_SANDBOX_READ, resource.c_str(),
                                            0);
@@ -313,14 +313,14 @@ index 18479382a277cb2b25626ec8d31442bfd1377ee6..b048bb27eee1001c2bc34092220150d3
        NOTREACHED();
        return nullptr;
 diff --git a/ui/accessibility/platform/inspect/ax_transform_mac.mm b/ui/accessibility/platform/inspect/ax_transform_mac.mm
-index fe043e6dc2203a9054ae367b70a3854b8560c9c7..8d8ba5065d3c50263650eb2452a0f81449d40a25 100644
+index fe043e6dc2203a9054ae367b70a3854b8560c9c7..6cc51d9df176512f6f296e0eb82bc31b5a9515fa 100644
 --- a/ui/accessibility/platform/inspect/ax_transform_mac.mm
 +++ b/ui/accessibility/platform/inspect/ax_transform_mac.mm
 @@ -88,6 +88,7 @@
      }
    }
  
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
    // AXTextMarker
    if (IsAXTextMarker(value)) {
      return AXTextMarkerToBaseValue(value, indexer);

--- a/patches/chromium/mas_use_public_apis_to_determine_if_a_font_is_a_system_font.patch
+++ b/patches/chromium/mas_use_public_apis_to_determine_if_a_font_is_a_system_font.patch
@@ -9,14 +9,14 @@ system font by checking if it's kCTFontPriorityAttribute is set to
 system priority.
 
 diff --git a/ui/gfx/platform_font_mac.mm b/ui/gfx/platform_font_mac.mm
-index b9858f5c8d9abcdea0ef40d8b0bc9c2606e977f5..72ffad13176771955f24b81bf73cf1d40faed56d 100644
+index b9858f5c8d9abcdea0ef40d8b0bc9c2606e977f5..e4a7f4ac33e113270ebdd17633b9c345619447d2 100644
 --- a/ui/gfx/platform_font_mac.mm
 +++ b/ui/gfx/platform_font_mac.mm
 @@ -25,9 +25,11 @@
  
  using Weight = Font::Weight;
  
-+#if !defined(MAS_BUILD)
++#if !IS_MAS_BUILD()
  extern "C" {
  bool CTFontDescriptorIsSystemUIFont(CTFontDescriptorRef);
  }
@@ -28,7 +28,7 @@ index b9858f5c8d9abcdea0ef40d8b0bc9c2606e977f5..72ffad13176771955f24b81bf73cf1d4
    // TODO(avi, etienneb): Figure out this font stuff.
    base::ScopedCFTypeRef<CTFontDescriptorRef> descriptor(
        CTFontCopyFontDescriptor(font));
-+#if defined(MAS_BUILD)
++#if IS_MAS_BUILD()
 +  CFNumberRef priority = (CFNumberRef)CTFontDescriptorCopyAttribute(descriptor.get(), (CFStringRef)kCTFontPriorityAttribute);
 +  SInt64 v;
 +  if (CFNumberGetValue(priority, kCFNumberSInt64Type, &v) && v == kCTFontPrioritySystem) {

--- a/patches/chromium/render_widget_host_view_mac.patch
+++ b/patches/chromium/render_widget_host_view_mac.patch
@@ -10,7 +10,7 @@ kinds of utility windows. Similarly for `disableAutoHideCursor`.
 Additionally, disables usage of some private APIs in MAS builds.
 
 diff --git a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm b/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
-index 22b03d5bd27f09731a3c2d6dbb03c7dc612a2975..274a7e784af522b8f58c36095ca6c0cdadb97671 100644
+index 22b03d5bd27f09731a3c2d6dbb03c7dc612a2975..75e6a47f6b96695f3ef3c3a599bd70cb92935623 100644
 --- a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
 +++ b/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
 @@ -158,6 +158,15 @@ void ExtractUnderlines(NSAttributedString* string,
@@ -65,7 +65,7 @@ index 22b03d5bd27f09731a3c2d6dbb03c7dc612a2975..274a7e784af522b8f58c36095ca6c0cd
  // Since this implementation doesn't have to wait any IPC calls, this doesn't
  // make any key-typing jank. --hbono 7/23/09
  //
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
  extern "C" {
  extern NSString* NSTextInputReplacementRangeAttributeName;
  }
@@ -78,7 +78,7 @@ index 22b03d5bd27f09731a3c2d6dbb03c7dc612a2975..274a7e784af522b8f58c36095ca6c0cd
                          NSUnderlineColorAttributeName,
                          NSMarkedClauseSegmentAttributeName,
 -                        NSTextInputReplacementRangeAttributeName, nil]);
-+#ifndef MAS_BUILD
++#if !IS_MAS_BUILD()
 +                        NSTextInputReplacementRangeAttributeName,
 +#endif
 +                        nil]);

--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -62,7 +62,7 @@
 #include "v8/include/v8.h"
 #endif
 
-#if !defined(MAS_BUILD)
+#if !IS_MAS_BUILD()
 #include "components/crash/core/app/crash_switches.h"  // nogncheck
 #include "components/crash/core/app/crashpad.h"        // nogncheck
 #include "components/crash/core/common/crash_key.h"
@@ -301,7 +301,7 @@ absl::optional<int> ElectronMainDelegate::BasicStartupComplete() {
                << " is not supported. See https://crbug.com/638180.";
 #endif
 
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
   // In MAS build we are using --disable-remote-core-animation.
   //
   // According to ccameron:
@@ -345,7 +345,7 @@ void ElectronMainDelegate::PreSandboxStartup() {
                                    process_type == ::switches::kZygoteProcess);
 #endif
 
-#if !defined(MAS_BUILD)
+#if !IS_MAS_BUILD()
   crash_reporter::InitializeCrashKeys();
 #endif
 
@@ -357,7 +357,7 @@ void ElectronMainDelegate::PreSandboxStartup() {
     LoadResourceBundle(locale);
   }
 
-#if BUILDFLAG(IS_WIN) || (BUILDFLAG(IS_MAC) && !defined(MAS_BUILD))
+#if BUILDFLAG(IS_WIN) || (BUILDFLAG(IS_MAC) && !IS_MAS_BUILD())
   // In the main process, we wait for JS to call crashReporter.start() before
   // initializing crashpad. If we're in the renderer, we want to initialize it
   // immediately at boot.
@@ -380,7 +380,7 @@ void ElectronMainDelegate::PreSandboxStartup() {
   }
 #endif
 
-#if !defined(MAS_BUILD)
+#if !IS_MAS_BUILD()
   crash_keys::SetCrashKeysFromCommandLine(*command_line);
   crash_keys::SetPlatformCrashKey();
 #endif

--- a/shell/app/electron_main_mac.cc
+++ b/shell/app/electron_main_mac.cc
@@ -11,7 +11,7 @@
 #include "shell/app/electron_library_main.h"
 #include "shell/app/uv_stdio_fix.h"
 
-#if defined(HELPER_EXECUTABLE) && !defined(MAS_BUILD)
+#if defined(HELPER_EXECUTABLE) && !IS_MAS_BUILD()
 #include <mach-o/dyld.h>
 #include <cstdio>
 
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]) {
   }
 #endif
 
-#if defined(HELPER_EXECUTABLE) && !defined(MAS_BUILD)
+#if defined(HELPER_EXECUTABLE) && !IS_MAS_BUILD()
   uint32_t exec_path_size = 0;
   int rv = _NSGetExecutablePath(NULL, &exec_path_size);
   if (rv != -1) {
@@ -65,7 +65,7 @@ int main(int argc, char* argv[]) {
       abort();
     }
   }
-#endif  // defined(HELPER_EXECUTABLE) && !defined(MAS_BUILD)
+#endif  // defined(HELPER_EXECUTABLE) && !IS_MAS_BUILD
 
   return ElectronMain(argc, argv);
 }

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -34,7 +34,7 @@
 #include "chrome/child/v8_crashpad_support_win.h"
 #endif
 
-#if !defined(MAS_BUILD)
+#if !IS_MAS_BUILD()
 #include "components/crash/core/app/crashpad.h"  // nogncheck
 #include "shell/app/electron_crash_reporter_client.h"
 #include "shell/common/crash_keys.h"
@@ -86,7 +86,7 @@ int SetNodeCliFlags() {
                            node::kDisallowedInEnvironment);
 }
 
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
 void SetCrashKeyStub(const std::string& key, const std::string& value) {}
 void ClearCrashKeyStub(const std::string& key) {}
 #endif
@@ -97,7 +97,7 @@ namespace electron {
 
 v8::Local<v8::Value> GetParameters(v8::Isolate* isolate) {
   std::map<std::string, std::string> keys;
-#if !defined(MAS_BUILD)
+#if !IS_MAS_BUILD()
   electron::crash_keys::GetCrashKeys(&keys);
 #endif
   return gin::ConvertToV8(isolate, keys);
@@ -113,7 +113,7 @@ int NodeMain(int argc, char* argv[]) {
 // TODO(deepak1556): Enable crashpad support on linux for
 // ELECTRON_RUN_AS_NODE processes.
 // Refs https://github.com/electron/electron/issues/36030
-#if BUILDFLAG(IS_WIN) || (BUILDFLAG(IS_MAC) && !defined(MAS_BUILD))
+#if BUILDFLAG(IS_WIN) || (BUILDFLAG(IS_MAC) && !IS_MAS_BUILD())
   ElectronCrashReporterClient::Create();
   crash_reporter::InitializeCrashpad(false, "node");
   crash_keys::SetCrashKeysFromCommandLine(
@@ -189,7 +189,7 @@ int NodeMain(int argc, char* argv[]) {
       // Setup process.crashReporter in child node processes
       gin_helper::Dictionary reporter = gin::Dictionary::CreateEmpty(isolate);
       reporter.SetMethod("getParameters", &GetParameters);
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
       reporter.SetMethod("addExtraParameter", &SetCrashKeyStub);
       reporter.SetMethod("removeExtraParameter", &ClearCrashKeyStub);
 #else

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1826,7 +1826,7 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
       .SetMethod("getAppMetrics", &App::GetAppMetrics)
       .SetMethod("getGPUFeatureStatus", &App::GetGPUFeatureStatus)
       .SetMethod("getGPUInfo", &App::GetGPUInfo)
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
       .SetMethod("startAccessingSecurityScopedResource",
                  &App::StartAccessingSecurityScopedResource)
 #endif

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -235,7 +235,7 @@ class App : public ElectronBrowserClient::Delegate,
   bool IsRunningUnderARM64Translation() const;
 #endif
 
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
   base::RepeatingCallback<void()> StartAccessingSecurityScopedResource(
       gin::Arguments* args);
 #endif

--- a/shell/browser/api/electron_api_crash_reporter.cc
+++ b/shell/browser/api/electron_api_crash_reporter.cc
@@ -30,7 +30,7 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
 
-#if !defined(MAS_BUILD)
+#if !IS_MAS_BUILD()
 #include "components/crash/core/app/crashpad.h"  // nogncheck
 #include "components/crash/core/browser/crash_upload_list_crashpad.h"  // nogncheck
 #include "components/crash/core/common/crash_key.h"
@@ -65,7 +65,7 @@ bool g_crash_reporter_initialized = false;
 
 namespace electron::api::crash_reporter {
 
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
 namespace {
 
 void NoOp() {}
@@ -132,7 +132,7 @@ void Start(const std::string& submit_url,
            const std::map<std::string, std::string>& extra,
            bool is_node_process) {
   TRACE_EVENT0("electron", "crash_reporter::Start");
-#if !defined(MAS_BUILD)
+#if !IS_MAS_BUILD()
   if (g_crash_reporter_initialized)
     return;
   g_crash_reporter_initialized = true;
@@ -182,7 +182,7 @@ void Start(const std::string& submit_url,
 
 namespace {
 
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
 void GetUploadedReports(
     v8::Isolate* isolate,
     base::OnceCallback<void(v8::Local<v8::Value>)> callback) {
@@ -237,13 +237,13 @@ v8::Local<v8::Value> GetUploadedReports(v8::Isolate* isolate) {
 #endif
 
 void SetUploadToServer(bool upload) {
-#if !defined(MAS_BUILD)
+#if !IS_MAS_BUILD()
   ElectronCrashReporterClient::Get()->SetCollectStatsConsent(upload);
 #endif
 }
 
 bool GetUploadToServer() {
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
   return false;
 #else
   return ElectronCrashReporterClient::Get()->GetCollectStatsConsent();
@@ -252,7 +252,7 @@ bool GetUploadToServer() {
 
 v8::Local<v8::Value> GetParameters(v8::Isolate* isolate) {
   std::map<std::string, std::string> keys;
-#if !defined(MAS_BUILD)
+#if !IS_MAS_BUILD()
   electron::crash_keys::GetCrashKeys(&keys);
 #endif
   return gin::ConvertToV8(isolate, keys);
@@ -264,7 +264,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   gin_helper::Dictionary dict(context->GetIsolate(), exports);
   dict.SetMethod("start", &electron::api::crash_reporter::Start);
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
   dict.SetMethod("addExtraParameter", &electron::api::crash_reporter::NoOp);
   dict.SetMethod("removeExtraParameter", &electron::api::crash_reporter::NoOp);
 #else

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -197,7 +197,7 @@
 #include "content/public/browser/plugin_service.h"
 #endif
 
-#ifndef MAS_BUILD
+#if !IS_MAS_BUILD()
 #include "chrome/browser/hang_monitor/hang_crash_dump.h"  // nogncheck
 #endif
 
@@ -2395,7 +2395,7 @@ void WebContents::ForcefullyCrashRenderer() {
     rph->ForceCrash();
 #else
     // Try to generate a crash report for the hung process.
-#ifndef MAS_BUILD
+#if !IS_MAS_BUILD()
     CrashDumpHungChildProcess(rph->GetProcess().Handle());
 #endif
     rph->Shutdown(content::RESULT_CODE_HUNG);

--- a/shell/browser/api/process_metric.cc
+++ b/shell/browser/api/process_metric.cc
@@ -160,7 +160,7 @@ ProcessMemoryInfo ProcessMetric::GetMemoryInfo() const {
 }
 
 bool ProcessMetric::IsSandboxed() const {
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
   return true;
 #else
   return sandbox_check(process.Pid(), nullptr, 0) != 0;

--- a/shell/browser/auto_updater.cc
+++ b/shell/browser/auto_updater.cc
@@ -16,7 +16,7 @@ void AutoUpdater::SetDelegate(Delegate* delegate) {
   delegate_ = delegate;
 }
 
-#if !BUILDFLAG(IS_MAC) || defined(MAS_BUILD)
+#if !BUILDFLAG(IS_MAC) || IS_MAS_BUILD()
 std::string AutoUpdater::GetFeedURL() {
   return "";
 }

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -309,7 +309,7 @@ bool Browser::UpdateUserActivityState(const std::string& type,
 Browser::LoginItemSettings Browser::GetLoginItemSettings(
     const LoginItemSettings& options) {
   LoginItemSettings settings;
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
   settings.open_at_login = platform_util::GetLoginItemEnabled();
 #else
   settings.open_at_login =
@@ -322,7 +322,7 @@ Browser::LoginItemSettings Browser::GetLoginItemSettings(
 }
 
 void Browser::SetLoginItemSettings(LoginItemSettings settings) {
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
   if (!platform_util::SetLoginItemEnabled(settings.open_at_login)) {
     LOG(ERROR) << "Unable to set login item enabled on sandboxed app.";
   }

--- a/shell/browser/notifications/mac/notification_center_delegate.mm
+++ b/shell/browser/notifications/mac/notification_center_delegate.mm
@@ -65,7 +65,7 @@
   return YES;
 }
 
-#if !defined(MAS_BUILD)
+#if !IS_MAS_BUILD()
 // This undocumented method notifies us if a user closes "Alert" notifications
 // https://chromium.googlesource.com/chromium/src/+/lkgr/chrome/browser/notifications/notification_platform_bridge_mac.mm
 - (void)userNotificationCenter:(NSUserNotificationCenter*)center
@@ -76,7 +76,7 @@
 }
 #endif
 
-#if !defined(MAS_BUILD)
+#if !IS_MAS_BUILD()
 // This undocumented method notifies us if a user closes "Banner" notifications
 // https://github.com/mozilla/gecko-dev/blob/master/widget/cocoa/OSXNotificationCenter.mm
 - (void)userNotificationCenter:(NSUserNotificationCenter*)center

--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -340,13 +340,13 @@ void OpenDialogCompletion(int chosen,
   if (chosen == NSModalResponseCancel) {
     dict.Set("canceled", true);
     dict.Set("filePaths", std::vector<base::FilePath>());
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
     dict.Set("bookmarks", std::vector<std::string>());
 #endif
   } else {
     std::vector<base::FilePath> paths;
     dict.Set("canceled", false);
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
     std::vector<std::string> bookmarks;
     if (security_scoped_bookmarks)
       ReadDialogPathsWithBookmarks(dialog, &paths, &bookmarks);
@@ -418,14 +418,14 @@ void SaveDialogCompletion(int chosen,
   if (chosen == NSModalResponseCancel) {
     dict.Set("canceled", true);
     dict.Set("filePath", base::FilePath());
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
     dict.Set("bookmark", base::StringPiece());
 #endif
   } else {
     std::string path = base::SysNSStringToUTF8([[dialog URL] path]);
     dict.Set("filePath", base::FilePath(path));
     dict.Set("canceled", false);
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
     std::string bookmark;
     if (security_scoped_bookmarks) {
       bookmark = GetBookmarkDataFromNSURL([dialog URL]);

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -61,7 +61,7 @@ void ElectronBindings::BindProcess(v8::Isolate* isolate,
                      base::BindRepeating(&ElectronBindings::GetCPUUsage,
                                          base::Unretained(metrics)));
 
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
   process->SetReadOnly("mas", true);
 #endif
 

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -39,7 +39,7 @@
 #include "third_party/blink/renderer/bindings/core/v8/v8_initializer.h"  // nogncheck
 #include "third_party/electron_node/src/debug_utils.h"
 
-#if !defined(MAS_BUILD)
+#if !IS_MAS_BUILD()
 #include "shell/common/crash_keys.h"
 #endif
 
@@ -147,7 +147,7 @@ bool g_is_initialized = false;
 void V8FatalErrorCallback(const char* location, const char* message) {
   LOG(ERROR) << "Fatal error in V8: " << location << " " << message;
 
-#if !defined(MAS_BUILD)
+#if !IS_MAS_BUILD()
   electron::crash_keys::SetCrashKey("electron.v8-fatal.message", message);
   electron::crash_keys::SetCrashKey("electron.v8-fatal.location", location);
 #endif

--- a/shell/renderer/api/electron_api_crash_reporter_renderer.cc
+++ b/shell/renderer/api/electron_api_crash_reporter_renderer.cc
@@ -6,7 +6,7 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
 
-#if !defined(MAS_BUILD)
+#if !IS_MAS_BUILD()
 #include "shell/common/crash_keys.h"
 #endif
 
@@ -14,13 +14,13 @@ namespace {
 
 v8::Local<v8::Value> GetParameters(v8::Isolate* isolate) {
   std::map<std::string, std::string> keys;
-#if !defined(MAS_BUILD)
+#if !IS_MAS_BUILD()
   electron::crash_keys::GetCrashKeys(&keys);
 #endif
   return gin::ConvertToV8(isolate, keys);
 }
 
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
 void SetCrashKeyStub(const std::string& key, const std::string& value) {}
 void ClearCrashKeyStub(const std::string& key) {}
 #endif
@@ -30,7 +30,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   gin_helper::Dictionary dict(context->GetIsolate(), exports);
-#if defined(MAS_BUILD)
+#if IS_MAS_BUILD()
   dict.SetMethod("addExtraParameter", &SetCrashKeyStub);
   dict.SetMethod("removeExtraParameter", &ClearCrashKeyStub);
 #else


### PR DESCRIPTION
This is missing-definition safe and thus allows us to move the definition of this macro away from "all compilation targets" to "just the compilation targets that depend on this macro".

In turn this makes the rebuild time changing from mas <-> darwin only 80 seconds on my machine, instead of the 12-15 minutes it used to take.  This will also allow us in the future to build both MAS and darwin on the same CI machine.  Costing us ~2 minutes on one machine but saving us anywhere from 30 minutes to an hour of CI time on other parts of the matrix.

I think before this lands I want to clean up the new patch file a bit (potentially merge those changes into the other MAS patch files) but I'll consider that tomorrow.

Notes: no-notes