### PR TITLE
chore: cherry-pick e545559df538 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -160,3 +160,4 @@ cherry-pick-819d876e1bb8.patch
 cherry-pick-43637378b14e.patch
 win_fix_touch_mode_detection_dcheck_in_canary.patch
 cherry-pick-ca2b108a0f1f.patch
+cherry-pick-e545559df538.patch

--- a/patches/chromium/cherry-pick-e545559df538.patch
+++ b/patches/chromium/cherry-pick-e545559df538.patch
@@ -1,7 +1,7 @@
-From e545559df5387c7cc1e13c4070153d1d402ccc66 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Victor Vasiliev <vasilvv@chromium.org>
 Date: Thu, 12 Jan 2023 22:03:48 +0000
-Subject: [PATCH] Ensure clean destruction of network::WebTransport
+Subject: Ensure clean destruction of network::WebTransport
 
 Once the destruction of the object begins, we should not process any
 callbacks, nor should we attempt to reset the streams on a connection
@@ -19,13 +19,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4139783
 Reviewed-by: Kenichi Ishibashi <bashi@chromium.org>
 Cr-Commit-Position: refs/branch-heads/5359@{#1326}
 Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}
----
 
 diff --git a/services/network/web_transport.cc b/services/network/web_transport.cc
-index 8ddbeb94..cd92d0f 100644
+index fd62b83d43052d9d588a211b59e46a6c25ffeb76..534954181abcd7c4cf11eade64a2aa97c62785cc 100644
 --- a/services/network/web_transport.cc
 +++ b/services/network/web_transport.cc
