### PR TITLE
fix: devtools allow restoring saved dock state on Windows

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2667,14 +2667,6 @@ void WebContents::OpenDevTools(gin::Arguments* args) {
     state = "detach";
   }
 
-#if BUILDFLAG(IS_WIN)
-  auto* win = static_cast<NativeWindowViews*>(owner_window());
-  // Force a detached state when WCO is enabled to match Chrome
-  // behavior and prevent occlusion of DevTools.
-  if (win && win->IsWindowControlsOverlayEnabled())
-    state = "detach";
-#endif
-
   bool activate = true;
   std::string title;
   if (args && args->Length() == 1) {

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -40,13 +40,6 @@ namespace electron {
 
 namespace {
 
-bool IsAppRTL() {
-  const std::string& locale = g_browser_process->GetApplicationLocale();
-  base::i18n::TextDirection text_direction =
-      base::i18n::GetTextDirectionForLocaleInStartUp(locale.c_str());
-  return text_direction == base::i18n::RIGHT_TO_LEFT;
-}
-
 NSString* GetAppPathForProtocol(const GURL& url) {
   NSURL* ns_url = [NSURL
       URLWithString:base::SysUTF8ToNSString(url.possibly_invalid_spec())];

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -596,14 +596,10 @@ void InspectableWebContents::LoadCompleted() {
       // position overlaps with the position of window controls to avoid
       // broken layout.
       if (win && win->IsWindowControlsOverlayEnabled()) {
-        if (IsAppRTL()) {
-          if (dock_state_ == "left") {
-            dock_state_ = "undocked";
-          }
-        } else {
-          if (dock_state_ == "right") {
-            dock_state_ = "undocked";
-          }
+        if (IsAppRTL() && dock_state_ == "left") {
+          dock_state_ = "undocked";
+        } else if (dock_state_ == "right") {
+          dock_state_ = "undocked";
         }
       }
     }

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -44,11 +44,13 @@
 #include "services/network/public/cpp/simple_url_loader_stream_consumer.h"
 #include "services/network/public/cpp/wrapper_shared_url_loader_factory.h"
 #include "shell/browser/api/electron_api_web_contents.h"
+#include "shell/browser/native_window_views.h"
 #include "shell/browser/net/asar/asar_url_loader_factory.h"
 #include "shell/browser/protocol_registry.h"
 #include "shell/browser/ui/inspectable_web_contents_delegate.h"
 #include "shell/browser/ui/inspectable_web_contents_view.h"
 #include "shell/browser/ui/inspectable_web_contents_view_delegate.h"
+#include "shell/common/application_info.h"
 #include "shell/common/platform_util.h"
 #include "third_party/blink/public/common/logging/logging_utils.h"
 #include "third_party/blink/public/common/page/page_zoom.h"
@@ -585,6 +587,27 @@ void InspectableWebContents::LoadCompleted() {
           prefs.FindString("currentDockState");
       base::RemoveChars(*current_dock_state, "\"", &dock_state_);
     }
+#if BUILDFLAG(IS_WIN)
+    auto* api_web_contents = api::WebContents::From(GetWebContents());
+    if (api_web_contents) {
+      auto* win =
+          static_cast<NativeWindowViews*>(api_web_contents->owner_window());
+      // When WCO is enabled, undock the devtools if the current dock
+      // position overlaps with the position of window controls to avoid
+      // broken layout.
+      if (win && win->IsWindowControlsOverlayEnabled()) {
+        if (IsAppRTL()) {
+          if (dock_state_ == "left") {
+            dock_state_ = "undocked";
+          }
+        } else {
+          if (dock_state_ == "right") {
+            dock_state_ = "undocked";
+          }
+        }
+      }
+    }
+#endif
     std::u16string javascript = base::UTF8ToUTF16(
         "UI.DockController.instance().setDockSide(\"" + dock_state_ + "\");");
     GetDevToolsWebContents()->GetPrimaryMainFrame()->ExecuteJavaScript(

--- a/shell/common/application_info.cc
+++ b/shell/common/application_info.cc
@@ -4,8 +4,10 @@
 
 #include "shell/common/application_info.h"
 
+#include "base/i18n/rtl.h"
 #include "base/no_destructor.h"
 #include "base/strings/stringprintf.h"
+#include "chrome/browser/browser_process.h"
 #include "chrome/common/chrome_version.h"
 #include "content/public/common/user_agent.h"
 #include "electron/electron_version.h"
@@ -45,6 +47,13 @@ std::string GetApplicationUserAgent() {
         name.c_str(), browser->GetVersion().c_str(), CHROME_VERSION_STRING);
   }
   return content::BuildUserAgentFromProduct(user_agent);
+}
+
+bool IsAppRTL() {
+  const std::string& locale = g_browser_process->GetApplicationLocale();
+  base::i18n::TextDirection text_direction =
+      base::i18n::GetTextDirectionForLocaleInStartUp(locale.c_str());
+  return text_direction == base::i18n::RIGHT_TO_LEFT;
 }
 
 }  // namespace electron

--- a/shell/common/application_info.h
+++ b/shell/common/application_info.h
@@ -25,6 +25,8 @@ std::string GetApplicationVersion();
 // Returns the user agent of Electron.
 std::string GetApplicationUserAgent();
 
+bool IsAppRTL();
+
 #if BUILDFLAG(IS_WIN)
 PCWSTR GetRawAppUserModelID();
 bool GetAppUserModelID(ScopedHString* app_id);


### PR DESCRIPTION
#### Description of Change

https://github.com/electron/electron/pull/35209 defaulted to `detach` position when opening devtools without any predefined state to workaround a bug in chromium, this took away the docking feature of devtools on Windows. https://github.com/electron/electron/pull/35754 was later added to respect the `state` option when opening devtools, although it is a good enough solution it takes away the option to rely on preferred dock state persisted to user data dir when opening devtools without any arguments.

This PR attempts to respect the persisted preferred dock state when WCO is enabled on Windows and instead of detaching the devtools it will now `undock` depending the dock state corresponding to the position of window controls. This allows users to still have control over the dock position without the application enforcing it.

Needed for https://github.com/microsoft/vscode/issues/168454

#### Release Notes

Notes: fix devtools to allow restoring saved dock state on Windows