### PR TITLE
ci: upload test results to ventifact

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -233,7 +233,6 @@ step-maybe-upload-ventifact: &step-maybe-upload-ventifact
   run:
     name: Upload test results to ventifact
     environment:
-      CIRCLE_TRIGGER_TIMESTAMP: << pipeline.trigger_parameters.circleci.event_time >>
       # TODO: REMOVE THESE BEFORE MERGING
       VENTIFACT_URL: https://ventifact.herokuapp.com
       VENTIFACT_AUTH_TOKEN: test
@@ -248,7 +247,7 @@ step-maybe-upload-ventifact: &step-maybe-upload-ventifact
           -d "@src/junit/test-results.xml"
           --url-query "source=circleci" \
           --url-query "id=$CIRCLE_WORKFLOW_JOB_ID" \
-          --url-query "timestamp=$CIRCLE_TRIGGER_TIMESTAMP" \
+          --url-query "timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
           --url-query "branch=$CIRCLE_BRANCH" \
           || true
       else

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -229,6 +229,32 @@ step-maybe-cleanup-arm64-mac: &step-maybe-cleanup-arm64-mac
 
     when: always
 
+step-maybe-upload-ventifact: &step-maybe-upload-ventifact
+  run:
+    name: Upload test results to ventifact
+    environment:
+      CIRCLE_TRIGGER_TIMESTAMP: << pipeline.trigger_parameters.circleci.event_time >>
+      # TODO: REMOVE THESE BEFORE MERGING
+      VENTIFACT_URL: https://ventifact.herokuapp.com
+      VENTIFACT_AUTH_TOKEN: test
+    command: |
+      if [ -n "$VENTIFACT_URL" -a -n "$VENTIFACT_AUTH_TOKEN" ]; then
+        curl \
+          -g \
+          -X PUT \
+          --url "$VENTIFACT_URL/api/junit" \
+          -H "Content-Type: application/xml" \
+          -H "Authorization: Bearer $VENTIFACT_AUTH_TOKEN" \
+          -d "@src/junit/test-results.xml"
+          --url-query "source=circleci" \
+          --url-query "id=$CIRCLE_WORKFLOW_JOB_ID" \
+          --url-query "timestamp=$CIRCLE_TRIGGER_TIMESTAMP" \
+          --url-query "branch=$CIRCLE_BRANCH" \
+          || true
+      else
+        echo "VENTIFACT_URL or VENTIFACT_AUTH_TOKEN not set, skipping upload"
+      fi
+
 step-checkout-electron: &step-checkout-electron
   checkout:
     path: src/electron
@@ -1487,6 +1513,7 @@ commands:
             fi
       - store_test_results:
           path: src/junit
+      - *step-maybe-upload-ventifact
 
       - *step-verify-mksnapshot
       - *step-verify-chromedriver

