### PR TITLE
test: use async helpers to simplify tests

### DIFF
--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -62,7 +62,7 @@ describe('BrowserWindow module', () => {
     ifit(process.platform === 'linux')('does not crash when setting large window icons', async () => {
       const appPath = path.join(fixtures, 'apps', 'xwindow-icon');
       const appProcess = childProcess.spawn(process.execPath, [appPath]);
-      await new Promise((resolve) => { appProcess.once('exit', resolve); });
+      await emittedOnce(appProcess, 'exit');
     });
 
     it('does not crash or throw when passed an invalid icon', async () => {

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -291,7 +291,7 @@ describe('session module', () => {
       expect(itemUrl).to.equal(url);
       expect(itemFilename).to.equal('mockFile.txt');
       // Delay till the next tick.
-      await new Promise<void>(resolve => setImmediate(() => resolve()));
+      await new Promise(setImmediate);
       expect(() => item.getURL()).to.throw('DownloadItem used after being destroyed');
     });
   });

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -364,7 +364,7 @@ describe('webContents module', () => {
 
     it('resolves when navigating within the page', async () => {
       await w.loadFile(path.join(fixturesPath, 'pages', 'base-page.html'));
-      await new Promise(resolve => setTimeout(resolve));
+      await delay();
       await expect(w.loadURL(w.getURL() + '#foo')).to.eventually.be.fulfilled();
     });
 

--- a/spec/api-web-frame-main-spec.ts
+++ b/spec/api-web-frame-main-spec.ts
@@ -6,7 +6,7 @@ import { BrowserWindow, WebFrameMain, webFrameMain, ipcMain, app, WebContents } 
 import { closeAllWindows } from './lib/window-helpers';
 import { emittedOnce, emittedNTimes } from './lib/events-helpers';
 import { AddressInfo } from 'net';
-import { defer, ifit, waitUntil } from './lib/spec-helpers';
+import { defer, delay, ifit, waitUntil } from './lib/spec-helpers';
 
 describe('webFrameMain module', () => {
   const fixtures = path.resolve(__dirname, 'fixtures');
@@ -297,7 +297,7 @@ describe('webFrameMain module', () => {
       const { mainFrame } = w.webContents;
       w.destroy();
       // Wait for WebContents, and thus RenderFrameHost, to be destroyed.
-      await new Promise(resolve => setTimeout(resolve, 0));
+      await delay();
       expect(() => mainFrame.url).to.throw();
     });
 
@@ -338,7 +338,7 @@ describe('webFrameMain module', () => {
       w.webContents.forcefullyCrashRenderer();
       await crashEvent;
       // A short wait seems to be required to reproduce the crash.
-      await new Promise(resolve => setTimeout(resolve, 100));
+      await delay(100);
       await w.webContents.loadURL(crossOriginUrl);
       // Log just to keep mainFrame in scope.
       console.log('mainFrame.url', mainFrame.url);

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -474,7 +474,7 @@ describe('command line switches', () => {
       const stdio = appProcess.stdio as unknown as [NodeJS.ReadableStream, NodeJS.WritableStream, NodeJS.WritableStream, NodeJS.WritableStream, NodeJS.ReadableStream];
       const pipe = new PipeTransport(stdio[3], stdio[4]);
       pipe.send({ id: 1, method: 'Browser.close', params: {} });
-      await new Promise(resolve => { appProcess!.on('exit', resolve); });
+      await emittedOnce(appProcess, 'exit');
     });
   });
 
@@ -2658,7 +2658,7 @@ ifdescribe((process.platform !== 'linux' || app.isUnityRunning()))('navigator.se
   async function waitForBadgeCount (value: number) {
     let badgeCount = app.getBadgeCount();
     while (badgeCount !== value) {
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await delay(10);
       badgeCount = app.getBadgeCount();
     }
     return badgeCount;

--- a/spec/get-files.ts
+++ b/spec/get-files.ts
@@ -1,4 +1,5 @@
 import * as walkdir from 'walkdir';
+import { emittedOnce } from './lib/events-helpers';
 
 export async function getFiles (directoryPath: string, { filter = null }: {filter?: ((file: string) => boolean) | null} = {}) {
   const files: string[] = [];
@@ -8,6 +9,6 @@ export async function getFiles (directoryPath: string, { filter = null }: {filte
   walker.on('file', (file) => {
     if (!filter || filter(file)) { files.push(file); }
   });
-  await new Promise((resolve) => walker.on('end', resolve));
+  await emittedOnce(walker, 'end');
   return files;
 }

--- a/spec/modules-spec.ts
+++ b/spec/modules-spec.ts
@@ -62,10 +62,8 @@ describe('modules support', () => {
 
       ifit(features.isRunAsNodeEnabled())('can be required in node binary', async function () {
         const child = childProcess.fork(path.join(fixtures, 'module', 'uv-dlopen.js'));
-        await new Promise<void>(resolve => child.once('exit', (exitCode) => {
-          expect(exitCode).to.equal(0);
-          resolve();
-        }));
+        const [exitCode] = await emittedOnce(child, 'exit');
+        expect(exitCode).to.equal(0);
       });
     });
 

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -104,7 +104,7 @@ describe('node feature', () => {
       it('has the electron version in process.versions', async () => {
         const source = 'process.send(process.versions)';
         const forked = require('child_process').fork('--eval', [source]);
-        const message = await new Promise(resolve => forked.once('message', resolve));
+        const [message] = await emittedOnce(forked, 'message');
         expect(message)
           .to.have.own.property('electron')
           .that.is.a('string')

--- a/spec/webview-spec.ts
+++ b/spec/webview-spec.ts
@@ -1774,6 +1774,14 @@ describe('<webview> tag', function () {
     describe('<webview>.goForward()', () => {
       useRemoteContext({ webPreferences: { webviewTag: true } });
       itremote('should work after a replaced history entry', async (fixtures: string) => {
+        function waitForEvent (target: EventTarget, event: string) {
+          return new Promise<any>(resolve => target.addEventListener(event, resolve, { once: true }));
+        }
+
+        function waitForEvents (target: EventTarget, ...events: string[]) {
+          return Promise.all(events.map(event => waitForEvent(webview, event)));
+        }
+
         const webview = new WebView();
 
         webview.setAttribute('nodeintegration', 'on');
@@ -1782,10 +1790,7 @@ describe('<webview> tag', function () {
         document.body.appendChild(webview);
 
         {
-          const [e] = await Promise.all([
-            new Promise<any>(resolve => webview.addEventListener('ipc-message', resolve, { once: true })),
-            new Promise<void>(resolve => webview.addEventListener('did-stop-loading', resolve, { once: true }))
-          ]);
+          const [e] = await waitForEvents(webview, 'ipc-message', 'did-stop-loading');
           expect(e.channel).to.equal('history');
           expect(e.args[0]).to.equal(1);
           expect(webview.canGoBack()).to.be.false();
@@ -1802,10 +1807,7 @@ describe('<webview> tag', function () {
         webview.goBack();
 
         {
-          const [e] = await Promise.all([
-            new Promise<any>(resolve => webview.addEventListener('ipc-message', resolve, { once: true })),
-            new Promise<void>(resolve => webview.addEventListener('did-stop-loading', resolve, { once: true }))
-          ]);
+          const [e] = await waitForEvents(webview, 'ipc-message', 'did-stop-loading');
           expect(e.channel).to.equal('history');
           expect(e.args[0]).to.equal(2);
           expect(webview.canGoBack()).to.be.false();


### PR DESCRIPTION
#### Description of Change
Use `emittedOnce`, `delay` and custom `waitForEvent(s)` to DRY

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes
Notes: none
