### PR TITLE
docs: updated package.json content and electron version in build first app guide

### DIFF
--- a/docs/tutorial/tutorial-2-first-app.md
+++ b/docs/tutorial/tutorial-2-first-app.md
@@ -81,10 +81,13 @@ the exact dependency versions to install.
   "version": "1.0.0",
   "description": "Hello World!",
   "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
   "author": "Jane Doe",
   "license": "MIT",
   "devDependencies": {
-    "electron": "19.0.0"
+    "electron": "^23.1.3"
   }
 }
 ```
@@ -137,13 +140,14 @@ script in the current directory and run it in dev mode.
   "version": "1.0.0",
   "description": "Hello World!",
   "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
   "author": "Jane Doe",
   "license": "MIT",
-  "scripts": {
-    "start": "electron ."
-  },
   "devDependencies": {
-    "electron": "^19.0.0"
+    "electron": "^23.1.3"
   }
 }
 ```

--- a/docs/tutorial/tutorial-2-first-app.md
+++ b/docs/tutorial/tutorial-2-first-app.md
@@ -87,7 +87,7 @@ the exact dependency versions to install.
   "author": "Jane Doe",
   "license": "MIT",
   "devDependencies": {
-    "electron": "^23.1.3"
+    "electron": "23.1.3"
   }
 }
 ```
@@ -147,7 +147,7 @@ script in the current directory and run it in dev mode.
   "author": "Jane Doe",
   "license": "MIT",
   "devDependencies": {
-    "electron": "^23.1.3"
+    "electron": "23.1.3"
   }
 }
 ```


### PR DESCRIPTION
#### Description of Change

The Building your First App guide states: "Your package.json file should look something like this after initializing your package and installing Electron." then `package.json` content is shown, but it is not up to date with how it looks now when creating the app by using the commands provided in the guide and the default values. This was corrected by adding:
```
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
```
which is added by default while `npm init`. Also bumped the electron version. 

#### Checklist

- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

notes: no-notes