### PR TITLE
chore: cherry-pick 2 changes from Release-1-M114

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -9,3 +9,5 @@ fix_disable_implies_dcheck_for_node_stream_array_buffers.patch
 force_cppheapcreateparams_to_be_noncopyable.patch
 chore_allow_customizing_microtask_policy_per_context.patch
 store_the_thread_stack_start_in_tls.patch
+cherry-pick-73af1a19a901.patch
+cherry-pick-0035a4a8dac2.patch

--- a/patches/v8/cherry-pick-0035a4a8dac2.patch
+++ b/patches/v8/cherry-pick-0035a4a8dac2.patch
@@ -1,0 +1,126 @@
+From 0035a4a8dac2104976ad31ce509917d0b0d287d2 Mon Sep 17 00:00:00 2001
+From: Igor Sheludko <ishell@chromium.org>
+Date: Fri, 02 Jun 2023 14:49:41 +0200
+Subject: [PATCH] Merged: [ic] Fix store handler selection for arguments objects
+
+Drive-by: fix printing of handlers in --trace-feedback-updates mode.
+
+Bug: chromium:1450481
+(cherry picked from commit e144f3b71e64e01d6ffd247eb15ca1ff56f6287b)
+
+Change-Id: I0d2c90d92aa006ab37a653822f3a514343a5bac4
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4583221
+Reviewed-by: Toon Verwaest <verwaest@chromium.org>
+Commit-Queue: Igor Sheludko <ishell@chromium.org>
+Cr-Commit-Position: refs/branch-heads/11.4@{#37}
+Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
+Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
+---
+
+diff --git a/src/diagnostics/objects-printer.cc b/src/diagnostics/objects-printer.cc
+index 4f5ea53..5c881a1 100644
+--- a/src/diagnostics/objects-printer.cc
++++ b/src/diagnostics/objects-printer.cc
+@@ -1338,12 +1338,18 @@
+     case FeedbackSlotKind::kSetKeyedStrict: {
+       os << InlineCacheState2String(ic_state());
+       if (ic_state() == InlineCacheState::MONOMORPHIC) {
+-        os << "\n   " << Brief(GetFeedback()) << ": ";
+-        Object handler = GetFeedbackExtra().GetHeapObjectOrSmi();
+-        if (handler.IsWeakFixedArray()) {
+-          handler = WeakFixedArray::cast(handler).Get(0).GetHeapObjectOrSmi();
++        HeapObject feedback = GetFeedback().GetHeapObject();
++        HeapObject feedback_extra = GetFeedbackExtra().GetHeapObject();
++        if (feedback.IsName()) {
++          os << " with name " << Brief(feedback);
++          WeakFixedArray array = WeakFixedArray::cast(feedback_extra);
++          os << "\n   " << Brief(array.Get(0)) << ": ";
++          Object handler = array.Get(1).GetHeapObjectOrSmi();
++          StoreHandler::PrintHandler(handler, os);
++        } else {
++          os << "\n   " << Brief(feedback) << ": ";
++          StoreHandler::PrintHandler(feedback_extra, os);
+         }
+-        StoreHandler::PrintHandler(handler, os);
+       } else if (ic_state() == InlineCacheState::POLYMORPHIC) {
+         HeapObject feedback = GetFeedback().GetHeapObject();
+         WeakFixedArray array;
+diff --git a/src/ic/handler-configuration.cc b/src/ic/handler-configuration.cc
+index 29dd9fa..306ff49 100644
+--- a/src/ic/handler-configuration.cc
++++ b/src/ic/handler-configuration.cc
+@@ -596,8 +596,11 @@
+     os << ", validity cell = ";
+     store_handler.validity_cell().ShortPrint(os);
+     os << ")" << std::endl;
++  } else if (handler.IsMap()) {
++    os << "StoreHandler(field transition to " << Brief(handler) << ")"
++       << std::endl;
+   } else {
+-    os << "StoreHandler(<unexpected>)(" << Brief(handler) << ")";
++    os << "StoreHandler(<unexpected>)(" << Brief(handler) << ")" << std::endl;
+   }
+ }
+ 
+diff --git a/src/ic/ic.cc b/src/ic/ic.cc
+index d548bbd..b8f5527 100644
+--- a/src/ic/ic.cc
++++ b/src/ic/ic.cc
+@@ -2283,10 +2283,18 @@
+              receiver_map->has_sealed_elements() ||
+              receiver_map->has_nonextensible_elements() ||
+              receiver_map->has_typed_array_or_rab_gsab_typed_array_elements()) {
++    // TODO(jgruber): Update counter name.
+     TRACE_HANDLER_STATS(isolate(), KeyedStoreIC_StoreFastElementStub);
+-    code = StoreHandler::StoreFastElementBuiltin(isolate(), store_mode);
+-    if (receiver_map->has_typed_array_or_rab_gsab_typed_array_elements()) {
+-      return code;
++    if (receiver_map->IsJSArgumentsObjectMap() &&
++        receiver_map->has_fast_packed_elements()) {
++      // Allow fast behaviour for in-bounds stores while making it miss and
++      // properly handle the out of bounds store case.
++      code = StoreHandler::StoreFastElementBuiltin(isolate(), STANDARD_STORE);
++    } else {
++      code = StoreHandler::StoreFastElementBuiltin(isolate(), store_mode);
++      if (receiver_map->has_typed_array_or_rab_gsab_typed_array_elements()) {
++        return code;
++      }
+     }
+   } else if (IsStoreInArrayLiteralIC()) {
+     // TODO(jgruber): Update counter name.
+@@ -2297,7 +2305,7 @@
+     TRACE_HANDLER_STATS(isolate(), KeyedStoreIC_StoreElementStub);
+     DCHECK(DICTIONARY_ELEMENTS == receiver_map->elements_kind() ||
+            receiver_map->has_frozen_elements());
+-    code = StoreHandler::StoreSlow(isolate(), store_mode);
++    return StoreHandler::StoreSlow(isolate(), store_mode);
+   }
+ 
+   if (IsAnyDefineOwn() || IsStoreInArrayLiteralIC()) return code;
+diff --git a/src/objects/map-inl.h b/src/objects/map-inl.h
+index 8bcce73..36594bb 100644
+--- a/src/objects/map-inl.h
++++ b/src/objects/map-inl.h
+@@ -614,6 +614,10 @@
+   return IsFastElementsKind(elements_kind());
+ }
+ 
++bool Map::has_fast_packed_elements() const {
++  return IsFastPackedElementsKind(elements_kind());
++}
++
+ bool Map::has_sloppy_arguments_elements() const {
+   return IsSloppyArgumentsElementsKind(elements_kind());
+ }
+diff --git a/src/objects/map.h b/src/objects/map.h
+index ba1d379..378eff5 100644
+--- a/src/objects/map.h
++++ b/src/objects/map.h
+@@ -428,6 +428,7 @@
+   inline bool has_fast_smi_or_object_elements() const;
+   inline bool has_fast_double_elements() const;
+   inline bool has_fast_elements() const;
++  inline bool has_fast_packed_elements() const;
+   inline bool has_sloppy_arguments_elements() const;
+   inline bool has_fast_sloppy_arguments_elements() const;
+   inline bool has_fast_string_wrapper_elements() const;

--- a/patches/v8/cherry-pick-0035a4a8dac2.patch
+++ b/patches/v8/cherry-pick-0035a4a8dac2.patch
@@ -1,7 +1,7 @@
-From 0035a4a8dac2104976ad31ce509917d0b0d287d2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Igor Sheludko <ishell@chromium.org>
-Date: Fri, 02 Jun 2023 14:49:41 +0200
-Subject: [PATCH] Merged: [ic] Fix store handler selection for arguments objects
+Date: Fri, 2 Jun 2023 14:49:41 +0200
+Subject: Merged: [ic] Fix store handler selection for arguments objects
 
 Drive-by: fix printing of handlers in --trace-feedback-updates mode.
 
@@ -15,13 +15,12 @@ Commit-Queue: Igor Sheludko <ishell@chromium.org>
 Cr-Commit-Position: refs/branch-heads/11.4@{#37}
 Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
 Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
----
 
 diff --git a/src/diagnostics/objects-printer.cc b/src/diagnostics/objects-printer.cc
-index 4f5ea53..5c881a1 100644
+index 213f6f8ea0af4157c66c9e2ac66ab4c8687dfd8d..9405e0dbfb107448e122b46e70e0eaf340102190 100644
 --- a/src/diagnostics/objects-printer.cc
 +++ b/src/diagnostics/objects-printer.cc
-@@ -1338,12 +1338,18 @@
+@@ -1338,12 +1338,18 @@ void FeedbackNexus::Print(std::ostream& os) {
      case FeedbackSlotKind::kSetKeyedStrict: {
        os << InlineCacheState2String(ic_state());
        if (ic_state() == InlineCacheState::MONOMORPHIC) {
@@ -46,10 +45,10 @@ index 4f5ea53..5c881a1 100644
          HeapObject feedback = GetFeedback().GetHeapObject();
          WeakFixedArray array;
 diff --git a/src/ic/handler-configuration.cc b/src/ic/handler-configuration.cc
-index 29dd9fa..306ff49 100644
+index 51c25e40dc0162d9b6bced1db712e42dae02d466..0eed4713837d7e683df8c021de10d0d0f341f1a8 100644
 --- a/src/ic/handler-configuration.cc
 +++ b/src/ic/handler-configuration.cc
-@@ -596,8 +596,11 @@
+@@ -593,8 +593,11 @@ void StoreHandler::PrintHandler(Object handler, std::ostream& os) {
      os << ", validity cell = ";
      store_handler.validity_cell().ShortPrint(os);
      os << ")" << std::endl;
@@ -63,10 +62,10 @@ index 29dd9fa..306ff49 100644
  }
  
 diff --git a/src/ic/ic.cc b/src/ic/ic.cc
-index d548bbd..b8f5527 100644
+index 55aa9d2c989f3fc846f0523ce5bd6a1483d448fa..ea879a1cf3bc303d482d795349bc9bbdfb46a3ec 100644
 --- a/src/ic/ic.cc
 +++ b/src/ic/ic.cc
-@@ -2283,10 +2283,18 @@
+@@ -2308,10 +2308,18 @@ Handle<Object> KeyedStoreIC::StoreElementHandler(
               receiver_map->has_sealed_elements() ||
               receiver_map->has_nonextensible_elements() ||
               receiver_map->has_typed_array_or_rab_gsab_typed_array_elements()) {
@@ -88,7 +87,7 @@ index d548bbd..b8f5527 100644
      }
    } else if (IsStoreInArrayLiteralIC()) {
      // TODO(jgruber): Update counter name.
-@@ -2297,7 +2305,7 @@
+@@ -2322,7 +2330,7 @@ Handle<Object> KeyedStoreIC::StoreElementHandler(
      TRACE_HANDLER_STATS(isolate(), KeyedStoreIC_StoreElementStub);
      DCHECK(DICTIONARY_ELEMENTS == receiver_map->elements_kind() ||
             receiver_map->has_frozen_elements());
@@ -98,10 +97,10 @@ index d548bbd..b8f5527 100644
  
    if (IsAnyDefineOwn() || IsStoreInArrayLiteralIC()) return code;
 diff --git a/src/objects/map-inl.h b/src/objects/map-inl.h
-index 8bcce73..36594bb 100644
+index 2c42cf2ee635896b1f5c631be5fbfa5dc167f763..077d7fb0562d731a1918d671a544fd0040759bf1 100644
 --- a/src/objects/map-inl.h
 +++ b/src/objects/map-inl.h
-@@ -614,6 +614,10 @@
+@@ -613,6 +613,10 @@ bool Map::has_fast_elements() const {
    return IsFastElementsKind(elements_kind());
  }
  
@@ -113,10 +112,10 @@ index 8bcce73..36594bb 100644
    return IsSloppyArgumentsElementsKind(elements_kind());
  }
 diff --git a/src/objects/map.h b/src/objects/map.h
-index ba1d379..378eff5 100644
+index bdc10ee2baa7b2ba3ffa8e1292eace4376f84a88..2e61b1eb97c701a5646bbadb6bbbe7f0c06e0351 100644
 --- a/src/objects/map.h
 +++ b/src/objects/map.h
-@@ -428,6 +428,7 @@
+@@ -426,6 +426,7 @@ class Map : public TorqueGeneratedMap<Map, HeapObject> {
    inline bool has_fast_smi_or_object_elements() const;
    inline bool has_fast_double_elements() const;
    inline bool has_fast_elements() const;

--- a/patches/v8/cherry-pick-73af1a19a901.patch
+++ b/patches/v8/cherry-pick-73af1a19a901.patch
@@ -1,7 +1,7 @@
-From 73af1a19a9015ce9e82ab7c4a7d220b659a04d68 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Igor Sheludko <ishell@chromium.org>
-Date: Thu, 01 Jun 2023 10:59:39 +0200
-Subject: [PATCH] Merged: [lookup] Robustify LookupIterator against own lookups
+Date: Thu, 1 Jun 2023 10:59:39 +0200
+Subject: Merged: [lookup] Robustify LookupIterator against own lookups
 
 ... on non-JSReceiver objects.
 
@@ -15,13 +15,12 @@ Commit-Queue: Igor Sheludko <ishell@chromium.org>
 Cr-Commit-Position: refs/branch-heads/11.4@{#35}
 Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
 Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
----
 
 diff --git a/src/objects/lookup-inl.h b/src/objects/lookup-inl.h
-index 00c95e0..8b57170 100644
+index d34f710147ea799bcc8a89b4b58e176918071bf6..474ade673c10c1d23a643bde876158723e6cff80 100644
 --- a/src/objects/lookup-inl.h
 +++ b/src/objects/lookup-inl.h
-@@ -190,7 +190,7 @@
+@@ -167,7 +167,7 @@ Handle<Name> PropertyKey::GetName(Isolate* isolate) {
  }
  
  Handle<Name> LookupIterator::name() const {
@@ -30,7 +29,7 @@ index 00c95e0..8b57170 100644
    return name_;
  }
  
-@@ -285,6 +285,7 @@
+@@ -258,6 +258,7 @@ void LookupIterator::UpdateProtector() {
  }
  
  InternalIndex LookupIterator::descriptor_number() const {
@@ -38,7 +37,7 @@ index 00c95e0..8b57170 100644
    DCHECK(!IsElement(*holder_));
    DCHECK(has_property_);
    DCHECK(holder_->HasFastProperties(isolate_));
-@@ -292,6 +293,7 @@
+@@ -265,6 +266,7 @@ InternalIndex LookupIterator::descriptor_number() const {
  }
  
  InternalIndex LookupIterator::dictionary_entry() const {
@@ -46,7 +45,7 @@ index 00c95e0..8b57170 100644
    DCHECK(!IsElement(*holder_));
    DCHECK(has_property_);
    DCHECK(!holder_->HasFastProperties(isolate_));
-@@ -306,13 +308,14 @@
+@@ -279,13 +281,14 @@ LookupIterator::Configuration LookupIterator::ComputeConfiguration(
  }
  
  // static
@@ -66,10 +65,10 @@ index 00c95e0..8b57170 100644
  
  template <class T>
 diff --git a/src/objects/lookup.cc b/src/objects/lookup.cc
-index 8fceef1..78c509b 100644
+index e3bf4794e88e7c3ae5d4028b16eeadf282d9c410..149149beba8d6e62dd5d821f7017b18e08445bd8 100644
 --- a/src/objects/lookup.cc
 +++ b/src/objects/lookup.cc
-@@ -42,27 +42,20 @@
+@@ -42,27 +42,20 @@ PropertyKey::PropertyKey(Isolate* isolate, Handle<Object> key, bool* success) {
    }
  }
  
@@ -108,7 +107,7 @@ index 8fceef1..78c509b 100644
  
    {
      DisallowGarbageCollection no_gc;
-@@ -135,19 +128,27 @@
+@@ -135,19 +128,27 @@ template void LookupIterator::RestartInternal<true>(InterceptorState);
  template void LookupIterator::RestartInternal<false>(InterceptorState);
  
  // static
@@ -149,7 +148,7 @@ index 8fceef1..78c509b 100644
    }
    Handle<HeapObject> root(
        lookup_start_object->GetPrototypeChainRootMap(isolate).prototype(isolate),
-@@ -918,6 +919,7 @@
+@@ -918,6 +919,7 @@ Handle<Object> LookupIterator::FetchValue(
  }
  
  bool LookupIterator::CanStayConst(Object value) const {
@@ -157,7 +156,7 @@ index 8fceef1..78c509b 100644
    DCHECK(!IsElement(*holder_));
    DCHECK(holder_->HasFastProperties(isolate_));
    DCHECK_EQ(PropertyLocation::kField, property_details_.location());
-@@ -951,6 +953,7 @@
+@@ -951,6 +953,7 @@ bool LookupIterator::CanStayConst(Object value) const {
  }
  
  bool LookupIterator::DictCanStayConst(Object value) const {
@@ -165,7 +164,7 @@ index 8fceef1..78c509b 100644
    DCHECK(!IsElement(*holder_));
    DCHECK(!holder_->HasFastProperties(isolate_));
    DCHECK(!holder_->IsJSGlobalObject());
-@@ -997,6 +1000,7 @@
+@@ -997,6 +1000,7 @@ int LookupIterator::GetAccessorIndex() const {
  
  FieldIndex LookupIterator::GetFieldIndex() const {
    DCHECK(has_property_);
@@ -173,7 +172,7 @@ index 8fceef1..78c509b 100644
    DCHECK(holder_->HasFastProperties(isolate_));
    DCHECK_EQ(PropertyLocation::kField, property_details_.location());
    DCHECK(!IsElement(*holder_));
-@@ -1004,6 +1008,7 @@
+@@ -1004,6 +1008,7 @@ FieldIndex LookupIterator::GetFieldIndex() const {
  }
  
  Handle<PropertyCell> LookupIterator::GetPropertyCell() const {
@@ -182,10 +181,10 @@ index 8fceef1..78c509b 100644
    Handle<JSGlobalObject> holder = GetHolder<JSGlobalObject>();
    return handle(holder->global_dictionary(isolate_, kAcquireLoad)
 diff --git a/src/objects/lookup.h b/src/objects/lookup.h
-index 06ed50e..5d2d926 100644
+index 9adee79b3028c53e6481a07316d74aed616f01bd..ef90316295c98d51b61c118cf331731f991d93d0 100644
 --- a/src/objects/lookup.h
 +++ b/src/objects/lookup.h
-@@ -222,11 +222,6 @@
+@@ -214,11 +214,6 @@ class V8_EXPORT_PRIVATE LookupIterator final {
                          Handle<Object> lookup_start_object,
                          Configuration configuration);
  
@@ -197,7 +196,7 @@ index 06ed50e..5d2d926 100644
    static void InternalUpdateProtector(Isolate* isolate, Handle<Object> receiver,
                                        Handle<Name> name);
  
-@@ -286,12 +281,12 @@
+@@ -278,12 +273,12 @@ class V8_EXPORT_PRIVATE LookupIterator final {
                                                     Configuration configuration,
                                                     Handle<Name> name);
  
@@ -218,7 +217,7 @@ index 06ed50e..5d2d926 100644
  
 diff --git a/test/mjsunit/regress/regress-crbug-1447430.js b/test/mjsunit/regress/regress-crbug-1447430.js
 new file mode 100644
-index 0000000..c7bb3e7
+index 0000000000000000000000000000000000000000..c7bb3e72e3af1b9f8c2fa82faeeb2d813fe6ab3c
 --- /dev/null
 +++ b/test/mjsunit/regress/regress-crbug-1447430.js
 @@ -0,0 +1,34 @@

--- a/patches/v8/cherry-pick-73af1a19a901.patch
+++ b/patches/v8/cherry-pick-73af1a19a901.patch
@@ -1,0 +1,258 @@
+From 73af1a19a9015ce9e82ab7c4a7d220b659a04d68 Mon Sep 17 00:00:00 2001
+From: Igor Sheludko <ishell@chromium.org>
+Date: Thu, 01 Jun 2023 10:59:39 +0200
+Subject: [PATCH] Merged: [lookup] Robustify LookupIterator against own lookups
+
+... on non-JSReceiver objects.
+
+Bug: chromium:1447430
+(cherry picked from commit 515f187ba067ee4a99fdf5198cca2c97abd342fd)
+
+Change-Id: Ib9382d90ce19d6b55ee0b236dd299ded03ade04d
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4575069
+Reviewed-by: Toon Verwaest <verwaest@chromium.org>
+Commit-Queue: Igor Sheludko <ishell@chromium.org>
+Cr-Commit-Position: refs/branch-heads/11.4@{#35}
+Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
+Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
+---
+
+diff --git a/src/objects/lookup-inl.h b/src/objects/lookup-inl.h
+index 00c95e0..8b57170 100644
+--- a/src/objects/lookup-inl.h
++++ b/src/objects/lookup-inl.h
+@@ -190,7 +190,7 @@
+ }
+ 
+ Handle<Name> LookupIterator::name() const {
+-  DCHECK(!IsElement(*holder_));
++  DCHECK_IMPLIES(!holder_.is_null(), !IsElement(*holder_));
+   return name_;
+ }
+ 
+@@ -285,6 +285,7 @@
+ }
+ 
+ InternalIndex LookupIterator::descriptor_number() const {
++  DCHECK(!holder_.is_null());
+   DCHECK(!IsElement(*holder_));
+   DCHECK(has_property_);
+   DCHECK(holder_->HasFastProperties(isolate_));
+@@ -292,6 +293,7 @@
+ }
+ 
+ InternalIndex LookupIterator::dictionary_entry() const {
++  DCHECK(!holder_.is_null());
+   DCHECK(!IsElement(*holder_));
+   DCHECK(has_property_);
+   DCHECK(!holder_->HasFastProperties(isolate_));
+@@ -306,13 +308,14 @@
+ }
+ 
+ // static
+-Handle<JSReceiver> LookupIterator::GetRoot(Isolate* isolate,
+-                                           Handle<Object> lookup_start_object,
+-                                           size_t index) {
++MaybeHandle<JSReceiver> LookupIterator::GetRoot(
++    Isolate* isolate, Handle<Object> lookup_start_object, size_t index,
++    Configuration configuration) {
+   if (lookup_start_object->IsJSReceiver(isolate)) {
+     return Handle<JSReceiver>::cast(lookup_start_object);
+   }
+-  return GetRootForNonJSReceiver(isolate, lookup_start_object, index);
++  return GetRootForNonJSReceiver(isolate, lookup_start_object, index,
++                                 configuration);
+ }
+ 
+ template <class T>
+diff --git a/src/objects/lookup.cc b/src/objects/lookup.cc
+index 8fceef1..78c509b 100644
+--- a/src/objects/lookup.cc
++++ b/src/objects/lookup.cc
+@@ -42,27 +42,20 @@
+   }
+ }
+ 
+-LookupIterator::LookupIterator(Isolate* isolate, Handle<Object> receiver,
+-                               Handle<Name> name, Handle<Map> transition_map,
+-                               PropertyDetails details, bool has_property)
+-    : configuration_(DEFAULT),
+-      state_(TRANSITION),
+-      has_property_(has_property),
+-      interceptor_state_(InterceptorState::kUninitialized),
+-      property_details_(details),
+-      isolate_(isolate),
+-      name_(name),
+-      transition_(transition_map),
+-      receiver_(receiver),
+-      lookup_start_object_(receiver),
+-      index_(kInvalidIndex) {
+-  holder_ = GetRoot(isolate, lookup_start_object_);
+-}
+-
+ template <bool is_element>
+ void LookupIterator::Start() {
+   // GetRoot might allocate if lookup_start_object_ is a string.
+-  holder_ = GetRoot(isolate_, lookup_start_object_, index_);
++  MaybeHandle<JSReceiver> maybe_holder =
++      GetRoot(isolate_, lookup_start_object_, index_, configuration_);
++  if (!maybe_holder.ToHandle(&holder_)) {
++    // This is an attempt to perform an own property lookup on a non-JSReceiver
++    // that doesn't have any properties.
++    DCHECK(!lookup_start_object_->IsJSReceiver());
++    DCHECK(!check_prototype_chain());
++    has_property_ = false;
++    state_ = NOT_FOUND;
++    return;
++  }
+ 
+   {
+     DisallowGarbageCollection no_gc;
+@@ -135,19 +128,27 @@
+ template void LookupIterator::RestartInternal<false>(InterceptorState);
+ 
+ // static
+-Handle<JSReceiver> LookupIterator::GetRootForNonJSReceiver(
+-    Isolate* isolate, Handle<Object> lookup_start_object, size_t index) {
+-  // Strings are the only objects with properties (only elements) directly on
+-  // the wrapper. Hence we can skip generating the wrapper for all other cases.
+-  if (lookup_start_object->IsString(isolate) &&
+-      index <
+-          static_cast<size_t>(String::cast(*lookup_start_object).length())) {
+-    // TODO(verwaest): Speed this up. Perhaps use a cached wrapper on the native
+-    // context, ensuring that we don't leak it into JS?
+-    Handle<JSFunction> constructor = isolate->string_function();
+-    Handle<JSObject> result = isolate->factory()->NewJSObject(constructor);
+-    Handle<JSPrimitiveWrapper>::cast(result)->set_value(*lookup_start_object);
+-    return result;
++MaybeHandle<JSReceiver> LookupIterator::GetRootForNonJSReceiver(
++    Isolate* isolate, Handle<Object> lookup_start_object, size_t index,
++    Configuration configuration) {
++  // Strings are the only non-JSReceiver objects with properties (only elements
++  // and 'length') directly on the wrapper. Hence we can skip generating
++  // the wrapper for all other cases.
++  bool own_property_lookup = (configuration & kPrototypeChain) == 0;
++  if (lookup_start_object->IsString(isolate)) {
++    if (own_property_lookup ||
++        index <
++            static_cast<size_t>(String::cast(*lookup_start_object).length())) {
++      // TODO(verwaest): Speed this up. Perhaps use a cached wrapper on the
++      // native context, ensuring that we don't leak it into JS?
++      Handle<JSFunction> constructor = isolate->string_function();
++      Handle<JSObject> result = isolate->factory()->NewJSObject(constructor);
++      Handle<JSPrimitiveWrapper>::cast(result)->set_value(*lookup_start_object);
++      return result;
++    }
++  } else if (own_property_lookup) {
++    // Signal that the lookup will not find anything.
++    return {};
+   }
+   Handle<HeapObject> root(
+       lookup_start_object->GetPrototypeChainRootMap(isolate).prototype(isolate),
+@@ -918,6 +919,7 @@
+ }
+ 
+ bool LookupIterator::CanStayConst(Object value) const {
++  DCHECK(!holder_.is_null());
+   DCHECK(!IsElement(*holder_));
+   DCHECK(holder_->HasFastProperties(isolate_));
+   DCHECK_EQ(PropertyLocation::kField, property_details_.location());
+@@ -951,6 +953,7 @@
+ }
+ 
+ bool LookupIterator::DictCanStayConst(Object value) const {
++  DCHECK(!holder_.is_null());
+   DCHECK(!IsElement(*holder_));
+   DCHECK(!holder_->HasFastProperties(isolate_));
+   DCHECK(!holder_->IsJSGlobalObject());
+@@ -997,6 +1000,7 @@
+ 
+ FieldIndex LookupIterator::GetFieldIndex() const {
+   DCHECK(has_property_);
++  DCHECK(!holder_.is_null());
+   DCHECK(holder_->HasFastProperties(isolate_));
+   DCHECK_EQ(PropertyLocation::kField, property_details_.location());
+   DCHECK(!IsElement(*holder_));
+@@ -1004,6 +1008,7 @@
+ }
+ 
+ Handle<PropertyCell> LookupIterator::GetPropertyCell() const {
++  DCHECK(!holder_.is_null());
+   DCHECK(!IsElement(*holder_));
+   Handle<JSGlobalObject> holder = GetHolder<JSGlobalObject>();
+   return handle(holder->global_dictionary(isolate_, kAcquireLoad)
+diff --git a/src/objects/lookup.h b/src/objects/lookup.h
+index 06ed50e..5d2d926 100644
+--- a/src/objects/lookup.h
++++ b/src/objects/lookup.h
+@@ -222,11 +222,6 @@
+                         Handle<Object> lookup_start_object,
+                         Configuration configuration);
+ 
+-  // For |ForTransitionHandler|.
+-  LookupIterator(Isolate* isolate, Handle<Object> receiver, Handle<Name> name,
+-                 Handle<Map> transition_map, PropertyDetails details,
+-                 bool has_property);
+-
+   static void InternalUpdateProtector(Isolate* isolate, Handle<Object> receiver,
+                                       Handle<Name> name);
+ 
+@@ -286,12 +281,12 @@
+                                                    Configuration configuration,
+                                                    Handle<Name> name);
+ 
+-  static Handle<JSReceiver> GetRootForNonJSReceiver(
+-      Isolate* isolate, Handle<Object> lookup_start_object,
+-      size_t index = kInvalidIndex);
+-  static inline Handle<JSReceiver> GetRoot(Isolate* isolate,
+-                                           Handle<Object> lookup_start_object,
+-                                           size_t index = kInvalidIndex);
++  static MaybeHandle<JSReceiver> GetRootForNonJSReceiver(
++      Isolate* isolate, Handle<Object> lookup_start_object, size_t index,
++      Configuration configuration);
++  static inline MaybeHandle<JSReceiver> GetRoot(
++      Isolate* isolate, Handle<Object> lookup_start_object, size_t index,
++      Configuration configuration);
+ 
+   State NotFound(JSReceiver const holder) const;
+ 
+diff --git a/test/mjsunit/regress/regress-crbug-1447430.js b/test/mjsunit/regress/regress-crbug-1447430.js
+new file mode 100644
+index 0000000..c7bb3e7
+--- /dev/null
++++ b/test/mjsunit/regress/regress-crbug-1447430.js
+@@ -0,0 +1,34 @@
++// Copyright 2023 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// Flags: --allow-natives-syntax
++
++var s = %CreatePrivateSymbol('x');
++
++(function TestSmi() {
++  function f(o, p) {
++    o[p] = 153;
++  }
++  (1).__proto__[s] = 42;
++  %PrepareFunctionForOptimization(f);
++  assertEquals(f(42, s), undefined);
++}());
++
++(function TestString() {
++  function f(o, p) {
++    o[p] = 153;
++  }
++  ('xyz').__proto__[s] = 42;
++  %PrepareFunctionForOptimization(f);
++  assertEquals(f('abc', s), undefined);
++}());
++
++(function TestSymbol() {
++  function f(o, p) {
++    o[p] = 153;
++  }
++  Symbol('xyz').__proto__[s] = 42;
++  %PrepareFunctionForOptimization(f);
++  assertEquals(f(Symbol('abc'), s), undefined);
++}());


### PR DESCRIPTION
<details>
<summary>electron/security#362 - 73af1a19a901 from v8</summary>
Merged: [lookup] Robustify LookupIterator against own lookups

... on non-JSReceiver objects.

Bug: chromium:1447430
(cherry picked from commit 515f187ba067ee4a99fdf5198cca2c97abd342fd)

Change-Id: Ib9382d90ce19d6b55ee0b236dd299ded03ade04d
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4575069
Reviewed-by: Toon Verwaest <verwaest@chromium.org>
Commit-Queue: Igor Sheludko <ishell@chromium.org>
Cr-Commit-Position: refs/branch-heads/11.4@{#35}
Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
</details>

<details>
<summary>electron/security#361 - 0035a4a8dac2 from v8</summary>
Merged: [ic] Fix store handler selection for arguments objects

Drive-by: fix printing of handlers in --trace-feedback-updates mode.

Bug: chromium:1450481
(cherry picked from commit e144f3b71e64e01d6ffd247eb15ca1ff56f6287b)

Change-Id: I0d2c90d92aa006ab37a653822f3a514343a5bac4
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4583221
Reviewed-by: Toon Verwaest <verwaest@chromium.org>
Commit-Queue: Igor Sheludko <ishell@chromium.org>
Cr-Commit-Position: refs/branch-heads/11.4@{#37}
Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
</details>

Notes:
* Security: backported fix for 1447430.
* Security: backported fix for CVE-2023-3079.