### PR TITLE
fix: crash when `dialog.showMessageBoxSync` with missing buttons

### DIFF
--- a/shell/browser/ui/message_box_mac.mm
+++ b/shell/browser/ui/message_box_mac.mm
@@ -76,14 +76,14 @@ NSAlert* CreateNSAlert(const MessageBoxSettings& settings) {
     [[ns_buttons objectAtIndex:settings.default_id] setKeyEquivalent:@"\r"];
   }
 
-  if (button_count > 1) {
+  if (button_count > 1 && settings.cancel_id >= 0) {
     // Bind cancel id button to escape key if there is more than one button.
-    if (settings.cancel_id >= 0 && settings.cancel_id < button_count) {
+    if (settings.cancel_id < button_count) {
       [[ns_buttons objectAtIndex:settings.cancel_id] setKeyEquivalent:@"\e"];
     }
 
     // TODO(@codebytere): This behavior violates HIG & should be deprecated.
-    if (settings.cancel_id >= 0 && settings.cancel_id == settings.default_id) {
+    if (settings.cancel_id == settings.default_id) {
       [[ns_buttons objectAtIndex:settings.default_id] highlight:YES];
     }
   }

--- a/shell/browser/ui/message_box_mac.mm
+++ b/shell/browser/ui/message_box_mac.mm
@@ -76,15 +76,16 @@ NSAlert* CreateNSAlert(const MessageBoxSettings& settings) {
     [[ns_buttons objectAtIndex:settings.default_id] setKeyEquivalent:@"\r"];
   }
 
-  // Bind cancel id button to escape key if there is more than one button
-  if (button_count > 1 && settings.cancel_id >= 0 &&
-      settings.cancel_id < button_count) {
-    [[ns_buttons objectAtIndex:settings.cancel_id] setKeyEquivalent:@"\e"];
-  }
+  if (button_count > 1) {
+    // Bind cancel id button to escape key if there is more than one button.
+    if (settings.cancel_id >= 0 && settings.cancel_id < button_count) {
+      [[ns_buttons objectAtIndex:settings.cancel_id] setKeyEquivalent:@"\e"];
+    }
 
-  // TODO(@codebytere): This behavior violates HIG & should be deprecated.
-  if (settings.cancel_id >= 0 && settings.cancel_id == settings.default_id) {
-    [[ns_buttons objectAtIndex:settings.default_id] highlight:YES];
+    // TODO(@codebytere): This behavior violates HIG & should be deprecated.
+    if (settings.cancel_id >= 0 && settings.cancel_id == settings.default_id) {
+      [[ns_buttons objectAtIndex:settings.default_id] highlight:YES];
+    }
   }
 
   if (!settings.checkbox_label.empty()) {

--- a/spec/api-dialog-spec.ts
+++ b/spec/api-dialog-spec.ts
@@ -146,6 +146,22 @@ describe('dialog module', () => {
       expect(result.response).to.equal(0);
     });
 
+    it('does not crash when there is a defaultId but no buttons', async () => {
+      const controller = new AbortController();
+      const signal = controller.signal;
+      const w = new BrowserWindow();
+      const p = dialog.showMessageBox(w, {
+        signal,
+        message: 'i am message',
+        type: 'info',
+        defaultId: 0,
+        title: 'i am title'
+      });
+      controller.abort();
+      const result = await p;
+      expect(result.response).to.equal(0);
+    });
+
     it('cancels message box', async () => {
       const controller = new AbortController();
       const signal = controller.signal;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/40676.

Fixes a potential crash when calling `dialog.showMessageBoxSync`, setting a `defaultId`, and not passing a `buttons` array. This was happening because `objectAtIndex` was being called on an empty array which causes an `NSRangeException`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes a potential crash when calling `dialog.showMessageBoxSync`.