### PR TITLE
chore: update extensions url handling to match upstream

### DIFF
--- a/spec/fixtures/extensions/chrome-tabs/api-async/background.js
+++ b/spec/fixtures/extensions/chrome-tabs/api-async/background.js
@@ -1,6 +1,6 @@
 /* global chrome */
 
-const handleRequest = (request, sender, sendResponse) => {
+const handleRequest = async (request, sender, sendResponse) => {
   const { method, args = [] } = request;
   const tabId = sender.tab.id;
 
@@ -53,7 +53,12 @@ const handleRequest = (request, sender, sendResponse) => {
 
     case 'update': {
       const [params] = args;
-      chrome.tabs.update(tabId, params).then(sendResponse);
+      try {
+        const response = await chrome.tabs.update(tabId, params);
+        sendResponse(response);
+      } catch (error) {
+        sendResponse({ error: error.message });
+      }
       break;
     }
   }


### PR DESCRIPTION
#### Description of Change

Refs:
- https://chromium-review.googlesource.com/c/chromium/src/+/4772028
- https://chromium-review.googlesource.com/c/chromium/src/+/4264656
- https://chromium-review.googlesource.com/c/chromium/src/+/4712150

Updates `chrome.tabs.update` url handling to match upstream Chromium. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.
