### PR TITLE
fix: do not call `after()` `async_hook` for `asyncId` 0

### DIFF
--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -278,8 +278,11 @@ void ErrorMessageListener(v8::Local<v8::Message> message,
     // Analogous to node/lib/internal/process/execution.js#L176-L180
     if (env->async_hooks()->fields()[node::AsyncHooks::kAfter]) {
       while (env->async_hooks()->fields()[node::AsyncHooks::kStackLength]) {
-        node::AsyncWrap::EmitAfter(env, env->execution_async_id());
-        env->async_hooks()->pop_async_context(env->execution_async_id());
+        double id = env->execution_async_id();
+        // Do not call EmitAfter for asyncId 0.
+        if (id != 0)
+          node::AsyncWrap::EmitAfter(env, id);
+        env->async_hooks()->pop_async_context(id);
       }
     }
 


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/nodejs/node/pull/41424

We need to keep our handling in [`ErrorMessageListener`](https://github.com/electron/electron/blob/cf5f0419f11516937e43e8259204339dffa22aa4/shell/common/node_bindings.cc#L269-L295) in sync with that in Node.js' [`createOnGlobalUncaughtException()`](https://github.com/nodejs/node/blob/c39b7c240e3b0d31076a81bcdb2a2561a4310df1/lib/internal/process/execution.js#L145-L193).

Fixing incidental to https://github.com/electron/electron/issues/40573, but that is unfortunately a separate issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix a potential issue with `async_hook` corruption in some error contexts.