### PR TITLE
feat: Allow customizing the default math font

### DIFF
--- a/docs/api/structures/web-preferences.md
+++ b/docs/api/structures/web-preferences.md
@@ -67,6 +67,7 @@
   * `monospace` string (optional) - Defaults to `Courier New`.
   * `cursive` string (optional) - Defaults to `Script`.
   * `fantasy` string (optional) - Defaults to `Impact`.
+  * `math` string (optional) - Defaults to `Latin Modern Math`.
 * `defaultFontSize` Integer (optional) - Defaults to `16`.
 * `defaultMonospaceFontSize` Integer (optional) - Defaults to `13`.
 * `minimumFontSize` Integer (optional) - Defaults to `0`.

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -450,6 +450,10 @@ void WebContentsPreferences::OverrideWebkitPrefs(
         iter != default_font_family_.end())
       prefs->fantasy_font_family_map[blink::web_pref::kCommonScript] =
           iter->second;
+    if (auto iter = default_font_family_.find("math");
+        iter != default_font_family_.end())
+      prefs->math_font_family_map[blink::web_pref::kCommonScript] =
+          iter->second;
   }
 
   if (default_font_size_)


### PR DESCRIPTION
#### Description of Change

Added `math` option to `defaultFontFamily` in webPreferences to allow customization of the default math font along with other fonts.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added support for customization of the default math font along with other fonts.

@zcbenz @deepak1556 