### PR TITLE
chore: add missing content::WebContentsDelegate section

### DIFF
--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -690,6 +690,7 @@ class WebContents : public ExclusiveAccessContext,
   bool CanUserExitFullscreen() const override;
   bool IsExclusiveAccessBubbleDisplayed() const override;
 
+  // content::WebContentsDelegate
   bool IsFullscreenForTabOrPending(const content::WebContents* source) override;
   bool TakeFocus(content::WebContents* source, bool reverse) override;
   content::PictureInPictureResult EnterPictureInPicture(


### PR DESCRIPTION
#### Description of Change
These methods implement `content::WebContentsDelegate`:
https://github.com/electron/electron/blob/a2d35e9cf53f324d8153cb56982074e1af5fb177/shell/browser/api/electron_api_web_contents.h#L693-L697

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
