### PR TITLE
build: remove enable_desktop_capturer flag

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -705,13 +705,6 @@ source_set("electron_lib") {
     ]
   }
 
-  if (enable_desktop_capturer) {
-    sources += [
-      "shell/browser/api/electron_api_desktop_capturer.cc",
-      "shell/browser/api/electron_api_desktop_capturer.h",
-    ]
-  }
-
   if (enable_views_api) {
     sources += [
       "shell/browser/api/views/electron_api_image_view.cc",

--- a/build/webpack/webpack.config.base.js
+++ b/build/webpack/webpack.config.base.js
@@ -53,14 +53,6 @@ module.exports = ({
 
     const ignoredModules = [];
 
-    if (defines.ENABLE_DESKTOP_CAPTURER === 'false') {
-      ignoredModules.push(
-        '@electron/internal/browser/desktop-capturer',
-        '@electron/internal/browser/api/desktop-capturer',
-        '@electron/internal/renderer/api/desktop-capturer'
-      );
-    }
-
     if (defines.ENABLE_VIEWS_API === 'false') {
       ignoredModules.push(
         '@electron/internal/browser/api/views/image-view.js'

--- a/buildflags/BUILD.gn
+++ b/buildflags/BUILD.gn
@@ -9,7 +9,6 @@ buildflag_header("buildflags") {
   header = "buildflags.h"
 
   flags = [
-    "ENABLE_DESKTOP_CAPTURER=$enable_desktop_capturer",
     "ENABLE_RUN_AS_NODE=$enable_run_as_node",
     "ENABLE_OSR=$enable_osr",
     "ENABLE_VIEWS_API=$enable_views_api",

--- a/buildflags/buildflags.gni
+++ b/buildflags/buildflags.gni
@@ -3,8 +3,6 @@
 # found in the LICENSE file.
 
 declare_args() {
-  enable_desktop_capturer = true
-
   # Allow running Electron as a node binary.
   enable_run_as_node = true
 

--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -37,6 +37,14 @@ static_library("chrome") {
     "//chrome/browser/icon_loader.h",
     "//chrome/browser/icon_manager.cc",
     "//chrome/browser/icon_manager.h",
+    "//chrome/browser/media/webrtc/desktop_media_list.cc",
+    "//chrome/browser/media/webrtc/desktop_media_list.h",
+    "//chrome/browser/media/webrtc/desktop_media_list_base.cc",
+    "//chrome/browser/media/webrtc/desktop_media_list_base.h",
+    "//chrome/browser/media/webrtc/desktop_media_list_observer.h",
+    "//chrome/browser/media/webrtc/native_desktop_media_list.cc",
+    "//chrome/browser/media/webrtc/native_desktop_media_list.h",
+    "//chrome/browser/media/webrtc/window_icon_util.h",
     "//chrome/browser/net/chrome_mojo_proxy_resolver_factory.cc",
     "//chrome/browser/net/chrome_mojo_proxy_resolver_factory.h",
     "//chrome/browser/net/proxy_config_monitor.cc",
@@ -160,6 +168,7 @@ static_library("chrome") {
   deps = [
     "//chrome/browser:resource_prefetch_predictor_proto",
     "//chrome/browser/resource_coordinator:mojo_bindings",
+    "//ui/snapshot",
   ]
 
   if (is_linux) {
@@ -189,20 +198,6 @@ static_library("chrome") {
       "//chrome/browser/win/icon_reader_service.h",
     ]
     public_deps += [ "//chrome/services/util_win:lib" ]
-  }
-
-  if (enable_desktop_capturer) {
-    sources += [
-      "//chrome/browser/media/webrtc/desktop_media_list.cc",
-      "//chrome/browser/media/webrtc/desktop_media_list.h",
-      "//chrome/browser/media/webrtc/desktop_media_list_base.cc",
-      "//chrome/browser/media/webrtc/desktop_media_list_base.h",
-      "//chrome/browser/media/webrtc/desktop_media_list_observer.h",
-      "//chrome/browser/media/webrtc/native_desktop_media_list.cc",
-      "//chrome/browser/media/webrtc/native_desktop_media_list.h",
-      "//chrome/browser/media/webrtc/window_icon_util.h",
-    ]
-    deps += [ "//ui/snapshot" ]
   }
 
   if (enable_widevine) {

--- a/filenames.gni
+++ b/filenames.gni
@@ -262,6 +262,8 @@ filenames = {
     "shell/browser/api/electron_api_data_pipe_holder.h",
     "shell/browser/api/electron_api_debugger.cc",
     "shell/browser/api/electron_api_debugger.h",
+    "shell/browser/api/electron_api_desktop_capturer.cc",
+    "shell/browser/api/electron_api_desktop_capturer.h",
     "shell/browser/api/electron_api_dialog.cc",
     "shell/browser/api/electron_api_download_item.cc",
     "shell/browser/api/electron_api_download_item.h",

--- a/lib/browser/api/module-list.ts
+++ b/lib/browser/api/module-list.ts
@@ -9,6 +9,7 @@ export const browserModuleList: ElectronInternal.ModuleEntry[] = [
   { name: 'BrowserWindow', loader: () => require('./browser-window') },
   { name: 'contentTracing', loader: () => require('./content-tracing') },
   { name: 'crashReporter', loader: () => require('./crash-reporter') },
+  { name: 'desktopCapturer', loader: () => require('./desktop-capturer') },
   { name: 'dialog', loader: () => require('./dialog') },
   { name: 'globalShortcut', loader: () => require('./global-shortcut') },
   { name: 'ipcMain', loader: () => require('./ipc-main') },
@@ -37,12 +38,6 @@ export const browserModuleList: ElectronInternal.ModuleEntry[] = [
   { name: 'WebContentsView', loader: () => require('./web-contents-view') },
   { name: 'webFrameMain', loader: () => require('./web-frame-main') }
 ];
-
-if (BUILDFLAG(ENABLE_DESKTOP_CAPTURER)) {
-  browserModuleList.push(
-    { name: 'desktopCapturer', loader: () => require('./desktop-capturer') }
-  );
-}
 
 if (BUILDFLAG(ENABLE_VIEWS_API)) {
   browserModuleList.push(

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -570,12 +570,8 @@ std::vector<int> BaseWindow::GetPosition() {
 }
 void BaseWindow::MoveAbove(const std::string& sourceId,
                            gin_helper::Arguments* args) {
-#if BUILDFLAG(ENABLE_DESKTOP_CAPTURER)
   if (!window_->MoveAbove(sourceId))
     args->ThrowError("Invalid media source id");
-#else
-  args->ThrowError("enable_desktop_capturer=true to use this feature");
-#endif
 }
 
 void BaseWindow::MoveTop() {

--- a/shell/common/api/features.cc
+++ b/shell/common/api/features.cc
@@ -14,10 +14,6 @@ bool IsBuiltinSpellCheckerEnabled() {
   return BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER);
 }
 
-bool IsDesktopCapturerEnabled() {
-  return BUILDFLAG(ENABLE_DESKTOP_CAPTURER);
-}
-
 bool IsOffscreenRenderingEnabled() {
   return BUILDFLAG(ENABLE_OSR);
 }
@@ -68,7 +64,6 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   gin_helper::Dictionary dict(context->GetIsolate(), exports);
   dict.SetMethod("isBuiltinSpellCheckerEnabled", &IsBuiltinSpellCheckerEnabled);
-  dict.SetMethod("isDesktopCapturerEnabled", &IsDesktopCapturerEnabled);
   dict.SetMethod("isOffscreenRenderingEnabled", &IsOffscreenRenderingEnabled);
   dict.SetMethod("isPDFViewerEnabled", &IsPDFViewerEnabled);
   dict.SetMethod("isRunAsNodeEnabled", &IsRunAsNodeEnabled);

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -50,6 +50,7 @@
   V(electron_browser_browser_view)       \
   V(electron_browser_content_tracing)    \
   V(electron_browser_crash_reporter)     \
+  V(electron_browser_desktop_capturer)   \
   V(electron_browser_dialog)             \
   V(electron_browser_event_emitter)      \
   V(electron_browser_global_shortcut)    \
@@ -99,9 +100,6 @@
 
 #define ELECTRON_VIEWS_BINDINGS(V) V(electron_browser_image_view)
 
-#define ELECTRON_DESKTOP_CAPTURER_BINDINGS(V) \
-  V(electron_browser_desktop_capturer)
-
 #define ELECTRON_TESTING_BINDINGS(V) V(electron_common_testing)
 
 // This is used to load built-in bindings. Instead of using
@@ -116,9 +114,6 @@ ELECTRON_RENDERER_BINDINGS(V)
 ELECTRON_UTILITY_BINDINGS(V)
 #if BUILDFLAG(ENABLE_VIEWS_API)
 ELECTRON_VIEWS_BINDINGS(V)
-#endif
-#if BUILDFLAG(ENABLE_DESKTOP_CAPTURER)
-ELECTRON_DESKTOP_CAPTURER_BINDINGS(V)
 #endif
 #if DCHECK_IS_ON()
 ELECTRON_TESTING_BINDINGS(V)
@@ -362,9 +357,6 @@ void NodeBindings::RegisterBuiltinBindings() {
     ELECTRON_BROWSER_BINDINGS(V)
 #if BUILDFLAG(ENABLE_VIEWS_API)
     ELECTRON_VIEWS_BINDINGS(V)
-#endif
-#if BUILDFLAG(ENABLE_DESKTOP_CAPTURER)
-    ELECTRON_DESKTOP_CAPTURER_BINDINGS(V)
 #endif
   }
   ELECTRON_COMMON_BINDINGS(V)

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1324,7 +1324,7 @@ describe('BrowserWindow module', () => {
       });
     });
 
-    ifdescribe(features.isDesktopCapturerEnabled())('BrowserWindow.moveAbove(mediaSourceId)', () => {
+    describe('BrowserWindow.moveAbove(mediaSourceId)', () => {
       it('should throw an exception if wrong formatting', async () => {
         const fakeSourceIds = [
           'none', 'screen:0', 'window:fake', 'window:1234', 'foobar:1:2'

--- a/spec/api-desktop-capturer-spec.ts
+++ b/spec/api-desktop-capturer-spec.ts
@@ -6,15 +6,7 @@ import { ifdescribe, ifit } from './lib/spec-helpers';
 
 import { closeAllWindows } from './lib/window-helpers';
 
-const features = process._linkedBinding('electron_common_features');
-
 ifdescribe(!process.arch.includes('arm') && process.platform !== 'win32')('desktopCapturer', () => {
-  if (!features.isDesktopCapturerEnabled()) {
-    // This condition can't go the `ifdescribe` call because its inner code
-    // it still executed, and if the feature is disabled some function calls here fail.
-    return;
-  }
-
   let w: BrowserWindow;
 
   before(async () => {

--- a/spec/api-media-handler-spec.ts
+++ b/spec/api-media-handler-spec.ts
@@ -2,11 +2,9 @@ import { expect } from 'chai';
 import { BrowserWindow, session, desktopCapturer } from 'electron/main';
 import { closeAllWindows } from './lib/window-helpers';
 import * as http from 'http';
-import { ifdescribe, ifit, listen } from './lib/spec-helpers';
+import { ifit, listen } from './lib/spec-helpers';
 
-const features = process._linkedBinding('electron_common_features');
-
-ifdescribe(features.isDesktopCapturerEnabled())('setDisplayMediaRequestHandler', () => {
+describe('setDisplayMediaRequestHandler', () => {
   afterEach(closeAllWindows);
   // These tests are done on an http server because navigator.userAgentData
   // requires a secure context.

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -10,13 +10,11 @@ declare var isolatedApi: {
 
 declare const BUILDFLAG: (flag: boolean) => boolean;
 
-declare const ENABLE_DESKTOP_CAPTURER: boolean;
 declare const ENABLE_VIEWS_API: boolean;
 
 declare namespace NodeJS {
   interface FeaturesBinding {
     isBuiltinSpellCheckerEnabled(): boolean;
-    isDesktopCapturerEnabled(): boolean;
     isOffscreenRenderingEnabled(): boolean;
     isPDFViewerEnabled(): boolean;
     isRunAsNodeEnabled(): boolean;


### PR DESCRIPTION
#### Description of Change
Disabling `enable_desktop_capturer` only saves around 40 KB in the generated binaries.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: The `enable_desktop_capturer` build flag has been removed.