### PR TITLE
chore: cherry-pick f098ff0d1230 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -131,10 +131,9 @@ cherry-pick-d9081493c4b2.patch
 cherry-pick-d6946b70b431.patch
 revert_x11_keep_windowcache_alive_for_a_time_interval.patch
 cherry-pick-9585757f9fad.patch
-cherry-pick-f098ff0d1230.patch
 cherry-pick-1d491fff578b.patch
 cherry-pick-2b30a50d0e62.patch
 cherry-pick-f58218891f8c.patch
 cherry-pick-ec53103cc72d.patch
-cherry-pick-f098ff0d1230.patch
 cherry-pick-63686953dc22.patch
+cherry-pick-f098ff0d1230.patch

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -131,3 +131,4 @@ cherry-pick-d9081493c4b2.patch
 cherry-pick-d6946b70b431.patch
 revert_x11_keep_windowcache_alive_for_a_time_interval.patch
 cherry-pick-9585757f9fad.patch
+cherry-pick-f098ff0d1230.patch

--- a/patches/chromium/cherry-pick-f098ff0d1230.patch
+++ b/patches/chromium/cherry-pick-f098ff0d1230.patch
@@ -1,0 +1,144 @@
+From f098ff0d123079690e53e64877bc2d814214b0f3 Mon Sep 17 00:00:00 2001
+From: Andrey Kosyakov <caseq@chromium.org>
+Date: Thu, 13 Apr 2023 03:55:24 +0000
+Subject: [PATCH] [m112] Retain DevToolsAgentHost after ForceDetachAllSessions()
+
+(cherry picked from commit 8c4aee2a90d08535cfb1bf0a59e00cae956b1762)
+
+Bug: 1424337
+Change-Id: Ie0ebe2a49ffbd2356b896c39446b93e09cd81f5a
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4378100
+Reviewed-by: Dmitry Gozman <dgozman@chromium.org>
+Commit-Queue: Andrey Kosyakov <caseq@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1123772}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4420271
+Commit-Queue: Srinivas Sista <srinivassista@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5615@{#1244}
+Cr-Branched-From: 9c6408ef696e83a9936b82bbead3d41c93c82ee4-refs/heads/main@{#1109224}
+---
+
+diff --git a/content/browser/devtools/auction_worklet_devtools_agent_host.cc b/content/browser/devtools/auction_worklet_devtools_agent_host.cc
+index 8566d562..03d7827 100644
+--- a/content/browser/devtools/auction_worklet_devtools_agent_host.cc
++++ b/content/browser/devtools/auction_worklet_devtools_agent_host.cc
+@@ -96,7 +96,7 @@
+ 
+ void AuctionWorkletDevToolsAgentHost::WorkletDestroyed() {
+   worklet_ = nullptr;
+-  ForceDetachAllSessions();
++  auto retain_this = ForceDetachAllSessionsImpl();
+   associated_agent_remote_.reset();
+ }
+ 
+diff --git a/content/browser/devtools/devtools_agent_host_impl.cc b/content/browser/devtools/devtools_agent_host_impl.cc
+index 712fc58..e6bb743 100644
+--- a/content/browser/devtools/devtools_agent_host_impl.cc
++++ b/content/browser/devtools/devtools_agent_host_impl.cc
+@@ -358,12 +358,18 @@
+ }
+ 
+ void DevToolsAgentHostImpl::ForceDetachAllSessions() {
+-  scoped_refptr<DevToolsAgentHostImpl> protect(this);
++  std::ignore = ForceDetachAllSessionsImpl();
++}
++
++scoped_refptr<DevToolsAgentHost>
++DevToolsAgentHostImpl::ForceDetachAllSessionsImpl() {
++  scoped_refptr<DevToolsAgentHost> retain_this(this);
+   while (!sessions_.empty()) {
+     DevToolsAgentHostClient* client = (*sessions_.begin())->GetClient();
+     DetachClient(client);
+     client->AgentHostClosed(this);
+   }
++  return retain_this;
+ }
+ 
+ void DevToolsAgentHostImpl::ForceDetachRestrictedSessions(
+diff --git a/content/browser/devtools/devtools_agent_host_impl.h b/content/browser/devtools/devtools_agent_host_impl.h
+index 7c1bb43..552b3ec 100644
+--- a/content/browser/devtools/devtools_agent_host_impl.h
++++ b/content/browser/devtools/devtools_agent_host_impl.h
+@@ -62,7 +62,6 @@
+   void DisconnectWebContents() override;
+   void ConnectWebContents(WebContents* wc) override;
+   RenderProcessHost* GetProcessHost() override;
+-  void ForceDetachAllSessions() override;
+ 
+   struct NetworkLoaderFactoryParamsAndInfo {
+     NetworkLoaderFactoryParamsAndInfo();
+@@ -126,8 +125,18 @@
+   DevToolsRendererChannel* GetRendererChannel() { return &renderer_channel_; }
+ 
+   const std::vector<DevToolsSession*>& sessions() const { return sessions_; }
++  // Returns refptr retaining `this`. All other references may be removed
++  // at this point, so `this` will become invalid as soon as returned refptr
++  // gets destroyed.
++  [[nodiscard]] scoped_refptr<DevToolsAgentHost> ForceDetachAllSessionsImpl();
+ 
+  private:
++  // Note that calling this may result in the instance being deleted,
++  // as instance may be owned by client sessions. This should not be
++  // used by methods of derived classes, use `ForceDetachAllSessionsImpl()`
++  // above instead.
++  void ForceDetachAllSessions() override;
++
+   friend class DevToolsAgentHost;  // for static methods
+   friend class DevToolsSession;
+   friend class DevToolsRendererChannel;
+diff --git a/content/browser/devtools/render_frame_devtools_agent_host.cc b/content/browser/devtools/render_frame_devtools_agent_host.cc
+index d0395bb..fe72606 100644
+--- a/content/browser/devtools/render_frame_devtools_agent_host.cc
++++ b/content/browser/devtools/render_frame_devtools_agent_host.cc
+@@ -547,9 +547,9 @@
+ }
+ 
+ void RenderFrameDevToolsAgentHost::DestroyOnRenderFrameGone() {
+-  scoped_refptr<RenderFrameDevToolsAgentHost> protect(this);
++  scoped_refptr<DevToolsAgentHost> retain_this;
+   if (IsAttached()) {
+-    ForceDetachAllSessions();
++    retain_this = ForceDetachAllSessionsImpl();
+     UpdateRawHeadersAccess(frame_host_);
+   }
+   ChangeFrameHostAndObservedProcess(nullptr);
+diff --git a/content/browser/devtools/service_worker_devtools_agent_host.cc b/content/browser/devtools/service_worker_devtools_agent_host.cc
+index 6b3bc3e8..d2b3073 100644
+--- a/content/browser/devtools/service_worker_devtools_agent_host.cc
++++ b/content/browser/devtools/service_worker_devtools_agent_host.cc
+@@ -320,8 +320,9 @@
+ 
+ void ServiceWorkerDevToolsAgentHost::RenderProcessHostDestroyed(
+     RenderProcessHost* host) {
++  scoped_refptr<DevToolsAgentHost> retain_this;
+   if (context_wrapper_->process_manager()->IsShutdown())
+-    ForceDetachAllSessions();
++    retain_this = ForceDetachAllSessionsImpl();
+   GetRendererChannel()->SetRenderer(mojo::NullRemote(), mojo::NullReceiver(),
+                                     ChildProcessHost::kInvalidUniqueID);
+   process_observation_.Reset();
+diff --git a/content/browser/devtools/web_contents_devtools_agent_host.cc b/content/browser/devtools/web_contents_devtools_agent_host.cc
+index 2b4276b..38ef33c 100644
+--- a/content/browser/devtools/web_contents_devtools_agent_host.cc
++++ b/content/browser/devtools/web_contents_devtools_agent_host.cc
+@@ -321,7 +321,7 @@
+ 
+ void WebContentsDevToolsAgentHost::WebContentsDestroyed() {
+   DCHECK_EQ(this, FindAgentHost(web_contents()));
+-  ForceDetachAllSessions();
++  auto retain_this = ForceDetachAllSessionsImpl();
+   auto_attacher_.reset();
+   g_agent_host_instances.Get().erase(web_contents());
+   Observe(nullptr);
+diff --git a/content/browser/devtools/worker_devtools_agent_host.cc b/content/browser/devtools/worker_devtools_agent_host.cc
+index 69bddee..5bca24a 100644
+--- a/content/browser/devtools/worker_devtools_agent_host.cc
++++ b/content/browser/devtools/worker_devtools_agent_host.cc
+@@ -87,7 +87,7 @@
+ }
+ 
+ void WorkerDevToolsAgentHost::Disconnected() {
+-  ForceDetachAllSessions();
++  auto retain_this = ForceDetachAllSessionsImpl();
+   GetRendererChannel()->SetRenderer(mojo::NullRemote(), mojo::NullReceiver(),
+                                     ChildProcessHost::kInvalidUniqueID);
+   std::move(destroyed_callback_).Run(this);

--- a/patches/chromium/cherry-pick-f098ff0d1230.patch
+++ b/patches/chromium/cherry-pick-f098ff0d1230.patch
@@ -1,7 +1,7 @@
-From f098ff0d123079690e53e64877bc2d814214b0f3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrey Kosyakov <caseq@chromium.org>
 Date: Thu, 13 Apr 2023 03:55:24 +0000
-Subject: [PATCH] [m112] Retain DevToolsAgentHost after ForceDetachAllSessions()
+Subject: Retain DevToolsAgentHost after ForceDetachAllSessions()
 
 (cherry picked from commit 8c4aee2a90d08535cfb1bf0a59e00cae956b1762)
 
@@ -15,13 +15,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4420271
 Commit-Queue: Srinivas Sista <srinivassista@chromium.org>
 Cr-Commit-Position: refs/branch-heads/5615@{#1244}
 Cr-Branched-From: 9c6408ef696e83a9936b82bbead3d41c93c82ee4-refs/heads/main@{#1109224}
----
 
 diff --git a/content/browser/devtools/auction_worklet_devtools_agent_host.cc b/content/browser/devtools/auction_worklet_devtools_agent_host.cc
-index 8566d562..03d7827 100644
+index 20a989999b6da5d269bca3d6c9bf181eea7180e7..34a13a884885926e3985098315fd9121902099e9 100644
 --- a/content/browser/devtools/auction_worklet_devtools_agent_host.cc
 +++ b/content/browser/devtools/auction_worklet_devtools_agent_host.cc
-@@ -96,7 +96,7 @@
+@@ -96,7 +96,7 @@ AuctionWorkletDevToolsAgentHost::~AuctionWorkletDevToolsAgentHost() = default;
  
  void AuctionWorkletDevToolsAgentHost::WorkletDestroyed() {
    worklet_ = nullptr;
@@ -31,10 +30,10 @@ index 8566d562..03d7827 100644
  }
  
 diff --git a/content/browser/devtools/devtools_agent_host_impl.cc b/content/browser/devtools/devtools_agent_host_impl.cc
-index 712fc58..e6bb743 100644
+index 12779c33fd74ce96ebfd7da2666f9fa3865ccfae..002e41a67314327a9b1354c3d6ed79f17b4dace8 100644
 --- a/content/browser/devtools/devtools_agent_host_impl.cc
 +++ b/content/browser/devtools/devtools_agent_host_impl.cc
-@@ -358,12 +358,18 @@
+@@ -358,12 +358,18 @@ bool DevToolsAgentHostImpl::Inspect() {
  }
  
  void DevToolsAgentHostImpl::ForceDetachAllSessions() {
@@ -55,10 +54,10 @@ index 712fc58..e6bb743 100644
  
  void DevToolsAgentHostImpl::ForceDetachRestrictedSessions(
 diff --git a/content/browser/devtools/devtools_agent_host_impl.h b/content/browser/devtools/devtools_agent_host_impl.h
-index 7c1bb43..552b3ec 100644
+index 7c1bb43345084074b27d4b87aa99af582657fb0f..552b3ec81de3b6e5f222f94835802e6c6aac645f 100644
 --- a/content/browser/devtools/devtools_agent_host_impl.h
 +++ b/content/browser/devtools/devtools_agent_host_impl.h
-@@ -62,7 +62,6 @@
+@@ -62,7 +62,6 @@ class CONTENT_EXPORT DevToolsAgentHostImpl : public DevToolsAgentHost {
    void DisconnectWebContents() override;
    void ConnectWebContents(WebContents* wc) override;
    RenderProcessHost* GetProcessHost() override;
@@ -66,7 +65,7 @@ index 7c1bb43..552b3ec 100644
  
    struct NetworkLoaderFactoryParamsAndInfo {
      NetworkLoaderFactoryParamsAndInfo();
-@@ -126,8 +125,18 @@
+@@ -126,8 +125,18 @@ class CONTENT_EXPORT DevToolsAgentHostImpl : public DevToolsAgentHost {
    DevToolsRendererChannel* GetRendererChannel() { return &renderer_channel_; }
  
    const std::vector<DevToolsSession*>& sessions() const { return sessions_; }
@@ -86,10 +85,10 @@ index 7c1bb43..552b3ec 100644
    friend class DevToolsSession;
    friend class DevToolsRendererChannel;
 diff --git a/content/browser/devtools/render_frame_devtools_agent_host.cc b/content/browser/devtools/render_frame_devtools_agent_host.cc
-index d0395bb..fe72606 100644
+index 2e0ecd508c3b6b3b3593985b19c0b2d92ebbe4f4..c4da2a97f95c0e213c0ce3fddc96b5596fc8bc0b 100644
 --- a/content/browser/devtools/render_frame_devtools_agent_host.cc
 +++ b/content/browser/devtools/render_frame_devtools_agent_host.cc
-@@ -547,9 +547,9 @@
+@@ -541,9 +541,9 @@ void RenderFrameDevToolsAgentHost::RenderFrameDeleted(RenderFrameHost* rfh) {
  }
  
  void RenderFrameDevToolsAgentHost::DestroyOnRenderFrameGone() {
@@ -102,10 +101,10 @@ index d0395bb..fe72606 100644
    }
    ChangeFrameHostAndObservedProcess(nullptr);
 diff --git a/content/browser/devtools/service_worker_devtools_agent_host.cc b/content/browser/devtools/service_worker_devtools_agent_host.cc
-index 6b3bc3e8..d2b3073 100644
+index 47d2d169a3eb6cf7c135beeb667cfa5b186987a2..14165045182712b71fef70b758f269b1cbbfc7e8 100644
 --- a/content/browser/devtools/service_worker_devtools_agent_host.cc
 +++ b/content/browser/devtools/service_worker_devtools_agent_host.cc
-@@ -320,8 +320,9 @@
+@@ -320,8 +320,9 @@ void ServiceWorkerDevToolsAgentHost::UpdateProcessHost() {
  
  void ServiceWorkerDevToolsAgentHost::RenderProcessHostDestroyed(
      RenderProcessHost* host) {
@@ -117,10 +116,10 @@ index 6b3bc3e8..d2b3073 100644
                                      ChildProcessHost::kInvalidUniqueID);
    process_observation_.Reset();
 diff --git a/content/browser/devtools/web_contents_devtools_agent_host.cc b/content/browser/devtools/web_contents_devtools_agent_host.cc
-index 2b4276b..38ef33c 100644
+index fb8e10a18bb725eb9280db8695ae12899dba2eef..2203dcef48c70ecc1758062ac871e80983059464 100644
 --- a/content/browser/devtools/web_contents_devtools_agent_host.cc
 +++ b/content/browser/devtools/web_contents_devtools_agent_host.cc
-@@ -321,7 +321,7 @@
+@@ -299,7 +299,7 @@ DevToolsAgentHostImpl* WebContentsDevToolsAgentHost::GetPrimaryFrameAgent() {
  
  void WebContentsDevToolsAgentHost::WebContentsDestroyed() {
    DCHECK_EQ(this, FindAgentHost(web_contents()));
@@ -130,10 +129,10 @@ index 2b4276b..38ef33c 100644
    g_agent_host_instances.Get().erase(web_contents());
    Observe(nullptr);
 diff --git a/content/browser/devtools/worker_devtools_agent_host.cc b/content/browser/devtools/worker_devtools_agent_host.cc
-index 69bddee..5bca24a 100644
+index db788e7298d6696ec5a354cb387dfdc4030d8ce0..0984b3ae35459d8676b903394577cc6a43601ac8 100644
 --- a/content/browser/devtools/worker_devtools_agent_host.cc
 +++ b/content/browser/devtools/worker_devtools_agent_host.cc
-@@ -87,7 +87,7 @@
+@@ -87,7 +87,7 @@ void WorkerDevToolsAgentHost::ChildWorkerCreated(
  }
  
  void WorkerDevToolsAgentHost::Disconnected() {


### PR DESCRIPTION
[m112] Retain DevToolsAgentHost after ForceDetachAllSessions()

(cherry picked from commit 8c4aee2a90d08535cfb1bf0a59e00cae956b1762)

Bug: 1424337
Change-Id: Ie0ebe2a49ffbd2356b896c39446b93e09cd81f5a
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4378100
Reviewed-by: Dmitry Gozman <dgozman@chromium.org>
Commit-Queue: Andrey Kosyakov <caseq@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1123772}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4420271
Commit-Queue: Srinivas Sista <srinivassista@chromium.org>
Cr-Commit-Position: refs/branch-heads/5615@{#1244}
Cr-Branched-From: 9c6408ef696e83a9936b82bbead3d41c93c82ee4-refs/heads/main@{#1109224}


Ref electron/security#316

Notes: Security: backported fix for CVE-2023-2135.