### PR TITLE
build: update devcontainer and use latest codespaces features

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -4,14 +4,13 @@ Welcome to the Codespaces Electron Developer Environment.
 
 ## Quick Start
 
-Upon creation of your codespace you should have [build tools](https://github.com/electron/build-tools) installed and an initialized gclient checkout of Electron.  In order to build electron you'll need to run the following commands.
+Upon creation of your codespace you should have [build tools](https://github.com/electron/build-tools) installed and an initialized gclient checkout of Electron.  In order to build electron you'll need to run the following command.
 
 ```bash
-e sync -vv
 e build
 ```
 
-The initial sync will take approximately ~30 minutes and the build will take ~8 minutes.  Incremental syncs and incremental builds are substantially quicker.
+The initial build will take ~8 minutes.  Incremental builds are substantially quicker.  If you pull changes from upstream that touch either the `patches` folder or the `DEPS` folder you will have to run `e sync` in order to keep your checkout up to date.
 
 ## Directory Structure
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,14 +12,28 @@
 		"mutantdino.resourcemonitor",
 		"dbaeumer.vscode-eslint",
 		"shakram02.bash-beautify",
-		"marshallofsound.gnls-electron"
+		"marshallofsound.gnls-electron",
+		"CircleCI.circleci"
 	],
 	"settings": {
+		"editor.tabSize": 2,
+		"bashBeautify.tabSize": 2,
+		"typescript.tsdk": "node_modules/typescript/lib",
 		"[gn]": {
 			"editor.formatOnSave": true
 		},
-		"editor.tabSize": 2,
-		"bashBeautify.tabSize": 2
+		"[javascript]": {
+			"editor.codeActionsOnSave": {
+				"source.fixAll.eslint": true
+			}
+		},
+		"[typescript]": {
+			"editor.codeActionsOnSave": {
+				"source.fixAll.eslint": true
+			}
+		},
+		"javascript.preferences.quoteStyle": "single",
+		"typescript.preferences.quoteStyle": "single"
 	},
 	"forwardPorts": [8088, 6080, 5901],
 	"portsAttributes": {
@@ -37,8 +51,8 @@
 		}
 	},
 	"hostRequirements": {
-		"storage": "32gb",
-		"cpus": 8
+		"storage": "128gb",
+		"cpus": 16
 	},
 	"remoteUser": "builduser",
 	"customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "buildtools",
 	"onCreateCommand": ".devcontainer/on-create-command.sh",
+	"updateContentCommand": ".devcontainer/update-content-command.sh",
 	"workspaceFolder": "/workspaces/gclient/src/electron",
 	"extensions": [
 		"joeleinbinder.mojom-language",
@@ -39,5 +40,12 @@
 		"storage": "32gb",
 		"cpus": 8
 	},
-	"remoteUser": "builduser"
+	"remoteUser": "builduser",
+	"customizations": {
+		"codespaces": {
+			"openFiles": [
+				".devcontainer/README.md"
+			]
+		}
+	}
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   buildtools:
-    image: ghcr.io/electron/devcontainer:27db4a3e3512bfd2e47f58cea69922da0835f1d9
+    image: ghcr.io/electron/devcontainer:3d8d44d0f15b05bef6149e448f9cc522111847e9
 
     volumes:
       - ..:/workspaces/gclient/src/electron:cached

--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -10,6 +10,7 @@ export PATH="$PATH:$buildtools/src"
 
 # Create the persisted buildtools config folder
 mkdir -p $buildtools_configs
+mkdir -p $gclient_root/.git-cache
 rm -f $buildtools/configs
 ln -s $buildtools_configs $buildtools/configs
 

--- a/.devcontainer/update-content-command.sh
+++ b/.devcontainer/update-content-command.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eo pipefail
+
+buildtools=$HOME/.electron_build_tools
+gclient_root=/workspaces/gclient
+buildtools_configs=/workspaces/buildtools-configs
+
+export PATH="$PATH:$buildtools/src"
+
+# Sync latest gclient
+e sync -vv

--- a/.devcontainer/update-content-command.sh
+++ b/.devcontainer/update-content-command.sh
@@ -3,10 +3,10 @@
 set -eo pipefail
 
 buildtools=$HOME/.electron_build_tools
-gclient_root=/workspaces/gclient
-buildtools_configs=/workspaces/buildtools-configs
 
 export PATH="$PATH:$buildtools/src"
 
-# Sync latest gclient
-e d gclient sync --with_branch_heads --with_tags
+# Sync latest gclient, but only in a prebuild
+if [ ! -z "$CODESPACES_PREBUILD_TOKEN" ]; then
+  e d gclient sync --with_branch_heads --with_tags
+fi

--- a/.devcontainer/update-content-command.sh
+++ b/.devcontainer/update-content-command.sh
@@ -10,3 +10,8 @@ export PATH="$PATH:$buildtools/src"
 if [ ! -z "$CODESPACES_PREBUILD_TOKEN" ]; then
   e d gclient sync --with_branch_heads --with_tags
 fi
+
+env | while IFS= read -r line; do
+  name=${line%%=*}
+  echo "Env: $name"
+done

--- a/.devcontainer/update-content-command.sh
+++ b/.devcontainer/update-content-command.sh
@@ -9,4 +9,4 @@ buildtools_configs=/workspaces/buildtools-configs
 export PATH="$PATH:$buildtools/src"
 
 # Sync latest gclient
-e sync -vv
+e d gclient sync --with_branch_heads --with_tags

--- a/.devcontainer/update-content-command.sh
+++ b/.devcontainer/update-content-command.sh
@@ -6,12 +6,5 @@ buildtools=$HOME/.electron_build_tools
 
 export PATH="$PATH:$buildtools/src"
 
-# Sync latest gclient, but only in a prebuild
-if [ ! -z "$CODESPACES_PREBUILD_TOKEN" ]; then
-  e d gclient sync --with_branch_heads --with_tags
-fi
-
-env | while IFS= read -r line; do
-  name=${line%%=*}
-  echo "Env: $name"
-done
+# Sync latest
+e d gclient sync --with_branch_heads --with_tags


### PR DESCRIPTION
With codespaces prebuild's and some other new codespaces features this is now super usable.

It takes ~12-15 minutes to go from nothing to a fully built linux checkout.  (Down from 1-2 hours)

Notes: no-notes
