### PR TITLE
fix: crash when unloading some WebViews

### DIFF
--- a/shell/browser/web_view_guest_delegate.cc
+++ b/shell/browser/web_view_guest_delegate.cc
@@ -40,10 +40,6 @@ void WebViewGuestDelegate::AttachToIframe(
 
   content::WebContents* guest_web_contents = api_web_contents_->web_contents();
 
-  // Force a refresh of the webPreferences so that OverrideWebkitPrefs runs on
-  // the new web contents before the renderer process initializes.
-  // guest_web_contents->NotifyPreferencesChanged();
-
   // Attach this inner WebContents |guest_web_contents| to the outer
   // WebContents |embedder_web_contents|. The outer WebContents's
   // frame |embedder_frame| hosts the inner WebContents.
@@ -76,15 +72,18 @@ content::WebContents* WebViewGuestDelegate::GetOwnerWebContents() {
 void WebViewGuestDelegate::OnZoomChanged(
     const WebContentsZoomController::ZoomChangedEventData& data) {
   if (data.web_contents == GetOwnerWebContents()) {
+    auto* zoom_controller = api_web_contents_->GetZoomController();
     if (data.temporary) {
-      api_web_contents_->GetZoomController()->SetTemporaryZoomLevel(
-          data.new_zoom_level);
+      zoom_controller->SetTemporaryZoomLevel(data.new_zoom_level);
     } else {
-      api_web_contents_->GetZoomController()->SetZoomLevel(data.new_zoom_level);
+      if (blink::PageZoomValuesEqual(data.new_zoom_level,
+                                     zoom_controller->GetZoomLevel()))
+        return;
+      zoom_controller->SetZoomLevel(data.new_zoom_level);
     }
     // Change the default zoom factor to match the embedders' new zoom level.
     double zoom_factor = blink::PageZoomLevelToZoomFactor(data.new_zoom_level);
-    api_web_contents_->GetZoomController()->SetDefaultZoomFactor(zoom_factor);
+    zoom_controller->SetDefaultZoomFactor(zoom_factor);
   }
 }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/40391.
Refs https://github.com/electron/electron/pull/39428.

Fixes an issue where WebViews could sometimes crash on unload as a result of recent changes made to WebContentsZoomController. Previously, we called back to observers in several fewer places, and when I updated the ZoomController impl, I didn't pull in changes to [`guest_view_base.cc`](https://source.chromium.org/chromium/chromium/src/+/main:components/guest_view/browser/guest_view_base.cc) which handle potential looping as a result of these events by early-exiting if the new zoom level isn't different.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where WebViews could sometimes crash on unload.