### PR TITLE
fix: promise resolved to early when browser initiated in-page navigation

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -447,7 +447,7 @@ WebContents.prototype.loadURL = function (url, options) {
     };
 
     let navigationStarted = false;
-    let browserIntendentInPageNavigation = false;
+    let browserInitiatedInPageNavigation = false;
     const navigationListener = (event: Electron.Event, url: string, isSameDocument: boolean, isMainFrame: boolean) => {
       if (isMainFrame) {
         if (navigationStarted && !isSameDocument) {
@@ -462,7 +462,7 @@ WebContents.prototype.loadURL = function (url, options) {
           // as the routing does not leave the document
           return rejectAndCleanup(-3, 'ERR_ABORTED', url);
         }
-        browserIntendentInPageNavigation = navigationStarted && isSameDocument;
+        browserInitiatedInPageNavigation = navigationStarted && isSameDocument;
         navigationStarted = true;
       }
     };
@@ -477,22 +477,22 @@ WebContents.prototype.loadURL = function (url, options) {
       // would be more appropriate.
       rejectAndCleanup(-2, 'ERR_FAILED', url);
     };
-    const finishListenerWhenUserIntendentNavigation = () => {
-      if (!browserIntendentInPageNavigation) {
+    const finishListenerWhenUserInitiatedNavigation = () => {
+      if (!browserInitiatedInPageNavigation) {
         finishListener();
       }
     };
     const removeListeners = () => {
       this.removeListener('did-finish-load', finishListener);
       this.removeListener('did-fail-load', failListener);
-      this.removeListener('did-navigate-in-page', finishListenerWhenUserIntendentNavigation);
+      this.removeListener('did-navigate-in-page', finishListenerWhenUserInitiatedNavigation);
       this.removeListener('did-start-navigation', navigationListener);
       this.removeListener('did-stop-loading', stopLoadingListener);
       this.removeListener('destroyed', stopLoadingListener);
     };
     this.on('did-finish-load', finishListener);
     this.on('did-fail-load', failListener);
-    this.on('did-navigate-in-page', finishListenerWhenUserIntendentNavigation);
+    this.on('did-navigate-in-page', finishListenerWhenUserInitiatedNavigation);
     this.on('did-start-navigation', navigationListener);
     this.on('did-stop-loading', stopLoadingListener);
     this.on('destroyed', stopLoadingListener);

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -447,7 +447,7 @@ WebContents.prototype.loadURL = function (url, options) {
     };
 
     let navigationStarted = false;
-    let browser_intendent_in_page_navigation = false;
+    let browserIntendentInPageNavigation = false;
     const navigationListener = (event: Electron.Event, url: string, isSameDocument: boolean, isMainFrame: boolean) => {
       if (isMainFrame) {
         if (navigationStarted && !isSameDocument) {
@@ -462,7 +462,7 @@ WebContents.prototype.loadURL = function (url, options) {
           // as the routing does not leave the document
           return rejectAndCleanup(-3, 'ERR_ABORTED', url);
         }
-        browser_intendent_in_page_navigation = navigationStarted && isSameDocument;
+        browserIntendentInPageNavigation = navigationStarted && isSameDocument;
         navigationStarted = true;
       }
     };
@@ -478,7 +478,7 @@ WebContents.prototype.loadURL = function (url, options) {
       rejectAndCleanup(-2, 'ERR_FAILED', url);
     };
     const finishListenerWhenUserIntendentNavigation = () => {
-      if (!browser_intendent_in_page_navigation) {
+      if (!browserIntendentInPageNavigation) {
         finishListener();
       }
     };

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -447,6 +447,7 @@ WebContents.prototype.loadURL = function (url, options) {
     };
 
     let navigationStarted = false;
+    let browser_intendent_in_page_navigation = false;
     const navigationListener = (event: Electron.Event, url: string, isSameDocument: boolean, isMainFrame: boolean) => {
       if (isMainFrame) {
         if (navigationStarted && !isSameDocument) {
@@ -461,6 +462,7 @@ WebContents.prototype.loadURL = function (url, options) {
           // as the routing does not leave the document
           return rejectAndCleanup(-3, 'ERR_ABORTED', url);
         }
+        browser_intendent_in_page_navigation = navigationStarted && isSameDocument;
         navigationStarted = true;
       }
     };
@@ -475,17 +477,22 @@ WebContents.prototype.loadURL = function (url, options) {
       // would be more appropriate.
       rejectAndCleanup(-2, 'ERR_FAILED', url);
     };
+    const finishListenerWhenUserIntendentNavigation = () => {
+      if (!browser_intendent_in_page_navigation) {
+        finishListener();
+      }
+    };
     const removeListeners = () => {
       this.removeListener('did-finish-load', finishListener);
       this.removeListener('did-fail-load', failListener);
-      this.removeListener('did-navigate-in-page', finishListener);
+      this.removeListener('did-navigate-in-page', finishListenerWhenUserIntendentNavigation);
       this.removeListener('did-start-navigation', navigationListener);
       this.removeListener('did-stop-loading', stopLoadingListener);
       this.removeListener('destroyed', stopLoadingListener);
     };
     this.on('did-finish-load', finishListener);
     this.on('did-fail-load', failListener);
-    this.on('did-navigate-in-page', finishListener);
+    this.on('did-navigate-in-page', finishListenerWhenUserIntendentNavigation);
     this.on('did-start-navigation', navigationListener);
     this.on('did-stop-loading', stopLoadingListener);
     this.on('destroyed', stopLoadingListener);

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -375,7 +375,7 @@ describe('webContents module', () => {
       await expect(w.loadURL(w.getURL() + '#foo')).to.eventually.be.fulfilled();
     });
 
-    it('resolves after browser intendent navigation', async () => {
+    it('resolves after browser initiated navigation', async () => {
       let finishedLoading = false;
       w.webContents.on('did-finish-load', function () {
         finishedLoading = true;

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -377,7 +377,7 @@ describe('webContents module', () => {
 
     it('resolves after browser intendent navigation', async () => {
       let finishedLoading = false;
-      w.webContents.on('did-finish-load', function() {
+      w.webContents.on('did-finish-load', function () {
           finishedLoading = true;
       });
 

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -375,6 +375,16 @@ describe('webContents module', () => {
       await expect(w.loadURL(w.getURL() + '#foo')).to.eventually.be.fulfilled();
     });
 
+    it('resolves after browser intendent navigation', async () => {
+      let finishedLoading = false;
+      w.webContents.on('did-finish-load', function() {
+          finishedLoading = true;
+      });
+
+      await w.loadFile(path.join(fixturesPath, 'pages', 'navigate_in_page_and_wait.html'));
+      expect(finishedLoading).to.be.true();
+    });
+
     it('rejects when failing to load a file URL', async () => {
       await expect(w.loadURL('file:non-existent')).to.eventually.be.rejected()
         .and.have.property('code', 'ERR_FILE_NOT_FOUND');

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -378,7 +378,7 @@ describe('webContents module', () => {
     it('resolves after browser intendent navigation', async () => {
       let finishedLoading = false;
       w.webContents.on('did-finish-load', function () {
-          finishedLoading = true;
+        finishedLoading = true;
       });
 
       await w.loadFile(path.join(fixturesPath, 'pages', 'navigate_in_page_and_wait.html'));

--- a/spec/fixtures/pages/navigate_in_page_and_wait.html
+++ b/spec/fixtures/pages/navigate_in_page_and_wait.html
@@ -1,0 +1,13 @@
+<html>
+<header>
+<script type="text/javascript">
+  window.history.replaceState(window.location.href, "Sample Title", window.location.href);
+  // Simulate that we load web page.
+  for (let i = 0; i < 10000; i++) {
+    console.log('wait : ' + i);
+  }
+</script>
+</header>
+<body>
+</body>
+</html>


### PR DESCRIPTION
#### Description of Change

After this fix [https://github.com/electron/electron/pull/36129](https://github.com/electron/electron/pull/36129) promise returned by `loadURL` function can be resolved before page finish loading. While page is loading it can trigger browser intendent in page navigation (e.g.: `window.history.replaceState` ). This PR fixes this problem.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix problem with promise resolved to early when browser intendent in-page navigation <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
