### PR TITLE
refactor: migrate deprecated LazyInstance code to NoDestructor

### DIFF
--- a/shell/browser/window_list.h
+++ b/shell/browser/window_list.h
@@ -7,7 +7,6 @@
 
 #include <vector>
 
-#include "base/lazy_instance.h"
 #include "base/observer_list.h"
 
 namespace electron {
@@ -49,13 +48,12 @@ class WindowList {
   WindowList();
   ~WindowList();
 
-  // A vector of the windows in this list, in the order they were added.
-  WindowVector windows_;
-
   // A list of observers which will be notified of every window addition and
   // removal across all WindowLists.
-  static base::LazyInstance<base::ObserverList<WindowListObserver>>::Leaky
-      observers_;
+  [[nodiscard]] static base::ObserverList<WindowListObserver>& GetObservers();
+
+  // A vector of the windows in this list, in the order they were added.
+  WindowVector windows_;
 
   static WindowList* instance_;
 };


### PR DESCRIPTION
#### Description of Change

First in a pair of PRs to stop using the deprecated class `base::LazyInstance`. [Its header file instructs callers to use `base::NoDestructor` instead](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/base/lazy_instance.h#5), so that's what this PR does.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none