### PR TITLE
fix: `chrome.tabs.update` return value

### DIFF
--- a/spec/extensions-spec.ts
+++ b/spec/extensions-spec.ts
@@ -950,6 +950,23 @@ describe('chrome extensions', () => {
           expect(response.status).to.equal('reloaded');
         });
       });
+
+      it('update', async () => {
+        await w.loadURL(url);
+
+        const message = { method: 'update', args: [{ muted: true }] };
+        w.webContents.executeJavaScript(`window.postMessage('${JSON.stringify(message)}', '*')`);
+
+        const [,, responseString] = await once(w.webContents, 'console-message');
+        const response = JSON.parse(responseString);
+
+        expect(response).to.have.property('mutedInfo').that.is.a('object');
+        const { mutedInfo } = response;
+        expect(mutedInfo).to.deep.eq({
+          muted: true,
+          reason: 'user'
+        });
+      });
     });
   });
 });

--- a/spec/fixtures/extensions/tabs-api-async/background.js
+++ b/spec/fixtures/extensions/tabs-api-async/background.js
@@ -42,6 +42,13 @@ const handleRequest = (request, sender, sendResponse) => {
       chrome.tabs.reload(tabId).then(() => {
         sendResponse({ status: 'reloaded' });
       });
+      break;
+    }
+
+    case 'update': {
+      const [params] = args;
+      chrome.tabs.update(tabId, params).then(sendResponse);
+      break;
     }
   }
 };

--- a/spec/fixtures/extensions/tabs-api-async/main.js
+++ b/spec/fixtures/extensions/tabs-api-async/main.js
@@ -34,6 +34,11 @@ const testMap = {
     chrome.runtime.sendMessage({ method: 'reload' }, response => {
       console.log(JSON.stringify(response));
     });
+  },
+  update (params) {
+    chrome.runtime.sendMessage({ method: 'update', args: [params] }, response => {
+      console.log(JSON.stringify(response));
+    });
   }
 };
 


### PR DESCRIPTION
#### Description of Change

Fixes an issue where `chrome.tabs.update` did not return a `tab` object that properly reflected potential properties that were changed, e.g. `muted`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `chrome.tabs.update` did not return a `tab` object that properly reflected potential properties that were changed.