### PR TITLE
feat: support for overriding useragent metadata

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1549,6 +1549,17 @@ This is the user agent that will be used when no user agent is set at the
 app has the same user agent.  Set to a custom value as early as possible
 in your app's initialization to ensure that your overridden value is used.
 
+#### `app.userAgentMetadataFallback`
+
+A [`UserAgentMetadata`](structures/useragent-metadata.md) object.
+
+The user agent metadata Electron will use as a global fallback.
+
+This is the metadata that will be used when no user agent metadata is set at the
+`webContents` or `session` level.  It is useful for ensuring that your entire
+app has the same user agent and metadata.  Set to a custom value as early as possible
+in your app's initialization to ensure that your overridden value is used.
+
 ### `app.runningUnderRosettaTranslation` _macOS_ _Readonly_ _Deprecated_
 
 A `boolean` which when `true` indicates that the app is currently running

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1467,6 +1467,7 @@ Captures a snapshot of the page within `rect`. Omitting `rect` will capture the 
 * `options` Object (optional)
   * `httpReferrer` (string | [Referrer](structures/referrer.md)) (optional) - An HTTP Referrer URL.
   * `userAgent` string (optional) - A user agent originating the request.
+  * `userAgentMetadata` [UserAgentMetadata](structures/useragent-metadata.md) (optional) - The user agent metadata.
   * `extraHeaders` string (optional) - Extra headers separated by "\n"
   * `postData` ([UploadRawData](structures/upload-raw-data.md) | [UploadFile](structures/upload-file.md))[] (optional)
   * `baseURLForDataURL` string (optional) - Base URL (with trailing path separator) for files to be loaded by the data URL. This is needed only if the specified `url` is a data URL and needs to load other files.

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -1182,12 +1182,13 @@ session.defaultSession.allowNTLMCredentialsForDomains('*example.com, *foobar.com
 session.defaultSession.allowNTLMCredentialsForDomains('*')
 ```
 
-#### `ses.setUserAgent(userAgent[, acceptLanguages])`
+#### `ses.setUserAgent(userAgent[, acceptLanguages][, userAgentMetadata])`
 
 * `userAgent` string
 * `acceptLanguages` string (optional)
+* `userAgentMetadata` [UserAgentMetadata](structures/useragent-metadata.md) (optional)
 
-Overrides the `userAgent` and `acceptLanguages` for this session.
+Overrides the `userAgent`, `acceptLanguages` and `userAgentMetadata` for this session.
 
 The `acceptLanguages` must a comma separated ordered list of language codes, for
 example `"en-US,fr,de,ko,zh-CN,ja"`.
@@ -1205,6 +1206,19 @@ will be temporary.
 #### `ses.getUserAgent()`
 
 Returns `string` - The user agent for this session.
+
+#### `ses.setUserAgentMetadata([userAgentMetadata])`
+
+* `userAgentMetadata` [UserAgentMetadata](structures/useragent-metadata.md) (optional)
+
+Overrides the `userAgentMetadata` for this session.
+
+This doesn't affect existing `WebContents`, and each `WebContents` can use
+`webContents.setUserAgent` to override the session-wide user agent.
+
+#### `ses.getUserAgentMetadata()`
+
+Returns `UserAgentMetadata` - The user agent metadata for this session.
 
 #### `ses.setSSLConfig(config)`
 

--- a/docs/api/structures/brand-version.md
+++ b/docs/api/structures/brand-version.md
@@ -1,0 +1,4 @@
+# BrandVersion Object
+
+* `brand` string - The brand of user agent.
+* `version` string - The version of user agent.

--- a/docs/api/structures/useragent-metadata.md
+++ b/docs/api/structures/useragent-metadata.md
@@ -1,0 +1,13 @@
+# UserAgentMetadata Object
+
+* `brands` [BrandVersion[]](brand-version.md) - The brand and versions.
+* `fullVersionList` [BrandVersion[]](brand-version.md) - The brand and full versions.
+* `fullVersion` string - full browser version.
+* `platform` string - The platform.
+* `platformVersion` string - The platform version.
+* `model` string - The model of mobile device.
+* `mobile` boolean - Whether the Electron is running on a mobile device.
+* `architecture` string - The platform architecture.
+* `bitness` string - The architecture bitness.
+* `wow64` string - Whether the Electron is running on a Wow64 platform.
+

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1003,6 +1003,7 @@ Emitted when the [mainFrame](web-contents.md#contentsmainframe-readonly), an `<i
 * `options` Object (optional)
   * `httpReferrer` (string | [Referrer](structures/referrer.md)) (optional) - An HTTP Referrer url.
   * `userAgent` string (optional) - A user agent originating the request.
+  * `userAgentMetadata` [UserAgentMetadata](structures/useragent-metadata.md) (optional) - The user agent metadata.
   * `extraHeaders` string (optional) - Extra headers separated by "\n".
   * `postData` ([UploadRawData](structures/upload-raw-data.md) | [UploadFile](structures/upload-file.md))[] (optional)
   * `baseURLForDataURL` string (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
@@ -1199,11 +1200,12 @@ contents.on('unresponsive', async () => {
 })
 ```
 
-#### `contents.setUserAgent(userAgent)`
+#### `contents.setUserAgent(userAgent[, userAgentMetadata])`
 
-* `userAgent` string
+* `userAgent` string - The user agent string.
+* `userAgentMetadata` [UserAgentMetadata](structures/useragent-metadata.md) (optional) - The user agent metadata.
 
-Overrides the user agent for this web page.
+Overrides the user agent and metadata for this web page.
 
 #### `contents.getUserAgent()`
 

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -266,6 +266,7 @@ webview.addEventListener('dom-ready', () => {
 * `options` Object (optional)
   * `httpReferrer` (string | [Referrer](structures/referrer.md)) (optional) - An HTTP Referrer url.
   * `userAgent` string (optional) - A user agent originating the request.
+  * `userAgentMetadata` [UserAgentMetadata](structures/useragent-metadata.md) (optional) - The user agent metadata.
   * `extraHeaders` string (optional) - Extra headers separated by "\n"
   * `postData` ([UploadRawData](structures/upload-raw-data.md) | [UploadFile](structures/upload-file.md))[] (optional)
   * `baseURLForDataURL` string (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -64,6 +64,7 @@
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_converters/net_converter.h"
+#include "shell/common/gin_converters/optional_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/object_template_builder.h"
@@ -1526,6 +1527,14 @@ void App::SetUserAgentFallback(const std::string& user_agent) {
   ElectronBrowserClient::Get()->SetUserAgent(user_agent);
 }
 
+void App::SetUserAgentMetadataFallback(absl::optional<blink::UserAgentMetadata> ua_metadata) {
+  ElectronBrowserClient::Get()->SetUserAgentMetadata(ua_metadata);
+}
+
+v8::Local<v8::Value> App::GetUserAgentMetadataFallback(v8::Isolate* isolate) {
+  return gin::ConvertToV8(isolate, ElectronBrowserClient::Get()->GetUserAgentMetadata());
+}
+
 #if BUILDFLAG(IS_WIN)
 
 bool App::IsRunningUnderARM64Translation() const {
@@ -1842,6 +1851,8 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
 #endif
       .SetProperty("userAgentFallback", &App::GetUserAgentFallback,
                    &App::SetUserAgentFallback)
+      .SetProperty("userAgentMetadataFallback", &App::GetUserAgentMetadataFallback,
+                   &App::SetUserAgentMetadataFallback)
       .SetMethod("configureHostResolver", &ConfigureHostResolver)
       .SetMethod("enableSandbox", &App::EnableSandbox);
 }

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -29,6 +29,7 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/promise.h"
+#include "third_party/blink/public/common/user_agent/user_agent_metadata.h"
 
 #if BUILDFLAG(USE_NSS_CERTS)
 #include "shell/browser/certificate_manager_model.h"
@@ -220,6 +221,8 @@ class App : public ElectronBrowserClient::Delegate,
   void EnableSandbox(gin_helper::ErrorThrower thrower);
   void SetUserAgentFallback(const std::string& user_agent);
   std::string GetUserAgentFallback();
+  void SetUserAgentMetadataFallback(absl::optional<blink::UserAgentMetadata> ua_meta);
+  v8::Local<v8::Value> GetUserAgentMetadataFallback(v8::Isolate* isolate);
 
 #if BUILDFLAG(IS_MAC)
   void SetActivationPolicy(gin_helper::ErrorThrower thrower,

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -23,6 +23,8 @@
 #include "shell/common/gin_helper/function_template_extensions.h"
 #include "shell/common/gin_helper/pinnable.h"
 #include "shell/common/gin_helper/promise.h"
+#include "third_party/blink/public/common/user_agent/user_agent_metadata.h"
+
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 #include "chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h"  // nogncheck
@@ -124,6 +126,8 @@ class Session : public gin::Wrappable<Session>,
   void AllowNTLMCredentialsForDomains(const std::string& domains);
   void SetUserAgent(const std::string& user_agent, gin::Arguments* args);
   std::string GetUserAgent();
+  void SetUserAgentMetadata(absl::optional<blink::UserAgentMetadata> ua_meta);
+  v8::Local<v8::Value> GetUserAgentMetadata(v8::Isolate* isolate);
   void SetSSLConfig(network::mojom::SSLConfigPtr config);
   bool IsPersistent();
   v8::Local<v8::Promise> GetBlobData(v8::Isolate* isolate,

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -189,7 +189,7 @@ class WebContents : public ExclusiveAccessContext,
   std::string GetMediaSourceID(content::WebContents* request_web_contents);
   bool IsCrashed() const;
   void ForcefullyCrashRenderer();
-  void SetUserAgent(const std::string& user_agent);
+  void SetUserAgent(const std::string& user_agent, absl::optional<blink::UserAgentMetadata> ua_metadata_override);
   std::string GetUserAgent();
   void InsertCSS(const std::string& css);
   v8::Local<v8::Promise> SavePage(const base::FilePath& full_file_path,

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1057,7 +1057,14 @@ void ElectronBrowserClient::SetUserAgent(const std::string& user_agent) {
 }
 
 blink::UserAgentMetadata ElectronBrowserClient::GetUserAgentMetadata() {
+  if (ua_metadata_override_) {
+    return ua_metadata_override_.value();
+  }
   return embedder_support::GetUserAgentMetadata();
+}
+
+void ElectronBrowserClient::SetUserAgentMetadata(absl::optional<blink::UserAgentMetadata> ua_metadata) {
+  ua_metadata_override_ = ua_metadata;
 }
 
 void ElectronBrowserClient::RegisterNonNetworkNavigationURLLoaderFactories(

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -97,6 +97,7 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
   std::string GetUserAgent() override;
   void SetUserAgent(const std::string& user_agent);
   blink::UserAgentMetadata GetUserAgentMetadata() override;
+  void SetUserAgentMetadata(absl::optional<blink::UserAgentMetadata> ua_metadata);
 
   content::SerialDelegate* GetSerialDelegate() override;
 
@@ -317,6 +318,7 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
   Delegate* delegate_ = nullptr;
 
   std::string user_agent_override_ = "";
+  absl::optional<blink::UserAgentMetadata> ua_metadata_override_;
 
   // Simple shared ID generator, used by ProxyingURLLoaderFactory and
   // ProxyingWebSocket classes.

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -249,6 +249,10 @@ void ElectronBrowserContext::SetUserAgent(const std::string& user_agent) {
   user_agent_ = user_agent;
 }
 
+void ElectronBrowserContext::SetUserAgentMetadata(absl::optional<blink::UserAgentMetadata> ua_metadata) {
+  ua_metadata_ = ua_metadata;
+}
+
 base::FilePath ElectronBrowserContext::GetPath() {
   return path_;
 }
@@ -321,6 +325,10 @@ ElectronBrowserContext::GetSpecialStoragePolicy() {
 
 std::string ElectronBrowserContext::GetUserAgent() const {
   return user_agent_.value_or(ElectronBrowserClient::Get()->GetUserAgent());
+}
+
+blink::UserAgentMetadata ElectronBrowserContext::GetUserAgentMetadata() const {
+  return ua_metadata_.value_or(ElectronBrowserClient::Get()->GetUserAgentMetadata());
 }
 
 predictors::PreconnectManager* ElectronBrowserContext::GetPreconnectManager() {

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -22,6 +22,7 @@
 #include "services/network/public/mojom/url_loader_factory.mojom.h"
 #include "shell/browser/media/media_device_id_salt.h"
 #include "third_party/blink/public/common/permissions/permission_utils.h"
+#include "third_party/blink/public/common/user_agent/user_agent_metadata.h"
 
 class PrefService;
 class ValueMapPrefStore;
@@ -134,6 +135,8 @@ class ElectronBrowserContext : public content::BrowserContext {
 
   void SetUserAgent(const std::string& user_agent);
   std::string GetUserAgent() const;
+  void SetUserAgentMetadata(absl::optional<blink::UserAgentMetadata> ua_metadata);
+  blink::UserAgentMetadata GetUserAgentMetadata() const;
   bool CanUseHttpCache() const;
   int GetMaxCacheSize() const;
   ResolveProxyHelper* GetResolveProxyHelper();
@@ -252,6 +255,7 @@ class ElectronBrowserContext : public content::BrowserContext {
   std::unique_ptr<ProtocolRegistry> protocol_registry_;
 
   absl::optional<std::string> user_agent_;
+  absl::optional<blink::UserAgentMetadata> ua_metadata_;
   base::FilePath path_;
   bool in_memory_ = false;
   bool use_cache_ = true;

--- a/shell/common/gin_converters/blink_converter.cc
+++ b/shell/common/gin_converters/blink_converter.cc
@@ -629,6 +629,93 @@ bool Converter<blink::mojom::Referrer>::FromV8(v8::Isolate* isolate,
   return true;
 }
 
+// static
+v8::Local<v8::Value> Converter<blink::UserAgentBrandVersion>::ToV8(
+    v8::Isolate* isolate,
+    const blink::UserAgentBrandVersion& val) {
+  gin_helper::Dictionary dict = gin::Dictionary::CreateEmpty(isolate);
+  dict.Set("brand", ConvertToV8(isolate, val.brand));
+  dict.Set("version", ConvertToV8(isolate, val.version));
+  return gin::ConvertToV8(isolate, dict);
+}
+//
+// static
+bool Converter<blink::UserAgentBrandVersion>::FromV8(v8::Isolate* isolate,
+                                                     v8::Local<v8::Value> val,
+                                                     blink::UserAgentBrandVersion* out) {
+  gin_helper::Dictionary dict;
+  if (!ConvertFromV8(isolate, val, &dict))
+    return false;
+
+  if (!dict.Get("brand", &out->brand)) {
+    return false;
+  }
+  if (!dict.Get("version", &out->version)) {
+    return false;
+  }
+  return true;
+}
+
+// static
+v8::Local<v8::Value> Converter<blink::UserAgentMetadata>::ToV8(
+    v8::Isolate* isolate,
+    const blink::UserAgentMetadata& val) {
+  gin_helper::Dictionary dict = gin::Dictionary::CreateEmpty(isolate);
+  dict.Set("brands", ConvertToV8(isolate, val.brand_version_list));
+  dict.Set("fullVersionList", ConvertToV8(isolate, val.brand_full_version_list));
+  dict.Set("fullVersion", ConvertToV8(isolate, val.full_version));
+  dict.Set("platform", ConvertToV8(isolate, val.platform));
+  dict.Set("architecture", ConvertToV8(isolate, val.architecture));
+  dict.Set("platformVersion", ConvertToV8(isolate, val.platform_version));
+  dict.Set("model", ConvertToV8(isolate, val.model));
+  dict.Set("mobile", ConvertToV8(isolate, val.mobile));
+  dict.Set("bitness", ConvertToV8(isolate, val.bitness));
+  dict.Set("wow64", ConvertToV8(isolate, val.wow64));
+  return gin::ConvertToV8(isolate, dict);
+}
+//
+// static
+bool Converter<blink::UserAgentMetadata>::FromV8(v8::Isolate* isolate,
+                                                 v8::Local<v8::Value> val,
+                                                 blink::UserAgentMetadata* out) {
+  gin_helper::Dictionary dict;
+  if (!ConvertFromV8(isolate, val, &dict))
+    return false;
+
+  if (!dict.Get("brands", &out->brand_version_list)) {
+    return false;
+  }
+  if (!dict.Get("fullVersionList", &out->brand_full_version_list)) {
+    return false;
+  }
+  if (!dict.Get("fullVersion", &out->full_version)) {
+    return false;
+  }
+  if (!dict.Get("platform", &out->platform)) {
+    return false;
+  }
+  if (!dict.Get("platformVersion", &out->platform_version)) {
+    return false;
+  }
+  if (!dict.Get("architecture", &out->architecture))  {
+    return false;
+  }
+  if (!dict.Get("model", &out->model)) {
+    return false;
+  }
+  if (!dict.Get("mobile", &out->mobile)) {
+    return false;
+  }
+  if (!dict.Get("bitness", &out->bitness)) {
+    return false;
+  }
+  if (!dict.Get("wow64", &out->wow64)) {
+    return false;
+  }
+
+  return true;
+}
+
 v8::Local<v8::Value> Converter<blink::CloneableMessage>::ToV8(
     v8::Isolate* isolate,
     const blink::CloneableMessage& in) {

--- a/shell/common/gin_converters/blink_converter.h
+++ b/shell/common/gin_converters/blink_converter.h
@@ -9,6 +9,7 @@
 #include "third_party/blink/public/common/context_menu_data/context_menu_data.h"
 #include "third_party/blink/public/common/input/web_input_event.h"
 #include "third_party/blink/public/common/messaging/cloneable_message.h"
+#include "third_party/blink/public/common/user_agent/user_agent_metadata.h"
 #include "third_party/blink/public/common/web_cache/web_cache_resource_type_stats.h"
 #include "third_party/blink/public/mojom/loader/referrer.mojom-forward.h"
 
@@ -124,6 +125,24 @@ struct Converter<blink::CloneableMessage> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      blink::CloneableMessage* out);
+};
+
+template <>
+struct Converter<blink::UserAgentBrandVersion > {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const blink::UserAgentBrandVersion & in);
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     blink::UserAgentBrandVersion * out);
+};
+
+template <>
+struct Converter<blink::UserAgentMetadata> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const blink::UserAgentMetadata& val);
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     blink::UserAgentMetadata* out);
 };
 
 v8::Local<v8::Value> EditFlagsToV8(v8::Isolate* isolate, int editFlags);


### PR DESCRIPTION
This commit adds support for overriding the user agent metadata at all levels including app, per session, and per web contents.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added support for overriding user agent metadata
