### PR TITLE
refactor: replace Object.prototype.hasOwnProperty() with Object.hasOwn()

### DIFF
--- a/lib/browser/api/dialog.ts
+++ b/lib/browser/api/dialog.ts
@@ -59,7 +59,7 @@ const checkAppInitialized = function () {
 const setupOpenDialogProperties = (properties: (keyof typeof OpenFileDialogProperties)[]): number => {
   let dialogProperties = 0;
   for (const property of properties) {
-    if (Object.prototype.hasOwnProperty.call(OpenFileDialogProperties, property)) { dialogProperties |= OpenFileDialogProperties[property]; }
+    if (Object.hasOwn(OpenFileDialogProperties, property)) { dialogProperties |= OpenFileDialogProperties[property]; }
   }
   return dialogProperties;
 };
@@ -67,7 +67,7 @@ const setupOpenDialogProperties = (properties: (keyof typeof OpenFileDialogPrope
 const setupSaveDialogProperties = (properties: (keyof typeof SaveFileDialogProperties)[]): number => {
   let dialogProperties = 0;
   for (const property of properties) {
-    if (Object.prototype.hasOwnProperty.call(SaveFileDialogProperties, property)) { dialogProperties |= SaveFileDialogProperties[property]; }
+    if (Object.hasOwn(SaveFileDialogProperties, property)) { dialogProperties |= SaveFileDialogProperties[property]; }
   }
   return dialogProperties;
 };

--- a/lib/browser/api/menu-item-roles.ts
+++ b/lib/browser/api/menu-item-roles.ts
@@ -311,7 +311,7 @@ export const roleList: Record<RoleId, Role> = {
 };
 
 const hasRole = (role: keyof typeof roleList) => {
-  return Object.prototype.hasOwnProperty.call(roleList, role);
+  return Object.hasOwn(roleList, role);
 };
 
 const canExecuteRole = (role: keyof typeof roleList) => {
@@ -336,7 +336,7 @@ export function getCheckStatus (role: RoleId) {
 }
 
 export function shouldOverrideCheckStatus (role: RoleId) {
-  return hasRole(role) && Object.prototype.hasOwnProperty.call(roleList[role], 'checked');
+  return hasRole(role) && Object.hasOwn(roleList[role], 'checked');
 }
 
 export function getDefaultAccelerator (role: RoleId) {

--- a/lib/browser/api/menu.ts
+++ b/lib/browser/api/menu.ts
@@ -213,9 +213,7 @@ function areValidTemplateItems (template: (MenuItemConstructorOptions | MenuItem
   return template.every(item =>
     item != null &&
     typeof item === 'object' &&
-    (Object.prototype.hasOwnProperty.call(item, 'label') ||
-     Object.prototype.hasOwnProperty.call(item, 'role') ||
-     item.type === 'separator'));
+    (Object.hasOwn(item, 'label') || Object.hasOwn(item, 'role') || item.type === 'separator'));
 }
 
 function sortTemplate (template: (MenuItemConstructorOptions | MenuItem)[]) {

--- a/lib/browser/api/net-client-request.ts
+++ b/lib/browser/api/net-client-request.ts
@@ -270,7 +270,7 @@ function parseOptions (optionsIn: ClientRequestConstructorOptions | string): Nod
     origin: options.origin,
     referrerPolicy: options.referrerPolicy,
     cache: options.cache,
-    allowNonHttpProtocols: Object.prototype.hasOwnProperty.call(options, kAllowNonHttpProtocols)
+    allowNonHttpProtocols: Object.hasOwn(options, kAllowNonHttpProtocols)
   };
   const headers: Record<string, string | string[]> = options.headers || {};
   for (const [name, value] of Object.entries(headers)) {

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -66,7 +66,7 @@ function validateResponse (res: Response) {
 
   if (res.type === 'error') return true;
 
-  const exists = (key: string) => Object.prototype.hasOwnProperty.call(res, key);
+  const exists = (key: string) => Object.hasOwn(res, key);
 
   if (exists('status') && typeof res.status !== 'number') return false;
   if (exists('statusText') && typeof res.statusText !== 'string') return false;

--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -219,7 +219,7 @@ const warnAboutExperimentalFeatures = function (webPreferences?: Electron.WebPre
  */
 const warnAboutEnableBlinkFeatures = function (webPreferences?: Electron.WebPreferences) {
   if (!webPreferences ||
-    !Object.prototype.hasOwnProperty.call(webPreferences, 'enableBlinkFeatures') ||
+    !Object.hasOwn(webPreferences, 'enableBlinkFeatures') ||
     (webPreferences.enableBlinkFeatures != null && webPreferences.enableBlinkFeatures.length === 0)) {
     return;
   }

--- a/lib/sandboxed_renderer/init.ts
+++ b/lib/sandboxed_renderer/init.ts
@@ -21,7 +21,7 @@ v8Util.setHiddenValue(global, 'Buffer', Buffer);
 // The process object created by webpack is not an event emitter, fix it so
 // the API is more compatible with non-sandboxed renderers.
 for (const prop of Object.keys(EventEmitter.prototype) as (keyof typeof process)[]) {
-  if (Object.prototype.hasOwnProperty.call(process, prop)) {
+  if (Object.hasOwn(process, prop)) {
     delete process[prop];
   }
 }

--- a/spec/api-net-spec.ts
+++ b/spec/api-net-spec.ts
@@ -81,7 +81,7 @@ let routeFailure = false;
 
 respondNTimes.toRoutes = (routes: Record<string, http.RequestListener>, n: number) => {
   return respondNTimes((request, response) => {
-    if (Object.prototype.hasOwnProperty.call(routes, request.url || '')) {
+    if (Object.hasOwn(routes, request.url || '')) {
       (async () => {
         await Promise.resolve(routes[request.url || ''](request, response));
       })().catch((err) => {

--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -1312,7 +1312,6 @@ describe('asar package', function () {
       itremote('can promisify all fs functions', function () {
         const originalFs = require('original-fs');
         const util = require('node:util');
-        const { hasOwnProperty } = Object.prototype;
 
         for (const [propertyName, originalValue] of Object.entries(originalFs)) {
           // Some properties exist but have a value of `undefined` on some platforms.
@@ -1321,7 +1320,7 @@ describe('asar package', function () {
           // Also check for `null`s, `hasOwnProperty()` can't handle them.
           if (typeof originalValue === 'undefined' || originalValue === null) continue;
 
-          if (hasOwnProperty.call(originalValue, util.promisify.custom)) {
+          if (Object.hasOwn(originalValue, util.promisify.custom)) {
             expect(fs).to.have.own.property(propertyName)
               .that.has.own.property(util.promisify.custom);
           }

--- a/spec/lib/spec-helpers.ts
+++ b/spec/lib/spec-helpers.ts
@@ -55,7 +55,7 @@ class RemoteControlApp {
         res.on('data', chunk => { chunks.push(chunk); });
         res.on('end', () => {
           const ret = v8.deserialize(Buffer.concat(chunks));
-          if (Object.prototype.hasOwnProperty.call(ret, 'error')) {
+          if (Object.hasOwn(ret, 'error')) {
             reject(new Error(`remote error: ${ret.error}\n\nTriggered at:`));
           } else {
             resolve(ret.result);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
     "module": "commonjs",
     "target": "es2020",
     "lib": [
-      "es2019",
-      "esnext.weakref",
+      "es2022",
       "dom",
       "dom.iterable"
     ],


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn
> Note: Object.hasOwn() is intended as a replacement for [Object.prototype.hasOwnProperty()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty).

Notes: none