### PR TITLE
test: resolve failing Node.js line number failure

### DIFF
--- a/patches/node/chore_update_fixtures_errors_force_colors_snapshot.patch
+++ b/patches/node/chore_update_fixtures_errors_force_colors_snapshot.patch
@@ -11,7 +11,7 @@ trying to see whether or not the lines are greyed out. One possibility
 would be to upstream a changed test that doesn't hardcode line numbers.
 
 diff --git a/test/fixtures/errors/force_colors.snapshot b/test/fixtures/errors/force_colors.snapshot
-index 0334a0b4faa3633aa8617b9538873e7f3540513b..d8c710e07602b68c9ad4eaaeab2bdf399ed5150b 100644
+index 0334a0b4faa3633aa8617b9538873e7f3540513b..28ba4d18fe5e3caf4d904a055550110fd4faa609 100644
 --- a/test/fixtures/errors/force_colors.snapshot
 +++ b/test/fixtures/errors/force_colors.snapshot
 @@ -4,11 +4,12 @@ throw new Error('Should include grayed stack trace')
@@ -28,7 +28,7 @@ index 0334a0b4faa3633aa8617b9538873e7f3540513b..d8c710e07602b68c9ad4eaaeab2bdf39
 +[90m    at Module.load (node:internal*modules*cjs*loader:1126:32)[39m
 +[90m    at node:internal*modules*cjs*loader:967:12[39m
 +[90m    at Function._load (node:electron*js2c*asar_bundle:756:32)[39m
-+[90m    at Function.executeUserEntryPoint [as runMain] (node:internal*modules*run_main:87:12)[39m
++[90m    at Function.executeUserEntryPoint [as runMain] (node:internal*modules*run_main:96:12)[39m
  [90m    at node:internal*main*run_main_module:23:47[39m
  
  Node.js *


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/39247
Refs https://github.com/electron/electron/pull/39154

#39154 wasn't rebase before merging so the snapshot update conflicts with #39247. This resolves that.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.