### PR TITLE
fix: potential crash calling `tray.popUpContextMenu()`

### DIFF
--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -342,7 +342,9 @@ void Tray::PopUpContextMenu(gin::Arguments* args) {
       }
     }
   }
-  tray_icon_->PopUpContextMenu(pos, menu.IsEmpty() ? nullptr : menu->model());
+
+  tray_icon_->PopUpContextMenu(
+      pos, menu.IsEmpty() ? nullptr : menu->model()->GetWeakPtr());
 }
 
 void Tray::CloseContextMenu() {

--- a/shell/browser/ui/tray_icon.cc
+++ b/shell/browser/ui/tray_icon.cc
@@ -21,7 +21,7 @@ void TrayIcon::RemoveBalloon() {}
 void TrayIcon::Focus() {}
 
 void TrayIcon::PopUpContextMenu(const gfx::Point& pos,
-                                raw_ptr<ElectronMenuModel> menu_model) {}
+                                base::WeakPtr<ElectronMenuModel> menu_model) {}
 
 void TrayIcon::CloseContextMenu() {}
 

--- a/shell/browser/ui/tray_icon.h
+++ b/shell/browser/ui/tray_icon.h
@@ -89,7 +89,7 @@ class TrayIcon {
 
   // Popups the menu.
   virtual void PopUpContextMenu(const gfx::Point& pos,
-                                raw_ptr<ElectronMenuModel> menu_model);
+                                base::WeakPtr<ElectronMenuModel> menu_model);
 
   virtual void CloseContextMenu();
 

--- a/shell/browser/ui/tray_icon_cocoa.h
+++ b/shell/browser/ui/tray_icon_cocoa.h
@@ -32,11 +32,11 @@ class TrayIconCocoa : public TrayIcon {
   std::string GetTitle() override;
   void SetIgnoreDoubleClickEvents(bool ignore) override;
   bool GetIgnoreDoubleClickEvents() override;
-  void PopUpOnUI(ElectronMenuModel* menu_model);
+  void PopUpOnUI(base::WeakPtr<ElectronMenuModel> menu_model);
   void PopUpContextMenu(const gfx::Point& pos,
-                        raw_ptr<ElectronMenuModel>) override;
+                        base::WeakPtr<ElectronMenuModel> menu_model) override;
   void CloseContextMenu() override;
-  void SetContextMenu(raw_ptr<ElectronMenuModel>) override;
+  void SetContextMenu(raw_ptr<ElectronMenuModel> menu_model) override;
   gfx::Rect GetBounds() override;
 
  private:

--- a/shell/browser/ui/win/notify_icon.cc
+++ b/shell/browser/ui/win/notify_icon.cc
@@ -86,7 +86,7 @@ void NotifyIcon::HandleClickEvent(int modifiers,
     return;
   } else if (!double_button_click) {  // single right click
     if (menu_model_)
-      PopUpContextMenu(gfx::Point(), menu_model_);
+      PopUpContextMenu(gfx::Point(), menu_model_->GetWeakPtr());
     else
       NotifyRightClicked(bounds, modifiers);
   }
