### PR TITLE
build: add missing header for `content::SyntheticGestureTarget`

### DIFF
--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -25,6 +25,7 @@
 #include "content/browser/renderer_host/render_widget_host_delegate.h"  // nogncheck
 #include "content/browser/renderer_host/render_widget_host_owner_delegate.h"  // nogncheck
 #include "content/common/input/synthetic_gesture.h"  // nogncheck
+#include "content/common/input/synthetic_gesture_target.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/context_factory.h"


### PR DESCRIPTION
GNU libstdc++ does not allow using std::unique_ptr on incomplete types, leading to a compile error.

#### Release Notes

Notes: none