### PR TITLE
fix: `webContents.print()` cancellation callback

### DIFF
--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -91,7 +91,7 @@ index 3a66a52b8d3c6da9cd8d7e9afdc8d59f528ec3d5..facaa6fbca8ee7c04f83607e62b81b95
                 : PdfRenderSettings::Mode::POSTSCRIPT_LEVEL3;
    }
 diff --git a/chrome/browser/printing/print_view_manager_base.cc b/chrome/browser/printing/print_view_manager_base.cc
-index d7a3961a5c79e4d4f9f0fc5fbd6f1c55ab65ca9d..cf200ee43464bcde31dc13c18524e58d4ac2479b 100644
+index d7a3961a5c79e4d4f9f0fc5fbd6f1c55ab65ca9d..45c3bd7ef13be525ea6fbc2610513a0b93536b9d 100644
 --- a/chrome/browser/printing/print_view_manager_base.cc
 +++ b/chrome/browser/printing/print_view_manager_base.cc
 @@ -23,7 +23,9 @@
@@ -149,16 +149,17 @@ index d7a3961a5c79e4d4f9f0fc5fbd6f1c55ab65ca9d..cf200ee43464bcde31dc13c18524e58d
      std::move(callback).Run(nullptr);
      return;
    }
-@@ -122,7 +142,7 @@ void OnDidScriptedPrint(
+@@ -122,7 +142,8 @@ void OnDidScriptedPrint(
  
    if (printer_query->last_status() != mojom::ResultCode::kSuccess ||
        !printer_query->settings().dpi()) {
 -    std::move(callback).Run(nullptr);
-+    std::move(callback).Run(nullptr, false);
++    bool canceled = printer_query->last_status() == mojom::ResultCode::kCanceled;
++    std::move(callback).Run(nullptr, canceled);
      return;
    }
  
-@@ -132,12 +152,13 @@ void OnDidScriptedPrint(
+@@ -132,12 +153,12 @@ void OnDidScriptedPrint(
                                  params->params.get());
    params->params->document_cookie = printer_query->cookie();
    if (!PrintMsgPrintParamsIsValid(*params->params)) {
@@ -169,8 +170,7 @@ index d7a3961a5c79e4d4f9f0fc5fbd6f1c55ab65ca9d..cf200ee43464bcde31dc13c18524e58d
  
    params->pages = printer_query->settings().ranges();
 -  std::move(callback).Run(std::move(params));
-+  bool canceled = printer_query->last_status() == mojom::ResultCode::kCanceled;
-+  std::move(callback).Run(std::move(params), canceled);
++  std::move(callback).Run(std::move(params), false);
    queue->QueuePrinterQuery(std::move(printer_query));
  }
  


### PR DESCRIPTION
#### Description of Change

Refs CL:3893234

Fixes an issue where `webContents.print()` stopped triggering its callback when the user cancelled the print dialog. This happened as a result of https://github.com/electron/electron/commit/5261e08d0c21b08a62a9f86340247aae0f4aeaf9 - the patch was modified to check for last status being cancelled, but this was done _after_ a check for `printer_query->last_status() != mojom::ResultCode::kSuccess`. This meant that code flow would never reach the cancellation check.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `webContents.print()` stopped triggering its callback when the user cancelled the print dialog.