### PR TITLE
chore: cherry-pick 2 changes from Release-1-M114

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -10,3 +10,5 @@ force_cppheapcreateparams_to_be_noncopyable.patch
 chore_allow_customizing_microtask_policy_per_context.patch
 cherry-pick-c605df24af3c.patch
 cherry-pick-f4b66ae451c2.patch
+merged_ic_fix_store_handler_selection_for_arguments_objects.patch
+cherry-pick-73af1a19a901.patch

--- a/patches/v8/cherry-pick-73af1a19a901.patch
+++ b/patches/v8/cherry-pick-73af1a19a901.patch
@@ -1,0 +1,258 @@
+From 73af1a19a9015ce9e82ab7c4a7d220b659a04d68 Mon Sep 17 00:00:00 2001
+From: Igor Sheludko <ishell@chromium.org>
+Date: Thu, 01 Jun 2023 10:59:39 +0200
+Subject: [PATCH] Merged: [lookup] Robustify LookupIterator against own lookups
+
+... on non-JSReceiver objects.
+
+Bug: chromium:1447430
+(cherry picked from commit 515f187ba067ee4a99fdf5198cca2c97abd342fd)
+
+Change-Id: Ib9382d90ce19d6b55ee0b236dd299ded03ade04d
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4575069
+Reviewed-by: Toon Verwaest <verwaest@chromium.org>
+Commit-Queue: Igor Sheludko <ishell@chromium.org>
+Cr-Commit-Position: refs/branch-heads/11.4@{#35}
+Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
+Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
+---
+
+diff --git a/src/objects/lookup-inl.h b/src/objects/lookup-inl.h
+index 00c95e0..8b57170 100644
+--- a/src/objects/lookup-inl.h
++++ b/src/objects/lookup-inl.h
+@@ -190,7 +190,7 @@
+ }
+ 
+ Handle<Name> LookupIterator::name() const {
+-  DCHECK(!IsElement(*holder_));
++  DCHECK_IMPLIES(!holder_.is_null(), !IsElement(*holder_));
+   return name_;
+ }
+ 
+@@ -285,6 +285,7 @@
+ }
+ 
+ InternalIndex LookupIterator::descriptor_number() const {
++  DCHECK(!holder_.is_null());
+   DCHECK(!IsElement(*holder_));
+   DCHECK(has_property_);
+   DCHECK(holder_->HasFastProperties(isolate_));
+@@ -292,6 +293,7 @@
+ }
+ 
+ InternalIndex LookupIterator::dictionary_entry() const {
++  DCHECK(!holder_.is_null());
+   DCHECK(!IsElement(*holder_));
+   DCHECK(has_property_);
+   DCHECK(!holder_->HasFastProperties(isolate_));
+@@ -306,13 +308,14 @@
+ }
+ 
+ // static
+-Handle<JSReceiver> LookupIterator::GetRoot(Isolate* isolate,
+-                                           Handle<Object> lookup_start_object,
+-                                           size_t index) {
++MaybeHandle<JSReceiver> LookupIterator::GetRoot(
++    Isolate* isolate, Handle<Object> lookup_start_object, size_t index,
++    Configuration configuration) {
+   if (lookup_start_object->IsJSReceiver(isolate)) {
+     return Handle<JSReceiver>::cast(lookup_start_object);
+   }
+-  return GetRootForNonJSReceiver(isolate, lookup_start_object, index);
++  return GetRootForNonJSReceiver(isolate, lookup_start_object, index,
++                                 configuration);
+ }
+ 
+ template <class T>
+diff --git a/src/objects/lookup.cc b/src/objects/lookup.cc
+index 8fceef1..78c509b 100644
+--- a/src/objects/lookup.cc
++++ b/src/objects/lookup.cc
+@@ -42,27 +42,20 @@
+   }
+ }
+ 
+-LookupIterator::LookupIterator(Isolate* isolate, Handle<Object> receiver,
+-                               Handle<Name> name, Handle<Map> transition_map,
+-                               PropertyDetails details, bool has_property)
+-    : configuration_(DEFAULT),
+-      state_(TRANSITION),
+-      has_property_(has_property),
+-      interceptor_state_(InterceptorState::kUninitialized),
+-      property_details_(details),
+-      isolate_(isolate),
+-      name_(name),
+-      transition_(transition_map),
+-      receiver_(receiver),
+-      lookup_start_object_(receiver),
+-      index_(kInvalidIndex) {
+-  holder_ = GetRoot(isolate, lookup_start_object_);
+-}
+-
+ template <bool is_element>
+ void LookupIterator::Start() {
+   // GetRoot might allocate if lookup_start_object_ is a string.
+-  holder_ = GetRoot(isolate_, lookup_start_object_, index_);
++  MaybeHandle<JSReceiver> maybe_holder =
++      GetRoot(isolate_, lookup_start_object_, index_, configuration_);
++  if (!maybe_holder.ToHandle(&holder_)) {
++    // This is an attempt to perform an own property lookup on a non-JSReceiver
++    // that doesn't have any properties.
++    DCHECK(!lookup_start_object_->IsJSReceiver());
++    DCHECK(!check_prototype_chain());
++    has_property_ = false;
++    state_ = NOT_FOUND;
++    return;
++  }
+ 
+   {
+     DisallowGarbageCollection no_gc;
+@@ -135,19 +128,27 @@
+ template void LookupIterator::RestartInternal<false>(InterceptorState);
+ 
+ // static
+-Handle<JSReceiver> LookupIterator::GetRootForNonJSReceiver(
+-    Isolate* isolate, Handle<Object> lookup_start_object, size_t index) {
+-  // Strings are the only objects with properties (only elements) directly on
+-  // the wrapper. Hence we can skip generating the wrapper for all other cases.
+-  if (lookup_start_object->IsString(isolate) &&
+-      index <
+-          static_cast<size_t>(String::cast(*lookup_start_object).length())) {
+-    // TODO(verwaest): Speed this up. Perhaps use a cached wrapper on the native
+-    // context, ensuring that we don't leak it into JS?
+-    Handle<JSFunction> constructor = isolate->string_function();
+-    Handle<JSObject> result = isolate->factory()->NewJSObject(constructor);
+-    Handle<JSPrimitiveWrapper>::cast(result)->set_value(*lookup_start_object);
+-    return result;
++MaybeHandle<JSReceiver> LookupIterator::GetRootForNonJSReceiver(
++    Isolate* isolate, Handle<Object> lookup_start_object, size_t index,
++    Configuration configuration) {
++  // Strings are the only non-JSReceiver objects with properties (only elements
++  // and 'length') directly on the wrapper. Hence we can skip generating
++  // the wrapper for all other cases.
++  bool own_property_lookup = (configuration & kPrototypeChain) == 0;
++  if (lookup_start_object->IsString(isolate)) {
++    if (own_property_lookup ||
++        index <
++            static_cast<size_t>(String::cast(*lookup_start_object).length())) {
++      // TODO(verwaest): Speed this up. Perhaps use a cached wrapper on the
++      // native context, ensuring that we don't leak it into JS?
++      Handle<JSFunction> constructor = isolate->string_function();
++      Handle<JSObject> result = isolate->factory()->NewJSObject(constructor);
++      Handle<JSPrimitiveWrapper>::cast(result)->set_value(*lookup_start_object);
++      return result;
++    }
++  } else if (own_property_lookup) {
++    // Signal that the lookup will not find anything.
++    return {};
+   }
+   Handle<HeapObject> root(
+       lookup_start_object->GetPrototypeChainRootMap(isolate).prototype(isolate),
+@@ -918,6 +919,7 @@
+ }
+ 
+ bool LookupIterator::CanStayConst(Object value) const {
++  DCHECK(!holder_.is_null());
+   DCHECK(!IsElement(*holder_));
+   DCHECK(holder_->HasFastProperties(isolate_));
+   DCHECK_EQ(PropertyLocation::kField, property_details_.location());
+@@ -951,6 +953,7 @@
+ }
+ 
+ bool LookupIterator::DictCanStayConst(Object value) const {
++  DCHECK(!holder_.is_null());
+   DCHECK(!IsElement(*holder_));
+   DCHECK(!holder_->HasFastProperties(isolate_));
+   DCHECK(!holder_->IsJSGlobalObject());
+@@ -997,6 +1000,7 @@
+ 
+ FieldIndex LookupIterator::GetFieldIndex() const {
+   DCHECK(has_property_);
++  DCHECK(!holder_.is_null());
+   DCHECK(holder_->HasFastProperties(isolate_));
+   DCHECK_EQ(PropertyLocation::kField, property_details_.location());
+   DCHECK(!IsElement(*holder_));
+@@ -1004,6 +1008,7 @@
+ }
+ 
+ Handle<PropertyCell> LookupIterator::GetPropertyCell() const {
++  DCHECK(!holder_.is_null());
+   DCHECK(!IsElement(*holder_));
+   Handle<JSGlobalObject> holder = GetHolder<JSGlobalObject>();
+   return handle(holder->global_dictionary(isolate_, kAcquireLoad)
+diff --git a/src/objects/lookup.h b/src/objects/lookup.h
+index 06ed50e..5d2d926 100644
+--- a/src/objects/lookup.h
++++ b/src/objects/lookup.h
+@@ -222,11 +222,6 @@
+                         Handle<Object> lookup_start_object,
+                         Configuration configuration);
+ 
+-  // For |ForTransitionHandler|.
+-  LookupIterator(Isolate* isolate, Handle<Object> receiver, Handle<Name> name,
+-                 Handle<Map> transition_map, PropertyDetails details,
+-                 bool has_property);
+-
+   static void InternalUpdateProtector(Isolate* isolate, Handle<Object> receiver,
+                                       Handle<Name> name);
+ 
+@@ -286,12 +281,12 @@
+                                                    Configuration configuration,
+                                                    Handle<Name> name);
+ 
+-  static Handle<JSReceiver> GetRootForNonJSReceiver(
+-      Isolate* isolate, Handle<Object> lookup_start_object,
+-      size_t index = kInvalidIndex);
+-  static inline Handle<JSReceiver> GetRoot(Isolate* isolate,
+-                                           Handle<Object> lookup_start_object,
+-                                           size_t index = kInvalidIndex);
++  static MaybeHandle<JSReceiver> GetRootForNonJSReceiver(
++      Isolate* isolate, Handle<Object> lookup_start_object, size_t index,
++      Configuration configuration);
++  static inline MaybeHandle<JSReceiver> GetRoot(
++      Isolate* isolate, Handle<Object> lookup_start_object, size_t index,
++      Configuration configuration);
+ 
+   State NotFound(JSReceiver const holder) const;
+ 
+diff --git a/test/mjsunit/regress/regress-crbug-1447430.js b/test/mjsunit/regress/regress-crbug-1447430.js
+new file mode 100644
+index 0000000..c7bb3e7
+--- /dev/null
++++ b/test/mjsunit/regress/regress-crbug-1447430.js
+@@ -0,0 +1,34 @@
++// Copyright 2023 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// Flags: --allow-natives-syntax
++
++var s = %CreatePrivateSymbol('x');
++
++(function TestSmi() {
++  function f(o, p) {
++    o[p] = 153;
++  }
++  (1).__proto__[s] = 42;
++  %PrepareFunctionForOptimization(f);
++  assertEquals(f(42, s), undefined);
++}());
++
++(function TestString() {
++  function f(o, p) {
++    o[p] = 153;
++  }
++  ('xyz').__proto__[s] = 42;
++  %PrepareFunctionForOptimization(f);
++  assertEquals(f('abc', s), undefined);
++}());
++
++(function TestSymbol() {
++  function f(o, p) {
++    o[p] = 153;
++  }
++  Symbol('xyz').__proto__[s] = 42;
++  %PrepareFunctionForOptimization(f);
++  assertEquals(f(Symbol('abc'), s), undefined);
++}());

--- a/patches/v8/cherry-pick-73af1a19a901.patch
+++ b/patches/v8/cherry-pick-73af1a19a901.patch
@@ -1,7 +1,7 @@
-From 73af1a19a9015ce9e82ab7c4a7d220b659a04d68 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Igor Sheludko <ishell@chromium.org>
-Date: Thu, 01 Jun 2023 10:59:39 +0200
-Subject: [PATCH] Merged: [lookup] Robustify LookupIterator against own lookups
+Date: Thu, 1 Jun 2023 10:59:39 +0200
+Subject: Merged: [lookup] Robustify LookupIterator against own lookups
 
 ... on non-JSReceiver objects.
 
@@ -15,13 +15,12 @@ Commit-Queue: Igor Sheludko <ishell@chromium.org>
 Cr-Commit-Position: refs/branch-heads/11.4@{#35}
 Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
 Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
----
 
 diff --git a/src/objects/lookup-inl.h b/src/objects/lookup-inl.h
-index 00c95e0..8b57170 100644
+index 44b8f9502e32a9a6fbbe60ebc5f8e0d184411b8f..782698bd7c488f5570288119e49784e16a93ddd2 100644
 --- a/src/objects/lookup-inl.h
 +++ b/src/objects/lookup-inl.h
-@@ -190,7 +190,7 @@
+@@ -167,7 +167,7 @@ Handle<Name> PropertyKey::GetName(Isolate* isolate) {
  }
  
  Handle<Name> LookupIterator::name() const {
@@ -30,7 +29,7 @@ index 00c95e0..8b57170 100644
    return name_;
  }
  
-@@ -285,6 +285,7 @@
+@@ -257,6 +257,7 @@ void LookupIterator::UpdateProtector() {
  }
  
  InternalIndex LookupIterator::descriptor_number() const {
@@ -38,7 +37,7 @@ index 00c95e0..8b57170 100644
    DCHECK(!IsElement(*holder_));
    DCHECK(has_property_);
    DCHECK(holder_->HasFastProperties(isolate_));
-@@ -292,6 +293,7 @@
+@@ -264,6 +265,7 @@ InternalIndex LookupIterator::descriptor_number() const {
  }
  
  InternalIndex LookupIterator::dictionary_entry() const {
@@ -46,7 +45,7 @@ index 00c95e0..8b57170 100644
    DCHECK(!IsElement(*holder_));
    DCHECK(has_property_);
    DCHECK(!holder_->HasFastProperties(isolate_));
-@@ -306,13 +308,14 @@
+@@ -278,13 +280,14 @@ LookupIterator::Configuration LookupIterator::ComputeConfiguration(
  }
  
  // static
@@ -66,10 +65,10 @@ index 00c95e0..8b57170 100644
  
  template <class T>
 diff --git a/src/objects/lookup.cc b/src/objects/lookup.cc
-index 8fceef1..78c509b 100644
+index 7c6f6c4a350fec92a3cc0a48a14c0b92f8d6021d..ce1502b859c0cce77fc054488e401ac82a073a7d 100644
 --- a/src/objects/lookup.cc
 +++ b/src/objects/lookup.cc
-@@ -42,27 +42,20 @@
+@@ -42,27 +42,20 @@ PropertyKey::PropertyKey(Isolate* isolate, Handle<Object> key, bool* success) {
    }
  }
  
@@ -108,7 +107,7 @@ index 8fceef1..78c509b 100644
  
    {
      DisallowGarbageCollection no_gc;
-@@ -135,19 +128,27 @@
+@@ -135,19 +128,27 @@ template void LookupIterator::RestartInternal<true>(InterceptorState);
  template void LookupIterator::RestartInternal<false>(InterceptorState);
  
  // static
@@ -149,7 +148,7 @@ index 8fceef1..78c509b 100644
    }
    Handle<HeapObject> root(
        lookup_start_object->GetPrototypeChainRootMap(isolate).prototype(isolate),
-@@ -918,6 +919,7 @@
+@@ -901,6 +902,7 @@ Handle<Object> LookupIterator::FetchValue(
  }
  
  bool LookupIterator::CanStayConst(Object value) const {
@@ -157,7 +156,7 @@ index 8fceef1..78c509b 100644
    DCHECK(!IsElement(*holder_));
    DCHECK(holder_->HasFastProperties(isolate_));
    DCHECK_EQ(PropertyLocation::kField, property_details_.location());
-@@ -951,6 +953,7 @@
+@@ -934,6 +936,7 @@ bool LookupIterator::CanStayConst(Object value) const {
  }
  
  bool LookupIterator::DictCanStayConst(Object value) const {
@@ -165,7 +164,7 @@ index 8fceef1..78c509b 100644
    DCHECK(!IsElement(*holder_));
    DCHECK(!holder_->HasFastProperties(isolate_));
    DCHECK(!holder_->IsJSGlobalObject());
-@@ -997,6 +1000,7 @@
+@@ -980,6 +983,7 @@ int LookupIterator::GetAccessorIndex() const {
  
  FieldIndex LookupIterator::GetFieldIndex() const {
    DCHECK(has_property_);
@@ -173,7 +172,7 @@ index 8fceef1..78c509b 100644
    DCHECK(holder_->HasFastProperties(isolate_));
    DCHECK_EQ(PropertyLocation::kField, property_details_.location());
    DCHECK(!IsElement(*holder_));
-@@ -1004,6 +1008,7 @@
+@@ -987,6 +991,7 @@ FieldIndex LookupIterator::GetFieldIndex() const {
  }
  
  Handle<PropertyCell> LookupIterator::GetPropertyCell() const {
@@ -182,10 +181,10 @@ index 8fceef1..78c509b 100644
    Handle<JSGlobalObject> holder = GetHolder<JSGlobalObject>();
    return handle(holder->global_dictionary(isolate_, kAcquireLoad)
 diff --git a/src/objects/lookup.h b/src/objects/lookup.h
-index 06ed50e..5d2d926 100644
+index 9adee79b3028c53e6481a07316d74aed616f01bd..ef90316295c98d51b61c118cf331731f991d93d0 100644
 --- a/src/objects/lookup.h
 +++ b/src/objects/lookup.h
-@@ -222,11 +222,6 @@
+@@ -214,11 +214,6 @@ class V8_EXPORT_PRIVATE LookupIterator final {
                          Handle<Object> lookup_start_object,
                          Configuration configuration);
  
@@ -197,7 +196,7 @@ index 06ed50e..5d2d926 100644
    static void InternalUpdateProtector(Isolate* isolate, Handle<Object> receiver,
                                        Handle<Name> name);
  
-@@ -286,12 +281,12 @@
+@@ -278,12 +273,12 @@ class V8_EXPORT_PRIVATE LookupIterator final {
                                                     Configuration configuration,
                                                     Handle<Name> name);
  
@@ -218,7 +217,7 @@ index 06ed50e..5d2d926 100644
  
 diff --git a/test/mjsunit/regress/regress-crbug-1447430.js b/test/mjsunit/regress/regress-crbug-1447430.js
 new file mode 100644
-index 0000000..c7bb3e7
+index 0000000000000000000000000000000000000000..c7bb3e72e3af1b9f8c2fa82faeeb2d813fe6ab3c
 --- /dev/null
 +++ b/test/mjsunit/regress/regress-crbug-1447430.js
 @@ -0,0 +1,34 @@

--- a/patches/v8/merged_ic_fix_store_handler_selection_for_arguments_objects.patch
+++ b/patches/v8/merged_ic_fix_store_handler_selection_for_arguments_objects.patch
@@ -1,0 +1,122 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Sheludko <ishell@chromium.org>
+Date: Fri, 2 Jun 2023 18:13:01 +0200
+Subject: Merged: [ic] Fix store handler selection for arguments objects
+
+Drive-by: fix printing of handlers in --trace-feedback-updates mode.
+
+(cherry picked from commit e144f3b71e64e01d6ffd247eb15ca1ff56f6287b)
+
+Bug: chromium:1450481
+Change-Id: Ifbb97d694b8520584df0610aad30805713b29c00
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4584889
+Reviewed-by: Toon Verwaest <verwaest@chromium.org>
+Commit-Queue: Igor Sheludko <ishell@chromium.org>
+Cr-Commit-Position: refs/branch-heads/10.9@{#32}
+Cr-Branched-From: 8ade6bf1fa237ad30dd9a05cc6ffe548131699e8-refs/heads/10.9.194@{#1}
+Cr-Branched-From: 9ff2515271f11cab783f0e82678ae0b925d77dd0-refs/heads/main@{#84164}
+
+diff --git a/src/diagnostics/objects-printer.cc b/src/diagnostics/objects-printer.cc
+index b763468f58f8f0be294af50188dd69b99c9428dc..e4e206f2b52095c95ac4c667f32f0620c753967c 100644
+--- a/src/diagnostics/objects-printer.cc
++++ b/src/diagnostics/objects-printer.cc
+@@ -1324,8 +1324,18 @@ void FeedbackNexus::Print(std::ostream& os) {
+     case FeedbackSlotKind::kSetKeyedStrict: {
+       os << InlineCacheState2String(ic_state());
+       if (ic_state() == InlineCacheState::MONOMORPHIC) {
+-        os << "\n   " << Brief(GetFeedback()) << ": ";
+-        StoreHandler::PrintHandler(GetFeedbackExtra().GetHeapObjectOrSmi(), os);
++        HeapObject feedback = GetFeedback().GetHeapObject();
++        HeapObject feedback_extra = GetFeedbackExtra().GetHeapObject();
++        if (feedback.IsName()) {
++          os << " with name " << Brief(feedback);
++          WeakFixedArray array = WeakFixedArray::cast(feedback_extra);
++          os << "\n   " << Brief(array.Get(0)) << ": ";
++          Object handler = array.Get(1).GetHeapObjectOrSmi();
++          StoreHandler::PrintHandler(handler, os);
++        } else {
++          os << "\n   " << Brief(feedback) << ": ";
++          StoreHandler::PrintHandler(feedback_extra, os);
++        }
+       } else if (ic_state() == InlineCacheState::POLYMORPHIC) {
+         WeakFixedArray array =
+             WeakFixedArray::cast(GetFeedback().GetHeapObject());
+diff --git a/src/ic/handler-configuration.cc b/src/ic/handler-configuration.cc
+index ece15ff24b9066158c85524ed0087f6804feb61c..ca49ed91db7b667fe3154a309e78130a9efe6d99 100644
+--- a/src/ic/handler-configuration.cc
++++ b/src/ic/handler-configuration.cc
+@@ -593,8 +593,11 @@ void StoreHandler::PrintHandler(Object handler, std::ostream& os) {
+     os << ", validity cell = ";
+     store_handler.validity_cell().ShortPrint(os);
+     os << ")" << std::endl;
++  } else if (handler.IsMap()) {
++    os << "StoreHandler(field transition to " << Brief(handler) << ")"
++       << std::endl;
+   } else {
+-    os << "StoreHandler(<unexpected>)(" << Brief(handler) << ")";
++    os << "StoreHandler(<unexpected>)(" << Brief(handler) << ")" << std::endl;
+   }
+ }
+ 
+diff --git a/src/ic/ic.cc b/src/ic/ic.cc
+index 0447e017fbedae66eac2ad9637d53121a008f5b0..93939fa4702922f58e8e5bcc019e569f42ab198e 100644
+--- a/src/ic/ic.cc
++++ b/src/ic/ic.cc
+@@ -2300,10 +2300,18 @@ Handle<Object> KeyedStoreIC::StoreElementHandler(
+              receiver_map->has_sealed_elements() ||
+              receiver_map->has_nonextensible_elements() ||
+              receiver_map->has_typed_array_or_rab_gsab_typed_array_elements()) {
++    // TODO(jgruber): Update counter name.
+     TRACE_HANDLER_STATS(isolate(), KeyedStoreIC_StoreFastElementStub);
+-    code = StoreHandler::StoreFastElementBuiltin(isolate(), store_mode);
+-    if (receiver_map->has_typed_array_or_rab_gsab_typed_array_elements()) {
+-      return code;
++    if (receiver_map->IsJSArgumentsObjectMap() &&
++        receiver_map->has_fast_packed_elements()) {
++      // Allow fast behaviour for in-bounds stores while making it miss and
++      // properly handle the out of bounds store case.
++      code = StoreHandler::StoreFastElementBuiltin(isolate(), STANDARD_STORE);
++    } else {
++      code = StoreHandler::StoreFastElementBuiltin(isolate(), store_mode);
++      if (receiver_map->has_typed_array_or_rab_gsab_typed_array_elements()) {
++        return code;
++      }
+     }
+   } else if (IsStoreInArrayLiteralIC()) {
+     // TODO(jgruber): Update counter name.
+@@ -2314,7 +2322,7 @@ Handle<Object> KeyedStoreIC::StoreElementHandler(
+     TRACE_HANDLER_STATS(isolate(), KeyedStoreIC_StoreElementStub);
+     DCHECK(DICTIONARY_ELEMENTS == receiver_map->elements_kind() ||
+            receiver_map->has_frozen_elements());
+-    code = StoreHandler::StoreSlow(isolate(), store_mode);
++    return StoreHandler::StoreSlow(isolate(), store_mode);
+   }
+ 
+   if (IsAnyDefineOwn() || IsStoreInArrayLiteralIC()) return code;
+diff --git a/src/objects/map-inl.h b/src/objects/map-inl.h
+index a83a060337739878f258c50d8013d5ba6c2262d8..723a961521f26cdad66a484f39037f94109e2cac 100644
+--- a/src/objects/map-inl.h
++++ b/src/objects/map-inl.h
+@@ -590,6 +590,10 @@ bool Map::has_fast_elements() const {
+   return IsFastElementsKind(elements_kind());
+ }
+ 
++bool Map::has_fast_packed_elements() const {
++  return IsFastPackedElementsKind(elements_kind());
++}
++
+ bool Map::has_sloppy_arguments_elements() const {
+   return IsSloppyArgumentsElementsKind(elements_kind());
+ }
+diff --git a/src/objects/map.h b/src/objects/map.h
+index 6914a51150f4235386f5dca7af0d8103bc64f9e2..8311850f82bc32b794873689789c510376f67233 100644
+--- a/src/objects/map.h
++++ b/src/objects/map.h
+@@ -422,6 +422,7 @@ class Map : public TorqueGeneratedMap<Map, HeapObject> {
+   inline bool has_fast_smi_or_object_elements() const;
+   inline bool has_fast_double_elements() const;
+   inline bool has_fast_elements() const;
++  inline bool has_fast_packed_elements() const;
+   inline bool has_sloppy_arguments_elements() const;
+   inline bool has_fast_sloppy_arguments_elements() const;
+   inline bool has_fast_string_wrapper_elements() const;


### PR DESCRIPTION
<details>
<summary>electron/security#362 - 73af1a19a901 from v8</summary>
Merged: [lookup] Robustify LookupIterator against own lookups

... on non-JSReceiver objects.

Bug: chromium:1447430
(cherry picked from commit 515f187ba067ee4a99fdf5198cca2c97abd342fd)

Change-Id: Ib9382d90ce19d6b55ee0b236dd299ded03ade04d
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4575069
Reviewed-by: Toon Verwaest <verwaest@chromium.org>
Commit-Queue: Igor Sheludko <ishell@chromium.org>
Cr-Commit-Position: refs/branch-heads/11.4@{#35}
Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
</details>

<details>
<summary>electron/security#361 - 0035a4a8dac2 from v8</summary>
Merged: [ic] Fix store handler selection for arguments objects

Drive-by: fix printing of handlers in --trace-feedback-updates mode.

Bug: chromium:1450481
(cherry picked from commit e144f3b71e64e01d6ffd247eb15ca1ff56f6287b)

Change-Id: I0d2c90d92aa006ab37a653822f3a514343a5bac4
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4583221
Reviewed-by: Toon Verwaest <verwaest@chromium.org>
Commit-Queue: Igor Sheludko <ishell@chromium.org>
Cr-Commit-Position: refs/branch-heads/11.4@{#37}
Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
</details>

Notes:
* Security: backported fix for 1447430.
* Security: backported fix for CVE-2023-3079.