### PR TITLE
fix: make plugin helper executable unconditional

### DIFF
--- a/shell/app/electron_main_delegate_mac.mm
+++ b/shell/app/electron_main_delegate_mac.mm
@@ -15,7 +15,6 @@
 #include "base/strings/sys_string_conversions.h"
 #include "content/common/mac_helpers.h"
 #include "content/public/common/content_paths.h"
-#include "ppapi/buildflags/buildflags.h"
 #include "shell/browser/mac/electron_application.h"
 #include "shell/common/application_info.h"
 #include "shell/common/mac/main_application_bundle.h"
@@ -41,11 +40,9 @@ base::FilePath GetHelperAppPath(const base::FilePath& frameworks_path,
   } else if (base::EndsWith(path.value(), content::kMacHelperSuffix_gpu,
                             base::CompareCase::SENSITIVE)) {
     helper_name += content::kMacHelperSuffix_gpu;
-#if BUILDFLAG(ENABLE_PLUGINS)
   } else if (base::EndsWith(path.value(), content::kMacHelperSuffix_plugin,
                             base::CompareCase::SENSITIVE)) {
     helper_name += content::kMacHelperSuffix_plugin;
-#endif
   }
 
   return frameworks_path.Append(name + " " + helper_name + ".app")

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -474,15 +474,10 @@ void ElectronBrowserClient::AppendExtraCommandLineSwitches(
         content::ChildProcessHost::CHILD_RENDERER);
     auto gpu_child_path = content::ChildProcessHost::GetChildPath(
         content::ChildProcessHost::CHILD_GPU);
-#if BUILDFLAG(ENABLE_PLUGINS)
     auto plugin_child_path = content::ChildProcessHost::GetChildPath(
         content::ChildProcessHost::CHILD_PLUGIN);
-#endif
-    if (program != renderer_child_path && program != gpu_child_path
-#if BUILDFLAG(ENABLE_PLUGINS)
-        && program != plugin_child_path
-#endif
-    ) {
+    if (program != renderer_child_path && program != gpu_child_path &&
+        program != plugin_child_path) {
       child_path = content::ChildProcessHost::GetChildPath(
           content::ChildProcessHost::CHILD_NORMAL);
       CHECK_EQ(program, child_path)

--- a/shell/common/mac/main_application_bundle.mm
+++ b/shell/common/mac/main_application_bundle.mm
@@ -11,7 +11,6 @@
 #include "base/path_service.h"
 #include "base/strings/string_util.h"
 #include "content/common/mac_helpers.h"
-#include "ppapi/buildflags/buildflags.h"
 
 namespace electron {
 
@@ -33,10 +32,8 @@ base::FilePath MainApplicationBundlePath() {
   // Up to Contents.
   if (!HasMainProcessKey() &&
       (base::EndsWith(path.value(), " Helper", base::CompareCase::SENSITIVE) ||
-#if BUILDFLAG(ENABLE_PLUGINS)
        base::EndsWith(path.value(), content::kMacHelperSuffix_plugin,
                       base::CompareCase::SENSITIVE) ||
-#endif
        base::EndsWith(path.value(), content::kMacHelperSuffix_renderer,
                       base::CompareCase::SENSITIVE) ||
        base::EndsWith(path.value(), content::kMacHelperSuffix_gpu,


### PR DESCRIPTION
#### Description of Change

Refs https://bugs.chromium.org/p/chromium/issues/detail?id=1342679

Plugin helper executable has use cases outside the plugin architecture of chromium to allow loading third-party unsigned libraries. We also leverage this capability in the [UtilityProcess API](https://github.com/electron/electron/blob/main/docs/api/utility-process.md#utilityprocessforkmodulepath-args-options)

`enable_plugins` is already on track for deletion in [upstream](https://bugs.chromium.org/p/chromium/issues/detail?id=702990) so they have made this executable [not conditional](https://chromium-review.googlesource.com/c/chromium/src/+/3751458) on that flag, the PR aligns to do the same in Electron. You can also refer to the linked issue as to why the executable has not been renamed.

/cc @miniak FYI

#### Release Notes

Notes: Remove plugin helper checks on macOS gated behind enable_plugins buildflag