### PR TITLE
chore: cherry-pick 9 changes from Release-1-M115

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -4,3 +4,6 @@ cherry-pick-ce029c91a662.patch
 cherry-pick-aed05b609629.patch
 translator_limit_the_size_of_private_variables_in_webgl_shaders.patch
 webgl_limit_total_size_of_private_data.patch
+cherry-pick-285c7712c506.patch
+cherry-pick-2bf945775fe6.patch
+cherry-pick-cafe56b591ed.patch

--- a/patches/angle/cherry-pick-285c7712c506.patch
+++ b/patches/angle/cherry-pick-285c7712c506.patch
@@ -1,0 +1,153 @@
+From 285c7712c50654e3d7238b059c4631bc91285514 Mon Sep 17 00:00:00 2001
+From: Shahbaz Youssefi <syoussefi@chromium.org>
+Date: Thu, 13 Jul 2023 15:23:49 -0400
+Subject: [PATCH] M116: Translator: Unconditionally limit variable sizes
+
+... instead of just for WebGL.  This is to avoid hitting driver bugs
+that were prevented with this check for WebGL on a compromised renderer
+that can create non-WebGL contexts.
+
+Bug: chromium:1464682
+Change-Id: I2b1c5a8c51f06225f5f850109d30778d97e574c7
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/4717371
+Reviewed-by: Roman Lavrov <romanl@google.com>
+---
+
+diff --git a/src/compiler/translator/Compiler.cpp b/src/compiler/translator/Compiler.cpp
+index 7b1ac4e..383feeb 100644
+--- a/src/compiler/translator/Compiler.cpp
++++ b/src/compiler/translator/Compiler.cpp
+@@ -397,9 +397,10 @@
+ 
+ bool TCompiler::shouldLimitTypeSizes() const
+ {
+-    // WebGL shaders limit the size of variables' types in shaders,
+-    // including arrays, structs and interface blocks.
+-    return IsWebGLBasedSpec(mShaderSpec);
++    // Prevent unrealistically large variable sizes in shaders.  This works around driver bugs
++    // around int-size limits (such as 2GB).  The limits are generously large enough that no real
++    // shader should ever hit it.
++    return true;
+ }
+ 
+ bool TCompiler::Init(const ShBuiltInResources &resources)
+diff --git a/src/compiler/translator/ValidateTypeSizeLimitations.cpp b/src/compiler/translator/ValidateTypeSizeLimitations.cpp
+index 2a033ad..19a4821 100644
+--- a/src/compiler/translator/ValidateTypeSizeLimitations.cpp
++++ b/src/compiler/translator/ValidateTypeSizeLimitations.cpp
+@@ -23,10 +23,10 @@
+ // Arbitrarily enforce that all types declared with a size in bytes of over 2 GB will cause
+ // compilation failure.
+ //
+-// For local and global variables, the limit is much lower (1MB) as that much memory won't fit in
++// For local and global variables, the limit is much lower (16MB) as that much memory won't fit in
+ // the GPU registers anyway.
+ constexpr size_t kMaxVariableSizeInBytes        = static_cast<size_t>(2) * 1024 * 1024 * 1024;
+-constexpr size_t kMaxPrivateVariableSizeInBytes = static_cast<size_t>(1) * 1024 * 1024;
++constexpr size_t kMaxPrivateVariableSizeInBytes = static_cast<size_t>(16) * 1024 * 1024;
+ 
+ // Traverses intermediate tree to ensure that the shader does not
+ // exceed certain implementation-defined limits on the sizes of types.
+diff --git a/src/compiler/translator/util.cpp b/src/compiler/translator/util.cpp
+index a91f8b0..a866b25 100644
+--- a/src/compiler/translator/util.cpp
++++ b/src/compiler/translator/util.cpp
+@@ -282,6 +282,9 @@
+ 
+             return kBoolGLType[type.getNominalSize() - 1];
+ 
++        case EbtYuvCscStandardEXT:
++            return GL_UNSIGNED_INT;
++
+         case EbtSampler2D:
+             return GL_SAMPLER_2D;
+         case EbtSampler3D:
+diff --git a/src/tests/gl_tests/WebGLCompatibilityTest.cpp b/src/tests/gl_tests/WebGLCompatibilityTest.cpp
+index 9ae56f5..a8d2ce4 100644
+--- a/src/tests/gl_tests/WebGLCompatibilityTest.cpp
++++ b/src/tests/gl_tests/WebGLCompatibilityTest.cpp
+@@ -5284,8 +5284,8 @@
+ 
+     constexpr char kVSArrayTooLarge[] =
+         R"(varying vec4 color;
+-// 1 MB / 32 aligned bytes per mat2 = 32768
+-const int array_size = 32769;
++// 16 MB / 32 aligned bytes per mat2 = 524288
++const int array_size = 524289;
+ void main()
+ {
+     mat2 array[array_size];
+@@ -5297,7 +5297,7 @@
+ 
+     constexpr char kVSArrayMuchTooLarge[] =
+         R"(varying vec4 color;
+-const int array_size = 55600;
++const int array_size = 757000;
+ void main()
+ {
+     mat2 array[array_size];
+@@ -5361,9 +5361,9 @@
+     constexpr char kTooLargeGlobalMemory1[] =
+         R"(precision mediump float;
+ 
+-// 1 MB / 16 bytes per vec4 = 65536
+-vec4 array[32768];
+-vec4 array2[32769];
++// 16 MB / 16 bytes per vec4 = 1048576
++vec4 array[524288];
++vec4 array2[524289];
+ 
+ void main()
+ {
+@@ -5376,9 +5376,9 @@
+     constexpr char kTooLargeGlobalMemory2[] =
+         R"(precision mediump float;
+ 
+-// 1 MB / 16 bytes per vec4 = 65536
+-vec4 array[32767];
+-vec4 array2[32767];
++// 16 MB / 16 bytes per vec4 = 1048576
++vec4 array[524287];
++vec4 array2[524287];
+ vec4 x, y, z;
+ 
+ void main()
+@@ -5392,12 +5392,12 @@
+     constexpr char kTooLargeGlobalAndLocalMemory1[] =
+         R"(precision mediump float;
+ 
+-// 1 MB / 16 bytes per vec4 = 65536
+-vec4 array[32768];
++// 16 MB / 16 bytes per vec4 = 1048576
++vec4 array[524288];
+ 
+ void main()
+ {
+-    vec4 array2[32769];
++    vec4 array2[524289];
+     if (array[0].x + array[1].x == 2.0)
+         gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+     else
+@@ -5408,18 +5408,18 @@
+     constexpr char kTooLargeGlobalAndLocalMemory2[] =
+         R"(precision mediump float;
+ 
+-// 1 MB / 16 bytes per vec4 = 65536
+-vec4 array[32768];
++// 16 MB / 16 bytes per vec4 = 1048576
++vec4 array[524288];
+ 
+ float f()
+ {
+-    vec4 array2[16384];
++    vec4 array2[524288];
+     return array2[0].x;
+ }
+ 
+ float g()
+ {
+-    vec4 array3[16383];
++    vec4 array3[524287];
+     return array3[0].x;
+ }
+ 

--- a/patches/angle/cherry-pick-2bf945775fe6.patch
+++ b/patches/angle/cherry-pick-2bf945775fe6.patch
@@ -1,0 +1,197 @@
+From 2bf945775fe634eb9e420c2263dae6043bbb5ece Mon Sep 17 00:00:00 2001
+From: Shahbaz Youssefi <syoussefi@chromium.org>
+Date: Fri, 14 Jul 2023 12:30:15 -0400
+Subject: [PATCH] M116: Translator: Limit variable sizes vs uint overflow
+
+Bug: chromium:1464680
+Change-Id: Iee41a2da7a7a330e6cc4d6da59a6e9836ee9dd36
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/4717372
+Reviewed-by: Roman Lavrov <romanl@google.com>
+---
+
+diff --git a/src/compiler/translator/ValidateTypeSizeLimitations.cpp b/src/compiler/translator/ValidateTypeSizeLimitations.cpp
+index 19a4821..f0ff9cb 100644
+--- a/src/compiler/translator/ValidateTypeSizeLimitations.cpp
++++ b/src/compiler/translator/ValidateTypeSizeLimitations.cpp
+@@ -7,6 +7,7 @@
+ #include "compiler/translator/ValidateTypeSizeLimitations.h"
+ 
+ #include "angle_gl.h"
++#include "common/mathutil.h"
+ #include "compiler/translator/Diagnostics.h"
+ #include "compiler/translator/Symbol.h"
+ #include "compiler/translator/SymbolTable.h"
+@@ -113,7 +114,8 @@
+ 
+     void validateTotalPrivateVariableSize()
+     {
+-        if (mTotalPrivateVariablesSize > kMaxPrivateVariableSizeInBytes)
++        if (mTotalPrivateVariablesSize.ValueOrDefault(std::numeric_limits<size_t>::max()) >
++            kMaxPrivateVariableSizeInBytes)
+         {
+             mDiagnostics->error(
+                 TSourceLoc{},
+@@ -231,7 +233,7 @@
+     TDiagnostics *mDiagnostics;
+     std::vector<int> mLoopSymbolIds;
+ 
+-    size_t mTotalPrivateVariablesSize;
++    angle::base::CheckedNumeric<size_t> mTotalPrivateVariablesSize;
+ };
+ 
+ }  // namespace
+diff --git a/src/tests/gl_tests/WebGLCompatibilityTest.cpp b/src/tests/gl_tests/WebGLCompatibilityTest.cpp
+index a8d2ce4..542d49f 100644
+--- a/src/tests/gl_tests/WebGLCompatibilityTest.cpp
++++ b/src/tests/gl_tests/WebGLCompatibilityTest.cpp
+@@ -5426,7 +5426,7 @@
+ float h()
+ {
+     vec4 value;
+-    float value2
++    float value2;
+     return value.x + value2;
+ }
+ 
+@@ -5438,6 +5438,131 @@
+         gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+ })";
+ 
++    constexpr char kTooLargeGlobalMemoryOverflow[] =
++        R"(precision mediump float;
++
++// 16 MB / 16 bytes per vec4 = 1048576
++// Create 256 arrays so each is small, but the total overflows a 32-bit number
++vec4 array[1048576], array2[1048576], array3[1048576], array4[1048576], array5[1048576];
++vec4 array6[1048576], array7[1048576], array8[1048576], array9[1048576], array10[1048576];
++vec4 array11[1048576], array12[1048576], array13[1048576], array14[1048576], array15[1048576];
++vec4 array16[1048576], array17[1048576], array18[1048576], array19[1048576], array20[1048576];
++vec4 array21[1048576], array22[1048576], array23[1048576], array24[1048576], array25[1048576];
++vec4 array26[1048576], array27[1048576], array28[1048576], array29[1048576], array30[1048576];
++vec4 array31[1048576], array32[1048576], array33[1048576], array34[1048576], array35[1048576];
++vec4 array36[1048576], array37[1048576], array38[1048576], array39[1048576], array40[1048576];
++vec4 array41[1048576], array42[1048576], array43[1048576], array44[1048576], array45[1048576];
++vec4 array46[1048576], array47[1048576], array48[1048576], array49[1048576], array50[1048576];
++vec4 array51[1048576], array52[1048576], array53[1048576], array54[1048576], array55[1048576];
++vec4 array56[1048576], array57[1048576], array58[1048576], array59[1048576], array60[1048576];
++vec4 array61[1048576], array62[1048576], array63[1048576], array64[1048576], array65[1048576];
++vec4 array66[1048576], array67[1048576], array68[1048576], array69[1048576], array70[1048576];
++vec4 array71[1048576], array72[1048576], array73[1048576], array74[1048576], array75[1048576];
++vec4 array76[1048576], array77[1048576], array78[1048576], array79[1048576], array80[1048576];
++vec4 array81[1048576], array82[1048576], array83[1048576], array84[1048576], array85[1048576];
++vec4 array86[1048576], array87[1048576], array88[1048576], array89[1048576], array90[1048576];
++vec4 array91[1048576], array92[1048576], array93[1048576], array94[1048576], array95[1048576];
++vec4 array96[1048576], array97[1048576], array98[1048576], array99[1048576], array100[1048576];
++vec4 array101[1048576], array102[1048576], array103[1048576], array104[1048576], array105[1048576];
++vec4 array106[1048576], array107[1048576], array108[1048576], array109[1048576], array110[1048576];
++vec4 array111[1048576], array112[1048576], array113[1048576], array114[1048576], array115[1048576];
++vec4 array116[1048576], array117[1048576], array118[1048576], array119[1048576], array120[1048576];
++vec4 array121[1048576], array122[1048576], array123[1048576], array124[1048576], array125[1048576];
++vec4 array126[1048576], array127[1048576], array128[1048576], array129[1048576], array130[1048576];
++vec4 array131[1048576], array132[1048576], array133[1048576], array134[1048576], array135[1048576];
++vec4 array136[1048576], array137[1048576], array138[1048576], array139[1048576], array140[1048576];
++vec4 array141[1048576], array142[1048576], array143[1048576], array144[1048576], array145[1048576];
++vec4 array146[1048576], array147[1048576], array148[1048576], array149[1048576], array150[1048576];
++vec4 array151[1048576], array152[1048576], array153[1048576], array154[1048576], array155[1048576];
++vec4 array156[1048576], array157[1048576], array158[1048576], array159[1048576], array160[1048576];
++vec4 array161[1048576], array162[1048576], array163[1048576], array164[1048576], array165[1048576];
++vec4 array166[1048576], array167[1048576], array168[1048576], array169[1048576], array170[1048576];
++vec4 array171[1048576], array172[1048576], array173[1048576], array174[1048576], array175[1048576];
++vec4 array176[1048576], array177[1048576], array178[1048576], array179[1048576], array180[1048576];
++vec4 array181[1048576], array182[1048576], array183[1048576], array184[1048576], array185[1048576];
++vec4 array186[1048576], array187[1048576], array188[1048576], array189[1048576], array190[1048576];
++vec4 array191[1048576], array192[1048576], array193[1048576], array194[1048576], array195[1048576];
++vec4 array196[1048576], array197[1048576], array198[1048576], array199[1048576], array200[1048576];
++vec4 array201[1048576], array202[1048576], array203[1048576], array204[1048576], array205[1048576];
++vec4 array206[1048576], array207[1048576], array208[1048576], array209[1048576], array210[1048576];
++vec4 array211[1048576], array212[1048576], array213[1048576], array214[1048576], array215[1048576];
++vec4 array216[1048576], array217[1048576], array218[1048576], array219[1048576], array220[1048576];
++vec4 array221[1048576], array222[1048576], array223[1048576], array224[1048576], array225[1048576];
++vec4 array226[1048576], array227[1048576], array228[1048576], array229[1048576], array230[1048576];
++vec4 array231[1048576], array232[1048576], array233[1048576], array234[1048576], array235[1048576];
++vec4 array236[1048576], array237[1048576], array238[1048576], array239[1048576], array240[1048576];
++vec4 array241[1048576], array242[1048576], array243[1048576], array244[1048576], array245[1048576];
++vec4 array246[1048576], array247[1048576], array248[1048576], array249[1048576], array250[1048576];
++vec4 array251[1048576], array252[1048576], array253[1048576], array254[1048576], array255[1048576];
++vec4 array256[1048576];
++
++void main()
++{
++    float f = array[0].x; f += array2[0].x; f += array3[0].x; f += array4[0].x; f += array5[0].x;
++    f += array6[0].x; f += array7[0].x; f += array8[0].x; f += array9[0].x; f += array10[0].x;
++    f += array11[0].x; f += array12[0].x; f += array13[0].x; f += array14[0].x; f += array15[0].x;
++    f += array16[0].x; f += array17[0].x; f += array18[0].x; f += array19[0].x; f += array20[0].x;
++    f += array21[0].x; f += array22[0].x; f += array23[0].x; f += array24[0].x; f += array25[0].x;
++    f += array26[0].x; f += array27[0].x; f += array28[0].x; f += array29[0].x; f += array30[0].x;
++    f += array31[0].x; f += array32[0].x; f += array33[0].x; f += array34[0].x; f += array35[0].x;
++    f += array36[0].x; f += array37[0].x; f += array38[0].x; f += array39[0].x; f += array40[0].x;
++    f += array41[0].x; f += array42[0].x; f += array43[0].x; f += array44[0].x; f += array45[0].x;
++    f += array46[0].x; f += array47[0].x; f += array48[0].x; f += array49[0].x; f += array50[0].x;
++    f += array51[0].x; f += array52[0].x; f += array53[0].x; f += array54[0].x; f += array55[0].x;
++    f += array56[0].x; f += array57[0].x; f += array58[0].x; f += array59[0].x; f += array60[0].x;
++    f += array61[0].x; f += array62[0].x; f += array63[0].x; f += array64[0].x; f += array65[0].x;
++    f += array66[0].x; f += array67[0].x; f += array68[0].x; f += array69[0].x; f += array70[0].x;
++    f += array71[0].x; f += array72[0].x; f += array73[0].x; f += array74[0].x; f += array75[0].x;
++    f += array76[0].x; f += array77[0].x; f += array78[0].x; f += array79[0].x; f += array80[0].x;
++    f += array81[0].x; f += array82[0].x; f += array83[0].x; f += array84[0].x; f += array85[0].x;
++    f += array86[0].x; f += array87[0].x; f += array88[0].x; f += array89[0].x; f += array90[0].x;
++    f += array91[0].x; f += array92[0].x; f += array93[0].x; f += array94[0].x; f += array95[0].x;
++    f += array96[0].x; f += array97[0].x; f += array98[0].x; f += array99[0].x; f += array100[0].x;
++    f += array101[0].x; f += array102[0].x; f += array103[0].x; f += array104[0].x;
++    f += array105[0].x; f += array106[0].x; f += array107[0].x; f += array108[0].x;
++    f += array109[0].x; f += array110[0].x; f += array111[0].x; f += array112[0].x;
++    f += array113[0].x; f += array114[0].x; f += array115[0].x; f += array116[0].x;
++    f += array117[0].x; f += array118[0].x; f += array119[0].x; f += array120[0].x;
++    f += array121[0].x; f += array122[0].x; f += array123[0].x; f += array124[0].x;
++    f += array125[0].x; f += array126[0].x; f += array127[0].x; f += array128[0].x;
++    f += array129[0].x; f += array130[0].x; f += array131[0].x; f += array132[0].x;
++    f += array133[0].x; f += array134[0].x; f += array135[0].x; f += array136[0].x;
++    f += array137[0].x; f += array138[0].x; f += array139[0].x; f += array140[0].x;
++    f += array141[0].x; f += array142[0].x; f += array143[0].x; f += array144[0].x;
++    f += array145[0].x; f += array146[0].x; f += array147[0].x; f += array148[0].x;
++    f += array149[0].x; f += array150[0].x; f += array151[0].x; f += array152[0].x;
++    f += array153[0].x; f += array154[0].x; f += array155[0].x; f += array156[0].x;
++    f += array157[0].x; f += array158[0].x; f += array159[0].x; f += array160[0].x;
++    f += array161[0].x; f += array162[0].x; f += array163[0].x; f += array164[0].x;
++    f += array165[0].x; f += array166[0].x; f += array167[0].x; f += array168[0].x;
++    f += array169[0].x; f += array170[0].x; f += array171[0].x; f += array172[0].x;
++    f += array173[0].x; f += array174[0].x; f += array175[0].x; f += array176[0].x;
++    f += array177[0].x; f += array178[0].x; f += array179[0].x; f += array180[0].x;
++    f += array181[0].x; f += array182[0].x; f += array183[0].x; f += array184[0].x;
++    f += array185[0].x; f += array186[0].x; f += array187[0].x; f += array188[0].x;
++    f += array189[0].x; f += array190[0].x; f += array191[0].x; f += array192[0].x;
++    f += array193[0].x; f += array194[0].x; f += array195[0].x; f += array196[0].x;
++    f += array197[0].x; f += array198[0].x; f += array199[0].x; f += array200[0].x;
++    f += array201[0].x; f += array202[0].x; f += array203[0].x; f += array204[0].x;
++    f += array205[0].x; f += array206[0].x; f += array207[0].x; f += array208[0].x;
++    f += array209[0].x; f += array210[0].x; f += array211[0].x; f += array212[0].x;
++    f += array213[0].x; f += array214[0].x; f += array215[0].x; f += array216[0].x;
++    f += array217[0].x; f += array218[0].x; f += array219[0].x; f += array220[0].x;
++    f += array221[0].x; f += array222[0].x; f += array223[0].x; f += array224[0].x;
++    f += array225[0].x; f += array226[0].x; f += array227[0].x; f += array228[0].x;
++    f += array229[0].x; f += array230[0].x; f += array231[0].x; f += array232[0].x;
++    f += array233[0].x; f += array234[0].x; f += array235[0].x; f += array236[0].x;
++    f += array237[0].x; f += array238[0].x; f += array239[0].x; f += array240[0].x;
++    f += array241[0].x; f += array242[0].x; f += array243[0].x; f += array244[0].x;
++    f += array245[0].x; f += array246[0].x; f += array247[0].x; f += array248[0].x;
++    f += array249[0].x; f += array250[0].x; f += array251[0].x; f += array252[0].x;
++    f += array253[0].x; f += array254[0].x; f += array255[0].x; f += array256[0].x;
++    if (f == 2.0)
++        gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
++    else
++        gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
++})";
++
+     GLuint program = CompileProgram(essl1_shaders::vs::Simple(), kTooLargeGlobalMemory1);
+     EXPECT_EQ(0u, program);
+ 
+@@ -5449,6 +5574,9 @@
+ 
+     program = CompileProgram(essl1_shaders::vs::Simple(), kTooLargeGlobalAndLocalMemory2);
+     EXPECT_EQ(0u, program);
++
++    program = CompileProgram(essl1_shaders::vs::Simple(), kTooLargeGlobalMemoryOverflow);
++    EXPECT_EQ(0u, program);
+ }
+ 
+ // Linking should fail when corresponding vertex/fragment uniform blocks have different precision

--- a/patches/angle/cherry-pick-cafe56b591ed.patch
+++ b/patches/angle/cherry-pick-cafe56b591ed.patch
@@ -1,0 +1,286 @@
+From cafe56b591edb77f041be70b58cac3a61565644a Mon Sep 17 00:00:00 2001
+From: Geoff Lang <geofflang@chromium.org>
+Date: Fri, 23 Jun 2023 14:46:28 -0400
+Subject: [PATCH] M116: GL: Ensure all instanced attributes have a buffer with data
+
+Apple OpenGL drivers sometimes crash when given an instanced draw with
+a buffer that has never been given data.
+
+It's not efficient to check if the attribute is both zero-sized and
+instanced so just ensure that every time a zero-sized buffer is bound
+to an attribute, it gets initialized with some data.
+
+Bug: chromium:1456243
+Change-Id: I66b7c7017843153db2df3bc50010cba765d03c5f
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/4642048
+Commit-Queue: Geoff Lang <geofflang@chromium.org>
+Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
+(cherry picked from commit 4e6124dae892690204f8e5996aeaad14f45e0a97)
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/4727452
+---
+
+diff --git a/include/platform/FeaturesGL_autogen.h b/include/platform/FeaturesGL_autogen.h
+index aa0565c..2f6e094 100644
+--- a/include/platform/FeaturesGL_autogen.h
++++ b/include/platform/FeaturesGL_autogen.h
+@@ -501,6 +501,12 @@
+         "supportsShaderPixelLocalStorageEXT", FeatureCategory::OpenGLFeatures,
+         "Backend GL context supports EXT_shader_pixel_local_storage extension", &members,
+         "http://anglebug.com/7279"};
++
++    FeatureInfo ensureNonEmptyBufferIsBoundForDraw = {
++        "ensureNonEmptyBufferIsBoundForDraw", FeatureCategory::OpenGLFeatures,
++        "Apple OpenGL drivers crash when drawing with a zero-sized buffer bound using a non-zero "
++        "divisor.",
++        &members, "http://crbug.com/1456243"};
+ };
+ 
+ inline FeaturesGL::FeaturesGL()  = default;
+diff --git a/include/platform/gl_features.json b/include/platform/gl_features.json
+index 032f29a..b358cea 100644
+--- a/include/platform/gl_features.json
++++ b/include/platform/gl_features.json
+@@ -699,6 +699,14 @@
+                 "Backend GL context supports EXT_shader_pixel_local_storage extension"
+             ],
+             "issue": "http://anglebug.com/7279"
++        },
++        {
++            "name": "ensure_non_empty_buffer_is_bound_for_draw",
++            "category": "Features",
++            "description": [
++                "Apple OpenGL drivers crash when drawing with a zero-sized buffer bound using a non-zero divisor."
++            ],
++            "issue": "http://crbug.com/1456243"
+         }
+     ]
+ }
+diff --git a/scripts/code_generation_hashes/ANGLE_features.json b/scripts/code_generation_hashes/ANGLE_features.json
+index d4576c2..503001c 100644
+--- a/scripts/code_generation_hashes/ANGLE_features.json
++++ b/scripts/code_generation_hashes/ANGLE_features.json
+@@ -2,7 +2,7 @@
+   "include/platform/FeaturesD3D_autogen.h":
+     "9923fb44d0a6f31948d0c8f46ee1d9e2",
+   "include/platform/FeaturesGL_autogen.h":
+-    "a795a806d71b0e6d1f9e6d95c6e11971",
++    "fef16ab3946346a2a7d5b76bb39471a4",
+   "include/platform/FeaturesMtl_autogen.h":
+     "407426c8874de9295482ace9c94bd812",
+   "include/platform/FeaturesVk_autogen.h":
+@@ -16,13 +16,13 @@
+   "include/platform/gen_features.py":
+     "062989f7a8f3ff3b383f98fc8908dc33",
+   "include/platform/gl_features.json":
+-    "3335055a70e35ebb7bf74c6d7c58897b",
++    "c9aead89696e7fd0c8bfe5c5ca85ca63",
+   "include/platform/mtl_features.json":
+     "c66d170e7a8eb3448030f4c423ed0133",
+   "include/platform/vk_features.json":
+     "416bbb28b9fa1a3c4ef141f243c0a9e6",
+   "util/angle_features_autogen.cpp":
+-    "73169f63c755192c3b4bd27d6f4096ca",
++    "288daaec490eb816883d744f108d74c9",
+   "util/angle_features_autogen.h":
+-    "7aa8120eb8f8fd335946b8c27074745d"
++    "daf25d3e4ffea143d1c082416513f7e7"
+ }
+\ No newline at end of file
+diff --git a/src/libANGLE/renderer/gl/BufferGL.cpp b/src/libANGLE/renderer/gl/BufferGL.cpp
+index c99fd5d..9651838 100644
+--- a/src/libANGLE/renderer/gl/BufferGL.cpp
++++ b/src/libANGLE/renderer/gl/BufferGL.cpp
+@@ -296,6 +296,11 @@
+     return angle::Result::Continue;
+ }
+ 
++size_t BufferGL::getBufferSize() const
++{
++    return mBufferSize;
++}
++
+ GLuint BufferGL::getBufferID() const
+ {
+     return mBufferID;
+diff --git a/src/libANGLE/renderer/gl/BufferGL.h b/src/libANGLE/renderer/gl/BufferGL.h
+index 7b57594..fe9138e 100644
+--- a/src/libANGLE/renderer/gl/BufferGL.h
++++ b/src/libANGLE/renderer/gl/BufferGL.h
+@@ -56,6 +56,7 @@
+                                 bool primitiveRestartEnabled,
+                                 gl::IndexRange *outRange) override;
+ 
++    size_t getBufferSize() const;
+     GLuint getBufferID() const;
+ 
+   private:
+diff --git a/src/libANGLE/renderer/gl/VertexArrayGL.cpp b/src/libANGLE/renderer/gl/VertexArrayGL.cpp
+index dc981de..fda9099 100644
+--- a/src/libANGLE/renderer/gl/VertexArrayGL.cpp
++++ b/src/libANGLE/renderer/gl/VertexArrayGL.cpp
+@@ -646,6 +646,7 @@
+ 
+ angle::Result VertexArrayGL::updateAttribPointer(const gl::Context *context, size_t attribIndex)
+ {
++    const angle::FeaturesGL &features = GetFeaturesGL(context);
+ 
+     const VertexAttribute &attrib = mState.getVertexAttribute(attribIndex);
+ 
+@@ -687,8 +688,16 @@
+     // is not NULL.
+ 
+     StateManagerGL *stateManager = GetStateManagerGL(context);
+-    GLuint bufferId              = GetNativeBufferID(arrayBuffer);
++    BufferGL *bufferGL           = GetImplAs<BufferGL>(arrayBuffer);
++    GLuint bufferId              = bufferGL->getBufferID();
+     stateManager->bindBuffer(gl::BufferBinding::Array, bufferId);
++    if (features.ensureNonEmptyBufferIsBoundForDraw.enabled && bufferGL->getBufferSize() == 0)
++    {
++        constexpr uint32_t data = 0;
++        ANGLE_TRY(bufferGL->setData(context, gl::BufferBinding::Array, &data, sizeof(data),
++                                    gl::BufferUsage::StaticDraw));
++        ASSERT(bufferGL->getBufferSize() > 0);
++    }
+     ANGLE_TRY(callVertexAttribPointer(context, static_cast<GLuint>(attribIndex), attrib,
+                                       binding.getStride(), binding.getOffset()));
+ 
+diff --git a/src/libANGLE/renderer/gl/renderergl_utils.cpp b/src/libANGLE/renderer/gl/renderergl_utils.cpp
+index 6911247..ab2a608 100644
+--- a/src/libANGLE/renderer/gl/renderergl_utils.cpp
++++ b/src/libANGLE/renderer/gl/renderergl_utils.cpp
+@@ -2465,6 +2465,9 @@
+     // EXT_shader_pixel_local_storage
+     ANGLE_FEATURE_CONDITION(features, supportsShaderPixelLocalStorageEXT,
+                             functions->hasGLESExtension("GL_EXT_shader_pixel_local_storage"));
++
++    // http://crbug.com/1456243
++    ANGLE_FEATURE_CONDITION(features, ensureNonEmptyBufferIsBoundForDraw, IsApple() || IsAndroid());
+ }
+ 
+ void InitializeFrontendFeatures(const FunctionsGL *functions, angle::FrontendFeatures *features)
+diff --git a/src/tests/angle_end2end_tests_expectations.txt b/src/tests/angle_end2end_tests_expectations.txt
+index 59ec7c2..44ff3e4 100644
+--- a/src/tests/angle_end2end_tests_expectations.txt
++++ b/src/tests/angle_end2end_tests_expectations.txt
+@@ -380,6 +380,7 @@
+ 7294 WIN D3D11 : StateChangeTestES3.StencilWriteMask/* = SKIP
+ 7316 WIN D3D11 : StateChangeTestES3.StencilTestAndFunc/* = SKIP
+ 7329 WIN D3D11 : StateChangeTestES3.PrimitiveRestart/* = SKIP
++1456243 WIN D3D11 : WebGL2CompatibilityTest.DrawWithZeroSizedBuffer/* = SKIP
+ 
+ // Android
+ 6095 ANDROID GLES : GLSLTest_ES3.InitGlobalComplexConstant/* = SKIP
+diff --git a/src/tests/gl_tests/WebGLCompatibilityTest.cpp b/src/tests/gl_tests/WebGLCompatibilityTest.cpp
+index 7dc56cd..bd7ecd1 100644
+--- a/src/tests/gl_tests/WebGLCompatibilityTest.cpp
++++ b/src/tests/gl_tests/WebGLCompatibilityTest.cpp
+@@ -1632,10 +1632,10 @@
+ 
+     constexpr GLuint kMaxIntAsGLuint = static_cast<GLuint>(std::numeric_limits<GLint>::max());
+     constexpr GLuint kIndexData[]    = {
+-           kMaxIntAsGLuint,
+-           kMaxIntAsGLuint + 1,
+-           kMaxIntAsGLuint + 2,
+-           kMaxIntAsGLuint + 3,
++        kMaxIntAsGLuint,
++        kMaxIntAsGLuint + 1,
++        kMaxIntAsGLuint + 2,
++        kMaxIntAsGLuint + 3,
+     };
+ 
+     GLBuffer indexBuffer;
+@@ -3687,8 +3687,8 @@
+ 
+     constexpr float readPixelsData[] = {-5000.0f, 0.0f, 0.0f, 1.0f};
+     const GLushort textureData[]     = {
+-            gl::float32ToFloat16(readPixelsData[0]), gl::float32ToFloat16(readPixelsData[1]),
+-            gl::float32ToFloat16(readPixelsData[2]), gl::float32ToFloat16(readPixelsData[3])};
++        gl::float32ToFloat16(readPixelsData[0]), gl::float32ToFloat16(readPixelsData[1]),
++        gl::float32ToFloat16(readPixelsData[2]), gl::float32ToFloat16(readPixelsData[3])};
+ 
+     for (auto extension : FloatingPointTextureExtensions)
+     {
+@@ -3748,8 +3748,8 @@
+ 
+     constexpr float readPixelsData[] = {7108.0f, -10.0f, 0.0f, 1.0f};
+     const GLushort textureData[]     = {
+-            gl::float32ToFloat16(readPixelsData[0]), gl::float32ToFloat16(readPixelsData[1]),
+-            gl::float32ToFloat16(readPixelsData[2]), gl::float32ToFloat16(readPixelsData[3])};
++        gl::float32ToFloat16(readPixelsData[0]), gl::float32ToFloat16(readPixelsData[1]),
++        gl::float32ToFloat16(readPixelsData[2]), gl::float32ToFloat16(readPixelsData[3])};
+ 
+     for (auto extension : FloatingPointTextureExtensions)
+     {
+@@ -3811,8 +3811,8 @@
+ 
+     constexpr float readPixelsData[] = {7000.0f, 100.0f, 33.0f, 1.0f};
+     const GLushort textureData[]     = {
+-            gl::float32ToFloat16(readPixelsData[0]), gl::float32ToFloat16(readPixelsData[1]),
+-            gl::float32ToFloat16(readPixelsData[2]), gl::float32ToFloat16(readPixelsData[3])};
++        gl::float32ToFloat16(readPixelsData[0]), gl::float32ToFloat16(readPixelsData[1]),
++        gl::float32ToFloat16(readPixelsData[2]), gl::float32ToFloat16(readPixelsData[3])};
+ 
+     for (auto extension : FloatingPointTextureExtensions)
+     {
+@@ -3874,8 +3874,8 @@
+ 
+     constexpr float readPixelsData[] = {7000.0f, 100.0f, 33.0f, -1.0f};
+     const GLushort textureData[]     = {
+-            gl::float32ToFloat16(readPixelsData[0]), gl::float32ToFloat16(readPixelsData[1]),
+-            gl::float32ToFloat16(readPixelsData[2]), gl::float32ToFloat16(readPixelsData[3])};
++        gl::float32ToFloat16(readPixelsData[0]), gl::float32ToFloat16(readPixelsData[1]),
++        gl::float32ToFloat16(readPixelsData[2]), gl::float32ToFloat16(readPixelsData[3])};
+ 
+     for (auto extension : FloatingPointTextureExtensions)
+     {
+@@ -5803,6 +5803,26 @@
+     }
+ }
+ 
++// Test for a mishandling of instanced vertex attributes with zero-sized buffers bound on Apple
++// OpenGL drivers.
++TEST_P(WebGL2CompatibilityTest, DrawWithZeroSizedBuffer)
++{
++    ANGLE_GL_PROGRAM(program, essl3_shaders::vs::Simple(), essl3_shaders::fs::Red());
++    glUseProgram(program);
++
++    GLBuffer buffer;
++    glBindBuffer(GL_ARRAY_BUFFER, buffer);
++
++    GLint posLocation = glGetAttribLocation(program, essl3_shaders::PositionAttrib());
++    glEnableVertexAttribArray(posLocation);
++
++    glVertexAttribDivisor(posLocation, 1);
++    glVertexAttribPointer(posLocation, 1, GL_UNSIGNED_BYTE, GL_FALSE, 9,
++                          reinterpret_cast<void *>(0x41424344));
++
++    glDrawArrays(GL_TRIANGLES, 0, 6);
++}
++
+ ANGLE_INSTANTIATE_TEST_ES2_AND_ES3(WebGLCompatibilityTest);
+ 
+ GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(WebGL2CompatibilityTest);
+diff --git a/util/angle_features_autogen.cpp b/util/angle_features_autogen.cpp
+index adb9610..a060dd2 100644
+--- a/util/angle_features_autogen.cpp
++++ b/util/angle_features_autogen.cpp
+@@ -118,6 +118,7 @@
+     {Feature::EnablePrecisionQualifiers, "enablePrecisionQualifiers"},
+     {Feature::EnablePreRotateSurfaces, "enablePreRotateSurfaces"},
+     {Feature::EnableProgramBinaryForCapture, "enableProgramBinaryForCapture"},
++    {Feature::EnsureNonEmptyBufferIsBoundForDraw, "ensureNonEmptyBufferIsBoundForDraw"},
+     {Feature::ExpandIntegerPowExpressions, "expandIntegerPowExpressions"},
+     {Feature::ExplicitlyEnablePerSampleShading, "explicitlyEnablePerSampleShading"},
+     {Feature::ExposeNonConformantExtensionsAndVersions, "exposeNonConformantExtensionsAndVersions"},
+diff --git a/util/angle_features_autogen.h b/util/angle_features_autogen.h
+index 3d8c47f..4064425 100644
+--- a/util/angle_features_autogen.h
++++ b/util/angle_features_autogen.h
+@@ -112,6 +112,7 @@
+     EnablePrecisionQualifiers,
+     EnablePreRotateSurfaces,
+     EnableProgramBinaryForCapture,
++    EnsureNonEmptyBufferIsBoundForDraw,
+     ExpandIntegerPowExpressions,
+     ExplicitlyEnablePerSampleShading,
+     ExposeNonConformantExtensionsAndVersions,

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -169,3 +169,9 @@ m114_webcodecs_fix_crash_when_changing_temporal_layer_count_in_av1.patch
 cherry-pick-933b9fad3a53.patch
 cherry-pick-b03973561862.patch
 cherry-pick-c60a1ab717c7.patch
+cherry-pick-d0c1b8954a1b.patch
+cherry-pick-abb3ebd3d2ef.patch
+cherry-pick-fa181f8768c9.patch
+cherry-pick-337124b13aaa.patch
+cherry-pick-83b0bdb696d8.patch
+cherry-pick-e40cb330b645.patch

--- a/patches/chromium/cherry-pick-337124b13aaa.patch
+++ b/patches/chromium/cherry-pick-337124b13aaa.patch
@@ -1,0 +1,53 @@
+From 337124b13aaaacc7b247d597c5d5abb954c1e497 Mon Sep 17 00:00:00 2001
+From: Gabriel Charette <gab@chromium.org>
+Date: Mon, 24 Jul 2023 16:59:44 +0000
+Subject: [PATCH] [Merge M116] [blink] Fix UAF in NonMainThreadTaskQueue
+
+The issue is that WorkerThreadScheduler::OnTaskCompleted's
+PerformMicrotaskCheckpoint() might result in a blink heap GC which may
+collect NonMainThreadWebSchedulingTaskQueueImpl (owned by
+GarbageCollected<DOMTaskQueue>) which might own the last ref to
+NonMainThreadTaskQueue. If the NonMainThreadTaskQueue is deleted,
+there's a UAF in the follow-up call to
+task_queue->OnTaskRunTimeReported(task_timing);
+
+Retain a ref to NonMainThreadTaskQueue throughout OnTaskCompleted() to
+prevent this.
+
+The other option, proposed @ crbug.com/1464113#c3 was to bind the ref
+ahead of time in the `on_task_completed_handler` but I am leery that
+this might prevent deleting queues with pending tasks.
+
+R=altimin@chromium.org
+
+(cherry picked from commit 3463ed58f68034e68a1291b6413776c2b72994e8)
+
+Bug: 1464113
+Change-Id: I877c609244ab90a0af1c87c317cf5a55e2fa60ff
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4678047
+Reviewed-by: Alexander Timin <altimin@chromium.org>
+Reviewed-by: Etienne Pierre-Doray <etiennep@chromium.org>
+Commit-Queue: Gabriel Charette <gab@chromium.org>
+Auto-Submit: Gabriel Charette <gab@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1170760}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4706171
+Commit-Queue: Alexander Timin <altimin@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5845@{#750}
+Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
+---
+
+diff --git a/third_party/blink/renderer/platform/scheduler/worker/non_main_thread_task_queue.cc b/third_party/blink/renderer/platform/scheduler/worker/non_main_thread_task_queue.cc
+index fac6a19..f88419d 100644
+--- a/third_party/blink/renderer/platform/scheduler/worker/non_main_thread_task_queue.cc
++++ b/third_party/blink/renderer/platform/scheduler/worker/non_main_thread_task_queue.cc
+@@ -69,6 +69,10 @@
+     base::LazyNow* lazy_now) {
+   // |non_main_thread_scheduler_| can be nullptr in tests.
+   if (non_main_thread_scheduler_) {
++    // The last ref to `non_main_thread_scheduler_` might be released as part of
++    // this task's cleanup microtasks, make sure it lives through its own
++    // cleanup: crbug.com/1464113.
++    auto self_ref = WrapRefCounted(this);
+     non_main_thread_scheduler_->OnTaskCompleted(this, task, task_timing,
+                                                 lazy_now);
+   }

--- a/patches/chromium/cherry-pick-83b0bdb696d8.patch
+++ b/patches/chromium/cherry-pick-83b0bdb696d8.patch
@@ -1,0 +1,58 @@
+From 83b0bdb696d81b2d94e3aee77b3b6f86b96274c3 Mon Sep 17 00:00:00 2001
+From: chromium-autoroll <chromium-autoroll@skia-public.iam.gserviceaccount.com>
+Date: Mon, 24 Jul 2023 17:52:17 +0000
+Subject: [PATCH] Roll SwiftShader from 222e07b368b1 to 8d9a45b1f3ab (12 revisions)
+
+https://swiftshader.googlesource.com/SwiftShader.git/+log/222e07b368b1..8d9a45b1f3ab
+
+2023-07-24 bclayton@google.com LLVMReactor: Remove CreateFreeze() call
+2023-07-23 bclayton@google.com LLVMReactor: Clamp RHS of bit shifts using type width
+2023-07-22 bclayton@google.com Fix another 'sign-compare' warning as error
+2023-07-22 bclayton@google.com Fix 'sign-compare' warning as error
+2023-07-21 bclayton@google.com LLVMReactor: Clamp RHS of bit shifts.
+2023-07-21 swiftshader.regress@gmail.com Regres: Update test lists @ 4a260c12
+2023-07-21 bclayton@google.com ExecutableMemory: Use VirtualAlloc() instead of `new` on windows
+2023-07-20 avi@google.com Don't allow Swiftshader to be compiled as ARC
+2023-07-18 tiszka@chromium.org [subzero] Fix integer overflows during alloca coalescing
+2023-07-12 aredulla@google.com [ssci] Added Shipped field to READMEs
+2023-07-11 jif@google.com [LLVM 16] Have Swiftshader built with Android.bp use LLVM 16.
+2023-07-04 jif@google.com [LLVM 16] Shifts do not generate poison values
+
+If this roll has caused a breakage, revert this CL and stop the roller
+using the controls here:
+https://autoroll.skia.org/r/swiftshader-chromium-autoroll
+Please CC capn@chromium.org,swiftshader-eng+autoroll@google.com on the revert to ensure that a human
+is aware of the problem.
+
+To file a bug in SwiftShader: https://bugs.chromium.org/p/swiftshader/issues/entry
+To file a bug in Chromium: https://bugs.chromium.org/p/chromium/issues/entry
+
+To report a problem with the AutoRoller itself, please file a bug:
+https://bugs.chromium.org/p/skia/issues/entry?template=Autoroller+Bug
+
+Documentation for the AutoRoller is here:
+https://skia.googlesource.com/buildbot/+doc/main/autoroll/README.md
+
+Cq-Include-Trybots: luci.chromium.try:linux_chromium_msan_rel_ng;luci.chromium.try:linux_optional_gpu_tests_rel;luci.chromium.try:mac_optional_gpu_tests_rel;luci.chromium.try:win_optional_gpu_tests_rel;luci.chromium.try:linux-swangle-try-x64;luci.chromium.try:win-swangle-try-x86
+Bug: chromium:1427865,chromium:1431761,chromium:1464038,chromium:1464680,chromium:1466124,chromium:733237
+Tbr: swiftshader-eng+autoroll@google.com
+Change-Id: Ifea78e22e4b836267a9094fffa87ddda27516f1c
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4711308
+Bot-Commit: chromium-autoroll <chromium-autoroll@skia-public.iam.gserviceaccount.com>
+Commit-Queue: chromium-autoroll <chromium-autoroll@skia-public.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/heads/main@{#1174303}
+---
+
+diff --git a/DEPS b/DEPS
+index 43fe726..6a951498 100644
+--- a/DEPS
++++ b/DEPS
+@@ -322,7 +322,7 @@
+   # Three lines of non-changing comments so that
+   # the commit queue can handle CLs rolling SwiftShader
+   # and whatever else without interference from each other.
+-  'swiftshader_revision': '222e07b368b179529b7dddf9069bc83e56988e8e',
++  'swiftshader_revision': '8d9a45b1f3ab73a78e44336d12749929b8539fb6',
+   # Three lines of non-changing comments so that
+   # the commit queue can handle CLs rolling PDFium
+   # and whatever else without interference from each other.

--- a/patches/chromium/cherry-pick-abb3ebd3d2ef.patch
+++ b/patches/chromium/cherry-pick-abb3ebd3d2ef.patch
@@ -1,0 +1,327 @@
+From abb3ebd3d2ef3614fd888160d81505702b932f2c Mon Sep 17 00:00:00 2001
+From: Takumi Fujimoto <takumif@chromium.org>
+Date: Tue, 18 Jul 2023 18:20:16 +0000
+Subject: [PATCH] Destroy CastDeviceListHost during KeyedServices shutdown
+
+This makes MediaNotificationService destroy all the CastDeviceListHosts
+that it's instantiated in its KeyedService shutdown. This is necessary
+because CastDeviceListHost depends on MediaRouter, another KeyedService.
+
+(cherry picked from commit ffc0dfef649ad5b1149f89bb24c70d43405442ba)
+
+Bug: 1457757
+Change-Id: I453279da77b141ad9cd89310fc8128cc7d2919f2
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4672319
+Reviewed-by: Tommy Steimel <steimel@chromium.org>
+Commit-Queue: Takumi Fujimoto <takumif@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1168361}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4692442
+Auto-Submit: Takumi Fujimoto <takumif@chromium.org>
+Commit-Queue: Tommy Steimel <steimel@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5790@{#1763}
+Cr-Branched-From: 1d71a337b1f6e707a13ae074dca1e2c34905eb9f-refs/heads/main@{#1148114}
+---
+
+diff --git a/chrome/browser/ui/global_media_controls/cast_device_list_host.cc b/chrome/browser/ui/global_media_controls/cast_device_list_host.cc
+index 643bf2a..18cca5d 100644
+--- a/chrome/browser/ui/global_media_controls/cast_device_list_host.cc
++++ b/chrome/browser/ui/global_media_controls/cast_device_list_host.cc
+@@ -88,7 +88,8 @@
+     : cast_controller_(std::move(dialog_controller)),
+       client_(std::move(client)),
+       media_remoting_callback_(std::move(media_remoting_callback)),
+-      hide_dialog_callback_(std::move(hide_dialog_callback)) {
++      hide_dialog_callback_(std::move(hide_dialog_callback)),
++      id_(next_id_++) {
+   cast_controller_->AddObserver(this);
+   cast_controller_->RegisterDestructor(
+       base::BindOnce(&CastDeviceListHost::DestroyCastController,
+@@ -181,3 +182,5 @@
+ void CastDeviceListHost::DestroyCastController() {
+   cast_controller_.reset();
+ }
++
++int CastDeviceListHost::next_id_ = 0;
+diff --git a/chrome/browser/ui/global_media_controls/cast_device_list_host.h b/chrome/browser/ui/global_media_controls/cast_device_list_host.h
+index c3b916e..6b1f1e5 100644
+--- a/chrome/browser/ui/global_media_controls/cast_device_list_host.h
++++ b/chrome/browser/ui/global_media_controls/cast_device_list_host.h
+@@ -36,10 +36,15 @@
+   void OnModelUpdated(const media_router::CastDialogModel& model) override;
+   void OnCastingStarted() override;
+ 
++  int id() const { return id_; }
++
+  private:
+   void StartCasting(const media_router::UIMediaSink& sink);
+   void DestroyCastController();
+ 
++  // Used to generate `id_`.
++  static int next_id_;
++
+   std::unique_ptr<media_router::CastDialogController> cast_controller_;
+   mojo::Remote<global_media_controls::mojom::DeviceListClient> client_;
+   std::vector<media_router::UIMediaSink> sinks_;
+@@ -47,6 +52,7 @@
+   MediaRemotingCallback media_remoting_callback_;
+   // Called whenever a tab mirroring session starts.
+   base::RepeatingClosure hide_dialog_callback_;
++  const int id_;
+ };
+ 
+ #endif  // CHROME_BROWSER_UI_GLOBAL_MEDIA_CONTROLS_CAST_DEVICE_LIST_HOST_H_
+diff --git a/chrome/browser/ui/global_media_controls/cast_device_list_host_unittest.cc b/chrome/browser/ui/global_media_controls/cast_device_list_host_unittest.cc
+index 2aee3352..8dea6987 100644
+--- a/chrome/browser/ui/global_media_controls/cast_device_list_host_unittest.cc
++++ b/chrome/browser/ui/global_media_controls/cast_device_list_host_unittest.cc
+@@ -22,6 +22,9 @@
+ using testing::_;
+ using testing::NiceMock;
+ using testing::Return;
++namespace mojom {
++using global_media_controls::mojom::DeviceListClient;
++}  // namespace mojom
+ 
+ namespace {
+ 
+@@ -72,24 +75,29 @@
+     testing::Test::SetUp();
+     auto dialog_controller = std::make_unique<MockCastDialogController>();
+     dialog_controller_ = dialog_controller.get();
+-    host_ = std::make_unique<CastDeviceListHost>(
+-        std::move(dialog_controller),
+-        client_receiver_.InitWithNewPipeAndPassRemote(),
+-        base::BindRepeating(&CastDeviceListHostTest::OnMediaRemotingRequested,
+-                            base::Unretained(this)),
+-        base::BindRepeating(&CastDeviceListHostTest::HideMediaDialog,
+-                            base::Unretained(this)));
++    host_ = CreateHost(std::move(dialog_controller), &client_receiver_);
+   }
+ 
+   MOCK_METHOD(void, OnMediaRemotingRequested, ());
+   MOCK_METHOD(void, HideMediaDialog, ());
+ 
+  protected:
++  std::unique_ptr<CastDeviceListHost> CreateHost(
++      std::unique_ptr<media_router::CastDialogController> dialog_controller,
++      mojo::PendingReceiver<mojom::DeviceListClient>* client_receiver) {
++    return std::make_unique<CastDeviceListHost>(
++        std::move(dialog_controller),
++        client_receiver->InitWithNewPipeAndPassRemote(),
++        base::BindRepeating(&CastDeviceListHostTest::OnMediaRemotingRequested,
++                            base::Unretained(this)),
++        base::BindRepeating(&CastDeviceListHostTest::HideMediaDialog,
++                            base::Unretained(this)));
++  }
++
+   content::BrowserTaskEnvironment task_environment_;
+   std::unique_ptr<CastDeviceListHost> host_;
+   raw_ptr<MockCastDialogController> dialog_controller_ = nullptr;
+-  mojo::PendingReceiver<global_media_controls::mojom::DeviceListClient>
+-      client_receiver_;
++  mojo::PendingReceiver<mojom::DeviceListClient> client_receiver_;
+ };
+ 
+ TEST_F(CastDeviceListHostTest, StartPresentation) {
+@@ -183,3 +191,11 @@
+   EXPECT_CALL(*dialog_controller_, ClearIssue(issue.id()));
+   host_->SelectDevice(sink.id);
+ }
++
++TEST_F(CastDeviceListHostTest, GetId) {
++  mojo::PendingReceiver<mojom::DeviceListClient> client_receiver;
++  std::unique_ptr<CastDeviceListHost> host2 = CreateHost(
++      std::make_unique<MockCastDialogController>(), &client_receiver);
++  // IDs should be unique.
++  EXPECT_NE(host_->id(), host2->id());
++}
+diff --git a/chrome/browser/ui/global_media_controls/media_notification_service.cc b/chrome/browser/ui/global_media_controls/media_notification_service.cc
+index 5c98ba69..f46900c 100644
+--- a/chrome/browser/ui/global_media_controls/media_notification_service.cc
++++ b/chrome/browser/ui/global_media_controls/media_notification_service.cc
+@@ -7,7 +7,6 @@
+ #include <memory>
+ 
+ #include "base/callback_list.h"
+-#include "base/metrics/field_trial_params.h"
+ #include "base/metrics/histogram_functions.h"
+ #include "base/ranges/algorithm.h"
+ #include "base/unguessable_token.h"
+@@ -25,7 +24,6 @@
+ #include "components/global_media_controls/public/media_dialog_delegate.h"
+ #include "components/global_media_controls/public/media_item_manager.h"
+ #include "components/global_media_controls/public/media_item_producer.h"
+-#include "components/global_media_controls/public/media_item_ui.h"
+ #include "components/media_message_center/media_notification_item.h"
+ #include "components/media_router/browser/media_router_factory.h"
+ #include "components/media_router/browser/presentation/start_presentation_context.h"
+@@ -211,14 +209,21 @@
+ }
+ 
+ void MediaNotificationService::Shutdown() {
+-  // `cast_notification_producer_` and
+-  // `presentation_request_notification_producer_` depend on MediaRouter,
+-  // which is another keyed service. So they must be destroyed here.
++  shutdown_has_started_ = true;
++  // `cast_notification_producer_`,
++  // `presentation_request_notification_producer_` and `host_receivers_`
++  // depend on MediaRouter, which is another keyed service. So they must be
++  // destroyed here.
+   if (cast_notification_producer_) {
+     item_manager_->RemoveItemProducer(cast_notification_producer_.get());
+   }
+   cast_notification_producer_.reset();
+   presentation_request_notification_producer_.reset();
++  for (const auto& host : host_receivers_) {
++    if (host.second) {
++      host.second->Close();
++    }
++  }
+ }
+ 
+ void MediaNotificationService::OnAudioSinkChosen(const std::string& item_id,
+@@ -445,7 +450,7 @@
+ 
+ void MediaNotificationService::CreateCastDeviceListHost(
+     std::unique_ptr<media_router::CastDialogController> dialog_controller,
+-    mojo::PendingReceiver<mojom::DeviceListHost> host_receiver,
++    mojo::PendingReceiver<mojom::DeviceListHost> host_pending_receiver,
+     mojo::PendingRemote<mojom::DeviceListClient> client_remote,
+     absl::optional<std::string> session_id) {
+   if (!dialog_controller) {
+@@ -459,14 +464,19 @@
+                 &MediaNotificationService::OnMediaRemotingRequested,
+                 weak_ptr_factory_.GetWeakPtr(), session_id.value())
+           : base::DoNothing();
+-  mojo::MakeSelfOwnedReceiver(
+-      std::make_unique<CastDeviceListHost>(
+-          std::move(dialog_controller), std::move(client_remote),
+-          std::move(media_remoting_callback_),
+-          base::BindRepeating(
+-              &global_media_controls::MediaItemManager::HideDialog,
+-              item_manager_->GetWeakPtr())),
+-      std::move(host_receiver));
++  auto host = std::make_unique<CastDeviceListHost>(
++      std::move(dialog_controller), std::move(client_remote),
++      std::move(media_remoting_callback_),
++      base::BindRepeating(&global_media_controls::MediaItemManager::HideDialog,
++                          item_manager_->GetWeakPtr()));
++  int host_id = host->id();
++  mojo::SelfOwnedReceiverRef<global_media_controls::mojom::DeviceListHost>
++      host_receiver = mojo::MakeSelfOwnedReceiver(
++          std::move(host), std::move(host_pending_receiver));
++  host_receiver->set_connection_error_handler(
++      base::BindOnce(&MediaNotificationService::RemoveDeviceListHost,
++                     weak_ptr_factory_.GetWeakPtr(), host_id));
++  host_receivers_.emplace(host_id, std::move(host_receiver));
+ }
+ 
+ void MediaNotificationService::set_device_provider_for_testing(
+@@ -529,3 +539,12 @@
+   }
+   return "";
+ }
++
++void MediaNotificationService::RemoveDeviceListHost(int host_id) {
++  // If shutdown has started, then we may currently be iterating through
++  // `host_receivers_` so we should not erase from it. `host_receivers_` will
++  // get destroyed soon anyways.
++  if (!shutdown_has_started_) {
++    host_receivers_.erase(host_id);
++  }
++}
+diff --git a/chrome/browser/ui/global_media_controls/media_notification_service.h b/chrome/browser/ui/global_media_controls/media_notification_service.h
+index 595875fb..a3d7488 100644
+--- a/chrome/browser/ui/global_media_controls/media_notification_service.h
++++ b/chrome/browser/ui/global_media_controls/media_notification_service.h
+@@ -24,6 +24,7 @@
+ #include "mojo/public/cpp/bindings/pending_receiver.h"
+ #include "mojo/public/cpp/bindings/pending_remote.h"
+ #include "mojo/public/cpp/bindings/receiver.h"
++#include "mojo/public/cpp/bindings/self_owned_receiver.h"
+ #include "services/metrics/public/cpp/ukm_source_id.h"
+ #include "third_party/abseil-cpp/absl/types/optional.h"
+ 
+@@ -157,6 +158,8 @@
+   std::string GetActiveControllableSessionForWebContents(
+       content::WebContents* web_contents) const;
+ 
++  void RemoveDeviceListHost(int host);
++
+   const raw_ptr<Profile> profile_;
+ 
+   std::unique_ptr<global_media_controls::MediaItemManager> item_manager_;
+@@ -181,6 +184,14 @@
+ 
+   mojo::Receiver<global_media_controls::mojom::DeviceService> receiver_;
+ 
++  // Maps from hosts' IDs to hosts.
++  std::map<
++      int,
++      mojo::SelfOwnedReceiverRef<global_media_controls::mojom::DeviceListHost>>
++      host_receivers_;
++
++  bool shutdown_has_started_ = false;
++
+   base::WeakPtrFactory<MediaNotificationService> weak_ptr_factory_{this};
+ };
+ 
+diff --git a/chrome/browser/ui/global_media_controls/media_notification_service_unittest.cc b/chrome/browser/ui/global_media_controls/media_notification_service_unittest.cc
+index 80dafff..f99bd29 100644
+--- a/chrome/browser/ui/global_media_controls/media_notification_service_unittest.cc
++++ b/chrome/browser/ui/global_media_controls/media_notification_service_unittest.cc
+@@ -556,7 +556,8 @@
+   service()->GetDeviceListHostForSession(
+       id.ToString(), TakeReceiverAndExpectNoDisconnect(host_remote),
+       TakeRemoteAndExpectNoDisconnect(client.receiver()));
+-  base::RunLoop().RunUntilIdle();
++  host_remote.FlushForTesting();
++  client.receiver().FlushForTesting();
+ }
+ 
+ TEST_F(MediaNotificationServiceCastTest,
+@@ -566,7 +567,8 @@
+   service()->GetDeviceListHostForSession(
+       "invalid_id", TakeReceiverAndExpectDisconnect(host_remote),
+       TakeRemoteAndExpectDisconnect(client.receiver()));
+-  base::RunLoop().RunUntilIdle();
++  host_remote.FlushForTesting();
++  client.receiver().FlushForTesting();
+ }
+ 
+ TEST_F(MediaNotificationServiceCastTest, GetDeviceListHostForPresentation) {
+@@ -577,7 +579,8 @@
+   service()->GetDeviceListHostForPresentation(
+       TakeReceiverAndExpectNoDisconnect(host_remote),
+       TakeRemoteAndExpectNoDisconnect(client.receiver()));
+-  base::RunLoop().RunUntilIdle();
++  host_remote.FlushForTesting();
++  client.receiver().FlushForTesting();
+ }
+ 
+ TEST_F(MediaNotificationServiceCastTest,
+@@ -587,7 +590,23 @@
+   service()->GetDeviceListHostForPresentation(
+       TakeReceiverAndExpectDisconnect(host_remote),
+       TakeRemoteAndExpectDisconnect(client.receiver()));
+-  base::RunLoop().RunUntilIdle();
++  host_remote.FlushForTesting();
++  client.receiver().FlushForTesting();
++}
++
++TEST_F(MediaNotificationServiceCastTest, DeleteDeviceListHostOnShutdown) {
++  mojo::Remote<mojom::DeviceListHost> host_remote;
++  MockDeviceListClient client;
++  auto id = SimulatePlayingControllableMediaForWebContents(web_contents());
++  service()->GetDeviceListHostForSession(
++      id.ToString(), TakeReceiverAndExpectDisconnect(host_remote),
++      TakeRemoteAndExpectDisconnect(client.receiver()));
++
++  // Shutdown() should cause a disconnect, fulfilling the expectations in
++  // TakeReceiver...() and TakeRemote...() above.
++  service()->Shutdown();
++  host_remote.FlushForTesting();
++  client.receiver().FlushForTesting();
+ }
+ 
+ TEST_F(MediaNotificationServiceCastTest,

--- a/patches/chromium/cherry-pick-d0c1b8954a1b.patch
+++ b/patches/chromium/cherry-pick-d0c1b8954a1b.patch
@@ -1,0 +1,49 @@
+From d0c1b8954a1be016b8a9725b818b750998fb842f Mon Sep 17 00:00:00 2001
+From: kylechar <kylechar@chromium.org>
+Date: Mon, 17 Jul 2023 23:14:41 +0000
+Subject: [PATCH] Ensure unique entries in frame_timing_details_
+
+CompositorFrameSinkSupport::DidPresentCompositorFrame() keeps
+|frame_timing_details_| map keyed on CompositorFrame frame_tokens. These
+are supposed to be unique but a malicious renderer could violate that
+assumption. Convert some DCHECKs into CHECKs to guard against problems
+related to this.
+
+(cherry picked from commit 9b62ab5a88379b37dbc712171fdfd5530b99a7a9)
+
+Bug: 1458819
+Change-Id: Ib0b9551d18ea421957e0dce49a2593043f4abb12
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4673638
+Reviewed-by: Jonathan Ross <jonross@chromium.org>
+Commit-Queue: Kyle Charbonneau <kylechar@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1169287}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4689943
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: Vasiliy Telezhnikov <vasilyt@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5735@{#1481}
+Cr-Branched-From: 2f562e4ddbaf79a3f3cb338b4d1bd4398d49eb67-refs/heads/main@{#1135570}
+---
+
+diff --git a/components/viz/service/frame_sinks/compositor_frame_sink_support.cc b/components/viz/service/frame_sinks/compositor_frame_sink_support.cc
+index aa83934..f1d7ec3e 100644
+--- a/components/viz/service/frame_sinks/compositor_frame_sink_support.cc
++++ b/components/viz/service/frame_sinks/compositor_frame_sink_support.cc
+@@ -789,7 +789,7 @@
+   DCHECK_LE(pending_received_frame_times_.size(), 25u);
+   auto received_frame_timestamp =
+       pending_received_frame_times_.find(frame_token);
+-  DCHECK(received_frame_timestamp != pending_received_frame_times_.end());
++  CHECK(received_frame_timestamp != pending_received_frame_times_.end());
+ 
+   FrameTimingDetails details;
+   details.received_compositor_frame_timestamp =
+@@ -810,8 +810,7 @@
+   pending_received_frame_times_.erase(received_frame_timestamp);
+ 
+   // We should only ever get one PresentationFeedback per frame_token.
+-  DCHECK(frame_timing_details_.find(frame_token) ==
+-         frame_timing_details_.end());
++  CHECK(!frame_timing_details_.contains(frame_token));
+   frame_timing_details_.emplace(frame_token, details);
+ 
+   if (!feedback.failed() && frame_sink_manager_->frame_counter()) {

--- a/patches/chromium/cherry-pick-e40cb330b645.patch
+++ b/patches/chromium/cherry-pick-e40cb330b645.patch
@@ -1,0 +1,45 @@
+From e40cb330b6457a9039966dc3c4e30259670e6af3 Mon Sep 17 00:00:00 2001
+From: Bence Béky <bnc@chromium.org>
+Date: Mon, 31 Jul 2023 15:31:39 +0000
+Subject: [PATCH] Check whether read side is closed when reading QuicChromiumClientStream
+
+When quic::QuicSpdyStream receives a RST_STREAM frame it clears the
+underlying read buffer. Subsequent read operations should check
+quic::QuicStream::read_side_closed() so that it doesn't access the
+cleared read buffer.
+
+This CL is cloned from https://crrev.com/c/4691923 by bashi@chromium.org.
+
+(cherry picked from commit ecf8b698d6ec2a7c4bed49714c80f4ee5516c50d)
+
+Bug: 1465224
+Change-Id: I35a908e11d09c67dea857b34653d6cf1cadbb407
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4728448
+Commit-Queue: Bence Béky <bnc@chromium.org>
+Auto-Submit: Bence Béky <bnc@chromium.org>
+Reviewed-by: Kenichi Ishibashi <bashi@chromium.org>
+Commit-Queue: Kenichi Ishibashi <bashi@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1176838}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4733554
+Reviewed-by: Bence Béky <bnc@chromium.org>
+Commit-Queue: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/5790@{#1904}
+Cr-Branched-From: 1d71a337b1f6e707a13ae074dca1e2c34905eb9f-refs/heads/main@{#1148114}
+---
+
+diff --git a/net/quic/quic_chromium_client_stream.cc b/net/quic/quic_chromium_client_stream.cc
+index d37a113..961ec67 100644
+--- a/net/quic/quic_chromium_client_stream.cc
++++ b/net/quic/quic_chromium_client_stream.cc
+@@ -206,6 +206,10 @@
+   if (!stream_)
+     return net_error_;
+ 
++  if (stream_->read_side_closed()) {
++    return OK;
++  }
++
+   int rv = stream_->Read(buffer, buffer_len);
+   if (rv != ERR_IO_PENDING)
+     return rv;

--- a/patches/chromium/cherry-pick-fa181f8768c9.patch
+++ b/patches/chromium/cherry-pick-fa181f8768c9.patch
@@ -1,0 +1,48 @@
+From fa181f8768c9471e12459a4f9d074f37f10bb505 Mon Sep 17 00:00:00 2001
+From: chromium-autoroll <chromium-autoroll@skia-public.iam.gserviceaccount.com>
+Date: Thu, 20 Jul 2023 00:29:47 +0000
+Subject: [PATCH] Roll WebRTC from dbb89430ef77 to e9e03a916050 (3 revisions)
+
+https://webrtc.googlesource.com/src.git/+log/dbb89430ef77..e9e03a916050
+
+2023-07-19 joachimr@meta.com Fix inaccurate contentType in RTCInbound/OutboundRtpStreamStats
+2023-07-19 phancke@microsoft.com Prevent SDP munging of duplicate SSRCs
+2023-07-19 chromium-webrtc-autoroll@webrtc-ci.iam.gserviceaccount.com Roll chromium_revision 21b76e39ae..58a3c40eba (1172261:1172400)
+
+If this roll has caused a breakage, revert this CL and stop the roller
+using the controls here:
+https://autoroll.skia.org/r/webrtc-chromium-autoroll
+Please CC webrtc-chromium-sheriffs-robots@google.com,webrtc-infra@google.com on the revert to ensure that a human
+is aware of the problem.
+
+To file a bug in WebRTC: https://bugs.chromium.org/p/webrtc/issues/entry
+To file a bug in Chromium: https://bugs.chromium.org/p/chromium/issues/entry
+
+To report a problem with the AutoRoller itself, please file a bug:
+https://bugs.chromium.org/p/skia/issues/entry?template=Autoroller+Bug
+
+Documentation for the AutoRoller is here:
+https://skia.googlesource.com/buildbot/+doc/main/autoroll/README.md
+
+Bug: chromium:1459124
+Tbr: webrtc-chromium-sheriffs-robots@google.com
+Change-Id: I2340d48bb0484a1dd608eb61bb97de4c3313307b
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4703308
+Bot-Commit: chromium-autoroll <chromium-autoroll@skia-public.iam.gserviceaccount.com>
+Commit-Queue: chromium-autoroll <chromium-autoroll@skia-public.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/heads/main@{#1172688}
+---
+
+diff --git a/DEPS b/DEPS
+index 0667eab6..f115f2e 100644
+--- a/DEPS
++++ b/DEPS
+@@ -1923,7 +1923,7 @@
+     Var('chromium_git') + '/external/github.com/gpuweb/cts.git' + '@' + '954ac6b88b2b197226503b74a32fc29884ebd856',
+ 
+   'src/third_party/webrtc':
+-    Var('webrtc_git') + '/src.git' + '@' + 'dbb89430ef772ebaf8a0170b0be150129eb9fd63',
++    Var('webrtc_git') + '/src.git' + '@' + 'e9e03a9160502b23749e8f64da517f83457e2ad3',
+ 
+   # Wuffs' canonical repository is at github.com/google/wuffs, but we use
+   # Skia's mirror of Wuffs, the same as in upstream Skia's DEPS file.


### PR DESCRIPTION
<details>
<summary>electron/security#385 - d0c1b8954a1b from chromium</summary>
Ensure unique entries in frame_timing_details_

CompositorFrameSinkSupport::DidPresentCompositorFrame() keeps
|frame_timing_details_| map keyed on CompositorFrame frame_tokens. These
are supposed to be unique but a malicious renderer could violate that
assumption. Convert some DCHECKs into CHECKs to guard against problems
related to this.

(cherry picked from commit 9b62ab5a88379b37dbc712171fdfd5530b99a7a9)

Bug: 1458819
Change-Id: Ib0b9551d18ea421957e0dce49a2593043f4abb12
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4673638
Reviewed-by: Jonathan Ross <jonross@chromium.org>
Commit-Queue: Kyle Charbonneau <kylechar@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1169287}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4689943
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Commit-Queue: Vasiliy Telezhnikov <vasilyt@chromium.org>
Cr-Commit-Position: refs/branch-heads/5735@{#1481}
Cr-Branched-From: 2f562e4ddbaf79a3f3cb338b4d1bd4398d49eb67-refs/heads/main@{#1135570}
</details>

<details>
<summary>electron/security#386 - abb3ebd3d2ef from chromium</summary>
Destroy CastDeviceListHost during KeyedServices shutdown

This makes MediaNotificationService destroy all the CastDeviceListHosts
that it's instantiated in its KeyedService shutdown. This is necessary
because CastDeviceListHost depends on MediaRouter, another KeyedService.

(cherry picked from commit ffc0dfef649ad5b1149f89bb24c70d43405442ba)

Bug: 1457757
Change-Id: I453279da77b141ad9cd89310fc8128cc7d2919f2
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4672319
Reviewed-by: Tommy Steimel <steimel@chromium.org>
Commit-Queue: Takumi Fujimoto <takumif@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1168361}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4692442
Auto-Submit: Takumi Fujimoto <takumif@chromium.org>
Commit-Queue: Tommy Steimel <steimel@chromium.org>
Cr-Commit-Position: refs/branch-heads/5790@{#1763}
Cr-Branched-From: 1d71a337b1f6e707a13ae074dca1e2c34905eb9f-refs/heads/main@{#1148114}
</details>

<details>
<summary>electron/security#384 - fa181f8768c9 from chromium</summary>
Roll WebRTC from dbb89430ef77 to e9e03a916050 (3 revisions)

https://webrtc.googlesource.com/src.git/+log/dbb89430ef77..e9e03a916050

2023-07-19 joachimr@meta.com Fix inaccurate contentType in RTCInbound/OutboundRtpStreamStats
2023-07-19 phancke@microsoft.com Prevent SDP munging of duplicate SSRCs
2023-07-19 chromium-webrtc-autoroll@webrtc-ci.iam.gserviceaccount.com Roll chromium_revision 21b76e39ae..58a3c40eba (1172261:1172400)

If this roll has caused a breakage, revert this CL and stop the roller
using the controls here:
https://autoroll.skia.org/r/webrtc-chromium-autoroll
Please CC webrtc-chromium-sheriffs-robots@google.com,webrtc-infra@google.com on the revert to ensure that a human
is aware of the problem.

To file a bug in WebRTC: https://bugs.chromium.org/p/webrtc/issues/entry
To file a bug in Chromium: https://bugs.chromium.org/p/chromium/issues/entry

To report a problem with the AutoRoller itself, please file a bug:
https://bugs.chromium.org/p/skia/issues/entry?template=Autoroller+Bug

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+doc/main/autoroll/README.md

Bug: chromium:1459124
Tbr: webrtc-chromium-sheriffs-robots@google.com
Change-Id: I2340d48bb0484a1dd608eb61bb97de4c3313307b
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4703308
Bot-Commit: chromium-autoroll <chromium-autoroll@skia-public.iam.gserviceaccount.com>
Commit-Queue: chromium-autoroll <chromium-autoroll@skia-public.iam.gserviceaccount.com>
Cr-Commit-Position: refs/heads/main@{#1172688}
</details>

<details>
<summary>electron/security#388 - 337124b13aaa from chromium</summary>
[Merge M116] [blink] Fix UAF in NonMainThreadTaskQueue

The issue is that WorkerThreadScheduler::OnTaskCompleted's
PerformMicrotaskCheckpoint() might result in a blink heap GC which may
collect NonMainThreadWebSchedulingTaskQueueImpl (owned by
GarbageCollected<DOMTaskQueue>) which might own the last ref to
NonMainThreadTaskQueue. If the NonMainThreadTaskQueue is deleted,
there's a UAF in the follow-up call to
task_queue->OnTaskRunTimeReported(task_timing);

Retain a ref to NonMainThreadTaskQueue throughout OnTaskCompleted() to
prevent this.

The other option, proposed @ crbug.com/1464113#c3 was to bind the ref
ahead of time in the `on_task_completed_handler` but I am leery that
this might prevent deleting queues with pending tasks.

R=altimin@chromium.org

(cherry picked from commit 3463ed58f68034e68a1291b6413776c2b72994e8)

Bug: 1464113
Change-Id: I877c609244ab90a0af1c87c317cf5a55e2fa60ff
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4678047
Reviewed-by: Alexander Timin <altimin@chromium.org>
Reviewed-by: Etienne Pierre-Doray <etiennep@chromium.org>
Commit-Queue: Gabriel Charette <gab@chromium.org>
Auto-Submit: Gabriel Charette <gab@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1170760}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4706171
Commit-Queue: Alexander Timin <altimin@chromium.org>
Cr-Commit-Position: refs/branch-heads/5845@{#750}
Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
</details>

<details>
<summary>electron/security#382 - 83b0bdb696d8 from chromium</summary>
Roll SwiftShader from 222e07b368b1 to 8d9a45b1f3ab (12 revisions)

https://swiftshader.googlesource.com/SwiftShader.git/+log/222e07b368b1..8d9a45b1f3ab

2023-07-24 bclayton@google.com LLVMReactor: Remove CreateFreeze() call
2023-07-23 bclayton@google.com LLVMReactor: Clamp RHS of bit shifts using type width
2023-07-22 bclayton@google.com Fix another 'sign-compare' warning as error
2023-07-22 bclayton@google.com Fix 'sign-compare' warning as error
2023-07-21 bclayton@google.com LLVMReactor: Clamp RHS of bit shifts.
2023-07-21 swiftshader.regress@gmail.com Regres: Update test lists @ 4a260c12
2023-07-21 bclayton@google.com ExecutableMemory: Use VirtualAlloc() instead of `new` on windows
2023-07-20 avi@google.com Don't allow Swiftshader to be compiled as ARC
2023-07-18 tiszka@chromium.org [subzero] Fix integer overflows during alloca coalescing
2023-07-12 aredulla@google.com [ssci] Added Shipped field to READMEs
2023-07-11 jif@google.com [LLVM 16] Have Swiftshader built with Android.bp use LLVM 16.
2023-07-04 jif@google.com [LLVM 16] Shifts do not generate poison values

If this roll has caused a breakage, revert this CL and stop the roller
using the controls here:
https://autoroll.skia.org/r/swiftshader-chromium-autoroll
Please CC capn@chromium.org,swiftshader-eng+autoroll@google.com on the revert to ensure that a human
is aware of the problem.

To file a bug in SwiftShader: https://bugs.chromium.org/p/swiftshader/issues/entry
To file a bug in Chromium: https://bugs.chromium.org/p/chromium/issues/entry

To report a problem with the AutoRoller itself, please file a bug:
https://bugs.chromium.org/p/skia/issues/entry?template=Autoroller+Bug

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+doc/main/autoroll/README.md

Cq-Include-Trybots: luci.chromium.try:linux_chromium_msan_rel_ng;luci.chromium.try:linux_optional_gpu_tests_rel;luci.chromium.try:mac_optional_gpu_tests_rel;luci.chromium.try:win_optional_gpu_tests_rel;luci.chromium.try:linux-swangle-try-x64;luci.chromium.try:win-swangle-try-x86
Bug: chromium:1427865,chromium:1431761,chromium:1464038,chromium:1464680,chromium:1466124,chromium:733237
Tbr: swiftshader-eng+autoroll@google.com
Change-Id: Ifea78e22e4b836267a9094fffa87ddda27516f1c
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4711308
Bot-Commit: chromium-autoroll <chromium-autoroll@skia-public.iam.gserviceaccount.com>
Commit-Queue: chromium-autoroll <chromium-autoroll@skia-public.iam.gserviceaccount.com>
Cr-Commit-Position: refs/heads/main@{#1174303}
</details>

<details>
<summary>electron/security#381 - 285c7712c506 from angle</summary>
M116: Translator: Unconditionally limit variable sizes

... instead of just for WebGL.  This is to avoid hitting driver bugs
that were prevented with this check for WebGL on a compromised renderer
that can create non-WebGL contexts.

Bug: chromium:1464682
Change-Id: I2b1c5a8c51f06225f5f850109d30778d97e574c7
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/4717371
Reviewed-by: Roman Lavrov <romanl@google.com>
</details>

<details>
<summary>electron/security#377 - 2bf945775fe6 from angle</summary>
M116: Translator: Limit variable sizes vs uint overflow

Bug: chromium:1464680
Change-Id: Iee41a2da7a7a330e6cc4d6da59a6e9836ee9dd36
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/4717372
Reviewed-by: Roman Lavrov <romanl@google.com>
</details>

<details>
<summary>electron/security#387 - cafe56b591ed from angle</summary>
M116: GL: Ensure all instanced attributes have a buffer with data

Apple OpenGL drivers sometimes crash when given an instanced draw with
a buffer that has never been given data.

It's not efficient to check if the attribute is both zero-sized and
instanced so just ensure that every time a zero-sized buffer is bound
to an attribute, it gets initialized with some data.

Bug: chromium:1456243
Change-Id: I66b7c7017843153db2df3bc50010cba765d03c5f
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/4642048
Commit-Queue: Geoff Lang <geofflang@chromium.org>
Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
(cherry picked from commit 4e6124dae892690204f8e5996aeaad14f45e0a97)
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/4727452
</details>

<details>
<summary>electron/security#380 - e40cb330b645 from chromium</summary>
Check whether read side is closed when reading QuicChromiumClientStream

When quic::QuicSpdyStream receives a RST_STREAM frame it clears the
underlying read buffer. Subsequent read operations should check
quic::QuicStream::read_side_closed() so that it doesn't access the
cleared read buffer.

This CL is cloned from https://crrev.com/c/4691923 by bashi@chromium.org.

(cherry picked from commit ecf8b698d6ec2a7c4bed49714c80f4ee5516c50d)

Bug: 1465224
Change-Id: I35a908e11d09c67dea857b34653d6cf1cadbb407
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4728448
Commit-Queue: Bence Béky <bnc@chromium.org>
Auto-Submit: Bence Béky <bnc@chromium.org>
Reviewed-by: Kenichi Ishibashi <bashi@chromium.org>
Commit-Queue: Kenichi Ishibashi <bashi@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1176838}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4733554
Reviewed-by: Bence Béky <bnc@chromium.org>
Commit-Queue: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Cr-Commit-Position: refs/branch-heads/5790@{#1904}
Cr-Branched-From: 1d71a337b1f6e707a13ae074dca1e2c34905eb9f-refs/heads/main@{#1148114}
</details>

Notes:
* Security: backported fix for CVE-2023-4071.
* Security: backported fix for CVE-2023-4075.
* Security: backported fix for CVE-2023-4076.
* Security: backported fix for CVE-2023-4074.
* Security: backported fix for CVE-2023-4072.
* Security: backported fix for 1464682.
* Security: backported fix for 1464680.
* Security: backported fix for CVE-2023-4073.
* Security: backported fix for 1465224.