### PR TITLE
refactor: more constexpr lookup tables

### DIFF
--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -6,6 +6,7 @@
 
 #include <string>
 
+#include "base/containers/fixed_flat_map.h"
 #include "gin/dictionary.h"
 #include "gin/object_template_builder.h"
 #include "shell/browser/api/electron_api_menu.h"
@@ -29,27 +30,16 @@ struct Converter<electron::TrayIcon::IconType> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      electron::TrayIcon::IconType* out) {
-    using IconType = electron::TrayIcon::IconType;
-    std::string mode;
-    if (ConvertFromV8(isolate, val, &mode)) {
-      if (mode == "none") {
-        *out = IconType::kNone;
-        return true;
-      } else if (mode == "info") {
-        *out = IconType::kInfo;
-        return true;
-      } else if (mode == "warning") {
-        *out = IconType::kWarning;
-        return true;
-      } else if (mode == "error") {
-        *out = IconType::kError;
-        return true;
-      } else if (mode == "custom") {
-        *out = IconType::kCustom;
-        return true;
-      }
-    }
-    return false;
+    using Val = electron::TrayIcon::IconType;
+    static constexpr auto Lookup =
+        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+            {"custom", Val::kCustom},
+            {"error", Val::kError},
+            {"info", Val::kInfo},
+            {"none", Val::kNone},
+            {"warning", Val::kWarning},
+        });
+    return FromV8WithLookup(isolate, val, Lookup, out);
   }
 };
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "base/containers/contains.h"
+#include "base/containers/fixed_flat_map.h"
 #include "base/containers/id_map.h"
 #include "base/files/file_util.h"
 #include "base/json/json_reader.h"
@@ -202,26 +203,15 @@ struct Converter<printing::mojom::MarginType> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      printing::mojom::MarginType* out) {
-    std::string type;
-    if (ConvertFromV8(isolate, val, &type)) {
-      if (type == "default") {
-        *out = printing::mojom::MarginType::kDefaultMargins;
-        return true;
-      }
-      if (type == "none") {
-        *out = printing::mojom::MarginType::kNoMargins;
-        return true;
-      }
-      if (type == "printableArea") {
-        *out = printing::mojom::MarginType::kPrintableAreaMargins;
-        return true;
-      }
-      if (type == "custom") {
-        *out = printing::mojom::MarginType::kCustomMargins;
-        return true;
-      }
-    }
-    return false;
+    using Val = printing::mojom::MarginType;
+    static constexpr auto Lookup =
+        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+            {"custom", Val::kCustomMargins},
+            {"default", Val::kDefaultMargins},
+            {"none", Val::kNoMargins},
+            {"printableArea", Val::kPrintableAreaMargins},
+        });
+    return FromV8WithLookup(isolate, val, Lookup, out);
   }
 };
 
@@ -230,22 +220,14 @@ struct Converter<printing::mojom::DuplexMode> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      printing::mojom::DuplexMode* out) {
-    std::string mode;
-    if (ConvertFromV8(isolate, val, &mode)) {
-      if (mode == "simplex") {
-        *out = printing::mojom::DuplexMode::kSimplex;
-        return true;
-      }
-      if (mode == "longEdge") {
-        *out = printing::mojom::DuplexMode::kLongEdge;
-        return true;
-      }
-      if (mode == "shortEdge") {
-        *out = printing::mojom::DuplexMode::kShortEdge;
-        return true;
-      }
-    }
-    return false;
+    using Val = printing::mojom::DuplexMode;
+    static constexpr auto Lookup =
+        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+            {"longEdge", Val::kLongEdge},
+            {"shortEdge", Val::kShortEdge},
+            {"simplex", Val::kSimplex},
+        });
+    return FromV8WithLookup(isolate, val, Lookup, out);
   }
 };
 
@@ -285,20 +267,14 @@ struct Converter<content::SavePageType> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      content::SavePageType* out) {
-    std::string save_type;
-    if (!ConvertFromV8(isolate, val, &save_type))
-      return false;
-    save_type = base::ToLowerASCII(save_type);
-    if (save_type == "htmlonly") {
-      *out = content::SAVE_PAGE_TYPE_AS_ONLY_HTML;
-    } else if (save_type == "htmlcomplete") {
-      *out = content::SAVE_PAGE_TYPE_AS_COMPLETE_HTML;
-    } else if (save_type == "mhtml") {
-      *out = content::SAVE_PAGE_TYPE_AS_MHTML;
-    } else {
-      return false;
-    }
-    return true;
+    using Val = content::SavePageType;
+    static constexpr auto Lookup =
+        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+            {"htmlcomplete", Val::SAVE_PAGE_TYPE_AS_COMPLETE_HTML},
+            {"htmlonly", Val::SAVE_PAGE_TYPE_AS_ONLY_HTML},
+            {"mhtml", Val::SAVE_PAGE_TYPE_AS_MHTML},
+        });
+    return FromV8WithLowerLookup(isoalte, val, Lookuop, out);
   }
 };
 
@@ -336,22 +312,15 @@ struct Converter<electron::api::WebContents::Type> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      electron::api::WebContents::Type* out) {
-    using Type = electron::api::WebContents::Type;
-    std::string type;
-    if (!ConvertFromV8(isolate, val, &type))
-      return false;
-    if (type == "backgroundPage") {
-      *out = Type::kBackgroundPage;
-    } else if (type == "browserView") {
-      *out = Type::kBrowserView;
-    } else if (type == "webview") {
-      *out = Type::kWebView;
-    } else if (type == "offscreen") {
-      *out = Type::kOffScreen;
-    } else {
-      return false;
-    }
-    return true;
+    using Val = electron::api::WebContents::Type;
+    static constexpr auto Lookup =
+        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+            {"backgroundPage", Val::kBackgroundPage},
+            {"browserView", Val::kBrowserView},
+            {"offscreen", Val::kOffScreen},
+            {"webview", Val::kWebView},
+        });
+    return FromV8WithLookup(isolate, val, Lookup, out);
   }
 };
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -274,7 +274,7 @@ struct Converter<content::SavePageType> {
             {"htmlonly", Val::SAVE_PAGE_TYPE_AS_ONLY_HTML},
             {"mhtml", Val::SAVE_PAGE_TYPE_AS_MHTML},
         });
-    return FromV8WithLowerLookup(isoalte, val, Lookuop, out);
+    return FromV8WithLowerLookup(isolate, val, Lookup, out);
   }
 };
 

--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <utility>
 
+#include "base/containers/fixed_flat_map.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/stringprintf.h"
 #include "base/uuid.h"
@@ -45,22 +46,17 @@ struct Converter<electron::ProtocolType> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      electron::ProtocolType* out) {
-    std::string type;
-    if (!ConvertFromV8(isolate, val, &type))
-      return false;
-    if (type == "buffer")
-      *out = electron::ProtocolType::kBuffer;
-    else if (type == "string")
-      *out = electron::ProtocolType::kString;
-    else if (type == "file")
-      *out = electron::ProtocolType::kFile;
-    else if (type == "http")
-      *out = electron::ProtocolType::kHttp;
-    else if (type == "stream")
-      *out = electron::ProtocolType::kStream;
-    else  // note "free" is internal type, not allowed to be passed from user
-      return false;
-    return true;
+    using Val = electron::ProtocolType;
+    static constexpr auto Lookup =
+        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+            // note "free" is internal type, not allowed to be passed from user
+            {"buffer", Val::kBuffer},
+            {"file", Val::kFile},
+            {"http", Val::kHttp},
+            {"stream", Val::kStream},
+            {"string", Val::kString},
+        });
+    return FromV8WithLookup(isolate, val, Lookup, out);
   }
 };
 

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "base/command_line.h"
+#include "base/containers/fixed_flat_map.h"
 #include "base/memory/ptr_util.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
