### PR TITLE
fix: BrowserView defaults to transparent

### DIFF
--- a/lib/browser/api/browser-view.ts
+++ b/lib/browser/api/browser-view.ts
@@ -17,6 +17,7 @@ export default class BrowserView {
     }
     webPreferences.type = 'browserView';
     this.#webContentsView = new WebContentsView({ webPreferences });
+    this.#webContentsView.setBackgroundColor('#00000000');
   }
 
   get webContents () {


### PR DESCRIPTION
#### Description of Change

The old BrowserView implementation defaulted to transparent views, so maintain
that behavior here. I think it's reasonable for the new WebContentsView impl to
be opaque by default as that reflects how Chromium does things "naturally", so
I'll leave that the way it is.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed BrowserViews not being transparent by default.
