### PR TITLE
ci: close previous release project board after creating new one

### DIFF
--- a/.github/workflows/branch-created.yml
+++ b/.github/workflows/branch-created.yml
@@ -78,6 +78,7 @@ jobs:
             core.setOutput("major", major)
             core.setOutput("next-major", nextMajor)
             core.setOutput("prev-major", prevMajor)
+            core.setOutput("prev-prev-major", prevMajor - 1)
             core.setOutput("template-view", JSON.stringify({
                 major,
                 "next-major": nextMajor,
@@ -100,7 +101,7 @@ jobs:
         uses: dsanders11/project-actions/find-project@3a81985616963f32fae17d1d1b406c631f3201a1 # v1.1.0
         id: find-prev-release-board
         with:
-          title: ${{ steps.generate-project-metadata.outputs.prev-major }}-x-y
+          title: ${{ steps.generate-project-metadata.outputs.prev-prev-major }}-x-y
       - name: Close Previous Release Project Board
         if: ${{ steps.check-major-version.outputs.MAJOR }}
         uses: dsanders11/project-actions/close-project@3a81985616963f32fae17d1d1b406c631f3201a1 # v1.1.0

--- a/.github/workflows/branch-created.yml
+++ b/.github/workflows/branch-created.yml
@@ -72,21 +72,37 @@ jobs:
         with:
           script: |
             const major = ${{ steps.check-major-version.outputs.MAJOR }}
+            const nextMajor = major + 1
+            const prevMajor = major - 1
 
+            core.setOutput("major", major)
+            core.setOutput("next-major", nextMajor)
+            core.setOutput("prev-major", prevMajor)
             core.setOutput("template-view", JSON.stringify({
                 major,
-                "next-major": major + 1,
-                "prev-major": major - 1,
+                "next-major": nextMajor,
+                "prev-major": prevMajor,
             }))
-            core.setOutput("title", `${major}-x-y`)
       - name: Create Release Project Board
         if: ${{ steps.check-major-version.outputs.MAJOR }}
-        uses: dsanders11/project-actions/copy-project@a24415515fa60a22f71f9d9d00e36ca82660cde9 # v1.0.1
+        uses: dsanders11/project-actions/copy-project@3a81985616963f32fae17d1d1b406c631f3201a1 # v1.1.0
         with:
           drafts: true
           project-number: 64
           # TODO - Set to public once GitHub fixes their GraphQL bug
           # public: true
+          link-to-repository: electron/electron
           template-view: ${{ steps.generate-project-metadata.outputs.template-view }}
-          title: ${{ steps.generate-project-metadata.outputs.title}}
+          title: ${{ steps.generate-project-metadata.outputs.major }}-x-y
           token: ${{ steps.generate-token.outputs.token }}
+      - name: Find Previous Release Project Board
+        if: ${{ steps.check-major-version.outputs.MAJOR }}
+        uses: dsanders11/project-actions/find-project@3a81985616963f32fae17d1d1b406c631f3201a1 # v1.1.0
+        id: find-prev-release-board
+        with:
+          title: ${{ steps.generate-project-metadata.outputs.prev-major }}-x-y
+      - name: Close Previous Release Project Board
+        if: ${{ steps.check-major-version.outputs.MAJOR }}
+        uses: dsanders11/project-actions/close-project@3a81985616963f32fae17d1d1b406c631f3201a1 # v1.1.0
+        with:
+          project-number: ${{ steps.find-prev-release-board.outputs.number }}


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Automates the closing of the previous release project board after creating the new one so that they don't build up.

Also sets the `link-to-repository` input when creating the new release project board, since I forgot that previously.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
