### PR TITLE
docs: improve globalShortcut and hookWindowMessage types

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1402,8 +1402,8 @@ The native type of the handle is `HWND` on Windows, `NSView*` on macOS, and
 
 * `message` Integer
 * `callback` Function
-  * `wParam` any - The `wParam` provided to the WndProc
-  * `lParam` any - The `lParam` provided to the WndProc
+  * `wParam` Buffer - The `wParam` provided to the WndProc
+  * `lParam` Buffer - The `lParam` provided to the WndProc
 
 Hooks a windows message. The `callback` is called when
 the message is received in the WndProc.

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -66,7 +66,7 @@ the app has been authorized as a [trusted accessibility client](https://develope
 
 ### `globalShortcut.registerAll(accelerators, callback)`
 
-* `accelerators` string[] - an array of [Accelerator](accelerator.md)s.
+* `accelerators` [Accelerator](accelerator.md)[] - an array of [Accelerator](accelerator.md)s.
 * `callback` Function
 
 Registers a global shortcut of all `accelerator` items in `accelerators`. The `callback` is called when any of the registered shortcuts are pressed by the user.


### PR DESCRIPTION
Just some narrowing I noticed could be done in passing

Notes: no-notes