### PR TITLE
build: ignore makeLatest on pre-releases

### DIFF
--- a/script/release/release.js
+++ b/script/release/release.js
@@ -318,12 +318,15 @@ function saveShaSumFile (checksums, fileName) {
 }
 
 async function publishRelease (release) {
-  const currentLatest = await octokit.repos.getLatestRelease({
-    owner: 'electron',
-    repo: targetRepo
-  });
+  let makeLatest;
+  if (!release.prerelease) {
+    const currentLatest = await octokit.repos.getLatestRelease({
+      owner: 'electron',
+      repo: targetRepo
+    });
 
-  const makeLatest = !release.prerelease && semver.gte(release.tag_name, currentLatest.data.tag_name);
+    makeLatest = semver.gte(release.tag_name, currentLatest.data.tag_name);
+  }
 
   return octokit.repos.updateRelease({
     owner: 'electron',

--- a/script/release/release.js
+++ b/script/release/release.js
@@ -318,7 +318,7 @@ function saveShaSumFile (checksums, fileName) {
 }
 
 async function publishRelease (release) {
-  let makeLatest;
+  let makeLatest = false;
   if (!release.prerelease) {
     const currentLatest = await octokit.repos.getLatestRelease({
       owner: 'electron',


### PR DESCRIPTION
#### Description of Change

Octokit's `repos.getLatestRelease` only works on non-draft and non-prerelease builds, so it was returning a 404 error when looking for the latest nightly, since the nightlies repo only contains prereleases. 

This PR modifies the call to only check on non-prerelease builds.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
