### PR TITLE
test: ensure fullscreen test is retryable

### DIFF
--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -2270,17 +2270,19 @@ describe('iframe using HTML fullscreen API while window is OS-fullscreened', () 
   );
   let w: BrowserWindow, server: http.Server;
 
-  before(() => {
+  beforeEach(async () => {
     server = http.createServer(async (_req, res) => {
       res.writeHead(200, { 'Content-Type': 'text/html' });
       res.write(await fullscreenChildHtml);
       res.end();
     });
 
-    server.listen(8989, '127.0.0.1');
-  });
+    await new Promise<void>((resolve) => {
+      server.listen(8989, '127.0.0.1', () => {
+        resolve();
+      });
+    });
 
-  beforeEach(() => {
     w = new BrowserWindow({
       show: true,
       fullscreen: true,


### PR DESCRIPTION
With retries in mocha only the `beforeEach` is re-run, we were shutting down the localhost server in an `afterEach` but setting it up in a `before`.  This moves the logic to a `beforeEach` and avoids a race condition where the server isn't listening when the test runs.

Notes: no-notes