--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -308,6 +308,7 @@ for:
             (Test-Path env:VENTIFACT_URL) -and
             (Test-Path env:VENTIFACT_AUTH_TOKEN)
           ) {
+            $ErrorActionPreference = 'SilentlyContinue'
             $branch = $env:APPVEYOR_REPO_BRANCH
             if (Test-Path env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH) {
               $branch = $env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH
@@ -316,7 +317,7 @@ for:
             $query = [System.Web.HttpUtility]::ParseQueryString("")
             $query.Set("source", "appveyor")
             $query.Set("id", $env:APPVEYOR_BUILD_ID)
-            $query.Set("timestamp", Get-Date -Format "o")
+            $query.Set("timestamp", (Get-Date -Format "o"))
             $query.Set("branch", $branch)
 
             $uri = [System.UriBuilder]::new("$env:VENTIFACT_URL/api/junit")

--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -36,12 +36,16 @@ environment:
   ELECTRON_ENABLE_STACK_DUMPING: 1
   ELECTRON_ALSO_LOG_TO_STDERR: 1
   MOCHA_REPORTER: mocha-multi-reporters
-  MOCHA_MULTI_REPORTERS: "@marshallofsound/mocha-appveyor-reporter, tap"
+  MOCHA_MULTI_REPORTERS: "@marshallofsound/mocha-appveyor-reporter, mocha-junit-reporter, tap"
+  ELECTRON_TEST_RESULTS_DIR: junit
   GOMA_FALLBACK_ON_AUTH_FAILURE: true
   DEPOT_TOOLS_WIN_TOOLCHAIN: 1
   DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL: "https://dev-cdn.electronjs.org/windows-toolchains/_"
   GYP_MSVS_HASH_27370823e7: 28622d16b1
   PYTHONIOENCODING: UTF-8
+  # TODO: REMOVE THESE BEFORE MERGING
+  VENTIFACT_URL: https://ventifact.herokuapp.com
+  VENTIFACT_AUTH_TOKEN: test
 
   matrix:
 
@@ -298,6 +302,37 @@ for:
             $env:npm_config_arch = "ia32"
           }
       - echo Running main test suite & node script/yarn test  --runners=main --enable-logging --disable-features=CalculateNativeWinOcclusion
+      - ps: |
+          if (
+            (Test-Path "src/junit/test-results.xml") -and
+            (Test-Path env:VENTIFACT_URL) -and
+            (Test-Path env:VENTIFACT_AUTH_TOKEN)
+          ) {
+            $branch = $env:APPVEYOR_REPO_BRANCH
+            if (Test-Path env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH) {
+              $branch = $env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH
+            }
+
+            $query = [System.Web.HttpUtility]::ParseQueryString("")
+            $query.Set("source", "appveyor")
+            $query.Set("id", $env:APPVEYOR_BUILD_ID)
+            $query.Set("timestamp", Get-Date -Format "o")
+            $query.Set("branch", $branch)
+
+            $uri = [System.UriBuilder]::new("$env:VENTIFACT_URL/api/junit")
+            $uri.Query = $query.ToString()
+
+            $headers = @{
+              "Content-Type" = "application/xml"
+              "Authorization" = "Bearer $env:VENTIFACT_AUTH_TOKEN"
+            }
+
+            Get-Content "src/junit/test-results.xml" |
+            Invoke-RestMethod `
+              -Method Put `
+              -Uri $uri.ToString() `
+              -Headers $headers
+          }
       - cd ..
       - echo Verifying non proprietary ffmpeg & python electron\script\verify-ffmpeg.py --build-dir out\Default --source-root %cd% --ffmpeg-path out\ffmpeg
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,12 +36,16 @@ environment:
   ELECTRON_ENABLE_STACK_DUMPING: 1
   ELECTRON_ALSO_LOG_TO_STDERR: 1
   MOCHA_REPORTER: mocha-multi-reporters
-  MOCHA_MULTI_REPORTERS: "@marshallofsound/mocha-appveyor-reporter, tap"
+  MOCHA_MULTI_REPORTERS: "@marshallofsound/mocha-appveyor-reporter, mocha-junit-reporter, tap"
+  ELECTRON_TEST_RESULTS_DIR: junit
   GOMA_FALLBACK_ON_AUTH_FAILURE: true
   DEPOT_TOOLS_WIN_TOOLCHAIN: 1
   DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL: "https://dev-cdn.electronjs.org/windows-toolchains/_"
   GYP_MSVS_HASH_27370823e7: 28622d16b1
   PYTHONIOENCODING: UTF-8
+  # TODO: REMOVE THESE BEFORE MERGING
+  VENTIFACT_URL: https://ventifact.herokuapp.com
+  VENTIFACT_AUTH_TOKEN: test
 
   matrix:
 
@@ -292,6 +296,37 @@ for:
             $env:npm_config_arch = "ia32"
           }
       - echo Running main test suite & node script/yarn test -- --trace-uncaught --runners=main --enable-logging=file --log-file=%cd%\electron.log
+      - ps: |
+          if (
+            (Test-Path "src/junit/test-results.xml") -and
+            (Test-Path env:VENTIFACT_URL) -and
+            (Test-Path env:VENTIFACT_AUTH_TOKEN)
+          ) {
+            $branch = $env:APPVEYOR_REPO_BRANCH
+            if (Test-Path env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH) {
+              $branch = $env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH
+            }
+
+            $query = [System.Web.HttpUtility]::ParseQueryString("")
+            $query.Set("source", "appveyor")
+            $query.Set("id", $env:APPVEYOR_BUILD_ID)
+            $query.Set("timestamp", Get-Date -Format "o")
+            $query.Set("branch", $branch)
+
+            $uri = [System.UriBuilder]::new("$env:VENTIFACT_URL/api/junit")
+            $uri.Query = $query.ToString()
+
+            $headers = @{
+              "Content-Type" = "application/xml"
+              "Authorization" = "Bearer $env:VENTIFACT_AUTH_TOKEN"
+            }
+
+            Get-Content "src/junit/test-results.xml" |
+            Invoke-RestMethod `
+              -Method Put `
+              -Uri $uri.ToString() `
+              -Headers $headers
+          }
       - echo Running native test suite & node script/yarn test -- --trace-uncaught --runners=native --enable-logging=file --log-file=%cd%\electron.log
       - cd ..
       - echo Verifying non proprietary ffmpeg & python electron\script\verify-ffmpeg.py --build-dir out\Default --source-root %cd% --ffmpeg-path out\ffmpeg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -302,6 +302,7 @@ for:
             (Test-Path env:VENTIFACT_URL) -and
             (Test-Path env:VENTIFACT_AUTH_TOKEN)
           ) {
+            $ErrorActionPreference = 'SilentlyContinue'
             $branch = $env:APPVEYOR_REPO_BRANCH
             if (Test-Path env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH) {
               $branch = $env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH
@@ -310,7 +311,7 @@ for:
             $query = [System.Web.HttpUtility]::ParseQueryString("")
             $query.Set("source", "appveyor")
             $query.Set("id", $env:APPVEYOR_BUILD_ID)
-            $query.Set("timestamp", Get-Date -Format "o")
+            $query.Set("timestamp", (Get-Date -Format "o"))
             $query.Set("branch", $branch)
 
             $uri = [System.UriBuilder]::new("$env:VENTIFACT_URL/api/junit")


### PR DESCRIPTION
#### Description of Change

**NOTE**: I'm still testing the actual CI runs in this PR.

Add a step to our CI runs to upload their test results (in JUnit XML format) to our [Ventifact](https://github.com/electron/ventifact) instance.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
