### PR TITLE
build: fixup appveyor image for release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: e-110.0.5415.0
+image: e-110.0.5415.0-fix
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default

--- a/script/setup-win-for-dev.bat
+++ b/script/setup-win-for-dev.bat
@@ -67,3 +67,6 @@ SET PATH=C:\Python27\;C:\Python27\Scripts;C:\Python39\;C:\Python39\Scripts;%PATH
 REM Setup Depot Tools
 git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git C:\depot_tools
 SET PATH=%PATH%;C:\depot_tools\
+
+REM Add symstore to PATH permanently
+setx path "%%path%%;C:\Program Files (x86)\Windows Kits\10\Debuggers\x64"

--- a/script/setup-win-for-dev.bat
+++ b/script/setup-win-for-dev.bat
@@ -1,7 +1,6 @@
 REM Parameters vs_buildtools.exe download link and wsdk version
 @ECHO OFF
 
-SET wsdk10_link=https://go.microsoft.com/fwlink/?linkid=2164145
 SET wsdk=10SDK.20348
 
 REM Check for disk space
@@ -54,13 +53,11 @@ REM Install Visual Studio Toolchain
 choco install visualstudio2019buildtools --package-parameters "--quiet --wait --norestart --nocache  --installPath ""%ProgramFiles(x86)%/Microsoft Visual Studio/2019/Community"" --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.140 --add Microsoft.VisualStudio.Component.VC.ATLMFC --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.MFC.ARM64 --add Microsoft.VisualStudio.Component.Windows%wsdk% --includeRecommended"
 
 REM Install Windows SDK
-powershell -command "& { iwr %wsdk10_link% -OutFile C:\TEMP\wsdk10.exe }"
-C:\TEMP\wsdk10.exe /features /quiet
+choco install windows-sdk-10-version-2104-all
 
 REM Install nodejs python git and yarn needed dependencies
 choco install -y nodejs-lts python2 git yarn
 choco install python --version 3.7.9
-choco install windows-sdk-10-version-2004-windbg
 call C:\ProgramData\chocolatey\bin\RefreshEnv.cmd
 SET PATH=C:\Python27\;C:\Python27\Scripts;C:\Python39\;C:\Python39\Scripts;%PATH%
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Windows release builds failed because `symstore` was not in the PATH of the appveyor baked images.  This PR updates the bake to set the path properly.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
