### PR TITLE
chore: remove deprecated systemPreferences color scheme events

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -27,24 +27,6 @@ Returns:
 
 * `event` Event
 
-### Event: 'inverted-color-scheme-changed' _Windows_ _Deprecated_
-
-Returns:
-
-* `event` Event
-* `invertedColorScheme` boolean - `true` if an inverted color scheme (a high contrast color scheme with light text and dark backgrounds) is being used, `false` otherwise.
-
-**Deprecated:** Should use the new [`updated`](native-theme.md#event-updated) event on the `nativeTheme` module.
-
-### Event: 'high-contrast-color-scheme-changed' _Windows_ _Deprecated_
-
-Returns:
-
-* `event` Event
-* `highContrastColorScheme` boolean - `true` if a high contrast theme is being used, `false` otherwise.
-
-**Deprecated:** Should use the new [`updated`](native-theme.md#event-updated) event on the `nativeTheme` module.
-
 ## Methods
 
 ### `systemPreferences.isSwipeTrackingFromScrollEventsEnabled()` _macOS_

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -27,6 +27,24 @@ The `ipcRenderer.sendTo()` API has been deprecated. It should be replaced by set
 
 The `senderId` and `senderIsMainFrame` properties of `IpcRendererEvent` have been deprecated as well.
 
+### Removed: color scheme events in `systemPreferences`
+
+The following `systemPreferences` events have been removed:
+
+* `inverted-color-scheme-changed`
+* `high-contrast-color-scheme-changed`
+
+Use the new `updated` event on the `nativeTheme` module instead.
+
+```js
+// Removed
+systemPreferences.on('inverted-color-scheme-changed', () => { /* ... */ })
+systemPreferences.on('high-contrast-color-scheme-changed', () => { /* ... */ })
+
+// Replace with
+nativeTheme.on('updated', () => { /* ... */ })
+```
+
 ## Planned Breaking API Changes (25.0)
 
 ### Deprecated: `protocol.{register,intercept}{Buffer,String,Stream,File,Http}Protocol`

--- a/shell/browser/api/electron_api_system_preferences.cc
+++ b/shell/browser/api/electron_api_system_preferences.cc
@@ -33,16 +33,6 @@ SystemPreferences::~SystemPreferences() {
 SystemPreferences::~SystemPreferences() = default;
 #endif
 
-bool SystemPreferences::IsInvertedColorScheme() {
-  return ui::NativeTheme::GetInstanceForNativeUi()
-             ->GetPlatformHighContrastColorScheme() ==
-         ui::NativeTheme::PlatformHighContrastColorScheme::kDark;
-}
-
-bool SystemPreferences::IsHighContrastColorScheme() {
-  return ui::NativeTheme::GetInstanceForNativeUi()->UserHasContrastPreference();
-}
-
 v8::Local<v8::Value> SystemPreferences::GetAnimationSettings(
     v8::Isolate* isolate) {
   gin_helper::Dictionary dict = gin::Dictionary::CreateEmpty(isolate);

--- a/shell/browser/api/electron_api_system_preferences.h
+++ b/shell/browser/api/electron_api_system_preferences.h
@@ -115,8 +115,6 @@ class SystemPreferences
   v8::Local<v8::Value> GetAppLevelAppearance(v8::Isolate* isolate);
   void SetAppLevelAppearance(gin::Arguments* args);
 #endif
-  bool IsInvertedColorScheme();
-  bool IsHighContrastColorScheme();
   v8::Local<v8::Value> GetAnimationSettings(v8::Isolate* isolate);
 
   // disable copy
@@ -157,10 +155,6 @@ class SystemPreferences
   HWND window_;
 
   std::string current_color_;
-
-  bool inverted_color_scheme_ = false;
-
-  bool high_contrast_color_scheme_ = false;
 
   std::unique_ptr<gfx::ScopedSysColorChangeListener> color_change_listener_;
 #endif

--- a/shell/browser/api/electron_api_system_preferences_win.cc
+++ b/shell/browser/api/electron_api_system_preferences_win.cc
@@ -158,9 +158,6 @@ std::string SystemPreferences::GetMediaAccessStatus(
 }
 
 void SystemPreferences::InitializeWindow() {
-  inverted_color_scheme_ = IsInvertedColorScheme();
-  high_contrast_color_scheme_ = IsHighContrastColorScheme();
-
   // Wait until app is ready before creating sys color listener
   // Creating this listener before the app is ready causes global shortcuts
   // to not fire
@@ -216,18 +213,6 @@ LRESULT CALLBACK SystemPreferences::WndProc(HWND hwnd,
 }
 
 void SystemPreferences::OnSysColorChange() {
-  bool new_inverted_color_scheme = IsInvertedColorScheme();
-  if (new_inverted_color_scheme != inverted_color_scheme_) {
-    inverted_color_scheme_ = new_inverted_color_scheme;
-    Emit("inverted-color-scheme-changed", new_inverted_color_scheme);
-  }
-
-  bool new_high_contrast_color_scheme = IsHighContrastColorScheme();
-  if (new_high_contrast_color_scheme != high_contrast_color_scheme_) {
-    high_contrast_color_scheme_ = new_high_contrast_color_scheme;
-    Emit("high-contrast-color-scheme-changed", new_high_contrast_color_scheme);
-  }
-
   Emit("color-changed");
 }
 

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -365,7 +365,10 @@ if (process.platform !== 'win32' || systemPreferences.isAeroGlassEnabled()) {
 
 if (process.platform === 'win32') {
   systemPreferences.on('color-changed', () => { console.log('color changed'); });
+  // @ts-expect-error Removed API
   systemPreferences.on('inverted-color-scheme-changed', (_, inverted) => console.log(inverted ? 'inverted' : 'not inverted'));
+  // @ts-expect-error Removed API
+  systemPreferences.on('high-contrast-color-scheme-changed', (_, highContrast) => console.log(highContrast ? 'high contrast' : 'not high contrast'));
   console.log('Color for menu is', systemPreferences.getColor('menu'));
 }
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

~~Needs #39334 to land first.~~

These events were marked as deprecated in #26848 but were never removed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: The deprecated color scheme changed events in systemPreferences have been removed <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
