### PR TITLE
fix: Do not activate app when calling focus on inactive panel window

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -486,7 +486,7 @@ void NativeWindowMac::Focus(bool focus) {
     // this safe, we're gating by versions.
     if (@available(macOS 14.0, *)) {
       if (!IsPanel(window_)) {
-        [[NSApplication sharedApplication] activateIgnoringOtherApps:NO];
+        [[NSApplication sharedApplication] activate];
       }
     } else {
       [[NSApplication sharedApplication] activateIgnoringOtherApps:NO];

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -127,6 +127,10 @@ bool IsFramelessWindow(NSView* view) {
   return window && !window->has_frame();
 }
 
+bool IsPanel(NSWindow* window) {
+  return [window level] == NSFloatingWindowLevel;
+}
+
 IMP original_set_frame_size = nullptr;
 IMP original_view_did_move_to_superview = nullptr;
 
@@ -469,7 +473,25 @@ void NativeWindowMac::Focus(bool focus) {
     return;
 
   if (focus) {
-    [[NSApplication sharedApplication] activateIgnoringOtherApps:NO];
+    // If we're a panel window, we do not want to activate the app,
+    // which enables Electron-apps to build Spotlight-like experiences.
+    //
+    // On macOS < Sonoma, "activateIgnoringOtherApps:NO" would not
+    // activate apps if focusing a window that is inActive. That
+    // changed with macOS Sonoma.
+    //
+    // There's a slim chance we should have never called
+    // activateIgnoringOtherApps, but we tried that many years ago
+    // and saw weird focus bugs on other macOS versions. So, to make
+    // this safe, we're gating by versions.
+    if (@available(macOS 14.0, *)) {
+      if (!IsPanel(window_)) {
+        [[NSApplication sharedApplication] activateIgnoringOtherApps:NO];
+      }
+    } else {
+      [[NSApplication sharedApplication] activateIgnoringOtherApps:NO];
+    }
+
     [window_ makeKeyAndOrderFront:nil];
   } else {
     [window_ orderOut:nil];

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -127,10 +127,6 @@ bool IsFramelessWindow(NSView* view) {
   return window && !window->has_frame();
 }
 
-bool IsPanel(NSWindow* window) {
-  return [window level] == NSFloatingWindowLevel;
-}
-
 IMP original_set_frame_size = nullptr;
 IMP original_view_did_move_to_superview = nullptr;
 
@@ -473,9 +469,6 @@ void NativeWindowMac::Focus(bool focus) {
     return;
 
   if (focus) {
-    // If we're a panel window, we do not want to activate the app,
-    // which enables Electron-apps to build Spotlight-like experiences.
-    //
     // On macOS < Sonoma, "activateIgnoringOtherApps:NO" would not
     // activate apps if focusing a window that is inActive. That
     // changed with macOS Sonoma.
@@ -485,9 +478,7 @@ void NativeWindowMac::Focus(bool focus) {
     // and saw weird focus bugs on other macOS versions. So, to make
     // this safe, we're gating by versions.
     if (@available(macOS 14.0, *)) {
-      if (!IsPanel(window_)) {
-        [[NSApplication sharedApplication] activate];
-      }
+      [[NSApplication sharedApplication] activate];
     } else {
       [[NSApplication sharedApplication] activateIgnoringOtherApps:NO];
     }


### PR DESCRIPTION
#### Description of Change

This PR fixes https://github.com/electron/electron/issues/39914. On macOS Sonoma, a BrowserWindow of the `panel` type could no longer be focused without also making the app the foregrounded app.

This was likely caused by us incorrectly calling `[[NSApplication sharedApplication] activateIgnoringOtherApps:NO];` in those scenarios. However, having done some sleuthing, we've tried to not call that method in recent years and saw different focus bugs. With that in mind, this PR does two things:

1. Adds a test for focusing an inactive panel window
2. Ensures that we do not call `activateIgnoringOtherApps` for panel windows on macOS 14.0 or newer.

We've also verified this approach internally at Notion. Anyone needing a fix for this urgently can [use this native module](https://github.com/abhaybuch/node-mac-window).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed app incorrectly activating panel windows on macOS Sonoma
