### PR TITLE
docs: mouse-enter and mouse-leave events on tray doesn't support Wind…

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -187,7 +187,7 @@ Returns:
 
 Emitted when the mouse clicks the tray icon.
 
-#### Event: 'mouse-enter' _macOS_ _Windows_
+#### Event: 'mouse-enter' _macOS_
 
 Returns:
 
@@ -196,7 +196,7 @@ Returns:
 
 Emitted when the mouse enters the tray icon.
 
-#### Event: 'mouse-leave' _macOS_ _Windows_
+#### Event: 'mouse-leave' _macOS_
 
 Returns:
 


### PR DESCRIPTION
Ref https://github.com/electron/electron/issues/13559.

`mouse-enter` and `mouse-leave` events on tray doesn't support Windows.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
