### PR TITLE
ci: only remove blocked/need-repro on comment

### DIFF
--- a/.github/workflows/issue-commented.yml
+++ b/.github/workflows/issue-commented.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove blocked/need-repro on comment
-        if: contains(github.event.issue.labels.*.name, 'blocked/need-repro')
+        if: ${{ contains(github.event.issue.labels.*.name, 'blocked/need-repro') && !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_URL: ${{ github.event.issue.html_url }}

--- a/.github/workflows/issue-commented.yml
+++ b/.github/workflows/issue-commented.yml
@@ -1,0 +1,23 @@
+name: Issue Commented
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  issue-commented:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove blocked/need-repro on comment
+        if: contains(github.event.issue.labels.*.name, 'blocked/need-repro')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: |
+          gh issue edit $ISSUE_URL --remove-label 'blocked/need-repro'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           days-before-stale: -1
           days-before-close: 10
+          remove-stale-when-updated: false
           stale-issue-label: blocked/need-repro
           stale-pr-label: not-a-real-label
           operations-per-run: 1750


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Currently the automation around https://github.com/electron/electron/labels/blocked%2Fneed-repro will remove the label on any activity on the issue, including labeling. This has caused several issues to have the label removed due to maintainers adding a label after the initial https://github.com/electron/electron/labels/blocked%2Fneed-repro label, even if it's just a couple of seconds later, since the stale bot compares timestamps.

Rework the automation a bit to tell `actions/stale` to not manage removing the label (it has no way to configure comments vs other activity) and have a separate workflow on issue comments to remove the label.

Also excludes maintainer comments from removing the label, so that the order of applying the label and making a comment does will not accidentally result in removing the label.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
