### PR TITLE
fix: Windows Toast notification dismissal from Action Center

### DIFF
--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -85,7 +85,7 @@ Emitted when the notification is closed by manual intervention from the user.
 This event is not guaranteed to be emitted in all cases where the notification
 is closed.
 
-On Windows, the `close` event is emitted when the notification leaves the screen either by programmatic dismissal via `notification.close()`, the user closing the notification, or via system timeout. If the notification remains in the Action Center afterwards, a further call to `notification.close()` will remove the notification from the action center, but the `close` event will not be emitted again.
+On Windows, the `close` event can be emitted in one of three ways: programmatic dismissal with `notification.close()`, by the user closing the notification, or via system timeout. If a notification is in the Action Center after the initial `close` event is emitted, a call to `notification.close()` will remove the notification from the action center but the `close` event will not be emitted again.
 
 #### Event: 'reply' _macOS_
 

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -85,6 +85,8 @@ Emitted when the notification is closed by manual intervention from the user.
 This event is not guaranteed to be emitted in all cases where the notification
 is closed.
 
+On Windows, the `close` event is emitted when the notification leaves the screen either by programmatic dismissal via `notification.close()`, the user closing the notification, or via system timeout. If the notification remains in the Action Center afterwards, a further call to `notification.close()` will remove the notification from the action center, but the `close` event will not be emitted again.
+
 #### Event: 'reply' _macOS_
 
 Returns:
@@ -126,6 +128,8 @@ shown notification and create a new one with identical properties.
 #### `notification.close()`
 
 Dismisses the notification.
