### PR TITLE
fix: focus rings with multiple buttons in `showMessageBox`

### DIFF
--- a/shell/browser/ui/message_box_mac.mm
+++ b/shell/browser/ui/message_box_mac.mm
@@ -71,9 +71,6 @@ NSAlert* CreateNSAlert(const MessageBoxSettings& settings) {
   int button_count = static_cast<int>([ns_buttons count]);
 
   if (settings.default_id >= 0 && settings.default_id < button_count) {
-    // Highlight the button at default_id
-    [[ns_buttons objectAtIndex:settings.default_id] highlight:YES];
-
     // The first button added gets set as the default selected, so remove
     // that and set the button @ default_id to be default.
     [[ns_buttons objectAtIndex:0] setKeyEquivalent:@""];
@@ -84,6 +81,11 @@ NSAlert* CreateNSAlert(const MessageBoxSettings& settings) {
   if (button_count > 1 && settings.cancel_id >= 0 &&
       settings.cancel_id < button_count) {
     [[ns_buttons objectAtIndex:settings.cancel_id] setKeyEquivalent:@"\e"];
+  }
+
+  // TODO(@codebytere): This behavior violates HIG & should be deprecated.
+  if (settings.cancel_id >= 0 && settings.cancel_id == settings.default_id) {
+    [[ns_buttons objectAtIndex:settings.default_id] highlight:YES];
   }
 
   if (!settings.checkbox_label.empty()) {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/36721.

We shouldn't manually highlight the default button unless there's a cancel button with respective `cancelId`. macOS automatically infers default button highlighting and changing that affects focus ring behavior and appearance.

<details><summary>Before</summary>
<img width="621" alt="Screenshot 2023-01-02 at 2 55 21 PM" src="https://user-images.githubusercontent.com/2036040/210240746-56404a91-81e6-4cef-a38a-c16f35d4b2e6.png">
</details>

<details><summary>After</summary>
<img width="623" alt="Screenshot 2023-01-02 at 2 54 26 PM" src="https://user-images.githubusercontent.com/2036040/210240756-52903e43-6c2e-4177-a648-396d4eab55c4.png">
</details>

Tested with https://gist.github.com/d9bd650ffc1efcf61016cbc81ea35652.

There's also another issue here with key equivalent accessibility, but i'm going to look into that as a follow-up.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue with incorrect focus ring highlighting when using `dialog.showMessageBox()`.
