### PR TITLE
fix: unify `BrowserWindow.isVisible()` logic cross-platform

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -667,7 +667,7 @@ Hides the window.
 
 #### `win.isVisible()`
 
-Returns `boolean` - Whether the window is visible to the user.
+Returns `boolean` - Whether the window is visible to the user in the foreground of the app.
 
 #### `win.isModal()`
 

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -491,10 +491,6 @@ void NativeWindowMac::Hide() {
 
 bool NativeWindowMac::IsVisible() {
   bool occluded = [window_ occlusionState] == NSWindowOcclusionStateVisible;
-
-  // For a window to be visible, it must be visible to the user in the
-  // foreground of the app, which means that it should not be minimized or
-  // occluded
   return [window_ isVisible] && !occluded && !IsMinimized();
 }
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -535,7 +535,17 @@ void NativeWindowViews::Hide() {
 }
 
 bool NativeWindowViews::IsVisible() {
+#if BUILDFLAG(IS_WIN)
+  // widget()->IsVisible() calls ::IsWindowVisible, which returns non-zero if a
+  // window or any of its parent windows are visible. We want to only check the
+  // current window.
+  bool visible =
+      ::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE) & WS_VISIBLE;
+  // WS_VISIBLE is true even if a window is miminized - explicitly check that.
+  return visible && !IsMinimized();
+#else
   return widget()->IsVisible();
+#endif
 }
 
 bool NativeWindowViews::IsEnabled() {

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1088,6 +1088,18 @@ describe('BrowserWindow module', () => {
       });
     });
 
+    describe('BrowserWindow.minimize()', () => {
+      // TODO(codebytere): Enable for Linux once maximize/minimize events work in CI.
+      ifit(process.platform !== 'linux')('should not be visible when the window is minimized', async () => {
+        const minimize = once(w, 'minimize');
+        w.minimize();
+        await minimize;
+
+        expect(w.isMinimized()).to.equal(true);
+        expect(w.isVisible()).to.equal(false);
+      });
+    });
+
     describe('BrowserWindow.showInactive()', () => {
       it('should not focus on window', () => {
         w.showInactive();


### PR DESCRIPTION
#### Description of Change

Some debugging recently alerted me to the fact that `BrowserWindow.isVisible()` incorrectly differs cross-platform. On macOS, a window only returns `true` for `isVisible()` if the window is in the foreground and not minimized. However, on Windows, a window could be minimized and yet incorrectly show as visible. This corrects that schism.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `BrowserWindow.isVisible()` would incorrectly return `true` for minimized windows on Windows.