### PR TITLE
docs: add `win.isFocusable()` return type

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1776,7 +1776,7 @@ On macOS it does not remove the focus from the window.
 
 #### `win.isFocusable()` _macOS_ _Windows_
 
-Returns whether the window can be focused.
+Returns `boolean` - Whether the window can be focused.
 
 #### `win.setParentWindow(parent)`
 


### PR DESCRIPTION
#### Description of Change

`BrowserWindow.prototype.isFocusable()` returns a `boolean`, but it wasn't documented.
I think it would also be important to change the `d.ts` file, but I couldn't figure out how.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

Notes: none