### PR TITLE
fix: printing optional access crash on Windows

### DIFF
--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -91,7 +91,7 @@ index 3a66a52b8d3c6da9cd8d7e9afdc8d59f528ec3d5..facaa6fbca8ee7c04f83607e62b81b95
                 : PdfRenderSettings::Mode::POSTSCRIPT_LEVEL3;
    }
 diff --git a/chrome/browser/printing/print_view_manager_base.cc b/chrome/browser/printing/print_view_manager_base.cc
-index c976fb2a814e4ff09650982034371e40d1ab77bc..c9115c7bbead588f3099bb194eb293b0e78ad211 100644
+index c976fb2a814e4ff09650982034371e40d1ab77bc..554fd00aee737c90cf8163eee822fca2c9f56071 100644
 --- a/chrome/browser/printing/print_view_manager_base.cc
 +++ b/chrome/browser/printing/print_view_manager_base.cc
 @@ -23,7 +23,9 @@
@@ -315,24 +315,27 @@ index c976fb2a814e4ff09650982034371e40d1ab77bc..c9115c7bbead588f3099bb194eb293b0
  
    std::unique_ptr<PrintSettings> print_settings =
        PrintSettingsFromJobSettings(job_settings);
-@@ -704,6 +751,16 @@ void PrintViewManagerBase::UpdatePrintSettings(
+@@ -704,7 +751,18 @@ void PrintViewManagerBase::UpdatePrintSettings(
      }
    }
  
+-#if BUILDFLAG(IS_WIN)
 +  std::unique_ptr<PrinterQuery> query =
 +      queue_->CreatePrinterQuery(GetCurrentTargetFrame()->GetGlobalId());
 +  auto* query_ptr = query.get();
++  auto job_settings_copy = job_settings.Clone();
 +  query_ptr->SetSettings(
-+      job_settings.Clone(),
++      std::move(job_settings_copy),
 +      base::BindOnce(&PrintViewManagerBase::CompleteUpdatePrintSettings,
 +                     weak_ptr_factory_.GetWeakPtr(), std::move(query),
 +                     std::move(job_settings), std::move(print_settings),
 +                     std::move(callback)));
 +
- #if BUILDFLAG(IS_WIN)
++#if 0 // See https://chromium-review.googlesource.com/412367
    // TODO(crbug.com/1424368):  Remove this if the printable areas can be made
    // fully available from `PrintBackend::GetPrinterSemanticCapsAndDefaults()`
