### PR TITLE
fix: destruction order of ElectronBrowserMainParts fields

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1324,13 +1324,13 @@ v8::Local<v8::Promise> App::GetFileIcon(const base::FilePath& path,
     icon_size = GetIconSizeByString(icon_size_string);
   }
 
-  auto* icon_manager = ElectronBrowserMainParts::Get()->GetIconManager();
+  auto& icon_manager = ElectronBrowserMainParts::Get()->GetIconManager();
   gfx::Image* icon =
-      icon_manager->LookupIconFromFilepath(normalized_path, icon_size, 1.0f);
+      icon_manager.LookupIconFromFilepath(normalized_path, icon_size, 1.0f);
   if (icon) {
     promise.Resolve(*icon);
   } else {
-    icon_manager->LoadIcon(
+    icon_manager.LoadIcon(
         normalized_path, icon_size, 1.0f,
         base::BindOnce(&OnIconDataAvailable, std::move(promise)),
         &cancelable_task_tracker_);

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -266,9 +266,9 @@ void GetFileIcon(const base::FilePath& path,
   base::FilePath normalized_path = path.NormalizePathSeparators();
   IconLoader::IconSize icon_size = IconLoader::IconSize::LARGE;
 
-  auto* icon_manager = ElectronBrowserMainParts::Get()->GetIconManager();
+  auto& icon_manager = ElectronBrowserMainParts::Get()->GetIconManager();
   gfx::Image* icon =
-      icon_manager->LookupIconFromFilepath(normalized_path, icon_size, 1.0f);
+      icon_manager.LookupIconFromFilepath(normalized_path, icon_size, 1.0f);
   if (icon) {
     gin_helper::Dictionary dict = gin::Dictionary::CreateEmpty(isolate);
     dict.Set("icon", *icon);
@@ -276,10 +276,10 @@ void GetFileIcon(const base::FilePath& path,
     dict.Set("path", normalized_path);
     promise.Resolve(dict);
   } else {
-    icon_manager->LoadIcon(normalized_path, icon_size, 1.0f,
-                           base::BindOnce(&OnIconDataAvailable, normalized_path,
-                                          app_display_name, std::move(promise)),
-                           cancelable_task_tracker_);
+    icon_manager.LoadIcon(normalized_path, icon_size, 1.0f,
+                          base::BindOnce(&OnIconDataAvailable, normalized_path,
+                                         app_display_name, std::move(promise)),
+                          cancelable_task_tracker_);
   }
 }
 

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -201,8 +201,7 @@ class DarkThemeObserver : public ui::NativeThemeObserver {
 // static
 ElectronBrowserMainParts* ElectronBrowserMainParts::self_ = nullptr;
 
-ElectronBrowserMainParts::ElectronBrowserMainParts()
-    : fake_browser_process_(std::make_unique<BrowserProcessImpl>()) {
+ElectronBrowserMainParts::ElectronBrowserMainParts() {
   DCHECK(!self_) << "Cannot have two ElectronBrowserMainParts";
   self_ = this;
 }
@@ -297,7 +296,7 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
                                /* is_preinit = */ false);
 
   // Initialize after user script environment creation.
-  fake_browser_process_->PostEarlyInitialization();
+  fake_browser_process_.PostEarlyInitialization();
 }
 
 int ElectronBrowserMainParts::PreCreateThreads() {
@@ -307,9 +306,9 @@ int ElectronBrowserMainParts::PreCreateThreads() {
 
   // Fetch the system locale for Electron.
 #if BUILDFLAG(IS_MAC)
-  fake_browser_process_->SetSystemLocale(GetCurrentSystemLocale());
+  fake_browser_process_.SetSystemLocale(GetCurrentSystemLocale());
 #else
-  fake_browser_process_->SetSystemLocale(base::i18n::GetConfiguredLocale());
+  fake_browser_process_.SetSystemLocale(base::i18n::GetConfiguredLocale());
 #endif
 
   auto* command_line = base::CommandLine::ForCurrentProcess();
@@ -350,7 +349,7 @@ int ElectronBrowserMainParts::PreCreateThreads() {
   // Initialize the app locale for Electron and Chromium.
   std::string app_locale = l10n_util::GetApplicationLocale(loaded_locale);
   ElectronBrowserClient::SetApplicationLocale(app_locale);
-  fake_browser_process_->SetApplicationLocale(app_locale);
+  fake_browser_process_.SetApplicationLocale(app_locale);
 
 #if BUILDFLAG(IS_LINUX)
   // Reset to the original LC_ALL since we should not be changing it.
@@ -373,7 +372,7 @@ int ElectronBrowserMainParts::PreCreateThreads() {
   Browser::Get()->ApplyForcedRTL();
 #endif
 
-  fake_browser_process_->PreCreateThreads();
+  fake_browser_process_.PreCreateThreads();
 
   // Notify observers.
   Browser::Get()->PreCreateThreads();
@@ -408,7 +407,7 @@ void ElectronBrowserMainParts::PostDestroyThreads() {
   device::BluetoothAdapterFactory::Shutdown();
   bluez::DBusBluezManagerWrapperLinux::Shutdown();
 #endif
-  fake_browser_process_->PostDestroyThreads();
+  fake_browser_process_.PostDestroyThreads();
 }
 
 void ElectronBrowserMainParts::ToolkitInitialized() {
@@ -513,7 +512,7 @@ int ElectronBrowserMainParts::PreMainMessageLoopRun() {
   // Notify observers that main thread message loop was initialized.
   Browser::Get()->PreMainMessageLoopRun();
 
-  fake_browser_process_->PreMainMessageLoopRun();
+  fake_browser_process_.PreMainMessageLoopRun();
 
   return GetExitCode();
 }
@@ -561,7 +560,7 @@ void ElectronBrowserMainParts::PostCreateMainMessageLoop() {
       base::nix::GetDesktopEnvironment(env.get());
   os_crypt::SelectedLinuxBackend selected_backend =
       os_crypt::SelectBackend(config->store, use_backend, desktop_env);
-  fake_browser_process_->SetLinuxStorageBackend(selected_backend);
+  fake_browser_process_.SetLinuxStorageBackend(selected_backend);
   OSCrypt::SetConfig(std::move(config));
 #endif
 #if BUILDFLAG(IS_MAC)
@@ -632,7 +631,7 @@ void ElectronBrowserMainParts::PostMainMessageLoopRun() {
   ElectronBrowserContext::browser_context_map().clear();
   default_context.reset();
 
-  fake_browser_process_->PostMainMessageLoopRun();
+  fake_browser_process_.PostMainMessageLoopRun();
   content::DevToolsAgentHost::StopRemoteDebuggingPipeHandler();
 
 #if BUILDFLAG(IS_LINUX)

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -203,8 +203,7 @@ class DarkThemeObserver : public ui::NativeThemeObserver {
 ElectronBrowserMainParts* ElectronBrowserMainParts::self_ = nullptr;
 
 ElectronBrowserMainParts::ElectronBrowserMainParts()
-    : fake_browser_process_(std::make_unique<BrowserProcessImpl>()),
-      browser_(std::make_unique<Browser>()) {
+    : fake_browser_process_(std::make_unique<BrowserProcessImpl>()) {
   DCHECK(!self_) << "Cannot have two ElectronBrowserMainParts";
   self_ = this;
 }

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -204,9 +204,7 @@ ElectronBrowserMainParts* ElectronBrowserMainParts::self_ = nullptr;
 
 ElectronBrowserMainParts::ElectronBrowserMainParts()
     : fake_browser_process_(std::make_unique<BrowserProcessImpl>()),
-      browser_(std::make_unique<Browser>()),
-      electron_bindings_(
-          std::make_unique<ElectronBindings>(node_bindings_->uv_loop())) {
+      browser_(std::make_unique<Browser>()) {
   DCHECK(!self_) << "Cannot have two ElectronBrowserMainParts";
   self_ = this;
 }
@@ -274,7 +272,7 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
   env->options()->unhandled_rejections = "warn-with-error-code";
 
   // Add Electron extended APIs.
-  electron_bindings_->BindTo(js_env_->isolate(), env->process_object());
+  electron_bindings_.BindTo(js_env_->isolate(), env->process_object());
 
   // Create explicit microtasks runner.
   js_env_->CreateMicrotasksRunner();

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -205,8 +205,6 @@ ElectronBrowserMainParts* ElectronBrowserMainParts::self_ = nullptr;
 ElectronBrowserMainParts::ElectronBrowserMainParts()
     : fake_browser_process_(std::make_unique<BrowserProcessImpl>()),
       browser_(std::make_unique<Browser>()),
-      node_bindings_(
-          NodeBindings::Create(NodeBindings::BrowserEnvironment::kBrowser)),
       electron_bindings_(
           std::make_unique<ElectronBindings>(node_bindings_->uv_loop())) {
   DCHECK(!self_) << "Cannot have two ElectronBrowserMainParts";

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -20,7 +20,6 @@
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/single_thread_task_runner.h"
-#include "chrome/browser/icon_manager.h"
 #include "chrome/browser/ui/color/chrome_color_mixers.h"
 #include "chrome/common/chrome_paths.h"
 #include "chrome/common/chrome_switches.h"
@@ -670,13 +669,6 @@ ElectronBrowserMainParts::GetGeolocationControl() {
         geolocation_control_.BindNewPipeAndPassReceiver());
   }
   return geolocation_control_.get();
-}
-
-IconManager* ElectronBrowserMainParts::GetIconManager() {
-  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
-  if (!icon_manager_.get())
-    icon_manager_ = std::make_unique<IconManager>();
-  return icon_manager_.get();
 }
 
 }  // namespace electron

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -11,6 +11,7 @@
 #include "base/functional/callback.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/timer/timer.h"
+#include "chrome/browser/icon_manager.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_main_parts.h"
 #include "electron/buildflags/buildflags.h"
@@ -24,7 +25,6 @@
 #include "ui/views/layout/layout_provider.h"
 
 class BrowserProcessImpl;
-class IconManager;
 
 namespace base {
 class FieldTrialList;
@@ -88,7 +88,7 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   device::mojom::GeolocationControl* GetGeolocationControl();
 
   // Returns handle to the class responsible for extracting file icons.
-  IconManager* GetIconManager();
+  IconManager& GetIconManager() { return icon_manager_; }
 
   Browser* browser() { return &browser_; }
   BrowserProcessImpl* browser_process() { return fake_browser_process_.get(); }
@@ -163,7 +163,7 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
       NodeBindings::Create(NodeBindings::BrowserEnvironment::kBrowser)};
   ElectronBindings electron_bindings_{node_bindings_->uv_loop()};
   std::unique_ptr<NodeEnvironment> node_env_;
-  std::unique_ptr<IconManager> icon_manager_;
+  IconManager icon_manager_;
   std::unique_ptr<base::FieldTrialList> field_trial_list_;
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -16,6 +16,7 @@
 #include "electron/buildflags/buildflags.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/device/public/mojom/geolocation_control.mojom.h"
+#include "shell/common/api/electron_bindings.h"
 #include "shell/common/node_bindings.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/display/screen.h"
@@ -45,7 +46,6 @@ class LinuxUiGetter;
 namespace electron {
 
 class Browser;
-class ElectronBindings;
 class JavascriptEnvironment;
 class NodeEnvironment;
 
@@ -159,8 +159,9 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
 
   std::unique_ptr<JavascriptEnvironment> js_env_;
   std::unique_ptr<Browser> browser_;
-  const std::unique_ptr<NodeBindings> node_bindings_ { NodeBindings::Create(NodeBindings::BrowserEnvironment::kBrowser) };
-  std::unique_ptr<ElectronBindings> electron_bindings_;
+  const std::unique_ptr<NodeBindings> node_bindings_{
+      NodeBindings::Create(NodeBindings::BrowserEnvironment::kBrowser)};
+  ElectronBindings electron_bindings_{node_bindings_->uv_loop()};
   std::unique_ptr<NodeEnvironment> node_env_;
   std::unique_ptr<IconManager> icon_manager_;
   std::unique_ptr<base::FieldTrialList> field_trial_list_;

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -16,6 +16,7 @@
 #include "electron/buildflags/buildflags.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/device/public/mojom/geolocation_control.mojom.h"
+#include "shell/common/node_bindings.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/display/screen.h"
 #include "ui/views/layout/layout_provider.h"
@@ -46,7 +47,6 @@ namespace electron {
 class Browser;
 class ElectronBindings;
 class JavascriptEnvironment;
-class NodeBindings;
 class NodeEnvironment;
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
@@ -159,7 +159,7 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
 
   std::unique_ptr<JavascriptEnvironment> js_env_;
   std::unique_ptr<Browser> browser_;
-  std::unique_ptr<NodeBindings> node_bindings_;
+  const std::unique_ptr<NodeBindings> node_bindings_ { NodeBindings::Create(NodeBindings::BrowserEnvironment::kBrowser) };
   std::unique_ptr<ElectronBindings> electron_bindings_;
   std::unique_ptr<NodeEnvironment> node_env_;
   std::unique_ptr<IconManager> icon_manager_;

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -18,13 +18,12 @@
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/device/public/mojom/geolocation_control.mojom.h"
 #include "shell/browser/browser.h"
+#include "shell/browser/browser_process_impl.h"
 #include "shell/common/api/electron_bindings.h"
 #include "shell/common/node_bindings.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/display/screen.h"
 #include "ui/views/layout/layout_provider.h"
-
-class BrowserProcessImpl;
 
 namespace base {
 class FieldTrialList;
@@ -91,7 +90,7 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   IconManager& GetIconManager() { return icon_manager_; }
 
   Browser* browser() { return &browser_; }
-  BrowserProcessImpl* browser_process() { return fake_browser_process_.get(); }
+  BrowserProcessImpl* browser_process() { return &fake_browser_process_; }
 
  protected:
   // content::BrowserMainParts:
@@ -151,7 +150,7 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   std::unique_ptr<views::LayoutProvider> layout_provider_;
 
   // A fake BrowserProcess object that used to feed the source code from chrome.
-  std::unique_ptr<BrowserProcessImpl> fake_browser_process_;
+  BrowserProcessImpl fake_browser_process_;
 
   // A place to remember the exit code once the message loop is ready.
   // Before then, we just exit() without any intermediate steps.

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -156,12 +156,12 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   // Before then, we just exit() without any intermediate steps.
   absl::optional<int> exit_code_;
 
-  std::unique_ptr<JavascriptEnvironment> js_env_;
   electron::Browser browser_;
   const std::unique_ptr<NodeBindings> node_bindings_{
       NodeBindings::Create(NodeBindings::BrowserEnvironment::kBrowser)};
   ElectronBindings electron_bindings_{node_bindings_->uv_loop()};
-  std::unique_ptr<NodeEnvironment> node_env_;
+  std::unique_ptr<JavascriptEnvironment> js_env_;  // depends-on: node_bindings_
+  std::unique_ptr<NodeEnvironment> node_env_;      // depends-on: js_env_
   IconManager icon_manager_;
   std::unique_ptr<base::FieldTrialList> field_trial_list_;
 

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -16,6 +16,7 @@
 #include "electron/buildflags/buildflags.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/device/public/mojom/geolocation_control.mojom.h"
+#include "shell/browser/browser.h"
 #include "shell/common/api/electron_bindings.h"
 #include "shell/common/node_bindings.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
@@ -45,7 +46,6 @@ class LinuxUiGetter;
 
 namespace electron {
 
-class Browser;
 class JavascriptEnvironment;
 class NodeEnvironment;
 
@@ -90,7 +90,7 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   // Returns handle to the class responsible for extracting file icons.
   IconManager* GetIconManager();
 
-  Browser* browser() { return browser_.get(); }
+  Browser* browser() { return &browser_; }
   BrowserProcessImpl* browser_process() { return fake_browser_process_.get(); }
 
  protected:
@@ -158,7 +158,7 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   absl::optional<int> exit_code_;
 
   std::unique_ptr<JavascriptEnvironment> js_env_;
-  std::unique_ptr<Browser> browser_;
+  electron::Browser browser_;
   const std::unique_ptr<NodeBindings> node_bindings_{
       NodeBindings::Create(NodeBindings::BrowserEnvironment::kBrowser)};
   ElectronBindings electron_bindings_{node_bindings_->uv_loop()};


### PR DESCRIPTION
#### Description of Change

Minor refactor of `ElectronBrowserMainParts` with two related goals:

1. fix a destruction order bug that caused a dangling pointer
2. make EBMP's fields' lifespans clearer, e.g. prefer to aggregate directly instead of via `unique_ptr<>` or, when indirection is necessary, prefer a `const unique_ptr<>` over a non-const one.

I came across this while working on the `raw_ptr<>` CI failures. The issue is that  `ElectronBrowserMainParts.js_env_` holds a pointer to a field owned by `ElectronBrowserMainParts.node_bindings_`  but due to order of field declaration, the latter is destroyed first & so `js_env_` holds a dangling pointer when it is destroyed.

CC @VerteDinde who showed interest in `raw_ptr<>` in https://github.com/electron/electron/issues/39370, but any review welcome.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none