### PR TITLE
feat: add powerMonitor.isSystemAutomaticallyResumed API

### DIFF
--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -73,6 +73,12 @@ Returns `boolean` - Whether the system is on battery power.
 To monitor for changes in this property, use the `on-battery` and `on-ac`
 events.
 
+### `powerMonitor.isSystemAutomaticallyResumed()` _Windows_
+
+Returns `boolean` - Whether the system was resumed automatically or due to user input.  This maps directly to the `IsSystemResumeAutomatic` win32 API.
+
+https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-issystemresumeautomatic
+
 ## Properties
 
 ### `powerMonitor.onBatteryPower`

--- a/lib/browser/api/power-monitor.ts
+++ b/lib/browser/api/power-monitor.ts
@@ -5,7 +5,8 @@ const {
   createPowerMonitor,
   getSystemIdleState,
   getSystemIdleTime,
-  isOnBatteryPower
+  isOnBatteryPower,
+  isSystemAutomaticallyResumed
 } = process._linkedBinding('electron_browser_power_monitor');
 
 class PowerMonitor extends EventEmitter {
@@ -53,6 +54,10 @@ class PowerMonitor extends EventEmitter {
 
   get onBatteryPower () {
     return this.isOnBatteryPower();
+  }
+
+  isSystemAutomaticallyResumed () {
+    return isSystemAutomaticallyResumed();
   }
 }
 

--- a/shell/browser/api/electron_api_power_monitor.cc
+++ b/shell/browser/api/electron_api_power_monitor.cc
@@ -150,6 +150,11 @@ void Initialize(v8::Local<v8::Object> exports,
                  base::BindRepeating(&GetSystemIdleState));
   dict.SetMethod("getSystemIdleTime", base::BindRepeating(&GetSystemIdleTime));
   dict.SetMethod("isOnBatteryPower", base::BindRepeating(&IsOnBatteryPower));
+#if BUILDFLAG(IS_WIN)
+  dict.SetMethod(
+      "isSystemAutomaticallyResumed",
+      base::BindRepeating(&PowerMonitor::IsSystemAutomaticallyResumed));
+#endif
 }
 
 }  // namespace

--- a/shell/browser/api/electron_api_power_monitor.h
+++ b/shell/browser/api/electron_api_power_monitor.h
@@ -69,6 +69,8 @@ class PowerMonitor : public gin::Wrappable<PowerMonitor>,
                            WPARAM wparam,
                            LPARAM lparam);
 
+  static bool IsSystemAutomaticallyResumed();
+
   // The window class of |window_|.
   ATOM atom_;
 

--- a/shell/browser/api/electron_api_power_monitor.h
+++ b/shell/browser/api/electron_api_power_monitor.h
@@ -25,6 +25,10 @@ class PowerMonitor : public gin::Wrappable<PowerMonitor>,
  public:
   static v8::Local<v8::Value> Create(v8::Isolate* isolate);
 
+#if BUILDFLAG(IS_WIN)
+  static bool IsSystemAutomaticallyResumed();
+#endif
+
   // gin::Wrappable
   static gin::WrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
@@ -68,8 +72,6 @@ class PowerMonitor : public gin::Wrappable<PowerMonitor>,
                            UINT message,
                            WPARAM wparam,
                            LPARAM lparam);
-
-  static bool IsSystemAutomaticallyResumed();
 
   // The window class of |window_|.
   ATOM atom_;

--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/api/electron_api_power_monitor.h"
 
+#include <winbase.h>
 #include <windows.h>
 #include <wtsapi32.h>
 
@@ -101,6 +102,10 @@ LRESULT CALLBACK PowerMonitor::WndProc(HWND hwnd,
     }
   }
   return ::DefWindowProc(hwnd, message, wparam, lparam);
+}
+
+bool PowerMonitor::IsSystemAutomaticallyResumed() {
+  return IsSystemResumeAutomatic();
 }
 
 }  // namespace api


### PR DESCRIPTION
Direct expose of win32 API

Notes: Added new `powerMonitor.isSystemAutomaticallyResumed` API to check if the system was woken by user input