### PR TITLE
chore: validate `.mjs` spec files in Node.js smoke tests

### DIFF
--- a/script/node-spec-runner.js
+++ b/script/node-spec-runner.js
@@ -57,8 +57,9 @@ async function main () {
   if (args.validateDisabled) {
     const missing = [];
     for (const test of DISABLED_TESTS) {
-      const testName = test.endsWith('.js') ? test : `${test}.js`;
-      if (!fs.existsSync(path.join(NODE_DIR, 'test', testName))) {
+      const js = path.join(NODE_DIR, 'test', `${test}.js`);
+      const mjs = path.join(NODE_DIR, 'test', `${test}.mjs`);
+      if (!fs.existsSync(js) && !fs.existsSync(mjs)) {
         missing.push(test);
       }
     }


### PR DESCRIPTION
#### Description of Change

Fixes an issue where smoke test validation incorrectly ignored `.mjs` files.

Before:
```
electron on git:check-mjs-too ❯ node script/node-spec-runner.js --validateDisabled
Found 1 missing disabled specs:
parallel/test-fetch
electron on git:check-mjs-too ❯
```

After:

```
electron on git:check-mjs-too ❯ node script/node-spec-runner.js --validateDisabled
electron on git:check-mjs-too ❯
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none