### PR TITLE
build: peg to a specific depot_tools so that we can use goma on older branches

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -252,6 +252,10 @@ step-depot-tools-get: &step-depot-tools-get
     name: Get depot tools
     command: |
       git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+      cd depot_tools
+      git fetch --depth 1 origin f76550541c751f956ef9287f2695a6c8a74bf709
+      git checkout f76550541c751f956ef9287f2695a6c8a74bf709
+      cd ..
       if [ "`uname`" == "Darwin" ]; then
         # remove ninjalog_uploader_wrapper.py from autoninja since we don't use it and it causes problems
         sed -i '' '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja

--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -94,6 +94,11 @@ for:
             Remove-Item -Recurse -Force $pwd\build-tools
           }
       - git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+      - ps: |
+          cd depot_tools
+          git fetch --depth 1 origin f76550541c751f956ef9287f2695a6c8a74bf709
+          git checkout f76550541c751f956ef9287f2695a6c8a74bf709
+          cd ..
       - ps: New-Item -Name depot_tools\.disable_auto_update -ItemType File
       - depot_tools\bootstrap\win_tools.bat
       - ps: $env:PATH="$pwd\depot_tools;$env:PATH"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -92,6 +92,11 @@ for:
             Remove-Item -Recurse -Force $pwd\build-tools
           }
       - git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+      - ps: |
+          cd depot_tools
+          git fetch --depth 1 origin f76550541c751f956ef9287f2695a6c8a74bf709
+          git checkout f76550541c751f956ef9287f2695a6c8a74bf709
+          cd ..
       - ps: New-Item -Name depot_tools\.disable_auto_update -ItemType File
       - depot_tools\bootstrap\win_tools.bat
       - ps: $env:PATH="$pwd\depot_tools;$env:PATH"


### PR DESCRIPTION
#### Description of Change
https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/5272474 broke our older branches building on goma, so this PR will lock the depot_tools revision so that older branches can continue to use goma.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
