### PR TITLE
chore: cherry-pick 8 changes from Release-1-M113

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -2,3 +2,4 @@ fix_rename_webswapcgllayer_to_webswapcgllayerchromium.patch
 cherry-pick-55e2b6daba9d.patch
 cherry-pick-ce029c91a662.patch
 cherry-pick-aed05b609629.patch
+cherry-pick-d0ee0197ddff.patch

--- a/patches/angle/cherry-pick-d0ee0197ddff.patch
+++ b/patches/angle/cherry-pick-d0ee0197ddff.patch
@@ -1,0 +1,208 @@
+From d0ee0197ddff25fe1a9876511c07542ac483702d Mon Sep 17 00:00:00 2001
+From: Shahbaz Youssefi <syoussefi@chromium.org>
+Date: Wed, 03 May 2023 13:41:36 -0400
+Subject: [PATCH] WebGL: Limit total size of private data
+
+... not just individual arrays.
+
+Bug: chromium:1431761
+Change-Id: I721e29aeceeaf12c3f6a67b668abffb8dfbc89b0
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/4503753
+Reviewed-by: Kenneth Russell <kbr@chromium.org>
+Commit-Queue: Shahbaz Youssefi <syoussefi@chromium.org>
+---
+
+diff --git a/src/compiler/translator/ValidateTypeSizeLimitations.cpp b/src/compiler/translator/ValidateTypeSizeLimitations.cpp
+index 6097b6d..2a033ad 100644
+--- a/src/compiler/translator/ValidateTypeSizeLimitations.cpp
++++ b/src/compiler/translator/ValidateTypeSizeLimitations.cpp
+@@ -35,7 +35,9 @@
+ {
+   public:
+     ValidateTypeSizeLimitationsTraverser(TSymbolTable *symbolTable, TDiagnostics *diagnostics)
+-        : TIntermTraverser(true, false, false, symbolTable), mDiagnostics(diagnostics)
++        : TIntermTraverser(true, false, false, symbolTable),
++          mDiagnostics(diagnostics),
++          mTotalPrivateVariablesSize(0)
+     {
+         ASSERT(diagnostics);
+     }
+@@ -93,18 +95,33 @@
+             const bool isPrivate = variableType.getQualifier() == EvqTemporary ||
+                                    variableType.getQualifier() == EvqGlobal ||
+                                    variableType.getQualifier() == EvqConst;
+-            if (layoutEncoder.getCurrentOffset() > kMaxPrivateVariableSizeInBytes && isPrivate)
++            if (isPrivate)
+             {
+-                error(asSymbol->getLine(),
+-                      "Size of declared private variable exceeds implementation-defined limit",
+-                      asSymbol->getName());
+-                return false;
++                if (layoutEncoder.getCurrentOffset() > kMaxPrivateVariableSizeInBytes)
++                {
++                    error(asSymbol->getLine(),
++                          "Size of declared private variable exceeds implementation-defined limit",
++                          asSymbol->getName());
++                    return false;
++                }
++                mTotalPrivateVariablesSize += layoutEncoder.getCurrentOffset();
+             }
+         }
+ 
+         return true;
+     }
+ 
++    void validateTotalPrivateVariableSize()
++    {
++        if (mTotalPrivateVariablesSize > kMaxPrivateVariableSizeInBytes)
++        {
++            mDiagnostics->error(
++                TSourceLoc{},
++                "Total size of declared private variables exceeds implementation-defined limit",
++                "");
++        }
++    }
++
+   private:
+     void error(TSourceLoc loc, const char *reason, const ImmutableString &token)
+     {
+@@ -213,6 +230,8 @@
+ 
+     TDiagnostics *mDiagnostics;
+     std::vector<int> mLoopSymbolIds;
++
++    size_t mTotalPrivateVariablesSize;
+ };
+ 
+ }  // namespace
+@@ -223,6 +242,7 @@
+ {
+     ValidateTypeSizeLimitationsTraverser validate(symbolTable, diagnostics);
+     root->traverse(&validate);
++    validate.validateTotalPrivateVariableSize();
+     return diagnostics->numErrors() == 0;
+ }
+ 
+diff --git a/src/tests/gl_tests/WebGLCompatibilityTest.cpp b/src/tests/gl_tests/WebGLCompatibilityTest.cpp
+index e62c8fb..996bad1 100644
+--- a/src/tests/gl_tests/WebGLCompatibilityTest.cpp
++++ b/src/tests/gl_tests/WebGLCompatibilityTest.cpp
+@@ -5271,11 +5271,12 @@
+     // fairly small array.
+     constexpr char kVSArrayOK[] =
+         R"(varying vec4 color;
+-const int array_size = 1000;
++const int array_size = 500;
+ void main()
+ {
+     mat2 array[array_size];
+-    if (array[0][0][0] == 2.0)
++    mat2 array2[array_size];
++    if (array[0][0][0] + array2[0][0][0] == 2.0)
+         color = vec4(0.0, 1.0, 0.0, 1.0);
+     else
+         color = vec4(1.0, 0.0, 0.0, 1.0);
+@@ -5353,6 +5354,103 @@
+     EXPECT_EQ(0u, program);
+ }
+ 
++// Reject attempts to allocate too much private memory.
++// This is an implementation-defined limit - crbug.com/1431761.
++TEST_P(WebGLCompatibilityTest, ValidateTotalPrivateSize)
++{
++    constexpr char kTooLargeGlobalMemory1[] =
++        R"(precision mediump float;
++
++// 1 MB / 16 bytes per vec4 = 65536
++vec4 array[32768];
++vec4 array2[32769];
++
++void main()
++{
++    if (array[0].x + array[1].x == 0.)
++        gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
++    else
++        gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
++})";
++
++    constexpr char kTooLargeGlobalMemory2[] =
++        R"(precision mediump float;
++
++// 1 MB / 16 bytes per vec4 = 65536
++vec4 array[32767];
++vec4 array2[32767];
++vec4 x, y, z;
++
++void main()
++{
++    if (array[0].x + array[1].x == x.w + y.w + z.w)
++        gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
++    else
++        gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
++})";
++
++    constexpr char kTooLargeGlobalAndLocalMemory1[] =
++        R"(precision mediump float;
++
++// 1 MB / 16 bytes per vec4 = 65536
++vec4 array[32768];
++
++void main()
++{
++    vec4 array2[32769];
++    if (array[0].x + array[1].x == 2.0)
++        gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
++    else
++        gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
++})";
++
++    // Note: The call stack is not taken into account for the purposes of total memory calculation.
++    constexpr char kTooLargeGlobalAndLocalMemory2[] =
++        R"(precision mediump float;
++
++// 1 MB / 16 bytes per vec4 = 65536
++vec4 array[32768];
++
++float f()
++{
++    vec4 array2[16384];
++    return array2[0].x;
++}
++
++float g()
++{
++    vec4 array3[16383];
++    return array3[0].x;
++}
++
++float h()
++{
++    vec4 value;
++    float value2
++    return value.x + value2;
++}
++
++void main()
++{
++    if (array[0].x + f() + g() + h() == 2.0)
++        gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
++    else
++        gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
++})";
++
++    GLuint program = CompileProgram(essl1_shaders::vs::Simple(), kTooLargeGlobalMemory1);
++    EXPECT_EQ(0u, program);
++
++    program = CompileProgram(essl1_shaders::vs::Simple(), kTooLargeGlobalMemory2);
++    EXPECT_EQ(0u, program);
++
++    program = CompileProgram(essl1_shaders::vs::Simple(), kTooLargeGlobalAndLocalMemory1);
++    EXPECT_EQ(0u, program);
++
++    program = CompileProgram(essl1_shaders::vs::Simple(), kTooLargeGlobalAndLocalMemory2);
++    EXPECT_EQ(0u, program);
++}
++
+ // Linking should fail when corresponding vertex/fragment uniform blocks have different precision
+ // qualifiers.
+ TEST_P(WebGL2CompatibilityTest, UniformBlockPrecisionMismatch)

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -157,3 +157,7 @@ cherry-pick-63686953dc22.patch
 cherry-pick-f098ff0d1230.patch
 cherry-pick-f58218891f8c.patch
 wayland_ensure_dnd_buffer_size_is_a_multiple_of_scale.patch
+cherry-pick-d6272b794cbb.patch
+cherry-pick-48785f698b1c.patch
+cherry-pick-9b6ca211234b.patch
+cherry-pick-675562695049.patch

