### PR TITLE
ci: don't run stale workflow jobs in parallel

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,6 +25,8 @@ jobs:
           only-pr-labels: not-a-real-label
   pending-repro:
     runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: stale
     steps:
       - uses: actions/stale@3de2653986ebd134983c79fe2be5d45cc3d9f4e1
         with:


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

By default the jobs in a workflow run in parallel which leaves open the small possibility that both jobs will act on the same issue like what happened in https://github.com/electron/electron/issues/34930 - although that one was a result of the workflow resuming after not having run for a while so both criteria were met, which they wouldn't normally be under normal circumstances.

Still, let's rule out the possibility, in case we add more jobs to the workflow going forward. `if: ${{ always() }}` ensures the job runs even if the job it depends on fails.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
