### PR TITLE
fix: make grant_file_protocol_extra_privileges fuse also block CORS fetches

### DIFF
--- a/spec/fixtures/apps/remote-control/main.js
+++ b/spec/fixtures/apps/remote-control/main.js
@@ -1,4 +1,7 @@
-const { app } = require('electron');
+// eslint-disable-next-line camelcase
+const electron_1 = require('electron');
+// eslint-disable-next-line camelcase
+const { app } = electron_1;
 const http = require('node:http');
 const v8 = require('node:v8');
 // eslint-disable-next-line camelcase,@typescript-eslint/no-unused-vars

--- a/spec/fuses-spec.ts
+++ b/spec/fuses-spec.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { startRemoteControlApp } from './lib/spec-helpers';
+import { once } from 'node:events';
+import { spawn } from 'node:child_process';
+import { BrowserWindow } from 'electron';
+import path = require('node:path');
+
+describe('fuses', () => {
+  it('can be enabled by command-line argument during testing', async () => {
+    const child0 = spawn(process.execPath, ['-v'], { env: { NODE_OPTIONS: '-e 0' } });
+    const [code0] = await once(child0, 'exit');
+    // Should exit with 9 because -e is not allowed in NODE_OPTIONS
+    expect(code0).to.equal(9);
+    const child1 = spawn(process.execPath, ['--set-fuse-node_options=0', '-v'], { env: { NODE_OPTIONS: '-e 0' } });
+    const [code1] = await once(child1, 'exit');
+    // Should print the version and exit with 0
+    expect(code1).to.equal(0);
+  });
+
+  it('disables fetching file:// URLs when grant_file_protocol_extra_privileges is 0', async () => {
+    const rc = await startRemoteControlApp(['--set-fuse-grant_file_protocol_extra_privileges=0']);
+    await expect(rc.remotely(async (fixture: string) => {
+      const bw = new BrowserWindow({ show: false });
+      await bw.loadFile(fixture);
+      return await bw.webContents.executeJavaScript("ajax('file:///etc/passwd')");
+    }, path.join(__dirname, 'fixtures', 'pages', 'fetch.html'))).to.eventually.be.rejectedWith('Failed to fetch');
+  });
+});


### PR DESCRIPTION
#### Description of Change

This adds new testing infrastructure for fuses, and uses it to add a test for
the grant_file_protocol_extra_privileges fuse. Also, fix a bug with the
implementation of that fuse.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed the `GrantFileProtocolExtraPrivileges` not correctly preventing `fetch()` calls to `file://` URLs.
