### PR TITLE
docs: rename `renderer.d.ts` in documentation

### DIFF
--- a/docs/tutorial/context-isolation.md
+++ b/docs/tutorial/context-isolation.md
@@ -82,9 +82,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
 })
 ```
 
-You can create a `renderer.d.ts` declaration file and globally augment the `Window` interface:
+You can create a `interface.d.ts` declaration file and globally augment the `Window` interface:
 
-```typescript title='renderer.d.ts' @ts-noisolate
+```typescript title='interface.d.ts' @ts-noisolate
 export interface IElectronAPI {
   loadPreferences: () => Promise<void>,
 }


### PR DESCRIPTION
#### Description of Change
`renderer.d.ts` doesn't compile when the declaration name has the same root name as the TS file.

https://github.com/Microsoft/TypeScript/issues/7624#issuecomment-202501572

https://stackoverflow.com/questions/59728371/typescript-d-ts-file-not-recognized



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] relevant documentation, tutorials, templates and examples are changed or added


#### Release Notes

Notes: none
