### PR TITLE
fix: defaults broken in shell.openExternal() options

### DIFF
--- a/shell/common/api/electron_api_shell.cc
+++ b/shell/common/api/electron_api_shell.cc
@@ -59,12 +59,10 @@ v8::Local<v8::Promise> OpenExternal(const GURL& url, gin::Arguments* args) {
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   platform_util::OpenExternalOptions options;
-  if (args->Length() >= 2) {
-    gin::Dictionary obj(nullptr);
-    if (args->GetNext(&obj)) {
-      obj.Get("activate", &options.activate);
-      obj.Get("workingDirectory", &options.working_dir);
-    }
+  gin_helper::Dictionary obj;
+  if (args->GetNext(&obj)) {
+    obj.Get("activate", &options.activate);
+    obj.Get("workingDirectory", &options.working_dir);
   }
 
   platform_util::OpenExternal(


### PR DESCRIPTION
Backport of #38038

See that PR for details.

Notes: Fixed broken defaults in `shell.openExternal()` options.