### PR TITLE
build: use node 18.12 in AppVeyor (23-x-y)

### DIFF
--- a/appveyor-bake.yml
+++ b/appveyor-bake.yml
@@ -6,7 +6,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: e-110.0.5481.77
+image: e-111.0.5560.0-node18
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: e-110.0.5481.77
+image: e-110.0.5481.77-node18
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default

--- a/script/prepare-appveyor.js
+++ b/script/prepare-appveyor.js
@@ -14,8 +14,8 @@ const ROLLER_BRANCH_PATTERN = /^roller\/chromium$/;
 
 const DEFAULT_BUILD_CLOUD_ID = '1598';
 const DEFAULT_BUILD_CLOUD = 'electronhq-16-core';
-const DEFAULT_BAKE_BASE_IMAGE = 'e-111.0.5560.0-2';
-const DEFAULT_BUILD_IMAGE = 'e-111.0.5560.0-2';
+const DEFAULT_BAKE_BASE_IMAGE = 'e-111.0.5560.0-node18';
+const DEFAULT_BUILD_IMAGE = 'e-111.0.5560.0-node18';
 
 const appveyorBakeJob = 'electron-bake-image';
 const appVeyorJobs = {
@@ -188,7 +188,7 @@ async function prepareAppVeyorImage (opts) {
     const [, CHROMIUM_VERSION] = versionRegex.exec(deps);
 
     const cloudId = opts.cloudId || DEFAULT_BUILD_CLOUD_ID;
-    const imageVersion = opts.imageVersion || `e-${CHROMIUM_VERSION}`;
+    const imageVersion = opts.imageVersion || `e-${CHROMIUM_VERSION}-node18`;
     const image = await checkAppVeyorImage({ cloudId, imageVersion });
 
     if (image && image.name) {

--- a/script/setup-win-for-dev.bat
+++ b/script/setup-win-for-dev.bat
@@ -56,8 +56,8 @@ REM Install Windows SDK
 choco install windows-sdk-10-version-2104-all
 
 REM Install nodejs python git and yarn needed dependencies
-choco install -y nodejs-lts python2 git yarn
-choco install python --version 3.7.9
+choco install -y --force nodejs --version=18.12.1
+choco install -y python2 git yarn
 call C:\ProgramData\chocolatey\bin\RefreshEnv.cmd
 SET PATH=C:\Python27\;C:\Python27\Scripts;C:\Python39\;C:\Python39\Scripts;%PATH%
 


### PR DESCRIPTION
#### Description of Change

Recent Node patches have introduced a bug where uploading artifacts will hit this Node bug: https://github.com/nodejs/node/issues/46221

This PR bakes a new image that uses Node v18.12.1, to avoid this bug while we find a solution to the duplex error.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
