### PR TITLE
ci: automatically add the 'has-repro-gist' label

### DIFF
--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -25,3 +25,42 @@ jobs:
           field-value: ${{ github.event.issue.user.login }}
           project-number: 90
           token: ${{ steps.generate-token.outputs.token }}
+  set-labels:
+    if: ${{ contains(github.event.issue.labels.*.name, 'bug :beetle:') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        uses: electron/github-app-auth-action@384fd19694fe7b6dcc9a684746c6976ad78228ae # v1.1.1
+        id: generate-token
+        with:
+          creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
+          org: electron
+      - run: npm install mdast-util-from-markdown@2.0.0 unist-util-select@5.1.0
+      - name: Add labels
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const { fromMarkdown } = await import('${{ github.workspace }}/node_modules/mdast-util-from-markdown/index.js');
+            const { select } = await import('${{ github.workspace }}/node_modules/unist-util-select/index.js');
+
+            const [ owner, repo ] = '${{ github.repository }}'.split('/');
+            const issue_number = ${{ github.event.issue.number }};
+
+            const tree = fromMarkdown(`${{ github.event.issue.body }}`);
+
+            const labels = [];
+
+            const gistUrl = select('heading:has(> text[value="Testcase Gist URL"]) + paragraph > text', tree)?.value.trim();
+            if (gistUrl !== undefined && gistUrl.startsWith('https://gist.github.com/')) {
+              labels.push('has-repro-gist');
+            }
+
+            if (labels.length) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number,
+                labels,
+              });
+            }


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Automation to parse the Markdown in new issues and adds the https://github.com/electron/electron/labels/has-repro-gist label if a Gist URL is found under the "Testcase Gist URL" header (otherwise it's a no-op).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
