### PR TITLE
docs: fix misleading code sample for handling deeplinks on Linux

### DIFF
--- a/docs/tutorial/launch-app-from-url-in-another-app.md
+++ b/docs/tutorial/launch-app-from-url-in-another-app.md
@@ -63,9 +63,9 @@ const createWindow = () => {
 
 In this next step, we will create our  `BrowserWindow` and tell our application how to handle an event in which an external protocol is clicked.
 
-This code will be different in Windows compared to MacOS and Linux. This is due to Windows requiring additional code in order to open the contents of the protocol link within the same Electron instance. Read more about this [here](../api/app.md#apprequestsingleinstancelockadditionaldata).
+This code will be different in Windows and Linux compared to MacOS. This is due to both platforms emitting the `second-instance` event rather than the `open-url` event and Windows requiring additional code in order to open the contents of the protocol link within the same Electron instance. Read more about this [here](../api/app.md#apprequestsingleinstancelockadditionaldata).
 
-#### Windows code:
+#### Windows and Linux code:
 
 ```javascript @ts-type={mainWindow:Electron.BrowserWindow} @ts-type={createWindow:()=>void}
 const gotTheLock = app.requestSingleInstanceLock()
@@ -80,8 +80,7 @@ if (!gotTheLock) {
       mainWindow.focus()
     }
     // the commandLine is array of strings in which last element is deep link url
-    // the url str ends with /
-    dialog.showErrorBox('Welcome Back', `You arrived from: ${commandLine.pop().slice(0, -1)}`)
+    dialog.showErrorBox('Welcome Back', `You arrived from: ${commandLine.pop()}`)
   })
 
   // Create mainWindow, load the rest of the app, etc...
@@ -91,7 +90,7 @@ if (!gotTheLock) {
 }
 ```
 
-#### MacOS and Linux code:
+#### MacOS code:
 
 ```javascript @ts-type={createWindow:()=>void}
 // This method will be called when Electron has finished


### PR DESCRIPTION
#### Description of Change

It looks like the code sample is incorrect here for handling deeplinks on Linux. After some trial and error debugging why my Linux app was not receiving any deeplinks to it, I realized that the `second-instance` event was being emitted like on Windows rather than the `open-url` event like MacOS does. Searching through some other issues in this repo confirmed my suspicions. e.g. https://github.com/electron/electron/issues/29336#issuecomment-848962145

Additionally, I found this line to be misleading:

> the url str ends with /

since that is not always the case. Particularly in situations where the deeplink contains a query param in which case this code sample would remove the last character of that param.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] `npm test` passes
- [X] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [X] relevant documentation, tutorials, templates and examples are changed or added
- [X] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

none
