### PR TITLE
fix: add an option to disable Chromium FD ownership enforcement (#31151)

### DIFF
--- a/docs/api/structures/web-preferences.md
+++ b/docs/api/structures/web-preferences.md
@@ -143,6 +143,9 @@
   contain the layout of the document—without requiring scrolling. Enabling
   this will cause the `preferred-size-changed` event to be emitted on the
   `WebContents` when the preferred size changes. Default is `false`.
+* `disableFdOwnershipEnforcement` boolean (optional) _Linux_ - Whether to
+  disable Chromium FD ownership enforcement, which could cause issues when
+  starting child processes manually. Default is `false`.
 
 [chrome-content-scripts]: https://developer.chrome.com/extensions/content_scripts#execution-environment
 [runtime-enabled-features]: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/runtime_enabled_features.json5

--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -72,7 +72,7 @@ To generate a Visual Studio project, you can pass the `--ide=vs2017` parameter
 to `gn gen`:
 
 ```powershell
-$ gn gen out/Testing --ide=vs2017
+$ gn gen out/Testing --ide=vs2017 --args="import(\"//electron/build/args/release.gn\")"
 ```
 
 ## Troubleshooting

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -825,6 +825,14 @@ WebContents::WebContents(v8::Isolate* isolate,
   // Whether to enable DevTools.
   options.Get("devTools", &enable_devtools_);
 
+#if BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_LINUX)
+  bool disable_fd_ownership_enforcement;
+  options.Get("disableFdOwnershipEnforcement",
+              &disable_fd_ownership_enforcement);
+
+  base::subtle::EnableFDOwnershipEnforcement(!disable_fd_ownership_enforcement);
+#endif
+
   // BrowserViews are not attached to a window initially so they should start
   // off as hidden. This is also important for compositor recycling. See:
   // https://github.com/electron/electron/pull/21372


### PR DESCRIPTION
#### Description of Change

Added a new option in webPreferences to be able to disable Chromium 92+ FD ownership enforcement.
Will fix many issues reported in #31151, as well as https://bugs.chromium.org/p/chromium/issues/detail?id=1280227.

Since this is my first contribution, please tell me if I did it wrong or if there's a better spot to put that code in.

Also fixed a missing argument in the windows build documentation for Visual Studio, which made me lose hours of work when trying to setup my dev environment.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: added an option to disable Chromium FD ownership enforcement