### PR TITLE
chore: formally deprecate `inputFieldType` in `context-menu` params

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -38,6 +38,11 @@ The autoresizing behavior is now standardized across all platforms.
 If your app uses `BrowserView.setAutoResize` to do anything more complex than making a BrowserView fill the entire window, it's likely you already had custom logic in place to handle this difference in behavior on macOS.
 If so, that logic will no longer be needed in Electron 30 as autoresizing behavior is consistent.
 
+### Deprecated: `inputFieldType` in `context-menu` params
+
+The `inputFieldType` property in the `context-menu` params has been deprecated and will be removed.
+Use `formControlType` instead.
+
 ## Planned Breaking API Changes (29.0)
 
 ### Behavior Changed: `ipcRenderer` can no longer be sent over the `contextBridge`

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -606,6 +606,18 @@ WebContents.prototype._init = function () {
     }
   });
 
+  this.on('context-menu', (event, params) => {
+    const { inputFieldType } = params;
+    delete (params as any).inputFieldType;
+    Object.defineProperty(params, 'inputFieldType', {
+      get () {
+        deprecate.warn('inputFieldType', 'formControlType');
+        return inputFieldType;
+      },
+      enumerable: true
+    });
+  });
+
   this.on('-before-unload-fired' as any, function (this: Electron.WebContents, event: Electron.Event, proceed: boolean) {
     const type = this.getType();
     // These are the "interactive" types, i.e. ones a user might be looking at.

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -6,6 +6,7 @@ import * as http from 'node:http';
 import { BrowserWindow, ipcMain, webContents, session, app, BrowserView, WebContents } from 'electron/main';
 import { closeAllWindows } from './lib/window-helpers';
 import { ifdescribe, defer, waitUntil, listen, ifit } from './lib/spec-helpers';
+import { expectDeprecationMessages } from './lib/deprecate-helpers';
 import { once } from 'node:events';
 import { setTimeout } from 'node:timers/promises';
 
@@ -2405,6 +2406,7 @@ describe('webContents module', () => {
       expect(params.frame).to.be.an('object');
       expect(params.x).to.be.a('number');
       expect(params.y).to.be.a('number');
+      expectDeprecationMessages(() => expect(params.inputFieldType).to.be.a('string'));
     });
   });
 


### PR DESCRIPTION
#### Description of Change
Deprecated since #40316

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: The `inputFieldType` property in the `context-menu` params has been deprecated and will be removed.