### PR TITLE
chore: do not inject DXVA_Decoding trace category

### DIFF
--- a/patches/chromium/build_add_electron_tracing_category.patch
+++ b/patches/chromium/build_add_electron_tracing_category.patch
@@ -8,14 +8,13 @@ categories in use are known / declared.  This patch is required for us
 to introduce a new Electron category for Electron-specific tracing.
 
 diff --git a/base/trace_event/builtin_categories.h b/base/trace_event/builtin_categories.h
-index 0cc26b32992cbbd5f599e0e062dd5b22bbf6d2dc..fd6a0eebd004f9e92ba577d73dfa75f685476288 100644
+index 0cc26b32992cbbd5f599e0e062dd5b22bbf6d2dc..2bc3fea0bc469a0cf26fa2a5af9c404294078f4a 100644
 --- a/base/trace_event/builtin_categories.h
 +++ b/base/trace_event/builtin_categories.h
-@@ -82,6 +82,8 @@
+@@ -82,6 +82,7 @@
    X("drm")                                                               \
    X("drmcursor")                                                         \
    X("dwrite")                                                            \
-+  X("DXVA_Decoding")                                                     \
 +  X("electron")                                                          \
    X("evdev")                                                             \
    X("event")                                                             \


### PR DESCRIPTION
#### Description of Change

Modify `build_add_electron_tracing_category.patch` so that it doesn't inject a `DXVA_Decoding` category. Looks like it was added by accident as part of the #38465 Chromium roll in 60ca38fb.

CC @electron/wg-upgrades 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none