### PR TITLE
fix: allow thick frame transparent window

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -235,10 +235,14 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
   options.Get(options::kMinimizable, &minimizable_);
   options.Get(options::kMaximizable, &maximizable_);
 
-  // Transparent window must not have thick frame.
-  options.Get("thickFrame", &thick_frame_);
-  if (transparent())
+  // Transparent window does not have thick frame for default.
+  absl::optional<bool> thick_frame_optional;
+  options.GetOptional("thickFrame", &thick_frame_optional);
+  if (transparent() && !thick_frame_optional.has_value()) {
     thick_frame_ = false;
+  } else {
+    thick_frame_ = thick_frame_optional.value();
+  }
 
   overlay_button_color_ = color_utils::GetSysSkColor(COLOR_BTNFACE);
   overlay_symbol_color_ = color_utils::GetSysSkColor(COLOR_BTNTEXT);


### PR DESCRIPTION
#### Description of Change

cc @clavin @codebytere  

Close https://github.com/electron/electron/issues/40121
Close https://github.com/electron/electron/issues/39959

In current Electron builds, the `WS_THICKFRAME` style is forcelly disabled when `transparent` option is set to true, which removes window animations of the window.

The missing of `WS_THICKFRAME` style also causes BrowserWindow with `backgroundMaterial: 'acrylic'` option losing acrylic style when losing focus, which requires `transparent` option to be true

Screenshot for BrowserWindow with `backgroundMaterial: 'acrylic'` and `thickFrame: false`
![image](https://github.com/electron/electron/assets/8194131/82af0294-1cac-463f-86c1-6e06044e07b1)

Screenshot for BrowserWindow with `backgroundMaterial: 'acrylic'` and `thickFrame: true`
![image](https://github.com/electron/electron/assets/8194131/2afa1c5d-45c2-45a2-942c-289df699ab51)


This PR removes the limitation of transparent window to use `WS_THICKFRAME` style, so that the issue aboves could be fixed

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes:  Fixed missing window animations and acrylic style in transparent window with `backgroundMaterial: 'acrylic'` option.
