### PR TITLE
fix: showAboutPanel also on linux

### DIFF
--- a/lib/browser/api/menu-item-roles.ts
+++ b/lib/browser/api/menu-item-roles.ts
@@ -26,7 +26,7 @@ export const roleList: Record<RoleId, Role> = {
     get label () {
       return isLinux ? 'About' : `About ${app.name}`;
     },
-    ...(isWindows && { appMethod: () => app.showAboutPanel() })
+    ...((isWindows || isLinux) && { appMethod: () => app.showAboutPanel() })
   },
   close: {
     label: isMac ? 'Close Window' : 'Close',


### PR DESCRIPTION
#### Description of Change

Similar to #23681 - `role`: `about` doesn't work on Linux, even though docs make it look like it works.

See also #23847 #23851 https://github.com/mifi/lossless-cut/issues/1537

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added about panel for menu role `about` on Linux as well
