### PR TITLE
refactor: remove unused fields, methods in gin_helper::Locker

### DIFF
--- a/shell/browser/javascript_environment.h
+++ b/shell/browser/javascript_environment.h
@@ -49,7 +49,7 @@ class JavascriptEnvironment {
   const raw_ptr<v8::Isolate> isolate_;
 
   // depends-on: isolate_
-  v8::Locker locker_;
+  const v8::Locker locker_;
 
   std::unique_ptr<MicrotasksRunner> microtasks_runner_;
 };

--- a/shell/common/gin_helper/event_emitter_caller.cc
+++ b/shell/common/gin_helper/event_emitter_caller.cc
@@ -4,7 +4,6 @@
 
 #include "shell/common/gin_helper/event_emitter_caller.h"
 
-#include "shell/common/gin_helper/locker.h"
 #include "shell/common/gin_helper/microtasks_scope.h"
 #include "shell/common/node_includes.h"
 

--- a/shell/common/gin_helper/locker.cc
+++ b/shell/common/gin_helper/locker.cc
@@ -8,10 +8,9 @@
 
 namespace gin_helper {
 
-Locker::Locker(v8::Isolate* isolate) {
-  if (electron::IsBrowserProcess())
-    locker_ = std::make_unique<v8::Locker>(isolate);
-}
+Locker::Locker(v8::Isolate* isolate)
+    : locker_{electron::IsBrowserProcess() ? new v8::Locker{isolate}
+                                           : nullptr} {}
 
 Locker::~Locker() = default;
 

--- a/shell/common/gin_helper/locker.h
+++ b/shell/common/gin_helper/locker.h
@@ -25,10 +25,7 @@ class Locker {
   void* operator new(size_t size);
   void operator delete(void*, size_t);
 
-  std::unique_ptr<v8::Locker> locker_;
-
-  static bool g_is_browser_process;
-  static bool g_is_renderer_process;
+  const std::unique_ptr<v8::Locker> locker_;
 };
 
 }  // namespace gin_helper

--- a/shell/common/gin_helper/locker.h
+++ b/shell/common/gin_helper/locker.h
@@ -22,9 +22,6 @@ class Locker {
   Locker& operator=(const Locker&) = delete;
 
  private:
-  void* operator new(size_t size);
-  void operator delete(void*, size_t);
-
   const std::unique_ptr<v8::Locker> locker_;
 };
 

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -31,7 +31,6 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/event.h"
 #include "shell/common/gin_helper/event_emitter_caller.h"
-#include "shell/common/gin_helper/locker.h"
 #include "shell/common/gin_helper/microtasks_scope.h"
 #include "shell/common/mac/main_application_bundle.h"
 #include "shell/common/world_ids.h"


### PR DESCRIPTION
#### Description of Change

Cleaning out some unused code. I did this while working on another `raw_ptr<>` fix; but since these changes aren't really related, I'm putting them in a standalone PR.

- remove unused field `gin_helper::Locker::g_is_renderer_process`
- remove unused field `gin_helper::Locker::g_is_browser_process`
- remove unused declaration `gin_helper::Locker::new()`
- remove unused declaration `gin_helper::Locker::delete()`

And `const`ify a couple of fields:

- declare `electron::JavascriptEnvironment::locker_` as `const`
- declare `gin_helper::Locker::locker_` as `const`

No particular stakeholders, but all reviews/feedback are welcome!

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none