### PR TITLE
fix: menu border being created properly on Windows 11

### DIFF
--- a/patches/chromium/fix_crash_on_nativetheme_change_during_context_menu_close.patch
+++ b/patches/chromium/fix_crash_on_nativetheme_change_during_context_menu_close.patch
@@ -15,7 +15,7 @@ This should be upstreamed, as other uses of MenuController in this
 file do check for menu controller being null.
 
 diff --git a/ui/views/controls/menu/menu_scroll_view_container.cc b/ui/views/controls/menu/menu_scroll_view_container.cc
-index c4f9cea175824f9f5d592e05affdf717a391dcd6..7163f3ff0c745ce1099685028179e5ed0c54ef05 100644
+index c4f9cea175824f9f5d592e05affdf717a391dcd6..74e084e4d5398371e39042c2d0ab51e7040b9451 100644
 --- a/ui/views/controls/menu/menu_scroll_view_container.cc
 +++ b/ui/views/controls/menu/menu_scroll_view_container.cc
 @@ -402,8 +402,7 @@ void MenuScrollViewContainer::CreateDefaultBorder() {

--- a/patches/chromium/fix_crash_on_nativetheme_change_during_context_menu_close.patch
+++ b/patches/chromium/fix_crash_on_nativetheme_change_during_context_menu_close.patch
@@ -35,7 +35,7 @@ index c4f9cea175824f9f5d592e05affdf717a391dcd6..7163f3ff0c745ce1099685028179e5ed
 -    if (menu_config.use_bubble_border && (corner_radius_ > 0) &&
 -        !menu_controller->IsCombobox()) {
 +    // Menu controller could be null during context menu being closed.
-+    bool is_combobox = menu_controller && !menu_controller->IsCombobox();
++    bool is_combobox = menu_controller && menu_controller->IsCombobox();
 +    if (menu_config.use_bubble_border && (corner_radius_ > 0) && !is_combobox) {
        CreateBubbleBorder();
      } else {


### PR DESCRIPTION
Backport of #38998.

See that PR for details.

Notes: Fixes an issue with the application menu overlapping menu items on Windows 11.