### PR TITLE
build: make ReactiveObjC/Mantle deps format consistent

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -9,6 +9,10 @@ vars = {
     '16fa32231e2ccd89d2804b3f765319128b20c4ac',
   'squirrel.mac_version':
     '0e5d146ba13101a1302d59ea6e6e0b3cace4ae38',
+  'reactiveobjc_version':
+    '74ab5baccc6f7202c8ac69a8d1e152c29dc1ea76',
+  'mantle_version':
+    '78d3966b3c331292ea29ec38661b25df0a245948',
 
   'pyyaml_version': '3.12',
 
@@ -17,6 +21,8 @@ vars = {
   'nodejs_git': 'https://github.com/nodejs',
   'yaml_git': 'https://github.com/yaml',
   'squirrel_git': 'https://github.com/Squirrel',
+  'reactiveobjc_git': 'https://github.com/ReactiveCocoa',
+  'mantle_git': 'https://github.com/Mantle',
 
   # KEEP IN SYNC WITH utils.js FILE
   'yarn_version': '1.15.2',
@@ -87,11 +93,11 @@ deps = {
     'condition': 'process_deps',
   },
   'src/third_party/squirrel.mac/vendor/ReactiveObjC': {
-    'url': 'https://github.com/ReactiveCocoa/ReactiveObjC.git@74ab5baccc6f7202c8ac69a8d1e152c29dc1ea76',
+    'url': Var("reactiveobjc_git") + '/ReactiveObjC.git@' + Var("reactiveobjc_version"),
     'condition': 'process_deps'
   },
   'src/third_party/squirrel.mac/vendor/Mantle': {
-    'url': 'https://github.com/Mantle/Mantle.git@78d3966b3c331292ea29ec38661b25df0a245948',
+    'url':  Var("mantle_git") + '/Mantle.git@' + Var("mantle_version"),
     'condition': 'process_deps',
   }
 }


### PR DESCRIPTION
#### Description of Change

As in title - they should match version formatting of other deps.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none