### PR TITLE
chore: cherry-pick fcf671adc2f3 from libaom

### DIFF
--- a/patches/config.json
+++ b/patches/config.json
@@ -23,5 +23,7 @@
 
   "src/electron/patches/sqlite": "src/third_party/sqlite/src",
 
-  "src/electron/patches/skia": "src/third_party/skia"
+  "src/electron/patches/skia": "src/third_party/skia",
+
+  "src/electron/patches/libaom": "src/third_party/libaom/source/libaom"
 }

--- a/patches/libaom/.patches
+++ b/patches/libaom/.patches
@@ -1,0 +1,1 @@
+rtc_avoid_scene_detection_on_resize.patch

--- a/patches/libaom/rtc_avoid_scene_detection_on_resize.patch
+++ b/patches/libaom/rtc_avoid_scene_detection_on_resize.patch
@@ -1,0 +1,72 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marco Paniconi <marpan@google.com>
+Date: Mon, 28 Nov 2022 14:25:08 -0800
+Subject: rtc: Avoid scene detection on resize
+
+Don't enter scene detection under external resize.
+Add rc->prev_coded_width/height to track the
+previous encoded frame eweight/height.
+The rc is part of layer context so this will be
+per spatial layer for SVC.
+
+This fixes the buffer overflow issue below.
+
+Bug: chromium:1393384
+Change-Id: I4b11818a27c439c2d2c42036dff7b8777f70a86e
+(cherry picked from commit bee1caded272127a6d6b70ac79479083d183d5d0)
+
+diff --git a/av1/encoder/ratectrl.c b/av1/encoder/ratectrl.c
+index 40da4f4564e670a74353613620ce162d445f32f8..daadb3ee7d70066d2e38293c4b2029cfee2aab4d 100644
+--- a/av1/encoder/ratectrl.c
++++ b/av1/encoder/ratectrl.c
+@@ -2128,6 +2128,9 @@ void av1_rc_postencode_update(AV1_COMP *cpi, uint64_t bytes_used) {
+   }
+ #endif
+   if (current_frame->frame_type == KEY_FRAME) rc->frames_since_key = 0;
++
++  rc->prev_coded_width = cm->width;
++  rc->prev_coded_height = cm->height;
+   // if (current_frame->frame_number == 1 && cm->show_frame)
+   /*
+   rc->this_frame_target =
+@@ -2144,6 +2147,8 @@ void av1_rc_postencode_update_drop_frame(AV1_COMP *cpi) {
+   cpi->rc.rc_2_frame = 0;
+   cpi->rc.rc_1_frame = 0;
+   cpi->rc.prev_avg_frame_bandwidth = cpi->rc.avg_frame_bandwidth;
++  cpi->rc.prev_coded_width = cpi->common.width;
++  cpi->rc.prev_coded_height = cpi->common.height;
+ }
+ 
+ int av1_find_qindex(double desired_q, aom_bit_depth_t bit_depth,
+@@ -3083,8 +3088,15 @@ void av1_get_one_pass_rt_params(AV1_COMP *cpi,
+     }
+   }
+   // Check for scene change: for SVC check on base spatial layer only.
+-  if (cpi->sf.rt_sf.check_scene_detection && svc->spatial_layer_id == 0)
+-    rc_scene_detection_onepass_rt(cpi);
++  if (cpi->sf.rt_sf.check_scene_detection && svc->spatial_layer_id == 0) {
++    if (rc->prev_coded_width == cm->width &&
++        rc->prev_coded_height == cm->height) {
++      rc_scene_detection_onepass_rt(cpi);
++    } else if (cpi->src_sad_blk_64x64) {
++      aom_free(cpi->src_sad_blk_64x64);
++      cpi->src_sad_blk_64x64 = NULL;
++    }
++  }
+   // Check for dynamic resize, for single spatial layer for now.
+   // For temporal layers only check on base temporal layer.
+   if (cpi->oxcf.resize_cfg.resize_mode == RESIZE_DYNAMIC) {
+diff --git a/av1/encoder/ratectrl.h b/av1/encoder/ratectrl.h
+index 5ac9660ab8d31440a5608bab6794286e63203da7..5291323ff4f1401a6a02a8332e552aa8c33b0b0f 100644
+--- a/av1/encoder/ratectrl.h
++++ b/av1/encoder/ratectrl.h
+@@ -252,6 +252,9 @@ typedef struct {
+   int frame_level_fast_extra_bits;
+ 
+   double frame_level_rate_correction_factors[RATE_FACTOR_LEVELS];
++
++  int prev_coded_width;
++  int prev_coded_height;
+   /*!\endcond */
+ } RATE_CONTROL;
+ 


### PR DESCRIPTION
rtc: Avoid scene detection on resize

Don't enter scene detection under external resize.
Add rc->prev_coded_width/height to track the
previous encoded frame eweight/height.
The rc is part of layer context so this will be
per spatial layer for SVC.

This fixes the buffer overflow issue below.

Bug: chromium:1393384
Change-Id: [I4b11818a27c439c2d2c42036dff7b8777f70a86e](https://aomedia-review.googlesource.com/#/q/I4b11818a27c439c2d2c42036dff7b8777f70a86e)
(cherry picked from commit bee1caded272127a6d6b70ac79479083d183d5d0)

Notes: Security: backported fix for chromium:1393384.
