### PR TITLE
feat: emit `devtools-open-url` event for DevTools link selection

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -492,6 +492,14 @@ The `focus` and `blur` events of `WebContents` should only be used to detect
 focus change between different `WebContents` and `BrowserView` in the same
 window.
 
+### Event: 'devtools-open-in-new-tab'
+
+Returns:
+
+* `url` string - URL of the link that was clicked or selected.
+
+Emitted when a link is clicked in DevTools or 'Open in new tab' is selected for a link in its context menu.
+
 #### Event: 'devtools-opened'
 
 Emitted when DevTools is opened.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -492,7 +492,7 @@ The `focus` and `blur` events of `WebContents` should only be used to detect
 focus change between different `WebContents` and `BrowserView` in the same
 window.
 
-### Event: 'devtools-open-in-new-tab'
+#### Event: 'devtools-open-url'
 
 Returns:
 

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -981,7 +981,7 @@ Returns:
 
 Emitted when mouse moves over a link or the keyboard moves the focus to a link.
 
-### Event: 'devtools-open-in-new-tab'
+### Event: 'devtools-open-url'
 
 Returns:
 

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -981,6 +981,14 @@ Returns:
 
 Emitted when mouse moves over a link or the keyboard moves the focus to a link.
 
+### Event: 'devtools-open-in-new-tab'
+
+Returns:
+
+* `url` string - URL of the link that was clicked or selected.
+
+Emitted when a link is clicked in DevTools or 'Open in new tab' is selected for a link in its context menu.
+
 ### Event: 'devtools-opened'
 
 Emitted when DevTools is opened.

--- a/lib/browser/web-view-events.ts
+++ b/lib/browser/web-view-events.ts
@@ -9,7 +9,7 @@ export const webViewEvents: Record<string, readonly string[]> = {
   'dom-ready': [],
   'console-message': ['level', 'message', 'line', 'sourceId'],
   'context-menu': ['params'],
-  'devtools-open-in-new-tab': ['url'],
+  'devtools-open-url': ['url'],
   'devtools-opened': [],
   'devtools-closed': [],
   'devtools-focused': [],

--- a/lib/browser/web-view-events.ts
+++ b/lib/browser/web-view-events.ts
@@ -9,6 +9,7 @@ export const webViewEvents: Record<string, readonly string[]> = {
   'dom-ready': [],
   'console-message': ['level', 'message', 'line', 'sourceId'],
   'context-menu': ['params'],
+  'devtools-open-in-new-tab': ['url'],
   'devtools-opened': [],
   'devtools-closed': [],
   'devtools-focused': [],

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3824,7 +3824,7 @@ void WebContents::DevToolsStopIndexing(int request_id) {
 }
 
 void WebContents::DevToolsOpenInNewTab(const std::string& url) {
-  Emit("devtools-open-in-new-tab", url);
+  Emit("devtools-open-url", url);
 }
 
 void WebContents::DevToolsSearchInPath(int request_id,

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3823,6 +3823,10 @@ void WebContents::DevToolsStopIndexing(int request_id) {
   devtools_indexing_jobs_.erase(it);
 }
 
+void WebContents::DevToolsOpenInNewTab(const std::string& url) {
+  Emit("devtools-open-in-new-tab", url);
+}
+
 void WebContents::DevToolsSearchInPath(int request_id,
                                        const std::string& file_system_path,
                                        const std::string& query) {

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -704,6 +704,7 @@ class WebContents : public ExclusiveAccessContext,
   void DevToolsIndexPath(int request_id,
                          const std::string& file_system_path,
                          const std::string& excluded_folders_message) override;
+  void DevToolsOpenInNewTab(const std::string& url) override;
   void DevToolsStopIndexing(int request_id) override;
   void DevToolsSearchInPath(int request_id,
                             const std::string& file_system_path,

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -723,7 +723,10 @@ void InspectableWebContents::SetIsDocked(DispatchCallback callback,
     std::move(callback).Run(nullptr);
 }
 
-void InspectableWebContents::OpenInNewTab(const std::string& url) {}
+void InspectableWebContents::OpenInNewTab(const std::string& url) {
+  if (delegate_)
+    delegate_->DevToolsOpenInNewTab(url);
+}
 
 void InspectableWebContents::ShowItemInFolder(
     const std::string& file_system_path) {

--- a/shell/browser/ui/inspectable_web_contents_delegate.h
+++ b/shell/browser/ui/inspectable_web_contents_delegate.h
@@ -31,6 +31,7 @@ class InspectableWebContentsDelegate {
   virtual void DevToolsIndexPath(int request_id,
                                  const std::string& file_system_path,
                                  const std::string& excluded_folders) {}
+  virtual void DevToolsOpenInNewTab(const std::string& url) {}                             
   virtual void DevToolsStopIndexing(int request_id) {}
   virtual void DevToolsSearchInPath(int request_id,
                                     const std::string& file_system_path,

--- a/shell/browser/ui/inspectable_web_contents_delegate.h
+++ b/shell/browser/ui/inspectable_web_contents_delegate.h
@@ -31,7 +31,7 @@ class InspectableWebContentsDelegate {
   virtual void DevToolsIndexPath(int request_id,
                                  const std::string& file_system_path,
                                  const std::string& excluded_folders) {}
-  virtual void DevToolsOpenInNewTab(const std::string& url) {}                             
+  virtual void DevToolsOpenInNewTab(const std::string& url) {}
   virtual void DevToolsStopIndexing(int request_id) {}
   virtual void DevToolsSearchInPath(int request_id,
                                     const std::string& file_system_path,


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/36715.

This PR adds a new event `devtools-open-url` corresponding to a link in DevTools being either clicked or selected for opening in a new tab via context menu. There is precedent for event emission corresponding to `DevToolsEmbedderMessageDispatcher::Delegate` methods - this was previously a no-op and so the primary change here is adding an implementation to surface the action to developers.

Alternatively, we could potentially have implemented the new window behavior ourselves, but this is (imo) a large security hole and as such I believe we should ibstead give developers more fine-grained control over handling and optionally opening new links there.

Tested by adding:

```js
mainWindow.loadURL('https://www.baidu.com/')

mainWindow.webContents.openDevTools()

mainWindow.webContents.on('devtools-open-url', (event, url) => {
  console.log(url)
})
```

to the `createWindow` method in a default Fiddle and confirming that `url` is correctly logged.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added a new `devtools-open-url` event to `webContents` to allow developers to open new windows with them.
