### PR TITLE
fix: package <__assertion_handler> as part of libcxx headers

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1464,8 +1464,10 @@ dist_zip("hunspell_dictionaries_zip") {
 }
 
 copy("libcxx_headers") {
-  sources = libcxx_headers + libcxx_licenses +
-            [ "//buildtools/third_party/libc++/__config_site" ]
+  sources = libcxx_headers + libcxx_licenses + [
+              "//buildtools/third_party/libc++/__assertion_handler",
+              "//buildtools/third_party/libc++/__config_site",
+            ]
   outputs = [ "$target_gen_dir/electron_libcxx_include/{{source_root_relative_dir}}/{{source_file_part}}" ]
 }
 


### PR DESCRIPTION
#### Description of Change

Refs https://chromium-review.googlesource.com/c/chromium/src/+/5208502

```
In file included from ../node_modules/node-addon-api/napi.h:5:
In file included from /mnt/vss/_work/1/s/.build/libcxx_headers/include/functional:515:
In file included from /mnt/vss/_work/1/s/.build/libcxx_headers/include/__algorithm/search.h:14:
In file included from /mnt/vss/_work/1/s/.build/libcxx_headers/include/__algorithm/iterator_operations.h:12:
In file included from /mnt/vss/_work/1/s/.build/libcxx_headers/include/__algorithm/iter_swap.h:14:
In file included from /mnt/vss/_work/1/s/.build/libcxx_headers/include/__utility/swap.h:16:
In file included from /mnt/vss/_work/1/s/.build/libcxx_headers/include/__type_traits/is_nothrow_move_constructible.h:15:
In file included from /mnt/vss/_work/1/s/.build/libcxx_headers/include/__type_traits/is_nothrow_constructible.h:17:
In file included from /mnt/vss/_work/1/s/.build/libcxx_headers/include/cstddef:36:
/mnt/vss/_work/1/s/.build/libcxx_headers/include/__assert:13:10: fatal error: '__assertion_handler' file not found
   13 | #include <__assertion_handler> // Note: this include is generated by CMake and is potentially vendor-provided.
      |          ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

#### Release Notes

Notes: fix missing `<__assertion_handler>` header when compiling with libc++