### PR TITLE
ci: make sure there is room to save src caches

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -1073,6 +1073,8 @@ commands:
       - run:
           name: << parameters.step-name >>
           command: |
+            # Delete caches older than 30 days
+            find /mnt/cross-instance-cache -mtime +30 -not -type d -delete
             cache_key="<< parameters.cache_key >>"
             final_cache_path=/mnt/cross-instance-cache/${cache_key}.tar
             echo "Using cache key: $cache_key"


### PR DESCRIPTION
#### Description of Change
Occasionally the storage used for src caches gets full and then the `linux-make-src-cache` job fails with an error, `No space left on device`, eg: https://app.circleci.com/pipelines/github/electron/electron/79111/workflows/8fd8b839-c684-4e4a-9bb8-2503222d76bf/jobs/1683438

This PR adds a step to clear out caches older than 30 days before attempting to save a new cache so that we make sure there is room to save a new cache.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
