### PR TITLE
fix: crashed events deprecation

### DIFF
--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -114,5 +114,11 @@ for (const name of events) {
 }
 
 // Deprecation.
-deprecate.event(app, 'gpu-process-crashed', 'child-process-gone');
-deprecate.event(app, 'renderer-process-crashed', 'render-process-gone');
+deprecate.event(app, 'gpu-process-crashed', 'child-process-gone', () => {
+  // the old event is still emitted by App::OnGpuProcessCrashed()
+  return undefined;
+});
+
+deprecate.event(app, 'renderer-process-crashed', 'render-process-gone', (event: Electron.Event, webContents: Electron.WebContents, details: Electron.RenderProcessGoneDetails) => {
+  return [event, webContents, details.reason === 'killed'];
+});

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -665,8 +665,8 @@ WebContents.prototype._init = function () {
     ipcMain.emit(channel, event, message);
   });
 
-  this.on('crashed', (event, ...args) => {
-    app.emit('renderer-process-crashed', event, this, ...args);
+  deprecate.event(this, 'crashed', 'render-process-gone', (event: Electron.Event, details: Electron.RenderProcessGoneDetails) => {
+    return [event, details.reason === 'killed'];
   });
 
   this.on('render-process-gone', (event, details) => {

--- a/lib/common/deprecate.ts
+++ b/lib/common/deprecate.ts
@@ -66,14 +66,17 @@ export function renameFunction<T extends Function> (fn: T, newName: string): T {
 }
 
 // change the name of an event
-export function event (emitter: NodeJS.EventEmitter, oldName: string, newName: string) {
+export function event (emitter: NodeJS.EventEmitter, oldName: string, newName: string, transformer: (...args: any[]) => any[] | undefined = (...args) => args) {
   const warn = newName.startsWith('-') /* internal event */
     ? warnOnce(`${oldName} event`)
     : warnOnce(`${oldName} event`, `${newName} event`);
   return emitter.on(newName, function (this: NodeJS.EventEmitter, ...args) {
     if (this.listenerCount(oldName) !== 0) {
       warn();
-      this.emit(oldName, ...args);
+      const transformedArgs = transformer(...args);
+      if (transformedArgs) {
+        this.emit(oldName, ...transformedArgs);
+      }
     }
   });
 }

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1729,13 +1729,6 @@ void WebContents::RenderViewDeleted(content::RenderViewHost* render_view_host) {
 
 void WebContents::PrimaryMainFrameRenderProcessGone(
     base::TerminationStatus status) {
-  auto weak_this = GetWeakPtr();
-  Emit("crashed", status == base::TERMINATION_STATUS_PROCESS_WAS_KILLED);
-
-  // User might destroy WebContents in the crashed event.
-  if (!weak_this || !web_contents())
-    return;
-
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
   gin_helper::Dictionary details = gin_helper::Dictionary::CreateEmpty(isolate);


### PR DESCRIPTION
#### Description of Change
Regressed by https://github.com/electron/electron/pull/33557/files#diff-ee83fd1a162a48cfe0ee8849a859f6d6700ceb6aa2bdee23b875d8941620c7c6

**`renderer-process-crashed` event**
```js
app.on('renderer-process-crashed', (event, wc, killed) => {
  console.log('app: renderer-process-crashed', wc.id, killed)
})

app.on('render-process-gone', (event, wc, details) => {
  console.log('app: render-process-gone', wc.id, details)
})

mainWindow.webContents.on('crashed', (event, killed) => {
  console.log('webContents: crashed', killed)
})

mainWindow.webContents.on('render-process-gone', (event, details) => {
  console.log('webContents: render-process-gone', details)
})
```

before:
```
app: renderer-process-crashed 1 true
webContents: crashed true
app: renderer-process-crashed 1 { reason: 'killed', exitCode: 2 }
app: render-process-gone 1 { reason: 'killed', exitCode: 2 }
(electron) 'renderer-process-crashed event' is deprecated and will be removed. Please use 'render-process-gone event' instead.
webContents: render-process-gone { reason: 'killed', exitCode: 2 }
```

after:
```
(electron) 'crashed event' is deprecated and will be removed. Please use 'render-process-gone event' instead.
webContents: crashed true
(electron) 'renderer-process-crashed event' is deprecated and will be removed. Please use 'render-process-gone event' instead.
app: renderer-process-crashed 1 true
app: render-process-gone 1 { reason: 'killed', exitCode: 2 }
webContents: render-process-gone { reason: 'killed', exitCode: 2 }
```

**`gpu-process-crashed` event**
```js
app.on('gpu-process-crashed', (event, killed) => {
  console.log('app: gpu-process-crashed', killed)
})

app.on('child-process-gone', (event, details) => {
  console.log('app: child-process-gone', details)
})
```

before:
```
(electron) 'gpu-process-crashed event' is deprecated and will be removed. Please use 'child-process-gone event' instead.
app: gpu-process-crashed { type: 'GPU', reason: 'killed', exitCode: 9, serviceName: 'GPU' }
app: child-process-gone { type: 'GPU', reason: 'killed', exitCode: 9, serviceName: 'GPU' }
app: gpu-process-crashed true
```

after:
```
(electron) 'gpu-process-crashed event' is deprecated and will be removed. Please use 'child-process-gone event' instead.
app: child-process-gone { type: 'GPU', reason: 'killed', exitCode: 9, serviceName: 'GPU' }
app: gpu-process-crashed true
```

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: Fixed deprecated `gpu-process-crashed` / `renderer-process-crashed` events being emitted twice and with incorrect arguments.