### PR TITLE
feat: add/update missing Display properties

### DIFF
--- a/docs/api/structures/display.md
+++ b/docs/api/structures/display.md
@@ -1,22 +1,25 @@
 # Display Object
 
-* `id` number - Unique identifier associated with the display.
+* `accelerometerSupport` string - Can be `available`, `unavailable`, `unknown`.
+* `bounds` [Rectangle](rectangle.md) - the bounds of the display in DIP points.
+* `colorDepth` number - The number of bits per pixel.
+* `colorSpace` string -  represent a color space (three-dimensional object which contains all realizable color combinations) for the purpose of color conversions.
+* `depthPerComponent` number - The number of bits per color component.
+* `detected` boolean - `true`` if the display is detected by the system.
+* `displayFrequency` number - The display refresh rate.
+* `id` number - Unique identifier associated with the display. A value of of -1 means the display is invalid or the correct `id` is not yet known, and a value of -10 means the display is a virtual display assigned to a unified desktop.
+* `internal` boolean - `true` for an internal display and `false` for an external display.
 * `label` string - User-friendly label, determined by the platform.
+* `maximumCursorSize` [Size](size.md) - Maximum cursor size in native pixels.
+* `nativeOrigin` [Point](point.md) - Returns the display's origin in pixel coordinates. Only available on windowing systems like X11 that position displays in pixel coordinates.
 * `rotation` number - Can be 0, 90, 180, 270, represents screen rotation in
   clock-wise degrees.
 * `scaleFactor` number - Output device's pixel scale factor.
 * `touchSupport` string - Can be `available`, `unavailable`, `unknown`.
 * `monochrome` boolean - Whether or not the display is a monochrome display.
-* `accelerometerSupport` string - Can be `available`, `unavailable`, `unknown`.
-* `colorSpace` string -  represent a color space (three-dimensional object which contains all realizable color combinations) for the purpose of color conversions
-* `colorDepth` number - The number of bits per pixel.
-* `depthPerComponent` number - The number of bits per color component.
-* `displayFrequency` number - The display refresh rate.
-* `bounds` [Rectangle](rectangle.md) - the bounds of the display in DIP points.
 * `size` [Size](size.md)
 * `workArea` [Rectangle](rectangle.md) - the work area of the display in DIP points.
-* `workAreaSize` [Size](size.md)
-* `internal` boolean - `true` for an internal display and `false` for an external display
+* `workAreaSize` [Size](size.md) - The size of the work area.
 
 The `Display` object represents a physical display connected to the system. A
 fake `Display` may exist on a headless system, or a `Display` may correspond to

--- a/shell/common/gin_converters/gfx_converter.cc
+++ b/shell/common/gin_converters/gfx_converter.cc
@@ -138,21 +138,24 @@ v8::Local<v8::Value> Converter<display::Display>::ToV8(
     v8::Isolate* isolate,
     const display::Display& val) {
   auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-  dict.Set("id", val.id());
-  dict.Set("label", val.label());
-  dict.Set("bounds", val.bounds());
-  dict.Set("workArea", val.work_area());
   dict.Set("accelerometerSupport", val.accelerometer_support());
-  dict.Set("monochrome", val.is_monochrome());
+  dict.Set("bounds", val.bounds());
   dict.Set("colorDepth", val.color_depth());
   dict.Set("colorSpace", val.GetColorSpaces().GetRasterColorSpace().ToString());
   dict.Set("depthPerComponent", val.depth_per_component());
-  dict.Set("size", val.size());
+  dict.Set("detected", val.detected());
   dict.Set("displayFrequency", val.display_frequency());
-  dict.Set("workAreaSize", val.work_area_size());
-  dict.Set("scaleFactor", val.device_scale_factor());
-  dict.Set("rotation", val.RotationAsDegree());
+  dict.Set("id", val.id());
   dict.Set("internal", val.IsInternal());
+  dict.Set("label", val.label());
+  dict.Set("maximumCursorSize", val.maximum_cursor_size());
+  dict.Set("monochrome", val.is_monochrome());
+  dict.Set("nativeOrigin", val.native_origin());
+  dict.Set("rotation", val.RotationAsDegree());
+  dict.Set("scaleFactor", val.device_scale_factor());
+  dict.Set("size", val.size());
+  dict.Set("workArea", val.work_area());
+  dict.Set("workAreaSize", val.work_area_size());
   dict.Set("touchSupport", val.touch_support());
   return dict.GetHandle();
 }

--- a/spec/api-screen-spec.ts
+++ b/spec/api-screen-spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
-import { screen } from 'electron/main';
-import { ifit } from './lib/spec-helpers';
+import { Display, screen } from 'electron/main';
 
 describe('screen module', () => {
   describe('methods reassignment', () => {
@@ -24,62 +23,100 @@ describe('screen module', () => {
   });
 
   describe('screen.getPrimaryDisplay()', () => {
+    let display: Display | null = null;
+
+    beforeEach(() => {
+      display = screen.getPrimaryDisplay();
+    });
+
+    afterEach(() => {
+      display = null;
+    });
+
     it('returns a display object', () => {
-      const display = screen.getPrimaryDisplay();
       expect(display).to.be.an('object');
     });
 
-    ifit(process.platform !== 'linux')('has the correct non-object properties', function () {
-      const display = screen.getPrimaryDisplay();
-
-      expect(display).to.have.property('scaleFactor').that.is.a('number');
-      expect(display).to.have.property('id').that.is.a('number');
-      expect(display).to.have.property('label').that.is.a('string');
-      expect(display).to.have.property('rotation').that.is.a('number');
-      expect(display).to.have.property('touchSupport').that.is.a('string');
+    it('has the correct non-object properties', function () {
       expect(display).to.have.property('accelerometerSupport').that.is.a('string');
-      expect(display).to.have.property('internal').that.is.a('boolean');
-      expect(display).to.have.property('monochrome').that.is.a('boolean');
-      expect(display).to.have.property('depthPerComponent').that.is.a('number');
       expect(display).to.have.property('colorDepth').that.is.a('number');
       expect(display).to.have.property('colorSpace').that.is.a('string');
+      expect(display).to.have.property('depthPerComponent').that.is.a('number');
+      expect(display).to.have.property('detected').that.is.a('boolean');
       expect(display).to.have.property('displayFrequency').that.is.a('number');
+      expect(display).to.have.property('id').that.is.a('number');
+      expect(display).to.have.property('internal').that.is.a('boolean');
+      expect(display).to.have.property('label').that.is.a('string');
+      expect(display).to.have.property('monochrome').that.is.a('boolean');
+      expect(display).to.have.property('scaleFactor').that.is.a('number');
+      expect(display).to.have.property('rotation').that.is.a('number');
+      expect(display).to.have.property('touchSupport').that.is.a('string');
     });
 
-    ifit(process.platform !== 'linux')('has a size object property', function () {
-      const display = screen.getPrimaryDisplay();
+    it('has a maximumCursorSize object property', () => {
+      expect(display).to.have.property('maximumCursorSize').that.is.an('object');
 
+      const { maximumCursorSize } = display!;
+      expect(maximumCursorSize).to.have.property('width').that.is.a('number');
+      expect(maximumCursorSize).to.have.property('height').that.is.a('number');
+    });
+
+    it('has a nativeOrigin object property', () => {
+      expect(display).to.have.property('nativeOrigin').that.is.an('object');
+
+      const { nativeOrigin } = display!;
+      expect(nativeOrigin).to.have.property('x').that.is.a('number');
+      expect(nativeOrigin).to.have.property('y').that.is.a('number');
+    });
+
+    it('has a size object property', () => {
       expect(display).to.have.property('size').that.is.an('object');
-      const size = display.size;
-      expect(size).to.have.property('width').that.is.greaterThan(0);
-      expect(size).to.have.property('height').that.is.greaterThan(0);
+
+      const { size } = display!;
+
+      if (process.platform === 'linux') {
+        expect(size).to.have.property('width').that.is.a('number');
+        expect(size).to.have.property('height').that.is.a('number');
+      } else {
+        expect(size).to.have.property('width').that.is.greaterThan(0);
+        expect(size).to.have.property('height').that.is.greaterThan(0);
+      }
     });
 
-    ifit(process.platform !== 'linux')('has a workAreaSize object property', function () {
-      const display = screen.getPrimaryDisplay();
-
+    it('has a workAreaSize object property', () => {
       expect(display).to.have.property('workAreaSize').that.is.an('object');
-      const workAreaSize = display.workAreaSize;
-      expect(workAreaSize).to.have.property('width').that.is.greaterThan(0);
-      expect(workAreaSize).to.have.property('height').that.is.greaterThan(0);
+
+      const { workAreaSize } = display!;
+
+      if (process.platform === 'linux') {
+        expect(workAreaSize).to.have.property('width').that.is.a('number');
+        expect(workAreaSize).to.have.property('height').that.is.a('number');
+      } else {
+        expect(workAreaSize).to.have.property('width').that.is.greaterThan(0);
+        expect(workAreaSize).to.have.property('height').that.is.greaterThan(0);
+      }
     });
 
-    ifit(process.platform !== 'linux')('has a bounds object property', function () {
-      const display = screen.getPrimaryDisplay();
-
+    it('has a bounds object property', () => {
       expect(display).to.have.property('bounds').that.is.an('object');
-      const bounds = display.bounds;
+
+      const { bounds } = display!;
       expect(bounds).to.have.property('x').that.is.a('number');
       expect(bounds).to.have.property('y').that.is.a('number');
-      expect(bounds).to.have.property('width').that.is.greaterThan(0);
-      expect(bounds).to.have.property('height').that.is.greaterThan(0);
+
+      if (process.platform === 'linux') {
+        expect(bounds).to.have.property('width').that.is.a('number');
+        expect(bounds).to.have.property('height').that.is.a('number');
+      } else {
+        expect(bounds).to.have.property('width').that.is.greaterThan(0);
+        expect(bounds).to.have.property('height').that.is.greaterThan(0);
+      }
     });
 
-    it('has a workArea object property', function () {
-      const display = screen.getPrimaryDisplay();
-
+    it('has a workArea object property', () => {
       expect(display).to.have.property('workArea').that.is.an('object');
-      const workArea = display.workArea;
+
+      const { workArea } = display!;
       expect(workArea).to.have.property('x').that.is.a('number');
       expect(workArea).to.have.property('y').that.is.a('number');
       expect(workArea).to.have.property('width').that.is.greaterThan(0);


### PR DESCRIPTION
#### Description of Change

This PR adds missing `display` properties [upstream](https://source.chromium.org/chromium/chromium/src/+/main:ui/display/display.h;l=210;drc=7fa0c25da15ae39bbd2fd720832ec4df4fee705a;bpv=1;bpt=1?q=display::Display&sq=package:chromium&type=cs) as well as corresponding tests. Also alphabetizes the properties in docs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: This PR adds several properties to the `display` object including `detected`, `maximumCursorSize`, and `nativeOrigin`.