-@@ -177,7 +177,7 @@
+@@ -177,7 +177,7 @@ class WebTransport::Stream final {
  
    ~Stream() {
      auto* stream = incoming_ ? incoming_.get() : outgoing_.get();
@@ -34,7 +33,7 @@ index 8ddbeb94..cd92d0f 100644
        return;
      }
      stream->MaybeResetDueToStreamObjectGone();
-@@ -399,7 +399,10 @@
+@@ -399,7 +399,10 @@ WebTransport::WebTransport(
    transport_->Connect();
  }
  
@@ -47,10 +46,10 @@ index 8ddbeb94..cd92d0f 100644
  void WebTransport::SendDatagram(base::span<const uint8_t> data,
                                  base::OnceCallback<void(bool)> callback) {
 diff --git a/services/network/web_transport_unittest.cc b/services/network/web_transport_unittest.cc
-index 81bf26f..1a9e6bc 100644
+index ffac5c19f9d154b91eb6aeac1e19a62277e4e7e8..46deb561091232fe64950be01e9157c8d891f111 100644
 --- a/services/network/web_transport_unittest.cc
 +++ b/services/network/web_transport_unittest.cc
-@@ -610,6 +610,51 @@
+@@ -611,6 +611,51 @@ TEST_F(WebTransportTest, EchoOnUnidirectionalStreams) {
    EXPECT_EQ(0u, resets_sent.size());
  }
  

--- a/patches/chromium/cherry-pick-e545559df538.patch
+++ b/patches/chromium/cherry-pick-e545559df538.patch
@@ -1,0 +1,104 @@
+From e545559df5387c7cc1e13c4070153d1d402ccc66 Mon Sep 17 00:00:00 2001
+From: Victor Vasiliev <vasilvv@chromium.org>
+Date: Thu, 12 Jan 2023 22:03:48 +0000
+Subject: [PATCH] Ensure clean destruction of network::WebTransport
+
+Once the destruction of the object begins, we should not process any
+callbacks, nor should we attempt to reset the streams on a connection
+that is already being closed.
+
+(cherry picked from commit 57c54ae221d60e9f9394d7ee69634d66c9cd26f3)
+
+Bug: 1376354
+Change-Id: Ib49e0ce0b177062cccd0e52368782e291cf8166c
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4117501
+Reviewed-by: Eric Orth <ericorth@chromium.org>
+Commit-Queue: Victor Vasiliev <vasilvv@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1085965}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4139783
+Reviewed-by: Kenichi Ishibashi <bashi@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5359@{#1326}
+Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}
+---
+
+diff --git a/services/network/web_transport.cc b/services/network/web_transport.cc
+index 8ddbeb94..cd92d0f 100644
+--- a/services/network/web_transport.cc
++++ b/services/network/web_transport.cc
+@@ -177,7 +177,7 @@
+ 
+   ~Stream() {
+     auto* stream = incoming_ ? incoming_.get() : outgoing_.get();
+-    if (!stream) {
++    if (!stream || transport_->closing_ || transport_->torn_down_) {
+       return;
+     }
+     stream->MaybeResetDueToStreamObjectGone();
+@@ -399,7 +399,10 @@
+   transport_->Connect();
+ }
+ 
+-WebTransport::~WebTransport() = default;
++WebTransport::~WebTransport() {
++  // Ensure that we ignore all callbacks while mid-destruction.
++  torn_down_ = true;
++}
+ 
+ void WebTransport::SendDatagram(base::span<const uint8_t> data,
+                                 base::OnceCallback<void(bool)> callback) {
+diff --git a/services/network/web_transport_unittest.cc b/services/network/web_transport_unittest.cc
+index 81bf26f..1a9e6bc 100644
+--- a/services/network/web_transport_unittest.cc
++++ b/services/network/web_transport_unittest.cc
+@@ -610,6 +610,51 @@
+   EXPECT_EQ(0u, resets_sent.size());
+ }
+ 
++TEST_F(WebTransportTest, DeleteClientWithStreamsOpen) {
++  base::RunLoop run_loop_for_handshake;
++  mojo::PendingRemote<mojom::WebTransportHandshakeClient> handshake_client;
++  TestHandshakeClient test_handshake_client(
++      handshake_client.InitWithNewPipeAndPassReceiver(),
++      run_loop_for_handshake.QuitClosure());
++
++  CreateWebTransport(GetURL("/echo"),
++                     url::Origin::Create(GURL("https://example.org/")),
++                     std::move(handshake_client));
++
++  run_loop_for_handshake.Run();
++
++  ASSERT_TRUE(test_handshake_client.has_seen_connection_establishment());
++
++  TestClient client(test_handshake_client.PassClientReceiver());
++  mojo::Remote<mojom::WebTransport> transport_remote(
++      test_handshake_client.PassTransport());
++
++  constexpr int kNumStreams = 10;
++  auto writable_for_outgoing =
++      std::make_unique<mojo::ScopedDataPipeProducerHandle[]>(kNumStreams);
++  for (int i = 0; i < kNumStreams; i++) {
++    const MojoCreateDataPipeOptions options = {
++        sizeof(options), MOJO_CREATE_DATA_PIPE_FLAG_NONE, 1, 4 * 1024};
++    mojo::ScopedDataPipeConsumerHandle readable_for_outgoing;
++    ASSERT_EQ(MOJO_RESULT_OK,
++              mojo::CreateDataPipe(&options, writable_for_outgoing[i],
++                                   readable_for_outgoing));
++    base::RunLoop run_loop_for_stream_creation;
++    bool stream_created;
++    transport_remote->CreateStream(
++        std::move(readable_for_outgoing),
++        /*writable=*/{},
++        base::BindLambdaForTesting([&](bool b, uint32_t /*id*/) {
++          stream_created = b;
++          run_loop_for_stream_creation.Quit();
++        }));
++    run_loop_for_stream_creation.Run();
++    ASSERT_TRUE(stream_created);
++  }
++
++  // Keep the streams open so that they are closed via destructor.
++}
++
+ // crbug.com/1129847: disabled because it is flaky.
+ TEST_F(WebTransportTest, DISABLED_EchoOnBidirectionalStream) {
+   base::RunLoop run_loop_for_handshake;


### PR DESCRIPTION
Ensure clean destruction of network::WebTransport

Once the destruction of the object begins, we should not process any
callbacks, nor should we attempt to reset the streams on a connection
that is already being closed.

(cherry picked from commit 57c54ae221d60e9f9394d7ee69634d66c9cd26f3)

Bug: 1376354
Change-Id: Ib49e0ce0b177062cccd0e52368782e291cf8166c
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4117501
Reviewed-by: Eric Orth <ericorth@chromium.org>
Commit-Queue: Victor Vasiliev <vasilvv@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1085965}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4139783
Reviewed-by: Kenichi Ishibashi <bashi@chromium.org>
Cr-Commit-Position: refs/branch-heads/5359@{#1326}
Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}

Ref https://github.com/electron/security/issues/269

Notes: Security: backported fix for 1376354.