### PR TITLE
fix: BrowserView.webContents can be null

### DIFF
--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -49,7 +49,7 @@ Objects created with `new BrowserView` have the following properties:
 
 #### `view.webContents` _Experimental_ _Deprecated_
 
-A [`WebContents`](web-contents.md) `| undefined` object owned by this view.
+A [`WebContents`](web-contents.md) `| null` object owned by this view.
 
 ### Instance Methods
 

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -49,7 +49,7 @@ Objects created with `new BrowserView` have the following properties:
 
 #### `view.webContents` _Experimental_ _Deprecated_
 
-A [`WebContents`](web-contents.md) object owned by this view.
+A [`WebContents`](web-contents.md) `| undefined` object owned by this view.
 
 ### Instance Methods
 


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/40567

Notes: The `webContents` property of BrowserView can be null. This was always true, but now the TypeScript types reflect this fact.