### PR TITLE
refactor: node::Environment self-cleanup

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -55,4 +55,4 @@ v8_builtins_profiling_log_file = ""
 
 # https://chromium.googlesource.com/chromium/src/+/main/docs/dangling_ptr.md
 # TODO(vertedinde): hunt down dangling pointers on Linux
-enable_dangling_raw_ptr_checks = false
+enable_dangling_raw_ptr_checks = true

--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -55,4 +55,4 @@ v8_builtins_profiling_log_file = ""
 
 # https://chromium.googlesource.com/chromium/src/+/main/docs/dangling_ptr.md
 # TODO(vertedinde): hunt down dangling pointers on Linux
-enable_dangling_raw_ptr_checks = true
+enable_dangling_raw_ptr_checks = false

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -266,26 +266,25 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
 
   node_bindings_->Initialize(js_env_->isolate()->GetCurrentContext());
   // Create the global environment.
-  auto env = node_bindings_->CreateEnvironment(
+  node_env_ = node_bindings_->CreateEnvironment(
       js_env_->isolate()->GetCurrentContext(), js_env_->platform());
-  node_env_ = env;
 
-  env->set_trace_sync_io(env->options()->trace_sync_io);
+  node_env_->set_trace_sync_io(node_env_->options()->trace_sync_io);
 
   // We do not want to crash the main process on unhandled rejections.
-  env->options()->unhandled_rejections = "warn-with-error-code";
+  node_env_->options()->unhandled_rejections = "warn-with-error-code";
 
   // Add Electron extended APIs.
-  electron_bindings_->BindTo(js_env_->isolate(), env->process_object());
+  electron_bindings_->BindTo(js_env_->isolate(), node_env_->process_object());
 
   // Create explicit microtasks runner.
   js_env_->CreateMicrotasksRunner();
 
   // Wrap the uv loop with global env.
-  node_bindings_->set_uv_env(env.get());
+  node_bindings_->set_uv_env(node_env_.get());
 
   // Load everything.
-  node_bindings_->LoadEnvironment(env.get());
+  node_bindings_->LoadEnvironment(node_env_.get());
 
   // We already initialized the feature list in PreEarlyInitialization(), but
   // the user JS script would not have had a chance to alter the command-line

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -37,6 +37,10 @@ class Screen;
 }
 #endif
 
+namespace node {
+class Environment;
+}
+
 namespace ui {
 class LinuxUiGetter;
 }
@@ -47,7 +51,6 @@ class Browser;
 class ElectronBindings;
 class JavascriptEnvironment;
 class NodeBindings;
-class NodeEnvironment;
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 class ElectronExtensionsClient;
@@ -166,7 +169,7 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   std::unique_ptr<JavascriptEnvironment> js_env_;
 
   // depends-on: js_env_'s isolate
-  std::unique_ptr<NodeEnvironment> node_env_;
+  std::shared_ptr<node::Environment> node_env_;
 
   // depends-on: js_env_'s isolate
   std::unique_ptr<Browser> browser_;

--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -340,12 +340,4 @@ void JavascriptEnvironment::DestroyMicrotasksRunner() {
   base::CurrentThread::Get()->RemoveTaskObserver(microtasks_runner_.get());
 }
 
-NodeEnvironment::NodeEnvironment(node::Environment* env) : env_(env) {}
-
-NodeEnvironment::~NodeEnvironment() {
-  auto* isolate_data = env_->isolate_data();
-  node::FreeEnvironment(env_);
-  node::FreeIsolateData(isolate_data);
-}
-
 }  // namespace electron

--- a/shell/browser/javascript_environment.h
+++ b/shell/browser/javascript_environment.h
@@ -9,7 +9,6 @@
 
 #include "base/memory/raw_ptr.h"
 #include "gin/public/isolate_holder.h"
-#include "shell/common/node_bindings.h"
 #include "uv.h"  // NOLINT(build/include_directory)
 #include "v8/include/v8-locker.h"
 

