### PR TITLE
docs: note accelerator case insensitivity

### DIFF
--- a/docs/api/accelerator.md
+++ b/docs/api/accelerator.md
@@ -4,7 +4,7 @@
 
 Accelerators are strings that can contain multiple modifiers and a single key code,
 combined by the `+` character, and are used to define keyboard shortcuts
-throughout your application.
+throughout your application.Accelerators are case sensitive.
 
 Examples:
 

--- a/docs/api/accelerator.md
+++ b/docs/api/accelerator.md
@@ -4,7 +4,7 @@
 
 Accelerators are strings that can contain multiple modifiers and a single key code,
 combined by the `+` character, and are used to define keyboard shortcuts
-throughout your application. Accelerators are case sensitive.
+throughout your application. Accelerators are case insensitive.
 
 Examples:
 

--- a/docs/api/accelerator.md
+++ b/docs/api/accelerator.md
@@ -4,7 +4,7 @@
 
 Accelerators are strings that can contain multiple modifiers and a single key code,
 combined by the `+` character, and are used to define keyboard shortcuts
-throughout your application.Accelerators are case sensitive.
+throughout your application. Accelerators are case sensitive.
 
 Examples:
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/38673.

Explicitly state that accelerators are case insensitive

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples --> none