### PR TITLE
test: use webContents.create() in type-safe way

### DIFF
--- a/spec/api-browser-view-spec.ts
+++ b/spec/api-browser-view-spec.ts
@@ -41,7 +41,7 @@ describe('BrowserView module', () => {
   });
 
   it('can be created with an existing webContents', async () => {
-    const wc = (webContents as any).create({ sandbox: true });
+    const wc = (webContents as typeof ElectronInternal.WebContents).create({ sandbox: true });
     await wc.loadURL('about:blank');
 
     view = new BrowserView({ webContents: wc } as any);

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -2184,7 +2184,7 @@ describe('BrowserWindow module', () => {
     });
 
     it('returns null for webContents without a BrowserWindow', () => {
-      const contents = (webContents as any).create({});
+      const contents = (webContents as typeof ElectronInternal.WebContents).create();
       try {
         expect(BrowserWindow.fromWebContents(contents)).to.be.null('BrowserWindow.fromWebContents(contents)');
       } finally {

--- a/spec/api-ipc-renderer-spec.ts
+++ b/spec/api-ipc-renderer-spec.ts
@@ -135,7 +135,7 @@ describe('ipcRenderer module', () => {
         const payload = 'Hello World!';
 
         before(async () => {
-          contents = (webContents as any).create({
+          contents = (webContents as typeof ElectronInternal.WebContents).create({
             preload: path.join(fixtures, 'module', 'preload-ipc-ping-pong.js'),
             ...webPreferences
           });

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -72,7 +72,7 @@ function defer (): Promise<any> & {resolve: Function, reject: Function} {
 describe('protocol module', () => {
   let contents: WebContents = null as unknown as WebContents;
   // NB. sandbox: true is used because it makes navigations much (~8x) faster.
-  before(() => { contents = (webContents as any).create({ sandbox: true }); });
+  before(() => { contents = (webContents as typeof ElectronInternal.WebContents).create({ sandbox: true }); });
   after(() => contents.destroy());
 
   async function ajax (url: string, options = {}) {
@@ -980,7 +980,10 @@ describe('protocol module', () => {
         callback('');
       });
 
-      const newContents: WebContents = (webContents as any).create({ nodeIntegration: true, contextIsolation: false });
+      const newContents = (webContents as typeof ElectronInternal.WebContents).create({
+        nodeIntegration: true,
+        contextIsolation: false
+      });
       const consoleMessages: string[] = [];
       newContents.on('console-message', (e, level, message) => consoleMessages.push(message));
       try {
@@ -1081,7 +1084,11 @@ describe('protocol module', () => {
       await registerStreamProtocol(standardScheme, protocolHandler);
       await registerStreamProtocol('stream', protocolHandler);
 
-      const newContents: WebContents = (webContents as any).create({ nodeIntegration: true, contextIsolation: false });
+      const newContents = (webContents as typeof ElectronInternal.WebContents).create({
+        nodeIntegration: true,
+        contextIsolation: false
+      });
+
       try {
         newContents.loadURL(testingScheme + '://fake-host');
         const [, response] = await emittedOnce(ipcMain, 'result');

--- a/spec/api-service-workers-spec.ts
+++ b/spec/api-service-workers-spec.ts
@@ -39,7 +39,7 @@ describe('session.serviceWorkers', () => {
       });
     });
 
-    w = (webContents as any).create({ session: ses });
+    w = (webContents as typeof ElectronInternal.WebContents).create({ session: ses });
   });
 
   afterEach(async () => {

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -3,7 +3,7 @@ import { AddressInfo } from 'net';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as http from 'http';
-import { BrowserWindow, ipcMain, webContents, session, WebContents, app, BrowserView } from 'electron/main';
+import { BrowserWindow, ipcMain, webContents, session, app, BrowserView } from 'electron/main';
 import { emittedOnce } from './lib/events-helpers';
 import { closeAllWindows } from './lib/window-helpers';
 import { ifdescribe, delay, defer, waitUntil } from './lib/spec-helpers';
@@ -48,11 +48,11 @@ describe('webContents module', () => {
 
   describe('fromFrame()', () => {
     it('returns WebContents for mainFrame', () => {
-      const contents = (webContents as any).create() as WebContents;
+      const contents = (webContents as typeof ElectronInternal.WebContents).create();
       expect(webContents.fromFrame(contents.mainFrame)).to.equal(contents);
     });
     it('returns undefined for disposed frame', async () => {
-      const contents = (webContents as any).create() as WebContents;
+      const contents = (webContents as typeof ElectronInternal.WebContents).create();
       const { mainFrame } = contents;
       contents.destroy();
       await waitUntil(() => typeof webContents.fromFrame(mainFrame) === 'undefined');
@@ -1549,7 +1549,7 @@ describe('webContents module', () => {
         // is fine to retry this test for a few times.
         this.retries(3);
 
-        const contents = (webContents as any).create() as WebContents;
+        const contents = (webContents as typeof ElectronInternal.WebContents).create();
         const originalEmit = contents.emit.bind(contents);
         contents.emit = (...args) => { return originalEmit(...args); };
         contents.once(e.name as any, () => contents.destroy());
@@ -2261,7 +2261,7 @@ describe('webContents module', () => {
     afterEach(closeAllWindows);
 
     it('closes when close() is called', async () => {
-      const w = (webContents as any).create() as WebContents;
+      const w = (webContents as typeof ElectronInternal.WebContents).create();
       const destroyed = emittedOnce(w, 'destroyed');
       w.close();
       await destroyed;
@@ -2269,7 +2269,7 @@ describe('webContents module', () => {
     });
 
     it('closes when close() is called after loading a page', async () => {
-      const w = (webContents as any).create() as WebContents;
+      const w = (webContents as typeof ElectronInternal.WebContents).create();
       await w.loadURL('about:blank');
       const destroyed = emittedOnce(w, 'destroyed');
       w.close();
@@ -2284,7 +2284,7 @@ describe('webContents module', () => {
         registry = new FinalizationRegistry(resolve as any);
       });
       (() => {
-        const w = (webContents as any).create() as WebContents;
+        const w = (webContents as typeof ElectronInternal.WebContents).create();
         registry!.register(w, 42);
       })();
       const i = setInterval(() => v8Util.requestGarbageCollectionForTesting(), 100);
@@ -2302,7 +2302,7 @@ describe('webContents module', () => {
     });
 
     it('ignores beforeunload if waitForBeforeUnload not specified', async () => {
-      const w = (webContents as any).create() as WebContents;
+      const w = (webContents as typeof ElectronInternal.WebContents).create();
       await w.loadURL('about:blank');
       await w.executeJavaScript('window.onbeforeunload = () => "hello"; null');
       w.on('will-prevent-unload', () => { throw new Error('unexpected will-prevent-unload'); });
@@ -2313,7 +2313,7 @@ describe('webContents module', () => {
     });
 
     it('runs beforeunload if waitForBeforeUnload is specified', async () => {
-      const w = (webContents as any).create() as WebContents;
+      const w = (webContents as typeof ElectronInternal.WebContents).create();
       await w.loadURL('about:blank');
       await w.executeJavaScript('window.onbeforeunload = () => "hello"; null');
       const willPreventUnload = emittedOnce(w, 'will-prevent-unload');
@@ -2323,7 +2323,7 @@ describe('webContents module', () => {
     });
 
     it('overriding beforeunload prevention results in webcontents close', async () => {
-      const w = (webContents as any).create() as WebContents;
+      const w = (webContents as typeof ElectronInternal.WebContents).create();
       await w.loadURL('about:blank');
       await w.executeJavaScript('window.onbeforeunload = () => "hello"; null');
       w.once('will-prevent-unload', e => e.preventDefault());

--- a/spec/api-web-request-spec.ts
+++ b/spec/api-web-request-spec.ts
@@ -52,7 +52,7 @@ describe('webRequest module', () => {
   let contents: WebContents = null as unknown as WebContents;
   // NB. sandbox: true is used because it makes navigations much (~8x) faster.
   before(async () => {
-    contents = (webContents as any).create({ sandbox: true });
+    contents = (webContents as typeof ElectronInternal.WebContents).create({ sandbox: true });
     await contents.loadFile(path.join(fixturesPath, 'pages', 'fetch.html'));
   });
   after(() => contents.destroy());
@@ -529,7 +529,7 @@ describe('webRequest module', () => {
         }
       });
 
-      const contents = (webContents as any).create({
+      const contents = (webContents as typeof ElectronInternal.WebContents).create({
         session: ses,
         nodeIntegration: true,
         webSecurity: false,

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -1472,7 +1472,7 @@ describe('chromium features', () => {
       });
 
       beforeEach(() => {
-        contents = (webContents as any).create({
+        contents = (webContents as typeof ElectronInternal.WebContents).create({
           nodeIntegration: true,
           contextIsolation: false
         });
@@ -1603,7 +1603,7 @@ describe('chromium features', () => {
       });
 
       it('default value allows websql', async () => {
-        contents = (webContents as any).create({
+        contents = (webContents as typeof ElectronInternal.WebContents).create({
           session: sqlSession,
           nodeIntegration: true,
           contextIsolation: false
@@ -1614,7 +1614,7 @@ describe('chromium features', () => {
       });
 
       it('when set to false can disallow websql', async () => {
-        contents = (webContents as any).create({
+        contents = (webContents as typeof ElectronInternal.WebContents).create({
           session: sqlSession,
           nodeIntegration: true,
           enableWebSQL: false,
@@ -1626,7 +1626,7 @@ describe('chromium features', () => {
       });
 
       it('when set to false does not disable indexedDB', async () => {
-        contents = (webContents as any).create({
+        contents = (webContents as typeof ElectronInternal.WebContents).create({
           session: sqlSession,
           nodeIntegration: true,
           enableWebSQL: false,

--- a/spec/fixtures/crash-cases/webcontents-create-leak-exit/index.js
+++ b/spec/fixtures/crash-cases/webcontents-create-leak-exit/index.js
@@ -1,6 +1,6 @@
 const { app, webContents } = require('electron');
 app.whenReady().then(function () {
-  webContents.create({});
+  webContents.create();
 
   app.quit();
 });

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as util from 'util';
 import { emittedOnce } from './lib/events-helpers';
 import { getRemoteContext, ifdescribe, ifit, itremote, useRemoteContext } from './lib/spec-helpers';
-import { webContents, WebContents } from 'electron/main';
+import { webContents } from 'electron/main';
 import { EventEmitter } from 'stream';
 
 const features = process._linkedBinding('electron_common_features');
@@ -780,7 +780,7 @@ describe('node feature', () => {
           // NOTE: temporary debug logging to try to catch flake.
           child.stderr.on('data', (m) => console.log(m.toString()));
           child.stdout.on('data', (m) => console.log(m.toString()));
-          const w = (webContents as any).create({}) as WebContents;
+          const w = (webContents as typeof ElectronInternal.WebContents).create();
           w.loadURL('about:blank')
             .then(() => w.executeJavaScript(`new Promise(resolve => {
               const connection = new WebSocket(${JSON.stringify(match[1])})

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -280,7 +280,7 @@ declare namespace ElectronInternal {
   }
 
   class WebContents extends Electron.WebContents {
-    static create(opts: Electron.WebPreferences): Electron.WebContents;
+    static create(opts?: Electron.WebPreferences): Electron.WebContents;
   }
 }
 


### PR DESCRIPTION
#### Description of Change
Improves type safety

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes
Notes: none
