### PR TITLE
chore: disable flaky node test

### DIFF
--- a/script/node-disabled-tests.json
+++ b/script/node-disabled-tests.json
@@ -24,6 +24,7 @@
   "parallel/test-crypto-secure-heap",
   "parallel/test-fetch",
   "parallel/test-fs-utimes-y2K38",
+  "parallel/test-heapsnapshot-near-heap-limit-by-api-in-worker",
   "parallel/test-heapsnapshot-near-heap-limit-worker",
   "parallel/test-http2-clean-output",
   "parallel/test-https-agent-session-reuse",


### PR DESCRIPTION
#### Description of Change

The node test `parallel/test-heapsnapshot-near-heap-limit-by-api-in-worker` has been flaky for us recently:

* https://app.circleci.com/pipelines/github/electron/electron/67691/workflows/ed8d62f3-eb83-40be-99d2-5119e01f4ddb/jobs/1486657
* https://app.circleci.com/pipelines/github/electron/electron/68070/workflows/b01ed73b-5352-4a2e-b076-3fd3b97624e0/jobs/1492764/tests#failed-test-0

#### Release Notes

Notes: none