### PR TITLE
refactor: api web contents ownership

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -786,12 +786,7 @@ WebContents::WebContents(v8::Isolate* isolate,
                          content::WebContents* web_contents)
     : content::WebContentsObserver(web_contents),
       type_(Type::kRemote),
-      id_(GetAllWebContents().Add(this)),
-      devtools_file_system_indexer_(
-          base::MakeRefCounted<DevToolsFileSystemIndexer>()),
-      exclusive_access_manager_(std::make_unique<ExclusiveAccessManager>(this)),
-      file_task_runner_(
-          base::ThreadPool::CreateSequencedTaskRunner({base::MayBlock()}))
+      id_(GetAllWebContents().Add(this))
 #if BUILDFLAG(ENABLE_PRINTING)
       ,
       print_task_runner_(CreatePrinterHandlerTaskRunner())
@@ -824,12 +819,7 @@ WebContents::WebContents(v8::Isolate* isolate,
                          Type type)
     : content::WebContentsObserver(web_contents.get()),
       type_(type),
-      id_(GetAllWebContents().Add(this)),
-      devtools_file_system_indexer_(
-          base::MakeRefCounted<DevToolsFileSystemIndexer>()),
-      exclusive_access_manager_(std::make_unique<ExclusiveAccessManager>(this)),
-      file_task_runner_(
-          base::ThreadPool::CreateSequencedTaskRunner({base::MayBlock()}))
+      id_(GetAllWebContents().Add(this))
 #if BUILDFLAG(ENABLE_PRINTING)
       ,
       print_task_runner_(CreatePrinterHandlerTaskRunner())
