### PR TITLE
chore: add patch upstream plan for resize patch

### DIFF
--- a/patches/chromium/fix_restore_original_resize_performance_on_macos.patch
+++ b/patches/chromium/fix_restore_original_resize_performance_on_macos.patch
@@ -7,6 +7,9 @@ Reverts https://chromium-review.googlesource.com/c/chromium/src/+/3118293 which
 fixed a android only regression but in the process regressed electron window
 resize perf wildly on macOS.
 
+This patch should be upstreamed as a conditional revert of the logic in desktop
+vs mobile runtimes.  i.e. restore the old logic only on desktop platforms
+
 diff --git a/content/browser/renderer_host/render_widget_host_impl.cc b/content/browser/renderer_host/render_widget_host_impl.cc
 index 749ee4641462aec1142f75de9f0459d7e7cf322f..4dcee366b8bd43add1f7e1dbedaf73403dd944cd 100644
 --- a/content/browser/renderer_host/render_widget_host_impl.cc


### PR DESCRIPTION
Was missing in the OG PR

Notes: none