### PR TITLE
fix: fallback to X11 capturer if pipewire fails on Wayland

### DIFF
--- a/patches/config.json
+++ b/patches/config.json
@@ -21,5 +21,7 @@
 
   "src/electron/patches/Mantle": "src/third_party/squirrel.mac/vendor/Mantle",
 
-  "src/electron/patches/ReactiveObjC": "src/third_party/squirrel.mac/vendor/ReactiveObjC"
+  "src/electron/patches/ReactiveObjC": "src/third_party/squirrel.mac/vendor/ReactiveObjC",
+
+  "src/electron/patches/webrtc": "src/third_party/webrtc"
 }

--- a/patches/webrtc/.patches
+++ b/patches/webrtc/.patches
@@ -1,0 +1,1 @@
+fix_fallback_to_x11_capturer_on_wayland.patch

--- a/patches/webrtc/fix_fallback_to_x11_capturer_on_wayland.patch
+++ b/patches/webrtc/fix_fallback_to_x11_capturer_on_wayland.patch
@@ -9,10 +9,9 @@ Desktop Capturer behaves inconsistently on Wayland. PipeWire does not
 always successfully start; if it does not, we return a nullptr rather
 than falling back on the X11 capturer, crashing the application.
 
-In addition to this patch, we should also more gracefully handle the
-nullptr return to avoid a hard crash. However, at minimum, we should
-try to fallback to X11 for desktop capturer, rather than just defaulting
-to nullptr.
+If the X11 capturer is enabled, we should at minimum try to fallback
+to X11 for desktop capturer. This patch re-enables that fallback,
+which was previously default behavior.
 
 This patch can be removed when 1) this fix is upstreamed, or 2) the
 stability of PipeWire initialization is improved upstream.

