### PR TITLE
feat: expose dummy module.exports to the sandboxed preload scripts

### DIFF
--- a/lib/sandboxed_renderer/init.ts
+++ b/lib/sandboxed_renderer/init.ts
@@ -120,15 +120,16 @@ require('@electron/internal/renderer/common-init');
 // - `Buffer`: Shim of `Buffer` implementation
 // - `global`: The window object, which is aliased to `global` by webpack.
 function runPreloadScript (preloadSrc: string) {
-  const preloadWrapperSrc = `(function(require, process, Buffer, global, setImmediate, clearImmediate, exports) {
+  const preloadWrapperSrc = `(function(require, process, Buffer, global, setImmediate, clearImmediate, exports, module) {
   ${preloadSrc}
   })`;
 
   // eval in window scope
   const preloadFn = binding.createPreloadScript(preloadWrapperSrc);
   const { setImmediate, clearImmediate } = require('timers');
+  const exports = {};
 
-  preloadFn(preloadRequire, preloadProcess, Buffer, global, setImmediate, clearImmediate, {});
+  preloadFn(preloadRequire, preloadProcess, Buffer, global, setImmediate, clearImmediate, exports, { exports });
 }
 
 for (const { preloadPath, preloadSrc, preloadError } of preloadScripts) {

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -1186,7 +1186,7 @@ describe('chromium features', () => {
       w.webContents.executeJavaScript('window.child = window.open(); child.opener = null');
       const [, { webContents }] = await once(app, 'browser-window-created');
       const [,, message] = await once(webContents, 'console-message');
-      expect(message).to.equal('{"require":"function","module":"undefined","process":"object","Buffer":"function"}');
+      expect(message).to.equal('{"require":"function","module":"object","exports":"object","process":"object","Buffer":"function"}');
     });
 
     it('disables the <webview> tag when it is disabled on the parent window', async () => {

--- a/spec/fixtures/module/preload.js
+++ b/spec/fixtures/module/preload.js
@@ -1,6 +1,7 @@
 const types = {
   require: typeof require,
   module: typeof module,
+  exports: typeof exports,
   process: typeof process,
   Buffer: typeof Buffer
 };


### PR DESCRIPTION
#### Description of Change
Fixes #38161

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: A dummy `module.exports` is now passed to the sandboxed preload scripts to improve compatibility with CommonJS modules.