### PR TITLE
test: fix "crash cases" tests not failing properly

### DIFF
--- a/spec/modules-spec.ts
+++ b/spec/modules-spec.ts
@@ -62,10 +62,10 @@ describe('modules support', () => {
 
       ifit(features.isRunAsNodeEnabled())('can be required in node binary', async function () {
         const child = childProcess.fork(path.join(fixtures, 'module', 'uv-dlopen.js'));
-        await new Promise<void>(resolve => child.once('exit', (exitCode) => {
-          expect(exitCode).to.equal(0);
-          resolve();
+        const exitCode = await new Promise<number | null>(resolve => child.once('exit', (exitCode) => {
+          resolve(exitCode);
         }));
+        expect(exitCode).to.equal(0);
       });
     });
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Exceptions thrown from failing `expect`s in the "exit" even handler do not reject the enclosing
promise and do not fail the corresponding test. Let's call `expect`s inside
`runFixtureAndEnsureCleanExit` instead to make sure tests tests fail nicely
if something goes wrong.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples --> no-notes
