### PR TITLE
build: fix building content_unittests

### DIFF
--- a/patches/chromium/allow_disabling_blink_scheduler_throttling_per_renderview.patch
+++ b/patches/chromium/allow_disabling_blink_scheduler_throttling_per_renderview.patch
@@ -5,6 +5,23 @@ Subject: allow disabling blink scheduler throttling per RenderView
 
 This allows us to disable throttling for hidden windows.
 
+diff --git a/content/browser/renderer_host/navigation_controller_impl_unittest.cc b/content/browser/renderer_host/navigation_controller_impl_unittest.cc
+index 1e9ee2d6e96e61f69a5942377971e0f638a1ac01..33129b6f7606d032cf012801aca48550b09e09fa 100644
+--- a/content/browser/renderer_host/navigation_controller_impl_unittest.cc
++++ b/content/browser/renderer_host/navigation_controller_impl_unittest.cc
+@@ -160,6 +160,12 @@ class MockPageBroadcast : public blink::mojom::PageBroadcast {
+               (network::mojom::AttributionSupport support),
+               (override));
+ 
++  MOCK_METHOD(
++      void,
++      SetSchedulerThrottling,
++      (bool allowed),
++      (override));
++
+   mojo::PendingAssociatedRemote<blink::mojom::PageBroadcast> GetRemote() {
+     return receiver_.BindNewEndpointAndPassDedicatedRemote();
+   }
 diff --git a/content/browser/renderer_host/render_view_host_impl.cc b/content/browser/renderer_host/render_view_host_impl.cc
 index 093bed2d057df4b12ae01b8edc11c7924233b0c5..43a24c45bc5adf1bb6a3eb00c3b3ad64e663522f 100644
 --- a/content/browser/renderer_host/render_view_host_impl.cc

--- a/patches/chromium/build_only_use_the_mas_build_config_in_the_required_components.patch
+++ b/patches/chromium/build_only_use_the_mas_build_config_in_the_required_components.patch
@@ -110,7 +110,7 @@ index 697fa7c5e98e7ee16b1b5e676f60a9689f7aac2b..f5e7278a6e391cbab61bbd2981127beb
  
    public_deps = [
 diff --git a/content/test/BUILD.gn b/content/test/BUILD.gn
-index 0967c510f870a6b66f0b577521e2d8df61f0c68d..317c8b68e2d5fb62ae73eec867d6c52a7132ff3c 100644
+index 0967c510f870a6b66f0b577521e2d8df61f0c68d..e533490c0001ff3f0a3ffe4369215ca1510c408c 100644
 --- a/content/test/BUILD.gn
 +++ b/content/test/BUILD.gn
 @@ -482,6 +482,7 @@ static_library("test_support") {
@@ -121,6 +121,14 @@ index 0967c510f870a6b66f0b577521e2d8df61f0c68d..317c8b68e2d5fb62ae73eec867d6c52a
    ]
  
    public_deps = [
+@@ -2916,6 +2917,7 @@ test("content_unittests") {
+   }
+ 
+   configs += [ "//build/config:precompiled_headers" ]
++  configs += ["//electron/build/config:mas_build"]
+ 
+   public_deps = [ "//content:content_resources" ]
+ 
 diff --git a/content/web_test/BUILD.gn b/content/web_test/BUILD.gn
 index e2a496c7be6045d0a69d4fdf227e4951602620ae..1fa040e47d6acdfcac203e30af88d5ac2db6e03f 100644
 --- a/content/web_test/BUILD.gn

--- a/patches/chromium/expose_setuseragent_on_networkcontext.patch
+++ b/patches/chromium/expose_setuseragent_on_networkcontext.patch
@@ -77,10 +77,10 @@ index 3ef031b0c876c36c51a91ba9724f8f2fd7b455ac..646d9276a9ca6a55cfcb156380bd9435
    SetAcceptLanguage(string new_accept_language);
  
 diff --git a/services/network/test/test_network_context.h b/services/network/test/test_network_context.h
-index a133f8b85fce871219963bbcc428f1e7a0c97a2c..d6ea67709877567ad83c5d25e7d2936647f184ff 100644
+index 5a15e699f24f0691f6d45c0e9f4dcf6f97944e31..462c432f36976b3dcc34fdc45515de9fb1f89524 100644
 --- a/services/network/test/test_network_context.h
 +++ b/services/network/test/test_network_context.h
-@@ -145,6 +145,7 @@ class TestNetworkContext : public mojom::NetworkContext {
+@@ -147,6 +147,7 @@ class TestNetworkContext : public mojom::NetworkContext {
    void CloseIdleConnections(CloseIdleConnectionsCallback callback) override {}
    void SetNetworkConditions(const base::UnguessableToken& throttling_profile_id,
                              mojom::NetworkConditionsPtr conditions) override {}

--- a/patches/chromium/network_service_allow_remote_certificate_verification_logic.patch
+++ b/patches/chromium/network_service_allow_remote_certificate_verification_logic.patch
@@ -208,3 +208,16 @@ index e696f8197cd9f5e158c148a207ae1398dd16c526..3ef031b0c876c36c51a91ba9724f8f2f
    // Creates a new URLLoaderFactory with the given |params|.
    CreateURLLoaderFactory(pending_receiver<URLLoaderFactory> url_loader_factory,
                           URLLoaderFactoryParams params);
+diff --git a/services/network/test/test_network_context.h b/services/network/test/test_network_context.h
+index a133f8b85fce871219963bbcc428f1e7a0c97a2c..5a15e699f24f0691f6d45c0e9f4dcf6f97944e31 100644
+--- a/services/network/test/test_network_context.h
++++ b/services/network/test/test_network_context.h
+@@ -62,6 +62,8 @@ class TestNetworkContext : public mojom::NetworkContext {
+   void CreateURLLoaderFactory(
+       mojo::PendingReceiver<mojom::URLLoaderFactory> receiver,
+       mojom::URLLoaderFactoryParamsPtr params) override {}
++  void SetCertVerifierClient(
++      mojo::PendingRemote<mojom::CertVerifierClient> client) override {}
+   void GetCookieManager(
+       mojo::PendingReceiver<mojom::CookieManager> cookie_manager) override {}
+   void GetRestrictedCookieManager(


### PR DESCRIPTION
#### Description of Change

Slightly modify the patches so the `content_unittests` target can be built, which is very helpful when upstreaming patches to Chromium.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none