### PR TITLE
docs: only macOS 10.13+ is supported now

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -269,7 +269,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     zoom to the width of the screen. This will also affect the behavior when
     calling `maximize()` directly. Default is `false`.
   * `tabbingIdentifier` string (optional) _macOS_ - Tab group name, allows
-    opening the window as a native tab on macOS 10.12+. Windows with the same
+    opening the window as a native tab. Windows with the same
     tabbing identifier will be grouped together. This also adds a native new
     tab button to your window's tab bar and allows your `app` and window to
     receive the `new-window-for-tab` event.
@@ -1859,7 +1859,7 @@ frameless window.
 
 Sets the touchBar layout for the current window. Specifying `null` or
 `undefined` clears the touch bar. This method only has an effect if the
-machine has a touch bar and is running on macOS 10.12.1+.
+machine has a touch bar.
 
 **Note:** The TouchBar API is currently experimental and may change or be
 removed in future Electron releases.

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -51,7 +51,7 @@ See [`Menu`](menu.md) for examples.
     the placement of their containing group after the containing group of the item
     with the specified label.
 
-**Note:** `acceleratorWorksWhenHidden` is specified as being macOS-only because accelerators always work when items are hidden on Windows and Linux. The option is exposed to users to give them the option to turn it off, as this is possible in native macOS development. This property is only usable on macOS High Sierra 10.13 or newer.
+**Note:** `acceleratorWorksWhenHidden` is specified as being macOS-only because accelerators always work when items are hidden on Windows and Linux. The option is exposed to users to give them the option to turn it off, as this is possible in native macOS development.
 
 ### Roles
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -394,8 +394,6 @@ system default and override the value of `getEffectiveAppearance`.
 
 Returns `boolean` - whether or not this device has the ability to use Touch ID.
 
-**NOTE:** This API will return `false` on macOS systems older than Sierra 10.12.2.
-
 ### `systemPreferences.promptTouchID(reason)` _macOS_
 
 * `reason` string - The reason you are asking for Touch ID authentication
@@ -414,8 +412,6 @@ systemPreferences.promptTouchID('To get consent for a Security-Gated Thing').the
 
 This API itself will not protect your user data; rather, it is a mechanism to allow you to do so. Native apps will need to set [Access Control Constants](https://developer.apple.com/documentation/security/secaccesscontrolcreateflags?language=objc) like [`kSecAccessControlUserPresence`](https://developer.apple.com/documentation/security/secaccesscontrolcreateflags/ksecaccesscontroluserpresence?language=objc) on their keychain entry so that reading it would auto-prompt for Touch ID biometric consent. This could be done with [`node-keytar`](https://github.com/atom/node-keytar), such that one would store an encryption key with `node-keytar` and only fetch it if `promptTouchID()` resolves.
 
-**NOTE:** This API will return a rejected Promise on macOS systems older than Sierra 10.12.2.
-
 ### `systemPreferences.isTrustedAccessibilityClient(prompt)` _macOS_
 
 * `prompt` boolean - whether or not the user will be informed via prompt if the current process is untrusted.
@@ -428,7 +424,7 @@ Returns `boolean` - `true` if the current process is a trusted accessibility cli
 
 Returns `string` - Can be `not-determined`, `granted`, `denied`, `restricted` or `unknown`.
 
-This user consent was not required on macOS 10.13 High Sierra or lower so this method will always return `granted`.
+This user consent was not required on macOS 10.13 High Sierra so this method will always return `granted`.
 macOS 10.14 Mojave or higher requires consent for `microphone` and `camera` access.
 macOS 10.15 Catalina or higher requires consent for `screen` access.
 
@@ -443,7 +439,7 @@ Returns `Promise<boolean>` - A promise that resolves with `true` if consent was 
 
 **Important:** In order to properly leverage this API, you [must set](https://developer.apple.com/documentation/avfoundation/cameras_and_media_capture/requesting_authorization_for_media_capture_on_macos?language=objc) the `NSMicrophoneUsageDescription` and `NSCameraUsageDescription` strings in your app's `Info.plist` file. The values for these keys will be used to populate the permission dialogs so that the user will be properly informed as to the purpose of the permission request. See [Electron Application Distribution](../tutorial/application-distribution.md#rebranding-with-downloaded-binaries) for more information about how to set these in the context of Electron.
 
-This user consent was not required until macOS 10.14 Mojave, so this method will always return `true` if your system is running 10.13 High Sierra or lower.
+This user consent was not required until macOS 10.14 Mojave, so this method will always return `true` if your system is running 10.13 High Sierra.
 
 ### `systemPreferences.getAnimationSettings()`
 

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -235,7 +235,7 @@ Sets the hover text for this tray icon.
 
 * `title` string
 * `options` Object (optional)
-  * `fontType` string (optional) - The font family variant to display, can be `monospaced` or `monospacedDigit`. `monospaced` is available in macOS 10.15+ and `monospacedDigit` is available in macOS 10.11+.  When left blank, the title uses the default system font.
+  * `fontType` string (optional) - The font family variant to display, can be `monospaced` or `monospacedDigit`. `monospaced` is available in macOS 10.15+ When left blank, the title uses the default system font.
 
 Sets the title displayed next to the tray icon in the status bar (Support ANSI colors).
 

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -236,6 +236,13 @@ webContents.printToPDF({
 
 ## Planned Breaking API Changes (20.0)
 
+### Removed: macOS 10.11 / 10.12 support
+
+macOS 10.11 (El Capitan) and macOS 10.12 (Sierra) are no longer supported by [Chromium](https://chromium-review.googlesource.com/c/chromium/src/+/3646050).
+
+Older versions of Electron will continue to run on these operating systems, but macOS 10.13 (High Sierra)
+or later will be required to run Electron v20.0.0 and higher.
+
 ### Default Changed: renderers without `nodeIntegration: true` are sandboxed by default
 
 Previously, renderers that specified a preload script defaulted to being


### PR DESCRIPTION
#### Description of Change
Update wording to assume the minimum supported macOS version is now 10.13 (High Sierra)
https://github.com/electron/electron/blob/17ea7f42fcf71527aef6646fcbc74abbda40db42/BUILD.gn#L40

This happened in #34272, which includes https://chromium-review.googlesource.com/c/chromium/src/+/3646050
Follow-up to #35911

Also add missing entry to breaking changes as this affects Electron 20+

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes
Notes: none
