### PR TITLE
chore: bump node 18.16.1 (26-x-y)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -4,7 +4,7 @@ vars = {
   'chromium_version':
     '116.0.5845.14',
   'node_version':
-    'v18.16.0',
+    'v18.16.1',
   'nan_version':
     '16fa32231e2ccd89d2804b3f765319128b20c4ac',
   'squirrel.mac_version':

--- a/patches/node/.patches
+++ b/patches/node/.patches
@@ -35,3 +35,4 @@ fix_libc_buffer_overflow_in_string_view_ctor.patch
 fix_preventing_potential_oob_in_ada_no_scheme_parsing.patch
 chore_remove_--no-harmony-atomics_related_code.patch
 fix_account_for_createexternalizablestring_v8_global.patch
+fix_wunreachable-code_warning_in_ares_init_rand_engine.patch

--- a/patches/node/build_add_gn_build_files.patch
+++ b/patches/node/build_add_gn_build_files.patch
@@ -676,10 +676,10 @@ rename from deps/base64/base64/lib/arch/ssse3/codec.c
 rename to deps/base64/base64/lib/arch/ssse3/ssse3_codec.c
 diff --git a/deps/cares/BUILD.gn b/deps/cares/BUILD.gn
 new file mode 100644
-index 0000000000000000000000000000000000000000..71a37834f4e693c190eb7e7d04e3f5ce67c487ad
+index 0000000000000000000000000000000000000000..2a902c68ca445b8451e442c314c60ee5a30719e4
 --- /dev/null
 +++ b/deps/cares/BUILD.gn
-@@ -0,0 +1,134 @@
+@@ -0,0 +1,135 @@
 +config("cares_config") {
 +  include_dirs = [ "include", "src/lib" ]
 +}
@@ -750,6 +750,7 @@ index 0000000000000000000000000000000000000000..71a37834f4e693c190eb7e7d04e3f5ce
 +    "src/lib/ares_private.h",
 +    "src/lib/ares_process.c",
 +    "src/lib/ares_query.c",
++    "src/lib/ares_rand.c",
 +    "src/lib/ares__read_line.c",
 +    "src/lib/ares__readaddrinfo.c",
 +    "src/lib/ares_search.c",
@@ -2182,7 +2183,7 @@ index 0000000000000000000000000000000000000000..4ab828dcbf322a9e28674e48c4a6868b
 +  args = rebase_path(inputs + outputs, root_build_dir)
 +}
 diff --git a/src/node_version.h b/src/node_version.h
-index cfab30173a4311582b1ebdc5a1b84b37117a8e69..c254fe22f9e2bc0f1746e773f7ecb0d1db31294b 100644
+index d08a0d731f6c14b0e66076a858214147821b5a32..67c008ee7724f10de476e7e523e902fa087eb2c8 100644
 --- a/src/node_version.h
 +++ b/src/node_version.h
 @@ -89,7 +89,10 @@

--- a/patches/node/chore_allow_the_node_entrypoint_to_be_a_builtin_module.patch
+++ b/patches/node/chore_allow_the_node_entrypoint_to_be_a_builtin_module.patch
@@ -8,10 +8,10 @@ they use themselves as the entry point. We should try to upstream some form
 of this.
 
 diff --git a/lib/internal/modules/cjs/loader.js b/lib/internal/modules/cjs/loader.js
