### PR TITLE
test: modify remote specs to allow skip or only

### DIFF
--- a/spec/lib/spec-helpers.ts
+++ b/spec/lib/spec-helpers.ts
@@ -176,8 +176,8 @@ export function useRemoteContext (opts?: any) {
   });
 }
 
-export async function itremote (name: string, fn: Function, args?: any[]) {
-  it(name, async () => {
+async function runRemote (type: 'skip' | 'none' | 'only', name: string, fn: Function, args?: any[]) {
+  const wrapped = async () => {
     const w = await getRemoteContext();
     const { ok, message } = await w.webContents.executeJavaScript(`(async () => {
       try {
@@ -192,8 +192,29 @@ export async function itremote (name: string, fn: Function, args?: any[]) {
       }
     })()`);
     if (!ok) { throw new AssertionError(message); }
-  });
+  };
+
+  let runFn: any = it;
+  if (type === 'only') {
+    runFn = it.only;
+  } else if (type === 'skip') {
+    runFn = it.skip;
+  }
+
+  runFn(name, wrapped);
 }
+
+export const itremote = Object.assign(
+  (name: string, fn: Function, args?: any[]) => {
+    runRemote('none', name, fn, args);
+  }, {
+    only: (name: string, fn: Function, args?: any[]) => {
+      runRemote('only', name, fn, args);
+    },
+    skip: (name: string, fn: Function, args?: any[]) => {
+      runRemote('skip', name, fn, args);
+    }
+  });
 
 export async function listen (server: http.Server | https.Server | http2.Http2SecureServer) {
   const hostname = '127.0.0.1';


### PR DESCRIPTION
#### Description of Change

Allow skipping or running `itremote` specs in isolation.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none