### PR TITLE
fix: destroy message port backend when JS env exits

### DIFF
--- a/shell/browser/api/message_port.h
+++ b/shell/browser/api/message_port.h
@@ -11,6 +11,7 @@
 #include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/connector.h"
 #include "mojo/public/cpp/bindings/message.h"
+#include "shell/common/gin_helper/cleaned_up_at_exit.h"
 #include "third_party/blink/public/common/messaging/message_port_channel.h"
 #include "third_party/blink/public/common/messaging/message_port_descriptor.h"
 
@@ -23,7 +24,9 @@ class Handle;
 namespace electron {
 
 // A non-blink version of blink::MessagePort.
-class MessagePort : public gin::Wrappable<MessagePort>, mojo::MessageReceiver {
+class MessagePort : public gin::Wrappable<MessagePort>,
+                    public gin_helper::CleanedUpAtExit,
+                    public mojo::MessageReceiver {
  public:
   ~MessagePort() override;
   static gin::Handle<MessagePort> Create(v8::Isolate* isolate);


### PR DESCRIPTION
#### Description of Change

Fixes the following two crashes we have seen in our releases with utility process

<details>
<summary>Crash 1</summary>

```
Thread 0:
0   electron::JavascriptEnvironment::GetIsolate() [0x9a5f8c8] in javascript_environment.cc:380
       x0 = 0x0000000000000000   x1 = 0x0000000000000000
       x2 = 0x0000000000000000   x3 = 0x000000012a000000
       x4 = 0x000000012a00b330   x5 = 0x0000000000000009
       x6 = 0x0000000000000002   x7 = 0x0000000000000000
       x8 = 0x0000000110747000   x9 = 0x23649dadec0d0055
      x10 = 0x0000000000000000  x11 = 0x0000000000000000
      x12 = 0x0000000000000735  x13 = 0x0000000000000073
      x14 = 0x0000000000000808  x15 = 0x0000000000000808
      x16 = 0x0000000185700e9c  x17 = 0x0000000185564d74
      x18 = 0x0000000000000000  x19 = 0x0000000000000001
      x20 = 0x000000012f71ea10  x21 = 0xaaaaaaaaaaaaaaaa
      x22 = 0x000000016d996268  x23 = 0x0000000128809800
      x24 = 0xaaaaaaaaaaaaaaaa  x25 = 0x000000016d996280
      x26 = 0x0000000000000019  x27 = 0x00000001106c1000
      x28 = 0x0000000000000001   fp = 0x000000016d996130
       lr = 0x0000000109a3ac04   sp = 0x000000016d995e90
       pc = 0x0000000109a5f8c8
1   electron::MessagePort::Accept(mojo::Message*) [0x9a3ac00] in message_port.cc:235
       fp = 0x000000016d9962f0   lr = 0x000000010c127ba4
       sp = 0x000000016d996140   pc = 0x0000000109a3ac04
2   mojo::Connector::ReadAllAvailableMessages() [0xc127ba0] in connector.cc:561
       fp = 0x000000016d996380   lr = 0x000000010be5aa60
       sp = 0x000000016d996300   pc = 0x000000010c127ba4
3   base::TaskAnnotator::RunTaskImpl(base::PendingTask&) [0xbe5aa5c] in callback.h:143
       fp = 0x000000016d996550   lr = 0x000000010be75484
       sp = 0x000000016d996390   pc = 0x000000010be5aa60
4   non-virtual thunk to base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() [0xbe75480] in task_annotator.h:74
       fp = 0x000000016d9965d0   lr = 0x000000010be27e90
       sp = 0x000000016d996560   pc = 0x000000010be75484
5   base::MessagePumpDefault::Run(base::MessagePump::Delegate*) [0xbe27e8c] in message_pump_default.cc:39
       fp = 0x000000016d996610   lr = 0x000000010be75ee4
       sp = 0x000000016d9965e0   pc = 0x000000010be27e90
6   base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) [0xbe75ee0] in thread_controller_with_message_pump_impl.cc:498
       fp = 0x000000016d9966b0   lr = 0x000000010be45424
       sp = 0x000000016d996620   pc = 0x000000010be75ee4
7   base::RunLoop::Run(base::Location const&) [0xbe45420] in run_loop.cc:141
       fp = 0x000000016d996830   lr = 0x000000010bbe55d4
       sp = 0x000000016d9966c0   pc = 0x000000010be45424
8   content::UtilityMain(content::MainFunctionParams) [0xbbe55d0] in utility_main.cc:275
       fp = 0x000000016d996940   lr = 0x0000000109c0d92c
       sp = 0x000000016d996840   pc = 0x000000010bbe55d4
9   content::RunOtherNamedProcessTypeMain(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, content::MainFunctionParams, content::ContentMainDelegate*) [0x9c0d928] in content_main_runner_impl.cc:680
       fp = 0x000000016d996a00   lr = 0x0000000109c0e210
       sp = 0x000000016d996950   pc = 0x0000000109c0d92c
10  content::ContentMainRunnerImpl::Run() [0x9c0e20c] in content_main_runner_impl.cc:1019
       fp = 0x000000016d996c90   lr = 0x0000000109c0cdfc
       sp = 0x000000016d996a10   pc = 0x0000000109c0e210
11  content::RunContentProcess(content::ContentMainParams, content::ContentMainRunner*) [0x9c0cdf8] in content_main.cc:411
       fp = 0x000000016d996d00   lr = 0x0000000109c0d2c8
       sp = 0x000000016d996ca0   pc = 0x0000000109c0cdfc
12  content::ContentMain(content::ContentMainParams) [0x9c0d2c4] in content_main.cc:439
       fp = 0x000000016d996df0   lr = 0x000000010998b18c
       sp = 0x000000016d996d10   pc = 0x0000000109c0d2c8
13  ElectronMain [0x998b188] in electron_library_main.mm:34
       fp = 0x000000016d996e40   lr = 0x000000010246899c
       sp = 0x000000016d996e00   pc = 0x000000010998b18c
14  main [0x2468998] in electron_main_mac.cc:68
       fp = 0x000000016d997130   lr = 0x00000001853dbe50
       sp = 0x000000016d996e50   pc = 0x000000010246899c
15  0x853dbe4c + 24140
       fp = 0x0000000000000000   lr = 0xe05b800000000000
       sp = 0x000000016d997140   pc = 0x00000001853dbe50
```
</details>

<details>
<summary>Crash 2</summary>

```
Thread 0:
0   v8::internal::GlobalHandles::Destroy(unsigned __int64 *) [0x89217292] in global-handles.cc:1132
      rax = 0xd0152800ce600000  rdx = 0xffffffffffffe0a0
      rcx = 0x000060ce003ac760  rbx = 0x000060ce0026c080
      rsi = 0x000060ce002814e0  rdi = 0x000060ce0026c0b8
      rbp = 0x000000b8a0dfef00  rsp = 0x000000b8a0dfec00
       r8 = 0x0000000000000000   r9 = 0x00007ffcc70fc730
      r10 = 0x00000ffef12fafcc  r11 = 0x0000000000001004
      r12 = 0xaaaaaaaaaaaaaaaa  r13 = 0x0000000000000009
      r14 = 0x000000b8a0dfed00  r15 = 0x000060ce0028e400
      rip = 0x00007ff789217292
1   class blink::MessagePortChannel electron::MessagePort::Disentangle() [0x8623ed83] in message_port.cc:149
      rbx = 0x000060ce0026c080  rbp = 0x000000b8a0dfef00
      rsp = 0x000000b8a0dfec30  r12 = 0xaaaaaaaaaaaaaaaa
      r13 = 0x0000000000000009  r14 = 0x000000b8a0dfed00
      r15 = 0x000060ce0028e400  rip = 0x00007ff78623ed83
2   void electron::MessagePort::Close() [0x8623f93d] in message_port.cc:107
      rbx = 0x000060ce0026c080  rbp = 0x000000b8a0dfef00
      rsp = 0x000000b8a0dfecb0  r12 = 0xaaaaaaaaaaaaaaaa
      r13 = 0x0000000000000009  r14 = 0x000000b8a0dfed00
      r15 = 0x000060ce0028e400  rip = 0x00007ff78623f93d
3   static void base::internal::Invoker<base::internal::BindState<void (mojo::Connector::*)(unsigned int),base::internal::UnretainedWrapper<mojo::Connector> >,void (unsigned int)>::Run(class base::internal::BindStateBase *, unsigned int) [0x8771f27a] in bind_internal.h:764
      rbx = 0x000060ce0026c080  rbp = 0x000000b8a0dfef00
      rsp = 0x000000b8a0dfed90  r12 = 0xaaaaaaaaaaaaaaaa
      r13 = 0x0000000000000009  r14 = 0x000000b8a0dfed00
      r15 = 0x000060ce0028e400  rip = 0x00007ff78771f27a
4   void mojo::SimpleWatcher::OnHandleReady(int, unsigned int, const struct mojo::HandleSignalsState & const) [0x8980373b] in simple_watcher.cc:278
      rbx = 0x000060ce0026c080  rbp = 0x000000b8a0dfef00
      rsp = 0x000000b8a0dfee50  r12 = 0xaaaaaaaaaaaaaaaa
      r13 = 0x0000000000000009  r14 = 0x000000b8a0dfed00
      r15 = 0x000060ce0028e400  rip = 0x00007ff78980373b
5   base::TaskAnnotator::RunTaskImpl(base::PendingTask &) [0x897c0b48] in task_annotator.cc:135
      rbx = 0x000060ce0026c080  rbp = 0x000000b8a0dfef00
      rsp = 0x000000b8a0dfef90  r12 = 0xaaaaaaaaaaaaaaaa
      r13 = 0x0000000000000009  r14 = 0x000000b8a0dfed00
      r15 = 0x000060ce0028e400  rip = 0x00007ff7897c0b48
6   base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() [0x89897c57] in thread_controller_with_message_pump_impl.cc:291
      rbx = 0x000060ce0026c080  rbp = 0x000000b8a0dfef00
      rsp = 0x000000b8a0dff040  r12 = 0xaaaaaaaaaaaaaaaa
      r13 = 0x0000000000000009  r14 = 0x000000b8a0dfed00
      r15 = 0x000060ce0028e400  rip = 0x00007ff789897c57
7   base::MessagePumpDefault::Run(base::MessagePump::Delegate *) [0x87c1db6c] in message_pump_default.cc:39
      rbx = 0x000060ce0026c080  rbp = 0x000000b8a0dfef00
      rsp = 0x000000b8a0dff260  r12 = 0xaaaaaaaaaaaaaaaa
      r13 = 0x0000000000000009  r14 = 0x000000b8a0dfed00
      r15 = 0x000060ce0028e400  rip = 0x00007ff787c1db6c
8   base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,base::TimeDelta) [0x87c27cfa] in thread_controller_with_message_pump_impl.cc:498
      rbx = 0x000060ce0026c080  rbp = 0x000000b8a0dfef00
      rsp = 0x000000b8a0dff310  r12 = 0xaaaaaaaaaaaaaaaa
      r13 = 0x0000000000000009  r14 = 0x000000b8a0dfed00
      r15 = 0x000060ce0028e400  rip = 0x00007ff787c27cfa
9   base::RunLoop::Run(base::Location const &) [0x8766459f] in run_loop.cc:141
      rbx = 0x000060ce0026c080  rbp = 0x000000b8a0dfef00
      rsp = 0x000000b8a0dff380  r12 = 0xaaaaaaaaaaaaaaaa
      r13 = 0x0000000000000009  r14 = 0x000000b8a0dfed00
      r15 = 0x000060ce0028e400  rip = 0x00007ff78766459f
10  content::UtilityMain(content::MainFunctionParams) [0x87446600] in utility_main.cc:275
      rbx = 0x000060ce0026c080  rbp = 0x000000b8a0dfef00
      rsp = 0x000000b8a0dff470  r12 = 0xaaaaaaaaaaaaaaaa
      r13 = 0x0000000000000009  r14 = 0x000000b8a0dfed00
      r15 = 0x000060ce0028e400  rip = 0x00007ff787446600
11  static int content::RunOtherNamedProcessTypeMain(const class std::__1::basic_string<char,std::__1::char_traits<char>,std::__1::allocator<char> > & const, struct content::MainFunctionParams, class content::ContentMainDelegate *) [0x863e165c] in content_main_runner_impl.cc:680
      rbx = 0x000060ce0026c080  rbp = 0x000000b8a0dfef00
      rsp = 0x000000b8a0dff6b0  r12 = 0xaaaaaaaaaaaaaaaa
      r13 = 0x0000000000000009  r14 = 0x000000b8a0dfed00
      r15 = 0x000060ce0028e400  rip = 0x00007ff7863e165c
12  content::ContentMainRunnerImpl::Run() [0x863e213d] in content_main_runner_impl.cc:1019
      rbx = 0x000060ce0026c080  rbp = 0x000000b8a0dfef00
      rsp = 0x000000b8a0dff7c0  r12 = 0xaaaaaaaaaaaaaaaa
      r13 = 0x0000000000000009  r14 = 0x000000b8a0dfed00
      r15 = 0x000060ce0028e400  rip = 0x00007ff7863e213d
13  static int content::RunContentProcess(struct content::ContentMainParams, class content::ContentMainRunner *) [0x863de6bc] in content_main.cc:411
      rbx = 0x000060ce0026c080  rbp = 0x000000b8a0dfef00
      rsp = 0x000000b8a0dff8e0  r12 = 0xaaaaaaaaaaaaaaaa
      r13 = 0x0000000000000009  r14 = 0x000000b8a0dfed00
      r15 = 0x000060ce0028e400  rip = 0x00007ff7863de6bc
14  content::ContentMain(content::ContentMainParams) [0x863dea30] in content_main.cc:439
      rbx = 0x000060ce0026c080  rbp = 0x000000b8a0dfef00
      rsp = 0x000000b8a0dffb50  r12 = 0xaaaaaaaaaaaaaaaa
      r13 = 0x0000000000000009  r14 = 0x000000b8a0dfed00
      r15 = 0x000060ce0028e400  rip = 0x00007ff7863dea30
15  wWinMain [0x8616ee7d] in electron_main_win.cc:247
      rbx = 0x000060ce0026c080  rbp = 0x000000b8a0dfef00
      rsp = 0x000000b8a0dffbe0  r12 = 0xaaaaaaaaaaaaaaaa
      r13 = 0x0000000000000009  r14 = 0x000000b8a0dfed00
      r15 = 0x000060ce0028e400  rip = 0x00007ff78616ee7d
16  static int __scrt_common_main_seh() [0x89c11992] in exe_common.inl:288
      rbx = 0x000060ce0026c080  rbp = 0x000000b8a0dfef00
      rsp = 0x000000b8a0dffdf0  r12 = 0xaaaaaaaaaaaaaaaa
      r13 = 0x0000000000000009  r14 = 0x000000b8a0dfed00
      r15 = 0x000060ce0028e400  rip = 0x00007ff789c11992
```
</details>

Currently `MessagePort` class in the utility process will outlive the Javascript environment and if there are pending messages while the process is being destroyed, when the chromium event loop flushes the messages it will cause UAF if the `MessagePort` class tries to call into JS. The change ensures
that the `MessagePort` class gets destroyed when the Javascript environment is destroyed.

#### Release Notes

Notes: fix crash in message ports when utility process exits.
