### PR TITLE
fix:#37964

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -816,6 +816,22 @@ WebContents.prototype._init = function () {
       callback('');
     }
   });
+  // Bluetooth connect
+  this.on('select-bluetooth-device',(navigator)=>{
+    if ("bluetooth" in navigator) {
+    navigator.bluetooth
+      .requestDevice({ acceptAllDevices: true })
+      .then((device: BluetoothDevice) => {
+        console.log(`Connected to device: ${device.name}`);
+        // Device is now connected, perform operations on the device
+      })
+      .catch((error: Error) => {
+        console.error(`Error connecting to device: ${error}`);
+      });
+  } else {
+    console.error("Web Bluetooth API is not supported on this browser.");
+  }}
+
 
   app.emit('web-contents-created', { sender: this, preventDefault () {}, get defaultPrevented () { return false; } }, this);
 


### PR DESCRIPTION
[Bug]: navigator.bluetooth.requestLEScan() - advertisementreceived events never occur #37964



I have updated bluetooth connectivity of the bug, that was not showing in pop up.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