--- a/patches/chromium/cherry-pick-48785f698b1c.patch
+++ b/patches/chromium/cherry-pick-48785f698b1c.patch
@@ -1,0 +1,105 @@
+From 48785f698b1cefcd0cf265001cd36a564abacf07 Mon Sep 17 00:00:00 2001
+From: Arthur Sonzogni <arthursonzogni@chromium.org>
+Date: Tue, 02 May 2023 09:40:37 +0000
+Subject: [PATCH] Avoid buffer overflow read in HFSReadNextNonIgnorableCodePoint
+
+Unicode codepoints goes beyond 0xFFFF.
+
+It exists upper and lower case characters there: `𞤡 `vs `𞥃`.
+
+The buffer overflow occurred when using the lookup table:
+```
+lower_case_table[codepoint >> 8]
+```
+
+Bug: 1425115
+Fixed: 1425115
+Change-Id: I679da02dbe570283a68176fbd3c0c620caa4f9ce
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4481260
+Reviewed-by: Alexander Timin <altimin@chromium.org>
+Commit-Queue: Arthur Sonzogni <arthursonzogni@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1138234}
+---
+
+diff --git a/base/files/file_path.cc b/base/files/file_path.cc
+index 12c684b..59bbc6e 100644
+--- a/base/files/file_path.cc
++++ b/base/files/file_path.cc
+@@ -789,7 +789,7 @@
+ #elif BUILDFLAG(IS_APPLE)
+ // Mac OS X specific implementation of file string comparisons.
+ 
+-// cf. http://developer.apple.com/mac/library/technotes/tn/tn1150.html#UnicodeSubtleties
++// cf. https://developer.apple.com/library/archive/technotes/tn/tn1150.html#UnicodeSubtleties
+ //
+ // "When using CreateTextEncoding to create a text encoding, you should set
+ // the TextEncodingBase to kTextEncodingUnicodeV2_0, set the
+@@ -815,11 +815,12 @@
+ // Ignored characters are mapped to zero.
+ //
+ // cf. downloadable file linked in
+-// http://developer.apple.com/mac/library/technotes/tn/tn1150.html#StringComparisonAlgorithm
++// https://developer.apple.com/library/archive/technotes/tn/tn1150.html#Downloads
+ 
+ namespace {
+ 
+-const UInt16 lower_case_table[] = {
++// clang-format off
++const UInt16 lower_case_table[11 * 256] = {
+   // High-byte indices ( == 0 iff no case mapping and no ignorables )
+ 
+   /* 0 */ 0x0100, 0x0200, 0x0000, 0x0300, 0x0400, 0x0500, 0x0000, 0x0000,
+@@ -1205,11 +1206,12 @@
+   /* F */ 0xFFF0, 0xFFF1, 0xFFF2, 0xFFF3, 0xFFF4, 0xFFF5, 0xFFF6, 0xFFF7,
+           0xFFF8, 0xFFF9, 0xFFFA, 0xFFFB, 0xFFFC, 0xFFFD, 0xFFFE, 0xFFFF,
+ };
++// clang-format on
+ 
+-// Returns the next non-ignorable codepoint within string starting from the
+-// position indicated by index, or zero if there are no more.
+-// The passed-in index is automatically advanced as the characters in the input
+-// HFS-decomposed UTF-8 strings are read.
++// Returns the next non-ignorable codepoint within `string` starting from the
++// position indicated by `index`, or zero if there are no more.
++// The passed-in `index` is automatically advanced as the characters in the
++// input HFS-decomposed UTF-8 strings are read.
+ inline base_icu::UChar32 HFSReadNextNonIgnorableCodepoint(const char* string,
+                                                           size_t length,
+                                                           size_t* index) {
+@@ -1220,12 +1222,16 @@
+     CBU8_NEXT(reinterpret_cast<const uint8_t*>(string), *index, length,
+               codepoint);
+     DCHECK_GT(codepoint, 0);
+-    if (codepoint > 0) {
++
++    // Note: Here, there are no lower case conversion implemented in the
++    // Supplementary Multilingual Plane (codepoint > 0xFFFF).
++
++    if (codepoint > 0 && codepoint <= 0xFFFF) {
+       // Check if there is a subtable for this upper byte.
+       int lookup_offset = lower_case_table[codepoint >> 8];
+       if (lookup_offset != 0)
+         codepoint = lower_case_table[lookup_offset + (codepoint & 0x00FF)];
+-      // Note: codepoint1 may be again 0 at this point if the character was
++      // Note: `codepoint` may be again 0 at this point if the character was
+       // an ignorable.
+     }
+   }
+diff --git a/base/files/file_path_unittest.cc b/base/files/file_path_unittest.cc
+index 7b30b15..9673a48 100644
+--- a/base/files/file_path_unittest.cc
++++ b/base/files/file_path_unittest.cc
+@@ -1203,6 +1203,13 @@
+     {{FPL("K\u0301U\u032DO\u0304\u0301N"), FPL("\u1E31\u1E77\u1E53n")}, 0},
+     {{FPL("k\u0301u\u032Do\u0304\u0301n"), FPL("\u1E30\u1E76\u1E52n")}, 0},
+     {{FPL("k\u0301u\u032Do\u0304\u0302n"), FPL("\u1E30\u1E76\u1E52n")}, 1},
++
++    // Codepoints > 0xFFFF
++    // Here, we compare the `Adlam Letter Shu` in its capital and small version.
++    {{FPL("\U0001E921"), FPL("\U0001E943")}, -1},
++    {{FPL("\U0001E943"), FPL("\U0001E921")}, 1},
++    {{FPL("\U0001E921"), FPL("\U0001E921")}, 0},
++    {{FPL("\U0001E943"), FPL("\U0001E943")}, 0},
+ #endif
+   };
+ 

--- a/patches/chromium/cherry-pick-675562695049.patch
+++ b/patches/chromium/cherry-pick-675562695049.patch
@@ -1,0 +1,142 @@
+From 6755626950491fac28d6631b19e16a5733435070 Mon Sep 17 00:00:00 2001
+From: Rakina Zata Amni <rakina@chromium.org>
+Date: Mon, 15 May 2023 03:21:49 +0000
+Subject: [PATCH] [M114] Return after ReadyCommitNavigation call in CommitErrorPage if it deletes NavigationRequest
+
+NavigationRequest::ReadyToCommitNavigation() can cause deletion of the
+NavigationRequest, so callers should check for that possibility after
+calling the function. A caller in CommitErrorPage is missing that
+check, which this CL adds, along with a regression test.
+
+(cherry picked from commit 42db806805ef2be64ee92803d3a784631b2a7df0)
+
+Bug: 1444360
+Change-Id: I3964da4909a6709b7730d25d6497b19c098f4f21
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4520493
+Commit-Queue: Charlie Reis <creis@chromium.org>
+Reviewed-by: Charlie Reis <creis@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1143298}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4531446
+Reviewed-by: Prudhvikumar Bommana <pbommana@google.com>
+Commit-Queue: Rakina Zata Amni <rakina@chromium.org>
+Commit-Queue: Prudhvikumar Bommana <pbommana@google.com>
+Owners-Override: Prudhvikumar Bommana <pbommana@google.com>
+Cr-Commit-Position: refs/branch-heads/5735@{#607}
+Cr-Branched-From: 2f562e4ddbaf79a3f3cb338b4d1bd4398d49eb67-refs/heads/main@{#1135570}
+---
+
+diff --git a/content/browser/renderer_host/navigation_request.cc b/content/browser/renderer_host/navigation_request.cc
+index c7cc3b84..a2530d4 100644
+--- a/content/browser/renderer_host/navigation_request.cc
++++ b/content/browser/renderer_host/navigation_request.cc
+@@ -5453,7 +5453,13 @@
+     topics_eligible_ = false;
+   }
+ 
++  base::WeakPtr<NavigationRequest> weak_self(weak_factory_.GetWeakPtr());
+   ReadyToCommitNavigation(true /* is_error */);
++  // The caller above might result in the deletion of `this`. Return immediately
++  // if so.
++  if (!weak_self) {
++    return;
++  }
+ 
+   PopulateDocumentTokenForCrossDocumentNavigation();
+   // Use a separate cache shard, and no cookies, for error pages.
+diff --git a/content/browser/renderer_host/navigation_request_browsertest.cc b/content/browser/renderer_host/navigation_request_browsertest.cc
+index f55e3f4..58f3526 100644
+--- a/content/browser/renderer_host/navigation_request_browsertest.cc
++++ b/content/browser/renderer_host/navigation_request_browsertest.cc
+@@ -46,6 +46,7 @@
+ #include "content/public/test/prerender_test_util.h"
+ #include "content/public/test/test_frame_navigation_observer.h"
+ #include "content/public/test/test_navigation_observer.h"
++#include "content/public/test/test_service.mojom.h"
+ #include "content/public/test/test_utils.h"
+ #include "content/public/test/url_loader_interceptor.h"
+ #include "content/shell/browser/shell.h"
+@@ -4384,4 +4385,84 @@
+   }
+ }
+ 
++// Tests that when trying to commit an error page for a failed navigation, but
++// the renderer process of the, the navigation won't commit and won't crash.
++// Regression test for https://crbug.com/1444360.
++IN_PROC_BROWSER_TEST_F(NavigationRequestBrowserTest,
++                       RendererCrashedBeforeCommitErrorPage) {
++  // Navigate to `url_a` first.
++  GURL url_a(embedded_test_server()->GetURL("a.com", "/title1.html"));
++  ASSERT_TRUE(NavigateToURL(shell(), url_a));
++
++  // Set up an URLLoaderInterceptor which will cause future navigations to fail.
++  auto url_loader_interceptor = std::make_unique<URLLoaderInterceptor>(
++      base::BindRepeating([](URLLoaderInterceptor::RequestParams* params) {
++        network::URLLoaderCompletionStatus status;
++        status.error_code = net::ERR_NOT_IMPLEMENTED;
++        params->client->OnComplete(status);
++        return true;
++      }));
++
++  // Do a navigation to `url_b1` that will fail and commit an error page. This
++  // is important so that the next error page navigation won't need to create a
++  // speculative RenderFrameHost (unless RenderDocument is enabled) and won't
++  // get cancelled earlier than commit time due to speculative RFH deletion.
++  GURL url_b1(embedded_test_server()->GetURL("b.com", "/title1.html"));
++  EXPECT_FALSE(NavigateToURL(shell(), url_b1));
++  EXPECT_EQ(shell()->web_contents()->GetLastCommittedURL(), url_b1);
++  EXPECT_TRUE(
++      shell()->web_contents()->GetPrimaryMainFrame()->IsErrorDocument());
++
++  // For the next navigation, set up a throttle that will be used to wait for
++  // WillFailRequest() and then defer the navigation, so that we can crash the
++  // error page process first.
++  TestNavigationThrottleInstaller installer(
++      shell()->web_contents(),
++      NavigationThrottle::PROCEED /* will_start_result */,
++      NavigationThrottle::PROCEED /* will_redirect_result */,
++      NavigationThrottle::DEFER /* will_fail_result */,
++      NavigationThrottle::PROCEED /* will_process_result */,
++      NavigationThrottle::PROCEED /* will_commit_without_url_loader_result */);
++
++  // Start a navigation to `url_b2` that will also fail, but before it commits
++  // an error page, cause the error page process to crash.
++  GURL url_b2(embedded_test_server()->GetURL("b.com", "/title2.html"));
++  TestNavigationManager manager(shell()->web_contents(), url_b2);
++  shell()->LoadURL(url_b2);
++  EXPECT_TRUE(manager.WaitForRequestStart());
++
++  // Resume the navigation and wait for WillFailRequest(). After this point, we
++  // will have picked the final RenderFrameHost & RenderProcessHost for the
++  // failed navigation.
++  manager.ResumeNavigation();
++  installer.WaitForThrottleWillFail();
++
++  // Kill the error page process. This will cause for the navigation to `url_b2`
++  // to return early in `NavigationRequest::ReadyToCommitNavigation()` and not
++  // commit a new error page.
++  RenderProcessHost* process_to_kill =
++      manager.GetNavigationHandle()->GetRenderFrameHost()->GetProcess();
++  ASSERT_TRUE(process_to_kill->IsInitializedAndNotDead());
++  {
++    // Trigger a renderer kill by calling DoSomething() which will cause a bad
++    // message to be reported.
++    RenderProcessHostBadIpcMessageWaiter kill_waiter(process_to_kill);
++    mojo::Remote<mojom::TestService> service;
++    process_to_kill->BindReceiver(service.BindNewPipeAndPassReceiver());
++    service->DoSomething(base::DoNothing());
++    EXPECT_EQ(bad_message::RPH_MOJO_PROCESS_ERROR, kill_waiter.Wait());
++  }
++  ASSERT_FALSE(process_to_kill->IsInitializedAndNotDead());
++
++  // Resume the navigation, which won't commit.
++  if (!ShouldCreateNewHostForAllFrames()) {
++    installer.navigation_throttle()->ResumeNavigation();
++  }
++  EXPECT_TRUE(manager.WaitForNavigationFinished());
++  EXPECT_FALSE(WaitForLoadStop(shell()->web_contents()));
++
++  // The tab stayed at `url_b1` as the `url_b2` navigation didn't commit.
++  EXPECT_EQ(shell()->web_contents()->GetLastCommittedURL(), url_b1);
++}
++
+ }  // namespace content

