### PR TITLE
fix: `shouldPrintBackgrounds` -> `printBackground` in `webContents.printToPDF`

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3149,7 +3149,7 @@ v8::Local<v8::Promise> WebContents::PrintToPDF(const base::Value& settings) {
   auto landscape = settings.GetDict().FindBool("landscape");
   auto display_header_footer =
       settings.GetDict().FindBool("displayHeaderFooter");
-  auto print_background = settings.GetDict().FindBool("shouldPrintBackgrounds");
+  auto print_background = settings.GetDict().FindBool("printBackground");
   auto scale = settings.GetDict().FindDouble("scale");
   auto paper_width = settings.GetDict().FindDouble("paperWidth");
   auto paper_height = settings.GetDict().FindDouble("paperHeight");


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/41136.
Refs https://github.com/electron/electron/pull/40257.

Fixes an issue where the `printBackground` option in `webContents.printToPDF` did not work as expected. The name was changed from `shouldPrintBackgrounds` to `printBackground` at the JS layer and not in the corresponding location in C++. This fixes that.

Tested with https://gist.github.com/drivron/1e1be91efbbbbc61e4a528d0e362be9f

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the `printBackground` option in `webContents.printToPDF` did not work as expected. 
