### PR TITLE
build: fixup mksnapshot args on linux

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -707,7 +707,7 @@ step-mksnapshot-build: &step-mksnapshot-build
         ninja -C out/Default electron:electron_mksnapshot -j $NUMBER_OF_NINJA_PROCESSES
         gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
         # Remove unused args from mksnapshot_args
-        SEDOPTION=
+        SEDOPTION="-i"
         if [ "`uname`" == "Darwin" ]; then
           SEDOPTION="-i ''"
         fi
@@ -1229,7 +1229,7 @@ commands:
               ninja -C out/Default tools/v8_context_snapshot -j $NUMBER_OF_NINJA_PROCESSES
               gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
               # Remove unused args from mksnapshot_args
-              SEDOPTION=
+              SEDOPTION="-i"
               if [ "`uname`" == "Darwin" ]; then
                 SEDOPTION="-i ''"
               fi


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
- Fixup of #36378 for Linux.  Unfortunately that PR did not remove the unneeded args for the Linux mksnapshot zips. 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> Removed unneeded --turbo-profiling-input argument from mksnapshot_args for Linux mksnapshot zips.
