### PR TITLE
fix: strip branded binaries

### DIFF
--- a/script/add-debug-link.py
+++ b/script/add-debug-link.py
@@ -4,11 +4,11 @@ import argparse
 import os
 import sys
 
-from lib.config import LINUX_BINARIES, PLATFORM
-from lib.util import execute, get_out_dir
+from lib.config import PLATFORM
+from lib.util import execute, get_linux_binaries, get_out_dir
 
 def add_debug_link_into_binaries(directory, target_cpu, debug_dir):
-  for binary in LINUX_BINARIES:
+  for binary in get_linux_binaries():
     binary_path = os.path.join(directory, binary)
     if os.path.isfile(binary_path):
       add_debug_link_into_binary(binary_path, target_cpu, debug_dir)

--- a/script/copy-debug-symbols.py
+++ b/script/copy-debug-symbols.py
@@ -4,12 +4,12 @@ import argparse
 import os
 import sys
 
-from lib.config import LINUX_BINARIES, PLATFORM
-from lib.util import execute, get_out_dir, safe_mkdir
+from lib.config import PLATFORM
+from lib.util import execute, get_linux_binaries, get_out_dir, safe_mkdir
 
 # It has to be done before stripping the binaries.
 def copy_debug_from_binaries(directory, out_dir, target_cpu, compress):
-  for binary in LINUX_BINARIES:
+  for binary in get_linux_binaries():
     binary_path = os.path.join(directory, binary)
     if os.path.isfile(binary_path):
       copy_debug_from_binary(binary_path, out_dir, target_cpu, compress)

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -13,16 +13,6 @@ PLATFORM = {
   'win32': 'win32',
 }[sys.platform]
 
-LINUX_BINARIES = [
-  'chrome-sandbox',
-  'chrome_crashpad_handler',
-  'electron',
-  'libEGL.so',
-  'libGLESv2.so',
-  'libffmpeg.so',
-  'libvk_swiftshader.so',
-]
-
 verbose_mode = False
 
 

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -215,3 +215,14 @@ def get_buildtools_executable(name):
   if sys.platform == 'win32':
     path += '.exe'
   return path
+
+def get_linux_binaries():
+  return [
+    'chrome-sandbox',
+    'chrome_crashpad_handler',
+    get_electron_branding()['project_name'],
+    'libEGL.so',
+    'libGLESv2.so',
+    'libffmpeg.so',
+    'libvk_swiftshader.so',
+  ]

--- a/script/strip-binaries.py
+++ b/script/strip-binaries.py
@@ -4,11 +4,11 @@ import argparse
 import os
 import sys
 
-from lib.config import LINUX_BINARIES, enable_verbose_mode
-from lib.util import execute, get_out_dir
+from lib.config import enable_verbose_mode
+from lib.util import execute, get_linux_binaries, get_out_dir
 
 def strip_binaries(directory, target_cpu):
-  for binary in LINUX_BINARIES:
+  for binary in get_linux_binaries():
     binary_path = os.path.join(directory, binary)
     if os.path.isfile(binary_path):
       strip_binary(binary_path, target_cpu)


### PR DESCRIPTION
#### Description of Change

When creating branded release builds and using scripts/strip-binaries.py
on Linux, the final artifacts end up unstripped due to the static set of
binaries considered for stripping.
With this patch the name of the electron binary is taken from the
BRANDING.json `project_name` key.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] ~~tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)~~
- [ ] ~~relevant documentation, tutorials, templates and examples are changed or added~~
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix binary stripping for branded release builds on Linux
