### PR TITLE
docs: use `node:` imports for node core modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ binary. Use this to spawn Electron from Node scripts:
 
 ```javascript
 const electron = require('electron')
-const proc = require('child_process')
+const proc = require('node:child_process')
 
 // will print something similar to /Users/maf/.../Electron
 console.log(electron)

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1333,7 +1333,7 @@ application name. For example:
 
 ``` js
 const { app } = require('electron')
-const path = require('path')
+const path = require('node:path')
 
 const appFolder = path.dirname(process.execPath)
 const updateExe = path.resolve(appFolder, '..', 'Update.exe')
@@ -1404,7 +1404,7 @@ Returns `Function` - This function **must** be called once you have finished acc
 
 ```js
 const { app, dialog } = require('electron')
-const fs = require('fs')
+const fs = require('node:fs')
 
 let filepath
 let bookmark

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1211,7 +1211,7 @@ const win = new BrowserWindow()
 const url = require('url').format({
   protocol: 'file',
   slashes: true,
-  pathname: require('path').join(__dirname, 'index.html')
+  pathname: require('node:path').join(__dirname, 'index.html')
 })
 
 win.loadURL(url)

--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -147,7 +147,7 @@ Be very cautious about which globals and APIs you expose to untrusted remote con
 
 ```javascript
 const { contextBridge } = require('electron')
