### PR TITLE
fix: avoid potential `CHECK()` failure in `DictionaryToRect()`

### DIFF
--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -15,6 +15,7 @@
 #include "base/json/string_escape.h"
 #include "base/memory/raw_ptr.h"
 #include "base/metrics/histogram.h"
+#include "base/ranges/algorithm.h"
 #include "base/stl_util.h"
 #include "base/strings/pattern.h"
 #include "base/strings/string_number_conversions.h"
@@ -108,32 +109,16 @@ base::Value::Dict RectToDictionary(const gfx::Rect& bounds) {
 }
 
 gfx::Rect DictionaryToRect(const base::Value::Dict& dict) {
-  const base::Value* found = dict.Find("x");
-  int x = found ? found->GetInt() : 0;
-
-  found = dict.Find("y");
-  int y = found ? found->GetInt() : 0;
-
-  found = dict.Find("width");
-  int width = found ? found->GetInt() : 800;
-
-  found = dict.Find("height");
-  int height = found ? found->GetInt() : 600;
-
-  return gfx::Rect(x, y, width, height);
-}
-
-bool IsPointInRect(const gfx::Point& point, const gfx::Rect& rect) {
-  return point.x() > rect.x() && point.x() < (rect.width() + rect.x()) &&
-         point.y() > rect.y() && point.y() < (rect.height() + rect.y());
+  return gfx::Rect{dict.FindInt("x").value_or(0), dict.FindInt("y").value_or(0),
+                   dict.FindInt("width").value_or(800),
+                   dict.FindInt("height").value_or(600)};
 }
 
 bool IsPointInScreen(const gfx::Point& point) {
-  for (const auto& display : display::Screen::GetScreen()->GetAllDisplays()) {
-    if (IsPointInRect(point, display.bounds()))
-      return true;
-  }
-  return false;
+  return base::ranges::any_of(display::Screen::GetScreen()->GetAllDisplays(),
+                              [&point](auto const& display) {
+                                return display.bounds().Contains(point);
+                              });
 }
 
 void SetZoomLevelForWebContents(content::WebContents* web_contents,


### PR DESCRIPTION
#### Description of Change

Two small cleanups I came across while reading iwc.cc on an unrelated topic:

- fix: In `DictionaryToRect()`, replace `base::Value::GetInt()` calls with `base::Value::FindInt()` to avoid potential `CHECK()` failures. (We were calling GetInt() without confirming that the Value was an int)
- refactor: In `IsPointInScreen()`, use [`gfx::Rect::Contains()`](https://chromium.googlesource.com/chromium/src/+/main/ui/gfx/geometry/rect.cc#147) instead of reinventing the wheel. 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.