### PR TITLE
docs: add PipeWire integration instructions for snaps

### DIFF
--- a/docs/tutorial/snapcraft.md
+++ b/docs/tutorial/snapcraft.md
@@ -91,14 +91,14 @@ version: '0.1'
 summary: Hello World Electron app
 description: |
   Simple Hello World Electron app as an example
-base: core18
+base: core22
 confinement: strict
 grade: stable
 
 apps:
   electron-packager-hello-world:
     command: electron-quick-start/electron-quick-start --no-sandbox
-    extensions: [gnome-3-34]
+    extensions: [gnome]
     plugs:
     - browser-support
     - network
@@ -235,6 +235,34 @@ apps:
     # libappindicator has readable resources.
     command: env TMPDIR=$XDG_RUNTIME_DIR PATH=/usr/local/bin:${PATH} ${SNAP}/bin/desktop-launch $SNAP/myApp/desktop
     desktop: usr/share/applications/desktop.desktop
+```
+
+## Optional: Enabling desktop capture
+
+Capturing the desktop requires PipeWire library in some Linux configurations that use
+the Wayland protocol. To bundle PipeWire with your application, ensure that the base
+snap is set to `core22` or newer. Next, create a part called `pipewire` and add it to
+the `after` section of your application:
+
+```yaml
+  pipewire:
+    plugin: nil
+    build-packages: [libpipewire-0.3-dev]
+    stage-packages: [pipewire]
+    prime:
+      - usr/lib/*/pipewire-*
+      - usr/lib/*/spa-*
+      - usr/lib/*/libpipewire*.so*
+      - usr/share/pipewire
+```
+
+Finally, configure your application's environment for PipeWire:
+
+```yaml
+    environment:
+      SPA_PLUGIN_DIR: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/spa-0.2
+      PIPEWIRE_CONFIG_NAME: $SNAP/usr/share/pipewire/pipewire.conf
+      PIPEWIRE_MODULE_DIR: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/pipewire-0.3
 ```
 
 [snapcraft-syntax]: https://docs.snapcraft.io/build-snaps/syntax


### PR DESCRIPTION
#### Description of Change
Added instructions to bundle PipeWire library in snap packages. PipeWire is dynamically loaded by Chromium and Electron, so it has to be bundled in a snap package. However, Ubuntu does not include libpipewire in any base snap, which necessitates manually bundling the library in every package. I've also updated the base snap in the example to the newest version.

I've tested the instructions using a [barebones Electron application](https://github.com/aiddya/desktop-capture-preview). I've also tested the changes in the example `snapcraft.yaml`. In my testing, `snapcraft` requires the output files to be world readable and writable and the files created by `electron-packager` are not. This is regardless of the base snap version. Once the permission issues are fixed, the changes create a valid snap package.

cc @VerteDinde 

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes

Notes: none