### PR TITLE
build: fix doc-only early exit on Appveyor

### DIFF
--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -68,9 +68,11 @@ for:
           node script/yarn.js install --frozen-lockfile
           node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER
           if ($LASTEXITCODE -eq 0) {
-            Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
+            Write-warning "Skipping build for doc only change"
+            Exit-AppveyorBuild
+          } else {
+            $global:LASTEXITCODE = 0
           }
-          $global:LASTEXITCODE = 0
       - cd ..
       - ps: Write-Host "Building $env:GN_CONFIG build"
       - git config --global core.longpaths true
@@ -222,9 +224,11 @@ for:
           node script/yarn.js install --frozen-lockfile
           node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER
           if ($LASTEXITCODE -eq 0) {
-            Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
+            Write-warning "Skipping build for doc only change"
+            Exit-AppveyorBuild
+          } else {
+            $global:LASTEXITCODE = 0
           }
-          $global:LASTEXITCODE = 0
       - cd ..
       - mkdir out\Default
       - cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,9 +66,11 @@ for:
           node script/yarn.js install --frozen-lockfile
           node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER
           if ($LASTEXITCODE -eq 0) {
-            Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
+            Write-warning "Skipping build for doc only change"
+            Exit-AppveyorBuild
+          } else {
+            $global:LASTEXITCODE = 0
           }
-          $global:LASTEXITCODE = 0
       - cd ..
       - ps: Write-Host "Building $env:GN_CONFIG build"
       - git config --global core.longpaths true
@@ -218,9 +220,11 @@ for:
           node script/yarn.js install --frozen-lockfile
           node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER
           if ($LASTEXITCODE -eq 0) {
-            Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
+            Write-warning "Skipping build for doc only change"
+            Exit-AppveyorBuild
+          } else {
+            $global:LASTEXITCODE = 0
           }
-          $global:LASTEXITCODE = 0
       - cd ..
       - mkdir out\Default
       - cd ..


### PR DESCRIPTION
#### Description of Change

Refs https://help.appveyor.com/discussions/problems/28242-exit-appveyorbuild-command-doesnt-work-in-if-statement

Fixes doc-only script exit not actually exiting on Appveyor, as seen [here](https://ci.appveyor.com/project/electron-bot/electron-ia32-testing/builds/47196053/job/b740sas00gsr8j7n?fullLog=true#L32).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
