### PR TITLE
docs: update debugging GN information

### DIFF
--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -78,6 +78,7 @@ origin URLs.
 $ cd src/electron
 $ git remote remove origin
 $ git remote add origin https://github.com/electron/electron
+$ git fetch
 $ git checkout main
 $ git branch --set-upstream-to=origin/main
 $ cd -

--- a/docs/development/debugging.md
+++ b/docs/development/debugging.md
@@ -39,19 +39,31 @@ This will allow you to observe call chains and identify potential issue areas.
 
 > Note that this will increase the size of the build significantly, taking up around 50G of disk space
 
-Write the following file to `electron/.git/info/exclude/debug.gn`
+Write the following file to `electron/build/args/debug.gn`
 
 ```gn
-import("//electron/build/args/testing.gn")
+import("testing.gn")
 is_debug = true
 symbol_level = 2
 forbid_non_component_debug_builds = false
 ```
 
+Then add `build/args/debug.gn` to the end of `electron/.git/info/exclude`, like this
+
+```sh
+# git ls-files --others --exclude-from=.git/info/exclude
+# Lines that start with '#' are comments.
+# For a project mostly in C, the following would be a good set of
+# exclude patterns (uncomment them if you want to use them):
+# *.[oa]
+# *~
+build/args/debug.gn
+```
+
 Then execute:
 
 ```sh
-$ gn gen out/Debug --args="import(\"//electron/.git/info/exclude/debug.gn\") $GN_EXTRA_ARGS"
+$ gn gen out/Debug --args="import(\"//electron/build/args/debug.gn\") $GN_EXTRA_ARGS"
 $ ninja -C out/Debug electron
 ```
 


### PR DESCRIPTION
#### Description of Change
Developers need to `git fetch` before `--set-upstream-to=origin/main`.

I found that `.git/info/exclude` is a regular file, not a directory. It's unlikely to add `debug.gn` reside it.
I guess the writer want readers not to use `.gitignore` but `.git/info/exclude`. Therefore, add `debug.gn` near `electron/build/args/testing.gn` and exclude it in `.git/info/exclude`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added

Noted:
`npm test` result
```
# tests 2601
# pass 2571
# fail 30
```
See the whole test output in the attachment.
[test-report.txt](https://github.com/electron/electron/files/11811897/test-report.txt)

I didn't change code. Maybe these failures are acceptable?

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
