### PR TITLE
fix: crash when closing active macOS native tab

### DIFF
--- a/shell/browser/ui/inspectable_web_contents_view_mac.mm
+++ b/shell/browser/ui/inspectable_web_contents_view_mac.mm
@@ -24,6 +24,7 @@ InspectableWebContentsViewMac::InspectableWebContentsViewMac(
           initWithInspectableWebContentsViewMac:this]) {}
 
 InspectableWebContentsViewMac::~InspectableWebContentsViewMac() {
+  [[NSNotificationCenter defaultCenter] removeObserver:view_];
   CloseDevTools();
 }
 


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/microsoft/vscode/issues/167936

Repro: https://gist.github.com/deepak1556/dfeed162dcfb36f3e3b07409885f32f2#file-steps-md

<details>
<summary>Stacktrace</summary>

```
Received signal 11 SEGV_ACCERR 00000000010e
0   Electron Framework                  0x0000000119aca6b4 base::debug::CollectStackTrace(void**, unsigned long) + 28
1   Electron Framework                  0x0000000119aba854 base::debug::StackTrace::StackTrace() + 24
2   Electron Framework                  0x0000000119aca610 base::debug::(anonymous namespace)::StackDumpSignalHandler(int, __siginfo*, void*) + 1204
3   libsystem_platform.dylib            0x000000018abf9a24 _sigtramp + 56
4   Electron Framework                  0x00000001157a1678 -[ElectronInspectableWebContentsView viewDidBecomeFirstResponder:] + 60
5   CoreFoundation                      0x000000018ac9c830 __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 148
6   CoreFoundation                      0x000000018ad306a8 ___CFXRegistrationPost_block_invoke + 88
7   CoreFoundation                      0x000000018ad305f0 _CFXRegistrationPost + 440
8   CoreFoundation                      0x000000018ac6b4b0 _CFXNotificationPost + 764
9   Foundation                          0x000000018bd20aac -[NSNotificationCenter postNotificationName:object:userInfo:] + 88
10  Electron Framework                  0x0000000119016240 -[RenderWidgetHostViewCocoa becomeFirstResponder] + 332
11  AppKit                              0x000000018e530c80 -[NSWindow _realMakeFirstResponder:] + 560
12  Electron Framework                  0x0000000119037cc8 content::RenderWidgetHostViewMac::Focus() + 72
13  Electron Framework                  0x0000000118f804e8 content::WebContentsImpl::RestoreFocus() + 76
14  Electron Framework                  0x00000001155e9e40 non-virtual thunk to electron::api::BrowserWindow::OnWindowFocus() + 56
15  Electron Framework                  0x00000001156d1638 electron::NativeWindow::NotifyWindowFocus() + 452
16  Electron Framework                  0x00000001157a4ad4 -[ElectronNSWindowDelegate windowDidBecomeMain:] + 32
17  CoreFoundation                      0x000000018ac9c830 __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 148
18  CoreFoundation                      0x000000018ad306a8 ___CFXRegistrationPost_block_invoke + 88
19  CoreFoundation                      0x000000018ad305f0 _CFXRegistrationPost + 440
20  CoreFoundation                      0x000000018ac6b4b0 _CFXNotificationPost + 764
21  Foundation                          0x000000018bd20aac -[NSNotificationCenter postNotificationName:object:userInfo:] + 88
22  AppKit                              0x000000018e53a5e8 -[NSWindow _changeKeyAndMainLimitedOK:] + 796
23  AppKit                              0x000000018e53a28c -[NSWindow makeKeyWindow] + 172
24  AppKit                              0x000000018e53a044 -[NSWindow _makeKeyRegardlessOfVisibility] + 56
25  AppKit                              0x000000018e53282c -[NSWindow makeKeyAndOrderFront:] + 24
26  AppKit                              0x000000018ee31fa0 __67-[NSWindowStackController _doTabSelectionAndWindowOrderingAtIndex:]_block_invoke + 248
27  AppKit                              0x000000018e481b48 NSPerformVisuallyAtomicChange + 108
28  AppKit                              0x000000018ee31d4c -[NSWindowStackController _doTabSelectionAndWindowOrderingAtIndex:] + 704
29  AppKit                              0x000000018ee30668 -[NSWindowStackController _removeSyncedItemAtIndex:] + 156
30  AppKit                              0x000000018ee30440 -[NSWindowStackController _removeSyncedTabBarItem:] + 56
31  AppKit                              0x000000018ee2e480 -[NSWindowStackController removeWindow:sendNotifications:] + 216
32  AppKit                              0x000000018e82bde4 -[NSWindow(NSWindowTabbing_Private) _doTabbedWindowCleanupForOrderOut] + 68
33  AppKit                              0x000000018eec44a4 -[NSWindow _finishClosingWindow] + 188
34  AppKit                              0x000000018e6c966c -[NSWindow _close] + 408
35  Electron Framework                  0x0000000115795848 electron::NativeWindowMac::CloseImmediately() + 100
36  Electron Framework                  0x00000001155ea140 electron::api::BrowserWindow::CloseImmediately() + 312
37  Electron Framework                  0x00000001155e9740 non-virtual thunk to electron::api::BrowserWindow::WebContentsDestroyed() + 76
38  Electron Framework                  0x0000000118f6c640 void content::WebContentsImpl::WebContentsObserverList::NotifyObservers<void (content::WebContentsObserver::*)()>(void (content::WebContentsObserver::*)()) + 612
39  Electron Framework                  0x0000000118f6ba70 content::WebContentsImpl::~WebContentsImpl() + 1344
40  Electron Framework                  0x0000000118f6c7ac content::WebContentsImpl::~WebContentsImpl() + 12
41  Electron Framework                  0x0000000115702d8c electron::InspectableWebContents::~InspectableWebContents() + 396
42  Electron Framework                  0x0000000115702f74 electron::InspectableWebContents::~InspectableWebContents() + 12
43  Electron Framework                  0x000000011565d2a8 electron::api::WebContents::~WebContents() + 424
44  Electron Framework                  0x000000011565d530 electron::api::WebContents::~WebContents() + 12
45  Electron Framework                  0x000000011565d640 electron::api::WebContents::DeleteThisIfAlive() + 96
46  Electron Framework                  0x00000001155eb008 base::internal::Invoker<base::internal::BindState<void (net::(anonymous namespace)::DnsHTTPAttempt::*)(), base::WeakPtr<net::(anonymous namespace)::DnsHTTPAttempt>>, void ()>::RunOnce(base::internal::BindStateBase*) + 92
47  Electron Framework                  0x0000000119a515f8 base::TaskAnnotator::RunTaskImpl(base::PendingTask&) + 308
48  Electron Framework                  0x0000000119a78870 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*) + 1164
49  Electron Framework                  0x0000000119a77ea0 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() + 104
50  Electron Framework                  0x0000000119ae2b14 base::MessagePumpCFRunLoopBase::RunWork() + 104
51  Electron Framework                  0x0000000119ae1bd4 base::mac::CallWithEHFrame(void () block_pointer) + 16
52  Electron Framework                  0x0000000119ae211c base::MessagePumpCFRunLoopBase::RunWorkSource(void*) + 68
53  CoreFoundation                      0x000000018aca7d78 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 28
54  CoreFoundation                      0x000000018aca7d0c __CFRunLoopDoSource0 + 176
55  CoreFoundation                      0x000000018aca7a7c __CFRunLoopDoSources0 + 244
56  CoreFoundation                      0x000000018aca6684 __CFRunLoopRun + 828
57  CoreFoundation                      0x000000018aca5c94 CFRunLoopRunSpecific + 600
58  HIToolbox                           0x0000000195275518 RunCurrentEventLoopInMode + 292
59  HIToolbox                           0x0000000195275354 ReceiveNextEventCommon + 648
60  HIToolbox                           0x00000001952750ac _BlockUntilNextEventMatchingListInModeWithFilter + 76
61  AppKit                              0x000000018e43f2fc _DPSNextEvent + 660
62  AppKit                              0x000000018ebfea20 -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 716
63  AppKit                              0x000000018e432a8c -[NSApplication run] + 476
64  Electron Framework                  0x0000000119ae33b0 base::MessagePumpNSApplication::DoRun(base::MessagePump::Delegate*) + 264
65  Electron Framework                  0x0000000119ae1c74 base::MessagePumpCFRunLoopBase::Run(base::MessagePump::Delegate*) + 144
66  Electron Framework                  0x0000000119a796b0 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) + 452
67  Electron Framework                  0x0000000119a30ec4 base::RunLoop::Run(base::Location const&) + 424
68  Electron Framework                  0x000000011887615c content::BrowserMainLoop::RunMainMessageLoop() + 140
69  Electron Framework                  0x0000000118877e4c content::BrowserMainRunnerImpl::Run() + 44
70  Electron Framework                  0x000000011887364c content::BrowserMain(content::MainFunctionParams) + 160
71  Electron Framework                  0x00000001158f2be4 content::RunBrowserProcessMain(content::MainFunctionParams, content::ContentMainDelegate*) + 208
72  Electron Framework                  0x00000001158f40fc content::ContentMainRunnerImpl::RunBrowser(content::MainFunctionParams, bool) + 600
73  Electron Framework                  0x00000001158f3d10 content::ContentMainRunnerImpl::Run() + 808
74  Electron Framework                  0x00000001158f22bc content::RunContentProcess(content::ContentMainParams, content::ContentMainRunner*) + 1380
75  Electron Framework                  0x00000001158f24d4 content::ContentMain(content::ContentMainParams) + 112
76  Electron Framework                  0x00000001155b2d48 ElectronMain + 128
77  dyld                                0x000000018a851058 start + 2224
```
</details>

In the above repro after closing the active tab `ElectronInspectableWebContentsView` can still receive notifications before its `dealloc` listener could be invoked when the inactive tab gets into focus causing a UAF, we now ensure to remove the notification observer in `~InspectableWebContentsViewMac` which gets destroyed synchronously when `InspectableWebContents::~InspectableWebContents` gets executed.

#### Release Notes

Notes: fix a rare crash when closing active native tab on macOS
