### PR TITLE
chore: cherry-pick 86fc0e9bedaf from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -137,8 +137,9 @@ cherry-pick-0407102d19b9.patch
 fix_crash_in_annotationagentimpl.patch
 cherry-pick-bfd926be8178.patch
 cherry-pick-9aa4c45f21b1.patch
-m108-lts_prevent_potential_integer_overflow_in.patch
 m108-lts_do_not_register_browser_watcher_activity_report_with.patch
+prevent_potential_integer_overflow_in_persistentmemoryallocator_1_2.patch
+m108-lts_prevent_potential_integer_overflow_in.patch
 cherry-pick-38de42d2bbc3.patch
 cherry-pick-8731bd8a30f6.patch
 cherry-pick-26bfa5807606.patch

--- a/patches/chromium/m108-lts_prevent_potential_integer_overflow_in.patch
+++ b/patches/chromium/m108-lts_prevent_potential_integer_overflow_in.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Will Harris <wfh@chromium.org>
 Date: Thu, 2 Mar 2023 17:21:30 +0000
-Subject: Prevent potential integer overflow in PersistentMemoryAllocator
+Subject: Prevent potential integer overflow in PersistentMemoryAllocator (2/2)
 
 https://crrev.com/c/4250177 added an extra check for potential
 integer overflow in GetAllocSize but forgot to add the same
@@ -29,25 +29,25 @@ Cr-Commit-Position: refs/branch-heads/5359@{#1402}
 Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}
 
 diff --git a/base/metrics/persistent_memory_allocator.cc b/base/metrics/persistent_memory_allocator.cc
-index bc4618bf30832d010570e8a490d3d893f064237b..d8146e96cf425adbf79a4ec484fcf72d151a888d 100644
+index b7edfc04c307662450f3a39c20142c3593fbacde..85b5290d8955240f8044054a280105e3f8362714 100644
 --- a/base/metrics/persistent_memory_allocator.cc
 +++ b/base/metrics/persistent_memory_allocator.cc
-@@ -881,8 +881,13 @@ PersistentMemoryAllocator::GetBlock(Reference ref,
+@@ -884,8 +884,13 @@ PersistentMemoryAllocator::GetBlock(Reference ref,
    if (ref % kAllocAlignment != 0)
      return nullptr;
    size += sizeof(BlockHeader);
 -  if (ref + size > mem_size_)
 +  uint32_t total_size;
 +  if (!base::CheckAdd(ref, size).AssignIfValid(&total_size)) {
-     return nullptr;
++    return nullptr;
 +  }
 +  if (total_size > mem_size_) {
-+    return nullptr;
+     return nullptr;
 +  }
  
    // Validation of referenced block-header.
    if (!free_ok) {
-@@ -892,8 +897,13 @@ PersistentMemoryAllocator::GetBlock(Reference ref,
+@@ -895,8 +900,13 @@ PersistentMemoryAllocator::GetBlock(Reference ref,
        return nullptr;
      if (block->size < size)
        return nullptr;

--- a/patches/chromium/prevent_potential_integer_overflow_in_persistentmemoryallocator_1_2.patch
+++ b/patches/chromium/prevent_potential_integer_overflow_in_persistentmemoryallocator_1_2.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Will Harris <wfh@chromium.org>
+Date: Thu, 2 Mar 2023 16:49:42 +0000
+Subject: Prevent potential integer overflow in PersistentMemoryAllocator (1/2)
+
+BUG=1415328
+
+(cherry picked from commit 19de280a0c28065acf2a7e001af5c981698a461c)
+
+Change-Id: I66dcae6a1aacc1310ddd715033b3704c932b9800
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4250177
+Commit-Queue: Will Harris <wfh@chromium.org>
+Commit-Queue: Alexei Svitkine <asvitkine@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1105177}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4279513
+Commit-Queue: Zakhar Voit <voit@google.com>
+Owners-Override: Victor-Gabriel Savu <vsavu@google.com>
+Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
+Cr-Commit-Position: refs/branch-heads/5359@{#1400}
+Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}
+
+diff --git a/base/metrics/persistent_memory_allocator.cc b/base/metrics/persistent_memory_allocator.cc
+index bc4618bf30832d010570e8a490d3d893f064237b..b7edfc04c307662450f3a39c20142c3593fbacde 100644
+--- a/base/metrics/persistent_memory_allocator.cc
++++ b/base/metrics/persistent_memory_allocator.cc
+@@ -531,7 +531,10 @@ size_t PersistentMemoryAllocator::GetAllocSize(Reference ref) const {
+   uint32_t size = block->size;
+   // Header was verified by GetBlock() but a malicious actor could change
+   // the value between there and here. Check it again.
+-  if (size <= sizeof(BlockHeader) || ref + size > mem_size_) {
++  uint32_t total_size;
++  if (size <= sizeof(BlockHeader) ||
++      !base::CheckAdd(ref, size).AssignIfValid(&total_size) ||
++      total_size > mem_size_) {
+     SetCorrupt();
+     return 0;
+   }


### PR DESCRIPTION
[M108-LTS] Prevent potential integer overflow in PersistentMemoryAllocator

BUG=[1415328](https://bugs.chromium.org/p/chromium/issues/detail?id=1415328)

(cherry picked from [commit 19de280a0c28065acf2a7e001af5c981698a461c](https://chromium-review.googlesource.com/q/commit:19de280a0c28065acf2a7e001af5c981698a461c))

Change-Id: [I66dcae6a1aacc1310ddd715033b3704c932b9800](https://chromium-review.googlesource.com/q/I66dcae6a1aacc1310ddd715033b3704c932b9800)
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4250177
Commit-Queue: Will Harris <wfh@chromium.org>
Commit-Queue: Alexei Svitkine <asvitkine@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1105177}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4279513
Commit-Queue: Zakhar Voit <voit@google.com>
Owners-Override: Victor-Gabriel Savu <vsavu@google.com>
Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
Cr-Commit-Position: refs/branch-heads/5359@{#1400}
Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}


Notes: Security: backported fix for 1417317.