### PR TITLE
chore: cherry-pick 1 changes from Release-0-M117

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -12,3 +12,4 @@ fix_set_proper_instruction_start_for_builtin.patch
 cherry-pick-8ff63d378f2c.patch
 merged_squashed_multiple_commits.patch
 cherry-pick-038530c94a06.patch
+cherry-pick-cf1d4d3c0b6e.patch

--- a/patches/v8/cherry-pick-cf1d4d3c0b6e.patch
+++ b/patches/v8/cherry-pick-cf1d4d3c0b6e.patch
@@ -1,0 +1,100 @@
+From cf1d4d3c0b6e02128a19a75c5c93fe2d34629e34 Mon Sep 17 00:00:00 2001
+From: Shu-yu Guo <syg@chromium.org>
+Date: Thu, 31 Aug 2023 08:59:12 -0700
+Subject: [PATCH] Merged: [interpreter] Fix TDZ elision in do-while tests
+
+(cherry picked from commit 1626e229a8965f975db6e9da0e7ab85f8c74333f)
+
+Change-Id: Ifb7461b6cfd62a10936470a760cb505cc5e1c60f
+Fixed: chromium:1477588
+Bug: v8:13723
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4862981
+Auto-Submit: Shu-yu Guo <syg@chromium.org>
+Commit-Queue: Shu-yu Guo <syg@chromium.org>
+Reviewed-by: Adam Klein <adamk@chromium.org>
+Cr-Commit-Position: refs/branch-heads/11.6@{#38}
+Cr-Branched-From: e29c028f391389a7a60ee37097e3ca9e396d6fa4-refs/heads/11.6.189@{#3}
+Cr-Branched-From: 95cbef20e2aa556a1ea75431a48b36c4de6b9934-refs/heads/main@{#88340}
+---
+
+diff --git a/src/interpreter/bytecode-generator.cc b/src/interpreter/bytecode-generator.cc
+index bd6c010..751411a 100644
+--- a/src/interpreter/bytecode-generator.cc
++++ b/src/interpreter/bytecode-generator.cc
+@@ -2435,8 +2435,16 @@
+     VisitIterationBodyInHoleCheckElisionScope(stmt, &loop_builder);
+     builder()->SetExpressionAsStatementPosition(stmt->cond());
+     BytecodeLabels loop_backbranch(zone());
+-    VisitForTest(stmt->cond(), &loop_backbranch, loop_builder.break_labels(),
+-                 TestFallthrough::kThen);
++    if (!loop_builder.break_labels()->empty()) {
++      // The test may be conditionally executed if there was a break statement
++      // inside the loop body, and therefore requires its own elision scope.
++      HoleCheckElisionScope elider(this);
++      VisitForTest(stmt->cond(), &loop_backbranch, loop_builder.break_labels(),
++                   TestFallthrough::kThen);
++    } else {
++      VisitForTest(stmt->cond(), &loop_backbranch, loop_builder.break_labels(),
++                   TestFallthrough::kThen);
++    }
+     loop_backbranch.Bind(builder());
+   }
+ }
+diff --git a/test/unittests/interpreter/bytecode-generator-unittest.cc b/test/unittests/interpreter/bytecode-generator-unittest.cc
+index add6f77..c6cd6d8 100644
+--- a/test/unittests/interpreter/bytecode-generator-unittest.cc
++++ b/test/unittests/interpreter/bytecode-generator-unittest.cc
+@@ -3231,6 +3231,10 @@
+     "do { x; } while (y);\n"
+     "x; y;\n",
+ 
++    // do-while with break
++    "do { x; break; } while (y);\n"
++    "x; y;\n",
++
+     // C-style for
+     "for (x; y; z) { w; }\n"
+     "x; y; z; w;\n",
+diff --git a/test/unittests/interpreter/bytecode_expectations/ElideRedundantHoleChecks.golden b/test/unittests/interpreter/bytecode_expectations/ElideRedundantHoleChecks.golden
+index 21819d9..eaca674 100644
+--- a/test/unittests/interpreter/bytecode_expectations/ElideRedundantHoleChecks.golden
++++ b/test/unittests/interpreter/bytecode_expectations/ElideRedundantHoleChecks.golden
+@@ -180,6 +180,38 @@
+ snippet: "
+   {
+     f = function f(a) {
++  do { x; break; } while (y);
++  x; y;
++    }
++    let w, x, y, z;
++    f();
++  }
++"
++frame size: 0
++parameter count: 2
++bytecode array length: 16
++bytecodes: [
++  /*   29 S> */ B(LdaImmutableCurrentContextSlot), U8(2),
++                B(ThrowReferenceErrorIfHole), U8(0),
++  /*   32 S> */ B(Jump), U8(2),
++  /*   52 S> */ B(LdaImmutableCurrentContextSlot), U8(2),
++                B(ThrowReferenceErrorIfHole), U8(0),
++  /*   55 S> */ B(LdaImmutableCurrentContextSlot), U8(3),
++                B(ThrowReferenceErrorIfHole), U8(1),
++                B(LdaUndefined),
++  /*   60 S> */ B(Return),
++]
++constant pool: [
++  ONE_BYTE_INTERNALIZED_STRING_TYPE ["x"],
++  ONE_BYTE_INTERNALIZED_STRING_TYPE ["y"],
++]
++handlers: [
++]
++
++---
++snippet: "
++  {
++    f = function f(a) {
+   for (x; y; z) { w; }
+   x; y; z; w;
+     }

--- a/patches/v8/cherry-pick-cf1d4d3c0b6e.patch
+++ b/patches/v8/cherry-pick-cf1d4d3c0b6e.patch
@@ -1,7 +1,7 @@
-From cf1d4d3c0b6e02128a19a75c5c93fe2d34629e34 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shu-yu Guo <syg@chromium.org>
 Date: Thu, 31 Aug 2023 08:59:12 -0700
-Subject: [PATCH] Merged: [interpreter] Fix TDZ elision in do-while tests
+Subject: Merged: [interpreter] Fix TDZ elision in do-while tests
 
 (cherry picked from commit 1626e229a8965f975db6e9da0e7ab85f8c74333f)
 
@@ -15,14 +15,13 @@ Reviewed-by: Adam Klein <adamk@chromium.org>
 Cr-Commit-Position: refs/branch-heads/11.6@{#38}
 Cr-Branched-From: e29c028f391389a7a60ee37097e3ca9e396d6fa4-refs/heads/11.6.189@{#3}
 Cr-Branched-From: 95cbef20e2aa556a1ea75431a48b36c4de6b9934-refs/heads/main@{#88340}
----
 
 diff --git a/src/interpreter/bytecode-generator.cc b/src/interpreter/bytecode-generator.cc
-index bd6c010..751411a 100644
+index 139ed00b4b3f9766a392b84db1ee9f32af57c146..6b656c4a53abacb884a3f23f871229d6e63e9ea1 100644
 --- a/src/interpreter/bytecode-generator.cc
 +++ b/src/interpreter/bytecode-generator.cc
-@@ -2435,8 +2435,16 @@
-     VisitIterationBodyInHoleCheckElisionScope(stmt, &loop_builder);
+@@ -2422,8 +2422,16 @@ void BytecodeGenerator::VisitDoWhileStatement(DoWhileStatement* stmt) {
+     VisitIterationBody(stmt, &loop_builder);
      builder()->SetExpressionAsStatementPosition(stmt->cond());
      BytecodeLabels loop_backbranch(zone());
 -    VisitForTest(stmt->cond(), &loop_backbranch, loop_builder.break_labels(),
@@ -41,10 +40,10 @@ index bd6c010..751411a 100644
    }
  }
 diff --git a/test/unittests/interpreter/bytecode-generator-unittest.cc b/test/unittests/interpreter/bytecode-generator-unittest.cc
-index add6f77..c6cd6d8 100644
+index 55315b2db8076161d02b97f4534fc2c56002a13f..14e4b28c0e963b178ecb0bc71b19d9e8fe267ef1 100644
 --- a/test/unittests/interpreter/bytecode-generator-unittest.cc
 +++ b/test/unittests/interpreter/bytecode-generator-unittest.cc
-@@ -3231,6 +3231,10 @@
+@@ -3237,6 +3237,10 @@ TEST_F(BytecodeGeneratorTest, ElideRedundantHoleChecks) {
      "do { x; } while (y);\n"
      "x; y;\n",
  
@@ -56,13 +55,17 @@ index add6f77..c6cd6d8 100644
      "for (x; y; z) { w; }\n"
      "x; y; z; w;\n",
 diff --git a/test/unittests/interpreter/bytecode_expectations/ElideRedundantHoleChecks.golden b/test/unittests/interpreter/bytecode_expectations/ElideRedundantHoleChecks.golden
-index 21819d9..eaca674 100644
+index 2aeaf6f4aeb9bc8e03f44aa33a8f5dc3723ae61a..8d71dbb36878ddd068a9ca238d06a00bfe7d1a44 100644
 --- a/test/unittests/interpreter/bytecode_expectations/ElideRedundantHoleChecks.golden
 +++ b/test/unittests/interpreter/bytecode_expectations/ElideRedundantHoleChecks.golden
-@@ -180,6 +180,38 @@
- snippet: "
-   {
-     f = function f(a) {
+@@ -176,6 +176,38 @@ constant pool: [
+ handlers: [
+ ]
+ 
++---
++snippet: "
++  {
++    f = function f(a) {
 +  do { x; break; } while (y);
 +  x; y;
 +    }
@@ -91,10 +94,6 @@ index 21819d9..eaca674 100644
 +handlers: [
 +]
 +
-+---
-+snippet: "
-+  {
-+    f = function f(a) {
-   for (x; y; z) { w; }
-   x; y; z; w;
-     }
+ ---
+ snippet: "
+   {


### PR DESCRIPTION
<details>
<summary>electron/security#404 - cf1d4d3c0b6e from v8</summary>
Merged: [interpreter] Fix TDZ elision in do-while tests

(cherry picked from commit 1626e229a8965f975db6e9da0e7ab85f8c74333f)

Change-Id: Ifb7461b6cfd62a10936470a760cb505cc5e1c60f
Fixed: chromium:1477588
Bug: v8:13723
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4862981
Auto-Submit: Shu-yu Guo <syg@chromium.org>
Commit-Queue: Shu-yu Guo <syg@chromium.org>
Reviewed-by: Adam Klein <adamk@chromium.org>
Cr-Commit-Position: refs/branch-heads/11.6@{#38}
Cr-Branched-From: e29c028f391389a7a60ee37097e3ca9e396d6fa4-refs/heads/11.6.189@{#3}
Cr-Branched-From: 95cbef20e2aa556a1ea75431a48b36c4de6b9934-refs/heads/main@{#88340}
</details>

Notes:
* Security: backported fix for 1477588.