### PR TITLE
chore: remove ViewsDelegate::IsWindowInMetro() override

### DIFF
--- a/shell/browser/ui/views/electron_views_delegate.h
+++ b/shell/browser/ui/views/electron_views_delegate.h
@@ -42,7 +42,6 @@ class ViewsDelegate : public views::ViewsDelegate {
 #if BUILDFLAG(IS_WIN)
   HICON GetDefaultWindowIcon() const override;
   HICON GetSmallWindowIcon() const override;
-  bool IsWindowInMetro(gfx::NativeWindow window) const override;
   int GetAppbarAutohideEdges(HMONITOR monitor,
                              base::OnceClosure callback) override;
 #elif BUILDFLAG(IS_LINUX) && !BUILDFLAG(IS_CHROMEOS)

--- a/shell/browser/ui/views/electron_views_delegate_win.cc
+++ b/shell/browser/ui/views/electron_views_delegate_win.cc
@@ -111,10 +111,6 @@ HICON ViewsDelegate::GetSmallWindowIcon() const {
   return GetDefaultWindowIcon();
 }
 
-bool ViewsDelegate::IsWindowInMetro(gfx::NativeWindow window) const {
-  return false;
-}
-
 int ViewsDelegate::GetAppbarAutohideEdges(HMONITOR monitor,
                                           base::OnceClosure callback) {
   // Initialize the map with EDGE_BOTTOM. This is important, as if we return an


### PR DESCRIPTION
#### Description of Change
The base implementation in https://source.chromium.org/chromium/chromium/src/+/main:ui/views/views_delegate.cc does the same
```
bool ViewsDelegate::IsWindowInMetro(gfx::NativeWindow window) const {
  return false;
}
```

#### Release Notes
Notes: none
