### PR TITLE
feat: `browserWindow.getBrowserViews()` to return sorted by z-index array

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1651,8 +1651,8 @@ Throws an error if `browserView` is not attached to `win`.
 
 #### `win.getBrowserViews()` _Experimental_
 
-Returns `BrowserView[]` - an array of all BrowserViews that have been attached
-with `addBrowserView` or `setBrowserView`.
+Returns `BrowserView[]` - a sorted by z-index array of all BrowserViews that have been attached
+with `addBrowserView` or `setBrowserView`. The top-most BrowserView is the last element of the array.
 
 **Note:** The BrowserView API is currently experimental and may change or be
 removed in future Electron releases.

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/api/electron_api_base_window.h"
 
+#include <algorithm>
 #include <string>
 #include <utility>
 #include <vector>
@@ -756,7 +757,7 @@ void BaseWindow::SetBrowserView(
 }
 
 void BaseWindow::AddBrowserView(gin::Handle<BrowserView> browser_view) {
-  if (!base::Contains(browser_views_, browser_view->ID())) {
+  if (!base::Contains(browser_views_, browser_view.ToV8())) {
     // If we're reparenting a BrowserView, ensure that it's detached from
     // its previous owner window.
     BaseWindow* owner_window = browser_view->owner_window();
@@ -770,34 +771,35 @@ void BaseWindow::AddBrowserView(gin::Handle<BrowserView> browser_view) {
     window_->AddBrowserView(browser_view->view());
     window_->AddDraggableRegionProvider(browser_view.get());
     browser_view->SetOwnerWindow(this);
-    browser_views_[browser_view->ID()].Reset(isolate(), browser_view.ToV8());
-    browser_views_ids_by_z_indexes_.push_back(browser_view->ID());
+    browser_views_.emplace_back().Reset(isolate(), browser_view.ToV8());
   }
 }
 
 void BaseWindow::RemoveBrowserView(gin::Handle<BrowserView> browser_view) {
-  auto iter = browser_views_.find(browser_view->ID());
+  auto iter = std::find(browser_views_.begin(), browser_views_.end(),
+                        browser_view.ToV8());
+
   if (iter != browser_views_.end()) {
     window_->RemoveBrowserView(browser_view->view());
     window_->RemoveDraggableRegionProvider(browser_view.get());
     browser_view->SetOwnerWindow(nullptr);
-    iter->second.Reset();
+    iter->Reset();
     browser_views_.erase(iter);
-    browser_views_ids_by_z_indexes_.remove(iter->first);
   }
 }
 
 void BaseWindow::SetTopBrowserView(gin::Handle<BrowserView> browser_view,
                                    gin_helper::Arguments* args) {
   BaseWindow* owner_window = browser_view->owner_window();
-  auto iter = browser_views_.find(browser_view->ID());
+  auto iter = std::find(browser_views_.begin(), browser_views_.end(),
+                        browser_view.ToV8());
   if (iter == browser_views_.end() || (owner_window && owner_window != this)) {
     args->ThrowError("Given BrowserView is not attached to the window");
     return;
   }
 
-  browser_views_ids_by_z_indexes_.remove(iter->first);
-  browser_views_ids_by_z_indexes_.push_back(iter->first);
+  browser_views_.erase(iter);
+  browser_views_.emplace_back().Reset(isolate(), browser_view.ToV8());
   window_->SetTopBrowserView(browser_view->view());
 }
 
@@ -1004,7 +1006,7 @@ v8::Local<v8::Value> BaseWindow::GetBrowserView(
     return v8::Null(isolate());
   } else if (browser_views_.size() == 1) {
     auto first_view = browser_views_.begin();
-    return v8::Local<v8::Value>::New(isolate(), (*first_view).second);
+    return v8::Local<v8::Value>::New(isolate(), *first_view);
   } else {
     args->ThrowError(
         "BrowserWindow have multiple BrowserViews, "
@@ -1016,9 +1018,8 @@ v8::Local<v8::Value> BaseWindow::GetBrowserView(
 std::vector<v8::Local<v8::Value>> BaseWindow::GetBrowserViews() const {
   std::vector<v8::Local<v8::Value>> ret;
 
-  for (auto const& browser_view_id : browser_views_ids_by_z_indexes_) {
-    ret.push_back(v8::Local<v8::Value>::New(
-        isolate(), browser_views_.at(browser_view_id)));
+  for (auto const& browser_view : browser_views_) {
+    ret.push_back(v8::Local<v8::Value>::New(isolate(), browser_view));
   }
 
   return ret;
@@ -1127,7 +1128,7 @@ void BaseWindow::ResetBrowserViews() {
   for (auto& item : browser_views_) {
     gin::Handle<BrowserView> browser_view;
     if (gin::ConvertFromV8(isolate(),
-                           v8::Local<v8::Value>::New(isolate(), item.second),
+                           v8::Local<v8::Value>::New(isolate(), item),
                            &browser_view) &&
         !browser_view.IsEmpty()) {
       // There's a chance that the BrowserView may have been reparented - only
@@ -1140,7 +1141,7 @@ void BaseWindow::ResetBrowserViews() {
       browser_view->SetOwnerWindow(nullptr);
     }
 
-    item.second.Reset();
+    item.Reset();
   }
 
   browser_views_.clear();

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -771,6 +771,7 @@ void BaseWindow::AddBrowserView(gin::Handle<BrowserView> browser_view) {
     window_->AddDraggableRegionProvider(browser_view.get());
     browser_view->SetOwnerWindow(this);
     browser_views_[browser_view->ID()].Reset(isolate(), browser_view.ToV8());
+    browser_views_z_indexes_.push_back(browser_view->ID());
   }
 }
 
@@ -782,6 +783,7 @@ void BaseWindow::RemoveBrowserView(gin::Handle<BrowserView> browser_view) {
     browser_view->SetOwnerWindow(nullptr);
     iter->second.Reset();
     browser_views_.erase(iter);
+    browser_views_z_indexes_.remove(iter->first);
   }
 }
 
@@ -794,6 +796,8 @@ void BaseWindow::SetTopBrowserView(gin::Handle<BrowserView> browser_view,
     return;
   }
 
+  browser_views_z_indexes_.remove(iter->first);
+  browser_views_z_indexes_.push_back(iter->first);
   window_->SetTopBrowserView(browser_view->view());
 }
 
@@ -1012,8 +1016,9 @@ v8::Local<v8::Value> BaseWindow::GetBrowserView(
 std::vector<v8::Local<v8::Value>> BaseWindow::GetBrowserViews() const {
   std::vector<v8::Local<v8::Value>> ret;
 
-  for (auto const& views_iter : browser_views_) {
-    ret.push_back(v8::Local<v8::Value>::New(isolate(), views_iter.second));
+  for (auto const& browser_view_id : browser_views_z_indexes_) {
+    ret.push_back(v8::Local<v8::Value>::New(
+        isolate(), browser_views_.at(browser_view_id)));
   }
 
   return ret;

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -771,7 +771,7 @@ void BaseWindow::AddBrowserView(gin::Handle<BrowserView> browser_view) {
     window_->AddDraggableRegionProvider(browser_view.get());
     browser_view->SetOwnerWindow(this);
     browser_views_[browser_view->ID()].Reset(isolate(), browser_view.ToV8());
-    browser_views_z_indexes_.push_back(browser_view->ID());
+    browser_views_ids_by_z_indexes_.push_back(browser_view->ID());
   }
 }
 
@@ -783,7 +783,7 @@ void BaseWindow::RemoveBrowserView(gin::Handle<BrowserView> browser_view) {
     browser_view->SetOwnerWindow(nullptr);
     iter->second.Reset();
     browser_views_.erase(iter);
-    browser_views_z_indexes_.remove(iter->first);
+    browser_views_ids_by_z_indexes_.remove(iter->first);
   }
 }
 
@@ -796,8 +796,8 @@ void BaseWindow::SetTopBrowserView(gin::Handle<BrowserView> browser_view,
     return;
   }
 
-  browser_views_z_indexes_.remove(iter->first);
-  browser_views_z_indexes_.push_back(iter->first);
+  browser_views_ids_by_z_indexes_.remove(iter->first);
+  browser_views_ids_by_z_indexes_.push_back(iter->first);
   window_->SetTopBrowserView(browser_view->view());
 }
 
@@ -1016,7 +1016,7 @@ v8::Local<v8::Value> BaseWindow::GetBrowserView(
 std::vector<v8::Local<v8::Value>> BaseWindow::GetBrowserViews() const {
   std::vector<v8::Local<v8::Value>> ret;
 
-  for (auto const& browser_view_id : browser_views_z_indexes_) {
+  for (auto const& browser_view_id : browser_views_ids_by_z_indexes_) {
     ret.push_back(v8::Local<v8::Value>::New(
         isolate(), browser_views_.at(browser_view_id)));
   }

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -275,6 +275,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
 #endif
 
   v8::Global<v8::Value> content_view_;
+  std::list<int32_t> browser_views_z_indexes_;
   std::map<int32_t, v8::Global<v8::Value>> browser_views_;
   v8::Global<v8::Value> menu_;
   v8::Global<v8::Value> parent_window_;

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_BROWSER_API_ELECTRON_API_BASE_WINDOW_H_
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_BASE_WINDOW_H_
 
-#include <list>
 #include <map>
 #include <memory>
 #include <string>
@@ -276,9 +275,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
 #endif
 
   v8::Global<v8::Value> content_view_;
-  // ids of attached browser views z-index sorted.
-  std::list<int32_t> browser_views_ids_by_z_indexes_;
-  std::map<int32_t, v8::Global<v8::Value>> browser_views_;
+  std::vector<v8::Global<v8::Value>> browser_views_;
   v8::Global<v8::Value> menu_;
   v8::Global<v8::Value> parent_window_;
   KeyWeakMap<int> child_windows_;

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_API_ELECTRON_API_BASE_WINDOW_H_
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_BASE_WINDOW_H_
 
+#include <list>
 #include <map>
 #include <memory>
 #include <string>
@@ -275,7 +276,8 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
 #endif
 
   v8::Global<v8::Value> content_view_;
-  std::list<int32_t> browser_views_z_indexes_;
+  // ids of attached browser views z-index sorted.
+  std::list<int32_t> browser_views_ids_by_z_indexes_;
   std::map<int32_t, v8::Global<v8::Value>> browser_views_;
   v8::Global<v8::Value> menu_;
   v8::Global<v8::Value> parent_window_;

--- a/spec/api-browser-view-spec.ts
+++ b/spec/api-browser-view-spec.ts
@@ -286,6 +286,23 @@ describe('BrowserView module', () => {
       expect(views[0].webContents.id).to.equal(view1.webContents.id);
       expect(views[1].webContents.id).to.equal(view2.webContents.id);
     });
+
+    it('persists ordering by z-index', () => {
+      const view1 = new BrowserView();
+      defer(() => view1.webContents.destroy());
+      w.addBrowserView(view1);
+      defer(() => w.removeBrowserView(view1));
+      const view2 = new BrowserView();
+      defer(() => view2.webContents.destroy());
+      w.addBrowserView(view2);
+      defer(() => w.removeBrowserView(view2));
+      w.setTopBrowserView(view1);
+
+      const views = w.getBrowserViews();
+      expect(views).to.have.lengthOf(2);
+      expect(views[0].webContents.id).to.equal(view2.webContents.id);
+      expect(views[1].webContents.id).to.equal(view1.webContents.id);
+    });
   });
 
   describe('BrowserWindow.setTopBrowserView()', () => {


### PR DESCRIPTION
#### Description of Change

This PR enhances `browserWindow.getBrowserViews()` to guarantee that browserViews are z-index sorted.
This is inspired by https://github.com/electron/electron/issues/29905 and will be useful for apps which support tabs.


#### Checklist
- [+] PR description included and stakeholders cc'd
- [+] `npm test` passes
- [+] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [+] relevant documentation, tutorials, templates and examples are changed or added
- [+] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

notes: browserWindow.getBrowserView() started to guarantee returning z-index sorted array.
