### PR TITLE
refactor: replace use of deprecated `base::JSONWriter::WriteJson()`

### DIFF
--- a/shell/browser/api/electron_api_debugger.cc
+++ b/shell/browser/api/electron_api_debugger.cc
@@ -159,8 +159,7 @@ v8::Local<v8::Promise> Debugger::SendCommand(gin::Arguments* args) {
     request.Set("sessionId", session_id);
   }
 
-  std::string json_args;
-  base::JSONWriter::Write(request, &json_args);
+  const auto json_args = base::WriteJson(request).value_or("");
   agent_host_->DispatchProtocolMessage(
       this, base::as_bytes(base::make_span(json_args)));
 

--- a/shell/browser/extensions/api/scripting/scripting_api.cc
+++ b/shell/browser/extensions/api/scripting/scripting_api.cc
@@ -631,10 +631,11 @@ ExtensionFunction::ResponseAction ScriptingExecuteScriptFunction::Run() {
     std::vector<std::string> string_args;
     string_args.reserve(injection_.args->size());
     for (const auto& arg : *injection_.args) {
-      std::string json;
-      if (!base::JSONWriter::Write(arg, &json))
+      if (auto json = base::WriteJson(arg)) {
+        string_args.push_back(std::move(*json));
+      } else {
         return RespondNow(Error("Unserializable argument passed."));
-      string_args.push_back(std::move(json));
+      }
     }
     args_expression = base::JoinString(string_args, ",");
   }

--- a/shell/browser/mac/dict_util.mm
+++ b/shell/browser/mac/dict_util.mm
@@ -13,10 +13,10 @@
 namespace electron {
 
 NSArray* ListValueToNSArray(const base::Value::List& value) {
-  std::string json;
-  if (!base::JSONWriter::Write(base::ValueView{value}, &json))
+  const auto json = base::WriteJson(value);
+  if (!json.has_value())
     return nil;
-  NSData* jsonData = [NSData dataWithBytes:json.c_str() length:json.length()];
+  NSData* jsonData = [NSData dataWithBytes:json->data() length:json->size()];
   id obj = [NSJSONSerialization JSONObjectWithData:jsonData
                                            options:0
                                              error:nil];
@@ -56,10 +56,10 @@ base::Value::List NSArrayToValue(NSArray* arr) {
 }
 
 NSDictionary* DictionaryValueToNSDictionary(const base::Value::Dict& value) {
-  std::string json;
-  if (!base::JSONWriter::Write(base::ValueView{value}, &json))
+  const auto json = base::WriteJson(value);
+  if (!json.has_value())
     return nil;
-  NSData* jsonData = [NSData dataWithBytes:json.c_str() length:json.length()];
+  NSData* jsonData = [NSData dataWithBytes:json->data() length:json->size()];
   id obj = [NSJSONSerialization JSONObjectWithData:jsonData
                                            options:0
                                              error:nil];

--- a/shell/browser/ui/webui/accessibility_ui.cc
+++ b/shell/browser/ui/webui/accessibility_ui.cc
@@ -295,11 +295,8 @@ void HandleAccessibilityRequestCallback(
 
   data.Set(kBrowsersField, std::move(window_list));
 
-  std::string json_string;
-  base::JSONWriter::Write(data, &json_string);
-
-  std::move(callback).Run(
-      base::MakeRefCounted<base::RefCountedString>(std::move(json_string)));
+  std::move(callback).Run(base::MakeRefCounted<base::RefCountedString>(
+      base::WriteJson(data).value_or("")));
 }
 
 }  // namespace


### PR DESCRIPTION
#### Description of Change

Another PR in the "remove deprecated API use" series.

`base/json/json_writer.h` documents `base::JSONWriter::WriteJson()` this way:

>   // Deprecated: use the standalone method `WriteJson()` instead.

So this PR does exactly that.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none