### PR TITLE
chore: cherry-pick 4 changes from Release-0-M115

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -132,3 +132,7 @@ potential_fix_for_flaky_desktopcaptureapitest_delegation_unittest.patch
 fix_select_the_first_menu_item_when_opened_via_keyboard.patch
 chore_add_buildflag_guard_around_new_include.patch
 fix_use_delegated_generic_capturer_when_available.patch
+cherry-pick-90c9a89aa794.patch
+cherry-pick-933b9fad3a53.patch
+cherry-pick-b03973561862.patch
+cherry-pick-c60a1ab717c7.patch

--- a/patches/chromium/cherry-pick-90c9a89aa794.patch
+++ b/patches/chromium/cherry-pick-90c9a89aa794.patch
@@ -1,0 +1,38 @@
+From 90c9a89aa794d8f6886a277fe88586b8aa1c0c27 Mon Sep 17 00:00:00 2001
+From: Alex Moshchuk <alexmos@chromium.org>
+Date: Tue, 06 Jun 2023 03:58:34 +0000
+Subject: [PATCH] Use &* instead of .get() for BrowserOrResourceContext's raw_ref
+
+Using * is more secure, as get() does not check the pointer for
+validity, whereas * does.
+
+Change-Id: I3ea99de76c68afe3358ddf0d263008129d3ad70f
+Bug: 1444438, 1444204
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4591832
+Reviewed-by: Daniel Cheng <dcheng@chromium.org>
+Commit-Queue: Alex Moshchuk <alexmos@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1153662}
+---
+
+diff --git a/content/public/browser/browser_or_resource_context.h b/content/public/browser/browser_or_resource_context.h
+index 9cf4618..04a9d03 100644
+--- a/content/public/browser/browser_or_resource_context.h
++++ b/content/public/browser/browser_or_resource_context.h
+@@ -50,7 +50,7 @@
+   // TODO(dcheng): Change this to return a ref.
+   BrowserContext* ToBrowserContext() const {
+     DCHECK_CURRENTLY_ON(BrowserThread::UI);
+-    return &absl::get<raw_ref<BrowserContext>>(storage_).get();
++    return &*absl::get<raw_ref<BrowserContext>>(storage_);
+   }
+ 
+   // To be called only on the UI thread. Will CHECK() if `this` does not hold a
+@@ -58,7 +58,7 @@
+   // TODO(dcheng): Change this to return a ref.
+   ResourceContext* ToResourceContext() const {
+     DCHECK_CURRENTLY_ON(BrowserThread::IO);
+-    return &absl::get<raw_ref<ResourceContext>>(storage_).get();
++    return &*absl::get<raw_ref<ResourceContext>>(storage_);
+   }
+ 
+  private:

