### PR TITLE
fix: remove `killed` check to allow multiple signals

### DIFF
--- a/npm/cli.js
+++ b/npm/cli.js
@@ -5,7 +5,9 @@ const proc = require('child_process');
 const electron = require('./');
 
 const child = proc.spawn(electron, process.argv.slice(2), { stdio: 'inherit', windowsHide: false });
+let childClosed = false;
 child.on('close', function (code, signal) {
+  childClosed = true;
   if (code === null) {
     console.error(electron, 'exited with signal', signal);
     process.exit(1);
@@ -15,7 +17,7 @@ child.on('close', function (code, signal) {
 
 const handleTerminationSignal = function (signal) {
   process.on(signal, function signalHandler () {
-    if (!child.killed) {
+    if (!childClosed) {
       child.kill(signal);
     }
   });
@@ -23,3 +25,4 @@ const handleTerminationSignal = function (signal) {
 
 handleTerminationSignal('SIGINT');
 handleTerminationSignal('SIGTERM');
+handleTerminationSignal('SIGUSR2');

--- a/script/start.js
+++ b/script/start.js
@@ -5,11 +5,17 @@ const utils = require('./lib/utils');
 const electronPath = utils.getAbsoluteElectronExec();
 
 const child = cp.spawn(electronPath, process.argv.slice(2), { stdio: 'inherit' });
-child.on('close', (code) => process.exit(code));
+let childClosed = false;
+child.on('close', (code) => {
+  childClosed = true;
+  process.exit(code);
+});
 
 const handleTerminationSignal = (signal) =>
   process.on(signal, () => {
-    child.kill(signal);
+    if (!childClosed) {
+      child.kill(signal);
+    }
   });
 
 handleTerminationSignal('SIGINT');


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Multiple instances of `SIGUSR2` must be handled for a good HMR experience. I can't think of a compelling reason to make signal forwarding contingent on the value of `child.killed`.

See: https://github.com/electron/electron/pull/33589

notes: none
