### PR TITLE
refactor: use constexpr lookup tables in gin helper

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -141,40 +141,25 @@ struct Converter<JumpListItem::Type> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      JumpListItem::Type* out) {
-    std::string item_type;
-    if (!ConvertFromV8(isolate, val, &item_type))
-      return false;
-
-    if (item_type == "task")
-      *out = JumpListItem::Type::kTask;
-    else if (item_type == "separator")
-      *out = JumpListItem::Type::kSeparator;
-    else if (item_type == "file")
-      *out = JumpListItem::Type::kFile;
-    else
-      return false;
-
-    return true;
+    return FromV8WithLookup(isolate, val, Lookup, out);
   }
 
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    JumpListItem::Type val) {
-    std::string item_type;
-    switch (val) {
-      case JumpListItem::Type::kTask:
-        item_type = "task";
-        break;
+    for (const auto& [name, item_val] : Lookup)
+      if (item_val == val)
+        return gin::ConvertToV8(isolate, name);
 
-      case JumpListItem::Type::kSeparator:
-        item_type = "separator";
-        break;
-
-      case JumpListItem::Type::kFile:
-        item_type = "file";
-        break;
-    }
-    return gin::ConvertToV8(isolate, item_type);
+    return gin::ConvertToV8(isolate, "");
   }
+
+ private:
+  static constexpr auto Lookup =
+      base::MakeFixedFlatMapSorted<base::StringPiece, JumpListItem::Type>({
+          {"file", JumpListItem::Type::kFile},
+          {"separator", JumpListItem::Type::kSeparator},
+          {"task", JumpListItem::Type::kTask},
+      });
 };
 
 template <>
@@ -247,46 +232,26 @@ struct Converter<JumpListCategory::Type> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      JumpListCategory::Type* out) {
-    std::string category_type;
-    if (!ConvertFromV8(isolate, val, &category_type))
-      return false;
-
-    if (category_type == "tasks")
-      *out = JumpListCategory::Type::kTasks;
-    else if (category_type == "frequent")
-      *out = JumpListCategory::Type::kFrequent;
-    else if (category_type == "recent")
-      *out = JumpListCategory::Type::kRecent;
-    else if (category_type == "custom")
-      *out = JumpListCategory::Type::kCustom;
-    else
-      return false;
-
-    return true;
+    return FromV8WithLookup(isolate, val, Lookup, out);
   }
 
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    JumpListCategory::Type val) {
-    std::string category_type;
-    switch (val) {
-      case JumpListCategory::Type::kTasks:
-        category_type = "tasks";
-        break;
+    for (const auto& [name, type_val] : Lookup)
+      if (type_val == val)
+        return gin::ConvertToV8(isolate, name);
 
-      case JumpListCategory::Type::kFrequent:
-        category_type = "frequent";
-        break;
-
-      case JumpListCategory::Type::kRecent:
-        category_type = "recent";
-        break;
-
-      case JumpListCategory::Type::kCustom:
-        category_type = "custom";
-        break;
-    }
-    return gin::ConvertToV8(isolate, category_type);
+    return gin::ConvertToV8(isolate, "");
   }
+
+ private:
+  static constexpr auto Lookup =
+      base::MakeFixedFlatMapSorted<base::StringPiece, JumpListCategory::Type>({
+          {"custom", JumpListCategory::Type::kCustom},
+          {"frequent", JumpListCategory::Type::kFrequent},
+          {"recent", JumpListCategory::Type::kRecent},
+          {"tasks", JumpListCategory::Type::kTasks},
+      });
 };
 
 template <>
