### PR TITLE
docs: update docs.microsoft.com links to learn.microsoft.com

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -804,7 +804,7 @@ editor. Please refer to [Apple's documentation][CFBundleURLTypes] for details.
 **Note:** In a Windows Store environment (when packaged as an `appx`) this API
 will return `true` for all calls but the registry key it sets won't be accessible
 by other applications.  In order to register your Windows Store application
-as a default protocol handler you must [declare the protocol in your manifest](https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-uap-protocol).
+as a default protocol handler you must [declare the protocol in your manifest](https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-uap-protocol).
 
 The API uses the Windows Registry and `LSSetDefaultHandlerForURLScheme` internally.
 

--- a/docs/api/structures/printer-info.md
+++ b/docs/api/structures/printer-info.md
@@ -7,7 +7,7 @@
 * `isDefault` boolean - whether or not a given printer is set as the default printer on the OS.
 * `options` Object - an object containing a variable number of platform-specific printer information.
 
-The number represented by `status` means different things on different platforms: on Windows its potential values can be found [here](https://docs.microsoft.com/en-us/windows/win32/printdocs/printer-info-2), and on Linux and macOS they can be found [here](https://www.cups.org/doc/cupspm.html).
+The number represented by `status` means different things on different platforms: on Windows its potential values can be found [here](https://learn.microsoft.com/en-us/windows/win32/printdocs/printer-info-2), and on Linux and macOS they can be found [here](https://www.cups.org/doc/cupspm.html).
 
 ## Example
 

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -269,9 +269,9 @@ Returns `boolean` - Whether double click events will be ignored.
 
 Displays a tray balloon.
 
-[NIIF_NOSOUND]: https://docs.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-notifyicondataa#niif_nosound-0x00000010
-[NIIF_LARGE_ICON]: https://docs.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-notifyicondataa#niif_large_icon-0x00000020
-[NIIF_RESPECT_QUIET_TIME]: https://docs.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-notifyicondataa#niif_respect_quiet_time-0x00000080
+[NIIF_NOSOUND]: https://learn.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-notifyicondataa#niif_nosound-0x00000010
+[NIIF_LARGE_ICON]: https://learn.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-notifyicondataa#niif_large_icon-0x00000020
+[NIIF_RESPECT_QUIET_TIME]: https://learn.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-notifyicondataa#niif_respect_quiet_time-0x00000080
 
 #### `tray.removeBalloon()` _Windows_
 

--- a/docs/development/azure-vm-setup.md
+++ b/docs/development/azure-vm-setup.md
@@ -1,6 +1,6 @@
 # Updating an Appveyor Azure Image
 
-Electron CI on Windows uses AppVeyor, which in turn uses Azure VM images to run.  Occasionally, these VM images need to be updated due to changes in Chromium requirements.  In order to update you will need [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-6) and the [Azure PowerShell module](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps?view=azps-1.8.0&viewFallbackFrom=azurermps-6.13.0).
+Electron CI on Windows uses AppVeyor, which in turn uses Azure VM images to run.  Occasionally, these VM images need to be updated due to changes in Chromium requirements.  In order to update you will need [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.3&viewFallbackFrom=powershell-6) and the [Azure PowerShell module](https://learn.microsoft.com/en-us/powershell/azure/install-az-ps?view=azps-9.5.0&viewFallbackFrom=azps-1.8.0).
 
 Occasionally we need to update these images owing to changes in Chromium or other miscellaneous build requirement changes.
 

--- a/docs/development/debugging-on-windows.md
+++ b/docs/development/debugging-on-windows.md
@@ -94,7 +94,7 @@ out [this video tutorial][procmon-instructions] provided by Microsoft.
 ## Using WinDbg
 <!-- TODO(@codebytere): add images and more information here? -->
 
-It's possible to debug crashes and issues in the Renderer process with [WinDbg](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/getting-started-with-windbg).
+It's possible to debug crashes and issues in the Renderer process with [WinDbg](https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/getting-started-with-windbg).
 
 To attach to a debug a process with WinDbg:
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -79,7 +79,7 @@ the Node.js source tree.
 
 #### Missing fonts
 
-[Some Windows 10 devices](https://docs.microsoft.com/en-us/typography/fonts/windows_10_font_list) do not ship with the Meiryo font installed, which may cause a font fallback test to fail. To install Meiryo:
+[Some Windows 10 devices](https://learn.microsoft.com/en-us/typography/fonts/windows_10_font_list) do not ship with the Meiryo font installed, which may cause a font fallback test to fail. To install Meiryo:
 
 1. Push the Windows key and search for _Manage optional features_.
 2. Click _Add a feature_.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -234,7 +234,7 @@ embedded content.
 [context isolation]: tutorial/context-isolation.md
 [mac app store submission guide]: tutorial/mac-app-store-submission-guide.md
 [main]: #main-process
-[msi]: https://docs.microsoft.com/en-us/windows/win32/msi/windows-installer-portal
+[msi]: https://learn.microsoft.com/en-us/windows/win32/msi/windows-installer-portal
 [Native Node Modules]: tutorial/using-native-node-modules.md
 [offscreen rendering]: tutorial/offscreen-rendering.md
 [process sandboxing]: tutorial/sandbox.md

--- a/docs/tutorial/code-signing.md
+++ b/docs/tutorial/code-signing.md
@@ -200,4 +200,4 @@ See the [Windows Store Guide][].
 [windows store guide]: ./windows-store-guide.md
 [maker-squirrel]: https://www.electronforge.io/config/makers/squirrel.windows
 [maker-msi]: https://www.electronforge.io/config/makers/wix-msi
-[signtool.exe]: https://docs.microsoft.com/en-us/dotnet/framework/tools/signtool-exe
+[signtool.exe]: https://learn.microsoft.com/en-us/dotnet/framework/tools/signtool-exe

--- a/docs/tutorial/tutorial-2-first-app.md
+++ b/docs/tutorial/tutorial-2-first-app.md
@@ -465,7 +465,7 @@ privileged APIs and how to communicate between processes.
 [repl]: ./repl.md
 [webpack]: https://webpack.js.org
 [window-all-closed]: ../api/app.md#event-window-all-closed
-[wsl]: https://docs.microsoft.com/en-us/windows/wsl/about#what-is-wsl-2
+[wsl]: https://learn.microsoft.com/en-us/windows/wsl/about#what-is-wsl-2
 
 <!-- Tutorial links -->
 

--- a/docs/tutorial/windows-arm.md
+++ b/docs/tutorial/windows-arm.md
@@ -88,7 +88,7 @@ After completing all of the above, open your cross-compilation command prompt an
 
 ## Debugging native modules
 
-Debugging native modules can be done with Visual Studio 2017 (running on your development machine) and corresponding [Visual Studio Remote Debugger](https://docs.microsoft.com/en-us/visualstudio/debugger/remote-debugging-cpp?view=vs-2019) running on the target device. To debug:
+Debugging native modules can be done with Visual Studio 2017 (running on your development machine) and corresponding [Visual Studio Remote Debugger](https://learn.microsoft.com/en-us/visualstudio/debugger/remote-debugging-cpp?view=vs-2019) running on the target device. To debug:
 
 1. Launch your app `.exe` on the target device via the _Command Prompt_ (passing `--inspect-brk` to pause it before any native modules are loaded).
 2. Launch Visual Studio 2017 on your development machine.

--- a/docs/tutorial/windows-taskbar.md
+++ b/docs/tutorial/windows-taskbar.md
@@ -89,7 +89,7 @@ app.setUserTasks([])
 > NOTE: The user tasks will still be displayed even after closing your
 application, so the icon and program path specified for a task should exist until your application is uninstalled.
 
-[msdn-jumplist]: https://docs.microsoft.com/en-us/windows/win32/shell/taskbar-extensions#tasks
+[msdn-jumplist]: https://learn.microsoft.com/en-us/windows/win32/shell/taskbar-extensions#tasks
 
 ### Thumbnail Toolbars
 
@@ -156,7 +156,7 @@ const win = new BrowserWindow()
 win.setThumbarButtons([])
 ```
 
-[msdn-thumbnail]: https://docs.microsoft.com/en-us/windows/win32/shell/taskbar-extensions#thumbnail-toolbars
+[msdn-thumbnail]: https://learn.microsoft.com/en-us/windows/win32/shell/taskbar-extensions#thumbnail-toolbars
 
 ### Icon Overlays in Taskbar
 
@@ -196,7 +196,7 @@ const win = new BrowserWindow()
 win.setOverlayIcon('path/to/overlay.png', 'Description for overlay')
 ```
 
-[msdn-icon-overlay]: https://docs.microsoft.com/en-us/windows/win32/shell/taskbar-extensions#icon-overlays
+[msdn-icon-overlay]: https://learn.microsoft.com/en-us/windows/win32/shell/taskbar-extensions#icon-overlays
 
 ### Flash Frame
 
@@ -230,7 +230,7 @@ win.flashFrame(true)
 In the above example, it is called when the window comes into focus,
 but you might use a timeout or some other event to disable it.
 
-[msdn-flash-frame]: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-flashwindow#remarks
+[msdn-flash-frame]: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-flashwindow#remarks
 
 [setthumbarbuttons]: ../api/browser-window.md#winsetthumbarbuttonsbuttons-windows
 [setusertaskstasks]: ../api/app.md#appsetusertaskstasks-windows


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Similar to https://github.com/electron/electron/pull/37603. `docs.microsoft.com` redirects to `learn.microsoft.com`, so updating these links.

Leaving one link on `docs/tutorial/windows-store-guide.md` because it looks like it might be a different page rather than a simple redirect, and needs to be dug further into, so leaving the original link to not lose that context.

cc @electron/docs 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
