### PR TITLE
refactor: inline simple getters, pt . 2

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1681,7 +1681,7 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
       .SetMethod("setBadgeCount",
                  base::BindRepeating(&Browser::SetBadgeCount, browser))
       .SetMethod("getBadgeCount",
-                 base::BindRepeating(&Browser::GetBadgeCount, browser))
+                 base::BindRepeating(&Browser::badge_count, browser))
       .SetMethod("getLoginItemSettings", &App::GetLoginItemSettings)
       .SetMethod("setLoginItemSettings",
                  base::BindRepeating(&Browser::SetLoginItemSettings, browser))

--- a/shell/browser/api/electron_api_safe_storage.cc
+++ b/shell/browser/api/electron_api_safe_storage.cc
@@ -31,7 +31,7 @@ bool IsEncryptionAvailable() {
   return OSCrypt::IsEncryptionAvailable() ||
          (use_password_v10 &&
           static_cast<BrowserProcessImpl*>(g_browser_process)
-                  ->GetLinuxStorageBackend() == "basic_text");
+                  ->linux_storage_backend() == "basic_text");
 #else
   return OSCrypt::IsEncryptionAvailable();
 #endif
@@ -46,7 +46,7 @@ std::string GetSelectedLinuxBackend() {
   if (!Browser::Get()->is_ready())
     return "unknown";
   return static_cast<BrowserProcessImpl*>(g_browser_process)
-      ->GetLinuxStorageBackend();
+      ->linux_storage_backend();
 }
 #endif
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2374,10 +2374,6 @@ base::ProcessId WebContents::GetOSProcessID() const {
   return base::GetProcId(process_handle);
 }
 
-WebContents::Type WebContents::GetType() const {
-  return type_;
-}
-
 bool WebContents::Equal(const WebContents* web_contents) const {
   return ID() == web_contents->ID();
 }
