### PR TITLE
fix: deadlock in Clipboard.readImage function.

### DIFF
--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -83,7 +83,7 @@ clipboard.writeHTML('<b>Hi</b>')
 
 * `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
-Returns [`NativeImage`](native-image.md) - The image content in the clipboard.
+Returns `Promise<NativeImage>` - fulfilled with the image content in the clipboard, which is a [NativeImage](native-image.md). Rejected when there is no image data in clipboard or unsupported image format.
 
 ### `clipboard.writeImage(image[, type])`
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -18,13 +18,16 @@ const win = new BrowserWindow({ icon: '/Users/somebody/images/window.png' })
 console.log(appIcon, win)
 ```
 
-Or read the image from the clipboard, which returns a `NativeImage`:
+Or read the image from the clipboard, which returns a `Promise<NativeImage>`:
 
 ```javascript
 const { clipboard, Tray } = require('electron')
-const image = clipboard.readImage()
-const appIcon = new Tray(image)
-console.log(appIcon)
+clipboard.readImage().then(image => {
+  const appIcon = new Tray(image)
+  console.log(appIcon)
+}).catch(error => {
+  console.error(error)
+})
 ```
 
 ## Supported Formats

--- a/shell/common/api/electron_api_clipboard.h
+++ b/shell/common/api/electron_api_clipboard.h
@@ -52,7 +52,7 @@ class Clipboard {
                             const std::string& url,
                             gin_helper::Arguments* args);
 
-  static gfx::Image ReadImage(gin_helper::Arguments* args);
+  static v8::Local<v8::Promise> ReadImage(gin_helper::Arguments* args);
   static void WriteImage(const gfx::Image& image, gin_helper::Arguments* args);
 
   static std::u16string ReadFindText();

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -987,10 +987,12 @@ console.log(clipboard.availableFormats());
 console.log(clipboard.readBookmark().title);
 clipboard.clear();
 
-clipboard.write({
-  html: '<html></html>',
-  text: 'Hello World!',
-  image: clipboard.readImage()
+clipboard.readImage().then(function (result) {
+  clipboard.write({
+    html: '<html></html>',
+    text: 'Hello World!',
+    image: result
+  });
 });
 
 // crash-reporter
@@ -1018,11 +1020,12 @@ appIcon2.destroy();
 const window2 = new BrowserWindow({ icon: '/Users/somebody/images/window.png' });
 console.log(window2.id);
 
-const image = clipboard.readImage();
-console.log(image.getSize());
+clipboard.readImage().then(function (result) {
+  console.log(result.getSize());
 
-const appIcon3 = new Tray(image);
-appIcon3.destroy();
+  const appIcon3 = new Tray(result);
+  appIcon3.destroy();
+});
 
 const appIcon4 = new Tray('/Users/somebody/images/icon.png');
 appIcon4.destroy();

--- a/spec/ts-smoke/electron/renderer.ts
+++ b/spec/ts-smoke/electron/renderer.ts
@@ -53,11 +53,13 @@ console.log(clipboard.readText('selection'));
 console.log(clipboard.availableFormats());
 clipboard.clear();
 
-clipboard.write({
-  html: '<html></html>',
-  text: 'Hello World!',
-  bookmark: 'Bookmark name',
-  image: clipboard.readImage()
+clipboard.readImage().then(function (result) {
+  clipboard.write({
+    html: '<html></html>',
+    text: 'Hello World!',
+    bookmark: 'Bookmark name',
+    image: result
+  });
 });
 
 // crash-reporter
@@ -135,8 +137,9 @@ holder.ondrop = function (e) {
 // nativeImage
 // https://github.com/electron/electron/blob/main/docs/api/native-image.md
 
-const image = clipboard.readImage();
-console.log(image.getSize());
+clipboard.readImage().then(function (result) {
+  console.log(result.getSize());
+});
 
 // https://github.com/electron/electron/blob/main/docs/api/process.md
 


### PR DESCRIPTION
#### Description of Change

There is deadlock in `Clipboard.readImage` on Windows when data in clipboard is bitmap or unsupported format (or no image data in clipboard).
Only solution for this problem is to convert `Clipboard.readImage` function to async function returning `Promise`.

Why we hit deadlock:
When data in clipboard is not PNG image or there is no image data in clipboard then `ClipboardWin::ReadPng` fallback to asynchronously decoding bitmap. In order to get results from async function `Clipboard.readImage` is blocked on main thread. Unfortunately results of decoding bitmap are send to main thread which is still blocked, and we have deadlock.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Resolves deadlock in Clipboard.readImage. <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
