### PR TITLE
feat: add cumulativeCPUUsage to AppMetrics and CPUUsage

### DIFF
--- a/docs/api/structures/cpu-usage.md
+++ b/docs/api/structures/cpu-usage.md
@@ -2,6 +2,8 @@
 
 * `percentCPUUsage` number - Percentage of CPU used since the last call to getCPUUsage.
   First call returns 0.
+* `cumulativeCPUUsage` number (optional) - Total seconds of CPU time used since process
+  startup.
 * `idleWakeupsPerSecond` number - The number of average idle CPU wakeups per second
   since the last call to getCPUUsage. First call returns 0. Will always return 0 on
   Windows.

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1276,10 +1276,17 @@ std::vector<gin_helper::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
     auto pid_dict = gin_helper::Dictionary::CreateEmpty(isolate);
     auto cpu_dict = gin_helper::Dictionary::CreateEmpty(isolate);
 
-    double usage =
-        process_metric.second->metrics->GetPlatformIndependentCPUUsage()
-            .value_or(0);
-    cpu_dict.Set("percentCPUUsage", usage / processor_count);
+    // Default usage percentage to 0 for compatibility
+    double usagePercent = 0;
+    if (auto usage = process_metric.second->metrics->GetCumulativeCPUUsage();
+        usage.has_value()) {
+      cpu_dict.Set("cumulativeCPUUsage", usage->InSecondsF());
+      usagePercent =
+          process_metric.second->metrics->GetPlatformIndependentCPUUsage(
+              *usage);
+    }
+
+    cpu_dict.Set("percentCPUUsage", usagePercent / processor_count);
 
 #if !BUILDFLAG(IS_WIN)
     cpu_dict.Set("idleWakeupsPerSecond",

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -1442,6 +1442,7 @@ describe('app module', () => {
 
         types.push(entry.type);
         expect(entry.cpu).to.have.ownProperty('percentCPUUsage').that.is.a('number');
+        expect(entry.cpu).to.have.ownProperty('cumulativeCPUUsage').that.is.a('number');
         expect(entry.cpu).to.have.ownProperty('idleWakeupsPerSecond').that.is.a('number');
 
         expect(entry.memory).to.have.property('workingSetSize').that.is.greaterThan(0);

--- a/spec/api-process-spec.ts
+++ b/spec/api-process-spec.ts
@@ -26,6 +26,7 @@ describe('process module', () => {
       it('returns a cpu usage object', async () => {
         const cpuUsage = await w.webContents.executeJavaScript('process.getCPUUsage()');
         expect(cpuUsage.percentCPUUsage).to.be.a('number');
+        expect(cpuUsage.cumulativeCPUUsage).to.be.a('number');
         expect(cpuUsage.idleWakeupsPerSecond).to.be.a('number');
       });
     });
@@ -124,6 +125,7 @@ describe('process module', () => {
       it('returns a cpu usage object', () => {
         const cpuUsage = process.getCPUUsage();
         expect(cpuUsage.percentCPUUsage).to.be.a('number');
+        expect(cpuUsage.cumulativeCPUUsage).to.be.a('number');
         expect(cpuUsage.idleWakeupsPerSecond).to.be.a('number');
       });
     });


### PR DESCRIPTION
#### Description of Change
This allows apps to measure their CPU usage over any given period without worrying about other calls affecting the output, as they would with `percentCPUUsage`.

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [X] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [X] relevant documentation, tutorials, templates and examples are changed or added
- [X] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

Haven't run the tests because I couldn't get the build process to cooperate locally, but this worked fine and returned results in line with expectations on a CI build I ran.

#### Release Notes

Notes: Added `cumulativeCPUUsage` to AppMetrics and CPUUsage
