### PR TITLE
fix: don't do self-destroy in LibnotifyNotification::Dismiss()

### DIFF
--- a/shell/browser/notifications/linux/libnotify_notification.cc
+++ b/shell/browser/notifications/linux/libnotify_notification.cc
@@ -159,21 +159,21 @@ void LibnotifyNotification::Show(const NotificationOptions& options) {
 
 void LibnotifyNotification::Dismiss() {
   if (!notification_) {
-    Destroy();
     return;
   }
 
   GError* error = nullptr;
+  on_dismissing_ = true;
   libnotify_loader_.notify_notification_close(notification_, &error);
   if (error) {
     log_and_clear_error(error, "notify_notification_close");
-    Destroy();
   }
+  on_dismissing_ = false;
 }
 
 void LibnotifyNotification::OnNotificationClosed(
     NotifyNotification* notification) {
-  NotificationDismissed();
+  NotificationDismissed(!on_dismissing_);
 }
 
 void LibnotifyNotification::OnNotificationView(NotifyNotification* notification,

--- a/shell/browser/notifications/linux/libnotify_notification.h
+++ b/shell/browser/notifications/linux/libnotify_notification.h
@@ -33,6 +33,7 @@ class LibnotifyNotification : public Notification {
   RAW_PTR_EXCLUSION NotifyNotification* notification_ = nullptr;
 
   ScopedGSignal signal_;
+  bool on_dismissing_ = false;
 };
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Callers of `Notification::Dismiss()` assume that the notification instance is not deleted after the call, but this was not the case for `LibnotifyNotification`:
- `Destroy()` would get `this` deleted.
- `notify_notification_close()` in portal environment triggers `LibnotifyNotification::OnNotificationClosed()`, and finally calls `Destroy()`

This patch removes all `Destroy()` in `Dismiss()`, and adds a boolean to tell whether `notify_notification_close()` is running, to avoid crash under portal environment.

Fixes #40461.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed crash in Notification::Close() under libnotify 0.8.x with portal environment. <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
