### PR TITLE
perf: avoid unnecessary base value clone

### DIFF
--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -329,10 +329,8 @@ void ElectronBrowserContext::InitPrefs() {
 #endif
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
-  base::Value::List current_dictionaries =
-      prefs()->GetList(spellcheck::prefs::kSpellCheckDictionaries).Clone();
   // No configured dictionaries, the default will be en-US
-  if (current_dictionaries.empty()) {
+  if (prefs()->GetList(spellcheck::prefs::kSpellCheckDictionaries).empty()) {
     std::string default_code = spellcheck::GetCorrespondingSpellCheckLanguage(
         base::i18n::GetConfiguredLocale());
     if (!default_code.empty()) {

--- a/shell/browser/mac/dict_util.mm
+++ b/shell/browser/mac/dict_util.mm
@@ -14,7 +14,7 @@ namespace electron {
 
 NSArray* ListValueToNSArray(const base::Value::List& value) {
   std::string json;
-  if (!base::JSONWriter::Write(base::Value(value.Clone()), &json))
+  if (!base::JSONWriter::Write(base::ValueView{value}, &json))
     return nil;
   NSData* jsonData = [NSData dataWithBytes:json.c_str() length:json.length()];
   id obj = [NSJSONSerialization JSONObjectWithData:jsonData
@@ -57,7 +57,7 @@ base::Value::List NSArrayToValue(NSArray* arr) {
 
 NSDictionary* DictionaryValueToNSDictionary(const base::Value::Dict& value) {
   std::string json;
-  if (!base::JSONWriter::Write(base::Value(value.Clone()), &json))
+  if (!base::JSONWriter::Write(base::ValueView{value}, &json))
     return nil;
   NSData* jsonData = [NSData dataWithBytes:json.c_str() length:json.length()];
   id obj = [NSJSONSerialization JSONObjectWithData:jsonData

--- a/shell/browser/usb/usb_chooser_context.cc
+++ b/shell/browser/usb/usb_chooser_context.cc
@@ -206,7 +206,7 @@ void UsbChooserContext::RevokeObjectPermissionInternal(
     v8::HandleScope scope(isolate);
     gin_helper::Dictionary details =
         gin_helper::Dictionary::CreateEmpty(isolate);
-    details.Set("device", object.Clone());
+    details.Set("device", object);
     details.Set("origin", origin.Serialize());
     session->Emit("usb-device-revoked", details);
   }

--- a/shell/common/gin_converters/extension_converter.cc
+++ b/shell/common/gin_converters/extension_converter.cc
@@ -22,7 +22,7 @@ v8::Local<v8::Value> Converter<const extensions::Extension*>::ToV8(
   dict.Set("path", extension->path());
   dict.Set("url", extension->url());
   dict.Set("version", extension->VersionString());
-  dict.Set("manifest", extension->manifest()->value()->Clone());
+  dict.Set("manifest", *extension->manifest()->value());
 
   return gin::ConvertToV8(isolate, dict);
 }

--- a/shell/common/gin_converters/value_converter.cc
+++ b/shell/common/gin_converters/value_converter.cc
@@ -25,14 +25,6 @@ bool Converter<base::Value::Dict>::FromV8(v8::Isolate* isolate,
   }
 }
 
-v8::Local<v8::Value> Converter<base::Value::Dict>::ToV8(
-    v8::Isolate* isolate,
-    const base::Value::Dict& val) {
-  base::Value value(val.Clone());
-  return content::V8ValueConverter::Create()->ToV8Value(
-      value, isolate->GetCurrentContext());
-}
-
 bool Converter<base::Value>::FromV8(v8::Isolate* isolate,
                                     v8::Local<v8::Value> val,
                                     base::Value* out) {
@@ -47,8 +39,9 @@ bool Converter<base::Value>::FromV8(v8::Isolate* isolate,
   }
 }
 
-v8::Local<v8::Value> Converter<base::Value>::ToV8(v8::Isolate* isolate,
-                                                  const base::Value& val) {
+v8::Local<v8::Value> Converter<base::ValueView>::ToV8(
+    v8::Isolate* isolate,
+    const base::ValueView val) {
   return content::V8ValueConverter::Create()->ToV8Value(
       val, isolate->GetCurrentContext());
 }
@@ -65,14 +58,6 @@ bool Converter<base::Value::List>::FromV8(v8::Isolate* isolate,
   } else {
     return false;
   }
-}
-
-v8::Local<v8::Value> Converter<base::Value::List>::ToV8(
-    v8::Isolate* isolate,
-    const base::Value::List& val) {
-  base::Value value(val.Clone());
-  return content::V8ValueConverter::Create()->ToV8Value(
-      value, isolate->GetCurrentContext());
 }
 
 }  // namespace gin

--- a/shell/common/gin_converters/value_converter.h
+++ b/shell/common/gin_converters/value_converter.h
@@ -11,12 +11,20 @@
 namespace gin {
 
 template <>
+struct Converter<base::ValueView> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const base::ValueView val);
+};
+
+template <>
 struct Converter<base::Value::Dict> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      base::Value::Dict* out);
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   const base::Value::Dict& val);
+                                   const base::Value::Dict& val) {
+    return gin::ConvertToV8(isolate, base::ValueView{val});
+  }
 };
 
 template <>
@@ -25,7 +33,9 @@ struct Converter<base::Value> {
                      v8::Local<v8::Value> val,
                      base::Value* out);
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   const base::Value& val);
+                                   const base::Value& val) {
+    return gin::ConvertToV8(isolate, base::ValueView{val});
+  }
 };
 
 template <>
@@ -34,7 +44,9 @@ struct Converter<base::Value::List> {
                      v8::Local<v8::Value> val,
                      base::Value::List* out);
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   const base::Value::List& val);
+                                   const base::Value::List& val) {
+    return gin::ConvertToV8(isolate, base::ValueView{val});
+  }
 };
 
 }  // namespace gin


### PR DESCRIPTION
#### Description of Change

Avoid redundant / unnecessary calls to `base::Value::Clone()`, `base::Value::List::Clone()`, `base::Value::Dict::Clone()`:

Most of this is updating our code to use `base::ValueView` introduced [here](https://chromium-review.googlesource.com/c/chromium/src/+/3466767). tl;dr it's a read-only adapter for Value, Value::Dict, and Value::List.

- when we're converting dicts and lists to V8, use `base::ValueView` to pass originals by const ref instead of cloning. (This really just involves us marshalling the args correctly,  since upstream code `V8ValueConverter` [already uses `base::ValueView`](https://chromium-review.googlesource.com/c/chromium/src/+/3737382).)
- the previous change allows a couple of one-off improvements, e.g. avoid cloning when emitting `usb-device-revoked`
- since `base::JSONWriter` [has been updated to use `base::ValueView`](https://chromium-review.googlesource.com/c/chromium/src/+/3466767), we can avoid cloning in `ListValueToNSArray()` and `DictionaryValueToNSDictionary()`
- one change that doesn't involve `ValueView`:  `ElectronBrowserContext::InitPrefs()` cloned a list only to test if it was empty or not (side-effect of 08ccc815748fcc55b319c7ee73ae90202bc44fa0). Just test the original instead.

No particular stakeholders, but all reviews welcomed.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none