### PR TITLE
feat(serial): allow Bluetooth ports to be requested by service class ID

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -475,6 +475,7 @@ source_set("electron_lib") {
     "//net:extras",
     "//net:net_resources",
     "//printing/buildflags",
+    "//services/device/public/cpp/bluetooth:bluetooth",
     "//services/device/public/cpp/geolocation",
     "//services/device/public/cpp/hid",
     "//services/device/public/mojom",

--- a/shell/browser/serial/electron_serial_delegate.cc
+++ b/shell/browser/serial/electron_serial_delegate.cc
@@ -35,7 +35,9 @@ std::unique_ptr<content::SerialChooser> ElectronSerialDelegate::RunChooser(
   if (controller) {
     DeleteControllerForFrame(frame);
   }
-  AddControllerForFrame(frame, std::move(filters), std::move(callback));
+  AddControllerForFrame(frame, std::move(filters),
+                        std::move(allowed_bluetooth_service_class_ids),
+                        std::move(callback));
 
   // Return a nullptr because the return value isn't used for anything, eg
   // there is no mechanism to cancel navigator.serial.requestPort(). The return
@@ -106,12 +108,14 @@ SerialChooserController* ElectronSerialDelegate::ControllerForFrame(
 SerialChooserController* ElectronSerialDelegate::AddControllerForFrame(
     content::RenderFrameHost* render_frame_host,
     std::vector<blink::mojom::SerialPortFilterPtr> filters,
+    std::vector<device::BluetoothUUID> allowed_bluetooth_service_class_ids,
     content::SerialChooser::Callback callback) {
   auto* web_contents =
       content::WebContents::FromRenderFrameHost(render_frame_host);
   auto controller = std::make_unique<SerialChooserController>(
-      render_frame_host, std::move(filters), std::move(callback), web_contents,
-      weak_factory_.GetWeakPtr());
+      render_frame_host, std::move(filters),
+      std::move(allowed_bluetooth_service_class_ids), std::move(callback),
+      web_contents, weak_factory_.GetWeakPtr());
   controller_map_.insert(
       std::make_pair(render_frame_host, std::move(controller)));
   return ControllerForFrame(render_frame_host);

--- a/shell/browser/serial/electron_serial_delegate.h
+++ b/shell/browser/serial/electron_serial_delegate.h
@@ -67,6 +67,7 @@ class ElectronSerialDelegate : public content::SerialDelegate,
   SerialChooserController* AddControllerForFrame(
       content::RenderFrameHost* render_frame_host,
       std::vector<blink::mojom::SerialPortFilterPtr> filters,
+      std::vector<device::BluetoothUUID> allowed_bluetooth_service_class_ids,
       content::SerialChooser::Callback callback);
 
   base::ScopedObservation<SerialChooserContext,

--- a/shell/browser/serial/serial_chooser_controller.cc
+++ b/shell/browser/serial/serial_chooser_controller.cc
@@ -11,6 +11,9 @@
 #include "base/functional/bind.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
+#include "device/bluetooth/public/cpp/bluetooth_uuid.h"
+#include "services/device/public/cpp/bluetooth/bluetooth_utils.h"
+#include "services/device/public/mojom/serial.mojom.h"
 #include "shell/browser/api/electron_api_session.h"
 #include "shell/browser/serial/serial_chooser_context.h"
 #include "shell/browser/serial/serial_chooser_context_factory.h"
@@ -58,14 +61,57 @@ struct Converter<device::mojom::SerialPortInfoPtr> {
 
 namespace electron {
 
+namespace {
+
+using ::device::mojom::SerialPortType;
+
+bool FilterMatchesPort(const blink::mojom::SerialPortFilter& filter,
+                       const device::mojom::SerialPortInfo& port) {
+  if (filter.bluetooth_service_class_id) {
+    if (!port.bluetooth_service_class_id) {
+      return false;
+    }
+    return device::BluetoothUUID(*port.bluetooth_service_class_id) ==
+           device::BluetoothUUID(*filter.bluetooth_service_class_id);
+  }
+  if (!filter.has_vendor_id) {
+    return true;
+  }
+  if (!port.has_vendor_id || port.vendor_id != filter.vendor_id) {
+    return false;
+  }
+  if (!filter.has_product_id) {
+    return true;
+  }
+  return port.has_product_id && port.product_id == filter.product_id;
+}
+
+bool BluetoothPortIsAllowed(
+    const std::vector<::device::BluetoothUUID>& allowed_ids,
+    const device::mojom::SerialPortInfo& port) {
+  if (!port.bluetooth_service_class_id) {
+    return true;
+  }
+  // Serial Port Profile is allowed by default.
+  if (*port.bluetooth_service_class_id == device::GetSerialPortProfileUUID()) {
+    return true;
+  }
+  return base::Contains(allowed_ids, port.bluetooth_service_class_id.value());
+}
+
+}  // namespace
+
 SerialChooserController::SerialChooserController(
     content::RenderFrameHost* render_frame_host,
     std::vector<blink::mojom::SerialPortFilterPtr> filters,
+    std::vector<::device::BluetoothUUID> allowed_bluetooth_service_class_ids,
     content::SerialChooser::Callback callback,
     content::WebContents* web_contents,
     base::WeakPtr<ElectronSerialDelegate> serial_delegate)
     : WebContentsObserver(web_contents),
       filters_(std::move(filters)),
+      allowed_bluetooth_service_class_ids_(
+          std::move(allowed_bluetooth_service_class_ids)),
       callback_(std::move(callback)),
       serial_delegate_(serial_delegate),
       render_frame_host_id_(render_frame_host->GetGlobalId()) {
@@ -93,10 +139,11 @@ api::Session* SerialChooserController::GetSession() {
 
 void SerialChooserController::OnPortAdded(
     const device::mojom::SerialPortInfo& port) {
-  if (!FilterMatchesAny(port))
+  if (!DisplayDevice(port))
     return;
 
   ports_.push_back(port.Clone());
+
   api::Session* session = GetSession();
   if (session) {
     session->Emit("serial-port-added", port.Clone(), web_contents());
@@ -105,9 +152,8 @@ void SerialChooserController::OnPortAdded(
 
 void SerialChooserController::OnPortRemoved(
     const device::mojom::SerialPortInfo& port) {
-  const auto it = std::find_if(
-      ports_.begin(), ports_.end(),
-      [&port](const auto& ptr) { return ptr->token == port.token; });
+  const auto it = base::ranges::find(ports_, port.token,
+                                     &device::mojom::SerialPortInfo::token);
   if (it != ports_.end()) {
     api::Session* session = GetSession();
     if (session) {
@@ -152,7 +198,7 @@ void SerialChooserController::OnGetDevices(
             });
 
   for (auto& port : ports) {
-    if (FilterMatchesAny(*port))
+    if (DisplayDevice(*port))
       ports_.push_back(std::move(port));
   }
 
@@ -169,21 +215,17 @@ void SerialChooserController::OnGetDevices(
   }
 }
 
-bool SerialChooserController::FilterMatchesAny(
+bool SerialChooserController::DisplayDevice(
     const device::mojom::SerialPortInfo& port) const {
-  if (filters_.empty())
-    return true;
+  if (filters_.empty()) {
+    return BluetoothPortIsAllowed(allowed_bluetooth_service_class_ids_, port);
+  }
 
   for (const auto& filter : filters_) {
-    if (filter->has_vendor_id &&
-        (!port.has_vendor_id || filter->vendor_id != port.vendor_id)) {
-      continue;
+    if (FilterMatchesPort(*filter, port) &&
+        BluetoothPortIsAllowed(allowed_bluetooth_service_class_ids_, port)) {
+      return true;
     }
-    if (filter->has_product_id &&
-        (!port.has_product_id || filter->product_id != port.product_id)) {
-      continue;
-    }
-    return true;
   }
 
   return false;

--- a/shell/browser/serial/serial_chooser_controller.h
+++ b/shell/browser/serial/serial_chooser_controller.h
@@ -34,6 +34,7 @@ class SerialChooserController final : public SerialChooserContext::PortObserver,
   SerialChooserController(
       content::RenderFrameHost* render_frame_host,
       std::vector<blink::mojom::SerialPortFilterPtr> filters,
+      std::vector<::device::BluetoothUUID> allowed_bluetooth_service_class_ids,
       content::SerialChooser::Callback callback,
       content::WebContents* web_contents,
       base::WeakPtr<ElectronSerialDelegate> serial_delegate);
@@ -55,11 +56,12 @@ class SerialChooserController final : public SerialChooserContext::PortObserver,
  private:
   api::Session* GetSession();
   void OnGetDevices(std::vector<device::mojom::SerialPortInfoPtr> ports);
-  bool FilterMatchesAny(const device::mojom::SerialPortInfo& port) const;
+  bool DisplayDevice(const device::mojom::SerialPortInfo& port) const;
   void RunCallback(device::mojom::SerialPortInfoPtr port);
   void OnDeviceChosen(const std::string& port_id);
 
   std::vector<blink::mojom::SerialPortFilterPtr> filters_;
+  std::vector<::device::BluetoothUUID> allowed_bluetooth_service_class_ids_;
   content::SerialChooser::Callback callback_;
   url::Origin origin_;
 


### PR DESCRIPTION
#### Description of Change

Refs CL:4522192.

In https://github.com/electron/electron/pull/38465 we added a parameter to `ElectronSerialDelegate::RunChooser` to account for upstream changes but never actually implemented the feature the parameter was added to support. This PR adds support for Bluetooth ports being requested by service class ID, thereby bringing our WebSerial implementation into alignment with the current state of the web platform api. Now, users can do e.g:

```js
const port = await navigator.serial.requestPort({
     filters: [{bluetoothServiceClassId: 0x1101}]
});
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added support for Bluetooth ports being requested by service class ID in `navigator.serial`.