--- a/patches/chromium/cherry-pick-933b9fad3a53.patch
+++ b/patches/chromium/cherry-pick-933b9fad3a53.patch
@@ -1,0 +1,405 @@
+From 933b9fad3a5396495f52e44259bcbb61e7913311 Mon Sep 17 00:00:00 2001
+From: Ken Rockot <rockot@google.com>
+Date: Fri, 09 Jun 2023 07:49:02 +0000
+Subject: [PATCH] Reland "ipcz: Refactor FragmentDescriptor decode"
+
+This is a reland of commit 17dd18d1f2194089b8433e0ca334c81343b591e2
+
+Original change's description:
+> ipcz: Refactor FragmentDescriptor decode
+>
+> Funnels untrusted FragmentDescriptor mapping through a new
+> Fragment::MappedFromDescriptor helper. See the linked bug
+> for more details.
+>
+> Fixed: 1450899
+> Change-Id: I4c7751b9f4299da4a13c0becc1b889160a0c6e66
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4599218
+> Reviewed-by: Daniel Cheng <dcheng@chromium.org>
+> Commit-Queue: Ken Rockot <rockot@google.com>
+> Cr-Commit-Position: refs/heads/main@{#1155133}
+
+Change-Id: I86ee9118a30dea59d837c377a1f751b20a85a3c3
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4602794
+Reviewed-by: Daniel Cheng <dcheng@chromium.org>
+Commit-Queue: Ken Rockot <rockot@google.com>
+Cr-Commit-Position: refs/heads/main@{#1155397}
+---
+
+diff --git a/third_party/ipcz/src/BUILD.gn b/third_party/ipcz/src/BUILD.gn
+index a9f072e..3e46dd6 100644
+--- a/third_party/ipcz/src/BUILD.gn
++++ b/third_party/ipcz/src/BUILD.gn
+@@ -212,6 +212,7 @@
+     "ipcz/application_object.h",
+     "ipcz/block_allocator.h",
+     "ipcz/box.h",
++    "ipcz/buffer_id.h",
+     "ipcz/buffer_pool.h",
+     "ipcz/driver_memory.h",
+     "ipcz/driver_memory_mapping.h",
+@@ -254,7 +255,6 @@
+     "ipcz/block_allocator_pool.cc",
+     "ipcz/block_allocator_pool.h",
+     "ipcz/box.cc",
+-    "ipcz/buffer_id.h",
+     "ipcz/buffer_pool.cc",
+     "ipcz/driver_memory.cc",
+     "ipcz/driver_memory_mapping.cc",
+@@ -379,6 +379,7 @@
+     "ipcz/driver_memory_test.cc",
+     "ipcz/driver_object_test.cc",
+     "ipcz/driver_transport_test.cc",
++    "ipcz/fragment_test.cc",
+     "ipcz/message_test.cc",
+     "ipcz/node_connector_test.cc",
+     "ipcz/node_link_memory_test.cc",
+diff --git a/third_party/ipcz/src/ipcz/block_allocator_pool.cc b/third_party/ipcz/src/ipcz/block_allocator_pool.cc
+index bd464f8..1b9d50b 100644
+--- a/third_party/ipcz/src/ipcz/block_allocator_pool.cc
++++ b/third_party/ipcz/src/ipcz/block_allocator_pool.cc
+@@ -86,7 +86,7 @@
+       FragmentDescriptor descriptor(
+           entry->buffer_id, checked_cast<uint32_t>(offset),
+           checked_cast<uint32_t>(allocator.block_size()));
+-      return Fragment(descriptor, block);
++      return Fragment::FromDescriptorUnsafe(descriptor, block);
+     }
+ 
+     // Allocation from the active allocator failed. Try another if available.
+diff --git a/third_party/ipcz/src/ipcz/buffer_pool.cc b/third_party/ipcz/src/ipcz/buffer_pool.cc
+index 6881346..27b2304 100644
+--- a/third_party/ipcz/src/ipcz/buffer_pool.cc
++++ b/third_party/ipcz/src/ipcz/buffer_pool.cc
+@@ -26,15 +26,11 @@
+   absl::MutexLock lock(&mutex_);
+   auto it = mappings_.find(descriptor.buffer_id());
+   if (it == mappings_.end()) {
+-    return Fragment(descriptor, nullptr);
++    return Fragment::PendingFromDescriptor(descriptor);
+   }
+ 
+   auto& [id, mapping] = *it;
+-  if (descriptor.end() > mapping.bytes().size()) {
+-    return {};
+-  }
+-
+-  return Fragment(descriptor, mapping.address_at(descriptor.offset()));
++  return Fragment::MappedFromDescriptor(descriptor, mapping);
+ }
+ 
+ bool BufferPool::AddBlockBuffer(
+diff --git a/third_party/ipcz/src/ipcz/buffer_pool_test.cc b/third_party/ipcz/src/ipcz/buffer_pool_test.cc
+index ee21cb21..49720f1 100644
+--- a/third_party/ipcz/src/ipcz/buffer_pool_test.cc
++++ b/third_party/ipcz/src/ipcz/buffer_pool_test.cc
+@@ -193,9 +193,11 @@
+             pool.GetTotalBlockCapacity(kBlockSize));
+ 
+   // We can't free something that isn't a valid allocation.
+-  EXPECT_FALSE(pool.FreeBlock(Fragment{{}, nullptr}));
+-  EXPECT_FALSE(pool.FreeBlock(Fragment{{BufferId{1000}, 0, 1}, nullptr}));
+-  EXPECT_FALSE(pool.FreeBlock(Fragment{{BufferId{0}, 0, 1}, bytes0.data()}));
++  EXPECT_FALSE(pool.FreeBlock(Fragment::FromDescriptorUnsafe({}, nullptr)));
++  EXPECT_FALSE(pool.FreeBlock(
++      Fragment::FromDescriptorUnsafe({BufferId{1000}, 0, 1}, nullptr)));
++  EXPECT_FALSE(pool.FreeBlock(
++      Fragment::FromDescriptorUnsafe({BufferId{0}, 0, 1}, bytes0.data())));
+ 
+   // Allocate all available capacity.
+   std::vector<Fragment> fragments;
+diff --git a/third_party/ipcz/src/ipcz/fragment.cc b/third_party/ipcz/src/ipcz/fragment.cc
+index 651d1c2f..2ef4ed8dc 100644
+--- a/third_party/ipcz/src/ipcz/fragment.cc
++++ b/third_party/ipcz/src/ipcz/fragment.cc
+@@ -6,10 +6,38 @@
+ 
+ #include <cstdint>
+ 
++#include "ipcz/driver_memory_mapping.h"
++#include "ipcz/fragment_descriptor.h"
+ #include "third_party/abseil-cpp/absl/base/macros.h"
++#include "util/safe_math.h"
+ 
+ namespace ipcz {
+ 
++// static
++Fragment Fragment::MappedFromDescriptor(const FragmentDescriptor& descriptor,
++                                        DriverMemoryMapping& mapping) {
++  if (descriptor.is_null()) {
++    return {};
++  }
++
++  const uint32_t end = SaturatedAdd(descriptor.offset(), descriptor.size());
++  if (end > mapping.bytes().size()) {
++    return {};
++  }
++  return Fragment{descriptor, mapping.address_at(descriptor.offset())};
++}
++
++// static
++Fragment Fragment::PendingFromDescriptor(const FragmentDescriptor& descriptor) {
++  return Fragment{descriptor, nullptr};
++}
++
++// static
++Fragment Fragment::FromDescriptorUnsafe(const FragmentDescriptor& descriptor,
++                                        void* base_address) {
++  return Fragment{descriptor, base_address};
++}
++
+ Fragment::Fragment(const FragmentDescriptor& descriptor, void* address)
+     : descriptor_(descriptor), address_(address) {
+   // If `address` is non-null, the descriptor must also be. Note that the
+diff --git a/third_party/ipcz/src/ipcz/fragment.h b/third_party/ipcz/src/ipcz/fragment.h
+index c0151fd..de65f08 100644
+--- a/third_party/ipcz/src/ipcz/fragment.h
++++ b/third_party/ipcz/src/ipcz/fragment.h
+@@ -14,21 +14,32 @@
+ 
+ namespace ipcz {
+ 
++class DriverMemoryMapping;
++
+ // Represents a span of memory located within the shared memory regions owned by
+ // a NodeLinkMemory, via BufferPool. This is essentially a FragmentDescriptor
+ // plus the actual mapped address of the given buffer and offset.
+ struct Fragment {
+   constexpr Fragment() = default;
+ 
+-  // Constructs a new Fragment over `descriptor`, mapped to `address`. If
+-  // `address` is null, the Fragment is considered "pending" -- it has a
+-  // potentially valid descriptor, but could not be resolved to a mapped address
+-  // yet (e.g. because the relevant BufferPool doesn't have the identified
+-  // buffer mapped yet.)
+-  Fragment(const FragmentDescriptor& descriptor, void* address);
+   Fragment(const Fragment&);
+   Fragment& operator=(const Fragment&);
+ 
++  // Returns a new concrete Fragment corresponding to `descriptor` within the
++  // context of `mapping`. This validates that the fragment's bounds fall within
++  // the bounds of `mapping`. If `descriptor` was null or validation fails, this
++  // returns a null Fragment.
++  static Fragment MappedFromDescriptor(const FragmentDescriptor& descriptor,
++                                       DriverMemoryMapping& mapping);
++
++  // Returns a pending Fragment corresponding to `descriptor`.
++  static Fragment PendingFromDescriptor(const FragmentDescriptor& descriptor);
++
++  // Returns a Fragment corresponding to `descriptor`, with the starting address
++  // already mapped to `address`.
++  static Fragment FromDescriptorUnsafe(const FragmentDescriptor& descriptor,
++                                       void* address);
++
+   // A null fragment is a fragment with a null descriptor, meaning it does not
+   // reference a valid buffer ID.
+   bool is_null() const { return descriptor_.is_null(); }
+@@ -66,6 +77,13 @@
+   }
+ 
+  private:
++  // Constructs a new Fragment over `descriptor`, mapped to `address`. If
++  // `address` is null, the Fragment is considered "pending" -- it has a
++  // potentially valid descriptor, but could not be resolved to a mapped address
++  // yet (e.g. because the relevant BufferPool doesn't have the identified
++  // buffer mapped yet.)
++  Fragment(const FragmentDescriptor& descriptor, void* address);
++
+   FragmentDescriptor descriptor_;
+ 
+   // The actual mapped address corresponding to `descriptor_`.
+diff --git a/third_party/ipcz/src/ipcz/fragment_descriptor.h b/third_party/ipcz/src/ipcz/fragment_descriptor.h
+index ed5229a..d8dbec5 100644
+--- a/third_party/ipcz/src/ipcz/fragment_descriptor.h
++++ b/third_party/ipcz/src/ipcz/fragment_descriptor.h
+@@ -36,7 +36,6 @@
+   BufferId buffer_id() const { return buffer_id_; }
+   uint32_t offset() const { return offset_; }
+   uint32_t size() const { return size_; }
+-  uint32_t end() const { return offset_ + size_; }
+ 
+  private:
+   // Identifies the shared memory buffer in which the memory resides. This ID is
+diff --git a/third_party/ipcz/src/ipcz/fragment_test.cc b/third_party/ipcz/src/ipcz/fragment_test.cc
+new file mode 100644
+index 0000000..e6b6baa
+--- /dev/null
++++ b/third_party/ipcz/src/ipcz/fragment_test.cc
+@@ -0,0 +1,102 @@
++// Copyright 2023 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "ipcz/fragment.h"
++
++#include <algorithm>
++#include <cstring>
++#include <limits>
++#include <string>
++#include <utility>
++
++#include "ipcz/buffer_id.h"
++#include "ipcz/driver_memory.h"
++#include "ipcz/driver_memory_mapping.h"
++#include "reference_drivers/sync_reference_driver.h"
++#include "testing/gtest/include/gtest/gtest.h"
++
++namespace ipcz {
++namespace {
++
++const IpczDriver& kTestDriver = reference_drivers::kSyncReferenceDriver;
++
++using FragmentTest = testing::Test;
++
++TEST_F(FragmentTest, FromDescriptorUnsafe) {
++  char kBuffer[] = "Hello, world!";
++
++  Fragment f = Fragment::FromDescriptorUnsafe({BufferId{0}, 1, 4}, kBuffer + 1);
++  EXPECT_FALSE(f.is_null());
++  EXPECT_FALSE(f.is_pending());
++  EXPECT_EQ(1u, f.offset());
++  EXPECT_EQ(4u, f.size());
++  EXPECT_EQ("ello", std::string(f.bytes().begin(), f.bytes().end()));
++
++  f = Fragment::FromDescriptorUnsafe({BufferId{0}, 7, 6}, kBuffer + 7);
++  EXPECT_FALSE(f.is_null());
++  EXPECT_FALSE(f.is_pending());
++  EXPECT_EQ(7u, f.offset());
++  EXPECT_EQ(6u, f.size());
++  EXPECT_EQ("world!", std::string(f.bytes().begin(), f.bytes().end()));
++}
++
++TEST_F(FragmentTest, PendingFromDescriptor) {
++  Fragment f = Fragment::PendingFromDescriptor({BufferId{0}, 5, 42});
++  EXPECT_TRUE(f.is_pending());
++  EXPECT_FALSE(f.is_null());
++  EXPECT_EQ(5u, f.offset());
++  EXPECT_EQ(42u, f.size());
++
++  f = Fragment::PendingFromDescriptor({kInvalidBufferId, 0, 0});
++  EXPECT_TRUE(f.is_null());
++  EXPECT_FALSE(f.is_pending());
++}
++
++TEST_F(FragmentTest, NullMappedFromDescriptor) {
++  constexpr size_t kDataSize = 32;
++  DriverMemory memory(kTestDriver, kDataSize);
++  auto mapping = memory.Map();
++
++  Fragment f =
++      Fragment::MappedFromDescriptor({kInvalidBufferId, 0, 0}, mapping);
++  EXPECT_TRUE(f.is_null());
++}
++
++TEST_F(FragmentTest, InvalidMappedFromDescriptor) {
++  constexpr size_t kDataSize = 32;
++  DriverMemory memory(kTestDriver, kDataSize);
++  auto mapping = memory.Map();
++
++  Fragment f;
++
++  // Offset out of bounds
++  f = Fragment::MappedFromDescriptor({BufferId{0}, kDataSize, 1}, mapping);
++  EXPECT_TRUE(f.is_null());
++
++  // Tail out of bounds
++  f = Fragment::MappedFromDescriptor({BufferId{0}, 0, kDataSize + 5}, mapping);
++  EXPECT_TRUE(f.is_null());
++
++  // Tail overflow
++  f = Fragment::MappedFromDescriptor(
++      {BufferId{0}, std::numeric_limits<uint32_t>::max(), 2}, mapping);
++  EXPECT_TRUE(f.is_null());
++}
++
++TEST_F(FragmentTest, ValidMappedFromDescriptor) {
++  const char kData[] = "0123456789abcdef";
++  DriverMemory memory(kTestDriver, std::size(kData));
++  auto mapping = memory.Map();
++  memcpy(mapping.bytes().data(), kData, std::size(kData));
++
++  Fragment f = Fragment::MappedFromDescriptor({BufferId{0}, 2, 11}, mapping);
++  EXPECT_FALSE(f.is_null());
++  EXPECT_FALSE(f.is_pending());
++  EXPECT_EQ(2u, f.offset());
++  EXPECT_EQ(11u, f.size());
++  EXPECT_EQ("23456789abc", std::string(f.bytes().begin(), f.bytes().end()));
++}
++
++}  // namespace
++}  // namespace ipcz
+diff --git a/third_party/ipcz/src/ipcz/node_link_memory.cc b/third_party/ipcz/src/ipcz/node_link_memory.cc
+index 480c756..e424192 100644
+--- a/third_party/ipcz/src/ipcz/node_link_memory.cc
++++ b/third_party/ipcz/src/ipcz/node_link_memory.cc
+@@ -260,8 +260,9 @@
+   FragmentDescriptor descriptor(kPrimaryBufferId,
+                                 ToOffset(state, primary_buffer_memory_.data()),
+                                 sizeof(RouterLinkState));
+-  return FragmentRef<RouterLinkState>(RefCountedFragment::kUnmanagedRef,
+-                                      Fragment(descriptor, state));
++  return FragmentRef<RouterLinkState>(
++      RefCountedFragment::kUnmanagedRef,
++      Fragment::FromDescriptorUnsafe(descriptor, state));
+ }
+ 
+ Fragment NodeLinkMemory::GetFragment(const FragmentDescriptor& descriptor) {
+diff --git a/third_party/ipcz/src/ipcz/ref_counted_fragment_test.cc b/third_party/ipcz/src/ipcz/ref_counted_fragment_test.cc
+index 69c14d57..90d807f 100644
+--- a/third_party/ipcz/src/ipcz/ref_counted_fragment_test.cc
++++ b/third_party/ipcz/src/ipcz/ref_counted_fragment_test.cc
+@@ -64,7 +64,8 @@
+ 
+   FragmentRef<TestObject> ref(
+       RefCountedFragment::kUnmanagedRef,
+-      Fragment(FragmentDescriptor(BufferId(0), 0, sizeof(object)), &object));
++      Fragment::FromDescriptorUnsafe(
++          FragmentDescriptor(BufferId(0), 0, sizeof(object)), &object));
+   EXPECT_EQ(1, object.ref_count_for_testing());
+   ref.reset();
+   EXPECT_EQ(0, object.ref_count_for_testing());
+@@ -75,7 +76,8 @@
+ 
+   FragmentRef<TestObject> ref1(
+       RefCountedFragment::kUnmanagedRef,
+-      Fragment(FragmentDescriptor(BufferId(0), 0, sizeof(object1)), &object1));
++      Fragment::FromDescriptorUnsafe(
++          FragmentDescriptor(BufferId(0), 0, sizeof(object1)), &object1));
+   EXPECT_EQ(1, object1.ref_count_for_testing());
+ 
+   FragmentRef<TestObject> other1 = ref1;
+@@ -88,7 +90,8 @@
+   TestObject object2;
+   auto ref2 = FragmentRef<TestObject>(
+       RefCountedFragment::kUnmanagedRef,
+-      Fragment(FragmentDescriptor(BufferId(0), 0, sizeof(object2)), &object2));
++      Fragment::FromDescriptorUnsafe(
++          FragmentDescriptor(BufferId(0), 0, sizeof(object2)), &object2));
+   EXPECT_EQ(1, object1.ref_count_for_testing());
+   EXPECT_EQ(1, object2.ref_count_for_testing());
+   ref2 = ref1;
+@@ -115,7 +118,8 @@
+ 
+   FragmentRef<TestObject> ref1(
+       RefCountedFragment::kUnmanagedRef,
+-      Fragment(FragmentDescriptor(BufferId(0), 0, sizeof(object1)), &object1));
++      Fragment::FromDescriptorUnsafe(
++          FragmentDescriptor(BufferId(0), 0, sizeof(object1)), &object1));
+   EXPECT_EQ(1, ref1.ref_count_for_testing());
+ 
+   FragmentRef<TestObject> other1 = std::move(ref1);
+@@ -133,10 +137,12 @@
+   TestObject object3;
+   FragmentRef<TestObject> ref2(
+       RefCountedFragment::kUnmanagedRef,
+-      Fragment(FragmentDescriptor(BufferId(0), 0, sizeof(object2)), &object2));
++      Fragment::FromDescriptorUnsafe(
++          FragmentDescriptor(BufferId(0), 0, sizeof(object2)), &object2));
+   FragmentRef<TestObject> ref3(
+       RefCountedFragment::kUnmanagedRef,
+-      Fragment(FragmentDescriptor(BufferId(0), 0, sizeof(object3)), &object3));
++      Fragment::FromDescriptorUnsafe(
++          FragmentDescriptor(BufferId(0), 0, sizeof(object3)), &object3));
+ 
+   EXPECT_FALSE(ref2.is_null());
+   EXPECT_TRUE(ref2.is_addressable());

