### PR TITLE
build: fix build-tools schema in config

### DIFF
--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -35,8 +35,13 @@ if [ ! -f $buildtools/configs/evm.testing.json ]; then
   write_config() {
     echo "
         {
-            \"root\": \"/workspaces/gclient\",
             \"goma\": \"$1\",
+            \"root\": \"/workspaces/gclient\",
+            \"remotes\": {
+                \"electron\": {
+                    \"origin\": \"https://github.com/electron/electron.git\"
+                }
+            }
             \"gen\": {
                 \"args\": [
                     \"import(\\\"//electron/build/args/testing.gn\\\")\",
@@ -48,11 +53,7 @@ if [ ! -f $buildtools/configs/evm.testing.json ]; then
                 \"CHROMIUM_BUILDTOOLS_PATH\": \"/workspaces/gclient/src/buildtools\",
                 \"GIT_CACHE_PATH\": \"/workspaces/gclient/.git-cache\"
             },
-            \"remotes\": {
-                \"electron\": {
-                    \"origin\": \"https://github.com/electron/electron.git\"
-                }
-            }
+            \"$schema\": \"file:///home/builduser/.electron_build_tools/evm-config.schema.json\"
         }
     " >$buildtools/configs/evm.testing.json
   }


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/build-tools/pull/421/

Prevents the following on every build in Codespaces:

```
builduser@9bbff9c296d0:/workspaces/gclient/src/electron$ e build
WARN We've made these temporary changes to your configuration:
 * added missing property $schema
Run "e sanitize-config" to make these changes permanent.
WARN We've made these temporary changes to your configuration:
 * added missing property $schema
Run "e sanitize-config" to make these changes permanent.
```

Also tweaks order of config to match build-tools default.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none