### PR TITLE
fix: `capturePage` promise never settling when callback isn't run

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -490,7 +490,7 @@ void OnCapturePageDone(gin_helper::Promise<gfx::Image> promise,
             FROM_HERE, base::BindOnce(&OnCapturePageDone, std::move(promise),
                                       std::move(capture_handle), bitmap))) {
       // When `PostTask` returns `false` the task definitely will not run.
-      promise.RejectWithErrorMessage("Unknown error");
+      promise.RejectWithErrorMessage("Failed to capture page");
     }
 
     return;


### PR DESCRIPTION
#### Description of Change

Probably fix: https://github.com/electron/electron/issues/36376

In `webContents.capturePage` API we use `RenderWidgetHostView.copyFromSurface` API to capture page content. To resolve promise once capturing is completed we provide callback `OnCapturePageDone`. This callback may not be run in UI thread. If this is the case, we re-invoke the same callback via `ui_task_runner->PostTask`.
However, according to docs in `task_runner.h`:

```
  // Posts the given task to be run.  Returns true if the task may be
  // run at some point in the future, and false if the task definitely
  // will not be run.
  //
  // Equivalent to PostDelayedTask(from_here, task, 0).
  bool PostTask(const Location& from_here, OnceClosure task);
```

We do not check the returned value for now. I change it to check the value and reject the promise immediately if we received `false`. It will help us to reduce number of cases when the promise never settle.
 
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added extra handling to address cases where `webContents.capturePage()` did not settle its Promise.
