### PR TITLE
fix: child window may have opener removed

### DIFF
--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -63,7 +63,7 @@ void ElectronRenderFrameObserver::DidClearWindowObject() {
   // Check DidInstallConditionalFeatures below for the background.
   auto* web_frame =
       static_cast<blink::WebLocalFrameImpl*>(render_frame_->GetWebFrame());
-  if (has_delayed_node_initialization_ && web_frame->Opener() &&
+  if (has_delayed_node_initialization_ &&
       !web_frame->IsOnInitialEmptyDocument()) {
     v8::Isolate* isolate = blink::MainThreadIsolate();
     v8::HandleScope handle_scope(isolate);

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -1150,6 +1150,23 @@ describe('chromium features', () => {
       expect(eventData).to.equal('size: 350 450');
     });
 
+    it('loads preload script after setting opener to null', async () => {
+      const w = new BrowserWindow({ show: false });
+      w.webContents.setWindowOpenHandler(() => ({
+        action: 'allow',
+        overrideBrowserWindowOptions: {
+          webPreferences: {
+            preload: path.join(fixturesPath, 'module', 'preload.js')
+          }
+        }
+      }));
+      w.loadURL('about:blank');
+      w.webContents.executeJavaScript('window.child = window.open(); child.opener = null');
+      const [, { webContents }] = await once(app, 'browser-window-created');
+      const [,, message] = await once(webContents, 'console-message');
+      expect(message).to.equal('{"require":"function","module":"undefined","process":"object","Buffer":"function"}');
+    });
+
     it('disables the <webview> tag when it is disabled on the parent window', async () => {
       const windowUrl = url.pathToFileURL(path.join(fixturesPath, 'pages', 'window-opener-no-webview-tag.html'));
       windowUrl.searchParams.set('p', `${fixturesPath}/pages/window-opener-webview.html`);


### PR DESCRIPTION
#### Description of Change

When handling node integration in child windows opened by `window.open`, the code assumed the child window's web frame must have a `opener`, which is not correct since the `opener` may be set to null.

Close https://github.com/electron/electron/issues/38844.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix `preload` script may not run in some child windows opened by `window.open`.