### PR TITLE
revert: compensate for title bar height when setting bounds on `BrowserView`

### DIFF
--- a/shell/browser/native_browser_view_mac.mm
+++ b/shell/browser/native_browser_view_mac.mm
@@ -58,21 +58,9 @@ void NativeBrowserViewMac::SetBounds(const gfx::Rect& bounds) {
   auto* view = iwc_view->GetNativeView().GetNativeNSView();
   auto* superview = view.superview;
   const auto superview_height = superview ? superview.frame.size.height : 0;
-
-  // We need to use the content rect to calculate the titlebar height if the
-  // superview is an framed NSWindow, otherwise it will be offset incorrectly by
-  // the height of the titlebar.
-  auto titlebar_height = 0;
-  if (auto* win = [superview window]) {
-    const auto content_rect_height =
-        [win contentRectForFrameRect:superview.frame].size.height;
-    titlebar_height = superview_height - content_rect_height;
-  }
-
-  auto new_height =
-      superview_height - bounds.y() - bounds.height() + titlebar_height;
   view.frame =
-      NSMakeRect(bounds.x(), new_height, bounds.width(), bounds.height());
+      NSMakeRect(bounds.x(), superview_height - bounds.y() - bounds.height(),
+                 bounds.width(), bounds.height());
 }
 
 gfx::Rect NativeBrowserViewMac::GetBounds() {
@@ -80,23 +68,12 @@ gfx::Rect NativeBrowserViewMac::GetBounds() {
   if (!iwc_view)
     return gfx::Rect();
   NSView* view = iwc_view->GetNativeView().GetNativeNSView();
-  auto* superview = view.superview;
-  const int superview_height = superview ? superview.frame.size.height : 0;
-
-  // We need to use the content rect to calculate the titlebar height if the
-  // superview is an framed NSWindow, otherwise it will be offset incorrectly by
-  // the height of the titlebar.
-  auto titlebar_height = 0;
-  if (auto* win = [superview window]) {
-    const auto content_rect_height =
-        [win contentRectForFrameRect:superview.frame].size.height;
-    titlebar_height = superview_height - content_rect_height;
-  }
-
-  auto new_height = superview_height - view.frame.origin.y -
-                    view.frame.size.height + titlebar_height;
-  return gfx::Rect(view.frame.origin.x, new_height, view.frame.size.width,
-                   view.frame.size.height);
+  const int superview_height =
+      (view.superview) ? view.superview.frame.size.height : 0;
+  return gfx::Rect(
+      view.frame.origin.x,
+      superview_height - view.frame.origin.y - view.frame.size.height,
+      view.frame.size.width, view.frame.size.height);
 }
 
 void NativeBrowserViewMac::SetBackgroundColor(SkColor color) {

--- a/spec/api-browser-view-spec.ts
+++ b/spec/api-browser-view-spec.ts
@@ -146,14 +146,7 @@ describe('BrowserView module', () => {
   });
 
   describe('BrowserView.getBounds()', () => {
-    it('returns correct bounds on a framed window', () => {
-      view = new BrowserView();
-      const bounds = { x: 10, y: 20, width: 30, height: 40 };
-      view.setBounds(bounds);
-      expect(view.getBounds()).to.deep.equal(bounds);
-    });
-
-    it('returns correct bounds on a frameless window', () => {
+    it('returns the current bounds', () => {
       view = new BrowserView();
       const bounds = { x: 10, y: 20, width: 30, height: 40 };
       view.setBounds(bounds);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/35994.
Refs https://github.com/electron/electron/pull/34713.

This reverts 75f9573e53338e15af7c7ccd07a529332847ea2c. We can look towards a better solution in the future but for now I think it's better than behavior is consistent cross-platform.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where setting bounds on `BrowserViews` can behave inconsistently across platforms.