### PR TITLE
fix: move nut-js to optional spec deps

### DIFF
--- a/spec/package.json
+++ b/spec/package.json
@@ -11,7 +11,6 @@
     "@electron-ci/is-valid-window": "file:./is-valid-window",
     "@electron-ci/uv-dlopen": "file:./fixtures/native-addon/uv-dlopen/",
     "@marshallofsound/mocha-appveyor-reporter": "^0.4.3",
-    "@nut-tree/nut-js": "^3.1.2",
     "@types/sinon": "^9.0.4",
     "@types/ws": "^7.2.0",
     "basic-auth": "^2.0.1",
@@ -38,6 +37,9 @@
     "winreg": "^1.2.4",
     "ws": "^7.4.6",
     "yargs": "^16.0.3"
+  },
+  "optionalDependencies": {
+    "@nut-tree/nut-js": "^3.1.2"
   },
   "resolutions": {
     "nan": "file:../../third_party/nan",


### PR DESCRIPTION
#### Description of Change

[Linux ARM tests are failing](https://app.circleci.com/pipelines/github/electron/electron/78108/workflows/d2287dc3-20f7-4ad3-88dd-4a1bc2b34af0/jobs/1665959?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary) following the [addition of draggable region tests](https://github.com/electron/electron/pull/41127):
```
error @nut-tree/nut-js@3.1.2: The CPU architecture "arm" is incompatible with this module.
error Found incompatible module
```

This dependency isn't used on Linux so moving to optional dependencies _should_ fix the build.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
