### PR TITLE
fix: apply size constraints to NSWindow

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -352,10 +352,14 @@ void NativeWindow::SetContentSizeConstraints(
   size_constraints_.reset();
 }
 
+// Windows/Linux:
 // The return value of GetContentSizeConstraints will be passed to Chromium
 // to set min/max sizes of window. Note that we are returning content size
 // instead of window size because that is what Chromium expects, see the
 // comment of |WidgetSizeIsClientSize| in Chromium's codebase to learn more.
+//
+// macOS:
+// The min/max sizes are set directly by calling NSWindow's methods.
 extensions::SizeConstraints NativeWindow::GetContentSizeConstraints() const {
   if (content_size_constraints_)
     return *content_size_constraints_;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -58,6 +58,8 @@ class NativeWindowMac : public NativeWindow,
   gfx::Rect GetBounds() override;
   bool IsNormal() override;
   gfx::Rect GetNormalBounds() override;
+  void SetSizeConstraints(
+      const extensions::SizeConstraints& window_constraints) override;
   void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints) override;
   void SetResizable(bool resizable) override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -761,6 +761,16 @@ gfx::Rect NativeWindowMac::GetNormalBounds() {
   // return widget()->GetRestoredBounds();
 }
 
+void NativeWindowMac::SetSizeConstraints(
+    const extensions::SizeConstraints& window_constraints) {
+  // Apply the size constraints to NSWindow.
+  if (window_constraints.HasMinimumSize())
+    [window_ setMinSize:window_constraints.GetMinimumSize().ToCGSize()];
+  if (window_constraints.HasMaximumSize())
+    [window_ setMaxSize:window_constraints.GetMaximumSize().ToCGSize()];
+  NativeWindow::SetSizeConstraints(window_constraints);
+}
+
 void NativeWindowMac::SetContentSizeConstraints(
     const extensions::SizeConstraints& size_constraints) {
   auto convertSize = [this](const gfx::Size& size) {
@@ -775,6 +785,7 @@ void NativeWindowMac::SetContentSizeConstraints(
     }
   };
 
+  // Apply the size constraints to NSWindow.
   NSView* content = [window_ contentView];
   if (size_constraints.HasMinimumSize()) {
     NSSize min_size = convertSize(size_constraints.GetMinimumSize());


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/39786.

On macOS the size constraints must be directly applied to NSWindow by calling `setMin/MaxSize` methods, https://github.com/electron/electron/pull/38974 did a modification to `SetSizeConstraints` which accidentally cut off the call to NSWindow methods.

Unfortunately I am unable to write a test for size constraints code, because changing window size with code ignores the size constraints in Cocoa.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix window size constraints not working on macOS.