-index f2e8dc028b8b60108f1aa2301d65001b5a3774c7..9bcb56adb6d0a8f0e4462226398687da6a5b5629 100644
+index 9783d9235ed43c7919ed2f26e35c96ae7ff1a08b..e4fd5e7dadb8230c9e07dbb7bc70b2117135c59a 100644
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
-@@ -1228,6 +1228,13 @@ Module.prototype._compile = function(content, filename) {
+@@ -1230,6 +1230,13 @@ Module.prototype._compile = function(content, filename) {
    if (getOptionValue('--inspect-brk') && process._eval == null) {
      if (!resolvedArgv) {
        // We enter the repl if we're not given a filename argument.

--- a/patches/node/fix_crypto_tests_to_run_with_bssl.patch
+++ b/patches/node/fix_crypto_tests_to_run_with_bssl.patch
@@ -420,7 +420,7 @@ index dd073274aef765e8f1e403aa2c8baf9694b521cb..fc6339e040debe61ecc61a3eb5b26823
  }
  
 diff --git a/test/parallel/test-crypto-dh.js b/test/parallel/test-crypto-dh.js
-index 18721fcf289e5545408e309db050a2ff0f4b0140..e5235e0a5fbd68416b4a9480818901b411ed91bd 100644
+index c730eac4ce76dde880fe2b36b17414b0c311ac0b..ec5510778f4aa77c68d10d7cc56fd3a45091121c 100644
 --- a/test/parallel/test-crypto-dh.js
 +++ b/test/parallel/test-crypto-dh.js
 @@ -49,7 +49,7 @@ for (const bits of [-1, 0, 1]) {
@@ -715,7 +715,7 @@ index 008ab129f0e019c659eecf5a76b7eb412c947fe3..6688f5d916f50e1e4fcfff1619c8634a
  
  cipher.end('Papaya!');  // Should not cause an unhandled exception.
 diff --git a/test/parallel/test-crypto-x509.js b/test/parallel/test-crypto-x509.js
-index 2f2e443a7f6482c26f3a065520c8764d8402a91f..ccfe79ac65a223139f293f7dd034096fcdbc81ab 100644
+index 930a2ba09088663298208f165f06a7710770938f..592b4140f14e659dfa38e438473c8d4ac4ae60ab 100644
 --- a/test/parallel/test-crypto-x509.js
 +++ b/test/parallel/test-crypto-x509.js
 @@ -111,7 +111,7 @@ const der = Buffer.from(
@@ -780,7 +780,7 @@ index 2f2e443a7f6482c26f3a065520c8764d8402a91f..ccfe79ac65a223139f293f7dd034096f
    assert.strictEqual(legacyObject.bits, legacyObjectCheck.bits);
    assert.strictEqual(legacyObject.exponent, legacyObjectCheck.exponent);
    assert.strictEqual(legacyObject.valid_from, legacyObjectCheck.valid_from);
-@@ -316,7 +318,7 @@ oans248kpal88CGqsN2so/wZKxVnpiXlPHMdiNL7hRSUqlHkUi07FrP2Htg8kjI=
+@@ -316,11 +318,12 @@ oans248kpal88CGqsN2so/wZKxVnpiXlPHMdiNL7hRSUqlHkUi07FrP2Htg8kjI=
    assert.strictEqual(
      legacyObject.fingerprint256,
      legacyObjectCheck.fingerprint256);
@@ -790,6 +790,16 @@ index 2f2e443a7f6482c26f3a065520c8764d8402a91f..ccfe79ac65a223139f293f7dd034096f
 -    legacyObjectCheck.serialNumber);
 +    legacyObjectCheck.serialNumberPattern);
  }
+ 
++/*
+ {
+   // This X.509 Certificate can be parsed by OpenSSL because it contains a
+   // structurally sound TBSCertificate structure. However, the SPKI field of the
+@@ -359,3 +362,4 @@ UcXd/5qu2GhokrKU2cPttU+XAN2Om6a0
+ 
+   assert.strictEqual(cert.checkIssued(cert), false);
+ }
++*/
 diff --git a/test/parallel/test-crypto.js b/test/parallel/test-crypto.js
 index a8ceb169de2b3de73f062083c42292babc673e73..8fb950d0814e5014faf5c1ef576b65795857da1b 100644
 --- a/test/parallel/test-crypto.js

--- a/patches/node/fix_wunreachable-code_warning_in_ares_init_rand_engine.patch
+++ b/patches/node/fix_wunreachable-code_warning_in_ares_init_rand_engine.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Charles Kerr <charles@charleskerr.com>
+Date: Thu, 22 Jun 2023 11:59:47 -0500
+Subject: fix: Wunreachable-code warning in ares__init_rand_engine()
+
+Fix upstream Win32 FTBFS when building with -Werror,-Wunreachable-code.
+
+This patch can be removed after the fix is picked up in Node.js.
+Upstream PR @ https://github.com/c-ares/c-ares/pull/531
+
+diff --git a/deps/cares/src/lib/ares_rand.c b/deps/cares/src/lib/ares_rand.c
+index 766c1e6ea9bda1784cfb611dbac66424806cd23a..12d943921e3ba61cbf7a2ed3194fcd5a6c61da8a 100644
+--- a/deps/cares/src/lib/ares_rand.c
++++ b/deps/cares/src/lib/ares_rand.c
+@@ -55,6 +55,7 @@ BOOLEAN WINAPI SystemFunction036(PVOID RandomBuffer, ULONG RandomBufferLength);
+ #  endif
+ #endif
+ 
++#if !defined(HAVE_ARC4RANDOM_BUF) && !defined(_WIN32)
+ 
+ #define ARES_RC4_KEY_LEN 32 /* 256 bits */
+ 
+@@ -129,6 +130,7 @@ static void ares_rc4_init(ares_rand_rc4 *rc4_state)
+   rc4_state->i = 0;
+   rc4_state->j = 0;
+ }
++#endif
+ 
+ /* Just outputs the key schedule, no need to XOR with any data since we have none */
+ static void ares_rc4_prng(ares_rand_rc4 *rc4_state, unsigned char *buf, size_t len)
+@@ -166,13 +168,13 @@ static int ares__init_rand_engine(ares_rand_state *state)
+     return 1;
+   }
+   /* Fall-Thru on failure to RC4 */
+-#endif
+ 
+   state->type = ARES_RAND_RC4;
+   ares_rc4_init(&state->state.rc4);
+ 
+   /* Currently cannot fail */
+   return 1;
++#endif
+ }
+ 
+ 
+@@ -276,4 +278,3 @@ unsigned short ares__generate_new_id(ares_rand_state *state)
+   ares__rand_bytes(state, (unsigned char *)&r, sizeof(r));
+   return r;
+ }
+-

