### PR TITLE
chore: remove deprecated renderer-process-crashed event on app

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -384,21 +384,6 @@ which contains more information about why the child process disappeared. It
 isn't always because it crashed. The `killed` boolean can be replaced by
 checking `reason === 'killed'` when you switch to that event.
 
-### Event: 'renderer-process-crashed' _Deprecated_
-
-Returns:
-
-* `event` Event
-* `webContents` [WebContents](web-contents.md)
-* `killed` boolean
-
-Emitted when the renderer process of `webContents` crashes or is killed.
-
-**Deprecated:** This event is superceded by the `render-process-gone` event
-which contains more information about why the render process disappeared. It
-isn't always because it crashed.  The `killed` boolean can be replaced by
-checking `reason === 'killed'` when you switch to that event.
-
 ### Event: 'render-process-gone'
 
 Returns:

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -12,6 +12,20 @@ This document uses the following convention to categorize breaking changes:
 * **Deprecated:** An API was marked as deprecated. The API will continue to function, but will emit a deprecation warning, and will be removed in a future release.
 * **Removed:** An API or feature was removed, and is no longer supported by Electron.
 
+## Planned Breaking API Changes (25.0)
+
+### Removed: app `renderer-process-crashed` event
+
+The deprecated `renderer-process-crashed` event on app has been removed. It is replaced by [`render-process-gone`](api/app.md#event-render-process-gone).
+
+```js
+// Removed in Electron 25.0
+app.on('renderer-process-crashed', (event, webContents, killed) => {})
+
+// Replace with
+app.on('render-process-gone', (event, webContents, details) => {})
+```
+
 ## Planned Breaking API Changes (23.0)
 
 ### Removed: Windows 7 / 8 / 8.1 support

--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -115,4 +115,3 @@ for (const name of events) {
 
 // Deprecation.
 deprecate.event(app, 'gpu-process-crashed', 'child-process-gone');
-deprecate.event(app, 'renderer-process-crashed', 'render-process-gone');

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -661,10 +661,6 @@ WebContents.prototype._init = function () {
     ipcMain.emit(channel, event, message);
   });
 
-  this.on('crashed', (event, ...args) => {
-    app.emit('renderer-process-crashed', event, this, ...args);
-  });
-
   this.on('render-process-gone', (event, details) => {
     app.emit('render-process-gone', event, this, details);
 

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -540,24 +540,6 @@ describe('app module', () => {
     });
 
     // FIXME: re-enable this test on win32.
-    ifit(process.platform !== 'win32')('should emit renderer-process-crashed event when renderer crashes', async () => {
-      w = new BrowserWindow({
-        show: false,
-        webPreferences: {
-          nodeIntegration: true,
-          contextIsolation: false
-        }
-      });
-      await w.loadURL('about:blank');
-
-      const emitted = emittedOnce(app, 'renderer-process-crashed');
-      w.webContents.executeJavaScript('process.crash()');
-
-      const [, webContents] = await emitted;
-      expect(webContents).to.equal(w.webContents);
-    });
-
-    // FIXME: re-enable this test on win32.
     ifit(process.platform !== 'win32')('should emit render-process-gone event when renderer crashes', async () => {
       w = new BrowserWindow({
         show: false,


### PR DESCRIPTION
#### Description of Change
It was deprecated since #23560. Deprecation warnings added in #33557

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: The deprecated `renderer-process-crashed` event on app has been removed.