### PR TITLE
feat: add label property to Display objects

### DIFF
--- a/docs/api/structures/display.md
+++ b/docs/api/structures/display.md
@@ -1,6 +1,7 @@
 # Display Object
 
 * `id` number - Unique identifier associated with the display.
+* `label` string - User-friendly label, determined by the platform.
 * `rotation` number - Can be 0, 90, 180, 270, represents screen rotation in
   clock-wise degrees.
 * `scaleFactor` number - Output device's pixel scale factor.

--- a/shell/common/gin_converters/gfx_converter.cc
+++ b/shell/common/gin_converters/gfx_converter.cc
@@ -144,6 +144,7 @@ v8::Local<v8::Value> Converter<display::Display>::ToV8(
   gin_helper::Dictionary dict = gin::Dictionary::CreateEmpty(isolate);
   dict.SetHidden("simple", true);
   dict.Set("id", val.id());
+  dict.Set("label", val.label());
   dict.Set("bounds", val.bounds());
   dict.Set("workArea", val.work_area());
   dict.Set("accelerometerSupport", val.accelerometer_support());

--- a/spec/api-screen-spec.ts
+++ b/spec/api-screen-spec.ts
@@ -34,6 +34,7 @@ describe('screen module', () => {
 
       expect(display).to.have.property('scaleFactor').that.is.a('number');
       expect(display).to.have.property('id').that.is.a('number');
+      expect(display).to.have.property('label').that.is.a('string');
       expect(display).to.have.property('rotation').that.is.a('number');
       expect(display).to.have.property('touchSupport').that.is.a('string');
       expect(display).to.have.property('accelerometerSupport').that.is.a('string');


### PR DESCRIPTION
#### Description of Change
Fix #36826. Implemented in Chromium by:
- [3646632: Plumb through display labels and add initial mac (>=10.15) implementation.](https://chromium-review.googlesource.com/c/chromium/src/+/3646632)
- [3697197: Add EDID labels for displays on Windows platform.](https://chromium-review.googlesource.com/c/chromium/src/+/3697197)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: Added `label` property to `Display` objects.
