### PR TITLE
ci: verified commits for appveyor update PR

### DIFF
--- a/.github/workflows/update_appveyor_image.yml
+++ b/.github/workflows/update_appveyor_image.yml
@@ -6,22 +6,23 @@ on:
   schedule:
     - cron: '0 8 * * 1-5' # runs 8:00 every business day (see https://crontab.guru)
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   bake-appveyor-image:
     name: Bake AppVeyor Image
-    permissions:
-      contents: write
-      pull-requests: write  # to create a new PR with updated Appveyor images
     runs-on: ubuntu-latest
     steps:
+    - name: Generate GitHub App token
+      uses: electron/github-app-auth-action@384fd19694fe7b6dcc9a684746c6976ad78228ae # v1.1.1
+      id: generate-token
+      with:
+        creds: ${{ secrets.APPVEYOR_UPDATER_GH_APP_CREDS }}
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         fetch-depth: 0
+        token: ${{ steps.generate-token.outputs.token }}
     - name: Yarn install
       run: |
         node script/yarn.js install --frozen-lockfile
@@ -49,26 +50,24 @@ jobs:
         diff -w -B appveyor.yml appveyor2.yml > appveyor.diff || true
         patch -f appveyor.yml < appveyor.diff
         rm appveyor2.yml appveyor.diff
+        git add appveyor.yml
     - name: (Optionally) Generate Commit Diff for WOA
       if: ${{ env.APPVEYOR_IMAGE_VERSION }}
       run: |
         diff -w -B appveyor-woa.yml appveyor-woa2.yml > appveyor-woa.diff || true
         patch -f appveyor-woa.yml < appveyor-woa.diff
         rm appveyor-woa2.yml appveyor-woa.diff
-    - name: (Optionally) Commit and Pull Request
+        git add appveyor-woa.yml
+    - name: (Optionally) Commit to Branch
       if: ${{ env.APPVEYOR_IMAGE_VERSION }}
-      uses: peter-evans/create-pull-request@b1ddad2c994a25fbc81a28b3ec0e368bb2021c50 # v6.0.0
+      uses: dsanders11/github-app-commit-action@1dd0a2d22c564461d3f598b6858856e8842d7a16 # v1.1.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: 'build: update appveyor image to latest version'
-        committer: GitHub <noreply@github.com>
-        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-        signoff: false
-        branch: bump-appveyor-image
-        delete-branch: true
-        reviewers: electron/wg-releases
-        title: 'build: update appveyor image to latest version'
-        labels: semver/none,no-backport
-        body: |
-          This PR updates appveyor.yml to the latest baked image, ${{ env.APPVEYOR_IMAGE_VERSION }}.
-          Notes: none
+        message: 'build: update appveyor image to latest version'
+        ref: bump-appveyor-image
+        token: ${{ steps.generate-token.outputs.token }}
+    - name: (Optionally) Create Pull Request
+      if: ${{ env.APPVEYOR_IMAGE_VERSION }}
+      run: |
+        printf "This PR updates appveyor.yml to the latest baked image, ${{ env.APPVEYOR_IMAGE_VERSION }}.\n\nNotes: none" | gh pr create --head bump-appveyor-image --reviewer electron/wg-releases --label no-backport --label semver/none --title 'build: update appveyor image to latest version' --body-file=-
+      env:
+        GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Make the commit for the update AppVeyor image workflow using `dsanders11/github-app-commit-action`, which will result in verified commits since it uses the GitHub API. This change drops the usage of `peter-evans/create-pull-request` as it was not playing nicely with the other changes, and the `gh` CLI has all the functionality we need for creating the PR (with the exception of the `delete-branch` feature, but that should happen on PR merge anyway).

It uses a dedicated GitHub app we created for the purpose as `github-actions[bot]` has several limitations, like not triggering other workflows and not being able to create PRs with `gh` CLI.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
