### PR TITLE
fix: errSecCSUnsigned is a valid return value

### DIFF
--- a/shell/common/mac/codesign_util.cc
+++ b/shell/common/mac/codesign_util.cc
@@ -105,6 +105,12 @@ bool ProcessSignatureIsSameWithCurrentApp(pid_t pid) {
   // Check whether the process meets the signature requirement of current app.
   status = SecCodeCheckValidity(process_code.get(), kSecCSDefaultFlags,
                                 self_requirement.get());
+  if (status == errSecCSUnsigned) {
+    // For some users the API may return errSecCSUnsigned as failure even though
+    // the process is signed.
+    // See also https://github.com/microsoft/vscode/issues/204085.
+    return false;
+  }
   if (status != errSecSuccess && status != errSecCSReqFailed) {
     OSSTATUS_LOG(ERROR, status) << "SecCodeCheckValidity";
     return false;


### PR DESCRIPTION
#### Description of Change

VS Code reported that some users get console warnings:

```
codesign_util.cc(108)] SecCodeCheckValidity: Error Domain=NSOSStatusErrorDomain Code=-67062 "(null)" (-67062)
```

And -67062 means errSecCSUnsigned, which likely means their terminal is an unsigned app.



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix console warnings about `SecCodeCheckValidity` on macOS.