### PR TITLE
refactor: use base::NoDestructor instead of base::LazyInstance

### DIFF
--- a/patches/chromium/feat_add_support_for_overriding_the_base_spellchecker_download_url.patch
+++ b/patches/chromium/feat_add_support_for_overriding_the_base_spellchecker_download_url.patch
@@ -9,15 +9,22 @@ production use cases.  This is unlikely to be upstreamed as the change
 is entirely in //chrome.
 
 diff --git a/chrome/browser/spellchecker/spellcheck_hunspell_dictionary.cc b/chrome/browser/spellchecker/spellcheck_hunspell_dictionary.cc
-index 48b7a20c212578ba9055b781b5c05b312fa7e974..3ae8136e5c938be80df141f7ca582d974fb08eed 100644
+index 48b7a20c212578ba9055b781b5c05b312fa7e974..d7d92f326ba94be7a3960d527bc2b6d8d15890fa 100644
 --- a/chrome/browser/spellchecker/spellcheck_hunspell_dictionary.cc
 +++ b/chrome/browser/spellchecker/spellcheck_hunspell_dictionary.cc
-@@ -49,6 +49,9 @@ namespace {
+@@ -13,6 +13,7 @@
+ #include "base/functional/bind.h"
+ #include "base/lazy_instance.h"
+ #include "base/location.h"
++#include "base/no_destructor.h"
+ #include "base/notreached.h"
+ #include "base/observer_list.h"
+ #include "base/path_service.h"
+@@ -49,6 +50,8 @@ namespace {
  base::LazyInstance<GURL>::Leaky g_download_url_for_testing =
      LAZY_INSTANCE_INITIALIZER;
  
-+base::LazyInstance<GURL>::Leaky g_base_download_url_override =
-+    LAZY_INSTANCE_INITIALIZER;
++base::NoDestructor<GURL> g_base_download_url_override;
 +
  // Close the file.
  void CloseDictionary(base::File file) {
@@ -27,7 +34,7 @@ index 48b7a20c212578ba9055b781b5c05b312fa7e974..3ae8136e5c938be80df141f7ca582d97
  }
  
 +void SpellcheckHunspellDictionary::SetBaseDownloadURL(const GURL url) {
-+  g_base_download_url_override.Get() = url;
++  *g_base_download_url_override = url;
 +}
 +
  GURL SpellcheckHunspellDictionary::GetDictionaryURL() {
@@ -37,8 +44,8 @@ index 48b7a20c212578ba9055b781b5c05b312fa7e974..3ae8136e5c938be80df141f7ca582d97
    std::string bdict_file = dictionary_file_.path.BaseName().MaybeAsASCII();
    DCHECK(!bdict_file.empty());
  
-+  if (g_base_download_url_override.Get() != GURL())
-+    return GURL(g_base_download_url_override.Get().spec() + base::ToLowerASCII(bdict_file));
++  if (*g_base_download_url_override != GURL())
++    return GURL(g_base_download_url_override->spec() + base::ToLowerASCII(bdict_file));
 +
    static const char kDownloadServerUrl[] =
        "https://redirector.gvt1.com/edgedl/chrome/dict/";

--- a/shell/browser/extensions/api/extension_action/extension_action_api.cc
+++ b/shell/browser/extensions/api/extension_action/extension_action_api.cc
@@ -11,6 +11,7 @@
 
 #include "base/functional/bind.h"
 #include "base/lazy_instance.h"
+#include "base/no_destructor.h"
 #include "base/observer_list.h"
 #include "extensions/browser/event_router.h"
 #include "extensions/browser/extension_prefs.h"
@@ -38,9 +39,6 @@ ExtensionActionAPI::Observer::~Observer() {}
 // ExtensionActionAPI
 //
 
-static base::LazyInstance<BrowserContextKeyedAPIFactory<ExtensionActionAPI>>::
-    DestructorAtExit g_extension_action_api_factory = LAZY_INSTANCE_INITIALIZER;
-
 ExtensionActionAPI::ExtensionActionAPI(content::BrowserContext* context)
     : browser_context_(context), extension_prefs_(nullptr) {}
 
@@ -49,7 +47,9 @@ ExtensionActionAPI::~ExtensionActionAPI() {}
 // static
 BrowserContextKeyedAPIFactory<ExtensionActionAPI>*
 ExtensionActionAPI::GetFactoryInstance() {
-  return g_extension_action_api_factory.Pointer();
+  static base::NoDestructor<BrowserContextKeyedAPIFactory<ExtensionActionAPI>>
+      instance;
+  return instance.get();
 }
 
 // static

--- a/shell/browser/extensions/api/extension_action/extension_action_api.cc
+++ b/shell/browser/extensions/api/extension_action/extension_action_api.cc
@@ -10,7 +10,6 @@
 #include <utility>
 
 #include "base/functional/bind.h"
-#include "base/lazy_instance.h"
 #include "base/no_destructor.h"
 #include "base/observer_list.h"
 #include "extensions/browser/event_router.h"

--- a/shell/browser/extensions/electron_extension_host_delegate.cc
+++ b/shell/browser/extensions/electron_extension_host_delegate.cc
@@ -8,7 +8,6 @@
 #include <string>
 #include <utility>
 
-#include "base/lazy_instance.h"
 #include "base/logging.h"
 #include "extensions/browser/media_capture_util.h"
 #include "shell/browser/api/electron_api_web_contents.h"

--- a/shell/common/asar/asar_util.cc
+++ b/shell/common/asar/asar_util.cc
@@ -10,7 +10,6 @@
 
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
-#include "base/lazy_instance.h"
 #include "base/logging.h"
 #include "base/no_destructor.h"
 #include "base/stl_util.h"

--- a/shell/common/extensions/electron_extensions_client.cc
+++ b/shell/common/extensions/electron_extensions_client.cc
@@ -7,8 +7,8 @@
 #include <memory>
 #include <string>
 
-#include "base/lazy_instance.h"
 #include "base/logging.h"
+#include "base/no_destructor.h"
 #include "components/version_info/version_info.h"
 #include "content/public/common/user_agent.h"
 #include "extensions/common/core_extensions_api_provider.h"
@@ -60,9 +60,6 @@ class ElectronPermissionMessageProvider
   }
 };
 
-base::LazyInstance<ElectronPermissionMessageProvider>::DestructorAtExit
-    g_permission_message_provider = LAZY_INSTANCE_INITIALIZER;
-
 }  // namespace
 
 ElectronExtensionsClient::ElectronExtensionsClient()
