### PR TITLE
chore: Show FIDO devices in the chooser if allowed

### DIFF
--- a/shell/browser/hid/electron_hid_delegate.cc
+++ b/shell/browser/hid/electron_hid_delegate.cc
@@ -133,6 +133,9 @@ std::unique_ptr<content::HidChooser> ElectronHidDelegate::RunChooser(
 bool ElectronHidDelegate::CanRequestDevicePermission(
     content::BrowserContext* browser_context,
     const url::Origin& origin) {
+  if (!browser_context)
+    return false;
+
   base::Value::Dict details;
   details.Set("securityOrigin", origin.GetURL().spec());
   auto* permission_manager = static_cast<ElectronPermissionManager*>(
@@ -147,21 +150,28 @@ bool ElectronHidDelegate::HasDevicePermission(
     content::BrowserContext* browser_context,
     const url::Origin& origin,
     const device::mojom::HidDeviceInfo& device) {
-  return GetChooserContext(browser_context)
-      ->HasDevicePermission(origin, device);
+  auto* chooser_context = GetChooserContext(browser_context);
+  if (!chooser_context)
+    return false;
+  return chooser_context->HasDevicePermission(origin, device);
 }
 
 void ElectronHidDelegate::RevokeDevicePermission(
     content::BrowserContext* browser_context,
     const url::Origin& origin,
     const device::mojom::HidDeviceInfo& device) {
-  return GetChooserContext(browser_context)
-      ->RevokeDevicePermission(origin, device);
+  auto* chooser_context = GetChooserContext(browser_context);
+  if (!chooser_context)
+    return;
+  chooser_context->RevokeDevicePermission(origin, device);
 }
 
 device::mojom::HidManager* ElectronHidDelegate::GetHidManager(
     content::BrowserContext* browser_context) {
-  return GetChooserContext(browser_context)->GetHidManager();
+  auto* chooser_context = GetChooserContext(browser_context);
+  if (!chooser_context)
+    return nullptr;
+  return chooser_context->GetHidManager();
 }
 
 void ElectronHidDelegate::AddObserver(content::BrowserContext* browser_context,
@@ -180,6 +190,8 @@ const device::mojom::HidDeviceInfo* ElectronHidDelegate::GetDeviceInfo(
     content::BrowserContext* browser_context,
     const std::string& guid) {
   auto* chooser_context = GetChooserContext(browser_context);
+  if (!chooser_context)
+    return nullptr;
   return chooser_context->GetDeviceInfo(guid);
 }
 
@@ -187,6 +199,8 @@ bool ElectronHidDelegate::IsFidoAllowedForOrigin(
     content::BrowserContext* browser_context,
     const url::Origin& origin) {
   auto* chooser_context = GetChooserContext(browser_context);
+  if (!chooser_context)
+    return false;
   return chooser_context->IsFidoAllowedForOrigin(origin);
 }
 

--- a/shell/browser/hid/electron_hid_delegate.cc
+++ b/shell/browser/hid/electron_hid_delegate.cc
@@ -186,8 +186,8 @@ const device::mojom::HidDeviceInfo* ElectronHidDelegate::GetDeviceInfo(
 bool ElectronHidDelegate::IsFidoAllowedForOrigin(
     content::BrowserContext* browser_context,
     const url::Origin& origin) {
-  return base::CommandLine::ForCurrentProcess()->HasSwitch(
-      switches::kDisableHidBlocklist);
+  auto* chooser_context = GetChooserContext(browser_context);
+  return chooser_context->IsFidoAllowedForOrigin(origin);
 }
 
 bool ElectronHidDelegate::IsServiceWorkerAllowedForOrigin(

--- a/shell/browser/hid/hid_chooser_context.cc
+++ b/shell/browser/hid/hid_chooser_context.cc
@@ -29,8 +29,13 @@
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "third_party/blink/public/common/permissions/permission_utils.h"
-
 #include "ui/base/l10n/l10n_util.h"
+
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+#include "base/containers/fixed_flat_set.h"
+#include "base/strings/string_piece.h"
+#include "extensions/common/constants.h"
+#endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 
 namespace electron {
 
@@ -179,6 +184,23 @@ bool HidChooserContext::HasDevicePermission(
       static_cast<blink::PermissionType>(
           WebContentsPermissionHelper::PermissionType::HID),
       origin, DeviceInfoToValue(device), browser_context_);
+}
+
+bool HidChooserContext::IsFidoAllowedForOrigin(const url::Origin& origin) {
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+  static constexpr auto kPrivilegedExtensionIds =
+      base::MakeFixedFlatSet<base::StringPiece>({
+          "ckcendljdlmgnhghiaomidhiiclmapok",  // gnubbyd-v3 dev
+          "lfboplenmmjcmpbkeemecobbadnmpfhi",  // gnubbyd-v3 prod
+      });
+
+  if (origin.scheme() == extensions::kExtensionScheme &&
+      base::Contains(kPrivilegedExtensionIds, origin.host())) {
+    return true;
+  }
+#endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+
+  return false;
 }
 
 void HidChooserContext::AddDeviceObserver(DeviceObserver* observer) {

--- a/shell/browser/hid/hid_chooser_context.cc
+++ b/shell/browser/hid/hid_chooser_context.cc
@@ -200,7 +200,10 @@ bool HidChooserContext::IsFidoAllowedForOrigin(const url::Origin& origin) {
   }
 #endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 
-  return false;
+  // This differs from upstream - we want to allow users greater
+  // ability to communicate with FIDO devices in Electron.
+  return base::CommandLine::ForCurrentProcess()->HasSwitch(
+      switches::kDisableHidBlocklist);
 }
 
 void HidChooserContext::AddDeviceObserver(DeviceObserver* observer) {

--- a/shell/browser/hid/hid_chooser_context.h
+++ b/shell/browser/hid/hid_chooser_context.h
@@ -78,6 +78,9 @@ class HidChooserContext : public KeyedService,
   bool HasDevicePermission(const url::Origin& origin,
                            const device::mojom::HidDeviceInfo& device);
 
+  // Returns true if `origin` is allowed to access FIDO reports.
+  bool IsFidoAllowedForOrigin(const url::Origin& origin);
+
   // For ScopedObserver.
   void AddDeviceObserver(DeviceObserver* observer);
   void RemoveDeviceObserver(DeviceObserver* observer);

--- a/shell/browser/hid/hid_chooser_controller.h
+++ b/shell/browser/hid/hid_chooser_controller.h
@@ -13,6 +13,7 @@
 #include "base/scoped_observation.h"
 #include "content/public/browser/global_routing_id.h"
 #include "content/public/browser/hid_chooser.h"
+#include "content/public/browser/weak_document_ptr.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "services/device/public/mojom/hid.mojom-forward.h"
@@ -20,6 +21,7 @@
 #include "shell/browser/hid/electron_hid_delegate.h"
 #include "shell/browser/hid/hid_chooser_context.h"
 #include "shell/common/gin_converters/frame_converter.h"
+#include "third_party/blink/public/mojom/devtools/console_message.mojom.h"
 #include "third_party/blink/public/mojom/hid/hid.mojom.h"
 
 namespace content {
@@ -76,6 +78,8 @@ class HidChooserController
   bool DisplayDevice(const device::mojom::HidDeviceInfo& device) const;
   bool FilterMatchesAny(const device::mojom::HidDeviceInfo& device) const;
   bool IsExcluded(const device::mojom::HidDeviceInfo& device) const;
+  void AddMessageToConsole(blink::mojom::ConsoleMessageLevel level,
+                           const std::string& message) const;
 
   // Add |device_info| to |device_map_|. The device is added to the chooser item
   // representing the physical device. If the chooser item does not yet exist, a
@@ -98,8 +102,8 @@ class HidChooserController
   std::vector<blink::mojom::HidDeviceFilterPtr> filters_;
   std::vector<blink::mojom::HidDeviceFilterPtr> exclusion_filters_;
   content::HidChooser::Callback callback_;
+  content::WeakDocumentPtr initiator_document_;
   const url::Origin origin_;
-  const int frame_tree_node_id_;
 
   // The lifetime of the chooser context is tied to the browser context used to
   // create it, and may be destroyed while the chooser is still active.


### PR DESCRIPTION
#### Description of Change

Refs CL:3309164

> This CL allows devices containing a top-level collection with a usage
from the FIDO usage page to appear in the WebHID device chooser if
the requesting origin is allowed to access FIDO.

Refs CL:3595839

> This CL makes sure users can see why a HID device does not show up in the browser picker to help debugging. See https://stackoverflow.com/a/71922823/422957 for context

Refs CL:3809913

> There is a smaller window between BrowserContext and HidService
destruction timing in service worker condition, which creates an UAF
issue as the stored BrowserContext pointer can still be accessed by the
HidService. This is fixed by using weak pointer of
ServiceWorkerContextCore to access BrowserContext when it is valid.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
