### PR TITLE
fix: handle Notification requireInteraction option

### DIFF
--- a/shell/browser/notifications/platform_notification_service.cc
+++ b/shell/browser/notifications/platform_notification_service.cc
@@ -35,6 +35,9 @@ void OnWebNotificationAllowed(base::WeakPtr<Notification> notification,
     options.icon = icon;
     options.silent = audio_muted ? true : data.silent;
     options.has_reply = false;
+    if (data.require_interaction)
+      options.timeout_type = u"never";
+
     notification->Show(options);
   } else {
     notification->Destroy();


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

This makes it so that HTML5 Notifications with the `requireInteraction` flag will not timeout/disappear automatically, taking advantage of the work done in https://github.com/electron/electron/pull/20153 for Linux/Windows. cc @codebytere @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Changed HTML5 Notifications created with the `requireInteraction` option to not timeout on Linux and Windows.