### PR TITLE
build: fix release notes script bug that omitted edited release-clerk comments

### DIFF
--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -99,7 +99,7 @@ const getNoteFromClerk = async (ghKey) => {
 
   const CLERK_LOGIN = 'release-clerk[bot]';
   const CLERK_NO_NOTES = '**No Release Notes**';
-  const PERSIST_LEAD = '**Release Notes Persisted**\n\n';
+  const PERSIST_LEAD = '**Release Notes Persisted**';
   const QUOTE_LEAD = '> ';
 
   for (const comment of comments.data.reverse()) {
@@ -130,6 +130,8 @@ const getNoteFromClerk = async (ghKey) => {
         .trim();
     }
   }
+
+  console.log(`WARN: no notes found in ${buildPullURL(ghKey)}`);
 };
 
 /**

--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -131,7 +131,7 @@ const getNoteFromClerk = async (ghKey) => {
     }
   }
 
-  console.log(`WARN: no notes found in ${buildPullURL(ghKey)}`);
+  console.warn(`WARN: no notes found in ${buildPullURL(ghKey)}`);
 };
 
 /**


### PR DESCRIPTION
#### Description of Change

This fixes the "some PRs are missing from the notes" issue I mentioned to @mlaurencin earlier today. Apparently, edited comments on GitHub can be stored with `\r\n\r\n` between paragraphs instead of `\n\n`, which broke the `PERSIST_LEAD` check in the notes generator.  Happily, the fix is easy: remove `\n\n` from the test.

I've also added a warning if we ever reach a PR that doesn't have a note _and_ doesn't have a no-note, so any future issues like this one won't fail silently.

CC @mlaurencin @VerteDinde 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none