### PR TITLE
fix: reparenting UAF crash on macOS

### DIFF
--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -157,6 +157,7 @@ class NativeWindowMac : public NativeWindow,
   bool IsActive() const override;
   // Remove the specified child window without closing it.
   void RemoveChildWindow(NativeWindow* child) override;
+  void RemoveChildFromParentWindow(NativeWindow* child);
   // Attach child windows, if the window is visible.
   void AttachChildren() override;
   // Detach window from parent without destroying it.

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -4677,6 +4677,21 @@ describe('BrowserWindow module', () => {
         expect(w.getChildWindows().length).to.equal(0);
       });
 
+      it('can handle child window close and reparent multiple times', async () => {
+        const w = new BrowserWindow({ show: false });
+        let c: BrowserWindow | null;
+
+        for (let i = 0; i < 5; i++) {
+          c = new BrowserWindow({ show: false, parent: w });
+          const closed = once(c, 'closed');
+          c.close();
+          await closed;
+        }
+
+        await setTimeout();
+        expect(w.getChildWindows().length).to.equal(0);
+      });
+
       ifit(process.platform === 'darwin')('child window matches visibility when visibility changes', async () => {
         const w = new BrowserWindow({ show: false });
         const c = new BrowserWindow({ show: false, parent: w });


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/38562.

Fixes an issue with potential UAF of child windows on close and reparent.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue with potential use-after-free of child windows on close and reparent.
