### PR TITLE
fix: NodeService order-of-destruction issue

### DIFF
--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -121,7 +121,8 @@ void ElectronRendererClient::DidCreateScriptContext(
   BindProcess(env->isolate(), &process_dict, render_frame);
 
   // Load everything.
-  node_bindings_->LoadEnvironment(env.get());
+  node_bindings_->LoadEnvironment(
+      env.get());  // FIXME(ckerr) node_bindings_ created this env, can remember
 
   if (node_bindings_->uv_env() == nullptr) {
     // Make uv loop being wrapped by window context.

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -121,8 +121,7 @@ void ElectronRendererClient::DidCreateScriptContext(
   BindProcess(env->isolate(), &process_dict, render_frame);
 
   // Load everything.
-  node_bindings_->LoadEnvironment(
-      env.get());  // FIXME(ckerr) node_bindings_ created this env, can remember
+  node_bindings_->LoadEnvironment(env.get());
 
   if (node_bindings_->uv_env() == nullptr) {
     // Make uv loop being wrapped by window context.

--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -20,10 +20,10 @@ namespace electron {
 
 NodeService::NodeService(
     mojo::PendingReceiver<node::mojom::NodeService> receiver)
-    : node_bindings_(
-          NodeBindings::Create(NodeBindings::BrowserEnvironment::kUtility)),
-      electron_bindings_(
-          std::make_unique<ElectronBindings>(node_bindings_->uv_loop())) {
+    : node_bindings_{NodeBindings::Create(
+          NodeBindings::BrowserEnvironment::kUtility)},
+      electron_bindings_{
+          std::make_unique<ElectronBindings>(node_bindings_->uv_loop())} {
   if (receiver.is_valid())
     receiver_.Bind(std::move(receiver));
 }

--- a/shell/services/node/node_service.h
+++ b/shell/services/node/node_service.h
@@ -37,10 +37,18 @@ class NodeService : public node::mojom::NodeService {
 
  private:
   bool node_env_stopped_ = false;
+
+  const std::unique_ptr<NodeBindings> node_bindings_;
+
+  // depends-on: node_bindings_'s uv_loop
+  const std::unique_ptr<ElectronBindings> electron_bindings_;
+
+  // depends-on: node_bindings_'s uv_loop
   std::unique_ptr<JavascriptEnvironment> js_env_;
-  std::unique_ptr<NodeBindings> node_bindings_;
-  std::unique_ptr<ElectronBindings> electron_bindings_;
+
+  // depends-on: js_env_'s isolate
   std::shared_ptr<node::Environment> node_env_;
+
   mojo::Receiver<node::mojom::NodeService> receiver_{this};
 };
 


### PR DESCRIPTION
#### Description of Change

Fix an order-of-destruction issue in NodeService: `js_env_` depends on the uv_loop from `node_bindings_`, but `node_bindings_` was being destroyed before `js_env_`.

This was ameliorated by the fact that the uv_loop's destruction process is complex -- the memory is freed in a callback after `uv_close()` finishes; see UvHandle in node_bindings.h for details --  but the real fix is to just get NodeService's fields' order correct.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none