### PR TITLE
fix: normalize path before calling `showItemInFolder` and `openPath`

### DIFF
--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -345,9 +345,11 @@ void OpenPath(const base::FilePath& full_path, OpenCallback callback) {
 
   base::ThreadPool::CreateCOMSTATaskRunner(
       {base::MayBlock(), base::TaskPriority::USER_BLOCKING})
-      ->PostTaskAndReplyWithResult(FROM_HERE,
-                                   base::BindOnce(&OpenPathOnThread, full_path),
-                                   std::move(callback));
+      ->PostTaskAndReplyWithResult(
+          FROM_HERE,
+          base::BindOnce(&OpenPathOnThread,
+                         full_path.NormalizePathSeparators()),
+          std::move(callback));
 }
 
 void OpenExternal(const GURL& url,

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -336,7 +336,8 @@ void ShowItemInFolder(const base::FilePath& full_path) {
   base::ThreadPool::CreateCOMSTATaskRunner(
       {base::MayBlock(), base::TaskPriority::USER_BLOCKING})
       ->PostTask(FROM_HERE,
-                 base::BindOnce(&ShowItemInFolderOnWorkerThread, full_path));
+                 base::BindOnce(&ShowItemInFolderOnWorkerThread,
+                                full_path.NormalizePathSeparators()));
 }
 
 void OpenPath(const base::FilePath& full_path, OpenCallback callback) {


### PR DESCRIPTION
#### Description of Change

Resolves #11617, e.g. before Windows Explorer wouldn't open when calling `shell.showItemInFolder(fullPath)` with a path that contains forward slashes. This PR makes the change of first normalizing the path that was passed in using `NormalizePathSeparators()`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `shell.showItemInFolder` not opening Windows Explorer if the passed path contains forward slashes

<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
