### PR TITLE
fix: `preferCSSPageSize` error type

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -317,7 +317,7 @@ WebContents.prototype.printToPDF = async function (options) {
 
   if (options.preferCSSPageSize !== undefined) {
     if (typeof options.preferCSSPageSize !== 'boolean') {
-      return Promise.reject(new Error('footerTemplate must be a String'));
+      return Promise.reject(new Error('preferCSSPageSize must be a Boolean'));
     }
     printSettings.preferCSSPageSize = options.preferCSSPageSize;
   }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/38751.

As in title.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `webContents.printToPDF`  `preferCSSPageSize` type error.