### PR TITLE
test: re-enable tests that aren't broken & remove old test

### DIFF
--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -282,18 +282,6 @@ describe('protocol module', () => {
         ipcMain.once('loaded-iframe-custom-protocol', () => done());
       });
 
-      // DISABLED-FIXME
-      it('throws an error when custom headers are invalid', (done) => {
-        registerFileProtocol(protocolName, (request, callback) => {
-          expect(() => callback({
-            path: filePath,
-            headers: { 'X-Great-Header': (42 as any) }
-          })).to.throw(Error, 'Value of \'X-Great-Header\' header has to be a string');
-          done();
-        });
-        ajax(protocolName + '://fake-host').catch(() => {});
-      });
-
       it('sends object as response', async () => {
         registerFileProtocol(protocolName, (request, callback) => callback({ path: filePath }));
         const r = await ajax(protocolName + '://fake-host');
@@ -880,7 +868,6 @@ describe('protocol module', () => {
       await requestReceived;
     });
 
-    // DISABLED-FIXME
     it('can access files through the FileSystem API', (done) => {
       const filePath = path.join(fixturesPath, 'pages', 'filesystem.html');
       protocol.registerFileProtocol(standardScheme, (request, callback) => callback({ path: filePath }));

--- a/spec/disabled-tests.json
+++ b/spec/disabled-tests.json
@@ -11,6 +11,5 @@
   "session module ses.cookies should set cookie for standard scheme",
   "webFrameMain module WebFrame.visibilityState should match window state",
   "reporting api sends a report for a deprecation",
-  "chromium features SpeechSynthesis should emit lifecycle events",
-  "version-bumper nextVersion bump versions bumps to beta from nightly"
+  "chromium features SpeechSynthesis should emit lifecycle events"
 ]

--- a/spec/disabled-tests.json
+++ b/spec/disabled-tests.json
@@ -6,7 +6,6 @@
   "process module main process process.takeHeapSnapshot() returns true on success",
   "protocol module protocol.registerFileProtocol throws an error when custom headers are invalid",
   "protocol module protocol.registerProtocol throws an error when custom headers are invalid",
-  "protocol module protocol.registerSchemesAsPrivileged standard can access files through the FileSystem API",
   "protocol module protocol.registerSchemesAsPrivileged cors-fetch disallows CORS and fetch requests when only supportFetchAPI is specified",
   "session module ses.cookies should set cookie for standard scheme",
   "webFrameMain module WebFrame.visibilityState should match window state",

--- a/spec/disabled-tests.json
+++ b/spec/disabled-tests.json
@@ -4,8 +4,6 @@
   "BrowserWindow module document.visibilityState/hidden visibilityState remains visible if backgroundThrottling is disabled",
   "Menu module Menu.setApplicationMenu unsets a menu with null",
   "process module main process process.takeHeapSnapshot() returns true on success",
-  "protocol module protocol.registerFileProtocol throws an error when custom headers are invalid",
-  "protocol module protocol.registerProtocol throws an error when custom headers are invalid",
   "protocol module protocol.registerSchemesAsPrivileged cors-fetch disallows CORS and fetch requests when only supportFetchAPI is specified",
   "session module ses.cookies should set cookie for standard scheme",
   "webFrameMain module WebFrame.visibilityState should match window state",

--- a/spec/version-bump-spec.ts
+++ b/spec/version-bump-spec.ts
@@ -132,7 +132,6 @@ describe('version-bumper', () => {
         ).to.be.rejectedWith('Cannot bump to beta from stable.');
       });
 
-      // DISABLED-FIXME(ELECTRON 15): Re-enable after Electron 15 alpha has released
       it('bumps to beta from nightly', async () => {
         const version = 'v2.0.0-nightly.19950901';
         const next = await nextVersion('beta', version);


### PR DESCRIPTION
#### Description of Change

Some of our disabled tests aren't actually broken and can simply be re-enabled.

Also, I removed a test that was old and basically just checked that giving a number where a string was expected would throw an error, where it has long since just been silently ignored instead. I find the behavior here to be negligible and am just opting to remove the test.

#### Release Notes

Notes: none
