### PR TITLE
ci: fixup diagnose_goma_log.py call

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -754,8 +754,8 @@ step-show-goma-stats: &step-show-goma-stats
     command: |
       set +e
       set +o pipefail
-      $GOMA_DIR/goma_ctl.py stat
-      $GOMA_DIR/diagnose_goma_log.py
+      python3 $GOMA_DIR/goma_ctl.py stat
+      python3 $GOMA_DIR/diagnose_goma_log.py
       true
     when: always
     background: true


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
The call to diagnose_goma_log.py after builds was failing with the error:
```
 File "/home/builduser/project/build-tools/third_party/goma/diagnose_goma_log.py", line 184
    yield from f
             ^
SyntaxError: invalid syntax
```
eg see https://app.circleci.com/pipelines/github/electron/electron/75261/workflows/0ea342e8-4faa-43bc-a706-9f59312f2c10/jobs/1616734/parallel-runs/0/steps/0-127.

This PR explictly runs that utility with python3 which fixes the issue.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
