### PR TITLE
chore: cherry-pick 7 changes from Release-1-M120

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -139,3 +139,8 @@ feat_allow_code_cache_in_custom_schemes.patch
 fix_font_flooding_in_dev_tools.patch
 cherry-pick-5fde415e06f9.patch
 cherry-pick-8d607d3921b8.patch
+cherry-pick-998e947b265f.patch
+cherry-pick-021598ea43c1.patch
+cherry-pick-76340163a820.patch
+cherry-pick-f15cfb9371c4.patch
+cherry-pick-4ca62c7a8b88.patch

--- a/patches/chromium/cherry-pick-021598ea43c1.patch
+++ b/patches/chromium/cherry-pick-021598ea43c1.patch
@@ -1,7 +1,7 @@
-From 021598ea43c1cbcd6317432858c0f61929c51b1b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Guido Urdaneta <guidou@chromium.org>
-Date: Mon, 04 Dec 2023 23:00:41 +0000
-Subject: [PATCH] [InsertableStreams] Drop frames received on the wrong task runner
+Date: Mon, 4 Dec 2023 23:00:41 +0000
+Subject: Drop frames received on the wrong task runner
 
 It can happen during transfer that a frame is posted from the
 background media thread to the task runner of the old execution
@@ -24,13 +24,12 @@ Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
 Auto-Submit: Guido Urdaneta <guidou@chromium.org>
 Cr-Commit-Position: refs/branch-heads/6099@{#1370}
 Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
----
 
 diff --git a/third_party/blink/renderer/modules/peerconnection/rtc_encoded_audio_underlying_source.cc b/third_party/blink/renderer/modules/peerconnection/rtc_encoded_audio_underlying_source.cc
-index a934e800..5556158 100644
+index b5a2f71bae81bba6e61d8f303d24a9df874ae885..4c7b0b982e3d314749e39178eb0fca706d11bd85 100644
 --- a/third_party/blink/renderer/modules/peerconnection/rtc_encoded_audio_underlying_source.cc
 +++ b/third_party/blink/renderer/modules/peerconnection/rtc_encoded_audio_underlying_source.cc
-@@ -60,7 +60,15 @@
+@@ -58,7 +58,15 @@ void RTCEncodedAudioUnderlyingSource::Trace(Visitor* visitor) const {
  
  void RTCEncodedAudioUnderlyingSource::OnFrameFromSource(
      std::unique_ptr<webrtc::TransformableAudioFrameInterface> webrtc_frame) {
@@ -48,10 +47,10 @@ index a934e800..5556158 100644
    // drop the new frame.
    if (!disconnect_callback_ || !GetExecutionContext()) {
 diff --git a/third_party/blink/renderer/modules/peerconnection/rtc_encoded_video_underlying_source.cc b/third_party/blink/renderer/modules/peerconnection/rtc_encoded_video_underlying_source.cc
-index 5655f36..71c1801 100644
+index 54ca7d1529b1772200c3691b56e847acc42d086d..8fb1d8460e289cd5e6764271f79dada7f121cb1b 100644
 --- a/third_party/blink/renderer/modules/peerconnection/rtc_encoded_video_underlying_source.cc
 +++ b/third_party/blink/renderer/modules/peerconnection/rtc_encoded_video_underlying_source.cc
-@@ -60,7 +60,15 @@
+@@ -58,7 +58,15 @@ void RTCEncodedVideoUnderlyingSource::Trace(Visitor* visitor) const {
  
  void RTCEncodedVideoUnderlyingSource::OnFrameFromSource(
      std::unique_ptr<webrtc::TransformableVideoFrameInterface> webrtc_frame) {

--- a/patches/chromium/cherry-pick-021598ea43c1.patch
+++ b/patches/chromium/cherry-pick-021598ea43c1.patch
@@ -1,0 +1,70 @@
+From 021598ea43c1cbcd6317432858c0f61929c51b1b Mon Sep 17 00:00:00 2001
+From: Guido Urdaneta <guidou@chromium.org>
+Date: Mon, 04 Dec 2023 23:00:41 +0000
+Subject: [PATCH] [InsertableStreams] Drop frames received on the wrong task runner
+
+It can happen during transfer that a frame is posted from the
+background media thread to the task runner of the old execution
+context, which can lead to races and UAF.
+
+This CL makes underlying sources drop frames received on the
+wrong task runner to avoid the problem.
+
+(cherry picked from commit 9d042e0d498356185fe9eb33c53b69fab33d06bf)
+
+Bug: 1505708
+Change-Id: I686228d88cb1c48bdf8c0b6bf85edd280a54300a
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5077845
+Commit-Queue: Guido Urdaneta <guidou@chromium.org>
+Reviewed-by: Tony Herre <toprice@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1231802}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5082444
+Commit-Queue: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: Guido Urdaneta <guidou@chromium.org>
+Cr-Commit-Position: refs/branch-heads/6099@{#1370}
+Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
+---
+
+diff --git a/third_party/blink/renderer/modules/peerconnection/rtc_encoded_audio_underlying_source.cc b/third_party/blink/renderer/modules/peerconnection/rtc_encoded_audio_underlying_source.cc
+index a934e800..5556158 100644
+--- a/third_party/blink/renderer/modules/peerconnection/rtc_encoded_audio_underlying_source.cc
++++ b/third_party/blink/renderer/modules/peerconnection/rtc_encoded_audio_underlying_source.cc
+@@ -60,7 +60,15 @@
+ 
+ void RTCEncodedAudioUnderlyingSource::OnFrameFromSource(
+     std::unique_ptr<webrtc::TransformableAudioFrameInterface> webrtc_frame) {
+-  DCHECK(task_runner_->BelongsToCurrentThread());
++  // It can happen that a frame is posted to the task runner of the old
++  // execution context during a stream transfer to a new context.
++  // TODO(https://crbug.com/1506631): Make the state updates related to the
++  // transfer atomic and turn this into a DCHECK.
++  if (!task_runner_->BelongsToCurrentThread()) {
++    DVLOG(1) << "Dropped frame posted to incorrect task runner. This can "
++                "happen during transfer.";
++    return;
++  }
+   // If the source is canceled or there are too many queued frames,
+   // drop the new frame.
+   if (!disconnect_callback_ || !GetExecutionContext()) {
+diff --git a/third_party/blink/renderer/modules/peerconnection/rtc_encoded_video_underlying_source.cc b/third_party/blink/renderer/modules/peerconnection/rtc_encoded_video_underlying_source.cc
+index 5655f36..71c1801 100644
+--- a/third_party/blink/renderer/modules/peerconnection/rtc_encoded_video_underlying_source.cc
++++ b/third_party/blink/renderer/modules/peerconnection/rtc_encoded_video_underlying_source.cc
+@@ -60,7 +60,15 @@
+ 
+ void RTCEncodedVideoUnderlyingSource::OnFrameFromSource(
+     std::unique_ptr<webrtc::TransformableVideoFrameInterface> webrtc_frame) {
+-  DCHECK(task_runner_->BelongsToCurrentThread());
++  // It can happen that a frame is posted to the task runner of the old
++  // execution context during a stream transfer to a new context.
++  // TODO(https://crbug.com/1506631): Make the state updates related to the
++  // transfer atomic and turn this into a DCHECK.
++  if (!task_runner_->BelongsToCurrentThread()) {
++    DVLOG(1) << "Dropped frame posted to incorrect task runner. This can "
++                "happen during transfer.";
++    return;
++  }
+   // If the source is canceled or there are too many queued frames,
+   // drop the new frame.
+   if (!disconnect_callback_ || !GetExecutionContext()) {

--- a/patches/chromium/cherry-pick-4ca62c7a8b88.patch
+++ b/patches/chromium/cherry-pick-4ca62c7a8b88.patch
@@ -1,7 +1,7 @@
-From 4ca62c7a8b88d3343f4ab743bbb939d6d19fb736 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Vasiliy Telezhnikov <vasilyt@chromium.org>
-Date: Thu, 07 Dec 2023 16:56:57 +0000
-Subject: [PATCH] Check for slugs count before deserializing Slugs in DrawSlugOp
+Date: Thu, 7 Dec 2023 16:56:57 +0000
+Subject: Check for slugs count before deserializing Slugs in DrawSlugOp
 
 Count is part of serialized data and while we never serialize values
 less then 1, it can be any value when coming over IPC, we should check
@@ -19,13 +19,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5096809
 Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
 Cr-Commit-Position: refs/branch-heads/6099@{#1428}
 Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
----
 
 diff --git a/cc/paint/paint_op.cc b/cc/paint/paint_op.cc
-index fa753ce..d82e97a 100644
+index bd39210efa9a4da6f3888dd25ef465a1d0a4cc70..4c88eaa1e57ddae2c7fb0ba94d66b843ab8f63f2 100644
 --- a/cc/paint/paint_op.cc
 +++ b/cc/paint/paint_op.cc
-@@ -971,10 +971,12 @@
+@@ -976,10 +976,12 @@ PaintOp* DrawSlugOp::Deserialize(PaintOpReader& reader, void* output) {
    reader.Read(&op->flags);
    unsigned int count = 0;
    reader.Read(&count);

--- a/patches/chromium/cherry-pick-4ca62c7a8b88.patch
+++ b/patches/chromium/cherry-pick-4ca62c7a8b88.patch
@@ -1,0 +1,44 @@
+From 4ca62c7a8b88d3343f4ab743bbb939d6d19fb736 Mon Sep 17 00:00:00 2001
+From: Vasiliy Telezhnikov <vasilyt@chromium.org>
+Date: Thu, 07 Dec 2023 16:56:57 +0000
+Subject: [PATCH] Check for slugs count before deserializing Slugs in DrawSlugOp
+
+Count is part of serialized data and while we never serialize values
+less then 1, it can be any value when coming over IPC, we should check
+that it's positive before substacting one.
+
+(cherry picked from commit 0527e0d5b08a13d63f4f1eeefa1b86ecfd0cb63b)
+
+Bug: 1506726
+Change-Id: I244f50a682f2e852b22ba88f1e9cddddb0fdfcb9
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5078779
+Reviewed-by: Peng Huang <penghuang@chromium.org>
+Commit-Queue: Vasiliy Telezhnikov <vasilyt@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1232013}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5096809
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/6099@{#1428}
+Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
+---
+
+diff --git a/cc/paint/paint_op.cc b/cc/paint/paint_op.cc
+index fa753ce..d82e97a 100644
+--- a/cc/paint/paint_op.cc
++++ b/cc/paint/paint_op.cc
+@@ -971,10 +971,12 @@
+   reader.Read(&op->flags);
+   unsigned int count = 0;
+   reader.Read(&count);
+-  reader.Read(&op->slug);
+-  op->extra_slugs.resize(count - 1);
+-  for (auto& extra_slug : op->extra_slugs) {
+-    reader.Read(&extra_slug);
++  if (count > 0) {
++    reader.Read(&op->slug);
++    op->extra_slugs.resize(count - 1);
++    for (auto& extra_slug : op->extra_slugs) {
++      reader.Read(&extra_slug);
++    }
+   }
+   return op;
+ }

--- a/patches/chromium/cherry-pick-76340163a820.patch
+++ b/patches/chromium/cherry-pick-76340163a820.patch
@@ -1,7 +1,7 @@
-From 76340163a820d608214be06807e24bcc326a97fb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paul Semel <paulsemel@chromium.org>
-Date: Wed, 06 Dec 2023 15:52:56 +0000
-Subject: [PATCH] [M120] ImageBitmapFactory: fix empty context dcheck
+Date: Wed, 6 Dec 2023 15:52:56 +0000
+Subject: ImageBitmapFactory: fix empty context dcheck
 
 Approved by:
 https://bugs.chromium.org/p/chromium/issues/detail?id=1502102#c34
@@ -19,13 +19,12 @@ Auto-Submit: Arthur Sonzogni <arthursonzogni@google.com>
 Reviewed-by: Paul Semel <paulsemel@chromium.org>
 Cr-Commit-Position: refs/branch-heads/6099@{#1416}
 Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
----
 
 diff --git a/third_party/blink/renderer/modules/canvas/imagebitmap/image_bitmap_factories.cc b/third_party/blink/renderer/modules/canvas/imagebitmap/image_bitmap_factories.cc
-index 8ddc44f5..665217c1 100644
+index 4693dbc043f27d3799c4df127a1a91905ca1860a..19a9bee39a6aafb528b004b7757a69f47cf10658 100644
 --- a/third_party/blink/renderer/modules/canvas/imagebitmap/image_bitmap_factories.cc
 +++ b/third_party/blink/renderer/modules/canvas/imagebitmap/image_bitmap_factories.cc
-@@ -155,7 +155,9 @@
+@@ -155,7 +155,9 @@ ScriptPromise ImageBitmapFactories::CreateImageBitmapFromBlob(
      ImageBitmapSource* bitmap_source,
      absl::optional<gfx::Rect> crop_rect,
      const ImageBitmapOptions* options) {

--- a/patches/chromium/cherry-pick-76340163a820.patch
+++ b/patches/chromium/cherry-pick-76340163a820.patch
@@ -1,0 +1,38 @@
+From 76340163a820d608214be06807e24bcc326a97fb Mon Sep 17 00:00:00 2001
+From: Paul Semel <paulsemel@chromium.org>
+Date: Wed, 06 Dec 2023 15:52:56 +0000
+Subject: [PATCH] [M120] ImageBitmapFactory: fix empty context dcheck
+
+Approved by:
+https://bugs.chromium.org/p/chromium/issues/detail?id=1502102#c34
+
+(cherry picked from commit c4d2f15b8f97076c8fd0f9aa5814b94db698b75c)
+
+Fixed: 1502102
+Change-Id: Ib42d2897d62136ae835561bcf56884b5624060a5
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5071252
+Commit-Queue: Paul Semel <paulsemel@chromium.org>
+Reviewed-by: Jean-Philippe Gravel <jpgravel@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1230617}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5088373
+Auto-Submit: Arthur Sonzogni <arthursonzogni@google.com>
+Reviewed-by: Paul Semel <paulsemel@chromium.org>
+Cr-Commit-Position: refs/branch-heads/6099@{#1416}
+Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
+---
+
+diff --git a/third_party/blink/renderer/modules/canvas/imagebitmap/image_bitmap_factories.cc b/third_party/blink/renderer/modules/canvas/imagebitmap/image_bitmap_factories.cc
+index 8ddc44f5..665217c1 100644
+--- a/third_party/blink/renderer/modules/canvas/imagebitmap/image_bitmap_factories.cc
++++ b/third_party/blink/renderer/modules/canvas/imagebitmap/image_bitmap_factories.cc
+@@ -155,7 +155,9 @@
+     ImageBitmapSource* bitmap_source,
+     absl::optional<gfx::Rect> crop_rect,
+     const ImageBitmapOptions* options) {
+-  DCHECK(script_state->ContextIsValid());
++  if (!script_state->ContextIsValid()) {
++    return ScriptPromise();
++  }
+ 
+   // imageOrientation: 'from-image' will be used to replace imageOrientation:
+   // 'none'. Adding a deprecation warning when 'none' is called in

--- a/patches/chromium/cherry-pick-998e947b265f.patch
+++ b/patches/chromium/cherry-pick-998e947b265f.patch
@@ -1,0 +1,175 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yi Gu <yigu@chromium.org>
+Date: Fri, 1 Dec 2023 00:10:37 +0000
+Subject: Check API permission before showing accounts UI
+
+The accounts fetch could be delayed for legitimate reasons. A user may be
+able to disable FedCM API (e.g. via settings or dismissing another FedCM
+UI on the same RP origin) before the browser receives the accounts
+response.
+
+This patch checks the API permission before showing the accounts UI.
+
+(cherry picked from commit 98676a2f66c4b4b802316eef70f4aab77e631f85)
+
+Change-Id: Idbbe88912941113ec3f54d7f222845cd774dc897
+Bug: 1500921
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5064052
+Commit-Queue: Yi Gu <yigu@chromium.org>
+Reviewed-by: Christian Biesinger <cbiesinger@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1229912}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5074630
+Auto-Submit: Yi Gu <yigu@chromium.org>
+Cr-Commit-Position: refs/branch-heads/6099@{#1255}
+Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
+
+diff --git a/content/browser/webid/federated_auth_request_impl.cc b/content/browser/webid/federated_auth_request_impl.cc
+index b2717870cd40ec50fb8c6d22fab5fae89f5c9a20..5c8431c19e376f493fbb22bfdf626188e1fdaf20 100644
+--- a/content/browser/webid/federated_auth_request_impl.cc
++++ b/content/browser/webid/federated_auth_request_impl.cc
+@@ -685,9 +685,7 @@ void FederatedAuthRequestImpl::RequestToken(
+   request_dialog_controller_ = CreateDialogController();
+   start_time_ = base::TimeTicks::Now();
+ 
+-  FederatedApiPermissionStatus permission_status =
+-      GetApiPermissionStatus(url::Origin::Create(
+-          idp_get_params_ptrs[0]->providers[0]->get_federated()->config_url));
++  FederatedApiPermissionStatus permission_status = GetApiPermissionStatus();
+ 
+   absl::optional<TokenStatus> error_token_status;
+   FederatedAuthRequestResult request_result =
+@@ -896,8 +894,7 @@ void FederatedAuthRequestImpl::LogoutRps(
+     return;
+   }
+ 
+-  if (GetApiPermissionStatus(origin()) !=
+-      FederatedApiPermissionStatus::GRANTED) {
++  if (GetApiPermissionStatus() != FederatedApiPermissionStatus::GRANTED) {
+     CompleteLogoutRequest(LogoutRpsStatus::kError);
+     return;
+   }
+@@ -1181,6 +1178,18 @@ void FederatedAuthRequestImpl::MaybeShowAccountsDialog() {
+     return;
+   }
+ 
++  // The accounts fetch could be delayed for legitimate reasons. A user may be
++  // able to disable FedCM API (e.g. via settings or dismissing another FedCM UI
++  // on the same RP origin) before the browser receives the accounts response.
++  // We should exit early without showing any UI.
++  if (GetApiPermissionStatus() != FederatedApiPermissionStatus::GRANTED) {
++    CompleteRequestWithError(
++        FederatedAuthRequestResult::kErrorDisabledInSettings,
++        TokenStatus::kDisabledInSettings,
++        /*should_delay_callback=*/true);
++    return;
++  }
++
+   // The RenderFrameHost may be alive but not visible in the following
+   // situations:
+   // Situation #1: User switched tabs
+@@ -1619,9 +1628,7 @@ void FederatedAuthRequestImpl::OnAccountSelected(const GURL& idp_config_url,
+   // settings are changed while an existing FedCM UI is displayed. Ideally, we
+   // should enforce this check before all requests but users typically won't
+   // have time to disable the FedCM API in other types of requests.
+-  url::Origin idp_origin = url::Origin::Create(idp_config_url);
+-  if (GetApiPermissionStatus(idp_origin) !=
+-      FederatedApiPermissionStatus::GRANTED) {
++  if (GetApiPermissionStatus() != FederatedApiPermissionStatus::GRANTED) {
+     CompleteRequestWithError(
+         FederatedAuthRequestResult::kErrorDisabledInSettings,
+         TokenStatus::kDisabledInSettings,
+@@ -2262,8 +2269,8 @@ void FederatedAuthRequestImpl::OnRejectRequest() {
+   }
+ }
+ 
+-FederatedApiPermissionStatus FederatedAuthRequestImpl::GetApiPermissionStatus(
+-    const url::Origin& idp_origin) {
++FederatedApiPermissionStatus
++FederatedAuthRequestImpl::GetApiPermissionStatus() {
+   DCHECK(api_permission_delegate_);
+   FederatedApiPermissionStatus status =
+       api_permission_delegate_->GetApiPermissionStatus(GetEmbeddingOrigin());
+@@ -2271,7 +2278,7 @@ FederatedApiPermissionStatus FederatedAuthRequestImpl::GetApiPermissionStatus(
+   // status API is enabled, in general or through OT.
+   if (status ==
+           FederatedApiPermissionStatus::BLOCKED_THIRD_PARTY_COOKIES_BLOCKED &&
+-      webid::GetIdpSigninStatusMode(render_frame_host(), idp_origin) ==
++      webid::GetIdpSigninStatusMode(render_frame_host(), url::Origin()) ==
+           FedCmIdpSigninStatusMode::ENABLED) {
+     status = FederatedApiPermissionStatus::GRANTED;
+   }
+diff --git a/content/browser/webid/federated_auth_request_impl.h b/content/browser/webid/federated_auth_request_impl.h
+index aaf21e3f443ae26d4918602943117d695c0e54ff..d7117ee9c1424107b168a45edc21b4182a27cbd8 100644
+--- a/content/browser/webid/federated_auth_request_impl.h
++++ b/content/browser/webid/federated_auth_request_impl.h
+@@ -109,10 +109,9 @@ class CONTENT_EXPORT FederatedAuthRequestImpl
+   // Rejects the pending request if it has not been resolved naturally yet.
+   void OnRejectRequest();
+ 
+-  // This wrapper around FederatedIdentityApiPermissionContextDelegate ensures
+-  // that we handle BLOCKED_THIRD_PARTY_COOKIES_BLOCKED correctly.
++  // Returns whether the API is enabled or not.
+   FederatedIdentityApiPermissionContextDelegate::PermissionStatus
+-  GetApiPermissionStatus(const url::Origin& idp_origin);
++  GetApiPermissionStatus();
+ 
+   struct IdentityProviderGetInfo {
+     IdentityProviderGetInfo(blink::mojom::IdentityProviderConfigPtr,
+diff --git a/content/browser/webid/federated_auth_request_impl_unittest.cc b/content/browser/webid/federated_auth_request_impl_unittest.cc
+index 347fc6a19609c88313ccbbe7fda7841c7ff8268d..ea886ed50780007ec0f2a7babc9caeaa58cb1bb8 100644
+--- a/content/browser/webid/federated_auth_request_impl_unittest.cc
++++ b/content/browser/webid/federated_auth_request_impl_unittest.cc
+@@ -711,15 +711,28 @@ class TestDialogController
+ 
+ class TestApiPermissionDelegate : public MockApiPermissionDelegate {
+  public:
+-  std::pair<url::Origin, ApiPermissionStatus> permission_override_ =
++  using PermissionOverride = std::pair<url::Origin, ApiPermissionStatus>;
++  PermissionOverride permission_override_ =
+       std::make_pair(url::Origin(), ApiPermissionStatus::GRANTED);
++  absl::optional<std::pair<size_t, PermissionOverride>>
++      permission_override_for_nth_;
+   std::set<url::Origin> embargoed_origins_;
++  size_t api_invocation_counter{0};
+ 
+   ApiPermissionStatus GetApiPermissionStatus(
+       const url::Origin& origin) override {
++    ++api_invocation_counter;
++
+     if (embargoed_origins_.count(origin))
+       return ApiPermissionStatus::BLOCKED_EMBARGO;
+ 
++    if (permission_override_for_nth_ &&
++        permission_override_for_nth_->first == api_invocation_counter) {
++      return (origin == permission_override_for_nth_->second.first)
++                 ? permission_override_for_nth_->second.second
++                 : ApiPermissionStatus::GRANTED;
++    }
++
+     return (origin == permission_override_.first)
+                ? permission_override_.second
+                : ApiPermissionStatus::GRANTED;
+@@ -4991,4 +5004,23 @@ TEST_F(FederatedAuthRequestImplTest, InvalidResponseErrorDialogDisabled) {
+   EXPECT_FALSE(dialog_controller_state_.did_show_error_dialog);
+ }
+ 
++// Test that the account UI is not displayed if FedCM is disabled after accounts
++// fetch.
++TEST_F(FederatedAuthRequestImplTest,
++       AccountUiNotDisplayedIfFedCmDisabledAfterAccountsFetch) {
++  test_api_permission_delegate_->permission_override_for_nth_ = std::make_pair(
++      /*override the nth invocation=*/2,
++      std::make_pair(main_test_rfh()->GetLastCommittedOrigin(),
++                     ApiPermissionStatus::BLOCKED_EMBARGO));
++
++  RequestExpectations expectations = {
++      RequestTokenStatus::kError,
++      FederatedAuthRequestResult::kErrorDisabledInSettings,
++      /*standalone_console_message=*/absl::nullopt,
++      /*selected_idp_config_url=*/absl::nullopt};
++  RunAuthTest(kDefaultRequestParameters, expectations, kConfigurationValid);
++  EXPECT_TRUE(DidFetch(FetchedEndpoint::ACCOUNTS));
++  EXPECT_FALSE(did_show_accounts_dialog());
++}
++
+ }  // namespace content

--- a/patches/chromium/cherry-pick-f15cfb9371c4.patch
+++ b/patches/chromium/cherry-pick-f15cfb9371c4.patch
@@ -1,0 +1,181 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kai Ninomiya <kainino@chromium.org>
+Date: Thu, 7 Dec 2023 14:31:32 +0000
+Subject: Fix reinit order in
+ ContextProviderCommandBuffer::BindToCurrentSequence
+
+See comments for explanation.
+
+(cherry picked from commit 7d8400ceb56db5fd97249f787251fe8b3928e6fd)
+
+Bug: 1505632
+Change-Id: I0f43821a9708af91303048332e9fae5e100deee5
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5069480
+Reviewed-by: Saifuddin Hitawala <hitawala@chromium.org>
+Commit-Queue: Kai Ninomiya <kainino@chromium.org>
+Reviewed-by: Brendon Tiszka <tiszka@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1230735}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5095795
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: Saifuddin Hitawala <hitawala@chromium.org>
+Auto-Submit: Kai Ninomiya <kainino@chromium.org>
+Cr-Commit-Position: refs/branch-heads/6099@{#1424}
+Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
+
+diff --git a/services/viz/public/cpp/gpu/context_provider_command_buffer.cc b/services/viz/public/cpp/gpu/context_provider_command_buffer.cc
+index 4d516f50bf2270c7fcf152dad5a11795a3e02232..da496e51d04af6699058cea36de0da65a01cdc3a 100644
+--- a/services/viz/public/cpp/gpu/context_provider_command_buffer.cc
++++ b/services/viz/public/cpp/gpu/context_provider_command_buffer.cc
+@@ -169,13 +169,13 @@ gpu::ContextResult ContextProviderCommandBuffer::BindToCurrentSequence() {
+     }
+ 
+     // The transfer buffer is used to serialize Dawn commands
+-    transfer_buffer_ =
++    auto transfer_buffer =
+         std::make_unique<gpu::TransferBuffer>(webgpu_helper.get());
+ 
+     // The WebGPUImplementation exposes the WebGPUInterface, as well as the
+     // gpu::ContextSupport interface.
+     auto webgpu_impl = std::make_unique<gpu::webgpu::WebGPUImplementation>(
+-        webgpu_helper.get(), transfer_buffer_.get(), command_buffer_.get());
++        webgpu_helper.get(), transfer_buffer.get(), command_buffer_.get());
+     bind_result_ = webgpu_impl->Initialize(memory_limits_);
+     if (bind_result_ != gpu::ContextResult::kSuccess) {
+       DLOG(ERROR) << "Failed to initialize WebGPUImplementation.";
+@@ -187,8 +187,11 @@ gpu::ContextResult ContextProviderCommandBuffer::BindToCurrentSequence() {
+     std::string unique_context_name =
+         base::StringPrintf("%s-%p", type_name.c_str(), webgpu_impl.get());
+ 
++    // IMPORTANT: These hold raw_ptrs to each other, so must be set together.
++    // See note in the header (and keep it up to date if things change).
+     impl_ = webgpu_impl.get();
+     webgpu_interface_ = std::move(webgpu_impl);
++    transfer_buffer_ = std::move(transfer_buffer);
+     helper_ = std::move(webgpu_helper);
+   } else if (attributes_.enable_raster_interface &&
+              !attributes_.enable_gles2_interface &&
+@@ -206,14 +209,14 @@ gpu::ContextResult ContextProviderCommandBuffer::BindToCurrentSequence() {
+     }
+     // The transfer buffer is used to copy resources between the client
+     // process and the GPU process.
+-    transfer_buffer_ =
++    auto transfer_buffer =
+         std::make_unique<gpu::TransferBuffer>(raster_helper.get());
+ 
+     // The RasterImplementation exposes the RasterInterface, as well as the
+     // gpu::ContextSupport interface.
+     DCHECK(channel_);
+     auto raster_impl = std::make_unique<gpu::raster::RasterImplementation>(
+-        raster_helper.get(), transfer_buffer_.get(),
++        raster_helper.get(), transfer_buffer.get(),
+         attributes_.bind_generates_resource,
+         attributes_.lose_context_when_out_of_memory, command_buffer_.get(),
+         channel_->image_decode_accelerator_proxy());
+@@ -230,8 +233,11 @@ gpu::ContextResult ContextProviderCommandBuffer::BindToCurrentSequence() {
+     raster_impl->TraceBeginCHROMIUM("gpu_toplevel",
+                                     unique_context_name.c_str());
+ 
++    // IMPORTANT: These hold raw_ptrs to each other, so must be set together.
++    // See note in the header (and keep it up to date if things change).
+     impl_ = raster_impl.get();
+     raster_interface_ = std::move(raster_impl);
++    transfer_buffer_ = std::move(transfer_buffer);
+     helper_ = std::move(raster_helper);
+   } else {
+     // The GLES2 helper writes the command buffer protocol.
+@@ -246,7 +252,7 @@ gpu::ContextResult ContextProviderCommandBuffer::BindToCurrentSequence() {
+ 
+     // The transfer buffer is used to copy resources between the client
+     // process and the GPU process.
+-    transfer_buffer_ =
++    auto transfer_buffer =
+         std::make_unique<gpu::TransferBuffer>(gles2_helper.get());
+ 
+     // The GLES2Implementation exposes the OpenGLES2 API, as well as the
+@@ -259,13 +265,13 @@ gpu::ContextResult ContextProviderCommandBuffer::BindToCurrentSequence() {
+       // we only use it if grcontext_support was requested.
+       gles2_impl = std::make_unique<
+           skia_bindings::GLES2ImplementationWithGrContextSupport>(
+-          gles2_helper.get(), /*share_group=*/nullptr, transfer_buffer_.get(),
++          gles2_helper.get(), /*share_group=*/nullptr, transfer_buffer.get(),
+           attributes_.bind_generates_resource,
+           attributes_.lose_context_when_out_of_memory,
+           support_client_side_arrays, command_buffer_.get());
+     } else {
+       gles2_impl = std::make_unique<gpu::gles2::GLES2Implementation>(
+-          gles2_helper.get(), /*share_group=*/nullptr, transfer_buffer_.get(),
++          gles2_helper.get(), /*share_group=*/nullptr, transfer_buffer.get(),
+           attributes_.bind_generates_resource,
+           attributes_.lose_context_when_out_of_memory,
+           support_client_side_arrays, command_buffer_.get());
+@@ -276,8 +282,11 @@ gpu::ContextResult ContextProviderCommandBuffer::BindToCurrentSequence() {
+       return bind_result_;
+     }
+ 
++    // IMPORTANT: These hold raw_ptrs to each other, so must be set together.
++    // See note in the header (and keep it up to date if things change).
+     impl_ = gles2_impl.get();
+     gles2_impl_ = std::move(gles2_impl);
++    transfer_buffer_ = std::move(transfer_buffer);
+     helper_ = std::move(gles2_helper);
+   }
+ 
+@@ -311,6 +320,7 @@ gpu::ContextResult ContextProviderCommandBuffer::BindToCurrentSequence() {
+             switches::kEnableGpuClientTracing)) {
+       // This wraps the real GLES2Implementation and we should always use this
+       // instead when it's present.
++      // IMPORTANT: This holds a raw_ptr to gles2_impl_.
+       trace_impl_ = std::make_unique<gpu::gles2::GLES2TraceImplementation>(
+           gles2_impl_.get());
+       gl = trace_impl_.get();
+diff --git a/services/viz/public/cpp/gpu/context_provider_command_buffer.h b/services/viz/public/cpp/gpu/context_provider_command_buffer.h
+index c5fdc66539ed7b0535e0ba84ac2858d7a95a4bb1..47600f1754a79a349ed48896bd8bab91b4634376 100644
+--- a/services/viz/public/cpp/gpu/context_provider_command_buffer.h
++++ b/services/viz/public/cpp/gpu/context_provider_command_buffer.h
+@@ -156,19 +156,42 @@ class ContextProviderCommandBuffer
+   // associated shared images are destroyed.
+   std::unique_ptr<gpu::ClientSharedImageInterface> shared_image_interface_;
+ 
+-  base::Lock context_lock_;  // Referenced by command_buffer_.
++  //////////////////////////////////////////////////////////////////////////////
++  // IMPORTANT NOTE: All of the objects in this block are part of a complex   //
++  // graph of raw pointers (holder or pointee of various raw_ptrs). They are  //
++  // defined in topological order: only later items point to earlier items.   //
++  // - When writing any member, always ensure its pointers to earlier members
++  //   are guaranteed to stay alive.
++  // - When clearing OR overwriting any member, always ensure objects that
++  //   point to it have already been cleared.
++  //     - The topological order of definitions guarantees that the
++  //       destructors will be called in the correct order (bottom to top).
++  //     - When overwriting multiple members, similarly do so in reverse order.
++  //
++  // Please note these comments are likely not to stay perfectly up-to-date.
++
++  base::Lock context_lock_;
++  // Points to the context_lock_ field of `this`.
+   std::unique_ptr<gpu::CommandBufferProxyImpl> command_buffer_;
++
++  // Points to command_buffer_.
+   std::unique_ptr<gpu::CommandBufferHelper> helper_;
++  // Points to helper_.
+   std::unique_ptr<gpu::TransferBuffer> transfer_buffer_;
+ 
++  // Points to transfer_buffer_, helper_, and command_buffer_.
+   std::unique_ptr<gpu::gles2::GLES2Implementation> gles2_impl_;
++  // Points to gles2_impl_.
+   std::unique_ptr<gpu::gles2::GLES2TraceImplementation> trace_impl_;
++  // Points to transfer_buffer_, helper_, and command_buffer_.
+   std::unique_ptr<gpu::raster::RasterInterface> raster_interface_;
++  // Points to transfer_buffer_, helper_, and command_buffer_.
+   std::unique_ptr<gpu::webgpu::WebGPUInterface> webgpu_interface_;
++  // This is an alias for gles2_impl_, raster_interface_, or webgpu_interface_.
++  raw_ptr<gpu::ImplementationBase> impl_ = nullptr;
+ 
+-  // Owned by one of gles2_impl_, raster_interface_, or webgpu_interface_. It
+-  // must be declared last and cleared first.
+-  raw_ptr<gpu::ImplementationBase> impl_;
++  // END IMPORTANT NOTE                                                       //
++  //////////////////////////////////////////////////////////////////////////////
+ 
+   std::unique_ptr<skia_bindings::GrContextForGLES2Interface> gr_context_;
+ 

--- a/patches/config.json
+++ b/patches/config.json
@@ -21,5 +21,7 @@
 
   "src/electron/patches/ReactiveObjC": "src/third_party/squirrel.mac/vendor/ReactiveObjC",
 
-  "src/electron/patches/webrtc": "src/third_party/webrtc"
+  "src/electron/patches/webrtc": "src/third_party/webrtc",
+
+  "src/electron/patches/libavif": "src/third_party/libavif/src"
 }

--- a/patches/libavif/.patches
+++ b/patches/libavif/.patches
@@ -1,0 +1,1 @@
+do_not_store_colorproperties_until_alpha_item_is_found.patch

--- a/patches/libavif/do_not_store_colorproperties_until_alpha_item_is_found.patch
+++ b/patches/libavif/do_not_store_colorproperties_until_alpha_item_is_found.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vignesh Venkatasubramanian <vigneshv@google.com>
+Date: Tue, 28 Nov 2023 08:44:22 -0800
+Subject: Do not store colorproperties until alpha item is found
+
+colorProperties could be pointing to a dangling pointer if
+findAlphaItem() resizes the meta.items array.
+
+Manual cherry-pick of PR #1808 into the chromium-m118 branch.
+
+diff --git a/src/read.c b/src/read.c
+index e3bad9833d665cdf704726ff47fd3b0ad3e8b02a..cf9f2a797c4b996f5b9877774e7848f3006dec54 100644
+--- a/src/read.c
++++ b/src/read.c
+@@ -3938,7 +3938,6 @@ avifResult avifDecoderReset(avifDecoder * decoder)
+             avifDiagnosticsPrintf(&decoder->diag, "Primary item not found");
+             return AVIF_RESULT_MISSING_IMAGE_ITEM;
+         }
+-        colorProperties = &colorItem->properties;
+         if (!memcmp(colorItem->type, "grid", 4)) {
+             avifROData readData;
+             AVIF_CHECKRES(avifDecoderItemRead(colorItem, decoder->io, &readData, 0, 0, data->diag));
+@@ -3995,6 +3994,8 @@ avifResult avifDecoderReset(avifDecoder * decoder)
+             }
+         }
+ 
++        colorProperties = &colorItem->properties;
++
+         // Find Exif and/or XMP metadata, if any
+         AVIF_CHECKRES(avifDecoderFindMetadata(decoder, data->meta, decoder->image, colorItem->id));
+ 

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -2,3 +2,4 @@ build_gn.patch
 do_not_export_private_v8_symbols_on_windows.patch
 fix_build_deprecated_attribute_for_older_msvc_versions.patch
 chore_allow_customizing_microtask_policy_per_context.patch
+cherry-pick-cbd09b2ca928.patch

--- a/patches/v8/cherry-pick-cbd09b2ca928.patch
+++ b/patches/v8/cherry-pick-cbd09b2ca928.patch
@@ -1,0 +1,72 @@
+From cbd09b2ca928f1fd929ef52e173aa81213e38cb8 Mon Sep 17 00:00:00 2001
+From: Marja Hölttä <marja@chromium.org>
+Date: Tue, 14 Nov 2023 14:45:27 +0100
+Subject: [PATCH] Merged: [promises, async stack traces] Fix the case when the closure has run
+
+We were using the closure pointing to NativeContext as a marker that the
+closure has run, but async stack trace code was confused about it.
+
+(cherry picked from commit bde3d360097607f36cd1d17cbe8412b84eae0a7f)
+
+Bug: chromium:1501326
+Change-Id: I30d438f3b2e3fdd7562ea9a79dde4561ce9b0083
+Cr-Original-Commit-Position: refs/heads/main@{#90949}
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5110982
+Commit-Queue: Marja Hölttä <marja@chromium.org>
+Reviewed-by: Shu-yu Guo <syg@chromium.org>
+Reviewed-by: Igor Sheludko <ishell@chromium.org>
+Auto-Submit: Marja Hölttä <marja@chromium.org>
+Cr-Commit-Position: refs/branch-heads/12.0@{#18}
+Cr-Branched-From: ed7b4caf1fb8184ad9e24346c84424055d4d430a-refs/heads/12.0.267@{#1}
+Cr-Branched-From: 210e75b19db4352c9b78dce0bae11c2dc3077df4-refs/heads/main@{#90651}
+---
+
+diff --git a/src/execution/isolate.cc b/src/execution/isolate.cc
+index 378d9dd..8eab851 100644
+--- a/src/execution/isolate.cc
++++ b/src/execution/isolate.cc
+@@ -1043,7 +1043,13 @@
+                                     isolate);
+       builder->AppendPromiseCombinatorFrame(function, combinator);
+ 
+-      // Now peak into the Promise.all() resolve element context to
++      if (IsNativeContext(*context)) {
++        // NativeContext is used as a marker that the closure was already
++        // called. We can't access the reject element context any more.
++        return;
++      }
++
++      // Now peek into the Promise.all() resolve element context to
+       // find the promise capability that's being resolved when all
+       // the concurrent promises resolve.
+       int const index =
+@@ -1062,7 +1068,13 @@
+           context->native_context()->promise_all_settled(), isolate);
+       builder->AppendPromiseCombinatorFrame(function, combinator);
+ 
+-      // Now peak into the Promise.allSettled() resolve element context to
++      if (IsNativeContext(*context)) {
++        // NativeContext is used as a marker that the closure was already
++        // called. We can't access the reject element context any more.
++        return;
++      }
++
++      // Now peek into the Promise.allSettled() resolve element context to
+       // find the promise capability that's being resolved when all
+       // the concurrent promises resolve.
+       int const index =
+@@ -1080,7 +1092,13 @@
+                                     isolate);
+       builder->AppendPromiseCombinatorFrame(function, combinator);
+ 
+-      // Now peak into the Promise.any() reject element context to
++      if (IsNativeContext(*context)) {
++        // NativeContext is used as a marker that the closure was already
++        // called. We can't access the reject element context any more.
++        return;
++      }
++
++      // Now peek into the Promise.any() reject element context to
+       // find the promise capability that's being resolved when any of
+       // the concurrent promises resolve.
+       int const index = PromiseBuiltins::kPromiseAnyRejectElementCapabilitySlot;

--- a/patches/v8/cherry-pick-cbd09b2ca928.patch
+++ b/patches/v8/cherry-pick-cbd09b2ca928.patch
@@ -1,7 +1,11 @@
-From cbd09b2ca928f1fd929ef52e173aa81213e38cb8 Mon Sep 17 00:00:00 2001
-From: Marja Hölttä <marja@chromium.org>
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marja=20H=C3=B6ltt=C3=A4?= <marja@chromium.org>
 Date: Tue, 14 Nov 2023 14:45:27 +0100
-Subject: [PATCH] Merged: [promises, async stack traces] Fix the case when the closure has run
+Subject: Merged: [promises, async stack traces] Fix the case when the closure
+ has run
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 We were using the closure pointing to NativeContext as a marker that the
 closure has run, but async stack trace code was confused about it.
@@ -19,13 +23,12 @@ Auto-Submit: Marja Hölttä <marja@chromium.org>
 Cr-Commit-Position: refs/branch-heads/12.0@{#18}
 Cr-Branched-From: ed7b4caf1fb8184ad9e24346c84424055d4d430a-refs/heads/12.0.267@{#1}
 Cr-Branched-From: 210e75b19db4352c9b78dce0bae11c2dc3077df4-refs/heads/main@{#90651}
----
 
 diff --git a/src/execution/isolate.cc b/src/execution/isolate.cc
-index 378d9dd..8eab851 100644
+index e7232e5c1fd50dbe72f94f3ad1072ffe52a5fb70..91eafe416cb43cf901e067f2663d142d3bf1febb 100644
 --- a/src/execution/isolate.cc
 +++ b/src/execution/isolate.cc
-@@ -1043,7 +1043,13 @@
+@@ -1020,7 +1020,13 @@ void CaptureAsyncStackTrace(Isolate* isolate, Handle<JSPromise> promise,
                                      isolate);
        builder->AppendPromiseCombinatorFrame(function, combinator);
  
@@ -40,7 +43,7 @@ index 378d9dd..8eab851 100644
        // find the promise capability that's being resolved when all
        // the concurrent promises resolve.
        int const index =
-@@ -1062,7 +1068,13 @@
+@@ -1039,7 +1045,13 @@ void CaptureAsyncStackTrace(Isolate* isolate, Handle<JSPromise> promise,
            context->native_context()->promise_all_settled(), isolate);
        builder->AppendPromiseCombinatorFrame(function, combinator);
  
@@ -55,7 +58,7 @@ index 378d9dd..8eab851 100644
        // find the promise capability that's being resolved when all
        // the concurrent promises resolve.
        int const index =
-@@ -1080,7 +1092,13 @@
+@@ -1057,7 +1069,13 @@ void CaptureAsyncStackTrace(Isolate* isolate, Handle<JSPromise> promise,
                                      isolate);
        builder->AppendPromiseCombinatorFrame(function, combinator);
  


### PR DESCRIPTION
<details>
<summary>electron/security#442 - 998e947b265f from chromium</summary>
[FedCM] Check API permission before showing accounts UI

The accounts fetch could be delayed for legitimate reasons. A user may be
able to disable FedCM API (e.g. via settings or dismissing another FedCM
UI on the same RP origin) before the browser receives the accounts
response.

This patch checks the API permission before showing the accounts UI.

(cherry picked from commit 98676a2f66c4b4b802316eef70f4aab77e631f85)

Change-Id: Idbbe88912941113ec3f54d7f222845cd774dc897
Bug: 1500921
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5064052
Commit-Queue: Yi Gu <yigu@chromium.org>
Reviewed-by: Christian Biesinger <cbiesinger@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1229912}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5074630
Auto-Submit: Yi Gu <yigu@chromium.org>
Cr-Commit-Position: refs/branch-heads/6099@{#1255}
Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
</details>

<details>
<summary>electron/security#437 - 021598ea43c1 from chromium</summary>
[InsertableStreams] Drop frames received on the wrong task runner

It can happen during transfer that a frame is posted from the
background media thread to the task runner of the old execution
context, which can lead to races and UAF.

This CL makes underlying sources drop frames received on the
wrong task runner to avoid the problem.

(cherry picked from commit 9d042e0d498356185fe9eb33c53b69fab33d06bf)

Bug: 1505708
Change-Id: I686228d88cb1c48bdf8c0b6bf85edd280a54300a
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5077845
Commit-Queue: Guido Urdaneta <guidou@chromium.org>
Reviewed-by: Tony Herre <toprice@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1231802}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5082444
Commit-Queue: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Auto-Submit: Guido Urdaneta <guidou@chromium.org>
Cr-Commit-Position: refs/branch-heads/6099@{#1370}
Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
</details>

<details>
<summary>electron/security#440 - 76340163a820 from chromium</summary>
[M120] ImageBitmapFactory: fix empty context dcheck

Approved by:
https://bugs.chromium.org/p/chromium/issues/detail?id=1502102#c34

(cherry picked from commit c4d2f15b8f97076c8fd0f9aa5814b94db698b75c)

Fixed: 1502102
Change-Id: Ib42d2897d62136ae835561bcf56884b5624060a5
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5071252
Commit-Queue: Paul Semel <paulsemel@chromium.org>
Reviewed-by: Jean-Philippe Gravel <jpgravel@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1230617}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5088373
Auto-Submit: Arthur Sonzogni <arthursonzogni@google.com>
Reviewed-by: Paul Semel <paulsemel@chromium.org>
Cr-Commit-Position: refs/branch-heads/6099@{#1416}
Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
</details>

<details>
<summary>electron/security#438 - f15cfb9371c4 from chromium</summary>
Fix reinit order in ContextProviderCommandBuffer::BindToCurrentSequence

See comments for explanation.

(cherry picked from commit 7d8400ceb56db5fd97249f787251fe8b3928e6fd)

Bug: 1505632
Change-Id: I0f43821a9708af91303048332e9fae5e100deee5
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5069480
Reviewed-by: Saifuddin Hitawala <hitawala@chromium.org>
Commit-Queue: Kai Ninomiya <kainino@chromium.org>
Reviewed-by: Brendon Tiszka <tiszka@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1230735}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5095795
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Commit-Queue: Saifuddin Hitawala <hitawala@chromium.org>
Auto-Submit: Kai Ninomiya <kainino@chromium.org>
Cr-Commit-Position: refs/branch-heads/6099@{#1424}
Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
</details>

<details>
<summary>electron/security#436 - 4ca62c7a8b88 from chromium</summary>
Check for slugs count before deserializing Slugs in DrawSlugOp

Count is part of serialized data and while we never serialize values
less then 1, it can be any value when coming over IPC, we should check
that it's positive before substacting one.

(cherry picked from commit 0527e0d5b08a13d63f4f1eeefa1b86ecfd0cb63b)

Bug: 1506726
Change-Id: I244f50a682f2e852b22ba88f1e9cddddb0fdfcb9
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5078779
Reviewed-by: Peng Huang <penghuang@chromium.org>
Commit-Queue: Vasiliy Telezhnikov <vasilyt@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1232013}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5096809
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Cr-Commit-Position: refs/branch-heads/6099@{#1428}
Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
</details>

<details>
<summary>electron/security#441 - cbd09b2ca928 from v8</summary>
Merged: [promises, async stack traces] Fix the case when the closure has run

We were using the closure pointing to NativeContext as a marker that the
closure has run, but async stack trace code was confused about it.

(cherry picked from commit bde3d360097607f36cd1d17cbe8412b84eae0a7f)

Bug: chromium:1501326
Change-Id: I30d438f3b2e3fdd7562ea9a79dde4561ce9b0083
Cr-Original-Commit-Position: refs/heads/main@{#90949}
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5110982
Commit-Queue: Marja Hölttä <marja@chromium.org>
Reviewed-by: Shu-yu Guo <syg@chromium.org>
Reviewed-by: Igor Sheludko <ishell@chromium.org>
Auto-Submit: Marja Hölttä <marja@chromium.org>
Cr-Commit-Position: refs/branch-heads/12.0@{#18}
Cr-Branched-From: ed7b4caf1fb8184ad9e24346c84424055d4d430a-refs/heads/12.0.267@{#1}
Cr-Branched-From: 210e75b19db4352c9b78dce0bae11c2dc3077df4-refs/heads/main@{#90651}
</details>

Notes:
* Security: backported fix for CVE-2023-6706.
* Security: backported fix for CVE-2023-6705.
* Security: backported fix for CVE-2023-6703.
* Security: backported fix for 1505632.
* Security: backported fix for 1506726.
* Security: backported fix for CVE-2023-6702.
* Security: backported fix for CVE-2023-6704.