### PR TITLE
test: enable Node.js report specs

### DIFF
--- a/patches/node/build_add_gn_build_files.patch
+++ b/patches/node/build_add_gn_build_files.patch
@@ -2104,6 +2104,38 @@ index 0000000000000000000000000000000000000000..4ab828dcbf322a9e28674e48c4a6868b
 +  script = "../../tools/compress_json.py"
 +  args = rebase_path(inputs + outputs, root_build_dir)
 +}
+diff --git a/src/node_metadata.cc b/src/node_metadata.cc
+index 6fe09f843e26b7f29faadf5035d368ed8b7eba38..c62132b6e1a37367611ba64fe90c0c94ffc1baa9 100644
+--- a/src/node_metadata.cc
++++ b/src/node_metadata.cc
+@@ -13,6 +13,7 @@
+ #include "uvwasi.h"
+ #include "v8.h"
+ #include "zlib.h"
++#include "electron/electron_version.h"
+ 
+ #if HAVE_OPENSSL
+ #include <openssl/opensslv.h>
+@@ -75,6 +76,7 @@ void Metadata::Versions::InitializeIntlVersions() {
+ Metadata::Versions::Versions() {
+   node = NODE_VERSION_STRING;
+   v8 = v8::V8::GetVersion();
++  electron = ELECTRON_VERSION_STRING;
+   uv = uv_version_string();
+   zlib = ZLIB_VERSION;
+   ares = ARES_VERSION_STR;
+diff --git a/src/node_metadata.h b/src/node_metadata.h
+index 1831bfd0baaac70277fc274a72235bf6a04697cb..3949e701543989f0e63a8ed59ae1adf41ffb04e2 100644
+--- a/src/node_metadata.h
++++ b/src/node_metadata.h
+@@ -36,6 +36,7 @@ namespace node {
+ #define NODE_VERSIONS_KEYS_BASE(V)                                             \
+   V(node)                                                                      \
+   V(v8)                                                                        \
++  V(electron)                                                                  \
+   V(uv)                                                                        \
+   V(zlib)                                                                      \
+   V(brotli)                                                                    \
 diff --git a/src/node_version.h b/src/node_version.h
 index 1e898ffcc9104bc50079a9850dc89767199c646e..0f5c5f1cc0845b5d005697d8ab1ab6167c541ced 100644
 --- a/src/node_version.h

--- a/patches/node/fix_handle_boringssl_and_openssl_incompatibilities.patch
+++ b/patches/node/fix_handle_boringssl_and_openssl_incompatibilities.patch
@@ -335,12 +335,12 @@ index 87d6ab3b9970e48db53cf7061d7208679c8b1dfc..4d79fbb4a30a7e57a7456413685706d9
  }  // namespace
  
 diff --git a/src/node_metadata.cc b/src/node_metadata.cc
-index 6fe09f843e26b7f29faadf5035d368ed8b7eba38..326a9ee8a6d24d0c78537bfe5d9da394a439da90 100644
+index c62132b6e1a37367611ba64fe90c0c94ffc1baa9..80c1b1684045d4afed014c9b64f164ce98a2cf67 100644
 --- a/src/node_metadata.cc
 +++ b/src/node_metadata.cc
-@@ -14,7 +14,7 @@
- #include "v8.h"
+@@ -15,7 +15,7 @@
  #include "zlib.h"
+ #include "electron/electron_version.h"
  
 -#if HAVE_OPENSSL
 +#if HAVE_OPENSSL && !defined(OPENSSL_IS_BORINGSSL)
@@ -348,7 +348,7 @@ index 6fe09f843e26b7f29faadf5035d368ed8b7eba38..326a9ee8a6d24d0c78537bfe5d9da394
  #if NODE_OPENSSL_HAS_QUIC
  #include <openssl/quic.h>
 diff --git a/src/node_metadata.h b/src/node_metadata.h
-index 1831bfd0baaac70277fc274a72235bf6a04697cb..1c0a3fcdeb44dc947bb8c38459533779575379da 100644
+index 3949e701543989f0e63a8ed59ae1adf41ffb04e2..0b4c3ce4484dca49027ad4ace311da39fc7dc922 100644
 --- a/src/node_metadata.h
 +++ b/src/node_metadata.h
 @@ -6,7 +6,7 @@

--- a/script/node-disabled-tests.json
+++ b/script/node-disabled-tests.json
@@ -132,17 +132,6 @@
   "parallel/test-worker-no-atomics",
   "parallel/test-worker-no-sab",
   "parallel/test-zlib-unused-weak",
-  "report/test-report-fatalerror-oomerror-compact",
-  "report/test-report-fatalerror-oomerror-directory",
-  "report/test-report-fatalerror-oomerror-filename",
-  "report/test-report-fatalerror-oomerror-set",
-  "report/test-report-getreport",
-  "report/test-report-signal",
-  "report/test-report-uncaught-exception",
-  "report/test-report-uncaught-exception-compat",
-  "report/test-report-uv-handles",
-  "report/test-report-worker",
-  "report/test-report-writereport",
   "sequential/test-tls-connect",
   "wpt/test-webcrypto"
 ]

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -235,11 +235,6 @@ int NodeMain(int argc, char* argv[]) {
 #endif
 
       process.Set("crashReporter", reporter);
-
-      gin_helper::Dictionary versions;
-      if (process.Get("versions", &versions)) {
-        versions.SetReadOnly(ELECTRON_PROJECT_NAME, ELECTRON_VERSION_STRING);
-      }
     }
 
     v8::HandleScope scope(isolate);

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -87,7 +87,6 @@ void ElectronBindings::BindTo(v8::Isolate* isolate,
 
   gin_helper::Dictionary versions;
   if (dict.Get("versions", &versions)) {
-    versions.SetReadOnly(ELECTRON_PROJECT_NAME, ELECTRON_VERSION_STRING);
     versions.SetReadOnly("chrome", CHROME_VERSION_STRING);
   }
 }


### PR DESCRIPTION
#### Description of Change

Enable Node.js report tests by shifting electron version binding to `process.versions`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none