### PR TITLE
fix: avoid package.json check on built-in modules

### DIFF
--- a/patches/node/fix_do_not_resolve_electron_entrypoints.patch
+++ b/patches/node/fix_do_not_resolve_electron_entrypoints.patch
@@ -6,19 +6,42 @@ Subject: fix: do not resolve electron entrypoints
 This wastes fs cycles and can result in strange behavior if this path actually exists on disk
 
 diff --git a/lib/internal/modules/run_main.js b/lib/internal/modules/run_main.js
-index 5a50d5d6afab6e6648f72a1c0efa1df4cd80bcd9..0be45309028b00a6957ee473322a9452a7fa7d67 100644
+index 5a50d5d6afab6e6648f72a1c0efa1df4cd80bcd9..ebc9999358ccf16689dc02322eb1aeb86355f39b 100644
 --- a/lib/internal/modules/run_main.js
 +++ b/lib/internal/modules/run_main.js
-@@ -13,6 +13,12 @@ const {
+@@ -3,6 +3,7 @@
+ const {
+   ObjectCreate,
+   StringPrototypeEndsWith,
++  StringPrototypeStartsWith,
+ } = primordials;
+ const CJSLoader = require('internal/modules/cjs/loader');
+ const { Module, toRealPath, readPackageScope } = CJSLoader;
+@@ -13,6 +14,13 @@ const {
  } = require('internal/modules/esm/handle_process_exit');
  
  function resolveMainPath(main) {
 +  // For built-in modules used as the main entry point we _never_
 +  // want to waste cycles resolving them to file paths on disk
 +  // that actually might exist
-+  if (typeof main === 'string' && main.startsWith('electron/js2c')) {
++  if (typeof main === 'string' && StringPrototypeStartsWith(main, 'electron/js2c')) {
 +    return main;
 +  }
++
    // Note extension resolution for the main entry point can be deprecated in a
    // future major.
    // Module._findPath is monkey-patchable here.
+@@ -28,6 +36,13 @@ function resolveMainPath(main) {
+ }
+ 
+ function shouldUseESMLoader(mainPath) {
++  // For built-in modules used as the main entry point we _never_
++  // want to waste cycles resolving them to file paths on disk
++  // that actually might exist
++  if (typeof mainPath === 'string' && StringPrototypeStartsWith(mainPath, 'electron/js2c')) {
++    return false;
++  }
++
+   /**
+    * @type {string[]} userLoaders A list of custom loaders registered by the user
+    * (or an empty list when none have been registered).


### PR DESCRIPTION
Follow up to #39247 to avoid another package.json lookup

Notes: no-notes