### PR TITLE
refactor: replace .indexOf() with .includes()

### DIFF
--- a/lib/browser/api/menu.ts
+++ b/lib/browser/api/menu.ts
@@ -82,7 +82,7 @@ Menu.prototype.popup = function (options = {}) {
 
   // find which window to use
   const wins = BaseWindow.getAllWindows();
-  if (!wins || wins.indexOf(window as any) === -1) {
+  if (!wins || !wins.includes(window as any)) {
     window = BaseWindow.getFocusedWindow() as any;
     if (!window && wins && wins.length > 0) {
       window = wins[0] as any;

--- a/script/release/prepare-release.js
+++ b/script/release/prepare-release.js
@@ -117,7 +117,7 @@ async function createRelease (branchToTarget, isBeta) {
     name: `electron ${newVersion}`,
     body: releaseBody,
     prerelease: releaseIsPrelease,
-    target_commitish: newVersion.indexOf('nightly') !== -1 ? 'main' : branchToTarget
+    target_commitish: newVersion.includes('nightly') ? 'main' : branchToTarget
   }).catch(err => {
     console.log(`${fail} Error creating new release: `, err);
     process.exit(1);

--- a/script/release/release.js
+++ b/script/release/release.js
@@ -50,7 +50,7 @@ async function getDraftRelease (version, skipValidation) {
   if (!skipValidation) {
     failureCount = 0;
     check(drafts.length === 1, 'one draft exists', true);
-    if (versionToCheck.indexOf('beta') > -1) {
+    if (versionToCheck.includes('beta')) {
       check(draft.prerelease, 'draft is a prerelease');
     }
     check(draft.body.length > 50 && !draft.body.includes('(placeholder)'), 'draft has release notes');

--- a/spec/api-menu-spec.ts
+++ b/spec/api-menu-spec.ts
@@ -948,7 +948,7 @@ describe('Menu module', function () {
       await new Promise<void>((resolve) => {
         appProcess.stdout.on('data', data => {
           output += data;
-          if (data.indexOf('Window has') > -1) {
+          if (data.includes('Window has')) {
             resolve();
           }
         });

--- a/spec/security-warnings-spec.ts
+++ b/spec/security-warnings-spec.ts
@@ -12,7 +12,7 @@ import { listen } from './lib/spec-helpers';
 import { setTimeout } from 'node:timers/promises';
 
 const messageContainsSecurityWarning = (event: Event, level: number, message: string) => {
-  return message.indexOf('Electron Security Warning') > -1;
+  return message.includes('Electron Security Warning');
 };
 
 const isLoaded = (event: Event, level: number, message: string) => {


### PR DESCRIPTION
Identified by https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-includes.md
Using the modern `includes()` instead of `indexOf()` is more readable.

Notes: none