### PR TITLE
fix: swipe event emission on macOS

### DIFF
--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -25,7 +25,6 @@ int ScopedDisableResize::disable_resize_ = 0;
 - (int64_t)_resizeDirectionForMouseLocation:(CGPoint)location;
 @end
 
-#if IS_MAS_BUILD()
 // See components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm
 @interface NSView (CRFrameViewAdditions)
 - (void)cr_mouseDownOnFrameView:(NSEvent*)event;
@@ -40,10 +39,10 @@ MouseDownImpl g_nsnextstepframe_mousedown;
 
 // This class is never instantiated, it's just a container for our swizzled
 // mouseDown method.
-@interface SwizzledMouseDownHolderClass : NSView
+@interface SwizzledMethodsClass : NSView
 @end
 
-@implementation SwizzledMouseDownHolderClass
+@implementation SwizzledMethodsClass
 - (void)swiz_nsthemeframe_mouseDown:(NSEvent*)event {
   if ([self.window respondsToSelector:@selector(shell)]) {
     electron::NativeWindowMac* shell =
@@ -64,22 +63,53 @@ MouseDownImpl g_nsnextstepframe_mousedown;
     g_nsnextstepframe_mousedown(self, @selector(mouseDown:), event);
   }
 }
+
+- (void)swiz_nsview_swipeWithEvent:(NSEvent*)event {
+  if ([self.window respondsToSelector:@selector(shell)]) {
+    electron::NativeWindowMac* shell =
+        (electron::NativeWindowMac*)[(id)self.window shell];
+    if (shell) {
+      if (event.deltaY == 1.0) {
+        shell->NotifyWindowSwipe("up");
+      } else if (event.deltaX == -1.0) {
+        shell->NotifyWindowSwipe("right");
+      } else if (event.deltaY == -1.0) {
+        shell->NotifyWindowSwipe("down");
+      } else if (event.deltaX == 1.0) {
+        shell->NotifyWindowSwipe("left");
+      }
+    }
+  }
+}
 @end
 
 namespace {
+#if IS_MAS_BUILD()
 void SwizzleMouseDown(NSView* frame_view,
                       SEL swiz_selector,
                       MouseDownImpl* orig_impl) {
   Method original_mousedown =
       class_getInstanceMethod([frame_view class], @selector(mouseDown:));
   *orig_impl = (MouseDownImpl)method_getImplementation(original_mousedown);
-  Method new_mousedown = class_getInstanceMethod(
-      [SwizzledMouseDownHolderClass class], swiz_selector);
+  Method new_mousedown =
+      class_getInstanceMethod([SwizzledMethodsClass class], swiz_selector);
   method_setImplementation(original_mousedown,
                            method_getImplementation(new_mousedown));
 }
+#else
+// components/remote_cocoa/app_shim/bridged_content_view.h overrides
+// swipeWithEvent, so we can't just override the implementation
+// in ElectronNSWindow like we do with for ex. rotateWithEvent.
+void SwizzleSwipeWithEvent(NSView* view, SEL swiz_selector) {
+  Method original_swipe_with_event =
+      class_getInstanceMethod([view class], @selector(swipeWithEvent:));
+  Method new_swipe_with_event =
+      class_getInstanceMethod([SwizzledMethodsClass class], swiz_selector);
+  method_setImplementation(original_swipe_with_event,
+                           method_getImplementation(new_swipe_with_event));
+}
+#endif
 }  // namespace
-#endif  // IS_MAS_BUILD
 
 @implementation ElectronNSWindow
 
@@ -125,8 +155,10 @@ void SwizzleMouseDown(NSView* frame_view,
                          &g_nsnextstepframe_mousedown);
       }
     }
+#else
+    NSView* view = [[self contentView] superview];
+    SwizzleSwipeWithEvent(view, @selector(swiz_nsview_swipeWithEvent:));
 #endif  // IS_MAS_BUILD
-
     shell_ = shell;
   }
   return self;
@@ -155,18 +187,6 @@ void SwizzleMouseDown(NSView* frame_view,
 }
 
 // NSWindow overrides.
-
-- (void)swipeWithEvent:(NSEvent*)event {
-  if (event.deltaY == 1.0) {
-    shell_->NotifyWindowSwipe("up");
-  } else if (event.deltaX == -1.0) {
-    shell_->NotifyWindowSwipe("right");
-  } else if (event.deltaY == -1.0) {
-    shell_->NotifyWindowSwipe("down");
-  } else if (event.deltaX == 1.0) {
-    shell_->NotifyWindowSwipe("left");
-  }
-}
 
 - (void)rotateWithEvent:(NSEvent*)event {
   shell_->NotifyWindowRotateGesture(event.rotation);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/37628.
Refs https://github.com/electron/electron/pull/35603

Fixes an issue where the 'swipe' event wasn't being emitted properly on macOS. This happened as a result of https://github.com/electron/electron/pull/35603, which removed our `OverrideNSWindowContentView` logic. This logic replaced `BridgedContentView` in `ElectronNSWindow` with our own logic, and enabled our implementation of `swipeWithEvent` to take precedence. After the removal of that code, the `swipeWithEvent` implementation in `BridgedContentView` would always be called regardless of our override. Fix this by forcing our implementation to be called instead.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the 'swipe' event wasn't being emitted properly on macOS.
