### PR TITLE
build: actually upload symbol zips

### DIFF
--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -75,6 +75,11 @@ def main():
   electron_zip = os.path.join(OUT_DIR, DIST_NAME)
   shutil.copy2(os.path.join(OUT_DIR, 'dist.zip'), electron_zip)
   upload_electron(release, electron_zip, args)
+
+  symbols_zip = os.path.join(OUT_DIR, SYMBOLS_NAME)
+  shutil.copy2(os.path.join(OUT_DIR, 'symbols.zip'), symbols_zip)
+  upload_electron(release, symbols_zip, args)
+
   if PLATFORM == 'darwin':
     if get_platform_key() == 'darwin' and get_target_arch() == 'x64':
       api_path = os.path.join(ELECTRON_DIR, 'electron-api.json')


### PR DESCRIPTION
Fixes issue caused by #37093 where we stopped uploading symbols

Notes: no-notes