### PR TITLE
ci: use new GitHub App for issue triage related actions

### DIFF
--- a/.github/workflows/branch-created.yml
+++ b/.github/workflows/branch-created.yml
@@ -60,16 +60,15 @@ jobs:
           done
       - name: Generate GitHub App token
         if: ${{ steps.check-major-version.outputs.MAJOR }}
+        uses: electron/github-app-auth-action@cc6751b3b5e4edc5b9a4ad0a021ac455653b6dc8 # v1.0.0
         id: generate-token
-        env:
-          RELEASE_BOARD_GH_APP_CREDS: ${{ secrets.RELEASE_BOARD_GH_APP_CREDS }}
-        run: |
-          TOKEN=$(npx @electron/github-app-auth --creds=$RELEASE_BOARD_GH_APP_CREDS --org=electron)
-          echo "TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
+        with:
+          creds: ${{ secrets.RELEASE_BOARD_GH_APP_CREDS }}
+          org: electron
       - name: Create Release Project Board
         if: ${{ steps.check-major-version.outputs.MAJOR }}
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           MAJOR: ${{ steps.check-major-version.outputs.MAJOR }}
           ELECTRON_ORG_ID: "O_kgDOAMybxg"
           ELECTRON_REPO_ID: "R_kgDOAI8xSw"

--- a/.github/workflows/issue-commented.yml
+++ b/.github/workflows/issue-commented.yml
@@ -5,20 +5,22 @@ on:
     types:
       - created
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   issue-commented:
     name: Remove blocked/need-repro on comment
     if: ${{ contains(github.event.issue.labels.*.name, 'blocked/need-repro') && !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association) }}
-    permissions:
-      issues: write
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        uses: electron/github-app-auth-action@cc6751b3b5e4edc5b9a4ad0a021ac455653b6dc8 # v1.0.0
+        id: generate-token
+        with:
+          creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
       - name: Remove label
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
         run: |
           gh issue edit $ISSUE_URL --remove-label 'blocked/need-repro'

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -14,18 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token
+        uses: electron/github-app-auth-action@cc6751b3b5e4edc5b9a4ad0a021ac455653b6dc8 # v1.0.0
         id: generate-token
-        env:
-          RELEASE_BOARD_GH_APP_CREDS: ${{ secrets.RELEASE_BOARD_GH_APP_CREDS }}
-        run: |
-          set -eo pipefail
-          TOKEN=$(npx @electron/github-app-auth --creds=$RELEASE_BOARD_GH_APP_CREDS --org=electron)
-          echo "TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
+        with:
+          creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
+          org: electron
       - name: Set status
-        if: ${{ steps.generate-token.outputs.TOKEN }}
         uses: github/update-project-action@2d475e08804f11f4022df7e21f5816531e97cb64 # v2
         with:
