### PR TITLE
fix: `webContents.print()` cancellation callback

### DIFF
--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -78,7 +78,7 @@ index b496ff49232f449fd6cea9dc1927b833c049497b..4c12ca65c1f800ddbbb792716f09f63f
                 : PdfRenderSettings::Mode::POSTSCRIPT_LEVEL3;
    }
 diff --git a/chrome/browser/printing/print_view_manager_base.cc b/chrome/browser/printing/print_view_manager_base.cc
-index 6756967e1df3d985eab45aaaefcf5dd2f7025b9a..a7e2b4c0b85c31044726330a752585b0d20ac2e0 100644
+index 6756967e1df3d985eab45aaaefcf5dd2f7025b9a..fbee0055b80b9c53e9d42245aa704b3a35717553 100644
 --- a/chrome/browser/printing/print_view_manager_base.cc
 +++ b/chrome/browser/printing/print_view_manager_base.cc
 @@ -23,7 +23,9 @@

--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -78,7 +78,7 @@ index b496ff49232f449fd6cea9dc1927b833c049497b..4c12ca65c1f800ddbbb792716f09f63f
                 : PdfRenderSettings::Mode::POSTSCRIPT_LEVEL3;
    }
 diff --git a/chrome/browser/printing/print_view_manager_base.cc b/chrome/browser/printing/print_view_manager_base.cc
-index 6756967e1df3d985eab45aaaefcf5dd2f7025b9a..c5743ccb09146aaa3ab2c5c8cb728af1291b4ebc 100644
+index 6756967e1df3d985eab45aaaefcf5dd2f7025b9a..a7e2b4c0b85c31044726330a752585b0d20ac2e0 100644
 --- a/chrome/browser/printing/print_view_manager_base.cc
 +++ b/chrome/browser/printing/print_view_manager_base.cc
 @@ -23,7 +23,9 @@
@@ -133,16 +133,17 @@ index 6756967e1df3d985eab45aaaefcf5dd2f7025b9a..c5743ccb09146aaa3ab2c5c8cb728af1
      std::move(callback).Run(nullptr);
      return;
    }
-@@ -118,7 +135,7 @@ void OnDidScriptedPrint(
+@@ -118,7 +135,8 @@ void OnDidScriptedPrint(
  
    if (printer_query->last_status() != mojom::ResultCode::kSuccess ||
        !printer_query->settings().dpi()) {
 -    std::move(callback).Run(nullptr);
-+    std::move(callback).Run(nullptr, false);
++    bool canceled = printer_query->last_status() == mojom::ResultCode::kCanceled;
++    std::move(callback).Run(nullptr, canceled);
      return;
    }
  
-@@ -128,12 +145,13 @@ void OnDidScriptedPrint(
+@@ -128,12 +146,12 @@ void OnDidScriptedPrint(
                                  params->params.get());
    params->params->document_cookie = printer_query->cookie();
    if (!PrintMsgPrintParamsIsValid(*params->params)) {
@@ -153,8 +154,7 @@ index 6756967e1df3d985eab45aaaefcf5dd2f7025b9a..c5743ccb09146aaa3ab2c5c8cb728af1
  
    params->pages = printer_query->settings().ranges();
 -  std::move(callback).Run(std::move(params));
-+  bool canceled = printer_query->last_status() == mojom::ResultCode::kCanceled;
-+  std::move(callback).Run(std::move(params), canceled);
++  std::move(callback).Run(std::move(params), false);
    queue->QueuePrinterQuery(std::move(printer_query));
  }
  


### PR DESCRIPTION
Backport of #38709.

See that PR for details.

Notes: Fixed an issue where `webContents.print()` stopped triggering its callback when the user cancelled the print dialog.