### PR TITLE
docs: note EXIF data unsupported in `nativeImage`

### DIFF
--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -51,8 +51,12 @@ Check the _Size requirements_ section in [this article][icons].
 
 [icons]: https://learn.microsoft.com/en-us/windows/win32/uxguide/vis-icons
 
-EXIF meta-data is currently not supported and will not be taken into account during
+:::note
+
+EXIF metadata is currently not supported and will not be taken into account during
 image encoding and decoding.
+
+:::
 
 ## High Resolution Image
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -51,6 +51,9 @@ Check the _Size requirements_ section in [this article][icons].
 
 [icons]: https://learn.microsoft.com/en-us/windows/win32/uxguide/vis-icons
 
+EXIF meta-data is currently not supported and will not be taken into account during
+image encoding and decoding.
+
 ## High Resolution Image
 
 On platforms that have high-DPI support such as Apple Retina displays, you can


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/41189.

Marks EXIF data as being unsupported in `nativeImage`. The simple [codec functions in Chromium](https://source.chromium.org/chromium/chromium/src/+/main:ui/gfx/codec/jpeg_codec.cc) we utilize right now do not take them into account.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none