### PR TITLE
build: add Markdown lint check for unescaped angle brackets

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,3 +1,17 @@
 {
-  "extends": "@electron/lint-roller/configs/markdownlint.json"
+  "extends": "@electron/lint-roller/configs/markdownlint.json",
+  "no-angle-brackets": true,
+  "no-inline-html": {
+    "allowed_elements": [
+      "br",
+      "details",
+      "img",
+      "li",
+      "summary",
+      "ul",
+      "unknown",
+      "Tabs",
+      "TabItem",
+    ]
+  }
 }

--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -17,7 +17,7 @@ following properties:
     method.
   * `url` string (optional) - The request URL. Must be provided in the absolute
     form with the protocol scheme specified as http or https.
-  * `headers` Record<string, string | string[]> (optional) - Headers to be sent
+  * `headers` Record\<string, string | string[]\> (optional) - Headers to be sent
     with the request.
   * `session` Session (optional) - The [`Session`](session.md) instance with
     which the request is associated.

--- a/docs/tutorial/tutorial-2-first-app.md
+++ b/docs/tutorial/tutorial-2-first-app.md
@@ -234,7 +234,7 @@ Notification) whereas camelCase modules are not instantiable (e.g. app, ipcRende
 <details><summary>Typed import aliases</summary>
 
 For better type checking when writing TypeScript code, you can choose to import
-main process modules from <code>electron/main</code>.
+main process modules from `electron/main`.
 
 ```js
 const { app, BrowserWindow } = require('electron/main')

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@electron/docs-parser": "^1.2.0",
     "@electron/fiddle-core": "^1.0.4",
     "@electron/github-app-auth": "^2.0.0",
-    "@electron/lint-roller": "^1.9.0",
+    "@electron/lint-roller": "^1.12.1",
     "@electron/typescript-definitions": "^8.15.2",
     "@octokit/rest": "^19.0.7",
     "@primer/octicons": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,10 +199,10 @@
     "@octokit/auth-app" "^4.0.13"
     "@octokit/rest" "^19.0.11"
 
-"@electron/lint-roller@^1.9.0":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@electron/lint-roller/-/lint-roller-1.11.1.tgz#bf4ab114e8cb3a77e2c634807d4af3d40c3ba863"
-  integrity sha512-LfErOK5MnSmoSyVN5OnHWsQ8p5It8JBE0AmRYCx65WS4BZudnYeRcohlRSOSi+GGqldujdKHyEo+fdY5lREL/Q==
+"@electron/lint-roller@^1.12.1":
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/@electron/lint-roller/-/lint-roller-1.12.1.tgz#3152b9a68815b2ab51cc5a4d462ae6769d5052ce"
+  integrity sha512-TGgVcHUAooM9/dV3iJTxhmKl35x/gzStsClz2/LWtBQZ59cRK+0YwWF5HWhtydGFIpOLEQGzCvUrty5zZLyd4w==
   dependencies:
     "@dsanders11/vscode-markdown-languageservice" "^0.3.0"
     balanced-match "^2.0.0"


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Follow-up to #41575 which adds a linting rule to enforce escaped angle brackets (technically only the opening one, since that's all that's needed to avoid the MDX issues). Includes a case that was missed in the original PR.

Also enables the `no-inline-html` rule (with certain elements allowed) as some usages of angle brackets will be considered as inline HTML by `markdown-it`, so we need a combination of both rules to ensure we catch all cases. The "unknown" element type is allowed because `markdownlint` is being overzealous and parsing the info string in some code blocks where we have TS types. It was quicker to allow that type than to try to fix the underlying issue (which may already be fixed upstream, will need to check).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
