### PR TITLE
fix: crash when calling `BrowserWindow.moveTop()` on modal children

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -812,7 +812,7 @@ bool NativeWindowMac::MoveAbove(const std::string& sourceId) {
   if (!webrtc::GetWindowOwnerPid(window_id))
     return false;
 
-  if (!parent()) {
+  if (!parent() || is_modal()) {
     [window_ orderWindow:NSWindowAbove relativeTo:window_id];
   } else {
     NSWindow* other_window = [NSApp windowWithWindowNumber:window_id];
@@ -823,10 +823,11 @@ bool NativeWindowMac::MoveAbove(const std::string& sourceId) {
 }
 
 void NativeWindowMac::MoveTop() {
-  if (!parent())
+  if (!parent() || is_modal()) {
     [window_ orderWindow:NSWindowAbove relativeTo:0];
-  else
+  } else {
     ReorderChildWindowAbove(window_, nullptr);
+  }
 }
 
 void NativeWindowMac::SetResizable(bool resizable) {

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1283,6 +1283,8 @@ describe('BrowserWindow module', () => {
     });
 
     describe('BrowserWindow.moveTop()', () => {
+      afterEach(closeAllWindows);
+
       it('should not steal focus', async () => {
         const posDelta = 50;
         const wShownInactive = once(w, 'show');
@@ -1323,6 +1325,15 @@ describe('BrowserWindow module', () => {
 
         await closeWindow(otherWindow, { assertNotWindows: false });
         expect(BrowserWindow.getAllWindows()).to.have.lengthOf(1);
+      });
+
+      it('should not crash when called on a modal child window', async () => {
+        const shown = once(w, 'show');
+        w.show();
+        await shown;
+
+        const child = new BrowserWindow({ modal: true, parent: w });
+        expect(() => { child.moveTop(); }).to.not.throw();
       });
     });
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/39413.
Follow-up to https://github.com/electron/electron/pull/39034.

We should only reorder child windows when the windows are _not_ sheet windows.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes a potential crash when calling `BrowserWindow.moveTop()` on modal child windows.