### PR TITLE
test: use render-process-gone event in tests

### DIFF
--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2226,8 +2226,8 @@ describe('webContents module', () => {
 
   describe('crashed event', () => {
     it('does not crash main process when destroying WebContents in it', (done) => {
-      const contents = (webContents as any).create({ nodeIntegration: true });
-      contents.once('crashed', () => {
+      const contents = (webContents as typeof ElectronInternal.WebContents).create({ nodeIntegration: true });
+      contents.once('render-process-gone', () => {
         contents.destroy();
         done();
       });

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -518,7 +518,7 @@ describe('chromium features', () => {
     it('does not crash', (done) => {
       const w = new BrowserWindow({ show: false });
       w.webContents.once('did-finish-load', () => { done(); });
-      w.webContents.once('crashed', () => done(new Error('WebContents crashed.')));
+      w.webContents.once('render-process-gone', () => done(new Error('WebContents crashed.')));
       w.loadFile(path.join(fixturesPath, 'pages', 'external-string.html'));
     });
   });
@@ -558,7 +558,7 @@ describe('chromium features', () => {
     it('does not crash', (done) => {
       const w = new BrowserWindow({ show: false });
       w.webContents.once('did-finish-load', () => { done(); });
-      w.webContents.once('crashed', () => done(new Error('WebContents crashed.')));
+      w.webContents.once('render-process-gone', () => done(new Error('WebContents crashed.')));
       w.loadFile(path.join(__dirname, 'fixtures', 'pages', 'jquery.html'));
     });
   });
@@ -596,7 +596,7 @@ describe('chromium features', () => {
           }).then(() => done());
         }
       });
-      w.webContents.on('crashed', () => done(new Error('WebContents crashed.')));
+      w.webContents.on('render-process-gone', () => done(new Error('WebContents crashed.')));
       w.loadFile(path.join(fixturesPath, 'pages', 'service-worker', 'index.html'));
     });
 
@@ -637,7 +637,7 @@ describe('chromium features', () => {
           });
         }
       });
-      w.webContents.on('crashed', () => done(new Error('WebContents crashed.')));
+      w.webContents.on('render-process-gone', () => done(new Error('WebContents crashed.')));
       w.loadFile(path.join(fixturesPath, 'pages', 'service-worker', 'index.html'));
     });
 
@@ -673,7 +673,7 @@ describe('chromium features', () => {
           });
         }
       });
-      w.webContents.on('crashed', () => done(new Error('WebContents crashed.')));
+      w.webContents.on('render-process-gone', () => done(new Error('WebContents crashed.')));
       w.loadFile(path.join(fixturesPath, 'pages', 'service-worker', 'custom-scheme-index.html'));
     });
 
@@ -1559,7 +1559,7 @@ describe('chromium features', () => {
             ...extraPreferences
           });
           let redirected = false;
-          w.webContents.on('crashed', () => {
+          w.webContents.on('render-process-gone', () => {
             expect.fail('renderer crashed / was killed');
           });
           w.webContents.on('did-redirect-navigation', (event, url) => {
@@ -2730,7 +2730,7 @@ ifdescribe((process.platform !== 'linux' || app.isUnityRunning()))('navigator.se
           }).then(() => done());
         }
       });
-      w.webContents.on('crashed', () => done(new Error('WebContents crashed.')));
+      w.webContents.on('render-process-gone', () => done(new Error('WebContents crashed.')));
       w.loadFile(path.join(fixturesPath, 'pages', 'service-worker', 'badge-index.html'), { search: '?setBadge' });
     });
 
@@ -2751,7 +2751,7 @@ ifdescribe((process.platform !== 'linux' || app.isUnityRunning()))('navigator.se
           }).then(() => done());
         }
       });
-      w.webContents.on('crashed', () => done(new Error('WebContents crashed.')));
+      w.webContents.on('render-process-gone', () => done(new Error('WebContents crashed.')));
       w.loadFile(path.join(fixturesPath, 'pages', 'service-worker', 'badge-index.html'), { search: '?clearBadge' });
     });
   });

--- a/spec/fixtures/no-proprietary-codecs.js
+++ b/spec/fixtures/no-proprietary-codecs.js
@@ -21,8 +21,8 @@ app.whenReady().then(() => {
     }
   });
 
-  window.webContents.on('crashed', (event, killed) => {
-    console.log(`WebContents crashed (killed=${killed})`);
+  window.webContents.on('render-process-gone', (event, details) => {
+    console.log(`WebContents crashed ${JSON.stringify(details)}`);
     app.exit(1);
   });
 


### PR DESCRIPTION
#### Description of Change
The old events are deprecated and going to be removed.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes
Notes: none
