### PR TITLE
ci: fix helperPath calls in ci configs

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -356,7 +356,7 @@ step-setup-rbe-for-build: &step-setup-rbe-for-build
       HELPER=$(node -p "require('./src/utils/reclient.js').helperPath({})")
       $HELPER login
       echo 'export RBE_service='`node -e "console.log(require('./src/utils/reclient.js').serviceAddress)"` >> $BASH_ENV
-      echo 'export RBE_experimental_credentials_helper='`node -e "console.log(require('./src/utils/reclient.js').helperPath)"` >> $BASH_ENV
+      echo 'export RBE_experimental_credentials_helper='`node -e "console.log(require('./src/utils/reclient.js').helperPath({}))"` >> $BASH_ENV
       echo 'export RBE_experimental_credentials_helper_args="print"' >> $BASH_ENV
 
 step-restore-brew-cache: &step-restore-brew-cache

--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -353,7 +353,7 @@ step-setup-rbe-for-build: &step-setup-rbe-for-build
       mkdir third_party
       # Pull down credential helper and print status
       node -e "require('./src/utils/reclient.js').downloadAndPrepare({})"
-      HELPER=$(node -p "require('./src/utils/reclient.js').helperPath")
+      HELPER=$(node -p "require('./src/utils/reclient.js').helperPath({})")
       $HELPER login
       echo 'export RBE_service='`node -e "console.log(require('./src/utils/reclient.js').serviceAddress)"` >> $BASH_ENV
       echo 'export RBE_experimental_credentials_helper='`node -e "console.log(require('./src/utils/reclient.js').helperPath)"` >> $BASH_ENV

--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -106,7 +106,7 @@ for:
       - mkdir third_party
       - ps: >-
           node -e "require('./src/utils/reclient.js').downloadAndPrepare({})"
-      - ps: $env:RECLIENT_HELPER = node -p "require('./src/utils/reclient.js').helperPath"
+      - ps: $env:RECLIENT_HELPER = node -p "require('./src/utils/reclient.js').helperPath({})"
       - ps: >-
           & $env:RECLIENT_HELPER login
       - ps: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -104,7 +104,7 @@ for:
       - mkdir third_party
       - ps: >-
           node -e "require('./src/utils/reclient.js').downloadAndPrepare({})"
-      - ps: $env:RECLIENT_HELPER = node -p "require('./src/utils/reclient.js').helperPath"
+      - ps: $env:RECLIENT_HELPER = node -p "require('./src/utils/reclient.js').helperPath({})"
       - ps: >-
           & $env:RECLIENT_HELPER login
       - ps: >-


### PR DESCRIPTION
#### Description of Change

Follow up to https://github.com/electron/build-tools/pull/559, which turned the RBE config's helperPath to a function call. This PR modifies the helperPath to a function which passes in an empty config. (Thanks to @codebytere for spotting this!)

Not needed in 28-26, as those branches still use GOMA.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
