### PR TITLE
fix: use `HasStyleMask(NSWindowStyleMaskResizable)` instead of `IsResizable()` for enabling/disabling window maximize button

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -916,7 +916,7 @@ bool NativeWindowMac::IsMaximizable() const {
 
 void NativeWindowMac::UpdateZoomButton() {
   [[window_ standardWindowButton:NSWindowZoomButton]
-      setEnabled:IsResizable() && (CanMaximize() || IsFullScreenable())];
+      setEnabled:HasStyleMask(NSWindowStyleMaskResizable) && (CanMaximize() || IsFullScreenable())];
 }
 
 void NativeWindowMac::SetFullScreenable(bool fullscreenable) {

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -916,7 +916,8 @@ bool NativeWindowMac::IsMaximizable() const {
 
 void NativeWindowMac::UpdateZoomButton() {
   [[window_ standardWindowButton:NSWindowZoomButton]
-      setEnabled:HasStyleMask(NSWindowStyleMaskResizable) && (CanMaximize() || IsFullScreenable())];
+      setEnabled:HasStyleMask(NSWindowStyleMaskResizable) &&
+                 (CanMaximize() || IsFullScreenable())];
 }
 
 void NativeWindowMac::SetFullScreenable(bool fullscreenable) {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/41023.

[The previous maximize button fix](https://github.com/electron/electron/pull/40705/files) had a [bug](https://github.com/electron/electron/pull/40705#issuecomment-1888106669) where the green button was disabled if the window got maximized. I incorrectly assumed that `SetResizable()` and `IsResizable()` were symmetric, but alas they're not:

```
bool NativeWindowMac::IsResizable() const {
  bool in_fs_transition =
      fullscreen_transition_state() != FullScreenTransitionState::kNone;
  bool has_rs_mask = HasStyleMask(NSWindowStyleMaskResizable);
  return has_rs_mask && !IsFullscreen() && !in_fs_transition;
}
```

The fix is to replace `IsResizable()` with `HasStyleMask(NSWindowStyleMaskResizable)` in `UpdateZoomButton()`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: fix macOS bug that causes window maximize button to be disabled in full-screen mode
