### PR TITLE
build: fix filenames.auto

### DIFF
--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -142,7 +142,6 @@ auto_filenames = {
     "lib/common/define-properties.ts",
     "lib/common/ipc-messages.ts",
     "lib/common/web-view-methods.ts",
-    "lib/common/webpack-globals-provider.ts",
     "lib/renderer/api/context-bridge.ts",
     "lib/renderer/api/crash-reporter.ts",
     "lib/renderer/api/ipc-renderer.ts",


### PR DESCRIPTION
This change happens on clean branches, not sure how it got out of sync

Notes: no-notes