### PR TITLE
fix: account for potentially swapped `FrameTreeNodeId` in `WebFrameMain`

### DIFF
--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -72,7 +72,17 @@ WebFrameMain* WebFrameMain::FromFrameTreeNodeId(int frame_tree_node_id) {
 
 // static
 WebFrameMain* WebFrameMain::FromRenderFrameHost(content::RenderFrameHost* rfh) {
-  return rfh ? FromFrameTreeNodeId(rfh->GetFrameTreeNodeId()) : nullptr;
+  if (!rfh)
+    return nullptr;
+
+  // TODO(codebytere): remove after refactoring away from FrameTreeNodeId as map
+  // key.
+  auto* ftn =
+      static_cast<content::RenderFrameHostImpl*>(rfh)->frame_tree_node();
+  if (!ftn)
+    return nullptr;
+
+  return FromFrameTreeNodeId(rfh->GetFrameTreeNodeId());
 }
 
 gin::WrapperInfo WebFrameMain::kWrapperInfo = {gin::kEmbedderNativeGin};
@@ -358,8 +368,9 @@ gin::Handle<WebFrameMain> WebFrameMain::New(v8::Isolate* isolate) {
 // static
 gin::Handle<WebFrameMain> WebFrameMain::From(v8::Isolate* isolate,
                                              content::RenderFrameHost* rfh) {
-  if (rfh == nullptr)
+  if (!rfh)
     return gin::Handle<WebFrameMain>();
+
   auto* web_frame = FromRenderFrameHost(rfh);
   if (web_frame)
     return gin::CreateHandle(isolate, web_frame);
@@ -376,12 +387,14 @@ gin::Handle<WebFrameMain> WebFrameMain::From(v8::Isolate* isolate,
 gin::Handle<WebFrameMain> WebFrameMain::FromOrNull(
     v8::Isolate* isolate,
     content::RenderFrameHost* rfh) {
-  if (rfh == nullptr)
+  if (!rfh)
     return gin::Handle<WebFrameMain>();
+
   auto* web_frame = FromRenderFrameHost(rfh);
-  if (web_frame)
-    return gin::CreateHandle(isolate, web_frame);
-  return gin::Handle<WebFrameMain>();
+  if (!web_frame)
+    return gin::Handle<WebFrameMain>();
+
+  return gin::CreateHandle(isolate, web_frame);
 }
 
 // static


### PR DESCRIPTION
#### Description of Change

Refs https://issues.chromium.org/issues/40169570
Refs https://github.com/electron/electron/pull/30076

Fixes a crash in `WebFrameMain::FromRenderFrameHost` that could occur when a given RenderFrameHost's FrameTreeNode is invalid. In https://github.com/electron/electron/pull/30076 we addressed cross-origin navigation disposing WebFrameMain instances by mapping FrameTreeNode ids to WebFrameMains. At the time, a RenderFrameHost's FrameTreeNode was constant for the lifetime of the RenderFrameHost - that's no longer the case. With prerendering and bfcache, a `RenderFrameHost` can travel from one `FrameTreeNode` to another one during prerender activation.

We should migrate our mapping logic away from 1:1 `FrameTreeNode` -> `RenderFrameHost` but this addresses it crashing in the short term.

<details><summary>Details</summary>
<p>

```
Electron Framework
content::RenderFrameHostImpl::GetFrameTreeNodeId() const frame_tree_node.h:141
Electron Framework
electron::api::WebFrameMain::FromRenderFrameHost(content::RenderFrameHost*) electron_api_web_frame_main.cc:80
Electron Framework
electron::api::WebFrameMain::From(v8::Isolate*, content::RenderFrameHost*) electron_api_web_frame_main.cc:434
Electron Framework
electron::api::WebContents::FindReply(content::WebContents*, int, int, gfx::Rect const&, int, bool, content::RenderFrameHost*) electron_api_web_contents.cc:1512
Electron Framework
content::WebContentsImpl::NotifyFindReply(int, int, gfx::Rect const&, int, bool, content::RenderFrameHost*) web_contents_impl.cc:8965
Electron Framework
content::FindRequestManager::FinalUpdateReceived(int, content::RenderFrameHost*) find_request_manager.cc:914
Electron Framework
content::FindRequestManager::HandleFinalUpdateForFrame(content::RenderFrameHostImpl*, int) find_request_manager.cc:451
Electron Framework
blink::mojom::FindInPageClientStubDispatch::Accept(blink::mojom::FindInPageClient*, mojo::Message*) find_in_page.mojom.cc:825
Electron Framework
mojo::InterfaceEndpointClient::HandleValidatedMessage(mojo::Message*) interface_endpoint_client.cc:1016
Electron Framework
mojo::MessageDispatcher::Accept(mojo::Message*) message_dispatcher.cc:43
Electron Framework
mojo::InterfaceEndpointClient::HandleIncomingMessage(mojo::Message*) interface_endpoint_client.cc:701
Electron Framework
mojo::internal::MultiplexRouter::Accept(mojo::Message*) multiplex_router.cc:1096
Electron Framework
mojo::MessageDispatcher::Accept(mojo::Message*) message_dispatcher.cc:43
Electron Framework
mojo::Connector::DispatchMessage(mojo::ScopedHandleBase<mojo::MessageHandle>) connector.cc:561
Electron Framework
base::internal::Invoker<base::internal::BindState<void (mojo::Connector::*)(char const*, unsigned int), base::internal::UnretainedWrapper<mojo::Connector, base::unretained_traits::MayNotDangle, (base::RawPtrTraits)0>, base::internal::UnretainedWrapper<char const, base::unretained_traits::MayNotDangle, (base::RawPtrTraits)0>>, void (unsigned int)>::Run(base::internal::BindStateBase*, unsigned int) connector.cc:618
Electron Framework
base::internal::Invoker<base::internal::BindState<void (*)(base::RepeatingCallback<void (unsigned int)> const&, unsigned int, mojo::HandleSignalsState const&), base::RepeatingCallback<void (unsigned int)>>, void (unsigned int, mojo::HandleSignalsState const&)>::Run(base::internal::BindStateBase*, unsigned int, mojo::HandleSignalsState const&) callback.h:333
Electron Framework
base::internal::Invoker<base::internal::BindState<void (mojo::SimpleWatcher::*)(int, unsigned int, mojo::HandleSignalsState const&), base::WeakPtr<mojo::SimpleWatcher>, int, unsigned int, mojo::HandleSignalsState>, void ()>::RunOnce(base::internal::BindStateBase*) callback.h:333
Electron Framework
base::TaskAnnotator::RunTaskImpl(base::PendingTask&) callback.h:152
Electron Framework
base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*) task_annotator.h:89
Electron Framework
non-virtual thunk to base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() thread_controller_with_message_pump_impl.cc:345
Electron Framework
invocation function for block in base::MessagePumpCFRunLoopBase::RunWorkSource(void*) message_pump_apple.mm:416
Electron Framework
invocation function for block in base::MessagePumpCFRunLoopBase::RunWorkSource(void*) message_pump_apple.mm:416
Electron Framework
base::apple::CallWithEHFrame(void () block_pointer)
CoreFoundation
0x8da8f9d8 + 514520
```

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
