### PR TITLE
chore: [20-x-y] cherry-pick c79148742421 from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -19,3 +19,4 @@ cherry-pick-80ed4b917477.patch
 cherry-pick-2ac0620a5bbb.patch
 cherry-pick-177e8bcd3584.patch
 cherry-pick-27fa951ae4a3.patch
+cherry-pick-c79148742421.patch

--- a/patches/v8/cherry-pick-c79148742421.patch
+++ b/patches/v8/cherry-pick-c79148742421.patch
@@ -1,0 +1,122 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shu-yu Guo <syg@chromium.org>
+Date: Fri, 28 Oct 2022 10:21:27 -0700
+Subject: Merged: Reland "[Promise.any] Fix errors allocation"
+
+Bug: chromium:1379054
+
+(cherry picked from commit 8b35091b2d244c975975e1c78e4cd09cb479b5dc)
+
+Change-Id: Iec8f8bb51f4434d6ae86887cf742f2883a9b7bef
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4004804
+Reviewed-by: Adam Klein <adamk@chromium.org>
+Commit-Queue: Shu-yu Guo <syg@chromium.org>
+Cr-Commit-Position: refs/branch-heads/10.8@{#34}
+Cr-Branched-From: f1bc03fd6b4c201abd9f0fd9d51fb989150f97b9-refs/heads/10.8.168@{#1}
+Cr-Branched-From: 237de893e1c0a0628a57d0f5797483d3add7f005-refs/heads/main@{#83672}
+
+diff --git a/include/v8-version.h b/include/v8-version.h
+index 7baa3bf9b725652ddaac1a3d39dd96a3520b9f26..fb1097518be399c6665d53c2be79ec81a210de71 100644
+--- a/include/v8-version.h
++++ b/include/v8-version.h
+@@ -11,7 +11,7 @@
+ #define V8_MAJOR_VERSION 10
+ #define V8_MINOR_VERSION 4
+ #define V8_BUILD_NUMBER 132
+-#define V8_PATCH_LEVEL 24
++#define V8_PATCH_LEVEL 25
+ 
+ // Use 1 for candidates and 0 otherwise.
+ // (Boolean macro values are not supported by all preprocessors.)
+diff --git a/src/builtins/promise-any.tq b/src/builtins/promise-any.tq
+index ffb285a06a83557d8657aef6c04acc5c65513a62..7e707e649f11bc946a6d1173180d7293fe94d8ce 100644
+--- a/src/builtins/promise-any.tq
++++ b/src/builtins/promise-any.tq
+@@ -119,7 +119,19 @@ PromiseAnyRejectElementClosure(
+           kPromiseAnyRejectElementRemainingSlot);
+ 
+   // 9. Set errors[index] to x.
+-  const newCapacity = IntPtrMax(SmiUntag(remainingElementsCount), index + 1);
++
++  // The max computation below is an optimization to avoid excessive allocations
++  // in the case of input promises being asynchronously rejected in ascending
++  // index order.
++  //
++  // Note that subtracting 1 from remainingElementsCount is intentional. The
++  // value of remainingElementsCount is 1 larger than the actual value during
++  // iteration. So in the case of synchronous rejection, newCapacity is the
++  // correct size by subtracting 1. In the case of asynchronous rejection this
++  // is 1 smaller than the correct size, but is not incorrect as it is maxed
++  // with index + 1.
++  const newCapacity =
++      IntPtrMax(SmiUntag(remainingElementsCount) - 1, index + 1);
+   if (newCapacity > errors.length_intptr) deferred {
+       errors = ExtractFixedArray(errors, 0, errors.length_intptr, newCapacity);
+       *ContextSlot(
+@@ -306,6 +318,7 @@ Reject(JSAny) {
+           PromiseAnyRejectElementContextSlots::
+               kPromiseAnyRejectElementErrorsSlot);
+ 
++      check(errors.length == index - 1);
+       const error = ConstructAggregateError(errors);
+       // 3. Return ThrowCompletion(error).
+       goto Reject(error);
+diff --git a/tools/v8heapconst.py b/tools/v8heapconst.py
+index 993785ec032917ba4004bc96366e55230dd60dbb..578388b5bb44672b000b95cdc89f573cbda72a00 100644
+--- a/tools/v8heapconst.py
++++ b/tools/v8heapconst.py
+@@ -537,30 +537,30 @@ KNOWN_OBJECTS = {
+   ("old_space", 0x04b35): "StringSplitCache",
+   ("old_space", 0x04f3d): "RegExpMultipleCache",
+   ("old_space", 0x05345): "BuiltinsConstantsTable",
+-  ("old_space", 0x05781): "AsyncFunctionAwaitRejectSharedFun",
+-  ("old_space", 0x057a5): "AsyncFunctionAwaitResolveSharedFun",
+-  ("old_space", 0x057c9): "AsyncGeneratorAwaitRejectSharedFun",
+-  ("old_space", 0x057ed): "AsyncGeneratorAwaitResolveSharedFun",
+-  ("old_space", 0x05811): "AsyncGeneratorYieldResolveSharedFun",
+-  ("old_space", 0x05835): "AsyncGeneratorReturnResolveSharedFun",
+-  ("old_space", 0x05859): "AsyncGeneratorReturnClosedRejectSharedFun",
+-  ("old_space", 0x0587d): "AsyncGeneratorReturnClosedResolveSharedFun",
+-  ("old_space", 0x058a1): "AsyncIteratorValueUnwrapSharedFun",
+-  ("old_space", 0x058c5): "PromiseAllResolveElementSharedFun",
+-  ("old_space", 0x058e9): "PromiseAllSettledResolveElementSharedFun",
+-  ("old_space", 0x0590d): "PromiseAllSettledRejectElementSharedFun",
+-  ("old_space", 0x05931): "PromiseAnyRejectElementSharedFun",
+-  ("old_space", 0x05955): "PromiseCapabilityDefaultRejectSharedFun",
+-  ("old_space", 0x05979): "PromiseCapabilityDefaultResolveSharedFun",
+-  ("old_space", 0x0599d): "PromiseCatchFinallySharedFun",
+-  ("old_space", 0x059c1): "PromiseGetCapabilitiesExecutorSharedFun",
+-  ("old_space", 0x059e5): "PromiseThenFinallySharedFun",
+-  ("old_space", 0x05a09): "PromiseThrowerFinallySharedFun",
+-  ("old_space", 0x05a2d): "PromiseValueThunkFinallySharedFun",
+-  ("old_space", 0x05a51): "ProxyRevokeSharedFun",
+-  ("old_space", 0x05a75): "ShadowRealmImportValueFulfilledSFI",
+-  ("old_space", 0x05a99): "SourceTextModuleExecuteAsyncModuleFulfilledSFI",
+-  ("old_space", 0x05abd): "SourceTextModuleExecuteAsyncModuleRejectedSFI",
++  ("old_space", 0x05785): "AsyncFunctionAwaitRejectSharedFun",
++  ("old_space", 0x057a9): "AsyncFunctionAwaitResolveSharedFun",
++  ("old_space", 0x057cd): "AsyncGeneratorAwaitRejectSharedFun",
++  ("old_space", 0x057f1): "AsyncGeneratorAwaitResolveSharedFun",
++  ("old_space", 0x05815): "AsyncGeneratorYieldResolveSharedFun",
++  ("old_space", 0x05839): "AsyncGeneratorReturnResolveSharedFun",
++  ("old_space", 0x0585d): "AsyncGeneratorReturnClosedRejectSharedFun",
++  ("old_space", 0x05881): "AsyncGeneratorReturnClosedResolveSharedFun",
++  ("old_space", 0x058a5): "AsyncIteratorValueUnwrapSharedFun",
++  ("old_space", 0x058c9): "PromiseAllResolveElementSharedFun",
++  ("old_space", 0x058ed): "PromiseAllSettledResolveElementSharedFun",
++  ("old_space", 0x05911): "PromiseAllSettledRejectElementSharedFun",
++  ("old_space", 0x05935): "PromiseAnyRejectElementSharedFun",
++  ("old_space", 0x05959): "PromiseCapabilityDefaultRejectSharedFun",
++  ("old_space", 0x0597d): "PromiseCapabilityDefaultResolveSharedFun",
++  ("old_space", 0x059a1): "PromiseCatchFinallySharedFun",
++  ("old_space", 0x059c5): "PromiseGetCapabilitiesExecutorSharedFun",
++  ("old_space", 0x059e9): "PromiseThenFinallySharedFun",
++  ("old_space", 0x05a0d): "PromiseThrowerFinallySharedFun",
++  ("old_space", 0x05a31): "PromiseValueThunkFinallySharedFun",
++  ("old_space", 0x05a55): "ProxyRevokeSharedFun",
++  ("old_space", 0x05a79): "ShadowRealmImportValueFulfilledSFI",
++  ("old_space", 0x05a9d): "SourceTextModuleExecuteAsyncModuleFulfilledSFI",
++  ("old_space", 0x05ac1): "SourceTextModuleExecuteAsyncModuleRejectedSFI",
+ }
+ 
+ # Lower 32 bits of first page addresses for various heap spaces.


### PR DESCRIPTION
Merged: Reland "[Promise.any] Fix errors allocation"

Bug: chromium:1379054

(cherry picked from commit 8b35091b2d244c975975e1c78e4cd09cb479b5dc)

Change-Id: Iec8f8bb51f4434d6ae86887cf742f2883a9b7bef
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4004804
Reviewed-by: Adam Klein <adamk@chromium.org>
Commit-Queue: Shu-yu Guo <syg@chromium.org>
Cr-Commit-Position: refs/branch-heads/10.8@{#34}
Cr-Branched-From: f1bc03fd6b4c201abd9f0fd9d51fb989150f97b9-refs/heads/10.8.168@{#1}
Cr-Branched-From: 237de893e1c0a0628a57d0f5797483d3add7f005-refs/heads/main@{#83672}


Ref electron/security#252

Notes: Security: backported fix for CVE-2022-4174.