### PR TITLE
ci: clean up docs only change logic

### DIFF
--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -66,7 +66,7 @@ for:
     build_script:
       - ps: |
           node script/yarn.js install --frozen-lockfile
-          node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH
+          node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER
           if ($LASTEXITCODE -eq 0) {
             Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
           }
@@ -220,7 +220,7 @@ for:
     build_script:
       - ps: |
           node script/yarn.js install --frozen-lockfile
-          node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH
+          node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER
           if ($LASTEXITCODE -eq 0) {
             Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
           }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,7 @@ for:
     build_script:
       - ps: |
           node script/yarn.js install --frozen-lockfile
-          node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH
+          node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER
           if ($LASTEXITCODE -eq 0) {
             Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
           }
@@ -216,7 +216,7 @@ for:
     build_script:
       - ps: |
           node script/yarn.js install --frozen-lockfile
-          node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH
+          node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER
           if ($LASTEXITCODE -eq 0) {
             Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
           }

--- a/script/doc-only-change.js
+++ b/script/doc-only-change.js
@@ -3,57 +3,40 @@ const { Octokit } = require('@octokit/rest');
 const octokit = new Octokit();
 
 async function checkIfDocOnlyChange () {
-  if (args.prNumber || args.prBranch || args.prURL) {
+  let { prNumber, prURL } = args;
+
+  if (prNumber || prURL) {
     try {
-      let pullRequestNumber = args.prNumber;
-      if (!pullRequestNumber || isNaN(pullRequestNumber)) {
+      // CircleCI doesn't provide the PR number except on forked PRs,
+      // so to cover all cases we just extract it from the PR URL.
+      if (!prNumber || isNaN(prNumber)) {
         if (args.prURL) {
-          // CircleCI doesn't provide the PR number for branch builds, but it does provide the PR URL
-          const pullRequestParts = args.prURL.split('/');
-          pullRequestNumber = pullRequestParts[pullRequestParts.length - 1];
-        } else if (args.prBranch) {
-          // AppVeyor doesn't provide a PR number for branch builds - figure it out from the branch
-          const prsForBranch = await octokit.pulls.list({
-            owner: 'electron',
-            repo: 'electron',
-            state: 'open',
-            head: `electron:${args.prBranch}`
-          });
-          if (prsForBranch.data.length === 1) {
-            pullRequestNumber = prsForBranch.data[0].number;
-          } else {
-            // If there are 0 PRs or more than one PR on a branch, just assume that this is more than a doc change
-            process.exit(1);
-          }
+          prNumber = prURL.split('/').pop();
         }
       }
+
       const filesChanged = await octokit.paginate(octokit.pulls.listFiles.endpoint.merge({
         owner: 'electron',
         repo: 'electron',
-        pull_number: pullRequestNumber,
+        pull_number: prNumber,
         per_page: 100
       }));
 
-      console.log('Changed Files:', filesChanged.map(fileInfo => fileInfo.filename));
+      console.log('Changed Files: ', filesChanged.map(fileInfo => fileInfo.filename));
 
-      const nonDocChange = filesChanged.find((fileInfo) => {
-        const fileDirs = fileInfo.filename.split('/');
-        if (fileDirs[0] !== 'docs') {
-          return true;
-        }
+      const nonDocChange = filesChanged.length === 0 || filesChanged.find(({ filename }) => {
+        const fileDirs = filename.split('/');
+        if (fileDirs[0] !== 'docs') return true;
       });
-      if (nonDocChange || filesChanged.length === 0) {
-        process.exit(1);
-      } else {
-        process.exit(0);
-      }
-    } catch (ex) {
-      console.error('Error getting list of files changed: ', ex);
+
+      process.exit(nonDocChange ? 1 : 0);
+    } catch (error) {
+      console.error('Error getting list of files changed: ', error);
       process.exit(-1);
     }
   } else {
     console.error(`Check if only the docs were changed for a commit.
-    Usage: doc-only-change.js --prNumber=PR_NUMBER || --prBranch=PR_BRANCH || --prURL=PR_URL`);
+    Usage: doc-only-change.js --prNumber=PR_NUMBER || --prURL=PR_URL`);
     process.exit(-1);
   }
 }


### PR DESCRIPTION
#### Description of Change

Clean up code in `script/docs-only-change.js` to account for current usage. At the moment, we don't use this file on CircleCI, and on Appveyor it seems now to be the case that `APPVEYOR_PULL_REQUEST_NUMBER` works on both forked and non-forked branches.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none