### PR TITLE
feat: Allow usage of an absolute path for partitions used in a session

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -42,6 +42,21 @@ To create a `Session` with `options`, you have to ensure the `Session` with the
 `partition` has never been used before. There is no way to change the `options`
 of an existing `Session` object.
 
+### `session.fromPath(path[, options])`
+
+* `path` string
+* `options` Object (optional)
+  * `cache` boolean - Whether to enable cache.
+
+Returns `Session` - A session instance from the absolute path as specified by the `path`
+string. When there is an existing `Session` with the same absolute path, it
+will be returned; otherwise a new `Session` instance will be created with `options`. The
+call will throw an error if the path is not an absolute path or an empty string.
+
+To create a `Session` with `options`, you have to ensure the `Session` with the
+`path` has never been used before. There is no way to change the `options`
+of an existing `Session` object.
+
 ## Properties
 
 The `session` module has the following properties:

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -51,7 +51,8 @@ of an existing `Session` object.
 Returns `Session` - A session instance from the absolute path as specified by the `path`
 string. When there is an existing `Session` with the same absolute path, it
 will be returned; otherwise a new `Session` instance will be created with `options`. The
-call will throw an error if the path is not an absolute path or an empty string.
+call will throw an error if the path is not an absolute path. Additionally, an error will
+be thrown if an empty string is provided.
 
 To create a `Session` with `options`, you have to ensure the `Session` with the
 `path` has never been used before. There is no way to change the `options`

--- a/lib/browser/api/session.ts
+++ b/lib/browser/api/session.ts
@@ -1,5 +1,5 @@
 import { fetchWithSession } from '@electron/internal/browser/api/net-fetch';
