### PR TITLE
fix: propagate layout call to all children of `InspectableWebContentsViewViews`

### DIFF
--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -216,6 +216,8 @@ const std::u16string InspectableWebContentsViewViews::GetTitle() {
 void InspectableWebContentsViewViews::Layout() {
   if (!devtools_web_view_->GetVisible()) {
     contents_web_view_->SetBoundsRect(GetContentsBounds());
+    // Propagate layout call to all children, for example browser views.
+    View::Layout();
     return;
   }
 
@@ -232,6 +234,9 @@ void InspectableWebContentsViewViews::Layout() {
 
   devtools_web_view_->SetBoundsRect(new_devtools_bounds);
   contents_web_view_->SetBoundsRect(new_contents_bounds);
+
+  // Propagate layout call to all children, for example browser views.
+  View::Layout();
 
   if (GetDelegate())
     GetDelegate()->DevToolsResized();


### PR DESCRIPTION
When BrowserView bounds are set from js, those might not trigger layout immediately, sometimes propagating InvalidateLayout call to parent. View is marked as needing layout, expecting to receive it from parent on next layout call. The problem is that BrowserView's view is added as child of InspectableWebContentsViews which does not call setBounds (which would trigger layout) on all of it's children when doing it's layout, so it skips propagating Layout call to its children BrowserViews views, even though those were marked as needing layout.
Call base class View::Layout which will iterate over views' children and call Layout on those that were marked as needing them.

Unfortunately I failed to create a spec test that would repro this behavior. It seems user click on button (like in gist in bug) might be needed to repro correctly.

Fixes #39993.

#### Checklist

- [x] `npm test` passes

#### Release Notes

Notes: Fixed BrowserView.setBounds calls not painting view in new bounds in some cases.
