### PR TITLE
test: helper to expect deprecation warnings

### DIFF
--- a/spec/lib/deprecate-helpers.ts
+++ b/spec/lib/deprecate-helpers.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+
+export async function expectDeprecationMessages (func: () => any, ...expected: string[]) {
+  const messages: string[] = [];
+
+  const originalWarn = console.warn;
+  console.warn = (message) => {
+    messages.push(message);
+  };
+
+  const warningListener = (error: Error) => {
+    messages.push(error.message);
+  };
+
+  process.on('warning', warningListener);
+
+  try {
+    return await func();
+  } finally {
+    // process.emitWarning seems to need us to wait a tick
+    await new Promise(process.nextTick);
+    console.warn = originalWarn;
+    process.off('warning', warningListener);
+    expect(messages).to.deep.equal(expected);
+  }
+}


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Adds a helper to be used in tests to check for deprecation warnings. Intended to be used in #39343 and #39356. Intended usage:

```diff
     it('can get printer list', async () => {
       const w = new BrowserWindow({ show: false, webPreferences: { sandbox: true } });
       await w.loadURL('about:blank');
-      const printers = w.webContents.getPrinters();
+
+      const printers = await expectDeprecationMessages(
+        () => w.webContents.getPrinters(),
+        'Deprecation Warning: getPrinters() is deprecated. Use the asynchronous and non-blocking version, getPrintersAsync(), instead.'
+      );
       expect(printers).to.be.an('array');
     });
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
