### PR TITLE
ci: automate release board creation

### DIFF
--- a/.github/workflows/branch-created.yml
+++ b/.github/workflows/branch-created.yml
@@ -15,41 +15,46 @@ jobs:
       repository-projects: write  # Required for labels
     runs-on: ubuntu-latest
     steps:
-      - name: New Release Branch Tasks
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: electron/electron
-          NUM_SUPPORTED_VERSIONS: 3
+      - name: Determine Major Version
+        id: check-major-version
         run: |
           if [[ ${{ github.event.ref }} =~ ^([0-9]+)-x-y$ ]]; then
-            MAJOR=${BASH_REMATCH[1]}
-            PREVIOUS_MAJOR=$((MAJOR - 1))
-            UNSUPPORTED_MAJOR=$((MAJOR - NUM_SUPPORTED_VERSIONS - 1))
-
-            # Create new labels
-            gh label create $MAJOR-x-y --color 8d9ee8 || true
-            gh label create target/$MAJOR-x-y --color ad244f --description "PR should also be added to the \"${MAJOR}-x-y\" branch." || true
-            gh label create merged/$MAJOR-x-y --color 61a3c6 --description "PR was merged to the \"${MAJOR}-x-y\" branch." || true
-            gh label create in-flight/$MAJOR-x-y --color db69a6 || true
-            gh label create needs-manual-bp/$MAJOR-x-y --color 8b5dba || true
-
-            # Change color of old labels
-            gh label edit $UNSUPPORTED_MAJOR-x-y --color ededed || true
-            gh label edit target/$UNSUPPORTED_MAJOR-x-y --color ededed || true
-            gh label edit merged/$UNSUPPORTED_MAJOR-x-y --color ededed || true
-            gh label edit in-flight/$UNSUPPORTED_MAJOR-x-y --color ededed || true
-            gh label edit needs-manual-bp/$UNSUPPORTED_MAJOR-x-y --color ededed || true
-
-            # Add the new target label to any PRs which:
-            #   * target the previous major
-            #   * are in-flight for the previous major
-            #   * need manual backport for the previous major
-            for PREVIOUS_MAJOR_LABEL in target/$PREVIOUS_MAJOR-x-y in-flight/$PREVIOUS_MAJOR-x-y needs-manual-bp/$PREVIOUS_MAJOR-x-y; do
-              PULL_REQUESTS=$(gh pr list --label $PREVIOUS_MAJOR_LABEL --jq .[].number --json number --limit 500)
-              if [[ $PULL_REQUESTS ]]; then
-                echo $PULL_REQUESTS | xargs -n 1 gh pr edit --add-label target/$MAJOR-x-y || true
-              fi
-            done
+            echo "MAJOR=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
           else
             echo "Not a release branch: ${{ github.event.ref }}"
           fi
