### PR TITLE
fix: defaults broken in shell.openExternal() options

### DIFF
--- a/shell/common/api/electron_api_shell.cc
+++ b/shell/common/api/electron_api_shell.cc
@@ -59,13 +59,11 @@ v8::Local<v8::Promise> OpenExternal(const GURL& url, gin::Arguments* args) {
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   platform_util::OpenExternalOptions options;
-  if (args->Length() >= 2) {
-    gin::Dictionary obj(nullptr);
-    if (args->GetNext(&obj)) {
-      obj.Get("activate", &options.activate);
-      obj.Get("workingDirectory", &options.working_dir);
-      obj.Get("logUsage", &options.log_usage);
-    }
+  gin_helper::Dictionary obj;
+  if (args->GetNext(&obj)) {
+    obj.Get("activate", &options.activate);
+    obj.Get("workingDirectory", &options.working_dir);
+    obj.Get("logUsage", &options.log_usage);
   }
 
   platform_util::OpenExternal(


### PR DESCRIPTION
#### Description of Change
When calling `shell.openExternal('https://example.com/');` it parses `activate` as `true` correctly.
However calling `shell.openExternal('https://example.com/', {});` would parse `activate` as `false`.

Related to:
https://github.com/electron/electron/blob/0240f6664e5c94d68cb9ad7fb1a9e7c8bbf281d3/shell/common/gin_helper/dictionary.h#L34-L50

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: Fixed broken defaults in `shell.openExternal()` options.
