### PR TITLE
feat: add missing 'cursor-changed' type values

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -736,14 +736,16 @@ Returns:
 * `size` [Size](structures/size.md) (optional) - the size of the `image`.
 * `hotspot` [Point](structures/point.md) (optional) - coordinates of the custom cursor's hotspot.
 
-Emitted when the cursor's type changes. The `type` parameter can be `default`,
-`crosshair`, `pointer`, `text`, `wait`, `help`, `e-resize`, `n-resize`,
-`ne-resize`, `nw-resize`, `s-resize`, `se-resize`, `sw-resize`, `w-resize`,
-`ns-resize`, `ew-resize`, `nesw-resize`, `nwse-resize`, `col-resize`,
-`row-resize`, `m-panning`, `e-panning`, `n-panning`, `ne-panning`, `nw-panning`,
-`s-panning`, `se-panning`, `sw-panning`, `w-panning`, `move`, `vertical-text`,
-`cell`, `context-menu`, `alias`, `progress`, `nodrop`, `copy`, `none`,
-`not-allowed`, `zoom-in`, `zoom-out`, `grab`, `grabbing` or `custom`.
+Emitted when the cursor's type changes. The `type` parameter can be `pointer`,
+`crosshair`, `hand`, `text`, `wait`, `help`, `e-resize`, `n-resize`, `ne-resize`,
+`nw-resize`, `s-resize`, `se-resize`, `sw-resize`, `w-resize`, `ns-resize`, `ew-resize`,
+`nesw-resize`, `nwse-resize`, `col-resize`, `row-resize`, `m-panning`, `m-panning-vertical`,
+`m-panning-horizontal`, `e-panning`, `n-panning`, `ne-panning`, `nw-panning`, `s-panning`,
+`se-panning`, `sw-panning`, `w-panning`, `move`, `vertical-text`, `cell`, `context-menu`,
+`alias`, `progress`, `nodrop`, `copy`, `none`, `not-allowed`, `zoom-in`, `zoom-out`, `grab`,
+`grabbing`, `custom`, `null`, `drag-drop-none`, `drag-drop-move`, `drag-drop-copy`,
+`drag-drop-link`, `ns-no-resize`, `ew-no-resize`, `nesw-no-resize`, `nwse-no-resize`,
+or `default`.
 
 If the `type` parameter is `custom`, the `image` parameter will hold the custom
 cursor image in a [`NativeImage`](native-image.md), and `scale`, `size` and `hotspot` will hold

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -384,11 +384,11 @@ namespace {
 std::string CursorTypeToString(const ui::Cursor& cursor) {
   switch (cursor.type()) {
     case ui::mojom::CursorType::kPointer:
-      return "default";
+      return "pointer";
     case ui::mojom::CursorType::kCross:
       return "crosshair";
     case ui::mojom::CursorType::kHand:
-      return "pointer";
+      return "hand";
     case ui::mojom::CursorType::kIBeam:
       return "text";
     case ui::mojom::CursorType::kWait:
@@ -425,6 +425,10 @@ std::string CursorTypeToString(const ui::Cursor& cursor) {
       return "row-resize";
     case ui::mojom::CursorType::kMiddlePanning:
       return "m-panning";
+    case ui::mojom::CursorType::kMiddlePanningVertical:
+      return "m-panning-vertical";
+    case ui::mojom::CursorType::kMiddlePanningHorizontal:
+      return "m-panning-horizontal";
     case ui::mojom::CursorType::kEastPanning:
       return "e-panning";
     case ui::mojom::CursorType::kNorthPanning:
@@ -471,6 +475,24 @@ std::string CursorTypeToString(const ui::Cursor& cursor) {
       return "grabbing";
     case ui::mojom::CursorType::kCustom:
       return "custom";
+    case ui::mojom::CursorType::kNull:
+      return "null";
+    case ui::mojom::CursorType::kDndNone:
+      return "drag-drop-none";
+    case ui::mojom::CursorType::kDndMove:
+      return "drag-drop-move";
+    case ui::mojom::CursorType::kDndCopy:
+      return "drag-drop-copy";
+    case ui::mojom::CursorType::kDndLink:
+      return "drag-drop-link";
+    case ui::mojom::CursorType::kNorthSouthNoResize:
+      return "ns-no-resize";
+    case ui::mojom::CursorType::kEastWestNoResize:
+      return "ew-no-resize";
+    case ui::mojom::CursorType::kNorthEastSouthWestNoResize:
+      return "nesw-no-resize";
+    case ui::mojom::CursorType::kNorthWestSouthEastNoResize:
+      return "nwse-no-resize";
     default:
       return "default";
   }


### PR DESCRIPTION
#### Description of Change

Follow-up to https://github.com/electron/electron/pull/38183.

Adds missing cursor types and corrects a previous error.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added several new cursor values to the `cursor-changed` event.
