### PR TITLE
fix: webview crash when removing in close event

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1297,7 +1297,9 @@ void WebContents::CloseContents(content::WebContents* source) {
   for (ExtendedWebContentsObserver& observer : observers_)
     observer.OnCloseContents();
 
-  Destroy();
+  // This is handled by the embedder frame.
+  if (!IsGuest())
+    Destroy();
 }
 
 void WebContents::ActivateContents(content::WebContents* source) {

--- a/spec/fixtures/crash-cases/webview-remove-on-wc-close/index.html
+++ b/spec/fixtures/crash-cases/webview-remove-on-wc-close/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+  <style>
+    .webview {
+      border: 1px solid black;
+    }
+  </style>
+</head>
+
+<body>
+  <button class="close-btn">close webview</button>
+  <webview class="webview" src="./webview.html"></webview>
+  <script>
+    const close = document.querySelector('.close-btn')
+    const webview = document.querySelector('.webview')
+
+    webview.addEventListener('close', () => {
+      webview.parentNode.removeChild(webview)
+    })
+
+    close.addEventListener('click', () => {
+      webview.executeJavaScript('window.close()', true)
+    })
+  </script>
+</body>
+
+</html>

--- a/spec/fixtures/crash-cases/webview-remove-on-wc-close/index.js
+++ b/spec/fixtures/crash-cases/webview-remove-on-wc-close/index.js
@@ -1,0 +1,29 @@
+const { app, BrowserWindow } = require('electron');
+
+app.whenReady().then(() => {
+  const win = new BrowserWindow({
+    webPreferences: {
+      webviewTag: true
+    }
+  });
+
+  win.loadFile('index.html');
+
+  win.webContents.on('did-attach-webview', (event, contents) => {
+    contents.on('render-process-gone', () => {
+      process.exit(1);
+    });
+
+    contents.on('destroyed', () => {
+      process.exit(0);
+    });
+
+    contents.on('did-finish-load', () => {
+      win.webContents.executeJavaScript('document.querySelector(\'.close-btn\').click()');
+    });
+
+    contents.on('will-prevent-unload', event => {
+      event.preventDefault();
+    });
+  });
+});

--- a/spec/fixtures/crash-cases/webview-remove-on-wc-close/webview.html
+++ b/spec/fixtures/crash-cases/webview-remove-on-wc-close/webview.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+
+<body>
+  <h1>webview page</h1>
+  <script>
+    window.addEventListener('beforeunload', event => {
+      event.returnValue = 'test'
+    })
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/38941.

Fixes an issue where removing a webview in a close callback could cause crashes. This happened as a result of a change made in https://github.com/electron/electron/pull/35509, where `WebContents::CloseContents` was changed to call `Destroy` instead of it being called in `OnCloseContents` by a `BrowserWindow` or `BrowserView`. This made it the case that `Destroy()` would also now be called for webview webContents', which could lead to crashes since that was previously handled by the embedder frame.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where removing a webview in a close callback could cause crashes.
