### PR TITLE
fix: Windows FrameView always appearing inactive

### DIFF
--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -37,14 +37,6 @@ bool ElectronDesktopWindowTreeHostWin::PreHandleMSG(UINT message,
   return native_window_view_->PreHandleMSG(message, w_param, l_param, result);
 }
 
-bool ElectronDesktopWindowTreeHostWin::ShouldPaintAsActive() const {
-  // Tell Chromium to use system default behavior when rendering inactive
-  // titlebar, otherwise it would render inactive titlebar as active under
-  // some cases.
-  // See also https://github.com/electron/electron/issues/24647.
-  return false;
-}
-
 bool ElectronDesktopWindowTreeHostWin::GetDwmFrameInsetsInPixels(
     gfx::Insets* insets) const {
   // Set DWMFrameInsets to prevent maximized frameless window from bleeding

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
@@ -31,7 +31,6 @@ class ElectronDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin,
                     WPARAM w_param,
                     LPARAM l_param,
                     LRESULT* result) override;
-  bool ShouldPaintAsActive() const override;
   bool GetDwmFrameInsetsInPixels(gfx::Insets* insets) const override;
   bool GetClientAreaInsets(gfx::Insets* insets,
                            HMONITOR monitor) const override;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/38385.
Refs CL:4435695.

Fixes an issue where Windows `FrameView`s always appeared inactive regardless of focus status. This was happening because Chromium added extra plumbing to set active state as a function of whether or not in `delegate_->ShouldPaintAsActive();` was `true` in `HWNDMessageHandler::PaintAsActiveChanged()`, and we'd overridden it to return false.

Confirmed not to regress https://github.com/electron/electron/issues/24647.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where Windows `FrameView`s always appeared inactive regardless of focus status.