@@ -43,20 +44,15 @@ struct Converter<blink::mojom::AutoplayPolicy> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      blink::mojom::AutoplayPolicy* out) {
-    std::string policy_str;
-    if (!ConvertFromV8(isolate, val, &policy_str))
-      return false;
-    if (policy_str == "no-user-gesture-required") {
-      *out = blink::mojom::AutoplayPolicy::kNoUserGestureRequired;
-      return true;
-    } else if (policy_str == "user-gesture-required") {
-      *out = blink::mojom::AutoplayPolicy::kUserGestureRequired;
-      return true;
-    } else if (policy_str == "document-user-activation-required") {
-      *out = blink::mojom::AutoplayPolicy::kDocumentUserActivationRequired;
-      return true;
-    }
-    return false;
+    using Val = blink::mojom::AutoplayPolicy;
+    static constexpr auto Lookup =
+        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+            {"document-user-activation-required",
+             Val::kDocumentUserActivationRequired},
+            {"no-user-gesture-required", Val::kNoUserGestureRequired},
+            {"user-gesture-required", Val::kUserGestureRequired},
+        });
+    return FromV8WithLookup(isolate, val, Lookup, out);
   }
 };
 
@@ -65,23 +61,15 @@ struct Converter<blink::mojom::V8CacheOptions> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      blink::mojom::V8CacheOptions* out) {
-    std::string v8_cache_options;
-    if (!ConvertFromV8(isolate, val, &v8_cache_options))
-      return false;
-    if (v8_cache_options == "none") {
-      *out = blink::mojom::V8CacheOptions::kNone;
-      return true;
-    } else if (v8_cache_options == "code") {
-      *out = blink::mojom::V8CacheOptions::kCode;
-      return true;
-    } else if (v8_cache_options == "bypassHeatCheck") {
-      *out = blink::mojom::V8CacheOptions::kCodeWithoutHeatCheck;
-      return true;
-    } else if (v8_cache_options == "bypassHeatCheckAndEagerCompile") {
-      *out = blink::mojom::V8CacheOptions::kFullCodeWithoutHeatCheck;
-      return true;
-    }
-    return false;
+    using Val = blink::mojom::V8CacheOptions;
+    static constexpr auto Lookup =
+        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+            {"bypassHeatCheck", Val::kCodeWithoutHeatCheck},
+            {"bypassHeatCheckAndEagerCompile", Val::kFullCodeWithoutHeatCheck},
+            {"code", Val::kCode},
+            {"none", Val::kNone},
+        });
+    return FromV8WithLookup(isolate, val, Lookup, out);
   }
 };
 

--- a/shell/common/gin_converters/content_converter.cc
+++ b/shell/common/gin_converters/content_converter.cc
@@ -6,6 +6,7 @@
 
 #include <string>
 
+#include "base/containers/fixed_flat_map.h"
 #include "content/public/browser/context_menu_params.h"
 #include "content/public/browser/native_web_keyboard_event.h"
 #include "content/public/browser/web_contents.h"
@@ -222,20 +223,14 @@ v8::Local<v8::Value> Converter<blink::PermissionType>::ToV8(
 bool Converter<content::StopFindAction>::FromV8(v8::Isolate* isolate,
                                                 v8::Local<v8::Value> val,
                                                 content::StopFindAction* out) {
-  std::string action;
-  if (!ConvertFromV8(isolate, val, &action))
-    return false;
-
-  if (action == "clearSelection")
-    *out = content::STOP_FIND_ACTION_CLEAR_SELECTION;
-  else if (action == "keepSelection")
-    *out = content::STOP_FIND_ACTION_KEEP_SELECTION;
-  else if (action == "activateSelection")
-    *out = content::STOP_FIND_ACTION_ACTIVATE_SELECTION;
-  else
-    return false;
-
-  return true;
+  using Val = content::StopFindAction;
+  static constexpr auto Lookup =
+      base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+          {"activateSelection", Val::STOP_FIND_ACTION_ACTIVATE_SELECTION},
+          {"clearSelection", Val::STOP_FIND_ACTION_CLEAR_SELECTION},
+          {"keepSelection", Val::STOP_FIND_ACTION_KEEP_SELECTION},
+      });
+  return FromV8WithLookup(isolate, val, Lookup, out);
 }
 
 // static

--- a/shell/common/keyboard_util.cc
+++ b/shell/common/keyboard_util.cc
@@ -4,6 +4,7 @@
 
 #include <string>
 
