### PR TITLE
chore: make `contentTracing.stopRecording()` failure clearer

### DIFF
--- a/shell/browser/api/electron_api_content_tracing.cc
+++ b/shell/browser/api/electron_api_content_tracing.cc
@@ -77,15 +77,20 @@ void StopTracing(gin_helper::Promise<base::FilePath> promise,
         }
       },
       std::move(promise), *file_path);
-  if (file_path) {
+
+  auto* instance = TracingController::GetInstance();
+  if (!instance->IsTracing()) {
+    std::move(resolve_or_reject)
+        .Run(absl::make_optional(
+            "Failed to stop tracing - no trace in progress"));
+  } else if (file_path) {
     auto split_callback = base::SplitOnceCallback(std::move(resolve_or_reject));
     auto endpoint = TracingController::CreateFileEndpoint(
         *file_path,
         base::BindOnce(std::move(split_callback.first), absl::nullopt));
-    if (!TracingController::GetInstance()->StopTracing(endpoint)) {
+    if (!instance->StopTracing(endpoint)) {
       std::move(split_callback.second)
-          .Run(absl::make_optional(
-              "Failed to stop tracing (was a trace in progress?)"));
+          .Run(absl::make_optional("Failed to stop tracing"));
     }
   } else {
     std::move(resolve_or_reject)

--- a/spec/api-content-tracing-spec.ts
+++ b/spec/api-content-tracing-spec.ts
@@ -114,7 +114,7 @@ ifdescribe(!(['arm', 'arm64', 'ia32'].includes(process.arch)))('contentTracing',
     });
 
     it('rejects if no trace is happening', async () => {
-      await expect(contentTracing.stopRecording()).to.be.rejected();
+      await expect(contentTracing.stopRecording()).to.be.rejectedWith('Failed to stop tracing - no trace in progress');
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Reject with a more descriptive error when `contentTracing.stopRecording()` fails because no trace was in progress.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Improve error message when `contentTracing.stopRecording()` fails because no trace was in progress.