### PR TITLE
fix: `webContents.print` parameter validation error

### DIFF
--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -194,6 +194,14 @@ describe('webContents module', () => {
       }).to.throw('webContents.print(): Invalid print settings specified.');
     });
 
+    it('throws when an invalid pageSize is passed', () => {
+      const badSize = 5;
+      expect(() => {
+        // @ts-ignore this line is intentionally incorrect
+        w.webContents.print({ pageSize: badSize });
+      }).to.throw(`Unsupported pageSize: ${badSize}`);
+    });
+
     it('throws when an invalid callback is passed', () => {
       expect(() => {
         // @ts-ignore this line is intentionally incorrect

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -242,6 +242,10 @@ declare namespace ElectronInternal {
     custom_display_name: string,
     height_microns: number,
     width_microns: number,
+    imageable_area_left_microns?: number,
+    imageable_area_bottom_microns?: number,
+    imageable_area_right_microns?: number,
+    imageable_area_top_microns?: number,
     is_default?: 'true',
   }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/38598.

Fixes an error with `webContents.print` parameter validation by adding missing options required to set printer printable area.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an error with `webContents.print` parameter validation by adding missing options required to set printer printable area.