### PR TITLE
docs: add link to Travis CI headless page

### DIFF
--- a/docs/tutorial/testing-on-headless-ci.md
+++ b/docs/tutorial/testing-on-headless-ci.md
@@ -32,18 +32,7 @@ xvfb-maybe electron-mocha ./test/*.js
 
 ### Travis CI
 
-On Travis, your `.travis.yml` should look roughly like this:
-
-```yml
-addons:
-  apt:
-    packages:
-      - xvfb
-
-install:
-  - export DISPLAY=':99.0'
-  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-```
+For Travis, see its [docs on using Xvfb](https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui).
 
 ### Jenkins
 


### PR DESCRIPTION

#### Description of Change

##### Summary
Travis has a [specific page](https://docs.travis-ci.com/user/gui-and-headless-browsers/) in its docs dedicated to headless, with several different methods of using `xvfb`
  - I consolidated a few links in https://github.com/facebook-atom/jest-electron-runner/issues/47#issuecomment-558848756, thought I'd add one of them to the official docs too

##### Details

Replace Travis config with a link to its docs, similar to the Jenkins link

##### Review Notes

Feel free to modify the wording as desired!

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [n/a] `npm test` passes
- [n/a] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
