### PR TITLE
refactor: prefer to inherit observer classes privately

### DIFF
--- a/shell/browser/api/electron_api_desktop_capturer.h
+++ b/shell/browser/api/electron_api_desktop_capturer.h
@@ -19,7 +19,7 @@ namespace electron::api {
 
 class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
                         public gin_helper::Pinnable<DesktopCapturer>,
-                        public DesktopMediaListObserver {
+                        private DesktopMediaListObserver {
  public:
   struct Source {
     DesktopMediaList::Source media_list_source;
@@ -51,6 +51,7 @@ class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
   explicit DesktopCapturer(v8::Isolate* isolate);
   ~DesktopCapturer() override;
 
+ private:
   // DesktopMediaListObserver:
   void OnSourceAdded(int index) override {}
   void OnSourceRemoved(int index) override {}
@@ -61,7 +62,6 @@ class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
   void OnDelegatedSourceListSelection() override {}
   void OnDelegatedSourceListDismissed() override {}
 
- private:
   using OnceCallback = base::OnceClosure;
 
   class DesktopListListener : public DesktopMediaListObserver {

--- a/shell/browser/api/electron_api_global_shortcut.h
+++ b/shell/browser/api/electron_api_global_shortcut.h
@@ -16,7 +16,7 @@
 
 namespace electron::api {
 
-class GlobalShortcut : public extensions::GlobalShortcutListener::Observer,
+class GlobalShortcut : private extensions::GlobalShortcutListener::Observer,
                        public gin::Wrappable<GlobalShortcut> {
  public:
   static gin::Handle<GlobalShortcut> Create(v8::Isolate* isolate);

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -17,7 +17,8 @@
 
 namespace electron::api {
 
-class View : public gin_helper::EventEmitter<View>, public views::ViewObserver {
+class View : public gin_helper::EventEmitter<View>,
+             private views::ViewObserver {
  public:
   static gin_helper::WrappableBase* New(gin::Arguments* args);
   static gin::Handle<View> Create(v8::Isolate* isolate);

--- a/shell/browser/api/frame_subscriber.h
+++ b/shell/browser/api/frame_subscriber.h
@@ -27,8 +27,8 @@ namespace electron::api {
 
 class WebContents;
 
-class FrameSubscriber : public content::WebContentsObserver,
-                        public viz::mojom::FrameSinkVideoConsumer {
+class FrameSubscriber : private content::WebContentsObserver,
+                        private viz::mojom::FrameSinkVideoConsumer {
  public:
   using FrameCaptureCallback =
       base::RepeatingCallback<void(const gfx::Image&, const gfx::Rect&)>;

--- a/shell/browser/api/gpuinfo_manager.h
+++ b/shell/browser/api/gpuinfo_manager.h
@@ -16,7 +16,7 @@
 namespace electron {
 
 // GPUInfoManager is a singleton used to manage and fetch GPUInfo
-class GPUInfoManager : public content::GpuDataManagerObserver {
+class GPUInfoManager : private content::GpuDataManagerObserver {
  public:
   static GPUInfoManager* GetInstance();
 
@@ -29,9 +29,10 @@ class GPUInfoManager : public content::GpuDataManagerObserver {
 
   void FetchCompleteInfo(gin_helper::Promise<base::Value> promise);
   void FetchBasicInfo(gin_helper::Promise<base::Value> promise);
-  void OnGpuInfoUpdate() override;
 
  private:
+  void OnGpuInfoUpdate() override;
+
   base::Value::Dict EnumerateGPUInfo(gpu::GPUInfo gpu_info) const;
 
   // These should be posted to the task queue

--- a/shell/browser/api/save_page_handler.h
+++ b/shell/browser/api/save_page_handler.h
@@ -23,8 +23,8 @@ class WebContents;
 namespace electron::api {
 
 // A self-destroyed class for handling save page request.
-class SavePageHandler : public content::DownloadManager::Observer,
-                        public download::DownloadItem::Observer {
+class SavePageHandler : private content::DownloadManager::Observer,
+                        private download::DownloadItem::Observer {
  public:
   SavePageHandler(content::WebContents* web_contents,
                   gin_helper::Promise<void> promise);

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -85,7 +85,7 @@ struct LoginItemSettings {
 };
 
 // This class is used for control application-wide operations.
-class Browser : public WindowListObserver {
+class Browser : private WindowListObserver {
  public:
   Browser();
   ~Browser() override;

--- a/shell/browser/cookie_change_notifier.h
+++ b/shell/browser/cookie_change_notifier.h
@@ -16,7 +16,7 @@ namespace electron {
 class ElectronBrowserContext;
 
 // Sends cookie-change notifications on the UI thread.
-class CookieChangeNotifier : public network::mojom::CookieChangeListener {
+class CookieChangeNotifier : private network::mojom::CookieChangeListener {
  public:
   explicit CookieChangeNotifier(ElectronBrowserContext* browser_context);
   ~CookieChangeNotifier() override;

--- a/shell/browser/electron_autofill_driver_factory.h
+++ b/shell/browser/electron_autofill_driver_factory.h
@@ -18,7 +18,7 @@ namespace electron {
 class AutofillDriver;
 
 class AutofillDriverFactory
-    : public content::WebContentsObserver,
+    : private content::WebContentsObserver,
       public content::WebContentsUserData<AutofillDriverFactory> {
  public:
   typedef base::OnceCallback<std::unique_ptr<AutofillDriver>()>
@@ -31,11 +31,6 @@ class AutofillDriverFactory
           pending_receiver,
       content::RenderFrameHost* render_frame_host);
 
-  // content::WebContentsObserver:
-  void RenderFrameDeleted(content::RenderFrameHost* render_frame_host) override;
-  void DidFinishNavigation(
-      content::NavigationHandle* navigation_handle) override;
-
   AutofillDriver* DriverForFrame(content::RenderFrameHost* render_frame_host);
   void AddDriverForFrame(content::RenderFrameHost* render_frame_host,
                          CreationCallback factory_method);
@@ -46,6 +41,11 @@ class AutofillDriverFactory
   WEB_CONTENTS_USER_DATA_KEY_DECL();
 
  private:
+  // content::WebContentsObserver:
+  void RenderFrameDeleted(content::RenderFrameHost* render_frame_host) override;
+  void DidFinishNavigation(
+      content::NavigationHandle* navigation_handle) override;
+
   explicit AutofillDriverFactory(content::WebContents* web_contents);
   friend class content::WebContentsUserData<AutofillDriverFactory>;
 

--- a/shell/browser/hid/hid_chooser_controller.h
+++ b/shell/browser/hid/hid_chooser_controller.h
@@ -36,8 +36,8 @@ class HidChooserContext;
 
 // HidChooserController provides data for the WebHID API permission prompt.
 class HidChooserController
-    : public content::WebContentsObserver,
-      public electron::HidChooserContext::DeviceObserver {
+    : private content::WebContentsObserver,
+      private electron::HidChooserContext::DeviceObserver {
  public:
   // Construct a chooser controller for Human Interface Devices (HID).
   // |render_frame_host| is used to initialize the chooser strings and to access

--- a/shell/browser/serial/serial_chooser_controller.h
+++ b/shell/browser/serial/serial_chooser_controller.h
@@ -28,8 +28,9 @@ namespace electron {
 class ElectronSerialDelegate;
 
 // SerialChooserController provides data for the Serial API permission prompt.
-class SerialChooserController final : public SerialChooserContext::PortObserver,
-                                      public content::WebContentsObserver {
+class SerialChooserController final
+    : private SerialChooserContext::PortObserver,
+      private content::WebContentsObserver {
  public:
   SerialChooserController(
       content::RenderFrameHost* render_frame_host,

--- a/shell/browser/ui/autofill_popup.h
+++ b/shell/browser/ui/autofill_popup.h
@@ -19,7 +19,7 @@ namespace electron {
 
 class AutofillPopupView;
 
-class AutofillPopup : public views::ViewObserver {
+class AutofillPopup : private views::ViewObserver {
  public:
   AutofillPopup();
   ~AutofillPopup() override;

--- a/shell/browser/usb/usb_chooser_controller.h
+++ b/shell/browser/usb/usb_chooser_controller.h
@@ -27,8 +27,8 @@ class RenderFrameHost;
 namespace electron {
 
 // UsbChooserController creates a chooser for WebUSB.
-class UsbChooserController final : public UsbChooserContext::DeviceObserver,
-                                   public content::WebContentsObserver {
+class UsbChooserController final : private UsbChooserContext::DeviceObserver,
+                                   private content::WebContentsObserver {
  public:
   UsbChooserController(
       content::RenderFrameHost* render_frame_host,

--- a/shell/browser/web_contents_zoom_controller.h
+++ b/shell/browser/web_contents_zoom_controller.h
@@ -18,7 +18,7 @@ class WebContentsZoomObserver;
 
 // Manages the zoom changes of WebContents.
 class WebContentsZoomController
-    : public content::WebContentsObserver,
+    : private content::WebContentsObserver,
       public content::WebContentsUserData<WebContentsZoomController> {
  public:
   // Defines how zoom changes are handled.

--- a/shell/browser/web_view_guest_delegate.h
+++ b/shell/browser/web_view_guest_delegate.h
@@ -19,7 +19,7 @@ class WebContents;
 }
 
 class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
-                             public WebContentsZoomObserver {
+                             private WebContentsZoomObserver {
  public:
   WebViewGuestDelegate(content::WebContents* embedder,
                        api::WebContents* api_web_contents);

--- a/shell/renderer/electron_autofill_agent.h
+++ b/shell/renderer/electron_autofill_agent.h
@@ -21,9 +21,9 @@
 
 namespace electron {
 
-class AutofillAgent : public content::RenderFrameObserver,
-                      public blink::WebAutofillClient,
-                      public mojom::ElectronAutofillAgent {
+class AutofillAgent : private content::RenderFrameObserver,
+                      private blink::WebAutofillClient,
+                      private mojom::ElectronAutofillAgent {
  public:
   explicit AutofillAgent(content::RenderFrame* frame,
                          blink::AssociatedInterfaceRegistry* registry);

--- a/shell/renderer/electron_render_frame_observer.h
+++ b/shell/renderer/electron_render_frame_observer.h
@@ -16,7 +16,7 @@ namespace electron {
 class RendererClientBase;
 
 // Helper class to forward the messages to the client.
-class ElectronRenderFrameObserver : public content::RenderFrameObserver {
+class ElectronRenderFrameObserver : private content::RenderFrameObserver {
  public:
   ElectronRenderFrameObserver(content::RenderFrame* frame,
                               RendererClientBase* renderer_client);
@@ -26,6 +26,7 @@ class ElectronRenderFrameObserver : public content::RenderFrameObserver {
   ElectronRenderFrameObserver& operator=(const ElectronRenderFrameObserver&) =
       delete;
 
+ private:
   // content::RenderFrameObserver:
   void DidClearWindowObject() override;
   void DidInstallConditionalFeatures(v8::Handle<v8::Context> context,
@@ -35,7 +36,6 @@ class ElectronRenderFrameObserver : public content::RenderFrameObserver {
   void OnDestruct() override;
   void DidMeaningfulLayout(blink::WebMeaningfulLayout layout_type) override;
 
- private:
   [[nodiscard]] bool ShouldNotifyClient(int world_id) const;
 
   void CreateIsolatedWorldContext();

--- a/shell/renderer/pepper_helper.h
+++ b/shell/renderer/pepper_helper.h
@@ -11,7 +11,7 @@
 
 // This class listens for Pepper creation events from the RenderFrame and
 // attaches the parts required for plugin support.
-class PepperHelper : public content::RenderFrameObserver {
+class PepperHelper : private content::RenderFrameObserver {
  public:
   explicit PepperHelper(content::RenderFrame* render_frame);
   ~PepperHelper() override;
@@ -20,6 +20,7 @@ class PepperHelper : public content::RenderFrameObserver {
   PepperHelper(const PepperHelper&) = delete;
   PepperHelper& operator=(const PepperHelper&) = delete;
 
+ private:
   // RenderFrameObserver.
   void DidCreatePepperPlugin(content::RendererPpapiHost* host) override;
   void OnDestruct() override;


### PR DESCRIPTION
#### Description of Change

We have a lot of classes that inherit from upstream observer classes to manage internal state, e.g. our `AutofillDriverFactory`  inherits from `content::WebContentsObserver` so that it can know when to close popups.

Since `WebContentsObserver` inherits `AutofillDriverFactory` publicly, we are accidentally exposing a _lot_ of public API (it's a 900+ LOC class!) to `WebContentsObserver`'s clients. We shouldn't do that; it might accidentally get used.

This PR uses private inheritance instead..

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.