### PR TITLE
test: put necessary steps into generate-identity.sh

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -566,7 +566,6 @@ step-install-signing-cert-on-mac: &step-install-signing-cert-on-mac
     name: Import and trust self-signed codesigning cert on MacOS
     command: |
       if  [ "$TARGET_ARCH" != "arm64" ] && [ "`uname`" == "Darwin" ]; then
-        sudo security authorizationdb write com.apple.trust-settings.admin allow
         cd src/electron
         ./script/codesign/generate-identity.sh
       fi

--- a/script/codesign/generate-identity.sh
+++ b/script/codesign/generate-identity.sh
@@ -16,6 +16,9 @@ cleanup
 # Create Working Dir
 mkdir -p "$dir"
 
+# Allow modification of Trust Settings
+sudo security authorizationdb write com.apple.trust-settings.admin allow
+
 # Generate Certs
 openssl req -new -newkey rsa:2048 -x509 -days 7300 -nodes -config "$(dirname $0)"/codesign.cnf -extensions extended -batch -out "$dir"/certificate.cer -keyout "$dir"/certificate.key
 sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$dir"/certificate.cer


### PR DESCRIPTION
#### Description of Change

The `generate-identity.sh` script is also used by vendor builds in their own CIs, some steps should be put in the script instead of circle ci config file.

#### Release Notes

Notes: none