### PR TITLE
docs: clarify `open-url` not preventable

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -127,8 +127,6 @@ Emitted when the user wants to open a URL with the application. Your application
 `Info.plist` file must define the URL scheme within the `CFBundleURLTypes` key, and
 set `NSPrincipalClass` to `AtomApplication`.
 
-You should call `event.preventDefault()` if you want to handle this event.
-
 As with the `open-file` event, be sure to register a listener for the `open-url`
 event early in your application startup to detect if the the application being
 is being opened to handle a URL. If you register the listener in response to a


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/37495.

Clarifies that `open-url` is not in fact preventable and has never been.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.