### PR TITLE
chore: cherry-pick 8fcc6df from webrtc

### DIFF
--- a/patches/webrtc/.patches
+++ b/patches/webrtc/.patches
@@ -1,3 +1,4 @@
 fix_fallback_to_x11_capturer_on_wayland.patch
 cherry-pick-0e9556a90cec.patch
 fix_mark_pipewire_capturer_as_failed_after_session_is_closed.patch
+pipewire_capturer_increase_buffer_size_to_avoid_buffer_overflow.patch

--- a/patches/webrtc/pipewire_capturer_increase_buffer_size_to_avoid_buffer_overflow.patch
+++ b/patches/webrtc/pipewire_capturer_increase_buffer_size_to_avoid_buffer_overflow.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jan Grulich <grulja@gmail.com>
+Date: Mon, 10 Jul 2023 10:07:38 +0200
+Subject: PipeWire capturer: increase buffer size to avoid buffer overflow
+
+Recently added framerate option can cause a buffer overflow and make
+PipeWire to fail on negotiation, which effectively makes screen sharing
+not to work.
+
+Bug: webrtc:15346
+Change-Id: I4a68e26c8f85ca287b06a25da500b6a7009e075f
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/311541
+Reviewed-by: Alexander Cooper <alcooper@chromium.org>
+Commit-Queue: Jan Grulich <grulja@gmail.com>
+Cr-Commit-Position: refs/heads/main@{#40413}
+
+diff --git a/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc b/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
+index 5b4e23c32dc48aa8d76fedebecb4382c12d51f8e..0c26e7a7d5ae28c3533b338e20abca3cfc1af282 100644
+--- a/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
++++ b/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
+@@ -281,7 +281,7 @@ void SharedScreenCastStreamPrivate::OnStreamParamChanged(
+ 
+   that->stream_size_ = DesktopSize(width, height);
+ 
+-  uint8_t buffer[1024] = {};
++  uint8_t buffer[2048] = {};
+   auto builder = spa_pod_builder{buffer, sizeof(buffer)};
+ 
+   // Setup buffers and meta header for new format.
+@@ -364,7 +364,7 @@ void SharedScreenCastStreamPrivate::OnRenegotiateFormat(void* data, uint64_t) {
+   {
+     PipeWireThreadLoopLock thread_loop_lock(that->pw_main_loop_);
+ 
+-    uint8_t buffer[2048] = {};
++    uint8_t buffer[4096] = {};
+ 
+     spa_pod_builder builder = spa_pod_builder{buffer, sizeof(buffer)};
+ 
+@@ -482,7 +482,7 @@ bool SharedScreenCastStreamPrivate::StartScreenCastStream(
+ 
+     pw_stream_add_listener(pw_stream_, &spa_stream_listener_,
+                            &pw_stream_events_, this);
+-    uint8_t buffer[2048] = {};
++    uint8_t buffer[4096] = {};
+ 
+     spa_pod_builder builder = spa_pod_builder{buffer, sizeof(buffer)};
+ 


### PR DESCRIPTION
#### Description of Change

Cherry pick https://webrtc-review.googlesource.com/c/src/+/311541 from WebRTC to fix a crash during stream renegotiation.

Fixes #39131

cc @VerteDinde

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash while screen sharing on Wayland with PipeWire.
