### PR TITLE
build: fixup libcxx zip

### DIFF
--- a/build/zip_libcxx.py
+++ b/build/zip_libcxx.py
@@ -30,8 +30,8 @@ def get_object_files(base_path, archive_name):
 def main(argv):
   dist_zip, = argv
   out_dir = os.path.dirname(dist_zip)
-  base_path_libcxx = os.path.join(out_dir, 'obj/third_party/libc++')
-  base_path_libcxxabi = os.path.join(out_dir, 'obj/third_party/libc++abi')
+  base_path_libcxx = os.path.join(out_dir, 'obj/buildtools/third_party/libc++')
+  base_path_libcxxabi = os.path.join(out_dir, 'obj/buildtools/third_party/libc++abi')
   object_files_libcxx = get_object_files(base_path_libcxx, 'libc++.a')
   object_files_libcxxabi = get_object_files(base_path_libcxxabi, 'libc++abi.a')
   with zipfile.ZipFile(


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

- #39375 was a bit too aggressive in addressing the CL [4666325: Move buildtools/third_party/lib*/trunk source paths to third_party/lib*/src.](https://chromium-review.googlesource.com/c/chromium/src/+/4666325).  This PR fixes our libcxx zip tool to grab the generated files from the proper directory.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
