### PR TITLE
chore: remove deprecated `webContents.getPrinters()`

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1536,14 +1536,6 @@ If you would like the page to stay hidden, you should ensure that `stayHidden` i
 Returns `boolean` - Whether this page is being captured. It returns true when the capturer count
 is large then 0.
 
-#### `contents.getPrinters()` _Deprecated_
-
-Get the system printer list.
-
-Returns [`PrinterInfo[]`](structures/printer-info.md)
-
-**Deprecated:** Should use the new [`contents.getPrintersAsync`](web-contents.md#contentsgetprintersasync) API.
-
 #### `contents.getPrintersAsync()`
 
 Get the system printer list.

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -85,6 +85,22 @@ systemPreferences.on('high-contrast-color-scheme-changed', () => { /* ... */ })
 nativeTheme.on('updated', () => { /* ... */ })
 ```
 
+### Removed: `webContents.getPrinters`
+
+The `webContents.getPrinters` method has been removed. Use
+`webContents.getPrintersAsync` instead.
+
+```js
+const w = new BrowserWindow({ show: false })
+
+// Removed
+console.log(w.webContents.getPrinters())
+// Replace with
+w.webContents.getPrintersAsync().then((printers) => {
+  console.log(printers)
+})
+```
+
 ## Planned Breaking API Changes (26.0)
 
 ### Deprecated: `webContents.getPrinters`

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -394,17 +394,6 @@ WebContents.prototype.print = function (options: ElectronInternal.WebContentsPri
   }
 };
 
-WebContents.prototype.getPrinters = function () {
-  // TODO(nornagon): this API has nothing to do with WebContents and should be
-  // moved.
-  if (printing.getPrinterList) {
-    return printing.getPrinterList();
-  } else {
-    console.error('Error: Printing feature is disabled.');
-    return [];
-  }
-};
-
 WebContents.prototype.getPrintersAsync = async function () {
   // TODO(nornagon): this API has nothing to do with WebContents and should be
   // moved.

--- a/shell/browser/api/electron_api_printing.cc
+++ b/shell/browser/api/electron_api_printing.cc
@@ -41,25 +41,6 @@ struct Converter<printing::PrinterBasicInfo> {
 namespace electron::api {
 
 #if BUILDFLAG(ENABLE_PRINTING)
-printing::PrinterList GetPrinterList(v8::Isolate* isolate) {
-  EmitWarning(node::Environment::GetCurrent(isolate),
-              "Deprecation Warning: getPrinters() is deprecated. "
-              "Use the asynchronous and non-blocking version, "
-              "getPrintersAsync(), instead.",
-              "electron");
-  printing::PrinterList printers;
-  auto print_backend = printing::PrintBackend::CreateInstance(
-      g_browser_process->GetApplicationLocale());
-  {
-    ScopedAllowBlockingForElectron allow_blocking;
-    printing::mojom::ResultCode code =
-        print_backend->EnumeratePrinters(printers);
-    if (code != printing::mojom::ResultCode::kSuccess)
-      LOG(INFO) << "Failed to enumerate printers";
-  }
-  return printers;
-}
-
 v8::Local<v8::Promise> GetPrinterListAsync(v8::Isolate* isolate) {
   gin_helper::Promise<printing::PrinterList> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
@@ -92,7 +73,6 @@ v8::Local<v8::Promise> GetPrinterListAsync(v8::Isolate* isolate) {
 namespace {
 
 #if BUILDFLAG(ENABLE_PRINTING)
-using electron::api::GetPrinterList;
 using electron::api::GetPrinterListAsync;
 #endif
 
@@ -103,7 +83,6 @@ void Initialize(v8::Local<v8::Object> exports,
   v8::Isolate* isolate = context->GetIsolate();
   gin_helper::Dictionary dict(isolate, exports);
 #if BUILDFLAG(ENABLE_PRINTING)
-  dict.SetMethod("getPrinterList", base::BindRepeating(&GetPrinterList));
   dict.SetMethod("getPrinterListAsync",
                  base::BindRepeating(&GetPrinterListAsync));
 #endif

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -1946,16 +1946,6 @@ describe('webContents module', () => {
     });
   });
 
-  ifdescribe(features.isPrintingEnabled())('getPrinters()', () => {
-    afterEach(closeAllWindows);
-    it('can get printer list', async () => {
-      const w = new BrowserWindow({ show: false, webPreferences: { sandbox: true } });
-      await w.loadURL('about:blank');
-      const printers = w.webContents.getPrinters();
-      expect(printers).to.be.an('array');
-    });
-  });
-
   ifdescribe(features.isPrintingEnabled())('getPrintersAsync()', () => {
     afterEach(closeAllWindows);
     it('can get printer list', async () => {

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -1275,6 +1275,9 @@ win4.webContents.on('devtools-open-url', (event, url) => {
 
 win4.loadURL('http://github.com');
 
+// @ts-expect-error Removed API
+win4.webContents.getPrinters();
+
 // TouchBar
 // https://github.com/electron/electron/blob/main/docs/api/touch-bar.md
 

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -70,7 +70,6 @@ declare namespace Electron {
     _sendInternal(channel: string, ...args: any[]): void;
     _printToPDF(options: any): Promise<Buffer>;
     _print(options: any, callback?: (success: boolean, failureReason: string) => void): void;
-    _getPrinters(): Electron.PrinterInfo[];
     _getPrintersAsync(): Promise<Electron.PrinterInfo[]>;
     _init(): void;
     canGoToIndex(index: number): boolean;


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Following up #39356 with the removal.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: The deprecated `webContents.getPrinters()` API has been removed. <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
