### PR TITLE
fix: type for received-apns-notification event

### DIFF
--- a/docs/api/push-notifications.md
+++ b/docs/api/push-notifications.md
@@ -26,6 +26,7 @@ The `pushNotification` module emits the following events:
 
 Returns:
 
+* `event` Event
 * `userInfo` Record<String, any>
 
 Emitted when the app receives a remote notification while running.


### PR DESCRIPTION
#### Description of Change

The types were incorrect in the initial commit; they excluded the initial `event` argument.

Notes: none