### PR TITLE
fix: invoke `app.dock.{hide|show}` instead of duplicating logic

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -23,6 +23,7 @@
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/desktop_media_id.h"
+#include "shell/browser/browser.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/browser/native_browser_view_mac.h"
 #include "shell/browser/ui/cocoa/electron_native_widget_mac.h"
@@ -1281,18 +1282,15 @@ void NativeWindowMac::SetOverlayIcon(const gfx::Image& overlay,
 void NativeWindowMac::SetVisibleOnAllWorkspaces(bool visible,
                                                 bool visibleOnFullScreen,
                                                 bool skipTransformProcessType) {
-  // In order for NSWindows to be visible on fullscreen we need to functionally
-  // mimic app.dock.hide() since Apple changed the underlying functionality of
+  // In order for NSWindows to be visible on fullscreen we need to invoke
+  // app.dock.hide() since Apple changed the underlying functionality of
   // NSWindows starting with 10.14 to disallow NSWindows from floating on top of
   // fullscreen apps.
   if (!skipTransformProcessType) {
-    ProcessSerialNumber psn = {0, kCurrentProcess};
     if (visibleOnFullScreen) {
-      [window_ setCanHide:NO];
-      TransformProcessType(&psn, kProcessTransformToUIElementApplication);
+      Browser::Get()->DockHide();
     } else {
-      [window_ setCanHide:YES];
-      TransformProcessType(&psn, kProcessTransformToForegroundApplication);
+      Browser::Get()->DockShow(JavascriptEnvironment::GetIsolate());
     }
   }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/37487.

Fixes an issue with potential dock icon duplication on macOS by calling into our existing `app.dock.show` and `app.dock.hide` implementations, which are also subject to the duplication bugs but include workarounds to prevent them from happening.

Tested with https://gist.github.com/PsychoLlama/fcb2790372b6e4957beac9be7e543d3d to verify no duplicates occur.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue with potential dock icon duplication on macOS.