### PR TITLE
fix: recommended `node-gyp` version in `node.h` error

### DIFF
--- a/patches/node/allow_embedder_to_control_codegenerationfromstringscallback.patch
+++ b/patches/node/allow_embedder_to_control_codegenerationfromstringscallback.patch
@@ -30,7 +30,7 @@ index 93d85d46dc6b3b30795b88ffa8070253f62e51bd..05f8232c4b38f51e8059e8d01b0eb247
    if ((s.flags & SHOULD_NOT_SET_PROMISE_REJECTION_CALLBACK) == 0) {
      auto* promise_reject_cb = s.promise_reject_callback ?
 diff --git a/src/node.h b/src/node.h
-index 38bbb20968772a4ba6bceddb04a83589f8582fc8..a5ee97ae83149a1924e9d6198ad4b2a7fd8b876d 100644
+index b5e4d42035a23b49fd144d563f5716fcaed2b45c..f2e2acc98c1165430e46351fe07637315cc2c38e 100644
 --- a/src/node.h
 +++ b/src/node.h
 @@ -374,6 +374,8 @@ struct IsolateSettings {

--- a/patches/node/build_ensure_native_module_compilation_fails_if_not_using_a_new.patch
+++ b/patches/node/build_ensure_native_module_compilation_fails_if_not_using_a_new.patch
@@ -52,7 +52,7 @@ index 08894bf3908916d1cb639810c5e1b2afae74ff4d..19cbde58df38009258db145c5f7dbe73
    o['variables']['v8_enable_lite_mode'] = 1 if options.v8_lite_mode else 0
    o['variables']['v8_enable_gdbjit'] = 1 if options.gdb else 0
 diff --git a/src/node.h b/src/node.h
-index b6a26f8adf11959f94a00de0cbf9016fcc8707cb..38bbb20968772a4ba6bceddb04a83589f8582fc8 100644
+index b6a26f8adf11959f94a00de0cbf9016fcc8707cb..b5e4d42035a23b49fd144d563f5716fcaed2b45c 100644
 --- a/src/node.h
 +++ b/src/node.h
 @@ -22,6 +22,12 @@
@@ -61,7 +61,7 @@ index b6a26f8adf11959f94a00de0cbf9016fcc8707cb..38bbb20968772a4ba6bceddb04a83589
  
 +#ifdef ELECTRON_ENSURE_CONFIG_GYPI
 +#ifndef USING_ELECTRON_CONFIG_GYPI
-+#error "It looks like you are building this native module without using the right config.gypi.  This normally means that you need to update electron-rebuild (>=3.2.8) or node-gyp (>=8.4.0) if you're building modules directly."
++#error "It looks like you are building this native module without using the right config.gypi.  This normally means that you need to update electron-rebuild (>=3.2.8) or node-gyp (>=9.0.0) if you're building modules directly."
 +#endif
 +#endif
 +


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/37829.

See that PR for details.

Notes: Fix recommended `node-gyp` version in `node.h` error