--- a/patches/chromium/cherry-pick-9b6ca211234b.patch
+++ b/patches/chromium/cherry-pick-9b6ca211234b.patch
@@ -1,0 +1,234 @@
+From 9b6ca211234b057a9ce4184a3315741dc040ecbf Mon Sep 17 00:00:00 2001
+From: Kevin McNee <mcnee@chromium.org>
+Date: Fri, 12 May 2023 19:53:19 +0000
+Subject: [PATCH] M114: Store BrowserPluginGuestDelegate as a weak ptr
+
+Store BrowserPluginGuestDelegate as a weak ptr
+
+In the case where a webview creates a popup window, the opener web
+contents temporarily owns the new guest web contents between the
+renderer creating and showing the window. If the opener is destroyed at
+this time, the new guest (WebViewGuest) is destroyed as well. Due to
+the ordering of the destruction of the new guest web contents, it may
+attempt to access the destroyed WebViewGuest through the delegate
+interface. We now access this delegate through a weak ptr.
+
+(cherry picked from commit db32d6929cf3177b52b034541e5bd6d3e19e18ca)
+
+Low-Coverage-Reason: NOTREACHED
+Bug: 1442516
+Change-Id: I417431ad487bc9db0551c1e0363379c5ff455d59
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4515455
+Reviewed-by: Alex Moshchuk <alexmos@chromium.org>
+Reviewed-by: James Maclean <wjmaclean@chromium.org>
+Commit-Queue: Kevin McNee <mcnee@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1141602}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4528155
+Auto-Submit: Kevin McNee <mcnee@chromium.org>
+Commit-Queue: Alex Moshchuk <alexmos@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5735@{#540}
+Cr-Branched-From: 2f562e4ddbaf79a3f3cb338b4d1bd4398d49eb67-refs/heads/main@{#1135570}
+---
+
+diff --git a/chrome/browser/apps/guest_view/web_view_browsertest.cc b/chrome/browser/apps/guest_view/web_view_browsertest.cc
+index 7cd25c75..014e41d1 100644
+--- a/chrome/browser/apps/guest_view/web_view_browsertest.cc
++++ b/chrome/browser/apps/guest_view/web_view_browsertest.cc
+@@ -48,6 +48,7 @@
+ #include "chrome/common/chrome_switches.h"
+ #include "chrome/common/pref_names.h"
+ #include "chrome/common/webui_url_constants.h"
++#include "chrome/test/base/tracing.h"
+ #include "chrome/test/base/ui_test_utils.h"
+ #include "components/download/public/common/download_task_runner.h"
+ #include "components/find_in_page/find_tab_helper.h"
+@@ -5554,6 +5555,63 @@
+             entry->metrics.begin()->second);
+ }
+ 
++class PopupWaiter : public content::WebContentsObserver {
++ public:
++  PopupWaiter(content::WebContents* opener, base::OnceClosure on_popup)
++      : content::WebContentsObserver(opener), on_popup_(std::move(on_popup)) {}
++
++  // WebContentsObserver:
++  // Note that `DidOpenRequestedURL` is used as it fires precisely after a new
++  // WebContents is created but before it is shown. This timing is necessary for
++  // the `ShutdownWithUnshownPopup` test.
++  void DidOpenRequestedURL(content::WebContents* new_contents,
++                           content::RenderFrameHost* source_render_frame_host,
++                           const GURL& url,
++                           const content::Referrer& referrer,
++                           WindowOpenDisposition disposition,
++                           ui::PageTransition transition,
++                           bool started_from_context_menu,
++                           bool renderer_initiated) override {
++    if (on_popup_) {
++      std::move(on_popup_).Run();
++    }
++  }
++
++ private:
++  base::OnceClosure on_popup_;
++};
++
++// Test destroying an opener webview while the created window has not been
++// shown by the renderer. Between the time of the renderer creating and showing
++// the new window, the created guest WebContents is owned by content/ and not by
++// WebViewGuest. See `WebContentsImpl::pending_contents_` for details. When we
++// destroy the new WebViewGuest, content/ must ensure that the guest WebContents
++// is destroyed safely.
++//
++// This test is conceptually similar to
++// testNewWindowOpenerDestroyedWhileUnattached, but for this test, we have
++// precise timing requirements that need to be controlled by the browser such
++// that we shutdown while the new window is pending.
++//
++// Regression test for https://crbug.com/1442516
++IN_PROC_BROWSER_TEST_F(WebViewTest, ShutdownWithUnshownPopup) {
++  ASSERT_TRUE(StartEmbeddedTestServer());
++
++  // Core classes in content often record trace events during destruction.
++  // Enable tracing to test that writing traces with partially destructed
++  // objects is done safely.
++  ASSERT_TRUE(tracing::BeginTracing("content,navigation"));
++
++  LoadAppWithGuest("web_view/simple");
++
++  base::RunLoop run_loop;
++  PopupWaiter popup_waiter(GetGuestWebContents(), run_loop.QuitClosure());
++  content::ExecuteScriptAsync(GetGuestRenderFrameHost(),
++                              "window.open(location.href);");
++  run_loop.Run();
++  CloseAppWindow(GetFirstAppWindow());
++}
++
+ IN_PROC_BROWSER_TEST_F(WebViewTest, InsertIntoDetachedIframe) {
+   TestHelper("testInsertIntoDetachedIframe", "web_view/shim",
+              NEEDS_TEST_SERVER);
+diff --git a/components/guest_view/browser/guest_view_base.cc b/components/guest_view/browser/guest_view_base.cc
+index 4ef55d1c..ba2fac2 100644
+--- a/components/guest_view/browser/guest_view_base.cc
++++ b/components/guest_view/browser/guest_view_base.cc
+@@ -124,6 +124,9 @@
+   void WebContentsDestroyed() override {
+     // If the opener is destroyed and the guest has not been attached, then
+     // destroy the guest.
++    // Note that the guest contents may be owned by content/ at this point. In
++    // this case, we expect content/ to safely destroy the contents without
++    // accessing delegate methods of the destroyed guest.
+     // Destroys `this`.
+     DestroyGuestIfUnattached(guest_);
+   }
+@@ -915,4 +918,9 @@
+   return web_contents()->GetPrimaryMainFrame();
+ }
+ 
++base::WeakPtr<content::BrowserPluginGuestDelegate>
++GuestViewBase::GetGuestDelegateWeakPtr() {
++  return weak_ptr_factory_.GetWeakPtr();
++}
++
+ }  // namespace guest_view
+diff --git a/components/guest_view/browser/guest_view_base.h b/components/guest_view/browser/guest_view_base.h
+index dccb7fcf..a15c73f 100644
+--- a/components/guest_view/browser/guest_view_base.h
++++ b/components/guest_view/browser/guest_view_base.h
+@@ -353,6 +353,8 @@
+   std::unique_ptr<content::WebContents> CreateNewGuestWindow(
+       const content::WebContents::CreateParams& create_params) final;
+   content::WebContents* GetOwnerWebContents() final;
++  base::WeakPtr<content::BrowserPluginGuestDelegate> GetGuestDelegateWeakPtr()
++      final;
+ 
+   // WebContentsDelegate implementation.
+   void ActivateContents(content::WebContents* contents) final;
+diff --git a/content/browser/browser_plugin/browser_plugin_guest.cc b/content/browser/browser_plugin/browser_plugin_guest.cc
+index a7501a5..2e47c12 100644
+--- a/content/browser/browser_plugin/browser_plugin_guest.cc
++++ b/content/browser/browser_plugin/browser_plugin_guest.cc
+@@ -25,9 +25,10 @@
+ 
+ BrowserPluginGuest::BrowserPluginGuest(WebContentsImpl* web_contents,
+                                        BrowserPluginGuestDelegate* delegate)
+-    : WebContentsObserver(web_contents), delegate_(delegate) {
+-  DCHECK(web_contents);
+-  DCHECK(delegate);
++    : WebContentsObserver(web_contents),
++      delegate_(delegate->GetGuestDelegateWeakPtr()) {
++  CHECK(web_contents);
++  CHECK(delegate_);
+   RecordAction(base::UserMetricsAction("BrowserPlugin.Guest.Create"));
+ }
+ 
+@@ -97,6 +98,11 @@
+ }
+ 
+ RenderFrameHostImpl* BrowserPluginGuest::GetProspectiveOuterDocument() {
++  if (!delegate_) {
++    // The guest delegate may only be null during some destruction scenarios.
++    CHECK(web_contents()->IsBeingDestroyed());
++    return nullptr;
++  }
+   return static_cast<RenderFrameHostImpl*>(
+       delegate_->GetProspectiveOuterDocument());
+ }
+diff --git a/content/browser/browser_plugin/browser_plugin_guest.h b/content/browser/browser_plugin/browser_plugin_guest.h
+index 17e98b6..7f308302 100644
+--- a/content/browser/browser_plugin/browser_plugin_guest.h
++++ b/content/browser/browser_plugin/browser_plugin_guest.h
+@@ -7,7 +7,7 @@
+ 
+ #include <vector>
+ 
+-#include "base/memory/raw_ptr.h"
++#include "base/memory/weak_ptr.h"
+ #include "build/build_config.h"
+ #include "content/public/browser/browser_plugin_guest_delegate.h"
+ #include "content/public/browser/web_contents_observer.h"
+@@ -78,7 +78,8 @@
+ 
+   void InitInternal(WebContentsImpl* owner_web_contents);
+ 
+-  const raw_ptr<BrowserPluginGuestDelegate, DanglingUntriaged> delegate_;
++  // May be null during guest destruction.
++  const base::WeakPtr<BrowserPluginGuestDelegate> delegate_;
+ };
+ 
+ }  // namespace content
+diff --git a/content/public/browser/browser_plugin_guest_delegate.cc b/content/public/browser/browser_plugin_guest_delegate.cc
+index 62cbad1..040d36a 100644
+--- a/content/public/browser/browser_plugin_guest_delegate.cc
++++ b/content/public/browser/browser_plugin_guest_delegate.cc
+@@ -20,4 +20,10 @@
+   return nullptr;
+ }
+ 
++base::WeakPtr<BrowserPluginGuestDelegate>
++BrowserPluginGuestDelegate::GetGuestDelegateWeakPtr() {
++  NOTREACHED();
++  return nullptr;
++}
++
+ }  // namespace content
+diff --git a/content/public/browser/browser_plugin_guest_delegate.h b/content/public/browser/browser_plugin_guest_delegate.h
+index 51a4efa8..d588b4d3 100644
+--- a/content/public/browser/browser_plugin_guest_delegate.h
++++ b/content/public/browser/browser_plugin_guest_delegate.h
+@@ -5,6 +5,7 @@
+ #ifndef CONTENT_PUBLIC_BROWSER_BROWSER_PLUGIN_GUEST_DELEGATE_H_
+ #define CONTENT_PUBLIC_BROWSER_BROWSER_PLUGIN_GUEST_DELEGATE_H_
+ 
++#include "base/memory/weak_ptr.h"
+ #include "content/common/content_export.h"
+ #include "content/public/browser/web_contents.h"
+ 
+@@ -28,6 +29,8 @@
+   // TODO(crbug.com/769461): Have all guest types return the specific owner
+   // RenderFrameHost and not assume it's the owner's main frame.
+   virtual RenderFrameHost* GetProspectiveOuterDocument();
++
++  virtual base::WeakPtr<BrowserPluginGuestDelegate> GetGuestDelegateWeakPtr();
+ };
+ 
+ }  // namespace content

