### PR TITLE
refactor: prefer base::Contains() over find() + end()

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/containers/contains.h"
 #include "base/task/single_thread_task_runner.h"
 #include "electron/buildflags/buildflags.h"
 #include "gin/dictionary.h"
@@ -757,8 +758,7 @@ void BaseWindow::SetBrowserView(
 }
 
 void BaseWindow::AddBrowserView(gin::Handle<BrowserView> browser_view) {
-  auto iter = browser_views_.find(browser_view->ID());
-  if (iter == browser_views_.end()) {
+  if (!base::Contains(browser_views_, browser_view->ID())) {
     // If we're reparenting a BrowserView, ensure that it's detached from
     // its previous owner window.
     BaseWindow* owner_window = browser_view->owner_window();

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -8,7 +8,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/containers/contains.h"
 #include "base/task/single_thread_task_runner.h"
 #include "electron/buildflags/buildflags.h"
 #include "gin/dictionary.h"
@@ -758,24 +757,23 @@ void BaseWindow::SetBrowserView(
 }
 
 void BaseWindow::AddBrowserView(gin::Handle<BrowserView> browser_view) {
-  auto const key = browser_view->ID();
-  if (!base::Contains(browser_views_, key)) {
-    return;
-  }
+  auto iter = browser_views_.find(browser_view->ID());
+  if (iter == browser_views_.end()) {
+    // If we're reparenting a BrowserView, ensure that it's detached from
+    // its previous owner window.
+    BaseWindow* owner_window = browser_view->owner_window();
+    if (owner_window) {
+      // iter == browser_views_.end() should imply owner_window != this.
+      DCHECK_NE(owner_window, this);
+      owner_window->RemoveBrowserView(browser_view);
+      browser_view->SetOwnerWindow(nullptr);
+    }
 
-  // If we're reparenting a BrowserView, ensure that it's detached from
-  // its previous owner window.
-  if (BaseWindow* owner_window = browser_view->owner_window(); owner_window) {
-    // iter == browser_views_.end() should imply owner_window != this.
-    DCHECK_NE(owner_window, this);
-    owner_window->RemoveBrowserView(browser_view);
-    browser_view->SetOwnerWindow(nullptr);
+    window_->AddBrowserView(browser_view->view());
+    window_->AddDraggableRegionProvider(browser_view.get());
+    browser_view->SetOwnerWindow(this);
+    browser_views_[browser_view->ID()].Reset(isolate(), browser_view.ToV8());
   }
-
-  window_->AddBrowserView(browser_view->view());
-  window_->AddDraggableRegionProvider(browser_view.get());
-  browser_view->SetOwnerWindow(this);
-  browser_views_.try_emplace(key, isolate(), browser_view.ToV8());
 }
 
 void BaseWindow::RemoveBrowserView(gin::Handle<BrowserView> browser_view) {

--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -62,8 +62,7 @@ GlobalShortcut::~GlobalShortcut() {
 }
 
 void GlobalShortcut::OnKeyPressed(const ui::Accelerator& accelerator) {
-  if (accelerator_callback_map_.find(accelerator) ==
-      accelerator_callback_map_.end()) {
+  if (!base::Contains(accelerator_callback_map_, accelerator)) {
     // This should never occur, because if it does, GlobalShortcutListener
     // notifies us with wrong accelerator.
     NOTREACHED();

--- a/shell/browser/api/electron_api_power_save_blocker.cc
+++ b/shell/browser/api/electron_api_power_save_blocker.cc
@@ -6,6 +6,7 @@
 
 #include <string>
 
+#include "base/containers/contains.h"
 #include "base/functional/callback_helpers.h"
 #include "content/public/browser/device_service.h"
 #include "gin/dictionary.h"
@@ -106,8 +107,8 @@ bool PowerSaveBlocker::Stop(int id) {
   return success;
 }
 
-bool PowerSaveBlocker::IsStarted(int id) {
-  return wake_lock_types_.find(id) != wake_lock_types_.end();
+bool PowerSaveBlocker::IsStarted(int id) const {
+  return base::Contains(wake_lock_types_, id);
 }
 
 // static

--- a/shell/browser/api/electron_api_power_save_blocker.h
+++ b/shell/browser/api/electron_api_power_save_blocker.h
@@ -37,7 +37,7 @@ class PowerSaveBlocker : public gin::Wrappable<PowerSaveBlocker> {
   void UpdatePowerSaveBlocker();
   int Start(device::mojom::WakeLockType type);
   bool Stop(int id);
-  bool IsStarted(int id);
+  bool IsStarted(int id) const;
 
   device::mojom::WakeLock* GetWakeLock();
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/containers/contains.h"
 #include "base/containers/id_map.h"
 #include "base/files/file_util.h"
 #include "base/json/json_reader.h"
@@ -729,8 +730,8 @@ std::map<std::string, std::string> GetAddedFileSystemPaths(
 
 bool IsDevToolsFileSystemAdded(content::WebContents* web_contents,
                                const std::string& file_system_path) {
-  auto file_system_paths = GetAddedFileSystemPaths(web_contents);
-  return file_system_paths.find(file_system_path) != file_system_paths.end();
+  return base::Contains(GetAddedFileSystemPaths(web_contents),
+                        file_system_path);
 }
 
 void SetBackgroundColor(content::RenderWidgetHostView* rwhv, SkColor color) {

--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 
+#include "base/containers/contains.h"
 #include "base/memory/raw_ptr.h"
 #include "base/stl_util.h"
 #include "base/task/sequenced_task_runner.h"
@@ -294,7 +295,7 @@ bool WebRequest::RequestFilter::MatchesURL(const GURL& url) const {
 
 bool WebRequest::RequestFilter::MatchesType(
     extensions::WebRequestResourceType type) const {
-  return types_.empty() || types_.find(type) != types_.end();
+  return types_.empty() || base::Contains(types_, type);
 }
 
 bool WebRequest::RequestFilter::MatchesRequest(

--- a/shell/browser/api/message_port.cc
+++ b/shell/browser/api/message_port.cc
@@ -8,6 +8,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "base/containers/contains.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/task/single_thread_task_runner.h"
 #include "gin/arguments.h"
@@ -221,7 +222,7 @@ std::vector<blink::MessagePortChannel> MessagePort::DisentanglePorts(
   // or cloned ports, throw an error (per section 8.3.3 of the HTML5 spec).
   for (unsigned i = 0; i < ports.size(); ++i) {
     auto* port = ports[i].get();
-    if (!port || port->IsNeutered() || visited.find(port) != visited.end()) {
+    if (!port || port->IsNeutered() || base::Contains(visited, port)) {
       std::string type;
       if (!port)
         type = "null";

--- a/shell/browser/hid/hid_chooser_controller.cc
+++ b/shell/browser/hid/hid_chooser_controller.cc
@@ -149,8 +149,7 @@ void HidChooserController::OnDeviceAdded(
 void HidChooserController::OnDeviceRemoved(
     const device::mojom::HidDeviceInfo& device) {
   auto id = PhysicalDeviceIdFromDeviceInfo(device);
-  auto items_it = std::find(items_.begin(), items_.end(), id);
-  if (items_it == items_.end())
+  if (!base::Contains(items_, id))
     return;
   api::Session* session = GetSession();
   if (session) {

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "base/containers/contains.h"
 #include "base/memory/ptr_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/values.h"
@@ -725,9 +726,7 @@ int NativeWindow::NonClientHitTest(const gfx::Point& point) {
 
 void NativeWindow::AddDraggableRegionProvider(
     DraggableRegionProvider* provider) {
-  if (std::find(draggable_region_providers_.begin(),
-                draggable_region_providers_.end(),
-                provider) == draggable_region_providers_.end()) {
+  if (!base::Contains(draggable_region_providers_, provider)) {
     draggable_region_providers_.push_back(provider);
   }
 }

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/containers/contains.h"
 #include "base/memory/raw_ptr.h"
 #include "base/stl_util.h"
 #include "base/strings/utf_string_conversions.h"
@@ -1438,8 +1439,7 @@ bool NativeWindowViews::IsVisibleOnAllWorkspaces() {
     std::vector<x11::Atom> wm_states;
     GetArrayProperty(static_cast<x11::Window>(GetAcceleratedWidget()),
                      x11::GetAtom("_NET_WM_STATE"), &wm_states);
-    return std::find(wm_states.begin(), wm_states.end(), sticky_atom) !=
-           wm_states.end();
+    return base::Contains(wm_states, sticky_atom);
   }
 #endif
   return false;

--- a/shell/browser/printing/print_view_manager_electron.cc
+++ b/shell/browser/printing/print_view_manager_electron.cc
@@ -6,6 +6,7 @@
 
 #include <utility>
 
+#include "base/containers/contains.h"
 #include "base/functional/bind.h"
 #include "build/build_config.h"
 #include "components/printing/browser/print_to_pdf/pdf_print_utils.h"
@@ -98,8 +99,7 @@ void PrintViewManagerElectron::GetDefaultPrintSettings(
 void PrintViewManagerElectron::ScriptedPrint(
     printing::mojom::ScriptedPrintParamsPtr params,
     ScriptedPrintCallback callback) {
-  auto entry = std::find(pdf_jobs_.begin(), pdf_jobs_.end(), params->cookie);
-  if (entry == pdf_jobs_.end()) {
+  if (!base::Contains(pdf_jobs_, params->cookie)) {
     PrintViewManagerBase::ScriptedPrint(std::move(params), std::move(callback));
     return;
   }

--- a/shell/browser/printing/print_view_manager_electron.cc
+++ b/shell/browser/printing/print_view_manager_electron.cc
@@ -135,8 +135,7 @@ void PrintViewManagerElectron::CheckForCancel(int32_t preview_ui_id,
 
 void PrintViewManagerElectron::DidGetPrintedPagesCount(int32_t cookie,
                                                        uint32_t number_pages) {
-  auto entry = std::find(pdf_jobs_.begin(), pdf_jobs_.end(), cookie);
-  if (entry == pdf_jobs_.end()) {
+  if (!base::Contains(pdf_jobs_, cookie)) {
     PrintViewManagerBase::DidGetPrintedPagesCount(cookie, number_pages);
   }
 }

--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -242,7 +242,7 @@ DialogResult ShowTaskDialogWstr(gfx::AcceleratedWidget parent,
   TaskDialogIndirect(&config, &id, nullptr, &verification_flag_checked);
 
   int button_id;
-  if (id_map.find(id) != id_map.end())  // common button.
+  if (base::Contains(id_map, id))  // common button.
     button_id = id_map[id];
   else if (id >= kIDStart)  // custom button.
     button_id = id - kIDStart;

--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -6,6 +6,7 @@
 
 #include <map>
 
+#include "base/containers/contains.h"
 #include "base/strings/utf_string_conversions.h"
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
@@ -71,7 +72,7 @@ std::string Clipboard::Read(const std::string& format_string) {
       clipboard->ExtractCustomPlatformNames(ui::ClipboardBuffer::kCopyPaste,
                                             /* data_dst = */ nullptr);
 #if BUILDFLAG(IS_LINUX)
-  if (custom_format_names.find(format_string) == custom_format_names.end()) {
+  if (!base::Contains(custom_format_names, format_string)) {
     custom_format_names =
         clipboard->ExtractCustomPlatformNames(ui::ClipboardBuffer::kSelection,
                                               /* data_dst = */ nullptr);
@@ -79,7 +80,7 @@ std::string Clipboard::Read(const std::string& format_string) {
 #endif
 
   ui::ClipboardFormatType format;
-  if (custom_format_names.find(format_string) != custom_format_names.end()) {
+  if (base::Contains(custom_format_names, format_string)) {
     format =
         ui::ClipboardFormatType(ui::ClipboardFormatType::CustomPlatformType(
             custom_format_names[format_string]));

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/containers/contains.h"
 #include "base/logging.h"
 #include "base/process/process.h"
 #include "base/process/process_handle.h"
@@ -100,8 +101,7 @@ void ElectronBindings::EnvironmentDestroyed(node::Environment* env) {
 
 void ElectronBindings::ActivateUVLoop(v8::Isolate* isolate) {
   node::Environment* env = node::Environment::GetCurrent(isolate);
-  if (std::find(pending_next_ticks_.begin(), pending_next_ticks_.end(), env) !=
-      pending_next_ticks_.end())
+  if (base::Contains(pending_next_ticks_, env))
     return;
 
   pending_next_ticks_.push_back(env);

--- a/shell/common/key_weak_map.h
+++ b/shell/common/key_weak_map.h
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/containers/contains.h"
 #include "base/memory/raw_ptr.h"
 #include "v8/include/v8.h"
 
@@ -52,7 +53,7 @@ class KeyWeakMap {
   }
 
   // Whether there is an object with |key| in this WeakMap.
-  bool Has(const K& key) const { return map_.find(key) != map_.end(); }
+  constexpr bool Has(const K& key) const { return base::Contains(map_, key); }
 
   // Returns all objects.
   std::vector<v8::Local<v8::Object>> Values(v8::Isolate* isolate) const {

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/containers/contains.h"
 #include "base/feature_list.h"
 #include "base/no_destructor.h"
 #include "base/strings/string_number_conversions.h"
@@ -63,7 +64,7 @@ bool DeepFreeze(const v8::Local<v8::Object>& object,
                 const v8::Local<v8::Context>& context,
                 std::set<int> frozen = std::set<int>()) {
   int hash = object->GetIdentityHash();
-  if (frozen.find(hash) != frozen.end())
+  if (base::Contains(frozen, hash))
     return true;
   frozen.insert(hash);
 

--- a/shell/renderer/api/electron_api_spell_check_client.cc
+++ b/shell/renderer/api/electron_api_spell_check_client.cc
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/containers/contains.h"
 #include "base/logging.h"
 #include "base/numerics/safe_conversions.h"
 #include "base/task/single_thread_task_runner.h"
@@ -192,13 +193,13 @@ void SpellCheckClient::OnSpellCheckDone(
   auto& word_list = pending_request_param_->wordlist();
 
   for (const auto& word : word_list) {
-    if (misspelled.find(word.text) != misspelled.end()) {
+    if (base::Contains(misspelled, word.text)) {
       // If this is a contraction, iterate through parts and accept the word
       // if none of them are misspelled
       if (!word.contraction_words.empty()) {
         auto all_correct = true;
         for (const auto& contraction_word : word.contraction_words) {
-          if (misspelled.find(contraction_word) != misspelled.end()) {
+          if (base::Contains(misspelled, contraction_word)) {
             all_correct = false;
             break;
           }

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "base/command_line.h"
+#include "base/containers/contains.h"
 #include "content/public/renderer/render_frame.h"
 #include "electron/buildflags/buildflags.h"
 #include "net/http/http_request_headers.h"
@@ -195,15 +196,13 @@ void ElectronRendererClient::WillDestroyWorkerContextOnWorkerThread(
 
 node::Environment* ElectronRendererClient::GetEnvironment(
     content::RenderFrame* render_frame) const {
-  if (injected_frames_.find(render_frame) == injected_frames_.end())
+  if (!base::Contains(injected_frames_, render_frame))
     return nullptr;
   v8::HandleScope handle_scope(v8::Isolate::GetCurrent());
   auto context =
       GetContext(render_frame->GetWebFrame(), v8::Isolate::GetCurrent());
   node::Environment* env = node::Environment::GetCurrent(context);
-  if (environments_.find(env) == environments_.end())
-    return nullptr;
-  return env;
+  return base::Contains(environments_, env) ? env : nullptr;
 }
 
 }  // namespace electron

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -217,7 +217,7 @@ void ElectronSandboxedRendererClient::WillReleaseScriptContext(
 void ElectronSandboxedRendererClient::EmitProcessEvent(
     content::RenderFrame* render_frame,
     const char* event_name) {
-  if (injected_frames_.find(render_frame) == injected_frames_.end())
+  if (!base::Contains(injected_frames_, render_frame))
     return;
 
   auto* isolate = blink::MainThreadIsolate();


### PR DESCRIPTION
#### Description of Change

A minor readability refactor to prefer `base::Contains()` over `std::find(begin(), end(), foo) != end()`.

No behavioral changes & no stakeholders in particular, but all reviews are welcomed.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none