### PR TITLE
refactor: replace deprecated base::Value::Set<Type>Key usage

### DIFF
--- a/shell/browser/hid/hid_chooser_context.cc
+++ b/shell/browser/hid/hid_chooser_context.cc
@@ -70,23 +70,23 @@ bool HidChooserContext::CanStorePersistentEntry(
 // static
 base::Value HidChooserContext::DeviceInfoToValue(
     const device::mojom::HidDeviceInfo& device) {
-  base::Value value(base::Value::Type::DICT);
-  value.SetStringKey(
+  base::Value::Dict value;
+  value.Set(
       kHidDeviceNameKey,
       base::UTF16ToUTF8(HidChooserContext::DisplayNameFromDeviceInfo(device)));
-  value.SetIntKey(kDeviceVendorIdKey, device.vendor_id);
-  value.SetIntKey(kDeviceProductIdKey, device.product_id);
+  value.Set(kDeviceVendorIdKey, device.vendor_id);
+  value.Set(kDeviceProductIdKey, device.product_id);
   if (HidChooserContext::CanStorePersistentEntry(device)) {
     // Use the USB serial number as a persistent identifier. If it is
     // unavailable, only ephemeral permissions may be granted.
-    value.SetStringKey(kDeviceSerialNumberKey, device.serial_number);
+    value.Set(kDeviceSerialNumberKey, device.serial_number);
   } else {
     // The GUID is a temporary ID created on connection that remains valid until
     // the device is disconnected. Ephemeral permissions are keyed by this ID
     // and must be granted again each time the device is connected.
-    value.SetStringKey(kHidGuidKey, device.guid);
+    value.Set(kHidGuidKey, device.guid);
   }
-  return value;
+  return base::Value(std::move(value));
 }
 
 void HidChooserContext::GrantDevicePermission(

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -97,12 +97,12 @@ const size_t kMaxMessageChunkSize = IPC::Channel::kMaximumMessageSize / 4;
 InspectableWebContents::List g_web_contents_instances_;
 
 base::Value RectToDictionary(const gfx::Rect& bounds) {
-  base::Value dict(base::Value::Type::DICT);
-  dict.SetKey("x", base::Value(bounds.x()));
-  dict.SetKey("y", base::Value(bounds.y()));
-  dict.SetKey("width", base::Value(bounds.width()));
-  dict.SetKey("height", base::Value(bounds.height()));
-  return dict;
+  base::Value::Dict dict;
+  dict.Set("x", bounds.x());
+  dict.Set("y", bounds.y());
+  dict.Set("width", bounds.width());
+  dict.Set("height", bounds.height());
+  return base::Value(std::move(dict));
 }
 
 gfx::Rect DictionaryToRect(const base::Value::Dict& dict) {
@@ -895,7 +895,7 @@ void InspectableWebContents::ClearPreferences() {
 
 void InspectableWebContents::GetSyncInformation(DispatchCallback callback) {
   base::Value result(base::Value::Type::DICT);
-  result.SetBoolKey("isSyncActive", false);
+  result.GetDict().Set("isSyncActive", false);
   std::move(callback).Run(&result);
 }
 

--- a/shell/browser/usb/usb_chooser_context.cc
+++ b/shell/browser/usb/usb_chooser_context.cc
@@ -82,40 +82,35 @@ UsbChooserContext::UsbChooserContext(ElectronBrowserContext* context)
 // static
 base::Value UsbChooserContext::DeviceInfoToValue(
     const device::mojom::UsbDeviceInfo& device_info) {
-  base::Value device_value(base::Value::Type::DICT);
-  device_value.SetStringKey(kDeviceNameKey, device_info.product_name
-                                                ? *device_info.product_name
-                                                : base::StringPiece16());
-  device_value.SetIntKey(kDeviceVendorIdKey, device_info.vendor_id);
-  device_value.SetIntKey(kDeviceProductIdKey, device_info.product_id);
+  base::Value::Dict device_value;
+  device_value.Set(kDeviceNameKey, device_info.product_name
+                                       ? *device_info.product_name
+                                       : base::StringPiece16());
+  device_value.Set(kDeviceVendorIdKey, device_info.vendor_id);
+  device_value.Set(kDeviceProductIdKey, device_info.product_id);
 
   if (device_info.manufacturer_name) {
-    device_value.SetStringKey("manufacturerName",
-                              *device_info.manufacturer_name);
+    device_value.Set("manufacturerName", *device_info.manufacturer_name);
   }
 
   // CanStorePersistentEntry checks if |device_info.serial_number| is not empty.
   if (CanStorePersistentEntry(device_info)) {
-    device_value.SetStringKey(kDeviceSerialNumberKey,
-                              *device_info.serial_number);
+    device_value.Set(kDeviceSerialNumberKey, *device_info.serial_number);
   }
 
-  device_value.SetStringKey(kDeviceIdKey, device_info.guid);
+  device_value.Set(kDeviceIdKey, device_info.guid);
 
-  device_value.SetIntKey("usbVersionMajor", device_info.usb_version_major);
-  device_value.SetIntKey("usbVersionMinor", device_info.usb_version_minor);
-  device_value.SetIntKey("usbVersionSubminor",
-                         device_info.usb_version_subminor);
-  device_value.SetIntKey("deviceClass", device_info.class_code);
-  device_value.SetIntKey("deviceSubclass", device_info.subclass_code);
-  device_value.SetIntKey("deviceProtocol", device_info.protocol_code);
-  device_value.SetIntKey("deviceVersionMajor",
-                         device_info.device_version_major);
-  device_value.SetIntKey("deviceVersionMinor",
-                         device_info.device_version_minor);
-  device_value.SetIntKey("deviceVersionSubminor",
-                         device_info.device_version_subminor);
-  return device_value;
+  device_value.Set("usbVersionMajor", device_info.usb_version_major);
+  device_value.Set("usbVersionMinor", device_info.usb_version_minor);
+  device_value.Set("usbVersionSubminor", device_info.usb_version_subminor);
+  device_value.Set("deviceClass", device_info.class_code);
+  device_value.Set("deviceSubclass", device_info.subclass_code);
+  device_value.Set("deviceProtocol", device_info.protocol_code);
+  device_value.Set("deviceVersionMajor", device_info.device_version_major);
+  device_value.Set("deviceVersionMinor", device_info.device_version_minor);
+  device_value.Set("deviceVersionSubminor",
+                   device_info.device_version_subminor);
+  return base::Value(std::move(device_value));
 }
 
 void UsbChooserContext::InitDeviceList(

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -389,28 +389,23 @@ void WebContentsPreferences::AppendCommandLineSwitches(
 }
 
 void WebContentsPreferences::SaveLastPreferences() {
-  last_web_preferences_ = base::Value(base::Value::Type::DICT);
-  last_web_preferences_.SetKey(options::kNodeIntegration,
-                               base::Value(node_integration_));
-  last_web_preferences_.SetKey(options::kNodeIntegrationInSubFrames,
-                               base::Value(node_integration_in_sub_frames_));
-  last_web_preferences_.SetKey(options::kSandbox, base::Value(IsSandboxed()));
-  last_web_preferences_.SetKey(options::kContextIsolation,
-                               base::Value(context_isolation_));
-  last_web_preferences_.SetKey(options::kJavaScript, base::Value(javascript_));
-  last_web_preferences_.SetKey(options::kEnableWebSQL,
-                               base::Value(enable_websql_));
-  last_web_preferences_.SetKey(options::kWebviewTag, base::Value(webview_tag_));
-  last_web_preferences_.SetKey("disablePopups", base::Value(disable_popups_));
-  last_web_preferences_.SetKey(options::kWebSecurity,
-                               base::Value(web_security_));
-  last_web_preferences_.SetKey(options::kAllowRunningInsecureContent,
-                               base::Value(allow_running_insecure_content_));
-  last_web_preferences_.SetKey(options::kExperimentalFeatures,
-                               base::Value(experimental_features_));
-  last_web_preferences_.SetKey(
-      options::kEnableBlinkFeatures,
-      base::Value(enable_blink_features_.value_or("")));
+  base::Value::Dict dict;
+  dict.Set(options::kNodeIntegration, node_integration_);
+  dict.Set(options::kNodeIntegrationInSubFrames,
+           node_integration_in_sub_frames_);
+  dict.Set(options::kSandbox, IsSandboxed());
+  dict.Set(options::kContextIsolation, context_isolation_);
+  dict.Set(options::kJavaScript, javascript_);
+  dict.Set(options::kEnableWebSQL, enable_websql_);
+  dict.Set(options::kWebviewTag, webview_tag_);
+  dict.Set("disablePopups", disable_popups_);
+  dict.Set(options::kWebSecurity, web_security_);
+  dict.Set(options::kAllowRunningInsecureContent,
+           allow_running_insecure_content_);
+  dict.Set(options::kExperimentalFeatures, experimental_features_);
+  dict.Set(options::kEnableBlinkFeatures, enable_blink_features_.value_or(""));
+
+  last_web_preferences_ = base::Value(std::move(dict));
 }
 
 void WebContentsPreferences::OverrideWebkitPrefs(

--- a/shell/common/gin_converters/hid_device_info_converter.h
+++ b/shell/common/gin_converters/hid_device_info_converter.h
@@ -18,7 +18,7 @@ struct Converter<device::mojom::HidDeviceInfoPtr> {
       v8::Isolate* isolate,
       const device::mojom::HidDeviceInfoPtr& device) {
     base::Value value = electron::HidChooserContext::DeviceInfoToValue(*device);
-    value.SetStringKey(
+    value.GetDict().Set(
         "deviceId",
         electron::HidChooserController::PhysicalDeviceIdFromDeviceInfo(
             *device));


### PR DESCRIPTION
#### Description of Change
These methods will probably get removed from Chromium at some point.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
