### PR TITLE
fix: use StartUpdating method for PipeWire capturer

### DIFF
--- a/patches/chromium/desktop_media_list.patch
+++ b/patches/chromium/desktop_media_list.patch
@@ -82,7 +82,7 @@ index 33ca7a53dfb6d2c9e3a33f0065a3acd806e82e01..9fdf2e8ff0056ff407015b914c6b03eb
    const Source& GetSource(int index) const override;
    DesktopMediaList::Type GetMediaListType() const override;
 diff --git a/chrome/browser/media/webrtc/native_desktop_media_list.cc b/chrome/browser/media/webrtc/native_desktop_media_list.cc
-index 836f7683b77b3b28f33984f27649d675ddddd5b7..84135d3cf983c88fc165a0fc012200e5132a52ff 100644
+index 836f7683b77b3b28f33984f27649d675ddddd5b7..18f795dd77754e115aa66a7404a2e4075372bc5f 100644
 --- a/chrome/browser/media/webrtc/native_desktop_media_list.cc
 +++ b/chrome/browser/media/webrtc/native_desktop_media_list.cc
 @@ -141,7 +141,7 @@ BOOL CALLBACK AllHwndCollector(HWND hwnd, LPARAM param) {
@@ -94,17 +94,20 @@ index 836f7683b77b3b28f33984f27649d675ddddd5b7..84135d3cf983c88fc165a0fc012200e5
  #endif
  
  }  // namespace
-@@ -451,6 +451,9 @@ void NativeDesktopMediaList::Worker::RefreshNextThumbnail() {
+@@ -451,6 +451,12 @@ void NativeDesktopMediaList::Worker::RefreshNextThumbnail() {
        FROM_HERE,
        base::BindOnce(&NativeDesktopMediaList::UpdateNativeThumbnailsFinished,
                       media_list_));
 +
 +  // This call is necessary to release underlying OS screen capture mechanisms.
-+  capturer_.reset();
++  // Skip if the source list is delegated, as the source list window will be active.
++  if (!capturer_->GetDelegatedSourceListController()) {
++    capturer_.reset();
++  }
  }
  
  void NativeDesktopMediaList::Worker::OnCaptureResult(
-@@ -823,6 +826,11 @@ void NativeDesktopMediaList::RefreshForVizFrameSinkWindows(
+@@ -823,6 +829,11 @@ void NativeDesktopMediaList::RefreshForVizFrameSinkWindows(
          FROM_HERE, base::BindOnce(&Worker::RefreshThumbnails,
                                    base::Unretained(worker_.get()),
                                    std::move(native_ids), thumbnail_size_));

--- a/shell/browser/api/electron_api_desktop_capturer.h
+++ b/shell/browser/api/electron_api_desktop_capturer.h
@@ -67,7 +67,8 @@ class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
   class DesktopListListener : public DesktopMediaListObserver {
    public:
     DesktopListListener(OnceCallback update_callback,
-                        OnceCallback failure_callback);
+                        OnceCallback failure_callback,
+                        bool skip_thumbnails);
     ~DesktopListListener() override;
 
    protected:
@@ -75,7 +76,7 @@ class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
     void OnSourceRemoved(int index) override {}
     void OnSourceMoved(int old_index, int new_index) override {}
     void OnSourceNameChanged(int index) override {}
-    void OnSourceThumbnailChanged(int index) override {}
+    void OnSourceThumbnailChanged(int index) override;
     void OnSourcePreviewChanged(size_t index) override {}
     void OnDelegatedSourceListSelection() override;
     void OnDelegatedSourceListDismissed() override;
@@ -83,6 +84,8 @@ class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
    private:
     OnceCallback update_callback_;
     OnceCallback failure_callback_;
+    bool have_selection_ = false;
+    bool have_thumbnail_ = false;
   };
 
   void UpdateSourcesList(DesktopMediaList* list);

--- a/shell/browser/api/electron_api_desktop_capturer.h
+++ b/shell/browser/api/electron_api_desktop_capturer.h
@@ -62,8 +62,34 @@ class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
   void OnDelegatedSourceListDismissed() override {}
 
  private:
-  void UpdateSourcesList(DesktopMediaList* list);
+  using OnceCallback = base::OnceClosure;
 
+  class DesktopListListener : public DesktopMediaListObserver {
+   public:
+    DesktopListListener(OnceCallback update_callback,
+                        OnceCallback failure_callback);
+    ~DesktopListListener() override;
+
+   protected:
+    void OnSourceAdded(int index) override {}
+    void OnSourceRemoved(int index) override {}
+    void OnSourceMoved(int old_index, int new_index) override {}
+    void OnSourceNameChanged(int index) override {}
+    void OnSourceThumbnailChanged(int index) override {}
+    void OnSourcePreviewChanged(size_t index) override {}
+    void OnDelegatedSourceListSelection() override;
+    void OnDelegatedSourceListDismissed() override;
+
+   private:
+    OnceCallback update_callback_;
+    OnceCallback failure_callback_;
+  };
+
+  void UpdateSourcesList(DesktopMediaList* list);
+  void HandleFailure();
+
+  std::unique_ptr<DesktopListListener> window_listener_;
+  std::unique_ptr<DesktopListListener> screen_listener_;
   std::unique_ptr<DesktopMediaList> window_capturer_;
   std::unique_ptr<DesktopMediaList> screen_capturer_;
   std::vector<DesktopCapturer::Source> captured_sources_;


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/38833

See that PR for details.

Notes: Fixed a crash when listing desktop capture sources on Wayland with PipeWire.