### PR TITLE
feat: add BrowserWindow.isHidden()

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -519,7 +519,11 @@ Hides the window.
 
 #### `win.isVisible()`
 
-Returns `boolean` - Whether the window is visible to the user.
+Returns `boolean` - Whether the window is visible to the user in the foreground of the app.
+
+#### `win.isHidden()`
+
+Returns `boolean` - Whether the window is hidden—it exists, but is inaccessible to the user.
 
 #### `win.isModal()`
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -648,6 +648,10 @@ Hides the window.
 
 Returns `boolean` - Whether the window is visible to the user in the foreground of the app.
 
+#### `win.isHidden()`
+
+Returns `boolean` - Whether the window is hidden—it exists, but is inaccessible to the user.
+
 #### `win.isModal()`
 
 Returns `boolean` - Whether current window is a modal window.

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -355,6 +355,10 @@ bool BaseWindow::IsVisible() const {
   return window_->IsVisible();
 }
 
+bool BaseWindow::IsHidden() const {
+  return window_->IsHidden();
+}
+
 bool BaseWindow::IsEnabled() const {
   return window_->IsEnabled();
 }
@@ -1086,6 +1090,7 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("showInactive", &BaseWindow::ShowInactive)
       .SetMethod("hide", &BaseWindow::Hide)
       .SetMethod("isVisible", &BaseWindow::IsVisible)
+      .SetMethod("isHidden", &BaseWindow::IsHidden)
       .SetMethod("isEnabled", &BaseWindow::IsEnabled)
       .SetMethod("setEnabled", &BaseWindow::SetEnabled)
       .SetMethod("maximize", &BaseWindow::Maximize)

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -98,6 +98,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void ShowInactive();
   void Hide();
   bool IsVisible() const;
+  bool IsHidden() const;
   bool IsEnabled() const;
   void SetEnabled(bool enable);
   void Maximize();

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -88,6 +88,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void ShowInactive() = 0;
   virtual void Hide() = 0;
   virtual bool IsVisible() const = 0;
+  virtual bool IsHidden() const = 0;
   virtual bool IsEnabled() const = 0;
   virtual void SetEnabled(bool enable) = 0;
   virtual void Maximize() = 0;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -45,6 +45,7 @@ class NativeWindowMac : public NativeWindow,
   void ShowInactive() override;
   void Hide() override;
   bool IsVisible() const override;
+  bool IsHidden() const override;
   bool IsEnabled() const override;
   void SetEnabled(bool enable) override;
   void Maximize() override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -566,6 +566,10 @@ bool NativeWindowMac::IsVisible() const {
   return [window_ isVisible] && !occluded && !IsMinimized();
 }
 
+bool NativeWindowMac::IsHidden() const {
+  return ![window_ isVisible];
+}
+
 bool NativeWindowMac::IsEnabled() const {
   return [window_ attachedSheet] == nil;
 }

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -569,10 +569,23 @@ bool NativeWindowViews::IsVisible() const {
   // current window.
   bool visible =
       ::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE) & WS_VISIBLE;
-  // WS_VISIBLE is true even if a window is miminized - explicitly check that.
+  // WS_VISIBLE is true even if a window is minimized - explicitly check that.
   return visible && !IsMinimized();
 #else
   return widget()->IsVisible();
+#endif
+}
+
+bool NativeWindowViews::IsHidden() const {
+#if BUILDFLAG(IS_WIN)
+  // widget()->IsVisible() calls ::IsWindowVisible, which returns non-zero if a
+  // window or any of its parent windows are visible. We want to only check the
+  // current window.
+  bool visible =
+      ::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE) & WS_VISIBLE;
+  return !visible;
+#else
+  return !widget()->IsVisible();
 #endif
 }
 

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -55,6 +55,7 @@ class NativeWindowViews : public NativeWindow,
   void ShowInactive() override;
   void Hide() override;
   bool IsVisible() const override;
+  bool IsHidden() const override;
   bool IsEnabled() const override;
   void SetEnabled(bool enable) override;
   void Maximize() override;

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1081,12 +1081,14 @@ describe('BrowserWindow module', () => {
         w.show();
         await p;
         expect(w.isVisible()).to.equal(true);
+        expect(w.isHidden()).to.equal(false);
       });
       it('emits when window is shown', async () => {
         const show = once(w, 'show');
         w.show();
         await show;
         expect(w.isVisible()).to.equal(true);
+        expect(w.isHidden()).to.equal(false);
       });
     });
 
@@ -1099,6 +1101,7 @@ describe('BrowserWindow module', () => {
         w.show();
         w.hide();
         expect(w.isVisible()).to.equal(false);
+        expect(w.isHidden()).to.equal(true);
       });
       it('emits when window is hidden', async () => {
         const shown = once(w, 'show');
@@ -1108,6 +1111,7 @@ describe('BrowserWindow module', () => {
         w.hide();
         await hidden;
         expect(w.isVisible()).to.equal(false);
+        expect(w.isHidden()).to.equal(true);
       });
     });
 
@@ -1120,6 +1124,7 @@ describe('BrowserWindow module', () => {
 
         expect(w.isMinimized()).to.equal(true);
         expect(w.isVisible()).to.equal(false);
+        expect(w.isHidden()).to.equal(false);
       });
     });
 
@@ -1177,8 +1182,10 @@ describe('BrowserWindow module', () => {
     describe('BrowserWindow.focus()', () => {
       it('does not make the window become visible', () => {
         expect(w.isVisible()).to.equal(false);
+        expect(w.isHidden()).to.equal(true);
         w.focus();
         expect(w.isVisible()).to.equal(false);
+        expect(w.isHidden()).to.equal(true);
       });
 
       ifit(process.platform !== 'win32')('focuses a blurred window', async () => {


### PR DESCRIPTION
#### Description of Change

Following the change to `BrowserWindow.isVisible()` in https://github.com/electron/electron/pull/38242 , it's no longer possible to determine if a window is hidden (not just minimized) on Windows.

On Mac, this was addressed in https://github.com/electron/electron/issues/30485 by adding [app.isHidden()](https://github.com/electron/electron/pull/32155).

I'm proposing adding `BrowserWindow.isHidden()` to provide a cross-platform solution to determine if a window is hidden.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `BrowserWindow.isHidden()`
