### PR TITLE
refactor: remove banned std::to_string() calls

### DIFF
--- a/shell/browser/api/electron_api_service_worker_context.cc
+++ b/shell/browser/api/electron_api_service_worker_context.cc
@@ -7,6 +7,7 @@
 #include <string_view>
 #include <utility>
 
+#include "base/strings/string_number_conversions.h"
 #include "chrome/browser/browser_process.h"
 #include "content/public/browser/console_message.h"
 #include "content/public/browser/storage_partition.h"
@@ -120,7 +121,7 @@ v8::Local<v8::Value> ServiceWorkerContext::GetAllRunningWorkerInfo(
       service_worker_context_->GetRunningServiceWorkerInfos();
   for (const auto& iter : info_map) {
     builder.Set(
-        std::to_string(iter.first),
+        base::NumberToString(iter.first),
         ServiceWorkerRunningInfoToDict(isolate, std::move(iter.second)));
   }
   return builder.Build();

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -16,7 +16,6 @@
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/memory/raw_ptr.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "base/uuid.h"

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -16,7 +16,6 @@
 #include "base/i18n/rtl.h"
 #include "base/mac/mac_util.h"
 #include "base/mac/mac_util.mm"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/sys_string_conversions.h"
 #include "chrome/browser/browser_process.h"
 #include "net/base/mac/url_conversions.h"

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -15,6 +15,7 @@
 #include "base/no_destructor.h"
 #include "base/path_service.h"
 #include "base/strings/escape.h"
+#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "chrome/common/chrome_paths.h"
 #include "chrome/common/pref_names.h"

--- a/shell/browser/hid/hid_chooser_context.cc
+++ b/shell/browser/hid/hid_chooser_context.cc
@@ -12,7 +12,6 @@
 
 #include "base/command_line.h"
 #include "base/containers/contains.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -16,6 +16,7 @@
 #include "base/environment.h"
 #include "base/logging.h"
 #include "base/strings/string_util_win.h"
+#include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
@@ -38,23 +39,22 @@ using Microsoft::WRL::Wrappers::HStringReference;
 
 namespace winui = ABI::Windows::UI;
 
-#define RETURN_IF_FAILED(hr) \
-  do {                       \
-    HRESULT _hrTemp = hr;    \
-    if (FAILED(_hrTemp)) {   \
-      return _hrTemp;        \
-    }                        \
+#define RETURN_IF_FAILED(hr)                           \
+  do {                                                 \
+    if (const HRESULT _hrTemp = hr; FAILED(_hrTemp)) { \
+      return _hrTemp;                                  \
+    }                                                  \
   } while (false)
-#define REPORT_AND_RETURN_IF_FAILED(hr, msg)                             \
-  do {                                                                   \
-    HRESULT _hrTemp = hr;                                                \
-    std::string _msgTemp = msg;                                          \
-    if (FAILED(_hrTemp)) {                                               \
-      std::string _err = _msgTemp + ",ERROR " + std::to_string(_hrTemp); \
-      DebugLog(_err);                                                    \
-      Notification::NotificationFailed(_err);                            \
-      return _hrTemp;                                                    \
-    }                                                                    \
+
+#define REPORT_AND_RETURN_IF_FAILED(hr, msg)                     \
+  do {                                                           \
+    if (const HRESULT _hrTemp = hr; FAILED(_hrTemp)) {           \
+      std::string _err =                                         \
+          base::StringPrintf("%s,ERROR %" PRId32, msg, _hrTemp); \
+      DebugLog(_err);                                            \
+      Notification::NotificationFailed(_err);                    \
+      return _hrTemp;                                            \
+    }                                                            \
   } while (false)
 
 namespace electron {

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -15,8 +15,9 @@
 
 #include "base/environment.h"
 #include "base/logging.h"
+#include "base/strings/strcat.h"
+#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util_win.h"
-#include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
@@ -46,15 +47,15 @@ namespace winui = ABI::Windows::UI;
     }                                                  \
   } while (false)
 
-#define REPORT_AND_RETURN_IF_FAILED(hr, msg)                     \
-  do {                                                           \
-    if (const HRESULT _hrTemp = hr; FAILED(_hrTemp)) {           \
-      std::string _err =                                         \
-          base::StringPrintf("%s,ERROR %" PRId32, msg, _hrTemp); \
-      DebugLog(_err);                                            \
-      Notification::NotificationFailed(_err);                    \
-      return _hrTemp;                                            \
-    }                                                            \
+#define REPORT_AND_RETURN_IF_FAILED(hr, msg)                              \
+  do {                                                                    \
+    if (const HRESULT _hrTemp = hr; FAILED(_hrTemp)) {                    \
+      std::string _err =                                                  \
+          base::StrCat({msg, ", ERROR ", base::NumberToString(_hrTemp)}); \
+      DebugLog(_err);                                                     \
+      Notification::NotificationFailed(_err);                             \
+      return _hrTemp;                                                     \
+    }                                                                     \
   } while (false)
 
 namespace electron {

--- a/shell/browser/ui/accelerator_util.cc
+++ b/shell/browser/ui/accelerator_util.cc
@@ -11,7 +11,6 @@
 
 #include "base/logging.h"
 #include "base/stl_util.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "shell/common/keyboard_util.h"

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -17,6 +17,7 @@
 #include "base/metrics/histogram.h"
 #include "base/stl_util.h"
 #include "base/strings/pattern.h"
+#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"

--- a/shell/browser/ui/webui/accessibility_ui.cc
+++ b/shell/browser/ui/webui/accessibility_ui.cc
@@ -16,7 +16,6 @@
 #include "base/json/json_writer.h"
 #include "base/strings/escape.h"
 #include "base/strings/pattern.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/values.h"
 #include "build/build_config.h"

--- a/shell/browser/ui/win/notify_icon.cc
+++ b/shell/browser/ui/win/notify_icon.cc
@@ -7,7 +7,6 @@
 #include <objbase.h>
 
 #include "base/logging.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util_win.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/win/windows_version.h"

--- a/shell/browser/usb/usb_chooser_context.cc
+++ b/shell/browser/usb/usb_chooser_context.cc
@@ -10,7 +10,6 @@
 #include "base/containers/contains.h"
 #include "base/functional/bind.h"
 #include "base/observer_list.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -13,7 +13,6 @@
 #include "base/command_line.h"
 #include "base/containers/fixed_flat_map.h"
 #include "base/memory/ptr_util.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
 #include "cc/base/switches.h"
 #include "content/public/browser/render_frame_host.h"

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -15,6 +15,7 @@
 #include "base/memory/raw_ptr.h"
 #include "base/no_destructor.h"
 #include "base/sequence_checker.h"
+#include "base/strings/string_number_conversions.h"
 #include "gin/handle.h"
 #include "gin/object_template_builder.h"
 #include "gin/wrappable.h"
@@ -263,7 +264,7 @@ class JSChunkedDataPipeGetter : public gin::Wrappable<JSChunkedDataPipeGetter>,
       promise.Resolve();
     } else {
       promise.RejectWithErrorMessage("mojo result not ok: " +
-                                     std::to_string(result));
+                                     base::NumberToString(result));
       Finished();
     }
   }

--- a/shell/common/asar/archive.cc
+++ b/shell/common/asar/archive.cc
@@ -15,7 +15,6 @@
 #include "base/json/json_reader.h"
 #include "base/logging.h"
 #include "base/pickle.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/values.h"
 #include "electron/fuses.h"
 #include "shell/common/asar/asar_util.h"

--- a/shell/common/crash_keys.cc
+++ b/shell/common/crash_keys.cc
@@ -4,6 +4,7 @@
 
 #include "shell/common/crash_keys.h"
 
+#include <cstdint>
 #include <deque>
 #include <map>
 #include <string>
@@ -12,6 +13,7 @@
 #include "base/environment.h"
 #include "base/no_destructor.h"
 #include "base/strings/string_split.h"
+#include "base/strings/stringprintf.h"
 #include "components/crash/core/common/crash_key.h"
 #include "content/public/common/content_switches.h"
 #include "electron/buildflags/buildflags.h"
@@ -55,11 +57,12 @@ void SetCrashKey(const std::string& key, const std::string& value) {
   if (key.size() >= kMaxCrashKeyNameLength) {
     node::Environment* env =
         node::Environment::GetCurrent(JavascriptEnvironment::GetIsolate());
-    EmitWarning(env,
-                "The crash key name, \"" + key + "\", is longer than " +
-                    std::to_string(kMaxCrashKeyNameLength) +
-                    " bytes, ignoring it.",
-                "electron");
+    EmitWarning(
+        env,
+        base::StringPrintf("The crash key name, \"%s\", is longer than %" PRIu32
+                           " bytes, ignoring it.",
+                           key.c_str(), kMaxCrashKeyNameLength),
+        "electron");
     return;
   }
 

--- a/shell/common/keyboard_util.cc
+++ b/shell/common/keyboard_util.cc
@@ -5,7 +5,6 @@
 #include <string>
 
 #include "base/containers/fixed_flat_map.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "shell/common/keyboard_util.h"
 #include "third_party/blink/public/common/input/web_input_event.h"

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -14,7 +14,6 @@
 #include "base/containers/contains.h"
 #include "base/feature_list.h"
 #include "base/no_destructor.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/trace_event/trace_event.h"
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_frame_observer.h"

--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -9,7 +9,6 @@
 
 #include "base/command_line.h"
 #include "base/memory/ref_counted_memory.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/trace_event/trace_event.h"
 #include "content/public/renderer/render_frame.h"
 #include "electron/buildflags/buildflags.h"


### PR DESCRIPTION
#### Description of Change

`std::to_string()` is [banned](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++-features.md#std_sto_i_l_ul_ll_ull_f_d_ld_to_string_banned), so use `base::NumberToString()` instead.

Any reviewers welcome.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: None