### PR TITLE
feat: support Mica/Acrylic on Windows

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1557,6 +1557,19 @@ will remove the vibrancy effect on the window.
 Note that `appearance-based`, `light`, `dark`, `medium-light`, and `ultra-dark` have been
 deprecated and will be removed in an upcoming version of macOS.
 
+#### `win.setBackgroundMaterial(material)` _Windows_
+
+* `material` string
+  * `auto` - Let the Desktop Window Manager (DWM) automatically decide the system-drawn backdrop material for this window. This is the default.
+  * `none` - Don't draw any system backdrop.
+  * `mica` - Draw the backdrop material effect corresponding to a long-lived window.
+  * `acrylic` - Draw the backdrop material effect corresponding to a transient window.
+  * `tabbed` - Draw the backdrop material effect corresponding to a window with a tabbed title bar.
+
+This method sets the browser window's system-drawn background material, including behind the non-client area.
+
+See the [Windows documentation](https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwm_systembackdrop_type) for more details.
+
 #### `win.setWindowButtonPosition(position)` _macOS_
 
 * `position` [Point](structures/point.md) | null

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1570,6 +1570,8 @@ This method sets the browser window's system-drawn background material, includin
 
 See the [Windows documentation](https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwm_systembackdrop_type) for more details.
 
+**Note:** This method is only supported on Windows 11 22H2 and up.
+
 #### `win.setWindowButtonPosition(position)` _macOS_
 
 * `position` [Point](structures/point.md) | null

--- a/docs/api/structures/browser-window-options.md
+++ b/docs/api/structures/browser-window-options.md
@@ -110,6 +110,9 @@
   `tooltip`, `content`, `under-window`, or `under-page`. Please note that
   `appearance-based`, `light`, `dark`, `medium-light`, and `ultra-dark` are
   deprecated and have been removed in macOS Catalina (10.15).
