### PR TITLE
refactor: add SessionPreferences::CreateForBrowserContext()

### DIFF
--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -345,7 +345,7 @@ Session::Session(v8::Isolate* isolate, ElectronBrowserContext* browser_context)
   // Observe DownloadManager to get download notifications.
   browser_context->GetDownloadManager()->AddObserver(this);
 
-  new SessionPreferences(browser_context);
+  SessionPreferences::CreateForBrowserContext(browser_context);
 
   protocol_.Reset(isolate, Protocol::Create(isolate, browser_context).ToV8());
 

--- a/shell/browser/session_preferences.cc
+++ b/shell/browser/session_preferences.cc
@@ -13,10 +13,15 @@ namespace electron {
 // static
 int SessionPreferences::kLocatorKey = 0;
 
-SessionPreferences::SessionPreferences(content::BrowserContext* context) {
-  context->SetUserData(&kLocatorKey, base::WrapUnique(this));
+// static
+void SessionPreferences::CreateForBrowserContext(
+    content::BrowserContext* context) {
+  DCHECK(context);
+  context->SetUserData(&kLocatorKey,
+                       base::WrapUnique(new SessionPreferences{}));
 }
 
+SessionPreferences::SessionPreferences() = default;
 SessionPreferences::~SessionPreferences() = default;
 
 // static

--- a/shell/browser/session_preferences.h
+++ b/shell/browser/session_preferences.h
@@ -23,7 +23,8 @@ class SessionPreferences : public base::SupportsUserData::Data {
   static std::vector<base::FilePath> GetValidPreloads(
       content::BrowserContext* context);
 
-  explicit SessionPreferences(content::BrowserContext* context);
+  static void CreateForBrowserContext(content::BrowserContext* context);
+
   ~SessionPreferences() override;
 
   void set_preloads(const std::vector<base::FilePath>& preloads) {
@@ -32,6 +33,8 @@ class SessionPreferences : public base::SupportsUserData::Data {
   const std::vector<base::FilePath>& preloads() const { return preloads_; }
 
  private:
+  SessionPreferences();
+
   // The user data key.
   static int kLocatorKey;
 


### PR DESCRIPTION
#### Description of Change

Copy the [NativeWindowRelay::CreateForWebContents()](https://github.com/electron/electron/blob/69790f4b2a3d386230480c00ba9653febba2b78b/shell/browser/native_window.cc#L779) idiom to simplify SessionPreferences's constructor and lifecycle. Previously, one had to call `new SessionPreferences` and ignore the return value.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none