### PR TITLE
docs: remove misleading info from will-finish-launching docs

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -23,8 +23,7 @@ The `app` object emits the following events:
 Emitted when the application has finished basic startup. On Windows and Linux,
 the `will-finish-launching` event is the same as the `ready` event; on macOS,
 this event represents the `applicationWillFinishLaunching` notification of
-`NSApplication`. You would usually set up listeners for the `open-file` and
-`open-url` events here, and start the crash reporter and auto updater.
+`NSApplication`.
 
 In most cases, you should do everything in the `ready` event handler.
 


### PR DESCRIPTION
#### Description of Change

crashReporter and open-url handlers should be registered before ready.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none