### PR TITLE
fix: WCO transparent background

### DIFF
--- a/docs/tutorial/window-customization.md
+++ b/docs/tutorial/window-customization.md
@@ -115,7 +115,7 @@ const win = new BrowserWindow({
 })
 ```
 
-On either platform `titleBarOverlay` can also be an object. On both macOS and Windows, the height of the overlay can be specified with the `height` property. On Windows, the color of the overlay and its symbols can be specified using the `color` and `symbolColor` properties respectively.
+On either platform `titleBarOverlay` can also be an object. On both macOS and Windows, the height of the overlay can be specified with the `height` property. On Windows, the color of the overlay and its symbols can be specified using the `color` and `symbolColor` properties respectively. `rgba()`, `hsla()`, and `#RRGGBBAA` color formats are supported to apply transparency.
 
 If a color option is not specified, the color will default to its system color for the window control buttons. Similarly, if the height option is not specified it will default to the default height:
 
@@ -135,10 +135,6 @@ const win = new BrowserWindow({
 > Note: Once your title bar overlay is enabled from the main process, you can access the overlay's
 > color and dimension values from a renderer using a set of readonly
 > [JavaScript APIs][overlay-javascript-apis] and [CSS Environment Variables][overlay-css-env-vars].
-
-### Limitations
-
-* Transparent colors are currently not supported. Progress updates for this feature can be found in PR [#33567](https://github.com/electron/electron/issues/33567).
 
 ## Create transparent windows
 

--- a/shell/browser/ui/views/win_caption_button_container.cc
+++ b/shell/browser/ui/views/win_caption_button_container.cc
@@ -13,6 +13,7 @@
 #include "shell/browser/ui/views/win_caption_button.h"
 #include "shell/browser/ui/views/win_frame_view.h"
 #include "ui/base/l10n/l10n_util.h"
+#include "ui/compositor/layer.h"
 #include "ui/strings/grit/ui_strings.h"
 #include "ui/views/background.h"
 #include "ui/views/layout/flex_layout.h"
@@ -129,9 +130,13 @@ void WinCaptionButtonContainer::AddedToWidget() {
   UpdateButtons();
 
   if (frame_view_->window()->IsWindowControlsOverlayEnabled()) {
-    SetBackground(views::CreateSolidBackground(
-        frame_view_->window()->overlay_button_color()));
+    const SkColor bg_color = frame_view_->window()->overlay_button_color();
+    const SkAlpha theme_alpha = SkColorGetA(bg_color);
+    SetBackground(views::CreateSolidBackground(bg_color));
     SetPaintToLayer();
+
+    if (theme_alpha < SK_AlphaOPAQUE)
+      layer()->SetFillsBoundsOpaquely(false);
   }
 }
 

--- a/shell/browser/ui/views/win_caption_button_container.cc
+++ b/shell/browser/ui/views/win_caption_button_container.cc
@@ -130,13 +130,7 @@ void WinCaptionButtonContainer::AddedToWidget() {
   UpdateButtons();
 
   if (frame_view_->window()->IsWindowControlsOverlayEnabled()) {
-    const SkColor bg_color = frame_view_->window()->overlay_button_color();
-    const SkAlpha theme_alpha = SkColorGetA(bg_color);
-    SetBackground(views::CreateSolidBackground(bg_color));
-    SetPaintToLayer();
-
-    if (theme_alpha < SK_AlphaOPAQUE)
-      layer()->SetFillsBoundsOpaquely(false);
+    UpdateBackground();
   }
 }
 
@@ -149,6 +143,16 @@ void WinCaptionButtonContainer::OnWidgetBoundsChanged(
     views::Widget* widget,
     const gfx::Rect& new_bounds) {
   UpdateButtons();
+}
+
+void WinCaptionButtonContainer::UpdateBackground() {
+  const SkColor bg_color = frame_view_->window()->overlay_button_color();
+  const SkAlpha theme_alpha = SkColorGetA(bg_color);
+  SetBackground(views::CreateSolidBackground(bg_color));
+  SetPaintToLayer();
+
+  if (theme_alpha < SK_AlphaOPAQUE)
+    layer()->SetFillsBoundsOpaquely(false);
 }
 
 void WinCaptionButtonContainer::UpdateButtons() {

--- a/shell/browser/ui/views/win_caption_button_container.h
+++ b/shell/browser/ui/views/win_caption_button_container.h
@@ -41,6 +41,9 @@ class WinCaptionButtonContainer : public views::View,
   gfx::Size GetButtonSize() const;
   void SetButtonSize(gfx::Size size);
 
+  // Sets caption button container background color.
+  void UpdateBackground();
+
   // Sets caption button visibility and enabled state based on window state.
   // Only one of maximize or restore button should ever be visible at the same
   // time, and both are disabled in tablet UI mode.

--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -59,8 +59,7 @@ void WinFrameView::InvalidateCaptionButtons() {
   if (!caption_button_container_)
     return;
 
-  caption_button_container_->SetBackground(
-      views::CreateSolidBackground(window()->overlay_button_color()));
+  caption_button_container_->UpdateBackground();
   caption_button_container_->InvalidateLayout();
   caption_button_container_->SchedulePaint();
 }


### PR DESCRIPTION
#### Description of Change

fixes https://github.com/electron/electron/issues/33567

WCO would not render properly when given colors containing non-opaque alpha values (e.g. `color: 'rgba(0,0,0,0)'`). The fix is to set the view's layer to not fill its bounds opaquely when the alpha value is not fully opaque.

fiddle gist: https://gist.github.com/samuelmaddock/666ab002510e259ef09fc33a2fd228a2
![electron-fiddle_2023-06-08_14-55-583d89](https://github.com/electron/electron/assets/1656324/5ec3c996-58bc-459e-96e9-bb6bab47aaa9)

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added transparent color support for WCO on Windows
