### PR TITLE
fix: `navigator.connection` not working as intended

### DIFF
--- a/shell/browser/browser_process_impl.cc
+++ b/shell/browser/browser_process_impl.cc
@@ -25,6 +25,8 @@
 #include "components/proxy_config/proxy_config_dictionary.h"
 #include "components/proxy_config/proxy_config_pref_names.h"
 #include "content/public/browser/child_process_security_policy.h"
+#include "content/public/browser/network_quality_observer_factory.h"
+#include "content/public/browser/network_service_instance.h"
 #include "content/public/common/content_switches.h"
 #include "electron/fuses.h"
 #include "extensions/common/constants.h"
@@ -123,6 +125,10 @@ void BrowserProcessImpl::PreCreateThreads() {
   // this can be created on first use.
   if (!SystemNetworkContextManager::GetInstance())
     SystemNetworkContextManager::CreateInstance(local_state_.get());
+}
+
+void BrowserProcessImpl::PreMainMessageLoopRun() {
+  CreateNetworkQualityObserver();
 }
 
 void BrowserProcessImpl::PostMainMessageLoopRun() {
@@ -327,4 +333,19 @@ device::GeolocationManager* BrowserProcessImpl::geolocation_manager() {
 void BrowserProcessImpl::SetGeolocationManager(
     std::unique_ptr<device::GeolocationManager> geolocation_manager) {
   geolocation_manager_ = std::move(geolocation_manager);
+}
+
+network::NetworkQualityTracker* BrowserProcessImpl::GetNetworkQualityTracker() {
+  if (!network_quality_tracker_) {
+    network_quality_tracker_ = std::make_unique<network::NetworkQualityTracker>(
+        base::BindRepeating(&content::GetNetworkService));
+  }
+  return network_quality_tracker_.get();
+}
+
+void BrowserProcessImpl::CreateNetworkQualityObserver() {
+  DCHECK(!network_quality_observer_);
+  network_quality_observer_ =
+      content::CreateNetworkQualityObserver(GetNetworkQualityTracker());
+  DCHECK(network_quality_observer_);
 }

--- a/shell/browser/browser_process_impl.h
+++ b/shell/browser/browser_process_impl.h
@@ -18,6 +18,7 @@
 #include "components/prefs/pref_service.h"
 #include "components/prefs/value_map_pref_store.h"
 #include "printing/buildflags/buildflags.h"
+#include "services/network/public/cpp/network_quality_tracker.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "shell/browser/net/system_network_context_manager.h"
 
@@ -44,6 +45,7 @@ class BrowserProcessImpl : public BrowserProcess {
   BuildState* GetBuildState() override;
   void PostEarlyInitialization();
   void PreCreateThreads();
+  void PreMainMessageLoopRun();
   void PostDestroyThreads() {}
   void PostMainMessageLoopRun();
 
@@ -110,6 +112,9 @@ class BrowserProcessImpl : public BrowserProcess {
       std::unique_ptr<device::GeolocationManager> geolocation_manager) override;
 
  private:
+  void CreateNetworkQualityObserver();
+  network::NetworkQualityTracker* GetNetworkQualityTracker();
+
 #if BUILDFLAG(ENABLE_PRINTING)
   std::unique_ptr<printing::PrintJobManager> print_job_manager_;
 #endif
@@ -117,6 +122,11 @@ class BrowserProcessImpl : public BrowserProcess {
   std::unique_ptr<device::GeolocationManager> geolocation_manager_;
   std::string locale_;
   std::string system_locale_;
+
+  std::unique_ptr<network::NetworkQualityTracker> network_quality_tracker_;
+  std::unique_ptr<
+      network::NetworkQualityTracker::RTTAndThroughputEstimatesObserver>
+      network_quality_observer_;
 };
 
 #endif  // ELECTRON_SHELL_BROWSER_BROWSER_PROCESS_IMPL_H_

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -524,6 +524,8 @@ int ElectronBrowserMainParts::PreMainMessageLoopRun() {
   // Notify observers that main thread message loop was initialized.
   Browser::Get()->PreMainMessageLoopRun();
 
+  fake_browser_process_->PreMainMessageLoopRun();
+
   return GetExitCode();
 }
 

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -1971,6 +1971,30 @@ describe('chromium features', () => {
     });
   });
 
+  // https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation
+  describe('navigator.connection', () => {
+    it('returns the correct value', async () => {
+      const w = new BrowserWindow({ show: false });
+
+      w.webContents.session.enableNetworkEmulation({
+        latency: 500,
+        downloadThroughput: 6400,
+        uploadThroughput: 6400
+      });
+
+      await w.loadURL(`file://${fixturesPath}/pages/blank.html`);
+      const rtt = await w.webContents.executeJavaScript('navigator.connection.rtt');
+      expect(rtt).to.be.a('number');
+
+      const downlink = await w.webContents.executeJavaScript('navigator.connection.downlink');
+      expect(downlink).to.be.a('number');
+
+      const effectiveTypes = ['slow-2g', '2g', '3g', '4g'];
+      const effectiveType = await w.webContents.executeJavaScript('navigator.connection.effectiveType');
+      expect(effectiveTypes).to.include(effectiveType);
+    });
+  });
+
   describe('navigator.userAgentData', () => {
     // These tests are done on an http server because navigator.userAgentData
     // requires a secure context.


### PR DESCRIPTION
Backport of #38491.

See that PR for details.

No interesting changes relative to 38491. Manual intervention was required because of minor code shear from #38301.

Notes: Fixed an issue where `navigator.connection` returned incorrect data.

CC @codebytere 