### PR TITLE
build: export matching patches

### DIFF
--- a/patches/config.json
+++ b/patches/config.json
@@ -1,27 +1,15 @@
-{
-  "src/electron/patches/chromium": "src",
-
-  "src/electron/patches/boringssl": "src/third_party/boringssl/src",
-
-  "src/electron/patches/devtools_frontend": "src/third_party/devtools-frontend/src",
-
-  "src/electron/patches/ffmpeg": "src/third_party/ffmpeg",
-
-  "src/electron/patches/v8":  "src/v8",
-
-  "src/electron/patches/node": "src/third_party/electron_node",
-
-  "src/electron/patches/nan": "src/third_party/nan",
-
-  "src/electron/patches/perfetto": "src/third_party/perfetto",
-
-  "src/electron/patches/squirrel.mac": "src/third_party/squirrel.mac",
-
-  "src/electron/patches/Mantle": "src/third_party/squirrel.mac/vendor/Mantle",
-
-  "src/electron/patches/ReactiveObjC": "src/third_party/squirrel.mac/vendor/ReactiveObjC",
-
-  "src/electron/patches/webrtc": "src/third_party/webrtc",
-
-  "src/electron/patches/reclient-configs": "src/third_party/engflow-reclient-configs"
+[
+  { "patch_dir": "src/electron/patches/chromium", "repo": "src" },
+  { "patch_dir": "src/electron/patches/boringssl", "repo": "src/third_party/boringssl/src" },
+  { "patch_dir": "src/electron/patches/devtools_frontend", "repo": "src/third_party/devtools-frontend/src" },
+  { "patch_dir": "src/electron/patches/ffmpeg", "repo": "src/third_party/ffmpeg" },
+  { "patch_dir": "src/electron/patches/v8", "repo": "src/v8" },
+  { "patch_dir": "src/electron/patches/node", "repo": "src/third_party/electron_node" },
+  { "patch_dir": "src/electron/patches/nan", "repo": "src/third_party/nan" },
+  { "patch_dir": "src/electron/patches/perfetto", "repo": "src/third_party/perfetto" },
+  { "patch_dir": "src/electron/patches/squirrel.mac", "repo": "src/third_party/squirrel.mac" },
+  { "patch_dir": "src/electron/patches/Mantle", "repo": "src/third_party/squirrel.mac/vendor/Mantle" },
+  { "patch_dir": "src/electron/patches/ReactiveObjC", "repo": "src/third_party/squirrel.mac/vendor/ReactiveObjC" },
+  { "patch_dir": "src/electron/patches/webrtc", "repo": "src/third_party/webrtc" },
+  { "patch_dir": "src/electron/patches/reclient-configs", "repo": "src/third_party/engflow-reclient-configs" }
 }

--- a/patches/config.json
+++ b/patches/config.json
@@ -12,4 +12,4 @@
   { "patch_dir": "src/electron/patches/ReactiveObjC", "repo": "src/third_party/squirrel.mac/vendor/ReactiveObjC" },
   { "patch_dir": "src/electron/patches/webrtc", "repo": "src/third_party/webrtc" },
   { "patch_dir": "src/electron/patches/reclient-configs", "repo": "src/third_party/engflow-reclient-configs" }
-}
+]

--- a/script/apply_all_patches.py
+++ b/script/apply_all_patches.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import os
+import warnings
 
 from lib import git
 from lib.patches import patch_from_dir
@@ -12,6 +13,7 @@ THREEWAY = "ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES" in os.environ
 def apply_patches(target):
   repo = target.get('repo')
   if not os.path.exists(repo):
