### PR TITLE
fix: `AXManualAccessibility` showing failure

### DIFF
--- a/docs/tutorial/accessibility.md
+++ b/docs/tutorial/accessibility.md
@@ -28,6 +28,8 @@ On macOS, third-party assistive technology can toggle accessibility features ins
 Electron applications by setting the `AXManualAccessibility` attribute
 programmatically:
 
+Using Objective-C:
+
 ```objc
 CFStringRef kAXManualAccessibility = CFSTR("AXManualAccessibility");
 
@@ -41,6 +43,17 @@ CFStringRef kAXManualAccessibility = CFSTR("AXManualAccessibility");
     AXUIElementSetAttributeValue(appRef, kAXManualAccessibility, value);
     CFRelease(appRef);
 }
+```
+
+Using Swift:
+
+```swift
+import Cocoa
+let name = CommandLine.arguments.count >= 2 ? CommandLine.arguments[1] : "Electron"
+let pid = NSWorkspace.shared.runningApplications.first(where: {$0.localizedName == name})!.processIdentifier
+let axApp = AXUIElementCreateApplication(pid)
+let result = AXUIElementSetAttributeValue(axApp, "AXManualAccessibility" as CFString, true as CFTypeRef)
+print("Setting 'AXManualAccessibility' \(error.rawValue == 0 ? "succeeded" : "failed")")
 ```
 
 [a11y-docs]: https://www.chromium.org/developers/design-documents/accessibility#TOC-How-Chrome-detects-the-presence-of-Assistive-Technology


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/37465.

Fixes an issue where using Swift etc to enable various a11y features within Electron using the `AXManualAccessibility` attribute would appear to fail. This was happening because we were always calling `[super accessibilitySetValue:value forAttribute:attribute]` in our override, and the custom attribute would always fail when that superclass function was shown. After this fix, the attribute correctly reflects success, with no failure and the `accessibility-support-changed` event correctly emitted on `app`.

I also took the opportunity to update the documentation a little to reflect multiple approaches.

Tested using the Swift REPL and the following code:

```swift
import Cocoa
let name = CommandLine.arguments.count >= 2 ? CommandLine.arguments[1] : "Electron"
let pid = NSWorkspace.shared.runningApplications.first(where: {$0.localizedName == name})!.processIdentifier
let axApp = AXUIElementCreateApplication(pid)
let result = AXUIElementSetAttributeValue(axApp, "AXManualAccessibility" as CFString, true as CFTypeRef)
print("Setting 'AXManualAccessibility' \(error.rawValue == 0 ? "succeeded" : "failed")")
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an perceived failure when when using Accessibility attribute `AXManualAccessibility` to enable a11y features in Electron.
