### PR TITLE
refactor: use getter property for RFH

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1870,7 +1870,7 @@ bool WebContents::EmitNavigationEvent(
   dict.Set("url", url);
   dict.Set("isSameDocument", is_same_document);
   dict.Set("isMainFrame", is_main_frame);
-  dict.Set("frame", frame_host);
+  dict.SetGetter("frame", frame_host);
   dict.SetGetter("initiator", initiator_frame_host);
 
   EmitWithoutEvent(event_name, event, url, is_same_document, is_main_frame,


### PR DESCRIPTION
#### Description of Change

Refactors navigation events to use a getter property for accessing the RFH. This is consistent with other RFH properties which allow us to defer instantiating WebFrameMain instances.

I noticed we were creating WebFrameMain instances for every frame so I added some debugging code to confirm
```diff
 WebFrameMain::WebFrameMain(content::RenderFrameHost* rfh)
     : frame_tree_node_id_(rfh->GetFrameTreeNodeId()), render_frame_(rfh) {
   GetWebFrameMainMap().emplace(frame_tree_node_id_, this);
+  if (!rfh->IsInPrimaryMainFrame()) {
+    LOG(ERROR) << base::debug::StackTrace();
+  }
 }
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
