### PR TITLE
refactor: prefer Sorted variant of MakeFixedFlatSet()

### DIFF
--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -54,13 +54,14 @@ namespace {
 // See https://nodejs.org/api/cli.html#cli_options
 void ExitIfContainsDisallowedFlags(const std::vector<std::string>& argv) {
   // Options that are unilaterally disallowed.
-  static constexpr auto disallowed = base::MakeFixedFlatSet<base::StringPiece>({
-      "--enable-fips",
-      "--force-fips",
-      "--openssl-config",
-      "--use-bundled-ca",
-      "--use-openssl-ca",
-  });
+  static constexpr auto disallowed =
+      base::MakeFixedFlatSetSorted<base::StringPiece>({
+          "--enable-fips",
+          "--force-fips",
+          "--openssl-config",
+          "--use-bundled-ca",
+          "--use-openssl-ca",
+      });
 
   for (const auto& arg : argv) {
     const auto key = base::StringPiece(arg).substr(0, arg.find('='));

--- a/shell/browser/usb/electron_usb_delegate.cc
+++ b/shell/browser/usb/electron_usb_delegate.cc
@@ -45,7 +45,7 @@ electron::UsbChooserContext* GetChooserContext(
 // These extensions can claim the smart card USB class and automatically gain
 // permissions for devices that have an interface with this class.
 constexpr auto kSmartCardPrivilegedExtensionIds =
-    base::MakeFixedFlatSet<base::StringPiece>({
+    base::MakeFixedFlatSetSorted<base::StringPiece>({
         // Smart Card Connector Extension and its Beta version, see
         // crbug.com/1233881.
         "khpfeaanjngmcnplbdlpegiifgpfgdco",

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -232,7 +232,7 @@ void ErrorMessageListener(v8::Local<v8::Message> message,
 // If node CLI inspect support is disabled, allow no debug options.
 bool IsAllowedOption(base::StringPiece option) {
   static constexpr auto debug_options =
-      base::MakeFixedFlatSet<base::StringPiece>({
+      base::MakeFixedFlatSetSorted<base::StringPiece>({
           "--debug",
           "--debug-brk",
           "--debug-port",
@@ -244,13 +244,14 @@ bool IsAllowedOption(base::StringPiece option) {
       });
 
   // This should be aligned with what's possible to set via the process object.
-  static constexpr auto options = base::MakeFixedFlatSet<base::StringPiece>({
-      "--trace-warnings",
-      "--trace-deprecation",
-      "--throw-deprecation",
-      "--no-deprecation",
-      "--dns-result-order",
-  });
+  static constexpr auto options =
+      base::MakeFixedFlatSetSorted<base::StringPiece>({
+          "--dns-result-order",
+          "--no-deprecation",
+          "--throw-deprecation",
+          "--trace-deprecation",
+          "--trace-warnings",
+      });
 
   if (debug_options.contains(option))
     return electron::fuses::IsNodeCliInspectEnabled();
@@ -262,14 +263,21 @@ bool IsAllowedOption(base::StringPiece option) {
 // See https://nodejs.org/api/cli.html#cli_node_options_options
 void SetNodeOptions(base::Environment* env) {
   // Options that are unilaterally disallowed
-  static constexpr auto disallowed = base::MakeFixedFlatSet<base::StringPiece>(
-      {"--enable-fips", "--force-fips", "--openssl-config", "--use-bundled-ca",
-       "--use-openssl-ca", "--experimental-policy"});
+  static constexpr auto disallowed =
+      base::MakeFixedFlatSetSorted<base::StringPiece>({
+          "--enable-fips",
+          "--experimental-policy",
+          "--force-fips",
+          "--openssl-config",
+          "--use-bundled-ca",
+          "--use-openssl-ca",
+      });
 
-  static constexpr auto pkg_opts = base::MakeFixedFlatSet<base::StringPiece>({
-      "--http-parser",
-      "--max-http-header-size",
-  });
+  static constexpr auto pkg_opts =
+      base::MakeFixedFlatSetSorted<base::StringPiece>({
+          "--http-parser",
+          "--max-http-header-size",
+      });
 
   if (env->HasVar("NODE_OPTIONS")) {
     if (electron::fuses::IsNodeOptionsEnabled()) {


### PR DESCRIPTION
#### Description of Change

https://chromium-review.googlesource.com/c/chromium/src/+/4660000 says that the sorted version is simpler at compile time because it can skip MakeFixedFlatSet()'s compile-time dynamic sorting.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none