### PR TITLE
fix: remove EarlyMallocZoneRegistration call

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -916,10 +916,7 @@ if (is_mac) {
       assert(defined(invoker.helper_name_suffix))
 
       output_name = electron_helper_name + invoker.helper_name_suffix
-      deps = [
-        ":electron_framework+link",
-        "//base/allocator:early_zone_registration_apple",
-      ]
+      deps = [ ":electron_framework+link" ]
       if (!is_mas_build) {
         deps += [ "//sandbox/mac:seatbelt" ]
       }
@@ -1080,7 +1077,6 @@ if (is_mac) {
       ":electron_app_plist",
       ":electron_app_resources",
       ":electron_fuses",
-      "//base/allocator:early_zone_registration_apple",
       "//electron/buildflags",
     ]
     if (is_mas_build) {

--- a/shell/app/electron_main_mac.cc
+++ b/shell/app/electron_main_mac.cc
@@ -5,7 +5,6 @@
 #include <cstdlib>
 #include <memory>
 
-#include "base/allocator/early_zone_registration_apple.h"
 #include "electron/buildflags/buildflags.h"
 #include "electron/fuses.h"
 #include "shell/app/electron_library_main.h"
@@ -50,7 +49,6 @@ bool IsEnvSet(const char* name) {
 }  // namespace
 
 int main(int argc, char* argv[]) {
-  partition_alloc::EarlyMallocZoneRegistration();
   FixStdioStreams();
 
   if (electron::fuses::IsRunAsNodeEnabled() &&


### PR DESCRIPTION
#### Description of Change

This PR reverts https://github.com/electron/electron/pull/33832 for 2 reasons:
1. The `EarlyMallocZoneRegistration` call is currently a no-op since PartitionAlloc is disabled in Electron.
2. The prerequisite of calling `EarlyMallocZoneRegistration` is that the whole application is built as a library and the executable binary loads the app by `dlopen` and `dlsym` (https://bugs.chromium.org/p/chromium/issues/detail?id=1452229 has some background information on this). Electron is currently still linking the executable binaries to the `Electron Framework` which does not match the prerequisite and will crash when  PartitionAlloc is enabled.

This PR will unblock https://github.com/electron/electron/pull/33981.

#### Release Notes

Notes: none