### PR TITLE
fix: initial dark mode title bar on Windows 10

### DIFF
--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
@@ -8,6 +8,7 @@
 #include <windows.h>
 
 #include "shell/browser/native_window_views.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/views/widget/desktop_aura/desktop_window_tree_host_win.h"
 
 namespace electron {
@@ -31,6 +32,7 @@ class ElectronDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin,
                     WPARAM w_param,
                     LPARAM l_param,
                     LRESULT* result) override;
+  bool ShouldPaintAsActive() const override;
   bool GetDwmFrameInsetsInPixels(gfx::Insets* insets) const override;
   bool GetClientAreaInsets(gfx::Insets* insets,
                            HMONITOR monitor) const override;
@@ -41,6 +43,7 @@ class ElectronDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin,
 
  private:
   raw_ptr<NativeWindowViews> native_window_view_;  // weak ref
+  absl::optional<bool> force_should_paint_as_active_;
 };
 
 }  // namespace electron

--- a/shell/browser/win/dark_mode.cc
+++ b/shell/browser/win/dark_mode.cc
@@ -25,16 +25,6 @@ HRESULT TrySetWindowTheme(HWND hWnd, bool dark) {
   if (FAILED(result))
     return result;
 
-  auto* os_info = base::win::OSInfo::GetInstance();
-  auto const version = os_info->version();
-
-  // Toggle the nonclient area active state to force a redraw (Win10 workaround)
-  if (version < base::win::Version::WIN11) {
-    HWND activeWindow = GetActiveWindow();
-    SendMessage(hWnd, WM_NCACTIVATE, hWnd != activeWindow, 0);
-    SendMessage(hWnd, WM_NCACTIVATE, hWnd == activeWindow, 0);
-  }
-
   return S_OK;
 }
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

The Windows 10 workaround we use to fix initial rendering of the title bar after changing the native theme stopped working after #38468 as a result of removing our hardcoded `ShouldPaintAsActive()` returning false. [Chromium's handling for the `WM_NCACTIVATE` message](https://source.chromium.org/chromium/chromium/src/+/main:ui/views/win/hwnd_message_handler.cc;l=2332-2381;drc=e6361d070be0adc585ebbff89fec76e2df4ad768) does a logical or between the requested `wParam` value and the result of `ShouldPaintAsActive()`, so before #38468 it was always doing `|| false` which meant the `wParam` value was always used. After the change in #38468 the workaround stopped working since it tries to toggle the title bar active state to force Windows to redraw it, but the logical or means you can't force it to render as inactive if `ShouldPaintAsActive()` is true.

This PR refactors the workaround to only be used when changing the theme of existing windows and temporarily forces the value of `ShouldPaintAsActive()` so that the title bar active state can be toggled. Also refactors to use `PaintAsActiveChanged()` when restoring the title bar state instead of specifically sending another `WM_NCACTIVATE` message to minimize the risk of any race conditions putting the title bar in an incorrect active state.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue on Windows 10 where the title bar was not correct after changing native theme <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->