### PR TITLE
docs: add missing webview `render-process-gone` event

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -413,18 +413,7 @@ Returns:
 
 * `event` Event
 * `webContents` [WebContents](web-contents.md)
-* `details` Object
-  * `reason` string - The reason the render process is gone.  Possible values:
-    * `clean-exit` - Process exited with an exit code of zero
-    * `abnormal-exit` - Process exited with a non-zero exit code
-    * `killed` - Process was sent a SIGTERM or otherwise killed externally
-    * `crashed` - Process crashed
-    * `oom` - Process ran out of memory
-    * `launch-failed` - Process never successfully launched
-    * `integrity-failure` - Windows code integrity checks failed
-  * `exitCode` Integer - The exit code of the process, unless `reason` is
-    `launch-failed`, in which case `exitCode` will be a platform-specific
-    launch failure error code.
+* `details` [RenderProcessGoneDetails](structures/render-process-gone-details.md)
 
 Emitted when the renderer process unexpectedly disappears.  This is normally
 because it was crashed or killed.

--- a/docs/api/structures/render-process-gone-details.md
+++ b/docs/api/structures/render-process-gone-details.md
@@ -1,0 +1,13 @@
+# RenderProcessGoneDetails Object
+
+* `reason` string - The reason the render process is gone.  Possible values:
+  * `clean-exit` - Process exited with an exit code of zero
+  * `abnormal-exit` - Process exited with a non-zero exit code
+  * `killed` - Process was sent a SIGTERM or otherwise killed externally
+  * `crashed` - Process crashed
+  * `oom` - Process ran out of memory
+  * `launch-failed` - Process never successfully launched
+  * `integrity-failure` - Windows code integrity checks failed
+* `exitCode` Integer - The exit code of the process, unless `reason` is
+  `launch-failed`, in which case `exitCode` will be a platform-specific
+  launch failure error code.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -479,18 +479,7 @@ checking `reason === 'killed'` when you switch to that event.
 Returns:
 
 * `event` Event
-* `details` Object
-  * `reason` string - The reason the render process is gone.  Possible values:
-    * `clean-exit` - Process exited with an exit code of zero
-    * `abnormal-exit` - Process exited with a non-zero exit code
-    * `killed` - Process was sent a SIGTERM or otherwise killed externally
-    * `crashed` - Process crashed
-    * `oom` - Process ran out of memory
-    * `launch-failed` - Process never successfully launched
-    * `integrity-failure` - Windows code integrity checks failed
-  * `exitCode` Integer - The exit code of the process, unless `reason` is
-    `launch-failed`, in which case `exitCode` will be a platform-specific
-    launch failure error code.
+* `details` [RenderProcessGoneDetails](structures/render-process-gone-details.md)
 
 Emitted when the renderer process unexpectedly disappears.  This is normally
 because it was crashed or killed.

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -983,9 +983,22 @@ ipcRenderer.on('ping', () => {
 })
 ```
 
-### Event: 'crashed'
+### Event: 'crashed' _Deprecated_
 
-Fired when the renderer process is crashed.
+Fired when the renderer process crashes or is killed.
+
+**Deprecated:** This event is superceded by the `render-process-gone` event
+which contains more information about why the render process disappeared. It
+isn't always because it crashed.
+
+### Event: 'render-process-gone'
+
+Returns:
+
+* `details` [RenderProcessGoneDetails](structures/render-process-gone-details.md)
+
+Fired when the renderer process unexpectedly disappears. This is normally
+because it was crashed or killed.
 
 ### Event: 'plugin-crashed'
 

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -115,6 +115,7 @@ auto_filenames = {
     "docs/api/structures/protocol-response.md",
     "docs/api/structures/rectangle.md",
     "docs/api/structures/referrer.md",
+    "docs/api/structures/render-process-gone-details.md",
     "docs/api/structures/resolved-endpoint.md",
     "docs/api/structures/resolved-host.md",
     "docs/api/structures/scrubber-item.md",


### PR DESCRIPTION
It should match the `webContents` events, which are used to implement the `webview` ones:
https://github.com/electron/electron/blob/9eeef5546927bc98d2bd8bc8089b998a58ed4e39/docs/api/web-contents.md?plain=1#L463-L496

Except for the `killed` argument, which is not being forwarded:
https://github.com/electron/electron/blob/9eeef5546927bc98d2bd8bc8089b998a58ed4e39/lib/browser/web-view-events.ts#L24-L25

Also adds `structures/render-process-gone-details.md` to eliminate duplicates

Notes: none