### PR TITLE
fix: only load Node.js environment when `nodeIntegration: true`

### DIFF
--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -381,6 +381,9 @@ void WebContentsPreferences::AppendCommandLineSwitches(
   if (node_integration_in_worker_)
     command_line->AppendSwitch(switches::kNodeIntegrationInWorker);
 
+  if (node_integration_)
+    command_line->AppendSwitch(switches::kNodeIntegration);
+
   // We are appending args to a webContents so let's save the current state
   // of our preferences object so that during the lifetime of the WebContents
   // we can fetch the options used to initially configure the WebContents

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -239,8 +239,13 @@ const char kAppPath[] = "app-path";
 // The command line switch versions of the options.
 const char kScrollBounce[] = "scroll-bounce";
 
-// Command switch passed to renderer process to control nodeIntegration.
+// Command switch passed to renderer process to control nodeIntegration in
+// workers.
 const char kNodeIntegrationInWorker[] = "node-integration-in-worker";
+
+// Command switch passed to renderer process to control nodeIntegration in
+// workers.
+const char kNodeIntegration[] = "node-integration";
 
 // Widevine options
 // Path to Widevine CDM binaries.

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -119,6 +119,7 @@ extern const char kAppPath[];
 
 extern const char kScrollBounce[];
 extern const char kNodeIntegrationInWorker[];
+extern const char kNodeIntegration[];
 
 extern const char kWidevineCdmPath[];
 extern const char kWidevineCdmVersion[];

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -63,12 +63,13 @@ void ElectronRendererClient::RunScriptsAtDocumentEnd(
 void ElectronRendererClient::DidCreateScriptContext(
     v8::Handle<v8::Context> renderer_context,
     content::RenderFrame* render_frame) {
-  // TODO(zcbenz): Do not create Node environment if node integration is not
-  // enabled.
-
   // Only load Node.js if we are a main frame or a devtools extension
   // unless Node.js support has been explicitly enabled for subframes.
-  if (!ShouldLoadPreload(renderer_context, render_frame))
+  auto* cmdline = base::CommandLine::ForCurrentProcess();
+  bool should_load_node = ShouldLoadPreload(renderer_context, render_frame) &&
+                          cmdline->HasSwitch(switches::kNodeIntegration);
+
+  if (!should_load_node)
     return;
 
   injected_frames_.insert(render_frame);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/38853.

Addresses a long-standing TODO. We can end up in a weird state when `nodeIntegration: false` but `contextIsolation: true`, because Node.js and Blink implement several of the same functionality. In the case of the issue above, we're calling `node::worker::MessagePort::New` when we create a  `MessageChannel`, which we shouldn't be at all because we should be exclusively using Blink's implementation [here](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/messaging/message_channel.h?q=third_party%2Fblink%2Frenderer%2Fcore%2Fmessaging%2Fmessage_channel.h&sq=package:chromium&type=cs).

<details><summary>Stacktrace</summary>
<p>

```
#
# Fatal error in ../../v8/src/api/api-inl.h, line 121
# Debug check failed: allow_empty_handle || !v8::internal::ValueHelper::IsEmpty(that).
#
#
#
#FailureMessage Object: 0x16ae1edf8
0   Electron Framework                  0x000000011f05eb10 base::debug::CollectStackTrace(void**, unsigned long) + 28
1   Electron Framework                  0x000000011f04fd38 base::debug::StackTrace::StackTrace() + 24
2   Electron Framework                  0x000000012091c868 gin::(anonymous namespace)::PrintStackTrace() + 40
3   Electron Framework                  0x00000001206e452c V8_Fatal(char const*, int, char const*, ...) + 268
4   Electron Framework                  0x00000001206e41d0 std::__Cr::enable_if<!std::is_function<std::__Cr::remove_pointer<unsigned char>::type>::value && !std::is_enum<unsigned char>::value && has_output_operator<unsigned char, v8::base::CheckMessageStream>::value, std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>>::type v8::base::PrintCheckOperand<unsigned char>(unsigned char) + 0
5   Electron Framework                  0x000000011bdbe250 v8::FunctionTemplate::SetClassName(v8::Local<v8::String>) + 328
6   Electron Framework                  0x00000001239a0360 node::worker::GetMessagePortConstructorTemplate(node::Environment*) + 128
7   Electron Framework                  0x00000001239a015c node::worker::MessagePort::New(node::Environment*, v8::Local<v8::Context>, std::__Cr::unique_ptr<node::worker::MessagePortData, std::__Cr::default_delete<node::worker::MessagePortData>>, std::__Cr::shared_ptr<node::worker::SiblingGroup>) + 72
8   Electron Framework                  0x00000001239a55d4 node::worker::(anonymous namespace)::MessageChannel(v8::FunctionCallbackInfo<v8::Value> const&) + 396
9   Electron Framework                  0x000000011beadbd8 v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo) + 288
10  Electron Framework                  0x000000011beac18c v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<true>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, unsigned long*, int) + 644
11  Electron Framework                  0x000000011beaadfc v8::internal::Builtin_Impl_HandleApiConstruct(v8::internal::BuiltinArguments, v8::internal::Isolate*) + 224
12  Electron Framework                  0x000000011beaa7c8 v8::internal::Builtin_HandleApiConstruct(int, unsigned long*, v8::internal::Isolate*) + 136
13  ???                                 0x0000000177eb4918 0x0 + 6306875672
14  ???                                 0x0000000177e0caa8 0x0 + 6306187944
15  ???                                 0x0000000177fb5aa0 0x0 + 6307928736
16  ???                                 0x0000000177e1017c 0x0 + 6306201980
17  ???                                 0x0000000177e1017c 0x0 + 6306201980
18  ???                                 0x0000000177e1017c 0x0 + 6306201980
19  ???                                 0x0000000177e1017c 0x0 + 6306201980
20  ???                                 0x0000000177e1017c 0x0 + 6306201980
21  ???                                 0x0000000177e1017c 0x0 + 6306201980
22  ???                                 0x00000001700a6f2c 0x0 + 6174699308
23  ???                                 0x00000001700a5f44 0x0 + 6174695236
24  ???                                 0x0000000177e1017c 0x0 + 6306201980
25  ???                                 0x0000000177e1017c 0x0 + 6306201980
26  ???                                 0x00000001707531b0 0x0 + 6181695920
27  ???                                 0x0000000177e1017c 0x0 + 6306201980
28  ???                                 0x0000000177e0d908 0x0 + 6306191624
29  ???                                 0x0000000177e0d5f8 0x0 + 6306190840
30  Electron Framework                  0x000000011c0f7c34 v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) + 4772
31  Electron Framework                  0x000000011c0f6870 v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>, int, v8::internal::Handle<v8::internal::Object>*) + 260
32  Electron Framework                  0x000000011bdf26d0 v8::Function::Call(v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*) + 1088
33  Electron Framework                  0x0000000120b8decc blink::V8ScriptRunner::CallFunction(v8::Local<v8::Function>, blink::ExecutionContext*, v8::Local<v8::Value>, int, v8::Local<v8::Value>*, v8::Isolate*) + 1076
34  Electron Framework                  0x000000012228707c blink::bindings::CallbackInvokeHelper<blink::CallbackFunctionBase, (blink::bindings::CallbackInvokeHelperMode)0, (blink::bindings::CallbackReturnTypeIsPromise)0>::CallInternal(int, v8::Local<v8::Value>*) + 228
35  Electron Framework                  0x0000000122286f80 blink::bindings::CallbackInvokeHelper<blink::CallbackFunctionBase, (blink::bindings::CallbackInvokeHelperMode)0, (blink::bindings::CallbackReturnTypeIsPromise)0>::Call(int, v8::Local<v8::Value>*) + 20
36  Electron Framework                  0x000000012228bbfc blink::V8EventHandlerNonNull::InvokeWithoutRunnabilityCheck(blink::bindings::V8ValueOrScriptWrappableAdapter, blink::HeapVector<blink::ScriptValue, 0u> const&) + 332
37  Electron Framework                  0x0000000121321adc blink::JSEventHandler::InvokeInternal(blink::EventTarget&, blink::Event&, v8::Local<v8::Value>) + 1196
38  Electron Framework                  0x0000000120f53314 blink::JSBasedEventListener::Invoke(blink::ExecutionContext*, blink::Event*) + 704
39  Electron Framework                  0x0000000120f56a78 blink::EventTarget::FireEventListeners(blink::Event&, blink::EventTargetData*, blink::HeapVector<blink::RegisteredEventListener, 1u>&) + 1808
40  Electron Framework                  0x0000000120f55fec blink::EventTarget::FireEventListeners(blink::Event&) + 448
41  Electron Framework                  0x0000000120f55e10 blink::EventTarget::DispatchEventInternal(blink::Event&) + 76
42  Electron Framework                  0x0000000121b8b6d0 blink::XMLHttpRequestProgressEventThrottle::DispatchReadyStateChangeEvent(blink::Event*, blink::XMLHttpRequestProgressEventThrottle::DeferredEventAction) + 252
43  Electron Framework                  0x0000000121b80d50 blink::XMLHttpRequest::DispatchReadyStateChangeEvent() + 300
44  Electron Framework                  0x0000000121b879a4 blink::XMLHttpRequest::EndLoading() + 176
45  Electron Framework                  0x0000000121b878a0 blink::XMLHttpRequest::DidFinishLoadingInternal() + 304
46  Electron Framework                  0x0000000121b8771c blink::XMLHttpRequest::DidFinishLoading(unsigned long long) + 432
47  Electron Framework                  0x000000012183683c blink::ThreadableLoader::NotifyFinished(blink::Resource*) + 292
48  Electron Framework                  0x000000011dafca24 blink::Resource::NotifyFinished() + 112
49  Electron Framework                  0x000000011dafd9e0 blink::Resource::Finish(base::TimeTicks, base::SingleThreadTaskRunner*) + 108
50  Electron Framework                  0x000000011db13be0 blink::ResourceFetcher::HandleLoaderFinish(blink::Resource*, base::TimeTicks, blink::ResourceFetcher::LoaderFinishType, unsigned int, bool, bool, long long) + 648
51  Electron Framework                  0x000000011db2ace8 blink::ResourceLoader::DidFinishLoading(base::TimeTicks, long long, unsigned long long, long long, bool, absl::optional<bool>) + 432
52  Electron Framework                  0x000000011db3b27c blink::ResponseBodyLoader::OnStateChange() + 1448
53  Electron Framework                  0x000000011db55c28 blink::URLLoader::Context::OnCompletedRequest(network::URLLoaderCompletionStatus const&) + 284
54  Electron Framework                  0x000000011db51b94 blink::ResourceRequestSender::OnRequestComplete(network::URLLoaderCompletionStatus const&) + 648
55  Electron Framework                  0x000000011db48024 blink::MojoURLLoaderClient::OnComplete(network::URLLoaderCompletionStatus const&) + 212
56  Electron Framework                  0x000000011bc88dc0 blink::ThrottlingURLLoader::OnComplete(network::URLLoaderCompletionStatus const&) + 468
57  Electron Framework                  0x000000011ad88a40 network::mojom::URLLoaderClientStubDispatch::Accept(network::mojom::URLLoaderClient*, mojo::Message*) + 740
58  Electron Framework                  0x000000011f35c3f0 mojo::InterfaceEndpointClient::HandleValidatedMessage(mojo::Message*) + 1164
59  Electron Framework                  0x000000011f3624d8 mojo::MessageDispatcher::Accept(mojo::Message*) + 236
60  Electron Framework                  0x000000011f35df70 mojo::InterfaceEndpointClient::HandleIncomingMessage(mojo::Message*) + 100
61  Electron Framework                  0x000000011f366b40 mojo::internal::MultiplexRouter::ProcessIncomingMessage(mojo::internal::MultiplexRouter::MessageWrapper*, mojo::internal::MultiplexRouter::ClientCallBehavior, base::SequencedTaskRunner*) + 860
62  Electron Framework                  0x000000011f366250 mojo::internal::MultiplexRouter::Accept(mojo::Message*) + 360
63  Electron Framework                  0x000000011f3624d8 mojo::MessageDispatcher::Accept(mojo::Message*) + 236
64  Electron Framework                  0x000000011f356acc mojo::Connector::DispatchMessage(mojo::ScopedHandleBase<mojo::MessageHandle>) + 360
65  Electron Framework                  0x000000011f357620 mojo::Connector::ReadAllAvailableMessages() + 224
66  Electron Framework                  0x000000011f3573cc mojo::Connector::OnWatcherHandleReady(char const*, unsigned int) + 84
67  Electron Framework                  0x000000011a7bdcc8 base::RepeatingCallback<void (std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&)>::Run(std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&) const & + 80
68  Electron Framework                  0x000000011a7bd8d4 base::RepeatingCallback<void (std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&)>::Run(std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&) const & + 92
69  Electron Framework                  0x000000011f38164c mojo::SimpleWatcher::OnHandleReady(int, unsigned int, mojo::HandleSignalsState const&) + 236
70  Electron Framework                  0x000000011f381a64 base::internal::Invoker<base::internal::BindState<void (mojo::SimpleWatcher::*)(int, unsigned int, mojo::HandleSignalsState const&), base::WeakPtr<mojo::SimpleWatcher>, int, unsigned int, mojo::HandleSignalsState>, void ()>::RunOnce(base::internal::BindStateBase*) + 108
71  Electron Framework                  0x000000011efe7bf8 base::TaskAnnotator::RunTaskImpl(base::PendingTask&) + 308
72  Electron Framework                  0x000000011f00e4b0 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*) + 1164
73  Electron Framework                  0x000000011f00dae0 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() + 104
74  Electron Framework                  0x000000011efa3b30 base::MessagePumpDefault::Run(base::MessagePump::Delegate*) + 152
75  Electron Framework                  0x000000011f00f304 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) + 472
76  Electron Framework                  0x000000011efc8ee4 base::RunLoop::Run(base::Location const&) + 396
77  Electron Framework                  0x000000012361ca80 content::RendererMain(content::MainFunctionParams) + 1396
78  Electron Framework                  0x000000011ab00670 content::RunOtherNamedProcessTypeMain(std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, content::MainFunctionParams, content::ContentMainDelegate*) + 760
79  Electron Framework                  0x000000011ab01444 content::ContentMainRunnerImpl::Run() + 772
80  Electron Framework                  0x000000011aaff8e4 content::RunContentProcess(content::ContentMainParams, content::ContentMainRunner*) + 1296
81  Electron Framework                  0x000000011aaffb48 content::ContentMain(content::ContentMainParams) + 112
82  Electron Framework                  0x000000011a7b6d9c ElectronMain + 128
83  Electron Helper (Renderer)          0x0000000104fdca00 main + 224
84  dyld                                0x00000001a5567f28 start + 2236
Renderer process crashed - see https://www.electronjs.org/docs/tutorial/application-debugging for potential debugging information.
```

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.