### PR TITLE
docs: fix a capitalization problem in messagePort tutorial

### DIFF
--- a/docs/tutorial/message-ports.md
+++ b/docs/tutorial/message-ports.md
@@ -150,7 +150,7 @@ renderer.
 
 ```js title='renderer.js (Renderer Process)' @ts-nocheck
 // elsewhere in your code to send a message to the other renderers message handler
-window.electronMessagePort.postmessage('ping')
+window.electronMessagePort.postMessage('ping')
 ```
 
 ### Worker process


### PR DESCRIPTION
For a rookie, this little mistake took a long time to find out.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.