+    warnings.warn('repo not found: %s' % repo)
     return
   patch_dir = target.get('patch_dir')
   git.import_patches(

--- a/script/apply_all_patches.py
+++ b/script/apply_all_patches.py
@@ -11,7 +11,7 @@ THREEWAY = "ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES" in os.environ
 
 def apply_patches(target):
   repo = target.get('repo')
-  if !os.path.exists(repo):
+  if not os.path.exists(repo):
     return
   patch_dir = target.get('patch_dir')
   git.import_patches(

--- a/script/apply_all_patches.py
+++ b/script/apply_all_patches.py
@@ -7,15 +7,24 @@ import os
 from lib import git
 from lib.patches import patch_from_dir
 
+THREEWAY = "ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES" in os.environ
 
-def apply_patches(dirs):
-  threeway = os.environ.get("ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES")
-  for patch_dir, repo in dirs.items():
-    if os.path.exists(repo):
-      git.import_patches(repo=repo, patch_data=patch_from_dir(patch_dir),
-        threeway=threeway is not None,
-        committer_name="Electron Scripts", committer_email="scripts@electron")
+def apply_patches(target):
+  repo = target.get('repo')
+  if !os.path.exists(repo):
+    return
+  patch_dir = target.get('patch_dir')
+  git.import_patches(
+    committer_email="scripts@electron",
+    committer_name="Electron Scripts",
+    patch_data=patch_from_dir(patch_dir),
+    repo=repo,
+    threeway=THREEWAY is not None,
+  )
 
+def apply_config(config):
+  for target in config:
+    apply_patches(target)
 
 def parse_args():
   parser = argparse.ArgumentParser(description='Apply Electron patches')
@@ -26,9 +35,8 @@ def parse_args():
 
 
 def main():
-  configs = parse_args().config
-  for config_json in configs:
-    apply_patches(json.load(config_json))
+  for config_json in parse_args().config:
+    apply_config(json.load(config_json))
 
 
 if __name__ == '__main__':

--- a/script/apply_all_patches.py
+++ b/script/apply_all_patches.py
@@ -19,7 +19,7 @@ def apply_patches(target):
     committer_name="Electron Scripts",
     patch_data=patch_from_dir(patch_dir),
     repo=repo,
-    threeway=THREEWAY is not None,
+    threeway=THREEWAY,
   )
 
 def apply_config(config):

--- a/script/export_all_patches.py
+++ b/script/export_all_patches.py
@@ -3,18 +3,27 @@
 import argparse
 import json
 import os
+import warnings
 
 from lib import git
 
 
-def export_patches(config, dry_run):
+def export_patches(target, dry_run):
+  repo = target.get('repo')
+  if not os.path.exists(repo):
+    warnings.warn('repo not found: %s' % repo)
+    return
+  git.export_patches(
+    dry_run=dry_run,
+    grep=target.get('grep'),
+    out_dir=target.get('patch_dir'),
+    repo=repo
+  )
+
+
+def export_config(config, dry_run):
   for target in config:
-    repo = target.get('repo')
-    if not os.path.exists(repo):
-      continue
-    out_dir = target.get('patch_dir')
-    grep = target.get('grep')
-    git.export_patches(dry_run=dry_run, grep=grep, out_dir=out_dir, repo=repo)
+    export_patches(target, dry_run)
 
 
 def parse_args():
@@ -32,7 +41,7 @@ def main():
   configs = parse_args().config
   dry_run = parse_args().dry_run
   for config_json in configs:
-    export_patches(json.load(config_json), dry_run)
+    export_config(json.load(config_json), dry_run)
 
 
 if __name__ == '__main__':

--- a/script/export_all_patches.py
+++ b/script/export_all_patches.py
@@ -14,7 +14,10 @@ def export_patches(config, dry_run):
       repo = target.get('repo')
       grep = target.get('grep')
       if os.path.exists(repo):
-        git.export_patches(repo=repo, out_dir=out_dir, dry_run=dry_run, grep=grep)
+        git.export_patches(dry_run=dry_run,
+                           grep=grep,
+                           out_dir=out_dir,
+                           repo=repo)
     return
 
   # previous config format was an object of patch dir key -> repo dir vals

--- a/script/export_all_patches.py
+++ b/script/export_all_patches.py
@@ -8,23 +8,13 @@ from lib import git
 
 
 def export_patches(config, dry_run):
-  if isinstance(config, list):
-    for target in config:
-      out_dir = target.get('patch_dir')
-      repo = target.get('repo')
-      grep = target.get('grep')
-      if os.path.exists(repo):
-        git.export_patches(dry_run=dry_run,
-                           grep=grep,
-                           out_dir=out_dir,
-                           repo=repo)
-    return
-
-  # previous config format was an object of patch dir key -> repo dir vals
-  if isinstance(config, dict):
-    for out_dir, repo in config.items():
-      if os.path.exists(repo):
-        git.export_patches(repo=repo, out_dir=out_dir, dry_run=dry_run)
+  for target in config:
+    repo = target.get('repo')
+    if not os.path.exists(repo):
+      continue
+    out_dir = target.get('patch_dir')
+    grep = target.get('grep')
+    git.export_patches(dry_run=dry_run, grep=grep, out_dir=out_dir, repo=repo)
 
 
 def parse_args():

--- a/script/export_all_patches.py
+++ b/script/export_all_patches.py
@@ -7,10 +7,21 @@ import os
 from lib import git
 
 
-def export_patches(dirs, dry_run):
-  for patch_dir, repo in dirs.items():
-    if os.path.exists(repo):
-      git.export_patches(repo=repo, out_dir=patch_dir, dry_run=dry_run)
+def export_patches(config, dry_run):
+  if isinstance(config, list):
+    for target in config:
+      out_dir = target.get('patch_dir')
+      repo = target.get('repo')
+      grep = target.get('grep')
+      if os.path.exists(repo):
+        git.export_patches(repo=repo, out_dir=out_dir, dry_run=dry_run, grep=grep)
+    return
+
+  # previous config format was an object of patch dir key -> repo dir vals
+  if isinstance(config, dict):
+    for out_dir, repo in config.items():
+      if os.path.exists(repo):
+        git.export_patches(repo=repo, out_dir=out_dir, dry_run=dry_run)
 
 
 def parse_args():

--- a/script/git-export-patches
+++ b/script/git-export-patches
@@ -10,13 +10,15 @@ def main(argv):
   parser.add_argument("-o", "--output",
       help="directory into which exported patches will be written",
       required=True)
+  parser.add_argument("--grep",
+      help="only export patches matching a keyword")
   parser.add_argument("patch_range",
       nargs='?',
       help="range of patches to export. Defaults to all commits since the "
            "most recent tag or remote branch.")
   args = parser.parse_args(argv)
 
-  git.export_patches('.', args.output, patch_range=args.patch_range)
+  git.export_patches('.', args.output, patch_range=args.patch_range, grep=args.grep)
 
 
 if __name__ == '__main__':

--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -188,10 +188,9 @@ def filter_patches(patches, key):
     return patches
   matches = []
   for patch in patches:
-    for line in patch:
-      if key in line:
-        matches.append(patch)
-        continue
+    if any(key in line for line in patch):
+      matches.append(patch)
+      continue
   return matches
 
 def munge_subject_to_filename(subject):
@@ -251,7 +250,7 @@ def export_patches(repo, out_dir, patch_range=None, dry_run=False, grep=None):
         num_patches, repo, patch_range[0:7]))
   patch_data = format_patch(repo, patch_range)
   patches = split_patches(patch_data)
