### PR TITLE
chore: script to find references to files in the docs

### DIFF
--- a/script/find-docs-references.ts
+++ b/script/find-docs-references.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env ts-node
+
+import * as path from 'path';
+
+import {
+  createLanguageService,
+  ILogger
+} from '@dsanders11/vscode-markdown-languageservice';
+import { CancellationTokenSource } from 'vscode-languageserver';
+import { URI } from 'vscode-uri';
+
+import { DocsWorkspace, MarkdownParser } from './lib/markdown';
+
+class NoOpLogger implements ILogger {
+  log (): void {}
+}
+
+async function main () {
+  if (process.argv.slice(2).length !== 1) {
+    console.log('Usage: script/find-docs-references.ts [file]');
+    process.exit(0);
+  }
+
+  const workspace = new DocsWorkspace(path.resolve(__dirname, '..', 'docs'));
+  const parser = new MarkdownParser();
+  const languageService = createLanguageService({
+    workspace,
+    parser,
+    logger: new NoOpLogger()
+  });
+
+  const uri = URI.file(path.resolve(process.argv[2]));
+
+  if (!workspace.hasMarkdownDocument(uri)) {
+    console.log(`Error: could not open file '${uri.path}'`);
+    process.exit(1);
+  }
+
+  const cts = new CancellationTokenSource();
+
+  try {
+    const references = await languageService.getFileReferences(uri, cts.token);
+    console.log(JSON.stringify(references, null, 4));
+  } finally {
+    cts.dispose();
+  }
+}
+
+if (process.mainModule === module) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

This is effectively "Find All References" from VS Code, in script form (it's leveraging the same code). I think it's a useful future tool when doing docs changes to ensure references aren't missed, and it could serve as a building block for further tooling.

```sh
$ ./script/find-docs-references.ts docs/api/protocol.md 
[
    {
        "uri": "file:///Users/dsanders/electron/src/electron/docs/README.md",
        "range": {
            "start": {
                "line": 127,
                "character": 13
            },
            "end": {
                "line": 127,
                "character": 28
            }
        }
    },
    {
        "uri": "file:///Users/dsanders/electron/src/electron/docs/api/session.md",
        "range": {
            "start": {
                "line": 1364,
                "character": 15
            },
            "end": {
                "line": 1364,
                "character": 26
            }
        }
    }
]
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
