### PR TITLE
chore: cherry-pick 3 changes from Release-3-M116

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -142,3 +142,5 @@ cherry-pick-aa23556ff213.patch
 networkcontext_don_t_access_url_loader_factories_during_destruction.patch
 cherry-pick-1939f7b78eda.patch
 cherry-pick-35c06406a658.patch
+cherry-pick-74a2eb9c8cb2.patch
+cherry-pick-26175b0903d8.patch

--- a/patches/chromium/cherry-pick-26175b0903d8.patch
+++ b/patches/chromium/cherry-pick-26175b0903d8.patch
@@ -1,0 +1,61 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yi Gu <yigu@chromium.org>
+Date: Thu, 31 Aug 2023 20:12:41 +0000
+Subject: [FedCM] ReportBadMessage when the provider list is empty
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The provider list should not be empty unless the API is called from a
+compromised renderer.
+
+(cherry picked from commit 3b19acb01dcea93b423aa0da56c4a9811a067353)
+
+Change-Id: I3e497fae2343342b3ec6b17bd663f2ec1bf12d54
+Bug: 1476403
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4822925
+Reviewed-by: Nicolás Peña <npm@chromium.org>
+Commit-Queue: Yi Gu <yigu@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1189841}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4833411
+Commit-Queue: Nicolás Peña <npm@chromium.org>
+Auto-Submit: Yi Gu <yigu@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5845@{#1698}
+Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
+
+diff --git a/content/browser/webid/federated_auth_request_impl.cc b/content/browser/webid/federated_auth_request_impl.cc
+index cbae35e588c2db4ac83a23d62fa7c5b0aec09324..194e4d937562ce73fb6e1e095dc16d13f74f002b 100644
+--- a/content/browser/webid/federated_auth_request_impl.cc
++++ b/content/browser/webid/federated_auth_request_impl.cc
+@@ -415,6 +415,16 @@ void FederatedAuthRequestImpl::RequestToken(
+     mojo::ReportBadMessage("idp_get_params_ptrs is empty.");
+     return;
+   }
++  // This could only happen with a compromised renderer process. We ensure that
++  // the provider list size is > 0 on the renderer side at the beginning of
++  // parsing |IdentityCredentialRequestOptions|.
++  for (auto& idp_get_params_ptr : idp_get_params_ptrs) {
++    if (idp_get_params_ptr->providers.size() == 0) {
++      mojo::ReportBadMessage("The provider list should not be empty.");
++      return;
++    }
++  }
++
+   // It should not be possible to receive multiple IDPs when the
+   // `kFedCmMultipleIdentityProviders` flag is disabled. But such a message
+   // could be received from a compromised renderer.
+@@ -425,14 +435,6 @@ void FederatedAuthRequestImpl::RequestToken(
+     return;
+   }
+ 
+-  // Check that providers are non-empty.
+-  for (auto& idp_get_params_ptr : idp_get_params_ptrs) {
+-    if (idp_get_params_ptr->providers.size() == 0) {
+-      std::move(callback).Run(RequestTokenStatus::kError, absl::nullopt, "");
+-      return;
+-    }
+-  }
+-
+   if (!fedcm_metrics_) {
+     // TODO(crbug.com/1307709): Handle FedCmMetrics for multiple IDPs.
+     fedcm_metrics_ =

--- a/patches/chromium/cherry-pick-26175b0903d8.patch
+++ b/patches/chromium/cherry-pick-26175b0903d8.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Yi Gu <yigu@chromium.org>
 Date: Thu, 31 Aug 2023 20:12:41 +0000
-Subject: [FedCM] ReportBadMessage when the provider list is empty
+Subject: ReportBadMessage when the provider list is empty
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/patches/chromium/cherry-pick-74a2eb9c8cb2.patch
+++ b/patches/chromium/cherry-pick-74a2eb9c8cb2.patch
@@ -1,7 +1,7 @@
-From 74a2eb9c8cb203d7cb916cfcd73053b1be745a2b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Yoichi Osato <yoichio@chromium.org>
 Date: Tue, 29 Aug 2023 02:37:46 +0000
-Subject: [PATCH] Readd lock when ObserverListMap::erase()
+Subject: Readd lock when ObserverListMap::erase()
 
 We should lock when remove an item from the map.
 This lock was accidentally removed in:
@@ -22,13 +22,12 @@ Reviewed-by: Kent Tamura <tkent@chromium.org>
 Commit-Queue: Kent Tamura <tkent@chromium.org>
 Cr-Commit-Position: refs/branch-heads/5845@{#1666}
 Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
----
 
 diff --git a/third_party/blink/renderer/platform/network/network_state_notifier.cc b/third_party/blink/renderer/platform/network/network_state_notifier.cc
-index 39c417e..e74b4ea4 100644
+index 39c417e0f8ec672d413bb69a3b98f06442183295..e74b4ea41b2b30037890f36dd9ff81d6ef3c4e88 100644
 --- a/third_party/blink/renderer/platform/network/network_state_notifier.cc
 +++ b/third_party/blink/renderer/platform/network/network_state_notifier.cc
-@@ -350,6 +350,7 @@
+@@ -350,6 +350,7 @@ void NetworkStateNotifier::RemoveObserver(
    DCHECK(task_runner->RunsTasksInCurrentSequence());
    DCHECK(observer);
  

--- a/patches/chromium/cherry-pick-74a2eb9c8cb2.patch
+++ b/patches/chromium/cherry-pick-74a2eb9c8cb2.patch
@@ -1,0 +1,38 @@
+From 74a2eb9c8cb203d7cb916cfcd73053b1be745a2b Mon Sep 17 00:00:00 2001
+From: Yoichi Osato <yoichio@chromium.org>
+Date: Tue, 29 Aug 2023 02:37:46 +0000
+Subject: [PATCH] Readd lock when ObserverListMap::erase()
+
+We should lock when remove an item from the map.
+This lock was accidentally removed in:
+https://chromium-review.googlesource.com/c/chromium/src/+/4280021
+
+(cherry picked from commit a41479ba6efb5e48b82edad972c7dded6f385b79)
+
+Bug: 1469928
+Change-Id: I2512e14d4ad9b246cadae947023dbccb5158da51
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4790983
+Auto-Submit: Yoichi Osato <yoichio@chromium.org>
+Reviewed-by: Yoichi Osato <yoichio@chromium.org>
+Reviewed-by: Koji Ishii <kojii@chromium.org>
+Commit-Queue: Koji Ishii <kojii@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1187668}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4820108
+Reviewed-by: Kent Tamura <tkent@chromium.org>
+Commit-Queue: Kent Tamura <tkent@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5845@{#1666}
+Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
+---
+
+diff --git a/third_party/blink/renderer/platform/network/network_state_notifier.cc b/third_party/blink/renderer/platform/network/network_state_notifier.cc
+index 39c417e..e74b4ea4 100644
+--- a/third_party/blink/renderer/platform/network/network_state_notifier.cc
++++ b/third_party/blink/renderer/platform/network/network_state_notifier.cc
+@@ -350,6 +350,7 @@
+   DCHECK(task_runner->RunsTasksInCurrentSequence());
+   DCHECK(observer);
+ 
++  base::AutoLock locker(lock_);
+   ObserverListMap& map = GetObserverMapFor(type);
+   DCHECK_NE(map.end(), map.find(observer));
+   map.erase(observer);

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -19,3 +19,4 @@ merged_compiler_stackcheck_can_have_side_effects.patch
 cherry-pick-8ff63d378f2c.patch
 cherry-pick-d671b099a57d.patch
 merged_squashed_multiple_commits.patch
+cherry-pick-038530c94a06.patch

--- a/patches/v8/cherry-pick-038530c94a06.patch
+++ b/patches/v8/cherry-pick-038530c94a06.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tobias Tebbi <tebbi@chromium.org>
+Date: Wed, 30 Aug 2023 10:59:48 +0200
+Subject: Merged: [turbofan] Growing a non-JSArray packed elements kind makes
+ it holey
+
+Bug: chromium:1473247
+(cherry picked from commit ae7dc61652805bc8e2b060d53b2b6da7cf846b6f)
+
+Change-Id: I5268513bc91ca0cc18e3e2115244c0b090afa0da
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4831892
+Auto-Submit: Leszek Swirski <leszeks@chromium.org>
+Owners-Override: Leszek Swirski <leszeks@chromium.org>
+Commit-Queue: Darius Mercadier <dmercadier@chromium.org>
+Reviewed-by: Darius Mercadier <dmercadier@chromium.org>
+Commit-Queue: Leszek Swirski <leszeks@chromium.org>
+Cr-Commit-Position: refs/branch-heads/11.6@{#34}
+Cr-Branched-From: e29c028f391389a7a60ee37097e3ca9e396d6fa4-refs/heads/11.6.189@{#3}
+Cr-Branched-From: 95cbef20e2aa556a1ea75431a48b36c4de6b9934-refs/heads/main@{#88340}
+
+diff --git a/src/compiler/js-native-context-specialization.cc b/src/compiler/js-native-context-specialization.cc
+index b6336828e564902923acefb789dc852aa56b8419..c2f9a4e0d1d2f8f1421ca17ee2c120e16fd09da5 100644
+--- a/src/compiler/js-native-context-specialization.cc
++++ b/src/compiler/js-native-context-specialization.cc
+@@ -3423,15 +3423,21 @@ JSNativeContextSpecialization::BuildElementAccess(
+       // the (potential) backing store growth would normalize and thus
+       // the elements kind of the {receiver} would change to slow mode.
+       //
+-      // For PACKED_*_ELEMENTS the {index} must be within the range
++      // For JSArray PACKED_*_ELEMENTS the {index} must be within the range
+       // [0,length+1[ to be valid. In case {index} equals {length},
+       // the {receiver} will be extended, but kept packed.
++      //
++      // Non-JSArray PACKED_*_ELEMENTS always grow by adding holes because they
++      // lack the magical length property, which requires a map transition.
++      // So we can assume that this did not happen if we did not see this map.
+       Node* limit =
+           IsHoleyElementsKind(elements_kind)
+               ? graph()->NewNode(simplified()->NumberAdd(), elements_length,
+                                  jsgraph()->Constant(JSObject::kMaxGap))
+-              : graph()->NewNode(simplified()->NumberAdd(), length,
+-                                 jsgraph()->OneConstant());
++          : receiver_is_jsarray
++              ? graph()->NewNode(simplified()->NumberAdd(), length,
++                                 jsgraph()->OneConstant())
++              : elements_length;
+       index = effect = graph()->NewNode(
+           simplified()->CheckBounds(
+               FeedbackSource(), CheckBoundsFlag::kConvertStringAndMinusZero),


### PR DESCRIPTION
<details>
<summary>electron/security#402 - 74a2eb9c8cb2 from chromium</summary>
Readd lock when ObserverListMap::erase()

We should lock when remove an item from the map.
This lock was accidentally removed in:
https://chromium-review.googlesource.com/c/chromium/src/+/4280021

(cherry picked from commit a41479ba6efb5e48b82edad972c7dded6f385b79)

Bug: 1469928
Change-Id: I2512e14d4ad9b246cadae947023dbccb5158da51
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4790983
Auto-Submit: Yoichi Osato <yoichio@chromium.org>
Reviewed-by: Yoichi Osato <yoichio@chromium.org>
Reviewed-by: Koji Ishii <kojii@chromium.org>
Commit-Queue: Koji Ishii <kojii@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1187668}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4820108
Reviewed-by: Kent Tamura <tkent@chromium.org>
Commit-Queue: Kent Tamura <tkent@chromium.org>
Cr-Commit-Position: refs/branch-heads/5845@{#1666}
Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
</details>

<details>
<summary>electron/security#401 - 038530c94a06 from v8</summary>
Merged: [turbofan] Growing a non-JSArray packed elements kind makes it holey

Bug: chromium:1473247
(cherry picked from commit ae7dc61652805bc8e2b060d53b2b6da7cf846b6f)

Change-Id: I5268513bc91ca0cc18e3e2115244c0b090afa0da
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4831892
Auto-Submit: Leszek Swirski <leszeks@chromium.org>
Owners-Override: Leszek Swirski <leszeks@chromium.org>
Commit-Queue: Darius Mercadier <dmercadier@chromium.org>
Reviewed-by: Darius Mercadier <dmercadier@chromium.org>
Commit-Queue: Leszek Swirski <leszeks@chromium.org>
Cr-Commit-Position: refs/branch-heads/11.6@{#34}
Cr-Branched-From: e29c028f391389a7a60ee37097e3ca9e396d6fa4-refs/heads/11.6.189@{#3}
Cr-Branched-From: 95cbef20e2aa556a1ea75431a48b36c4de6b9934-refs/heads/main@{#88340}
</details>

<details>
<summary>electron/security#400 - 26175b0903d8 from chromium</summary>
[FedCM] ReportBadMessage when the provider list is empty

The provider list should not be empty unless the API is called from a
compromised renderer.

(cherry picked from commit 3b19acb01dcea93b423aa0da56c4a9811a067353)

Change-Id: I3e497fae2343342b3ec6b17bd663f2ec1bf12d54
Bug: 1476403
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4822925
Reviewed-by: Nicolás Peña <npm@chromium.org>
Commit-Queue: Yi Gu <yigu@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1189841}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4833411
Commit-Queue: Nicolás Peña <npm@chromium.org>
Auto-Submit: Yi Gu <yigu@chromium.org>
Cr-Commit-Position: refs/branch-heads/5845@{#1698}
Cr-Branched-From: 5a5dff63a4a4c63b9b18589819bebb2566c85443-refs/heads/main@{#1160321}
</details>

Notes:
* Security: backported fix for CVE-2023-4763.
* Security: backported fix for CVE-2023-4762.
* Security: backported fix for CVE-2023-4761.