### PR TITLE
refactor: cleanup global variable declarations

### DIFF
--- a/lib/isolated_renderer/init.ts
+++ b/lib/isolated_renderer/init.ts
@@ -1,6 +1,7 @@
-/* global isolatedApi */
-
 import type * as webViewElementModule from '@electron/internal/renderer/web-view/web-view-element';
+import type { WebViewImplHooks } from '@electron/internal/renderer/web-view/web-view-impl';
+
+declare const isolatedApi: WebViewImplHooks;
 
 if (isolatedApi.guestViewInternal) {
   // Must setup the WebView element in main world.

--- a/lib/sandboxed_renderer/init.ts
+++ b/lib/sandboxed_renderer/init.ts
@@ -1,9 +1,14 @@
-/* global binding */
 import * as events from 'events';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
 import type * as ipcRendererUtilsModule from '@electron/internal/renderer/ipc-renderer-internal-utils';
 import type * as ipcRendererInternalModule from '@electron/internal/renderer/ipc-renderer-internal';
+
+declare const binding: {
+  get: (name: string) => any;
+  process: NodeJS.Process;
+  createPreloadScript: (src: string) => Function
+};
 
 const { EventEmitter } = events;
 

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -1,13 +1,3 @@
-/* eslint-disable no-var */
-declare var internalBinding: any;
-declare var binding: { get: (name: string) => any; process: NodeJS.Process; createPreloadScript: (src: string) => Function };
-
-declare var isolatedApi: {
-  guestViewInternal: any;
-  allowGuestViewElementDefinition: NodeJS.InternalWebFrame['allowGuestViewElementDefinition'];
-  setIsWebView: (iframe: HTMLIFrameElement) => void;
-}
-
 declare const BUILDFLAG: (flag: boolean) => boolean;
 
 declare const ENABLE_DESKTOP_CAPTURER: boolean;


### PR DESCRIPTION
Declare the globals for each init separately. Also reuse `WebViewImplHooks` for  `isolatedApi` type
https://github.com/electron/electron/blob/e7b8bb4766da58fa693ec3e82c0af9b0a3406c9d/lib/renderer/web-view/web-view-impl.ts#L14-L18

Notes: none