### PR TITLE
Add optional `outputSize` to `opts` of `webContents.capturePage([rect, opts])`

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1162,6 +1162,9 @@ Returns `boolean` - Whether the window's document has been edited.
 * `opts` Object (optional)
   * `stayHidden` boolean (optional) -  Keep the page hidden instead of visible. Default is `false`.
   * `stayAwake` boolean (optional) -  Keep the system awake instead of allowing it to sleep. Default is `false`.
+  * `outputSize` Object (optional)
+    * `height` number - Height of result image.
+    * `width` number - Width of result image.
 
 Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1519,12 +1519,16 @@ console.log(requestId)
 * `opts` Object (optional)
   * `stayHidden` boolean (optional) -  Keep the page hidden instead of visible. Default is `false`.
   * `stayAwake` boolean (optional) -  Keep the system awake instead of allowing it to sleep. Default is `false`.
+  * `outputSize` Object (optional)
+    * `height` number - Height of result image.
+    * `width` number - Width of result image.
 
 Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
 
 Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page.
 The page is considered visible when its browser window is hidden and the capturer count is non-zero.
 If you would like the page to stay hidden, you should ensure that `stayHidden` is set to true.
+If you would like to change the size of returned image you should pass `outputSize`.
 
 #### `contents.isBeingCaptured()`
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "shell/browser/api/electron_api_web_contents.h"
-
 #include <limits>
 #include <memory>
 #include <optional>
@@ -3506,11 +3505,13 @@ v8::Local<v8::Promise> WebContents::CapturePage(gin::Arguments* args) {
 
   bool stay_hidden = false;
   bool stay_awake = false;
+  gfx::Size bitmap_size;
   if (args && args->Length() == 2) {
     gin_helper::Dictionary options;
     if (args->GetNext(&options)) {
       options.Get("stayHidden", &stay_hidden);
       options.Get("stayAwake", &stay_awake);
+      options.Get("outputSize", &bitmap_size);
     }
   }
 
@@ -3533,16 +3534,17 @@ v8::Local<v8::Promise> WebContents::CapturePage(gin::Arguments* args) {
   const gfx::Size view_size =
       rect.IsEmpty() ? view->GetViewBounds().size() : rect.size();
 
-  // By default, the requested bitmap size is the view size in screen
-  // coordinates.  However, if there's more pixel detail available on the
-  // current system, increase the requested bitmap size to capture it all.
-  gfx::Size bitmap_size = view_size;
-  const gfx::NativeView native_view = view->GetNativeView();
-  const float scale = display::Screen::GetScreen()
-                          ->GetDisplayNearestView(native_view)
-                          .device_scale_factor();
-  if (scale > 1.0f)
-    bitmap_size = gfx::ScaleToCeiledSize(view_size, scale);
+  if (bitmap_size.IsEmpty()) {
+    // By default, the requested bitmap size is the view size in screen
+    // coordinates.  However, if there's more pixel detail available on the
+    // current system, increase the requested bitmap size to capture it all.
+    const gfx::NativeView native_view = view->GetNativeView();
+    const float scale = display::Screen::GetScreen()
+                            ->GetDisplayNearestView(native_view)
+                            .device_scale_factor();
+    if (scale > 1.0f)
+      bitmap_size = gfx::ScaleToCeiledSize(view_size, scale);
+  }
 
   view->CopyFromSurface(gfx::Rect(rect.origin(), view_size), bitmap_size,
                         base::BindOnce(&OnCapturePageDone, std::move(promise),


### PR DESCRIPTION
#### Description of Change
This PR adds optional parameter `outputSize` to `opts` of `webContents.capturePage([rect, opts])`. The main purpose of this parameter is to improve speed and resources consumption when generating small thumbnails of web pages.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

notes: Added optional `outputSize` to `opts` of `webContents.capturePage([rect, opts])`.
