### PR TITLE
fix: set window contents as opaque to decrease DWM GPU usage

### DIFF
--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -133,4 +133,10 @@ void ElectronDesktopWindowTreeHostWin::OnNativeThemeUpdated(
   }
 }
 
+bool ElectronDesktopWindowTreeHostWin::ShouldWindowContentsBeTransparent()
+    const {
+  return native_window_view_->GetOpacity() < 1.0 ||
+         native_window_view_->transparent();
+}
+
 }  // namespace electron

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -135,6 +135,10 @@ void ElectronDesktopWindowTreeHostWin::OnNativeThemeUpdated(
 
 bool ElectronDesktopWindowTreeHostWin::ShouldWindowContentsBeTransparent()
     const {
+  // Window should be marked as opaque if no transparency setting has been set,
+  // otherwise videos rendered in the window will trigger a DirectComposition
+  // redraw for every frame.
+  // https://github.com/electron/electron/pull/39895
   return native_window_view_->GetOpacity() < 1.0 ||
          native_window_view_->transparent();
 }

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
@@ -40,6 +40,7 @@ class ElectronDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin,
 
   // ui::NativeThemeObserver:
   void OnNativeThemeUpdated(ui::NativeTheme* observed_theme) override;
+  bool ShouldWindowContentsBeTransparent() const override;
 
  private:
   raw_ptr<NativeWindowViews> native_window_view_;  // weak ref


### PR DESCRIPTION
#### Description of Change

The window contents of Electron windows are marked as transparent even though neither `transparent` nor `opacity` settings are set in the `BrowserWindow` options.

**Debugging DirectComposition redraws**

Chromium 118 has a new flag called `DCompDebugVisualization` that uses [EnableDrawRegions](https://learn.microsoft.com/en-us/windows/win32/api/dcomp/nf-dcomp-idcompositionvisualdebug-enableredrawregions) to display on the screen sections of a window that are redrawn by DirectComposition.

**The problem**

With `DCompDebugVisualization`, we can notice a difference in the frequency of redraws of `<video>` elements in Chromium compared to a regular non-transparent window in Electron.

While a video stream is rendered on screen, almost no redraws are displayed in Chromium. On Electron, a redraw is displayed for every video frame rendered.

Electron Fiddle gist: https://gist.github.com/brhenrique/100fc28409508d1730fb4216268cf04a

**Why it happens?**

When the contents of the window are set to be transparent, `DirectCompositionChildSurfaceWin::SetDrawRectangle` will use `DXGI_ALPHA_MODE_PREMULTIPLIED` instead of `DXGI_ALPHA_MODE_IGNORE`. This will trigger the DC redraw for every video frame.

**Solution**

If neither `transparent` nor `opacity` settings are used with a `BrowserWindow`, it seems safe to assume the contents of the BrowserWindow won't need alpha blending with other windows. So in this PR we override `ShouldWindowContentsBeTransparent` to take into account the transparency and opacity settings of the native window.

**Results**

_Rendering 4 480p video elements in a blank opaque non-fullscreen Electron window on a 2160p display_

Before: DWM uses 16-18% GPU
After: DWM uses less than 1%

_Rendering 4 480p video elements in a blank opaque non-fullscreen Electron window on a 1080p display_

Before: DWM uses 6-8% GPU
After: DWM uses less than 1%


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: prevent DWM from redrawing video frames rendered on opaque windows
