### PR TITLE
docs: correct `powerSaveBlocker.stop(id)` return type

### DIFF
--- a/docs/api/power-save-blocker.md
+++ b/docs/api/power-save-blocker.md
@@ -49,6 +49,8 @@ is used.
 
 Stops the specified power save blocker.
 
+Returns `boolean` - Whether the specified `powerSaveBlocker` has been stopped.
+
 ### `powerSaveBlocker.isStarted(id)`
 
 * `id` Integer - The power save blocker id returned by `powerSaveBlocker.start`.

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -904,7 +904,8 @@ app.whenReady().then(() => {
 const id = powerSaveBlocker.start('prevent-display-sleep');
 console.log(powerSaveBlocker.isStarted(id));
 
-powerSaveBlocker.stop(id);
+const stopped = powerSaveBlocker.stop(id);
+console.log(`The powerSaveBlocker is ${stopped ? 'stopped' : 'not stopped'}`);
 
 // protocol
 // https://github.com/electron/electron/blob/main/docs/api/protocol.md


### PR DESCRIPTION
#### Description of Change

Supersedes https://github.com/electron/electron/pull/39080 - which we determined to be employing ChatGPT.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
