### PR TITLE
docs: Quick Start | Electron Forge chapter requirements updated

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -459,9 +459,11 @@ To summarize all the steps we've done:
 The fastest way to distribute your newly created app is using
 [Electron Forge](https://www.electronforge.io).
 
-As prerequire, you must have installed rpm.
-- For Linux (Debian-based) : `sudo apt install rpm`
-- For other OS : Follow the official instructions depending your system
+:::info
+
+To build an RPM package for Linux, you will need to [install its required system dependencies](https://www.electronforge.io/config/makers/rpm).
+
+:::
 
 1. Add a description to your `package.json` file, otherwise rpmbuild will fail. Blank description are not valid.
 2. Add Electron Forge as a development dependency of your app, and use its `import` command to set up

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -459,6 +459,10 @@ To summarize all the steps we've done:
 The fastest way to distribute your newly created app is using
 [Electron Forge](https://www.electronforge.io).
 
+As prerequire, you must have installed rpm.
+- For Linux (Debian-based) : `sudo apt install rpm`
+- For other OS : Follow the official instructions depending your system
+
 1. Add Electron Forge as a development dependency of your app, and use its `import` command to set up
 Forge's scaffolding:
 

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -463,7 +463,8 @@ As prerequire, you must have installed rpm.
 - For Linux (Debian-based) : `sudo apt install rpm`
 - For other OS : Follow the official instructions depending your system
 
-1. Add Electron Forge as a development dependency of your app, and use its `import` command to set up
+1. Add a description to your `package.json` file, otherwise rpmbuild will fail. Blank description are not valid.
+2. Add Electron Forge as a development dependency of your app, and use its `import` command to set up
 Forge's scaffolding:
 
    ```sh npm2yarn
@@ -482,7 +483,7 @@ Forge's scaffolding:
    Thanks for using "electron-forge"!!!
    ```
 
-2. Create a distributable using Forge's `make` command:
+3. Create a distributable using Forge's `make` command:
 
    ```sh npm2yarn
    npm run make


### PR DESCRIPTION
#### Description of Change

Added 2 points for the deploiement chapter with Electron Forge.
These 2 points are required, else the rpmbuild will fail.
- install rpm (it was not mentionned in the doc)
- add a non-blank description to the package.json file of your project

#### Checklist
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added

Notes: none