### PR TITLE
docs: use "id" instead of "label" for positions

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -38,18 +38,18 @@ See [`Menu`](menu.md) for examples.
     `Menu.buildFromTemplate`.
   * `id` string (optional) - Unique within a single menu. If defined then it can be used
     as a reference to this item by the position attribute.
-  * `before` string[] (optional) - Inserts this item before the item with the specified label. If
+  * `before` string[] (optional) - Inserts this item before the item with the specified id. If
     the referenced item doesn't exist the item will be inserted at the end of  the menu. Also implies
     that the menu item in question should be placed in the same “group” as the item.
-  * `after` string[] (optional) - Inserts this item after the item with the specified label. If the
+  * `after` string[] (optional) - Inserts this item after the item with the specified id. If the
     referenced item doesn't exist the item will be inserted at the end of
     the menu.
   * `beforeGroupContaining` string[] (optional) - Provides a means for a single context menu to declare
     the placement of their containing group before the containing group of the item
-    with the specified label.
+    with the specified id.
   * `afterGroupContaining` string[] (optional) - Provides a means for a single context menu to declare
     the placement of their containing group after the containing group of the item
-    with the specified label.
+    with the specified id.
 
 **Note:** `acceleratorWorksWhenHidden` is specified as being macOS-only because accelerators always work when items are hidden on Windows and Linux. The option is exposed to users to give them the option to turn it off, as this is possible in native macOS development.
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -336,16 +336,16 @@ browser windows.
 
 You can make use of `before`, `after`, `beforeGroupContaining`, `afterGroupContaining` and `id` to control how the item will be placed when building a menu with `Menu.buildFromTemplate`.
 
-* `before` - Inserts this item before the item with the specified label. If the
+* `before` - Inserts this item before the item with the specified id. If the
   referenced item doesn't exist the item will be inserted at the end of
   the menu. Also implies that the menu item in question should be placed in the same “group” as the item.
-* `after` - Inserts this item after the item with the specified label. If the
+* `after` - Inserts this item after the item with the specified id. If the
   referenced item doesn't exist the item will be inserted at the end of
   the menu. Also implies that the menu item in question should be placed in the same “group” as the item.
 * `beforeGroupContaining` - Provides a means for a single context menu to declare
-  the placement of their containing group before the containing group of the item with the specified label.
+  the placement of their containing group before the containing group of the item with the specified id.
 * `afterGroupContaining` - Provides a means for a single context menu to declare
-  the placement of their containing group after the containing group of the item with the specified label.
+  the placement of their containing group after the containing group of the item with the specified id.
 
 By default, items will be inserted in the order they exist in the template unless one of the specified positioning keywords is used.
 


### PR DESCRIPTION
#### Description of Change

The documentation for the `Menu` and `MenuItem` classes describes the constructor options `before`, `after`, `beforeGroupContaining` and `afterGroupContaining` wrongly. It is said, that the placement would be relative to the `MenuItem` containing the specified **labels**. The placement however is relative to a `MenuItem` with the specified **id** as shown in the example in the `Menu` classes [documentation](https://www.electronjs.org/docs/latest/api/menu#examples-1). This PR changes the descriptions to reflect this.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples --> none
