### PR TITLE
test: enable CircleCI's "re-run failed tests only" feature

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1504,9 +1504,9 @@ commands:
             if [ "$IS_ASAN" == "1" ]; then
               ASAN_SYMBOLIZE="$PWD/tools/valgrind/asan/asan_symbolize.py --executable-path=$PWD/out/Default/electron"
               echo "Piping output to ASAN_SYMBOLIZE ($ASAN_SYMBOLIZE)"
-              circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings --verbose 2>&1 | $ASAN_SYMBOLIZE
+              echo $TEST_FILES | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings --verbose 2>&1 | $ASAN_SYMBOLIZE
             else
-              circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings --verbose
+              echo $TEST_FILES | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings --verbose
             fi
       - run:
           name: Check test results existence

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1484,29 +1484,25 @@ commands:
           command: |
             cd src
             if [ "$IS_ASAN" == "1" ]; then
+              ASAN_SYMBOLIZE="$PWD/tools/valgrind/asan/asan_symbolize.py --executable-path=$PWD/out/Default/electron"
               export ASAN_OPTIONS="symbolize=0 handle_abort=1"
               export G_SLICE=always-malloc
               export NSS_DISABLE_ARENA_FREE_LIST=1
               export NSS_DISABLE_UNLOAD=1
               export LLVM_SYMBOLIZER_PATH=$PWD/third_party/llvm-build/Release+Asserts/bin/llvm-symbolizer
               export MOCHA_TIMEOUT=180000
+              echo "Piping output to ASAN_SYMBOLIZE ($ASAN_SYMBOLIZE)"
+              (cd electron && (circleci tests glob "spec/*-spec.ts" | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings --verbose 2>&1)) | $ASAN_SYMBOLIZE
             else
               if [ "$TARGET_ARCH" == "arm" ] || [ "$TARGET_ARCH" == "arm64" ]; then
                 export ELECTRON_SKIP_NATIVE_MODULE_TESTS=true
+                (cd electron && node script/yarn test --runners=main --trace-uncaught --enable-logging)
               else
                 if [ "$TARGET_ARCH" == "ia32" ]; then
                   npm_config_arch=x64 node electron/node_modules/dugite/script/download-git.js
                 fi
+                (cd electron && (circleci tests glob "spec/*-spec.ts" | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings --verbose))
               fi
-            fi
-            cd electron
-            TEST_FILES=$(circleci tests glob "spec/*-spec.ts")
-            if [ "$IS_ASAN" == "1" ]; then
-              ASAN_SYMBOLIZE="$PWD/tools/valgrind/asan/asan_symbolize.py --executable-path=$PWD/out/Default/electron"
-              echo "Piping output to ASAN_SYMBOLIZE ($ASAN_SYMBOLIZE)"
-              echo $TEST_FILES | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings --verbose 2>&1 | $ASAN_SYMBOLIZE
-            else
-              echo $TEST_FILES | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings --verbose
             fi
       - run:
           name: Check test results existence

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1492,7 +1492,7 @@ commands:
               export LLVM_SYMBOLIZER_PATH=$PWD/third_party/llvm-build/Release+Asserts/bin/llvm-symbolizer
               export MOCHA_TIMEOUT=180000
               echo "Piping output to ASAN_SYMBOLIZE ($ASAN_SYMBOLIZE)"
-              (cd electron && (circleci tests glob "spec/*-spec.ts" | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings --verbose 2>&1)) | $ASAN_SYMBOLIZE
+              (cd electron && (circleci tests glob "spec/*-spec.ts" | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings 2>&1)) | $ASAN_SYMBOLIZE
             else
               if [ "$TARGET_ARCH" == "arm" ] || [ "$TARGET_ARCH" == "arm64" ]; then
                 export ELECTRON_SKIP_NATIVE_MODULE_TESTS=true
@@ -1501,7 +1501,7 @@ commands:
                 if [ "$TARGET_ARCH" == "ia32" ]; then
                   npm_config_arch=x64 node electron/node_modules/dugite/script/download-git.js
                 fi
-                (cd electron && (circleci tests glob "spec/*-spec.ts" | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings --verbose))
+                (cd electron && (circleci tests glob "spec/*-spec.ts" | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings))
               fi
             fi
       - store_test_results:

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1504,15 +1504,6 @@ commands:
                 (cd electron && (circleci tests glob "spec/*-spec.ts" | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings --verbose))
               fi
             fi
-      - run:
-          name: Check test results existence
-          command: |
-            cd src
-
-            # Check if test results exist and are not empty.
-            if [ ! -s "junit/test-results-main.xml" ]; then
-              exit 1
-            fi
       - store_test_results:
           path: src/junit
 

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -452,7 +452,7 @@ step-get-more-space-on-mac: &step-get-more-space-on-mac
       fi
     background: true
 
-# On macOS delete all .git directories under src/ expect for
+# On macOS delete all .git directories under src/ except for
 # third_party/angle/ and third_party/dawn/ because of build time generation of files
 # gen/angle/commit.h depends on third_party/angle/.git/HEAD
 # https://chromium-review.googlesource.com/c/angle/angle/+/2074924
@@ -1484,25 +1484,29 @@ commands:
           command: |
             cd src
             if [ "$IS_ASAN" == "1" ]; then
-              ASAN_SYMBOLIZE="$PWD/tools/valgrind/asan/asan_symbolize.py --executable-path=$PWD/out/Default/electron"
               export ASAN_OPTIONS="symbolize=0 handle_abort=1"
               export G_SLICE=always-malloc
               export NSS_DISABLE_ARENA_FREE_LIST=1
               export NSS_DISABLE_UNLOAD=1
               export LLVM_SYMBOLIZER_PATH=$PWD/third_party/llvm-build/Release+Asserts/bin/llvm-symbolizer
               export MOCHA_TIMEOUT=180000
