### PR TITLE
test: fixup assertNotWindows

### DIFF
--- a/spec/lib/window-helpers.ts
+++ b/spec/lib/window-helpers.ts
@@ -12,12 +12,14 @@ async function ensureWindowIsClosed (window: BaseWindow | null) {
       // window.
       const isClosed = once(window, 'closed');
       window.destroy();
+      console.log('In ensureWindowIsClosed; awaiting window is closed');
       await isClosed;
     } else {
       // If there's no WebContents or if the WebContents is already destroyed,
       // then the 'closed' event has already been emitted so there's nothing to
       // wait for.
       window.destroy();
+      console.log('In ensureWindowIsClosed; NOT awaiting window is closed');
     }
   }
 }
@@ -29,13 +31,20 @@ export const closeWindow = async (
   await ensureWindowIsClosed(window);
 
   if (assertNotWindows) {
-    const windows = BaseWindow.getAllWindows();
-    try {
-      expect(windows).to.have.lengthOf(0);
-    } finally {
-      for (const win of windows) {
-        await ensureWindowIsClosed(win);
-      }
+    let windows = BaseWindow.getAllWindows();
+    if (windows.length > 0) {
+      console.log('ALERT --- EXPECTED WINDOWS TO BE CLOSED BUT THEY ARE NOT CLOSED!!!!');
+      setTimeout(async () => {
+        // Wait until next tick to assert that all windows have been closed.
+        windows = BaseWindow.getAllWindows();
+        try {
+          expect(windows).to.have.lengthOf(0);
+        } finally {
+          for (const win of windows) {
+            await ensureWindowIsClosed(win);
+          }
+        }
+      });
     }
   }
 };

--- a/spec/lib/window-helpers.ts
+++ b/spec/lib/window-helpers.ts
@@ -12,14 +12,12 @@ async function ensureWindowIsClosed (window: BaseWindow | null) {
       // window.
       const isClosed = once(window, 'closed');
       window.destroy();
-      console.log('In ensureWindowIsClosed; awaiting window is closed');
       await isClosed;
     } else {
       // If there's no WebContents or if the WebContents is already destroyed,
       // then the 'closed' event has already been emitted so there's nothing to
       // wait for.
       window.destroy();
-      console.log('In ensureWindowIsClosed; NOT awaiting window is closed');
     }
   }
 }
@@ -33,7 +31,6 @@ export const closeWindow = async (
   if (assertNotWindows) {
     let windows = BaseWindow.getAllWindows();
     if (windows.length > 0) {
-      console.log('ALERT --- EXPECTED WINDOWS TO BE CLOSED BUT THEY ARE NOT CLOSED!!!!');
       setTimeout(async () => {
         // Wait until next tick to assert that all windows have been closed.
         windows = BaseWindow.getAllWindows();


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
- It appears that after #40871 was merged, Linux starting flaking in tests using the `closeWindow` helper.  I added a setTimeout so that we wait until the next tick to verify that windows have been closed and that appears to have resolved the issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
