### PR TITLE
fix: guard more private API usage on MAS builds

### DIFF
--- a/patches/chromium/mas_no_private_api.patch
+++ b/patches/chromium/mas_no_private_api.patch
@@ -222,10 +222,159 @@ index f35d9ef2a2df3db8ecbf1d7b909c7b1cf33f3cd9..a710b8b4f851666fd65bb37f69ec2fa7
  
  bool SandboxCompiler::CompilePolicyToProto(mac::SandboxPolicy& policy,
 diff --git a/sandbox/mac/seatbelt.cc b/sandbox/mac/seatbelt.cc
-index 15c835e118456394c0a00ac98c11241c14ca75bd..49332a94219fc3e64ab05baa04681325edddfeb0 100644
+index 15c835e118456394c0a00ac98c11241c14ca75bd..83759e5fbc252fa57ca2fa122873dfac3d61d46d 100644
 --- a/sandbox/mac/seatbelt.cc
 +++ b/sandbox/mac/seatbelt.cc
-@@ -175,7 +175,11 @@ void Seatbelt::FreeError(char* errorbuf) {
+@@ -9,7 +9,7 @@
+ 
+ extern "C" {
+ #include <sandbox.h>
+-
++#if !IS_MAS_BUILD()
+ int sandbox_init_with_parameters(const char* profile,
+                                  uint64_t flags,
+                                  const char* const parameters[],
+@@ -40,13 +40,13 @@ sandbox_profile_t* sandbox_compile_string(const char* data,
+                                           char** error);
+ int sandbox_apply(sandbox_profile_t*);
+ void sandbox_free_profile(sandbox_profile_t*);
+-
++#endif
+ }  // extern "C"
+ 
+ namespace sandbox {
+ 
+ namespace {
+-
++#if !IS_MAS_BUILD()
+ bool HandleSandboxResult(int rv, char* errorbuf, std::string* error) {
+   if (rv == 0) {
+     if (error)
+@@ -74,36 +74,48 @@ bool HandleSandboxErrno(int rv, const char* message, std::string* error) {
+   }
+   return false;
+ }
+-
++#endif
+ }  // namespace
+ 
+ // static
+ Seatbelt::Parameters Seatbelt::Parameters::Create() {
+   Parameters params;
++#if !IS_MAS_BUILD()
+   params.params_ = ::sandbox_create_params();
++#endif
+   return params;
+ }
+ 
+ Seatbelt::Parameters::Parameters() = default;
+ 
+ Seatbelt::Parameters::Parameters(Seatbelt::Parameters&& other) {
++#if !IS_MAS_BUILD()
+   params_ = std::exchange(other.params_, nullptr);
++#endif
+ }
+ 
+ Seatbelt::Parameters& Seatbelt::Parameters::operator=(
+     Seatbelt::Parameters&& other) {
++#if !IS_MAS_BUILD()
+   params_ = std::exchange(other.params_, nullptr);
++#endif
+   return *this;
+ }
+ 
+ bool Seatbelt::Parameters::Set(const char* key, const char* value) {
++#if !IS_MAS_BUILD()
+   return ::sandbox_set_param(params_, key, value) == 0;
++#else
++  return true;
++#endif
+ }
+ 
+ Seatbelt::Parameters::~Parameters() {
++#if !IS_MAS_BUILD()
+   if (params_) {
+     ::sandbox_free_params(params_);
+   }
++#endif
+ }
+ 
+ // Initialize the static member variables.
+@@ -114,6 +126,7 @@ const char* Seatbelt::kProfilePureComputation = kSBXProfilePureComputation;
+ 
+ // static
+ bool Seatbelt::Init(const char* profile, uint64_t flags, std::string* error) {
++#if !IS_MAS_BUILD()
+ // OS X deprecated these functions, but did not provide a suitable replacement,
+ // so ignore the deprecation warning.
+ #pragma clang diagnostic push
+@@ -122,6 +135,9 @@ bool Seatbelt::Init(const char* profile, uint64_t flags, std::string* error) {
+   int rv = ::sandbox_init(profile, flags, &errorbuf);
+   return HandleSandboxResult(rv, errorbuf, error);
+ #pragma clang diagnostic pop
++#else
++  return true;
++#endif
+ }
+ 
+ // static
+@@ -129,10 +145,14 @@ bool Seatbelt::InitWithParams(const char* profile,
+                               uint64_t flags,
+                               const char* const parameters[],
+                               std::string* error) {
++#if !IS_MAS_BUILD()
+   char* errorbuf = nullptr;
+   int rv =
+       ::sandbox_init_with_parameters(profile, flags, parameters, &errorbuf);
+   return HandleSandboxResult(rv, errorbuf, error);
++#else
++  return true;
++#endif
+ }
+ 
+ // static
+@@ -140,6 +160,7 @@ bool Seatbelt::Compile(const char* profile,
+                        const Seatbelt::Parameters& params,
+                        std::string& compiled_profile,
+                        std::string* error) {
++#if !IS_MAS_BUILD()
+   char* errorbuf = nullptr;
+   sandbox_profile_t* sandbox_profile =
+       ::sandbox_compile_string(profile, params.params(), &errorbuf);
+@@ -149,33 +170,44 @@ bool Seatbelt::Compile(const char* profile,
+   compiled_profile.assign(reinterpret_cast<const char*>(sandbox_profile->data),
+                           sandbox_profile->size);
+   ::sandbox_free_profile(sandbox_profile);
++#endif
+   return true;
+ }
+ 
+ // static
+ bool Seatbelt::ApplyCompiledProfile(const std::string& profile,
+                                     std::string* error) {
++#if !IS_MAS_BUILD()
+   sandbox_profile_t sbox_profile = {
+       .builtin = nullptr,
+       .data = reinterpret_cast<const uint8_t*>(profile.data()),
+       .size = profile.size()};
+   return HandleSandboxErrno(::sandbox_apply(&sbox_profile),
+                             "sandbox_apply: ", error);
++#else
++  return true;
++#endif
+ }
+ 
+ // static
+ void Seatbelt::FreeError(char* errorbuf) {
++#if !IS_MAS_BUILD()
+ // OS X deprecated these functions, but did not provide a suitable replacement,
+ // so ignore the deprecation warning.
+ #pragma clang diagnostic push
+ #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+   return ::sandbox_free_error(errorbuf);
+ #pragma clang diagnostic pop
++#endif
+ }
  
  // static
  bool Seatbelt::IsSandboxed() {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/37292.
Refs CL:4079319

Guards more usage of private APIs (see [here](https://opensource.apple.com/source/WTF/WTF-7607.3.9/wtf/spi/darwin/SandboxSPI.h.auto.html)) on Mac App Store builds causing rejections.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed potential private API usage for MAS builds on macOS.
