### PR TITLE
fix: toggling DevTools while minimized on Windows

### DIFF
--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -142,8 +142,11 @@ void InspectableWebContentsViewViews::CloseDevTools() {
 
   devtools_visible_ = false;
   if (devtools_window_) {
-    inspectable_web_contents()->SaveDevToolsBounds(
-        devtools_window_->GetWindowBoundsInScreen());
+    auto save_bounds = devtools_window_->IsMinimized()
+                           ? devtools_window_->GetRestoredBounds()
+                           : devtools_window_->GetWindowBoundsInScreen();
+    inspectable_web_contents()->SaveDevToolsBounds(save_bounds);
+
     devtools_window_.reset();
     devtools_window_web_view_ = nullptr;
     devtools_window_delegate_ = nullptr;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/39991.

Fixes an issue where if a user opened DevTools in detached mode, minimized the DevTools window, and then toggled DevTools off and on again, the window would no longer be visible to the user. This was happening because our existing logic saved the last known DevTools window bounds prior to closure, and then attempted to restore to those bounds if the DevTools window was re-opened. However, if the window was minimized prior to being toggled off, then the saved bounds would be wildly inaccurate as a result of our calling `GetWindowBoundsInScreen()`:

```console
 InspectableWebContents::SaveDevToolsBounds(): -16000,-16000 157x25
```

This fixes that by using the normal bounds if the window is not currently on screen.

Tested with https://gist.github.com/c985de2d95ffedb47bc966edaf3bfe8c

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where closing and opening a minimized DevTools window would not work as expected.