### PR TITLE
fix: handle closing `webContents` in `BrowserView`s

### DIFF
--- a/shell/browser/api/electron_api_browser_view.cc
+++ b/shell/browser/api/electron_api_browser_view.cc
@@ -126,6 +126,9 @@ BrowserView::~BrowserView() {
 }
 
 void BrowserView::WebContentsDestroyed() {
+  if (owner_window())
+    owner_window()->window()->RemoveDraggableRegionProvider(this);
+
   api_web_contents_ = nullptr;
   web_contents_.Reset();
   Unpin();

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -112,6 +112,7 @@ BrowserWindow::~BrowserWindow() {
     api_web_contents_->RemoveObserver(this);
     // Destroy the WebContents.
     OnCloseContents();
+    api_web_contents_->Destroy();
   }
 }
 
@@ -139,7 +140,6 @@ void BrowserWindow::WebContentsDestroyed() {
 
 void BrowserWindow::OnCloseContents() {
   BaseWindow::ResetBrowserViews();
-  api_web_contents_->Destroy();
 }
 
 void BrowserWindow::OnRendererResponsive(content::RenderProcessHost*) {
@@ -198,7 +198,11 @@ void BrowserWindow::OnCloseButtonClicked(bool* prevent_default) {
 
   // Trigger beforeunload events for associated BrowserViews.
   for (NativeBrowserView* view : window_->browser_views()) {
-    auto* vwc = view->GetInspectableWebContents()->GetWebContents();
+    auto* iwc = view->GetInspectableWebContents();
+    if (!iwc)
+      continue;
+
+    auto* vwc = iwc->GetWebContents();
     auto* api_web_contents = api::WebContents::From(vwc);
 
     // Required to make beforeunload handler work.

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1222,9 +1222,7 @@ void WebContents::CloseContents(content::WebContents* source) {
   for (ExtendedWebContentsObserver& observer : observers_)
     observer.OnCloseContents();
 
-  // If there are observers, OnCloseContents will call Destroy()
-  if (observers_.empty())
-    Destroy();
+  Destroy();
 }
 
 void WebContents::ActivateContents(content::WebContents* source) {

--- a/spec/api-browser-view-spec.ts
+++ b/spec/api-browser-view-spec.ts
@@ -345,6 +345,15 @@ describe('BrowserView module', () => {
       const [code] = await once(rc.process, 'exit');
       expect(code).to.equal(0);
     });
+
+    it('emits the destroyed event when webContents.close() is called', async () => {
+      view = new BrowserView();
+      w.setBrowserView(view);
+      await view.webContents.loadFile(path.join(fixtures, 'pages', 'a.html'));
+
+      view.webContents.close();
+      await once(view.webContents, 'destroyed');
+    });
   });
 
   describe('window.open()', () => {

--- a/spec/api-browser-view-spec.ts
+++ b/spec/api-browser-view-spec.ts
@@ -354,6 +354,15 @@ describe('BrowserView module', () => {
       view.webContents.close();
       await once(view.webContents, 'destroyed');
     });
+
+    it('emits the destroyed event when window.close() is called', async () => {
+      view = new BrowserView();
+      w.setBrowserView(view);
+      await view.webContents.loadFile(path.join(fixtures, 'pages', 'a.html'));
+
+      view.webContents.executeJavaScript('window.close()');
+      await once(view.webContents, 'destroyed');
+    });
   });
 
   describe('window.open()', () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/37356.
Closes https://github.com/electron/electron/issues/37419.
Closes https://github.com/electron/electron/issues/37378.
Refs https://github.com/electron/electron/pull/37205.

Take 2. 

The combination of https://github.com/electron/electron/pull/35509 and https://github.com/electron/electron/pull/35603 meant that if a user called `webContents.destroy()` on a `BrowserView`'s `webContents`, the associated `DraggableRegionProvider` would not be removed from the `NativeWindow`, as the only codepath for doing so relied on the user removing the _entire_ `BrowserView` via `BrowserWindow.removeBrowserView`. The first approach I tried fixed a symptom, but then prevented the `destroyed` event from emitting if a `BrowserView` still existed.

This PR undoes that change in favor of this better change, which ensures the `DraggableRegionProvider` isn't left around for a ghost `BrowserView` `webContents`.

Tested with:
- https://gist.github.com/YauheniBH-EF/190ea8ff42c09a15763705ed4647b02e to prevent regression of https://github.com/electron/electron/issues/37162
- https://gist.github.com/mgalla10/cdff38e750ae49d01500445b019493ca

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `destroyed` event not emitted on `close` for `BrowserView.webContents`.