### PR TITLE
docs: correct `powerSaveBlocker.stop(id)` return type

### DIFF
--- a/docs/api/power-save-blocker.md
+++ b/docs/api/power-save-blocker.md
@@ -49,6 +49,8 @@ is used.
 
 Stops the specified power save blocker.
 
+Returns `boolean` - Whether the specified `powerSaveBlocker` has been stopped.
+
 ### `powerSaveBlocker.isStarted(id)`
 
 * `id` Integer - The power save blocker id returned by `powerSaveBlocker.start`.

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -892,7 +892,8 @@ app.whenReady().then(() => {
 const id = powerSaveBlocker.start('prevent-display-sleep')
 console.log(powerSaveBlocker.isStarted(id))
 
-powerSaveBlocker.stop(id)
+const stopped = powerSaveBlocker.stop(id)
+console.log(`The powerSaveBlocker is ${stopped ? 'stopped' : 'not stopped'}`)
 
 // protocol
 // https://github.com/electron/electron/blob/master/docs/api/protocol.md


### PR DESCRIPTION
Backport of #39320.

See that PR for details.

Notes: none