### PR TITLE
fix: WCO maximize button visibility when non-maximizable

### DIFF
--- a/shell/browser/ui/views/win_caption_button_container.cc
+++ b/shell/browser/ui/views/win_caption_button_container.cc
@@ -156,35 +156,25 @@ void WinCaptionButtonContainer::UpdateBackground() {
 }
 
 void WinCaptionButtonContainer::UpdateButtons() {
-  const bool is_maximized = frame_view_->frame()->IsMaximized();
-  restore_button_->SetVisible(is_maximized);
-  maximize_button_->SetVisible(!is_maximized);
-
   const bool minimizable = frame_view_->window()->IsMinimizable();
   minimize_button_->SetEnabled(minimizable);
   minimize_button_->SetVisible(minimizable);
 
-  // In touch mode, windows cannot be taken out of fullscreen or tiled mode, so
-  // the maximize/restore button should be disabled.
-  const bool is_touch = ui::TouchUiController::Get()->touch_ui();
-  restore_button_->SetEnabled(!is_touch);
+  const bool is_maximized = frame_view_->frame()->IsMaximized();
+  const bool maximizable = frame_view_->window()->IsMaximizable();
+  restore_button_->SetVisible(is_maximized && maximizable);
+  maximize_button_->SetVisible(!is_maximized && maximizable);
 
   // In touch mode, windows cannot be taken out of fullscreen or tiled mode, so
   // the maximize/restore button should be disabled, unless the window is not
   // maximized.
-  const bool maximizable = frame_view_->window()->IsMaximizable();
-  maximize_button_->SetEnabled(!(is_touch && is_maximized) && maximizable);
+  const bool is_touch = ui::TouchUiController::Get()->touch_ui();
+  restore_button_->SetEnabled(!is_touch);
+  maximize_button_->SetEnabled(!is_touch || !is_maximized);
 
+  // If the window isn't closable, the close button should be disabled.
   const bool closable = frame_view_->window()->IsClosable();
   close_button_->SetEnabled(closable);
-
-  // If all three of closable, maximizable, and minimizable are disabled,
-  // Windows natively only shows the disabled closable button. Copy that
-  // behavior here.
-  if (!maximizable && !closable && !minimizable) {
-    minimize_button_->SetVisible(false);
-    maximize_button_->SetVisible(false);
-  }
 
   InvalidateLayout();
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/41786.

Fixes a bug where a window with maximization disabled and WCO enabled would still show its maximization button. This diverged from [upstream behavior](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/views/frame/browser_caption_button_container_win.cc;l=212?q=%22windows%20cannot%20be%20taken%20out%20of%20fullscreen%20or%20tiled%20mode%22&sq=package:chromium&type=cs), which shows the button if it both can maximize and is not currently maximized. This also cleans up existing code to remove redundancies and better match upstream.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes a bug where a window with maximization disabled and WCO enabled would still show its maximization button