-const crypto = require('crypto')
+const crypto = require('node:crypto')
 contextBridge.exposeInMainWorld('nodeCrypto', {
   sha256sum (data) {
     const hash = crypto.createHash('sha256')

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -33,7 +33,7 @@ to register it to that session explicitly.
 
 ```javascript
 const { app, BrowserWindow, net, protocol, session } = require('electron')
-const path = require('path')
+const path = require('node:path')
 const url = require('url')
 
 app.whenReady().then(() => {
@@ -122,7 +122,7 @@ Example:
 
 ```js
 const { app, net, protocol } = require('electron')
-const { join } = require('path')
+const { join } = require('node:path')
 const { pathToFileURL } = require('url')
 
 protocol.registerSchemesAsPrivileged([

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -103,7 +103,7 @@ const { session } = require('electron')
 session.defaultSession.on('will-download', (event, item, webContents) => {
   event.preventDefault()
   require('got')(item.getURL()).then((response) => {
-    require('fs').writeFileSync('/somewhere', response.body)
+    require('node:fs').writeFileSync('/somewhere', response.body)
   })
 })
 ```
@@ -1193,7 +1193,7 @@ automatically.  To clear the handler, call `setBluetoothPairingHandler(null)`.
 
 ```javascript
 const { app, BrowserWindow, session } = require('electron')
-const path = require('path')
+const path = require('node:path')
 
 function createWindow () {
   let bluetoothPinCallback = null
@@ -1457,7 +1457,7 @@ extension to be loaded.
 
 ```js
 const { app, session } = require('electron')
-const path = require('path')
+const path = require('node:path')
 
 app.whenReady().then(async () => {
   await session.defaultSession.loadExtension(
@@ -1544,7 +1544,7 @@ A [`Protocol`](protocol.md) object for this session.
 
 ```javascript
 const { app, session } = require('electron')
-const path = require('path')
+const path = require('node:path')
 
 app.whenReady().then(() => {
   const protocol = session.fromPartition('some-partition').protocol

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1638,9 +1638,9 @@ An example of `webContents.printToPDF`:
 
 ```javascript
 const { BrowserWindow } = require('electron')
-const fs = require('fs')
-const path = require('path')
-const os = require('os')
+const fs = require('node:fs')
+const path = require('node:path')
+const os = require('node:os')
 
 const win = new BrowserWindow()
 win.loadURL('https://github.com')

--- a/docs/tutorial/asar-archives.md
+++ b/docs/tutorial/asar-archives.md
@@ -42,14 +42,14 @@ $ asar list /path/to/example.asar
 Read a file in the ASAR archive:
 
 ```javascript
-const fs = require('fs')
+const fs = require('node:fs')
 fs.readFileSync('/path/to/example.asar/file.txt')
 ```
 
 List all files under the root of the archive:
 
 ```javascript
-const fs = require('fs')
+const fs = require('node:fs')
 fs.readdirSync('/path/to/example.asar')
 ```
 
@@ -99,7 +99,7 @@ You can also set `process.noAsar` to `true` to disable the support for `asar` in
 the `fs` module:
 
 ```javascript
-const fs = require('fs')
+const fs = require('node:fs')
 process.noAsar = true
 fs.readFileSync('/path/to/example.asar')
 ```

--- a/docs/tutorial/automated-testing.md
+++ b/docs/tutorial/automated-testing.md
@@ -260,7 +260,7 @@ To create a custom driver, we'll use Node.js' [`child_process`](https://nodejs.o
 The test suite will spawn the Electron process, then establish a simple messaging protocol:
 
 ```js title='testDriver.js' @ts-nocheck
-const childProcess = require('child_process')
+const childProcess = require('node:child_process')
 const electronPath = require('electron')
 
 // spawn the process

--- a/docs/tutorial/dark-mode.md
+++ b/docs/tutorial/dark-mode.md
@@ -136,7 +136,7 @@ Finally, the `main.js` file represents the main process and contains the actual 
 
 ```js
 const { app, BrowserWindow, ipcMain, nativeTheme } = require('electron')
-const path = require('path')
+const path = require('node:path')
 
 const createWindow = () => {
   const win = new BrowserWindow({

--- a/docs/tutorial/devtools-extension.md
+++ b/docs/tutorial/devtools-extension.md
@@ -35,8 +35,8 @@ Using the [React Developer Tools][react-devtools] as an example:
 
    ```javascript
    const { app, session } = require('electron')
-   const path = require('path')
-   const os = require('os')
+   const path = require('node:path')
+   const os = require('node:os')
 
    // on macOS
    const reactDevToolsPath = path.join(

--- a/docs/tutorial/ipc.md
+++ b/docs/tutorial/ipc.md
@@ -52,7 +52,7 @@ In the main process, set an IPC listener on the `set-title` channel with the `ip
 
 ```javascript {6-10,22} title='main.js (Main Process)'
 const { app, BrowserWindow, ipcMain } = require('electron')
-const path = require('path')
+const path = require('node:path')
 
 // ...
 
@@ -183,7 +183,7 @@ provided to the renderer process. Please refer to
 
 ```javascript {6-13,25} title='main.js (Main Process)'
 const { app, BrowserWindow, dialog, ipcMain } = require('electron')
-const path = require('path')
+const path = require('node:path')
 
 // ...
 
@@ -378,7 +378,7 @@ target renderer.
 
 ```javascript {11-26} title='main.js (Main Process)'
 const { app, BrowserWindow, Menu, ipcMain } = require('electron')
-const path = require('path')
+const path = require('node:path')
 
 function createWindow () {
   const mainWindow = new BrowserWindow({

--- a/docs/tutorial/launch-app-from-url-in-another-app.md
+++ b/docs/tutorial/launch-app-from-url-in-another-app.md
@@ -27,7 +27,7 @@ control our application lifecycle and create a native browser window.
 
 ```javascript
 const { app, BrowserWindow, shell } = require('electron')
-const path = require('path')
+const path = require('node:path')
 ```
 
 Next, we will proceed to register our application to handle all "`electron-fiddle://`" protocols.

--- a/docs/tutorial/message-ports.md
+++ b/docs/tutorial/message-ports.md
@@ -303,7 +303,7 @@ without having to step through the isolated world.
 
 ```js title='main.js (Main Process)'
 const { BrowserWindow, app, MessageChannelMain } = require('electron')
-const path = require('path')
+const path = require('node:path')
 
 app.whenReady().then(async () => {
   // Create a BrowserWindow with contextIsolation enabled.

--- a/docs/tutorial/native-file-drag-drop.md
+++ b/docs/tutorial/native-file-drag-drop.md
@@ -22,7 +22,7 @@ In `preload.js` use the [`contextBridge`][] to inject a method `window.electron.
 
 ```js
 const { contextBridge, ipcRenderer } = require('electron')
-const path = require('path')
+const path = require('node:path')
 
 contextBridge.exposeInMainWorld('electron', {
   startDrag: (fileName) => {

--- a/docs/tutorial/offscreen-rendering.md
+++ b/docs/tutorial/offscreen-rendering.md
@@ -41,7 +41,7 @@ To enable this mode, GPU acceleration has to be disabled by calling the
 
 ```javascript fiddle='docs/fiddles/features/offscreen-rendering'
 const { app, BrowserWindow } = require('electron')
-const fs = require('fs')
+const fs = require('node:fs')
 
 app.disableHardwareAcceleration()
 

--- a/docs/tutorial/performance.md
+++ b/docs/tutorial/performance.md
@@ -174,7 +174,7 @@ equally fictitious `foo-parser` module. In traditional Node.js development,
 you might write code that eagerly loads dependencies:
 
 ```js title='parser.js' @ts-expect-error=[2]
-const fs = require('fs')
+const fs = require('node:fs')
 const fooParser = require('foo-parser')
 
 class Parser {
@@ -198,7 +198,7 @@ do this work a little later, when `getParsedFiles()` is actually called?
 
 ```js title='parser.js' @ts-expect-error=[20]
 // "fs" is likely already being loaded, so the `require()` call is cheap
-const fs = require('fs')
+const fs = require('node:fs')
 
 class Parser {
   async getFiles () {

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -292,7 +292,7 @@ to the `webPreferences.preload` option in your existing `BrowserWindow` construc
 ```js
 const { app, BrowserWindow } = require('electron')
 // include the Node.js 'path' module at the top of your file
-const path = require('path')
+const path = require('node:path')
 
 // modify your existing createWindow() function
 const createWindow = () => {
@@ -358,7 +358,7 @@ The full code is available below:
 
 // Modules to control application life and create native browser window
 const { app, BrowserWindow } = require('electron')
-const path = require('path')
+const path = require('node:path')
 
 const createWindow = () => {
   // Create the browser window.

--- a/docs/tutorial/recent-documents.md
+++ b/docs/tutorial/recent-documents.md
@@ -26,8 +26,8 @@ the application via JumpList or dock menu, respectively.
 
 ```javascript fiddle='docs/fiddles/features/recent-documents'
 const { app, BrowserWindow } = require('electron')
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 
 const createWindow = () => {
   const win = new BrowserWindow({

--- a/docs/tutorial/represented-file.md
+++ b/docs/tutorial/represented-file.md
@@ -29,7 +29,7 @@ To set the represented file of window, you can use the
 
 ```javascript fiddle='docs/fiddles/features/represented-file'
 const { app, BrowserWindow } = require('electron')
-const os = require('os')
+const os = require('node:os')
 
 const createWindow = () => {
   const win = new BrowserWindow({

--- a/docs/tutorial/tutorial-3-preload.md
+++ b/docs/tutorial/tutorial-3-preload.md
@@ -83,7 +83,7 @@ To attach this script to your renderer process, pass its path to the
 
 ```js {2,8-10} title="main.js"
 const { app, BrowserWindow } = require('electron')
-const path = require('path')
+const path = require('node:path')
 
 const createWindow = () => {
   const win = new BrowserWindow({
@@ -204,7 +204,7 @@ you send out the `invoke` call from the renderer.
 
 ```js {1,15} title="main.js"
 const { app, BrowserWindow, ipcMain } = require('electron')
-const path = require('path')
+const path = require('node:path')
 
 const createWindow = () => {
   const win = new BrowserWindow({

--- a/docs/tutorial/window-customization.md
+++ b/docs/tutorial/window-customization.md
@@ -184,7 +184,7 @@ allowing events such as `mouseleave` to be emitted:
 
 ```javascript title='main.js'
 const { BrowserWindow, ipcMain } = require('electron')
-const path = require('path')
+const path = require('node:path')
 
 const win = new BrowserWindow({
   webPreferences: {

--- a/docs/tutorial/windows-taskbar.md
+++ b/docs/tutorial/windows-taskbar.md
@@ -126,7 +126,7 @@ following lines:
 
 ```javascript
 const { BrowserWindow, nativeImage } = require('electron')
-const path = require('path')
+const path = require('node:path')
 
 const win = new BrowserWindow()
 


### PR DESCRIPTION
#### Description of Change

Core Node.js modules (e.g. `os`, `fs`, `path`) can be [imported using the `node:` prefixed syntax as of Node.js 16.0/14.18](https://nodejs.org/dist/latest-v18.x/docs/api/modules.html#core-modules). Node's own documentation has moved to use this prefix syntax for clarity reasons (https://github.com/nodejs/node/pull/42752).

After discussing with @electron/docs, we believe we should migrate the syntax in our docs as well to follow suit.

> **Note**
> None of the examples in `breaking-changes.md` have been updated since users may be on older versions of Electron that do not support the `node:` syntax.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
