### PR TITLE
docs: clarify which electron modules are exposed in sandboxed renderers

### DIFF
--- a/docs/tutorial/sandbox.md
+++ b/docs/tutorial/sandbox.md
@@ -46,7 +46,7 @@ scripts attached to sandboxed renderers will still have a polyfilled subset of N
 APIs available. A `require` function similar to Node's `require` module is exposed,
 but can only import a subset of Electron and Node's built-in modules:
 
-* `electron` (only renderer process modules)
+* `electron` (following renderer process modules: `contextBridge`, `crashReporter`, `ipcRenderer`, `nativeImage`, `webFrame`)
 * [`events`](https://nodejs.org/api/events.html)
 * [`timers`](https://nodejs.org/api/timers.html)
 * [`url`](https://nodejs.org/api/url.html)


### PR DESCRIPTION
Notes: none