### PR TITLE
fix: dangling raw_ptr in OSRWHV destructor

### DIFF
--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -187,6 +187,12 @@ OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
       frame_rate_(frame_rate),
       size_(initial_size),
       painting_(painting),
+      delegated_frame_host_client_{
+          std::make_unique<ElectronDelegatedFrameHostClient>(this)},
+      delegated_frame_host_{std::make_unique<content::DelegatedFrameHost>(
+          AllocateFrameSinkId(),
+          delegated_frame_host_client_.get(),
+          true /* should_register_frame_sink_id */)},
       cursor_manager_(std::make_unique<content::CursorManager>(this)),
       mouse_wheel_phase_handler_(this),
       backing_(std::make_unique<SkBitmap>()) {
@@ -204,12 +210,6 @@ OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
       delegated_frame_host_allocator_.GetCurrentLocalSurfaceId();
   compositor_allocator_.GenerateId();
   compositor_surface_id_ = compositor_allocator_.GetCurrentLocalSurfaceId();
-
-  delegated_frame_host_client_ =
-      std::make_unique<ElectronDelegatedFrameHostClient>(this);
-  delegated_frame_host_ = std::make_unique<content::DelegatedFrameHost>(
-      AllocateFrameSinkId(), delegated_frame_host_client_.get(),
-      true /* should_register_frame_sink_id */);
 
   root_layer_ = std::make_unique<ui::Layer>(ui::LAYER_SOLID_COLOR);
 
@@ -247,7 +247,6 @@ OffScreenRenderWidgetHostView::~OffScreenRenderWidgetHostView() {
         content::DelegatedFrameHost::HiddenCause::kOther);
   delegated_frame_host_->DetachFromCompositor();
 
-  delegated_frame_host_.reset();
   compositor_.reset();
   root_layer_.reset();
 }

--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -279,16 +279,21 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
   viz::ParentLocalSurfaceIdAllocator compositor_allocator_;
 
   std::unique_ptr<ui::Layer> root_layer_;
+
+  // depends-on: root_layer_
   std::unique_ptr<ui::Compositor> compositor_;
-  std::unique_ptr<content::DelegatedFrameHost> delegated_frame_host_;
+
+  // depends-on: render_widget_host_, root_layer_
+  const std::unique_ptr<ElectronDelegatedFrameHostClient>
+      delegated_frame_host_client_;
+
+  // depends-on: delegated_frame_host_client_
+  const std::unique_ptr<content::DelegatedFrameHost> delegated_frame_host_;
 
   std::unique_ptr<content::CursorManager> cursor_manager_;
 
   raw_ptr<OffScreenHostDisplayClient> host_display_client_;
   std::unique_ptr<OffScreenVideoConsumer> video_consumer_;
-
-  std::unique_ptr<ElectronDelegatedFrameHostClient>
-      delegated_frame_host_client_;
 
   content::MouseWheelPhaseHandler mouse_wheel_phase_handler_;
 


### PR DESCRIPTION
#### Description of Change

`delegated_frame_host_` holds a pointer to `delegated_frame_host_client_`. Since `delegated_frame_host_client_` was being destroyed first, that pointer was dangling in the OSRWHV destructor.

Also, make these two unique_ptr fields `const` since they point to the same objects for the lifespan of the OSRWHV.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none