### PR TITLE
chore: remove load-url event

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -465,7 +465,6 @@ WebContents.prototype.loadURL = function (url, options) {
   // Add a no-op rejection handler to silence the unhandled rejection error.
   p.catch(() => {});
   this._loadURL(url, options);
-  this.emit('load-url', url, options);
   return p;
 };
 


### PR DESCRIPTION
This event is undocumented and unused since 77297f37a3df4e430e2627accdaa1c9235684a08. It was added at the dawn of time but was never documented.

Notes: none