### PR TITLE
ci: ignore blocked label removed on closed issues

### DIFF
--- a/.github/workflows/issue-unlabeled.yml
+++ b/.github/workflows/issue-unlabeled.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   issue-unlabeled-blocked:
     name: All blocked/* labels removed
-    if: startsWith(github.event.label.name, 'blocked/')
+    if: startsWith(github.event.label.name, 'blocked/') && github.event.issue.state == 'open'
     runs-on: ubuntu-latest
     steps:
       - name: Check for any blocked labels


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

The blocked label is removed after the issue is closed by the stale workflow, so don't change the triage status for closed issues.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
