### PR TITLE
build: remove `ScriptOrModule` V8 flag

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -10,9 +10,6 @@ v8_embedder_string = "-electron.0"
 # TODO: this breaks mksnapshot
 v8_enable_snapshot_native_code_counters = false
 
-# TODO(codebytere): remove when Node.js handles https://chromium-review.googlesource.com/c/v8/v8/+/3211575
-v8_scriptormodule_legacy_lifetime = true
-
 # we use this api
 v8_enable_javascript_promise_hooks = true
 


### PR DESCRIPTION
#### Description of Change

This was addressed in https://github.com/nodejs/node/pull/44198, which landed in v18.8.0, and so can be removed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
