### PR TITLE
fix: don't check for Desktop Environment in unity_service.cc

### DIFF
--- a/shell/browser/linux/unity_service.cc
+++ b/shell/browser/linux/unity_service.cc
@@ -51,20 +51,9 @@ unity_launcher_entry_set_progress_visible_func entry_set_progress_visible =
     nullptr;
 
 void EnsureLibUnityLoaded() {
-  using base::nix::GetDesktopEnvironment;
-
   if (attempted_load)
     return;
   attempted_load = true;
-
-  auto env = base::Environment::Create();
-  base::nix::DesktopEnvironment desktop_env = GetDesktopEnvironment(env.get());
-
-  // The "icon-tasks" KDE task manager also honors Unity Launcher API.
-  if (desktop_env != base::nix::DESKTOP_ENVIRONMENT_UNITY &&
-      desktop_env != base::nix::DESKTOP_ENVIRONMENT_KDE4 &&
-      desktop_env != base::nix::DESKTOP_ENVIRONMENT_KDE5)
-    return;
 
   // Ubuntu still hasn't given us a nice libunity.so symlink.
   void* unity_lib = dlopen("libunity.so.4", RTLD_LAZY);


### PR DESCRIPTION
#### Description of Change

Electron uses libunity to implement [setProgressBar](https://www.electronjs.org/de/docs/latest/api/browser-window#winsetprogressbarprogress-options) and [setBadgeCount](https://www.electronjs.org/de/docs/latest/api/browser-window#winsetprogressbarprogress-options). The Unity Launcher API is currently supported by multiple Programs and Desktop. Electron cheeks for some reason which desktop environment the User is using.

This is completely pointless. libunity just emits a DBus signal. If a Desktop Environment don't support the API, it just don't listen to the signal, so there is no harm when emitting this signal.

On the other hand, this Signal is supported by various Software such as the [Dash to Dock](https://github.com/micheleg/dash-to-dock/blob/c569e2e3dd4b79f848d22d23375ecad1038b2d97/launcherAPI.js#L15) or Plank. If Electron checks the Desktop Environment, it will not work, unset you set `XDG_CURRENT_DESKTOP=KDE`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Don't check for Desktop Environment in setProgressBar and setBadgeCount.
