### PR TITLE
test: prewarm Node headers cache if specifying Electron version

### DIFF
--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -5,6 +5,7 @@ const childProcess = require('child_process');
 const crypto = require('crypto');
 const fs = require('fs-extra');
 const { hashElement } = require('folder-hash');
+const os = require('os');
 const path = require('path');
 const unknownFlags = [];
 
@@ -260,7 +261,18 @@ async function installSpecModules (dir) {
     env.npm_config_target = args.electronVersion;
     env.npm_config_disturl = 'https://electronjs.org/headers';
     env.npm_config_runtime = 'electron';
+    env.npm_config_devdir = path.join(os.homedir(), '.electron-gyp');
     env.npm_config_build_from_source = 'true';
+    const { status } = childProcess.spawnSync('npm', ['run', 'node-gyp-install', '--ensure'], {
+      env,
+      cwd: dir,
+      stdio: 'inherit',
+      shell: true
+    });
+    if (status !== 0) {
+      console.log(`${fail} Failed to "npm run node-gyp-install" install in '${dir}'`);
+      process.exit(1);
+    }
   } else {
     env.npm_config_nodedir = path.resolve(BASE, `out/${utils.getOutDir({ shouldLog: true })}/gen/node_headers`);
   }

--- a/spec/package.json
+++ b/spec/package.json
@@ -3,6 +3,9 @@
   "productName": "Electron Test Main",
   "main": "index.js",
   "version": "0.1.0",
+  "scripts": {
+    "node-gyp-install": "node-gyp install"
+  },
   "devDependencies": {
     "@electron-ci/echo": "file:./fixtures/native-addon/echo",
     "@electron-ci/uv-dlopen": "file:./fixtures/native-addon/uv-dlopen/",


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Workaround to a `node-gyp` issue on Windows being fixed in https://github.com/nodejs/node-gyp/pull/2846 which can lead to errors due to header cache corruption. Also sets `npm_config_devdir` properly, which was missing before.

The addition of the `node-gyp-install` script is to ensure the `node-gyp` version bundled with `npm` is used (`npx` doesn't use that version) to avoid any inconsistency issues.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
