### PR TITLE
docs: update E24/E25 breaking changes

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -61,6 +61,44 @@ protocol.handle('some-protocol', () => {
 })
 ```
 
+### Deprecated: `BrowserWindow.setTrafficLightPosition(position)`
+
+`BrowserWindow.setTrafficLightPosition(position)` has been deprecated, the
+`BrowserWindow.setWindowButtonPosition(position)` API should be used instead
+which accepts `null` instead of `{ x: 0, y: 0 }` to reset the position to
+system default.
+
+```js
+// Deprecated in Electron 25
+win.setTrafficLightPosition({ x: 10, y: 10 })
+win.setTrafficLightPosition({ x: 0, y: 0 })
+
+// Replace with
+win.setWindowButtonPosition({ x: 10, y: 10 })
+win.setWindowButtonPosition(null)
+```
+
+### Deprecated: `BrowserWindow.getTrafficLightPosition()`
+
+`BrowserWindow.getTrafficLightPosition()` has been deprecated, the
+`BrowserWindow.getWindowButtonPosition()` API should be used instead
+which returns `null` instead of `{ x: 0, y: 0 }` when there is no custom
+position.
+
+```js
+// Deprecated in Electron 25
+const pos = win.getTrafficLightPosition()
+if (pos.x === 0 && pos.y === 0) {
+  // No custom position.
+}
+
+// Replace with
+const ret = win.getWindowButtonPosition()
+if (ret === null) {
+  // No custom position.
+}
+```
+
 ## Planned Breaking API Changes (24.0)
 
 ### API Changed: `nativeImage.createThumbnailFromPath(path, size)`

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -98,44 +98,6 @@ nativeImage.createThumbnailFromPath(imagePath, size).then(result => {
 })
 ```
 
-### Deprecated: `BrowserWindow.setTrafficLightPosition(position)`
-
-`BrowserWindow.setTrafficLightPosition(position)` has been deprecated, the
-`BrowserWindow.setWindowButtonPosition(position)` API should be used instead
-which accepts `null` instead of `{ x: 0, y: 0 }` to reset the position to
-system default.
-
-```js
-// Removed in Electron 24
-win.setTrafficLightPosition({ x: 10, y: 10 })
-win.setTrafficLightPosition({ x: 0, y: 0 })
-
-// Replace with
-win.setWindowButtonPosition({ x: 10, y: 10 })
-win.setWindowButtonPosition(null)
-```
-
-### Deprecated: `BrowserWindow.getTrafficLightPosition()`
-
-`BrowserWindow.getTrafficLightPosition()` has been deprecated, the
-`BrowserWindow.getWindowButtonPosition()` API should be used instead
-which returns `null` instead of `{ x: 0, y: 0 }` when there is no custom
-position.
-
-```js
-// Removed in Electron 24
-const pos = win.getTrafficLightPosition()
-if (pos.x === 0 && pos.y === 0) {
-  // No custom position.
-}
-
-// Replace with
-const ret = win.getWindowButtonPosition()
-if (ret === null) {
-  // No custom position.
-}
-```
-
 ## Planned Breaking API Changes (23.0)
 
 ### Behavior Changed: Draggable Regions on macOS


### PR DESCRIPTION
#### Description of Change

This PR corrects two APIs that were listed as deprecated in 24-x-y - they were actually deprecated in 25-x-y.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none