### PR TITLE
fix: make titlebar opaque while fullscreen

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1692,6 +1692,9 @@ void NativeWindowMac::NotifyWindowEnterFullScreen() {
   // Restore the window title under fullscreen mode.
   if (buttons_proxy_)
     [window_ setTitleVisibility:NSWindowTitleVisible];
+
+  if (transparent() || !has_frame())
+    [window_ setTitlebarAppearsTransparent:NO];
 }
 
 void NativeWindowMac::NotifyWindowLeaveFullScreen() {
@@ -1701,6 +1704,9 @@ void NativeWindowMac::NotifyWindowLeaveFullScreen() {
     [buttons_proxy_ redraw];
     [buttons_proxy_ setVisible:YES];
   }
+
+  if (transparent() || !has_frame())
+    [window_ setTitlebarAppearsTransparent:YES];
 }
 
 void NativeWindowMac::NotifyWindowWillEnterFullScreen() {


### PR DESCRIPTION
Screenshots included for reference

| | Windowed | Fullscreen |
|-|-|-|
| **Before** | <img width="912" alt="image" src="https://github.com/electron/electron/assets/6634592/e1408faa-4196-4bbe-89d3-b98b4660c2b5"> | <img width="1728" alt="image" src="https://github.com/electron/electron/assets/6634592/a55ebc1c-099d-4a84-8808-0299a6eb9722"> |
| **After** | <img width="912" alt="image" src="https://github.com/electron/electron/assets/6634592/fd2ce9c2-9c4f-4799-9d62-5a069543a8d6"> | <img width="1728" alt="image" src="https://github.com/electron/electron/assets/6634592/a3a9e956-f5f7-44a2-8e44-5c4bafa2275d"> |

Note in fullscreen the titlebar only "peeks" over the content if you mouseover the top of the screen, it doesn't take up any frame dimensions

Notes: Fixed issue where titlebar would be transparent for transparent windows that are fullscreen