### PR TITLE
fix: modal rounding on nonmodal windows

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1401,15 +1401,15 @@ void NativeWindowMac::UpdateVibrancyRadii(bool fullscreen) {
   if (vibrantView != nil && !vibrancy_type_.empty()) {
     const bool no_rounded_corner = !HasStyleMask(NSWindowStyleMaskTitled);
     const int macos_version = base::mac::MacOSMajorVersion();
+    const bool modal = is_modal();
 
     // If the window is modal, its corners are rounded on macOS >= 11 or higher
     // unless the user has explicitly passed noRoundedCorners.
     bool should_round_modal =
-        is_modal() ? (macos_version >= 11 && !no_rounded_corner) : false;
+        !no_rounded_corner && macos_version >= 11 && modal;
     // If the window is nonmodal, its corners are rounded if it is frameless and
     // the user hasn't passed noRoundedCorners.
-    bool should_round_nonmodal =
-        !is_modal() && !has_frame() && !no_rounded_corner;
+    bool should_round_nonmodal = !no_rounded_corner && !modal && !has_frame();
 
     if (should_round_nonmodal || should_round_modal) {
       CGFloat radius;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1402,13 +1402,14 @@ void NativeWindowMac::UpdateVibrancyRadii(bool fullscreen) {
     const bool no_rounded_corner = !HasStyleMask(NSWindowStyleMaskTitled);
     const int macos_version = base::mac::MacOSMajorVersion();
 
-    // Modal window corners are rounded on macOS >= 11 or higher if the user
-    // hasn't passed noRoundedCorners.
+    // If the window is modal, its corners are rounded on macOS >= 11 or higher
+    // unless the user has explicitly passed noRoundedCorners.
     bool should_round_modal =
-        !no_rounded_corner && (macos_version >= 11 ? true : !is_modal());
-    // Nonmodal window corners are rounded if they're frameless and the user
-    // hasn't passed noRoundedCorners.
-    bool should_round_nonmodal = !no_rounded_corner && !has_frame();
+        is_modal() ? (macos_version >= 11 && !no_rounded_corner) : false;
+    // If the window is nonmodal, its corners are rounded if it is frameless and
+    // the user hasn't passed noRoundedCorners.
+    bool should_round_nonmodal =
+        !is_modal() && !has_frame() && !no_rounded_corner;
 
     if (should_round_nonmodal || should_round_modal) {
       CGFloat radius;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/40800.

Fixes an issue where non-modal windows with vibrancy could have incorrectly rounded corners on Sonoma. This happened as a result of the following logic:

```c+
bool should_round_modal =
        !no_rounded_corner && (macos_version >= 11 ? true : !is_modal());
```

Which would incorrectly be `true` in this case.

Tested with https://gist.github.com/977c2ba87b683011bf1e093f6dd06d2f

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where non-modal windows with vibrancy could have incorrectly rounded corners on Sonoma.
