### PR TITLE
fix: typescript error for optional dependency

### DIFF
--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6607,6 +6607,7 @@ describe('BrowserWindow module', () => {
       // WOA fails to load libnut so we're using require to defer loading only
       // on supported platforms.
       // "@nut-tree\libnut-win32\build\Release\libnut.node is not a valid Win32 application."
+      // @ts-ignore: nut-js is an optional dependency so it may not be installed
       const { mouse, straightTo, centerOf, Region, Button } = require('@nut-tree/nut-js') as typeof import('@nut-tree/nut-js');
 
       const display = screen.getPrimaryDisplay();


### PR DESCRIPTION
#### Description of Change

One more try for fixing https://github.com/electron/electron/pull/41199 🤞 

```
electron/spec/api-browser-window-spec.ts(6610,108): error TS2307: Cannot find module '@nut-tree/nut-js' or its corresponding type declarations.
```

Addresses [failure in linux-arm-testing-tests](https://app.circleci.com/pipelines/github/electron/electron/78153/workflows/ccb3fa14-053f-4683-a1ac-0740c2dee134/jobs/1666690?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary) by ignoring `@nut-tree/nut-js` type imports on platforms which don't install the optional dependecy.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
