### PR TITLE
refactor: inline simple getters

### DIFF
--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -214,26 +214,23 @@ void Notification::FillObjectTemplate(v8::Isolate* isolate,
   gin::ObjectTemplateBuilder(isolate, GetClassName(), templ)
       .SetMethod("show", &Notification::Show)
       .SetMethod("close", &Notification::Close)
-      .SetProperty("title", &Notification::get_title, &Notification::SetTitle)
-      .SetProperty("subtitle", &Notification::get_subtitle,
+      .SetProperty("title", &Notification::title, &Notification::SetTitle)
+      .SetProperty("subtitle", &Notification::subtitle,
                    &Notification::SetSubtitle)
-      .SetProperty("body", &Notification::get_body, &Notification::SetBody)
-      .SetProperty("silent", &Notification::get_silent,
-                   &Notification::SetSilent)
-      .SetProperty("hasReply", &Notification::get_has_reply,
+      .SetProperty("body", &Notification::body, &Notification::SetBody)
+      .SetProperty("silent", &Notification::is_silent, &Notification::SetSilent)
+      .SetProperty("hasReply", &Notification::has_reply,
                    &Notification::SetHasReply)
-      .SetProperty("timeoutType", &Notification::get_timeout_type,
+      .SetProperty("timeoutType", &Notification::timeout_type,
                    &Notification::SetTimeoutType)
-      .SetProperty("replyPlaceholder", &Notification::get_reply_placeholder,
+      .SetProperty("replyPlaceholder", &Notification::reply_placeholder,
                    &Notification::SetReplyPlaceholder)
-      .SetProperty("urgency", &Notification::get_urgency,
-                   &Notification::SetUrgency)
-      .SetProperty("sound", &Notification::get_sound, &Notification::SetSound)
-      .SetProperty("actions", &Notification::get_actions,
-                   &Notification::SetActions)
-      .SetProperty("closeButtonText", &Notification::get_close_button_text,
+      .SetProperty("urgency", &Notification::urgency, &Notification::SetUrgency)
+      .SetProperty("sound", &Notification::sound, &Notification::SetSound)
+      .SetProperty("actions", &Notification::actions, &Notification::SetActions)
+      .SetProperty("closeButtonText", &Notification::close_button_text,
                    &Notification::SetCloseButtonText)
-      .SetProperty("toastXml", &Notification::get_toast_xml,
+      .SetProperty("toastXml", &Notification::toast_xml,
                    &Notification::SetToastXml)
       .Build();
 }

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -89,55 +89,6 @@ gin::Handle<Notification> Notification::New(gin_helper::ErrorThrower thrower,
   return gin::CreateHandle(thrower.isolate(), new Notification(args));
 }
 
-// Getters
-std::u16string Notification::GetTitle() const {
-  return title_;
-}
-
-std::u16string Notification::GetSubtitle() const {
-  return subtitle_;
-}
-
-std::u16string Notification::GetBody() const {
-  return body_;
-}
-
-bool Notification::GetSilent() const {
-  return silent_;
-}
-
-bool Notification::GetHasReply() const {
-  return has_reply_;
-}
-
-std::u16string Notification::GetTimeoutType() const {
-  return timeout_type_;
-}
-
-std::u16string Notification::GetReplyPlaceholder() const {
-  return reply_placeholder_;
-}
-
-std::u16string Notification::GetSound() const {
-  return sound_;
-}
-
-std::u16string Notification::GetUrgency() const {
-  return urgency_;
-}
-
-std::vector<electron::NotificationAction> Notification::GetActions() const {
-  return actions_;
-}
-
-std::u16string Notification::GetCloseButtonText() const {
-  return close_button_text_;
-}
-
-std::u16string Notification::GetToastXml() const {
-  return toast_xml_;
-}
-
 // Setters
 void Notification::SetTitle(const std::u16string& new_title) {
   title_ = new_title;
@@ -263,25 +214,26 @@ void Notification::FillObjectTemplate(v8::Isolate* isolate,
   gin::ObjectTemplateBuilder(isolate, GetClassName(), templ)
       .SetMethod("show", &Notification::Show)
       .SetMethod("close", &Notification::Close)
-      .SetProperty("title", &Notification::GetTitle, &Notification::SetTitle)
-      .SetProperty("subtitle", &Notification::GetSubtitle,
+      .SetProperty("title", &Notification::get_title, &Notification::SetTitle)
+      .SetProperty("subtitle", &Notification::get_subtitle,
                    &Notification::SetSubtitle)
-      .SetProperty("body", &Notification::GetBody, &Notification::SetBody)
-      .SetProperty("silent", &Notification::GetSilent, &Notification::SetSilent)
-      .SetProperty("hasReply", &Notification::GetHasReply,
+      .SetProperty("body", &Notification::get_body, &Notification::SetBody)
+      .SetProperty("silent", &Notification::get_silent,
+                   &Notification::SetSilent)
+      .SetProperty("hasReply", &Notification::get_has_reply,
                    &Notification::SetHasReply)
-      .SetProperty("timeoutType", &Notification::GetTimeoutType,
+      .SetProperty("timeoutType", &Notification::get_timeout_type,
                    &Notification::SetTimeoutType)
-      .SetProperty("replyPlaceholder", &Notification::GetReplyPlaceholder,
+      .SetProperty("replyPlaceholder", &Notification::get_reply_placeholder,
                    &Notification::SetReplyPlaceholder)
-      .SetProperty("urgency", &Notification::GetUrgency,
+      .SetProperty("urgency", &Notification::get_urgency,
                    &Notification::SetUrgency)
-      .SetProperty("sound", &Notification::GetSound, &Notification::SetSound)
-      .SetProperty("actions", &Notification::GetActions,
+      .SetProperty("sound", &Notification::get_sound, &Notification::SetSound)
+      .SetProperty("actions", &Notification::get_actions,
                    &Notification::SetActions)
-      .SetProperty("closeButtonText", &Notification::GetCloseButtonText,
+      .SetProperty("closeButtonText", &Notification::get_close_button_text,
                    &Notification::SetCloseButtonText)
-      .SetProperty("toastXml", &Notification::GetToastXml,
+      .SetProperty("toastXml", &Notification::get_toast_xml,
                    &Notification::SetToastXml)
       .Build();
 }

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -67,18 +67,20 @@ class Notification : public gin::Wrappable<Notification>,
   void Close();
 
   // Prop Getters
-  std::u16string GetTitle() const;
-  std::u16string GetSubtitle() const;
-  std::u16string GetBody() const;
-  bool GetSilent() const;
-  bool GetHasReply() const;
-  std::u16string GetTimeoutType() const;
-  std::u16string GetReplyPlaceholder() const;
-  std::u16string GetUrgency() const;
-  std::u16string GetSound() const;
-  std::vector<electron::NotificationAction> GetActions() const;
-  std::u16string GetCloseButtonText() const;
-  std::u16string GetToastXml() const;
+  std::u16string get_title() const { return title_; }
+  std::u16string get_subtitle() const { return subtitle_; }
+  std::u16string get_body() const { return body_; }
+  bool get_silent() const { return silent_; }
+  bool get_has_reply() const { return has_reply_; }
+  std::u16string get_timeout_type() const { return timeout_type_; }
+  std::u16string get_reply_placeholder() const { return reply_placeholder_; }
+  std::u16string get_urgency() const { return urgency_; }
+  std::u16string get_sound() const { return sound_; }
+  std::vector<electron::NotificationAction> get_actions() const {
+    return actions_;
+  }
+  std::u16string get_close_button_text() const { return close_button_text_; }
+  std::u16string get_toast_xml() const { return toast_xml_; }
 
   // Prop Setters
   void SetTitle(const std::u16string& new_title);

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -67,20 +67,18 @@ class Notification : public gin::Wrappable<Notification>,
   void Close();
 
   // Prop Getters
-  std::u16string get_title() const { return title_; }
-  std::u16string get_subtitle() const { return subtitle_; }
-  std::u16string get_body() const { return body_; }
-  bool get_silent() const { return silent_; }
-  bool get_has_reply() const { return has_reply_; }
-  std::u16string get_timeout_type() const { return timeout_type_; }
-  std::u16string get_reply_placeholder() const { return reply_placeholder_; }
-  std::u16string get_urgency() const { return urgency_; }
-  std::u16string get_sound() const { return sound_; }
-  std::vector<electron::NotificationAction> get_actions() const {
-    return actions_;
-  }
-  std::u16string get_close_button_text() const { return close_button_text_; }
-  std::u16string get_toast_xml() const { return toast_xml_; }
+  std::u16string title() const { return title_; }
+  std::u16string subtitle() const { return subtitle_; }
+  std::u16string body() const { return body_; }
+  bool is_silent() const { return silent_; }
+  bool has_reply() const { return has_reply_; }
+  std::u16string timeout_type() const { return timeout_type_; }
+  std::u16string reply_placeholder() const { return reply_placeholder_; }
+  std::u16string urgency() const { return urgency_; }
+  std::u16string sound() const { return sound_; }
+  std::vector<electron::NotificationAction> actions() const { return actions_; }
+  std::u16string close_button_text() const { return close_button_text_; }
+  std::u16string toast_xml() const { return toast_xml_; }
 
   // Prop Setters
   void SetTitle(const std::u16string& new_title);

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -67,18 +67,20 @@ class Notification : public gin::Wrappable<Notification>,
   void Close();
 
   // Prop Getters
-  std::u16string title() const { return title_; }
-  std::u16string subtitle() const { return subtitle_; }
-  std::u16string body() const { return body_; }
+  const std::u16string& title() const { return title_; }
+  const std::u16string& subtitle() const { return subtitle_; }
+  const std::u16string& body() const { return body_; }
   bool is_silent() const { return silent_; }
   bool has_reply() const { return has_reply_; }
-  std::u16string timeout_type() const { return timeout_type_; }
-  std::u16string reply_placeholder() const { return reply_placeholder_; }
-  std::u16string urgency() const { return urgency_; }
-  std::u16string sound() const { return sound_; }
-  std::vector<electron::NotificationAction> actions() const { return actions_; }
-  std::u16string close_button_text() const { return close_button_text_; }
-  std::u16string toast_xml() const { return toast_xml_; }
+  const std::u16string& timeout_type() const { return timeout_type_; }
+  const std::u16string& reply_placeholder() const { return reply_placeholder_; }
+  const std::u16string& urgency() const { return urgency_; }
+  const std::u16string& sound() const { return sound_; }
+  const std::vector<electron::NotificationAction>& actions() const {
+    return actions_;
+  }
+  const std::u16string& close_button_text() const { return close_button_text_; }
+  const std::u16string& toast_xml() const { return toast_xml_; }
 
   // Prop Setters
   void SetTitle(const std::u16string& new_title);

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -384,14 +384,6 @@ bool ElectronBrowserContext::IsOffTheRecord() {
   return in_memory_;
 }
 
-bool ElectronBrowserContext::CanUseHttpCache() const {
-  return use_cache_;
-}
-
-int ElectronBrowserContext::GetMaxCacheSize() const {
-  return max_cache_size_;
-}
-
 std::string ElectronBrowserContext::GetMediaDeviceIDSalt() {
   if (!media_device_id_salt_.get())
     media_device_id_salt_ = std::make_unique<MediaDeviceIDSalt>(prefs_.get());

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -120,7 +120,7 @@ class ElectronBrowserContext : public content::BrowserContext {
   void SetUserAgent(const std::string& user_agent);
   std::string GetUserAgent() const;
   bool can_use_http_cache() const { return use_cache_; }
-  int get_max_cache_size() const { return max_cache_size_; }
+  int max_cache_size() const { return max_cache_size_; }
   ResolveProxyHelper* GetResolveProxyHelper();
   predictors::PreconnectManager* GetPreconnectManager();
   scoped_refptr<network::SharedURLLoaderFactory> GetURLLoaderFactory();

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -119,8 +119,8 @@ class ElectronBrowserContext : public content::BrowserContext {
 
   void SetUserAgent(const std::string& user_agent);
   std::string GetUserAgent() const;
-  bool CanUseHttpCache() const;
-  int GetMaxCacheSize() const;
+  bool can_use_http_cache() const { return use_cache_; }
+  int get_max_cache_size() const { return max_cache_size_; }
   ResolveProxyHelper* GetResolveProxyHelper();
   predictors::PreconnectManager* GetPreconnectManager();
   scoped_refptr<network::SharedURLLoaderFactory> GetURLLoaderFactory();

--- a/shell/browser/extensions/api/tabs/tabs_api.cc
+++ b/shell/browser/extensions/api/tabs/tabs_api.cc
@@ -369,7 +369,7 @@ ExtensionFunction::ResponseAction TabsSetZoomFunction::Run() {
       params->zoom_factor > 0
           ? blink::PageZoomFactorToZoomLevel(params->zoom_factor)
           : blink::PageZoomFactorToZoomLevel(
-                zoom_controller->get_default_zoom_factor());
+                zoom_controller->default_zoom_factor());
 
   zoom_controller->SetZoomLevel(zoom_level);
 

--- a/shell/browser/extensions/api/tabs/tabs_api.cc
+++ b/shell/browser/extensions/api/tabs/tabs_api.cc
@@ -369,7 +369,7 @@ ExtensionFunction::ResponseAction TabsSetZoomFunction::Run() {
       params->zoom_factor > 0
           ? blink::PageZoomFactorToZoomLevel(params->zoom_factor)
           : blink::PageZoomFactorToZoomLevel(
-                zoom_controller->GetDefaultZoomFactor());
+                zoom_controller->get_default_zoom_factor());
 
   zoom_controller->SetZoomLevel(zoom_level);
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1405,7 +1405,7 @@ void NativeWindowViews::SetAutoHideMenuBar(bool auto_hide) {
 }
 
 bool NativeWindowViews::IsMenuBarAutoHide() const {
-  return root_view_.IsMenuBarAutoHide();
+  return root_view_.is_menu_bar_auto_hide();
 }
 
 void NativeWindowViews::SetMenuBarVisibility(bool visible) {
@@ -1413,7 +1413,7 @@ void NativeWindowViews::SetMenuBarVisibility(bool visible) {
 }
 
 bool NativeWindowViews::IsMenuBarVisible() const {
-  return root_view_.IsMenuBarVisible();
+  return root_view_.is_menu_bar_visible();
 }
 
 void NativeWindowViews::SetBackgroundMaterial(const std::string& material) {
@@ -1529,7 +1529,7 @@ gfx::Rect NativeWindowViews::ContentBoundsToWindowBounds(
   }
 #endif
 
-  if (root_view_.HasMenu() && root_view_.IsMenuBarVisible()) {
+  if (root_view_.HasMenu() && root_view_.is_menu_bar_visible()) {
     int menu_bar_height = root_view_.GetMenuBarHeight();
     window_bounds.set_y(window_bounds.y() - menu_bar_height);
     window_bounds.set_height(window_bounds.height() + menu_bar_height);
@@ -1556,7 +1556,7 @@ gfx::Rect NativeWindowViews::WindowBoundsToContentBounds(
   content_bounds.set_size(ScreenToDIPRect(hwnd, content_bounds).size());
 #endif
 
-  if (root_view_.HasMenu() && root_view_.IsMenuBarVisible()) {
+  if (root_view_.HasMenu() && root_view_.is_menu_bar_visible()) {
     int menu_bar_height = root_view_.GetMenuBarHeight();
     content_bounds.set_y(content_bounds.y() + menu_bar_height);
     content_bounds.set_height(content_bounds.height() - menu_bar_height);

--- a/shell/browser/net/network_context_service.cc
+++ b/shell/browser/net/network_context_service.cc
@@ -81,7 +81,7 @@ void NetworkContextService::ConfigureNetworkContextParams(
   if (!in_memory) {
     // Configure the HTTP cache path and size.
     network_context_params->http_cache_max_size =
-        browser_context_->get_max_cache_size();
+        browser_context_->max_cache_size();
 
     network_context_params->file_paths =
         network::mojom::NetworkContextFilePaths::New();

--- a/shell/browser/net/network_context_service.cc
+++ b/shell/browser/net/network_context_service.cc
@@ -72,7 +72,7 @@ void NetworkContextService::ConfigureNetworkContextParams(
 
   // Enable the HTTP cache.
   network_context_params->http_cache_enabled =
-      browser_context_->CanUseHttpCache();
+      browser_context_->can_use_http_cache();
 
   network_context_params->cookie_manager_params =
       network::mojom::CookieManagerParams::New();
@@ -81,7 +81,7 @@ void NetworkContextService::ConfigureNetworkContextParams(
   if (!in_memory) {
     // Configure the HTTP cache path and size.
     network_context_params->http_cache_max_size =
-        browser_context_->GetMaxCacheSize();
+        browser_context_->get_max_cache_size();
 
     network_context_params->file_paths =
         network::mojom::NetworkContextFilePaths::New();

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -727,10 +727,10 @@ void OffScreenRenderWidgetHostView::CompositeFrame(
       }
 
       for (auto* proxy_view : proxy_views_) {
-        gfx::Rect rect = proxy_view->get_bounds();
+        gfx::Rect rect = proxy_view->bounds();
         gfx::Point origin_in_pixels =
             gfx::ToFlooredPoint(gfx::ConvertPointToPixels(rect.origin(), sf));
-        canvas.writePixels(*proxy_view->get_bitmap(), origin_in_pixels.x(),
+        canvas.writePixels(*proxy_view->bitmap(), origin_in_pixels.x(),
                            origin_in_pixels.y());
       }
     }
@@ -786,7 +786,7 @@ void OffScreenRenderWidgetHostView::SynchronizeVisualProperties() {
 void OffScreenRenderWidgetHostView::SendMouseEvent(
     const blink::WebMouseEvent& event) {
   for (auto* proxy_view : proxy_views_) {
-    gfx::Rect bounds = proxy_view->get_bounds();
+    gfx::Rect bounds = proxy_view->bounds();
     if (bounds.Contains(event.PositionInWidget().x(),
                         event.PositionInWidget().y())) {
       blink::WebMouseEvent proxy_event(event);
@@ -824,7 +824,7 @@ void OffScreenRenderWidgetHostView::SendMouseEvent(
 void OffScreenRenderWidgetHostView::SendMouseWheelEvent(
     const blink::WebMouseWheelEvent& event) {
   for (auto* proxy_view : proxy_views_) {
-    gfx::Rect bounds = proxy_view->get_bounds();
+    gfx::Rect bounds = proxy_view->bounds();
     if (bounds.Contains(event.PositionInWidget().x(),
                         event.PositionInWidget().y())) {
       blink::WebMouseWheelEvent proxy_event(event);

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -235,7 +235,7 @@ OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
         this, base::BindRepeating(&OffScreenRenderWidgetHostView::OnPaint,
                                   weak_ptr_factory_.GetWeakPtr()));
     video_consumer_->SetActive(is_painting());
-    video_consumer_->SetFrameRate(get_frame_rate());
+    video_consumer_->SetFrameRate(this->frame_rate());
   }
 }
 
@@ -558,7 +558,7 @@ OffScreenRenderWidgetHostView::CreateViewForWidget(
   }
 
   return new OffScreenRenderWidgetHostView(
-      transparent_, true, embedder_host_view->get_frame_rate(), callback_,
+      transparent_, true, embedder_host_view->frame_rate(), callback_,
       render_widget_host, embedder_host_view, size());
 }
 
@@ -923,10 +923,10 @@ void OffScreenRenderWidgetHostView::SetPainting(bool painting) {
 
 void OffScreenRenderWidgetHostView::SetFrameRate(int frame_rate) {
   if (parent_host_view_) {
-    if (parent_host_view_->get_frame_rate() == get_frame_rate())
+    if (parent_host_view_->frame_rate() == this->frame_rate())
       return;
 
-    frame_rate_ = parent_host_view_->get_frame_rate();
+    frame_rate_ = parent_host_view_->frame_rate();
   } else {
     if (frame_rate <= 0)
       frame_rate = 1;
@@ -939,7 +939,7 @@ void OffScreenRenderWidgetHostView::SetFrameRate(int frame_rate) {
   SetupFrameRate(true);
 
   if (video_consumer_) {
-    video_consumer_->SetFrameRate(get_frame_rate());
+    video_consumer_->SetFrameRate(this->frame_rate());
   }
 
   for (auto* guest_host_view : guest_host_views_)

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -135,7 +135,7 @@ class ElectronDelegatedFrameHostClient
       const ElectronDelegatedFrameHostClient&) = delete;
 
   ui::Layer* DelegatedFrameHostGetLayer() const override {
-    return view_->get_root_layer();
+    return view_->root_layer();
   }
 
   bool DelegatedFrameHostIsVisible() const override {
@@ -214,8 +214,8 @@ OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
   root_layer_ = std::make_unique<ui::Layer>(ui::LAYER_SOLID_COLOR);
 
   bool opaque = SkColorGetA(background_color_) == SK_AlphaOPAQUE;
-  get_root_layer()->SetFillsBoundsOpaquely(opaque);
-  get_root_layer()->SetColor(background_color_);
+  root_layer()->SetFillsBoundsOpaquely(opaque);
+  root_layer()->SetColor(background_color_);
 
   ui::ContextFactory* context_factory = content::GetContextFactory();
   compositor_ = std::make_unique<ui::Compositor>(
@@ -306,7 +306,7 @@ void OffScreenRenderWidgetHostView::ShowWithVisibility(
 
   delegated_frame_host_->AttachToCompositor(compositor_.get());
   delegated_frame_host_->WasShown(GetLocalSurfaceId(),
-                                  get_root_layer()->bounds().size(), {});
+                                  root_layer()->bounds().size(), {});
 
   if (render_widget_host_)
     render_widget_host_->WasShown({});
@@ -988,10 +988,10 @@ void OffScreenRenderWidgetHostView::ResizeRootLayer(bool force) {
 
   gfx::Size size = GetViewBounds().size();
 
-  if (!force && !sf_did_change && size == get_root_layer()->bounds().size())
+  if (!force && !sf_did_change && size == root_layer()->bounds().size())
     return;
 
-  get_root_layer()->SetBounds(gfx::Rect(size));
+  root_layer()->SetBounds(gfx::Rect(size));
 
   const gfx::Size& size_in_pixels =
       gfx::ToFlooredSize(gfx::ConvertSizeToPixels(size, sf));
@@ -1031,8 +1031,8 @@ void OffScreenRenderWidgetHostView::UpdateBackgroundColorFromRenderer(
   background_color_ = color;
 
   bool opaque = SkColorGetA(color) == SK_AlphaOPAQUE;
-  get_root_layer()->SetFillsBoundsOpaquely(opaque);
-  get_root_layer()->SetColor(color);
+  root_layer()->SetFillsBoundsOpaquely(opaque);
+  root_layer()->SetColor(color);
 }
 
 void OffScreenRenderWidgetHostView::NotifyHostAndDelegateOnWasShown(

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -135,7 +135,7 @@ class ElectronDelegatedFrameHostClient
       const ElectronDelegatedFrameHostClient&) = delete;
 
   ui::Layer* DelegatedFrameHostGetLayer() const override {
-    return view_->GetRootLayer();
+    return view_->get_root_layer();
   }
 
   bool DelegatedFrameHostIsVisible() const override {
@@ -214,8 +214,8 @@ OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
   root_layer_ = std::make_unique<ui::Layer>(ui::LAYER_SOLID_COLOR);
 
   bool opaque = SkColorGetA(background_color_) == SK_AlphaOPAQUE;
-  GetRootLayer()->SetFillsBoundsOpaquely(opaque);
-  GetRootLayer()->SetColor(background_color_);
+  get_root_layer()->SetFillsBoundsOpaquely(opaque);
+  get_root_layer()->SetColor(background_color_);
 
   ui::ContextFactory* context_factory = content::GetContextFactory();
   compositor_ = std::make_unique<ui::Compositor>(
@@ -234,8 +234,8 @@ OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
     video_consumer_ = std::make_unique<OffScreenVideoConsumer>(
         this, base::BindRepeating(&OffScreenRenderWidgetHostView::OnPaint,
                                   weak_ptr_factory_.GetWeakPtr()));
-    video_consumer_->SetActive(IsPainting());
-    video_consumer_->SetFrameRate(GetFrameRate());
+    video_consumer_->SetActive(is_painting());
+    video_consumer_->SetFrameRate(get_frame_rate());
   }
 }
 
@@ -262,7 +262,7 @@ void OffScreenRenderWidgetHostView::InitAsChild(gfx::NativeView) {
   parent_host_view_->Hide();
 
   ResizeRootLayer(false);
-  SetPainting(parent_host_view_->IsPainting());
+  SetPainting(parent_host_view_->is_painting());
 }
 
 void OffScreenRenderWidgetHostView::SetSize(const gfx::Size& size) {
@@ -294,7 +294,7 @@ bool OffScreenRenderWidgetHostView::HasFocus() {
 }
 
 bool OffScreenRenderWidgetHostView::IsSurfaceAvailableForCopy() {
-  return GetDelegatedFrameHost()->CanCopyFromCompositingSurface();
+  return get_delegated_frame_host()->CanCopyFromCompositingSurface();
 }
 
 void OffScreenRenderWidgetHostView::ShowWithVisibility(
@@ -306,7 +306,7 @@ void OffScreenRenderWidgetHostView::ShowWithVisibility(
 
   delegated_frame_host_->AttachToCompositor(compositor_.get());
   delegated_frame_host_->WasShown(GetLocalSurfaceId(),
-                                  GetRootLayer()->bounds().size(), {});
+                                  get_root_layer()->bounds().size(), {});
 
   if (render_widget_host_)
     render_widget_host_->WasShown({});
@@ -320,9 +320,9 @@ void OffScreenRenderWidgetHostView::Hide() {
     render_widget_host_->WasHidden();
 
   // TODO(deermichel): correct or kOther?
-  GetDelegatedFrameHost()->WasHidden(
+  get_delegated_frame_host()->WasHidden(
       content::DelegatedFrameHost::HiddenCause::kOccluded);
-  GetDelegatedFrameHost()->DetachFromCompositor();
+  get_delegated_frame_host()->DetachFromCompositor();
 
   is_showing_ = false;
 }
@@ -384,9 +384,9 @@ void OffScreenRenderWidgetHostView::TakeFallbackContentFrom(
               ->IsRenderWidgetHostViewChildFrame());
   auto* view_osr = static_cast<OffScreenRenderWidgetHostView*>(view);
   SetBackgroundColor(view_osr->background_color_);
-  if (GetDelegatedFrameHost() && view_osr->GetDelegatedFrameHost()) {
-    GetDelegatedFrameHost()->TakeFallbackContentFrom(
-        view_osr->GetDelegatedFrameHost());
+  if (get_delegated_frame_host() && view_osr->get_delegated_frame_host()) {
+    get_delegated_frame_host()->TakeFallbackContentFrom(
+        view_osr->get_delegated_frame_host());
   }
 }
 
@@ -397,11 +397,11 @@ void OffScreenRenderWidgetHostView::
 
 void OffScreenRenderWidgetHostView::UpdateFrameSinkIdRegistration() {
   RenderWidgetHostViewBase::UpdateFrameSinkIdRegistration();
-  GetDelegatedFrameHost()->SetIsFrameSinkIdOwner(is_frame_sink_id_owner());
+  get_delegated_frame_host()->SetIsFrameSinkIdOwner(is_frame_sink_id_owner());
 }
 
 void OffScreenRenderWidgetHostView::ResetFallbackToFirstNavigationSurface() {
-  GetDelegatedFrameHost()->ResetFallbackToFirstNavigationSurface();
+  get_delegated_frame_host()->ResetFallbackToFirstNavigationSurface();
 }
 
 void OffScreenRenderWidgetHostView::InitAsPopup(
@@ -423,7 +423,7 @@ void OffScreenRenderWidgetHostView::InitAsPopup(
   popup_position_ = bounds;
 
   ResizeRootLayer(true);
-  SetPainting(parent_host_view_->IsPainting());
+  SetPainting(parent_host_view_->is_painting());
   Show();
 }
 
@@ -483,8 +483,8 @@ void OffScreenRenderWidgetHostView::CopyFromSurface(
     const gfx::Rect& src_rect,
     const gfx::Size& output_size,
     base::OnceCallback<void(const SkBitmap&)> callback) {
-  GetDelegatedFrameHost()->CopyFromCompositingSurface(src_rect, output_size,
-                                                      std::move(callback));
+  get_delegated_frame_host()->CopyFromCompositingSurface(src_rect, output_size,
+                                                         std::move(callback));
 }
 
 display::ScreenInfo OffScreenRenderWidgetHostView::GetScreenInfo() const {
@@ -516,8 +516,8 @@ void OffScreenRenderWidgetHostView::SetDisplayFeatureForTesting(
     const content::DisplayFeature* display_feature) {}
 
 viz::SurfaceId OffScreenRenderWidgetHostView::GetCurrentSurfaceId() const {
-  return GetDelegatedFrameHost()
-             ? GetDelegatedFrameHost()->GetCurrentSurfaceId()
+  return get_delegated_frame_host()
+             ? get_delegated_frame_host()->GetCurrentSurfaceId()
              : viz::SurfaceId();
 }
 
@@ -558,12 +558,12 @@ OffScreenRenderWidgetHostView::CreateViewForWidget(
   }
 
   return new OffScreenRenderWidgetHostView(
-      transparent_, true, embedder_host_view->GetFrameRate(), callback_,
+      transparent_, true, embedder_host_view->get_frame_rate(), callback_,
       render_widget_host, embedder_host_view, size());
 }
 
 const viz::FrameSinkId& OffScreenRenderWidgetHostView::GetFrameSinkId() const {
-  return GetDelegatedFrameHost()->frame_sink_id();
+  return get_delegated_frame_host()->frame_sink_id();
 }
 
 void OffScreenRenderWidgetHostView::DidNavigate() {
@@ -645,7 +645,7 @@ OffScreenRenderWidgetHostView::CreateHostDisplayClient(
       gfx::kNullAcceleratedWidget,
       base::BindRepeating(&OffScreenRenderWidgetHostView::OnPaint,
                           weak_ptr_factory_.GetWeakPtr()));
-  host_display_client_->SetActive(IsPainting());
+  host_display_client_->SetActive(is_painting());
   return base::WrapUnique(host_display_client_.get());
 }
 
@@ -915,22 +915,18 @@ void OffScreenRenderWidgetHostView::SetPainting(bool painting) {
     guest_host_view->SetPainting(painting);
 
   if (video_consumer_) {
-    video_consumer_->SetActive(IsPainting());
+    video_consumer_->SetActive(is_painting());
   } else if (host_display_client_) {
-    host_display_client_->SetActive(IsPainting());
+    host_display_client_->SetActive(is_painting());
   }
-}
-
-bool OffScreenRenderWidgetHostView::IsPainting() const {
-  return painting_;
 }
 
 void OffScreenRenderWidgetHostView::SetFrameRate(int frame_rate) {
   if (parent_host_view_) {
-    if (parent_host_view_->GetFrameRate() == GetFrameRate())
+    if (parent_host_view_->get_frame_rate() == get_frame_rate())
       return;
 
-    frame_rate_ = parent_host_view_->GetFrameRate();
+    frame_rate_ = parent_host_view_->get_frame_rate();
   } else {
     if (frame_rate <= 0)
       frame_rate = 1;
@@ -943,29 +939,16 @@ void OffScreenRenderWidgetHostView::SetFrameRate(int frame_rate) {
   SetupFrameRate(true);
 
   if (video_consumer_) {
-    video_consumer_->SetFrameRate(GetFrameRate());
+    video_consumer_->SetFrameRate(get_frame_rate());
   }
 
   for (auto* guest_host_view : guest_host_views_)
     guest_host_view->SetFrameRate(frame_rate);
 }
 
-int OffScreenRenderWidgetHostView::GetFrameRate() const {
-  return frame_rate_;
-}
-
-ui::Layer* OffScreenRenderWidgetHostView::GetRootLayer() const {
-  return root_layer_.get();
-}
-
 const viz::LocalSurfaceId& OffScreenRenderWidgetHostView::GetLocalSurfaceId()
     const {
   return delegated_frame_host_surface_id_;
-}
-
-content::DelegatedFrameHost*
-OffScreenRenderWidgetHostView::GetDelegatedFrameHost() const {
-  return delegated_frame_host_.get();
 }
 
 void OffScreenRenderWidgetHostView::SetupFrameRate(bool force) {
@@ -1005,10 +988,10 @@ void OffScreenRenderWidgetHostView::ResizeRootLayer(bool force) {
 
   gfx::Size size = GetViewBounds().size();
 
-  if (!force && !sf_did_change && size == GetRootLayer()->bounds().size())
+  if (!force && !sf_did_change && size == get_root_layer()->bounds().size())
     return;
 
-  GetRootLayer()->SetBounds(gfx::Rect(size));
+  get_root_layer()->SetBounds(gfx::Rect(size));
 
   const gfx::Size& size_in_pixels =
       gfx::ToFlooredSize(gfx::ConvertSizeToPixels(size, sf));
@@ -1023,7 +1006,7 @@ void OffScreenRenderWidgetHostView::ResizeRootLayer(bool force) {
   delegated_frame_host_surface_id_ =
       delegated_frame_host_allocator_.GetCurrentLocalSurfaceId();
 
-  GetDelegatedFrameHost()->EmbedSurface(
+  get_delegated_frame_host()->EmbedSurface(
       delegated_frame_host_surface_id_, size,
       cc::DeadlinePolicy::UseDefaultDeadline());
 
@@ -1048,8 +1031,8 @@ void OffScreenRenderWidgetHostView::UpdateBackgroundColorFromRenderer(
   background_color_ = color;
 
   bool opaque = SkColorGetA(color) == SK_AlphaOPAQUE;
-  GetRootLayer()->SetFillsBoundsOpaquely(opaque);
-  GetRootLayer()->SetColor(color);
+  get_root_layer()->SetFillsBoundsOpaquely(opaque);
+  get_root_layer()->SetColor(color);
 }
 
 void OffScreenRenderWidgetHostView::NotifyHostAndDelegateOnWasShown(

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -294,7 +294,7 @@ bool OffScreenRenderWidgetHostView::HasFocus() {
 }
 
 bool OffScreenRenderWidgetHostView::IsSurfaceAvailableForCopy() {
-  return get_delegated_frame_host()->CanCopyFromCompositingSurface();
+  return delegated_frame_host()->CanCopyFromCompositingSurface();
 }
 
 void OffScreenRenderWidgetHostView::ShowWithVisibility(
@@ -320,9 +320,9 @@ void OffScreenRenderWidgetHostView::Hide() {
     render_widget_host_->WasHidden();
 
   // TODO(deermichel): correct or kOther?
-  get_delegated_frame_host()->WasHidden(
+  delegated_frame_host()->WasHidden(
       content::DelegatedFrameHost::HiddenCause::kOccluded);
-  get_delegated_frame_host()->DetachFromCompositor();
+  delegated_frame_host()->DetachFromCompositor();
 
   is_showing_ = false;
 }
@@ -384,9 +384,9 @@ void OffScreenRenderWidgetHostView::TakeFallbackContentFrom(
               ->IsRenderWidgetHostViewChildFrame());
   auto* view_osr = static_cast<OffScreenRenderWidgetHostView*>(view);
   SetBackgroundColor(view_osr->background_color_);
-  if (get_delegated_frame_host() && view_osr->get_delegated_frame_host()) {
-    get_delegated_frame_host()->TakeFallbackContentFrom(
-        view_osr->get_delegated_frame_host());
+  if (delegated_frame_host() && view_osr->delegated_frame_host()) {
+    delegated_frame_host()->TakeFallbackContentFrom(
+        view_osr->delegated_frame_host());
   }
 }
 
@@ -397,11 +397,11 @@ void OffScreenRenderWidgetHostView::
 
 void OffScreenRenderWidgetHostView::UpdateFrameSinkIdRegistration() {
   RenderWidgetHostViewBase::UpdateFrameSinkIdRegistration();
-  get_delegated_frame_host()->SetIsFrameSinkIdOwner(is_frame_sink_id_owner());
+  delegated_frame_host()->SetIsFrameSinkIdOwner(is_frame_sink_id_owner());
 }
 
 void OffScreenRenderWidgetHostView::ResetFallbackToFirstNavigationSurface() {
-  get_delegated_frame_host()->ResetFallbackToFirstNavigationSurface();
+  delegated_frame_host()->ResetFallbackToFirstNavigationSurface();
 }
 
 void OffScreenRenderWidgetHostView::InitAsPopup(
@@ -483,8 +483,8 @@ void OffScreenRenderWidgetHostView::CopyFromSurface(
     const gfx::Rect& src_rect,
     const gfx::Size& output_size,
     base::OnceCallback<void(const SkBitmap&)> callback) {
-  get_delegated_frame_host()->CopyFromCompositingSurface(src_rect, output_size,
-                                                         std::move(callback));
+  delegated_frame_host()->CopyFromCompositingSurface(src_rect, output_size,
+                                                     std::move(callback));
 }
 
 display::ScreenInfo OffScreenRenderWidgetHostView::GetScreenInfo() const {
@@ -516,9 +516,8 @@ void OffScreenRenderWidgetHostView::SetDisplayFeatureForTesting(
     const content::DisplayFeature* display_feature) {}
 
 viz::SurfaceId OffScreenRenderWidgetHostView::GetCurrentSurfaceId() const {
-  return get_delegated_frame_host()
-             ? get_delegated_frame_host()->GetCurrentSurfaceId()
-             : viz::SurfaceId();
+  return delegated_frame_host() ? delegated_frame_host()->GetCurrentSurfaceId()
+                                : viz::SurfaceId();
 }
 
 std::unique_ptr<content::SyntheticGestureTarget>
@@ -563,7 +562,7 @@ OffScreenRenderWidgetHostView::CreateViewForWidget(
 }
 
 const viz::FrameSinkId& OffScreenRenderWidgetHostView::GetFrameSinkId() const {
-  return get_delegated_frame_host()->frame_sink_id();
+  return delegated_frame_host()->frame_sink_id();
 }
 
 void OffScreenRenderWidgetHostView::DidNavigate() {
@@ -1006,7 +1005,7 @@ void OffScreenRenderWidgetHostView::ResizeRootLayer(bool force) {
   delegated_frame_host_surface_id_ =
       delegated_frame_host_allocator_.GetCurrentLocalSurfaceId();
 
-  get_delegated_frame_host()->EmbedSurface(
+  delegated_frame_host()->EmbedSurface(
       delegated_frame_host_surface_id_, size,
       cc::DeadlinePolicy::UseDefaultDeadline());
 

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -727,10 +727,10 @@ void OffScreenRenderWidgetHostView::CompositeFrame(
       }
 
       for (auto* proxy_view : proxy_views_) {
-        gfx::Rect rect = proxy_view->GetBounds();
+        gfx::Rect rect = proxy_view->get_bounds();
         gfx::Point origin_in_pixels =
             gfx::ToFlooredPoint(gfx::ConvertPointToPixels(rect.origin(), sf));
-        canvas.writePixels(*proxy_view->GetBitmap(), origin_in_pixels.x(),
+        canvas.writePixels(*proxy_view->get_bitmap(), origin_in_pixels.x(),
                            origin_in_pixels.y());
       }
     }
@@ -786,7 +786,7 @@ void OffScreenRenderWidgetHostView::SynchronizeVisualProperties() {
 void OffScreenRenderWidgetHostView::SendMouseEvent(
     const blink::WebMouseEvent& event) {
   for (auto* proxy_view : proxy_views_) {
-    gfx::Rect bounds = proxy_view->GetBounds();
+    gfx::Rect bounds = proxy_view->get_bounds();
     if (bounds.Contains(event.PositionInWidget().x(),
                         event.PositionInWidget().y())) {
       blink::WebMouseEvent proxy_event(event);
@@ -824,7 +824,7 @@ void OffScreenRenderWidgetHostView::SendMouseEvent(
 void OffScreenRenderWidgetHostView::SendMouseWheelEvent(
     const blink::WebMouseWheelEvent& event) {
   for (auto* proxy_view : proxy_views_) {
-    gfx::Rect bounds = proxy_view->GetBounds();
+    gfx::Rect bounds = proxy_view->get_bounds();
     if (bounds.Contains(event.PositionInWidget().x(),
                         event.PositionInWidget().y())) {
       blink::WebMouseWheelEvent proxy_event(event);

--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -217,7 +217,7 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
 
   ui::Layer* root_layer() const { return root_layer_.get(); }
 
-  content::DelegatedFrameHost* get_delegated_frame_host() const {
+  content::DelegatedFrameHost* delegated_frame_host() const {
     return delegated_frame_host_.get();
   }
 

--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -210,14 +210,16 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
   void SendMouseWheelEvent(const blink::WebMouseWheelEvent& event);
 
   void SetPainting(bool painting);
-  bool IsPainting() const;
+  bool is_painting() const { return painting_; }
 
   void SetFrameRate(int frame_rate);
-  int GetFrameRate() const;
+  int get_frame_rate() const { return frame_rate_; }
 
-  ui::Layer* GetRootLayer() const;
+  ui::Layer* get_root_layer() const { return root_layer_.get(); }
 
-  content::DelegatedFrameHost* GetDelegatedFrameHost() const;
+  content::DelegatedFrameHost* get_delegated_frame_host() const {
+    return delegated_frame_host_.get();
+  }
 
   void Invalidate();
   void InvalidateBounds(const gfx::Rect&);

--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -215,7 +215,7 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
   void SetFrameRate(int frame_rate);
   int get_frame_rate() const { return frame_rate_; }
 
-  ui::Layer* get_root_layer() const { return root_layer_.get(); }
+  ui::Layer* root_layer() const { return root_layer_.get(); }
 
   content::DelegatedFrameHost* get_delegated_frame_host() const {
     return delegated_frame_host_.get();

--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -213,7 +213,7 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
   bool is_painting() const { return painting_; }
 
   void SetFrameRate(int frame_rate);
-  int get_frame_rate() const { return frame_rate_; }
+  int frame_rate() const { return frame_rate_; }
 
   ui::Layer* root_layer() const { return root_layer_.get(); }
 

--- a/shell/browser/osr/osr_video_consumer.cc
+++ b/shell/browser/osr/osr_video_consumer.cc
@@ -42,7 +42,7 @@ OffScreenVideoConsumer::OffScreenVideoConsumer(
   video_capturer_->SetFormat(media::PIXEL_FORMAT_ARGB);
 
   SizeChanged(view_->SizeInPixels());
-  SetFrameRate(view_->GetFrameRate());
+  SetFrameRate(view_->get_frame_rate());
 }
 
 OffScreenVideoConsumer::~OffScreenVideoConsumer() = default;

--- a/shell/browser/osr/osr_video_consumer.cc
+++ b/shell/browser/osr/osr_video_consumer.cc
@@ -42,7 +42,7 @@ OffScreenVideoConsumer::OffScreenVideoConsumer(
   video_capturer_->SetFormat(media::PIXEL_FORMAT_ARGB);
 
   SizeChanged(view_->SizeInPixels());
-  SetFrameRate(view_->get_frame_rate());
+  SetFrameRate(view_->frame_rate());
 }
 
 OffScreenVideoConsumer::~OffScreenVideoConsumer() = default;

--- a/shell/browser/osr/osr_view_proxy.cc
+++ b/shell/browser/osr/osr_view_proxy.cc
@@ -29,20 +29,12 @@ void OffscreenViewProxy::RemoveObserver() {
   observer_ = nullptr;
 }
 
-const SkBitmap* OffscreenViewProxy::GetBitmap() const {
-  return view_bitmap_.get();
-}
-
 void OffscreenViewProxy::SetBitmap(const SkBitmap& bitmap) {
   if (view_bounds_.width() == bitmap.width() &&
       view_bounds_.height() == bitmap.height() && observer_) {
     view_bitmap_ = std::make_unique<SkBitmap>(bitmap);
     observer_->OnProxyViewPaint(view_bounds_);
   }
-}
-
-const gfx::Rect& OffscreenViewProxy::GetBounds() {
-  return view_bounds_;
 }
 
 void OffscreenViewProxy::SetBounds(const gfx::Rect& bounds) {

--- a/shell/browser/osr/osr_view_proxy.h
+++ b/shell/browser/osr/osr_view_proxy.h
@@ -31,10 +31,10 @@ class OffscreenViewProxy {
   void SetObserver(OffscreenViewProxyObserver* observer);
   void RemoveObserver();
 
-  const SkBitmap* GetBitmap() const;
+  const SkBitmap* get_bitmap() const { return view_bitmap_.get(); }
   void SetBitmap(const SkBitmap& bitmap);
 
-  const gfx::Rect& GetBounds();
+  const gfx::Rect& get_bounds() { return view_bounds_; }
   void SetBounds(const gfx::Rect& bounds);
 
   void OnEvent(ui::Event* event);

--- a/shell/browser/osr/osr_view_proxy.h
+++ b/shell/browser/osr/osr_view_proxy.h
@@ -31,10 +31,10 @@ class OffscreenViewProxy {
   void SetObserver(OffscreenViewProxyObserver* observer);
   void RemoveObserver();
 
-  const SkBitmap* get_bitmap() const { return view_bitmap_.get(); }
+  const SkBitmap* bitmap() const { return view_bitmap_.get(); }
   void SetBitmap(const SkBitmap& bitmap);
 
-  const gfx::Rect& get_bounds() { return view_bounds_; }
+  const gfx::Rect& bounds() { return view_bounds_; }
   void SetBounds(const gfx::Rect& bounds);
 
   void OnEvent(ui::Event* event);

--- a/shell/browser/osr/osr_web_contents_view.cc
+++ b/shell/browser/osr/osr_web_contents_view.cc
@@ -139,7 +139,7 @@ OffScreenWebContentsView::CreateViewForChildWidget(
           : web_contents_impl->GetRenderWidgetHostView());
 
   return new OffScreenRenderWidgetHostView(transparent_, painting_,
-                                           view->GetFrameRate(), callback_,
+                                           view->get_frame_rate(), callback_,
                                            render_widget_host, view, GetSize());
 }
 
@@ -191,12 +191,9 @@ void OffScreenWebContentsView::SetPainting(bool painting) {
 }
 
 bool OffScreenWebContentsView::IsPainting() const {
-  auto* view = GetView();
-  if (view != nullptr) {
-    return view->IsPainting();
-  } else {
-    return painting_;
-  }
+  if (auto* view = GetView())
+    return view->is_painting();
+  return painting_;
 }
 
 void OffScreenWebContentsView::SetFrameRate(int frame_rate) {
@@ -208,12 +205,9 @@ void OffScreenWebContentsView::SetFrameRate(int frame_rate) {
 }
 
 int OffScreenWebContentsView::GetFrameRate() const {
-  auto* view = GetView();
-  if (view != nullptr) {
-    return view->GetFrameRate();
-  } else {
-    return frame_rate_;
-  }
+  if (auto* view = GetView())
+    return view->get_frame_rate();
+  return frame_rate_;
 }
 
 OffScreenRenderWidgetHostView* OffScreenWebContentsView::GetView() const {

--- a/shell/browser/osr/osr_web_contents_view.cc
+++ b/shell/browser/osr/osr_web_contents_view.cc
@@ -139,7 +139,7 @@ OffScreenWebContentsView::CreateViewForChildWidget(
           : web_contents_impl->GetRenderWidgetHostView());
 
   return new OffScreenRenderWidgetHostView(transparent_, painting_,
-                                           view->get_frame_rate(), callback_,
+                                           view->frame_rate(), callback_,
                                            render_widget_host, view, GetSize());
 }
 
@@ -206,7 +206,7 @@ void OffScreenWebContentsView::SetFrameRate(int frame_rate) {
 
 int OffScreenWebContentsView::GetFrameRate() const {
   if (auto* view = GetView())
-    return view->get_frame_rate();
+    return view->frame_rate();
   return frame_rate_;
 }
 

--- a/shell/browser/ui/views/root_view.cc
+++ b/shell/browser/ui/views/root_view.cc
@@ -84,10 +84,6 @@ void RootView::SetAutoHideMenuBar(bool auto_hide) {
   menu_bar_autohide_ = auto_hide;
 }
 
-bool RootView::IsMenuBarAutoHide() const {
-  return menu_bar_autohide_;
-}
-
 void RootView::SetMenuBarVisibility(bool visible) {
   if (!window_->content_view() || !menu_bar_ || menu_bar_visible_ == visible)
     return;
@@ -102,10 +98,6 @@ void RootView::SetMenuBarVisibility(bool visible) {
   }
 
   Layout();
-}
-
-bool RootView::IsMenuBarVisible() const {
-  return menu_bar_visible_;
 }
 
 void RootView::HandleKeyEvent(const content::NativeWebKeyboardEvent& event) {

--- a/shell/browser/ui/views/root_view.h
+++ b/shell/browser/ui/views/root_view.h
@@ -36,9 +36,9 @@ class RootView : public views::View {
   bool HasMenu() const;
   int GetMenuBarHeight() const;
   void SetAutoHideMenuBar(bool auto_hide);
-  bool IsMenuBarAutoHide() const;
+  bool is_menu_bar_auto_hide() const { return menu_bar_autohide_; }
   void SetMenuBarVisibility(bool visible);
-  bool IsMenuBarVisible() const;
+  bool is_menu_bar_visible() const { return menu_bar_visible_; }
   void HandleKeyEvent(const content::NativeWebKeyboardEvent& event);
   void ResetAltState();
   void RestoreFocus();

--- a/shell/browser/web_contents_zoom_controller.cc
+++ b/shell/browser/web_contents_zoom_controller.cc
@@ -333,7 +333,7 @@ void WebContentsZoomController::RenderFrameHostChanged(
 void WebContentsZoomController::SetZoomFactorOnNavigationIfNeeded(
     const GURL& url) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
-  if (blink::PageZoomValuesEqual(get_default_zoom_factor(), kPageZoomEpsilon))
+  if (blink::PageZoomValuesEqual(default_zoom_factor(), kPageZoomEpsilon))
     return;
 
   content::GlobalRenderFrameHostId old_rfh_id_ =
@@ -356,7 +356,7 @@ void WebContentsZoomController::SetZoomFactorOnNavigationIfNeeded(
   // pref store < kZoomFactor < setZoomLevel
   std::string host = net::GetHostOrSpecFromURL(url);
   std::string scheme = url.scheme();
-  double zoom_factor = get_default_zoom_factor();
+  double zoom_factor = default_zoom_factor();
   double zoom_level = blink::PageZoomFactorToZoomLevel(zoom_factor);
   if (host_zoom_map_->HasZoomLevel(scheme, host)) {
     zoom_level = host_zoom_map_->GetZoomLevelForHostAndScheme(scheme, host);

--- a/shell/browser/web_contents_zoom_controller.cc
+++ b/shell/browser/web_contents_zoom_controller.cc
@@ -142,10 +142,6 @@ void WebContentsZoomController::SetDefaultZoomFactor(double factor) {
   default_zoom_factor_ = factor;
 }
 
-double WebContentsZoomController::GetDefaultZoomFactor() {
-  return default_zoom_factor_;
-}
-
 void WebContentsZoomController::SetTemporaryZoomLevel(double level) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
   content::GlobalRenderFrameHostId old_rfh_id_ =
@@ -337,7 +333,7 @@ void WebContentsZoomController::RenderFrameHostChanged(
 void WebContentsZoomController::SetZoomFactorOnNavigationIfNeeded(
     const GURL& url) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
-  if (blink::PageZoomValuesEqual(GetDefaultZoomFactor(), kPageZoomEpsilon))
+  if (blink::PageZoomValuesEqual(get_default_zoom_factor(), kPageZoomEpsilon))
     return;
 
   content::GlobalRenderFrameHostId old_rfh_id_ =
@@ -360,7 +356,7 @@ void WebContentsZoomController::SetZoomFactorOnNavigationIfNeeded(
   // pref store < kZoomFactor < setZoomLevel
   std::string host = net::GetHostOrSpecFromURL(url);
   std::string scheme = url.scheme();
-  double zoom_factor = GetDefaultZoomFactor();
+  double zoom_factor = get_default_zoom_factor();
   double zoom_level = blink::PageZoomFactorToZoomLevel(zoom_factor);
   if (host_zoom_map_->HasZoomLevel(scheme, host)) {
     zoom_level = host_zoom_map_->GetZoomLevelForHostAndScheme(scheme, host);

--- a/shell/browser/web_contents_zoom_controller.h
+++ b/shell/browser/web_contents_zoom_controller.h
@@ -81,7 +81,7 @@ class WebContentsZoomController
   bool SetZoomLevel(double zoom_level);
 
   void SetDefaultZoomFactor(double factor);
-  double GetDefaultZoomFactor();
+  double get_default_zoom_factor() { return default_zoom_factor_; }
 
   // Sets the temporary zoom level through HostZoomMap.
   void SetTemporaryZoomLevel(double level);

--- a/shell/browser/web_contents_zoom_controller.h
+++ b/shell/browser/web_contents_zoom_controller.h
@@ -81,7 +81,7 @@ class WebContentsZoomController
   bool SetZoomLevel(double zoom_level);
 
   void SetDefaultZoomFactor(double factor);
-  double get_default_zoom_factor() { return default_zoom_factor_; }
+  double default_zoom_factor() { return default_zoom_factor_; }
 
   // Sets the temporary zoom level through HostZoomMap.
   void SetTemporaryZoomLevel(double level);


### PR DESCRIPTION
#### Description of Change

Follow the [Chromium C++ style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md) advice on [inline functions](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md#inline-functions):

> Simple accessors should generally be the only inline functions. These should be named using `snake_case()`. Virtual functions should never be declared this way.

This PR inlines some nonvirtual simple getters and uses `snake_case()` to denote that they are simple getters.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none