### PR TITLE
chore: remove py2 compatibility code

### DIFF
--- a/build/dump_syms.py
+++ b/build/dump_syms.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import collections
 import os

--- a/build/npm-run.py
+++ b/build/npm-run.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from __future__ import print_function
+
 import os
 import subprocess
 import sys

--- a/build/profile_toolchain.py
+++ b/build/profile_toolchain.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+#!/usr/bin/env python3
 
 import contextlib
 import sys

--- a/build/zip.py
+++ b/build/zip.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from __future__ import print_function
+
 import os
 import subprocess
 import sys

--- a/build/zip_libcxx.py
+++ b/build/zip_libcxx.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from __future__ import print_function
+
 import os
 import subprocess
 import sys

--- a/script/add-debug-link.py
+++ b/script/add-debug-link.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from __future__ import print_function
+
 import argparse
 import os
 import sys

--- a/script/copy-debug-symbols.py
+++ b/script/copy-debug-symbols.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from __future__ import print_function
+
 import argparse
 import os
 import sys

--- a/script/generate-config-gypi.py
+++ b/script/generate-config-gypi.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
 import ast
 import os
 import pprint

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
 import os
 import sys
 

--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -6,8 +6,6 @@ Everything here should be project agnostic: it shouldn't rely on project's
 structure, or make assumptions about the passed arguments or calls' outcomes.
 """
 
-from __future__ import unicode_literals
-
 import io
 import os
 import posixpath
@@ -229,14 +227,6 @@ def remove_patch_filename(patch):
     force_keep_next_line = l.startswith('Subject: ')
 
 
-def to_utf8(patch):
-  """Python 2/3 compatibility: unicode has been renamed to str in Python3"""
-  if sys.version_info[0] >= 3:
-    return str(patch, "utf-8")
-
-  return unicode(patch, "utf-8")
-
-
 def export_patches(repo, out_dir, patch_range=None, dry_run=False):
   if not os.path.exists(repo):
     sys.stderr.write(
@@ -263,7 +253,7 @@ def export_patches(repo, out_dir, patch_range=None, dry_run=False):
     for patch in patches:
       filename = get_file_name(patch)
       filepath = posixpath.join(out_dir, filename)
-      existing_patch = to_utf8(io.open(filepath, 'rb').read())
+      existing_patch = str(io.open(filepath, 'rb').read(), 'utf-8')
       formatted_patch = join_patch(patch)
       if formatted_patch != existing_patch:
         bad_patches.append(filename)

--- a/script/lib/native_tests.py
+++ b/script/lib/native_tests.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import os
 import subprocess
@@ -9,11 +9,6 @@ from lib.util import SRC_DIR
 PYYAML_LIB_DIR = os.path.join(SRC_DIR, 'third_party', 'pyyaml', 'lib')
 sys.path.append(PYYAML_LIB_DIR)
 import yaml  #pylint: disable=wrong-import-position,wrong-import-order
-
-try:
-  basestring        # Python 2
-except NameError:   # Python 3
-  basestring = str  # pylint: disable=redefined-builtin
 
 
 class Verbosity:
@@ -148,7 +143,7 @@ class TestsList():
     if isinstance(value, dict):
       return value
 
-    if isinstance(value, basestring):
+    if isinstance(value, str):
       return {value: None}
 
     raise AssertionError("unexpected shorthand type: {}".format(type(value)))

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
 import contextlib
 import errno
 import json
@@ -8,11 +7,7 @@ import os
 import shutil
 import subprocess
 import sys
-# Python 3 / 2 compat import
-try:
-  from urllib.request import urlopen
-except ImportError:
-  from urllib2 import urlopen
+from urllib.request import urlopen
 import zipfile
 
 # from lib.config import is_verbose_mode

--- a/script/native-tests.py
+++ b/script/native-tests.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
-
 import argparse
 import os
 import sys

--- a/script/patches-mtime-cache.py
+++ b/script/patches-mtime-cache.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
-
 import argparse
 import hashlib
 import json
@@ -168,13 +166,7 @@ def main():
             traceback.print_exc(file=sys.stderr)
             return 0
     elif args.operation == "set":
-        # Python 2/3 compatibility
-        try:
-            user_input = raw_input
-        except NameError:
-            user_input = input
-
-        answer = user_input(
+        answer = input(
             "WARNING: Manually setting mtimes could mess up your build. "
             "If you're sure, type yes: "
         )

--- a/script/release/uploaders/upload-index-json.py
+++ b/script/release/uploaders/upload-index-json.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
 import json
 import os
 import sys

--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
 import argparse
 import datetime
 import hashlib

--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -7,8 +7,6 @@ It runs over multiple files and directories in parallel.
 A diff output is produced and a sensible exit code is returned.
 """
 
-from __future__ import print_function, unicode_literals
-
 import argparse
 import codecs
 import difflib

--- a/script/strip-binaries.py
+++ b/script/strip-binaries.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from __future__ import print_function
+
 import argparse
 import os
 import sys

--- a/script/verify-chromedriver.py
+++ b/script/verify-chromedriver.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
-
 import argparse
 import os
 import re

--- a/script/verify-ffmpeg.py
+++ b/script/verify-ffmpeg.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from __future__ import print_function
+
 import argparse
 import os
 import platform

--- a/script/verify-mksnapshot.py
+++ b/script/verify-mksnapshot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from __future__ import print_function
+
 import argparse
 import glob
 import os

--- a/script/zip-symbols.py
+++ b/script/zip-symbols.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
 import argparse
 import glob
 import os


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

These Python scripts have all been moved to running with Python 3, so let's drop the old Python 2 compatibility code.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
