### PR TITLE
chore: cherry-pick 0f481c9ddf2a from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -19,3 +19,4 @@ cherry-pick-80ed4b917477.patch
 cherry-pick-2ac0620a5bbb.patch
 cherry-pick-177e8bcd3584.patch
 cherry-pick-27fa951ae4a3.patch
+cherry-pick-0f481c9ddf2a.patch

--- a/patches/v8/cherry-pick-0f481c9ddf2a.patch
+++ b/patches/v8/cherry-pick-0f481c9ddf2a.patch
@@ -1,0 +1,70 @@
+From 0f481c9ddf2a0ca4eaaa9e729003cc2956f779da Mon Sep 17 00:00:00 2001
+From: Clemens Backes <clemensb@chromium.org>
+Date: Thu, 15 Dec 2022 11:58:50 +0100
+Subject: [PATCH] Merged: [wasm][turbofan] Load 32-bit values more efficiently
+
+When loading a 32-bit value from the stack, just load 32 bit and
+zero-extend them into the target register, instead of loading the full
+64 bits.
+
+As there are things to fix (see https://crbug.com/1356461), we only
+enable this optimization for Wasm for now.
+
+Also include the related fix https://crrev.com/c/4096985.
+
+R=mslekova@chromium.org
+
+(cherry picked from commit 2ee52447c878721c89a55a780eb689ecba6817d3)
+(cherry picked from commit a38209949fcbf045231c316e2d790b8b70ccb7ef)
+
+Bug: chromium:1395604
+Change-Id: I54a2182ada6fadbfcf5565f0dc8d4f477ecff393
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4110897
+Reviewed-by: Maya Lekova <mslekova@chromium.org>
+Commit-Queue: Clemens Backes <clemensb@chromium.org>
+Cr-Commit-Position: refs/branch-heads/10.8@{#46}
+Cr-Branched-From: f1bc03fd6b4c201abd9f0fd9d51fb989150f97b9-refs/heads/10.8.168@{#1}
+Cr-Branched-From: 237de893e1c0a0628a57d0f5797483d3add7f005-refs/heads/main@{#83672}
+---
+
+diff --git a/src/compiler/backend/x64/code-generator-x64.cc b/src/compiler/backend/x64/code-generator-x64.cc
+index 6a29cb3..e3f759f 100644
+--- a/src/compiler/backend/x64/code-generator-x64.cc
++++ b/src/compiler/backend/x64/code-generator-x64.cc
+@@ -5295,7 +5295,22 @@
+     case MoveType::kStackToRegister: {
+       Operand src = g.ToOperand(source);
+       if (source->IsStackSlot()) {
+-        __ movq(g.ToRegister(destination), src);
++        MachineRepresentation mr =
++            LocationOperand::cast(source)->representation();
++        const bool is_32_bit = mr == MachineRepresentation::kWord32 ||
++                               mr == MachineRepresentation::kCompressed ||
++                               mr == MachineRepresentation::kCompressedPointer;
++        // TODO(13581): Fix this for other code kinds (see
++        // https://crbug.com/1356461).
++        if (code_kind() == CodeKind::WASM_FUNCTION && is_32_bit) {
++          // When we need only 32 bits, move only 32 bits. Benefits:
++          // - Save a byte here and there (depending on the destination
++          //   register; "movl eax, ..." is smaller than "movq rax, ...").
++          // - Safeguard against accidental decompression of compressed slots.
++          __ movl(g.ToRegister(destination), src);
++        } else {
++          __ movq(g.ToRegister(destination), src);
++        }
+       } else {
+         DCHECK(source->IsFPStackSlot());
+         XMMRegister dst = g.ToDoubleRegister(destination);
+diff --git a/src/wasm/graph-builder-interface.cc b/src/wasm/graph-builder-interface.cc
+index fb1f19c..abf68f8 100644
+--- a/src/wasm/graph-builder-interface.cc
++++ b/src/wasm/graph-builder-interface.cc
+@@ -2106,7 +2106,7 @@
+       }
+       if (exception_value != nullptr) {
+         *exception_value = builder_->LoopExitValue(
+-            *exception_value, MachineRepresentation::kWord32);
++            *exception_value, MachineRepresentation::kTaggedPointer);
+       }
+       if (wrap_exit_values) {
+         WrapLocalsAtLoopExit(decoder, control);

--- a/patches/v8/cherry-pick-0f481c9ddf2a.patch
+++ b/patches/v8/cherry-pick-0f481c9ddf2a.patch
@@ -1,7 +1,7 @@
-From 0f481c9ddf2a0ca4eaaa9e729003cc2956f779da Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Clemens Backes <clemensb@chromium.org>
 Date: Thu, 15 Dec 2022 11:58:50 +0100
-Subject: [PATCH] Merged: [wasm][turbofan] Load 32-bit values more efficiently
+Subject: Merged: [wasm][turbofan] Load 32-bit values more efficiently
 
 When loading a 32-bit value from the stack, just load 32 bit and
 zero-extend them into the target register, instead of loading the full
@@ -25,13 +25,12 @@ Commit-Queue: Clemens Backes <clemensb@chromium.org>
 Cr-Commit-Position: refs/branch-heads/10.8@{#46}
 Cr-Branched-From: f1bc03fd6b4c201abd9f0fd9d51fb989150f97b9-refs/heads/10.8.168@{#1}
 Cr-Branched-From: 237de893e1c0a0628a57d0f5797483d3add7f005-refs/heads/main@{#83672}
----
 
 diff --git a/src/compiler/backend/x64/code-generator-x64.cc b/src/compiler/backend/x64/code-generator-x64.cc
-index 6a29cb3..e3f759f 100644
+index 9fd4635d8911716019bf0116123b85a408e247ca..86e017936bab415c003476844cb981e8ad5d1e56 100644
 --- a/src/compiler/backend/x64/code-generator-x64.cc
 +++ b/src/compiler/backend/x64/code-generator-x64.cc
-@@ -5295,7 +5295,22 @@
+@@ -5119,7 +5119,22 @@ void CodeGenerator::AssembleMove(InstructionOperand* source,
      case MoveType::kStackToRegister: {
        Operand src = g.ToOperand(source);
        if (source->IsStackSlot()) {
@@ -56,12 +55,12 @@ index 6a29cb3..e3f759f 100644
          DCHECK(source->IsFPStackSlot());
          XMMRegister dst = g.ToDoubleRegister(destination);
 diff --git a/src/wasm/graph-builder-interface.cc b/src/wasm/graph-builder-interface.cc
-index fb1f19c..abf68f8 100644
+index 3d899eded2d744731f2acfadce6f4d55b1417c4d..a9587d7548495dfdb0a6cf43ab22a3d06d1a76e7 100644
 --- a/src/wasm/graph-builder-interface.cc
 +++ b/src/wasm/graph-builder-interface.cc
-@@ -2106,7 +2106,7 @@
-       }
+@@ -2061,7 +2061,7 @@ class WasmGraphBuildingInterface {
        if (exception_value != nullptr) {
+         // TODO(manoskouk): Can we assign a wasm type to the exception value?
          *exception_value = builder_->LoopExitValue(
 -            *exception_value, MachineRepresentation::kWord32);
 +            *exception_value, MachineRepresentation::kTaggedPointer);


### PR DESCRIPTION
Merged: [wasm][turbofan] Load 32-bit values more efficiently

When loading a 32-bit value from the stack, just load 32 bit and
zero-extend them into the target register, instead of loading the full
64 bits.

As there are things to fix (see https://crbug.com/1356461), we only
enable this optimization for Wasm for now.

Also include the related fix https://crrev.com/c/4096985.

R=mslekova@chromium.org

(cherry picked from commit 2ee52447c878721c89a55a780eb689ecba6817d3)
(cherry picked from commit a38209949fcbf045231c316e2d790b8b70ccb7ef)

Bug: chromium:1395604
Change-Id: I54a2182ada6fadbfcf5565f0dc8d4f477ecff393
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4110897
Reviewed-by: Maya Lekova <mslekova@chromium.org>
Commit-Queue: Clemens Backes <clemensb@chromium.org>
Cr-Commit-Position: refs/branch-heads/10.8@{#46}
Cr-Branched-From: f1bc03fd6b4c201abd9f0fd9d51fb989150f97b9-refs/heads/10.8.168@{#1}
Cr-Branched-From: 237de893e1c0a0628a57d0f5797483d3add7f005-refs/heads/main@{#83672}


Notes: Security: backported fix for 1395604.