### PR TITLE
fix: crash using `powerMonitor` before ready event

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -81,7 +81,8 @@
 #include "base/environment.h"
 #include "chrome/browser/ui/views/dark_mode_manager_linux.h"
 #include "device/bluetooth/bluetooth_adapter_factory.h"
-#include "device/bluetooth/dbus/dbus_bluez_manager_wrapper_linux.h"
+#include "device/bluetooth/dbus/bluez_dbus_manager.h"
+#include "device/bluetooth/dbus/bluez_dbus_thread_manager.h"
 #include "electron/electron_gtk_stubs.h"
 #include "ui/base/cursor/cursor_factory.h"
 #include "ui/base/ime/linux/linux_input_method_context_factory.h"
@@ -386,7 +387,8 @@ void ElectronBrowserMainParts::PostDestroyThreads() {
 #endif
 #if BUILDFLAG(IS_LINUX)
   device::BluetoothAdapterFactory::Shutdown();
-  bluez::DBusBluezManagerWrapperLinux::Shutdown();
+  bluez::BluezDBusManager::Shutdown();
+  bluez::BluezDBusThreadManager::Shutdown();
 #endif
   fake_browser_process_->PostDestroyThreads();
 }
@@ -508,7 +510,8 @@ void ElectronBrowserMainParts::PostCreateMainMessageLoop() {
   ui::OzonePlatform::GetInstance()->PostCreateMainMessageLoop(
       std::move(shutdown_cb),
       content::GetUIThreadTaskRunner({content::BrowserTaskType::kUserInput}));
-  bluez::DBusBluezManagerWrapperLinux::Initialize();
+  if (!bluez::BluezDBusManager::IsInitialized())
+    bluez::BluezDBusManager::Initialize(nullptr /* system_bus */);
 
   // Set up crypt config. This needs to be done before anything starts the
   // network service, as the raw encryption key needs to be shared with the

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -82,7 +82,7 @@
 #include "chrome/browser/ui/views/dark_mode_manager_linux.h"
 #include "device/bluetooth/bluetooth_adapter_factory.h"
 #include "device/bluetooth/dbus/bluez_dbus_manager.h"
-#include "device/bluetooth/dbus/bluez_dbus_thread_manager.h"
+#include "device/bluetooth/dbus/dbus_bluez_manager_wrapper_linux.h"
 #include "electron/electron_gtk_stubs.h"
 #include "ui/base/cursor/cursor_factory.h"
 #include "ui/base/ime/linux/linux_input_method_context_factory.h"
@@ -387,8 +387,7 @@ void ElectronBrowserMainParts::PostDestroyThreads() {
 #endif
 #if BUILDFLAG(IS_LINUX)
   device::BluetoothAdapterFactory::Shutdown();
-  bluez::BluezDBusManager::Shutdown();
-  bluez::BluezDBusThreadManager::Shutdown();
+  bluez::DBusBluezManagerWrapperLinux::Shutdown();
 #endif
   fake_browser_process_->PostDestroyThreads();
 }
@@ -511,7 +510,7 @@ void ElectronBrowserMainParts::PostCreateMainMessageLoop() {
       std::move(shutdown_cb),
       content::GetUIThreadTaskRunner({content::BrowserTaskType::kUserInput}));
   if (!bluez::BluezDBusManager::IsInitialized())
-    bluez::BluezDBusManager::Initialize(nullptr /* system_bus */);
+    bluez::DBusBluezManagerWrapperLinux::Initialize();
 
   // Set up crypt config. This needs to be done before anything starts the
   // network service, as the raw encryption key needs to be shared with the

--- a/shell/browser/lib/power_observer_linux.cc
+++ b/shell/browser/lib/power_observer_linux.cc
@@ -11,6 +11,7 @@
 #include "base/files/file_path.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
+#include "device/bluetooth/dbus/bluez_dbus_manager.h"
 #include "device/bluetooth/dbus/bluez_dbus_thread_manager.h"
 
 namespace {
@@ -34,6 +35,9 @@ PowerObserverLinux::PowerObserverLinux(
     base::PowerSuspendObserver* suspend_observer)
     : suspend_observer_(suspend_observer),
       lock_owner_name_(GetExecutableBaseName()) {
+  if (!bluez::BluezDBusManager::IsInitialized())
+    bluez::BluezDBusManager::Initialize(nullptr /* system bus */);
+
   auto* bus = bluez::BluezDBusThreadManager::Get()->GetSystemBus();
   if (!bus) {
     LOG(WARNING) << "Failed to get system bus connection";

--- a/shell/browser/lib/power_observer_linux.cc
+++ b/shell/browser/lib/power_observer_linux.cc
@@ -13,6 +13,7 @@
 #include "base/logging.h"
 #include "device/bluetooth/dbus/bluez_dbus_manager.h"
 #include "device/bluetooth/dbus/bluez_dbus_thread_manager.h"
+#include "device/bluetooth/dbus/dbus_bluez_manager_wrapper_linux.h"
 
 namespace {
 
@@ -36,7 +37,7 @@ PowerObserverLinux::PowerObserverLinux(
     : suspend_observer_(suspend_observer),
       lock_owner_name_(GetExecutableBaseName()) {
   if (!bluez::BluezDBusManager::IsInitialized())
-    bluez::BluezDBusManager::Initialize(nullptr /* system bus */);
+    bluez::DBusBluezManagerWrapperLinux::Initialize();
 
   auto* bus = bluez::BluezDBusThreadManager::Get()->GetSystemBus();
   if (!bus) {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/40694.
Refs https://github.com/electron/electron/pull/37937.

This PR fixes a crash resultant in trying to listen to power-related events before the `ready` event is emitted on Linux. This was happening because the `PowerObserverLinux` ctor called `bluez::BluezDBusThreadManager::Get()`, which assumed that `bluez::BluezDBusThreadManager::Initialize()` had already been called and `CHECK`ed if it hadn't been. However, our existing logic did not call `bluez::BluezDBusThreadManager::Initialize()` until `ElectronBrowserMainParts::PostCreateMainMessageLoop()`, which meant that trying to use:

```js
  powerMonitor.on('suspend', () => {
    console.log('suspend')
  });

  powerMonitor.on('resume', () => {
    console.log('resume')
  });
```

before the `ready` event would immediately die. I chose to fix this by calling `bluez::BluezDBusThreadManager::Initialize()` as soon as it was needed, and adding a check to ensure that it was not initialized more than once. Alternately, we can bring back the `ready` event requirement.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash resultant from trying to listen to power-related events before the `ready` event was emitted on Linux. 