### PR TITLE
test: support 'latest'/'latest@X' Electron version strings

### DIFF
--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -64,10 +64,24 @@ if (args.runners !== undefined) {
 async function main () {
   if (args.electronVersion) {
     const versions = await ElectronVersions.create();
-    if (!versions.isVersion(args.electronVersion)) {
+    if (args.electronVersion === 'latest') {
+      args.electronVersion = versions.latest.version;
+    } else if (args.electronVersion.startsWith('latest@')) {
+      const majorVersion = parseInt(args.electronVersion.slice('latest@'.length));
+      const ver = versions.inMajor(majorVersion).slice(-1)[0];
+      if (ver) {
+        args.electronVersion = ver.version;
+      } else {
+        console.log(`${fail} '${majorVersion}' is not a recognized Electron major version`);
+        process.exit(1);
+      }
+    } else if (!versions.isVersion(args.electronVersion)) {
       console.log(`${fail} '${args.electronVersion}' is not a recognized Electron version`);
       process.exit(1);
     }
+
+    const versionString = `v${args.electronVersion}`;
+    console.log(`Running against Electron ${versionString.green}`);
   }
 
   const [lastSpecHash, lastSpecInstallHash] = loadLastSpecHash();


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Expands on #36944 to support version strings which get the latest version on a major version. Also adds a log message to state which version is being used.

```sh
yarn test --electronVersion latest
yarn test --electronVersion latest@24
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