--- a/patches/webrtc/fix_fallback_to_x11_capturer_on_wayland.patch
+++ b/patches/webrtc/fix_fallback_to_x11_capturer_on_wayland.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: VerteDinde <keeleymhammond@gmail.com>
+Date: Sun, 5 Mar 2023 21:04:37 -0800
+Subject: fix: fallback to X11 capturer on Wayland
+
+CL: https://webrtc-review.googlesource.com/c/src/+/279163
+
+Desktop Capturer behaves inconsistently on Wayland. PipeWire does not
+always successfully start; if it does not, we return a nullptr rather
+than falling back on the X11 capturer, crashing the application.
+
+In addition to this patch, we should also more gracefully handle the
+nullptr return to avoid a hard crash. However, at minimum, we should
+try to fallback to X11 for desktop capturer, rather than just defaulting
+to nullptr.
+
+This patch can be removed when 1) this fix is upstreamed, or 2) the
+stability of PipeWire initialization is improved upstream.
+
+Patch_Filename: fix_fallback_to_x11_desktop_capturer_wayland.patch
+
+diff --git a/modules/desktop_capture/screen_capturer_linux.cc b/modules/desktop_capture/screen_capturer_linux.cc
+index 44993837e8bbd84a11ec9d187349a95f83258910..cd9f8b0be6a19d057fe9150382fb72bc4032b343 100644
+--- a/modules/desktop_capture/screen_capturer_linux.cc
++++ b/modules/desktop_capture/screen_capturer_linux.cc
+@@ -34,11 +34,10 @@ std::unique_ptr<DesktopCapturer> DesktopCapturer::CreateRawScreenCapturer(
+ #endif  // defined(WEBRTC_USE_PIPEWIRE)
+ 
+ #if defined(WEBRTC_USE_X11)
+-  if (!DesktopCapturer::IsRunningUnderWayland())
+-    return ScreenCapturerX11::CreateRawScreenCapturer(options);
+-#endif  // defined(WEBRTC_USE_X11)
+-
++  return ScreenCapturerX11::CreateRawScreenCapturer(options);
++#else
+   return nullptr;
++#endif  // defined(WEBRTC_USE_X11)
+ }
+ 
+ }  // namespace webrtc
+diff --git a/modules/desktop_capture/window_capturer_linux.cc b/modules/desktop_capture/window_capturer_linux.cc
+index 4205bf9bc0eede48cdc39353c77ceb6e7529fd51..785dc01a1911fd027401b1461223668333e05558 100644
+--- a/modules/desktop_capture/window_capturer_linux.cc
++++ b/modules/desktop_capture/window_capturer_linux.cc
+@@ -34,11 +34,10 @@ std::unique_ptr<DesktopCapturer> DesktopCapturer::CreateRawWindowCapturer(
+ #endif  // defined(WEBRTC_USE_PIPEWIRE)
+ 
+ #if defined(WEBRTC_USE_X11)
+-  if (!DesktopCapturer::IsRunningUnderWayland())
+-    return WindowCapturerX11::CreateRawWindowCapturer(options);
+-#endif  // defined(WEBRTC_USE_X11)
+-
++  return WindowCapturerX11::CreateRawWindowCapturer(options);
++#else
+   return nullptr;
++#endif  // defined(WEBRTC_USE_X11)
+ }
+ 
+ }  // namespace webrtc

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -207,27 +207,31 @@ void DesktopCapturer::StartHandling(bool capture_window,
     // Initialize the source list.
     // Apply the new thumbnail size and restart capture.
     if (capture_window) {
-      window_capturer_ = std::make_unique<NativeDesktopMediaList>(
-          DesktopMediaList::Type::kWindow,
-          content::desktop_capture::CreateWindowCapturer());
-      window_capturer_->SetThumbnailSize(thumbnail_size);
-      window_capturer_->Update(
-          base::BindOnce(&DesktopCapturer::UpdateSourcesList,
-                         weak_ptr_factory_.GetWeakPtr(),
-                         window_capturer_.get()),
-          /* refresh_thumbnails = */ true);
+      if (auto capturer = content::desktop_capture::CreateWindowCapturer();
+          capturer) {
+        window_capturer_ = std::make_unique<NativeDesktopMediaList>(
+            DesktopMediaList::Type::kWindow, std::move(capturer));
+        window_capturer_->SetThumbnailSize(thumbnail_size);
+        window_capturer_->Update(
+            base::BindOnce(&DesktopCapturer::UpdateSourcesList,
+                           weak_ptr_factory_.GetWeakPtr(),
+                           window_capturer_.get()),
+            /* refresh_thumbnails = */ true);
+      }
     }
 
     if (capture_screen) {
-      screen_capturer_ = std::make_unique<NativeDesktopMediaList>(
-          DesktopMediaList::Type::kScreen,
-          content::desktop_capture::CreateScreenCapturer());
-      screen_capturer_->SetThumbnailSize(thumbnail_size);
-      screen_capturer_->Update(
-          base::BindOnce(&DesktopCapturer::UpdateSourcesList,
-                         weak_ptr_factory_.GetWeakPtr(),
-                         screen_capturer_.get()),
-          /* refresh_thumbnails = */ true);
+      if (auto capturer = content::desktop_capture::CreateScreenCapturer();
+          capturer) {
+        screen_capturer_ = std::make_unique<NativeDesktopMediaList>(
+            DesktopMediaList::Type::kScreen, std::move(capturer));
+        screen_capturer_->SetThumbnailSize(thumbnail_size);
+        screen_capturer_->Update(
+            base::BindOnce(&DesktopCapturer::UpdateSourcesList,
+                           weak_ptr_factory_.GetWeakPtr(),
+                           screen_capturer_.get()),
+            /* refresh_thumbnails = */ true);
+      }
     }
   }
 }


### PR DESCRIPTION
#### Description of Change

Closes #37463 

Desktop Capturer behaves inconsistently on Wayland. We use PipeWire within WebRTC on Wayland to gather desktop window & screen capture sources. However, PipeWire does not always successfully start, and beginning with this CL, we no longer fall back to the X11 capturer, even if it is enabled: https://webrtc-review.googlesource.com/c/src/+/279163

Currently if neither PipeWire or X11 can be used, we return a nullptr in place of the capturer sources, crashing the application.

This PR does two things:
1. Reinstates the previous fallback behavior in WebRTC, so that if PipeWire fails on Wayland, we can still attempt to gather capture sources, rather than simply failing. I'll submit this as a patch for upstream consideration as well.
2. Ensures that a lower level capturer of some kind exists before trying to create one within Electron's `DesktopCapturer::StartHandling` method. (Thanks @ckerr!)


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash on capturing sources when using desktopCapturer API on Wayland.
