### PR TITLE
fix: properly stream `uploadData` in `protocol.handle()`

### DIFF
--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -80,6 +80,8 @@ function convertToRequestBody (uploadData: ProtocolRequest['uploadData']): Reque
           // knowledge of the `Session` associated with the current request by
           // always pulling `Blob` data out of the default `Session`.
           controller.enqueue(await session.defaultSession.getBlobData(chunk.blobUUID));
+        } else {
+          throw new Error(`Unknown upload data chunk type: ${chunk.type}`);
         }
       }
     }

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -104,8 +104,12 @@ Protocol.prototype.handle = function (this: Electron.Protocol, scheme: string, h
   const success = register.call(this, scheme, async (preq: ProtocolRequest, cb: any) => {
     try {
       const body = convertToRequestBody(preq.uploadData);
+      const headers = new Headers(preq.headers);
+      if (headers.get('origin') === 'null') {
+        headers.delete('origin');
+      }
       const req = new Request(preq.url, {
-        headers: preq.headers,
+        headers,
         method: preq.method,
         referrer: preq.referrer,
         body,

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -73,6 +73,13 @@ function convertToRequestBody (uploadData: ProtocolRequest['uploadData']): Reque
         } else if (chunk.type === 'stream') {
           current = makeStreamFromPipe(chunk.body).getReader();
           return this.pull!(controller);
+        } else if (chunk.type === 'blob') {
+          // Note that even though `getBlobData()` is a `Session` API, it doesn't
+          // actually use the `Session` context. Its implementation solely relies
+          // on global variables which allows us to implement this feature without
+          // knowledge of the `Session` associated with the current request by
+          // always pulling `Blob` data out of the default `Session`.
+          controller.enqueue(await session.defaultSession.getBlobData(chunk.blobUUID));
         }
       }
     }

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -79,7 +79,6 @@ function convertToRequestBody (uploadData: ProtocolRequest['uploadData']): Reque
   }) as RequestInit['body'];
 }
 
-// TODO(codebytere): Use Object.hasOwn() once we update to ECMAScript 2022.
 function validateResponse (res: Response) {
   if (!res || typeof res !== 'object') return false;
 


### PR DESCRIPTION
#### Description of Change

Fixes a few annoying bugs which prevented requests intercepted with `protocol.handle()` from being properly forwarded to `net.fetch()`:
Fixes #39658
Fixes #40754 
Fixes #40826

I considered submitting multiple pull requests, but the fixes would've generated conflicts with each other. In essence I've just streamlined the `pull()` implementation of `convertToRequestBody()` and added a test case for every fixed bug. I also added an explicit error condition in case an unknown/new chunk type gets pushed into the protocol handler. Otherwise it is _very_
unobvious and hard to figure out why your request has been mutilated.

If you like, I am willing to fix the chunk type definitions / remove the `any` casts. However, I'd need some guidance on whether I should introduce local `type`s or add them to the public API.

Additionally I noticed while reviewing the C++ parts that the `cb`, which is passed to the actual handler function `async (preq: ProtocolRequest, cb: any)`, never accesses the `statusText` property. Is there a reason for passing `statusText` in anyways?

cc: @nornagon, @codebytere 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix various bugs which could prevent forwarding requests intercepted with protocol.handle().
