### PR TITLE
fix: `dangling_raw_ptr` warning in `electron_api_web_contents`

### DIFF
--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -773,9 +773,6 @@ class WebContents : public ExclusiveAccessContext,
   // Whether the guest view has been attached.
   bool attached_ = false;
 
-  // The zoom controller for this webContents.
-  raw_ptr<WebContentsZoomController> zoom_controller_ = nullptr;
-
   // The type of current WebContents.
   Type type_ = Type::kBrowserWindow;
 
@@ -819,6 +816,11 @@ class WebContents : public ExclusiveAccessContext,
   // dialog_manager_, so we can make sure inspectable_web_contents_ is
   // destroyed before dialog_manager_, otherwise a crash would happen.
   std::unique_ptr<InspectableWebContents> inspectable_web_contents_;
+
+  // The zoom controller for this webContents.
+  // Note: owned by inspectable_web_contents_, so declare this *after*
+  // that field to ensure the dtor destroys them in the right order.
+  raw_ptr<WebContentsZoomController> zoom_controller_ = nullptr;
 
   // Maps url to file path, used by the file requests sent from devtools.
   typedef std::map<std::string, base::FilePath> PathsMap;


### PR DESCRIPTION
#### Description of Change

Fix the [dangling_raw_ptr](https://chromium.googlesource.com/chromium/src.git/+/main/docs/dangling_ptr.md) warning discussed in https://github.com/electron/electron/pull/38167. (There is at least one more I'm still tracking down, so this PR doesn't re-enable the leak checks in CI yet.)

This one was mostly harmless: `electron::api::WebContents` had two fields declared in this order:

```c++
  raw_ptr<WebContentsZoomController> zoom_controller_ = nullptr;

  std::unique_ptr<InspectableWebContents> inspectable_web_contents_;
```

The problem is that `inspectable_web_contents_` owns the object pointed to by `zoom_controller_`, so when `~WebContents()` is run and the fields are destroyed in reverse order, `inspectable_web_contents_` is destroyed first, causing `zoom_controller_` to be (temporarily) dangling.

CC @jkleinsc, @deepak1556 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: no-notes