### PR TITLE
fix: RTL `WindowButtonsProxy` buttons

### DIFF
--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -202,6 +202,8 @@ class Browser : public WindowListObserver {
   bool UpdateUserActivityState(const std::string& type,
                                base::Value::Dict user_info);
 
+  void ApplyForcedRTL();
+
   // Bounce the dock icon.
   enum class BounceType {
     kCritical = 0,        // NSCriticalRequest

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -16,9 +16,9 @@
 #include "base/mac/scoped_cftyperef.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/sys_string_conversions.h"
+#include "chrome/browser/browser_process.h"
 #include "net/base/mac/url_conversions.h"
 #include "shell/browser/badging/badge_manager.h"
-#include "shell/browser/browser_process_impl.h"
 #include "shell/browser/mac/dict_util.h"
 #include "shell/browser/mac/electron_application.h"
 #include "shell/browser/mac/electron_application_delegate.h"
@@ -38,14 +38,6 @@
 namespace electron {
 
 namespace {
-
-bool IsSystemRTL() {
-  const std::string& locale =
-      static_cast<BrowserProcessImpl*>(g_browser_process)->GetSystemLocale();
-  base::i18n::TextDirection text_direction =
-      base::i18n::GetTextDirectionForLocaleInStartUp(locale.c_str());
-  return text_direction == base::i18n::RIGHT_TO_LEFT;
-}
 
 bool IsAppRTL() {
   const std::string& locale = g_browser_process->GetApplicationLocale();
@@ -350,10 +342,8 @@ void Browser::ApplyForcedRTL() {
 
   // An Electron app should respect RTL behavior of application locale over
   // system locale.
-  auto should_be_rtl =
-      dir == base::i18n::RIGHT_TO_LEFT || (IsAppRTL() && !IsSystemRTL());
-  auto should_be_ltr =
-      dir == base::i18n::LEFT_TO_RIGHT || (!IsAppRTL() && IsSystemRTL());
+  auto should_be_rtl = dir == base::i18n::RIGHT_TO_LEFT || IsAppRTL();
+  auto should_be_ltr = dir == base::i18n::LEFT_TO_RIGHT || !IsAppRTL();
 
   // -registerDefaults: won't do the trick here because these defaults exist
   // (in the global domain) to reflect the system locale. They need to be set

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 
+#include "base/i18n/rtl.h"
 #include "base/mac/bundle_locations.h"
 #include "base/mac/foundation_util.h"
 #include "base/mac/mac_util.h"
@@ -17,6 +18,7 @@
 #include "base/strings/sys_string_conversions.h"
 #include "net/base/mac/url_conversions.h"
 #include "shell/browser/badging/badge_manager.h"
+#include "shell/browser/browser_process_impl.h"
 #include "shell/browser/mac/dict_util.h"
 #include "shell/browser/mac/electron_application.h"
 #include "shell/browser/mac/electron_application_delegate.h"
@@ -36,6 +38,21 @@
 namespace electron {
 
 namespace {
+
+bool IsSystemRTL() {
+  const std::string& locale =
+      static_cast<BrowserProcessImpl*>(g_browser_process)->GetSystemLocale();
+  base::i18n::TextDirection text_direction =
+      base::i18n::GetTextDirectionForLocaleInStartUp(locale.c_str());
+  return text_direction == base::i18n::RIGHT_TO_LEFT;
+}
+
+bool IsAppRTL() {
+  const std::string& locale = g_browser_process->GetApplicationLocale();
+  base::i18n::TextDirection text_direction =
+      base::i18n::GetTextDirectionForLocaleInStartUp(locale.c_str());
+  return text_direction == base::i18n::RIGHT_TO_LEFT;
+}
 
 NSString* GetAppPathForProtocol(const GURL& url) {
   NSURL* ns_url = [NSURL
@@ -323,6 +340,34 @@ bool Browser::UpdateUserActivityState(const std::string& type,
     observer.OnUpdateUserActivityState(&prevent_default, type,
                                        user_info.Clone());
   return prevent_default;
+}
+
+// Modified from chrome/browser/ui/cocoa/l10n_util.mm.
+void Browser::ApplyForcedRTL() {
+  NSUserDefaults* defaults = NSUserDefaults.standardUserDefaults;
+
+  auto dir = base::i18n::GetForcedTextDirection();
+
+  // An Electron app should respect RTL behavior of application locale over
+  // system locale.
+  auto should_be_rtl =
+      dir == base::i18n::RIGHT_TO_LEFT || (IsAppRTL() && !IsSystemRTL());
+  auto should_be_ltr =
+      dir == base::i18n::LEFT_TO_RIGHT || (!IsAppRTL() && IsSystemRTL());
+
+  // -registerDefaults: won't do the trick here because these defaults exist
+  // (in the global domain) to reflect the system locale. They need to be set
+  // in Chrome's domain to supersede the system value.
+  if (should_be_rtl) {
+    [defaults setBool:YES forKey:@"AppleTextDirection"];
+    [defaults setBool:YES forKey:@"NSForceRightToLeftWritingDirection"];
+  } else if (should_be_ltr) {
+    [defaults setBool:YES forKey:@"AppleTextDirection"];
+    [defaults setBool:NO forKey:@"NSForceRightToLeftWritingDirection"];
+  } else {
+    [defaults removeObjectForKey:@"AppleTextDirection"];
+    [defaults removeObjectForKey:@"NSForceRightToLeftWritingDirection"];
+  }
 }
 
 Browser::LoginItemSettings Browser::GetLoginItemSettings(

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -382,6 +382,7 @@ int ElectronBrowserMainParts::PreCreateThreads() {
 
 #if BUILDFLAG(IS_MAC)
   ui::InitIdleMonitor();
+  Browser::Get()->ApplyForcedRTL();
 #endif
 
   fake_browser_process_->PreCreateThreads();


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/36539.

Fixes an issue where custom traffic lights wouldn't properly respect an application's locale setting if it differed from the system setting and had a different directionality. This was happening because macOS native elements set their origin and axis based upon the system locale RTL setting, and so even when we took RTL into account in `WindowButtonsProxy` it would still be incorrect. To fix this, we set Apple app-level defaults to force RTL or LTR if it differs from the system locale. This PR also adds support for `--force-ui-direction` similar to CL:956297

Tested with https://gist.github.com/8dc6c09539222ee3ad86146123982011, using an English system locale setting.

<details><summary>Before</summary>
<img width="912" alt="Screenshot 2023-01-09 at 9 53 04 AM" src="https://user-images.githubusercontent.com/2036040/211271552-4e47f3f2-6bd7-4332-97a6-741efe05416b.png">
</details>

<details><summary>After</summary>
<img width="912" alt="Screenshot 2023-01-09 at 10 28 47 AM" src="https://user-images.githubusercontent.com/2036040/211277024-9a30cd58-74fb-48dc-9d13-7c9b930e54b9.png">
</details>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an RTL issue that could happen in some locales when calling `BrowserWindow.setTrafficLightPosition()` on macOS.