### PR TITLE
fix: use StartUpdating method for PipeWire capturer

### DIFF
--- a/patches/chromium/desktop_media_list.patch
+++ b/patches/chromium/desktop_media_list.patch
@@ -82,7 +82,7 @@ index 33ca7a53dfb6d2c9e3a33f0065a3acd806e82e01..9fdf2e8ff0056ff407015b914c6b03eb
    const Source& GetSource(int index) const override;
    DesktopMediaList::Type GetMediaListType() const override;
 diff --git a/chrome/browser/media/webrtc/native_desktop_media_list.cc b/chrome/browser/media/webrtc/native_desktop_media_list.cc
-index 4da983eee1abad065dd8a76a7efd308ef5897a09..5c34fda5db161ad1e563a953995bfe06f902b53f 100644
+index 4da983eee1abad065dd8a76a7efd308ef5897a09..4ed2373e812708af01f81ff2b05bbdbf4543bc80 100644
 --- a/chrome/browser/media/webrtc/native_desktop_media_list.cc
 +++ b/chrome/browser/media/webrtc/native_desktop_media_list.cc
 @@ -142,7 +142,7 @@ BOOL CALLBACK AllHwndCollector(HWND hwnd, LPARAM param) {
@@ -94,17 +94,20 @@ index 4da983eee1abad065dd8a76a7efd308ef5897a09..5c34fda5db161ad1e563a953995bfe06
  #endif
  
  }  // namespace
-@@ -452,6 +452,9 @@ void NativeDesktopMediaList::Worker::RefreshNextThumbnail() {
+@@ -452,6 +452,12 @@ void NativeDesktopMediaList::Worker::RefreshNextThumbnail() {
        FROM_HERE,
        base::BindOnce(&NativeDesktopMediaList::UpdateNativeThumbnailsFinished,
                       media_list_));
 +
 +  // This call is necessary to release underlying OS screen capture mechanisms.
-+  capturer_.reset();
++  // Skip if the source list is delegated, as the source list window will be active.
++  if (!capturer_->GetDelegatedSourceListController()) {
++    capturer_.reset();
++  }
  }
  
  void NativeDesktopMediaList::Worker::OnCaptureResult(
-@@ -824,6 +827,11 @@ void NativeDesktopMediaList::RefreshForVizFrameSinkWindows(
+@@ -824,6 +830,11 @@ void NativeDesktopMediaList::RefreshForVizFrameSinkWindows(
          FROM_HERE, base::BindOnce(&Worker::RefreshThumbnails,
                                    base::Unretained(worker_.get()),
                                    std::move(native_ids), thumbnail_size_));

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -181,6 +181,22 @@ DesktopCapturer::DesktopCapturer(v8::Isolate* isolate) {}
 
 DesktopCapturer::~DesktopCapturer() = default;
 
+DesktopCapturer::DesktopListListener::DesktopListListener(
+    OnceCallback update_callback,
+    OnceCallback failure_callback)
+    : update_callback_(std::move(update_callback)),
+      failure_callback_(std::move(failure_callback)) {}
+
+DesktopCapturer::DesktopListListener::~DesktopListListener() = default;
+
+void DesktopCapturer::DesktopListListener::OnDelegatedSourceListSelection() {
+  std::move(update_callback_).Run();
+}
+
+void DesktopCapturer::DesktopListListener::OnDelegatedSourceListDismissed() {
+  std::move(failure_callback_).Run();
+}
+
 void DesktopCapturer::StartHandling(bool capture_window,
                                     bool capture_screen,
                                     const gfx::Size& thumbnail_size,
@@ -207,27 +223,51 @@ void DesktopCapturer::StartHandling(bool capture_window,
     // Initialize the source list.
     // Apply the new thumbnail size and restart capture.
     if (capture_window) {
-      window_capturer_ = std::make_unique<NativeDesktopMediaList>(
-          DesktopMediaList::Type::kWindow,
-          content::desktop_capture::CreateWindowCapturer());
-      window_capturer_->SetThumbnailSize(thumbnail_size);
-      window_capturer_->Update(
-          base::BindOnce(&DesktopCapturer::UpdateSourcesList,
-                         weak_ptr_factory_.GetWeakPtr(),
-                         window_capturer_.get()),
-          /* refresh_thumbnails = */ true);
+      if (auto capturer = content::desktop_capture::CreateWindowCapturer();
+          capturer) {
+        window_capturer_ = std::make_unique<NativeDesktopMediaList>(
+            DesktopMediaList::Type::kWindow, std::move(capturer));
+        window_capturer_->SetThumbnailSize(thumbnail_size);
+
+        OnceCallback update_callback = base::BindOnce(
+            &DesktopCapturer::UpdateSourcesList, weak_ptr_factory_.GetWeakPtr(),
+            window_capturer_.get());
+
+        if (window_capturer_->IsSourceListDelegated()) {
+          OnceCallback failure_callback = base::BindOnce(
+              &DesktopCapturer::HandleFailure, weak_ptr_factory_.GetWeakPtr());
+          window_listener_ = std::make_unique<DesktopListListener>(
+              std::move(update_callback), std::move(failure_callback));
+          window_capturer_->StartUpdating(window_listener_.get());
+        } else {
+          window_capturer_->Update(std::move(update_callback),
+                                   /* refresh_thumbnails = */ true);
+        }
+      }
     }
 
     if (capture_screen) {
-      screen_capturer_ = std::make_unique<NativeDesktopMediaList>(
-          DesktopMediaList::Type::kScreen,
-          content::desktop_capture::CreateScreenCapturer());
-      screen_capturer_->SetThumbnailSize(thumbnail_size);
-      screen_capturer_->Update(
-          base::BindOnce(&DesktopCapturer::UpdateSourcesList,
-                         weak_ptr_factory_.GetWeakPtr(),
-                         screen_capturer_.get()),
-          /* refresh_thumbnails = */ true);
+      if (auto capturer = content::desktop_capture::CreateScreenCapturer();
+          capturer) {
+        screen_capturer_ = std::make_unique<NativeDesktopMediaList>(
+            DesktopMediaList::Type::kScreen, std::move(capturer));
+        screen_capturer_->SetThumbnailSize(thumbnail_size);
+
+        OnceCallback update_callback = base::BindOnce(
+            &DesktopCapturer::UpdateSourcesList, weak_ptr_factory_.GetWeakPtr(),
+            screen_capturer_.get());
+
+        if (screen_capturer_->IsSourceListDelegated()) {
+          OnceCallback failure_callback = base::BindOnce(
+              &DesktopCapturer::HandleFailure, weak_ptr_factory_.GetWeakPtr());
+          screen_listener_ = std::make_unique<DesktopListListener>(
+              std::move(update_callback), std::move(failure_callback));
+          screen_capturer_->StartUpdating(screen_listener_.get());
+        } else {
+          screen_capturer_->Update(std::move(update_callback),
+                                   /* refresh_thumbnails = */ true);
+        }
+      }
     }
   }
 }
@@ -266,12 +306,7 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
       // |media_list_sources|.
       if (!webrtc::DxgiDuplicatorController::Instance()->GetDeviceNames(
               &device_names)) {
-        v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-        v8::HandleScope scope(isolate);
-        gin_helper::CallMethod(this, "_onerror", "Failed to get sources.");
-
-        Unpin();
-
+        HandleFailure();
         return;
       }
 
@@ -319,6 +354,14 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
 
     Unpin();
   }
+}
+
+void DesktopCapturer::HandleFailure() {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope scope(isolate);
+  gin_helper::CallMethod(this, "_onerror", "Failed to get sources.");
+
+  Unpin();
 }
 
 // static

