### PR TITLE
fix: linker error missing uv__strtok

### DIFF
--- a/patches/node/build_add_gn_build_files.patch
+++ b/patches/node/build_add_gn_build_files.patch
@@ -1012,10 +1012,10 @@ index 0000000000000000000000000000000000000000..bfbd4e656db1a6c73048443f96f1d576
 +}
 diff --git a/deps/uv/BUILD.gn b/deps/uv/BUILD.gn
 new file mode 100644
-index 0000000000000000000000000000000000000000..d6bed57461820ce08391fc424a1f842bd282fa75
+index 0000000000000000000000000000000000000000..e90becfab51beb090394db9d3c94d73e546b39ef
 --- /dev/null
 +++ b/deps/uv/BUILD.gn
-@@ -0,0 +1,196 @@
+@@ -0,0 +1,198 @@
 +config("libuv_config") {
 +  include_dirs = [ "include" ]
 +
@@ -1085,6 +1085,8 @@ index 0000000000000000000000000000000000000000..d6bed57461820ce08391fc424a1f842b
 +    "src/random.c",
 +    "src/strscpy.c",
 +    "src/strscpy.h",
++    "src/strtok.c",
++    "src/strtok.h",
 +    "src/threadpool.c",
 +    "src/timer.c",
 +    "src/uv-common.c",


### PR DESCRIPTION
This symbol is referenced inside what seems to be dead code in `uv__search_path` in third_party/electron_node/deps/uv/src/unix/core.c
When compiling in LTO mode, the reference is removed, but not during a non-LTO build.

This should be backported to 24, but not to 22. (It depends on whether libuv has that file.)

#### Release Notes

none
