### PR TITLE
build: add pretest script to create TS definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "preinstall": "node -e 'process.exit(0)'",
     "prepack": "check-for-leaks",
     "prepare": "husky install",
+    "pretest": "npm run create-typescript-definitions",
     "repl": "node ./script/start.js --interactive",
     "start": "node ./script/start.js",
     "test": "node ./script/spec-runner.js",


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

To better support running tests without doing a build. A build generates `electron.d.ts` via the `gn-typescript-definitions` script.  Running the `create-typescript-definitions` in `pretest` should ensure the TS definitions exist and are up-to-date when switching branches.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
