### PR TITLE
refactor: remove unused OffScreenRenderWidgetHostView  fields

### DIFF
--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -726,10 +726,8 @@ void OffScreenRenderWidgetHostView::CompositeFrame(
     }
   }
 
-  paint_callback_running_ = true;
   callback_.Run(gfx::IntersectRects(gfx::Rect(size_in_pixels), damage_rect),
                 frame);
-  paint_callback_running_ = false;
 
   ReleaseResize();
 }

--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -258,7 +258,6 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
   int frame_rate_ = 0;
   int frame_rate_threshold_us_ = 0;
 
-  gfx::Vector2dF last_scroll_offset_;
   gfx::Size size_;
   bool painting_;
 

--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -268,8 +268,6 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
   bool hold_resize_ = false;
   bool pending_resize_ = false;
 
-  bool paint_callback_running_ = false;
-
   viz::LocalSurfaceId delegated_frame_host_surface_id_;
   viz::ParentLocalSurfaceIdAllocator delegated_frame_host_allocator_;
 

--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -19,7 +19,6 @@
 #include "base/memory/raw_ptr.h"
 #include "base/process/kill.h"
 #include "base/threading/thread.h"
-#include "base/time/time.h"
 #include "components/viz/common/quads/compositor_frame.h"
 #include "components/viz/common/surfaces/parent_local_surface_id_allocator.h"
 #include "content/browser/renderer_host/delegated_frame_host.h"  // nogncheck
@@ -258,8 +257,6 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
 
   int frame_rate_ = 0;
   int frame_rate_threshold_us_ = 0;
-
-  base::Time last_time_ = base::Time::Now();
 
   gfx::Vector2dF last_scroll_offset_;
   gfx::Size size_;


### PR DESCRIPTION
#### Description of Change

Literally just removing unused fields.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none