### PR TITLE
fix: normalize path before calling `showItemInFolder`

### DIFF
--- a/shell/common/api/electron_api_shell.cc
+++ b/shell/common/api/electron_api_shell.cc
@@ -71,6 +71,18 @@ v8::Local<v8::Promise> OpenExternal(const GURL& url, gin::Arguments* args) {
   return handle;
 }
 
+v8::Local<v8::Promise> ShowItemInFolder(v8::Isolate* isolate,
+                                        const base::FilePath& full_path) {
+  gin_helper::Promise<const std::string&> promise(isolate);
+  v8::Local<v8::Promise> handle = promise.GetHandle();
+
+  base::FilePath normalized_full_path = full_path.NormalizePathSeparators();
+
+  platform_util::ShowItemInFolder(normalized_full_path);
+
+  return handle;
+}
+
 v8::Local<v8::Promise> OpenPath(v8::Isolate* isolate,
                                 const base::FilePath& full_path) {
   gin_helper::Promise<const std::string&> promise(isolate);
@@ -172,7 +184,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   gin_helper::Dictionary dict(context->GetIsolate(), exports);
-  dict.SetMethod("showItemInFolder", &platform_util::ShowItemInFolder);
+  dict.SetMethod("showItemInFolder", &ShowItemInFolder);
   dict.SetMethod("openPath", &OpenPath);
   dict.SetMethod("openExternal", &OpenExternal);
   dict.SetMethod("trashItem", &TrashItem);


### PR DESCRIPTION
#### Description of Change

Resolves #11617, e.g. before Windows Explorer wouldn't open when calling `shell.showItemInFolder(fullPath)` with a path that contains forward slashes. This PR makes the change of first normalizing the path that was passed in using `NormalizePathSeparators()`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `shell.showItemInFolder` not opening Windows Explorer if the passed path contains forward slashes

<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
