### PR TITLE
build: move chrome_lib_arc to chromium_src/BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -540,7 +540,6 @@ source_set("electron_lib") {
 
   if (is_mac) {
     deps += [
-      ":chrome_lib_arc",
       ":electron_lib_arc",
       "//components/remote_cocoa/app_shim",
       "//components/remote_cocoa/browser",
@@ -770,32 +769,6 @@ source_set("electron_lib") {
 }
 
 if (is_mac) {
-  source_set("chrome_lib_arc") {
-    include_dirs = [ "." ]
-    sources = [
-      "//chrome/browser/extensions/global_shortcut_listener_mac.h",
-      "//chrome/browser/extensions/global_shortcut_listener_mac.mm",
-      "//chrome/browser/icon_loader_mac.mm",
-      "//chrome/browser/media/webrtc/system_media_capture_permissions_mac.h",
-      "//chrome/browser/media/webrtc/system_media_capture_permissions_mac.mm",
-      "//chrome/browser/media/webrtc/system_media_capture_permissions_stats_mac.h",
-      "//chrome/browser/media/webrtc/system_media_capture_permissions_stats_mac.mm",
-      "//chrome/browser/media/webrtc/window_icon_util_mac.mm",
-      "//chrome/browser/platform_util_mac.mm",
-      "//chrome/browser/process_singleton_mac.mm",
-    ]
-
-    deps = [
-      "//base",
-      "//skia",
-      "//third_party/electron_node:node_lib",
-      "//third_party/webrtc_overrides:webrtc_component",
-      "//v8",
-    ]
-
-    configs += [ "//build/config/compiler:enable_arc" ]
-  }
-
   source_set("electron_lib_arc") {
     include_dirs = [ "." ]
     sources = [

--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -218,6 +218,10 @@ static_library("chrome") {
     public_deps += [ "//chrome/services/util_win:lib" ]
   }
 
+  if (is_mac) {
+    public_deps += [ ":chrome_lib_arc" ]
+  }
+
   if (enable_widevine) {
     sources += [
       "//chrome/renderer/media/chrome_key_systems.cc",
@@ -328,6 +332,34 @@ static_library("chrome") {
     } else {
       sources += [ "//chrome/browser/hang_monitor/hang_crash_dump.cc" ]
     }
+  }
+}
+
+if (is_mac) {
+  source_set("chrome_lib_arc") {
+    include_dirs = [ "." ]
+    sources = [
+      "//chrome/browser/extensions/global_shortcut_listener_mac.h",
+      "//chrome/browser/extensions/global_shortcut_listener_mac.mm",
+      "//chrome/browser/icon_loader_mac.mm",
+      "//chrome/browser/media/webrtc/system_media_capture_permissions_mac.h",
+      "//chrome/browser/media/webrtc/system_media_capture_permissions_mac.mm",
+      "//chrome/browser/media/webrtc/system_media_capture_permissions_stats_mac.h",
+      "//chrome/browser/media/webrtc/system_media_capture_permissions_stats_mac.mm",
+      "//chrome/browser/media/webrtc/window_icon_util_mac.mm",
+      "//chrome/browser/platform_util_mac.mm",
+      "//chrome/browser/process_singleton_mac.mm",
+    ]
+
+    deps = [
+      "//base",
+      "//skia",
+      "//third_party/electron_node:node_lib",
+      "//third_party/webrtc_overrides:webrtc_component",
+      "//v8",
+    ]
+
+    configs += [ "//build/config/compiler:enable_arc" ]
   }
 }
 


### PR DESCRIPTION
#### Description of Change

Follow up to https://github.com/electron/electron/pull/38465, this PR moves the chromium src files that need ARC support from Electron's top-level BUILD.gn into the chromium_src/BUILD.gn, for better separation of concerns.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
