### PR TITLE
chore: fix dangling promise in npm install

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -70,29 +70,25 @@ function isInstalled () {
 
 // unzips and makes path.txt point at the correct executable
 function extractFile (zipPath) {
-  return new Promise((resolve, reject) => {
-    const distPath = process.env.ELECTRON_OVERRIDE_DIST_PATH || path.join(__dirname, 'dist');
+  const distPath = process.env.ELECTRON_OVERRIDE_DIST_PATH || path.join(__dirname, 'dist');
 
-    extract(zipPath, { dir: path.join(__dirname, 'dist') })
-      .then(() => {
-        // If the zip contains an "electron.d.ts" file,
-        // move that up
-        const srcTypeDefPath = path.join(distPath, 'electron.d.ts');
-        const targetTypeDefPath = path.join(__dirname, 'electron.d.ts');
-        const hasTypeDefinitions = fs.existsSync(srcTypeDefPath);
+  return extract(zipPath, { dir: path.join(__dirname, 'dist') }).then(() => {
+    // If the zip contains an "electron.d.ts" file,
+    // move that up
+    const srcTypeDefPath = path.join(distPath, 'electron.d.ts');
+    const targetTypeDefPath = path.join(__dirname, 'electron.d.ts');
+    const hasTypeDefinitions = fs.existsSync(srcTypeDefPath);
 
-        if (hasTypeDefinitions) {
-          try {
-            fs.renameSync(srcTypeDefPath, targetTypeDefPath);
-          } catch (err) {
-            reject(err);
-          }
-        }
+    if (hasTypeDefinitions) {
+      try {
+        fs.renameSync(srcTypeDefPath, targetTypeDefPath);
+      } catch (err) {
+        reject(err);
+      }
+    }
 
-        // Write a "path.txt" file.
-        return fs.promises.writeFile(path.join(__dirname, 'path.txt'), platformPath);
-      })
-      .catch((err) => reject(err));
+    // Write a "path.txt" file.
+    return fs.promises.writeFile(path.join(__dirname, 'path.txt'), platformPath);
   });
 }
 

--- a/npm/install.js
+++ b/npm/install.js
@@ -83,7 +83,7 @@ function extractFile (zipPath) {
       try {
         fs.renameSync(srcTypeDefPath, targetTypeDefPath);
       } catch (err) {
-        reject(err);
+        throw err;
       }
     }
 

--- a/npm/install.js
+++ b/npm/install.js
@@ -80,11 +80,7 @@ function extractFile (zipPath) {
     const hasTypeDefinitions = fs.existsSync(srcTypeDefPath);
 
     if (hasTypeDefinitions) {
-      try {
-        fs.renameSync(srcTypeDefPath, targetTypeDefPath);
-      } catch (err) {
-        throw err;
-      }
+      fs.renameSync(srcTypeDefPath, targetTypeDefPath);
     }
 
     // Write a "path.txt" file.


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Fix an unresolved promise introduced in #33979, where the `resolve` is never called.

This problem was not observable because there's no variable holding reference to the promise, so V8 will correctly GC it. But the code logic still has problem.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
