### PR TITLE
chore: fix clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+---
+Checks: '-modernize-use-nullptr'
+InheritParentConfig: true
+...

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -243,8 +243,8 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
     std::vector<DesktopCapturer::Source> window_sources;
     window_sources.reserve(list->GetSourceCount());
     for (int i = 0; i < list->GetSourceCount(); i++) {
-      window_sources.emplace_back(DesktopCapturer::Source{
-          list->GetSource(i), std::string(), fetch_window_icons_});
+      window_sources.emplace_back(list->GetSource(i), std::string(),
+                                  fetch_window_icons_);
     }
     std::move(window_sources.begin(), window_sources.end(),
               std::back_inserter(captured_sources_));
@@ -256,8 +256,7 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
     std::vector<DesktopCapturer::Source> screen_sources;
     screen_sources.reserve(list->GetSourceCount());
     for (int i = 0; i < list->GetSourceCount(); i++) {
-      screen_sources.emplace_back(
-          DesktopCapturer::Source{list->GetSource(i), std::string()});
+      screen_sources.emplace_back(list->GetSource(i), std::string());
     }
 #if BUILDFLAG(IS_WIN)
     // Gather the same unique screen IDs used by the electron.screen API in

--- a/shell/browser/api/electron_api_system_preferences.cc
+++ b/shell/browser/api/electron_api_system_preferences.cc
@@ -17,19 +17,21 @@ namespace electron::api {
 
 gin::WrapperInfo SystemPreferences::kWrapperInfo = {gin::kEmbedderNativeGin};
 
-// NOLINTNEXTLINE(modernize-use-equals-default)
+#if BUILDFLAG(IS_WIN)
 SystemPreferences::SystemPreferences() {
-#if BUILDFLAG(IS_WIN)
   InitializeWindow();
-#endif
 }
+#else
+SystemPreferences::SystemPreferences() = default;
+#endif
 
-// NOLINTNEXTLINE(modernize-use-equals-default)
-SystemPreferences::~SystemPreferences() {
 #if BUILDFLAG(IS_WIN)
+SystemPreferences::~SystemPreferences() {
   Browser::Get()->RemoveObserver(this);
-#endif
 }
+#else
+SystemPreferences::~SystemPreferences() = default;
+#endif
 
 bool SystemPreferences::IsInvertedColorScheme() {
   return ui::NativeTheme::GetInstanceForNativeUi()

--- a/shell/browser/api/electron_api_system_preferences.cc
+++ b/shell/browser/api/electron_api_system_preferences.cc
@@ -17,12 +17,14 @@ namespace electron::api {
 
 gin::WrapperInfo SystemPreferences::kWrapperInfo = {gin::kEmbedderNativeGin};
 
+// NOLINTNEXTLINE(modernize-use-equals-default)
 SystemPreferences::SystemPreferences() {
 #if BUILDFLAG(IS_WIN)
   InitializeWindow();
 #endif
 }
 
+// NOLINTNEXTLINE(modernize-use-equals-default)
 SystemPreferences::~SystemPreferences() {
 #if BUILDFLAG(IS_WIN)
   Browser::Get()->RemoveObserver(this);

--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -455,6 +455,7 @@ v8::Local<v8::Promise> SystemPreferences::PromptTouchID(
                   operation:LAAccessControlOperationUseKeySign
             localizedReason:[NSString stringWithUTF8String:reason.c_str()]
                       reply:^(BOOL success, NSError* error) {
+                        // NOLINTBEGIN(bugprone-use-after-move)
                         if (!success) {
                           std::string err_msg = std::string(
                               [error.localizedDescription UTF8String]);
@@ -470,6 +471,7 @@ v8::Local<v8::Promise> SystemPreferences::PromptTouchID(
                                   gin_helper::Promise<void>::ResolvePromise,
                                   std::move(p)));
                         }
+                        // NOLINTEND(bugprone-use-after-move)
                       }];
 
   return handle;

--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -279,7 +279,7 @@ void UtilityProcessWrapper::PostMessage(gin::Arguments* args) {
 
 bool UtilityProcessWrapper::Kill() const {
   if (pid_ == base::kNullProcessId)
-    return 0;
+    return false;
   base::Process process = base::Process::Open(pid_);
   bool result = process.Terminate(content::RESULT_CODE_NORMAL_EXIT, false);
   // Refs https://bugs.chromium.org/p/chromium/issues/detail?id=818244

--- a/shell/browser/api/gpu_info_enumerator.cc
+++ b/shell/browser/api/gpu_info_enumerator.cc
@@ -8,7 +8,7 @@
 
 namespace electron {
 
-GPUInfoEnumerator::GPUInfoEnumerator() : value_stack_(), current_{} {}
+GPUInfoEnumerator::GPUInfoEnumerator() = default;
 
 GPUInfoEnumerator::~GPUInfoEnumerator() = default;
 

--- a/shell/browser/bluetooth/electron_bluetooth_delegate.cc
+++ b/shell/browser/bluetooth/electron_bluetooth_delegate.cc
@@ -84,7 +84,7 @@ std::string ElectronBluetoothDelegate::GetDeviceAddress(
     RenderFrameHost* frame,
     const WebBluetoothDeviceId& device_id) {
   NOTIMPLEMENTED();
-  return nullptr;
+  return "";
 }
 
 WebBluetoothDeviceId ElectronBluetoothDelegate::AddScannedDevice(

--- a/shell/browser/electron_permission_manager.cc
+++ b/shell/browser/electron_permission_manager.cc
@@ -203,16 +203,16 @@ void ElectronPermissionManager::RequestPermissionsWithDetails(
   int request_id = pending_requests_.Add(std::make_unique<PendingRequest>(
       render_frame_host, permissions, std::move(response_callback)));
 
+  details.Set("requestingUrl", render_frame_host->GetLastCommittedURL().spec());
+  details.Set("isMainFrame", render_frame_host->GetParent() == nullptr);
+  base::Value dict_value(std::move(details));
+
   for (size_t i = 0; i < permissions.size(); ++i) {
     auto permission = permissions[i];
     const auto callback =
         base::BindRepeating(&ElectronPermissionManager::OnPermissionResponse,
                             base::Unretained(this), request_id, i);
-    details.Set("requestingUrl",
-                render_frame_host->GetLastCommittedURL().spec());
-    details.Set("isMainFrame", render_frame_host->GetParent() == nullptr);
-    request_handler_.Run(web_contents, permission, callback,
-                         base::Value(std::move(details)));
+    request_handler_.Run(web_contents, permission, callback, dict_value);
   }
 }
 

--- a/shell/browser/file_select_helper.cc
+++ b/shell/browser/file_select_helper.cc
@@ -71,8 +71,6 @@ struct FileSelectHelper::ActiveDirectoryEnumeration {
 FileSelectHelper::FileSelectHelper()
     : render_frame_host_(nullptr),
       web_contents_(nullptr),
-      select_file_dialog_(),
-      select_file_types_(),
       dialog_type_(ui::SelectFileDialog::SELECT_OPEN_FILE),
       dialog_mode_(FileChooserParams::Mode::kOpen) {}
 

--- a/shell/browser/font_defaults.cc
+++ b/shell/browser/font_defaults.cc
@@ -103,13 +103,11 @@ const FontDefault kFontDefaults[] = {
      IDS_FIXED_FONT_FAMILY_TRADITIONAL_HAN},
 #endif
 };
-const size_t kFontDefaultsLength = std::size(kFontDefaults);
 
 // ^^^^^ DO NOT EDIT ^^^^^
 
 std::string GetDefaultFontForPref(const char* pref_name) {
-  for (size_t i = 0; i < kFontDefaultsLength; ++i) {
-    FontDefault pref = kFontDefaults[i];
+  for (auto pref : kFontDefaults) {
     if (strcmp(pref.pref_name, pref_name) == 0) {
       return l10n_util::GetStringUTF8(pref.resource_id);
     }

--- a/shell/browser/linux/unity_service.cc
+++ b/shell/browser/linux/unity_service.cc
@@ -15,7 +15,7 @@
 
 // Unity data typedefs.
 typedef struct _UnityInspector UnityInspector;
-typedef UnityInspector* (*unity_inspector_get_default_func)(void);
+typedef UnityInspector* (*unity_inspector_get_default_func)();
 typedef gboolean (*unity_inspector_get_unity_running_func)(
     UnityInspector* self);
 

--- a/shell/browser/net/asar/asar_url_loader.cc
+++ b/shell/browser/net/asar/asar_url_loader.cc
@@ -166,8 +166,8 @@ class AsarURLLoader : public network::mojom::URLLoader {
       auto asar_validator = std::make_unique<AsarFileValidator>(
           std::move(info.integrity.value()), std::move(file));
       file_validator_raw = asar_validator.get();
-      readable_data_source.reset(new mojo::FilteredDataSource(
-          std::move(file_data_source), std::move(asar_validator)));
+      readable_data_source = std::make_unique<mojo::FilteredDataSource>(
+          std::move(file_data_source), std::move(asar_validator));
     } else {
       readable_data_source = std::move(file_data_source);
     }

--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -36,8 +36,7 @@ std::string MakeCaseInsensitivePattern(const std::string& extension) {
     return extension;
 
   std::string pattern("*.");
-  for (std::size_t i = 0, n = extension.size(); i < n; i++) {
-    char ch = extension[i];
+  for (char ch : extension) {
     if (!base::IsAsciiAlpha(ch)) {
       pattern.push_back(ch);
       continue;

--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -283,7 +283,7 @@ void ReadDialogPathsWithBookmarks(NSOpenPanel* dialog,
   NSArray* urls = [dialog URLs];
   for (NSURL* url in urls)
     if ([url isFileURL]) {
-      paths->push_back(base::FilePath(base::SysNSStringToUTF8([url path])));
+      paths->emplace_back(base::SysNSStringToUTF8([url path]));
       bookmarks->push_back(GetBookmarkDataFromNSURL(url));
     }
 }

--- a/shell/browser/ui/webui/accessibility_ui.cc
+++ b/shell/browser/ui/webui/accessibility_ui.cc
@@ -152,7 +152,7 @@ void AddPropertyFilters(std::vector<ui::AXPropertyFilter>* property_filters,
                         ui::AXPropertyFilter::Type type) {
   for (const std::string& attribute : base::SplitString(
            attributes, " ", base::KEEP_WHITESPACE, base::SPLIT_WANT_NONEMPTY)) {
-    property_filters->push_back(ui::AXPropertyFilter(attribute, type));
+    property_filters->emplace_back(attribute, type);
   }
 }
 

--- a/shell/browser/usb/usb_chooser_context_factory.cc
+++ b/shell/browser/usb/usb_chooser_context_factory.cc
@@ -15,7 +15,7 @@ UsbChooserContextFactory::UsbChooserContextFactory()
           "UsbChooserContext",
           BrowserContextDependencyManager::GetInstance()) {}
 
-UsbChooserContextFactory::~UsbChooserContextFactory() {}
+UsbChooserContextFactory::~UsbChooserContextFactory() = default;
 
 KeyedService* UsbChooserContextFactory::BuildServiceInstanceFor(
     content::BrowserContext* context) const {

--- a/shell/browser/usb/usb_chooser_controller.cc
+++ b/shell/browser/usb/usb_chooser_controller.cc
@@ -54,7 +54,7 @@ UsbChooserController::UsbChooserController(
 }
 
 UsbChooserController::~UsbChooserController() {
-  RunCallback(/*device=*/nullptr);
+  RunCallback(/*device_info=*/nullptr);
 }
 
 api::Session* UsbChooserController::GetSession() {
@@ -85,7 +85,7 @@ void UsbChooserController::OnDeviceRemoved(
 void UsbChooserController::OnDeviceChosen(gin::Arguments* args) {
   std::string device_id;
   if (!args->GetNext(&device_id) || device_id.empty()) {
-    RunCallback(/*device=*/nullptr);
+    RunCallback(/*device_info=*/nullptr);
   } else {
     auto* device_info = chooser_context_->GetDeviceInfo(device_id);
     if (device_info) {
@@ -95,7 +95,7 @@ void UsbChooserController::OnDeviceChosen(gin::Arguments* args) {
       node::Environment* env = node::Environment::GetCurrent(isolate);
       EmitWarning(env, "The device id " + device_id + " was not found.",
                   "UnknownUsbDeviceId");
-      RunCallback(/*device=*/nullptr);
+      RunCallback(/*device_info=*/nullptr);
     }
   }
 }
@@ -131,7 +131,7 @@ void UsbChooserController::GotUsbDeviceList(
                                          weak_factory_.GetWeakPtr())));
   }
   if (!prevent_default) {
-    RunCallback(/*port=*/nullptr);
+    RunCallback(/*device_info=*/nullptr);
   }
 }
 

--- a/shell/common/gin_helper/trackable_object.cc
+++ b/shell/common/gin_helper/trackable_object.cc
@@ -21,7 +21,7 @@ class IDUserData : public base::SupportsUserData::Data {
  public:
   explicit IDUserData(int32_t id) : id_(id) {}
 
-  operator int32_t() const { return id_; }
+  explicit operator int32_t() const { return id_; }
 
  private:
   int32_t id_;
@@ -58,7 +58,7 @@ int32_t TrackableObjectBase::GetIDFromWrappedClass(
     auto* id =
         static_cast<IDUserData*>(wrapped->GetUserData(kTrackedObjectKey));
     if (id)
-      return *id;
+      return int32_t(*id);
   }
   return 0;
 }

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -61,7 +61,7 @@ class ShowItemHelper {
     return *instance;
   }
 
-  ShowItemHelper() {}
+  ShowItemHelper() = default;
 
   ShowItemHelper(const ShowItemHelper&) = delete;
   ShowItemHelper& operator=(const ShowItemHelper&) = delete;

--- a/shell/renderer/electron_autofill_agent.cc
+++ b/shell/renderer/electron_autofill_agent.cc
@@ -46,7 +46,7 @@ void GetDataListSuggestions(const blink::WebInputElement& element,
     if (option.Value() != option.Label())
       labels->push_back(option.Label().Utf16());
     else
-      labels->push_back(std::u16string());
+      labels->emplace_back();
   }
 
   TrimStringVectorForIPC(values);


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Fixes the current warnings from `clang-tidy`, other than `modernize-use-nullptr` which I'm disabling for now as there's too much noise.  There's a couple false positives I had to silence with `// NOLINT`.

The goal is to add a `clang-tidy` CI job, but that will be done in a future PR.

For completeness, here is the `clang-tidy` output without the fixes:

<details><summary>Warnings</summary>

```
../../electron/shell/common/gin_helper/trackable_object.cc:24:3: warning: 'operator int' must be marked explicit to avoid unintentional implicit conversions [google-explicit-constructor]
  operator int32_t() const { return id_; }
  ^
  explicit 

../../electron/shell/browser/api/electron_api_desktop_capturer.cc:246:35: warning: unnecessary temporary object created while calling emplace_back [modernize-use-emplace]
      window_sources.emplace_back(DesktopCapturer::Source{
                                  ^~~~~~~~~~~~~~~~~~~~~~~~
../../electron/shell/browser/api/electron_api_desktop_capturer.cc:260:11: warning: unnecessary temporary object created while calling emplace_back [modernize-use-emplace]
          DesktopCapturer::Source{list->GetSource(i), std::string()});
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../../electron/shell/browser/ui/webui/accessibility_ui.cc:155:23: warning: use emplace_back instead of push_back [modernize-use-emplace]
    property_filters->push_back(ui::AXPropertyFilter(attribute, type));
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~               ~
                      emplace_back(
../../electron/shell/browser/usb/usb_chooser_context_factory.cc:18:27: warning: use '= default' to define a trivial destructor [modernize-use-equals-default]
UsbChooserContextFactory::~UsbChooserContextFactory() {}
                          ^                           ~~
                                                      = default;
../../electron/shell/browser/usb/usb_chooser_controller.cc:57:15: warning: argument name 'device' in comment does not match parameter name 'device_info' [bugprone-argument-comment]
  RunCallback(/*device=*/nullptr);
              ^
../../electron/shell/browser/usb/usb_chooser_controller.h:61:52: note: 'device_info' declared here
  void RunCallback(device::mojom::UsbDeviceInfoPtr device_info);
                                                   ^
../../electron/shell/browser/usb/usb_chooser_controller.cc:88:17: warning: argument name 'device' in comment does not match parameter name 'device_info' [bugprone-argument-comment]
    RunCallback(/*device=*/nullptr);
                ^
../../electron/shell/browser/usb/usb_chooser_controller.h:61:52: note: 'device_info' declared here
  void RunCallback(device::mojom::UsbDeviceInfoPtr device_info);
                                                   ^
../../electron/shell/browser/usb/usb_chooser_controller.cc:98:19: warning: argument name 'device' in comment does not match parameter name 'device_info' [bugprone-argument-comment]
      RunCallback(/*device=*/nullptr);
                  ^
../../electron/shell/browser/usb/usb_chooser_controller.h:61:52: note: 'device_info' declared here
  void RunCallback(device::mojom::UsbDeviceInfoPtr device_info);
                                                   ^
../../electron/shell/browser/usb/usb_chooser_controller.cc:134:17: warning: argument name 'port' in comment does not match parameter name 'device_info' [bugprone-argument-comment]
    RunCallback(/*port=*/nullptr);
                ^
../../electron/shell/browser/usb/usb_chooser_controller.h:61:52: note: 'device_info' declared here
  void RunCallback(device::mojom::UsbDeviceInfoPtr device_info);
                                                   ^

../../electron/shell/browser/api/electron_api_utility_process.cc:282:12: warning: converting integer literal to bool, use bool literal instead [modernize-use-bool-literals]
    return 0;
           ^
           false

../../electron/shell/browser/api/electron_api_system_preferences_mac.mm:465:45: warning: 'p' used after it was moved [bugprone-use-after-move]
                                  std::move(p), std::move(err_msg)));
                                            ^
../../electron/shell/browser/api/electron_api_system_preferences_mac.mm:469:31: note: move occurred here
                              base::BindOnce(
                              ^
../../electron/shell/browser/api/electron_api_system_preferences_mac.mm:465:45: note: the use and move are unsequenced, i.e. there is no guarantee about the order in which they are evaluated
                                  std::move(p), std::move(err_msg)));
                                            ^
../../electron/shell/browser/api/electron_api_system_preferences_mac.mm:471:45: warning: 'p' used after it was moved [bugprone-use-after-move]
                                  std::move(p)));
                                            ^
../../electron/shell/browser/api/electron_api_system_preferences_mac.mm:463:31: note: move occurred here
                              base::BindOnce(
                              ^
../../electron/shell/browser/api/electron_api_system_preferences_mac.mm:471:45: note: the use and move are unsequenced, i.e. there is no guarantee about the order in which they are evaluated
                                  std::move(p)));
                                            ^
../../electron/shell/browser/ui/file_dialog_mac.mm:286:14: warning: use emplace_back instead of push_back [modernize-use-emplace]
      paths->push_back(base::FilePath(base::SysNSStringToUTF8([url path])));
             ^~~~~~~~~~~~~~~~~~~~~~~~~                                   ~
             emplace_back(
../../electron/shell/renderer/electron_autofill_agent.cc:49:15: warning: use emplace_back instead of push_back [modernize-use-emplace]
      labels->push_back(std::u16string());
              ^~~~~~~~~~~~~~~~~~~~~~~~~~
              emplace_back(

../../electron/shell/browser/api/gpu_info_enumerator.cc:11:42: warning: initializer for member 'value_stack_' is redundant [readability-redundant-member-init]
GPUInfoEnumerator::GPUInfoEnumerator() : value_stack_(), current_{} {}
                                         ^~~~~~~~~~~~~~
../../electron/shell/browser/api/gpu_info_enumerator.cc:11:58: warning: initializer for member 'current_' is redundant [readability-redundant-member-init]
GPUInfoEnumerator::GPUInfoEnumerator() : value_stack_(), current_{} {}
                                                         ^~~~~~~~~~~
../../electron/shell/browser/bluetooth/electron_bluetooth_delegate.cc:87:10: warning: constructing string from nullptr is undefined behaviour [bugprone-string-constructor]
  return nullptr;
         ^
../../electron/shell/browser/electron_permission_manager.cc:211:5: warning: 'details' used after it was moved [bugprone-use-after-move]
    details.Set("requestingUrl",
    ^
../../electron/shell/browser/electron_permission_manager.cc:215:26: note: move occurred here
                         base::Value(std::move(details)));
                         ^
../../electron/shell/browser/electron_permission_manager.cc:211:5: note: the use happens in a later loop iteration than the move
    details.Set("requestingUrl",
    ^
../../electron/shell/browser/file_select_helper.cc:74:7: warning: initializer for member 'select_file_dialog_' is redundant [readability-redundant-member-init]
      select_file_dialog_(),
      ^~~~~~~~~~~~~~~~~~~~~
../../electron/shell/browser/file_select_helper.cc:75:7: warning: initializer for member 'select_file_types_' is redundant [readability-redundant-member-init]
      select_file_types_(),
      ^~~~~~~~~~~~~~~~~~~~
../../electron/shell/browser/font_defaults.cc:111:3: warning: use range-based for loop instead [modernize-loop-convert]
  for (size_t i = 0; i < kFontDefaultsLength; ++i) {
  ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      (auto pref : kFontDefaults)
../../electron/shell/browser/net/asar/asar_url_loader.cc:169:28: warning: use std::make_unique instead [modernize-make-unique]
      readable_data_source.reset(new mojo::FilteredDataSource(
                          ~^~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                           = std::make_unique<mojo::FilteredDataSource>
```
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