+#include "base/containers/fixed_flat_map.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "shell/common/keyboard_util.h"
@@ -14,304 +15,181 @@ namespace electron {
 
 namespace {
 
-// Return key code represented by |str|.
-ui::KeyboardCode KeyboardCodeFromKeyIdentifier(
-    base::StringPiece s,
-    absl::optional<char16_t>* shifted_char) {
-  std::string str = base::ToLowerASCII(s);
-  if (str == "ctrl" || str == "control") {
-    return ui::VKEY_CONTROL;
-  } else if (str == "super" || str == "cmd" || str == "command" ||
-             str == "meta") {
-    return ui::VKEY_COMMAND;
-  } else if (str == "commandorcontrol" || str == "cmdorctrl") {
+using CodeAndShiftedChar = std::pair<ui::KeyboardCode, absl::optional<char16_t>>;
+
+constexpr CodeAndShiftedChar KeyboardCodeFromKeyIdentifier(base::StringPiece str) {
 #if BUILDFLAG(IS_MAC)
-    return ui::VKEY_COMMAND;
+    constexpr auto CommandOrControl = ui::VKEY_COMMAND;
 #else
-    return ui::VKEY_CONTROL;
+    constexpr auto CommandOrControl = ui::VKEY_CONTROL;
 #endif
-  } else if (str == "alt" || str == "option") {
-    return ui::VKEY_MENU;
-  } else if (str == "shift") {
-    return ui::VKEY_SHIFT;
-  } else if (str == "altgr") {
-    return ui::VKEY_ALTGR;
-  } else if (str == "plus") {
-    shifted_char->emplace('+');
-    return ui::VKEY_OEM_PLUS;
-  } else if (str == "capslock") {
-    return ui::VKEY_CAPITAL;
-  } else if (str == "numlock") {
-    return ui::VKEY_NUMLOCK;
-  } else if (str == "scrolllock") {
-    return ui::VKEY_SCROLL;
-  } else if (str == "tab") {
-    return ui::VKEY_TAB;
-  } else if (str == "num0") {
-    return ui::VKEY_NUMPAD0;
-  } else if (str == "num1") {
-    return ui::VKEY_NUMPAD1;
-  } else if (str == "num2") {
-    return ui::VKEY_NUMPAD2;
-  } else if (str == "num3") {
-    return ui::VKEY_NUMPAD3;
-  } else if (str == "num4") {
-    return ui::VKEY_NUMPAD4;
-  } else if (str == "num5") {
-    return ui::VKEY_NUMPAD5;
-  } else if (str == "num6") {
-    return ui::VKEY_NUMPAD6;
-  } else if (str == "num7") {
-    return ui::VKEY_NUMPAD7;
-  } else if (str == "num8") {
-    return ui::VKEY_NUMPAD8;
-  } else if (str == "num9") {
-    return ui::VKEY_NUMPAD9;
-  } else if (str == "numadd") {
-    return ui::VKEY_ADD;
-  } else if (str == "nummult") {
-    return ui::VKEY_MULTIPLY;
-  } else if (str == "numdec") {
-    return ui::VKEY_DECIMAL;
-  } else if (str == "numsub") {
-    return ui::VKEY_SUBTRACT;
-  } else if (str == "numdiv") {
-    return ui::VKEY_DIVIDE;
-  } else if (str == "space") {
-    return ui::VKEY_SPACE;
-  } else if (str == "backspace") {
-    return ui::VKEY_BACK;
-  } else if (str == "delete") {
-    return ui::VKEY_DELETE;
-  } else if (str == "insert") {
-    return ui::VKEY_INSERT;
-  } else if (str == "enter" || str == "return") {
-    return ui::VKEY_RETURN;
-  } else if (str == "up") {
-    return ui::VKEY_UP;
-  } else if (str == "down") {
-    return ui::VKEY_DOWN;
-  } else if (str == "left") {
-    return ui::VKEY_LEFT;
-  } else if (str == "right") {
-    return ui::VKEY_RIGHT;
-  } else if (str == "home") {
-    return ui::VKEY_HOME;
-  } else if (str == "end") {
-    return ui::VKEY_END;
-  } else if (str == "pageup") {
-    return ui::VKEY_PRIOR;
-  } else if (str == "pagedown") {
-    return ui::VKEY_NEXT;
-  } else if (str == "esc" || str == "escape") {
-    return ui::VKEY_ESCAPE;
-  } else if (str == "volumemute") {
-    return ui::VKEY_VOLUME_MUTE;
-  } else if (str == "volumeup") {
-    return ui::VKEY_VOLUME_UP;
-  } else if (str == "volumedown") {
-    return ui::VKEY_VOLUME_DOWN;
-  } else if (str == "medianexttrack") {
-    return ui::VKEY_MEDIA_NEXT_TRACK;
-  } else if (str == "mediaprevioustrack") {
-    return ui::VKEY_MEDIA_PREV_TRACK;
-  } else if (str == "mediastop") {
-    return ui::VKEY_MEDIA_STOP;
-  } else if (str == "mediaplaypause") {
-    return ui::VKEY_MEDIA_PLAY_PAUSE;
-  } else if (str == "printscreen") {
-    return ui::VKEY_SNAPSHOT;
-  } else if (str.size() > 1 && str[0] == 'f') {
-    // F1 - F24.
-    int n;
-    if (base::StringToInt(str.c_str() + 1, &n) && n > 0 && n < 25) {
-      return static_cast<ui::KeyboardCode>(ui::VKEY_F1 + n - 1);
-    } else {
-      LOG(WARNING) << str << "is not available on keyboard";
-      return ui::VKEY_UNKNOWN;
-    }
-  } else {
-    if (str.size() > 2)
-      LOG(WARNING) << "Invalid accelerator token: " << str;
-    return ui::VKEY_UNKNOWN;
-  }
+
+    constexpr auto Lookup = base::MakeFixedFlatMapSorted<base::StringPiece, CodeAndShiftedChar>({
+      {"alt", {ui::VKEY_MENU, {}}},
+      {"altgr", {ui::VKEY_ALTGR, {}}},
+      {"backspace", {ui::VKEY_BACK, {}}},
+      {"capslock", {ui::VKEY_CAPITAL, {}}},
+      {"cmd", {ui::VKEY_COMMAND, {}}},
+      {"cmdorctrl", {CommandOrControl, {}}},
+      {"command", {ui::VKEY_COMMAND, {}}},
+      {"commandorcontrol", {CommandOrControl, {}}},
+      {"control", {ui::VKEY_CONTROL, {}}},
+      {"ctrl", {ui::VKEY_CONTROL, {}}},
+      {"delete", {ui::VKEY_DELETE, {}}},
+      {"down", {ui::VKEY_DOWN, {}}},
+      {"end", {ui::VKEY_END, {}}},
+      {"enter", {ui::VKEY_RETURN, {}}},
+      {"esc", {ui::VKEY_ESCAPE, {}}},
+      {"escape", {ui::VKEY_ESCAPE, {}}},
+      {"f1", {ui::VKEY_F1, {}}},
+      {"f10", {ui::VKEY_F10, {}}},
+      {"f11", {ui::VKEY_F11, {}}},
+      {"f12", {ui::VKEY_F12, {}}},
+      {"f13", {ui::VKEY_F13, {}}},
+      {"f14", {ui::VKEY_F14, {}}},
+      {"f15", {ui::VKEY_F15, {}}},
+      {"f16", {ui::VKEY_F16, {}}},
+      {"f17", {ui::VKEY_F17, {}}},
+      {"f18", {ui::VKEY_F18, {}}},
+      {"f19", {ui::VKEY_F19, {}}},
+      {"f2", {ui::VKEY_F2, {}}},
+      {"f20", {ui::VKEY_F20, {}}},
+      {"f21", {ui::VKEY_F21, {}}},
+      {"f22", {ui::VKEY_F22, {}}},
+      {"f23", {ui::VKEY_F23, {}}},
+      {"f24", {ui::VKEY_F24, {}}},
+      {"f3", {ui::VKEY_F3, {}}},
+      {"f4", {ui::VKEY_F4, {}}},
+      {"f5", {ui::VKEY_F5, {}}},
+      {"f6", {ui::VKEY_F6, {}}},
+      {"f7", {ui::VKEY_F7, {}}},
+      {"f8", {ui::VKEY_F8, {}}},
+      {"f9", {ui::VKEY_F9, {}}},
+      {"home", {ui::VKEY_HOME, {}}},
+      {"insert", {ui::VKEY_INSERT, {}}},
+      {"left", {ui::VKEY_LEFT, {}}},
+      {"medianexttrack", {ui::VKEY_MEDIA_NEXT_TRACK, {}}},
+      {"mediaplaypause", {ui::VKEY_MEDIA_PLAY_PAUSE, {}}},
+      {"mediaprevioustrack", {ui::VKEY_MEDIA_PREV_TRACK, {}}},
+      {"mediastop", {ui::VKEY_MEDIA_STOP, {}}},
+      {"meta", {ui::VKEY_COMMAND, {}}},
+      {"num0", {ui::VKEY_NUMPAD0, {}}},
+      {"num1", {ui::VKEY_NUMPAD1, {}}},
+      {"num2", {ui::VKEY_NUMPAD2, {}}},
+      {"num3", {ui::VKEY_NUMPAD3, {}}},
+      {"num4", {ui::VKEY_NUMPAD4, {}}},
+      {"num5", {ui::VKEY_NUMPAD5, {}}},
+      {"num6", {ui::VKEY_NUMPAD6, {}}},
+      {"num7", {ui::VKEY_NUMPAD7, {}}},
+      {"num8", {ui::VKEY_NUMPAD8, {}}},
+      {"num9", {ui::VKEY_NUMPAD9, {}}},
+      {"numadd", {ui::VKEY_ADD, {}}},
+      {"numdec", {ui::VKEY_DECIMAL, {}}},
+      {"numdiv", {ui::VKEY_DIVIDE, {}}},
+      {"numlock", {ui::VKEY_NUMLOCK, {}}},
+      {"nummult", {ui::VKEY_MULTIPLY, {}}},
+      {"numsub", {ui::VKEY_SUBTRACT, {}}},
+      {"option", {ui::VKEY_MENU, {}}},
+      {"pagedown", {ui::VKEY_NEXT, {}}},
+      {"pageup", {ui::VKEY_PRIOR, {}}},
+      {"plus", {ui::VKEY_OEM_PLUS, '+'}},
+      {"printscreen", {ui::VKEY_SNAPSHOT, {}}},
+      {"return", {ui::VKEY_RETURN, {}}},
+      {"right", {ui::VKEY_RIGHT, {}}},
+      {"scrolllock", {ui::VKEY_SCROLL, {}}},
+      {"shift", {ui::VKEY_SHIFT, {}}},
+      {"space", {ui::VKEY_SPACE, {}}},
+      {"super", {ui::VKEY_COMMAND, {}}},
+      {"tab", {ui::VKEY_TAB, {}}},
+      {"up", {ui::VKEY_UP, {}}},
+      {"volumedown", {ui::VKEY_VOLUME_DOWN, {}}},
+      {"volumemute", {ui::VKEY_VOLUME_MUTE, {}}},
+      {"volumeup", {ui::VKEY_VOLUME_UP, {}}},
+    });
+
+    if (auto* const iter = Lookup.find(str); iter != Lookup.end())
+      return iter->second;
+
+    return {ui::VKEY_UNKNOWN, {}};
 }
 
-constexpr ui::KeyboardCode KeyboardCodeFromCharCode(char16_t c, bool* shifted) {
-  c = base::ToLowerASCII(c);
-  *shifted = false;
+constexpr CodeAndShiftedChar KeyboardCodeFromCharCode(char16_t c) {
   switch (c) {
-    case 0x08:
-      return ui::VKEY_BACK;
-    case 0x7F:
-      return ui::VKEY_DELETE;
-    case 0x09:
-      return ui::VKEY_TAB;
-    case 0x0D:
-      return ui::VKEY_RETURN;
-    case 0x1B:
-      return ui::VKEY_ESCAPE;
-    case ' ':
-      return ui::VKEY_SPACE;
-    case 'a':
-      return ui::VKEY_A;
-    case 'b':
-      return ui::VKEY_B;
-    case 'c':
-      return ui::VKEY_C;
-    case 'd':
-      return ui::VKEY_D;
-    case 'e':
-      return ui::VKEY_E;
-    case 'f':
-      return ui::VKEY_F;
-    case 'g':
-      return ui::VKEY_G;
-    case 'h':
-      return ui::VKEY_H;
-    case 'i':
-      return ui::VKEY_I;
-    case 'j':
-      return ui::VKEY_J;
-    case 'k':
-      return ui::VKEY_K;
-    case 'l':
-      return ui::VKEY_L;
-    case 'm':
-      return ui::VKEY_M;
-    case 'n':
-      return ui::VKEY_N;
-    case 'o':
-      return ui::VKEY_O;
-    case 'p':
-      return ui::VKEY_P;
-    case 'q':
-      return ui::VKEY_Q;
-    case 'r':
-      return ui::VKEY_R;
-    case 's':
-      return ui::VKEY_S;
-    case 't':
-      return ui::VKEY_T;
-    case 'u':
-      return ui::VKEY_U;
-    case 'v':
-      return ui::VKEY_V;
-    case 'w':
-      return ui::VKEY_W;
-    case 'x':
-      return ui::VKEY_X;
-    case 'y':
-      return ui::VKEY_Y;
-    case 'z':
-      return ui::VKEY_Z;
-    case ')':
-      *shifted = true;
-      [[fallthrough]];
-    case '0':
-      return ui::VKEY_0;
-    case '!':
-      *shifted = true;
-      [[fallthrough]];
-    case '1':
-      return ui::VKEY_1;
-    case '@':
-      *shifted = true;
-      [[fallthrough]];
-    case '2':
-      return ui::VKEY_2;
-    case '#':
-      *shifted = true;
-      [[fallthrough]];
-    case '3':
-      return ui::VKEY_3;
-    case '$':
-      *shifted = true;
-      [[fallthrough]];
-    case '4':
-      return ui::VKEY_4;
-    case '%':
-      *shifted = true;
-      [[fallthrough]];
-    case '5':
-      return ui::VKEY_5;
-    case '^':
-      *shifted = true;
-      [[fallthrough]];
-    case '6':
-      return ui::VKEY_6;
-    case '&':
-      *shifted = true;
-      [[fallthrough]];
-    case '7':
-      return ui::VKEY_7;
-    case '*':
-      *shifted = true;
-      [[fallthrough]];
-    case '8':
-      return ui::VKEY_8;
-    case '(':
-      *shifted = true;
-      [[fallthrough]];
-    case '9':
-      return ui::VKEY_9;
-    case ':':
-      *shifted = true;
-      [[fallthrough]];
-    case ';':
-      return ui::VKEY_OEM_1;
-    case '+':
-      *shifted = true;
-      [[fallthrough]];
-    case '=':
-      return ui::VKEY_OEM_PLUS;
-    case '<':
-      *shifted = true;
-      [[fallthrough]];
-    case ',':
-      return ui::VKEY_OEM_COMMA;
-    case '_':
-      *shifted = true;
-      [[fallthrough]];
-    case '-':
-      return ui::VKEY_OEM_MINUS;
-    case '>':
-      *shifted = true;
-      [[fallthrough]];
-    case '.':
-      return ui::VKEY_OEM_PERIOD;
-    case '?':
-      *shifted = true;
-      [[fallthrough]];
-    case '/':
-      return ui::VKEY_OEM_2;
-    case '~':
-      *shifted = true;
-      [[fallthrough]];
-    case '`':
-      return ui::VKEY_OEM_3;
-    case '{':
-      *shifted = true;
-      [[fallthrough]];
-    case '[':
-      return ui::VKEY_OEM_4;
-    case '|':
-      *shifted = true;
-      [[fallthrough]];
-    case '\\':
-      return ui::VKEY_OEM_5;
-    case '}':
-      *shifted = true;
-      [[fallthrough]];
-    case ']':
-      return ui::VKEY_OEM_6;
-    case '"':
-      *shifted = true;
-      [[fallthrough]];
-    case '\'':
-      return ui::VKEY_OEM_7;
-    default:
-      return ui::VKEY_UNKNOWN;
+    case ' ': return {ui::VKEY_SPACE, {}};
+    case '!': return {ui::VKEY_1, '!'};
+    case '"': return {ui::VKEY_OEM_7, '"'};
+    case '#': return {ui::VKEY_3, '#'};
+    case '$': return {ui::VKEY_4, '$'};
+    case '%': return {ui::VKEY_5, '%'};
+    case '&': return {ui::VKEY_7, '&'};
+    case '(': return {ui::VKEY_9, '('};
+    case ')': return {ui::VKEY_0, ')'};
+    case '*': return {ui::VKEY_8, '*'};
+    case '+': return {ui::VKEY_OEM_PLUS, '+'};
+    case ',': return {ui::VKEY_OEM_COMMA, {}};
+    case '-': return {ui::VKEY_OEM_MINUS, {}};
+    case '.': return {ui::VKEY_OEM_PERIOD, {}};
+    case '/': return {ui::VKEY_OEM_2, {}};
+    case '0': return {ui::VKEY_0, {}};
+    case '1': return {ui::VKEY_1, {}};
+    case '2': return {ui::VKEY_2, {}};
+    case '3': return {ui::VKEY_3, {}};
+    case '4': return {ui::VKEY_4, {}};
+    case '5': return {ui::VKEY_5, {}};
+    case '6': return {ui::VKEY_6, {}};
+    case '7': return {ui::VKEY_7, {}};
+    case '8': return {ui::VKEY_8, {}};
+    case '9': return {ui::VKEY_9, {}};
+    case ':': return {ui::VKEY_OEM_1, ':'};
+    case ';': return {ui::VKEY_OEM_1, {}};
+    case '<': return {ui::VKEY_OEM_COMMA, '<'};
+    case '=': return {ui::VKEY_OEM_PLUS, {}};
+    case '>': return {ui::VKEY_OEM_PERIOD, '>'};
+    case '?': return {ui::VKEY_OEM_2, '?'};
+    case '@': return {ui::VKEY_2, '@'};
+    case '[': return {ui::VKEY_OEM_4, {}};
+    case '\'': return {ui::VKEY_OEM_7, {}};
+    case '\\': return {ui::VKEY_OEM_5, {}};
+    case ']': return {ui::VKEY_OEM_6, {}};
+    case '^': return {ui::VKEY_6, '^'};
+    case '_': return {ui::VKEY_OEM_MINUS, '_'};
+    case '`': return {ui::VKEY_OEM_3, {}};
+    case 'a': return {ui::VKEY_A, {}};
+    case 'b': return {ui::VKEY_B, {}};
+    case 'c': return {ui::VKEY_C, {}};
+    case 'd': return {ui::VKEY_D, {}};
+    case 'e': return {ui::VKEY_E, {}};
+    case 'f': return {ui::VKEY_F, {}};
+    case 'g': return {ui::VKEY_G, {}};
+    case 'h': return {ui::VKEY_H, {}};
+    case 'i': return {ui::VKEY_I, {}};
+    case 'j': return {ui::VKEY_J, {}};
+    case 'k': return {ui::VKEY_K, {}};
+    case 'l': return {ui::VKEY_L, {}};
+    case 'm': return {ui::VKEY_M, {}};
+    case 'n': return {ui::VKEY_N, {}};
+    case 'o': return {ui::VKEY_O, {}};
+    case 'p': return {ui::VKEY_P, {}};
+    case 'q': return {ui::VKEY_Q, {}};
+    case 'r': return {ui::VKEY_R, {}};
+    case 's': return {ui::VKEY_S, {}};
+    case 't': return {ui::VKEY_T, {}};
+    case 'u': return {ui::VKEY_U, {}};
+    case 'v': return {ui::VKEY_V, {}};
+    case 'w': return {ui::VKEY_W, {}};
+    case 'x': return {ui::VKEY_X, {}};
+    case 'y': return {ui::VKEY_Y, {}};
+    case 'z': return {ui::VKEY_Z, {}};
+    case '{': return {ui::VKEY_OEM_4, '{'};
+    case '|': return {ui::VKEY_OEM_5, '|'};
+    case '}': return {ui::VKEY_OEM_6, '}'};
+    case '~': return {ui::VKEY_OEM_3, '~'};
+    case 0x08: return {ui::VKEY_BACK, {}};
+    case 0x09: return {ui::VKEY_TAB, {}};
+    case 0x0D: return {ui::VKEY_RETURN, {}};
+    case 0x1B: return {ui::VKEY_ESCAPE, {}};
+    case 0x7F: return {ui::VKEY_DELETE, {}};
+    default: return {ui::VKEY_UNKNOWN, {}};
   }
 }
 
@@ -319,15 +197,15 @@ constexpr ui::KeyboardCode KeyboardCodeFromCharCode(char16_t c, bool* shifted) {
 
 ui::KeyboardCode KeyboardCodeFromStr(base::StringPiece str,
                                      absl::optional<char16_t>* shifted_char) {
-  if (str.size() == 1) {
-    bool shifted = false;
-    auto ret = KeyboardCodeFromCharCode(str[0], &shifted);
-    if (shifted)
-      shifted_char->emplace(str[0]);
-    return ret;
-  } else {
-    return KeyboardCodeFromKeyIdentifier(str, shifted_char);
-  }
+  auto const [code, shifted] = str.size() == 1
+    ? KeyboardCodeFromCharCode(base::ToLowerASCII(str[0]))
+    : KeyboardCodeFromKeyIdentifier(base::ToLowerASCII(str));
+
+  if (code == ui::VKEY_UNKNOWN)
+    LOG(WARNING) << "Invalid accelerator token: " << str;
+
+  *shifted_char = shifted;
+  return code;
 }
 
 }  // namespace electron

--- a/shell/common/keyboard_util.cc
+++ b/shell/common/keyboard_util.cc
@@ -15,181 +15,259 @@ namespace electron {
 
 namespace {
 
-using CodeAndShiftedChar = std::pair<ui::KeyboardCode, absl::optional<char16_t>>;
+using CodeAndShiftedChar =
+    std::pair<ui::KeyboardCode, absl::optional<char16_t>>;
 
-constexpr CodeAndShiftedChar KeyboardCodeFromKeyIdentifier(base::StringPiece str) {
+constexpr CodeAndShiftedChar KeyboardCodeFromKeyIdentifier(
+    base::StringPiece str) {
 #if BUILDFLAG(IS_MAC)
-    constexpr auto CommandOrControl = ui::VKEY_COMMAND;
+  constexpr auto CommandOrControl = ui::VKEY_COMMAND;
 #else
-    constexpr auto CommandOrControl = ui::VKEY_CONTROL;
+  constexpr auto CommandOrControl = ui::VKEY_CONTROL;
 #endif
 
-    constexpr auto Lookup = base::MakeFixedFlatMapSorted<base::StringPiece, CodeAndShiftedChar>({
-      {"alt", {ui::VKEY_MENU, {}}},
-      {"altgr", {ui::VKEY_ALTGR, {}}},
-      {"backspace", {ui::VKEY_BACK, {}}},
-      {"capslock", {ui::VKEY_CAPITAL, {}}},
-      {"cmd", {ui::VKEY_COMMAND, {}}},
-      {"cmdorctrl", {CommandOrControl, {}}},
-      {"command", {ui::VKEY_COMMAND, {}}},
-      {"commandorcontrol", {CommandOrControl, {}}},
-      {"control", {ui::VKEY_CONTROL, {}}},
-      {"ctrl", {ui::VKEY_CONTROL, {}}},
-      {"delete", {ui::VKEY_DELETE, {}}},
-      {"down", {ui::VKEY_DOWN, {}}},
-      {"end", {ui::VKEY_END, {}}},
-      {"enter", {ui::VKEY_RETURN, {}}},
-      {"esc", {ui::VKEY_ESCAPE, {}}},
-      {"escape", {ui::VKEY_ESCAPE, {}}},
-      {"f1", {ui::VKEY_F1, {}}},
-      {"f10", {ui::VKEY_F10, {}}},
-      {"f11", {ui::VKEY_F11, {}}},
-      {"f12", {ui::VKEY_F12, {}}},
-      {"f13", {ui::VKEY_F13, {}}},
-      {"f14", {ui::VKEY_F14, {}}},
-      {"f15", {ui::VKEY_F15, {}}},
-      {"f16", {ui::VKEY_F16, {}}},
-      {"f17", {ui::VKEY_F17, {}}},
-      {"f18", {ui::VKEY_F18, {}}},
-      {"f19", {ui::VKEY_F19, {}}},
-      {"f2", {ui::VKEY_F2, {}}},
-      {"f20", {ui::VKEY_F20, {}}},
-      {"f21", {ui::VKEY_F21, {}}},
-      {"f22", {ui::VKEY_F22, {}}},
-      {"f23", {ui::VKEY_F23, {}}},
-      {"f24", {ui::VKEY_F24, {}}},
-      {"f3", {ui::VKEY_F3, {}}},
-      {"f4", {ui::VKEY_F4, {}}},
-      {"f5", {ui::VKEY_F5, {}}},
-      {"f6", {ui::VKEY_F6, {}}},
-      {"f7", {ui::VKEY_F7, {}}},
-      {"f8", {ui::VKEY_F8, {}}},
-      {"f9", {ui::VKEY_F9, {}}},
-      {"home", {ui::VKEY_HOME, {}}},
-      {"insert", {ui::VKEY_INSERT, {}}},
-      {"left", {ui::VKEY_LEFT, {}}},
-      {"medianexttrack", {ui::VKEY_MEDIA_NEXT_TRACK, {}}},
-      {"mediaplaypause", {ui::VKEY_MEDIA_PLAY_PAUSE, {}}},
-      {"mediaprevioustrack", {ui::VKEY_MEDIA_PREV_TRACK, {}}},
-      {"mediastop", {ui::VKEY_MEDIA_STOP, {}}},
-      {"meta", {ui::VKEY_COMMAND, {}}},
-      {"num0", {ui::VKEY_NUMPAD0, {}}},
-      {"num1", {ui::VKEY_NUMPAD1, {}}},
-      {"num2", {ui::VKEY_NUMPAD2, {}}},
-      {"num3", {ui::VKEY_NUMPAD3, {}}},
-      {"num4", {ui::VKEY_NUMPAD4, {}}},
-      {"num5", {ui::VKEY_NUMPAD5, {}}},
-      {"num6", {ui::VKEY_NUMPAD6, {}}},
-      {"num7", {ui::VKEY_NUMPAD7, {}}},
-      {"num8", {ui::VKEY_NUMPAD8, {}}},
-      {"num9", {ui::VKEY_NUMPAD9, {}}},
-      {"numadd", {ui::VKEY_ADD, {}}},
-      {"numdec", {ui::VKEY_DECIMAL, {}}},
-      {"numdiv", {ui::VKEY_DIVIDE, {}}},
-      {"numlock", {ui::VKEY_NUMLOCK, {}}},
-      {"nummult", {ui::VKEY_MULTIPLY, {}}},
-      {"numsub", {ui::VKEY_SUBTRACT, {}}},
-      {"option", {ui::VKEY_MENU, {}}},
-      {"pagedown", {ui::VKEY_NEXT, {}}},
-      {"pageup", {ui::VKEY_PRIOR, {}}},
-      {"plus", {ui::VKEY_OEM_PLUS, '+'}},
-      {"printscreen", {ui::VKEY_SNAPSHOT, {}}},
-      {"return", {ui::VKEY_RETURN, {}}},
-      {"right", {ui::VKEY_RIGHT, {}}},
-      {"scrolllock", {ui::VKEY_SCROLL, {}}},
-      {"shift", {ui::VKEY_SHIFT, {}}},
-      {"space", {ui::VKEY_SPACE, {}}},
-      {"super", {ui::VKEY_COMMAND, {}}},
-      {"tab", {ui::VKEY_TAB, {}}},
-      {"up", {ui::VKEY_UP, {}}},
-      {"volumedown", {ui::VKEY_VOLUME_DOWN, {}}},
-      {"volumemute", {ui::VKEY_VOLUME_MUTE, {}}},
-      {"volumeup", {ui::VKEY_VOLUME_UP, {}}},
-    });
+  constexpr auto Lookup =
+      base::MakeFixedFlatMapSorted<base::StringPiece, CodeAndShiftedChar>({
+          {"alt", {ui::VKEY_MENU, {}}},
+          {"altgr", {ui::VKEY_ALTGR, {}}},
+          {"backspace", {ui::VKEY_BACK, {}}},
+          {"capslock", {ui::VKEY_CAPITAL, {}}},
+          {"cmd", {ui::VKEY_COMMAND, {}}},
+          {"cmdorctrl", {CommandOrControl, {}}},
+          {"command", {ui::VKEY_COMMAND, {}}},
+          {"commandorcontrol", {CommandOrControl, {}}},
+          {"control", {ui::VKEY_CONTROL, {}}},
+          {"ctrl", {ui::VKEY_CONTROL, {}}},
+          {"delete", {ui::VKEY_DELETE, {}}},
+          {"down", {ui::VKEY_DOWN, {}}},
+          {"end", {ui::VKEY_END, {}}},
+          {"enter", {ui::VKEY_RETURN, {}}},
+          {"esc", {ui::VKEY_ESCAPE, {}}},
+          {"escape", {ui::VKEY_ESCAPE, {}}},
+          {"f1", {ui::VKEY_F1, {}}},
+          {"f10", {ui::VKEY_F10, {}}},
+          {"f11", {ui::VKEY_F11, {}}},
+          {"f12", {ui::VKEY_F12, {}}},
+          {"f13", {ui::VKEY_F13, {}}},
+          {"f14", {ui::VKEY_F14, {}}},
+          {"f15", {ui::VKEY_F15, {}}},
+          {"f16", {ui::VKEY_F16, {}}},
+          {"f17", {ui::VKEY_F17, {}}},
+          {"f18", {ui::VKEY_F18, {}}},
+          {"f19", {ui::VKEY_F19, {}}},
+          {"f2", {ui::VKEY_F2, {}}},
+          {"f20", {ui::VKEY_F20, {}}},
+          {"f21", {ui::VKEY_F21, {}}},
+          {"f22", {ui::VKEY_F22, {}}},
+          {"f23", {ui::VKEY_F23, {}}},
+          {"f24", {ui::VKEY_F24, {}}},
+          {"f3", {ui::VKEY_F3, {}}},
+          {"f4", {ui::VKEY_F4, {}}},
+          {"f5", {ui::VKEY_F5, {}}},
+          {"f6", {ui::VKEY_F6, {}}},
+          {"f7", {ui::VKEY_F7, {}}},
+          {"f8", {ui::VKEY_F8, {}}},
+          {"f9", {ui::VKEY_F9, {}}},
+          {"home", {ui::VKEY_HOME, {}}},
+          {"insert", {ui::VKEY_INSERT, {}}},
+          {"left", {ui::VKEY_LEFT, {}}},
+          {"medianexttrack", {ui::VKEY_MEDIA_NEXT_TRACK, {}}},
+          {"mediaplaypause", {ui::VKEY_MEDIA_PLAY_PAUSE, {}}},
+          {"mediaprevioustrack", {ui::VKEY_MEDIA_PREV_TRACK, {}}},
+          {"mediastop", {ui::VKEY_MEDIA_STOP, {}}},
+          {"meta", {ui::VKEY_COMMAND, {}}},
+          {"num0", {ui::VKEY_NUMPAD0, {}}},
+          {"num1", {ui::VKEY_NUMPAD1, {}}},
+          {"num2", {ui::VKEY_NUMPAD2, {}}},
+          {"num3", {ui::VKEY_NUMPAD3, {}}},
+          {"num4", {ui::VKEY_NUMPAD4, {}}},
+          {"num5", {ui::VKEY_NUMPAD5, {}}},
+          {"num6", {ui::VKEY_NUMPAD6, {}}},
+          {"num7", {ui::VKEY_NUMPAD7, {}}},
+          {"num8", {ui::VKEY_NUMPAD8, {}}},
+          {"num9", {ui::VKEY_NUMPAD9, {}}},
+          {"numadd", {ui::VKEY_ADD, {}}},
+          {"numdec", {ui::VKEY_DECIMAL, {}}},
+          {"numdiv", {ui::VKEY_DIVIDE, {}}},
+          {"numlock", {ui::VKEY_NUMLOCK, {}}},
+          {"nummult", {ui::VKEY_MULTIPLY, {}}},
+          {"numsub", {ui::VKEY_SUBTRACT, {}}},
+          {"option", {ui::VKEY_MENU, {}}},
+          {"pagedown", {ui::VKEY_NEXT, {}}},
+          {"pageup", {ui::VKEY_PRIOR, {}}},
+          {"plus", {ui::VKEY_OEM_PLUS, '+'}},
+          {"printscreen", {ui::VKEY_SNAPSHOT, {}}},
+          {"return", {ui::VKEY_RETURN, {}}},
+          {"right", {ui::VKEY_RIGHT, {}}},
+          {"scrolllock", {ui::VKEY_SCROLL, {}}},
+          {"shift", {ui::VKEY_SHIFT, {}}},
+          {"space", {ui::VKEY_SPACE, {}}},
+          {"super", {ui::VKEY_COMMAND, {}}},
+          {"tab", {ui::VKEY_TAB, {}}},
+          {"up", {ui::VKEY_UP, {}}},
+          {"volumedown", {ui::VKEY_VOLUME_DOWN, {}}},
+          {"volumemute", {ui::VKEY_VOLUME_MUTE, {}}},
+          {"volumeup", {ui::VKEY_VOLUME_UP, {}}},
+      });
 
-    if (auto* const iter = Lookup.find(str); iter != Lookup.end())
-      return iter->second;
+  if (auto* const iter = Lookup.find(str); iter != Lookup.end())
+    return iter->second;
 
-    return {ui::VKEY_UNKNOWN, {}};
+  return {ui::VKEY_UNKNOWN, {}};
 }
 
 constexpr CodeAndShiftedChar KeyboardCodeFromCharCode(char16_t c) {
   switch (c) {
-    case ' ': return {ui::VKEY_SPACE, {}};
-    case '!': return {ui::VKEY_1, '!'};
-    case '"': return {ui::VKEY_OEM_7, '"'};
-    case '#': return {ui::VKEY_3, '#'};
-    case '$': return {ui::VKEY_4, '$'};
-    case '%': return {ui::VKEY_5, '%'};
-    case '&': return {ui::VKEY_7, '&'};
-    case '(': return {ui::VKEY_9, '('};
-    case ')': return {ui::VKEY_0, ')'};
-    case '*': return {ui::VKEY_8, '*'};
-    case '+': return {ui::VKEY_OEM_PLUS, '+'};
-    case ',': return {ui::VKEY_OEM_COMMA, {}};
-    case '-': return {ui::VKEY_OEM_MINUS, {}};
-    case '.': return {ui::VKEY_OEM_PERIOD, {}};
-    case '/': return {ui::VKEY_OEM_2, {}};
-    case '0': return {ui::VKEY_0, {}};
-    case '1': return {ui::VKEY_1, {}};
-    case '2': return {ui::VKEY_2, {}};
-    case '3': return {ui::VKEY_3, {}};
-    case '4': return {ui::VKEY_4, {}};
-    case '5': return {ui::VKEY_5, {}};
-    case '6': return {ui::VKEY_6, {}};
-    case '7': return {ui::VKEY_7, {}};
-    case '8': return {ui::VKEY_8, {}};
-    case '9': return {ui::VKEY_9, {}};
-    case ':': return {ui::VKEY_OEM_1, ':'};
-    case ';': return {ui::VKEY_OEM_1, {}};
-    case '<': return {ui::VKEY_OEM_COMMA, '<'};
-    case '=': return {ui::VKEY_OEM_PLUS, {}};
-    case '>': return {ui::VKEY_OEM_PERIOD, '>'};
-    case '?': return {ui::VKEY_OEM_2, '?'};
-    case '@': return {ui::VKEY_2, '@'};
-    case '[': return {ui::VKEY_OEM_4, {}};
-    case '\'': return {ui::VKEY_OEM_7, {}};
-    case '\\': return {ui::VKEY_OEM_5, {}};
-    case ']': return {ui::VKEY_OEM_6, {}};
-    case '^': return {ui::VKEY_6, '^'};
-    case '_': return {ui::VKEY_OEM_MINUS, '_'};
-    case '`': return {ui::VKEY_OEM_3, {}};
-    case 'a': return {ui::VKEY_A, {}};
-    case 'b': return {ui::VKEY_B, {}};
-    case 'c': return {ui::VKEY_C, {}};
-    case 'd': return {ui::VKEY_D, {}};
-    case 'e': return {ui::VKEY_E, {}};
-    case 'f': return {ui::VKEY_F, {}};
-    case 'g': return {ui::VKEY_G, {}};
-    case 'h': return {ui::VKEY_H, {}};
-    case 'i': return {ui::VKEY_I, {}};
-    case 'j': return {ui::VKEY_J, {}};
-    case 'k': return {ui::VKEY_K, {}};
-    case 'l': return {ui::VKEY_L, {}};
-    case 'm': return {ui::VKEY_M, {}};
-    case 'n': return {ui::VKEY_N, {}};
-    case 'o': return {ui::VKEY_O, {}};
-    case 'p': return {ui::VKEY_P, {}};
-    case 'q': return {ui::VKEY_Q, {}};
-    case 'r': return {ui::VKEY_R, {}};
-    case 's': return {ui::VKEY_S, {}};
-    case 't': return {ui::VKEY_T, {}};
-    case 'u': return {ui::VKEY_U, {}};
-    case 'v': return {ui::VKEY_V, {}};
-    case 'w': return {ui::VKEY_W, {}};
-    case 'x': return {ui::VKEY_X, {}};
-    case 'y': return {ui::VKEY_Y, {}};
-    case 'z': return {ui::VKEY_Z, {}};
-    case '{': return {ui::VKEY_OEM_4, '{'};
-    case '|': return {ui::VKEY_OEM_5, '|'};
-    case '}': return {ui::VKEY_OEM_6, '}'};
-    case '~': return {ui::VKEY_OEM_3, '~'};
-    case 0x08: return {ui::VKEY_BACK, {}};
-    case 0x09: return {ui::VKEY_TAB, {}};
-    case 0x0D: return {ui::VKEY_RETURN, {}};
-    case 0x1B: return {ui::VKEY_ESCAPE, {}};
-    case 0x7F: return {ui::VKEY_DELETE, {}};
-    default: return {ui::VKEY_UNKNOWN, {}};
+    case ' ':
+      return {ui::VKEY_SPACE, {}};
+    case '!':
+      return {ui::VKEY_1, '!'};
+    case '"':
+      return {ui::VKEY_OEM_7, '"'};
+    case '#':
+      return {ui::VKEY_3, '#'};
+    case '$':
+      return {ui::VKEY_4, '$'};
+    case '%':
+      return {ui::VKEY_5, '%'};
+    case '&':
+      return {ui::VKEY_7, '&'};
+    case '(':
+      return {ui::VKEY_9, '('};
+    case ')':
+      return {ui::VKEY_0, ')'};
+    case '*':
+      return {ui::VKEY_8, '*'};
+    case '+':
+      return {ui::VKEY_OEM_PLUS, '+'};
+    case ',':
+      return {ui::VKEY_OEM_COMMA, {}};
+    case '-':
+      return {ui::VKEY_OEM_MINUS, {}};
+    case '.':
+      return {ui::VKEY_OEM_PERIOD, {}};
+    case '/':
+      return {ui::VKEY_OEM_2, {}};
+    case '0':
+      return {ui::VKEY_0, {}};
+    case '1':
+      return {ui::VKEY_1, {}};
+    case '2':
+      return {ui::VKEY_2, {}};
+    case '3':
+      return {ui::VKEY_3, {}};
+    case '4':
+      return {ui::VKEY_4, {}};
+    case '5':
+      return {ui::VKEY_5, {}};
+    case '6':
+      return {ui::VKEY_6, {}};
+    case '7':
+      return {ui::VKEY_7, {}};
+    case '8':
+      return {ui::VKEY_8, {}};
+    case '9':
+      return {ui::VKEY_9, {}};
+    case ':':
+      return {ui::VKEY_OEM_1, ':'};
+    case ';':
+      return {ui::VKEY_OEM_1, {}};
+    case '<':
+      return {ui::VKEY_OEM_COMMA, '<'};
+    case '=':
+      return {ui::VKEY_OEM_PLUS, {}};
+    case '>':
+      return {ui::VKEY_OEM_PERIOD, '>'};
+    case '?':
+      return {ui::VKEY_OEM_2, '?'};
+    case '@':
+      return {ui::VKEY_2, '@'};
+    case '[':
+      return {ui::VKEY_OEM_4, {}};
+    case '\'':
+      return {ui::VKEY_OEM_7, {}};
+    case '\\':
+      return {ui::VKEY_OEM_5, {}};
+    case ']':
+      return {ui::VKEY_OEM_6, {}};
+    case '^':
+      return {ui::VKEY_6, '^'};
+    case '_':
+      return {ui::VKEY_OEM_MINUS, '_'};
+    case '`':
+      return {ui::VKEY_OEM_3, {}};
+    case 'a':
+      return {ui::VKEY_A, {}};
+    case 'b':
+      return {ui::VKEY_B, {}};
+    case 'c':
+      return {ui::VKEY_C, {}};
+    case 'd':
+      return {ui::VKEY_D, {}};
+    case 'e':
+      return {ui::VKEY_E, {}};
+    case 'f':
+      return {ui::VKEY_F, {}};
+    case 'g':
+      return {ui::VKEY_G, {}};
+    case 'h':
+      return {ui::VKEY_H, {}};
+    case 'i':
+      return {ui::VKEY_I, {}};
+    case 'j':
+      return {ui::VKEY_J, {}};
+    case 'k':
+      return {ui::VKEY_K, {}};
+    case 'l':
+      return {ui::VKEY_L, {}};
+    case 'm':
+      return {ui::VKEY_M, {}};
+    case 'n':
+      return {ui::VKEY_N, {}};
+    case 'o':
+      return {ui::VKEY_O, {}};
+    case 'p':
+      return {ui::VKEY_P, {}};
+    case 'q':
+      return {ui::VKEY_Q, {}};
+    case 'r':
+      return {ui::VKEY_R, {}};
+    case 's':
+      return {ui::VKEY_S, {}};
+    case 't':
+      return {ui::VKEY_T, {}};
+    case 'u':
+      return {ui::VKEY_U, {}};
+    case 'v':
+      return {ui::VKEY_V, {}};
+    case 'w':
+      return {ui::VKEY_W, {}};
+    case 'x':
+      return {ui::VKEY_X, {}};
+    case 'y':
+      return {ui::VKEY_Y, {}};
+    case 'z':
+      return {ui::VKEY_Z, {}};
+    case '{':
+      return {ui::VKEY_OEM_4, '{'};
+    case '|':
+      return {ui::VKEY_OEM_5, '|'};
+    case '}':
+      return {ui::VKEY_OEM_6, '}'};
+    case '~':
+      return {ui::VKEY_OEM_3, '~'};
+    case 0x08:
+      return {ui::VKEY_BACK, {}};
+    case 0x09:
+      return {ui::VKEY_TAB, {}};
+    case 0x0D:
+      return {ui::VKEY_RETURN, {}};
+    case 0x1B:
+      return {ui::VKEY_ESCAPE, {}};
+    case 0x7F:
+      return {ui::VKEY_DELETE, {}};
+    default:
+      return {ui::VKEY_UNKNOWN, {}};
   }
 }
 
@@ -197,9 +275,9 @@ constexpr CodeAndShiftedChar KeyboardCodeFromCharCode(char16_t c) {
 
 ui::KeyboardCode KeyboardCodeFromStr(base::StringPiece str,
                                      absl::optional<char16_t>* shifted_char) {
-  auto const [code, shifted] = str.size() == 1
-    ? KeyboardCodeFromCharCode(base::ToLowerASCII(str[0]))
-    : KeyboardCodeFromKeyIdentifier(base::ToLowerASCII(str));
+  auto const [code, shifted] =
+      str.size() == 1 ? KeyboardCodeFromCharCode(base::ToLowerASCII(str[0]))
+                      : KeyboardCodeFromKeyIdentifier(base::ToLowerASCII(str));
 
   if (code == ui::VKEY_UNKNOWN)
     LOG(WARNING) << "Invalid accelerator token: " << str;

--- a/shell/common/keyboard_util.cc
+++ b/shell/common/keyboard_util.cc
@@ -16,7 +16,7 @@ namespace {
 
 // Return key code represented by |str|.
 ui::KeyboardCode KeyboardCodeFromKeyIdentifier(
-    const std::string& s,
+    base::StringPiece s,
     absl::optional<char16_t>* shifted_char) {
   std::string str = base::ToLowerASCII(s);
   if (str == "ctrl" || str == "control") {
@@ -137,9 +137,7 @@ ui::KeyboardCode KeyboardCodeFromKeyIdentifier(
   }
 }
 
-}  // namespace
-
-ui::KeyboardCode KeyboardCodeFromCharCode(char16_t c, bool* shifted) {
+constexpr ui::KeyboardCode KeyboardCodeFromCharCode(char16_t c, bool* shifted) {
   c = base::ToLowerASCII(c);
   *shifted = false;
   switch (c) {
@@ -317,7 +315,9 @@ ui::KeyboardCode KeyboardCodeFromCharCode(char16_t c, bool* shifted) {
   }
 }
 
-ui::KeyboardCode KeyboardCodeFromStr(const std::string& str,
+}  // namespace
+
+ui::KeyboardCode KeyboardCodeFromStr(base::StringPiece str,
                                      absl::optional<char16_t>* shifted_char) {
   if (str.size() == 1) {
     bool shifted = false;

--- a/shell/common/keyboard_util.h
+++ b/shell/common/keyboard_util.h
@@ -5,21 +5,17 @@
 #ifndef ELECTRON_SHELL_COMMON_KEYBOARD_UTIL_H_
 #define ELECTRON_SHELL_COMMON_KEYBOARD_UTIL_H_
 
-#include <string>
+#include <base/strings/string_piece.h>
 
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/events/keycodes/keyboard_codes.h"
 
 namespace electron {
 
-// Return key code of the char, and also determine whether the SHIFT key is
-// pressed.
-ui::KeyboardCode KeyboardCodeFromCharCode(char16_t c, bool* shifted);
-
 // Return key code of the |str|, if the original key is a shifted character,
 // for example + and /, set it in |shifted_char|.
 // pressed.
-ui::KeyboardCode KeyboardCodeFromStr(const std::string& str,
+ui::KeyboardCode KeyboardCodeFromStr(base::StringPiece str,
                                      absl::optional<char16_t>* shifted_char);
 
 }  // namespace electron

--- a/shell/common/keyboard_util.h
+++ b/shell/common/keyboard_util.h
@@ -5,8 +5,7 @@
 #ifndef ELECTRON_SHELL_COMMON_KEYBOARD_UTIL_H_
 #define ELECTRON_SHELL_COMMON_KEYBOARD_UTIL_H_
 
-#include <base/strings/string_piece.h>
-
+#include "base/strings/string_piece.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/events/keycodes/keyboard_codes.h"
 


### PR DESCRIPTION
#### Description of Change

A followup to #38818, use `gin::FromV8WithLookup()` for more key-value lookup converters.

Feedback / review welcomed from anyone; also CC @miniak as 38818's reviewer.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none