### PR TITLE
fix: dangling raw_ptr in ElectronBrowserMainParts dtor

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -204,11 +204,11 @@ ElectronBrowserMainParts* ElectronBrowserMainParts::self_ = nullptr;
 
 ElectronBrowserMainParts::ElectronBrowserMainParts()
     : fake_browser_process_(std::make_unique<BrowserProcessImpl>()),
-      browser_(std::make_unique<Browser>()),
-      node_bindings_(
-          NodeBindings::Create(NodeBindings::BrowserEnvironment::kBrowser)),
-      electron_bindings_(
-          std::make_unique<ElectronBindings>(node_bindings_->uv_loop())) {
+      node_bindings_{
+          NodeBindings::Create(NodeBindings::BrowserEnvironment::kBrowser)},
+      electron_bindings_{
+          std::make_unique<ElectronBindings>(node_bindings_->uv_loop())},
+      browser_{std::make_unique<Browser>()} {
   DCHECK(!self_) << "Cannot have two ElectronBrowserMainParts";
   self_ = this;
 }

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -157,7 +157,6 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   // Before then, we just exit() without any intermediate steps.
   absl::optional<int> exit_code_;
 
-  std::unique_ptr<Browser> browser_;
   std::unique_ptr<NodeBindings> node_bindings_;
 
   // depends-on: node_bindings_
@@ -166,8 +165,11 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   // depends-on: node_bindings_
   std::unique_ptr<JavascriptEnvironment> js_env_;
 
-  // depends-on: js_env_
+  // depends-on: js_env_'s isolate
   std::unique_ptr<NodeEnvironment> node_env_;
+
+  // depends-on: js_env_'s isolate
+  std::unique_ptr<Browser> browser_;
 
   std::unique_ptr<IconManager> icon_manager_;
   std::unique_ptr<base::FieldTrialList> field_trial_list_;

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -157,11 +157,18 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   // Before then, we just exit() without any intermediate steps.
   absl::optional<int> exit_code_;
 
-  std::unique_ptr<JavascriptEnvironment> js_env_;
   std::unique_ptr<Browser> browser_;
   std::unique_ptr<NodeBindings> node_bindings_;
+
+  // depends-on: node_bindings_
   std::unique_ptr<ElectronBindings> electron_bindings_;
+
+  // depends-on: node_bindings_
+  std::unique_ptr<JavascriptEnvironment> js_env_;
+
+  // depends-on: js_env_
   std::unique_ptr<NodeEnvironment> node_env_;
+
   std::unique_ptr<IconManager> icon_manager_;
   std::unique_ptr<base::FieldTrialList> field_trial_list_;
 


### PR DESCRIPTION
#### Description of Change

Another order-of-destruction issue similar to https://github.com/electron/electron/pull/39521.

```c++
class ElectronBrowserMainParts
{
    ....
    std::unique_ptr<JavascriptEnvironment> js_env_;
    std::unique_ptr<NodeBindings> node_bindings_;
    ....
};
````

`js_env_` holds a pointer to the uv loop owned by `node_bindings_`, so when `node_bindings_` is destroyed before `js_env_` in the EBMP destructor, `js_env_` is holding onto a dangling pointer when its destructor is called.

CC @deepak1556, @codebytere who reviewed 39521 and @VerteDinde for raw_ptr fun.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.