### PR TITLE
fix: fix vibrancy applying without transparency on MacOS

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -42,23 +42,11 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
   auto web_preferences = gin_helper::Dictionary::CreateEmpty(isolate);
   options.Get(options::kWebPreferences, &web_preferences);
 
-  bool transparent = false;
-  options.Get(options::kTransparent, &transparent);
-
-  std::string vibrancy_type;
-#if BUILDFLAG(IS_MAC)
-  options.Get(options::kVibrancyType, &vibrancy_type);
-#endif
-
   // Copy the backgroundColor to webContents.
   std::string color;
   if (options.Get(options::kBackgroundColor, &color)) {
     web_preferences.SetHidden(options::kBackgroundColor, color);
-#if BUILDFLAG(IS_WIN)
   } else if (window_->IsTranslucent()) {
-#else
-  } else if (!vibrancy_type.empty() || transparent) {
-#endif
     // If the BrowserWindow is transparent or a vibrancy type has been set,
     // also propagate transparency to the WebContents unless a separate
     // backgroundColor has been set.

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -42,11 +42,23 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
   auto web_preferences = gin_helper::Dictionary::CreateEmpty(isolate);
   options.Get(options::kWebPreferences, &web_preferences);
 
+  bool transparent = false;
+  options.Get(options::kTransparent, &transparent);
+
+  std::string vibrancy_type;
+#if BUILDFLAG(IS_MAC)
+  options.Get(options::kVibrancyType, &vibrancy_type);
+#endif
+
   // Copy the backgroundColor to webContents.
   std::string color;
   if (options.Get(options::kBackgroundColor, &color)) {
     web_preferences.SetHidden(options::kBackgroundColor, color);
+#if BUILDFLAG(IS_WIN)
   } else if (window_->IsTranslucent()) {
+#else
+  } else if (!vibrancy_type.empty() || transparent) {
+#endif
     // If the BrowserWindow is transparent or a vibrancy type has been set,
     // also propagate transparency to the WebContents unless a separate
     // backgroundColor has been set.

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -101,6 +101,11 @@ NativeWindow::NativeWindow(const gin_helper::Dictionary& options,
   options.Get(options::kTransparent, &transparent_);
   options.Get(options::kEnableLargerThanScreen, &enable_larger_than_screen_);
   options.Get(options::kTitleBarStyle, &title_bar_style_);
+#if BUILDFLAG(IS_WIN)
+  options.Get(options::kBackgroundMaterial, &background_material_);
+#elif BUILDFLAG(IS_MAC)
+  options.Get(options::kVibrancyType, &vibrancy_);
+#endif
 
   v8::Local<v8::Value> titlebar_overlay;
   if (options.Get(options::ktitleBarOverlay, &titlebar_overlay)) {


### PR DESCRIPTION
#### Description of Change

A follow-up to #39708 - this PR fixes applying transparency as a background color when vibrancy is also set. 

Closes https://github.com/electron/electron/issues/40039

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue with applying vibrancy on non-transparent windows on MacOS.
