### PR TITLE
feat: add support for unlocking with Apple Watch

### DIFF
--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -425,9 +425,10 @@ std::string SystemPreferences::GetSystemColor(gin_helper::ErrorThrower thrower,
 
 bool SystemPreferences::CanPromptTouchID() {
   base::scoped_nsobject<LAContext> context([[LAContext alloc] init]);
-  if (![context
-          canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
-                      error:nil])
+  LAPolicy auth_policy = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
+  if (@available(macOS 10.15, *))
+    auth_policy = LAPolicyDeviceOwnerAuthenticationWithBiometricsOrWatch;
+  if (![context canEvaluatePolicy:auth_policy error:nil])
     return false;
   if (@available(macOS 10.13.2, *))
     return [context biometryType] == LABiometryTypeTouchID;


### PR DESCRIPTION
#### Description of Change

If you have an Apple laptop in clamshell mode (lid is closed) and you don't have an Apple Keyboard with TouchID, `LAPolicyDeviceOwnerAuthenticationWithBiometrics` policy cannot be evaluated, and `CanPromptTouchID` returns false even if you have an Apple Watch capable of unlocking the laptop. This new policy is mirroring macOS behavior.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: `SystemPreferences::CanPromptTouchID` (macOS) now supports Apple Watch