-  if grep is not None:
+  if grep:
     patches = filter_patches(patches, grep)
 
   try:

--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -149,6 +149,7 @@ def format_patch(repo, since):
     'format-patch',
     '--keep-subject',
     '--no-stat',
+    '--notes',
     '--stdout',
 
     # Per RFC 3676 the signature is separated from the body by a line with

--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -182,6 +182,17 @@ def split_patches(patch_data):
     patches[-1].append(line)
   return patches
 
+def filter_patches(patches, key):
+  """Return patches that include the specified key"""
+  if key is None:
+    return patches
+  matches = []
+  for patch in patches:
+    for line in patch:
+      if key in line:
+        matches.append(patch)
+        continue
+  return matches
 
 def munge_subject_to_filename(subject):
   """Derive a suitable filename from a commit's subject"""
@@ -228,7 +239,7 @@ def remove_patch_filename(patch):
     force_keep_next_line = l.startswith('Subject: ')
 
 
-def export_patches(repo, out_dir, patch_range=None, dry_run=False):
+def export_patches(repo, out_dir, patch_range=None, dry_run=False, grep=None):
   if not os.path.exists(repo):
     sys.stderr.write(
       "Skipping patches in {} because it does not exist.\n".format(repo)
@@ -240,6 +251,8 @@ def export_patches(repo, out_dir, patch_range=None, dry_run=False):
         num_patches, repo, patch_range[0:7]))
   patch_data = format_patch(repo, patch_range)
   patches = split_patches(patch_data)
