### PR TITLE
docs: disablewebsecurity on webview-tag can not be changed for an active session

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -184,6 +184,8 @@ page is loaded, use the `setUserAgent` method to change the user agent.
 A `boolean`. When this attribute is present the guest page will have web security disabled.
 Web security is enabled by default.
 
+This value can only be modified before the first navigation.
+
 ### `partition`
 
 ```html


### PR DESCRIPTION
#### Description of Change

Like the partition, changing the `disablewebsecurity` attribute on a `webview` doesn't work. There is no exception, but if changed after creation there is no actual change in the websecurity setting of the underlying webcontents.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
