### PR TITLE
fix: Chrome Extensions service worker host registration

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -162,6 +162,7 @@
 #include "extensions/browser/guest_view/mime_handler_view/mime_handler_view_guest.h"
 #include "extensions/browser/process_manager.h"
 #include "extensions/browser/process_map.h"
+#include "extensions/browser/service_worker/service_worker_host.h"
 #include "extensions/browser/url_loader_factory_manager.h"
 #include "extensions/common/api/mime_handler.mojom.h"
 #include "extensions/common/constants.h"
@@ -1554,6 +1555,9 @@ void ElectronBrowserClient::ExposeInterfacesToRenderer(
                           render_process_host->GetID()));
   associated_registry->AddInterface<extensions::mojom::GuestView>(
       base::BindRepeating(&extensions::ExtensionsGuestView::CreateForExtensions,
+                          render_process_host->GetID()));
+  associated_registry->AddInterface<extensions::mojom::ServiceWorkerHost>(
+      base::BindRepeating(&extensions::ServiceWorkerHost::BindReceiver,
                           render_process_host->GetID()));
 #endif
 }

--- a/spec/extensions-spec.ts
+++ b/spec/extensions-spec.ts
@@ -711,5 +711,20 @@ describe('chrome extensions', () => {
       const scope = await registrationPromise;
       expect(scope).equals(extension.url);
     });
+
+    it('can run chrome extension APIs', async () => {
+      const customSession = session.fromPartition(`persist:${uuid.v4()}`);
+      const w = new BrowserWindow({ show: false, webPreferences: { session: customSession, nodeIntegration: true } });
+      await customSession.loadExtension(path.join(fixtures, 'extensions', 'mv3-service-worker'));
+
+      await w.loadURL(url);
+
+      w.webContents.executeJavaScript('window.postMessage(\'fetch-confirmation\', \'*\')');
+
+      const [, , responseString] = await once(w.webContents, 'console-message');
+      const { message } = JSON.parse(responseString);
+
+      expect(message).to.equal('Hello from background.js');
+    });
   });
 });

--- a/spec/fixtures/extensions/mv3-service-worker/background.js
+++ b/spec/fixtures/extensions/mv3-service-worker/background.js
@@ -1,1 +1,7 @@
-console.log('service worker installed');
+/* global chrome */
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message === 'fetch-confirmation') {
+    sendResponse({ message: 'Hello from background.js' });
+  }
+});

--- a/spec/fixtures/extensions/mv3-service-worker/main.js
+++ b/spec/fixtures/extensions/mv3-service-worker/main.js
@@ -1,0 +1,13 @@
+/* global chrome */
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  sendResponse(message);
+});
+
+window.addEventListener('message', (event) => {
+  if (event.data === 'fetch-confirmation') {
+    chrome.runtime.sendMessage('fetch-confirmation', response => {
+      console.log(JSON.stringify(response));
+    });
+  }
+}, false);

--- a/spec/fixtures/extensions/mv3-service-worker/manifest.json
+++ b/spec/fixtures/extensions/mv3-service-worker/manifest.json
@@ -3,6 +3,17 @@
   "description": "Test for extension service worker support.",
   "version": "1.0",
   "manifest_version": 3,
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "main.js"
+      ],
+      "run_at": "document_start"
+    }
+  ],
   "background": {
     "service_worker": "background.js"
   }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/34178.

Fixes basic Chrome Extension Manifest V3 service worker functionality. Previously, the service worker would register but could not run any chrome APIs:

```
[61131:0731/100424.234951:ERROR:render_process_host_impl.cc(3967)] Request for unknown Channel-associated interface: extensions.mojom.ServiceWorkerHost
```

This fixes that and adds a simple regression test.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where service workers could not run Chrome APIs in Chrome Extensions Manifest V3.