### PR TITLE
build: use upstream's presubmit cpplint filters.

### DIFF
--- a/script/lint.js
+++ b/script/lint.js
@@ -27,6 +27,32 @@ const IGNORELIST = new Set([
 
 const IS_WINDOWS = process.platform === 'win32';
 
+const CPPLINT_FILTERS = [
+  // from presubmit_canned_checks.py OFF_BY_DEFAULT_LINT_FILTERS
+  '-build/include',
+  '-build/include_order',
+  '-build/namespaces',
+  '-readability/casting',
+  '-runtime/int',
+  '-whitespace/braces',
+  // from presubmit_canned_checks.py OFF_UNLESS_MANUALLY_ENABLED_LINT_FILTERS
+  '-build/c++11',
+  '-build/header_guard',
+  '-readability/todo',
+  '-runtime/references',
+  '-whitespace/braces',
+  '-whitespace/comma',
+  '-whitespace/end_of_line',
+  '-whitespace/forcolon',
+  '-whitespace/indent',
+  '-whitespace/line_length',
+  '-whitespace/newline',
+  '-whitespace/operators',
+  '-whitespace/parens',
+  '-whitespace/semicolon',
+  '-whitespace/tab'
+];
+
 function spawnAndCheckExitCode (cmd, args, opts) {
   opts = { stdio: 'inherit', ...opts };
   const { error, status, signal } = childProcess.spawnSync(cmd, args, opts);
@@ -75,7 +101,7 @@ const LINTERS = [{
     const clangFormatFlags = opts.fix ? ['--fix'] : [];
     for (const chunk of chunkFilenames(filenames)) {
       spawnAndCheckExitCode('python3', ['script/run-clang-format.py', ...clangFormatFlags, ...chunk]);
-      cpplint(chunk);
+      cpplint([`--filter=${CPPLINT_FILTERS.join(',')}`, ...chunk]);
     }
   }
 }, {
@@ -85,31 +111,7 @@ const LINTERS = [{
   run: (opts, filenames) => {
     const clangFormatFlags = opts.fix ? ['--fix'] : [];
     spawnAndCheckExitCode('python3', ['script/run-clang-format.py', '-r', ...clangFormatFlags, ...filenames]);
-    const filter = [
-      // from presubmit_canned_checks.py OFF_BY_DEFAULT_LINT_FILTERS
-      '-build/include',
-      '-build/include_order',
-      '-build/namespaces',
-      '-readability/casting',
-      '-runtime/int',
-      '-whitespace/braces',
-      // from presubmit_canned_checks.py OFF_UNLESS_MANUALLY_ENABLED_LINT_FILTERS
-      '-build/c++11',
-      '-build/header_guard',
-      '-readability/todo',
-      '-runtime/references',
-      '-whitespace/braces',
-      '-whitespace/comma',
-      '-whitespace/end_of_line',
-      '-whitespace/forcolon',
-      '-whitespace/indent',
-      '-whitespace/line_length',
-      '-whitespace/newline',
-      '-whitespace/operators',
-      '-whitespace/parens',
-      '-whitespace/semicolon',
-      '-whitespace/tab'
-    ];
+    const filter = [...CPPLINT_FILTERS, '-readability/braces'];
     cpplint(['--extensions=mm,h', `--filter=${filter.join(',')}`, ...filenames]);
   }
 }, {

--- a/script/lint.js
+++ b/script/lint.js
@@ -86,11 +86,29 @@ const LINTERS = [{
     const clangFormatFlags = opts.fix ? ['--fix'] : [];
     spawnAndCheckExitCode('python3', ['script/run-clang-format.py', '-r', ...clangFormatFlags, ...filenames]);
     const filter = [
-      '-readability/braces',
+      // from presubmit_canned_checks.py OFF_BY_DEFAULT_LINT_FILTERS
+      '-build/include',
+      '-build/include_order',
+      '-build/namespaces',
       '-readability/casting',
+      '-runtime/int',
       '-whitespace/braces',
+      // from presubmit_canned_checks.py OFF_UNLESS_MANUALLY_ENABLED_LINT_FILTERS
+      '-build/c++11',
+      '-build/header_guard',
+      '-readability/todo',
+      '-runtime/references',
+      '-whitespace/braces',
+      '-whitespace/comma',
+      '-whitespace/end_of_line',
+      '-whitespace/forcolon',
       '-whitespace/indent',
-      '-whitespace/parens'
+      '-whitespace/line_length',
+      '-whitespace/newline',
+      '-whitespace/operators',
+      '-whitespace/parens',
+      '-whitespace/semicolon',
+      '-whitespace/tab'
     ];
     cpplint(['--extensions=mm,h', `--filter=${filter.join(',')}`, ...filenames]);
   }


### PR DESCRIPTION
#### Description of Change

Our list of cpplint filters does not match upstream's and so our checks are not in line with the Google + Chromium style guides. This PR copies the cpplint filters from `depot_tools` into our own linter. (Maybe we should rewrite the linter in python so we can pick up depot-tools code directly instead of duplicating it?)

This showed up on my radar because I was hitting cpplint's do-not-pass-non-const-references warning while working on `raw_ref` and I saw that there is a lot of upstream code that passes non-const references :smile_cat:  Marking for backports in anticipation of backporting `raw_ref` code.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none