### PR TITLE
build: remove unused python code

### DIFF
--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -30,10 +30,6 @@ def get_target_arch():
   return arch
 
 
-def get_env_var(name):
-  return os.environ.get('ELECTRON_' + name, '')
-
-
 def enable_verbose_mode():
   print('Running in verbose mode')
   global verbose_mode

--- a/script/lib/native_tests.py
+++ b/script/lib/native_tests.py
@@ -121,11 +121,6 @@ class TestsList():
         for binary in binaries])
     return suite_returncode
 
-  def run_only(self, binary_name, output_dir=None, verbosity=Verbosity.CHATTY,
-      disabled_tests_policy=DisabledTestsPolicy.DISABLE):
-    return self.run([binary_name], output_dir, verbosity,
-                    disabled_tests_policy)
-
   def run_all(self, output_dir=None, verbosity=Verbosity.CHATTY,
       disabled_tests_policy=DisabledTestsPolicy.DISABLE):
     return self.run(self.get_for_current_platform(), output_dir, verbosity,

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -25,11 +25,8 @@ ELECTRON_DIR = os.path.abspath(
 TS_NODE = os.path.join(ELECTRON_DIR, 'node_modules', '.bin', 'ts-node')
 SRC_DIR = os.path.abspath(os.path.join(__file__, '..', '..', '..', '..'))
 
-NPM = 'npm'
 if sys.platform in ['win32', 'cygwin']:
-  NPM += '.cmd'
   TS_NODE += '.cmd'
-
 
 @contextlib.contextmanager
 def scoped_cwd(path):
@@ -39,18 +36,6 @@ def scoped_cwd(path):
     yield
   finally:
     os.chdir(cwd)
-
-
-@contextlib.contextmanager
-def scoped_env(key, value):
-  origin = ''
-  if key in os.environ:
-    origin = os.environ[key]
-  os.environ[key] = value
-  try:
-    yield
-  finally:
-    os.environ[key] = origin
 
 
 def download(text, url, path):


### PR DESCRIPTION
#### Description of Change

Remove unused Python functions and variables in our `script` directory. Determined with the [vulture](https://pypi.org/project/vulture/) static analyzer.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none