### PR TITLE
feat: expose app accessibility transparency settings api

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -401,6 +401,10 @@ Returns an object with system animation settings.
 
 ## Properties
 
+### `systemPreferences.accessibilityDisplayShouldReduceTransparency()` _macOS_
+
+A `boolean` property which determines whether the app avoids using semitransparent backgrounds. This maps to [NSWorkspace.accessibilityDisplayShouldReduceTransparency](https://developer.apple.com/documentation/appkit/nsworkspace/1533006-accessibilitydisplayshouldreduce)
+
 ### `systemPreferences.effectiveAppearance` _macOS_ _Readonly_
 
 A `string` property that can be `dark`, `light` or `unknown`.

--- a/shell/browser/api/electron_api_system_preferences.cc
+++ b/shell/browser/api/electron_api_system_preferences.cc
@@ -96,6 +96,9 @@ gin::ObjectTemplateBuilder SystemPreferences::GetObjectTemplateBuilder(
       .SetMethod("isTrustedAccessibilityClient",
                  &SystemPreferences::IsTrustedAccessibilityClient)
       .SetMethod("askForMediaAccess", &SystemPreferences::AskForMediaAccess)
+      .SetProperty(
+          "accessibilityDisplayShouldReduceTransparency",
+          &SystemPreferences::AccessibilityDisplayShouldReduceTransparency)
 #endif
       .SetMethod("getAnimationSettings",
                  &SystemPreferences::GetAnimationSettings);

--- a/shell/browser/api/electron_api_system_preferences.h
+++ b/shell/browser/api/electron_api_system_preferences.h
@@ -96,6 +96,7 @@ class SystemPreferences
                       gin::Arguments* args);
   void RemoveUserDefault(const std::string& name);
   bool IsSwipeTrackingFromScrollEventsEnabled();
+  bool AccessibilityDisplayShouldReduceTransparency();
 
   std::string GetSystemColor(gin_helper::ErrorThrower thrower,
                              const std::string& color);

--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -602,4 +602,9 @@ v8::Local<v8::Value> SystemPreferences::GetEffectiveAppearance(
       isolate, [NSApplication sharedApplication].effectiveAppearance);
 }
 
+bool SystemPreferences::AccessibilityDisplayShouldReduceTransparency() {
+  return [[NSWorkspace sharedWorkspace]
+      accessibilityDisplayShouldReduceTransparency];
+}
+
 }  // namespace electron::api

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -382,8 +382,6 @@ if (process.platform === 'darwin') {
   // @ts-expect-error Removed API
   systemPreferences.setAppLevelAppearance('dark');
   // @ts-expect-error Removed API
-  console.log(systemPreferences.appLevelAppearance);
-  // @ts-expect-error Removed API
   console.log(systemPreferences.getColor('alternate-selected-control-text'));
 }
 


### PR DESCRIPTION
Backport of #39631 

See that PR for details

Notes: Exposed an API to allow apps to determine whether to avoid using semitransparent backgrounds.