### PR TITLE
docs: fixed a typo in `process.defaultApp` doc

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -49,8 +49,11 @@ beginning to load the web page or the main script.
 
 ### `process.defaultApp` _Readonly_
 
-A `boolean`. When app is started by being passed as parameter to the default app, this
+A `boolean`. When the app is started by being passed as parameter to the default Electron executable, this
 property is `true` in the main process, otherwise it is `undefined`.
+For example when running the app with `electron .`, it is `true`,
+even if the app is packaged ([`isPackaged`](app.md#appispackaged-readonly)) is `true`.
+This can be useful to determine how many arguments will need to be sliced off from `process.argv`.
 
 ### `process.isMainFrame` _Readonly_
 


### PR DESCRIPTION
#### Description of Change

Tweaked a typo in `process.defaultApp`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none