### PR TITLE
test: add test and `api_feature` definition for `chrome.scripting.globalParams`

### DIFF
--- a/shell/common/extensions/api/_api_features.json
+++ b/shell/common/extensions/api/_api_features.json
@@ -39,6 +39,14 @@
     "contexts": ["blessed_extension", "unblessed_extension", "content_script"],
     "max_manifest_version": 2
   },
+  "extension.lastError": {
+    "contexts": [
+      "blessed_extension",
+      "unblessed_extension",
+      "content_script"
+    ],
+    "max_manifest_version": 2
+  },
   "i18n": {
     "channel": "stable",
     "extension_types": ["extension"],
@@ -68,5 +76,10 @@
   "scripting": {
     "dependencies": ["permission:scripting"],
     "contexts": ["blessed_extension"]
+  },
+  "scripting.globalParams": {
+    "channel": "trunk",
+    "dependencies": ["permission:scripting"],
+    "contexts": ["content_script"]
   }
 }

--- a/spec/extensions-spec.ts
+++ b/spec/extensions-spec.ts
@@ -1285,6 +1285,16 @@ describe('chrome extensions', () => {
         });
       });
 
+      it('globalParams', async () => {
+        await w.loadURL(url);
+
+        const message = { method: 'globalParams' };
+        w.webContents.executeJavaScript(`window.postMessage('${JSON.stringify(message)}', '*')`);
+        const [,, responseString] = await once(w.webContents, 'console-message');
+        const response = JSON.parse(responseString);
+        expect(response).to.deep.equal({ changed: true });
+      });
+
       it('insertCSS', async () => {
         await w.loadURL(url);
 

--- a/spec/fixtures/extensions/chrome-scripting/background.js
+++ b/spec/fixtures/extensions/chrome-scripting/background.js
@@ -20,6 +20,27 @@ const handleRequest = async (request, sender, sendResponse) => {
       break;
     }
 
+    case 'globalParams' : {
+      await chrome.scripting.executeScript({
+        target: { tabId },
+        func: () => {
+          chrome.scripting.globalParams.changed = true;
+        },
+        world: 'ISOLATED'
+      });
+
+      const results = await chrome.scripting.executeScript({
+        target: { tabId },
+        func: () => JSON.stringify(chrome.scripting.globalParams),
+        world: 'ISOLATED'
+      });
+
+      const result = JSON.parse(results[0].result);
+
+      sendResponse(result);
+      break;
+    }
+
     case 'registerContentScripts': {
       await chrome.scripting.registerContentScripts([{
         id: 'session-script',

--- a/spec/fixtures/extensions/chrome-scripting/main.js
+++ b/spec/fixtures/extensions/chrome-scripting/main.js
@@ -19,6 +19,11 @@ const map = {
     chrome.runtime.sendMessage({ method: 'insertCSS' }, response => {
       console.log(JSON.stringify(response));
     });
+  },
+  globalParams () {
+    chrome.runtime.sendMessage({ method: 'globalParams' }, response => {
+      console.log(JSON.stringify(response));
+    });
   }
 };
 


### PR DESCRIPTION
#### Description of Change

Adds a test and `_api_features.json` definition for `chrome.scripting.globalParams`. Also adds a missing `extension.lastError` definition and manifest cap.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none