### PR TITLE
build: use Xcode 13.4.1

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -54,7 +54,7 @@ executors:
         type: enum
         enum: ["macos.x86.medium.gen2", "large"]
     macos:
-      xcode: 13.3.0
+      xcode: 13.4.1
     resource_class: << parameters.size >>
 
   # Electron Runners


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
CircleCI has deprecated Xcode 13 except for the final release, 13.4.1, and are removing them on August 7, 2023. Since the `23-x-y` branch is being supported until Aug 2023, move to 13.4.1.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