-          github_token: ${{ steps.generate-token.outputs.TOKEN }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           organization: electron
           project_number: 90
           content_id: ${{ github.event.issue.node_id }}
@@ -49,11 +46,18 @@ jobs:
           if [[ $COMMENT_COUNT -eq 0 ]]; then
             echo "SHOULD_COMMENT=1" >> "$GITHUB_OUTPUT"
           fi
+      - name: Generate GitHub App token
+        if: ${{ steps.check-for-comment.outputs.SHOULD_COMMENT }}
+        uses: electron/github-app-auth-action@cc6751b3b5e4edc5b9a4ad0a021ac455653b6dc8 # v1.0.0
+        id: generate-token
+        with:
+          creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
       - name: Create comment
         if: ${{ steps.check-for-comment.outputs.SHOULD_COMMENT }}
         uses: actions-cool/issues-helper@275328970dbc3bfc3bc43f5fe741bf3638300c0a # v3.3.3
         with:
           actions: 'create-comment'
+          token: ${{ steps.generate-token.outputs.token }}
           body: |
             <!-- blocked/need-repro -->
 

--- a/.github/workflows/issue-unlabeled.yml
+++ b/.github/workflows/issue-unlabeled.yml
@@ -23,18 +23,16 @@ jobs:
           fi
       - name: Generate GitHub App token
         if: ${{ steps.check-for-blocked-labels.outputs.NOT_BLOCKED }}
+        uses: electron/github-app-auth-action@cc6751b3b5e4edc5b9a4ad0a021ac455653b6dc8 # v1.0.0
         id: generate-token
-        env:
-          RELEASE_BOARD_GH_APP_CREDS: ${{ secrets.RELEASE_BOARD_GH_APP_CREDS }}
-        run: |
-          set -eo pipefail
-          TOKEN=$(npx @electron/github-app-auth --creds=$RELEASE_BOARD_GH_APP_CREDS --org=electron)
-          echo "TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
+        with:
+          creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
+          org: electron
       - name: Set status
-        if: ${{ steps.generate-token.outputs.TOKEN }}
+        if: ${{ steps.check-for-blocked-labels.outputs.NOT_BLOCKED }}
         uses: github/update-project-action@2d475e08804f11f4022df7e21f5816531e97cb64 # v2
         with:
-          github_token: ${{ steps.generate-token.outputs.TOKEN }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           organization: electron
           project_number: 90
           content_id: ${{ github.event.issue.node_id }}

--- a/.github/workflows/pull-request-labeled.yml
+++ b/.github/workflows/pull-request-labeled.yml
@@ -14,18 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token
+        uses: electron/github-app-auth-action@cc6751b3b5e4edc5b9a4ad0a021ac455653b6dc8 # v1.0.0
         id: generate-token
-        env:
-          RELEASE_BOARD_GH_APP_CREDS: ${{ secrets.RELEASE_BOARD_GH_APP_CREDS }}
-        run: |
-          set -eo pipefail
-          TOKEN=$(npx @electron/github-app-auth --creds=$RELEASE_BOARD_GH_APP_CREDS --org=electron)
-          echo "TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
+        with:
+          creds: ${{ secrets.RELEASE_BOARD_GH_APP_CREDS }}
+          org: electron
       - name: Set status
-        if: ${{ steps.generate-token.outputs.TOKEN }}
         uses: dsanders11/update-project-action@7ade91760df70df76770a238abee7a4869e01cf8
         with:
-          github_token: ${{ steps.generate-token.outputs.TOKEN }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           organization: electron
           project_number: 94
           content_id: ${{ github.event.pull_request.node_id }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,15 +5,20 @@ on:
     # 1:30am every day
     - cron: '30 1 * * *'
 
-permissions:
-  issues: write
+permissions: {}
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        uses: electron/github-app-auth-action@cc6751b3b5e4edc5b9a4ad0a021ac455653b6dc8 # v1.0.0
+        id: generate-token
+        with:
+          creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
       - uses: actions/stale@5ebf00ea0e4c1561e9b43a292ed34424fb1d4578 # tag: v6.0.1
         with:
+          repo-token: ${{ steps.generate-token.outputs.token }}
           days-before-stale: 90
           days-before-close: 30
           stale-issue-label: stale
@@ -29,8 +34,14 @@ jobs:
     if: ${{ always() }}
     needs: stale
     steps:
+      - name: Generate GitHub App token
+        uses: electron/github-app-auth-action@cc6751b3b5e4edc5b9a4ad0a021ac455653b6dc8 # v1.0.0
+        id: generate-token
+        with:
+          creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
       - uses: actions/stale@5ebf00ea0e4c1561e9b43a292ed34424fb1d4578 # tag: v6.0.1
         with:
+          repo-token: ${{ steps.generate-token.outputs.token }}
           days-before-stale: -1
           days-before-close: 10
           remove-stale-when-updated: false


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

The main motivation here is that actions taken by the default `github-actions` bot will not trigger other workflows. This caused some of the automation added in #39464 (which intended to change the status of an issue on the issue triage project when an issue is unlabeled) not to work since the label being removed was done by `github-actions` so the other workflow was not triggered.

For consistency I've changed all issue triage actions to be done by the same GitHub App, which will make it easier to do things like search or checking in other automation, and will let us provide a bit of a more polished UX instead of having it all coming from `github-actions`.

This PR also updates all token generation from using `npx @electron/github-app-auth` to using the new `electron/github-app-auth-action`.

The GitHub App has already been created and `ISSUE_TRIAGE_GH_APP_CREDS` has been populated, thanks to @VerteDinde. 👍 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
