### PR TITLE
ci: fix skipping docs-only builds on CircleCI for backports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - checkout
       - path-filtering/set-parameters:
-          base-revision: main
+          base-revision: << pipeline.git.branch >>
           mapping: |
             ^((?!docs/).)*$ run-build-mac true
             ^((?!docs/).)*$ run-build-linux true


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Currently CircleCI builds are still happening for backports of docs-only changes. This tweaks the config so that CircleCI builds should be skipped regardless of branch for docs-only changes.

Refs: https://discuss.circleci.com/t/path-filtering-to-reduce-build-cost-in-branches/40685/2

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
