### PR TITLE
refactor: use direct aggregation in NativeWindowViews

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -164,8 +164,9 @@ class NativeWindowClientView : public views::ClientView {
  public:
   NativeWindowClientView(views::Widget* widget,
                          views::View* root_view,
-                         NativeWindowViews& window)
-      : views::ClientView{widget, root_view}, window_{window} {}
+                         NativeWindowViews* window)
+      : views::ClientView{widget, root_view},
+        window_{raw_ref<NativeWindowViews>::from_ptr(window)} {}
   ~NativeWindowClientView() override = default;
 
   // disable copy
@@ -1636,7 +1637,7 @@ bool NativeWindowViews::ShouldDescendIntoChildForEventHandling(
 }
 
 views::ClientView* NativeWindowViews::CreateClientView(views::Widget* widget) {
-  return new NativeWindowClientView{widget, GetContentsView(), *this};
+  return new NativeWindowClientView{widget, GetContentsView(), this};
 }
 
 std::unique_ptr<views::NonClientFrameView>

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -164,8 +164,8 @@ class NativeWindowClientView : public views::ClientView {
  public:
   NativeWindowClientView(views::Widget* widget,
                          views::View* root_view,
-                         NativeWindowViews* window)
-      : views::ClientView(widget, root_view), window_(window) {}
+                         NativeWindowViews& window)
+      : views::ClientView{widget, root_view}, window_{window} {}
   ~NativeWindowClientView() override = default;
 
   // disable copy
@@ -178,7 +178,7 @@ class NativeWindowClientView : public views::ClientView {
   }
 
  private:
-  raw_ptr<NativeWindowViews> window_;
+  const raw_ref<NativeWindowViews> window_;
 };
 
 }  // namespace
@@ -1636,7 +1636,7 @@ bool NativeWindowViews::ShouldDescendIntoChildForEventHandling(
 }
 
 views::ClientView* NativeWindowViews::CreateClientView(views::Widget* widget) {
-  return new NativeWindowClientView{widget, GetContentsView(), this};
+  return new NativeWindowClientView{widget, GetContentsView(), *this};
 }
 
 std::unique_ptr<views::NonClientFrameView>

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -187,14 +187,13 @@ class NativeWindowClientView : public views::ClientView {
 NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
                                      NativeWindow* parent)
     : NativeWindow(options, parent),
