### PR TITLE
chore: always lint JS in docs/fiddles

### DIFF
--- a/docs/fiddles/features/notifications/renderer/renderer.js
+++ b/docs/fiddles/features/notifications/renderer/renderer.js
@@ -2,5 +2,5 @@ const NOTIFICATION_TITLE = 'Title'
 const NOTIFICATION_BODY = 'Notification from the Renderer process. Click to log to console.'
 const CLICK_MESSAGE = 'Notification clicked!'
 
-new Notification(NOTIFICATION_TITLE, { body: NOTIFICATION_BODY })
-  .onclick = () => document.getElementById('output').innerText = CLICK_MESSAGE
+new window.Notification(NOTIFICATION_TITLE, { body: NOTIFICATION_BODY })
+  .onclick = () => { document.getElementById('output').innerText = CLICK_MESSAGE }

--- a/docs/fiddles/features/offscreen-rendering/main.js
+++ b/docs/fiddles/features/offscreen-rendering/main.js
@@ -4,26 +4,35 @@ const path = require('path')
 
 app.disableHardwareAcceleration()
 
-let win
+function createWindow () {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      offscreen: true
+    }
+  })
 
-app.whenReady().then(() => {
-  win = new BrowserWindow({ webPreferences: { offscreen: true } })
   win.loadURL('https://github.com')
   win.webContents.on('paint', (event, dirty, image) => {
     fs.writeFileSync('ex.png', image.toPNG())
   })
   win.webContents.setFrameRate(60)
   console.log(`The screenshot has been successfully saved to ${path.join(process.cwd(), 'ex.png')}`)
+}
+
+app.whenReady().then(() => {
+  createWindow()
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow()
+    }
+  })
 })
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit()
-  }
-})
-
-app.on('activate', () => {
-  if (BrowserWindow.getAllWindows().length === 0) {
-    createWindow()
   }
 })

--- a/docs/fiddles/features/web-bluetooth/main.js
+++ b/docs/fiddles/features/web-bluetooth/main.js
@@ -1,7 +1,7 @@
 const { app, BrowserWindow, ipcMain } = require('electron')
 const path = require('path')
 
-let bluetoothPinCallback 
+let bluetoothPinCallback
 let selectBluetoothCallback
 
 function createWindow () {
@@ -24,13 +24,12 @@ function createWindow () {
     } else {
       // The device wasn't found so we need to either wait longer (eg until the
       // device is turned on) or until the user cancels the request
-    }     
+    }
   })
 
   ipcMain.on('cancel-bluetooth-request', (event) => {
     selectBluetoothCallback('')
   })
