### PR TITLE
refactor: use UvHandle in UvTaskRunner

### DIFF
--- a/shell/app/uv_task_runner.cc
+++ b/shell/app/uv_task_runner.cc
@@ -18,11 +18,10 @@ UvTaskRunner::~UvTaskRunner() = default;
 bool UvTaskRunner::PostDelayedTask(const base::Location& from_here,
                                    base::OnceClosure task,
                                    base::TimeDelta delay) {
-  auto* const timer = new uv_timer_t{};
+  auto* timer = new uv_timer_t;
   timer->data = this;
   uv_timer_init(loop_, timer);
   uv_timer_start(timer, UvTaskRunner::OnTimeout, delay.InMilliseconds(), 0);
-
   tasks_.try_emplace(UvHandle<uv_timer_t>{timer}, std::move(task));
   return true;
 }
@@ -45,7 +44,7 @@ void UvTaskRunner::OnTimeout(uv_timer_t* timer) {
     if (it->first.get() == timer) {
       std::move(it->second).Run();
       tasks.erase(it);
-      return;
+      break;
     }
   }
 }

--- a/shell/app/uv_task_runner.h
+++ b/shell/app/uv_task_runner.h
@@ -10,6 +10,7 @@
 #include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
 #include "base/task/single_thread_task_runner.h"
+#include "shell/common/node_bindings.h"
 #include "uv.h"  // NOLINT(build/include_directory)
 
 namespace base {
@@ -40,11 +41,10 @@ class UvTaskRunner : public base::SingleThreadTaskRunner {
  private:
   ~UvTaskRunner() override;
   static void OnTimeout(uv_timer_t* timer);
-  static void OnClose(uv_handle_t* handle);
 
-  raw_ptr<uv_loop_t> loop_;
+  const raw_ptr<uv_loop_t> loop_;
 
-  std::map<uv_timer_t*, base::OnceClosure> tasks_;
+  std::map<electron::UvHandle<uv_timer_t>, base::OnceClosure> tasks_;
 };
 
 }  // namespace electron

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -412,7 +412,6 @@ NodeBindings::~NodeBindings() {
 
   // Clear uv.
   uv_sem_destroy(&embed_sem_);
-  dummy_uv_handle_.reset();
 
   // Clean up worker loop
   if (in_worker_loop())

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -72,6 +72,10 @@ class UvHandle {
     return t_ < that.t_;
   }
 
+  [[nodiscard]] constexpr bool operator==(const T* that_handle) const noexcept {
+    return t_ == that_handle;
+  }
+
  private:
   static void OnClosed(uv_handle_t* handle) {
     delete reinterpret_cast<T*>(handle);


### PR DESCRIPTION
#### Description of Change

- Main change: our `UvHandle` wrapper class exists to manage `uv_handle*`'s life cycles the way that libuv expects. Refactor `UvTaskRunner` to use that wrapper class instead of keeping raw `uv_handle*` pointers directly.

- Related cleanup in `UvHandle`: do a `constexpr` pass,  make the class map-Key friendly, improve comment clarity.

No particular stakeholders, but all reviews welcome!

CC @zcbenz who did review [on the original `UvHandle` PR](https://github.com/electron/electron/pull/25332) and @codebytere for All Things Node.js :smile_cat: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none