### PR TITLE
chore: cherry-pick d1d654d73222 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -147,3 +147,4 @@ cherry-pick-65ad70274d4b.patch
 cherry-pick-f46db6aac3e9.patch
 cherry-pick-2ef09109c0ec.patch
 cherry-pick-f98adc846aad.patch
+cherry-pick-d1d654d73222.patch

--- a/patches/chromium/cherry-pick-d1d654d73222.patch
+++ b/patches/chromium/cherry-pick-d1d654d73222.patch
@@ -1,0 +1,39 @@
+From d1d654d7322244ad394000ef2622c0871e856cfa Mon Sep 17 00:00:00 2001
+From: Ken Rockot <rockot@google.com>
+Date: Wed, 07 Dec 2022 20:35:15 +0000
+Subject: [PATCH] [M108] Mojo: Fix potential UAF in IPC Channel
+
+(cherry picked from commit 120b4b05ac7eaa9024f677394aa663c2702174ce)
+
+Fixed: 1394692
+Change-Id: I1753b79eb6e9230ebb663eca47295d81dd859068
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4066994
+Commit-Queue: Ken Rockot <rockot@google.com>
+Reviewed-by: Daniel Cheng <dcheng@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1077742}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4085806
+Commit-Queue: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: Ken Rockot <rockot@google.com>
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/5359@{#1115}
+Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}
+---
+
+diff --git a/ipc/ipc_mojo_bootstrap.cc b/ipc/ipc_mojo_bootstrap.cc
+index c5aa680..42926d8 100644
+--- a/ipc/ipc_mojo_bootstrap.cc
++++ b/ipc/ipc_mojo_bootstrap.cc
+@@ -673,9 +673,12 @@
+     void OnSyncMessageEventReady() {
+       DCHECK(task_runner_->RunsTasksInCurrentSequence());
+ 
+-      scoped_refptr<Endpoint> keepalive(this);
++      // SUBTLE: The order of these scoped_refptrs matters.
++      // `controller_keepalive` MUST outlive `keepalive` because the Endpoint
++      // holds raw pointer to the AssociatedGroupController.
+       scoped_refptr<AssociatedGroupController> controller_keepalive(
+           controller_.get());
++      scoped_refptr<Endpoint> keepalive(this);
+       base::AutoLock locker(controller_->lock_);
+       bool more_to_process = false;
+       if (!sync_messages_.empty()) {

--- a/patches/chromium/cherry-pick-d1d654d73222.patch
+++ b/patches/chromium/cherry-pick-d1d654d73222.patch
@@ -1,7 +1,7 @@
-From d1d654d7322244ad394000ef2622c0871e856cfa Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ken Rockot <rockot@google.com>
-Date: Wed, 07 Dec 2022 20:35:15 +0000
-Subject: [PATCH] [M108] Mojo: Fix potential UAF in IPC Channel
+Date: Wed, 7 Dec 2022 20:35:15 +0000
+Subject: Mojo: Fix potential UAF in IPC Channel
 
 (cherry picked from commit 120b4b05ac7eaa9024f677394aa663c2702174ce)
 
@@ -17,13 +17,12 @@ Auto-Submit: Ken Rockot <rockot@google.com>
 Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
 Cr-Commit-Position: refs/branch-heads/5359@{#1115}
 Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}
----
 
 diff --git a/ipc/ipc_mojo_bootstrap.cc b/ipc/ipc_mojo_bootstrap.cc
-index c5aa680..42926d8 100644
+index a0bd86951a20cf2d60c7805a3a7fa687d66ca329..eb8fa358b0a72eea2e294c531549da5fc81f394c 100644
 --- a/ipc/ipc_mojo_bootstrap.cc
 +++ b/ipc/ipc_mojo_bootstrap.cc
-@@ -673,9 +673,12 @@
+@@ -629,9 +629,12 @@ class ChannelAssociatedGroupController
      void OnSyncMessageEventReady() {
        DCHECK(task_runner_->RunsTasksInCurrentSequence());
  


### PR DESCRIPTION
[M108] Mojo: Fix potential UAF in IPC Channel

(cherry picked from commit 120b4b05ac7eaa9024f677394aa663c2702174ce)

Fixed: 1394692
Change-Id: I1753b79eb6e9230ebb663eca47295d81dd859068
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4066994
Commit-Queue: Ken Rockot <rockot@google.com>
Reviewed-by: Daniel Cheng <dcheng@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1077742}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4085806
Commit-Queue: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Auto-Submit: Ken Rockot <rockot@google.com>
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Cr-Commit-Position: refs/branch-heads/5359@{#1115}
Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}


Ref electron/security#258

Notes: Security: backported fix for CVE-2022-4437.