### PR TITLE
fix: account for `BrowserView` bounds in setting autofill popup bounds

### DIFF
--- a/shell/browser/electron_autofill_driver.cc
+++ b/shell/browser/electron_autofill_driver.cc
@@ -11,6 +11,7 @@
 #include "content/public/browser/render_widget_host_view.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/javascript_environment.h"
+#include "shell/browser/native_browser_view.h"
 #include "shell/browser/native_window.h"
 
 namespace electron {
@@ -36,7 +37,11 @@ void AutofillDriver::ShowAutofillPopup(
   v8::HandleScope scope(isolate);
   auto* web_contents = api::WebContents::From(
       content::WebContents::FromRenderFrameHost(render_frame_host_));
-  if (!web_contents || !web_contents->owner_window())
+  if (!web_contents)
+    return;
+
+  auto* owner_window = web_contents->owner_window();
+  if (!owner_window)
     return;
 
   auto* embedder = web_contents->embedder();
@@ -55,9 +60,23 @@ void AutofillDriver::ShowAutofillPopup(
     embedder_frame_host = embedder->web_contents()->GetPrimaryMainFrame();
   }
 
+  // Ensure that if the WebContents belongs to a BrowserView,
+  // the popup is positioned relative to the BrowserView's bounds.
+  for (NativeBrowserView* bv : owner_window->browser_views()) {
+    auto* iwc = bv->GetInspectableWebContents();
+    if (!iwc)
+      continue;
+
+    auto* awc = api::WebContents::From(iwc->GetWebContents());
+    if (awc == web_contents) {
+      auto bv_origin = bv->GetBounds().origin();
+      popup_bounds.Offset(gfx::Vector2dF(bv_origin.x(), bv_origin.y()));
+      break;
+    }
+  }
+
   autofill_popup_->CreateView(render_frame_host_, embedder_frame_host, osr,
-                              web_contents->owner_window()->content_view(),
-                              popup_bounds);
+                              owner_window->content_view(), popup_bounds);
   autofill_popup_->SetItems(values, labels);
 }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/38245.

Fixes an issue where `<datalist>` popup positioning did not account for the possibility of the `WebContents` belonging to a `BrowserView` and adjust accordingly.

<details><summary>Before</summary>
<img width="789" alt="Screenshot 2023-05-30 at 2 19 08 PM" src="https://github.com/electron/electron/assets/2036040/b74878b0-97a0-498a-a8e7-dc97c3986ecb">
</details>

<details><summary>After</summary>
<img width="788" alt="Screenshot 2023-05-30 at 2 31 57 PM" src="https://github.com/electron/electron/assets/2036040/f241db66-cc72-454d-89ad-5e1c822232d3">
</details>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where `<datalist>` popups are positions incorrectly in `BrowserView`s.
