### PR TITLE
fix: resizing borders in nondraggable regions

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -24,6 +24,10 @@
 #include "ui/base/hit_test.h"
 #include "ui/views/widget/widget.h"
 
+#if !BUILDFLAG(IS_MAC)
+#include "shell/browser/ui/views/frameless_view.h"
+#endif
+
 #if BUILDFLAG(IS_WIN)
 #include "ui/base/win/shell.h"
 #include "ui/display/win/screen_win.h"
@@ -693,6 +697,17 @@ void NativeWindow::NotifyWindowMessage(UINT message,
 #endif
 
 int NativeWindow::NonClientHitTest(const gfx::Point& point) {
+#if !BUILDFLAG(IS_MAC)
+  // We need to ensure we account for resizing borders on Windows and Linux.
+  if ((!has_frame() || has_client_frame()) && IsResizable()) {
+    auto* frame =
+        static_cast<FramelessView*>(widget()->non_client_view()->frame_view());
+    int border_hit = frame->ResizingBorderHitTest(point);
+    if (border_hit != HTNOWHERE)
+      return border_hit;
+  }
+#endif
+
   for (auto* provider : draggable_region_providers_) {
     int hit = provider->NonClientHitTest(point);
     if (hit != HTNOWHERE)

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1592,19 +1592,7 @@ views::View* NativeWindowViews::GetContentsView() {
 bool NativeWindowViews::ShouldDescendIntoChildForEventHandling(
     gfx::NativeView child,
     const gfx::Point& location) {
-  // App window should claim mouse events that fall within any BrowserViews'
-  // draggable region.
-  if (NonClientHitTest(location) != HTNOWHERE)
-    return false;
-
-  // And the events on border for dragging resizable frameless window.
-  if ((!has_frame() || has_client_frame()) && resizable_) {
-    auto* frame =
-        static_cast<FramelessView*>(widget()->non_client_view()->frame_view());
-    return frame->ResizingBorderHitTest(location) == HTNOWHERE;
-  }
-
-  return true;
+  return NonClientHitTest(location) == HTNOWHERE;
 }
 
 views::ClientView* NativeWindowViews::CreateClientView(views::Widget* widget) {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/37008.
Refs https://github.com/electron/electron/pull/36230.

The above refactor improved draggable regions by typing them most closely to WebContents, but introduced an issue whereby draggable regions could take precedence over resizing borders on Windows. This was happening as a result of `NativeWindow::NonClientHitTest`, which returned the first non-HTNOWHERE value it found. This meant that the window's border coordinates would not take appropriate precedence, and instead of `HTBOTTOM`, `HTLEFT`, etc being returned for the window edge coordinates, `HTCAPTION` would instead be returned and the window bordered rendered useless. We fix this by first checking `ResizingBorderHitTest` results in `NativeWindow::NonClientHitTest` and proceeding to draggable region calculations if we are not on a resizing window border.

Tested with https://gist.github.com/takumus/9054bde77c8206143232fed2659bf108

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where some frameless windows with draggable regions were not resizable on Windows.