### PR TITLE
docs: remove redundant IPC event sections

### DIFF
--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -122,15 +122,15 @@ Handles a single `invoke`able IPC message, then removes the listener. See
 
 Removes any handler for `channel`, if present.
 
-## IpcMainEvent object
+## `IpcMainEvent` object
 
 The documentation for the `event` object passed to the `callback` can be found
-in the [`ipc-main-event`][ipc-main-event] structure docs.
+in the [`IpcMainEvent`][ipc-main-event] structure docs.
 
-## IpcMainInvokeEvent object
+## `IpcMainInvokeEvent` object
 
 The documentation for the `event` object passed to `handle` callbacks can be
-found in the [`ipc-main-invoke-event`][ipc-main-invoke-event]
+found in the [`IpcMainInvokeEvent`][ipc-main-invoke-event]
 structure docs.
 
 [IPC tutorial]: ../tutorial/ipc.md

--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -110,7 +110,7 @@ provided to the renderer process. Please refer to
 
 * `channel` string
 * `listener` Function<Promise\<void&#62; | any&#62;
-  * `event` IpcMainInvokeEvent
+  * `event` [IpcMainInvokeEvent][ipc-main-invoke-event]
   * `...args` any[]
 
 Handles a single `invoke`able IPC message, then removes the listener. See
@@ -121,17 +121,6 @@ Handles a single `invoke`able IPC message, then removes the listener. See
 * `channel` string
 
 Removes any handler for `channel`, if present.
-
-## `IpcMainEvent` object
-
-The documentation for the `event` object passed to the `callback` can be found
-in the [`IpcMainEvent`][ipc-main-event] structure docs.
-
-## `IpcMainInvokeEvent` object
-
-The documentation for the `event` object passed to `handle` callbacks can be
-found in the [`IpcMainInvokeEvent`][ipc-main-invoke-event]
-structure docs.
 
 [IPC tutorial]: ../tutorial/ipc.md
 [event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -26,7 +26,7 @@ The `ipcRenderer` module has the following method to listen for events and send 
 
 * `channel` string
 * `listener` Function
-  * `event` IpcRendererEvent
+  * `event` [IpcRendererEvent][ipc-renderer-event]
   * `...args` any[]
 
 Listens to `channel`, when a new message arrives `listener` would be called with
@@ -36,7 +36,7 @@ Listens to `channel`, when a new message arrives `listener` would be called with
 
 * `channel` string
 * `listener` Function
-  * `event` IpcRendererEvent
+  * `event` [IpcRendererEvent][ipc-renderer-event]
   * `...args` any[]
 
 Adds a one time `listener` function for the event. This `listener` is invoked
@@ -208,12 +208,8 @@ Sends a message to a window with `webContentsId` via `channel`.
 Like `ipcRenderer.send` but the event will be sent to the `<webview>` element in
 the host page instead of the main process.
 
-## Event object
-
-The documentation for the `event` object passed to the `callback` can be found
-in the [`IpcRendererEvent`](./structures/ipc-renderer-event.md) structure docs.
-
 [event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter
 [SCA]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 [`window.postMessage`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 [`MessagePort`]: https://developer.mozilla.org/en-US/docs/Web/API/MessagePort
+[ipc-renderer-event]: ./structures/ipc-renderer-event.md

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -211,7 +211,7 @@ the host page instead of the main process.
 ## Event object
 
 The documentation for the `event` object passed to the `callback` can be found
-in the [`ipc-renderer-event`](./structures/ipc-renderer-event.md) structure docs.
+in the [`IpcRendererEvent`](./structures/ipc-renderer-event.md) structure docs.
 
 [event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter
 [SCA]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

These weren't using the actual event names, which is a bit confusing.

cc @electron/docs

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
