### PR TITLE
refactor: use base::Value::Take*()

### DIFF
--- a/shell/browser/extensions/electron_extension_system.cc
+++ b/shell/browser/extensions/electron_extension_system.cc
@@ -103,7 +103,7 @@ std::unique_ptr<base::Value::Dict> ParseManifest(
     LOG(ERROR) << "Failed to parse extension manifest.";
     return std::unique_ptr<base::Value::Dict>();
   }
-  return std::make_unique<base::Value::Dict>(std::move(manifest->GetDict()));
+  return std::make_unique<base::Value::Dict>(std::move(*manifest).TakeDict());
 }
 
 void ElectronExtensionSystem::LoadComponentExtensions() {

--- a/shell/common/asar/archive.cc
+++ b/shell/common/asar/archive.cc
@@ -270,7 +270,7 @@ bool Archive::Init() {
   }
 
   header_size_ = 8 + size;
-  header_ = std::move(value->GetDict());
+  header_ = std::move(*value).TakeDict();
   return true;
 }
 

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -244,10 +244,8 @@ bool Converter<net::HttpRequestHeaders>::FromV8(v8::Isolate* isolate,
   if (!ConvertFromV8(isolate, val, &dict))
     return false;
   for (const auto it : dict) {
-    if (it.second.is_string()) {
-      std::string value = it.second.GetString();
-      out->SetHeader(it.first, value);
-    }
+    if (it.second.is_string())
+      out->SetHeader(it.first, std::move(it.second).TakeString());
   }
   return true;
 }

--- a/shell/common/gin_converters/value_converter.cc
+++ b/shell/common/gin_converters/value_converter.cc
@@ -18,7 +18,7 @@ bool Converter<base::Value::Dict>::FromV8(v8::Isolate* isolate,
       content::V8ValueConverter::Create()->FromV8Value(
           val, isolate->GetCurrentContext());
   if (value && value->is_dict()) {
-    *out = std::move(value->GetDict());
+    *out = std::move(*value).TakeDict();
     return true;
   } else {
     return false;
@@ -53,7 +53,7 @@ bool Converter<base::Value::List>::FromV8(v8::Isolate* isolate,
       content::V8ValueConverter::Create()->FromV8Value(
           val, isolate->GetCurrentContext());
   if (value && value->is_list()) {
-    *out = std::move(value->GetList());
+    *out = std::move(*value).TakeList();
     return true;
   } else {
     return false;


### PR DESCRIPTION
#### Description of Change

Use `base::Value::TakeDict()`, `TakeList()`, and `TakeString()` where appropriate.

1. The docs recommend changing our current `std::move(value.Get*())` to `std::move(value).Take*()` for better build-time checks.
2. In some cases, e.g. when we're pulling data out of  a temporary `base::Value::Dict`, we can avoid extra work by `Take*()`ing objects directly from the temporary dict instead of copying them.

Description from [values.h code comments](https://chromium.googlesource.com/chromium/src/+/main/base/values.h#282):

>   // Transfers ownership of the underlying value. Similarly to `Get...()`
  // variants above, fails with a `CHECK()` on a type mismatch. After
  // transferring the ownership `*this` is in a valid, but unspecified, state.
  // Prefer over `std::move(value.Get...())` so clang-tidy can warn about
  // potential use-after-move mistakes.
  std::string TakeString() &&;
  Dict TakeDict() &&;
  List TakeList() &&;

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.