### PR TITLE
refactor: remove unused switches

### DIFF
--- a/shell/common/electron_constants.cc
+++ b/shell/common/electron_constants.cc
@@ -9,7 +9,6 @@ namespace electron {
 const char kBrowserForward[] = "browser-forward";
 const char kBrowserBackward[] = "browser-backward";
 
-const char kCertificateError[] = "Certificate Error";
 const char kValidCertificate[] = "Valid Certificate";
 const char kValidCertificateDescription[] =
     "The connection to this site is using a valid, trusted server certificate.";

--- a/shell/common/electron_constants.cc
+++ b/shell/common/electron_constants.cc
@@ -9,8 +9,6 @@ namespace electron {
 const char kBrowserForward[] = "browser-forward";
 const char kBrowserBackward[] = "browser-backward";
 
-const char kValidCertificateDescription[] =
-    "The connection to this site is using a valid, trusted server certificate.";
 const char kSecureProtocol[] = "Secure TLS connection";
 const char kSecureProtocolDescription[] =
     "The connection to this site is using a strong protocol version "

--- a/shell/common/electron_constants.cc
+++ b/shell/common/electron_constants.cc
@@ -9,9 +9,6 @@ namespace electron {
 const char kBrowserForward[] = "browser-forward";
 const char kBrowserBackward[] = "browser-backward";
 
-const char kSHA1MajorDescription[] =
-    "The certificate for this site expires in 2017 or later, "
-    "and the certificate chain contains a certificate signed using SHA-1.";
 const char kSHA1MinorDescription[] =
     "The certificate for this site expires in 2016, "
     "and the certificate chain contains a certificate signed using SHA-1.";

--- a/shell/common/electron_constants.cc
+++ b/shell/common/electron_constants.cc
@@ -9,9 +9,6 @@ namespace electron {
 const char kBrowserForward[] = "browser-forward";
 const char kBrowserBackward[] = "browser-backward";
 
-const char kSHA1MinorDescription[] =
-    "The certificate for this site expires in 2016, "
-    "and the certificate chain contains a certificate signed using SHA-1.";
 const char kCertificateError[] = "Certificate Error";
 const char kValidCertificate[] = "Valid Certificate";
 const char kValidCertificateDescription[] =

--- a/shell/common/electron_constants.cc
+++ b/shell/common/electron_constants.cc
@@ -9,11 +9,6 @@ namespace electron {
 const char kBrowserForward[] = "browser-forward";
 const char kBrowserBackward[] = "browser-backward";
 
-const char kSecureProtocol[] = "Secure TLS connection";
-const char kSecureProtocolDescription[] =
-    "The connection to this site is using a strong protocol version "
-    "and cipher suite.";
-
 const char kDeviceVendorIdKey[] = "vendorId";
 const char kDeviceProductIdKey[] = "productId";
 const char kDeviceSerialNumberKey[] = "serialNumber";

--- a/shell/common/electron_constants.cc
+++ b/shell/common/electron_constants.cc
@@ -9,7 +9,6 @@ namespace electron {
 const char kBrowserForward[] = "browser-forward";
 const char kBrowserBackward[] = "browser-backward";
 
-const char kValidCertificate[] = "Valid Certificate";
 const char kValidCertificateDescription[] =
     "The connection to this site is using a valid, trusted server certificate.";
 const char kSecureProtocol[] = "Secure TLS connection";

--- a/shell/common/electron_constants.cc
+++ b/shell/common/electron_constants.cc
@@ -9,7 +9,6 @@ namespace electron {
 const char kBrowserForward[] = "browser-forward";
 const char kBrowserBackward[] = "browser-backward";
 
-const char kSHA1Certificate[] = "SHA-1 Certificate";
 const char kSHA1MajorDescription[] =
     "The certificate for this site expires in 2017 or later, "
     "and the certificate chain contains a certificate signed using SHA-1.";

--- a/shell/common/electron_constants.h
+++ b/shell/common/electron_constants.h
@@ -15,10 +15,6 @@ namespace electron {
 extern const char kBrowserForward[];
 extern const char kBrowserBackward[];
 
-// Strings describing Chrome security policy for DevTools security panel.
-extern const char kSecureProtocol[];
-extern const char kSecureProtocolDescription[];
-
 // Keys for Device APIs
 extern const char kDeviceVendorIdKey[];
 extern const char kDeviceProductIdKey[];

--- a/shell/common/electron_constants.h
+++ b/shell/common/electron_constants.h
@@ -16,7 +16,6 @@ extern const char kBrowserForward[];
 extern const char kBrowserBackward[];
 
 // Strings describing Chrome security policy for DevTools security panel.
-extern const char kValidCertificate[];
 extern const char kValidCertificateDescription[];
 extern const char kSecureProtocol[];
 extern const char kSecureProtocolDescription[];

--- a/shell/common/electron_constants.h
+++ b/shell/common/electron_constants.h
@@ -16,7 +16,6 @@ extern const char kBrowserForward[];
 extern const char kBrowserBackward[];
 
 // Strings describing Chrome security policy for DevTools security panel.
-extern const char kSHA1MajorDescription[];
 extern const char kSHA1MinorDescription[];
 extern const char kCertificateError[];
 extern const char kValidCertificate[];

--- a/shell/common/electron_constants.h
+++ b/shell/common/electron_constants.h
@@ -16,7 +16,6 @@ extern const char kBrowserForward[];
 extern const char kBrowserBackward[];
 
 // Strings describing Chrome security policy for DevTools security panel.
-extern const char kSHA1Certificate[];
 extern const char kSHA1MajorDescription[];
 extern const char kSHA1MinorDescription[];
 extern const char kCertificateError[];

--- a/shell/common/electron_constants.h
+++ b/shell/common/electron_constants.h
@@ -16,7 +16,6 @@ extern const char kBrowserForward[];
 extern const char kBrowserBackward[];
 
 // Strings describing Chrome security policy for DevTools security panel.
-extern const char kValidCertificateDescription[];
 extern const char kSecureProtocol[];
 extern const char kSecureProtocolDescription[];
 

--- a/shell/common/electron_constants.h
+++ b/shell/common/electron_constants.h
@@ -16,7 +16,6 @@ extern const char kBrowserForward[];
 extern const char kBrowserBackward[];
 
 // Strings describing Chrome security policy for DevTools security panel.
-extern const char kCertificateError[];
 extern const char kValidCertificate[];
 extern const char kValidCertificateDescription[];
 extern const char kSecureProtocol[];

--- a/shell/common/electron_constants.h
+++ b/shell/common/electron_constants.h
@@ -16,7 +16,6 @@ extern const char kBrowserForward[];
 extern const char kBrowserBackward[];
 
 // Strings describing Chrome security policy for DevTools security panel.
-extern const char kSHA1MinorDescription[];
 extern const char kCertificateError[];
 extern const char kValidCertificate[];
 extern const char kValidCertificateDescription[];

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -123,8 +123,6 @@ const char kZoomFactor[] = "zoomFactor";
 // Script that will be loaded by guest WebContents before other scripts.
 const char kPreloadScript[] = "preload";
 
-const char kPreloadScripts[] = "preloadScripts";
-
 // Enable the node integration.
 const char kNodeIntegration[] = "nodeIntegration";
 

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -171,9 +171,6 @@ const char kJavaScript[] = "javascript";
 // Enables image support.
 const char kImages[] = "images";
 
-// Image animation policy.
-const char kImageAnimationPolicy[] = "imageAnimationPolicy";
-
 // Make TextArea elements resizable.
 const char kTextAreasAreResizable[] = "textAreasAreResizable";
 

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -67,7 +67,6 @@ extern const char kOverlayHeight[];
 // WebPreferences.
 extern const char kZoomFactor[];
 extern const char kPreloadScript[];
-extern const char kPreloadScripts[];
 extern const char kNodeIntegration[];
 extern const char kContextIsolation[];
 extern const char kExperimentalFeatures[];

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -85,7 +85,6 @@ extern const char kNodeIntegrationInSubFrames[];
 extern const char kDisableHtmlFullscreenWindowResize[];
 extern const char kJavaScript[];
 extern const char kImages[];
-extern const char kImageAnimationPolicy[];
 extern const char kTextAreasAreResizable[];
 extern const char kWebGL[];
 extern const char kNavigateOnDragDrop[];


### PR DESCRIPTION
#### Description of Change

Cleanup PR that removes leftover `electron::switches` that are no longer used.

No particular stakeholders, but all reviews welcomed. :smile_cat: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none