### PR TITLE
fix: `isMaximized` after minimize/fullscreen on macOS

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -562,6 +562,11 @@ void NativeWindowMac::Unmaximize() {
 }
 
 bool NativeWindowMac::IsMaximized() {
+  // It's possible for [window_ isZoomed] to be true
+  // when the window is minimized or fullscreened.
+  if (IsMinimized() || IsFullscreen())
+    return false;
+
   if (HasStyleMask(NSWindowStyleMaskResizable) != 0)
     return [window_ isZoomed];
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1665,6 +1665,42 @@ describe('BrowserWindow module', () => {
           expectBoundsEqual(w.getNormalBounds(), bounds);
         });
 
+        it('correctly reports maximized state after maximizing then minimizing', async () => {
+          w.destroy();
+          w = new BrowserWindow({ show: false });
+
+          w.show();
+
+          const maximize = once(w, 'maximize');
+          w.maximize();
+          await maximize;
+
+          const minimize = once(w, 'minimize');
+          w.minimize();
+          await minimize;
+
+          expect(w.isMaximized()).to.equal(false);
+          expect(w.isMinimized()).to.equal(true);
+        });
+
+        it('correctly reports maximized state after maximizing then fullscreening', async () => {
+          w.destroy();
+          w = new BrowserWindow({ show: false });
+
+          w.show();
+
+          const maximize = once(w, 'maximize');
+          w.maximize();
+          await maximize;
+
+          const enterFS = once(w, 'enter-full-screen');
+          w.setFullScreen(true);
+          await enterFS;
+
+          expect(w.isMaximized()).to.equal(false);
+          expect(w.isFullScreen()).to.equal(true);
+        });
+
         it('does not change size for a frameless window with min size', async () => {
           w.destroy();
           w = new BrowserWindow({


### PR DESCRIPTION
#### Description of Change

When an NSWindow is initially minimized on macOS, it's possible for `[window_ isZoomed]` to be true
when the window is minimized or fullscreened. This adds an explicit guard to fix that, thereby matching [Chromium behavior](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/views/apps/chrome_native_app_window_views_mac.mm;l=145-148?q=window%20%22isZoomed%5D%22%20%22minimized%22&sq=package:chromium).

See https://github.com/electron/electron/pull/38234#issuecomment-1546518668

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `BrowserWindow.isMaximized()` could incorrectly return true for minimized or fullscreened windows on macOS.
