### PR TITLE
fix: defaultFontFamily in webPreferences

### DIFF
--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -425,24 +425,28 @@ void WebContentsPreferences::OverrideWebkitPrefs(
   prefs->web_security_enabled = web_security_;
   prefs->allow_running_insecure_content = allow_running_insecure_content_;
 
-  if (auto font =
-          default_font_family_.find("standard") != default_font_family_.end())
-    prefs->standard_font_family_map[blink::web_pref::kCommonScript] = font;
-  if (auto font =
-          default_font_family_.find("serif") != default_font_family_.end())
-    prefs->serif_font_family_map[blink::web_pref::kCommonScript] = font;
-  if (auto font =
-          default_font_family_.find("sansSerif") != default_font_family_.end())
-    prefs->sans_serif_font_family_map[blink::web_pref::kCommonScript] = font;
-  if (auto font =
-          default_font_family_.find("monospace") != default_font_family_.end())
-    prefs->fixed_font_family_map[blink::web_pref::kCommonScript] = font;
-  if (auto font =
-          default_font_family_.find("cursive") != default_font_family_.end())
-    prefs->cursive_font_family_map[blink::web_pref::kCommonScript] = font;
-  if (auto font =
-          default_font_family_.find("fantasy") != default_font_family_.end())
-    prefs->fantasy_font_family_map[blink::web_pref::kCommonScript] = font;
+  if (auto iter = default_font_family_.find("standard");
+      iter != default_font_family_.end())
+    prefs->standard_font_family_map[blink::web_pref::kCommonScript] =
+        iter->second;
+  if (auto iter = default_font_family_.find("serif");
+      iter != default_font_family_.end())
+    prefs->serif_font_family_map[blink::web_pref::kCommonScript] = iter->second;
+  if (auto iter = default_font_family_.find("sansSerif");
+      iter != default_font_family_.end())
+    prefs->sans_serif_font_family_map[blink::web_pref::kCommonScript] =
+        iter->second;
+  if (auto iter = default_font_family_.find("monospace");
+      iter != default_font_family_.end())
+    prefs->fixed_font_family_map[blink::web_pref::kCommonScript] = iter->second;
+  if (auto iter = default_font_family_.find("cursive");
+      iter != default_font_family_.end())
+    prefs->cursive_font_family_map[blink::web_pref::kCommonScript] =
+        iter->second;
+  if (auto iter = default_font_family_.find("fantasy");
+      iter != default_font_family_.end())
+    prefs->fantasy_font_family_map[blink::web_pref::kCommonScript] =
+        iter->second;
 
   if (default_font_size_)
     prefs->default_font_size = *default_font_size_;

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -425,28 +425,30 @@ void WebContentsPreferences::OverrideWebkitPrefs(
   prefs->web_security_enabled = web_security_;
   prefs->allow_running_insecure_content = allow_running_insecure_content_;
 
-  if (auto iter = default_font_family_.find("standard");
-      iter != default_font_family_.end())
-    prefs->standard_font_family_map[blink::web_pref::kCommonScript] =
-        iter->second;
-  if (auto iter = default_font_family_.find("serif");
-      iter != default_font_family_.end())
-    prefs->serif_font_family_map[blink::web_pref::kCommonScript] = iter->second;
-  if (auto iter = default_font_family_.find("sansSerif");
-      iter != default_font_family_.end())
-    prefs->sans_serif_font_family_map[blink::web_pref::kCommonScript] =
-        iter->second;
-  if (auto iter = default_font_family_.find("monospace");
-      iter != default_font_family_.end())
-    prefs->fixed_font_family_map[blink::web_pref::kCommonScript] = iter->second;
-  if (auto iter = default_font_family_.find("cursive");
-      iter != default_font_family_.end())
-    prefs->cursive_font_family_map[blink::web_pref::kCommonScript] =
-        iter->second;
-  if (auto iter = default_font_family_.find("fantasy");
-      iter != default_font_family_.end())
-    prefs->fantasy_font_family_map[blink::web_pref::kCommonScript] =
-        iter->second;
+  if (!default_font_family_.empty()) {
+    if (auto iter = default_font_family_.find("standard");
+        iter != default_font_family_.end())
+      prefs->standard_font_family_map[blink::web_pref::kCommonScript] =
+          iter->second;
+    if (auto iter = default_font_family_.find("serif");
+        iter != default_font_family_.end())
+      prefs->serif_font_family_map[blink::web_pref::kCommonScript] = iter->second;
+    if (auto iter = default_font_family_.find("sansSerif");
+        iter != default_font_family_.end())
+      prefs->sans_serif_font_family_map[blink::web_pref::kCommonScript] =
+          iter->second;
+    if (auto iter = default_font_family_.find("monospace");
+        iter != default_font_family_.end())
+      prefs->fixed_font_family_map[blink::web_pref::kCommonScript] = iter->second;
+    if (auto iter = default_font_family_.find("cursive");
+        iter != default_font_family_.end())
+      prefs->cursive_font_family_map[blink::web_pref::kCommonScript] =
+          iter->second;
+    if (auto iter = default_font_family_.find("fantasy");
+        iter != default_font_family_.end())
+      prefs->fantasy_font_family_map[blink::web_pref::kCommonScript] =
+          iter->second;
+  }
 
   if (default_font_size_)
     prefs->default_font_size = *default_font_size_;

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3867,6 +3867,22 @@ describe('BrowserWindow module', () => {
         expect(w.getSize()).to.deep.equal(size);
       });
     });
