### PR TITLE
fix: webContents.print options should be optional

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -263,12 +263,10 @@ WebContents.prototype.printToPDF = async function (options) {
 
 // TODO(codebytere): deduplicate argument sanitization by moving rest of
 // print param logic into new file shared between printToPDF and print
-WebContents.prototype.print = function (options: ElectronInternal.WebContentsPrintOptions, callback) {
-  if (typeof options !== 'object') {
+WebContents.prototype.print = function (options: ElectronInternal.WebContentsPrintOptions = {}, callback) {
+  if (typeof options !== 'object' || options == null) {
     throw new TypeError('webContents.print(): Invalid print settings specified.');
   }
-
-  const printSettings: Record<string, any> = { ...options };
 
   const pageSize = options.pageSize ?? 'A4';
   if (typeof pageSize === 'object') {
@@ -283,7 +281,7 @@ WebContents.prototype.print = function (options: ElectronInternal.WebContentsPri
       throw new RangeError('height and width properties must be minimum 352 microns.');
     }
 
-    printSettings.mediaSize = {
+    options.mediaSize = {
       name: 'CUSTOM',
       custom_display_name: 'Custom',
       height_microns: height,
@@ -295,7 +293,7 @@ WebContents.prototype.print = function (options: ElectronInternal.WebContentsPri
     };
   } else if (typeof pageSize === 'string' && PDFPageSizes[pageSize]) {
     const mediaSize = PDFPageSizes[pageSize];
-    printSettings.mediaSize = {
+    options.mediaSize = {
       ...mediaSize,
       imageable_area_left_microns: 0,
       imageable_area_bottom_microns: 0,
@@ -308,9 +306,9 @@ WebContents.prototype.print = function (options: ElectronInternal.WebContentsPri
 
   if (this._print) {
     if (callback) {
-      this._print(printSettings, callback);
+      this._print(options, callback);
     } else {
-      this._print(printSettings);
+      this._print(options);
     }
   } else {
     console.error('Error: Printing feature is disabled.');

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -187,10 +187,31 @@ describe('webContents module', () => {
 
     afterEach(closeAllWindows);
 
+    it('does not throw when options are not passed', () => {
+      expect(() => {
+        w.webContents.print();
+      }).not.to.throw();
+
+      expect(() => {
+        w.webContents.print(undefined);
+      }).not.to.throw();
+    });
+
+    it('does not throw when options object is empty', () => {
+      expect(() => {
+        w.webContents.print({});
+      }).not.to.throw();
+    });
+
     it('throws when invalid settings are passed', () => {
       expect(() => {
         // @ts-ignore this line is intentionally incorrect
         w.webContents.print(true);
+      }).to.throw('webContents.print(): Invalid print settings specified.');
+
+      expect(() => {
+        // @ts-ignore this line is intentionally incorrect
+        w.webContents.print(null);
       }).to.throw('webContents.print(): Invalid print settings specified.');
     });
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/41464.

Fixes an issue where `webContents.print(options)` failed if `options` was not passed or `undefined` is passed. This fixes that issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where `webContents.print(options)` failed if `options` was not passed or `undefined` is passed.