+      - name: New Release Branch Tasks
+        if: ${{ steps.check-major-version.outputs.MAJOR }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: electron/electron
+          MAJOR: ${{ steps.check-major-version.outputs.MAJOR }}
+          NUM_SUPPORTED_VERSIONS: 3
+        run: |
+          PREVIOUS_MAJOR=$((MAJOR - 1))
+          UNSUPPORTED_MAJOR=$((MAJOR - NUM_SUPPORTED_VERSIONS - 1))
+
+          # Create new labels
+          gh label create $MAJOR-x-y --color 8d9ee8 || true
+          gh label create target/$MAJOR-x-y --color ad244f --description "PR should also be added to the \"${MAJOR}-x-y\" branch." || true
+          gh label create merged/$MAJOR-x-y --color 61a3c6 --description "PR was merged to the \"${MAJOR}-x-y\" branch." || true
+          gh label create in-flight/$MAJOR-x-y --color db69a6 || true
+          gh label create needs-manual-bp/$MAJOR-x-y --color 8b5dba || true
+
+          # Change color of old labels
+          gh label edit $UNSUPPORTED_MAJOR-x-y --color ededed || true
+          gh label edit target/$UNSUPPORTED_MAJOR-x-y --color ededed || true
+          gh label edit merged/$UNSUPPORTED_MAJOR-x-y --color ededed || true
+          gh label edit in-flight/$UNSUPPORTED_MAJOR-x-y --color ededed || true
+          gh label edit needs-manual-bp/$UNSUPPORTED_MAJOR-x-y --color ededed || true
+
+          # Add the new target label to any PRs which:
+          #   * target the previous major
+          #   * are in-flight for the previous major
+          #   * need manual backport for the previous major
+          for PREVIOUS_MAJOR_LABEL in target/$PREVIOUS_MAJOR-x-y in-flight/$PREVIOUS_MAJOR-x-y needs-manual-bp/$PREVIOUS_MAJOR-x-y; do
+            PULL_REQUESTS=$(gh pr list --label $PREVIOUS_MAJOR_LABEL --jq .[].number --json number --limit 500)
+            if [[ $PULL_REQUESTS ]]; then
+              echo $PULL_REQUESTS | xargs -n 1 gh pr edit --add-label target/$MAJOR-x-y || true
+            fi
+          done

--- a/.github/workflows/branch-created.yml
+++ b/.github/workflows/branch-created.yml
@@ -58,3 +58,152 @@ jobs:
               echo $PULL_REQUESTS | xargs -n 1 gh pr edit --add-label target/$MAJOR-x-y || true
             fi
           done
+      - name: Generate GitHub App token
+        if: ${{ steps.check-major-version.outputs.MAJOR }}
+        id: generate-token
+        env:
+          RELEASE_BOARD_GH_APP_CREDS: ${{ secrets.RELEASE_BOARD_GH_APP_CREDS }}
+        run: |
+          TOKEN=$(npx @electron/github-app-auth --creds=$RELEASE_BOARD_GH_APP_CREDS --org electron)
+          echo "TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
+      - name: Create Release Project Board
+        if: ${{ steps.check-major-version.outputs.MAJOR }}
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.TOKEN }}
+          MAJOR: ${{ steps.check-major-version.outputs.MAJOR }}
+          ELECTRON_ORG_ID: "O_kgDOAMybxg"
+          ELECTRON_REPO_ID: "R_kgDOAI8xSw"
+          TEMPLATE_PROJECT_ID: "PVT_kwDOAMybxs4AQvib"
+        run: |
+          # Copy template to create new project board
+          PROJECT_ID=$(gh api graphql -f query='mutation ($ownerId: ID!, $projectId: ID!, $title: String!) {  
+            copyProjectV2(input: {
+              includeDraftIssues: true,
+              ownerId: $ownerId,
+              projectId: $projectId,
+              title: $title
+            }) {
+              projectV2 {
+                id
+              }
+            }
+          }' -f ownerId=$ELECTRON_ORG_ID -f projectId=$TEMPLATE_PROJECT_ID -f title="${MAJOR}-x-y" | jq -r '.data.copyProjectV2.projectV2.id')
+
+          # Make the new project public
+          gh api graphql -f query='mutation ($projectId: ID!) {                                                                                             
+            updateProjectV2(input: {
+              projectId: $projectId,
+              public: true,
+            }) {
+              projectV2 {
+                id
+              }
+            }
+          }' -f projectId=$PROJECT_ID
+
+          # Link the new project to the Electron repository
+          gh api graphql -f query='mutation ($projectId: ID!, $repositoryId: ID!) {                                                                                             
+            linkProjectV2ToRepository(input: {
+              projectId: $projectId,
+              repositoryId: $repositoryId
+            }) {
+              clientMutationId
+            }
+          }' -f projectId=$PROJECT_ID -f repositoryId=$ELECTRON_REPO_ID
+
+          # Get all draft issues on the new project board
+          gh api graphql -f query='query ($id: ID!) {
+            node(id: $id) {
+              ... on ProjectV2 {
+                items(first: 100) {
+                  nodes {
+                    ... on ProjectV2Item {
+                      id
+                      content {
+                        ... on DraftIssue { id title
+                          body
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }' -f id=$PROJECT_ID > issues.json
+          PROJECT_ITEMS=$(jq '.data.node.items.nodes[] | select(.content.id != null) | .id' issues.json)
+
+          # TODO(dsanders11): remove the following "Stable Prep Items" sections once
+          # GitHub extends project template copying to retain the status field value
+          # of draft issues in the template.
+          #
+          # Refs https://github.com/orgs/community/discussions/54576#discussioncomment-6096892
+
+          # Get field ID and option value for "Stable Prep Items"
+          gh api graphql -f query='query ($id: ID!) {
+            node(id: $id) {
+              ... on ProjectV2 {
+                field(name: "Status") {
+                  ... on ProjectV2SingleSelectField {
+                    id
+                    options {
+                      ... on ProjectV2SingleSelectFieldOption {
+                        id
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }' -f id=$PROJECT_ID > status_field.json
+          FIELD_ID=$(jq -r '.data.node.field.id' status_field.json)
+          FIELD_OPTION_ID=$(jq -r '.data.node.field.options[] | select(.name == "Stable Prep Items") | .id' status_field.json)
+
+          # Move draft issues to "Stable Prep" column
+          echo "$PROJECT_ITEMS" | xargs -I ITEM_ID -n 1 gh api graphql -f query='mutation ($projectId: ID!, $fieldId: ID!, $itemId: ID!, $value: String!) {                                                                                             
+            updateProjectV2ItemFieldValue(input: {
+              projectId: $projectId,
+              fieldId: $fieldId,
+              itemId: $itemId,
+              value: {
+                singleSelectOptionId: $value
+              }
+            }) {
+              projectV2Item {
+                id
+              }
+            }
+          }' -f projectId=$PROJECT_ID -f fieldId=$FIELD_ID -f itemId=ITEM_ID -f value=$FIELD_OPTION_ID
+
+          #
+          # Do template replacement for draft issues
+          #
+          echo "{\"major\": $MAJOR, \"next-major\": $((MAJOR + 1))}" > variables.json
+
+          # npx mustache is annoyingly slow, so install mustache directly
+          yarn add -D mustache
+
+          for PROJECT_ITEM_ID in $PROJECT_ITEMS; do
+            # These are done with the raw output flag and sent to file to better retain formatting
+            jq -r ".data.node.items.nodes[] | select(.id == $PROJECT_ITEM_ID) | .content.title" issues.json > title.txt
+            jq -r ".data.node.items.nodes[] | select(.id == $PROJECT_ITEM_ID) | .content.body" issues.json > body.txt
+
+            ./node_modules/.bin/mustache variables.json title.txt new_title.txt
+            ./node_modules/.bin/mustache variables.json body.txt new_body.txt
+
+            # Only update draft issues which had content change when interpolated
+            if ! cmp --silent -- new_title.txt title.txt || ! cmp --silent -- new_body.txt body.txt; then
+              DRAFT_ISSUE_ID=$(jq ".data.node.items.nodes[] | select(.id == $PROJECT_ITEM_ID) | .content.id" issues.json)
+              gh api graphql -f query='mutation ($draftIssueId: ID!, $title: String!, $body: String!) {                                                                                             
+                updateProjectV2DraftIssue(input: {
+                  draftIssueId: $draftIssueId,
+                  title: $title,
+                  body: $body
+                }) {
+                  draftIssue {
+                    id
+                  }
+                }
+              }' -f draftIssueId=$DRAFT_ISSUE_ID -f title="$(cat new_title.txt)" -f body="$(cat new_body.txt)"
+            fi
+          done


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Automates creating the new release project board when a new release branch is created.

1. Copies from the template project to a new project with the correct name (`N-x-y`)
2. Makes the new project board public
3. Links the project board with this repository
4. Moves draft items on the new project board to the "Stable Prep Items" column
    * 🚧 This will be removed in the future once GitHub finishes implementing functionality such that draft items will retain their status field value when creating a new project board from the template
    * ⚠️ Some items should actually be in "Beta Prep Items" but it's non-trivial to figure out which draft item should go to which column, so just accept this shortcoming until GitHub retains the status field values
6. Use `mustache` to do template interpolation on the draft issues
    * `{{ major }}` is the major for the branch being created (i.e. `{{ major }}-x-y`), AKA the major in the board title
    * `{{ next-major }}` is major + 1
    * ❓ Some of the existing draft issues mention dates, I don't have a good solution for templating those at the moment (but I have a rough plan for a larger refactor where those could become accessible in a machine-readable way)

> **Warning**
> Workflows are not carried over from the template project, so these must still be manually set up.

This PR has been split into two commits, the first simply refactors pulling out the major version from the branch name so it can be easily reused in later steps.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
