### PR TITLE
refactor: use `replaceAll()` instead of `replace()` when appropriate

### DIFF
--- a/lib/browser/api/dialog.ts
+++ b/lib/browser/api/dialog.ts
@@ -33,7 +33,7 @@ const normalizeAccessKey = (text: string) => {
   // macOS does not have access keys so remove single ampersands
   // and replace double ampersands with a single ampersand
   if (process.platform === 'darwin') {
-    return text.replace(/&(&?)/g, '$1');
+    return text.replaceAll(/&(&?)/g, '$1');
   }
 
   // Linux uses a single underscore as an access key prefix so escape
@@ -41,7 +41,7 @@ const normalizeAccessKey = (text: string) => {
   // ampersands with a single ampersand, and replace a single ampersand with
   // a single underscore
   if (process.platform === 'linux') {
-    return text.replace(/_/g, '__').replace(/&(.?)/g, (match, after) => {
+    return text.replaceAll('_', '__').replaceAll(/&(.?)/g, (match, after) => {
       if (after === '&') return after;
       return `_${after}`;
     });

--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -63,8 +63,8 @@ if (process.platform === 'win32') {
 
   if (fs.existsSync(updateDotExe)) {
     const packageDir = path.dirname(path.resolve(updateDotExe));
-    const packageName = path.basename(packageDir).replace(/\s/g, '');
-    const exeName = path.basename(process.execPath).replace(/\.exe$/i, '').replace(/\s/g, '');
+    const packageName = path.basename(packageDir).replaceAll(/\s/g, '');
+    const exeName = path.basename(process.execPath).replace(/\.exe$/i, '').replaceAll(/\s/g, '');
 
     app.setAppUserModelId(`com.squirrel.${packageName}.${exeName}`);
   }

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3425,7 +3425,7 @@ describe('BrowserWindow module', () => {
         w.loadURL(pageUrl);
         const [, url] = await once(ipcMain, 'answer');
         const expectedUrl = process.platform === 'win32'
-          ? 'file:///' + htmlPath.replace(/\\/g, '/')
+          ? 'file:///' + htmlPath.replaceAll('\\', '/')
           : pageUrl;
         expect(url).to.equal(expectedUrl);
       });
@@ -3475,7 +3475,7 @@ describe('BrowserWindow module', () => {
         w.loadURL(pageUrl);
         const [, { url, frameName, options }] = await once(w.webContents, 'did-create-window') as [BrowserWindow, Electron.DidCreateWindowDetails];
         const expectedUrl = process.platform === 'win32'
-          ? 'file:///' + htmlPath.replace(/\\/g, '/')
+          ? 'file:///' + htmlPath.replaceAll('\\', '/')
           : pageUrl;
         expect(url).to.equal(expectedUrl);
         expect(frameName).to.equal('popup!');

--- a/spec/api-debugger-spec.ts
+++ b/spec/api-debugger-spec.ts
@@ -111,7 +111,7 @@ describe('debugger module', () => {
     it('fires message event', async () => {
       const url = process.platform !== 'win32'
         ? `file://${path.join(fixtures, 'pages', 'a.html')}`
-        : `file:///${path.join(fixtures, 'pages', 'a.html').replace(/\\/g, '/')}`;
+        : `file:///${path.join(fixtures, 'pages', 'a.html').replaceAll('\\', '/')}`;
       w.webContents.loadURL(url);
       w.webContents.debugger.attach();
       const message = emittedUntil(w.webContents.debugger, 'message',

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -1128,7 +1128,7 @@ describe('protocol module', () => {
       protocol.handle('file', (req) => {
         let file;
         if (process.platform === 'win32') {
-          file = `file:///${filePath.replace(/\\/g, '/')}`;
+          file = `file:///${filePath.replaceAll('\\', '/')}`;
         } else {
           file = `file://${filePath}`;
         }

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -237,7 +237,7 @@ describe('session module', () => {
 
           appProcess.stdout.on('data', data => { output += data; });
           appProcess.on('exit', () => {
-            resolve(output.replace(/(\r\n|\n|\r)/gm, ''));
+            resolve(output.replaceAll(/(\r\n|\n|\r)/gm, ''));
           });
         });
       };

--- a/spec/api-web-request-spec.ts
+++ b/spec/api-web-request-spec.ts
@@ -181,7 +181,7 @@ describe('webRequest module', () => {
         callback({ cancel: true });
       });
       const fileURL = url.format({
-        pathname: path.join(fixturesPath, 'blank.html').replace(/\\/g, '/'),
+        pathname: path.join(fixturesPath, 'blank.html').replaceAll('\\', '/'),
         protocol: 'file',
         slashes: true
       });
@@ -395,7 +395,7 @@ describe('webRequest module', () => {
         onSendHeadersCalled = true;
       });
       await ajax(url.format({
-        pathname: path.join(fixturesPath, 'blank.html').replace(/\\/g, '/'),
+        pathname: path.join(fixturesPath, 'blank.html').replaceAll('\\', '/'),
         protocol: 'file',
         slashes: true
       }));

--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -90,7 +90,7 @@ describe('asar package', () => {
       await w.loadFile(path.join(fixtures, 'workers', 'load_worker.html'));
 
       const workerUrl = url.format({
-        pathname: path.resolve(fixtures, 'workers', 'workers.asar', 'worker.js').replace(/\\/g, '/'),
+        pathname: path.resolve(fixtures, 'workers', 'workers.asar', 'worker.js').replaceAll('\\', '/'),
         protocol: 'file',
         slashes: true
       });
@@ -103,7 +103,7 @@ describe('asar package', () => {
       await w.loadFile(path.join(fixtures, 'workers', 'load_shared_worker.html'));
 
       const workerUrl = url.format({
-        pathname: path.resolve(fixtures, 'workers', 'workers.asar', 'shared_worker.js').replace(/\\/g, '/'),
+        pathname: path.resolve(fixtures, 'workers', 'workers.asar', 'shared_worker.js').replaceAll('\\', '/'),
         protocol: 'file',
         slashes: true
       });
@@ -1243,7 +1243,7 @@ describe('asar package', function () {
           const echo = path.join(asarDir, 'echo.asar', 'echo');
 
           const stdout = await promisify(require(childProcess).exec)('echo ' + echo + ' foo bar');
-          expect(stdout.toString().replace(/\r/g, '')).to.equal(echo + ' foo bar\n');
+          expect(stdout.toString().replaceAll('\r', '')).to.equal(echo + ' foo bar\n');
         }, [childProcess]);
       });
 
@@ -1252,7 +1252,7 @@ describe('asar package', function () {
           const echo = path.join(asarDir, 'echo.asar', 'echo');
 
           const stdout = require(childProcess).execSync('echo ' + echo + ' foo bar');
-          expect(stdout.toString().replace(/\r/g, '')).to.equal(echo + ' foo bar\n');
+          expect(stdout.toString().replaceAll('\r', '')).to.equal(echo + ' foo bar\n');
         }, [childProcess]);
       });
 

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -284,7 +284,7 @@ describe('web security', () => {
   describe('accessing file://', () => {
     async function loadFile (w: BrowserWindow) {
       const thisFile = url.format({
-        pathname: __filename.replace(/\\/g, '/'),
+        pathname: __filename.replaceAll('\\', '/'),
         protocol: 'file',
         slashes: true
       });
@@ -461,7 +461,7 @@ describe('command line switches', () => {
         throw new Error(`Process exited with code "${code}" signal "${signal}" output "${output}" stderr "${stderr}"`);
       }
 
-      output = output.replace(/(\r\n|\n|\r)/gm, '');
+      output = output.replaceAll(/(\r\n|\n|\r)/gm, '');
       expect(output).to.equal(result);
     };
 
@@ -1050,7 +1050,7 @@ describe('chromium features', () => {
     it('defines a window.location getter', async () => {
       let targetURL: string;
       if (process.platform === 'win32') {
-        targetURL = `file:///${fixturesPath.replace(/\\/g, '/')}/pages/base-page.html`;
+        targetURL = `file:///${fixturesPath.replaceAll('\\', '/')}/pages/base-page.html`;
       } else {
         targetURL = `file://${fixturesPath}/pages/base-page.html`;
       }
@@ -1977,7 +1977,7 @@ describe('chromium features', () => {
 
   ifdescribe(features.isPDFViewerEnabled())('PDF Viewer', () => {
     const pdfSource = url.format({
-      pathname: path.join(__dirname, 'fixtures', 'cat.pdf').replace(/\\/g, '/'),
+      pathname: path.join(__dirname, 'fixtures', 'cat.pdf').replaceAll('\\', '/'),
       protocol: 'file',
       slashes: true
     });

--- a/spec/webview-spec.ts
+++ b/spec/webview-spec.ts
@@ -249,7 +249,7 @@ describe('<webview> tag', function () {
       });
       await w.loadURL('about:blank');
       const src = url.format({
-        pathname: `${fixtures.replace(/\\/g, '/')}/pages/theme-color.html`,
+        pathname: `${fixtures.replaceAll('\\', '/')}/pages/theme-color.html`,
         protocol: 'file',
         slashes: true
       });


### PR DESCRIPTION
Identified by https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-replace-all.md

Notes: none