### PR TITLE
chore: cherry-pick 5 changes from Release-3-M119

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -135,3 +135,6 @@ revert_same_party_cookie_attribute_removal.patch
 crash_gpu_process_and_clear_shader_cache_when_skia_reports.patch
 scale_rects_properly_in_syncgetfirstrectforrange.patch
 fix_restore_original_resize_performance_on_macos.patch
+cherry-pick-3f45b1af5e41.patch
+cherry-pick-e13061c50998.patch
+cherry-pick-6cc0d9aa5b3f.patch

--- a/patches/chromium/cherry-pick-3f45b1af5e41.patch
+++ b/patches/chromium/cherry-pick-3f45b1af5e41.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alvin Ji <alvinji@chromium.org>
+Date: Mon, 13 Nov 2023 20:24:24 +0000
+Subject: Check context status before creating new platform destination
+
+RealtimeAudioDestinationHandler::SetSinkDescriptor creates new
+destination platofrm without validating context status. This can
+reactivate the audio rendering thread when AudioContext is already in
+closed state.
+
+(cherry picked from commit 0f9bb9a1083865d4e51059e588f27f729ab32753)
+
+Bug: 1500856
+Change-Id: If1fd531324b56fcdc38d315fd84d4cec577a14bc
+Test: Locally confirmed with ASAN
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5021160
+Reviewed-by: Alvin Ji <alvinji@chromium.org>
+Commit-Queue: Alvin Ji <alvinji@chromium.org>
+Reviewed-by: Hongchan Choi <hongchan@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1223168}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5026373
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: Hongchan Choi <hongchan@chromium.org>
+Cr-Commit-Position: refs/branch-heads/6099@{#607}
+Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
+
+diff --git a/third_party/blink/renderer/modules/webaudio/realtime_audio_destination_handler.cc b/third_party/blink/renderer/modules/webaudio/realtime_audio_destination_handler.cc
+index 2e4757d155800700b7c6a8b7cbf2e02250cfce65..c27eb3ac07f22a4cd1ae2f86da896d255a761292 100644
+--- a/third_party/blink/renderer/modules/webaudio/realtime_audio_destination_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/realtime_audio_destination_handler.cc
+@@ -405,6 +405,17 @@ void RealtimeAudioDestinationHandler::SetSinkDescriptor(
+                   GetCallbackBufferSize()));
+   DCHECK(IsMainThread());
+ 
++  // After the context is closed, `SetSinkDescriptor` request will be ignored
++  // because it will trigger the recreation of the platform destination. This in
++  // turn can activate the audio rendering thread.
++  AudioContext* context = static_cast<AudioContext*>(Context());
++  CHECK(context);
++  if (context->ContextState() == AudioContext::kClosed) {
++    std::move(callback).Run(
++        media::OutputDeviceStatus::OUTPUT_DEVICE_STATUS_ERROR_INTERNAL);
++    return;
++  }
++
+   // Create a pending AudioDestination to replace the current one.
+   scoped_refptr<AudioDestination> pending_platform_destination =
+       AudioDestination::Create(

--- a/patches/chromium/cherry-pick-6cc0d9aa5b3f.patch
+++ b/patches/chromium/cherry-pick-6cc0d9aa5b3f.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vignesh Venkatasubramanian <vigneshv@google.com>
+Date: Tue, 21 Nov 2023 00:14:19 +0000
+Subject: Roll src/third_party/libavif/src/ d1c26fa..b2d36b1 (2 commits)
+
+https://chromium.googlesource.com/external/github.com/AOMediaCodec/libavif.git/+log/d1c26fa..b2d36b1
+
+$ git log d1c26fa..b2d36b1 --date=short --no-merges --format='%ad %ae %s'
+2023-11-15 vigneshv@google.com Remove potential out of bound access to alphaItemIndices
+2023-11-15 vigneshv@google.com Do not store potentially invalid pointers
+
+Bug: 1501766, 1501770
+Test: blink_platform_unittests
+Change-Id: I72915b1187ca651e6f47f8d44e946644ebe9fce4
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5046038
+Reviewed-by: Dale Curtis <dalecurtis@chromium.org>
+Commit-Queue: Vignesh Venkat <vigneshv@google.com>
+Reviewed-by: Wan-Teh Chang <wtc@google.com>
+Cr-Commit-Position: refs/branch-heads/5993@{#1630}
+Cr-Branched-From: 511350718e646be62331ae9d7213d10ec320d514-refs/heads/main@{#1192594}
+
+diff --git a/DEPS b/DEPS
+index 79011df08eb07e67c1d4261ca324a9fbce042690..8073700e6367cfcd6910aa80f3a749f3cce6cbfa 100644
+--- a/DEPS
++++ b/DEPS
+@@ -469,7 +469,7 @@ vars = {
+   # Three lines of non-changing comments so that
+   # the commit queue can handle CLs rolling libavif
+   # and whatever else without interference from each other.
+-  'libavif_revision': 'd1c26facaf5a8a97919ceee06814d05d10e25622',
++  'libavif_revision': 'b2d36b1c3bfc806694cd4ff0cb188270823fe6d8',
+   # Three lines of non-changing comments so that
+   # the commit queue can handle CLs rolling libavif
+   # and whatever else without interference from each other.
+diff --git a/third_party/libavif/src b/third_party/libavif/src
+index d1c26facaf5a8a97919ceee06814d05d10e25622..b2d36b1c3bfc806694cd4ff0cb188270823fe6d8 160000
+--- a/third_party/libavif/src
++++ b/third_party/libavif/src
+@@ -1 +1 @@
+-Subproject commit d1c26facaf5a8a97919ceee06814d05d10e25622
++Subproject commit b2d36b1c3bfc806694cd4ff0cb188270823fe6d8

--- a/patches/chromium/cherry-pick-e13061c50998.patch
+++ b/patches/chromium/cherry-pick-e13061c50998.patch
@@ -1,0 +1,116 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ken Rockot <rockot@google.com>
+Date: Thu, 16 Nov 2023 23:44:43 +0000
+Subject: Reland: Fix IPC Channel pipe teardown
+
+This is a reland with the new test temporarily disabled on Android
+until it can run without disrupting other tests.
+
+(cherry picked from commit cd4c1f165c16c6d8161b5372ef7f61c715e01a42)
+
+Fixed: 1494461
+Change-Id: If1d83c2dce62020f78dd50abc460973759002a1a
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5015115
+Commit-Queue: Ken Rockot <rockot@google.com>
+Reviewed-by: Robert Sesek <rsesek@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1221953}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5037764
+Reviewed-by: Daniel Cheng <dcheng@chromium.org>
+Auto-Submit: Ken Rockot <rockot@google.com>
+Commit-Queue: Daniel Cheng <dcheng@chromium.org>
+Cr-Commit-Position: refs/branch-heads/5993@{#1618}
+Cr-Branched-From: 511350718e646be62331ae9d7213d10ec320d514-refs/heads/main@{#1192594}
+
+diff --git a/ipc/ipc_mojo_bootstrap.cc b/ipc/ipc_mojo_bootstrap.cc
+index 7a7ededd03fbddac42503bece789500e7d48eed1..c642de4a00c883d8e1f589a9adfb704472ce7062 100644
+--- a/ipc/ipc_mojo_bootstrap.cc
++++ b/ipc/ipc_mojo_bootstrap.cc
+@@ -793,13 +793,12 @@ class ChannelAssociatedGroupController
+         // handle.
+         DCHECK(!endpoint->client());
+         DCHECK(endpoint->peer_closed());
+-        MarkClosedAndMaybeRemove(endpoint);
++        MarkClosed(endpoint);
+       } else {
+-        MarkPeerClosedAndMaybeRemove(endpoint);
++        MarkPeerClosed(endpoint);
+       }
+     }
+-
+-    DCHECK(endpoints_.empty());
++    endpoints_.clear();
+ 
+     GetMemoryDumpProvider().RemoveController(this);
+   }
+@@ -844,15 +843,19 @@ class ChannelAssociatedGroupController
+     base::AutoLock locker(lock_);
+     encountered_error_ = true;
+ 
++    std::vector<uint32_t> endpoints_to_remove;
+     std::vector<scoped_refptr<Endpoint>> endpoints_to_notify;
+     for (auto iter = endpoints_.begin(); iter != endpoints_.end();) {
+       Endpoint* endpoint = iter->second.get();
+       ++iter;
+ 
+-      if (endpoint->client())
++      if (endpoint->client()) {
+         endpoints_to_notify.push_back(endpoint);
++      }
+ 
+-      MarkPeerClosedAndMaybeRemove(endpoint);
++      if (MarkPeerClosed(endpoint)) {
++        endpoints_to_remove.push_back(endpoint->id());
++      }
+     }
+ 
+     for (auto& endpoint : endpoints_to_notify) {
+@@ -861,6 +864,10 @@ class ChannelAssociatedGroupController
+       if (endpoint->client())
+         NotifyEndpointOfError(endpoint.get(), false /* force_async */);
+     }
++
++    for (uint32_t id : endpoints_to_remove) {
++      endpoints_.erase(id);
++    }
+   }
+ 
+   void NotifyEndpointOfError(Endpoint* endpoint, bool force_async) {
+@@ -899,19 +906,33 @@ class ChannelAssociatedGroupController
+     NotifyEndpointOfError(endpoint, false /* force_async */);
+   }
+ 
+-  void MarkClosedAndMaybeRemove(Endpoint* endpoint) {
++  // Marks `endpoint` as closed and returns true if and only if its peer was
++  // also already closed.
++  bool MarkClosed(Endpoint* endpoint) {
+     lock_.AssertAcquired();
+     endpoint->set_closed();
+-    if (endpoint->closed() && endpoint->peer_closed())
+-      endpoints_.erase(endpoint->id());
++    return endpoint->peer_closed();
+   }
+ 
+-  void MarkPeerClosedAndMaybeRemove(Endpoint* endpoint) {
++  // Marks `endpoint` as having a closed peer and returns true if and only if
++  // `endpoint` itself was also already closed.
++  bool MarkPeerClosed(Endpoint* endpoint) {
+     lock_.AssertAcquired();
+     endpoint->set_peer_closed();
+     endpoint->SignalSyncMessageEvent();
+-    if (endpoint->closed() && endpoint->peer_closed())
++    return endpoint->closed();
++  }
++
++  void MarkClosedAndMaybeRemove(Endpoint* endpoint) {
++    if (MarkClosed(endpoint)) {
+       endpoints_.erase(endpoint->id());
++    }
++  }
++
++  void MarkPeerClosedAndMaybeRemove(Endpoint* endpoint) {
++    if (MarkPeerClosed(endpoint)) {
++      endpoints_.erase(endpoint->id());
++    }
+   }
+ 
+   Endpoint* FindOrInsertEndpoint(mojo::InterfaceId id, bool* inserted) {

--- a/patches/config.json
+++ b/patches/config.json
@@ -21,5 +21,7 @@
 
   "src/electron/patches/ReactiveObjC": "src/third_party/squirrel.mac/vendor/ReactiveObjC",
 
+  "src/electron/patches/skia": "src/third_party/skia",
+
   "src/electron/patches/webrtc": "src/third_party/webrtc"
 }

--- a/patches/openscreen/.patches
+++ b/patches/openscreen/.patches
@@ -1,0 +1,1 @@
+cherry-pick-971d6055e7b7.patch

--- a/patches/openscreen/cherry-pick-971d6055e7b7.patch
+++ b/patches/openscreen/cherry-pick-971d6055e7b7.patch
@@ -1,0 +1,142 @@
+From 971d6055e7b78c474e2e734e55a2991fbb7ab665 Mon Sep 17 00:00:00 2001
+From: Jordan Bayles <jophba@chromium.org>
+Date: Mon, 30 Oct 2023 15:10:00 -0700
+Subject: [PATCH] [Cast Streaming] fix heap use-after-free
+
+This patch fixes a use after free, caused by using an iterator
+after it has been invalidated by a call to std::map::erase().
+
+Bug: 1491210
+Change-Id: I0c546eb6474af82f052b89e819a4886a004270f0
+Reviewed-on: https://chromium-review.googlesource.com/c/openscreen/+/4981212
+Reviewed-by: Mark Foltz <mfoltz@chromium.org>
+Commit-Queue: Jordan Bayles <jophba@chromium.org>
+Reviewed-by: Muyao Xu <muyaoxu@google.com>
+---
+
+diff --git a/cast/streaming/statistics_analyzer.cc b/cast/streaming/statistics_analyzer.cc
+index b0658f5..81d10c5 100644
+--- a/cast/streaming/statistics_analyzer.cc
++++ b/cast/streaming/statistics_analyzer.cc
+@@ -144,16 +144,22 @@
+ void StatisticsAnalyzer::RecordFrameLatencies(const FrameEvent& frame_event) {
+   FrameInfoMap& frame_infos = recent_frame_infos_.Get(frame_event.media_type);
+ 
++  // Event is too old, don't bother.
++  const bool map_is_full = frame_infos.size() == kMaxRecentFrameInfoMapSize;
++  if (map_is_full && frame_event.rtp_timestamp <= frame_infos.begin()->first) {
++    return;
++  }
++
+   auto it = frame_infos.find(frame_event.rtp_timestamp);
+   if (it == frame_infos.end()) {
++    if (map_is_full) {
++      frame_infos.erase(frame_infos.begin());
++    }
++
+     auto emplace_result =
+         frame_infos.emplace(frame_event.rtp_timestamp, FrameInfo{});
+     OSP_CHECK(emplace_result.second);
+     it = emplace_result.first;
+-
+-    if (frame_infos.size() >= kMaxRecentFrameInfoMapSize) {
+-      frame_infos.erase(frame_infos.begin());
+-    }
+   }
+ 
+   switch (frame_event.type) {
+diff --git a/cast/streaming/statistics_analyzer_unittest.cc b/cast/streaming/statistics_analyzer_unittest.cc
+index 22313ce..be89474 100644
+--- a/cast/streaming/statistics_analyzer_unittest.cc
++++ b/cast/streaming/statistics_analyzer_unittest.cc
+@@ -635,4 +635,90 @@
+                                    (frame_interval_ms * num_events)));
+ }
+ 
++TEST_F(StatisticsAnalyzerTest, LotsOfEventsStillWorksProperly) {
++  constexpr std::array<StatisticsEventType, 5> kEventsToReport{
++      StatisticsEventType::kFrameCaptureBegin,
++      StatisticsEventType::kFrameCaptureEnd, StatisticsEventType::kFrameEncoded,
++      StatisticsEventType::kFrameAckSent, StatisticsEventType::kFramePlayedOut};
++  constexpr int kNumFrames = 1000;
++  constexpr int kNumEvents = kNumFrames * kEventsToReport.size();
++
++  constexpr std::array<int, 5> kFramePlayoutDelayDeltasMs{10, 14, 3, 40, 1};
++  constexpr std::array<int, 25> kTimestampOffsetsMs{
++      // clang-format off
++      0, 13, 39, 278, 552,   // Frame One.
++      0, 14, 34, 239, 373,   // Frame Two.
++      0, 19, 29, 245, 389,   // Frame Three.
++      0, 17, 37, 261, 390,   // Frame Four.
++      0, 14, 44, 290, 440,   // Frame Five.
++      // clang-format on
++  };
++
++  constexpr std::array<std::pair<StatisticType, double>, 7> kExpectedStats{{
++      {StatisticType::kNumLateFrames, 1000},
++      {StatisticType::kNumFramesCaptured, 1000},
++      {StatisticType::kAvgEndToEndLatencyMs, 428.8},
++      {StatisticType::kAvgCaptureLatencyMs, 15.4},
++      {StatisticType::kAvgFrameLatencyMs, 226},
++      {StatisticType::kAvgEncodeTimeMs, 21.2},
++      {StatisticType::kEnqueueFps, 40},
++  }};
++
++  constexpr std::array<std::pair<HistogramType, std::array<int, 30>>, 4>
++      kExpectedHistograms{
++          {{HistogramType::kCaptureLatencyMs, {0, 1000}},
++           {HistogramType::kEncodeTimeMs, {0, 200, 800}},
++           {HistogramType::kEndToEndLatencyMs,
++            {0, 0, 0, 0, 0,   0,   0, 0, 0,   0, 0, 0, 0, 0,  0,
++             0, 0, 0, 0, 200, 400, 0, 0, 200, 0, 0, 0, 0, 200
++
++            }},
++           {HistogramType::kFrameLatenessMs, {0, 800, 0, 200}}}};
++
++  // We don't check stats the first 49 times, only the last.
++  {
++    testing::InSequence s;
++    EXPECT_CALL(stats_client_, OnStatisticsUpdated(_)).Times(49);
++    EXPECT_CALL(stats_client_, OnStatisticsUpdated(_))
++        .WillOnce(Invoke([&](const SenderStats& stats) {
++          for (const auto& stat_pair : kExpectedStats) {
++            ExpectStatEq(stats.video_statistics, stat_pair.first,
++                         stat_pair.second);
++          }
++          for (const auto& histogram_pair : kExpectedHistograms) {
++            ExpectHistoBuckets(stats.video_histograms, histogram_pair.first,
++                               histogram_pair.second);
++          }
++        }));
++  }
++
++  analyzer_->ScheduleAnalysis();
++  RtpTimeTicks rtp_timestamp;
++  int current_event = 0;
++  for (int frame_id = 0; frame_id < kNumFrames; frame_id++) {
++    for (StatisticsEventType event_type : kEventsToReport) {
++      FrameEvent event(kDefaultFrameEvent);
++      event.type = event_type;
++      event.frame_id = FrameId(frame_id);
++      event.rtp_timestamp = rtp_timestamp;
++      event.timestamp =
++          fake_clock_.now() +
++          milliseconds(
++              kTimestampOffsetsMs[current_event % kTimestampOffsetsMs.size()]);
++      event.delay_delta = milliseconds(
++          kFramePlayoutDelayDeltasMs[frame_id %
++                                     kFramePlayoutDelayDeltasMs.size()]);
++      collector_->CollectFrameEvent(std::move(event));
++
++      current_event++;
++    }
++    fake_clock_.Advance(
++        milliseconds(kDefaultStatIntervalMs * kEventsToReport.size()));
++    rtp_timestamp += RtpTimeDelta::FromTicks(90);
++  }
++
++  fake_clock_.Advance(milliseconds(kDefaultStatsAnalysisIntervalMs -
++                                   (kDefaultStatIntervalMs * kNumEvents)));
++}
++
+ }  // namespace openscreen::cast

--- a/patches/skia/.patches
+++ b/patches/skia/.patches
@@ -1,0 +1,1 @@
+avoid_combining_extremely_large_meshes.patch

--- a/patches/skia/avoid_combining_extremely_large_meshes.patch
+++ b/patches/skia/avoid_combining_extremely_large_meshes.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: John Stiles <johnstiles@google.com>
+Date: Fri, 24 Nov 2023 09:40:11 -0500
+Subject: Avoid combining extremely large meshes.
+
+Bug: chromium:1505053
+Change-Id: I42f2ff872bbf054686ec7af0cc85ff63055fcfbf
+Reviewed-on: https://skia-review.googlesource.com/c/skia/+/782936
+Commit-Queue: Michael Ludwig <michaelludwig@google.com>
+Reviewed-by: Michael Ludwig <michaelludwig@google.com>
+Auto-Submit: John Stiles <johnstiles@google.com>
+
+diff --git a/src/gpu/ganesh/ops/DrawMeshOp.cpp b/src/gpu/ganesh/ops/DrawMeshOp.cpp
+index aa6b0f3a82d6a01fb8194d2c675d03d5d4e5e697..34dfd1d4c3980d8f4ce877cedccff8b9eb979c35 100644
+--- a/src/gpu/ganesh/ops/DrawMeshOp.cpp
++++ b/src/gpu/ganesh/ops/DrawMeshOp.cpp
+@@ -1031,10 +1031,13 @@ GrOp::CombineResult MeshOp::onCombineIfPossible(GrOp* t, SkArenaAlloc*, const Gr
+         return CombineResult::kCannotCombine;
+     }
+ 
++    if (fVertexCount > INT32_MAX - that->fVertexCount) {
++        return CombineResult::kCannotCombine;
++    }
+     if (SkToBool(fIndexCount) != SkToBool(that->fIndexCount)) {
+         return CombineResult::kCannotCombine;
+     }
+-    if (SkToBool(fIndexCount) && fVertexCount + that->fVertexCount > SkToInt(UINT16_MAX)) {
++    if (SkToBool(fIndexCount) && fVertexCount > UINT16_MAX - that->fVertexCount) {
+         return CombineResult::kCannotCombine;
+     }
+ 


### PR DESCRIPTION
<details>
<summary>electron/security#432 - 971d6055e7b7 from openscreen</summary>
[Cast Streaming] fix heap use-after-free

This patch fixes a use after free, caused by using an iterator
after it has been invalidated by a call to std::map::erase().

Bug: 1491210
Change-Id: I0c546eb6474af82f052b89e819a4886a004270f0
Reviewed-on: https://chromium-review.googlesource.com/c/openscreen/+/4981212
Reviewed-by: Mark Foltz <mfoltz@chromium.org>
Commit-Queue: Jordan Bayles <jophba@chromium.org>
Reviewed-by: Muyao Xu <muyaoxu@google.com>
</details>

<details>
<summary>electron/security#430 - 3f45b1af5e41 from chromium</summary>
Check context status before creating new platform destination

RealtimeAudioDestinationHandler::SetSinkDescriptor creates new
destination platofrm without validating context status. This can
reactivate the audio rendering thread when AudioContext is already in
closed state.

(cherry picked from commit 0f9bb9a1083865d4e51059e588f27f729ab32753)

Bug: 1500856
Change-Id: If1fd531324b56fcdc38d315fd84d4cec577a14bc
Test: Locally confirmed with ASAN
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5021160
Reviewed-by: Alvin Ji <alvinji@chromium.org>
Commit-Queue: Alvin Ji <alvinji@chromium.org>
Reviewed-by: Hongchan Choi <hongchan@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1223168}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5026373
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Commit-Queue: Hongchan Choi <hongchan@chromium.org>
Cr-Commit-Position: refs/branch-heads/6099@{#607}
Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
</details>

<details>
<summary>electron/security#431 - e13061c50998 from chromium</summary>
[M118] Reland: Fix IPC Channel pipe teardown

This is a reland with the new test temporarily disabled on Android
until it can run without disrupting other tests.

(cherry picked from commit cd4c1f165c16c6d8161b5372ef7f61c715e01a42)

Fixed: 1494461
Change-Id: If1d83c2dce62020f78dd50abc460973759002a1a
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5015115
Commit-Queue: Ken Rockot <rockot@google.com>
Reviewed-by: Robert Sesek <rsesek@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1221953}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5037764
Reviewed-by: Daniel Cheng <dcheng@chromium.org>
Auto-Submit: Ken Rockot <rockot@google.com>
Commit-Queue: Daniel Cheng <dcheng@chromium.org>
Cr-Commit-Position: refs/branch-heads/5993@{#1618}
Cr-Branched-From: 511350718e646be62331ae9d7213d10ec320d514-refs/heads/main@{#1192594}
</details>

<details>
<summary>electron/security#429 - 6cc0d9aa5b3f from chromium</summary>
[M118] Roll src/third_party/libavif/src/ d1c26fa..b2d36b1 (2 commits)

https://chromium.googlesource.com/external/github.com/AOMediaCodec/libavif.git/+log/d1c26fa..b2d36b1

$ git log d1c26fa..b2d36b1 --date=short --no-merges --format='%ad %ae %s'
2023-11-15 vigneshv@google.com Remove potential out of bound access to alphaItemIndices
2023-11-15 vigneshv@google.com Do not store potentially invalid pointers

Bug: 1501766, 1501770
Test: blink_platform_unittests
Change-Id: I72915b1187ca651e6f47f8d44e946644ebe9fce4
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5046038
Reviewed-by: Dale Curtis <dalecurtis@chromium.org>
Commit-Queue: Vignesh Venkat <vigneshv@google.com>
Reviewed-by: Wan-Teh Chang <wtc@google.com>
Cr-Commit-Position: refs/branch-heads/5993@{#1630}
Cr-Branched-From: 511350718e646be62331ae9d7213d10ec320d514-refs/heads/main@{#1192594}
</details>

<details>
<summary>electron/security#432 - 6169a1fabae1 from skia</summary>
Avoid combining extremely large meshes.

Bug: [chromium:1505053](https://bugs.chromium.org/p/chromium/issues/detail?id=1505053)
Change-Id: [I42f2ff872bbf054686ec7af0cc85ff63055fcfbf](https://skia-review.googlesource.com/q/I42f2ff872bbf054686ec7af0cc85ff63055fcfbf)
Reviewed-on: https://skia-review.googlesource.com/c/skia/+/782936
Commit-Queue: Michael Ludwig <michaelludwig@google.com>
Reviewed-by: Michael Ludwig <michaelludwig@google.com>
Auto-Submit: John Stiles <johnstiles@google.com>
</details>

Notes:
* Security: backported fix for 1491210.
* Security: backported fix for CVE-2023-6345
* Security: backported fix for CVE-2023-6346.
* Security: backported fix for CVE-2023-6347.
* Security: backported fix for CVE-2023-6350.