### PR TITLE
fix: variable name should comply with naming convention

### DIFF
--- a/build/generate_node_defines.py
+++ b/build/generate_node_defines.py
@@ -4,7 +4,7 @@ import sys
 
 DEFINE_EXTRACT_REGEX = re.compile('^ *# *define (\w*)', re.MULTILINE)
 
-def main(outDir, headers):
+def main(out_dir, headers):
   defines = []
   for filename in headers:
     with open(filename, 'r') as f:
@@ -15,13 +15,13 @@ def main(outDir, headers):
   for define in defines:
     push_and_undef += '#pragma push_macro("%s")\n' % define
     push_and_undef += '#undef %s\n' % define
-  with open(os.path.join(outDir, 'push_and_undef_node_defines.h'), 'w') as o:
+  with open(os.path.join(out_dir, 'push_and_undef_node_defines.h'), 'w') as o:
     o.write(push_and_undef)
 
   pop = ''
   for define in defines:
     pop += '#pragma pop_macro("%s")\n' % define
-  with open(os.path.join(outDir, 'pop_node_defines.h'), 'w') as o:
+  with open(os.path.join(out_dir, 'pop_node_defines.h'), 'w') as o:
     o.write(pop)
 
 def read_defines(content):


### PR DESCRIPTION
This repository follows PEP 8.

In this case, the variable `outDir` should be replaced with `out_dir`.

PEP 8 Style Guide: https://peps.python.org/pep-0008/#descriptive-naming-styles
Google Python Style Guide (a superset of PEP 8): https://google.github.io/styleguide/pyguide.html#316-naming

Notes: none