### PR TITLE
fix: `select-usb-device` should respect `filters` option

### DIFF
--- a/shell/browser/usb/usb_chooser_controller.cc
+++ b/shell/browser/usb/usb_chooser_controller.cc
@@ -120,6 +120,14 @@ void UsbChooserController::GotUsbDeviceList(
     auto* rfh = content::RenderFrameHost::FromID(render_frame_host_id_);
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
     v8::HandleScope scope(isolate);
+
+    // "select-usb-device" should respect |filters|.
+    devices.erase(std::remove_if(devices.begin(), devices.end(),
+                                 [this](const auto& device_info) {
+                                   return !DisplayDevice(*device_info);
+                                 }),
+                  devices.end());
+
     v8::Local<v8::Object> details = gin::DataObjectBuilder(isolate)
                                         .Set("deviceList", devices)
                                         .Set("frame", rfh)


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/39279.

Fixes an issue where `select-usb-device` did not respect the `filter` option in `navigator.usb.requestDevice()`. This is respected in Chromium using [this logic](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/usb/usb_chooser_controller.cc;l=245-253) which was missing in our own. To fix this, remove filtered items from the vector prior to creating the `v8::Object` to emit in the event.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `select-usb-device` did not respect the `filter` option in `navigator.usb.requestDevice()`.