### PR TITLE
fix: ignore all NODE_ envs from foreign parent in node process

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -656,6 +656,7 @@ filenames = {
     "shell/common/node_includes.h",
     "shell/common/node_util.cc",
     "shell/common/node_util.h",
+    "shell/common/node_util_mac.mm",
     "shell/common/options_switches.cc",
     "shell/common/options_switches.h",
     "shell/common/platform_util.cc",

--- a/shell/common/mac/codesign_util.h
+++ b/shell/common/mac/codesign_util.h
@@ -12,11 +12,11 @@ namespace electron {
 
 // Given a pid, return true if the process has the same code signature with
 // with current app.
-// This API returns true if current app is not signed, because checking
-// code signature is meaningless in this case, and failing the signature check
-// would break some features with unsigned binary (for example, process.send
-// stops working in processes created by child_process.fork, due to the
-// NODE_CHANNEL_ID env getting removed).
+// This API returns true if current app is not signed or ad-hoc signed, because
+// checking code signature is meaningless in this case, and failing the
+// signature check would break some features with unsigned binary (for example,
+// process.send stops working in processes created by child_process.fork, due
+// to the NODE_CHANNEL_ID env getting removed).
 bool ProcessSignatureIsSameWithCurrentApp(pid_t pid);
 
 }  // namespace electron

--- a/shell/common/mac/codesign_util.h
+++ b/shell/common/mac/codesign_util.h
@@ -10,9 +10,14 @@
 
 namespace electron {
 
-// Given a pid, check if the process belongs to current app by comparing its
-// code signature with current app.
-bool ProcessBelongToCurrentApp(pid_t pid);
+// Given a pid, return true if the process has the same code signature with
+// with current app.
+// This API returns true if current app is not signed, because checking
+// code signature is meaningless in this case, and failing the signature check
+// would break some features with unsigned binary (for example, process.send
+// stops working in processes created by child_process.fork, due to the
+// NODE_CHANNEL_ID env getting removed).
+bool ProcessSignatureIsSameWithCurrentApp(pid_t pid);
 
 }  // namespace electron
 

--- a/shell/common/node_util.h
+++ b/shell/common/node_util.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+#include "build/build_config.h"
 #include "v8/include/v8.h"
 
 namespace node {
@@ -25,6 +26,12 @@ v8::MaybeLocal<v8::Value> CompileAndCall(
     const char* id,
     std::vector<v8::Local<v8::String>>* parameters,
     std::vector<v8::Local<v8::Value>>* arguments);
+
+#if BUILDFLAG(IS_MAC)
+// Unset all environment variables that start with NODE_. Return false if there
+// is no node env at all.
+bool UnsetAllNodeEnvs();
+#endif
 
 }  // namespace electron::util
 

--- a/shell/common/node_util_mac.mm
+++ b/shell/common/node_util_mac.mm
@@ -1,0 +1,23 @@
+// Copyright (c) 2023 Microsoft, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/common/node_util.h"
+
+#include <Foundation/Foundation.h>
+
+namespace electron::util {
+
+bool UnsetAllNodeEnvs() {
+  bool has_unset = false;
+  for (NSString* env in NSProcessInfo.processInfo.environment) {
+    if (![env hasPrefix:@"NODE_"])
+      continue;
+    const char* name = [[env componentsSeparatedByString:@"="][0] UTF8String];
+    unsetenv(name);
+    has_unset = true;
+  }
+  return has_unset;
+}
+
+}  // namespace electron::util

--- a/spec/fixtures/api/fork-with-node-options.js
+++ b/spec/fixtures/api/fork-with-node-options.js
@@ -2,11 +2,14 @@ const { execFileSync } = require('node:child_process');
 const path = require('node:path');
 
 const fixtures = path.resolve(__dirname, '..');
+const failJs = path.join(fixtures, 'module', 'fail.js');
 
 const env = {
   ELECTRON_RUN_AS_NODE: 'true',
   // Process will exit with 1 if NODE_OPTIONS is accepted.
-  NODE_OPTIONS: `--require "${path.join(fixtures, 'module', 'fail.js')}"`
+  NODE_OPTIONS: `--require "${failJs}"`,
+  // Try bypassing the check with NODE_REPL_EXTERNAL_MODULE.
+  NODE_REPL_EXTERNAL_MODULE: failJs
 };
 // Provide a lower cased NODE_OPTIONS in case some code ignores case sensitivity
 // when reading NODE_OPTIONS.

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -673,7 +673,7 @@ describe('node feature', () => {
     });
 
     const script = path.join(fixtures, 'api', 'fork-with-node-options.js');
-    const nodeOptionsWarning = 'NODE_OPTIONS is disabled because this process is invoked by other apps';
+    const nodeOptionsWarning = 'Node.js environment variables are disabled because this process is invoked by other apps';
 
     it('is disabled when invoked by other apps in ELECTRON_RUN_AS_NODE mode', async () => {
       await withTempDirectory(async (dir) => {


### PR DESCRIPTION
#### Description of Change

This is a followup to https://github.com/electron/electron/pull/40579. 

@deepak1556 found that it is possible to work around the protection of `NODE_OPTIONS` by using another env `NODE_REPL_EXTERNAL_MODULE`, we think it is better just removing all envs start with `NODE_` in case there are new creative ways invented to work around the protection.

Note that `NODE_REPL_EXTERNAL_MODULE` only works in repl mode so only the `ELECTRON_RUN_AS_NODE` processes are affected.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Unset all Node envs in node process when parent is a foreign process.