### PR TITLE
docs: cleanup reference links

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -25,6 +25,5 @@
   "single-h1": false,
   "no-inline-html": false,
   "emphasis-style": false,
-  "strong-style": false,
-  "link-image-reference-definitions": false
+  "strong-style": false
 }

--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -271,8 +271,6 @@ By default inspector websocket url is available in stderr and under /json/list e
 
 [app]: app.md
 [append-switch]: command-line.md#commandlineappendswitchswitch-value
-[ready]: app.md#event-ready
-[play-silent-audio]: https://github.com/atom/atom/pull/9485/files
 [debugging-main-process]: ../tutorial/debugging-main-process.md
 [logging]: https://source.chromium.org/chromium/chromium/src/+/main:base/logging.h
 [node-cli]: https://nodejs.org/api/cli.html

--- a/docs/api/debugger.md
+++ b/docs/api/debugger.md
@@ -59,7 +59,6 @@ Returns:
 Emitted whenever the debugging target issues an instrumentation event.
 
 [rdp]: https://chromedevtools.github.io/devtools-protocol/
-[`webContents.findInPage`]: web-contents.md#contentsfindinpagetext-options
 
 ### Instance Methods
 

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -25,7 +25,7 @@ See [`Menu`](menu.md) for examples.
   * `icon` ([NativeImage](native-image.md) | string) (optional)
   * `enabled` boolean (optional) - If false, the menu item will be greyed out and
     unclickable.
