### PR TITLE
fix: `AXManualAccessibility` showing failure

### DIFF
--- a/docs/tutorial/accessibility.md
+++ b/docs/tutorial/accessibility.md
@@ -28,6 +28,8 @@ On macOS, third-party assistive technology can toggle accessibility features ins
 Electron applications by setting the `AXManualAccessibility` attribute
 programmatically:
 
+Using Objective-C:
+
 ```objc
 CFStringRef kAXManualAccessibility = CFSTR("AXManualAccessibility");
 
@@ -41,6 +43,17 @@ CFStringRef kAXManualAccessibility = CFSTR("AXManualAccessibility");
     AXUIElementSetAttributeValue(appRef, kAXManualAccessibility, value);
     CFRelease(appRef);
 }
+```
+
+Using Swift:
+
+```swift
+import Cocoa
+let name = CommandLine.arguments.count >= 2 ? CommandLine.arguments[1] : "Electron"
+let pid = NSWorkspace.shared.runningApplications.first(where: {$0.localizedName == name})!.processIdentifier
+let axApp = AXUIElementCreateApplication(pid)
+let result = AXUIElementSetAttributeValue(axApp, "AXManualAccessibility" as CFString, true as CFTypeRef)
+print("Setting 'AXManualAccessibility' \(error.rawValue == 0 ? "succeeded" : "failed")")
 ```
 
 [a11y-docs]: https://www.chromium.org/developers/design-documents/accessibility#TOC-How-Chrome-detects-the-presence-of-Assistive-Technology


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/38102

Notes: Fixed an perceived failure when when using Accessibility attribute `AXManualAccessibility` to enable a11y features in Electron.