### PR TITLE
fix: missing badge text on Windows

### DIFF
--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -40,6 +40,7 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/skia_util.h"
 #include "shell/common/thread_restrictions.h"
+#include "skia/ext/font_utils.h"
 #include "skia/ext/legacy_display_globals.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkFont.h"
@@ -591,7 +592,7 @@ void Browser::UpdateBadgeContents(
     paint.reset();
     paint.setColor(kForegroundColor);
 
-    SkFont font;
+    SkFont font = skia::DefaultFont();
 
     SkRect bounds;
     int text_size = kMaxTextSize;

--- a/shell/browser/ui/win/taskbar_host.h
+++ b/shell/browser/ui/win/taskbar_host.h
@@ -52,7 +52,7 @@ class TaskbarHost {
 
   // Set the overlay icon in taskbar.
   bool SetOverlayIcon(HWND window,
-                      const SkBitmap& overlay,
+                      const SkBitmap& bitmap,
                       const std::string& text);
 
   // Set the region of the window to show as a thumbnail in taskbar.


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/41589.
Refs CL:5053607

Fixes an issue where badge text set using the Badging API no longer appeared correctly on Windows. This happened because Chromium removed Skia `SkFont` default value setting to `skia::DefaultFont()`, which meant it would be a null value and nothing would be painted properly. Also pulls in some updates from `chrome/browser/taskbar/taskbar_decorator_win.cc`, where this function was initially adapted from to handle erstwhile Windows rendering issues.

<details><summary>Before</summary>
<p>

<img width="55" alt="Screenshot 2024-03-15 at 7 02 12 PM" src="https://github.com/electron/electron/assets/2036040/148e7486-004c-408e-859c-0ece61defb49">

</p>
</details> 

<details><summary>After</summary>
<p>

<img width="58" alt="Screenshot 2024-03-15 at 7 01 43 PM" src="https://github.com/electron/electron/assets/2036040/480ef07b-260a-4d77-aef7-b39adfacbd03">

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where badge text set using the Badging API no longer appeared correctly on Windows.
