### PR TITLE
ci: increase "gclient sync" output timeout

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -289,6 +289,7 @@ step-depot-tools-add-to-path: &step-depot-tools-add-to-path
 step-gclient-sync: &step-gclient-sync
   run:
     name: Gclient sync
+    no_output_timeout: 30m
     command: |
       # If we did not restore a complete sync then we need to sync for realz
       if [ ! -s "src/electron/.circle-sync-done" ]; then


### PR DESCRIPTION
#### Description of Change

#40953 removed the git cache from the gclient sync step, which may be causing release builds to timeout. Rather than adding it back it, let's increase the gclient sync step output timeout limit to allow a new cache (minus git cache) to be built. Then we can compare the total build numbers and see what the differences are.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
