### PR TITLE
chore: implement `WebContentsDelegate::GetFullscreenState`

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3731,6 +3731,12 @@ bool WebContents::IsFullscreenForTabOrPending(
   return is_html_fullscreen() || (in_transition && is_html_transition);
 }
 
+content::FullscreenState WebContents::GetFullscreenState(
+    const content::WebContents* source) const {
+  return exclusive_access_manager_->fullscreen_controller()->GetFullscreenState(
+      source);
+}
+
 bool WebContents::TakeFocus(content::WebContents* source, bool reverse) {
   if (source && source->GetOutermostWebContents() == source) {
     // If this is the outermost web contents and the user has tabbed or

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -692,6 +692,8 @@ class WebContents : public ExclusiveAccessContext,
 
   // content::WebContentsDelegate
   bool IsFullscreenForTabOrPending(const content::WebContents* source) override;
+  content::FullscreenState GetFullscreenState(
+      const content::WebContents* web_contents) const override;
   bool TakeFocus(content::WebContents* source, bool reverse) override;
   content::PictureInPictureResult EnterPictureInPicture(
       content::WebContents* web_contents) override;


### PR DESCRIPTION
#### Description of Change

Refs https://chromium-review.googlesource.com/c/chromium/src/+/4255184

Implements `WebContentsDelegate::GetFullscreenState` and resolves an error now seen intermittently in the console: 

```
[77991:0502/100511.081484:ERROR:web_contents_delegate.cc(174)] Not implemented reached in virtual FullscreenState content::WebContentsDelegate::GetFullscreenState(const WebContents *) const
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none