### PR TITLE
docs: fix some string union typings

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1134,11 +1134,11 @@ indicates success while any other value indicates failure according to Chromium 
     resolver will attempt to use the system's DNS settings to do DNS lookups
     itself. Enabled by default on macOS, disabled by default on Windows and
     Linux.
-  * `secureDnsMode` string (optional) - Can be "off", "automatic" or "secure".
-    Configures the DNS-over-HTTP mode. When "off", no DoH lookups will be
-    performed. When "automatic", DoH lookups will be performed first if DoH is
+  * `secureDnsMode` string (optional) - Can be 'off', 'automatic' or 'secure'.
+    Configures the DNS-over-HTTP mode. When 'off', no DoH lookups will be
+    performed. When 'automatic', DoH lookups will be performed first if DoH is
     available, and insecure DNS lookups will be performed as a fallback. When
-    "secure", only DoH lookups will be performed. Defaults to "automatic".
+    'secure', only DoH lookups will be performed. Defaults to 'automatic'.
   * `secureDnsServers` string[]&#32;(optional) - A list of DNS-over-HTTP
     server templates. See [RFC8484 § 3][] for details on the template format.
     Most servers support the POST method; the template for such servers is

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1211,7 +1211,7 @@ Returns `string` - The user agent for this web page.
 
 * `css` string
 * `options` Object (optional)
-  * `cssOrigin` string (optional) - Can be either 'user' or 'author'. Sets the [cascade origin](https://www.w3.org/TR/css3-cascade/#cascade-origin) of the inserted stylesheet. Default is 'author'.
+  * `cssOrigin` string (optional) - Can be 'user' or 'author'. Sets the [cascade origin](https://www.w3.org/TR/css3-cascade/#cascade-origin) of the inserted stylesheet. Default is 'author'.
 
 Returns `Promise<string>` - A promise that resolves with a key for the inserted CSS that can later be used to remove the CSS via `contents.removeInsertedCSS(key)`.
 

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -113,7 +113,7 @@ webFrame.setSpellCheckProvider('en-US', {
 
 * `css` string
 * `options` Object (optional)
-  * `cssOrigin` string (optional) - Can be either 'user' or 'author'. Sets the [cascade origin](https://www.w3.org/TR/css3-cascade/#cascade-origin) of the inserted stylesheet. Default is 'author'.
+  * `cssOrigin` string (optional) - Can be 'user' or 'author'. Sets the [cascade origin](https://www.w3.org/TR/css3-cascade/#cascade-origin) of the inserted stylesheet. Default is 'author'.
 
 Returns `string` - A key for the inserted CSS that can later be used to remove
 the CSS via `webFrame.removeInsertedCSS(key)`.

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -429,6 +429,11 @@ win2.once('ready-to-show', () => {
 app.relaunch({ args: process.argv.slice(1).concat(['--relaunch']) });
 app.exit(0);
 
+app.configureHostResolver({ secureDnsMode: 'off' });
+
+// @ts-expect-error Invalid type value
+app.configureHostResolver({ secureDnsMode: 'foo' });
+
 // @ts-expect-error Removed API
 console.log(app.runningUnderRosettaTranslation);
 
@@ -1283,6 +1288,11 @@ win4.webContents.on('paint', (event, dirty, _image) => {
 win4.webContents.on('devtools-open-url', (event, url) => {
   console.log(url);
 });
+
+win4.webContents.insertCSS('body {}', { cssOrigin: 'user' });
+
+// @ts-expect-error Invalid type value
+win4.webContents.insertCSS('body {}', { cssOrigin: 'foo' });
 
 win4.loadURL('http://github.com');
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Another instance of #38339. `electron/docs-parser` doesn't like double quotes, or the word 'either'.  See the [Artifact Comparison check output](https://github.com/electron/electron/pull/40180/checks?check_run_id=17622455127) for difference.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
