### PR TITLE
chore: rename built-in modules to bindings to match naming update in node

### DIFF
--- a/docs/development/creating-api.md
+++ b/docs/development/creating-api.md
@@ -138,7 +138,7 @@ interface Process {
 At the very bottom of your `api_name.cc` file:
 
 ```cpp title='api_name.cc'
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_{api_name},Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_{api_name},Initialize)
 ```
 
 In your [`shell/common/node_bindings.cc`](https://github.com/electron/electron/blob/main/shell/common/node_bindings.cc) file, add your node binding name to Electron's built-in modules.

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -146,8 +146,8 @@ int NodeMain(int argc, char* argv[]) {
     feature_list->InitializeFromCommandLine("", "");
     base::FeatureList::SetInstance(std::move(feature_list));
 
-    // Explicitly register electron's builtin modules.
-    NodeBindings::RegisterBuiltinModules();
+    // Explicitly register electron's builtin bindings.
+    NodeBindings::RegisterBuiltinBindings();
 
     // Parse and set Node.js cli flags.
     int flags_exit_code = SetNodeCliFlags();

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1865,4 +1865,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_app, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_app, Initialize)

--- a/shell/browser/api/electron_api_auto_updater.cc
+++ b/shell/browser/api/electron_api_auto_updater.cc
@@ -149,4 +149,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_auto_updater, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_auto_updater, Initialize)

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -1359,4 +1359,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_base_window, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_base_window, Initialize)

--- a/shell/browser/api/electron_api_browser_view.cc
+++ b/shell/browser/api/electron_api_browser_view.cc
@@ -221,4 +221,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_browser_view, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_browser_view, Initialize)

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -488,4 +488,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_window, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_window, Initialize)

--- a/shell/browser/api/electron_api_content_tracing.cc
+++ b/shell/browser/api/electron_api_content_tracing.cc
@@ -178,4 +178,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_content_tracing, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_content_tracing, Initialize)

--- a/shell/browser/api/electron_api_crash_reporter.cc
+++ b/shell/browser/api/electron_api_crash_reporter.cc
@@ -279,4 +279,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_crash_reporter, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_crash_reporter, Initialize)

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -356,4 +356,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_desktop_capturer, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_desktop_capturer, Initialize)

--- a/shell/browser/api/electron_api_dialog.cc
+++ b/shell/browser/api/electron_api_dialog.cc
@@ -105,4 +105,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_dialog, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_dialog, Initialize)

--- a/shell/browser/api/electron_api_event.cc
+++ b/shell/browser/api/electron_api_event.cc
@@ -25,4 +25,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_event, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_event, Initialize)

--- a/shell/browser/api/electron_api_event_emitter.cc
+++ b/shell/browser/api/electron_api_event_emitter.cc
@@ -46,4 +46,4 @@ v8::Local<v8::Object> GetEventEmitterPrototype(v8::Isolate* isolate) {
 
 }  // namespace electron
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_event_emitter, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_event_emitter, Initialize)

--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -195,4 +195,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_global_shortcut, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_global_shortcut, Initialize)

--- a/shell/browser/api/electron_api_in_app_purchase.cc
+++ b/shell/browser/api/electron_api_in_app_purchase.cc
@@ -230,4 +230,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_in_app_purchase, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_in_app_purchase, Initialize)

--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -321,4 +321,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_menu, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_menu, Initialize)

--- a/shell/browser/api/electron_api_native_theme.cc
+++ b/shell/browser/api/electron_api_native_theme.cc
@@ -170,4 +170,4 @@ bool Converter<ui::NativeTheme::ThemeSource>::FromV8(
 
 }  // namespace gin
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_native_theme, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_native_theme, Initialize)

--- a/shell/browser/api/electron_api_net.cc
+++ b/shell/browser/api/electron_api_net.cc
@@ -58,4 +58,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_net, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_net, Initialize)

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -299,4 +299,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_notification, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_notification, Initialize)

--- a/shell/browser/api/electron_api_power_monitor.cc
+++ b/shell/browser/api/electron_api_power_monitor.cc
@@ -154,4 +154,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_power_monitor, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_power_monitor, Initialize)

