### PR TITLE
fix: typos in comment section of `in_app_purchase.mm`

### DIFF
--- a/shell/browser/mac/in_app_purchase.mm
+++ b/shell/browser/mac/in_app_purchase.mm
@@ -79,10 +79,10 @@
 }
 
 /**
- * Process product informations and start the payment.
+ * Process product information and start the payment.
  *
  * @param request - The product request.
- * @param response - The informations about the list of products.
+ * @param response - The information about the list of products.
  */
 - (void)productsRequest:(SKProductsRequest*)request
      didReceiveResponse:(SKProductsResponse*)response {


### PR DESCRIPTION
#### Description of Change

fix typo (information has no plural) in the comment section of `in_app_purchase.mm`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

notes: none