### PR TITLE
chore: cherry-pick 3 changes from Release-1-M116

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -1,2 +1,3 @@
 fix_rename_webswapcgllayer_to_webswapcgllayerchromium.patch
 cherry-pick-5486190be556.patch
+cherry-pick-e4669a74888d.patch

--- a/patches/angle/cherry-pick-e4669a74888d.patch
+++ b/patches/angle/cherry-pick-e4669a74888d.patch
@@ -1,0 +1,396 @@
+From e4669a74888d7f9bd93d79f72829d576776dfb8a Mon Sep 17 00:00:00 2001
+From: Charlie Lao <cclao@google.com>
+Date: Tue, 08 Aug 2023 10:14:47 -0700
+Subject: [PATCH] [M114-LTS] Vulkan: Fix data race with DynamicDescriptorPool
+
+Right now DynamicDescriptorPool::destroyCachedDescriptorSet can be
+called from garbage clean up thread, while simultaneously accessed from
+context main thread, and data race will happen and cause bugs. This can
+only happen when the buffer is not being suballocated. In this case,
+suballocation owns the bufferBlock and bufferBlock gets destroyed when
+suballocation is destroyed from garbage collection thread. If buffer is
+suballocated, the shared group owns pool which owns bufferBlocks and
+they gets destroyed from shared group with the share group lock. This CL
+avoids this race problem by release the shared cacheKey when the buffer
+is released, while we still had the shared group lock.
+
+Bug: chromium:1469542
+Change-Id: Ie6235fcfb77dee2a12b2ebde44042c3845fc0aca
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/4790523
+(cherry picked from commit b48983ab8c74d2fcd9ef17c80727affb9e690c53)
+---
+
+diff --git a/src/libANGLE/renderer/vulkan/BufferVk.cpp b/src/libANGLE/renderer/vulkan/BufferVk.cpp
+index 2e07deb..93a1092 100644
+--- a/src/libANGLE/renderer/vulkan/BufferVk.cpp
++++ b/src/libANGLE/renderer/vulkan/BufferVk.cpp
+@@ -305,7 +305,7 @@
+     RendererVk *renderer = contextVk->getRenderer();
+     if (mBuffer.valid())
+     {
+-        mBuffer.releaseBufferAndDescriptorSetCache(contextVk);
++        mBuffer.releaseBufferAndDescriptorSetCache(renderer);
+     }
+     if (mStagingBuffer.valid())
+     {
+@@ -623,7 +623,7 @@
+         memcpy(dstMapPtr, srcMapPtr, static_cast<size_t>(mState.getSize()));
+     }
+ 
+-    src.releaseBufferAndDescriptorSetCache(contextVk);
++    src.releaseBufferAndDescriptorSetCache(contextVk->getRenderer());
+ 
+     // Return the already mapped pointer with the offset adjustment to avoid the call to unmap().
+     *mapPtr = dstMapPtr + offset;
+@@ -1029,7 +1029,7 @@
+ 
+     if (prevBuffer.valid())
+     {
+-        prevBuffer.releaseBufferAndDescriptorSetCache(contextVk);
++        prevBuffer.releaseBufferAndDescriptorSetCache(contextVk->getRenderer());
+     }
+ 
+     return angle::Result::Continue;
+@@ -1151,7 +1151,7 @@
+ 
+     if (mBuffer.valid())
+     {
+-        mBuffer.releaseBufferAndDescriptorSetCache(contextVk);
++        mBuffer.releaseBufferAndDescriptorSetCache(renderer);
+     }
+ 
+     // Allocate the buffer directly
+diff --git a/src/libANGLE/renderer/vulkan/Suballocation.h b/src/libANGLE/renderer/vulkan/Suballocation.h
+index d25481b..276f6b4 100644
+--- a/src/libANGLE/renderer/vulkan/Suballocation.h
++++ b/src/libANGLE/renderer/vulkan/Suballocation.h
+@@ -86,6 +86,13 @@
+     {
+         mDescriptorSetCacheManager.addKey(sharedCacheKey);
+     }
++    void releaseAllCachedDescriptorSetCacheKeys(RendererVk *renderer)
++    {
++        if (!mDescriptorSetCacheManager.empty())
++        {
++            mDescriptorSetCacheManager.releaseKeys(renderer);
++        }
++    }
+ 
+   private:
+     mutable std::mutex mVirtualBlockMutex;
+diff --git a/src/libANGLE/renderer/vulkan/TextureVk.cpp b/src/libANGLE/renderer/vulkan/TextureVk.cpp
+index d43c172..5e6419f 100644
+--- a/src/libANGLE/renderer/vulkan/TextureVk.cpp
++++ b/src/libANGLE/renderer/vulkan/TextureVk.cpp
+@@ -1623,7 +1623,7 @@
+         onStateChange(angle::SubjectMessage::SubjectChanged);
+     }
+     mRedefinedLevels.reset();
+-    mDescriptorSetCacheManager.releaseKeys(contextVk);
++    mDescriptorSetCacheManager.releaseKeys(contextVk->getRenderer());
+ }
+ 
+ void TextureVk::initImageUsageFlags(ContextVk *contextVk, angle::FormatID actualFormatID)
+@@ -2857,7 +2857,7 @@
+ 
+         mBufferViews.release(contextVk);
+         mBufferViews.init(renderer, offset, size);
+-        mDescriptorSetCacheManager.releaseKeys(contextVk);
++        mDescriptorSetCacheManager.releaseKeys(renderer);
+         return angle::Result::Continue;
+     }
+ 
+@@ -3300,7 +3300,7 @@
+ {
+     RendererVk *renderer = contextVk->getRenderer();
+ 
+-    mDescriptorSetCacheManager.releaseKeys(contextVk);
++    mDescriptorSetCacheManager.releaseKeys(renderer);
+ 
+     if (mImage == nullptr)
+     {
+diff --git a/src/libANGLE/renderer/vulkan/vk_cache_utils.cpp b/src/libANGLE/renderer/vulkan/vk_cache_utils.cpp
+index f750428..ae86b29 100644
+--- a/src/libANGLE/renderer/vulkan/vk_cache_utils.cpp
++++ b/src/libANGLE/renderer/vulkan/vk_cache_utils.cpp
+@@ -2589,11 +2589,19 @@
+ {
+     contextVk->getShareGroup()->getFramebufferCache().erase(contextVk, desc);
+ }
++void ReleaseCachedObject(RendererVk *renderer, const FramebufferDesc &desc)
++{
++    UNREACHABLE();
++}
+ 
+ void ReleaseCachedObject(ContextVk *contextVk, const DescriptorSetDescAndPool &descAndPool)
+ {
++    UNREACHABLE();
++}
++void ReleaseCachedObject(RendererVk *renderer, const DescriptorSetDescAndPool &descAndPool)
++{
+     ASSERT(descAndPool.mPool != nullptr);
+-    descAndPool.mPool->releaseCachedDescriptorSet(contextVk, descAndPool.mDesc);
++    descAndPool.mPool->releaseCachedDescriptorSet(renderer, descAndPool.mDesc);
+ }
+ 
+ void DestroyCachedObject(RendererVk *renderer, const FramebufferDesc &desc)
+@@ -6261,6 +6269,22 @@
+ }
+ 
+ template <class SharedCacheKeyT>
++void SharedCacheKeyManager<SharedCacheKeyT>::releaseKeys(RendererVk *renderer)
++{
++    for (SharedCacheKeyT &sharedCacheKey : mSharedCacheKeys)
++    {
++        if (*sharedCacheKey.get() != nullptr)
++        {
++            // Immediate destroy the cached object and the key itself when first releaseKeys call is
++            // made
++            ReleaseCachedObject(renderer, *(*sharedCacheKey.get()));
++            *sharedCacheKey.get() = nullptr;
++        }
++    }
++    mSharedCacheKeys.clear();
++}
++
++template <class SharedCacheKeyT>
+ void SharedCacheKeyManager<SharedCacheKeyT>::destroyKeys(RendererVk *renderer)
+ {
+     for (SharedCacheKeyT &sharedCacheKey : mSharedCacheKeys)
+diff --git a/src/libANGLE/renderer/vulkan/vk_cache_utils.h b/src/libANGLE/renderer/vulkan/vk_cache_utils.h
+index 8c9d452..f85459a 100644
+--- a/src/libANGLE/renderer/vulkan/vk_cache_utils.h
++++ b/src/libANGLE/renderer/vulkan/vk_cache_utils.h
+@@ -1932,6 +1932,7 @@
+     void addKey(const SharedCacheKeyT &key);
+     // Iterate over the descriptor array and release the descriptor and cache.
+     void releaseKeys(ContextVk *contextVk);
++    void releaseKeys(RendererVk *rendererVk);
+     // Iterate over the descriptor array and destroy the descriptor and cache.
+     void destroyKeys(RendererVk *renderer);
+     void clear();
+diff --git a/src/libANGLE/renderer/vulkan/vk_helpers.cpp b/src/libANGLE/renderer/vulkan/vk_helpers.cpp
+index 9088e09bf..8bc027d 100644
+--- a/src/libANGLE/renderer/vulkan/vk_helpers.cpp
++++ b/src/libANGLE/renderer/vulkan/vk_helpers.cpp
+@@ -3798,7 +3798,7 @@
+     return mDescriptorPools[mCurrentPoolIndex]->get().init(context, mPoolSizes, mMaxSetsPerPool);
+ }
+ 
+-void DynamicDescriptorPool::releaseCachedDescriptorSet(ContextVk *contextVk,
++void DynamicDescriptorPool::releaseCachedDescriptorSet(RendererVk *renderer,
+                                                        const DescriptorSetDesc &desc)
+ {
+     VkDescriptorSet descriptorSet;
+@@ -3812,7 +3812,7 @@
+         // Wrap it with helper object so that it can be GPU tracked and add it to resource list.
+         DescriptorSetHelper descriptorSetHelper(poolOut->get().getResourceUse(), descriptorSet);
+         poolOut->get().addGarbage(std::move(descriptorSetHelper));
+-        checkAndReleaseUnusedPool(contextVk->getRenderer(), poolOut);
++        checkAndReleaseUnusedPool(renderer, poolOut);
+     }
+ }
+ 
+@@ -5016,6 +5016,12 @@
+ 
+     if (mSuballocation.valid())
+     {
++        if (!mSuballocation.isSuballocated())
++        {
++            // Destroy cacheKeys now to avoid getting into situation that having to destroy
++            // descriptorSet from garbage collection thread.
++            mSuballocation.getBufferBlock()->releaseAllCachedDescriptorSetCacheKeys(renderer);
++        }
+         renderer->collectSuballocationGarbage(mUse, std::move(mSuballocation),
+                                               std::move(mBufferForVertexArray));
+     }
+@@ -5024,17 +5030,15 @@
+     ASSERT(!mBufferForVertexArray.valid());
+ }
+ 
+-void BufferHelper::releaseBufferAndDescriptorSetCache(ContextVk *contextVk)
++void BufferHelper::releaseBufferAndDescriptorSetCache(RendererVk *renderer)
+ {
+-    RendererVk *renderer = contextVk->getRenderer();
+-
+     if (renderer->hasResourceUseFinished(getResourceUse()))
+     {
+         mDescriptorSetCacheManager.destroyKeys(renderer);
+     }
+     else
+     {
+-        mDescriptorSetCacheManager.releaseKeys(contextVk);
++        mDescriptorSetCacheManager.releaseKeys(renderer);
+     }
+ 
+     release(renderer);
+diff --git a/src/libANGLE/renderer/vulkan/vk_helpers.h b/src/libANGLE/renderer/vulkan/vk_helpers.h
+index d2405b6..962dfe8 100644
+--- a/src/libANGLE/renderer/vulkan/vk_helpers.h
++++ b/src/libANGLE/renderer/vulkan/vk_helpers.h
+@@ -252,7 +252,7 @@
+                                              VkDescriptorSet *descriptorSetOut,
+                                              SharedDescriptorSetCacheKey *sharedCacheKeyOut);
+ 
+-    void releaseCachedDescriptorSet(ContextVk *contextVk, const DescriptorSetDesc &desc);
++    void releaseCachedDescriptorSet(RendererVk *renderer, const DescriptorSetDesc &desc);
+     void destroyCachedDescriptorSet(RendererVk *renderer, const DescriptorSetDesc &desc);
+ 
+     template <typename Accumulator>
+@@ -777,7 +777,7 @@
+ 
+     void destroy(RendererVk *renderer);
+     void release(RendererVk *renderer);
+-    void releaseBufferAndDescriptorSetCache(ContextVk *contextVk);
++    void releaseBufferAndDescriptorSetCache(RendererVk *renderer);
+ 
+     BufferSerial getBufferSerial() const { return mSerial; }
+     BufferSerial getBlockSerial() const
+diff --git a/src/tests/gl_tests/TransformFeedbackTest.cpp b/src/tests/gl_tests/TransformFeedbackTest.cpp
+index ea3eeea..226eb1f 100644
+--- a/src/tests/gl_tests/TransformFeedbackTest.cpp
++++ b/src/tests/gl_tests/TransformFeedbackTest.cpp
+@@ -507,8 +507,8 @@
+ 
+     const std::array<uint32_t, 12> kInitialData = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+     const std::array<uint32_t, 12> kUpdateData  = {
+-         0x12345678u, 0x9ABCDEF0u, 0x13579BDFu, 0x2468ACE0u, 0x23456781u, 0xABCDEF09u,
+-         0x3579BDF1u, 0x468ACE02u, 0x34567812u, 0xBCDEF09Au, 0x579BDF13u, 0x68ACE024u,
++        0x12345678u, 0x9ABCDEF0u, 0x13579BDFu, 0x2468ACE0u, 0x23456781u, 0xABCDEF09u,
++        0x3579BDF1u, 0x468ACE02u, 0x34567812u, 0xBCDEF09Au, 0x579BDF13u, 0x68ACE024u,
+     };
+ 
+     GLBuffer buffer;
+@@ -3749,9 +3749,9 @@
+     constexpr size_t kCapturedVaryingsCount = 3;
+     constexpr std::array<size_t, kCapturedVaryingsCount> kCaptureSizes = {8, 9, 4};
+     const std::vector<float> kExpected[kCapturedVaryingsCount]         = {
+-                {0.27, 0.30, 0.33, 0.36, 0.39, 0.42, 0.45, 0.48},
+-                {0.63, 0.66, 0.69, 0.72, 0.75, 0.78, 0.81, 0.84, 0.87},
+-                {0.25, 0.5, 0.75, 1.0},
++        {0.27, 0.30, 0.33, 0.36, 0.39, 0.42, 0.45, 0.48},
++        {0.63, 0.66, 0.69, 0.72, 0.75, 0.78, 0.81, 0.84, 0.87},
++        {0.25, 0.5, 0.75, 1.0},
+     };
+ 
+     ANGLE_GL_PROGRAM_TRANSFORM_FEEDBACK(program, kVS, kFS, tfVaryings, GL_INTERLEAVED_ATTRIBS);
+@@ -3848,9 +3848,9 @@
+     constexpr size_t kCapturedVaryingsCount                            = 3;
+     constexpr std::array<size_t, kCapturedVaryingsCount> kCaptureSizes = {1, 2, 1};
+     const std::vector<float> kExpected[kCapturedVaryingsCount]         = {
+-                {0.25},
+-                {0.5, 0.75},
+-                {1.0},
++        {0.25},
++        {0.5, 0.75},
++        {1.0},
+     };
+ 
+     ANGLE_GL_PROGRAM_TRANSFORM_FEEDBACK(program, kVS, kFS, tfVaryings, GL_SEPARATE_ATTRIBS);
+@@ -4392,6 +4392,51 @@
+     glEndTransformFeedback();
+ }
+ 
++// Test bufferData call and transform feedback.
++TEST_P(TransformFeedbackTest, BufferDataAndTransformFeedback)
++{
++    const char kVS[] = R"(#version 300 es
++flat out highp int var;
++void main() {
++var = 1;
++})";
++
++    const char kFS[] = R"(#version 300 es
++flat in highp int var;
++out highp int color;
++void main() {
++color = var;
++})";
++
++    ANGLE_GL_PROGRAM(program, kVS, kFS);
++
++    GLTexture texture;
++    glBindTexture(GL_TEXTURE_2D, texture);
++    glTexStorage2D(GL_TEXTURE_2D, 1, GL_R32I, 1, 1);
++
++    GLFramebuffer fbo;
++    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
++    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
++    EXPECT_GL_FRAMEBUFFER_COMPLETE(GL_FRAMEBUFFER);
++
++    constexpr int kClearColor[] = {123, 0, 0, 0};
++    glClearBufferiv(GL_COLOR, 0, kClearColor);
++    glDrawArrays(GL_POINTS, 0, 1);
++
++    const char *kVarying = "var";
++    glTransformFeedbackVaryings(program, 1, &kVarying, GL_INTERLEAVED_ATTRIBS);
++    glLinkProgram(program);
++    ASSERT_GL_NO_ERROR();
++
++    GLBuffer buffer;
++    glBindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, 0, buffer);
++    glBufferData(GL_TRANSFORM_FEEDBACK_BUFFER, 0x7ffc * 10000, nullptr, GL_DYNAMIC_READ);
++    glBeginTransformFeedback(GL_POINTS);
++    glDrawArrays(GL_POINTS, 0, 1);
++    glEndTransformFeedback();
++    glFlush();
++}
++
+ GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(TransformFeedbackTest);
+ ANGLE_INSTANTIATE_TEST_ES3_AND(TransformFeedbackTest,
+                                ES3_VULKAN()
+diff --git a/src/tests/gl_tests/UniformBufferTest.cpp b/src/tests/gl_tests/UniformBufferTest.cpp
+index 4d005c0..71b8504 100644
+--- a/src/tests/gl_tests/UniformBufferTest.cpp
++++ b/src/tests/gl_tests/UniformBufferTest.cpp
+@@ -3422,6 +3422,50 @@
+     EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
+ }
+ 
++// Calling BufferData and use it in a loop to force descriptorSet creation and destroy.
++TEST_P(UniformBufferTest, BufferDataInLoop)
++{
++    glClear(GL_COLOR_BUFFER_BIT);
++
++    // Use large buffer size to get around suballocation, so that we will gets a new buffer with
++    // bufferData call.
++    static constexpr size_t kBufferSize = 4 * 1024 * 1024;
++    std::vector<float> floatData;
++    floatData.resize(kBufferSize / (sizeof(float)), 0.0f);
++    floatData[0] = 0.5f;
++    floatData[1] = 0.75f;
++    floatData[2] = 0.25f;
++    floatData[3] = 1.0f;
++
++    GLTexture textures[2];
++    GLFramebuffer fbos[2];
++    for (int i = 0; i < 2; i++)
++    {
++        glBindTexture(GL_TEXTURE_2D, textures[i]);
++        glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, 256, 256);
++
++        glBindFramebuffer(GL_FRAMEBUFFER, fbos[i]);
++        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textures[i], 0);
++        EXPECT_GL_FRAMEBUFFER_COMPLETE(GL_FRAMEBUFFER);
++    }
++
++    for (int loop = 0; loop < 10; loop++)
++    {
++        int i = loop & 0x1;
++        // Switch FBO to get around deferred flush
++        glBindFramebuffer(GL_FRAMEBUFFER, fbos[i]);
++        glBindBuffer(GL_UNIFORM_BUFFER, mUniformBuffer);
++        glBufferData(GL_UNIFORM_BUFFER, kBufferSize, floatData.data(), GL_STATIC_DRAW);
++
++        glBindBufferBase(GL_UNIFORM_BUFFER, 0, mUniformBuffer);
++        glUniformBlockBinding(mProgram, mUniformBufferIndex, 0);
++        drawQuad(mProgram, essl3_shaders::PositionAttrib(), 0.5f);
++        glFlush();
++    }
++    ASSERT_GL_NO_ERROR();
++    EXPECT_PIXEL_NEAR(0, 0, 128, 191, 64, 255, 1);
++}
++
+ class WebGL2UniformBufferTest : public UniformBufferTest
+ {
+   protected:

--- a/patches/angle/cherry-pick-e4669a74888d.patch
+++ b/patches/angle/cherry-pick-e4669a74888d.patch
@@ -1,7 +1,7 @@
-From e4669a74888d7f9bd93d79f72829d576776dfb8a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Charlie Lao <cclao@google.com>
-Date: Tue, 08 Aug 2023 10:14:47 -0700
-Subject: [PATCH] [M114-LTS] Vulkan: Fix data race with DynamicDescriptorPool
+Date: Tue, 8 Aug 2023 10:14:47 -0700
+Subject: M116: Vulkan: Fix data race with DynamicDescriptorPool
 
 Right now DynamicDescriptorPool::destroyCachedDescriptorSet can be
 called from garbage clean up thread, while simultaneously accessed from
@@ -17,14 +17,13 @@ is released, while we still had the shared group lock.
 Bug: chromium:1469542
 Change-Id: Ie6235fcfb77dee2a12b2ebde44042c3845fc0aca
 Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/4790523
-(cherry picked from commit b48983ab8c74d2fcd9ef17c80727affb9e690c53)
----
+Reviewed-by: Yuly Novikov <ynovikov@chromium.org>
 
 diff --git a/src/libANGLE/renderer/vulkan/BufferVk.cpp b/src/libANGLE/renderer/vulkan/BufferVk.cpp
-index 2e07deb..93a1092 100644
+index 0898e7d67f47b0d87476a70b9bede290d22ca87a..2957ddf5dede7ffcf7a918ba2f6c8235feb7357b 100644
 --- a/src/libANGLE/renderer/vulkan/BufferVk.cpp
 +++ b/src/libANGLE/renderer/vulkan/BufferVk.cpp
-@@ -305,7 +305,7 @@
+@@ -285,7 +285,7 @@ void BufferVk::release(ContextVk *contextVk)
      RendererVk *renderer = contextVk->getRenderer();
      if (mBuffer.valid())
      {
@@ -33,7 +32,7 @@ index 2e07deb..93a1092 100644
      }
      if (mStagingBuffer.valid())
      {
-@@ -623,7 +623,7 @@
+@@ -628,7 +628,7 @@ angle::Result BufferVk::ghostMappedBuffer(ContextVk *contextVk,
          memcpy(dstMapPtr, srcMapPtr, static_cast<size_t>(mState.getSize()));
      }
  
@@ -42,16 +41,16 @@ index 2e07deb..93a1092 100644
  
      // Return the already mapped pointer with the offset adjustment to avoid the call to unmap().
      *mapPtr = dstMapPtr + offset;
-@@ -1029,7 +1029,7 @@
+@@ -966,7 +966,7 @@ angle::Result BufferVk::acquireAndUpdate(ContextVk *contextVk,
  
-     if (prevBuffer.valid())
+     if (src.valid())
      {
--        prevBuffer.releaseBufferAndDescriptorSetCache(contextVk);
-+        prevBuffer.releaseBufferAndDescriptorSetCache(contextVk->getRenderer());
+-        src.releaseBufferAndDescriptorSetCache(contextVk);
++        src.releaseBufferAndDescriptorSetCache(contextVk->getRenderer());
      }
  
      return angle::Result::Continue;
-@@ -1151,7 +1151,7 @@
+@@ -1073,7 +1073,7 @@ angle::Result BufferVk::acquireBufferHelper(ContextVk *contextVk, size_t sizeInB
  
      if (mBuffer.valid())
      {
@@ -61,10 +60,10 @@ index 2e07deb..93a1092 100644
  
      // Allocate the buffer directly
 diff --git a/src/libANGLE/renderer/vulkan/Suballocation.h b/src/libANGLE/renderer/vulkan/Suballocation.h
-index d25481b..276f6b4 100644
+index d25481bdbbb12d9377eb8ae540a8603a16e453b1..276f6b4c854df2a2a4a353f2893c4bc2df9e8502 100644
 --- a/src/libANGLE/renderer/vulkan/Suballocation.h
 +++ b/src/libANGLE/renderer/vulkan/Suballocation.h
-@@ -86,6 +86,13 @@
+@@ -86,6 +86,13 @@ class BufferBlock final : angle::NonCopyable
      {
          mDescriptorSetCacheManager.addKey(sharedCacheKey);
      }
@@ -79,19 +78,19 @@ index d25481b..276f6b4 100644
    private:
      mutable std::mutex mVirtualBlockMutex;
 diff --git a/src/libANGLE/renderer/vulkan/TextureVk.cpp b/src/libANGLE/renderer/vulkan/TextureVk.cpp
-index d43c172..5e6419f 100644
+index 1375e39971faff88db94c09b50b8c0db761eaba2..903def6e88e8d0f3a16f1f891429b9e088191f32 100644
 --- a/src/libANGLE/renderer/vulkan/TextureVk.cpp
 +++ b/src/libANGLE/renderer/vulkan/TextureVk.cpp
-@@ -1623,7 +1623,7 @@
-         onStateChange(angle::SubjectMessage::SubjectChanged);
-     }
+@@ -1617,7 +1617,7 @@ void TextureVk::releaseAndDeleteImageAndViews(ContextVk *contextVk)
+ 
+     mBufferViews.release(contextVk);
      mRedefinedLevels.reset();
 -    mDescriptorSetCacheManager.releaseKeys(contextVk);
 +    mDescriptorSetCacheManager.releaseKeys(contextVk->getRenderer());
  }
  
  void TextureVk::initImageUsageFlags(ContextVk *contextVk, angle::FormatID actualFormatID)
-@@ -2857,7 +2857,7 @@
+@@ -2845,7 +2845,7 @@ angle::Result TextureVk::syncState(const gl::Context *context,
  
          mBufferViews.release(contextVk);
          mBufferViews.init(renderer, offset, size);
@@ -100,7 +99,7 @@ index d43c172..5e6419f 100644
          return angle::Result::Continue;
      }
  
-@@ -3300,7 +3300,7 @@
+@@ -3285,7 +3285,7 @@ void TextureVk::releaseImageViews(ContextVk *contextVk)
  {
      RendererVk *renderer = contextVk->getRenderer();
  
@@ -110,10 +109,10 @@ index d43c172..5e6419f 100644
      if (mImage == nullptr)
      {
 diff --git a/src/libANGLE/renderer/vulkan/vk_cache_utils.cpp b/src/libANGLE/renderer/vulkan/vk_cache_utils.cpp
-index f750428..ae86b29 100644
+index abab85dcfb5da21630b9e8987543a09e7fb9e6c4..965e6ee4e1f8349c057e7fdbca7ebaa4593823ac 100644
 --- a/src/libANGLE/renderer/vulkan/vk_cache_utils.cpp
 +++ b/src/libANGLE/renderer/vulkan/vk_cache_utils.cpp
-@@ -2589,11 +2589,19 @@
+@@ -2588,11 +2588,19 @@ void ReleaseCachedObject(ContextVk *contextVk, const FramebufferDesc &desc)
  {
      contextVk->getShareGroup()->getFramebufferCache().erase(contextVk, desc);
  }
@@ -123,21 +122,22 @@ index f750428..ae86b29 100644
 +}
  
  void ReleaseCachedObject(ContextVk *contextVk, const DescriptorSetDescAndPool &descAndPool)
- {
++{
 +    UNREACHABLE();
 +}
 +void ReleaseCachedObject(RendererVk *renderer, const DescriptorSetDescAndPool &descAndPool)
-+{
+ {
      ASSERT(descAndPool.mPool != nullptr);
 -    descAndPool.mPool->releaseCachedDescriptorSet(contextVk, descAndPool.mDesc);
 +    descAndPool.mPool->releaseCachedDescriptorSet(renderer, descAndPool.mDesc);
  }
  
  void DestroyCachedObject(RendererVk *renderer, const FramebufferDesc &desc)
-@@ -6261,6 +6269,22 @@
+@@ -6255,6 +6263,22 @@ void SharedCacheKeyManager<SharedCacheKeyT>::releaseKeys(ContextVk *contextVk)
+     mSharedCacheKeys.clear();
  }
  
- template <class SharedCacheKeyT>
++template <class SharedCacheKeyT>
 +void SharedCacheKeyManager<SharedCacheKeyT>::releaseKeys(RendererVk *renderer)
 +{
 +    for (SharedCacheKeyT &sharedCacheKey : mSharedCacheKeys)
@@ -153,15 +153,14 @@ index f750428..ae86b29 100644
 +    mSharedCacheKeys.clear();
 +}
 +
-+template <class SharedCacheKeyT>
+ template <class SharedCacheKeyT>
  void SharedCacheKeyManager<SharedCacheKeyT>::destroyKeys(RendererVk *renderer)
  {
-     for (SharedCacheKeyT &sharedCacheKey : mSharedCacheKeys)
 diff --git a/src/libANGLE/renderer/vulkan/vk_cache_utils.h b/src/libANGLE/renderer/vulkan/vk_cache_utils.h
-index 8c9d452..f85459a 100644
+index 2d9784c1e0db828a5aacefa19168795da85fc5a5..c7213a1193fee21595737047e2379231039b66e9 100644
 --- a/src/libANGLE/renderer/vulkan/vk_cache_utils.h
 +++ b/src/libANGLE/renderer/vulkan/vk_cache_utils.h
-@@ -1932,6 +1932,7 @@
+@@ -1937,6 +1937,7 @@ class SharedCacheKeyManager
      void addKey(const SharedCacheKeyT &key);
      // Iterate over the descriptor array and release the descriptor and cache.
      void releaseKeys(ContextVk *contextVk);
@@ -170,10 +169,10 @@ index 8c9d452..f85459a 100644
      void destroyKeys(RendererVk *renderer);
      void clear();
 diff --git a/src/libANGLE/renderer/vulkan/vk_helpers.cpp b/src/libANGLE/renderer/vulkan/vk_helpers.cpp
-index 9088e09bf..8bc027d 100644
+index b6efd6855a819d28f60a79848dd811a347704d44..b56e78f8f5335e14826c58bfc521bd7d8e55caeb 100644
 --- a/src/libANGLE/renderer/vulkan/vk_helpers.cpp
 +++ b/src/libANGLE/renderer/vulkan/vk_helpers.cpp
-@@ -3798,7 +3798,7 @@
+@@ -3598,7 +3598,7 @@ angle::Result DynamicDescriptorPool::allocateNewPool(Context *context)
      return mDescriptorPools[mCurrentPoolIndex]->get().init(context, mPoolSizes, mMaxSetsPerPool);
  }
  
@@ -182,7 +181,7 @@ index 9088e09bf..8bc027d 100644
                                                         const DescriptorSetDesc &desc)
  {
      VkDescriptorSet descriptorSet;
-@@ -3812,7 +3812,7 @@
+@@ -3612,7 +3612,7 @@ void DynamicDescriptorPool::releaseCachedDescriptorSet(ContextVk *contextVk,
          // Wrap it with helper object so that it can be GPU tracked and add it to resource list.
          DescriptorSetHelper descriptorSetHelper(poolOut->get().getResourceUse(), descriptorSet);
          poolOut->get().addGarbage(std::move(descriptorSetHelper));
@@ -191,7 +190,7 @@ index 9088e09bf..8bc027d 100644
      }
  }
  
-@@ -5016,6 +5016,12 @@
+@@ -4807,6 +4807,12 @@ void BufferHelper::release(RendererVk *renderer)
  
      if (mSuballocation.valid())
      {
@@ -204,7 +203,7 @@ index 9088e09bf..8bc027d 100644
          renderer->collectSuballocationGarbage(mUse, std::move(mSuballocation),
                                                std::move(mBufferForVertexArray));
      }
-@@ -5024,17 +5030,15 @@
+@@ -4815,17 +4821,15 @@ void BufferHelper::release(RendererVk *renderer)
      ASSERT(!mBufferForVertexArray.valid());
  }
  
@@ -225,10 +224,10 @@ index 9088e09bf..8bc027d 100644
  
      release(renderer);
 diff --git a/src/libANGLE/renderer/vulkan/vk_helpers.h b/src/libANGLE/renderer/vulkan/vk_helpers.h
-index d2405b6..962dfe8 100644
+index 29f7d2141fab70e0f542b05004b21701883a39c9..d81f9a4b9b07c6e34094d6d275a04c74c2652d3a 100644
 --- a/src/libANGLE/renderer/vulkan/vk_helpers.h
 +++ b/src/libANGLE/renderer/vulkan/vk_helpers.h
-@@ -252,7 +252,7 @@
+@@ -247,7 +247,7 @@ class DynamicDescriptorPool final : angle::NonCopyable
                                               VkDescriptorSet *descriptorSetOut,
                                               SharedDescriptorSetCacheKey *sharedCacheKeyOut);
  
@@ -237,7 +236,7 @@ index d2405b6..962dfe8 100644
      void destroyCachedDescriptorSet(RendererVk *renderer, const DescriptorSetDesc &desc);
  
      template <typename Accumulator>
-@@ -777,7 +777,7 @@
+@@ -771,7 +771,7 @@ class BufferHelper : public ReadWriteResource
  
      void destroy(RendererVk *renderer);
      void release(RendererVk *renderer);
@@ -247,10 +246,10 @@ index d2405b6..962dfe8 100644
      BufferSerial getBufferSerial() const { return mSerial; }
      BufferSerial getBlockSerial() const
 diff --git a/src/tests/gl_tests/TransformFeedbackTest.cpp b/src/tests/gl_tests/TransformFeedbackTest.cpp
-index ea3eeea..226eb1f 100644
+index ea3eeea4015dcb56f710c873b22c95d168bb287c..226eb1f049bb708e0221c81e9b836a67594eb7b0 100644
 --- a/src/tests/gl_tests/TransformFeedbackTest.cpp
 +++ b/src/tests/gl_tests/TransformFeedbackTest.cpp
-@@ -507,8 +507,8 @@
+@@ -507,8 +507,8 @@ TEST_P(TransformFeedbackTest, UseAsUBOThenUpdateThenCapture)
  
      const std::array<uint32_t, 12> kInitialData = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
      const std::array<uint32_t, 12> kUpdateData  = {
@@ -261,7 +260,7 @@ index ea3eeea..226eb1f 100644
      };
  
      GLBuffer buffer;
-@@ -3749,9 +3749,9 @@
+@@ -3749,9 +3749,9 @@ void main()
      constexpr size_t kCapturedVaryingsCount = 3;
      constexpr std::array<size_t, kCapturedVaryingsCount> kCaptureSizes = {8, 9, 4};
      const std::vector<float> kExpected[kCapturedVaryingsCount]         = {
@@ -274,7 +273,7 @@ index ea3eeea..226eb1f 100644
      };
  
      ANGLE_GL_PROGRAM_TRANSFORM_FEEDBACK(program, kVS, kFS, tfVaryings, GL_INTERLEAVED_ATTRIBS);
-@@ -3848,9 +3848,9 @@
+@@ -3848,9 +3848,9 @@ void main()
      constexpr size_t kCapturedVaryingsCount                            = 3;
      constexpr std::array<size_t, kCapturedVaryingsCount> kCaptureSizes = {1, 2, 1};
      const std::vector<float> kExpected[kCapturedVaryingsCount]         = {
@@ -287,7 +286,7 @@ index ea3eeea..226eb1f 100644
      };
  
      ANGLE_GL_PROGRAM_TRANSFORM_FEEDBACK(program, kVS, kFS, tfVaryings, GL_SEPARATE_ATTRIBS);
-@@ -4392,6 +4392,51 @@
+@@ -4392,6 +4392,51 @@ TEST_P(TransformFeedbackTest, RenderOnceChangeXfbBufferRenderAgain)
      glEndTransformFeedback();
  }
  
@@ -340,10 +339,10 @@ index ea3eeea..226eb1f 100644
  ANGLE_INSTANTIATE_TEST_ES3_AND(TransformFeedbackTest,
                                 ES3_VULKAN()
 diff --git a/src/tests/gl_tests/UniformBufferTest.cpp b/src/tests/gl_tests/UniformBufferTest.cpp
-index 4d005c0..71b8504 100644
+index 4d005c0740d5ff918af103236aa18e8249e00acc..71b85043bd9ca49018e9ed79fa36f24f8499757e 100644
 --- a/src/tests/gl_tests/UniformBufferTest.cpp
 +++ b/src/tests/gl_tests/UniformBufferTest.cpp
-@@ -3422,6 +3422,50 @@
+@@ -3422,6 +3422,50 @@ void main() {
      EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
  }
  

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -140,3 +140,4 @@ cherry-pick-b03973561862.patch
 cherry-pick-c60a1ab717c7.patch
 cherry-pick-aa23556ff213.patch
 networkcontext_don_t_access_url_loader_factories_during_destruction.patch
+cherry-pick-1939f7b78eda.patch

--- a/patches/chromium/cherry-pick-1939f7b78eda.patch
+++ b/patches/chromium/cherry-pick-1939f7b78eda.patch
@@ -1,7 +1,7 @@
-From 1939f7b78edaf058782203f32df820f17010ba25 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Rune Lillesveen <futhark@chromium.org>
 Date: Thu, 24 Aug 2023 10:53:36 +0000
-Subject: [PATCH] [M114-LTS] Don't keep pointer to popped stack memory for :has()
+Subject: Don't keep pointer to popped stack memory for :has()
 
 The sibling_features pass into UpdateFeaturesFromCombinator may be
 initialized to last_compound_in_adjacent_chain_features if null. The
@@ -25,13 +25,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4777251
 Cr-Commit-Position: refs/branch-heads/5845@{#1482}
 Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
 (cherry picked from commit 34e544e4dedf299211f104a2822d98ce1db80f61)
----
 
 diff --git a/third_party/blink/renderer/core/css/rule_feature_set.cc b/third_party/blink/renderer/core/css/rule_feature_set.cc
-index 8ca157a..0c0c5b8 100644
+index 35483b54816197b3244cac4bb32759a88de57664..c6a93968829a8dc6d14247e8882a9a3fdcfb6f84 100644
 --- a/third_party/blink/renderer/core/css/rule_feature_set.cc
 +++ b/third_party/blink/renderer/core/css/rule_feature_set.cc
-@@ -1325,6 +1325,7 @@
+@@ -1322,6 +1322,7 @@ void RuleFeatureSet::AddFeaturesToInvalidationSetsForLogicalCombinationInHas(
          descendant_features);
  
      const CSSSelector* compound_in_logical_combination = complex;
@@ -39,7 +38,7 @@ index 8ca157a..0c0c5b8 100644
      InvalidationSetFeatures last_compound_in_adjacent_chain_features;
      while (compound_in_logical_combination) {
        AddFeaturesToInvalidationSetsForLogicalCombinationInHasContext context(
-@@ -1336,14 +1337,14 @@
+@@ -1333,14 +1334,14 @@ void RuleFeatureSet::AddFeaturesToInvalidationSetsForLogicalCombinationInHas(
          last_in_compound =
              SkipAddingAndGetLastInCompoundForLogicalCombinationInHas(
                  compound_in_logical_combination, compound_containing_has,
@@ -58,7 +57,7 @@ index 8ca157a..0c0c5b8 100644
        }
  
        if (!last_in_compound) {
-@@ -1358,7 +1359,7 @@
+@@ -1355,7 +1356,7 @@ void RuleFeatureSet::AddFeaturesToInvalidationSetsForLogicalCombinationInHas(
                  ? CSSSelector::kIndirectAdjacent
                  : previous_combinator,
              context.last_compound_in_adjacent_chain,
@@ -69,7 +68,7 @@ index 8ca157a..0c0c5b8 100644
  
 diff --git a/third_party/blink/web_tests/external/wpt/css/selectors/has-sibling-chrome-crash.html b/third_party/blink/web_tests/external/wpt/css/selectors/has-sibling-chrome-crash.html
 new file mode 100644
-index 0000000..0306e3e
+index 0000000000000000000000000000000000000000..0306e3e39272c321fc3539aa582b4e239ffe2fa1
 --- /dev/null
 +++ b/third_party/blink/web_tests/external/wpt/css/selectors/has-sibling-chrome-crash.html
 @@ -0,0 +1,10 @@

--- a/patches/chromium/cherry-pick-1939f7b78eda.patch
+++ b/patches/chromium/cherry-pick-1939f7b78eda.patch
@@ -1,0 +1,85 @@
+From 1939f7b78edaf058782203f32df820f17010ba25 Mon Sep 17 00:00:00 2001
+From: Rune Lillesveen <futhark@chromium.org>
+Date: Thu, 24 Aug 2023 10:53:36 +0000
+Subject: [PATCH] [M114-LTS] Don't keep pointer to popped stack memory for :has()
+
+The sibling_features pass into UpdateFeaturesFromCombinator may be
+initialized to last_compound_in_adjacent_chain_features if null. The
+outer while loop in
+AddFeaturesToInvalidationSetsForLogicalCombinationInHas() could then
+reference to the last_compound_in_adjacent_chain_features which is
+popped from the stack on every outer iteration. That caused an ASAN
+failure for reading stack memory that had been popped.
+
+Instead make sure each inner iteration restarts with the same
+sibling_features pointer, which seems to have been the intent here.
+
+(cherry picked from commit 5e213507a2f0d6e3c96904a710407b01493670bd)
+
+Bug: 1470477
+Change-Id: I260c93016f8ab0d165e4b29ca1aea810bede5b97
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4759326
+Commit-Queue: Rune Lillesveen <futhark@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1181365}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4777251
+Cr-Commit-Position: refs/branch-heads/5845@{#1482}
+Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
+(cherry picked from commit 34e544e4dedf299211f104a2822d98ce1db80f61)
+---
+
+diff --git a/third_party/blink/renderer/core/css/rule_feature_set.cc b/third_party/blink/renderer/core/css/rule_feature_set.cc
+index 8ca157a..0c0c5b8 100644
+--- a/third_party/blink/renderer/core/css/rule_feature_set.cc
++++ b/third_party/blink/renderer/core/css/rule_feature_set.cc
+@@ -1325,6 +1325,7 @@
+         descendant_features);
+ 
+     const CSSSelector* compound_in_logical_combination = complex;
++    InvalidationSetFeatures* inner_sibling_features = sibling_features;
+     InvalidationSetFeatures last_compound_in_adjacent_chain_features;
+     while (compound_in_logical_combination) {
+       AddFeaturesToInvalidationSetsForLogicalCombinationInHasContext context(
+@@ -1336,14 +1337,14 @@
+         last_in_compound =
+             SkipAddingAndGetLastInCompoundForLogicalCombinationInHas(
+                 compound_in_logical_combination, compound_containing_has,
+-                sibling_features, descendant_features, previous_combinator,
+-                add_features_method);
++                inner_sibling_features, descendant_features,
++                previous_combinator, add_features_method);
+       } else {
+         last_in_compound =
+             AddFeaturesAndGetLastInCompoundForLogicalCombinationInHas(
+                 compound_in_logical_combination, compound_containing_has,
+-                sibling_features, descendant_features, previous_combinator,
+-                add_features_method);
++                inner_sibling_features, descendant_features,
++                previous_combinator, add_features_method);
+       }
+ 
+       if (!last_in_compound) {
+@@ -1358,7 +1359,7 @@
+                 ? CSSSelector::kIndirectAdjacent
+                 : previous_combinator,
+             context.last_compound_in_adjacent_chain,
+-            last_compound_in_adjacent_chain_features, sibling_features,
++            last_compound_in_adjacent_chain_features, inner_sibling_features,
+             descendant_features);
+       }
+ 
+diff --git a/third_party/blink/web_tests/external/wpt/css/selectors/has-sibling-chrome-crash.html b/third_party/blink/web_tests/external/wpt/css/selectors/has-sibling-chrome-crash.html
+new file mode 100644
+index 0000000..0306e3e
+--- /dev/null
++++ b/third_party/blink/web_tests/external/wpt/css/selectors/has-sibling-chrome-crash.html
+@@ -0,0 +1,10 @@
++<!DOCTYPE html>
++<title>CSS Selectors Test: Chrome crash issue 1470477</title>
++<link rel="help" href="https://crbug.com/1470477">
++<style>
++  :has(> :where(label:first-child + [a="a"]:only-of-type,
++    [a="a"]:only-of-type + label:last-child)) label:last-child {
++      margin-inline: 1em;
++  }
++</style>
++<p>PASS if this tests does not crash</p>

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -18,3 +18,4 @@ merged_runtime_set_instance_prototypes_directly_on_maps.patch
 merged_compiler_stackcheck_can_have_side_effects.patch
 cherry-pick-8ff63d378f2c.patch
 cherry-pick-d671b099a57d.patch
+merged_squashed_multiple_commits.patch

--- a/patches/v8/merged_squashed_multiple_commits.patch
+++ b/patches/v8/merged_squashed_multiple_commits.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Samuel=20Gro=C3=9F?= <saelo@chromium.org>
+Date: Thu, 17 Aug 2023 09:10:19 +0000
+Subject: Merged: Squashed multiple commits.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Merged: [runtime] Recreate enum cache on map update
+Revision: 1c623f9ff6e077be1c66f155485ea4005ddb6574
+
+Merged: [runtime] Don't try to create empty enum cache.
+Revision: 5516e06237c9f0013121f47319e8c253c896d52d
+
+BUG=chromium:1470668,chromium:1472317
+R=tebbi@chromium.org
+
+Change-Id: I31d5491aba663661ba68bb55631747a195ed084e
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4788990
+Commit-Queue: Samuel Groß <saelo@chromium.org>
+Reviewed-by: Tobias Tebbi <tebbi@chromium.org>
+Cr-Commit-Position: refs/branch-heads/11.6@{#32}
+Cr-Branched-From: e29c028f391389a7a60ee37097e3ca9e396d6fa4-refs/heads/11.6.189@{#3}
+Cr-Branched-From: 95cbef20e2aa556a1ea75431a48b36c4de6b9934-refs/heads/main@{#88340}
+
+diff --git a/src/objects/map-updater.cc b/src/objects/map-updater.cc
+index be6568aac4730d08601e883b80092bbd6ee8081a..2ebfc84d3e326abf2602a1af8309024a46cb9c9d 100644
+--- a/src/objects/map-updater.cc
++++ b/src/objects/map-updater.cc
+@@ -11,6 +11,7 @@
+ #include "src/execution/isolate.h"
+ #include "src/handles/handles.h"
+ #include "src/objects/field-type.h"
++#include "src/objects/keys.h"
+ #include "src/objects/objects-inl.h"
+ #include "src/objects/objects.h"
+ #include "src/objects/property-details.h"
+@@ -1035,6 +1036,13 @@ MapUpdater::State MapUpdater::ConstructNewMap() {
+   // the new descriptors to maintain descriptors sharing invariant.
+   split_map->ReplaceDescriptors(isolate_, *new_descriptors);
+ 
++  // If the old descriptors had an enum cache, make sure the new ones do too.
++  if (old_descriptors_->enum_cache().keys().length() > 0 &&
++      new_map->NumberOfEnumerableProperties() > 0) {
++    FastKeyAccumulator::InitializeFastPropertyEnumCache(
++        isolate_, new_map, new_map->NumberOfEnumerableProperties());
++  }
++
+   if (has_integrity_level_transition_) {
+     target_map_ = new_map;
+     state_ = kAtIntegrityLevelSource;


### PR DESCRIPTION
<details>
<summary>electron/security#396 - 1939f7b78eda from chromium</summary>
[M114-LTS] Don't keep pointer to popped stack memory for :has()

The sibling_features pass into UpdateFeaturesFromCombinator may be
initialized to last_compound_in_adjacent_chain_features if null. The
outer while loop in
AddFeaturesToInvalidationSetsForLogicalCombinationInHas() could then
reference to the last_compound_in_adjacent_chain_features which is
popped from the stack on every outer iteration. That caused an ASAN
failure for reading stack memory that had been popped.

Instead make sure each inner iteration restarts with the same
sibling_features pointer, which seems to have been the intent here.

(cherry picked from commit 5e213507a2f0d6e3c96904a710407b01493670bd)

Bug: 1470477
Change-Id: I260c93016f8ab0d165e4b29ca1aea810bede5b97
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4759326
Commit-Queue: Rune Lillesveen <futhark@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1181365}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4777251
Cr-Commit-Position: refs/branch-heads/5845@{#1482}
Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
(cherry picked from commit 34e544e4dedf299211f104a2822d98ce1db80f61)
</details>

<details>
<summary>electron/security#398 - e4669a74888d from angle</summary>
[M114-LTS] Vulkan: Fix data race with DynamicDescriptorPool

Right now DynamicDescriptorPool::destroyCachedDescriptorSet can be
called from garbage clean up thread, while simultaneously accessed from
context main thread, and data race will happen and cause bugs. This can
only happen when the buffer is not being suballocated. In this case,
suballocation owns the bufferBlock and bufferBlock gets destroyed when
suballocation is destroyed from garbage collection thread. If buffer is
suballocated, the shared group owns pool which owns bufferBlocks and
they gets destroyed from shared group with the share group lock. This CL
avoids this race problem by release the shared cacheKey when the buffer
is released, while we still had the shared group lock.

Bug: chromium:1469542
Change-Id: Ie6235fcfb77dee2a12b2ebde44042c3845fc0aca
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/4790523
(cherry picked from commit b48983ab8c74d2fcd9ef17c80727affb9e690c53)
</details>

Notes:
* Security: backported fix for CVE-2023-4427.
* Security: backported fix for CVE-2023-4428.
* Security: backported fix for CVE-2023-4430.