### PR TITLE
fix: support esm entrypoint to utility process

### DIFF
--- a/spec/fixtures/api/utility-process/esm.mjs
+++ b/spec/fixtures/api/utility-process/esm.mjs
@@ -1,0 +1,2 @@
+console.log(import.meta.url);
+process.exit(0);

--- a/spec/fixtures/api/utility-process/exception.mjs
+++ b/spec/fixtures/api/utility-process/exception.mjs
@@ -1,0 +1,1 @@
+nonExistingFunc(); // eslint-disable-line no-undef


### PR DESCRIPTION
Closes #40031

I'm not aware of any synchronous module load guarantees / expectations with the utility process API so just swapping to using the ESM loader instead of the CJS loader should work fine.  (the esm loader falls back to CJS) 

Notes: The `UtilityProcess` API now supports ESM entrypoints