--- a/patches/chromium/cherry-pick-b03973561862.patch
+++ b/patches/chromium/cherry-pick-b03973561862.patch
@@ -1,0 +1,129 @@
+From b0397356186229e3aab75991d48ef632bfe276af Mon Sep 17 00:00:00 2001
+From: Tommi <tommi@chromium.org>
+Date: Wed, 05 Jul 2023 10:55:53 +0000
+Subject: [PATCH] [M116] Make RTCDataChannel's channel and observer pointers const.
+
+This allows channel properties to be queried while the RTCDataChannel
+instance exists and avoids potential null deref after entering the
+kClosed state.
+
+(cherry picked from commit 08d5ad011f53a1995bfccef6728bfa62541f7608)
+
+Bug: 1456567, 1457421
+Change-Id: I4747f9c00804b35711667d7320ec6188f20910c4
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4663082
+Commit-Queue: Tomas Gunnarsson <tommi@chromium.org>
+Reviewed-by: Elad Alon <eladalon@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1165406}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4665530
+Cr-Commit-Position: refs/branch-heads/5845@{#300}
+Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
+---
+
+diff --git a/third_party/blink/renderer/modules/peerconnection/rtc_data_channel.cc b/third_party/blink/renderer/modules/peerconnection/rtc_data_channel.cc
+index 7312c7e..edf7e09 100644
+--- a/third_party/blink/renderer/modules/peerconnection/rtc_data_channel.cc
++++ b/third_party/blink/renderer/modules/peerconnection/rtc_data_channel.cc
+@@ -207,11 +207,12 @@
+     rtc::scoped_refptr<webrtc::DataChannelInterface> channel)
+     : main_thread_(main_thread),
+       blink_channel_(blink_channel),
+-      webrtc_channel_(channel) {}
++      webrtc_channel_(std::move(channel)) {
++  CHECK(webrtc_channel_.get());
++}
+ 
+ RTCDataChannel::Observer::~Observer() {
+   DCHECK(!blink_channel_) << "Reference to blink channel hasn't been released.";
+-  DCHECK(!webrtc_channel_.get()) << "Unregister hasn't been called.";
+ }
+ 
+ const rtc::scoped_refptr<webrtc::DataChannelInterface>&
+@@ -221,13 +222,8 @@
+ 
+ void RTCDataChannel::Observer::Unregister() {
+   DCHECK(main_thread_->BelongsToCurrentThread());
++  webrtc_channel_->UnregisterObserver();
+   blink_channel_ = nullptr;
+-  if (webrtc_channel_.get()) {
+-    webrtc_channel_->UnregisterObserver();
+-    // Now that we're guaranteed to not get further OnStateChange callbacks,
+-    // it's safe to release our reference to the channel.
+-    webrtc_channel_ = nullptr;
+-  }
+ }
+ 
+ void RTCDataChannel::Observer::OnStateChange() {
+@@ -279,7 +275,7 @@
+ 
+ RTCDataChannel::RTCDataChannel(
+     ExecutionContext* context,
+-    rtc::scoped_refptr<webrtc::DataChannelInterface> channel,
++    rtc::scoped_refptr<webrtc::DataChannelInterface> data_channel,
+     RTCPeerConnectionHandler* peer_connection_handler)
+     : ActiveScriptWrappable<RTCDataChannel>({}),
+       ExecutionContextLifecycleObserver(context),
+@@ -289,7 +285,7 @@
+       observer_(base::MakeRefCounted<Observer>(
+           context->GetTaskRunner(TaskType::kNetworking),
+           this,
+-          channel)),
++          std::move(data_channel))),
+       signaling_thread_(peer_connection_handler->signaling_thread()) {
+   DCHECK(peer_connection_handler);
+ 
+@@ -298,13 +294,13 @@
+   // on the signaling thread and RTCDataChannel construction posted on the main
+   // thread. Done in a single synchronous call to the signaling thread to ensure
+   // channel state consistency.
+-  // TODO(tommi): Check it this^ is still possible.
+-  channel->RegisterObserver(observer_.get());
+-  if (channel->state() != state_) {
++  // TODO(tommi): Check if this^ is still possible.
++  channel()->RegisterObserver(observer_.get());
++  if (channel()->state() != state_) {
+     observer_->OnStateChange();
+   }
+ 
+-  IncrementCounters(*channel.get());
++  IncrementCounters(*channel().get());
+ }
+ 
+ RTCDataChannel::~RTCDataChannel() = default;
+@@ -663,9 +659,8 @@
+   if (stopped_)
+     return;
+ 
+-  // Clears the weak persistent reference to this on-heap object.
++  // Clear the weak persistent reference to this on-heap object.
+   observer_->Unregister();
+-  observer_ = nullptr;
+ }
+ 
+ void RTCDataChannel::ScheduleDispatchEvent(Event* event) {
+diff --git a/third_party/blink/renderer/modules/peerconnection/rtc_data_channel.h b/third_party/blink/renderer/modules/peerconnection/rtc_data_channel.h
+index 78240bf8..5998c4c 100644
+--- a/third_party/blink/renderer/modules/peerconnection/rtc_data_channel.h
++++ b/third_party/blink/renderer/modules/peerconnection/rtc_data_channel.h
+@@ -151,7 +151,7 @@
+ 
+     const scoped_refptr<base::SingleThreadTaskRunner> main_thread_;
+     WeakPersistent<RTCDataChannel> blink_channel_;
+-    rtc::scoped_refptr<webrtc::DataChannelInterface> webrtc_channel_;
++    const rtc::scoped_refptr<webrtc::DataChannelInterface> webrtc_channel_;
+   };
+ 
+   void OnStateChange(webrtc::DataChannelInterface::DataState state);
+@@ -199,7 +199,11 @@
+   unsigned buffered_amount_ = 0u;
+   bool stopped_ = false;
+   bool closed_from_owner_ = false;
+-  scoped_refptr<Observer> observer_;
++  // Keep the `observer_` reference const to make it clear that we don't want
++  // to free the underlying channel (or callback observer) until the
++  // `RTCDataChannel` instance goes away. This allows properties to be queried
++  // after the state reaches `kClosed`.
++  const scoped_refptr<Observer> observer_;
+   scoped_refptr<base::SingleThreadTaskRunner> signaling_thread_;
+   THREAD_CHECKER(thread_checker_);
+ };

