### PR TITLE
fix: sync api::Screen wrapper method sigs to upstream

### DIFF
--- a/shell/browser/api/electron_api_screen.cc
+++ b/shell/browser/api/electron_api_screen.cc
@@ -87,22 +87,6 @@ gfx::Point Screen::GetCursorScreenPoint(v8::Isolate* isolate) {
   return screen_->GetCursorScreenPoint();
 }
 
-display::Display Screen::GetPrimaryDisplay() {
-  return screen_->GetPrimaryDisplay();
-}
-
-std::vector<display::Display> Screen::GetAllDisplays() {
-  return screen_->GetAllDisplays();
-}
-
-display::Display Screen::GetDisplayNearestPoint(const gfx::Point& point) {
-  return screen_->GetDisplayNearestPoint(point);
-}
-
-display::Display Screen::GetDisplayMatching(const gfx::Rect& match_rect) {
-  return screen_->GetDisplayMatching(match_rect);
-}
-
 #if BUILDFLAG(IS_WIN)
 
 static gfx::Rect ScreenToDIPRect(electron::NativeWindow* window,

--- a/shell/browser/api/electron_api_screen.h
+++ b/shell/browser/api/electron_api_screen.h
@@ -42,10 +42,18 @@ class Screen : public gin::Wrappable<Screen>,
   ~Screen() override;
 
   gfx::Point GetCursorScreenPoint(v8::Isolate* isolate);
-  display::Display GetPrimaryDisplay();
-  std::vector<display::Display> GetAllDisplays();
-  display::Display GetDisplayNearestPoint(const gfx::Point& point);
-  display::Display GetDisplayMatching(const gfx::Rect& match_rect);
+  display::Display GetPrimaryDisplay() const {
+    return screen_->GetPrimaryDisplay();
+  }
+  const std::vector<display::Display>& GetAllDisplays() const {
+    return screen_->GetAllDisplays();
+  }
+  display::Display GetDisplayNearestPoint(const gfx::Point& point) const {
+    return screen_->GetDisplayNearestPoint(point);
+  }
+  display::Display GetDisplayMatching(const gfx::Rect& match_rect) const {
+    return screen_->GetDisplayMatching(match_rect);
+  }
 
   // display::DisplayObserver:
   void OnDisplayAdded(const display::Display& new_display) override;


### PR DESCRIPTION
#### Description of Change

Sync the signatures of the `api::Screen`'s Display wrappers  to match the `ui::Display` methods that they wrap:

- make `GetAllDisplays()` const and return a const reference. Currently we're always returning a new vector.
- make `GetPrimaryDisplay()` const
- make `GetDisplayNearestPoint()` const
- make `GetDisplayMatching()` const

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none