### PR TITLE
fix: DCHECK in MessageSync in rare cases

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1837,22 +1837,23 @@ class ReplyChannel : public gin::Wrappable<ReplyChannel> {
   }
   const char* GetTypeName() override { return "ReplyChannel"; }
 
+  void SendError(const std::string& msg) {
+    v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
+    // If there's no current context, it means we're shutting down, so we
+    // don't need to send an event.
+    if (!isolate->GetCurrentContext().IsEmpty()) {
+      v8::HandleScope scope(isolate);
+      auto message = gin::DataObjectBuilder(isolate).Set("error", msg).Build();
+      SendReply(isolate, message);
+    }
+  }
+
  private:
   explicit ReplyChannel(InvokeCallback callback)
       : callback_(std::move(callback)) {}
   ~ReplyChannel() override {
-    if (callback_) {
-      v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
-      // If there's no current context, it means we're shutting down, so we
-      // don't need to send an event.
-      if (!isolate->GetCurrentContext().IsEmpty()) {
-        v8::HandleScope scope(isolate);
-        auto message = gin::DataObjectBuilder(isolate)
-                           .Set("error", "reply was never sent")
-                           .Build();
-        SendReply(isolate, message);
-      }
-    }
+    if (callback_)
+      SendError("reply was never sent");
   }
 
   bool SendReply(v8::Isolate* isolate, v8::Local<v8::Value> arg) {
@@ -1877,8 +1878,14 @@ gin::Handle<gin_helper::internal::Event> WebContents::MakeEventWithSender(
     content::RenderFrameHost* frame,
     electron::mojom::ElectronApiIPC::InvokeCallback callback) {
   v8::Local<v8::Object> wrapper;
-  if (!GetWrapper(isolate).ToLocal(&wrapper))
+  if (!GetWrapper(isolate).ToLocal(&wrapper)) {
+    if (callback) {
+      // We must always invoke the callback if present.
+      ReplyChannel::Create(isolate, std::move(callback))
+          ->SendError("WebContents was destroyed");
+    }
     return gin::Handle<gin_helper::internal::Event>();
+  }
   gin::Handle<gin_helper::internal::Event> event =
       gin_helper::internal::Event::New(isolate);
   gin_helper::Dictionary dict(isolate, event.ToV8().As<v8::Object>());


### PR DESCRIPTION
#### Description of Change

The InvokeCallback _must_ be called before it's destroyed; this was the only
path I could see that could possibly result in the callback being destroyed
before being called. Hopefully this fixes DCHECKs we've been seeing
occasionally in CI.

Notes: none
