### PR TITLE
build: fixup Codespaces build-tools setup

### DIFF
--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -16,6 +16,8 @@ ln -s $buildtools_configs $buildtools/configs
 
 # Write the gclient config if it does not already exist
 if [ ! -f $gclient_root/.gclient ]; then
+  echo "Creating gclient config"
+
   echo "solutions = [
       { \"name\"        : \"src/electron\",
           \"url\"         : \"https://github.com/electron/electron\",
@@ -32,6 +34,8 @@ fi
 # Write the default buildtools config file if it does
 # not already exist
 if [ ! -f $buildtools/configs/evm.testing.json ]; then
+  echo "Creating build-tools testing config"
+
   write_config() {
     echo "
         {
@@ -53,9 +57,9 @@ if [ ! -f $buildtools/configs/evm.testing.json ]; then
                 \"CHROMIUM_BUILDTOOLS_PATH\": \"/workspaces/gclient/src/buildtools\",
                 \"GIT_CACHE_PATH\": \"/workspaces/gclient/.git-cache\"
             },
-            \"$schema\": \"file:///home/builduser/.electron_build_tools/evm-config.schema.json\"
+            \"\$schema\": \"file:///home/builduser/.electron_build_tools/evm-config.schema.json\"
         }
-    " >$buildtools/configs/evm.testing.json
+    " >$buildtools/configs/evm.testing1.json
   }
 
   # Start out as cache only
@@ -67,10 +71,12 @@ if [ ! -f $buildtools/configs/evm.testing.json ]; then
   # if it works we can use the goma cluster
   export NOTGOMA_CODESPACES_TOKEN=$GITHUB_TOKEN
   if e d goma_auth login; then
+    echo "$GITHUB_USER has GOMA access - switching to cluster mode"
     write_config cluster
   fi
 else
-  # Even if the config file existed we still need to re-auth with the goma
-  # cluster
+  echo "build-tools testing config already exists"
+
+  # Re-auth with the goma cluster regardless.
   NOTGOMA_CODESPACES_TOKEN=$GITHUB_TOKEN e d goma_auth login || true
 fi

--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -59,7 +59,7 @@ if [ ! -f $buildtools/configs/evm.testing.json ]; then
             },
             \"\$schema\": \"file:///home/builduser/.electron_build_tools/evm-config.schema.json\"
         }
-    " >$buildtools/configs/evm.testing1.json
+    " >$buildtools/configs/evm.testing.json
   }
 
   # Start out as cache only


### PR DESCRIPTION
#### Description of Change

It was trying to infer `$schema` as a variable since it was not properly escaped. Also add some extra logging.

<details><summary>Error Log</summary>
<p>

<img width="1356" alt="Screenshot 2023-07-17 at 12 04 12 PM" src="https://github.com/electron/electron/assets/2036040/2a160fd5-ee58-4745-8e1c-daabb3b64716">

</p>
</details> 

<details><summary>Previously Generated Config</summary>
<p>

```

        {
            "goma": "cache-only",
            "root": "/workspaces/gclient",
            "remotes": {
                "electron": {
                    "origin": "https://github.com/electron/electron.git"
                }
            },
            "gen": {
                "args": [
                    "import(\"//electron/build/args/testing.gn\")",
                    "import(\"/home/builduser/.electron_build_tools/third_party/goma.gn\")"
                ],
                "out": "Testing"
            },
            "env": {
                "CHROMIUM_BUILDTOOLS_PATH": "/workspaces/gclient/src/buildtools",
                "GIT_CACHE_PATH": "/workspaces/gclient/.git-cache"
            },
            "": "file:///home/builduser/.electron_build_tools/evm-config.schema.json"
        }
```

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none