### PR TITLE
refactor: remove deprecated BrowserContext::ResourceContext

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1228,13 +1228,11 @@ void App::ImportCertificate(gin_helper::ErrorThrower thrower,
     return;
   }
 
-  auto* browser_context = ElectronBrowserContext::From("", false);
+  ElectronBrowserContext::From("", false);
   if (!certificate_manager_model_) {
-    CertificateManagerModel::Create(
-        browser_context,
-        base::BindOnce(&App::OnCertificateManagerModelCreated,
-                       base::Unretained(this), std::move(options),
-                       std::move(callback)));
+    CertificateManagerModel::Create(base::BindOnce(
+        &App::OnCertificateManagerModelCreated, base::Unretained(this),
+        std::move(options), std::move(callback)));
     return;
   }
 

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1228,7 +1228,6 @@ void App::ImportCertificate(gin_helper::ErrorThrower thrower,
     return;
   }
 
-  ElectronBrowserContext::From("", false);
   if (!certificate_manager_model_) {
     CertificateManagerModel::Create(base::BindOnce(
         &App::OnCertificateManagerModelCreated, base::Unretained(this),

--- a/shell/browser/certificate_manager_model.cc
+++ b/shell/browser/certificate_manager_model.cc
@@ -23,7 +23,7 @@ namespace {
 
 net::NSSCertDatabase* g_nss_cert_database = nullptr;
 
-net::NSSCertDatabase* GetNSSCertDatabaseForResourceContext(
+net::NSSCertDatabase* GetNSSCertDatabase(
     base::OnceCallback<void(net::NSSCertDatabase*)> callback) {
   // This initialization is not thread safe. This CHECK ensures that this code
   // is only run on a single thread.
@@ -54,7 +54,7 @@ net::NSSCertDatabase* GetNSSCertDatabaseForResourceContext(
 //                  \--------------------------------------v
 //                                CertificateManagerModel::GetCertDBOnIOThread
 //                                                         |
-//                                     GetNSSCertDatabaseForResourceContext
+//                                                 GetNSSCertDatabase
 //                                                         |
 //                               CertificateManagerModel::DidGetCertDBOnIOThread
 //                  v--------------------------------------/
@@ -153,7 +153,7 @@ void CertificateManagerModel::GetCertDBOnIOThread(CreationCallback callback) {
       &CertificateManagerModel::DidGetCertDBOnIOThread, std::move(callback)));
 
   net::NSSCertDatabase* cert_db =
-      GetNSSCertDatabaseForResourceContext(std::move(split_callback.first));
+      GetNSSCertDatabase(std::move(split_callback.first));
 
   // If the NSS database was already available, |cert_db| is non-null and
   // |did_get_cert_db_callback| has not been called. Call it explicitly.

--- a/shell/browser/certificate_manager_model.cc
+++ b/shell/browser/certificate_manager_model.cc
@@ -7,9 +7,7 @@
 #include <utility>
 
 #include "base/functional/bind.h"
-#include "base/logging.h"
-#include "base/strings/utf_string_conversions.h"
-#include "content/public/browser/browser_context.h"
+#include "base/memory/ptr_util.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/resource_context.h"
@@ -67,8 +65,7 @@ net::NSSCertDatabase* GetNSSCertDatabaseForResourceContext(
 //               callback
 
 // static
-void CertificateManagerModel::Create(content::BrowserContext* browser_context,
-                                     CreationCallback callback) {
+void CertificateManagerModel::Create(CreationCallback callback) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
   content::GetIOThreadTaskRunner({})->PostTask(
       FROM_HERE, base::BindOnce(&CertificateManagerModel::GetCertDBOnIOThread,

--- a/shell/browser/certificate_manager_model.cc
+++ b/shell/browser/certificate_manager_model.cc
@@ -26,7 +26,6 @@ namespace {
 net::NSSCertDatabase* g_nss_cert_database = nullptr;
 
 net::NSSCertDatabase* GetNSSCertDatabaseForResourceContext(
-    content::ResourceContext* context,
     base::OnceCallback<void(net::NSSCertDatabase*)> callback) {
   // This initialization is not thread safe. This CHECK ensures that this code
   // is only run on a single thread.
@@ -159,8 +158,8 @@ void CertificateManagerModel::GetCertDBOnIOThread(
   auto split_callback = base::SplitOnceCallback(base::BindOnce(
       &CertificateManagerModel::DidGetCertDBOnIOThread, std::move(callback)));
 
-  net::NSSCertDatabase* cert_db = GetNSSCertDatabaseForResourceContext(
-      context, std::move(split_callback.first));
+  net::NSSCertDatabase* cert_db =
+      GetNSSCertDatabaseForResourceContext(std::move(split_callback.first));
 
   // If the NSS database was already available, |cert_db| is non-null and
   // |did_get_cert_db_callback| has not been called. Call it explicitly.

--- a/shell/browser/certificate_manager_model.cc
+++ b/shell/browser/certificate_manager_model.cc
@@ -72,7 +72,6 @@ void CertificateManagerModel::Create(content::BrowserContext* browser_context,
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
   content::GetIOThreadTaskRunner({})->PostTask(
       FROM_HERE, base::BindOnce(&CertificateManagerModel::GetCertDBOnIOThread,
-                                browser_context->GetResourceContext(),
                                 std::move(callback)));
 }
 
@@ -150,9 +149,7 @@ void CertificateManagerModel::DidGetCertDBOnIOThread(
 }
 
 // static
-void CertificateManagerModel::GetCertDBOnIOThread(
-    content::ResourceContext* context,
-    CreationCallback callback) {
+void CertificateManagerModel::GetCertDBOnIOThread(CreationCallback callback) {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
 
   auto split_callback = base::SplitOnceCallback(base::BindOnce(

--- a/shell/browser/certificate_manager_model.h
+++ b/shell/browser/certificate_manager_model.h
@@ -13,11 +13,6 @@
 #include "base/memory/ref_counted.h"
 #include "net/cert/nss_cert_database.h"
 
-namespace content {
-class BrowserContext;
-class ResourceContext;
-}  // namespace content
-
 // CertificateManagerModel provides the data to be displayed in the certificate
 // manager dialog, and processes changes from the view.
 class CertificateManagerModel {

--- a/shell/browser/certificate_manager_model.h
+++ b/shell/browser/certificate_manager_model.h
@@ -105,8 +105,7 @@ class CertificateManagerModel {
                                      CreationCallback callback);
   static void DidGetCertDBOnIOThread(CreationCallback callback,
                                      net::NSSCertDatabase* cert_db);
-  static void GetCertDBOnIOThread(content::ResourceContext* context,
-                                  CreationCallback callback);
+  static void GetCertDBOnIOThread(CreationCallback callback);
 
   raw_ptr<net::NSSCertDatabase> cert_db_;
   // Whether the certificate database has a public slot associated with the

--- a/shell/browser/certificate_manager_model.h
+++ b/shell/browser/certificate_manager_model.h
@@ -26,10 +26,8 @@ class CertificateManagerModel {
       base::OnceCallback<void(std::unique_ptr<CertificateManagerModel>)>;
 
   // Creates a CertificateManagerModel. The model will be passed to the callback
-  // when it is ready. The caller must ensure the model does not outlive the
-  // |browser_context|.
-  static void Create(content::BrowserContext* browser_context,
-                     CreationCallback callback);
+  // when it is ready.
+  static void Create(CreationCallback callback);
 
   // disable copy
   CertificateManagerModel(const CertificateManagerModel&) = delete;


### PR DESCRIPTION
#### Description of Change

Another PR in the "remove deprecated API use" series.

`BrowserContext::GetResourceContext()` was deprecated a month ago by https://chromium-review.googlesource.com/c/chromium/src/+/5139789 because "[ResourceContext] seems to be an empty class meant to be removed at some point."

We use it in one place; and indeed, that use does seem superfluous. This PR removes it.

All reviewers welcomed. CC @zcbenz because I have a question about one change, mentioned inline

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.