### PR TITLE
feat: emit `context-menu` event from extensions

### DIFF
--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -326,6 +326,9 @@ class WebContents : public ExclusiveAccessContext,
                                           const base::FilePath& file_path);
   v8::Local<v8::Promise> GetProcessMemoryInfo(v8::Isolate* isolate);
 
+  bool HandleContextMenu(content::RenderFrameHost& render_frame_host,
+                         const content::ContextMenuParams& params) override;
+
   // Properties.
   int32_t ID() const { return id_; }
   v8::Local<v8::Value> Session(v8::Isolate* isolate);
@@ -551,8 +554,6 @@ class WebContents : public ExclusiveAccessContext,
   void RendererResponsive(
       content::WebContents* source,
       content::RenderWidgetHost* render_widget_host) override;
-  bool HandleContextMenu(content::RenderFrameHost& render_frame_host,
-                         const content::ContextMenuParams& params) override;
   void FindReply(content::WebContents* web_contents,
                  int request_id,
                  int number_of_matches,

--- a/shell/browser/extensions/electron_extensions_api_client.cc
+++ b/shell/browser/extensions/electron_extensions_api_client.cc
@@ -65,10 +65,19 @@ class ElectronMimeHandlerViewGuestDelegate
   // MimeHandlerViewGuestDelegate.
   bool HandleContextMenu(content::RenderFrameHost& render_frame_host,
                          const content::ContextMenuParams& params) override {
-    // TODO(nornagon): surface this event to JS
-    LOG(INFO) << "HCM";
+    auto* web_contents =
+        content::WebContents::FromRenderFrameHost(&render_frame_host);
+    if (!web_contents)
+      return true;
+
+    electron::api::WebContents* api_web_contents =
+        electron::api::WebContents::From(
+            web_contents->GetOutermostWebContents());
+    if (api_web_contents)
+      api_web_contents->HandleContextMenu(render_frame_host, params);
     return true;
   }
+
   void RecordLoadMetric(bool in_main_frame,
                         const std::string& mime_type) override {}
 };


### PR DESCRIPTION
#### Description of Change

This PR surfaces context menu handling from extensions. This means that, among other thing, developers can now create context menus for PDF documents.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Surface the `context-menu` event from extensions.
