### PR TITLE
docs: Modify the sample code that returns null objects

### DIFF
--- a/docs/tutorial/context-isolation.md
+++ b/docs/tutorial/context-isolation.md
@@ -19,7 +19,7 @@ Exposing APIs from your preload script to a loaded website in the renderer proce
 ```javascript title='preload.js'
 // preload with contextIsolation disabled
 window.myAPI = {
-  doAThing: () => {}
+  doAThing: () => ({})
 }
 ```
 


### PR DESCRIPTION
When context isolation is enabled, the exported API sample code used by the renderer process should not return undefined, which will be mistaken for no access or other conditions