### PR TITLE
ci: set issue status to triaged on status/{confirmed,reviewed} label

### DIFF
--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -8,6 +8,24 @@ permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 
 jobs:
+  issue-labeled-with-status:
+    name: status/{confirmed,reviewed} label added
+    if: github.event.label.name == 'status/confirmed' || github.event.label.name == 'status/reviewed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        uses: electron/github-app-auth-action@384fd19694fe7b6dcc9a684746c6976ad78228ae # v1.1.1
+        id: generate-token
+        with:
+          creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
+          org: electron
+      - name: Set status
+        uses: dsanders11/project-actions/edit-item@82e99438bd44a14ad18d92d036dbc25cbfb9a8c4 # v1.2.0
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          project-number: 90
+          field: Status
+          field-value: ✅ Triaged
   issue-labeled-blocked:
     name: blocked/* label added
     if: startsWith(github.event.label.name, 'blocked/')


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Help cut down on manual work by setting the status when https://github.com/electron/electron/labels/status%2Fconfirmed or https://github.com/electron/electron/labels/status%2Freviewed are set. Being conservative with what labels will set the triaged status to avoid accidentally being overzealous since it's ambiguous to determine triage status from labels.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
