### PR TITLE
chore: clean up `ElectronPermissionManager`

### DIFF
--- a/shell/browser/electron_permission_manager.cc
+++ b/shell/browser/electron_permission_manager.cc
@@ -146,9 +146,14 @@ void ElectronPermissionManager::RequestPermission(
     content::RenderFrameHost* render_frame_host,
     const GURL& requesting_origin,
     bool user_gesture,
-    StatusCallback response_callback) {
+    StatusCallback callback) {
+  if (render_frame_host->IsNestedWithinFencedFrame()) {
+    std::move(callback).Run(blink::mojom::PermissionStatus::DENIED);
+    return;
+  }
+
   RequestPermissionWithDetails(permission, render_frame_host, requesting_origin,
-                               user_gesture, {}, std::move(response_callback));
+                               user_gesture, {}, std::move(callback));
 }
 
 void ElectronPermissionManager::RequestPermissionWithDetails(
@@ -170,9 +175,15 @@ void ElectronPermissionManager::RequestPermissions(
     content::RenderFrameHost* render_frame_host,
     const GURL& requesting_origin,
     bool user_gesture,
-    StatusesCallback response_callback) {
+    StatusesCallback callback) {
+  if (render_frame_host->IsNestedWithinFencedFrame()) {
+    std::move(callback).Run(std::vector<blink::mojom::PermissionStatus>(
+        permissions.size(), blink::mojom::PermissionStatus::DENIED));
+    return;
+  }
+
   RequestPermissionsWithDetails(permissions, render_frame_host, user_gesture,
-                                {}, std::move(response_callback));
+                                {}, std::move(callback));
 }
 
 void ElectronPermissionManager::RequestPermissionsWithDetails(
@@ -248,6 +259,12 @@ void ElectronPermissionManager::RequestPermissionsFromCurrentDocument(
     bool user_gesture,
     base::OnceCallback<void(const std::vector<blink::mojom::PermissionStatus>&)>
         callback) {
+  if (render_frame_host->IsNestedWithinFencedFrame()) {
+    std::move(callback).Run(std::vector<blink::mojom::PermissionStatus>(
+        permissions.size(), blink::mojom::PermissionStatus::DENIED));
+    return;
+  }
+
   RequestPermissionsWithDetails(permissions, render_frame_host, user_gesture,
                                 {}, std::move(callback));
 }
@@ -274,19 +291,6 @@ ElectronPermissionManager::GetPermissionResultForOriginWithoutContext(
       status, content::PermissionStatusSource::UNSPECIFIED);
 }
 
-ElectronPermissionManager::SubscriptionId
-ElectronPermissionManager::SubscribePermissionStatusChange(
-    blink::PermissionType permission,
-    content::RenderProcessHost* render_process_host,
-    content::RenderFrameHost* render_frame_host,
-    const GURL& requesting_origin,
-    base::RepeatingCallback<void(blink::mojom::PermissionStatus)> callback) {
-  return SubscriptionId(-1);
-}
-
-void ElectronPermissionManager::UnsubscribePermissionStatusChange(
-    SubscriptionId id) {}
-
 void ElectronPermissionManager::CheckBluetoothDevicePair(
     gin_helper::Dictionary details,
     PairCallback pair_callback) const {
@@ -304,9 +308,9 @@ bool ElectronPermissionManager::CheckPermissionWithDetails(
     content::RenderFrameHost* render_frame_host,
     const GURL& requesting_origin,
     base::Value::Dict details) const {
-  if (check_handler_.is_null()) {
+  if (check_handler_.is_null())
     return true;
-  }
+
   auto* web_contents =
       render_frame_host
           ? content::WebContents::FromRenderFrameHost(render_frame_host)
@@ -336,18 +340,17 @@ bool ElectronPermissionManager::CheckDevicePermission(
     const url::Origin& origin,
     const base::Value& device,
     ElectronBrowserContext* browser_context) const {
-  if (device_permission_handler_.is_null()) {
+  if (device_permission_handler_.is_null())
     return browser_context->CheckDevicePermission(origin, device, permission);
-  } else {
-    v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-    v8::HandleScope scope(isolate);
-    v8::Local<v8::Object> details = gin::DataObjectBuilder(isolate)
-                                        .Set("deviceType", permission)
-                                        .Set("origin", origin.Serialize())
-                                        .Set("device", device.Clone())
-                                        .Build();
-    return device_permission_handler_.Run(details);
-  }
+
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope scope(isolate);
+  v8::Local<v8::Object> details = gin::DataObjectBuilder(isolate)
+                                      .Set("deviceType", permission)
+                                      .Set("origin", origin.Serialize())
+                                      .Set("device", device.Clone())
+                                      .Build();
+  return device_permission_handler_.Run(details);
 }
 
 void ElectronPermissionManager::GrantDevicePermission(
@@ -371,22 +374,23 @@ void ElectronPermissionManager::RevokeDevicePermission(
 ElectronPermissionManager::USBProtectedClasses
 ElectronPermissionManager::CheckProtectedUSBClasses(
     const USBProtectedClasses& classes) const {
-  if (protected_usb_handler_.is_null()) {
+  if (protected_usb_handler_.is_null())
     return classes;
-  } else {
-    v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-    v8::HandleScope scope(isolate);
-    v8::Local<v8::Object> details = gin::DataObjectBuilder(isolate)
-                                        .Set("protectedClasses", classes)
-                                        .Build();
-    return protected_usb_handler_.Run(details);
-  }
+
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope scope(isolate);
+  v8::Local<v8::Object> details =
+      gin::DataObjectBuilder(isolate).Set("protectedClasses", classes).Build();
+  return protected_usb_handler_.Run(details);
 }
 
 blink::mojom::PermissionStatus
 ElectronPermissionManager::GetPermissionStatusForCurrentDocument(
     blink::PermissionType permission,
     content::RenderFrameHost* render_frame_host) {
+  if (render_frame_host->IsNestedWithinFencedFrame())
+    return blink::mojom::PermissionStatus::DENIED;
+
   base::Value::Dict details;
   details.Set("embeddingOrigin",
               content::PermissionUtil::GetLastCommittedOriginAsURL(
@@ -412,12 +416,25 @@ ElectronPermissionManager::GetPermissionStatusForEmbeddedRequester(
     blink::PermissionType permission,
     content::RenderFrameHost* render_frame_host,
     const url::Origin& overridden_origin) {
-  if (render_frame_host->IsNestedWithinFencedFrame()) {
+  if (render_frame_host->IsNestedWithinFencedFrame())
     return blink::mojom::PermissionStatus::DENIED;
-  }
+
   return GetPermissionStatus(
       permission, overridden_origin.GetURL(),
       render_frame_host->GetLastCommittedOrigin().GetURL());
 }
+
+ElectronPermissionManager::SubscriptionId
+ElectronPermissionManager::SubscribePermissionStatusChange(
+    blink::PermissionType permission,
+    content::RenderProcessHost* render_process_host,
+    content::RenderFrameHost* render_frame_host,
+    const GURL& requesting_origin,
+    base::RepeatingCallback<void(blink::mojom::PermissionStatus)> callback) {
+  return SubscriptionId();
+}
+
+void ElectronPermissionManager::UnsubscribePermissionStatusChange(
+    SubscriptionId id) {}
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

Fix a few differences between our `PermissionManager` and [`ShellPermissionManager`](https://source.chromium.org/chromium/chromium/src/+/main:content/shell/browser/shell_permission_manager.cc;bpv=0;bpt=1) - namely missing FencedFrame checks and unnecessary else-after-returns.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none