### PR TITLE
chore: generator objects can't be sent over the context bridge

### DIFF
--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -96,9 +96,9 @@ bool IsPlainObject(const v8::Local<v8::Value>& object) {
            object->IsWeakMap() || object->IsWeakSet() ||
            object->IsArrayBuffer() || object->IsArrayBufferView() ||
            object->IsArray() || object->IsDataView() ||
-           object->IsSharedArrayBuffer() || object->IsProxy() ||
+           object->IsSharedArrayBuffer() || object->IsGeneratorObject() ||
            object->IsWasmModuleObject() || object->IsWasmMemoryObject() ||
-           object->IsModuleNamespaceObject());
+           object->IsModuleNamespaceObject() || object->IsProxy());
 }
 
 bool IsPlainArray(const v8::Local<v8::Value>& arr) {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/37504.

They were previously being sent over the bridge as plain objects, but without all their distinguishing properties. This corrects that and conforms to docs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.
