### PR TITLE
build: fix with `enable_pdf_viewer = false`

### DIFF
--- a/shell/browser/extensions/api/resources_private/resources_private_api.cc
+++ b/shell/browser/extensions/api/resources_private/resources_private_api.cc
@@ -13,15 +13,15 @@
 #include "chrome/grit/generated_resources.h"
 #include "components/strings/grit/components_strings.h"
 #include "components/zoom/page_zoom_constants.h"
-#include "pdf/buildflags.h"
+#include "electron/buildflags/buildflags.h"
 #include "printing/buildflags/buildflags.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/webui/web_ui_util.h"
 
-#if BUILDFLAG(ENABLE_PDF)
+#if BUILDFLAG(ENABLE_PDF_VIEWER)
 #include "chrome/browser/pdf/pdf_extension_util.h"
 #include "pdf/pdf_features.h"
-#endif  // BUILDFLAG(ENABLE_PDF)
+#endif  // BUILDFLAG(ENABLE_PDF_VIEWER)
 
 // To add a new component to this API, simply:
 // 1. Add your component to the Component enum in
@@ -48,7 +48,7 @@ ExtensionFunction::ResponseAction ResourcesPrivateGetStringsFunction::Run() {
 
   switch (component) {
     case api::resources_private::COMPONENT_PDF:
-#if BUILDFLAG(ENABLE_PDF)
+#if BUILDFLAG(ENABLE_PDF_VIEWER)
       pdf_extension_util::AddStrings(
           pdf_extension_util::PdfViewerContext::kPdfViewer, &dict);
       pdf_extension_util::AddAdditionalData(true, false, &dict);


### PR DESCRIPTION
#### Description of Change

Fix build with `enable_pdf_viewer = false`. Without this fix, the following linker error occurs:

<details><summary>Linker Error</summary>
<p>

```
ld64.lld: error: undefined symbol: pdf_extension_util::AddAdditionalData(bool, bool, base::Value::Dict*)
>>> referenced by resources_private_api.cc:54 (../../electron/shell/browser/extensions/api/resources_private/resources_private_api.cc:54)
>>>               obj/electron/electron_lib/resources_private_api.o:(symbol extensions::ResourcesPrivateGetStringsFunction::Run()+0x84)

ld64.lld: error: undefined symbol: pdf_extension_util::AddStrings(pdf_extension_util::PdfViewerContext, base::Value::Dict*)
>>> referenced by resources_private_api.cc:52 (../../electron/shell/browser/extensions/api/resources_private/resources_private_api.cc:52)
>>>               obj/electron/electron_lib/resources_private_api.o:(symbol extensions::ResourcesPrivateGetStringsFunction::Run()+0x74)
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
Traceback (most recent call last):
  File "/Users/codebytere/Developer/electron-gn/src/out/Testing/../../build/toolchain/apple/linker_driver.py", line 389, in <module>
    LinkerDriver(sys.argv).run()
  File "/Users/codebytere/Developer/electron-gn/src/out/Testing/../../build/toolchain/apple/linker_driver.py", line 172, in run
    subprocess.check_call([self._driver_path] + compiler_driver_args,
  File "/Users/codebytere/.electron_build_tools/third_party/Xcode/Xcode-14.3.0.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/subprocess.py", line 373, in check_call
    raise CalledProcessError(retcode, cmd)
```

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed build failure when PDF viewer is disabled.
