### PR TITLE
ci: explicitly use python3 to start goma

### DIFF
--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -118,7 +118,7 @@ for:
       - ps: .\src\electron\script\start-goma.ps1 -gomaDir $env:LOCAL_GOMA_DIR
       - ps: >-
           if (Test-Path 'env:RAW_GOMA_AUTH') {
-            $goma_login = python $env:LOCAL_GOMA_DIR\goma_auth.py info
+            $goma_login = python3 $env:LOCAL_GOMA_DIR\goma_auth.py info
             if ($goma_login -eq 'Login as Fermi Planck') {
               Write-warning "Goma authentication is correct";
             } else {
@@ -168,7 +168,7 @@ for:
       - ninja -C out/Default electron:hunspell_dictionaries_zip
       - ninja -C out/Default electron:electron_chromedriver_zip
       - ninja -C out/Default electron:node_headers
-      - python %LOCAL_GOMA_DIR%\goma_ctl.py stat
+      - python3 %LOCAL_GOMA_DIR%\goma_ctl.py stat
       - ps: >-
           Get-CimInstance -Namespace root\cimv2 -Class Win32_product | Select vendor, description, @{l='install_location';e='InstallLocation'}, @{l='install_date';e='InstallDate'}, @{l='install_date_2';e='InstallDate2'}, caption, version, name, @{l='sku_number';e='SKUNumber'} | ConvertTo-Json | Out-File -Encoding utf8 -FilePath .\installed_software.json
       - python3 electron/build/profile_toolchain.py --output-json=out/Default/windows_toolchain_profile.json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -116,7 +116,7 @@ for:
       - ps: .\src\electron\script\start-goma.ps1 -gomaDir $env:LOCAL_GOMA_DIR
       - ps: >-
           if (Test-Path 'env:RAW_GOMA_AUTH') {
-            $goma_login = python $env:LOCAL_GOMA_DIR\goma_auth.py info
+            $goma_login = python3 $env:LOCAL_GOMA_DIR\goma_auth.py info
             if ($goma_login -eq 'Login as Fermi Planck') {
               Write-warning "Goma authentication is correct";
             } else {
@@ -166,7 +166,7 @@ for:
       - ninja -C out/Default electron:hunspell_dictionaries_zip
       - ninja -C out/Default electron:electron_chromedriver_zip
       - ninja -C out/Default electron:node_headers
-      - python %LOCAL_GOMA_DIR%\goma_ctl.py stat
+      - python3 %LOCAL_GOMA_DIR%\goma_ctl.py stat
       - ps: >-
           Get-CimInstance -Namespace root\cimv2 -Class Win32_product | Select vendor, description, @{l='install_location';e='InstallLocation'}, @{l='install_date';e='InstallDate'}, @{l='install_date_2';e='InstallDate2'}, caption, version, name, @{l='sku_number';e='SKUNumber'} | ConvertTo-Json | Out-File -Encoding utf8 -FilePath .\installed_software.json
       - python3 electron/build/profile_toolchain.py --output-json=out/Default/windows_toolchain_profile.json

--- a/script/start-goma.ps1
+++ b/script/start-goma.ps1
@@ -1,6 +1,6 @@
 ﻿param([string]$gomaDir=$PWD)
 $cmdPath = Join-Path -Path $gomaDir -ChildPath "goma_ctl.py"
-Start-Process -FilePath cmd -ArgumentList "/C", "python", "$cmdPath", "ensure_start"
+Start-Process -FilePath cmd -ArgumentList "/C", "python3", "$cmdPath", "ensure_start"
 $timedOut = $false; $waitTime = 0; $waitIncrement = 5; $timeout=120;
 Do { sleep $waitIncrement; $timedOut = (($waitTime+=$waitIncrement) -gt $timeout); iex "$gomaDir\gomacc.exe port 2" > $null; } Until(($LASTEXITCODE -eq 0) -or $timedOut)
 if ($timedOut) {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
- [electron/build-tools/#510](https://github.com/electron/build-tools/pull/510) updated Goma to a newer version that requires python3, so the script to start Goma on AppVeyor has to be updated to use python3.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
