### PR TITLE
fix: ensure `WebContents` before checking draggable region

### DIFF
--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -81,11 +81,14 @@ void WebContentsView::SetBackgroundColor(std::optional<WrappedSkColor> color) {
 }
 
 int WebContentsView::NonClientHitTest(const gfx::Point& point) {
-  gfx::Point local_point(point);
-  views::View::ConvertPointFromWidget(view(), &local_point);
-  SkRegion* region = api_web_contents_->draggable_region();
-  if (region && region->contains(local_point.x(), local_point.y()))
-    return HTCAPTION;
+  if (api_web_contents_) {
+    gfx::Point local_point(point);
+    views::View::ConvertPointFromWidget(view(), &local_point);
+    SkRegion* region = api_web_contents_->draggable_region();
+    if (region && region->contains(local_point.x(), local_point.y()))
+      return HTCAPTION;
+  }
+
   return HTNOWHERE;
 }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/41142

Fixes an issue with potential crashes while closing or interacting with a WebContentsView after its associated WebContents has been cleaned up. We first need to ensure that `api_web_contents_` is not nullptr, as is done [several](https://github.com/electron/electron/blob/69a7f75a1a6c43908e4a5a81a841c926bc20a993/shell/browser/api/electron_api_web_contents_view.cc#L71) other [places](https://github.com/electron/electron/blob/69a7f75a1a6c43908e4a5a81a841c926bc20a993/shell/browser/api/electron_api_web_contents_view.cc#L63) in the same file.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash while closing or interacting with a WebContentsView after its associated WebContents has been cleaned up.