### PR TITLE
chore: remove unused electron::api::View code

### DIFF
--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -21,20 +21,6 @@ View::~View() {
     delete view_;
 }
 
-#if BUILDFLAG(ENABLE_VIEWS_API)
-void View::AddChildView(gin::Handle<View> child) {
-  AddChildViewAt(child, child_views_.size());
-}
-
-void View::AddChildViewAt(gin::Handle<View> child, size_t index) {
-  if (index > child_views_.size())
-    return;
-  child_views_.emplace(child_views_.begin() + index,     // index
-                       isolate(), child->GetWrapper());  // v8::Global(args...)
-  view()->AddChildViewAt(child->view(), index);
-}
-#endif
-
 // static
 gin_helper::WrappableBase* View::New(gin::Arguments* args) {
   auto* view = new View();
@@ -46,11 +32,6 @@ gin_helper::WrappableBase* View::New(gin::Arguments* args) {
 void View::BuildPrototype(v8::Isolate* isolate,
                           v8::Local<v8::FunctionTemplate> prototype) {
   prototype->SetClassName(gin::StringToV8(isolate, "View"));
-#if BUILDFLAG(ENABLE_VIEWS_API)
-  gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
-      .SetMethod("addChildView", &View::AddChildView)
-      .SetMethod("addChildViewAt", &View::AddChildViewAt);
-#endif
 }
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -5,10 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_API_ELECTRON_API_VIEW_H_
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_VIEW_H_
 
-#include <vector>
-
 #include "base/memory/raw_ptr.h"
-#include "electron/buildflags/buildflags.h"
 #include "gin/handle.h"
 #include "shell/common/gin_helper/wrappable.h"
 #include "ui/views/view.h"
@@ -21,11 +18,6 @@ class View : public gin_helper::Wrappable<View> {
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
-
-#if BUILDFLAG(ENABLE_VIEWS_API)
-  void AddChildView(gin::Handle<View> child);
-  void AddChildViewAt(gin::Handle<View> child, size_t index);
-#endif
 
   views::View* view() const { return view_; }
 
@@ -42,8 +34,6 @@ class View : public gin_helper::Wrappable<View> {
   void set_delete_view(bool should) { delete_view_ = should; }
 
  private:
-  std::vector<v8::Global<v8::Object>> child_views_;
-
   bool delete_view_ = true;
   raw_ptr<views::View> view_ = nullptr;
 };


### PR DESCRIPTION
#### Description of Change

Remove code in `electron::api::View` that was added in 2c8dc9e but is now unused. Short discussion today in `#ask-anything` from with @zcbenz confirming it should be safe to just remove the code.

CC: @zcbenz 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none