### PR TITLE
build: remove older branch migration helpers

### DIFF
--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -71,7 +71,7 @@ async function handleGitCall (args, gitDir) {
 }
 
 async function getCurrentBranch (gitDir) {
-  const RELEASE_BRANCH_PATTERN = /^\d+-\d+-x$/;
+  const RELEASE_BRANCH_PATTERN = /^\d+-x-y$/;
   const MAIN_BRANCH_PATTERN = /^main$/;
   const ORIGIN_MAIN_BRANCH_PATTERN = /^origin\/main$/;
 

--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -6,11 +6,6 @@ const path = require('path');
 const ELECTRON_DIR = path.resolve(__dirname, '..', '..');
 const SRC_DIR = path.resolve(ELECTRON_DIR, '..');
 
-const RELEASE_BRANCH_PATTERN = /(\d)+-(?:(?:[0-9]+-x$)|(?:x+-y$))/;
-// TODO(main-migration): Simplify once main branch is renamed
-const MAIN_BRANCH_PATTERN = /^(main|master)$/;
-const ORIGIN_MAIN_BRANCH_PATTERN = /^origin\/(main|master)$/;
-
 require('colors');
 const pass = '✓'.green;
 const fail = '✗'.red;
@@ -76,6 +71,10 @@ async function handleGitCall (args, gitDir) {
 }
 
 async function getCurrentBranch (gitDir) {
+  const RELEASE_BRANCH_PATTERN = /^\d+-\d+-x$/;
+  const MAIN_BRANCH_PATTERN = /^main$/;
+  const ORIGIN_MAIN_BRANCH_PATTERN = /^origin\/main$/;
+
   let branch = await handleGitCall(['rev-parse', '--abbrev-ref', 'HEAD'], gitDir);
   if (!MAIN_BRANCH_PATTERN.test(branch) && !RELEASE_BRANCH_PATTERN.test(branch)) {
     const lastCommit = await handleGitCall(['rev-parse', 'HEAD'], gitDir);

--- a/script/release/notes/index.js
+++ b/script/release/notes/index.js
@@ -76,8 +76,7 @@ const getAllBranches = async () => {
     return branches.split('\n')
       .map(branch => branch.trim())
       .filter(branch => !!branch)
-      // TODO(main-migration): Simplify once branch rename is complete.
-      .filter(branch => branch !== 'origin/HEAD -> origin/master' && branch !== 'origin/HEAD -> origin/main')
+      .filter(branch => branch !== 'origin/HEAD -> origin/main')
       .sort();
   } catch (err) {
     console.error('Failed to fetch all branches');
@@ -86,8 +85,7 @@ const getAllBranches = async () => {
 };
 
 const getStabilizationBranches = async () => {
-  return (await getAllBranches())
-    .filter(branch => /^origin\/\d+-\d+-x$/.test(branch) || /^origin\/\d+-x-y$/.test(branch));
+  return (await getAllBranches()).filter(branch => /^origin\/\d+-\d+-x$/.test(branch));
 };
 
 const getPreviousStabilizationBranch = async (current) => {

--- a/script/release/notes/index.js
+++ b/script/release/notes/index.js
@@ -85,7 +85,7 @@ const getAllBranches = async () => {
 };
 
 const getStabilizationBranches = async () => {
-  return (await getAllBranches()).filter(branch => /^origin\/\d+-\d+-x$/.test(branch));
+  return (await getAllBranches()).filter(branch => /^origin\/\d+-x-y$/.test(branch));
 };
 
 const getPreviousStabilizationBranch = async (current) => {

--- a/script/release/publish-to-npm.js
+++ b/script/release/publish-to-npm.js
@@ -132,13 +132,8 @@ new Promise((resolve, reject) => {
     const currentBranch = await getCurrentBranch();
 
     if (isNightlyElectronVersion) {
-      // TODO(main-migration): Simplify once main branch is renamed.
-      if (currentBranch === 'master' || currentBranch === 'main') {
-        // Nightlies get published to their own module, so they should be tagged as latest
-        npmTag = 'latest';
-      } else {
-        npmTag = `nightly-${currentBranch}`;
-      }
+      // Nightlies get published to their own module, so they should be tagged as latest
+      npmTag = currentBranch === 'main' ? 'latest' : `nightly-${currentBranch}`;
 
       const currentJson = JSON.parse(fs.readFileSync(path.join(tempDir, 'package.json'), 'utf8'));
       currentJson.name = 'electron-nightly';
@@ -149,7 +144,7 @@ new Promise((resolve, reject) => {
         JSON.stringify(currentJson, null, 2)
       );
     } else {
-      if (currentBranch === 'master' || currentBranch === 'main') {
+      if (currentBranch === 'main') {
         // This should never happen, main releases should be nightly releases
         // this is here just-in-case
         throw new Error('Unreachable release phase, can\'t tag a non-nightly release on the main branch');

--- a/script/release/version-utils.js
+++ b/script/release/version-utils.js
@@ -73,8 +73,7 @@ async function nextNightly (v) {
   const pre = `nightly.${getCurrentDate()}`;
 
   const branch = (await GitProcess.exec(['rev-parse', '--abbrev-ref', 'HEAD'], ELECTRON_DIR)).stdout.trim();
-  // TODO(main-migration): Simplify once main branch is renamed
-  if (branch === 'master' || branch === 'main') {
+  if (branch === 'main') {
     next = semver.inc(await getLastMajorForMain(), 'major');
   } else if (isStable(v)) {
     next = semver.inc(next, 'patch');


### PR DESCRIPTION
#### Description of Change

The main migration has been complete for some time, and so there are no longer any branches which might release off of master. Address TODOs and simplify code accordingly. There also aren't any branches that should take the `1-x-y` format any longer, so simplify that as well.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none