### PR TITLE
chore: add missing `gin::Wrappable` `GetTypeName` overrides

### DIFF
--- a/shell/browser/api/electron_api_data_pipe_holder.cc
+++ b/shell/browser/api/electron_api_data_pipe_holder.cc
@@ -162,6 +162,10 @@ v8::Local<v8::Promise> DataPipeHolder::ReadAll(v8::Isolate* isolate) {
   return handle;
 }
 
+const char* DataPipeHolder::GetTypeName() {
+  return "DataPipeHolder";
+}
+
 // static
 gin::Handle<DataPipeHolder> DataPipeHolder::Create(
     v8::Isolate* isolate,

--- a/shell/browser/api/electron_api_data_pipe_holder.h
+++ b/shell/browser/api/electron_api_data_pipe_holder.h
@@ -18,7 +18,9 @@ namespace electron::api {
 // Retains reference to the data pipe.
 class DataPipeHolder : public gin::Wrappable<DataPipeHolder> {
  public:
+  // gin::Wrappable
   static gin::WrapperInfo kWrapperInfo;
+  const char* GetTypeName() override;
 
   static gin::Handle<DataPipeHolder> Create(
       v8::Isolate* isolate,

--- a/shell/browser/api/electron_api_power_save_blocker.cc
+++ b/shell/browser/api/electron_api_power_save_blocker.cc
@@ -124,6 +124,10 @@ gin::ObjectTemplateBuilder PowerSaveBlocker::GetObjectTemplateBuilder(
       .SetMethod("isStarted", &PowerSaveBlocker::IsStarted);
 }
 
+const char* PowerSaveBlocker::GetTypeName() {
+  return "PowerSaveBlocker";
+}
+
 }  // namespace electron::api
 
 namespace {

--- a/shell/browser/api/electron_api_power_save_blocker.h
+++ b/shell/browser/api/electron_api_power_save_blocker.h
@@ -19,10 +19,10 @@ class PowerSaveBlocker : public gin::Wrappable<PowerSaveBlocker> {
   static gin::Handle<PowerSaveBlocker> Create(v8::Isolate* isolate);
 
   // gin::Wrappable
+  static gin::WrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;
-
-  static gin::WrapperInfo kWrapperInfo;
+  const char* GetTypeName() override;
 
   // disable copy
   PowerSaveBlocker(const PowerSaveBlocker&) = delete;

--- a/shell/browser/api/electron_api_web_request.h
+++ b/shell/browser/api/electron_api_web_request.h
@@ -24,8 +24,6 @@ namespace electron::api {
 
 class WebRequest : public gin::Wrappable<WebRequest>, public WebRequestAPI {
  public:
-  static gin::WrapperInfo kWrapperInfo;
-
   // Return the WebRequest object attached to |browser_context|, create if there
   // is no one.
   // Note that the lifetime of WebRequest object is managed by Session, instead
@@ -44,6 +42,7 @@ class WebRequest : public gin::Wrappable<WebRequest>, public WebRequestAPI {
                                       content::BrowserContext* browser_context);
 
   // gin::Wrappable:
+  static gin::WrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;
   const char* GetTypeName() override;

--- a/shell/browser/api/message_port.h
+++ b/shell/browser/api/message_port.h
@@ -53,9 +53,9 @@ class MessagePort : public gin::Wrappable<MessagePort>,
       bool* threw_exception);
 
   // gin::Wrappable
+  static gin::WrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;
-  static gin::WrapperInfo kWrapperInfo;
   const char* GetTypeName() override;
 
  private:

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -182,6 +182,8 @@ class JSChunkedDataPipeGetter : public gin::Wrappable<JSChunkedDataPipeGetter>,
         .SetMethod("done", &JSChunkedDataPipeGetter::Done);
   }
 
+  const char* GetTypeName() override { return "JSChunkedDataPipeGetter"; }
+
   static gin::WrapperInfo kWrapperInfo;
   ~JSChunkedDataPipeGetter() override = default;
 

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -271,6 +271,8 @@ class ChunkedDataPipeReadableStream
         .SetMethod("read", &ChunkedDataPipeReadableStream::Read);
   }
 
+  const char* GetTypeName() override { return "ChunkedDataPipeReadableStream"; }
+
   static gin::WrapperInfo kWrapperInfo;
 
  private:

--- a/shell/common/gin_helper/event.cc
+++ b/shell/common/gin_helper/event.cc
@@ -28,4 +28,8 @@ Event::~Event() = default;
 
 gin::WrapperInfo Event::kWrapperInfo = {gin::kEmbedderNativeGin};
 
+const char* Event::GetTypeName() {
+  return GetClassName();
+}
+
 }  // namespace gin_helper::internal

--- a/shell/common/gin_helper/event.h
+++ b/shell/common/gin_helper/event.h
@@ -31,6 +31,7 @@ class Event : public gin::Wrappable<Event>,
 
   // gin::Wrappable
   static gin::WrapperInfo kWrapperInfo;
+  const char* GetTypeName() override;
 
   ~Event() override;
 


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/microsoft/vscode/issues/192119#issuecomment-1842407599.

Adds missing `gin::Wrappable` `GetTypeName` overrides.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none