### PR TITLE
fix: printing crash when settings invalid

### DIFF
--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -617,7 +617,7 @@ index 82f44b6c90f292772b56253a99578394b5cc2881..91ee0c3d66c33adee346060a0ecd931d
    // Tells the browser printing failed.
    PrintingFailed(int32 cookie, PrintFailureReason reason);
 diff --git a/components/printing/renderer/print_render_frame_helper.cc b/components/printing/renderer/print_render_frame_helper.cc
-index f1e72946e69e8e12d0436366587648b683d9f4f8..2c7db9c160ac200a2abf671c9b01a24acba4207a 100644
+index f1e72946e69e8e12d0436366587648b683d9f4f8..205598b3b14d72dc97bf664143a97073677fe52b 100644
 --- a/components/printing/renderer/print_render_frame_helper.cc
 +++ b/components/printing/renderer/print_render_frame_helper.cc
 @@ -45,6 +45,7 @@
@@ -748,7 +748,7 @@ index f1e72946e69e8e12d0436366587648b683d9f4f8..2c7db9c160ac200a2abf671c9b01a24a
    // Check if the printer returned any settings, if the settings are null,
    // assume there are no printer drivers configured. So safely terminate.
 -  if (!settings.params) {
-+  if (!settings->params) {
++  if (!settings || !settings->params) {
      // Caller will reset `print_pages_params_`.
      return false;
    }


### PR DESCRIPTION
#### Description of Change

Fixes the following potential crash:

<details><summary>Stacktrace</summary>

```sh
[18342:0503/150402.720320:FATAL:struct_ptr.h(85)] Check failed: ptr_. 
0   Electron Framework                  0x000000011a5d6ae4 base::debug::CollectStackTrace(void**, unsigned long) + 28
1   Electron Framework                  0x000000011a5c6c7c base::debug::StackTrace::StackTrace() + 24
2   Electron Framework                  0x000000011a50f158 logging::LogMessage::~LogMessage() + 156
3   Electron Framework                  0x000000011a4fb45c logging::(anonymous namespace)::DCheckLogMessage::~DCheckLogMessage() + 60
4   Electron Framework                  0x000000011a4fb13c logging::CheckError::~CheckError() + 40
5   Electron Framework                  0x000000011a4fb16c logging::CheckError::~CheckError() + 12
6   Electron Framework                  0x000000011ee5c508 printing::PrintRenderFrameHelper::InitPrintSettings(bool, base::Value::Dict) + 412
7   Electron Framework                  0x000000011ee5acd4 printing::PrintRenderFrameHelper::CalculateNumberOfPages(blink::WebLocalFrame*, blink::WebNode const&, unsigned int*, base::Value::Dict) + 144
8   Electron Framework                  0x000000011ee54108 printing::PrintRenderFrameHelper::Print(blink::WebLocalFrame*, blink::WebNode const&, printing::PrintRenderFrameHelper::PrintRequestType, bool, base::Value::Dict) + 196
9   Electron Framework                  0x000000011ee54784 printing::PrintRenderFrameHelper::PrintRequestedPages(bool, base::Value::Dict) + 244
10  Electron Framework                  0x0000000119ecaa50 printing::mojom::PrintRenderFrameStubDispatch::Accept(printing::mojom::PrintRenderFrame*, mojo::Message*) + 268
11  Electron Framework                  0x000000011a8f6c80 mojo::InterfaceEndpointClient::HandleValidatedMessage(mojo::Message*) + 1200
12  Electron Framework                  0x000000011a8fcbc4 mojo::MessageDispatcher::Accept(mojo::Message*) + 148
13  Electron Framework                  0x000000011a8f8758 mojo::InterfaceEndpointClient::HandleIncomingMessage(mojo::Message*) + 100
14  Electron Framework                  0x000000011acee52c IPC::(anonymous namespace)::ChannelAssociatedGroupController::AcceptOnEndpointThread(mojo::Message) + 480
15  Electron Framework                  0x000000011a8faa00 base::internal::Invoker<base::internal::BindState<void (mojo::(anonymous namespace)::ThreadSafeInterfaceEndpointClientProxy::*)(mojo::Message), scoped_refptr<mojo::(anonymous namespace)::ThreadSafeInterfaceEndpointClientProxy>, mojo::Message>, void ()>::RunOnce(base::internal::BindStateBase*) + 84
16  Electron Framework                  0x000000011a55d814 base::TaskAnnotator::RunTaskImpl(base::PendingTask&) + 244
17  Electron Framework                  0x000000011a58491c base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*) + 1164
18  Electron Framework                  0x000000011a583f4c base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() + 104
19  Electron Framework                  0x000000011a5171e4 base::MessagePumpDefault::Run(base::MessagePump::Delegate*) + 152
20  Electron Framework                  0x000000011a58575c base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) + 452
21  Electron Framework                  0x000000011a53d3d8 base::RunLoop::Run(base::Location const&) + 424
22  Electron Framework                  0x000000011eba94c0 content::RendererMain(content::MainFunctionParams) + 1456
23  Electron Framework                  0x0000000116352980 content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char, std::Cr::char_traits<char>, std::Cr::allocator<char>> const&, content::MainFunctionParams, content::ContentMainDelegate*) + 716
24  Electron Framework                  0x0000000116353738 content::ContentMainRunnerImpl::Run() + 764
25  Electron Framework                  0x0000000116351d10 content::RunContentProcess(content::ContentMainParams, content::ContentMainRunner*) + 1380
26  Electron Framework                  0x0000000116351f28 content::ContentMain(content::ContentMainParams) + 112
27  Electron Framework                  0x0000000116012d48 ElectronMain + 128
28  Electron Helper (Renderer)          0x0000000100fd8a00 main + 224
29  dyld                                0x00000001a5567f28 start + 2236
Task trace:
0   Electron Framework                  0x000000011acea458 IPC::(anonymous namespace)::ChannelAssociatedGroupController::Accept(mojo::Message*) + 820
Crash keys:
  "blink_scheduler_async_stack" = "0x11ACEA458 0x0"
  "renderer_foreground" = "false"
  "v8_ro_space_firstpage_address" = "0x348f00000000"
  "v8_isolate_address" = "0x148008000"
  "num-experiments" = "0"
  "platform" = "darwin"
  "process_type" = "renderer"
  "osarch" = "arm64"
  "pid" = "18342"
  "ptype" = "renderer"
Renderer process crashed - see https://www.electronjs.org/docs/tutorial/application-debugging for potential debugging information.
```

</details>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash when calling `webContents.print` with invalid settings.
