### PR TITLE
feat: add logUsage to shell.openExternal() options

### DIFF
--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -40,6 +40,8 @@ Open the given file in the desktop's default manner.
 * `options` Object (optional)
   * `activate` boolean (optional) _macOS_ - `true` to bring the opened application to the foreground. The default is `true`.
   * `workingDirectory` string (optional) _Windows_ - The working directory.
+  * `logUsage` boolean (optional) _Windows_ - Indicates a user initiated launch that enables tracking of frequently used programs and other behaviors.
+                                              The default is `false`.
 
 Returns `Promise<void>`
 

--- a/shell/common/api/electron_api_shell.cc
+++ b/shell/common/api/electron_api_shell.cc
@@ -64,6 +64,7 @@ v8::Local<v8::Promise> OpenExternal(const GURL& url, gin::Arguments* args) {
     if (args->GetNext(&obj)) {
       obj.Get("activate", &options.activate);
       obj.Get("workingDirectory", &options.working_dir);
+      obj.Get("logUsage", &options.log_usage);
     }
   }
 

--- a/shell/common/platform_util.h
+++ b/shell/common/platform_util.h
@@ -28,6 +28,7 @@ void OpenPath(const base::FilePath& full_path, OpenCallback callback);
 struct OpenExternalOptions {
   bool activate = true;
   base::FilePath working_dir;
+  bool log_usage = false;
 };
 
 // Open the given external protocol URL in the desktop's default manner.


### PR DESCRIPTION
#### Description of Change
Allow passing the `SEE_MASK_FLAG_LOG_USAGE` flag to `ShellExecuteEx` on Windows.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: Added `logUsage` to `shell.openExternal()` options, which allows passing the `SEE_MASK_FLAG_LOG_USAGE` flag to `ShellExecuteEx` on Windows.