### PR TITLE
fix: titlebar incorrectly displayed on frameless windows

### DIFF
--- a/patches/chromium/fix_activate_background_material_on_windows.patch
+++ b/patches/chromium/fix_activate_background_material_on_windows.patch
@@ -1,19 +1,23 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: clavin <clavin@electronjs.org>
-Date: Wed, 30 Aug 2023 18:15:36 -0700
+Date: Mon, 11 Dec 2023 20:43:34 -0300
 Subject: fix: activate background material on windows
 
 This patch adds a condition to the HWND message handler to allow windows
 with translucent background materials to become activated.
 
+It also ensures the lParam of WM_NCACTIVATE is set to -1 so as to not repaint
+the client area, which can lead to a title bar incorrectly being displayed in
+frameless windows.
+
 This patch likely can't be upstreamed as-is, as Chromium doesn't have
 this use case in mind currently.
 
 diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
-index 29da2517abd90daec44c3e187f35b5f1aa8b9845..bbf996eaf933c33202344e698b8655e05ef53dc7 100644
+index 29da2517abd90daec44c3e187f35b5f1aa8b9845..e1af8af290117d85d96b7e0aa3d286a92c6a7a8e 100644
 --- a/ui/views/win/hwnd_message_handler.cc
 +++ b/ui/views/win/hwnd_message_handler.cc
-@@ -880,7 +880,7 @@ void HWNDMessageHandler::FrameTypeChanged() {
+@@ -880,13 +880,13 @@ void HWNDMessageHandler::FrameTypeChanged() {
  
  void HWNDMessageHandler::PaintAsActiveChanged() {
    if (!delegate_->HasNonClientView() || !delegate_->CanActivate() ||
@@ -22,3 +26,34 @@ index 29da2517abd90daec44c3e187f35b5f1aa8b9845..bbf996eaf933c33202344e698b8655e0
        (delegate_->GetFrameMode() == FrameMode::CUSTOM_DRAWN)) {
      return;
    }
+ 
+   DefWindowProcWithRedrawLock(WM_NCACTIVATE, delegate_->ShouldPaintAsActive(),
+-                              0);
++                              delegate_->HasFrame() ? 0 : -1);
+ }
+ 
+ void HWNDMessageHandler::SetWindowIcons(const gfx::ImageSkia& window_icon,
+@@ -2233,17 +2233,18 @@ LRESULT HWNDMessageHandler::OnNCActivate(UINT message,
+   if (IsVisible())
+     delegate_->SchedulePaint();
+ 
+-  // Calling DefWindowProc is only necessary if there's a system frame being
+-  // drawn. Otherwise it can draw an incorrect title bar and cause visual
+-  // corruption.
+-  if (!delegate_->HasFrame() ||
++  // If the window is translucent, it may have the Mica background.
++  // In that case, it's necessary to call |DefWindowProc|, but we can
++  // pass -1 in the lParam to prevent any non-client area elements from
++  // being displayed.
++  if ((!delegate_->HasFrame() && !is_translucent_) ||
+       delegate_->GetFrameMode() == FrameMode::CUSTOM_DRAWN) {
+     SetMsgHandled(TRUE);
+     return TRUE;
+   }
+ 
+   return DefWindowProcWithRedrawLock(WM_NCACTIVATE, paint_as_active || active,
+-                                     0);
++                                     delegate_->HasFrame() ? 0 : -1);
+ }
+ 
+ LRESULT HWNDMessageHandler::OnNCCalcSize(BOOL mode, LPARAM l_param) {

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -135,12 +135,12 @@ void ElectronDesktopWindowTreeHostWin::OnNativeThemeUpdated(
 
 bool ElectronDesktopWindowTreeHostWin::ShouldWindowContentsBeTransparent()
     const {
-  // Window should be marked as opaque if no transparency setting has been set,
-  // otherwise videos rendered in the window will trigger a DirectComposition
-  // redraw for every frame.
+  // Window should be marked as opaque if no transparency setting has been
+  // set, otherwise animations or videos rendered in the window will trigger a
+  // DirectComposition redraw for every frame.
   // https://github.com/electron/electron/pull/39895
   return native_window_view_->GetOpacity() < 1.0 ||
-         native_window_view_->transparent();
+         native_window_view_->IsTranslucent();
 }
 
 }  // namespace electron


### PR DESCRIPTION
Manual backport of #40749

Notes: fix incorrect title bar shown on frameless transparent windows