### PR TITLE
fix: broken shader cache due to compilation error

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -138,3 +138,5 @@ cherry-pick-d756d71a652c.patch
 parameterize_axtreeserializer_by_vector_type.patch
 avoid_allocating_recordid_objects_in_elementtiming_and_lcp.patch
 cherry-pick-80106e31c7ea.patch
+gpu_use_load_program_shader_shm_count_on_drdc_thread.patch
+crash_gpu_process_and_clear_shader_cache_when_skia_reports.patch

--- a/patches/chromium/crash_gpu_process_and_clear_shader_cache_when_skia_reports.patch
+++ b/patches/chromium/crash_gpu_process_and_clear_shader_cache_when_skia_reports.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: deepak1556 <hop2deep@gmail.com>
+Date: Sun, 5 Nov 2023 21:05:04 +0900
+Subject: Crash GPU process and clear shader cache when skia reports
+ compileError.
+
+Refs https://chromium-review.googlesource.com/c/chromium/src/+/4988290
+
+diff --git a/gpu/command_buffer/service/shared_context_state.cc b/gpu/command_buffer/service/shared_context_state.cc
+index c0d19ba3e2ba35d801d33240d9c845eb7cdb4fc1..c37f24925cb59a265e7bbbf03a3f16ca550287d5 100644
+--- a/gpu/command_buffer/service/shared_context_state.cc
++++ b/gpu/command_buffer/service/shared_context_state.cc
+@@ -4,6 +4,7 @@
+ 
+ #include "gpu/command_buffer/service/shared_context_state.h"
+ 
++#include "base/immediate_crash.h"
+ #include "base/observer_list.h"
+ #include "base/strings/stringprintf.h"
+ #include "base/system/sys_info.h"
+@@ -84,6 +85,12 @@ void SharedContextState::compileError(const char* shader, const char* errors) {
+                << "------------------------\n"
+                << shader << "\nErrors:\n"
+                << errors;
++    // Increase shader cache shm count and crash the GPU process so that the
++    // browser process would clear the cache.
++    GpuProcessActivityFlags::ScopedSetFlag set_flag(
++        activity_flags_.get(), ActivityFlagsBase::FLAG_LOADING_PROGRAM_BINARY);
++
++    base::ImmediateCrash();
+   }
+ }
+ 
+@@ -273,6 +280,7 @@ bool SharedContextState::InitializeGanesh(
+     gl::ProgressReporter* progress_reporter) {
+   progress_reporter_ = progress_reporter;
+   gr_shader_cache_ = cache;
++  activity_flags_ = activity_flags;
+ 
+   size_t max_resource_cache_bytes;
+   size_t glyph_cache_max_texture_bytes;
+diff --git a/gpu/command_buffer/service/shared_context_state.h b/gpu/command_buffer/service/shared_context_state.h
+index b493316b8667ca1ff66e07eacc4b42091b7b212b..6ffd0bb55cf2f6e4eb66e4ba2ad19b29a014c21d 100644
+--- a/gpu/command_buffer/service/shared_context_state.h
++++ b/gpu/command_buffer/service/shared_context_state.h
+@@ -387,6 +387,8 @@ class GPU_GLES2_EXPORT SharedContextState
+   std::vector<uint8_t> scratch_deserialization_buffer_;
+   raw_ptr<gpu::raster::GrShaderCache, DanglingUntriaged> gr_shader_cache_ =
+       nullptr;
++  raw_ptr<GpuProcessActivityFlags, DanglingUntriaged> activity_flags_ =
++      nullptr;
+ 
+   // |need_context_state_reset| is set whenever Skia may have altered the
+   // driver's GL state.

--- a/patches/chromium/gpu_use_load_program_shader_shm_count_on_drdc_thread.patch
+++ b/patches/chromium/gpu_use_load_program_shader_shm_count_on_drdc_thread.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: deepak1556 <hop2deep@gmail.com>
+Date: Sun, 5 Nov 2023 18:22:15 +0900
+Subject: gpu: Use load_program_shader_shm_count on DrDC thread
+
+Refs https://chromium-review.googlesource.com/c/chromium/src/+/4766018
+
+diff --git a/components/viz/service/display_embedder/compositor_gpu_thread.cc b/components/viz/service/display_embedder/compositor_gpu_thread.cc
+index a9ca58db18823c09457eb89eb9776ce51ec668b2..d8384bddd7ebd45c5fa87ddb7af10c967db9ac25 100644
+--- a/components/viz/service/display_embedder/compositor_gpu_thread.cc
++++ b/components/viz/service/display_embedder/compositor_gpu_thread.cc
+@@ -207,7 +207,8 @@ CompositorGpuThread::GetSharedContextState() {
+   // Initialize Skia.
+   if (!shared_context_state->InitializeSkia(
+           gpu_preferences, workarounds, gpu_channel_manager_->gr_shader_cache(),
+-          /*activity_flags=*/nullptr, /*progress_reporter=*/nullptr)) {
++          gpu_channel_manager_->activity_flags(),
++          /*progress_reporter=*/nullptr)) {
+     LOG(ERROR) << "Failed to Initialize Skia for DrDC SharedContextState";
+   }
+   shared_context_state_ = std::move(shared_context_state);


### PR DESCRIPTION
#### Description of Change

Backports https://github.com/electron/electron/pull/40450

The patch is different from the backport PR mainly because the atomic count `use_shader_cache_shm_count` was introduced in Chromium 118 as part of https://chromium-review.googlesource.com/c/chromium/src/+/4762849. There are no behavior changes between the count and the flag as you can see in the CL. I tried to keep the backport minimal by replicating the change from https://chromium-review.googlesource.com/c/chromium/src/+/4988290 using the atomic flag instead.

#### Release Notes

Notes: Fix rendering on Linux due to broken shader cache compilation with driver updates
