### PR TITLE
build: disable v8 builtins pgo

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -52,3 +52,6 @@ use_perfetto_client_library = false
 
 # Ref: https://chromium-review.googlesource.com/c/chromium/src/+/4402277
 enable_check_raw_ptr_fields = false
+
+# Disables the builtins PGO for V8
+v8_builtins_profiling_log_file = ""


### PR DESCRIPTION
#### Description of Change

[This commit was relanded](https://chromium-review.googlesource.com/c/v8/v8/+/4406038) in the last Chromium roll, which now causes builtins PGO to break the release builds. This PR disables the builtins PGO in Electron, as we don't ship the needed profiling information with mksnapshot anyway.

Note: Please don't merge until the publish-linux job passes.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
