### PR TITLE
build: work around ScreenCaptureKit bad feature flag parsing in Chromium

### DIFF
--- a/shell/browser/feature_list_mac.mm
+++ b/shell/browser/feature_list_mac.mm
@@ -6,6 +6,8 @@
 
 #include <string>
 
+#include "base/dcheck_is_on.h"
+
 namespace electron {
 
 std::string EnablePlatformSpecificFeatures() {
@@ -19,8 +21,12 @@ std::string EnablePlatformSpecificFeatures() {
     // chrome/browser/media/webrtc/thumbnail_capturer_mac.mm
     // kThumbnailCapturerMac,
     // chrome/browser/media/webrtc/thumbnail_capturer_mac.mm
+#if DCHECK_IS_ON()
+    return "";
+#else
     return "ScreenCaptureKitPickerScreen,ScreenCaptureKitStreamPickerSonoma,"
            "ThumbnailCapturerMac:capture_mode/sc_screenshot_manager";
+#endif
   }
   return "";
 }


### PR DESCRIPTION
#### Description of Change

Ref https://github.com/electron/electron/pull/41397.

<details><summary>Details</summary>
<p>

```
[64768:0318/145439.936909:FATAL:feature_list.cc(873)] Check failed: trial. trial='StudyThumbnailCapturerMac' does not exist
0   Electron Framework                  0x000000011cb39cc0 base::debug::CollectStackTrace(void const**, unsigned long) + 28
1   Electron Framework                  0x000000011cb29a20 base::debug::StackTrace::StackTrace() + 24
2   Electron Framework                  0x000000011ca57b40 logging::LogMessage::Flush() + 132
3   Electron Framework                  0x000000011ca57a3c logging::LogMessage::~LogMessage() + 36
4   Electron Framework                  0x000000011ca4200c logging::(anonymous namespace)::DCheckLogMessage::~DCheckLogMessage() + 124
5   Electron Framework                  0x000000011ca4205c logging::(anonymous namespace)::DCheckLogMessage::~DCheckLogMessage() + 12
6   Electron Framework                  0x000000011ca41ae0 logging::CheckError::~CheckError() + 44
7   Electron Framework                  0x000000011ca41b48 logging::CheckError::~CheckError() + 12
8   Electron Framework                  0x000000011ca46734 base::FeatureList::RegisterOverridesFromCommandLine(std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, base::FeatureList::OverrideState) + 404
9   Electron Framework                  0x000000011ca46380 base::FeatureList::InitFromCommandLine(std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&) + 1708
10  Electron Framework                  0x000000011ca48474 base::FeatureList::InitInstance(std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, std::__Cr::vector<std::__Cr::pair<std::__Cr::reference_wrapper<base::Feature[abi:logically_const] const> const, base::FeatureList::OverrideState>, std::__Cr::allocator<std::__Cr::pair<std::__Cr::reference_wrapper<base::Feature[abi:logically_const] const> const, base::FeatureList::OverrideState>>> const&) + 180
11  Electron Framework                  0x000000011ca483b4 base::FeatureList::InitInstance(std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&) + 28
12  Electron Framework                  0x0000000117aff9f0 electron::InitializeFeatureList() + 596
13  Electron Framework                  0x00000001179be050 electron::ElectronMainDelegate::PreBrowserMain() + 12
14  Electron Framework                  0x0000000117da13ac content::ContentMainRunnerImpl::RunBrowser(content::MainFunctionParams, bool) + 912
15  Electron Framework                  0x0000000117da0fac content::ContentMainRunnerImpl::Run() + 1424
16  Electron Framework                  0x0000000117d9e9ac content::RunContentProcess(content::ContentMainParams, content::ContentMainRunner*) + 1192
17  Electron Framework                  0x0000000117d9ebf0 content::ContentMain(content::ContentMainParams) + 112
18  Electron Framework                  0x00000001179bacb4 ElectronMain + 320
19  dyld                                0x000000019c13e0e0 start + 2360
Crash keys:
  "platform" = "darwin"
  "process_type" = "browser"

Electron exited with signal SIGTRAP.
```

</p>
</details> 

This works fine in release builds but bombs in testing because of the way [feature flags are currently parsed](https://source.chromium.org/chromium/chromium/src/+/main:base/feature_list.h;l=283):

> // If a feature appears on both lists, then it will be disabled. If
  // a list entry has the format "FeatureName<TrialName" then this
  // initialization will also associate the feature state override with the
  // named field trial, if it exists. If a list entry has the format
  // "FeatureName:k1/v1/k2/v2", "FeatureName<TrialName:k1/v1/k2/v2" or
  // "FeatureName<TrialName.GroupName:k1/v1/k2/v2" then this initialization will
  // also associate the feature state override with the named field trial and
  // its params. If the feature params part is provided but trial and/or group
  // isn't, this initialization will also create a synthetic trial, named
  // "Study" followed by the feature name, i.e. "StudyFeature", and group, named
  // "Group" followed by the feature name, i.e. "GroupFeature", for the params.
  // If a feature name is prefixed with the '*' character, it will be created
  // with OVERRIDE_USE_DEFAULT - which is useful for associating with a trial
  // while using the default state.

To fix this for now and unblock local development on macOS 14.4, only set it in release.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
