### PR TITLE
fix: recognize 'undefined' header value in `ClientRequest`

### DIFF
--- a/lib/common/api/net-client-request.ts
+++ b/lib/common/api/net-client-request.ts
@@ -209,6 +209,22 @@ type ExtraURLLoaderOptions = {
    headers: Record<string, { name: string, value: string | string[] }>;
    allowNonHttpProtocols: boolean;
 }
+
+function headerValidation (name: any, value: any): void {
+  if (typeof name !== 'string') {
+    throw new TypeError('`name` should be a string in setHeader(name, value)');
+  }
+  if (value == null) {
+    throw new Error('`value` required in setHeader("' + name + '", value)');
+  }
+  if (!isValidHeaderName(name)) {
+    throw new Error(`Invalid header name: '${name}'`);
+  }
+  if (!isValidHeaderValue(value.toString())) {
+    throw new Error(`Invalid value for header '${name}': '${value}'`);
+  }
+}
+
 function parseOptions (optionsIn: ClientRequestConstructorOptions | string): NodeJS.CreateURLLoaderOptions & ExtraURLLoaderOptions {
   // eslint-disable-next-line node/no-deprecated-api
   const options: any = typeof optionsIn === 'string' ? url.parse(optionsIn) : { ...optionsIn };
@@ -275,12 +291,7 @@ function parseOptions (optionsIn: ClientRequestConstructorOptions | string): Nod
   };
   const headers: Record<string, string | string[]> = options.headers || {};
   for (const [name, value] of Object.entries(headers)) {
-    if (!isValidHeaderName(name)) {
-      throw new Error(`Invalid header name: '${name}'`);
-    }
-    if (!isValidHeaderValue(value.toString())) {
-      throw new Error(`Invalid value for header '${name}': '${value}'`);
-    }
+    headerValidation(name, value);
     const key = name.toLowerCase();
     urlLoaderOptions.headers[key] = { name, value };
   }
@@ -351,21 +362,10 @@ export class ClientRequest extends Writable implements Electron.ClientRequest {
   }
 
   setHeader (name: string, value: string) {
-    if (typeof name !== 'string') {
-      throw new TypeError('`name` should be a string in setHeader(name, value)');
-    }
-    if (value == null) {
-      throw new Error('`value` required in setHeader("' + name + '", value)');
-    }
     if (this._started || this._firstWrite) {
       throw new Error('Can\'t set headers after they are sent');
     }
-    if (!isValidHeaderName(name)) {
-      throw new Error(`Invalid header name: '${name}'`);
-    }
-    if (!isValidHeaderValue(value.toString())) {
-      throw new Error(`Invalid value for header '${name}': '${value}'`);
-    }
+    headerValidation(name, value);
 
     const key = name.toLowerCase();
     this._urlLoaderOptions.headers[key] = { name, value };

--- a/lib/common/api/net-client-request.ts
+++ b/lib/common/api/net-client-request.ts
@@ -210,7 +210,7 @@ type ExtraURLLoaderOptions = {
    allowNonHttpProtocols: boolean;
 }
 
-function headerValidation (name: any, value: any): void {
+function validateHeader (name: any, value: any): void {
   if (typeof name !== 'string') {
     throw new TypeError('`name` should be a string in setHeader(name, value)');
   }
@@ -291,7 +291,7 @@ function parseOptions (optionsIn: ClientRequestConstructorOptions | string): Nod
   };
   const headers: Record<string, string | string[]> = options.headers || {};
   for (const [name, value] of Object.entries(headers)) {
-    headerValidation(name, value);
+    validateHeader(name, value);
     const key = name.toLowerCase();
     urlLoaderOptions.headers[key] = { name, value };
   }
@@ -365,7 +365,7 @@ export class ClientRequest extends Writable implements Electron.ClientRequest {
     if (this._started || this._firstWrite) {
       throw new Error('Can\'t set headers after they are sent');
     }
-    headerValidation(name, value);
+    validateHeader(name, value);
 
     const key = name.toLowerCase();
     this._urlLoaderOptions.headers[key] = { name, value };

--- a/spec/api-net-session-spec.ts
+++ b/spec/api-net-session-spec.ts
@@ -616,6 +616,25 @@ describe('net module (session)', () => {
         });
       }).to.throw('`partition` should be a string');
     });
+
+    it('should throw if given a header value that is empty(null/undefined)', () => {
+      const emptyHeaderValues = [null, undefined];
+      const errorMsg = '`value` required in setHeader("foo", value)';
+
+      for (const emptyValue of emptyHeaderValues) {
+        expect(() => {
+          net.request({
+            url: 'https://foo',
+            headers: { foo: emptyValue }
+          });
+        }).to.throw(errorMsg);
+
+        const request = net.request({ url: 'https://foo' });
+        expect(() => {
+          request.setHeader('foo', emptyValue);
+        }).to.throw(errorMsg);
+      }
+    });
   });
 
   describe('net.fetch', () => {

--- a/spec/api-net-session-spec.ts
+++ b/spec/api-net-session-spec.ts
@@ -625,13 +625,13 @@ describe('net module (session)', () => {
         expect(() => {
           net.request({
             url: 'https://foo',
-            headers: { foo: emptyValue }
-          });
+            headers: { foo: emptyValue as any }
+          } as any);
         }).to.throw(errorMsg);
 
         const request = net.request({ url: 'https://foo' });
         expect(() => {
-          request.setHeader('foo', emptyValue);
+          request.setHeader('foo', emptyValue as any);
         }).to.throw(errorMsg);
       }
     });


### PR DESCRIPTION
#### Description of Change
There was an issue I encountered that I mistakenly used `undefined` as a header value when using `electron.net.request()`, then threw an error "Cannot read properties of undefined (reading ‘toString’)". It's a non-semantic error and unfriendly for debug. 

I've check the source code, then found out there do have a `empty` check but it's only checked the `null` and miss out `undefined`.

Please let me know if this correction is need, then I'll add ut for it.



<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes

#### Release Notes

Notes: fix(ClientRequest): recognize the 'undefined' header value
