### PR TITLE
fix: `app.runningUnderARM64Translation()` always returning true on ARM64

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1491,7 +1491,9 @@ bool App::IsRunningUnderARM64Translation() const {
     return false;
   }
 
-  return nativeMachine == IMAGE_FILE_MACHINE_ARM64;
+  return nativeMachine == IMAGE_FILE_MACHINE_ARM64 &&
+         (processMachine == IMAGE_FILE_MACHINE_I386 ||
+          processMachine == IMAGE_FILE_MACHINE_AMD64);
 }
 #endif
 


### PR DESCRIPTION
#### Description of Change
https://source.chromium.org/chromium/chromium/src/+/main:base/win/windows_version.cc;l=127-155?q=IsWow64Process2&ss=chromium

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: Fixed `app.runningUnderARM64Translation()` always returning true on ARM64.