--- a/patches/chromium/cherry-pick-d6272b794cbb.patch
+++ b/patches/chromium/cherry-pick-d6272b794cbb.patch
@@ -1,0 +1,106 @@
+From d6272b794cbbb146303c3acb48713244a92cce48 Mon Sep 17 00:00:00 2001
+From: Simon Zünd <szuend@chromium.org>
+Date: Tue, 02 May 2023 06:05:35 +0000
+Subject: [PATCH] [devtools] Delete PendingRequest first in DevToolsDataSource
+
+The way URLDataSources are used in Chromium, it can happen that the
+"content::URLDataSource::GotDataCallback" closure is the last shared
+owner of the data source itself. This means that the URLDataSource
+is deleted after the callback is done running.
+
+This CL fixes an invalid access to DevToolsDataSource, where we
+access `this` in the OnLoadComplete method after we call the
+GotDataCallback.
+
+R=dsv@chromium.org
+
+Fixed: 1435166
+Change-Id: I32e4a717ca27bc011449c8f8efeaffe70aaa8898
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4487280
+Reviewed-by: Andrey Kosyakov <caseq@chromium.org>
+Commit-Queue: Simon Zünd <szuend@chromium.org>
+Reviewed-by: Danil Somsikov <dsv@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1138173}
+---
+
+diff --git a/chrome/browser/ui/webui/devtools_ui_data_source.cc b/chrome/browser/ui/webui/devtools_ui_data_source.cc
+index c60d70f..991599d 100644
+--- a/chrome/browser/ui/webui/devtools_ui_data_source.cc
++++ b/chrome/browser/ui/webui/devtools_ui_data_source.cc
+@@ -365,11 +365,13 @@
+ void DevToolsDataSource::OnLoadComplete(
+     std::list<PendingRequest>::iterator request_iter,
+     std::unique_ptr<std::string> response_body) {
+-  std::move(request_iter->callback)
+-      .Run(response_body ? base::MakeRefCounted<base::RefCountedString>(
+-                               std::move(*response_body))
+-                         : CreateNotFoundResponse());
++  GotDataCallback callback = std::move(request_iter->callback);
+   pending_requests_.erase(request_iter);
++  std::move(callback).Run(response_body
++                              ? base::MakeRefCounted<base::RefCountedString>(
++                                    std::move(*response_body))
++                              : CreateNotFoundResponse());
++  // `this` might no longer be valid after `callback` has run.
+ }
+ 
+ DevToolsDataSource::PendingRequest::PendingRequest() = default;
+diff --git a/chrome/browser/ui/webui/devtools_ui_data_source_unittest.cc b/chrome/browser/ui/webui/devtools_ui_data_source_unittest.cc
+index b4f41411..c07c43b 100644
+--- a/chrome/browser/ui/webui/devtools_ui_data_source_unittest.cc
++++ b/chrome/browser/ui/webui/devtools_ui_data_source_unittest.cc
+@@ -9,13 +9,17 @@
+ #include "base/command_line.h"
+ #include "base/functional/bind.h"
+ #include "base/memory/ref_counted_memory.h"
++#include "base/memory/scoped_refptr.h"
+ #include "base/strings/strcat.h"
+ #include "base/strings/string_piece.h"
++#include "base/test/bind.h"
+ #include "build/build_config.h"
+ #include "chrome/common/chrome_switches.h"
+ #include "chrome/common/url_constants.h"
+ #include "content/public/browser/url_data_source.h"
++#include "content/public/test/browser_task_environment.h"
+ #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
++#include "services/network/test/test_shared_url_loader_factory.h"
+ #include "testing/gtest/include/gtest/gtest.h"
+ 
+ namespace {
+@@ -356,3 +360,36 @@
+   ASSERT_TRUE(base::StartsWith(data(), kDevToolsUITest404Response,
+                                base::CompareCase::SENSITIVE));
+ }
++
++class DevToolsUIDataSourceWithTaskEnvTest : public testing::Test {
++ public:
++  DevToolsUIDataSourceWithTaskEnvTest()
++      : task_environment_(content::BrowserTaskEnvironment::IO_MAINLOOP) {}
++
++ private:
++  content::BrowserTaskEnvironment task_environment_;
++};
++
++TEST_F(DevToolsUIDataSourceWithTaskEnvTest,
++       GotDataCallbackOwnsDevToolsDataSource) {
++  scoped_refptr<network::SharedURLLoaderFactory> factory =
++      base::MakeRefCounted<network::TestSharedURLLoaderFactory>();
++  DevToolsDataSource* data_source = new DevToolsDataSource(factory);
++
++  DevToolsDataSource::GotDataCallback callback = base::BindOnce(
++      [](DevToolsDataSource* data_source,
++         scoped_refptr<base::RefCountedMemory> payload) {
++        // Do nothing in the callback.
++      },
++      base::Owned(data_source));
++
++  // `callback` controls the life-time of the data_source now, so data_source is
++  // deleted after the callback is done running. This is similar to what
++  // WebUIURLLoaderFactory is doing.
++
++  const GURL path =
++      DevToolsUrl().Resolve(DevToolsRemotePath(kDevToolsUITestFrontEndUrl));
++  content::WebContents::Getter wc_getter;
++  data_source->StartDataRequest(path, std::move(wc_getter),
++                                std::move(callback));
++}

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -15,3 +15,6 @@ cherry-pick-546e00df97ac.patch
 cherry-pick-f6ddbf42b1ea.patch
 cherry-pick-c605df24af3c.patch
 cherry-pick-f4b66ae451c2.patch
+cherry-pick-cb8697b04426.patch
+cherry-pick-2c8a019f39d2.patch
+cherry-pick-b8020e1973d7.patch

