### PR TITLE
fix: remove unneeded --turbo-profiling-input args from mksnapshot_args

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -701,6 +701,13 @@ step-mksnapshot-build: &step-mksnapshot-build
       if [ "$USE_PREBUILT_V8_CONTEXT_SNAPSHOT" != "1" ]; then
         ninja -C out/Default electron:electron_mksnapshot -j $NUMBER_OF_NINJA_PROCESSES
         gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
+        # Remove unused args from mksnapshot_args
+        SEDOPTION=
+        if [ "`uname`" == "Darwin" ]; then
+          SEDOPTION="-i ''"
+        fi
+        sed $SEDOPTION '/.*builtins-pgo/d' out/Default/mksnapshot_args
+        sed $SEDOPTION '/--turbo-profiling-input/d' out/Default/mksnapshot_args
       fi
       if [ "`uname`" != "Darwin" ]; then
         if [ "$TARGET_ARCH" == "arm" ]; then
@@ -1216,6 +1223,13 @@ commands:
               ninja -C out/Default electron:electron_mksnapshot_zip -j $NUMBER_OF_NINJA_PROCESSES
               ninja -C out/Default tools/v8_context_snapshot -j $NUMBER_OF_NINJA_PROCESSES
               gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
+              # Remove unused args from mksnapshot_args
+              SEDOPTION=
+              if [ "`uname`" == "Darwin" ]; then
+                SEDOPTION="-i ''"
+              fi
+              sed $SEDOPTION '/.*builtins-pgo/d' out/Default/mksnapshot_args
+              sed $SEDOPTION '/--turbo-profiling-input/d' out/Default/mksnapshot_args
               (cd out/Default; zip mksnapshot.zip mksnapshot_args clang_x64_v8_arm64/gen/v8/embedded.S)
               if [ "<< parameters.clean-prebuilt-snapshot >>" == "true" ]; then
                 rm -rf out/Default/clang_x64_v8_arm64/gen

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -179,7 +179,11 @@ for:
     - ninja -C out/ffmpeg electron:electron_ffmpeg_zip
     - ninja -C out/Default electron:electron_dist_zip
     - ninja -C out/Default shell_browser_ui_unittests
-    - gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
+    - gn desc out/Default v8:run_mksnapshot_default args > out/Default/default_mksnapshot_args
+    - ps: >-
+        # Remove unused args from mksnapshot_args
+
+        Get-Content out/Default/default_mksnapshot_args | Where-Object { -not $_.Contains('--turbo-profiling-input') -And -not $_.Contains('builtins-pgo') } | Set-Content out/Default/mksnapshot_args
     - ninja -C out/Default electron:electron_mksnapshot_zip
     - cd out\Default
     - 7z a mksnapshot.zip mksnapshot_args gen\v8\embedded.S
@@ -190,7 +194,6 @@ for:
     - python %LOCAL_GOMA_DIR%\goma_ctl.py stat
     - python3 electron/build/profile_toolchain.py --output-json=out/Default/windows_toolchain_profile.json
     - 7z a node_headers.zip out\Default\gen\node_headers
-    - 7z a builtins-pgo.zip v8\tools\builtins-pgo
     - ps: >-
         if ($env:GN_CONFIG -eq 'release') {
           # Needed for msdia140.dll on 64-bit windows
@@ -235,7 +238,6 @@ for:
       - if exist out\Default\mksnapshot.zip (appveyor-retry appveyor PushArtifact out\Default\mksnapshot.zip)
       - if exist out\Default\hunspell_dictionaries.zip (appveyor-retry appveyor PushArtifact out\Default\hunspell_dictionaries.zip)
       - if exist out\Default\electron.lib (appveyor-retry appveyor PushArtifact out\Default\electron.lib)
-      - if exist builtins-pgo.zip (appveyor-retry appveyor PushArtifact builtins-pgo.zip)
       - ps: >-
           if ((Test-Path "pdb.zip") -And ($env:GN_CONFIG -ne 'release')) {
             appveyor-retry appveyor PushArtifact pdb.zip
@@ -269,7 +271,7 @@ for:
         # Download build artifacts
         $apiUrl = 'https://ci.appveyor.com/api'             
         $build_info = Invoke-RestMethod -Method Get -Uri "$apiUrl/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/builds/$env:APPVEYOR_BUILD_ID"
-        $artifacts_to_download = @('dist.zip','shell_browser_ui_unittests.exe','chromedriver.zip','ffmpeg.zip','node_headers.zip','mksnapshot.zip','electron.lib','builtins-pgo.zip')
+        $artifacts_to_download = @('dist.zip','shell_browser_ui_unittests.exe','chromedriver.zip','ffmpeg.zip','node_headers.zip','mksnapshot.zip','electron.lib')
         foreach ($job in $build_info.build.jobs) {
           if ($job.name -eq "Build") {
             $jobId = $job.jobId
@@ -290,7 +292,6 @@ for:
         }
     - ps: 7z x -y -osrc\out\ffmpeg ffmpeg.zip
     - ps: 7z x -y -osrc node_headers.zip
-    - ps: 7z x -y -osrc builtins-pgo.zip
 
     test_script:
       # Workaround for https://github.com/appveyor/ci/issues/2420


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Recent V8 changes added a new `--turbo-profiling-input` flag to mksnapshot_args but the default profile is empty, so we do not need to include this argument.  For additional context, see https://source.chromium.org/chromium/chromium/src/+/main:v8/BUILD.gn;l=179
- Fixes #36309
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
