### PR TITLE
fix: delete desktop capturers when they're not needed

### DIFF
--- a/patches/webrtc/.patches
+++ b/patches/webrtc/.patches
@@ -1,1 +1,2 @@
 fix_fallback_to_x11_capturer_on_wayland.patch
+fix_mark_pipewire_capturer_as_failed_after_session_is_closed.patch

--- a/patches/webrtc/fix_mark_pipewire_capturer_as_failed_after_session_is_closed.patch
+++ b/patches/webrtc/fix_mark_pipewire_capturer_as_failed_after_session_is_closed.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Athul Iddya <athul@iddya.com>
+Date: Sat, 22 Jul 2023 11:11:01 -0700
+Subject: fix: mark PipeWire capturer as failed after session is closed
+
+After a PipeWire screencast session is successfully started, the
+consumer is expected to keep calling CaptureFrame() from the
+DesktopCapturer interface in a loop to pull frames. A PipeWire
+screencast session can be closed by the server on user action. Once the
+session is closed, there's no point in calling CaptureFrame() again as
+the capture has to be restarted. Inform the caller of the failure by
+returning Result::ERROR_PERMANENT on the next invocation of
+CaptureFrame().
+
+diff --git a/modules/desktop_capture/linux/wayland/base_capturer_pipewire.cc b/modules/desktop_capture/linux/wayland/base_capturer_pipewire.cc
+index 4ef00e68ab58333648b8acaf4256f4b57a42734d..5a67c18c1d1f62aa5e3162d9778ca665bac4a1bb 100644
+--- a/modules/desktop_capture/linux/wayland/base_capturer_pipewire.cc
++++ b/modules/desktop_capture/linux/wayland/base_capturer_pipewire.cc
+@@ -109,6 +109,7 @@ void BaseCapturerPipeWire::OnScreenCastRequestResult(RequestResponse result,
+ void BaseCapturerPipeWire::OnScreenCastSessionClosed() {
+   if (!capturer_failed_) {
+     options_.screencast_stream()->StopScreenCastStream();
++    capturer_failed_ = true;
+   }
+ }
+ 

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -399,6 +399,9 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
     v8::HandleScope scope(isolate);
     gin_helper::CallMethod(this, "_onfinished", captured_sources_);
 
+    screen_capturer_.reset();
+    window_capturer_.reset();
+
     Unpin();
   }
 }
@@ -407,6 +410,9 @@ void DesktopCapturer::HandleFailure() {
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope scope(isolate);
   gin_helper::CallMethod(this, "_onerror", "Failed to get sources.");
+
+  screen_capturer_.reset();
+  window_capturer_.reset();
 
   Unpin();
 }


### PR DESCRIPTION
#### Description of Change

Delete desktop capturer objects by resetting the DesktopMediaList objects that own them after the sources have been collected. Capturers that are not delegated are already being reset via a patch on NativeDesktopMediaList. That is not safe for delegated capturers as thumbnail generation depends on user events. Deleting the DesktopMediaList object is safe for all capturers and releases OS capture resources as soon as possible.

Also added patch to workaround https://bugs.chromium.org/p/chromium/issues/detail?id=1467060. 

Fixes #39112

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `desktopCapturer` thumbnail generation after screen sharing is cancelled on Wayland.
