### PR TITLE
fix: avoid deprecated value apis

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -607,13 +607,13 @@ int ImportIntoCertStore(CertificateManagerModel* model, base::Value options) {
   net::ScopedCERTCertificateList imported_certs;
   int rv = -1;
 
-  std::string* cert_path_ptr = options.FindStringKey("certificate");
-  if (cert_path_ptr)
-    cert_path = *cert_path_ptr;
+  if (const base::Value::Dict* dict = options.GetIfDict(); dict != nullptr) {
+    if (const std::string* str = dict->FindString("certificate"); str)
+      cert_path = *str;
 
-  std::string* pwd = options.FindStringKey("password");
-  if (pwd)
-    password = base::UTF8ToUTF16(*pwd);
+    if (const std::string* str = dict->FindString("password"); str)
+      password = base::UTF8ToUTF16(*str);
+  }
 
   if (!cert_path.empty()) {
     if (base::ReadFileToString(base::FilePath(cert_path), &file_data)) {

--- a/shell/browser/usb/usb_chooser_context.cc
+++ b/shell/browser/usb/usb_chooser_context.cc
@@ -180,7 +180,10 @@ void UsbChooserContext::RevokeObjectPermissionInternal(
     const url::Origin& origin,
     const base::Value& object,
     bool revoked_by_website = false) {
-  if (object.FindStringKey(kDeviceSerialNumberKey)) {
+  const base::Value::Dict* object_dict = object.GetIfDict();
+  DCHECK(object_dict != nullptr);
+
+  if (object_dict->FindString(kDeviceSerialNumberKey) != nullptr) {
     auto* permission_manager = static_cast<ElectronPermissionManager*>(
         browser_context_->GetPermissionControllerDelegate());
     permission_manager->RevokeDevicePermission(
@@ -188,7 +191,7 @@ void UsbChooserContext::RevokeObjectPermissionInternal(
             WebContentsPermissionHelper::PermissionType::USB),
         origin, object, browser_context_);
   } else {
-    const std::string* guid = object.FindStringKey(kDeviceIdKey);
+    const std::string* guid = object_dict->FindString(kDeviceIdKey);
     auto it = ephemeral_devices_.find(origin);
     if (it != ephemeral_devices_.end()) {
       it->second.erase(*guid);

--- a/shell/browser/zoom_level_delegate.cc
+++ b/shell/browser/zoom_level_delegate.cc
@@ -100,7 +100,7 @@ void ZoomLevelDelegate::ExtractPerHostZoomLevels(
     const base::Value::Dict& host_zoom_dictionary) {
   std::vector<std::string> keys_to_remove;
   base::Value::Dict host_zoom_dictionary_copy = host_zoom_dictionary.Clone();
-  for (auto [host, value] : host_zoom_dictionary_copy) {
+  for (auto const [host, value] : host_zoom_dictionary_copy) {
     const absl::optional<double> zoom_level = value.GetIfDouble();
 
     // Filter out A) the empty host, B) zoom levels equal to the default; and
@@ -123,10 +123,11 @@ void ZoomLevelDelegate::ExtractPerHostZoomLevels(
   // have an empty host.
   {
     ScopedDictPrefUpdate update(pref_service_, kPartitionPerHostZoomLevels);
-    base::Value* sanitized_host_zoom_dictionary = update->Find(partition_key_);
+    base::Value::Dict* sanitized_host_zoom_dictionary =
+        update->FindDict(partition_key_);
     if (sanitized_host_zoom_dictionary) {
-      for (const std::string& s : keys_to_remove)
-        sanitized_host_zoom_dictionary->RemoveKey(s);
+      for (const std::string& key : keys_to_remove)
+        sanitized_host_zoom_dictionary->Remove(key);
     }
   }
 }


### PR DESCRIPTION
#### Description of Change

Fixes use of deprecated `base::Value` API calls in Electron:

- `FindStringKey()` -> `Dict::FindString()`
- `RemoveKey()` -> `Dict::Remove()`

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none