### PR TITLE
fix: incorrect wco bounds in macOS fullscreen

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -537,7 +537,7 @@ void NativeWindow::PreviewFile(const std::string& path,
 
 void NativeWindow::CloseFilePreview() {}
 
-gfx::Rect NativeWindow::GetWindowControlsOverlayRect() {
+absl::optional<gfx::Rect> NativeWindow::GetWindowControlsOverlayRect() {
   return overlay_rect_;
 }
 
@@ -665,6 +665,7 @@ void NativeWindow::NotifyWindowMoved() {
 }
 
 void NativeWindow::NotifyWindowEnterFullScreen() {
+  NotifyLayoutWindowControlsOverlay();
   for (NativeWindowObserver& observer : observers_)
     observer.OnWindowEnterFullScreen();
 }
@@ -690,6 +691,7 @@ void NativeWindow::NotifyWindowSheetEnd() {
 }
 
 void NativeWindow::NotifyWindowLeaveFullScreen() {
+  NotifyLayoutWindowControlsOverlay();
   for (NativeWindowObserver& observer : observers_)
     observer.OnWindowLeaveFullScreen();
 }
@@ -733,10 +735,10 @@ void NativeWindow::NotifyWindowSystemContextMenu(int x,
 }
 
 void NativeWindow::NotifyLayoutWindowControlsOverlay() {
-  gfx::Rect bounding_rect = GetWindowControlsOverlayRect();
-  if (!bounding_rect.IsEmpty()) {
+  auto bounding_rect = GetWindowControlsOverlayRect();
+  if (bounding_rect.has_value()) {
     for (NativeWindowObserver& observer : observers_)
-      observer.UpdateWindowControlsOverlay(bounding_rect);
+      observer.UpdateWindowControlsOverlay(bounding_rect.value());
   }
 }
 

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -286,7 +286,7 @@ class NativeWindow : public base::SupportsUserData,
     return weak_factory_.GetWeakPtr();
   }
 
-  virtual gfx::Rect GetWindowControlsOverlayRect();
+  virtual absl::optional<gfx::Rect> GetWindowControlsOverlayRect();
   virtual void SetWindowControlsOverlayRect(const gfx::Rect& overlay_rect);
 
   // Methods called by the WebContents.

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -153,7 +153,7 @@ class NativeWindowMac : public NativeWindow,
   void CloseFilePreview() override;
   gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) const override;
   gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) const override;
-  gfx::Rect GetWindowControlsOverlayRect() override;
+  absl::optional<gfx::Rect> GetWindowControlsOverlayRect() override;
   void NotifyWindowEnterFullScreen() override;
   void NotifyWindowLeaveFullScreen() override;
   void SetActive(bool is_key) override;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/39885.

Fixes an issue where webContents elements in the traffic light area couldn't be interacted with if a BrowserWindow with `titleBarOverlay` enabled was fullscreen. This was happening
1) Because we didn't notify WebContents when a given `BrowserWindow` entered or exited fullscreen that it should update WCO
2) We didn't account for a scenario where bounds could be `{ 0, 0 }` intentionally while the overlay was active.

This addresses that by making the return value of `GetWindowControlsOverlayRect` optional to distinguish intent. See [here](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/views/frame/browser_view.cc;l=2247-2256;drc=f5bdc89c7395ed24f1b8d196a3bdd6232d5bf771;bpv=1;bpt=1) for similar handling upstream.

Tested with https://gist.github.com/sergeichestakov/c84835f4d80182744b99e837268edc7c 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue with webContents interaction with fullscreen and WCO on macOS.
