### PR TITLE
docs: add mdn link to web-request-filter.md

### DIFF
--- a/docs/api/structures/web-request-filter.md
+++ b/docs/api/structures/web-request-filter.md
@@ -1,3 +1,5 @@
 # WebRequestFilter Object
 
 * `urls` string[] - Array of URL patterns that will be used to filter out the requests that do not match the URL patterns.
+
+See [here](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns) for an explanation of the URL pattern format.

--- a/docs/api/structures/web-request-filter.md
+++ b/docs/api/structures/web-request-filter.md
@@ -1,4 +1,3 @@
 # WebRequestFilter Object
 
 * `urls` string[] - Array of [URL patterns](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns) that will be used to filter out the requests that do not match the URL patterns.
-

--- a/docs/api/structures/web-request-filter.md
+++ b/docs/api/structures/web-request-filter.md
@@ -1,5 +1,4 @@
 # WebRequestFilter Object
 
-* `urls` string[] - Array of URL patterns that will be used to filter out the requests that do not match the URL patterns.
+* `urls` string[] - Array of [URL patterns](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns) that will be used to filter out the requests that do not match the URL patterns.
 
-See [here](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns) for an explanation of the URL pattern format.


### PR DESCRIPTION
#### Description of Change

When I was using the Electron docs I wanted to know how to use [webRequest.onBeforeSendHeaders](https://www.electronjs.org/docs/latest/api/web-request#webrequestonbeforesendheadersfilter-listener) but I was unable to correctly guess the correct format for the `WebRequestFilter` URL strings, and there was no explanation in the Electron docs. Eventually I googled it and found the MDN article which helped me.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] PR description included and stakeholders cc'd
- [x ] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes

Notes: none
