### PR TITLE
docs: fix typing of session.setDevicePermissionHandler

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -1024,7 +1024,7 @@ Passing `null` instead of a function resets the handler to its default state.
   * `details` Object
     * `deviceType` string - The type of device that permission is being requested on, can be `hid`, `serial`, or `usb`.
     * `origin` string - The origin URL of the device permission check.
-    * `device` [HIDDevice](structures/hid-device.md) | [SerialPort](structures/serial-port.md)- the device that permission is being requested for.
+    * `device` [HIDDevice](structures/hid-device.md) | [SerialPort](structures/serial-port.md) | [USBDevice](structures/usb-device.md) - the device that permission is being requested for.
 
 Sets the handler which can be used to respond to device permission checks for the `session`.
 Returning `true` will allow the device to be permitted and `false` will reject it.

--- a/docs/tutorial/devices.md
+++ b/docs/tutorial/devices.md
@@ -129,7 +129,7 @@ Electron provides several APIs for working with the WebUSB API:
   when handling the `select-usb-device` event.
   **Note:** These two events only fire until the callback from `select-usb-device`
   is called.  They are not intended to be used as a generic usb device listener.
-* The [`usb-device-revoked' event on the Session](../api/session.md#event-usb-device-revoked) can
+* The [`usb-device-revoked` event on the Session](../api/session.md#event-usb-device-revoked) can
   be used to respond when [device.forget()](https://developer.chrome.com/articles/usb/#revoke-access)
   is called on a USB device.
 * [`ses.setDevicePermissionHandler(handler)`](../api/session.md#sessetdevicepermissionhandlerhandler)


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

`USBDevice` was missing as a possible type for `device`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
