### PR TITLE
perf: prefer base::StringPiece over std::string for build-time strings

### DIFF
--- a/shell/browser/api/electron_api_cookies.cc
+++ b/shell/browser/api/electron_api_cookies.cc
@@ -169,7 +169,7 @@ base::Time ParseTimeProperty(const absl::optional<double>& value) {
   return base::Time::FromDoubleT(*value);
 }
 
-std::string InclusionStatusToString(net::CookieInclusionStatus status) {
+base::StringPiece InclusionStatusToString(net::CookieInclusionStatus status) {
   if (status.HasExclusionReason(net::CookieInclusionStatus::EXCLUDE_HTTP_ONLY))
     return "Failed to create httponly cookie";
   if (status.HasExclusionReason(

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -167,7 +167,7 @@ const char* const kBuiltinSchemes[] = {
 };
 
 // Convert error code to string.
-std::string ErrorCodeToString(ProtocolError error) {
+constexpr base::StringPiece ErrorCodeToString(ProtocolError error) {
   switch (error) {
     case ProtocolError::kRegistered:
       return "The scheme has been registered";

--- a/shell/browser/api/electron_api_service_worker_context.cc
+++ b/shell/browser/api/electron_api_service_worker_context.cc
@@ -25,33 +25,36 @@ namespace electron::api {
 
 namespace {
 
-std::string MessageSourceToString(
+constexpr base::StringPiece MessageSourceToString(
     const blink::mojom::ConsoleMessageSource source) {
-  if (source == blink::mojom::ConsoleMessageSource::kXml)
-    return "xml";
-  if (source == blink::mojom::ConsoleMessageSource::kJavaScript)
-    return "javascript";
-  if (source == blink::mojom::ConsoleMessageSource::kNetwork)
-    return "network";
-  if (source == blink::mojom::ConsoleMessageSource::kConsoleApi)
-    return "console-api";
-  if (source == blink::mojom::ConsoleMessageSource::kStorage)
-    return "storage";
-  if (source == blink::mojom::ConsoleMessageSource::kRendering)
-    return "rendering";
-  if (source == blink::mojom::ConsoleMessageSource::kSecurity)
-    return "security";
-  if (source == blink::mojom::ConsoleMessageSource::kDeprecation)
-    return "deprecation";
-  if (source == blink::mojom::ConsoleMessageSource::kWorker)
-    return "worker";
-  if (source == blink::mojom::ConsoleMessageSource::kViolation)
-    return "violation";
-  if (source == blink::mojom::ConsoleMessageSource::kIntervention)
-    return "intervention";
-  if (source == blink::mojom::ConsoleMessageSource::kRecommendation)
-    return "recommendation";
-  return "other";
+  switch (source) {
+    case blink::mojom::ConsoleMessageSource::kXml:
+      return "xml";
+    case blink::mojom::ConsoleMessageSource::kJavaScript:
+      return "javascript";
+    case blink::mojom::ConsoleMessageSource::kNetwork:
+      return "network";
+    case blink::mojom::ConsoleMessageSource::kConsoleApi:
+      return "console-api";
+    case blink::mojom::ConsoleMessageSource::kStorage:
+      return "storage";
+    case blink::mojom::ConsoleMessageSource::kRendering:
+      return "rendering";
+    case blink::mojom::ConsoleMessageSource::kSecurity:
+      return "security";
+    case blink::mojom::ConsoleMessageSource::kDeprecation:
+      return "deprecation";
+    case blink::mojom::ConsoleMessageSource::kWorker:
+      return "worker";
+    case blink::mojom::ConsoleMessageSource::kViolation:
+      return "violation";
+    case blink::mojom::ConsoleMessageSource::kIntervention:
+      return "intervention";
+    case blink::mojom::ConsoleMessageSource::kRecommendation:
+      return "recommendation";
+    default:
+      return "other";
+  }
 }
 
 v8::Local<v8::Value> ServiceWorkerRunningInfoToDict(

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -379,8 +379,9 @@ namespace electron::api {
 
 namespace {
 
-std::string CursorTypeToString(const ui::Cursor& cursor) {
-  switch (cursor.type()) {
+constexpr base::StringPiece CursorTypeToString(
+    ui::mojom::CursorType cursor_type) {
+  switch (cursor_type) {
     case ui::mojom::CursorType::kPointer:
       return "pointer";
     case ui::mojom::CursorType::kCross:
@@ -3515,14 +3516,14 @@ bool WebContents::IsBeingCaptured() {
 
 void WebContents::OnCursorChanged(const ui::Cursor& cursor) {
   if (cursor.type() == ui::mojom::CursorType::kCustom) {
-    Emit("cursor-changed", CursorTypeToString(cursor),
+    Emit("cursor-changed", CursorTypeToString(cursor.type()),
          gfx::Image::CreateFrom1xBitmap(cursor.custom_bitmap()),
          cursor.image_scale_factor(),
          gfx::Size(cursor.custom_bitmap().width(),
                    cursor.custom_bitmap().height()),
          cursor.custom_hotspot());
   } else {
-    Emit("cursor-changed", CursorTypeToString(cursor));
+    Emit("cursor-changed", CursorTypeToString(cursor.type()));
   }
 }
 

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -19,7 +19,8 @@
 
 namespace {
 
-std::string MediaStreamTypeToString(blink::mojom::MediaStreamType type) {
+constexpr base::StringPiece MediaStreamTypeToString(
+    blink::mojom::MediaStreamType type) {
   switch (type) {
     case blink::mojom::MediaStreamType::DEVICE_AUDIO_CAPTURE:
       return "audio";

--- a/shell/common/gin_converters/blink_converter.cc
+++ b/shell/common/gin_converters/blink_converter.cc
@@ -180,9 +180,9 @@ struct Converter<blink::WebInputEvent::Modifiers> {
   }
 };
 
-std::vector<std::string> ModifiersToArray(int modifiers) {
+std::vector<base::StringPiece> ModifiersToArray(int modifiers) {
   using Modifiers = blink::WebInputEvent::Modifiers;
-  std::vector<std::string> modifier_strings;
+  std::vector<base::StringPiece> modifier_strings;
   if (modifiers & Modifiers::kShiftKey)
     modifier_strings.push_back("shift");
   if (modifiers & Modifiers::kControlKey)

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -383,7 +383,7 @@ class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
 
  private:
   bool MaybeGetRenderFrame(v8::Isolate* isolate,
-                           const std::string& method_name,
+                           const base::StringPiece method_name,
                            content::RenderFrame** render_frame_ptr) {
     std::string error_msg;
     if (!MaybeGetRenderFrame(&error_msg, method_name, render_frame_ptr)) {
@@ -394,13 +394,12 @@ class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
   }
 
   bool MaybeGetRenderFrame(std::string* error_msg,
-                           const std::string& method_name,
+                           const base::StringPiece method_name,
                            content::RenderFrame** render_frame_ptr) {
     auto* frame = render_frame();
     if (!frame) {
-      *error_msg = "Render frame was torn down before webFrame." + method_name +
-                   " could be "
-                   "executed";
+      *error_msg = base::ToString("Render frame was torn down before webFrame.",
+                                  method_name, " could be executed");
       return false;
     }
     *render_frame_ptr = frame;


### PR DESCRIPTION
#### Description of Change

In places where we're dealing with a set of strings that are known at build time, e.g. the names of cursor types, prefer `base::StringPiece` over `std::string`. The former involves no heap allocations and are constexpr. (In fact, most of these lookup helper functions are constexpr now in this PR).

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none