### PR TITLE
test: fixup node flakes

### DIFF
--- a/patches/node/chore_update_fixtures_errors_force_colors_snapshot.patch
+++ b/patches/node/chore_update_fixtures_errors_force_colors_snapshot.patch
@@ -11,7 +11,7 @@ trying to see whether or not the lines are greyed out. One possibility
 would be to upstream a changed test that doesn't hardcode line numbers.
 
 diff --git a/test/fixtures/errors/force_colors.snapshot b/test/fixtures/errors/force_colors.snapshot
-index 0334a0b4faa3633aa8617b9538873e7f3540513b..0300d397c6a5b82ef2d0feafca5f8bd746b1f5b0 100644
+index 0334a0b4faa3633aa8617b9538873e7f3540513b..8c047001ede7b66cab5146444fe2b48190b64359 100644
 --- a/test/fixtures/errors/force_colors.snapshot
 +++ b/test/fixtures/errors/force_colors.snapshot
 @@ -4,11 +4,12 @@ throw new Error('Should include grayed stack trace')
@@ -27,7 +27,7 @@ index 0334a0b4faa3633aa8617b9538873e7f3540513b..0300d397c6a5b82ef2d0feafca5f8bd7
 +[90m    at Object..js (node:internal*modules*cjs*loader:1326:10)[39m
 +[90m    at Module.load (node:internal*modules*cjs*loader:1126:32)[39m
 +[90m    at node:internal*modules*cjs*loader:967:12[39m
-+[90m    at Function._load (node:electron*js2c*asar_bundle:776:32)[39m
++[90m    at Function._load (node:electron*js2c*asar_bundle:777:32)[39m
 +[90m    at Function.executeUserEntryPoint [as runMain] (node:internal*modules*run_main:96:12)[39m
  [90m    at node:internal*main*run_main_module:23:47[39m
  

--- a/patches/node/test_formally_mark_some_tests_as_flaky.patch
+++ b/patches/node/test_formally_mark_some_tests_as_flaky.patch
@@ -7,10 +7,10 @@ Instead of disabling the tests, flag them as flaky so they still run
 but don't cause CI failures on flakes.
 
 diff --git a/test/parallel/parallel.status b/test/parallel/parallel.status
-index 913ae4b0b10a7d508d864539cf075fa9c2f9362c..985f1c0d0c0c6afc049bf1d89f91412ecf431215 100644
+index 913ae4b0b10a7d508d864539cf075fa9c2f9362c..0539a599e57d40c5da650dcf5ffe9a67763506e1 100644
 --- a/test/parallel/parallel.status
 +++ b/test/parallel/parallel.status
-@@ -5,6 +5,12 @@ prefix parallel
+@@ -5,6 +5,13 @@ prefix parallel
  # sample-test                        : PASS,FLAKY
  
  [true] # This section applies to all platforms
@@ -20,6 +20,7 @@ index 913ae4b0b10a7d508d864539cf075fa9c2f9362c..985f1c0d0c0c6afc049bf1d89f91412e
 +test-fetch: PASS, FLAKY
 +test-cluster-bind-privileged-port: PASS, FLAKY
 +test-cluster-shared-handle-bind-privileged-port: PASS, FLAKY
++test-debugger-random-port-with-inspect-port: PASS, FLAKY
  
  [$system==win32]
  # https://github.com/nodejs/node/issues/24497


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
The node test `parallel/test-debugger-random-port-with-inspect-port` has been flaky of late, so this PR marks it as such.

Additionally, the node test `parallel/test-node-output-errors` has started failing due to a line number change, so this PR also updates the patch for that test to fix the issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
