### PR TITLE
refactor: remove unused Locker fields

### DIFF
--- a/shell/browser/javascript_environment.h
+++ b/shell/browser/javascript_environment.h
@@ -49,7 +49,7 @@ class JavascriptEnvironment {
   const raw_ptr<v8::Isolate> isolate_;
 
   // depends-on: isolate_
-  v8::Locker locker_;
+  const v8::Locker locker_;
 
   std::unique_ptr<MicrotasksRunner> microtasks_runner_;
 };

--- a/shell/common/gin_helper/event_emitter_caller.cc
+++ b/shell/common/gin_helper/event_emitter_caller.cc
@@ -4,7 +4,6 @@
 
 #include "shell/common/gin_helper/event_emitter_caller.h"
 
-#include "shell/common/gin_helper/locker.h"
 #include "shell/common/gin_helper/microtasks_scope.h"
 #include "shell/common/node_includes.h"
 

--- a/shell/common/gin_helper/locker.cc
+++ b/shell/common/gin_helper/locker.cc
@@ -8,10 +8,9 @@
 
 namespace gin_helper {
 
-Locker::Locker(v8::Isolate* isolate) {
-  if (electron::IsBrowserProcess())
-    locker_ = std::make_unique<v8::Locker>(isolate);
-}
+Locker::Locker(v8::Isolate* isolate)
+    : locker_{electron::IsBrowserProcess() ? new v8::Locker{isolate}
+                                           : nullptr} {}
 
 Locker::~Locker() = default;
 

--- a/shell/common/gin_helper/locker.h
+++ b/shell/common/gin_helper/locker.h
@@ -22,12 +22,7 @@ class Locker {
   Locker& operator=(const Locker&) = delete;
 
  private:
-  void* operator new(size_t size);
-  void operator delete(void*, size_t);
-
-  std::unique_ptr<v8::Locker> locker_;
-
-  static bool g_is_browser_process;
+  const std::unique_ptr<v8::Locker> locker_;
 };
 
 }  // namespace gin_helper

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -30,7 +30,6 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/event.h"
 #include "shell/common/gin_helper/event_emitter_caller.h"
-#include "shell/common/gin_helper/locker.h"
 #include "shell/common/gin_helper/microtasks_scope.h"
 #include "shell/common/mac/main_application_bundle.h"
 #include "third_party/blink/renderer/bindings/core/v8/v8_initializer.h"  // nogncheck


### PR DESCRIPTION
#### Description of Change

Manually backport https://github.com/electron/electron/pull/39803 to 27-x-y.

No interesting changes relative to 39803; just had some minor code shear that tripped trop.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none