### PR TITLE
chore: cherry-pick d9081493c4b2 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -146,3 +146,4 @@ cherry-pick-b5c9e5efe5dd.patch
 cherry-pick-56bd20b295b4.patch
 cherry-pick-1235110fce18.patch
 cherry-pick-b041159d06ad.patch
+cherry-pick-d9081493c4b2.patch

--- a/patches/chromium/cherry-pick-d9081493c4b2.patch
+++ b/patches/chromium/cherry-pick-d9081493c4b2.patch
@@ -1,0 +1,91 @@
+From d9081493c4b2d7dece6312335c868a33f7c4958e Mon Sep 17 00:00:00 2001
+From: kylechar <kylechar@chromium.org>
+Date: Tue, 28 Feb 2023 21:02:51 +0000
+Subject: [PATCH] Add CHECKs in HostFrameSinkManager
+
+It looks like it's possible for a compromised renderer to get multiple
+things to register the same FrameSinkId with HostFrameSinkManager. This
+violates assumptions around ownership so turn DCHECKs here into CHECKs.
+Also convert DCHECKs into CHECKs for registering/unregistering frame
+sink hierarchy just in case.
+
+(cherry picked from commit a707ac2d95e4726f4cf0267c9b0c038926c2a691)
+
+Bug: 1414018
+Change-Id: If948e758a8484024666f4066360620bc3a9cb493
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4283141
+Reviewed-by: Martin Kreichgauer <martinkr@google.com>
+Reviewed-by: Jonathan Ross <jonross@chromium.org>
+Commit-Queue: Kyle Charbonneau <kylechar@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1109533}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4298330
+Cr-Commit-Position: refs/branch-heads/5615@{#69}
+Cr-Branched-From: 9c6408ef696e83a9936b82bbead3d41c93c82ee4-refs/heads/main@{#1109224}
+---
+
+diff --git a/components/viz/host/host_frame_sink_manager.cc b/components/viz/host/host_frame_sink_manager.cc
+index 284e9ef..21e6cab 100644
+--- a/components/viz/host/host_frame_sink_manager.cc
++++ b/components/viz/host/host_frame_sink_manager.cc
+@@ -65,7 +65,7 @@
+   DCHECK(client);
+ 
+   FrameSinkData& data = frame_sink_data_map_[frame_sink_id];
+-  DCHECK(!data.IsFrameSinkRegistered());
++  CHECK(!data.IsFrameSinkRegistered());
+   DCHECK(!data.has_created_compositor_frame_sink);
+   data.client = client;
+   data.report_activation = report_activation;
+@@ -84,7 +84,7 @@
+   DCHECK(frame_sink_id.is_valid());
+ 
+   FrameSinkData& data = frame_sink_data_map_[frame_sink_id];
+-  DCHECK(data.IsFrameSinkRegistered());
++  CHECK(data.IsFrameSinkRegistered());
+ 
+   const bool destroy_synchronously =
+       data.has_created_compositor_frame_sink && data.wait_on_destruction;
+@@ -225,14 +225,14 @@
+     return false;
+   }
+ 
++  FrameSinkData& parent_data = iter->second;
++  CHECK(!base::Contains(parent_data.children, child_frame_sink_id));
++  parent_data.children.push_back(child_frame_sink_id);
++
+   // Register and store the parent.
+   frame_sink_manager_->RegisterFrameSinkHierarchy(parent_frame_sink_id,
+                                                   child_frame_sink_id);
+ 
+-  FrameSinkData& parent_data = iter->second;
+-  DCHECK(!base::Contains(parent_data.children, child_frame_sink_id));
+-  parent_data.children.push_back(child_frame_sink_id);
+-
+   return true;
+ }
+ 
+@@ -241,8 +241,9 @@
+     const FrameSinkId& child_frame_sink_id) {
+   // Unregister and clear the stored parent.
+   FrameSinkData& parent_data = frame_sink_data_map_[parent_frame_sink_id];
+-  DCHECK(base::Contains(parent_data.children, child_frame_sink_id));
+-  base::Erase(parent_data.children, child_frame_sink_id);
++  size_t num_erased = base::Erase(parent_data.children, child_frame_sink_id);
++  CHECK_EQ(num_erased, 1u);
++
+   if (parent_data.IsEmpty())
+     frame_sink_data_map_.erase(parent_frame_sink_id);
+ 
+diff --git a/components/viz/service/frame_sinks/frame_sink_manager_impl.cc b/components/viz/service/frame_sinks/frame_sink_manager_impl.cc
+index 5e18213..cfbc9d1 100644
+--- a/components/viz/service/frame_sinks/frame_sink_manager_impl.cc
++++ b/components/viz/service/frame_sinks/frame_sink_manager_impl.cc
+@@ -286,7 +286,7 @@
+   }
+ 
+   auto iter = frame_sink_source_map_.find(parent_frame_sink_id);
+-  DCHECK(iter != frame_sink_source_map_.end());
++  CHECK(iter != frame_sink_source_map_.end());
+ 
+   // Remove |child_frame_sink_id| from parents list of children.
+   auto& mapping = iter->second;


### PR DESCRIPTION
Add CHECKs in HostFrameSinkManager

It looks like it's possible for a compromised renderer to get multiple
things to register the same FrameSinkId with HostFrameSinkManager. This
violates assumptions around ownership so turn DCHECKs here into CHECKs.
Also convert DCHECKs into CHECKs for registering/unregistering frame
sink hierarchy just in case.

(cherry picked from commit a707ac2d95e4726f4cf0267c9b0c038926c2a691)

Bug: 1414018
Change-Id: If948e758a8484024666f4066360620bc3a9cb493
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4283141
Reviewed-by: Martin Kreichgauer <martinkr@google.com>
Reviewed-by: Jonathan Ross <jonross@chromium.org>
Commit-Queue: Kyle Charbonneau <kylechar@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1109533}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4298330
Cr-Commit-Position: refs/branch-heads/5615@{#69}
Cr-Branched-From: 9c6408ef696e83a9936b82bbead3d41c93c82ee4-refs/heads/main@{#1109224}


Ref electron/security#308

Notes: Security: backported fix for CVE-2023-1810.