### PR TITLE
doc: Fix the example's syntax error

### DIFF
--- a/docs/tutorial/tutorial-2-first-app.md
+++ b/docs/tutorial/tutorial-2-first-app.md
@@ -274,7 +274,7 @@ calling `createWindow()` once its promise is fulfilled.
 You typically listen to Node.js events by using an emitter's `.on` function.
 
 ```diff
-+ app.on('ready').then(() => {
++ app.on('ready', () => {
 - app.whenReady().then(() => {
   createWindow()
 })


### PR DESCRIPTION
Fixed the example's syntax error

#### Description of Change
Changed `app.on('ready').then(xxx)` to `app.on('ready', xxx)`。
By using the first code will make application throw an TypeError.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
