### PR TITLE
perf: avoid redundant lookup in BluetoothChooser::AddOrUpdateDevice()

### DIFF
--- a/shell/browser/lib/bluetooth_chooser.cc
+++ b/shell/browser/lib/bluetooth_chooser.cc
@@ -110,13 +110,10 @@ void BluetoothChooser::AddOrUpdateDevice(const std::string& device_id,
     // an event
     return;
   }
-  bool changed = false;
-  auto entry = device_map_.find(device_id);
-  if (entry == device_map_.end()) {
-    device_map_[device_id] = device_name;
-    changed = true;
-  } else if (should_update_name) {
-    entry->second = device_name;
+
+  auto [iter, changed] = device_map_.try_emplace(device_id, device_name);
+  if (!changed && should_update_name) {
+    iter->second = device_name;
     changed = true;
   }
 
@@ -139,11 +136,8 @@ std::vector<electron::BluetoothChooser::DeviceInfo>
 BluetoothChooser::GetDeviceList() {
   std::vector<electron::BluetoothChooser::DeviceInfo> vec;
   vec.reserve(device_map_.size());
-  for (const auto& it : device_map_) {
-    DeviceInfo info = {it.first, it.second};
-    vec.push_back(info);
-  }
-
+  for (const auto& [device_id, device_name] : device_map_)
+    vec.emplace_back(device_id, device_name);
   return vec;
 }
 


### PR DESCRIPTION
#### Description of Change

Another in a small set of PRs to avoid redundant map lookups, this time in BluetoothChooser::AddOrUpdateDevice().

No particular stakeholders; any review welcomed

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none