### PR TITLE
docs: Properly document runAsNode utility process option

### DIFF
--- a/docs/api/utility-process.md
+++ b/docs/api/utility-process.md
@@ -21,8 +21,7 @@ Process: [Main](../glossary.md#main-process)<br />
     of the child process. Default is `inherit`.
     String value can be one of `pipe`, `ignore`, `inherit`, for more details on these values you can refer to
     [stdio][] documentation from Node.js. Currently this option only supports configuring `stdout` and
-    `stderr` to either `pipe`, `inherit` or `ignore`. Configuring `stdin` is not supported; any property
-    other than `ignore` will result in an error.
+    `stderr` to either `pipe`, `inherit` or `ignore`. Configuring `stdin` to any property other than `ignore` is not supported and will result in an error.
     For example, the supported values will be processed as following:
     * `pipe`: equivalent to \['ignore', 'pipe', 'pipe']
     * `ignore`: equivalent to \['ignore', 'ignore', 'ignore']

--- a/docs/api/utility-process.md
+++ b/docs/api/utility-process.md
@@ -21,12 +21,12 @@ Process: [Main](../glossary.md#main-process)<br />
     of the child process. Default is `inherit`.
     String value can be one of `pipe`, `ignore`, `inherit`, for more details on these values you can refer to
     [stdio][] documentation from Node.js. Currently this option only supports configuring `stdout` and
-    `stderr` to either `pipe`, `inherit` or `ignore`. Configuring `stdin` is not supported; `stdin` will
-    always be ignored.
+    `stderr` to either `pipe`, `inherit` or `ignore`. Configuring `stdin` is not supported; any property
+    other than `ignore` will result in an error.
     For example, the supported values will be processed as following:
-    * `pipe`: equivalent to \['ignore', 'pipe', 'pipe'] (the default)
+    * `pipe`: equivalent to \['ignore', 'pipe', 'pipe']
     * `ignore`: equivalent to \['ignore', 'ignore', 'ignore']
-    * `inherit`: equivalent to \['ignore', 'inherit', 'inherit']
+    * `inherit`: equivalent to \['ignore', 'inherit', 'inherit'] (the default)
   * `serviceName` string (optional) - Name of the process that will appear in `name` property of
     [`ProcessMetric`](structures/process-metric.md) returned by [`app.getAppMetrics`](app.md#appgetappmetrics)
     and [`child-process-gone` event of `app`](app.md#event-child-process-gone).

--- a/docs/tutorial/fuses.md
+++ b/docs/tutorial/fuses.md
@@ -15,7 +15,7 @@ Fuses are the solution to this problem, at a high level they are "magic bits" in
 **Default:** Enabled
 **@electron/fuses:** `FuseV1Options.RunAsNode`
 
-The runAsNode fuse toggles whether the `ELECTRON_RUN_AS_NODE` environment variable is respected or not.  Please note that if this fuse is disabled then `process.fork` in the main process will not function as expected as it depends on this environment variable to function.
+The runAsNode fuse toggles whether the `ELECTRON_RUN_AS_NODE` environment variable is respected or not.  Please note that if this fuse is disabled then `process.fork` in the main process will not function as expected as it depends on this environment variable to function. Instead, we recommend that you use [Utility Processes](../api/utility-process.md), which work for many use cases where you need a standalone Node.js process (like a Sqlite server process or similar scenarios).
 
 ### `cookieEncryption`
 


### PR DESCRIPTION
#### Description of Change

This PR properly documents (1) that utility processes do _not_ receive an `stdout/stderr` `pipe` by default and (2) that they are excellent alternatives to `process.fork` when the `RunAsNode` fuse is set to `false`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: no-notes
