### PR TITLE
feat: add `httpOnly` `cookies.get` filter

### DIFF
--- a/docs/api/cookies.md
+++ b/docs/api/cookies.md
@@ -78,6 +78,7 @@ The following methods are available on instances of `Cookies`:
   * `path` string (optional) - Retrieves cookies whose path matches `path`.
   * `secure` boolean (optional) - Filters cookies by their Secure property.
   * `session` boolean (optional) - Filters out session or persistent cookies.
+  * `httpOnly` boolean (optional) - Filters cookies by httpOnly.
 
 Returns `Promise<Cookie[]>` - A promise which resolves an array of cookie objects.
 

--- a/shell/browser/api/electron_api_cookies.cc
+++ b/shell/browser/api/electron_api_cookies.cc
@@ -133,6 +133,9 @@ bool MatchesCookie(const base::Value::Dict& filter,
   absl::optional<bool> session_filter = filter.FindBool("session");
   if (session_filter && *session_filter == cookie.IsPersistent())
     return false;
+  absl::optional<bool> httpOnly_filter = filter.FindBool("httpOnly");
+  if (httpOnly_filter && *httpOnly_filter != cookie.IsHttpOnly())
+    return false;
   return true;
 }
 

--- a/spec/api-net-spec.ts
+++ b/spec/api-net-spec.ts
@@ -878,6 +878,39 @@ describe('net module', () => {
       expect(cookies[0].name).to.equal('cookie2');
     });
 
+    it('should be able correctly filter out cookies that are httpOnly', async () => {
+      const sess = session.fromPartition(`cookie-tests-${Math.random()}`);
+
+      await Promise.all([
+        sess.cookies.set({
+          url: 'https://electronjs.org',
+          domain: 'electronjs.org',
+          name: 'cookie1',
+          value: '1',
+          httpOnly: true
+        }),
+        sess.cookies.set({
+          url: 'https://electronjs.org',
+          domain: 'electronjs.org',
+          name: 'cookie2',
+          value: '2',
+          httpOnly: false
+        })
+      ]);
+
+      const httpOnlyCookies = await sess.cookies.get({
+        httpOnly: true
+      });
+      expect(httpOnlyCookies).to.have.lengthOf(1);
+      expect(httpOnlyCookies[0].name).to.equal('cookie1');
+
+      const cookies = await sess.cookies.get({
+        httpOnly: false
+      });
+      expect(cookies).to.have.lengthOf(1);
+      expect(cookies[0].name).to.equal('cookie2');
+    });
+
     describe('when {"credentials":"omit"}', () => {
       it('should not send cookies');
       it('should not store cookies');


### PR DESCRIPTION
#### Description of Change

The existing filter does not fully cover some scenarios, such as `httpOnly`. This `httpOnly` filter can avoid additional judgments at the js level.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Add `httpOnly` to the cookie filter.
