### PR TITLE
fix: assert module in the renderer process

### DIFF
--- a/patches/node/.patches
+++ b/patches/node/.patches
@@ -41,3 +41,4 @@ fix_ftbfs_werror_wextra-semi.patch
 fix_isurl_implementation.patch
 ci_ensure_node_tests_set_electron_run_as_node.patch
 chore_update_fixtures_errors_force_colors_snapshot.patch
+fix_assert_module_in_the_renderer_process.patch

--- a/patches/node/fix_assert_module_in_the_renderer_process.patch
+++ b/patches/node/fix_assert_module_in_the_renderer_process.patch
@@ -1,0 +1,75 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Wed, 16 Aug 2023 19:15:29 +0200
+Subject: fix: assert module in the renderer process
+
+When creating a Node.js Environment, embedders have the option to disable Node.js'
+default overriding of Error.prepareStackTrace. However, the assert module depends on
+a WeakMap that is populated with the error stacktraces in the overridden function.
+
+This adds handling to fall back to the default implementation if Error.prepareStackTrace
+if the override has been disabled.
+
+This will be upstreamed.
+
+diff --git a/lib/assert.js b/lib/assert.js
+index 04c2dd3bfcfdfbb4b8079c306e1d80aa48027787..34658819d09cc20f372798caec79e19c4a36565d 100644
+--- a/lib/assert.js
++++ b/lib/assert.js
+@@ -66,6 +66,7 @@ const { inspect } = require('internal/util/inspect');
+ const { isPromise, isRegExp } = require('internal/util/types');
+ const { EOL } = require('internal/constants');
+ const { BuiltinModule } = require('internal/bootstrap/loaders');
++const { getEmbedderOptions } = require('internal/options');
+ const { isError } = require('internal/util');
+ 
+ const errorCache = new SafeMap();
+@@ -293,8 +294,16 @@ function getErrMessage(message, fn) {
+   ErrorCaptureStackTrace(err, fn);
+   if (errorStackTraceLimitIsWritable) Error.stackTraceLimit = tmpLimit;
+ 
+-  overrideStackTrace.set(err, (_, stack) => stack);
+-  const call = err.stack[0];
++  let call;
++  if (getEmbedderOptions().hasPrepareStackTraceCallback) {
++    overrideStackTrace.set(err, (_, stack) => stack);
++    call = err.stack[0];
++  } else {
++    const tmpPrepare = Error.prepareStackTrace;
++    Error.prepareStackTrace = (_, stack) => stack;
++    call = err.stack[0];
++    Error.prepareStackTrace = tmpPrepare;
++  }
+ 
+   const filename = call.getFileName();
+   const line = call.getLineNumber() - 1;
+diff --git a/src/api/environment.cc b/src/api/environment.cc
+index d5a03d5e10faaa204b3f9f290fed79be824c78b1..c4caef25af670658965fc740ce03c2d2c4ed3e66 100644
+--- a/src/api/environment.cc
++++ b/src/api/environment.cc
+@@ -263,6 +263,9 @@ void SetIsolateErrorHandlers(v8::Isolate* isolate, const IsolateSettings& s) {
+     auto* prepare_stack_trace_cb = s.prepare_stack_trace_callback ?
+         s.prepare_stack_trace_callback : PrepareStackTraceCallback;
+     isolate->SetPrepareStackTraceCallback(prepare_stack_trace_cb);
++  } else {
++    auto env = Environment::GetCurrent(isolate);
++    env->set_prepare_stack_trace_callback(Local<Function>());
+   }
+ }
+ 
+diff --git a/src/node_options.cc b/src/node_options.cc
+index 499d048fcb82e50a302d74e2c7f87f3696103a40..7ad8d80faee840e4dd224d946871b2ff08b0c23c 100644
+--- a/src/node_options.cc
++++ b/src/node_options.cc
+@@ -1205,6 +1205,11 @@ void GetEmbedderOptions(const FunctionCallbackInfo<Value>& args) {
+   Local<Context> context = env->context();
+   Local<Object> ret = Object::New(isolate);
+ 
++  if (ret->Set(context,
++           FIXED_ONE_BYTE_STRING(env->isolate(), "hasPrepareStackTraceCallback"),
++           Boolean::New(isolate, !env->prepare_stack_trace_callback().IsEmpty()))
++      .IsNothing()) return;
++
+   if (ret->Set(context,
+            FIXED_ONE_BYTE_STRING(env->isolate(), "shouldNotRegisterESMLoader"),
+            Boolean::New(isolate, env->should_not_register_esm_loader()))


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/39079.

When creating a Node.js Environment, embedders have the option to disable Node.js' default overriding of `Error.prepareStackTrace`. However, the `assert` module depends on a WeakMap that is populated with the error stacktraces in the overridden function.

This adds handling to fall back to the default implementation if `Error.prepareStackTrace` if the override has been disabled.

This will be upstreamed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where the Node.js `assert` module did not work in the renderer process.