### PR TITLE
docs: Modify the sample code that returns null objects

### DIFF
--- a/docs/tutorial/context-isolation.md
+++ b/docs/tutorial/context-isolation.md
@@ -39,7 +39,7 @@ There is a dedicated module in Electron to help you do this in a painless way. T
 const { contextBridge } = require('electron')
 
 contextBridge.exposeInMainWorld('myAPI', {
-  doAThing: () => {}
+  doAThing: () => ({})
 })
 ```
 


### PR DESCRIPTION
When context isolation is enabled, the exported API sample code used by the renderer process should not return undefined, which will be mistaken for no access or other conditions