### PR TITLE
chore: cherry-pick 1 changes from Release-0-M114

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -128,3 +128,4 @@ add_gin_converter_support_for_arraybufferview.patch
 chore_defer_usb_service_getdevices_request_until_usb_service_is.patch
 cherry-pick-48a136e77e6d.patch
 cherry-pick-e6e23ba00379.patch
+cherry-pick-e6b75a8b4900.patch

--- a/patches/chromium/cherry-pick-e6b75a8b4900.patch
+++ b/patches/chromium/cherry-pick-e6b75a8b4900.patch
@@ -1,0 +1,51 @@
+From e6b75a8b4900535ea72775af93178e32f2e602be Mon Sep 17 00:00:00 2001
+From: chromium-autoroll <chromium-autoroll@skia-public.iam.gserviceaccount.com>
+Date: Fri, 12 May 2023 18:56:04 +0000
+Subject: [PATCH] Roll PDFium from 4c16842f61a1 to e60fa0d7d773 (6 revisions)
+
+https://pdfium.googlesource.com/pdfium.git/+log/4c16842f61a1..e60fa0d7d773
+
+2023-05-12 thestig@chromium.org Remove struct CFX_CTTGSUBTable::TLangSysRecord
+2023-05-11 thestig@chromium.org Stop storing `CFX_Font::m_pSubData`
+2023-05-11 thestig@chromium.org Improve error handling in CPDF_CIDFont::GetGlyphIndex()
+2023-05-11 tsepez@chromium.org Observe widget across SetOptionSelection() calls.
+2023-05-11 tsepez@chromium.org Always check return code from CPWL_ComboBox::SetPopup().
+2023-05-11 dorianrudo97@gmail.com Save dash array and phase of GraphState in CPDF_PageContentGenerator
+
+If this roll has caused a breakage, revert this CL and stop the roller
+using the controls here:
+https://autoroll.skia.org/r/pdfium-autoroll
+Please CC dhoss@chromium.org,pdfium-deps-rolls@chromium.org,thestig@chromium.org on the revert to ensure that a human
+is aware of the problem.
+
+To file a bug in PDFium: https://bugs.chromium.org/p/pdfium/issues/entry
+To file a bug in Chromium: https://bugs.chromium.org/p/chromium/issues/entry
+
+To report a problem with the AutoRoller itself, please file a bug:
+https://bugs.chromium.org/p/skia/issues/entry?template=Autoroller+Bug
+
+Documentation for the AutoRoller is here:
+https://skia.googlesource.com/buildbot/+doc/main/autoroll/README.md
+
+Bug: chromium:1444238,chromium:1444581
+Tbr: pdfium-deps-rolls@chromium.org
+Change-Id: I48188bbffa2048b5adf6abaeadd097dcd331fcb0
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4527458
+Commit-Queue: chromium-autoroll <chromium-autoroll@skia-public.iam.gserviceaccount.com>
+Bot-Commit: chromium-autoroll <chromium-autoroll@skia-public.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/heads/main@{#1143435}
+---
+
+diff --git a/DEPS b/DEPS
+index 944222b..6f6cb1d 100644
+--- a/DEPS
++++ b/DEPS
+@@ -316,7 +316,7 @@
+   # Three lines of non-changing comments so that
+   # the commit queue can handle CLs rolling PDFium
+   # and whatever else without interference from each other.
+-  'pdfium_revision': '4c16842f61a150b40c4dd104775dec19225ae7fe',
++  'pdfium_revision': 'e60fa0d7d7733b23c444daa048dd509972d68cfe',
+   # Three lines of non-changing comments so that
+   # the commit queue can handle CLs rolling BoringSSL
+   # and whatever else without interference from each other.


### PR DESCRIPTION
<details>
<summary>electron/security#353 - e6b75a8b4900 from chromium</summary>
Roll PDFium from 4c16842f61a1 to e60fa0d7d773 (6 revisions)

https://pdfium.googlesource.com/pdfium.git/+log/4c16842f61a1..e60fa0d7d773

2023-05-12 thestig@chromium.org Remove struct CFX_CTTGSUBTable::TLangSysRecord
2023-05-11 thestig@chromium.org Stop storing `CFX_Font::m_pSubData`
2023-05-11 thestig@chromium.org Improve error handling in CPDF_CIDFont::GetGlyphIndex()
2023-05-11 tsepez@chromium.org Observe widget across SetOptionSelection() calls.
2023-05-11 tsepez@chromium.org Always check return code from CPWL_ComboBox::SetPopup().
2023-05-11 dorianrudo97@gmail.com Save dash array and phase of GraphState in CPDF_PageContentGenerator

If this roll has caused a breakage, revert this CL and stop the roller
using the controls here:
https://autoroll.skia.org/r/pdfium-autoroll
Please CC dhoss@chromium.org,pdfium-deps-rolls@chromium.org,thestig@chromium.org on the revert to ensure that a human
is aware of the problem.

To file a bug in PDFium: https://bugs.chromium.org/p/pdfium/issues/entry
To file a bug in Chromium: https://bugs.chromium.org/p/chromium/issues/entry

To report a problem with the AutoRoller itself, please file a bug:
https://bugs.chromium.org/p/skia/issues/entry?template=Autoroller+Bug

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+doc/main/autoroll/README.md

Bug: chromium:1444238,chromium:1444581
Tbr: pdfium-deps-rolls@chromium.org
Change-Id: I48188bbffa2048b5adf6abaeadd097dcd331fcb0
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4527458
Commit-Queue: chromium-autoroll <chromium-autoroll@skia-public.iam.gserviceaccount.com>
Bot-Commit: chromium-autoroll <chromium-autoroll@skia-public.iam.gserviceaccount.com>
Cr-Commit-Position: refs/heads/main@{#1143435}
</details>

Notes:
* Security: backported fix for CVE-2023-2931.