### PR TITLE
fix: crash when thread isolated pool is enabled in the renderer process

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -52,3 +52,11 @@ use_perfetto_client_library = false
 
 # Disables the builtins PGO for V8
 v8_builtins_profiling_log_file = ""
+
+# Disable threadisolated allocator implementation from gin for partition allocator,
+# we are seeing crashes for Linux x64 users when node integration is enabled in the
+# renderer process causing SIGSEGV when the periodic memory reclaimer runs,
+# Refs https://github.com/electron/electron/issues/39775.
+# The current only user of this pool is the v8 CFI which is
+# not enabled on this branch, so it is safe to disable the feature.
+enable_pkeys = false


### PR DESCRIPTION
#### Description of Change

Data collected from the linked issue,

1) Issue is isolated to Linux x64 users
2) Issue does not happen with builds that had enable_pkeys = false
3) Affected users run with renderer sandbox disabled which disables zygote in our case
4) Some users have reported crash does not happen with Chromium 118
5) I am unable to repro the issue on Ubuntu 22.04 vm with 4k page size, seems isolated to specific setups.

Given pkeys feature is only enabled on Linux x64 and is primarily used to implement thread isolated allocator whose consumer is v8 CFI which is currently disabled on this branch, I am inclined to disable the feature as there are no negative side effects. Also, given the issue is claimed to be addressed in Electron 27 and higher, this is an isolated fix which should make Electron 26 stable for the affected uesrs.

Fixes https://github.com/electron/electron/issues/39775

#### Release Notes

Notes: fix crash in renderer process due to partition allocator when sandbox is disabled