@@ -845,12 +835,7 @@ WebContents::WebContents(v8::Isolate* isolate,
 
 WebContents::WebContents(v8::Isolate* isolate,
                          const gin_helper::Dictionary& options)
-    : id_(GetAllWebContents().Add(this)),
-      devtools_file_system_indexer_(
-          base::MakeRefCounted<DevToolsFileSystemIndexer>()),
-      exclusive_access_manager_(std::make_unique<ExclusiveAccessManager>(this)),
-      file_task_runner_(
-          base::ThreadPool::CreateSequencedTaskRunner({base::MayBlock()}))
+    : id_(GetAllWebContents().Add(this))
 #if BUILDFLAG(ENABLE_PRINTING)
       ,
       print_task_runner_(CreatePrinterHandlerTaskRunner())
@@ -1412,7 +1397,7 @@ bool WebContents::PlatformHandleKeyboardEvent(
 content::KeyboardEventProcessingResult WebContents::PreHandleKeyboardEvent(
     content::WebContents* source,
     const content::NativeWebKeyboardEvent& event) {
-  if (exclusive_access_manager_->HandleUserKeyEvent(event))
+  if (exclusive_access_manager_.HandleUserKeyEvent(event))
     return content::KeyboardEventProcessingResult::HANDLED;
 
   if (event.GetType() == blink::WebInputEvent::Type::kRawKeyDown ||
@@ -1500,7 +1485,7 @@ void WebContents::OnEnterFullscreenModeForTab(
 
   owner_window()->set_fullscreen_transition_type(
       NativeWindow::FullScreenTransitionType::HTML);
-  exclusive_access_manager_->fullscreen_controller()->EnterFullscreenModeForTab(
+  exclusive_access_manager_.fullscreen_controller()->EnterFullscreenModeForTab(
       requesting_frame, options.display_id);
 
   SetHtmlApiFullscreen(true);
@@ -1518,7 +1503,7 @@ void WebContents::ExitFullscreenModeForTab(content::WebContents* source) {
 
   // This needs to be called before we exit fullscreen on the native window,
   // or the controller will incorrectly think we weren't fullscreen and bail.
-  exclusive_access_manager_->fullscreen_controller()->ExitFullscreenModeForTab(
+  exclusive_access_manager_.fullscreen_controller()->ExitFullscreenModeForTab(
       source);
 
   SetHtmlApiFullscreen(false);
@@ -1577,7 +1562,7 @@ void WebContents::RequestExclusivePointerAccess(
     bool last_unlocked_by_target,
     bool allowed) {
   if (allowed) {
-    exclusive_access_manager_->mouse_lock_controller()->RequestToLockMouse(
+    exclusive_access_manager_.mouse_lock_controller()->RequestToLockMouse(
         web_contents, user_gesture, last_unlocked_by_target);
   } else {
     web_contents->GotResponseToLockMouseRequest(
@@ -1597,18 +1582,18 @@ void WebContents::RequestToLockMouse(content::WebContents* web_contents,
 }
 
 void WebContents::LostMouseLock() {
-  exclusive_access_manager_->mouse_lock_controller()->LostMouseLock();
+  exclusive_access_manager_.mouse_lock_controller()->LostMouseLock();
 }
 
 void WebContents::RequestKeyboardLock(content::WebContents* web_contents,
                                       bool esc_key_locked) {
-  exclusive_access_manager_->keyboard_lock_controller()->RequestKeyboardLock(
+  exclusive_access_manager_.keyboard_lock_controller()->RequestKeyboardLock(
       web_contents, esc_key_locked);
 }
 
 void WebContents::CancelKeyboardLockRequest(
     content::WebContents* web_contents) {
-  exclusive_access_manager_->keyboard_lock_controller()
+  exclusive_access_manager_.keyboard_lock_controller()
       ->CancelKeyboardLockRequest(web_contents);
 }
 
@@ -3878,8 +3863,10 @@ bool WebContents::IsFullscreenForTabOrPending(
 
 content::FullscreenState WebContents::GetFullscreenState(
     const content::WebContents* source) const {
-  return exclusive_access_manager_->fullscreen_controller()->GetFullscreenState(
-      source);
+  // `const_cast` here because EAM does not have const getters
+  return const_cast<ExclusiveAccessManager*>(&exclusive_access_manager_)
+      ->fullscreen_controller()
+      ->GetFullscreenState(source);
 }
 
 bool WebContents::TakeFocus(content::WebContents* source, bool reverse) {

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -14,9 +14,11 @@
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "base/observer_list_types.h"
+#include "base/task/thread_pool.h"
 #include "chrome/browser/devtools/devtools_eye_dropper.h"
 #include "chrome/browser/devtools/devtools_file_system_indexer.h"
 #include "chrome/browser/ui/exclusive_access/exclusive_access_context.h"  // nogncheck
+#include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
 #include "content/common/frame.mojom.h"
 #include "content/public/browser/devtools_agent_host.h"
 #include "content/public/browser/keyboard_event_processing_result.h"
@@ -74,8 +76,6 @@ class ResourceRequestBody;
 namespace gin {
 class Arguments;
 }
-
-class ExclusiveAccessManager;
 
 class SkRegion;
 
@@ -803,9 +803,10 @@ class WebContents : public ExclusiveAccessContext,
   // Whether window is fullscreened by window api.
   bool native_fullscreen_ = false;
 
-  scoped_refptr<DevToolsFileSystemIndexer> devtools_file_system_indexer_;
+  const scoped_refptr<DevToolsFileSystemIndexer> devtools_file_system_indexer_ =
+      base::MakeRefCounted<DevToolsFileSystemIndexer>();
 
-  std::unique_ptr<ExclusiveAccessManager> exclusive_access_manager_;
+  ExclusiveAccessManager exclusive_access_manager_{this};
 
   std::unique_ptr<DevToolsEyeDropper> eye_dropper_;
 
@@ -827,10 +828,11 @@ class WebContents : public ExclusiveAccessContext,
           DevToolsIndexingJobsMap;
   DevToolsIndexingJobsMap devtools_indexing_jobs_;
 
-  scoped_refptr<base::SequencedTaskRunner> file_task_runner_;
+  const scoped_refptr<base::SequencedTaskRunner> file_task_runner_ =
+      base::ThreadPool::CreateSequencedTaskRunner({base::MayBlock()});
 
 #if BUILDFLAG(ENABLE_PRINTING)
-  scoped_refptr<base::TaskRunner> print_task_runner_;
+  const scoped_refptr<base::TaskRunner> print_task_runner_;
 #endif
 
   // Stores the frame thats currently in fullscreen, nullptr if there is none.


### PR DESCRIPTION
Manually backport #38695 to 25-x-y. See that PR for details.

No noteworthy changes compared to 38695; the manual intervention was just changing an instance of `foo->bar` to `foo.bar`

Notes: none