### PR TITLE
test: move desktopCapturer usage from renderer to main in ts-smoke

### DIFF
--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -4,6 +4,7 @@ import {
   BrowserWindow,
   contentTracing,
   dialog,
+  desktopCapturer,
   globalShortcut,
   ipcMain,
   Menu,
@@ -13,17 +14,14 @@ import {
   powerSaveBlocker,
   protocol,
   Tray,
-  clipboard,
-  crashReporter,
-  nativeImage,
   screen,
-  shell,
   session,
   systemPreferences,
   webContents,
   TouchBar
-} from 'electron';
+} from 'electron/main';
 
+import { clipboard, crashReporter, nativeImage, shell } from 'electron/common';
 import * as path from 'path';
 
 // Quick start
@@ -507,6 +505,11 @@ dialog.showOpenDialog(win3, {
 }).then(ret => {
   console.log(ret);
 });
+
+// desktopCapturer
+// https://github.com/electron/electron/blob/main/docs/api/desktop-capturer.md
+
+ipcMain.handle('get-sources', (event, options) => desktopCapturer.getSources(options));
 
 // global-shortcut
 // https://github.com/electron/electron/blob/main/docs/api/global-shortcut.md

--- a/spec/ts-smoke/electron/renderer.ts
+++ b/spec/ts-smoke/electron/renderer.ts
@@ -1,12 +1,6 @@
 
-import {
-  desktopCapturer,
-  ipcRenderer,
-  webFrame,
-  clipboard,
-  crashReporter,
-  shell
-} from 'electron';
+import { ipcRenderer, webFrame } from 'electron/renderer';
+import { clipboard, crashReporter, shell } from 'electron/common';
 
 // In renderer process (web page).
 // https://github.com/electron/electron/blob/main/docs/api/ipc-renderer.md
@@ -79,7 +73,7 @@ crashReporter.start({
 // desktopCapturer
 // https://github.com/electron/electron/blob/main/docs/api/desktop-capturer.md
 
-desktopCapturer.getSources({ types: ['window', 'screen'] }).then(sources => {
+getSources({ types: ['window', 'screen'] }).then(sources => {
   for (let i = 0; i < sources.length; ++i) {
     if (sources[i].name === 'Electron') {
       (navigator as any).webkitGetUserMedia({
@@ -99,6 +93,10 @@ desktopCapturer.getSources({ types: ['window', 'screen'] }).then(sources => {
     }
   }
 });
+
+function getSources (options: Electron.SourcesOptions) {
+  return ipcRenderer.invoke('get-sources', options) as Promise<Electron.DesktopCapturerSource[]>;
+}
 
 function gotStream (stream: any) {
   (document.querySelector('video') as HTMLVideoElement).src = URL.createObjectURL(stream);


### PR DESCRIPTION
#### Description of Change
Follow-up to #30720. The `desktopCapturer` module is now only available in the main process.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes
Notes: none
