### PR TITLE
fix: wide string concatenation

### DIFF
--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -142,7 +142,7 @@ bool FormatCommandLineString(std::wstring* exe,
 
   if (!launch_args.empty()) {
     std::u16string joined_launch_args = base::JoinString(launch_args, u" ");
-    *exe = base::StrCat({*exe, base::AsWStringView(joined_launch_args)});
+    *exe = base::StrCat({*exe, L" ", base::AsWStringView(joined_launch_args)});
   }
 
   return true;

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -19,8 +19,8 @@
 #include "base/files/file_path.h"
 #include "base/logging.h"
 #include "base/path_service.h"
+#include "base/strings/strcat_win.h"
 #include "base/strings/string_util.h"
-#include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/win/registry.h"
 #include "base/win/win_util.h"
@@ -68,13 +68,14 @@ bool GetProtocolLaunchPath(gin::Arguments* args, std::wstring* exe) {
 
   // Read in optional args arg
   std::vector<std::wstring> launch_args;
-  if (args->GetNext(&launch_args) && !launch_args.empty())
-    *exe = base::UTF8ToWide(
-        base::StringPrintf("\"%ls\" \"%ls\" \"%%1\"", exe->c_str(),
-                           base::JoinString(launch_args, L"\"  \"").c_str()));
-  else
-    *exe =
-        base::UTF8ToWide(base::StringPrintf("\"%ls\" \"%%1\"", exe->c_str()));
+  if (args->GetNext(&launch_args) && !launch_args.empty()) {
+    std::wstring joined_args = base::JoinString(launch_args, L"\" \"");
+    *exe = base::StrCat(
+        {L"\"", exe->c_str(), L"\" \"", joined_args.c_str(), L"\" \"%1\""});
+  } else {
+    *exe = base::StrCat({L"\"", exe->c_str(), L"\" \"%1\""});
+  }
+
   return true;
 }
 
@@ -142,8 +143,7 @@ bool FormatCommandLineString(std::wstring* exe,
 
   if (!launch_args.empty()) {
     std::u16string joined_launch_args = base::JoinString(launch_args, u" ");
-    *exe = base::UTF8ToWide(base::StringPrintf(
-        "%ls %ls", exe->c_str(), base::as_wcstr(joined_launch_args)));
+    *exe = base::StrCat({exe->c_str(), base::as_wcstr(joined_launch_args)});
   }
 
   return true;

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -70,10 +70,9 @@ bool GetProtocolLaunchPath(gin::Arguments* args, std::wstring* exe) {
   std::vector<std::wstring> launch_args;
   if (args->GetNext(&launch_args) && !launch_args.empty()) {
     std::wstring joined_args = base::JoinString(launch_args, L"\" \"");
-    *exe = base::StrCat(
-        {L"\"", exe->c_str(), L"\" \"", joined_args.c_str(), L"\" \"%1\""});
+    *exe = base::StrCat({L"\"", *exe, L"\" \"", joined_args, L"\" \"%1\""});
   } else {
-    *exe = base::StrCat({L"\"", exe->c_str(), L"\" \"%1\""});
+    *exe = base::StrCat({L"\"", *exe, L"\" \"%1\""});
   }
 
   return true;
@@ -143,7 +142,7 @@ bool FormatCommandLineString(std::wstring* exe,
 
   if (!launch_args.empty()) {
     std::u16string joined_launch_args = base::JoinString(launch_args, u" ");
-    *exe = base::StrCat({exe->c_str(), base::as_wcstr(joined_launch_args)});
+    *exe = base::StrCat({*exe, base::AsWStringView(joined_launch_args)});
   }
 
   return true;

--- a/shell/browser/relauncher_win.cc
+++ b/shell/browser/relauncher_win.cc
@@ -8,7 +8,8 @@
 
 #include "base/logging.h"
 #include "base/process/launch.h"
-#include "base/strings/stringprintf.h"
+#include "base/strings/strcat_win.h"
+#include "base/strings/string_number_conversions_win.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/win/scoped_handle.h"
 #include "sandbox/win/src/nt_internals.h"
@@ -109,8 +110,8 @@ StringType AddQuoteForArg(const StringType& arg) {
 }  // namespace
 
 StringType GetWaitEventName(base::ProcessId pid) {
-  return base::UTF8ToWide(
-      base::StringPrintf("%ls-%d", kWaitEventName, static_cast<int>(pid)));
+  return base::StrCat(
+      {kWaitEventName, L"-", base::NumberToWString(static_cast<int>(pid))});
 }
 
 StringType ArgvToCommandLineString(const StringVector& argv) {


### PR DESCRIPTION
#### Description of Change

In a recent Chromium roll (#40045) we make some changes that were caused by this following revision: [Remove Windows-specific wstring variants of StringPrintf() etc.](https://chromium-review.googlesource.com/c/chromium/src/+/4776412).

While the changes we made appear to be correct, we're observing some unicode conversion errors in practice, where the strings we modified are ending up with U+FFFE (the "replacement character") in them, indicating a string encoding conversion issue.

I'm still digging into the specifics of what exactly is going wrong and verifying that this PR is indeed correct, but this PR brings us in line with the changes Chromium made to address these situations: using `base::StrCat` (and a few `base::NumberToWString`). (See: multiple revisions attached to [Chromium bug 1371963](https://bugs.chromium.org/p/chromium/issues/detail?id=1371963), each starting with `Remove usage of wstring StringPrintf():`.)

#### Release Notes

Notes: Fixed default protocol handler behavior on Windows.