+
+    describe('"defaultFontFamily" option', () => {
+      it('can change the standard font family', async () => {
+        const w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            defaultFontFamily: {
+              standard: 'Impact'
+            }
+          }
+        });
+        await w.loadFile(path.join(fixtures, 'pages', 'content.html'));
+        const fontFamily = await w.webContents.executeJavaScript("window.getComputedStyle(document.getElementsByTagName('p')[0])['font-family']", true);
+        expect(fontFamily).to.equal('Impact');
+      });
+    });
   });
 
   describe('beforeunload handler', function () {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

This fix brought to you by `clang-tidy`, which detected the problem:

```
../../electron/shell/browser/web_contents_preferences.cc:430:71: warning: an integer is interpreted as a character code when assigning it to a string; if this is intended, cast the integer to the appropriate character type; if you want a string representation, use the appropriate conversion facility [bugprone-string-integer-assignment]
    prefs->standard_font_family_map[blink::web_pref::kCommonScript] = font;
                                                                      ^
../../electron/shell/browser/web_contents_preferences.cc:433:68: warning: an integer is interpreted as a character code when assigning it to a string; if this is intended, cast the integer to the appropriate character type; if you want a string representation, use the appropriate conversion facility [bugprone-string-integer-assignment]
    prefs->serif_font_family_map[blink::web_pref::kCommonScript] = font;
                                                                   ^
../../electron/shell/browser/web_contents_preferences.cc:436:73: warning: an integer is interpreted as a character code when assigning it to a string; if this is intended, cast the integer to the appropriate character type; if you want a string representation, use the appropriate conversion facility [bugprone-string-integer-assignment]
    prefs->sans_serif_font_family_map[blink::web_pref::kCommonScript] = font;
                                                                        ^
../../electron/shell/browser/web_contents_preferences.cc:439:68: warning: an integer is interpreted as a character code when assigning it to a string; if this is intended, cast the integer to the appropriate character type; if you want a string representation, use the appropriate conversion facility [bugprone-string-integer-assignment]
    prefs->fixed_font_family_map[blink::web_pref::kCommonScript] = font;
                                                                   ^
../../electron/shell/browser/web_contents_preferences.cc:442:70: warning: an integer is interpreted as a character code when assigning it to a string; if this is intended, cast the integer to the appropriate character type; if you want a string representation, use the appropriate conversion facility [bugprone-string-integer-assignment]
    prefs->cursive_font_family_map[blink::web_pref::kCommonScript] = font;
                                                                     ^
../../electron/shell/browser/web_contents_preferences.cc:445:70: warning: an integer is interpreted as a character code when assigning it to a string; if this is intended, cast the integer to the appropriate character type; if you want a string representation, use the appropriate conversion facility [bugprone-string-integer-assignment]
    prefs->fantasy_font_family_map[blink::web_pref::kCommonScript] = font;
```

Got broken by the refactors in #30193 (which shipped in v16) and there was no test coverage.

As far as I can tell, though, no one has reported the issue in that time, so that may speak to how used this option is.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue which made defaultFontFamily in webPreferences have no effect <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
