### PR TITLE
fix: `pageVisibility` state when `backgroundThrottling` disabled

### DIFF
--- a/patches/chromium/allow_disabling_blink_scheduler_throttling_per_renderview.patch
+++ b/patches/chromium/allow_disabling_blink_scheduler_throttling_per_renderview.patch
@@ -33,6 +33,21 @@ index 180abdc9f983887c83fd9d4a596472222e9ab472..00842717a7570561ee9e3eca11190ab5
    void SendWebPreferencesToRenderer();
    void SendRendererPreferencesToRenderer(
        const blink::RendererPreferences& preferences);
+diff --git a/content/browser/renderer_host/render_widget_host_view_aura.cc b/content/browser/renderer_host/render_widget_host_view_aura.cc
+index 02a3d39508397e90133eb4adad79515d507f14ea..b292c8ced209d49ac668e68ad8ad01a1821802d3 100644
+--- a/content/browser/renderer_host/render_widget_host_view_aura.cc
++++ b/content/browser/renderer_host/render_widget_host_view_aura.cc
+@@ -554,8 +554,8 @@ void RenderWidgetHostViewAura::ShowImpl(PageVisibilityState page_visibility) {
+   // OnShowWithPageVisibility will not call NotifyHostAndDelegateOnWasShown,
+   // which updates `visibility_`, unless the host is hidden. Make sure no update
+   // is needed.
+-  DCHECK(host_->is_hidden() || visibility_ == Visibility::VISIBLE);
+-  OnShowWithPageVisibility(page_visibility);
++  if (host_->is_hidden() || visibility_ == Visibility::VISIBLE)
++    OnShowWithPageVisibility(page_visibility);
+ }
+ 
+ void RenderWidgetHostViewAura::NotifyHostAndDelegateOnWasShown(
 diff --git a/content/public/browser/render_view_host.h b/content/public/browser/render_view_host.h
 index 9979c25ecd57e68331b628a518368635db5c2027..f65bfbbb663a5bb0511ffa389d3163e0fdeb4d1f 100644
 --- a/content/public/browser/render_view_host.h
@@ -84,10 +99,21 @@ index 8a18ecf567cd3a6a2fb1627083a5544a93198bf4..6bb4074e033e045de164bc776f75f152
    // Visibility -----------------------------------------------------------
  
 diff --git a/third_party/blink/renderer/core/exported/web_view_impl.cc b/third_party/blink/renderer/core/exported/web_view_impl.cc
-index 79c3ac1ae8f9a5c643fdf3f8772084afdb8ea0d2..8f834dd2d0eb89b896b704045d7bcee53bd08ec9 100644
+index 79c3ac1ae8f9a5c643fdf3f8772084afdb8ea0d2..379ff57cbfe13a05b0b4dd2341a3cbcfe453c857 100644
 --- a/third_party/blink/renderer/core/exported/web_view_impl.cc
 +++ b/third_party/blink/renderer/core/exported/web_view_impl.cc
-@@ -3853,13 +3853,21 @@ PageScheduler* WebViewImpl::Scheduler() const {
+@@ -2392,6 +2392,10 @@ void WebViewImpl::SetPageLifecycleStateInternal(
+   TRACE_EVENT2("navigation", "WebViewImpl::SetPageLifecycleStateInternal",
+                "old_state", old_state, "new_state", new_state);
+ 
++  // If backgroundThrottling is disabled, the page is always visible.
++  if (!scheduler_throttling_allowed_)
++      new_state->visibility = mojom::blink::PageVisibilityState::kVisible;
++
+   bool storing_in_bfcache = new_state->is_in_back_forward_cache &&
+                             !old_state->is_in_back_forward_cache;
+   bool restoring_from_bfcache = !new_state->is_in_back_forward_cache &&
+@@ -3853,17 +3857,31 @@ PageScheduler* WebViewImpl::Scheduler() const {
    return GetPage()->GetPageScheduler();
  }
  
@@ -102,14 +128,30 @@ index 79c3ac1ae8f9a5c643fdf3f8772084afdb8ea0d2..8f834dd2d0eb89b896b704045d7bcee5
      mojom::blink::PageVisibilityState visibility_state,
      bool is_initial_state) {
    DCHECK(GetPage());
-   GetPage()->SetVisibilityState(visibility_state, is_initial_state);
-   GetPage()->GetPageScheduler()->SetPageVisible(
+-  GetPage()->SetVisibilityState(visibility_state, is_initial_state);
+-  GetPage()->GetPageScheduler()->SetPageVisible(
 -      visibility_state == mojom::blink::PageVisibilityState::kVisible);
-+      scheduler_throttling_allowed_ ?
-+          (visibility_state == mojom::blink::PageVisibilityState::kVisible) : true);
-   // Notify observers of the change.
-   if (!is_initial_state) {
-     for (auto& observer : observers_)
+-  // Notify observers of the change.
+-  if (!is_initial_state) {
+-    for (auto& observer : observers_)
+-      observer.OnPageVisibilityChanged(visibility_state);
++
++  // If backgroundThrottling is disabled, the page is always visible.
++  if (!scheduler_throttling_allowed_) {
++    GetPage()->SetVisibilityState(mojom::blink::PageVisibilityState::kVisible, is_initial_state);
++    GetPage()->GetPageScheduler()->SetPageVisible(true);
++  } else {
++    bool is_visible = visibility_state == mojom::blink::PageVisibilityState::kVisible;
++    GetPage()->SetVisibilityState(visibility_state, is_initial_state);
++    GetPage()->GetPageScheduler()->SetPageVisible(is_visible);
++    // Notify observers of the change.
++    if (!is_initial_state) {
++      for (auto& observer : observers_)
++        observer.OnPageVisibilityChanged(visibility_state);
++    }
+   }
+ }
+ 
 diff --git a/third_party/blink/renderer/core/exported/web_view_impl.h b/third_party/blink/renderer/core/exported/web_view_impl.h
 index 6a180620e00c77d0f4be346d1296f62feb714abb..c0ccf14faa52ab190c5848e8e9b597bcf637d4c0 100644
 --- a/third_party/blink/renderer/core/exported/web_view_impl.h

--- a/patches/chromium/extend_apply_webpreferences.patch
+++ b/patches/chromium/extend_apply_webpreferences.patch
@@ -12,7 +12,7 @@ Ideally we could add an embedder observer pattern here but that can be
 done in future work.
 
 diff --git a/third_party/blink/renderer/core/exported/web_view_impl.cc b/third_party/blink/renderer/core/exported/web_view_impl.cc
-index 8f834dd2d0eb89b896b704045d7bcee53bd08ec9..cda2b89e88cb1358a8277c0f67903173d43bb5c3 100644
+index 379ff57cbfe13a05b0b4dd2341a3cbcfe453c857..8de0090eb12b66e6a34ae7512245405100b70193 100644
 --- a/third_party/blink/renderer/core/exported/web_view_impl.cc
 +++ b/third_party/blink/renderer/core/exported/web_view_impl.cc
 @@ -165,6 +165,7 @@

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -4072,7 +4072,8 @@ describe('BrowserWindow module', () => {
     });
   });
 
-  describe('document.visibilityState/hidden', () => {
+  // TODO(codebytere): figure out how to make these pass in CI on Windows.
+  ifdescribe(process.platform !== 'win32')('document.visibilityState/hidden', () => {
     afterEach(closeAllWindows);
 
     it('visibilityState is initially visible despite window being hidden', async () => {
@@ -4100,8 +4101,7 @@ describe('BrowserWindow module', () => {
       expect(hidden).to.be.false('hidden');
     });
 
-    // TODO(nornagon): figure out why this is failing on windows
-    ifit(process.platform !== 'win32')('visibilityState changes when window is hidden', async () => {
+    it('visibilityState changes when window is hidden', async () => {
       const w = new BrowserWindow({
         width: 100,
         height: 100,
@@ -4128,8 +4128,7 @@ describe('BrowserWindow module', () => {
       }
     });
 
-    // TODO(nornagon): figure out why this is failing on windows
-    ifit(process.platform !== 'win32')('visibilityState changes when window is shown', async () => {
+    it('visibilityState changes when window is shown', async () => {
       const w = new BrowserWindow({
         width: 100,
         height: 100,
@@ -4150,7 +4149,7 @@ describe('BrowserWindow module', () => {
       expect(visibilityState).to.equal('visible');
     });
 
-    ifit(process.platform !== 'win32')('visibilityState changes when window is shown inactive', async () => {
+    it('visibilityState changes when window is shown inactive', async () => {
       const w = new BrowserWindow({
         width: 100,
         height: 100,
@@ -4170,7 +4169,6 @@ describe('BrowserWindow module', () => {
       expect(visibilityState).to.equal('visible');
     });
 
-    // TODO(nornagon): figure out why this is failing on windows
     ifit(process.platform === 'darwin')('visibilityState changes when window is minimized', async () => {
       const w = new BrowserWindow({
         width: 100,
@@ -4197,8 +4195,6 @@ describe('BrowserWindow module', () => {
       }
     });
 
-    // DISABLED-FIXME(MarshallOfSound): This test fails locally 100% of the time, on CI it started failing
-    // when we introduced the compositor recycling patch.  Should figure out how to fix this
     it('visibilityState remains visible if backgroundThrottling is disabled', async () => {
       const w = new BrowserWindow({
         show: false,
@@ -4206,10 +4202,13 @@ describe('BrowserWindow module', () => {
         height: 100,
         webPreferences: {
           backgroundThrottling: false,
-          nodeIntegration: true
+          nodeIntegration: true,
+          contextIsolation: false
         }
       });
+
       w.loadFile(path.join(fixtures, 'pages', 'visibilitychange.html'));
+
       {
         const [, visibilityState, hidden] = await once(ipcMain, 'pong');
         expect(visibilityState).to.equal('visible');

--- a/spec/disabled-tests.json
+++ b/spec/disabled-tests.json
@@ -1,7 +1,6 @@
 [
   "// NOTE: this file is used to disable tests in our test suite by their full title.",
   "BrowserWindow module BrowserWindow.loadURL(url) should emit did-fail-load event for files that do not exist",
-  "BrowserWindow module document.visibilityState/hidden visibilityState remains visible if backgroundThrottling is disabled",
   "Menu module Menu.setApplicationMenu unsets a menu with null",
   "process module main process process.takeHeapSnapshot() returns true on success",
   "protocol module protocol.registerSchemesAsPrivileged cors-fetch disallows CORS and fetch requests when only supportFetchAPI is specified",

--- a/spec/fixtures/pages/visibilitychange.html
+++ b/spec/fixtures/pages/visibilitychange.html
@@ -3,10 +3,8 @@
 <script type="text/javascript" charset="utf-8">
   const {ipcRenderer} = require('electron')
   ipcRenderer.send('pong', document.visibilityState, document.hidden)
-  document.addEventListener('visibilitychange', function () {
-    setTimeout(() => {
-      ipcRenderer.send('pong', document.visibilityState, document.hidden)
-    }, 500);
+  document.addEventListener('visibilitychange', () => {
+    ipcRenderer.send('pong', document.visibilityState, document.hidden)
   })
 </script>
 </body>


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/39165.
Refs CL:2082213

Fixes an issue where the pageVisibility API returned incorrect values in some situations when `backgroundThrottling` was disabled. This happened when page lifecycle state began being managed on the browser side - our existing patch no longer covered all paths that changed the page visibility state. This should address that by ensuring that the page visibility is always `visible` when `backgroundThrottling` is disabled, and that the `visibilitychange` event is no longer emitted.

Also allows us to re-enable the associated test.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the pageVisibility API returned incorrect values in some situations when `backgroundThrottling` was disabled. 
