### PR TITLE
refactor: use `Date.now()` instead of `+new Date()`

### DIFF
--- a/spec/api-content-tracing-spec.ts
+++ b/spec/api-content-tracing-spec.ts
@@ -128,10 +128,10 @@ ifdescribe(!(['arm', 'arm64', 'ia32'].includes(process.arch)))('contentTracing',
         traceOptions: 'record-until-full'
       });
       {
-        const start = +new Date();
+        const start = Date.now();
         let n = 0;
         const f = () => {};
-        while (+new Date() - start < 200 || n < 500) {
+        while (Date.now() - start < 200 || n < 500) {
           await setTimeout(0);
           f();
           n++;

--- a/spec/api-crash-reporter-spec.ts
+++ b/spec/api-crash-reporter-spec.ts
@@ -426,7 +426,7 @@ ifdescribe(!isLinuxOnArm && !process.mas && !process.env.DISABLE_CRASH_REPORTER_
       );
       expect(firstReport).to.not.be.null();
       expect(firstReport.date).to.be.an.instanceOf(Date);
-      expect((+new Date()) - (+firstReport.date)).to.be.lessThan(30000);
+      expect((Date.now()) - (+firstReport.date)).to.be.lessThan(30000);
     });
   });
 

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -69,7 +69,7 @@ describe('session module', () => {
       const name = '1';
       const value = '1';
 
-      await cookies.set({ url, name, value, expirationDate: (+new Date()) / 1000 + 120 });
+      await cookies.set({ url, name, value, expirationDate: (Date.now()) / 1000 + 120 });
       const c = (await cookies.get({ url }))[0];
       expect(c.name).to.equal(name);
       expect(c.value).to.equal(value);
@@ -121,7 +121,7 @@ describe('session module', () => {
       const name = '1';
       const value = '1';
 
-      await cookies.set({ url, name, value, expirationDate: (+new Date()) / 1000 + 120 });
+      await cookies.set({ url, name, value, expirationDate: (Date.now()) / 1000 + 120 });
       const cs = await cookies.get({ domain: '127.0.0.1' });
       expect(cs.some(c => c.name === name && c.value === value)).to.equal(true);
     });
@@ -150,7 +150,7 @@ describe('session module', () => {
       const { cookies } = session.defaultSession;
       const name = 'DidOverwrite';
       for (const value of ['No', 'Yes']) {
-        await cookies.set({ url, name, value, expirationDate: (+new Date()) / 1000 + 120 });
+        await cookies.set({ url, name, value, expirationDate: (Date.now()) / 1000 + 120 });
         const list = await cookies.get({ url });
 
         expect(list.some(cookie => cookie.name === name && cookie.value === value)).to.equal(true);
@@ -162,7 +162,7 @@ describe('session module', () => {
       const name = '2';
       const value = '2';
 
-      await cookies.set({ url, name, value, expirationDate: (+new Date()) / 1000 + 120 });
+      await cookies.set({ url, name, value, expirationDate: (Date.now()) / 1000 + 120 });
       await cookies.remove(url, name);
       const list = await cookies.get({ url });
 
@@ -177,7 +177,7 @@ describe('session module', () => {
       const name = 'custom';
       const value = '1';
 
-      await cookies.set({ url, name, value, expirationDate: (+new Date()) / 1000 + 120 });
+      await cookies.set({ url, name, value, expirationDate: (Date.now()) / 1000 + 120 });
       const list = await cookies.get({ url });
 
       expect(list).to.have.lengthOf(1);
@@ -192,7 +192,7 @@ describe('session module', () => {
       const value = 'bar';
 
       const a = once(cookies, 'changed');
-      await cookies.set({ url, name, value, expirationDate: (+new Date()) / 1000 + 120 });
+      await cookies.set({ url, name, value, expirationDate: (Date.now()) / 1000 + 120 });
       const [, setEventCookie, setEventCause, setEventRemoved] = await a;
 
       const b = once(cookies, 'changed');

--- a/spec/lib/spec-helpers.ts
+++ b/spec/lib/spec-helpers.ts
@@ -141,11 +141,11 @@ export async function repeatedly<T> (
   opts?: { until?: (x: T) => boolean, timeLimit?: number }
 ) {
   const { until = (x: T) => !!x, timeLimit = 10000 } = opts ?? {};
-  const begin = +new Date();
+  const begin = Date.now();
   while (true) {
     const ret = await fn();
     if (until(ret)) { return ret; }
-    if (+new Date() - begin > timeLimit) { throw new Error(`repeatedly timed out (limit=${timeLimit})`); }
+    if (Date.now() - begin > timeLimit) { throw new Error(`repeatedly timed out (limit=${timeLimit})`); }
   }
 }
 


### PR DESCRIPTION
Identified by https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-date-now.md
Using `Date.now();` is more readable than `+new Date();`

Notes: none