-  * `acceleratorWorksWhenHidden` boolean (optional) _macOS_ - default is `true`, and when `false` will prevent the accelerator from triggering the item if the item is not visible`.
+  * `acceleratorWorksWhenHidden` boolean (optional) _macOS_ - default is `true`, and when `false` will prevent the accelerator from triggering the item if the item is not visible.
   * `visible` boolean (optional) - If false, the menu item will be entirely hidden.
   * `checked` boolean (optional) - Should only be specified for `checkbox` or `radio` type
     menu items.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -154,7 +154,6 @@ Notice that just setting the background in the CSS does not have the desired eff
 
 [memory-management]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Memory_Management
 [variable-scope]: https://msdn.microsoft.com/library/bzt2dkta(v=vs.94).aspx
-[electron-module]: https://www.npmjs.com/package/electron
 [storage]: https://developer.mozilla.org/en-US/docs/Web/API/Storage
 [local-storage]: https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage
 [session-storage]: https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -239,6 +239,4 @@ embedded content.
 [offscreen rendering]: tutorial/offscreen-rendering.md
 [process sandboxing]: tutorial/sandbox.md
 [renderer]: #renderer-process
-[userland]: #userland
 [UtilityProcess]: api/utility-process.md
-[v8]: #v8

--- a/docs/tutorial/code-signing.md
+++ b/docs/tutorial/code-signing.md
@@ -189,7 +189,6 @@ can find [its documentation here](https://www.electron.build/code-signing).
 See the [Windows Store Guide].
 
 [apple developer program]: https://developer.apple.com/programs/
-[`electron-forge`]: https://github.com/electron/forge
 [`@electron/osx-sign`]: https://github.com/electron/osx-sign
 [`electron-packager`]: https://github.com/electron/electron-packager
 [`@electron/notarize`]: https://github.com/electron/notarize

--- a/docs/tutorial/performance.md
+++ b/docs/tutorial/performance.md
@@ -437,7 +437,6 @@ Call `Menu.setApplicationMenu(null)` before `app.on("ready")`. This will prevent
 [web-workers]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers
 [request-idle-callback]: https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback
 [multithreading]: ./multithreading.md
-[caniuse]: https://caniuse.com/
 [jquery-need]: https://youmightnotneedjquery.com/
 [service-workers]: https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API
 [webpack]: https://webpack.js.org/

--- a/docs/tutorial/process-model.md
+++ b/docs/tutorial/process-model.md
@@ -235,4 +235,3 @@ there is need to fork a child process from the main process.
 [context-bridge]: ../api/context-bridge.md
 [ipcrenderer]: ../api/ipc-renderer.md
 [UtilityProcess]: ../api/utility-process.md
-[tutorial]: ./tutorial-1-prerequisites.md

--- a/docs/tutorial/sandbox.md
+++ b/docs/tutorial/sandbox.md
@@ -162,7 +162,6 @@ backported. Your best chance at staying secure is to be on the latest stable
 version of Electron.
 
 [sandbox]: https://chromium.googlesource.com/chromium/src/+/main/docs/design/sandbox.md
-[issue-28466]: https://github.com/electron/electron/issues/28466
 [browser-window]: ../api/browser-window.md
 [enable-sandbox]: ../api/app.md#appenablesandbox
 [no-sandbox]: ../api/command-line-switches.md#--no-sandbox

--- a/docs/tutorial/tutorial-1-prerequisites.md
+++ b/docs/tutorial/tutorial-1-prerequisites.md
@@ -135,9 +135,7 @@ the list of versions in the [electron/releases] repository.
 [node-guide]: https://nodejs.dev/en/learn/
 [node-download]: https://nodejs.org/en/download/
 [nvm]: https://github.com/nvm-sh/nvm
-[process-model]: ./process-model.md
 [`process.versions`]: https://nodejs.org/api/process.html#processversions
-[github]: https://github.com/
 [git guides]: https://github.com/git-guides/
 [github desktop]: https://desktop.github.com/
 [visual studio code]: https://code.visualstudio.com/

--- a/docs/tutorial/tutorial-2-first-app.md
+++ b/docs/tutorial/tutorial-2-first-app.md
@@ -445,14 +445,12 @@ privileged APIs and how to communicate between processes.
 <!-- Links -->
 
 [activate]: ../api/app.md#event-activate-macos
-[advanced-installation]: installation.md
 [app]: ../api/app.md
 [app-quit]: ../api/app.md#appquit
 [app-ready]: ../api/app.md#event-ready
 [app-when-ready]: ../api/app.md#appwhenready
 [application debugging]: ./application-debugging.md
 [browser-window]: ../api/browser-window.md
-[commonjs]: https://nodejs.org/docs/../api/modules.html#modules_modules_commonjs_modules
 [compound task]: https://code.visualstudio.com/Docs/editor/tasks#_compound-tasks
 [devtools extension]: ./devtools-extension.md
 [event emitters]: https://nodejs.org/api/events.html#events
@@ -465,7 +463,6 @@ privileged APIs and how to communicate between processes.
 [process-model]: process-model.md
 [react]: https://reactjs.org
 [repl]: ./repl.md
-[sandbox]: ./sandbox.md
 [webpack]: https://webpack.js.org
 [window-all-closed]: ../api/app.md#event-window-all-closed
 [wsl]: https://docs.microsoft.com/en-us/windows/wsl/about#what-is-wsl-2

--- a/docs/tutorial/tutorial-3-preload.md
+++ b/docs/tutorial/tutorial-3-preload.md
@@ -254,32 +254,15 @@ functionality to your app, then teaching you distributing your app to users.
 
 <!-- Links -->
 
-[advanced-installation]: ./installation.md
-[application debugging]: ./application-debugging.md
-[app]: ../api/app.md
-[app-ready]: ../api/app.md#event-ready
-[app-when-ready]: ../api/app.md#appwhenready
-[browser-window]: ../api/browser-window.md
-[commonjs]: https://nodejs.org/docs/latest/api/modules.html#modules_modules_commonjs_modules
-[compound task]: https://code.visualstudio.com/Docs/editor/tasks#_compound-tasks
 [content-script]: https://developer.chrome.com/docs/extensions/mv3/content_scripts/
 [contextbridge]: ../api/context-bridge.md
-[context-isolation]: ./context-isolation.md
 [`document.getelementbyid`]: https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementById
-[devtools-extension]: ./devtools-extension.md
 [dirname]: https://nodejs.org/api/modules.html#modules_dirname
 [global]: https://developer.mozilla.org/en-US/docs/Glossary/Global_object
 [ipc]: ./ipc.md
-[mdn-csp]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
 [modules]: ../api/app.md
 [node-api]: https://nodejs.org/dist/latest/docs/api/
-[package-json-main]: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#main
-[package-scripts]: https://docs.npmjs.com/cli/v7/using-npm/scripts
 [path-join]: https://nodejs.org/api/path.html#path_path_join_paths
-[process-model]: ./process-model.md
-[react]: https://reactjs.org
-[sandbox]: ./sandbox.md
-[webpack]: https://webpack.js.org
 
 <!-- Tutorial links -->
 

--- a/docs/tutorial/tutorial-4-adding-features.md
+++ b/docs/tutorial/tutorial-4-adding-features.md
@@ -65,7 +65,6 @@ into end users' hands.
 [discord]: https://discord.gg/electronjs
 [github]: https://github.com/electron/website/issues/new
 [how-to]: ./examples.md
-[node-platform]: https://nodejs.org/api/process.html#process_process_platform
 
 <!-- Tutorial links -->
 

--- a/docs/tutorial/window-customization.md
+++ b/docs/tutorial/window-customization.md
@@ -268,7 +268,6 @@ behave correctly on all platforms, you should never use a custom context menu on
 draggable areas.
 
 [`blur()`]: https://developer.mozilla.org/en-US/docs/Web/CSS/filter-function/blur()
-[`BrowserWindow`]: ../api/browser-window.md
 [chrome]: https://developer.mozilla.org/en-US/docs/Glossary/Chrome
 [ignore-mouse-events]: ../api/browser-window.md#winsetignoremouseeventsignore-options
 [overlay-css-env-vars]: https://github.com/WICG/window-controls-overlay/blob/main/explainer.md#css-environment-variables


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Cleans up unused and duplicate reference link definitions, and switches on the `markdownlint` rule to check them. The change in `docs/api/menu-item.md` fixes a rogue backtick which was causing a false positive with the linting rule - shouldn't have any effect on rendering.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
