### PR TITLE
fix: `resizable: false` should disable fullscreen button at start

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -198,10 +198,6 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
     SetSizeConstraints(size_constraints);
   }
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX)
-  bool resizable;
-  if (options.Get(options::kResizable, &resizable)) {
-    SetResizable(resizable);
-  }
   bool closable;
   if (options.Get(options::kClosable, &closable)) {
     SetClosable(closable);
@@ -223,6 +219,7 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
   if (options.Get(options::kAlwaysOnTop, &top) && top) {
     SetAlwaysOnTop(ui::ZOrderLevel::kFloatingWindow);
   }
+
   bool fullscreenable = true;
   bool fullscreen = false;
   if (options.Get(options::kFullscreen, &fullscreen) && !fullscreen) {
@@ -231,12 +228,18 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
     fullscreenable = false;
 #endif
   }
-  // Overridden by 'fullscreenable'.
+
   options.Get(options::kFullScreenable, &fullscreenable);
   SetFullScreenable(fullscreenable);
-  if (fullscreen) {
+
+  if (fullscreen)
     SetFullScreen(true);
+
+  bool resizable;
+  if (options.Get(options::kResizable, &resizable)) {
+    SetResizable(resizable);
   }
+
   bool skip;
   if (options.Get(options::kSkipTaskbar, &skip)) {
     SetSkipTaskbar(skip);

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -818,7 +818,24 @@ void NativeWindowMac::MoveTop() {
 void NativeWindowMac::SetResizable(bool resizable) {
   ScopedDisableResize disable_resize;
   SetStyleMask(resizable, NSWindowStyleMaskResizable);
+
+  // Right now, resizable and fullscreenable are decoupled in
+  // documentation and on Windows/Linux. Chromium disables
+  // fullscreenability if resizability is false on macOS as well
+  // as disabling the maximize traffic light unless the window
+  // is both resizable and maximizable. To work around this, we want
+  // to match behavior on other platforms by disabiliting the maximize
+  // button but keeping fullscreenability enabled.
+  // TODO(codebytere): refactor this once we have a better solution.
   SetCanResize(resizable);
+  if (!resizable) {
+    SetFullScreenable(true);
+    [[window_ standardWindowButton:NSWindowZoomButton] setEnabled:false];
+  } else {
+    SetFullScreenable(true);
+    [[window_ standardWindowButton:NSWindowZoomButton]
+        setEnabled:IsFullScreenable()];
+  }
 }
 
 bool NativeWindowMac::IsResizable() {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/39077. 

Fixes an issue where non-resizable windows incorrectly enabled the fullscreen/maximize button on initial window creation on macOS. Once the window was fullscreened and then un-fullscreened, the button was correctly disabled. This happened becuase `SetFullScreenable` should only be called on macOS at initial window creation when it's disabled. This change aligns defaults across platforms: a disabled  fullscreen/maximize button on app boot is the current behavior on Windows and Linux as well. A test cannot be added because despite the incorrectly enabled button, `window.isResizable` did correctly return `false`.

<details><summary>Default on Windows</summary>
<p>

<img width="802" alt="Screenshot 2023-07-13 at 1 00 30 PM" src="https://github.com/electron/electron/assets/2036040/02e9e0bf-12e3-4ac1-9c11-c672aacd7a70">

</p>
</details>

<details><summary>macOS UI After This Change</summary>
<p>

<img width="868" alt="Screenshot 2023-07-13 at 1 00 46 PM" src="https://github.com/electron/electron/assets/2036040/1ec50a92-0960-4ff8-8dea-5b0110a29e75">

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where non-resizable windows incorrectly enabled the fullscreen/maximize button on initial window creation on macOS
