### PR TITLE
build: use aks backed runners for linux builds

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -43,9 +43,8 @@ executors:
         description: "Docker executor size"
         type: enum
         # aks-linux-medium === 8 core (32 core host, shared with other builds)
-        # aks-linux-large === 16 core (32 core host, shared with other builds)
-        # aks-linux-large-dedicated === 32 core
-        enum: ["medium", "electronjs/aks-linux-medium", "electronjs/aks-linux-large", "electronjs/aks-linux-large-dedicated"]
+        # aks-linux-large === 32 core
+        enum: ["medium", "electronjs/aks-linux-medium", "electronjs/aks-linux-large"]
     docker:
       - image: ghcr.io/electron/build:e6bebd08a51a0d78ec23e5b3fd7e7c0846412328
     resource_class: << parameters.size >>
@@ -1701,7 +1700,7 @@ jobs:
   linux-x64-testing:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large-dedicated
+      size: electronjs/aks-linux-large
     environment:
       <<: *env-global
       <<: *env-testing-build
@@ -1718,7 +1717,7 @@ jobs:
   linux-x64-testing-asan:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large-dedicated
+      size: electronjs/aks-linux-large
     environment:
       <<: *env-global
       <<: *env-testing-build
@@ -1747,7 +1746,7 @@ jobs:
   linux-x64-publish:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large-dedicated
+      size: electronjs/aks-linux-large
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-release-build
@@ -1770,7 +1769,7 @@ jobs:
   linux-arm-testing:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large-dedicated
+      size: electronjs/aks-linux-large
     environment:
       <<: *env-global
       <<: *env-arm
@@ -1790,7 +1789,7 @@ jobs:
   linux-arm-publish:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large-dedicated
+      size: electronjs/aks-linux-large
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-arm
@@ -1815,7 +1814,7 @@ jobs:
   linux-arm64-testing:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large-dedicated
+      size: electronjs/aks-linux-large
     environment:
       <<: *env-global
       <<: *env-arm64
@@ -1846,7 +1845,7 @@ jobs:
   linux-arm64-publish:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large-dedicated
+      size: electronjs/aks-linux-large
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-arm64

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -2041,7 +2041,7 @@ jobs:
   linux-x64-testing-tests:
     executor:
       name: linux-docker
-      size: xlarge
+      size: medium
     environment:
       <<: *env-linux-medium
       <<: *env-headless-testing

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -42,9 +42,10 @@ executors:
       size:
         description: "Docker executor size"
         type: enum
-        # aks-linux-large === 16 core (32 core host, shared with another build)
+        # aks-linux-medium === 8 core (32 core host, shared with other builds)
+        # aks-linux-large === 16 core (32 core host, shared with other builds)
         # aks-linux-large-dedicated === 32 core
-        enum: ["medium", "xlarge", "electronjs/aks-linux-large", "electronjs/aks-linux-large-dedicated"]
+        enum: ["medium", "electronjs/aks-linux-medium", "electronjs/aks-linux-large", "electronjs/aks-linux-large-dedicated"]
     docker:
       - image: ghcr.io/electron/build:e6bebd08a51a0d78ec23e5b3fd7e7c0846412328
     resource_class: << parameters.size >>
@@ -1625,7 +1626,7 @@ jobs:
   linux-make-src-cache:
     executor:
       name: linux-docker
-      size: xlarge
+      size: electronjs/aks-linux-medium
     environment:
       <<: *env-linux-2xlarge
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
@@ -1642,7 +1643,7 @@ jobs:
   mac-checkout:
     executor:
       name: linux-docker
-      size: xlarge
+      size: electronjs/aks-linux-medium
     environment:
       <<: *env-linux-2xlarge
       <<: *env-testing-build
@@ -1661,7 +1662,7 @@ jobs:
   mac-make-src-cache-x64:
     executor:
       name: linux-docker
-      size: xlarge
+      size: electronjs/aks-linux-medium
     environment:
       <<: *env-linux-2xlarge
       <<: *env-testing-build
@@ -1680,7 +1681,7 @@ jobs:
   mac-make-src-cache-arm64:
     executor:
       name: linux-docker
-      size: xlarge
+      size: electronjs/aks-linux-medium
     environment:
       <<: *env-linux-2xlarge
       <<: *env-testing-build
@@ -2054,7 +2055,7 @@ jobs:
   linux-x64-testing-asan-tests:
     executor:
       name: linux-docker
-      size: xlarge
+      size: electronjs/aks-linux-medium
     environment:
       <<: *env-linux-medium
       <<: *env-headless-testing
@@ -2081,7 +2082,7 @@ jobs:
   linux-x64-testing-node:
     executor:
       name: linux-docker
-      size: xlarge
+      size: electronjs/aks-linux-medium
     environment:
       <<: *env-linux-medium
       <<: *env-headless-testing

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1715,7 +1715,7 @@ jobs:
   linux-x64-testing-asan:
     executor:
       name: linux-docker
-      size: 2xlarge
+      size: electronjs/aks-linux-large
     environment:
       <<: *env-global
       <<: *env-testing-build
@@ -1767,7 +1767,7 @@ jobs:
   linux-arm-testing:
     executor:
       name: linux-docker
-      size: 2xlarge
+      size: electronjs/aks-linux-large
     environment:
       <<: *env-global
       <<: *env-arm
