### PR TITLE
build: don't rename files in `electron_node/deps/base64`

### DIFF
--- a/patches/node/build_add_gn_build_files.patch
+++ b/patches/node/build_add_gn_build_files.patch
@@ -405,10 +405,10 @@ index 0000000000000000000000000000000000000000..a564653c3f05608d59fed5aa071d63b8
 +}
 diff --git a/deps/base64/BUILD.gn b/deps/base64/BUILD.gn
 new file mode 100644
-index 0000000000000000000000000000000000000000..694e1991bb11c9ea85fcc69a0e06265d4b0c5aab
+index 0000000000000000000000000000000000000000..9b97aabe865e4cf12f6c3ccda196b372769a823b
 --- /dev/null
 +++ b/deps/base64/BUILD.gn
-@@ -0,0 +1,152 @@
+@@ -0,0 +1,135 @@
 +config("base64_config") {
 +  include_dirs = [
 +    "base64/include",
@@ -420,7 +420,15 @@ index 0000000000000000000000000000000000000000..694e1991bb11c9ea85fcc69a0e06265d
 +
 +static_library("base64") {
 +  defines = []
-+  deps = []
++  deps = [
++    ":base64_neon32",
++    ":base64_neon64",
++    ":base64_avx",
++    ":base64_avx2",
++    ":base64_sse41",
++    ":base64_sse42",
++    ":base64_ssse3",
++  ]
 +
 +  public_configs = [ ":base64_config" ]
 +
@@ -438,157 +446,104 @@ index 0000000000000000000000000000000000000000..694e1991bb11c9ea85fcc69a0e06265d
 +    "base64/lib/lib.c",
 +    "base64/lib/tables/tables.c",
 +  ]
-+
-+  if (target_cpu == "arm") {
-+    defines += [ "HAVE_NEON32=1" ]
-+    deps += [ ":base64_neon32" ]
-+  } else {
-+    sources += [ "base64/lib/arch/neon32/neon32_codec.c" ]
-+  }
-+
-+  if (target_cpu == "arm64") {
-+    defines += [ "HAVE_NEON64=1" ]
-+    deps += [ ":base64_neon64" ]
-+  } else {
-+    sources += [ "base64/lib/arch/neon64/neon64_codec.c" ]
-+  }
-+
-+  if (target_cpu == "ia32" || target_cpu == "x64" || target_cpu == "x32") {
-+    defines += [
-+      "HAVE_SSSE3=1",
-+      "HAVE_SSE41=1",
-+      "HAVE_SSE42=1",
-+      "HAVE_AVX=1",
-+      "HAVE_AVX2=1",
-+    ]
-+
-+    deps += [
-+      ":base64_avx",
-+      ":base64_avx2",
-+      ":base64_sse41",
-+      ":base64_sse42",
-+      ":base64_ssse3",
-+    ]
-+  } else {
-+    sources += [
-+      "base64/lib/arch/avx/avx_codec.c",
-+      "base64/lib/arch/avx2/avx2_codec.c",
-+      "base64/lib/arch/sse41/sse41_codec.c",
-+      "base64/lib/arch/sse42/sse42_codec.c",
-+      "base64/lib/arch/ssse3/ssse3_codec.c",
-+    ]
-+  }
 +}
 +
 +source_set("base64_ssse3") {
 +  public_configs = [ ":base64_config" ]
 +
-+  defines = [ "HAVE_SSSE3=1" ]
++  if (target_cpu == "ia32" || target_cpu == "x64" || target_cpu == "x32") {
++    defines = [ "HAVE_SSSE3=1" ]
 +
-+  cflags = [ "-mssse3" ]
-+  cflags_c = [ "-Wno-implicit-fallthrough" ]
++    cflags = [ "-mssse3" ]
++    cflags_c = [ "-Wno-implicit-fallthrough" ]
++  }
 +
-+  sources = [ "base64/lib/arch/ssse3/ssse3_codec.c" ]
++  sources = [ "base64/lib/arch/ssse3/codec.c" ]
 +}
 +
 +source_set("base64_sse41") {
 +  public_configs = [ ":base64_config" ]
 +
-+  defines = [ "HAVE_SSE41=1" ]
++  if (target_cpu == "ia32" || target_cpu == "x64" || target_cpu == "x32") {
++    defines = [ "HAVE_SSE41=1" ]
 +
-+  cflags = [ "-msse4.1" ]
-+  cflags_c = [ "-Wno-implicit-fallthrough" ]
++    cflags = [ "-msse4.1" ]
++    cflags_c = [ "-Wno-implicit-fallthrough" ]
++  }
 +
-+  sources = [ "base64/lib/arch/sse41/sse41_codec.c" ]
++  sources = [ "base64/lib/arch/sse41/codec.c" ]
 +}
++
 +
 +source_set("base64_sse42") {
 +  public_configs = [ ":base64_config" ]
 +
-+  defines = [
-+    "BASE64_STATIC_DEFINE",
-+    "HAVE_SSE42=1",
-+  ]
++  if (target_cpu == "ia32" || target_cpu == "x64" || target_cpu == "x32") {
++    defines = [
++      "BASE64_STATIC_DEFINE",
++      "HAVE_SSE42=1",
++    ]
 +
-+  cflags = [ "-msse4.2" ]
-+  cflags_c = [ "-Wno-implicit-fallthrough" ]
++    cflags = [ "-msse4.2" ]
++    cflags_c = [ "-Wno-implicit-fallthrough" ]
++  }
 +
-+  sources = [ "base64/lib/arch/sse42/sse42_codec.c" ]
++  sources = [ "base64/lib/arch/sse42/codec.c" ]
 +}
 +
 +source_set("base64_avx") {
 +  public_configs = [ ":base64_config" ]
 +
-+  defines = [ "HAVE_AVX=1" ]
++  if (target_cpu == "ia32" || target_cpu == "x64" || target_cpu == "x32") {
++    defines = [ "HAVE_AVX=1" ]
 +
-+  cflags = [ "-mavx" ]
-+  cflags_c = [ "-Wno-implicit-fallthrough" ]
++    cflags = [ "-mavx" ]
++    cflags_c = [ "-Wno-implicit-fallthrough" ]
++  }
 +
-+  sources = [ "base64/lib/arch/avx/avx_codec.c" ]
++  sources = [ "base64/lib/arch/avx/codec.c" ]
 +}
 +
 +source_set("base64_avx2") {
 +  public_configs = [ ":base64_config" ]
 +
-+  defines = [ "HAVE_AVX2=1" ]
++  if (target_cpu == "ia32" || target_cpu == "x64" || target_cpu == "x32") {
++    defines = [ "HAVE_AVX2=1" ]
 +
-+  cflags = [ "-mavx2" ]
-+  cflags_c = [
-+    "-Wno-implicit-fallthrough",
-+    "-Wno-implicit-function-declaration",
-+  ]
++    cflags = [ "-mavx2" ]
++    cflags_c = [
++      "-Wno-implicit-fallthrough",
++      "-Wno-implicit-function-declaration",
++    ]
++  }
 +
-+  sources = [ "base64/lib/arch/avx2/avx2_codec.c" ]
++  sources = [ "base64/lib/arch/avx2/codec.c" ]
 +}
 +
 +source_set("base64_neon32") {
 +  public_configs = [ ":base64_config" ]
 +
-+  defines = [ "HAVE_NEON32=1" ]
++  if (target_cpu == "arm") {
++    defines = [ "HAVE_NEON32=1" ]
 +
-+  cflags = [ "-mfpu=neon" ]
-+  cflags_c = [ "-Wno-implicit-fallthrough" ]
++    cflags = [ "-mfpu=neon" ]
++    cflags_c = [ "-Wno-implicit-fallthrough" ]
++  }
 +
-+  sources = [ "base64/lib/arch/neon32/neon32_codec.c" ]
++  sources = [ "base64/lib/arch/neon32/codec.c" ]
 +}
 +
 +source_set("base64_neon64") {
 +  public_configs = [ ":base64_config" ]
 +
-+  defines = [ "HAVE_NEON64=1" ]
++  if (target_cpu == "arm64") {
++    defines = [ "HAVE_NEON64=1" ]
 +
-+  cflags_c = [ "-Wno-implicit-fallthrough" ]
++    cflags_c = [ "-Wno-implicit-fallthrough" ]
++  }
 +
-+  sources = [ "base64/lib/arch/neon64/neon64_codec.c" ]
++  sources = [ "base64/lib/arch/neon64/codec.c" ]
 +}
-diff --git a/deps/base64/base64/lib/arch/avx/codec.c b/deps/base64/base64/lib/arch/avx/avx_codec.c
-similarity index 100%
-rename from deps/base64/base64/lib/arch/avx/codec.c
-rename to deps/base64/base64/lib/arch/avx/avx_codec.c
-diff --git a/deps/base64/base64/lib/arch/avx2/codec.c b/deps/base64/base64/lib/arch/avx2/avx2_codec.c
-similarity index 100%
-rename from deps/base64/base64/lib/arch/avx2/codec.c
-rename to deps/base64/base64/lib/arch/avx2/avx2_codec.c
-diff --git a/deps/base64/base64/lib/arch/neon32/codec.c b/deps/base64/base64/lib/arch/neon32/neon32_codec.c
-similarity index 100%
-rename from deps/base64/base64/lib/arch/neon32/codec.c
-rename to deps/base64/base64/lib/arch/neon32/neon32_codec.c
-diff --git a/deps/base64/base64/lib/arch/neon64/codec.c b/deps/base64/base64/lib/arch/neon64/neon64_codec.c
-similarity index 100%
-rename from deps/base64/base64/lib/arch/neon64/codec.c
-rename to deps/base64/base64/lib/arch/neon64/neon64_codec.c
-diff --git a/deps/base64/base64/lib/arch/sse41/codec.c b/deps/base64/base64/lib/arch/sse41/sse41_codec.c
-similarity index 100%
-rename from deps/base64/base64/lib/arch/sse41/codec.c
-rename to deps/base64/base64/lib/arch/sse41/sse41_codec.c
-diff --git a/deps/base64/base64/lib/arch/sse42/codec.c b/deps/base64/base64/lib/arch/sse42/sse42_codec.c
-similarity index 100%
-rename from deps/base64/base64/lib/arch/sse42/codec.c
-rename to deps/base64/base64/lib/arch/sse42/sse42_codec.c
-diff --git a/deps/base64/base64/lib/arch/ssse3/codec.c b/deps/base64/base64/lib/arch/ssse3/ssse3_codec.c
-similarity index 100%
-rename from deps/base64/base64/lib/arch/ssse3/codec.c
-rename to deps/base64/base64/lib/arch/ssse3/ssse3_codec.c
 diff --git a/deps/cares/BUILD.gn b/deps/cares/BUILD.gn
 new file mode 100644
 index 0000000000000000000000000000000000000000..2a902c68ca445b8451e442c314c60ee5a30719e4


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/35999/files#r1018305596.

Finally addresses an old TODO to use a separate build target for conflicting filenames instead of renaming files in the source tree.

Done in preparation for Node.js v20 upgrade, which I'll look to start soon as it entered Active LTS on [`2023-10-24`](https://github.com/nodejs/release#release-schedule)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none