### PR TITLE
fix: draggable regions shouldn't capture clicks on frames windows

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1988,6 +1988,9 @@ void WebContents::MessageHost(const std::string& channel,
 
 void WebContents::UpdateDraggableRegions(
     std::vector<mojom::DraggableRegionPtr> regions) {
+  if (owner_window() && owner_window()->has_frame())
+    return;
+
   draggable_region_ = DraggableRegionsToSkRegion(regions);
 }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/37515
Refs https://github.com/electron/electron/pull/36230

The refactor lost this [check for frameless windows](https://github.com/electron/electron/pull/36230/files#diff-bfaa73008a8b883d15dd11323996e12e24ae556c8a03e8dd0ad43b8785cf099dL151) which meant that draggable regions started taking effect for framed windows as well as capturing clicks. This fixes that by only setting `draggable_region_` in `WebContents::UpdateDraggableRegions` if the window is frameless.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where draggable regions incorrectly captured clicks in framed windows.