### PR TITLE
Fix test

### DIFF
--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -276,12 +276,10 @@ void SwizzleMouseDown(NSView* frame_view,
 }
 
 - (void)beginPreviewPanelControl:(QLPreviewPanel*)panel {
-  panel.delegate = [self delegate];
   panel.dataSource = static_cast<id<QLPreviewPanelDataSource>>([self delegate]);
 }
 
 - (void)endPreviewPanelControl:(QLPreviewPanel*)panel {
-  panel.delegate = nil;
   panel.dataSource = nil;
 }
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5242,7 +5242,7 @@ describe('BrowserWindow module', () => {
 
     it('should not call BrowserWindow show event', async () => {
       const w = new BrowserWindow({ show: false });
-      const shown = once(w, 'show');
+      const shown = emittedOnce(w, 'show');
       w.show();
       await shown;
 
@@ -5252,7 +5252,7 @@ describe('BrowserWindow module', () => {
       });
 
       w.previewFile(__filename);
-      await setTimeout(500);
+      await delay(500);
       expect(showCalled).to.equal(false, 'should not have called show twice');
     });
   });

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5239,6 +5239,22 @@ describe('BrowserWindow module', () => {
         w.closeFilePreview();
       }).to.not.throw();
     });
+
+    it('should not call BrowserWindow show event', async () => {
+      const w = new BrowserWindow({ show: false });
+      const shown = once(w, 'show');
+      w.show();
+      await shown;
+
+      let showCalled = false;
+      w.on('show', () => {
+        showCalled = true;
+      });
+
+      w.previewFile(__filename);
+      await setTimeout(500);
+      expect(showCalled).to.equal(false, 'should not have called show twice');
+    });
   });
 
   // TODO (jkleinsc) renable these tests on mas arm64


### PR DESCRIPTION
This fixes the test failures in https://github.com/electron/electron/pull/37577, which is a backport of https://github.com/electron/electron/pull/37530 to 23-x-y. The problem was a result of https://github.com/electron/electron/pull/37374.