### PR TITLE
fix: Ignore `-webkit-app-region: drag;` when window is in full screen mode.

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -765,6 +765,11 @@ int NativeWindow::NonClientHitTest(const gfx::Point& point) {
   }
 #endif
 
+  // This is to disable dragging in HTML5 full screen mode.
+  // Details: https://github.com/electron/electron/issues/41002
+  if (GetWidget()->IsFullscreen())
+    return HTNOWHERE;
+
   for (auto* provider : draggable_region_providers_) {
     int hit = provider->NonClientHitTest(point);
     if (hit != HTNOWHERE)


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/41002

This is a workaround to close issue when an underlying view with `-webkit-app-region: drag;` blocks UI interaction on other overlayed views.

We already do this for MacOS [here](https://github.com/electron/electron/blob/03a3deca181807c2b152264a11f92c70b7adc9ef/shell/browser/native_window_mac.mm#L1757)

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: CSS style `-webkit-app-region: drag;` has no effect in full screen mode.