### PR TITLE
fix: enable `BrowserWindow.id` access post-destruction

### DIFF
--- a/lib/browser/api/browser-window.ts
+++ b/lib/browser/api/browser-window.ts
@@ -12,6 +12,14 @@ BrowserWindow.prototype._init = function (this: BWT) {
   // Avoid recursive require.
   const { app } = require('electron');
 
+  // Set ID at constructon time so it's accessible after
+  // underlying window destruction.
+  const id = this.id;
+  Object.defineProperty(this, 'id', {
+    value: id,
+    writable: false
+  });
+
   const nativeSetBounds = this.setBounds;
   this.setBounds = (bounds, ...opts) => {
     bounds = {

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -126,6 +126,13 @@ describe('BrowserWindow module', () => {
       w.webContents.on('destroyed', () => w.close());
     });
 
+    it('should allow access to id after destruction', async () => {
+      const closed = once(w, 'closed');
+      w.destroy();
+      await closed;
+      expect(w.id).to.be.a('number');
+    });
+
     it('should emit unload handler', async () => {
       await w.loadFile(path.join(fixtures, 'api', 'unload.html'));
       const closed = once(w, 'closed');


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/38170.

Enable access to `BrowserWindow.id` after the window has been destroyed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where accessing `BrowserWindow.id` threw an error after the window was destroyed.