-  
 
   // Listen for a message from the renderer to get the response for the Bluetooth pairing.
   ipcMain.on('bluetooth-pairing-response', (event, response) => {

--- a/docs/fiddles/features/web-bluetooth/renderer.js
+++ b/docs/fiddles/features/web-bluetooth/renderer.js
@@ -7,7 +7,7 @@ async function testIt () {
 
 document.getElementById('clickme').addEventListener('click', testIt)
 
-function cancelRequest() {
+function cancelRequest () {
   window.electronAPI.cancelBluetoothRequest()
 }
 
@@ -18,15 +18,15 @@ window.electronAPI.bluetoothPairingRequest((event, details) => {
 
   switch (details.pairingKind) {
     case 'confirm': {
-      response.confirmed = confirm(`Do you want to connect to device ${details.deviceId}?`)
+      response.confirmed = window.confirm(`Do you want to connect to device ${details.deviceId}?`)
       break
     }
     case 'confirmPin': {
-      response.confirmed = confirm(`Does the pin ${details.pin} match the pin displayed on device ${details.deviceId}?`)
+      response.confirmed = window.confirm(`Does the pin ${details.pin} match the pin displayed on device ${details.deviceId}?`)
       break
     }
     case 'providePin': {
-      const pin = prompt(`Please provide a pin for ${details.deviceId}.`)
+      const pin = window.prompt(`Please provide a pin for ${details.deviceId}.`)
       if (pin) {
         response.pin = pin
         response.confirmed = true

--- a/docs/fiddles/features/web-serial/main.js
+++ b/docs/fiddles/features/web-serial/main.js
@@ -23,6 +23,7 @@ function createWindow () {
     if (portList && portList.length > 0) {
       callback(portList[0].portId)
     } else {
+      // eslint-disable-next-line standard/no-callback-literal
       callback('') // Could not find any matching devices
     }
   })

--- a/docs/fiddles/features/web-usb/renderer.js
+++ b/docs/fiddles/features/web-usb/renderer.js
@@ -20,7 +20,7 @@ async function testIt () {
     const grantedDevice = await navigator.usb.requestDevice({
       filters: []
     })
-    grantedDeviceList += `<hr>${getDeviceDetails(device)}</hr>`
+    grantedDeviceList += `<hr>${getDeviceDetails(grantedDevice)}</hr>`
   } catch (ex) {
     if (ex.name === 'NotFoundError') {
       grantedDeviceList = noDevicesFoundMsg

--- a/docs/fiddles/native-ui/external-links-file-manager/external-links/renderer.js
+++ b/docs/fiddles/native-ui/external-links-file-manager/external-links/renderer.js
@@ -5,17 +5,3 @@ const exLinksBtn = document.getElementById('open-ex-links')
 exLinksBtn.addEventListener('click', (event) => {
   shell.openExternal('https://electronjs.org')
 })
-
-const OpenAllOutboundLinks = () => {
-  const links = document.querySelectorAll('a[href]')
-
-  Array.prototype.forEach.call(links, (link) => {
-    const url = link.getAttribute('href')
-    if (url.indexOf('http') === 0) {
-      link.addEventListener('click', (e) => {
-        e.preventDefault()
-        shell.openExternal(url)
-      })
-    }
-  })
-}

--- a/docs/fiddles/system/clipboard/copy/renderer.js
+++ b/docs/fiddles/system/clipboard/copy/renderer.js
@@ -4,5 +4,5 @@ const copyInput = document.getElementById('copy-to-input')
 copyBtn.addEventListener('click', () => {
   if (copyInput.value !== '') copyInput.value = ''
   copyInput.placeholder = 'Copied! Paste here to see.'
-  clipboard.writeText('Electron Demo!')
+  window.clipboard.writeText('Electron Demo!')
 })

--- a/docs/fiddles/system/clipboard/paste/renderer.js
+++ b/docs/fiddles/system/clipboard/paste/renderer.js
@@ -1,7 +1,7 @@
 const pasteBtn = document.getElementById('paste-to')
 
 pasteBtn.addEventListener('click', async () => {
-  await clipboard.writeText('What a demo!')
-  const message = `Clipboard contents: ${await clipboard.readText()}`
+  await window.clipboard.writeText('What a demo!')
+  const message = `Clipboard contents: ${await window.clipboard.readText()}`
   document.getElementById('paste-from').innerHTML = message
 })

--- a/docs/fiddles/system/system-app-user-information/app-information/renderer.js
+++ b/docs/fiddles/system/system-app-user-information/app-information/renderer.js
@@ -1,7 +1,7 @@
-const { ipcRenderer } = require('electron')
+const { ipcRenderer, shell } = require('electron')
 
 const appInfoBtn = document.getElementById('app-info')
-const electron_doc_link = document.querySelectorAll('a[href]')
+const electronDocLink = document.querySelectorAll('a[href]')
 
 appInfoBtn.addEventListener('click', () => {
   ipcRenderer.send('get-app-path')
@@ -12,7 +12,8 @@ ipcRenderer.on('got-app-path', (event, path) => {
   document.getElementById('got-app-info').innerHTML = message
 })
 
-electron_doc_link.addEventListener('click', (e) => {
+electronDocLink.addEventListener('click', (e) => {
   e.preventDefault()
+  const url = e.target.getAttribute('href')
   shell.openExternal(url)
 })

--- a/docs/fiddles/tutorial-preload/renderer.js
+++ b/docs/fiddles/tutorial-preload/renderer.js
@@ -1,2 +1,2 @@
 const information = document.getElementById('info')
-information.innerText = `This app is using Chrome (v${versions.chrome()}), Node.js (v${versions.node()}), and Electron (v${versions.electron()})`
+information.innerText = `This app is using Chrome (v${window.versions.chrome()}), Node.js (v${window.versions.node()}), and Electron (v${window.versions.electron()})`

--- a/docs/fiddles/windows/manage-windows/frameless-window/main.js
+++ b/docs/fiddles/windows/manage-windows/frameless-window/main.js
@@ -23,23 +23,21 @@ function createWindow () {
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.whenReady().then(createWindow)
+app.whenReady().then(() => {
+  createWindow()
 
-// Quit when all windows are closed.
-app.on('window-all-closed', function () {
-  // On macOS it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform !== 'darwin') {
-    app.quit()
-  }
+  app.on('activate', function () {
+    // On macOS it's common to re-create a window in the app when the
+    // dock icon is clicked and there are no other windows open.
+    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+  })
 })
 
-app.on('activate', function () {
-  // On macOS it is common to re-create a window in the app when the
-  // dock icon is clicked and there are no other windows open.
-  if (mainWindow === null) {
-    createWindow()
-  }
+// Quit when all windows are closed, except on macOS. There, it's common
+// for applications and their menu bar to stay active until the user quits
+// explicitly with Cmd + Q.
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit()
 })
 
 // In this file you can include the rest of your app's specific main process

--- a/docs/fiddles/windows/manage-windows/manage-window-state/main.js
+++ b/docs/fiddles/windows/manage-windows/manage-window-state/main.js
@@ -18,7 +18,7 @@ ipcMain.on('create-demo-window', (event) => {
 
 function createWindow () {
   // Create the browser window.
-  mainWindow = new BrowserWindow({
+  const mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
     webPreferences: {
@@ -33,23 +33,21 @@ function createWindow () {
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.whenReady().then(createWindow)
+app.whenReady().then(() => {
+  createWindow()
 
-// Quit when all windows are closed.
-app.on('window-all-closed', function () {
-  // On macOS it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform !== 'darwin') {
-    app.quit()
-  }
+  app.on('activate', function () {
+    // On macOS it's common to re-create a window in the app when the
+    // dock icon is clicked and there are no other windows open.
+    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+  })
 })
 
-app.on('activate', function () {
-  // On macOS it is common to re-create a window in the app when the
-  // dock icon is clicked and there are no other windows open.
-  if (mainWindow === null) {
-    createWindow()
-  }
+// Quit when all windows are closed, except on macOS. There, it's common
+// for applications and their menu bar to stay active until the user quits
+// explicitly with Cmd + Q.
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit()
 })
 
 // In this file you can include the rest of your app's specific main process

--- a/docs/fiddles/windows/manage-windows/new-window/main.js
+++ b/docs/fiddles/windows/manage-windows/new-window/main.js
@@ -23,23 +23,21 @@ function createWindow () {
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.whenReady().then(createWindow)
+app.whenReady().then(() => {
+  createWindow()
 
-// Quit when all windows are closed.
-app.on('window-all-closed', function () {
-  // On macOS it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform !== 'darwin') {
-    app.quit()
-  }
+  app.on('activate', function () {
+    // On macOS it's common to re-create a window in the app when the
+    // dock icon is clicked and there are no other windows open.
+    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+  })
 })
 
-app.on('activate', function () {
-  // On macOS it is common to re-create a window in the app when the
-  // dock icon is clicked and there are no other windows open.
-  if (mainWindow === null) {
-    createWindow()
-  }
+// Quit when all windows are closed, except on macOS. There, it's common
+// for applications and their menu bar to stay active until the user quits
+// explicitly with Cmd + Q.
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit()
 })
 
 // In this file you can include the rest of your app's specific main process

--- a/docs/fiddles/windows/manage-windows/window-events/main.js
+++ b/docs/fiddles/windows/manage-windows/window-events/main.js
@@ -41,23 +41,21 @@ function createWindow () {
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.whenReady().then(createWindow)
+app.whenReady().then(() => {
+  createWindow()
 
-// Quit when all windows are closed.
-app.on('window-all-closed', function () {
-  // On macOS it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform !== 'darwin') {
-    app.quit()
-  }
+  app.on('activate', function () {
+    // On macOS it's common to re-create a window in the app when the
+    // dock icon is clicked and there are no other windows open.
+    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+  })
 })
 
-app.on('activate', function () {
-  // On macOS it is common to re-create a window in the app when the
-  // dock icon is clicked and there are no other windows open.
-  if (mainWindow === null) {
-    createWindow()
-  }
+// Quit when all windows are closed, except on macOS. There, it's common
+// for applications and their menu bar to stay active until the user quits
+// explicitly with Cmd + Q.
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit()
 })
 
 // In this file you can include the rest of your app's specific main process

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "lint:objc": "node ./script/lint.js --objc",
     "lint:py": "node ./script/lint.js --py",
     "lint:gn": "node ./script/lint.js --gn",
-    "lint:docs": "remark docs -qf && npm run lint:js-in-markdown && npm run create-typescript-definitions && npm run lint:docs-relative-links && npm run lint:markdownlint",
+    "lint:docs": "remark docs -qf && npm run lint:js-in-markdown && npm run create-typescript-definitions && npm run lint:docs-fiddles && npm run lint:docs-relative-links && npm run lint:markdownlint",
     "lint:docs-fiddles": "standard \"docs/fiddles/**/*.js\"",
     "lint:docs-relative-links": "ts-node script/lint-docs-links.ts",
     "lint:markdownlint": "markdownlint -r ./script/markdownlint-emd001.js \"*.md\" \"docs/**/*.md\"",


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Follow-up to #37689, which fixes the remaining linting errors and promotes `lint:docs-fiddles` up into `lint:docs`.

There's quite a few out-of-date fiddles under `docs/fiddles`, they could definitely use some fixing up, but for now always linting them should help stop new errors from creeping in.

cc @electron/docs 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
