### PR TITLE
fix: emit will-navigate for links in chrome: pages

### DIFF
--- a/shell/browser/electron_navigation_throttle.cc
+++ b/shell/browser/electron_navigation_throttle.cc
@@ -4,9 +4,11 @@
 
 #include "shell/browser/electron_navigation_throttle.h"
 
+#include "content/browser/renderer_host/render_frame_host_impl.h"  // nogncheck
 #include "content/public/browser/navigation_handle.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/javascript_environment.h"
+#include "ui/base/page_transition_types.h"
 
 namespace electron {
 
@@ -37,11 +39,26 @@ ElectronNavigationThrottle::WillStartRequest() {
     return PROCEED;
   }
 
-  if (handle->IsRendererInitiated() &&
+  bool is_renderer_initiated = handle->IsRendererInitiated();
+
+  // Chrome's internal pages always mark navigation as browser-initiated. Let's
+  // ignore that.
+  // https://source.chromium.org/chromium/chromium/src/+/main:content/browser/renderer_host/navigator.cc;l=883-892;drc=0c8ffbe78dc0ef2047849e45cefb3f621043e956
+  if (!is_renderer_initiated &&
+      ui::PageTransitionIsWebTriggerable(handle->GetPageTransition())) {
+    auto* render_frame_host = contents->GetPrimaryMainFrame();
+    auto* rfh_impl =
+        static_cast<content::RenderFrameHostImpl*>(render_frame_host);
+    if (rfh_impl && rfh_impl->web_ui()) {
+      is_renderer_initiated = true;
+    }
+  }
+
+  if (is_renderer_initiated &&
       api_contents->EmitNavigationEvent("will-frame-navigate", handle)) {
     return CANCEL;
   }
-  if (handle->IsRendererInitiated() && handle->IsInMainFrame() &&
+  if (is_renderer_initiated && handle->IsInMainFrame() &&
       api_contents->EmitNavigationEvent("will-navigate", handle)) {
     return CANCEL;
   }

--- a/shell/browser/electron_navigation_throttle.cc
+++ b/shell/browser/electron_navigation_throttle.cc
@@ -49,9 +49,7 @@ ElectronNavigationThrottle::WillStartRequest() {
     auto* render_frame_host = contents->GetPrimaryMainFrame();
     auto* rfh_impl =
         static_cast<content::RenderFrameHostImpl*>(render_frame_host);
-    if (rfh_impl && rfh_impl->web_ui()) {
-      is_renderer_initiated = true;
-    }
+    is_renderer_initiated = rfh_impl && rfh_impl->web_ui();
   }
 
   if (is_renderer_initiated &&

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -584,6 +584,26 @@ describe('BrowserWindow module', () => {
           expect(initiator).not.to.be.undefined();
           expect(initiator).to.equal(subframe);
         });
+
+        it('is triggered when navigating from chrome: to http:', async () => {
+          let hasEmittedWillNavigate = false;
+          const willNavigatePromise = new Promise((resolve) => {
+            w.webContents.once('will-navigate', e => {
+              e.preventDefault();
+              hasEmittedWillNavigate = true;
+              resolve(e.url);
+            });
+          });
+          await w.loadURL('chrome://gpu');
+
+          // shouldn't emit for browser-initiated request via loadURL
+          expect(hasEmittedWillNavigate).to.equal(false);
+
+          w.webContents.executeJavaScript(`location.href = ${JSON.stringify(url)}`);
+          const navigatedTo = await willNavigatePromise;
+          expect(navigatedTo).to.equal(url + '/');
+          expect(w.webContents.getURL()).to.equal('chrome://gpu/');
+        });
       });
 
       describe('will-frame-navigate event', () => {


### PR DESCRIPTION
#### Description of Change

Navigating to links within `chrome:` pages—such as chrome://gpu—don't emit the "will-navigate" event. This is caused by navigations in pages with Web UI (e.g. `chrome:` pages) to [always be set as browser-initiated requests.](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/renderer_host/navigator.cc;l=883-892;drc=0c8ffbe78dc0ef2047849e45cefb3f621043e956)

To fix this, we're overriding the browser-initiated flag for certain page transitions with navigations on Web UI pages. Pressing links is a [link page transition](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/renderer_host/navigator.cc;l=860;drc=0c8ffbe78dc0ef2047849e45cefb3f621043e956) while calling `loadURL` uses [a different page transition type.](https://github.com/electron/electron/blob/fcdd5cba71b82c13c4f64a3e529dea91ed72d23c/shell/browser/api/electron_api_web_contents.cc#L2385-L2386)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed "will-navigate" not being emitted when pressing links in `chrome:` pages.
