### PR TITLE
docs: Fix incorrect highlight in an example snippet

### DIFF
--- a/docs/tutorial/tutorial-3-preload.md
+++ b/docs/tutorial/tutorial-3-preload.md
@@ -202,7 +202,7 @@ Then, set up your `handle` listener in the main process. We do this _before_
 loading the HTML file so that the handler is guaranteed to be ready before
 you send out the `invoke` call from the renderer.
 
-```js {1,11} title="main.js"
+```js {1,12} title="main.js"
 const { app, BrowserWindow, ipcMain } = require('electron')
 const path = require('path')
 


### PR DESCRIPTION
#### Description of Change

At the moment, the "Communicating between processes" `main.js` snippet highlights the line containing `})` when the relevant line for this part of the tutorial is `ipcMain.handle('ping', () => 'pong')`, this change just updates the highlighted line.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes

Notes: none
