### PR TITLE
fix: failing build with `enable_electron_extensions=false`

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -333,6 +333,34 @@ static_library("chrome") {
         "//components/pdf/renderer",
       ]
     }
+  } else {
+    # These are required by the webRequest module.
+    sources += [
+      "//extensions/browser/api/declarative_net_request/request_action.cc",
+      "//extensions/browser/api/declarative_net_request/request_action.h",
+      "//extensions/browser/api/web_request/form_data_parser.cc",
+      "//extensions/browser/api/web_request/form_data_parser.h",
+      "//extensions/browser/api/web_request/upload_data_presenter.cc",
+      "//extensions/browser/api/web_request/upload_data_presenter.h",
+      "//extensions/browser/api/web_request/web_request_api_constants.cc",
+      "//extensions/browser/api/web_request/web_request_api_constants.h",
+      "//extensions/browser/api/web_request/web_request_info.cc",
+      "//extensions/browser/api/web_request/web_request_info.h",
+      "//extensions/browser/api/web_request/web_request_resource_type.cc",
+      "//extensions/browser/api/web_request/web_request_resource_type.h",
+      "//extensions/browser/extension_api_frame_id_map.cc",
+      "//extensions/browser/extension_api_frame_id_map.h",
+      "//extensions/browser/extension_navigation_ui_data.cc",
+      "//extensions/browser/extension_navigation_ui_data.h",
+      "//extensions/browser/extensions_browser_client.cc",
+      "//extensions/browser/extensions_browser_client.h",
+      "//extensions/browser/guest_view/web_view/web_view_renderer_state.cc",
+      "//extensions/browser/guest_view/web_view/web_view_renderer_state.h",
+    ]
+
+    public_deps += [
+      "//extensions/browser/api/declarative_net_request/flat:extension_ruleset",
+    ]
   }
 
   if (!is_mas_build) {

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -57,7 +57,7 @@
 #include "crypto/crypto_buildflags.h"
 #include "electron/buildflags/buildflags.h"
 #include "electron/shell/common/api/api.mojom.h"
-#include "extensions/browser/api/messaging/messaging_api_message_filter.h"
+#include "extensions/browser/extension_navigation_ui_data.h"
 #include "mojo/public/cpp/bindings/binder_map.h"
 #include "net/ssl/ssl_cert_request_info.h"
 #include "ppapi/buildflags/buildflags.h"
@@ -113,6 +113,7 @@
 #include "shell/common/options_switches.h"
 #include "shell/common/platform_util.h"
 #include "shell/common/thread_restrictions.h"
+#include "third_party/blink/public/common/associated_interfaces/associated_interface_registry.h"
 #include "third_party/blink/public/common/loader/url_loader_throttle.h"
 #include "third_party/blink/public/common/tokens/tokens.h"
 #include "third_party/blink/public/common/web_preferences/web_preferences.h"
@@ -145,6 +146,7 @@
 #include "content/public/browser/child_process_security_policy.h"
 #include "content/public/browser/file_url_loader.h"
 #include "content/public/browser/web_ui_url_loader_factory.h"
+#include "extensions/browser/api/messaging/messaging_api_message_filter.h"
 #include "extensions/browser/api/mime_handler_private/mime_handler_private.h"
 #include "extensions/browser/api/web_request/web_request_api.h"
 #include "extensions/browser/browser_context_keyed_api_factory.h"
@@ -152,7 +154,6 @@
 #include "extensions/browser/extension_host.h"
 #include "extensions/browser/extension_message_filter.h"
 #include "extensions/browser/extension_navigation_throttle.h"
-#include "extensions/browser/extension_navigation_ui_data.h"
 #include "extensions/browser/extension_prefs.h"
 #include "extensions/browser/extension_protocols.h"
 #include "extensions/browser/extension_registry.h"
@@ -170,7 +171,6 @@
 #include "shell/browser/extensions/electron_extension_message_filter.h"
 #include "shell/browser/extensions/electron_extension_system.h"
 #include "shell/browser/extensions/electron_extension_web_contents_observer.h"
-#include "third_party/blink/public/common/associated_interfaces/associated_interface_registry.h"
 #endif
 
 #if BUILDFLAG(ENABLE_PLUGINS)
@@ -1211,12 +1211,12 @@ void ElectronBrowserClient::
   protocol_registry->RegisterURLLoaderFactories(factories,
                                                 false /* allow_file_access */);
 
-#if BUILDFLAG(ENABLE_EXTENSIONS)
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   factories->emplace(
       extensions::kExtensionScheme,
       extensions::CreateExtensionServiceWorkerScriptURLLoaderFactory(
           browser_context));
-#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+#endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 }
 
 bool ElectronBrowserClient::ShouldTreatURLSchemeAsFirstPartyWhenTopLevel(
@@ -1404,9 +1404,10 @@ void ElectronBrowserClient::OverrideURLLoaderFactoryParams(
       factory_params->disable_web_security = true;
     }
   }
-
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   extensions::URLLoaderFactoryManager::OverrideURLLoaderFactoryParams(
       browser_context, origin, is_for_isolated_world, factory_params);
+#endif
 }
 
 void ElectronBrowserClient::
