### PR TITLE
fix: `protocol.handle` not intercepting file protocol

### DIFF
--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -9,7 +9,7 @@ const { registerSchemesAsPrivileged, getStandardSchemes, Protocol } = process._l
 const ERR_FAILED = -2;
 const ERR_UNEXPECTED = -9;
 
-const isBuiltInScheme = (scheme: string) => scheme === 'http' || scheme === 'https';
+const isBuiltInScheme = (scheme: string) => ['http', 'https', 'file'].includes(scheme);
 
 function makeStreamFromPipe (pipe: any): ReadableStream {
   const buf = new Uint8Array(1024 * 1024 /* 1 MB */);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/39031.
Refs https://github.com/electron/electron/pull/36674

Fixes an issue where `protocol.handle()` never called its callback with the `'file'` scheme. This was happening because we were not noting `file:` as a buildin scheme, which meant that `Protocol.prototype.handle` was calling `registerProtocol` instead of `interceptProtocol` under the hood.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `protocol.handle()` never called its callback with the `'file'` scheme.