-              echo "Piping output to ASAN_SYMBOLIZE ($ASAN_SYMBOLIZE)"
-              (cd electron && node script/yarn test --runners=main --trace-uncaught --enable-logging --files $(circleci tests glob spec/*-spec.ts | circleci tests split --split-by=timings)) 2>&1 | $ASAN_SYMBOLIZE
             else
               if [ "$TARGET_ARCH" == "arm" ] || [ "$TARGET_ARCH" == "arm64" ]; then
                 export ELECTRON_SKIP_NATIVE_MODULE_TESTS=true
-                (cd electron && node script/yarn test --runners=main --trace-uncaught --enable-logging)
               else
                 if [ "$TARGET_ARCH" == "ia32" ]; then
                   npm_config_arch=x64 node electron/node_modules/dugite/script/download-git.js
                 fi
-                (cd electron && node script/yarn test --runners=main --trace-uncaught --enable-logging --files $(circleci tests glob spec/*-spec.ts | circleci tests split --split-by=timings))
               fi
+            fi
+            cd electron
+            TEST_FILES=$(circleci tests glob "spec/*-spec.ts")
+            if [ "$IS_ASAN" == "1" ]; then
+              ASAN_SYMBOLIZE="$PWD/tools/valgrind/asan/asan_symbolize.py --executable-path=$PWD/out/Default/electron"
+              echo "Piping output to ASAN_SYMBOLIZE ($ASAN_SYMBOLIZE)"
+              circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings --verbose 2>&1 | $ASAN_SYMBOLIZE
+            else
+              circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings --verbose
             fi
       - run:
           name: Check test results existence

--- a/spec/crash-spec.ts
+++ b/spec/crash-spec.ts
@@ -72,3 +72,9 @@ describe('crash cases', () => {
     });
   }
 });
+
+describe('testing circleci config change', () => {
+  it('fails', () => {
+    expect(true).to.be.false();
+  });
+});

--- a/spec/crash-spec.ts
+++ b/spec/crash-spec.ts
@@ -72,9 +72,3 @@ describe('crash cases', () => {
     });
   }
 });
-
-describe('testing circleci config change', () => {
-  it('fails', () => {
-    expect(true).to.be.false();
-  });
-});

--- a/spec/index.js
+++ b/spec/index.js
@@ -138,7 +138,12 @@ app.whenReady().then(async () => {
   testFiles.sort().forEach((file) => {
     mocha.addFile(file);
   });
-  console.log('Test files: ', testFiles);
+
+  if (validTestPaths.length > 0 && testFiles.length === 0) {
+    console.error('Test files were provided, but they did not match any searched files');
+    console.error('provided file paths (relative to electron/):', validTestPaths);
+    process.exit(1);
+  }
 
   const cb = () => {
     // Ensure the callback is called after runner is defined

--- a/spec/index.js
+++ b/spec/index.js
@@ -134,6 +134,7 @@ app.whenReady().then(async () => {
   testFiles.sort().forEach((file) => {
     mocha.addFile(file);
   });
+  console.log('Test files: ', testFiles);
 
   const cb = () => {
     // Ensure the callback is called after runner is defined

--- a/spec/index.js
+++ b/spec/index.js
@@ -107,6 +107,8 @@ app.whenReady().then(async () => {
   if (argv.grep) mocha.grep(argv.grep);
   if (argv.invert) mocha.invert();
 
+  const baseElectronDir = path.resolve(__dirname, '..');
+  const validTestPaths = argv.files && argv.files.map(file => path.relative(baseElectronDir, file));
   const filter = (file) => {
     if (!/-spec\.[tj]s$/.test(file)) {
       return false;
@@ -121,8 +123,7 @@ app.whenReady().then(async () => {
       return false;
     }
 
-    const baseElectronDir = path.resolve(__dirname, '..');
-    if (argv.files && !argv.files.includes(path.relative(baseElectronDir, file))) {
+    if (validTestPaths && !validTestPaths.includes(path.relative(baseElectronDir, file))) {
       return false;
     }
 

--- a/spec/index.js
+++ b/spec/index.js
@@ -108,7 +108,10 @@ app.whenReady().then(async () => {
   if (argv.invert) mocha.invert();
 
   const baseElectronDir = path.resolve(__dirname, '..');
-  const validTestPaths = argv.files && argv.files.map(file => path.relative(baseElectronDir, file));
+  const validTestPaths = argv.files && argv.files.map(file =>
+    path.isAbsolute(file)
+      ? path.relative(baseElectronDir, file)
+      : file);
   const filter = (file) => {
     if (!/-spec\.[tj]s$/.test(file)) {
       return false;

--- a/spec/index.js
+++ b/spec/index.js
@@ -139,7 +139,7 @@ app.whenReady().then(async () => {
     mocha.addFile(file);
   });
 
-  if (validTestPaths.length > 0 && testFiles.length === 0) {
+  if (validTestPaths && validTestPaths.length > 0 && testFiles.length === 0) {
     console.error('Test files were provided, but they did not match any searched files');
     console.error('provided file paths (relative to electron/):', validTestPaths);
     process.exit(1);


### PR DESCRIPTION
#### Description of Change

We've been granted early access to the preview of [CircleCI's "re-run failed tests only" feature](https://circleci.com/docs/rerun-failed-tests-only/). This PR updates our test suite runner and CircleCI config to enable this feature to work.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes

Notes: none
