### PR TITLE
fix: nodeIntegrationInWorker fails to boot in AudioWorklets

### DIFF
--- a/lib/worker/init.ts
+++ b/lib/worker/init.ts
@@ -21,8 +21,9 @@ global.module = new Module('electron/js2c/worker_init');
 global.require = makeRequireFunction(global.module);
 
 // Set the __filename to the path of html file if it is file: protocol.
-if (self.location.protocol === 'file:') {
-  const pathname = process.platform === 'win32' && self.location.pathname[0] === '/' ? self.location.pathname.substr(1) : self.location.pathname;
+// NB. 'self' isn't defined in an AudioWorklet.
+if (typeof self !== 'undefined' && self.location.protocol === 'file:') {
+  const pathname = process.platform === 'win32' && self?.location.pathname[0] === '/' ? self?.location.pathname.substr(1) : self?.location.pathname;
   global.__filename = path.normalize(decodeURIComponent(pathname));
   global.__dirname = path.dirname(global.__filename);
 


### PR DESCRIPTION
#### Description of Change

When 'nodeIntegrationInWorker: true', worker_init is loaded in worker scopes.
That script assumed that `self` was always available, which isn't the case in
AudioWorkletGlobalScope.

Found while investigating https://github.com/electron/electron/issues/37038, but this does not address that issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed audio worklet scripts failing to run when `nodeIntegrationInWorker: true`.
