### PR TITLE
ci: do conditional in blocked/need-repro workflows at job level

### DIFF
--- a/.github/workflows/issue-commented.yml
+++ b/.github/workflows/issue-commented.yml
@@ -10,12 +10,13 @@ permissions:
 
 jobs:
   issue-commented:
+    name: Remove blocked/need-repro on comment
+    if: ${{ contains(github.event.issue.labels.*.name, 'blocked/need-repro') && !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association) }}
     permissions:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - name: Remove blocked/need-repro on comment
-        if: ${{ contains(github.event.issue.labels.*.name, 'blocked/need-repro') && !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association) }}
+      - name: Remove label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_URL: ${{ github.event.issue.html_url }}

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -9,12 +9,13 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 
 jobs:
   issue-labeled:
+    name: blocked/need-repro label added
+    if: github.event.label.name == 'blocked/need-repro'
     permissions:
       issues: write  # for actions-cool/issues-helper to update issues
     runs-on: ubuntu-latest
     steps:
-      - name: blocked/need-repro label added
-        if: github.event.label.name == 'blocked/need-repro'
+      - name: Create comment
         uses: actions-cool/issues-helper@dad28fdb88da5f082c04659b7373d85790f9b135 # v3.3.0
         with:
           actions: 'create-comment'


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

This should drop GHA usage of these workflows significantly since the jobs won't need to be started if the conditional is false. Also improves the UX since the workflow runs will show which were skipped without needing to click into each run.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
