### PR TITLE
docs: The return type of the stop function corrected to as boolean type

### DIFF
--- a/docs/api/power-save-blocker.md
+++ b/docs/api/power-save-blocker.md
@@ -7,12 +7,21 @@ Process: [Main](../glossary.md#main-process)
 For example:
 
 ```javascript
-const { powerSaveBlocker } = require('electron')
+// const { powerSaveBlocker } = require('electron')
 
-const id = powerSaveBlocker.start('prevent-display-sleep')
-console.log(powerSaveBlocker.isStarted(id))
+// const id = powerSaveBlocker.start('prevent-display-sleep')
+// console.log(powerSaveBlocker.isStarted(id))
 
-powerSaveBlocker.stop(id)
+// powerSaveBlocker.stop(id)
+const { powerSaveBlocker } = require('electron');
+
+const id = powerSaveBlocker.start('prevent-display-sleep');
+console.log(powerSaveBlocker.isStarted(id));
+
+const stopped = powerSaveBlocker.stop(id) as unknown as boolean;
+console.log(stopped);
+
+
 ```
 
 ## Methods


### PR DESCRIPTION
#### The return type of the stop function corrected to as boolean type

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

Expected Behavior Now
The return type of the stop function should be correctly typed as boolean
 
- changes added at https://github.com/VIRAT9358/electron/blob/my-branch/docs/api/power-save-blocker.md


#### Release Notes

Notes: none
