### PR TITLE
docs: link net.request options to ClientRequestConstructorOptions

### DIFF
--- a/docs/api/net.md
+++ b/docs/api/net.md
@@ -54,7 +54,7 @@ The `net` module has the following methods:
 
 ### `net.request(options)`
 
-* `options` (ClientRequestConstructorOptions | string) - The `ClientRequest` constructor options.
+* `options` ([ClientRequestConstructorOptions](client-request.md#new-clientrequestoptions) | string) - The `ClientRequest` constructor options.
 
 Returns [`ClientRequest`](./client-request.md)
 


### PR DESCRIPTION
Closes #36548

This should be linked 👍 

Notes: no-notes