### PR TITLE
chore: fix notes stack updates

### DIFF
--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -485,6 +485,24 @@ const getNotes = async (fromRef, toRef, newVersion) => {
   return notes;
 };
 
+const compareVersions = (v1, v2) => {
+  const [split1, split2] = [v1.split('.'), v2.split('.')];
+
+  if (split1.length !== split2.length) {
+    throw new Error(`Expected version strings to have same number of sections: ${split1} and ${split2}`);
+  }
+  for (let i = 0; i < split1.length; i++) {
+    const p1 = parseInt(split1[i], 10);
+    const p2 = parseInt(split2[i], 10);
+
+    if (p1 > p2) return 1;
+    else if (p1 < p2) return -1;
+    // Continue checking the value if this portion is equal
+  }
+
+  return 0;
+};
+
 const removeSupercededStackUpdates = (commits) => {
   const updateRegex = /^Updated ([a-zA-Z.]+) to v?([\d.]+)/;
   const notupdates = [];
@@ -496,24 +514,10 @@ const removeSupercededStackUpdates = (commits) => {
       notupdates.push(commit);
       continue;
     }
-    const [, dep, version] = match;
-    if (!newest[dep]) {
-      newest[dep] = { commit, version };
-      continue;
-    }
 
-    const newestSplit = newest[dep].version.split('.');
-    const replacementSplit = version.split('.');
-    if (newestSplit.length !== replacementSplit.length) {
-      throw new Error(`Expected version strings to have same number of sections: ${newest[dep].version} and ${version}`);
-    }
-    for (let i = 0; i < newestSplit.length; i++) {
-      if (parseInt(replacementSplit[i]) < parseInt(newestSplit[i])) {
-        break;
-      } else if (parseInt(replacementSplit[i]) > parseInt(newestSplit[i])) {
-        newest[dep] = { commit, version };
-        break;
-      }
+    const [, dep, version] = match;
+    if (!newest[dep] || compareVersions(version, newest[dep].version) > 0) {
+      newest[dep] = { commit, version };
     }
   }
 

--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -505,7 +505,9 @@ const removeSupercededStackUpdates = (commits) => {
     const newestSplit = newest[dep].version.split('.');
     const replacementSplit = version.split('.');
     for (let i = 0; i < newestSplit.length; i++) {
-      if (parseInt(replacementSplit[i]) > parseInt(newestSplit[i])) {
+      if (parseInt(replacementSplit[i]) < parseInt(newestSplit[i])) {
+        break;
+      } else if (parseInt(replacementSplit[i]) > parseInt(newestSplit[i])) {
         newest[dep] = { commit, version };
         break;
       }

--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -497,8 +497,18 @@ const removeSupercededStackUpdates = (commits) => {
       continue;
     }
     const [, dep, version] = match;
-    if (!newest[dep] || newest[dep].version < version) {
+    if (!newest[dep]) {
       newest[dep] = { commit, version };
+      continue;
+    }
+
+    const newestSplit = newest[dep].version.split('.');
+    const replacementSplit = version.split('.');
+    for (let i = 0; i < newestSplit.length; i++) {
+      if (parseInt(replacementSplit[i]) > parseInt(newestSplit[i])) {
+        newest[dep] = { commit, version };
+        break;
+      }
     }
   }
 

--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -504,6 +504,9 @@ const removeSupercededStackUpdates = (commits) => {
 
     const newestSplit = newest[dep].version.split('.');
     const replacementSplit = version.split('.');
+    if (newestSplit.length !== replacementSplit.length) {
+      throw new Error(`Expected version strings to have same number of sections: ${newest[dep].version} and ${version}`);
+    }
     for (let i = 0; i < newestSplit.length; i++) {
       if (parseInt(replacementSplit[i]) < parseInt(newestSplit[i])) {
         break;

--- a/spec/release-notes-spec.ts
+++ b/spec/release-notes-spec.ts
@@ -211,4 +211,51 @@ describe('release notes', () => {
       expect(results.breaking[0].hash).to.equal(testCommit.sha1);
     });
   });
+  // test that when you have multiple stack updates only the
+  // latest will be kept
+  describe('superseding stack updates', () => {
+    const oldBranch = '27-x-y';
+    const newBranch = '28-x-y';
+
+    const version = 'v28.0.0';
+
+    it('with different major versions', async function () {
+      const mostRecentCommit = new Commit('9d0e6d09f0be0abbeae46dd3d66afd96d2daacaa', 'chore: bump chromium to 119.0.6043.0');
+
+      const sharedChromiumHistory = [
+        new Commit('029127a8b6f7c511fca4612748ad5b50e43aadaa', 'chore: bump chromium to 118.0.5993.0') // merge-base
+      ];
+      const chromiumPatchUpdates = [
+        new Commit('d9ba26273ad3e7a34c905eccbd5dabda4eb7b402', 'chore: bump chromium to 118.0.5991.0'),
+        mostRecentCommit,
+        new Commit('d6c8ff2e7050f30dffd784915bcbd2a9f993cdb2', 'chore: bump chromium to 119.0.6029.0')
+      ];
+
+      gitFake.setBranch(oldBranch, sharedChromiumHistory);
+      gitFake.setBranch(newBranch, [...sharedChromiumHistory, ...chromiumPatchUpdates]);
+
+      const results: any = await notes.get(oldBranch, newBranch, version);
+      expect(results.other).to.have.lengthOf(1);
+      expect(results.other[0].hash).to.equal(mostRecentCommit.sha1);
+    });
+    it('with different build versions', async function () {
+      const mostRecentCommit = new Commit('8f7a48879ef8633a76279803637cdee7f7c6cd4f', 'chore: bump chromium to 119.0.6045.0');
+
+      const sharedChromiumHistory = [
+        new Commit('029127a8b6f7c511fca4612748ad5b50e43aadaa', 'chore: bump chromium to 118.0.5993.0') // merge-base
+      ];
+      const chromiumPatchUpdates = [
+        mostRecentCommit,
+        new Commit('9d0e6d09f0be0abbeae46dd3d66afd96d2daacaa', 'chore: bump chromium to 119.0.6043.0'),
+        new Commit('d6c8ff2e7050f30dffd784915bcbd2a9f993cdb2', 'chore: bump chromium to 119.0.6029.0')
+      ];
+
+      gitFake.setBranch(oldBranch, sharedChromiumHistory);
+      gitFake.setBranch(newBranch, [...sharedChromiumHistory, ...chromiumPatchUpdates]);
+
+      const results: any = await notes.get(oldBranch, newBranch, version);
+      expect(results.other).to.have.lengthOf(1);
+      expect(results.other[0].hash).to.equal(mostRecentCommit.sha1);
+    });
+  });
 });


### PR DESCRIPTION
#### Description of Change

This PR fixes an issue that would appear when there were multiple Chromium stack upgrades between versions. The notes script did not correctly handle the comparisons needed to determine which stack upgrade superceded which. An example of the previous issue can be seen here: https://github.com/electron/electron/releases/tag/v29.1.1 lists Chromium 122.0.6261.95, however according to https://github.com/electron/electron/blob/v29.1.1/DEPS it's 122.0.6261.111.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: None
