### PR TITLE
chore: bump chromium to 118.0.5993.31 (includes fix for CVE-2023-5217)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -2,7 +2,7 @@ gclient_gn_args_from = 'src'
 
 vars = {
   'chromium_version':
-    '118.0.5993.18',
+    '118.0.5993.29',
   'node_version':
     'v18.17.1',
   'nan_version':


### PR DESCRIPTION
#### Description of Change

Backport of #40015

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Updated Chromium to 118.0.5993.31 (includes fix for CVE-2023-5217)
