### PR TITLE
chore: cherry-pick 2 changes from Release-3-M119

### DIFF
--- a/patches/config.json
+++ b/patches/config.json
@@ -11,6 +11,8 @@
 
   "src/electron/patches/node": "src/third_party/electron_node",
 
+  "src/electron/patches/libavif": "src/third_party/libavif/src",
+
   "src/electron/patches/nan": "src/third_party/nan",
 
   "src/electron/patches/perfetto": "src/third_party/perfetto",

--- a/patches/libavif/.patches
+++ b/patches/libavif/.patches
@@ -1,0 +1,2 @@
+remove_potential_out_of_bound_access_to_alphaitemindices.patch
+do_not_store_potentially_invalid_pointers.patch

--- a/patches/libavif/do_not_store_potentially_invalid_pointers.patch
+++ b/patches/libavif/do_not_store_potentially_invalid_pointers.patch
@@ -1,0 +1,68 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vignesh Venkatasubramanian <vigneshv@google.com>
+Date: Wed, 15 Nov 2023 15:22:49 -0800
+Subject: Do not store potentially invalid pointers
+
+Manual cherry-pick of PR #1757 into the chromium-m118 branch.
+
+diff --git a/src/read.c b/src/read.c
+index 53ea5156c04f0f2ce96aaa1762100863309c31e8..d99960e01f1c2dc0ebf7d2cf0dead78bbf8a174b 100644
+--- a/src/read.c
++++ b/src/read.c
+@@ -769,6 +769,8 @@ static void avifMetaDestroy(avifMeta * meta)
+     avifFree(meta);
+ }
+ 
++// CAUTION: This function could potentially resize the meta->items array thereby invalidating all existing pointers that are being
++// stored locally. So if this function is being called, exercise caution in the caller to not use invalid pointers.
+ static avifDecoderItem * avifMetaFindItem(avifMeta * meta, uint32_t itemID)
+ {
+     if (itemID == 0) {
+@@ -3614,17 +3616,20 @@ static avifBool avifDecoderItemIsAlphaAux(avifDecoderItem * item, uint32_t color
+     return auxCProp && isAlphaURN(auxCProp->u.auxC.auxType);
+ }
+ 
+-// Finds the alpha item whose parent item is colorItem and sets it in the alphaItem output parameter. Returns AVIF_RESULT_OK on
+-// success. Note that *alphaItem can be NULL even if the return value is AVIF_RESULT_OK. If the colorItem is a grid and the alpha
+-// item is represented as a set of auxl items to each color tile, then a fake item will be created and *isAlphaItemInInput will be
+-// set to AVIF_FALSE. In this case, the alpha item merely exists to hold the locations of the alpha tile items. The data of this
+-// item need not be read and the pixi property cannot be validated. Otherwise, *isAlphaItemInInput will be set to AVIF_TRUE when
+-// *alphaItem is not NULL.
++// Finds the alpha item whose parent item is *colorItemPtr and sets it in the alphaItem output parameter. Returns AVIF_RESULT_OK
++// on success. Note that *alphaItem can be NULL even if the return value is AVIF_RESULT_OK. If the *colorItemPtr is a grid and the
++// alpha item is represented as a set of auxl items to each color tile, then a fake item will be created and *isAlphaItemInInput
++// will be set to AVIF_FALSE. In this case, the alpha item merely exists to hold the locations of the alpha tile items. The data
++// of this item need not be read and the pixi property cannot be validated. Otherwise, *isAlphaItemInInput will be set to
++// AVIF_TRUE when *alphaItem is not NULL. If the data->meta->items array is resized, then the value in *colorItemPtr could become
++// invalid. This function also resets *colorItemPtr to the right value if an alpha item was found and added to the data->meta->items
++// array.
+ static avifResult avifDecoderDataFindAlphaItem(avifDecoderData * data,
+-                                               avifDecoderItem * colorItem,
++                                               avifDecoderItem ** colorItemPtr,
+                                                avifDecoderItem ** alphaItem,
+                                                avifBool * isAlphaItemInInput)
+ {
++    const avifDecoderItem * colorItem = *colorItemPtr;
+     for (uint32_t itemIndex = 0; itemIndex < data->meta->items.count; ++itemIndex) {
+         avifDecoderItem * item = &data->meta->items.item[itemIndex];
+         if (avifDecoderItemShouldBeSkipped(item)) {
+@@ -3700,6 +3705,10 @@ static avifResult avifDecoderDataFindAlphaItem(avifDecoderData * data,
+         *isAlphaItemInInput = AVIF_FALSE;
+         return AVIF_RESULT_OUT_OF_MEMORY;
+     }
++    // avifMetaFindItem() could invalidate all existing item pointers. So reset the colorItem pointers.
++    *colorItemPtr = &data->meta->items.item[colorItemIndex];
++    colorItem = *colorItemPtr;
++
+     memcpy((*alphaItem)->type, "grid", 4);
+     (*alphaItem)->width = colorItem->width;
+     (*alphaItem)->height = colorItem->height;
+@@ -3949,7 +3958,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
+ 
+         avifBool isAlphaItemInInput;
+         avifDecoderItem * alphaItem;
+-        AVIF_CHECKRES(avifDecoderDataFindAlphaItem(data, colorItem, &alphaItem, &isAlphaItemInInput));
++        AVIF_CHECKRES(avifDecoderDataFindAlphaItem(data, &colorItem, &alphaItem, &isAlphaItemInInput));
+         avifCodecType alphaCodecType = AVIF_CODEC_TYPE_UNKNOWN;
+         if (alphaItem) {
+             if (!memcmp(alphaItem->type, "grid", 4)) {

--- a/patches/libavif/remove_potential_out_of_bound_access_to_alphaitemindices.patch
+++ b/patches/libavif/remove_potential_out_of_bound_access_to_alphaitemindices.patch
@@ -1,0 +1,78 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vignesh Venkatasubramanian <vigneshv@google.com>
+Date: Mon, 13 Nov 2023 19:39:10 -0800
+Subject: Remove potential out of bound access to alphaItemIndices
+
+It is possible to craft a file that has more alpha auxiliary items
+than color items and trigger an out of bound access into
+alphaItemIndices in the for loop.
+
+Fix is to ensure that each color grid item has exactly one alpha
+grid item. Also, ensure that there are exactly the same number of
+color grids as informed in the grid config before trying to
+find the alpha item.
+
+Also, update a diagnostic error message to cover all cases (i.e.)
+there can be more grids than necessary as well.
+
+diff --git a/src/read.c b/src/read.c
+index 3d8ffe28810aece5078b6efa0b19ec3b5d1a03c5..53ea5156c04f0f2ce96aaa1762100863309c31e8 100644
+--- a/src/read.c
++++ b/src/read.c
+@@ -1417,7 +1417,7 @@ static avifBool avifDecoderGenerateImageGridTiles(avifDecoder * decoder, avifIma
+ 
+     if (tilesAvailable != grid->rows * grid->columns) {
+         avifDiagnosticsPrintf(&decoder->diag,
+-                              "Grid image of dimensions %ux%u requires %u tiles, and only %u were found",
++                              "Grid image of dimensions %ux%u requires %u tiles, but %u were found",
+                               grid->columns,
+                               grid->rows,
+                               grid->rows * grid->columns,
+@@ -3659,21 +3659,41 @@ static avifResult avifDecoderDataFindAlphaItem(avifDecoderData * data,
+             maxItemID = item->id;
+         }
+         if (item->dimgForID == colorItem->id) {
++            avifBool seenAlphaForCurrentItem = AVIF_FALSE;
+             for (uint32_t j = 0; j < colorItem->meta->items.count; ++j) {
+                 avifDecoderItem * auxlItem = &colorItem->meta->items.item[j];
+                 if (avifDecoderItemIsAlphaAux(auxlItem, item->id)) {
++                    if (seenAlphaForCurrentItem || auxlItem->dimgForID != 0) {
++                        // One of the following invalid cases:
++                        // * Multiple items are claiming to be the alpha auxiliary of the current item.
++                        // * Alpha auxiliary is dimg for another item.
++                        avifFree(alphaItemIndices);
++                        *isAlphaItemInInput = AVIF_FALSE;
++                        return AVIF_RESULT_INVALID_IMAGE_GRID;
++                    }
+                     alphaItemIndices[alphaItemCount++] = j;
++                    seenAlphaForCurrentItem = AVIF_TRUE;
+                 }
+             }
++            if (!seenAlphaForCurrentItem) {
++                // No alpha auxiliary item was found for the current item. Treat this as an image without alpha.
++                avifFree(alphaItemIndices);
++                *isAlphaItemInInput = AVIF_FALSE;
++                return AVIF_RESULT_OK;
++            }
+         }
+     }
+-    if (alphaItemCount != colorItemCount) {
+-        // Not all the color items had an alpha auxiliary attached to it. Report this case as an image without alpha channel.
+-        avifFree(alphaItemIndices);
+-        *alphaItem = NULL;
+-        *isAlphaItemInInput = AVIF_FALSE;
+-        return AVIF_RESULT_OK;
++    assert(alphaItemCount == colorItemCount);
++
++    int colorItemIndex = -1;
++    for (uint32_t i = 0; i < data->meta->items.count; ++i) {
++        if (colorItem->id == data->meta->items.item[i].id) {
++            colorItemIndex = i;
++            break;
++        }
+     }
++    assert(colorItemIndex >= 0);
++
+     *alphaItem = avifMetaFindItem(colorItem->meta, maxItemID + 1);
+     if (*alphaItem == NULL) {
+         avifFree(alphaItemIndices);


### PR DESCRIPTION
* 6cc0d9aa5b3fb from libavif
* 922fca786b61a from libavif

<details>
<summary>electron/security#429 - 6cc0d9aa5b3fb from libavif</summary>
Remove potential out of bound access to alphaItemIndices

It is possible to craft a file that has more alpha auxiliary items
than color items and trigger an out of bound access into
alphaItemIndices in the for loop.

Fix is to ensure that each color grid item has exactly one alpha
grid item. Also, ensure that there are exactly the same number of
color grids as informed in the grid config before trying to
find the alpha item.

Also, update a diagnostic error message to cover all cases (i.e.)
there can be more grids than necessary as well.

Bug: 1501766, 1501770
Reviewed-on: https://chromium.googlesource.com/external/github.com/AOMediaCodec/libavif.git/+/6d62963f74aa76dbe05ac8c84bed94dece9ddde5
[118] Manual Backport: https://chromium.googlesource.com/external/github.com/AOMediaCodec/libavif.git/+/b2d36b1c3bfc806694cd4ff0cb188270823fe6d8
</details>

<details>
<summary>electron/security#429 - 922fca786b61a from libavif</summary>
Do not store item pointers until all items are created

Calling avifMetaFindOrCreateItem() could invalidate all the
existing item pointers that are being stored by the caller (since
the function could resize the item array).

This patch fixes avifDecoderReset by storing the item indices
instead of item pointers until all the items are either created
or found.

Bug: 1501766, 1501770
Reviewed-on: https://chromium.googlesource.com/external/github.com/AOMediaCodec/libavif.git/+/2041109967c1746178c736e0a1504d9c97b51a5c
[118] Manual Backport: https://chromium.googlesource.com/external/github.com/AOMediaCodec/libavif.git/+/922fca786b61a83cfa0a7198bfcb61ece511394d
</details>

Follow up to https://github.com/electron/electron/pull/40643, which mistakenly patched DEPS directly.

Notes:
* Security: backported fix for CVE-2023-6350.
