### PR TITLE
fix: check for string before calling netBinding.fileURLToFilePath(params.preload);

### DIFF
--- a/lib/browser/guest-view-manager.ts
+++ b/lib/browser/guest-view-manager.ts
@@ -42,7 +42,7 @@ function makeWebPreferences (embedder: Electron.WebContents, params: Record<stri
     ...parsedWebPreferences
   };
 
-  if (params.preload) {
+  if (typeof params.preload === 'string') {
     webPreferences.preload = netBinding.fileURLToFilePath(params.preload);
   }
 


### PR DESCRIPTION
#### Description of Change
The native `fileURLToFilePath` method throws an exception if the argument is not a string

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes
Notes: none