### PR TITLE
chore: update `_api_features` manifest requirements

### DIFF
--- a/shell/common/extensions/api/_api_features.json
+++ b/shell/common/extensions/api/_api_features.json
@@ -4,6 +4,15 @@
     "extension_types": ["extension"],
     "contexts": ["blessed_extension"]
   },
+  "tabs.executeScript": {
+    "max_manifest_version": 2
+  },
+  "tabs.insertCSS": {
+    "max_manifest_version": 2
+  },
+  "tabs.removeCSS": {
+    "max_manifest_version": 2
+  },
   "extension": {
     "channel": "stable",
     "extension_types": ["extension"],
@@ -14,7 +23,8 @@
     "disallow_for_service_workers": true
   },
   "extension.getURL": {
-    "contexts": ["blessed_extension", "unblessed_extension", "content_script"]
+    "contexts": ["blessed_extension", "unblessed_extension", "content_script"],
+    "max_manifest_version": 2
   },
   "i18n": {
     "channel": "stable",

--- a/shell/common/extensions/api/resources_private.idl
+++ b/shell/common/extensions/api/resources_private.idl
@@ -1,4 +1,4 @@
-// Copyright 2015 The Chromium Authors. All rights reserved.
+// Copyright 2015 The Chromium Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -15,9 +15,9 @@ namespace resourcesPrivate {
     // chrome/browser/extensions/api/resources_private/resources_private_api.cc
     // for instructions on adding a new component to this API.
     //
-    // |component| : Internal chrome component to get strings for.
+    // |component| : Internal Chrome component to get strings for.
     // |callback| : Called with a dictionary mapping names to strings.
-    static void getStrings(Component component,
-                           GetStringsCallback callback);
+    [supportsPromises] static void getStrings(Component component,
+                                              GetStringsCallback callback);
   };
 };


### PR DESCRIPTION
#### Description of Change

Updates Electron's copy of `extensions/api/_api_features.json` to match [upstream](https://source.chromium.org/chromium/chromium/src/+/main:chrome/common/extensions/api/_api_features.json) where applicable. Also update `extensions/api/resources_private.idl` to add `[supportsPromises]` for Manifest V3.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
