### PR TITLE
chore: cherry-pick 5 changes from Release-2-M114, Release-1-M110 and Release-0-M110

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -163,3 +163,4 @@ cherry-pick-ea1cd76358e0.patch
 cherry-pick-48785f698b1c.patch
 m108-lts_return_after_readycommitnavigation_call_in_commiterrorpage.patch
 m114_merge_fix_a_crash_caused_by_calling_trace_event.patch
+base_do_not_use_va_args_twice_in_asprintf.patch

--- a/patches/chromium/base_do_not_use_va_args_twice_in_asprintf.patch
+++ b/patches/chromium/base_do_not_use_va_args_twice_in_asprintf.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Benoit Lize <lizeb@chromium.org>
 Date: Fri, 9 Jun 2023 17:59:08 +0000
-Subject: [base] Do not use va_args twice in asprintf()
+Subject: Do not use va_args twice in asprintf()
 
 (cherry picked from commit 3cff0cb19a6d01cbdd9932f43dabaaeda9c0330a)
 

--- a/patches/chromium/base_do_not_use_va_args_twice_in_asprintf.patch
+++ b/patches/chromium/base_do_not_use_va_args_twice_in_asprintf.patch
@@ -1,0 +1,96 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benoit Lize <lizeb@chromium.org>
+Date: Fri, 9 Jun 2023 17:59:08 +0000
+Subject: [base] Do not use va_args twice in asprintf()
+
+(cherry picked from commit 3cff0cb19a6d01cbdd9932f43dabaaeda9c0330a)
+
+Bug: 1450536
+Change-Id: Ib34d96935278869a63897f9a1c66afc98865d90f
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4579347
+Reviewed-by: Egor Pasko <pasko@chromium.org>
+Commit-Queue: Benoit Lize <lizeb@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1151796}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4604070
+Reviewed-by: Michael Thiessen <mthiesse@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5735@{#1224}
+Cr-Branched-From: 2f562e4ddbaf79a3f3cb338b4d1bd4398d49eb67-refs/heads/main@{#1135570}
+
+diff --git a/base/allocator/partition_allocator/shim/allocator_shim_override_linker_wrapped_symbols.h b/base/allocator/partition_allocator/shim/allocator_shim_override_linker_wrapped_symbols.h
+index 621873126602463a09efca1bf1548ed10910d323..de2af6d7d54e254b9e7b8264b53d30a338fb13e8 100644
+--- a/base/allocator/partition_allocator/shim/allocator_shim_override_linker_wrapped_symbols.h
++++ b/base/allocator/partition_allocator/shim/allocator_shim_override_linker_wrapped_symbols.h
+@@ -123,13 +123,21 @@ SHIM_ALWAYS_EXPORT char* __wrap_getcwd(char* buffer, size_t size) {
+ SHIM_ALWAYS_EXPORT int __wrap_vasprintf(char** strp,
+                                         const char* fmt,
+                                         va_list va_args) {
++  // There are cases where we need to use the list of arguments twice, namely
++  // when the original buffer is too small. It is not allowed to walk the list
++  // twice, so make a copy for the second invocation of vsnprintf().
++  va_list va_args_copy;
++  va_copy(va_args_copy, va_args);
++
+   constexpr int kInitialSize = 128;
+   *strp = static_cast<char*>(
+       malloc(kInitialSize));  // Our malloc() doesn't return nullptr.
+ 
+   int actual_size = vsnprintf(*strp, kInitialSize, fmt, va_args);
+-  if (actual_size < 0)
++  if (actual_size < 0) {
++    va_end(va_args_copy);
+     return actual_size;
++  }
+   *strp =
+       static_cast<char*>(realloc(*strp, static_cast<size_t>(actual_size + 1)));
+ 
+@@ -139,9 +147,14 @@ SHIM_ALWAYS_EXPORT int __wrap_vasprintf(char** strp,
+   //
+   // This is very lightly used in Chromium in practice, see crbug.com/116558 for
+   // details.
+-  if (actual_size >= kInitialSize)
+-    return vsnprintf(*strp, static_cast<size_t>(actual_size + 1), fmt, va_args);
+-
++  if (actual_size >= kInitialSize) {
++    int ret = vsnprintf(*strp, static_cast<size_t>(actual_size + 1), fmt,
++                        va_args_copy);
++    va_end(va_args_copy);
++    return ret;
++  }
++
++  va_end(va_args_copy);
+   return actual_size;
+ }
+ 
+diff --git a/base/allocator/partition_allocator/shim/allocator_shim_unittest.cc b/base/allocator/partition_allocator/shim/allocator_shim_unittest.cc
+index 6caf9d6ffe0db92602ac1e448f45da422e077c2c..57d36f722e1aa747cda3a808104cc108147552c1 100644
+--- a/base/allocator/partition_allocator/shim/allocator_shim_unittest.cc
++++ b/base/allocator/partition_allocator/shim/allocator_shim_unittest.cc
+@@ -706,6 +706,28 @@ TEST_F(AllocatorShimTest, InterceptVasprintf) {
+   // Should not crash.
+ }
+ 
++TEST_F(AllocatorShimTest, InterceptLongVasprintf) {
++  char* str = nullptr;
++  const char* lorem_ipsum =
++      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. "
++      "Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, "
++      "ultricies sed, dolor. Cras elementum ultrices diam. Maecenas ligula "
++      "massa, varius a, semper congue, euismod non, mi. Proin porttitor, orci "
++      "nec nonummy molestie, enim est eleifend mi, non fermentum diam nisl sit "
++      "amet erat. Duis semper. Duis arcu massa, scelerisque vitae, consequat "
++      "in, pretium a, enim. Pellentesque congue. Ut in risus volutpat libero "
++      "pharetra tempor. Cras vestibulum bibendum augue. Praesent egestas leo "
++      "in pede. Praesent blandit odio eu enim. Pellentesque sed dui ut augue "
++      "blandit sodales. Vestibulum ante ipsum primis in faucibus orci luctus "
++      "et ultrices posuere cubilia Curae; Aliquam nibh. Mauris ac mauris sed "
++      "pede pellentesque fermentum. Maecenas adipiscing ante non diam sodales "
++      "hendrerit.";
++  int err = asprintf(&str, "%s", lorem_ipsum);
++  EXPECT_EQ(err, static_cast<int>(strlen(lorem_ipsum)));
++  EXPECT_TRUE(str);
++  free(str);
++}
++
+ #endif  // BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)
+ 
+ #endif  // BUILDFLAG(IS_ANDROID)

--- a/patches/config.json
+++ b/patches/config.json
@@ -27,5 +27,7 @@
 
   "src/electron/patches/skia": "src/third_party/skia",
 
-  "src/electron/patches/dawn": "src/third_party/dawn"
+  "src/electron/patches/dawn": "src/third_party/dawn",
+
+  "src/electron/patches/webrtc": "src/third_party/webrtc"
 }

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -21,3 +21,4 @@ merged_ic_fix_store_handler_selection_for_arguments_objects.patch
 cherry-pick-73af1a19a901.patch
 merged_regexp_fix_clobbered_register_in_global_unicode_special.patch
 m108-lts_api_fix_v8_object_setaccessorproperty.patch
+cherry-pick-2e76270cf65e.patch

--- a/patches/v8/cherry-pick-2e76270cf65e.patch
+++ b/patches/v8/cherry-pick-2e76270cf65e.patch
@@ -1,7 +1,7 @@
-From 2e76270cf65e13348f8705fc95d6a7580c6174b2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shu-yu Guo <syg@chromium.org>
-Date: Mon, 05 Jun 2023 16:05:52 -0700
-Subject: [PATCH] Merged: Check for encoding when appending in string builder
+Date: Mon, 5 Jun 2023 16:05:52 -0700
+Subject: Merged: Check for encoding when appending in string builder
 
 Fixed: chromium:1450114
 (cherry picked from commit a7e2bef27b72f187a7dcdf95714df686f56d9e0b)
@@ -12,13 +12,12 @@ Reviewed-by: Igor Sheludko <ishell@chromium.org>
 Cr-Commit-Position: refs/branch-heads/11.4@{#41}
 Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
 Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
----
 
 diff --git a/src/strings/string-builder.cc b/src/strings/string-builder.cc
-index f6871d9..30540b6 100644
+index 9d1e3a95746b47b99c15f18ec593549d79e10b8c..c7e98e55763aba2d64f4070e25759489f850f589 100644
 --- a/src/strings/string-builder.cc
 +++ b/src/strings/string-builder.cc
-@@ -317,12 +317,21 @@
+@@ -306,12 +306,21 @@ bool IncrementalStringBuilder::CanAppendByCopy(Handle<String> string) {
  void IncrementalStringBuilder::AppendStringByCopy(Handle<String> string) {
    DCHECK(CanAppendByCopy(string));
  

--- a/patches/v8/cherry-pick-2e76270cf65e.patch
+++ b/patches/v8/cherry-pick-2e76270cf65e.patch
@@ -1,0 +1,46 @@
+From 2e76270cf65e13348f8705fc95d6a7580c6174b2 Mon Sep 17 00:00:00 2001
+From: Shu-yu Guo <syg@chromium.org>
+Date: Mon, 05 Jun 2023 16:05:52 -0700
+Subject: [PATCH] Merged: Check for encoding when appending in string builder
+
+Fixed: chromium:1450114
+(cherry picked from commit a7e2bef27b72f187a7dcdf95714df686f56d9e0b)
+
+Change-Id: I5838383b6b12d137e84c8a36863ef88000e85c76
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4604652
+Reviewed-by: Igor Sheludko <ishell@chromium.org>
+Cr-Commit-Position: refs/branch-heads/11.4@{#41}
+Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
+Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
+---
+
+diff --git a/src/strings/string-builder.cc b/src/strings/string-builder.cc
+index f6871d9..30540b6 100644
+--- a/src/strings/string-builder.cc
++++ b/src/strings/string-builder.cc
+@@ -317,12 +317,21 @@
+ void IncrementalStringBuilder::AppendStringByCopy(Handle<String> string) {
+   DCHECK(CanAppendByCopy(string));
+ 
+-  Handle<SeqOneByteString> part =
+-      Handle<SeqOneByteString>::cast(current_part());
+   {
+     DisallowGarbageCollection no_gc;
+-    String::WriteToFlat(*string, part->GetChars(no_gc) + current_index_, 0,
+-                        string->length());
++    if (encoding_ == String::ONE_BYTE_ENCODING) {
++      String::WriteToFlat(
++          *string,
++          Handle<SeqOneByteString>::cast(current_part())->GetChars(no_gc) +
++              current_index_,
++          0, string->length());
++    } else {
++      String::WriteToFlat(
++          *string,
++          Handle<SeqTwoByteString>::cast(current_part())->GetChars(no_gc) +
++              current_index_,
++          0, string->length());
++    }
+   }
+   current_index_ += string->length();
+   DCHECK(current_index_ <= part_length_);

--- a/patches/webrtc/.patches
+++ b/patches/webrtc/.patches
@@ -1,2 +1,3 @@
 cherry-pick-e0efbd45ea74.patch
 cherry-pick-218b56e51638.patch
+m114_move_transceiver_iteration_loop_over_to_the_signaling_thread.patch

--- a/patches/webrtc/cherry-pick-218b56e51638.patch
+++ b/patches/webrtc/cherry-pick-218b56e51638.patch
@@ -1,7 +1,7 @@
-From 218b56e516386cd57c7513197528c3124bcd7ef3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Alexander Cooper <alcooper@chromium.org>
-Date: Wed, 08 Feb 2023 14:16:01 -0800
-Subject: [PATCH] Fix Destruction inside WGC Callback
+Date: Wed, 8 Feb 2023 14:16:01 -0800
+Subject: Fix Destruction inside WGC Callback
 
 If we are notified of the destruction of the window before a
 CaptureFrame call can fail, then we may end up attempting to destroy the
@@ -29,13 +29,12 @@ Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/293246
 Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
 Cr-Commit-Position: refs/branch-heads/5481@{#5}
 Cr-Branched-From: 2e1a9a4ae0234d4b1ea7a6fd4188afa1fb20379d-refs/heads/main@{#38901}
----
 
 diff --git a/modules/desktop_capture/win/wgc_capture_session.cc b/modules/desktop_capture/win/wgc_capture_session.cc
-index e165291..ea5565c 100644
+index 831257b4d476d674303f835f6002b22bf809a772..20045b6d1d1250fc9b634e51fe3875b484d6c397 100644
 --- a/modules/desktop_capture/win/wgc_capture_session.cc
 +++ b/modules/desktop_capture/win/wgc_capture_session.cc
-@@ -397,17 +397,14 @@
+@@ -388,17 +388,14 @@ HRESULT WgcCaptureSession::OnItemClosed(WGC::IGraphicsCaptureItem* sender,
  
    RTC_LOG(LS_INFO) << "Capture target has been closed.";
    item_closed_ = true;

--- a/patches/webrtc/cherry-pick-e0efbd45ea74.patch
+++ b/patches/webrtc/cherry-pick-e0efbd45ea74.patch
@@ -1,7 +1,11 @@
-From e0efbd45ea7421fb944c7343254ac5dc22bee541 Mon Sep 17 00:00:00 2001
-From: Henrik Boström <hbos@webrtc.org>
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Henrik=20Bostr=C3=B6m?= <hbos@webrtc.org>
 Date: Fri, 20 Jan 2023 10:48:31 +0100
-Subject: [PATCH] [Merge-110] [Stats] Handle the case of missing certificates.
+Subject: =?UTF-8?q?=C2=A0[Stats]=20Handle=20the=20case=20of=20missing=20ce?=
+ =?UTF-8?q?rtificates.?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 Certificates being missing is a sign of a bug (e.g. webrtc:14844, to be
 fixed separately) which is why we have a DCHECK. But this DCHECK does
@@ -22,13 +26,12 @@ Cr-Original-Commit-Position: refs/heads/main@{#39159}
 Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/291380
 Cr-Commit-Position: refs/branch-heads/5481@{#2}
 Cr-Branched-From: 2e1a9a4ae0234d4b1ea7a6fd4188afa1fb20379d-refs/heads/main@{#38901}
----
 
 diff --git a/pc/rtc_stats_collector.cc b/pc/rtc_stats_collector.cc
-index d500a7b..1d88566 100644
+index ff7e334169da41c400d94387527734362d5dbeaa..c16e9ac7eaade4785f16afa46b2051f338095ca3 100644
 --- a/pc/rtc_stats_collector.cc
 +++ b/pc/rtc_stats_collector.cc
-@@ -2192,16 +2192,17 @@
+@@ -2197,16 +2197,17 @@ void RTCStatsCollector::ProduceTransportStats_n(
      // exist.
      const auto& certificate_stats_it =
          transport_cert_stats.find(transport_name);

--- a/patches/webrtc/m114_move_transceiver_iteration_loop_over_to_the_signaling_thread.patch
+++ b/patches/webrtc/m114_move_transceiver_iteration_loop_over_to_the_signaling_thread.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tommi <tommi@webrtc.org>
 Date: Thu, 1 Jun 2023 16:08:52 +0200
-Subject: [M114] Move transceiver iteration loop over to the signaling thread.
+Subject: Move transceiver iteration loop over to the signaling thread.
 
 This is required for ReportTransportStats since iterating over the
 transceiver list from the network thread is not safe.

--- a/patches/webrtc/m114_move_transceiver_iteration_loop_over_to_the_signaling_thread.patch
+++ b/patches/webrtc/m114_move_transceiver_iteration_loop_over_to_the_signaling_thread.patch
@@ -1,0 +1,126 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tommi <tommi@webrtc.org>
+Date: Thu, 1 Jun 2023 16:08:52 +0200
+Subject: [M114] Move transceiver iteration loop over to the signaling thread.
+
+This is required for ReportTransportStats since iterating over the
+transceiver list from the network thread is not safe.
+
+(cherry picked from commit dba22d31909298161318e00d43a80cdb0abc940f)
+
+No-Try: true
+Bug: chromium:1446274, webrtc:12692
+Change-Id: I7c514df9f029112c4b1da85826af91217850fb26
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/307340
+Reviewed-by: Harald Alvestrand <hta@webrtc.org>
+Commit-Queue: Tomas Gunnarsson <tommi@webrtc.org>
+Cr-Original-Commit-Position: refs/heads/main@{#40197}
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/308001
+Reviewed-by: Mirko Bonadei <mbonadei@webrtc.org>
+Cr-Commit-Position: refs/branch-heads/5735@{#3}
+Cr-Branched-From: df7df199abd619e75b9f1d9a7e12fc3f3f748775-refs/heads/main@{#39949}
+
+diff --git a/pc/peer_connection.cc b/pc/peer_connection.cc
+index 4615ce5a2c413dba798c3f9f8f7d4c1ae78bf9af..62179cd44c57dc6d808579353b398412db5e1ed6 100644
+--- a/pc/peer_connection.cc
++++ b/pc/peer_connection.cc
+@@ -716,9 +716,6 @@ JsepTransportController* PeerConnection::InitializeTransportController_n(
+   transport_controller_->SubscribeIceConnectionState(
+       [this](cricket::IceConnectionState s) {
+         RTC_DCHECK_RUN_ON(network_thread());
+-        if (s == cricket::kIceConnectionConnected) {
+-          ReportTransportStats();
+-        }
+         signaling_thread()->PostTask(
+             SafeTask(signaling_thread_safety_.flag(), [this, s]() {
+               RTC_DCHECK_RUN_ON(signaling_thread());
+@@ -2372,6 +2369,20 @@ void PeerConnection::OnTransportControllerConnectionState(
+     case cricket::kIceConnectionConnected:
+       RTC_LOG(LS_INFO) << "Changing to ICE connected state because "
+                           "all transports are writable.";
++      {
++        std::vector<RtpTransceiverProxyRefPtr> transceivers;
++        if (ConfiguredForMedia()) {
++          transceivers = rtp_manager()->transceivers()->List();
++        }
++
++        network_thread()->PostTask(
++            SafeTask(network_thread_safety_,
++                     [this, transceivers = std::move(transceivers)] {
++                       RTC_DCHECK_RUN_ON(network_thread());
++                       ReportTransportStats(std::move(transceivers));
++                     }));
++      }
++
+       SetIceConnectionState(PeerConnectionInterface::kIceConnectionConnected);
+       NoteUsageEvent(UsageEvent::ICE_STATE_CONNECTED);
+       break;
+@@ -2701,20 +2712,18 @@ void PeerConnection::OnTransportControllerGatheringState(
+ }
+ 
+ // Runs on network_thread().
+-void PeerConnection::ReportTransportStats() {
++void PeerConnection::ReportTransportStats(
++    std::vector<RtpTransceiverProxyRefPtr> transceivers) {
+   TRACE_EVENT0("webrtc", "PeerConnection::ReportTransportStats");
+   rtc::Thread::ScopedDisallowBlockingCalls no_blocking_calls;
+   std::map<std::string, std::set<cricket::MediaType>>
+       media_types_by_transport_name;
+-  if (ConfiguredForMedia()) {
+-    for (const auto& transceiver :
+-         rtp_manager()->transceivers()->UnsafeList()) {
+-      if (transceiver->internal()->channel()) {
+-        std::string transport_name(
+-            transceiver->internal()->channel()->transport_name());
+-        media_types_by_transport_name[transport_name].insert(
+-            transceiver->media_type());
+-      }
++  for (const auto& transceiver : transceivers) {
++    if (transceiver->internal()->channel()) {
++      std::string transport_name(
++          transceiver->internal()->channel()->transport_name());
++      media_types_by_transport_name[transport_name].insert(
++          transceiver->media_type());
+     }
+   }
+ 
+diff --git a/pc/peer_connection.h b/pc/peer_connection.h
+index 36a9d2ac743a81e2c4ac8b4abd73d2fd40c3dd40..ea221e697322bd8b8c161edada7a448a68fa7f68 100644
+--- a/pc/peer_connection.h
++++ b/pc/peer_connection.h
+@@ -563,7 +563,8 @@ class PeerConnection : public PeerConnectionInternal,
+ 
+   // Invoked when TransportController connection completion is signaled.
+   // Reports stats for all transports in use.
+-  void ReportTransportStats() RTC_RUN_ON(network_thread());
++  void ReportTransportStats(std::vector<RtpTransceiverProxyRefPtr> transceivers)
++      RTC_RUN_ON(network_thread());
+ 
+   // Gather the usage of IPv4/IPv6 as best connection.
+   static void ReportBestConnectionState(const cricket::TransportStats& stats);
+diff --git a/pc/peer_connection_integrationtest.cc b/pc/peer_connection_integrationtest.cc
+index 19cc6ce3cfc8b8b38d45f5df9c28fe6dd01572f5..da8a53ef5d91c9c14dc6f42a10d176c7f6089ada 100644
+--- a/pc/peer_connection_integrationtest.cc
++++ b/pc/peer_connection_integrationtest.cc
+@@ -1831,6 +1831,10 @@ TEST_P(PeerConnectionIntegrationTest,
+   EXPECT_EQ_WAIT(webrtc::PeerConnectionInterface::kIceConnectionConnected,
+                  callee()->ice_connection_state(), kDefaultTimeout);
+ 
++  // Part of reporting the stats will occur on the network thread, so flush it
++  // before checking NumEvents.
++  SendTask(network_thread(), [] {});
++
+   EXPECT_METRIC_EQ(1, webrtc::metrics::NumEvents(
+                           "WebRTC.PeerConnection.CandidatePairType_UDP",
+                           webrtc::kIceCandidatePairHostNameHostName));
+@@ -1959,6 +1963,10 @@ TEST_P(PeerConnectionIntegrationIceStatesTest, MAYBE_VerifyBestConnection) {
+   EXPECT_EQ_WAIT(webrtc::PeerConnectionInterface::kIceConnectionConnected,
+                  callee()->ice_connection_state(), kDefaultTimeout);
+ 
++  // Part of reporting the stats will occur on the network thread, so flush it
++  // before checking NumEvents.
++  SendTask(network_thread(), [] {});
++
+   // TODO(bugs.webrtc.org/9456): Fix it.
+   const int num_best_ipv4 = webrtc::metrics::NumEvents(
+       "WebRTC.PeerConnection.IPMetrics", webrtc::kBestConnections_IPv4);


### PR DESCRIPTION
<details>
<summary>electron/security#364 - 2e76270cf65e from v8</summary>
Merged: Check for encoding when appending in string builder

Fixed: chromium:1450114
(cherry picked from commit a7e2bef27b72f187a7dcdf95714df686f56d9e0b)

Change-Id: I5838383b6b12d137e84c8a36863ef88000e85c76
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4604652
Reviewed-by: Igor Sheludko <ishell@chromium.org>
Cr-Commit-Position: refs/branch-heads/11.4@{#41}
Cr-Branched-From: 8a8a1e7086dacc426965d3875914efa66663c431-refs/heads/11.4.183@{#1}
Cr-Branched-From: 5483d8e816e0bbce865cbbc3fa0ab357e6330bab-refs/heads/main@{#87241}
</details>

Notes:
* Security: backported fix for CVE-2023-3215.
* Security: backported fix for CVE-2023-3216.
* Security: backported fix for 1450536.
* Security: backported fix for CVE-2023-0698.
* Security: backported fix for CVE-2023-0932.