### PR TITLE
fix: prevent `PopUpButtonHandler` premature dealloc

### DIFF
--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -66,14 +66,18 @@
 
 // Manages the PopUpButtonHandler.
 @interface ElectronAccessoryView : NSView
+@property(nonatomic, strong) PopUpButtonHandler* popUpButtonHandler;
 @end
 
 @implementation ElectronAccessoryView
+
+@synthesize popUpButtonHandler;
 
 - (void)dealloc {
   auto* popupButton =
       static_cast<NSPopUpButton*>([[self subviews] objectAtIndex:1]);
   popupButton.target = nil;
+  popUpButtonHandler = nil;
 }
 
 @end
@@ -149,6 +153,7 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
 
   [accessoryView addSubview:label];
   [accessoryView addSubview:popupButton];
+  [accessoryView setPopUpButtonHandler:popUpButtonHandler];
 
   [dialog setAccessoryView:accessoryView];
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/40284
Refs [this roll](https://github.com/electron/electron/commit/c5b9f766f373f4d403a8af2f75e28ca2d901cc32#diff-69dd8c727cf22d632f5ed17d9f4024ecdf95e8e11a8da32cc614a21460685cb9)

See [here](https://developer.apple.com/documentation/appkit/nscontrol/1428885-target?language=objc) - turns out `target` is weak so we need to retain it elsewhere.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an error changing file format in `dialog.showOpenDialog` on macOS.