### PR TITLE
fix: set minimize visibility true with enable

### DIFF
--- a/shell/browser/ui/views/win_caption_button_container.cc
+++ b/shell/browser/ui/views/win_caption_button_container.cc
@@ -162,6 +162,7 @@ void WinCaptionButtonContainer::UpdateButtons() {
 
   const bool minimizable = frame_view_->window()->IsMinimizable();
   minimize_button_->SetEnabled(minimizable);
+  minimize_button_->SetVisible(minimizable);
 
   // In touch mode, windows cannot be taken out of fullscreen or tiled mode, so
   // the maximize/restore button should be disabled.


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Closes https://github.com/electron/electron/issues/38667

Previously, if all three buttons (maximize, minimize, and close) were disabled, minimize’s visibility got set to false with nothing setting it back to true. Now minimize’s visibility gets set to true when it is enabled.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->None
