### PR TITLE
docs: tiny spelling correction on process-model.md

### DIFF
--- a/docs/tutorial/process-model.md
+++ b/docs/tutorial/process-model.md
@@ -113,7 +113,7 @@ For a full list of Electron's main process modules, check out our API documentat
 Each Electron app spawns a separate renderer process for each open `BrowserWindow`
 (and each web embed). As its name implies, a renderer is responsible for
 _rendering_ web content. For all intents and purposes, code ran in renderer processes
-should behave according to web standards (insofar as Chromium does, at least).
+should behave according to web standards (in so far as Chromium does, at least).
 
 Therefore, all user interfaces and app functionality within a single browser
 window should be written with the same tools and paradigms that you use on the


### PR DESCRIPTION
spelling correction. insofar as -> in so far as

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
