### PR TITLE
docs: fixup incorrect value for disabling sandbox

### DIFF
--- a/docs/tutorial/sandbox.md
+++ b/docs/tutorial/sandbox.md
@@ -84,7 +84,7 @@ the `sandbox: false` preference in the [`BrowserWindow`][browser-window] constru
 app.whenReady().then(() => {
   const win = new BrowserWindow({
     webPreferences: {
-      sandbox: true
+      sandbox: false
     }
   })
   win.loadURL('https://google.com')


### PR DESCRIPTION
#### Description of Change

For disabling the sandbox, `sandbox` should be assigned to false, however the demo code is using incorrect value.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

@electron/docs

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: None<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
