### PR TITLE
fix: destruction order of js env fields

### DIFF
--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -104,9 +104,10 @@ gin::IsolateHolder CreateIsolateHolder(v8::Isolate* isolate) {
 
 JavascriptEnvironment::JavascriptEnvironment(uv_loop_t* event_loop,
                                              bool setup_wasm_streaming)
-    : isolate_(Initialize(event_loop, setup_wasm_streaming)),
-      isolate_holder_(CreateIsolateHolder(isolate_)),
-      locker_(isolate_) {
+    : isolate_holder_{CreateIsolateHolder(
+          Initialize(event_loop, setup_wasm_streaming))},
+      isolate_{isolate_holder_.isolate()},
+      locker_{isolate_} {
   isolate_->Enter();
 
   v8::HandleScope scope(isolate_);

--- a/shell/browser/javascript_environment.h
+++ b/shell/browser/javascript_environment.h
@@ -43,8 +43,12 @@ class JavascriptEnvironment {
   v8::Isolate* Initialize(uv_loop_t* event_loop, bool setup_wasm_streaming);
   std::unique_ptr<node::MultiIsolatePlatform> platform_;
 
-  raw_ptr<v8::Isolate> isolate_;
   gin::IsolateHolder isolate_holder_;
+
+  // owned-by: isolate_holder_
+  const raw_ptr<v8::Isolate> isolate_;
+
+  // depends-on: isolate_
   v8::Locker locker_;
 
   std::unique_ptr<MicrotasksRunner> microtasks_runner_;


### PR DESCRIPTION
#### Description of Change

Fix a minor `raw_ptr` issue in JavascriptEnvironment:

```c++
class JavascriptEnvironment
{
    ...
    raw_ptr<Isolate> isolate_;
    IsolateHolder isolate_holder_;
    ...
};
```

The isolate that `isolate_` points to is owned by `isolate_holder_`, which disposes it in the isolate holder's destructor. Since classes destroy their fields in reverse order, `isolate_holder_` is destroyed first and so `isolate_` is a dangling pointer when it is destroyed.

CC @VerteDinde 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none