### PR TITLE
chore: formally deprecate `gpu-process-crashed` event

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -103,6 +103,19 @@ win.webContents.on('render-process-gone', (event, details) => { /* ... */ })
 webview.addEventListener('render-process-gone', (event) => { /* ... */ })
 ```
 
+### Deprecated: `gpu-process-crashed` event on `app`
+
+The `gpu-process-crashed` event on `app` has been deprecated.
+Use the new `child-process-gone` event instead.
+
+```js
+// Deprecated
+app.on('gpu-process-crashed', (event, killed) => { /* ... */ })
+
+// Replace with
+app.on('child-process-gone', (event, details) => { /* ... */ })
+```
+
 ## Planned Breaking API Changes (27.0)
 
 ### Removed: macOS 10.13 / 10.14 support


### PR DESCRIPTION
#### Description of Change
Follow-up to #40089. Deprecated by #24367.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: The `gpu-process-crashed` event on `app` has been deprecated.