### PR TITLE
fix: InAppPurchase pre-emptive deallocation

### DIFF
--- a/shell/browser/mac/in_app_purchase.mm
+++ b/shell/browser/mac/in_app_purchase.mm
@@ -26,6 +26,7 @@
   in_app_purchase::InAppPurchaseCallback callback_;
   NSInteger quantity_;
   NSString* username_;
+  InAppPurchase __strong* self_;
 }
 
 - (id)initWithCallback:(in_app_purchase::InAppPurchaseCallback)callback
@@ -53,6 +54,7 @@
     callback_ = std::move(callback);
     quantity_ = quantity;
     username_ = [username copy];
+    self_ = self;
   }
 
   return self;
@@ -91,6 +93,7 @@
   // Return if the product is not found or invalid.
   if (product == nil) {
     [self runCallback:false];
+    self_ = nil;
     return;
   }
 
@@ -114,6 +117,7 @@
 
   // Notify that the payment has been added to the queue with success.
   [self runCallback:true];
+  self_ = nil;
 }
 
 /**
@@ -126,10 +130,6 @@
     content::GetUIThreadTaskRunner({})->PostTask(
         FROM_HERE, base::BindOnce(std::move(callback_), isProductValid));
   }
-}
-
-- (void)dealloc {
-  username_ = nil;
 }
 
 @end

--- a/shell/browser/mac/in_app_purchase_product.mm
+++ b/shell/browser/mac/in_app_purchase_product.mm
@@ -24,6 +24,7 @@
 @interface InAppPurchaseProduct : NSObject <SKProductsRequestDelegate> {
  @private
   in_app_purchase::InAppPurchaseProductsCallback callback_;
+  InAppPurchaseProduct __strong* self_;
 }
 
 - (id)initWithCallback:(in_app_purchase::InAppPurchaseProductsCallback)callback;
@@ -43,6 +44,7 @@
     (in_app_purchase::InAppPurchaseProductsCallback)callback {
   if ((self = [super init])) {
     callback_ = std::move(callback);
+    self_ = self;
   }
 
   return self;
@@ -81,6 +83,7 @@
   // Send the callback to the browser thread.
   content::GetUIThreadTaskRunner({})->PostTask(
       FROM_HERE, base::BindOnce(std::move(callback_), converted));
+  self_ = nil;
 }
 
 /**

--- a/spec/api-in-app-purchase-spec.ts
+++ b/spec/api-in-app-purchase-spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { inAppPurchase } from 'electron/main';
+import { ifdescribe } from './lib/spec-helpers';
 
 describe('inAppPurchase module', function () {
   if (process.platform !== 'darwin') return;
@@ -33,11 +34,9 @@ describe('inAppPurchase module', function () {
     expect(inAppPurchase.getReceiptURL()).to.match(/_MASReceipt\/receipt$/);
   });
 
-  // The following three tests are disabled because they hit Apple servers, and
-  // Apple started blocking requests from AWS IPs (we think), so they fail on CI.
-  // TODO: find a way to mock out the server requests so we can test these APIs
-  // without relying on a remote service.
-  xdescribe('handles product purchases', () => {
+  // This fails on x64 in CI - likely owing to some weirdness with the machines.
+  // We should look into fixing it there but at least run it on arm6 machines.
+  ifdescribe(process.arch !== 'x64')('handles product purchases', () => {
     it('purchaseProduct() fails when buying invalid product', async () => {
       const success = await inAppPurchase.purchaseProduct('non-exist');
       expect(success).to.be.false('failed to purchase non-existent product');


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/40851.
Refs https://github.com/electron/electron/pull/39304/commits/e6bbc74e485e3b76100aa6c46b59f6ead7ce4131.

When we migrated to ARC both the `InAppPurchase` and `InAppPurchaseProduct` objects became automatically managed. They were being created in static methods, and so went out of scope at the end of `in_app_purchase::PurchaseProduct` and `in_app_purchase::GetProducts` respectively where they were then immediately deallocated without their associated callbacks ever being called. These classes should be refactored more largely but for now maintaining a strong reference to themselves until they're no longer needed should address the immediate issue.

This was missed because our IAP tests were disabled - they seem to work again so i've re-enabled them in this PR as well.

Tested with https://gist.github.com/ccbaa4e5fc9039a2438e572404737018

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `inAppPurchase.getProducts` and `inAppPurchase.purchasedProduct` did not resolve as expected.