--- a/shell/browser/api/electron_api_power_save_blocker.cc
+++ b/shell/browser/api/electron_api_power_save_blocker.cc
@@ -139,5 +139,5 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_power_save_blocker,
-                                 Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_power_save_blocker,
+                                  Initialize)

--- a/shell/browser/api/electron_api_printing.cc
+++ b/shell/browser/api/electron_api_printing.cc
@@ -111,4 +111,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_printing, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_printing, Initialize)

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -339,4 +339,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_protocol, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_protocol, Initialize)

--- a/shell/browser/api/electron_api_push_notifications.cc
+++ b/shell/browser/api/electron_api_push_notifications.cc
@@ -73,5 +73,5 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_push_notifications,
-                                 Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_push_notifications,
+                                  Initialize)

--- a/shell/browser/api/electron_api_safe_storage.cc
+++ b/shell/browser/api/electron_api_safe_storage.cc
@@ -131,4 +131,4 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("decryptString", &electron::safestorage::DecryptString);
 }
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_safe_storage, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_safe_storage, Initialize)

--- a/shell/browser/api/electron_api_screen.cc
+++ b/shell/browser/api/electron_api_screen.cc
@@ -196,4 +196,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_screen, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_screen, Initialize)

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -1313,4 +1313,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_session, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_session, Initialize)

--- a/shell/browser/api/electron_api_system_preferences.cc
+++ b/shell/browser/api/electron_api_system_preferences.cc
@@ -132,5 +132,5 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_system_preferences,
-                                 Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_system_preferences,
+                                  Initialize)

--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -436,4 +436,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_tray, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_tray, Initialize)

--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -417,4 +417,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_utility_process, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_utility_process, Initialize)

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -76,4 +76,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_view, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_view, Initialize)

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -4244,4 +4244,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_web_contents, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_web_contents, Initialize)

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -131,4 +131,5 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_web_contents_view, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_web_contents_view,
+                                  Initialize)

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -459,4 +459,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_web_frame_main, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_web_frame_main, Initialize)

--- a/shell/browser/api/electron_api_web_view_manager.cc
+++ b/shell/browser/api/electron_api_web_view_manager.cc
@@ -47,4 +47,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_web_view_manager, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_web_view_manager, Initialize)

--- a/shell/browser/api/message_port.cc
+++ b/shell/browser/api/message_port.cc
@@ -293,4 +293,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_message_port, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_message_port, Initialize)

--- a/shell/browser/api/views/electron_api_image_view.cc
+++ b/shell/browser/api/views/electron_api_image_view.cc
@@ -56,4 +56,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_image_view, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_image_view, Initialize)

--- a/shell/common/api/crashpad_support.cc
+++ b/shell/common/api/crashpad_support.cc
@@ -36,4 +36,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_common_crashpad_support, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_common_crashpad_support, Initialize)

--- a/shell/common/api/electron_api_asar.cc
+++ b/shell/common/api/electron_api_asar.cc
@@ -246,4 +246,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_common_asar, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_common_asar, Initialize)

--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -291,4 +291,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_common_clipboard, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_common_clipboard, Initialize)

--- a/shell/common/api/electron_api_command_line.cc
+++ b/shell/common/api/electron_api_command_line.cc
@@ -67,4 +67,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_common_command_line, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_common_command_line, Initialize)

--- a/shell/common/api/electron_api_environment.cc
+++ b/shell/common/api/electron_api_environment.cc
@@ -42,4 +42,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_common_environment, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_common_environment, Initialize)

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -641,4 +641,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_common_native_image, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_common_native_image, Initialize)

--- a/shell/common/api/electron_api_shell.cc
+++ b/shell/common/api/electron_api_shell.cc
@@ -186,4 +186,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_common_shell, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_common_shell, Initialize)

--- a/shell/common/api/electron_api_testing.cc
+++ b/shell/common/api/electron_api_testing.cc
@@ -44,5 +44,5 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_common_testing, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_common_testing, Initialize)
 #endif

--- a/shell/common/api/electron_api_v8_util.cc
+++ b/shell/common/api/electron_api_v8_util.cc
@@ -138,4 +138,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_common_v8_util, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_common_v8_util, Initialize)

