### PR TITLE
docs: tiny update on example message-ports.md

### DIFF
--- a/docs/tutorial/message-ports.md
+++ b/docs/tutorial/message-ports.md
@@ -365,7 +365,7 @@ window.onmessage = (event) => {
     // process.
     port.onmessage = (event) => {
       console.log('from main process:', event.data)
-      port.postMessage(event.data * 2)
+      port.postMessage(event.data.test * 2)
     }
   }
 }


### PR DESCRIPTION
fix example multiplying object * number. It should multiply number * number.

Notes: none
