### PR TITLE
fix: `utilityProcess.postMessage` crash with invalid transferrable

### DIFF
--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -53,6 +53,25 @@ GetAllUtilityProcessWrappers() {
   return *s_all_utility_process_wrappers;
 }
 
+namespace {
+
+bool IsValidWrappable(const v8::Local<v8::Value>& obj) {
+  v8::Local<v8::Object> port = v8::Local<v8::Object>::Cast(obj);
+
+  if (!port->IsObject())
+    return false;
+
+  if (port->InternalFieldCount() != gin::kNumberOfInternalFields)
+    return false;
+
+  const auto* info = static_cast<gin::WrapperInfo*>(
+      port->GetAlignedPointerFromInternalField(gin::kWrapperInfoIndex));
+
+  return info && info->embedder == gin::kEmbedderNativeGin;
+}
+
+}  // namespace
+
 namespace api {
 
 gin::WrapperInfo UtilityProcessWrapper::kWrapperInfo = {
@@ -293,28 +312,46 @@ void UtilityProcessWrapper::PostMessage(gin::Arguments* args) {
     return;
 
   blink::TransferableMessage transferable_message;
+
+  auto* isolate = args->isolate();
+  gin_helper::ErrorThrower thrower(isolate);
+
+  // |message| is any value that can be serialized to StructuredClone.
   v8::Local<v8::Value> message_value;
-  if (args->GetNext(&message_value)) {
-    if (!electron::SerializeV8Value(args->isolate(), message_value,
-                                    &transferable_message)) {
-      // SerializeV8Value sets an exception.
-      return;
-    }
+  args->GetNext(&message_value);
+
+  if (!electron::SerializeV8Value(isolate, message_value,
+                                  &transferable_message)) {
+    // SerializeV8Value sets an exception.
+    return;
   }
 
   v8::Local<v8::Value> transferables;
   std::vector<gin::Handle<MessagePort>> wrapped_ports;
   if (args->GetNext(&transferables)) {
-    if (!gin::ConvertFromV8(args->isolate(), transferables, &wrapped_ports)) {
-      gin_helper::ErrorThrower(args->isolate())
-          .ThrowTypeError("Invalid value for transfer");
+    std::vector<v8::Local<v8::Value>> wrapped_port_values;
+    if (!gin::ConvertFromV8(isolate, transferables, &wrapped_port_values)) {
+      thrower.ThrowTypeError("transferables must be an array of MessagePorts");
+      return;
+    }
+
+    for (unsigned i = 0; i < wrapped_port_values.size(); ++i) {
+      if (!IsValidWrappable(wrapped_port_values[i])) {
+        thrower.ThrowTypeError("Port at index " + base::NumberToString(i) +
+                               " is not a valid port");
+        return;
+      }
+    }
+
+    if (!gin::ConvertFromV8(isolate, transferables, &wrapped_ports)) {
+      thrower.ThrowTypeError("Passed an invalid MessagePort");
       return;
     }
   }
 
   bool threw_exception = false;
-  transferable_message.ports = MessagePort::DisentanglePorts(
-      args->isolate(), wrapped_ports, &threw_exception);
+  transferable_message.ports =
+      MessagePort::DisentanglePorts(isolate, wrapped_ports, &threw_exception);
   if (threw_exception)
     return;
 

--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -53,25 +53,6 @@ GetAllUtilityProcessWrappers() {
   return *s_all_utility_process_wrappers;
 }
 
-namespace {
-
-bool IsValidWrappable(const v8::Local<v8::Value>& obj) {
-  v8::Local<v8::Object> port = v8::Local<v8::Object>::Cast(obj);
-
-  if (!port->IsObject())
-    return false;
-
-  if (port->InternalFieldCount() != gin::kNumberOfInternalFields)
-    return false;
-
-  const auto* info = static_cast<gin::WrapperInfo*>(
-      port->GetAlignedPointerFromInternalField(gin::kWrapperInfoIndex));
-
-  return info && info->embedder == gin::kEmbedderNativeGin;
-}
-
-}  // namespace
-
 namespace api {
 
 gin::WrapperInfo UtilityProcessWrapper::kWrapperInfo = {
@@ -313,45 +294,45 @@ void UtilityProcessWrapper::PostMessage(gin::Arguments* args) {
 
   blink::TransferableMessage transferable_message;
 
-  auto* isolate = args->isolate();
-  gin_helper::ErrorThrower thrower(isolate);
+  gin_helper::ErrorThrower thrower(args->isolate());
 
   // |message| is any value that can be serialized to StructuredClone.
   v8::Local<v8::Value> message_value;
-  args->GetNext(&message_value);
-
-  if (!electron::SerializeV8Value(isolate, message_value,
-                                  &transferable_message)) {
-    // SerializeV8Value sets an exception.
-    return;
+  if (args->GetNext(&message_value)) {
+    if (!electron::SerializeV8Value(args->isolate(), message_value,
+                                    &transferable_message)) {
+      // SerializeV8Value sets an exception.
+      return;
+    }
   }
 
   v8::Local<v8::Value> transferables;
   std::vector<gin::Handle<MessagePort>> wrapped_ports;
   if (args->GetNext(&transferables)) {
     std::vector<v8::Local<v8::Value>> wrapped_port_values;
-    if (!gin::ConvertFromV8(isolate, transferables, &wrapped_port_values)) {
+    if (!gin::ConvertFromV8(args->isolate(), transferables,
+                            &wrapped_port_values)) {
       thrower.ThrowTypeError("transferables must be an array of MessagePorts");
       return;
     }
 
     for (unsigned i = 0; i < wrapped_port_values.size(); ++i) {
-      if (!IsValidWrappable(wrapped_port_values[i])) {
+      if (!gin_helper::IsValidWrappable(wrapped_port_values[i])) {
         thrower.ThrowTypeError("Port at index " + base::NumberToString(i) +
                                " is not a valid port");
         return;
       }
     }
 
-    if (!gin::ConvertFromV8(isolate, transferables, &wrapped_ports)) {
+    if (!gin::ConvertFromV8(args->isolate(), transferables, &wrapped_ports)) {
       thrower.ThrowTypeError("Passed an invalid MessagePort");
       return;
     }
   }
 
   bool threw_exception = false;
-  transferable_message.ports =
-      MessagePort::DisentanglePorts(isolate, wrapped_ports, &threw_exception);
+  transferable_message.ports = MessagePort::DisentanglePorts(
+      args->isolate(), wrapped_ports, &threw_exception);
   if (threw_exception)
     return;
 

--- a/shell/common/gin_helper/wrappable.cc
+++ b/shell/common/gin_helper/wrappable.cc
@@ -9,6 +9,21 @@
 
 namespace gin_helper {
 
+bool IsValidWrappable(const v8::Local<v8::Value>& obj) {
+  v8::Local<v8::Object> port = v8::Local<v8::Object>::Cast(obj);
+
+  if (!port->IsObject())
+    return false;
+
+  if (port->InternalFieldCount() != gin::kNumberOfInternalFields)
+    return false;
+
+  const auto* info = static_cast<gin::WrapperInfo*>(
+      port->GetAlignedPointerFromInternalField(gin::kWrapperInfoIndex));
+
+  return info && info->embedder == gin::kEmbedderNativeGin;
+}
+
 WrappableBase::WrappableBase() = default;
 
 WrappableBase::~WrappableBase() {

--- a/shell/common/gin_helper/wrappable.h
+++ b/shell/common/gin_helper/wrappable.h
@@ -11,6 +11,11 @@
 
 namespace gin_helper {
 
+// WrapperInfo logic upstream doesn't take into account that an object
+// might have the correct number of internal fields but not be a WrappableBase.
+// We tried to upstream this, but were told to handle it on the embedder side.
+bool IsValidWrappable(const v8::Local<v8::Value>& obj);
+
 namespace internal {
 
 void* FromV8Impl(v8::Isolate* isolate, v8::Local<v8::Value> val);

--- a/spec/api-ipc-spec.ts
+++ b/spec/api-ipc-spec.ts
@@ -425,6 +425,20 @@ describe('ipc module', () => {
         expect(port2).not.to.be.null();
       });
 
+      it('should not throw when supported values are passed as message', () => {
+        const { port1 } = new MessageChannelMain();
+
+        // @ts-expect-error - this shouldn't crash.
+        expect(() => { port1.postMessage(); }).to.not.throw();
+
+        expect(() => { port1.postMessage(undefined); }).to.not.throw();
+        expect(() => { port1.postMessage(42); }).to.not.throw();
+        expect(() => { port1.postMessage(false); }).to.not.throw();
+        expect(() => { port1.postMessage([]); }).to.not.throw();
+        expect(() => { port1.postMessage('hello'); }).to.not.throw();
+        expect(() => { port1.postMessage({ hello: 'goodbye' }); }).to.not.throw();
+      });
+
       it('throws an error when an invalid parameter is sent to postMessage', () => {
         const { port1 } = new MessageChannelMain();
 

--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -284,6 +284,20 @@ describe('utilityProcess module', () => {
       await exit;
     });
 
+    it('throws when an invalid transferrable is passed', () => {
+      const child = utilityProcess.fork(path.join(fixturesPath, 'post-message.js'));
+      expect(() => {
+        // @ts-expect-error
+        const buffer = new ArrayBuffer();
+        child.postMessage('Hello', [buffer as any]);
+      }).to.throw(/Port at index 0 is not a valid port/);
+
+      expect(() => {
+        // @ts-expect-error
+        child.postMessage('hey', [false]);
+      }).to.throw(/Port at index 0 is not a valid port/);
+    });
+
     it('supports queuing messages on the receiving end', async () => {
       const child = utilityProcess.fork(path.join(fixturesPath, 'post-message-queue.js'));
       const p = once(child, 'spawn');

--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -284,6 +284,20 @@ describe('utilityProcess module', () => {
       await exit;
     });
 
+    it('does not throw when supported values are passed', () => {
+      const child = utilityProcess.fork(path.join(fixturesPath, 'post-message.js'));
+
+      // @ts-expect-error - this shouldn't crash.
+      expect(() => { child.postMessage(); }).to.not.throw();
+
+      expect(() => { child.postMessage(undefined); }).to.not.throw();
+      expect(() => { child.postMessage(42); }).to.not.throw();
+      expect(() => { child.postMessage(false); }).to.not.throw();
+      expect(() => { child.postMessage([]); }).to.not.throw();
+      expect(() => { child.postMessage('hello'); }).to.not.throw();
+      expect(() => { child.postMessage({ hello: 'goodbye' }); }).to.not.throw();
+    });
+
     it('throws when an invalid transferrable is passed', () => {
       const child = utilityProcess.fork(path.join(fixturesPath, 'post-message.js'));
       expect(() => {


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/37585

Fixes a potential crash in `utilityProcess.postMessage` when calling with an invalid transferable. From the original PR:

> When passing an (unsupported) ArrayBuffer, for example, this happened because we try to unwrap everything in the transferrables list and upstream's [WrapperInfo ](https://source.chromium.org/chromium/chromium/src/+/main:gin/wrapper_info.cc;l=10-16;drc=0e9a0b6e9bb6ec59521977eec805f5d0bca833e0) logic doesn't take into account that an object might have the correct number of internal fields but not be a WrappableBase.

This applies here as well.

This PR also removes a check in `message_port.cc` for at least one argument being passed. The type of `message` is `any` per spec, and thus null or undefined is acceptable. As it was, if null or undefined were passed the error wouldn't be thrown regardless, as those values can be converted to `v8::Value`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes a potential crash in `utilityProcess.postMessage` when calling with an invalid transferable. 