### PR TITLE
Fixed main.js to comply with readme example

### DIFF
--- a/docs/fiddles/ipc/pattern-1/main.js
+++ b/docs/fiddles/ipc/pattern-1/main.js
@@ -1,28 +1,24 @@
 const {app, BrowserWindow, ipcMain} = require('electron')
 const path = require('path')
 
+function handleSetTitle (event, title) {
+  const webContents = event.sender
+  const win = BrowserWindow.fromWebContents(webContents)
+  win.setTitle(title)
+}
+
 function createWindow () {
   const mainWindow = new BrowserWindow({
     webPreferences: {
       preload: path.join(__dirname, 'preload.js')
     }
   })
-
-  ipcMain.on('set-title', (event, title) => {
-    const webContents = event.sender
-    const win = BrowserWindow.fromWebContents(webContents)
-    win.setTitle(title)
-  })
-
   mainWindow.loadFile('index.html')
 }
 
 app.whenReady().then(() => {
+  ipcMain.on('set-title', handleSetTitle)
   createWindow()
-
-  app.on('activate', function () {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow()
-  })
 })
 
 app.on('window-all-closed', function () {


### PR DESCRIPTION
#### Description of Change

I got a bit confused with the exemple on of the Render to Main pattern [here](https://www.electronjs.org/docs/latest/tutorial/ipc#pattern-1-renderer-to-main-one-way) until I noticed the content provided in the first `main.js` didn't match that of the preceeding `main.js`. I attempt to fix that by bringing the code from the second main.js to the first.

#### Checklist

- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes

Notes: Fixed IPC documentation for first pattern
