### PR TITLE
chore: cherry-pick 0407102d19b9 and 183a57f4eabc from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -151,3 +151,4 @@ cherry-pick-06851790480e.patch
 cherry-pick-e79b89b47dac.patch
 m108-lts_simplify_webmediaplayermscompositor_destruction.patch
 m108-lts_further_simplify_webmediaplayermscompositor_lifetime.patch
+cherry-pick-0407102d19b9.patch

--- a/patches/chromium/cherry-pick-0407102d19b9.patch
+++ b/patches/chromium/cherry-pick-0407102d19b9.patch
@@ -1,0 +1,89 @@
+From 0407102d19b98fd3364fd42ee735667a1608f6d6 Mon Sep 17 00:00:00 2001
+From: Peter Boström <pbos@chromium.org>
+Date: Tue, 14 Mar 2023 16:49:10 +0000
+Subject: [PATCH] [M108-LTS] Convert known it != end() DCHECK failures to CHECK
+
+These have hit on DCHECK builds in the wild and precede erasing or
+dereferencing an iterator that is UB.
+
+This CL excludes DCHECK failures that precede non-DCHECK handling of the
+it != end() failures. Those should probably be rewritten as CHECKs
+but are less urgent and semi-orthogonal.
+
+Known crashes (one per file) are:
+
+crash/dc49e3cadab36d4c
+crash/0ee3427d25937024
+crash/b89303e84d123019
+crash/cc35183b861a4992
+
+(cherry picked from commit 1aec0b297900a7b59bd24314dff239f3c5697f45)
+
+Bug: 1418734
+Change-Id: I81ed7b45be33769e250c65c8bb7334a34be4380e
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4288168
+Commit-Queue: Peter Boström <pbos@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1109350}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4296138
+Commit-Queue: Roger Felipe Zanoni da Silva <rzanoni@google.com>
+Reviewed-by: Achuith Bhandarkar <achuith@chromium.org>
+Owners-Override: Achuith Bhandarkar <achuith@chromium.org>
+Reviewed-by: Peter Boström <pbos@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5359@{#1406}
+Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}
+---
+
+diff --git a/base/scoped_multi_source_observation.h b/base/scoped_multi_source_observation.h
+index 07ea3ed..cd368c23 100644
+--- a/base/scoped_multi_source_observation.h
++++ b/base/scoped_multi_source_observation.h
+@@ -68,7 +68,7 @@
+   // Remove the object passed to the constructor as an observer from |source|.
+   void RemoveObservation(Source* source) {
+     auto it = base::ranges::find(sources_, source);
+-    DCHECK(it != sources_.end());
++    CHECK(it != sources_.end());
+     sources_.erase(it);
+     (source->*RemoveObsFn)(observer_);
+   }
+diff --git a/cc/tiles/gpu_image_decode_cache.cc b/cc/tiles/gpu_image_decode_cache.cc
+index 8a49e44..4ad050d 100644
+--- a/cc/tiles/gpu_image_decode_cache.cc
++++ b/cc/tiles/gpu_image_decode_cache.cc
+@@ -1379,8 +1379,8 @@
+   }
+ 
+   auto entries_it = paint_image_entries_.find(it->second->paint_image_id);
+-  DCHECK(entries_it != paint_image_entries_.end());
+-  DCHECK_GT(entries_it->second.count, 0u);
++  CHECK(entries_it != paint_image_entries_.end());
++  CHECK_GT(entries_it->second.count, 0u);
+ 
+   // If this is the last entry for this image, remove its tracking.
+   --entries_it->second.count;
+diff --git a/third_party/blink/renderer/core/annotation/annotation_agent_impl.cc b/third_party/blink/renderer/core/annotation/annotation_agent_impl.cc
+index 4f4fbb6..9e91816 100644
+--- a/third_party/blink/renderer/core/annotation/annotation_agent_impl.cc
++++ b/third_party/blink/renderer/core/annotation/annotation_agent_impl.cc
+@@ -117,7 +117,7 @@
+ 
+   EphemeralRangeInFlatTree range = attached_range_->ToEphemeralRange();
+ 
+-  DCHECK(range.Nodes().begin() != range.Nodes().end());
++  CHECK(range.Nodes().begin() != range.Nodes().end());
+ 
+   Node& first_node = *range.Nodes().begin();
+ 
+diff --git a/ui/base/interaction/element_tracker_mac.mm b/ui/base/interaction/element_tracker_mac.mm
+index d3b8d98..b467aa2 100644
+--- a/ui/base/interaction/element_tracker_mac.mm
++++ b/ui/base/interaction/element_tracker_mac.mm
+@@ -50,7 +50,7 @@
+ 
+   void ActivateElement(ElementIdentifier identifier) {
+     const auto it = elements_.find(identifier);
+-    DCHECK(it != elements_.end());
++    CHECK(it != elements_.end());
+     ui::ElementTracker::GetFrameworkDelegate()->NotifyElementActivated(
+         it->second.get());
+   }

