### PR TITLE
build: fixup codespaces on-create

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,8 @@
 			]
 		},
 		"vscode": {
-			"extensions": ["joeleinbinder.mojom-language",
+			"extensions": [
+				"joeleinbinder.mojom-language",
 				"rafaelmaiolla.diff",
 				"surajbarkale.ninja",
 				"ms-vscode.cpptools",

--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -39,7 +39,6 @@ if [ ! -f $buildtools/configs/evm.testing.json ]; then
   write_config() {
     echo "
         {
-            \"goma\": \"$1\",
             \"root\": \"/workspaces/gclient\",
             \"remotes\": {
                 \"electron\": {
@@ -49,7 +48,7 @@ if [ ! -f $buildtools/configs/evm.testing.json ]; then
             \"gen\": {
                 \"args\": [
                     \"import(\\\"//electron/build/args/testing.gn\\\")\",
-                    \"import(\\\"/home/builduser/.electron_build_tools/third_party/goma.gn\\\")\"
+                    \"use_remoteexec = true\"
                 ],
                 \"out\": \"Testing\"
             },
@@ -57,26 +56,18 @@ if [ ! -f $buildtools/configs/evm.testing.json ]; then
                 \"CHROMIUM_BUILDTOOLS_PATH\": \"/workspaces/gclient/src/buildtools\",
                 \"GIT_CACHE_PATH\": \"/workspaces/gclient/.git-cache\"
             },
-            \"\$schema\": \"file:///home/builduser/.electron_build_tools/evm-config.schema.json\"
+            \"\$schema\": \"file:///home/builduser/.electron_build_tools/evm-config.schema.json\",
+            \"configValidationLevel\": \"strict\",
+            \"reclient\": \"$1\",
+            \"goma\": \"none\",
+            \"preserveXcode\": 5
         }
     " >$buildtools/configs/evm.testing.json
   }
 
-  # Start out as cache only
-  write_config cache-only
+  write_config remote_exec
 
-  e use testing
-
-  # Attempt to auth to the goma service via codespaces tokens
-  # if it works we can use the goma cluster
-  export NOTGOMA_CODESPACES_TOKEN=$GITHUB_TOKEN
-  if e d goma_auth login; then
-    echo "$GITHUB_USER has GOMA access - switching to cluster mode"
-    write_config cluster
-  fi
+  e use testing 
 else
   echo "build-tools testing config already exists"
-
-  # Re-auth with the goma cluster regardless.
-  NOTGOMA_CODESPACES_TOKEN=$GITHUB_TOKEN e d goma_auth login || true
 fi


### PR DESCRIPTION
#### Description of Change

Update Codespaces creation command logic to use RBE instead of Goma.

At the moment, you'll still need to monitor the creation process and watch for the output of `e d rbe login` so that you can login and use the service:

```
Please visit https://auth.notgoma.com/rbe/8d716b0723ad1ed73a6d6388e5cbb66e6dfeea2b2810f1765c52ec1354a57d80 to obtain RBE authentication...

Authentication Status: Authenticated
Since:     2024-02-23 16:21:04 +0100 CET
Expires:   2024-05-23 17:21:04 +0200 CEST
Cluster:   rbe.notgoma.com
Principal: github/codebytere
Access:    Cache & Execute
```

However, even if it times out the fallback is to use `--no-remote` so the codespace shouldn't fail.

Confirmed success:

```console
Outcome: success User: builduser WorkspaceFolder: /workspaces/gclient/src/electron
devcontainer process exited with exit code 0
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.
