### PR TITLE
build: fix Appveyor test workflow checkout

### DIFF
--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -51,6 +51,11 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: base-woa
       APPVEYOR_BUILD_WORKER_CLOUD: electronhq-woa
 
+clone_script:
+- ps: git clone -q $("--branch=" + $Env:APPVEYOR_REPO_BRANCH) $("https://github.com/" + $Env:APPVEYOR_REPO_NAME + ".git") $Env:APPVEYOR_BUILD_FOLDER
+- ps: if (!$Env:APPVEYOR_PULL_REQUEST_NUMBER) {$("git checkout -qf " + $Env:APPVEYOR_REPO_COMMIT)}
+- ps: if ($Env:APPVEYOR_PULL_REQUEST_NUMBER) {git fetch -q origin +refs/pull/$($Env:APPVEYOR_PULL_REQUEST_NUMBER)/head; git checkout -qf FETCH_HEAD}
+
 clone_folder: C:\projects\src\electron
 
 skip_branch_with_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,7 @@ environment:
 clone_script:
 - ps: git clone -q $("--branch=" + $Env:APPVEYOR_REPO_BRANCH) $("https://github.com/" + $Env:APPVEYOR_REPO_NAME + ".git") $Env:APPVEYOR_BUILD_FOLDER
 - ps: if (!$Env:APPVEYOR_PULL_REQUEST_NUMBER) {$("git checkout -qf " + $Env:APPVEYOR_REPO_COMMIT)}
-- ps: if ($Env:APPVEYOR_PULL_REQUEST_NUMBER) {git fetch -q origin +refs/pull/$($Env:APPVEYOR_PULL_REQUEST_NUMBER)/merge; git checkout -qf FETCH_HEAD}
+- ps: if ($Env:APPVEYOR_PULL_REQUEST_NUMBER) {git fetch -q origin +refs/pull/$($Env:APPVEYOR_PULL_REQUEST_NUMBER)/head; git checkout -qf FETCH_HEAD}
 
 clone_folder: C:\projects\src\electron
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,6 +49,11 @@ environment:
     - job_name: Test
       job_depends_on: Build
 
+clone_script:
+- ps: git clone -q $("--branch=" + $Env:APPVEYOR_REPO_BRANCH) $("https://github.com/" + $Env:APPVEYOR_REPO_NAME + ".git") $Env:APPVEYOR_BUILD_FOLDER
+- ps: if (!$Env:APPVEYOR_PULL_REQUEST_NUMBER) {$("git checkout -qf " + $Env:APPVEYOR_REPO_COMMIT)}
+- ps: if ($Env:APPVEYOR_PULL_REQUEST_NUMBER) {git fetch -q origin +refs/pull/$($Env:APPVEYOR_PULL_REQUEST_NUMBER)/merge; git checkout -qf FETCH_HEAD}
+
 clone_folder: C:\projects\src\electron
 
 skip_branch_with_pr: true


### PR DESCRIPTION
#### Description of Change

Fixes an issue where Appveyor will checkout `main` for test builds, which causes failures if the branch at hand has not been rebased to contain fixes necessary for new tests to pass. Below is a sample failure that occurred on the roll branch, because https://github.com/electron/electron/pull/38754 was merged, and the new test was checked out on the roll and run despite the branch build not containing the associated source changes.

<details><summary>Example</summary>
<p>

<img width="1443" alt="Screenshot 2023-07-18 at 2 07 24 PM" src="https://github.com/electron/electron/assets/2036040/845f0650-e8ec-4c10-ae6a-44823dd866e3">

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
