### PR TITLE
fix: allow cancelling of bluetooth requests

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -777,20 +777,24 @@ Returns:
 * `callback` Function
   * `deviceId` string
 
-Emitted when bluetooth device needs to be selected on call to
-`navigator.bluetooth.requestDevice`. To use `navigator.bluetooth` api
-`webBluetooth` should be enabled. If `event.preventDefault` is not called,
-first available device will be selected. `callback` should be called with
-`deviceId` to be selected, passing empty string to `callback` will
-cancel the request.
+Emitted when a bluetooth device needs to be selected when a call to
+`navigator.bluetooth.requestDevice` is made. `callback` should be called with
+the `deviceId` of the device to be selected.  Passing an empty string to
+`callback` will cancel the request.
 
-If no event listener is added for this event, all bluetooth requests will be cancelled.
+If an event listener is not added for this event, or if `event.preventDefault`
+is not called when handling this event, the first available device will be
+automatically selected.
+
+Due to the nature of bluetooth, scanning for devices when
+`navigator.bluetooth.requestDevice` is called may take time and will cause
+`select-bluetooth-device` to fire multiple times until `callback` is called
+with either a device id or an empty string to cancel the request.
 
 ```javascript title='main.js'
 const { app, BrowserWindow } = require('electron')
 
 let win = null
-app.commandLine.appendSwitch('enable-experimental-web-platform-features')
 
 app.whenReady().then(() => {
   win = new BrowserWindow({ width: 800, height: 600 })
@@ -800,6 +804,9 @@ app.whenReady().then(() => {
       return device.deviceName === 'test'
     })
     if (!result) {
+      // The device wasn't found so we need to either wait longer (eg until the
+      // device is turned on) or cancel the request by calling the callback 
+      // with an empty string.
       callback('')
     } else {
       callback(result.deviceId)

--- a/docs/fiddles/features/web-bluetooth/index.html
+++ b/docs/fiddles/features/web-bluetooth/index.html
@@ -9,6 +9,7 @@
     <h1>Web Bluetooth API</h1>
 
     <button id="clickme">Test Bluetooth</button>
+    <button id="cancel">Cancel Bluetooth Request</button>
 
     <p>Currently selected bluetooth device: <strong id="device-name""></strong></p>
 

--- a/docs/fiddles/features/web-bluetooth/main.js
+++ b/docs/fiddles/features/web-bluetooth/main.js
@@ -1,6 +1,9 @@
 const {app, BrowserWindow, ipcMain} = require('electron')
 const path = require('path')
 
+let bluetoothPinCallback 
+let selectBluetoothCallback
+
 function createWindow () {
   const mainWindow = new BrowserWindow({
     width: 800,
@@ -12,10 +15,22 @@ function createWindow () {
 
   mainWindow.webContents.on('select-bluetooth-device', (event, deviceList, callback) => {
     event.preventDefault()
-    if (deviceList && deviceList.length > 0) {
-      callback(deviceList[0].deviceId)
-    }
+    selectBluetoothCallback = callback
+    const result = deviceList.find((device) => {
+      return device.deviceName === 'test'
+    })
+    if (result) {
+      callback(result.deviceId)
+    } else {
+      // The device wasn't found so we need to either wait longer (eg until the
+      // device is turned on) or until the user cancels the request
+    }     
   })
+
+  ipcMain.on('cancel-bluetooth-request', (event) => {
+    selectBluetoothCallback('')
+  })
+  
 
   // Listen for a message from the renderer to get the response for the Bluetooth pairing.
   ipcMain.on('bluetooth-pairing-response', (event, response) => {

--- a/docs/fiddles/features/web-bluetooth/preload.js
+++ b/docs/fiddles/features/web-bluetooth/preload.js
@@ -1,6 +1,7 @@
 const { contextBridge, ipcRenderer } = require('electron')
 
 contextBridge.exposeInMainWorld('electronAPI', {
+  cancelBluetoothRequest: (callback) => ipcRenderer.send('cancel-bluetooth-request', callback),
   bluetoothPairingRequest: (callback) => ipcRenderer.on('bluetooth-pairing-request', callback),
   bluetoothPairingResponse: (response) => ipcRenderer.send('bluetooth-pairing-response', response)
 })

--- a/docs/fiddles/features/web-bluetooth/renderer.js
+++ b/docs/fiddles/features/web-bluetooth/renderer.js
@@ -7,6 +7,12 @@ async function testIt() {
 
 document.getElementById('clickme').addEventListener('click',testIt)
 
+function cancelRequest() {
+  window.electronAPI.cancelBluetoothRequest()
+}
+
+document.getElementById('cancel').addEventListener('click', cancelRequest)
+
 window.electronAPI.bluetoothPairingRequest((event, details) => {
   const response = {}
 

--- a/shell/browser/lib/bluetooth_chooser.h
+++ b/shell/browser/lib/bluetooth_chooser.h
@@ -44,7 +44,6 @@ class BluetoothChooser : public content::BluetoothChooser {
   std::map<std::string, std::u16string> device_map_;
   api::WebContents* api_web_contents_;
   EventHandler event_handler_;
-  int num_retries_ = 0;
   bool refreshing_ = false;
   bool rescan_ = false;
 };


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
There was an issue where bluetooth requests could not be cancelled when no devices are returned because `select-bluetooth-device` never fires in that case and the only way to cancel a bluetooth request is to call the callback from `select-bluetooth-device` with an empty string.  This PR fixes that issue by always firing `select-bluetooth-device` regardless of whether devices are available or not.

Additionally, this PR updates the bluetooth documentation to be more accurate and contain more explanation about how `select-bluetooth-device` works as well as to update the example fiddle to include logic to cancel a bluetooth request.
 
- Fixes #37090
- Fixes #37436


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->Fixed canceling of bluetooth requests when no devices are returned.
