### PR TITLE
fix: make sure classes in lib correctly implement Electron interfaces

### DIFF
--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -100,7 +100,7 @@ longer than the maximum length will be truncated.
 
 ### `crashReporter.getLastCrashReport()`
 
-Returns [`CrashReport`](structures/crash-report.md) - The date and ID of the
+Returns [`CrashReport | null`](structures/crash-report.md) - The date and ID of the
 last crash report. Only crash reports that have been uploaded will be returned;
 even if a crash report is present on disk it will not be returned until it is
 uploaded. In the case that there are no uploaded reports, `null` is returned.

--- a/lib/browser/api/auto-updater/auto-updater-win.ts
+++ b/lib/browser/api/auto-updater/auto-updater-win.ts
@@ -2,7 +2,7 @@ import { app } from 'electron/main';
 import { EventEmitter } from 'events';
 import * as squirrelUpdate from '@electron/internal/browser/api/auto-updater/squirrel-update-win';
 
-class AutoUpdater extends EventEmitter {
+class AutoUpdater extends EventEmitter implements Electron.AutoUpdater {
   updateAvailable: boolean = false;
   updateURL: string | null = null;
 
@@ -15,7 +15,7 @@ class AutoUpdater extends EventEmitter {
   }
 
   getFeedURL () {
-    return this.updateURL;
+    return this.updateURL ?? '';
   }
 
   setFeedURL (options: { url: string } | string) {

--- a/lib/browser/api/crash-reporter.ts
+++ b/lib/browser/api/crash-reporter.ts
@@ -3,7 +3,7 @@ import * as deprecate from '@electron/internal/common/deprecate';
 
 const binding = process._linkedBinding('electron_browser_crash_reporter');
 
-class CrashReporter {
+class CrashReporter implements Electron.CrashReporter {
   start (options: Electron.CrashReporterStartOptions) {
     const {
       productName = app.name,

--- a/lib/browser/api/message-channel.ts
+++ b/lib/browser/api/message-channel.ts
@@ -1,10 +1,12 @@
 import { MessagePortMain } from '@electron/internal/browser/message-port-main';
+import { EventEmitter } from 'events';
 const { createPair } = process._linkedBinding('electron_browser_message_port');
 
-export default class MessageChannelMain {
+export default class MessageChannelMain extends EventEmitter implements Electron.MessageChannelMain {
   port1: MessagePortMain;
   port2: MessagePortMain;
   constructor () {
+    super();
     const { port1, port2 } = createPair();
     this.port1 = new MessagePortMain(port1);
     this.port2 = new MessagePortMain(port2);

--- a/lib/browser/api/power-monitor.ts
+++ b/lib/browser/api/power-monitor.ts
@@ -8,7 +8,7 @@ const {
   isOnBatteryPower
 } = process._linkedBinding('electron_browser_power_monitor');
 
-class PowerMonitor extends EventEmitter {
+class PowerMonitor extends EventEmitter implements Electron.PowerMonitor {
   constructor () {
     super();
     // Don't start the event source until both a) the app is ready and b)

--- a/lib/browser/api/share-menu.ts
+++ b/lib/browser/api/share-menu.ts
@@ -1,9 +1,11 @@
 import { BrowserWindow, Menu, SharingItem, PopupOptions } from 'electron/main';
+import { EventEmitter } from 'events';
 
-class ShareMenu {
+class ShareMenu extends EventEmitter implements Electron.ShareMenu {
   private menu: Menu;
 
   constructor (sharingItem: SharingItem) {
+    super();
     this.menu = new (Menu as any)({ sharingItem });
   }
 

--- a/lib/browser/api/utility-process.ts
+++ b/lib/browser/api/utility-process.ts
@@ -4,7 +4,7 @@ import { Socket } from 'net';
 import { MessagePortMain } from '@electron/internal/browser/message-port-main';
 const { _fork } = process._linkedBinding('electron_browser_utility_process');
 
-class ForkUtilityProcess extends EventEmitter {
+class ForkUtilityProcess extends EventEmitter implements Electron.UtilityProcess {
   #handle: ElectronInternal.UtilityProcessWrapper | null;
   #stdout: Duplex | null = null;
   #stderr: Duplex | null = null;

--- a/lib/browser/ipc-main-impl.ts
+++ b/lib/browser/ipc-main-impl.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import { IpcMainInvokeEvent } from 'electron/main';
 
-export class IpcMainImpl extends EventEmitter {
+export class IpcMainImpl extends EventEmitter implements Electron.IpcMain {
   private _invokeHandlers: Map<string, (e: IpcMainInvokeEvent, ...args: any[]) => void> = new Map();
 
   constructor () {

--- a/lib/browser/message-port-main.ts
+++ b/lib/browser/message-port-main.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 
-export class MessagePortMain extends EventEmitter {
+export class MessagePortMain extends EventEmitter implements Electron.MessagePortMain {
   _internalPort: any;
   constructor (internalPort: any) {
     super();

--- a/lib/utility/parent-port.ts
+++ b/lib/utility/parent-port.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import { MessagePortMain } from '@electron/internal/browser/message-port-main';
 const { createParentPort } = process._linkedBinding('electron_utility_parent_port');
 
-export class ParentPort extends EventEmitter {
+export class ParentPort extends EventEmitter implements Electron.ParentPort {
   #port: ParentPort;
   constructor () {
     super();

--- a/spec/api-autoupdater-darwin-spec.ts
+++ b/spec/api-autoupdater-darwin-spec.ts
@@ -564,11 +564,11 @@ ifdescribe(process.platform === 'darwin' && !(process.env.CI && process.arch ===
       });
 
       it('should compare version numbers correctly', () => {
-        expect(autoUpdater.isVersionAllowedForUpdate('1.0.0', '2.0.0')).to.equal(true);
-        expect(autoUpdater.isVersionAllowedForUpdate('1.0.1', '1.0.10')).to.equal(true);
-        expect(autoUpdater.isVersionAllowedForUpdate('1.0.10', '1.0.1')).to.equal(false);
-        expect(autoUpdater.isVersionAllowedForUpdate('1.31.1', '1.32.0')).to.equal(true);
-        expect(autoUpdater.isVersionAllowedForUpdate('1.31.1', '0.32.0')).to.equal(false);
+        expect(autoUpdater.isVersionAllowedForUpdate!('1.0.0', '2.0.0')).to.equal(true);
+        expect(autoUpdater.isVersionAllowedForUpdate!('1.0.1', '1.0.10')).to.equal(true);
+        expect(autoUpdater.isVersionAllowedForUpdate!('1.0.10', '1.0.1')).to.equal(false);
+        expect(autoUpdater.isVersionAllowedForUpdate!('1.31.1', '1.32.0')).to.equal(true);
+        expect(autoUpdater.isVersionAllowedForUpdate!('1.31.1', '0.32.0')).to.equal(false);
       });
     });
 

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -20,7 +20,7 @@ declare namespace Electron {
   }
 
   interface AutoUpdater {
-    isVersionAllowedForUpdate(currentVersion: string, targetVersion: string): boolean;
+    isVersionAllowedForUpdate?(currentVersion: string, targetVersion: string): boolean;
   }
 
   type TouchBarItemType = NonNullable<Electron.TouchBarConstructorOptions['items']>[0];


### PR DESCRIPTION
We are already doing it in some places such as
https://github.com/electron/electron/blob/beb0cbc6d02815f5d4c6ed3dcdff931a5d8ba0cf/lib/browser/api/net-client-request.ts#L299

Let's do it consistently everywhere

Notes: none