### PR TITLE
refactor: remove BrowserWindow::OnWindow{Show,Hide}

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -418,16 +418,6 @@ void BrowserWindow::NotifyWindowUnresponsive() {
   }
 }
 
-void BrowserWindow::OnWindowShow() {
-  web_contents()->WasShown();
-  BaseWindow::OnWindowShow();
-}
-
-void BrowserWindow::OnWindowHide() {
-  web_contents()->WasOccluded();
-  BaseWindow::OnWindowHide();
-}
-
 // static
 gin_helper::WrappableBase* BrowserWindow::New(gin_helper::ErrorThrower thrower,
                                               gin::Arguments* args) {

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -72,8 +72,6 @@ class BrowserWindow : public BaseWindow,
   void SetBackgroundColor(const std::string& color_name) override;
   void SetBrowserView(
       absl::optional<gin::Handle<BrowserView>> browser_view) override;
-  void OnWindowShow() override;
-  void OnWindowHide() override;
 
   // BrowserWindow APIs.
   void FocusOnWebView();


### PR DESCRIPTION
Tests pass without this. Original PR that added this had lots of tests: https://github.com/electron/electron/pull/19988

Notes: none
