### PR TITLE
fix: BrowserView and <webview> should be transparent by default

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3778,15 +3778,17 @@ void WebContents::SetImageAnimationPolicy(const std::string& new_policy) {
 }
 
 void WebContents::SetBackgroundColor(absl::optional<SkColor> maybe_color) {
-  web_contents()->SetPageBaseBackgroundColor(maybe_color);
+  SkColor color = maybe_color.value_or(type_ == Type::kWebView ||
+                                               type_ == Type::kBrowserView
+                                           ? SK_ColorTRANSPARENT
+                                           : SK_ColorWHITE);
+  web_contents()->SetPageBaseBackgroundColor(color);
 
   content::RenderFrameHost* rfh = web_contents()->GetPrimaryMainFrame();
   if (!rfh)
     return;
   content::RenderWidgetHostView* rwhv = rfh->GetView();
   if (rwhv) {
-    SkColor color =
-        maybe_color.value_or(IsGuest() ? SK_ColorTRANSPARENT : SK_ColorWHITE);
     rwhv->SetBackgroundColor(color);
     static_cast<content::RenderWidgetHostViewBase*>(rwhv)
         ->SetContentBackgroundColor(color);


### PR DESCRIPTION
#### Description of Change

This regressed with #35658. Chrome defaults this to white:
https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/exported/web_view_impl.cc;l=3301;drc=926dafb2e32d6676e53fde59efaff1aa4ea1dd61,
but we want transparent for &lt;webview> and BrowserView.

I'll leave it as white for WebContentsView as that matches more closely with
Chromium's behavior.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed &lt;webview&gt; and BrowserViews being white instead of transparent by default.
