### PR TITLE
chore: replace uses of `ComPtr::GetAddressOf()` with `ComPtr::operator&`

### DIFF
--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -278,7 +278,7 @@ void ShowItemInFolderOnWorkerThread(const base::FilePath& full_path) {
     return;
 
   Microsoft::WRL::ComPtr<IShellFolder> desktop;
-  HRESULT hr = SHGetDesktopFolder(desktop.GetAddressOf());
+  HRESULT hr = SHGetDesktopFolder(&desktop);
   if (FAILED(hr))
     return;
 
@@ -297,8 +297,7 @@ void ShowItemInFolderOnWorkerThread(const base::FilePath& full_path) {
     return;
 
   const ITEMIDLIST* highlight[] = {file_item};
-  hr = SHOpenFolderAndSelectItems(dir_item, std::size(highlight), highlight,
-                                  NULL);
+  hr = SHOpenFolderAndSelectItems(dir_item, std::size(highlight), highlight, 0);
   if (FAILED(hr)) {
     // On some systems, the above call mysteriously fails with "file not
     // found" even though the file is there.  In these cases, ShellExecute()
@@ -379,9 +378,8 @@ bool MoveItemToTrashWithError(const base::FilePath& path,
 
   // Create an IShellItem from the supplied source path.
   Microsoft::WRL::ComPtr<IShellItem> delete_item;
-  if (FAILED(SHCreateItemFromParsingName(
-          path.value().c_str(), NULL,
-          IID_PPV_ARGS(delete_item.GetAddressOf())))) {
+  if (FAILED(SHCreateItemFromParsingName(path.value().c_str(), NULL,
+                                         IID_PPV_ARGS(&delete_item)))) {
     *error = "Failed to parse path";
     return false;
   }


### PR DESCRIPTION
#### Description of Change

Refs CL:2271074.

Replaces uses of `ComPtr::GetAddressOf()` with `ComPtr::operator&`. From the CL:

> Microsoft::WRL::ComPtr<T>::GetAddressOf() is banned due to the ease
of causing memory leaks. 

> Also replace CopyTo(foo.GetAddressOf()) with As(&foo) since CopyTo(&foo)
does not work if we are copying to different interfaces.

> Also replace QueryInterface(foo.GetAddressOf()) with
QueryInterface(IID_PPV_ARGS(&foo)).

Also brings in CL:3491805.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
