### PR TITLE
build: redundant regex character class in generate-config-gypi.py

### DIFF
--- a/script/generate-config-gypi.py
+++ b/script/generate-config-gypi.py
@@ -40,7 +40,7 @@ def read_electron_args():
     for line in file_in:
       if line.startswith('#'):
         continue
-      m = re.match('([\w_]+) = (.+)', line)
+      m = re.match('(\w+) = (.+)', line)
       if m == None:
         continue
       args[m.group(1)] = m.group(2)


### PR DESCRIPTION
#### Description of Change

'\w' already includes '_'. solves a SyntaxWarning on python 3.12.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none