### PR TITLE
fix: `window.open` causing occasional Node.js crashes

### DIFF
--- a/patches/chromium/fix_harden_blink_scriptstate_maybefrom.patch
+++ b/patches/chromium/fix_harden_blink_scriptstate_maybefrom.patch
@@ -40,13 +40,14 @@ accessing uninitialized lower indexes can return garbage values that cannot be n
 Refer to v8::EmbedderDataSlot::store_aligned_pointer for context.
 
 diff --git a/gin/public/gin_embedders.h b/gin/public/gin_embedders.h
-index 8d7c5631fd8f1499c67384286f0e3c4037673b32..6a7491bc27334f6d1b1175eaa472c888e2b35b5e 100644
+index 8d7c5631fd8f1499c67384286f0e3c4037673b32..99b2e2f63be8a46c5546dd53bc9b05e8c54e857c 100644
 --- a/gin/public/gin_embedders.h
 +++ b/gin/public/gin_embedders.h
-@@ -18,6 +18,7 @@ namespace gin {
+@@ -18,6 +18,8 @@ namespace gin {
  enum GinEmbedder : uint16_t {
    kEmbedderNativeGin,
    kEmbedderBlink,
++  kEmbedderElectron,
 +  kEmbedderBlinkTag,
    kEmbedderPDFium,
    kEmbedderFuchsia,

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -144,10 +144,8 @@ void ElectronRendererClient::WillReleaseScriptContext(
   microtask_queue->set_microtasks_policy(v8::MicrotasksPolicy::kExplicit);
 
   node::FreeEnvironment(env);
-  if (node_bindings_->uv_env() == nullptr) {
-    node::FreeIsolateData(node_bindings_->isolate_data(context));
-    node_bindings_->clear_isolate_data(context);
-  }
+  node::FreeIsolateData(node_bindings_->isolate_data(context));
+  node_bindings_->clear_isolate_data(context);
 
   microtask_queue->set_microtasks_policy(old_policy);
 

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -6,6 +6,7 @@
 
 #include "base/command_line.h"
 #include "base/containers/contains.h"
+#include "base/debug/stack_trace.h"
 #include "content/public/renderer/render_frame.h"
 #include "electron/buildflags/buildflags.h"
 #include "net/http/http_request_headers.h"
@@ -144,8 +145,8 @@ void ElectronRendererClient::WillReleaseScriptContext(
 
   node::FreeEnvironment(env);
   if (node_bindings_->uv_env() == nullptr) {
-    node::FreeIsolateData(node_bindings_->isolate_data());
-    node_bindings_->set_isolate_data(nullptr);
+    node::FreeIsolateData(node_bindings_->isolate_data(context));
+    node_bindings_->clear_isolate_data(context);
   }
 
   microtask_queue->set_microtasks_policy(old_policy);

--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -41,25 +41,7 @@ WebWorkerObserver::WebWorkerObserver()
       electron_bindings_(
           std::make_unique<ElectronBindings>(node_bindings_->uv_loop())) {}
 
-WebWorkerObserver::~WebWorkerObserver() {
-  // Destroying the node environment will also run the uv loop,
-  // Node.js expects `kExplicit` microtasks policy and will run microtasks
-  // checkpoints after every call into JavaScript. Since we use a different
-  // policy in the renderer - switch to `kExplicit`
-  auto* env = node_bindings_->uv_env();
-  v8::MicrotaskQueue* microtask_queue = env->context()->GetMicrotaskQueue();
-  auto old_policy = microtask_queue->microtasks_policy();
-  DCHECK_EQ(microtask_queue->GetMicrotasksScopeDepth(), 0);
-  microtask_queue->set_microtasks_policy(v8::MicrotasksPolicy::kExplicit);
-
-  node::FreeEnvironment(env);
-  if (node_bindings_->uv_env() == nullptr) {
-    node::FreeIsolateData(node_bindings_->isolate_data(env->context()));
-    node_bindings_->clear_isolate_data(env->context());
-  }
-
-  microtask_queue->set_microtasks_policy(old_policy);
-}
+WebWorkerObserver::~WebWorkerObserver() = default;
 
 void WebWorkerObserver::WorkerScriptReadyForEvaluation(
     v8::Local<v8::Context> worker_context) {
@@ -99,6 +81,21 @@ void WebWorkerObserver::ContextWillDestroy(v8::Local<v8::Context> context) {
   node::Environment* env = node::Environment::GetCurrent(context);
   if (env)
     gin_helper::EmitEvent(env->isolate(), env->process_object(), "exit");
+
+  // Destroying the node environment will also run the uv loop,
+  // Node.js expects `kExplicit` microtasks policy and will run microtasks
+  // checkpoints after every call into JavaScript. Since we use a different
+  // policy in the renderer - switch to `kExplicit`
+  v8::MicrotaskQueue* microtask_queue = context->GetMicrotaskQueue();
+  auto old_policy = microtask_queue->microtasks_policy();
+  DCHECK_EQ(microtask_queue->GetMicrotasksScopeDepth(), 0);
+  microtask_queue->set_microtasks_policy(v8::MicrotasksPolicy::kExplicit);
+
+  node::FreeEnvironment(env);
+  node::FreeIsolateData(node_bindings_->isolate_data(context));
+  node_bindings_->clear_isolate_data(context);
+
+  microtask_queue->set_microtasks_policy(old_policy);
 
   if (lazy_tls->Get())
     lazy_tls->Set(nullptr);

--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -97,6 +97,9 @@ void WebWorkerObserver::ContextWillDestroy(v8::Local<v8::Context> context) {
 
   microtask_queue->set_microtasks_policy(old_policy);
 
+  // ElectronBindings is tracking node environments.
+  electron_bindings_->EnvironmentDestroyed(env);
+
   if (lazy_tls->Get())
     lazy_tls->Set(nullptr);
 }

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -1114,6 +1114,28 @@ describe('chromium features', () => {
       expect(frameName).to.equal('__proto__');
     });
 
+    it('works when used in conjunction with the vm module', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true,
+          contextIsolation: false
+        }
+      });
+
+      await w.loadFile(path.resolve(__dirname, 'fixtures', 'blank.html'));
+
+      const { contextObject } = await w.webContents.executeJavaScript(`(async () => {
+        const vm = require('node:vm');
+        const contextObject = { count: 1, type: 'gecko' };
+        window.open('');
+        vm.runInNewContext('count += 1; type = "chameleon";', contextObject);
+        return { contextObject };
+      })()`);
+
+      expect(contextObject).to.deep.equal({ count: 2, type: 'chameleon' });
+    });
+
     // FIXME(nornagon): I'm not sure this ... ever was correct?
     xit('inherit options of parent window', async () => {
       const w = new BrowserWindow({ show: false, width: 123, height: 456 });


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/37404.
Closes https://github.com/electron/electron/issues/36858.

Refs https://github.com/electron/electron/pull/35999

Fixes an issue where `window.open` can interfere with various aspects of Node.js functionality.

Node.js stores `IsolateData` internally on the `Environment` as a member, whereas Blink stores it using [`V8PerIsolateData`](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/bindings/v8_per_isolate_data.h). This creates a situation where, in the renderer process, a previous `IsolateData` could be used for a new `v8::Context`, which then created a schism in the intended connection between the two. This would, for example, be a problem when using the vm module, because [`ContextifyScript::InstanceOf`](https://github.com/nodejs/node/blob/7f9e60aa1ae9f7da7227c333c1b25809d7ea3c4d/src/node_contextify.cc#L933-L937) would try to check this condition from the `IsolateData` which was mismatched. We fix this by adding a new embedder index and associating it with the context, so that we ensure the `IsolateData` Node.js is using is correctly associated with the current `V8::Context`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `window.open` can interfere with various aspects of Node.js functionality.
