### PR TITLE
fix: `chrome://process-internals` failing to load

### DIFF
--- a/electron_paks.gni
+++ b/electron_paks.gni
@@ -77,6 +77,7 @@ template("electron_extra_paks") {
       "//content:content_resources",
       "//content/browser/resources/gpu:resources",
       "//content/browser/resources/media:resources",
+      "//content/browser/resources/process:resources",
       "//content/browser/tracing:resources",
       "//content/browser/webrtc/resources",
       "//electron:resources",
@@ -96,6 +97,7 @@ template("electron_extra_paks") {
     # New paks should be added here by default.
     sources += [
       "$root_gen_dir/content/browser/devtools/devtools_resources.pak",
+      "$root_gen_dir/content/process_resources.pak",
       "$root_gen_dir/ui/resources/webui_resources.pak",
     ]
     deps += [ "//content/browser/devtools:devtools_resources" ]

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -2113,7 +2113,8 @@ describe('chromium features', () => {
       'chrome://gpu',
       'chrome://media-internals',
       'chrome://tracing',
-      'chrome://webrtc-internals'
+      'chrome://webrtc-internals',
+      'chrome://process-internals'
     ];
 
     for (const url of urls) {
@@ -2121,8 +2122,9 @@ describe('chromium features', () => {
         it('loads the page successfully', async () => {
           const w = new BrowserWindow({ show: false });
           await w.loadURL(url);
+          const host = url.substring('chrome://'.length);
           const pageExists = await w.webContents.executeJavaScript(
-            "window.hasOwnProperty('chrome') && window.chrome.hasOwnProperty('send')"
+            `window.hasOwnProperty('chrome') && window.location.host === '${host}'`
           );
           expect(pageExists).to.be.true();
         });


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/41459.
Refs CL:4472030

Broke in https://github.com/electron/electron/pull/38033 as a result of the above CL. Updates our `pak` file to handle changes and allow `chrome://process-internals` to load again.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `chrome://process-internals` failing to load.
