### PR TITLE
docs: `browserView.webContents` can be `null`

### DIFF
--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -41,7 +41,7 @@ Objects created with `new BrowserView` have the following properties:
 
 #### `view.webContents` _Experimental_
 
-A `WebContents | null` property that returns the `WebContents` owned by this view or `null` if the contents are [destroyed](web-contents.md#event-destroyed). 
+A `WebContents | null` property that returns the `WebContents` owned by this view or `null` if the contents are [destroyed](web-contents.md#event-destroyed).
 
 ### Instance Methods
 

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -41,8 +41,7 @@ Objects created with `new BrowserView` have the following properties:
 
 #### `view.webContents` _Experimental_
 
-Returns `WebContents | null` - The `WebContents` owned by this view
-or `null` if the contents are [destroyed](web-contents.md#event-destroyed).
+Returns `WebContents | null` - The `WebContents` owned by this view or `null` if the contents are [destroyed](web-contents.md#event-destroyed).
 
 ### Instance Methods
 

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -41,7 +41,7 @@ Objects created with `new BrowserView` have the following properties:
 
 #### `view.webContents` _Experimental_
 
-Returns `WebContents | null` - The [web contents](web-contents.md) object owned by this view, or `null` when web contents were [destroyed](web-contents.md#event-destroyed).
+Returns `WebContents | null` - The [`webContents`](web-contents.md) object owned by this view, or `null` when web contents were [destroyed](web-contents.md#event-destroyed).
 
 ### Instance Methods
 

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -41,7 +41,10 @@ Objects created with `new BrowserView` have the following properties:
 
 #### `view.webContents` _Experimental_
 
-Returns `WebContents | null` - The [`webContents`](web-contents.md) object owned by this view, or `null` when web contents were [destroyed](web-contents.md#event-destroyed).
+* `webContents` [WebContents](web-contents.md)
+
+Returns `BrowserWindow | null` - The `webContents` owned by this view
+or `null` if the contents are [destroyed](web-contents.md#event-destroyed).
 
 ### Instance Methods
 

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -41,7 +41,7 @@ Objects created with `new BrowserView` have the following properties:
 
 #### `view.webContents` _Experimental_
 
-Returns `WebContents | null` - The `WebContents` owned by this view or `null` if the contents are [destroyed](web-contents.md#event-destroyed).
+A `WebContents | null` property that returns the `WebContents` owned by this view or `null` if the contents are [destroyed](web-contents.md#event-destroyed). 
 
 ### Instance Methods
 

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -43,7 +43,7 @@ Objects created with `new BrowserView` have the following properties:
 
 * `webContents` [WebContents](web-contents.md)
 
-Returns `BrowserWindow | null` - The `webContents` owned by this view
+Returns `WebContents | null` - The `WebContents` owned by this view
 or `null` if the contents are [destroyed](web-contents.md#event-destroyed).
 
 ### Instance Methods

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -41,8 +41,6 @@ Objects created with `new BrowserView` have the following properties:
 
 #### `view.webContents` _Experimental_
 
-* `webContents` [WebContents](web-contents.md)
-
 Returns `WebContents | null` - The `WebContents` owned by this view
 or `null` if the contents are [destroyed](web-contents.md#event-destroyed).
 

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -41,7 +41,7 @@ Objects created with `new BrowserView` have the following properties:
 
 #### `view.webContents` _Experimental_
 
-A [`WebContents`](web-contents.md) object owned by this view.
+Returns `WebContents | null` - The [web contents](web-contents.md) object owned by this view, or `null` when web contents were [destroyed](web-contents.md#event-destroyed).
 
 ### Instance Methods
 

--- a/lib/browser/api/browser-window.ts
+++ b/lib/browser/api/browser-window.ts
@@ -93,7 +93,7 @@ BrowserWindow.fromWebContents = (webContents: WebContents) => {
 BrowserWindow.fromBrowserView = (browserView: BrowserView) => {
   const { webContents } = browserView;
   if (!webContents) return null;
-  return BrowserWindow.fromWebContents(browserView.webContents);
+  return BrowserWindow.fromWebContents(webContents);
 };
 
 BrowserWindow.prototype.setTouchBar = function (touchBar) {

--- a/lib/browser/api/browser-window.ts
+++ b/lib/browser/api/browser-window.ts
@@ -91,6 +91,8 @@ BrowserWindow.fromWebContents = (webContents: WebContents) => {
 };
 
 BrowserWindow.fromBrowserView = (browserView: BrowserView) => {
+  const { webContents } = browserView;
+  if (!webContents) return null;
   return BrowserWindow.fromWebContents(browserView.webContents);
 };
 


### PR DESCRIPTION
#### Description of Change

`null` was introduced as a possibility for destroyed `webContents` by @mlaurencin in: https://github.com/electron/electron/pull/25411 

This change updates the documentation (and hopefully the typescript types) to reflect that.

Fixes: https://github.com/electron/electron/issues/40567

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: `browserView.webContents` types now correctly reflects that destroyed `webContents` can be set to `null`
