### PR TITLE
ci: automation for deprecation project board

### DIFF
--- a/.github/workflows/pull-request-labeled.yml
+++ b/.github/workflows/pull-request-labeled.yml
@@ -1,0 +1,33 @@
+name: Pull Request Labeled
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  pull-request-labeled-deprecation-review-complete:
+    name: deprecation-review/complete label added
+    if: github.event.label.name == 'deprecation-review/complete ✅'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        env:
+          RELEASE_BOARD_GH_APP_CREDS: ${{ secrets.RELEASE_BOARD_GH_APP_CREDS }}
+        run: |
+          set -eo pipefail
+          TOKEN=$(npx @electron/github-app-auth --creds=$RELEASE_BOARD_GH_APP_CREDS --org electron)
+          echo "TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
+      - name: Set status
+        if: ${{ steps.generate-token.outputs.TOKEN }}
+        uses: github/update-project-action@2d475e08804f11f4022df7e21f5816531e97cb64 # v2
+        with:
+          github_token: ${{ steps.generate-token.outputs.TOKEN }}
+          organization: electron
+          project_number: 94
+          content_id: ${{ github.event.pull_request.node_id }}
+          field: Status
+          value: ✅ Reviewed


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Adds automation for the deprecation project board in support of https://github.com/electron/cation/pull/144. At the moment that consists solely of setting the project board status of a PR to "✅ Reviewed" when it is labeled with https://github.com/electron/electron/labels/deprecation-review%2Fcomplete%20%E2%9C%85.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
