### PR TITLE
fix: crash in `MessagePortMain` with some `postMessage` params

### DIFF
--- a/shell/browser/api/message_port.cc
+++ b/shell/browser/api/message_port.cc
@@ -28,7 +28,7 @@ namespace electron {
 
 namespace {
 
-bool IsValidWrappable(v8::Local<v8::Value> obj) {
+bool IsValidWrappable(const v8::Local<v8::Value>& obj) {
   v8::Local<v8::Object> port = v8::Local<v8::Object>::Cast(obj);
 
   if (!port->IsObject())

--- a/shell/browser/api/message_port.cc
+++ b/shell/browser/api/message_port.cc
@@ -26,6 +26,25 @@
 
 namespace electron {
 
+namespace {
+
+bool IsValidWrappable(v8::Local<v8::Value> obj) {
+  v8::Local<v8::Object> port = v8::Local<v8::Object>::Cast(obj);
+
+  if (!port->IsObject())
+    return false;
+
+  if (port->InternalFieldCount() != gin::kNumberOfInternalFields)
+    return false;
+
+  const auto* info = static_cast<gin::WrapperInfo*>(
+      port->GetAlignedPointerFromInternalField(gin::kWrapperInfoIndex));
+
+  return info && info->embedder == gin::kEmbedderNativeGin;
+}
+
+}  // namespace
+
 gin::WrapperInfo MessagePort::kWrapperInfo = {gin::kEmbedderNativeGin};
 
 MessagePort::MessagePort() = default;
@@ -48,10 +67,11 @@ void MessagePort::PostMessage(gin::Arguments* args) {
   DCHECK(!IsNeutered());
 
   blink::TransferableMessage transferable_message;
+  gin_helper::ErrorThrower thrower(args->isolate());
 
   v8::Local<v8::Value> message_value;
   if (!args->GetNext(&message_value)) {
-    args->ThrowTypeError("Expected at least one argument to postMessage");
+    thrower.ThrowTypeError("Expected at least one argument to postMessage");
     return;
   }
 
@@ -61,8 +81,23 @@ void MessagePort::PostMessage(gin::Arguments* args) {
   v8::Local<v8::Value> transferables;
   std::vector<gin::Handle<MessagePort>> wrapped_ports;
   if (args->GetNext(&transferables)) {
+    std::vector<v8::Local<v8::Value>> wrapped_port_values;
+    if (!gin::ConvertFromV8(args->isolate(), transferables,
+                            &wrapped_port_values)) {
+      thrower.ThrowTypeError("transferables must be an array of MessagePorts");
+      return;
+    }
+
+    for (unsigned i = 0; i < wrapped_port_values.size(); ++i) {
+      if (!IsValidWrappable(wrapped_port_values[i])) {
+        thrower.ThrowTypeError("Port at index " + base::NumberToString(i) +
+                               " is not a valid port");
+        return;
+      }
+    }
+
     if (!gin::ConvertFromV8(args->isolate(), transferables, &wrapped_ports)) {
-      args->ThrowError();
+      thrower.ThrowTypeError("Passed an invalid MessagePort");
       return;
     }
   }
@@ -70,9 +105,8 @@ void MessagePort::PostMessage(gin::Arguments* args) {
   // Make sure we aren't connected to any of the passed-in ports.
   for (unsigned i = 0; i < wrapped_ports.size(); ++i) {
     if (wrapped_ports[i].get() == this) {
-      gin_helper::ErrorThrower(args->isolate())
-          .ThrowError("Port at index " + base::NumberToString(i) +
-                      " contains the source port.");
+      thrower.ThrowError("Port at index " + base::NumberToString(i) +
+                         " contains the source port.");
       return;
     }
   }

--- a/spec/api-ipc-spec.ts
+++ b/spec/api-ipc-spec.ts
@@ -355,6 +355,31 @@ describe('ipc module', () => {
         expect(port2).not.to.be.null();
       });
 
+      it('throws an error when an invalid parameter is sent to postMessage', () => {
+        const { port1 } = new MessageChannelMain();
+
+        expect(() => {
+          const buffer = new ArrayBuffer(10) as any;
+          port1.postMessage(null, [buffer]);
+        }).to.throw(/Port at index 0 is not a valid port/);
+
+        expect(() => {
+          port1.postMessage(null, ['1' as any]);
+        }).to.throw(/Port at index 0 is not a valid port/);
+
+        expect(() => {
+          port1.postMessage(null, [new Date() as any]);
+        }).to.throw(/Port at index 0 is not a valid port/);
+      });
+
+      it('throws when postMessage transferables contains the source port', () => {
+        const { port1 } = new MessageChannelMain();
+
+        expect(() => {
+          port1.postMessage(null, [port1]);
+        }).to.throw(/Port at index 0 contains the source port./);
+      });
+
       it('can send messages within the process', async () => {
         const { port1, port2 } = new MessageChannelMain();
         port2.postMessage('hello');
@@ -423,7 +448,7 @@ describe('ipc module', () => {
         const { port1 } = new MessageChannelMain();
         expect(() => {
           port1.postMessage(null, [null] as any);
-        }).to.throw(/conversion failure/);
+        }).to.throw(/Port at index 0 is not a valid port/);
       });
 
       it('throws when passing duplicate ports', () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/37565.

Fixes an issue where calling `port.postMessage` in `MessagePortMain` with some invalid parameters could cause a crash. When passing an (unsupported) `ArrayBuffer`, for example, this happened because we try to unwrap everything in the transferrables list and upstream's [`WrapperInfo`](https://source.chromium.org/chromium/chromium/src/+/main:gin/wrapper_info.cc;l=10-16;drc=0e9a0b6e9bb6ec59521977eec805f5d0bca833e0) logic doesn't take into account that an object might have the correct number of internal fields but not be a `WrappableBase`. I first tried to [upstream this](https://chromium-review.googlesource.com/c/chromium/src/+/4335426) but was told it's for now better handler on the embedder's side.

We can therefore address this by iterating through the transferrables list and verifying the items are valid.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where calling `port.postMessage` in `MessagePortMain` with some invalid parameters could cause a crash. 