### PR TITLE
fix: remove types from GTK CSS selectors

### DIFF
--- a/shell/browser/ui/views/client_frame_view_linux.cc
+++ b/shell/browser/ui/views/client_frame_view_linux.cc
@@ -309,13 +309,13 @@ void ClientFrameViewLinux::PaintAsActiveChanged() {
 
 void ClientFrameViewLinux::UpdateThemeValues() {
   gtk::GtkCssContext window_context =
-      gtk::AppendCssNodeToStyleContext({}, "GtkWindow#window.background.csd");
+      gtk::AppendCssNodeToStyleContext({}, "window.background.csd");
   gtk::GtkCssContext headerbar_context = gtk::AppendCssNodeToStyleContext(
-      {}, "GtkHeaderBar#headerbar.default-decoration.titlebar");
-  gtk::GtkCssContext title_context = gtk::AppendCssNodeToStyleContext(
-      headerbar_context, "GtkLabel#label.title");
+      {}, "headerbar.default-decoration.titlebar");
+  gtk::GtkCssContext title_context =
+      gtk::AppendCssNodeToStyleContext(headerbar_context, "label.title");
   gtk::GtkCssContext button_context = gtk::AppendCssNodeToStyleContext(
-      headerbar_context, "GtkButton#button.image-button");
+      headerbar_context, "button.image-button");
 
   gtk_style_context_set_parent(headerbar_context, window_context);
   gtk_style_context_set_parent(title_context, headerbar_context);


### PR DESCRIPTION
#### Description of Change

Remove types from GTK CSS selectors similar to Chromium's changes in [CL 4289229](https://chromium-review.googlesource.com/c/chromium/src/+/4289229).

Fixes #38786

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed display of title bar buttons on Wayland.