--- a/patches/node/pass_all_globals_through_require.patch
+++ b/patches/node/pass_all_globals_through_require.patch
@@ -6,7 +6,7 @@ Subject: Pass all globals through "require"
 (cherry picked from commit 7d015419cb7a0ecfe6728431a4ed2056cd411d62)
 
 diff --git a/lib/internal/modules/cjs/loader.js b/lib/internal/modules/cjs/loader.js
-index 31649227ed8eb36f58ec0b88d498b9e45009f76b..61605a052f976dc7fad224c3c81c2187f3862cdb 100644
+index 55931329dcddb60fff0bdf681bbfad6f62fdcbb7..65e685a7cacf3f70fddf15b1068d59fa604323ea 100644
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
 @@ -142,6 +142,13 @@ const {
@@ -23,7 +23,7 @@ index 31649227ed8eb36f58ec0b88d498b9e45009f76b..61605a052f976dc7fad224c3c81c2187
  const {
    isProxy,
  } = require('internal/util/types');
-@@ -1249,10 +1256,12 @@ Module.prototype._compile = function(content, filename) {
+@@ -1251,10 +1258,12 @@ Module.prototype._compile = function(content, filename) {
    if (requireDepth === 0) statCache = new SafeMap();
    if (inspectorWrapper) {
      result = inspectorWrapper(compiledWrapper, thisValue, exports,

--- a/patches/node/refactor_allow_embedder_overriding_of_internal_fs_calls.patch
+++ b/patches/node/refactor_allow_embedder_overriding_of_internal_fs_calls.patch
@@ -22,7 +22,7 @@ index 07c6d5e9351a96aeca1179c20287dc3fb7ec1eab..13ea68c96fd415f976aab0f291a1b7c6
  // release cycle, remove the Proxy and setter and update the
  // getter to either return a read-only object or always return
 diff --git a/lib/internal/modules/cjs/loader.js b/lib/internal/modules/cjs/loader.js
-index 61605a052f976dc7fad224c3c81c2187f3862cdb..f2e8dc028b8b60108f1aa2301d65001b5a3774c7 100644
+index 65e685a7cacf3f70fddf15b1068d59fa604323ea..9783d9235ed43c7919ed2f26e35c96ae7ff1a08b 100644
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
 @@ -94,7 +94,7 @@ const fs = require('fs');


### PR DESCRIPTION
#### Description of Change

Updating Node.js to v18.16.1.

See [all changes in v18.16.0..v18.16.1](https://github.com/nodejs/node/compare/v18.16.0...v18.16.1)

This would be great to backport into electron 26, since that stream is still in beta and node released many security updates in this version (src: https://nodejs.org/en/blog/vulnerability/june-2023-security-releases)

Please consider including this in the 26 stream 🙏 

Cherry picked from main 327af3b03c

Backport of #38869

cc @ckerr @codebytere @jkleinsc 

#### Checklist

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: Updated Node.js to v18.16.1 to address security fixes.