### PR TITLE
feat: enable whole-program optimization native modules by default

### DIFF
--- a/script/generate-config-gypi.py
+++ b/script/generate-config-gypi.py
@@ -23,7 +23,8 @@ def run_node_configure(target_cpu):
   args += ['--openssl-no-asm']
 
   # Enable whole-program optimization for electron native modules.
-  args += ['--with-ltcg']
+  if sys.platform == "win32":
+    args += ['--with-ltcg']
   subprocess.check_call([sys.executable, configure] + args)
 
 def read_node_config_gypi():

--- a/script/generate-config-gypi.py
+++ b/script/generate-config-gypi.py
@@ -57,6 +57,8 @@ def main(target_file, target_cpu):
   v['node_module_version'] = int(args['node_module_version'])
   # Used by certain versions of node-gyp.
   v['build_v8_with_gn'] = 'false'
+  # Enable whole-program optimization for electron native modules.
+  v['node-with-ltcg'] = 'true'
 
   with open(target_file, 'w+') as f:
     f.write(pprint.pformat(config, indent=2))

--- a/script/generate-config-gypi.py
+++ b/script/generate-config-gypi.py
@@ -21,6 +21,9 @@ def run_node_configure(target_cpu):
   # Work around "No acceptable ASM compiler found" error on some System,
   # it breaks nothing since Electron does not use OpenSSL.
   args += ['--openssl-no-asm']
+
+  # Enable whole-program optimization for electron native modules.
+  args += ['--with-ltcg']
   subprocess.check_call([sys.executable, configure] + args)
 
 def read_node_config_gypi():
@@ -57,8 +60,6 @@ def main(target_file, target_cpu):
   v['node_module_version'] = int(args['node_module_version'])
   # Used by certain versions of node-gyp.
   v['build_v8_with_gn'] = 'false'
-  # Enable whole-program optimization for electron native modules.
-  v['node-with-ltcg'] = 'true'
 
   with open(target_file, 'w+') as f:
     f.write(pprint.pformat(config, indent=2))


### PR DESCRIPTION
#### Description of Change

Enable whole-program optimization by default in script that generates config.gypi needed for electron native modules.
Related work item: #36936 

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Whole-program optimization is enabled by default in electron node headers config file.