-      root_view_(std::make_unique<RootView>(this)),
       keyboard_event_handler_(
           std::make_unique<views::UnhandledKeyboardEventHandler>()) {
   options.Get(options::kTitle, &title_);
 
   bool menu_bar_autohide;
   if (options.Get(options::kAutoHideMenuBar, &menu_bar_autohide))
-    root_view_->SetAutoHideMenuBar(menu_bar_autohide);
+    root_view_.SetAutoHideMenuBar(menu_bar_autohide);
 
 #if BUILDFLAG(IS_WIN)
   // On Windows we rely on the CanResize() to indicate whether window can be
@@ -455,12 +454,12 @@ void NativeWindowViews::SetGTKDarkThemeEnabled(bool use_dark_theme) {
 
 void NativeWindowViews::SetContentView(views::View* view) {
   if (content_view()) {
-    root_view_->RemoveChildView(content_view());
+    root_view_.RemoveChildView(content_view());
   }
   set_content_view(view);
   focused_view_ = view;
-  root_view_->AddChildView(content_view());
-  root_view_->Layout();
+  root_view_.AddChildView(content_view());
+  root_view_.Layout();
 }
 
 void NativeWindowViews::Close() {
@@ -1097,7 +1096,7 @@ bool NativeWindowViews::IsTabletMode() const {
 }
 
 SkColor NativeWindowViews::GetBackgroundColor() {
-  auto* background = root_view_->background();
+  auto* background = root_view_.background();
   if (!background)
     return SK_ColorTRANSPARENT;
   return background->get_color();
@@ -1105,7 +1104,7 @@ SkColor NativeWindowViews::GetBackgroundColor() {
 
 void NativeWindowViews::SetBackgroundColor(SkColor background_color) {
   // web views' background color.
-  root_view_->SetBackground(views::CreateSolidBackground(background_color));
+  root_view_.SetBackground(views::CreateSolidBackground(background_color));
 
 #if BUILDFLAG(IS_WIN)
   // Set the background color of native window.
@@ -1240,7 +1239,7 @@ void NativeWindowViews::SetMenu(ElectronMenuModel* menu_model) {
   // Remove global menu bar.
   if (global_menu_bar_ && menu_model == nullptr) {
     global_menu_bar_.reset();
-    root_view_->UnregisterAcceleratorsWithFocusManager();
+    root_view_.UnregisterAcceleratorsWithFocusManager();
     return;
   }
 
@@ -1249,7 +1248,7 @@ void NativeWindowViews::SetMenu(ElectronMenuModel* menu_model) {
     if (!global_menu_bar_)
       global_menu_bar_ = std::make_unique<GlobalMenuBarX11>(this);
     if (global_menu_bar_->IsServerStarted()) {
-      root_view_->RegisterAcceleratorsWithFocusManager(menu_model);
+      root_view_.RegisterAcceleratorsWithFocusManager(menu_model);
       global_menu_bar_->SetMenu(menu_model);
       return;
     }
@@ -1260,13 +1259,13 @@ void NativeWindowViews::SetMenu(ElectronMenuModel* menu_model) {
   gfx::Size content_size = GetContentSize();
   bool should_reset_size = use_content_size_ && has_frame() &&
                            !IsMenuBarAutoHide() &&
-                           ((!!menu_model) != root_view_->HasMenu());
+                           ((!!menu_model) != root_view_.HasMenu());
 
-  root_view_->SetMenu(menu_model);
+  root_view_.SetMenu(menu_model);
 
   if (should_reset_size) {
     // Enlarge the size constraints for the menu.
-    int menu_bar_height = root_view_->GetMenuBarHeight();
+    int menu_bar_height = root_view_.GetMenuBarHeight();
     extensions::SizeConstraints constraints = GetContentSizeConstraints();
     if (constraints.HasMinimumSize()) {
       gfx::Size min_size = constraints.GetMinimumSize();
@@ -1393,19 +1392,19 @@ void NativeWindowViews::SetOverlayIcon(const gfx::Image& overlay,
 }
 
 void NativeWindowViews::SetAutoHideMenuBar(bool auto_hide) {
-  root_view_->SetAutoHideMenuBar(auto_hide);
+  root_view_.SetAutoHideMenuBar(auto_hide);
 }
 
 bool NativeWindowViews::IsMenuBarAutoHide() {
-  return root_view_->IsMenuBarAutoHide();
+  return root_view_.IsMenuBarAutoHide();
 }
 
 void NativeWindowViews::SetMenuBarVisibility(bool visible) {
-  root_view_->SetMenuBarVisibility(visible);
+  root_view_.SetMenuBarVisibility(visible);
 }
 
 bool NativeWindowViews::IsMenuBarVisible() {
-  return root_view_->IsMenuBarVisible();
+  return root_view_.IsMenuBarVisible();
 }
 
 void NativeWindowViews::SetBackgroundMaterial(const std::string& material) {
@@ -1503,8 +1502,8 @@ gfx::Rect NativeWindowViews::ContentBoundsToWindowBounds(
   }
 #endif
 
-  if (root_view_->HasMenu() && root_view_->IsMenuBarVisible()) {
-    int menu_bar_height = root_view_->GetMenuBarHeight();
+  if (root_view_.HasMenu() && root_view_.IsMenuBarVisible()) {
+    int menu_bar_height = root_view_.GetMenuBarHeight();
     window_bounds.set_y(window_bounds.y() - menu_bar_height);
     window_bounds.set_height(window_bounds.height() + menu_bar_height);
   }
@@ -1530,8 +1529,8 @@ gfx::Rect NativeWindowViews::WindowBoundsToContentBounds(
   content_bounds.set_size(ScreenToDIPRect(hwnd, content_bounds).size());
 #endif
 
-  if (root_view_->HasMenu() && root_view_->IsMenuBarVisible()) {
-    int menu_bar_height = root_view_->GetMenuBarHeight();
+  if (root_view_.HasMenu() && root_view_.IsMenuBarVisible()) {
+    int menu_bar_height = root_view_.GetMenuBarHeight();
     content_bounds.set_y(content_bounds.y() + menu_bar_height);
     content_bounds.set_height(content_bounds.height() - menu_bar_height);
   }
@@ -1574,7 +1573,7 @@ void NativeWindowViews::OnWidgetActivationChanged(views::Widget* changed_widget,
   if (!active && IsMenuBarAutoHide() && IsMenuBarVisible())
     SetMenuBarVisibility(false);
 
-  root_view_->ResetAltState();
+  root_view_.ResetAltState();
 }
 
 void NativeWindowViews::OnWidgetBoundsChanged(views::Widget* changed_widget,
@@ -1630,7 +1629,7 @@ std::u16string NativeWindowViews::GetWindowTitle() const {
 }
 
 views::View* NativeWindowViews::GetContentsView() {
-  return root_view_.get();
+  return &root_view_;
 }
 
 bool NativeWindowViews::ShouldDescendIntoChildForEventHandling(
@@ -1640,7 +1639,7 @@ bool NativeWindowViews::ShouldDescendIntoChildForEventHandling(
 }
 
 views::ClientView* NativeWindowViews::CreateClientView(views::Widget* widget) {
-  return new NativeWindowClientView(widget, root_view_.get(), this);
+  return new NativeWindowClientView{widget, GetContentsView(), this};
 }
 
 std::unique_ptr<views::NonClientFrameView>
@@ -1680,8 +1679,8 @@ void NativeWindowViews::HandleKeyboardEvent(
 #endif
 
   keyboard_event_handler_->HandleKeyboardEvent(event,
-                                               root_view_->GetFocusManager());
-  root_view_->HandleKeyEvent(event);
+                                               root_view_.GetFocusManager());
+  root_view_.HandleKeyEvent(event);
 }
 
 void NativeWindowViews::OnMouseEvent(ui::MouseEvent* event) {
@@ -1689,7 +1688,7 @@ void NativeWindowViews::OnMouseEvent(ui::MouseEvent* event) {
     return;
 
   // Alt+Click should not toggle menu bar.
-  root_view_->ResetAltState();
+  root_view_.ResetAltState();
 
 #if BUILDFLAG(IS_LINUX)
   if (event->changed_button_flags() == ui::EF_BACK_MOUSE_BUTTON)

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -36,7 +36,6 @@
 #include "ui/gfx/image/image.h"
 #include "ui/gfx/native_widget_types.h"
 #include "ui/views/background.h"
-#include "ui/views/controls/webview/unhandled_keyboard_event_handler.h"
 #include "ui/views/controls/webview/webview.h"
 #include "ui/views/widget/native_widget_private.h"
 #include "ui/views/widget/widget.h"
@@ -186,9 +185,7 @@ class NativeWindowClientView : public views::ClientView {
 
 NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
                                      NativeWindow* parent)
-    : NativeWindow(options, parent),
-      keyboard_event_handler_(
-          std::make_unique<views::UnhandledKeyboardEventHandler>()) {
+    : NativeWindow(options, parent) {
   options.Get(options::kTitle, &title_);
 
   bool menu_bar_autohide;
@@ -1678,8 +1675,8 @@ void NativeWindowViews::HandleKeyboardEvent(
     NotifyWindowExecuteAppCommand(kBrowserForward);
 #endif
 
-  keyboard_event_handler_->HandleKeyboardEvent(event,
-                                               root_view_.GetFocusManager());
+  keyboard_event_handler_.HandleKeyboardEvent(event,
+                                              root_view_.GetFocusManager());
   root_view_.HandleKeyEvent(event);
 }
 

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -14,6 +14,7 @@
 
 #include "base/memory/raw_ptr.h"
 #include "shell/browser/ui/views/root_view.h"
+#include "ui/views/controls/webview/unhandled_keyboard_event_handler.h"
 #include "ui/views/widget/widget_observer.h"
 
 #if defined(USE_OZONE)
@@ -28,10 +29,6 @@
 #include "shell/browser/ui/win/taskbar_host.h"
 
 #endif
-
-namespace views {
-class UnhandledKeyboardEventHandler;
-}
 
 namespace electron {
 
@@ -322,7 +319,7 @@ class NativeWindowViews : public NativeWindow,
 #endif
 
   // Handles unhandled keyboard messages coming back from the renderer process.
-  std::unique_ptr<views::UnhandledKeyboardEventHandler> keyboard_event_handler_;
+  views::UnhandledKeyboardEventHandler keyboard_event_handler_;
 
   // Whether the window should be enabled based on user calls to SetEnabled()
   bool is_enabled_ = true;

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
+#include "shell/browser/ui/views/root_view.h"
 #include "ui/views/widget/widget_observer.h"
 
 #if defined(USE_OZONE)
@@ -35,7 +36,6 @@ class UnhandledKeyboardEventHandler;
 namespace electron {
 
 class GlobalMenuBarX11;
-class RootView;
 class WindowStateWatcher;
 
 #if defined(USE_OZONE_PLATFORM_X11)
@@ -251,7 +251,7 @@ class NativeWindowViews : public NativeWindow,
   // Maintain window placement.
   void MoveBehindTaskBarIfNeeded();
 
-  std::unique_ptr<RootView> root_view_;
+  RootView root_view_{this};
 
   // The view should be focused by default.
   raw_ptr<views::View> focused_view_ = nullptr;


### PR DESCRIPTION
#### Description of Change

**What:** Before and after this PR, `NativeWindowViews` owns a `RootView` and `KeyboardEventHandler` that are created in the constructor and destroyed in the destructor. Previously they were implemented as `unique_ptr`s. This PR removes the `unique_ptr` wrapper and aggregates them directly.

**Why:** we pass a *lot* of pointers around and it's often difficult to tell who owns a pointer & what its lifecycle is. Using direct aggregation makes it explicit and clear that these two fields' lifecycles are identical to the NativeWindowViews that owns them.

If the team is OK with this change there are other places where similar changes are possible, so for this trial balloon PR I'm CC'ing people who have been active in shell/lbrowser/ui and shelll/browser/api recently: @codebytere @deepak1556 @dsanders11 @jkleinsc @miniak @zcbenz

Fun side note: first use of `raw_ref` in Electron. [Upstream usage guidelines here](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md#non_owning-pointers-in-class-fields). 


#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none