### PR TITLE
test: disable flaky `<webview>.capturePage()` specs

### DIFF
--- a/spec/webview-spec.ts
+++ b/spec/webview-spec.ts
@@ -14,8 +14,6 @@ import { HexColors, ScreenCapture } from './lib/screen-helpers';
 declare let WebView: any;
 const features = process._linkedBinding('electron_common_features');
 
-const isMacArm64 = (process.platform === 'darwin' && process.arch === 'arm64');
-
 async function loadWebView (w: WebContents, attributes: Record<string, string>, opts?: {openDevTools?: boolean}): Promise<void> {
   const { openDevTools } = {
     openDevTools: false,
@@ -2107,9 +2105,8 @@ describe('<webview> tag', function () {
       }
     });
 
-    // TODO(miniak): figure out why this is failing on windows
-    // TODO(vertedinde): figure out why this is failing on mac arm64
-    ifdescribe(process.platform !== 'win32' && !isMacArm64)('<webview>.capturePage()', () => {
+    // FIXME: This test is flaking constantly on Linux and macOS.
+    xdescribe('<webview>.capturePage()', () => {
       it('returns a Promise with a NativeImage', async function () {
         this.retries(5);
 


### PR DESCRIPTION
#### Description of Change

Flaking on Linux and macOS x64 too now:
* https://app.circleci.com/pipelines/github/electron/electron/79689/workflows/07ff3787-8219-45b3-8027-13f5ffce97d3/jobs/1693178/tests
* https://app.circleci.com/pipelines/github/electron/electron/79689/workflows/0acb9086-8617-49b5-8f47-977904c4cc12/jobs/1693219/tests

Disable entirely to get CI back to green.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none