### PR TITLE
fix: move report_raw_headers to TrustedParams

### DIFF
--- a/patches/chromium/feat_expose_raw_response_headers_from_urlloader.patch
+++ b/patches/chromium/feat_expose_raw_response_headers_from_urlloader.patch
@@ -17,69 +17,70 @@ headers, moving forward we should find a way in upstream to provide
 access to these headers for loader clients created on the browser process.
 
 diff --git a/services/network/public/cpp/resource_request.cc b/services/network/public/cpp/resource_request.cc
-index 65921550e62dbcd79f77192951b95991c3e904a1..c45a2a8c5adf3df78b4e4c4c0d4d945ade2a6826 100644
+index 65921550e62dbcd79f77192951b95991c3e904a1..067ef0d9f869402fb47e2a2cea77a5771ef9d75a 100644
 --- a/services/network/public/cpp/resource_request.cc
 +++ b/services/network/public/cpp/resource_request.cc
-@@ -234,6 +234,7 @@ bool ResourceRequest::EqualsForTesting(const ResourceRequest& request) const {
-          do_not_prompt_for_login == request.do_not_prompt_for_login &&
-          is_outermost_main_frame == request.is_outermost_main_frame &&
-          transition_type == request.transition_type &&
-+         report_raw_headers == request.report_raw_headers &&
-          previews_state == request.previews_state &&
-          upgrade_if_insecure == request.upgrade_if_insecure &&
-          is_revalidating == request.is_revalidating &&
+@@ -139,6 +139,7 @@ bool ResourceRequest::TrustedParams::EqualsForTesting(
+     const TrustedParams& other) const {
+   return isolation_info.IsEqualForTesting(other.isolation_info) &&
+          disable_secure_dns == other.disable_secure_dns &&
++         report_raw_headers == other.report_raw_headers &&
+          has_user_activation == other.has_user_activation &&
+          client_security_state == other.client_security_state;
+ }
 diff --git a/services/network/public/cpp/resource_request.h b/services/network/public/cpp/resource_request.h
-index b3ff3cc494d5d63ed0af9745131cfd52da12cd43..9bd521e08540102e992423cb0a6eacbfc514f03b 100644
+index b3ff3cc494d5d63ed0af9745131cfd52da12cd43..05954160ee3cbc86a3dec4ba2b1f6750cd6d5209 100644
 --- a/services/network/public/cpp/resource_request.h
 +++ b/services/network/public/cpp/resource_request.h
-@@ -160,6 +160,7 @@ struct COMPONENT_EXPORT(NETWORK_CPP_BASE) ResourceRequest {
-   bool do_not_prompt_for_login = false;
-   bool is_outermost_main_frame = false;
-   int transition_type = 0;
-+  bool report_raw_headers = false;
-   int previews_state = 0;
-   bool upgrade_if_insecure = false;
-   bool is_revalidating = false;
+@@ -62,6 +62,7 @@ struct COMPONENT_EXPORT(NETWORK_CPP_BASE) ResourceRequest {
+     net::IsolationInfo isolation_info;
+     bool disable_secure_dns = false;
+     bool has_user_activation = false;
++    bool report_raw_headers = false;
+     mojo::PendingRemote<mojom::CookieAccessObserver> cookie_observer;
+     mojo::PendingRemote<mojom::URLLoaderNetworkServiceObserver>
+         url_loader_network_observer;
 diff --git a/services/network/public/cpp/url_request_mojom_traits.cc b/services/network/public/cpp/url_request_mojom_traits.cc
-index 1702f66d2ec0871f15e475ae3901b48637140d59..9b4370d6c0e08662fac1892217e28f142c983576 100644
+index 1702f66d2ec0871f15e475ae3901b48637140d59..824523653ae45ae9b66f316f9ee608f351aae728 100644
 --- a/services/network/public/cpp/url_request_mojom_traits.cc
 +++ b/services/network/public/cpp/url_request_mojom_traits.cc
-@@ -210,6 +210,7 @@ bool StructTraits<
-   out->do_not_prompt_for_login = data.do_not_prompt_for_login();
-   out->is_outermost_main_frame = data.is_outermost_main_frame();
-   out->transition_type = data.transition_type();
+@@ -88,6 +88,7 @@ bool StructTraits<network::mojom::TrustedUrlRequestParamsDataView,
+   }
+   out->disable_secure_dns = data.disable_secure_dns();
+   out->has_user_activation = data.has_user_activation();
 +  out->report_raw_headers = data.report_raw_headers();
-   out->previews_state = data.previews_state();
-   out->upgrade_if_insecure = data.upgrade_if_insecure();
-   out->is_revalidating = data.is_revalidating();
+   out->cookie_observer = data.TakeCookieObserver<
+       mojo::PendingRemote<network::mojom::CookieAccessObserver>>();
+   out->url_loader_network_observer = data.TakeUrlLoaderNetworkObserver<
 diff --git a/services/network/public/cpp/url_request_mojom_traits.h b/services/network/public/cpp/url_request_mojom_traits.h
-index af527034303f0660934d50a441fa178ddaeca475..65e0719fef13fbf730d74f9982d1b54d741a60fd 100644
+index af527034303f0660934d50a441fa178ddaeca475..aa1a1290ebb261a4f5045cf14882e750822784c4 100644
 --- a/services/network/public/cpp/url_request_mojom_traits.h
 +++ b/services/network/public/cpp/url_request_mojom_traits.h
-@@ -272,6 +272,9 @@ struct COMPONENT_EXPORT(NETWORK_CPP_BASE)
-   static int32_t transition_type(const network::ResourceRequest& request) {
-     return request.transition_type;
+@@ -65,6 +65,10 @@ struct COMPONENT_EXPORT(NETWORK_CPP_BASE)
+       const network::ResourceRequest::TrustedParams& trusted_params) {
+     return trusted_params.has_user_activation;
    }
-+  static bool report_raw_headers(const network::ResourceRequest& request) {
-+    return request.report_raw_headers;
++  static bool report_raw_headers(
++      const network::ResourceRequest::TrustedParams& trusted_params) {
++    return trusted_params.report_raw_headers;
 +  }
-   static int32_t previews_state(const network::ResourceRequest& request) {
-     return request.previews_state;
-   }
+   static mojo::PendingRemote<network::mojom::CookieAccessObserver>
+   cookie_observer(
+       const network::ResourceRequest::TrustedParams& trusted_params) {
 diff --git a/services/network/public/mojom/url_request.mojom b/services/network/public/mojom/url_request.mojom
-index bf3c8e3dc4d15d33118144f801b661fed667a5ba..733bb2b2b20094520c3e944288dfa01dad01ebc5 100644
+index bf3c8e3dc4d15d33118144f801b661fed667a5ba..4bce0983d28d44d3dd6d34aaca684f1f978e18fd 100644
 --- a/services/network/public/mojom/url_request.mojom
 +++ b/services/network/public/mojom/url_request.mojom
-@@ -317,6 +317,9 @@ struct URLRequest {
-   // about this.
-   int32 transition_type;
+@@ -55,6 +55,9 @@ struct TrustedUrlRequestParams {
+   // without user gesture. Used to determine the `Sec-Fetch-User` header.
+   bool has_user_activation;
  
-+  // Whether to provide unfiltered response headers.
++  // [Electron] Whether to provide unfiltered response headers.
 +  bool report_raw_headers;
 +
-   // Whether or not to request a Preview version of the resource or let the
-   // browser decide.
-   // Note: this is an enum of type PreviewsState.
+   // Observer which should be notified when this URLRequest reads or writes
+   // a cookie. If this is set to non-null, the observer passed to
+   // URLLoaderFactory will be ignored.
 diff --git a/services/network/public/mojom/url_response_head.mojom b/services/network/public/mojom/url_response_head.mojom
 index f4cbafde0cfa92e3e93f5480242025b3d5c822c4..73a7a02a224a4737c4f7a97a98a73e7f67ce3250 100644
 --- a/services/network/public/mojom/url_response_head.mojom
@@ -103,17 +104,17 @@ index f4cbafde0cfa92e3e93f5480242025b3d5c822c4..73a7a02a224a4737c4f7a97a98a73e7f
    string mime_type;
  
 diff --git a/services/network/url_loader.cc b/services/network/url_loader.cc
-index 023729747d16816a6ba38159ace5ab1ec7bb2db5..93b14019539c3527cd7f119093bb16e47186f060 100644
+index 023729747d16816a6ba38159ace5ab1ec7bb2db5..aa3277bfd3dc1f7bab474ba0ff21f8c6e1d851eb 100644
 --- a/services/network/url_loader.cc
 +++ b/services/network/url_loader.cc
-@@ -463,6 +463,7 @@ URLLoader::URLLoader(
-           mojo::SimpleWatcher::ArmingPolicy::MANUAL,
-           base::SequencedTaskRunner::GetCurrentDefault()),
-       per_factory_corb_state_(context.GetMutableCorbState()),
-+      report_raw_headers_(request.report_raw_headers),
-       devtools_request_id_(request.devtools_request_id),
-       request_mode_(request.mode),
-       request_credentials_mode_(request.credentials_mode),
+@@ -582,6 +582,7 @@ URLLoader::URLLoader(
+ 
+   if (request.trusted_params) {
+     has_user_activation_ = request.trusted_params->has_user_activation;
++    report_raw_headers_ = request.trusted_params->report_raw_headers;
+   }
+ 
+   throttling_token_ = network::ScopedThrottlingToken::MaybeCreate(
 @@ -645,7 +646,7 @@ URLLoader::URLLoader(
    url_request_->SetRequestHeadersCallback(base::BindRepeating(
        &URLLoader::SetRawRequestHeadersAndNotify, base::Unretained(this)));

--- a/patches/chromium/feat_expose_raw_response_headers_from_urlloader.patch
+++ b/patches/chromium/feat_expose_raw_response_headers_from_urlloader.patch
@@ -17,10 +17,18 @@ headers, moving forward we should find a way in upstream to provide
 access to these headers for loader clients created on the browser process.
 
 diff --git a/services/network/public/cpp/resource_request.cc b/services/network/public/cpp/resource_request.cc
-index 65921550e62dbcd79f77192951b95991c3e904a1..067ef0d9f869402fb47e2a2cea77a5771ef9d75a 100644
+index 65921550e62dbcd79f77192951b95991c3e904a1..743e81c07052979dfb83cc0ed44a6653ddf52321 100644
 --- a/services/network/public/cpp/resource_request.cc
 +++ b/services/network/public/cpp/resource_request.cc
-@@ -139,6 +139,7 @@ bool ResourceRequest::TrustedParams::EqualsForTesting(
+@@ -119,6 +119,7 @@ ResourceRequest::TrustedParams& ResourceRequest::TrustedParams::operator=(
+   isolation_info = other.isolation_info;
+   disable_secure_dns = other.disable_secure_dns;
+   has_user_activation = other.has_user_activation;
++  report_raw_headers = other.report_raw_headers;
+   cookie_observer =
+       Clone(&const_cast<mojo::PendingRemote<mojom::CookieAccessObserver>&>(
+           other.cookie_observer));
+@@ -139,6 +140,7 @@ bool ResourceRequest::TrustedParams::EqualsForTesting(
      const TrustedParams& other) const {
    return isolation_info.IsEqualForTesting(other.isolation_info) &&
           disable_secure_dns == other.disable_secure_dns &&

--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -280,7 +280,7 @@ SimpleURLLoaderWrapper::SimpleURLLoaderWrapper(
   // Chromium filters headers using browser rules, while for net module we have
   // every header passed. The following setting will allow us to capture the
   // raw headers in the URLLoader.
-  request->report_raw_headers = true;
+  request->trusted_params->report_raw_headers = true;
   // SimpleURLLoader wants to control the request body itself. We have other
   // ideas.
   auto request_body = std::move(request->request_body);


### PR DESCRIPTION
#### Description of Change

This moves the report_raw_headers parameter to the TrustedParams struct inside
URLRequest.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none
