### PR TITLE
feat: activate Happy Eyeballs in NodeJS

### DIFF
--- a/spec/api-net-spec.ts
+++ b/spec/api-net-spec.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import * as dns from 'dns';
 import { net, session, ClientRequest, BrowserWindow, ClientRequestConstructorOptions } from 'electron/main';
 import * as http from 'http';
 import * as url from 'url';

--- a/spec/api-net-spec.ts
+++ b/spec/api-net-spec.ts
@@ -7,8 +7,7 @@ import { AddressInfo, Socket } from 'net';
 import { emittedOnce } from './lib/events-helpers';
 import { defer, delay } from './lib/spec-helpers';
 
-// See https://github.com/nodejs/node/issues/40702.
-dns.setDefaultResultOrder('ipv4first');
+net.setDefaultAutoSelectFamily(true);
 
 const kOneKiloByte = 1024;
 const kOneMegaByte = kOneKiloByte * kOneKiloByte;


### PR DESCRIPTION
Implements https://github.com/electron/electron/issues/37044
Fixes https://github.com/electron/electron/issues/31515
Updates https://github.com/electron/electron/commit/75d2caf451c925a826229ae27264c9b54de9b6db, https://github.com/electron/electron/pull/35999

#### Description of Change

Activates usage of the Happy Eyeballs algorithm according to RFC 8305 introduced in NodeJS v18.13. Solves connections problems in IPv4- and IPv6-only networks by creating alternating connection attempts to IPv4 and IPv6 addresses as returned by the DNS resolver.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [X] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: activates usage of the Happy Eyeballs algorithm according to RFC 8305 introduced in NodeJS v18.13.
