### PR TITLE
refactor: prefer using `base::NoDestructor` to `base::{Singleton,LazyInstance}`

### DIFF
--- a/shell/browser/badging/badge_manager_factory.cc
+++ b/shell/browser/badging/badge_manager_factory.cc
@@ -21,7 +21,8 @@ BadgeManager* BadgeManagerFactory::GetForBrowserContext(
 
 // static
 BadgeManagerFactory* BadgeManagerFactory::GetInstance() {
-  return base::Singleton<BadgeManagerFactory>::get();
+  static base::NoDestructor<BadgeManagerFactory> instance;
+  return instance.get();
 }
 
 BadgeManagerFactory::BadgeManagerFactory()

--- a/shell/browser/badging/badge_manager_factory.h
+++ b/shell/browser/badging/badge_manager_factory.h
@@ -9,7 +9,7 @@
 
 namespace base {
 template <typename T>
-struct DefaultSingletonTraits;
+class NoDestructor;
 }
 
 namespace badging {
@@ -30,7 +30,7 @@ class BadgeManagerFactory : public BrowserContextKeyedServiceFactory {
   BadgeManagerFactory& operator=(const BadgeManagerFactory&) = delete;
 
  private:
-  friend struct base::DefaultSingletonTraits<BadgeManagerFactory>;
+  friend base::NoDestructor<BadgeManagerFactory>;
 
   BadgeManagerFactory();
   ~BadgeManagerFactory() override;

--- a/shell/browser/extensions/electron_extension_system_factory.cc
+++ b/shell/browser/extensions/electron_extension_system_factory.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/extensions/electron_extension_system_factory.h"
 
+#include "base/no_destructor.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
 #include "extensions/browser/extension_prefs_factory.h"
 #include "extensions/browser/extension_registry_factory.h"
@@ -21,7 +22,8 @@ ExtensionSystem* ElectronExtensionSystemFactory::GetForBrowserContext(
 
 // static
 ElectronExtensionSystemFactory* ElectronExtensionSystemFactory::GetInstance() {
-  return base::Singleton<ElectronExtensionSystemFactory>::get();
+  static base::NoDestructor<ElectronExtensionSystemFactory> instance;
+  return instance.get();
 }
 
 ElectronExtensionSystemFactory::ElectronExtensionSystemFactory()

--- a/shell/browser/extensions/electron_extension_system_factory.h
+++ b/shell/browser/extensions/electron_extension_system_factory.h
@@ -5,8 +5,12 @@
 #ifndef ELECTRON_SHELL_BROWSER_EXTENSIONS_ELECTRON_EXTENSION_SYSTEM_FACTORY_H_
 #define ELECTRON_SHELL_BROWSER_EXTENSIONS_ELECTRON_EXTENSION_SYSTEM_FACTORY_H_
 
-#include "base/memory/singleton.h"
 #include "extensions/browser/extension_system_provider.h"
+
+namespace base {
+template <typename T>
+class NoDestructor;
+}  // namespace base
 
 namespace extensions {
 
@@ -26,7 +30,7 @@ class ElectronExtensionSystemFactory : public ExtensionSystemProvider {
       const ElectronExtensionSystemFactory&) = delete;
 
  private:
-  friend struct base::DefaultSingletonTraits<ElectronExtensionSystemFactory>;
+  friend base::NoDestructor<ElectronExtensionSystemFactory>;
 
   ElectronExtensionSystemFactory();
   ~ElectronExtensionSystemFactory() override;

--- a/shell/browser/media/media_capture_devices_dispatcher.cc
+++ b/shell/browser/media/media_capture_devices_dispatcher.cc
@@ -3,7 +3,7 @@
 // found in the LICENSE-CHROMIUM file.
 
 #include "shell/browser/media/media_capture_devices_dispatcher.h"
-
+// #include "base/no_destructor.h"
 #include "base/logging.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/media_capture_devices.h"
@@ -13,7 +13,8 @@ using content::BrowserThread;
 namespace electron {
 
 MediaCaptureDevicesDispatcher* MediaCaptureDevicesDispatcher::GetInstance() {
-  return base::Singleton<MediaCaptureDevicesDispatcher>::get();
+  static base::NoDestructor<MediaCaptureDevicesDispatcher> instance;
+  return instance.get();
 }
 
 MediaCaptureDevicesDispatcher::MediaCaptureDevicesDispatcher() {

--- a/shell/browser/media/media_capture_devices_dispatcher.h
+++ b/shell/browser/media/media_capture_devices_dispatcher.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_BROWSER_MEDIA_MEDIA_CAPTURE_DEVICES_DISPATCHER_H_
 #define ELECTRON_SHELL_BROWSER_MEDIA_MEDIA_CAPTURE_DEVICES_DISPATCHER_H_
 
-#include "base/memory/singleton.h"
 #include "components/webrtc/media_stream_device_enumerator_impl.h"
 #include "content/public/browser/media_observer.h"
 #include "content/public/browser/media_stream_request.h"
@@ -45,7 +44,7 @@ class MediaCaptureDevicesDispatcher
       const MediaCaptureDevicesDispatcher&) = delete;
 
  private:
-  friend struct base::DefaultSingletonTraits<MediaCaptureDevicesDispatcher>;
+  friend base::NoDestructor<MediaCaptureDevicesDispatcher>;
 
   MediaCaptureDevicesDispatcher();
   ~MediaCaptureDevicesDispatcher() override;

--- a/shell/browser/net/network_context_service_factory.cc
+++ b/shell/browser/net/network_context_service_factory.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/net/network_context_service_factory.h"
 
+#include "base/no_destructor.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
 #include "shell/browser/net/network_context_service.h"
 
@@ -16,7 +17,8 @@ NetworkContextService* NetworkContextServiceFactory::GetForContext(
 }
 
 NetworkContextServiceFactory* NetworkContextServiceFactory::GetInstance() {
-  return base::Singleton<NetworkContextServiceFactory>::get();
+  static base::NoDestructor<NetworkContextServiceFactory> instance;
+  return instance.get();
 }
 
 NetworkContextServiceFactory::NetworkContextServiceFactory()

--- a/shell/browser/net/network_context_service_factory.h
+++ b/shell/browser/net/network_context_service_factory.h
@@ -14,6 +14,11 @@ namespace content {
 class BrowserContext;
 }
 
+namespace base {
+template <typename T>
+class NoDestructor;
+}
+
 namespace electron {
 
 class NetworkContextService;
@@ -33,7 +38,7 @@ class NetworkContextServiceFactory : public BrowserContextKeyedServiceFactory {
       delete;
 
  private:
-  friend struct base::DefaultSingletonTraits<NetworkContextServiceFactory>;
+  friend base::NoDestructor<NetworkContextServiceFactory>;
 
   NetworkContextServiceFactory();
   ~NetworkContextServiceFactory() override;

--- a/shell/browser/serial/serial_chooser_context_factory.cc
+++ b/shell/browser/serial/serial_chooser_context_factory.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/serial/serial_chooser_context_factory.h"
 
+#include "base/no_destructor.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
 #include "shell/browser/electron_browser_context.h"
 #include "shell/browser/serial/serial_chooser_context.h"
@@ -26,7 +27,8 @@ KeyedService* SerialChooserContextFactory::BuildServiceInstanceFor(
 
 // static
 SerialChooserContextFactory* SerialChooserContextFactory::GetInstance() {
-  return base::Singleton<SerialChooserContextFactory>::get();
+  static base::NoDestructor<SerialChooserContextFactory> instance;
+  return instance.get();
 }
 
 // static

--- a/shell/browser/serial/serial_chooser_context_factory.h
+++ b/shell/browser/serial/serial_chooser_context_factory.h
@@ -5,9 +5,13 @@
 #ifndef ELECTRON_SHELL_BROWSER_SERIAL_SERIAL_CHOOSER_CONTEXT_FACTORY_H_
 #define ELECTRON_SHELL_BROWSER_SERIAL_SERIAL_CHOOSER_CONTEXT_FACTORY_H_
 
-#include "base/memory/singleton.h"
 #include "components/keyed_service/content/browser_context_keyed_service_factory.h"
 #include "shell/browser/serial/serial_chooser_context.h"
+
+namespace base {
+template <typename T>
+class NoDestructor;
+}  // namespace base
 
 namespace electron {
 
@@ -20,7 +24,7 @@ class SerialChooserContextFactory : public BrowserContextKeyedServiceFactory {
   static SerialChooserContextFactory* GetInstance();
 
  private:
-  friend struct base::DefaultSingletonTraits<SerialChooserContextFactory>;
+  friend base::NoDestructor<SerialChooserContextFactory>;
 
   SerialChooserContextFactory();
   ~SerialChooserContextFactory() override;

--- a/shell/browser/usb/usb_chooser_context_factory.cc
+++ b/shell/browser/usb/usb_chooser_context_factory.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/usb/usb_chooser_context_factory.h"
 
+#include "base/no_destructor.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
 #include "shell/browser/electron_browser_context.h"
 #include "shell/browser/usb/usb_chooser_context.h"
@@ -26,7 +27,8 @@ KeyedService* UsbChooserContextFactory::BuildServiceInstanceFor(
 
 // static
 UsbChooserContextFactory* UsbChooserContextFactory::GetInstance() {
-  return base::Singleton<UsbChooserContextFactory>::get();
+  static base::NoDestructor<UsbChooserContextFactory> instance;
+  return instance.get();
 }
 
 // static

--- a/shell/browser/usb/usb_chooser_context_factory.h
+++ b/shell/browser/usb/usb_chooser_context_factory.h
@@ -5,8 +5,12 @@
 #ifndef ELECTRON_SHELL_BROWSER_USB_USB_CHOOSER_CONTEXT_FACTORY_H_
 #define ELECTRON_SHELL_BROWSER_USB_USB_CHOOSER_CONTEXT_FACTORY_H_
 
-#include "base/memory/singleton.h"
 #include "components/keyed_service/content/browser_context_keyed_service_factory.h"
+
+namespace base {
+template <typename T>
+class NoDestructor;
+}  // namespace base
 
 namespace electron {
 
@@ -24,7 +28,7 @@ class UsbChooserContextFactory : public BrowserContextKeyedServiceFactory {
   UsbChooserContextFactory& operator=(const UsbChooserContextFactory&) = delete;
 
  private:
-  friend struct base::DefaultSingletonTraits<UsbChooserContextFactory>;
+  friend base::NoDestructor<UsbChooserContextFactory>;
 
   UsbChooserContextFactory();
   ~UsbChooserContextFactory() override;


### PR DESCRIPTION
#### Description of Change

Ref https://issues.chromium.org/issues/40611103.

Seen while starting to work on https://github.com/electron/electron/issues/28422 - incidental cleanup.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none