### PR TITLE
build: ensure correct dsymutil is downloaded for macOS

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -534,6 +534,14 @@ step-fix-sync: &step-fix-sync
         # Remove extra output from calling gclient getdep which always calls update_depot_tools
         sed -i '' "s/Updating depot_tools... //g" gn_ensure_file
         cipd ensure --root src/buildtools/mac -ensure-file gn_ensure_file
+
+        # Fix dsymutil (wrong binary)
+        if  [ "$TARGET_ARCH" == "arm64" ]; then
+          export DSYM_SHA_FILE=src/tools/clang/dsymutil/bin/dsymutil.arm64.sha1
+        else
+          export DSYM_SHA_FILE=src/tools/clang/dsymutil/bin/dsymutil.x64.sha1
+        fi
+        python3 src/third_party/depot_tools/download_from_google_storage.py --no_resume --no_auth --bucket chromium-browser-clang -s $DSYM_SHA_FILE -o src/tools/clang/dsymutil/bin/dsymutil
       fi
 
       # Make sure we are using the right ninja


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
- #38258 moved macOS arm builds to m1 hosts but unfortunately that broke release builds.  This PR should fix those release builds.
- 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
