### PR TITLE
chore: add missing content::WebContentsDelegate section

### DIFF
--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -694,6 +694,7 @@ class WebContents : public ExclusiveAccessContext,
   bool CanUserExitFullscreen() const override;
   bool IsExclusiveAccessBubbleDisplayed() const override;
 
+  // content::WebContentsDelegate
   bool IsFullscreenForTabOrPending(const content::WebContents* source) override;
   content::FullscreenState GetFullscreenState(
       const content::WebContents* web_contents) const override;


### PR DESCRIPTION
Backport of #38133.

See that PR for details.

No manual changes; I guess trop was just having a bad day

Notes: none

