### PR TITLE
ci: update appveyor image (21-x-y)

### DIFF
--- a/appveyor-bake.yml
+++ b/appveyor-bake.yml
@@ -6,7 +6,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: Windows_Default_Appveyor
+image: e-111.0.5560.0-2
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default
@@ -16,17 +16,60 @@ environment:
   GOMA_FALLBACK_ON_AUTH_FAILURE: true
   DEPOT_TOOLS_WIN_TOOLCHAIN: 0
   PYTHONIOENCODING: UTF-8
+
+# The following lines are needed when baking from a completely new image (eg MicrosoftWindowsServer:WindowsServer:2019-Datacenter:latest via image: base-windows-server2019)
+# init:
+#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+#   - appveyor version
+#   - ps: $ErrorActionPreference = 'Stop'
+#   - ps: 'Write-Host "OS Build: $((Get-CimInstance Win32_OperatingSystem).BuildNumber)"'
+
+# clone_folder: '%USERPROFILE%\image-bake-scripts'
+
+# clone_script:  
+#   - ps: Invoke-WebRequest "https://github.com/appveyor/build-images/archive/1f90d94e74c8243c909a09b994e527584dfcb838.zip" -OutFile "$env:temp\scripts.zip"
+#   - ps: Expand-Archive -Path "$env:temp\scripts.zip" -DestinationPath "$env:temp\scripts" -Force
+#   - ps: Copy-Item -Path "$env:temp\scripts\build-images-1f90d94e74c8243c909a09b994e527584dfcb838\scripts\Windows\*" -Destination $env:APPVEYOR_BUILD_FOLDER -Recurse  
+
 build_script:
-  - ps: Resize-Partition -DriveLetter C -Size (256GB) # ensure initial partition size
-  - ps: Get-Partition -DriveLetter C
+# The following lines are needed when baking from a completely new image (eg MicrosoftWindowsServer:WindowsServer:2019-Datacenter:latest via image: base-windows-server2019)
+  # - ps: .\init_server.ps1
+  # - ps: .\extend_system_volume.ps1
+
+  # # Restart VM
+  # - ps: Start-Sleep -s 5; Restart-Computer
+  # - ps: Start-Sleep -s 5
+
+  # - appveyor version
+  # - ps: .\install_path_utils.ps1
+  # - ps: .\install_powershell_core.ps1
+  # - ps: .\install_powershell_get.ps1
+  # - ps: .\install_7zip.ps1
+  # - ps: .\install_chocolatey.ps1
+  # - ps: .\install_webpi.ps1
+  # - ps: .\install_nuget.ps1
+  # - ps: .\install_pstools.ps1
+
+  # - ps: .\install_git.ps1
+  # - ps: .\install_git_lfs.ps1
+
+  # # Restart VM
+  # - ps: Start-Sleep -s 5; Restart-Computer
+  # - ps: Start-Sleep -s 5
+# END LINES FOR COMPLETELY NEW IMAGE
+
   - git config --global core.longpaths true
-  - cd ..
-  - mkdir src
-  - ps: git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git  
-  - ps: $env:PATH="$pwd\depot_tools;$env:PATH"  
+  - ps: >-
+      if (-not (Test-Path -Path C:\projects\src)) {
+        New-Item -Path C:\projects\src -ItemType Directory
+      }
+  - cd C:\projects\
+  - git clone -q --branch=%APPVEYOR_REPO_BRANCH% https://github.com/electron/electron.git C:\projects\src\electron
+  - git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+  - ps: $env:PATH="$pwd\depot_tools;$env:PATH"
   - update_depot_tools.bat
-  - ps: Move-Item $env:APPVEYOR_BUILD_FOLDER -Destination src\electron
-  - src\electron\script\setup-win-for-dev.bat
+  # Uncomment the following line if windows deps change
+  # - src\electron\script\setup-win-for-dev.bat
   - >-
       gclient config
       --name "src\electron"
