### PR TITLE
ci: tweak new release board workflow

### DIFF
--- a/.github/workflows/branch-created.yml
+++ b/.github/workflows/branch-created.yml
@@ -8,7 +8,7 @@ permissions: {}
 jobs:
   release-branch-created:
     name: Release Branch Created
-    if: ${{ github.event.ref_type == 'branch' && endsWith(github.event.ref, '-x-y') }}
+    if: ${{ github.event.ref_type == 'branch' && endsWith(github.event.ref, '-x-y') && !startsWith(github.event.ref, 'roller') }}
     permissions:
       contents: read
       pull-requests: write
@@ -87,6 +87,7 @@ jobs:
       - name: Create Release Project Board
         if: ${{ steps.check-major-version.outputs.MAJOR }}
         uses: dsanders11/project-actions/copy-project@3a81985616963f32fae17d1d1b406c631f3201a1 # v1.1.0
+        id: create-release-board
         with:
           drafts: true
           project-number: 64
@@ -96,6 +97,10 @@ jobs:
           template-view: ${{ steps.generate-project-metadata.outputs.template-view }}
           title: ${{ steps.generate-project-metadata.outputs.major }}-x-y
           token: ${{ steps.generate-token.outputs.token }}
+      - name: Dump Release Project Board Contents
+        run: gh project item-list ${{ steps.create-release-board.outputs.number }} --owner electron --format json | jq
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Find Previous Release Project Board
         if: ${{ steps.check-major-version.outputs.MAJOR }}
         uses: dsanders11/project-actions/find-project@3a81985616963f32fae17d1d1b406c631f3201a1 # v1.1.0


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Skips roller branches earlier when looking for release branches - GitHub's expressions aren't expressive enough to fully describe the `N-x-y` pattern, but checking for the trailing `-x-y` early skips most all branches except roller branches so this tweak early skips those as well.

Dump the contents of the newly created project items (after template substitution) so that we can more easily compare to the final state and update the template project with any changes.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
