### PR TITLE
ci: update release project board workflows

### DIFF
--- a/.github/workflows/branch-created.yml
+++ b/.github/workflows/branch-created.yml
@@ -60,106 +60,33 @@ jobs:
           done
       - name: Generate GitHub App token
         if: ${{ steps.check-major-version.outputs.MAJOR }}
-        uses: electron/github-app-auth-action@cc6751b3b5e4edc5b9a4ad0a021ac455653b6dc8 # v1.0.0
+        uses: electron/github-app-auth-action@384fd19694fe7b6dcc9a684746c6976ad78228ae # v1.1.1
         id: generate-token
         with:
           creds: ${{ secrets.RELEASE_BOARD_GH_APP_CREDS }}
           org: electron
+      - name: Generate Release Project Board Metadata
+        if: ${{ steps.check-major-version.outputs.MAJOR }}
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        id: generate-project-metadata
+        with:
+          script: |
+            const major = ${{ steps.check-major-version.outputs.MAJOR }}
+
+            core.setOutput("template-view", JSON.stringify({
+                major,
+                "next-major": major + 1,
+                "prev-major": major - 1,
+            }))
+            core.setOutput("title", `${major}-x-y`)
       - name: Create Release Project Board
         if: ${{ steps.check-major-version.outputs.MAJOR }}
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          MAJOR: ${{ steps.check-major-version.outputs.MAJOR }}
-          ELECTRON_ORG_ID: "O_kgDOAMybxg"
-          ELECTRON_REPO_ID: "R_kgDOAI8xSw"
-          TEMPLATE_PROJECT_ID: "PVT_kwDOAMybxs4AQvib"
-        run: |
-          # Copy template to create new project board
-          PROJECT_ID=$(gh api graphql -f query='mutation ($ownerId: ID!, $projectId: ID!, $title: String!) {  
-            copyProjectV2(input: {
-              includeDraftIssues: true,
-              ownerId: $ownerId,
-              projectId: $projectId,
-              title: $title
-            }) {
-              projectV2 {
-                id
-              }
-            }
-          }' -f ownerId=$ELECTRON_ORG_ID -f projectId=$TEMPLATE_PROJECT_ID -f title="${MAJOR}-x-y" | jq -r '.data.copyProjectV2.projectV2.id')
-
-          # Make the new project public
-          gh api graphql -f query='mutation ($projectId: ID!) {                                                                                             
-            updateProjectV2(input: {
-              projectId: $projectId,
-              public: true,
-            }) {
-              projectV2 {
-                id
-              }
-            }
-          }' -f projectId=$PROJECT_ID
-
-          # Link the new project to the Electron repository
-          gh api graphql -f query='mutation ($projectId: ID!, $repositoryId: ID!) {                                                                                             
-            linkProjectV2ToRepository(input: {
-              projectId: $projectId,
-              repositoryId: $repositoryId
-            }) {
-              clientMutationId
-            }
-          }' -f projectId=$PROJECT_ID -f repositoryId=$ELECTRON_REPO_ID
-
-          # Get all draft issues on the new project board
-          gh api graphql -f query='query ($id: ID!) {
-            node(id: $id) {
-              ... on ProjectV2 {
-                items(first: 100) {
-                  nodes {
-                    ... on ProjectV2Item {
-                      id
-                      content {
-                        ... on DraftIssue { id title
-                          body
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }' -f id=$PROJECT_ID > issues.json
-          PROJECT_ITEMS=$(jq '.data.node.items.nodes[] | select(.content.id != null) | .id' issues.json)
-
-          #
-          # Do template replacement for draft issues
-          #
-          echo "{\"major\": $MAJOR, \"next-major\": $((MAJOR + 1)), \"prev-major\": $((MAJOR - 1))}" > variables.json
-
-          # npx mustache is annoyingly slow, so install mustache directly
-          yarn add -D mustache
-
-          for PROJECT_ITEM_ID in $PROJECT_ITEMS; do
-            # These are done with the raw output flag and sent to file to better retain formatting
-            jq -r ".data.node.items.nodes[] | select(.id == $PROJECT_ITEM_ID) | .content.title" issues.json > title.txt
-            jq -r ".data.node.items.nodes[] | select(.id == $PROJECT_ITEM_ID) | .content.body" issues.json > body.txt
-
-            ./node_modules/.bin/mustache variables.json title.txt new_title.txt
-            ./node_modules/.bin/mustache variables.json body.txt new_body.txt
-
-            # Only update draft issues which had content change when interpolated
-            if ! cmp --silent -- new_title.txt title.txt || ! cmp --silent -- new_body.txt body.txt; then
-              DRAFT_ISSUE_ID=$(jq ".data.node.items.nodes[] | select(.id == $PROJECT_ITEM_ID) | .content.id" issues.json)
-              gh api graphql -f query='mutation ($draftIssueId: ID!, $title: String!, $body: String!) {                                                                                             
-                updateProjectV2DraftIssue(input: {
-                  draftIssueId: $draftIssueId,
-                  title: $title,
-                  body: $body
-                }) {
-                  draftIssue {
-                    id
-                  }
-                }
-              }' -f draftIssueId=$DRAFT_ISSUE_ID -f title="$(cat new_title.txt)" -f body="$(cat new_body.txt)"
-            fi
-          done
+        uses: dsanders11/project-actions/copy-project@a24415515fa60a22f71f9d9d00e36ca82660cde9 # v1.0.1
+        with:
+          drafts: true
+          project-number: 64
+          # TODO - Set to public once GitHub fixes their GraphQL bug
+          # public: true
+          template-view: ${{ steps.generate-project-metadata.outputs.template-view }}
+          title: ${{ steps.generate-project-metadata.outputs.title}}
+          token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/stable-prep-items.yml
+++ b/.github/workflows/stable-prep-items.yml
@@ -1,0 +1,35 @@
+name: Check Stable Prep Items
+
+on:
+  schedule:
+    - cron:  '0 */12 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  check-stable-prep-items:
+    name: Check Stable Prep Items
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        uses: electron/github-app-auth-action@384fd19694fe7b6dcc9a684746c6976ad78228ae # v1.1.1
+        id: generate-token
+        with:
+          creds: ${{ secrets.RELEASE_BOARD_GH_APP_CREDS }}
+          org: electron
+      - name: Find Newest Release Project Board
+        id: find-project-number
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -eo pipefail
+          PROJECT_NUMBER=$(gh project list --owner electron --format json | jq -r '.projects | map(select(.title | test("^[0-9]+-x-y$"))) | max_by(.number) | .number')
+          echo "PROJECT_NUMBER=$PROJECT_NUMBER" >> "$GITHUB_OUTPUT"
+      - name: Update Completed Stable Prep Items
+        uses: dsanders11/project-actions/completed-by@a24415515fa60a22f71f9d9d00e36ca82660cde9 # v1.0.1
+        with:
+          field: Prep Status
+          field-value: ✅ Complete
+          project-number: ${{ steps.find-project-number.outputs.PROJECT_NUMBER }}
+          token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

A few different goodies here. The generic logic around creating the new release project board from our template has been pushed to [`dsanders11/project-actions`](https://github.com/dsanders11/project-actions/) where it's got full test coverage (including integration tests) and can be iterated on without needing to involve `e/e`.

The project visibility unfortunately cannot be set to public automatically due to a GitHub bug, so for now that's commented out and we'll manually make it public.

#### Template Field Values

As part of this change, there's added support for setting field values on draft issues when the new release project board is created. This can be done by adding an HTML comment to the draft issue body which maps field names to field values, and is done after the normal mustache templating so the values can come from template values. No current usage, but the feature will be used in the future to automatically set the date fields on draft issues, once that data is available somewhere in machine-readable form.

```html
<!-- fields
  {
    "Start Date": "2023-11-01",
    "End Date": "{{ end-date }}"
  }
-->
```

#### Stable Prep Completed By

Another feature being added is support for linking pull requests to our draft issues for stable prep items using the syntax "Completed by https://github.com/electron/electron/pull/N", similar to GitHub's "Closes" syntax in pull requests. There can be multiple linked pull requests, and when they're all merged, the stable prep item will be marked as completed.

These will be checked by a workflow that runs every 12 hours, and we can adjust as needed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
