### PR TITLE
fix: Cmd+Tab not working when exiting kiosk mode

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1030,9 +1030,12 @@ void NativeWindowMac::SetKiosk(bool kiosk) {
     is_kiosk_ = true;
     SetFullScreen(true);
   } else if (!kiosk && is_kiosk_) {
-    [NSApp setPresentationOptions:kiosk_options_];
     is_kiosk_ = false;
     SetFullScreen(false);
+
+    // Set presentation options *after* asynchronously exiting
+    // fullscreen to ensure they take effect.
+    [NSApp setPresentationOptions:kiosk_options_];
   }
 }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/33503.
Refs https://github.com/electron/electron/pull/25470.

Fixes an issue on macOS when trying to switch processes with `Cmd+Tab` after exiting Kiosk Mode. We need to ensure that presentation options are reset _after_ exiting fullscreen, otherwise the fullscreen action takes precedence and causes them to improperly be reset.

Tested with https://gist.github.com/40902920c8fb6c0e2ebcd8fdb936cbf6.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue on macOS when trying to switch processes with `Cmd+Tab` after exiting Kiosk Mode. 