### PR TITLE
fix: crash calling `BrowserWindow.removeBrowserView()` with destroyed `webContents`

### DIFF
--- a/shell/browser/api/electron_api_browser_view.cc
+++ b/shell/browser/api/electron_api_browser_view.cc
@@ -131,6 +131,10 @@ void BrowserView::WebContentsDestroyed() {
   Unpin();
 }
 
+void BrowserView::OnCloseContents() {
+  api_web_contents_ = nullptr;
+}
+
 // static
 gin::Handle<BrowserView> BrowserView::New(gin_helper::ErrorThrower thrower,
                                           gin::Arguments* args) {

--- a/shell/browser/api/electron_api_browser_view.h
+++ b/shell/browser/api/electron_api_browser_view.h
@@ -71,6 +71,9 @@ class BrowserView : public gin::Wrappable<BrowserView>,
   // content::WebContentsObserver:
   void WebContentsDestroyed() override;
 
+  // ExtendedWebContentsObserver:
+  void OnCloseContents() override;
+
  private:
   void SetAutoResize(AutoResizeFlags flags);
   void SetBounds(const gfx::Rect& bounds);

--- a/spec/api-browser-view-spec.ts
+++ b/spec/api-browser-view-spec.ts
@@ -257,6 +257,20 @@ describe('BrowserView module', () => {
         w.removeBrowserView(view);
       }).to.not.throw();
     });
