### PR TITLE
fix: Notification 'Show' button visible when no actions exist

### DIFF
--- a/shell/browser/notifications/mac/cocoa_notification.mm
+++ b/shell/browser/notifications/mac/cocoa_notification.mm
@@ -64,6 +64,11 @@ void CocoaNotification::Show(const NotificationOptions& options) {
                                               options.reply_placeholder)];
   }
 
+  // We need to explicitly set this to false if there are no
+  // actions, otherwise a Show button will appear by default.
+  if (options.actions.size() == 0)
+    [notification_ setHasActionButton:false];
+
   int i = 0;
   action_index_ = UINT_MAX;
   NSMutableArray* additionalActions =
@@ -75,7 +80,6 @@ void CocoaNotification::Show(const NotificationOptions& options) {
       // become additional actions.
       if (!options.has_reply && action_index_ == UINT_MAX) {
         // First button observed is the displayed action
-        [notification_ setHasActionButton:true];
         [notification_
             setActionButtonTitle:base::SysUTF16ToNSString(action.text)];
         action_index_ = i;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/38995.

Fixes an issue where notifications created on macOS which have no actions will erroneously have a `Show` button visible. As per [documentation](https://developer.apple.com/documentation/foundation/nsusernotification/1411564-hasactionbutton?language=objc), `[NSUserNotification hasActionButton]` is true by default, and so we need to explicitly set it to false when no actions exist.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where notifications created on macOS which have no actions will erroneously have a `Show` button visible. 