### PR TITLE
ci: fixup gn check to actually run gn check

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -970,26 +970,13 @@ step-ts-compile: &step-ts-compile
 # List of all steps.
 steps-electron-gn-check: &steps-electron-gn-check
   steps:
-    - *step-checkout-electron
-    - *step-depot-tools-get
-    - *step-depot-tools-add-to-path
     - install-python2-mac
-    - *step-setup-env-for-build
     - *step-setup-goma-for-build
-    - *step-generate-deps-hash
-    - *step-touch-sync-done
-    - maybe-restore-portaled-src-cache
-    - run:
-        name: Ensure src checkout worked
-        command: |
-          if [ ! -d "src/third_party/blink" ]; then
-            echo src cache was not restored for an unknown reason
-            exit 1
-          fi
-    - run:
-        name: Wipe Electron
-        command: rm -rf src/electron
-    - *step-checkout-electron
+    - checkout-from-cache
+    - *step-setup-env-for-build
+    - *step-wait-for-goma
+    - *step-gn-gen-default
+    - *step-gn-check
 
 steps-electron-ts-compile-for-doc-change: &steps-electron-ts-compile-for-doc-change
   steps:


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

- Recent chromium rolls missed updates to filenames.libcxx.gni, resulting in followup PRs (#37567 and #37588) to fix the release builds.
- It turns out that we have a check for updates to this file in the 
[GN check ](https://app.circleci.com/pipelines/github/electron/electron/66709/workflows/c09619ff-070a-4990-a5b5-1a3e9aaed100/jobs/1470570/parallel-runs/0/steps/0-120), step that is supposed to run as part of our *-testing-gn-check jobs.
- However this step was accidentally removed last year in #34921 (via 539803d2e05545c380a254da3202224583b3708e) which means we haven't been running GN checks and checks for generated files needing updates.
- This PR fixes the GN check jobs to actually run the `GN check` step.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
