### PR TITLE
fix: use chrome headers in net.request for everything except cookie

### DIFF
--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -577,9 +577,7 @@ void SimpleURLLoaderWrapper::OnResponseStarted(
   dict.Set("statusCode", response_head.headers->response_code());
   dict.Set("statusMessage", response_head.headers->GetStatusText());
   dict.Set("httpVersion", response_head.headers->GetHttpVersion());
-  // Note that |response_head.headers| are filtered by Chromium and should not
-  // be used here.
-  DCHECK(!response_head.raw_response_headers.empty());
+  dict.Set("headers", response_head.headers.get());
   dict.Set("rawHeaders", response_head.raw_response_headers);
   Emit("response-started", final_url, dict);
 }

--- a/spec/api-net-spec.ts
+++ b/spec/api-net-spec.ts
@@ -623,6 +623,19 @@ describe('net module', () => {
       expect(response.headers['set-cookie']).to.have.same.members(cookie);
     });
 
+    it('should be able to receive content-type', async () => {
+      const contentType = 'mime/test; charset=test';
+      const serverUrl = await respondOnce.toSingleURL((request, response) => {
+        response.statusCode = 200;
+        response.statusMessage = 'OK';
+        response.setHeader('content-type', contentType);
+        response.end();
+      });
+      const urlRequest = net.request(serverUrl);
+      const response = await getResponse(urlRequest);
+      expect(response.headers['content-type']).to.equal(contentType);
+    });
+
     it('should not use the sessions cookie store by default', async () => {
       const serverUrl = await respondOnce.toSingleURL((request, response) => {
         response.statusCode = 200;

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -145,6 +145,7 @@ declare namespace NodeJS {
     statusMessage: string;
     httpVersion: { major: number, minor: number };
     rawHeaders: { key: string, value: string }[];
+    headers: Record<string, string[]>;
   };
 
   type RedirectInfo = {


### PR DESCRIPTION
#### Description of Change

Chrome's parsed headers contain everything except the cookies ([ref](https://source.chromium.org/chromium/chromium/src/+/main:services/network/public/cpp/net_ipc_param_traits.cc;l=190;drc=098756533733ea50b2dcb1c40d9a9e18d49febbe)), so use those and add in the set-cookie header at the end.

Closes #27895.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed net.request response headers missing `Content-Type`.
