### PR TITLE
refactor: use literals instead of new RegExp() where possible

### DIFF
--- a/script/prepare-appveyor.js
+++ b/script/prepare-appveyor.js
@@ -182,8 +182,7 @@ async function prepareAppVeyorImage (opts) {
   if (ROLLER_BRANCH_PATTERN.test(branch)) {
     useAppVeyorImage(branch, { ...opts, version: DEFAULT_BUILD_IMAGE, cloudId: DEFAULT_BUILD_CLOUD_ID });
   } else {
-    // eslint-disable-next-line no-control-regex
-    const versionRegex = new RegExp('chromium_version\':\n +\'(.+?)\',', 'm');
+    const versionRegex = /chromium_version':\n +'(.+?)',/m;
     const deps = fs.readFileSync(path.resolve(__dirname, '..', 'DEPS'), 'utf8');
     const [, CHROMIUM_VERSION] = versionRegex.exec(deps);
 

--- a/script/release/prepare-release.js
+++ b/script/release/prepare-release.js
@@ -187,8 +187,7 @@ async function promptForVersion (version) {
 
 // function to determine if there have been commits to main since the last release
 async function changesToRelease () {
-  // eslint-disable-next-line no-useless-escape
-  const lastCommitWasRelease = new RegExp('^Bump v[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?(-alpha\.[0-9]+)?(-nightly\.[0-9]+)?$', 'g');
+  const lastCommitWasRelease = /^Bump v[0-9]+.[0-9]+.[0-9]+(-beta.[0-9]+)?(-alpha.[0-9]+)?(-nightly.[0-9]+)?$/g;
   const lastCommit = await GitProcess.exec(['log', '-n', '1', '--pretty=format:\'%s\''], ELECTRON_DIR);
   return !lastCommitWasRelease.test(lastCommit.stdout);
 }


### PR DESCRIPTION
It also solves two more eslint suppressions started by #38417

Notes: none