### PR TITLE
build: Fix Codespaces prebuilds with missing comma

### DIFF
--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -41,7 +41,7 @@ if [ ! -f $buildtools/configs/evm.testing.json ]; then
                 \"electron\": {
                     \"origin\": \"https://github.com/electron/electron.git\"
                 }
-            }
+            },
             \"gen\": {
                 \"args\": [
                     \"import(\\\"//electron/build/args/testing.gn\\\")\",


### PR DESCRIPTION
#### Description of Change

This PR adds one comma to fix [the errors that cropped up in Codespaces Prebuilds](https://github.com/electron/electron/actions/runs/4749172572/jobs/8436158247), due to some errant copy-pasta from #37765.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none