### PR TITLE
refactor: use `TypeError` instead of generic `Error` when appropriate

### DIFF
--- a/lib/browser/api/auto-updater/auto-updater-win.ts
+++ b/lib/browser/api/auto-updater/auto-updater-win.ts
@@ -24,12 +24,12 @@ class AutoUpdater extends EventEmitter {
       if (typeof options.url === 'string') {
         updateURL = options.url;
       } else {
-        throw new Error('Expected options object to contain a \'url\' string property in setFeedUrl call');
+        throw new TypeError('Expected options object to contain a \'url\' string property in setFeedUrl call');
       }
     } else if (typeof options === 'string') {
       updateURL = options;
     } else {
-      throw new Error('Expected an options object with a \'url\' property to be provided');
+      throw new TypeError('Expected an options object with a \'url\' property to be provided');
     }
     this.updateURL = updateURL;
   }

--- a/lib/browser/api/touch-bar.ts
+++ b/lib/browser/api/touch-bar.ts
@@ -331,7 +331,7 @@ class TouchBar extends EventEmitter implements Electron.TouchBar {
     const idSet = new Set();
     items.forEach((item) => {
       if (!(item instanceof TouchBarItem)) {
-        throw new Error('Each item must be an instance of TouchBarItem');
+        throw new TypeError('Each item must be an instance of TouchBarItem');
       }
 
       if (item.type === 'other_items_proxy') {

--- a/lib/browser/api/utility-process.ts
+++ b/lib/browser/api/utility-process.ts
@@ -34,19 +34,19 @@ class ForkUtilityProcess extends EventEmitter {
 
     if (options.execArgv != null) {
       if (!Array.isArray(options.execArgv)) {
-        throw new Error('execArgv must be an array of strings.');
+        throw new TypeError('execArgv must be an array of strings.');
       }
     }
 
     if (options.serviceName != null) {
       if (typeof options.serviceName !== 'string') {
-        throw new Error('serviceName must be a string.');
+        throw new TypeError('serviceName must be a string.');
       }
     }
 
     if (options.cwd != null) {
       if (typeof options.cwd !== 'string') {
-        throw new Error('cwd path must be a string.');
+        throw new TypeError('cwd path must be a string.');
       }
     }
 

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -411,7 +411,7 @@ WebContents.prototype.getPrintersAsync = async function () {
 
 WebContents.prototype.loadFile = function (filePath, options = {}) {
   if (typeof filePath !== 'string') {
-    throw new Error('Must pass filePath as a string');
+    throw new TypeError('Must pass filePath as a string');
   }
   const { query, search, hash } = options;
 

--- a/lib/browser/api/web-frame-main.ts
+++ b/lib/browser/api/web-frame-main.ts
@@ -13,7 +13,7 @@ Object.defineProperty(WebFrameMain.prototype, 'ipc', {
 
 WebFrameMain.prototype.send = function (channel, ...args) {
   if (typeof channel !== 'string') {
-    throw new Error('Missing required channel argument');
+    throw new TypeError('Missing required channel argument');
   }
 
   try {
@@ -25,7 +25,7 @@ WebFrameMain.prototype.send = function (channel, ...args) {
 
 WebFrameMain.prototype._sendInternal = function (channel, ...args) {
   if (typeof channel !== 'string') {
-    throw new Error('Missing required channel argument');
+    throw new TypeError('Missing required channel argument');
   }
 
   try {

--- a/lib/browser/ipc-main-impl.ts
+++ b/lib/browser/ipc-main-impl.ts
@@ -16,7 +16,7 @@ export class IpcMainImpl extends EventEmitter {
       throw new Error(`Attempted to register a second handler for '${method}'`);
     }
     if (typeof fn !== 'function') {
-      throw new Error(`Expected handler to be a function, but found type '${typeof fn}'`);
+      throw new TypeError(`Expected handler to be a function, but found type '${typeof fn}'`);
     }
     this._invokeHandlers.set(method, fn);
   };

--- a/lib/renderer/web-view/guest-view-internal.ts
+++ b/lib/renderer/web-view/guest-view-internal.ts
@@ -20,7 +20,7 @@ export function deregisterEvents (viewInstanceId: number) {
 
 export function createGuest (iframe: HTMLIFrameElement, elementInstanceId: number, params: Record<string, any>): Promise<number> {
   if (!(iframe instanceof HTMLIFrameElement)) {
-    throw new Error('Invalid embedder frame');
+    throw new TypeError('Invalid embedder frame');
   }
 
   const embedderFrameId = webFrame.getWebFrameId(iframe.contentWindow!);

--- a/script/release/uploaders/upload-to-github.ts
+++ b/script/release/uploaders/upload-to-github.ts
@@ -18,7 +18,7 @@ const releaseId = parseInt(process.argv[4], 10);
 const releaseVersion = process.argv[5];
 
 if (isNaN(releaseId)) {
-  throw new Error('Provided release ID was not a valid integer');
+  throw new TypeError('Provided release ID was not a valid integer');
 }
 
 const getHeaders = (filePath: string, fileName: string) => {

--- a/spec/lib/video-helpers.js
+++ b/spec/lib/video-helpers.js
@@ -477,7 +477,7 @@ WhammyVideo.prototype.add = function (frame, duration) {
     // quickly store image data so we don't block cpu. encode in compile method.
     frame = frame.getContext('2d').getImageData(0, 0, frame.width, frame.height);
   } else if (typeof frame !== 'string') {
-    throw new Error('frame must be a a HTMLCanvasElement, a CanvasRenderingContext2D or a DataURI formatted string');
+    throw new TypeError('frame must be a a HTMLCanvasElement, a CanvasRenderingContext2D or a DataURI formatted string');
   }
   if (typeof frame === 'string' && !(/^data:image\/webp;base64,/ig).test(frame)) {
     throw new Error('Input must be formatted properly as a base64 encoded DataURI of type image/webp');


### PR DESCRIPTION
Identified by https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-type-error.md

Notes: none