### PR TITLE
test: disable flaky asar worker test on ASan build

### DIFF
--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -4,7 +4,7 @@ import * as url from 'url';
 import { Worker } from 'worker_threads';
 import { BrowserWindow, ipcMain } from 'electron/main';
 import { closeAllWindows } from './lib/window-helpers';
-import { getRemoteContext, ifdescribe, itremote, useRemoteContext } from './lib/spec-helpers';
+import { getRemoteContext, ifdescribe, ifit, itremote, useRemoteContext } from './lib/spec-helpers';
 import * as importedFs from 'fs';
 import { once } from 'events';
 
@@ -115,7 +115,8 @@ describe('asar package', () => {
   });
 
   describe('worker threads', function () {
-    it('should start worker thread from asar file', function (callback) {
+    // DISABLED-FIXME(#38192): only disabled for ASan.
+    ifit(!process.env.IS_ASAN)('should start worker thread from asar file', function (callback) {
       const p = path.join(asarDir, 'worker_threads.asar', 'worker.js');
       const w = new Worker(p);
 


### PR DESCRIPTION
#### Description of Change

See #38192:

> This test seems to flake only on ASan builds. The DCHECK below seems to obscure any information the `v8::internal::Isolate::StackOverflow()` method would normally expose.
>
> There's no information in the failed test output that points specifically to this test, however this is always the test that should be running when the crash occurs, so I'm identifying this test as the source of the flake.

#### Release Notes

Notes: none
