### PR TITLE
refactor: use associated `v8::Context` for event setup

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -270,7 +270,7 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
 
   v8::HandleScope scope(js_env_->isolate());
 
-  node_bindings_->Initialize();
+  node_bindings_->Initialize(js_env_->isolate()->GetCurrentContext());
   // Create the global environment.
   node::Environment* env = node_bindings_->CreateEnvironment(
       js_env_->isolate()->GetCurrentContext(), js_env_->platform());

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -415,7 +415,7 @@ void NodeBindings::SetNodeCliFlags() {
   }
 }
 
-void NodeBindings::Initialize() {
+void NodeBindings::Initialize(v8::Local<v8::Context> context) {
   TRACE_EVENT0("electron", "NodeBindings::Initialize");
   // Open node's error reporting system for browser process.
 
@@ -463,8 +463,7 @@ void NodeBindings::Initialize() {
     SetErrorMode(GetErrorMode() & ~SEM_NOGPFAULTERRORBOX);
 #endif
 
-  v8::Isolate* isolate = v8::Isolate::GetCurrent();
-  gin_helper::internal::Event::GetConstructor(isolate->GetCurrentContext());
+  gin_helper::internal::Event::GetConstructor(context);
 
   g_is_initialized = true;
 }

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -85,7 +85,7 @@ class NodeBindings {
   virtual ~NodeBindings();
 
   // Setup V8, libuv.
-  void Initialize();
+  void Initialize(v8::Local<v8::Context> context);
 
   void SetNodeCliFlags();
 

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -76,7 +76,7 @@ void ElectronRendererClient::DidCreateScriptContext(
 
   if (!node_integration_initialized_) {
     node_integration_initialized_ = true;
-    node_bindings_->Initialize();
+    node_bindings_->Initialize(renderer_context);
     node_bindings_->PrepareEmbedThread();
   }
 

--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -47,7 +47,7 @@ void NodeService::Initialize(node::mojom::NodeServiceParamsPtr params) {
 
   v8::HandleScope scope(js_env_->isolate());
 
-  node_bindings_->Initialize();
+  node_bindings_->Initialize(js_env_->isolate()->GetCurrentContext());
 
   // Append program path for process.argv0
   auto program = base::CommandLine::ForCurrentProcess()->GetProgram();


### PR DESCRIPTION
#### Description of Change

We should avoid `v8::Isolate::GetCurrent()` where possible, and we can instead  directly pass a Context in all cases here.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
