### PR TITLE
fix: file selection when disallowed on macOS

### DIFF
--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -281,11 +281,29 @@ void ReadDialogPathsWithBookmarks(NSOpenPanel* dialog,
                                   std::vector<base::FilePath>* paths,
                                   std::vector<std::string>* bookmarks) {
   NSArray* urls = [dialog URLs];
-  for (NSURL* url in urls)
-    if ([url isFileURL]) {
-      paths->emplace_back(base::SysNSStringToUTF8([url path]));
-      bookmarks->push_back(GetBookmarkDataFromNSURL(url));
+  for (NSURL* url in urls) {
+    if (![url isFileURL])
+      continue;
+
+    NSString* path = [url path];
+
+    // There's a bug in macOS where despite a request to disallow file
+    // selection, files/packages can be selected. If file selection
+    // was disallowed, drop any files selected. See crbug.com/1357523.
+    if (![dialog canChooseFiles]) {
+      BOOL is_directory;
+      BOOL exists =
+          [[NSFileManager defaultManager] fileExistsAtPath:path
+                                               isDirectory:&is_directory];
+      BOOL is_package =
+          [[NSWorkspace sharedWorkspace] isFilePackageAtPath:path];
+      if (!exists || !is_directory || is_package)
+        continue;
     }
+
+    paths->emplace_back(base::SysNSStringToUTF8(path));
+    bookmarks->push_back(GetBookmarkDataFromNSURL(url));
+  }
 }
 
 void ReadDialogPaths(NSOpenPanel* dialog, std::vector<base::FilePath>* paths) {


### PR DESCRIPTION
#### Description of Change

Refs [crbug.com/1357523](crbug.com/1357523)

Fixes an issue where files could in some circumstances be selection when `openFile` was not passed as a dialog property. Essentially, there's a bug in macOS where despite a request to disallow file selection, files/packages can be selected. If file selection was disallowed, we should drop any files selected.

Reproducible with the following:

<details><summary>Code Snippet</summary>

```js
const { app, BrowserWindow, dialog } = require('electron')

app.whenReady().then(() => {
  const mainWindow = new BrowserWindow()

  dialog.showOpenDialog(mainWindow, { properties: [] }).then(result => {
    if (result.canceled) {
      console.log('Dialog was canceled')
    } else if (result.filePaths.length > 0) {
      const file = result.filePaths[0]
      mainWindow.loadURL(`file://${file}`)
    } else {
      console.log('No files were selected')
    }
  }).catch(err => {
    console.log(err)
  })
})
```

</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where files could in some circumstances be selection when `openFile` was not passed as a dialog property. 