@@ -40,13 +83,25 @@ build_script:
   - ps: cd ..\..
   - gclient sync --with_branch_heads --with_tags --nohooks
   - ps: regsvr32 /s "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\DIA SDK\bin\amd64\msdia140.dll"
+
+# The following lines are needed when baking from a completely new image (eg MicrosoftWindowsServer:WindowsServer:2019-Datacenter:latest via image: base-windows-server2019)
+  # # Restart VM
+  # - ps: Start-Sleep -s 5; Restart-Computer 
+  # - ps: Start-Sleep -s 5
+
+  # - cd %USERPROFILE%\image-bake-scripts
+  # - appveyor version
+  # - ps: .\optimize_dotnet_runtime.ps1
+  # - ps: .\disable_windows_background_services.ps1
+  # - ps: .\enforce_windows_firewall.ps1
+  # - ps: .\cleanup_windows.ps1  
+# END LINES FOR COMPLETELY NEW IMAGE  
 on_image_bake:
   - ps: >-
       echo "Baking image: $env:APPVEYOR_BAKE_IMAGE at dir $PWD"
-  - ps: Remove-Item -Recurse -Force $pwd\depot_tools
-  - ps: Remove-Item -Recurse -Force $pwd\src\electron
-# Uncomment these lines to enable RDP
-#on_finish:
-#  - ps: >-
-#       $env:APPVEYOR_RDP_PASSWORD = "electron"
-#       $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  - ps: Remove-Item -Recurse -Force C:\projects\depot_tools
+  - ps: Remove-Item -Recurse -Force C:\projects\src\electron
+# Uncomment these lines and set APPVEYOR_RDP_PASSWORD in project settings to enable RDP after bake is done
+# # on_finish:
+#   - ps: >-
+#        $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -29,7 +29,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: e-106.0.5249.199
+image: e-106.0.5249.199-2
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default
@@ -82,8 +82,8 @@ for:
           if (Test-Path -Path "$pwd\build-tools") {
             Remove-Item -Recurse -Force $pwd\build-tools
           }
-      - ps: | 
-          git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+      - git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git          
+      - ps: |
           cd depot_tools
           git fetch --depth 1 origin b7d8efd8bee494f4cfacacc19cf50fc4d4be3900
           git checkout b7d8efd8bee494f4cfacacc19cf50fc4d4be3900

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: e-106.0.5249.199
+image: e-106.0.5249.199-2
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default
@@ -80,8 +80,8 @@ for:
           if (Test-Path -Path "$pwd\build-tools") {
             Remove-Item -Recurse -Force $pwd\build-tools
           }
+      - git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
       - ps: |
-          git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
           cd depot_tools
           git fetch --depth 1 origin b7d8efd8bee494f4cfacacc19cf50fc4d4be3900
           git checkout b7d8efd8bee494f4cfacacc19cf50fc4d4be3900

--- a/script/prepare-appveyor.js
+++ b/script/prepare-appveyor.js
@@ -14,8 +14,8 @@ const ROLLER_BRANCH_PATTERN = /^roller\/chromium$/;
 
 const DEFAULT_BUILD_CLOUD_ID = '1598';
 const DEFAULT_BUILD_CLOUD = 'electronhq-16-core';
-const DEFAULT_BAKE_BASE_IMAGE = 'Windows_Default_Appveyor';
-const DEFAULT_BUILD_IMAGE = 'Windows_Default_Appveyor';
+const DEFAULT_BAKE_BASE_IMAGE = 'base-windows-server2019';
+const DEFAULT_BUILD_IMAGE = 'base-windows-server2019';
 
 const appveyorBakeJob = 'electron-bake-image';
 const appVeyorJobs = {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Updates the Appveyor image to a newly baked image with the latest Appveyor build agent.  This should hopefully resolve some of the hanging we have recently seen on Appveyor jobs.  Additionally, this restores console output during Appveyor runs (previously it would stop updating the Appveyor UI).

This is a manual backport of #37211.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none