### PR TITLE
fix: `Storage.{get|set|clear}Cookies` via CDP not working

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -962,7 +962,8 @@ content::MediaObserver* ElectronBrowserClient::GetMediaObserver() {
 
 std::unique_ptr<content::DevToolsManagerDelegate>
 ElectronBrowserClient::CreateDevToolsManagerDelegate() {
-  return std::make_unique<DevToolsManagerDelegate>();
+  auto* context = ElectronBrowserContext::From("", false);
+  return std::make_unique<DevToolsManagerDelegate>(context);
 }
 
 NotificationPresenter* ElectronBrowserClient::GetNotificationPresenter() {

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -962,8 +962,7 @@ content::MediaObserver* ElectronBrowserClient::GetMediaObserver() {
 
 std::unique_ptr<content::DevToolsManagerDelegate>
 ElectronBrowserClient::CreateDevToolsManagerDelegate() {
-  auto* context = ElectronBrowserContext::From("", false);
-  return std::make_unique<DevToolsManagerDelegate>(context);
+  return std::make_unique<DevToolsManagerDelegate>();
 }
 
 NotificationPresenter* ElectronBrowserClient::GetNotificationPresenter() {

--- a/shell/browser/ui/devtools_manager_delegate.cc
+++ b/shell/browser/ui/devtools_manager_delegate.cc
@@ -15,6 +15,7 @@
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "chrome/common/chrome_paths.h"
+#include "content/public/browser/browser_context.h"
 #include "content/public/browser/devtools_agent_host.h"
 #include "content/public/browser/devtools_frontend_host.h"
 #include "content/public/browser/devtools_socket_factory.h"
@@ -97,7 +98,9 @@ void DevToolsManagerDelegate::StartHttpHandler() {
       CreateSocketFactory(), session_data, base::FilePath());
 }
 
-DevToolsManagerDelegate::DevToolsManagerDelegate() = default;
+DevToolsManagerDelegate::DevToolsManagerDelegate(
+    content::BrowserContext* browser_context)
+    : browser_context_(browser_context) {}
 
 DevToolsManagerDelegate::~DevToolsManagerDelegate() = default;
 
@@ -137,6 +140,10 @@ std::string DevToolsManagerDelegate::GetDiscoveryPageHTML() {
 
 bool DevToolsManagerDelegate::HasBundledFrontendResources() {
   return true;
+}
+
+content::BrowserContext* DevToolsManagerDelegate::GetDefaultBrowserContext() {
+  return browser_context_;
 }
 
 }  // namespace electron

--- a/shell/browser/ui/devtools_manager_delegate.cc
+++ b/shell/browser/ui/devtools_manager_delegate.cc
@@ -15,7 +15,6 @@
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "chrome/common/chrome_paths.h"
-#include "content/public/browser/browser_context.h"
 #include "content/public/browser/devtools_agent_host.h"
 #include "content/public/browser/devtools_frontend_host.h"
 #include "content/public/browser/devtools_socket_factory.h"
@@ -29,6 +28,7 @@
 #include "net/socket/stream_socket.h"
 #include "net/socket/tcp_server_socket.h"
 #include "shell/browser/browser.h"
+#include "shell/browser/electron_browser_context.h"
 #include "shell/common/electron_paths.h"
 #include "third_party/inspector_protocol/crdtp/dispatch.h"
 #include "ui/base/resource/resource_bundle.h"
@@ -98,9 +98,7 @@ void DevToolsManagerDelegate::StartHttpHandler() {
       CreateSocketFactory(), session_data, base::FilePath());
 }
 
-DevToolsManagerDelegate::DevToolsManagerDelegate(
-    content::BrowserContext* browser_context)
-    : browser_context_(browser_context) {}
+DevToolsManagerDelegate::DevToolsManagerDelegate() = default;
 
 DevToolsManagerDelegate::~DevToolsManagerDelegate() = default;
 
@@ -143,7 +141,7 @@ bool DevToolsManagerDelegate::HasBundledFrontendResources() {
 }
 
 content::BrowserContext* DevToolsManagerDelegate::GetDefaultBrowserContext() {
-  return browser_context_;
+  return ElectronBrowserContext::From("", false);
 }
 
 }  // namespace electron

--- a/shell/browser/ui/devtools_manager_delegate.h
+++ b/shell/browser/ui/devtools_manager_delegate.h
@@ -10,13 +10,17 @@
 #include "base/compiler_specific.h"
 #include "content/public/browser/devtools_manager_delegate.h"
 
+namespace content {
+class BrowserContext;
+}
+
 namespace electron {
 
 class DevToolsManagerDelegate : public content::DevToolsManagerDelegate {
  public:
   static void StartHttpHandler();
 
-  DevToolsManagerDelegate();
+  explicit DevToolsManagerDelegate(content::BrowserContext* browser_context);
   ~DevToolsManagerDelegate() override;
 
   // disable copy
@@ -33,6 +37,10 @@ class DevToolsManagerDelegate : public content::DevToolsManagerDelegate {
       TargetType target_type) override;
   std::string GetDiscoveryPageHTML() override;
   bool HasBundledFrontendResources() override;
+  content::BrowserContext* GetDefaultBrowserContext() override;
+
+ private:
+  raw_ptr<content::BrowserContext> browser_context_;
 };
 
 }  // namespace electron

--- a/shell/browser/ui/devtools_manager_delegate.h
+++ b/shell/browser/ui/devtools_manager_delegate.h
@@ -20,7 +20,7 @@ class DevToolsManagerDelegate : public content::DevToolsManagerDelegate {
  public:
   static void StartHttpHandler();
 
-  explicit DevToolsManagerDelegate(content::BrowserContext* browser_context);
+  DevToolsManagerDelegate();
   ~DevToolsManagerDelegate() override;
 
   // disable copy
@@ -38,9 +38,6 @@ class DevToolsManagerDelegate : public content::DevToolsManagerDelegate {
   std::string GetDiscoveryPageHTML() override;
   bool HasBundledFrontendResources() override;
   content::BrowserContext* GetDefaultBrowserContext() override;
-
- private:
-  raw_ptr<content::BrowserContext> browser_context_;
 };
 
 }  // namespace electron

--- a/spec/api-debugger-spec.ts
+++ b/spec/api-debugger-spec.ts
@@ -177,6 +177,38 @@ describe('debugger module', () => {
       await loadingFinished;
     });
 
+    it('can get and set cookies using the Storage API', async () => {
+      await w.webContents.loadURL('about:blank');
+      w.webContents.debugger.attach('1.1');
+
+      await w.webContents.debugger.sendCommand('Storage.clearCookies', {});
+      await w.webContents.debugger.sendCommand('Storage.setCookies', {
+        cookies: [
+          {
+            name: 'cookieOne',
+            value: 'cookieValueOne',
+            url: 'https://cookieone.com'
+          },
+          {
+            name: 'cookieTwo',
+            value: 'cookieValueTwo',
+            url: 'https://cookietwo.com'
+          }
+        ]
+      });
+
+      const { cookies } = await w.webContents.debugger.sendCommand('Storage.getCookies', {});
+      expect(cookies).to.have.lengthOf(2);
+
+      const cookieOne = cookies.find((cookie: any) => cookie.name === 'cookieOne');
+      expect(cookieOne.domain).to.equal('cookieone.com');
+      expect(cookieOne.value).to.equal('cookieValueOne');
+
+      const cookieTwo = cookies.find((cookie: any) => cookie.name === 'cookieTwo');
+      expect(cookieTwo.domain).to.equal('cookietwo.com');
+      expect(cookieTwo.value).to.equal('cookieValueTwo');
+    });
+
     it('uses empty sessionId by default', async () => {
       w.webContents.loadURL('about:blank');
       w.webContents.debugger.attach();


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/41703.

Addresses an issue where calling `Storage.{get|set|clear}Cookies` via the Chrome Devtools protocol would return the following error:

> Browser context management is not supported.

This happened as a result of [this logic](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/devtools/protocol/storage_handler.cc;l=957;drc=05bb4ce2df79db9c7f4fd9ef1856f0c41bca440f;bpv=1;bpt=1) for Storage handling which relies on a browser context being available via `DevToolsManagerDelegate::GetDefaultBrowserContext()`. Chrome's subclasses of `DevToolsManagerDelegate` override this to return a valid `BrowserContext`, but ours did not until this PR and so it would always be nullptr.

We can address this by returning the default `BrowserContext` in our subclass. This is modeled after the approach taken by [`ShellDevToolsManagerDelegate::GetDefaultBrowserContext()`](https://source.chromium.org/chromium/chromium/src/+/main:content/shell/browser/shell_devtools_manager_delegate.cc;drc=05bb4ce2df79db9c7f4fd9ef1856f0c41bca440f;bpv=1;bpt=1;l=192).

cc @mxschmitt 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed usage of `Storage.{get|set|clear}Cookies` via the Chrome DevTools Protocol.
