### PR TITLE
feat: remove on(ready) requirement from powerMonitor

### DIFF
--- a/lib/browser/api/power-monitor.ts
+++ b/lib/browser/api/power-monitor.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'events';
-import { app } from 'electron/main';
 
 const {
   createPowerMonitor,
@@ -14,28 +13,26 @@ class PowerMonitor extends EventEmitter {
     // Don't start the event source until both a) the app is ready and b)
     // there's a listener registered for a powerMonitor event.
     this.once('newListener', () => {
-      app.whenReady().then(() => {
-        const pm = createPowerMonitor();
-        pm.emit = this.emit.bind(this);
+      const pm = createPowerMonitor();
+      pm.emit = this.emit.bind(this);
 
-        if (process.platform === 'linux') {
-          // On Linux, we inhibit shutdown in order to give the app a chance to
-          // decide whether or not it wants to prevent the shutdown. We don't
-          // inhibit the shutdown event unless there's a listener for it. This
-          // keeps the C++ code informed about whether there are any listeners.
-          pm.setListeningForShutdown(this.listenerCount('shutdown') > 0);
-          this.on('newListener', (event) => {
-            if (event === 'shutdown') {
-              pm.setListeningForShutdown(this.listenerCount('shutdown') + 1 > 0);
-            }
-          });
-          this.on('removeListener', (event) => {
-            if (event === 'shutdown') {
-              pm.setListeningForShutdown(this.listenerCount('shutdown') > 0);
-            }
-          });
-        }
-      });
+      if (process.platform === 'linux') {
+        // On Linux, we inhibit shutdown in order to give the app a chance to
+        // decide whether or not it wants to prevent the shutdown. We don't
+        // inhibit the shutdown event unless there's a listener for it. This
+        // keeps the C++ code informed about whether there are any listeners.
+        pm.setListeningForShutdown(this.listenerCount('shutdown') > 0);
+        this.on('newListener', (event) => {
+          if (event === 'shutdown') {
+            pm.setListeningForShutdown(this.listenerCount('shutdown') + 1 > 0);
+          }
+        });
+        this.on('removeListener', (event) => {
+          if (event === 'shutdown') {
+            pm.setListeningForShutdown(this.listenerCount('shutdown') > 0);
+          }
+        });
+      }
     });
   }
 

--- a/shell/browser/api/electron_api_power_monitor.cc
+++ b/shell/browser/api/electron_api_power_monitor.cc
@@ -91,7 +91,6 @@ void PowerMonitor::SetListeningForShutdown(bool is_listening) {
 
 // static
 v8::Local<v8::Value> PowerMonitor::Create(v8::Isolate* isolate) {
-  CHECK(Browser::Get()->is_ready());
   auto* pm = new PowerMonitor(isolate);
   auto handle = gin::CreateHandle(isolate, pm).ToV8();
   pm->Pin(isolate);

--- a/spec/api-power-monitor-spec.ts
+++ b/spec/api-power-monitor-spec.ts
@@ -8,7 +8,7 @@
 // python-dbusmock.
 import { expect } from 'chai';
 import * as dbus from 'dbus-native';
-import { ifdescribe } from './lib/spec-helpers';
+import { ifdescribe, startRemoteControlApp } from './lib/spec-helpers';
 import { promisify } from 'util';
 import { setTimeout } from 'timers/promises';
 
@@ -133,6 +133,11 @@ describe('powerMonitor', () => {
         });
       });
     });
+  });
+
+  it('is usable before app ready', async () => {
+    const remoteApp = await startRemoteControlApp(['--boot-eval=globalThis.initialValue=require("electron").powerMonitor.getSystemIdleTime()']);
+    expect(await remoteApp.remoteEval('globalThis.initialValue')).to.be.a('number');
   });
 
   describe('when powerMonitor module is loaded', () => {


### PR DESCRIPTION
#### Description of Change

This doesn't seem to be needed any more.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
