### PR TITLE
refactor: simplify code by using base::Value::EnsureList()

### DIFF
--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -114,10 +114,7 @@ v8::Local<v8::Value> HttpResponseHeadersToV8(
         std::string filename = "\"" + header.filename() + "\"";
         value = decodedFilename + "; filename=" + filename;
       }
-      base::Value::List* values = response_headers.FindList(key);
-      if (!values)
-        values = &response_headers.Set(key, base::Value::List())->GetList();
-      values->Append(base::Value(value));
+      response_headers.EnsureList(key)->Append(value);
     }
   }
   return gin::ConvertToV8(v8::Isolate::GetCurrent(), response_headers);

--- a/shell/browser/api/gpu_info_enumerator.cc
+++ b/shell/browser/api/gpu_info_enumerator.cc
@@ -49,15 +49,7 @@ void GPUInfoEnumerator::EndGPUDevice() {
   auto& top_value = value_stack_.top();
   // GPUDevice can be more than one. So create a list of all.
   // The first one is the active GPU device.
-  if (base::Value* list_value = top_value.Find(kGPUDeviceKey)) {
-    DCHECK(list_value->is_list());
-    base::Value::List& list = list_value->GetList();
-    list.Append(std::move(current_));
-  } else {
-    base::Value::List gpus;
-    gpus.Append(std::move(current_));
-    top_value.Set(kGPUDeviceKey, std::move(gpus));
-  }
+  top_value.EnsureList(kGPUDeviceKey)->Append(std::move(current_));
   current_ = std::move(top_value);
   value_stack_.pop();
 }


### PR DESCRIPTION
#### Description of Change

Use  [`base::Value::EnsureList()`](https://chromium.googlesource.com/chromium/src/+/HEAD/base/values.h#391)  where appropriate to simplify our code. In particular, the new version of `GPUInfoEnumerator::EndGPUDevice()` is easier to read IMO.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.