+* `backgroundMaterial` string (optional) _Windows_ - Set the window's
+  system-drawn background material, including behind the non-client area.
+  Can be `auto`, `none`, `mica`, `acrylic` or `tabbed`. See [win.setBackgroundMaterial](../browser-window.md#winsetbackgroundmaterialmaterial-windows) for more information.
 * `zoomToPageWidth` boolean (optional) _macOS_ - Controls the behavior on
   macOS when option-clicking the green stoplight button on the toolbar or by
   clicking the Window > Zoom menu item. If `true`, the window will grow to

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -864,6 +864,12 @@ void BaseWindow::SetVibrancy(v8::Isolate* isolate, v8::Local<v8::Value> value) {
   window_->SetVibrancy(type);
 }
 
+void BaseWindow::SetBackgroundMaterial(v8::Isolate* isolate,
+                                       v8::Local<v8::Value> value) {
+  std::string type = gin::V8ToString(isolate, value);
+  window_->SetBackgroundMaterial(type);
+}
+
 #if BUILDFLAG(IS_MAC)
 std::string BaseWindow::GetAlwaysOnTopLevel() {
   return window_->GetAlwaysOnTopLevel();
@@ -1267,6 +1273,7 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setAutoHideCursor", &BaseWindow::SetAutoHideCursor)
 #endif
       .SetMethod("setVibrancy", &BaseWindow::SetVibrancy)
+      .SetMethod("setBackgroundMaterial", &BaseWindow::SetBackgroundMaterial)
 
 #if BUILDFLAG(IS_MAC)
       .SetMethod("isHiddenInMissionControl",

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -864,10 +864,8 @@ void BaseWindow::SetVibrancy(v8::Isolate* isolate, v8::Local<v8::Value> value) {
   window_->SetVibrancy(type);
 }
 
-void BaseWindow::SetBackgroundMaterial(v8::Isolate* isolate,
-                                       v8::Local<v8::Value> value) {
-  std::string type = gin::V8ToString(isolate, value);
-  window_->SetBackgroundMaterial(type);
+void BaseWindow::SetBackgroundMaterial(const std::string& material_type) {
+  window_->SetBackgroundMaterial(material_type);
 }
 
 #if BUILDFLAG(IS_MAC)

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -190,6 +190,8 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   bool IsVisibleOnAllWorkspaces();
   void SetAutoHideCursor(bool auto_hide);
   virtual void SetVibrancy(v8::Isolate* isolate, v8::Local<v8::Value> value);
+  virtual void SetBackgroundMaterial(v8::Isolate* isolate,
+                                     v8::Local<v8::Value> value);
 
 #if BUILDFLAG(IS_MAC)
   std::string GetAlwaysOnTopLevel();

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -190,8 +190,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   bool IsVisibleOnAllWorkspaces();
   void SetAutoHideCursor(bool auto_hide);
   virtual void SetVibrancy(v8::Isolate* isolate, v8::Local<v8::Value> value);
-  virtual void SetBackgroundMaterial(v8::Isolate* isolate,
-                                     v8::Local<v8::Value> value);
+  void SetBackgroundMaterial(const std::string& vibrancy);
 
 #if BUILDFLAG(IS_MAC)
   std::string GetAlwaysOnTopLevel();

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -249,6 +249,11 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
   if (options.Get(options::kVibrancyType, &type)) {
     SetVibrancy(type);
   }
+#elif BUILDFLAG(IS_WIN)
+  std::string material;
+  if (options.Get(options::kBackgroundMaterial, &material)) {
+    SetBackgroundMaterial(material);
+  }
 #endif
   std::string color;
   if (options.Get(options::kBackgroundColor, &color)) {
@@ -444,6 +449,8 @@ bool NativeWindow::AddTabbedWindow(NativeWindow* window) {
 }
 
 void NativeWindow::SetVibrancy(const std::string& type) {}
+
+void NativeWindow::SetBackgroundMaterial(const std::string& type) {}
 
 void NativeWindow::SetTouchBar(
     std::vector<gin_helper::PersistentDictionary> items) {}

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -215,6 +215,8 @@ class NativeWindow : public base::SupportsUserData,
   // Vibrancy API
   virtual void SetVibrancy(const std::string& type);
 
+  virtual void SetBackgroundMaterial(const std::string& type);
+
   // Traffic Light API
 #if BUILDFLAG(IS_MAC)
   virtual void SetWindowButtonVisibility(bool visible) = 0;

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -137,6 +137,7 @@ class NativeWindowViews : public NativeWindow,
   bool IsMenuBarAutoHide() override;
   void SetMenuBarVisibility(bool visible) override;
   bool IsMenuBarVisible() override;
+  void SetBackgroundMaterial(const std::string& type) override;
 
   void SetVisibleOnAllWorkspaces(bool visible,
                                  bool visibleOnFullScreen,

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -110,6 +110,9 @@ const char kWebPreferences[] = "webPreferences";
 // Add a vibrancy effect to the browser window
 const char kVibrancyType[] = "vibrancy";
 
+// Add a vibrancy effect to the browser window.
+const char kBackgroundMaterial[] = "backgroundMaterial";
+
 // Specify how the material appearance should reflect window activity state on
 // macOS.
 const char kVisualEffectState[] = "visualEffectState";

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -55,6 +55,7 @@ extern const char kOpacity[];
 extern const char kFocusable[];
 extern const char kWebPreferences[];
 extern const char kVibrancyType[];
+extern const char kBackgroundMaterial[];
 extern const char kVisualEffectState[];
 extern const char kTrafficLightPosition[];
 extern const char kRoundedCorners[];


### PR DESCRIPTION
#### Description of Change

Supersedes https://github.com/electron/electron/pull/30298.

Closes https://github.com/electron/electron/issues/16391.
Closes https://github.com/electron/electron/issues/29937.

Adds support for background material effects on Windows with `win.setBackgroundMaterial(material)`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Add support for Mica and Acrylic background effects on Windows.