### PR TITLE
feat: `keyboard.lock()` should use permissions helper

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -901,6 +901,7 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
     * `midiSysex` - Request the use of system exclusive messages in the [Web MIDI API](https://developer.mozilla.org/en-US/docs/Web/API/Web_MIDI_API).
     * `notifications` - Request notification creation and the ability to display them in the user's system tray using the [Notifications API](https://developer.mozilla.org/en-US/docs/Web/API/notification)
     * `pointerLock` - Request to directly interpret mouse movements as an input method via the [Pointer Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API). These requests always appear to originate from the main frame.
+    * `keyboardLock` - Request capture of keypresses for any or all of the keys on the physical keyboard via the [Keyboard Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Keyboard/lock). These requests always appear to originate from the main frame.
     * `openExternal` - Request to open links in external applications.
     * `window-management` - Request access to enumerate screens using the [`getScreenDetails`](https://developer.chrome.com/en/articles/multi-screen-window-placement/) API.
     * `unknown` - An unrecognized permission request.

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1517,11 +1517,10 @@ void WebContents::FindReply(content::WebContents* web_contents,
   Emit("found-in-page", result.GetHandle());
 }
 
-void WebContents::RequestExclusivePointerAccess(
-    content::WebContents* web_contents,
-    bool user_gesture,
-    bool last_unlocked_by_target,
-    bool allowed) {
+void WebContents::OnRequestToLockMouse(content::WebContents* web_contents,
+                                       bool user_gesture,
+                                       bool last_unlocked_by_target,
+                                       bool allowed) {
   if (allowed) {
     exclusive_access_manager_.mouse_lock_controller()->RequestToLockMouse(
         web_contents, user_gesture, last_unlocked_by_target);
@@ -1538,7 +1537,7 @@ void WebContents::RequestToLockMouse(content::WebContents* web_contents,
       WebContentsPermissionHelper::FromWebContents(web_contents);
   permission_helper->RequestPointerLockPermission(
       user_gesture, last_unlocked_by_target,
-      base::BindOnce(&WebContents::RequestExclusivePointerAccess,
+      base::BindOnce(&WebContents::OnRequestToLockMouse,
                      base::Unretained(this)));
 }
 
@@ -1546,10 +1545,24 @@ void WebContents::LostMouseLock() {
   exclusive_access_manager_.mouse_lock_controller()->LostMouseLock();
 }
 
+void WebContents::OnRequestKeyboardLock(content::WebContents* web_contents,
+                                        bool esc_key_locked,
+                                        bool allowed) {
+  if (allowed) {
+    exclusive_access_manager_.keyboard_lock_controller()->RequestKeyboardLock(
+        web_contents, esc_key_locked);
+  } else {
+    web_contents->GotResponseToKeyboardLockRequest(false);
+  }
+}
+
 void WebContents::RequestKeyboardLock(content::WebContents* web_contents,
                                       bool esc_key_locked) {
-  exclusive_access_manager_.keyboard_lock_controller()->RequestKeyboardLock(
-      web_contents, esc_key_locked);
+  auto* permission_helper =
+      WebContentsPermissionHelper::FromWebContents(web_contents);
+  permission_helper->RequestKeyboardLockPermission(
+      esc_key_locked, base::BindOnce(&WebContents::OnRequestKeyboardLock,
+                                     base::Unretained(this)));
 }
 
 void WebContents::CancelKeyboardLockRequest(

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -568,14 +568,17 @@ class WebContents : public ExclusiveAccessContext,
                  const gfx::Rect& selection_rect,
                  int active_match_ordinal,
                  bool final_update) override;
-  void RequestExclusivePointerAccess(content::WebContents* web_contents,
-                                     bool user_gesture,
-                                     bool last_unlocked_by_target,
-                                     bool allowed);
+  void OnRequestToLockMouse(content::WebContents* web_contents,
+                            bool user_gesture,
+                            bool last_unlocked_by_target,
+                            bool allowed);
   void RequestToLockMouse(content::WebContents* web_contents,
                           bool user_gesture,
                           bool last_unlocked_by_target) override;
   void LostMouseLock() override;
+  void OnRequestKeyboardLock(content::WebContents* web_contents,
+                             bool esc_key_locked,
+                             bool allowed);
   void RequestKeyboardLock(content::WebContents* web_contents,
                            bool esc_key_locked) override;
   void CancelKeyboardLockRequest(content::WebContents* web_contents) override;

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -253,6 +253,15 @@ void WebContentsPermissionHelper::RequestPointerLockPermission(
       user_gesture);
 }
 
+void WebContentsPermissionHelper::RequestKeyboardLockPermission(
+    bool esc_key_locked,
+    base::OnceCallback<void(content::WebContents*, bool, bool)> callback) {
+  RequestPermission(
+      web_contents_->GetPrimaryMainFrame(),
+      static_cast<blink::PermissionType>(PermissionType::KEYBOARD_LOCK),
+      base::BindOnce(std::move(callback), web_contents_, esc_key_locked));
+}
+
 void WebContentsPermissionHelper::RequestOpenExternalPermission(
     content::RenderFrameHost* requesting_frame,
     base::OnceCallback<void(bool)> callback,

--- a/shell/browser/web_contents_permission_helper.h
+++ b/shell/browser/web_contents_permission_helper.h
@@ -31,7 +31,8 @@ class WebContentsPermissionHelper
     OPEN_EXTERNAL,
     SERIAL,
     HID,
-    USB
+    USB,
+    KEYBOARD_LOCK
   };
 
   // Asynchronous Requests
@@ -44,6 +45,9 @@ class WebContentsPermissionHelper
       bool last_unlocked_by_target,
       base::OnceCallback<void(content::WebContents*, bool, bool, bool)>
           callback);
+  void RequestKeyboardLockPermission(
+      bool esc_key_locked,
+      base::OnceCallback<void(content::WebContents*, bool, bool)> callback);
   void RequestWebNotificationPermission(
       content::RenderFrameHost* requesting_frame,
       base::OnceCallback<void(bool)> callback);

--- a/shell/common/gin_converters/content_converter.cc
+++ b/shell/common/gin_converters/content_converter.cc
@@ -249,6 +249,8 @@ v8::Local<v8::Value> Converter<blink::PermissionType>::ToV8(
   switch (static_cast<PermissionType>(val)) {
     case PermissionType::POINTER_LOCK:
       return StringToV8(isolate, "pointerLock");
+    case PermissionType::KEYBOARD_LOCK:
+      return StringToV8(isolate, "keyboardLock");
     case PermissionType::FULLSCREEN:
       return StringToV8(isolate, "fullscreen");
     case PermissionType::OPEN_EXTERNAL:


### PR DESCRIPTION
#### Description of Change

Similar APIs are routed through our permissions helper, and it breaks from our permissions expectations to have this API not be controllable through `ses.setPermissionRequestHandler(handler)`.

This change brings it in line with other APIs like the [`Pointer Lock API`](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `keyboardLock` to `ses.setPermissionRequestHandler(handler)`.