### PR TITLE
fix: ShowItemUsingFileManager should escape path in Linux

### DIFF
--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -21,6 +21,7 @@
 #include "base/posix/eintr_wrapper.h"
 #include "base/process/kill.h"
 #include "base/process/launch.h"
+#include "base/strings/escape.h"
 #include "base/strings/string_util.h"
 #include "base/threading/thread_restrictions.h"
 #include "components/dbus/thread_linux/dbus_thread_linux.h"
@@ -216,8 +217,9 @@ class ShowItemHelper {
     dbus::MessageWriter writer(&show_items_call);
 
     writer.AppendArrayOfStrings(
-        {"file://" + full_path.value()});  // List of file(s) to highlight.
-    writer.AppendString({});               // startup-id
+        {"file://" + base::EscapePath(
+                         full_path.value())});  // List of file(s) to highlight.
+    writer.AppendString({});                    // startup-id
 
     ShowItemUsingBusCall(&show_items_call, full_path);
   }


### PR DESCRIPTION
#### Description of Change

According to https://edeproject.org/spec/file-uri-spec.txt , strings passed to `org.freedesktop.FileManager1.ShowItems` are regarded as _escaped file paths_:

> The specification for file: URIs, RFC2396[1] and RFC1738[2] says that
file URIs are of the form:
   `file://<hostname>/<path>`
>
> Where the hostname and path parts can contain a limited subset of
ASCII characters, representing their ASCII values, and any other bytes
escaped by using a % followed by a two digit hex value. As a special
case the hostname part can be "localhost" or empty meaning the machine
the URI is being interpreted on.

Hence, we should escape the file path passed in before sending it to dbus.

This will fix https://github.com/microsoft/vscode/issues/198045 .

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed file paths passed to `shell.showItemInFolder` not being escaped in Linux.