--- a/shell/browser/javascript_environment.h
+++ b/shell/browser/javascript_environment.h
@@ -9,6 +9,7 @@
 
 #include "base/memory/raw_ptr.h"
 #include "gin/public/isolate_holder.h"
+#include "shell/common/node_bindings.h"
 #include "uv.h"  // NOLINT(build/include_directory)
 #include "v8/include/v8-locker.h"
 
@@ -52,22 +53,6 @@ class JavascriptEnvironment {
   v8::Locker locker_;
 
   std::unique_ptr<MicrotasksRunner> microtasks_runner_;
-};
-
-// Manage the Node Environment automatically.
-class NodeEnvironment {
- public:
-  explicit NodeEnvironment(node::Environment* env);
-  ~NodeEnvironment();
-
-  // disable copy
-  NodeEnvironment(const NodeEnvironment&) = delete;
-  NodeEnvironment& operator=(const NodeEnvironment&) = delete;
-
-  node::Environment* env() { return env_; }
-
- private:
-  raw_ptr<node::Environment> env_;
 };
 
 }  // namespace electron

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_COMMON_NODE_BINDINGS_H_
 #define ELECTRON_SHELL_COMMON_NODE_BINDINGS_H_
 
+#include <memory>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -95,12 +96,15 @@ class NodeBindings {
   std::vector<std::string> ParseNodeCliFlags();
 
   // Create the environment and load node.js.
