### PR TITLE
ci(not-really): autoclose issues with blocked/need-repro and no response

### DIFF
--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -11,10 +11,9 @@ jobs:
   issue-labeled:
     permissions:
       issues: write  # for actions-cool/issues-helper to update issues
-      pull-requests: write  # for actions-cool/issues-helper to update PRs
     runs-on: ubuntu-latest
     steps:
-      - name: blocked/need-repro
+      - name: blocked/need-repro label added
         if: github.event.label.name == 'blocked/need-repro'
         uses: actions-cool/issues-helper@dad28fdb88da5f082c04659b7373d85790f9b135 # v3.3.0
         with:
@@ -27,4 +26,3 @@ jobs:
             Stand-alone test cases make fixing issues go more smoothly: it ensure everyone's looking at the same issue, it removes all unnecessary variables from the equation, and it can also provide the basis for automated regression tests. 
 
             Now adding the `blocked/need-repro` label for this reason. After you make a test case, please link to it in a followup comment. This issue will be closed in 10 days if the above is not addressed.
-  

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,3 +23,14 @@ jobs:
             This issue has been closed due to inactivity, and will not be monitored.  If this is a bug and you can reproduce this issue on a [supported version of Electron](https://www.electronjs.org/docs/latest/tutorial/electron-timelines#timeline) please open a new issue and include instructions for reproducing the issue.
           exempt-issue-labels: "discussion,security \U0001F512,enhancement :sparkles:"
           only-pr-labels: not-a-real-label
+  pending-repro:
+    steps:
+      - uses: actions/stale@3de2653986ebd134983c79fe2be5d45cc3d9f4e1
+        with:
+          days-before-stale: -1
+          days-before-close: 10
+          stale-issue-label: blocked/need-repro
+          stale-pr-label: not-a-real-label
+          operations-per-run: 1750
+          close-issue-message: >
+            Unfortunately, without a way to reproduce this issue, we're unable to continue investigation. This issue has been closed and will not be monitored further. If you're able to provide a minimal test case that reproduces this issue on a [supported version of Electron](https://www.electronjs.org/docs/latest/tutorial/electron-timelines#timeline) please open a new issue and include instructions for reproducing the issue.


### PR DESCRIPTION
#### Description of Change
The bot that responds to blocked/need-repro says that the issue will be closed
in 10 days with no response, so this makes that true.

Notes: none
