### PR TITLE
feat: enable WaylandWindowDecorations by default

### DIFF
--- a/shell/browser/native_window_features.cc
+++ b/shell/browser/native_window_features.cc
@@ -5,6 +5,6 @@
 #include "shell/browser/native_window_features.h"
 
 namespace features {
-const base::Feature kWaylandWindowDecorations{
-    "WaylandWindowDecorations", base::FEATURE_DISABLED_BY_DEFAULT};
+const base::Feature kWaylandWindowDecorations{"WaylandWindowDecorations",
+                                              base::FEATURE_ENABLED_BY_DEFAULT};
 }


### PR DESCRIPTION
#### Description of Change

Reasons to enable the feature by default:

* This feature flag only takes effect when the user opts into Wayland using one of the command line flags.
* When using a compositor that supports XDG Decoration protocol (KDE and Sway), then this flag has no effect.
* When using a compositor that doesn't support XDG Decoration protocol (GNOME and Weston), then this flag is necessary to have a functional window that can be moved and closed easily. This just adds more friction for users.
* The feature was introduced behind a flag about 18 months ago and there aren't any open issues specific to this feature.

cc-ing reviewers of the original PR @nornagon @zcbenz @ckerr 

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: no-notes