### PR TITLE
fix: use ScreenCaptureKit exclusively on macOS 14.4 and higher

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -383,6 +383,7 @@ filenames = {
     "shell/browser/extended_web_contents_observer.h",
     "shell/browser/feature_list.cc",
     "shell/browser/feature_list.h",
+    "shell/browser/feature_list_mac.mm",
     "shell/browser/file_select_helper.cc",
     "shell/browser/file_select_helper.h",
     "shell/browser/file_select_helper_mac.mm",

--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -49,6 +49,11 @@ void InitializeFeatureList() {
       // 'custom dictionary word list API' spec to crash.
       std::string(",") + spellcheck::kWinDelaySpellcheckServiceInit.name;
 #endif
+  std::string platform_specific_enable_features =
+      EnablePlatformSpecificFeatures();
+  if (platform_specific_enable_features.size() > 0) {
+    enable_features += std::string(",") + platform_specific_enable_features;
+  }
   base::FeatureList::InitInstance(enable_features, disable_features);
 }
 
@@ -59,5 +64,11 @@ void InitializeFieldTrials() {
 
   base::FieldTrialList::CreateTrialsFromString(force_fieldtrials);
 }
+
+#if !BUILDFLAG(IS_MAC)
+std::string EnablePlatformSpecificFeatures() {
+  return "";
+}
+#endif
 
 }  // namespace electron

--- a/shell/browser/feature_list.h
+++ b/shell/browser/feature_list.h
@@ -5,9 +5,12 @@
 #ifndef ELECTRON_SHELL_BROWSER_FEATURE_LIST_H_
 #define ELECTRON_SHELL_BROWSER_FEATURE_LIST_H_
 
+#include <string>
+
 namespace electron {
 void InitializeFeatureList();
 void InitializeFieldTrials();
+std::string EnablePlatformSpecificFeatures();
 }  // namespace electron
 
 #endif  // ELECTRON_SHELL_BROWSER_FEATURE_LIST_H_

--- a/shell/browser/feature_list_mac.mm
+++ b/shell/browser/feature_list_mac.mm
@@ -1,0 +1,28 @@
+// Copyright (c) 2024 Salesforce, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "electron/shell/browser/feature_list.h"
+
+#include <string>
+
+namespace electron {
+
+std::string EnablePlatformSpecificFeatures() {
+  if (@available(macOS 14.4, *)) {
+    // These flags aren't exported so reference them by name directly, they are
+    // used to ensure that screen and window capture exclusive use
+    // ScreenCaptureKit APIs to avoid warning dialogs on macOS 14.4 and higher.
+    // kScreenCaptureKitPickerScreen,
+    // chrome/browser/media/webrtc/thumbnail_capturer_mac.mm
+    // kScreenCaptureKitStreamPickerSonoma,
+    // chrome/browser/media/webrtc/thumbnail_capturer_mac.mm
+    // kThumbnailCapturerMac,
+    // chrome/browser/media/webrtc/thumbnail_capturer_mac.mm
+    return "ScreenCaptureKitPickerScreen,ScreenCaptureKitStreamPickerSonoma,"
+           "ThumbnailCapturerMac:capture_mode/sc_screenshot_manager";
+  }
+  return "";
+}
+
+}  // namespace electron


### PR DESCRIPTION
This fixes a nasty warning / permission dialog that pops up to end-users when consuming legacy APIs.  Chrome has flipped these flags via field trials as have other Electron apps. It should just be the default.

Notes: Ensure ScreenCaptureKit is used exclusively on macOS 14.4 and higher to avoid permission prompts