### PR TITLE
chore: cherry-pick 9aa4c45f21b1 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -151,3 +151,4 @@ cherry-pick-06851790480e.patch
 cherry-pick-e79b89b47dac.patch
 m108-lts_simplify_webmediaplayermscompositor_destruction.patch
 m108-lts_further_simplify_webmediaplayermscompositor_lifetime.patch
+cherry-pick-9aa4c45f21b1.patch

--- a/patches/chromium/cherry-pick-9aa4c45f21b1.patch
+++ b/patches/chromium/cherry-pick-9aa4c45f21b1.patch
@@ -1,7 +1,10 @@
-From 9aa4c45f21b1fbb6666090fabf3d03297ad982e3 Mon Sep 17 00:00:00 2001
-From: Henrik Boström <hbos@chromium.org>
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Henrik=20Bostr=C3=B6m?= <hbos@chromium.org>
 Date: Tue, 14 Mar 2023 13:07:19 +0000
-Subject: [PATCH] [M108-LTS] Shutdown RtpContributingSourceCache in Dispose().
+Subject: Shutdown RtpContributingSourceCache in Dispose().
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 The cache is an off-heap object, but it is owned by an on-heap object
 (RTCPeerConnection). Dispoing the owning object poisons memory owned by
@@ -26,13 +29,12 @@ Reviewed-by: Henrik Boström <hbos@chromium.org>
 Commit-Queue: Zakhar Voit <voit@google.com>
 Cr-Commit-Position: refs/branch-heads/5359@{#1404}
 Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}
----
 
 diff --git a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
-index e951bf3..8aeb349 100644
+index ec4b8985b5fb072ea98f4c36a3d0b341000d96ad..386491b2b6b4dedaee96a798272d98cde41be5fa 100644
 --- a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
 +++ b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
