### PR TITLE
fix: `keyCode`s being incorrectly converted in `webContents.sendInputEvent()`

### DIFF
--- a/shell/common/gin_converters/blink_converter.cc
+++ b/shell/common/gin_converters/blink_converter.cc
@@ -10,6 +10,7 @@
 
 #include "base/containers/fixed_flat_map.h"
 #include "base/strings/string_util.h"
+#include "base/strings/utf_string_conversion_utils.h"
 #include "base/strings/utf_string_conversions.h"
 #include "gin/converter.h"
 #include "gin/data_object_builder.h"
@@ -275,11 +276,18 @@ bool Converter<blink::WebKeyboardEvent>::FromV8(v8::Isolate* isolate,
 
   if ((out->GetType() == blink::WebInputEvent::Type::kChar ||
        out->GetType() == blink::WebInputEvent::Type::kRawKeyDown)) {
+    // If the keyCode is e.g. Space or Plus we want to use the character
+    // instead of the keyCode: ' ' instead of 'Space', '+' instead of 'Plus'.
+    std::string character_str;
+    if (str.size() > 1 && domKey.IsCharacter())
+      base::WriteUnicodeCharacter(domKey.ToCharacter(), &character_str);
+
     // Make sure to not read beyond the buffer in case some bad code doesn't
     // NULL-terminate it (this is called from plugins).
     size_t text_length_cap = blink::WebKeyboardEvent::kTextLengthCap;
-    std::u16string text16 = base::UTF8ToUTF16(str);
-
+    std::u16string text16 = character_str.empty()
+                                ? base::UTF8ToUTF16(str)
+                                : base::UTF8ToUTF16(character_str);
     std::fill_n(out->text, text_length_cap, 0);
     std::fill_n(out->unmodified_text, text_length_cap, 0);
     for (size_t i = 0; i < std::min(text_length_cap - 1, text16.size()); ++i) {

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -839,6 +839,20 @@ describe('webContents module', () => {
       expect(altKey).to.be.false();
     });
 
+    it('can correctly convert accelerators to key codes', async () => {
+      const keyup = once(ipcMain, 'keyup');
+      w.webContents.sendInputEvent({ keyCode: 'Plus', type: 'char' });
+      w.webContents.sendInputEvent({ keyCode: 'Space', type: 'char' });
+      w.webContents.sendInputEvent({ keyCode: 'Plus', type: 'char' });
+      w.webContents.sendInputEvent({ keyCode: 'Space', type: 'char' });
+      w.webContents.sendInputEvent({ keyCode: 'Plus', type: 'char' });
+      w.webContents.sendInputEvent({ keyCode: 'Plus', type: 'keyUp' });
+
+      await keyup;
+      const inputText = await w.webContents.executeJavaScript('document.getElementById("input").value');
+      expect(inputText).to.equal('+ + +');
+    });
+
     it('can send char events with modifiers', async () => {
       const keypress = once(ipcMain, 'keypress');
       w.webContents.sendInputEvent({ type: 'keyDown', keyCode: 'Z' });

--- a/spec/fixtures/pages/key-events.html
+++ b/spec/fixtures/pages/key-events.html
@@ -1,11 +1,17 @@
 <html>
 <body>
+<input type="text" id="input" autofocus/>
 <script type="text/javascript" charset="utf-8">
+const { ipcRenderer } = require('electron')
+
 document.onkeydown = function (e) {
-  require('electron').ipcRenderer.send('keydown', e.key, e.code, e.keyCode, e.shiftKey, e.ctrlKey, e.altKey)
+  ipcRenderer.send('keydown', e.key, e.code, e.keyCode, e.shiftKey, e.ctrlKey, e.altKey)
 }
 document.onkeypress = function (e) {
-  require('electron').ipcRenderer.send('keypress', e.key, e.code, e.keyCode, e.shiftKey, e.ctrlKey, e.altKey)
+  ipcRenderer.send('keypress', e.key, e.code, e.keyCode, e.shiftKey, e.ctrlKey, e.altKey)
+}
+document.onkeyup = function (e) {
+  ipcRenderer.send('keyup', e.key, e.code, e.keyCode, e.shiftKey, e.ctrlKey, e.altKey)
 }
 </script>
 </body>


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/39610.

Fixed an issue where accelerators representing DOM keys were not correctly converted in `webContents.sendInputEvent()`. This was happening because our internal conversion logic was correctly parsing strings their respective `ui::KeyboardCode` values, but then failing to check whether the DOM code represented a standalone valid character. This led to an issue where a call to, for example, `w.webContents.sendInputEvent({ keyCode: 'Plus', type: 'char' })` would get [truncated](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/common/input/web_keyboard_event.h;l=20) and then sent to the input as the char string and not the dom key character if one existed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where accelerators representing DOM keys were not correctly converted in `webContents.sendInputEvent()`.