### PR TITLE
chore: remove invalid constexpr qualification

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -433,7 +433,7 @@ IconLoader::IconSize GetIconSizeByString(const std::string& size) {
 }
 
 // Return the path constant from string.
-constexpr int GetPathConstant(base::StringPiece name) {
+int GetPathConstant(base::StringPiece name) {
   // clang-format off
   constexpr auto Lookup = base::MakeFixedFlatMapSorted<base::StringPiece, int>({
       {"appData", DIR_APP_DATA},


### PR DESCRIPTION
GetPathConstant calls base::internal::flat_tree<Key, GetKeyFromValue, KeyCompare, Container>::find(Key const&) const which is not constexpr. GCC 12 and earlier raise a compile error on this.

Notes: none