### PR TITLE
ci: fail appveyor build if artifacts are missing

### DIFF
--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -203,16 +203,28 @@ for:
     on_finish:
       # Uncomment this lines to enable RDP
       # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-      - cd C:\projects\src
-      - if exist out\Default\windows_toolchain_profile.json ( appveyor-retry appveyor PushArtifact out\Default\windows_toolchain_profile.json )
-      - if exist out\Default\dist.zip (appveyor-retry appveyor PushArtifact out\Default\dist.zip)
-      - if exist out\Default\shell_browser_ui_unittests.exe (appveyor-retry appveyor PushArtifact out\Default\shell_browser_ui_unittests.exe)
-      - if exist out\Default\chromedriver.zip (appveyor-retry appveyor PushArtifact out\Default\chromedriver.zip)
-      - if exist out\ffmpeg\ffmpeg.zip (appveyor-retry appveyor PushArtifact out\ffmpeg\ffmpeg.zip)
-      - if exist node_headers.zip (appveyor-retry appveyor PushArtifact node_headers.zip)
-      - if exist out\Default\mksnapshot.zip (appveyor-retry appveyor PushArtifact out\Default\mksnapshot.zip)
-      - if exist out\Default\hunspell_dictionaries.zip (appveyor-retry appveyor PushArtifact out\Default\hunspell_dictionaries.zip)
-      - if exist out\Default\electron.lib (appveyor-retry appveyor PushArtifact out\Default\electron.lib)
+      - ps: |
+          cd C:\projects\src
+          $missing_artifacts = $false
+          $artifacts_to_upload = @('dist.zip','windows_toolchain_profile.json','shell_browser_ui_unittests.exe','chromedriver.zip','ffmpeg.zip','node_headers.zip','mksnapshot.zip','electron.lib','hunspell_dictionaries.zip')
+          foreach($artifact_name in $artifacts_to_upload) {
+            if ($artifact_name -eq 'ffmpeg.zip') {
+              $artifact_file = "out\ffmpeg\ffmpeg.zip"
+            } elseif ($artifact_name -eq 'node_headers.zip') {
+              $artifact_file = $artifact_name
+            } else {
+              $artifact_file = "out\Default\$artifact_name"
+            }
+            if (Test-Path $artifact_file) {
+              appveyor-retry appveyor PushArtifact $artifact_file          
+            } else {
+              Write-warning "$artifact_name is missing and cannot be added to artifacts"
+              $missing_artifacts = $true
+            }
+          }
+          if ($missing_artifacts) {
+            throw "Build failed due to missing artifacts"
+          }
       - ps: >-
           if ((Test-Path "pdb.zip") -And ($env:GN_CONFIG -ne 'release')) {
             appveyor-retry appveyor PushArtifact pdb.zip
@@ -245,7 +257,7 @@ for:
           # Download build artifacts
           $apiUrl = 'https://ci.appveyor.com/api'
           $build_info = Invoke-RestMethod -Method Get -Uri "$apiUrl/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/builds/$env:APPVEYOR_BUILD_ID"
-          $artifacts_to_download = @('dist.zip','ffmpeg.zip','node_headers.zip','pdb.zip','electron.lib')
+          $artifacts_to_download = @('dist.zip','ffmpeg.zip','node_headers.zip','electron.lib')
           foreach ($job in $build_info.build.jobs) {
             if ($job.name -eq "Build Arm on X64 Windows") {
               $jobId = $job.jobId
@@ -257,10 +269,13 @@ for:
                 }
                 Invoke-RestMethod -Method Get -Uri "$apiUrl/buildjobs/$jobId/artifacts/$artifact_name" -OutFile $outfile
               }
+              # Uncomment the following lines to download the pdb.zip to show real stacktraces when crashes happen during testing
+              # Invoke-RestMethod -Method Get -Uri "$apiUrl/buildjobs/$jobId/artifacts/pdb.zip" -OutFile pdb.zip
+              # 7z x -y -osrc pdb.zip
             }
           }
       - ps: |
