### PR TITLE
ci: fix add issues labels workflow when backticks present

### DIFF
--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -47,7 +47,7 @@ jobs:
             const [ owner, repo ] = '${{ github.repository }}'.split('/');
             const issue_number = ${{ github.event.issue.number }};
 
-            const tree = fromMarkdown(`${{ github.event.issue.body }}`);
+            const tree = fromMarkdown(${{ toJSON(github.event.issue.body) }});
 
             const labels = [];
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Previous implementation would fail if the issue body included backticks. Using `${{ toJSON(...) }}` will pop out a double-quoted string with any double-quotes in the body escaped, so it should handle all cases.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
