### PR TITLE
docs: clarify supported accelerator punctuation

### DIFF
--- a/docs/api/accelerator.md
+++ b/docs/api/accelerator.md
@@ -55,7 +55,7 @@ The `Super` (or `Meta`) key is mapped to the `Windows` key on Windows and Linux 
 * `0` to `9`
 * `A` to `Z`
 * `F1` to `F24`
-* Punctuation like `~`, `!`, `@`, `#`, `$`, etc.
+* Various Punctuation: `)`, `!`, `@`, `#`, `$`, `%`, `^`, `&`, `*`, `(`, `:`, `;`, `:`, `+`, `=`, `<`, `,`, `_`, `-`, `>`, `.`, `?`, `/`, `~`, `` ` ``, `{`, `]`, `[`, `|`, `\`, `}`, `"`
 * `Plus`
 * `Space`
 * `Tab`

--- a/shell/common/keyboard_util.cc
+++ b/shell/common/keyboard_util.cc
@@ -207,7 +207,6 @@ ui::KeyboardCode KeyboardCodeFromCharCode(char16_t c, bool* shifted) {
       return ui::VKEY_Y;
     case 'z':
       return ui::VKEY_Z;
-
     case ')':
       *shifted = true;
       [[fallthrough]];
@@ -258,7 +257,6 @@ ui::KeyboardCode KeyboardCodeFromCharCode(char16_t c, bool* shifted) {
       [[fallthrough]];
     case '9':
       return ui::VKEY_9;
-
     case ':':
       *shifted = true;
       [[fallthrough]];
@@ -314,7 +312,6 @@ ui::KeyboardCode KeyboardCodeFromCharCode(char16_t c, bool* shifted) {
       [[fallthrough]];
     case '\'':
       return ui::VKEY_OEM_7;
-
     default:
       return ui::VKEY_UNKNOWN;
   }


### PR DESCRIPTION
#### Description of Change

 Closes https://github.com/electron/electron/issues/38676.

Clarifies supported acceleration per [`keyboard_util.cc`](https://github.com/electron/electron/blob/28ada6ea8bd2abeca8812e6d284c1f5f3974286b/shell/common/keyboard_util.cc#L142-L321)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