--- a/shell/browser/api/electron_api_desktop_capturer.h
+++ b/shell/browser/api/electron_api_desktop_capturer.h
@@ -67,7 +67,8 @@ class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
   class DesktopListListener : public DesktopMediaListObserver {
    public:
     DesktopListListener(OnceCallback update_callback,
-                        OnceCallback failure_callback);
+                        OnceCallback failure_callback,
+                        bool skip_thumbnails);
     ~DesktopListListener() override;
 
    protected:
@@ -75,7 +76,7 @@ class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
     void OnSourceRemoved(int index) override {}
     void OnSourceMoved(int old_index, int new_index) override {}
     void OnSourceNameChanged(int index) override {}
-    void OnSourceThumbnailChanged(int index) override {}
+    void OnSourceThumbnailChanged(int index) override;
     void OnSourcePreviewChanged(size_t index) override {}
     void OnDelegatedSourceListSelection() override;
     void OnDelegatedSourceListDismissed() override;
@@ -83,6 +84,8 @@ class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
    private:
     OnceCallback update_callback_;
     OnceCallback failure_callback_;
+    bool have_selection_ = false;
+    bool have_thumbnail_ = false;
   };
 
   void UpdateSourcesList(DesktopMediaList* list);

--- a/shell/browser/api/electron_api_desktop_capturer.h
+++ b/shell/browser/api/electron_api_desktop_capturer.h
@@ -62,8 +62,34 @@ class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
   void OnDelegatedSourceListDismissed() override {}
 
  private:
-  void UpdateSourcesList(DesktopMediaList* list);
+  using OnceCallback = base::OnceClosure;
 
+  class DesktopListListener : public DesktopMediaListObserver {
+   public:
+    DesktopListListener(OnceCallback update_callback,
+                        OnceCallback failure_callback);
+    ~DesktopListListener() override;
+
+   protected:
+    void OnSourceAdded(int index) override {}
+    void OnSourceRemoved(int index) override {}
+    void OnSourceMoved(int old_index, int new_index) override {}
+    void OnSourceNameChanged(int index) override {}
+    void OnSourceThumbnailChanged(int index) override {}
+    void OnSourcePreviewChanged(size_t index) override {}
+    void OnDelegatedSourceListSelection() override;
+    void OnDelegatedSourceListDismissed() override;
+
+   private:
+    OnceCallback update_callback_;
+    OnceCallback failure_callback_;
+  };
+
+  void UpdateSourcesList(DesktopMediaList* list);
+  void HandleFailure();
+
+  std::unique_ptr<DesktopListListener> window_listener_;
+  std::unique_ptr<DesktopListListener> screen_listener_;
   std::unique_ptr<DesktopMediaList> window_capturer_;
   std::unique_ptr<DesktopMediaList> screen_capturer_;
   std::vector<DesktopCapturer::Source> captured_sources_;


### PR DESCRIPTION
Backport of #38833

See that PR for details.

Notes: Fixed a crash when listing desktop capture sources on Wayland with PipeWire.