### PR TITLE
ci: add logging to uploading to GitHub releases

### DIFF
--- a/script/release/uploaders/upload-to-github.ts
+++ b/script/release/uploaders/upload-to-github.ts
@@ -27,7 +27,9 @@ const getHeaders = (filePath: string, fileName: string) => {
   if (!extension) {
     throw new Error(`Failed to get headers for extensionless file: ${fileName}`);
   }
+  console.log(`About to get size of ${filePath}`);
   const size = fs.statSync(filePath).size;
+  console.log(`Got size of ${filePath}: ${size}`);
   const options: Record<string, string> = {
     json: 'text/json',
     zip: 'application/zip',
@@ -46,10 +48,13 @@ const uploadUrl = `https://uploads.github.com/repos/electron/${targetRepo}/relea
 let retry = 0;
 
 function uploadToGitHub () {
+  console.log(`in uploadToGitHub for ${filePath}, ${fileName}`);
+  const fileData = fs.createReadStream(filePath);
+  console.log(`in uploadToGitHub, created readstream for ${filePath}`);
   octokit.repos.uploadReleaseAsset({
     url: uploadUrl,
     headers: getHeaders(filePath, fileName),
-    data: fs.createReadStream(filePath) as any,
+    data: fileData as any,
     name: fileName,
     owner: 'electron',
     repo: targetRepo,

--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -362,10 +362,13 @@ def upload_io_to_github(release, filename, filepath, version):
       (filename))
   script_path = os.path.join(
     ELECTRON_DIR, 'script', 'release', 'uploaders', 'upload-to-github.ts')
-  upload_gh_output = execute([TS_NODE, script_path, filepath, filename, 
-          str(release['id']), version])
+  upload_process = subprocess.Popen([TS_NODE, script_path, filepath, filename, 
+          str(release['id']), version], stdout=subprocess.PIPE, 
+          stderr=subprocess.STDOUT)
   if is_verbose_mode():
-    print(upload_gh_output)
+    for c in iter(lambda: upload_process.stdout.read(1), b""):
+      sys.stdout.buffer.write(c)
+      sys.stdout.flush()
 
 
 def upload_sha256_checksum(version, file_path, key_prefix=None):


### PR DESCRIPTION
#### Description of Change
We continue to see timeout errors when uploading to GitHub for releases, eg https://app.circleci.com/pipelines/github/electron/electron/78872/workflows/7322ac80-17f0-494f-98b4-d4c093653b18/jobs/1679041.

This PR adds additional logging to the script that uploads to GitHub.  Additionally the python script that calls that script has been changed to stream the logging instead of waiting until the script is done.  Hopefully this will provide enough additional context to diagnose the timeout issue.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
