### PR TITLE
docs: fix 'usb-device-added', 'usb-device-removed', 'usb-device-revoked' typings

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -520,6 +520,7 @@ Returns:
 
 * `event` Event
 * `device` [USBDevice](structures/usb-device.md)
+* `webContents` [WebContents](web-contents.md)
 
 Emitted after `navigator.usb.requestDevice` has been called and
 `select-usb-device` has fired if a new device becomes available before
@@ -533,6 +534,7 @@ Returns:
 
 * `event` Event
 * `device` [USBDevice](structures/usb-device.md)
+* `webContents` [WebContents](web-contents.md)
 
 Emitted after `navigator.usb.requestDevice` has been called and
 `select-usb-device` has fired if a device has been removed before the callback

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -519,9 +519,7 @@ app.whenReady().then(() => {
 Returns:
 
 * `event` Event
-* `details` Object
-  * `device` [USBDevice](structures/usb-device.md)
-  * `frame` [WebFrameMain](web-frame-main.md)
+* `device` [USBDevice](structures/usb-device.md)
 
 Emitted after `navigator.usb.requestDevice` has been called and
 `select-usb-device` has fired if a new device becomes available before
@@ -534,9 +532,7 @@ with the newly added device.
 Returns:
 
 * `event` Event
-* `details` Object
-  * `device` [USBDevice](structures/usb-device.md)
-  * `frame` [WebFrameMain](web-frame-main.md)
+* `device` [USBDevice](structures/usb-device.md)
 
 Emitted after `navigator.usb.requestDevice` has been called and
 `select-usb-device` has fired if a device has been removed before the callback
@@ -550,7 +546,7 @@ Returns:
 
 * `event` Event
 * `details` Object
-  * `device` [USBDevice[]](structures/usb-device.md)
+  * `device` [USBDevice](structures/usb-device.md)
   * `origin` string (optional) - The origin that the device has been revoked from.
 
 Emitted after `USBDevice.forget()` has been called.  This event can be used


### PR DESCRIPTION
#### Description of Change
WebUSB API (added with https://github.com/electron/electron/pull/36289) docs and Typescript typings are not correct. 

References:
- `usb-device-added`: https://github.com/electron/electron/blob/f12e12b341cbc202388d704449b2fcf6c1743ae0/shell/browser/usb/usb_chooser_controller.cc#L72
- `usb-device-removed`: https://github.com/electron/electron/blob/f12e12b341cbc202388d704449b2fcf6c1743ae0/shell/browser/usb/usb_chooser_controller.cc#L81
- `usb-device-revoked`: https://github.com/electron/electron/blob/f12e12b341cbc202388d704449b2fcf6c1743ae0/shell/browser/usb/usb_chooser_context.cc#L211

CC: @jkleinsc 

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix 'usb-device-added', 'usb-device-removed', 'usb-device-revoked' typings
