### PR TITLE
docs: remove invalid appcache value from storages in clearStorageData()

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -561,7 +561,7 @@ Clears the session’s HTTP cache.
   * `origin` string (optional) - Should follow `window.location.origin`’s representation
     `scheme://host:port`.
   * `storages` string[] (optional) - The types of storages to clear, can contain:
-    `appcache`, `cookies`, `filesystem`, `indexdb`, `localstorage`,
+    `cookies`, `filesystem`, `indexdb`, `localstorage`,
     `shadercache`, `websql`, `serviceworkers`, `cachestorage`. If not
     specified, clear all storage types.
   * `quotas` string[] (optional) - The types of quotas to clear, can contain:


### PR DESCRIPTION
#### Description of Change
It was removed in https://github.com/electron/electron/commit/bd10b19b0cdc46cdbadb570af89305e64541b679#diff-f8e925ef3d92ba436cccb0dde7392b784e2f5ecdee8a0156f68c4017e733eb39

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes
Notes: Remove `appcache` storage type from `session.clearStorageData` supported storages.
