### PR TITLE
docs: document e27 breaking change of dropping macOS 10.13, 10.14

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -12,6 +12,15 @@ This document uses the following convention to categorize breaking changes:
 * **Deprecated:** An API was marked as deprecated. The API will continue to function, but will emit a deprecation warning, and will be removed in a future release.
 * **Removed:** An API or feature was removed, and is no longer supported by Electron.
 
+## Planned Breaking API Changes (27.0)
+
+### Removed: macOS 10.13 / 10.14 support
+
+macOS 10.13 (High Sierra) and macOS 10.14 (Mojave) are no longer supported by [Chromium](https://chromium-review.googlesource.com/c/chromium/src/+/4629466).
+
+Older versions of Electron will continue to run on these operating systems, but macOS 10.15 (Catalina)
+or later will be required to run Electron v27.0.0 and higher.
+
 ## Planned Breaking API Changes (25.0)
 
 ### Deprecated: `protocol.{register,intercept}{Buffer,String,Stream,File,Http}Protocol`


### PR DESCRIPTION
#### Description of Change

macOS 10.13 (High Sierra) and macOS 10.14 (Mojave) are no longer supported by Chromium as of [this commit](https://chromium-review.googlesource.com/c/chromium/src/+/4629466) which will land in Electron in [this Chromium roll](https://github.com/electron/electron/pull/38891), so let's document that breaking change.

Copied from similar 10.11 / 10.12 notice in Electron 20 from #37286

CC @miniak, @electron/wg-releases 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes

Notes: none