### PR TITLE
perf: small perf changes in HidChooserController

### DIFF
--- a/shell/browser/hid/hid_chooser_controller.cc
+++ b/shell/browser/hid/hid_chooser_controller.cc
@@ -306,15 +306,14 @@ bool HidChooserController::IsExcluded(
 bool HidChooserController::AddDeviceInfo(
     const device::mojom::HidDeviceInfo& device) {
   const auto& id = PhysicalDeviceIdFromDeviceInfo(device);
-  auto find_it = device_map_.find(id);
-  if (find_it != device_map_.end()) {
-    find_it->second.push_back(device.Clone());
-    return false;
-  }
-  // A new device was connected. Append it to the end of the chooser list.
-  device_map_[id].push_back(device.Clone());
-  items_.push_back(id);
-  return true;
+  auto [iter, is_new_physical_device] = device_map_.try_emplace(id);
+  iter->second.emplace_back(device.Clone());
+
+  // append new devices to the chooser list
+  if (is_new_physical_device)
+    items_.emplace_back(id);
+
+  return is_new_physical_device;
 }
 
 bool HidChooserController::RemoveDeviceInfo(

--- a/shell/browser/hid/hid_chooser_controller.cc
+++ b/shell/browser/hid/hid_chooser_controller.cc
@@ -106,7 +106,7 @@ HidChooserController::~HidChooserController() {
 }
 
 // static
-std::string HidChooserController::PhysicalDeviceIdFromDeviceInfo(
+const std::string& HidChooserController::PhysicalDeviceIdFromDeviceInfo(
     const device::mojom::HidDeviceInfo& device) {
   // A single physical device may expose multiple HID interfaces, each
   // represented by a HidDeviceInfo object. When a device exposes multiple
@@ -148,11 +148,10 @@ void HidChooserController::OnDeviceAdded(
 
 void HidChooserController::OnDeviceRemoved(
     const device::mojom::HidDeviceInfo& device) {
-  auto id = PhysicalDeviceIdFromDeviceInfo(device);
-  if (!base::Contains(items_, id))
+  if (!base::Contains(items_, PhysicalDeviceIdFromDeviceInfo(device)))
     return;
-  api::Session* session = GetSession();
-  if (session) {
+
+  if (api::Session* session = GetSession(); session != nullptr) {
     auto* rfh = content::RenderFrameHost::FromID(render_frame_host_id_);
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
     v8::HandleScope scope(isolate);
@@ -306,7 +305,7 @@ bool HidChooserController::IsExcluded(
 
 bool HidChooserController::AddDeviceInfo(
     const device::mojom::HidDeviceInfo& device) {
-  auto id = PhysicalDeviceIdFromDeviceInfo(device);
+  const auto& id = PhysicalDeviceIdFromDeviceInfo(device);
   auto find_it = device_map_.find(id);
   if (find_it != device_map_.end()) {
     find_it->second.push_back(device.Clone());
@@ -320,7 +319,7 @@ bool HidChooserController::AddDeviceInfo(
 
 bool HidChooserController::RemoveDeviceInfo(
     const device::mojom::HidDeviceInfo& device) {
-  auto id = PhysicalDeviceIdFromDeviceInfo(device);
+  const auto& id = PhysicalDeviceIdFromDeviceInfo(device);
   auto find_it = device_map_.find(id);
   DCHECK(find_it != device_map_.end());
   auto& device_infos = find_it->second;
@@ -338,7 +337,7 @@ bool HidChooserController::RemoveDeviceInfo(
 
 void HidChooserController::UpdateDeviceInfo(
     const device::mojom::HidDeviceInfo& device) {
-  auto id = PhysicalDeviceIdFromDeviceInfo(device);
+  const auto& id = PhysicalDeviceIdFromDeviceInfo(device);
   auto physical_device_it = device_map_.find(id);
   DCHECK(physical_device_it != device_map_.end());
   auto& device_infos = physical_device_it->second;

--- a/shell/browser/hid/hid_chooser_controller.h
+++ b/shell/browser/hid/hid_chooser_controller.h
@@ -54,7 +54,7 @@ class HidChooserController
   ~HidChooserController() override;
 
   // static
-  static std::string PhysicalDeviceIdFromDeviceInfo(
+  static const std::string& PhysicalDeviceIdFromDeviceInfo(
       const device::mojom::HidDeviceInfo& device);
 
   // HidChooserContext::DeviceObserver:


### PR DESCRIPTION
#### Description of Change

A small perf cleanup in `HidChooserController`. Nothing major, but avoids some easily avoidable work while also making `AddDeviceInfo()` a little more readable.

- avoid a second map lookup in HidChooserController::AddDeviceInfo() when adding a new physical device.
- have PhysicalDeviceIdFromDeviceInfo() return a const& instead of creating a new string.

CC @jkleinsc as the primary on HidChooserController, but any reviews welcomed.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none