### PR TITLE
test: rename & split internal module tests

### DIFF
--- a/spec/parse-features-string-spec.ts
+++ b/spec/parse-features-string-spec.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import { parseCommaSeparatedKeyValue } from '../lib/browser/parse-features-string';
+
+describe('feature-string parsing', () => {
+  it('is indifferent to whitespace around keys and values', () => {
+    const checkParse = (string: string, parsed: Record<string, string | boolean>) => {
+      const features = parseCommaSeparatedKeyValue(string);
+      expect(features).to.deep.equal(parsed);
+    };
+    checkParse('a=yes,c=d', { a: true, c: 'd' });
+    checkParse('a=yes ,c=d', { a: true, c: 'd' });
+    checkParse('a=yes, c=d', { a: true, c: 'd' });
+    checkParse('a=yes , c=d', { a: true, c: 'd' });
+    checkParse(' a=yes , c=d', { a: true, c: 'd' });
+    checkParse(' a= yes , c=d', { a: true, c: 'd' });
+    checkParse(' a = yes , c=d', { a: true, c: 'd' });
+    checkParse(' a = yes , c =d', { a: true, c: 'd' });
+    checkParse(' a = yes , c = d', { a: true, c: 'd' });
+    checkParse(' a = yes , c = d ', { a: true, c: 'd' });
+  });
+});

--- a/spec/process-binding-spec.ts
+++ b/spec/process-binding-spec.ts
@@ -2,26 +2,6 @@ import { expect } from 'chai';
 import { BrowserWindow } from 'electron/main';
 import { closeAllWindows } from './lib/window-helpers';
 
-describe('feature-string parsing', () => {
-  it('is indifferent to whitespace around keys and values', () => {
-    const { parseCommaSeparatedKeyValue } = require('../lib/browser/parse-features-string');
-    const checkParse = (string: string, parsed: Record<string, string | boolean>) => {
-      const features = parseCommaSeparatedKeyValue(string);
-      expect(features).to.deep.equal(parsed);
-    };
-    checkParse('a=yes,c=d', { a: true, c: 'd' });
-    checkParse('a=yes ,c=d', { a: true, c: 'd' });
-    checkParse('a=yes, c=d', { a: true, c: 'd' });
-    checkParse('a=yes , c=d', { a: true, c: 'd' });
-    checkParse(' a=yes , c=d', { a: true, c: 'd' });
-    checkParse(' a= yes , c=d', { a: true, c: 'd' });
-    checkParse(' a = yes , c=d', { a: true, c: 'd' });
-    checkParse(' a = yes , c =d', { a: true, c: 'd' });
-    checkParse(' a = yes , c = d', { a: true, c: 'd' });
-    checkParse(' a = yes , c = d ', { a: true, c: 'd' });
-  });
-});
-
 describe('process._linkedBinding', () => {
   describe('in the main process', () => {
     it('can access electron_browser bindings', () => {

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -249,7 +249,6 @@ declare namespace ElectronInternal {
 
   interface ModuleEntry {
     name: string;
-    private?: boolean;
     loader: ModuleLoader;
   }
 


### PR DESCRIPTION
#### Description of Change
Separate `parse-features-string` internal module tests from `process._linkedBinding` ones.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [X] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes
Notes: none
