### PR TITLE
docs: add typescript install tutorials

### DIFF
--- a/docs/tutorial/tutorial-2-first-app.md
+++ b/docs/tutorial/tutorial-2-first-app.md
@@ -352,6 +352,71 @@ app.whenReady().then(() => {
 
 ```
 
+
+## Optional: Install TypeScript
+If you wanna create an Electron project with TypeScript. Follow these steps:
+
+Install typescript and types.
+```shell
+npm install typescript @types/node -D
+```
+
+Create a `tsconfig.json` in your project.
+
+```json title='tsconfig.json'
+{
+    "compilerOptions": {
+        "isolatedModules": false,
+        "target": "ES6",
+        "allowJs": true,
+        "module": "CommonJS",
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+        "noImplicitAny": true,
+        "sourceMap": true,
+        "baseUrl": ".",
+        "outDir": "./dist",
+        "moduleResolution": "node",
+        "resolveJsonModule": true,
+    },
+    "include": ["**/*"],
+    "exclude": ["node_modules", "dist"]
+}
+```
+:::info
+
+Please pay attention to "outDir", we will use it later. It means the directory which TypeScript compiler uses to save compiled files.
+
+:::
+
+Then configure the `package.json`. There're two changes:
+1. Added `"prestart": "tsc"` to "scripts", it'll make TypeScript compiler compile your source code first before your application start.
+2. Added the prefix `dist/` to "main", it tells typescript to use the compiled js file as the entry of your application.
+
+```json title='package.json'
+{
+  "name": "my-electron-app",
+  "version": "1.0.0",
+  "description": "Hello World!",
+  "main": "dist/main.js",
+  "scripts": {
+    "prestart": "tsc",
+    "start": "electron .",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Jane Doe",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^18.15.13",
+    "electron": "^24.1.2",
+    "typescript": "^5.0.4"
+  }
+}
+```
+
+TypeScript configuration finished!
+You could write TypeScripts in your Electron project and use **import** fragment instead of `require` function of CommonJS now!
+
 ## Optional: Debugging from VS Code
 
 If you want to debug your application using VS Code, you need to attach VS Code to


### PR DESCRIPTION
This section taught how to install and configuration typescript with electron.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
