### PR TITLE
build: remove unneeded dlls in Windows zip

### DIFF
--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -177,7 +177,12 @@ for:
             # built on CI.
             7z a pdb.zip out\Default\*.pdb
           }
-      - python3 electron/script/zip_manifests/check-zip-manifest.py out/Default/dist.zip electron/script/zip_manifests/dist_zip.win.%TARGET_ARCH%.manifest
+      - ps: |
+          $manifest_file = "electron/script/zip_manifests/dist_zip.win.$env:TARGET_ARCH.manifest"
+          python3 electron/script/zip_manifests/check-zip-manifest.py out/Default/dist.zip $manifest_file
+          if ($LASTEXITCODE -ne 0) {
+            throw "Zip contains files not listed in the manifest $manifest_file"
+          }
       - ps: |
           cd C:\projects\src
           $missing_artifacts = $false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -174,7 +174,12 @@ for:
             # built on CI.
             7z a pdb.zip out\Default\*.pdb
           }
-      - python3 electron/script/zip_manifests/check-zip-manifest.py out/Default/dist.zip electron/script/zip_manifests/dist_zip.win.%TARGET_ARCH%.manifest
+      - ps: |
+          $manifest_file = "electron/script/zip_manifests/dist_zip.win.$env:TARGET_ARCH.manifest"
+          python3 electron/script/zip_manifests/check-zip-manifest.py out/Default/dist.zip $manifest_file
+          if ($LASTEXITCODE -ne 0) {
+            throw "Zip contains files not listed in the manifest $manifest_file"
+          }
       - ps: |
           cd C:\projects\src
           $missing_artifacts = $false

--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -24,6 +24,10 @@ enable_printing = true
 angle_enable_vulkan_validation_layers = false
 dawn_enable_vulkan_validation_layers = false
 
+# Removes dxc dll's that are only used experimentally.
+# See https://bugs.chromium.org/p/chromium/issues/detail?id=1474897
+dawn_use_built_dxc = false
+
 # These are disabled because they cause the zip manifest to differ between
 # testing and release builds.
 # See https://chromium-review.googlesource.com/c/chromium/src/+/2774898.


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

28.0.0 windows builds shipped with two new dlls: `dxcompiler.dll` and `dxil.dll`.  Those DLLs were added for experimental usage of https://github.com/microsoft/DirectXShaderCompiler in Chromium's WebGPU support.  Since they are [experimental](https://bugs.chromium.org/p/chromium/issues/detail?id=1474897) for now, we can remove them.   

Additionally, this PR fixes our check for new files in zip files on Windows.  Now when a new addition to the zip file is detected the build will fail on Windows (like it already does on macOS and Linux).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->Removed extraneous dlls from Windows zip files.
