### PR TITLE
feat: add enableLocalEcho flag to setDisplayMediaRequestHandler() callback

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -917,8 +917,9 @@ session.fromPartition('some-partition').setPermissionCheckHandler((webContents, 
         currently only supported on Windows. If a WebFrameMain is specified,
         will capture audio from that frame.
       * `enableLocalEcho` Boolean (optional) - If `audio` is a [WebFrameMain](web-frame-main.md)
-         and if this is set to `false`, then prevents input from being echoed in the local output
-         stream (e.g., speaker). Defaults to `false`.
+         and this is set to `true`, then local playback of audio will not be muted (e.g. using `MediaRecorder`
+         to record `WebFrameMain` with this flag set to `true` will allow audio to pass through to the speakers
+         while recording). Default is `false`.
 
 This handler will be called when web content requests access to display media
 via the `navigator.mediaDevices.getDisplayMedia` API. Use the

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -916,6 +916,9 @@ session.fromPartition('some-partition').setPermissionCheckHandler((webContents, 
         Specifying a loopback device will capture system audio, and is
         currently only supported on Windows. If a WebFrameMain is specified,
         will capture audio from that frame.
+      * `enableLocalEcho` Boolean (optional) - If `audio` is a [WebFrameMain](web-frame-main.md)
+         and if this is set to `false`, then prevents input from being echoed in the local output
+         stream (e.g., speaker). Defaults to `false`.
 
 This handler will be called when web content requests access to display media
 via the `navigator.mediaDevices.getDisplayMedia` API. Use the

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -504,13 +504,13 @@ void ElectronBrowserContext::DisplayMediaDeviceChosen(
       bool enable_local_echo = false;
       result_dict.Get("enableLocalEcho", &enable_local_echo);
       bool disable_local_echo = !enable_local_echo;
-      devices.audio_device = blink::MediaStreamDevice(
-          request.audio_type,
-          content::WebContentsMediaCaptureId(rfh->GetProcess()->GetID(),
-                                             rfh->GetRoutingID(),
-                                             disable_local_echo)
-              .ToString(),
-          "Tab audio");
+      devices.audio_device =
+          blink::MediaStreamDevice(request.audio_type,
+                                   content::WebContentsMediaCaptureId(
+                                       rfh->GetProcess()->GetID(),
+                                       rfh->GetRoutingID(), disable_local_echo)
+                                       .ToString(),
+                                   "Tab audio");
     } else if (result_dict.Get("audio", &id)) {
       devices.audio_device =
           blink::MediaStreamDevice(request.audio_type, id, "System audio");

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -501,11 +501,14 @@ void ElectronBrowserContext::DisplayMediaDeviceChosen(
       devices.audio_device =
           blink::MediaStreamDevice(request.audio_type, id, name);
     } else if (result_dict.Get("audio", &rfh)) {
+      bool enable_local_echo = false;
+      result_dict.Get("enableLocalEcho", &enable_local_echo);
+      bool disable_local_echo = !enable_local_echo;
       devices.audio_device = blink::MediaStreamDevice(
           request.audio_type,
           content::WebContentsMediaCaptureId(rfh->GetProcess()->GetID(),
                                              rfh->GetRoutingID(),
-                                             /* disable_local_echo= */ true)
+                                             disable_local_echo)
               .ToString(),
           "Tab audio");
     } else if (result_dict.Get("audio", &id)) {


### PR DESCRIPTION
#### Description of Change

This adds a boolean option called `enableLocalEcho` to the callback handler for `setDisplayMediaRequestHandler()` which prevents input from being echoed in the local output stream (e.g., speaker). It can only be used if the `audio` property is set to a `WebFrameMain`. Closes https://github.com/electron/electron/issues/37293.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added the `enableLocalEcho` flag to the session handler `ses.setDisplayMediaRequestHandler()` callback for allowing remote audio input to be echoed in the local output stream when `audio` is a `WebFrameMain`.