### PR TITLE
fix: check PipeWire init before creating generic capturer

### DIFF
--- a/patches/webrtc/.patches
+++ b/patches/webrtc/.patches
@@ -1,2 +1,3 @@
 fix_fallback_to_x11_capturer_on_wayland.patch
 fix_mark_pipewire_capturer_as_failed_after_session_is_closed.patch
+fix_check_pipewire_init_before_creating_generic_capturer.patch

--- a/patches/webrtc/fix_check_pipewire_init_before_creating_generic_capturer.patch
+++ b/patches/webrtc/fix_check_pipewire_init_before_creating_generic_capturer.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Athul Iddya <athul@iddya.com>
+Date: Tue, 12 Sep 2023 22:19:46 -0700
+Subject: fix: check PipeWire init before creating generic capturer
+
+Check if PipeWire can be initialized before creating generic capturer.
+This harmonizes the conditions with the ones used in Linux
+implementations of DesktopCapturer::CreateRawScreenCapturer and
+DesktopCapturer::CreateRawWindowCapturer.
+
+diff --git a/modules/desktop_capture/desktop_capturer.cc b/modules/desktop_capture/desktop_capturer.cc
+index a52a76c2625cf0a2eae7ab5b841e0bf4ff499d88..099313bc1b4e75ebbe62c30190a068f68bfe5366 100644
+--- a/modules/desktop_capture/desktop_capturer.cc
++++ b/modules/desktop_capture/desktop_capturer.cc
+@@ -113,7 +113,7 @@ std::unique_ptr<DesktopCapturer> DesktopCapturer::CreateGenericCapturer(
+   std::unique_ptr<DesktopCapturer> capturer;
+ 
+ #if defined(WEBRTC_USE_PIPEWIRE)
+-  if (options.allow_pipewire() && DesktopCapturer::IsRunningUnderWayland()) {
++  if (options.allow_pipewire() && BaseCapturerPipeWire::IsSupported()) {
+     capturer = std::make_unique<BaseCapturerPipeWire>(
+         options, CaptureType::kAnyScreenContent);
+   }


### PR DESCRIPTION
#### Description of Change

Check if PipeWire can be initialized before creating generic capturer. This harmonizes the conditions with the ones used in Linux implementations of `DesktopCapturer::CreateRawScreenCapturer` and `DesktopCapturer::CreateRawWindowCapturer`. This allows `desktopCapturer.getSources()` to fallback to X11 capture when PipeWire library is not available.

cc @VerteDinde 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
