### PR TITLE
build: update typescript-definitions to 8.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@electron/fiddle-core": "^1.0.4",
     "@electron/github-app-auth": "^2.0.0",
     "@electron/lint-roller": "^1.9.0",
-    "@electron/typescript-definitions": "^8.15.1",
+    "@electron/typescript-definitions": "^8.15.2",
     "@octokit/rest": "^19.0.7",
     "@primer/octicons": "^10.0.0",
     "@types/basic-auth": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,10 +219,10 @@
     vscode-languageserver-textdocument "^1.0.8"
     vscode-uri "^3.0.7"
 
-"@electron/typescript-definitions@^8.15.1":
-  version "8.15.1"
-  resolved "https://registry.yarnpkg.com/@electron/typescript-definitions/-/typescript-definitions-8.15.1.tgz#9d4ff7361e8a4dee65d353e2884e7733c1c12dad"
-  integrity sha512-R8Kl8J+o+q3Pn1tM4fU4Qan63g1Oyd1meAlHwIPAJ8LfYC/N09SYJcNuwgvaxb/SHFIcr4BWZKHOVa4makuo6A==
+"@electron/typescript-definitions@^8.15.2":
+  version "8.15.2"
+  resolved "https://registry.yarnpkg.com/@electron/typescript-definitions/-/typescript-definitions-8.15.2.tgz#1152e3d3731d236b50a3dee5a108176ce43fd703"
+  integrity sha512-6vlWnnNfZrg9QFOGgoLaQZ/nTCg+Y1laz02pUsRRmCJIpJZOY3HnWnIuav7e8g5IIwHMVc8JSohR+YRgiRk/eA==
   dependencies:
     "@types/node" "^11.13.7"
     chalk "^2.4.2"


### PR DESCRIPTION
#### Description of Change
Updating typescript-definitions to 8.15.2.
* electron/typescript-definitions/pull/253

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: none
