### PR TITLE
docs: wording in IPC tutorial docs

### DIFF
--- a/docs/tutorial/ipc.md
+++ b/docs/tutorial/ipc.md
@@ -280,8 +280,8 @@ selected file path in the `#filePath` element.
 ### Note: legacy approaches
 
 The `ipcRenderer.invoke` API was added in Electron 7 as a developer-friendly way to tackle two-way
-IPC from the renderer process. However, there exist a couple alternative approaches to this IPC
-pattern.
+IPC from the renderer process. However, a couple of alternative approaches to this IPC pattern
+exist.
 
 :::warning Avoid legacy approaches if possible
 We recommend using `ipcRenderer.invoke` whenever possible. The following two-way renderer-to-main


### PR DESCRIPTION
Description of Change

A very minor grammar fix update to wording in the IPC tutorial.

cc @electron/docs

Checklist

- [x] PR description included and stakeholders cc'd

Release Notes
Notes: none