### PR TITLE
chore: throw an error when trying to subclass `BrowserWindow`

### DIFF
--- a/lib/browser/api/browser-window.ts
+++ b/lib/browser/api/browser-window.ts
@@ -70,9 +70,7 @@ BrowserWindow.prototype._init = function (this: BWT) {
   });
 };
 
-const isBrowserWindow = (win: any) => {
-  return win && win.constructor.name === 'BrowserWindow';
-};
+const isBrowserWindow = (win: any) => win instanceof BrowserWindow;
 
 BrowserWindow.fromId = (id: number) => {
   const win = BaseWindow.fromId(id);

--- a/lib/browser/api/browser-window.ts
+++ b/lib/browser/api/browser-window.ts
@@ -5,6 +5,10 @@ const { BrowserWindow } = process._linkedBinding('electron_browser_window') as {
 Object.setPrototypeOf(BrowserWindow.prototype, BaseWindow.prototype);
 
 BrowserWindow.prototype._init = function (this: BWT) {
+  if (this.constructor.name !== 'BrowserWindow') {
+    throw new Error('Subclassing BrowserWindow is not supported in Electron');
+  }
+
   // Call parent class's _init.
   (BaseWindow.prototype as any)._init.call(this);
 
@@ -70,7 +74,9 @@ BrowserWindow.prototype._init = function (this: BWT) {
   });
 };
 
-const isBrowserWindow = (win: any) => win instanceof BrowserWindow;
+const isBrowserWindow = (win: any) => {
+  return win && win.constructor.name === 'BrowserWindow';
+};
 
 BrowserWindow.fromId = (id: number) => {
   const win = BaseWindow.fromId(id);

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -65,6 +65,21 @@ describe('BrowserWindow module', () => {
       }).not.to.throw();
     });
 
+    it('does not allow subclassing', () => {
+      class SubclassWindow extends BrowserWindow {
+        mood: string = 'happy';
+        constructor (options: any) {
+          super(options);
+          this.mood = options.mood;
+        }
+      }
+
+      expect(() => {
+        /* eslint-disable-next-line no-new */
+        new SubclassWindow({ show: false, mood: 'excited' });
+      }).to.throw(/Subclassing BrowserWindow is not supported in Electron/);
+    });
+
     ifit(process.platform === 'linux')('does not crash when setting large window icons', async () => {
       const appPath = path.join(fixtures, 'apps', 'xwindow-icon');
       const appProcess = childProcess.spawn(process.execPath, [appPath]);
@@ -2756,28 +2771,6 @@ describe('BrowserWindow module', () => {
       const windows = BrowserWindow.getAllWindows();
       expect(windows).to.have.lengthOf(2);
       expect(windows.map((w) => w.id)).to.include.members([a.id, c.id]);
-    });
-
-    it('returns subclass instances of BrowserWindow', () => {
-      class SubclassWindow extends BrowserWindow {
-        mood: string = 'happy';
-        constructor (options: any) {
-          super(options);
-          this.mood = options.mood;
-        }
-      }
-
-      const a = new BrowserWindow({ show: false });
-      const b = new BrowserWindow({ show: false });
-      const c = new SubclassWindow({ show: false, mood: 'excited' });
-
-      const windows = BrowserWindow.getAllWindows();
-      expect(windows).to.have.lengthOf(3);
-      expect(windows.map((w) => w.id)).to.include.members([a.id, b.id, c.id]);
-
-      const scw = windows.find((w) => w.id === c.id) as SubclassWindow;
-      expect(scw).to.be.an.instanceOf(SubclassWindow);
-      expect(scw.mood).to.equal('excited');
     });
   });
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -2733,6 +2733,54 @@ describe('BrowserWindow module', () => {
     });
   });
 
+  describe('BrowserWindow.getAllWindows', () => {
+    afterEach(closeAllWindows);
+
+    it('returns an array of all created BrowserWindow instances', () => {
+      const a = new BrowserWindow({ show: false });
+      const b = new BrowserWindow({ show: false });
+      const c = new BrowserWindow({ show: false });
+
+      const windows = BrowserWindow.getAllWindows();
+      expect(windows).to.have.lengthOf(3);
+      expect(windows.map((w) => w.id)).to.include.members([a.id, b.id, c.id]);
+    });
+
+    it('does not return destroyed windows', () => {
+      const a = new BrowserWindow({ show: false });
+      const b = new BrowserWindow({ show: false });
+      const c = new BrowserWindow({ show: false });
+
+      b.destroy();
+
+      const windows = BrowserWindow.getAllWindows();
+      expect(windows).to.have.lengthOf(2);
+      expect(windows.map((w) => w.id)).to.include.members([a.id, c.id]);
+    });
+
+    it('returns subclass instances of BrowserWindow', () => {
+      class SubclassWindow extends BrowserWindow {
+        mood: string = 'happy';
+        constructor (options: any) {
+          super(options);
+          this.mood = options.mood;
+        }
+      }
+
+      const a = new BrowserWindow({ show: false });
+      const b = new BrowserWindow({ show: false });
+      const c = new SubclassWindow({ show: false, mood: 'excited' });
+
+      const windows = BrowserWindow.getAllWindows();
+      expect(windows).to.have.lengthOf(3);
+      expect(windows.map((w) => w.id)).to.include.members([a.id, b.id, c.id]);
+
+      const scw = windows.find((w) => w.id === c.id) as SubclassWindow;
+      expect(scw).to.be.an.instanceOf(SubclassWindow);
+      expect(scw.mood).to.equal('excited');
+    });
+  });
+
   describe('BrowserWindow.fromId(id)', () => {
     afterEach(closeAllWindows);
     it('returns the window with id', () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/41785.

Explicitly throws an error when users try to subclass BrowserWindow as it causes issues over the binding / lifecycle boundaries.

Also adds some tests.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `BrowserWindow.getAllWindows()` did not return subclasses of `BrowserWindow`.