### PR TITLE
test: fix nativeTheme test when system in dark mode

### DIFF
--- a/spec/api-native-theme-spec.ts
+++ b/spec/api-native-theme-spec.ts
@@ -36,6 +36,7 @@ describe('nativeTheme module', () => {
     });
 
     it('should emit the "updated" event when it is set and the resulting "shouldUseDarkColors" value changes', async () => {
+      nativeTheme.themeSource = 'light';
       let updatedEmitted = emittedOnce(nativeTheme, 'updated');
       nativeTheme.themeSource = 'dark';
       await updatedEmitted;


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Fixed a test which is supposed to trigger a change to `nativeTheme.themeSource`, but would only happen if the system was in light mode. If the system was in dark mode, the test would not trigger a change since it set `nativeTheme.themeSource` to "dark" initially. I've updated the test to first set `nativeTheme.themeSource` to "light" before then changing it to "dark" to ensure a change is triggered regardless of the system theme.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
