### PR TITLE
fix: don't set delegate for `QLPreviewPanel`

### DIFF
--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -276,12 +276,10 @@ void SwizzleMouseDown(NSView* frame_view,
 }
 
 - (void)beginPreviewPanelControl:(QLPreviewPanel*)panel {
-  panel.delegate = [self delegate];
   panel.dataSource = static_cast<id<QLPreviewPanelDataSource>>([self delegate]);
 }
 
 - (void)endPreviewPanelControl:(QLPreviewPanel*)panel {
-  panel.delegate = nil;
   panel.dataSource = nil;
 }
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5275,6 +5275,22 @@ describe('BrowserWindow module', () => {
         w.closeFilePreview();
       }).to.not.throw();
     });
+
+    it('should not call BrowserWindow show event', async () => {
+      const w = new BrowserWindow({ show: false });
+      const shown = once(w, 'show');
+      w.show();
+      await shown;
+
+      let showCalled = false;
+      w.on('show', () => {
+        showCalled = true;
+      });
+
+      w.previewFile(__filename);
+      await setTimeout(500);
+      expect(showCalled).to.equal(false, 'should not have called show twice');
+    });
   });
 
   // TODO (jkleinsc) renable these tests on mas arm64


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/37476

The QuickLook NSWindow's delegate is set to the same object as the delegate for the BrowserWindow's NSWindow [here](https://github.com/electron/electron/blob/f5385bcdec1951db34f8e55754265701530f5888/shell/browser/ui/cocoa/electron_ns_window.mm#L279). The delegate's [handler for windowDidChangeOcclusionState](https://github.com/electron/electron/blob/99f6ff430f57683ad0a240045c3cfbfbb8d67686/shell/browser/ui/cocoa/electron_ns_window_delegate.mm#L44) doesn't seem to expect handling events for the QuickLook window, and so when the QuickLook window becomes occluded, it assumes that the BrowserWindow has been occluded.

There's a similar issue for other NSWindowDelegate methods besides windowDidChangeOcclusionState. So resizing/moving the QuickLook window will cause the BrowserWindow's resize/will-resize/resized/move/will-move/moved events to fire.

The code has moved around a bit but I think this may have existed since BrowserWindow.previewFile was added in 2016 in https://github.com/electron/electron/pull/7592. FYI @lauracpierre @zcbenz @bengotow

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed issue with BrowserWindow not updating after call to previewFile. <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
