### PR TITLE
chore: cherry-pick 38de42d2bbc3 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -133,3 +133,4 @@ m108-lts_further_simplify_webmediaplayermscompositor_lifetime.patch
 cherry-pick-e79b89b47dac.patch
 cherry-pick-06851790480e.patch
 cherry-pick-aeec1ba5893d.patch
+cherry-pick-38de42d2bbc3.patch

--- a/patches/chromium/cherry-pick-38de42d2bbc3.patch
+++ b/patches/chromium/cherry-pick-38de42d2bbc3.patch
@@ -1,0 +1,38 @@
+From 38de42d2bbc3ece9ba1bd57334633d351afa3f93 Mon Sep 17 00:00:00 2001
+From: Will Harris <wfh@chromium.org>
+Date: Thu, 02 Mar 2023 10:23:28 +0000
+Subject: [PATCH] [M108-LTS] Fix potential out of bounds write in base::SampleVectorBase
+
+BUG=1417185
+
+(cherry picked from commit 552939b035e724e022fedb90fd80cd008e441fcf)
+
+Change-Id: I70719d0f9afb81dda373f88ab3a1c177397659ec
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4265437
+Commit-Queue: Will Harris <wfh@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1106984}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4289351
+Commit-Queue: Zakhar Voit <voit@google.com>
+Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
+Owners-Override: Victor-Gabriel Savu <vsavu@google.com>
+Cr-Commit-Position: refs/branch-heads/5359@{#1397}
+Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}
+---
+
+diff --git a/base/metrics/sample_vector.cc b/base/metrics/sample_vector.cc
+index cec7687..a699557 100644
+--- a/base/metrics/sample_vector.cc
++++ b/base/metrics/sample_vector.cc
+@@ -274,6 +274,12 @@
+   if (sample.count == 0)
+     return;
+ 
++  // Stop here if the sample bucket would be out of range for the AtomicCount
++  // array.
++  if (sample.bucket >= counts_size()) {
++    return;
++  }
++
+   // Move the value into storage. Sum and redundant-count already account
+   // for this entry so no need to call IncreaseSumAndCount().
+   subtle::NoBarrier_AtomicIncrement(&counts()[sample.bucket], sample.count);


### PR DESCRIPTION
[M108-LTS] Fix potential out of bounds write in base::SampleVectorBase

BUG=1417185

(cherry picked from commit 552939b035e724e022fedb90fd80cd008e441fcf)

Change-Id: I70719d0f9afb81dda373f88ab3a1c177397659ec
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4265437
Commit-Queue: Will Harris <wfh@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1106984}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4289351
Commit-Queue: Zakhar Voit <voit@google.com>
Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
Owners-Override: Victor-Gabriel Savu <vsavu@google.com>
Cr-Commit-Position: refs/branch-heads/5359@{#1397}
Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}


Notes: Security: backported fix for 1417185.