### PR TITLE
fix: `user-did-{resign|become}-active` events on macOS

### DIFF
--- a/shell/browser/api/electron_api_power_monitor_mac.mm
+++ b/shell/browser/api/electron_api_power_monitor_mac.mm
@@ -22,41 +22,45 @@
 
 - (id)init {
   if ((self = [super init])) {
-    NSDistributedNotificationCenter* distCenter =
+    NSDistributedNotificationCenter* distributed_center =
         [NSDistributedNotificationCenter defaultCenter];
     // A notification that the screen was locked.
-    [distCenter addObserver:self
-                   selector:@selector(onScreenLocked:)
-                       name:@"com.apple.screenIsLocked"
-                     object:nil];
+    [distributed_center addObserver:self
+                           selector:@selector(onScreenLocked:)
+                               name:@"com.apple.screenIsLocked"
+                             object:nil];
     // A notification that the screen was unlocked by the user.
-    [distCenter addObserver:self
-                   selector:@selector(onScreenUnlocked:)
-                       name:@"com.apple.screenIsUnlocked"
-                     object:nil];
+    [distributed_center addObserver:self
+                           selector:@selector(onScreenUnlocked:)
+                               name:@"com.apple.screenIsUnlocked"
+                             object:nil];
     // A notification that the workspace posts before the machine goes to sleep.
-    [distCenter addObserver:self
-                   selector:@selector(isSuspending:)
-                       name:NSWorkspaceWillSleepNotification
-                     object:nil];
+    [distributed_center addObserver:self
+                           selector:@selector(isSuspending:)
+                               name:NSWorkspaceWillSleepNotification
+                             object:nil];
     // A notification that the workspace posts when the machine wakes from
     // sleep.
-    [distCenter addObserver:self
-                   selector:@selector(isResuming:)
-                       name:NSWorkspaceDidWakeNotification
-                     object:nil];
+    [distributed_center addObserver:self
+                           selector:@selector(isResuming:)
+                               name:NSWorkspaceDidWakeNotification
+                             object:nil];
+
+    NSNotificationCenter* shared_center =
+        [[NSWorkspace sharedWorkspace] notificationCenter];
+
     // A notification that the workspace posts when the user session becomes
     // active.
-    [distCenter addObserver:self
-                   selector:@selector(onUserDidBecomeActive:)
-                       name:NSWorkspaceSessionDidBecomeActiveNotification
-                     object:nil];
+    [shared_center addObserver:self
+                      selector:@selector(onUserDidBecomeActive:)
+                          name:NSWorkspaceSessionDidBecomeActiveNotification
+                        object:nil];
     // A notification that the workspace posts when the user session becomes
     // inactive.
-    [distCenter addObserver:self
-                   selector:@selector(onUserDidResignActive:)
-                       name:NSWorkspaceSessionDidResignActiveNotification
-                     object:nil];
+    [shared_center addObserver:self
+                      selector:@selector(onUserDidResignActive:)
+                          name:NSWorkspaceSessionDidResignActiveNotification
+                        object:nil];
   }
   return self;
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/41497.

Fixes an issue where `user-did-{resign|become}-active` were not emitted properly on macOS.

This was happening because per [docs](https://developer.apple.com/documentation/appkit/nsworkspacesessiondidresignactivenotification?language=objc) the notification object is the shared NSWorkspace instance - we need to add an observer to `[[NSWorkspace sharedWorkspace] notificationCenter]` and not `[NSDistributedNotificationCenter defaultCenter]`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `user-did-{resign|become}-active` were not emitted properly on macOS.