--- a/patches/chromium/cherry-pick-0407102d19b9.patch
+++ b/patches/chromium/cherry-pick-0407102d19b9.patch
@@ -1,7 +1,10 @@
-From 0407102d19b98fd3364fd42ee735667a1608f6d6 Mon Sep 17 00:00:00 2001
-From: Peter Boström <pbos@chromium.org>
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Peter=20Bostr=C3=B6m?= <pbos@chromium.org>
 Date: Tue, 14 Mar 2023 16:49:10 +0000
-Subject: [PATCH] [M108-LTS] Convert known it != end() DCHECK failures to CHECK
+Subject: Convert known it != end() DCHECK failures to CHECK
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 These have hit on DCHECK builds in the wild and precede erasing or
 dereferencing an iterator that is UB.
@@ -31,13 +34,12 @@ Owners-Override: Achuith Bhandarkar <achuith@chromium.org>
 Reviewed-by: Peter Boström <pbos@chromium.org>
 Cr-Commit-Position: refs/branch-heads/5359@{#1406}
 Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}
----
 
 diff --git a/base/scoped_multi_source_observation.h b/base/scoped_multi_source_observation.h
-index 07ea3ed..cd368c23 100644
+index fe2f2c7a07929bf74c2e9d93dd24bb99c5c0f60e..5a8b0fc5d832d3160b48978572ef385a47320d5d 100644
 --- a/base/scoped_multi_source_observation.h
 +++ b/base/scoped_multi_source_observation.h