--- a/shell/common/api/features.cc
+++ b/shell/common/api/features.cc
@@ -84,4 +84,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_common_features, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_common_features, Initialize)

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -43,7 +43,7 @@
 #include "shell/common/crash_keys.h"
 #endif
 
-#define ELECTRON_BROWSER_MODULES(V)      \
+#define ELECTRON_BROWSER_BINDINGS(V)     \
   V(electron_browser_app)                \
   V(electron_browser_auto_updater)       \
   V(electron_browser_browser_view)       \
@@ -78,7 +78,7 @@
   V(electron_browser_web_view_manager)   \
   V(electron_browser_window)
 
-#define ELECTRON_COMMON_MODULES(V)    \
+#define ELECTRON_COMMON_BINDINGS(V)   \
   V(electron_common_asar)             \
   V(electron_common_clipboard)        \
   V(electron_common_command_line)     \
@@ -89,38 +89,39 @@
   V(electron_common_shell)            \
   V(electron_common_v8_util)
 
-#define ELECTRON_RENDERER_MODULES(V)  \
+#define ELECTRON_RENDERER_BINDINGS(V) \
   V(electron_renderer_context_bridge) \
   V(electron_renderer_crash_reporter) \
   V(electron_renderer_ipc)            \
   V(electron_renderer_web_frame)
 
-#define ELECTRON_UTILITY_MODULES(V) V(electron_utility_parent_port)
+#define ELECTRON_UTILITY_BINDINGS(V) V(electron_utility_parent_port)
 
-#define ELECTRON_VIEWS_MODULES(V) V(electron_browser_image_view)
+#define ELECTRON_VIEWS_BINDINGS(V) V(electron_browser_image_view)
 
-#define ELECTRON_DESKTOP_CAPTURER_MODULE(V) V(electron_browser_desktop_capturer)
+#define ELECTRON_DESKTOP_CAPTURER_BINDINGS(V) \
+  V(electron_browser_desktop_capturer)
 
-#define ELECTRON_TESTING_MODULE(V) V(electron_common_testing)
+#define ELECTRON_TESTING_BINDINGS(V) V(electron_common_testing)
 
-// This is used to load built-in modules. Instead of using
+// This is used to load built-in bindings. Instead of using
 // __attribute__((constructor)), we call the _register_<modname>
-// function for each built-in modules explicitly. This is only
-// forward declaration. The definitions are in each module's
-// implementation when calling the NODE_LINKED_MODULE_CONTEXT_AWARE.
+// function for each built-in bindings explicitly. This is only
+// forward declaration. The definitions are in each binding's
+// implementation when calling the NODE_LINKED_BINDING_CONTEXT_AWARE.
 #define V(modname) void _register_##modname();
-ELECTRON_BROWSER_MODULES(V)
-ELECTRON_COMMON_MODULES(V)
-ELECTRON_RENDERER_MODULES(V)
-ELECTRON_UTILITY_MODULES(V)
+ELECTRON_BROWSER_BINDINGS(V)
+ELECTRON_COMMON_BINDINGS(V)
+ELECTRON_RENDERER_BINDINGS(V)
+ELECTRON_UTILITY_BINDINGS(V)
 #if BUILDFLAG(ENABLE_VIEWS_API)
-ELECTRON_VIEWS_MODULES(V)
+ELECTRON_VIEWS_BINDINGS(V)
 #endif
 #if BUILDFLAG(ENABLE_DESKTOP_CAPTURER)
-ELECTRON_DESKTOP_CAPTURER_MODULE(V)
+ELECTRON_DESKTOP_CAPTURER_BINDINGS(V)
 #endif
 #if DCHECK_IS_ON()
-ELECTRON_TESTING_MODULE(V)
+ELECTRON_TESTING_BINDINGS(V)
 #endif
 #undef V
 
@@ -336,29 +337,29 @@ NodeBindings::~NodeBindings() {
     stop_and_close_uv_loop(uv_loop_);
 }
 
