### PR TITLE
fix: macOS maximize button shouldn't be disabled just because the window is non-fullscreenable

### DIFF
--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -238,6 +238,8 @@ class NativeWindowMac : public NativeWindow,
   void InternalSetParentWindow(NativeWindow* parent, bool attach);
   void SetForwardMouseMessages(bool forward);
 
+  void UpdateZoomButton();
+
   ElectronNSWindow* window_;  // Weak ref, managed by widget_.
 
   ElectronNSWindowDelegate* __strong window_delegate_;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -924,7 +924,7 @@ bool NativeWindowMac::IsMaximizable() {
 
 void NativeWindowMac::UpdateZoomButton() {
   [[window_ standardWindowButton:NSWindowZoomButton]
-      setEnabled:(CanMaximize() && IsResizable()) || IsFullScreenable()];
+      setEnabled:IsResizable() && (CanMaximize() || IsFullScreenable())];
 }
 
 void NativeWindowMac::SetFullScreenable(bool fullscreenable) {

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -887,8 +887,7 @@ void NativeWindowMac::SetResizable(bool resizable) {
   // the maximize button and ensure fullscreenability matches user setting.
   SetCanResize(resizable);
   SetFullScreenable(was_fullscreenable);
-  [[window_ standardWindowButton:NSWindowZoomButton]
-      setEnabled:resizable ? was_fullscreenable : false];
+  UpdateZoomButton();
 }
 
 bool NativeWindowMac::IsResizable() {
@@ -916,11 +915,16 @@ bool NativeWindowMac::IsMinimizable() {
 
 void NativeWindowMac::SetMaximizable(bool maximizable) {
   maximizable_ = maximizable;
-  [[window_ standardWindowButton:NSWindowZoomButton] setEnabled:maximizable];
+  UpdateZoomButton();
 }
 
 bool NativeWindowMac::IsMaximizable() {
   return [[window_ standardWindowButton:NSWindowZoomButton] isEnabled];
+}
+
+void NativeWindowMac::UpdateZoomButton() {
+  [[window_ standardWindowButton:NSWindowZoomButton]
+      setEnabled:(CanMaximize() && IsResizable()) || IsFullScreenable()];
 }
 
 void NativeWindowMac::SetFullScreenable(bool fullscreenable) {
@@ -929,6 +933,8 @@ void NativeWindowMac::SetFullScreenable(bool fullscreenable) {
   // On EL Capitan this flag is required to hide fullscreen button.
   SetCollectionBehavior(!fullscreenable,
                         NSWindowCollectionBehaviorFullScreenAuxiliary);
+
+  UpdateZoomButton();
 }
 
 bool NativeWindowMac::IsFullScreenable() {

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5611,6 +5611,19 @@ describe('BrowserWindow module', () => {
         expect(w2.isFullScreenable()).to.be.false('isFullScreenable');
         expect(w3.isFullScreenable()).to.be.false('isFullScreenable');
       });
+
+      it('does not disable maximize button if window is resizable', () => {
+        const w = new BrowserWindow({
+          resizable: true,
+          fullscreenable: false
+        });
+
+        expect(w.isMaximizable()).to.be.true('isMaximizable');
+
+        w.setResizable(false);
+
+        expect(w.isMaximizable()).to.be.false('isMaximizable');
+      });
     });
 
     ifdescribe(process.platform === 'darwin')('isHiddenInMissionControl state', () => {


### PR DESCRIPTION
#### Description of Change

This PR fixes this bug: https://github.com/electron/electron/issues/39833

An [earlier PR](https://github.com/electron/electron/pull/39620/files#diff-148ef9a1a6f049d9fef8c6272a4871d89315f8fc6cd80dc2d41a28b21b29184cR848) (cc @codebytere) incorrectly disabled `NSWindowZoomButton` if the window was non-fullscreenable. However, if a macOS window is non-fullscreenable, the green zoom button turns into a maximize button (with a plus sign instead of the full-screen arrows), so it is still useful and shouldn't be disabled.

Here I'm enabling the button if the window is *fullscreenable OR (resizable AND maximizable)*. I'm also ensuring that this invariant holds whenever any of these 3 flags change (i.e. fullscreenable, resizable, maximizable).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed the enabled/disabled behavior of the maximize/fullscreen button of macOS windows