### PR TITLE
chore: cherry-pick 86fc0e9bedaf and 8d52bc14b306 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -133,3 +133,5 @@ m108-lts_further_simplify_webmediaplayermscompositor_lifetime.patch
 cherry-pick-e79b89b47dac.patch
 cherry-pick-06851790480e.patch
 cherry-pick-aeec1ba5893d.patch
+m108-lts_prevent_potential_integer_overflow_in.patch
+m108-lts_do_not_register_browser_watcher_activity_report_with.patch

--- a/patches/chromium/m108-lts_do_not_register_browser_watcher_activity_report_with.patch
+++ b/patches/chromium/m108-lts_do_not_register_browser_watcher_activity_report_with.patch
@@ -1,8 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Will Harris <wfh@chromium.org>
 Date: Thu, 2 Mar 2023 17:01:49 +0000
-Subject: [M108-LTS] Do not register browser_watcher activity report with
- crashpad
+Subject: Do not register browser_watcher activity report with crashpad
 
 BUG=1415328
 

--- a/patches/chromium/m108-lts_do_not_register_browser_watcher_activity_report_with.patch
+++ b/patches/chromium/m108-lts_do_not_register_browser_watcher_activity_report_with.patch
@@ -1,0 +1,73 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Will Harris <wfh@chromium.org>
+Date: Thu, 2 Mar 2023 17:01:49 +0000
+Subject: [M108-LTS] Do not register browser_watcher activity report with
+ crashpad
+
+BUG=1415328
+
+(cherry picked from commit f93c88303ccbb64014a575b8ae093aa166832922)
+
+Change-Id: I109f6dac083a69a26841ee5e975e02093ca4cbf6
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4257669
+Commit-Queue: Will Harris <wfh@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1106253}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4279942
+Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
+Commit-Queue: Zakhar Voit <voit@google.com>
+Owners-Override: Victor-Gabriel Savu <vsavu@google.com>
+Cr-Commit-Position: refs/branch-heads/5359@{#1401}
+Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}
+
+diff --git a/components/crash/core/app/BUILD.gn b/components/crash/core/app/BUILD.gn
+index 09219dd91f4205b38b36d3f62483cf2e9fc3782b..a45dec6b0708a0b0df1fc0f62283c730611b93b7 100644
+--- a/components/crash/core/app/BUILD.gn
++++ b/components/crash/core/app/BUILD.gn
+@@ -159,7 +159,6 @@ if (is_win) {
+     deps = [
+       "//base",
+       "//build:chromeos_buildflags",
+-      "//components/browser_watcher:activity_report",
+       "//components/gwp_asan/buildflags",
+       "//third_party/crashpad/crashpad/client",
+       "//third_party/crashpad/crashpad/handler",
+diff --git a/components/crash/core/app/DEPS b/components/crash/core/app/DEPS
+index 9717215396c918c46e683321115ed55ebcf6534d..9053a97a7068d5c3a240c9c7e99b0f7c2c2c038d 100644
+--- a/components/crash/core/app/DEPS
++++ b/components/crash/core/app/DEPS
+@@ -3,7 +3,6 @@ include_rules = [
+   "+third_party/breakpad",
+ 
+   "+components/crash/android/jni_headers",
+-  "+components/browser_watcher/activity_report_user_stream_data_source.h",
+   "+components/gwp_asan/buildflags/buildflags.h",
+   "+components/gwp_asan/crash_handler/crash_handler.h",
+   "+content/public/common/content_descriptors.h",
+diff --git a/components/crash/core/app/run_as_crashpad_handler_win.cc b/components/crash/core/app/run_as_crashpad_handler_win.cc
+index 5ae2702540dd635fa208f01ee84e92b2c2f1e220..ac2a160a172a75e6e4d12033b62c73551fb3e288 100644
+--- a/components/crash/core/app/run_as_crashpad_handler_win.cc
++++ b/components/crash/core/app/run_as_crashpad_handler_win.cc
+@@ -16,7 +16,6 @@
+ #include "base/strings/string_util.h"
+ #include "base/strings/utf_string_conversions.h"
+ #include "base/threading/platform_thread.h"
+-#include "components/browser_watcher/activity_report_user_stream_data_source.h"
+ #include "components/gwp_asan/buildflags/buildflags.h"
+ #include "third_party/crashpad/crashpad/client/crashpad_info.h"
+ #include "third_party/crashpad/crashpad/client/simple_string_dictionary.h"
+@@ -81,15 +80,6 @@ int RunAsCrashpadHandler(const base::CommandLine& command_line,
+   argv.clear();
+ 
+   crashpad::UserStreamDataSources user_stream_data_sources;
+-  // Interpret an empty user data directory as a missing value.
+-  if (!user_data_dir.empty()) {
+-    // Register an extension to collect stability information. The extension
+-    // will be invoked for any registered process' crashes, but information only
+-    // exists for instrumented browser processes.
+-    user_stream_data_sources.push_back(
+-        std::make_unique<browser_watcher::ActivityReportUserStreamDataSource>(
+-            user_data_dir));
+-  }
+ 
+ #if BUILDFLAG(ENABLE_GWP_ASAN)
+   user_stream_data_sources.push_back(

--- a/patches/chromium/m108-lts_prevent_potential_integer_overflow_in.patch
+++ b/patches/chromium/m108-lts_prevent_potential_integer_overflow_in.patch
@@ -1,8 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Will Harris <wfh@chromium.org>
 Date: Thu, 2 Mar 2023 17:21:30 +0000
-Subject: [M108-LTS] Prevent potential integer overflow in
- PersistentMemoryAllocator
+Subject: Prevent potential integer overflow in PersistentMemoryAllocator
 
 https://crrev.com/c/4250177 added an extra check for potential
 integer overflow in GetAllocSize but forgot to add the same
@@ -30,25 +29,25 @@ Cr-Commit-Position: refs/branch-heads/5359@{#1402}
 Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}
 
 diff --git a/base/metrics/persistent_memory_allocator.cc b/base/metrics/persistent_memory_allocator.cc
-index b7edfc04c307662450f3a39c20142c3593fbacde..85b5290d8955240f8044054a280105e3f8362714 100644
+index bc4618bf30832d010570e8a490d3d893f064237b..d8146e96cf425adbf79a4ec484fcf72d151a888d 100644
 --- a/base/metrics/persistent_memory_allocator.cc
 +++ b/base/metrics/persistent_memory_allocator.cc
-@@ -884,8 +884,13 @@ PersistentMemoryAllocator::GetBlock(Reference ref,
+@@ -881,8 +881,13 @@ PersistentMemoryAllocator::GetBlock(Reference ref,
    if (ref % kAllocAlignment != 0)
      return nullptr;
    size += sizeof(BlockHeader);
 -  if (ref + size > mem_size_)
 +  uint32_t total_size;
 +  if (!base::CheckAdd(ref, size).AssignIfValid(&total_size)) {
-+    return nullptr;
+     return nullptr;
 +  }
 +  if (total_size > mem_size_) {
-     return nullptr;
++    return nullptr;
 +  }
  
    // Validation of referenced block-header.
    if (!free_ok) {
-@@ -895,8 +900,13 @@ PersistentMemoryAllocator::GetBlock(Reference ref,
+@@ -892,8 +897,13 @@ PersistentMemoryAllocator::GetBlock(Reference ref,
        return nullptr;
      if (block->size < size)
        return nullptr;

--- a/patches/chromium/m108-lts_prevent_potential_integer_overflow_in.patch
+++ b/patches/chromium/m108-lts_prevent_potential_integer_overflow_in.patch
@@ -1,0 +1,65 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Will Harris <wfh@chromium.org>
+Date: Thu, 2 Mar 2023 17:21:30 +0000
+Subject: [M108-LTS] Prevent potential integer overflow in
+ PersistentMemoryAllocator
+
+https://crrev.com/c/4250177 added an extra check for potential
+integer overflow in GetAllocSize but forgot to add the same
+check in GetBlock.
+
+This meant that it was possible to get a pointer to a block
+but calling GetAllocSize on the same block would return zero.
+
+This change makes the two functions consistent with each other
+so calling GetBlock on invalid data will return nullptr.
+
+BUG=1417317,1415328
+
+(cherry picked from commit 81be8e8f2e13a9f1fe6d3150205a3c13af1db6e9)
+
+Change-Id: I8eb3d91bae4528fc97517d202baf337536a4c81f
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4264177
+Commit-Queue: Alexei Svitkine <asvitkine@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1107105}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4280124
+Owners-Override: Victor-Gabriel Savu <vsavu@google.com>
+Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
+Commit-Queue: Zakhar Voit <voit@google.com>
+Cr-Commit-Position: refs/branch-heads/5359@{#1402}
+Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}
+
+diff --git a/base/metrics/persistent_memory_allocator.cc b/base/metrics/persistent_memory_allocator.cc
+index b7edfc04c307662450f3a39c20142c3593fbacde..85b5290d8955240f8044054a280105e3f8362714 100644
+--- a/base/metrics/persistent_memory_allocator.cc
++++ b/base/metrics/persistent_memory_allocator.cc
+@@ -884,8 +884,13 @@ PersistentMemoryAllocator::GetBlock(Reference ref,
+   if (ref % kAllocAlignment != 0)
+     return nullptr;
+   size += sizeof(BlockHeader);
+-  if (ref + size > mem_size_)
++  uint32_t total_size;
++  if (!base::CheckAdd(ref, size).AssignIfValid(&total_size)) {
++    return nullptr;
++  }
++  if (total_size > mem_size_) {
+     return nullptr;
++  }
+ 
+   // Validation of referenced block-header.
+   if (!free_ok) {
+@@ -895,8 +900,13 @@ PersistentMemoryAllocator::GetBlock(Reference ref,
+       return nullptr;
+     if (block->size < size)
+       return nullptr;
+-    if (ref + block->size > mem_size_)
++    uint32_t block_size;
++    if (!base::CheckAdd(ref, block->size).AssignIfValid(&block_size)) {
+       return nullptr;
++    }
++    if (block_size > mem_size_) {
++      return nullptr;
++    }
+     if (type_id != 0 &&
+         block->type_id.load(std::memory_order_relaxed) != type_id) {
+       return nullptr;


### PR DESCRIPTION
[M108-LTS] Prevent potential integer overflow in PersistentMemoryAllocator

BUG=1415328

(cherry picked from commit 19de280a0c28065acf2a7e001af5c981698a461c)

Change-Id: I66dcae6a1aacc1310ddd715033b3704c932b9800
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4250177
Commit-Queue: Will Harris <wfh@chromium.org>
Commit-Queue: Alexei Svitkine <asvitkine@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1105177}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4279513
Commit-Queue: Zakhar Voit <voit@google.com>
Owners-Override: Victor-Gabriel Savu <vsavu@google.com>
Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
Cr-Commit-Position: refs/branch-heads/5359@{#1400}
Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}

============

[M108-LTS] Do not register browser_watcher activity report with crashpad

BUG=[1415328](https://bugs.chromium.org/p/chromium/issues/detail?id=1415328)

(cherry picked from [commit f93c88303ccbb64014a575b8ae093aa166832922](https://chromium-review.googlesource.com/q/commit:f93c88303ccbb64014a575b8ae093aa166832922))

Change-Id: [I109f6dac083a69a26841ee5e975e02093ca4cbf6](https://chromium-review.googlesource.com/q/I109f6dac083a69a26841ee5e975e02093ca4cbf6)
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4257669
Commit-Queue: Will Harris <wfh@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1106253}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4279942
Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
Commit-Queue: Zakhar Voit <voit@google.com>
Owners-Override: Victor-Gabriel Savu <vsavu@google.com>
Cr-Commit-Position: refs/branch-heads/5359@{#1401}
Cr-Branched-From: 27d3765d341b09369006d030f83f582a29eb57ae-refs/heads/main@{#1058933}

Notes: Security: backported fix for CVE-2023-1219.