### PR TITLE
docs: update incorrect grammar

### DIFF
--- a/docs/tutorial/tutorial-5-packaging.md
+++ b/docs/tutorial/tutorial-5-packaging.md
@@ -127,7 +127,7 @@ documentation.
 
 ## Important: signing your code
 
-In order to distribute desktop applications to end users, we _highly recommended_ for you
+In order to distribute desktop applications to end users, we _highly recommend_ that you
 to **code sign** your Electron app. Code signing is an important part of shipping
 desktop applications, and is mandatory for the auto-update step in the final part
 of the tutorial.


### PR DESCRIPTION
#### Description of Change

A sentence within the documentation located under [Important: signing your code](https://www.electronjs.org/docs/latest/tutorial/tutorial-packaging#important-signing-your-code) is grammatically incorrect. 

> In order to distribute desktop applications to end users, we highly recommended for you to code sign your Electron app.

Update the sentence above to read "we highly recommend that you code sign your Electron app".