### PR TITLE
docs: add a note that Tray setImage can segfault on Linux 

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -218,6 +218,8 @@ Destroys the tray icon immediately.
 
 Sets the `image` associated with this tray icon.
 
+Note: setImage is known to cause segfaults, and should not be used on Linux.
+
 #### `tray.setPressedImage(image)` _macOS_
 
 * `image` ([NativeImage](native-image.md) | string)

--- a/package.json
+++ b/package.json
@@ -148,5 +148,8 @@
   },
   "resolutions": {
     "nan": "nodejs/nan#16fa32231e2ccd89d2804b3f765319128b20c4ac"
+  },
+  "dependencies": {
+    "babel-plugin-transform-async-to-generator": "^6.24.1"
   }
 }


### PR DESCRIPTION
#### Description of Change
Added a note in `tray.md` that "setImage is known to cause segfaults, and should not be used on Linux". With reference to issue #36274
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added


#### Release Notes

Notes: none
<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
