### PR TITLE
docs: fix typing of dialog type value

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -223,10 +223,10 @@ expanding and collapsing the dialog.
 * `browserWindow` [BrowserWindow](browser-window.md) (optional)
 * `options` Object
   * `message` string - Content of the message box.
-  * `type` string (optional) - Can be `"none"`, `"info"`, `"error"`, `"question"` or
-  `"warning"`. On Windows, `"question"` displays the same icon as `"info"`, unless
-  you set an icon using the `"icon"` option. On macOS, both `"warning"` and
-  `"error"` display the same warning icon.
+  * `type` string (optional) - Can be `none`, `info`, `error`, `question` or
+  `warning`. On Windows, `question` displays the same icon as `info`, unless
+  you set an icon using the `icon` option. On macOS, both `warning` and
+  `error` display the same warning icon.
   * `buttons` string[]&#32;(optional) - Array of texts for buttons. On Windows, an empty array
     will result in one button labeled "OK".
   * `defaultId` Integer (optional) - Index of the button in the buttons array which will
@@ -266,10 +266,10 @@ If `browserWindow` is not shown dialog will not be attached to it. In such case 
 * `browserWindow` [BrowserWindow](browser-window.md) (optional)
 * `options` Object
   * `message` string - Content of the message box.
-  * `type` string (optional) - Can be `"none"`, `"info"`, `"error"`, `"question"` or
-  `"warning"`. On Windows, `"question"` displays the same icon as `"info"`, unless
-  you set an icon using the `"icon"` option. On macOS, both `"warning"` and
-  `"error"` display the same warning icon.
+  * `type` string (optional) - Can be `none`, `info`, `error`, `question` or
+  `warning`. On Windows, `question` displays the same icon as `info`, unless
+  you set an icon using the `icon` option. On macOS, both `warning` and
+  `error` display the same warning icon.
   * `buttons` string[]&#32;(optional) - Array of texts for buttons. On Windows, an empty array
     will result in one button labeled "OK".
   * `defaultId` Integer (optional) - Index of the button in the buttons array which will


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

These weren't being processed properly by `electron/docs-parser` since they had quotes inside of the backticks. See Archeologist output for difference.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
