### PR TITLE
chore: migrate base::StringPiece to std::string_view (#40915)

### DIFF
--- a/shell/app/electron_content_client.cc
+++ b/shell/app/electron_content_client.cc
@@ -5,6 +5,7 @@
 #include "shell/app/electron_content_client.h"
 
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -105,12 +106,12 @@ bool IsWidevineAvailable(
 }
 #endif  // BUILDFLAG(ENABLE_WIDEVINE)
 
-void AppendDelimitedSwitchToVector(const base::StringPiece cmd_switch,
+void AppendDelimitedSwitchToVector(const std::string_view cmd_switch,
                                    std::vector<std::string>* append_me) {
   auto* command_line = base::CommandLine::ForCurrentProcess();
   auto switch_value = command_line->GetSwitchValueASCII(cmd_switch);
   if (!switch_value.empty()) {
-    constexpr base::StringPiece delimiter(",", 1);
+    constexpr std::string_view delimiter{",", 1};
     auto tokens =
         base::SplitString(switch_value, delimiter, base::TRIM_WHITESPACE,
                           base::SPLIT_WANT_NONEMPTY);

--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/apple/bundle_locations.h"
@@ -80,9 +81,9 @@ namespace {
 
 const char kRelauncherProcess[] = "relauncher";
 
-constexpr base::StringPiece kElectronDisableSandbox("ELECTRON_DISABLE_SANDBOX");
-constexpr base::StringPiece kElectronEnableStackDumping(
-    "ELECTRON_ENABLE_STACK_DUMPING");
+constexpr std::string_view kElectronDisableSandbox{"ELECTRON_DISABLE_SANDBOX"};
+constexpr std::string_view kElectronEnableStackDumping{
+    "ELECTRON_ENABLE_STACK_DUMPING"};
 
 // Returns true if this subprocess type needs the ResourceBundle initialized
 // and resources loaded.

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -7,6 +7,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -59,17 +60,16 @@ namespace {
 // See https://nodejs.org/api/cli.html#cli_options
 void ExitIfContainsDisallowedFlags(const std::vector<std::string>& argv) {
   // Options that are unilaterally disallowed.
-  static constexpr auto disallowed =
-      base::MakeFixedFlatSetSorted<base::StringPiece>({
-          "--enable-fips",
-          "--force-fips",
-          "--openssl-config",
-          "--use-bundled-ca",
-          "--use-openssl-ca",
-      });
+  static constexpr auto disallowed = base::MakeFixedFlatSet<std::string_view>({
+      "--enable-fips",
+      "--force-fips",
+      "--openssl-config",
+      "--use-bundled-ca",
+      "--use-openssl-ca",
+  });
 
   for (const auto& arg : argv) {
-    const auto key = base::StringPiece(arg).substr(0, arg.find('='));
+    const auto key = std::string_view{arg}.substr(0, arg.find('='));
     if (disallowed.contains(key)) {
       LOG(ERROR) << "The Node.js cli flag " << key
                  << " is not supported in Electron";

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -247,7 +248,7 @@ struct Converter<JumpListCategory::Type> {
 
  private:
   static constexpr auto Lookup =
-      base::MakeFixedFlatMapSorted<base::StringPiece, JumpListCategory::Type>({
+      base::MakeFixedFlatMap<std::string_view, JumpListCategory::Type>({
           {"custom", JumpListCategory::Type::kCustom},
           {"frequent", JumpListCategory::Type::kFrequent},
           {"recent", JumpListCategory::Type::kRecent},
@@ -407,7 +408,7 @@ struct Converter<net::SecureDnsMode> {
                      v8::Local<v8::Value> val,
                      net::SecureDnsMode* out) {
     static constexpr auto Lookup =
-        base::MakeFixedFlatMapSorted<base::StringPiece, net::SecureDnsMode>({
+        base::MakeFixedFlatMap<std::string_view, net::SecureDnsMode>({
             {"automatic", net::SecureDnsMode::kAutomatic},
             {"off", net::SecureDnsMode::kOff},
             {"secure", net::SecureDnsMode::kSecure},
@@ -433,9 +434,9 @@ IconLoader::IconSize GetIconSizeByString(const std::string& size) {
 }
 
 // Return the path constant from string.
-int GetPathConstant(base::StringPiece name) {
+int GetPathConstant(std::string_view name) {
   // clang-format off
-  constexpr auto Lookup = base::MakeFixedFlatMapSorted<base::StringPiece, int>({
+  constexpr auto Lookup = base::MakeFixedFlatMap<std::string_view, int>({
       {"appData", DIR_APP_DATA},
 #if BUILDFLAG(IS_POSIX)
       {"cache", base::DIR_CACHE},

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "content/public/browser/browser_task_traits.h"
@@ -261,7 +262,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void RemoveFromParentChildWindows();
 
   template <typename... Args>
-  void EmitEventSoon(base::StringPiece eventName) {
+  void EmitEventSoon(std::string_view eventName) {
     content::GetUIThreadTaskRunner({})->PostTask(
         FROM_HERE,
         base::BindOnce(base::IgnoreResult(&BaseWindow::Emit<Args...>),

--- a/shell/browser/api/electron_api_cookies.cc
+++ b/shell/browser/api/electron_api_cookies.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/api/electron_api_cookies.h"
 
+#include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/time/time.h"
@@ -169,7 +171,7 @@ base::Time ParseTimeProperty(const absl::optional<double>& value) {
   return base::Time::FromSecondsSinceUnixEpoch(*value);
 }
 
-base::StringPiece InclusionStatusToString(net::CookieInclusionStatus status) {
+std::string_view InclusionStatusToString(net::CookieInclusionStatus status) {
   if (status.HasExclusionReason(net::CookieInclusionStatus::EXCLUDE_HTTP_ONLY))
     return "Failed to create httponly cookie";
   if (status.HasExclusionReason(

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/api/electron_api_protocol.h"
 
+#include <string_view>
 #include <vector>
 
 #include "base/command_line.h"
@@ -193,7 +194,7 @@ const char* const kBuiltinSchemes[] = {
 };
 
 // Convert error code to string.
-constexpr base::StringPiece ErrorCodeToString(ProtocolError error) {
+constexpr std::string_view ErrorCodeToString(ProtocolError error) {
   switch (error) {
     case ProtocolError::kRegistered:
       return "The scheme has been registered";

--- a/shell/browser/api/electron_api_screen.cc
+++ b/shell/browser/api/electron_api_screen.cc
@@ -5,6 +5,7 @@
 #include "shell/browser/api/electron_api_screen.h"
 
 #include <string>
+#include <string_view>
 
 #include "base/functional/bind.h"
 #include "gin/dictionary.h"
@@ -49,13 +50,13 @@ std::vector<std::string> MetricsToArray(uint32_t metrics) {
 }
 
 void DelayEmit(Screen* screen,
-               base::StringPiece name,
+               const std::string_view name,
                const display::Display& display) {
   screen->Emit(name, display);
 }
 
 void DelayEmitWithMetrics(Screen* screen,
-                          base::StringPiece name,
+                          const std::string_view name,
                           const display::Display& display,
                           const std::vector<std::string>& metrics) {
   screen->Emit(name, display, metrics);

--- a/shell/browser/api/electron_api_service_worker_context.cc
+++ b/shell/browser/api/electron_api_service_worker_context.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/api/electron_api_service_worker_context.h"
 
+#include <string_view>
 #include <utility>
 
 #include "base/strings/string_number_conversions.h"
@@ -25,7 +26,7 @@ namespace electron::api {
 
 namespace {
 
-constexpr base::StringPiece MessageSourceToString(
+constexpr std::string_view MessageSourceToString(
     const blink::mojom::ConsoleMessageSource source) {
   switch (source) {
     case blink::mojom::ConsoleMessageSource::kXml:

--- a/shell/browser/api/electron_api_system_preferences_win.cc
+++ b/shell/browser/api/electron_api_system_preferences_win.cc
@@ -2,10 +2,12 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <iomanip>
+#include <string_view>
+
 #include <dwmapi.h>
 #include <windows.devices.enumeration.h>
 #include <wrl/client.h>
-#include <iomanip>
 
 #include "shell/browser/api/electron_api_system_preferences.h"
 
@@ -98,39 +100,38 @@ std::string SystemPreferences::GetAccentColor() {
 
 std::string SystemPreferences::GetColor(gin_helper::ErrorThrower thrower,
                                         const std::string& color) {
-  static constexpr auto Lookup =
-      base::MakeFixedFlatMapSorted<base::StringPiece, int>({
-          {"3d-dark-shadow", COLOR_3DDKSHADOW},
-          {"3d-face", COLOR_3DFACE},
-          {"3d-highlight", COLOR_3DHIGHLIGHT},
-          {"3d-light", COLOR_3DLIGHT},
-          {"3d-shadow", COLOR_3DSHADOW},
-          {"active-border", COLOR_ACTIVEBORDER},
-          {"active-caption", COLOR_ACTIVECAPTION},
-          {"active-caption-gradient", COLOR_GRADIENTACTIVECAPTION},
-          {"app-workspace", COLOR_APPWORKSPACE},
-          {"button-text", COLOR_BTNTEXT},
-          {"caption-text", COLOR_CAPTIONTEXT},
-          {"desktop", COLOR_DESKTOP},
-          {"disabled-text", COLOR_GRAYTEXT},
-          {"highlight", COLOR_HIGHLIGHT},
-          {"highlight-text", COLOR_HIGHLIGHTTEXT},
-          {"hotlight", COLOR_HOTLIGHT},
-          {"inactive-border", COLOR_INACTIVEBORDER},
-          {"inactive-caption", COLOR_INACTIVECAPTION},
-          {"inactive-caption-gradient", COLOR_GRADIENTINACTIVECAPTION},
-          {"inactive-caption-text", COLOR_INACTIVECAPTIONTEXT},
-          {"info-background", COLOR_INFOBK},
-          {"info-text", COLOR_INFOTEXT},
-          {"menu", COLOR_MENU},
-          {"menu-highlight", COLOR_MENUHILIGHT},
-          {"menu-text", COLOR_MENUTEXT},
-          {"menubar", COLOR_MENUBAR},
-          {"scrollbar", COLOR_SCROLLBAR},
-          {"window", COLOR_WINDOW},
-          {"window-frame", COLOR_WINDOWFRAME},
-          {"window-text", COLOR_WINDOWTEXT},
-      });
+  static constexpr auto Lookup = base::MakeFixedFlatMap<std::string_view, int>({
+      {"3d-dark-shadow", COLOR_3DDKSHADOW},
+      {"3d-face", COLOR_3DFACE},
+      {"3d-highlight", COLOR_3DHIGHLIGHT},
+      {"3d-light", COLOR_3DLIGHT},
+      {"3d-shadow", COLOR_3DSHADOW},
+      {"active-border", COLOR_ACTIVEBORDER},
+      {"active-caption", COLOR_ACTIVECAPTION},
+      {"active-caption-gradient", COLOR_GRADIENTACTIVECAPTION},
+      {"app-workspace", COLOR_APPWORKSPACE},
+      {"button-text", COLOR_BTNTEXT},
+      {"caption-text", COLOR_CAPTIONTEXT},
+      {"desktop", COLOR_DESKTOP},
+      {"disabled-text", COLOR_GRAYTEXT},
+      {"highlight", COLOR_HIGHLIGHT},
+      {"highlight-text", COLOR_HIGHLIGHTTEXT},
+      {"hotlight", COLOR_HOTLIGHT},
+      {"inactive-border", COLOR_INACTIVEBORDER},
+      {"inactive-caption", COLOR_INACTIVECAPTION},
+      {"inactive-caption-gradient", COLOR_GRADIENTINACTIVECAPTION},
+      {"inactive-caption-text", COLOR_INACTIVECAPTIONTEXT},
+      {"info-background", COLOR_INFOBK},
+      {"info-text", COLOR_INFOTEXT},
+      {"menu", COLOR_MENU},
+      {"menu-highlight", COLOR_MENUHILIGHT},
+      {"menu-text", COLOR_MENUTEXT},
+      {"menubar", COLOR_MENUBAR},
+      {"scrollbar", COLOR_SCROLLBAR},
+      {"window", COLOR_WINDOW},
+      {"window-frame", COLOR_WINDOWFRAME},
+      {"window-text", COLOR_WINDOWTEXT},
+  });
 
   if (const auto* iter = Lookup.find(color); iter != Lookup.end())
     return ToRGBAHex(color_utils::GetSysSkColor(iter->second));

--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -5,6 +5,7 @@
 #include "shell/browser/api/electron_api_tray.h"
 
 #include <string>
+#include <string_view>
 
 #include "base/containers/fixed_flat_map.h"
 #include "gin/dictionary.h"
@@ -32,7 +33,7 @@ struct Converter<electron::TrayIcon::IconType> {
                      electron::TrayIcon::IconType* out) {
     using Val = electron::TrayIcon::IconType;
     static constexpr auto Lookup =
-        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+        base::MakeFixedFlatMapSorted<std::string_view, Val>({
             {"custom", Val::kCustom},
             {"error", Val::kError},
             {"info", Val::kInfo},

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -206,7 +207,7 @@ struct Converter<printing::mojom::MarginType> {
                      printing::mojom::MarginType* out) {
     using Val = printing::mojom::MarginType;
     static constexpr auto Lookup =
-        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+        base::MakeFixedFlatMapSorted<std::string_view, Val>({
             {"custom", Val::kCustomMargins},
             {"default", Val::kDefaultMargins},
             {"none", Val::kNoMargins},
@@ -223,7 +224,7 @@ struct Converter<printing::mojom::DuplexMode> {
                      printing::mojom::DuplexMode* out) {
     using Val = printing::mojom::DuplexMode;
     static constexpr auto Lookup =
-        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+        base::MakeFixedFlatMapSorted<std::string_view, Val>({
             {"longEdge", Val::kLongEdge},
             {"shortEdge", Val::kShortEdge},
             {"simplex", Val::kSimplex},
@@ -270,7 +271,7 @@ struct Converter<content::SavePageType> {
                      content::SavePageType* out) {
     using Val = content::SavePageType;
     static constexpr auto Lookup =
-        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+        base::MakeFixedFlatMapSorted<std::string_view, Val>({
             {"htmlcomplete", Val::SAVE_PAGE_TYPE_AS_COMPLETE_HTML},
             {"htmlonly", Val::SAVE_PAGE_TYPE_AS_ONLY_HTML},
             {"mhtml", Val::SAVE_PAGE_TYPE_AS_MHTML},
@@ -315,7 +316,7 @@ struct Converter<electron::api::WebContents::Type> {
                      electron::api::WebContents::Type* out) {
     using Val = electron::api::WebContents::Type;
     static constexpr auto Lookup =
-        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+        base::MakeFixedFlatMapSorted<std::string_view, Val>({
             {"backgroundPage", Val::kBackgroundPage},
             {"browserView", Val::kBrowserView},
             {"offscreen", Val::kOffScreen},
@@ -343,7 +344,7 @@ namespace electron::api {
 
 namespace {
 
-constexpr base::StringPiece CursorTypeToString(
+constexpr std::string_view CursorTypeToString(
     ui::mojom::CursorType cursor_type) {
   switch (cursor_type) {
     case ui::mojom::CursorType::kPointer:

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -365,7 +366,7 @@ class WebContents : public ExclusiveAccessContext,
 
   // this.emit(name, new Event(sender, message), args...);
   template <typename... Args>
-  bool EmitWithSender(base::StringPiece name,
+  bool EmitWithSender(const std::string_view name,
                       content::RenderFrameHost* frame,
                       electron::mojom::ElectronApiIPC::InvokeCallback callback,
                       Args&&... args) {

--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/containers/contains.h"
@@ -33,7 +34,7 @@
 #include "shell/common/gin_helper/dictionary.h"
 
 static constexpr auto ResourceTypes =
-    base::MakeFixedFlatMapSorted<base::StringPiece,
+    base::MakeFixedFlatMapSorted<std::string_view,
                                  extensions::WebRequestResourceType>({
         {"cspReport", extensions::WebRequestResourceType::CSP_REPORT},
         {"font", extensions::WebRequestResourceType::FONT},
@@ -77,7 +78,7 @@ struct UserData : public base::SupportsUserData::Data {
   raw_ptr<WebRequest> data;
 };
 
-extensions::WebRequestResourceType ParseResourceType(base::StringPiece value) {
+extensions::WebRequestResourceType ParseResourceType(std::string_view value) {
   if (const auto* iter = ResourceTypes.find(value); iter != ResourceTypes.end())
     return iter->second;
 

--- a/shell/browser/electron_browser_main_parts_linux.cc
+++ b/shell/browser/electron_browser_main_parts_linux.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/electron_browser_main_parts.h"
 
+#include <string_view>
+
 #include "base/command_line.h"
 #include "base/environment.h"
 #include "ui/ozone/public/ozone_switches.h"
@@ -15,8 +17,8 @@
 #include "shell/common/thread_restrictions.h"
 #endif
 
-constexpr base::StringPiece kElectronOzonePlatformHint(
-    "ELECTRON_OZONE_PLATFORM_HINT");
+constexpr std::string_view kElectronOzonePlatformHint{
+    "ELECTRON_OZONE_PLATFORM_HINT"};
 
 #if BUILDFLAG(OZONE_PLATFORM_WAYLAND)
 

--- a/shell/browser/event_emitter_mixin.h
+++ b/shell/browser/event_emitter_mixin.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_EVENT_EMITTER_MIXIN_H_
 #define ELECTRON_SHELL_BROWSER_EVENT_EMITTER_MIXIN_H_
 
+#include <string_view>
 #include <utility>
 
 #include "gin/handle.h"
@@ -25,7 +26,7 @@ class EventEmitterMixin {
   // this.emit(name, new Event(), args...);
   // Returns true if event.preventDefault() was called during processing.
   template <typename... Args>
-  bool Emit(base::StringPiece name, Args&&... args) {
+  bool Emit(const std::string_view name, Args&&... args) {
     v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
     v8::HandleScope handle_scope(isolate);
     v8::Local<v8::Object> wrapper;
@@ -39,7 +40,7 @@ class EventEmitterMixin {
 
   // this.emit(name, args...);
   template <typename... Args>
-  void EmitWithoutEvent(base::StringPiece name, Args&&... args) {
+  void EmitWithoutEvent(const std::string_view name, Args&&... args) {
     v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
     v8::HandleScope handle_scope(isolate);
     v8::Local<v8::Object> wrapper;

--- a/shell/browser/extensions/electron_extension_system.cc
+++ b/shell/browser/extensions/electron_extension_system.cc
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/files/file_path.h"
@@ -93,7 +94,7 @@ void ElectronExtensionSystem::InitForRegularProfile(bool extensions_enabled) {
 }
 
 std::unique_ptr<base::Value::Dict> ParseManifest(
-    base::StringPiece manifest_contents) {
+    const std::string_view manifest_contents) {
   JSONStringValueDeserializer deserializer(manifest_contents);
   std::unique_ptr<base::Value> manifest =
       deserializer.Deserialize(nullptr, nullptr);

--- a/shell/browser/hid/hid_chooser_context.cc
+++ b/shell/browser/hid/hid_chooser_context.cc
@@ -6,6 +6,10 @@
 
 #include <utility>
 
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+#include <string_view>
+#endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+
 #include "base/command_line.h"
 #include "base/containers/contains.h"
 #include "base/strings/string_util.h"
@@ -32,7 +36,6 @@
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 #include "base/containers/fixed_flat_set.h"
-#include "base/strings/string_piece.h"
 #include "extensions/common/constants.h"
 #endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 
@@ -188,7 +191,7 @@ bool HidChooserContext::HasDevicePermission(
 bool HidChooserContext::IsFidoAllowedForOrigin(const url::Origin& origin) {
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   static constexpr auto kPrivilegedExtensionIds =
-      base::MakeFixedFlatSet<base::StringPiece>({
+      base::MakeFixedFlatSet<std::string_view>({
           "ckcendljdlmgnhghiaomidhiiclmapok",  // gnubbyd-v3 dev
           "lfboplenmmjcmpbkeemecobbadnmpfhi",  // gnubbyd-v3 prod
       });

--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -7,6 +7,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/containers/fixed_flat_map.h"
@@ -48,7 +49,7 @@ struct Converter<electron::ProtocolType> {
                      electron::ProtocolType* out) {
     using Val = electron::ProtocolType;
     static constexpr auto Lookup =
-        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+        base::MakeFixedFlatMapSorted<std::string_view, Val>({
             // note "free" is internal type, not allowed to be passed from user
             {"buffer", Val::kBuffer},
             {"file", Val::kFile},

--- a/shell/browser/net/node_stream_loader.cc
+++ b/shell/browser/net/node_stream_loader.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/net/node_stream_loader.h"
 
+#include <string_view>
 #include <utility>
 
 #include "mojo/public/cpp/system/string_data_source.h"
@@ -135,8 +136,8 @@ void NodeStreamLoader::ReadMore() {
   is_reading_ = false;
   is_writing_ = true;
   producer_->Write(std::make_unique<mojo::StringDataSource>(
-                       base::StringPiece(node::Buffer::Data(buffer),
-                                         node::Buffer::Length(buffer)),
+                       std::string_view{node::Buffer::Data(buffer),
+                                        node::Buffer::Length(buffer)},
                        mojo::StringDataSource::AsyncWritingMode::
                            STRING_STAYS_VALID_UNTIL_COMPLETION),
                    base::BindOnce(&NodeStreamLoader::DidWrite, weak));

--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -5,6 +5,7 @@
 #include "shell/browser/ui/file_dialog.h"
 
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -441,7 +442,7 @@ void SaveDialogCompletion(int chosen,
     dict.Set("canceled", true);
     dict.Set("filePath", base::FilePath());
 #if IS_MAS_BUILD()
-    dict.Set("bookmark", base::StringPiece());
+    dict.Set("bookmark", std::string_view{});
 #endif
   } else {
     std::string path = base::SysNSStringToUTF8([[dialog URL] path]);

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -6,6 +6,7 @@
 #include "shell/browser/ui/inspectable_web_contents.h"
 
 #include <memory>
+#include <string_view>
 #include <utility>
 
 #include "base/base64.h"
@@ -950,8 +951,8 @@ void InspectableWebContents::DispatchProtocolMessage(
   if (!frontend_loaded_)
     return;
 
-  base::StringPiece str_message(reinterpret_cast<const char*>(message.data()),
-                                message.size());
+  const std::string_view str_message{
+      reinterpret_cast<const char*>(message.data()), message.size()};
   if (str_message.length() < kMaxMessageChunkSize) {
     CallClientFunction("DevToolsAPI", "dispatchMessage",
                        base::Value(std::string(str_message)));

--- a/shell/browser/usb/electron_usb_delegate.cc
+++ b/shell/browser/usb/electron_usb_delegate.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/usb/electron_usb_delegate.h"
 
+#include <string_view>
 #include <utility>
 
 #include "base/containers/contains.h"
@@ -45,7 +46,7 @@ electron::UsbChooserContext* GetChooserContext(
 // These extensions can claim the smart card USB class and automatically gain
 // permissions for devices that have an interface with this class.
 constexpr auto kSmartCardPrivilegedExtensionIds =
-    base::MakeFixedFlatSetSorted<base::StringPiece>({
+    base::MakeFixedFlatSetSorted<std::string_view>({
         // Smart Card Connector Extension and its Beta version, see
         // crbug.com/1233881.
         "khpfeaanjngmcnplbdlpegiifgpfgdco",

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/web_contents_permission_helper.h"
 
+#include <string_view>
 #include <utility>
 
 #include "content/public/browser/browser_context.h"
@@ -17,7 +18,7 @@
 
 namespace {
 
-constexpr base::StringPiece MediaStreamTypeToString(
+constexpr std::string_view MediaStreamTypeToString(
     blink::mojom::MediaStreamType type) {
   switch (type) {
     case blink::mojom::MediaStreamType::DEVICE_AUDIO_CAPTURE:

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -45,7 +46,7 @@ struct Converter<blink::mojom::AutoplayPolicy> {
                      blink::mojom::AutoplayPolicy* out) {
     using Val = blink::mojom::AutoplayPolicy;
     static constexpr auto Lookup =
-        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+        base::MakeFixedFlatMapSorted<std::string_view, Val>({
             {"document-user-activation-required",
              Val::kDocumentUserActivationRequired},
             {"no-user-gesture-required", Val::kNoUserGestureRequired},
@@ -62,7 +63,7 @@ struct Converter<blink::mojom::V8CacheOptions> {
                      blink::mojom::V8CacheOptions* out) {
     using Val = blink::mojom::V8CacheOptions;
     static constexpr auto Lookup =
-        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+        base::MakeFixedFlatMapSorted<std::string_view, Val>({
             {"bypassHeatCheck", Val::kCodeWithoutHeatCheck},
             {"bypassHeatCheckAndEagerCompile", Val::kFullCodeWithoutHeatCheck},
             {"code", Val::kCode},

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -69,7 +70,7 @@ struct Converter<network::mojom::CredentialsMode> {
                      network::mojom::CredentialsMode* out) {
     using Val = network::mojom::CredentialsMode;
     static constexpr auto Lookup =
-        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+        base::MakeFixedFlatMapSorted<std::string_view, Val>({
             {"include", Val::kInclude},
             {"omit", Val::kOmit},
             // Note: This only makes sense if the request
@@ -87,7 +88,7 @@ struct Converter<blink::mojom::FetchCacheMode> {
                      blink::mojom::FetchCacheMode* out) {
     using Val = blink::mojom::FetchCacheMode;
     static constexpr auto Lookup =
-        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+        base::MakeFixedFlatMapSorted<std::string_view, Val>({
             {"default", Val::kDefault},
             {"force-cache", Val::kForceCache},
             {"no-cache", Val::kValidateCache},
@@ -107,7 +108,7 @@ struct Converter<net::ReferrerPolicy> {
     using Val = net::ReferrerPolicy;
     // clang-format off
     static constexpr auto Lookup =
-        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+        base::MakeFixedFlatMapSorted<std::string_view, Val>({
             {"", Val::REDUCE_GRANULARITY_ON_TRANSITION_CROSS_ORIGIN},
             {"no-referrer", Val::NO_REFERRER},
             {"no-referrer-when-downgrade", Val::CLEAR_ON_TRANSITION_FROM_SECURE_TO_INSECURE},
@@ -547,7 +548,7 @@ gin::Handle<SimpleURLLoaderWrapper> SimpleURLLoaderWrapper::Create(
   if (std::string mode; opts.Get("mode", &mode)) {
     using Val = network::mojom::RequestMode;
     static constexpr auto Lookup =
-        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+        base::MakeFixedFlatMapSorted<std::string_view, Val>({
             {"cors", Val::kCors},
             {"navigate", Val::kNavigate},
             {"no-cors", Val::kNoCors},
@@ -560,7 +561,7 @@ gin::Handle<SimpleURLLoaderWrapper> SimpleURLLoaderWrapper::Create(
   if (std::string destination; opts.Get("destination", &destination)) {
     using Val = network::mojom::RequestDestination;
     static constexpr auto Lookup =
-        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+        base::MakeFixedFlatMapSorted<std::string_view, Val>({
             {"audio", Val::kAudio},
             {"audioworklet", Val::kAudioWorklet},
             {"document", Val::kDocument},
@@ -695,7 +696,7 @@ gin::Handle<SimpleURLLoaderWrapper> SimpleURLLoaderWrapper::Create(
   return ret;
 }
 
-void SimpleURLLoaderWrapper::OnDataReceived(base::StringPiece string_piece,
+void SimpleURLLoaderWrapper::OnDataReceived(std::string_view string_piece,
                                             base::OnceClosure resume) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();

--- a/shell/common/asar/archive.cc
+++ b/shell/common/asar/archive.cc
@@ -5,6 +5,7 @@
 #include "shell/common/asar/archive.h"
 
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -104,7 +105,7 @@ bool FillFileInfoWithNode(Archive::FileInfo* info,
 
   const std::string* offset = node->FindString("offset");
   if (offset &&
-      base::StringToUint64(base::StringPiece(*offset), &info->offset)) {
+      base::StringToUint64(std::string_view{*offset}, &info->offset)) {
     info->offset += header_size;
   } else {
     return false;

--- a/shell/common/gin_converters/blink_converter.cc
+++ b/shell/common/gin_converters/blink_converter.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/containers/fixed_flat_map.h"
@@ -135,7 +136,7 @@ struct Converter<blink::WebMouseEvent::Button> {
                      blink::WebMouseEvent::Button* out) {
     using Val = blink::WebMouseEvent::Button;
     static constexpr auto Lookup =
-        base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+        base::MakeFixedFlatMapSorted<std::string_view, Val>({
             {"left", Val::kLeft},
             {"middle", Val::kMiddle},
             {"right", Val::kRight},
@@ -148,7 +149,7 @@ struct Converter<blink::WebMouseEvent::Button> {
 
 // these are the modifier names we both accept and return
 static constexpr auto Modifiers =
-    base::MakeFixedFlatMapSorted<base::StringPiece, blink::WebInputEvent::Modifiers>({
+    base::MakeFixedFlatMapSorted<std::string_view, blink::WebInputEvent::Modifiers>({
         {"alt", blink::WebInputEvent::Modifiers::kAltKey},
         {"capslock", blink::WebInputEvent::Modifiers::kCapsLockOn},
         {"control", blink::WebInputEvent::Modifiers::kControlKey},
@@ -167,14 +168,14 @@ static constexpr auto Modifiers =
 
 // these are the modifier names we accept but do not return
 static constexpr auto ModifierAliases =
-    base::MakeFixedFlatMapSorted<base::StringPiece, blink::WebInputEvent::Modifiers>({
+    base::MakeFixedFlatMapSorted<std::string_view, blink::WebInputEvent::Modifiers>({
         {"cmd", blink::WebInputEvent::Modifiers::kMetaKey},
         {"command", blink::WebInputEvent::Modifiers::kMetaKey},
         {"ctrl", blink::WebInputEvent::Modifiers::kControlKey},
 });
 
 static constexpr auto ReferrerPolicies =
-    base::MakeFixedFlatMapSorted<base::StringPiece, network::mojom::ReferrerPolicy>({
+    base::MakeFixedFlatMapSorted<std::string_view, network::mojom::ReferrerPolicy>({
         {"default", network::mojom::ReferrerPolicy::kDefault},
         {"no-referrer", network::mojom::ReferrerPolicy::kNever},
         {"no-referrer-when-downgrade", network::mojom::ReferrerPolicy::kNoReferrerWhenDowngrade},
@@ -197,8 +198,8 @@ struct Converter<blink::WebInputEvent::Modifiers> {
   }
 };
 
-std::vector<base::StringPiece> ModifiersToArray(int modifiers) {
-  std::vector<base::StringPiece> modifier_strings;
+std::vector<std::string_view> ModifiersToArray(int modifiers) {
+  std::vector<std::string_view> modifier_strings;
 
   for (const auto& [name, mask] : Modifiers)
     if (mask & modifiers)
@@ -463,7 +464,7 @@ v8::Local<v8::Value>
 Converter<absl::optional<blink::mojom::FormControlType>>::ToV8(
     v8::Isolate* isolate,
     const absl::optional<blink::mojom::FormControlType>& in) {
-  base::StringPiece str{"none"};
+  std::string_view str{"none"};
   if (in.has_value()) {
     switch (*in) {
       case blink::mojom::FormControlType::kButtonButton:

--- a/shell/common/gin_converters/content_converter.cc
+++ b/shell/common/gin_converters/content_converter.cc
@@ -5,6 +5,7 @@
 #include "shell/common/gin_converters/content_converter.h"
 
 #include <string>
+#include <string_view>
 
 #include "base/containers/fixed_flat_map.h"
 #include "content/public/browser/context_menu_params.h"
@@ -24,7 +25,7 @@
 
 namespace {
 
-[[nodiscard]] constexpr base::StringPiece FormControlToInputFieldTypeString(
+[[nodiscard]] constexpr std::string_view FormControlToInputFieldTypeString(
     const absl::optional<blink::mojom::FormControlType> form_control_type) {
   if (!form_control_type)
     return "none";
@@ -323,7 +324,7 @@ bool Converter<content::StopFindAction>::FromV8(v8::Isolate* isolate,
                                                 content::StopFindAction* out) {
   using Val = content::StopFindAction;
   static constexpr auto Lookup =
-      base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+      base::MakeFixedFlatMapSorted<std::string_view, Val>({
           {"activateSelection", Val::STOP_FIND_ACTION_ACTIVATE_SELECTION},
           {"clearSelection", Val::STOP_FIND_ACTION_CLEAR_SELECTION},
           {"keepSelection", Val::STOP_FIND_ACTION_KEEP_SELECTION},

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -5,6 +5,7 @@
 #include "shell/common/gin_converters/net_converter.h"
 
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -691,7 +692,7 @@ bool Converter<net::DnsQueryType>::FromV8(v8::Isolate* isolate,
                                           v8::Local<v8::Value> val,
                                           net::DnsQueryType* out) {
   static constexpr auto Lookup =
-      base::MakeFixedFlatMapSorted<base::StringPiece, net::DnsQueryType>({
+      base::MakeFixedFlatMapSorted<std::string_view, net::DnsQueryType>({
           {"A", net::DnsQueryType::A},
           {"AAAA", net::DnsQueryType::AAAA},
       });
@@ -704,7 +705,7 @@ bool Converter<net::HostResolverSource>::FromV8(v8::Isolate* isolate,
                                                 net::HostResolverSource* out) {
   using Val = net::HostResolverSource;
   static constexpr auto Lookup =
-      base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+      base::MakeFixedFlatMapSorted<std::string_view, Val>({
           {"any", Val::ANY},
           {"dns", Val::DNS},
           {"localOnly", Val::LOCAL_ONLY},
@@ -721,7 +722,7 @@ bool Converter<network::mojom::ResolveHostParameters::CacheUsage>::FromV8(
     network::mojom::ResolveHostParameters::CacheUsage* out) {
   using Val = network::mojom::ResolveHostParameters::CacheUsage;
   static constexpr auto Lookup =
-      base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+      base::MakeFixedFlatMapSorted<std::string_view, Val>({
           {"allowed", Val::ALLOWED},
           {"disallowed", Val::DISALLOWED},
           {"staleAllowed", Val::STALE_ALLOWED},
@@ -736,7 +737,7 @@ bool Converter<network::mojom::SecureDnsPolicy>::FromV8(
     network::mojom::SecureDnsPolicy* out) {
   using Val = network::mojom::SecureDnsPolicy;
   static constexpr auto Lookup =
-      base::MakeFixedFlatMapSorted<base::StringPiece, Val>({
+      base::MakeFixedFlatMapSorted<std::string_view, Val>({
           {"allow", Val::ALLOW},
           {"disable", Val::DISABLE},
       });

--- a/shell/common/gin_helper/arguments.cc
+++ b/shell/common/gin_helper/arguments.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE.chromium file.
 
+#include <string_view>
+
 #include "shell/common/gin_helper/arguments.h"
 
 #include "v8/include/v8-exception.h"
@@ -15,7 +17,7 @@ void Arguments::ThrowError() const {
   gin::Arguments::ThrowError();
 }
 
-void Arguments::ThrowError(base::StringPiece message) const {
+void Arguments::ThrowError(const std::string_view message) const {
   isolate()->ThrowException(
       v8::Exception::Error(gin::StringToV8(isolate(), message)));
 }

--- a/shell/common/gin_helper/arguments.h
+++ b/shell/common/gin_helper/arguments.h
@@ -5,6 +5,8 @@
 #ifndef ELECTRON_SHELL_COMMON_GIN_HELPER_ARGUMENTS_H_
 #define ELECTRON_SHELL_COMMON_GIN_HELPER_ARGUMENTS_H_
 
+#include <string_view>
+
 #include "gin/arguments.h"
 
 namespace gin_helper {
@@ -40,7 +42,7 @@ class Arguments : public gin::Arguments {
 
   // Throw error with custom error message.
   void ThrowError() const;
-  void ThrowError(base::StringPiece message) const;
+  void ThrowError(std::string_view message) const;
 
  private:
   // MUST NOT ADD ANY DATA MEMBER.

--- a/shell/common/gin_helper/dictionary.h
+++ b/shell/common/gin_helper/dictionary.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_COMMON_GIN_HELPER_DICTIONARY_H_
 #define ELECTRON_SHELL_COMMON_GIN_HELPER_DICTIONARY_H_
 
+#include <string_view>
 #include <type_traits>
 #include <utility>
 
@@ -68,7 +69,7 @@ class Dictionary : public gin::Dictionary {
 
   // Like normal Get but put result in an absl::optional.
   template <typename T>
-  bool GetOptional(base::StringPiece key, absl::optional<T>* out) const {
+  bool GetOptional(const std::string_view key, absl::optional<T>* out) const {
     T ret;
     if (Get(key, &ret)) {
       out->emplace(std::move(ret));
@@ -79,7 +80,7 @@ class Dictionary : public gin::Dictionary {
   }
 
   template <typename T>
-  bool GetHidden(base::StringPiece key, T* out) const {
+  bool GetHidden(std::string_view key, T* out) const {
     v8::Local<v8::Context> context = isolate()->GetCurrentContext();
     v8::Local<v8::Private> privateKey =
         v8::Private::ForApi(isolate(), gin::StringToV8(isolate(), key));
@@ -92,7 +93,7 @@ class Dictionary : public gin::Dictionary {
   }
 
   template <typename T>
-  bool SetHidden(base::StringPiece key, T val) {
+  bool SetHidden(std::string_view key, T val) {
     v8::Local<v8::Value> v8_value;
     if (!gin::TryConvertToV8(isolate(), val, &v8_value))
       return false;
@@ -105,7 +106,7 @@ class Dictionary : public gin::Dictionary {
   }
 
   template <typename T>
-  bool SetMethod(base::StringPiece key, const T& callback) {
+  bool SetMethod(std::string_view key, const T& callback) {
     auto context = isolate()->GetCurrentContext();
     auto templ = CallbackTraits<T>::CreateTemplate(isolate(), callback);
     return GetHandle()
@@ -147,7 +148,7 @@ class Dictionary : public gin::Dictionary {
   }
 
   template <typename T>
-  bool SetReadOnly(base::StringPiece key, const T& val) {
+  bool SetReadOnly(std::string_view key, const T& val) {
     v8::Local<v8::Value> v8_value;
     if (!gin::TryConvertToV8(isolate(), val, &v8_value))
       return false;
@@ -160,7 +161,7 @@ class Dictionary : public gin::Dictionary {
   // Note: If we plan to add more Set methods, consider adding an option instead
   // of copying code.
   template <typename T>
-  bool SetReadOnlyNonConfigurable(base::StringPiece key, T val) {
+  bool SetReadOnlyNonConfigurable(std::string_view key, T val) {
     v8::Local<v8::Value> v8_value;
     if (!gin::TryConvertToV8(isolate(), val, &v8_value))
       return false;
@@ -171,13 +172,13 @@ class Dictionary : public gin::Dictionary {
     return !result.IsNothing() && result.FromJust();
   }
 
-  bool Has(base::StringPiece key) const {
+  bool Has(std::string_view key) const {
     v8::Maybe<bool> result = GetHandle()->Has(isolate()->GetCurrentContext(),
                                               gin::StringToV8(isolate(), key));
     return !result.IsNothing() && result.FromJust();
   }
 
-  bool Delete(base::StringPiece key) {
+  bool Delete(std::string_view key) {
     v8::Maybe<bool> result = GetHandle()->Delete(
         isolate()->GetCurrentContext(), gin::StringToV8(isolate(), key));
     return !result.IsNothing() && result.FromJust();

--- a/shell/common/gin_helper/error_thrower.cc
+++ b/shell/common/gin_helper/error_thrower.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <string_view>
+
 #include "shell/common/gin_helper/error_thrower.h"
 
 #include "gin/converter.h"
@@ -15,27 +17,28 @@ ErrorThrower::ErrorThrower(v8::Isolate* isolate) : isolate_(isolate) {}
 // costly to invoke
 ErrorThrower::ErrorThrower() : isolate_(v8::Isolate::GetCurrent()) {}
 
-void ErrorThrower::ThrowError(base::StringPiece err_msg) const {
+void ErrorThrower::ThrowError(const std::string_view err_msg) const {
   Throw(v8::Exception::Error, err_msg);
 }
 
-void ErrorThrower::ThrowTypeError(base::StringPiece err_msg) const {
+void ErrorThrower::ThrowTypeError(const std::string_view err_msg) const {
   Throw(v8::Exception::TypeError, err_msg);
 }
 
-void ErrorThrower::ThrowRangeError(base::StringPiece err_msg) const {
+void ErrorThrower::ThrowRangeError(const std::string_view err_msg) const {
   Throw(v8::Exception::RangeError, err_msg);
 }
 
-void ErrorThrower::ThrowReferenceError(base::StringPiece err_msg) const {
+void ErrorThrower::ThrowReferenceError(const std::string_view err_msg) const {
   Throw(v8::Exception::ReferenceError, err_msg);
 }
 
-void ErrorThrower::ThrowSyntaxError(base::StringPiece err_msg) const {
+void ErrorThrower::ThrowSyntaxError(const std::string_view err_msg) const {
   Throw(v8::Exception::SyntaxError, err_msg);
 }
 
-void ErrorThrower::Throw(ErrorGenerator gen, base::StringPiece err_msg) const {
+void ErrorThrower::Throw(ErrorGenerator gen,
+                         const std::string_view err_msg) const {
   v8::Local<v8::Value> exception = gen(gin::StringToV8(isolate_, err_msg), {});
   if (!isolate_->IsExecutionTerminating())
     isolate_->ThrowException(exception);

--- a/shell/common/gin_helper/error_thrower.h
+++ b/shell/common/gin_helper/error_thrower.h
@@ -5,8 +5,9 @@
 #ifndef ELECTRON_SHELL_COMMON_GIN_HELPER_ERROR_THROWER_H_
 #define ELECTRON_SHELL_COMMON_GIN_HELPER_ERROR_THROWER_H_
 
+#include <string_view>
+
 #include "base/memory/raw_ptr.h"
-#include "base/strings/string_piece.h"
 #include "v8/include/v8.h"
 
 namespace gin_helper {
@@ -17,18 +18,18 @@ class ErrorThrower {
   ErrorThrower();
   ~ErrorThrower() = default;
 
-  void ThrowError(base::StringPiece err_msg) const;
-  void ThrowTypeError(base::StringPiece err_msg) const;
-  void ThrowRangeError(base::StringPiece err_msg) const;
-  void ThrowReferenceError(base::StringPiece err_msg) const;
-  void ThrowSyntaxError(base::StringPiece err_msg) const;
+  void ThrowError(std::string_view err_msg) const;
+  void ThrowTypeError(std::string_view err_msg) const;
+  void ThrowRangeError(std::string_view err_msg) const;
+  void ThrowReferenceError(std::string_view err_msg) const;
+  void ThrowSyntaxError(std::string_view err_msg) const;
 
   v8::Isolate* isolate() const { return isolate_; }
 
  private:
   using ErrorGenerator = v8::Local<v8::Value> (*)(v8::Local<v8::String> err_msg,
                                                   v8::Local<v8::Value> options);
-  void Throw(ErrorGenerator gen, base::StringPiece err_msg) const;
+  void Throw(ErrorGenerator gen, std::string_view err_msg) const;
 
   raw_ptr<v8::Isolate> isolate_;
 };

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_COMMON_GIN_HELPER_EVENT_EMITTER_H_
 #define ELECTRON_SHELL_COMMON_GIN_HELPER_EVENT_EMITTER_H_
 
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -38,7 +39,7 @@ class EventEmitter : public gin_helper::Wrappable<T> {
 
   // this.emit(name, new Event(), args...);
   template <typename... Args>
-  bool Emit(base::StringPiece name, Args&&... args) {
+  bool Emit(const std::string_view name, Args&&... args) {
     v8::HandleScope handle_scope(isolate());
     v8::Local<v8::Object> wrapper = GetWrapper();
     if (wrapper.IsEmpty())
@@ -58,7 +59,7 @@ class EventEmitter : public gin_helper::Wrappable<T> {
  private:
   // this.emit(name, event, args...);
   template <typename... Args>
-  bool EmitWithEvent(base::StringPiece name,
+  bool EmitWithEvent(const std::string_view name,
                      gin::Handle<gin_helper::internal::Event> event,
                      Args&&... args) {
     // It's possible that |this| will be deleted by EmitEvent, so save anything

--- a/shell/common/gin_helper/object_template_builder.cc
+++ b/shell/common/gin_helper/object_template_builder.cc
@@ -12,14 +12,14 @@ ObjectTemplateBuilder::ObjectTemplateBuilder(
     : isolate_(isolate), template_(templ) {}
 
 ObjectTemplateBuilder& ObjectTemplateBuilder::SetImpl(
-    const base::StringPiece& name,
+    const std::string_view name,
     v8::Local<v8::Data> val) {
   template_->Set(gin::StringToSymbol(isolate_, name), val);
   return *this;
 }
 
 ObjectTemplateBuilder& ObjectTemplateBuilder::SetPropertyImpl(
-    const base::StringPiece& name,
+    const std::string_view name,
     v8::Local<v8::FunctionTemplate> getter,
     v8::Local<v8::FunctionTemplate> setter) {
   template_->SetAccessorProperty(gin::StringToSymbol(isolate_, name), getter,

--- a/shell/common/gin_helper/object_template_builder.h
+++ b/shell/common/gin_helper/object_template_builder.h
@@ -5,6 +5,8 @@
 #ifndef ELECTRON_SHELL_COMMON_GIN_HELPER_OBJECT_TEMPLATE_BUILDER_H_
 #define ELECTRON_SHELL_COMMON_GIN_HELPER_OBJECT_TEMPLATE_BUILDER_H_
 
+#include <string_view>
+
 #include "base/memory/raw_ptr.h"
 #include "shell/common/gin_helper/function_template.h"
 
@@ -28,7 +30,7 @@ class ObjectTemplateBuilder {
   // poetic license here in order that all calls to Set() can be via the '.'
   // operator and line up nicely.
   template <typename T>
-  ObjectTemplateBuilder& SetValue(const base::StringPiece& name, T val) {
+  ObjectTemplateBuilder& SetValue(const std::string_view name, T val) {
     return SetImpl(name, ConvertToV8(isolate_, val));
   }
 
@@ -37,19 +39,19 @@ class ObjectTemplateBuilder {
   // will want to use one of the first two options. Also see
   // gin::CreateFunctionTemplate() for creating raw function templates.
   template <typename T>
-  ObjectTemplateBuilder& SetMethod(const base::StringPiece& name,
+  ObjectTemplateBuilder& SetMethod(const std::string_view name,
                                    const T& callback) {
     return SetImpl(name, CallbackTraits<T>::CreateTemplate(isolate_, callback));
   }
   template <typename T>
-  ObjectTemplateBuilder& SetProperty(const base::StringPiece& name,
+  ObjectTemplateBuilder& SetProperty(const std::string_view name,
                                      const T& getter) {
     return SetPropertyImpl(name,
                            CallbackTraits<T>::CreateTemplate(isolate_, getter),
                            v8::Local<v8::FunctionTemplate>());
   }
   template <typename T, typename U>
-  ObjectTemplateBuilder& SetProperty(const base::StringPiece& name,
+  ObjectTemplateBuilder& SetProperty(const std::string_view name,
                                      const T& getter,
                                      const U& setter) {
     return SetPropertyImpl(name,
@@ -60,10 +62,10 @@ class ObjectTemplateBuilder {
   v8::Local<v8::ObjectTemplate> Build();
 
  private:
-  ObjectTemplateBuilder& SetImpl(const base::StringPiece& name,
+  ObjectTemplateBuilder& SetImpl(const std::string_view name,
                                  v8::Local<v8::Data> val);
   ObjectTemplateBuilder& SetPropertyImpl(
-      const base::StringPiece& name,
+      const std::string_view name,
       v8::Local<v8::FunctionTemplate> getter,
       v8::Local<v8::FunctionTemplate> setter);
 

--- a/shell/common/gin_helper/promise.cc
+++ b/shell/common/gin_helper/promise.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <string_view>
+
 #include "shell/common/gin_helper/promise.h"
 
 namespace gin_helper {
@@ -43,7 +45,8 @@ v8::Maybe<bool> PromiseBase::Reject(v8::Local<v8::Value> except) {
   return GetInner()->Reject(GetContext(), except);
 }
 
-v8::Maybe<bool> PromiseBase::RejectWithErrorMessage(base::StringPiece message) {
+v8::Maybe<bool> PromiseBase::RejectWithErrorMessage(
+    const std::string_view message) {
   v8::HandleScope handle_scope(isolate());
   gin_helper::MicrotasksScope microtasks_scope(
       isolate(), GetContext()->GetMicrotaskQueue());

--- a/shell/common/gin_helper/promise.h
+++ b/shell/common/gin_helper/promise.h
@@ -6,12 +6,12 @@
 #define ELECTRON_SHELL_COMMON_GIN_HELPER_PROMISE_H_
 
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <utility>
 
 #include "base/memory/raw_ptr.h"
-#include "base/strings/string_piece.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "shell/common/gin_converters/std_converter.h"
@@ -47,19 +47,20 @@ class PromiseBase {
   //
   // Note: The parameter type is PromiseBase&& so it can take the instances of
   // Promise<T> type.
-  static void RejectPromise(PromiseBase&& promise, base::StringPiece errmsg) {
+  static void RejectPromise(PromiseBase&& promise,
+                            const std::string_view errmsg) {
     if (electron::IsBrowserProcess() &&
         !content::BrowserThread::CurrentlyOn(content::BrowserThread::UI)) {
       content::GetUIThreadTaskRunner({})->PostTask(
           FROM_HERE,
           base::BindOnce(
-              // Note that this callback can not take StringPiece,
+              // Note that this callback can not take std::string_view,
               // as StringPiece only references string internally and
               // will blow when a temporary string is passed.
               [](PromiseBase&& promise, std::string str) {
                 promise.RejectWithErrorMessage(str);
               },
-              std::move(promise), std::string(errmsg.data(), errmsg.size())));
+              std::move(promise), std::string{errmsg}));
     } else {
       promise.RejectWithErrorMessage(errmsg);
     }
@@ -67,7 +68,7 @@ class PromiseBase {
 
   v8::Maybe<bool> Reject();
   v8::Maybe<bool> Reject(v8::Local<v8::Value> except);
-  v8::Maybe<bool> RejectWithErrorMessage(base::StringPiece message);
+  v8::Maybe<bool> RejectWithErrorMessage(std::string_view message);
 
   v8::Local<v8::Context> GetContext() const;
   v8::Local<v8::Promise> GetHandle() const;

--- a/shell/common/keyboard_util.cc
+++ b/shell/common/keyboard_util.cc
@@ -18,7 +18,7 @@ using CodeAndShiftedChar =
     std::pair<ui::KeyboardCode, absl::optional<char16_t>>;
 
 constexpr CodeAndShiftedChar KeyboardCodeFromKeyIdentifier(
-    base::StringPiece str) {
+    const std::string_view str) {
 #if BUILDFLAG(IS_MAC)
   constexpr auto CommandOrControl = ui::VKEY_COMMAND;
 #else
@@ -26,7 +26,7 @@ constexpr CodeAndShiftedChar KeyboardCodeFromKeyIdentifier(
 #endif
 
   constexpr auto Lookup =
-      base::MakeFixedFlatMapSorted<base::StringPiece, CodeAndShiftedChar>({
+      base::MakeFixedFlatMapSorted<std::string_view, CodeAndShiftedChar>({
           {"alt", {ui::VKEY_MENU, {}}},
           {"altgr", {ui::VKEY_ALTGR, {}}},
           {"backspace", {ui::VKEY_BACK, {}}},
@@ -272,7 +272,7 @@ constexpr CodeAndShiftedChar KeyboardCodeFromCharCode(char16_t c) {
 
 }  // namespace
 
-ui::KeyboardCode KeyboardCodeFromStr(base::StringPiece str,
+ui::KeyboardCode KeyboardCodeFromStr(const std::string_view str,
                                      absl::optional<char16_t>* shifted_char) {
   auto const [code, shifted] =
       str.size() == 1 ? KeyboardCodeFromCharCode(base::ToLowerASCII(str[0]))

--- a/shell/common/keyboard_util.h
+++ b/shell/common/keyboard_util.h
@@ -5,8 +5,10 @@
 #ifndef ELECTRON_SHELL_COMMON_KEYBOARD_UTIL_H_
 #define ELECTRON_SHELL_COMMON_KEYBOARD_UTIL_H_
 
-#include "base/strings/string_piece.h"
+#include <string_view>
+
 #include "third_party/abseil-cpp/absl/types/optional.h"
+
 #include "ui/events/keycodes/keyboard_codes.h"
 
 namespace electron {
@@ -14,7 +16,7 @@ namespace electron {
 // Return key code of the |str|, if the original key is a shifted character,
 // for example + and /, set it in |shifted_char|.
 // pressed.
-ui::KeyboardCode KeyboardCodeFromStr(base::StringPiece str,
+ui::KeyboardCode KeyboardCodeFromStr(std::string_view str,
                                      absl::optional<char16_t>* shifted_char);
 
 }  // namespace electron

--- a/shell/common/logging.cc
+++ b/shell/common/logging.cc
@@ -5,6 +5,7 @@
 #include "shell/common/logging.h"
 
 #include <string>
+#include <string_view>
 
 #include "base/base_switches.h"
 #include "base/command_line.h"
@@ -19,8 +20,8 @@
 
 namespace logging {
 
-constexpr base::StringPiece kLogFileName("ELECTRON_LOG_FILE");
-constexpr base::StringPiece kElectronEnableLogging("ELECTRON_ENABLE_LOGGING");
+constexpr std::string_view kLogFileName{"ELECTRON_LOG_FILE"};
+constexpr std::string_view kElectronEnableLogging{"ELECTRON_ENABLE_LOGGING"};
 
 base::FilePath GetLogFileName(const base::CommandLine& command_line) {
   std::string filename = command_line.GetSwitchValueASCII(switches::kLogFile);

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -300,9 +301,9 @@ void ErrorMessageListener(v8::Local<v8::Message> message,
 
 // Only allow a specific subset of options in non-ELECTRON_RUN_AS_NODE mode.
 // If node CLI inspect support is disabled, allow no debug options.
-bool IsAllowedOption(base::StringPiece option) {
+bool IsAllowedOption(const std::string_view option) {
   static constexpr auto debug_options =
-      base::MakeFixedFlatSetSorted<base::StringPiece>({
+      base::MakeFixedFlatSetSorted<std::string_view>({
           "--debug",
           "--debug-brk",
           "--debug-port",
@@ -315,7 +316,7 @@ bool IsAllowedOption(base::StringPiece option) {
 
   // This should be aligned with what's possible to set via the process object.
   static constexpr auto options =
-      base::MakeFixedFlatSetSorted<base::StringPiece>({
+      base::MakeFixedFlatSetSorted<std::string_view>({
           "--dns-result-order",
           "--no-deprecation",
           "--throw-deprecation",
@@ -334,7 +335,7 @@ bool IsAllowedOption(base::StringPiece option) {
 void SetNodeOptions(base::Environment* env) {
   // Options that are unilaterally disallowed
   static constexpr auto disallowed =
-      base::MakeFixedFlatSetSorted<base::StringPiece>({
+      base::MakeFixedFlatSetSorted<std::string_view>({
           "--enable-fips",
           "--experimental-policy",
           "--force-fips",
@@ -344,7 +345,7 @@ void SetNodeOptions(base::Environment* env) {
       });
 
   static constexpr auto pkg_opts =
-      base::MakeFixedFlatSetSorted<base::StringPiece>({
+      base::MakeFixedFlatSetSorted<std::string_view>({
           "--http-parser",
           "--max-http-header-size",
       });
@@ -488,7 +489,7 @@ std::vector<std::string> NodeBindings::ParseNodeCliFlags() {
 #else
     const auto& option = arg;
 #endif
-    const auto stripped = base::StringPiece(option).substr(0, option.find('='));
+    const auto stripped = std::string_view{option}.substr(0, option.find('='));
     // Only allow no-op or a small set of debug/trace related options.
     if (IsAllowedOption(stripped) || stripped == "--")
       args.push_back(option);

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -5,6 +5,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -386,7 +387,7 @@ class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
 
  private:
   bool MaybeGetRenderFrame(v8::Isolate* isolate,
-                           const base::StringPiece method_name,
+                           const std::string_view method_name,
                            content::RenderFrame** render_frame_ptr) {
     std::string error_msg;
     if (!MaybeGetRenderFrame(&error_msg, method_name, render_frame_ptr)) {
@@ -397,7 +398,7 @@ class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
   }
 
   bool MaybeGetRenderFrame(std::string* error_msg,
-                           const base::StringPiece method_name,
+                           const std::string_view method_name,
                            content::RenderFrame** render_frame_ptr) {
     auto* frame = render_frame();
     if (!frame) {


### PR DESCRIPTION
Manually backport #40915 to 28-x-y. See that PR for details.

Notes: none.