### PR TITLE
docs: update node and chromium link in default_app

### DIFF
--- a/default_app/preload.ts
+++ b/default_app/preload.ts
@@ -43,8 +43,8 @@ async function initialize () {
   }
 
   replaceText('.electron-version', `Electron v${process.versions.electron}`);
-  replaceText('.chrome-version', `Chromium v${process.versions.chrome}`);
-  replaceText('.node-version', `Node v${process.versions.node}`);
+  replaceText('.chrome-version', `<a href="https://www.chromium.org/v${process.versions.chrome}">Chromium v${process.versions.chrome}</a>`);
+  replaceText('.node-version', `<a href="https://nodejs.org/docs/v${process.versions.node}">Node v${process.versions.node}</a>`);
   replaceText('.v8-version', `v8 v${process.versions.v8}`);
   replaceText('.command-example', `${electronPath} path-to-app`);
 


### PR DESCRIPTION
#### Description of Change

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes:  #14728 issue: update node and chromium link

![docs link](https://github.com/electron/electron/assets/92733250/7d543b4e-b3d0-4a41-b1b6-91c68b5b3fc3)

