### PR TITLE
test: use `await` to call "closeWindow"

### DIFF
--- a/spec/api-web-contents-view-spec.ts
+++ b/spec/api-web-contents-view-spec.ts
@@ -4,7 +4,11 @@ import { BaseWindow, WebContentsView } from 'electron/main';
 
 describe('WebContentsView', () => {
   let w: BaseWindow;
-  afterEach(() => closeWindow(w as any).then(() => { w = null as unknown as BaseWindow; }));
+
+  afterEach(async () => {
+    await closeWindow(w as any);
+    w = null as unknown as BaseWindow;
+  });
 
   it('can be used as content view', () => {
     w = new BaseWindow({ show: false });

--- a/spec/extensions-spec.ts
+++ b/spec/extensions-spec.ts
@@ -559,9 +559,10 @@ describe('chrome extensions', () => {
             });
           });
 
-          afterEach(() => {
+          afterEach(async () => {
             removeAllExtensions();
-            return closeWindow(w).then(() => { w = null as unknown as BrowserWindow; });
+            await closeWindow(w);
+            w = null as unknown as BrowserWindow;
           });
 
           it('should run content script at document_start', async () => {


### PR DESCRIPTION
#### Description of Change

Nothing is broken, but this way it is a bit more readable.
Also, in all other places that's how `closeWindow` is called now.


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
