### PR TITLE
chore: update node types version

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@electron/get": "^2.0.0",
-    "@types/node": "^16.11.26",
+    "@types/node": "^18.11.18",
     "extract-zip": "^2.0.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@types/klaw": "^3.0.1",
     "@types/minimist": "^1.2.0",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^16.11.26",
+    "@types/node": "^18.11.18",
     "@types/semver": "^7.3.3",
     "@types/send": "^0.14.5",
     "@types/split": "^1.0.0",

--- a/spec/types-spec.ts
+++ b/spec/types-spec.ts
@@ -5,7 +5,6 @@ describe('bundled @types/node', () => {
     expect(require('../npm/package.json').dependencies).to.have.property('@types/node');
     const range = require('../npm/package.json').dependencies['@types/node'];
     expect(range).to.match(/^\^.+/, 'should allow any type dep in a major range');
-    // TODO(codebytere): re-enable after https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52594 is merged.
-    // expect(range.slice(1).split('.')[0]).to.equal(process.versions.node.split('.')[0]);
+    expect(range.slice(1).split('.')[0]).to.equal(process.versions.node.split('.')[0]);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -912,10 +912,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.4.13.tgz#7dfd9c14661edc65cccd43a29eb454174642370d"
   integrity sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg==
 
-"@types/node@^16.11.26":
-  version "16.11.26"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.26.tgz#63d204d136c9916fb4dcd1b50f9740fe86884e47"
-  integrity sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==
+"@types/node@^18.11.18":
+  version "18.11.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
+  integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
#### Description of Change

Address standing TODO - update `@types/node` to re-enable spec.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Updates Node.js types to v18.