-void NodeBindings::RegisterBuiltinModules() {
+void NodeBindings::RegisterBuiltinBindings() {
 #define V(modname) _register_##modname();
   auto* command_line = base::CommandLine::ForCurrentProcess();
   std::string process_type =
       command_line->GetSwitchValueASCII(::switches::kProcessType);
   if (process_type.empty()) {
-    ELECTRON_BROWSER_MODULES(V)
+    ELECTRON_BROWSER_BINDINGS(V)
 #if BUILDFLAG(ENABLE_VIEWS_API)
-    ELECTRON_VIEWS_MODULES(V)
+    ELECTRON_VIEWS_BINDINGS(V)
 #endif
 #if BUILDFLAG(ENABLE_DESKTOP_CAPTURER)
-    ELECTRON_DESKTOP_CAPTURER_MODULE(V)
+    ELECTRON_DESKTOP_CAPTURER_BINDINGS(V)
 #endif
   }
-  ELECTRON_COMMON_MODULES(V)
+  ELECTRON_COMMON_BINDINGS(V)
   if (process_type == ::switches::kRendererProcess) {
-    ELECTRON_RENDERER_MODULES(V)
+    ELECTRON_RENDERER_BINDINGS(V)
   }
   if (process_type == ::switches::kUtilityProcess) {
-    ELECTRON_UTILITY_MODULES(V)
+    ELECTRON_UTILITY_BINDINGS(V)
   }
 #if DCHECK_IS_ON()
-  ELECTRON_TESTING_MODULE(V)
+  ELECTRON_TESTING_BINDINGS(V)
 #endif
 #undef V
 }
@@ -424,8 +425,8 @@ void NodeBindings::Initialize() {
     ElectronCommandLine::InitializeFromCommandLine();
 #endif
 
-  // Explicitly register electron's builtin modules.
-  RegisterBuiltinModules();
+  // Explicitly register electron's builtin bindings.
+  RegisterBuiltinBindings();
 
   // Parse and set Node.js cli flags.
   SetNodeCliFlags();

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -79,7 +79,7 @@ class NodeBindings {
   enum class BrowserEnvironment { kBrowser, kRenderer, kUtility, kWorker };
 
   static NodeBindings* Create(BrowserEnvironment browser_env);
-  static void RegisterBuiltinModules();
+  static void RegisterBuiltinBindings();
   static bool IsInitialized();
 
   virtual ~NodeBindings();

--- a/shell/common/node_includes.h
+++ b/shell/common/node_includes.h
@@ -31,10 +31,10 @@
 
 #include "electron/pop_node_defines.h"
 
-// Alternative to NODE_MODULE_CONTEXT_AWARE_X.
-// Allows to explicitly register builtin modules instead of using
+// Alternative to NODE_BINDING_CONTEXT_AWARE_X.
+// Allows to explicitly register builtin bindings instead of using
 // __attribute__((constructor)).
-#define NODE_LINKED_MODULE_CONTEXT_AWARE(modname, regfunc) \
+#define NODE_LINKED_BINDING_CONTEXT_AWARE(modname, regfunc) \
   NODE_BINDING_CONTEXT_AWARE_CPP(modname, regfunc, nullptr, NM_F_LINKED)
 
 #endif  // ELECTRON_SHELL_COMMON_NODE_INCLUDES_H_

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -740,4 +740,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_renderer_context_bridge, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_renderer_context_bridge, Initialize)

--- a/shell/renderer/api/electron_api_crash_reporter_renderer.cc
+++ b/shell/renderer/api/electron_api_crash_reporter_renderer.cc
@@ -42,4 +42,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_renderer_crash_reporter, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_renderer_crash_reporter, Initialize)

--- a/shell/renderer/api/electron_api_ipc_renderer.cc
+++ b/shell/renderer/api/electron_api_ipc_renderer.cc
@@ -237,4 +237,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_renderer_ipc, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_renderer_ipc, Initialize)

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -916,4 +916,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_renderer_web_frame, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_renderer_web_frame, Initialize)

--- a/shell/services/node/parent_port.cc
+++ b/shell/services/node/parent_port.cc
@@ -130,4 +130,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_LINKED_MODULE_CONTEXT_AWARE(electron_utility_parent_port, Initialize)
+NODE_LINKED_BINDING_CONTEXT_AWARE(electron_utility_parent_port, Initialize)


### PR DESCRIPTION
#### Description of Change
Follow-up to https://github.com/nodejs/node/pull/45551 and #37129

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