-          $out_default_zips = @('dist.zip','pdb.zip')
+          $out_default_zips = @('dist.zip')
           foreach($zip_name in $out_default_zips) {
             7z x -y -osrc\out\Default $zip_name
           }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -201,16 +201,28 @@ for:
     on_finish:
       # Uncomment this lines to enable RDP
       # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-      - cd C:\projects\src
-      - if exist out\Default\windows_toolchain_profile.json ( appveyor-retry appveyor PushArtifact out\Default\windows_toolchain_profile.json )
-      - if exist out\Default\dist.zip (appveyor-retry appveyor PushArtifact out\Default\dist.zip)
-      - if exist out\Default\shell_browser_ui_unittests.exe (appveyor-retry appveyor PushArtifact out\Default\shell_browser_ui_unittests.exe)
-      - if exist out\Default\chromedriver.zip (appveyor-retry appveyor PushArtifact out\Default\chromedriver.zip)
-      - if exist out\ffmpeg\ffmpeg.zip (appveyor-retry appveyor PushArtifact out\ffmpeg\ffmpeg.zip)
-      - if exist node_headers.zip (appveyor-retry appveyor PushArtifact node_headers.zip)
-      - if exist out\Default\mksnapshot.zip (appveyor-retry appveyor PushArtifact out\Default\mksnapshot.zip)
-      - if exist out\Default\hunspell_dictionaries.zip (appveyor-retry appveyor PushArtifact out\Default\hunspell_dictionaries.zip)
-      - if exist out\Default\electron.lib (appveyor-retry appveyor PushArtifact out\Default\electron.lib)
+      - ps: |
+          cd C:\projects\src
+          $missing_artifacts = $false
+          $artifacts_to_upload = @('dist.zip','windows_toolchain_profile.json','shell_browser_ui_unittests.exe','chromedriver.zip','ffmpeg.zip','node_headers.zip','mksnapshot.zip','electron.lib','hunspell_dictionaries.zip')
+          foreach($artifact_name in $artifacts_to_upload) {
+            if ($artifact_name -eq 'ffmpeg.zip') {
+              $artifact_file = "out\ffmpeg\ffmpeg.zip"
+            } elseif ($artifact_name -eq 'node_headers.zip') {
+              $artifact_file = $artifact_name
+            } else {
+              $artifact_file = "out\Default\$artifact_name"
+            }
+            if (Test-Path $artifact_file) {
+              appveyor-retry appveyor PushArtifact $artifact_file          
+            } else {
+              Write-warning "$artifact_name is missing and cannot be added to artifacts"
+              $missing_artifacts = $true
+            }
+          }
+          if ($missing_artifacts) {
+            throw "Build failed due to missing artifacts"
+          }
       - ps: >-
           if ((Test-Path "pdb.zip") -And ($env:GN_CONFIG -ne 'release')) {
             appveyor-retry appveyor PushArtifact pdb.zip
@@ -253,6 +265,9 @@ for:
                 }
                 Invoke-RestMethod -Method Get -Uri "$apiUrl/buildjobs/$jobId/artifacts/$artifact_name" -OutFile $outfile
               }
+              # Uncomment the following lines to download the pdb.zip to show real stacktraces when crashes happen during testing
+              # Invoke-RestMethod -Method Get -Uri "$apiUrl/buildjobs/$jobId/artifacts/pdb.zip" -OutFile pdb.zip
+              # 7z x -y -osrc pdb.zip
             }
           }
       - ps: |


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Appveyor builds with failed compilation are sometimes getting the build job marked as successful (eg https://ci.appveyor.com/project/electron-bot/electron-ia32-testing/builds/47593406/job/umjyx8edik5uob56).  The test job does fail (eg https://ci.appveyor.com/project/electron-bot/electron-ia32-testing/builds/47593406/job/56veskcjys0in3b3), but it is confusing because it looks like the build succeeds.  This PR adds a check at the end of the build to fail if the artifacts are not present.

Additionally this PR adds a commented out block to our appveyor configs to download and extract pdb.zip to get full stack traces when crashes happen during testing.  By default this file isn't downloaded as it is rather large.

See https://ci.appveyor.com/project/electron-bot/electron-ia32-testing/builds/47624753/job/7om10xv9r4xws0k6 for an example of what happens when an artifact file is missing.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
