### PR TITLE
fix: A bug fix Issue #37336

### DIFF
--- a/docs/fiddles/features/keyboard-shortcuts/interception-from-main/main.js
+++ b/docs/fiddles/features/keyboard-shortcuts/interception-from-main/main.js
@@ -4,9 +4,21 @@ app.whenReady().then(() => {
   const win = new BrowserWindow({ width: 800, height: 600 })
 
   win.loadFile('index.html')
+  
+  let preventNextKeyUp = false
+
   win.webContents.on('before-input-event', (event, input) => {
     if (input.control && input.key.toLowerCase() === 'i') {
       console.log('Pressed Control+I')
+      event.preventDefault()
+      preventNextKeyUp = true
+    }
+  })
+  
+
+ win.webContents.on('keyup', (event) => {
+    if (preventNextKeyUp) {
+      preventNextKeyUp = false
       event.preventDefault()
     }
   })


### PR DESCRIPTION
#### Description of Change

In this updated code, a flag called preventNextKeyUp is introduced to keep track of whether event.preventDefault() was called in the "before-input-event" event. If event.preventDefault() was called, the flag is set to true. In the subsequent "keyup" event, if the flag is set to true, event.preventDefault() is called again to ensure that the default behavior of the key press is prevented.

#### Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/electron/electron/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://www.github.com/electron/electron/issues) for a bug report that matches the one I want to file, without success.


#### Release Notes

Notes: none