### PR TITLE
fix: `serial-port-added` should respect filters

### DIFF
--- a/shell/browser/serial/serial_chooser_controller.cc
+++ b/shell/browser/serial/serial_chooser_controller.cc
@@ -93,6 +93,9 @@ api::Session* SerialChooserController::GetSession() {
 
 void SerialChooserController::OnPortAdded(
     const device::mojom::SerialPortInfo& port) {
+  if (!FilterMatchesAny(port))
+    return;
+
   ports_.push_back(port.Clone());
   api::Session* session = GetSession();
   if (session) {


### PR DESCRIPTION
#### Description of Change

The `serial-port-added` event shouldn't be emitted if the serial port being added doesn't pass filters that were set. This fixes that - upstream logic does [the same](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/serial/serial_chooser_controller.cc;l=219;bpv=1;bpt=1).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where the `serial-port-added` event improperly respected filters set by `serial.requestPort()`
