### PR TITLE
chore: cherry-pick eec1810760cc from webrtc

### DIFF
--- a/patches/webrtc/.patches
+++ b/patches/webrtc/.patches
@@ -1,3 +1,4 @@
 fix_fallback_to_x11_capturer_on_wayland.patch
 cherry-pick-0e9556a90cec.patch
 fix_mark_pipewire_capturer_as_failed_after_session_is_closed.patch
+cherry-pick-eec1810760cc.patch

--- a/patches/webrtc/cherry-pick-eec1810760cc.patch
+++ b/patches/webrtc/cherry-pick-eec1810760cc.patch
@@ -1,0 +1,39 @@
+From eec1810760ccbdf95c68ed0d2c2ae10a8575551a Mon Sep 17 00:00:00 2001
+From: Tommi <tommi@webrtc.org>
+Date: Thu, 22 Jun 2023 10:13:52 +0200
+Subject: [PATCH] Avoid touching channel after OnSctpDataChannelClosed
+
+Bug: chromium:1454086
+Change-Id: I39573b706c4031d091c45a182b13cb3b2dba6233
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/309920
+Reviewed-by: Harald Alvestrand <hta@webrtc.org>
+Commit-Queue: Tomas Gunnarsson <tommi@webrtc.org>
+Cr-Commit-Position: refs/heads/main@{#40332}
+---
+
+diff --git a/pc/data_channel_controller.cc b/pc/data_channel_controller.cc
+index 7fea6c5..93599fd 100644
+--- a/pc/data_channel_controller.cc
++++ b/pc/data_channel_controller.cc
+@@ -70,6 +70,11 @@
+     SctpDataChannel* channel,
+     DataChannelInterface::DataState state) {
+   RTC_DCHECK_RUN_ON(network_thread());
++
++  // Stash away the internal id here in case `OnSctpDataChannelClosed` ends up
++  // releasing the last reference to the channel.
++  const int channel_id = channel->internal_id();
++
+   if (state == DataChannelInterface::DataState::kClosed)
+     OnSctpDataChannelClosed(channel);
+ 
+@@ -77,8 +82,7 @@
+                                        ? DataChannelUsage::kHaveBeenUsed
+                                        : DataChannelUsage::kInUse;
+   signaling_thread()->PostTask(SafeTask(
+-      signaling_safety_.flag(), [this, channel_id = channel->internal_id(),
+-                                 state = state, channel_usage] {
++      signaling_safety_.flag(), [this, channel_id, state, channel_usage] {
+         RTC_DCHECK_RUN_ON(signaling_thread());
+         channel_usage_ = channel_usage;
+         pc_->OnSctpDataChannelStateChanged(channel_id, state);


### PR DESCRIPTION
Avoid touching channel after OnSctpDataChannelClosed

Bug: chromium:1454086
Change-Id: I39573b706c4031d091c45a182b13cb3b2dba6233
Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/309920
Reviewed-by: Harald Alvestrand <hta@webrtc.org>
Commit-Queue: Tomas Gunnarsson <tommi@webrtc.org>
Cr-Commit-Position: refs/heads/main@{#40332}


Notes: Backported fix for chromium:1454086.