### PR TITLE
test: make capturePage color matching timeouts consistent

### DIFF
--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6357,7 +6357,7 @@ describe('BrowserWindow module', () => {
       foregroundWindow.loadFile(path.join(__dirname, 'fixtures', 'pages', 'css-transparent.html'));
       await once(ipcMain, 'set-transparent');
 
-      await setTimeout();
+      await setTimeout(1000);
       const screenCapture = await captureScreen();
       const centerColor = getPixelColor(screenCapture, {
         x: display.size.width / 2,
@@ -6380,7 +6380,7 @@ describe('BrowserWindow module', () => {
         await once(window, 'show');
         await window.webContents.loadURL('data:text/html,<head><meta name="color-scheme" content="dark"></head>');
 
-        await setTimeout(500);
+        await setTimeout(1000);
         const screenCapture = await captureScreen();
         const centerColor = getPixelColor(screenCapture, {
           x: display.size.width / 2,
@@ -6410,6 +6410,7 @@ describe('BrowserWindow module', () => {
       w.loadURL('about:blank');
       await once(w, 'ready-to-show');
 
+      await setTimeout(1000);
       const screenCapture = await captureScreen();
       const centerColor = getPixelColor(screenCapture, {
         x: display.size.width / 2,


### PR DESCRIPTION
#### Description of Change

It used to be the case that `BrowserWindow "transparent" option should not display a visible background` flaked much more frequently before we added a 1000ms timeout. We have timeouts in similar test that still flake ([see here](https://app.circleci.com/pipelines/github/electron/electron/75310/workflows/83c548f4-6514-4afc-af24-b792cfab0017/jobs/1617798/tests)) - I think we should make these consistent as we've seen that 1000ms is more reliably enough time to prevent snapshot races.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none