### PR TITLE
docs: In the Tray example code, call destroy() when the app quits

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -12,6 +12,7 @@ Process: [Main](../glossary.md#main-process)
 const { app, Menu, Tray } = require('electron')
 
 let tray = null
+
 app.whenReady().then(() => {
   tray = new Tray('/path/to/my/icon')
   const contextMenu = Menu.buildFromTemplate([
@@ -22,6 +23,13 @@ app.whenReady().then(() => {
   ])
   tray.setToolTip('This is my application.')
   tray.setContextMenu(contextMenu)
+})
+
+app.on('quit', () => {
+  // If the tray icon is not destroyed, on some
+  // platforms (including Windows) it may not
+  // disappear until the mouse moves over it.
+  tray?.destroy()
 })
 ```
 


### PR DESCRIPTION
#### Description of Change

On Windows (and maybe other platforms), failing to destroy the tray icon before the application exits will leave the icon in the tray until it is interacted with. Calling `tray.destroy()` in the app's `quit` event handler fixes this. I think it is worthwhile to demonstrate best practices in the documentation to avoid having many new Electron apps exhibit this behavior.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none