### PR TITLE
docs: add missing deprecation to webview crashed event

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -983,7 +983,7 @@ ipcRenderer.on('ping', () => {
 })
 ```
 
-### Event: 'crashed'
+### Event: 'crashed' _Deprecated_
 
 Fired when the renderer process is crashed.
 


### PR DESCRIPTION
This event is based on that one, which is also deprecated:
https://github.com/electron/electron/blob/1b3e4dae8dd1a15f8cd71d78c4b89cfcf8ca311f/docs/api/web-contents.md?plain=1#L463

Notes: none