### PR TITLE
docs: corrected the ipcMain import path

### DIFF
--- a/docs/tutorial/tutorial-3-preload.md
+++ b/docs/tutorial/tutorial-3-preload.md
@@ -203,7 +203,7 @@ loading the HTML file so that the handler is guaranteed to be ready before
 you send out the `invoke` call from the renderer.
 
 ```js {1,15} title="main.js"
-const { app, BrowserWindow, ipcMain } = require('electron')
+const { app, BrowserWindow, ipcMain } = require('electron/main')
 const path = require('node:path')
 
 const createWindow = () => {


### PR DESCRIPTION
corrected the import path for ipcMain

#### Description of Change

Changed import path from electron to electron/main. Since ipcMain can only be imported from electron/main.

#### Checklist


- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes:  none
