### PR TITLE
fix: `getNormalBounds()` for transparent windows on Windows

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -787,6 +787,10 @@ gfx::Size NativeWindowViews::GetContentSize() {
 }
 
 gfx::Rect NativeWindowViews::GetNormalBounds() {
+#if BUILDFLAG(IS_WIN)
+  if (IsMaximized() && transparent())
+    return restore_bounds_;
+#endif
   return widget()->GetRestoredBounds();
 }
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1720,6 +1720,23 @@ describe('BrowserWindow module', () => {
           expect(w.isFullScreen()).to.equal(true);
         });
 
+        it('checks normal bounds for maximized transparent window', async () => {
+          w.destroy();
+          w = new BrowserWindow({
+            transparent: true,
+            show: false
+          });
+          w.show();
+
+          const bounds = w.getNormalBounds();
+
+          const maximize = once(w, 'maximize');
+          w.maximize();
+          await maximize;
+
+          expectBoundsEqual(w.getNormalBounds(), bounds);
+        });
+
         it('does not change size for a frameless window with min size', async () => {
           w.destroy();
           w = new BrowserWindow({


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/38180.

Fixes an issue where `getNormalBounds()` returns incorrect bounds when a BrowserWindow is transparent and maximized. The underlying logic in widget doesn't account well for the transparent case - this is something we [already account for](https://github.com/electron/electron/blob/3ce35f224efa3a6e9bfc9b642816961b8691491b/shell/browser/native_window_views_win.cc#L190-L194) in [other areas](https://github.com/electron/electron/blob/eb0f47d377841d17f7880e42e23e7cd451d19fbe/shell/browser/native_window_views.cc#L617-L621). 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `getNormalBounds()` returns incorrect bounds for transparent maximized windows on Windows.