-@@ -68,7 +68,7 @@
+@@ -68,7 +68,7 @@ class ScopedMultiSourceObservation {
    // Remove the object passed to the constructor as an observer from |source|.
    void RemoveObservation(Source* source) {
      auto it = base::ranges::find(sources_, source);
@@ -47,10 +49,10 @@ index 07ea3ed..cd368c23 100644
      (source->*RemoveObsFn)(observer_);
    }
 diff --git a/cc/tiles/gpu_image_decode_cache.cc b/cc/tiles/gpu_image_decode_cache.cc
-index 8a49e44..4ad050d 100644
+index 4b5068986f36ce813928e05c4ace213a3847fa1c..cee4079cd0f2f872364291ad402d612cb0eacba4 100644
 --- a/cc/tiles/gpu_image_decode_cache.cc
 +++ b/cc/tiles/gpu_image_decode_cache.cc
-@@ -1379,8 +1379,8 @@
+@@ -1389,8 +1389,8 @@ Iterator GpuImageDecodeCache::RemoveFromPersistentCache(Iterator it) {
    }
  
    auto entries_it = paint_image_entries_.find(it->second->paint_image_id);
@@ -62,10 +64,10 @@ index 8a49e44..4ad050d 100644
    // If this is the last entry for this image, remove its tracking.
    --entries_it->second.count;
 diff --git a/third_party/blink/renderer/core/annotation/annotation_agent_impl.cc b/third_party/blink/renderer/core/annotation/annotation_agent_impl.cc
-index 4f4fbb6..9e91816 100644
+index 248e0f6bec4c9546edf9a6eed778ee045f41707f..9ab2218009596781725381924821548841eaceb7 100644
 --- a/third_party/blink/renderer/core/annotation/annotation_agent_impl.cc
 +++ b/third_party/blink/renderer/core/annotation/annotation_agent_impl.cc
-@@ -117,7 +117,7 @@
+@@ -117,7 +117,7 @@ void AnnotationAgentImpl::ScrollIntoView() const {
  
    EphemeralRangeInFlatTree range = attached_range_->ToEphemeralRange();
  
@@ -75,10 +77,10 @@ index 4f4fbb6..9e91816 100644
    Node& first_node = *range.Nodes().begin();
  
 diff --git a/ui/base/interaction/element_tracker_mac.mm b/ui/base/interaction/element_tracker_mac.mm
-index d3b8d98..b467aa2 100644
+index b29ae9babb04d699ad529e4bd51b0cd12252f3cf..4d495fc36bbb62e8b828d2532424aba03b3c5950 100644
 --- a/ui/base/interaction/element_tracker_mac.mm
 +++ b/ui/base/interaction/element_tracker_mac.mm
-@@ -50,7 +50,7 @@
+@@ -50,7 +50,7 @@ void AddElement(ElementIdentifier identifier,
  
    void ActivateElement(ElementIdentifier identifier) {
      const auto it = elements_.find(identifier);


### PR DESCRIPTION
[M108-LTS] Convert known it != end() DCHECK failures to CHECK

These have hit on DCHECK builds in the wild and precede erasing or
dereferencing an iterator that is UB.

This CL excludes DCHECK failures that precede non-DCHECK handling of the
it != end() failures. Those should probably be rewritten as CHECKs
but are less urgent and semi-orthogonal.

Known crashes (one per file) are:

crash/dc49e3cadab36d4c
crash/0ee3427d25937024
crash/b89303e84d123019
crash/cc35183b861a4992

(cherry picked from commit 1aec0b297900a7b59bd24314dff239f3c5697f45)

Bug: 1418734
Change-Id: I81ed7b45be33769e250c65c8bb7334a34be4380e
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4288168
Commit-Queue: Peter Boström <pbos@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1109350}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4296138
Commit-Queue: Roger Felipe Zanoni da Silva <rzanoni@google.com>
Reviewed-by: Achuith Bhandarkar <achuith@chromium.org>
Owners-Override: Achuith Bhandarkar <achuith@chromium.org>
Reviewed-by: Peter Boström <pbos@chromium.org>
Cr-Commit-Position: refs/branch-heads/5359@{#1406}
Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}

============

[M108-LTS] Fix crash in AnnotationAgentImpl

This crash was occurring because the EphemeralRangeInFlatTree didn't
produce a Node. This is surprising since the RangeInFlatTree that it
comes from is checked for !IsCollapsed().

It turns out it's possible for RangeInFlatTree to be !IsCollapsed but
converting to EphemeralRangeInFlatTree causes IsCollapsed.

This CL ensures we early-out in the case that's tripping the CHECK. It
keeps the early-out exactly matching the CHECK since it must be merged
so we want to be extra sure. A followup will change this condition to
!EphemeralRangeInFlatTree::IsCollapsed which should be equivalent.

(cherry picked from [commit 92782b6d34b7a5e26d184e217f8f44e97539686e](https://chromium-review.googlesource.com/q/commit:92782b6d34b7a5e26d184e217f8f44e97539686e))

Bug: [1419712](https://bugs.chromium.org/p/chromium/issues/detail?id=1419712), [1418734](https://bugs.chromium.org/p/chromium/issues/detail?id=1418734)
Change-Id: [Id1d66a7a67711d463780b37c00600183d6c14f32](https://chromium-review.googlesource.com/q/Id1d66a7a67711d463780b37c00600183d6c14f32)
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4304486
Commit-Queue: David Bokan <bokan@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1112568}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4337742
Reviewed-by: Achuith Bhandarkar <achuith@chromium.org>
Owners-Override: Achuith Bhandarkar <achuith@chromium.org>
Commit-Queue: Zakhar Voit <voit@google.com>
Cr-Commit-Position: refs/branch-heads/5359@{#1409}
Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}

Notes: Security: backported fix for 1418734.