### PR TITLE
chore: cherry-pick 2 changes from Release-1-M117

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -172,3 +172,4 @@ cherry-pick-c60a1ab717c7.patch
 networkcontext_don_t_access_url_loader_factories_during_destruction.patch
 don_t_keep_pointer_to_popped_stack_memory_for_has.patch
 cherry-pick-35c06406a658.patch
+cherry-pick-b11e7d07a6f4.patch

--- a/patches/chromium/cherry-pick-b11e7d07a6f4.patch
+++ b/patches/chromium/cherry-pick-b11e7d07a6f4.patch
@@ -1,0 +1,41 @@
+From b11e7d07a6f47c4c60b21cc238e5c3f80cbcdb68 Mon Sep 17 00:00:00 2001
+From: Lei Zhang <thestig@chromium.org>
+Date: Wed, 13 Sep 2023 23:32:40 +0000
+Subject: [PATCH] M117: Check for object destruction in PdfViewWebPlugin::UpdateFocus()
+
+PdfViewWebPlugin::UpdateFocus() can potentially triggers its own
+destruction. Add a check for this and bail out.
+
+(cherry picked from commit cacf485a202b342526374d444375b80a044add76)
+
+Bug: 1480184
+Change-Id: I5e7760ed541a2bffb9dd1ebeb522f10650049033
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4852346
+Reviewed-by: Tom Sepez <tsepez@chromium.org>
+Code-Coverage: findit-for-me@appspot.gserviceaccount.com <findit-for-me@appspot.gserviceaccount.com>
+Commit-Queue: Lei Zhang <thestig@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1194210}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4863395
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/5938@{#1286}
+Cr-Branched-From: 2b50cb4bcc2318034581a816714d9535dc38966d-refs/heads/main@{#1181205}
+---
+
+diff --git a/pdf/pdf_view_web_plugin.cc b/pdf/pdf_view_web_plugin.cc
+index ae90d41..db456df 100644
+--- a/pdf/pdf_view_web_plugin.cc
++++ b/pdf/pdf_view_web_plugin.cc
+@@ -518,7 +518,13 @@
+   if (has_focus_ != focused) {
+     engine_->UpdateFocus(focused);
+     client_->UpdateTextInputState();
++
++    // Make sure `this` is still alive after the UpdateSelectionBounds() call.
++    auto weak_this = weak_factory_.GetWeakPtr();
+     client_->UpdateSelectionBounds();
++    if (!weak_this) {
++      return;
++    }
+   }
+   has_focus_ = focused;
+ 

--- a/patches/chromium/cherry-pick-b11e7d07a6f4.patch
+++ b/patches/chromium/cherry-pick-b11e7d07a6f4.patch
@@ -1,7 +1,7 @@
-From b11e7d07a6f47c4c60b21cc238e5c3f80cbcdb68 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Lei Zhang <thestig@chromium.org>
 Date: Wed, 13 Sep 2023 23:32:40 +0000
-Subject: [PATCH] M117: Check for object destruction in PdfViewWebPlugin::UpdateFocus()
+Subject: M117: Check for object destruction in PdfViewWebPlugin::UpdateFocus()
 
 PdfViewWebPlugin::UpdateFocus() can potentially triggers its own
 destruction. Add a check for this and bail out.
@@ -19,13 +19,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4863395
 Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
 Cr-Commit-Position: refs/branch-heads/5938@{#1286}
 Cr-Branched-From: 2b50cb4bcc2318034581a816714d9535dc38966d-refs/heads/main@{#1181205}
----
 
 diff --git a/pdf/pdf_view_web_plugin.cc b/pdf/pdf_view_web_plugin.cc
-index ae90d41..db456df 100644
+index cdedca1425dd5be31b2d0b5220d0e050d0b0fb59..b14777df757c8c9b3e5474e7f0f73fe316bfee58 100644
 --- a/pdf/pdf_view_web_plugin.cc
 +++ b/pdf/pdf_view_web_plugin.cc
-@@ -518,7 +518,13 @@
+@@ -519,7 +519,13 @@ void PdfViewWebPlugin::UpdateFocus(bool focused,
    if (has_focus_ != focused) {
      engine_->UpdateFocus(focused);
      client_->UpdateTextInputState();

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -31,3 +31,4 @@ merged_compiler_check_for_read-only_property_on.patch
 shared-struct_fix_for-in_enumeration.patch
 merged_squashed_multiple_commits.patch
 cherry-pick-038530c94a06.patch
+cherry-pick-b0ad701a609a.patch

--- a/patches/v8/cherry-pick-b0ad701a609a.patch
+++ b/patches/v8/cherry-pick-b0ad701a609a.patch
@@ -1,0 +1,57 @@
+From b0ad701a609a0a10327384b658695619773a7918 Mon Sep 17 00:00:00 2001
+From: Shu-yu Guo <syg@chromium.org>
+Date: Wed, 06 Sep 2023 17:36:38 -0700
+Subject: [PATCH] Merged: [builtins] Clear FixedArray slot in Promise builtins
+
+(cherry picked from commit f1884222ad56734e56d80f9707e0e8279af9049e)
+
+Bug: chromium:1479104
+Change-Id: Iddc16d8add4dc6bf6f55f537da44770bea6f4bc3
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4862980
+Auto-Submit: Shu-yu Guo <syg@chromium.org>
+Reviewed-by: Adam Klein <adamk@chromium.org>
+Commit-Queue: Adam Klein <adamk@chromium.org>
+Cr-Commit-Position: refs/branch-heads/11.6@{#36}
+Cr-Branched-From: e29c028f391389a7a60ee37097e3ca9e396d6fa4-refs/heads/11.6.189@{#3}
+Cr-Branched-From: 95cbef20e2aa556a1ea75431a48b36c4de6b9934-refs/heads/main@{#88340}
+---
+
+diff --git a/src/builtins/promise-any.tq b/src/builtins/promise-any.tq
+index 45bafac..d531d57 100644
+--- a/src/builtins/promise-any.tq
++++ b/src/builtins/promise-any.tq
+@@ -106,9 +106,10 @@
+   const index = identityHash - 1;
+ 
+   // 6. Let errors be F.[[Errors]].
+-  let errors = *ContextSlot(
++  let errorsRef:&FixedArray = ContextSlot(
+       context,
+       PromiseAnyRejectElementContextSlots::kPromiseAnyRejectElementErrorsSlot);
++  let errors = *errorsRef;
+ 
+   // 7. Let promiseCapability be F.[[Capability]].
+ 
+@@ -134,10 +135,7 @@
+       IntPtrMax(SmiUntag(remainingElementsCount) - 1, index + 1);
+   if (newCapacity > errors.length_intptr) deferred {
+       errors = ExtractFixedArray(errors, 0, errors.length_intptr, newCapacity);
+-      *ContextSlot(
+-          context,
+-          PromiseAnyRejectElementContextSlots::
+-              kPromiseAnyRejectElementErrorsSlot) = errors;
++      *errorsRef = errors;
+     }
+   errors.objects[index] = value;
+ 
+@@ -155,6 +153,10 @@
+ 
+     //   b. Set error.[[AggregateErrors]] to errors.
+     const error = ConstructAggregateError(errors);
++
++    // After this point, errors escapes to user code. Clear the slot.
++    *errorsRef = kEmptyFixedArray;
++
+     //   c. Return ? Call(promiseCapability.[[Reject]], undefined, « error »).
+     const capability = *ContextSlot(
+         context,

--- a/patches/v8/cherry-pick-b0ad701a609a.patch
+++ b/patches/v8/cherry-pick-b0ad701a609a.patch
@@ -1,7 +1,7 @@
-From b0ad701a609a0a10327384b658695619773a7918 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shu-yu Guo <syg@chromium.org>
-Date: Wed, 06 Sep 2023 17:36:38 -0700
-Subject: [PATCH] Merged: [builtins] Clear FixedArray slot in Promise builtins
+Date: Wed, 6 Sep 2023 17:36:38 -0700
+Subject: Merged: [builtins] Clear FixedArray slot in Promise builtins
 
 (cherry picked from commit f1884222ad56734e56d80f9707e0e8279af9049e)
 
@@ -14,13 +14,12 @@ Commit-Queue: Adam Klein <adamk@chromium.org>
 Cr-Commit-Position: refs/branch-heads/11.6@{#36}
 Cr-Branched-From: e29c028f391389a7a60ee37097e3ca9e396d6fa4-refs/heads/11.6.189@{#3}
 Cr-Branched-From: 95cbef20e2aa556a1ea75431a48b36c4de6b9934-refs/heads/main@{#88340}
----
 
 diff --git a/src/builtins/promise-any.tq b/src/builtins/promise-any.tq
-index 45bafac..d531d57 100644
+index 45bafac0e6b09143b69b21a7292f9ed6b9c46239..d531d57a375ba33bf11ccf698da5918f1e25f38c 100644
 --- a/src/builtins/promise-any.tq
 +++ b/src/builtins/promise-any.tq
-@@ -106,9 +106,10 @@
+@@ -106,9 +106,10 @@ PromiseAnyRejectElementClosure(
    const index = identityHash - 1;
  
    // 6. Let errors be F.[[Errors]].
@@ -32,7 +31,7 @@ index 45bafac..d531d57 100644
  
    // 7. Let promiseCapability be F.[[Capability]].
  
-@@ -134,10 +135,7 @@
+@@ -134,10 +135,7 @@ PromiseAnyRejectElementClosure(
        IntPtrMax(SmiUntag(remainingElementsCount) - 1, index + 1);
    if (newCapacity > errors.length_intptr) deferred {
        errors = ExtractFixedArray(errors, 0, errors.length_intptr, newCapacity);
@@ -44,7 +43,7 @@ index 45bafac..d531d57 100644
      }
    errors.objects[index] = value;
  
-@@ -155,6 +153,10 @@
+@@ -155,6 +153,10 @@ PromiseAnyRejectElementClosure(
  
      //   b. Set error.[[AggregateErrors]] to errors.
      const error = ConstructAggregateError(errors);


### PR DESCRIPTION
<details>
<summary>electron/security#409 - b0ad701a609a from v8</summary>
Merged: [builtins] Clear FixedArray slot in Promise builtins

(cherry picked from commit f1884222ad56734e56d80f9707e0e8279af9049e)

Bug: chromium:1479104
Change-Id: Iddc16d8add4dc6bf6f55f537da44770bea6f4bc3
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4862980
Auto-Submit: Shu-yu Guo <syg@chromium.org>
Reviewed-by: Adam Klein <adamk@chromium.org>
Commit-Queue: Adam Klein <adamk@chromium.org>
Cr-Commit-Position: refs/branch-heads/11.6@{#36}
Cr-Branched-From: e29c028f391389a7a60ee37097e3ca9e396d6fa4-refs/heads/11.6.189@{#3}
Cr-Branched-From: 95cbef20e2aa556a1ea75431a48b36c4de6b9934-refs/heads/main@{#88340}
</details>

<details>
<summary>electron/security#408 - b11e7d07a6f4 from chromium</summary>
M117: Check for object destruction in PdfViewWebPlugin::UpdateFocus()

PdfViewWebPlugin::UpdateFocus() can potentially triggers its own
destruction. Add a check for this and bail out.

(cherry picked from commit cacf485a202b342526374d444375b80a044add76)

Bug: 1480184
Change-Id: I5e7760ed541a2bffb9dd1ebeb522f10650049033
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4852346
Reviewed-by: Tom Sepez <tsepez@chromium.org>
Code-Coverage: findit-for-me@appspot.gserviceaccount.com <findit-for-me@appspot.gserviceaccount.com>
Commit-Queue: Lei Zhang <thestig@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1194210}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4863395
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Cr-Commit-Position: refs/branch-heads/5938@{#1286}
Cr-Branched-From: 2b50cb4bcc2318034581a816714d9535dc38966d-refs/heads/main@{#1181205}
</details>

Notes:
* Security: backported fix for 1479104.
* Security: backported fix for 1480184.