### PR TITLE
chore: set wg-releases as CODEOWNER for AppVeyor configs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,9 @@ DEPS                                    @electron/wg-upgrades
 /docs/breaking-changes.md               @electron/wg-releases
 /npm/                                   @electron/wg-releases
 /script/release                         @electron/wg-releases
+appveyor.yml                            @electron/wg-releases
+appveyor-bake.yml                       @electron/wg-releases
+appveyor-woa.yml                        @electron/wg-releases
 
 # Security WG
 /lib/browser/devtools.ts                @electron/wg-security

--- a/.github/workflows/update_appveyor_image.yml
+++ b/.github/workflows/update_appveyor_image.yml
@@ -68,6 +68,6 @@ jobs:
     - name: (Optionally) Create Pull Request
       if: ${{ env.APPVEYOR_IMAGE_VERSION }}
       run: |
-        printf "This PR updates appveyor.yml to the latest baked image, ${{ env.APPVEYOR_IMAGE_VERSION }}.\n\nNotes: none" | gh pr create --head bump-appveyor-image --reviewer electron/wg-releases --label no-backport --label semver/none --title 'build: update appveyor image to latest version' --body-file=-
+        printf "This PR updates appveyor.yml to the latest baked image, ${{ env.APPVEYOR_IMAGE_VERSION }}.\n\nNotes: none" | gh pr create --head bump-appveyor-image --label no-backport --label semver/none --title 'build: update appveyor image to latest version' --body-file=-
       env:
         GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Follow-up to #41470, [which couldn't open a PR when run](https://github.com/electron/electron/actions/runs/8098946962/job/22133568640) due to the reviewer team not being found. Looks like this is because the bot would need perms to read the org teams. Rather than give the bot additional permissions, it seems more reasonable to simply mark those files as owned by the team in `CODEOWNERS`, which should accomplish the same thing.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
