### PR TITLE
docs: explain avoiding top-level await with whenReady

### DIFF
--- a/docs/tutorial/esm.md
+++ b/docs/tutorial/esm.md
@@ -75,14 +75,14 @@ app.whenReady().then(() => {
 You must not use a top-level `await` with the app's `whenReady` promise. Doing so will cause the app to hang.
 Instead, use the promise's `then` function.
 
-```js
+```js @ts-nocheck
 // Works ✅
 app.whenReady().then(() => {
   console.log('The app is ready')
 })
 
 // Hangs ❌
-await app.whenReady();
+await app.whenReady()
 console.log('The app is ready')
 ```
 

--- a/docs/tutorial/esm.md
+++ b/docs/tutorial/esm.md
@@ -72,6 +72,20 @@ app.whenReady().then(() => {
 })
 ```
 
+You must not use a top-level `await` with the app's `whenReady` promise. Doing so will cause the app to hang.
+Instead, use the promise's `then` function.
+
+```js
+// Works ✅
+app.whenReady().then(() => {
+  console.log('The app is ready')
+})
+
+// Hangs ❌
+await app.whenReady();
+console.log('The app is ready')
+```
+
 :::caution Transpiler translations
 
 JavaScript transpilers (e.g. Babel, TypeScript) have historically supported ES Module


### PR DESCRIPTION
#### Description of Change

Using a top-level `await` with an app's `whenReady` promise will cause the app to hang. This does not seem to be documented on the page that explains the caveats when using ESM. This PR adds a note with a positive and negative example to help users avoid this pitfall.

This PR is currently in draft mode since I made the change on GitHub.com and I haven't had the chance to run any lint commands if needed.

See #40719. This PR does not fix that issue, but it does document the current behavior.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Explained that `whenReady` cannot be awaited at the top-level when using ESM.