### PR TITLE
fix: instantiate tab video tracks from BrowserCaptureMediaStreamTrack 

### DIFF
--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -580,7 +580,7 @@ void ElectronBrowserContext::DisplayMediaDeviceChosen(
       blink::MediaStreamDevice video_device(request.video_type, id, name);
       video_device.display_media_info = DesktopMediaIDToDisplayMediaInformation(
           nullptr, url::Origin::Create(request.security_origin),
-          content::DesktopMediaID::Parse(request.requested_video_device_id));
+          content::DesktopMediaID::Parse(video_device.id));
       devices.video_device = video_device;
     } else if (result_dict.Get("video", &rfh)) {
       auto* web_contents = content::WebContents::FromRenderFrameHost(rfh);
@@ -592,7 +592,7 @@ void ElectronBrowserContext::DisplayMediaDeviceChosen(
           base::UTF16ToUTF8(web_contents->GetTitle()));
       video_device.display_media_info = DesktopMediaIDToDisplayMediaInformation(
           web_contents, url::Origin::Create(request.security_origin),
-          content::DesktopMediaID::Parse(request.requested_video_device_id));
+          content::DesktopMediaID::Parse(video_device.id));
       devices.video_device = video_device;
     } else {
       gin_helper::ErrorThrower(args->isolate())

--- a/spec/api-media-handler-spec.ts
+++ b/spec/api-media-handler-spec.ts
@@ -283,6 +283,29 @@ describe('setDisplayMediaRequestHandler', () => {
     expect(ok).to.be.true(message);
   });
 
+  it('returns a MediaStream with BrowserCaptureMediaStreamTrack when the current tab is selected', async () => {
+    const ses = session.fromPartition('' + Math.random());
+    let requestHandlerCalled = false;
+    ses.setDisplayMediaRequestHandler((request, callback) => {
+      requestHandlerCalled = true;
+      callback({ video: w.webContents.mainFrame });
+    });
+    const w = new BrowserWindow({ show: false, webPreferences: { session: ses } });
+    await w.loadURL(serverUrl);
+    const { ok, message } = await w.webContents.executeJavaScript(`
+      navigator.mediaDevices.getDisplayMedia({
+        preferCurrentTab: true,
+        video: true,
+        audio: false,
+      }).then(stream => {
+        const [videoTrack] = stream.getVideoTracks();
+        return { ok: videoTrack instanceof BrowserCaptureMediaStreamTrack, message: null };
+      }, e => ({ok: false, message: e.message}))
+    `, true);
+    expect(requestHandlerCalled).to.be.true();
+    expect(ok).to.be.true(message);
+  });
+
   ifit(!(process.platform === 'darwin' && process.arch === 'x64'))('can supply a screen response to preferCurrentTab', async () => {
     const ses = session.fromPartition('' + Math.random());
     let requestHandlerCalled = false;


### PR DESCRIPTION
#### Description of Change

It seems `display_surface` in `display_media_info` wasn't correctly set when the display media source is a tab, which causes `getDisplayMedia` to return a `MediaStreamTrack` instead of  `BrowserCaptureMediaStreamTrack` for browser sources.

Looking at the uses of `DesktopMediaID::Parse` in Chromium, it looks like the id it's supposed to receive is the id of a `MediaStreamSource` instead of the id of `MediaStreamRequest`.

With this change, it'll be possible to use the new[ Region Capture API](https://www.w3.org/TR/mediacapture-region/) with tab/browser capturing.

Fixes https://github.com/electron/electron/issues/36331

*Before*
![Screenshot 2023-07-12 132812](https://github.com/electron/electron/assets/6992723/57763cdb-52ea-40d1-96a5-f0f6b34ca388)

*After*
![Screenshot 2023-07-12 132940](https://github.com/electron/electron/assets/6992723/88f852da-eb02-49c2-b0e5-c4978111ac7a)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: support Region Capture API with tab MediaStream
