### PR TITLE
docs: clarify before `ready` usage

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -41,6 +41,10 @@ that was used to open the application, if it was launched from Notification Cent
 You can also call `app.isReady()` to check if this event has already fired and `app.whenReady()`
 to get a Promise that is fulfilled when Electron is initialized.
 
+**Note**: The `ready` event is only fired after the main process has finished running the first
+tick of the event loop. If an Electron API needs to be called before the `ready` event, ensure
+that it is called synchronously in the top-level context of the main process.
+
 ### Event: 'window-all-closed'
 
 Emitted when all windows have been closed.


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/29315

Took a stab at this long-standing docs issue. Please clarify my wording if I'm misusing some of the terminology here.

cc @pushkin- @nornagon @electron/docs 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
