### PR TITLE
fix: prevent errors when extensions listen for `chrome.tabs` events

### DIFF
--- a/shell/common/extensions/api/tabs.json
+++ b/shell/common/extensions/api/tabs.json
@@ -704,7 +704,350 @@
         }
       }
     ],
+    // Electron does not yet support tab events -  we define them here because otherwise extensions crash when
+    // they try to listen for them.
     "events": [
+      {
+        "name": "onCreated",
+        "type": "function",
+        "description": "Fired when a tab is created. Note that the tab's URL and tab group membership may not be set at the time this event is fired, but you can listen to onUpdated events so as to be notified when a URL is set or the tab is added to a tab group.",
+        "parameters": [
+          {
+            "$ref": "Tab",
+            "name": "tab",
+            "description": "Details of the tab that was created."
+          }
+        ]
+      },
+      {
+        "name": "onUpdated",
+        "type": "function",
+        "description": "Fired when a tab is updated.",
+        "parameters": [
+          {
+            "type": "integer",
+            "name": "tabId",
+            "minimum": 0
+          },
+          {
+            "type": "object",
+            "name": "changeInfo",
+            "description": "Lists the changes to the state of the tab that was updated.",
+            "properties": {
+              "status": {
+                "$ref": "TabStatus",
+                "optional": true,
+                "description": "The tab's loading status."
+              },
+              "url": {
+                "type": "string",
+                "optional": true,
+                "description": "The tab's URL if it has changed."
+              },
+              "groupId": {
+                "type": "integer",
+                "optional": true,
+                "minimum": -1,
+                "description": "The tab's new group."
+              },
+              "pinned": {
+                "type": "boolean",
+                "optional": true,
+                "description": "The tab's new pinned state."
+              },
+              "audible": {
+                "type": "boolean",
+                "optional": true,
+                "description": "The tab's new audible state."
+              },
+              "discarded": {
+                "type": "boolean",
+                "optional": true,
+                "description": "The tab's new discarded state."
+              },
+              "autoDiscardable": {
+                "type": "boolean",
+                "optional": true,
+                "description": "The tab's new auto-discardable state."
+              },
+              "mutedInfo": {
+                "$ref": "MutedInfo",
+                "optional": true,
+                "description": "The tab's new muted state and the reason for the change."
+              },
+              "favIconUrl": {
+                "type": "string",
+                "optional": true,
+                "description": "The tab's new favicon URL."
+              },
+              "title": {
+                "type": "string",
+                "optional": true,
+                "description": "The tab's new title."
+              }
+            }
+          },
+          {
+            "$ref": "Tab",
+            "name": "tab",
+            "description": "Gives the state of the tab that was updated."
+          }
+        ]
+      },
+      {
+        "name": "onMoved",
+        "type": "function",
+        "description": "Fired when a tab is moved within a window. Only one move event is fired, representing the tab the user directly moved. Move events are not fired for the other tabs that must move in response to the manually-moved tab. This event is not fired when a tab is moved between windows; for details, see $(ref:tabs.onDetached).",
+        "parameters": [
+          {
+            "type": "integer",
+            "name": "tabId",
+            "minimum": 0
+          },
+          {
+            "type": "object",
+            "name": "moveInfo",
+            "properties": {
+              "windowId": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "fromIndex": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "toIndex": {
+                "type": "integer",
+                "minimum": 0
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "onSelectionChanged",
+        "deprecated": "Please use $(ref:tabs.onActivated).",
+        "type": "function",
+        "description": "Fires when the selected tab in a window changes.",
+        "parameters": [
+          {
+            "type": "integer",
+            "name": "tabId",
+            "minimum": 0,
+            "description": "The ID of the tab that has become active."
+          },
+          {
+            "type": "object",
+            "name": "selectInfo",
+            "properties": {
+              "windowId": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "The ID of the window the selected tab changed inside of."
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "onActiveChanged",
+        "deprecated": "Please use $(ref:tabs.onActivated).",
+        "type": "function",
+        "description": "Fires when the selected tab in a window changes. Note that the tab's URL may not be set at the time this event fired, but you can listen to $(ref:tabs.onUpdated) events so as to be notified when a URL is set.",
+        "parameters": [
+          {
+            "type": "integer",
+            "name": "tabId",
+            "minimum": 0,
+            "description": "The ID of the tab that has become active."
+          },
+          {
+            "type": "object",
+            "name": "selectInfo",
+            "properties": {
+              "windowId": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "The ID of the window the selected tab changed inside of."
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "onActivated",
+        "type": "function",
+        "description": "Fires when the active tab in a window changes. Note that the tab's URL may not be set at the time this event fired, but you can listen to onUpdated events so as to be notified when a URL is set.",
+        "parameters": [
+          {
+            "type": "object",
+            "name": "activeInfo",
+            "properties": {
+              "tabId": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "The ID of the tab that has become active."
+              },
+              "windowId": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "The ID of the window the active tab changed inside of."
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "onHighlightChanged",
+        "deprecated": "Please use $(ref:tabs.onHighlighted).",
+        "type": "function",
+        "description": "Fired when the highlighted or selected tabs in a window changes.",
+        "parameters": [
+          {
+            "type": "object",
+            "name": "selectInfo",
+            "properties": {
+              "windowId": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "The window whose tabs changed."
+              },
+              "tabIds": {
+                "type": "array",
+                "name": "tabIds",
+                "items": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "description": "All highlighted tabs in the window."
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "onHighlighted",
+        "type": "function",
+        "description": "Fired when the highlighted or selected tabs in a window changes.",
+        "parameters": [
+          {
+            "type": "object",
+            "name": "highlightInfo",
+            "properties": {
+              "windowId": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "The window whose tabs changed."
+              },
+              "tabIds": {
+                "type": "array",
+                "name": "tabIds",
+                "items": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "description": "All highlighted tabs in the window."
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "onDetached",
+        "type": "function",
+        "description": "Fired when a tab is detached from a window; for example, because it was moved between windows.",
+        "parameters": [
+          {
+            "type": "integer",
+            "name": "tabId",
+            "minimum": 0
+          },
+          {
+            "type": "object",
+            "name": "detachInfo",
+            "properties": {
+              "oldWindowId": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "oldPosition": {
+                "type": "integer",
+                "minimum": 0
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "onAttached",
+        "type": "function",
+        "description": "Fired when a tab is attached to a window; for example, because it was moved between windows.",
+        "parameters": [
+          {
+            "type": "integer",
+            "name": "tabId",
+            "minimum": 0
+          },
+          {
+            "type": "object",
+            "name": "attachInfo",
+            "properties": {
+              "newWindowId": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "newPosition": {
+                "type": "integer",
+                "minimum": 0
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "onRemoved",
+        "type": "function",
+        "description": "Fired when a tab is closed.",
+        "parameters": [
+          {
+            "type": "integer",
+            "name": "tabId",
+            "minimum": 0
+          },
+          {
+            "type": "object",
+            "name": "removeInfo",
+            "properties": {
+              "windowId": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "The window whose tab is closed."
+              },
+              "isWindowClosing": {
+                "type": "boolean",
+                "description": "True when the tab was closed because its parent window was closed."
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "onReplaced",
+        "type": "function",
+        "description": "Fired when a tab is replaced with another tab due to prerendering or instant.",
+        "parameters": [
+          {
+            "type": "integer",
+            "name": "addedTabId",
+            "minimum": 0
+          },
+          {
+            "type": "integer",
+            "name": "removedTabId",
+            "minimum": 0
+          }
+        ]
+      },
       {
         "name": "onZoomChange",
         "type": "function",

--- a/shell/common/extensions/api/tabs.json
+++ b/shell/common/extensions/api/tabs.json
@@ -709,6 +709,7 @@
     "events": [
       {
         "name": "onCreated",
+        "deprecated": "chrome.tabs.onCreated is not current supported in Electron",
         "type": "function",
         "description": "Fired when a tab is created. Note that the tab's URL and tab group membership may not be set at the time this event is fired, but you can listen to onUpdated events so as to be notified when a URL is set or the tab is added to a tab group.",
         "parameters": [
@@ -721,6 +722,7 @@
       },
       {
         "name": "onUpdated",
+        "deprecated": "chrome.tabs.onUpdated is not current supported in Electron",
         "type": "function",
         "description": "Fired when a tab is updated.",
         "parameters": [
@@ -796,6 +798,7 @@
       },
       {
         "name": "onMoved",
+        "deprecated": "chrome.tabs.onMoved is not current supported in Electron",
         "type": "function",
         "description": "Fired when a tab is moved within a window. Only one move event is fired, representing the tab the user directly moved. Move events are not fired for the other tabs that must move in response to the manually-moved tab. This event is not fired when a tab is moved between windows; for details, see $(ref:tabs.onDetached).",
         "parameters": [
@@ -826,7 +829,7 @@
       },
       {
         "name": "onSelectionChanged",
-        "deprecated": "Please use $(ref:tabs.onActivated).",
+        "deprecated": "chrome.tabs.onSelectionChanged is not current supported in Electron",
         "type": "function",
         "description": "Fires when the selected tab in a window changes.",
         "parameters": [
@@ -851,7 +854,7 @@
       },
       {
         "name": "onActiveChanged",
-        "deprecated": "Please use $(ref:tabs.onActivated).",
+        "deprecated": "chrome.tabs.onActiveChanged is not current supported in Electron",
         "type": "function",
         "description": "Fires when the selected tab in a window changes. Note that the tab's URL may not be set at the time this event fired, but you can listen to $(ref:tabs.onUpdated) events so as to be notified when a URL is set.",
         "parameters": [
@@ -876,6 +879,7 @@
       },
       {
         "name": "onActivated",
+        "deprecated": "chrome.tabs.onActivated is not current supported in Electron",
         "type": "function",
         "description": "Fires when the active tab in a window changes. Note that the tab's URL may not be set at the time this event fired, but you can listen to onUpdated events so as to be notified when a URL is set.",
         "parameters": [
@@ -899,7 +903,7 @@
       },
       {
         "name": "onHighlightChanged",
-        "deprecated": "Please use $(ref:tabs.onHighlighted).",
+        "deprecated": "chrome.tabs.onHighlightChanged is not current supported in Electron",
         "type": "function",
         "description": "Fired when the highlighted or selected tabs in a window changes.",
         "parameters": [
@@ -927,6 +931,7 @@
       },
       {
         "name": "onHighlighted",
+        "deprecated": "chrome.tabs.onHighlighted is not current supported in Electron",
         "type": "function",
         "description": "Fired when the highlighted or selected tabs in a window changes.",
         "parameters": [
@@ -954,6 +959,7 @@
       },
       {
         "name": "onDetached",
+        "deprecated": "chrome.tabs.onDetached is not current supported in Electron",
         "type": "function",
         "description": "Fired when a tab is detached from a window; for example, because it was moved between windows.",
         "parameters": [
@@ -980,6 +986,7 @@
       },
       {
         "name": "onAttached",
+        "deprecated": "chrome.tabs.onAttached is not current supported in Electron",
         "type": "function",
         "description": "Fired when a tab is attached to a window; for example, because it was moved between windows.",
         "parameters": [
@@ -1006,6 +1013,7 @@
       },
       {
         "name": "onRemoved",
+        "deprecated": "chrome.tabs.onRemoved is not current supported in Electron",
         "type": "function",
         "description": "Fired when a tab is closed.",
         "parameters": [
@@ -1033,6 +1041,7 @@
       },
       {
         "name": "onReplaced",
+        "deprecated": "chrome.tabs.onReplaced is not current supported in Electron",
         "type": "function",
         "description": "Fired when a tab is replaced with another tab due to prerendering or instant.",
         "parameters": [
@@ -1050,6 +1059,7 @@
       },
       {
         "name": "onZoomChange",
+        "deprecated": "chrome.tabs.onZoomChange is not current supported in Electron",
         "type": "function",
         "description": "Fired when a tab is zoomed.",
         "parameters": [


### PR DESCRIPTION
#### Description of Change

Fixes two errors in Chrome extensions that are thrown when extensions listen for `chrome.tabs`. Initially, these weren't added to our `tabs.json` file as we didn't initially intend to support them. However, the way that extension generation works, omitting them from the JSON file actually means that attempting to listen to them _at all_ will throw an error, which we don't want.  We don't need to implement them or make them work as intended in order to define them as valid events to listen to here. No documentation or tests are changed as support has not changed as a result of this PR.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an error where listening to certain `chrome.tabs` events would throw incorrectly.
