### PR TITLE
fix: wrong default port in docs

### DIFF
--- a/docs/tutorial/debugging-main-process.md
+++ b/docs/tutorial/debugging-main-process.md
@@ -14,10 +14,10 @@ process:
 
 Electron will listen for V8 inspector protocol messages on the specified `port`,
 an external debugger will need to connect on this port. The default `port` is
-`5858`.
+`9229`.
 
 ```shell
-electron --inspect=5858 your/app
+electron --inspect=9229 your/app
 ```
 
 ### `--inspect-brk=[port]`


### PR DESCRIPTION
#### Description of Change
Wrong default port when debugging. See https://www.electronjs.org/docs/latest/api/command-line-switches#--inspecthostport
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed documentation of the default `--inspect` port.