### PR TITLE
feat: allow more Node.js cli flags in main process

### DIFF
--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -241,19 +241,25 @@ Electron supports some of the [CLI flags][node-cli] supported by Node.js.
 
 **Note:** Passing unsupported command line switches to Electron when it is not running in `ELECTRON_RUN_AS_NODE` will have no effect.
 
-### --inspect-brk\[=\[host:]port]
+### `--inspect-brk\[=\[host:]port]`
 
 Activate inspector on host:port and break at start of user script. Default host:port is 127.0.0.1:9229.
 
 Aliased to `--debug-brk=[host:]port`.
 
-### --inspect-port=\[host:]port
+#### `--inspect-brk-node[=[host:]port]`
+
+Activate inspector on `host:port` and break at start of the first internal
+JavaScript script executed when the inspector is available.
+Default `host:port` is `127.0.0.1:9229`.
+
+### `--inspect-port=\[host:]port`
 
 Set the `host:port` to be used when the inspector is activated. Useful when activating the inspector by sending the SIGUSR1 signal. Default host is `127.0.0.1`.
 
 Aliased to `--debug-port=[host:]port`.
 
-### --inspect\[=\[host:]port]
+### `--inspect\[=\[host:]port]`
 
 Activate inspector on `host:port`. Default is `127.0.0.1:9229`.
 
@@ -263,11 +269,27 @@ See the [Debugging the Main Process][debugging-main-process] guide for more deta
 
 Aliased to `--debug[=[host:]port`.
 
-### --inspect-publish-uid=stderr,http
+### `--inspect-publish-uid=stderr,http`
 
 Specify ways of the inspector web socket url exposure.
 
 By default inspector websocket url is available in stderr and under /json/list endpoint on http://host:port/json/list.
+
+### `--no-deprecation`
+
+Silence deprecation warnings.
+
+### `--throw-deprecation`
+
+Throw errors for deprecations.
+
+### `--trace-deprecation`
+
+Print stack traces for deprecations.
+
+### `--trace-warnings`
+
+Print stack traces for process warnings (including deprecations).
 
 [app]: app.md
 [append-switch]: command-line.md#commandlineappendswitchswitch-value

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -404,7 +404,8 @@ void NodeBindings::SetNodeCliFlags() {
 #endif
     const auto stripped = base::StringPiece(option).substr(0, option.find('='));
 
-    // Only allow in no-op (--) option or DebugOptions
+    // Only allow in no-op (--) option or a small set of debug
+    // and trace related options.
     if (IsAllowedOption(stripped) || stripped == "--")
       args.push_back(option);
   }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/39322.

This PR allows a few more cli flags to be set in the main process. We currently allow these to be set indirectly via the [`process` object](https://github.com/electron/electron/blob/67a6fbf2656c5aa18c59721b56b081c156e79fad/docs/api/process.md#L93-L110),  which causes Node.js itself to add them to cli flags. This aligns what's permitted so that users can set them in either place. Before this, Node.js would log the process warning in a way that ultimately created more confusion for users. They would be told to set the flag to see warnings, but if they did, it would be silently dropped and seem to have no effect.

<details><summary>Before</summary>
<p>

```
electron-trace-warnings-issue on git:main ❯ npm start            11:40AM

> electron-quick-start@1.0.0 start
> e start --trace-warnings .

Running "/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/MacOS/Electron --trace-warnings ."
(node:48122) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 window-all-closed listeners added to [App]. Use emitter.setMaxListeners() to increase limit
(Use `Electron --trace-warnings ...` to show where the warning was created)
```

</p>
</details> 

<details><summary>After</summary>
<p>

```
electron-trace-warnings-issue on git:main ❯ npm start            11:30AM

> electron-quick-start@1.0.0 start
> e start --trace-warnings .

Running "/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/MacOS/Electron --trace-warnings ."
(node:47282) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 window-all-closed listeners added to [App]. Use emitter.setMaxListeners() to increase limit
    at _addListener (node:events:587:17)
    at App.addListener (node:events:605:10)
    at Object.<anonymous> (/Users/codebytere/Developer/repros/electron-trace-warnings-isssue/main.js:41:7)
    at Module._compile (node:internal/modules/cjs/loader:1271:14)
    at Object..js (node:internal/modules/cjs/loader:1326:10)
    at Module.load (node:internal/modules/cjs/loader:1126:32)
    at node:internal/modules/cjs/loader:967:12
    at Function._load (node:electron/js2c/asar_bundle:756:32)
    at loadApplicationPackage (/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Resources/default_app.asar/main.js:121:16)
```

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added support for several more Node.js cli flags in the main process.