+
+On Windows, calling `notification.close()` while the notification is visible on screen will dismiss the notification and remove it from the Action Center. If `notification.close()` is called after the notification is no longer visible on screen, calling `notification.close()` will try remove it from the Action Center.
 
 ### Instance Properties
 

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -216,7 +216,11 @@ void Notification::NotificationClosed() {
 
 void Notification::Close() {
   if (notification_) {
-    notification_->Dismiss();
+    if (notification_->is_dismissed()) {
+      notification_->Remove();
+    } else {
+      notification_->Dismiss();
+    }
     notification_->set_delegate(nullptr);
     notification_.reset();
   }

--- a/shell/browser/notifications/notification.cc
+++ b/shell/browser/notifications/notification.cc
@@ -27,10 +27,14 @@ void Notification::NotificationClicked() {
   Destroy();
 }
 
-void Notification::NotificationDismissed() {
+void Notification::NotificationDismissed(bool should_destroy) {
   if (delegate())
     delegate()->NotificationClosed();
-  Destroy();
+
+  set_is_dismissed(true);
+
+  if (should_destroy)
+    Destroy();
 }
 
 void Notification::NotificationFailed(const std::string& error) {
@@ -38,6 +42,8 @@ void Notification::NotificationFailed(const std::string& error) {
     delegate()->NotificationFailed(error);
   Destroy();
 }
+
+void Notification::Remove() {}
 
 void Notification::Destroy() {
   presenter()->RemoveNotification(this);

--- a/shell/browser/notifications/notification.h
+++ b/shell/browser/notifications/notification.h
@@ -53,10 +53,11 @@ class Notification {
   // Closes the notification, this instance will be destroyed after the
   // notification gets closed.
   virtual void Dismiss() = 0;
+  virtual void Remove();
 
   // Should be called by derived classes.
   void NotificationClicked();
-  void NotificationDismissed();
+  void NotificationDismissed(bool should_destroy = true);
   void NotificationFailed(const std::string& error = "");
 
   // delete this.
@@ -68,10 +69,12 @@ class Notification {
 
   void set_delegate(NotificationDelegate* delegate) { delegate_ = delegate; }
   void set_notification_id(const std::string& id) { notification_id_ = id; }
+  void set_is_dismissed(bool dismissed) { is_dismissed_ = dismissed; }
 
   NotificationDelegate* delegate() const { return delegate_; }
   NotificationPresenter* presenter() const { return presenter_; }
   const std::string& notification_id() const { return notification_id_; }
+  bool is_dismissed() const { return is_dismissed_; }
 
   // disable copy
   Notification(const Notification&) = delete;
@@ -85,6 +88,7 @@ class Notification {
   raw_ptr<NotificationDelegate> delegate_;
   raw_ptr<NotificationPresenter> presenter_;
   std::string notification_id_;
+  bool is_dismissed_ = false;
 
   base::WeakPtrFactory<Notification> weak_factory_{this};
 };

--- a/shell/browser/notifications/notification.h
+++ b/shell/browser/notifications/notification.h
@@ -50,9 +50,14 @@ class Notification {
 
   // Shows the notification.
   virtual void Show(const NotificationOptions& options) = 0;
-  // Closes the notification, this instance will be destroyed after the
-  // notification gets closed.
+
+  // Dismisses the notification. On some platforms this will result in full
+  // removal and destruction of the notification, but if the initial dismissal
+  // does not fully get rid of the notification it will be destroyed in Remove.
   virtual void Dismiss() = 0;
+
+  // Removes the notification if it was not fully removed during dismissal,
+  // as can happen on some platforms including Windows.
   virtual void Remove();
 
   // Should be called by derived classes.

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -34,6 +34,8 @@ using ABI::Windows::Data::Xml::Dom::IXmlNodeList;
 using ABI::Windows::Data::Xml::Dom::IXmlText;
 using Microsoft::WRL::Wrappers::HStringReference;
 
+namespace winui = ABI::Windows::UI;
+
 #define RETURN_IF_FAILED(hr) \
   do {                       \
     HRESULT _hrTemp = hr;    \
@@ -47,8 +49,7 @@ using Microsoft::WRL::Wrappers::HStringReference;
     std::string _msgTemp = msg;                                          \
     if (FAILED(_hrTemp)) {                                               \
       std::string _err = _msgTemp + ",ERROR " + std::to_string(_hrTemp); \
-      if (IsDebuggingNotifications())                                    \
-        LOG(INFO) << _err;                                               \
+      DebugLog(_err);                                                    \
       Notification::NotificationFailed(_err);                            \
       return _hrTemp;                                                    \
     }                                                                    \
@@ -58,17 +59,23 @@ namespace electron {
 
 namespace {
 
-bool IsDebuggingNotifications() {
-  return base::Environment::Create()->HasVar("ELECTRON_DEBUG_NOTIFICATIONS");
+// This string needs to be max 16 characters to work on Windows 10 prior to
+// applying Creators Update (build 15063).
+constexpr wchar_t kGroup[] = L"Notifications";
+
+void DebugLog(const std::string& log_msg) {
+  if (base::Environment::Create()->HasVar("ELECTRON_DEBUG_NOTIFICATIONS"))
+    LOG(INFO) << log_msg;
 }
+
 }  // namespace
 
 // static
-ComPtr<ABI::Windows::UI::Notifications::IToastNotificationManagerStatics>
+ComPtr<winui::Notifications::IToastNotificationManagerStatics>
     WindowsToastNotification::toast_manager_;
 
 // static
-ComPtr<ABI::Windows::UI::Notifications::IToastNotifier>
+ComPtr<winui::Notifications::IToastNotifier>
     WindowsToastNotification::toast_notifier_;
 
 // static
@@ -112,17 +119,37 @@ WindowsToastNotification::~WindowsToastNotification() {
 
 void WindowsToastNotification::Show(const NotificationOptions& options) {
   if (SUCCEEDED(ShowInternal(options))) {
-    if (IsDebuggingNotifications())
-      LOG(INFO) << "Notification created";
+    DebugLog("Notification created");
 
     if (delegate())
       delegate()->NotificationDisplayed();
   }
 }
 
+void WindowsToastNotification::Remove() {
+  DebugLog("Removing notification from action center");
+
+  ComPtr<winui::Notifications::IToastNotificationManagerStatics2>
+      toast_manager2;
+  if (FAILED(toast_manager_.As(&toast_manager2)))
+    return;
+
+  ComPtr<winui::Notifications::IToastNotificationHistory> notification_history;
+  if (FAILED(toast_manager2->get_History(&notification_history)))
+    return;
+
+  ScopedHString app_id;
+  if (!GetAppUserModelID(&app_id))
+    return;
+
+  ScopedHString group(kGroup);
+  ScopedHString tag(base::as_wcstr(base::UTF8ToUTF16(notification_id())));
+  notification_history->RemoveGroupedTagWithId(tag, group, app_id);
+}
+
 void WindowsToastNotification::Dismiss() {
-  if (IsDebuggingNotifications())
-    LOG(INFO) << "Hiding notification";
+  DebugLog("Hiding notification");
+
   toast_notifier_->Hide(toast_notification_.Get());
 }
 
@@ -151,8 +178,7 @@ HRESULT WindowsToastNotification::ShowInternal(
     return E_FAIL;
   }
 
-  ComPtr<ABI::Windows::UI::Notifications::IToastNotificationFactory>
-      toast_factory;
+  ComPtr<winui::Notifications::IToastNotificationFactory> toast_factory;
   REPORT_AND_RETURN_IF_FAILED(
       Windows::Foundation::GetActivationFactory(toast_str, &toast_factory),
       "WinAPI: GetActivationFactory failed");
@@ -160,6 +186,19 @@ HRESULT WindowsToastNotification::ShowInternal(
   REPORT_AND_RETURN_IF_FAILED(toast_factory->CreateToastNotification(
                                   toast_xml.Get(), &toast_notification_),
                               "WinAPI: CreateToastNotification failed");
+
+  ComPtr<winui::Notifications::IToastNotification2> toast2;
+  REPORT_AND_RETURN_IF_FAILED(
+      toast_notification_->QueryInterface(IID_PPV_ARGS(&toast2)),
+      "WinAPI: Getting Notification interface failed");
+
+  ScopedHString group(kGroup);
+  REPORT_AND_RETURN_IF_FAILED(toast2->put_Group(group),
+                              "WinAPI: Setting group failed");
+
+  ScopedHString tag(base::as_wcstr(base::UTF8ToUTF16(notification_id())));
+  REPORT_AND_RETURN_IF_FAILED(toast2->put_Tag(tag),
+                              "WinAPI: Setting tag failed");
 
   REPORT_AND_RETURN_IF_FAILED(SetupCallbacks(toast_notification_.Get()),
                               "WinAPI: SetupCallbacks failed");
@@ -170,22 +209,20 @@ HRESULT WindowsToastNotification::ShowInternal(
 }
 
 HRESULT WindowsToastNotification::GetToastXml(
-    ABI::Windows::UI::Notifications::IToastNotificationManagerStatics*
-        toastManager,
+    winui::Notifications::IToastNotificationManagerStatics* toastManager,
     const std::u16string& title,
     const std::u16string& msg,
     const std::wstring& icon_path,
     const std::u16string& timeout_type,
     bool silent,
     IXmlDocument** toast_xml) {
-  ABI::Windows::UI::Notifications::ToastTemplateType template_type;
+  winui::Notifications::ToastTemplateType template_type;
   if (title.empty() || msg.empty()) {
     // Single line toast.
     template_type =
         icon_path.empty()
-            ? ABI::Windows::UI::Notifications::ToastTemplateType_ToastText01
-            : ABI::Windows::UI::Notifications::
-                  ToastTemplateType_ToastImageAndText01;
+            ? winui::Notifications::ToastTemplateType_ToastText01
+            : winui::Notifications::ToastTemplateType_ToastImageAndText01;
     REPORT_AND_RETURN_IF_FAILED(
         toast_manager_->GetTemplateContent(template_type, toast_xml),
         "XML: Fetching XML ToastImageAndText01 template failed");
@@ -199,9 +236,8 @@ HRESULT WindowsToastNotification::GetToastXml(
     // Title and body toast.
     template_type =
         icon_path.empty()
-            ? ABI::Windows::UI::Notifications::ToastTemplateType_ToastText02
-            : ABI::Windows::UI::Notifications::
-                  ToastTemplateType_ToastImageAndText02;
+            ? winui::Notifications::ToastTemplateType_ToastText02
+            : winui::Notifications::ToastTemplateType_ToastImageAndText02;
     REPORT_AND_RETURN_IF_FAILED(
         toastManager->GetTemplateContent(template_type, toast_xml),
         "XML: Fetching XML ToastImageAndText02 template failed");
@@ -567,7 +603,7 @@ HRESULT WindowsToastNotification::XmlDocumentFromString(
 }
 
 HRESULT WindowsToastNotification::SetupCallbacks(
-    ABI::Windows::UI::Notifications::IToastNotification* toast) {
+    winui::Notifications::IToastNotification* toast) {
   event_handler_ = Make<ToastEventHandler>(this);
   RETURN_IF_FAILED(
       toast->add_Activated(event_handler_.Get(), &activated_token_));
@@ -578,7 +614,7 @@ HRESULT WindowsToastNotification::SetupCallbacks(
 }
 
 bool WindowsToastNotification::RemoveCallbacks(
-    ABI::Windows::UI::Notifications::IToastNotification* toast) {
+    winui::Notifications::IToastNotification* toast) {
   if (FAILED(toast->remove_Activated(activated_token_)))
     return false;
 
@@ -597,32 +633,29 @@ ToastEventHandler::ToastEventHandler(Notification* notification)
 ToastEventHandler::~ToastEventHandler() = default;
 
 IFACEMETHODIMP ToastEventHandler::Invoke(
-    ABI::Windows::UI::Notifications::IToastNotification* sender,
+    winui::Notifications::IToastNotification* sender,
     IInspectable* args) {
   content::GetUIThreadTaskRunner({})->PostTask(
       FROM_HERE,
       base::BindOnce(&Notification::NotificationClicked, notification_));
-  if (IsDebuggingNotifications())
-    LOG(INFO) << "Notification clicked";
+  DebugLog("Notification clicked");
 
   return S_OK;
 }
 
 IFACEMETHODIMP ToastEventHandler::Invoke(
-    ABI::Windows::UI::Notifications::IToastNotification* sender,
-    ABI::Windows::UI::Notifications::IToastDismissedEventArgs* e) {
+    winui::Notifications::IToastNotification* sender,
+    winui::Notifications::IToastDismissedEventArgs* e) {
   content::GetUIThreadTaskRunner({})->PostTask(
-      FROM_HERE,
-      base::BindOnce(&Notification::NotificationDismissed, notification_));
-  if (IsDebuggingNotifications())
-    LOG(INFO) << "Notification dismissed";
-
+      FROM_HERE, base::BindOnce(&Notification::NotificationDismissed,
+                                notification_, false));
+  DebugLog("Notification dismissed");
   return S_OK;
 }
 
 IFACEMETHODIMP ToastEventHandler::Invoke(
-    ABI::Windows::UI::Notifications::IToastNotification* sender,
-    ABI::Windows::UI::Notifications::IToastFailedEventArgs* e) {
+    winui::Notifications::IToastNotification* sender,
+    winui::Notifications::IToastFailedEventArgs* e) {
   HRESULT error;
   e->get_ErrorCode(&error);
   std::string errorMessage =
@@ -630,8 +663,7 @@ IFACEMETHODIMP ToastEventHandler::Invoke(
   content::GetUIThreadTaskRunner({})->PostTask(
       FROM_HERE, base::BindOnce(&Notification::NotificationFailed,
                                 notification_, errorMessage));
-  if (IsDebuggingNotifications())
-    LOG(INFO) << errorMessage;
+  DebugLog(errorMessage);
 
   return S_OK;
 }

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -8,6 +8,8 @@
 
 #include "shell/browser/notifications/win/windows_toast_notification.h"
 
+#include <string_view>
+
 #include <shlobj.h>
 #include <wrl\wrappers\corewrappers.h>
 
@@ -63,7 +65,7 @@ namespace {
 // applying Creators Update (build 15063).
 constexpr wchar_t kGroup[] = L"Notifications";
 
-void DebugLog(const std::string& log_msg) {
+void DebugLog(std::string_view log_msg) {
   if (base::Environment::Create()->HasVar("ELECTRON_DEBUG_NOTIFICATIONS"))
     LOG(INFO) << log_msg;
 }

--- a/shell/browser/notifications/win/windows_toast_notification.h
+++ b/shell/browser/notifications/win/windows_toast_notification.h
@@ -52,6 +52,7 @@ class WindowsToastNotification : public Notification {
   // Notification:
   void Show(const NotificationOptions& options) override;
   void Dismiss() override;
+  void Remove() override;
 
  private:
   friend class ToastEventHandler;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/40133

Inspiration [taken from upstream](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/notifications/notification_platform_bridge_win.cc;l=447?q=IToastNotificationHistory&sq=package:chromium)

This PR closes a longstanding issue whereby Windows Toast notifications could only be dismissed and prevented from living in the Action Center until removed by the user if `.close` is called on them while the Notification is visible to the user. On an API level, When `ToastNotifier.Hide` is called, the `ToastNotification` is removed from the screen if it is currently visible, and it is _not_ sent to the Action Center. A `ToastNotification` is considered dismissed per underlying callbacks if it leaves the screen, and so our existing logic destroyed and garbage collected the underlying notification as soon as the notification left the screen _regardless_ of whether it was dismissed programmatically, by the user, or by timeout.

If it was dismissed by the user or by timeout, it entered the Action Center, and `notification.close()` then appeared to have no effect because the notification in JS-land was still alive. In order to address this problem, and ensure that the notification's behavior aligned more closely with 1) our documentation and 2) other platforms, we need to make some changes to garbage collection behavior as well as which APIs are called depending on whether the `ToastNotification` has already entered the Action Center. If it is dismissed by timeout or sent to the Action Center by the user, we want to notify the user via event, but now, we do _not_ want to immediately destroy the underlying notification. We instead want to wait until the notification is destroyed programmatically or removed from the action center to destroy the underlying `ToastNotification`. We use the `ToastNotificationHistory` class to remove it from the Action Center.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where Windows Toast notifications weren't properly dismissed from the Action Center on `notification.close()` if they'd previously been dismissed.