### PR TITLE
feat: add app.setNodePreload API

### DIFF
--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -74,6 +74,7 @@ class App : public ElectronBrowserClient::Delegate,
 #endif
 
   base::FilePath GetAppPath() const;
+  const std::optional<base::FilePath>& GetNodePreload() const;
   void RenderProcessReady(content::RenderProcessHost* host);
   void RenderProcessExited(content::RenderProcessHost* host);
 
@@ -224,6 +225,8 @@ class App : public ElectronBrowserClient::Delegate,
   std::string GetUserAgentFallback();
   v8::Local<v8::Promise> SetProxy(gin::Arguments* args);
   v8::Local<v8::Promise> ResolveProxy(gin::Arguments* args);
+  void SetNodePreload(gin_helper::ErrorThrower thrower,
+                      std::optional<base::FilePath> preload);
 
 #if BUILDFLAG(IS_MAC)
   void SetActivationPolicy(gin_helper::ErrorThrower thrower,
@@ -261,6 +264,7 @@ class App : public ElectronBrowserClient::Delegate,
   base::CancelableTaskTracker cancelable_task_tracker_;
 
   base::FilePath app_path_;
+  std::optional<base::FilePath> preload_;
 
   // pid -> electron::ProcessMetric
   base::flat_map<int, std::unique_ptr<electron::ProcessMetric>> app_metrics_;

--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -21,6 +21,7 @@
 #include "gin/object_template_builder.h"
 #include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "shell/browser/api/electron_api_app.h"
 #include "shell/browser/api/message_port.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/browser/net/system_network_context_manager.h"
@@ -65,6 +66,10 @@ UtilityProcessWrapper::UtilityProcessWrapper(
     base::EnvironmentMap env_map,
     base::FilePath current_working_directory,
     bool use_plugin_helper) {
+  App* app = App::Get();
+  if (app->GetNodePreload())
+    params->preload = app->GetNodePreload();
+
 #if BUILDFLAG(IS_WIN)
   base::win::ScopedHandle stdout_write(nullptr);
   base::win::ScopedHandle stderr_write(nullptr);

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -548,8 +548,12 @@ void ElectronBrowserClient::AppendExtraCommandLineSwitches(
 #endif
 
     if (delegate_) {
-      auto app_path = static_cast<api::App*>(delegate_)->GetAppPath();
-      command_line->AppendSwitchPath(switches::kAppPath, app_path);
+      api::App* app = static_cast<api::App*>(delegate_);
+      command_line->AppendSwitchPath(switches::kAppPath, app->GetAppPath());
+      if (app->GetNodePreload()) {
+        command_line->AppendSwitchPath(switches::kNodePreload,
+                                       *app->GetNodePreload());
+      }
     }
 
     auto env = base::Environment::Create();

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -257,7 +257,9 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
   node_bindings_->set_uv_env(node_env_.get());
 
   // Load everything.
-  node_bindings_->LoadEnvironment(node_env_.get());
+  // Note that we are not passing preload script here, it is impossible for
+  // users to set preload script before we load app's main script.
+  node_bindings_->LoadEnvironment(node_env_.get(), std::nullopt);
 
   // Wait for app
   node_bindings_->JoinAppCode();

--- a/shell/common/application_info.cc
+++ b/shell/common/application_info.cc
@@ -4,14 +4,18 @@
 
 #include "shell/common/application_info.h"
 
+#include "base/base_paths.h"
+#include "base/command_line.h"
 #include "base/i18n/rtl.h"
 #include "base/no_destructor.h"
+#include "base/path_service.h"
 #include "base/strings/stringprintf.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/common/chrome_version.h"
 #include "content/public/common/user_agent.h"
 #include "electron/electron_version.h"
 #include "shell/browser/browser.h"
+#include "shell/common/mac/main_application_bundle.h"
 
 namespace electron {
 
@@ -54,6 +58,18 @@ bool IsAppRTL() {
   base::i18n::TextDirection text_direction =
       base::i18n::GetTextDirectionForLocaleInStartUp(locale.c_str());
   return text_direction == base::i18n::RIGHT_TO_LEFT;
+}
+
+base::FilePath GetResourcesPath() {
+#if BUILDFLAG(IS_MAC)
+  return MainApplicationBundlePath().Append("Contents").Append("Resources");
+#else
+  auto* command_line = base::CommandLine::ForCurrentProcess();
+  base::FilePath exec_path(command_line->GetProgram());
+  base::PathService::Get(base::FILE_EXE, &exec_path);
+
+  return exec_path.DirName().Append(FILE_PATH_LITERAL("resources"));
+#endif
 }
 
 }  // namespace electron

--- a/shell/common/application_info.h
+++ b/shell/common/application_info.h
@@ -13,6 +13,10 @@
 
 #include <string>
 
+namespace base {
+class FilePath;
+}
+
 namespace electron {
 
 std::string& OverriddenApplicationName();
@@ -24,6 +28,9 @@ std::string GetApplicationName();
 std::string GetApplicationVersion();
 // Returns the user agent of Electron.
 std::string GetApplicationUserAgent();
+
+// Get the path to app's resources dir, i.e. process.resourcesPath.
+base::FilePath GetResourcesPath();
 
 bool IsAppRTL();
 

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -107,7 +107,8 @@ class NodeBindings {
           std::nullopt);
 
   // Load node.js in the environment.
-  void LoadEnvironment(node::Environment* env);
+  void LoadEnvironment(node::Environment* env,
+                       std::optional<base::FilePath> preload);
 
   // Prepare embed thread for message loop integration.
   void PrepareEmbedThread();
@@ -219,11 +220,9 @@ class NodeBindings {
   base::WeakPtrFactory<NodeBindings> weak_factory_{this};
 };
 
-// A thread-safe function responsible for loading preload script which runs for
-// all node environments (including child processes and workers).
-void OnNodePreload(node::Environment* env,
-                   v8::Local<v8::Value> process,
-                   v8::Local<v8::Value> require);
+// Return Electron's EmbedderPreloadCallback.
+node::EmbedderPreloadCallback GetNodePreloadCallback(
+    std::optional<base::FilePath> preload);
 
 }  // namespace electron
 

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -236,6 +236,9 @@ const char kAppUserModelId[] = "app-user-model-id";
 // The application path
 const char kAppPath[] = "app-path";
 
+// Used to pass preload script to node and renderer processes.
+const char kNodePreload[] = "node-preload";
+
 // The command line switch versions of the options.
 const char kScrollBounce[] = "scroll-bounce";
 

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -116,6 +116,7 @@ extern const char kStreamingSchemes[];
 extern const char kCodeCacheSchemes[];
 extern const char kAppUserModelId[];
 extern const char kAppPath[];
+extern const char kNodePreload[];
 
 extern const char kScrollBounce[];
 extern const char kNodeIntegrationInWorker[];

--- a/shell/renderer/electron_renderer_client.h
+++ b/shell/renderer/electron_renderer_client.h
@@ -53,6 +53,7 @@ class ElectronRendererClient : public RendererClientBase {
 
   const std::unique_ptr<NodeBindings> node_bindings_;
   const std::unique_ptr<ElectronBindings> electron_bindings_;
+  std::optional<base::FilePath> node_preload_;
 
   // The node::Environment::GetCurrent API does not return nullptr when it
   // is called for a context without node::Environment, so we have to keep

--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -46,7 +46,8 @@ WebWorkerObserver::WebWorkerObserver()
 WebWorkerObserver::~WebWorkerObserver() = default;
 
 void WebWorkerObserver::WorkerScriptReadyForEvaluation(
-    v8::Local<v8::Context> worker_context) {
+    v8::Local<v8::Context> worker_context,
+    std::optional<base::FilePath> node_preload) {
   v8::Context::Scope context_scope(worker_context);
   auto* isolate = worker_context->GetIsolate();
   v8::MicrotasksScope microtasks_scope(
@@ -70,7 +71,7 @@ void WebWorkerObserver::WorkerScriptReadyForEvaluation(
   electron_bindings_->BindTo(env->isolate(), env->process_object());
 
   // Load everything.
-  node_bindings_->LoadEnvironment(env.get());
+  node_bindings_->LoadEnvironment(env.get(), std::move(node_preload));
 
   // Make uv loop being wrapped by window context.
   node_bindings_->set_uv_env(env.get());

--- a/shell/renderer/web_worker_observer.h
+++ b/shell/renderer/web_worker_observer.h
@@ -10,6 +10,10 @@
 #include "base/containers/flat_set.h"
 #include "v8/include/v8.h"
 
+namespace base {
+class FilePath;
+}
+
 namespace node {
 
 class Environment;
@@ -36,7 +40,9 @@ class WebWorkerObserver {
   WebWorkerObserver(const WebWorkerObserver&) = delete;
   WebWorkerObserver& operator=(const WebWorkerObserver&) = delete;
 
-  void WorkerScriptReadyForEvaluation(v8::Local<v8::Context> context);
+  void WorkerScriptReadyForEvaluation(
+      v8::Local<v8::Context> context,
+      std::optional<base::FilePath> node_preload);
   void ContextWillDestroy(v8::Local<v8::Context> context);
 
  private:

--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -130,7 +130,7 @@ void NodeService::Initialize(node::mojom::NodeServiceParamsPtr params) {
   // the exit handler set above will be triggered and it expects
   // both Node Env and JavaScriptEnvironment are setup to perform
   // a clean shutdown of this process.
-  node_bindings_->LoadEnvironment(node_env_.get());
+  node_bindings_->LoadEnvironment(node_env_.get(), std::move(params->preload));
 
   // Run entry script.
   node_bindings_->PrepareEmbedThread();

--- a/shell/services/node/public/mojom/node_service.mojom
+++ b/shell/services/node/public/mojom/node_service.mojom
@@ -12,6 +12,7 @@ import "third_party/blink/public/mojom/messaging/message_port_descriptor.mojom";
 
 struct NodeServiceParams {
   mojo_base.mojom.FilePath script;
+  mojo_base.mojom.FilePath? preload;
   array<string> args;
   array<string> exec_args;
   blink.mojom.MessagePortDescriptor port;

--- a/spec/fixtures/apps/print-process/main.js
+++ b/spec/fixtures/apps/print-process/main.js
@@ -1,0 +1,2 @@
+console.log(process.preloadRun);
+process.exit(0);

--- a/spec/fixtures/apps/print-process/package.json
+++ b/spec/fixtures/apps/print-process/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "electron-test-print-process",
+  "main": "main.js"
+}

--- a/spec/fixtures/module/node-preload.js
+++ b/spec/fixtures/module/node-preload.js
@@ -1,0 +1,5 @@
+process.preloadRun = true;
+
+exports.onBuiltinModulesPatched = () => {
+  require('node:module')._nodeModulePaths = () => { return ['patched']; };
+};

--- a/spec/fixtures/module/send-process.js
+++ b/spec/fixtures/module/send-process.js
@@ -1,0 +1,1 @@
+process.send(process);

--- a/spec/fixtures/module/utility-post-process.js
+++ b/spec/fixtures/module/utility-post-process.js
@@ -1,0 +1,1 @@
+process.parentPort.postMessage(JSON.stringify(process));

--- a/spec/fixtures/module/worker-post-process.js
+++ b/spec/fixtures/module/worker-post-process.js
@@ -1,0 +1,2 @@
+const { parentPort } = require('node:worker_threads');
+parentPort.postMessage(JSON.stringify(process));


### PR DESCRIPTION
#### Description of Change

For certain apps they want stricter security checks than the default settings provided by Electron. For example in VS Code, they restrict module search paths in certain locations, and forbids file operations into UNC locations.

The `app.setNodePreload` API provides them a way to apply the restrictions reliably without patching Electron.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Add `app.setNodePreload` API.