### PR TITLE
fix: DCHECK minimizing parent window with non-modal child

### DIFF
--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -149,6 +149,9 @@ class NativeWindow : public base::SupportsUserData,
   virtual std::string GetAlwaysOnTopLevel() = 0;
   virtual void SetActive(bool is_key) = 0;
   virtual bool IsActive() const = 0;
+  virtual void RemoveChildWindow(NativeWindow* child) = 0;
+  virtual void AttachChildren() = 0;
+  virtual void DetachChildren() = 0;
 #endif
 
   // Ability to augment the window title for the screen readers.
@@ -382,6 +385,10 @@ class NativeWindow : public base::SupportsUserData,
 
   int32_t window_id() const { return next_id_; }
 
+  void add_child_window(NativeWindow* child) {
+    child_windows_.push_back(child);
+  }
+
   int NonClientHitTest(const gfx::Point& point);
   void AddDraggableRegionProvider(DraggableRegionProvider* provider);
   void RemoveDraggableRegionProvider(DraggableRegionProvider* provider);
@@ -421,6 +428,8 @@ class NativeWindow : public base::SupportsUserData,
       FullScreenTransitionState::kNone;
   FullScreenTransitionType fullscreen_transition_type_ =
       FullScreenTransitionType::kNone;
+
+  std::list<NativeWindow*> child_windows_;
 
  private:
   std::unique_ptr<views::Widget> widget_;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -155,6 +155,12 @@ class NativeWindowMac : public NativeWindow,
   void NotifyWindowLeaveFullScreen() override;
   void SetActive(bool is_key) override;
   bool IsActive() const override;
+  // Remove the specified child window without closing it.
+  void RemoveChildWindow(NativeWindow* child) override;
+  // Attach child windows, if the window is visible.
+  void AttachChildren() override;
+  // Detach window from parent without destroying it.
+  void DetachChildren() override;
 
   void NotifyWindowWillEnterFullScreen();
   void NotifyWindowWillLeaveFullScreen();

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -239,6 +239,7 @@ using FullScreenTransitionState =
   level_ = [window level];
   shell_->SetWindowLevel(NSNormalWindowLevel);
   shell_->UpdateWindowOriginalFrame();
+  shell_->DetachChildren();
 }
 
 - (void)windowDidMiniaturize:(NSNotification*)notification {
@@ -248,6 +249,7 @@ using FullScreenTransitionState =
 
 - (void)windowDidDeminiaturize:(NSNotification*)notification {
   [super windowDidDeminiaturize:notification];
+  shell_->AttachChildren();
   shell_->SetWindowLevel(level_);
   shell_->NotifyWindowRestore();
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/38459.

[`NativeWidgetNSWindowBridge::NotifyVisibilityChangeDown()`](https://source.chromium.org/chromium/chromium/src/+/main:components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm;l=1667) expects that the parent window's children have all been hidden before the window is hidden, or there is a DCHECK. This fixes that.

We previously solved something similar in https://github.com/electron/electron/issues/29821 - however, here, we can't just detach the windows. The children need to reappear when the window becomes visible again, so we instead need to add some mechanics to hide and restore windows appropriately. I took my cue upstream from [`components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm`](https://source.chromium.org/chromium/chromium/src/+/refs/heads/main:components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm) - which has these same mechanics for similar reasons.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed potential issues when minimizing parent windows with non-modal children on macOS.