### PR TITLE
fix: re-enable WindowCaptureMacV2

### DIFF
--- a/patches/chromium/desktop_media_list.patch
+++ b/patches/chromium/desktop_media_list.patch
@@ -4,7 +4,6 @@ Date: Thu, 18 Oct 2018 17:07:01 -0700
 Subject: desktop_media_list.patch
 
 * Use our grit resources instead of the chrome ones.
-* Disabled WindowCaptureMacV2 feature for https://github.com/electron/electron/pull/30507
 * Ensure "OnRefreshComplete()" even if there are no items in the list
 
 diff --git a/chrome/browser/media/webrtc/desktop_media_list.h b/chrome/browser/media/webrtc/desktop_media_list.h
@@ -85,16 +84,7 @@ diff --git a/chrome/browser/media/webrtc/native_desktop_media_list.cc b/chrome/b
 index b548c9fbd3c0bf425447b29dcd866cd27e96b14c..f994ac6086c7b4cd3e8534f34691189d78a21601 100644
 --- a/chrome/browser/media/webrtc/native_desktop_media_list.cc
 +++ b/chrome/browser/media/webrtc/native_desktop_media_list.cc
-@@ -147,7 +147,7 @@ BOOL CALLBACK AllHwndCollector(HWND hwnd, LPARAM param) {
- #if BUILDFLAG(IS_MAC)
- BASE_FEATURE(kWindowCaptureMacV2,
-              "WindowCaptureMacV2",
--             base::FEATURE_ENABLED_BY_DEFAULT);
-+             base::FEATURE_DISABLED_BY_DEFAULT);
- #endif
- 
- }  // namespace
-@@ -457,6 +457,9 @@ void NativeDesktopMediaList::Worker::RefreshNextThumbnail() {
+@@ -451,6 +451,9 @@ void NativeDesktopMediaList::Worker::RefreshNextThumbnail() {
        FROM_HERE,
        base::BindOnce(&NativeDesktopMediaList::UpdateNativeThumbnailsFinished,
                       media_list_));

--- a/patches/chromium/desktop_media_list.patch
+++ b/patches/chromium/desktop_media_list.patch
@@ -81,10 +81,10 @@ index 33ca7a53dfb6d2c9e3a33f0065a3acd806e82e01..9fdf2e8ff0056ff407015b914c6b03eb
    const Source& GetSource(int index) const override;
    DesktopMediaList::Type GetMediaListType() const override;
 diff --git a/chrome/browser/media/webrtc/native_desktop_media_list.cc b/chrome/browser/media/webrtc/native_desktop_media_list.cc
-index b548c9fbd3c0bf425447b29dcd866cd27e96b14c..f994ac6086c7b4cd3e8534f34691189d78a21601 100644
+index b548c9fbd3c0bf425447b29dcd866cd27e96b14c..1e4c572deb0b20416f3fa65f7fe6d33612e3b691 100644
 --- a/chrome/browser/media/webrtc/native_desktop_media_list.cc
 +++ b/chrome/browser/media/webrtc/native_desktop_media_list.cc
-@@ -451,6 +451,9 @@ void NativeDesktopMediaList::Worker::RefreshNextThumbnail() {
+@@ -457,6 +457,9 @@ void NativeDesktopMediaList::Worker::RefreshNextThumbnail() {
        FROM_HERE,
        base::BindOnce(&NativeDesktopMediaList::UpdateNativeThumbnailsFinished,
                       media_list_));

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -152,8 +152,10 @@ struct Converter<electron::api::DesktopCapturer::Source> {
       v8::Isolate* isolate,
       const electron::api::DesktopCapturer::Source& source) {
     gin_helper::Dictionary dict = gin::Dictionary::CreateEmpty(isolate);
-    content::DesktopMediaID id = source.media_list_source.id;
     dict.Set("name", base::UTF16ToUTF8(source.media_list_source.name));
+    content::DesktopMediaID id = source.media_list_source.id;
+    if (id.window_id == id.id)
+      id.window_id = content::DesktopMediaID::kNullId;
     dict.Set("id", id.ToString());
     dict.Set("thumbnail",
              electron::api::NativeImage::Create(

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1240,18 +1240,8 @@ gfx::AcceleratedWidget NativeWindowMac::GetAcceleratedWidget() const {
 }
 
 content::DesktopMediaID NativeWindowMac::GetDesktopMediaID() const {
-  auto desktop_media_id = content::DesktopMediaID(
-      content::DesktopMediaID::TYPE_WINDOW, GetAcceleratedWidget());
-  // c.f.
-  // https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/media/webrtc/native_desktop_media_list.cc;l=775-780;drc=79502ab47f61bff351426f57f576daef02b1a8dc
-  // Refs https://github.com/electron/electron/pull/30507
-  // TODO(deepak1556): Match upstream for `kWindowCaptureMacV2`
-#if 0
-    if (remote_cocoa::ScopedCGWindowID::Get(desktop_media_id.id)) {
-      desktop_media_id.window_id = desktop_media_id.id;
-    }
-#endif
-  return desktop_media_id;
+  return content::DesktopMediaID(content::DesktopMediaID::TYPE_WINDOW,
+                                 GetAcceleratedWidget());
 }
 
 NativeWindowHandle NativeWindowMac::GetNativeWindowHandle() const {

--- a/spec/api-desktop-capturer-spec.ts
+++ b/spec/api-desktop-capturer-spec.ts
@@ -113,7 +113,12 @@ ifdescribe(!process.arch.includes('arm') && process.platform !== 'win32')('deskt
   });
 
   it('getSources should not incorrectly duplicate window_id', async () => {
-    const w = new BrowserWindow({ show: false, width: 100, height: 100, webPreferences: { contextIsolation: false } });
+    const w = new BrowserWindow({
+      show: false,
+      width: 100,
+      height: 100,
+      webPreferences: { contextIsolation: false }
+    });
     const wShown = once(w, 'show');
     const wFocused = once(w, 'focus');
     w.show();


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/30507.

Per upstream CRBUG:1179098, issues have been fixed and is no longer reproducible when testing with https://gist.github.com/925744c7c67347d67c5b29e91c31e37e . 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none