### PR TITLE
chore: cherry-pick 1 changes from Release-2-M120

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -141,3 +141,4 @@ revert_same_party_cookie_attribute_removal.patch
 fix_restore_original_resize_performance_on_macos.patch
 fix_font_flooding_in_dev_tools.patch
 feat_allow_code_cache_in_custom_schemes.patch
+cherry-pick-8d607d3921b8.patch

--- a/patches/chromium/cherry-pick-8d607d3921b8.patch
+++ b/patches/chromium/cherry-pick-8d607d3921b8.patch
@@ -1,0 +1,34 @@
+From 8d607d3921b8274982dc9e3b0ff6ddcc069254cc Mon Sep 17 00:00:00 2001
+From: Gustaf Ullberg <gustaf@chromium.org>
+Date: Wed, 20 Dec 2023 16:59:29 +0000
+Subject: [PATCH] WebRtcAudioSink: Stop on invalid configuration
+
+(cherry picked from commit 340b7e300d380460a039a07b90f62d1febae9da5)
+
+Bug: 1513170
+Change-Id: Ia4ca55e9eafb81789b28b8b8c54e615ac28df633
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5136295
+Reviewed-by: Harald Alvestrand <hta@chromium.org>
+Commit-Queue: Gustaf Ullberg <gustaf@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1239233}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5136708
+Owners-Override: Krishna Govind <govind@chromium.org>
+Commit-Queue: Krishna Govind <govind@chromium.org>
+Reviewed-by: Krishna Govind <govind@chromium.org>
+Cr-Commit-Position: refs/branch-heads/6099@{#1566}
+Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
+---
+
+diff --git a/third_party/blink/renderer/platform/peerconnection/webrtc_audio_sink.cc b/third_party/blink/renderer/platform/peerconnection/webrtc_audio_sink.cc
+index cd5b8b83..de4a661 100644
+--- a/third_party/blink/renderer/platform/peerconnection/webrtc_audio_sink.cc
++++ b/third_party/blink/renderer/platform/peerconnection/webrtc_audio_sink.cc
+@@ -121,7 +121,7 @@
+ }
+ 
+ void WebRtcAudioSink::OnSetFormat(const media::AudioParameters& params) {
+-  DCHECK(params.IsValid());
++  CHECK(params.IsValid());
+   SendLogMessage(base::StringPrintf("OnSetFormat([label=%s] {params=[%s]})",
+                                     adapter_->label().c_str(),
+                                     params.AsHumanReadableString().c_str()));

--- a/patches/chromium/cherry-pick-8d607d3921b8.patch
+++ b/patches/chromium/cherry-pick-8d607d3921b8.patch
@@ -1,7 +1,7 @@
-From 8d607d3921b8274982dc9e3b0ff6ddcc069254cc Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gustaf Ullberg <gustaf@chromium.org>
 Date: Wed, 20 Dec 2023 16:59:29 +0000
-Subject: [PATCH] WebRtcAudioSink: Stop on invalid configuration
+Subject: WebRtcAudioSink: Stop on invalid configuration
 
 (cherry picked from commit 340b7e300d380460a039a07b90f62d1febae9da5)
 
@@ -17,13 +17,12 @@ Commit-Queue: Krishna Govind <govind@chromium.org>
 Reviewed-by: Krishna Govind <govind@chromium.org>
 Cr-Commit-Position: refs/branch-heads/6099@{#1566}
 Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
----
 
 diff --git a/third_party/blink/renderer/platform/peerconnection/webrtc_audio_sink.cc b/third_party/blink/renderer/platform/peerconnection/webrtc_audio_sink.cc
-index cd5b8b83..de4a661 100644
+index cd5b8b83ce3904f0d13152627602a57b2af116cf..de4a661d6322220ed04c471a14570e91f3f76896 100644
 --- a/third_party/blink/renderer/platform/peerconnection/webrtc_audio_sink.cc
 +++ b/third_party/blink/renderer/platform/peerconnection/webrtc_audio_sink.cc
-@@ -121,7 +121,7 @@
+@@ -121,7 +121,7 @@ void WebRtcAudioSink::OnData(const media::AudioBus& audio_bus,
  }
  
  void WebRtcAudioSink::OnSetFormat(const media::AudioParameters& params) {


### PR DESCRIPTION
<details>
<summary>electron/security#443 - 8d607d3921b8 from chromium</summary>
WebRtcAudioSink: Stop on invalid configuration

(cherry picked from commit 340b7e300d380460a039a07b90f62d1febae9da5)

Bug: 1513170
Change-Id: Ia4ca55e9eafb81789b28b8b8c54e615ac28df633
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5136295
Reviewed-by: Harald Alvestrand <hta@chromium.org>
Commit-Queue: Gustaf Ullberg <gustaf@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1239233}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5136708
Owners-Override: Krishna Govind <govind@chromium.org>
Commit-Queue: Krishna Govind <govind@chromium.org>
Reviewed-by: Krishna Govind <govind@chromium.org>
Cr-Commit-Position: refs/branch-heads/6099@{#1566}
Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
</details>

Notes:
* Security: backported fix for CVE-2023-7024.