### PR TITLE
fix: rounded corners on vibrant macOS modals

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1409,11 +1409,21 @@ void NativeWindowMac::UpdateVibrancyRadii(bool fullscreen) {
 
   if (vibrantView != nil && !vibrancy_type_.empty()) {
     const bool no_rounded_corner = !HasStyleMask(NSWindowStyleMaskTitled);
-    if (!has_frame() && !is_modal() && !no_rounded_corner) {
+    const int macos_version = base::mac::MacOSMajorVersion();
+
+    // Modal window corners are rounded on macOS >= 11 or higher if the user
+    // hasn't passed noRoundedCorners.
+    bool should_round_modal =
+        !no_rounded_corner && (macos_version >= 11 ? true : !is_modal());
+    // Nonmodal window corners are rounded if they're frameless and the user
+    // hasn't passed noRoundedCorners.
+    bool should_round_nonmodal = !no_rounded_corner && !has_frame();
+
+    if (should_round_nonmodal || should_round_modal) {
       CGFloat radius;
       if (fullscreen) {
         radius = 0.0f;
-      } else if (@available(macOS 11.0, *)) {
+      } else if (macos_version >= 11) {
         radius = 9.0f;
       } else {
         // Smaller corner radius on versions prior to Big Sur.


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/39960.

Fixes an issue where vibrant windows incorrectly have square corners when they're modals. This was initially changed in https://github.com/electron/electron/pull/24250 in response to the current design of macOS whereby modals were flush to the top of their parent window, which is no longer the case. There also isn't really a concept of framelessness on parented modals, so that condition only applies to non-modal windows.

<details><summary>Before</summary>
<p>

<img width="868" alt="Screenshot 2023-09-26 at 12 35 07 PM" src="https://github.com/electron/electron/assets/2036040/7b9fbe09-dfea-43c0-82e7-18a2b280a189">

</p>
</details>

<details><summary>After</summary>
<p>

<img width="868" alt="Screenshot 2023-09-26 at 12 56 39 PM" src="https://github.com/electron/electron/assets/2036040/7b9ecf97-3bc1-43ad-b6d2-59c9df7c89c2">

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where vibrant windows incorrectly have square corners when they're modals on macOS.