--- a/patches/chromium/cherry-pick-c60a1ab717c7.patch
+++ b/patches/chromium/cherry-pick-c60a1ab717c7.patch
@@ -1,0 +1,188 @@
+From c60a1ab717c77636508995c044a6c0e8086ac011 Mon Sep 17 00:00:00 2001
+From: Taylor Bergquist <tbergquist@chromium.org>
+Date: Tue, 11 Jul 2023 01:32:22 +0000
+Subject: [PATCH] Fix UAF when exiting a nested run loop in TabDragContextImpl::OnGestureEvent.
+
+OnGestureEvent may call ContinueDrag, which may run a nested run loop. After the nested run loop returns, multiple seconds of time may have passed, and the world may be in a very different state; in particular, the window that contains this TabDragContext may have closed.
+
+This CL checks if this has happened, and returns early in that case.
+
+(cherry picked from commit 63d6b8ba8126b16215d33670df8c67dcbc6c9bef)
+
+Bug: 1453465
+Change-Id: I6095c0afeb5aa5f422717f1bbd93b96175e52afa
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4657527
+Reviewed-by: Darryl James <dljames@chromium.org>
+Commit-Queue: Taylor Bergquist <tbergquist@chromium.org>
+Code-Coverage: Findit <findit-for-me@appspot.gserviceaccount.com>
+Cr-Original-Commit-Position: refs/heads/main@{#1164449}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4676126
+Reviewed-by: Shibalik Mohapatra <shibalik@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5845@{#410}
+Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
+---
+
+diff --git a/chrome/browser/ui/views/tabs/fake_tab_slot_controller.cc b/chrome/browser/ui/views/tabs/fake_tab_slot_controller.cc
+index 6f341a7..fb1af9351 100644
+--- a/chrome/browser/ui/views/tabs/fake_tab_slot_controller.cc
++++ b/chrome/browser/ui/views/tabs/fake_tab_slot_controller.cc
+@@ -43,6 +43,12 @@
+   return false;
+ }
+ 
++TabSlotController::Liveness FakeTabSlotController::ContinueDrag(
++    views::View* view,
++    const ui::LocatedEvent& event) {
++  return Liveness::kAlive;
++}
++
+ bool FakeTabSlotController::EndDrag(EndDragReason reason) {
+   return false;
+ }
+diff --git a/chrome/browser/ui/views/tabs/fake_tab_slot_controller.h b/chrome/browser/ui/views/tabs/fake_tab_slot_controller.h
+index 83ef920..588f17c 100644
+--- a/chrome/browser/ui/views/tabs/fake_tab_slot_controller.h
++++ b/chrome/browser/ui/views/tabs/fake_tab_slot_controller.h
+@@ -60,8 +60,8 @@
+       TabSlotView* source,
+       const ui::LocatedEvent& event,
+       const ui::ListSelectionModel& original_selection) override {}
+-  void ContinueDrag(views::View* view, const ui::LocatedEvent& event) override {
+-  }
++  Liveness ContinueDrag(views::View* view,
++                        const ui::LocatedEvent& event) override;
+   bool EndDrag(EndDragReason reason) override;
+   Tab* GetTabAt(const gfx::Point& point) override;
+   const Tab* GetAdjacentTab(const Tab* tab, int offset) override;
+diff --git a/chrome/browser/ui/views/tabs/tab_slot_controller.h b/chrome/browser/ui/views/tabs/tab_slot_controller.h
+index 81927f9..6633a083 100644
+--- a/chrome/browser/ui/views/tabs/tab_slot_controller.h
++++ b/chrome/browser/ui/views/tabs/tab_slot_controller.h
+@@ -49,6 +49,8 @@
+     kEvent
+   };
+ 
++  enum class Liveness { kAlive, kDeleted };
++
+   virtual const ui::ListSelectionModel& GetSelectionModel() const = 0;
+ 
+   // Returns the tab at |index|.
+@@ -126,9 +128,10 @@
+       const ui::LocatedEvent& event,
+       const ui::ListSelectionModel& original_selection) = 0;
+ 
+-  // Continues dragging a Tab.
+-  virtual void ContinueDrag(views::View* view,
+-                            const ui::LocatedEvent& event) = 0;
++  // Continues dragging a Tab. May enter a nested event loop - returns
++  // Liveness::kDeleted if `this` was destroyed during this nested event loop,
++  // and Liveness::kAlive if `this` is still alive.
++  virtual Liveness ContinueDrag(views::View* view, const ui::LocatedEvent& event) = 0;
+ 
+   // Ends dragging a Tab. Returns whether the tab has been destroyed.
+   virtual bool EndDrag(EndDragReason reason) = 0;
+diff --git a/chrome/browser/ui/views/tabs/tab_strip.cc b/chrome/browser/ui/views/tabs/tab_strip.cc
+index 64b3659..51d8102 100644
+--- a/chrome/browser/ui/views/tabs/tab_strip.cc
++++ b/chrome/browser/ui/views/tabs/tab_strip.cc
+@@ -178,7 +178,7 @@
+   }
+ 
+   bool OnMouseDragged(const ui::MouseEvent& event) override {
+-    ContinueDrag(this, event);
++    (void)ContinueDrag(this, event);
+     return true;
+   }
+ 
+@@ -189,6 +189,7 @@
+   void OnMouseCaptureLost() override { EndDrag(END_DRAG_CAPTURE_LOST); }
+ 
+   void OnGestureEvent(ui::GestureEvent* event) override {
++    Liveness tabstrip_alive = Liveness::kAlive;
+     switch (event->type()) {
+       case ui::ET_GESTURE_SCROLL_END:
+       case ui::ET_SCROLL_FLING_START:
+@@ -202,7 +203,8 @@
+       }
+ 
+       case ui::ET_GESTURE_SCROLL_UPDATE:
+-        ContinueDrag(this, *event);
++        // N.B. !! ContinueDrag may enter a nested run loop !!
++        tabstrip_alive = ContinueDrag(this, *event);
+         break;
+ 
+       case ui::ET_GESTURE_TAP_DOWN:
+@@ -214,6 +216,12 @@
+     }
+     event->SetHandled();
+ 
++    // If tabstrip was destroyed (during ContinueDrag above), return early to
++    // avoid UAF below.
++    if (tabstrip_alive == Liveness::kDeleted) {
++      return;
++    }
++
+     // TabDragContext gets event capture as soon as a drag session begins, which
+     // precludes TabStrip from ever getting events like tap or long tap. Forward
+     // this on to TabStrip so it can respond to those events.
+@@ -302,20 +310,20 @@
+       std::move(drag_controller_set_callback_).Run(drag_controller_.get());
+   }
+ 
+-  void ContinueDrag(views::View* view, const ui::LocatedEvent& event) {
+-    if (drag_controller_.get() &&
+-        drag_controller_->event_source() == EventSourceFromEvent(event)) {
+-      gfx::Point screen_location(event.location());
+-      views::View::ConvertPointToScreen(view, &screen_location);
+-
+-      // Note: |tab_strip_| can be destroyed during drag, also destroying
+-      // |this|.
+-      base::WeakPtr<TabDragContext> weak_ptr(weak_factory_.GetWeakPtr());
+-      drag_controller_->Drag(screen_location);
+-
+-      if (!weak_ptr)
+-        return;
++  Liveness ContinueDrag(views::View* view, const ui::LocatedEvent& event) {
++    if (!drag_controller_.get() ||
++        drag_controller_->event_source() != EventSourceFromEvent(event)) {
++      return Liveness::kAlive;
+     }
++
++    gfx::Point screen_location(event.location());
++    views::View::ConvertPointToScreen(view, &screen_location);
++
++    // Note: `tab_strip_` can be destroyed during drag, also destroying `this`.
++    base::WeakPtr<TabDragContext> weak_ptr(weak_factory_.GetWeakPtr());
++    drag_controller_->Drag(screen_location);
++
++    return weak_ptr ? Liveness::kAlive : Liveness::kDeleted;
+   }
+ 
+   bool EndDrag(EndDragReason reason) {
+@@ -1593,8 +1601,10 @@
+   drag_context_->MaybeStartDrag(source, event, original_selection);
+ }
+ 
+-void TabStrip::ContinueDrag(views::View* view, const ui::LocatedEvent& event) {
+-  drag_context_->ContinueDrag(view, event);
++TabSlotController::Liveness TabStrip::ContinueDrag(
++    views::View* view,
++    const ui::LocatedEvent& event) {
++  return drag_context_->ContinueDrag(view, event);
+ }
+ 
+ bool TabStrip::EndDrag(EndDragReason reason) {
+diff --git a/chrome/browser/ui/views/tabs/tab_strip.h b/chrome/browser/ui/views/tabs/tab_strip.h
+index 5fc4bde..601151ba 100644
+--- a/chrome/browser/ui/views/tabs/tab_strip.h
++++ b/chrome/browser/ui/views/tabs/tab_strip.h
+@@ -278,7 +278,8 @@
+       TabSlotView* source,
+       const ui::LocatedEvent& event,
+       const ui::ListSelectionModel& original_selection) override;
+-  void ContinueDrag(views::View* view, const ui::LocatedEvent& event) override;
++  Liveness ContinueDrag(views::View* view,
++                        const ui::LocatedEvent& event) override;
+   bool EndDrag(EndDragReason reason) override;
+   Tab* GetTabAt(const gfx::Point& point) override;
+   const Tab* GetAdjacentTab(const Tab* tab, int offset) override;


### PR DESCRIPTION
<details>
<summary>electron/security#375 - 90c9a89aa794 from chromium</summary>
Use &* instead of .get() for BrowserOrResourceContext's raw_ref

Using * is more secure, as get() does not check the pointer for
validity, whereas * does.

Change-Id: I3ea99de76c68afe3358ddf0d263008129d3ad70f
Bug: 1444438, 1444204
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4591832
Reviewed-by: Daniel Cheng <dcheng@chromium.org>
Commit-Queue: Alex Moshchuk <alexmos@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1153662}
</details>

<details>
<summary>electron/security#374 - 933b9fad3a53 from chromium</summary>
Reland "ipcz: Refactor FragmentDescriptor decode"

This is a reland of commit 17dd18d1f2194089b8433e0ca334c81343b591e2

Original change's description:
> ipcz: Refactor FragmentDescriptor decode
>
> Funnels untrusted FragmentDescriptor mapping through a new
> Fragment::MappedFromDescriptor helper. See the linked bug
> for more details.
>
> Fixed: 1450899
> Change-Id: I4c7751b9f4299da4a13c0becc1b889160a0c6e66
> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4599218
> Reviewed-by: Daniel Cheng <dcheng@chromium.org>
> Commit-Queue: Ken Rockot <rockot@google.com>
> Cr-Commit-Position: refs/heads/main@{#1155133}

Change-Id: I86ee9118a30dea59d837c377a1f751b20a85a3c3
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4602794
Reviewed-by: Daniel Cheng <dcheng@chromium.org>
Commit-Queue: Ken Rockot <rockot@google.com>
Cr-Commit-Position: refs/heads/main@{#1155397}
</details>

<details>
<summary>electron/security#372 - b03973561862 from chromium</summary>
[M116] Make RTCDataChannel's channel and observer pointers const.

This allows channel properties to be queried while the RTCDataChannel
instance exists and avoids potential null deref after entering the
kClosed state.

(cherry picked from commit 08d5ad011f53a1995bfccef6728bfa62541f7608)

Bug: 1456567, 1457421
Change-Id: I4747f9c00804b35711667d7320ec6188f20910c4
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4663082
Commit-Queue: Tomas Gunnarsson <tommi@chromium.org>
Reviewed-by: Elad Alon <eladalon@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1165406}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4665530
Cr-Commit-Position: refs/branch-heads/5845@{#300}
Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
</details>

<details>
<summary>electron/security#373 - c60a1ab717c7 from chromium</summary>
Fix UAF when exiting a nested run loop in TabDragContextImpl::OnGestureEvent.

OnGestureEvent may call ContinueDrag, which may run a nested run loop. After the nested run loop returns, multiple seconds of time may have passed, and the world may be in a very different state; in particular, the window that contains this TabDragContext may have closed.

This CL checks if this has happened, and returns early in that case.

(cherry picked from commit 63d6b8ba8126b16215d33670df8c67dcbc6c9bef)

Bug: 1453465
Change-Id: I6095c0afeb5aa5f422717f1bbd93b96175e52afa
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4657527
Reviewed-by: Darryl James <dljames@chromium.org>
Commit-Queue: Taylor Bergquist <tbergquist@chromium.org>
Code-Coverage: Findit <findit-for-me@appspot.gserviceaccount.com>
Cr-Original-Commit-Position: refs/heads/main@{#1164449}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4676126
Reviewed-by: Shibalik Mohapatra <shibalik@chromium.org>
Cr-Commit-Position: refs/branch-heads/5845@{#410}
Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
</details>

Notes:
* Security: backported fix for 1444438.
* Security: backported fix for CVE-2023-3732.
* Security: backported fix for CVE-2023-3728.
* Security: backported fix for CVE-2023-3730.