### PR TITLE
fix: check for Node.js-created module when `contextIsolation` disabled

### DIFF
--- a/patches/node/chore_expose_importmoduledynamically_and.patch
+++ b/patches/node/chore_expose_importmoduledynamically_and.patch
@@ -87,7 +87,7 @@ index a1b0f812391486c5a429398326091a30bbe81692..a316d077f2d2ff38564959345cf8ef29
  
  MaybeLocal<Value> ModuleWrap::SyntheticModuleEvaluationStepsCallback(
 diff --git a/src/module_wrap.h b/src/module_wrap.h
-index 6435bad40936fe235822c0597310b94ab98082f3..c51eb99ce3eb54bc30ae922e0357b637b09d53c6 100644
+index 6435bad40936fe235822c0597310b94ab98082f3..8f30f546cc47bdb402ef4b1217d7bbb675a85ef7 100644
 --- a/src/module_wrap.h
 +++ b/src/module_wrap.h
 @@ -30,7 +30,14 @@ enum HostDefinedOptions : int {
@@ -106,3 +106,20 @@ index 6435bad40936fe235822c0597310b94ab98082f3..c51eb99ce3eb54bc30ae922e0357b637
   public:
    enum InternalFields {
      kModuleSlot = BaseObject::kInternalFieldCount,
+@@ -65,6 +72,8 @@ class ModuleWrap : public BaseObject {
+     return true;
+   }
+ 
++  static ModuleWrap* GetFromModule(node::Environment*, v8::Local<v8::Module>);
++
+  private:
+   ModuleWrap(Environment* env,
+              v8::Local<v8::Object> object,
+@@ -99,7 +108,6 @@ class ModuleWrap : public BaseObject {
+       v8::Local<v8::String> specifier,
+       v8::Local<v8::FixedArray> import_assertions,
+       v8::Local<v8::Module> referrer);
+-  static ModuleWrap* GetFromModule(node::Environment*, v8::Local<v8::Module>);
+ 
+   v8::Global<v8::Module> module_;
+   std::unordered_map<std::string, v8::Global<v8::Promise>> resolve_cache_;

--- a/patches/node/fix_missing_include_for_node_extern.patch
+++ b/patches/node/fix_missing_include_for_node_extern.patch
@@ -13,7 +13,7 @@ causing the following error:
 This should be upstreamed.
 
 diff --git a/src/module_wrap.h b/src/module_wrap.h
-index c51eb99ce3eb54bc30ae922e0357b637b09d53c6..55317ced78ee9ceaa13f7e00477c59370eb335fa 100644
+index 8f30f546cc47bdb402ef4b1217d7bbb675a85ef7..a39f3f36f8e736881c7795cfba1d72e0507ea802 100644
 --- a/src/module_wrap.h
 +++ b/src/module_wrap.h
 @@ -7,6 +7,7 @@

--- a/spec/esm-spec.ts
+++ b/spec/esm-spec.ts
@@ -141,7 +141,7 @@ describe('esm', () => {
       const hostsUrl = pathToFileURL(process.platform === 'win32' ? 'C:\\Windows\\System32\\drivers\\etc\\hosts' : '/etc/hosts');
 
       describe('without context isolation', () => {
-        it('should use blinks dynamic loader in the main world', async () => {
+        it('should use Blinks dynamic loader in the main world', async () => {
           const [webContents] = await loadWindowWithPreload('', {
             nodeIntegration: true,
             sandbox: false,
@@ -156,13 +156,18 @@ describe('esm', () => {
           }
 
           expect(error).to.not.equal(null);
-          // This is a blink specific error message
+          // This is a Blink specific error message
           expect(error?.message).to.include('Failed to fetch dynamically imported module');
+        });
+
+        it('should use import.meta callback handling from Node.js for Node.js modules', async () => {
+          const result = await runFixture(path.resolve(fixturePath, 'import-meta'));
+          expect(result.code).to.equal(0);
         });
       });
 
       describe('with context isolation', () => {
-        it('should use nodes esm dynamic loader in the isolated context', async () => {
+        it('should use Node.js ESM dynamic loader in the isolated context', async () => {
           const [, preloadError] = await loadWindowWithPreload(`await import(${JSON.stringify(hostsUrl)})`, {
             nodeIntegration: true,
             sandbox: false,
@@ -174,7 +179,7 @@ describe('esm', () => {
           expect(preloadError!.toString()).to.include('Unknown file extension');
         });
 
-        it('should use blinks dynamic loader in the main world', async () => {
+        it('should use Blinks dynamic loader in the main world', async () => {
           const [webContents] = await loadWindowWithPreload('', {
             nodeIntegration: true,
             sandbox: false,

--- a/spec/fixtures/esm/import-meta/index.html
+++ b/spec/fixtures/esm/import-meta/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'">
+  <title>Hello World!</title>
+</head>
+
+<body>
+  <h1>Hello World!</h1>
+  We are using Node.js <span id="node-version"></span>,
+  Chromium <span id="chrome-version"></span>,
+  and Electron <span id="electron-version"></span>.
+</body>
+
+</html>

--- a/spec/fixtures/esm/import-meta/main.mjs
+++ b/spec/fixtures/esm/import-meta/main.mjs
@@ -1,0 +1,33 @@
+import { app, BrowserWindow } from 'electron'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path';
+
+async function createWindow() {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      preload: fileURLToPath(new URL('preload.mjs', import.meta.url)),
+      sandbox: false,
+      contextIsolation: false
+    }
+  })
+
+  await mainWindow.loadFile('index.html')
+
+  const importMetaPreload = await mainWindow.webContents.executeJavaScript('window.importMetaPath');
+  const expected = join(dirname(fileURLToPath(import.meta.url)), 'preload.mjs');
+
+  process.exit(importMetaPreload === expected ? 0 : 1);
+}
+
+app.whenReady().then(() => {
+  createWindow()
+
+  app.on('activate', function () {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+  })
+})
+
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit()
+})

--- a/spec/fixtures/esm/import-meta/package.json
+++ b/spec/fixtures/esm/import-meta/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "main.mjs",
+  "type": "module"
+}

--- a/spec/fixtures/esm/import-meta/preload.mjs
+++ b/spec/fixtures/esm/import-meta/preload.mjs
@@ -1,0 +1,3 @@
+import { fileURLToPath } from 'node:url'
+
+window.importMetaPath = fileURLToPath(import.meta.url)


### PR DESCRIPTION
Backport of #40993.

See that PR for details.

Notes: Fixes an issue where `import.meta.url` did not work in the renderer process with `contextIsolation` enabled.