### PR TITLE
refactor: remove unused BaseWindow::setContentView()

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -309,12 +309,6 @@ void BaseWindow::OnWindowMessage(UINT message, WPARAM w_param, LPARAM l_param) {
 }
 #endif
 
-void BaseWindow::SetContentView(gin::Handle<View> view) {
-  ResetBrowserViews();
-  content_view_.Reset(isolate(), view.ToV8());
-  window_->SetContentView(view->view());
-}
-
 void BaseWindow::CloseImmediately() {
   if (!window_->IsClosed())
     window_->CloseImmediately();
@@ -972,13 +966,6 @@ void BaseWindow::SetGTKDarkThemeEnabled(bool use_dark_theme) {
   window_->SetGTKDarkThemeEnabled(use_dark_theme);
 }
 
-v8::Local<v8::Value> BaseWindow::GetContentView() const {
-  if (content_view_.IsEmpty())
-    return v8::Null(isolate());
-  else
-    return v8::Local<v8::Value>::New(isolate(), content_view_);
-}
-
 v8::Local<v8::Value> BaseWindow::GetParentWindow() const {
   if (parent_window_.IsEmpty())
     return v8::Null(isolate());
@@ -1165,7 +1152,6 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
   prototype->SetClassName(gin::StringToV8(isolate, "BaseWindow"));
   gin_helper::Destroyable::MakeDestroyable(isolate, prototype);
   gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
-      .SetMethod("setContentView", &BaseWindow::SetContentView)
       .SetMethod("close", &BaseWindow::Close)
       .SetMethod("focus", &BaseWindow::Focus)
       .SetMethod("blur", &BaseWindow::Blur)
@@ -1303,7 +1289,6 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setAspectRatio", &BaseWindow::SetAspectRatio)
       .SetMethod("previewFile", &BaseWindow::PreviewFile)
       .SetMethod("closeFilePreview", &BaseWindow::CloseFilePreview)
-      .SetMethod("getContentView", &BaseWindow::GetContentView)
       .SetMethod("getParentWindow", &BaseWindow::GetParentWindow)
       .SetMethod("getChildWindows", &BaseWindow::GetChildWindows)
       .SetMethod("getBrowserView", &BaseWindow::GetBrowserView)

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -87,7 +87,6 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
 #endif
 
   // Public APIs of NativeWindow.
-  void SetContentView(gin::Handle<View> view);
   void Close();
   virtual void CloseImmediately();
   virtual void Focus();
@@ -224,7 +223,6 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void SetGTKDarkThemeEnabled(bool use_dark_theme);
 
   // Public getters of NativeWindow.
-  v8::Local<v8::Value> GetContentView() const;
   v8::Local<v8::Value> GetParentWindow() const;
   std::vector<v8::Local<v8::Object>> GetChildWindows() const;
   v8::Local<v8::Value> GetBrowserView(gin_helper::Arguments* args) const;
@@ -273,7 +271,6 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   MessageCallbackMap messages_callback_map_;
 #endif
 
-  v8::Global<v8::Value> content_view_;
   std::map<int32_t, v8::Global<v8::Value>> browser_views_;
   v8::Global<v8::Value> menu_;
   v8::Global<v8::Value> parent_window_;

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -98,9 +98,6 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
 
   InitWithArgs(args);
 
-  // Install the content view after BaseWindow's JS code is initialized.
-  SetContentView(gin::CreateHandle<View>(isolate, web_contents_view.get()));
-
   // Init window after everything has been setup.
   window()->InitFromOptions(options);
 }

--- a/spec/api-view-spec.ts
+++ b/spec/api-view-spec.ts
@@ -1,15 +1,10 @@
 import { closeWindow } from './lib/window-helpers';
-import { BaseWindow, View } from 'electron/main';
+import { BaseWindow } from 'electron/main';
 
 describe('View', () => {
   let w: BaseWindow;
   afterEach(async () => {
     await closeWindow(w as any);
     w = null as unknown as BaseWindow;
-  });
-
-  it('can be used as content view', () => {
-    w = new BaseWindow({ show: false });
-    w.setContentView(new View());
   });
 });

--- a/spec/api-web-contents-view-spec.ts
+++ b/spec/api-web-contents-view-spec.ts
@@ -10,11 +10,6 @@ describe('WebContentsView', () => {
     w = null as unknown as BaseWindow;
   });
 
-  it('can be used as content view', () => {
-    w = new BaseWindow({ show: false });
-    w.setContentView(new WebContentsView({}));
-  });
-
   function triggerGCByAllocation () {
     const arr = [];
     for (let i = 0; i < 1000000; i++) {

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -155,7 +155,6 @@ declare namespace Electron {
   // Experimental views API
   class BaseWindow {
     constructor(args: {show: boolean})
-    setContentView(view: View): void
     static fromId(id: number): BaseWindow;
     static getAllWindows(): BaseWindow[];
     isFocused(): boolean;


### PR DESCRIPTION
#### Description of Change

I'm unsure about this PR & am pushing it up to get opinion from other devs on it and also to see what CI thinks. I _think_ this code is unused and safe to remove but I'm not sure if there's anything I've missed.

 - `BaseWindow.setContentView()` is implemented in C++ and declared in internal-electron.ts, but its only use seems to be some simple specs confirming that it can be invoked.
 - `BaseWindow.getContentView()` is implemented in C++ and doesn't appear to be called.
 - These two functions touch a C++ field, `BaseWindow::content_view_`, that is not used anywhere else.

Are these functions doing anything that I'm missing and/or are there plans for them? In other words, should they be kept or removed?

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none