### PR TITLE
chore: add deprecated `app.runningUnderRosettaTranslation` to breaking-changes.md

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -716,6 +716,18 @@ to open synchronously scriptable child windows, among other incompatibilities.
 See the documentation for [window.open in Electron](api/window-open.md)
 for more details.
 
+### Deprecated: `app.runningUnderRosettaTranslation`
+
+The `app.runningUnderRosettaTranslation` property has been deprecated.
+Use `app.runningUnderARM64Translation` instead.
+
+```js
+// Deprecated
+console.log(app.runningUnderRosettaTranslation)
+// Replace with
+console.log(app.runningUnderARM64Translation)
+```
+
 ## Planned Breaking API Changes (14.0)
 
 ### Removed: `remote` module


### PR DESCRIPTION
#### Description of Change
It has been deprecated since #29168

#### Checklist
- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: The `app.runningUnderRosettaTranslation` property has been deprecated.