### PR TITLE
fix: make sure invalid URL loads promises are fulfilled.

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -391,7 +391,7 @@ WebContents.prototype.loadURL = function (url, options) {
       if (!error && isMainFrame) {
         error = { errorCode, errorDescription, url: validatedURL };
       }
-      if (!navigationStarted) {
+      if (!navigationStarted && isMainFrame) {
         finishListener();
       }
     };

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -366,11 +366,6 @@ WebContents.prototype.loadURL = function (url, options) {
         resolveAndCleanup();
       }
     };
-    const failListener = (event: Electron.Event, errorCode: number, errorDescription: string, validatedURL: string, isMainFrame: boolean) => {
-      if (!error && isMainFrame) {
-        error = { errorCode, errorDescription, url: validatedURL };
-      }
-    };
 
     let navigationStarted = false;
     let browserInitiatedInPageNavigation = false;
@@ -390,6 +385,14 @@ WebContents.prototype.loadURL = function (url, options) {
         }
         browserInitiatedInPageNavigation = navigationStarted && isSameDocument;
         navigationStarted = true;
+      }
+    };
+    const failListener = (event: Electron.Event, errorCode: number, errorDescription: string, validatedURL: string, isMainFrame: boolean) => {
+      if (!error && isMainFrame) {
+        error = { errorCode, errorDescription, url: validatedURL };
+      }
+      if (!navigationStarted) {
+        finishListener();
       }
     };
     const stopLoadingListener = () => {

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -519,6 +519,10 @@ describe('webContents module', () => {
       await expect(w.loadURL('file:non-existent')).to.eventually.be.rejected();
       await expect(w.loadURL('file:non-existent')).to.eventually.be.rejected();
     });
+
+    it('invalid URL load rejects', async () => {
+      await expect(w.loadURL('invalidURL')).to.eventually.be.rejected();
+    });
   });
 
   describe('getFocusedWebContents() API', () => {


### PR DESCRIPTION
#### Description of Change
Invalid URLs never start navigation so there will be no navigation finish and did-fail-load will be only event raised in such cases. Fulfill the loadURL promise in did-fail-load if navigation was not started.

This change fixes #41193.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Properly reject webcontents.loadURL promise on invalid URL load.
