### PR TITLE
chore: drop ada ICU requirement for parsing hostnames

### DIFF
--- a/patches/node/build_add_gn_build_files.patch
+++ b/patches/node/build_add_gn_build_files.patch
@@ -415,10 +415,10 @@ index 0000000000000000000000000000000000000000..24c122008e0fc009833cf9189ebf4388
 +}
 diff --git a/deps/ada/BUILD.gn b/deps/ada/BUILD.gn
 new file mode 100644
-index 0000000000000000000000000000000000000000..a564653c3f05608d59fed5aa071d63b81f4e0e42
+index 0000000000000000000000000000000000000000..1ce69e9deba1a9b191e8d95f4c82e0ec1f7b50ca
 --- /dev/null
 +++ b/deps/ada/BUILD.gn
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,12 @@
 +import("//v8/gni/v8.gni")
 +
 +config("ada_config") {
@@ -430,22 +430,6 @@ index 0000000000000000000000000000000000000000..a564653c3f05608d59fed5aa071d63b8
 +  sources = [ "ada.cpp" ]
 +
 +  public_configs = [ ":ada_config" ]
-+
-+  defines = []
-+  deps = []
-+
-+  if (v8_enable_i18n_support) {
-+    deps += [
-+      "//third_party/icu:icui18n",
-+      "//third_party/icu:icuuc",
-+    ]
-+
-+    if (is_win) {
-+      deps += [ "//third_party/icu:icudata" ]
-+    }
-+  } else {
-+    defines += [ "ADA_HAS_ICU=0" ]
-+  }
 +}
 diff --git a/deps/base64/BUILD.gn b/deps/base64/BUILD.gn
 new file mode 100644


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/nodejs/node/pull/47339.

ICU is no longer requires to parse hostnames in Node.js' ada dependency and can be removed from our BUILD.gn patches.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.