### PR TITLE
build: print error and retry on symstore fail

### DIFF
--- a/script/release/uploaders/upload-symbols.py
+++ b/script/release/uploaders/upload-symbols.py
@@ -80,8 +80,14 @@ def main():
 
 
 def run_symstore(pdb, dest, product):
-  execute(['symstore', 'add', '/r', '/f', pdb, '/s', dest, '/t', product])
-
+  for attempt in range(2):
+    try:
+      execute(['symstore', 'add', '/r', '/f', pdb, '/s', dest, '/t', product])
+      break
+    except Exception as e:
+      print(f"An error occurred while adding '{pdb}' to SymStore: {str(e)}")
+      if attempt == 0:
+        print("Retrying...")
 
 def upload_symbols(files):
   store_artifact(SYMBOLS_DIR, 'symbols',


### PR DESCRIPTION
#### Description of Change

Improvement attempt to address recent failures like [this](https://ci.appveyor.com/project/electron-bot/electron-woa-release/build/1.0.2766/job/l44f5qklp1sm2230).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none