### PR TITLE
docs: add missing vibrancy breaking change

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -233,6 +233,18 @@ systemPreferences.on('high-contrast-color-scheme-changed', () => { /* ... */ })
 nativeTheme.on('updated', () => { /* ... */ })
 ```
 
+### Removed: Some `window.setVibrancy` options on macOS
+
+The following vibrancy options have been removed:
+
+* 'light'
+* 'medium-light'
+* 'dark'
+* 'ultra-dark'
+* 'appearance-based'
+
+These were previously deprecated and have been removed by Apple in 10.15.
+
 ### Removed: `webContents.getPrinters`
 
 The `webContents.getPrinters` method has been removed. Use


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/40799.

Adds missing breaking vibrancy change forced in https://github.com/electron/electron/pull/38891

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
