### PR TITLE
fix: traffic lights not working when child windows are restored via parent window

### DIFF
--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.h
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.h
@@ -23,6 +23,10 @@ class NativeWindowMac;
   int level_;
   bool is_resizable_;
 
+  // Whether the window is currently minimized. Used to work
+  // around a macOS bug with child window minimization.
+  bool is_minimized_;
+
   // Only valid during a live resize.
   // Used to keep track of whether a resize is happening horizontally or
   // vertically, even if physically the user is resizing in both directions.

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -55,10 +55,22 @@ using FullScreenTransitionState =
 
   // check occlusion binary flag
   if (window.occlusionState & NSWindowOcclusionStateVisible) {
-    // The app is visible
+    // There's a macOS bug where if a child window is minimized, and then both
+    // windows are restored via activation of the parent window, the child
+    // window is not properly deminiaturized. This causes traffic light bugs
+    // like the close and miniaturize buttons having no effect. We need to call
+    // deminiaturize on the child window to fix this. Unfortunately, this also
+    // hits ANOTHER bug where even after calling deminiaturize,
+    // windowDidDeminiaturize is not posted on the child window if it was
+    // incidentally restored by the parent, so we need to manually reset
+    // is_minimized_ here.
+    if (shell_->parent() && is_minimized_) {
+      shell_->Restore();
+      is_minimized_ = false;
+    }
+
     shell_->NotifyWindowShow();
   } else {
-    // The app is not visible
     shell_->NotifyWindowHide();
   }
 }
@@ -248,11 +260,15 @@ using FullScreenTransitionState =
 
 - (void)windowDidMiniaturize:(NSNotification*)notification {
   [super windowDidMiniaturize:notification];
+  is_minimized_ = true;
+
   shell_->NotifyWindowMinimize();
 }
 
 - (void)windowDidDeminiaturize:(NSNotification*)notification {
   [super windowDidDeminiaturize:notification];
+  is_minimized_ = false;
+
   shell_->AttachChildren();
   shell_->SetWindowLevel(level_);
   shell_->NotifyWindowRestore();


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/39078.

This is rooted in a macOS bug where if a child window is minimized, and then both windows are restored via activation of the parent window, the child window is not properly deminiaturized. This causes traffic light bugs like the close and miniaturize buttons having no effect. We need to call deminiaturize on the child window to fix this. Unfortunately, this also hits ANOTHER bug where even after calling deminiaturize, `windowDidDeminiaturize` is not posted on the child window if it was restored as a side effect of parent restoration, so we need to manually reset `is_minimized_` here.

Tested with https://gist.github.com/pushkin-/c7f43c9692b085adca3a784a390eb89b.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where macOS traffic lights could malfunction on child windows in some circumstances.
