### PR TITLE
refactor: constexpr lookup tables

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "base/command_line.h"
+#include "base/containers/fixed_flat_map.h"
 #include "base/containers/span.h"
 #include "base/environment.h"
 #include "base/files/file_path.h"
@@ -473,51 +474,38 @@ IconLoader::IconSize GetIconSizeByString(const std::string& size) {
 }
 
 // Return the path constant from string.
-int GetPathConstant(const std::string& name) {
-  if (name == "appData")
-    return DIR_APP_DATA;
-  else if (name == "sessionData")
-    return DIR_SESSION_DATA;
-  else if (name == "userData")
-    return chrome::DIR_USER_DATA;
-  else if (name == "cache")
+constexpr int GetPathConstant(base::StringPiece name) {
+  // clang-format off
+  constexpr auto Lookup = base::MakeFixedFlatMapSorted<base::StringPiece, int>({
+      {"appData", DIR_APP_DATA},
 #if BUILDFLAG(IS_POSIX)
-    return base::DIR_CACHE;
+      {"cache", base::DIR_CACHE},
 #else
-    return base::DIR_ROAMING_APP_DATA;
+      {"cache", base::DIR_ROAMING_APP_DATA},
 #endif
-  else if (name == "userCache")
-    return DIR_USER_CACHE;
-  else if (name == "logs")
-    return DIR_APP_LOGS;
-  else if (name == "crashDumps")
-    return DIR_CRASH_DUMPS;
-  else if (name == "home")
-    return base::DIR_HOME;
-  else if (name == "temp")
-    return base::DIR_TEMP;
-  else if (name == "userDesktop" || name == "desktop")
-    return base::DIR_USER_DESKTOP;
-  else if (name == "exe")
-    return base::FILE_EXE;
-  else if (name == "module")
-    return base::FILE_MODULE;
-  else if (name == "documents")
-    return chrome::DIR_USER_DOCUMENTS;
-  else if (name == "downloads")
-    return chrome::DIR_DEFAULT_DOWNLOADS;
-  else if (name == "music")
-    return chrome::DIR_USER_MUSIC;
-  else if (name == "pictures")
-    return chrome::DIR_USER_PICTURES;
-  else if (name == "videos")
-    return chrome::DIR_USER_VIDEOS;
+      {"crashDumps", DIR_CRASH_DUMPS},
+      {"desktop", base::DIR_USER_DESKTOP},
+      {"documents", chrome::DIR_USER_DOCUMENTS},
+      {"downloads", chrome::DIR_DEFAULT_DOWNLOADS},
+      {"exe", base::FILE_EXE},
+      {"home", base::DIR_HOME},
+      {"logs", DIR_APP_LOGS},
+      {"module", base::FILE_MODULE},
+      {"music", chrome::DIR_USER_MUSIC},
+      {"pictures", chrome::DIR_USER_PICTURES},
 #if BUILDFLAG(IS_WIN)
-  else if (name == "recent")
-    return electron::DIR_RECENT;
+      {"recent", electron::DIR_RECENT},
 #endif
-  else
-    return -1;
+      {"sessionData", DIR_SESSION_DATA},
+      {"temp", base::DIR_TEMP},
+      {"userCache", DIR_USER_CACHE},
+      {"userData", chrome::DIR_USER_DATA},
+      {"userDesktop", base::DIR_USER_DESKTOP},
+      {"videos", chrome::DIR_USER_VIDEOS},
+  });
+  // clang-format on
+  const auto* iter = Lookup.find(name);
+  return iter != Lookup.end() ? iter->second : -1;
 }
 
 bool NotificationCallbackWrapper(

--- a/shell/browser/api/electron_api_system_preferences_win.cc
+++ b/shell/browser/api/electron_api_system_preferences_win.cc
@@ -9,6 +9,7 @@
 
 #include "shell/browser/api/electron_api_system_preferences.h"
 
+#include "base/containers/fixed_flat_map.h"
 #include "base/win/core_winrt_util.h"
 #include "base/win/windows_types.h"
 #include "base/win/wrapped_window_proc.h"
@@ -97,73 +98,45 @@ std::string SystemPreferences::GetAccentColor() {
 
 std::string SystemPreferences::GetColor(gin_helper::ErrorThrower thrower,
                                         const std::string& color) {
-  int id;
-  if (color == "3d-dark-shadow") {
-    id = COLOR_3DDKSHADOW;
-  } else if (color == "3d-face") {
-    id = COLOR_3DFACE;
-  } else if (color == "3d-highlight") {
-    id = COLOR_3DHIGHLIGHT;
-  } else if (color == "3d-light") {
-    id = COLOR_3DLIGHT;
-  } else if (color == "3d-shadow") {
-    id = COLOR_3DSHADOW;
-  } else if (color == "active-border") {
-    id = COLOR_ACTIVEBORDER;
-  } else if (color == "active-caption") {
-    id = COLOR_ACTIVECAPTION;
-  } else if (color == "active-caption-gradient") {
-    id = COLOR_GRADIENTACTIVECAPTION;
-  } else if (color == "app-workspace") {
-    id = COLOR_APPWORKSPACE;
-  } else if (color == "button-text") {
-    id = COLOR_BTNTEXT;
-  } else if (color == "caption-text") {
-    id = COLOR_CAPTIONTEXT;
-  } else if (color == "desktop") {
-    id = COLOR_DESKTOP;
-  } else if (color == "disabled-text") {
-    id = COLOR_GRAYTEXT;
-  } else if (color == "highlight") {
-    id = COLOR_HIGHLIGHT;
-  } else if (color == "highlight-text") {
-    id = COLOR_HIGHLIGHTTEXT;
-  } else if (color == "hotlight") {
-    id = COLOR_HOTLIGHT;
-  } else if (color == "inactive-border") {
-    id = COLOR_INACTIVEBORDER;
-  } else if (color == "inactive-caption") {
-    id = COLOR_INACTIVECAPTION;
-  } else if (color == "inactive-caption-gradient") {
-    id = COLOR_GRADIENTINACTIVECAPTION;
-  } else if (color == "inactive-caption-text") {
-    id = COLOR_INACTIVECAPTIONTEXT;
-  } else if (color == "info-background") {
-    id = COLOR_INFOBK;
-  } else if (color == "info-text") {
-    id = COLOR_INFOTEXT;
-  } else if (color == "menu") {
-    id = COLOR_MENU;
-  } else if (color == "menu-highlight") {
-    id = COLOR_MENUHILIGHT;
-  } else if (color == "menubar") {
-    id = COLOR_MENUBAR;
-  } else if (color == "menu-text") {
-    id = COLOR_MENUTEXT;
-  } else if (color == "scrollbar") {
-    id = COLOR_SCROLLBAR;
-  } else if (color == "window") {
-    id = COLOR_WINDOW;
-  } else if (color == "window-frame") {
-    id = COLOR_WINDOWFRAME;
-  } else if (color == "window-text") {
-    id = COLOR_WINDOWTEXT;
-  } else {
-    thrower.ThrowError("Unknown color: " + color);
-    return "";
-  }
+  static constexpr auto Lookup =
+      base::MakeFixedFlatMapSorted<base::StringPiece, int>({
+          {"3d-dark-shadow", COLOR_3DDKSHADOW},
+          {"3d-face", COLOR_3DFACE},
+          {"3d-highlight", COLOR_3DHIGHLIGHT},
+          {"3d-light", COLOR_3DLIGHT},
+          {"3d-shadow", COLOR_3DSHADOW},
+          {"active-border", COLOR_ACTIVEBORDER},
+          {"active-caption", COLOR_ACTIVECAPTION},
+          {"active-caption-gradient", COLOR_GRADIENTACTIVECAPTION},
+          {"app-workspace", COLOR_APPWORKSPACE},
+          {"button-text", COLOR_BTNTEXT},
+          {"caption-text", COLOR_CAPTIONTEXT},
+          {"desktop", COLOR_DESKTOP},
+          {"disabled-text", COLOR_GRAYTEXT},
+          {"highlight", COLOR_HIGHLIGHT},
+          {"highlight-text", COLOR_HIGHLIGHTTEXT},
+          {"hotlight", COLOR_HOTLIGHT},
+          {"inactive-border", COLOR_INACTIVEBORDER},
+          {"inactive-caption", COLOR_INACTIVECAPTION},
+          {"inactive-caption-gradient", COLOR_GRADIENTINACTIVECAPTION},
+          {"inactive-caption-text", COLOR_INACTIVECAPTIONTEXT},
+          {"info-background", COLOR_INFOBK},
+          {"info-text", COLOR_INFOTEXT},
+          {"menu", COLOR_MENU},
+          {"menu-highlight", COLOR_MENUHILIGHT},
+          {"menu-text", COLOR_MENUTEXT},
+          {"menubar", COLOR_MENUBAR},
+          {"scrollbar", COLOR_SCROLLBAR},
+          {"window", COLOR_WINDOW},
+          {"window-frame", COLOR_WINDOWFRAME},
+          {"window-text", COLOR_WINDOWTEXT},
+      });
 
-  return ToRGBHex(color_utils::GetSysSkColor(id));
+  if (const auto* iter = Lookup.find(color); iter != Lookup.end())
+    return ToRGBHex(color_utils::GetSysSkColor(iter->second));
+
+  thrower.ThrowError("Unknown color: " + color);
+  return "";
 }
 
 std::string SystemPreferences::GetMediaAccessStatus(

--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/containers/fixed_flat_map.h"
 #include "base/no_destructor.h"
 #include "gin/handle.h"
 #include "gin/object_template_builder.h"
@@ -553,62 +554,46 @@ gin::Handle<SimpleURLLoaderWrapper> SimpleURLLoaderWrapper::Create(
     request->trusted_params->has_user_activation = has_user_activation;
   }
 
-  std::string mode;
-  if (opts.Get("mode", &mode) && !mode.empty()) {
-    if (mode == "navigate") {
-      request->mode = network::mojom::RequestMode::kNavigate;
-    } else if (mode == "cors") {
-      request->mode = network::mojom::RequestMode::kCors;
-    } else if (mode == "no-cors") {
-      request->mode = network::mojom::RequestMode::kNoCors;
-    } else if (mode == "same-origin") {
-      request->mode = network::mojom::RequestMode::kSameOrigin;
-    }
+  if (std::string mode; opts.Get("mode", &mode)) {
+    using Val = network::mojom::RequestMode;
+    static constexpr auto Lookup =
+        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+            {"cors", Val::kCors},
+            {"navigate", Val::kNavigate},
+            {"no-cors", Val::kNoCors},
+            {"same-origin", Val::kSameOrigin},
+        });
+    if (auto* iter = Lookup.find(mode); iter != Lookup.end())
+      request->mode = iter->second;
   }
 
-  std::string destination;
-  if (opts.Get("destination", &destination) && !destination.empty()) {
-    if (destination == "empty") {
-      request->destination = network::mojom::RequestDestination::kEmpty;
-    } else if (destination == "audio") {
-      request->destination = network::mojom::RequestDestination::kAudio;
-    } else if (destination == "audioworklet") {
-      request->destination = network::mojom::RequestDestination::kAudioWorklet;
-    } else if (destination == "document") {
-      request->destination = network::mojom::RequestDestination::kDocument;
-    } else if (destination == "embed") {
-      request->destination = network::mojom::RequestDestination::kEmbed;
-    } else if (destination == "font") {
-      request->destination = network::mojom::RequestDestination::kFont;
-    } else if (destination == "frame") {
-      request->destination = network::mojom::RequestDestination::kFrame;
-    } else if (destination == "iframe") {
-      request->destination = network::mojom::RequestDestination::kIframe;
-    } else if (destination == "image") {
-      request->destination = network::mojom::RequestDestination::kImage;
-    } else if (destination == "manifest") {
-      request->destination = network::mojom::RequestDestination::kManifest;
-    } else if (destination == "object") {
-      request->destination = network::mojom::RequestDestination::kObject;
-    } else if (destination == "paintworklet") {
-      request->destination = network::mojom::RequestDestination::kPaintWorklet;
-    } else if (destination == "report") {
-      request->destination = network::mojom::RequestDestination::kReport;
-    } else if (destination == "script") {
-      request->destination = network::mojom::RequestDestination::kScript;
-    } else if (destination == "serviceworker") {
-      request->destination = network::mojom::RequestDestination::kServiceWorker;
-    } else if (destination == "style") {
-      request->destination = network::mojom::RequestDestination::kStyle;
-    } else if (destination == "track") {
-      request->destination = network::mojom::RequestDestination::kTrack;
-    } else if (destination == "video") {
-      request->destination = network::mojom::RequestDestination::kVideo;
-    } else if (destination == "worker") {
-      request->destination = network::mojom::RequestDestination::kWorker;
-    } else if (destination == "xslt") {
-      request->destination = network::mojom::RequestDestination::kXslt;
-    }
+  if (std::string destination; opts.Get("destination", &destination)) {
+    using Val = network::mojom::RequestDestination;
+    static constexpr auto Lookup =
+        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+            {"audio", Val::kAudio},
+            {"audioworklet", Val::kAudioWorklet},
+            {"document", Val::kDocument},
+            {"embed", Val::kEmbed},
+            {"empty", Val::kEmpty},
+            {"font", Val::kFont},
+            {"frame", Val::kFrame},
+            {"iframe", Val::kIframe},
+            {"image", Val::kImage},
+            {"manifest", Val::kManifest},
+            {"object", Val::kObject},
+            {"paintworklet", Val::kPaintWorklet},
+            {"report", Val::kReport},
+            {"script", Val::kScript},
+            {"serviceworker", Val::kServiceWorker},
+            {"style", Val::kStyle},
+            {"track", Val::kTrack},
+            {"video", Val::kVideo},
+            {"worker", Val::kWorker},
+            {"xslt", Val::kXslt},
+        });
+    if (auto* iter = Lookup.find(destination); iter != Lookup.end())
+      request->destination = iter->second;
   }
 
   bool credentials_specified =


### PR DESCRIPTION
Manual backport of #38771. See that PR for details.

Manual intervention needed due to `#include` shear; no other changes to the patch.

Notes: none