### PR TITLE
docs: Crowdin link, removed the from VSC, and changed Twitter to X

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Electron Discord Invite](https://img.shields.io/discord/745037351163527189?color=%237289DA&label=chat&logo=discord&logoColor=white)](https://discord.gg/electronjs)
 
 :memo: Available Translations: 🇨🇳 🇧🇷 🇪🇸 🇯🇵 🇷🇺 🇫🇷 🇺🇸 🇩🇪.
-View these docs in other languages on our [Crowdin](https://crowdin.com/project/electron) project.
+View these docs in other languages on our [Crowdin](https://crowdin.com/project/electron?_gl=1*1n5ijv*_up*MQ..*_ga*OTI0OTM5MjIxLjE3MTIzNTk4NTc.*_ga_SRNRQ29Q3E*MTcxMjM1OTg1Ny4xLjAuMTcxMjM1OTg1Ny4wLjAuMTA2NzM0NzEyNQ..) project.
 
 The Electron framework lets you write cross-platform desktop applications
 using JavaScript, HTML and CSS. It is based on [Node.js](https://nodejs.org/) and

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ View these docs in other languages on our [Crowdin](https://crowdin.com/project/
 
 The Electron framework lets you write cross-platform desktop applications
 using JavaScript, HTML and CSS. It is based on [Node.js](https://nodejs.org/) and
-[Chromium](https://www.chromium.org) and is used by the [Visual Studio
+[Chromium](https://www.chromium.org) and is used by [Visual Studio
 Code](https://github.com/Microsoft/vscode/) and many other [apps](https://electronjs.org/apps).
 
-Follow [@electronjs](https://twitter.com/electronjs) on Twitter for important
+Follow [@electronjs](https://twitter.com/electronjs) on X (formerly known as Twitter) for important
 announcements.
 
 This project adheres to the Contributor Covenant
@@ -95,7 +95,7 @@ See the [Advanced Installation Instructions](https://www.electronjs.org/docs/lat
 
 ## Documentation translations
 
-We crowdsource translations for our documentation via [Crowdin](https://crowdin.com/project/electron).
+We crowdsource translations for our documentation via [Crowdin](https://crowdin.com/project/electron?_gl=1*1n5ijv*_up*MQ..*_ga*OTI0OTM5MjIxLjE3MTIzNTk4NTc.*_ga_SRNRQ29Q3E*MTcxMjM1OTg1Ny4xLjAuMTcxMjM1OTg1Ny4wLjAuMTA2NzM0NzEyNQ..).
 We currently accept translations for Chinese (Simplified), French, German, Japanese, Portuguese,
 Russian, and Spanish.
 


### PR DESCRIPTION
The Crowdin link was not working and sent to a 403 page. Visual Studio Code doesn't need the article "the" in front of it as it is a proper name.   Changed Twitter to X

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] PR description included and stakeholders cc'd

#### Release Notes

Notes: no-notes
