### PR TITLE
refactor: use direct aggregation for api::Menu::model_

### DIFF
--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -62,9 +62,7 @@ Menu::Menu(gin::Arguments* args) {
 }
 
 Menu::~Menu() {
-  if (model_) {
-    model_.RemoveObserver(this);
-  }
+  model_.RemoveObserver(this);
 }
 
 bool InvokeBoolMethod(const Menu* menu,
@@ -184,7 +182,7 @@ void Menu::InsertSubMenuAt(int index,
                            int command_id,
                            const std::u16string& label,
                            Menu* menu) {
-  model_.InsertSubMenuAt(index, command_id, label, menu->model_.get());
+  model_.InsertSubMenuAt(index, command_id, label, model());
 }
 
 void Menu::SetIcon(int index, const gfx::Image& image) {

--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -185,7 +185,6 @@ void Menu::InsertSubMenuAt(int index,
                            int command_id,
                            const std::u16string& label,
                            Menu* menu) {
-  menu->parent_ = this;
   model_->InsertSubMenuAt(index, command_id, label, menu->model_.get());
 }
 

--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -182,7 +182,7 @@ void Menu::InsertSubMenuAt(int index,
                            int command_id,
                            const std::u16string& label,
                            Menu* menu) {
-  model_.InsertSubMenuAt(index, command_id, label, model());
+  model_.InsertSubMenuAt(index, command_id, label, menu->model());
 }
 
 void Menu::SetIcon(int index, const gfx::Image& image) {

--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -48,23 +48,22 @@ namespace electron::api {
 
 gin::WrapperInfo Menu::kWrapperInfo = {gin::kEmbedderNativeGin};
 
-Menu::Menu(gin::Arguments* args)
-    : model_(std::make_unique<ElectronMenuModel>(this)) {
-  model_->AddObserver(this);
+Menu::Menu(gin::Arguments* args) {
+  model_.AddObserver(this);
 
 #if BUILDFLAG(IS_MAC)
   gin_helper::Dictionary options;
   if (args->GetNext(&options)) {
     ElectronMenuModel::SharingItem item;
     if (options.Get("sharingItem", &item))
-      model_->SetSharingItem(std::move(item));
+      model_.SetSharingItem(std::move(item));
   }
 #endif
 }
 
 Menu::~Menu() {
   if (model_) {
-    model_->RemoveObserver(this);
+    model_.RemoveObserver(this);
   }
 }
 
@@ -161,97 +160,97 @@ base::OnceClosure Menu::BindSelfToClosure(base::OnceClosure callback) {
 void Menu::InsertItemAt(int index,
                         int command_id,
                         const std::u16string& label) {
-  model_->InsertItemAt(index, command_id, label);
+  model_.InsertItemAt(index, command_id, label);
 }
 
 void Menu::InsertSeparatorAt(int index) {
-  model_->InsertSeparatorAt(index, ui::NORMAL_SEPARATOR);
+  model_.InsertSeparatorAt(index, ui::NORMAL_SEPARATOR);
 }
 
 void Menu::InsertCheckItemAt(int index,
                              int command_id,
                              const std::u16string& label) {
-  model_->InsertCheckItemAt(index, command_id, label);
+  model_.InsertCheckItemAt(index, command_id, label);
 }
 
 void Menu::InsertRadioItemAt(int index,
                              int command_id,
                              const std::u16string& label,
                              int group_id) {
-  model_->InsertRadioItemAt(index, command_id, label, group_id);
+  model_.InsertRadioItemAt(index, command_id, label, group_id);
 }
 
 void Menu::InsertSubMenuAt(int index,
                            int command_id,
                            const std::u16string& label,
                            Menu* menu) {
-  model_->InsertSubMenuAt(index, command_id, label, menu->model_.get());
+  model_.InsertSubMenuAt(index, command_id, label, menu->model_.get());
 }
 
 void Menu::SetIcon(int index, const gfx::Image& image) {
-  model_->SetIcon(index, ui::ImageModel::FromImage(image));
+  model_.SetIcon(index, ui::ImageModel::FromImage(image));
 }
 
 void Menu::SetSublabel(int index, const std::u16string& sublabel) {
-  model_->SetSecondaryLabel(index, sublabel);
+  model_.SetSecondaryLabel(index, sublabel);
 }
 
 void Menu::SetToolTip(int index, const std::u16string& toolTip) {
-  model_->SetToolTip(index, toolTip);
+  model_.SetToolTip(index, toolTip);
 }
 
 void Menu::SetRole(int index, const std::u16string& role) {
-  model_->SetRole(index, role);
+  model_.SetRole(index, role);
 }
 
 void Menu::Clear() {
-  model_->Clear();
+  model_.Clear();
 }
 
 int Menu::GetIndexOfCommandId(int command_id) const {
-  return model_->GetIndexOfCommandId(command_id).value_or(-1);
+  return model_.GetIndexOfCommandId(command_id).value_or(-1);
 }
 
 int Menu::GetItemCount() const {
-  return model_->GetItemCount();
+  return model_.GetItemCount();
 }
 
 int Menu::GetCommandIdAt(int index) const {
-  return model_->GetCommandIdAt(index);
+  return model_.GetCommandIdAt(index);
 }
 
 std::u16string Menu::GetLabelAt(int index) const {
-  return model_->GetLabelAt(index);
+  return model_.GetLabelAt(index);
 }
 
 std::u16string Menu::GetSublabelAt(int index) const {
-  return model_->GetSecondaryLabelAt(index);
+  return model_.GetSecondaryLabelAt(index);
 }
 
 std::u16string Menu::GetToolTipAt(int index) const {
-  return model_->GetToolTipAt(index);
+  return model_.GetToolTipAt(index);
 }
 
 std::u16string Menu::GetAcceleratorTextAtForTesting(int index) const {
   ui::Accelerator accelerator;
-  model_->GetAcceleratorAtWithParams(index, true, &accelerator);
+  model_.GetAcceleratorAtWithParams(index, true, &accelerator);
   return accelerator.GetShortcutText();
 }
 
 bool Menu::IsItemCheckedAt(int index) const {
-  return model_->IsItemCheckedAt(index);
+  return model_.IsItemCheckedAt(index);
 }
 
 bool Menu::IsEnabledAt(int index) const {
-  return model_->IsEnabledAt(index);
+  return model_.IsEnabledAt(index);
 }
 
 bool Menu::IsVisibleAt(int index) const {
-  return model_->IsVisibleAt(index);
+  return model_.IsVisibleAt(index);
 }
 
 bool Menu::WorksWhenHiddenAt(int index) const {
-  return model_->WorksWhenHiddenAt(index);
+  return model_.WorksWhenHiddenAt(index);
 }
 
 void Menu::OnMenuWillClose() {

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -9,7 +9,6 @@
 #include <string>
 
 #include "base/functional/callback.h"
-#include "base/memory/raw_ptr.h"
 #include "gin/arguments.h"
 #include "shell/browser/api/electron_api_base_window.h"
 #include "shell/browser/event_emitter_mixin.h"
@@ -83,7 +82,6 @@ class Menu : public gin::Wrappable<Menu>,
   virtual std::u16string GetAcceleratorTextAtForTesting(int index) const;
 
   std::unique_ptr<ElectronMenuModel> model_;
-  raw_ptr<Menu> parent_ = nullptr;
 
   // Observable:
   void OnMenuWillClose() override;

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_BROWSER_API_ELECTRON_API_MENU_H_
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_MENU_H_
 
-#include <memory>
 #include <string>
 
 #include "base/functional/callback.h"
@@ -40,7 +39,7 @@ class Menu : public gin::Wrappable<Menu>,
   static void SendActionToFirstResponder(const std::string& action);
 #endif
 
-  ElectronMenuModel* model() const { return model_.get(); }
+  constexpr ElectronMenuModel* model() { return &model_; }
 
   // disable copy
   Menu(const Menu&) = delete;
@@ -81,7 +80,7 @@ class Menu : public gin::Wrappable<Menu>,
   virtual void ClosePopupAt(int32_t window_id) = 0;
   virtual std::u16string GetAcceleratorTextAtForTesting(int index) const;
 
-  std::unique_ptr<ElectronMenuModel> model_;
+  ElectronMenuModel model_{this};
 
   // Observable:
   void OnMenuWillClose() override;

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -80,8 +80,6 @@ class Menu : public gin::Wrappable<Menu>,
   virtual void ClosePopupAt(int32_t window_id) = 0;
   virtual std::u16string GetAcceleratorTextAtForTesting(int index) const;
 
-  ElectronMenuModel model_{this};
-
   // Observable:
   void OnMenuWillClose() override;
   void OnMenuWillShow() override;
@@ -115,6 +113,8 @@ class Menu : public gin::Wrappable<Menu>,
   bool IsEnabledAt(int index) const;
   bool IsVisibleAt(int index) const;
   bool WorksWhenHiddenAt(int index) const;
+
+  ElectronMenuModel model_{this};
 };
 
 }  // namespace electron::api

--- a/shell/browser/ui/electron_menu_model.cc
+++ b/shell/browser/ui/electron_menu_model.cc
@@ -33,7 +33,7 @@ void ElectronMenuModel::SetToolTip(size_t index,
   toolTips_[command_id] = toolTip;
 }
 
-std::u16string ElectronMenuModel::GetToolTipAt(size_t index) {
+std::u16string ElectronMenuModel::GetToolTipAt(size_t index) const {
   const int command_id = GetCommandIdAt(index);
   const auto iter = toolTips_.find(command_id);
   return iter == std::end(toolTips_) ? std::u16string() : iter->second;
@@ -44,7 +44,7 @@ void ElectronMenuModel::SetRole(size_t index, const std::u16string& role) {
   roles_[command_id] = role;
 }
 
-std::u16string ElectronMenuModel::GetRoleAt(size_t index) {
+std::u16string ElectronMenuModel::GetRoleAt(size_t index) const {
   const int command_id = GetCommandIdAt(index);
   const auto iter = roles_.find(command_id);
   return iter == std::end(roles_) ? std::u16string() : iter->second;

--- a/shell/browser/ui/electron_menu_model.h
+++ b/shell/browser/ui/electron_menu_model.h
@@ -83,9 +83,9 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
   void RemoveObserver(Observer* obs) { observers_.RemoveObserver(obs); }
 
   void SetToolTip(size_t index, const std::u16string& toolTip);
-  std::u16string GetToolTipAt(size_t index);
+  std::u16string GetToolTipAt(size_t index) const;
   void SetRole(size_t index, const std::u16string& role);
-  std::u16string GetRoleAt(size_t index);
+  std::u16string GetRoleAt(size_t index) const;
   void SetSecondaryLabel(size_t index, const std::u16string& sublabel);
   std::u16string GetSecondaryLabelAt(size_t index) const override;
   bool GetAcceleratorAtWithParams(size_t index,


### PR DESCRIPTION
#### Description of Change

A cleanup PR for api::Menu:

- Remove unused `parent_` field. (Apparently never used? :confused:)
- Make `api::Menu::model_` private
- Make `api::Menu::model_` an `ElectronMenuModel` instead of a `unique_ptr<ElectronMenuModel>` since the model's lifespan is directly tied to the Menu (similar change to #38559)
- Make `ElectronMenuModel::GetToolTipAt()` const (partially for correctness + also because otherwise `api::Menu::GetToolTipAt()` won't compile now that it's no longer a `unique_ptr` :smile_cat:)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none