### PR TITLE
chore: remove deprecated capturer count APIs

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1367,31 +1367,6 @@ If you would like the page to stay hidden, you should ensure that `stayHidden` i
 Returns `boolean` - Whether this page is being captured. It returns true when the capturer count
 is large then 0.
 
-#### `contents.incrementCapturerCount([size, stayHidden, stayAwake])` _Deprecated_
-
-* `size` [Size](structures/size.md) (optional) - The preferred size for the capturer.
-* `stayHidden` boolean (optional) -  Keep the page hidden instead of visible.
-* `stayAwake` boolean (optional) -  Keep the system awake instead of allowing it to sleep.
-
-Increase the capturer count by one. The page is considered visible when its browser window is
-hidden and the capturer count is non-zero. If you would like the page to stay hidden, you should ensure that `stayHidden` is set to true.
-
-This also affects the Page Visibility API.
-
-**Deprecated:** This API's functionality is now handled automatically within `contents.capturePage()`. See [breaking changes](../breaking-changes.md).
-
-#### `contents.decrementCapturerCount([stayHidden, stayAwake])` _Deprecated_
-
-* `stayHidden` boolean (optional) -  Keep the page in hidden state instead of visible.
-* `stayAwake` boolean (optional) -  Keep the system awake instead of allowing it to sleep.
-
-Decrease the capturer count by one. The page will be set to hidden or occluded state when its
-browser window is hidden or occluded and the capturer count reaches zero. If you want to
-decrease the hidden capturer count instead you should set `stayHidden` to true.
-
-**Deprecated:** This API's functionality is now handled automatically within `contents.capturePage()`.
-See [breaking changes](../breaking-changes.md).
-
 #### `contents.getPrinters()` _Deprecated_
 
 Get the system printer list.

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3237,47 +3237,6 @@ v8::Local<v8::Promise> WebContents::CapturePage(gin::Arguments* args) {
   return handle;
 }
 
-// TODO(codebytere): remove in Electron v23.
-void WebContents::IncrementCapturerCount(gin::Arguments* args) {
-  EmitWarning(node::Environment::GetCurrent(args->isolate()),
-              "webContents.incrementCapturerCount() is deprecated and will be "
-              "removed in v23",
-              "electron");
-
-  gfx::Size size;
-  bool stay_hidden = false;
-  bool stay_awake = false;
-
-  // get size arguments if they exist
-  args->GetNext(&size);
-  // get stayHidden arguments if they exist
-  args->GetNext(&stay_hidden);
-  // get stayAwake arguments if they exist
-  args->GetNext(&stay_awake);
-
-  std::ignore = web_contents()
-                    ->IncrementCapturerCount(size, stay_hidden, stay_awake)
-                    .Release();
-}
-
-// TODO(codebytere): remove in Electron v23.
-void WebContents::DecrementCapturerCount(gin::Arguments* args) {
-  EmitWarning(node::Environment::GetCurrent(args->isolate()),
-              "webContents.decrementCapturerCount() is deprecated and will be "
-              "removed in v23",
-              "electron");
-
-  bool stay_hidden = false;
-  bool stay_awake = false;
-
-  // get stayHidden arguments if they exist
-  args->GetNext(&stay_hidden);
-  // get stayAwake arguments if they exist
-  args->GetNext(&stay_awake);
-
-  web_contents()->DecrementCapturerCount(stay_hidden, stay_awake);
-}
-
 bool WebContents::IsBeingCaptured() {
   return web_contents()->IsBeingCaptured();
 }
@@ -4106,8 +4065,6 @@ v8::Local<v8::ObjectTemplate> WebContents::FillObjectTemplate(
       .SetMethod("setEmbedder", &WebContents::SetEmbedder)
       .SetMethod("setDevToolsWebContents", &WebContents::SetDevToolsWebContents)
       .SetMethod("getNativeView", &WebContents::GetNativeView)
-      .SetMethod("incrementCapturerCount", &WebContents::IncrementCapturerCount)
-      .SetMethod("decrementCapturerCount", &WebContents::DecrementCapturerCount)
       .SetMethod("isBeingCaptured", &WebContents::IsBeingCaptured)
       .SetMethod("setWebRTCIPHandlingPolicy",
                  &WebContents::SetWebRTCIPHandlingPolicy)

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -215,8 +215,6 @@ class WebContents : public ExclusiveAccessContext,
   void SetEmbedder(const WebContents* embedder);
   void SetDevToolsWebContents(const WebContents* devtools);
   v8::Local<v8::Value> GetNativeView(v8::Isolate* isolate) const;
-  void IncrementCapturerCount(gin::Arguments* args);
-  void DecrementCapturerCount(gin::Arguments* args);
   bool IsBeingCaptured();
   void HandleNewRenderFrame(content::RenderFrameHost* render_frame_host);
 

--- a/spec/api-browser-view-spec.ts
+++ b/spec/api-browser-view-spec.ts
@@ -398,28 +398,8 @@ describe('BrowserView module', () => {
       });
       await view.webContents.loadFile(path.join(fixtures, 'pages', 'a.html'));
 
-      view.webContents.incrementCapturerCount();
       const image = await view.webContents.capturePage();
       expect(image.isEmpty()).to.equal(false);
-    });
-
-    it('should increase the capturer count', () => {
-      view = new BrowserView({
-        webPreferences: {
-          backgroundThrottling: false
-        }
-      });
-      w.setBrowserView(view);
-      view.setBounds({
-        ...w.getBounds(),
-        x: 0,
-        y: 0
-      });
-
-      view.webContents.incrementCapturerCount();
-      expect(view.webContents.isBeingCaptured()).to.be.true();
-      view.webContents.decrementCapturerCount();
-      expect(view.webContents.isBeingCaptured()).to.be.false();
     });
   });
 });

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1789,7 +1789,6 @@ describe('BrowserWindow module', () => {
       w.loadFile(path.join(fixtures, 'pages', 'a.html'));
       await emittedOnce(w, 'ready-to-show');
 
-      w.webContents.incrementCapturerCount();
       const image = await w.capturePage();
       expect(image.isEmpty()).to.equal(false);
     });
@@ -1806,14 +1805,6 @@ describe('BrowserWindow module', () => {
       // Check the 25th byte in the PNG.
       // Values can be 0,2,3,4, or 6. We want 6, which is RGB + Alpha
       expect(imgBuffer[25]).to.equal(6);
-    });
-
-    it('should increase the capturer count', () => {
-      const w = new BrowserWindow({ show: false });
-      w.webContents.incrementCapturerCount();
-      expect(w.webContents.isBeingCaptured()).to.be.true();
-      w.webContents.decrementCapturerCount();
-      expect(w.webContents.isBeingCaptured()).to.be.false();
     });
   });
 


### PR DESCRIPTION
#### Description of Change
Follow-up to #35710. This is already documented:
- [Removed: webContents.incrementCapturerCount(stayHidden, stayAwake)](https://github.com/electron/electron/blob/main/docs/breaking-changes.md#removed-webcontentsincrementcapturercountstayhidden-stayawake)
- [Removed: webContents.decrementCapturerCount(stayHidden, stayAwake)](https://github.com/electron/electron/blob/main/docs/breaking-changes.md#removed-webcontentsdecrementcapturercountstayhidden-stayawake)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: The deprecated `incrementCapturerCount()` / `decrementCapturerCount()` methods have been removed.
