### PR TITLE
fix: maximized window bounds when toggle setResizable

### DIFF
--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -190,6 +190,8 @@ class NativeWindowViews : public NativeWindow,
   void set_overlay_symbol_color(SkColor color) {
     overlay_symbol_color_ = color;
   }
+
+  void UpdateThickFrame();
 #endif
 
  private:

--- a/shell/browser/ui/win/electron_desktop_native_widget_aura.cc
+++ b/shell/browser/ui/win/electron_desktop_native_widget_aura.cc
@@ -30,6 +30,16 @@ void ElectronDesktopNativeWidgetAura::InitNativeWidget(
   views::DesktopNativeWidgetAura::InitNativeWidget(std::move(params));
 }
 
+#if BUILDFLAG(IS_WIN)
+void ElectronDesktopNativeWidgetAura::OnSizeConstraintsChanged() {
+  views::DesktopNativeWidgetAura::OnSizeConstraintsChanged();
+
+  // OnSizeConstraintsChanged can remove thick frame depending from
+  // resizable state, so add it if needed.
+  native_window_view_->UpdateThickFrame();
+}
+#endif
+
 void ElectronDesktopNativeWidgetAura::Activate() {
   // Activate can cause the focused window to be blurred so only
   // call when the window being activated is visible. This prevents

--- a/shell/browser/ui/win/electron_desktop_native_widget_aura.h
+++ b/shell/browser/ui/win/electron_desktop_native_widget_aura.h
@@ -27,6 +27,9 @@ class ElectronDesktopNativeWidgetAura : public views::DesktopNativeWidgetAura {
 
   // views::DesktopNativeWidgetAura:
   void InitNativeWidget(views::Widget::InitParams params) override;
+#if BUILDFLAG(IS_WIN)
+  void OnSizeConstraintsChanged() override;
+#endif
 
   // internal::NativeWidgetPrivate:
   void Activate() override;

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5071,6 +5071,55 @@ describe('BrowserWindow module', () => {
         w.setContentSize(10, 10);
         expectBoundsEqual(w.getContentSize(), [10, 10]);
       });
+
+      ifit(process.platform === 'win32')('do not change window with frame bounds when maximized', () => {
+        const w = new BrowserWindow({
+          show: true,
+          frame: true,
+          thickFrame: true
+        });
+        expect(w.isResizable()).to.be.true('resizable');
+        w.maximize();
+        expect(w.isMaximized()).to.be.true('maximized');
+        const bounds = w.getBounds();
+        w.setResizable(false);
+        expectBoundsEqual(w.getBounds(), bounds);
+        w.setResizable(true);
+        expectBoundsEqual(w.getBounds(), bounds);
+      });
+
+      ifit(process.platform === 'win32')('do not change window without frame bounds when maximized', () => {
+        const w = new BrowserWindow({
+          show: true,
+          frame: false,
+          thickFrame: true
+        });
+        expect(w.isResizable()).to.be.true('resizable');
+        w.maximize();
+        expect(w.isMaximized()).to.be.true('maximized');
+        const bounds = w.getBounds();
+        w.setResizable(false);
+        expectBoundsEqual(w.getBounds(), bounds);
+        w.setResizable(true);
+        expectBoundsEqual(w.getBounds(), bounds);
+      });
+
+      ifit(process.platform === 'win32')('do not change window transparent without frame bounds when maximized', () => {
+        const w = new BrowserWindow({
+          show: true,
+          frame: false,
+          thickFrame: true,
+          transparent: true
+        });
+        expect(w.isResizable()).to.be.true('resizable');
+        w.maximize();
+        expect(w.isMaximized()).to.be.true('maximized');
+        const bounds = w.getBounds();
+        w.setResizable(false);
+        expectBoundsEqual(w.getBounds(), bounds);
+        w.setResizable(true);
+        expectBoundsEqual(w.getBounds(), bounds);
+      });
     });
 
     describe('loading main frame state', () => {


### PR DESCRIPTION
#### Description of Change

Currently when we toggle setResizable function on maximized window then this window will change bounds and will not be equal to screen bounds.
This is happening because when we toggle setResizable then also HWNDMessageHandler::SizeConstraintsChanged() is called, where WS_THICKFRAME window style is removed.
Solution for this issue is to add WS_THICKFRAME for maximized window even if window is not resizable.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix problem with bounds of maximized window when  toggle BrowserWindow.setResizable function. <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