+
+    it('can be called on a BrowserView with a destroyed webContents', (done) => {
+      view = new BrowserView();
+      w.addBrowserView(view);
+
+      view.webContents.on('destroyed', () => {
+        w.removeBrowserView(view);
+        done();
+      });
+
+      view.webContents.loadURL('data:text/html,hello there').then(() => {
+        view.webContents.close();
+      });
+    });
   });
 
   describe('BrowserWindow.getBrowserViews()', () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/37642.

Fixes an issue where calling `BrowserWindow.removeBrowserView()` with a destroyed `webContents` could caus a crash. This is a bit of an edge case, and happens specifically when calling `BrowserWindow.removeBrowserView()` in the `destroyed` event callback of the BrowserView's `webContents`. In this case, the callback is called and executed before `content::WebContentsObserver::WebContentsDestroyed()` is reached. We fix this by hooking into `OnCloseContents()`, which is called as a result of `view.webContents.close()` being called, and ensuring relevant cleanup is done both there and in `OnCloseContents()`, depending on how the `webContents` is being torn down.

<details><summary>Stacktrace</summary>
<p>

```
Received signal 11 SEGV_ACCERR 000000000048
0   Electron Framework                  0x000000011ac36b10 base::debug::CollectStackTrace(void**, unsigned long) + 28
1   Electron Framework                  0x000000011ac27d38 base::debug::StackTrace::StackTrace() + 24
2   Electron Framework                  0x000000011ac36a6c base::debug::(anonymous namespace)::StackDumpSignalHandler(int, __siginfo*, void*) + 1204
3   libsystem_platform.dylib            0x00000001a58eea84 _sigtramp + 56
4   Electron Framework                  0x000000011aba4bf0 base::SequenceCheckerImpl::CalledOnValidSequence(std::__Cr::unique_ptr<base::debug::StackTrace, std::__Cr::default_delete<base::debug::StackTrace>>*) const + 40
5   Electron Framework                  0x000000011aba4ac4 base::ScopedValidateSequenceChecker::ScopedValidateSequenceChecker(base::SequenceCheckerImpl const&) + 40
6   Electron Framework                  0x000000011abbb154 base::SupportsUserData::RemoveUserData(void const*) + 48
7   Electron Framework                  0x0000000116448264 electron::api::WebContents::SetOwnerWindow(content::WebContents*, electron::NativeWindow*) + 252
8   Electron Framework                  0x00000001163c4330 electron::api::BrowserView::SetOwnerWindow(electron::api::BaseWindow*) + 60
9   Electron Framework                  0x00000001163b6aec electron::api::BaseWindow::RemoveBrowserView(gin::Handle<electron::api::BrowserView>) + 168
10  Electron Framework                  0x00000001163bbdcc base::RepeatingCallback<void (electron::api::BaseWindow*, gin::Handle<electron::api::View>)>::Run(electron::api::BaseWindow*, gin::Handle<electron::api::View>) const & + 88
11  Electron Framework                  0x00000001163c0968 gin_helper::Dispatcher<void (electron::api::BaseWindow*, gin::Handle<electron::api::BrowserView>)>::DispatchToCallback(v8::FunctionCallbackInfo<v8::Value> const&) + 300
12  ???                                 0x000000015fe11d5c 0x0 + 5903555932
13  ???                                 0x000000015fe1017c 0x0 + 5903548796
14  ???                                 0x00000001580e36c4 0x0 + 5772293828
15  ???                                 0x000000015fe0d908 0x0 + 5903538440
16  ???                                 0x000000015fe0d5f8 0x0 + 5903537656
17  Electron Framework                  0x0000000117cd07b4 v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) + 4772
18  Electron Framework                  0x0000000117ccf3f0 v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>, int, v8::internal::Handle<v8::internal::Object>*) + 260
19  Electron Framework                  0x00000001179cb250 v8::Function::Call(v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*) + 1088
20  Electron Framework                  0x000000011f493ab0 node::InternalMakeCallback(node::Environment*, v8::Local<v8::Object>, v8::Local<v8::Object>, v8::Local<v8::Function>, int, v8::Local<v8::Value>*, node::async_context) + 500
21  Electron Framework                  0x000000011f493e20 node::MakeCallback(v8::Isolate*, v8::Local<v8::Object>, v8::Local<v8::Function>, int, v8::Local<v8::Value>*, node::async_context) + 260
22  Electron Framework                  0x00000001165380d0 gin_helper::internal::CallMethodWithArgs(v8::Isolate*, v8::Local<v8::Object>, char const*, std::__Cr::vector<v8::Local<v8::Value>, std::__Cr::allocator<v8::Local<v8::Value>>>*) + 116
23  Electron Framework                  0x00000001164405b0 bool gin_helper::EventEmitterMixin<electron::api::WebContents>::Emit<>(base::BasicStringPiece<char, std::__Cr::char_traits<char>>) + 180
24  Electron Framework                  0x0000000116448674 electron::api::WebContents::WebContentsDestroyed() + 200
25  Electron Framework                  0x000000011a0839a0 void content::WebContentsImpl::WebContentsObserverList::NotifyObservers<void (content::WebContentsObserver::*)()>(void (content::WebContentsObserver::*)()) + 612
26  Electron Framework                  0x000000011a082d94 content::WebContentsImpl::~WebContentsImpl() + 1348
27  Electron Framework                  0x000000011a083b0c content::WebContentsImpl::~WebContentsImpl() + 12
28  Electron Framework                  0x00000001164eacd0 electron::InspectableWebContents::~InspectableWebContents() + 472
29  Electron Framework                  0x00000001164ead48 electron::InspectableWebContents::~InspectableWebContents() + 12
30  Electron Framework                  0x00000001164403bc electron::api::WebContents::~WebContents() + 424
31  Electron Framework                  0x0000000116440644 electron::api::WebContents::~WebContents() + 12
32  Electron Framework                  0x0000000116440754 electron::api::WebContents::DeleteThisIfAlive() + 96
33  Electron Framework                  0x00000001163c90c4 base::internal::Invoker<base::internal::BindState<void (net::(anonymous namespace)::DnsHTTPAttempt::*)(), base::WeakPtr<net::(anonymous namespace)::DnsHTTPAttempt>>, void ()>::RunOnce(base::internal::BindStateBase*) + 92
34  Electron Framework                  0x000000011abbfbf8 base::TaskAnnotator::RunTaskImpl(base::PendingTask&) + 308
35  Electron Framework                  0x000000011abe64b0 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*) + 1164
36  Electron Framework                  0x000000011abe5ae0 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() + 104
37  Electron Framework                  0x00000001165d0b50 base::MessagePumpCFRunLoopBase::RunWork() + 176
38  Electron Framework                  0x000000011ac48f60 base::mac::CallWithEHFrame(void () block_pointer) + 16
39  Electron Framework                  0x00000001165d005c base::MessagePumpCFRunLoopBase::RunWorkSource(void*) + 68
40  CoreFoundation                      0x00000001a599e710 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 28
41  CoreFoundation                      0x00000001a599e6a4 __CFRunLoopDoSource0 + 176
42  CoreFoundation                      0x00000001a599e414 __CFRunLoopDoSources0 + 244
43  CoreFoundation                      0x00000001a599d01c __CFRunLoopRun + 828
44  CoreFoundation                      0x00000001a599c58c CFRunLoopRunSpecific + 612
45  HIToolbox                           0x00000001af1d1df4 RunCurrentEventLoopInMode + 292
46  HIToolbox                           0x00000001af1d1c30 ReceiveNextEventCommon + 648
47  HIToolbox                           0x00000001af1d1988 _BlockUntilNextEventMatchingListInModeWithFilter + 76
48  AppKit                              0x00000001a8bbbf58 _DPSNextEvent + 636
49  AppKit                              0x00000001a8bbb0f4 -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 716
50  AppKit                              0x00000001a8baf558 -[NSApplication run] + 464
51  Electron Framework                  0x00000001165d15f4 base::MessagePumpNSApplication::DoRun(base::MessagePump::Delegate*) + 400
52  Electron Framework                  0x00000001165cf95c base::MessagePumpCFRunLoopBase::Run(base::MessagePump::Delegate*) + 144
53  Electron Framework                  0x000000011abe7304 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) + 472
54  Electron Framework                  0x000000011aba0ee4 base::RunLoop::Run(base::Location const&) + 396
55  Electron Framework                  0x000000011996cc1c content::BrowserMainLoop::RunMainMessageLoop() + 144
56  Electron Framework                  0x000000011996e950 content::BrowserMainRunnerImpl::Run() + 44
57  Electron Framework                  0x000000011996a108 content::BrowserMain(content::MainFunctionParams) + 160
58  Electron Framework                  0x00000001166d8eb8 content::RunBrowserProcessMain(content::MainFunctionParams, content::ContentMainDelegate*) + 280
59  Electron Framework                  0x00000001166da3dc content::ContentMainRunnerImpl::RunBrowser(content::MainFunctionParams, bool) + 600
60  Electron Framework                  0x00000001166d9ff0 content::ContentMainRunnerImpl::Run() + 816
61  Electron Framework                  0x00000001166d8464 content::RunContentProcess(content::ContentMainParams, content::ContentMainRunner*) + 1296
62  Electron Framework                  0x00000001166d86c8 content::ContentMain(content::ContentMainParams) + 112
63  Electron Framework                  0x000000011638ed9c ElectronMain + 128
64  dyld                                0x00000001a5567f28 start + 2236
[end of stack trace]

Electron exited with signal SIGSEGV.
```

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash calling `BrowserWindow.removeBrowserView()` with a destroyed `webContents`.