-  node::Environment* CreateEnvironment(v8::Handle<v8::Context> context,
-                                       node::MultiIsolatePlatform* platform,
-                                       std::vector<std::string> args,
-                                       std::vector<std::string> exec_args);
-  node::Environment* CreateEnvironment(v8::Handle<v8::Context> context,
-                                       node::MultiIsolatePlatform* platform);
+  std::shared_ptr<node::Environment> CreateEnvironment(
+      v8::Handle<v8::Context> context,
+      node::MultiIsolatePlatform* platform,
+      std::vector<std::string> args,
+      std::vector<std::string> exec_args);
+
+  std::shared_ptr<node::Environment> CreateEnvironment(
+      v8::Handle<v8::Context> context,
+      node::MultiIsolatePlatform* platform);
 
   // Load node.js in the environment.
   void LoadEnvironment(node::Environment* env);

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -26,12 +26,6 @@ class SingleThreadTaskRunner;
 
 namespace electron {
 
-// Choose a reasonable unique index that's higher than any Blink uses
-// and thus unlikely to collide with an existing index.
-static constexpr int kElectronContextEmbedderDataIndex =
-    static_cast<int>(gin::kPerContextDataStartIndex) +
-    static_cast<int>(gin::kEmbedderElectron);
-
 // A helper class to manage uv_handle_t types, e.g. uv_async_t.
 //
 // As per the uv docs: "uv_close() MUST be called on each handle before
@@ -115,12 +109,6 @@ class NodeBindings {
   // Notify embed thread to start polling after environment is loaded.
   void StartPolling();
 
-  // Clears the PerIsolateData.
-  void clear_isolate_data(v8::Local<v8::Context> context) {
-    context->SetAlignedPointerInEmbedderData(kElectronContextEmbedderDataIndex,
-                                             nullptr);
-  }
-
   node::IsolateData* isolate_data(v8::Local<v8::Context> context) const {
     if (context->GetNumberOfEmbedderDataFields() <=
         kElectronContextEmbedderDataIndex) {
@@ -171,6 +159,12 @@ class NodeBindings {
   raw_ptr<uv_loop_t> uv_loop_;
 
  private:
+  // Choose a reasonable unique index that's higher than any Blink uses
+  // and thus unlikely to collide with an existing index.
+  static constexpr int kElectronContextEmbedderDataIndex =
+      static_cast<int>(gin::kPerContextDataStartIndex) +
+      static_cast<int>(gin::kEmbedderElectron);
+
   // Thread to poll uv events.
   static void EmbedThreadRunner(void* arg);
 

--- a/shell/renderer/electron_renderer_client.h
+++ b/shell/renderer/electron_renderer_client.h
@@ -55,7 +55,7 @@ class ElectronRendererClient : public RendererClientBase {
   // The node::Environment::GetCurrent API does not return nullptr when it
   // is called for a context without node::Environment, so we have to keep
   // a book of the environments created.
-  std::set<node::Environment*> environments_;
+  std::set<std::shared_ptr<node::Environment>> environments_;
 
   // Getting main script context from web frame would lazily initializes
   // its script context. Doing so in a web page without scripts would trigger

--- a/shell/renderer/web_worker_observer.h
+++ b/shell/renderer/web_worker_observer.h
@@ -6,6 +6,7 @@
 #define ELECTRON_SHELL_RENDERER_WEB_WORKER_OBSERVER_H_
 
 #include <memory>
+#include <set>
 
 #include "v8/include/v8.h"
 
@@ -39,8 +40,8 @@ class WebWorkerObserver {
   void ContextWillDestroy(v8::Local<v8::Context> context);
 
  private:
-  const std::unique_ptr<NodeBindings> node_bindings_;
-  const std::unique_ptr<ElectronBindings> electron_bindings_;
+  std::unique_ptr<NodeBindings> node_bindings_;
+  std::unique_ptr<ElectronBindings> electron_bindings_;
   std::set<std::shared_ptr<node::Environment>> environments_;
 };
 

--- a/shell/renderer/web_worker_observer.h
+++ b/shell/renderer/web_worker_observer.h
@@ -9,6 +9,12 @@
 
 #include "v8/include/v8.h"
 
+namespace node {
+
+class Environment;
+
+}  // namespace node
+
 namespace electron {
 
 class ElectronBindings;
@@ -33,8 +39,9 @@ class WebWorkerObserver {
   void ContextWillDestroy(v8::Local<v8::Context> context);
 
  private:
-  std::unique_ptr<NodeBindings> node_bindings_;
-  std::unique_ptr<ElectronBindings> electron_bindings_;
+  const std::unique_ptr<NodeBindings> node_bindings_;
+  const std::unique_ptr<ElectronBindings> electron_bindings_;
+  std::set<std::shared_ptr<node::Environment>> environments_;
 };
 
 }  // namespace electron

--- a/shell/services/node/node_service.h
+++ b/shell/services/node/node_service.h
@@ -11,12 +11,17 @@
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "shell/services/node/public/mojom/node_service.mojom.h"
 
+namespace node {
+
+class Environment;
+
+}  // namespace node
+
 namespace electron {
 
 class ElectronBindings;
 class JavascriptEnvironment;
 class NodeBindings;
-class NodeEnvironment;
 
 class NodeService : public node::mojom::NodeService {
  public:
@@ -35,7 +40,7 @@ class NodeService : public node::mojom::NodeService {
   std::unique_ptr<JavascriptEnvironment> js_env_;
   std::unique_ptr<NodeBindings> node_bindings_;
   std::unique_ptr<ElectronBindings> electron_bindings_;
-  std::unique_ptr<NodeEnvironment> node_env_;
+  std::shared_ptr<node::Environment> node_env_;
   mojo::Receiver<node::mojom::NodeService> receiver_{this};
 };
 


### PR DESCRIPTION
#### Description of Change

- `NodeBindings::CreateEnvironment()` now returns a `std::shared_ptr<node::Environment>` instead of a raw pointer. The new shared pointer has a custom deleter that knows how to cleanup both the `node::Environment` and its `node::IsolateData`.
- Remove duplicated cleanup code from `ElectronRenderClient`, `WebWorkerObserver`, and `NodeEnvironment`, which all had code similar to the new deleter.
- Removed now-unused class `NodeEnvironment`.
- side refactor: since only NodeBindings uses `kElectronContextEmbedderDataIndex`, make it a private field.

The initial motivation for this PR was to fix a dangling `raw_ptr` bug in `NodeEnvironment`; but when investigating the code, it looks like there's an opportunity to reduce coupling across the above classes and remove some code duplication.

**note:** I'd particularly like revewer :eyes: on the changes in `NodeBindings.cc`, e.g. is the `v8::Context` being handled correctly when it's passed to the deleter lambda?

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.