### PR TITLE
fix: `webContents.print({ silent: true })` not working correctly

### DIFF
--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -91,7 +91,7 @@ index 3a66a52b8d3c6da9cd8d7e9afdc8d59f528ec3d5..facaa6fbca8ee7c04f83607e62b81b95
                 : PdfRenderSettings::Mode::POSTSCRIPT_LEVEL3;
    }
 diff --git a/chrome/browser/printing/print_view_manager_base.cc b/chrome/browser/printing/print_view_manager_base.cc
-index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffdd4ff2077 100644
+index 2bb42383d753ac39953adf5dccf1cbc02f100b88..2ff3f9391cb60082e2e72af8d9d82c9e33f2e7f6 100644
 --- a/chrome/browser/printing/print_view_manager_base.cc
 +++ b/chrome/browser/printing/print_view_manager_base.cc
 @@ -23,7 +23,9 @@
@@ -212,7 +212,43 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
    return true;
  }
  
-@@ -451,7 +482,8 @@ void PrintViewManagerBase::GetDefaultPrintSettingsReply(
+@@ -323,12 +354,13 @@ void PrintViewManagerBase::OnDidUpdatePrintableArea(
+   }
+   PRINTER_LOG(EVENT) << "Paper printable area updated for vendor id "
+                      << print_settings->requested_media().vendor_id;
+-  CompleteUpdatePrintSettings(std::move(job_settings),
++  CompleteUpdatePrintSettings(nullptr /* printer_query */, std::move(job_settings),
+                               std::move(print_settings), std::move(callback));
+ }
+ #endif
+ 
+ void PrintViewManagerBase::CompleteUpdatePrintSettings(
++    std::unique_ptr<PrinterQuery> printer_query,
+     base::Value::Dict job_settings,
+     std::unique_ptr<PrintSettings> print_settings,
+     UpdatePrintSettingsCallback callback) {
+@@ -336,7 +368,8 @@ void PrintViewManagerBase::CompleteUpdatePrintSettings(
+   settings->pages = GetPageRangesFromJobSettings(job_settings);
+   settings->params = mojom::PrintParams::New();
+   RenderParamsFromPrintSettings(*print_settings, settings->params.get());
+-  settings->params->document_cookie = PrintSettings::NewCookie();
++  settings->params->document_cookie = printer_query ? printer_query->cookie()
++                                                    : PrintSettings::NewCookie();
+   if (!PrintMsgPrintParamsIsValid(*settings->params)) {
+     mojom::PrinterType printer_type = static_cast<mojom::PrinterType>(
+         *job_settings.FindInt(kSettingPrinterType));
+@@ -348,6 +381,10 @@ void PrintViewManagerBase::CompleteUpdatePrintSettings(
+     return;
+   }
+ 
++  if (printer_query && printer_query->cookie() && printer_query->settings().dpi()) {
++    queue_->QueuePrinterQuery(std::move(printer_query));
++  }
++
+   set_cookie(settings->params->document_cookie);
+   std::move(callback).Run(std::move(settings));
+ }
+@@ -451,7 +488,8 @@ void PrintViewManagerBase::GetDefaultPrintSettingsReply(
  void PrintViewManagerBase::ScriptedPrintReply(
      ScriptedPrintCallback callback,
      int process_id,
@@ -222,7 +258,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
  
  #if BUILDFLAG(ENABLE_OOP_PRINTING)
-@@ -466,12 +498,15 @@ void PrintViewManagerBase::ScriptedPrintReply(
+@@ -466,12 +504,15 @@ void PrintViewManagerBase::ScriptedPrintReply(
      return;
    }
  
@@ -240,7 +276,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
    }
  }
  
-@@ -608,10 +643,12 @@ void PrintViewManagerBase::DidPrintDocument(
+@@ -608,10 +649,12 @@ void PrintViewManagerBase::DidPrintDocument(
  void PrintViewManagerBase::GetDefaultPrintSettings(
      GetDefaultPrintSettingsCallback callback) {
    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
@@ -253,7 +289,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
  #if BUILDFLAG(ENABLE_OOP_PRINTING)
    if (printing::features::kEnableOopPrintDriversJobPrint.Get() &&
  #if BUILDFLAG(ENABLE_PRINT_CONTENT_ANALYSIS)
-@@ -662,10 +699,12 @@ void PrintViewManagerBase::UpdatePrintSettings(
+@@ -662,10 +705,12 @@ void PrintViewManagerBase::UpdatePrintSettings(
      base::Value::Dict job_settings,
      UpdatePrintSettingsCallback callback) {
    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
@@ -266,7 +302,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
  
    absl::optional<int> printer_type_value =
        job_settings.FindInt(kSettingPrinterType);
-@@ -676,6 +715,7 @@ void PrintViewManagerBase::UpdatePrintSettings(
+@@ -676,6 +721,7 @@ void PrintViewManagerBase::UpdatePrintSettings(
  
    mojom::PrinterType printer_type =
        static_cast<mojom::PrinterType>(*printer_type_value);
@@ -274,7 +310,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
    if (printer_type != mojom::PrinterType::kExtension &&
        printer_type != mojom::PrinterType::kPdf &&
        printer_type != mojom::PrinterType::kLocal) {
-@@ -695,6 +735,7 @@ void PrintViewManagerBase::UpdatePrintSettings(
+@@ -695,6 +741,7 @@ void PrintViewManagerBase::UpdatePrintSettings(
      if (value > 0)
        job_settings.Set(kSettingRasterizePdfDpi, value);
    }
@@ -282,7 +318,32 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
  
    std::unique_ptr<PrintSettings> print_settings =
        PrintSettingsFromJobSettings(job_settings);
-@@ -744,7 +785,7 @@ void PrintViewManagerBase::UpdatePrintSettings(
+@@ -714,6 +761,16 @@ void PrintViewManagerBase::UpdatePrintSettings(
+     }
+   }
+ 
++  std::unique_ptr<PrinterQuery> query =
++      queue_->CreatePrinterQuery(GetCurrentTargetFrame()->GetGlobalId());
++  auto* query_ptr = query.get();
++  query_ptr->SetSettings(
++      job_settings.Clone(),
++      base::BindOnce(&PrintViewManagerBase::CompleteUpdatePrintSettings,
++                     weak_ptr_factory_.GetWeakPtr(), std::move(query),
++                     std::move(job_settings), std::move(print_settings),
++                     std::move(callback)));
++
+ #if BUILDFLAG(IS_WIN)
+   // TODO(crbug.com/1424368):  Remove this if the printable areas can be made
+   // fully available from `PrintBackend::GetPrinterSemanticCapsAndDefaults()`
+@@ -736,15 +793,13 @@ void PrintViewManagerBase::UpdatePrintSettings(
+   }
+ #endif
+ 
+-  CompleteUpdatePrintSettings(std::move(job_settings),
+-                              std::move(print_settings), std::move(callback));
+ }
+ #endif  // BUILDFLAG(ENABLE_PRINT_PREVIEW)
+ 
  void PrintViewManagerBase::IsPrintingEnabled(
      IsPrintingEnabledCallback callback) {
    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
@@ -291,7 +352,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
  }
  
  void PrintViewManagerBase::ScriptedPrint(mojom::ScriptedPrintParamsPtr params,
-@@ -760,14 +801,14 @@ void PrintViewManagerBase::ScriptedPrint(mojom::ScriptedPrintParamsPtr params,
+@@ -760,14 +815,14 @@ void PrintViewManagerBase::ScriptedPrint(mojom::ScriptedPrintParamsPtr params,
      // didn't happen for some reason.
      bad_message::ReceivedBadMessage(
          render_process_host, bad_message::PVMB_SCRIPTED_PRINT_FENCED_FRAME);
@@ -308,7 +369,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
      return;
    }
  #endif
-@@ -802,6 +843,7 @@ void PrintViewManagerBase::PrintingFailed(int32_t cookie,
+@@ -802,6 +857,7 @@ void PrintViewManagerBase::PrintingFailed(int32_t cookie,
  
    PrintManager::PrintingFailed(cookie, reason);
  
@@ -316,7 +377,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
    // `PrintingFailed()` can occur because asynchronous compositing results
    // don't complete until after a print job has already failed and been
    // destroyed.  In such cases the error notification to the user will
-@@ -811,7 +853,7 @@ void PrintViewManagerBase::PrintingFailed(int32_t cookie,
+@@ -811,7 +867,7 @@ void PrintViewManagerBase::PrintingFailed(int32_t cookie,
        print_job_->document()->cookie() == cookie) {
      ShowPrintErrorDialogForGenericError();
    }
@@ -325,7 +386,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
    ReleasePrinterQuery();
  }
  
-@@ -823,15 +865,24 @@ void PrintViewManagerBase::RemoveTestObserver(TestObserver& observer) {
+@@ -823,15 +879,24 @@ void PrintViewManagerBase::RemoveTestObserver(TestObserver& observer) {
    test_observers_.RemoveObserver(&observer);
  }
  
@@ -350,7 +411,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
  }
  
  void PrintViewManagerBase::RenderFrameDeleted(
-@@ -883,7 +934,12 @@ void PrintViewManagerBase::OnJobDone() {
+@@ -883,7 +948,12 @@ void PrintViewManagerBase::OnJobDone() {
    // Printing is done, we don't need it anymore.
    // print_job_->is_job_pending() may still be true, depending on the order
    // of object registration.
@@ -364,7 +425,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
    ReleasePrintJob();
  }
  
-@@ -892,9 +948,10 @@ void PrintViewManagerBase::OnCanceling() {
+@@ -892,9 +962,10 @@ void PrintViewManagerBase::OnCanceling() {
  }
  
  void PrintViewManagerBase::OnFailed() {
@@ -376,7 +437,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
    TerminatePrintJob(true);
  }
  
-@@ -904,7 +961,7 @@ bool PrintViewManagerBase::RenderAllMissingPagesNow() {
+@@ -904,7 +975,7 @@ bool PrintViewManagerBase::RenderAllMissingPagesNow() {
  
    // Is the document already complete?
    if (print_job_->document() && print_job_->document()->IsComplete()) {
@@ -385,7 +446,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
      return true;
    }
  
-@@ -952,7 +1009,10 @@ bool PrintViewManagerBase::CreateNewPrintJob(
+@@ -952,7 +1023,10 @@ bool PrintViewManagerBase::CreateNewPrintJob(
  
    // Disconnect the current `print_job_`.
    auto weak_this = weak_ptr_factory_.GetWeakPtr();
@@ -397,7 +458,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
    if (!weak_this)
      return false;
  
-@@ -973,7 +1033,7 @@ bool PrintViewManagerBase::CreateNewPrintJob(
+@@ -973,7 +1047,7 @@ bool PrintViewManagerBase::CreateNewPrintJob(
  #endif
    print_job_->AddObserver(*this);
  
@@ -406,7 +467,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
    return true;
  }
  
-@@ -1041,6 +1101,11 @@ void PrintViewManagerBase::ReleasePrintJob() {
+@@ -1041,6 +1115,11 @@ void PrintViewManagerBase::ReleasePrintJob() {
    }
  #endif
  
@@ -418,7 +479,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
    if (!print_job_)
      return;
  
-@@ -1048,7 +1113,7 @@ void PrintViewManagerBase::ReleasePrintJob() {
+@@ -1048,7 +1127,7 @@ void PrintViewManagerBase::ReleasePrintJob() {
      // printing_rfh_ should only ever point to a RenderFrameHost with a live
      // RenderFrame.
      DCHECK(rfh->IsRenderFrameLive());
@@ -427,7 +488,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
    }
  
    print_job_->RemoveObserver(*this);
-@@ -1090,7 +1155,7 @@ bool PrintViewManagerBase::RunInnerMessageLoop() {
+@@ -1090,7 +1169,7 @@ bool PrintViewManagerBase::RunInnerMessageLoop() {
  }
  
  bool PrintViewManagerBase::OpportunisticallyCreatePrintJob(int cookie) {
@@ -436,7 +497,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
      return true;
  
    if (!cookie) {
-@@ -1199,7 +1264,7 @@ void PrintViewManagerBase::ReleasePrinterQuery() {
+@@ -1199,7 +1278,7 @@ void PrintViewManagerBase::ReleasePrinterQuery() {
  }
  
  void PrintViewManagerBase::CompletePrintNow(content::RenderFrameHost* rfh) {
@@ -445,7 +506,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
  
    for (auto& observer : GetTestObservers()) {
      observer.OnPrintNow(rfh);
-@@ -1249,7 +1314,7 @@ void PrintViewManagerBase::CompleteScriptedPrintAfterContentAnalysis(
+@@ -1249,7 +1328,7 @@ void PrintViewManagerBase::CompleteScriptedPrintAfterContentAnalysis(
    set_analyzing_content(/*analyzing*/ false);
    if (!allowed || !printing_rfh_ || IsCrashed() ||
        !printing_rfh_->IsRenderFrameLive()) {
@@ -455,7 +516,7 @@ index 2bb42383d753ac39953adf5dccf1cbc02f100b88..65f2ad490414f1631cb65ead5dafcffd
    }
    CompleteScriptedPrint(printing_rfh_, std::move(params), std::move(callback));
 diff --git a/chrome/browser/printing/print_view_manager_base.h b/chrome/browser/printing/print_view_manager_base.h
-index 8af22e511701a595b77bea31da096caedc2e47ce..d1e3bc5ea012de1f1155546ef66c5e3e1c6b11de 100644
+index 8af22e511701a595b77bea31da096caedc2e47ce..3136fac6935c998de10e36474b85521dba18012a 100644
 --- a/chrome/browser/printing/print_view_manager_base.h
 +++ b/chrome/browser/printing/print_view_manager_base.h
 @@ -47,6 +47,8 @@ namespace printing {
@@ -505,7 +566,15 @@ index 8af22e511701a595b77bea31da096caedc2e47ce..d1e3bc5ea012de1f1155546ef66c5e3e
   protected:
    explicit PrintViewManagerBase(content::WebContents* web_contents);
  
-@@ -293,7 +308,8 @@ class PrintViewManagerBase : public PrintManager, public PrintJob::Observer {
+@@ -264,6 +279,7 @@ class PrintViewManagerBase : public PrintManager, public PrintJob::Observer {
+                                 bool success);
+ #endif
+   void CompleteUpdatePrintSettings(
++      std::unique_ptr<PrinterQuery> printer_query,
+       base::Value::Dict job_settings,
+       std::unique_ptr<PrintSettings> print_settings,
+       UpdatePrintSettingsCallback callback);
+@@ -293,7 +309,8 @@ class PrintViewManagerBase : public PrintManager, public PrintJob::Observer {
    // Runs `callback` with `params` to reply to ScriptedPrint().
    void ScriptedPrintReply(ScriptedPrintCallback callback,
                            int process_id,
@@ -515,7 +584,7 @@ index 8af22e511701a595b77bea31da096caedc2e47ce..d1e3bc5ea012de1f1155546ef66c5e3e
  
    // Requests the RenderView to render all the missing pages for the print job.
    // No-op if no print job is pending. Returns true if at least one page has
-@@ -363,8 +379,11 @@ class PrintViewManagerBase : public PrintManager, public PrintJob::Observer {
+@@ -363,8 +380,11 @@ class PrintViewManagerBase : public PrintManager, public PrintJob::Observer {
    // The current RFH that is printing with a system printing dialog.
    raw_ptr<content::RenderFrameHost> printing_rfh_ = nullptr;
  


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/35996.

Fixes an issue where silent printing has no effect and settings are not applied.

Refs CL:3893234

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue with `webContents.print({ silent: true })` not working correctly.