### PR TITLE
fix: asar integration for require('node:child_process')

### DIFF
--- a/lib/asar/fs-wrapper.ts
+++ b/lib/asar/fs-wrapper.ts
@@ -838,7 +838,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     const originalModuleLoad = Module._load;
     Module._load = (request: string, ...args: any[]) => {
       const loadResult = originalModuleLoad(request, ...args);
-      if (request === 'child_process') {
+      if (request === 'child_process' || request === 'node:child_process') {
         if (!asarReady.has(loadResult)) {
           asarReady.add(loadResult);
           // Just to make it obvious what we are dealing with here


### PR DESCRIPTION
#### Description of Change
Follow-up to #38567

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: Fixed asar integration for `node:child_process` imports.