### PR TITLE
fix: ensure app load is limited to real asar files when appropriate

### DIFF
--- a/lib/asar/fs-wrapper.ts
+++ b/lib/asar/fs-wrapper.ts
@@ -27,7 +27,7 @@ const cachedArchives = new Map<string, NodeJS.AsarArchive>();
 const getOrCreateArchive = (archivePath: string) => {
   const isCached = cachedArchives.has(archivePath);
   if (isCached) {
-    return cachedArchives.get(archivePath);
+    return cachedArchives.get(archivePath)!;
   }
 
   try {
@@ -38,6 +38,8 @@ const getOrCreateArchive = (archivePath: string) => {
     return null;
   }
 };
+
+process._getOrCreateArchive = getOrCreateArchive;
 
 const asarRe = /\.asar/i;
 

--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -84,11 +84,20 @@ const v8Util = process._linkedBinding('electron_common_v8_util');
 let packagePath = null;
 let packageJson = null;
 const searchPaths: string[] = v8Util.getHiddenValue(global, 'appSearchPaths');
+const searchPathsOnlyLoadASAR: boolean = v8Util.getHiddenValue(global, 'appSearchPathsOnlyLoadASAR');
+// Borrow the _getOrCreateArchive asar helper
+const getOrCreateArchive = process._getOrCreateArchive;
+delete process._getOrCreateArchive;
 
 if (process.resourcesPath) {
   for (packagePath of searchPaths) {
     try {
       packagePath = path.join(process.resourcesPath, packagePath);
+      if (searchPathsOnlyLoadASAR) {
+        if (!getOrCreateArchive?.(packagePath)) {
+          continue;
+        }
+      }
       packageJson = Module._load(path.join(packagePath, 'package.json'));
       break;
     } catch {

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -586,6 +586,13 @@ std::shared_ptr<node::Environment> NodeBindings::CreateEnvironment(
                          electron::fuses::IsOnlyLoadAppFromAsarEnabled()
                              ? app_asar_search_paths
                              : search_paths));
+    context->Global()->SetPrivate(
+        context,
+        v8::Private::ForApi(
+            isolate, gin::ConvertToV8(isolate, "appSearchPathsOnlyLoadASAR")
+                         .As<v8::String>()),
+        gin::ConvertToV8(isolate,
+                         electron::fuses::IsOnlyLoadAppFromAsarEnabled()));
   }
 
   base::FilePath resources_path = GetResourcesPath();

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -254,6 +254,7 @@ declare namespace NodeJS {
     // Additional properties
     _firstFileName?: string;
     _serviceStartupScript: string;
+    _getOrCreateArchive?: (path: string) => NodeJS.AsarArchive | null;
 
     helperExecPath: string;
     mainModule?: NodeJS.Module | undefined;


### PR DESCRIPTION
Just because something exists in a `*.asar` path doesn't mean it's actually an asar file.

Notes: no-notes