### PR TITLE
docs: update breaking changes language

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -42,10 +42,10 @@ If so, that logic will no longer be needed in Electron 30 as autoresizing behavi
 
 ### Behavior Changed: `ipcRenderer` can no longer be sent over the `contextBridge`
 
-Attempting to send `ipcRenderer` as an object over the `contextBridge` will now result in
+Attempting to send the entire `ipcRenderer` module as an object over the `contextBridge` will now result in
 an empty object on the receiving side of the bridge. This change was made to remove / mitigate
-a security footgun, you should not directly expose ipcRenderer or it's methods over the bridge.
-Instead provide a safe wrapper like below:
+a security footgun. You should not directly expose ipcRenderer or its methods over the bridge.
+Instead, provide a safe wrapper like below:
 
 ```js
 contextBridge.exposeInMainWorld('app', {


### PR DESCRIPTION
#### Description of Change

This PR updates the language in breaking-changes.md to reflect better phrasing suggested by @erickzhao in the Electron 29 release blog post.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
