### PR TITLE
docs: remove reference to electron/releases

### DIFF
--- a/docs/tutorial/tutorial-1-prerequisites.md
+++ b/docs/tutorial/tutorial-1-prerequisites.md
@@ -121,14 +121,13 @@ need to install Node.js themselves as a prerequisite to running your app.
 
 To check which version of Node.js is running in your app, you can access the global
 [`process.versions`][] variable in the main process or preload script. You can also reference
-the list of versions in the [electron/releases][] repository.
+<https://releases.electronjs.org/releases.json>.
 
 :::
 
 <!-- Links -->
 
 [chromium]: https://www.chromium.org/
-[electron/releases]: https://github.com/electron/releases/blob/master/readme.md#releases
 [homebrew]: https://brew.sh/
 [mdn-guide]: https://developer.mozilla.org/en-US/docs/Learn/
 [node]: https://nodejs.org/


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

`electron/releases` has been deprecated, so point folks at `releases.json`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
