### PR TITLE
ci: correctly export RBE_experimental_credentials_helper_args

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -357,6 +357,7 @@ step-setup-rbe-for-build: &step-setup-rbe-for-build
       $HELPER login
       echo 'export RBE_service='`node -e "console.log(require('./src/utils/reclient.js').serviceAddress)"` >> $BASH_ENV
       echo 'export RBE_experimental_credentials_helper='`node -e "console.log(require('./src/utils/reclient.js').helperPath)"` >> $BASH_ENV
+      echo 'export RBE_experimental_credentials_helper_args="print"' >> $BASH_ENV
 
 step-restore-brew-cache: &step-restore-brew-cache
   restore_cache:

--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -113,6 +113,8 @@ for:
           $env:RBE_service = node -e "console.log(require('./src/utils/reclient.js').serviceAddress)"
       - ps: >-
           $env:RBE_experimental_credentials_helper = $env:RECLIENT_HELPER
+      - ps: >-
+          $env:RBE_experimental_credentials_helper_args = "print"
       - cd ..\..
       - ps: $env:CHROMIUM_BUILDTOOLS_PATH="$pwd\src\buildtools"
       - ps: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -111,6 +111,8 @@ for:
           $env:RBE_service = node -e "console.log(require('./src/utils/reclient.js').serviceAddress)"
       - ps: >-
           $env:RBE_experimental_credentials_helper = $env:RECLIENT_HELPER
+      - ps: >-
+          $env:RBE_experimental_credentials_helper_args = "print"
       - cd ..\..
       - ps: $env:CHROMIUM_BUILDTOOLS_PATH="$pwd\src\buildtools"
       - ps: >-


### PR DESCRIPTION
#### Description of Change

Ref https://github.com/electron/rbe-credential-helper/pull/7
Ref https://github.com/electron/build-tools/pull/542

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.