### PR TITLE
chore: cherry-pick 4 changes from Release-1-M121

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -144,3 +144,7 @@ feat_allow_code_cache_in_custom_schemes.patch
 enable_partition_alloc_ref_count_size.patch
 ensure_an_axcontext_before_painting.patch
 safely_crash_on_dangling_profile.patch
+cherry-pick-91a02d67a83d.patch
+cherry-pick-8755f76bec32.patch
+cherry-pick-1f8bec968902.patch
+cherry-pick-4a98f9e304be.patch

--- a/patches/chromium/cherry-pick-1f8bec968902.patch
+++ b/patches/chromium/cherry-pick-1f8bec968902.patch
@@ -1,0 +1,126 @@
+From 1f8bec96890207503a59249a8d4140a4c7767782 Mon Sep 17 00:00:00 2001
+From: Tsuyoshi Horo <horo@chromium.org>
+Date: Wed, 24 Jan 2024 02:04:24 +0000
+Subject: [PATCH] [M120] Fix UAF in SourceStreamToDataPipe
+
+SourceStreamToDataPipe::ReadMore() is passing a callback with
+Unretained(this) to net::SourceStream::Read(). But this callback may be
+called even after the SourceStream is destructed. This is causing UAF
+issue (crbug.com/1511085).
+
+To solve this problem, this CL changes ReadMore() method to pass a
+callback with a weak ptr of this.
+
+(cherry picked from commit 6e36a69da1b73f9aea9c54bfbe6c5b9cb2c672a5)
+
+Bug: 1511085
+Change-Id: Idd4e34ff300ff5db2de1de7b303841c7db3a964a
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5179746
+Reviewed-by: Adam Rice <ricea@chromium.org>
+Commit-Queue: Tsuyoshi Horo <horo@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1244526}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5231558
+Reviewed-by: Kenichi Ishibashi <bashi@chromium.org>
+Cr-Commit-Position: refs/branch-heads/6099@{#1860}
+Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
+---
+
+diff --git a/services/network/public/cpp/source_stream_to_data_pipe.cc b/services/network/public/cpp/source_stream_to_data_pipe.cc
+index 6be1210..62ad4f9 100644
+--- a/services/network/public/cpp/source_stream_to_data_pipe.cc
++++ b/services/network/public/cpp/source_stream_to_data_pipe.cc
+@@ -56,9 +56,9 @@
+   int num_bytes = base::checked_cast<int>(pending_write_->size());
+   scoped_refptr<net::IOBuffer> buffer(
+       new network::NetToMojoIOBuffer(pending_write_.get()));
+-  int result = source_->Read(
+-      buffer.get(), num_bytes,
+-      base::BindOnce(&SourceStreamToDataPipe::DidRead, base::Unretained(this)));
++  int result = source_->Read(buffer.get(), num_bytes,
++                             base::BindOnce(&SourceStreamToDataPipe::DidRead,
++                                            weak_factory_.GetWeakPtr()));
+ 
+   if (result != net::ERR_IO_PENDING)
+     DidRead(result);
+diff --git a/services/network/public/cpp/source_stream_to_data_pipe_unittest.cc b/services/network/public/cpp/source_stream_to_data_pipe_unittest.cc
+index 7061418..54159df 100644
+--- a/services/network/public/cpp/source_stream_to_data_pipe_unittest.cc
++++ b/services/network/public/cpp/source_stream_to_data_pipe_unittest.cc
+@@ -6,7 +6,9 @@
+ 
+ #include "base/functional/bind.h"
+ #include "base/memory/raw_ptr.h"
++#include "base/test/bind.h"
+ #include "base/test/task_environment.h"
++#include "net/base/net_errors.h"
+ #include "net/filter/mock_source_stream.h"
+ #include "testing/gtest/include/gtest/gtest.h"
+ #include "third_party/abseil-cpp/absl/types/optional.h"
+@@ -42,6 +44,33 @@
+   const ReadResultType read_result_type;
+ };
+ 
++class DummyPendingSourceStream : public net::SourceStream {
++ public:
++  DummyPendingSourceStream() : net::SourceStream(SourceStream::TYPE_NONE) {}
++  ~DummyPendingSourceStream() override = default;
++
++  DummyPendingSourceStream(const DummyPendingSourceStream&) = delete;
++  DummyPendingSourceStream& operator=(const DummyPendingSourceStream&) = delete;
++
++  // SourceStream implementation
++  int Read(net::IOBuffer* dest_buffer,
++           int buffer_size,
++           net::CompletionOnceCallback callback) override {
++    callback_ = std::move(callback);
++    return net::ERR_IO_PENDING;
++  }
++  std::string Description() const override { return ""; }
++  bool MayHaveMoreBytes() const override { return true; }
++
++  net::CompletionOnceCallback TakeCompletionCallback() {
++    CHECK(callback_);
++    return std::move(callback_);
++  }
++
++ private:
++  net::CompletionOnceCallback callback_;
++};
++
+ }  // namespace
+ 
+ class SourceStreamToDataPipeTest
+@@ -212,4 +241,33 @@
+   EXPECT_EQ(ReadPipe(&output), net::OK);
+   EXPECT_EQ(output, message);
+ }
++
++TEST(SourceStreamToDataPipeCallbackTest, CompletionCallbackAfterDestructed) {
++  base::test::TaskEnvironment task_environment;
++
++  std::unique_ptr<DummyPendingSourceStream> source =
++      std::make_unique<DummyPendingSourceStream>();
++  DummyPendingSourceStream* source_ptr = source.get();
++  const MojoCreateDataPipeOptions data_pipe_options{
++      sizeof(MojoCreateDataPipeOptions), MOJO_CREATE_DATA_PIPE_FLAG_NONE, 1, 1};
++  mojo::ScopedDataPipeProducerHandle producer_end;
++  mojo::ScopedDataPipeConsumerHandle consumer_end;
++  CHECK_EQ(MOJO_RESULT_OK, mojo::CreateDataPipe(&data_pipe_options,
++                                                producer_end, consumer_end));
++
++  std::unique_ptr<SourceStreamToDataPipe> adapter =
++      std::make_unique<SourceStreamToDataPipe>(std::move(source),
++                                               std::move(producer_end));
++  bool callback_called = false;
++  adapter->Start(
++      base::BindLambdaForTesting([&](int result) { callback_called = true; }));
++  net::CompletionOnceCallback callback = source_ptr->TakeCompletionCallback();
++  adapter.reset();
++
++  // Test that calling `callback` after deleting `adapter` must not cause UAF
++  // (crbug.com/1511085).
++  std::move(callback).Run(net::ERR_FAILED);
++  EXPECT_FALSE(callback_called);
++}
++
+ }  // namespace network

