### PR TITLE
chore: cherry-pick 4 changes from Release-1-M116

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -3,3 +3,4 @@ cherry-pick-285c7712c506.patch
 cherry-pick-2bf945775fe6.patch
 cherry-pick-cafe56b591ed.patch
 cherry-pick-5486190be556.patch
+cherry-pick-e4669a74888d.patch

--- a/patches/angle/cherry-pick-e4669a74888d.patch
+++ b/patches/angle/cherry-pick-e4669a74888d.patch
@@ -1,0 +1,396 @@
+From e4669a74888d7f9bd93d79f72829d576776dfb8a Mon Sep 17 00:00:00 2001
+From: Charlie Lao <cclao@google.com>
+Date: Tue, 08 Aug 2023 10:14:47 -0700
+Subject: [PATCH] [M114-LTS] Vulkan: Fix data race with DynamicDescriptorPool
+
+Right now DynamicDescriptorPool::destroyCachedDescriptorSet can be
+called from garbage clean up thread, while simultaneously accessed from
+context main thread, and data race will happen and cause bugs. This can
+only happen when the buffer is not being suballocated. In this case,
+suballocation owns the bufferBlock and bufferBlock gets destroyed when
+suballocation is destroyed from garbage collection thread. If buffer is
+suballocated, the shared group owns pool which owns bufferBlocks and
+they gets destroyed from shared group with the share group lock. This CL
+avoids this race problem by release the shared cacheKey when the buffer
+is released, while we still had the shared group lock.
+
+Bug: chromium:1469542
+Change-Id: Ie6235fcfb77dee2a12b2ebde44042c3845fc0aca
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/4790523
+(cherry picked from commit b48983ab8c74d2fcd9ef17c80727affb9e690c53)
+---
+
+diff --git a/src/libANGLE/renderer/vulkan/BufferVk.cpp b/src/libANGLE/renderer/vulkan/BufferVk.cpp
+index 2e07deb..93a1092 100644
+--- a/src/libANGLE/renderer/vulkan/BufferVk.cpp
++++ b/src/libANGLE/renderer/vulkan/BufferVk.cpp
+@@ -305,7 +305,7 @@
+     RendererVk *renderer = contextVk->getRenderer();
+     if (mBuffer.valid())
+     {
+-        mBuffer.releaseBufferAndDescriptorSetCache(contextVk);
++        mBuffer.releaseBufferAndDescriptorSetCache(renderer);
+     }
+     if (mStagingBuffer.valid())
+     {
+@@ -623,7 +623,7 @@
+         memcpy(dstMapPtr, srcMapPtr, static_cast<size_t>(mState.getSize()));
+     }
+ 
+-    src.releaseBufferAndDescriptorSetCache(contextVk);
++    src.releaseBufferAndDescriptorSetCache(contextVk->getRenderer());
+ 
+     // Return the already mapped pointer with the offset adjustment to avoid the call to unmap().
+     *mapPtr = dstMapPtr + offset;
+@@ -1029,7 +1029,7 @@
+ 
+     if (prevBuffer.valid())
+     {
+-        prevBuffer.releaseBufferAndDescriptorSetCache(contextVk);
++        prevBuffer.releaseBufferAndDescriptorSetCache(contextVk->getRenderer());
+     }
+ 
+     return angle::Result::Continue;
+@@ -1151,7 +1151,7 @@
+ 
+     if (mBuffer.valid())
+     {
+-        mBuffer.releaseBufferAndDescriptorSetCache(contextVk);
++        mBuffer.releaseBufferAndDescriptorSetCache(renderer);
+     }
+ 
+     // Allocate the buffer directly
+diff --git a/src/libANGLE/renderer/vulkan/Suballocation.h b/src/libANGLE/renderer/vulkan/Suballocation.h
+index d25481b..276f6b4 100644
+--- a/src/libANGLE/renderer/vulkan/Suballocation.h
++++ b/src/libANGLE/renderer/vulkan/Suballocation.h
+@@ -86,6 +86,13 @@
+     {
+         mDescriptorSetCacheManager.addKey(sharedCacheKey);
+     }
++    void releaseAllCachedDescriptorSetCacheKeys(RendererVk *renderer)
++    {
++        if (!mDescriptorSetCacheManager.empty())
++        {
++            mDescriptorSetCacheManager.releaseKeys(renderer);
++        }
++    }
+ 
+   private:
+     mutable std::mutex mVirtualBlockMutex;
+diff --git a/src/libANGLE/renderer/vulkan/TextureVk.cpp b/src/libANGLE/renderer/vulkan/TextureVk.cpp
+index d43c172..5e6419f 100644
+--- a/src/libANGLE/renderer/vulkan/TextureVk.cpp
++++ b/src/libANGLE/renderer/vulkan/TextureVk.cpp
+@@ -1623,7 +1623,7 @@
+         onStateChange(angle::SubjectMessage::SubjectChanged);
+     }
+     mRedefinedLevels.reset();
+-    mDescriptorSetCacheManager.releaseKeys(contextVk);
++    mDescriptorSetCacheManager.releaseKeys(contextVk->getRenderer());
+ }
+ 
+ void TextureVk::initImageUsageFlags(ContextVk *contextVk, angle::FormatID actualFormatID)
+@@ -2857,7 +2857,7 @@
+ 
+         mBufferViews.release(contextVk);
+         mBufferViews.init(renderer, offset, size);
+-        mDescriptorSetCacheManager.releaseKeys(contextVk);
++        mDescriptorSetCacheManager.releaseKeys(renderer);
+         return angle::Result::Continue;
+     }
+ 
+@@ -3300,7 +3300,7 @@
+ {
+     RendererVk *renderer = contextVk->getRenderer();
+ 
+-    mDescriptorSetCacheManager.releaseKeys(contextVk);
++    mDescriptorSetCacheManager.releaseKeys(renderer);
+ 
+     if (mImage == nullptr)
+     {
+diff --git a/src/libANGLE/renderer/vulkan/vk_cache_utils.cpp b/src/libANGLE/renderer/vulkan/vk_cache_utils.cpp
+index f750428..ae86b29 100644
+--- a/src/libANGLE/renderer/vulkan/vk_cache_utils.cpp
++++ b/src/libANGLE/renderer/vulkan/vk_cache_utils.cpp
+@@ -2589,11 +2589,19 @@
+ {
+     contextVk->getShareGroup()->getFramebufferCache().erase(contextVk, desc);
+ }
++void ReleaseCachedObject(RendererVk *renderer, const FramebufferDesc &desc)
++{
++    UNREACHABLE();
++}
+ 
+ void ReleaseCachedObject(ContextVk *contextVk, const DescriptorSetDescAndPool &descAndPool)
+ {
++    UNREACHABLE();
++}
++void ReleaseCachedObject(RendererVk *renderer, const DescriptorSetDescAndPool &descAndPool)
++{
+     ASSERT(descAndPool.mPool != nullptr);
+-    descAndPool.mPool->releaseCachedDescriptorSet(contextVk, descAndPool.mDesc);
++    descAndPool.mPool->releaseCachedDescriptorSet(renderer, descAndPool.mDesc);
+ }
+ 
+ void DestroyCachedObject(RendererVk *renderer, const FramebufferDesc &desc)
+@@ -6261,6 +6269,22 @@
+ }
+ 
+ template <class SharedCacheKeyT>
++void SharedCacheKeyManager<SharedCacheKeyT>::releaseKeys(RendererVk *renderer)
++{
++    for (SharedCacheKeyT &sharedCacheKey : mSharedCacheKeys)
++    {
++        if (*sharedCacheKey.get() != nullptr)
++        {
++            // Immediate destroy the cached object and the key itself when first releaseKeys call is
++            // made
++            ReleaseCachedObject(renderer, *(*sharedCacheKey.get()));
++            *sharedCacheKey.get() = nullptr;
++        }
++    }
++    mSharedCacheKeys.clear();
++}
++
++template <class SharedCacheKeyT>
+ void SharedCacheKeyManager<SharedCacheKeyT>::destroyKeys(RendererVk *renderer)
+ {
+     for (SharedCacheKeyT &sharedCacheKey : mSharedCacheKeys)
+diff --git a/src/libANGLE/renderer/vulkan/vk_cache_utils.h b/src/libANGLE/renderer/vulkan/vk_cache_utils.h
+index 8c9d452..f85459a 100644
+--- a/src/libANGLE/renderer/vulkan/vk_cache_utils.h
++++ b/src/libANGLE/renderer/vulkan/vk_cache_utils.h
+@@ -1932,6 +1932,7 @@
+     void addKey(const SharedCacheKeyT &key);
+     // Iterate over the descriptor array and release the descriptor and cache.
+     void releaseKeys(ContextVk *contextVk);
++    void releaseKeys(RendererVk *rendererVk);
+     // Iterate over the descriptor array and destroy the descriptor and cache.
+     void destroyKeys(RendererVk *renderer);
+     void clear();
+diff --git a/src/libANGLE/renderer/vulkan/vk_helpers.cpp b/src/libANGLE/renderer/vulkan/vk_helpers.cpp
+index 9088e09bf..8bc027d 100644
+--- a/src/libANGLE/renderer/vulkan/vk_helpers.cpp
++++ b/src/libANGLE/renderer/vulkan/vk_helpers.cpp
+@@ -3798,7 +3798,7 @@
+     return mDescriptorPools[mCurrentPoolIndex]->get().init(context, mPoolSizes, mMaxSetsPerPool);
+ }
+ 
+-void DynamicDescriptorPool::releaseCachedDescriptorSet(ContextVk *contextVk,
++void DynamicDescriptorPool::releaseCachedDescriptorSet(RendererVk *renderer,
+                                                        const DescriptorSetDesc &desc)
+ {
+     VkDescriptorSet descriptorSet;
+@@ -3812,7 +3812,7 @@
+         // Wrap it with helper object so that it can be GPU tracked and add it to resource list.
+         DescriptorSetHelper descriptorSetHelper(poolOut->get().getResourceUse(), descriptorSet);
+         poolOut->get().addGarbage(std::move(descriptorSetHelper));
+-        checkAndReleaseUnusedPool(contextVk->getRenderer(), poolOut);
++        checkAndReleaseUnusedPool(renderer, poolOut);
+     }
+ }
+ 
+@@ -5016,6 +5016,12 @@
+ 
+     if (mSuballocation.valid())
+     {
++        if (!mSuballocation.isSuballocated())
++        {
++            // Destroy cacheKeys now to avoid getting into situation that having to destroy
++            // descriptorSet from garbage collection thread.
++            mSuballocation.getBufferBlock()->releaseAllCachedDescriptorSetCacheKeys(renderer);
++        }
+         renderer->collectSuballocationGarbage(mUse, std::move(mSuballocation),
+                                               std::move(mBufferForVertexArray));
+     }
+@@ -5024,17 +5030,15 @@
+     ASSERT(!mBufferForVertexArray.valid());
+ }
+ 
+-void BufferHelper::releaseBufferAndDescriptorSetCache(ContextVk *contextVk)
++void BufferHelper::releaseBufferAndDescriptorSetCache(RendererVk *renderer)
+ {
+-    RendererVk *renderer = contextVk->getRenderer();
+-
+     if (renderer->hasResourceUseFinished(getResourceUse()))
+     {
+         mDescriptorSetCacheManager.destroyKeys(renderer);
+     }
+     else
+     {
+-        mDescriptorSetCacheManager.releaseKeys(contextVk);
++        mDescriptorSetCacheManager.releaseKeys(renderer);
+     }
+ 
+     release(renderer);
+diff --git a/src/libANGLE/renderer/vulkan/vk_helpers.h b/src/libANGLE/renderer/vulkan/vk_helpers.h
+index d2405b6..962dfe8 100644
+--- a/src/libANGLE/renderer/vulkan/vk_helpers.h
++++ b/src/libANGLE/renderer/vulkan/vk_helpers.h
+@@ -252,7 +252,7 @@
+                                              VkDescriptorSet *descriptorSetOut,
+                                              SharedDescriptorSetCacheKey *sharedCacheKeyOut);
+ 
+-    void releaseCachedDescriptorSet(ContextVk *contextVk, const DescriptorSetDesc &desc);
++    void releaseCachedDescriptorSet(RendererVk *renderer, const DescriptorSetDesc &desc);
+     void destroyCachedDescriptorSet(RendererVk *renderer, const DescriptorSetDesc &desc);
+ 
+     template <typename Accumulator>
+@@ -777,7 +777,7 @@
+ 
+     void destroy(RendererVk *renderer);
+     void release(RendererVk *renderer);
+-    void releaseBufferAndDescriptorSetCache(ContextVk *contextVk);
++    void releaseBufferAndDescriptorSetCache(RendererVk *renderer);
+ 
+     BufferSerial getBufferSerial() const { return mSerial; }
+     BufferSerial getBlockSerial() const
+diff --git a/src/tests/gl_tests/TransformFeedbackTest.cpp b/src/tests/gl_tests/TransformFeedbackTest.cpp
+index ea3eeea..226eb1f 100644
+--- a/src/tests/gl_tests/TransformFeedbackTest.cpp
++++ b/src/tests/gl_tests/TransformFeedbackTest.cpp
+@@ -507,8 +507,8 @@
+ 
+     const std::array<uint32_t, 12> kInitialData = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+     const std::array<uint32_t, 12> kUpdateData  = {
+-         0x12345678u, 0x9ABCDEF0u, 0x13579BDFu, 0x2468ACE0u, 0x23456781u, 0xABCDEF09u,
+-         0x3579BDF1u, 0x468ACE02u, 0x34567812u, 0xBCDEF09Au, 0x579BDF13u, 0x68ACE024u,
++        0x12345678u, 0x9ABCDEF0u, 0x13579BDFu, 0x2468ACE0u, 0x23456781u, 0xABCDEF09u,
++        0x3579BDF1u, 0x468ACE02u, 0x34567812u, 0xBCDEF09Au, 0x579BDF13u, 0x68ACE024u,
+     };
+ 
+     GLBuffer buffer;
+@@ -3749,9 +3749,9 @@
+     constexpr size_t kCapturedVaryingsCount = 3;
+     constexpr std::array<size_t, kCapturedVaryingsCount> kCaptureSizes = {8, 9, 4};
+     const std::vector<float> kExpected[kCapturedVaryingsCount]         = {
+-                {0.27, 0.30, 0.33, 0.36, 0.39, 0.42, 0.45, 0.48},
+-                {0.63, 0.66, 0.69, 0.72, 0.75, 0.78, 0.81, 0.84, 0.87},
+-                {0.25, 0.5, 0.75, 1.0},
++        {0.27, 0.30, 0.33, 0.36, 0.39, 0.42, 0.45, 0.48},
++        {0.63, 0.66, 0.69, 0.72, 0.75, 0.78, 0.81, 0.84, 0.87},
++        {0.25, 0.5, 0.75, 1.0},
+     };
+ 
+     ANGLE_GL_PROGRAM_TRANSFORM_FEEDBACK(program, kVS, kFS, tfVaryings, GL_INTERLEAVED_ATTRIBS);
+@@ -3848,9 +3848,9 @@
+     constexpr size_t kCapturedVaryingsCount                            = 3;
+     constexpr std::array<size_t, kCapturedVaryingsCount> kCaptureSizes = {1, 2, 1};
+     const std::vector<float> kExpected[kCapturedVaryingsCount]         = {
+-                {0.25},
+-                {0.5, 0.75},
+-                {1.0},
++        {0.25},
++        {0.5, 0.75},
++        {1.0},
+     };
+ 
+     ANGLE_GL_PROGRAM_TRANSFORM_FEEDBACK(program, kVS, kFS, tfVaryings, GL_SEPARATE_ATTRIBS);
+@@ -4392,6 +4392,51 @@
+     glEndTransformFeedback();
+ }
+ 
++// Test bufferData call and transform feedback.
++TEST_P(TransformFeedbackTest, BufferDataAndTransformFeedback)
++{
++    const char kVS[] = R"(#version 300 es
++flat out highp int var;
++void main() {
++var = 1;
++})";
++
++    const char kFS[] = R"(#version 300 es
++flat in highp int var;
++out highp int color;
++void main() {
++color = var;
++})";
++
++    ANGLE_GL_PROGRAM(program, kVS, kFS);
++
++    GLTexture texture;
++    glBindTexture(GL_TEXTURE_2D, texture);
++    glTexStorage2D(GL_TEXTURE_2D, 1, GL_R32I, 1, 1);
++
++    GLFramebuffer fbo;
++    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
++    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
++    EXPECT_GL_FRAMEBUFFER_COMPLETE(GL_FRAMEBUFFER);
++
++    constexpr int kClearColor[] = {123, 0, 0, 0};
++    glClearBufferiv(GL_COLOR, 0, kClearColor);
++    glDrawArrays(GL_POINTS, 0, 1);
++
++    const char *kVarying = "var";
++    glTransformFeedbackVaryings(program, 1, &kVarying, GL_INTERLEAVED_ATTRIBS);
++    glLinkProgram(program);
++    ASSERT_GL_NO_ERROR();
++
++    GLBuffer buffer;
++    glBindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, 0, buffer);
++    glBufferData(GL_TRANSFORM_FEEDBACK_BUFFER, 0x7ffc * 10000, nullptr, GL_DYNAMIC_READ);
++    glBeginTransformFeedback(GL_POINTS);
++    glDrawArrays(GL_POINTS, 0, 1);
++    glEndTransformFeedback();
++    glFlush();
++}
++
+ GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(TransformFeedbackTest);
+ ANGLE_INSTANTIATE_TEST_ES3_AND(TransformFeedbackTest,
+                                ES3_VULKAN()
+diff --git a/src/tests/gl_tests/UniformBufferTest.cpp b/src/tests/gl_tests/UniformBufferTest.cpp
+index 4d005c0..71b8504 100644
+--- a/src/tests/gl_tests/UniformBufferTest.cpp
++++ b/src/tests/gl_tests/UniformBufferTest.cpp
+@@ -3422,6 +3422,50 @@
+     EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
+ }
+ 
++// Calling BufferData and use it in a loop to force descriptorSet creation and destroy.
++TEST_P(UniformBufferTest, BufferDataInLoop)
++{
++    glClear(GL_COLOR_BUFFER_BIT);
++
++    // Use large buffer size to get around suballocation, so that we will gets a new buffer with
++    // bufferData call.
++    static constexpr size_t kBufferSize = 4 * 1024 * 1024;
++    std::vector<float> floatData;
++    floatData.resize(kBufferSize / (sizeof(float)), 0.0f);
++    floatData[0] = 0.5f;
++    floatData[1] = 0.75f;
++    floatData[2] = 0.25f;
++    floatData[3] = 1.0f;
++
++    GLTexture textures[2];
++    GLFramebuffer fbos[2];
++    for (int i = 0; i < 2; i++)
++    {
++        glBindTexture(GL_TEXTURE_2D, textures[i]);
++        glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, 256, 256);
++
++        glBindFramebuffer(GL_FRAMEBUFFER, fbos[i]);
++        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textures[i], 0);
++        EXPECT_GL_FRAMEBUFFER_COMPLETE(GL_FRAMEBUFFER);
++    }
++
++    for (int loop = 0; loop < 10; loop++)
++    {
++        int i = loop & 0x1;
++        // Switch FBO to get around deferred flush
++        glBindFramebuffer(GL_FRAMEBUFFER, fbos[i]);
++        glBindBuffer(GL_UNIFORM_BUFFER, mUniformBuffer);
++        glBufferData(GL_UNIFORM_BUFFER, kBufferSize, floatData.data(), GL_STATIC_DRAW);
++
++        glBindBufferBase(GL_UNIFORM_BUFFER, 0, mUniformBuffer);
++        glUniformBlockBinding(mProgram, mUniformBufferIndex, 0);
++        drawQuad(mProgram, essl3_shaders::PositionAttrib(), 0.5f);
++        glFlush();
++    }
++    ASSERT_GL_NO_ERROR();
++    EXPECT_PIXEL_NEAR(0, 0, 128, 191, 64, 255, 1);
++}
++
+ class WebGL2UniformBufferTest : public UniformBufferTest
+ {
+   protected:

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -134,3 +134,5 @@ cherry-pick-abb3ebd3d2ef.patch
 cherry-pick-83b0bdb696d8.patch
 cherry-pick-e40cb330b645.patch
 networkcontext_don_t_access_url_loader_factories_during_destruction.patch
+cherry-pick-1939f7b78eda.patch
+cherry-pick-37447eb52a74.patch

--- a/patches/chromium/cherry-pick-1939f7b78eda.patch
+++ b/patches/chromium/cherry-pick-1939f7b78eda.patch
@@ -1,7 +1,7 @@
-From 1939f7b78edaf058782203f32df820f17010ba25 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Rune Lillesveen <futhark@chromium.org>
 Date: Thu, 24 Aug 2023 10:53:36 +0000
-Subject: [PATCH] [M114-LTS] Don't keep pointer to popped stack memory for :has()
+Subject: Don't keep pointer to popped stack memory for :has()
 
 The sibling_features pass into UpdateFeaturesFromCombinator may be
 initialized to last_compound_in_adjacent_chain_features if null. The
@@ -25,13 +25,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4777251
 Cr-Commit-Position: refs/branch-heads/5845@{#1482}
 Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
 (cherry picked from commit 34e544e4dedf299211f104a2822d98ce1db80f61)
----
 
 diff --git a/third_party/blink/renderer/core/css/rule_feature_set.cc b/third_party/blink/renderer/core/css/rule_feature_set.cc
-index 8ca157a..0c0c5b8 100644
+index 8ca157a45433988b9d339f1d3c6b6aa091e1e9a5..0c0c5b8e633f42f10e0fd692e59f0427d8481590 100644
 --- a/third_party/blink/renderer/core/css/rule_feature_set.cc
 +++ b/third_party/blink/renderer/core/css/rule_feature_set.cc
-@@ -1325,6 +1325,7 @@
+@@ -1325,6 +1325,7 @@ void RuleFeatureSet::AddFeaturesToInvalidationSetsForLogicalCombinationInHas(
          descendant_features);
  
      const CSSSelector* compound_in_logical_combination = complex;
@@ -39,7 +38,7 @@ index 8ca157a..0c0c5b8 100644
      InvalidationSetFeatures last_compound_in_adjacent_chain_features;
      while (compound_in_logical_combination) {
        AddFeaturesToInvalidationSetsForLogicalCombinationInHasContext context(
-@@ -1336,14 +1337,14 @@
+@@ -1336,14 +1337,14 @@ void RuleFeatureSet::AddFeaturesToInvalidationSetsForLogicalCombinationInHas(
          last_in_compound =
              SkipAddingAndGetLastInCompoundForLogicalCombinationInHas(
                  compound_in_logical_combination, compound_containing_has,
@@ -58,7 +57,7 @@ index 8ca157a..0c0c5b8 100644
        }
  
        if (!last_in_compound) {
-@@ -1358,7 +1359,7 @@
+@@ -1358,7 +1359,7 @@ void RuleFeatureSet::AddFeaturesToInvalidationSetsForLogicalCombinationInHas(
                  ? CSSSelector::kIndirectAdjacent
                  : previous_combinator,
              context.last_compound_in_adjacent_chain,
@@ -69,7 +68,7 @@ index 8ca157a..0c0c5b8 100644
  
 diff --git a/third_party/blink/web_tests/external/wpt/css/selectors/has-sibling-chrome-crash.html b/third_party/blink/web_tests/external/wpt/css/selectors/has-sibling-chrome-crash.html
 new file mode 100644
-index 0000000..0306e3e
+index 0000000000000000000000000000000000000000..0306e3e39272c321fc3539aa582b4e239ffe2fa1
 --- /dev/null
 +++ b/third_party/blink/web_tests/external/wpt/css/selectors/has-sibling-chrome-crash.html
 @@ -0,0 +1,10 @@

--- a/patches/chromium/cherry-pick-1939f7b78eda.patch
+++ b/patches/chromium/cherry-pick-1939f7b78eda.patch
@@ -1,0 +1,85 @@
+From 1939f7b78edaf058782203f32df820f17010ba25 Mon Sep 17 00:00:00 2001
+From: Rune Lillesveen <futhark@chromium.org>
+Date: Thu, 24 Aug 2023 10:53:36 +0000
+Subject: [PATCH] [M114-LTS] Don't keep pointer to popped stack memory for :has()
+
+The sibling_features pass into UpdateFeaturesFromCombinator may be
+initialized to last_compound_in_adjacent_chain_features if null. The
+outer while loop in
+AddFeaturesToInvalidationSetsForLogicalCombinationInHas() could then
+reference to the last_compound_in_adjacent_chain_features which is
+popped from the stack on every outer iteration. That caused an ASAN
+failure for reading stack memory that had been popped.
+
+Instead make sure each inner iteration restarts with the same
+sibling_features pointer, which seems to have been the intent here.
+
+(cherry picked from commit 5e213507a2f0d6e3c96904a710407b01493670bd)
+
+Bug: 1470477
+Change-Id: I260c93016f8ab0d165e4b29ca1aea810bede5b97
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4759326
+Commit-Queue: Rune Lillesveen <futhark@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1181365}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4777251
+Cr-Commit-Position: refs/branch-heads/5845@{#1482}
+Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
+(cherry picked from commit 34e544e4dedf299211f104a2822d98ce1db80f61)
+---
+
+diff --git a/third_party/blink/renderer/core/css/rule_feature_set.cc b/third_party/blink/renderer/core/css/rule_feature_set.cc
+index 8ca157a..0c0c5b8 100644
+--- a/third_party/blink/renderer/core/css/rule_feature_set.cc
++++ b/third_party/blink/renderer/core/css/rule_feature_set.cc
+@@ -1325,6 +1325,7 @@
+         descendant_features);
+ 
+     const CSSSelector* compound_in_logical_combination = complex;
++    InvalidationSetFeatures* inner_sibling_features = sibling_features;
+     InvalidationSetFeatures last_compound_in_adjacent_chain_features;
+     while (compound_in_logical_combination) {
+       AddFeaturesToInvalidationSetsForLogicalCombinationInHasContext context(
+@@ -1336,14 +1337,14 @@
+         last_in_compound =
+             SkipAddingAndGetLastInCompoundForLogicalCombinationInHas(
+                 compound_in_logical_combination, compound_containing_has,
+-                sibling_features, descendant_features, previous_combinator,
+-                add_features_method);
++                inner_sibling_features, descendant_features,
++                previous_combinator, add_features_method);
+       } else {
+         last_in_compound =
+             AddFeaturesAndGetLastInCompoundForLogicalCombinationInHas(
+                 compound_in_logical_combination, compound_containing_has,
+-                sibling_features, descendant_features, previous_combinator,
+-                add_features_method);
++                inner_sibling_features, descendant_features,
++                previous_combinator, add_features_method);
+       }
+ 
+       if (!last_in_compound) {
+@@ -1358,7 +1359,7 @@
+                 ? CSSSelector::kIndirectAdjacent
+                 : previous_combinator,
+             context.last_compound_in_adjacent_chain,
+-            last_compound_in_adjacent_chain_features, sibling_features,
++            last_compound_in_adjacent_chain_features, inner_sibling_features,
+             descendant_features);
+       }
+ 
+diff --git a/third_party/blink/web_tests/external/wpt/css/selectors/has-sibling-chrome-crash.html b/third_party/blink/web_tests/external/wpt/css/selectors/has-sibling-chrome-crash.html
+new file mode 100644
+index 0000000..0306e3e
+--- /dev/null
++++ b/third_party/blink/web_tests/external/wpt/css/selectors/has-sibling-chrome-crash.html
+@@ -0,0 +1,10 @@
++<!DOCTYPE html>
++<title>CSS Selectors Test: Chrome crash issue 1470477</title>
++<link rel="help" href="https://crbug.com/1470477">
++<style>
++  :has(> :where(label:first-child + [a="a"]:only-of-type,
++    [a="a"]:only-of-type + label:last-child)) label:last-child {
++      margin-inline: 1em;
++  }
++</style>
++<p>PASS if this tests does not crash</p>

--- a/patches/chromium/cherry-pick-37447eb52a74.patch
+++ b/patches/chromium/cherry-pick-37447eb52a74.patch
@@ -1,7 +1,7 @@
-From 37447eb52a7431195ca73f6d808363048b4a984b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tsuyoshi Horo <horo@chromium.org>
 Date: Thu, 24 Aug 2023 10:50:31 +0000
-Subject: [PATCH] [M114-LTS] Fix ExtensionLocalizationThrottle::WillProcessResponse
+Subject: Fix ExtensionLocalizationThrottle::WillProcessResponse
 
 Synchronous call of `delegate_->CancelWithError()` inside
 blink::URLLoaderThrottle::WillProcessResponse() in Blink can cause UAF.
@@ -22,13 +22,12 @@ Auto-Submit: Tsuyoshi Horo <horo@chromium.org>
 Cr-Commit-Position: refs/branch-heads/5845@{#1471}
 Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
 (cherry picked from commit 28759f24f051b5e79b2ae75f4f39ff63e5607119)
----
 
 diff --git a/extensions/renderer/extension_localization_throttle.cc b/extensions/renderer/extension_localization_throttle.cc
-index d045667..382283c 100644
+index d0456671b7eea52ac6cd7aa89c4b39d5661112f3..382283cea8a8a061f769dc234b67ef8b53b47517 100644
 --- a/extensions/renderer/extension_localization_throttle.cc
 +++ b/extensions/renderer/extension_localization_throttle.cc
-@@ -217,7 +217,14 @@
+@@ -217,7 +217,14 @@ void ExtensionLocalizationThrottle::WillProcessResponse(
        mojo::CreateDataPipe(/*options=*/nullptr, producer_handle, body);
  
    if (create_pipe_result != MOJO_RESULT_OK || force_error_for_test_) {
@@ -44,7 +43,7 @@ index d045667..382283c 100644
      return;
    }
  
-@@ -248,4 +255,10 @@
+@@ -248,4 +255,10 @@ void ExtensionLocalizationThrottle::WillProcessResponse(
                         std::move(producer_handle));
  }
  
@@ -56,10 +55,10 @@ index d045667..382283c 100644
 +
  }  // namespace extensions
 diff --git a/extensions/renderer/extension_localization_throttle.h b/extensions/renderer/extension_localization_throttle.h
-index b697247..69805be 100644
+index b697247caff1af060411b5c2786698266acab269..69805be5db7c9aded2192bc9e190a513cd0481e8 100644
 --- a/extensions/renderer/extension_localization_throttle.h
 +++ b/extensions/renderer/extension_localization_throttle.h
-@@ -39,8 +39,10 @@
+@@ -39,8 +39,10 @@ class ExtensionLocalizationThrottle : public blink::URLLoaderThrottle {
  
   private:
    ExtensionLocalizationThrottle();
@@ -71,10 +70,10 @@ index b697247..69805be 100644
  
  }  // namespace extensions
 diff --git a/extensions/renderer/extension_localization_throttle_unittest.cc b/extensions/renderer/extension_localization_throttle_unittest.cc
-index ef6ec9c..7324023 100644
+index ef6ec9cf84361e08db824757899e73af4e3c9d84..732402366b697e3e982fe5feb3d25cb2e726abdd 100644
 --- a/extensions/renderer/extension_localization_throttle_unittest.cc
 +++ b/extensions/renderer/extension_localization_throttle_unittest.cc
-@@ -382,8 +382,12 @@
+@@ -382,8 +382,12 @@ TEST_F(ExtensionLocalizationThrottleTest, CreateDataPipeError) {
    response_head->mime_type = "text/css";
    bool defer = false;
    throttle->WillProcessResponse(url, response_head.get(), &defer);

--- a/patches/chromium/cherry-pick-37447eb52a74.patch
+++ b/patches/chromium/cherry-pick-37447eb52a74.patch
@@ -1,0 +1,90 @@
+From 37447eb52a7431195ca73f6d808363048b4a984b Mon Sep 17 00:00:00 2001
+From: Tsuyoshi Horo <horo@chromium.org>
+Date: Thu, 24 Aug 2023 10:50:31 +0000
+Subject: [PATCH] [M114-LTS] Fix ExtensionLocalizationThrottle::WillProcessResponse
+
+Synchronous call of `delegate_->CancelWithError()` inside
+blink::URLLoaderThrottle::WillProcessResponse() in Blink can cause UAF.
+To fix this, this CL change ExtensionLocalizationThrottle::
+WillProcessResponse() to set `defer` to true, and asynchronously call
+`delegate_->CancelWithError()`.
+
+(cherry picked from commit 6bb386bf2a6462eb2a33100833d564a2fd0f8225)
+
+Bug: 1469754
+Change-Id: Ic129ba4b39a9c1ab00eb6609db824b065296e66d
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4751579
+Commit-Queue: Tsuyoshi Horo <horo@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1180638}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4777752
+Commit-Queue: David Bertoni <dbertoni@chromium.org>
+Auto-Submit: Tsuyoshi Horo <horo@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5845@{#1471}
+Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
+(cherry picked from commit 28759f24f051b5e79b2ae75f4f39ff63e5607119)
+---
+
+diff --git a/extensions/renderer/extension_localization_throttle.cc b/extensions/renderer/extension_localization_throttle.cc
+index d045667..382283c 100644
+--- a/extensions/renderer/extension_localization_throttle.cc
++++ b/extensions/renderer/extension_localization_throttle.cc
+@@ -217,7 +217,14 @@
+       mojo::CreateDataPipe(/*options=*/nullptr, producer_handle, body);
+ 
+   if (create_pipe_result != MOJO_RESULT_OK || force_error_for_test_) {
+-    delegate_->CancelWithError(net::ERR_INSUFFICIENT_RESOURCES, kCancelReason);
++    // Synchronous call of `delegate_->CancelWithError` can cause a UAF error.
++    // So defer the request here.
++    *defer = true;
++    base::SingleThreadTaskRunner::GetCurrentDefault()->PostTask(
++        FROM_HERE,
++        base::BindOnce(base::BindOnce(
++            &ExtensionLocalizationThrottle::DeferredCancelWithError,
++            weak_factory_.GetWeakPtr(), net::ERR_INSUFFICIENT_RESOURCES)));
+     return;
+   }
+ 
+@@ -248,4 +255,10 @@
+                        std::move(producer_handle));
+ }
+ 
++void ExtensionLocalizationThrottle::DeferredCancelWithError(int error_code) {
++  if (delegate_) {
++    delegate_->CancelWithError(error_code, kCancelReason);
++  }
++}
++
+ }  // namespace extensions
+diff --git a/extensions/renderer/extension_localization_throttle.h b/extensions/renderer/extension_localization_throttle.h
+index b697247..69805be 100644
+--- a/extensions/renderer/extension_localization_throttle.h
++++ b/extensions/renderer/extension_localization_throttle.h
+@@ -39,8 +39,10 @@
+ 
+  private:
+   ExtensionLocalizationThrottle();
++  void DeferredCancelWithError(int error_code);
+ 
+   bool force_error_for_test_ = false;
++  base::WeakPtrFactory<ExtensionLocalizationThrottle> weak_factory_{this};
+ };
+ 
+ }  // namespace extensions
+diff --git a/extensions/renderer/extension_localization_throttle_unittest.cc b/extensions/renderer/extension_localization_throttle_unittest.cc
+index ef6ec9c..7324023 100644
+--- a/extensions/renderer/extension_localization_throttle_unittest.cc
++++ b/extensions/renderer/extension_localization_throttle_unittest.cc
+@@ -382,8 +382,12 @@
+   response_head->mime_type = "text/css";
+   bool defer = false;
+   throttle->WillProcessResponse(url, response_head.get(), &defer);
+-  EXPECT_FALSE(defer);
++  EXPECT_TRUE(defer);
+   EXPECT_FALSE(delegate->is_intercepted());
++  EXPECT_FALSE(delegate->cancel_error_code());
++
++  // Run loop to call DeferredCancelWithError().
++  base::RunLoop().RunUntilIdle();
+ 
+   ASSERT_TRUE(delegate->cancel_error_code());
+   EXPECT_EQ(net::ERR_INSUFFICIENT_RESOURCES, *delegate->cancel_error_code());

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -10,3 +10,4 @@ force_cppheapcreateparams_to_be_noncopyable.patch
 chore_allow_customizing_microtask_policy_per_context.patch
 fix_set_proper_instruction_start_for_builtin.patch
 cherry-pick-8ff63d378f2c.patch
