### PR TITLE
fix: `GetCursorScreenpoint()` sometimes wrongly returns `(0,0)`

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -127,3 +127,4 @@ fix_restore_original_resize_performance_on_macos.patch
 feat_allow_code_cache_in_custom_schemes.patch
 build_run_reclient_cfg_generator_after_chrome.patch
 fix_suppress_clang_-wimplicit-const-int-float-conversion_in.patch
+fix_getcursorscreenpoint_wrongly_returns_0_0.patch

--- a/patches/chromium/fix_getcursorscreenpoint_wrongly_returns_0_0.patch
+++ b/patches/chromium/fix_getcursorscreenpoint_wrongly_returns_0_0.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Charles Kerr <charles@charleskerr.com>
+Date: Thu, 8 Feb 2024 00:41:40 -0600
+Subject: fix: GetCursorScreenPoint() wrongly returns 0, 0
+
+Fixes #41143. Discussion of the issue at
+https://github.com/electron/electron/issues/41143#issuecomment-1933443163
+
+This patch should be backported to e29, upstreamed to Chromium, and then
+removed if it lands upstream.
+
+diff --git a/ui/events/x/events_x_utils.cc b/ui/events/x/events_x_utils.cc
+index aa047f2bd39643dc471b25eeb567b0dd3731e0e0..eb312fb1c115751041930539d0d5f15208461e04 100644
+--- a/ui/events/x/events_x_utils.cc
++++ b/ui/events/x/events_x_utils.cc
+@@ -586,6 +586,9 @@ gfx::Point EventLocationFromXEvent(const x11::Event& xev) {
+ gfx::Point EventSystemLocationFromXEvent(const x11::Event& xev) {
+   if (auto* crossing = xev.As<x11::CrossingEvent>())
+     return gfx::Point(crossing->root_x, crossing->root_y);
++  if (auto* crossing = xev.As<x11::Input::CrossingEvent>())
++    return gfx::Point(Fp1616ToDouble(crossing->root_x),
++                      Fp1616ToDouble(crossing->root_y));
+   if (auto* button = xev.As<x11::ButtonEvent>())
+     return gfx::Point(button->root_x, button->root_y);
+   if (auto* motion = xev.As<x11::MotionNotifyEvent>())


### PR DESCRIPTION
#### Description of Change

Fixes #41143.

The bug was introduced in https://chromium-review.googlesource.com/c/chromium/src/+/5214873 which tests for `x11::Input::CrossingEvent` but calls `ui::EventSystemLocationFromXEvent()`, which uses the similarly-named-but-different-class `x11::CrossingEvent`. This mismatch causes `x11::Input::CrossingEvent`s to incorrectly record the cursor's location at `0, 0`.

https://chromium-review.googlesource.com/c/chromium/src/+/5225569  exposed the 5214873 bug to Electron via `X11ScreenOzone::GetCursorScreenPoint()`, which caches the return value of `X11ScreenOzone::GetCursorScreenPoint() ` to avoid a round trip to X.

This patch should be backported to e29 to fix the release blocker + upstreamed to Chromium.

All reviews welcome!

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed Electron 29.0.0-beta.3 regression that could pop up context menus in the wrong location.