@@ -440,20 +405,13 @@ struct Converter<net::SecureDnsMode> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      net::SecureDnsMode* out) {
-    std::string s;
-    if (!ConvertFromV8(isolate, val, &s))
-      return false;
-    if (s == "off") {
-      *out = net::SecureDnsMode::kOff;
-      return true;
-    } else if (s == "automatic") {
-      *out = net::SecureDnsMode::kAutomatic;
-      return true;
-    } else if (s == "secure") {
-      *out = net::SecureDnsMode::kSecure;
-      return true;
-    }
-    return false;
+    static constexpr auto Lookup =
+        base::MakeFixedFlatMapSorted<base::StringPiece, net::SecureDnsMode>({
+            {"automatic", net::SecureDnsMode::kAutomatic},
+            {"off", net::SecureDnsMode::kOff},
+            {"secure", net::SecureDnsMode::kSecure},
+        });
+    return FromV8WithLookup(isolate, val, Lookup, out);
   }
 };
 }  // namespace gin

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -689,57 +689,28 @@ v8::Local<v8::Value> Converter<net::IPEndPoint>::ToV8(
 bool Converter<net::DnsQueryType>::FromV8(v8::Isolate* isolate,
                                           v8::Local<v8::Value> val,
                                           net::DnsQueryType* out) {
-  std::string query_type;
-  if (!ConvertFromV8(isolate, val, &query_type))
-    return false;
-
-  if (query_type == "A") {
-    *out = net::DnsQueryType::A;
-    return true;
-  }
-
-  if (query_type == "AAAA") {
-    *out = net::DnsQueryType::AAAA;
-    return true;
-  }
-
-  return false;
+  static constexpr auto Lookup =
+      base::MakeFixedFlatMapSorted<base::StringPiece, net::DnsQueryType>({
+          {"A", net::DnsQueryType::A},
+          {"AAAA", net::DnsQueryType::AAAA},
+      });
+  return FromV8WithLookup(isolate, val, Lookup, out);
 }
 
 // static
 bool Converter<net::HostResolverSource>::FromV8(v8::Isolate* isolate,
                                                 v8::Local<v8::Value> val,
                                                 net::HostResolverSource* out) {
-  std::string query_type;
-  if (!ConvertFromV8(isolate, val, &query_type))
-    return false;
-
-  if (query_type == "any") {
-    *out = net::HostResolverSource::ANY;
-    return true;
-  }
-
-  if (query_type == "system") {
-    *out = net::HostResolverSource::SYSTEM;
-    return true;
-  }
-
-  if (query_type == "dns") {
-    *out = net::HostResolverSource::DNS;
-    return true;
-  }
-
-  if (query_type == "mdns") {
-    *out = net::HostResolverSource::MULTICAST_DNS;
-    return true;
-  }
-
-  if (query_type == "localOnly") {
-    *out = net::HostResolverSource::LOCAL_ONLY;
-    return true;
-  }
-
-  return false;
+  using Val = net::HostResolverSource;
+  static constexpr auto Lookup =
+      base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+          {"any", Val::ANY},
+          {"dns", Val::DNS},
+          {"localOnly", Val::LOCAL_ONLY},
+          {"mdns", Val::MULTICAST_DNS},
+          {"system", Val::SYSTEM},
+      });
+  return FromV8WithLookup(isolate, val, Lookup, out);
 }
 
 // static
@@ -747,26 +718,14 @@ bool Converter<network::mojom::ResolveHostParameters::CacheUsage>::FromV8(
     v8::Isolate* isolate,
     v8::Local<v8::Value> val,
     network::mojom::ResolveHostParameters::CacheUsage* out) {
-  std::string query_type;
-  if (!ConvertFromV8(isolate, val, &query_type))
-    return false;
-
-  if (query_type == "allowed") {
-    *out = network::mojom::ResolveHostParameters::CacheUsage::ALLOWED;
-    return true;
-  }
-
-  if (query_type == "staleAllowed") {
-    *out = network::mojom::ResolveHostParameters::CacheUsage::STALE_ALLOWED;
-    return true;
-  }
-
-  if (query_type == "disallowed") {
-    *out = network::mojom::ResolveHostParameters::CacheUsage::DISALLOWED;
-    return true;
-  }
-
-  return false;
+  using Val = network::mojom::ResolveHostParameters::CacheUsage;
+  static constexpr auto Lookup =
+      base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+          {"allowed", Val::ALLOWED},
+          {"disallowed", Val::DISALLOWED},
+          {"staleAllowed", Val::STALE_ALLOWED},
+      });
+  return FromV8WithLookup(isolate, val, Lookup, out);
 }
 
 // static
