### PR TITLE
chore: cherry-pick 5 changes from Release-3-M120

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -1,3 +1,5 @@
 cherry-pick-285c7712c506.patch
 cherry-pick-2bf945775fe6.patch
 cherry-pick-cafe56b591ed.patch
+cherry-pick-0c1d249c3fe2.patch
+cherry-pick-01f439363dcb.patch

--- a/patches/angle/cherry-pick-01f439363dcb.patch
+++ b/patches/angle/cherry-pick-01f439363dcb.patch
@@ -1,0 +1,136 @@
+From 01f439363dcbc21ff2012fb1feb542d275261b3b Mon Sep 17 00:00:00 2001
+From: Shahbaz Youssefi <syoussefi@chromium.org>
+Date: Tue, 05 Dec 2023 13:36:53 -0500
+Subject: [PATCH] M120: Vulkan: Don't crash when glCopyTexImage2D redefines itself
+
+The Vulkan backend marks a level being redefined as such before doing
+the copy.  If a single-level texture was being redefined, it releases it
+so it can be immediately reallocated.  If the source of the copy is the
+same texture, this causes a crash.
+
+This can be properly supported by using a temp image to do the copy, but
+that is not implemented in this change.
+
+Bug: chromium:1501798
+Change-Id: I3a902b1e9eec41afd385d9c75a8c95dc986070a8
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5143829
+Reviewed-by: Cody Northrop <cnorthrop@google.com>
+---
+
+diff --git a/src/libANGLE/renderer/vulkan/TextureVk.cpp b/src/libANGLE/renderer/vulkan/TextureVk.cpp
+index 83bdcac..9cb3c1e 100644
+--- a/src/libANGLE/renderer/vulkan/TextureVk.cpp
++++ b/src/libANGLE/renderer/vulkan/TextureVk.cpp
+@@ -940,8 +940,28 @@
+         gl::GetInternalFormatInfo(internalFormat, GL_UNSIGNED_BYTE);
+     const vk::Format &vkFormat = renderer->getFormat(internalFormatInfo.sizedInternalFormat);
+ 
++    // The texture level being redefined might be the same as the one bound to the framebuffer.
++    // This _could_ be supported by using a temp image before redefining the level (and potentially
++    // discarding the image).  However, this is currently unimplemented.
++    FramebufferVk *framebufferVk = vk::GetImpl(source);
++    RenderTargetVk *colorReadRT  = framebufferVk->getColorReadRenderTarget();
++    vk::ImageHelper *srcImage    = &colorReadRT->getImageForCopy();
++    const bool isCubeMap         = index.getType() == gl::TextureType::CubeMap;
++    gl::LevelIndex levelIndex(getNativeImageIndex(index).getLevelIndex());
++    const uint32_t layerIndex    = index.hasLayer() ? index.getLayerIndex() : 0;
++    const uint32_t redefinedFace = isCubeMap ? layerIndex : 0;
++    const uint32_t sourceFace    = isCubeMap ? colorReadRT->getLayerIndex() : 0;
++    const bool isSelfCopy = mImage == srcImage && levelIndex == colorReadRT->getLevelIndex() &&
++                            redefinedFace == sourceFace;
++
+     ANGLE_TRY(redefineLevel(context, index, vkFormat, newImageSize));
+ 
++    if (isSelfCopy)
++    {
++        UNIMPLEMENTED();
++        return angle::Result::Continue;
++    }
++
+     return copySubImageImpl(context, index, gl::Offset(0, 0, 0), sourceArea, internalFormatInfo,
+                             source);
+ }
+@@ -2017,7 +2037,8 @@
+                 mImage->getLevelCount() == 1 && mImage->getFirstAllocatedLevel() == levelIndexGL;
+ 
+             // If incompatible, and redefining the single-level image, release it so it can be
+-            // recreated immediately.  This is an optimization to avoid an extra copy.
++            // recreated immediately.  This is needed so that the texture can be reallocated with
++            // the correct format/size.
+             //
+             // This is not done for cubemaps because every face may be separately redefined.  Note
+             // that this is not possible for texture arrays in general.
+diff --git a/src/tests/angle_end2end_tests_expectations.txt b/src/tests/angle_end2end_tests_expectations.txt
+index ef93b9e..9f92e28 100644
+--- a/src/tests/angle_end2end_tests_expectations.txt
++++ b/src/tests/angle_end2end_tests_expectations.txt
+@@ -29,6 +29,8 @@
+ 6989 GLES : BlitFramebufferTestES31.OOBResolve/* = SKIP
+ 7881 VULKAN : MultithreadingTestES3.UnsynchronizedTextureReads/* = SKIP
+ 7881 VULKAN : MultithreadingTestES3.UnsynchronizedTextureReads2/* = SKIP
++// Incorrectly handled pretty much in all backends
++8446 : CopyTexImageTestES3.RedefineSameLevel/* = SKIP
+ 
+ 6743 OPENGL : SimpleStateChangeTestES3.RespecifyBufferAfterBeginTransformFeedback/* = SKIP
+ 6743 GLES : SimpleStateChangeTestES3.RespecifyBufferAfterBeginTransformFeedback/* = SKIP
+diff --git a/src/tests/gl_tests/CopyTexImageTest.cpp b/src/tests/gl_tests/CopyTexImageTest.cpp
+index e0a8fb8..bcdae07 100644
+--- a/src/tests/gl_tests/CopyTexImageTest.cpp
++++ b/src/tests/gl_tests/CopyTexImageTest.cpp
+@@ -1263,6 +1263,56 @@
+     glBindTexture(GL_TEXTURE_3D, 0);
+ }
+ 
++// Make sure a single-level texture can be redefined through glCopyTexImage2D from a framebuffer
++// bound to the same texture.  Regression test for a bug in the Vulkan backend where the texture was
++// released before the copy.
++TEST_P(CopyTexImageTestES3, RedefineSameLevel)
++{
++    constexpr GLsizei kSize     = 32;
++    constexpr GLsizei kHalfSize = kSize / 2;
++
++    // Create a single-level texture with four colors in different regions.
++    std::vector<GLColor> initData(kSize * kSize);
++    for (GLsizei y = 0; y < kSize; ++y)
++    {
++        const bool isTop = y < kHalfSize;
++        for (GLsizei x = 0; x < kSize; ++x)
++        {
++            const bool isLeft = x < kHalfSize;
++
++            GLColor color           = isLeft && isTop    ? GLColor::red
++                                      : isLeft && !isTop ? GLColor::green
++                                      : !isLeft && isTop ? GLColor::blue
++                                                         : GLColor::yellow;
++            color.A                 = 123;
++            initData[y * kSize + x] = color;
++        }
++    }
++
++    GLTexture tex;
++    glBindTexture(GL_TEXTURE_2D, tex);
++    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, kSize, kSize, 0, GL_RGBA, GL_UNSIGNED_BYTE,
++                 initData.data());
++
++    // Bind the framebuffer to the same texture
++    GLFramebuffer framebuffer;
++    glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
++    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, tex, 0);
++
++    // Redefine the texture
++    glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, kHalfSize / 2, kHalfSize / 2, kHalfSize, kHalfSize,
++                     0);
++
++    // Verify copy is done correctly.
++    ASSERT_GL_FRAMEBUFFER_COMPLETE(GL_FRAMEBUFFER);
++
++    EXPECT_PIXEL_RECT_EQ(0, 0, kHalfSize / 2, kHalfSize / 2, GLColor::red);
++    EXPECT_PIXEL_RECT_EQ(kHalfSize / 2, 0, kHalfSize / 2, kHalfSize / 2, GLColor::blue);
++    EXPECT_PIXEL_RECT_EQ(0, kHalfSize / 2, kHalfSize / 2, kHalfSize / 2, GLColor::green);
++    EXPECT_PIXEL_RECT_EQ(kHalfSize / 2, kHalfSize / 2, kHalfSize / 2, kHalfSize / 2,
++                         GLColor::yellow);
++}
++
+ ANGLE_INSTANTIATE_TEST(CopyTexImageTest,
+                        ANGLE_ALL_TEST_PLATFORMS_ES2,
+                        ES2_D3D11_PRESENT_PATH_FAST(),

--- a/patches/angle/cherry-pick-0c1d249c3fe2.patch
+++ b/patches/angle/cherry-pick-0c1d249c3fe2.patch
@@ -1,0 +1,181 @@
+From 0c1d249c3fe252f7f52724111431a3db183de135 Mon Sep 17 00:00:00 2001
+From: Shahbaz Youssefi <syoussefi@chromium.org>
+Date: Thu, 30 Nov 2023 13:53:00 -0500
+Subject: [PATCH] M120: Translator: Optimize field-name-collision check
+
+As each field of the struct was encountered, its name was linearly
+checked against previously added fields.  That's O(n^2).
+
+The name collision check is now moved to when the struct is completely
+defined, and is done with an unordered_map.
+
+Bug: chromium:1505009
+Change-Id: I3fbc23493e5a03e61b631af615cffaf9995fd566
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5143826
+Reviewed-by: Cody Northrop <cnorthrop@google.com>
+---
+
+diff --git a/src/compiler/translator/ParseContext.cpp b/src/compiler/translator/ParseContext.cpp
+index e26f77b..3e675ab 100644
+--- a/src/compiler/translator/ParseContext.cpp
++++ b/src/compiler/translator/ParseContext.cpp
+@@ -4726,6 +4726,9 @@
+     const TVector<unsigned int> *arraySizes,
+     const TSourceLoc &arraySizesLine)
+ {
++    // Ensure there are no duplicate field names
++    checkDoesNotHaveDuplicateFieldNames(fieldList, nameLine);
++
+     const bool isGLPerVertex = blockName == "gl_PerVertex";
+     // gl_PerVertex is allowed to be redefined and therefore not reserved
+     if (!isGLPerVertex)
+@@ -6274,28 +6277,25 @@
+     return new TDeclarator(identifier, arraySizes, loc);
+ }
+ 
+-void TParseContext::checkDoesNotHaveDuplicateFieldName(const TFieldList::const_iterator begin,
+-                                                       const TFieldList::const_iterator end,
+-                                                       const ImmutableString &name,
+-                                                       const TSourceLoc &location)
++void TParseContext::checkDoesNotHaveDuplicateFieldNames(const TFieldList *fields,
++                                                        const TSourceLoc &location)
+ {
+-    for (auto fieldIter = begin; fieldIter != end; ++fieldIter)
++    TUnorderedMap<ImmutableString, uint32_t, ImmutableString::FowlerNollVoHash<sizeof(size_t)>>
++        fieldNames;
++    for (TField *field : *fields)
+     {
+-        if ((*fieldIter)->name() == name)
++        // Note: operator[] adds this name to the map if it doesn't already exist, and initializes
++        // its value to 0.
++        uint32_t count = ++fieldNames[field->name()];
++        if (count != 1)
+         {
+-            error(location, "duplicate field name in structure", name);
++            error(location, "Duplicate field name in structure", field->name());
+         }
+     }
+ }
+ 
+ TFieldList *TParseContext::addStructFieldList(TFieldList *fields, const TSourceLoc &location)
+ {
+-    for (TFieldList::const_iterator fieldIter = fields->begin(); fieldIter != fields->end();
+-         ++fieldIter)
+-    {
+-        checkDoesNotHaveDuplicateFieldName(fields->begin(), fieldIter, (*fieldIter)->name(),
+-                                           location);
+-    }
+     return fields;
+ }
+ 
+@@ -6303,12 +6303,8 @@
+                                                    const TFieldList *newlyAddedFields,
+                                                    const TSourceLoc &location)
+ {
+-    for (TField *field : *newlyAddedFields)
+-    {
+-        checkDoesNotHaveDuplicateFieldName(processedFields->begin(), processedFields->end(),
+-                                           field->name(), location);
+-        processedFields->push_back(field);
+-    }
++    processedFields->insert(processedFields->end(), newlyAddedFields->begin(),
++                            newlyAddedFields->end());
+     return processedFields;
+ }
+ 
+@@ -6401,7 +6397,10 @@
+         }
+     }
+ 
+-    // ensure we do not specify any storage qualifiers on the struct members
++    // Ensure there are no duplicate field names
++    checkDoesNotHaveDuplicateFieldNames(fieldList, structLine);
++
++    // Ensure we do not specify any storage qualifiers on the struct members
+     for (unsigned int typeListIndex = 0; typeListIndex < fieldList->size(); typeListIndex++)
+     {
+         TField &field              = *(*fieldList)[typeListIndex];
+diff --git a/src/compiler/translator/ParseContext.h b/src/compiler/translator/ParseContext.h
+index 9e1354e..b63dbba 100644
+--- a/src/compiler/translator/ParseContext.h
++++ b/src/compiler/translator/ParseContext.h
+@@ -354,10 +354,7 @@
+                                             const TSourceLoc &loc,
+                                             const TVector<unsigned int> *arraySizes);
+ 
+-    void checkDoesNotHaveDuplicateFieldName(const TFieldList::const_iterator begin,
+-                                            const TFieldList::const_iterator end,
+-                                            const ImmutableString &name,
+-                                            const TSourceLoc &location);
++    void checkDoesNotHaveDuplicateFieldNames(const TFieldList *fields, const TSourceLoc &location);
+     TFieldList *addStructFieldList(TFieldList *fields, const TSourceLoc &location);
+     TFieldList *combineStructFieldLists(TFieldList *processedFields,
+                                         const TFieldList *newlyAddedFields,
+diff --git a/src/tests/angle_end2end_tests_expectations.txt b/src/tests/angle_end2end_tests_expectations.txt
+index f1ac04e..7b6b332 100644
+--- a/src/tests/angle_end2end_tests_expectations.txt
++++ b/src/tests/angle_end2end_tests_expectations.txt
+@@ -1053,6 +1053,8 @@
+ 7389 SWIFTSHADER : Texture2DTest.ManySupersedingTextureUpdates/* = SKIP
+ 7389 MAC OPENGL : Texture2DTest.ManySupersedingTextureUpdates/* = SKIP
+ 
++8437 MAC OPENGL : GLSLTest_ES3.LotsOfFieldsInStruct/* = SKIP
++
+ // GL, GLES run into issues with cleanup
+ 7495 WIN OpenGL : EGLMultiContextTest.ReuseUnterminatedDisplay/* = SKIP
+ 7495 WIN GLES : EGLMultiContextTest.ReuseUnterminatedDisplay/* = SKIP
+diff --git a/src/tests/gl_tests/GLSLTest.cpp b/src/tests/gl_tests/GLSLTest.cpp
+index ef4a129..2758eb9 100644
+--- a/src/tests/gl_tests/GLSLTest.cpp
++++ b/src/tests/gl_tests/GLSLTest.cpp
+@@ -18141,6 +18141,50 @@
+     EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::red);
+ }
+ 
++// Test that Metal compiler doesn't inline non-const globals
++TEST_P(WebGLGLSLTest, InvalidGlobalsNotInlined)
++{
++    constexpr char kFS[] = R"(#version 100
++  precision highp float;
++  float v1 = 0.5;
++  float v2 = v1;
++
++  float f1() {
++    return v2;
++  }
++
++  void main() {
++    gl_FragColor = vec4(v1 + f1(),0.0,0.0, 1.0);
++  })";
++    ANGLE_GL_PROGRAM(program, essl1_shaders::vs::Simple(), kFS);
++    ASSERT_GL_NO_ERROR();
++}
++
++// Test that a struct can have lots of fields.  Regression test for an inefficient O(n^2) check for
++// fields having unique names.
++TEST_P(GLSLTest_ES3, LotsOfFieldsInStruct)
++{
++    std::ostringstream fs;
++    fs << R"(#version 300 es
++precision highp float;
++struct LotsOfFields
++{
++)";
++    // Note: 16383 is the SPIR-V limit for struct member count.
++    for (uint32_t i = 0; i < 16383; ++i)
++    {
++        fs << "    float field" << i << ";\n";
++    }
++    fs << R"(};
++uniform B { LotsOfFields s; };
++out vec4 color;
++void main() {
++    color = vec4(s.field0, 0.0, 0.0, 1.0);
++})";
++
++    ANGLE_GL_PROGRAM(program, essl3_shaders::vs::Simple(), fs.str().c_str());
++}
++
+ }  // anonymous namespace
+ 
+ ANGLE_INSTANTIATE_TEST_ES2_AND_ES3_AND(

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -152,3 +152,5 @@ cherry-pick-021598ea43c1.patch
 cherry-pick-76340163a820.patch
 cherry-pick-f15cfb9371c4.patch
 cherry-pick-4ca62c7a8b88.patch
+cherry-pick-5b2fddadaa12.patch
+cherry-pick-50a1bddfca85.patch

--- a/patches/chromium/cherry-pick-50a1bddfca85.patch
+++ b/patches/chromium/cherry-pick-50a1bddfca85.patch
@@ -1,0 +1,117 @@
+From 50a1bddfca85046282797f0361c35c92f9eacf6a Mon Sep 17 00:00:00 2001
+From: Austin Eng <enga@chromium.org>
+Date: Tue, 19 Dec 2023 17:25:51 +0000
+Subject: [PATCH] Use cross thread handles to bind args for async webgpu context creation
+
+(cherry picked from commit 542b278a0c1de7202f4bf5e3e5cbdc2dd6c337d4)
+
+Fixed: 1506923
+Change-Id: I174703cbd993471e3afb39c0cfa4cce2770755f7
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5113019
+Reviewed-by: Corentin Wallez <cwallez@chromium.org>
+Commit-Queue: Austin Eng <enga@chromium.org>
+Reviewed-by: Stephen White <senorblanco@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1237179}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5133239
+Cr-Commit-Position: refs/branch-heads/6099@{#1551}
+Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
+---
+
+diff --git a/third_party/blink/renderer/modules/webgpu/gpu.cc b/third_party/blink/renderer/modules/webgpu/gpu.cc
+index 3067c9a..92c0428f 100644
+--- a/third_party/blink/renderer/modules/webgpu/gpu.cc
++++ b/third_party/blink/renderer/modules/webgpu/gpu.cc
+@@ -39,11 +39,13 @@
+ #include "third_party/blink/renderer/platform/graphics/gpu/dawn_control_client_holder.h"
+ #include "third_party/blink/renderer/platform/graphics/gpu/webgpu_callback.h"
+ #include "third_party/blink/renderer/platform/graphics/web_graphics_context_3d_provider_util.h"
++#include "third_party/blink/renderer/platform/heap/cross_thread_handle.h"
+ #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+ #include "third_party/blink/renderer/platform/heap/thread_state.h"
+ #include "third_party/blink/renderer/platform/instrumentation/use_counter.h"
+ #include "third_party/blink/renderer/platform/privacy_budget/identifiability_digest_helpers.h"
+ #include "third_party/blink/renderer/platform/weborigin/kurl.h"
++#include "third_party/blink/renderer/platform/wtf/cross_thread_functional.h"
+ 
+ namespace blink {
+ 
+@@ -300,9 +302,19 @@
+     CreateWebGPUGraphicsContext3DProviderAsync(
+         execution_context->Url(),
+         execution_context->GetTaskRunner(TaskType::kWebGPU),
+-        WTF::BindOnce(
+-            [](GPU* gpu, ExecutionContext* execution_context,
++        CrossThreadBindOnce(
++            [](CrossThreadHandle<GPU> gpu_handle,
++               CrossThreadHandle<ExecutionContext> execution_context_handle,
+                std::unique_ptr<WebGraphicsContext3DProvider> context_provider) {
++              auto unwrap_gpu = MakeUnwrappingCrossThreadHandle(gpu_handle);
++              auto unwrap_execution_context =
++                  MakeUnwrappingCrossThreadHandle(execution_context_handle);
++              if (!unwrap_gpu || !unwrap_execution_context) {
++                return;
++              }
++              auto* gpu = unwrap_gpu.GetOnCreationThread();
++              auto* execution_context =
++                  unwrap_execution_context.GetOnCreationThread();
+               const KURL& url = execution_context->Url();
+               context_provider =
+                   CheckContextProvider(url, std::move(context_provider));
+@@ -324,7 +336,8 @@
+                 std::move(callback).Run();
+               }
+             },
+-            WrapPersistent(this), WrapPersistent(execution_context)));
++            MakeCrossThreadHandle(this),
++            MakeCrossThreadHandle(execution_context)));
+     return;
+   }
+ 
+diff --git a/third_party/blink/renderer/platform/graphics/web_graphics_context_3d_provider_util.cc b/third_party/blink/renderer/platform/graphics/web_graphics_context_3d_provider_util.cc
+index e981c2d..29569d4 100644
+--- a/third_party/blink/renderer/platform/graphics/web_graphics_context_3d_provider_util.cc
++++ b/third_party/blink/renderer/platform/graphics/web_graphics_context_3d_provider_util.cc
+@@ -122,8 +122,8 @@
+ void CreateWebGPUGraphicsContext3DProviderAsync(
+     const KURL& url,
+     scoped_refptr<base::SingleThreadTaskRunner> current_thread_task_runner,
+-    base::OnceCallback<void(std::unique_ptr<WebGraphicsContext3DProvider>)>
+-        callback) {
++    WTF::CrossThreadOnceFunction<
++        void(std::unique_ptr<WebGraphicsContext3DProvider>)> callback) {
+   if (IsMainThread()) {
+     std::move(callback).Run(
+         Platform::Current()->CreateWebGPUGraphicsContext3DProvider(url));
+@@ -141,8 +141,7 @@
+             AccessMainThreadForWebGraphicsContext3DProvider()),
+         FROM_HERE,
+         CrossThreadBindOnce(&CreateWebGPUGraphicsContextOnMainThreadAsync, url,
+-                            current_thread_task_runner,
+-                            CrossThreadBindOnce(std::move(callback))));
++                            current_thread_task_runner, std::move(callback)));
+   }
+ }
+ 
+diff --git a/third_party/blink/renderer/platform/graphics/web_graphics_context_3d_provider_util.h b/third_party/blink/renderer/platform/graphics/web_graphics_context_3d_provider_util.h
+index 8fcab24b..8b785cc3 100644
+--- a/third_party/blink/renderer/platform/graphics/web_graphics_context_3d_provider_util.h
++++ b/third_party/blink/renderer/platform/graphics/web_graphics_context_3d_provider_util.h
+@@ -10,6 +10,7 @@
+ #include "third_party/blink/public/platform/web_graphics_context_3d_provider.h"
+ #include "third_party/blink/renderer/platform/platform_export.h"
+ #include "third_party/blink/renderer/platform/weborigin/kurl.h"
++#include "third_party/blink/renderer/platform/wtf/functional.h"
+ 
+ namespace blink {
+ 
+@@ -42,8 +43,8 @@
+ PLATFORM_EXPORT void CreateWebGPUGraphicsContext3DProviderAsync(
+     const KURL& url,
+     scoped_refptr<base::SingleThreadTaskRunner> current_thread_task_runner,
+-    base::OnceCallback<void(std::unique_ptr<WebGraphicsContext3DProvider>)>
+-        callback);
++    WTF::CrossThreadOnceFunction<
++        void(std::unique_ptr<WebGraphicsContext3DProvider>)> callback);
+ 
+ }  // namespace blink
+ 

--- a/patches/chromium/cherry-pick-5b2fddadaa12.patch
+++ b/patches/chromium/cherry-pick-5b2fddadaa12.patch
@@ -1,0 +1,62 @@
+From 5b2fddadaa12e4f4aa8166de13446db5e339c4fa Mon Sep 17 00:00:00 2001
+From: Hongchan Choi <hongchan@chromium.org>
+Date: Tue, 12 Dec 2023 02:34:29 +0000
+Subject: [PATCH] Clamp the input value correctly before scheduling an AudioParam event
+
+When the AudioParam value is set via the setter, it internally calls
+the setValueAtTime() function to schedule the change. However, the
+current code does not correctly clamp the value within the nominal
+range. This CL fixes the problem.
+
+(cherry picked from commit c97b506c1e32951dd39e11e453e1ecc29cc0b35c)
+
+Bug: 1505086
+Test: Locally confirmed with both negative and positive param values.
+Change-Id: Ibb0aae168161af9ea95c5e11a929b3aa2c621c73
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5100625
+Reviewed-by: Michael Wilson <mjwilson@chromium.org>
+Commit-Queue: Hongchan Choi <hongchan@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1235028}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5112838
+Commit-Queue: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: Hongchan Choi <hongchan@chromium.org>
+Cr-Commit-Position: refs/branch-heads/6099@{#1497}
+Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
+---
+
+diff --git a/third_party/blink/renderer/modules/webaudio/audio_param.cc b/third_party/blink/renderer/modules/webaudio/audio_param.cc
+index 8c7b9d0..95a40d3 100644
+--- a/third_party/blink/renderer/modules/webaudio/audio_param.cc
++++ b/third_party/blink/renderer/modules/webaudio/audio_param.cc
+@@ -120,12 +120,15 @@
+ void AudioParam::setValue(float value, ExceptionState& exception_state) {
+   WarnIfOutsideRange("value", value);
+ 
+-  // This is to signal any errors, if necessary, about conflicting
+-  // automations.
+-  setValueAtTime(value, Context()->currentTime(), exception_state);
+-  // This is to change the value so that an immediate query for the
+-  // value returns the expected values.
++  // Change the intrinsic value so that an immediate query for the value
++  // returns the value that the user code provided. It also clamps the value
++  // to the nominal range.
+   Handler().SetValue(value);
++
++  // Use the intrinsic value (after clamping) to schedule the actual
++  // automation event.
++  setValueAtTime(Handler().IntrinsicValue(), Context()->currentTime(),
++                 exception_state);
+ }
+ 
+ float AudioParam::defaultValue() const {
+diff --git a/third_party/blink/web_tests/webaudio/AudioParam/worklet-warnings-expected.txt b/third_party/blink/web_tests/webaudio/AudioParam/worklet-warnings-expected.txt
+index 86586c24..c88dd11 100644
+--- a/third_party/blink/web_tests/webaudio/AudioParam/worklet-warnings-expected.txt
++++ b/third_party/blink/web_tests/webaudio/AudioParam/worklet-warnings-expected.txt
+@@ -1,5 +1,4 @@
+ CONSOLE WARNING: AudioWorkletNode("noise-generator").amplitude.value 99 outside nominal range [0, 1]; value will be clamped.
+-CONSOLE WARNING: AudioWorkletNode("noise-generator").amplitude.setValueAtTime value 99 outside nominal range [0, 1]; value will be clamped.
+ CONSOLE WARNING: AudioWorkletNode("noise-generator").amplitude.setValueAtTime value -1 outside nominal range [0, 1]; value will be clamped.
+ CONSOLE WARNING: AudioWorkletNode("noise-generator").amplitude.linearRampToValueAtTime value 5 outside nominal range [0, 1]; value will be clamped.
+ This is a testharness.js-based test.

--- a/patches/sqlite/.patches
+++ b/patches/sqlite/.patches
@@ -1,0 +1,1 @@
+cherry-pick-cd9486849ba3.patch

--- a/patches/sqlite/cherry-pick-cd9486849ba3.patch
+++ b/patches/sqlite/cherry-pick-cd9486849ba3.patch
@@ -1,0 +1,325 @@
+From cd9486849ba3c3ec753f556fd29c0aabee122a28 Mon Sep 17 00:00:00 2001
+From: Evan Stade <estade@chromium.org>
+Date: Fri, 15 Dec 2023 21:38:02 +0000
+Subject: [PATCH] Fix a spurious "misuse of aggregate function" error that could occur when an aggregate function was used within the FROM clause of a sub-select of the select that owns the aggregate. e.g. "SELECT (SELECT x FROM (SELECT sum(t1.a) AS x)) FROM t1". [forum:/forumpost/c9970a37ed | Forum post c9970a37ed].
+
+FossilOrigin-Name: 4470f657d2069972d02a00983252dec1f814d90c0d8d0906e320e955111e8c11
+(cherry picked from commit 5e4233a9e48b124d4d342b757b34e4ae849f5cf8)
+
+Bug: 1511689
+Change-Id: I69263fc0a5fa66df5c09b964864568f2fc7a6ca5
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/deps/sqlite/+/5123910
+Auto-Submit: Evan Stade <estade@chromium.org>
+Commit-Queue: Ayu Ishii <ayui@chromium.org>
+Reviewed-by: Ayu Ishii <ayui@chromium.org>
+---
+
+diff --git a/amalgamation/sqlite3.c b/amalgamation/sqlite3.c
+index 7a7015b..10206b6 100644
+--- a/amalgamation/sqlite3.c
++++ b/amalgamation/sqlite3.c
+@@ -18,7 +18,7 @@
+ ** separate file. This file contains only code for the core SQLite library.
+ **
+ ** The content in this amalgamation comes from Fossil check-in
+-** 880e9508d4389fd84d41506c9d2e3196802 with changes in files:
++** 671f2481b87df31f3882268bb63c1f87dbd with changes in files:
+ **
+ **    manifest.uuid
+ */
+@@ -463,7 +463,7 @@
+ */
+ #define SQLITE_VERSION        "3.43.2"
+ #define SQLITE_VERSION_NUMBER 3043002
+-#define SQLITE_SOURCE_ID      "2023-10-10 12:14:04 0880e9508d4389fd84d41506c9d2e3196802bad743f210d6710dd8447f0f9c35"
++#define SQLITE_SOURCE_ID      "2023-10-10 12:14:04 1671f2481b87df31f3882268bb63c1f87dbdfbc618c35ce078e50286cb060c11"
+ 
+ /*
+ ** CAPI3REF: Run-Time Library Version Numbers
+@@ -19010,6 +19010,7 @@
+   int nRef;            /* Number of names resolved by this context */
+   int nNcErr;          /* Number of errors encountered while resolving names */
+   int ncFlags;         /* Zero or more NC_* flags defined below */
++  int nNestedSelect;   /* Number of nested selects using this NC */
+   Select *pWinSelect;  /* SELECT statement for any window functions */
+ };
+ 
+@@ -106417,11 +106418,12 @@
+           while( pNC2
+               && sqlite3ReferencesSrcList(pParse, pExpr, pNC2->pSrcList)==0
+           ){
+-            pExpr->op2++;
++            pExpr->op2 += (1 + pNC2->nNestedSelect);
+             pNC2 = pNC2->pNext;
+           }
+           assert( pDef!=0 || IN_RENAME_OBJECT );
+           if( pNC2 && pDef ){
++            pExpr->op2 += pNC2->nNestedSelect;
+             assert( SQLITE_FUNC_MINMAX==NC_MinMaxAgg );
+             assert( SQLITE_FUNC_ANYORDER==NC_OrderAgg );
+             testcase( (pDef->funcFlags & SQLITE_FUNC_MINMAX)!=0 );
+@@ -106982,6 +106984,7 @@
+ 
+     /* Recursively resolve names in all subqueries in the FROM clause
+     */
++    if( pOuterNC ) pOuterNC->nNestedSelect++;
+     for(i=0; i<p->pSrc->nSrc; i++){
+       SrcItem *pItem = &p->pSrc->a[i];
+       if( pItem->pSelect && (pItem->pSelect->selFlags & SF_Resolved)==0 ){
+@@ -107006,6 +107009,7 @@
+         }
+       }
+     }
++    if( pOuterNC ) pOuterNC->nNestedSelect--;
+ 
+     /* Set up the local name-context to pass to sqlite3ResolveExprNames() to
+     ** resolve the result-set expression list.
+diff --git a/amalgamation/sqlite3.h b/amalgamation/sqlite3.h
+index 7cbf759..cfaaf1d 100644
+--- a/amalgamation/sqlite3.h
++++ b/amalgamation/sqlite3.h
+@@ -148,7 +148,7 @@
+ */
+ #define SQLITE_VERSION        "3.43.2"
+ #define SQLITE_VERSION_NUMBER 3043002
+-#define SQLITE_SOURCE_ID      "2023-10-10 12:14:04 0880e9508d4389fd84d41506c9d2e3196802bad743f210d6710dd8447f0f9c35"
++#define SQLITE_SOURCE_ID      "2023-10-10 12:14:04 1671f2481b87df31f3882268bb63c1f87dbdfbc618c35ce078e50286cb060c11"
+ 
+ /*
+ ** CAPI3REF: Run-Time Library Version Numbers
+diff --git a/amalgamation_dev/sqlite3.c b/amalgamation_dev/sqlite3.c
+index 838d5aa..6a595f6 100644
+--- a/amalgamation_dev/sqlite3.c
++++ b/amalgamation_dev/sqlite3.c
+@@ -18,7 +18,7 @@
+ ** separate file. This file contains only code for the core SQLite library.
+ **
+ ** The content in this amalgamation comes from Fossil check-in
+-** 880e9508d4389fd84d41506c9d2e3196802 with changes in files:
++** 671f2481b87df31f3882268bb63c1f87dbd with changes in files:
+ **
+ **    manifest.uuid
+ */
+@@ -463,7 +463,7 @@
+ */
+ #define SQLITE_VERSION        "3.43.2"
+ #define SQLITE_VERSION_NUMBER 3043002
+-#define SQLITE_SOURCE_ID      "2023-10-10 12:14:04 0880e9508d4389fd84d41506c9d2e3196802bad743f210d6710dd8447f0f9c35"
++#define SQLITE_SOURCE_ID      "2023-10-10 12:14:04 1671f2481b87df31f3882268bb63c1f87dbdfbc618c35ce078e50286cb060c11"
+ 
+ /*
+ ** CAPI3REF: Run-Time Library Version Numbers
+@@ -19023,6 +19023,7 @@
+   int nRef;            /* Number of names resolved by this context */
+   int nNcErr;          /* Number of errors encountered while resolving names */
+   int ncFlags;         /* Zero or more NC_* flags defined below */
++  int nNestedSelect;   /* Number of nested selects using this NC */
+   Select *pWinSelect;  /* SELECT statement for any window functions */
+ };
+ 
+@@ -106430,11 +106431,12 @@
+           while( pNC2
+               && sqlite3ReferencesSrcList(pParse, pExpr, pNC2->pSrcList)==0
+           ){
+-            pExpr->op2++;
++            pExpr->op2 += (1 + pNC2->nNestedSelect);
+             pNC2 = pNC2->pNext;
+           }
+           assert( pDef!=0 || IN_RENAME_OBJECT );
+           if( pNC2 && pDef ){
++            pExpr->op2 += pNC2->nNestedSelect;
+             assert( SQLITE_FUNC_MINMAX==NC_MinMaxAgg );
+             assert( SQLITE_FUNC_ANYORDER==NC_OrderAgg );
+             testcase( (pDef->funcFlags & SQLITE_FUNC_MINMAX)!=0 );
+@@ -106995,6 +106997,7 @@
+ 
+     /* Recursively resolve names in all subqueries in the FROM clause
+     */
++    if( pOuterNC ) pOuterNC->nNestedSelect++;
+     for(i=0; i<p->pSrc->nSrc; i++){
+       SrcItem *pItem = &p->pSrc->a[i];
+       if( pItem->pSelect && (pItem->pSelect->selFlags & SF_Resolved)==0 ){
+@@ -107019,6 +107022,7 @@
+         }
+       }
+     }
++    if( pOuterNC ) pOuterNC->nNestedSelect--;
+ 
+     /* Set up the local name-context to pass to sqlite3ResolveExprNames() to
+     ** resolve the result-set expression list.
+diff --git a/amalgamation_dev/sqlite3.h b/amalgamation_dev/sqlite3.h
+index 7cbf759..cfaaf1d 100644
+--- a/amalgamation_dev/sqlite3.h
++++ b/amalgamation_dev/sqlite3.h
+@@ -148,7 +148,7 @@
+ */
+ #define SQLITE_VERSION        "3.43.2"
+ #define SQLITE_VERSION_NUMBER 3043002
+-#define SQLITE_SOURCE_ID      "2023-10-10 12:14:04 0880e9508d4389fd84d41506c9d2e3196802bad743f210d6710dd8447f0f9c35"
++#define SQLITE_SOURCE_ID      "2023-10-10 12:14:04 1671f2481b87df31f3882268bb63c1f87dbdfbc618c35ce078e50286cb060c11"
+ 
+ /*
+ ** CAPI3REF: Run-Time Library Version Numbers
+diff --git a/manifest b/manifest
+index f08242b..e9000cb 100644
+--- a/manifest
++++ b/manifest
+@@ -682,14 +682,14 @@
+ F src/prepare.c 80548297dc0e1fb3139cdebffb5a1bcac3dfac66d791012dd74838e70445072d
+ F src/printf.c 9da63b9ae1c14789bcae12840f5d800fd9302500cd2d62733fac77f0041b4750
+ F src/random.c 606b00941a1d7dd09c381d3279a058d771f406c5213c9932bbd93d5587be4b9c
+-F src/resolve.c 37953a5f36c60bea413c3c04efcd433b6177009f508ef2ace0494728912fe2e9
++F src/resolve.c 3448d354f3f875abb65f97f899a4a36434417624690ba145408636f61aa9bb5d
+ F src/rowset.c 8432130e6c344b3401a8874c3cb49fefe6873fec593294de077afea2dce5ec97
+ F src/select.c e9fb48546ab1882639a3a960383f6342dddb776c0227615f8e19de51f0102f68
+ F src/shell.c.in d381ea090c17db5d50049e6c06e9e175d8d712c7f9bc7a0b8a51616af44f060c
+ F src/sqlite.h.in 73a366c1c45d5ac9888cfe81c458826a44498531d106cfb4f328193ab5f6f17d
+ F src/sqlite3.rc 5121c9e10c3964d5755191c80dd1180c122fc3a8
+ F src/sqlite3ext.h 2f30b2671f4c03cd27a43f039e11251391066c97d11385f5f963bb40b03038ac
+-F src/sqliteInt.h 0a388da373e8134449d94e7a09da5680a32365c8f8e1edda43fff4b76d41edcb
++F src/sqliteInt.h 6352d84f0d0571b6a5906a702e2384cf1796bec155b796cb97bf5f4f70aa40d6
+ F src/sqliteLimit.h 33b1c9baba578d34efe7dfdb43193b366111cdf41476b1e82699e14c11ee1fb6
+ F src/status.c 160c445d7d28c984a0eae38c144f6419311ed3eace59b44ac6dafc20db4af749
+ F src/table.c 0f141b58a16de7e2fbe81c308379e7279f4c6b50eb08efeec5892794a0ba30d1
+@@ -779,7 +779,7 @@
+ F test/affinity3.test f094773025eddf31135c7ad4cde722b7696f8eb07b97511f98585addf2a510a9
+ F test/aggerror.test a867e273ef9e3d7919f03ef4f0e8c0d2767944f2
+ F test/aggfault.test 777f269d0da5b0c2524c7ff6d99ae9a93db4f1b1839a914dd2a12e3035c29829
+-F test/aggnested.test 7269d07ac879fce161cb26c8fabe65cba5715742fac8a1fccac570dcdaf28f00
++F test/aggnested.test e1977bdc0a154b99c139b879b78c46030aa6ee97fb06bf65d6784a536e25b743
+ F test/alias.test 4529fbc152f190268a15f9384a5651bbbabc9d87
+ F test/all.test 2ecb8bbd52416642e41c9081182a8df05d42c75637afd4488aace78cc4b69e13
+ F test/alter.test 313073774ab5c3f2ef1d3f0d03757c9d3a81284ae7e1b4a6ca34db088f886896
+@@ -1938,7 +1938,7 @@
+ F test/win32lock.test e0924eb8daac02bf80e9da88930747bd44dd9b230b7759fed927b1655b467c9c
+ F test/win32longpath.test 4baffc3acb2e5188a5e3a895b2b543ed09e62f7c72d713c1feebf76222fe9976
+ F test/win32nolock.test ac4f08811a562e45a5755e661f45ca85892bdbbc
+-F test/window1.test 1e7e13d36235b9a08fcb9790f2b05383f2f8c9538532b027f455766686926114
++F test/window1.test 8f8585432c71e2fc6c33994c8e7c808628429a5ae9856eb17d658d12f7fe3b94
+ F test/window2.tcl 492c125fa550cda1dd3555768a2303b3effbeceee215293adf8871efc25f1476
+ F test/window2.test e466a88bd626d66edc3d352d7d7e1d5531e0079b549ba44efb029d1fbff9fd3c
+ F test/window3.tcl acea6e86a4324a210fd608d06741010ca83ded9fde438341cb978c49928faf03
+diff --git a/src/resolve.c b/src/resolve.c
+index 7fc0151..2c56515 100644
+--- a/src/resolve.c
++++ b/src/resolve.c
+@@ -1212,11 +1212,12 @@
+           while( pNC2
+               && sqlite3ReferencesSrcList(pParse, pExpr, pNC2->pSrcList)==0
+           ){
+-            pExpr->op2++;
++            pExpr->op2 += (1 + pNC2->nNestedSelect);
+             pNC2 = pNC2->pNext;
+           }
+           assert( pDef!=0 || IN_RENAME_OBJECT );
+           if( pNC2 && pDef ){
++            pExpr->op2 += pNC2->nNestedSelect;
+             assert( SQLITE_FUNC_MINMAX==NC_MinMaxAgg );
+             assert( SQLITE_FUNC_ANYORDER==NC_OrderAgg );
+             testcase( (pDef->funcFlags & SQLITE_FUNC_MINMAX)!=0 );
+@@ -1777,6 +1778,7 @@
+  
+     /* Recursively resolve names in all subqueries in the FROM clause
+     */
++    if( pOuterNC ) pOuterNC->nNestedSelect++;
+     for(i=0; i<p->pSrc->nSrc; i++){
+       SrcItem *pItem = &p->pSrc->a[i];
+       if( pItem->pSelect && (pItem->pSelect->selFlags & SF_Resolved)==0 ){
+@@ -1801,6 +1803,7 @@
+         }
+       }
+     }
++    if( pOuterNC ) pOuterNC->nNestedSelect--;
+  
+     /* Set up the local name-context to pass to sqlite3ResolveExprNames() to
+     ** resolve the result-set expression list.
+diff --git a/src/sqliteInt.h b/src/sqliteInt.h
+index b0cdbc1..9145aa7 100644
+--- a/src/sqliteInt.h
++++ b/src/sqliteInt.h
+@@ -3362,6 +3362,7 @@
+   int nRef;            /* Number of names resolved by this context */
+   int nNcErr;          /* Number of errors encountered while resolving names */
+   int ncFlags;         /* Zero or more NC_* flags defined below */
++  int nNestedSelect;   /* Number of nested selects using this NC */
+   Select *pWinSelect;  /* SELECT statement for any window functions */
+ };
+ 
+diff --git a/test/aggnested.test b/test/aggnested.test
+index 1b8b608..4e74d75 100644
+--- a/test/aggnested.test
++++ b/test/aggnested.test
+@@ -358,6 +358,60 @@
+   FROM t2 GROUP BY 'constant_string';
+ } {{}}
+ 
++#-------------------------------------------------------------------------
++reset_db
++
++do_execsql_test 7.0 {
++  CREATE TABLE invoice (
++      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
++      amount DOUBLE PRECISION DEFAULT NULL,
++      name VARCHAR(100) DEFAULT NULL
++  );
++
++  INSERT INTO invoice (amount, name) VALUES 
++      (4.0, 'Michael'), (15.0, 'Bara'), (4.0, 'Michael'), (6.0, 'John');
++}
++
++do_execsql_test 7.1 {
++  SELECT sum(amount), name
++    from invoice
++  group by name
++  having (select v > 6 from (select sum(amount) v) t)
++} {
++  15.0 Bara
++  8.0 Michael
++}
++
++do_execsql_test 7.2 {
++  SELECT (select 1 from (select sum(amount))) FROM invoice
++} {1}
++
++do_execsql_test 8.0 {
++  CREATE TABLE t1(x INT);
++  INSERT INTO t1 VALUES(100);
++  INSERT INTO t1 VALUES(20);
++  INSERT INTO t1 VALUES(3);
++  SELECT (SELECT y FROM (SELECT sum(x) AS y) AS t2 ) FROM t1;
++} {123}
++
++do_execsql_test 8.1 {
++  SELECT (
++    SELECT y FROM (
++      SELECT z AS y FROM (SELECT sum(x) AS z) AS t2 
++    ) 
++  ) FROM t1;
++} {123}
++
++do_execsql_test 8.2 {
++  SELECT (
++    SELECT a FROM (
++      SELECT y AS a FROM (
++        SELECT z AS y FROM (SELECT sum(x) AS z) AS t2 
++      ) 
++    )
++  ) FROM t1;
++} {123}
++
+ 
+ 
+  
+diff --git a/test/window1.test b/test/window1.test
+index 37a5183..ea9acad 100644
+--- a/test/window1.test
++++ b/test/window1.test
+@@ -1881,7 +1881,7 @@
+     SELECT max(y) OVER( ORDER BY (SELECT x FROM (SELECT sum(y) AS x FROM t1)))
+   )
+   FROM t3;
+-} {1 {misuse of aggregate: sum()}}
++} {0 5}
+ 
+ # 2020-06-06 ticket 1f6f353b684fc708
+ reset_db


