### PR TITLE
fix: on error, reset spawnedProcess

### DIFF
--- a/lib/browser/api/auto-updater/squirrel-update-win.ts
+++ b/lib/browser/api/auto-updater/squirrel-update-win.ts
@@ -38,6 +38,8 @@ const spawnUpdate = async function (args: string[], options: { detached: boolean
     spawnedProcess.stderr.on('data', (data) => { stderr += data; });
 
     spawnedProcess.on('error', (error) => {
+      spawnedProcess = undefined;
+      spawnedArgs = [];
       reject(error);
     });
 


### PR DESCRIPTION
#### Description of Change
For squirrel update in case of errors during the update the `exit` event listener may not be called resulting on `spawnedProcess` remains defined in memory preventing further updates checks to run with success.

#### Checklist

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none