### PR TITLE
chore: cherry-pick 1 changes from Release-2-M119

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -142,3 +142,4 @@ gpu_use_load_program_shader_shm_count_on_drdc_thread.patch
 crash_gpu_process_and_clear_shader_cache_when_skia_reports.patch
 cherry-pick-3df423a5b8de.patch
 scale_rects_properly_in_syncgetfirstrectforrange.patch
+cherry-pick-9384cddc7705.patch

--- a/patches/chromium/cherry-pick-9384cddc7705.patch
+++ b/patches/chromium/cherry-pick-9384cddc7705.patch
@@ -1,0 +1,43 @@
+From 9384cddc77054d9935d5a1217ca9510180be0714 Mon Sep 17 00:00:00 2001
+From: Nidhi Jaju <nidhijaju@chromium.org>
+Date: Wed, 08 Nov 2023 04:19:31 +0000
+Subject: [PATCH] [Merge to M118] Make URLSearchParams persistent to avoid UaF
+
+The URLSearchParams::Create() function returns an on-heap object, but it
+can be garbage collected, so making it a persistent variable in
+DidFetchDataLoadedString() mitigates the issue.
+
+(cherry picked from commit 8b1bd7726a1394e2fe287f6a882822d8ee9d4e96)
+
+Bug: 1497997
+Change-Id: I4ae0f93fccc561cd8a088d3fa0bf2968bf298acf
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4996929
+Reviewed-by: Adam Rice <ricea@chromium.org>
+Commit-Queue: Nidhi Jaju <nidhijaju@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1218682}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5007484
+Commit-Queue: Adam Rice <ricea@chromium.org>
+Auto-Submit: Nidhi Jaju <nidhijaju@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5993@{#1546}
+Cr-Branched-From: 511350718e646be62331ae9d7213d10ec320d514-refs/heads/main@{#1192594}
+---
+
+diff --git a/third_party/blink/renderer/core/fetch/body.cc b/third_party/blink/renderer/core/fetch/body.cc
+index 86aac83..4f396c1 100644
+--- a/third_party/blink/renderer/core/fetch/body.cc
++++ b/third_party/blink/renderer/core/fetch/body.cc
+@@ -135,8 +135,13 @@
+ 
+   void DidFetchDataLoadedString(const String& string) override {
+     auto* formData = MakeGarbageCollected<FormData>();
+-    for (const auto& pair : URLSearchParams::Create(string)->Params())
++    // URLSearchParams::Create() returns an on-heap object, but it can be
++    // garbage collected, so making it a persistent variable on the stack
++    // mitigates use-after-free scenarios. See crbug.com/1497997.
++    Persistent<URLSearchParams> search_params = URLSearchParams::Create(string);
++    for (const auto& pair : search_params->Params()) {
+       formData->append(pair.first, pair.second);
++    }
+     DidFetchDataLoadedFormData(formData);
+   }
+ };

--- a/patches/chromium/cherry-pick-9384cddc7705.patch
+++ b/patches/chromium/cherry-pick-9384cddc7705.patch
@@ -1,7 +1,7 @@
-From 9384cddc77054d9935d5a1217ca9510180be0714 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nidhi Jaju <nidhijaju@chromium.org>
-Date: Wed, 08 Nov 2023 04:19:31 +0000
-Subject: [PATCH] [Merge to M118] Make URLSearchParams persistent to avoid UaF
+Date: Wed, 8 Nov 2023 04:19:31 +0000
+Subject: Make URLSearchParams persistent to avoid UaF
 
 The URLSearchParams::Create() function returns an on-heap object, but it
 can be garbage collected, so making it a persistent variable in
@@ -20,13 +20,12 @@ Commit-Queue: Adam Rice <ricea@chromium.org>
 Auto-Submit: Nidhi Jaju <nidhijaju@chromium.org>
 Cr-Commit-Position: refs/branch-heads/5993@{#1546}
 Cr-Branched-From: 511350718e646be62331ae9d7213d10ec320d514-refs/heads/main@{#1192594}
----
 
 diff --git a/third_party/blink/renderer/core/fetch/body.cc b/third_party/blink/renderer/core/fetch/body.cc
-index 86aac83..4f396c1 100644
+index 86aac83becddb7aad0b8172311ccf2cd182bc7e6..4f396c124a1e33772e447e8f8000f31937a57fa6 100644
 --- a/third_party/blink/renderer/core/fetch/body.cc
 +++ b/third_party/blink/renderer/core/fetch/body.cc
-@@ -135,8 +135,13 @@
+@@ -135,8 +135,13 @@ class BodyFormDataConsumer final : public BodyConsumerBase {
  
    void DidFetchDataLoadedString(const String& string) override {
      auto* formData = MakeGarbageCollected<FormData>();


### PR DESCRIPTION
<details>
<summary>electron/security#427 - 9384cddc7705 from chromium</summary>
[Merge to M118] Make URLSearchParams persistent to avoid UaF

The URLSearchParams::Create() function returns an on-heap object, but it
can be garbage collected, so making it a persistent variable in
DidFetchDataLoadedString() mitigates the issue.

(cherry picked from commit 8b1bd7726a1394e2fe287f6a882822d8ee9d4e96)

Bug: 1497997
Change-Id: I4ae0f93fccc561cd8a088d3fa0bf2968bf298acf
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4996929
Reviewed-by: Adam Rice <ricea@chromium.org>
Commit-Queue: Nidhi Jaju <nidhijaju@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1218682}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5007484
Commit-Queue: Adam Rice <ricea@chromium.org>
Auto-Submit: Nidhi Jaju <nidhijaju@chromium.org>
Cr-Commit-Position: refs/branch-heads/5993@{#1546}
Cr-Branched-From: 511350718e646be62331ae9d7213d10ec320d514-refs/heads/main@{#1192594}
</details>

Notes:
* Security: backported fix for CVE-2023-5997.