### PR TITLE
test: re-enable multi-window fullscreen test

### DIFF
--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5536,14 +5536,13 @@ describe('BrowserWindow module', () => {
         expect(w.isFullScreen()).to.be.false('isFullScreen');
       });
 
-      // FIXME: https://github.com/electron/electron/issues/30140
-      xit('multiple windows inherit correct fullscreen state', async () => {
+      it('multiple windows inherit correct fullscreen state', async () => {
         const w = new BrowserWindow();
         const enterFullScreen = once(w, 'enter-full-screen');
         w.setFullScreen(true);
         await enterFullScreen;
         expect(w.isFullScreen()).to.be.true('isFullScreen');
-        await setTimeout();
+        await setTimeout(1000);
         const w2 = new BrowserWindow({ show: false });
         const enterFullScreen2 = once(w2, 'enter-full-screen');
         w2.show();


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/30140.

Re-enable multiple window fullscreen inheritance test. This was disabled because it was flaking at the point the second window was opened, which upon investigation is a small bug in AppKit which means that `windowDidEnterFullScreen` fires in a way that creates a race condition with a second window opening. With a short enough timeout, the second window doesn't correctly reflect the fullscreen status of the first one, and doesn't open in fullscreen. This is fixed consistently with a 1 second delay.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
