### PR TITLE
fix: ElectronBrowserContext::PartitionKey comparisons

### DIFF
--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <variant>
 #include <vector>
 
@@ -80,41 +81,20 @@ class ElectronBrowserContext : public content::BrowserContext {
 
   // partition_id => browser_context
   struct PartitionKey {
-    enum class KeyType { Partition, FilePath };
-    std::string location;
-    bool in_memory;
-    KeyType partition_type;
+    PartitionKey(const std::string_view partition, bool in_memory)
+        : type_{Partition}, location_{partition}, in_memory_{in_memory} {}
 
-    PartitionKey(const std::string& partition, bool in_memory)
-        : location(partition),
-          in_memory(in_memory),
-          partition_type(KeyType::Partition) {}
     explicit PartitionKey(const base::FilePath& file_path)
-        : location(file_path.AsUTF8Unsafe()),
-          in_memory(false),
-          partition_type(KeyType::FilePath) {}
+        : type_{Path}, location_{file_path.AsUTF8Unsafe()}, in_memory_{false} {}
 
-    bool operator<(const PartitionKey& other) const {
-      if (partition_type == KeyType::Partition) {
-        if (location == other.location)
-          return in_memory < other.in_memory;
-        return location < other.location;
-      } else {
-        if (location == other.location)
-          return false;
-        return location < other.location;
-      }
-    }
+    friend auto operator<=>(const PartitionKey&, const PartitionKey&) = default;
 
-    bool operator==(const PartitionKey& other) const {
-      if (partition_type == KeyType::Partition) {
-        return (location == other.location) && (in_memory < other.in_memory);
-      } else {
-        if (location == other.location)
-          return true;
-        return false;
-      }
-    }
+   private:
+    enum class Type { Partition, Path };
+
+    Type type_;
+    std::string location_;
+    bool in_memory_;
   };
 
   using BrowserContextMap =


### PR DESCRIPTION
#### Description of Change

Use [c++20 default comparisons](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++-features.md#Default-comparisons-allowed) to simplify + fix two bugs in PartitionKey sorting:

1. The equality operator is broken. `PartitionKey{"foo", false}` is both equal to, and less than, `PartitionKey{"foo", true}`

2. For some keys, the same session can be retrieved via both `fromPath()` and `fromPartition()`. This use case was discussed and removed from the original PR [after code review](https://github.com/electron/electron/pull/36728/commits/3f1aea9af91e17b2605eb8a5837bbb81888d76da#r1099745359) said "always returning different sessions feels lower maintenance." The current behavior is a bug that comes from the comparison operators not checking the keys' types.

All reviews welcomed. CC @zcbenz as the 36728 reviewer who discussed the 'same session' use case

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `session.fromPartition()` key lookup bug.