### PR TITLE
ci: make sure that strip_binary.gni is properly preserved

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -413,6 +413,15 @@ step-get-more-space-on-mac: &step-get-more-space-on-mac
         tmpify ~/.rubies
         tmpify ~/Library/Caches/Homebrew
         tmpify /usr/local/Homebrew
+
+        # the contents of build/linux/strip_binary.gni aren't used, but
+        # https://chromium-review.googlesource.com/c/chromium/src/+/4278307
+        # needs the file to exist.
+        mv ~/project/src/build/linux/strip_binary.gni "${TMPDIR}"/
+        tmpify ~/project/src/build/linux/
+        mkdir -p ~/project/src/build/linux
+        mv "${TMPDIR}/strip_binary.gni" ~/project/src/build/linux/
+
         sudo rm -rf $TMPDIR/del-target
 
         # sudo rm -rf "/System/Library/Desktop Pictures"
@@ -436,14 +445,6 @@ step-get-more-space-on-mac: &step-get-more-space-on-mac
         sudo rm -rf /Applications/Safari.app
         sudo rm -rf ~/project/src/third_party/catapult/tracing/test_data
         sudo rm -rf ~/project/src/third_party/angle/third_party/VK-GL-CTS
-
-        # the contents of build/linux/strip_binary.gni aren't used, but
-        # https://chromium-review.googlesource.com/c/chromium/src/+/4278307
-        # needs the file to exist.
-        mv ~/project/src/build/linux/strip_binary.gni "${TMPDIR}"/
-        sudo rm -rf ~/project/src/build/linux
-        mkdir -p ~/project/src/build/linux
-        mv "${TMPDIR}/strip_binary.gni" ~/project/src/build/linux/
 
         # lipo off some huge binaries arm64 versions to save space
         strip_arm_deep $(xcode-select -p)/../SharedFrameworks


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
- #37130 added logic to preserve `strip_binary.gni` on macOS but due to the fact that the `Free up space on MacOS` step runs in the background, on occasion the file gets deleted and a build step runs that needs it before the file is restored.
This change uses the `tmpify` function to move the directory `~/project/src/build/linux/` instead of deleting it directly which is a quicker operation than running `rm -rf ~/project/src/build/linux`.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
