### PR TITLE
fix: `BrowserView` crash when 'beforeunload' prevented

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -112,7 +112,6 @@ BrowserWindow::~BrowserWindow() {
     api_web_contents_->RemoveObserver(this);
     // Destroy the WebContents.
     OnCloseContents();
-    api_web_contents_->Destroy();
   }
 }
 
@@ -140,6 +139,7 @@ void BrowserWindow::WebContentsDestroyed() {
 
 void BrowserWindow::OnCloseContents() {
   BaseWindow::ResetBrowserViews();
+  api_web_contents_->Destroy();
 }
 
 void BrowserWindow::OnRendererResponsive(content::RenderProcessHost*) {

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1222,7 +1222,9 @@ void WebContents::CloseContents(content::WebContents* source) {
   for (ExtendedWebContentsObserver& observer : observers_)
     observer.OnCloseContents();
 
-  Destroy();
+  // If there are observers, OnCloseContents will call Destroy()
+  if (observers_.empty())
+    Destroy();
 }
 
 void WebContents::ActivateContents(content::WebContents* source) {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/37162.
Refs https://github.com/electron/electron/pull/35509 & https://github.com/electron/electron/pull/36230

When `Destroy()` is called in `WebContents::CloseContents` instead of `BrowserWindow::OnCloseContents`, this leads to a crash when `beforeunload` is prevented in the renderer process instead and there is at least one BrowserView present. This is owing to the `WebContents` being nullptr in the BrowserView when it is called by `NativeWindow::NonClientHitTest` as a result of clicking the close button. This is fixed by moving the destroy call back to `OnCloseContents` so that BrowserViews are reset properly prior.

Tested with https://gist.github.com/YauheniBH-EF/190ea8ff42c09a15763705ed4647b02e

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash when `BrowserView`s are present and a user attempts to prevent `beforeunload` in the renderer process.
