### PR TITLE
build: remove `mips64el` build config

### DIFF
--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -12,7 +12,7 @@
 #  - "ELECTRON_RELEASE" Set it to '1' upload binaries on success.
 #  - "NPM_CONFIG_ARCH" E.g. 'x86'. Is used to build native Node.js modules.
 #      Must match 'target_cpu' passed to "GN_EXTRA_ARGS" and "TARGET_ARCH" value.
-#  - "TARGET_ARCH" Choose from {'ia32', 'x64', 'arm', 'arm64', 'mips64el'}.
+#  - "TARGET_ARCH" Choose from {'ia32', 'x64', 'arm', 'arm64'}.
 #      Is used in some publishing scripts, but does NOT affect the Electron binary.
 #      Must match 'target_cpu' passed to "GN_EXTRA_ARGS" and "NPM_CONFIG_ARCH" value.
 #  - "UPLOAD_TO_STORAGE" Set it to '1' upload a release to the Azure bucket.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@
 #  - "ELECTRON_RELEASE" Set it to '1' upload binaries on success.
 #  - "NPM_CONFIG_ARCH" E.g. 'x86'. Is used to build native Node.js modules.
 #      Must match 'target_cpu' passed to "GN_EXTRA_ARGS" and "TARGET_ARCH" value.
-#  - "TARGET_ARCH" Choose from {'ia32', 'x64', 'arm', 'arm64', 'mips64el'}.
+#  - "TARGET_ARCH" Choose from {'ia32', 'x64', 'arm', 'arm64'}.
 #      Is used in some publishing scripts, but does NOT affect the Electron binary.
 #      Must match 'target_cpu' passed to "GN_EXTRA_ARGS" and "NPM_CONFIG_ARCH" value.
 #  - "UPLOAD_TO_STORAGE" Set it to '1' upload a release to the Azure bucket.

--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -75,10 +75,6 @@ def main():
   electron_zip = os.path.join(OUT_DIR, DIST_NAME)
   shutil.copy2(os.path.join(OUT_DIR, 'dist.zip'), electron_zip)
   upload_electron(release, electron_zip, args)
-  if get_target_arch() != 'mips64el':
-    symbols_zip = os.path.join(OUT_DIR, SYMBOLS_NAME)
-    shutil.copy2(os.path.join(OUT_DIR, 'symbols.zip'), symbols_zip)
-    upload_electron(release, symbols_zip, args)
   if PLATFORM == 'darwin':
     if get_platform_key() == 'darwin' and get_target_arch() == 'x64':
       api_path = os.path.join(ELECTRON_DIR, 'electron-api.json')

--- a/script/strip-binaries.py
+++ b/script/strip-binaries.py
@@ -18,8 +18,6 @@ def strip_binary(binary_path, target_cpu):
     strip = 'arm-linux-gnueabihf-strip'
   elif target_cpu == 'arm64':
     strip = 'aarch64-linux-gnu-strip'
-  elif target_cpu == 'mips64el':
-    strip = 'mips64el-redhat-linux-strip'
   else:
     strip = 'strip'
   execute([

--- a/script/zip-symbols.py
+++ b/script/zip-symbols.py
@@ -16,8 +16,6 @@ OUT_DIR = get_out_dir()
 
 def main():
   print('Zipping Symbols')
-  if get_target_arch() == 'mips64el':
-    return
 
   args = parse_args()
   dist_name = 'symbols.zip'


### PR DESCRIPTION
#### Description of Change

To my knowledge we don't build it and it hasn't worked in years.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
