### PR TITLE
feat: add `did-resign-active` event on app

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -150,9 +150,20 @@ Returns:
 
 * `event` Event
 
-Emitted when mac application become active. Difference from `activate` event is
+Emitted when the application becomes active. This differs from the `activate` event in
 that `did-become-active` is emitted every time the app becomes active, not only
-when Dock icon is clicked or application is re-launched.
+when Dock icon is clicked or application is re-launched. It is also emitted when a user
+switches to the app via the macOS App Switcher.
+
+### Event: 'did-resign-active' _macOS_
+
+Returns:
+
+* `event` Event
+
+Emitted when the app is no longer active and doesn’t have focus. This can be triggered,
+for example, by clicking on another application or by using the macOS App Switcher to
+switch to another application.
 
 ### Event: 'continue-activity' _macOS_
 

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -787,6 +787,10 @@ void App::OnNewWindowForTab() {
 void App::OnDidBecomeActive() {
   Emit("did-become-active");
 }
+
+void App::OnDidResignActive() {
+  Emit("did-resign-active");
+}
 #endif
 
 bool App::CanCreateWindow(

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -116,6 +116,7 @@ class App : public ElectronBrowserClient::Delegate,
                                  base::Value::Dict user_info) override;
   void OnNewWindowForTab() override;
   void OnDidBecomeActive() override;
+  void OnDidResignActive() override;
 #endif
 
   // content::ContentBrowserClient:

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -291,6 +291,11 @@ void Browser::DidBecomeActive() {
   for (BrowserObserver& observer : observers_)
     observer.OnDidBecomeActive();
 }
+
+void Browser::DidResignActive() {
+  for (BrowserObserver& observer : observers_)
+    observer.OnDidResignActive();
+}
 #endif
 
 }  // namespace electron

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -278,8 +278,11 @@ class Browser : public WindowListObserver {
   // Tell the application to create a new window for a tab.
   void NewWindowForTab();
 
-  // Tell the application that application did become active
+  // Indicate that the app is now active.
   void DidBecomeActive();
+  // Indicate that the app is no longer active and doesn’t have focus.
+  void DidResignActive();
+
 #endif  // BUILDFLAG(IS_MAC)
 
   // Tell the application that application is activated with visible/invisible

--- a/shell/browser/browser_observer.h
+++ b/shell/browser/browser_observer.h
@@ -78,8 +78,10 @@ class BrowserObserver : public base::CheckedObserver {
   // User clicked the native macOS new tab button. (macOS only)
   virtual void OnNewWindowForTab() {}
 
-  // Browser did become active.
+  // Browser became active.
   virtual void OnDidBecomeActive() {}
+  // Browser lost active status.
+  virtual void OnDidResignActive() {}
 #endif
 
  protected:

--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -92,6 +92,10 @@ static NSDictionary* UNNotificationResponseToNSDictionary(
   electron::Browser::Get()->DidBecomeActive();
 }
 
+- (void)applicationDidResignActive:(NSNotification*)notification {
+  electron::Browser::Get()->DidResignActive();
+}
+
 - (NSMenu*)applicationDockMenu:(NSApplication*)sender {
   if (menu_controller_)
     return [menu_controller_ menu];


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/37891

This PR adds a new 'did-resign-active' event on `app`, which forms a pair with pre-existing event 'did-become-active'. This event is emitted when the app is no longer active and doesn’t have focus. This can be triggered, for example, by clicking on another application or by using the macOS App Switcher to switch to another application.

The instigating issue requested exposure of `hidesOnDeactivate` - i chose to pursue this route instead because we already have a plethora of BrowserWindow options, and exposing that option is fairly limiting. There are several things a user might want to do upon app deactivation besides hide the app - background work, UI changes, etc. This solves the user's issue while also allowing for a greater range of use cases.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added new 'did-resign-active' event on `app`.