### PR TITLE
fix: `navigator.keyboard.lock()` fullscreen exit handling

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1334,12 +1334,6 @@ bool WebContents::HandleKeyboardEvent(
 bool WebContents::PlatformHandleKeyboardEvent(
     content::WebContents* source,
     const content::NativeWebKeyboardEvent& event) {
-  // Escape exits tabbed fullscreen mode.
-  if (event.windows_key_code == ui::VKEY_ESCAPE && is_html_fullscreen()) {
-    ExitFullscreenModeForTab(source);
-    return true;
-  }
-
   // Check if the webContents has preferences and to ignore shortcuts
   auto* web_preferences = WebContentsPreferences::From(source);
   if (web_preferences && web_preferences->ShouldIgnoreMenuShortcuts())

--- a/shell/browser/api/electron_api_web_contents_mac.mm
+++ b/shell/browser/api/electron_api_web_contents_mac.mm
@@ -42,12 +42,6 @@ bool WebContents::PlatformHandleKeyboardEvent(
       event.GetType() == content::NativeWebKeyboardEvent::Type::kChar)
     return false;
 
-  // Escape exits tabbed fullscreen mode.
-  if (event.windows_key_code == ui::VKEY_ESCAPE && is_html_fullscreen()) {
-    ExitFullscreenModeForTab(source);
-    return true;
-  }
-
   // Check if the webContents has preferences and to ignore shortcuts
   auto* web_preferences = WebContentsPreferences::From(source);
   if (web_preferences && web_preferences->ShouldIgnoreMenuShortcuts())

--- a/spec/fixtures/pages/modal.html
+++ b/spec/fixtures/pages/modal.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<body>
+  <dialog id="favDialog">
+    <form>
+      <p>
+        <label>
+          Favorite animal:
+          <select>
+            <option value="default">Choose…</option>
+            <option>Brine shrimp</option>
+            <option>Red panda</option>
+            <option>Spider monkey</option>
+          </select>
+        </label>
+      </p>
+      <div>
+        <button value="cancel" formmethod="dialog">Cancel</button>
+        <button id="confirmBtn" value="default">Confirm</button>
+      </div>
+    </form>
+  </dialog>
+</body>
+
+</html>

--- a/spec/webview-spec.ts
+++ b/spec/webview-spec.ts
@@ -547,17 +547,16 @@ describe('<webview> tag', function () {
       await close;
     });
 
-    // Sending ESC via sendInputEvent only works on Windows.
-    ifit(process.platform === 'win32')('pressing ESC should unfullscreen window', async () => {
+    it('pressing ESC should unfullscreen window', async () => {
       const [w, webview] = await loadWebViewWindow();
       const enterFullScreen = once(w, 'enter-full-screen');
       await webview.executeJavaScript('document.getElementById("div").requestFullscreen()', true);
       await enterFullScreen;
 
       const leaveFullScreen = once(w, 'leave-full-screen');
-      w.webContents.sendInputEvent({ type: 'keyDown', keyCode: 'Escape' });
+      webview.sendInputEvent({ type: 'keyDown', keyCode: 'Escape' });
       await leaveFullScreen;
-      await setTimeout();
+      await setTimeout(1000);
       expect(w.isFullScreen()).to.be.false();
 
       const close = once(w, 'closed');


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/40342.

Fixes an issue where `navigator.keyboard.lock()` did not work per [latest expected behavior](https://developer.chrome.com/blog/better-full-screen-mode) - pressing <kbd>Esc</kbd> exited fullscreen immediately despite a keyboard lock being present to capture the key. We added this behavior historically when we didn't use the `ExclusiveAccessManager` - it now handles fullscreen capture and exit when necessary.

This can be tested with https://fullscreen-keyboard-lock.glitch.me - now, pressing and holding escape correctly triggers [`RequiresPressAndHoldEscToExit()`](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/exclusive_access/keyboard_lock_controller.cc;drc=2d0a33ccdfa8ac1a9bdf1d86d3b9138f99484bdf;bpv=1;bpt=1;l=69) and associated logic.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where `navigator.keyboard.lock()` did not work per [latest expected behavior](https://developer.chrome.com/blog/better-full-screen-mode)
