### PR TITLE
docs: update external links

### DIFF
--- a/docs/api/cookies.md
+++ b/docs/api/cookies.md
@@ -22,7 +22,7 @@ session.defaultSession.cookies.get({})
   })
 
 // Query all cookies associated with a specific url.
-session.defaultSession.cookies.get({ url: 'http://www.github.com' })
+session.defaultSession.cookies.get({ url: 'https://www.github.com' })
   .then((cookies) => {
     console.log(cookies)
   }).catch((error) => {
@@ -31,7 +31,7 @@ session.defaultSession.cookies.get({ url: 'http://www.github.com' })
 
 // Set a cookie with the given cookie data;
 // may overwrite equivalent cookies if they exist.
-const cookie = { url: 'http://www.github.com', name: 'dummy_name', value: 'dummy' }
+const cookie = { url: 'https://www.github.com', name: 'dummy_name', value: 'dummy' }
 session.defaultSession.cookies.set(cookie)
   .then(() => {
     // success

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -13,7 +13,7 @@ property of [`WebContents`](web-contents.md), or from the `session` module.
 const { BrowserWindow } = require('electron')
 
 const win = new BrowserWindow({ width: 800, height: 600 })
-win.loadURL('http://github.com')
+win.loadURL('https://github.com')
 
 const ses = win.webContents.session
 console.log(ses.getUserAgent())

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -13,7 +13,7 @@ the [`BrowserWindow`](browser-window.md) object. An example of accessing the
 const { BrowserWindow } = require('electron')
 
 const win = new BrowserWindow({ width: 800, height: 1500 })
-win.loadURL('http://github.com')
+win.loadURL('https://github.com')
 
 const contents = win.webContents
 console.log(contents)
@@ -895,7 +895,7 @@ const win = new BrowserWindow({ webPreferences: { offscreen: true } })
 win.webContents.on('paint', (event, dirty, image) => {
   // updateBitmap(dirty, image.getBitmap())
 })
-win.loadURL('http://github.com')
+win.loadURL('https://github.com')
 ```
 
 #### Event: 'devtools-reload-page'
@@ -1071,7 +1071,7 @@ Returns `string` - The URL of the current web page.
 ```javascript
 const { BrowserWindow } = require('electron')
 const win = new BrowserWindow({ width: 800, height: 600 })
-win.loadURL('http://github.com').then(() => {
+win.loadURL('https://github.com').then(() => {
   const currentURL = win.webContents.getURL()
   console.log(currentURL)
 })
@@ -1651,7 +1651,7 @@ const path = require('path')
 const os = require('os')
 
 const win = new BrowserWindow()
-win.loadURL('http://github.com')
+win.loadURL('https://github.com')
 
 win.webContents.on('did-finish-load', () => {
   // Use default printing options

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -112,7 +112,7 @@ The `src` attribute can also accept data URLs, such as
 ### `nodeintegration`
 
 ```html
-<webview src="http://www.google.com/" nodeintegration></webview>
+<webview src="https://www.google.com/" nodeintegration></webview>
 ```
 
 A `boolean`. When this attribute is present the guest page in `webview` will have node
@@ -123,7 +123,7 @@ page.
 ### `nodeintegrationinsubframes`
 
 ```html
-<webview src="http://www.google.com/" nodeintegrationinsubframes></webview>
+<webview src="https://www.google.com/" nodeintegrationinsubframes></webview>
 ```
 
 A `boolean` for the experimental option for enabling NodeJS support in sub-frames such as iframes
@@ -161,7 +161,7 @@ after this script has finished executing.
 ### `httpreferrer`
 
 ```html
-<webview src="https://www.github.com/" httpreferrer="http://cheng.guru"></webview>
+<webview src="https://www.github.com/" httpreferrer="https://example.com/"></webview>
 ```
 
 A `string` that sets the referrer URL for the guest page.

--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -23,7 +23,7 @@ store from `.pdb` files.
   SDK, open Visual Studio Installer, select
   `Modify` → `Individual Components`, scroll down and select the appropriate
   Windows SDK to install. Another option would be to look at the
-  [Windows SDK and emulator archive](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive)
+  [Windows SDK and emulator archive](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/)
   and download the standalone version of the SDK respectively.
   * The SDK Debugging Tools must also be installed. If the Windows 10 SDK was installed
   via the Visual Studio installer, then they can be installed by going to:
@@ -32,7 +32,7 @@ store from `.pdb` files.
   Or, you can download the standalone SDK installer and use it to install the Debugging Tools.
 
 If you don't currently have a Windows installation,
-[dev.microsoftedge.com](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/)
+[developer.microsoft.com](https://developer.microsoft.com/en-us/windows/downloads/virtual-machines/)
 has timebombed versions of Windows that you can use to build Electron.
 
 Building Electron is done entirely with command-line scripts and cannot be done

--- a/docs/development/debugging-on-windows.md
+++ b/docs/development/debugging-on-windows.md
@@ -88,7 +88,7 @@ is doing to the operating system, it can be a valuable resource.
 For an introduction to ProcMon's basic and advanced debugging features, go check
 out [this video tutorial][procmon-instructions] provided by Microsoft.
 
-[sys-internals]: https://technet.microsoft.com/en-us/sysinternals/processmonitor.aspx
+[sys-internals]: https://learn.microsoft.com/en-us/sysinternals/downloads/procmon
 [procmon-instructions]: https://learn.microsoft.com/en-us/shows/defrag-tools/4-process-monitor
 
 ## Using WinDbg

--- a/docs/development/issues.md
+++ b/docs/development/issues.md
@@ -24,7 +24,7 @@ contribute:
 
 ## Asking for General Help
 
-[The Electron website](https://electronjs.org/community) has a
+[The Electron website](https://www.electronjs.org/community) has a
 list of resources for getting programming help, reporting security issues,
 contributing, and more. Please use the issue tracker for bugs only!
 

--- a/docs/fiddles/menus/customize-menus/index.html
+++ b/docs/fiddles/menus/customize-menus/index.html
@@ -21,7 +21,7 @@
 
       <p>
         Open the
-        <a href="https://electronjs.org/docs/api/menu"
+        <a href="https://www.electronjs.org/docs/latest/api/menu"
           >full API documentation<span
             >(opens in new window)</span
           ></a
@@ -62,7 +62,7 @@
             <ul>
               <li>
                 <a
-                  href="https://developer.apple.com/macos/human-interface-guidelines/menus/menu-anatomy/"
+                  href="https://developer.apple.com/design/human-interface-guidelines/the-menu-bar"
                   >macOS<span
                     >(opens in new window)</span
                   ></a
@@ -70,7 +70,7 @@
               </li>
               <li>
                 <a
-                  href="https://learn.microsoft.com/en-us/previous-versions/windows/desktop/bb226797"
+                  href="https://learn.microsoft.com/en-us/windows/apps/design/controls/menus-and-context-menus"
                   >Windows<span
                     >(opens in new window)</span
                   ></a
@@ -78,7 +78,7 @@
               </li>
               <li>
                 <a
-                  href="https://developer.gnome.org/hig/stable/menu-bars.html.en"
+                  href="https://developer.gnome.org/hig/patterns/controls/menus.html"
                   >Linux<span
                     >(opens in new window)</span
                   ></a
@@ -111,7 +111,7 @@
           <p>
             See the full
             <a
-              href="https://electronjs.org/docs/api/web-contents/#event-context-menu"
+              href="https://www.electronjs.org/docs/latest/api/web-contents/#event-context-menu"
               >context-menu event documentation</a
             >
             for all the available properties.

--- a/docs/fiddles/menus/shortcuts/index.html
+++ b/docs/fiddles/menus/shortcuts/index.html
@@ -21,10 +21,10 @@
 
 		<p>
 			Open the full documentation for the
-			<a href="https://electronjs.org/docs/api/menu">Menu</a>,
-			<a href="https://electronjs.org/docs/api/accelerator">Accelerator</a>,
+			<a href="https://www.electronjs.org/docs/latest/api/menu">Menu</a>,
+			<a href="https://www.electronjs.org/docs/latest/api/accelerator">Accelerator</a>,
 			and
-			<a href="https://electronjs.org/docs/api/global-shortcut">globalShortcut</a>
+			<a href="https://www.electronjs.org/docs/latest/api/global-shortcut">globalShortcut</a>
 			APIs in your browser.
 		</p>
 
@@ -56,12 +56,12 @@
 
 					<ul>
 						<li><a
-								href="https://developer.apple.com/library/mac/documentation/UserExperience/Conceptual/OSXHIGuidelines/Keyboard.html">macOS</a>
+								href="https://developer.apple.com/design/human-interface-guidelines/keyboards">macOS</a>
 						</li>
 						<li><a
-								href="http://windows.microsoft.com/en-us/windows-10/keyboard-shortcuts">Windows</a></li>
+								href="https://support.microsoft.com/en-us/windows/keyboard-shortcuts-in-windows-dcc61a57-8ff0-cffe-9796-cb9706c75eec">Windows</a></li>
 						<li><a
-								href="https://developer.gnome.org/hig/stable/keyboard-input.html.en">Linux</a></li>
+								href="https://developer.gnome.org/hig/guidelines/keyboard.html">Linux</a></li>
 					</ul>
 				</div>
 

--- a/docs/fiddles/native-ui/dialogs/error-dialog/index.html
+++ b/docs/fiddles/native-ui/dialogs/error-dialog/index.html
@@ -23,7 +23,7 @@
 
       <p>
         Open the
-        <a href="https://electronjs.org/docs/api/dialog/">
+        <a href="https://www.electronjs.org/docs/latest/api/dialog/">
           full API documentation (opens in new window)
           </a>
         in your browser.

--- a/docs/fiddles/native-ui/dialogs/information-dialog/index.html
+++ b/docs/fiddles/native-ui/dialogs/information-dialog/index.html
@@ -23,7 +23,7 @@
 
       <p>
         Open the
-        <a href="https://electronjs.org/docs/api/dialog/">
+        <a href="https://www.electronjs.org/docs/latest/api/dialog/">
           full API documentation (opens in new window)
         </a>
         in your browser.

--- a/docs/fiddles/native-ui/dialogs/open-file-or-directory/index.html
+++ b/docs/fiddles/native-ui/dialogs/open-file-or-directory/index.html
@@ -23,7 +23,7 @@
 
       <p>
         Open the
-        <a href="https://electronjs.org/docs/api/dialog/">
+        <a href="https://www.electronjs.org/docs/latest/api/dialog/">
           full API documentation (opens in new window)
         </a>
         in your browser.

--- a/docs/fiddles/native-ui/dialogs/save-dialog/index.html
+++ b/docs/fiddles/native-ui/dialogs/save-dialog/index.html
@@ -23,7 +23,7 @@
 
       <p>
         Open the
-        <a href="https://electronjs.org/docs/api/dialog/">
+        <a href="https://www.electronjs.org/docs/latest/api/dialog/">
           full API documentation (opens in new window)
         </a>
         in your browser.

--- a/docs/fiddles/native-ui/drag-and-drop/index.html
+++ b/docs/fiddles/native-ui/drag-and-drop/index.html
@@ -16,7 +16,7 @@
 
       <p>
         Open the
-        <a href="https://electronjs.org/docs/tutorial/native-file-drag-drop">
+        <a href="https://www.electronjs.org/docs/latest/tutorial/native-file-drag-drop">
           full API documentation (opens in new window)
         </a>
         in your browser.

--- a/docs/fiddles/native-ui/external-links-file-manager/index.html
+++ b/docs/fiddles/native-ui/external-links-file-manager/index.html
@@ -17,7 +17,7 @@
       <p>This module works in both the main and renderer process.</p>
       <p>
         Open the
-        <a href="https://electronjs.org/docs/api/shell">
+        <a href="https://www.electronjs.org/docs/latest/api/shell">
           full API documentation (opens in new window)
         </a>
         in your browser.

--- a/docs/fiddles/native-ui/notifications/index.html
+++ b/docs/fiddles/native-ui/notifications/index.html
@@ -26,7 +26,7 @@
 
       <p>
         Open the
-        <a href="https://electronjs.org/docs/latest/tutorial/notifications">
+        <a href="https://www.electronjs.org/docs/latest/tutorial/notifications">
           full API documentation<span>(opens in new window)</span>
         </a>
         in your browser.

--- a/docs/fiddles/native-ui/tray/index.html
+++ b/docs/fiddles/native-ui/tray/index.html
@@ -15,7 +15,7 @@
 
       <p>
         Open the
-        <a href="https://electronjs.org/docs/api/tray">
+        <a href="https://www.electronjs.org/docs/latest/api/tray">
           full API documentation
         </a>
         in your browser.
@@ -29,7 +29,7 @@
               On Linux distributions that only have app indicator support, users
               will need to install <code>libappindicator1</code> to make the
               tray icon work. See the
-              <a href="https://electronjs.org/docs/api/tray">
+              <a href="https://www.electronjs.org/docs/latest/api/tray">
                 full API documentation
               </a>
               for more details about using Tray on Linux.

--- a/docs/fiddles/screen/fit-screen/main.js
+++ b/docs/fiddles/screen/fit-screen/main.js
@@ -1,7 +1,7 @@
 // Retrieve information about screen size, displays, cursor position, etc.
 //
 // For more info, see:
-// https://electronjs.org/docs/api/screen
+// https://www.electronjs.org/docs/latest/api/screen
 
 const { app, BrowserWindow } = require('electron')
 

--- a/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/index.html
+++ b/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/index.html
@@ -16,7 +16,7 @@
   <p>These methods allow you to set and unset the protocols your app should be the default app for. Similar to when a
     browser asks to be your default for viewing web pages.</p>
 
-  <p>Open the <a href="https://www.electronjs.org/docs/api/protocol">full protocol API documentation</a> in your
+  <p>Open the <a href="https://www.electronjs.org/docs/latest/api/protocol">full protocol API documentation</a> in your
     browser.</p>
 
   -----

--- a/docs/fiddles/system/system-app-user-information/app-information/index.html
+++ b/docs/fiddles/system/system-app-user-information/app-information/index.html
@@ -14,7 +14,7 @@
           </div>
           <p>The main process <code>app</code> module can be used to get the path at which your app is located on the user's computer.</p>
           <p>In this example, to get that information from the renderer process, we use the <code>ipc</code> module to send a message to the main process requesting the app's path.</p>
-          <p>See the <a id="electron-docs" href="https://electronjs.org/docs/api/app">app module documentation<span class="u-visible-to-screen-reader">(opens in new window)</span></a> for more.</p>
+          <p>See the <a id="electron-docs" href="https://www.electronjs.org/docs/latest/api/app">app module documentation<span class="u-visible-to-screen-reader">(opens in new window)</span></a> for more.</p>
         </div>
       </div>
     </div>

--- a/docs/fiddles/system/system-information/get-version-information/index.html
+++ b/docs/fiddles/system/system-information/get-version-information/index.html
@@ -15,7 +15,7 @@
           </div>
           <p>The <code>process</code> module is built into Node.js (therefore you can use this in both the main and renderer processes) and in Electron apps this object has a few more useful properties on it.</p>
           <p>The example below gets the version of Electron in use by the app.</p>
-          <p>See the <a href="https://electronjs.org/docs/api/process">process documentation <span>(opens in new window)</span></a> for more.</p>
+          <p>See the <a href="https://www.electronjs.org/docs/latest/api/process">process documentation <span>(opens in new window)</span></a> for more.</p>
         </div>
       </div>
     </div>

--- a/docs/fiddles/windows/manage-windows/frameless-window/index.html
+++ b/docs/fiddles/windows/manage-windows/frameless-window/index.html
@@ -22,7 +22,7 @@
 
       <p>
         Open the
-        <a href="https://electronjs.org/docs/api/browser-window">
+        <a href="https://www.electronjs.org/docs/latest/api/browser-window">
           full API documentation (opens in new window)
         </a>
         in your browser.
@@ -59,7 +59,7 @@
 
           <p>
             For more details, see the
-            <a href="https://electronjs.org/docs/tutorial/window-customization/">
+            <a href="https://www.electronjs.org/docs/latest/tutorial/window-customization">
               Window Customization
 
             </a>

--- a/docs/fiddles/windows/manage-windows/manage-window-state/index.html
+++ b/docs/fiddles/windows/manage-windows/manage-window-state/index.html
@@ -22,7 +22,7 @@
 
       <p>
         Open the
-        <a href="https://electronjs.org/docs/api/browser-window">
+        <a href="https://www.electronjs.org/docs/latest/api/browser-window">
           full API documentation (opens in new window)
         </a>
         in your browser.
@@ -47,7 +47,7 @@
             There are a lot of methods for controlling the state of the window
             such as the size, location, and focus status as well as events to
             listen to for window changes. Visit the
-            <a href="https://electronjs.org/docs/api/browser-window">
+            <a href="https://www.electronjs.org/docs/latest/api/browser-window">
               documentation (opens in new window)
             </a>
             for the full list.

--- a/docs/fiddles/windows/manage-windows/new-window/renderer.js
+++ b/docs/fiddles/windows/manage-windows/new-window/renderer.js
@@ -10,5 +10,5 @@ newWindowBtn.addEventListener('click', (event) => {
 
 link.addEventListener('click', (e) => {
   e.preventDefault()
-  shell.openExternal('https://electronjs.org/docs/api/browser-window')
+  shell.openExternal('https://www.electronjs.org/docs/latest/api/browser-window')
 })

--- a/docs/fiddles/windows/manage-windows/window-events/index.html
+++ b/docs/fiddles/windows/manage-windows/window-events/index.html
@@ -22,7 +22,7 @@
 
       <p>
         Open the
-        <a href="https://electronjs.org/docs/api/browser-window">
+        <a href="https://www.electronjs.org/docs/latest/api/browser-window">
           full API documentation (opens in new window)
         </a>
         in your browser.

--- a/docs/tutorial/automated-testing.md
+++ b/docs/tutorial/automated-testing.md
@@ -103,7 +103,7 @@ const driver = new webdriver.Builder()
   })
   .forBrowser('chrome') // note: use .forBrowser('electron') for selenium-webdriver <= 3.6.0
   .build()
-driver.get('http://www.google.com')
+driver.get('https://www.google.com')
 driver.findElement(webdriver.By.name('q')).sendKeys('webdriver')
 driver.findElement(webdriver.By.name('btnG')).click()
 driver.wait(() => {

--- a/docs/tutorial/electron-timelines.md
+++ b/docs/tutorial/electron-timelines.md
@@ -43,7 +43,7 @@ check out our [Electron Versioning](./electron-versioning.md) doc.
 
 **Historical changes:**
 
-* Since Electron 5, Electron has been publicizing its release dates ([see blog post](https://electronjs.org/blog/electron-5-0-timeline)).
+* Since Electron 5, Electron has been publicizing its release dates ([see blog post](https://www.electronjs.org/blog/electron-5-0-timeline)).
 * Since Electron 6, Electron major versions have been targeting every other Chromium major version. Each Electron stable should happen on the same day as Chrome stable ([see blog post](https://www.electronjs.org/blog/12-week-cadence)).
 * Since Electron 16, Electron has been releasing major versions on an 8-week cadence in accordance to Chrome's change to a 4-week release cadence ([see blog post](https://www.electronjs.org/blog/8-week-cadence)).
 

--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -71,6 +71,6 @@ Are you getting stuck anywhere? Here are a few links to places to look:
 [chromium]: https://www.chromium.org/
 [discord]: https://discord.gg/electronjs
 [examples]: examples.md
-[fiddle]: https://electronjs.org/fiddle
+[fiddle]: https://www.electronjs.org/fiddle
 [issue-tracker]: https://github.com/electron/electron/issues
 [node]: https://nodejs.org/

--- a/docs/tutorial/tutorial-6-publishing-updating.md
+++ b/docs/tutorial/tutorial-6-publishing-updating.md
@@ -221,7 +221,7 @@ rest of our docs and happy developing! If you have questions, please stop by our
 [autoupdater]: ../api/auto-updater.md
 [code-signed]: ./code-signing.md
 [discord server]: https://discord.gg/electronjs
-[electron fiddle]: https://electronjs.org/fiddle
+[electron fiddle]: https://www.electronjs.org/fiddle
 [fiddle-build]: https://github.com/electron/fiddle/blob/main/.github/workflows/build.yaml
 [fiddle-forge-config]: https://github.com/electron/fiddle/blob/main/forge.config.js
 [github actions]: https://github.com/features/actions

--- a/docs/tutorial/windows-store-guide.md
+++ b/docs/tutorial/windows-store-guide.md
@@ -148,9 +148,9 @@ You will receive two files: `DesktopAppConverter.zip` and `BaseImage-14316.wim`.
 
 Once installation succeeded, you can move on to compiling your Electron app.
 
-[windows-sdk]: https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk
-[app-converter]: https://docs.microsoft.com/en-us/windows/uwp/porting/desktop-to-uwp-run-desktop-app-converter
-[add-appxpackage]: https://technet.microsoft.com/en-us/library/hh856048.aspx
+[windows-sdk]: https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/
+[app-converter]: https://learn.microsoft.com/en-us/windows/msix/packaging-tool/tool-overview
+[add-appxpackage]: https://learn.microsoft.com/en-us/previous-versions//hh856048(v=technet.10)?redirectedfrom=MSDN
 [electron-packager]: https://github.com/electron/electron-packager
 [electron-windows-store]: https://github.com/electron-userland/electron-windows-store
 [background-task]: https://github.com/felixrieseberg/electron-uwp-background


### PR DESCRIPTION
- Fix outdated links such as `docs.microsoft.com`
- Update the links to the canonical redirected forms
- Replace `http://` with `https://`

Notes: none