### PR TITLE
chore: cherry-pick 38de42d2bbc3 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -151,3 +151,4 @@ cherry-pick-06851790480e.patch
 cherry-pick-e79b89b47dac.patch
 m108-lts_simplify_webmediaplayermscompositor_destruction.patch
 m108-lts_further_simplify_webmediaplayermscompositor_lifetime.patch
+cherry-pick-38de42d2bbc3.patch

--- a/patches/chromium/cherry-pick-38de42d2bbc3.patch
+++ b/patches/chromium/cherry-pick-38de42d2bbc3.patch
@@ -1,7 +1,7 @@
-From 38de42d2bbc3ece9ba1bd57334633d351afa3f93 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Will Harris <wfh@chromium.org>
-Date: Thu, 02 Mar 2023 10:23:28 +0000
-Subject: [PATCH] [M108-LTS] Fix potential out of bounds write in base::SampleVectorBase
+Date: Thu, 2 Mar 2023 10:23:28 +0000
+Subject: Fix potential out of bounds write in base::SampleVectorBase
 
 BUG=1417185
 
@@ -17,13 +17,12 @@ Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
 Owners-Override: Victor-Gabriel Savu <vsavu@google.com>
 Cr-Commit-Position: refs/branch-heads/5359@{#1397}
 Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}
----
 
 diff --git a/base/metrics/sample_vector.cc b/base/metrics/sample_vector.cc
-index cec7687..a699557 100644
+index 18f7f8a4adff18d733c57d497dccdaacb9cc814f..90daf7ce4e0e7567a7c2cafa2a6b5a70bd99417a 100644
 --- a/base/metrics/sample_vector.cc
 +++ b/base/metrics/sample_vector.cc
-@@ -274,6 +274,12 @@
+@@ -274,6 +274,12 @@ void SampleVectorBase::MoveSingleSampleToCounts() {
    if (sample.count == 0)
      return;
  

--- a/patches/chromium/cherry-pick-38de42d2bbc3.patch
+++ b/patches/chromium/cherry-pick-38de42d2bbc3.patch
@@ -1,0 +1,38 @@
+From 38de42d2bbc3ece9ba1bd57334633d351afa3f93 Mon Sep 17 00:00:00 2001
+From: Will Harris <wfh@chromium.org>
+Date: Thu, 02 Mar 2023 10:23:28 +0000
+Subject: [PATCH] [M108-LTS] Fix potential out of bounds write in base::SampleVectorBase
+
+BUG=1417185
+
+(cherry picked from commit 552939b035e724e022fedb90fd80cd008e441fcf)
+
+Change-Id: I70719d0f9afb81dda373f88ab3a1c177397659ec
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4265437
+Commit-Queue: Will Harris <wfh@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1106984}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4289351
+Commit-Queue: Zakhar Voit <voit@google.com>
+Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
+Owners-Override: Victor-Gabriel Savu <vsavu@google.com>
+Cr-Commit-Position: refs/branch-heads/5359@{#1397}
+Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}
+---
+
+diff --git a/base/metrics/sample_vector.cc b/base/metrics/sample_vector.cc
+index cec7687..a699557 100644
+--- a/base/metrics/sample_vector.cc
++++ b/base/metrics/sample_vector.cc
+@@ -274,6 +274,12 @@
+   if (sample.count == 0)
+     return;
+ 
++  // Stop here if the sample bucket would be out of range for the AtomicCount
++  // array.
++  if (sample.bucket >= counts_size()) {
++    return;
++  }
++
+   // Move the value into storage. Sum and redundant-count already account
+   // for this entry so no need to call IncreaseSumAndCount().
+   subtle::NoBarrier_AtomicIncrement(&counts()[sample.bucket], sample.count);


### PR DESCRIPTION
[M108-LTS] Fix potential out of bounds write in base::SampleVectorBase

BUG=1417185

(cherry picked from commit 552939b035e724e022fedb90fd80cd008e441fcf)

Change-Id: I70719d0f9afb81dda373f88ab3a1c177397659ec
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4265437
Commit-Queue: Will Harris <wfh@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1106984}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4289351
Commit-Queue: Zakhar Voit <voit@google.com>
Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
Owners-Override: Victor-Gabriel Savu <vsavu@google.com>
Cr-Commit-Position: refs/branch-heads/5359@{#1397}
Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}


Notes: Security: backported fix for CVE-2023-1220.