### PR TITLE
chore: cherry-pick e79b89b47dac from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -146,3 +146,4 @@ cherry-pick-43637378b14e.patch
 cherry-pick-57c54ae221d6.patch
 cherry-pick-ca2b108a0f1f.patch
 cherry-pick-d652130c4bc2.patch
+cherry-pick-e79b89b47dac.patch

--- a/patches/chromium/cherry-pick-e79b89b47dac.patch
+++ b/patches/chromium/cherry-pick-e79b89b47dac.patch
@@ -1,0 +1,59 @@
+From e79b89b47dacd0efe12cd0a8328a53f62d1a3a9c Mon Sep 17 00:00:00 2001
+From: Vasiliy Telezhnikov <vasilyt@chromium.org>
+Date: Fri, 10 Feb 2023 17:36:57 +0000
+Subject: [PATCH] CHECK that YUV readback finished synchronously
+
+DoReadbackYUVImagePixelsINTERNAL is implemented using skia asynchronous
+readback and to make it synchronous we use sync cpu and gpu. In some
+edge cases on linux we saw that doesn't happen if readback triggered
+vulkan device lost.
+
+To avoid use after free, CHECK that callback was actually called. In
+case of device-lost gpu process will restart anyway, so while this is
+not proper fix of the problem, it doesn't result in worse user visible
+behaviour.
+
+(cherry picked from commit 081df1e7d3712131bcaa575bda2e37ec7f6aa83d)
+
+Bug: 1399742
+Change-Id: Ie2172539bb907b9696ef62c70d398aca3967177c
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4143606
+Reviewed-by: Peng Huang <penghuang@chromium.org>
+Commit-Queue: Vasiliy Telezhnikov <vasilyt@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1093064}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4239960
+Cr-Commit-Position: refs/branch-heads/5481@{#1084}
+Cr-Branched-From: 130f3e4d850f4bc7387cfb8d08aa993d288a67a9-refs/heads/main@{#1084008}
+---
+
+diff --git a/gpu/command_buffer/service/raster_decoder.cc b/gpu/command_buffer/service/raster_decoder.cc
+index bd5d2b5..0c530ff 100644
+--- a/gpu/command_buffer/service/raster_decoder.cc
++++ b/gpu/command_buffer/service/raster_decoder.cc
+@@ -2533,6 +2533,7 @@
+ namespace {
+ struct YUVReadbackResult {
+   std::unique_ptr<const SkImage::AsyncReadResult> async_result;
++  bool finished = false;
+ };
+ 
+ void OnReadYUVImagePixelsDone(
+@@ -2540,6 +2541,7 @@
+     std::unique_ptr<const SkImage::AsyncReadResult> async_result) {
+   YUVReadbackResult* context = reinterpret_cast<YUVReadbackResult*>(raw_ctx);
+   context->async_result = std::move(async_result);
++  context->finished = true;
+ }
+ }  // namespace
+ 
+@@ -2737,6 +2739,10 @@
+   // asynchronous by removing this flush and implementing a query that can
+   // signal back to client process.
+   gr_context()->flushAndSubmit(true);
++
++  // The call above will sync up gpu and CPU, resulting in callback being run
++  // during flushAndSubmit. To prevent UAF make sure it indeed happened.
++  CHECK(yuv_result.finished);
+   if (!yuv_result.async_result) {
+     LOCAL_SET_GL_ERROR(GL_INVALID_OPERATION, "glReadbackYUVImagePixels",
+                        "Failed to read pixels from SkImage");

--- a/patches/chromium/cherry-pick-e79b89b47dac.patch
+++ b/patches/chromium/cherry-pick-e79b89b47dac.patch
@@ -1,7 +1,7 @@
-From e79b89b47dacd0efe12cd0a8328a53f62d1a3a9c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Vasiliy Telezhnikov <vasilyt@chromium.org>
 Date: Fri, 10 Feb 2023 17:36:57 +0000
-Subject: [PATCH] CHECK that YUV readback finished synchronously
+Subject: CHECK that YUV readback finished synchronously
 
 DoReadbackYUVImagePixelsINTERNAL is implemented using skia asynchronous
 readback and to make it synchronous we use sync cpu and gpu. In some
@@ -24,13 +24,12 @@ Cr-Original-Commit-Position: refs/heads/main@{#1093064}
 Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4239960
 Cr-Commit-Position: refs/branch-heads/5481@{#1084}
 Cr-Branched-From: 130f3e4d850f4bc7387cfb8d08aa993d288a67a9-refs/heads/main@{#1084008}
----
 
 diff --git a/gpu/command_buffer/service/raster_decoder.cc b/gpu/command_buffer/service/raster_decoder.cc
-index bd5d2b5..0c530ff 100644
+index 23260eb92a8f09159dadb1167d8f2a90a6fd21c6..ecfbf5d92a8aa738aea5d26af82d3c1d2e7c04be 100644
 --- a/gpu/command_buffer/service/raster_decoder.cc
 +++ b/gpu/command_buffer/service/raster_decoder.cc
-@@ -2533,6 +2533,7 @@
+@@ -2680,6 +2680,7 @@ void RasterDecoderImpl::DoReadbackARGBImagePixelsINTERNAL(
  namespace {
  struct YUVReadbackResult {
    std::unique_ptr<const SkImage::AsyncReadResult> async_result;
@@ -38,7 +37,7 @@ index bd5d2b5..0c530ff 100644
  };
  
  void OnReadYUVImagePixelsDone(
-@@ -2540,6 +2541,7 @@
+@@ -2687,6 +2688,7 @@ void OnReadYUVImagePixelsDone(
      std::unique_ptr<const SkImage::AsyncReadResult> async_result) {
    YUVReadbackResult* context = reinterpret_cast<YUVReadbackResult*>(raw_ctx);
    context->async_result = std::move(async_result);
@@ -46,7 +45,7 @@ index bd5d2b5..0c530ff 100644
  }
  }  // namespace
  
-@@ -2737,6 +2739,10 @@
+@@ -2884,6 +2886,10 @@ void RasterDecoderImpl::DoReadbackYUVImagePixelsINTERNAL(
    // asynchronous by removing this flush and implementing a query that can
    // signal back to client process.
    gr_context()->flushAndSubmit(true);


### PR DESCRIPTION
CHECK that YUV readback finished synchronously

DoReadbackYUVImagePixelsINTERNAL is implemented using skia asynchronous
readback and to make it synchronous we use sync cpu and gpu. In some
edge cases on linux we saw that doesn't happen if readback triggered
vulkan device lost.

To avoid use after free, CHECK that callback was actually called. In
case of device-lost gpu process will restart anyway, so while this is
not proper fix of the problem, it doesn't result in worse user visible
behaviour.

(cherry picked from commit 081df1e7d3712131bcaa575bda2e37ec7f6aa83d)

Bug: 1399742
Change-Id: Ie2172539bb907b9696ef62c70d398aca3967177c
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4143606
Reviewed-by: Peng Huang <penghuang@chromium.org>
Commit-Queue: Vasiliy Telezhnikov <vasilyt@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1093064}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4239960
Cr-Commit-Position: refs/branch-heads/5481@{#1084}
Cr-Branched-From: 130f3e4d850f4bc7387cfb8d08aa993d288a67a9-refs/heads/main@{#1084008}


Ref electron/security#283

Notes: Security: backported fix for CVE-2023-0929.