### PR TITLE
test: use expect(dir).to.be.an.instanceof(fs.Dirent);

### DIFF
--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -899,7 +899,7 @@ describe('asar package', function () {
         const p = path.join(asarDir, 'a.asar');
         const dirs = fs.readdirSync(p, { withFileTypes: true });
         for (const dir of dirs) {
-          expect(dir instanceof fs.Dirent).to.be.true();
+          expect(dir).to.be.an.instanceof(fs.Dirent);
         }
         const names = dirs.map(a => a.name);
         expect(names).to.deep.equal(['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);
@@ -909,7 +909,7 @@ describe('asar package', function () {
         const p = path.join(asarDir, 'a.asar', 'dir3');
         const dirs = fs.readdirSync(p, { withFileTypes: true });
         for (const dir of dirs) {
-          expect(dir instanceof fs.Dirent).to.be.true();
+          expect(dir).to.be.an.instanceof(fs.Dirent);
         }
         const names = dirs.map(a => a.name);
         expect(names).to.deep.equal(['file1', 'file2', 'file3']);
@@ -941,7 +941,7 @@ describe('asar package', function () {
 
         const dirs = await promisify(fs.readdir)(p, { withFileTypes: true });
         for (const dir of dirs) {
-          expect(dir instanceof fs.Dirent).to.be.true();
+          expect(dir).to.be.an.instanceof(fs.Dirent);
         }
 
         const names = dirs.map((a: any) => a.name);
@@ -1004,7 +1004,7 @@ describe('asar package', function () {
         const p = path.join(asarDir, 'a.asar');
         const dirs = await fs.promises.readdir(p, { withFileTypes: true });
         for (const dir of dirs) {
-          expect(dir instanceof fs.Dirent).to.be.true();
+          expect(dir).to.be.an.instanceof(fs.Dirent);
         }
         const names = dirs.map(a => a.name);
         expect(names).to.deep.equal(['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);


### PR DESCRIPTION
#### Description of Change
Just a small improvement for consistency and better diagnostics
```
not ok 108 asar package node api fs.promises.readdir supports withFileTypes
  expected false to be true
  AssertionError: expected false to be true
      at Context.<anonymous> (electron/spec/lib/spec-helpers.ts:191:22)
```
turns into
```
not ok 108 asar package node api fs.promises.readdir supports withFileTypes
  expected { Object (name) } to be an instance of Dirent
  AssertionError: expected { Object (name) } to be an instance of Dirent
      at Context.<anonymous> (electron/spec/lib/spec-helpers.ts:191:22)
```

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes
Notes: none
