### PR TITLE
fix: menu bar visibility when exiting full screen

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -731,10 +731,14 @@ void NativeWindowViews::SetFullScreen(bool fullscreen) {
                                             gfx::Rect());
 
   // Auto-hide menubar when in fullscreen.
-  if (fullscreen)
+  if (fullscreen){
+    menu_bar_visible_before_fullscreen_ = IsMenuBarVisible();
     SetMenuBarVisibility(false);
-  else
-    SetMenuBarVisibility(!IsMenuBarAutoHide());
+  }
+  else{
+    SetMenuBarVisibility(!IsMenuBarAutoHide() && menu_bar_visible_before_fullscreen_);
+    menu_bar_visible_before_fullscreen_ = false;
+  }
 #endif
 }
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -731,12 +731,12 @@ void NativeWindowViews::SetFullScreen(bool fullscreen) {
                                             gfx::Rect());
 
   // Auto-hide menubar when in fullscreen.
-  if (fullscreen){
+  if (fullscreen) {
     menu_bar_visible_before_fullscreen_ = IsMenuBarVisible();
     SetMenuBarVisibility(false);
-  }
-  else{
-    SetMenuBarVisibility(!IsMenuBarAutoHide() && menu_bar_visible_before_fullscreen_);
+  } else {
+    SetMenuBarVisibility(!IsMenuBarAutoHide() &&
+                         menu_bar_visible_before_fullscreen_);
     menu_bar_visible_before_fullscreen_ = false;
   }
 #endif

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -321,7 +321,7 @@ class NativeWindowViews : public NativeWindow,
   // Handles unhandled keyboard messages coming back from the renderer process.
   views::UnhandledKeyboardEventHandler keyboard_event_handler_;
 
-  // Whether the menubar is visible before fullscreen entered
+  // Whether the menubar is visible before the window enters fullscreen
   bool menu_bar_visible_before_fullscreen_ = false;
 
   // Whether the window should be enabled based on user calls to SetEnabled()

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -320,6 +320,9 @@ class NativeWindowViews : public NativeWindow,
 
   // Handles unhandled keyboard messages coming back from the renderer process.
   views::UnhandledKeyboardEventHandler keyboard_event_handler_;
+  
+  // Whether the menubar is visible before fullscreen entered
+  bool menu_bar_visible_before_fullscreen_ = false;
 
   // Whether the window should be enabled based on user calls to SetEnabled()
   bool is_enabled_ = true;

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -320,7 +320,7 @@ class NativeWindowViews : public NativeWindow,
 
   // Handles unhandled keyboard messages coming back from the renderer process.
   views::UnhandledKeyboardEventHandler keyboard_event_handler_;
-  
+
   // Whether the menubar is visible before fullscreen entered
   bool menu_bar_visible_before_fullscreen_ = false;
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5344,7 +5344,7 @@ describe('BrowserWindow module', () => {
         expect(w.isMenuBarVisible()).to.be.true('isMenuBarVisible');
         w.setMenuBarVisibility(false);
         expect(w.isMenuBarVisible()).to.be.false('isMenuBarVisible');
-    
+
         const enterFS = once(w, 'enter-full-screen');
         w.setFullScreen(true);
         await enterFS;
@@ -5354,7 +5354,7 @@ describe('BrowserWindow module', () => {
         w.setFullScreen(false);
         await exitFS;
         expect(w.fullScreen).to.be.false('not fullscreen');
-    
+
         expect(w.isMenuBarVisible()).to.be.false('isMenuBarVisible');
       });
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5338,7 +5338,7 @@ describe('BrowserWindow module', () => {
       });
     });
 
-    describe('when fullscreen state is changed', () => {
+    ifdescribe(process.platform !== 'darwin')('when fullscreen state is changed', () => {
       it('correctly remembers state prior to fullscreen change', async () => {
         const w = new BrowserWindow({ show: false });
         expect(w.isMenuBarVisible()).to.be.true('isMenuBarVisible');

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5338,6 +5338,48 @@ describe('BrowserWindow module', () => {
       });
     });
 
+    describe('when fullscreen state is changed', () => {
+      it('correctly remembers state prior to fullscreen change', async () => {
+        const w = new BrowserWindow({ show: false });
+        expect(w.isMenuBarVisible()).to.be.true('isMenuBarVisible');
+        w.setMenuBarVisibility(false);
+        expect(w.isMenuBarVisible()).to.be.false('isMenuBarVisible');
+    
+        const enterFS = once(w, 'enter-full-screen');
+        w.setFullScreen(true);
+        await enterFS;
+        expect(w.fullScreen).to.be.true('not fullscreen');
+
+        const exitFS = once(w, 'leave-full-screen');
+        w.setFullScreen(false);
+        await exitFS;
+        expect(w.fullScreen).to.be.false('not fullscreen');
+    
+        expect(w.isMenuBarVisible()).to.be.false('isMenuBarVisible');
+      });
+
+      it('correctly remembers state prior to fullscreen change with autoHide', async () => {
+        const w = new BrowserWindow({ show: false });
+        expect(w.autoHideMenuBar).to.be.false('autoHideMenuBar');
+        w.autoHideMenuBar = ture;
+        expect(w.autoHideMenuBar).to.be.true('autoHideMenuBar');
+        w.setMenuBarVisibility(false);
+        expect(w.isMenuBarVisible()).to.be.false('isMenuBarVisible');
+
+        const enterFS = once(w, 'enter-full-screen');
+        w.setFullScreen(true);
+        await enterFS;
+        expect(w.fullScreen).to.be.true('not fullscreen');
+
+        const exitFS = once(w, 'leave-full-screen');
+        w.setFullScreen(false);
+        await exitFS;
+        expect(w.fullScreen).to.be.false('not fullscreen');
+
+        expect(w.isMenuBarVisible()).to.be.false('isMenuBarVisible');
+      });
+    });
+
     ifdescribe(process.platform === 'darwin')('fullscreenable state', () => {
       it('with functions', () => {
         it('can be set with fullscreenable constructor option', () => {

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5361,7 +5361,7 @@ describe('BrowserWindow module', () => {
       it('correctly remembers state prior to fullscreen change with autoHide', async () => {
         const w = new BrowserWindow({ show: false });
         expect(w.autoHideMenuBar).to.be.false('autoHideMenuBar');
-        w.autoHideMenuBar = ture;
+        w.autoHideMenuBar = true;
         expect(w.autoHideMenuBar).to.be.true('autoHideMenuBar');
         w.setMenuBarVisibility(false);
         expect(w.isMenuBarVisible()).to.be.false('isMenuBarVisible');


### PR DESCRIPTION
#### Description of Change

Closes #35807.

As mentioned in https://github.com/electron/electron/issues/35807#issuecomment-1567678931, when exiting fullscreen, in addition to judging the `IsMenuBarAutoHide()` of the window, you should also judge the user-set visibility property of menu bar. As I known, when entering fullscreen, `IsMenuBarVisible()` will change and may not be consistent with the state set by `mainWindow.setMenuBarVisibility` .

Therefore, I added the `menu_bar_visible_before_fullscreen_`  to identify the visibility of the menu bar before entering fullscreen, and when exiting fullscreen to set the visibility of the menu bar, I also need to determine the value of this variable.

First time PR, not sure if this is the best way. Works for me though.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes visibility of menu bar when exiting full screen
