### PR TITLE
fix: use the process cache to reduce the memory for asar file

### DIFF
--- a/shell/common/api/electron_api_asar.cc
+++ b/shell/common/api/electron_api_asar.cc
@@ -39,7 +39,7 @@ class Archive : public node::ObjectWrap {
   Archive& operator=(const Archive&) = delete;
 
  protected:
-  explicit Archive(std::unique_ptr<asar::Archive> archive)
+  explicit Archive(std::shared_ptr<asar::Archive> archive)
       : archive_(std::move(archive)) {}
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args) {
@@ -52,8 +52,8 @@ class Archive : public node::ObjectWrap {
       return;
     }
 
-    auto archive = std::make_unique<asar::Archive>(path);
-    if (!archive->Init()) {
+    auto archive = asar::GetOrCreateAsarArchive(path);
+    if (!archive) {
       isolate->ThrowException(v8::Exception::Error(node::FIXED_ONE_BYTE_STRING(
           isolate, "failed to initialize archive")));
       return;
@@ -190,7 +190,7 @@ class Archive : public node::ObjectWrap {
         isolate, wrap->archive_ ? wrap->archive_->GetUnsafeFD() : -1));
   }
 
-  std::unique_ptr<asar::Archive> archive_;
+  std::shared_ptr<asar::Archive> archive_;
 };
 
 static void InitAsarSupport(const v8::FunctionCallbackInfo<v8::Value>& args) {


### PR DESCRIPTION
#### Description of Change

The memory leaks at /lib/asar/fs-wrapper.ts, const cachedArchives = new Map<string, NodeJS.AsarArchive>() Whenever a new worker is created, it will have an instance of this map. The contents of this map will not be cleaned up immediately.
And there is a process-level cache at /shell/common/asar/asar_util.cc, static base::NoDestructor<ArchiveMap> s_archive_map
In summary, I decide to use this process-level cache to save the asar cache instead of creating a new one for each worker

Resolves https://github.com/electron/electron/issues/36597

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes

#### Release Notes

Notes: use the process cache to reduce the memory for asar file