### PR DESCRIPTION
<details>
<summary>electron/security#446 - 5b2fddadaa12 from chromium</summary>
Clamp the input value correctly before scheduling an AudioParam event

When the AudioParam value is set via the setter, it internally calls
the setValueAtTime() function to schedule the change. However, the
current code does not correctly clamp the value within the nominal
range. This CL fixes the problem.

(cherry picked from commit c97b506c1e32951dd39e11e453e1ecc29cc0b35c)

Bug: 1505086
Test: Locally confirmed with both negative and positive param values.
Change-Id: Ibb0aae168161af9ea95c5e11a929b3aa2c621c73
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5100625
Reviewed-by: Michael Wilson <mjwilson@chromium.org>
Commit-Queue: Hongchan Choi <hongchan@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1235028}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5112838
Commit-Queue: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Auto-Submit: Hongchan Choi <hongchan@chromium.org>
Cr-Commit-Position: refs/branch-heads/6099@{#1497}
Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
</details>

<details>
<summary>electron/security#444 - cd9486849ba3 from sqlite</summary>
Fix a spurious "misuse of aggregate function" error that could occur when an aggregate function was used within the FROM clause of a sub-select of the select that owns the aggregate. e.g. "SELECT (SELECT x FROM (SELECT sum(t1.a) AS x)) FROM t1". [forum:/forumpost/c9970a37ed | Forum post c9970a37ed].

FossilOrigin-Name: 4470f657d2069972d02a00983252dec1f814d90c0d8d0906e320e955111e8c11
(cherry picked from commit 5e4233a9e48b124d4d342b757b34e4ae849f5cf8)

Bug: 1511689
Change-Id: I69263fc0a5fa66df5c09b964864568f2fc7a6ca5
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/deps/sqlite/+/5123910
Auto-Submit: Evan Stade <estade@chromium.org>
Commit-Queue: Ayu Ishii <ayui@chromium.org>
Reviewed-by: Ayu Ishii <ayui@chromium.org>
</details>

<details>
<summary>electron/security#445 - 50a1bddfca85 from chromium</summary>
Use cross thread handles to bind args for async webgpu context creation

(cherry picked from commit 542b278a0c1de7202f4bf5e3e5cbdc2dd6c337d4)

Fixed: 1506923
Change-Id: I174703cbd993471e3afb39c0cfa4cce2770755f7
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5113019
Reviewed-by: Corentin Wallez <cwallez@chromium.org>
Commit-Queue: Austin Eng <enga@chromium.org>
Reviewed-by: Stephen White <senorblanco@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1237179}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5133239
Cr-Commit-Position: refs/branch-heads/6099@{#1551}
Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
</details>

<details>
<summary>electron/security#447 - 0c1d249c3fe2 from angle</summary>
M120: Translator: Optimize field-name-collision check

As each field of the struct was encountered, its name was linearly
checked against previously added fields.  That's O(n^2).

The name collision check is now moved to when the struct is completely
defined, and is done with an unordered_map.

Bug: chromium:1505009
Change-Id: I3fbc23493e5a03e61b631af615cffaf9995fd566
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5143826
Reviewed-by: Cody Northrop <cnorthrop@google.com>
</details>

<details>
<summary>electron/security#448 - 01f439363dcb from angle</summary>
M120: Vulkan: Don't crash when glCopyTexImage2D redefines itself

The Vulkan backend marks a level being redefined as such before doing
the copy.  If a single-level texture was being redefined, it releases it
so it can be immediately reallocated.  If the source of the copy is the
same texture, this causes a crash.

This can be properly supported by using a temp image to do the copy, but
that is not implemented in this change.

Bug: chromium:1501798
Change-Id: I3a902b1e9eec41afd385d9c75a8c95dc986070a8
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5143829
Reviewed-by: Cody Northrop <cnorthrop@google.com>
</details>

Notes:
* Security: backported fix for CVE-2024-0224.
* Security: backported fix for 1511689.
* Security: backported fix for CVE-2024-0225.
* Security: backported fix for CVE-2024-0223.
* Security: backported fix for CVE-2024-0222.