### PR TITLE
fix: make window.flashFrame(bool) flash continuously on macOS

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1007,7 +1007,7 @@ std::string NativeWindowMac::GetTitle() const {
 
 void NativeWindowMac::FlashFrame(bool flash) {
   if (flash) {
-    attention_request_id_ = [NSApp requestUserAttention:NSInformationalRequest];
+    attention_request_id_ = [NSApp requestUserAttention:NSCriticalRequest];
   } else {
     [NSApp cancelUserAttentionRequest:attention_request_id_];
     attention_request_id_ = 0;


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
I was developing a cross-platform (Windows, macOS) application and found that the Windows behavior was consistent with the semantics of `flashFrame(bool)`. i.e. the first call `flashFrame(true)` will start and it will continue until you call `flashFrame(false)`. However, the macOS implementation is not at parity with this. The first `flashFrame(true)` call will indeed flash, but only once (given the [NSInformationalRequest](https://developer.apple.com/documentation/appkit/nsrequestuserattentiontype/nsinformationalrequest) level). The solution to have it flash continuously until you stop it would be to change it to [NSCriticalRequest](https://developer.apple.com/documentation/appkit/nsrequestuserattentiontype/nscriticalrequest)). If somebody did want to explicitly use NSInformationalRequest they can still use [`dock.bounce('informational')`](https://www.electronjs.org/docs/latest/api/dock#dockbouncetype-macos) . The main objective here is to bring the macOS into parity with the Windows, so that a developer would need to only call flashFrame in a platform independent manner. Currently, I was doing:

```javascript
    if (__DARWIN__) {
      // This is used instead of flashFrame in order to match the OS dialog behavior.
      app.dock.bounce('critical')
    } else {
      this.window.once('focus', () => this.window.flashFrame(false))
      this.window.flashFrame(true)
    }
```

I did not find any unit tests for this piece of code and I do not know how to assert on the userAttentionRequest given ther underlying API does not expose a way to read the state.
If you feel any docs need updating let me know and I can update them.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples --> made window.flashFrame(bool) flash continuously on macOS