### PR TITLE
fix: validate `printToPDF` `margins` against `pageSize`

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -220,6 +220,16 @@ function parsePageSize (pageSize: string | ElectronInternal.PageSize) {
 let pendingPromise: Promise<any> | undefined;
 WebContents.prototype.printToPDF = async function (options) {
   const margins = checkType(options.margins ?? {}, 'object', 'margins');
+  const pageSize = parsePageSize(options.pageSize ?? 'letter');
+
+  const { top, bottom, left, right } = margins;
+  const validHeight = [top, bottom].every(u => u === undefined || u <= pageSize.paperHeight);
+  const validWidth = [left, right].every(u => u === undefined || u <= pageSize.paperWidth);
+
+  if (!validHeight || !validWidth) {
+    throw new Error('margins must be less than or equal to pageSize');
+  }
+
   const printSettings = {
     requestID: getNextId(),
     landscape: checkType(options.landscape ?? false, 'boolean', 'landscape'),
@@ -236,7 +246,7 @@ WebContents.prototype.printToPDF = async function (options) {
     preferCSSPageSize: checkType(options.preferCSSPageSize ?? false, 'boolean', 'preferCSSPageSize'),
     generateTaggedPDF: checkType(options.generateTaggedPDF ?? false, 'boolean', 'generateTaggedPDF'),
     generateDocumentOutline: checkType(options.generateDocumentOutline ?? false, 'boolean', 'generateDocumentOutline'),
-    ...parsePageSize(options.pageSize ?? 'letter')
+    ...pageSize
   };
 
   if (this._printToPDF) {

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2053,6 +2053,20 @@ describe('webContents module', () => {
       }
     });
 
+    it('rejects when margins exceed physical page size', async () => {
+      await w.loadURL('data:text/html,<h1>Hello, World!</h1>');
+
+      await expect(w.webContents.printToPDF({
+        pageSize: 'Letter',
+        margins: {
+          top: 100,
+          bottom: 100,
+          left: 5,
+          right: 5
+        }
+      })).to.eventually.be.rejectedWith('margins must be less than or equal to pageSize');
+    });
+
     it('does not crash when called multiple times in parallel', async () => {
       await w.loadURL('data:text/html,<h1>Hello, World!</h1>');
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/41064.

Fixes an issue where `webContents.printToPDF` could fail when certain combinations of `margins` and `pageSize` values are passed. Previously, the call would fail with a somewhat misleading `Content area is empty.` error. This happened because `print_to_pdf::GetPrintPagesParams()` calls `printing::RenderParamsFromPrintSettings`, which validates that the requested margins are less than or equal to the physical page size. If they exceed the physical page size, Chromium clamps them down to 0, which leads to the content area being empty. To address this, I've chosen to validate `margins` against `pageSize` and throw a more descriptive error.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where `webContents.printToPDF` could fail when certain combinations of `margins` and `pageSize` values are passed.
