### PR TITLE
test: remove workaround for fixed Menu.closePopup issue

### DIFF
--- a/spec/api-menu-spec.ts
+++ b/spec/api-menu-spec.ts
@@ -817,10 +817,7 @@ describe('Menu module', function () {
     it('should emit menu-will-close event', (done) => {
       menu.on('menu-will-close', () => { done(); });
       menu.popup({ window: w });
-      // https://github.com/electron/electron/issues/19411
-      setTimeout().then(() => {
-        menu.closePopup();
-      });
+      menu.closePopup();
     });
 
     it('returns immediately', () => {
@@ -849,18 +846,12 @@ describe('Menu module', function () {
 
       expect(x).to.equal(100);
       expect(y).to.equal(101);
-      // https://github.com/electron/electron/issues/19411
-      setTimeout().then(() => {
-        menu.closePopup();
-      });
+      menu.closePopup();
     });
 
     it('works with a given BrowserWindow, no options, and a callback', (done) => {
       menu.popup({ window: w, callback: () => done() });
-      // https://github.com/electron/electron/issues/19411
-      setTimeout().then(() => {
-        menu.closePopup();
-      });
+      menu.closePopup();
     });
 
     it('prevents menu from getting garbage-collected when popuping', async () => {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Was fixed a while ago in #20114, so remove the workaround on these tests.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