@@ -191,7 +191,7 @@ void NotifyIcon::Focus() {
 }
 
 void NotifyIcon::PopUpContextMenu(const gfx::Point& pos,
-                                  raw_ptr<ElectronMenuModel> menu_model) {
+                                  base::WeakPtr<ElectronMenuModel> menu_model) {
   // Returns if context menu isn't set.
   if (menu_model == nullptr && menu_model_ == nullptr)
     return;
@@ -209,9 +209,13 @@ void NotifyIcon::PopUpContextMenu(const gfx::Point& pos,
   if (pos.IsOrigin())
     rect.set_origin(display::Screen::GetScreen()->GetCursorScreenPoint());
 
-  menu_runner_ = std::make_unique<views::MenuRunner>(
-      menu_model != nullptr ? menu_model : menu_model_,
-      views::MenuRunner::HAS_MNEMONICS);
+  if (menu_model) {
+    menu_runner_ = std::make_unique<views::MenuRunner>(
+        menu_model.get(), views::MenuRunner::HAS_MNEMONICS);
+  } else {
+    menu_runner_ = std::make_unique<views::MenuRunner>(
+        menu_model_, views::MenuRunner::HAS_MNEMONICS);
+  }
   menu_runner_->RunMenuAt(nullptr, nullptr, rect,
                           views::MenuAnchorPosition::kTopLeft,
                           ui::MENU_SOURCE_MOUSE);

--- a/shell/browser/ui/win/notify_icon.h
+++ b/shell/browser/ui/win/notify_icon.h
@@ -13,6 +13,7 @@
 #include <string>
 
 #include "base/compiler_specific.h"
+#include "base/memory/weak_ptr.h"
 #include "base/win/scoped_gdi_object.h"
 #include "shell/browser/ui/tray_icon.h"
 #include "shell/browser/ui/win/notify_icon_host.h"
@@ -65,7 +66,7 @@ class NotifyIcon : public TrayIcon {
   void RemoveBalloon() override;
   void Focus() override;
   void PopUpContextMenu(const gfx::Point& pos,
-                        raw_ptr<ElectronMenuModel> menu_model) override;
+                        base::WeakPtr<ElectronMenuModel> menu_model) override;
   void CloseContextMenu() override;
   void SetContextMenu(raw_ptr<ElectronMenuModel> menu_model) override;
   gfx::Rect GetBounds() override;


### PR DESCRIPTION
#### Description of Change

Speculative fix for a crash i've been seeing in CI a fair bit recently, but haven't been able to repro locally. It looks like the ElectronMenuModel is going away before this callback is called. We use `base::Unretained` here which isn't safe if we can't guarantee lifetime which I don't think we can here.

[Sample Failure](https://app.circleci.com/pipelines/github/electron/electron/72626/workflows/3b520c71-d6d4-410e-8e7e-d02decab2211/jobs/1570135)

<details><summary>Stacktrace</summary>
<p>

```
Received signal 11 SEGV_MAPERR 000000000018
0   Electron Framework                  0x0000000129ff4632 base::debug::CollectStackTrace(void**, unsigned long) + 18
1   Electron Framework                  0x0000000129fe2393 base::debug::StackTrace::StackTrace() + 19
2   Electron Framework                  0x0000000129ff4581 base::debug::(anonymous namespace)::StackDumpSignalHandler(int, __siginfo*, void*) + 1361
3   libsystem_platform.dylib            0x00007ff8126dedfd _sigtramp + 29
4   ???                                 0x00006000023fd380 0x0 + 105553154003840
5   Electron Framework                  0x0000000129bcc352 base::internal::Invoker<base::internal::BindState<void (electron::TrayIconCocoa::*)(electron::ElectronMenuModel*), base::WeakPtr<electron::TrayIconCocoa>, base::internal::UnretainedWrapper<electron::ElectronMenuModel, base::unretained_traits::MayNotDangle, (base::RawPtrTraits)0>>, void ()>::RunOnce(base::internal::BindStateBase*) + 98
6   Electron Framework                  0x0000000129f66dec base::TaskAnnotator::RunTaskImpl(base::PendingTask&) + 300
7   Electron Framework                  0x0000000129f96f17 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*) + 1655
8   Electron Framework                  0x0000000129f962e4 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() + 132
9   Electron Framework                  0x0000000129f97ae5 non-virtual thunk to base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() + 21
10  Electron Framework                  0x0000000129ffcfbc base::MessagePumpCFRunLoopBase::RunWork() + 204
11  Electron Framework                  0x0000000129ffce93 ___ZN4base24MessagePumpCFRunLoopBase19RunDelayedWorkTimerEP16__CFRunLoopTimerPv_block_invoke + 51
12  Electron Framework                  0x0000000129ffbe32 base::mac::CallWithEHFrame(void () block_pointer) + 10
13  Electron Framework                  0x0000000129ffc42f base::MessagePumpCFRunLoopBase::RunDelayedWorkTimer(__CFRunLoopTimer*, void*) + 63
14  CoreFoundation                      0x00007ff8127a8f69 __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 20
15  CoreFoundation                      0x00007ff8127a8a58 __CFRunLoopDoTimer + 923
16  CoreFoundation                      0x00007ff8127a85c8 __CFRunLoopDoTimers + 307
17  CoreFoundation                      0x00007ff81278ed06 __CFRunLoopRun + 2010
18  CoreFoundation                      0x00007ff81278de6c CFRunLoopRunSpecific + 562
19  HIToolbox                           0x00007ff81b43c5e6 RunCurrentEventLoopInMode + 292
20  HIToolbox                           0x00007ff81b43c34a ReceiveNextEventCommon + 594
21  HIToolbox                           0x00007ff81b43c0e5 _BlockUntilNextEventMatchingListInModeWithFilter + 70
22  AppKit                              0x00007ff8151c7fad _DPSNextEvent + 927
23  AppKit                              0x00007ff8151c666a -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1394
24  AppKit                              0x00007ff8151b8d19 -[NSApplication run] + 586
25  Electron Framework                  0x0000000129ffdacf base::MessagePumpNSApplication::DoRun(base::MessagePump::Delegate*) + 511
26  Electron Framework                  0x0000000129ffbec3 base::MessagePumpCFRunLoopBase::Run(base::MessagePump::Delegate*) + 131
27  Electron Framework                  0x0000000129f9806b base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) + 539
28  Electron Framework                  0x0000000129f40925 base::RunLoop::Run(base::Location const&) + 437
29  Electron Framework                  0x000000012878cdc2 content::BrowserMainLoop::RunMainMessageLoop() + 146
30  Electron Framework                  0x000000012878f195 content::BrowserMainRunnerImpl::Run() + 37
31  Electron Framework                  0x0000000128789c1a content::BrowserMain(content::MainFunctionParams) + 154
32  Electron Framework                  0x000000012466951c content::RunBrowserProcessMain(content::MainFunctionParams, content::ContentMainDelegate*) + 284
33  Electron Framework                  0x000000012466aa97 content::ContentMainRunnerImpl::RunBrowser(content::MainFunctionParams, bool) + 631
34  Electron Framework                  0x000000012466a678 content::ContentMainRunnerImpl::Run() + 824
35  Electron Framework                  0x0000000124668a3e content::RunContentProcess(content::ContentMainParams, content::ContentMainRunner*) + 1454
36  Electron Framework                  0x0000000124668d03 content::ContentMain(content::ContentMainParams) + 115
37  Electron Framework                  0x00000001241eeaf0 ElectronMain + 160
38  dyld                                0x000000010b08352e start + 462
[end of stack trace]
✗ Electron tests failed with kill signal SIGSEGV.
```

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash when calling `tray.popUpContextMenu` on macOS.
