### PR TITLE
fix: Page update docs/latest/tutorial/tutorial-preload

### DIFF
--- a/docs/tutorial/tutorial-3-preload.md
+++ b/docs/tutorial/tutorial-3-preload.md
@@ -78,8 +78,9 @@ contextBridge.exposeInMainWorld('versions', {
 })
 ```
 
-To attach this script to your renderer process, pass its path to the
-`webPreferences.preload` option in the BrowserWindow constructor:
+To attach this script to your renderer process, you need to add Node.js "path" module, 
+it provides a set of functions for working with paths in the file system `const path = require('path')`, 
+also pass its path to the `webPreferences.preload` option in the BrowserWindow constructor.
 
 ```js {2,8-10} title="main.js"
 const { app, BrowserWindow } = require('electron')


### PR DESCRIPTION
I noticed that on the website page (https://www.electronjs.org/docs/latest/tutorial/tutorial-preload)  skipped and didn't specify when to add `const path = require('path')`.  Because of this, an error occurs and the program does not start.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Correct basic information in the documentation on the site.
