### PR TITLE
refactor:  KeyWeakMap cleanup

### DIFF
--- a/shell/common/gin_helper/trackable_object.h
+++ b/shell/common/gin_helper/trackable_object.h
@@ -107,7 +107,7 @@ class TrackableObject : public TrackableObjectBase, public EventEmitter<T> {
 
   // Removes this instance from the weak map.
   void RemoveFromWeakMap() {
-    if (weak_map_ && weak_map_->Has(weak_map_id()))
+    if (weak_map_)
       weak_map_->Remove(weak_map_id());
   }
 

--- a/shell/common/key_weak_map.h
+++ b/shell/common/key_weak_map.h
@@ -14,7 +14,7 @@
 
 namespace electron {
 
-// Like ES6's WeakMap, but the key is Integer and the value is Weak Pointer.
+// Like ES6's WeakMap, with a K key and Weak Pointer value.
 template <typename K>
 class KeyWeakMap {
  public:

--- a/shell/common/key_weak_map.h
+++ b/shell/common/key_weak_map.h
@@ -19,7 +19,7 @@ template <typename K>
 class KeyWeakMap {
  public:
   KeyWeakMap() {}
-  virtual ~KeyWeakMap() {
+  ~KeyWeakMap() {
     for (auto& p : map_)
       p.second.second.ClearWeak();
   }

--- a/shell/common/key_weak_map.h
+++ b/shell/common/key_weak_map.h
@@ -45,11 +45,12 @@ class KeyWeakMap {
 
   // Returns all objects.
   std::vector<v8::Local<v8::Object>> Values(v8::Isolate* isolate) const {
-    std::vector<v8::Local<v8::Object>> keys;
-    keys.reserve(map_.size());
+    std::vector<v8::Local<v8::Object>> values;
+    values.reserve(map_.size());
     for (const auto& it : map_)
-      keys.emplace_back(v8::Local<v8::Object>::New(isolate, it.second.second));
-    return keys;
+      values.emplace_back(
+          v8::Local<v8::Object>::New(isolate, it.second.second));
+    return values;
   }
 
   // Remove object with |key| in the WeakMap.

--- a/shell/common/key_weak_map.h
+++ b/shell/common/key_weak_map.h
@@ -19,12 +19,6 @@ namespace electron {
 template <typename K>
 class KeyWeakMap {
  public:
-  // Records the key and self, used by SetWeak.
-  struct KeyObject {
-    K key;
-    raw_ptr<KeyWeakMap> self;
-  };
-
   KeyWeakMap() {}
   virtual ~KeyWeakMap() {
     for (auto& p : map_)
@@ -75,6 +69,12 @@ class KeyWeakMap {
   }
 
  private:
+  // Records the key and self, used by SetWeak.
+  struct KeyObject {
+    K key;
+    raw_ptr<KeyWeakMap> self;
+  };
+
   static void OnObjectGC(
       const v8::WeakCallbackInfo<typename KeyWeakMap<K>::KeyObject>& data) {
     KeyWeakMap<K>::KeyObject* key_object = data.GetParameter();

--- a/shell/common/key_weak_map.h
+++ b/shell/common/key_weak_map.h
@@ -38,11 +38,9 @@ class KeyWeakMap {
 
   // Gets the object from WeakMap by its |key|.
   v8::MaybeLocal<v8::Object> Get(v8::Isolate* isolate, const K& key) {
-    auto iter = map_.find(key);
-    if (iter == map_.end())
-      return v8::MaybeLocal<v8::Object>();
-    else
+    if (auto iter = map_.find(key); iter != map_.end())
       return v8::Local<v8::Object>::New(isolate, iter->second.second);
+    return {};
   }
 
   // Returns all objects.

--- a/shell/common/key_weak_map.h
+++ b/shell/common/key_weak_map.h
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/containers/contains.h"
 #include "base/memory/raw_ptr.h"
 #include "v8/include/v8.h"
 
@@ -45,9 +44,6 @@ class KeyWeakMap {
     else
       return v8::Local<v8::Object>::New(isolate, iter->second.second);
   }
-
-  // Whether there is an object with |key| in this WeakMap.
-  constexpr bool Has(const K& key) const { return base::Contains(map_, key); }
 
   // Returns all objects.
   std::vector<v8::Local<v8::Object>> Values(v8::Isolate* isolate) const {


### PR DESCRIPTION
#### Description of Change

Code cleanup in `KeyWeakMap`:

- Make the impl struct `KeyObject` private
- Remove unused method `KeyWeakMap::Has()`
- Destructor was virtual but didn't need to be
- Rename misnamed local variable in `KeyValueMap::Values()`: was `keys`, is now `values`

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none