### PR TITLE
ci: automation for issue triage board

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,7 @@ name: Bug Report
 description: Report an Electron bug
 title: "[Bug]: "
 labels: "bug :beetle:"
+projects: ["electron/90"]
 body:
 - type: checkboxes
   attributes:

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -8,7 +8,30 @@ permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 
 jobs:
-  issue-labeled:
+  issue-labeled-blocked:
+    name: blocked/* label added
+    if: startsWith(github.event.label.name, 'blocked/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        env:
+          RELEASE_BOARD_GH_APP_CREDS: ${{ secrets.RELEASE_BOARD_GH_APP_CREDS }}
+        run: |
+          set -eo pipefail
+          TOKEN=$(npx @electron/github-app-auth --creds=$RELEASE_BOARD_GH_APP_CREDS --org electron)
+          echo "TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
+      - name: Set status
+        if: ${{ steps.generate-token.outputs.TOKEN }}
+        uses: github/update-project-action@2d475e08804f11f4022df7e21f5816531e97cb64 # v2
+        with:
+          github_token: ${{ steps.generate-token.outputs.TOKEN }}
+          organization: electron
+          project_number: 90
+          content_id: ${{ github.event.issue.node_id }}
+          field: Status
+          value: 🛑 Blocked
+  issue-labeled-blocked-need-repro:
     name: blocked/need-repro label added
     if: github.event.label.name == 'blocked/need-repro'
     permissions:

--- a/.github/workflows/issue-unlabeled.yml
+++ b/.github/workflows/issue-unlabeled.yml
@@ -1,0 +1,42 @@
+name: Issue Unlabeled
+
+on:
+  issues:
+    types: [unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  issue-unlabeled-blocked:
+    name: All blocked/* labels removed
+    if: startsWith(github.event.label.name, 'blocked/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for any blocked labels
+        id: check-for-blocked-labels
+        run: |
+          set -eo pipefail
+          BLOCKED_LABEL_COUNT=$(echo '${{ toJSON(github.event.issue.labels.*.name) }}' | jq '[ .[] | select(startswith("blocked/")) ] | length')
+          if [[ $BLOCKED_LABEL_COUNT -eq 0 ]]; then
+            echo "NOT_BLOCKED=1" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Generate GitHub App token
+        if: ${{ steps.check-for-blocked-labels.outputs.NOT_BLOCKED }}
+        id: generate-token
+        env:
+          RELEASE_BOARD_GH_APP_CREDS: ${{ secrets.RELEASE_BOARD_GH_APP_CREDS }}
+        run: |
+          set -eo pipefail
+          TOKEN=$(npx @electron/github-app-auth --creds=$RELEASE_BOARD_GH_APP_CREDS --org electron)
+          echo "TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
+      - name: Set status
+        if: ${{ steps.generate-token.outputs.TOKEN }}
+        uses: github/update-project-action@2d475e08804f11f4022df7e21f5816531e97cb64 # v2
+        with:
+          github_token: ${{ steps.generate-token.outputs.TOKEN }}
+          organization: electron
+          project_number: 90
+          content_id: ${{ github.event.issue.node_id }}
+          field: Status
+          value: 📥 Was Blocked


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Automation for an issue triage board:

* Adds new bugs to the board via [the new `projects` field on the issue template](https://github.blog/changelog/2023-08-10-github-issues-projects-august-10th-update/#updates-to-issue-forms)
* Toggles the item blocked status when labels starting with `blocked/` are added or removed from the issue

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
