### PR TITLE
fix: only exit fullscreen conditionally with `setKiosk`

### DIFF
--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -233,6 +233,7 @@ class NativeWindowMac : public NativeWindow,
   // The views::View that fills the client area.
   std::unique_ptr<RootViewMac> root_view_;
 
+  bool fullscreen_before_kiosk_ = false;
   bool is_kiosk_ = false;
   bool zoom_to_page_width_ = false;
   absl::optional<gfx::Point> traffic_light_position_;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1030,10 +1030,13 @@ void NativeWindowMac::SetKiosk(bool kiosk) {
         NSApplicationPresentationDisableHideApplication;
     [NSApp setPresentationOptions:options];
     is_kiosk_ = true;
-    SetFullScreen(true);
+    fullscreen_before_kiosk_ = IsFullscreen();
+    if (!fullscreen_before_kiosk_)
+      SetFullScreen(true);
   } else if (!kiosk && is_kiosk_) {
     is_kiosk_ = false;
-    SetFullScreen(false);
+    if (!fullscreen_before_kiosk_)
+      SetFullScreen(false);
 
     // Set presentation options *after* asynchronously exiting
     // fullscreen to ensure they take effect.

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5176,19 +5176,32 @@ describe('BrowserWindow module', () => {
 
       it('should not be changed by setKiosk method', async () => {
         const w = new BrowserWindow();
+
+        const enterFullScreen = emittedOnce(w, 'enter-full-screen');
+        w.setKiosk(true);
+        await enterFullScreen;
+        expect(w.isFullScreen()).to.be.true('isFullScreen');
+
+        const leaveFullScreen = emittedOnce(w, 'leave-full-screen');
+        w.setKiosk(false);
+        await leaveFullScreen;
+        expect(w.isFullScreen()).to.be.false('isFullScreen');
+      });
+
+      it('should stay fullscreen if fullscreen before kiosk', async () => {
+        const w = new BrowserWindow();
+
         const enterFullScreen = emittedOnce(w, 'enter-full-screen');
         w.setFullScreen(true);
         await enterFullScreen;
         expect(w.isFullScreen()).to.be.true('isFullScreen');
-        await delay();
+
         w.setKiosk(true);
-        await delay();
         w.setKiosk(false);
+
+        // Wait enough time for a fullscreen change to take effect.
+        await delay(2000);
         expect(w.isFullScreen()).to.be.true('isFullScreen');
-        const leaveFullScreen = emittedOnce(w, 'leave-full-screen');
-        w.setFullScreen(false);
-        await leaveFullScreen;
-        expect(w.isFullScreen()).to.be.false('isFullScreen');
       });
 
       // FIXME: https://github.com/electron/electron/issues/30140


### PR DESCRIPTION
Backport of #38219.

See that PR for details.

Notes: Fixed an issue where calls to `window.setKiosk(false)` would exit fullscreen regardless of the fullscreen state prior to kiosk mode.