### PR TITLE
chore: force LF endings for .html files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,4 +11,5 @@ patches/**/.patches merge=union
 *.ts text eol=lf
 *.py text eol=lf
 *.ps1 text eol=lf
+*.html text eol=lf
 *.md text eol=lf


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Adding `.html` to the list of source files we force to LF line endings. Was causing problems with trop, although a general fix for that was put into place with https://github.com/electron/trop/pull/254.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
