### PR TITLE
fix: use nested run loop in clipboard.readImage

### DIFF
--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -9,6 +9,7 @@
 #include "base/containers/contains.h"
 #include "base/run_loop.h"
 #include "base/strings/utf_string_conversions.h"
+#include "shell/browser/browser.h"
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
@@ -220,10 +221,18 @@ void Clipboard::WriteBookmark(const std::u16string& title,
 }
 
 gfx::Image Clipboard::ReadImage(gin_helper::Arguments* args) {
+  // The ReadPng uses thread pool which requires app ready.
+  if (IsBrowserProcess() && !Browser::Get()->is_ready()) {
+    args->ThrowError(
+        "clipboard.readImage is available only after app ready in the main "
+        "process");
+    return gfx::Image();
+  }
+
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
   absl::optional<gfx::Image> image;
 
-  base::RunLoop run_loop;
+  base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
   base::RepeatingClosure callback = run_loop.QuitClosure();
   clipboard->ReadPng(
       GetClipboardBuffer(args),

--- a/spec/api-clipboard-spec.ts
+++ b/spec/api-clipboard-spec.ts
@@ -16,6 +16,11 @@ ifdescribe(process.platform !== 'win32' || process.arch !== 'arm64')('clipboard 
       const readImage = clipboard.readImage();
       expect(readImage.toDataURL()).to.equal(i.toDataURL());
     });
+
+    it('works for empty image', () => {
+      clipboard.writeText('Not an Image');
+      expect(clipboard.readImage().isEmpty()).to.be.true();
+    });
   });
 
   describe('clipboard.readText()', () => {


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/39069.
Closes https://github.com/electron/electron/pull/39446.

Must explicitly specify kNestableTasksAllowed to make nested run loop work. 

Note that this is totally valid trick, there are a few examples can be found in Chromium:
https://source.chromium.org/chromium/chromium/src/+/refs/heads/main:components/printing/renderer/print_render_frame_helper.cc;l=2607;drc=b86abfa407f3f35d3e5904e76b9a8d3a741bdc8b
https://source.chromium.org/chromium/chromium/src/+/main:components/ui_devtools/agent_util.cc;l=38;drc=8ba1bad80dc22235693a0dd41fe55c0fd2dbdabd

/cc @codebytere @TomaszMa

#### Release Notes

Notes: Fix `clipboard.readImage()` getting blocked when there is no PNG image in the clipboard.