### PR TITLE
fix: raw_ptr destruction order in NodeBindings

### DIFF
--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -394,19 +394,11 @@ base::FilePath GetResourcesPath() {
   return exec_path.DirName().Append(FILE_PATH_LITERAL("resources"));
 #endif
 }
-
 }  // namespace
 
 NodeBindings::NodeBindings(BrowserEnvironment browser_env)
     : browser_env_{browser_env},
-      uv_loop_{browser_env == BrowserEnvironment::kWorker ? &worker_loop_
-                                                          : uv_default_loop()} {
-  if (browser_env == BrowserEnvironment::kWorker)
-    uv_loop_init(&worker_loop_);
-
-  // Interrupt embed polling when a handle is started.
-  uv_loop_configure(uv_loop_, UV_LOOP_INTERRUPT_ON_IO_CHANGE);
-}
+      uv_loop_{InitEventLoop(browser_env, &worker_loop_)} {}
 
 NodeBindings::~NodeBindings() {
   // Quit the embed thread.
@@ -425,6 +417,24 @@ NodeBindings::~NodeBindings() {
   // Clean up worker loop
   if (in_worker_loop())
     stop_and_close_uv_loop(uv_loop_);
+}
+
+// static
+uv_loop_t* NodeBindings::InitEventLoop(BrowserEnvironment browser_env,
+                                       uv_loop_t* worker_loop) {
+  uv_loop_t* event_loop = nullptr;
+
+  if (browser_env == BrowserEnvironment::kWorker) {
+    uv_loop_init(worker_loop);
+    event_loop = worker_loop;
+  } else {
+    event_loop = uv_default_loop();
+  }
+
+  // Interrupt embed polling when a handle is started.
+  uv_loop_configure(event_loop, UV_LOOP_INTERRUPT_ON_IO_CHANGE);
+
+  return event_loop;
 }
 
 void NodeBindings::RegisterBuiltinBindings() {

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -398,7 +398,7 @@ base::FilePath GetResourcesPath() {
 }  // namespace
 
 NodeBindings::NodeBindings(BrowserEnvironment browser_env)
-    : browser_env_(browser_env) {
+    : browser_env_{browser_env} {
   if (browser_env == BrowserEnvironment::kWorker) {
     uv_loop_init(&worker_loop_);
     uv_loop_ = &worker_loop_;

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -398,13 +398,11 @@ base::FilePath GetResourcesPath() {
 }  // namespace
 
 NodeBindings::NodeBindings(BrowserEnvironment browser_env)
-    : browser_env_{browser_env} {
-  if (browser_env == BrowserEnvironment::kWorker) {
+    : browser_env_{browser_env},
+      uv_loop_{browser_env == BrowserEnvironment::kWorker ? &worker_loop_
+                                                          : uv_default_loop()} {
+  if (browser_env == BrowserEnvironment::kWorker)
     uv_loop_init(&worker_loop_);
-    uv_loop_ = &worker_loop_;
-  } else {
-    uv_loop_ = uv_default_loop();
-  }
 
   // Interrupt embed polling when a handle is started.
   uv_loop_configure(uv_loop_, UV_LOOP_INTERRUPT_ON_IO_CHANGE);

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -155,6 +155,9 @@ class NodeBindings {
   void WakeupEmbedThread();
 
  private:
+  static uv_loop_t* InitEventLoop(BrowserEnvironment browser_env,
+                                  uv_loop_t* worker_loop);
+
   // Run the libuv loop for once.
   void UvRunOnce();
 

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -134,8 +134,6 @@ class NodeBindings {
 
   uv_loop_t* uv_loop() const { return uv_loop_; }
 
-  bool in_worker_loop() const { return uv_loop_ == &worker_loop_; }
-
   // disable copy
   NodeBindings(const NodeBindings&) = delete;
   NodeBindings& operator=(const NodeBindings&) = delete;
@@ -169,6 +167,10 @@ class NodeBindings {
   raw_ptr<uv_loop_t> uv_loop_;
 
  private:
+  [[nodiscard]] constexpr bool in_worker_loop() const {
+    return browser_env_ == BrowserEnvironment::kWorker;
+  }
+
   // Choose a reasonable unique index that's higher than any Blink uses
   // and thus unlikely to collide with an existing index.
   static constexpr int kElectronContextEmbedderDataIndex =

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -148,14 +148,19 @@ class NodeBindings {
   // Called to poll events in new thread.
   virtual void PollEvents() = 0;
 
-  // Run the libuv loop for once.
-  void UvRunOnce();
-
   // Make the main thread run libuv loop.
   void WakeupMainThread();
 
   // Interrupt the PollEvents.
   void WakeupEmbedThread();
+
+ private:
+  // Run the libuv loop for once.
+  void UvRunOnce();
+
+  [[nodiscard]] constexpr bool in_worker_loop() const {
+    return browser_env_ == BrowserEnvironment::kWorker;
+  }
 
   // Which environment we are running.
   const BrowserEnvironment browser_env_;
@@ -169,11 +174,6 @@ class NodeBindings {
 
   // Current thread's MessageLoop.
   scoped_refptr<base::SingleThreadTaskRunner> task_runner_;
-
- private:
-  [[nodiscard]] constexpr bool in_worker_loop() const {
-    return browser_env_ == BrowserEnvironment::kWorker;
-  }
 
   // Choose a reasonable unique index that's higher than any Blink uses
   // and thus unlikely to collide with an existing index.

--- a/shell/common/node_bindings_linux.cc
+++ b/shell/common/node_bindings_linux.cc
@@ -10,7 +10,9 @@ namespace electron {
 
 NodeBindingsLinux::NodeBindingsLinux(BrowserEnvironment browser_env)
     : NodeBindings(browser_env), epoll_(epoll_create(1)) {
-  int backend_fd = uv_backend_fd(uv_loop_);
+  auto* const event_loop = uv_loop();
+
+  int backend_fd = uv_backend_fd(event_loop);
   struct epoll_event ev = {0};
   ev.events = EPOLLIN;
   ev.data.fd = backend_fd;
@@ -18,7 +20,9 @@ NodeBindingsLinux::NodeBindingsLinux(BrowserEnvironment browser_env)
 }
 
 void NodeBindingsLinux::PollEvents() {
-  int timeout = uv_backend_timeout(uv_loop_);
+  auto* const event_loop = uv_loop();
+
+  int timeout = uv_backend_timeout(event_loop);
 
   // Wait for new libuv events.
   int r;

--- a/shell/common/node_bindings_mac.cc
+++ b/shell/common/node_bindings_mac.cc
@@ -18,15 +18,17 @@ NodeBindingsMac::NodeBindingsMac(BrowserEnvironment browser_env)
     : NodeBindings(browser_env) {}
 
 void NodeBindingsMac::PollEvents() {
+  auto* const event_loop = uv_loop();
+
   struct timeval tv;
-  int timeout = uv_backend_timeout(uv_loop_);
+  int timeout = uv_backend_timeout(event_loop);
   if (timeout != -1) {
     tv.tv_sec = timeout / 1000;
     tv.tv_usec = (timeout % 1000) * 1000;
   }
 
   fd_set readset;
-  int fd = uv_backend_fd(uv_loop_);
+  int fd = uv_backend_fd(event_loop);
   FD_ZERO(&readset);
   FD_SET(fd, &readset);
 

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -27,10 +27,10 @@
 namespace electron {
 
 ElectronRendererClient::ElectronRendererClient()
-    : node_bindings_(
-          NodeBindings::Create(NodeBindings::BrowserEnvironment::kRenderer)),
-      electron_bindings_(
-          std::make_unique<ElectronBindings>(node_bindings_->uv_loop())) {}
+    : node_bindings_{NodeBindings::Create(
+          NodeBindings::BrowserEnvironment::kRenderer)},
+      electron_bindings_{
+          std::make_unique<ElectronBindings>(node_bindings_->uv_loop())} {}
 
 ElectronRendererClient::~ElectronRendererClient() = default;
 
@@ -121,7 +121,8 @@ void ElectronRendererClient::DidCreateScriptContext(
   BindProcess(env->isolate(), &process_dict, render_frame);
 
   // Load everything.
-  node_bindings_->LoadEnvironment(env.get());
+  node_bindings_->LoadEnvironment(
+      env.get());  // FIXME(ckerr) node_bindings_ created this env, can remember
 
   if (node_bindings_->uv_env() == nullptr) {
     // Make uv loop being wrapped by window context.

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -121,8 +121,7 @@ void ElectronRendererClient::DidCreateScriptContext(
   BindProcess(env->isolate(), &process_dict, render_frame);
 
   // Load everything.
-  node_bindings_->LoadEnvironment(
-      env.get());  // FIXME(ckerr) node_bindings_ created this env, can remember
+  node_bindings_->LoadEnvironment(env.get());
 
   if (node_bindings_->uv_env() == nullptr) {
     // Make uv loop being wrapped by window context.

--- a/shell/renderer/electron_renderer_client.h
+++ b/shell/renderer/electron_renderer_client.h
@@ -51,8 +51,8 @@ class ElectronRendererClient : public RendererClientBase {
   // Whether the node integration has been initialized.
   bool node_integration_initialized_ = false;
 
-  std::unique_ptr<NodeBindings> node_bindings_;
-  std::unique_ptr<ElectronBindings> electron_bindings_;
+  const std::unique_ptr<NodeBindings> node_bindings_;
+  const std::unique_ptr<ElectronBindings> electron_bindings_;
 
   // The node::Environment::GetCurrent API does not return nullptr when it
   // is called for a context without node::Environment, so we have to keep


### PR DESCRIPTION
#### Description of Change

Another `raw_ptr<>` bugifx PR similar to #39521, #39539

Main fix: declare `NodeBindings::worker_loop_` before `NodeBindings::uv_loop_`, since the latter is a `raw_ptr<>` that may point to the former. If `uv_loop_` is declared first, it can be a dangling `raw_ptr<>` in the destructor since classes destroy their fields in reverse order of declaration.

Secondary cleanups: reduce the scope and mutability of related fields & methods by making them `const` or `private` as applicable.

CC @codebytere @deepak1556 @VerteDinde who did review on previous PRs

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none