-@@ -643,12 +643,18 @@
+@@ -741,12 +741,18 @@ RTCPeerConnection::~RTCPeerConnection() {
  }
  
  void RTCPeerConnection::Dispose() {
@@ -55,10 +57,10 @@ index e951bf3..8aeb349 100644
  
  ScriptPromise RTCPeerConnection::createOffer(ScriptState* script_state,
 diff --git a/third_party/blink/renderer/modules/peerconnection/rtp_contributing_source_cache.cc b/third_party/blink/renderer/modules/peerconnection/rtp_contributing_source_cache.cc
-index 1f91cf9..5ad457f 100644
+index a52ddd405ebdbdf297cf1f504bfeb0edfba11477..d4b21570e6469f7dfe0f8b668448f2ca4e919766 100644
 --- a/third_party/blink/renderer/modules/peerconnection/rtp_contributing_source_cache.cc
 +++ b/third_party/blink/renderer/modules/peerconnection/rtp_contributing_source_cache.cc
-@@ -102,6 +102,10 @@
+@@ -100,6 +100,10 @@ RtpContributingSourceCache::RtpContributingSourceCache(
    DCHECK(worker_thread_runner_);
  }
  
@@ -70,10 +72,10 @@ index 1f91cf9..5ad457f 100644
  RtpContributingSourceCache::getSynchronizationSources(
      ScriptState* script_state,
 diff --git a/third_party/blink/renderer/modules/peerconnection/rtp_contributing_source_cache.h b/third_party/blink/renderer/modules/peerconnection/rtp_contributing_source_cache.h
-index 0d0ef9d..3a42751 100644
+index b8d78d80aeea132273f230400a3b4d95a50342f0..827f5eb3524bbdf5974dca35cd5b2cc7df08b20f 100644
 --- a/third_party/blink/renderer/modules/peerconnection/rtp_contributing_source_cache.h
 +++ b/third_party/blink/renderer/modules/peerconnection/rtp_contributing_source_cache.h
-@@ -43,6 +43,10 @@
+@@ -43,6 +43,10 @@ class RtpContributingSourceCache {
        RTCPeerConnection* pc,
        scoped_refptr<base::SingleThreadTaskRunner> worker_thread_runner);
  

--- a/patches/chromium/cherry-pick-9aa4c45f21b1.patch
+++ b/patches/chromium/cherry-pick-9aa4c45f21b1.patch
@@ -1,0 +1,86 @@
+From 9aa4c45f21b1fbb6666090fabf3d03297ad982e3 Mon Sep 17 00:00:00 2001
+From: Henrik Boström <hbos@chromium.org>
+Date: Tue, 14 Mar 2023 13:07:19 +0000
+Subject: [PATCH] [M108-LTS] Shutdown RtpContributingSourceCache in Dispose().
+
+The cache is an off-heap object, but it is owned by an on-heap object
+(RTCPeerConnection). Dispoing the owning object poisons memory owned by
+it, but the cache may have in-flight tasks (cache doing ClearCache in a
+delayed microtask). This CL adds a Shutdown() method to ensure the
+cache isn't doing anything in the next microtask after disposal.
+
+No reliable way to repro this has been found but the change should be
+safe so hoping we can land without tests.
+
+(cherry picked from commit 4d450ecd6ec7776c7505dcf7d2f04157ff3ba0eb)
+
+Bug: 1413628
+Change-Id: I479aace9859f4c10cd75d4aa5a34808b4726299d
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4247023
+Commit-Queue: Henrik Boström <hbos@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1105653}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4291513
+Reviewed-by: Achuith Bhandarkar <achuith@chromium.org>
+Owners-Override: Achuith Bhandarkar <achuith@chromium.org>
+Reviewed-by: Henrik Boström <hbos@chromium.org>
+Commit-Queue: Zakhar Voit <voit@google.com>
+Cr-Commit-Position: refs/branch-heads/5359@{#1404}
+Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}
+---
+
+diff --git a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
+index e951bf3..8aeb349 100644
+--- a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
++++ b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
+@@ -643,12 +643,18 @@
+ }
+ 
+ void RTCPeerConnection::Dispose() {
+-  // Promptly clears the handler
+-  // so that content/ doesn't access it in a lazy sweeping phase.
+-  // Other references to the handler use a weak pointer, preventing access.
++  // Promptly clears the handler so that content doesn't access it in a lazy
++  // sweeping phase. Other references to the handler use a weak pointer,
++  // preventing access.
+   if (peer_handler_) {
+     peer_handler_.reset();
+   }
++  // Memory owned by RTCPeerConnection must not be touched after Dispose().
++  // Shut down the cache to cancel any in-flight tasks that may otherwise have
++  // used the cache.
++  if (rtp_contributing_source_cache_.has_value()) {
++    rtp_contributing_source_cache_.value().Shutdown();
++  }
+ }
+ 
+ ScriptPromise RTCPeerConnection::createOffer(ScriptState* script_state,
+diff --git a/third_party/blink/renderer/modules/peerconnection/rtp_contributing_source_cache.cc b/third_party/blink/renderer/modules/peerconnection/rtp_contributing_source_cache.cc
+index 1f91cf9..5ad457f 100644
+--- a/third_party/blink/renderer/modules/peerconnection/rtp_contributing_source_cache.cc
++++ b/third_party/blink/renderer/modules/peerconnection/rtp_contributing_source_cache.cc
+@@ -102,6 +102,10 @@
+   DCHECK(worker_thread_runner_);
+ }
+ 
++void RtpContributingSourceCache::Shutdown() {
++  weak_factory_.InvalidateWeakPtrs();
++}
++
+ HeapVector<Member<RTCRtpSynchronizationSource>>
+ RtpContributingSourceCache::getSynchronizationSources(
+     ScriptState* script_state,
+diff --git a/third_party/blink/renderer/modules/peerconnection/rtp_contributing_source_cache.h b/third_party/blink/renderer/modules/peerconnection/rtp_contributing_source_cache.h
+index 0d0ef9d..3a42751 100644
+--- a/third_party/blink/renderer/modules/peerconnection/rtp_contributing_source_cache.h
++++ b/third_party/blink/renderer/modules/peerconnection/rtp_contributing_source_cache.h
+@@ -43,6 +43,10 @@
+       RTCPeerConnection* pc,
+       scoped_refptr<base::SingleThreadTaskRunner> worker_thread_runner);
+ 
++  // When the owner of this object is Disposed(), this method must be called to
++  // cancel any in-flight tasks.
++  void Shutdown();
++
+   HeapVector<Member<RTCRtpSynchronizationSource>> getSynchronizationSources(
+       ScriptState* script_state,
+       ExceptionState& exception_state,


### PR DESCRIPTION
[M108-LTS] Shutdown RtpContributingSourceCache in Dispose().

The cache is an off-heap object, but it is owned by an on-heap object
(RTCPeerConnection). Dispoing the owning object poisons memory owned by
it, but the cache may have in-flight tasks (cache doing ClearCache in a
delayed microtask). This CL adds a Shutdown() method to ensure the
cache isn't doing anything in the next microtask after disposal.

No reliable way to repro this has been found but the change should be
safe so hoping we can land without tests.

(cherry picked from commit 4d450ecd6ec7776c7505dcf7d2f04157ff3ba0eb)

Bug: 1413628
Change-Id: I479aace9859f4c10cd75d4aa5a34808b4726299d
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4247023
Commit-Queue: Henrik Boström <hbos@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1105653}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4291513
Reviewed-by: Achuith Bhandarkar <achuith@chromium.org>
Owners-Override: Achuith Bhandarkar <achuith@chromium.org>
Reviewed-by: Henrik Boström <hbos@chromium.org>
Commit-Queue: Zakhar Voit <voit@google.com>
Cr-Commit-Position: refs/branch-heads/5359@{#1404}
Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}


Ref electron/security#293

Notes: Security: backported fix for CVE-2023-1218.