### PR TITLE
fix: `win.isMaximized()` for transparent windows on Windows

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -656,7 +656,7 @@ bool NativeWindowViews::IsMaximized() {
     return true;
   } else {
 #if BUILDFLAG(IS_WIN)
-    if (transparent()) {
+    if (transparent() && !IsMinimized()) {
       // Compare the size of the window with the size of the display
       auto display = display::Screen::GetScreen()->GetDisplayNearestWindow(
           GetNativeWindow());

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6059,6 +6059,24 @@ describe('BrowserWindow module', () => {
   describe('"transparent" option', () => {
     afterEach(closeAllWindows);
 
+    ifit(process.platform !== 'linux')('correctly returns isMaximized() when the window is maximized then minimized', async () => {
+      const w = new BrowserWindow({
+        frame: false,
+        transparent: true
+      });
+
+      const maximize = once(w, 'maximize');
+      w.maximize();
+      await maximize;
+
+      const minimize = once(w, 'minimize');
+      w.minimize();
+      await minimize;
+
+      expect(w.isMaximized()).to.be.false();
+      expect(w.isMinimized()).to.be.true();
+    });
+
     // Only applicable on Windows where transparent windows can't be maximized.
     ifit(process.platform === 'win32')('can show maximized frameless window', async () => {
       const display = screen.getPrimaryDisplay();


### PR DESCRIPTION
#### Description of Change

Fixes an issue where calling `win.minimize()` directly after calling `win.maximize()`, and then calling `win.isMaximized()` incorrectly returns `true`.

This is happening because widget methods don't work as expected in several cases for transparent windows, and so we fall back to an approximation approach where we compare bounds. However, bounds when minimized match the screen area when minimized, so the resulting comparison can false positive to true. We should ensure it's not minimized before proceeding.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where calling `win.minimize()` directly after calling `win.maximize()`, and then calling `win.isMaximized()` incorrectly returns `true`.
