### PR TITLE
test: make color snapshot matching fuzzier

### DIFF
--- a/patches/node/chore_update_fixtures_errors_force_colors_snapshot.patch
+++ b/patches/node/chore_update_fixtures_errors_force_colors_snapshot.patch
@@ -23,12 +23,12 @@ index 0334a0b4faa3633aa8617b9538873e7f3540513b..0300d397c6a5b82ef2d0feafca5f8bd7
 -[90m    at Module.load (node:internal*modules*cjs*loader:1119:32)[39m
 -[90m    at Module._load (node:internal*modules*cjs*loader:960:12)[39m
 -[90m    at Function.executeUserEntryPoint [as runMain] (node:internal*modules*run_main:81:12)[39m
-+[90m    at Module._compile (node:internal*modules*cjs*loader:1271:14)[39m
-+[90m    at Object..js (node:internal*modules*cjs*loader:1326:10)[39m
-+[90m    at Module.load (node:internal*modules*cjs*loader:1126:32)[39m
-+[90m    at node:internal*modules*cjs*loader:967:12[39m
-+[90m    at Function._load (node:electron*js2c*asar_bundle:776:32)[39m
-+[90m    at Function.executeUserEntryPoint [as runMain] (node:internal*modules*run_main:96:12)[39m
++[90m    at Module._compile (node:internal*modules*cjs*loader:*:*)[39m
++[90m    at Object..js (node:internal*modules*cjs*loader:*:*)[39m
++[90m    at Module.load (node:internal*modules*cjs*loader:*:*)[39m
++[90m    at node:internal*modules*cjs*loader:*:*[39m
++[90m    at Function._load (node:electron*js2c*asar_bundle:*:*)[39m
++[90m    at Function.executeUserEntryPoint [as runMain] (node:internal*modules*run_main:*:*)[39m
  [90m    at node:internal*main*run_main_module:23:47[39m
  
  Node.js *

--- a/patches/node/chore_update_fixtures_errors_force_colors_snapshot.patch
+++ b/patches/node/chore_update_fixtures_errors_force_colors_snapshot.patch
@@ -11,7 +11,7 @@ trying to see whether or not the lines are greyed out. One possibility
 would be to upstream a changed test that doesn't hardcode line numbers.
 
 diff --git a/test/fixtures/errors/force_colors.snapshot b/test/fixtures/errors/force_colors.snapshot
-index 0334a0b4faa3633aa8617b9538873e7f3540513b..0300d397c6a5b82ef2d0feafca5f8bd746b1f5b0 100644
+index 0334a0b4faa3633aa8617b9538873e7f3540513b..07b7e0d23e0096eb3ec2e66f98686863e2e38b55 100644
 --- a/test/fixtures/errors/force_colors.snapshot
 +++ b/test/fixtures/errors/force_colors.snapshot
 @@ -4,11 +4,12 @@ throw new Error('Should include grayed stack trace')


### PR DESCRIPTION
This is failing on Linux Ci across PRs and is fairly brittle. We already patch it so make it less subject to failure.

Notes: none.