### PR TITLE
fix: fullscreen crashing with no roundedCorners and no frame

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -683,9 +683,6 @@ void NativeWindowMac::DetachChildren() {
 }
 
 void NativeWindowMac::SetFullScreen(bool fullscreen) {
-  if (!has_frame() && !HasStyleMask(NSWindowStyleMaskTitled))
-    return;
-
   // [NSWindow -toggleFullScreen] is an asynchronous operation, which means
   // that it's possible to call it while a fullscreen transition is currently
   // in process. This can create weird behavior (incl. phantom windows),
@@ -718,7 +715,8 @@ void NativeWindowMac::SetFullScreen(bool fullscreen) {
                                      ? FullScreenTransitionState::kEntering
                                      : FullScreenTransitionState::kExiting;
 
-  [window_ toggleFullScreenMode:nil];
+  if (![window_ toggleFullScreenMode:nil])
+    fullscreen_transition_state_ = FullScreenTransitionState::kNone;
 }
 
 bool NativeWindowMac::IsFullscreen() const {

--- a/shell/browser/ui/cocoa/electron_ns_window.h
+++ b/shell/browser/ui/cocoa/electron_ns_window.h
@@ -44,7 +44,7 @@ class ScopedDisableResize {
 - (electron::NativeWindowMac*)shell;
 - (id)accessibilityFocusedUIElement;
 - (NSRect)originalContentRectForFrameRect:(NSRect)frameRect;
-- (void)toggleFullScreenMode:(id)sender;
+- (BOOL)toggleFullScreenMode:(id)sender;
 - (NSImage*)_cornerMask;
 @end
 

--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -334,7 +334,10 @@ void SwizzleSwipeWithEvent(NSView* view, SEL swiz_selector) {
   }
 }
 
-- (void)toggleFullScreenMode:(id)sender {
+- (BOOL)toggleFullScreenMode:(id)sender {
+  if (!shell_->has_frame() && !shell_->HasStyleMask(NSWindowStyleMaskTitled))
+    return NO;
+
   bool is_simple_fs = shell_->IsSimpleFullScreen();
   bool always_simple_fs = shell_->always_simple_fullscreen();
 
@@ -363,6 +366,8 @@ void SwizzleSwipeWithEvent(NSView* view, SEL swiz_selector) {
     bool maximizable = shell_->IsMaximizable();
     shell_->SetMaximizable(maximizable);
   }
+
+  return YES;
 }
 
 - (void)performMiniaturize:(id)sender {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/35403.

Patches a gap in https://github.com/electron/electron/pull/35421 - we also need to prevent fullscreen entrance via menu.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where BrowserWindows could crash on macOS with `frame: false` and `roundedCorners: false` when going fullscreen.
