### PR TITLE
chore: cherry-pick 3fbd1dca6a4d from libvpx

### DIFF
--- a/patches/config.json
+++ b/patches/config.json
@@ -25,5 +25,7 @@
 
   "src/electron/patches/skia": "src/third_party/skia",
 
-  "src/electron/patches/libwebp": "src/third_party/libwebp/src"
+  "src/electron/patches/libwebp": "src/third_party/libwebp/src",
+
+  "src/electron/patches/libvpx": "src/third_party/libvpx/source/libvpx"
 }

--- a/patches/libvpx/.patches
+++ b/patches/libvpx/.patches
@@ -1,0 +1,1 @@
+cherry-pick-3fbd1dca6a4d.patch

--- a/patches/libvpx/cherry-pick-3fbd1dca6a4d.patch
+++ b/patches/libvpx/cherry-pick-3fbd1dca6a4d.patch
@@ -1,0 +1,43 @@
+From 3fbd1dca6a4d2dad332a2110d646e4ffef36d590 Mon Sep 17 00:00:00 2001
+From: James Zern <jzern@google.com>
+Date: Mon, 25 Sep 2023 18:55:59 -0700
+Subject: [PATCH] VP8: disallow thread count changes
+
+Currently allocations are done at encoder creation time. Going from
+threaded to non-threaded would cause a crash.
+
+Bug: chromium:1486441
+Change-Id: Ie301c2a70847dff2f0daae408fbef1e4d42e73d4
+---
+
+diff --git a/test/encode_api_test.cc b/test/encode_api_test.cc
+index a8a4df2..f1c98b2 100644
+--- a/test/encode_api_test.cc
++++ b/test/encode_api_test.cc
+@@ -370,10 +370,6 @@
+ 
+   for (const auto *iface : kCodecIfaces) {
+     SCOPED_TRACE(vpx_codec_iface_name(iface));
+-    if (!IsVP9(iface)) {
+-      GTEST_SKIP() << "TODO(https://crbug.com/1486441) remove this condition "
+-                      "after VP8 is fixed.";
+-    }
+     for (int i = 0; i < (IsVP9(iface) ? 2 : 1); ++i) {
+       vpx_codec_enc_cfg_t cfg = {};
+       struct Encoder {
+diff --git a/vp8/encoder/onyx_if.c b/vp8/encoder/onyx_if.c
+index c65afc6..c5e9970 100644
+--- a/vp8/encoder/onyx_if.c
++++ b/vp8/encoder/onyx_if.c
+@@ -1447,6 +1447,11 @@
+   last_h = cpi->oxcf.Height;
+   prev_number_of_layers = cpi->oxcf.number_of_layers;
+ 
++  if (cpi->initial_width) {
++    // TODO(https://crbug.com/1486441): Allow changing thread counts; the
++    // allocation is done once in vp8_create_compressor().
++    oxcf->multi_threaded = cpi->oxcf.multi_threaded;
++  }
+   cpi->oxcf = *oxcf;
+ 
+   switch (cpi->oxcf.Mode) {

--- a/patches/libvpx/cherry-pick-3fbd1dca6a4d.patch
+++ b/patches/libvpx/cherry-pick-3fbd1dca6a4d.patch
@@ -10,7 +10,7 @@ Bug: chromium:1486441
 Change-Id: Ie301c2a70847dff2f0daae408fbef1e4d42e73d4
 
 diff --git a/vp8/encoder/onyx_if.c b/vp8/encoder/onyx_if.c
-index 94fb6e256e8f4f1077aa6e2aef84e3bc7070da0f..f68339d2b4f4b2ca654a835cc56c537fb5e7d260 100644
+index bcf5227029731c47b54d3d8cb339c23cd0986f36..27bacad8f97e8f141627ee6f7b85ab044dad4217 100644
 --- a/vp8/encoder/onyx_if.c
 +++ b/vp8/encoder/onyx_if.c
 @@ -1443,6 +1443,11 @@ void vp8_change_config(VP8_COMP *cpi, VP8_CONFIG *oxcf) {

--- a/patches/libvpx/cherry-pick-3fbd1dca6a4d.patch
+++ b/patches/libvpx/cherry-pick-3fbd1dca6a4d.patch
@@ -1,35 +1,19 @@
-From 3fbd1dca6a4d2dad332a2110d646e4ffef36d590 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: James Zern <jzern@google.com>
 Date: Mon, 25 Sep 2023 18:55:59 -0700
-Subject: [PATCH] VP8: disallow thread count changes
+Subject: VP8: disallow thread count changes
 
 Currently allocations are done at encoder creation time. Going from
 threaded to non-threaded would cause a crash.
 
 Bug: chromium:1486441
 Change-Id: Ie301c2a70847dff2f0daae408fbef1e4d42e73d4
----
 
-diff --git a/test/encode_api_test.cc b/test/encode_api_test.cc
-index a8a4df2..f1c98b2 100644
---- a/test/encode_api_test.cc
-+++ b/test/encode_api_test.cc
-@@ -370,10 +370,6 @@
- 
-   for (const auto *iface : kCodecIfaces) {
-     SCOPED_TRACE(vpx_codec_iface_name(iface));
--    if (!IsVP9(iface)) {
--      GTEST_SKIP() << "TODO(https://crbug.com/1486441) remove this condition "
--                      "after VP8 is fixed.";
--    }
-     for (int i = 0; i < (IsVP9(iface) ? 2 : 1); ++i) {
-       vpx_codec_enc_cfg_t cfg = {};
-       struct Encoder {
 diff --git a/vp8/encoder/onyx_if.c b/vp8/encoder/onyx_if.c
-index c65afc6..c5e9970 100644
+index 94fb6e256e8f4f1077aa6e2aef84e3bc7070da0f..f68339d2b4f4b2ca654a835cc56c537fb5e7d260 100644
 --- a/vp8/encoder/onyx_if.c
 +++ b/vp8/encoder/onyx_if.c
-@@ -1447,6 +1447,11 @@
+@@ -1443,6 +1443,11 @@ void vp8_change_config(VP8_COMP *cpi, VP8_CONFIG *oxcf) {
    last_h = cpi->oxcf.Height;
    prev_number_of_layers = cpi->oxcf.number_of_layers;
  


### PR DESCRIPTION
VP8: disallow thread count changes

Currently allocations are done at encoder creation time. Going from
threaded to non-threaded would cause a crash.

Bug: chromium:1486441
Change-Id: Ie301c2a70847dff2f0daae408fbef1e4d42e73d4


Notes: Security: backported fix for CVE-2023-5217.