### PR TITLE
fix: use tiled edges to calculate frame inset sizes in Linux

### DIFF
--- a/shell/browser/ui/views/client_frame_view_linux.cc
+++ b/shell/browser/ui/views/client_frame_view_linux.cc
@@ -150,7 +150,13 @@ void ClientFrameViewLinux::Init(NativeWindowViews* window,
 }
 
 gfx::Insets ClientFrameViewLinux::GetBorderDecorationInsets() const {
-  return frame_provider_->GetFrameThicknessDip();
+  const auto insets = frame_provider_->GetFrameThicknessDip();
+  // We shouldn't draw frame decorations for the tiled edges.
+  // See https://wayland.app/protocols/xdg-shell#xdg_toplevel:enum:state
+  return gfx::Insets::TLBR(tiled_edges().top ? 0 : insets.top(),
+                           tiled_edges().left ? 0 : insets.left(),
+                           tiled_edges().bottom ? 0 : insets.bottom(),
+                           tiled_edges().right ? 0 : insets.right());
 }
 
 gfx::Insets ClientFrameViewLinux::GetInputInsets() const {


### PR DESCRIPTION
#### Description of Change

Adapt to the window frame size calculation changes in [CL 3970920](https://chromium-review.googlesource.com/c/chromium/src/+/3970920) by setting the inset sizes to 0 for tiled edges.

cc @jkleinsc 

Fixes #39470 

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed decorations for tiled windows on Wayland.
