### PR TITLE
build: run on circle hosts for forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,9 @@ jobs:
             curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/main/install.sh | DESTDIR=$CIRCLECI_BINARY bash
             node build.js
           name: Pack config.yml
+      - run:
+          name: Set params
+          command: node .circleci/config/params.js
       - continuation/continue:
           configuration_path: .circleci/config-staging/built.yml
           parameters: /tmp/pipeline-parameters.json

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -34,6 +34,11 @@ parameters:
     type: enum
     default: all
     enum: ["all", "osx-x64", "osx-arm64", "mas-x64", "mas-arm64"]
+  
+  large-linux-executor:
+    type: enum
+    default: electronjs/aks-linux-large
+    enum: ["electronjs/aks-linux-large", "2xlarge"]
 
 # Executors
 executors:
@@ -42,9 +47,9 @@ executors:
       size:
         description: "Docker executor size"
         type: enum
-        # aks-linux-medium === 8 core (32 core host, shared with other builds)
         # aks-linux-large === 32 core
-        enum: ["medium", "xlarge", "electronjs/aks-linux-medium", "electronjs/aks-linux-large"]
+        # 2xlarge should not be used directly, use the pipeline param instead
+        enum: ["medium", "xlarge", "electronjs/aks-linux-large", "2xlarge"]
     docker:
       - image: ghcr.io/electron/build:e6bebd08a51a0d78ec23e5b3fd7e7c0846412328
     resource_class: << parameters.size >>
@@ -1703,7 +1708,7 @@ jobs:
   linux-x64-testing:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large
+      size: << pipeline.parameters.large-linux-executor >>
     environment:
       <<: *env-global
       <<: *env-testing-build
@@ -1720,7 +1725,7 @@ jobs:
   linux-x64-testing-asan:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large
+      size: << pipeline.parameters.large-linux-executor >>
     environment:
       <<: *env-global
       <<: *env-testing-build
@@ -1749,7 +1754,7 @@ jobs:
   linux-x64-publish:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large
+      size: << pipeline.parameters.large-linux-executor >>
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-release-build
@@ -1772,7 +1777,7 @@ jobs:
   linux-arm-testing:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large
+      size: << pipeline.parameters.large-linux-executor >>
     environment:
       <<: *env-global
       <<: *env-arm
@@ -1792,7 +1797,7 @@ jobs:
   linux-arm-publish:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large
+      size: << pipeline.parameters.large-linux-executor >>
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-arm
@@ -1817,7 +1822,7 @@ jobs:
   linux-arm64-testing:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large
+      size: << pipeline.parameters.large-linux-executor >>
     environment:
       <<: *env-global
       <<: *env-arm64
@@ -1848,7 +1853,7 @@ jobs:
   linux-arm64-publish:
     executor:
       name: linux-docker
-      size: electronjs/aks-linux-large
+      size: << pipeline.parameters.large-linux-executor >>
     environment:
       <<: *env-linux-2xlarge-release
       <<: *env-arm64

--- a/.circleci/config/params.js
+++ b/.circleci/config/params.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+
+const PARAMS_PATH = '/tmp/pipeline-parameters.json';
+
+const content = JSON.parse(fs.readFileSync(PARAMS_PATH, 'utf-8'));
+
+// Choose resource class for linux hosts
+const currentBranch = process.env.CIRCLE_BRANCH || '';
+content['large-linux-executor'] = /^pull\/[0-9-]+$/.test(currentBranch) ? '2xlarge' : 'electronjs/aks-linux-large';
+
+fs.writeFileSync(PARAMS_PATH, JSON.stringify(content));


### PR DESCRIPTION
Makes it so that fork PRs use circle resources instead of our internal resources 🤔 

Notes: none