### PR TITLE
refactor: update `WebContentsZoomController`

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -494,6 +494,7 @@ filenames = {
     "shell/browser/web_contents_preferences.h",
     "shell/browser/web_contents_zoom_controller.cc",
     "shell/browser/web_contents_zoom_controller.h",
+    "shell/browser/web_contents_zoom_observer.h",
     "shell/browser/web_view_guest_delegate.cc",
     "shell/browser/web_view_guest_delegate.h",
     "shell/browser/web_view_manager.cc",

--- a/shell/browser/extensions/api/tabs/tabs_api.cc
+++ b/shell/browser/extensions/api/tabs/tabs_api.cc
@@ -39,19 +39,19 @@ void ZoomModeToZoomSettings(WebContentsZoomController::ZoomMode zoom_mode,
                             api::tabs::ZoomSettings* zoom_settings) {
   DCHECK(zoom_settings);
   switch (zoom_mode) {
-    case WebContentsZoomController::ZoomMode::kDefault:
+    case WebContentsZoomController::ZOOM_MODE_DEFAULT:
       zoom_settings->mode = api::tabs::ZOOM_SETTINGS_MODE_AUTOMATIC;
       zoom_settings->scope = api::tabs::ZOOM_SETTINGS_SCOPE_PER_ORIGIN;
       break;
-    case WebContentsZoomController::ZoomMode::kIsolated:
+    case WebContentsZoomController::ZOOM_MODE_ISOLATED:
       zoom_settings->mode = api::tabs::ZOOM_SETTINGS_MODE_AUTOMATIC;
       zoom_settings->scope = api::tabs::ZOOM_SETTINGS_SCOPE_PER_TAB;
       break;
-    case WebContentsZoomController::ZoomMode::kManual:
+    case WebContentsZoomController::ZOOM_MODE_MANUAL:
       zoom_settings->mode = api::tabs::ZOOM_SETTINGS_MODE_MANUAL;
       zoom_settings->scope = api::tabs::ZOOM_SETTINGS_SCOPE_PER_TAB;
       break;
-    case WebContentsZoomController::ZoomMode::kDisabled:
+    case WebContentsZoomController::ZOOM_MODE_DISABLED:
       zoom_settings->mode = api::tabs::ZOOM_SETTINGS_MODE_DISABLED;
       zoom_settings->scope = api::tabs::ZOOM_SETTINGS_SCOPE_PER_TAB;
       break;
@@ -329,24 +329,24 @@ ExtensionFunction::ResponseAction TabsSetZoomSettingsFunction::Run() {
   // Determine the correct internal zoom mode to set |web_contents| to from the
   // user-specified |zoom_settings|.
   WebContentsZoomController::ZoomMode zoom_mode =
-      WebContentsZoomController::ZoomMode::kDefault;
+      WebContentsZoomController::ZOOM_MODE_DEFAULT;
   switch (params->zoom_settings.mode) {
     case tabs::ZOOM_SETTINGS_MODE_NONE:
     case tabs::ZOOM_SETTINGS_MODE_AUTOMATIC:
       switch (params->zoom_settings.scope) {
         case tabs::ZOOM_SETTINGS_SCOPE_NONE:
         case tabs::ZOOM_SETTINGS_SCOPE_PER_ORIGIN:
-          zoom_mode = WebContentsZoomController::ZoomMode::kDefault;
+          zoom_mode = WebContentsZoomController::ZOOM_MODE_DEFAULT;
           break;
         case tabs::ZOOM_SETTINGS_SCOPE_PER_TAB:
-          zoom_mode = WebContentsZoomController::ZoomMode::kIsolated;
+          zoom_mode = WebContentsZoomController::ZOOM_MODE_ISOLATED;
       }
       break;
     case tabs::ZOOM_SETTINGS_MODE_MANUAL:
-      zoom_mode = WebContentsZoomController::ZoomMode::kManual;
+      zoom_mode = WebContentsZoomController::ZOOM_MODE_MANUAL;
       break;
     case tabs::ZOOM_SETTINGS_MODE_DISABLED:
-      zoom_mode = WebContentsZoomController::ZoomMode::kDisabled;
+      zoom_mode = WebContentsZoomController::ZOOM_MODE_DISABLED;
   }
 
   contents->GetZoomController()->SetZoomMode(zoom_mode);

--- a/shell/browser/web_contents_zoom_controller.h
+++ b/shell/browser/web_contents_zoom_controller.h
@@ -14,40 +14,49 @@
 
 namespace electron {
 
+class WebContentsZoomObserver;
+
 // Manages the zoom changes of WebContents.
 class WebContentsZoomController
     : public content::WebContentsObserver,
       public content::WebContentsUserData<WebContentsZoomController> {
  public:
-  class Observer : public base::CheckedObserver {
-   public:
-    virtual void OnZoomLevelChanged(content::WebContents* web_contents,
-                                    double level,
-                                    bool is_temporary) {}
-    virtual void OnZoomControllerWebContentsDestroyed() {}
-
-   protected:
-    ~Observer() override {}
-  };
-
   // Defines how zoom changes are handled.
-  enum class ZoomMode {
+  enum ZoomMode {
     // Results in default zoom behavior, i.e. zoom changes are handled
     // automatically and on a per-origin basis, meaning that other tabs
     // navigated to the same origin will also zoom.
-    kDefault,
+    ZOOM_MODE_DEFAULT,
     // Results in zoom changes being handled automatically, but on a per-tab
     // basis. Tabs in this zoom mode will not be affected by zoom changes in
     // other tabs, and vice versa.
-    kIsolated,
+    ZOOM_MODE_ISOLATED,
     // Overrides the automatic handling of zoom changes. The |onZoomChange|
     // event will still be dispatched, but the page will not actually be zoomed.
     // These zoom changes can be handled manually by listening for the
     // |onZoomChange| event. Zooming in this mode is also on a per-tab basis.
-    kManual,
+    ZOOM_MODE_MANUAL,
     // Disables all zooming in this tab. The tab will revert to the default
     // zoom level, and all attempted zoom changes will be ignored.
-    kDisabled,
+    ZOOM_MODE_DISABLED,
+  };
+
+  struct ZoomChangedEventData {
+    ZoomChangedEventData(content::WebContents* web_contents,
+                         double old_zoom_level,
+                         double new_zoom_level,
+                         bool temporary,
+                         WebContentsZoomController::ZoomMode zoom_mode)
+        : web_contents(web_contents),
+          old_zoom_level(old_zoom_level),
+          new_zoom_level(new_zoom_level),
+          temporary(temporary),
+          zoom_mode(zoom_mode) {}
+    raw_ptr<content::WebContents> web_contents;
+    double old_zoom_level;
+    double new_zoom_level;
+    bool temporary;
+    WebContentsZoomController::ZoomMode zoom_mode;
   };
 
   explicit WebContentsZoomController(content::WebContents* web_contents);
@@ -58,23 +67,28 @@ class WebContentsZoomController
   WebContentsZoomController& operator=(const WebContentsZoomController&) =
       delete;
 
-  void AddObserver(Observer* observer);
-  void RemoveObserver(Observer* observer);
+  void AddObserver(WebContentsZoomObserver* observer);
+  void RemoveObserver(WebContentsZoomObserver* observer);
 
   void SetEmbedderZoomController(WebContentsZoomController* controller);
 
-  // Methods for managing zoom levels.
-  void SetZoomLevel(double level);
-  double GetZoomLevel();
+  // Gets the current zoom level by querying HostZoomMap (if not in manual zoom
+  // mode) or from the ZoomController local value otherwise.
+  double GetZoomLevel() const;
+
+  // Sets the zoom level through HostZoomMap.
+  // Returns true on success.
+  bool SetZoomLevel(double zoom_level);
+
   void SetDefaultZoomFactor(double factor);
   double GetDefaultZoomFactor();
+
+  // Sets the temporary zoom level through HostZoomMap.
   void SetTemporaryZoomLevel(double level);
   bool UsesTemporaryZoomLevel();
 
   // Sets the zoom mode, which defines zoom behavior (see enum ZoomMode).
   void SetZoomMode(ZoomMode zoom_mode);
-
-  void ResetZoomModeOnNavigationIfNeeded(const GURL& url);
 
   ZoomMode zoom_mode() const { return zoom_mode_; }
 
@@ -86,8 +100,9 @@ class WebContentsZoomController
   }
 
  protected:
-  // content::WebContentsObserver:
-  void DidFinishNavigation(content::NavigationHandle* handle) override;
+  // content::WebContentsObserver overrides:
+  void DidFinishNavigation(
+      content::NavigationHandle* navigation_handle) override;
   void WebContentsDestroyed() override;
   void RenderFrameHostChanged(content::RenderFrameHost* old_host,
                               content::RenderFrameHost* new_host) override;
@@ -95,28 +110,39 @@ class WebContentsZoomController
  private:
   friend class content::WebContentsUserData<WebContentsZoomController>;
 
-  // Called after a navigation has committed to set default zoom factor.
+  void ResetZoomModeOnNavigationIfNeeded(const GURL& url);
   void SetZoomFactorOnNavigationIfNeeded(const GURL& url);
+  void OnZoomLevelChanged(const content::HostZoomMap::ZoomLevelChange& change);
+
+  // Updates the zoom icon and zoom percentage based on current values and
+  // notifies the observer if changes have occurred. |host| may be empty,
+  // meaning the change should apply to ~all sites. If it is not empty, the
+  // change only affects sites with the given host.
+  void UpdateState(const std::string& host);
 
   // The current zoom mode.
-  ZoomMode zoom_mode_ = ZoomMode::kDefault;
+  ZoomMode zoom_mode_ = ZOOM_MODE_DEFAULT;
 
-  // Current zoom level.
-  double zoom_level_ = 1.0;
+  // The current zoom level.
+  double zoom_level_;
 
-  // kZoomFactor.
-  double default_zoom_factor_ = 0;
-
-  const double kPageZoomEpsilon = 0.001;
+  // The current default zoom factor.
+  double default_zoom_factor_;
 
   int old_process_id_ = -1;
   int old_view_id_ = -1;
 
+  std::unique_ptr<ZoomChangedEventData> event_data_;
+
   raw_ptr<WebContentsZoomController> embedder_zoom_controller_ = nullptr;
 
-  base::ObserverList<Observer> observers_;
+  // Observer receiving notifications on state changes.
+  base::ObserverList<WebContentsZoomObserver> observers_;
 
+  // Keep track of the HostZoomMap we're currently subscribed to.
   raw_ptr<content::HostZoomMap> host_zoom_map_;
+
+  base::CallbackListSubscription zoom_subscription_;
 
   WEB_CONTENTS_USER_DATA_KEY_DECL();
 };

--- a/shell/browser/web_contents_zoom_observer.h
+++ b/shell/browser/web_contents_zoom_observer.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2023 Microsoft, GmbH
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_BROWSER_WEB_CONTENTS_ZOOM_OBSERVER_H_
+#define ELECTRON_SHELL_BROWSER_WEB_CONTENTS_ZOOM_OBSERVER_H_
+
+#include "shell/browser/web_contents_zoom_controller.h"
+
+namespace electron {
+
+// Interface for objects that wish to be notified of changes in
+// WebContentsZoomController.
+class WebContentsZoomObserver : public base::CheckedObserver {
+ public:
+  // Fired when the ZoomController is destructed. Observers should deregister
+  // themselves from the ZoomObserver in this event handler. Note that
+  // ZoomController::FromWebContents() returns nullptr at this point already.
+  virtual void OnZoomControllerDestroyed(
+      WebContentsZoomController* zoom_controller) = 0;
+
+  // Notification that the zoom percentage has changed.
+  virtual void OnZoomChanged(
+      const WebContentsZoomController::ZoomChangedEventData& data) {}
+};
+
+}  // namespace electron
+
+#endif  // ELECTRON_SHELL_BROWSER_WEB_CONTENTS_ZOOM_OBSERVER_H_

--- a/shell/browser/web_view_guest_delegate.cc
+++ b/shell/browser/web_view_guest_delegate.cc
@@ -73,23 +73,23 @@ content::WebContents* WebViewGuestDelegate::GetOwnerWebContents() {
   return embedder_web_contents_;
 }
 
-void WebViewGuestDelegate::OnZoomLevelChanged(
-    content::WebContents* web_contents,
-    double level,
-    bool is_temporary) {
-  if (web_contents == GetOwnerWebContents()) {
-    if (is_temporary) {
-      api_web_contents_->GetZoomController()->SetTemporaryZoomLevel(level);
+void WebViewGuestDelegate::OnZoomChanged(
+    const WebContentsZoomController::ZoomChangedEventData& data) {
+  if (data.web_contents == GetOwnerWebContents()) {
+    if (data.temporary) {
+      api_web_contents_->GetZoomController()->SetTemporaryZoomLevel(
+          data.new_zoom_level);
     } else {
-      api_web_contents_->GetZoomController()->SetZoomLevel(level);
+      api_web_contents_->GetZoomController()->SetZoomLevel(data.new_zoom_level);
     }
     // Change the default zoom factor to match the embedders' new zoom level.
-    double zoom_factor = blink::PageZoomLevelToZoomFactor(level);
+    double zoom_factor = blink::PageZoomLevelToZoomFactor(data.new_zoom_level);
     api_web_contents_->GetZoomController()->SetDefaultZoomFactor(zoom_factor);
   }
 }
 
-void WebViewGuestDelegate::OnZoomControllerWebContentsDestroyed() {
+void WebViewGuestDelegate::OnZoomControllerDestroyed(
+    WebContentsZoomController* zoom_controller) {
   ResetZoomController();
 }
 

--- a/shell/browser/web_view_guest_delegate.h
+++ b/shell/browser/web_view_guest_delegate.h
@@ -10,6 +10,7 @@
 #include "base/memory/raw_ptr.h"
 #include "content/public/browser/browser_plugin_guest_delegate.h"
 #include "shell/browser/web_contents_zoom_controller.h"
+#include "shell/browser/web_contents_zoom_observer.h"
 
 namespace electron {
 
@@ -18,7 +19,7 @@ class WebContents;
 }
 
 class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
-                             public WebContentsZoomController::Observer {
+                             public WebContentsZoomObserver {
  public:
   WebViewGuestDelegate(content::WebContents* embedder,
                        api::WebContents* api_web_contents);
@@ -41,11 +42,11 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
   base::WeakPtr<content::BrowserPluginGuestDelegate> GetGuestDelegateWeakPtr()
       final;
 
-  // WebContentsZoomController::Observer:
-  void OnZoomLevelChanged(content::WebContents* web_contents,
-                          double level,
-                          bool is_temporary) override;
-  void OnZoomControllerWebContentsDestroyed() override;
+  // WebContentsZoomObserver:
+  void OnZoomControllerDestroyed(
+      WebContentsZoomController* zoom_controller) override;
+  void OnZoomChanged(
+      const WebContentsZoomController::ZoomChangedEventData& data) override;
 
  private:
   void ResetZoomController();


### PR DESCRIPTION
#### Description of Change

Refs https://codereview.chromium.org/301733006.
Refs https://github.com/electron/electron/pull/8537

This PR refactors and updates our ZoomController implementation to bring it into line with the current state of [`components/zoom/zoom_controller.cc`](https://source.chromium.org/chromium/chromium/src/+/main:components/zoom/zoom_controller.cc;l=176) upstream. This is being done as a precursor to supporting tab events in `chrome.tabs`, which expect data be sent to observers in struct form and contain both new and old zoom values.

Relevant Changes 
- Pulls `WebContentsZoomObserver` into a standalone file
- Zoom data is now sent to observers as a `ZoomEventChangeData` struct
- Triggers observers through a callback set on `ZoomHostMap`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
