### PR TITLE
fix: ensure windows respect fullscreenability with different resizability values

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -834,23 +834,19 @@ void NativeWindowMac::SetResizable(bool resizable) {
   ScopedDisableResize disable_resize;
   SetStyleMask(resizable, NSWindowStyleMaskResizable);
 
+  bool was_fullscreenable = IsFullScreenable();
+
   // Right now, resizable and fullscreenable are decoupled in
   // documentation and on Windows/Linux. Chromium disables
-  // fullscreenability if resizability is false on macOS as well
-  // as disabling the maximize traffic light unless the window
-  // is both resizable and maximizable. To work around this, we want
-  // to match behavior on other platforms by disabiliting the maximize
-  // button but keeping fullscreenability enabled.
-  // TODO(codebytere): refactor this once we have a better solution.
+  // fullscreen collection behavior as well as the maximize traffic
+  // light in SetCanResize if resizability is false on macOS unless
+  // the window is both resizable and maximizable. We want consistent
+  // cross-platform behavior, so if resizability is disabled we disable
+  // the maximize button and ensure fullscreenability matches user setting.
   SetCanResize(resizable);
-  if (!resizable) {
-    SetFullScreenable(true);
-    [[window_ standardWindowButton:NSWindowZoomButton] setEnabled:false];
-  } else {
-    SetFullScreenable(true);
-    [[window_ standardWindowButton:NSWindowZoomButton]
-        setEnabled:IsFullScreenable()];
-  }
+  SetFullScreenable(was_fullscreenable);
+  [[window_ standardWindowButton:NSWindowZoomButton]
+      setEnabled:resizable ? was_fullscreenable : false];
 }
 
 bool NativeWindowMac::IsResizable() {

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5432,6 +5432,26 @@ describe('BrowserWindow module', () => {
         expect(child.fullScreen).to.be.false('fullscreen');
         expect(child.fullScreenable).to.be.false('fullscreenable');
       });
+
+      it('is set correctly with different resizable values', async () => {
+        const w1 = new BrowserWindow({
+          resizable: false,
+          fullscreenable: false
+        });
+
+        const w2 = new BrowserWindow({
+          resizable: true,
+          fullscreenable: false
+        });
+
+        const w3 = new BrowserWindow({
+          fullscreenable: false
+        });
+
+        expect(w1.isFullScreenable()).to.be.false('isFullScreenable');
+        expect(w2.isFullScreenable()).to.be.false('isFullScreenable');
+        expect(w3.isFullScreenable()).to.be.false('isFullScreenable');
+      });
     });
 
     ifdescribe(process.platform === 'darwin')('isHiddenInMissionControl state', () => {

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5416,6 +5416,22 @@ describe('BrowserWindow module', () => {
           expect(w.isFullScreenable()).to.be.true('isFullScreenable');
         });
       });
+
+      it('does not open non-fullscreenable child windows in fullscreen if parent is fullscreen', async () => {
+        const w = new BrowserWindow();
+
+        const enterFS = once(w, 'enter-full-screen');
+        w.setFullScreen(true);
+        await enterFS;
+
+        const child = new BrowserWindow({ parent: w, resizable: false, fullscreenable: false });
+        const shown = once(child, 'show');
+        await shown;
+
+        expect(child.resizable).to.be.false('resizable');
+        expect(child.fullScreen).to.be.false('fullscreen');
+        expect(child.fullScreenable).to.be.false('fullscreenable');
+      });
     });
 
     ifdescribe(process.platform === 'darwin')('isHiddenInMissionControl state', () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/39614
Closes https://github.com/electron/electron/issues/39630.

Fixes an issue where child windows opened when the parent window is _already fullscreen_ did not respect the child windows' fullscreenability and resizability settings.

Confirmed not to regress https://github.com/electron/electron/issues/39077.

Tested with https://gist.github.com/pushkin-/3b4bcdb219eee85789e95f6d94ec8a92

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where child windows opened when the parent window is _already fullscreen_ did not respect the child windows' fullscreenability and resizability settings.
