### PR TITLE
docs: add missing headers option to ClientRequest options

### DIFF
--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -17,6 +17,8 @@ following properties:
     method.
   * `url` string (optional) - The request URL. Must be provided in the absolute
     form with the protocol scheme specified as http or https.
+  * `headers` Record<string, string | string[]> (optional) - Headers to be sent
+    with the request.
   * `session` Session (optional) - The [`Session`](session.md) instance with
     which the request is associated.
   * `partition` string (optional) - The name of the [`partition`](session.md)

--- a/spec/api-net-spec.ts
+++ b/spec/api-net-spec.ts
@@ -935,12 +935,11 @@ describe('net module', () => {
           response.end();
         });
         const serverUrl = url.parse(serverUrlUnparsed);
-        const options = {
+        const urlRequest = net.request({
           port: serverUrl.port ? parseInt(serverUrl.port, 10) : undefined,
           hostname: '127.0.0.1',
           headers: { [customHeaderName]: customHeaderValue }
-        };
-        const urlRequest = net.request(options);
+        });
         const response = await getResponse(urlRequest);
         expect(response.statusCode).to.be.equal(200);
         await collectStreamBody(response);


### PR DESCRIPTION
#### Description of Change

As pointed out by @daihere1993, this option was supported but missing from the
types/docs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added missing documentation for `headers` option in ClientRequest.
