### PR TITLE
fix: initial dark mode title bar on Windows 10

### DIFF
--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
@@ -8,6 +8,7 @@
 #include <windows.h>
 
 #include "shell/browser/native_window_views.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/views/widget/desktop_aura/desktop_window_tree_host_win.h"
 
 namespace electron {
@@ -31,6 +32,7 @@ class ElectronDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin,
                     WPARAM w_param,
                     LPARAM l_param,
                     LRESULT* result) override;
+  bool ShouldPaintAsActive() const override;
   bool GetDwmFrameInsetsInPixels(gfx::Insets* insets) const override;
   bool GetClientAreaInsets(gfx::Insets* insets,
                            HMONITOR monitor) const override;
@@ -41,6 +43,7 @@ class ElectronDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin,
 
  private:
   NativeWindowViews* native_window_view_;  // weak ref
+  absl::optional<bool> force_should_paint_as_active_;
 };
 
 }  // namespace electron

--- a/shell/browser/win/dark_mode.cc
+++ b/shell/browser/win/dark_mode.cc
@@ -25,16 +25,6 @@ HRESULT TrySetWindowTheme(HWND hWnd, bool dark) {
   if (FAILED(result))
     return result;
 
-  auto* os_info = base::win::OSInfo::GetInstance();
-  auto const version = os_info->version();
-
-  // Toggle the nonclient area active state to force a redraw (Win10 workaround)
-  if (version < base::win::Version::WIN11) {
-    HWND activeWindow = GetActiveWindow();
-    SendMessage(hWnd, WM_NCACTIVATE, hWnd != activeWindow, 0);
-    SendMessage(hWnd, WM_NCACTIVATE, hWnd == activeWindow, 0);
-  }
-
   return S_OK;
 }
 


### PR DESCRIPTION
Backport of #39287.

See that PR for details.

Notes: Fixed an issue on Windows 10 where the title bar was not correct after changing native theme