### PR TITLE
docs: fix return type for ipcMain handle functions

### DIFF
--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -72,7 +72,7 @@ Removes listeners of the specified `channel`.
 ### `ipcMain.handle(channel, listener)`
 
 * `channel` string
-* `listener` Function<Promise\<void&#62; | any&#62;
+* `listener` Function<Promise\<any&#62; | any&#62;
   * `event` [IpcMainInvokeEvent][ipc-main-invoke-event]
   * `...args` any[]
 
@@ -109,7 +109,7 @@ provided to the renderer process. Please refer to
 ### `ipcMain.handleOnce(channel, listener)`
 
 * `channel` string
-* `listener` Function<Promise\<void&#62; | any&#62;
+* `listener` Function<Promise\<any&#62; | any&#62;
   * `event` [IpcMainInvokeEvent][ipc-main-invoke-event]
   * `...args` any[]
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Per the description, the value resolved by the promise is used, so it shouldn't be `Promise<void>`. From a practical standpoint this has little effect on typing since the union with `any` makes the whole thing `any`, but better to be accurate in the docs. Ideally we'd replace `any` with a type union of IPC serializable types, but we don't have an easy way to do that at the moment.

cc @electron/docs 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
