### PR TITLE
fix: don't reject `loadURL()` promise from  `did-fail-load` - use `did-finish-load` instead

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -345,12 +345,13 @@ WebContents.prototype.loadURL = function (url, options) {
       removeListeners();
       reject(err);
     };
+    let doFinish = () => resolveAndCleanup();
     const finishListener = () => {
-      resolveAndCleanup();
+      doFinish();
     };
     const failListener = (event: Electron.Event, errorCode: number, errorDescription: string, validatedURL: string, isMainFrame: boolean) => {
       if (isMainFrame) {
-        rejectAndCleanup(errorCode, errorDescription, validatedURL);
+        doFinish = () => rejectAndCleanup(errorCode, errorDescription, validatedURL);
       }
     };
 

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -345,12 +345,14 @@ WebContents.prototype.loadURL = function (url, options) {
       removeListeners();
       reject(err);
     };
+    let didFail = false;
     let doFinish = () => resolveAndCleanup();
     const finishListener = () => {
       doFinish();
     };
     const failListener = (event: Electron.Event, errorCode: number, errorDescription: string, validatedURL: string, isMainFrame: boolean) => {
-      if (isMainFrame) {
+      if (!didFail && isMainFrame) {
+        didFail = true;
         doFinish = () => rejectAndCleanup(errorCode, errorDescription, validatedURL);
       }
     };

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -333,27 +333,31 @@ WebContents.prototype.loadFile = function (filePath, options = {}) {
   }));
 };
 
+type LoadError = { errorCode: number, errorDescription: string, url: string };
+
 WebContents.prototype.loadURL = function (url, options) {
   const p = new Promise<void>((resolve, reject) => {
     const resolveAndCleanup = () => {
       removeListeners();
       resolve();
     };
-    const rejectAndCleanup = (errorCode: number, errorDescription: string, url: string) => {
+    let error: LoadError | undefined;
+    const rejectAndCleanup = ({ errorCode, errorDescription, url }: LoadError) => {
       const err = new Error(`${errorDescription} (${errorCode}) loading '${typeof url === 'string' ? url.substr(0, 2048) : url}'`);
       Object.assign(err, { errno: errorCode, code: errorDescription, url });
       removeListeners();
       reject(err);
     };
-    let didFail = false;
-    let doFinish = () => resolveAndCleanup();
     const finishListener = () => {
-      doFinish();
+      if (error) {
+        rejectAndCleanup(error);
+      } else {
+        resolveAndCleanup();
+      }
     };
     const failListener = (event: Electron.Event, errorCode: number, errorDescription: string, validatedURL: string, isMainFrame: boolean) => {
-      if (!didFail && isMainFrame) {
-        didFail = true;
-        doFinish = () => rejectAndCleanup(errorCode, errorDescription, validatedURL);
+      if (!error && isMainFrame) {
+        error = { errorCode, errorDescription, url: validatedURL };
       }
     };
 
@@ -371,7 +375,7 @@ WebContents.prototype.loadURL = function (url, options) {
           // considered navigation events but are triggered with isSameDocument.
           // We can ignore these to allow virtual routing on page load as long
           // as the routing does not leave the document
-          return rejectAndCleanup(-3, 'ERR_ABORTED', url);
+          return rejectAndCleanup({ errorCode: -3, errorDescription: 'ERR_ABORTED', url });
         }
         browserInitiatedInPageNavigation = navigationStarted && isSameDocument;
         navigationStarted = true;
@@ -386,7 +390,10 @@ WebContents.prototype.loadURL = function (url, options) {
       // TODO(jeremy): enumerate all the cases in which this can happen. If
       // the only one is with a bad scheme, perhaps ERR_INVALID_ARGUMENT
       // would be more appropriate.
-      rejectAndCleanup(-2, 'ERR_FAILED', url);
+      if (!error) {
+        error = { errorCode: -2, errorDescription: 'ERR_FAILED', url: url };
+      }
+      finishListener();
     };
     const finishListenerWhenUserInitiatedNavigation = () => {
       if (!browserInitiatedInPageNavigation) {

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -514,6 +514,11 @@ describe('webContents module', () => {
         .and.have.property('errno', -355); // ERR_INCOMPLETE_CHUNKED_ENCODING
       s.close();
     });
+
+    it('subsequent load failures reject each time', async () => {
+      await expect(w.loadURL('file:non-existent')).to.eventually.be.rejected();
+      await expect(w.loadURL('file:non-existent')).to.eventually.be.rejected();
+    });
   });
 
   describe('getFocusedWebContents() API', () => {


### PR DESCRIPTION
#### Description of Change

Fixes this issue: https://github.com/electron/electron/issues/40640

The promise from `WebContents.loadURL()` rejects as soon as it receives `did-fail-load`. However, `did-fail-load` will be followed by a `did-finish-load`, which means that if the client code immediately issues another `loadURL()` when the promise rejects, this `loadURL()` will be resolved by the _previous_ call's `did-finish-load`.

This PR changes the `did-fail-load` handler to only note the failure, and leave it to `did-finish-load` to actually resolve/reject the promise.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `WebContents.loadURL()` incorrectly failing if called immediately after a previous call to `loadURL()` failed.
