### PR TITLE
fix: macOS tray button selection with VoiceOver

### DIFF
--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -52,7 +52,12 @@
     NSStatusItem* item = [[NSStatusBar systemStatusBar]
         statusItemWithLength:NSVariableStatusItemLength];
     statusItem_.reset([item retain]);
-    [[statusItem_ button] addSubview:self];  // inject custom view
+    [[statusItem_ button] addSubview:self];
+
+    // We need to set the target and action on the button, otherwise
+    // VoiceOver doesn't know where to send the select action.
+    [[statusItem_ button] setTarget:self];
+    [[statusItem_ button] setAction:@selector(mouseDown:)];
     [self updateDimensions];
   }
   return self;
@@ -191,6 +196,25 @@
 }
 
 - (void)mouseDown:(NSEvent*)event {
+  // If |event| does not respond to locationInWindow, we've
+  // arrived here from VoiceOver, which does not pass an event.
+  // Create a synthetic event to pass to the click handler.
+  if (![event respondsToSelector:@selector(locationInWindow)]) {
+    event = [NSEvent mouseEventWithType:NSEventTypeRightMouseDown
+                               location:NSMakePoint(0, 0)
+                          modifierFlags:0
+                              timestamp:NSApp.currentEvent.timestamp
+                           windowNumber:0
+                                context:nil
+                            eventNumber:0
+                             clickCount:1
+                               pressure:1.0];
+
+    // We also need to explicitly call the click handler here, since
+    // VoiceOver won't trigger mouseUp.
+    [self handleClickNotifications:event];
+  }
+
   trayIcon_->NotifyMouseDown(
       gfx::ScreenPointFromNSPoint([event locationInWindow]),
       ui::EventFlagsFromModifiers([event modifierFlags]));


### PR DESCRIPTION
Backport of #39352.

See that PR for details.

Notes: Fixes an accessibility issue where `VoiceOver` couldn't trigger the tray action when selected to emit the click event.