### PR TITLE
fix: size constraints on macOS

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -133,36 +133,7 @@ NativeWindow::NativeWindow(const gin_helper::Dictionary& options,
   }
 #endif
 
-  WindowList::AddWindow(this);
-}
-
-NativeWindow::~NativeWindow() {
-  // It's possible that the windows gets destroyed before it's closed, in that
-  // case we need to ensure the Widget delegate gets destroyed and
-  // OnWindowClosed message is still notified.
-  if (widget_->widget_delegate())
-    widget_->OnNativeWidgetDestroyed();
-  NotifyWindowClosed();
-}
-
-void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
-  // Setup window from options.
-  int x = -1, y = -1;
-  bool center;
-  if (options.Get(options::kX, &x) && options.Get(options::kY, &y)) {
-    SetPosition(gfx::Point(x, y));
-
-#if BUILDFLAG(IS_WIN)
-    // FIXME(felixrieseberg): Dirty, dirty workaround for
-    // https://github.com/electron/electron/issues/10862
-    // Somehow, we need to call `SetBounds` twice to get
-    // usable results. The root cause is still unknown.
-    SetPosition(gfx::Point(x, y));
-#endif
-  } else if (options.Get(options::kCenter, &center) && center) {
-    Center();
-  }
-
+  // Size constraints must be set before the widget is initialized.
   bool use_content_size = false;
   options.Get(options::kUseContentSize, &use_content_size);
 
@@ -197,6 +168,37 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
   } else {
     SetSizeConstraints(size_constraints);
   }
+
+  WindowList::AddWindow(this);
+}
+
+NativeWindow::~NativeWindow() {
+  // It's possible that the windows gets destroyed before it's closed, in that
+  // case we need to ensure the Widget delegate gets destroyed and
+  // OnWindowClosed message is still notified.
+  if (widget_->widget_delegate())
+    widget_->OnNativeWidgetDestroyed();
+  NotifyWindowClosed();
+}
+
+void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
+  // Setup window from options.
+  int x = -1, y = -1;
+  bool center;
+  if (options.Get(options::kX, &x) && options.Get(options::kY, &y)) {
+    SetPosition(gfx::Point(x, y));
+
+#if BUILDFLAG(IS_WIN)
+    // FIXME(felixrieseberg): Dirty, dirty workaround for
+    // https://github.com/electron/electron/issues/10862
+    // Somehow, we need to call `SetBounds` twice to get
+    // usable results. The root cause is still unknown.
+    SetPosition(gfx::Point(x, y));
+#endif
+  } else if (options.Get(options::kCenter, &center) && center) {
+    Center();
+  }
+
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX)
   bool closable;
   if (options.Get(options::kClosable, &closable)) {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/39786.
Refs https://github.com/electron/electron/pull/38974

Fixes an issue where min/max size didn't work for BrowserWindows on macOS. This was happening after a (necessary) change to size constraint calculations forced by Chromium - we just didn't recognize that this calculation had to happen prior to widget initialization to produce the correct behavior.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where min/max size didn't work for BrowserWindows on macOS.