### PR TITLE
chore: update https://cs.chromium.org/ links to https://source.chromium.org/

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1910,7 +1910,7 @@ removed in future Electron releases.
 On a Window with Window Controls Overlay already enabled, this method updates
 the style of the title bar overlay.
 
-[runtime-enabled-features]: https://cs.chromium.org/chromium/src/third_party/blink/renderer/platform/runtime_enabled_features.json5?l=70
+[runtime-enabled-features]: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/runtime_enabled_features.json5
 [page-visibility-api]: https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
 [quick-look]: https://en.wikipedia.org/wiki/Quick_Look
 [vibrancy-docs]: https://developer.apple.com/documentation/appkit/nsvisualeffectview?preferredLanguage=objc

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -1001,7 +1001,7 @@ Emitted when DevTools is closed.
 
 Emitted when DevTools is focused / opened.
 
-[runtime-enabled-features]: https://cs.chromium.org/chromium/src/third_party/blink/renderer/platform/runtime_enabled_features.json5?l=70
+[runtime-enabled-features]: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/runtime_enabled_features.json5
 [chrome-webview]: https://developer.chrome.com/docs/extensions/reference/webviewTag/
 
 ### Event: 'context-menu'

--- a/docs/development/chromium-development.md
+++ b/docs/development/chromium-development.md
@@ -18,8 +18,8 @@ See also [V8 Development](v8-development.md)
 
 ### Code Resources
 
-- [Code Search](https://cs.chromium.org/) - Indexed and searchable source code for Chromium and associated projects.
-- [Source Code](https://cs.chromium.org/chromium/src/) - The source code for Chromium itself.
+- [Code Search](https://source.chromium.org/chromium) - Indexed and searchable source code for Chromium and associated projects.
+- [Source Code](https://source.chromium.org/chromium/chromium/src) - The source code for Chromium itself.
 - [Chromium Review](https://chromium-review.googlesource.com) - The searchable code host which facilitates code reviews for Chromium and related projects.
 
 ### Informational Resources

--- a/shell/utility/electron_content_utility_client.cc
+++ b/shell/utility/electron_content_utility_client.cc
@@ -84,8 +84,7 @@ ElectronContentUtilityClient::ElectronContentUtilityClient() = default;
 ElectronContentUtilityClient::~ElectronContentUtilityClient() = default;
 
 // The guts of this came from the chromium implementation
-// https://cs.chromium.org/chromium/src/chrome/utility/
-// chrome_content_utility_client.cc?sq=package:chromium&dr=CSs&g=0&l=142
+// https://source.chromium.org/chromium/chromium/src/+/main:chrome/utility/chrome_content_utility_client.cc
 void ElectronContentUtilityClient::ExposeInterfacesToBrowser(
     mojo::BinderMap* binders) {
 #if BUILDFLAG(IS_WIN)

--- a/spec/api-dialog-spec.ts
+++ b/spec/api-dialog-spec.ts
@@ -80,7 +80,7 @@ describe('dialog module', () => {
     afterEach(closeAllWindows);
 
     // parentless message boxes are synchronous on macOS
-    // dangling message boxes on windows cause a DCHECK: https://cs.chromium.org/chromium/src/base/win/message_window.cc?l=68&rcl=7faa4bf236a866d007dc5672c9ce42660e67a6a6
+    // dangling message boxes on windows cause a DCHECK: https://source.chromium.org/chromium/chromium/src/+/main:base/win/message_window.cc;drc=7faa4bf236a866d007dc5672c9ce42660e67a6a6;l=68
     ifit(process.platform !== 'darwin' && process.platform !== 'win32')('should not throw for a parentless message box', () => {
       expect(() => {
         dialog.showMessageBox({ message: 'i am message' });


### PR DESCRIPTION
#### Description of Change
https://cs.chromium.org/ was replaced by https://source.chromium.org/

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes
Notes: none
