### PR TITLE
perf: avoid redundant map lookup in NativeImage::GetHICON()

### DIFF
--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -202,21 +202,23 @@ bool NativeImage::TryConvertNativeImage(v8::Isolate* isolate,
 
 #if BUILDFLAG(IS_WIN)
 HICON NativeImage::GetHICON(int size) {
-  auto iter = hicons_.find(size);
-  if (iter != hicons_.end())
+  if (auto iter = hicons_.find(size); iter != hicons_.end())
     return iter->second.get();
 
   // First try loading the icon with specified size.
   if (!hicon_path_.empty()) {
-    hicons_[size] = ReadICOFromPath(size, hicon_path_);
-    return hicons_[size].get();
+    auto& hicon = hicons_[size];
+    hicon = ReadICOFromPath(size, hicon_path_);
+    return hicon.get();
   }
 
   // Then convert the image to ICO.
   if (image_.IsEmpty())
     return NULL;
-  hicons_[size] = IconUtil::CreateHICONFromSkBitmap(image_.AsBitmap());
-  return hicons_[size].get();
+
+  auto& hicon = hicons_[size];
+  hicon = IconUtil::CreateHICONFromSkBitmap(image_.AsBitmap());
+  return hicon.get();
 }
 #endif
 


### PR DESCRIPTION
#### Description of Change

Small cleanup to avoid redundant map lookups in `NativeImage::GetHICON()`.

No particular stakeholders; any reviews welcomed.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none