### PR TITLE
fix: don't double-log unhandled rejections

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -279,7 +279,7 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
   env->set_trace_sync_io(env->options()->trace_sync_io);
 
   // We do not want to crash the main process on unhandled rejections.
-  env->options()->unhandled_rejections = "warn";
+  env->options()->unhandled_rejections = "warn-with-error-code";
 
   // Add Electron extended APIs.
   electron_bindings_->BindTo(js_env_->isolate(), env->process_object());

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -96,7 +96,7 @@ void ElectronRendererClient::DidCreateScriptContext(
   env->options()->force_context_aware = true;
 
   // We do not want to crash the renderer process on unhandled rejections.
-  env->options()->unhandled_rejections = "warn";
+  env->options()->unhandled_rejections = "warn-with-error-code";
 
   environments_.insert(env);
 

--- a/spec/fixtures/api/unhandled-rejection-handled.js
+++ b/spec/fixtures/api/unhandled-rejection-handled.js
@@ -1,0 +1,13 @@
+const { app } = require('electron');
+
+const handleUnhandledRejection = (reason) => {
+  console.error(`Unhandled Rejection: ${reason.stack}`);
+  app.quit();
+};
+
+const main = async () => {
+  process.on('unhandledRejection', handleUnhandledRejection);
+  throw new Error('oops');
+};
+
+main();

--- a/spec/fixtures/api/unhandled-rejection.js
+++ b/spec/fixtures/api/unhandled-rejection.js
@@ -1,0 +1,5 @@
+const main = async () => {
+  throw new Error('oops');
+};
+
+main();

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -226,6 +226,42 @@ describe('node feature', () => {
         }));
         expect(result).to.equal('hello');
       });
+
+      it('does not log the warning more than once when the rejection is unhandled', async () => {
+        const appPath = path.join(mainFixturesPath, 'api', 'unhandled-rejection.js');
+        const appProcess = childProcess.spawn(process.execPath, [appPath]);
+
+        let output = '';
+        const out = (data: string) => {
+          output += data;
+          if (/UnhandledPromiseRejectionWarning/.test(data)) {
+            appProcess.kill();
+          }
+        };
+        appProcess.stdout!.on('data', out);
+        appProcess.stderr!.on('data', out);
+
+        await once(appProcess, 'exit');
+        expect(/UnhandledPromiseRejectionWarning/.test(output)).to.equal(true);
+        const matches = output.match(/Error: oops/gm);
+        expect(matches).to.have.lengthOf(1);
+      });
+
+      it('does not log the warning more than once when the rejection is handled', async () => {
+        const appPath = path.join(mainFixturesPath, 'api', 'unhandled-rejection-handled.js');
+        const appProcess = childProcess.spawn(process.execPath, [appPath]);
+
+        let output = '';
+        const out = (data: string) => { output += data; };
+        appProcess.stdout!.on('data', out);
+        appProcess.stderr!.on('data', out);
+
+        const [code] = await once(appProcess, 'exit');
+        expect(code).to.equal(0);
+        expect(/UnhandledPromiseRejectionWarning/.test(output)).to.equal(false);
+        const matches = output.match(/Error: oops/gm);
+        expect(matches).to.have.lengthOf(1);
+      });
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/36829.

Switches from unhandled rejection style from `warn` to `warn-with-error-code`. The `warn` mode always triggers a warning, no matter if the `unhandledRejection` hook is set or not - this isn't really intuitive behavior. We added this initially in https://github.com/electron/electron/pull/29244, because Node.js themselves switched their unhandled rejection behavior to throw by default and we didn't want unhandled rejections to crash the main or renderer processes. `warn-with-error-code` now only warns if the error is not handled with the `unhandledRejection` hook - it also sets the process exit code to 1, but this doesn't affect Electron as it sets its own exit code.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where unhandled rejections could cause duplicate logs in some cases.
