### PR TITLE
chore: cherry-pick 2 changes from Release-1-M114

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -15,3 +15,5 @@ cherry-pick-546e00df97ac.patch
 cherry-pick-f6ddbf42b1ea.patch
 cherry-pick-c605df24af3c.patch
 cherry-pick-f4b66ae451c2.patch
+merged_ic_fix_store_handler_selection_for_arguments_objects.patch
+cherry-pick-73af1a19a901.patch

--- a/patches/v8/cherry-pick-73af1a19a901.patch
+++ b/patches/v8/cherry-pick-73af1a19a901.patch
@@ -1,0 +1,257 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Sheludko <ishell@chromium.org>
+Date: Thu, 1 Jun 2023 10:59:39 +0200
+Subject: Merged: [lookup] Robustify LookupIterator against own lookups
+
+... on non-JSReceiver objects.
+
+Bug: chromium:1447430
+(cherry picked from commit 515f187ba067ee4a99fdf5198cca2c97abd342fd)
+
+Change-Id: Ib9382d90ce19d6b55ee0b236dd299ded03ade04d
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4575069
+Reviewed-by: Toon Verwaest <verwaest@chromium.org>
+Commit-Queue: Igor Sheludko <ishell@chromium.org>
+Cr-Commit-Position: refs/branch-heads/11.4@{#35}
+Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
+Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
+
+diff --git a/src/objects/lookup-inl.h b/src/objects/lookup-inl.h
+index ff30fcc4f211f49d244e8431cfdb5cba29484329..579a195f06beec657271b8f84b5d92bc8c908d55 100644
+--- a/src/objects/lookup-inl.h
++++ b/src/objects/lookup-inl.h
+@@ -167,7 +167,7 @@ Handle<Name> PropertyKey::GetName(Isolate* isolate) {
+ }
+ 
+ Handle<Name> LookupIterator::name() const {
+-  DCHECK(!IsElement(*holder_));
++  DCHECK_IMPLIES(!holder_.is_null(), !IsElement(*holder_));
+   return name_;
+ }
+ 
+@@ -254,6 +254,7 @@ void LookupIterator::UpdateProtector() {
+ }
+ 
+ InternalIndex LookupIterator::descriptor_number() const {
++  DCHECK(!holder_.is_null());
+   DCHECK(!IsElement(*holder_));
+   DCHECK(has_property_);
+   DCHECK(holder_->HasFastProperties(isolate_));
+@@ -261,6 +262,7 @@ InternalIndex LookupIterator::descriptor_number() const {
+ }
+ 
+ InternalIndex LookupIterator::dictionary_entry() const {
++  DCHECK(!holder_.is_null());
+   DCHECK(!IsElement(*holder_));
+   DCHECK(has_property_);
+   DCHECK(!holder_->HasFastProperties(isolate_));
+@@ -275,13 +277,14 @@ LookupIterator::Configuration LookupIterator::ComputeConfiguration(
+ }
+ 
+ // static
+-Handle<JSReceiver> LookupIterator::GetRoot(Isolate* isolate,
+-                                           Handle<Object> lookup_start_object,
+-                                           size_t index) {
++MaybeHandle<JSReceiver> LookupIterator::GetRoot(
++    Isolate* isolate, Handle<Object> lookup_start_object, size_t index,
++    Configuration configuration) {
+   if (lookup_start_object->IsJSReceiver(isolate)) {
+     return Handle<JSReceiver>::cast(lookup_start_object);
+   }
+-  return GetRootForNonJSReceiver(isolate, lookup_start_object, index);
++  return GetRootForNonJSReceiver(isolate, lookup_start_object, index,
++                                 configuration);
+ }
+ 
+ template <class T>
+diff --git a/src/objects/lookup.cc b/src/objects/lookup.cc
+index e08ebaff089f8ab0a1b347f9eb5befd85e3c115b..920d28ffa81798c2e5fe9e15db016501d72728c6 100644
+--- a/src/objects/lookup.cc
++++ b/src/objects/lookup.cc
+@@ -42,27 +42,20 @@ PropertyKey::PropertyKey(Isolate* isolate, Handle<Object> key, bool* success) {
+   }
+ }
+ 
+-LookupIterator::LookupIterator(Isolate* isolate, Handle<Object> receiver,
+-                               Handle<Name> name, Handle<Map> transition_map,
+-                               PropertyDetails details, bool has_property)
+-    : configuration_(DEFAULT),
+-      state_(TRANSITION),
+-      has_property_(has_property),
+-      interceptor_state_(InterceptorState::kUninitialized),
+-      property_details_(details),
+-      isolate_(isolate),
+-      name_(name),
+-      transition_(transition_map),
+-      receiver_(receiver),
+-      lookup_start_object_(receiver),
+-      index_(kInvalidIndex) {
+-  holder_ = GetRoot(isolate, lookup_start_object_);
+-}
+-
+ template <bool is_element>
+ void LookupIterator::Start() {
+   // GetRoot might allocate if lookup_start_object_ is a string.
+-  holder_ = GetRoot(isolate_, lookup_start_object_, index_);
++  MaybeHandle<JSReceiver> maybe_holder =
++      GetRoot(isolate_, lookup_start_object_, index_, configuration_);
++  if (!maybe_holder.ToHandle(&holder_)) {
++    // This is an attempt to perform an own property lookup on a non-JSReceiver
++    // that doesn't have any properties.
++    DCHECK(!lookup_start_object_->IsJSReceiver());
++    DCHECK(!check_prototype_chain());
++    has_property_ = false;
++    state_ = NOT_FOUND;
++    return;
++  }
+ 
+   {
+     DisallowGarbageCollection no_gc;
+@@ -135,19 +128,27 @@ template void LookupIterator::RestartInternal<true>(InterceptorState);
+ template void LookupIterator::RestartInternal<false>(InterceptorState);
+ 
+ // static
+-Handle<JSReceiver> LookupIterator::GetRootForNonJSReceiver(
+-    Isolate* isolate, Handle<Object> lookup_start_object, size_t index) {
+-  // Strings are the only objects with properties (only elements) directly on
+-  // the wrapper. Hence we can skip generating the wrapper for all other cases.
+-  if (lookup_start_object->IsString(isolate) &&
+-      index <
+-          static_cast<size_t>(String::cast(*lookup_start_object).length())) {
+-    // TODO(verwaest): Speed this up. Perhaps use a cached wrapper on the native
+-    // context, ensuring that we don't leak it into JS?
+-    Handle<JSFunction> constructor = isolate->string_function();
+-    Handle<JSObject> result = isolate->factory()->NewJSObject(constructor);
+-    Handle<JSPrimitiveWrapper>::cast(result)->set_value(*lookup_start_object);
+-    return result;
++MaybeHandle<JSReceiver> LookupIterator::GetRootForNonJSReceiver(
++    Isolate* isolate, Handle<Object> lookup_start_object, size_t index,
++    Configuration configuration) {
++  // Strings are the only non-JSReceiver objects with properties (only elements
++  // and 'length') directly on the wrapper. Hence we can skip generating
++  // the wrapper for all other cases.
++  bool own_property_lookup = (configuration & kPrototypeChain) == 0;
++  if (lookup_start_object->IsString(isolate)) {
++    if (own_property_lookup ||
++        index <
++            static_cast<size_t>(String::cast(*lookup_start_object).length())) {
++      // TODO(verwaest): Speed this up. Perhaps use a cached wrapper on the
++      // native context, ensuring that we don't leak it into JS?
++      Handle<JSFunction> constructor = isolate->string_function();
++      Handle<JSObject> result = isolate->factory()->NewJSObject(constructor);
++      Handle<JSPrimitiveWrapper>::cast(result)->set_value(*lookup_start_object);
++      return result;
++    }
++  } else if (own_property_lookup) {
++    // Signal that the lookup will not find anything.
++    return {};
+   }
+   Handle<HeapObject> root(
+       lookup_start_object->GetPrototypeChainRootMap(isolate).prototype(isolate),
+@@ -903,6 +904,7 @@ Handle<Object> LookupIterator::FetchValue(
+ }
+ 
+ bool LookupIterator::IsConstFieldValueEqualTo(Object value) const {
++  DCHECK(!holder_.is_null());
+   DCHECK(!IsElement(*holder_));
+   DCHECK(holder_->HasFastProperties(isolate_));
+   DCHECK_EQ(PropertyLocation::kField, property_details_.location());
+@@ -944,6 +946,7 @@ bool LookupIterator::IsConstFieldValueEqualTo(Object value) const {
+ }
+ 
+ bool LookupIterator::IsConstDictValueEqualTo(Object value) const {
++  DCHECK(!holder_.is_null());
+   DCHECK(!IsElement(*holder_));
+   DCHECK(!holder_->HasFastProperties(isolate_));
+   DCHECK(!holder_->IsJSGlobalObject());
+@@ -994,6 +997,7 @@ int LookupIterator::GetAccessorIndex() const {
+ 
+ FieldIndex LookupIterator::GetFieldIndex() const {
+   DCHECK(has_property_);
++  DCHECK(!holder_.is_null());
+   DCHECK(holder_->HasFastProperties(isolate_));
+   DCHECK_EQ(PropertyLocation::kField, property_details_.location());
+   DCHECK(!IsElement(*holder_));
+@@ -1001,6 +1005,7 @@ FieldIndex LookupIterator::GetFieldIndex() const {
+ }
+ 
+ Handle<PropertyCell> LookupIterator::GetPropertyCell() const {
++  DCHECK(!holder_.is_null());
+   DCHECK(!IsElement(*holder_));
+   Handle<JSGlobalObject> holder = GetHolder<JSGlobalObject>();
+   return handle(holder->global_dictionary(isolate_, kAcquireLoad)
+diff --git a/src/objects/lookup.h b/src/objects/lookup.h
+index 782a09225c17a92ee8f08d20ede0902613158c27..15bcda75f2493bf4800d250e37f4273de36a6334 100644
+--- a/src/objects/lookup.h
++++ b/src/objects/lookup.h
+@@ -214,11 +214,6 @@ class V8_EXPORT_PRIVATE LookupIterator final {
+                         Handle<Object> lookup_start_object,
+                         Configuration configuration);
+ 
+-  // For |ForTransitionHandler|.
+-  LookupIterator(Isolate* isolate, Handle<Object> receiver, Handle<Name> name,
+-                 Handle<Map> transition_map, PropertyDetails details,
+-                 bool has_property);
+-
+   static void InternalUpdateProtector(Isolate* isolate, Handle<Object> receiver,
+                                       Handle<Name> name);
+ 
+@@ -278,12 +273,12 @@ class V8_EXPORT_PRIVATE LookupIterator final {
+                                                    Configuration configuration,
+                                                    Handle<Name> name);
+ 
+-  static Handle<JSReceiver> GetRootForNonJSReceiver(
+-      Isolate* isolate, Handle<Object> lookup_start_object,
+-      size_t index = kInvalidIndex);
+-  static inline Handle<JSReceiver> GetRoot(Isolate* isolate,
+-                                           Handle<Object> lookup_start_object,
+-                                           size_t index = kInvalidIndex);
++  static MaybeHandle<JSReceiver> GetRootForNonJSReceiver(
++      Isolate* isolate, Handle<Object> lookup_start_object, size_t index,
++      Configuration configuration);
++  static inline MaybeHandle<JSReceiver> GetRoot(
++      Isolate* isolate, Handle<Object> lookup_start_object, size_t index,
++      Configuration configuration);
+ 
+   State NotFound(JSReceiver const holder) const;
+ 
+diff --git a/test/mjsunit/regress/regress-crbug-1447430.js b/test/mjsunit/regress/regress-crbug-1447430.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..c7bb3e72e3af1b9f8c2fa82faeeb2d813fe6ab3c
+--- /dev/null
++++ b/test/mjsunit/regress/regress-crbug-1447430.js
+@@ -0,0 +1,34 @@
++// Copyright 2023 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// Flags: --allow-natives-syntax
++
++var s = %CreatePrivateSymbol('x');
++
++(function TestSmi() {
++  function f(o, p) {
++    o[p] = 153;
++  }
++  (1).__proto__[s] = 42;
++  %PrepareFunctionForOptimization(f);
++  assertEquals(f(42, s), undefined);
++}());
++
++(function TestString() {
++  function f(o, p) {
++    o[p] = 153;
++  }
++  ('xyz').__proto__[s] = 42;
++  %PrepareFunctionForOptimization(f);
++  assertEquals(f('abc', s), undefined);
++}());
++
++(function TestSymbol() {
++  function f(o, p) {
++    o[p] = 153;
++  }
++  Symbol('xyz').__proto__[s] = 42;
++  %PrepareFunctionForOptimization(f);
++  assertEquals(f(Symbol('abc'), s), undefined);
++}());

--- a/patches/v8/merged_ic_fix_store_handler_selection_for_arguments_objects.patch
+++ b/patches/v8/merged_ic_fix_store_handler_selection_for_arguments_objects.patch
@@ -1,0 +1,122 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Sheludko <ishell@chromium.org>
+Date: Fri, 2 Jun 2023 18:13:01 +0200
+Subject: Merged: [ic] Fix store handler selection for arguments objects
+
+Drive-by: fix printing of handlers in --trace-feedback-updates mode.
+
+(cherry picked from commit e144f3b71e64e01d6ffd247eb15ca1ff56f6287b)
+
+Bug: chromium:1450481
+Change-Id: Ifbb97d694b8520584df0610aad30805713b29c00
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4584889
+Reviewed-by: Toon Verwaest <verwaest@chromium.org>
+Commit-Queue: Igor Sheludko <ishell@chromium.org>
+Cr-Commit-Position: refs/branch-heads/10.9@{#32}
+Cr-Branched-From: 8ade6bf1fa237ad30dd9a05cc6ffe548131699e8-refs/heads/10.9.194@{#1}
+Cr-Branched-From: 9ff2515271f11cab783f0e82678ae0b925d77dd0-refs/heads/main@{#84164}
+
+diff --git a/src/diagnostics/objects-printer.cc b/src/diagnostics/objects-printer.cc
+index ce4d15b2c27e145be7e8dd2b98f1519ed11ce2f6..6063de51c2e4920f354ab55f53fe2f87f15ab369 100644
+--- a/src/diagnostics/objects-printer.cc
++++ b/src/diagnostics/objects-printer.cc
+@@ -1308,8 +1308,18 @@ void FeedbackNexus::Print(std::ostream& os) {
+     case FeedbackSlotKind::kSetKeyedStrict: {
+       os << InlineCacheState2String(ic_state());
+       if (ic_state() == InlineCacheState::MONOMORPHIC) {
+-        os << "\n   " << Brief(GetFeedback()) << ": ";
+-        StoreHandler::PrintHandler(GetFeedbackExtra().GetHeapObjectOrSmi(), os);
++        HeapObject feedback = GetFeedback().GetHeapObject();
++        HeapObject feedback_extra = GetFeedbackExtra().GetHeapObject();
++        if (feedback.IsName()) {
++          os << " with name " << Brief(feedback);
++          WeakFixedArray array = WeakFixedArray::cast(feedback_extra);
++          os << "\n   " << Brief(array.Get(0)) << ": ";
++          Object handler = array.Get(1).GetHeapObjectOrSmi();
++          StoreHandler::PrintHandler(handler, os);
++        } else {
++          os << "\n   " << Brief(feedback) << ": ";
++          StoreHandler::PrintHandler(feedback_extra, os);
++        }
+       } else if (ic_state() == InlineCacheState::POLYMORPHIC) {
+         WeakFixedArray array =
+             WeakFixedArray::cast(GetFeedback().GetHeapObject());
+diff --git a/src/ic/handler-configuration.cc b/src/ic/handler-configuration.cc
+index 43511407e0eb54e2ce22ee132d8a4d37c52b13a7..cd6d834d6b7ec84c1d46105449ca775cd970f4f2 100644
+--- a/src/ic/handler-configuration.cc
++++ b/src/ic/handler-configuration.cc
+@@ -584,8 +584,11 @@ void StoreHandler::PrintHandler(Object handler, std::ostream& os) {
+     os << ", validity cell = ";
+     store_handler.validity_cell().ShortPrint(os);
+     os << ")" << std::endl;
++  } else if (handler.IsMap()) {
++    os << "StoreHandler(field transition to " << Brief(handler) << ")"
++       << std::endl;
+   } else {
+-    os << "StoreHandler(<unexpected>)(" << Brief(handler) << ")";
++    os << "StoreHandler(<unexpected>)(" << Brief(handler) << ")" << std::endl;
+   }
+ }
+ 
+diff --git a/src/ic/ic.cc b/src/ic/ic.cc
+index ae1dde1a8c587dfc80a0a62e96b7bbfe6ba5eea5..78a38c5d5332af5ae0b7caa945c6d69667278703 100644
+--- a/src/ic/ic.cc
++++ b/src/ic/ic.cc
+@@ -2291,10 +2291,18 @@ Handle<Object> KeyedStoreIC::StoreElementHandler(
+              receiver_map->has_sealed_elements() ||
+              receiver_map->has_nonextensible_elements() ||
+              receiver_map->has_typed_array_or_rab_gsab_typed_array_elements()) {
++    // TODO(jgruber): Update counter name.
+     TRACE_HANDLER_STATS(isolate(), KeyedStoreIC_StoreFastElementStub);
+-    code = StoreHandler::StoreFastElementBuiltin(isolate(), store_mode);
+-    if (receiver_map->has_typed_array_or_rab_gsab_typed_array_elements()) {
+-      return code;
++    if (receiver_map->IsJSArgumentsObjectMap() &&
++        receiver_map->has_fast_packed_elements()) {
++      // Allow fast behaviour for in-bounds stores while making it miss and
++      // properly handle the out of bounds store case.
++      code = StoreHandler::StoreFastElementBuiltin(isolate(), STANDARD_STORE);
++    } else {
++      code = StoreHandler::StoreFastElementBuiltin(isolate(), store_mode);
++      if (receiver_map->has_typed_array_or_rab_gsab_typed_array_elements()) {
++        return code;
++      }
+     }
+   } else if (IsStoreInArrayLiteralIC()) {
+     // TODO(jgruber): Update counter name.
+@@ -2305,7 +2313,7 @@ Handle<Object> KeyedStoreIC::StoreElementHandler(
+     TRACE_HANDLER_STATS(isolate(), KeyedStoreIC_StoreElementStub);
+     DCHECK(DICTIONARY_ELEMENTS == receiver_map->elements_kind() ||
+            receiver_map->has_frozen_elements());
+-    code = StoreHandler::StoreSlow(isolate(), store_mode);
++    return StoreHandler::StoreSlow(isolate(), store_mode);
+   }
+ 
+   if (IsAnyDefineOwn() || IsStoreInArrayLiteralIC()) return code;
+diff --git a/src/objects/map-inl.h b/src/objects/map-inl.h
+index 04cdb99e103c5ab51c22a91fd7ba0712b757556c..5f93c39b652946a5ad8f23235f958dde4b84cbb4 100644
+--- a/src/objects/map-inl.h
++++ b/src/objects/map-inl.h
+@@ -589,6 +589,10 @@ bool Map::has_fast_elements() const {
+   return IsFastElementsKind(elements_kind());
+ }
+ 
++bool Map::has_fast_packed_elements() const {
++  return IsFastPackedElementsKind(elements_kind());
++}
++
+ bool Map::has_sloppy_arguments_elements() const {
+   return IsSloppyArgumentsElementsKind(elements_kind());
+ }
+diff --git a/src/objects/map.h b/src/objects/map.h
+index 6914a51150f4235386f5dca7af0d8103bc64f9e2..8311850f82bc32b794873689789c510376f67233 100644
+--- a/src/objects/map.h
++++ b/src/objects/map.h
+@@ -422,6 +422,7 @@ class Map : public TorqueGeneratedMap<Map, HeapObject> {
+   inline bool has_fast_smi_or_object_elements() const;
+   inline bool has_fast_double_elements() const;
+   inline bool has_fast_elements() const;
++  inline bool has_fast_packed_elements() const;
+   inline bool has_sloppy_arguments_elements() const;
+   inline bool has_fast_sloppy_arguments_elements() const;
+   inline bool has_fast_string_wrapper_elements() const;

--- a/patches/v8/merged_ic_fix_store_handler_selection_for_arguments_objects.patch
+++ b/patches/v8/merged_ic_fix_store_handler_selection_for_arguments_objects.patch
@@ -17,7 +17,7 @@ Cr-Branched-From: 8ade6bf1fa237ad30dd9a05cc6ffe548131699e8-refs/heads/10.9.194@{
 Cr-Branched-From: 9ff2515271f11cab783f0e82678ae0b925d77dd0-refs/heads/main@{#84164}
 
 diff --git a/src/diagnostics/objects-printer.cc b/src/diagnostics/objects-printer.cc
-index ce4d15b2c27e145be7e8dd2b98f1519ed11ce2f6..6063de51c2e4920f354ab55f53fe2f87f15ab369 100644
+index 71604afa7a067e14a891057de4011416f45f4f19..3f94e8aa7701eef49d5a35fd552742279b5e8586 100644
 --- a/src/diagnostics/objects-printer.cc
 +++ b/src/diagnostics/objects-printer.cc
 @@ -1308,8 +1308,18 @@ void FeedbackNexus::Print(std::ostream& os) {
@@ -59,10 +59,10 @@ index 43511407e0eb54e2ce22ee132d8a4d37c52b13a7..cd6d834d6b7ec84c1d46105449ca775c
  }
  
 diff --git a/src/ic/ic.cc b/src/ic/ic.cc
-index ae1dde1a8c587dfc80a0a62e96b7bbfe6ba5eea5..78a38c5d5332af5ae0b7caa945c6d69667278703 100644
+index fff21e90bad3451e2d942ec327cb02f394fecc46..f86d9acf9073aba1662de103c5dd5d6056df19bf 100644
 --- a/src/ic/ic.cc
 +++ b/src/ic/ic.cc
-@@ -2291,10 +2291,18 @@ Handle<Object> KeyedStoreIC::StoreElementHandler(
+@@ -2296,10 +2296,18 @@ Handle<Object> KeyedStoreIC::StoreElementHandler(
               receiver_map->has_sealed_elements() ||
               receiver_map->has_nonextensible_elements() ||
               receiver_map->has_typed_array_or_rab_gsab_typed_array_elements()) {
@@ -84,7 +84,7 @@ index ae1dde1a8c587dfc80a0a62e96b7bbfe6ba5eea5..78a38c5d5332af5ae0b7caa945c6d696
      }
    } else if (IsStoreInArrayLiteralIC()) {
      // TODO(jgruber): Update counter name.
-@@ -2305,7 +2313,7 @@ Handle<Object> KeyedStoreIC::StoreElementHandler(
+@@ -2310,7 +2318,7 @@ Handle<Object> KeyedStoreIC::StoreElementHandler(
      TRACE_HANDLER_STATS(isolate(), KeyedStoreIC_StoreElementStub);
      DCHECK(DICTIONARY_ELEMENTS == receiver_map->elements_kind() ||
             receiver_map->has_frozen_elements());


### PR DESCRIPTION
<details>
<summary>electron/security#362 - 73af1a19a901 from v8</summary>
Merged: [lookup] Robustify LookupIterator against own lookups

... on non-JSReceiver objects.

Bug: chromium:1447430
(cherry picked from commit 515f187ba067ee4a99fdf5198cca2c97abd342fd)

Change-Id: Ib9382d90ce19d6b55ee0b236dd299ded03ade04d
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4575069
Reviewed-by: Toon Verwaest <verwaest@chromium.org>
Commit-Queue: Igor Sheludko <ishell@chromium.org>
Cr-Commit-Position: refs/branch-heads/11.4@{#35}
Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
</details>

<details>
<summary>electron/security#361 - 0035a4a8dac2 from v8</summary>
Merged: [ic] Fix store handler selection for arguments objects

Drive-by: fix printing of handlers in --trace-feedback-updates mode.

Bug: chromium:1450481
(cherry picked from commit e144f3b71e64e01d6ffd247eb15ca1ff56f6287b)

Change-Id: I0d2c90d92aa006ab37a653822f3a514343a5bac4
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4583221
Reviewed-by: Toon Verwaest <verwaest@chromium.org>
Commit-Queue: Igor Sheludko <ishell@chromium.org>
Cr-Commit-Position: refs/branch-heads/11.4@{#37}
Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
</details>

Notes:
* Security: backported fix for 1447430.
* Security: backported fix for CVE-2023-3079.