### PR TITLE
fix: crash when using vm after `window.open()`

### DIFF
--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -96,7 +96,7 @@ void ElectronRenderFrameObserver::DidInstallConditionalFeatures(
   // actual page has started to load.
   auto* web_frame =
       static_cast<blink::WebLocalFrameImpl*>(render_frame_->GetWebFrame());
-  if (web_frame->Opener() && web_frame->IsOnInitialEmptyDocument()) {
+  if (web_frame->Opener()) {
     // FIXME(zcbenz): Chromium does not do any browser side navigation for
     // window.open('about:blank'), so there is no way to override WebPreferences
     // of it. We should not delay Node.js initialization as there will be no
@@ -104,7 +104,11 @@ void ElectronRenderFrameObserver::DidInstallConditionalFeatures(
     // Please check http://crbug.com/1215096 for updates which may help remove
     // this hack.
     GURL url = web_frame->GetDocument().Url();
-    if (!url.IsAboutBlank()) {
+    bool is_only_initially_blank =
+        web_frame->IsOnInitialEmptyDocument() && !url.IsAboutBlank();
+    bool is_intentionally_blank =
+        !web_frame->IsOnInitialEmptyDocument() && url.IsAboutBlank();
+    if (is_only_initially_blank || is_intentionally_blank) {
       has_delayed_node_initialization_ = true;
       return;
     }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/37404.
Refs https://github.com/electron/electron/pull/32057.

Fixes a potential crash when using the `vm` module in the renderer process after calling `window.open('')`. This started happening after https://github.com/nodejs/node/pull/44252, which we rolled into Electron via https://github.com/electron/electron/commit/75d2caf451c925a826229ae27264c9b54de9b6db. It appears that eagerly loading the Node.js environment when opening a child window with a blank url also requires a delay, otherwise Node.js isn't able to properly set up the `v8::Context` for use with vm.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash when using the `vm` module in the renderer process after calling `window.open('')`.
