### PR TITLE
fix: explorer restart does not recreated thumbnail toolbar buttons

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -254,6 +254,10 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
 
   if (title_bar_style_ != TitleBarStyle::kNormal)
     set_has_frame(false);
+
+  // If the taskbar is re-created after we start up, we have to rebuild all of
+  // our buttons.
+  taskbar_created_message_ = RegisterWindowMessage(TEXT("TaskbarCreated"));
 #endif
 
   if (enable_larger_than_screen())

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -318,6 +318,10 @@ class NativeWindowViews : public NativeWindow,
   // Controls Overlay if enabled on Windows.
   SkColor overlay_button_color_;
   SkColor overlay_symbol_color_;
+
+  // The message ID of the "TaskbarCreated" message, sent to us when we need to
+  // reset our thumbar buttons.
+  UINT taskbar_created_message_ = 0;
 #endif
 
   // Handles unhandled keyboard messages coming back from the renderer process.

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -221,6 +221,12 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
     return true;
   }
 
+  if (message == taskbar_created_message_) {
+    // We need to reset all of our buttons because the taskbar went away.
+    taskbar_host_.RestoreThumbarButtons(GetAcceleratedWidget());
+    return true;
+  }
+
   switch (message) {
     // Screen readers send WM_GETOBJECT in order to get the accessibility
     // object, so take this opportunity to push Chromium into accessible


### PR DESCRIPTION
#### Description of Change
###### Problem
When explorer restarted, it didn't regenerate the thumbnail toolbar button, so the button was removed.
Also, `BrowserWindow.setThumbarButtons` prevented adding buttons because `TaskbarHost.thumbar_buttons_added_` was `true`.

###### Fixes
Restore thumbnail toolbar buttons when receiving "TaskbarCreated" message in `NativeWindowViews` class.
closes #39550

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: Fixed to regenerate thumbnail toolbar buttons when explorer is restarted.
