### PR TITLE
fix: webview background color on reload

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1523,13 +1523,15 @@ void WebContents::HandleNewRenderFrame(
   // Set the background color of RenderWidgetHostView.
   auto* web_preferences = WebContentsPreferences::From(web_contents());
   if (web_preferences) {
-    absl::optional<SkColor> maybe_color = web_preferences->GetBackgroundColor();
-    web_contents()->SetPageBaseBackgroundColor(maybe_color);
-
+    auto maybe_color = web_preferences->GetBackgroundColor();
     bool guest = IsGuest() || type_ == Type::kBrowserView;
-    SkColor color =
+
+    // If webPreferences has no color stored we need to explicitly set guest
+    // webContents background color to transparent.
+    auto bg_color =
         maybe_color.value_or(guest ? SK_ColorTRANSPARENT : SK_ColorWHITE);
-    SetBackgroundColor(rwhv, color);
+    web_contents()->SetPageBaseBackgroundColor(bg_color);
+    SetBackgroundColor(rwhv, bg_color);
   }
 
   if (!background_throttling_)


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/36417.

Fixes an issue where webview background color would not correctly be set on reload. This was happening as a result of https://github.com/electron/electron/pull/33435, where I fixed an issue with _missing_ transparency but made it such that when `webPreferences` had no color stored the initial background color would be set to white. Instead, we need to explicitly set guest webContents background color to transparent when `webPreferences` has no color stored.

Tested with https://gist.github.com/PerfectPan/100900b7758293b8f72b23d0babdb1cc and confirmed not to regress https://github.com/electron/electron/issues/33374

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `webView`s could have an incorrect initial background color following reloads.
