### PR TITLE
build: drop python2 from CI

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -975,7 +975,6 @@ step-ts-compile: &step-ts-compile
 # List of all steps.
 steps-electron-gn-check: &steps-electron-gn-check
   steps:
-    - install-python2-mac
     - *step-setup-goma-for-build
     - checkout-from-cache
     - *step-setup-env-for-build
@@ -994,31 +993,6 @@ steps-electron-ts-compile-for-doc-change: &steps-electron-ts-compile-for-doc-cha
 
 # Command Aliases
 commands:
-  install-python2-mac:
-    steps:
-      - restore_cache:
-          keys:
-            - v2.7.18-python-cache-{{ arch }}
-          name: Restore python cache
-      - run:
-          name: Install python2 on macos
-          command: |
-            if [ "`uname`" == "Darwin" ] && [ "$IS_ELECTRON_RUNNER" != "1" ]; then
-              if [ ! -f "python-downloads/python-2.7.18-macosx10.9.pkg" ]; then
-                mkdir python-downloads
-                echo 'Downloading Python 2.7.18'
-                curl -O https://dev-cdn.electronjs.org/python/python-2.7.18-macosx10.9.pkg
-                mv python-2.7.18-macosx10.9.pkg python-downloads
-              else
-                echo 'Using Python install from cache'
-              fi
-              sudo installer -pkg python-downloads/python-2.7.18-macosx10.9.pkg -target /
-            fi
-      - save_cache:
-          paths:
-            - python-downloads
-          key: v2.7.18-python-cache-{{ arch }}
-          name: Persisting python cache
   maybe-restore-portaled-src-cache:
     parameters:
       halt-if-successful:
@@ -1315,7 +1289,6 @@ commands:
             - run: rm -rf src/electron
       - *step-restore-brew-cache
       - *step-install-gnutar-on-mac
-      - install-python2-mac
       - *step-save-brew-cache
       - when:
           condition: << parameters.build >>
@@ -1476,7 +1449,6 @@ commands:
       - *step-setup-linux-for-headless-testing
       - *step-restore-brew-cache
       - *step-fix-known-hosts-linux
-      - install-python2-mac
       - *step-install-signing-cert-on-mac
 
       - run:
@@ -1577,7 +1549,6 @@ commands:
             - *step-depot-tools-get
       - *step-depot-tools-add-to-path
       - *step-restore-brew-cache
-      - install-python2-mac
       - *step-get-more-space-on-mac
       - when:
           condition: << parameters.checkout >>

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -279,7 +279,7 @@ step-gclient-sync: &step-gclient-sync
         ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES=1 gclient sync --with_branch_heads --with_tags
         if [ "$IS_RELEASE" != "true" ]; then
           # Re-export all the patches to check if there were changes.
-          python src/electron/script/export_all_patches.py src/electron/patches/config.json
+          python3 src/electron/script/export_all_patches.py src/electron/patches/config.json
           cd src/electron
           git update-index --refresh || true
           if ! git diff-index --quiet HEAD --; then
@@ -680,9 +680,9 @@ step-verify-mksnapshot: &step-verify-mksnapshot
       if [ "$IS_ASAN" != "1" ]; then
         cd src
         if [ "$TARGET_ARCH" == "arm" ] || [ "$TARGET_ARCH" == "arm64" ]; then
-          python electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default --snapshot-files-dir $PWD/cross-arch-snapshots
+          python3 electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default --snapshot-files-dir $PWD/cross-arch-snapshots
         else
-          python electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default
+          python3 electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default
         fi
       fi
 
@@ -692,7 +692,7 @@ step-verify-chromedriver: &step-verify-chromedriver
     command: |
       if [ "$IS_ASAN" != "1" ]; then
         cd src
-        python electron/script/verify-chromedriver.py --source-root "$PWD" --build-dir out/Default
+        python3 electron/script/verify-chromedriver.py --source-root "$PWD" --build-dir out/Default
       fi
 
 step-setup-linux-for-headless-testing: &step-setup-linux-for-headless-testing
@@ -818,7 +818,7 @@ step-maybe-cross-arch-snapshot: &step-maybe-cross-arch-snapshot
         elif [ "`uname`" == "Darwin" ]; then
           cp "out/Default/$MKSNAPSHOT_PATH/libffmpeg.dylib" out/Default
         fi
-        python electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default --create-snapshot-only
+        python3 electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default --create-snapshot-only
         mkdir cross-arch-snapshots
         cp out/Default-mksnapshot-test/*.bin cross-arch-snapshots
         # Clean up so that ninja does not get confused

--- a/script/verify-chromedriver.py
+++ b/script/verify-chromedriver.py
@@ -17,6 +17,7 @@ def main():
   chromedriver_name = {
     'darwin': 'chromedriver',
     'win32': 'chromedriver.exe',
+    'linux': 'chromedriver',
     'linux2': 'chromedriver'
 }
 


### PR DESCRIPTION
We shouldn't need this anymore, if this is green we merge it 🥳 

Notes: no-notes