### PR TITLE
test: disable transparency tests on macOS arm64

### DIFF
--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6471,8 +6471,8 @@ describe('BrowserWindow module', () => {
       expect(w.getBounds()).to.deep.equal(newBounds);
     });
 
-    // Linux and arm64 platforms (WOA and macOS) do not return any capture sources
-    ifit(process.platform === 'darwin' && process.arch === 'x64')('should not display a visible background', async () => {
+    // FIXME(codebytere): figure out why these are failing on macOS arm64.
+    ifit(process.platform === 'darwin' && process.arch !== 'arm64')('should not display a visible background', async () => {
       const display = screen.getPrimaryDisplay();
 
       const backgroundWindow = new BrowserWindow({
@@ -6514,7 +6514,8 @@ describe('BrowserWindow module', () => {
       );
     });
 
-    ifit(process.platform === 'darwin')('Allows setting a transparent window via CSS', async () => {
+    // FIXME(codebytere): figure out why these are failing on macOS arm64.
+    ifit(process.platform === 'darwin' && process.arch !== 'arm64')('Allows setting a transparent window via CSS', async () => {
       const display = screen.getPrimaryDisplay();
 
       const backgroundWindow = new BrowserWindow({


### PR DESCRIPTION
#### Description of Change

As in title. These are consistently failing on arm64 with a [window pollution issue](https://circleci-tasks-prod.s3.us-east-1.amazonaws.com/storage/artifacts/6f0d7dce-43d4-4fdd-997a-ade727476389/7391d75b-72ac-4154-89aa-3dae4773d37e/0/src/electron/spec/artifacts/color-mismatch-017b1914c837b325d6f652f6.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQVFQINEODM3JFTG4%2F20240313%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240313T084642Z&X-Amz-Expires=60&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEFEaCXVzLWVhc3QtMSJHMEUCIHuUfWwNtCduQJjIE3B5agvxDSjS5HoghrTEVdyghU68AiEA4AJrSfX4Ku5i4XkKelSHthnx5hQJtY200u42%2BFT2Cg8qqwIIWhADGgwwNDU0NjY4MDY1NTYiDGIBKptOGxdWQ80QAyqIApkfQcq3Gq5jDDz%2BBWq7dYB%2B%2BtgFXXsRZVeF1%2FBkdHzSTtDp9THNlgf5rUExjX9DsNaXxLAz%2BlHmkO197neFM4Mq9tnGLLoYs4NirMgCbGYxBIKAe1U7dL6kNuFO2cKJ%2BnhjibPnWcroNf9p6mmKoE472fh9Yz0j3BHBF2m2MW9WLz1IssoDvmlsfQ7OY9NagVPWWGoUv3bZshG2QezPSZlBeTzZAl50ii8kHdEDsyoZ%2FiN7pkLHCMjxsAnPMQcVQ65kKB5wJpkdi%2FDUkFjyWeaoPhke177Dx9Wdu159AXgBVOS64WH%2FMq70c3yZ%2FgdevFmQj%2BtX8KwqRNeEahMB%2BXeuz%2Bw7ksLXzzDnzcWvBjqdAavrUzQRhqQ52z7C2rpdDrUe1q6qb32LUdPTY3tOHNxLex15xInKpgGoD%2FZL1ngEUC9nAkP0b40D1pYeWptfrBmpCoopr8ULNJNJsv3l7BEIVIReM2p3107Njqk0KCzy4AmoUA6adiPCNyXgarjFASlwFo4%2BCRgSuqq%2FObeVoZn3rONydnk81%2F2Q1WCHEL9a7MpHkZUZch6exElqk0w%3D&X-Amz-SignedHeaders=host&x-id=GetObject&X-Amz-Signature=bc008a9336483e8385ae1472d1b8e5725492a4110c9c62d3155fb313c0f60058).

Issue is https://github.com/electron/electron/issues/41581

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none