@@ -1464,7 +1465,7 @@ void ElectronBrowserClient::
           },
           &render_frame_host));
 #endif
-#if BUILDFLAG(ENABLE_EXTENSIONS)
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   associated_registry.AddInterface<extensions::mojom::LocalFrameHost>(
       base::BindRepeating(
           [](content::RenderFrameHost* render_frame_host,

--- a/shell/browser/hid/electron_hid_delegate.cc
+++ b/shell/browser/hid/electron_hid_delegate.cc
@@ -11,6 +11,7 @@
 #include "base/containers/contains.h"
 #include "chrome/common/chrome_features.h"
 #include "content/public/browser/web_contents.h"
+#include "electron/buildflags/buildflags.h"
 #include "services/device/public/cpp/hid/hid_switches.h"
 #include "shell/browser/electron_permission_manager.h"
 #include "shell/browser/hid/hid_chooser_context.h"
@@ -19,9 +20,9 @@
 #include "shell/browser/web_contents_permission_helper.h"
 #include "third_party/blink/public/common/permissions/permission_utils.h"
 
-#if BUILDFLAG(ENABLE_EXTENSIONS)
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 #include "extensions/common/constants.h"
-#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+#endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 
 namespace {
 
@@ -128,14 +129,14 @@ bool ElectronHidDelegate::IsFidoAllowedForOrigin(
 
 bool ElectronHidDelegate::IsServiceWorkerAllowedForOrigin(
     const url::Origin& origin) {
-#if BUILDFLAG(ENABLE_EXTENSIONS)
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   // WebHID is only available on extension service workers with feature flag
   // enabled for now.
   if (base::FeatureList::IsEnabled(
           features::kEnableWebHidOnExtensionServiceWorker) &&
       origin.scheme() == extensions::kExtensionScheme)
     return true;
-#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+#endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   return false;
 }
 

--- a/shell/browser/plugins/plugin_utils.cc
+++ b/shell/browser/plugins/plugin_utils.cc
@@ -9,11 +9,11 @@
 #include "base/containers/contains.h"
 #include "base/values.h"
 #include "content/public/common/webplugininfo.h"
-#include "extensions/buildflags/buildflags.h"
+#include "electron/buildflags/buildflags.h"
 #include "url/gurl.h"
 #include "url/origin.h"
 
-#if BUILDFLAG(ENABLE_EXTENSIONS)
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 #include "extensions/browser/extension_registry.h"
 #include "extensions/browser/extension_util.h"
 #include "extensions/common/constants.h"
@@ -36,7 +36,7 @@ base::flat_map<std::string, std::string>
 PluginUtils::GetMimeTypeToExtensionIdMap(
     content::BrowserContext* browser_context) {
   base::flat_map<std::string, std::string> mime_type_to_extension_id_map;
-#if BUILDFLAG(ENABLE_EXTENSIONS)
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   std::vector<std::string> allowed_extension_ids =
       MimeTypesHandler::GetMIMETypeAllowlist();
   // Go through the white-listed extensions and try to use them to intercept

--- a/shell/browser/usb/electron_usb_delegate.cc
+++ b/shell/browser/usb/electron_usb_delegate.cc
@@ -13,7 +13,7 @@
 #include "base/scoped_observation.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"
-#include "extensions/buildflags/buildflags.h"
+#include "electron/buildflags/buildflags.h"
 #include "services/device/public/mojom/usb_enumeration_options.mojom.h"
 #include "shell/browser/electron_permission_manager.h"
 #include "shell/browser/usb/usb_chooser_context.h"
@@ -21,7 +21,7 @@
 #include "shell/browser/usb/usb_chooser_controller.h"
 #include "shell/browser/web_contents_permission_helper.h"
 
-#if BUILDFLAG(ENABLE_EXTENSIONS)
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 #include "base/containers/fixed_flat_set.h"
 #include "chrome/common/chrome_features.h"
 #include "extensions/browser/extension_registry.h"
@@ -40,7 +40,7 @@ electron::UsbChooserContext* GetChooserContext(
       browser_context);
 }
 
-#if BUILDFLAG(ENABLE_EXTENSIONS)
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 // These extensions can claim the smart card USB class and automatically gain
 // permissions for devices that have an interface with this class.
 constexpr auto kSmartCardPrivilegedExtensionIds =
@@ -64,12 +64,12 @@ bool DeviceHasInterfaceWithClass(
   }
   return false;
 }
-#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+#endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 
 bool IsDevicePermissionAutoGranted(
     const url::Origin& origin,
     const device::mojom::UsbDeviceInfo& device_info) {
-#if BUILDFLAG(ENABLE_EXTENSIONS)
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   // Note: The `DeviceHasInterfaceWithClass()` call is made after checking the
   // origin, since that method call is expensive.
   if (origin.scheme() == extensions::kExtensionScheme &&
@@ -78,7 +78,7 @@ bool IsDevicePermissionAutoGranted(
                                   device::mojom::kUsbSmartCardClass)) {
     return true;
   }
-#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+#endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 
   return false;
 }
@@ -250,14 +250,14 @@ ElectronUsbDelegate::GetContextObserver(
 
 bool ElectronUsbDelegate::IsServiceWorkerAllowedForOrigin(
     const url::Origin& origin) {
-#if BUILDFLAG(ENABLE_EXTENSIONS)
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   // WebUSB is only available on extension service workers for now.
   if (base::FeatureList::IsEnabled(
           features::kEnableWebUsbOnExtensionServiceWorker) &&
       origin.scheme() == extensions::kExtensionScheme) {
     return true;
   }
-#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+#endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   return false;
 }
 

--- a/shell/renderer/printing/print_render_frame_helper_delegate.cc
+++ b/shell/renderer/printing/print_render_frame_helper_delegate.cc
@@ -7,15 +7,15 @@
 #include <utility>
 
 #include "content/public/renderer/render_frame.h"
-#include "extensions/buildflags/buildflags.h"
+#include "electron/buildflags/buildflags.h"
 #include "third_party/blink/public/web/web_element.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 
-#if BUILDFLAG(ENABLE_EXTENSIONS)
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 #include "chrome/common/pdf_util.h"
 #include "extensions/common/constants.h"
 #include "extensions/renderer/guest_view/mime_handler_view/post_message_support.h"
-#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+#endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 
 namespace electron {
 
@@ -26,14 +26,14 @@ PrintRenderFrameHelperDelegate::~PrintRenderFrameHelperDelegate() = default;
 // Return the PDF object element if |frame| is the out of process PDF extension.
 blink::WebElement PrintRenderFrameHelperDelegate::GetPdfElement(
     blink::WebLocalFrame* frame) {
-#if BUILDFLAG(ENABLE_EXTENSIONS)
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   if (frame->Parent() &&
       IsPdfInternalPluginAllowedOrigin(frame->Parent()->GetSecurityOrigin())) {
     auto plugin_element = frame->GetDocument().QuerySelector("embed");
     DCHECK(!plugin_element.IsNull());
     return plugin_element;
   }
-#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+#endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   return blink::WebElement();
 }
 
@@ -43,7 +43,7 @@ bool PrintRenderFrameHelperDelegate::IsPrintPreviewEnabled() {
 
 bool PrintRenderFrameHelperDelegate::OverridePrint(
     blink::WebLocalFrame* frame) {
-#if BUILDFLAG(ENABLE_EXTENSIONS)
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   auto* post_message_support =
       extensions::PostMessageSupport::FromWebLocalFrame(frame);
   if (post_message_support) {
@@ -56,7 +56,7 @@ bool PrintRenderFrameHelperDelegate::OverridePrint(
     post_message_support->PostMessageFromValue(base::Value(std::move(message)));
     return true;
   }
-#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+#endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   return false;
 }
 

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -235,14 +235,6 @@ void RendererClientBase::RenderThreadStarted() {
   extensions::ExtensionsRendererClient::Set(extensions_renderer_client_.get());
 
   thread->AddObserver(extensions_renderer_client_->GetDispatcher());
-#endif
-
-#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
-  spellcheck_ = std::make_unique<SpellCheck>(this);
-#endif
-
-  blink::WebCustomElement::AddEmbedderCustomElementName("webview");
-  blink::WebCustomElement::AddEmbedderCustomElementName("browserplugin");
 
   WTF::String extension_scheme(extensions::kExtensionScheme);
   // Extension resources are HTTP-like and safe to expose to the fetch API. The
@@ -255,6 +247,14 @@ void RendererClientBase::RenderThreadStarted() {
       extension_scheme);
   blink::SchemeRegistry::RegisterURLSchemeAsBypassingContentSecurityPolicy(
       extension_scheme);
+#endif
+
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
+  spellcheck_ = std::make_unique<SpellCheck>(this);
+#endif
+
+  blink::WebCustomElement::AddEmbedderCustomElementName("webview");
+  blink::WebCustomElement::AddEmbedderCustomElementName("browserplugin");
 
   std::vector<std::string> fetch_enabled_schemes =
       ParseSchemesCLISwitch(command_line, switches::kFetchSchemes);


### PR DESCRIPTION
Backport of #40032.

See that PR for details.

Notes: Fixes failing build when `enable_electron_extensions=false`.