### PR TITLE
build: update @electron/docs-parser and @electron/typescript-definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "devDependencies": {
     "@azure/storage-blob": "^12.9.0",
     "@electron/asar": "^3.2.1",
-    "@electron/docs-parser": "^1.1.1",
+    "@electron/docs-parser": "^1.2.0",
     "@electron/fiddle-core": "^1.0.4",
     "@electron/github-app-auth": "^2.0.0",
     "@electron/lint-roller": "^1.9.0",
-    "@electron/typescript-definitions": "^8.14.5",
+    "@electron/typescript-definitions": "^8.15.1",
     "@octokit/rest": "^19.0.7",
     "@primer/octicons": "^10.0.0",
     "@types/basic-auth": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -146,10 +146,10 @@
   optionalDependencies:
     "@types/glob" "^7.1.1"
 
-"@electron/docs-parser@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@electron/docs-parser/-/docs-parser-1.1.1.tgz#14bec2940f81f4debb95a2b0f186f7f00d682899"
-  integrity sha512-IB6XCDaNTHqm7h0Joa1LUtZhmBvItRWp0KUNuNtuXLEv/6q6ZYw9wn89QzlFYxgH8ZTleF9dWpJby0mIpsX0Ng==
+"@electron/docs-parser@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@electron/docs-parser/-/docs-parser-1.2.0.tgz#dc3032012dd270c667777e097e185d92e7ff86ef"
+  integrity sha512-Rz/lMLRDSvEshYNmSC30v/3rk7Mj6EL/76wraKvfM5XvYPHsmApo9CedvcJNNMm7+Rc29NOohoqA4B2/XtFm1Q==
   dependencies:
     "@types/markdown-it" "^12.0.0"
     chai "^4.2.0"
@@ -219,10 +219,10 @@
     vscode-languageserver-textdocument "^1.0.8"
     vscode-uri "^3.0.7"
 
-"@electron/typescript-definitions@^8.14.5":
-  version "8.14.7"
-  resolved "https://registry.yarnpkg.com/@electron/typescript-definitions/-/typescript-definitions-8.14.7.tgz#f8838eac200fa8106ce0a6b7044463b0fd86e9b6"
-  integrity sha512-y1kOB9Ckkd09+KpNDIID6LHO7WP69WoMiogGwNIRtBnEZIeK/aN5uy6plEF1OXYoJVkRKkM/ZSBhhwhk4H1rEA==
+"@electron/typescript-definitions@^8.15.1":
+  version "8.15.1"
+  resolved "https://registry.yarnpkg.com/@electron/typescript-definitions/-/typescript-definitions-8.15.1.tgz#9d4ff7361e8a4dee65d353e2884e7733c1c12dad"
+  integrity sha512-R8Kl8J+o+q3Pn1tM4fU4Qan63g1Oyd1meAlHwIPAJ8LfYC/N09SYJcNuwgvaxb/SHFIcr4BWZKHOVa4makuo6A==
   dependencies:
     "@types/node" "^11.13.7"
     chalk "^2.4.2"


### PR DESCRIPTION
#### Description of Change

Upgrades docs-parser and typescript-definitions to add new 'electron/utility' namespace added in:
- https://github.com/electron/docs-parser/pull/95
- https://github.com/electron/typescript-definitions/pull/246
- https://github.com/electron/typescript-definitions/pull/247

Also removes obsolete remote interface: https://github.com/electron/typescript-definitions/pull/249

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: no-notes
<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
