### PR TITLE
build: add flag for setting vendor version

### DIFF
--- a/buildflags/BUILD.gn
+++ b/buildflags/BUILD.gn
@@ -14,4 +14,15 @@ buildflag_header("buildflags") {
     "ENABLE_BUILTIN_SPELLCHECKER=$enable_builtin_spellchecker",
     "OVERRIDE_LOCATION_PROVIDER=$enable_fake_location_provider",
   ]
+
+  if (electron_vendor_version != "") {
+    result = string_split(electron_vendor_version, ":")
+    flags += [
+      "HAS_VENDOR_VERSION=true",
+      "VENDOR_VERSION_NAME=\"${result[0]}\"",
+      "VENDOR_VERSION_VALUE=\"${result[1]}\"",
+    ]
+  } else {
+    flags += [ "HAS_VENDOR_VERSION=false" ]
+  }
 }

--- a/buildflags/buildflags.gni
+++ b/buildflags/buildflags.gni
@@ -21,4 +21,10 @@ declare_args() {
   # Packagers and vendor builders should set this in gn args to avoid running
   # the script that reads git tag.
   override_electron_version = ""
+
+  # Define an extra item that will show in process.versions, the value must
+  # be in the format of "key:value".
+  # Packagers and vendor builders can set this in gn args to attach extra info
+  # about the build in the binary.
+  electron_vendor_version = ""
 }

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -942,6 +942,10 @@ void OnNodePreload(node::Environment* env,
   if (dict.Get("versions", &versions)) {
     versions.SetReadOnly(ELECTRON_PROJECT_NAME, ELECTRON_VERSION_STRING);
     versions.SetReadOnly("chrome", CHROME_VERSION_STRING);
+#if BUILDFLAG(HAS_VENDOR_VERSION)
+    versions.SetReadOnly(BUILDFLAG(VENDOR_VERSION_NAME),
+                         BUILDFLAG(VENDOR_VERSION_VALUE));
+#endif
   }
 
   // Execute lib/node/init.ts.


### PR DESCRIPTION
#### Description of Change

For linux packagers and vendor builds, it is very common to add an extra field to `process.versions` to attach more information about the build, like which party did the build and the build ID in CI.

It was usually done by patching Electron, this PR makes it possible with a gn arg only.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none