### PR TITLE
perf: omit unnecessary work from `ElectronRenderFrameObserver::ShouldNotifyClient()`

### DIFF
--- a/shell/renderer/electron_render_frame_observer.h
+++ b/shell/renderer/electron_render_frame_observer.h
@@ -37,10 +37,9 @@ class ElectronRenderFrameObserver : public content::RenderFrameObserver {
   void DidMeaningfulLayout(blink::WebMeaningfulLayout layout_type) override;
 
  private:
-  bool ShouldNotifyClient(int world_id);
+  [[nodiscard]] bool ShouldNotifyClient(int world_id) const;
+
   void CreateIsolatedWorldContext();
-  bool IsMainWorld(int world_id);
-  bool IsIsolatedWorld(int world_id);
   void OnTakeHeapSnapshot(IPC::PlatformFileForTransit file_handle,
                           const std::string& channel);
 


### PR DESCRIPTION
#### Description of Change

A couple of small perf improvements to `ElectronRenderFrameObserver::ShouldNotifyClient()`:

- `GetBlinkPreferences()` returns a `const&`, so we can use that reference instead of making a temporary copy

- Don't copy the URL object unless we need it

- Move `is_main_world()` and `is_isolated_world()` from the header into an anonymous namespace in the .cc file so they can be inlined and made constexpr

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.