### PR TITLE
fix: do not activate app when showing a panel on Mac

### DIFF
--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -176,6 +176,8 @@ class NativeWindowMac : public NativeWindow,
 
   void UpdateWindowOriginalFrame();
 
+  bool IsPanel();
+
   // Set the attribute of NSWindow while work around a bug of zoom button.
   bool HasStyleMask(NSUInteger flag) const;
   void SetStyleMask(bool on, NSUInteger flag);

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1246,7 +1246,6 @@ describe('BrowserWindow module', () => {
         }
       });
 
-      // FIXME: disabled in `disabled-tests.json`
       ifit(process.platform === 'darwin')('it does not activate the app if focusing an inactive panel', async () => {
         // Show to focus app, then remove existing window
         w.show();
@@ -1269,7 +1268,7 @@ describe('BrowserWindow module', () => {
         const isShow = once(w, 'show');
         const isFocus = once(w, 'focus');
 
-        w.showInactive();
+        w.show();
         w.focus();
 
         await isShow;

--- a/spec/disabled-tests.json
+++ b/spec/disabled-tests.json
@@ -7,6 +7,5 @@
   "session module ses.cookies should set cookie for standard scheme",
   "webFrameMain module WebFrame.visibilityState should match window state",
   "reporting api sends a report for a deprecation",
-  "chromium features SpeechSynthesis should emit lifecycle events",
-  "BrowserWindow module focus and visibility BrowserWindow.focus() it does not activate the app if focusing an inactive panel"
+  "chromium features SpeechSynthesis should emit lifecycle events"
 ]


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Resolves https://github.com/electron/electron/issues/41273.

This is a follow-up to https://github.com/electron/electron/pull/40307 and https://github.com/electron/electron/pull/40570 to make sure that panel windows can be both shown and focused without activating the app. The previous attempts had a few issues:

1. The `IsPanel()` function checked for `NSPanel`. But Electron "panel" windows are not true panels, they are `ElectronPanelWindow` which inherit from `NSWindow` without going through `NSPanel` at all. So this function never actually returned true. 
2. The logic to avoid activation relied on the flaky/situational/deprecated `activateIgnoringOtherApps:NO`. It is better to simply not make any call to activate the app at all when focusing a panel window.
3. Activation handling was included in `Focus()` but not in `Show()`, which also activates the app but should not do so in the case of panel windows to support Spotlight-like workflows .

This MR avoids relying on the deprecated function in Sonoma+, applies the same logic to Focus() and Show(), and does not activate the app if the window is a panel.

Tagging @felixrieseberg who last worked on this panel code for thoughts on this approach.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where showing or focusing a panel window would activate the app on Mac.