--- a/patches/chromium/cherry-pick-1f8bec968902.patch
+++ b/patches/chromium/cherry-pick-1f8bec968902.patch
@@ -1,7 +1,7 @@
-From 1f8bec96890207503a59249a8d4140a4c7767782 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tsuyoshi Horo <horo@chromium.org>
 Date: Wed, 24 Jan 2024 02:04:24 +0000
-Subject: [PATCH] [M120] Fix UAF in SourceStreamToDataPipe
+Subject: Fix UAF in SourceStreamToDataPipe
 
 SourceStreamToDataPipe::ReadMore() is passing a callback with
 Unretained(this) to net::SourceStream::Read(). But this callback may be
@@ -23,13 +23,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5231558
 Reviewed-by: Kenichi Ishibashi <bashi@chromium.org>
 Cr-Commit-Position: refs/branch-heads/6099@{#1860}
 Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
----
 
 diff --git a/services/network/public/cpp/source_stream_to_data_pipe.cc b/services/network/public/cpp/source_stream_to_data_pipe.cc
-index 6be1210..62ad4f9 100644
+index 6be121003a1044ea55e086e7b0853589ded52732..62ad4f9fd58f29fae844cde5bbdb8273fdb40ae4 100644
 --- a/services/network/public/cpp/source_stream_to_data_pipe.cc
 +++ b/services/network/public/cpp/source_stream_to_data_pipe.cc
-@@ -56,9 +56,9 @@
+@@ -56,9 +56,9 @@ void SourceStreamToDataPipe::ReadMore() {
    int num_bytes = base::checked_cast<int>(pending_write_->size());
    scoped_refptr<net::IOBuffer> buffer(
        new network::NetToMojoIOBuffer(pending_write_.get()));
@@ -43,7 +42,7 @@ index 6be1210..62ad4f9 100644
    if (result != net::ERR_IO_PENDING)
      DidRead(result);
 diff --git a/services/network/public/cpp/source_stream_to_data_pipe_unittest.cc b/services/network/public/cpp/source_stream_to_data_pipe_unittest.cc
-index 7061418..54159df 100644
+index 7061418c5141d936f04b1193c98e66efc5e72ac5..54159df39afa7cf6e2faa51da185dc034b923209 100644
 --- a/services/network/public/cpp/source_stream_to_data_pipe_unittest.cc
 +++ b/services/network/public/cpp/source_stream_to_data_pipe_unittest.cc
 @@ -6,7 +6,9 @@
@@ -56,7 +55,7 @@ index 7061418..54159df 100644
  #include "net/filter/mock_source_stream.h"
  #include "testing/gtest/include/gtest/gtest.h"
  #include "third_party/abseil-cpp/absl/types/optional.h"
-@@ -42,6 +44,33 @@
+@@ -42,6 +44,33 @@ struct SourceStreamToDataPipeTestParam {
    const ReadResultType read_result_type;
  };
  
@@ -90,7 +89,7 @@ index 7061418..54159df 100644
  }  // namespace
  
  class SourceStreamToDataPipeTest
-@@ -212,4 +241,33 @@
+@@ -212,4 +241,33 @@ TEST_P(SourceStreamToDataPipeTest, MayHaveMoreBytes) {
    EXPECT_EQ(ReadPipe(&output), net::OK);
    EXPECT_EQ(output, message);
  }

--- a/patches/chromium/cherry-pick-4a98f9e304be.patch
+++ b/patches/chromium/cherry-pick-4a98f9e304be.patch
@@ -1,7 +1,10 @@
-From 4a98f9e304be8129401e797cd3491d53bec05785 Mon Sep 17 00:00:00 2001
-From: Peter Boström <pbos@chromium.org>
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Peter=20Bostr=C3=B6m?= <pbos@chromium.org>
 Date: Fri, 26 Jan 2024 19:37:57 +0000
-Subject: [PATCH] Speculatively fix race in mojo ShutDownOnIOThread
+Subject: Speculatively fix race in mojo ShutDownOnIOThread
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 This acquires `write_lock_` before resetting handles used by WriteNoLock
 (which is called under the same lock in another thread). We also set
@@ -27,13 +30,12 @@ Cr-Original-Commit-Position: refs/heads/main@{#1250580}
 Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5239564
 Cr-Commit-Position: refs/branch-heads/6099@{#1883}
 Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
----
 
 diff --git a/mojo/core/channel_posix.cc b/mojo/core/channel_posix.cc
-index 0a35963..eae6b07 100644
+index 0a3596382d0e9a40c72bfb4ead6f0338a61253d6..eae6b0768463679b5043514dc5745da52b80ae10 100644
 --- a/mojo/core/channel_posix.cc
 +++ b/mojo/core/channel_posix.cc
-@@ -246,16 +246,21 @@
+@@ -246,16 +246,21 @@ void ChannelPosix::WaitForWriteOnIOThreadNoLock() {
  void ChannelPosix::ShutDownOnIOThread() {
    base::CurrentThread::Get()->RemoveDestructionObserver(this);
  

--- a/patches/chromium/cherry-pick-4a98f9e304be.patch
+++ b/patches/chromium/cherry-pick-4a98f9e304be.patch
@@ -1,0 +1,65 @@
+From 4a98f9e304be8129401e797cd3491d53bec05785 Mon Sep 17 00:00:00 2001
+From: Peter Boström <pbos@chromium.org>
+Date: Fri, 26 Jan 2024 19:37:57 +0000
+Subject: [PATCH] Speculatively fix race in mojo ShutDownOnIOThread
+
+This acquires `write_lock_` before resetting handles used by WriteNoLock
+(which is called under the same lock in another thread). We also set
+`reject_writes_` to prevent future write attempts after shutdown. That
+seems strictly more correct.
+
+We also acquire `fds_to_close_lock_` before clearing the FDs.
+
+I was unable to repro locally as content_browsertests just times out
+in my local setup without reporting anything interesting. This seems
+strictly more correct though.
+
+(cherry picked from commit 9755d9d81e4a8cb5b4f76b23b761457479dbb06b)
+
+Bug: 1519980
+Change-Id: I96279936ca908ecb98eddd381df20d61597cba43
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5226127
+Auto-Submit: Peter Boström <pbos@chromium.org>
+Reviewed-by: Ken Rockot <rockot@google.com>
+Commit-Queue: Ken Rockot <rockot@google.com>
+Commit-Queue: Peter Boström <pbos@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1250580}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5239564
+Cr-Commit-Position: refs/branch-heads/6099@{#1883}
+Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
+---
+
+diff --git a/mojo/core/channel_posix.cc b/mojo/core/channel_posix.cc
+index 0a35963..eae6b07 100644
+--- a/mojo/core/channel_posix.cc
++++ b/mojo/core/channel_posix.cc
+@@ -246,16 +246,21 @@
+ void ChannelPosix::ShutDownOnIOThread() {
+   base::CurrentThread::Get()->RemoveDestructionObserver(this);
+ 
+-  read_watcher_.reset();
+-  write_watcher_.reset();
+-  if (leak_handle_) {
+-    std::ignore = socket_.release();
+-  } else {
+-    socket_.reset();
+-  }
++  {
++    base::AutoLock lock(write_lock_);
++    reject_writes_ = true;
++    read_watcher_.reset();
++    write_watcher_.reset();
++    if (leak_handle_) {
++      std::ignore = socket_.release();
++    } else {
++      socket_.reset();
++    }
+ #if BUILDFLAG(IS_IOS)
+-  fds_to_close_.clear();
++    base::AutoLock fd_lock(fds_to_close_lock_);
++    fds_to_close_.clear();
+ #endif
++  }
+ 
+   // May destroy the |this| if it was the last reference.
+   self_ = nullptr;

--- a/patches/chromium/cherry-pick-8755f76bec32.patch
+++ b/patches/chromium/cherry-pick-8755f76bec32.patch
@@ -1,7 +1,7 @@
-From 8755f76bec326c654370de6dd68eea693df74ede Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Guido Urdaneta <guidou@chromium.org>
 Date: Thu, 18 Jan 2024 16:47:18 +0000
-Subject: [PATCH] [RTCPeerConnection] Exit early from RTCPeerConnectionHandler
+Subject: Exit early from RTCPeerConnectionHandler
 
 For certain operations that require a live client
 (i.e., RTCPeerConnection, which is garbage collected),
@@ -20,13 +20,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5210359
 Reviewed-by: Tomas Gunnarsson <tommi@chromium.org>
 Commit-Queue: Guido Urdaneta <guidou@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#1248826}
----
 
 diff --git a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc
-index 03f1b44..f08815c 100644
+index 015c5abec1facd3fe9b427b197a137682b11f526..3afc7074a5775542ba2393aa007ff7c5abb3f728 100644
 --- a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc
 +++ b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc
-@@ -839,15 +839,19 @@
+@@ -1056,15 +1056,19 @@ bool RTCPeerConnectionHandler::Initialize(
      WebLocalFrame* frame,
      ExceptionState& exception_state) {
    DCHECK(task_runner_->RunsTasksInCurrentSequence());
@@ -48,7 +47,7 @@ index 03f1b44..f08815c 100644
    peer_connection_tracker_ = PeerConnectionTracker::From(*frame);
  
    configuration_ = server_configuration;
-@@ -2058,10 +2062,13 @@
+@@ -2321,10 +2325,13 @@ void RTCPeerConnectionHandler::OnIceCandidate(const String& sdp,
                                                int sdp_mline_index,
                                                int component,
                                                int address_family) {
@@ -64,10 +63,10 @@ index 03f1b44..f08815c 100644
    // This line can cause garbage collection.
    auto* platform_candidate = MakeGarbageCollected<RTCIceCandidatePlatform>(
 diff --git a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler_test.cc b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler_test.cc
-index bbbed46..f872765 100644
+index eb44aabb481a66e08d432a9ed4f202d5ca27ee90..ee703c4317f57483a67ea0b67a19137cc859ecc6 100644
 --- a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler_test.cc
 +++ b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler_test.cc
-@@ -541,7 +541,7 @@
+@@ -602,7 +602,7 @@ class RTCPeerConnectionHandlerTest : public SimTest {
      waitable_event->Signal();
    }
  
@@ -76,7 +75,7 @@ index bbbed46..f872765 100644
    ScopedTestingPlatformSupport<AudioCapturerSourceTestingPlatformSupport>
        webrtc_audio_device_platform_support_;
    Persistent<MockRTCPeerConnectionHandlerClient> mock_client_;
-@@ -1054,4 +1054,32 @@
+@@ -1170,4 +1170,32 @@ TEST_F(RTCPeerConnectionHandlerTest,
    observer->OnIceCandidate(native_candidate.get());
  }
  

--- a/patches/chromium/cherry-pick-8755f76bec32.patch
+++ b/patches/chromium/cherry-pick-8755f76bec32.patch
@@ -1,0 +1,111 @@
+From 8755f76bec326c654370de6dd68eea693df74ede Mon Sep 17 00:00:00 2001
+From: Guido Urdaneta <guidou@chromium.org>
+Date: Thu, 18 Jan 2024 16:47:18 +0000
+Subject: [PATCH] [RTCPeerConnection] Exit early from RTCPeerConnectionHandler
+
+For certain operations that require a live client
+(i.e., RTCPeerConnection, which is garbage collected),
+PeerConnectionHandler keeps a pointer to the client on the stack
+to prevent garbage collection.
+
+In some cases, the client may have already been garbage collected
+(the client is null). In that case, there is no point in doing the
+operation and it should exit early to avoid UAF/crashes.
+
+This CL adds early exit to the cases that do not already have it.
+
+Bug: 1514777
+Change-Id: I27e9541cfaa74d978799c03e2832a0980f9e5710
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5210359
+Reviewed-by: Tomas Gunnarsson <tommi@chromium.org>
+Commit-Queue: Guido Urdaneta <guidou@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1248826}
+---
+
+diff --git a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc
+index 03f1b44..f08815c 100644
+--- a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc
++++ b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc
+@@ -839,15 +839,19 @@
+     WebLocalFrame* frame,
+     ExceptionState& exception_state) {
+   DCHECK(task_runner_->RunsTasksInCurrentSequence());
+-  DCHECK(frame);
+   DCHECK(dependency_factory_);
+-  frame_ = frame;
+ 
+   CHECK(!initialize_called_);
+   initialize_called_ = true;
+ 
+   // Prevent garbage collection of client_ during processing.
+   auto* client_on_stack = client_.Get();
++  if (!client_on_stack) {
++    return false;
++  }
++
++  DCHECK(frame);
++  frame_ = frame;
+   peer_connection_tracker_ = PeerConnectionTracker::From(*frame);
+ 
+   configuration_ = server_configuration;
+@@ -2058,10 +2062,13 @@
+                                               int sdp_mline_index,
+                                               int component,
+                                               int address_family) {
++  DCHECK(task_runner_->RunsTasksInCurrentSequence());
+   // In order to ensure that the RTCPeerConnection is not garbage collected
+   // from under the function, we keep a pointer to it on the stack.
+   auto* client_on_stack = client_.Get();
+-  DCHECK(task_runner_->RunsTasksInCurrentSequence());
++  if (!client_on_stack) {
++    return;
++  }
+   TRACE_EVENT0("webrtc", "RTCPeerConnectionHandler::OnIceCandidateImpl");
+   // This line can cause garbage collection.
+   auto* platform_candidate = MakeGarbageCollected<RTCIceCandidatePlatform>(
+diff --git a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler_test.cc b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler_test.cc
+index bbbed46..f872765 100644
+--- a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler_test.cc
++++ b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler_test.cc
+@@ -541,7 +541,7 @@
+     waitable_event->Signal();
+   }
+ 
+- public:
++ protected:
+   ScopedTestingPlatformSupport<AudioCapturerSourceTestingPlatformSupport>
+       webrtc_audio_device_platform_support_;
+   Persistent<MockRTCPeerConnectionHandlerClient> mock_client_;
+@@ -1054,4 +1054,32 @@
+   observer->OnIceCandidate(native_candidate.get());
+ }
+ 
++TEST_F(RTCPeerConnectionHandlerTest,
++       OnIceCandidateAfterClientGarbageCollectionDoesNothing) {
++  testing::InSequence sequence;
++  EXPECT_CALL(*mock_tracker_.Get(),
++              TrackAddIceCandidate(pc_handler_.get(), _,
++                                   PeerConnectionTracker::kSourceLocal, true))
++      .Times(0);
++
++  std::unique_ptr<webrtc::IceCandidateInterface> native_candidate(
++      mock_dependency_factory_->CreateIceCandidate("sdpMid", 1, kDummySdp));
++  mock_client_ = nullptr;
++  WebHeap::CollectAllGarbageForTesting();
++  pc_handler_->observer()->OnIceCandidate(native_candidate.get());
++  RunMessageLoopsUntilIdle();
++}
++
++TEST_F(RTCPeerConnectionHandlerTest,
++       OnIceCandidateAfterClientGarbageCollectionFails) {
++  DummyExceptionStateForTesting exception_state;
++  auto pc_handler = CreateRTCPeerConnectionHandlerUnderTest();
++  mock_client_ = nullptr;
++  WebHeap::CollectAllGarbageForTesting();
++  EXPECT_FALSE(pc_handler->Initialize(
++      /*context=*/nullptr, webrtc::PeerConnectionInterface::RTCConfiguration(),
++      /*media_constraints=*/nullptr,
++      /*frame=*/nullptr, exception_state));
++}
++
+ }  // namespace blink

--- a/patches/chromium/cherry-pick-91a02d67a83d.patch
+++ b/patches/chromium/cherry-pick-91a02d67a83d.patch
@@ -1,0 +1,126 @@
+From 91a02d67a83dd9fe81fcfb13196461327de44d8e Mon Sep 17 00:00:00 2001
+From: Jean-Philippe Gravel <jpgravel@chromium.org>
+Date: Tue, 23 Jan 2024 21:37:50 +0000
+Subject: [PATCH] Fix use-after-free in DrawTextInternal
+
+DrawTextInternal was calling GetOrCreatePaintCanvas multiple times,
+once at the start of the function, once inside of the
+BaseRenderingContext2DAutoRestoreSkCanvas helper class and once in the
+Draw call. GetOrCreatePaintCanvas destroys the canvas resource provider
+if the GPU context is lost. If this happens on the second call to
+GetOrCreatePaintCanvas, destroying the resource provider will
+invalidate the cc::PaintCanvas returned by the first call to
+GetOrCreatePaintCanvas.
+
+The GPU process can technically crash at any point during the renderer
+process execution (perhaps because of something another renderer
+process did). We therefore have to assume that any call to
+GetOrCreatePaintCanvas can invalidate previously returned
+cc::PaintCanvas.
+
+(cherry picked from commit d4a197e4913f8e5072263b59aedc29f2b5af3e93)
+
+Change-Id: Ifa77735ab1b2b55b3d494f886b8566299937f6fe
+Fixed: 1511567
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5198419
+Reviewed-by: Fernando Serboncini <fserb@chromium.org>
+Commit-Queue: Jean-Philippe Gravel <jpgravel@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1248204}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5230237
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/6099@{#1859}
+Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
+---
+
+diff --git a/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc b/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc
+index cf74c80..aa61546 100644
+--- a/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc
++++ b/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc
+@@ -2709,40 +2709,6 @@
+   return GetState().GetFont();
+ }
+ 
+-namespace {
+-
+-// Drawing methods need to use this instead of SkAutoCanvasRestore in case
+-// overdraw detection substitutes the recording canvas (to discard overdrawn
+-// draw calls).
+-class BaseRenderingContext2DAutoRestoreSkCanvas {
+-  STACK_ALLOCATED();
+-
+- public:
+-  explicit BaseRenderingContext2DAutoRestoreSkCanvas(
+-      BaseRenderingContext2D* context)
+-      : context_(context) {
+-    DCHECK(context_);
+-    cc::PaintCanvas* c = context_->GetOrCreatePaintCanvas();
+-    if (c) {
+-      save_count_ = c->getSaveCount();
+-    }
+-  }
+-
+-  ~BaseRenderingContext2DAutoRestoreSkCanvas() {
+-    cc::PaintCanvas* c = context_->GetOrCreatePaintCanvas();
+-    if (c) {
+-      c->restoreToCount(save_count_);
+-    }
+-    context_->ValidateStateStack();
+-  }
+-
+- private:
+-  BaseRenderingContext2D* context_;
+-  int save_count_ = 0;
+-};
+-
+-}  // namespace
+-
+ void BaseRenderingContext2D::DrawTextInternal(
+     const String& text,
+     double x,
+@@ -2763,8 +2729,10 @@
+     canvas->GetDocument().UpdateStyleAndLayoutTreeForNode(
+         canvas, DocumentUpdateReason::kCanvas);
+   }
+-  cc::PaintCanvas* c = GetOrCreatePaintCanvas();
+-  if (!c) {
++
++  // Abort if we don't have a paint canvas (e.g. the context was lost).
++  cc::PaintCanvas* paint_canvas = GetOrCreatePaintCanvas();
++  if (!paint_canvas) {
+     return;
+   }
+ 
+@@ -2835,14 +2803,13 @@
+     InflateStrokeRect(bounds);
+   }
+ 
+-  BaseRenderingContext2DAutoRestoreSkCanvas state_restorer(this);
+   if (use_max_width) {
+-    c->save();
++    paint_canvas->save();
+     // We draw when fontWidth is 0 so compositing operations (eg, a "copy" op)
+     // still work. As the width of canvas is scaled, so text can be scaled to
+     // match the given maxwidth, update text location so it appears on desired
+     // place.
+-    c->scale(ClampTo<float>(width / font_width), 1);
++    paint_canvas->scale(ClampTo<float>(width / font_width), 1);
+     location.set_x(location.x() / ClampTo<float>(width / font_width));
+   }
+ 
+@@ -2873,6 +2840,16 @@
+       { return false; },
+       bounds, paint_type, CanvasRenderingContext2DState::kNoImage,
+       CanvasPerformanceMonitor::DrawType::kText);
++
++  if (use_max_width) {
++    // Cannot use `paint_canvas` in case recording canvas was substituted or
++    // destroyed during draw call.
++    cc::PaintCanvas* c = GetPaintCanvas();
++    if (c) {
++      c->restore();
++    }
++  }
++  ValidateStateStack();
+ }
+ 
+ TextMetrics* BaseRenderingContext2D::measureText(const String& text) {

--- a/patches/chromium/cherry-pick-91a02d67a83d.patch
+++ b/patches/chromium/cherry-pick-91a02d67a83d.patch
@@ -1,7 +1,7 @@
-From 91a02d67a83dd9fe81fcfb13196461327de44d8e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jean-Philippe Gravel <jpgravel@chromium.org>
 Date: Tue, 23 Jan 2024 21:37:50 +0000
-Subject: [PATCH] Fix use-after-free in DrawTextInternal
+Subject: Fix use-after-free in DrawTextInternal
 
 DrawTextInternal was calling GetOrCreatePaintCanvas multiple times,
 once at the start of the function, once inside of the
@@ -30,13 +30,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5230237
 Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
 Cr-Commit-Position: refs/branch-heads/6099@{#1859}
 Cr-Branched-From: e6ee4500f7d6549a9ac1354f8d056da49ef406be-refs/heads/main@{#1217362}
----
 
 diff --git a/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc b/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc
-index cf74c80..aa61546 100644
+index cf74c803a0d4b5a3229f2ebc9d8637ba4294f6a9..aa61546c345d0de41f36f372fb9981a8881269d6 100644
 --- a/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc
 +++ b/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc
-@@ -2709,40 +2709,6 @@
+@@ -2709,40 +2709,6 @@ const Font& BaseRenderingContext2D::AccessFont(HTMLCanvasElement* canvas) {
    return GetState().GetFont();
  }
  
@@ -77,7 +76,7 @@ index cf74c80..aa61546 100644
  void BaseRenderingContext2D::DrawTextInternal(
      const String& text,
      double x,
-@@ -2763,8 +2729,10 @@
+@@ -2763,8 +2729,10 @@ void BaseRenderingContext2D::DrawTextInternal(
      canvas->GetDocument().UpdateStyleAndLayoutTreeForNode(
          canvas, DocumentUpdateReason::kCanvas);
    }
@@ -90,7 +89,7 @@ index cf74c80..aa61546 100644
      return;
    }
  
-@@ -2835,14 +2803,13 @@
+@@ -2835,14 +2803,13 @@ void BaseRenderingContext2D::DrawTextInternal(
      InflateStrokeRect(bounds);
    }
  
@@ -107,7 +106,7 @@ index cf74c80..aa61546 100644
      location.set_x(location.x() / ClampTo<float>(width / font_width));
    }
  
-@@ -2873,6 +2840,16 @@
+@@ -2873,6 +2840,16 @@ void BaseRenderingContext2D::DrawTextInternal(
        { return false; },
        bounds, paint_type, CanvasRenderingContext2DState::kNoImage,
        CanvasPerformanceMonitor::DrawType::kText);


### PR DESCRIPTION
<details>
<summary>electron/security#460 - d4a197e4913f from chromium</summary>
Fix use-after-free in DrawTextInternal

DrawTextInternal was calling GetOrCreatePaintCanvas multiple times,
once at the start of the function, once inside of the
BaseRenderingContext2DAutoRestoreSkCanvas helper class and once in the
Draw call. GetOrCreatePaintCanvas destroys the canvas resource provider
if the GPU context is lost. If this happens on the second call to
GetOrCreatePaintCanvas, destroying the resource provider will
invalidate the cc::PaintCanvas returned by the first call to
GetOrCreatePaintCanvas.

The GPU process can technically crash at any point during the renderer
process execution (perhaps because of something another renderer
process did). We therefore have to assume that any call to
GetOrCreatePaintCanvas can invalidate previously returned
cc::PaintCanvas.

Change-Id: Ifa77735ab1b2b55b3d494f886b8566299937f6fe
Fixed: 1511567
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5198419
Reviewed-by: Fernando Serboncini <fserb@chromium.org>
Commit-Queue: Jean-Philippe Gravel <jpgravel@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1248204}
</details>

<details>
<summary>electron/security#459 - 8755f76bec32 from chromium</summary>
[RTCPeerConnection] Exit early from RTCPeerConnectionHandler

For certain operations that require a live client
(i.e., RTCPeerConnection, which is garbage collected),
PeerConnectionHandler keeps a pointer to the client on the stack
to prevent garbage collection.

In some cases, the client may have already been garbage collected
(the client is null). In that case, there is no point in doing the
operation and it should exit early to avoid UAF/crashes.

This CL adds early exit to the cases that do not already have it.

Bug: 1514777
Change-Id: I27e9541cfaa74d978799c03e2832a0980f9e5710
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5210359
Reviewed-by: Tomas Gunnarsson <tommi@chromium.org>
Commit-Queue: Guido Urdaneta <guidou@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1248826}
</details>

<details>
<summary>electron/security#461 - e321f354a613 from chromium</summary>
[M121] Fix UAF in SourceStreamToDataPipe

SourceStreamToDataPipe::ReadMore() is passing a callback with
Unretained(this) to net::SourceStream::Read(). But this callback may be
called even after the SourceStream is destructed. This is causing UAF
issue (crbug.com/1511085).

To solve this problem, this CL changes ReadMore() method to pass a
callback with a weak ptr of this.

(cherry picked from commit 6e36a69da1b73f9aea9c54bfbe6c5b9cb2c672a5)

Bug: 1511085
Change-Id: Idd4e34ff300ff5db2de1de7b303841c7db3a964a
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5179746
Reviewed-by: Adam Rice <ricea@chromium.org>
Commit-Queue: Tsuyoshi Horo <horo@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1244526}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5231537
Reviewed-by: Kenichi Ishibashi <bashi@chromium.org>
Cr-Commit-Position: refs/branch-heads/6167@{#1621}
Cr-Branched-From: 222e786949e76e342d325ea0d008b4b6273f3a89-refs/heads/main@{#1233107}
</details>

Notes:
* Security: backported fix for 1511567.
* Security: backported fix for 1514777.
* Security: backported fix for 1511085.
* Security: backported fix for 1519980.