@@ -1812,7 +1812,7 @@ jobs:
   linux-arm64-testing:
     executor:
       name: linux-docker
-      size: 2xlarge
+      size: electronjs/aks-linux-large
     environment:
       <<: *env-global
       <<: *env-arm64

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -42,7 +42,9 @@ executors:
       size:
         description: "Docker executor size"
         type: enum
-        enum: ["medium", "xlarge", "2xlarge", "electronjs/aks-linux-large"]
+        # aks-linux-large === 16 core (32 core host, shared with another build)
+        # aks-linux-large-dedicated === 32 core
+        enum: ["medium", "xlarge", "electronjs/aks-linux-large", "electronjs/aks-linux-large-dedicated"]
     docker:
       - image: ghcr.io/electron/build:e6bebd08a51a0d78ec23e5b3fd7e7c0846412328
     resource_class: << parameters.size >>
@@ -1744,7 +1746,7 @@ jobs:
   linux-x64-publish:
     executor:
       name: linux-docker
-      size: 2xlarge
+      size: electronjs/aks-linux-large-dedicated
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-release-build
@@ -1787,7 +1789,7 @@ jobs:
   linux-arm-publish:
     executor:
       name: linux-docker
-      size: 2xlarge
+      size: electronjs/aks-linux-large-dedicated
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-arm
@@ -1843,7 +1845,7 @@ jobs:
   linux-arm64-publish:
     executor:
       name: linux-docker
-      size: 2xlarge
+      size: electronjs/aks-linux-large-dedicated
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-arm64

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -42,7 +42,7 @@ executors:
       size:
         description: "Docker executor size"
         type: enum
-        enum: ["medium", "xlarge", "2xlarge"]
+        enum: ["medium", "xlarge", "2xlarge", "electronjs/aks-linux-large"]
     docker:
       - image: ghcr.io/electron/build:e6bebd08a51a0d78ec23e5b3fd7e7c0846412328
     resource_class: << parameters.size >>
@@ -1698,7 +1698,7 @@ jobs:
   linux-x64-testing:
     executor:
       name: linux-docker
-      size: xlarge
+      size: electronjs/aks-linux-large
     environment:
       <<: *env-global
       <<: *env-testing-build

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -44,7 +44,7 @@ executors:
         type: enum
         # aks-linux-medium === 8 core (32 core host, shared with other builds)
         # aks-linux-large === 32 core
-        enum: ["medium", "electronjs/aks-linux-medium", "electronjs/aks-linux-large"]
+        enum: ["medium", "xlarge", "electronjs/aks-linux-medium", "electronjs/aks-linux-large"]
     docker:
       - image: ghcr.io/electron/build:e6bebd08a51a0d78ec23e5b3fd7e7c0846412328
     resource_class: << parameters.size >>
@@ -1625,7 +1625,7 @@ jobs:
   linux-make-src-cache:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-medium
+      size: xlarge
     environment:
       <<: *env-linux-2xlarge
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
@@ -1642,7 +1642,7 @@ jobs:
   mac-checkout:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-medium
+      size: xlarge
     environment:
       <<: *env-linux-2xlarge
       <<: *env-testing-build
@@ -1661,7 +1661,7 @@ jobs:
   mac-make-src-cache-x64:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-medium
+      size: xlarge
     environment:
       <<: *env-linux-2xlarge
       <<: *env-testing-build
@@ -1680,7 +1680,7 @@ jobs:
   mac-make-src-cache-arm64:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-medium
+      size: xlarge
     environment:
       <<: *env-linux-2xlarge
       <<: *env-testing-build
@@ -2041,7 +2041,7 @@ jobs:
   linux-x64-testing-tests:
     executor:
       name: linux-docker
-      size: medium
+      size: xlarge
     environment:
       <<: *env-linux-medium
       <<: *env-headless-testing
@@ -2054,7 +2054,7 @@ jobs:
   linux-x64-testing-asan-tests:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-medium
+      size: xlarge
     environment:
       <<: *env-linux-medium
       <<: *env-headless-testing
@@ -2081,7 +2081,7 @@ jobs:
   linux-x64-testing-node:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-medium
+      size: xlarge
     environment:
       <<: *env-linux-medium
       <<: *env-headless-testing

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1701,7 +1701,7 @@ jobs:
   linux-x64-testing:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large
+      size: electronjs/aks-linux-large-dedicated
     environment:
       <<: *env-global
       <<: *env-testing-build
@@ -1718,7 +1718,7 @@ jobs:
   linux-x64-testing-asan:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large
+      size: electronjs/aks-linux-large-dedicated
     environment:
       <<: *env-global
       <<: *env-testing-build
@@ -1770,7 +1770,7 @@ jobs:
   linux-arm-testing:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large
+      size: electronjs/aks-linux-large-dedicated
     environment:
       <<: *env-global
       <<: *env-arm
@@ -1815,7 +1815,7 @@ jobs:
   linux-arm64-testing:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large
+      size: electronjs/aks-linux-large-dedicated
     environment:
       <<: *env-global
       <<: *env-arm64


### PR DESCRIPTION
This changes nothing about the build environment, only the underlying build infrastructure.  Linux jobs are still run inside the same docker containers but now those docker containers run inside an auto scaling kubernetes cluster.  The plan per #wg-infra is to merge this and monitor for any _perceived_ impact to build times and measure actual impact to CI infra costs.  At any point this change can be reverted if it is causing issues.

Notes: none