### PR TITLE
build: use container runner for arm tests

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1631,15 +1631,10 @@ commands:
               echo "Piping output to ASAN_SYMBOLIZE ($ASAN_SYMBOLIZE)"
               (cd electron && (circleci tests glob "spec/*-spec.ts" | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings 2>&1)) | $ASAN_SYMBOLIZE
             else
-              if [ "$TARGET_ARCH" == "arm" ]; then
-                export ELECTRON_SKIP_NATIVE_MODULE_TESTS=true
-                (cd electron && node script/yarn test --runners=main --trace-uncaught --enable-logging)
-              else
-                if [ "$TARGET_ARCH" == "ia32" ]; then
-                  npm_config_arch=x64 node electron/node_modules/dugite/script/download-git.js
-                fi
-                (cd electron && (circleci tests glob "spec/*-spec.ts" | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings))
+              if [ "$TARGET_ARCH" == "ia32" ]; then
+                npm_config_arch=x64 node electron/node_modules/dugite/script/download-git.js
               fi
+              (cd electron && (circleci tests glob "spec/*-spec.ts" | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings))
             fi
       - store_test_results:
           path: src/junit
@@ -2267,6 +2262,7 @@ jobs:
       <<: *env-global
       <<: *env-headless-testing
       <<: *env-stack-dumping
+    parallelism: 3
     steps:
       - electron-tests:
           artifact-key: linux-arm

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -86,7 +86,7 @@ executors:
   linux-arm64:
     resource_class: electronjs/aks-linux-arm-test
     docker:
-      - image: ghcr.io/electron/test:arm64v8-9a4acb4e8085c2439541a70aa28daae64feb44bf
+      - image: ghcr.io/electron/test:arm64v8-603263bdff4eec4967430e4684f57dc92969f647
 
 # The config expects the following environment variables to be set:
 #  - "SLACK_WEBHOOK" Slack hook URL to send notifications.

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1629,12 +1629,12 @@ commands:
               export LLVM_SYMBOLIZER_PATH=$PWD/third_party/llvm-build/Release+Asserts/bin/llvm-symbolizer
               export MOCHA_TIMEOUT=180000
               echo "Piping output to ASAN_SYMBOLIZE ($ASAN_SYMBOLIZE)"
-              (cd electron && (circleci tests glob "spec/*-spec.ts" | xargs -L1 realpath | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings 2>&1)) | $ASAN_SYMBOLIZE
+              (cd electron && (circleci tests glob "spec/*-spec.ts" | xargs -I@ -P4 bash -c "echo $(pwd)/@" | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings 2>&1)) | $ASAN_SYMBOLIZE
             else
               if [ "$TARGET_ARCH" == "ia32" ]; then
                 npm_config_arch=x64 node electron/node_modules/dugite/script/download-git.js
               fi
-              (cd electron && (circleci tests glob "spec/*-spec.ts" | xargs -L1 realpath | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings))
+              (cd electron && (circleci tests glob "spec/*-spec.ts" | xargs -I@ -P4 bash -c "echo $(pwd)/@" | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings))
             fi
       - store_test_results:
           path: src/junit

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -80,8 +80,9 @@ executors:
     machine: true
 
   linux-arm:
-    resource_class: electronjs/linux-arm
-    machine: true
+    resource_class: electronjs/aks-linux-arm-test
+    docker:
+      - image: ghcr.io/electron/test:arm32v7-8e0f85b708fa58e28e4824954d6fd55adfda5e9e
 
   linux-arm64:
     resource_class: electronjs/aks-linux-arm-test

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -86,7 +86,7 @@ executors:
   linux-arm64:
     resource_class: electronjs/aks-linux-arm-test
     docker:
-      - image: ghcr.io/electron/test:arm64v8-603263bdff4eec4967430e4684f57dc92969f647
+      - image: ghcr.io/electron/test:arm64v8-76d5d29e247972da3855a01c2d8cf72c5998233a
 
 # The config expects the following environment variables to be set:
 #  - "SLACK_WEBHOOK" Slack hook URL to send notifications.

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1629,12 +1629,12 @@ commands:
               export LLVM_SYMBOLIZER_PATH=$PWD/third_party/llvm-build/Release+Asserts/bin/llvm-symbolizer
               export MOCHA_TIMEOUT=180000
               echo "Piping output to ASAN_SYMBOLIZE ($ASAN_SYMBOLIZE)"
-              (cd electron && (circleci tests glob "spec/*-spec.ts" | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings 2>&1)) | $ASAN_SYMBOLIZE
+              (cd electron && (circleci tests glob "spec/*-spec.ts" | xargs -L1 realpath | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings 2>&1)) | $ASAN_SYMBOLIZE
             else
               if [ "$TARGET_ARCH" == "ia32" ]; then
                 npm_config_arch=x64 node electron/node_modules/dugite/script/download-git.js
               fi
-              (cd electron && (circleci tests glob "spec/*-spec.ts" | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings))
+              (cd electron && (circleci tests glob "spec/*-spec.ts" | xargs -L1 realpath | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings))
             fi
       - store_test_results:
           path: src/junit

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1630,7 +1630,7 @@ commands:
               echo "Piping output to ASAN_SYMBOLIZE ($ASAN_SYMBOLIZE)"
               (cd electron && (circleci tests glob "spec/*-spec.ts" | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings 2>&1)) | $ASAN_SYMBOLIZE
             else
-              if [ "$TARGET_ARCH" == "arm" ] || [ "$TARGET_ARCH" == "arm64" ]; then
+              if [ "$TARGET_ARCH" == "arm" ]; then
                 export ELECTRON_SKIP_NATIVE_MODULE_TESTS=true
                 (cd electron && node script/yarn test --runners=main --trace-uncaught --enable-logging)
               else
@@ -2277,6 +2277,7 @@ jobs:
       <<: *env-global
       <<: *env-headless-testing
       <<: *env-stack-dumping
+    parallelism: 3
     steps:
       - electron-tests:
           artifact-key: linux-arm64

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -84,8 +84,9 @@ executors:
     machine: true
 
   linux-arm64:
-    resource_class: electronjs/linux-arm64
-    machine: true
+    resource_class: electronjs/aks-linux-arm-test
+    docker:
+      - image: ghcr.io/electron/test:arm64v8-9a4acb4e8085c2439541a70aa28daae64feb44bf
 
 # The config expects the following environment variables to be set:
 #  - "SLACK_WEBHOOK" Slack hook URL to send notifications.


### PR DESCRIPTION
Uses images generated by https://github.com/electron/build-images/pull/32 that run on arm64 hosts in our kubernetes infra to run our arm64/32 tests.  This dramatically speeds up our linux CI.

This PR also fixes the circleci test splitting command to, well, actually work.  So tests are more consistent in their duration as well now.

Notes: no-notes