### PR TITLE
fix: filter exceptions passed to blink message handler

### DIFF
--- a/shell/renderer/electron_renderer_client.h
+++ b/shell/renderer/electron_renderer_client.h
@@ -36,6 +36,7 @@ class ElectronRendererClient : public RendererClientBase {
 
  private:
   // content::ContentRendererClient:
+  void RenderThreadStarted() override;
   void RenderFrameCreated(content::RenderFrame*) override;
   void RunScriptsAtDocumentStart(content::RenderFrame* render_frame) override;
   void RunScriptsAtDocumentEnd(content::RenderFrame* render_frame) override;


### PR DESCRIPTION
#### Description of Change

This is a partial fix for https://github.com/electron/electron/issues/37404.

Blink installs a global V8 message handler to print exceptions to devtools, which will crash when seeing an exception from a foreign context. Since we can not prevent Node from using a non-blink context (from `vm` module, or from native modules, or from Node's internal code), we should add a wrapper to prevent blink from accessing foreign contexts in the message handler.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix crash when throwing exception from context created by Node.js `vm` module.