### PR TITLE
fix: crash on `WebWorkerObserver` script execution

### DIFF
--- a/shell/renderer/web_worker_observer.h
+++ b/shell/renderer/web_worker_observer.h
@@ -17,8 +17,13 @@ class NodeBindings;
 // Watches for WebWorker and insert node integration to it.
 class WebWorkerObserver {
  public:
+  WebWorkerObserver();
+  ~WebWorkerObserver();
+
   // Returns the WebWorkerObserver for current worker thread.
   static WebWorkerObserver* GetCurrent();
+  // Creates a new WebWorkerObserver for a given context.
+  static WebWorkerObserver* Create();
 
   // disable copy
   WebWorkerObserver(const WebWorkerObserver&) = delete;
@@ -28,9 +33,6 @@ class WebWorkerObserver {
   void ContextWillDestroy(v8::Local<v8::Context> context);
 
  private:
-  WebWorkerObserver();
-  ~WebWorkerObserver();
-
   std::unique_ptr<NodeBindings> node_bindings_;
   std::unique_ptr<ElectronBindings> electron_bindings_;
 };

--- a/spec/fixtures/crash-cases/worker-multiple-destroy/index.html
+++ b/spec/fixtures/crash-cases/worker-multiple-destroy/index.html
@@ -1,0 +1,22 @@
+<html>
+
+<body>
+  <style>
+    textarea {
+      background-image: url(checkerboard);
+      background-image: paint(checkerboard);
+    }
+
+    @supports (background: paint(id)) {
+      background-image: paint(checkerboard);
+    }
+  </style>
+  <textarea></textarea>
+  <script>
+    const addPaintWorklet = async () => {
+      await CSS.paintWorklet.addModule('worklet.js');
+    }
+  </script>
+</body>
+
+</html>

--- a/spec/fixtures/crash-cases/worker-multiple-destroy/index.js
+++ b/spec/fixtures/crash-cases/worker-multiple-destroy/index.js
@@ -1,0 +1,38 @@
+const { app, BrowserWindow } = require('electron');
+
+async function createWindow () {
+  const mainWindow = new BrowserWindow({
+    webPreferences: {
+      nodeIntegrationInWorker: true
+    }
+  });
+
+  let loads = 1;
+  mainWindow.webContents.on('did-finish-load', async () => {
+    if (loads === 2) {
+      process.exit(0);
+    } else {
+      loads++;
+      await mainWindow.webContents.executeJavaScript('addPaintWorklet()');
+      await mainWindow.webContents.executeJavaScript('location.reload()');
+    }
+  });
+
+  mainWindow.webContents.on('render-process-gone', () => {
+    process.exit(1);
+  });
+
+  await mainWindow.loadFile('index.html');
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/spec/fixtures/crash-cases/worker-multiple-destroy/worklet.js
+++ b/spec/fixtures/crash-cases/worker-multiple-destroy/worklet.js
@@ -1,0 +1,18 @@
+class CheckerboardPainter {
+  paint (ctx, geom, properties) {
+    const colors = ['red', 'green', 'blue'];
+    const size = 32;
+    for (let y = 0; y < (geom.height / size); y++) {
+      for (let x = 0; x < (geom.width / size); x++) {
+        const color = colors[(x + y) % colors.length];
+        ctx.beginPath();
+        ctx.fillStyle = color;
+        ctx.rect(x * size, y * size, size, size);
+        ctx.fill();
+      }
+    }
+  }
+}
+
+// eslint-disable-next-line no-undef
+registerPaint('checkerboard', CheckerboardPainter);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/37038.

It can be the case that `WorkerScriptReadyForEvaluationOnWorkerThread` is called multiple times on the same RendererClient, leading to a situation where `WorkerScriptReadyForEvaluation` is called again on a previously-created `WebWorkerObserver`, but a new context. When the context is finally destroyed and the observer cleaned up, we then see a crash when closing handles in the event loop. We can fix this by ensuring that each new call to `WorkerScriptReadyForEvaluationOnWorkerThread` creates a new observer. To my understanding, it _should_ be the case that there can be multiple Workers/Worklets per renderer process, so we shouldn't destroy previous ones before creating new ones.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash in some types of Worklets.
