### PR TITLE
build: modify `gclient.py` with unified patch

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -267,9 +267,10 @@ step-depot-tools-get: &step-depot-tools-get
                          parent=self,
       EOF
         git apply --3way gclient.diff
-        # Ensure depot_tools does not update.
-        touch .disable_auto_update
       fi
+      # Ensure depot_tools does not update.
+      test -d depot_tools && cd depot_tools
+      touch .disable_auto_update
 
 step-depot-tools-add-to-path: &step-depot-tools-add-to-path
   run:

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -250,23 +250,25 @@ step-depot-tools-get: &step-depot-tools-get
         sed -i '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
         # Remove swift-format dep from cipd on macOS until we send a patch upstream.
         cd depot_tools
-        cat > gclient_diff.patch << EOF
+        cat > gclient.diff \<< 'EOF'
       diff --git a/gclient.py b/gclient.py
-      index 8ca899ca..1c21d0be 100755
+      index 3a9c5c6..f222043 100755
       --- a/gclient.py
       +++ b/gclient.py
-      @@ -714,7 +714,8 @@ class Dependency(gclient_utils.WorkItem, DependencySettings):
+      @@ -712,7 +712,8 @@ class Dependency(gclient_utils.WorkItem, DependencySettings):
       
-            if dep_type == 'cipd':
-              cipd_root = self.GetCipdRoot()
+             if dep_type == 'cipd':
+               cipd_root = self.GetCipdRoot()
       -        for package in dep_value.get('packages', []):
       +        packages = dep_value.get('packages', [])
       +        for package in (x for x in packages if "infra/3pp/tools/swift-format" not in x.get('package')):
-                deps_to_add.append(
-                    CipdDependency(
-                        parent=self,
+                 deps_to_add.append(
+                     CipdDependency(
+                         parent=self,
       EOF
-        git apply --3way gclient_diff.patch
+        git apply --3way gclient.diff
+        # Ensure depot_tools does not update.
+        touch .disable_auto_update
       fi
 
 step-depot-tools-add-to-path: &step-depot-tools-add-to-path

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -250,13 +250,23 @@ step-depot-tools-get: &step-depot-tools-get
         sed -i '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
         # Remove swift-format dep from cipd on macOS until we send a patch upstream.
         cd depot_tools
-        patch gclient.py -R \<<'EOF'
-      676,677c676
-      <         packages = dep_value.get('packages', [])
-      <         for package in (x for x in packages if "infra/3pp/tools/swift-format" not in x.get('package')):
-      ---
-      >         for package in dep_value.get('packages', []):
+        cat > gclient_diff.patch << EOF
+      diff --git a/gclient.py b/gclient.py
+      index 8ca899ca..1c21d0be 100755
+      --- a/gclient.py
+      +++ b/gclient.py
+      @@ -714,7 +714,8 @@ class Dependency(gclient_utils.WorkItem, DependencySettings):
+      
+            if dep_type == 'cipd':
+              cipd_root = self.GetCipdRoot()
+      -        for package in dep_value.get('packages', []):
+      +        packages = dep_value.get('packages', [])
+      +        for package in (x for x in packages if "infra/3pp/tools/swift-format" not in x.get('package')):
+                deps_to_add.append(
+                    CipdDependency(
+                        parent=self,
       EOF
+        git apply --3way gclient_diff.patch
       fi
 
 step-depot-tools-add-to-path: &step-depot-tools-add-to-path


### PR DESCRIPTION
#### Description of Change

Switch to unified patch and also ensure `depot_tools` doesn't update during CI runs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
