### PR TITLE
ci: update appveyor image to e-112.0.5615.29

### DIFF
--- a/appveyor-bake.yml
+++ b/appveyor-bake.yml
@@ -6,7 +6,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: e-112.0.5607.0-vs2022
+image: e-112.0.5615.29
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default

--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -29,7 +29,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: e-112.0.5607.0-vs2022
+image: e-112.0.5615.29
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: e-112.0.5607.0-vs2022
+image: e-112.0.5615.29
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default

--- a/script/prepare-appveyor.js
+++ b/script/prepare-appveyor.js
@@ -14,8 +14,8 @@ const ROLLER_BRANCH_PATTERN = /^roller\/chromium$/;
 
 const DEFAULT_BUILD_CLOUD_ID = '1598';
 const DEFAULT_BUILD_CLOUD = 'electronhq-16-core';
-const DEFAULT_BAKE_BASE_IMAGE = 'e-112.0.5607.0-vs2022';
-const DEFAULT_BUILD_IMAGE = 'e-112.0.5607.0-vs2022';
+const DEFAULT_BAKE_BASE_IMAGE = 'e-112.0.5615.29';
+const DEFAULT_BUILD_IMAGE = 'e-112.0.5615.29';
 
 const appveyorBakeJob = 'electron-bake-image';
 const appVeyorJobs = {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Updates the Appveyor image for 24-x-y to 112.0.5615.29

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
