### PR TITLE
build: remove enable_picture_in_picture build flag

### DIFF
--- a/buildflags/BUILD.gn
+++ b/buildflags/BUILD.gn
@@ -15,7 +15,6 @@ buildflag_header("buildflags") {
     "ENABLE_PDF_VIEWER=$enable_pdf_viewer",
     "ENABLE_ELECTRON_EXTENSIONS=$enable_electron_extensions",
     "ENABLE_BUILTIN_SPELLCHECKER=$enable_builtin_spellchecker",
-    "ENABLE_PICTURE_IN_PICTURE=$enable_picture_in_picture",
     "OVERRIDE_LOCATION_PROVIDER=$enable_fake_location_provider",
   ]
 }

--- a/buildflags/buildflags.gni
+++ b/buildflags/buildflags.gni
@@ -12,8 +12,6 @@ declare_args() {
 
   enable_pdf_viewer = true
 
-  enable_picture_in_picture = true
-
   # Provide a fake location provider for mocking
   # the geolocation responses. Disable it if you
   # need to test with chromium's location provider.

--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -51,6 +51,8 @@ static_library("chrome") {
     "//chrome/browser/net/proxy_config_monitor.h",
     "//chrome/browser/net/proxy_service_factory.cc",
     "//chrome/browser/net/proxy_service_factory.h",
+    "//chrome/browser/picture_in_picture/picture_in_picture_window_manager.cc",
+    "//chrome/browser/picture_in_picture/picture_in_picture_window_manager.h",
     "//chrome/browser/platform_util.cc",
     "//chrome/browser/platform_util.h",
     "//chrome/browser/predictors/preconnect_manager.cc",
@@ -94,6 +96,28 @@ static_library("chrome") {
     "//chrome/browser/ui/views/eye_dropper/eye_dropper.h",
     "//chrome/browser/ui/views/eye_dropper/eye_dropper_view.cc",
     "//chrome/browser/ui/views/eye_dropper/eye_dropper_view.h",
+    "//chrome/browser/ui/views/overlay/back_to_tab_label_button.cc",
+    "//chrome/browser/ui/views/overlay/close_image_button.cc",
+    "//chrome/browser/ui/views/overlay/close_image_button.h",
+    "//chrome/browser/ui/views/overlay/constants.h",
+    "//chrome/browser/ui/views/overlay/hang_up_button.cc",
+    "//chrome/browser/ui/views/overlay/hang_up_button.h",
+    "//chrome/browser/ui/views/overlay/overlay_window_image_button.cc",
+    "//chrome/browser/ui/views/overlay/overlay_window_image_button.h",
+    "//chrome/browser/ui/views/overlay/playback_image_button.cc",
+    "//chrome/browser/ui/views/overlay/playback_image_button.h",
+    "//chrome/browser/ui/views/overlay/resize_handle_button.cc",
+    "//chrome/browser/ui/views/overlay/resize_handle_button.h",
+    "//chrome/browser/ui/views/overlay/simple_overlay_window_image_button.cc",
+    "//chrome/browser/ui/views/overlay/simple_overlay_window_image_button.h",
+    "//chrome/browser/ui/views/overlay/skip_ad_label_button.cc",
+    "//chrome/browser/ui/views/overlay/skip_ad_label_button.h",
+    "//chrome/browser/ui/views/overlay/toggle_camera_button.cc",
+    "//chrome/browser/ui/views/overlay/toggle_camera_button.h",
+    "//chrome/browser/ui/views/overlay/toggle_microphone_button.cc",
+    "//chrome/browser/ui/views/overlay/toggle_microphone_button.h",
+    "//chrome/browser/ui/views/overlay/video_overlay_window_views.cc",
+    "//chrome/browser/ui/views/overlay/video_overlay_window_views.h",
     "//extensions/browser/app_window/size_constraints.cc",
     "//extensions/browser/app_window/size_constraints.h",
     "//ui/views/native_window_tracker.h",
@@ -166,9 +190,12 @@ static_library("chrome") {
   ]
 
   deps = [
+    "//chrome/app/vector_icons",
     "//chrome/browser:resource_prefetch_predictor_proto",
     "//chrome/browser/resource_coordinator:mojo_bindings",
+    "//components/vector_icons:vector_icons",
     "//ui/snapshot",
+    "//ui/views/controls/webview",
   ]
 
   if (is_linux) {
@@ -269,41 +296,6 @@ static_library("chrome") {
       ]
       deps += [ "//printing:printing_base" ]
     }
-  }
-
-  if (enable_picture_in_picture) {
-    sources += [
-      "//chrome/browser/picture_in_picture/picture_in_picture_window_manager.cc",
-      "//chrome/browser/picture_in_picture/picture_in_picture_window_manager.h",
-      "//chrome/browser/ui/views/overlay/back_to_tab_label_button.cc",
-      "//chrome/browser/ui/views/overlay/close_image_button.cc",
-      "//chrome/browser/ui/views/overlay/close_image_button.h",
-      "//chrome/browser/ui/views/overlay/constants.h",
-      "//chrome/browser/ui/views/overlay/hang_up_button.cc",
-      "//chrome/browser/ui/views/overlay/hang_up_button.h",
-      "//chrome/browser/ui/views/overlay/overlay_window_image_button.cc",
-      "//chrome/browser/ui/views/overlay/overlay_window_image_button.h",
-      "//chrome/browser/ui/views/overlay/playback_image_button.cc",
-      "//chrome/browser/ui/views/overlay/playback_image_button.h",
-      "//chrome/browser/ui/views/overlay/resize_handle_button.cc",
-      "//chrome/browser/ui/views/overlay/resize_handle_button.h",
-      "//chrome/browser/ui/views/overlay/simple_overlay_window_image_button.cc",
-      "//chrome/browser/ui/views/overlay/simple_overlay_window_image_button.h",
-      "//chrome/browser/ui/views/overlay/skip_ad_label_button.cc",
-      "//chrome/browser/ui/views/overlay/skip_ad_label_button.h",
-      "//chrome/browser/ui/views/overlay/toggle_camera_button.cc",
-      "//chrome/browser/ui/views/overlay/toggle_camera_button.h",
-      "//chrome/browser/ui/views/overlay/toggle_microphone_button.cc",
-      "//chrome/browser/ui/views/overlay/toggle_microphone_button.h",
-      "//chrome/browser/ui/views/overlay/video_overlay_window_views.cc",
-      "//chrome/browser/ui/views/overlay/video_overlay_window_views.h",
-    ]
-
-    deps += [
-      "//chrome/app/vector_icons",
-      "//components/vector_icons:vector_icons",
-      "//ui/views/controls/webview",
-    ]
   }
 
   if (enable_electron_extensions) {

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -23,6 +23,7 @@
 #include "base/threading/scoped_blocking_call.h"
 #include "base/values.h"
 #include "chrome/browser/browser_process.h"
+#include "chrome/browser/picture_in_picture/picture_in_picture_window_manager.h"
 #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
 #include "chrome/browser/ui/views/eye_dropper/eye_dropper.h"
 #include "chrome/common/pref_names.h"
@@ -183,10 +184,6 @@
 #include "printing/backend/win_helper.h"
 #endif
 #endif  // BUILDFLAG(ENABLE_PRINTING)
-
-#if BUILDFLAG(ENABLE_PICTURE_IN_PICTURE)
-#include "chrome/browser/picture_in_picture/picture_in_picture_window_manager.h"
-#endif
 
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
 #include "components/pdf/browser/pdf_web_contents_helper.h"  // nogncheck
@@ -3896,18 +3893,12 @@ bool WebContents::TakeFocus(content::WebContents* source, bool reverse) {
 
 content::PictureInPictureResult WebContents::EnterPictureInPicture(
     content::WebContents* web_contents) {
-#if BUILDFLAG(ENABLE_PICTURE_IN_PICTURE)
   return PictureInPictureWindowManager::GetInstance()
       ->EnterVideoPictureInPicture(web_contents);
-#else
-  return content::PictureInPictureResult::kNotSupported;
-#endif
 }
 
 void WebContents::ExitPictureInPicture() {
-#if BUILDFLAG(ENABLE_PICTURE_IN_PICTURE)
   PictureInPictureWindowManager::GetInstance()->ExitPictureInPicture();
-#endif
 }
 
 void WebContents::DevToolsSaveToFile(const std::string& url,

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -186,7 +186,7 @@
 #include "components/crash/core/app/crashpad.h"        // nogncheck
 #endif
 
-#if BUILDFLAG(ENABLE_PICTURE_IN_PICTURE) && BUILDFLAG(IS_WIN)
+#if BUILDFLAG(IS_WIN)
 #include "chrome/browser/ui/views/overlay/video_overlay_window_views.h"
 #include "shell/browser/browser.h"
 #include "ui/aura/window.h"
@@ -422,9 +422,6 @@ void ElectronBrowserClient::OverrideWebkitPrefs(
   prefs->default_minimum_page_scale_factor = 1.f;
   prefs->default_maximum_page_scale_factor = 1.f;
   prefs->navigate_on_drag_drop = false;
-#if !BUILDFLAG(ENABLE_PICTURE_IN_PICTURE)
-  prefs->picture_in_picture_enabled = false;
-#endif
 
   ui::NativeTheme* native_theme = ui::NativeTheme::GetInstanceForNativeUi();
   prefs->preferred_color_scheme =
@@ -674,7 +671,6 @@ bool ElectronBrowserClient::CanCreateWindow(
   return false;
 }
 
-#if BUILDFLAG(ENABLE_PICTURE_IN_PICTURE)
 std::unique_ptr<content::VideoOverlayWindow>
 ElectronBrowserClient::CreateWindowForVideoPictureInPicture(
     content::VideoPictureInPictureWindowController* controller) {
@@ -692,7 +688,6 @@ ElectronBrowserClient::CreateWindowForVideoPictureInPicture(
 #endif
   return overlay_window;
 }
-#endif
 
 void ElectronBrowserClient::GetAdditionalAllowedSchemesForFileSystem(
     std::vector<std::string>* additional_schemes) {

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -160,11 +160,9 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
                        bool user_gesture,
                        bool opener_suppressed,
                        bool* no_javascript_access) override;
-#if BUILDFLAG(ENABLE_PICTURE_IN_PICTURE)
   std::unique_ptr<content::VideoOverlayWindow>
   CreateWindowForVideoPictureInPicture(
       content::VideoPictureInPictureWindowController* controller) override;
-#endif
   void GetAdditionalAllowedSchemesForFileSystem(
       std::vector<std::string>* additional_schemes) override;
   void GetAdditionalWebUISchemes(

--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -36,10 +36,6 @@ void InitializeFeatureList() {
   disable_features +=
       std::string(",") + features::kSpareRendererForSitePerProcess.name;
 
-#if !BUILDFLAG(ENABLE_PICTURE_IN_PICTURE)
-  disable_features += std::string(",") + media::kPictureInPicture.name;
-#endif
-
 #if BUILDFLAG(IS_WIN)
   disable_features +=
       // Disable async spellchecker suggestions for Windows, which causes

--- a/shell/common/api/features.cc
+++ b/shell/common/api/features.cc
@@ -42,10 +42,6 @@ bool IsExtensionsEnabled() {
   return BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS);
 }
 
-bool IsPictureInPictureEnabled() {
-  return BUILDFLAG(ENABLE_PICTURE_IN_PICTURE);
-}
-
 bool IsComponentBuild() {
 #if defined(COMPONENT_BUILD)
   return true;
@@ -67,7 +63,6 @@ void Initialize(v8::Local<v8::Object> exports,
                  &IsFakeLocationProviderEnabled);
   dict.SetMethod("isViewApiEnabled", &IsViewApiEnabled);
   dict.SetMethod("isPrintingEnabled", &IsPrintingEnabled);
-  dict.SetMethod("isPictureInPictureEnabled", &IsPictureInPictureEnabled);
   dict.SetMethod("isComponentBuild", &IsComponentBuild);
   dict.SetMethod("isExtensionsEnabled", &IsExtensionsEnabled);
 }

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2065,8 +2065,7 @@ describe('webContents module', () => {
 
       await w.webContents.executeJavaScript('document.createElement(\'video\').canPlayType(\'video/webm; codecs="vp8.0"\')', true);
 
-      const result = await w.webContents.executeJavaScript(
-        `runTest(${features.isPictureInPictureEnabled()})`, true);
+      const result = await w.webContents.executeJavaScript('runTest(true)', true);
       expect(result).to.be.true();
     });
   });

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -11,7 +11,6 @@ declare namespace NodeJS {
     isFakeLocationProviderEnabled(): boolean;
     isViewApiEnabled(): boolean;
     isPrintingEnabled(): boolean;
-    isPictureInPictureEnabled(): boolean;
     isExtensionsEnabled(): boolean;
     isComponentBuild(): boolean;
   }


### PR DESCRIPTION
#### Description of Change
The size difference is ~140 KiB (0.07%) on macOS, which is not very significant.
<img width="831" alt="Screenshot 2023-06-08 at 8 48 47 AM" src="https://github.com/electron/electron/assets/1281234/12cefdf0-944c-4a71-962c-f45f8de964c5">

Nobody seems to be even using `enable_picture_in_picture = false` as it does not build currently:
```
../../electron/shell/browser/feature_list.cc:40:42: error: use of undeclared identifier 'mediablink'
  disable_features += std::string(",") + mediablink::features::kDocumentPictureInPictureAPI.name;
                                         ^
1 error generated.
```

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: The `enable_picture_in_picture` build flag has been removed.