### PR TITLE
ci: ensure correct ninja is used

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -486,7 +486,9 @@ step-fix-sync: &step-fix-sync
   run:
     name: Fix Sync
     command: |
+      SEDOPTION="-i"
       if [ "`uname`" == "Darwin" ]; then
+        SEDOPTION="-i ''"
         # Fix Clang Install (wrong binary)
         rm -rf src/third_party/llvm-build
         python3 src/tools/clang/scripts/update.py
@@ -496,12 +498,12 @@ step-fix-sync: &step-fix-sync
         # Remove extra output from calling gclient getdep which always calls update_depot_tools
         sed -i '' "s/Updating depot_tools... //g" esbuild_ensure_file
         cipd ensure --root src/third_party/devtools-frontend/src/third_party/esbuild -ensure-file esbuild_ensure_file
-
-        # Fix ninja (wrong binary)
-        echo 'infra/3pp/tools/ninja/${platform}' `gclient getdep --deps-file=src/DEPS -r 'src/third_party/ninja:infra/3pp/tools/ninja/${platform}'` > ninja_ensure_file
-        sed -i '' "s/Updating depot_tools... //g" ninja_ensure_file
-        cipd ensure --root src/third_party/ninja -ensure-file ninja_ensure_file
       fi
+
+      # Make sure we are using the right ninja
+      echo 'infra/3pp/tools/ninja/${platform}' `gclient getdep --deps-file=src/DEPS -r 'src/third_party/ninja:infra/3pp/tools/ninja/${platform}'` > ninja_ensure_file
+      sed $SEDOPTION "s/Updating depot_tools... //g" ninja_ensure_file
+      cipd ensure --root src/third_party/ninja -ensure-file ninja_ensure_file
 
       cd src/third_party/angle
       rm .git/objects/info/alternates

--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -51,6 +51,8 @@ environment:
 
 clone_folder: C:\projects\src\electron
 
+skip_branch_with_pr: true
+
 # the first failed job cancels other jobs and fails entire build
 matrix:
   fast_finish: true
@@ -130,6 +132,7 @@ for:
           }
       - if "%RUN_GCLIENT_SYNC%"=="true" ( gclient sync --with_branch_heads --with_tags ) else ( gclient runhooks )
       - cd src
+      - ps: $env:PATH="$pwd\third_party\ninja;$env:PATH"
       - set BUILD_CONFIG_PATH=//electron/build/args/%GN_CONFIG%.gn
       - gn gen out/Default "--args=import(\"%BUILD_CONFIG_PATH%\") import(\"%GN_GOMA_FILE%\") %GN_EXTRA_ARGS% "
       - gn check out/Default //electron:electron_lib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,6 +49,8 @@ environment:
 
 clone_folder: C:\projects\src\electron
 
+skip_branch_with_pr: true
+
 # the first failed job cancels other jobs and fails entire build
 matrix:
   fast_finish: true
@@ -128,6 +130,7 @@ for:
           }
       - if "%RUN_GCLIENT_SYNC%"=="true" ( gclient sync --with_branch_heads --with_tags ) else ( gclient runhooks )
       - cd src
+      - ps: $env:PATH="$pwd\third_party\ninja;$env:PATH"
       - set BUILD_CONFIG_PATH=//electron/build/args/%GN_CONFIG%.gn
       - gn gen out/Default "--args=import(\"%BUILD_CONFIG_PATH%\") import(\"%GN_GOMA_FILE%\") %GN_EXTRA_ARGS% "
       - gn check out/Default //electron:electron_lib


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Due to recent changes in depot_tools/ninja we need to explictly include ninja from src/third_party/ninja in the path.

Additionally this adds logic to our appveyor builds to ensure that multiple builds don't run per commit.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
