### PR TITLE
feat: expose app accessibility transparency settings api

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -401,7 +401,7 @@ Returns an object with system animation settings.
 
 ### `systemPreferences.accessibilityDisplayShouldReduceTransparency()` _macOS_
 
-Returns `boolean` - whether the app avoids using semitransparent backgrounds.
+Returns `boolean` - whether the app avoids using semitransparent backgrounds, maps to [NSWorkspace.accessibilityDisplayShouldReduceTransparency](https://developer.apple.com/documentation/appkit/nsworkspace/1533006-accessibilitydisplayshouldreduce)
 
 ## Properties
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -399,7 +399,7 @@ Returns `Object`:
 
 Returns an object with system animation settings.
 
-### `systemPreferences.accessabilityDisplayShouldReduceTransparency()` _macOS_
+### `systemPreferences.accessibilityDisplayShouldReduceTransparency()` _macOS_
 
 Returns `boolean` - whether the app avoids using semitransparent backgrounds.
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -399,15 +399,11 @@ Returns `Object`:
 
 Returns an object with system animation settings.
 
-### `systemPreferences.getAccessibilityDisplayShouldReduceTransparency()` _macOS_
-
-Returns `boolean` - Returns whether the app avoids using semitransparent backgrounds. This maps to [NSWorkspace.accessibilityDisplayShouldReduceTransparency](https://developer.apple.com/documentation/appkit/nsworkspace/1533006-accessibilitydisplayshouldreduce)
-
 ## Properties
 
 ### `systemPreferences.accessibilityDisplayShouldReduceTransparency()` _macOS_
 
-A `boolean` property. It determines whether the app avoids using semitransparent backgrounds. This maps to [NSWorkspace.accessibilityDisplayShouldReduceTransparency](https://developer.apple.com/documentation/appkit/nsworkspace/1533006-accessibilitydisplayshouldreduce)
+A `boolean` property which determines whether the app avoids using semitransparent backgrounds. This maps to [NSWorkspace.accessibilityDisplayShouldReduceTransparency](https://developer.apple.com/documentation/appkit/nsworkspace/1533006-accessibilitydisplayshouldreduce)
 
 ### `systemPreferences.effectiveAppearance` _macOS_ _Readonly_
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -399,6 +399,10 @@ Returns `Object`:
 
 Returns an object with system animation settings.
 
+### `systemPreferences.accessabilityDisplayShouldReduceTransparency()` _macOS_
+
+Returns `boolean` - whether the app avoids using semitransparent backgrounds.
+
 ## Properties
 
 ### `systemPreferences.effectiveAppearance` _macOS_ _Readonly_

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -399,11 +399,15 @@ Returns `Object`:
 
 Returns an object with system animation settings.
 
-### `systemPreferences.accessibilityDisplayShouldReduceTransparency()` _macOS_
+### `systemPreferences.getAccessibilityDisplayShouldReduceTransparency()` _macOS_
 
-Returns `boolean` - whether the app avoids using semitransparent backgrounds, maps to [NSWorkspace.accessibilityDisplayShouldReduceTransparency](https://developer.apple.com/documentation/appkit/nsworkspace/1533006-accessibilitydisplayshouldreduce)
+Returns `boolean` - Returns whether the app avoids using semitransparent backgrounds. This maps to [NSWorkspace.accessibilityDisplayShouldReduceTransparency](https://developer.apple.com/documentation/appkit/nsworkspace/1533006-accessibilitydisplayshouldreduce)
 
 ## Properties
+
+### `systemPreferences.accessibilityDisplayShouldReduceTransparency()` _macOS_
+
+A `boolean` property. It determines whether the app avoids using semitransparent backgrounds. This maps to [NSWorkspace.accessibilityDisplayShouldReduceTransparency](https://developer.apple.com/documentation/appkit/nsworkspace/1533006-accessibilitydisplayshouldreduce)
 
 ### `systemPreferences.effectiveAppearance` _macOS_ _Readonly_
 

--- a/shell/browser/api/electron_api_system_preferences.cc
+++ b/shell/browser/api/electron_api_system_preferences.cc
@@ -96,8 +96,11 @@ gin::ObjectTemplateBuilder SystemPreferences::GetObjectTemplateBuilder(
                  &SystemPreferences::IsTrustedAccessibilityClient)
       .SetMethod("askForMediaAccess", &SystemPreferences::AskForMediaAccess)
       .SetMethod(
+          "getAccessibilityDisplayShouldReduceTransparency",
+          &SystemPreferences::getAccessibilityDisplayShouldReduceTransparency)
+      .SetProperty(
           "accessibilityDisplayShouldReduceTransparency",
-          &SystemPreferences::AccessibilityDisplayShouldReduceTransparency)
+          &SystemPreferences::getAccessibilityDisplayShouldReduceTransparency)
 #endif
       .SetMethod("getAnimationSettings",
                  &SystemPreferences::GetAnimationSettings);

--- a/shell/browser/api/electron_api_system_preferences.cc
+++ b/shell/browser/api/electron_api_system_preferences.cc
@@ -95,6 +95,9 @@ gin::ObjectTemplateBuilder SystemPreferences::GetObjectTemplateBuilder(
       .SetMethod("isTrustedAccessibilityClient",
                  &SystemPreferences::IsTrustedAccessibilityClient)
       .SetMethod("askForMediaAccess", &SystemPreferences::AskForMediaAccess)
+      .SetMethod(
+          "accessibilityDisplayShouldReduceTransparency",
+          &SystemPreferences::AccessibilityDisplayShouldReduceTransparency)
 #endif
       .SetMethod("getAnimationSettings",
                  &SystemPreferences::GetAnimationSettings);

--- a/shell/browser/api/electron_api_system_preferences.cc
+++ b/shell/browser/api/electron_api_system_preferences.cc
@@ -95,12 +95,9 @@ gin::ObjectTemplateBuilder SystemPreferences::GetObjectTemplateBuilder(
       .SetMethod("isTrustedAccessibilityClient",
                  &SystemPreferences::IsTrustedAccessibilityClient)
       .SetMethod("askForMediaAccess", &SystemPreferences::AskForMediaAccess)
-      .SetMethod(
-          "getAccessibilityDisplayShouldReduceTransparency",
-          &SystemPreferences::getAccessibilityDisplayShouldReduceTransparency)
       .SetProperty(
           "accessibilityDisplayShouldReduceTransparency",
-          &SystemPreferences::getAccessibilityDisplayShouldReduceTransparency)
+          &SystemPreferences::GetAccessibilityDisplayShouldReduceTransparency)
 #endif
       .SetMethod("getAnimationSettings",
                  &SystemPreferences::GetAnimationSettings);

--- a/shell/browser/api/electron_api_system_preferences.cc
+++ b/shell/browser/api/electron_api_system_preferences.cc
@@ -97,7 +97,7 @@ gin::ObjectTemplateBuilder SystemPreferences::GetObjectTemplateBuilder(
       .SetMethod("askForMediaAccess", &SystemPreferences::AskForMediaAccess)
       .SetProperty(
           "accessibilityDisplayShouldReduceTransparency",
-          &SystemPreferences::GetAccessibilityDisplayShouldReduceTransparency)
+          &SystemPreferences::AccessibilityDisplayShouldReduceTransparency)
 #endif
       .SetMethod("getAnimationSettings",
                  &SystemPreferences::GetAnimationSettings);

--- a/shell/browser/api/electron_api_system_preferences.h
+++ b/shell/browser/api/electron_api_system_preferences.h
@@ -96,6 +96,7 @@ class SystemPreferences
                       gin::Arguments* args);
   void RemoveUserDefault(const std::string& name);
   bool IsSwipeTrackingFromScrollEventsEnabled();
+  bool AccessibilityDisplayShouldReduceTransparency();
 
   std::string GetSystemColor(gin_helper::ErrorThrower thrower,
                              const std::string& color);

--- a/shell/browser/api/electron_api_system_preferences.h
+++ b/shell/browser/api/electron_api_system_preferences.h
@@ -96,7 +96,7 @@ class SystemPreferences
                       gin::Arguments* args);
   void RemoveUserDefault(const std::string& name);
   bool IsSwipeTrackingFromScrollEventsEnabled();
-  bool AccessibilityDisplayShouldReduceTransparency();
+  bool GetAccessibilityDisplayShouldReduceTransparency();
 
   std::string GetSystemColor(gin_helper::ErrorThrower thrower,
                              const std::string& color);

--- a/shell/browser/api/electron_api_system_preferences.h
+++ b/shell/browser/api/electron_api_system_preferences.h
@@ -96,7 +96,7 @@ class SystemPreferences
                       gin::Arguments* args);
   void RemoveUserDefault(const std::string& name);
   bool IsSwipeTrackingFromScrollEventsEnabled();
-  bool GetAccessibilityDisplayShouldReduceTransparency();
+  bool AccessibilityDisplayShouldReduceTransparency();
 
   std::string GetSystemColor(gin_helper::ErrorThrower thrower,
                              const std::string& color);

--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -598,4 +598,9 @@ v8::Local<v8::Value> SystemPreferences::GetEffectiveAppearance(
       isolate, [NSApplication sharedApplication].effectiveAppearance);
 }
 
+bool SystemPreferences::AccessibilityDisplayShouldReduceTransparency() {
+  return [[NSWorkspace sharedWorkspace]
+      accessibilityDisplayShouldReduceTransparency];
+}
+
 }  // namespace electron::api

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -382,8 +382,6 @@ if (process.platform === 'darwin') {
   // @ts-expect-error Removed API
   systemPreferences.setAppLevelAppearance('dark');
   // @ts-expect-error Removed API
-  console.log(systemPreferences.appLevelAppearance);
-  // @ts-expect-error Removed API
   console.log(systemPreferences.getColor('alternate-selected-control-text'));
 }
 


### PR DESCRIPTION
#### Description of Change

Exposes an [api](https://developer.apple.com/documentation/appkit/nsworkspace/1533006-accessibilitydisplayshouldreduce) that reads the System Preferences to determine whether the app avoids using semitransparent backgrounds. If the property is  TRUE, don't use use semitransparent backgrounds in the UI.

This setting can be changed by choosing System Preferences > Accessibility > Display and selecting "Reduce transparency".

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Exposed an API to allow apps to determine whether to avoid using semitransparent backgrounds.
