### PR TITLE
build: fix build with "enable_pdf_viewer=false"

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -737,6 +737,12 @@ source_set("electron_lib") {
 
   if (enable_electron_extensions) {
     sources += filenames.lib_sources_extensions
+    if (enable_pdf_viewer) {
+      sources += [
+        "shell/browser/extensions/api/pdf_viewer_private/pdf_viewer_private_api.cc",
+        "shell/browser/extensions/api/pdf_viewer_private/pdf_viewer_private_api.h",
+      ]
+    }
     deps += [
       "shell/browser/extensions/api:api_registration",
       "shell/common/extensions/api",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -737,12 +737,6 @@ source_set("electron_lib") {
 
   if (enable_electron_extensions) {
     sources += filenames.lib_sources_extensions
-    if (enable_pdf_viewer) {
-      sources += [
-        "shell/browser/extensions/api/pdf_viewer_private/pdf_viewer_private_api.cc",
-        "shell/browser/extensions/api/pdf_viewer_private/pdf_viewer_private_api.h",
-      ]
-    }
     deps += [
       "shell/browser/extensions/api:api_registration",
       "shell/common/extensions/api",
@@ -779,6 +773,8 @@ source_set("electron_lib") {
     sources += [
       "shell/browser/electron_pdf_web_contents_helper_client.cc",
       "shell/browser/electron_pdf_web_contents_helper_client.h",
+      "shell/browser/extensions/api/pdf_viewer_private/pdf_viewer_private_api.cc",
+      "shell/browser/extensions/api/pdf_viewer_private/pdf_viewer_private_api.h",
     ]
   }
 

--- a/filenames.gni
+++ b/filenames.gni
@@ -695,8 +695,6 @@ filenames = {
     "shell/browser/extensions/api/management/electron_management_api_delegate.h",
     "shell/browser/extensions/api/resources_private/resources_private_api.cc",
     "shell/browser/extensions/api/resources_private/resources_private_api.h",
-    "shell/browser/extensions/api/pdf_viewer_private/pdf_viewer_private_api.cc",
-    "shell/browser/extensions/api/pdf_viewer_private/pdf_viewer_private_api.h",
     "shell/browser/extensions/api/runtime/electron_runtime_api_delegate.cc",
     "shell/browser/extensions/api/runtime/electron_runtime_api_delegate.h",
     "shell/browser/extensions/api/streams_private/streams_private_api.cc",


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
"pdf_viewer_private_api.{cc,h}" should only be compiled when `enable_pdf_viewer=true`.
Related to #38127.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
