### PR TITLE
chore: cherry-pick 3 changes from Release-2-M114

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -132,3 +132,4 @@ cherry-pick-94af9d13a14b.patch
 cherry-pick-ea1cd76358e0.patch
 m114_merge_fix_a_crash_caused_by_calling_trace_event.patch
 mojoipcz_copy_incoming_messages_early.patch
+base_do_not_use_va_args_twice_in_asprintf.patch

--- a/patches/chromium/base_do_not_use_va_args_twice_in_asprintf.patch
+++ b/patches/chromium/base_do_not_use_va_args_twice_in_asprintf.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Benoit Lize <lizeb@chromium.org>
 Date: Fri, 9 Jun 2023 17:59:08 +0000
-Subject: [base] Do not use va_args twice in asprintf()
+Subject: Do not use va_args twice in asprintf()
 
 (cherry picked from commit 3cff0cb19a6d01cbdd9932f43dabaaeda9c0330a)
 

--- a/patches/chromium/base_do_not_use_va_args_twice_in_asprintf.patch
+++ b/patches/chromium/base_do_not_use_va_args_twice_in_asprintf.patch
@@ -1,0 +1,96 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benoit Lize <lizeb@chromium.org>
+Date: Fri, 9 Jun 2023 17:59:08 +0000
+Subject: [base] Do not use va_args twice in asprintf()
+
+(cherry picked from commit 3cff0cb19a6d01cbdd9932f43dabaaeda9c0330a)
+
+Bug: 1450536
+Change-Id: Ib34d96935278869a63897f9a1c66afc98865d90f
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4579347
+Reviewed-by: Egor Pasko <pasko@chromium.org>
+Commit-Queue: Benoit Lize <lizeb@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1151796}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4604070
+Reviewed-by: Michael Thiessen <mthiesse@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5735@{#1224}
+Cr-Branched-From: 2f562e4ddbaf79a3f3cb338b4d1bd4398d49eb67-refs/heads/main@{#1135570}
+
+diff --git a/base/allocator/partition_allocator/shim/allocator_shim_override_linker_wrapped_symbols.h b/base/allocator/partition_allocator/shim/allocator_shim_override_linker_wrapped_symbols.h
+index 621873126602463a09efca1bf1548ed10910d323..de2af6d7d54e254b9e7b8264b53d30a338fb13e8 100644
+--- a/base/allocator/partition_allocator/shim/allocator_shim_override_linker_wrapped_symbols.h
++++ b/base/allocator/partition_allocator/shim/allocator_shim_override_linker_wrapped_symbols.h
+@@ -123,13 +123,21 @@ SHIM_ALWAYS_EXPORT char* __wrap_getcwd(char* buffer, size_t size) {
+ SHIM_ALWAYS_EXPORT int __wrap_vasprintf(char** strp,
+                                         const char* fmt,
+                                         va_list va_args) {
++  // There are cases where we need to use the list of arguments twice, namely
++  // when the original buffer is too small. It is not allowed to walk the list
++  // twice, so make a copy for the second invocation of vsnprintf().
++  va_list va_args_copy;
++  va_copy(va_args_copy, va_args);
++
+   constexpr int kInitialSize = 128;
+   *strp = static_cast<char*>(
+       malloc(kInitialSize));  // Our malloc() doesn't return nullptr.
+ 
+   int actual_size = vsnprintf(*strp, kInitialSize, fmt, va_args);
+-  if (actual_size < 0)
++  if (actual_size < 0) {
++    va_end(va_args_copy);
+     return actual_size;
++  }
+   *strp =
+       static_cast<char*>(realloc(*strp, static_cast<size_t>(actual_size + 1)));
+ 
+@@ -139,9 +147,14 @@ SHIM_ALWAYS_EXPORT int __wrap_vasprintf(char** strp,
+   //
+   // This is very lightly used in Chromium in practice, see crbug.com/116558 for
+   // details.
+-  if (actual_size >= kInitialSize)
+-    return vsnprintf(*strp, static_cast<size_t>(actual_size + 1), fmt, va_args);
+-
++  if (actual_size >= kInitialSize) {
++    int ret = vsnprintf(*strp, static_cast<size_t>(actual_size + 1), fmt,
++                        va_args_copy);
++    va_end(va_args_copy);
++    return ret;
++  }
++
++  va_end(va_args_copy);
+   return actual_size;
+ }
+ 
+diff --git a/base/allocator/partition_allocator/shim/allocator_shim_unittest.cc b/base/allocator/partition_allocator/shim/allocator_shim_unittest.cc
+index dcf26fa5fc6d51de6276aa6fdcc4691f781c4bfd..fd46a15799864acaf58ef57315606bf515b48b15 100644
+--- a/base/allocator/partition_allocator/shim/allocator_shim_unittest.cc
++++ b/base/allocator/partition_allocator/shim/allocator_shim_unittest.cc
+@@ -734,6 +734,28 @@ TEST_F(AllocatorShimTest, InterceptVasprintf) {
+   // Should not crash.
+ }
+ 
++TEST_F(AllocatorShimTest, InterceptLongVasprintf) {
++  char* str = nullptr;
++  const char* lorem_ipsum =
++      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. "
++      "Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, "
++      "ultricies sed, dolor. Cras elementum ultrices diam. Maecenas ligula "
++      "massa, varius a, semper congue, euismod non, mi. Proin porttitor, orci "
++      "nec nonummy molestie, enim est eleifend mi, non fermentum diam nisl sit "
++      "amet erat. Duis semper. Duis arcu massa, scelerisque vitae, consequat "
++      "in, pretium a, enim. Pellentesque congue. Ut in risus volutpat libero "
++      "pharetra tempor. Cras vestibulum bibendum augue. Praesent egestas leo "
++      "in pede. Praesent blandit odio eu enim. Pellentesque sed dui ut augue "
++      "blandit sodales. Vestibulum ante ipsum primis in faucibus orci luctus "
++      "et ultrices posuere cubilia Curae; Aliquam nibh. Mauris ac mauris sed "
++      "pede pellentesque fermentum. Maecenas adipiscing ante non diam sodales "
++      "hendrerit.";
++  int err = asprintf(&str, "%s", lorem_ipsum);
++  EXPECT_EQ(err, static_cast<int>(strlen(lorem_ipsum)));
++  EXPECT_TRUE(str);
++  free(str);
++}
++
+ #endif  // BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)
+ 
+ #endif  // BUILDFLAG(IS_ANDROID)

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -13,3 +13,4 @@ cherry-pick-3b0607d14060.patch
 cherry-pick-9c6dfc733fce.patch
 cherry-pick-73af1a19a901.patch
 cherry-pick-0035a4a8dac2.patch
+cherry-pick-2e76270cf65e.patch

--- a/patches/v8/cherry-pick-2e76270cf65e.patch
+++ b/patches/v8/cherry-pick-2e76270cf65e.patch
@@ -1,7 +1,7 @@
-From 2e76270cf65e13348f8705fc95d6a7580c6174b2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shu-yu Guo <syg@chromium.org>
-Date: Mon, 05 Jun 2023 16:05:52 -0700
-Subject: [PATCH] Merged: Check for encoding when appending in string builder
+Date: Mon, 5 Jun 2023 16:05:52 -0700
+Subject: Merged: Check for encoding when appending in string builder
 
 Fixed: chromium:1450114
 (cherry picked from commit a7e2bef27b72f187a7dcdf95714df686f56d9e0b)
@@ -12,13 +12,12 @@ Reviewed-by: Igor Sheludko <ishell@chromium.org>
 Cr-Commit-Position: refs/branch-heads/11.4@{#41}
 Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
 Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
----
 
 diff --git a/src/strings/string-builder.cc b/src/strings/string-builder.cc
-index f6871d9..30540b6 100644
+index f6871d9e6aa33942ec595e3076f689c2008989d7..30540b6a32a006fa4417d612a1243f18f59d3c2e 100644
 --- a/src/strings/string-builder.cc
 +++ b/src/strings/string-builder.cc
-@@ -317,12 +317,21 @@
+@@ -317,12 +317,21 @@ bool IncrementalStringBuilder::CanAppendByCopy(Handle<String> string) {
  void IncrementalStringBuilder::AppendStringByCopy(Handle<String> string) {
    DCHECK(CanAppendByCopy(string));
  

--- a/patches/v8/cherry-pick-2e76270cf65e.patch
+++ b/patches/v8/cherry-pick-2e76270cf65e.patch
@@ -1,0 +1,46 @@
+From 2e76270cf65e13348f8705fc95d6a7580c6174b2 Mon Sep 17 00:00:00 2001
+From: Shu-yu Guo <syg@chromium.org>
+Date: Mon, 05 Jun 2023 16:05:52 -0700
+Subject: [PATCH] Merged: Check for encoding when appending in string builder
+
+Fixed: chromium:1450114
+(cherry picked from commit a7e2bef27b72f187a7dcdf95714df686f56d9e0b)
+
+Change-Id: I5838383b6b12d137e84c8a36863ef88000e85c76
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4604652
+Reviewed-by: Igor Sheludko <ishell@chromium.org>
+Cr-Commit-Position: refs/branch-heads/11.4@{#41}
+Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
+Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
+---
+
+diff --git a/src/strings/string-builder.cc b/src/strings/string-builder.cc
+index f6871d9..30540b6 100644
+--- a/src/strings/string-builder.cc
++++ b/src/strings/string-builder.cc
+@@ -317,12 +317,21 @@
+ void IncrementalStringBuilder::AppendStringByCopy(Handle<String> string) {
+   DCHECK(CanAppendByCopy(string));
+ 
+-  Handle<SeqOneByteString> part =
+-      Handle<SeqOneByteString>::cast(current_part());
+   {
+     DisallowGarbageCollection no_gc;
+-    String::WriteToFlat(*string, part->GetChars(no_gc) + current_index_, 0,
+-                        string->length());
++    if (encoding_ == String::ONE_BYTE_ENCODING) {
++      String::WriteToFlat(
++          *string,
++          Handle<SeqOneByteString>::cast(current_part())->GetChars(no_gc) +
++              current_index_,
++          0, string->length());
++    } else {
++      String::WriteToFlat(
++          *string,
++          Handle<SeqTwoByteString>::cast(current_part())->GetChars(no_gc) +
++              current_index_,
++          0, string->length());
++    }
+   }
+   current_index_ += string->length();
+   DCHECK(current_index_ <= part_length_);

--- a/patches/webrtc/.patches
+++ b/patches/webrtc/.patches
@@ -1,1 +1,2 @@
 fix_fallback_to_x11_capturer_on_wayland.patch
+m114_move_transceiver_iteration_loop_over_to_the_signaling_thread.patch

--- a/patches/webrtc/m114_move_transceiver_iteration_loop_over_to_the_signaling_thread.patch
+++ b/patches/webrtc/m114_move_transceiver_iteration_loop_over_to_the_signaling_thread.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tommi <tommi@webrtc.org>
 Date: Thu, 1 Jun 2023 16:08:52 +0200
-Subject: [M114] Move transceiver iteration loop over to the signaling thread.
+Subject: Move transceiver iteration loop over to the signaling thread.
 
 This is required for ReportTransportStats since iterating over the
 transceiver list from the network thread is not safe.

--- a/patches/webrtc/m114_move_transceiver_iteration_loop_over_to_the_signaling_thread.patch
+++ b/patches/webrtc/m114_move_transceiver_iteration_loop_over_to_the_signaling_thread.patch
@@ -1,0 +1,126 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tommi <tommi@webrtc.org>
+Date: Thu, 1 Jun 2023 16:08:52 +0200
+Subject: [M114] Move transceiver iteration loop over to the signaling thread.
+
+This is required for ReportTransportStats since iterating over the
+transceiver list from the network thread is not safe.
+
+(cherry picked from commit dba22d31909298161318e00d43a80cdb0abc940f)
+
+No-Try: true
+Bug: chromium:1446274, webrtc:12692
+Change-Id: I7c514df9f029112c4b1da85826af91217850fb26
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/307340
+Reviewed-by: Harald Alvestrand <hta@webrtc.org>
+Commit-Queue: Tomas Gunnarsson <tommi@webrtc.org>
+Cr-Original-Commit-Position: refs/heads/main@{#40197}
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/308001
+Reviewed-by: Mirko Bonadei <mbonadei@webrtc.org>
+Cr-Commit-Position: refs/branch-heads/5735@{#3}
+Cr-Branched-From: df7df199abd619e75b9f1d9a7e12fc3f3f748775-refs/heads/main@{#39949}
+
+diff --git a/pc/peer_connection.cc b/pc/peer_connection.cc
+index 88b99bb515325b9c616b7d06495c7a9c924133b2..5701504e7a6ebd96bd5cafdbe37de4a510f6a436 100644
+--- a/pc/peer_connection.cc
++++ b/pc/peer_connection.cc
+@@ -728,9 +728,6 @@ JsepTransportController* PeerConnection::InitializeTransportController_n(
+   transport_controller_->SubscribeIceConnectionState(
+       [this](cricket::IceConnectionState s) {
+         RTC_DCHECK_RUN_ON(network_thread());
+-        if (s == cricket::kIceConnectionConnected) {
+-          ReportTransportStats();
+-        }
+         signaling_thread()->PostTask(
+             SafeTask(signaling_thread_safety_.flag(), [this, s]() {
+               RTC_DCHECK_RUN_ON(signaling_thread());
+@@ -2415,6 +2412,20 @@ void PeerConnection::OnTransportControllerConnectionState(
+     case cricket::kIceConnectionConnected:
+       RTC_LOG(LS_INFO) << "Changing to ICE connected state because "
+                           "all transports are writable.";
++      {
++        std::vector<RtpTransceiverProxyRefPtr> transceivers;
++        if (ConfiguredForMedia()) {
++          transceivers = rtp_manager()->transceivers()->List();
++        }
++
++        network_thread()->PostTask(
++            SafeTask(network_thread_safety_,
++                     [this, transceivers = std::move(transceivers)] {
++                       RTC_DCHECK_RUN_ON(network_thread());
++                       ReportTransportStats(std::move(transceivers));
++                     }));
++      }
++
+       SetIceConnectionState(PeerConnectionInterface::kIceConnectionConnected);
+       NoteUsageEvent(UsageEvent::ICE_STATE_CONNECTED);
+       break;
+@@ -2762,20 +2773,18 @@ void PeerConnection::OnTransportControllerGatheringState(
+ }
+ 
+ // Runs on network_thread().
+-void PeerConnection::ReportTransportStats() {
++void PeerConnection::ReportTransportStats(
++    std::vector<RtpTransceiverProxyRefPtr> transceivers) {
+   TRACE_EVENT0("webrtc", "PeerConnection::ReportTransportStats");
+   rtc::Thread::ScopedDisallowBlockingCalls no_blocking_calls;
+   std::map<std::string, std::set<cricket::MediaType>>
+       media_types_by_transport_name;
+-  if (ConfiguredForMedia()) {
+-    for (const auto& transceiver :
+-         rtp_manager()->transceivers()->UnsafeList()) {
+-      if (transceiver->internal()->channel()) {
+-        std::string transport_name(
+-            transceiver->internal()->channel()->transport_name());
+-        media_types_by_transport_name[transport_name].insert(
+-            transceiver->media_type());
+-      }
++  for (const auto& transceiver : transceivers) {
++    if (transceiver->internal()->channel()) {
++      std::string transport_name(
++          transceiver->internal()->channel()->transport_name());
++      media_types_by_transport_name[transport_name].insert(
++          transceiver->media_type());
+     }
+   }
+ 
+diff --git a/pc/peer_connection.h b/pc/peer_connection.h
+index 850142b9584a9f2e5b29b337b2bcd433d4b0224d..69b2ca7925eceb636aa4d22b9397cb25a7637051 100644
+--- a/pc/peer_connection.h
++++ b/pc/peer_connection.h
+@@ -569,7 +569,8 @@ class PeerConnection : public PeerConnectionInternal,
+ 
+   // Invoked when TransportController connection completion is signaled.
+   // Reports stats for all transports in use.
+-  void ReportTransportStats() RTC_RUN_ON(network_thread());
++  void ReportTransportStats(std::vector<RtpTransceiverProxyRefPtr> transceivers)
++      RTC_RUN_ON(network_thread());
+ 
+   // Gather the usage of IPv4/IPv6 as best connection.
+   static void ReportBestConnectionState(const cricket::TransportStats& stats);
+diff --git a/pc/peer_connection_integrationtest.cc b/pc/peer_connection_integrationtest.cc
+index 1d1bec3e93e0e87bb0b1da13c13ed11712ad0480..c373e2f643b33dea4e619e38dfc8d1007f2cedad 100644
+--- a/pc/peer_connection_integrationtest.cc
++++ b/pc/peer_connection_integrationtest.cc
+@@ -1831,6 +1831,10 @@ TEST_P(PeerConnectionIntegrationTest,
+   EXPECT_EQ_WAIT(webrtc::PeerConnectionInterface::kIceConnectionConnected,
+                  callee()->ice_connection_state(), kDefaultTimeout);
+ 
++  // Part of reporting the stats will occur on the network thread, so flush it
++  // before checking NumEvents.
++  SendTask(network_thread(), [] {});
++
+   EXPECT_METRIC_EQ(1, webrtc::metrics::NumEvents(
+                           "WebRTC.PeerConnection.CandidatePairType_UDP",
+                           webrtc::kIceCandidatePairHostNameHostName));
+@@ -1959,6 +1963,10 @@ TEST_P(PeerConnectionIntegrationIceStatesTest, MAYBE_VerifyBestConnection) {
+   EXPECT_EQ_WAIT(webrtc::PeerConnectionInterface::kIceConnectionConnected,
+                  callee()->ice_connection_state(), kDefaultTimeout);
+ 
++  // Part of reporting the stats will occur on the network thread, so flush it
++  // before checking NumEvents.
++  SendTask(network_thread(), [] {});
++
+   // TODO(bugs.webrtc.org/9456): Fix it.
+   const int num_best_ipv4 = webrtc::metrics::NumEvents(
+       "WebRTC.PeerConnection.IPMetrics", webrtc::kBestConnections_IPv4);


### PR DESCRIPTION
<details>
<summary>electron/security#364 - 2e76270cf65e from v8</summary>
Merged: Check for encoding when appending in string builder

Fixed: chromium:1450114
(cherry picked from commit a7e2bef27b72f187a7dcdf95714df686f56d9e0b)

Change-Id: I5838383b6b12d137e84c8a36863ef88000e85c76
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4604652
Reviewed-by: Igor Sheludko <ishell@chromium.org>
Cr-Commit-Position: refs/branch-heads/11.4@{#41}
Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
</details>

Notes:
* Security: backported fix for CVE-2023-3215.
* Security: backported fix for CVE-2023-3216.
* Security: backported fix for 1450536.