### PR TITLE
build: log got error response bodies

### DIFF
--- a/script/prepare-appveyor.js
+++ b/script/prepare-appveyor.js
@@ -70,7 +70,14 @@ async function checkAppVeyorImage (options) {
     const { cloudSettings } = settings;
     return cloudSettings.images.find(image => image.name === `${options.imageVersion}`) || null;
   } catch (err) {
-    console.log('Could not call AppVeyor: ', err);
+    if (err.response?.body) {
+      console.error('Could not call AppVeyor: ', {
+        statusCode: err.response.statusCode,
+        body: JSON.parse(err.response.body)
+      });
+    } else {
+      console.error('Error calling AppVeyor:', err);
+    }
   }
 }
 

--- a/script/release/ci-release-build.js
+++ b/script/release/ci-release-build.js
@@ -183,7 +183,14 @@ async function circleCIRequest (url, method, requestBody) {
   }
 
   return makeRequest(requestOpts, true).catch(err => {
-    console.log('Error calling CircleCI:', err);
+    if (err.response?.body) {
+      console.error('Could not call CircleCI: ', {
+        statusCode: err.response.statusCode,
+        body: JSON.parse(err.response.body)
+      });
+    } else {
+      console.error('Error calling CircleCI:', err);
+    }
   });
 }
 
@@ -234,7 +241,14 @@ async function callAppVeyor (targetBranch, job, options) {
     const buildUrl = `https://ci.appveyor.com/project/electron-bot/${appVeyorJobs[job]}/build/${version}`;
     console.log(`AppVeyor release build request for ${job} successful.  Check build status at ${buildUrl}`);
   } catch (err) {
-    console.log('Could not call AppVeyor: ', err);
+    if (err.response?.body) {
+      console.error('Could not call AppVeyor: ', {
+        statusCode: err.response.statusCode,
+        body: JSON.parse(err.response.body)
+      });
+    } else {
+      console.error('Error calling AppVeyor:', err);
+    }
   }
 }
 

--- a/script/release/get-url-hash.js
+++ b/script/release/get-url-hash.js
@@ -22,7 +22,14 @@ module.exports = async function getUrlHash (targetUrl, algorithm = 'sha256', att
     return resp.body.trim();
   } catch (err) {
     if (attempts > 1) {
-      console.error('Failed to get URL hash for', targetUrl, 'we will retry', err);
+      if (err.response?.body) {
+        console.error(`Failed to get URL hash for ${targetUrl} - we will retry`, {
+          statusCode: err.response.statusCode,
+          body: JSON.parse(err.response.body)
+        });
+      } else {
+        console.error(`Failed to get URL hash for ${targetUrl} - we will retry`, err);
+      }
       return getUrlHash(targetUrl, algorithm, attempts - 1);
     }
     throw err;


### PR DESCRIPTION
#### Description of Change

`got` error response bodies are optional and not logged by default. When we trigger CI builds, we want to see them if they fail. This fixes that.

Locally, using a bad token:

```console
electron on git:main ❯ node script/release/ci-release-build.js main                         9:47PM
Triggering AppVeyor to run build job: electron-x64 on branch: main with release flag.
Triggering AppVeyor to run build job: electron-ia32 on branch: main with release flag.
Triggering AppVeyor to run build job: electron-woa on branch: main with release flag.
3 jobs were requested.
Could not call AppVeyor:  { statusCode: 401, body: { message: 'Authorization required' } }
Could not call AppVeyor:  { statusCode: 401, body: { message: 'Authorization required' } }
Could not call AppVeyor:  { statusCode: 401, body: { message: 'Authorization required' } }
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
