### PR TITLE
build: disable unneeded depot_tools update on Windows CI

### DIFF
--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -85,6 +85,8 @@ for:
             Remove-Item -Recurse -Force $pwd\build-tools
           }
       - git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+      - ps: New-Item -Name depot_tools\.disable_auto_update -ItemType File
+      - depot_tools\bootstrap\win_tools.bat
       - ps: $env:PATH="$pwd\depot_tools;$env:PATH"
       - ps: >-
           if (Test-Path -Path "$pwd\src\electron") {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,6 +83,8 @@ for:
             Remove-Item -Recurse -Force $pwd\build-tools
           }
       - git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+      - ps: New-Item -Name depot_tools\.disable_auto_update -ItemType File
+      - depot_tools\bootstrap\win_tools.bat
       - ps: $env:PATH="$pwd\depot_tools;$env:PATH"
       - ps: >-
           if (Test-Path -Path "$pwd\src\electron") {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Windows builds were failing trying to run depot_tools update, eg https://ci.appveyor.com/project/electron-bot/electron-x64-release/build/1.0.2597/job/s0d7nqm8w5yxlfrm.  It appears that the error that stopped the build has resolved itself, but there still are goma errors present that this PR will resolve.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