@@ -85,7 +82,9 @@ void ElectronExtensionsClient::InitializeWebStoreUrls(
 const extensions::PermissionMessageProvider&
 ElectronExtensionsClient::GetPermissionMessageProvider() const {
   NOTIMPLEMENTED();
-  return g_permission_message_provider.Get();
+
+  base::NoDestructor<ElectronPermissionMessageProvider> instance;
+  return *instance;
 }
 
 const std::string ElectronExtensionsClient::GetProductName() {

--- a/shell/common/extensions/electron_extensions_client.cc
+++ b/shell/common/extensions/electron_extensions_client.cc
@@ -83,7 +83,7 @@ const extensions::PermissionMessageProvider&
 ElectronExtensionsClient::GetPermissionMessageProvider() const {
   NOTIMPLEMENTED();
 
-  base::NoDestructor<ElectronPermissionMessageProvider> instance;
+  static base::NoDestructor<ElectronPermissionMessageProvider> instance;
   return *instance;
 }
 


### PR DESCRIPTION
#### Description of Change

Second of a pair of PRs to stop using the deprecated class `base::LazyInstance`.  Its documentation says to use `base::NoDestructor` instead, so that's what this PR does.

Any reviews welcomed. CC @codebytere and @miniak, who reviewed the previous #40927.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none