@@ -774,21 +733,13 @@ bool Converter<network::mojom::SecureDnsPolicy>::FromV8(
     v8::Isolate* isolate,
     v8::Local<v8::Value> val,
     network::mojom::SecureDnsPolicy* out) {
-  std::string query_type;
-  if (!ConvertFromV8(isolate, val, &query_type))
-    return false;
-
-  if (query_type == "allow") {
-    *out = network::mojom::SecureDnsPolicy::ALLOW;
-    return true;
-  }
-
-  if (query_type == "disable") {
-    *out = network::mojom::SecureDnsPolicy::DISABLE;
-    return true;
-  }
-
-  return false;
+  using Val = network::mojom::SecureDnsPolicy;
+  static constexpr auto Lookup =
+      base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+          {"allow", Val::ALLOW},
+          {"disable", Val::DISABLE},
+      });
+  return FromV8WithLookup(isolate, val, Lookup, out);
 }
 
 // static

--- a/shell/common/gin_converters/std_converter.h
+++ b/shell/common/gin_converters/std_converter.h
@@ -210,6 +210,61 @@ struct Converter<std::wstring> {
 };
 #endif
 
+namespace detail {
+
+// Get a key from `key_val` and check `lookup` for a matching entry.
+// Return true iff a match is found, and set `*out` to the entry's value.
+template <typename KeyType, typename Out, typename Map>
+bool FromV8WithLookup(
+    v8::Isolate* isolate,
+    v8::Local<v8::Value> key_val,
+    const Map& table,
+    Out* out,
+    std::function<void(KeyType&)> transform = [](KeyType&) {}) {
+  static_assert(std::is_same_v<typename Map::mapped_type, Out>);
+
+  auto key = KeyType{};
+  if (!ConvertFromV8(isolate, key_val, &key))
+    return false;
+
+  transform(key);
+
+  if (const auto* iter = table.find(key); iter != table.end()) {
+    *out = iter->second;
+    return true;
+  }
+
+  return false;
+}
+
+}  // namespace detail
+
+// Convert `key_val to a string key and check `lookup` for a matching entry.
+// Return true iff a match is found, and set `*out` to the entry's value.
+template <typename Out, typename Map>
+bool FromV8WithLookup(v8::Isolate* isolate,
+                      v8::Local<v8::Value> key_val,
+                      const Map& table,
+                      Out* out) {
+  return detail::FromV8WithLookup<std::string>(isolate, key_val, table, out);
+}
+
+// Convert `key_val` to a lowercase string key and check `lookup` for a matching
+// entry. Return true iff a match is found, and set `*out` to the entry's value.
+template <typename Out, typename Map>
+bool FromV8WithLowerLookup(v8::Isolate* isolate,
+                           v8::Local<v8::Value> key_val,
+                           const Map& table,
+                           Out* out) {
+  static constexpr auto to_lower_ascii_inplace = [](std::string& str) {
+    for (auto& ch : str)
+      ch = base::ToLowerASCII(ch);
+  };
+
+  return detail::FromV8WithLookup<std::string>(isolate, key_val, table, out,
+                                               to_lower_ascii_inplace);
+}
+
 }  // namespace gin
 
 #endif  // ELECTRON_SHELL_COMMON_GIN_CONVERTERS_STD_CONVERTER_H_


### PR DESCRIPTION
#### Description of Change

A followup to #38771. Use `base::fixed_flat_map` for `FromV8()` string-to-value conversions.

CC @miniak and @dsanders11 + all reviews welcomed.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none