### PR TITLE
ci: update automation workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,7 +2,6 @@ name: Bug Report
 description: Report an Electron bug
 title: "[Bug]: "
 labels: "bug :beetle:"
-projects: ["electron/90"]
 body:
 - type: checkboxes
   attributes:

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -20,14 +20,12 @@ jobs:
           creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
           org: electron
       - name: Set status
-        uses: github/update-project-action@2d475e08804f11f4022df7e21f5816531e97cb64 # v2
+        uses: dsanders11/project-actions/edit-item@a24415515fa60a22f71f9d9d00e36ca82660cde9 # v1.0.1
         with:
-          github_token: ${{ steps.generate-token.outputs.token }}
-          organization: electron
-          project_number: 90
-          content_id: ${{ github.event.issue.node_id }}
+          token: ${{ steps.generate-token.outputs.token }}
+          project-number: 90
           field: Status
-          value: 🛑 Blocked
+          field-value: 🛑 Blocked
   issue-labeled-blocked-need-repro:
     name: blocked/need-repro label added
     if: github.event.label.name == 'blocked/need-repro'

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -1,0 +1,27 @@
+name: Issue Opened
+
+on:
+  issues:
+    types:
+      - opened
+
+permissions: {}
+
+jobs:
+  add-to-issue-triage:
+    if: ${{ contains(github.event.issue.labels.*.name, 'bug :beetle:') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        uses: electron/github-app-auth-action@384fd19694fe7b6dcc9a684746c6976ad78228ae # v1.1.1
+        id: generate-token
+        with:
+          creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
+          org: electron
+      - name: Add to Issue Triage
+        uses: dsanders11/project-actions/add-item@a24415515fa60a22f71f9d9d00e36ca82660cde9 # v1.0.1
+        with:
+          field: Reporter
+          field-value: ${{ github.event.issue.user.login }}
+          project-number: 90
+          token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/issue-unlabeled.yml
+++ b/.github/workflows/issue-unlabeled.yml
@@ -30,11 +30,9 @@ jobs:
           org: electron
       - name: Set status
         if: ${{ steps.check-for-blocked-labels.outputs.NOT_BLOCKED }}
-        uses: github/update-project-action@2d475e08804f11f4022df7e21f5816531e97cb64 # v2
+        uses: dsanders11/project-actions/edit-item@a24415515fa60a22f71f9d9d00e36ca82660cde9 # v1.0.1
         with:
-          github_token: ${{ steps.generate-token.outputs.token }}
-          organization: electron
-          project_number: 90
-          content_id: ${{ github.event.issue.node_id }}
+          token: ${{ steps.generate-token.outputs.token }}
+          project-number: 90
           field: Status
-          value: 📥 Was Blocked
+          field-value: 📥 Was Blocked

--- a/.github/workflows/pull-request-labeled.yml
+++ b/.github/workflows/pull-request-labeled.yml
@@ -20,11 +20,9 @@ jobs:
           creds: ${{ secrets.RELEASE_BOARD_GH_APP_CREDS }}
           org: electron
       - name: Set status
-        uses: dsanders11/update-project-action@7ade91760df70df76770a238abee7a4869e01cf8
+        uses: dsanders11/project-actions/edit-item@a24415515fa60a22f71f9d9d00e36ca82660cde9 # v1.0.1
         with:
-          github_token: ${{ steps.generate-token.outputs.token }}
-          organization: electron
-          project_number: 94
-          content_id: ${{ github.event.pull_request.node_id }}
+          token: ${{ steps.generate-token.outputs.token }}
+          project-number: 94
           field: Status
-          value: ✅ Reviewed
+          field-value: ✅ Reviewed


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Switches to [`dsanders11/project-actions`](https://github.com/dsanders11/project-actions) as `github/update-project-action` is not being adequately maintained.

Adds a workflow to add issues to the issue triage board as GitHub has a bug which prevents filtering on the bug label currently, and it also lets set custom fields while we do so. Removes the projects field from the bug template, which was the initial attempt at working around the GitHub bug, but it turns out that doesn't work if the project is private.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
