### PR TITLE
chore: remove deprecated `crashed` and `renderer-process-crashed` events

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -391,21 +391,6 @@ which contains more information about why the child process disappeared. It
 isn't always because it crashed. The `killed` boolean can be replaced by
 checking `reason === 'killed'` when you switch to that event.
 
-### Event: 'renderer-process-crashed' _Deprecated_
-
-Returns:
-
-* `event` Event
-* `webContents` [WebContents](web-contents.md)
-* `killed` boolean
-
-Emitted when the renderer process of `webContents` crashes or is killed.
-
-**Deprecated:** This event is superceded by the `render-process-gone` event
-which contains more information about why the render process disappeared. It
-isn't always because it crashed.  The `killed` boolean can be replaced by
-checking `reason === 'killed'` when you switch to that event.
-
 ### Event: 'render-process-gone'
 
 Returns:

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -460,20 +460,6 @@ win.webContents.on('will-prevent-unload', (event) => {
 
 **Note:** This will be emitted for `BrowserViews` but will _not_ be respected - this is because we have chosen not to tie the `BrowserView` lifecycle to its owning BrowserWindow should one exist per the [specification](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event).
 
-#### Event: 'crashed' _Deprecated_
-
-Returns:
-
-* `event` Event
-* `killed` boolean
-
-Emitted when the renderer process crashes or is killed.
-
-**Deprecated:** This event is superceded by the `render-process-gone` event
-which contains more information about why the render process disappeared. It
-isn't always because it crashed.  The `killed` boolean can be replaced by
-checking `reason === 'killed'` when you switch to that event.
-
 #### Event: 'render-process-gone'
 
 Returns:

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -986,14 +986,6 @@ ipcRenderer.on('ping', () => {
 })
 ```
 
-### Event: 'crashed' _Deprecated_
-
-Fired when the renderer process crashes or is killed.
-
-**Deprecated:** This event is superceded by the `render-process-gone` event
-which contains more information about why the render process disappeared. It
-isn't always because it crashed.
-
 ### Event: 'render-process-gone'
 
 Returns:

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -12,6 +12,36 @@ This document uses the following convention to categorize breaking changes:
 * **Deprecated:** An API was marked as deprecated. The API will continue to function, but will emit a deprecation warning, and will be removed in a future release.
 * **Removed:** An API or feature was removed, and is no longer supported by Electron.
 
+## Planned Breaking API Changes (29.0)
+
+### Removed: `renderer-process-crashed` event on `app`
+
+The `renderer-process-crashed` event on `app` has been removed.
+Use the new `render-process-gone` event instead.
+
+```js
+// Removed
+app.on('renderer-process-crashed', (event, webContents, killed) => { /* ... */ })
+
+// Replace with
+app.on('render-process-gone', (event, webContents, details) => { /* ... */ })
+```
+
+### Removed: `crashed` event on `WebContents` and `<webview>`
+
+The `crashed` events on `WebContents` and `<webview>` have been removed.
+Use the new `render-process-gone` event instead.
+
+```js
+// Removed
+win.webContents.on('crashed', (event, killed) => { /* ... */ })
+webview.addEventListener('crashed', (event) => { /* ... */ })
+
+// Replace with
+win.webContents.on('render-process-gone', (event, details) => { /* ... */ })
+webview.addEventListener('render-process-gone', (event) => { /* ... */ })
+```
+
 ## Planned Breaking API Changes (28.0)
 
 ### Behavior Changed: `WebContents.backgroundThrottling` set to false affects all `WebContents` in the host `BrowserWindow`

--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -118,7 +118,3 @@ deprecate.event(app, 'gpu-process-crashed', 'child-process-gone', () => {
   // the old event is still emitted by App::OnGpuProcessCrashed()
   return undefined;
 });
-
-deprecate.event(app, 'renderer-process-crashed', 'render-process-gone', (event: Electron.Event, webContents: Electron.WebContents, details: Electron.RenderProcessGoneDetails) => {
-  return [event, webContents, details.reason === 'killed'];
-});

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -665,10 +665,6 @@ WebContents.prototype._init = function () {
     ipcMain.emit(channel, event, message);
   });
 
-  deprecate.event(this, 'crashed', 'render-process-gone', (event: Electron.Event, details: Electron.RenderProcessGoneDetails) => {
-    return [event, details.reason === 'killed'];
-  });
-
   this.on('render-process-gone', (event, details) => {
     app.emit('render-process-gone', event, this, details);
 

--- a/lib/browser/web-view-events.ts
+++ b/lib/browser/web-view-events.ts
@@ -21,7 +21,6 @@ export const webViewEvents: Record<string, readonly string[]> = {
   'did-navigate-in-page': ['url', 'isMainFrame', 'frameProcessId', 'frameRoutingId'],
   '-focus-change': ['focus'],
   close: [],
-  crashed: [],
   'render-process-gone': ['details'],
   'plugin-crashed': ['name', 'version'],
   destroyed: [],

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -9,7 +9,6 @@ import { promisify } from 'node:util';
 import { app, BrowserWindow, Menu, session, net as electronNet, WebContents } from 'electron/main';
 import { closeWindow, closeAllWindows } from './lib/window-helpers';
 import { ifdescribe, ifit, listen, waitUntil } from './lib/spec-helpers';
-import { expectDeprecationMessages } from './lib/deprecate-helpers';
 import { once } from 'node:events';
 import split = require('split')
 
@@ -525,27 +524,6 @@ describe('app module', () => {
       w = new BrowserWindow({ show: false });
       const [, webContents] = await emitted;
       expect(webContents.id).to.equal(w.webContents.id);
-    });
-
-    // FIXME: re-enable this test on win32.
-    ifit(process.platform !== 'win32')('should emit renderer-process-crashed event when renderer crashes', async () => {
-      w = new BrowserWindow({
-        show: false,
-        webPreferences: {
-          nodeIntegration: true,
-          contextIsolation: false
-        }
-      });
-      await w.loadURL('about:blank');
-
-      expectDeprecationMessages(async () => {
-        const emitted = once(app, 'renderer-process-crashed') as Promise<[any, WebContents, boolean]>;
-        w.webContents.executeJavaScript('process.crash()');
-
-        const [, webContents, killed] = await emitted;
-        expect(webContents).to.equal(w.webContents);
-        expect(killed).to.be.false();
-      }, '\'renderer-process-crashed event\' is deprecated and will be removed. Please use \'render-process-gone event\' instead.');
     });
 
     // FIXME: re-enable this test on win32.

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -6,7 +6,6 @@ import * as http from 'node:http';
 import { BrowserWindow, ipcMain, webContents, session, app, BrowserView, WebContents } from 'electron/main';
 import { closeAllWindows } from './lib/window-helpers';
 import { ifdescribe, defer, waitUntil, listen, ifit } from './lib/spec-helpers';
-import { expectDeprecationMessages } from './lib/deprecate-helpers';
 import { once } from 'node:events';
 import { setTimeout } from 'node:timers/promises';
 
@@ -2341,30 +2340,6 @@ describe('webContents module', () => {
       bw.webContents.executeJavaScript('child.document.title = "new title"');
       const [, title] = await once(child, 'page-title-updated') as [any, string];
       expect(title).to.equal('new title');
-    });
-  });
-
-  describe('crashed event', () => {
-    it('does not crash main process when destroying WebContents in it', (done) => {
-      const contents = (webContents as typeof ElectronInternal.WebContents).create({ nodeIntegration: true });
-      contents.once('crashed', () => {
-        contents.destroy();
-        done();
-      });
-      contents.loadURL('about:blank').then(() => contents.forcefullyCrashRenderer());
-    });
-
-    it('logs a warning', async () => {
-      const contents = (webContents as typeof ElectronInternal.WebContents).create({ nodeIntegration: true });
-      await contents.loadURL('about:blank');
-
-      expectDeprecationMessages(async () => {
-        const crashEvent = once(contents, 'crashed');
-        contents.forcefullyCrashRenderer();
-        const [, killed] = await crashEvent;
-
-        expect(killed).to.be.a('boolean');
-      }, '\'crashed event\' is deprecated and will be removed. Please use \'render-process-gone event\' instead.');
     });
   });
 

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -432,6 +432,9 @@ app.exit(0);
 // @ts-expect-error Removed API
 console.log(app.runningUnderRosettaTranslation);
 
+// @ts-expect-error Removed API
+app.on('renderer-process-crashed', () => {});
+
 // auto-updater
 // https://github.com/electron/electron/blob/main/docs/api/auto-updater.md
 
@@ -1295,6 +1298,9 @@ win4.webContents.on('scroll-touch-begin', () => {});
 win4.webContents.on('scroll-touch-edge', () => {});
 // @ts-expect-error Removed API
 win4.webContents.on('scroll-touch-end', () => {});
+
+// @ts-expect-error Removed API
+win4.webContents.on('crashed', () => {});
 
 // TouchBar
 // https://github.com/electron/electron/blob/main/docs/api/touch-bar.md


### PR DESCRIPTION
#### Description of Change
Follow-up to #40089

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: The deprecated `renderer-process-crashed` event on `app` and `crashed` event on `WebContents` and `<webview>` have been removed.