### PR TITLE
refactor: type-safe imports in lib/node/init.ts

### DIFF
--- a/lib/node/init.ts
+++ b/lib/node/init.ts
@@ -3,14 +3,14 @@ import { wrapFsWithAsar } from './asar-fs-wrapper';
 wrapFsWithAsar(require('fs'));
 
 // Hook child_process.fork.
-const cp = require('child_process');
+import cp = require('child_process'); // eslint-disable-line import/first
 const originalFork = cp.fork;
-cp.fork = (modulePath: string, args: any, options: any) => {
+cp.fork = (modulePath, args?, options?: cp.ForkOptions) => {
   // Parse optional args.
   if (args == null) {
     args = [];
   } else if (typeof args === 'object' && !Array.isArray(args)) {
-    options = args;
+    options = args as cp.ForkOptions;
     args = [];
   }
   // Fallback to original fork to report arg type errors.
@@ -22,7 +22,7 @@ cp.fork = (modulePath: string, args: any, options: any) => {
   // the electron binary run like upstream Node.js.
   options = options ?? {};
   options.env = Object.create(options.env || process.env);
-  options.env.ELECTRON_RUN_AS_NODE = 1;
+  options.env!.ELECTRON_RUN_AS_NODE = '1';
   // On mac the child script runs in helper executable.
   if (!options.execPath && process.platform === 'darwin') {
     options.execPath = process.helperExecPath;
@@ -31,7 +31,7 @@ cp.fork = (modulePath: string, args: any, options: any) => {
 };
 
 // Prevent Node from adding paths outside this app to search paths.
-const path = require('path');
+import path = require('path'); // eslint-disable-line import/first
 const Module = require('module');
 const resourcesPathWithTrailingSlash = process.resourcesPath + path.sep;
 const originalNodeModulePaths = Module._nodeModulePaths;


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/41148

See that PR for details.

Notes: none