### PR TITLE
docs: Change factuality and word choice in app.runningUnderARM64Translation

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1566,5 +1566,4 @@ an ARM64 translator (like the macOS
 or Windows [WOW](https://en.wikipedia.org/wiki/Windows_on_Windows)).
 
 You can use this property to prompt users to download the arm64 version of
-your application when they are running the x64 version under Rosetta
-incorrectly.
+your application when they are mistakenly running the x64 version under Rosetta or WOW.


### PR DESCRIPTION
Added "or WOW" to display the use of Windows as a possible scenario.

Changed the wording of that same sentence in `app.runningUnderARM64Translation` to make it appear clearer. Replaced "incorrectly" with "mistakenly" and moved this word to before the verb instead of the end of the sentence.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
