### PR TITLE
chore: fix import from patches.py in script/lib/git.py

### DIFF
--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -13,7 +13,10 @@ import re
 import subprocess
 import sys
 
-from .patches import PATCH_FILENAME_PREFIX, is_patch_location_line
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(SCRIPT_DIR)
+
+from patches import PATCH_FILENAME_PREFIX, is_patch_location_line
 
 UPSTREAM_HEAD='refs/patches/upstream-head'
 


### PR DESCRIPTION
We are getting this error in our internal builds
```
Traceback (most recent call last):
  File "/Volumes/Builds/work/electron-28/src/microsoft/scripts/import_patches.py", line 20, in <module>
    import git  # pylint: disable=wrong-import-position
    ^^^^^^^^^^
  File "/Volumes/Builds/work/electron-28/src/electron/script/lib/git.py", line 18, in <module>
    from .patches import PATCH_FILENAME_PREFIX, is_patch_location_line
ImportError: attempted relative import with no known parent package
```

our script does this
```python
SCRIPTS_LIB_DIR = os.path.join(ELECTRON_DIR, 'script', 'lib')
sys.path.append(SCRIPTS_LIB_DIR)

import git
from patches import patch_from_dir
```

Notes: none