### PR TITLE
fix: recommended `node-gyp` version in `node.h` error

### DIFF
--- a/patches/node/allow_embedder_to_control_codegenerationfromstringscallback.patch
+++ b/patches/node/allow_embedder_to_control_codegenerationfromstringscallback.patch
@@ -30,7 +30,7 @@ index a994221445471b92d12ed9cb3bef9ffb70670ab6..d6c6fd9c257cb51ba387c4b4d07a24ff
    Mutex::ScopedLock lock(node::per_process::cli_options_mutex);
    if (per_process::cli_options->get_per_isolate_options()
 diff --git a/src/node.h b/src/node.h
-index 6ff7527d4fe4d126bda80615ffed75f77f700b86..5a849f047feca5d4d101c21c125e1c0500150077 100644
+index 03f55b0a1853c055eb6c709a8e7916c2a95672d3..47ac8c24ef5e26822f694b583767e850fc5f7d96 100644
 --- a/src/node.h
 +++ b/src/node.h
 @@ -463,6 +463,8 @@ struct IsolateSettings {

--- a/patches/node/build_ensure_native_module_compilation_fails_if_not_using_a_new.patch
+++ b/patches/node/build_ensure_native_module_compilation_fails_if_not_using_a_new.patch
@@ -52,7 +52,7 @@ index bfa20f5fc7a64b30b464327f4086a027e9a23359..f9d849260c3d7b1368d375125ae587ea
    o['variables']['v8_enable_javascript_promise_hooks'] = 1
    o['variables']['v8_enable_lite_mode'] = 1 if options.v8_lite_mode else 0
 diff --git a/src/node.h b/src/node.h
-index 173e0bc669a2fd90e764da72e09003f4c7311fd7..6ff7527d4fe4d126bda80615ffed75f77f700b86 100644
+index 173e0bc669a2fd90e764da72e09003f4c7311fd7..03f55b0a1853c055eb6c709a8e7916c2a95672d3 100644
 --- a/src/node.h
 +++ b/src/node.h
 @@ -22,6 +22,12 @@
@@ -61,7 +61,7 @@ index 173e0bc669a2fd90e764da72e09003f4c7311fd7..6ff7527d4fe4d126bda80615ffed75f7
  
 +#ifdef ELECTRON_ENSURE_CONFIG_GYPI
 +#ifndef USING_ELECTRON_CONFIG_GYPI
-+#error "It looks like you are building this native module without using the right config.gypi.  This normally means that you need to update electron-rebuild (>=3.2.8) or node-gyp (>=8.4.0) if you're building modules directly."
++#error "It looks like you are building this native module without using the right config.gypi.  This normally means that you need to update electron-rebuild (>=3.2.8) or node-gyp (>=9.0.0) if you're building modules directly."
 +#endif
 +#endif
 +

--- a/patches/node/src_allow_optional_isolation_termination_in_node.patch
+++ b/patches/node/src_allow_optional_isolation_termination_in_node.patch
@@ -61,7 +61,7 @@ index 1067dee74c8877d9a3a0da6527c4c37faf9bd15f..b550fd4aa8488c6d721db3dee94cc4ce
  }
  
 diff --git a/src/node.h b/src/node.h
-index 5a849f047feca5d4d101c21c125e1c0500150077..db9a9c5c54f176ffdfc67e045b970729341eee7f 100644
+index 47ac8c24ef5e26822f694b583767e850fc5f7d96..f1fb363becf1f1b3b3ef0b2782c6561d29aa7cbd 100644
 --- a/src/node.h
 +++ b/src/node.h
 @@ -316,7 +316,7 @@ NODE_EXTERN int Start(int argc, char* argv[]);


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

In
https://github.com/electron/electron/blob/main/docs/tutorial/using-native-node-modules.md#using-npm, we recommend setting the `npm_config_disturl` variable but doing that does not work on node-gyp v8.4.0 because after
https://github.com/nodejs/node-gyp/pull/2497
landed, the dist URL was read only from `gyp.opts['dist-url']`. The fix for reading the value from `npm_config_disturl` by parsing `gyp.opts.disturl` was landed in
https://github.com/nodejs/node-gyp/pull/2547 and that change was released in node-gyp v9.0.0, so this change updates the error macro to recommend node-gyp v9.0.0 as the minimum required version.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix recommended `node-gyp` version in `node.h` error <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->

cc @zcbenz