### PR TITLE
Clear all USB protected classes

### DIFF
--- a/shell/browser/usb/electron_usb_delegate.cc
+++ b/shell/browser/usb/electron_usb_delegate.cc
@@ -152,37 +152,7 @@ void ElectronUsbDelegate::AdjustProtectedInterfaceClasses(
     const url::Origin& origin,
     content::RenderFrameHost* frame,
     std::vector<uint8_t>& classes) {
-  // Isolated Apps have unrestricted access to any USB interface class.
-  if (frame &&
-      frame->GetWebExposedIsolationLevel() >=
-          content::WebExposedIsolationLevel::kMaybeIsolatedApplication) {
-    // TODO(https://crbug.com/1236706): Should the list of interface classes the
-    // app expects to claim be encoded in the Web App Manifest?
-    classes.clear();
-    return;
-  }
-
-#if BUILDFLAG(ENABLE_EXTENSIONS)
-  // Don't enforce protected interface classes for Chrome Apps since the
-  // chrome.usb API has no such restriction.
-  if (origin.scheme() == extensions::kExtensionScheme) {
-    auto* extension_registry =
-        extensions::ExtensionRegistry::Get(browser_context);
-    if (extension_registry) {
-      const extensions::Extension* extension =
-          extension_registry->enabled_extensions().GetByID(origin.host());
-      if (extension && extension->is_platform_app()) {
-        classes.clear();
-        return;
-      }
-    }
-  }
-
-  if (origin.scheme() == extensions::kExtensionScheme &&
-      base::Contains(kSmartCardPrivilegedExtensionIds, origin.host())) {
-    base::Erase(classes, device::mojom::kUsbSmartCardClass);
-  }
-#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+  classes.clear();
 }
 
 std::unique_ptr<UsbChooser> ElectronUsbDelegate::RunChooser(


### PR DESCRIPTION
#### Description of Change

Allow all access to all USB devices.

https://github.com/electron/electron/issues/14545#issuecomment-1532269807


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
