### PR TITLE
fix: add language to html in quick-start.md

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -126,7 +126,7 @@ folder of your project:
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8">
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
@@ -420,9 +420,8 @@ window.addEventListener('DOMContentLoaded', () => {
 
 ```html
 <!--index.html-->
-
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8">
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->


### PR DESCRIPTION
We must define language in HTML for different reasons (accessibility++)

#### Description of Change

A very simple, yet important, change - only defined language for `<html>` to be `<html lang="en">`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes

#### Release Notes

Notes: none