--- a/patches/v8/cherry-pick-2c8a019f39d2.patch
+++ b/patches/v8/cherry-pick-2c8a019f39d2.patch
@@ -1,0 +1,302 @@
+From 2c8a019f39d29b403f881d9b5932e3219fdcc832 Mon Sep 17 00:00:00 2001
+From: Shu-yu Guo <syg@chromium.org>
+Date: Wed, 26 Apr 2023 10:56:03 -0700
+Subject: [PATCH] [regexp] Fix clobbered register in global Unicode special case
+
+Bug: chromium:1439691
+Change-Id: I53f22f484b226b5ad3eb9ffef8a9f44fe962beba
+Fixed: chromium:1439691
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4477629
+Reviewed-by: Jakob Linke <jgruber@chromium.org>
+Commit-Queue: Shu-yu Guo <syg@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#87288}
+---
+
+diff --git a/src/regexp/arm/regexp-macro-assembler-arm.cc b/src/regexp/arm/regexp-macro-assembler-arm.cc
+index 6f1180e..4cf2fcf 100644
+--- a/src/regexp/arm/regexp-macro-assembler-arm.cc
++++ b/src/regexp/arm/regexp-macro-assembler-arm.cc
+@@ -892,19 +892,18 @@
+       __ add(r2, r2, Operand(num_saved_registers_ * kSystemPointerSize));
+       __ str(r2, MemOperand(frame_pointer(), kRegisterOutputOffset));
+ 
+-      // Prepare r0 to initialize registers with its value in the next run.
+-      __ ldr(r0, MemOperand(frame_pointer(), kStringStartMinusOneOffset));
+-
+       // Restore the original regexp stack pointer value (effectively, pop the
+       // stored base pointer).
+       PopRegExpBasePointer(backtrack_stackpointer(), r2);
+ 
++      Label reload_string_start_minus_one;
++
+       if (global_with_zero_length_check()) {
+         // Special case for zero-length matches.
+         // r4: capture start index
+         __ cmp(current_input_offset(), r4);
+         // Not a zero-length match, restart.
+-        __ b(ne, &load_char_start_regexp);
++        __ b(ne, &reload_string_start_minus_one);
+         // Offset from the end is zero if we already reached the end.
+         __ cmp(current_input_offset(), Operand::Zero());
+         __ b(eq, &exit_label_);
+@@ -916,6 +915,11 @@
+         if (global_unicode()) CheckNotInSurrogatePair(0, &advance);
+       }
+ 
++      __ bind(&reload_string_start_minus_one);
++      // Prepare r0 to initialize registers with its value in the next run.
++      // Must be immediately before the jump to avoid clobbering.
++      __ ldr(r0, MemOperand(frame_pointer(), kStringStartMinusOneOffset));
++
+       __ b(&load_char_start_regexp);
+     } else {
+       __ mov(r0, Operand(SUCCESS));
+diff --git a/src/regexp/ia32/regexp-macro-assembler-ia32.cc b/src/regexp/ia32/regexp-macro-assembler-ia32.cc
+index 33f79d3..70037dc 100644
+--- a/src/regexp/ia32/regexp-macro-assembler-ia32.cc
++++ b/src/regexp/ia32/regexp-macro-assembler-ia32.cc
+@@ -937,19 +937,18 @@
+       __ add(Operand(ebp, kRegisterOutputOffset),
+              Immediate(num_saved_registers_ * kSystemPointerSize));
+ 
+-      // Prepare eax to initialize registers with its value in the next run.
+-      __ mov(eax, Operand(ebp, kStringStartMinusOneOffset));
+-
+       // Restore the original regexp stack pointer value (effectively, pop the
+       // stored base pointer).
+       PopRegExpBasePointer(backtrack_stackpointer(), ebx);
+ 
++      Label reload_string_start_minus_one;
++
+       if (global_with_zero_length_check()) {
+         // Special case for zero-length matches.
+         // edx: capture start index
+         __ cmp(edi, edx);
+         // Not a zero-length match, restart.
+-        __ j(not_equal, &load_char_start_regexp);
++        __ j(not_equal, &reload_string_start_minus_one);
+         // edi (offset from the end) is zero if we already reached the end.
+         __ test(edi, edi);
+         __ j(zero, &exit_label_, Label::kNear);
+@@ -963,6 +962,12 @@
+         }
+         if (global_unicode()) CheckNotInSurrogatePair(0, &advance);
+       }
++
++      __ bind(&reload_string_start_minus_one);
++      // Prepare eax to initialize registers with its value in the next run.
++      // Must be immediately before the jump to avoid clobbering.
++      __ mov(eax, Operand(ebp, kStringStartMinusOneOffset));
++
+       __ jmp(&load_char_start_regexp);
+     } else {
+       __ mov(eax, Immediate(SUCCESS));
+diff --git a/src/regexp/loong64/regexp-macro-assembler-loong64.cc b/src/regexp/loong64/regexp-macro-assembler-loong64.cc
+index 66a6d9f..232c868 100644
+--- a/src/regexp/loong64/regexp-macro-assembler-loong64.cc
++++ b/src/regexp/loong64/regexp-macro-assembler-loong64.cc
+@@ -865,18 +865,17 @@
+         __ Add_d(a2, a2, num_saved_registers_ * kIntSize);
+         __ St_d(a2, MemOperand(frame_pointer(), kRegisterOutputOffset));
+ 
+-        // Prepare a0 to initialize registers with its value in the next run.
+-        __ Ld_d(a0, MemOperand(frame_pointer(), kStringStartMinusOneOffset));
+-
+         // Restore the original regexp stack pointer value (effectively, pop the
+         // stored base pointer).
+         PopRegExpBasePointer(backtrack_stackpointer(), a2);
+ 
++        Label reload_string_start_minus_one;
++
+         if (global_with_zero_length_check()) {
+           // Special case for zero-length matches.
+           // t3: capture start index
+           // Not a zero-length match, restart.
+-          __ Branch(&load_char_start_regexp, ne, current_input_offset(),
++          __ Branch(&reload_string_start_minus_one, ne, current_input_offset(),
+                     Operand(t3));
+           // Offset from the end is zero if we already reached the end.
+           __ Branch(&exit_label_, eq, current_input_offset(),
+@@ -889,6 +888,11 @@
+           if (global_unicode()) CheckNotInSurrogatePair(0, &advance);
+         }
+ 
++        __ bind(&reload_string_start_minus_one);
++        // Prepare a0 to initialize registers with its value in the next run.
++        // Must be immediately before the jump to avoid clobbering.
++        __ Ld_d(a0, MemOperand(frame_pointer(), kStringStartMinusOneOffset));
++
+         __ Branch(&load_char_start_regexp);
+       } else {
+         __ li(a0, Operand(SUCCESS));
+diff --git a/src/regexp/mips64/regexp-macro-assembler-mips64.cc b/src/regexp/mips64/regexp-macro-assembler-mips64.cc
+index 4818a43..eac2c7c 100644
+--- a/src/regexp/mips64/regexp-macro-assembler-mips64.cc
++++ b/src/regexp/mips64/regexp-macro-assembler-mips64.cc
+@@ -911,19 +911,18 @@
+         __ Daddu(a2, a2, num_saved_registers_ * kIntSize);
+         __ Sd(a2, MemOperand(frame_pointer(), kRegisterOutputOffset));
+ 
+-        // Prepare a0 to initialize registers with its value in the next run.
+-        __ Ld(a0, MemOperand(frame_pointer(), kStringStartMinusOneOffset));
+-
+         // Restore the original regexp stack pointer value (effectively, pop the
+         // stored base pointer).
+         PopRegExpBasePointer(backtrack_stackpointer(), a2);
+ 
++        Label reload_string_start_minus_one;
++
+         if (global_with_zero_length_check()) {
+           // Special case for zero-length matches.
+           // t3: capture start index
+           // Not a zero-length match, restart.
+-          __ Branch(
+-              &load_char_start_regexp, ne, current_input_offset(), Operand(t3));
++          __ Branch(&reload_string_start_minus_one, ne, current_input_offset(),
++                    Operand(t3));
+           // Offset from the end is zero if we already reached the end.
+           __ Branch(&exit_label_, eq, current_input_offset(),
+                     Operand(zero_reg));
+@@ -935,6 +934,11 @@
+           if (global_unicode()) CheckNotInSurrogatePair(0, &advance);
+         }
+ 
++        __ bind(&reload_string_start_minus_one);
++        // Prepare a0 to initialize registers with its value in the next run.
++        // Must be immediately before the jump to avoid clobbering.
++        __ Ld(a0, MemOperand(frame_pointer(), kStringStartMinusOneOffset));
++
+         __ Branch(&load_char_start_regexp);
+       } else {
+         __ li(v0, Operand(SUCCESS));
+diff --git a/src/regexp/riscv/regexp-macro-assembler-riscv.cc b/src/regexp/riscv/regexp-macro-assembler-riscv.cc
+index fbe2b71..95d004a 100644
+--- a/src/regexp/riscv/regexp-macro-assembler-riscv.cc
++++ b/src/regexp/riscv/regexp-macro-assembler-riscv.cc
+@@ -876,19 +876,17 @@
+         __ AddWord(a2, a2, num_saved_registers_ * kIntSize);
+         __ StoreWord(a2, MemOperand(frame_pointer(), kRegisterOutputOffset));
+ 
+-        // Prepare a0 to initialize registers with its value in the next run.
+-        __ LoadWord(a0,
+-                    MemOperand(frame_pointer(), kStringStartMinusOneOffset));
+-
+         // Restore the original regexp stack pointer value (effectively, pop the
+         // stored base pointer).
+         PopRegExpBasePointer(backtrack_stackpointer(), a2);
+ 
++        Label reload_string_start_minus_one;
++
+         if (global_with_zero_length_check()) {
+           // Special case for zero-length matches.
+           // s3: capture start index
+           // Not a zero-length match, restart.
+-          __ Branch(&load_char_start_regexp, ne, current_input_offset(),
++          __ Branch(&reload_string_start_minus_one, ne, current_input_offset(),
+                     Operand(s3));
+           // Offset from the end is zero if we already reached the end.
+           __ Branch(&exit_label_, eq, current_input_offset(),
+@@ -901,6 +899,12 @@
+           if (global_unicode()) CheckNotInSurrogatePair(0, &advance);
+         }
+ 
++        __ bind(&reload_string_start_minus_one);
++        // Prepare a0 to initialize registers with its value in the next run.
++        // Must be immediately before the jump to avoid clobbering.
++        __ LoadWord(a0,
++                    MemOperand(frame_pointer(), kStringStartMinusOneOffset));
++
+         __ Branch(&load_char_start_regexp);
+       } else {
+         __ li(a0, Operand(SUCCESS));
+diff --git a/src/regexp/s390/regexp-macro-assembler-s390.cc b/src/regexp/s390/regexp-macro-assembler-s390.cc
+index 525fc32..5c207f3 100644
+--- a/src/regexp/s390/regexp-macro-assembler-s390.cc
++++ b/src/regexp/s390/regexp-macro-assembler-s390.cc
+@@ -953,19 +953,18 @@
+       __ AddS64(r4, Operand(num_saved_registers_ * kIntSize));
+       __ StoreU64(r4, MemOperand(frame_pointer(), kRegisterOutputOffset));
+ 
+-      // Prepare r2 to initialize registers with its value in the next run.
+-      __ LoadU64(r2, MemOperand(frame_pointer(), kStringStartMinusOneOffset));
+-
+       // Restore the original regexp stack pointer value (effectively, pop the
+       // stored base pointer).
+       PopRegExpBasePointer(backtrack_stackpointer(), r4);
+ 
++      Label reload_string_start_minus_one;
++
+       if (global_with_zero_length_check()) {
+         // Special case for zero-length matches.
+         // r6: capture start index
+         __ CmpS64(current_input_offset(), r6);
+         // Not a zero-length match, restart.
+-        __ bne(&load_char_start_regexp);
++        __ bne(&reload_string_start_minus_one);
+         // Offset from the end is zero if we already reached the end.
+         __ CmpS64(current_input_offset(), Operand::Zero());
+         __ beq(&exit_label_);
+@@ -976,6 +975,11 @@
+         if (global_unicode()) CheckNotInSurrogatePair(0, &advance);
+       }
+ 
++      __ bind(&reload_string_start_minus_one);
++      // Prepare r2 to initialize registers with its value in the next run.
++      // Must be immediately before the jump to avoid clobbering.
++      __ LoadU64(r2, MemOperand(frame_pointer(), kStringStartMinusOneOffset));
++
+       __ b(&load_char_start_regexp);
+     } else {
+       __ mov(r2, Operand(SUCCESS));
+diff --git a/src/regexp/x64/regexp-macro-assembler-x64.cc b/src/regexp/x64/regexp-macro-assembler-x64.cc
+index 90ff269..53b2f5a 100644
+--- a/src/regexp/x64/regexp-macro-assembler-x64.cc
++++ b/src/regexp/x64/regexp-macro-assembler-x64.cc
+@@ -976,19 +976,18 @@
+       __ addq(Operand(rbp, kRegisterOutputOffset),
+               Immediate(num_saved_registers_ * kIntSize));
+ 
+-      // Prepare rax to initialize registers with its value in the next run.
+-      __ movq(rax, Operand(rbp, kStringStartMinusOneOffset));
+-
+       // Restore the original regexp stack pointer value (effectively, pop the
+       // stored base pointer).
+       PopRegExpBasePointer(backtrack_stackpointer(), kScratchRegister);
+ 
++      Label reload_string_start_minus_one;
++
+       if (global_with_zero_length_check()) {
+         // Special case for zero-length matches.
+         // rdx: capture start index
+         __ cmpq(rdi, rdx);
+         // Not a zero-length match, restart.
+-        __ j(not_equal, &load_char_start_regexp);
++        __ j(not_equal, &reload_string_start_minus_one);
+         // rdi (offset from the end) is zero if we already reached the end.
+         __ testq(rdi, rdi);
+         __ j(zero, &exit_label_, Label::kNear);
+@@ -1003,6 +1002,11 @@
+         if (global_unicode()) CheckNotInSurrogatePair(0, &advance);
+       }
+ 
++      __ bind(&reload_string_start_minus_one);
++      // Prepare rax to initialize registers with its value in the next run.
++      // Must be immediately before the jump to avoid clobbering.
++      __ movq(rax, Operand(rbp, kStringStartMinusOneOffset));
++
+       __ jmp(&load_char_start_regexp);
+     } else {
+       __ Move(rax, SUCCESS);
+diff --git a/test/mjsunit/regress/regress-crbug-1439691.js b/test/mjsunit/regress/regress-crbug-1439691.js
+new file mode 100644
+index 0000000..6c55835
+--- /dev/null
++++ b/test/mjsunit/regress/regress-crbug-1439691.js
+@@ -0,0 +1,7 @@
++// Copyright 2023 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++function f0() {
++}
++/(?!(a))\1/gudyi[Symbol.replace]("f\uD83D\uDCA9ba\u2603", f0);

--- a/patches/v8/cherry-pick-b8020e1973d7.patch
+++ b/patches/v8/cherry-pick-b8020e1973d7.patch
@@ -1,0 +1,359 @@
+From b8020e1973d7d3a50b17c076cd948f079e59f9e5 Mon Sep 17 00:00:00 2001
+From: Igor Sheludko <ishell@chromium.org>
+Date: Thu, 27 Apr 2023 11:11:32 +0200
+Subject: [PATCH] [api] Fix v8::Object::SetAccessorProperty
+
+... by using JavaScript spec compliant JSReceiver::DefineOwnProperty.
+
+Drive-by:
+- cleanup comments in include/v8-object.h, insert links to
+respective pages of https://tc39.es/ecma262/ when referencing spec,
+- rename JSObject::DefineAccessor() to
+  JSObject::DefineOwnAccessorIgnoreAttributes().
+
+Bug: chromium:1433211
+Change-Id: Ia9edaadd68f1986f18581156ad8f79c438b77744
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4458947
+Commit-Queue: Igor Sheludko <ishell@chromium.org>
+Reviewed-by: Toon Verwaest <verwaest@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#87302}
+---
+
+diff --git a/include/v8-object.h b/include/v8-object.h
+index 6c03d63..6954c00 100644
+--- a/include/v8-object.h
++++ b/include/v8-object.h
+@@ -247,13 +247,16 @@
+   V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context, uint32_t index,
+                                         Local<Value> value);
+ 
+-  // Implements CreateDataProperty (ECMA-262, 7.3.4).
+-  //
+-  // Defines a configurable, writable, enumerable property with the given value
+-  // on the object unless the property already exists and is not configurable
+-  // or the object is not extensible.
+-  //
+-  // Returns true on success.
++  /**
++   * Implements CreateDataProperty(O, P, V), see
++   * https://tc39.es/ecma262/#sec-createdataproperty.
++   *
++   * Defines a configurable, writable, enumerable property with the given value
++   * on the object unless the property already exists and is not configurable
++   * or the object is not extensible.
++   *
++   * Returns true on success.
++   */
+   V8_WARN_UNUSED_RESULT Maybe<bool> CreateDataProperty(Local<Context> context,
+                                                        Local<Name> key,
+                                                        Local<Value> value);
+@@ -261,29 +264,35 @@
+                                                        uint32_t index,
+                                                        Local<Value> value);
+ 
+-  // Implements DefineOwnProperty.
+-  //
+-  // In general, CreateDataProperty will be faster, however, does not allow
+-  // for specifying attributes.
+-  //
+-  // Returns true on success.
++  /**
++   * Implements [[DefineOwnProperty]] for data property case, see
++   * https://tc39.es/ecma262/#table-essential-internal-methods.
++   *
++   * In general, CreateDataProperty will be faster, however, does not allow
++   * for specifying attributes.
++   *
++   * Returns true on success.
++   */
+   V8_WARN_UNUSED_RESULT Maybe<bool> DefineOwnProperty(
+       Local<Context> context, Local<Name> key, Local<Value> value,
+       PropertyAttribute attributes = None);
+ 
+-  // Implements Object.DefineProperty(O, P, Attributes), see Ecma-262 19.1.2.4.
+-  //
+-  // The defineProperty function is used to add an own property or
+-  // update the attributes of an existing own property of an object.
+-  //
+-  // Both data and accessor descriptors can be used.
+-  //
+-  // In general, CreateDataProperty is faster, however, does not allow
+-  // for specifying attributes or an accessor descriptor.
+-  //
+-  // The PropertyDescriptor can change when redefining a property.
+-  //
+-  // Returns true on success.
++  /**
++   * Implements Object.defineProperty(O, P, Attributes), see
++   * https://tc39.es/ecma262/#sec-object.defineproperty.
++   *
++   * The defineProperty function is used to add an own property or
++   * update the attributes of an existing own property of an object.
++   *
++   * Both data and accessor descriptors can be used.
++   *
++   * In general, CreateDataProperty is faster, however, does not allow
++   * for specifying attributes or an accessor descriptor.
++   *
++   * The PropertyDescriptor can change when redefining a property.
++   *
++   * Returns true on success.
++   */
+   V8_WARN_UNUSED_RESULT Maybe<bool> DefineProperty(
+       Local<Context> context, Local<Name> key, PropertyDescriptor& descriptor);
+ 
+@@ -302,14 +311,15 @@
+       Local<Context> context, Local<Value> key);
+ 
+   /**
+-   * Returns Object.getOwnPropertyDescriptor as per ES2016 section 19.1.2.6.
++   * Implements Object.getOwnPropertyDescriptor(O, P), see
++   * https://tc39.es/ecma262/#sec-object.getownpropertydescriptor.
+    */
+   V8_WARN_UNUSED_RESULT MaybeLocal<Value> GetOwnPropertyDescriptor(
+       Local<Context> context, Local<Name> key);
+ 
+   /**
+-   * Object::Has() calls the abstract operation HasProperty(O, P) described
+-   * in ECMA-262, 7.3.10. Has() returns
++   * Object::Has() calls the abstract operation HasProperty(O, P), see
++   * https://tc39.es/ecma262/#sec-hasproperty. Has() returns
+    * true, if the object has the property, either own or on the prototype chain.
+    * Interceptors, i.e., PropertyQueryCallbacks, are called if present.
+    *
+@@ -347,7 +357,7 @@
+ 
+   void SetAccessorProperty(Local<Name> name, Local<Function> getter,
+                            Local<Function> setter = Local<Function>(),
+-                           PropertyAttribute attribute = None,
++                           PropertyAttribute attributes = None,
+                            AccessControl settings = DEFAULT);
+ 
+   /**
+diff --git a/src/api/api-natives.cc b/src/api/api-natives.cc
+index 1ce33d5..f4fe0ae 100644
+--- a/src/api/api-natives.cc
++++ b/src/api/api-natives.cc
+@@ -97,10 +97,10 @@
+     Handle<Code> trampoline = BUILTIN_CODE(isolate, DebugBreakTrampoline);
+     Handle<JSFunction>::cast(setter)->set_code(*trampoline);
+   }
+-  RETURN_ON_EXCEPTION(
+-      isolate,
+-      JSObject::DefineAccessor(object, name, getter, setter, attributes),
+-      Object);
++  RETURN_ON_EXCEPTION(isolate,
++                      JSObject::DefineOwnAccessorIgnoreAttributes(
++                          object, name, getter, setter, attributes),
++                      Object);
+   return object;
+ }
+ 
+diff --git a/src/api/api.cc b/src/api/api.cc
+index 8113cf7..6f70ee5 100644
+--- a/src/api/api.cc
++++ b/src/api/api.cc
+@@ -5138,7 +5138,7 @@
+ 
+ void Object::SetAccessorProperty(Local<Name> name, Local<Function> getter,
+                                  Local<Function> setter,
+-                                 PropertyAttribute attribute,
++                                 PropertyAttribute attributes,
+                                  AccessControl settings) {
+   // TODO(verwaest): Remove |settings|.
+   DCHECK_EQ(v8::DEFAULT, settings);
+@@ -5150,9 +5150,20 @@
+   i::Handle<i::Object> getter_i = v8::Utils::OpenHandle(*getter);
+   i::Handle<i::Object> setter_i = v8::Utils::OpenHandle(*setter, true);
+   if (setter_i.is_null()) setter_i = i_isolate->factory()->null_value();
+-  i::JSObject::DefineAccessor(i::Handle<i::JSObject>::cast(self),
+-                              v8::Utils::OpenHandle(*name), getter_i, setter_i,
+-                              static_cast<i::PropertyAttributes>(attribute));
++
++  i::PropertyDescriptor desc;
++  desc.set_enumerable(!(attributes & v8::DontEnum));
++  desc.set_configurable(!(attributes & v8::DontDelete));
++  desc.set_get(getter_i);
++  desc.set_set(setter_i);
++
++  i::Handle<i::Name> name_i = v8::Utils::OpenHandle(*name);
++  // DefineOwnProperty might still throw if the receiver is a JSProxy and it
++  // might fail if the receiver is non-extensible or already has this property
++  // as non-configurable.
++  Maybe<bool> success = i::JSReceiver::DefineOwnProperty(
++      i_isolate, self, name_i, &desc, Just(i::kDontThrow));
++  USE(success);
+ }
+ 
+ Maybe<bool> Object::SetNativeDataProperty(
+diff --git a/src/init/bootstrapper.cc b/src/init/bootstrapper.cc
+index 05ac99f..7a63bf6 100644
+--- a/src/init/bootstrapper.cc
++++ b/src/init/bootstrapper.cc
+@@ -638,7 +638,9 @@
+   Handle<JSFunction> setter =
+       SimpleCreateFunction(isolate, setter_name, call_setter, 1, true);
+ 
+-  JSObject::DefineAccessor(base, name, getter, setter, DONT_ENUM).Check();
++  JSObject::DefineOwnAccessorIgnoreAttributes(base, name, getter, setter,
++                                              DONT_ENUM)
++      .Check();
+ }
+ 
+ void SimpleInstallGetterSetter(Isolate* isolate, Handle<JSObject> base,
+@@ -662,7 +664,8 @@
+ 
+   Handle<Object> setter = isolate->factory()->undefined_value();
+ 
+-  JSObject::DefineAccessor(base, property_name, getter, setter, DONT_ENUM)
++  JSObject::DefineOwnAccessorIgnoreAttributes(base, property_name, getter,
++                                              setter, DONT_ENUM)
+       .Check();
+ 
+   return getter;
+diff --git a/src/objects/js-objects.cc b/src/objects/js-objects.cc
+index 8fbf7a1..f3a45f1 100644
+--- a/src/objects/js-objects.cc
++++ b/src/objects/js-objects.cc
+@@ -1541,7 +1541,8 @@
+                 ? desc->set()
+                 : Handle<Object>::cast(isolate->factory()->null_value()));
+         MaybeHandle<Object> result =
+-            JSObject::DefineAccessor(it, getter, setter, desc->ToAttributes());
++            JSObject::DefineOwnAccessorIgnoreAttributes(it, getter, setter,
++                                                        desc->ToAttributes());
+         if (result.is_null()) return Nothing<bool>();
+       }
+     }
+@@ -1725,8 +1726,8 @@
+               : current->has_set()
+                     ? current->set()
+                     : Handle<Object>::cast(isolate->factory()->null_value()));
+-      MaybeHandle<Object> result =
+-          JSObject::DefineAccessor(it, getter, setter, attrs);
++      MaybeHandle<Object> result = JSObject::DefineOwnAccessorIgnoreAttributes(
++          it, getter, setter, attrs);
+       if (result.is_null()) return Nothing<bool>();
+     }
+   }
+@@ -4703,22 +4704,19 @@
+   UNREACHABLE();
+ }
+ 
+-MaybeHandle<Object> JSObject::DefineAccessor(Handle<JSObject> object,
+-                                             Handle<Name> name,
+-                                             Handle<Object> getter,
+-                                             Handle<Object> setter,
+-                                             PropertyAttributes attributes) {
++MaybeHandle<Object> JSObject::DefineOwnAccessorIgnoreAttributes(
++    Handle<JSObject> object, Handle<Name> name, Handle<Object> getter,
++    Handle<Object> setter, PropertyAttributes attributes) {
+   Isolate* isolate = object->GetIsolate();
+ 
+   PropertyKey key(isolate, name);
+   LookupIterator it(isolate, object, key, LookupIterator::OWN_SKIP_INTERCEPTOR);
+-  return DefineAccessor(&it, getter, setter, attributes);
++  return DefineOwnAccessorIgnoreAttributes(&it, getter, setter, attributes);
+ }
+ 
+-MaybeHandle<Object> JSObject::DefineAccessor(LookupIterator* it,
+-                                             Handle<Object> getter,
+-                                             Handle<Object> setter,
+-                                             PropertyAttributes attributes) {
++MaybeHandle<Object> JSObject::DefineOwnAccessorIgnoreAttributes(
++    LookupIterator* it, Handle<Object> getter, Handle<Object> setter,
++    PropertyAttributes attributes) {
+   Isolate* isolate = it->isolate();
+ 
+   it->UpdateProtector();
+diff --git a/src/objects/js-objects.h b/src/objects/js-objects.h
+index 80a64a6..870eb81 100644
+--- a/src/objects/js-objects.h
++++ b/src/objects/js-objects.h
+@@ -538,13 +538,14 @@
+   GetPropertyAttributesWithFailedAccessCheck(LookupIterator* it);
+ 
+   // Defines an AccessorPair property on the given object.
+-  V8_EXPORT_PRIVATE static MaybeHandle<Object> DefineAccessor(
+-      Handle<JSObject> object, Handle<Name> name, Handle<Object> getter,
+-      Handle<Object> setter, PropertyAttributes attributes);
+-  static MaybeHandle<Object> DefineAccessor(LookupIterator* it,
+-                                            Handle<Object> getter,
+-                                            Handle<Object> setter,
+-                                            PropertyAttributes attributes);
++  V8_EXPORT_PRIVATE static MaybeHandle<Object>
++  DefineOwnAccessorIgnoreAttributes(Handle<JSObject> object, Handle<Name> name,
++                                    Handle<Object> getter,
++                                    Handle<Object> setter,
++                                    PropertyAttributes attributes);
++  static MaybeHandle<Object> DefineOwnAccessorIgnoreAttributes(
++      LookupIterator* it, Handle<Object> getter, Handle<Object> setter,
++      PropertyAttributes attributes);
+ 
+   // Defines an AccessorInfo property on the given object.
+   V8_WARN_UNUSED_RESULT static MaybeHandle<Object> SetAccessor(
+diff --git a/src/runtime/runtime-object.cc b/src/runtime/runtime-object.cc
+index d72c1fd..c83ee5e 100644
+--- a/src/runtime/runtime-object.cc
++++ b/src/runtime/runtime-object.cc
+@@ -1082,7 +1082,8 @@
+   auto attrs = PropertyAttributesFromInt(args.smi_value_at(4));
+ 
+   RETURN_FAILURE_ON_EXCEPTION(
+-      isolate, JSObject::DefineAccessor(obj, name, getter, setter, attrs));
++      isolate, JSObject::DefineOwnAccessorIgnoreAttributes(obj, name, getter,
++                                                           setter, attrs));
+   return ReadOnlyRoots(isolate).undefined_value();
+ }
+ 
+@@ -1209,8 +1210,8 @@
+ 
+   RETURN_FAILURE_ON_EXCEPTION(
+       isolate,
+-      JSObject::DefineAccessor(object, name, getter,
+-                               isolate->factory()->null_value(), attrs));
++      JSObject::DefineOwnAccessorIgnoreAttributes(
++          object, name, getter, isolate->factory()->null_value(), attrs));
+   return ReadOnlyRoots(isolate).undefined_value();
+ }
+ 
+@@ -1354,8 +1355,8 @@
+ 
+   RETURN_FAILURE_ON_EXCEPTION(
+       isolate,
+-      JSObject::DefineAccessor(object, name, isolate->factory()->null_value(),
+-                               setter, attrs));
++      JSObject::DefineOwnAccessorIgnoreAttributes(
++          object, name, isolate->factory()->null_value(), setter, attrs));
+   return ReadOnlyRoots(isolate).undefined_value();
+ }
+ 
+diff --git a/src/sandbox/testing.cc b/src/sandbox/testing.cc
+index adf8696..0dec24c 100644
+--- a/src/sandbox/testing.cc
++++ b/src/sandbox/testing.cc
+@@ -160,7 +160,8 @@
+   Handle<String> property_name = factory->NewStringFromAsciiChecked(name);
+   Handle<JSFunction> getter = CreateFunc(isolate, func, property_name, false);
+   Handle<Object> setter = factory->null_value();
+-  JSObject::DefineAccessor(object, property_name, getter, setter, FROZEN);
++  JSObject::DefineOwnAccessorIgnoreAttributes(object, property_name, getter,
++                                              setter, FROZEN);
+ }
+ 
+ void InstallFunction(Isolate* isolate, Handle<JSObject> holder,
+diff --git a/test/cctest/test-code-stub-assembler.cc b/test/cctest/test-code-stub-assembler.cc
+index 5efe528..4c2c8ed 100644
+--- a/test/cctest/test-code-stub-assembler.cc
++++ b/test/cctest/test-code-stub-assembler.cc
+@@ -1178,7 +1178,9 @@
+       Handle<AccessorPair> pair = Handle<AccessorPair>::cast(value);
+       Handle<Object> getter(pair->getter(), isolate);
+       Handle<Object> setter(pair->setter(), isolate);
+-      JSObject::DefineAccessor(object, names[i], getter, setter, NONE).Check();
++      JSObject::DefineOwnAccessorIgnoreAttributes(object, names[i], getter,
++                                                  setter, NONE)
++          .Check();
+     } else {
+       JSObject::AddProperty(isolate, object, names[i], value, NONE);
+     }

--- a/patches/v8/cherry-pick-cb8697b04426.patch
+++ b/patches/v8/cherry-pick-cb8697b04426.patch
@@ -1,0 +1,75 @@
+From cb8697b04426ca11233b6efa98bd18cc4c932ded Mon Sep 17 00:00:00 2001
+From: pthier <pthier@chromium.org>
+Date: Tue, 25 Apr 2023 14:04:28 +0200
+Subject: [PATCH] Reland "[regexp] Handle empty ranges in unicode sets"
+
+This is a reland of commit 91fce33456683ec1d132c645ce927f9bdf92637e
+
+Changes since revert:
+- Skip added test in no-internalization builds.
+
+Original change's description:
+> [regexp] Handle empty ranges in unicode sets
+>
+> If a unicode set operation contains only an empty range, we generated a
+> set expression without operands. However the expression should match
+> nothing, so add the special operand not matching anything instead.
+>
+> Bug: chromium:1437346
+> Change-Id: I8dd58884aaf6915277c80effbda43ea715049146
+> Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4474547
+> Commit-Queue: Patrick Thier <pthier@chromium.org>
+> Reviewed-by: Jakob Linke <jgruber@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#87257}
+
+Bug: chromium:1437346
+Change-Id: I60a19a6feb72a82873e3c82ca0a3d3d38bbc1ad9
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4474551
+Auto-Submit: Patrick Thier <pthier@chromium.org>
+Reviewed-by: Jakob Linke <jgruber@chromium.org>
+Commit-Queue: Jakob Linke <jgruber@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#87268}
+---
+
+diff --git a/src/regexp/regexp-parser.cc b/src/regexp/regexp-parser.cc
+index ef7ae24..8d27289 100644
+--- a/src/regexp/regexp-parser.cc
++++ b/src/regexp/regexp-parser.cc
+@@ -2774,6 +2774,14 @@
+     return ReportError(RegExpError::kNegatedCharacterClassWithStrings);
+   }
+ 
++  if (operands->is_empty()) {
++    // Return empty expression if no operands were added (e.g. [\P{Any}]
++    // produces an empty range).
++    DCHECK(ranges->is_empty());
++    DCHECK(strings->empty());
++    return RegExpClassSetExpression::Empty(zone(), is_negated);
++  }
++
+   return zone()->template New<RegExpClassSetExpression>(
+       RegExpClassSetExpression::OperationType::kUnion, is_negated,
+       may_contain_strings, operands);
+diff --git a/test/mjsunit/mjsunit.status b/test/mjsunit/mjsunit.status
+index 0014d43..9e49533 100644
+--- a/test/mjsunit/mjsunit.status
++++ b/test/mjsunit/mjsunit.status
+@@ -500,6 +500,7 @@
+   'harmony/regexp-property-*': [PASS,FAIL],
+   'regress/regress-1262423': [PASS,FAIL],
+   'regress/regress-793588': [PASS,FAIL],
++  'regress/regress-crbug-1437346': [PASS,FAIL],
+ 
+   # RegExp unicode tests relies on ICU for property classes and
+   # case-insensitive unicode patterns.
+diff --git a/test/mjsunit/regress/regress-crbug-1437346.js b/test/mjsunit/regress/regress-crbug-1437346.js
+new file mode 100644
+index 0000000..d94789c
+--- /dev/null
++++ b/test/mjsunit/regress/regress-crbug-1437346.js
+@@ -0,0 +1,5 @@
++// Copyright 2023 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++assertFalse(/[\P{Any}]/v.test());


### PR DESCRIPTION
<details>
<summary>undefined - cb8697b04426 from v8</summary>
Reland "[regexp] Handle empty ranges in unicode sets"

This is a reland of commit 91fce33456683ec1d132c645ce927f9bdf92637e

Changes since revert:
- Skip added test in no-internalization builds.

Original change's description:
> [regexp] Handle empty ranges in unicode sets
>
> If a unicode set operation contains only an empty range, we generated a
> set expression without operands. However the expression should match
> nothing, so add the special operand not matching anything instead.
>
> Bug: chromium:1437346
> Change-Id: I8dd58884aaf6915277c80effbda43ea715049146
> Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4474547
> Commit-Queue: Patrick Thier <pthier@chromium.org>
> Reviewed-by: Jakob Linke <jgruber@chromium.org>
> Cr-Commit-Position: refs/heads/main@{#87257}

Bug: chromium:1437346
Change-Id: I60a19a6feb72a82873e3c82ca0a3d3d38bbc1ad9
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4474551
Auto-Submit: Patrick Thier <pthier@chromium.org>
Reviewed-by: Jakob Linke <jgruber@chromium.org>
Commit-Queue: Jakob Linke <jgruber@chromium.org>
Cr-Commit-Position: refs/heads/main@{#87268}
</details>

<details>
<summary>undefined - 2c8a019f39d2 from v8</summary>
[regexp] Fix clobbered register in global Unicode special case

Bug: chromium:1439691
Change-Id: I53f22f484b226b5ad3eb9ffef8a9f44fe962beba
Fixed: chromium:1439691
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4477629
Reviewed-by: Jakob Linke <jgruber@chromium.org>
Commit-Queue: Shu-yu Guo <syg@chromium.org>
Cr-Commit-Position: refs/heads/main@{#87288}
</details>

<details>
<summary>undefined - b8020e1973d7 from v8</summary>
[api] Fix v8::Object::SetAccessorProperty

... by using JavaScript spec compliant JSReceiver::DefineOwnProperty.

Drive-by:
- cleanup comments in include/v8-object.h, insert links to
respective pages of https://tc39.es/ecma262/ when referencing spec,
- rename JSObject::DefineAccessor() to
  JSObject::DefineOwnAccessorIgnoreAttributes().

Bug: chromium:1433211
Change-Id: Ia9edaadd68f1986f18581156ad8f79c438b77744
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4458947
Commit-Queue: Igor Sheludko <ishell@chromium.org>
Reviewed-by: Toon Verwaest <verwaest@chromium.org>
Cr-Commit-Position: refs/heads/main@{#87302}
</details>

<details>
<summary>undefined - d6272b794cbb from chromium</summary>
[devtools] Delete PendingRequest first in DevToolsDataSource

The way URLDataSources are used in Chromium, it can happen that the
"content::URLDataSource::GotDataCallback" closure is the last shared
owner of the data source itself. This means that the URLDataSource
is deleted after the callback is done running.

This CL fixes an invalid access to DevToolsDataSource, where we
access `this` in the OnLoadComplete method after we call the
GotDataCallback.

R=dsv@chromium.org

Fixed: 1435166
Change-Id: I32e4a717ca27bc011449c8f8efeaffe70aaa8898
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4487280
Reviewed-by: Andrey Kosyakov <caseq@chromium.org>
Commit-Queue: Simon Zünd <szuend@chromium.org>
Reviewed-by: Danil Somsikov <dsv@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1138173}
</details>

<details>
<summary>undefined - 48785f698b1c from chromium</summary>
Avoid buffer overflow read in HFSReadNextNonIgnorableCodePoint

Unicode codepoints goes beyond 0xFFFF.

It exists upper and lower case characters there: `𞤡 `vs `𞥃`.

The buffer overflow occurred when using the lookup table:
```
lower_case_table[codepoint >> 8]
```

Bug: 1425115
Fixed: 1425115
Change-Id: I679da02dbe570283a68176fbd3c0c620caa4f9ce
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4481260
Reviewed-by: Alexander Timin <altimin@chromium.org>
Commit-Queue: Arthur Sonzogni <arthursonzogni@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1138234}
</details>

<details>
<summary>undefined - d0ee0197ddff from angle</summary>
WebGL: Limit total size of private data

... not just individual arrays.

Bug: chromium:1431761
Change-Id: I721e29aeceeaf12c3f6a67b668abffb8dfbc89b0
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/4503753
Reviewed-by: Kenneth Russell <kbr@chromium.org>
Commit-Queue: Shahbaz Youssefi <syoussefi@chromium.org>
</details>

<details>
<summary>undefined - 9b6ca211234b from chromium</summary>
M114: Store BrowserPluginGuestDelegate as a weak ptr

Store BrowserPluginGuestDelegate as a weak ptr

In the case where a webview creates a popup window, the opener web
contents temporarily owns the new guest web contents between the
renderer creating and showing the window. If the opener is destroyed at
this time, the new guest (WebViewGuest) is destroyed as well. Due to
the ordering of the destruction of the new guest web contents, it may
attempt to access the destroyed WebViewGuest through the delegate
interface. We now access this delegate through a weak ptr.

(cherry picked from commit db32d6929cf3177b52b034541e5bd6d3e19e18ca)

Low-Coverage-Reason: NOTREACHED
Bug: 1442516
Change-Id: I417431ad487bc9db0551c1e0363379c5ff455d59
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4515455
Reviewed-by: Alex Moshchuk <alexmos@chromium.org>
Reviewed-by: James Maclean <wjmaclean@chromium.org>
Commit-Queue: Kevin McNee <mcnee@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1141602}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4528155
Auto-Submit: Kevin McNee <mcnee@chromium.org>
Commit-Queue: Alex Moshchuk <alexmos@chromium.org>
Cr-Commit-Position: refs/branch-heads/5735@{#540}
Cr-Branched-From: 2f562e4ddbaf79a3f3cb338b4d1bd4398d49eb67-refs/heads/main@{#1135570}
</details>

<details>
<summary>undefined - 675562695049 from chromium</summary>
[M114] Return after ReadyCommitNavigation call in CommitErrorPage if it deletes NavigationRequest

NavigationRequest::ReadyToCommitNavigation() can cause deletion of the
NavigationRequest, so callers should check for that possibility after
calling the function. A caller in CommitErrorPage is missing that
check, which this CL adds, along with a regression test.

(cherry picked from commit 42db806805ef2be64ee92803d3a784631b2a7df0)

Bug: 1444360
Change-Id: I3964da4909a6709b7730d25d6497b19c098f4f21
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4520493
Commit-Queue: Charlie Reis <creis@chromium.org>
Reviewed-by: Charlie Reis <creis@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1143298}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4531446
Reviewed-by: Prudhvikumar Bommana <pbommana@google.com>
Commit-Queue: Rakina Zata Amni <rakina@chromium.org>
Commit-Queue: Prudhvikumar Bommana <pbommana@google.com>
Owners-Override: Prudhvikumar Bommana <pbommana@google.com>
Cr-Commit-Position: refs/branch-heads/5735@{#607}
Cr-Branched-From: 2f562e4ddbaf79a3f3cb338b4d1bd4398d49eb67-refs/heads/main@{#1135570}
</details>

Notes:
* Security: backported fix for 1437346.
* Security: backported fix for 1439691.
* Security: backported fix for CVE-2023-2724.
* Security: backported fix for CVE-2023-2723.
* Security: backported fix for 1425115.
* Security: backported fix for 1431761.
* Security: backported fix for CVE-2023-2725.
* Security: backported fix for CVE-2023-2721.