### PR TITLE
refactor: replace use of deprecated base::GetProcId() 

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2398,12 +2398,11 @@ int WebContents::GetProcessID() const {
 }
 
 base::ProcessId WebContents::GetOSProcessID() const {
-  base::ProcessHandle process_handle = web_contents()
-                                           ->GetPrimaryMainFrame()
-                                           ->GetProcess()
-                                           ->GetProcess()
-                                           .Handle();
-  return base::GetProcId(process_handle);
+  return web_contents()
+      ->GetPrimaryMainFrame()
+      ->GetProcess()
+      ->GetProcess()
+      .Pid();
 }
 
 WebContents::Type WebContents::GetType() const {

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -273,9 +273,7 @@ std::string WebFrameMain::Name() const {
 base::ProcessId WebFrameMain::OSProcessID() const {
   if (!CheckRenderFrame())
     return -1;
-  base::ProcessHandle process_handle =
-      render_frame_->GetProcess()->GetProcess().Handle();
-  return base::GetProcId(process_handle);
+  return render_frame_->GetProcess()->GetProcess().Pid();
 }
 
 int WebFrameMain::ProcessID() const {

--- a/shell/browser/ui/webui/accessibility_ui.cc
+++ b/shell/browser/ui/webui/accessibility_ui.cc
@@ -96,7 +96,7 @@ base::Value::Dict BuildTargetDescriptor(
   target_data.Set(kRoutingIdField, routing_id);
   target_data.Set(kUrlField, url.spec());
   target_data.Set(kNameField, base::EscapeForHTML(name));
-  target_data.Set(kPidField, static_cast<int>(base::GetProcId(handle)));
+  target_data.Set(kPidField, static_cast<int>(base::Process{handle}.Pid()));
   target_data.Set(kFaviconUrlField, favicon_url.spec());
   target_data.Set(kAccessibilityModeField,
                   static_cast<int>(accessibility_mode.flags()));


### PR DESCRIPTION
#### Description of Change

Xref: https://codereview.chromium.org/921913002/patch/20001/30001

> // DEPRECATED. New code should be using Process::Pid() instead.
> BASE_EXPORT ProcessId GetProcId(ProcessHandle process);

Replace calls to `base::GetProcId()` with `Process::Pid()`. This has been deprecated for awhile now so upstream doesn't seem to be in a hurry; but since it's an easy cleanup, I don't see any reason to _not_ update...

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none