### PR TITLE
test: use process.getSystemVersion() for macOS version check

### DIFF
--- a/spec/api-native-theme-spec.ts
+++ b/spec/api-native-theme-spec.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { nativeTheme, systemPreferences, BrowserWindow, ipcMain } from 'electron/main';
 import { once } from 'node:events';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import * as semver from 'semver';
 import { setTimeout } from 'node:timers/promises';
@@ -60,7 +59,7 @@ describe('nativeTheme module', () => {
       expect(called).to.equal(false);
     });
 
-    ifdescribe(process.platform === 'darwin' && semver.gte(os.release(), '18.0.0'))('on macOS 10.14', () => {
+    ifdescribe(process.platform === 'darwin' && semver.gte(process.getSystemVersion(), '10.14.0'))('on macOS 10.14', () => {
       it('should update appLevelAppearance when set', () => {
         nativeTheme.themeSource = 'dark';
         expect(systemPreferences.appLevelAppearance).to.equal('dark');


### PR DESCRIPTION
It's more convenient than using the kernel version via `os.release()`

Notes: none