### PR TITLE
test: re-enable `app.getGPUInfo()` specs on Linux

### DIFF
--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -1446,8 +1446,7 @@ describe('app module', () => {
     });
   });
 
-  // FIXME https://github.com/electron/electron/issues/24224
-  ifdescribe(process.platform !== 'linux')('getGPUInfo() API', () => {
+  ifdescribe(!process.env.IS_ASAN)('getGPUInfo() API', () => {
     const appPath = path.join(fixturesPath, 'api', 'gpu-info.js');
 
     const getGPUInfo = async (type: string) => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/24224.

They seem to work now except in Asan builds - re-enable them everywhere else. Better to have them partially running on Linux than not at all.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