-const { fromPartition, Session } = process._linkedBinding('electron_browser_session');
+const { fromPartition, fromPath, Session } = process._linkedBinding('electron_browser_session');
 
 Session.prototype.fetch = function (input: RequestInfo, init?: RequestInit) {
   return fetchWithSession(input, init, this);
@@ -7,6 +7,7 @@ Session.prototype.fetch = function (input: RequestInfo, init?: RequestInit) {
 
 export default {
   fromPartition,
+  fromPath,
   get defaultSession () {
     return fromPartition('');
   }

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -12,7 +12,9 @@
 #include <vector>
 
 #include "base/command_line.h"
+#include "base/files/file_enumerator.h"
 #include "base/files/file_path.h"
+#include "base/files/file_util.h"
 #include "base/guid.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
@@ -1207,6 +1209,30 @@ gin::Handle<Session> Session::FromPartition(v8::Isolate* isolate,
 }
 
 // static
+absl::optional<gin::Handle<Session>> Session::FromPath(
+    v8::Isolate* isolate,
+    const base::FilePath& path,
+    base::Value::Dict options) {
+  ElectronBrowserContext* browser_context;
+
+  if (path.empty()) {
+    gin_helper::Promise<v8::Local<v8::Value>> promise(isolate);
+    promise.RejectWithErrorMessage("An empty path was specified");
+    return absl::nullopt;
+  }
+  if (!path.IsAbsolute()) {
+    gin_helper::Promise<v8::Local<v8::Value>> promise(isolate);
+    promise.RejectWithErrorMessage("An absolute path was not provided");
+    return absl::nullopt;
+  }
+
+  browser_context =
+      ElectronBrowserContext::FromPath(std::move(path), std::move(options));
+
+  return CreateFrom(isolate, browser_context);
+}
+
+// static
 gin::Handle<Session> Session::New() {
   gin_helper::ErrorThrower(JavascriptEnvironment::GetIsolate())
       .ThrowError("Session objects cannot be created with 'new'");
@@ -1311,6 +1337,23 @@ v8::Local<v8::Value> FromPartition(const std::string& partition,
       .ToV8();
 }
 
+v8::Local<v8::Value> FromPath(const base::FilePath& path,
+                              gin::Arguments* args) {
+  if (!electron::Browser::Get()->is_ready()) {
+    args->ThrowTypeError("Session can only be received when app is ready");
+    return v8::Null(args->isolate());
+  }
+  base::Value::Dict options;
+  args->GetNext(&options);
+  absl::optional<gin::Handle<Session>> session_handle =
+      Session::FromPath(args->isolate(), path, std::move(options));
+
+  if (session_handle)
+    return session_handle.value().ToV8();
+  else
+    return v8::Null(args->isolate());
+}
+
 void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context,
@@ -1319,6 +1362,7 @@ void Initialize(v8::Local<v8::Object> exports,
   gin_helper::Dictionary dict(isolate, exports);
   dict.Set("Session", Session::GetConstructor(context));
   dict.SetMethod("fromPartition", &FromPartition);
+  dict.SetMethod("fromPath", &FromPath);
 }
 
 }  // namespace

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -82,6 +82,12 @@ class Session : public gin::Wrappable<Session>,
                                             const std::string& partition,
                                             base::Value::Dict options = {});
 
+  // Gets the Session based on |path|.
+  static absl::optional<gin::Handle<Session>> FromPath(
+      v8::Isolate* isolate,
+      const base::FilePath& path,
+      base::Value::Dict options = {});
+
   ElectronBrowserContext* browser_context() const { return browser_context_; }
 
   // gin::Wrappable

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -65,6 +65,9 @@ using DisplayMediaResponseCallbackJs =
 using DisplayMediaRequestHandler =
     base::RepeatingCallback<void(const content::MediaStreamRequest&,
                                  DisplayMediaResponseCallbackJs)>;
+using PartitionOrPath =
+    std::variant<std::reference_wrapper<const std::string>,
+                 std::reference_wrapper<const base::FilePath>>;
 
 class ElectronBrowserContext : public content::BrowserContext {
  public:
@@ -74,22 +77,43 @@ class ElectronBrowserContext : public content::BrowserContext {
 
   // partition_id => browser_context
   struct PartitionKey {
-    std::string partition;
+    enum class KeyType { Partition, FilePath };
+    std::string location;
     bool in_memory;
+    KeyType partition_type;
 
     PartitionKey(const std::string& partition, bool in_memory)
-        : partition(partition), in_memory(in_memory) {}
+        : location(partition),
+          in_memory(in_memory),
+          partition_type(KeyType::Partition) {}
+    explicit PartitionKey(const base::FilePath& file_path)
+        : location(file_path.AsUTF8Unsafe()),
+          in_memory(false),
+          partition_type(KeyType::FilePath) {}
 
     bool operator<(const PartitionKey& other) const {
-      if (partition == other.partition)
-        return in_memory < other.in_memory;
-      return partition < other.partition;
+      if (partition_type == KeyType::Partition) {
+        if (location == other.location)
+          return in_memory < other.in_memory;
+        return location < other.location;
+      } else {
+        if (location == other.location)
+          return false;
+        return location < other.location;
+      }
     }
 
     bool operator==(const PartitionKey& other) const {
-      return (partition == other.partition) && (in_memory == other.in_memory);
+      if (partition_type == KeyType::Partition) {
+        return (location == other.location) && (in_memory < other.in_memory);
+      } else {
+        if (location == other.location)
+          return true;
+        return false;
+      }
     }
   };
+
   using BrowserContextMap =
       std::map<PartitionKey, std::unique_ptr<ElectronBrowserContext>>;
 
@@ -99,6 +123,12 @@ class ElectronBrowserContext : public content::BrowserContext {
   static ElectronBrowserContext* From(const std::string& partition,
                                       bool in_memory,
                                       base::Value::Dict options = {});
+
+  // Get or create the BrowserContext using the |path|.
+  // The |options| will be passed to constructor when there is no
+  // existing BrowserContext.
+  static ElectronBrowserContext* FromPath(const base::FilePath& path,
+                                          base::Value::Dict options = {});
 
   static BrowserContextMap& browser_context_map();
 
@@ -190,9 +220,11 @@ class ElectronBrowserContext : public content::BrowserContext {
                              blink::PermissionType permissionType);
 
  private:
-  ElectronBrowserContext(const std::string& partition,
+  ElectronBrowserContext(const PartitionOrPath partition_location,
                          bool in_memory,
                          base::Value::Dict options);
+
+  ElectronBrowserContext(base::FilePath partition, base::Value::Dict options);
 
   static void DisplayMediaDeviceChosen(
       const content::MediaStreamRequest& request,

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -31,6 +31,14 @@ describe('session module', () => {
     });
   });
 
+  describe('session.fromPath(path)', () => {
+    it('returns storage path of a session which was created with an absolute path', () => {
+      const tmppath = require('electron').app.getPath('temp');
+      const ses = session.fromPath(tmppath);
+      expect(ses.storagePath).to.equal(tmppath);
+    });
+  });
+
   describe('ses.cookies', () => {
     const name = '0';
     const value = '0';

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -226,7 +226,7 @@ declare namespace NodeJS {
     _linkedBinding(name: 'electron_browser_power_save_blocker'): { powerSaveBlocker: Electron.PowerSaveBlocker };
     _linkedBinding(name: 'electron_browser_push_notifications'): { pushNotifications: Electron.PushNotifications };
     _linkedBinding(name: 'electron_browser_safe_storage'): { safeStorage: Electron.SafeStorage };
-    _linkedBinding(name: 'electron_browser_session'): {fromPartition: typeof Electron.Session.fromPartition, Session: typeof Electron.Session};
+    _linkedBinding(name: 'electron_browser_session'): {fromPartition: typeof Electron.Session.fromPartition, fromPath: typeof Electron.Session.fromPath, Session: typeof Electron.Session};
     _linkedBinding(name: 'electron_browser_screen'): { createScreen(): Electron.Screen };
     _linkedBinding(name: 'electron_browser_system_preferences'): { systemPreferences: Electron.SystemPreferences };
     _linkedBinding(name: 'electron_browser_tray'): { Tray: Electron.Tray };


### PR DESCRIPTION
Description of Change
Allow an absolute path to be passed to the session.fromPath() API.
This allows multiple browser windows to be created with absolute paths specified in the session.fromPath() parameters.


Checklist

- [x]  PR description included and stakeholders cc'd
- [x] npm test passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

Release Notes
notes: Allows an absolute path to be passed to the session.fromPath() API.