### PR TITLE
chore: update @electron/lint-roller and improve doc type checks

### DIFF
--- a/docs/development/creating-api.md
+++ b/docs/development/creating-api.md
@@ -129,7 +129,7 @@ void Initialize(v8::Local<v8::Object> exports,
 
 In the [`typings/internal-ambient.d.ts`](https://github.com/electron/electron/blob/main/typings/internal-ambient.d.ts) file, we need to append a new property onto the `Process` interface like so:
 
-```ts title='typings/internal-ambient.d.ts'
+```ts title='typings/internal-ambient.d.ts' @ts-nocheck
 interface Process {
     _linkedBinding(name: 'electron_browser_{api_name}'): Electron.ApiName;
 }
@@ -164,7 +164,7 @@ An example of the contents of this file can be found [here](https://github.com/e
 
 Add your module to the module list found at `"lib/browser/api/module-list.ts"` like so:
 
-```typescript title='lib/browser/api/module-list.ts'
+```typescript title='lib/browser/api/module-list.ts' @ts-nocheck
 export const browserModuleList: ElectronInternal.ModuleEntry[] = [
   { name: 'apiName', loader: () => require('./api-name') },
 ];

--- a/docs/tutorial/context-isolation.md
+++ b/docs/tutorial/context-isolation.md
@@ -84,7 +84,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
 You can create a `renderer.d.ts` declaration file and globally augment the `Window` interface:
 
-```typescript title='renderer.d.ts'
+```typescript title='renderer.d.ts' @ts-noisolate
 export interface IElectronAPI {
   loadPreferences: () => Promise<void>,
 }
@@ -98,7 +98,7 @@ declare global {
 
 Doing so will ensure that the TypeScript compiler will know about the `electronAPI` property on your global `window` object when writing scripts in your renderer process:
 
-```typescript title='renderer.ts' @ts-nocheck
+```typescript title='renderer.ts'
 window.electronAPI.loadPreferences()
 ```
 

--- a/docs/tutorial/ipc.md
+++ b/docs/tutorial/ipc.md
@@ -412,7 +412,7 @@ function createWindow () {
 For the purposes of the tutorial, it's important to note that the `click` handler
 sends a message (either `1` or `-1`) to the renderer process through the `update-counter` channel.
 
-```javascript @ts-nocheck
+```javascript @ts-type={mainWindow:Electron.BrowserWindow}
 click: () => mainWindow.webContents.send('update-counter', -1)
 ```
 
@@ -486,13 +486,13 @@ To tie it all together, we'll create an interface in the loaded HTML file that c
 Finally, to make the values update in the HTML document, we'll add a few lines of DOM manipulation
 so that the value of the `#counter` element is updated whenever we fire an `update-counter` event.
 
-```javascript title='renderer.js (Renderer Process)' @ts-nocheck
+```javascript title='renderer.js (Renderer Process)' @ts-window-type={electronAPI:{onUpdateCounter:(callback:(event:Electron.IpcRendererEvent,value:number)=>void)=>void}}
 const counter = document.getElementById('counter')
 
 window.electronAPI.onUpdateCounter((_event, value) => {
   const oldValue = Number(counter.innerText)
   const newValue = oldValue + value
-  counter.innerText = newValue
+  counter.innerText = newValue.toString()
 })
 ```
 
@@ -509,13 +509,13 @@ We can demonstrate this with slight modifications to the code from the previous 
 renderer process, use the `event` parameter to send a reply back to the main process through the
 `counter-value` channel.
 
-```javascript title='renderer.js (Renderer Process)' @ts-nocheck
+```javascript title='renderer.js (Renderer Process)' @ts-window-type={electronAPI:{onUpdateCounter:(callback:(event:Electron.IpcRendererEvent,value:number)=>void)=>void}}
 const counter = document.getElementById('counter')
 
 window.electronAPI.onUpdateCounter((event, value) => {
   const oldValue = Number(counter.innerText)
   const newValue = oldValue + value
-  counter.innerText = newValue
+  counter.innerText = newValue.toString()
   event.sender.send('counter-value', newValue)
 })
 ```

--- a/docs/tutorial/message-ports.md
+++ b/docs/tutorial/message-ports.md
@@ -126,7 +126,7 @@ app.whenReady().then(async () => {
 Then, in your preload scripts you receive the port through IPC and set up the
 listeners.
 
-```js title='preloadMain.js and preloadSecondary.js (Preload scripts)' @ts-nocheck
+```js title='preloadMain.js and preloadSecondary.js (Preload scripts)' @ts-window-type={electronMessagePort:MessagePort}
 const { ipcRenderer } = require('electron')
 
 ipcRenderer.on('port', e => {
@@ -148,7 +148,7 @@ That means window.electronMessagePort is globally available and you can call
 `postMessage` on it from anywhere in your app to send a message to the other
 renderer.
 
-```js title='renderer.js (Renderer Process)' @ts-nocheck
+```js title='renderer.js (Renderer Process)' @ts-window-type={electronMessagePort:MessagePort}
 // elsewhere in your code to send a message to the other renderers message handler
 window.electronMessagePort.postMessage('ping')
 ```

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@electron/docs-parser": "^1.1.1",
     "@electron/fiddle-core": "^1.0.4",
     "@electron/github-app-auth": "^2.0.0",
-    "@electron/lint-roller": "^1.5.0",
+    "@electron/lint-roller": "^1.8.0",
     "@electron/typescript-definitions": "^8.14.5",
     "@octokit/rest": "^19.0.7",
     "@primer/octicons": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,12 +199,13 @@
     "@octokit/auth-app" "^4.0.13"
     "@octokit/rest" "^19.0.11"
 
-"@electron/lint-roller@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@electron/lint-roller/-/lint-roller-1.5.0.tgz#9b743979e1b03327e475fa696bb781eb2ea05ef2"
-  integrity sha512-205UxwJEx8zv5wLwPq4wMA0OYrJ7d1GuqOhPav0Uy2HWe4K+DZbSP50safCvZCSpI6Op3DMo79tp5i8VppuPWA==
+"@electron/lint-roller@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@electron/lint-roller/-/lint-roller-1.8.0.tgz#26c29f2b2b7eaa9429fde04b178d7fdfe9d56da9"
+  integrity sha512-4LKE2SeSM3kdorDoFMzvZBTKvNUPAJl8apH9e1E9Gb5SKhFBZuG9CIJwtPKwtRYiGmBfu/HxoHuGEGkycxM+3Q==
   dependencies:
     "@dsanders11/vscode-markdown-languageservice" "^0.3.0"
+    balanced-match "^2.0.0"
     glob "^8.1.0"
     markdown-it "^13.0.1"
     markdownlint-cli "^0.33.0"
@@ -1570,6 +1571,11 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+balanced-match@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
+  integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
 
 base64-js@^1.3.1:
   version "1.5.1"


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Tightens up a few remaining usages of blocks which were using `@ts-nocheck`, and starts type checking TypeScript blocks as well. Allows typing variables on the `Window` object, which would have caught #39130.

The remaining usages of `@ts-nocheck` are mostly code blocks using external modules where adding the types would add extra complexity for small gain. Good enough for now, support for external module type checking may be added to `@electron/lint-roller` in the future.

cc @electron/docs

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
