### PR TITLE
chore: remove deprecated `inputFieldType`

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -778,9 +778,6 @@ Returns:
     `input-text`, `input-time`, `input-url`, `input-week`, `output`, `reset-button`,
     `select-list`, `select-list`, `select-multiple`, `select-one`, `submit-button`,
     and `text-area`,
-  * `inputFieldType` string _Deprecated_ - If the context menu was invoked on an
-    input field, the type of that field. Possible values include `none`,
-    `plainText`, `password`, `other`.
   * `spellcheckEnabled` boolean - If the context is editable, whether or not spellchecking is enabled.
   * `menuSourceType` string - Input source that invoked the context menu.
     Can be `none`, `mouse`, `keyboard`, `touch`, `touchMenu`, `longPress`, `longTap`, `touchHandle`, `stylus`, `adjustSelection`, or `adjustSelectionReset`.

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -1111,9 +1111,6 @@ Returns:
     `input-text`, `input-time`, `input-url`, `input-week`, `output`, `reset-button`,
     `select-list`, `select-list`, `select-multiple`, `select-one`, `submit-button`,
     and `text-area`,
-  * `inputFieldType` string _Deprecated_ - If the context menu was invoked on an
-    input field, the type of that field. Possible values include `none`,
-    `plainText`, `password`, `other`.
   * `spellcheckEnabled` boolean - If the context is editable, whether or not spellchecking is enabled.
   * `menuSourceType` string - Input source that invoked the context menu.
     Can be `none`, `mouse`, `keyboard`, `touch`, `touchMenu`, `longPress`, `longTap`, `touchHandle`, `stylus`, `adjustSelection`, or `adjustSelectionReset`.

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -38,6 +38,12 @@ The autoresizing behavior is now standardized across all platforms.
 If your app uses `BrowserView.setAutoResize` to do anything more complex than making a BrowserView fill the entire window, it's likely you already had custom logic in place to handle this difference in behavior on macOS.
 If so, that logic will no longer be needed in Electron 30 as autoresizing behavior is consistent.
 
+### Removed: `params.inputFormType` property on `context-menu` on `WebContents`
+
+The `inputFormType` property of the params object in the `context-menu`
+event from `WebContents` has been removed. Use the new `formControlType`
+property instead.
+
 ## Planned Breaking API Changes (29.0)
 
 ### Behavior Changed: `ipcRenderer` can no longer be sent over the `contextBridge`

--- a/shell/common/gin_converters/content_converter.cc
+++ b/shell/common/gin_converters/content_converter.cc
@@ -23,51 +23,6 @@
 #include "ui/events/keycodes/dom/keycode_converter.h"
 #include "ui/events/keycodes/keyboard_code_conversion.h"
 
-namespace {
-
-[[nodiscard]] constexpr std::string_view FormControlToInputFieldTypeString(
-    const std::optional<blink::mojom::FormControlType> form_control_type) {
-  if (!form_control_type)
-    return "none";
-
-  switch (*form_control_type) {
-    case blink::mojom::FormControlType::kInputPassword:
-      return "password";
-
-    case blink::mojom::FormControlType::kInputText:
-      return "plainText";
-
-    // other input types:
-    case blink::mojom::FormControlType::kInputButton:
-    case blink::mojom::FormControlType::kInputCheckbox:
-    case blink::mojom::FormControlType::kInputColor:
-    case blink::mojom::FormControlType::kInputDate:
-    case blink::mojom::FormControlType::kInputDatetimeLocal:
-    case blink::mojom::FormControlType::kInputEmail:
-    case blink::mojom::FormControlType::kInputFile:
-    case blink::mojom::FormControlType::kInputHidden:
-    case blink::mojom::FormControlType::kInputImage:
-    case blink::mojom::FormControlType::kInputMonth:
-    case blink::mojom::FormControlType::kInputNumber:
-    case blink::mojom::FormControlType::kInputRadio:
-    case blink::mojom::FormControlType::kInputRange:
-    case blink::mojom::FormControlType::kInputReset:
-    case blink::mojom::FormControlType::kInputSearch:
-    case blink::mojom::FormControlType::kInputSubmit:
-    case blink::mojom::FormControlType::kInputTelephone:
-    case blink::mojom::FormControlType::kInputTime:
-    case blink::mojom::FormControlType::kInputUrl:
-    case blink::mojom::FormControlType::kInputWeek:
-      return "other";
-
-    // not an input type
-    default:
-      return "none";
-  }
-}
-
-}  // namespace
-
 namespace gin {
 
 static constexpr auto MenuSourceTypes =
@@ -162,12 +117,6 @@ v8::Local<v8::Value> Converter<ContextMenuParamsWithRenderFrameHost>::ToV8(
   dict.Set("frameCharset", params.frame_charset);
   dict.Set("referrerPolicy", params.referrer_policy);
   dict.Set("formControlType", params.form_control_type);
-
-  // NB: inputFieldType is deprecated because the upstream
-  // field was removed; we are emulating it now until removal
-  dict.Set("inputFieldType",
-           FormControlToInputFieldTypeString(params.form_control_type));
-
   dict.Set("menuSourceType", params.source_type);
 
   return gin::ConvertToV8(isolate, dict);

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -1319,6 +1319,11 @@ win4.webContents.on('scroll-touch-end', () => {});
 // @ts-expect-error Removed API
 win4.webContents.on('crashed', () => {});
 
+win4.webContents.on('context-menu', (event, params) => {
+  // @ts-expect-error Removed API
+  console.log(params.inputFieldType);
+});
+
 // TouchBar
 // https://github.com/electron/electron/blob/main/docs/api/touch-bar.md
 


### PR DESCRIPTION
#### Description of Change
Follow-up to #40316

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: The `inputFieldType` property in the `context-menu` params has been removed.
