### PR TITLE
test: try closing windows more aggressively in transparent specs

### DIFF
--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6427,7 +6427,9 @@ describe('BrowserWindow module', () => {
   });
 
   describe('"transparent" option', () => {
-    afterEach(closeAllWindows);
+    afterEach(() => {
+      closeAllWindows({ assertNotWindows: true });
+    });
 
     ifit(process.platform !== 'linux')('correctly returns isMaximized() when the window is maximized then minimized', async () => {
       const w = new BrowserWindow({
@@ -6570,7 +6572,9 @@ describe('BrowserWindow module', () => {
   });
 
   describe('"backgroundColor" option', () => {
-    afterEach(closeAllWindows);
+    afterEach(() => {
+      closeAllWindows({ assertNotWindows: true });
+    });
 
     // Linux/WOA doesn't return any capture sources.
     ifit(process.platform === 'darwin')('should display the set color', async () => {

--- a/spec/lib/window-helpers.ts
+++ b/spec/lib/window-helpers.ts
@@ -46,8 +46,8 @@ export const closeWindow = async (
   }
 };
 
-export async function closeAllWindows () {
+export async function closeAllWindows (options = { assertNotWindows: false }) {
   for (const w of BaseWindow.getAllWindows()) {
-    await closeWindow(w, { assertNotWindows: false });
+    await closeWindow(w, options);
   }
 }


### PR DESCRIPTION
#### Description of Change

Attempt to address failures as seen in https://app.circleci.com/pipelines/github/electron/electron/79254/workflows/d1df908d-28ea-444f-80a7-05054a70cfc3/jobs/1685636/tests - looking at the artifacts shows that the failure is being caused by pollution by unclosed windows.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
