### PR TITLE
chore: cherry-pick 1 change from Release-3-M122

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -159,3 +159,4 @@ fix_a_crash_when_a_bmp_image_contains_an_unnecessary_eof_code.patch
 m120_ipcz_fix_a_few_weak_asserts.patch
 prevent_mojotrap_event_re-ordering.patch
 m122_cherry_pick_cve-2024-25062_libxml_fix.patch
+update_crashpad_to_37afd37401253ebcebcf6e07ce15c8cfecb1a1cc.patch

--- a/patches/chromium/update_crashpad_to_37afd37401253ebcebcf6e07ce15c8cfecb1a1cc.patch
+++ b/patches/chromium/update_crashpad_to_37afd37401253ebcebcf6e07ce15c8cfecb1a1cc.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Joshua Peraza <jperaza@chromium.org>
+Date: Tue, 5 Mar 2024 18:09:48 +0000
+Subject: Update Crashpad to 37afd37401253ebcebcf6e07ce15c8cfecb1a1cc
+
+29ac83caeb94 [Fuchsia] remove use of fuchsia mac sdk
+37afd3740125 Properly update iterator
+
+(cherry picked from commit 80b0e498bec1722e8cc310fe52698e7b690956f2)
+
+Bug: 325296797
+Change-Id: I7eb39d1bccec802f1b043eebd20ec0e658fe0e04
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5311633
+Reviewed-by: Nico Weber <thakis@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1264232}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5335538
+Reviewed-by: Mark Mentovai <mark@chromium.org>
+Commit-Queue: Joshua Peraza <jperaza@chromium.org>
+Cr-Commit-Position: refs/branch-heads/6261@{#1024}
+Cr-Branched-From: 9755d9d81e4a8cb5b4f76b23b761457479dbb06b-refs/heads/main@{#1250580}
+
+diff --git a/third_party/crashpad/README.chromium b/third_party/crashpad/README.chromium
+index 9edcee3aa81a84cd38bba2660557dfc6f48e380c..bafe29b422506207a11a22f6793c38d6c5fa5a5f 100644
+--- a/third_party/crashpad/README.chromium
++++ b/third_party/crashpad/README.chromium
+@@ -1,8 +1,8 @@
+ Name: Crashpad
+ Short Name: crashpad
+ URL: https://crashpad.chromium.org/
+-Version: unknown
+-Revision: a7cfe95351e301512eb0efc03f92fee63c1c82b2
++Version: N/A
++Revision: 37afd37401253ebcebcf6e07ce15c8cfecb1a1cc
+ License: Apache 2.0
+ License File: crashpad/LICENSE
+ Security Critical: yes
+diff --git a/third_party/crashpad/crashpad/DEPS b/third_party/crashpad/crashpad/DEPS
+index b7d44b11c3f8eb8275971eb29c5bcca313f70179..f6f7a31963245b47724eb75584033e68c90a90d6 100644
+--- a/third_party/crashpad/crashpad/DEPS
++++ b/third_party/crashpad/crashpad/DEPS
+@@ -121,16 +121,6 @@ deps = {
+            '0d6902558d92fe3d49ba9a8f638ddea829be595b',
+     'condition': 'checkout_fuchsia',
+   },
+-  'crashpad/third_party/fuchsia/sdk/mac-amd64': {
+-    'packages': [
+-      {
+-        'package': 'fuchsia/sdk/core/mac-amd64',
+-        'version': 'latest'
+-      },
+-    ],
+-    'condition': 'checkout_fuchsia and host_os == "mac"',
+-    'dep_type': 'cipd'
+-  },
+   'crashpad/third_party/fuchsia/sdk/linux-amd64': {
+     'packages': [
+       {
+diff --git a/third_party/crashpad/crashpad/snapshot/sanitized/module_snapshot_sanitized.cc b/third_party/crashpad/crashpad/snapshot/sanitized/module_snapshot_sanitized.cc
+index 192b4cb10add6e3aaa70b96b86bc8ae90b90a070..476ebe019eee87d76a8bceaa885dc58f01c6af62 100644
+--- a/third_party/crashpad/crashpad/snapshot/sanitized/module_snapshot_sanitized.cc
++++ b/third_party/crashpad/crashpad/snapshot/sanitized/module_snapshot_sanitized.cc
+@@ -97,9 +97,11 @@ ModuleSnapshotSanitized::AnnotationsSimpleMap() const {
+   std::map<std::string, std::string> annotations =
+       snapshot_->AnnotationsSimpleMap();
+   if (allowed_annotations_) {
+-    for (auto kv = annotations.begin(); kv != annotations.end(); ++kv) {
+-      if (!KeyIsAllowed(kv->first, *allowed_annotations_)) {
+-        annotations.erase(kv);
++    for (auto kv = annotations.begin(); kv != annotations.end();) {
++      if (KeyIsAllowed(kv->first, *allowed_annotations_)) {
++        ++kv;
++      } else {
++        kv = annotations.erase(kv);
+       }
+     }
+   }


### PR DESCRIPTION
* 2a7dc5af567b4434cc346e9e2aa5dcd01ef64148 from chromium

#### Release Notes

Notes:
* Security: backported fix for 325296797.