### PR TITLE
chore: `process.mainModule` -> `require.main`

### DIFF
--- a/script/yarn.js
+++ b/script/yarn.js
@@ -3,13 +3,9 @@ const fs = require('fs');
 const path = require('path');
 
 const YARN_VERSION = /'yarn_version': '(.+?)'/.exec(fs.readFileSync(path.resolve(__dirname, '../DEPS'), 'utf8'))[1];
+const NPX_CMD = process.platform === 'win32' ? 'npx.cmd' : 'npx';
 
-exports.YARN_VERSION = YARN_VERSION;
-
-// If we are running "node script/yarn" run as the yarn CLI
-if (process.mainModule === module) {
-  const NPX_CMD = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-
+if (require.main === module) {
   const child = cp.spawn(NPX_CMD, [`yarn@${YARN_VERSION}`, ...process.argv.slice(2)], {
     stdio: 'inherit',
     env: {
@@ -20,3 +16,5 @@ if (process.mainModule === module) {
 
   child.on('exit', code => process.exit(code));
 }
+
+exports.YARN_VERSION = YARN_VERSION;


### PR DESCRIPTION
#### Description of Change

`process.mainModule` is long since deprecated - this should be `require.main`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none