### PR TITLE
build: don't modify `deps/v8/tools` paths

### DIFF
--- a/patches/node/build_add_gn_build_files.patch
+++ b/patches/node/build_add_gn_build_files.patch
@@ -2216,10 +2216,10 @@ index 9f2fbc1e53937448aa27c1f5fe110eabc7edc0df..ea77c7598153bb8a9ba20c89a4ece2c1
  // bootstrap scripts, whose source are bundled into the binary as static data.
 diff --git a/tools/generate_gn_filenames_json.py b/tools/generate_gn_filenames_json.py
 new file mode 100755
-index 0000000000000000000000000000000000000000..7848ddb1841b6d4f36e9376c73564eb4ff6d7c08
+index 0000000000000000000000000000000000000000..e620a64ad1fa0ac7fc517a87ceaf019b1ad616c6
 --- /dev/null
 +++ b/tools/generate_gn_filenames_json.py
-@@ -0,0 +1,90 @@
+@@ -0,0 +1,98 @@
 +#!/usr/bin/env python3
 +import json
 +import os
@@ -2268,7 +2268,15 @@ index 0000000000000000000000000000000000000000..7848ddb1841b6d4f36e9376c73564eb4
 +
 +  def filter_v8_files(files):
 +    if any(f.startswith('deps/v8/') for f in files):
-+      files = [f.replace('deps/v8/', '../../v8/', 1) if f.endswith('js') else f.replace('deps/v8/', '//v8/') for f in files]
++      new_files = []
++      for f in files:
++        if f.startswith('deps/v8/tools'):
++          new_files.append(f)
++        elif f.endswith('js'):
++          new_files.append(f.replace('deps/v8/', '../../v8/', 1))
++        else:
++          new_files.append(f.replace('deps/v8/', '//v8/'))
++      files = new_files
 +
 +    if any(f == '<@(node_builtin_shareable_builtins)' for f in files):
 +      files.remove('<@(node_builtin_shareable_builtins)')


### PR DESCRIPTION
#### Description of Change

Prior to this, `generate_gn_filenames_json.py` replaced all files starting with `deps/v8` with references to the version of v8 we actually use in `src/v8`. However, this causes problems for the set of files in `deps/v8/tools` as they're not compiled and Node.js depends on them directly with hardcoded paths. Up to now, I've just been manually changing this back after running `generate_gn_filenames_json.py`: https://github.com/electron/electron/blob/3f4c55b70d478340eef25e4c09e957dbcb30ed85/patches/node/build_add_gn_build_files.patch#L1716-L1726

We should figure out a better long-term path for this but for now this prevents needing to undo the change during roll filename generation.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
