### PR TITLE
test: add spec for `child-process-gone` event for utility process

### DIFF
--- a/docs/api/utility-process.md
+++ b/docs/api/utility-process.md
@@ -29,7 +29,7 @@ Process: [Main](../glossary.md#main-process)<br />
     * `inherit`: equivalent to \['ignore', 'inherit', 'inherit']
   * `serviceName` string (optional) - Name of the process that will appear in `name` property of
     [`child-process-gone` event of `app`](app.md#event-child-process-gone).
-    Default is `node.mojom.NodeService`.
+    Default is `Node Utility Process`.
   * `allowLoadingUnsignedLibraries` boolean (optional) _macOS_ - With this flag, the utility process will be
     launched via the `Electron Helper (Plugin).app` helper executable on macOS, which can be
     codesigned with `com.apple.security.cs.disable-library-validation` and

--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as childProcess from 'child_process';
 import * as path from 'path';
-import { BrowserWindow, MessageChannelMain, utilityProcess } from 'electron/main';
+import { BrowserWindow, MessageChannelMain, utilityProcess, app } from 'electron/main';
 import { ifit } from './lib/spec-helpers';
 import { closeWindow } from './lib/window-helpers';
 import { once } from 'events';
@@ -83,6 +83,26 @@ describe('utilityProcess module', () => {
       const child = utilityProcess.fork(path.join(fixturesPath, 'custom-exit.js'), [`--exitCode=${exitCode}`]);
       const [code] = await once(child, 'exit');
       expect(code).to.equal(exitCode);
+    });
+  });
+
+  describe('app \'child-process-gone\' event', () => {
+    it('with default serviceName', async () => {
+      utilityProcess.fork(path.join(fixturesPath, 'crash.js'));
+      const [, details] = await once(app, 'child-process-gone') as [any, Electron.Details];
+      expect(details.type).to.equal('Utility');
+      expect(details.serviceName).to.equal('node.mojom.NodeService');
+      expect(details.name).to.equal('Node Utility Process');
+      expect(details.reason).to.be.oneOf(['crashed', 'abnormal-exit']);
+    });
+
+    it('with custom serviceName', async () => {
+      utilityProcess.fork(path.join(fixturesPath, 'crash.js'), [], { serviceName: 'Hello World!' });
+      const [, details] = await once(app, 'child-process-gone') as [any, Electron.Details];
+      expect(details.type).to.equal('Utility');
+      expect(details.serviceName).to.equal('node.mojom.NodeService');
+      expect(details.name).to.equal('Hello World!');
+      expect(details.reason).to.be.oneOf(['crashed', 'abnormal-exit']);
     });
   });
 


### PR DESCRIPTION
Backport of #40281

See that PR for details.

Notes: none