### PR TITLE
build: force LF checkout of more files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,12 +4,27 @@
 patches/**/.patches merge=union
 
 # Source code and markdown files should always use LF as line ending.
+*.c text eol=lf
 *.cc text eol=lf
-*.mm text eol=lf
+*.cpp text eol=lf
+*.csv text eol=lf
+*.grd   text eol=lf
+*.grdp   text eol=lf
+*.gn text eol=lf
+*.gni text eol=lf
 *.h text eol=lf
-*.js text eol=lf
-*.ts text eol=lf
+*.html   text eol=lf
+*.idl text eol=lf
+*.in   text eol=lf
+*.js   text eol=lf
+*.json   text eol=lf
+*.json5 text eol=lf
+*.md text eol=lf
+*.mm text eol=lf
+*.mojom text eol=lf
+*.proto text eol=lf
 *.py text eol=lf
 *.ps1 text eol=lf
-*.html text eol=lf
-*.md text eol=lf
+*.sh text eol=lf
+*.ts text eol=lf
+*.txt   text eol=lf


### PR DESCRIPTION
#### Description of Change

Ran into an issue with this today in an `.idl` file. Update our `.gitattributes` file to more closely match [Chromium's](https://source.chromium.org/chromium/chromium/src/+/main:.gitattributes)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none