### PR TITLE
fix: `app.setLoginItemSettings` error getting swallowed by gin conversion

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -583,6 +583,8 @@ filenames = {
     "shell/common/gin_converters/hid_device_info_converter.h",
     "shell/common/gin_converters/image_converter.cc",
     "shell/common/gin_converters/image_converter.h",
+    "shell/common/gin_converters/login_item_settings_converter.cc",
+    "shell/common/gin_converters/login_item_settings_converter.h",
     "shell/common/gin_converters/media_converter.cc",
     "shell/common/gin_converters/media_converter.h",
     "shell/common/gin_converters/message_box_converter.cc",

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -89,7 +89,6 @@
 
 #if BUILDFLAG(IS_MAC)
 #include <CoreFoundation/CoreFoundation.h>
-#include "base/mac/mac_util.h"
 #include "shell/browser/ui/cocoa/electron_bundle_mover.h"
 #endif
 
@@ -354,49 +353,6 @@ struct Converter<Browser::LaunchItem> {
   }
 };
 #endif
-
-template <>
-struct Converter<Browser::LoginItemSettings> {
-  static bool FromV8(v8::Isolate* isolate,
-                     v8::Local<v8::Value> val,
-                     Browser::LoginItemSettings* out) {
-    gin_helper::Dictionary dict;
-    if (!ConvertFromV8(isolate, val, &dict))
-      return false;
-
-    dict.Get("openAtLogin", &(out->open_at_login));
-    dict.Get("openAsHidden", &(out->open_as_hidden));
-    dict.Get("path", &(out->path));
-    dict.Get("args", &(out->args));
-#if BUILDFLAG(IS_WIN)
-    dict.Get("name", &(out->name));
-    dict.Get("enabled", &(out->enabled));
-#elif BUILDFLAG(IS_MAC)
-    dict.Get("serviceName", &(out->service_name));
-    dict.Get("type", &(out->type));
-#endif
-    return true;
-  }
-
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   Browser::LoginItemSettings val) {
-    auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-#if BUILDFLAG(IS_WIN)
-    dict.Set("launchItems", val.launch_items);
-    dict.Set("executableWillLaunchAtLogin",
-             val.executable_will_launch_at_login);
-#elif BUILDFLAG(IS_MAC)
-    if (base::mac::MacOSMajorVersion() >= 13)
-      dict.Set("status", val.status);
-#endif
-    dict.Set("openAtLogin", val.open_at_login);
-    dict.Set("openAsHidden", val.open_as_hidden);
-    dict.Set("restoreState", val.restore_state);
-    dict.Set("wasOpenedAtLogin", val.opened_at_login);
-    dict.Set("wasOpenedAsHidden", val.opened_as_hidden);
-    return dict.GetHandle();
-  }
-};
 
 template <>
 struct Converter<content::CertificateRequestResultType> {
@@ -1216,8 +1172,8 @@ void App::SetAccessibilitySupportEnabled(gin_helper::ErrorThrower thrower,
   Browser::Get()->OnAccessibilitySupportChanged();
 }
 
-Browser::LoginItemSettings App::GetLoginItemSettings(gin::Arguments* args) {
-  Browser::LoginItemSettings options;
+v8::Local<v8::Value> App::GetLoginItemSettings(gin::Arguments* args) {
+  LoginItemSettings options;
   args->GetNext(&options);
   return Browser::Get()->GetLoginItemSettings(options);
 }

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -323,37 +323,6 @@ struct Converter<JumpListResult> {
 };
 #endif
 
-#if BUILDFLAG(IS_WIN)
-template <>
-struct Converter<Browser::LaunchItem> {
-  static bool FromV8(v8::Isolate* isolate,
-                     v8::Local<v8::Value> val,
-                     Browser::LaunchItem* out) {
-    gin_helper::Dictionary dict;
-    if (!ConvertFromV8(isolate, val, &dict))
-      return false;
-
-    dict.Get("name", &(out->name));
-    dict.Get("path", &(out->path));
-    dict.Get("args", &(out->args));
-    dict.Get("scope", &(out->scope));
-    dict.Get("enabled", &(out->enabled));
-    return true;
-  }
-
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   Browser::LaunchItem val) {
-    auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-    dict.Set("name", val.name);
-    dict.Set("path", val.path);
-    dict.Set("args", val.args);
-    dict.Set("scope", val.scope);
-    dict.Set("enabled", val.enabled);
-    return dict.GetHandle();
-  }
-};
-#endif
-
 template <>
 struct Converter<content::CertificateRequestResultType> {
   static bool FromV8(v8::Isolate* isolate,

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -206,7 +206,7 @@ class App : public ElectronBrowserClient::Delegate,
   bool IsAccessibilitySupportEnabled();
   void SetAccessibilitySupportEnabled(gin_helper::ErrorThrower thrower,
                                       bool enabled);
-  Browser::LoginItemSettings GetLoginItemSettings(gin::Arguments* args);
+  v8::Local<v8::Value> GetLoginItemSettings(gin::Arguments* args);
 #if BUILDFLAG(USE_NSS_CERTS)
   void ImportCertificate(gin_helper::ErrorThrower thrower,
                          base::Value options,

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -27,6 +27,10 @@
 
 namespace electron {
 
+LoginItemSettings::LoginItemSettings() = default;
+LoginItemSettings::~LoginItemSettings() = default;
+LoginItemSettings::LoginItemSettings(const LoginItemSettings& other) = default;
+
 namespace {
 
 // Call |quit| after Chromium is fully started.
@@ -48,11 +52,6 @@ Browser::LaunchItem::LaunchItem() = default;
 Browser::LaunchItem::~LaunchItem() = default;
 Browser::LaunchItem::LaunchItem(const LaunchItem& other) = default;
 #endif
-
-Browser::LoginItemSettings::LoginItemSettings() = default;
-Browser::LoginItemSettings::~LoginItemSettings() = default;
-Browser::LoginItemSettings::LoginItemSettings(const LoginItemSettings& other) =
-    default;
 
 Browser::Browser() {
   WindowList::AddObserver(this);

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -31,6 +31,12 @@ LoginItemSettings::LoginItemSettings() = default;
 LoginItemSettings::~LoginItemSettings() = default;
 LoginItemSettings::LoginItemSettings(const LoginItemSettings& other) = default;
 
+#if BUILDFLAG(IS_WIN)
+LaunchItem::LaunchItem() = default;
+LaunchItem::~LaunchItem() = default;
+LaunchItem::LaunchItem(const LaunchItem& other) = default;
+#endif
+
 namespace {
 
 // Call |quit| after Chromium is fully started.
@@ -46,12 +52,6 @@ void RunQuitClosure(base::OnceClosure quit) {
 }
 
 }  // namespace
-
-#if BUILDFLAG(IS_WIN)
-Browser::LaunchItem::LaunchItem() = default;
-Browser::LaunchItem::~LaunchItem() = default;
-Browser::LaunchItem::LaunchItem(const LaunchItem& other) = default;
-#endif
 
 Browser::Browser() {
   WindowList::AddObserver(this);

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -42,6 +42,20 @@ namespace electron {
 
 class ElectronMenuModel;
 
+#if BUILDFLAG(IS_WIN)
+struct LaunchItem {
+  std::wstring name;
+  std::wstring path;
+  std::wstring scope;
+  std::vector<std::wstring> args;
+  bool enabled = true;
+
+  LaunchItem();
+  ~LaunchItem();
+  LaunchItem(const LaunchItem&);
+};
+#endif
+
 struct LoginItemSettings {
   bool open_at_login = false;
   bool open_as_hidden = false;
@@ -140,20 +154,6 @@ class Browser : public WindowListObserver {
   // Set/Get the badge count.
   bool SetBadgeCount(std::optional<int> count);
   [[nodiscard]] int badge_count() const { return badge_count_; }
-
-#if BUILDFLAG(IS_WIN)
-  struct LaunchItem {
-    std::wstring name;
-    std::wstring path;
-    std::wstring scope;
-    std::vector<std::wstring> args;
-    bool enabled = true;
-
-    LaunchItem();
-    ~LaunchItem();
-    LaunchItem(const LaunchItem&);
-  };
-#endif
 
   void SetLoginItemSettings(LoginItemSettings settings);
   v8::Local<v8::Value> GetLoginItemSettings(const LoginItemSettings& options);

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -17,6 +17,7 @@
 #include "gin/dictionary.h"
 #include "shell/browser/browser_observer.h"
 #include "shell/browser/window_list_observer.h"
+#include "shell/common/gin_converters/login_item_settings_converter.h"
 #include "shell/common/gin_helper/promise.h"
 
 #if BUILDFLAG(IS_WIN)
@@ -40,6 +41,34 @@ class Arguments;
 namespace electron {
 
 class ElectronMenuModel;
+
+struct LoginItemSettings {
+  bool open_at_login = false;
+  bool open_as_hidden = false;
+  bool restore_state = false;
+  bool opened_at_login = false;
+  bool opened_as_hidden = false;
+  std::u16string path;
+  std::vector<std::u16string> args;
+
+#if BUILDFLAG(IS_MAC)
+  std::string type = "mainAppService";
+  std::string service_name;
+  std::string status;
+#elif BUILDFLAG(IS_WIN)
+  // used in browser::setLoginItemSettings
+  bool enabled = true;
+  std::wstring name;
+
+  // used in browser::getLoginItemSettings
+  bool executable_will_launch_at_login = false;
+  std::vector<LaunchItem> launch_items;
+#endif
+
+  LoginItemSettings();
+  ~LoginItemSettings();
+  LoginItemSettings(const LoginItemSettings&);
+};
 
 // This class is used for control application-wide operations.
 class Browser : public WindowListObserver {
@@ -126,36 +155,8 @@ class Browser : public WindowListObserver {
   };
 #endif
 
-  // Set/Get the login item settings of the app
-  struct LoginItemSettings {
-    bool open_at_login = false;
-    bool open_as_hidden = false;
-    bool restore_state = false;
-    bool opened_at_login = false;
-    bool opened_as_hidden = false;
-    std::u16string path;
-    std::vector<std::u16string> args;
-
-#if BUILDFLAG(IS_MAC)
-    std::string type = "mainAppService";
-    std::string service_name;
-    std::string status;
-#elif BUILDFLAG(IS_WIN)
-    // used in browser::setLoginItemSettings
-    bool enabled = true;
-    std::wstring name;
-
-    // used in browser::getLoginItemSettings
-    bool executable_will_launch_at_login = false;
-    std::vector<LaunchItem> launch_items;
-#endif
-
-    LoginItemSettings();
-    ~LoginItemSettings();
-    LoginItemSettings(const LoginItemSettings&);
-  };
   void SetLoginItemSettings(LoginItemSettings settings);
-  LoginItemSettings GetLoginItemSettings(const LoginItemSettings& options);
+  v8::Local<v8::Value> GetLoginItemSettings(const LoginItemSettings& options);
 
 #if BUILDFLAG(IS_MAC)
   // Set the handler which decides whether to shutdown.

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -11,9 +11,11 @@
 #include "base/environment.h"
 #include "base/process/launch.h"
 #include "electron/electron_version.h"
+#include "shell/browser/javascript_environment.h"
 #include "shell/browser/native_window.h"
 #include "shell/browser/window_list.h"
 #include "shell/common/application_info.h"
+#include "shell/common/gin_converters/login_item_settings_converter.h"
 #include "shell/common/thread_restrictions.h"
 
 #if BUILDFLAG(IS_LINUX)
@@ -138,9 +140,10 @@ bool Browser::SetBadgeCount(std::optional<int> count) {
 
 void Browser::SetLoginItemSettings(LoginItemSettings settings) {}
 
-Browser::LoginItemSettings Browser::GetLoginItemSettings(
+v8::Local<v8::Value> Browser::GetLoginItemSettings(
     const LoginItemSettings& options) {
-  return LoginItemSettings();
+  LoginItemSettings settings;
+  return gin::ConvertToV8(JavascriptEnvironment::GetIsolate(), settings);
 }
 
 std::string Browser::GetExecutableFileVersion() const {

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -30,12 +30,14 @@
 #include "shell/browser/api/electron_api_app.h"
 #include "shell/browser/badging/badge_manager.h"
 #include "shell/browser/electron_browser_main_parts.h"
+#include "shell/browser/javascript_environment.h"
 #include "shell/browser/ui/message_box.h"
 #include "shell/browser/ui/win/jump_list.h"
 #include "shell/browser/window_list.h"
 #include "shell/common/application_info.h"
 #include "shell/common/gin_converters/file_path_converter.h"
 #include "shell/common/gin_converters/image_converter.h"
+#include "shell/common/gin_converters/login_item_settings_converter.h"
 #include "shell/common/gin_helper/arguments.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/skia_util.h"
@@ -158,7 +160,7 @@ std::vector<Browser::LaunchItem> GetLoginItemSettingsHelper(
     base::win::RegistryValueIterator* it,
     boolean* executable_will_launch_at_login,
     std::wstring scope,
-    const Browser::LoginItemSettings& options) {
+    const LoginItemSettings& options) {
   std::vector<Browser::LaunchItem> launch_items;
 
   base::FilePath lookup_exe_path;
@@ -656,7 +658,7 @@ void Browser::SetLoginItemSettings(LoginItemSettings settings) {
   }
 }
 
-Browser::LoginItemSettings Browser::GetLoginItemSettings(
+v8::Local<v8::Value> Browser::GetLoginItemSettings(
     const LoginItemSettings& options) {
   LoginItemSettings settings;
   std::wstring keyPath = L"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
@@ -692,7 +694,7 @@ Browser::LoginItemSettings Browser::GetLoginItemSettings(
 
   settings.executable_will_launch_at_login = executable_will_launch_at_login;
   settings.launch_items = launch_items;
-  return settings;
+  return gin::ConvertToV8(JavascriptEnvironment::GetIsolate(), settings);
 }
 
 PCWSTR Browser::GetAppUserModelID() {

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -156,12 +156,12 @@ bool FormatCommandLineString(std::wstring* exe,
 // a list of launchItem with matching paths to our application.
 // if a launchItem with a matching path also has a matching entry within the
 // startup_approved_key_path, set executable_will_launch_at_login to be `true`
-std::vector<Browser::LaunchItem> GetLoginItemSettingsHelper(
+std::vector<LaunchItem> GetLoginItemSettingsHelper(
     base::win::RegistryValueIterator* it,
     boolean* executable_will_launch_at_login,
     std::wstring scope,
     const LoginItemSettings& options) {
-  std::vector<Browser::LaunchItem> launch_items;
+  std::vector<LaunchItem> launch_items;
 
   base::FilePath lookup_exe_path;
   if (options.path.empty()) {
@@ -185,7 +185,7 @@ std::vector<Browser::LaunchItem> GetLoginItemSettingsHelper(
 
       // add launch item to vector if it has a matching path (case-insensitive)
       if (exe_match) {
-        Browser::LaunchItem launch_item;
+        LaunchItem launch_item;
         launch_item.name = it->Name();
         launch_item.path = registry_launch_path.value();
         launch_item.args = registry_launch_cmd.GetArgs();
@@ -677,7 +677,7 @@ v8::Local<v8::Value> Browser::GetLoginItemSettings(
   // if there exists a launch entry with property enabled=='true',
   // set executable_will_launch_at_login to 'true'.
   boolean executable_will_launch_at_login = false;
-  std::vector<Browser::LaunchItem> launch_items;
+  std::vector<LaunchItem> launch_items;
   base::win::RegistryValueIterator hkcu_iterator(HKEY_CURRENT_USER,
                                                  keyPath.c_str());
   base::win::RegistryValueIterator hklm_iterator(HKEY_LOCAL_MACHINE,
@@ -685,10 +685,8 @@ v8::Local<v8::Value> Browser::GetLoginItemSettings(
 
   launch_items = GetLoginItemSettingsHelper(
       &hkcu_iterator, &executable_will_launch_at_login, L"user", options);
-  std::vector<Browser::LaunchItem> launch_items_hklm =
-      GetLoginItemSettingsHelper(&hklm_iterator,
-                                 &executable_will_launch_at_login, L"machine",
-                                 options);
+  std::vector<LaunchItem> launch_items_hklm = GetLoginItemSettingsHelper(
+      &hklm_iterator, &executable_will_launch_at_login, L"machine", options);
   launch_items.insert(launch_items.end(), launch_items_hklm.begin(),
                       launch_items_hklm.end());
 

--- a/shell/common/gin_converters/login_item_settings_converter.cc
+++ b/shell/common/gin_converters/login_item_settings_converter.cc
@@ -13,6 +13,35 @@
 
 namespace gin {
 
+#if BUILDFLAG(IS_WIN)
+bool Converter<electron::LaunchItem>::FromV8(v8::Isolate* isolate,
+                                             v8::Local<v8::Value> val,
+                                             electron::LaunchItem* out) {
+  gin_helper::Dictionary dict;
+  if (!ConvertFromV8(isolate, val, &dict))
+    return false;
+
+  dict.Get("name", &(out->name));
+  dict.Get("path", &(out->path));
+  dict.Get("args", &(out->args));
+  dict.Get("scope", &(out->scope));
+  dict.Get("enabled", &(out->enabled));
+  return true;
+}
+
+v8::Local<v8::Value> Converter<electron::LaunchItem>::ToV8(
+    v8::Isolate* isolate,
+    electron::LaunchItem val) {
+  auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
+  dict.Set("name", val.name);
+  dict.Set("path", val.path);
+  dict.Set("args", val.args);
+  dict.Set("scope", val.scope);
+  dict.Set("enabled", val.enabled);
+  return dict.GetHandle();
+}
+#endif
+
 bool Converter<electron::LoginItemSettings>::FromV8(
     v8::Isolate* isolate,
     v8::Local<v8::Value> val,
@@ -35,7 +64,6 @@ bool Converter<electron::LoginItemSettings>::FromV8(
   return true;
 }
 
-// static
 v8::Local<v8::Value> Converter<electron::LoginItemSettings>::ToV8(
     v8::Isolate* isolate,
     electron::LoginItemSettings val) {

--- a/shell/common/gin_converters/login_item_settings_converter.cc
+++ b/shell/common/gin_converters/login_item_settings_converter.cc
@@ -1,0 +1,58 @@
+// Copyright (c) 2024 Microsoft, GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/common/gin_converters/login_item_settings_converter.h"
+
+#if BUILDFLAG(IS_MAC)
+#include "base/mac/mac_util.h"
+#endif
+
+#include "shell/browser/browser.h"
+#include "shell/common/gin_helper/dictionary.h"
+
+namespace gin {
+
+bool Converter<electron::LoginItemSettings>::FromV8(
+    v8::Isolate* isolate,
+    v8::Local<v8::Value> val,
+    electron::LoginItemSettings* out) {
+  gin_helper::Dictionary dict;
+  if (!ConvertFromV8(isolate, val, &dict))
+    return false;
+
+  dict.Get("openAtLogin", &(out->open_at_login));
+  dict.Get("openAsHidden", &(out->open_as_hidden));
+  dict.Get("path", &(out->path));
+  dict.Get("args", &(out->args));
+#if BUILDFLAG(IS_WIN)
+  dict.Get("name", &(out->name));
+  dict.Get("enabled", &(out->enabled));
+#elif BUILDFLAG(IS_MAC)
+  dict.Get("serviceName", &(out->service_name));
+  dict.Get("type", &(out->type));
+#endif
+  return true;
+}
+
+// static
+v8::Local<v8::Value> Converter<electron::LoginItemSettings>::ToV8(
+    v8::Isolate* isolate,
+    electron::LoginItemSettings val) {
+  auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
+#if BUILDFLAG(IS_WIN)
+  dict.Set("launchItems", val.launch_items);
+  dict.Set("executableWillLaunchAtLogin", val.executable_will_launch_at_login);
+#elif BUILDFLAG(IS_MAC)
+  if (base::mac::MacOSMajorVersion() >= 13)
+    dict.Set("status", val.status);
+#endif
+  dict.Set("openAtLogin", val.open_at_login);
+  dict.Set("openAsHidden", val.open_as_hidden);
+  dict.Set("restoreState", val.restore_state);
+  dict.Set("wasOpenedAtLogin", val.opened_at_login);
+  dict.Set("wasOpenedAsHidden", val.opened_as_hidden);
+  return dict.GetHandle();
+}
+
+}  // namespace gin

--- a/shell/common/gin_converters/login_item_settings_converter.h
+++ b/shell/common/gin_converters/login_item_settings_converter.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2024 Microsoft, GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_COMMON_GIN_CONVERTERS_LOGIN_ITEM_SETTINGS_CONVERTER_H_
+#define ELECTRON_SHELL_COMMON_GIN_CONVERTERS_LOGIN_ITEM_SETTINGS_CONVERTER_H_
+
+#include "gin/converter.h"
+
+namespace electron {
+struct LoginItemSettings;
+}  // namespace electron
+
+namespace gin {
+
+template <>
+struct Converter<electron::LoginItemSettings> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   electron::LoginItemSettings val);
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     electron::LoginItemSettings* out);
+};
+
+}  // namespace gin
+
+#endif  // ELECTRON_SHELL_COMMON_GIN_CONVERTERS_LOGIN_ITEM_SETTINGS_CONVERTER_H_

--- a/shell/common/gin_converters/login_item_settings_converter.h
+++ b/shell/common/gin_converters/login_item_settings_converter.h
@@ -9,9 +9,21 @@
 
 namespace electron {
 struct LoginItemSettings;
+struct LaunchItem;
 }  // namespace electron
 
 namespace gin {
+
+#if BUILDFLAG(IS_WIN)
+template <>
+struct Converter<electron::LaunchItem> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   electron::LaunchItem val);
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     electron::LaunchItem* out);
+};
+#endif
 
 template <>
 struct Converter<electron::LoginItemSettings> {

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -760,8 +760,7 @@ describe('app module', () => {
         }).to.throw(/'name' is required when type is not mainAppService/);
       });
 
-      // TODO this test does not work on CircleCI arm64 macs
-      ifit(isVenturaOrHigher && process.arch !== 'arm64')('throws when getting non-default type with no name', () => {
+      ifit(isVenturaOrHigher)('throws when getting non-default type with no name', () => {
         expect(() => {
           app.getLoginItemSettings({
             type: 'daemonService'


### PR DESCRIPTION
#### Description of Change

Fixes an issue where errors thrown `app.setLoginItemSettings` would be silently swallowed and the object returned. To fix this, we return a `v8::Local<v8::Value>` and shift the conversion locale.

This was missed in our tests as our machines weren't running a high enough version of macOS.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `app.getLoginItemSettings` didn't correctly throw errors.