+merged_squashed_multiple_commits.patch

--- a/patches/v8/merged_squashed_multiple_commits.patch
+++ b/patches/v8/merged_squashed_multiple_commits.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Samuel=20Gro=C3=9F?= <saelo@chromium.org>
+Date: Thu, 17 Aug 2023 09:10:19 +0000
+Subject: Merged: Squashed multiple commits.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Merged: [runtime] Recreate enum cache on map update
+Revision: 1c623f9ff6e077be1c66f155485ea4005ddb6574
+
+Merged: [runtime] Don't try to create empty enum cache.
+Revision: 5516e06237c9f0013121f47319e8c253c896d52d
+
+BUG=chromium:1470668,chromium:1472317
+R=tebbi@chromium.org
+
+Change-Id: I31d5491aba663661ba68bb55631747a195ed084e
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4788990
+Commit-Queue: Samuel Groß <saelo@chromium.org>
+Reviewed-by: Tobias Tebbi <tebbi@chromium.org>
+Cr-Commit-Position: refs/branch-heads/11.6@{#32}
+Cr-Branched-From: e29c028f391389a7a60ee37097e3ca9e396d6fa4-refs/heads/11.6.189@{#3}
+Cr-Branched-From: 95cbef20e2aa556a1ea75431a48b36c4de6b9934-refs/heads/main@{#88340}
+
+diff --git a/src/objects/map-updater.cc b/src/objects/map-updater.cc
+index bc7c3f5c3d6352cad8f82c0fbc9be3f5ee6b6b7e..723df19907b9642d99922e2e99171ef45260bafd 100644
+--- a/src/objects/map-updater.cc
++++ b/src/objects/map-updater.cc
+@@ -12,6 +12,7 @@
+ #include "src/handles/handles.h"
+ #include "src/heap/parked-scope.h"
+ #include "src/objects/field-type.h"
++#include "src/objects/keys.h"
+ #include "src/objects/objects-inl.h"
+ #include "src/objects/objects.h"
+ #include "src/objects/property-details.h"
+@@ -1037,6 +1038,13 @@ MapUpdater::State MapUpdater::ConstructNewMap() {
+   // the new descriptors to maintain descriptors sharing invariant.
+   split_map->ReplaceDescriptors(isolate_, *new_descriptors);
+ 
++  // If the old descriptors had an enum cache, make sure the new ones do too.
++  if (old_descriptors_->enum_cache().keys().length() > 0 &&
++      new_map->NumberOfEnumerableProperties() > 0) {
++    FastKeyAccumulator::InitializeFastPropertyEnumCache(
++        isolate_, new_map, new_map->NumberOfEnumerableProperties());
++  }
++
+   if (has_integrity_level_transition_) {
+     target_map_ = new_map;
+     state_ = kAtIntegrityLevelSource;


### PR DESCRIPTION
<details>
<summary>electron/security#396 - 1939f7b78eda from chromium</summary>
[M114-LTS] Don't keep pointer to popped stack memory for :has()

The sibling_features pass into UpdateFeaturesFromCombinator may be
initialized to last_compound_in_adjacent_chain_features if null. The
outer while loop in
AddFeaturesToInvalidationSetsForLogicalCombinationInHas() could then
reference to the last_compound_in_adjacent_chain_features which is
popped from the stack on every outer iteration. That caused an ASAN
failure for reading stack memory that had been popped.

Instead make sure each inner iteration restarts with the same
sibling_features pointer, which seems to have been the intent here.

(cherry picked from commit 5e213507a2f0d6e3c96904a710407b01493670bd)

Bug: 1470477
Change-Id: I260c93016f8ab0d165e4b29ca1aea810bede5b97
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4759326
Commit-Queue: Rune Lillesveen <futhark@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1181365}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4777251
Cr-Commit-Position: refs/branch-heads/5845@{#1482}
Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
(cherry picked from commit 34e544e4dedf299211f104a2822d98ce1db80f61)
</details>

<details>
<summary>electron/security#397 - 37447eb52a74 from chromium</summary>
[M114-LTS] Fix ExtensionLocalizationThrottle::WillProcessResponse

Synchronous call of `delegate_->CancelWithError()` inside
blink::URLLoaderThrottle::WillProcessResponse() in Blink can cause UAF.
To fix this, this CL change ExtensionLocalizationThrottle::
WillProcessResponse() to set `defer` to true, and asynchronously call
`delegate_->CancelWithError()`.

(cherry picked from commit 6bb386bf2a6462eb2a33100833d564a2fd0f8225)

Bug: 1469754
Change-Id: Ic129ba4b39a9c1ab00eb6609db824b065296e66d
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4751579
Commit-Queue: Tsuyoshi Horo <horo@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1180638}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4777752
Commit-Queue: David Bertoni <dbertoni@chromium.org>
Auto-Submit: Tsuyoshi Horo <horo@chromium.org>
Cr-Commit-Position: refs/branch-heads/5845@{#1471}
Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
(cherry picked from commit 28759f24f051b5e79b2ae75f4f39ff63e5607119)
</details>

<details>
<summary>electron/security#398 - e4669a74888d from angle</summary>
[M114-LTS] Vulkan: Fix data race with DynamicDescriptorPool

Right now DynamicDescriptorPool::destroyCachedDescriptorSet can be
called from garbage clean up thread, while simultaneously accessed from
context main thread, and data race will happen and cause bugs. This can
only happen when the buffer is not being suballocated. In this case,
suballocation owns the bufferBlock and bufferBlock gets destroyed when
suballocation is destroyed from garbage collection thread. If buffer is
suballocated, the shared group owns pool which owns bufferBlocks and
they gets destroyed from shared group with the share group lock. This CL
avoids this race problem by release the shared cacheKey when the buffer
is released, while we still had the shared group lock.

Bug: chromium:1469542
Change-Id: Ie6235fcfb77dee2a12b2ebde44042c3845fc0aca
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/4790523
(cherry picked from commit b48983ab8c74d2fcd9ef17c80727affb9e690c53)
</details>

Notes:
* Security: backported fix for CVE-2023-4427.
* Security: backported fix for CVE-2023-4428.
* Security: backported fix for CVE-2023-4429.
* Security: backported fix for CVE-2023-4430.