### PR TITLE
docs: backslash escape parametrized TypeScript types

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -32,7 +32,7 @@ In most cases, you should do everything in the `ready` event handler.
 Returns:
 
 * `event` Event
-* `launchInfo` Record<string, any> | [NotificationResponse](structures/notification-response.md) _macOS_
+* `launchInfo` Record\<string, any\> | [NotificationResponse](structures/notification-response.md) _macOS_
 
 Emitted once, when Electron has finished initializing. On macOS, `launchInfo`
 holds the `userInfo` of the [`NSUserNotification`](https://developer.apple.com/documentation/foundation/nsusernotification)
@@ -970,7 +970,7 @@ app.setJumpList([
 
 ### `app.requestSingleInstanceLock([additionalData])`
 
-* `additionalData` Record<any, any> (optional) - A JSON object containing additional data to send to the first instance.
+* `additionalData` Record\<any, any\> (optional) - A JSON object containing additional data to send to the first instance.
 
 Returns `boolean`
 

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -103,7 +103,7 @@ The `autoUpdater` object has the following methods:
 
 * `options` Object
   * `url` string
-  * `headers` Record<string, string> (optional) _macOS_ - HTTP request headers.
+  * `headers` Record\<string, string\> (optional) _macOS_ - HTTP request headers.
   * `serverType` string (optional) _macOS_ - Can be `json` or `default`, see the [Squirrel.Mac][squirrel-mac]
     README for more information.
 

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -656,7 +656,7 @@ Closes the currently open [Quick Look][quick-look] panel.
 
 #### `win.setBounds(bounds[, animate])`
 
-* `bounds` Partial<[Rectangle](structures/rectangle.md)>
+* `bounds` Partial\<[Rectangle](structures/rectangle.md)\>
 * `animate` boolean (optional) _macOS_
 
 Resizes and moves the window to the supplied bounds. Any properties that are not supplied will default to their current values.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -779,7 +779,7 @@ Closes the currently open [Quick Look][quick-look] panel.
 
 #### `win.setBounds(bounds[, animate])`
 
-* `bounds` Partial<[Rectangle](structures/rectangle.md)>
+* `bounds` Partial\<[Rectangle](structures/rectangle.md)\>
 * `animate` boolean (optional) _macOS_
 
 Resizes and moves the window to the supplied bounds. Any properties that are not supplied will default to their current values.
@@ -1215,7 +1215,7 @@ win.loadURL('http://localhost:8000/post', {
 
 * `filePath` string
 * `options` Object (optional)
-  * `query` Record<string, string> (optional) - Passed to `url.format()`.
+  * `query` Record\<string, string\> (optional) - Passed to `url.format()`.
   * `search` string (optional) - Passed to `url.format()`.
   * `hash` string (optional) - Passed to `url.format()`.
 

--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -158,7 +158,7 @@ Returns:
 * `statusCode` Integer
 * `method` string
 * `redirectUrl` string
-* `responseHeaders` Record<string, string[]>
+* `responseHeaders` Record\<string, string[]\>
 
 Emitted when the server returns a redirect response (e.g. 301 Moved
 Permanently). Calling [`request.followRedirect`](#requestfollowredirect) will

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -59,14 +59,14 @@ The `crashReporter` module has the following methods:
     number of crashes uploaded to 1/hour. Default is `false`.
   * `compress` boolean (optional) - If true, crash reports will be compressed
     and uploaded with `Content-Encoding: gzip`. Default is `true`.
-  * `extra` Record<string, string> (optional) - Extra string key/value
+  * `extra` Record\<string, string\> (optional) - Extra string key/value
     annotations that will be sent along with crash reports that are generated
     in the main process. Only string values are supported. Crashes generated in
     child processes will not contain these extra
     parameters to crash reports generated from child processes, call
     [`addExtraParameter`](#crashreporteraddextraparameterkey-value) from the
     child process.
-  * `globalExtra` Record<string, string> (optional) - Extra string key/value
+  * `globalExtra` Record\<string, string\> (optional) - Extra string key/value
     annotations that will be sent along with any crash reports generated in any
     process. These annotations cannot be changed once the crash reporter has
     been started. If a key is present in both the global extra parameters and

--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -72,7 +72,7 @@ Removes listeners of the specified `channel`.
 ### `ipcMain.handle(channel, listener)`
 
 * `channel` string
-* `listener` Function<Promise\<any&#62; | any&#62;
+* `listener` Function\<Promise\<any\> | any\>
   * `event` [IpcMainInvokeEvent][ipc-main-invoke-event]
   * `...args` any[]
 
@@ -109,7 +109,7 @@ provided to the renderer process. Please refer to
 ### `ipcMain.handleOnce(channel, listener)`
 
 * `channel` string
-* `listener` Function<Promise\<any&#62; | any&#62;
+* `listener` Function\<Promise\<any\> | any\>
   * `event` [IpcMainInvokeEvent][ipc-main-invoke-event]
   * `...args` any[]
 

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -111,7 +111,7 @@ expect streaming responses.
 
 * `scheme` string - scheme to handle, for example `https` or `my-app`. This is
   the bit before the `:` in a URL.
-* `handler` Function<[GlobalResponse](https://nodejs.org/api/globals.html#response) | Promise<GlobalResponse>>
+* `handler` Function\<[GlobalResponse](https://nodejs.org/api/globals.html#response) | Promise\<GlobalResponse\>\>
   * `request` [GlobalRequest](https://nodejs.org/api/globals.html#request)
 
 Register a protocol handler for `scheme`. Requests made to URLs with this

--- a/docs/api/push-notifications.md
+++ b/docs/api/push-notifications.md
@@ -27,7 +27,7 @@ The `pushNotification` module emits the following events:
 Returns:
 
 * `event` Event
-* `userInfo` Record<String, any>
+* `userInfo` Record\<String, any\>
 
 Emitted when the app receives a remote notification while running.
 See: https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428430-application?language=objc

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -1216,7 +1216,7 @@ Returns `Promise<Buffer>` - resolves with blob data.
 
 * `url` string
 * `options` Object (optional)
-  * `headers` Record<string, string> (optional) - HTTP request headers.
+  * `headers` Record\<string, string\> (optional) - HTTP request headers.
 
 Initiates a download of the resource at `url`.
 The API will generate a [DownloadItem](download-item.md) that can be accessed

--- a/docs/api/structures/file-path-with-headers.md
+++ b/docs/api/structures/file-path-with-headers.md
@@ -1,4 +1,4 @@
 # FilePathWithHeaders Object
 
 * `path` string - The path to the file to send.
-* `headers` Record<string, string> (optional) - Additional headers to be sent.
+* `headers` Record\<string, string\> (optional) - Additional headers to be sent.

--- a/docs/api/structures/notification-response.md
+++ b/docs/api/structures/notification-response.md
@@ -3,5 +3,5 @@
 * `actionIdentifier` string - The identifier string of the action that the user selected.
 * `date` number - The delivery date of the notification.
 * `identifier` string - The unique identifier for this notification request.
-* `userInfo` Record<string, any> - A dictionary of custom information associated with the notification.
+* `userInfo` Record\<string, any\> - A dictionary of custom information associated with the notification.
 * `userText` string (optional) - The text entered or chosen by the user.

--- a/docs/api/structures/protocol-request.md
+++ b/docs/api/structures/protocol-request.md
@@ -4,4 +4,4 @@
 * `referrer` string
 * `method` string
 * `uploadData` [UploadData[]](upload-data.md) (optional)
-* `headers` Record<string, string>
+* `headers` Record\<string, string\>

--- a/docs/api/structures/protocol-response.md
+++ b/docs/api/structures/protocol-response.md
@@ -10,7 +10,7 @@
   `"text/html"`. Setting `mimeType` would implicitly set the `content-type`
   header in response, but if `content-type` is already set in `headers`, the
   `mimeType` would be ignored.
-* `headers` Record<string, string | string[]> (optional) - An object containing the response headers. The
+* `headers` Record\<string, string | string[]\> (optional) - An object containing the response headers. The
   keys must be string, and values must be either string or Array of string.
 * `data` (Buffer | string | ReadableStream) (optional) - The response body. When
   returning stream as response, this is a Node.js readable stream representing

--- a/docs/api/structures/trace-config.md
+++ b/docs/api/structures/trace-config.md
@@ -19,7 +19,7 @@
   include in the trace. If not specified, trace all processes.
 * `histogram_names` string[] (optional) - a list of [histogram][] names to report
   with the trace.
-* `memory_dump_config` Record<string, any> (optional) - if the
+* `memory_dump_config` Record\<string, any\> (optional) - if the
   `disabled-by-default-memory-infra` category is enabled, this contains
   optional additional configuration for data collection. See the [Chromium
   memory-infra docs][memory-infra docs] for more information.

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -36,7 +36,7 @@ Returns `boolean` - Whether the Swipe between pages setting is on.
 ### `systemPreferences.postNotification(event, userInfo[, deliverImmediately])` _macOS_
 
 * `event` string
-* `userInfo` Record<string, any>
+* `userInfo` Record\<string, any\>
 * `deliverImmediately` boolean (optional) - `true` to post notifications immediately even when the subscribing app is inactive.
 
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
@@ -45,7 +45,7 @@ that contains the user information dictionary sent along with the notification.
 ### `systemPreferences.postLocalNotification(event, userInfo)` _macOS_
 
 * `event` string
-* `userInfo` Record<string, any>
+* `userInfo` Record\<string, any\>
 
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
 that contains the user information dictionary sent along with the notification.
@@ -53,7 +53,7 @@ that contains the user information dictionary sent along with the notification.
 ### `systemPreferences.postWorkspaceNotification(event, userInfo)` _macOS_
 
 * `event` string
-* `userInfo` Record<string, any>
+* `userInfo` Record\<string, any\>
 
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
 that contains the user information dictionary sent along with the notification.
@@ -63,7 +63,7 @@ that contains the user information dictionary sent along with the notification.
 * `event` string | null
 * `callback` Function
   * `event` string
-  * `userInfo` Record<string, unknown>
+  * `userInfo` Record\<string, unknown\>
   * `object` string
 
 Returns `number` - The ID of this subscription
@@ -92,7 +92,7 @@ If `event` is null, the `NSDistributedNotificationCenter` doesn’t use it as cr
 * `event` string | null
 * `callback` Function
   * `event` string
-  * `userInfo` Record<string, unknown>
+  * `userInfo` Record\<string, unknown\>
   * `object` string
 
 Returns `number` - The ID of this subscription
@@ -107,7 +107,7 @@ If `event` is null, the `NSNotificationCenter` doesn’t use it as criteria for 
 * `event` string | null
 * `callback` Function
   * `event` string
-  * `userInfo` Record<string, unknown>
+  * `userInfo` Record\<string, unknown\>
   * `object` string
 
 Returns `number` - The ID of this subscription
@@ -137,7 +137,7 @@ Same as `unsubscribeNotification`, but removes the subscriber from `NSWorkspace.
 
 ### `systemPreferences.registerDefaults(defaults)` _macOS_
 
-* `defaults` Record<string, string | boolean | number> - a dictionary of (`key: value`) user defaults
+* `defaults` Record\<string, string | boolean | number\> - a dictionary of (`key: value`) user defaults
 
 Add the specified defaults to your application's `NSUserDefaults`.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -237,7 +237,7 @@ See [`window.open()`](window-open.md) for more details and how to use this in co
 
 Returns:
 
-* `details` Event<>
+* `details` Event\<\>
   * `url` string - The URL the frame is navigating to.
   * `isSameDocument` boolean - This event does not fire for same document navigations using window.history api and reference fragment navigations.
     This property is always set to `false` for this event.
@@ -270,7 +270,7 @@ Calling `event.preventDefault()` will prevent the navigation.
 
 Returns:
 
-* `details` Event<>
+* `details` Event\<\>
   * `url` string - The URL the frame is navigating to.
   * `isSameDocument` boolean - This event does not fire for same document navigations using window.history api and reference fragment navigations.
     This property is always set to `false` for this event.
@@ -300,7 +300,7 @@ Calling `event.preventDefault()` will prevent the navigation.
 
 Returns:
 
-* `details` Event<>
+* `details` Event\<\>
   * `url` string - The URL the frame is navigating to.
   * `isSameDocument` boolean - Whether the navigation happened without changing
     document. Examples of same document navigations are reference fragment
@@ -324,7 +324,7 @@ Emitted when any frame (including main) starts navigating.
 
 Returns:
 
-* `details` Event<>
+* `details` Event\<\>
   * `url` string - The URL the frame is navigating to.
   * `isSameDocument` boolean - Whether the navigation happened without changing
     document. Examples of same document navigations are reference fragment
@@ -355,7 +355,7 @@ redirect).
 
 Returns:
 
-* `details` Event<>
+* `details` Event\<\>
   * `url` string - The URL the frame is navigating to.
   * `isSameDocument` boolean - Whether the navigation happened without changing
     document. Examples of same document navigations are reference fragment
@@ -683,7 +683,7 @@ Emitted when media is paused or done playing.
 
 Returns:
 
-* `event` Event<>
+* `event` Event\<\>
   * `audible` boolean - True if one or more frames or child `webContents` are emitting audio.
 
 Emitted when media becomes audible or inaudible.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -900,7 +900,7 @@ Returns:
 * `webPreferences` [WebPreferences](structures/web-preferences.md) - The web preferences that will be used by the guest
   page. This object can be modified to adjust the preferences for the guest
   page.
-* `params` Record<string, string> - The other `<webview>` parameters such as the `src` URL.
+* `params` Record\<string, string\> - The other `<webview>` parameters such as the `src` URL.
   This object can be modified to adjust the parameters of the guest page.
 
 Emitted when a `<webview>`'s web contents is being attached to this web
@@ -1020,7 +1020,7 @@ win.webContents.loadURL('https://github.com', options)
 
 * `filePath` string
 * `options` Object (optional)
-  * `query` Record<string, string> (optional) - Passed to `url.format()`.
+  * `query` Record\<string, string\> (optional) - Passed to `url.format()`.
   * `search` string (optional) - Passed to `url.format()`.
   * `hash` string (optional) - Passed to `url.format()`.
 
@@ -1051,7 +1051,7 @@ win.loadFile('src/index.html')
 
 * `url` string
 * `options` Object (optional)
-  * `headers` Record<string, string> (optional) - HTTP request headers.
+  * `headers` Record\<string, string\> (optional) - HTTP request headers.
 
 Initiates a download of the resource at `url` without navigating. The
 `will-download` event of `session` will be triggered.
@@ -1288,7 +1288,7 @@ Ignore application menu shortcuts while this web contents is focused.
 
 #### `contents.setWindowOpenHandler(handler)`
 
-* `handler` Function<[WindowOpenHandlerResponse](structures/window-open-handler-response.md)>
+* `handler` Function\<[WindowOpenHandlerResponse](structures/window-open-handler-response.md)\>
   * `details` Object
     * `url` string - The _resolved_ version of the URL passed to `window.open()`. e.g. opening a window with `window.open('foo')` will yield something like `https://the-origin/the/current/path/foo`.
     * `frameName` string - Name of the window provided in `window.open()`
@@ -1583,7 +1583,7 @@ Returns `Promise<PrinterInfo[]>` - Resolves with a [`PrinterInfo[]`](structures/
     * `from` number - Index of the first page to print (0-based).
     * `to` number - Index of the last page to print (inclusive) (0-based).
   * `duplexMode` string (optional) - Set the duplex mode of the printed web page. Can be `simplex`, `shortEdge`, or `longEdge`.
-  * `dpi` Record<string, number> (optional)
+  * `dpi` Record\<string, number\> (optional)
     * `horizontal` number (optional) - The horizontal dpi.
     * `vertical` number (optional) - The vertical dpi.
   * `header` string (optional) - string to be printed as page header.

--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -99,11 +99,11 @@ Some examples of valid `urls`:
     * `referrer` string
     * `timestamp` Double
     * `uploadData` [UploadData[]](structures/upload-data.md) (optional)
-    * `requestHeaders` Record<string, string>
+    * `requestHeaders` Record\<string, string\>
   * `callback` Function
     * `beforeSendResponse` Object
       * `cancel` boolean (optional)
-      * `requestHeaders` Record<string, string | string[]> (optional) - When provided, request will be made
+      * `requestHeaders` Record\<string, string | string[]\> (optional) - When provided, request will be made
   with these headers.
 
 The `listener` will be called with `listener(details, callback)` before sending
@@ -126,7 +126,7 @@ The `callback` has to be called with a `response` object.
     * `resourceType` string - Can be `mainFrame`, `subFrame`, `stylesheet`, `script`, `image`, `font`, `object`, `xhr`, `ping`, `cspReport`, `media`, `webSocket` or `other`.
     * `referrer` string
     * `timestamp` Double
-    * `requestHeaders` Record<string, string>
+    * `requestHeaders` Record\<string, string\>
 
 The `listener` will be called with `listener(details)` just before a request is
 going to be sent to the server, modifications of previous `onBeforeSendHeaders`
@@ -148,11 +148,11 @@ response are visible by the time this listener is fired.
     * `timestamp` Double
     * `statusLine` string
     * `statusCode` Integer
-    * `responseHeaders` Record<string, string[]> (optional)
+    * `responseHeaders` Record\<string, string[]\> (optional)
   * `callback` Function
     * `headersReceivedResponse` Object
       * `cancel` boolean (optional)
-      * `responseHeaders` Record<string, string | string[]> (optional) - When provided, the server is assumed
+      * `responseHeaders` Record\<string, string | string[]\> (optional) - When provided, the server is assumed
         to have responded with these headers.
       * `statusLine` string (optional) - Should be provided when overriding
         `responseHeaders` to change header status otherwise original response
@@ -177,7 +177,7 @@ The `callback` has to be called with a `response` object.
     * `resourceType` string - Can be `mainFrame`, `subFrame`, `stylesheet`, `script`, `image`, `font`, `object`, `xhr`, `ping`, `cspReport`, `media`, `webSocket` or `other`.
     * `referrer` string
     * `timestamp` Double
-    * `responseHeaders` Record<string, string[]> (optional)
+    * `responseHeaders` Record\<string, string[]\> (optional)
     * `fromCache` boolean - Indicates whether the response was fetched from disk
       cache.
     * `statusCode` Integer
@@ -207,7 +207,7 @@ and response headers are available.
     * `ip` string (optional) - The server IP address that the request was
       actually sent to.
     * `fromCache` boolean
-    * `responseHeaders` Record<string, string[]> (optional)
+    * `responseHeaders` Record\<string, string[]\> (optional)
 
 The `listener` will be called with `listener(details)` when a server initiated
 redirect is about to occur.
@@ -226,7 +226,7 @@ redirect is about to occur.
     * `resourceType` string - Can be `mainFrame`, `subFrame`, `stylesheet`, `script`, `image`, `font`, `object`, `xhr`, `ping`, `cspReport`, `media`, `webSocket` or `other`.
     * `referrer` string
     * `timestamp` Double
-    * `responseHeaders` Record<string, string[]> (optional)
+    * `responseHeaders` Record\<string, string[]\> (optional)
     * `fromCache` boolean
     * `statusCode` Integer
     * `statusLine` string

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -287,7 +287,7 @@ e.g. the `http://` or `file://`.
 
 * `url` string
 * `options` Object (optional)
-  * `headers` Record<string, string> (optional) - HTTP request headers.
+  * `headers` Record\<string, string\> (optional) - HTTP request headers.
 
 Initiates a download of the resource at `url` without navigating.
 
@@ -580,7 +580,7 @@ Stops any `findInPage` request for the `webview` with the provided `action`.
     * `from` number - Index of the first page to print (0-based).
     * `to` number - Index of the last page to print (inclusive) (0-based).
   * `duplexMode` string (optional) - Set the duplex mode of the printed web page. Can be `simplex`, `shortEdge`, or `longEdge`.
-  * `dpi` Record<string, number> (optional)
+  * `dpi` Record\<string, number\> (optional)
     * `horizontal` number (optional) - The horizontal dpi.
     * `vertical` number (optional) - The vertical dpi.
   * `header` string (optional) - string to be printed as page header.

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -1686,7 +1686,7 @@ folder
 └── file3
 ```
 
-In Electron <=6, this would return a `FileList` with a `File` object for:
+In Electron &lt;=6, this would return a `FileList` with a `File` object for:
 
 ```console
 path/to/folder


### PR DESCRIPTION
#### Description of Change

As discussed in the last @electron/wg-ecosystem meeting, the website upgrade to MDX 3 requires us to add additional escape characters to our parametrized API types.

This is because `Record<string, string>` will not render on MDX 3, while it did on MDX 1 and still does on most other Markdown implementations.

Escaping `<` as `\<` and escaping `>` as `\>` provides a solution that's _good enough_ on all environments. For example, for `Record\<string, string\>`:

* On GFM (github.com), it renders as `Record<string, string>`.
* On MDX 1 (current site), it renders as `Record\<string, string>`.
* On MDX 3 (Docusaurus 3 upgrade), it renders as `Record<string, string>`.

See CI run for Archeologist showing no changes in the TS output.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
