### PR TITLE
fix: all children showing when showing child window

### DIFF
--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -189,6 +189,9 @@ class NativeWindowMac : public NativeWindow,
     has_deferred_window_close_ = defer_close;
   }
 
+  void set_wants_to_be_visible(bool visible) { wants_to_be_visible_ = visible; }
+  bool wants_to_be_visible() const { return wants_to_be_visible_; }
+
   enum class VisualEffectState {
     kFollowWindow,
     kActive,
@@ -254,6 +257,10 @@ class NativeWindowMac : public NativeWindow,
   // fullscreen transition, to defer the -[NSWindow close] call until the
   // transition is complete.
   bool has_deferred_window_close_ = false;
+
+  // If true, the window is either visible, or wants to be visible but is
+  // currently hidden due to having a hidden parent.
+  bool wants_to_be_visible_ = false;
 
   NSInteger attention_request_id_ = 0;  // identifier from requestUserAttention
 

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -258,6 +258,7 @@ using FullScreenTransitionState =
   [super windowDidMiniaturize:notification];
   is_minimized_ = true;
 
+  shell_->set_wants_to_be_visible(false);
   shell_->NotifyWindowMinimize();
 }
 
@@ -265,6 +266,7 @@ using FullScreenTransitionState =
   [super windowDidDeminiaturize:notification];
   is_minimized_ = false;
 
+  shell_->set_wants_to_be_visible(true);
   shell_->AttachChildren();
   shell_->SetWindowLevel(level_);
   shell_->NotifyWindowRestore();

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -4680,7 +4680,27 @@ describe('BrowserWindow module', () => {
         expect(w.getChildWindows().length).to.equal(0);
       });
 
-      ifit(process.platform === 'darwin')('child window matches visibility when visibility changes', async () => {
+      ifit(process.platform === 'darwin')('only shows the intended window when a child with siblings is shown', async () => {
+        const w = new BrowserWindow({ show: false });
+        const childOne = new BrowserWindow({ show: false, parent: w });
+        const childTwo = new BrowserWindow({ show: false, parent: w });
+
+        const parentShown = once(w, 'show');
+        w.show();
+        await parentShown;
+
+        expect(childOne.isVisible()).to.be.false('childOne is visible');
+        expect(childTwo.isVisible()).to.be.false('childTwo is visible');
+
+        const childOneShown = once(childOne, 'show');
+        childOne.show();
+        await childOneShown;
+
+        expect(childOne.isVisible()).to.be.true('childOne is not visible');
+        expect(childTwo.isVisible()).to.be.false('childTwo is visible');
+      });
+
+      ifit(process.platform === 'darwin')('child matches parent visibility when parent visibility changes', async () => {
         const w = new BrowserWindow({ show: false });
         const c = new BrowserWindow({ show: false, parent: w });
 
@@ -4707,7 +4727,7 @@ describe('BrowserWindow module', () => {
         expect(c.isVisible()).to.be.true('child is visible');
       });
 
-      ifit(process.platform === 'darwin')('matches child window visibility when visibility changes', async () => {
+      ifit(process.platform === 'darwin')('parent matches child visibility when child visibility changes', async () => {
         const w = new BrowserWindow({ show: false });
         const c = new BrowserWindow({ show: false, parent: w });
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/39704.

Fixes an issue where calling `show()` on a child `BrowserWindow` would incorrectly show all other children attached to the same parent. This was happening because logic to handle de- and re-attachment of children to a parent window did not properly take into account whether the window was visible prior. I will likely follow this up with a bit more of a cleanup around parent-child attachment logic but this fixes the immediate issue [similarly to Chromium](https://source.chromium.org/chromium/chromium/src/+/main:components/remote_cocoa/app_shim/native_widget_ns_window_bridge.h;l=413;drc=7593550779a58b1caf30dcbf6adc73eb52b617a4;bpv=1;bpt=1)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where calling `show()` on a child `BrowserWindow` would show all other children attached to the same parent on macOS.