### PR TITLE
test: disable CapturableScreen tests on Windows x64

### DIFF
--- a/spec/crash-spec.ts
+++ b/spec/crash-spec.ts
@@ -40,9 +40,13 @@ const shouldRunCase = (crashCase: string) => {
     case 'quit-on-crashed-event': {
       return (process.platform !== 'win32' || process.arch !== 'ia32');
     }
-    // TODO(jkleinsc) fix this test on Linux on arm/arm64
+    // TODO(jkleinsc) fix this test on Linux on arm/arm64 and 32bit windows
     case 'js-execute-iframe': {
-      return (process.platform !== 'linux' || (process.arch !== 'arm64' && process.arch !== 'arm'));
+      if (process.platform === 'win32') {
+        return process.arch !== 'ia32';
+      } else {
+        return (process.platform !== 'linux' || (process.arch !== 'arm64' && process.arch !== 'arm'));
+      }
     }
     default: {
       return true;

--- a/spec/lib/screen-helpers.ts
+++ b/spec/lib/screen-helpers.ts
@@ -171,10 +171,8 @@ export class ScreenCapture {
  * - Linux: virtual screen display is 0x0
  * - Win32 arm64 (WOA): virtual screen display is 0x0
  * - Win32 ia32: skipped
+ * - Win32 x64: virtual screen display is 0x0
  */
 export const hasCapturableScreen = () => {
-  return (
-    process.platform === 'darwin' ||
-    (process.platform === 'win32' && process.arch === 'x64')
-  );
+  return process.platform === 'darwin';
 };


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
- #41127 was merged without running Windows x64 tests: https://ci.appveyor.com/project/electron-bot/electron-x64-testing/builds/49069062/job/nys9sfsv7hgn7bw1.  It turns out that the test added in that PR does not work on Windows x64
- #41377 also was merged without running Windows x64 tests and the test added in that PR does not work on Windows x64.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
