### PR TITLE
build: strip warnings from stdout in `get_release`

### DIFF
--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -384,7 +384,11 @@ def upload_sha256_checksum(version, file_path, key_prefix=None):
 def get_release(version):
   script_path = os.path.join(
     ELECTRON_DIR, 'script', 'release', 'find-github-release.js')
-  release_info = execute(['node', script_path, version])
+
+  # Strip warnings from stdout to ensure the only output is the desired object
+  release_env = os.environ.copy()
+  release_env['NODE_NO_WARNINGS'] = '1'
+  release_info = execute(['node', script_path, version], release_env)
   if is_verbose_mode():
     print('Release info for version: {}:\n'.format(version))
     print(release_info)


### PR DESCRIPTION
#### Description of Change

Prevent a similar problem as occurred in Sudowoodo yesterday by ensuring warnings are stripped from stdout.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none