### PR TITLE
perf: use flat_set, flat_map for small, trivially-moved containers

### DIFF
--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -5,11 +5,11 @@
 #ifndef ELECTRON_SHELL_BROWSER_API_ELECTRON_API_APP_H_
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_APP_H_
 
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "base/containers/flat_map.h"
 #include "base/task/cancelable_task_tracker.h"
 #include "chrome/browser/icon_manager.h"
 #include "chrome/browser/process_singleton.h"
@@ -259,9 +259,8 @@ class App : public ElectronBrowserClient::Delegate,
 
   base::FilePath app_path_;
 
-  using ProcessMetricMap =
-      std::map<int, std::unique_ptr<electron::ProcessMetric>>;
-  ProcessMetricMap app_metrics_;
+  // pid -> electron::ProcessMetric
+  base::flat_map<int, std::unique_ptr<electron::ProcessMetric>> app_metrics_;
 
   bool disable_hw_acceleration_ = false;
   bool disable_domain_blocking_for_3DAPIs_ = false;

--- a/shell/browser/api/electron_api_menu_views.cc
+++ b/shell/browser/api/electron_api_menu_views.cc
@@ -52,24 +52,26 @@ void MenuViews::PopupAt(BaseWindow* window,
   auto close_callback = base::AdaptCallbackForRepeating(
       base::BindOnce(&MenuViews::OnClosed, weak_factory_.GetWeakPtr(),
                      window_id, std::move(callback_with_ref)));
-  menu_runners_[window_id] =
+  auto& runner = menu_runners_[window_id] =
       std::make_unique<MenuRunner>(model(), flags, std::move(close_callback));
-  menu_runners_[window_id]->RunMenuAt(
-      native_window->widget(), nullptr, gfx::Rect(location, gfx::Size()),
-      views::MenuAnchorPosition::kTopLeft, source_type);
+  runner->RunMenuAt(native_window->widget(), nullptr,
+                    gfx::Rect{location, gfx::Size{}},
+                    views::MenuAnchorPosition::kTopLeft, source_type);
 }
 
 void MenuViews::ClosePopupAt(int32_t window_id) {
-  auto runner = menu_runners_.find(window_id);
-  if (runner != menu_runners_.end()) {
+  if (auto iter = menu_runners_.find(window_id); iter != menu_runners_.end()) {
     // Close the runner for the window.
-    runner->second->Cancel();
-  } else if (window_id == -1) {
-    // Or just close all opened runners.
-    for (auto it = menu_runners_.begin(); it != menu_runners_.end();) {
-      // The iterator is invalidated after the call.
-      (it++)->second->Cancel();
-    }
+    iter->second->Cancel();
+    return;
+  }
+
+  if (window_id == -1) {
+    // When -1 is passed in, close all opened runners.
+    // Note: `Cancel()` invalidaes iters, so move() to a temp before looping
+    auto tmp = std::move(menu_runners_);
+    for (auto& [id, runner] : tmp)
+      runner->Cancel();
   }
 }
 

--- a/shell/browser/api/electron_api_menu_views.h
+++ b/shell/browser/api/electron_api_menu_views.h
@@ -5,9 +5,9 @@
 #ifndef ELECTRON_SHELL_BROWSER_API_ELECTRON_API_MENU_VIEWS_H_
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_MENU_VIEWS_H_
 
-#include <map>
 #include <memory>
 
+#include "base/containers/flat_map.h"
 #include "base/memory/weak_ptr.h"
 #include "shell/browser/api/electron_api_menu.h"
 #include "ui/display/screen.h"
@@ -33,7 +33,7 @@ class MenuViews : public Menu {
   void OnClosed(int32_t window_id, base::OnceClosure callback);
 
   // window ID -> open context menu
-  std::map<int32_t, std::unique_ptr<views::MenuRunner>> menu_runners_;
+  base::flat_map<int32_t, std::unique_ptr<views::MenuRunner>> menu_runners_;
 
   base::WeakPtrFactory<MenuViews> weak_factory_{this};
 };

--- a/shell/browser/api/electron_api_power_save_blocker.h
+++ b/shell/browser/api/electron_api_power_save_blocker.h
@@ -5,8 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_API_ELECTRON_API_POWER_SAVE_BLOCKER_H_
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_POWER_SAVE_BLOCKER_H_
 
-#include <map>
-
+#include "base/containers/flat_map.h"
 #include "gin/handle.h"
 #include "gin/object_template_builder.h"
 #include "gin/wrappable.h"
@@ -48,8 +47,7 @@ class PowerSaveBlocker : public gin::Wrappable<PowerSaveBlocker> {
   bool is_wake_lock_active_ = false;
 
   // Map from id to the corresponding blocker type for each request.
-  using WakeLockTypeMap = std::map<int, device::mojom::WakeLockType>;
-  WakeLockTypeMap wake_lock_types_;
+  base::flat_map<int, device::mojom::WakeLockType> wake_lock_types_;
 
   mojo::Remote<device::mojom::WakeLock> wake_lock_;
 };

--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -4,7 +4,6 @@
 
 #include "shell/browser/api/electron_api_system_preferences.h"
 
-#include <map>
 #include <string>
 #include <utility>
 
@@ -14,6 +13,7 @@
 #import <Security/Security.h>
 
 #include "base/apple/scoped_cftyperef.h"
+#include "base/containers/flat_map.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/sys_string_conversions.h"
 #include "base/task/sequenced_task_runner.h"
@@ -81,7 +81,7 @@ namespace {
 int g_next_id = 0;
 
 // The map to convert |id| to |int|.
-std::map<int, id> g_id_map;
+base::flat_map<int, id> g_id_map;
 
 AVMediaType ParseMediaType(const std::string& media_type) {
   if (media_type == "camera") {

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -5,12 +5,12 @@
 #ifndef ELECTRON_SHELL_BROWSER_ELECTRON_BROWSER_CLIENT_H_
 #define ELECTRON_SHELL_BROWSER_ELECTRON_BROWSER_CLIENT_H_
 
-#include <map>
 #include <memory>
-#include <set>
 #include <string>
 #include <vector>
 
+#include "base/containers/flat_map.h"
+#include "base/containers/flat_set.h"
 #include "base/files/file_path.h"
 #include "base/memory/raw_ptr.h"
 #include "base/synchronization/lock.h"
@@ -313,9 +313,9 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
   bool IsRendererSubFrame(int process_id) const;
 
   // pending_render_process => web contents.
-  std::map<int, content::WebContents*> pending_processes_;
+  base::flat_map<int, content::WebContents*> pending_processes_;
 
-  std::set<int> renderer_is_subframe_;
+  base::flat_set<int> renderer_is_subframe_;
 
   std::unique_ptr<PlatformNotificationService> notification_service_;
   std::unique_ptr<NotificationPresenter> notification_presenter_;

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -6,13 +6,12 @@
 #define ELECTRON_SHELL_BROWSER_NET_PROXYING_URL_LOADER_FACTORY_H_
 
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <set>
 #include <string>
 #include <vector>
 
-#include "base/memory/raw_ptr.h"
+#include "base/containers/flat_map.h"
 #include "base/memory/raw_ref.h"
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/content_browser_client.h"
@@ -274,11 +273,11 @@ class ProxyingURLLoaderFactory
 
   // Mapping from our own internally generated request ID to an
   // InProgressRequest instance.
-  std::map<uint64_t, std::unique_ptr<InProgressRequest>> requests_;
+  base::flat_map<uint64_t, std::unique_ptr<InProgressRequest>> requests_;
 
   // A mapping from the network stack's notion of request ID to our own
   // internally generated request ID for the same request.
-  std::map<int32_t, uint64_t> network_request_id_to_web_request_id_;
+  base::flat_map<int32_t, uint64_t> network_request_id_to_web_request_id_;
 
   std::vector<std::string> ignore_connections_limit_domains_;
 };

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "base/containers/flat_map.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/content_browser_client.h"

--- a/shell/browser/notifications/linux/libnotify_notification.cc
+++ b/shell/browser/notifications/linux/libnotify_notification.cc
@@ -4,9 +4,9 @@
 
 #include "shell/browser/notifications/linux/libnotify_notification.h"
 
-#include <set>
 #include <string>
 
+#include "base/containers/flat_set.h"
 #include "base/files/file_enumerator.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
@@ -24,8 +24,8 @@ namespace {
 
 LibNotifyLoader libnotify_loader_;
 
-const std::set<std::string>& GetServerCapabilities() {
-  static std::set<std::string> caps;
+const base::flat_set<std::string>& GetServerCapabilities() {
+  static base::flat_set<std::string> caps;
   if (caps.empty()) {
     auto* capabilities = libnotify_loader_.notify_get_server_caps();
     for (auto* l = capabilities; l != nullptr; l = l->next)
@@ -36,7 +36,7 @@ const std::set<std::string>& GetServerCapabilities() {
 }
 
 bool HasCapability(const std::string& capability) {
-  return GetServerCapabilities().count(capability) != 0;
+  return GetServerCapabilities().contains(capability);
 }
 
 bool NotifierSupportsActions() {

--- a/shell/browser/ui/electron_menu_model.h
+++ b/shell/browser/ui/electron_menu_model.h
@@ -5,10 +5,10 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_ELECTRON_MENU_MODEL_H_
 #define ELECTRON_SHELL_BROWSER_UI_ELECTRON_MENU_MODEL_H_
 
-#include <map>
 #include <string>
 #include <vector>
 
+#include "base/containers/flat_map.h"
 #include "base/files/file_path.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
@@ -119,9 +119,9 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
   absl::optional<SharingItem> sharing_item_;
 #endif
 
-  std::map<int, std::u16string> toolTips_;   // command id -> tooltip
-  std::map<int, std::u16string> roles_;      // command id -> role
-  std::map<int, std::u16string> sublabels_;  // command id -> sublabel
+  base::flat_map<int, std::u16string> toolTips_;   // command id -> tooltip
+  base::flat_map<int, std::u16string> roles_;      // command id -> role
+  base::flat_map<int, std::u16string> sublabels_;  // command id -> sublabel
   base::ObserverList<Observer> observers_;
 
   base::WeakPtrFactory<ElectronMenuModel> weak_factory_{this};

--- a/shell/browser/ui/gtk/menu_util.cc
+++ b/shell/browser/ui/gtk/menu_util.cc
@@ -7,9 +7,9 @@
 #include <gdk/gdk.h>
 #include <gtk/gtk.h>
 
-#include <map>
 #include <string>
 
+#include "base/containers/flat_map.h"
 #include "base/strings/utf_string_conversions.h"
 #include "chrome/app/chrome_command_ids.h"
 #include "shell/browser/ui/gtk_util.h"
@@ -150,7 +150,7 @@ void BuildSubmenuFromModel(ui::MenuModel* model,
                            MenuActivatedCallback item_activated_cb,
                            bool* block_activation,
                            std::vector<ScopedGSignal>* signals) {
-  std::map<int, GtkWidget*> radio_groups;
+  base::flat_map<int, GtkWidget*> radio_groups;
   GtkWidget* menu_item = nullptr;
   for (size_t i = 0; i < model->GetItemCount(); ++i) {
     std::string label = ui::ConvertAcceleratorsFromWindowsStyle(

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -203,11 +203,10 @@ class InspectableWebContents::NetworkResourceLoader
                      URLLoaderFactoryHolder url_loader_factory,
                      DispatchCallback callback,
                      base::TimeDelta retry_delay = base::TimeDelta()) {
-    auto resource_loader =
+    bindings->loaders_.insert(
         std::make_unique<InspectableWebContents::NetworkResourceLoader>(
             stream_id, bindings, resource_request, traffic_annotation,
-            std::move(url_loader_factory), std::move(callback), retry_delay);
-    bindings->loaders_.insert(std::move(resource_loader));
+            std::move(url_loader_factory), std::move(callback), retry_delay));
   }
 
   NetworkResourceLoader(
@@ -308,7 +307,7 @@ class InspectableWebContents::NetworkResourceLoader
       std::move(callback_).Run(&response);
     }
 
-    bindings_->loaders_.erase(bindings_->loaders_.find(this));
+    bindings_->loaders_.erase(this);
   }
 
   void OnRetry(base::OnceClosure start_retry) override {}

--- a/shell/browser/ui/inspectable_web_contents.h
+++ b/shell/browser/ui/inspectable_web_contents.h
@@ -6,11 +6,11 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_INSPECTABLE_WEB_CONTENTS_H_
 #define ELECTRON_SHELL_BROWSER_UI_INSPECTABLE_WEB_CONTENTS_H_
 
-#include <map>
 #include <memory>
 #include <set>
 #include <string>
 
+#include "base/containers/flat_map.h"
 #include "base/containers/span.h"
 #include "base/containers/unique_ptr_adapters.h"
 #include "base/memory/raw_ptr.h"
@@ -244,8 +244,8 @@ class InspectableWebContents
   std::set<std::unique_ptr<NetworkResourceLoader>, base::UniquePtrComparator>
       loaders_;
 
-  using ExtensionsAPIs = std::map<std::string, std::string>;
-  ExtensionsAPIs extensions_api_;
+  // origin -> script
+  base::flat_map<std::string, std::string> extensions_api_;
 
   // Contains the set of synced settings.
   // The DevTools frontend *must* call `Register` for each setting prior to

--- a/shell/browser/ui/inspectable_web_contents.h
+++ b/shell/browser/ui/inspectable_web_contents.h
@@ -7,10 +7,10 @@
 #define ELECTRON_SHELL_BROWSER_UI_INSPECTABLE_WEB_CONTENTS_H_
 
 #include <memory>
-#include <set>
 #include <string>
 
 #include "base/containers/flat_map.h"
+#include "base/containers/flat_set.h"
 #include "base/containers/span.h"
 #include "base/containers/unique_ptr_adapters.h"
 #include "base/memory/raw_ptr.h"
@@ -241,7 +241,8 @@ class InspectableWebContents
       embedder_message_dispatcher_;
 
   class NetworkResourceLoader;
-  std::set<std::unique_ptr<NetworkResourceLoader>, base::UniquePtrComparator>
+  base::flat_set<std::unique_ptr<NetworkResourceLoader>,
+                 base::UniquePtrComparator>
       loaders_;
 
   // origin -> script

--- a/shell/browser/ui/message_box_gtk.cc
+++ b/shell/browser/ui/message_box_gtk.cc
@@ -4,9 +4,8 @@
 
 #include "shell/browser/ui/message_box.h"
 
-#include <map>
-
 #include "base/containers/contains.h"
+#include "base/containers/flat_map.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
@@ -43,8 +42,8 @@ MessageBoxSettings::~MessageBoxSettings() = default;
 namespace {
 
 // <ID, messageBox> map
-std::map<int, GtkWidget*>& GetDialogsMap() {
-  static base::NoDestructor<std::map<int, GtkWidget*>> dialogs;
+base::flat_map<int, GtkWidget*>& GetDialogsMap() {
+  static base::NoDestructor<base::flat_map<int, GtkWidget*>> dialogs;
   return *dialogs;
 }
 

--- a/shell/browser/ui/message_box_mac.mm
+++ b/shell/browser/ui/message_box_mac.mm
@@ -4,7 +4,6 @@
 
 #include "shell/browser/ui/message_box.h"
 
-#include <map>
 #include <string>
 #include <utility>
 #include <vector>
@@ -12,6 +11,7 @@
 #import <Cocoa/Cocoa.h>
 
 #include "base/containers/contains.h"
+#include "base/containers/flat_map.h"
 #include "base/functional/callback.h"
 #include "base/mac/mac_util.h"
 #include "base/no_destructor.h"
@@ -31,8 +31,8 @@ MessageBoxSettings::~MessageBoxSettings() = default;
 namespace {
 
 // <ID, messageBox> map
-std::map<int, NSAlert*>& GetDialogsMap() {
-  static base::NoDestructor<std::map<int, NSAlert*>> dialogs;
+base::flat_map<int, NSAlert*>& GetDialogsMap() {
+  static base::NoDestructor<base::flat_map<int, NSAlert*>> dialogs;
   return *dialogs;
 }
 

--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -8,7 +8,6 @@
 
 #include <commctrl.h>
 
-#include <map>
 #include <vector>
 
 #include "base/containers/contains.h"
@@ -42,8 +41,8 @@ struct DialogResult {
 // Note that the HWND is stored in a unique_ptr, because the pointer of HWND
 // will be passed between threads and we need to ensure the memory of HWND is
 // not changed while dialogs map is modified.
-std::flat_map<int, std::unique_ptr<HWND>>& GetDialogsMap() {
-  static base::NoDestructor<std::flat_map<int, std::unique_ptr<HWND>>> dialogs;
+base::flat_map<int, std::unique_ptr<HWND>>& GetDialogsMap() {
+  static base::NoDestructor<base::flat_map<int, std::unique_ptr<HWND>>> dialogs;
   return *dialogs;
 }
 
@@ -96,7 +95,7 @@ CommonButtonID GetCommonID(const std::wstring& button) {
 // Determine whether the buttons are common buttons, if so map common ID
 // to button ID.
 void MapToCommonID(const std::vector<std::wstring>& buttons,
-                   std::map<int, int>* id_map,
+                   base::flat_map<int, int>* id_map,
                    TASKDIALOG_COMMON_BUTTON_FLAGS* button_flags,
                    std::vector<TASKDIALOG_BUTTON>* dialog_buttons) {
   for (size_t i = 0; i < buttons.size(); ++i) {
@@ -216,7 +215,7 @@ DialogResult ShowTaskDialogWstr(gfx::AcceleratedWidget parent,
 
   // Iterate through the buttons, put common buttons in dwCommonButtons
   // and custom buttons in pButtons.
-  std::map<int, int> id_map;
+  base::flat_map<int, int> id_map;
   std::vector<TASKDIALOG_BUTTON> dialog_buttons;
   if (no_link) {
     for (size_t i = 0; i < buttons.size(); ++i)

--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "base/containers/contains.h"
+#include "base/containers/flat_map.h"
 #include "base/no_destructor.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
@@ -41,8 +42,8 @@ struct DialogResult {
 // Note that the HWND is stored in a unique_ptr, because the pointer of HWND
 // will be passed between threads and we need to ensure the memory of HWND is
 // not changed while dialogs map is modified.
-std::map<int, std::unique_ptr<HWND>>& GetDialogsMap() {
-  static base::NoDestructor<std::map<int, std::unique_ptr<HWND>>> dialogs;
+std::flat_map<int, std::unique_ptr<HWND>>& GetDialogsMap() {
+  static base::NoDestructor<std::flat_map<int, std::unique_ptr<HWND>>> dialogs;
   return *dialogs;
 }
 

--- a/shell/browser/ui/views/electron_views_delegate.h
+++ b/shell/browser/ui/views/electron_views_delegate.h
@@ -5,11 +5,11 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_VIEWS_ELECTRON_VIEWS_DELEGATE_H_
 #define ELECTRON_SHELL_BROWSER_UI_VIEWS_ELECTRON_VIEWS_DELEGATE_H_
 
-#include <map>
 #include <memory>
 #include <string>
 
 #include "base/compiler_specific.h"
+#include "base/containers/flat_map.h"
 #include "ui/views/views_delegate.h"
 
 namespace electron {
@@ -58,8 +58,6 @@ class ViewsDelegate : public views::ViewsDelegate {
 
  private:
 #if BUILDFLAG(IS_WIN)
-  using AppbarAutohideEdgeMap = std::map<HMONITOR, int>;
-
   // Callback on main thread with the edges. |returned_edges| is the value that
   // was returned from the call to GetAutohideEdges() that initiated the lookup.
   void OnGotAppbarAutohideEdges(base::OnceClosure callback,
@@ -67,7 +65,7 @@ class ViewsDelegate : public views::ViewsDelegate {
                                 int returned_edges,
                                 int edges);
 
-  AppbarAutohideEdgeMap appbar_autohide_edge_map_;
+  base::flat_map<HMONITOR, int> appbar_autohide_edge_map_;
   // If true we're in the process of notifying a callback from
   // GetAutohideEdges().start a new query.
   bool in_autohide_edges_callback_ = false;

--- a/shell/browser/ui/views/electron_views_delegate_win.cc
+++ b/shell/browser/ui/views/electron_views_delegate_win.cc
@@ -119,7 +119,7 @@ int ViewsDelegate::GetAppbarAutohideEdges(HMONITOR monitor,
   // in us thinking there is no auto-hide edges. By returning at least one edge
   // we don't initially go fullscreen until we figure out the real auto-hide
   // edges.
-  if (!appbar_autohide_edge_map_.count(monitor))
+  if (!appbar_autohide_edge_map_.contains(monitor))
     appbar_autohide_edge_map_[monitor] = EDGE_BOTTOM;
 
   // We use the SHAppBarMessage API to get the taskbar autohide state. This API

--- a/shell/browser/web_view_manager.h
+++ b/shell/browser/web_view_manager.h
@@ -5,8 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_WEB_VIEW_MANAGER_H_
 #define ELECTRON_SHELL_BROWSER_WEB_VIEW_MANAGER_H_
 
-#include <map>
-
+#include "base/containers/flat_map.h"
 #include "base/memory/raw_ptr.h"
 #include "content/public/browser/browser_plugin_guest_manager.h"
 
@@ -38,7 +37,7 @@ class WebViewManager : public content::BrowserPluginGuestManager {
     raw_ptr<content::WebContents> embedder;
   };
   // guest_instance_id => (web_contents, embedder)
-  std::map<int, WebContentsWithEmbedder> web_contents_embedder_map_;
+  base::flat_map<int, WebContentsWithEmbedder> web_contents_embedder_map_;
 };
 
 }  // namespace electron

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -5,10 +5,10 @@
 #ifndef ELECTRON_SHELL_COMMON_API_ELECTRON_API_NATIVE_IMAGE_H_
 #define ELECTRON_SHELL_COMMON_API_ELECTRON_API_NATIVE_IMAGE_H_
 
-#include <map>
 #include <string>
 #include <vector>
 
+#include "base/containers/flat_map.h"
 #include "base/memory/raw_ptr.h"
 #include "base/values.h"
 #include "gin/handle.h"
@@ -130,7 +130,9 @@ class NativeImage : public gin::Wrappable<NativeImage> {
 
 #if BUILDFLAG(IS_WIN)
   base::FilePath hicon_path_;
-  std::map<int, base::win::ScopedHICON> hicons_;
+
+  // size -> hicon
+  base::flat_map<int, base::win::ScopedHICON> hicons_;
 #endif
 
   gfx::Image image_;

--- a/shell/renderer/electron_renderer_client.h
+++ b/shell/renderer/electron_renderer_client.h
@@ -6,8 +6,8 @@
 #define ELECTRON_SHELL_RENDERER_ELECTRON_RENDERER_CLIENT_H_
 
 #include <memory>
-#include <set>
 
+#include "base/containers/flat_set.h"
 #include "shell/renderer/renderer_client_base.h"
 
 namespace node {
@@ -57,12 +57,12 @@ class ElectronRendererClient : public RendererClientBase {
   // The node::Environment::GetCurrent API does not return nullptr when it
   // is called for a context without node::Environment, so we have to keep
   // a book of the environments created.
-  std::set<std::shared_ptr<node::Environment>> environments_;
+  base::flat_set<std::shared_ptr<node::Environment>> environments_;
 
   // Getting main script context from web frame would lazily initializes
   // its script context. Doing so in a web page without scripts would trigger
   // assertion, so we have to keep a book of injected web frames.
-  std::set<content::RenderFrame*> injected_frames_;
+  base::flat_set<content::RenderFrame*> injected_frames_;
 };
 
 }  // namespace electron

--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -98,7 +98,7 @@ void WebWorkerObserver::ContextWillDestroy(v8::Local<v8::Context> context) {
   DCHECK_EQ(microtask_queue->GetMicrotasksScopeDepth(), 0);
   microtask_queue->set_microtasks_policy(v8::MicrotasksPolicy::kExplicit);
 
-  std::erase_if(environments_,
+  base::EraseIf(environments_,
                 [env](auto const& item) { return item.get() == env; });
 
   microtask_queue->set_microtasks_policy(old_policy);

--- a/shell/renderer/web_worker_observer.h
+++ b/shell/renderer/web_worker_observer.h
@@ -6,8 +6,8 @@
 #define ELECTRON_SHELL_RENDERER_WEB_WORKER_OBSERVER_H_
 
 #include <memory>
-#include <set>
 
+#include "base/containers/flat_set.h"
 #include "v8/include/v8.h"
 
 namespace node {
@@ -42,7 +42,7 @@ class WebWorkerObserver {
  private:
   std::unique_ptr<NodeBindings> node_bindings_;
   std::unique_ptr<ElectronBindings> electron_bindings_;
-  std::set<std::shared_ptr<node::Environment>> environments_;
+  base::flat_set<std::shared_ptr<node::Environment>> environments_;
 };
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

`base::flat_map` and `base::flat_set` are STL-like map & set containers that are implemented using `std::vector` instead of an red-black tree, so they have good memory locality and lower overhead, especially for containers with smaller sizes. The upstream [usage advice](https://chromium.googlesource.com/chromium/src/+/HEAD/base/containers/README.md#Map-and-set-selection-Usage-advice) recommends:

>  Most maps and sets in Chrome are small and contain objects that can be moved efficiently. In this case, consider `base::flat_map` and `base::flat_set`.
>
> You need to be aware of the maximum expected size of the container since individual inserts and deletes are O(n), giving O(n^2) construction time for the entire map. But because it avoids mallocs in most cases, inserts are better or comparable to other containers even for several dozen items, and efficiently-moved types are unlikely to have performance problems for most cases until you have hundreds of items. If your container can be constructed in one shot, the constructor from vector gives O(n log n) construction times and it should be strictly better than a `std::map`.

This PR replaces `std::map` and `std::set` with their flat counterparts iff they match those recommendations: they are all smaller containers with trivially-`move`able types (e.g. ints and pointers).

This is a general cleanup PR so no specific stateholders, but all reviews welcomed

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none