@@ -3371,7 +3367,7 @@ bool WebContents::IsFocused() const {
   if (!view)
     return false;
 
-  if (GetType() != Type::kBackgroundPage) {
+  if (type() != Type::kBackgroundPage) {
     auto* window = web_contents()->GetNativeView()->GetToplevelWindow();
     if (window && !window->IsVisible())
       return false;
@@ -4412,7 +4408,7 @@ void WebContents::FillObjectTemplate(v8::Isolate* isolate,
       .SetMethod("getZoomLevel", &WebContents::GetZoomLevel)
       .SetMethod("setZoomFactor", &WebContents::SetZoomFactor)
       .SetMethod("getZoomFactor", &WebContents::GetZoomFactor)
-      .SetMethod("getType", &WebContents::GetType)
+      .SetMethod("getType", &WebContents::type)
       .SetMethod("_getPreloadPaths", &WebContents::GetPreloadPaths)
       .SetMethod("getLastWebPreferences", &WebContents::GetLastWebPreferences)
       .SetMethod("getOwnerBrowserWindow", &WebContents::GetOwnerBrowserWindow)

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -852,7 +852,7 @@ WebContents::WebContents(v8::Isolate* isolate,
   session_.Reset(isolate, session.ToV8());
 
   std::unique_ptr<content::WebContents> web_contents;
-  if (IsGuest()) {
+  if (is_guest()) {
     scoped_refptr<content::SiteInstance> site_instance =
         content::SiteInstance::CreateForURL(session->browser_context(),
                                             GURL("chrome-guest://fake-host"));
@@ -922,7 +922,7 @@ void WebContents::InitWithSessionAndOptions(
     const gin_helper::Dictionary& options) {
   Observe(owned_web_contents.get());
   InitWithWebContents(std::move(owned_web_contents), session->browser_context(),
-                      IsGuest());
+                      is_guest());
 
   inspectable_web_contents_->GetView()->SetDelegate(this);
 
@@ -982,7 +982,7 @@ void WebContents::InitWithSessionAndOptions(
 
   SetUserAgent(GetBrowserContext()->GetUserAgent());
 
-  if (IsGuest()) {
+  if (is_guest()) {
     NativeWindow* owner_window = nullptr;
     if (embedder_) {
       // New WebContents's owner_window is the embedder's owner_window.
@@ -1017,7 +1017,7 @@ void WebContents::InitWithExtensionView(v8::Isolate* isolate,
   // Allow toggling DevTools for background pages
   Observe(web_contents);
   InitWithWebContents(std::unique_ptr<content::WebContents>(web_contents),
-                      GetBrowserContext(), IsGuest());
+                      GetBrowserContext(), is_guest());
   inspectable_web_contents_->GetView()->SetDelegate(this);
 }
 #endif
@@ -1066,7 +1066,7 @@ WebContents::~WebContents() {
 
   // For guest view based on OOPIF, the WebContents is released by the embedder
   // frame, and we need to clear the reference to the memory.
-  bool not_owned_by_this = IsGuest() && attached_;
+  bool not_owned_by_this = is_guest() && attached_;
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   // And background pages are owned by extensions::ExtensionHost.
   if (type_ == Type::kBackgroundPage)
@@ -1096,7 +1096,7 @@ void WebContents::DeleteThisIfAlive() {
 void WebContents::Destroy() {
   // The content::WebContents should be destroyed asynchronously when possible
   // as user may choose to destroy WebContents during an event of it.
-  if (Browser::Get()->is_shutting_down() || IsGuest()) {
+  if (Browser::Get()->is_shutting_down() || is_guest()) {
     DeleteThisIfAlive();
   } else {
     content::GetUIThreadTaskRunner({})->PostTask(
@@ -2155,7 +2155,7 @@ void WebContents::DidFinishNavigation(
         Emit("did-navigate", url, http_response_code, http_status_text);
       }
     }
-    if (IsGuest())
+    if (is_guest())
       Emit("load-commit", url, is_main_frame);
   } else {
     auto url = navigation_handle->GetURL();
@@ -3567,10 +3567,6 @@ void WebContents::OnCursorChanged(const ui::Cursor& cursor) {
   }
 }
 
-bool WebContents::IsGuest() const {
-  return type_ == Type::kWebView;
-}
-
 void WebContents::AttachToIframe(content::WebContents* embedder_web_contents,
                                  int embedder_frame_id) {
   attached_ = true;
@@ -3782,7 +3778,7 @@ void WebContents::SetImageAnimationPolicy(const std::string& new_policy) {
 }
 
 void WebContents::SetBackgroundColor(std::optional<SkColor> maybe_color) {
-  SkColor color = maybe_color.value_or((IsGuest() && guest_transparent_) ||
+  SkColor color = maybe_color.value_or((is_guest() && guest_transparent_) ||
                                                type_ == Type::kBrowserView
                                            ? SK_ColorTRANSPARENT
                                            : SK_ColorWHITE);
@@ -4304,7 +4300,7 @@ void WebContents::UpdateHtmlApiFullscreen(bool fullscreen) {
   }
 
   // Make sure all child webviews quit html fullscreen.
-  if (!fullscreen && !IsGuest()) {
+  if (!fullscreen && !is_guest()) {
     auto* manager = WebViewManager::GetWebViewManager(web_contents());
     manager->ForEachGuest(web_contents(), [&](content::WebContents* guest) {
       WebContents* api_web_contents = WebContents::From(guest);

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -292,7 +292,7 @@ class WebContents : public ExclusiveAccessContext,
   v8::Local<v8::Promise> CapturePage(gin::Arguments* args);
 
   // Methods for creating <webview>.
-  bool IsGuest() const;
+  [[nodiscard]] bool is_guest() const { return type_ == Type::kWebView; }
   void AttachToIframe(content::WebContents* embedder_web_contents,
                       int embedder_frame_id);
   void DetachFromOuterFrame();

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -173,7 +173,7 @@ class WebContents : public ExclusiveAccessContext,
   void SetBackgroundThrottling(bool allowed);
   int GetProcessID() const;
   base::ProcessId GetOSProcessID() const;
-  Type GetType() const;
+  [[nodiscard]] Type type() const { return type_; }
   bool Equal(const WebContents* web_contents) const;
   void LoadURL(const GURL& url, const gin_helper::Dictionary& options);
   void Reload();

--- a/shell/browser/api/electron_api_web_contents_mac.mm
+++ b/shell/browser/api/electron_api_web_contents_mac.mm
@@ -24,7 +24,7 @@ bool WebContents::IsFocused() const {
   if (!view)
     return false;
 
-  if (GetType() != Type::kBackgroundPage) {
+  if (type() != Type::kBackgroundPage) {
     auto window = [web_contents()->GetNativeView().GetNativeNSView() window];
     // On Mac the render widget host view does not lose focus when the window
     // loses focus so check if the top level window is the key window.

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -159,10 +159,6 @@ void Browser::SetName(const std::string& name) {
   OverriddenApplicationName() = name;
 }
 
-int Browser::GetBadgeCount() {
-  return badge_count_;
-}
-
 bool Browser::OpenFile(const std::string& file_path) {
   bool prevent_default = false;
   for (BrowserObserver& observer : observers_)

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -110,7 +110,7 @@ class Browser : public WindowListObserver {
 
   // Set/Get the badge count.
   bool SetBadgeCount(std::optional<int> count);
-  int GetBadgeCount();
+  [[nodiscard]] int badge_count() const { return badge_count_; }
 
 #if BUILDFLAG(IS_WIN)
   struct LaunchItem {

--- a/shell/browser/browser_process_impl.cc
+++ b/shell/browser/browser_process_impl.cc
@@ -340,10 +340,6 @@ void BrowserProcessImpl::SetLinuxStorageBackend(
       break;
   }
 }
-
-const std::string& BrowserProcessImpl::GetLinuxStorageBackend() const {
-  return selected_linux_storage_backend_;
-}
 #endif  // BUILDFLAG(IS_LINUX)
 
 void BrowserProcessImpl::SetApplicationLocale(const std::string& locale) {

--- a/shell/browser/browser_process_impl.h
+++ b/shell/browser/browser_process_impl.h
@@ -59,7 +59,9 @@ class BrowserProcessImpl : public BrowserProcess {
 
 #if BUILDFLAG(IS_LINUX)
   void SetLinuxStorageBackend(os_crypt::SelectedLinuxBackend selected_backend);
-  const std::string& GetLinuxStorageBackend() const;
+  [[nodiscard]] const std::string& linux_storage_backend() const {
+    return selected_linux_storage_backend_;
+  }
 #endif
 
   void EndSession() override {}

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -520,14 +520,6 @@ bool NativeWindow::IsMenuBarVisible() const {
   return true;
 }
 
-double NativeWindow::GetAspectRatio() const {
-  return aspect_ratio_;
-}
-
-gfx::Size NativeWindow::GetAspectRatioExtraSize() const {
-  return aspect_ratio_extraSize_;
-}
-
 void NativeWindow::SetAspectRatio(double aspect_ratio,
                                   const gfx::Size& extra_size) {
   aspect_ratio_ = aspect_ratio;

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -264,8 +264,10 @@ class NativeWindow : public base::SupportsUserData,
   virtual bool IsMenuBarVisible() const;
 
   // Set the aspect ratio when resizing window.
-  double GetAspectRatio() const;
-  gfx::Size GetAspectRatioExtraSize() const;
+  [[nodiscard]] double aspect_ratio() const { return aspect_ratio_; }
+  [[nodiscard]] gfx::Size aspect_ratio_extra_size() const {
+    return aspect_ratio_extraSize_;
+  }
   virtual void SetAspectRatio(double aspect_ratio, const gfx::Size& extra_size);
 
   // File preview APIs.

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -641,7 +641,7 @@ bool NativeWindowMac::IsMaximized() const {
   if (HasStyleMask(NSWindowStyleMaskResizable) != 0)
     return [window_ isZoomed];
 
-  NSRect rectScreen = GetAspectRatio() > 0.0
+  NSRect rectScreen = aspect_ratio() > 0.0
                           ? default_frame_for_zoom()
                           : [[NSScreen mainScreen] visibleFrame];
 

--- a/shell/browser/ui/autofill_popup.cc
+++ b/shell/browser/ui/autofill_popup.cc
@@ -231,7 +231,7 @@ void AutofillPopup::SetItems(const std::vector<std::u16string>& values,
 void AutofillPopup::AcceptSuggestion(int index) {
   mojo::AssociatedRemote<mojom::ElectronAutofillAgent> autofill_agent;
   frame_host_->GetRemoteAssociatedInterfaces()->GetInterface(&autofill_agent);
-  autofill_agent->AcceptDataListSuggestion(GetValueAt(index));
+  autofill_agent->AcceptDataListSuggestion(value_at(index));
 }
 
 void AutofillPopup::UpdatePopupBounds() {
@@ -272,11 +272,10 @@ int AutofillPopup::GetDesiredPopupWidth() {
   int popup_width = element_bounds_.width();
 
   for (size_t i = 0; i < values_.size(); ++i) {
-    int row_size =
-        kEndPadding + 2 * kPopupBorderThickness +
-        gfx::GetStringWidth(GetValueAt(i), GetValueFontListForRow(i)) +
-        gfx::GetStringWidth(GetLabelAt(i), GetLabelFontListForRow(i));
-    if (!GetLabelAt(i).empty())
+    int row_size = kEndPadding + 2 * kPopupBorderThickness +
+                   gfx::GetStringWidth(value_at(i), GetValueFontListForRow(i)) +
+                   gfx::GetStringWidth(label_at(i), GetLabelFontListForRow(i));
+    if (!label_at(i).empty())
       row_size += kNamePadding + kEndPadding;
 
     popup_width = std::max(popup_width, row_size);
@@ -305,18 +304,6 @@ ui::ColorId AutofillPopup::GetBackgroundColorIDForRow(int index) const {
   return (view_ && index == view_->GetSelectedLine())
              ? ui::kColorResultsTableHoveredBackground
              : ui::kColorResultsTableNormalBackground;
-}
-
-int AutofillPopup::GetLineCount() {
-  return values_.size();
-}
-
-std::u16string AutofillPopup::GetValueAt(int i) {
-  return values_.at(i);
-}
-
-std::u16string AutofillPopup::GetLabelAt(int i) {
-  return labels_.at(i);
 }
 
 int AutofillPopup::LineFromY(int y) const {

--- a/shell/browser/ui/autofill_popup.h
+++ b/shell/browser/ui/autofill_popup.h
@@ -57,9 +57,9 @@ class AutofillPopup : public views::ViewObserver {
   const gfx::FontList& GetLabelFontListForRow(int index) const;
   ui::ColorId GetBackgroundColorIDForRow(int index) const;
 
-  int GetLineCount();
-  std::u16string GetValueAt(int i);
-  std::u16string GetLabelAt(int i);
+  int line_count() const { return values_.size(); }
+  const std::u16string& value_at(int i) const { return values_.at(i); }
+  const std::u16string& label_at(int i) const { return labels_.at(i); }
   int LineFromY(int y) const;
 
   int selected_index_;

--- a/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.mm
+++ b/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.mm
@@ -27,7 +27,7 @@
   devtools_is_first_responder_ = NO;
   attached_to_window_ = NO;
 
-  if (inspectableWebContentsView_->inspectable_web_contents()->IsGuest()) {
+  if (inspectableWebContentsView_->inspectable_web_contents()->is_guest()) {
     fake_view_ = [[NSView alloc] init];
     [fake_view_ setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
     [self addSubview:fake_view_];

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -493,8 +493,8 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
   if (menu_)
     return menu_;
 
-  if (model_ && model_->GetSharingItem()) {
-    NSMenu* menu = [self createShareMenuForItem:*model_->GetSharingItem()];
+  if (model_ && model_->sharing_item()) {
+    NSMenu* menu = [self createShareMenuForItem:*model_->sharing_item()];
     menu_ = menu;
   } else {
     menu_ = [[NSMenu alloc] initWithTitle:@""];

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -76,7 +76,7 @@ using FullScreenTransitionState =
 - (NSRect)windowWillUseStandardFrame:(NSWindow*)window
                         defaultFrame:(NSRect)frame {
   if (!shell_->zoom_to_page_width()) {
-    if (shell_->GetAspectRatio() > 0.0)
+    if (shell_->aspect_ratio() > 0.0)
       shell_->set_default_frame_for_zoom(frame);
     return frame;
   }
@@ -104,7 +104,7 @@ using FullScreenTransitionState =
   // Set the width. Don't touch y or height.
   frame.size.width = zoomed_width;
 
-  if (shell_->GetAspectRatio() > 0.0)
+  if (shell_->aspect_ratio() > 0.0)
     shell_->set_default_frame_for_zoom(frame);
 
   return frame;
@@ -139,13 +139,12 @@ using FullScreenTransitionState =
 
 - (NSSize)windowWillResize:(NSWindow*)sender toSize:(NSSize)frameSize {
   NSSize newSize = frameSize;
-  double aspectRatio = shell_->GetAspectRatio();
   NSWindow* window = shell_->GetNativeWindow().GetNativeNSWindow();
 
-  if (aspectRatio > 0.0) {
-    gfx::Size windowSize = shell_->GetSize();
-    gfx::Size contentSize = shell_->GetContentSize();
-    gfx::Size extraSize = shell_->GetAspectRatioExtraSize();
+  if (const double aspectRatio = shell_->aspect_ratio(); aspectRatio > 0.0) {
+    const gfx::Size windowSize = shell_->GetSize();
+    const gfx::Size contentSize = shell_->GetContentSize();
+    const gfx::Size extraSize = shell_->aspect_ratio_extra_size();
 
     double titleBarHeight = windowSize.height() - contentSize.height();
     double extraWidthPlusFrame =

--- a/shell/browser/ui/electron_menu_model.cc
+++ b/shell/browser/ui/electron_menu_model.cc
@@ -99,11 +99,6 @@ bool ElectronMenuModel::GetSharingItemAt(size_t index,
 void ElectronMenuModel::SetSharingItem(SharingItem item) {
   sharing_item_.emplace(std::move(item));
 }
-
-const std::optional<ElectronMenuModel::SharingItem>&
-ElectronMenuModel::GetSharingItem() const {
-  return sharing_item_;
-}
 #endif
 
 void ElectronMenuModel::MenuWillClose() {

--- a/shell/browser/ui/electron_menu_model.h
+++ b/shell/browser/ui/electron_menu_model.h
@@ -98,7 +98,10 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
   bool GetSharingItemAt(size_t index, SharingItem* item) const;
   // Set/Get the SharingItem of this menu.
   void SetSharingItem(SharingItem item);
-  const std::optional<SharingItem>& GetSharingItem() const;
+  [[nodiscard]] const std::optional<SharingItem>& sharing_item() const {
+    return sharing_item_;
+  }
+
 #endif
 
   // ui::SimpleMenuModel:

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -512,10 +512,6 @@ void InspectableWebContents::CallClientFunction(
       std::move(arguments), std::move(cb));
 }
 
-gfx::Rect InspectableWebContents::GetDevToolsBounds() const {
-  return devtools_bounds_;
-}
-
 void InspectableWebContents::SaveDevToolsBounds(const gfx::Rect& bounds) {
   pref_service_->Set(kDevToolsBoundsPref,
                      base::Value{RectToDictionary(bounds)});

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -384,10 +384,6 @@ InspectableWebContentsDelegate* InspectableWebContents::GetDelegate() const {
   return delegate_;
 }
 
-bool InspectableWebContents::IsGuest() const {
-  return is_guest_;
-}
-
 void InspectableWebContents::ReleaseWebContents() {
   web_contents_.release();
   WebContentsDestroyed();
@@ -454,7 +450,7 @@ void InspectableWebContents::CloseDevTools() {
       managed_devtools_web_contents_.reset();
     }
     embedder_message_dispatcher_.reset();
-    if (!IsGuest())
+    if (!is_guest())
       web_contents_->Focus();
   }
 }

--- a/shell/browser/ui/inspectable_web_contents.h
+++ b/shell/browser/ui/inspectable_web_contents.h
@@ -76,7 +76,9 @@ class InspectableWebContents
   void InspectElement(int x, int y);
 
   // Return the last position and size of devtools window.
-  gfx::Rect GetDevToolsBounds() const;
+  [[nodiscard]] const gfx::Rect& dev_tools_bounds() const {
+    return devtools_bounds_;
+  }
   void SaveDevToolsBounds(const gfx::Rect& bounds);
 
   // Return the last set zoom level of devtools window.

--- a/shell/browser/ui/inspectable_web_contents.h
+++ b/shell/browser/ui/inspectable_web_contents.h
@@ -55,7 +55,7 @@ class InspectableWebContents
 
   void SetDelegate(InspectableWebContentsDelegate* delegate);
   InspectableWebContentsDelegate* GetDelegate() const;
-  bool IsGuest() const;
+  [[nodiscard]] bool is_guest() const { return is_guest_; }
   void ReleaseWebContents();
   void SetDevToolsWebContents(content::WebContents* devtools);
   void SetDockState(const std::string& state);

--- a/shell/browser/ui/views/autofill_popup_view.cc
+++ b/shell/browser/ui/views/autofill_popup_view.cc
@@ -124,7 +124,7 @@ void AutofillPopupView::OnSuggestionsChanged() {
     return;
 
   CreateChildViews();
-  if (popup_->GetLineCount() == 0) {
+  if (popup_->line_count() == 0) {
     popup_->Hide();
     return;
   }
@@ -177,28 +177,28 @@ void AutofillPopupView::DrawAutofillEntry(gfx::Canvas* canvas,
 
   int x_align_left = value_rect.x();
   const int value_width = gfx::GetStringWidth(
-      popup_->GetValueAt(index), popup_->GetValueFontListForRow(index));
+      popup_->value_at(index), popup_->GetValueFontListForRow(index));
   int value_x_align_left = x_align_left;
   value_x_align_left =
       is_rtl ? value_rect.right() - value_width : value_rect.x();
 
   canvas->DrawStringRectWithFlags(
-      popup_->GetValueAt(index), popup_->GetValueFontListForRow(index),
+      popup_->value_at(index), popup_->GetValueFontListForRow(index),
       GetColorProvider()->GetColor(ui::kColorResultsTableNormalText),
       gfx::Rect(value_x_align_left, value_rect.y(), value_width,
                 value_rect.height()),
       text_align);
 
   // Draw the label text, if one exists.
-  if (!popup_->GetLabelAt(index).empty()) {
-    const int label_width = gfx::GetStringWidth(
-        popup_->GetLabelAt(index), popup_->GetLabelFontListForRow(index));
+  if (auto const& label = popup_->label_at(index); !label.empty()) {
+    const int label_width =
+        gfx::GetStringWidth(label, popup_->GetLabelFontListForRow(index));
     int label_x_align_left = x_align_left;
     label_x_align_left =
         is_rtl ? value_rect.x() : value_rect.right() - label_width;
 
     canvas->DrawStringRectWithFlags(
-        popup_->GetLabelAt(index), popup_->GetLabelFontListForRow(index),
+        label, popup_->GetLabelFontListForRow(index),
         GetColorProvider()->GetColor(ui::kColorResultsTableDimmedText),
         gfx::Rect(label_x_align_left, entry_rect.y(), label_width,
                   entry_rect.height()),
@@ -212,8 +212,8 @@ void AutofillPopupView::CreateChildViews() {
 
   RemoveAllChildViews();
 
-  for (int i = 0; i < popup_->GetLineCount(); ++i) {
-    auto* child_view = new AutofillPopupChildView(popup_->GetValueAt(i));
+  for (int i = 0; i < popup_->line_count(); ++i) {
+    auto* child_view = new AutofillPopupChildView(popup_->value_at(i));
     child_view->set_drag_controller(this);
     AddChildView(child_view);
   }
@@ -234,8 +234,7 @@ void AutofillPopupView::DoUpdateBoundsAndRedrawPopup() {
 }
 
 void AutofillPopupView::OnPaint(gfx::Canvas* canvas) {
-  if (!popup_ ||
-      static_cast<size_t>(popup_->GetLineCount()) != children().size())
+  if (!popup_ || static_cast<size_t>(popup_->line_count()) != children().size())
     return;
   gfx::Canvas* draw_canvas = canvas;
   SkBitmap bitmap;
@@ -252,7 +251,7 @@ void AutofillPopupView::OnPaint(gfx::Canvas* canvas) {
       GetColorProvider()->GetColor(ui::kColorResultsTableNormalBackground));
   OnPaintBorder(draw_canvas);
 
-  for (int i = 0; i < popup_->GetLineCount(); ++i) {
+  for (int i = 0; i < popup_->line_count(); ++i) {
     gfx::Rect line_rect = popup_->GetRowBounds(i);
 
     DrawAutofillEntry(draw_canvas, i, line_rect);
@@ -381,7 +380,7 @@ bool AutofillPopupView::HandleKeyPressEvent(
       SetSelectedLine(0);
       return true;
     case ui::VKEY_NEXT:  // Page down.
-      SetSelectedLine(popup_->GetLineCount() - 1);
+      SetSelectedLine(popup_->line_count() - 1);
       return true;
     case ui::VKEY_ESCAPE:
       popup_->Hide();
@@ -421,7 +420,7 @@ void AutofillPopupView::AcceptSuggestion(int index) {
 }
 
 bool AutofillPopupView::AcceptSelectedLine() {
-  if (!selected_line_ || selected_line_.value() >= popup_->GetLineCount())
+  if (!selected_line_ || selected_line_.value() >= popup_->line_count())
     return false;
 
   AcceptSuggestion(selected_line_.value());
@@ -441,7 +440,7 @@ void AutofillPopupView::SetSelectedLine(std::optional<int> selected_line) {
     return;
   if (selected_line_ == selected_line)
     return;
-  if (selected_line && selected_line.value() >= popup_->GetLineCount())
+  if (selected_line && selected_line.value() >= popup_->line_count())
     return;
 
   auto previous_selected_line(selected_line_);
@@ -461,7 +460,7 @@ void AutofillPopupView::SelectNextLine() {
     return;
 
   int new_selected_line = selected_line_ ? *selected_line_ + 1 : 0;
-  if (new_selected_line >= popup_->GetLineCount())
+  if (new_selected_line >= popup_->line_count())
     new_selected_line = 0;
 
   SetSelectedLine(new_selected_line);
@@ -473,7 +472,7 @@ void AutofillPopupView::SelectPreviousLine() {
 
   int new_selected_line = selected_line_.value_or(0) - 1;
   if (new_selected_line < 0)
-    new_selected_line = popup_->GetLineCount() - 1;
+    new_selected_line = popup_->line_count() - 1;
 
   SetSelectedLine(new_selected_line);
 }

--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -83,7 +83,7 @@ InspectableWebContentsViewViews::InspectableWebContentsViewViews(
     : InspectableWebContentsView(inspectable_web_contents),
       devtools_web_view_(new views::WebView(nullptr)),
       title_(u"Developer Tools") {
-  if (!inspectable_web_contents_->IsGuest() &&
+  if (!inspectable_web_contents_->is_guest() &&
       inspectable_web_contents_->GetWebContents()->GetNativeView()) {
     auto* contents_web_view = new views::WebView(nullptr);
     contents_web_view->SetWebContents(

--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -116,8 +116,7 @@ void InspectableWebContentsViewViews::ShowDevTools(bool activate) {
   if (devtools_window_) {
     devtools_window_web_view_->SetWebContents(
         inspectable_web_contents_->GetDevToolsWebContents());
-    devtools_window_->SetBounds(
-        inspectable_web_contents()->GetDevToolsBounds());
+    devtools_window_->SetBounds(inspectable_web_contents()->dev_tools_bounds());
     if (activate) {
       devtools_window_->Show();
     } else {
@@ -182,7 +181,7 @@ void InspectableWebContentsViewViews::SetIsDocked(bool docked, bool activate) {
     views::Widget::InitParams params;
     params.ownership = views::Widget::InitParams::WIDGET_OWNS_NATIVE_WIDGET;
     params.delegate = devtools_window_delegate_;
-    params.bounds = inspectable_web_contents()->GetDevToolsBounds();
+    params.bounds = inspectable_web_contents()->dev_tools_bounds();
 
 #if BUILDFLAG(IS_LINUX)
     params.wm_role_name = "devtools";


### PR DESCRIPTION
#### Description of Change

This PR follows up on #41125 by inlining more simple getters in line with the Chromium C++ style guide.

All reviews welcomed. CC'ing @codebytere, @zcbenz since they also reviewed 41125.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.