### PR TITLE
docs: fix return typing of ses.getExtension

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -1491,7 +1491,7 @@ is emitted.
 
 * `extensionId` string - ID of extension to query
 
-Returns `Extension` | `null` - The loaded extension with the given ID.
+Returns `Extension | null` - The loaded extension with the given ID.
 
 **Note:** This API cannot be called before the `ready` event of the `app` module
 is emitted.


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

This isn't being processed properly by `electron/docs-parser`, looks like it's due to multiple backticked types being union'd together, when we normally do it inside of the backticks. See the [Artifact Comparison check output](https://github.com/electron/electron/pull/39697/checks?check_run_id=16363303239) for difference.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
