### PR TITLE
docs: use automatic link syntax for symbol server link

### DIFF
--- a/docs/development/debugging-with-symbol-server.md
+++ b/docs/development/debugging-with-symbol-server.md
@@ -15,7 +15,7 @@ calls, and other compiler optimizations. The only workaround is to build an
 unoptimized local build.
 
 The official symbol server URL for Electron is
-https://symbols.electronjs.org.
+<https://symbols.electronjs.org>.
 You cannot visit this URL directly, you must add it to the symbol path of your
 debugging tool. In the examples below, a local cache directory is used to avoid
 repeatedly fetching the PDB from the server. Replace `c:\code\symbols` with an


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

The docs website is including the trailing period in the link in the rendered HTML. Use the angle brackets automatic link syntax in Markdown to make it explicit what the link is.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
