### PR TITLE
test: add disabled tests list

### DIFF
--- a/spec/disabled-tests.json
+++ b/spec/disabled-tests.json
@@ -1,0 +1,3 @@
+[
+  "// NOTE: this file is used to disable tests in our test suite by their full title."
+]

--- a/spec/index.js
+++ b/spec/index.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const v8 = require('v8');
 
@@ -64,6 +65,18 @@ app.whenReady().then(async () => {
     };
   }
   const mocha = new Mocha(mochaOptions);
+
+  // Add a root hook on mocha to skip any tests that are disabled
+  const disabledTests = new Set(
+    JSON.parse(
+      fs.readFileSync(path.join(__dirname, 'disabled-tests.json'), 'utf8')
+    )
+  );
+  mocha.suite.beforeEach(function () {
+    if (disabledTests.has(this.currentTest?.fullTitle())) {
+      this.skip();
+    }
+  });
 
   // The cleanup method is registered this way rather than through an
   // `afterEach` at the top level so that it can run before other `afterEach`


### PR DESCRIPTION
As part of the test love initiative (see #proj-test-love-initiative in Slack), this PR adds a simple JSON list for disabling tests.

> "Why not just add `.skip` to tests?" you might ask.

There are two reasons why I'm adding this list and hook instead of advocating for adding `.skip` to disable tests:

1. We use a number of helpers like `ifit` and `ifdescribe`, among others, which makes it complicated to skip, say, only a specific platform but not the others.
2. In the future we want to build automation around disabling tests. Adding `.skip` to test source code is a very complex task, whereas adding a string to a JSON list is trivial.

While this list is an empty stub currently, I will be moving tests that are currently marked `.skip` in our test suite to use this list instead in a later PR.

#### Release Notes
Notes: none
