### PR TITLE
chore: reland “fix ambiguous reference gcc compile error”

### DIFF
--- a/shell/browser/serial/electron_serial_delegate.h
+++ b/shell/browser/serial/electron_serial_delegate.h
@@ -45,9 +45,9 @@ class ElectronSerialDelegate : public content::SerialDelegate,
   device::mojom::SerialPortManager* GetPortManager(
       content::RenderFrameHost* frame) override;
   void AddObserver(content::RenderFrameHost* frame,
-                   Observer* observer) override;
+                   content::SerialDelegate::Observer* observer) override;
   void RemoveObserver(content::RenderFrameHost* frame,
-                      Observer* observer) override;
+                      content::SerialDelegate::Observer* observer) override;
 
   void DeleteControllerForFrame(content::RenderFrameHost* render_frame_host);
 


### PR DESCRIPTION
This is a reland of #35714. The broken code got reintroduced in #35310 due to a mismerge.