### PR TITLE
chore: fix TrustedTypes policy in `chrome://accessibility`

### DIFF
--- a/shell/browser/ui/webui/accessibility_ui.cc
+++ b/shell/browser/ui/webui/accessibility_ui.cc
@@ -321,6 +321,10 @@ ElectronAccessibilityUI::ElectronAccessibilityUI(content::WebUI* web_ui)
       base::BindRepeating(&HandleAccessibilityRequestCallback,
                           web_ui->GetWebContents()->GetBrowserContext()));
 
+  html_source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::TrustedTypes,
+      "trusted-types parse-html-subset sanitize-inner-html;");
+
   web_ui->AddMessageHandler(
       std::make_unique<ElectronAccessibilityUIMessageHandler>());
 }


### PR DESCRIPTION
#### Description of Change

Refs CL:4219030

Fixes the following error seen when loading `chrome://accessibility`, which prevented the Top Level Windows section from populating:

```
[59750:0504/101326.049599:ERROR:CONSOLE(27)] "Refused to create a TrustedTypePolicy named 'sanitize-inner-html' because it violates the following Content Security Policy directive: "trusted-types ".", source: chrome://resources/js/parse_html_subset.js (27)
[59750:0504/101326.049984:ERROR:CONSOLE(27)] "Uncaught TypeError: Failed to execute 'createPolicy' on 'TrustedTypePolicyFactory': Policy "sanitize-inner-html" disallowed.", source: chrome://resources/js/parse_html_subset.js (27)
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an error seen in the Top Level Windows section of `chrome://accessibility`.
