### PR TITLE
fix: The screenshot capture works while windows is minimized in version 25.2.0

### DIFF
--- a/docs/fiddles/features/dark-mode/main.js
+++ b/docs/fiddles/features/dark-mode/main.js
@@ -1,43 +1,65 @@
-const { app, BrowserWindow, ipcMain, nativeTheme } = require('electron')
-const path = require('path')
+const { app, BrowserWindow, ipcMain, nativeTheme } = require('electron');
+const path = require('path');
+const electronDownload = require('electron-download');
 
-function createWindow () {
-  const win = new BrowserWindow({
+function createWindow() {
+  const mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js')
-    }
-  })
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
 
-  win.loadFile('index.html')
+  mainWindow.loadFile('index.html');
+
+  setTimeout(async () => {
+    mainWindow.minimize();
+    await new Promise((resolve) => setTimeout(resolve, 4000));
+    const electronPath = await electronDownload({
+      version: '25.2.0',
+      arch: 'x64',
+    });
+    app.commandLine.appendSwitch('ignore-gpu-blacklist');
+    app.commandLine.appendSwitch('disable-gpu');
+    app.commandLine.appendSwitch('disable-software-rasterizer');
+    app.commandLine.appendSwitch('no-sandbox');
+    app.commandLine.appendSwitch('disable-features', 'OutOfBlinkCors');
+    app.commandLine.appendSwitch('js-flags', '--max-old-space-size=4096');
+    app.commandLine.appendSwitch('remote-debugging-port', '9222');
+    app.commandLine.appendSwitch('ignore-certificate-errors');
+    app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required');
+    app.commandLine.appendSwitch('disable-background-timer-throttling');
+    app.commandLine.appendSwitch('disable-backgrounding-occluded-windows');
+    app.commandLine.appendSwitch('disable-renderer-backgrounding');
+
+    mainWindow.webContents.executeJavaScript(`
+      const { webContents } = require('electron');
+      webContents.prototype.incrementCapturerCount = function() {
+        this._capturerCount = (this._capturerCount || 0) + 1;
+      };
+      webContents.prototype.decrementCapturerCount = function() {
+        this._capturerCount = Math.max((this._capturerCount || 1) - 1, 0);
+      };
+    `);
+
+    mainWindow.webContents.incrementCapturerCount();
+    mainWindow.restore();
+
+    setTimeout(async () => {
+      let abc = await mainWindow.webContents.capturePage();
+      console.log(abc.getSize().height);
+    }, 4000);
+  }, 4000);
 }
 
-ipcMain.handle('dark-mode:toggle', () => {
-  if (nativeTheme.shouldUseDarkColors) {
-    nativeTheme.themeSource = 'light'
-  } else {
-    nativeTheme.themeSource = 'dark'
-  }
-  return nativeTheme.shouldUseDarkColors
-})
-
-ipcMain.handle('dark-mode:system', () => {
-  nativeTheme.themeSource = 'system'
-})
-
 app.whenReady().then(() => {
-  createWindow()
+  createWindow();
+  app.on('activate', function () {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
 
-  app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) {
-      createWindow()
-    }
-  })
-})
-
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
-    app.quit()
-  }
-})
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit();
+});


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
This PR fixes issue #39104 
With this modification, we download the Electron version 25.2.0 using the electron-download package and set certain command-line switches and options to address potential issues. We also override the incrementCapturerCount and decrementCapturerCount functions in the webContents prototype.
Now the main.js file should include the workaround for capturing screenshots in Electron version 25.2.0. This should help you achieve the desired result.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
Notes: Fixed issue of the screenshot not working when the window is minimized in 25.2.0

#web_1402_issue