### PR TITLE
chore: re-enable node/no-deprecated-api linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,8 +20,7 @@
     "prefer-const": ["error", {
       "destructuring": "all"
     }],
-    "standard/no-callback-literal": "off",
-    "node/no-deprecated-api": "off"
+    "standard/no-callback-literal": "off"
   },
   "parserOptions": {
     "ecmaVersion": 6,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,6 @@
     "semi": ["error", "always"],
     "no-var": "error",
     "no-unused-vars": "off",
-    "no-global-assign": "off",
     "guard-for-in": "error",
     "@typescript-eslint/no-unused-vars": ["error", {
       "vars": "all",

--- a/lib/browser/api/net-client-request.ts
+++ b/lib/browser/api/net-client-request.ts
@@ -209,6 +209,7 @@ type ExtraURLLoaderOptions = {
    allowNonHttpProtocols: boolean;
 }
 function parseOptions (optionsIn: ClientRequestConstructorOptions | string): NodeJS.CreateURLLoaderOptions & ExtraURLLoaderOptions {
+  // eslint-disable-next-line node/no-deprecated-api
   const options: any = typeof optionsIn === 'string' ? url.parse(optionsIn) : { ...optionsIn };
 
   let urlStr: string = options.url;
@@ -241,6 +242,7 @@ function parseOptions (optionsIn: ClientRequestConstructorOptions | string): Nod
       // an invalid request.
       throw new TypeError('Request path contains unescaped characters');
     }
+    // eslint-disable-next-line node/no-deprecated-api
     const pathObj = url.parse(options.path || '/');
     urlObj.pathname = pathObj.pathname;
     urlObj.search = pathObj.search;

--- a/lib/browser/devtools.ts
+++ b/lib/browser/devtools.ts
@@ -1,6 +1,5 @@
 import { dialog, Menu } from 'electron/main';
 import * as fs from 'fs';
-import * as url from 'url';
 
 import { ipcMainInternal } from '@electron/internal/browser/ipc-main-internal';
 import * as ipcMainUtils from '@electron/internal/browser/ipc-main-internal-utils';
@@ -49,7 +48,7 @@ const getEditMenuItems = function (): Electron.MenuItemConstructorOptions[] {
 };
 
 const isChromeDevTools = function (pageURL: string) {
-  const { protocol } = url.parse(pageURL);
+  const { protocol } = new URL(pageURL);
   return protocol === 'devtools:';
 };
 


### PR DESCRIPTION
Fix errors reported by `node/no-deprecated-api` or suppress in-place

Notes: none