### PR TITLE
chore: cherry-pick 28b9c1c04e78 from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -11,3 +11,4 @@ revert_runtime_dhceck_terminating_exception_in_microtasks.patch
 chore_disable_is_execution_terminating_dcheck.patch
 cherry-pick-27fa951ae4a3.patch
 cherry-pick-c79148742421.patch
+cherry-pick-28b9c1c04e78.patch

--- a/patches/v8/cherry-pick-28b9c1c04e78.patch
+++ b/patches/v8/cherry-pick-28b9c1c04e78.patch
@@ -1,0 +1,78 @@
+From 28b9c1c04e782d527b5dedf0214de7b3a456f5f9 Mon Sep 17 00:00:00 2001
+From: Clemens Backes <clemensb@chromium.org>
+Date: Tue, 13 Dec 2022 22:37:27 +0100
+Subject: [PATCH] Merged: [arm] Do not emit the constant pool before a branch
+
+After computing the branch offset but before emitting the actual branch,
+we should not emit a constant pool. Otherwise the previously computed
+offset would be off.
+
+Instead of handling this indirectly via the Assembler::branch_offset
+method, do this directly in the Assembler::b method (and friends), so it
+is not missed on other call sites.
+
+R=nicohartmann@chromium.org
+
+(cherry picked from commit 9be597d194e108ba718610b9a611fe19a0fbfde5)
+Bug: chromium:1399424
+
+Change-Id: Ie30ba70508b4fb8913f79e049a33108608915704
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4118864
+Reviewed-by: Nico Hartmann <nicohartmann@chromium.org>
+Commit-Queue: Clemens Backes <clemensb@chromium.org>
+Cr-Commit-Position: refs/branch-heads/10.8@{#48}
+Cr-Branched-From: f1bc03fd6b4c201abd9f0fd9d51fb989150f97b9-refs/heads/10.8.168@{#1}
+Cr-Branched-From: 237de893e1c0a0628a57d0f5797483d3add7f005-refs/heads/main@{#83672}
+---
+
+diff --git a/src/codegen/arm/assembler-arm.cc b/src/codegen/arm/assembler-arm.cc
+index b2d7cad..3fe769a0 100644
+--- a/src/codegen/arm/assembler-arm.cc
++++ b/src/codegen/arm/assembler-arm.cc
+@@ -1444,10 +1444,6 @@
+     L->link_to(pc_offset());
+   }
+ 
+-  // Block the emission of the constant pool, since the branch instruction must
+-  // be emitted at the pc offset recorded by the label.
+-  if (!is_const_pool_blocked()) BlockConstPoolFor(1);
+-
+   return target_pos - (pc_offset() + Instruction::kPcLoadDelta);
+ }
+ 
+@@ -1458,6 +1454,11 @@
+   int imm24 = branch_offset >> 2;
+   const bool b_imm_check = is_int24(imm24);
+   CHECK(b_imm_check);
++
++  // Block the emission of the constant pool before the next instruction.
++  // Otherwise the passed-in branch offset would be off.
++  BlockConstPoolFor(1);
++
+   emit(cond | B27 | B25 | (imm24 & kImm24Mask));
+ 
+   if (cond == al) {
+@@ -1472,6 +1473,11 @@
+   int imm24 = branch_offset >> 2;
+   const bool bl_imm_check = is_int24(imm24);
+   CHECK(bl_imm_check);
++
++  // Block the emission of the constant pool before the next instruction.
++  // Otherwise the passed-in branch offset would be off.
++  BlockConstPoolFor(1);
++
+   emit(cond | B27 | B25 | B24 | (imm24 & kImm24Mask));
+ }
+ 
+@@ -1481,6 +1487,11 @@
+   int imm24 = branch_offset >> 2;
+   const bool blx_imm_check = is_int24(imm24);
+   CHECK(blx_imm_check);
++
++  // Block the emission of the constant pool before the next instruction.
++  // Otherwise the passed-in branch offset would be off.
++  BlockConstPoolFor(1);
++
+   emit(kSpecialCondition | B27 | B25 | h | (imm24 & kImm24Mask));
+ }
+ 