-@@ -726,15 +783,13 @@ void PrintViewManagerBase::UpdatePrintSettings(
+   // for in-browser queries.
+@@ -726,15 +784,13 @@ void PrintViewManagerBase::UpdatePrintSettings(
    }
  #endif
  
@@ -349,7 +352,7 @@ index c976fb2a814e4ff09650982034371e40d1ab77bc..c9115c7bbead588f3099bb194eb293b0
  }
  
  void PrintViewManagerBase::ScriptedPrint(mojom::ScriptedPrintParamsPtr params,
-@@ -750,14 +805,14 @@ void PrintViewManagerBase::ScriptedPrint(mojom::ScriptedPrintParamsPtr params,
+@@ -750,14 +806,14 @@ void PrintViewManagerBase::ScriptedPrint(mojom::ScriptedPrintParamsPtr params,
      // didn't happen for some reason.
      bad_message::ReceivedBadMessage(
          render_process_host, bad_message::PVMB_SCRIPTED_PRINT_FENCED_FRAME);
@@ -366,7 +369,7 @@ index c976fb2a814e4ff09650982034371e40d1ab77bc..c9115c7bbead588f3099bb194eb293b0
      return;
    }
  #endif
-@@ -792,6 +847,7 @@ void PrintViewManagerBase::PrintingFailed(int32_t cookie,
+@@ -792,6 +848,7 @@ void PrintViewManagerBase::PrintingFailed(int32_t cookie,
  
    PrintManager::PrintingFailed(cookie, reason);
  
@@ -374,7 +377,7 @@ index c976fb2a814e4ff09650982034371e40d1ab77bc..c9115c7bbead588f3099bb194eb293b0
    // `PrintingFailed()` can occur because asynchronous compositing results
    // don't complete until after a print job has already failed and been
    // destroyed.  In such cases the error notification to the user will
-@@ -801,7 +857,7 @@ void PrintViewManagerBase::PrintingFailed(int32_t cookie,
+@@ -801,7 +858,7 @@ void PrintViewManagerBase::PrintingFailed(int32_t cookie,
        print_job_->document()->cookie() == cookie) {
      ShowPrintErrorDialogForGenericError();
    }
@@ -383,7 +386,7 @@ index c976fb2a814e4ff09650982034371e40d1ab77bc..c9115c7bbead588f3099bb194eb293b0
    ReleasePrinterQuery();
  }
  
-@@ -813,15 +869,24 @@ void PrintViewManagerBase::RemoveTestObserver(TestObserver& observer) {
+@@ -813,15 +870,24 @@ void PrintViewManagerBase::RemoveTestObserver(TestObserver& observer) {
    test_observers_.RemoveObserver(&observer);
  }
  
@@ -408,7 +411,7 @@ index c976fb2a814e4ff09650982034371e40d1ab77bc..c9115c7bbead588f3099bb194eb293b0
  }
  
  void PrintViewManagerBase::RenderFrameDeleted(
-@@ -873,7 +938,12 @@ void PrintViewManagerBase::OnJobDone() {
+@@ -873,7 +939,12 @@ void PrintViewManagerBase::OnJobDone() {
    // Printing is done, we don't need it anymore.
    // print_job_->is_job_pending() may still be true, depending on the order
    // of object registration.
@@ -422,7 +425,7 @@ index c976fb2a814e4ff09650982034371e40d1ab77bc..c9115c7bbead588f3099bb194eb293b0
    ReleasePrintJob();
  }
  
-@@ -882,9 +952,10 @@ void PrintViewManagerBase::OnCanceling() {
+@@ -882,9 +953,10 @@ void PrintViewManagerBase::OnCanceling() {
  }
  
  void PrintViewManagerBase::OnFailed() {
@@ -434,7 +437,7 @@ index c976fb2a814e4ff09650982034371e40d1ab77bc..c9115c7bbead588f3099bb194eb293b0
    TerminatePrintJob(true);
  }
  
-@@ -894,7 +965,7 @@ bool PrintViewManagerBase::RenderAllMissingPagesNow() {
+@@ -894,7 +966,7 @@ bool PrintViewManagerBase::RenderAllMissingPagesNow() {
  
    // Is the document already complete?
    if (print_job_->document() && print_job_->document()->IsComplete()) {
@@ -443,7 +446,7 @@ index c976fb2a814e4ff09650982034371e40d1ab77bc..c9115c7bbead588f3099bb194eb293b0
      return true;
    }
  
-@@ -942,7 +1013,10 @@ bool PrintViewManagerBase::CreateNewPrintJob(
+@@ -942,7 +1014,10 @@ bool PrintViewManagerBase::CreateNewPrintJob(
  
    // Disconnect the current `print_job_`.
    auto weak_this = weak_ptr_factory_.GetWeakPtr();
@@ -455,7 +458,7 @@ index c976fb2a814e4ff09650982034371e40d1ab77bc..c9115c7bbead588f3099bb194eb293b0
    if (!weak_this)
      return false;
  
-@@ -963,7 +1037,7 @@ bool PrintViewManagerBase::CreateNewPrintJob(
+@@ -963,7 +1038,7 @@ bool PrintViewManagerBase::CreateNewPrintJob(
  #endif
    print_job_->AddObserver(*this);
  
@@ -464,7 +467,7 @@ index c976fb2a814e4ff09650982034371e40d1ab77bc..c9115c7bbead588f3099bb194eb293b0
    return true;
  }
  
-@@ -1031,6 +1105,11 @@ void PrintViewManagerBase::ReleasePrintJob() {
+@@ -1031,6 +1106,11 @@ void PrintViewManagerBase::ReleasePrintJob() {
    }
  #endif
  
@@ -476,7 +479,7 @@ index c976fb2a814e4ff09650982034371e40d1ab77bc..c9115c7bbead588f3099bb194eb293b0
    if (!print_job_)
      return;
  
-@@ -1038,7 +1117,7 @@ void PrintViewManagerBase::ReleasePrintJob() {
+@@ -1038,7 +1118,7 @@ void PrintViewManagerBase::ReleasePrintJob() {
      // printing_rfh_ should only ever point to a RenderFrameHost with a live
      // RenderFrame.
      DCHECK(rfh->IsRenderFrameLive());
@@ -485,7 +488,7 @@ index c976fb2a814e4ff09650982034371e40d1ab77bc..c9115c7bbead588f3099bb194eb293b0
    }
  
    print_job_->RemoveObserver(*this);
-@@ -1080,7 +1159,7 @@ bool PrintViewManagerBase::RunInnerMessageLoop() {
+@@ -1080,7 +1160,7 @@ bool PrintViewManagerBase::RunInnerMessageLoop() {
  }
  
  bool PrintViewManagerBase::OpportunisticallyCreatePrintJob(int cookie) {
@@ -494,7 +497,7 @@ index c976fb2a814e4ff09650982034371e40d1ab77bc..c9115c7bbead588f3099bb194eb293b0
      return true;
  
    if (!cookie) {
-@@ -1224,7 +1303,7 @@ void PrintViewManagerBase::ReleasePrinterQuery() {
+@@ -1224,7 +1304,7 @@ void PrintViewManagerBase::ReleasePrinterQuery() {
  }
  
  void PrintViewManagerBase::CompletePrintNow(content::RenderFrameHost* rfh) {
@@ -503,7 +506,7 @@ index c976fb2a814e4ff09650982034371e40d1ab77bc..c9115c7bbead588f3099bb194eb293b0
  
    for (auto& observer : GetTestObservers()) {
      observer.OnPrintNow(rfh);
-@@ -1274,7 +1353,7 @@ void PrintViewManagerBase::CompleteScriptedPrintAfterContentAnalysis(
+@@ -1274,7 +1354,7 @@ void PrintViewManagerBase::CompleteScriptedPrintAfterContentAnalysis(
    set_analyzing_content(/*analyzing*/ false);
    if (!allowed || !printing_rfh_ || IsCrashed() ||
        !printing_rfh_->IsRenderFrameLive()) {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/38975
Closes https://github.com/electron/electron/issues/38944

Refs CL:4412367 and CL:4409898

Fixes an issue where printing on Windows could trigger a `RAW: Bad optional access` crash. This happened as a result of cloning `job_settings` and calling `std::move` on it in the same function call, which interestingly works just fine on macOS but doesn't on Windows.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where printing on Windows could trigger a crash. 
