### PR TITLE
fix: recommended `node-gyp` version in `node.h` error

### DIFF
--- a/patches/node/allow_embedder_to_control_codegenerationfromstringscallback.patch
+++ b/patches/node/allow_embedder_to_control_codegenerationfromstringscallback.patch
@@ -30,7 +30,7 @@ index b6981c37d5b286e22f24d11751eb05f72ca27619..c4a3a54753767e7686a0e32996bcda0c
    Mutex::ScopedLock lock(node::per_process::cli_options_mutex);
    if (per_process::cli_options->get_per_isolate_options()
 diff --git a/src/node.h b/src/node.h
-index bee494f9da8470530ee9ec58958f8f2c7ce6a302..387ce8e5edf6524db170e2d46ef501a1cd956d98 100644
+index f8f2cde5c2e07e032955b0342a31db52f20460f3..7e1be61a9cca8205666a129bafa2b2f4f4dbcc4b 100644
 --- a/src/node.h
 +++ b/src/node.h
 @@ -461,6 +461,8 @@ struct IsolateSettings {

--- a/patches/node/build_ensure_native_module_compilation_fails_if_not_using_a_new.patch
+++ b/patches/node/build_ensure_native_module_compilation_fails_if_not_using_a_new.patch
@@ -52,7 +52,7 @@ index 1b7a721585764aecfd855ee47c47a3bd235d2ef3..c152ea9f29478729ec3752132140e3ec
    o['variables']['v8_enable_javascript_promise_hooks'] = 1
    o['variables']['v8_enable_lite_mode'] = 1 if options.v8_lite_mode else 0
 diff --git a/src/node.h b/src/node.h
-index 10061d4298368bc0ad53c0c8c3a3c964c13d4c3c..bee494f9da8470530ee9ec58958f8f2c7ce6a302 100644
+index 10061d4298368bc0ad53c0c8c3a3c964c13d4c3c..f8f2cde5c2e07e032955b0342a31db52f20460f3 100644
 --- a/src/node.h
 +++ b/src/node.h
 @@ -22,6 +22,12 @@
@@ -61,7 +61,7 @@ index 10061d4298368bc0ad53c0c8c3a3c964c13d4c3c..bee494f9da8470530ee9ec58958f8f2c
  
 +#ifdef ELECTRON_ENSURE_CONFIG_GYPI
 +#ifndef USING_ELECTRON_CONFIG_GYPI
-+#error "It looks like you are building this native module without using the right config.gypi.  This normally means that you need to update electron-rebuild (>=3.2.8) or node-gyp (>=8.4.0) if you're building modules directly."
++#error "It looks like you are building this native module without using the right config.gypi.  This normally means that you need to update electron-rebuild (>=3.2.8) or node-gyp (>=9.0.0) if you're building modules directly."
 +#endif
 +#endif
 +


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/37829.

See that PR for details.

Notes: Fix recommended `node-gyp` version in `node.h` error