--- a/patches/v8/cherry-pick-28b9c1c04e78.patch
+++ b/patches/v8/cherry-pick-28b9c1c04e78.patch
@@ -1,7 +1,7 @@
-From 28b9c1c04e782d527b5dedf0214de7b3a456f5f9 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Clemens Backes <clemensb@chromium.org>
 Date: Tue, 13 Dec 2022 22:37:27 +0100
-Subject: [PATCH] Merged: [arm] Do not emit the constant pool before a branch
+Subject: Merged: [arm] Do not emit the constant pool before a branch
 
 After computing the branch offset but before emitting the actual branch,
 we should not emit a constant pool. Otherwise the previously computed
@@ -23,13 +23,12 @@ Commit-Queue: Clemens Backes <clemensb@chromium.org>
 Cr-Commit-Position: refs/branch-heads/10.8@{#48}
 Cr-Branched-From: f1bc03fd6b4c201abd9f0fd9d51fb989150f97b9-refs/heads/10.8.168@{#1}
 Cr-Branched-From: 237de893e1c0a0628a57d0f5797483d3add7f005-refs/heads/main@{#83672}
----
 
 diff --git a/src/codegen/arm/assembler-arm.cc b/src/codegen/arm/assembler-arm.cc
-index b2d7cad..3fe769a0 100644
+index 645edb17a4892aec70f0221cec889996a6868242..a95d4df308fd4651093a4911ad1c50226e059ebb 100644
 --- a/src/codegen/arm/assembler-arm.cc
 +++ b/src/codegen/arm/assembler-arm.cc
-@@ -1444,10 +1444,6 @@
+@@ -1462,10 +1462,6 @@ int Assembler::branch_offset(Label* L) {
      L->link_to(pc_offset());
    }
  
@@ -40,7 +39,7 @@ index b2d7cad..3fe769a0 100644
    return target_pos - (pc_offset() + Instruction::kPcLoadDelta);
  }
  
-@@ -1458,6 +1454,11 @@
+@@ -1476,6 +1472,11 @@ void Assembler::b(int branch_offset, Condition cond, RelocInfo::Mode rmode) {
    int imm24 = branch_offset >> 2;
    const bool b_imm_check = is_int24(imm24);
    CHECK(b_imm_check);
@@ -52,7 +51,7 @@ index b2d7cad..3fe769a0 100644
    emit(cond | B27 | B25 | (imm24 & kImm24Mask));
  
    if (cond == al) {
-@@ -1472,6 +1473,11 @@
+@@ -1490,6 +1491,11 @@ void Assembler::bl(int branch_offset, Condition cond, RelocInfo::Mode rmode) {
    int imm24 = branch_offset >> 2;
    const bool bl_imm_check = is_int24(imm24);
    CHECK(bl_imm_check);
@@ -64,7 +63,7 @@ index b2d7cad..3fe769a0 100644
    emit(cond | B27 | B25 | B24 | (imm24 & kImm24Mask));
  }
  
-@@ -1481,6 +1487,11 @@
+@@ -1499,6 +1505,11 @@ void Assembler::blx(int branch_offset) {
    int imm24 = branch_offset >> 2;
    const bool blx_imm_check = is_int24(imm24);
    CHECK(blx_imm_check);


### PR DESCRIPTION
Merged: [arm] Do not emit the constant pool before a branch

After computing the branch offset but before emitting the actual branch,
we should not emit a constant pool. Otherwise the previously computed
offset would be off.

Instead of handling this indirectly via the Assembler::branch_offset
method, do this directly in the Assembler::b method (and friends), so it
is not missed on other call sites.

R=nicohartmann@chromium.org

(cherry picked from commit 9be597d194e108ba718610b9a611fe19a0fbfde5)
Bug: chromium:1399424

Change-Id: Ie30ba70508b4fb8913f79e049a33108608915704
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4118864
Reviewed-by: Nico Hartmann <nicohartmann@chromium.org>
Commit-Queue: Clemens Backes <clemensb@chromium.org>
Cr-Commit-Position: refs/branch-heads/10.8@{#48}
Cr-Branched-From: f1bc03fd6b4c201abd9f0fd9d51fb989150f97b9-refs/heads/10.8.168@{#1}
Cr-Branched-From: 237de893e1c0a0628a57d0f5797483d3add7f005-refs/heads/main@{#83672}


Notes: Security: backported fix for 1399424.