### PR TITLE
fix: new WebAssembly API support in Node.js

### DIFF
--- a/script/node-disabled-tests.json
+++ b/script/node-disabled-tests.json
@@ -121,7 +121,6 @@
   "parallel/test-trace-events-v8",
   "parallel/test-trace-events-vm",
   "parallel/test-trace-events-worker-metadata",
-  "parallel/test-wasm-web-api",
   "parallel/test-webcrypto-derivebits-cfrg",
   "parallel/test-webcrypto-derivekey-cfrg",
   "parallel/test-webcrypto-encrypt-decrypt",

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -190,9 +190,6 @@ int NodeMain(int argc, char* argv[]) {
           static_cast<node::EnvironmentFlags::Flags>(env_flags));
       CHECK_NE(nullptr, env);
 
-      node::IsolateSettings is;
-      node::SetIsolateUpForNode(isolate, is);
-
       gin_helper::Dictionary process(isolate, env->process_object());
       process.SetMethod("crash", &ElectronBindings::Crash);
 

--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -73,8 +73,9 @@ struct base::trace_event::TraceValue::Helper<
 
 namespace electron {
 
-JavascriptEnvironment::JavascriptEnvironment(uv_loop_t* event_loop)
-    : isolate_(Initialize(event_loop)),
+JavascriptEnvironment::JavascriptEnvironment(uv_loop_t* event_loop,
+                                             bool setup_for_node)
+    : isolate_(Initialize(event_loop, setup_for_node)),
       isolate_holder_(base::ThreadTaskRunnerHandle::Get(),
                       gin::IsolateHolder::kSingleThread,
                       gin::IsolateHolder::kAllowAtomicsWait,
@@ -247,7 +248,8 @@ class TracingControllerImpl : public node::tracing::TracingController {
   }
 };
 
-v8::Isolate* JavascriptEnvironment::Initialize(uv_loop_t* event_loop) {
+v8::Isolate* JavascriptEnvironment::Initialize(uv_loop_t* event_loop,
+                                               bool setup_for_node) {
   auto* cmd = base::CommandLine::ForCurrentProcess();
 
   // --js-flags.
@@ -276,6 +278,10 @@ v8::Isolate* JavascriptEnvironment::Initialize(uv_loop_t* event_loop) {
 
   v8::Isolate* isolate = v8::Isolate::Allocate();
   platform_->RegisterIsolate(isolate, event_loop);
+
+  if (setup_for_node)
+    node::SetIsolateUpForNode(isolate);
+
   g_isolate = isolate;
 
   return isolate;

--- a/shell/browser/javascript_environment.h
+++ b/shell/browser/javascript_environment.h
@@ -22,7 +22,8 @@ class MicrotasksRunner;
 // Manage the V8 isolate and context automatically.
 class JavascriptEnvironment {
  public:
-  explicit JavascriptEnvironment(uv_loop_t* event_loop);
+  explicit JavascriptEnvironment(uv_loop_t* event_loop,
+                                 bool setup_for_node = false);
   ~JavascriptEnvironment();
 
   // disable copy
@@ -41,7 +42,7 @@ class JavascriptEnvironment {
   static v8::Isolate* GetIsolate();
 
  private:
-  v8::Isolate* Initialize(uv_loop_t* event_loop);
+  v8::Isolate* Initialize(uv_loop_t* event_loop, bool setup_for_node);
   std::unique_ptr<node::MultiIsolatePlatform> platform_;
 
   v8::Isolate* isolate_;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/36282.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Enabled support for  `WebAssembly.{compileStreaming|instantiateStreaming}` in Node.js.