### PR TITLE
chore: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For more installation options and troubleshooting tips, see
 Each Electron release provides binaries for macOS, Windows, and Linux.
 
 * macOS (High Sierra and up): Electron provides 64-bit Intel and ARM binaries for macOS. Apple Silicon support was added in Electron 11.
-* Windows (Windows 10 and up): Electron provides `ia32` (`x86`), `x64` (`amd64`), and `arm64` binaries for Windows. Windows on ARM support was added in Electron 5.0.8. Support for Windows 7 and 8 was [removed in Electron 23, in line with Chromium's Windows deprecation policy](https://www.electronjs.org/blog/windows-7-to-8-1-deprecation-notice).
+* Windows (Windows 10 and up): Electron provides `ia32` (`x86`), `x64` (`amd64`), and `arm64` binaries for Windows. Windows on ARM support was added in Electron 5.0.8. Support for Windows 7, 8 and 8.1 was [removed in Electron 23, in line with Chromium's Windows deprecation policy](https://www.electronjs.org/blog/windows-7-to-8-1-deprecation-notice).
 * Linux: The prebuilt binaries of Electron are built on Ubuntu 20.04. They have also been verified to work on:
   * Ubuntu 14.04 and newer
   * Fedora 24 and newer


### PR DESCRIPTION
Follow-up to #36427

replace `Support for Windows 7 and 8 was removed in Electron 23`
with `Support for Windows 7, 8 and 8.1 was removed in Electron 23`

Notes: none