### PR TITLE
test: fixup parallel/test-node-output-error test

### DIFF
--- a/patches/node/chore_update_fixtures_errors_force_colors_snapshot.patch
+++ b/patches/node/chore_update_fixtures_errors_force_colors_snapshot.patch
@@ -11,7 +11,7 @@ trying to see whether or not the lines are greyed out. One possibility
 would be to upstream a changed test that doesn't hardcode line numbers.
 
 diff --git a/test/fixtures/errors/force_colors.snapshot b/test/fixtures/errors/force_colors.snapshot
-index 0334a0b4faa3633aa8617b9538873e7f3540513b..7f85ddc507c9c38ce85ed2a48f8152eef168717b 100644
+index 0334a0b4faa3633aa8617b9538873e7f3540513b..fa9989f55980aeddd3fa944318488c0289e3ab6e 100644
 --- a/test/fixtures/errors/force_colors.snapshot
 +++ b/test/fixtures/errors/force_colors.snapshot
 @@ -4,11 +4,12 @@ throw new Error('Should include grayed stack trace')
@@ -27,7 +27,7 @@ index 0334a0b4faa3633aa8617b9538873e7f3540513b..7f85ddc507c9c38ce85ed2a48f8152ee
 +[90m    at Object..js (node:internal*modules*cjs*loader:1326:10)[39m
 +[90m    at Module.load (node:internal*modules*cjs*loader:1126:32)[39m
 +[90m    at node:internal*modules*cjs*loader:967:12[39m
-+[90m    at Function._load (node:electron*js2c*asar_bundle:757:32)[39m
++[90m    at Function._load (node:electron*js2c*asar_bundle:743:32)[39m
 +[90m    at Function.executeUserEntryPoint [as runMain] (node:internal*modules*run_main:96:12)[39m
  [90m    at node:internal*main*run_main_module:23:47[39m
  


### PR DESCRIPTION
Backport of #39972

See that PR for details.


Notes: none.
