### PR TITLE
chore: fix content tracing flake

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1631,6 +1631,9 @@ commands:
               echo "Piping output to ASAN_SYMBOLIZE ($ASAN_SYMBOLIZE)"
               (cd electron && (circleci tests glob "spec/*-spec.ts" | xargs -I@ -P4 bash -c "echo $(pwd)/@" | circleci tests run --command="xargs node script/yarn test --runners=main --trace-uncaught --enable-logging --files" --split-by=timings 2>&1)) | $ASAN_SYMBOLIZE
             else
+              if [ "$TARGET_ARCH" == "arm" ] || [ "$TARGET_ARCH" == "arm64" ]; then
+                export ELECTRON_SKIP_NATIVE_MODULE_TESTS=true
+              fi
               if [ "$TARGET_ARCH" == "ia32" ]; then
                 npm_config_arch=x64 node electron/node_modules/dugite/script/download-git.js
               fi

--- a/spec/api-content-tracing-spec.ts
+++ b/spec/api-content-tracing-spec.ts
@@ -73,7 +73,7 @@ ifdescribe(!(['arm', 'arm64'].includes(process.arch)) || (process.platform !== '
       // If the `categoryFilter` param above is not respected
       // the file size will be above 50KB.
       const fileSizeInKiloBytes = getFileSizeInKiloBytes(outputFilePath);
-      const expectedMaximumFileSize = 10; // Depends on a platform.
+      const expectedMaximumFileSize = 50; // Depends on a platform.
 
       expect(fileSizeInKiloBytes).to.be.above(0,
         `the trace output file is empty, check "${outputFilePath}"`);


### PR DESCRIPTION
The code comment above indicates 50kb should be the limit, I ran some historical CI and it looks like we were around ~9.8 before and now we're barely over 10.  Instead of being on the edge let's just move the boundary to where it doesn't flake but still would fail when appropriate

Notes: none