+  if grep is not None:
+    patches = filter_patches(patches, grep)
 
   try:
     os.mkdir(out_dir)

--- a/script/lint.js
+++ b/script/lint.js
@@ -201,10 +201,9 @@ const LINTERS = [{
       process.exit(1);
     }
 
-    const config = JSON.parse(fs.readFileSync(patchesConfig, 'utf8'));
-    for (const key of Object.keys(config)) {
+    for (const target of JSON.parse(fs.readFileSync(patchesConfig, 'utf8'))) {
       // The directory the config points to should exist
-      const targetPatchesDir = path.resolve(__dirname, '../../..', key);
+      const targetPatchesDir = path.resolve(__dirname, '../../..', target.patch_dir);
       if (!fs.existsSync(targetPatchesDir)) {
         console.error(`target patch directory: "${targetPatchesDir}" does not exist`);
         process.exit(1);

--- a/script/patches-mtime-cache.py
+++ b/script/patches-mtime-cache.py
@@ -12,7 +12,9 @@ from lib.patches import patch_from_dir
 
 
 def patched_file_paths(patches_config):
-    for patch_dir, repo in patches_config.items():
+    for target in patches_config:
+        patch_dir = target.get('patch_dir')
+        repo = target.get('repo')
         for line in patch_from_dir(patch_dir).split("\n"):
             if line.startswith("+++"):
                 yield posixpath.join(repo, line[6:])


### PR DESCRIPTION
#### Description of Change

In our 'export patches' scripts, support filtering which patches get exported.

Not ready for code review just yet but I'm happy to answer any questions / concerns anyone has.

## Rationale:

The tldr is when building Electron, we want to make it simpler to import/export downstream patches that don't make sense being upstreamed into `electron/electron`.

In the same way that [Electron patches upstream code like Chromium and V8](https://github.com/electron/electron/tree/main/patches), Microsoft's internal build of Electron has its own "downstream" patches to change Chromium, V8, and even Electron :smile_cat: . Keeping those "downstream" changes up-to-date with each new Electron release is a similar procedure to how @wg-upgrades keeps its patches up-to-date with each new Node or Chromium bump, so we have the same need that wg-upgrades has to export and lint patches.

I'd like to modify the tooling in `electron/electron` (and `electron/build-tools`) to make it possible to use these tools to maintain those "downstream" patches.

The code in [`electron/electron script/`](https://github.com/electron/electron/tree/main/script) currently exports all patches from a repo (e.g. Chromium, V8, FFmpeg) into a directory and creates a `.patches` file for them, based on the config file in `electron/electron patches/config.json`.

So I'm looking for a way to specify the `config.json` (so we can use a downstream file with our own patch directories) and a way of filtering which patches get exported, so that instead of "all patches from a repo" we can instead say "all downstream patches from a repo".

## The Code Changes:

1. Add metainfo to Microsoft's downstream `.patch` files via [git Notes](https://git-scm.com/docs/git-notes). This doesn't affect the `electron/electron` patches; it just gives the downstream patches a place to add greppable metainfo.
2. In `electron/electron`, update `script/lib/git.py`'s `format_patch()` to include Notes so that they are propagated when exporting patches.
3. In `electron/electron`, update `script/lib/git.py`'s `export_patches()` to add an optional `grep` argument which limits which patches are exported.
4. In `electron/electron`, update the format of `patches/config.json` to allow for more per-target metainfo. It's currently a single object with patch dir key -> repo dir pairs. I'd like to have an array of objects instead so that extra metainfo can be added.
5. In `electron/electron`, update `script/export_all_patches.py` to support the new `config.json` format
6. In `electron/build-tools`, update `src/e-patches.js` to support the new `config.json` format

CC @mlaurencin, @jkleinsc, also courtesy CC @miniak @alexeykuzmin 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.