### PR TITLE
docs: update incorrect grammar

### DIFF
--- a/docs/tutorial/tutorial-5-packaging.md
+++ b/docs/tutorial/tutorial-5-packaging.md
@@ -127,8 +127,7 @@ documentation.
 
 ## Important: signing your code
 
-In order to distribute desktop applications to end users, we _highly recommended_ for you
-to **code sign** your Electron app. Code signing is an important part of shipping
+In order to distribute desktop applications to end users, we _highly recommend_ that you **code sign** your Electron app. Code signing is an important part of shipping
 desktop applications, and is mandatory for the auto-update step in the final part
 of the tutorial.
 


### PR DESCRIPTION
 #### Description of Change

The first sentence within the documentation "[Important: signing your code](https://www.electronjs.org/docs/latest/tutorial/tutorial-packaging#important-signing-your-code)" is grammatically incorrect.

> In order to distribute desktop applications to end users, we highly recommended for you to code sign your Electron app.

I've adjusted the copy to switch "highly recommended" to "highly recommend". I've also switched out "for you to code sign" for "that you code sign" for clarity. 

> In order to distribute desktop applications to end users, we _highly recommend_ that you **code sign** your Electron app.

#### Checklist

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none
