### PR TITLE
fix: crash on macOS non-programmatic close

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -439,11 +439,14 @@ void NativeWindowMac::Close() {
   if ([window_ attachedSheet])
     [window_ endSheet:[window_ attachedSheet]];
 
+  // window_ could be nil after performClose.
+  bool should_notify = is_modal() && parent() && IsVisible();
+
   [window_ performClose:nil];
 
   // Closing a sheet doesn't trigger windowShouldClose,
   // so we need to manually call it ourselves here.
-  if (is_modal() && parent() && IsVisible()) {
+  if (should_notify) {
     NotifyWindowCloseButtonClicked();
   }
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/40798
Refs https://github.com/microsoft/vscode/issues/204563

Fixes a crash that started occurring sporadically with some types of macOS window close after `PartitionAlloc` was enabled upstream. It seems to be the case now that `performClose:` can cause `window_` to be null, thus causing the call to `IsVisible` to crash trying to access a deallocated instance. There's probably  more effective long-term fix here but we can fix this by moving the conditional determining whether we should call `NotifyWindowCloseButtonClicked()` for a closed sheet above `performClosure` to avoid this problem altogether.

Using the `Cmd+Tab -> Cmd+Q` repro provided in https://github.com/electron/electron/issues/40798 I tracked this back to https://github.com/electron/electron/compare/v28.0.0-alpha.3...v28.0.0-alpha.4 - specifically reverting https://github.com/electron/electron/pull/33981 fixes the issue as well so we should investigate that further as a follow up.

h/t @MarshallOfSound for [speculating this fix](https://electronhq.slack.com/archives/C064GBL9LBZ/p1705516529637959) in response to what might be the same issue in Discord.

cc @deepak1556 @bpasero 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash that started occurring sporadically with some types of macOS window close
