### PR TITLE
refactor: use content::GlobalRenderFrameHostId

### DIFF
--- a/shell/browser/electron_api_ipc_handler_impl.cc
+++ b/shell/browser/electron_api_ipc_handler_impl.cc
@@ -14,8 +14,7 @@ namespace electron {
 ElectronApiIPCHandlerImpl::ElectronApiIPCHandlerImpl(
     content::RenderFrameHost* frame_host,
     mojo::PendingAssociatedReceiver<mojom::ElectronApiIPC> receiver)
-    : render_process_id_(frame_host->GetProcess()->GetID()),
-      render_frame_id_(frame_host->GetRoutingID()) {
+    : render_frame_host_id_(frame_host->GetGlobalId()) {
   content::WebContents* web_contents =
       content::WebContents::FromRenderFrameHost(frame_host);
   DCHECK(web_contents);
@@ -96,7 +95,7 @@ void ElectronApiIPCHandlerImpl::MessageHost(const std::string& channel,
 }
 
 content::RenderFrameHost* ElectronApiIPCHandlerImpl::GetRenderFrameHost() {
-  return content::RenderFrameHost::FromID(render_process_id_, render_frame_id_);
+  return content::RenderFrameHost::FromID(render_frame_host_id_);
 }
 
 // static

--- a/shell/browser/electron_api_ipc_handler_impl.h
+++ b/shell/browser/electron_api_ipc_handler_impl.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "base/memory/weak_ptr.h"
+#include "content/public/browser/global_routing_id.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "electron/shell/common/api/api.mojom.h"
 #include "mojo/public/cpp/bindings/associated_receiver.h"
@@ -68,8 +69,7 @@ class ElectronApiIPCHandlerImpl : public mojom::ElectronApiIPC,
 
   content::RenderFrameHost* GetRenderFrameHost();
 
-  const int render_process_id_;
-  const int render_frame_id_;
+  content::GlobalRenderFrameHostId render_frame_host_id_;
 
   mojo::AssociatedReceiver<mojom::ElectronApiIPC> receiver_{this};
 

--- a/shell/browser/electron_permission_manager.cc
+++ b/shell/browser/electron_permission_manager.cc
@@ -55,8 +55,7 @@ class ElectronPermissionManager::PendingRequest {
   PendingRequest(content::RenderFrameHost* render_frame_host,
                  const std::vector<blink::PermissionType>& permissions,
                  StatusesCallback callback)
-      : render_process_id_(render_frame_host->GetProcess()->GetID()),
-        render_frame_id_(render_frame_host->GetGlobalId()),
+      : render_frame_host_id_(render_frame_host->GetGlobalId()),
         callback_(std::move(callback)),
         permissions_(permissions),
         results_(permissions.size(), blink::mojom::PermissionStatus::DENIED),
@@ -70,7 +69,7 @@ class ElectronPermissionManager::PendingRequest {
       const auto permission = permissions_[permission_id];
       if (permission == blink::PermissionType::MIDI_SYSEX) {
         content::ChildProcessSecurityPolicy::GetInstance()
-            ->GrantSendMidiSysExMessage(render_process_id_);
+            ->GrantSendMidiSysExMessage(render_frame_host_id_.child_id);
       } else if (permission == blink::PermissionType::GEOLOCATION) {
         ElectronBrowserMainParts::Get()
             ->GetGeolocationControl()
@@ -83,7 +82,7 @@ class ElectronPermissionManager::PendingRequest {
   }
 
   content::RenderFrameHost* GetRenderFrameHost() {
-    return content::RenderFrameHost::FromID(render_frame_id_);
+    return content::RenderFrameHost::FromID(render_frame_host_id_);
   }
 
   bool IsComplete() const { return remaining_results_ == 0; }
@@ -95,8 +94,7 @@ class ElectronPermissionManager::PendingRequest {
   }
 
  private:
-  int render_process_id_;
-  content::GlobalRenderFrameHostId render_frame_id_;
+  content::GlobalRenderFrameHostId render_frame_host_id_;
   StatusesCallback callback_;
   std::vector<blink::PermissionType> permissions_;
   std::vector<blink::mojom::PermissionStatus> results_;

--- a/shell/browser/electron_web_contents_utility_handler_impl.cc
+++ b/shell/browser/electron_web_contents_utility_handler_impl.cc
@@ -14,8 +14,7 @@ namespace electron {
 ElectronWebContentsUtilityHandlerImpl::ElectronWebContentsUtilityHandlerImpl(
     content::RenderFrameHost* frame_host,
     mojo::PendingAssociatedReceiver<mojom::ElectronWebContentsUtility> receiver)
-    : render_process_id_(frame_host->GetProcess()->GetID()),
-      render_frame_id_(frame_host->GetRoutingID()) {
+    : render_frame_host_id_(frame_host->GetGlobalId()) {
   content::WebContents* web_contents =
       content::WebContents::FromRenderFrameHost(frame_host);
   DCHECK(web_contents);
@@ -70,7 +69,7 @@ void ElectronWebContentsUtilityHandlerImpl::DoGetZoomLevel(
 
 content::RenderFrameHost*
 ElectronWebContentsUtilityHandlerImpl::GetRenderFrameHost() {
-  return content::RenderFrameHost::FromID(render_process_id_, render_frame_id_);
+  return content::RenderFrameHost::FromID(render_frame_host_id_);
 }
 
 // static

--- a/shell/browser/electron_web_contents_utility_handler_impl.h
+++ b/shell/browser/electron_web_contents_utility_handler_impl.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "base/memory/weak_ptr.h"
+#include "content/public/browser/global_routing_id.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "electron/shell/common/api/api.mojom.h"
 #include "mojo/public/cpp/bindings/associated_receiver.h"
@@ -59,8 +60,7 @@ class ElectronWebContentsUtilityHandlerImpl
 
   content::RenderFrameHost* GetRenderFrameHost();
 
-  const int render_process_id_;
-  const int render_frame_id_;
+  content::GlobalRenderFrameHostId render_frame_host_id_;
 
   mojo::AssociatedReceiver<mojom::ElectronWebContentsUtility> receiver_{this};
 


### PR DESCRIPTION
We are already storing `content::GlobalRenderFrameHostId` in `UsbChooserController`, `SerialChooserController` and `HidChooserController`.

Notes: none