### PR TITLE
Link to VS Code instead of Atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ View these docs in other languages on our [Crowdin](https://crowdin.com/project/
 
 The Electron framework lets you write cross-platform desktop applications
 using JavaScript, HTML and CSS. It is based on [Node.js](https://nodejs.org/) and
-[Chromium](https://www.chromium.org) and is used by the [Atom
-editor](https://github.com/atom/atom) and many other [apps](https://electronjs.org/apps).
+[Chromium](https://www.chromium.org) and is used by [Visual Studio Code](https://github.com/microsoft/vscode) and many other [apps](https://electronjs.org/apps).
 
 Follow [@electronjs](https://twitter.com/electronjs) on Twitter for important
 announcements.


### PR DESCRIPTION
Since Atom was decommissioned and VS Code lives on, it seemed fitting to change up what was linked from the Electron README. I loved Atom. It was such a fun editor to build packages for. Moving forward, as people come to the README for Electron I'd love to have an active app linked.