### PR TITLE
chore: remove obsolete internal electron module test

### DIFF
--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -14,20 +14,6 @@ import split = require('split')
 
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
-describe('electron module', () => {
-  it('does not expose internal modules to require', () => {
-    expect(() => {
-      require('clipboard');
-    }).to.throw(/Cannot find module 'clipboard'/);
-  });
-
-  describe('require("electron")', () => {
-    it('always returns the internal electron module', () => {
-      require('electron');
-    });
-  });
-});
-
 describe('app module', () => {
   let server: https.Server;
   let secureUrl: string;


### PR DESCRIPTION
#### Description of Change
This is long irrelevant now that there is a single `require('electron')` module

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes
Notes: none