### PR TITLE
fix: perform microtask checkpoint before `MicrotaskRunner` destruction

### DIFF
--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -333,11 +333,13 @@ void JavascriptEnvironment::CreateMicrotasksRunner() {
 
 void JavascriptEnvironment::DestroyMicrotasksRunner() {
   DCHECK(microtasks_runner_);
+  microtasks_runner_->PerformCheckpoint();
   {
     v8::HandleScope scope(isolate_);
     gin_helper::CleanedUpAtExit::DoCleanup();
   }
   base::CurrentThread::Get()->RemoveTaskObserver(microtasks_runner_.get());
+  microtasks_runner_.reset();
 }
 
 }  // namespace electron

--- a/shell/browser/microtasks_runner.cc
+++ b/shell/browser/microtasks_runner.cc
@@ -14,11 +14,7 @@ namespace electron {
 
 MicrotasksRunner::MicrotasksRunner(v8::Isolate* isolate) : isolate_(isolate) {}
 
-void MicrotasksRunner::WillProcessTask(const base::PendingTask& pending_task,
-                                       bool was_blocked_or_low_priority) {}
-
-void MicrotasksRunner::DidProcessTask(const base::PendingTask& pending_task) {
-  v8::Isolate::Scope scope(isolate_);
+void MicrotasksRunner::PerformCheckpoint() {
   // In the browser process we follow Node.js microtask policy of kExplicit
   // and let the MicrotaskRunner which is a task observer for chromium UI thread
   // scheduler run the microtask checkpoint. This worked fine because Node.js
@@ -26,13 +22,20 @@ void MicrotasksRunner::DidProcessTask(const base::PendingTask& pending_task) {
   // https://github.com/electron/electron/issues/20013 Node.js now performs its
   // own microtask checkpoint and it may happen is some situations that there is
   // contention for performing checkpoint between Node.js and chromium, ending
-  // up Node.js dealying its callbacks. To fix this, now we always lets Node.js
+  // up Node.js delaying its callbacks. To fix this, now we always let Node.js
   // handle the checkpoint in the browser process.
-  {
-    v8::HandleScope handle_scope(isolate_);
-    node::CallbackScope microtasks_scope(isolate_, v8::Object::New(isolate_),
-                                         {0, 0});
-  }
+  // node::CallbackScope performs the checkpoint when it goes out of scope.
+  v8::Isolate::Scope scope(isolate_);
+  v8::HandleScope handle_scope(isolate_);
+  node::CallbackScope microtasks_scope(isolate_, v8::Object::New(isolate_),
+                                       {0, 0});
+}
+
+void MicrotasksRunner::WillProcessTask(const base::PendingTask& pending_task,
+                                       bool was_blocked_or_low_priority) {}
+
+void MicrotasksRunner::DidProcessTask(const base::PendingTask& pending_task) {
+  PerformCheckpoint();
 }
 
 }  // namespace electron

--- a/shell/browser/microtasks_runner.h
+++ b/shell/browser/microtasks_runner.h
@@ -24,6 +24,8 @@ class MicrotasksRunner : public base::TaskObserver {
  public:
   explicit MicrotasksRunner(v8::Isolate* isolate);
 
+  void PerformCheckpoint();
+
   // base::TaskObserver
   void WillProcessTask(const base::PendingTask& pending_task,
                        bool was_blocked_or_low_priority) override;


### PR DESCRIPTION
#### Description of Change

Fix a bug that caused periodic test failures. [Sample failure](https://app.circleci.com/pipelines/github/electron/electron/71642/workflows/4ad01143-3178-4f6e-b98a-62ccee3d5f60/jobs/1552614?invite=true#step-111-1233):

> not ok 396 utilityProcess module stderr property is valid when child process launches with pipe stdio configuration
> expected '' to equal 'world'
> AssertionError: expected '' to equal 'world'
>      at Context.<anonymous> ([electron/spec/api-utility-process-spec.ts:176:22](https://github.com/electron/electron/blob/41ab5f327f8ab820e8559334f0ac0e6208f59d7e/spec/api-utility-process-spec.ts#L176))
>      at processTicksAndRejections (node:internal/process/task_queues:95:5)

The problem seems to be that the test spawned [this script](https://github.com/electron/electron/blob/41ab5f327f8ab820e8559334f0ac0e6208f59d7e/spec/fixtures/api/utility-process/log.js)  which wrote to stderr immediately before exiting and it was possible for there to still be pending queued tasks when [NodeService destroyed the microtask runner](https://github.com/electron/electron/blob/41ab5f327f8ab820e8559334f0ac0e6208f59d7e/shell/services/node/node_service.cc#L69).

The approach extracts the [tell-v8-to-perform-a-checkpoint code](https://github.com/electron/electron/blob/41ab5f327f8ab820e8559334f0ac0e6208f59d7e/shell/browser/microtasks_runner.cc#L22) from `MicrotaskRunner::DidProcessTask()` into a new public convenience function `MicrotaskRunner::PerformCheckpoint()`. It calls that function from `JavascriptEnvironment::DestroyMicrotaskRunner()`  before destroying the microtask runner.

In `main` I'm able to trigger this  test failure about 50% of the time. In this branch I wasn't able to break it in 100 iterations.

CC @deepak1556 who has done a lot of work in this code in #24131 and #34980 and @codebytere's CallbackScope code in #27001

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed bug that could fail to process pending microtasks added to a child process immediately before calling `process.exit()`.