### PR TITLE
refactor: remove deprecated ToInternalValue()

### DIFF
--- a/shell/browser/extensions/electron_extension_loader.cc
+++ b/shell/browser/extensions/electron_extension_loader.cc
@@ -150,8 +150,9 @@ void ElectronExtensionLoader::FinishExtensionLoad(
           extensions::pref_names::kPrefPreferences);
 
       auto preference = update.Create();
-      const int64_t us = base::Time::Now().since_origin().InMicroseconds();
-      preference->SetString("install_time", base::NumberToString(us));
+      const int64_t now_usec =
+          base::Time::Now().since_origin().InMicroseconds();
+      preference->SetString("install_time", base::NumberToString(now_usec));
     }
   }
 

--- a/shell/browser/extensions/electron_extension_loader.cc
+++ b/shell/browser/extensions/electron_extension_loader.cc
@@ -148,10 +148,10 @@ void ElectronExtensionLoader::FinishExtensionLoad(
       ExtensionPrefs::ScopedDictionaryUpdate update(
           extension_prefs, extension.get()->id(),
           extensions::pref_names::kPrefPreferences);
+
       auto preference = update.Create();
-      const base::Time install_time = base::Time::Now();
-      preference->SetString(
-          "install_time", base::NumberToString(install_time.ToInternalValue()));
+      const int64_t us = base::Time::Now().since_origin().InMicroseconds();
+      preference->SetString("install_time", base::NumberToString(us));
     }
   }
 

--- a/shell/browser/notifications/win/notification_presenter_win.cc
+++ b/shell/browser/notifications/win/notification_presenter_win.cc
@@ -76,8 +76,8 @@ std::wstring NotificationPresenterWin::SaveIconToFilesystem(
   if (origin.is_valid()) {
     filename = base::MD5String(origin.spec()) + ".png";
   } else {
-    const int64_t us = base::Time::Now().since_origin().InMicroseconds();
-    filename = base::NumberToString(us) + ".png";
+    const int64_t now_usec = base::Time::Now().since_origin().InMicroseconds();
+    filename = base::NumberToString(now_usec) + ".png";
   }
 
   ScopedAllowBlockingForElectron allow_blocking;

--- a/shell/browser/notifications/win/notification_presenter_win.cc
+++ b/shell/browser/notifications/win/notification_presenter_win.cc
@@ -14,6 +14,7 @@
 #include "base/files/file_util.h"
 #include "base/hash/md5.h"
 #include "base/logging.h"
+#include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
 #include "base/win/windows_version.h"
@@ -75,8 +76,8 @@ std::wstring NotificationPresenterWin::SaveIconToFilesystem(
   if (origin.is_valid()) {
     filename = base::MD5String(origin.spec()) + ".png";
   } else {
-    base::TimeTicks now = base::TimeTicks::Now();
-    filename = std::to_string(now.ToInternalValue()) + ".png";
+    const int64_t us = base::Time::Now().since_origin().InMicroseconds();
+    filename = base::NumberToString(us) + ".png";
   }
 
   ScopedAllowBlockingForElectron allow_blocking;


### PR DESCRIPTION
#### Description of Change

In the base::Time* classes, `ToInternalValue()` is deprecated / not to be used in new code.  This PR updates the two cases where Electron was using that API.

Xref: https://bugs.chromium.org/p/chromium/issues/detail?id=634507

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.