### PR TITLE
fix: destroy `NodeService` message pipe last

### DIFF
--- a/shell/services/node/node_service.h
+++ b/shell/services/node/node_service.h
@@ -61,6 +61,12 @@ class NodeService : public node::mojom::NodeService {
   void Initialize(node::mojom::NodeServiceParamsPtr params) override;
 
  private:
+  // This needs to be initialized first so that it can be destroyed last
+  // after the node::Environment is destroyed. This ensures that if
+  // there are crashes in the node::Environment destructor, they
+  // will be propagated to the exit handler.
+  mojo::Receiver<node::mojom::NodeService> receiver_{this};
+
   bool node_env_stopped_ = false;
 
   const std::unique_ptr<NodeBindings> node_bindings_;
@@ -73,8 +79,6 @@ class NodeService : public node::mojom::NodeService {
 
   // depends-on: js_env_'s isolate
   std::shared_ptr<node::Environment> node_env_;
-
-  mojo::Receiver<node::mojom::NodeService> receiver_{this};
 };
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/microsoft/vscode/issues/196823

Fixes an issue where crashes in `node::Environment` destruction may not get propagated to the `NodeService` exit handler as the handler is destroyed prior to the `Environment`. By moving this member variable to the top of the list, we guarantee that it's destroyed last and thus that the utility process won't send faulty exit events while the process is still active.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where crashes in `node::Environment` destruction potentially wouldn't be propagated to the `NodeService` exit handler.