### PR TITLE
chore: cherry-pick 3 changes from Release-5-M120

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -147,3 +147,4 @@ cherry-pick-4ca62c7a8b88.patch
 cherry-pick-5b2fddadaa12.patch
 cherry-pick-50a1bddfca85.patch
 reland_mojom_ts_generator_handle_empty_module_path_identically_to.patch
+cherry-pick-c1cda70a433a.patch

--- a/patches/chromium/cherry-pick-c1cda70a433a.patch
+++ b/patches/chromium/cherry-pick-c1cda70a433a.patch
@@ -1,0 +1,31 @@
+From c1cda70a433a0c625b280eb88ed6ff4f4feffa12 Mon Sep 17 00:00:00 2001
+From: Mike Wasserman <msw@chromium.org>
+Date: Thu, 21 Dec 2023 22:33:05 +0000
+Subject: [PATCH] Speculative fix for UAF in content::WebContentsImpl::ExitFullscreenMode
+
+Bug: 1506535, 854815
+Change-Id: Iace64d63f8cea2dbfbc761ad233db42451ec101c
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5146875
+Commit-Queue: John Abd-El-Malek <jam@chromium.org>
+Auto-Submit: Mike Wasserman <msw@chromium.org>
+Reviewed-by: John Abd-El-Malek <jam@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1240353}
+---
+
+diff --git a/content/browser/web_contents/web_contents_impl.cc b/content/browser/web_contents/web_contents_impl.cc
+index 97f45e33..d425d19 100644
+--- a/content/browser/web_contents/web_contents_impl.cc
++++ b/content/browser/web_contents/web_contents_impl.cc
+@@ -3879,7 +3879,12 @@
+   }
+ 
+   if (delegate_) {
++    // This may spin the message loop and destroy this object crbug.com/1506535
++    base::WeakPtr<WebContentsImpl> weak_ptr = weak_factory_.GetWeakPtr();
+     delegate_->ExitFullscreenModeForTab(this);
++    if (!weak_ptr) {
++      return;
++    }
+ 
+     if (keyboard_lock_widget_) {
+       delegate_->CancelKeyboardLockRequest(this);

--- a/patches/chromium/cherry-pick-c1cda70a433a.patch
+++ b/patches/chromium/cherry-pick-c1cda70a433a.patch
@@ -1,7 +1,8 @@
-From c1cda70a433a0c625b280eb88ed6ff4f4feffa12 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mike Wasserman <msw@chromium.org>
 Date: Thu, 21 Dec 2023 22:33:05 +0000
-Subject: [PATCH] Speculative fix for UAF in content::WebContentsImpl::ExitFullscreenMode
+Subject: Speculative fix for UAF in
+ content::WebContentsImpl::ExitFullscreenMode
 
 Bug: 1506535, 854815
 Change-Id: Iace64d63f8cea2dbfbc761ad233db42451ec101c
@@ -10,14 +11,13 @@ Commit-Queue: John Abd-El-Malek <jam@chromium.org>
 Auto-Submit: Mike Wasserman <msw@chromium.org>
 Reviewed-by: John Abd-El-Malek <jam@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#1240353}
----
 
 diff --git a/content/browser/web_contents/web_contents_impl.cc b/content/browser/web_contents/web_contents_impl.cc
-index 97f45e33..d425d19 100644
+index dd060f4207516af6b7db21593dcbed3848d47409..0ecc7989e7bfa459c80b4fe10705781257dd9b7d 100644
 --- a/content/browser/web_contents/web_contents_impl.cc
 +++ b/content/browser/web_contents/web_contents_impl.cc
-@@ -3879,7 +3879,12 @@
-   }
+@@ -3748,7 +3748,12 @@ void WebContentsImpl::ExitFullscreenMode(bool will_cause_resize) {
+     static_cast<RenderWidgetHostViewBase*>(view)->ExitFullscreenMode();
  
    if (delegate_) {
 +    // This may spin the message loop and destroy this object crbug.com/1506535
@@ -27,5 +27,5 @@ index 97f45e33..d425d19 100644
 +      return;
 +    }
  
-     if (keyboard_lock_widget_) {
+     if (keyboard_lock_widget_)
        delegate_->CancelKeyboardLockRequest(this);

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -5,3 +5,5 @@ chore_allow_customizing_microtask_policy_per_context.patch
 cherry-pick-cbd09b2ca928.patch
 merged_turboshaft_fix_structuraloptimization_because_of_ignored.patch
 cherry-pick-389ea9be7d68.patch
+cherry-pick-46cb67e3b296.patch
+cherry-pick-78dd4b31847a.patch

--- a/patches/v8/cherry-pick-46cb67e3b296.patch
+++ b/patches/v8/cherry-pick-46cb67e3b296.patch
@@ -1,0 +1,44 @@
+From 46cb67e3b296e50d7fda5a58233d18b9f3dab0d5 Mon Sep 17 00:00:00 2001
+From: Dominik Inführ <dinfuehr@chromium.org>
+Date: Mon, 18 Dec 2023 09:15:00 +0100
+Subject: [PATCH] [codegen] Install BytecodeArray last in SharedFunctionInfo
+
+Maglev assumes that when a SharedFunctionInfo has a BytecodeArray,
+then it should also have FeedbackMetadata. However, this may not
+hold with concurrent compilation when the SharedFunctionInfo is
+re-compiled after being flushed. Here the BytecodeArray was installed
+on the SFI before the FeedbackMetadata and a concurrent thread could
+observe the BytecodeArray but not the FeedbackMetadata.
+
+Drive-by: Reset the age field before setting the BytecodeArray as
+well. This ensures that the concurrent marker will not observe the
+old age for the new BytecodeArray.
+
+Bug: chromium:1507412
+Change-Id: I8855ed7ecc50c4a47d2c89043d62ac053858bc75
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5125960
+Reviewed-by: Leszek Swirski <leszeks@chromium.org>
+Commit-Queue: Dominik Inführ <dinfuehr@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#91568}
+---
+
+diff --git a/src/codegen/compiler.cc b/src/codegen/compiler.cc
+index d3b9135..cd196f7 100644
+--- a/src/codegen/compiler.cc
++++ b/src/codegen/compiler.cc
+@@ -721,12 +721,12 @@
+     }
+ #endif  // V8_ENABLE_WEBASSEMBLY
+ 
+-    shared_info->set_bytecode_array(*compilation_info->bytecode_array());
+-    shared_info->set_age(0);
+-
+     Handle<FeedbackMetadata> feedback_metadata = FeedbackMetadata::New(
+         isolate, compilation_info->feedback_vector_spec());
+     shared_info->set_feedback_metadata(*feedback_metadata, kReleaseStore);
++
++    shared_info->set_age(0);
++    shared_info->set_bytecode_array(*compilation_info->bytecode_array());
+   } else {
+ #if V8_ENABLE_WEBASSEMBLY
+     DCHECK(compilation_info->has_asm_wasm_data());

--- a/patches/v8/cherry-pick-46cb67e3b296.patch
+++ b/patches/v8/cherry-pick-46cb67e3b296.patch
@@ -1,7 +1,10 @@
-From 46cb67e3b296e50d7fda5a58233d18b9f3dab0d5 Mon Sep 17 00:00:00 2001
-From: Dominik Inführ <dinfuehr@chromium.org>
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Dominik=20Inf=C3=BChr?= <dinfuehr@chromium.org>
 Date: Mon, 18 Dec 2023 09:15:00 +0100
-Subject: [PATCH] [codegen] Install BytecodeArray last in SharedFunctionInfo
+Subject: Install BytecodeArray last in SharedFunctionInfo
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 Maglev assumes that when a SharedFunctionInfo has a BytecodeArray,
 then it should also have FeedbackMetadata. However, this may not
@@ -20,13 +23,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5125960
 Reviewed-by: Leszek Swirski <leszeks@chromium.org>
 Commit-Queue: Dominik Inführ <dinfuehr@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#91568}
----
 
 diff --git a/src/codegen/compiler.cc b/src/codegen/compiler.cc
-index d3b9135..cd196f7 100644
+index 3204e37c88ee1402cd4db0b95a1734cac0acac2f..734898b17b0e1d7124a5c4e56af767114b7dd09f 100644
 --- a/src/codegen/compiler.cc
 +++ b/src/codegen/compiler.cc
-@@ -721,12 +721,12 @@
+@@ -724,12 +724,12 @@ void InstallUnoptimizedCode(UnoptimizedCompilationInfo* compilation_info,
      }
  #endif  // V8_ENABLE_WEBASSEMBLY
  

--- a/patches/v8/cherry-pick-78dd4b31847a.patch
+++ b/patches/v8/cherry-pick-78dd4b31847a.patch
@@ -1,0 +1,28 @@
+From 78dd4b31847ab1f5b06ef3d8742a9f3835fb6919 Mon Sep 17 00:00:00 2001
+From: Leszek Swirski <leszeks@chromium.org>
+Date: Mon, 08 Jan 2024 11:13:58 +0100
+Subject: [PATCH] [maglev] Fix allocation folding in derived constructors
+
+Bug: v8:7700
+Change-Id: Ia33724d39d1397c7d47c36d14071abce6ed4b0fc
+Fixed: chromium:1515930
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5173470
+Commit-Queue: Patrick Thier <pthier@chromium.org>
+Reviewed-by: Patrick Thier <pthier@chromium.org>
+Commit-Queue: Leszek Swirski <leszeks@chromium.org>
+Auto-Submit: Leszek Swirski <leszeks@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#91709}
+---
+
+diff --git a/src/maglev/maglev-graph-builder.cc b/src/maglev/maglev-graph-builder.cc
+index ad7eccf..3dd3df5 100644
+--- a/src/maglev/maglev-graph-builder.cc
++++ b/src/maglev/maglev-graph-builder.cc
+@@ -5597,6 +5597,7 @@
+           object = BuildAllocateFastObject(
+               FastObject(new_target_function->AsJSFunction(), zone(), broker()),
+               AllocationType::kYoung);
++          ClearCurrentRawAllocation();
+         } else {
+           object = BuildCallBuiltin<Builtin::kFastNewObject>(
+               {GetConstant(current_function), new_target});

--- a/patches/v8/cherry-pick-78dd4b31847a.patch
+++ b/patches/v8/cherry-pick-78dd4b31847a.patch
@@ -1,7 +1,7 @@
-From 78dd4b31847ab1f5b06ef3d8742a9f3835fb6919 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Leszek Swirski <leszeks@chromium.org>
-Date: Mon, 08 Jan 2024 11:13:58 +0100
-Subject: [PATCH] [maglev] Fix allocation folding in derived constructors
+Date: Mon, 8 Jan 2024 11:13:58 +0100
+Subject: Fix allocation folding in derived constructors
 
 Bug: v8:7700
 Change-Id: Ia33724d39d1397c7d47c36d14071abce6ed4b0fc
@@ -12,13 +12,12 @@ Reviewed-by: Patrick Thier <pthier@chromium.org>
 Commit-Queue: Leszek Swirski <leszeks@chromium.org>
 Auto-Submit: Leszek Swirski <leszeks@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#91709}
----
 
 diff --git a/src/maglev/maglev-graph-builder.cc b/src/maglev/maglev-graph-builder.cc
-index ad7eccf..3dd3df5 100644
+index 1c9f8141e8bbcfe40a120ee1a607baedfa6a1726..2128213a9ef86c3ca2b7f883d80350f921c61687 100644
 --- a/src/maglev/maglev-graph-builder.cc
 +++ b/src/maglev/maglev-graph-builder.cc
-@@ -5597,6 +5597,7 @@
+@@ -5149,6 +5149,7 @@ bool MaglevGraphBuilder::TryBuildFindNonDefaultConstructorOrConstruct(
            object = BuildAllocateFastObject(
                FastObject(new_target_function->AsJSFunction(), zone(), broker()),
                AllocationType::kYoung);


### PR DESCRIPTION
<details>
<summary>electron/security#451 - 46cb67e3b296 from v8</summary>
[codegen] Install BytecodeArray last in SharedFunctionInfo

Maglev assumes that when a SharedFunctionInfo has a BytecodeArray,
then it should also have FeedbackMetadata. However, this may not
hold with concurrent compilation when the SharedFunctionInfo is
re-compiled after being flushed. Here the BytecodeArray was installed
on the SFI before the FeedbackMetadata and a concurrent thread could
observe the BytecodeArray but not the FeedbackMetadata.

Drive-by: Reset the age field before setting the BytecodeArray as
well. This ensures that the concurrent marker will not observe the
old age for the new BytecodeArray.

Bug: chromium:1507412
Change-Id: I8855ed7ecc50c4a47d2c89043d62ac053858bc75
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5125960
Reviewed-by: Leszek Swirski <leszeks@chromium.org>
Commit-Queue: Dominik Inführ <dinfuehr@chromium.org>
Cr-Commit-Position: refs/heads/main@{#91568}
</details>

<details>
<summary>electron/security#452 - c1cda70a433a from chromium</summary>
Speculative fix for UAF in content::WebContentsImpl::ExitFullscreenMode

Bug: 1506535, 854815
Change-Id: Iace64d63f8cea2dbfbc761ad233db42451ec101c
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5146875
Commit-Queue: John Abd-El-Malek <jam@chromium.org>
Auto-Submit: Mike Wasserman <msw@chromium.org>
Reviewed-by: John Abd-El-Malek <jam@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1240353}
</details>

<details>
<summary>electron/security#450 - 78dd4b31847a from v8</summary>
[maglev] Fix allocation folding in derived constructors

Bug: v8:7700
Change-Id: Ia33724d39d1397c7d47c36d14071abce6ed4b0fc
Fixed: chromium:1515930
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5173470
Commit-Queue: Patrick Thier <pthier@chromium.org>
Reviewed-by: Patrick Thier <pthier@chromium.org>
Commit-Queue: Leszek Swirski <leszeks@chromium.org>
Auto-Submit: Leszek Swirski <leszeks@chromium.org>
Cr-Commit-Position: refs/heads/main@{#91709}
</details>

Notes:
* Security: backported fix for CVE-2024-0518.
* Security: backported fix for 1506535.
* Security: backported fix for CVE-2024-0517.