### PR TITLE
chore: remove obsolete "simple" object annotations for the remote module

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1347,8 +1347,6 @@ std::vector<gin_helper::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
     auto pid_dict = gin_helper::Dictionary::CreateEmpty(isolate);
     auto cpu_dict = gin_helper::Dictionary::CreateEmpty(isolate);
 
-    pid_dict.SetHidden("simple", true);
-    cpu_dict.SetHidden("simple", true);
     cpu_dict.Set(
         "percentCPUUsage",
         process_metric.second->metrics->GetPlatformIndependentCPUUsage() /
@@ -1383,7 +1381,6 @@ std::vector<gin_helper::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
     auto memory_info = process_metric.second->GetMemoryInfo();
 
     auto memory_dict = gin_helper::Dictionary::CreateEmpty(isolate);
-    memory_dict.SetHidden("simple", true);
     memory_dict.Set("workingSetSize",
                     static_cast<double>(memory_info.working_set_size >> 10));
     memory_dict.Set(

--- a/shell/browser/api/electron_api_in_app_purchase.cc
+++ b/shell/browser/api/electron_api_in_app_purchase.cc
@@ -21,7 +21,6 @@ struct Converter<in_app_purchase::PaymentDiscount> {
       v8::Isolate* isolate,
       const in_app_purchase::PaymentDiscount& paymentDiscount) {
     auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-    dict.SetHidden("simple", true);
     dict.Set("identifier", paymentDiscount.identifier);
     dict.Set("keyIdentifier", paymentDiscount.keyIdentifier);
     dict.Set("nonce", paymentDiscount.nonce);
@@ -36,7 +35,6 @@ struct Converter<in_app_purchase::Payment> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const in_app_purchase::Payment& payment) {
     auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-    dict.SetHidden("simple", true);
     dict.Set("productIdentifier", payment.productIdentifier);
     dict.Set("quantity", payment.quantity);
     dict.Set("applicationUsername", payment.applicationUsername);
@@ -52,7 +50,6 @@ struct Converter<in_app_purchase::Transaction> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const in_app_purchase::Transaction& val) {
     auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-    dict.SetHidden("simple", true);
     dict.Set("transactionIdentifier", val.transactionIdentifier);
     dict.Set("transactionDate", val.transactionDate);
     dict.Set("originalTransactionIdentifier",
@@ -72,7 +69,6 @@ struct Converter<in_app_purchase::ProductSubscriptionPeriod> {
       const in_app_purchase::ProductSubscriptionPeriod&
           productSubscriptionPeriod) {
     auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-    dict.SetHidden("simple", true);
     dict.Set("numberOfUnits", productSubscriptionPeriod.numberOfUnits);
     dict.Set("unit", productSubscriptionPeriod.unit);
     return dict.GetHandle();
@@ -85,7 +81,6 @@ struct Converter<in_app_purchase::ProductDiscount> {
       v8::Isolate* isolate,
       const in_app_purchase::ProductDiscount& productDiscount) {
     auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-    dict.SetHidden("simple", true);
     dict.Set("identifier", productDiscount.identifier);
     dict.Set("type", productDiscount.type);
     dict.Set("price", productDiscount.price);
@@ -105,7 +100,6 @@ struct Converter<in_app_purchase::Product> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const in_app_purchase::Product& val) {
     auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-    dict.SetHidden("simple", true);
     dict.Set("productIdentifier", val.productIdentifier);
     dict.Set("localizedDescription", val.localizedDescription);
     dict.Set("localizedTitle", val.localizedTitle);

--- a/shell/browser/api/electron_api_system_preferences.cc
+++ b/shell/browser/api/electron_api_system_preferences.cc
@@ -36,7 +36,6 @@ SystemPreferences::~SystemPreferences() = default;
 v8::Local<v8::Value> SystemPreferences::GetAnimationSettings(
     v8::Isolate* isolate) {
   auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-  dict.SetHidden("simple", true);
   dict.Set("shouldRenderRichAnimation",
            gfx::Animation::ShouldRenderRichAnimation());
   dict.Set("scrollAnimationsEnabledBySystem",

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -140,7 +140,6 @@ v8::Local<v8::Value> ElectronBindings::GetHeapStatistics(v8::Isolate* isolate) {
   isolate->GetHeapStatistics(&v8_heap_stats);
 
   auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-  dict.SetHidden("simple", true);
   dict.Set("totalHeapSize",
            static_cast<double>(v8_heap_stats.total_heap_size() >> 10));
   dict.Set(
@@ -185,7 +184,6 @@ v8::Local<v8::Value> ElectronBindings::GetSystemMemoryInfo(
   }
 
   auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-  dict.SetHidden("simple", true);
   dict.Set("total", mem_info.total);
 
   // See Chromium's "base/process/process_metrics.h" for an explanation.
@@ -236,7 +234,6 @@ v8::Local<v8::Value> ElectronBindings::GetBlinkMemoryInfo(
   auto total = blink::ProcessHeap::TotalAllocatedSpace();
 
   auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-  dict.SetHidden("simple", true);
   dict.Set("allocated", static_cast<double>(allocated >> 10));
   dict.Set("total", static_cast<double>(total >> 10));
   return dict.GetHandle();
@@ -289,7 +286,6 @@ v8::Local<v8::Value> ElectronBindings::GetCPUUsage(
     base::ProcessMetrics* metrics,
     v8::Isolate* isolate) {
   auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-  dict.SetHidden("simple", true);
   int processor_count = base::SysInfo::NumberOfProcessors();
   dict.Set("percentCPUUsage",
            metrics->GetPlatformIndependentCPUUsage() / processor_count);
@@ -310,7 +306,6 @@ v8::Local<v8::Value> ElectronBindings::GetIOCounters(v8::Isolate* isolate) {
   auto metrics = base::ProcessMetrics::CreateCurrentProcessMetrics();
   base::IoCounters io_counters;
   auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-  dict.SetHidden("simple", true);
 
   if (metrics->GetIOCounters(&io_counters)) {
     dict.Set("readOperationCount", io_counters.ReadOperationCount);

--- a/shell/common/gin_converters/gfx_converter.cc
+++ b/shell/common/gin_converters/gfx_converter.cc
@@ -18,7 +18,6 @@ namespace gin {
 v8::Local<v8::Value> Converter<gfx::Point>::ToV8(v8::Isolate* isolate,
                                                  const gfx::Point& val) {
   auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-  dict.SetHidden("simple", true);
   dict.Set("x", val.x());
   dict.Set("y", val.y());
   return dict.GetHandle();
@@ -41,7 +40,6 @@ bool Converter<gfx::Point>::FromV8(v8::Isolate* isolate,
 v8::Local<v8::Value> Converter<gfx::PointF>::ToV8(v8::Isolate* isolate,
                                                   const gfx::PointF& val) {
   auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-  dict.SetHidden("simple", true);
   dict.Set("x", val.x());
   dict.Set("y", val.y());
   return dict.GetHandle();
@@ -63,7 +61,6 @@ bool Converter<gfx::PointF>::FromV8(v8::Isolate* isolate,
 v8::Local<v8::Value> Converter<gfx::Size>::ToV8(v8::Isolate* isolate,
                                                 const gfx::Size& val) {
   auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-  dict.SetHidden("simple", true);
   dict.Set("width", val.width());
   dict.Set("height", val.height());
   return dict.GetHandle();
@@ -85,7 +82,6 @@ bool Converter<gfx::Size>::FromV8(v8::Isolate* isolate,
 v8::Local<v8::Value> Converter<gfx::Rect>::ToV8(v8::Isolate* isolate,
                                                 const gfx::Rect& val) {
   auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-  dict.SetHidden("simple", true);
   dict.Set("x", val.x());
   dict.Set("y", val.y());
   dict.Set("width", val.width());
@@ -142,7 +138,6 @@ v8::Local<v8::Value> Converter<display::Display>::ToV8(
     v8::Isolate* isolate,
     const display::Display& val) {
   auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-  dict.SetHidden("simple", true);
   dict.Set("id", val.id());
   dict.Set("label", val.label());
   dict.Set("bounds", val.bounds());


### PR DESCRIPTION
Notes: none