### PR TITLE
fix: check for Node.js-created module when `contextIsolation` disabled

### DIFF
--- a/patches/node/chore_expose_importmoduledynamically_and.patch
+++ b/patches/node/chore_expose_importmoduledynamically_and.patch
@@ -82,7 +82,7 @@ index 0645b3ddf506df2a76f5661f0ec6bb35d5d8b94e..e0f1b2d51f3055b2250f2c0dc1dfd104
  
  MaybeLocal<Value> ModuleWrap::SyntheticModuleEvaluationStepsCallback(
 diff --git a/src/module_wrap.h b/src/module_wrap.h
-index 58b233d036515c52d9bd5574c776c2ea65d2ecb1..5f7ef75480a76761c6fa62061c8700c812a3fc6f 100644
+index 1fc801edced9c5e44613846b4dc555804c5bae97..767d183c6b6b6d97726cf5d63c0b202bd9ae10a6 100644
 --- a/src/module_wrap.h
 +++ b/src/module_wrap.h
 @@ -30,7 +30,14 @@ enum HostDefinedOptions : int {
@@ -100,4 +100,21 @@ index 58b233d036515c52d9bd5574c776c2ea65d2ecb1..5f7ef75480a76761c6fa62061c8700c8
 +class NODE_EXTERN ModuleWrap : public BaseObject {
   public:
    enum InternalFields {
-     kModuleWrapBaseField = BaseObject::kInternalFieldCount,
+     kModuleSlot = BaseObject::kInternalFieldCount,
+@@ -65,6 +72,8 @@ class ModuleWrap : public BaseObject {
+     return true;
+   }
+ 
++  static ModuleWrap* GetFromModule(node::Environment*, v8::Local<v8::Module>);
++
+  private:
+   ModuleWrap(Environment* env,
+              v8::Local<v8::Object> object,
+@@ -99,7 +108,6 @@ class ModuleWrap : public BaseObject {
+       v8::Local<v8::String> specifier,
+       v8::Local<v8::FixedArray> import_attributes,
+       v8::Local<v8::Module> referrer);
+-  static ModuleWrap* GetFromModule(node::Environment*, v8::Local<v8::Module>);
+ 
+   v8::Global<v8::Module> module_;
+   std::unordered_map<std::string, v8::Global<v8::Promise>> resolve_cache_;

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -126,6 +126,8 @@ ELECTRON_TESTING_BINDINGS(V)
 #endif
 #undef V
 
+using node::loader::ModuleWrap;
+
 namespace {
 
 void stop_and_close_uv_loop(uv_loop_t* loop) {
@@ -216,16 +218,24 @@ v8::MaybeLocal<v8::Promise> HostImportModuleDynamically(
 void HostInitializeImportMetaObject(v8::Local<v8::Context> context,
                                     v8::Local<v8::Module> module,
                                     v8::Local<v8::Object> meta) {
-  if (node::Environment::GetCurrent(context) == nullptr) {
+  node::Environment* env = node::Environment::GetCurrent(context);
+  if (env == nullptr) {
     if (electron::IsBrowserProcess() || electron::IsUtilityProcess())
       return;
     return blink::V8Initializer::HostGetImportMetaProperties(context, module,
                                                              meta);
   }
 
-  // If we're running with contextIsolation enabled in the renderer process,
-  // fall back to Blink's logic.
   if (electron::IsRendererProcess()) {
+    // If the module is created by Node.js, use Node.js' handling.
+    if (env != nullptr) {
+      ModuleWrap* wrap = ModuleWrap::GetFromModule(env, module);
+      if (wrap)
+        return ModuleWrap::HostInitializeImportMetaObjectCallback(context,
+                                                                  module, meta);
+    }
+
+    // If contextIsolation is enabled, fall back to Blink's handling.
     blink::WebLocalFrame* frame =
         blink::WebLocalFrame::FrameForContext(context);
     if (!frame || frame->GetScriptContextWorldId(context) !=
@@ -235,8 +245,8 @@ void HostInitializeImportMetaObject(v8::Local<v8::Context> context,
     }
   }
 
-  return node::loader::ModuleWrap::HostInitializeImportMetaObjectCallback(
-      context, module, meta);
+  return ModuleWrap::HostInitializeImportMetaObjectCallback(context, module,
+                                                            meta);
 }
 
 v8::ModifyCodeGenerationFromStringsResult ModifyCodeGenerationFromStrings(

--- a/spec/fixtures/esm/import-meta/index.html
+++ b/spec/fixtures/esm/import-meta/index.html
@@ -1,0 +1,15 @@
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'">
+    <title>Hello World!</title>
+  </head>
+  <body>
+    <h1>Hello World!</h1>
+    We are using Node.js <span id="node-version"></span>,
+    Chromium <span id="chrome-version"></span>,
+    and Electron <span id="electron-version"></span>.
+  </body>
+</html>

--- a/spec/fixtures/esm/import-meta/main.mjs
+++ b/spec/fixtures/esm/import-meta/main.mjs
@@ -1,0 +1,33 @@
+import { app, BrowserWindow } from 'electron'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path';
+
+async function createWindow() {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      preload: fileURLToPath(new URL('preload.mjs', import.meta.url)),
+      sandbox: false,
+      contextIsolation: false
+    }
+  })
+
+  await mainWindow.loadFile('index.html')
+
+  const importMetaPreload = await mainWindow.webContents.executeJavaScript('window.importMetaPath');
+  const expected = join(dirname(fileURLToPath(import.meta.url)), 'preload.mjs');
+
+  process.exit(importMetaPreload === expected ? 0 : 1);
+}
+
+app.whenReady().then(() => {
+  createWindow()
+
+  app.on('activate', function () {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+  })
+})
+
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit()
+})

--- a/spec/fixtures/esm/import-meta/package.json
+++ b/spec/fixtures/esm/import-meta/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "main.mjs",
+  "type": "module"
+}

--- a/spec/fixtures/esm/import-meta/preload.mjs
+++ b/spec/fixtures/esm/import-meta/preload.mjs
@@ -1,0 +1,3 @@
+import { fileURLToPath } from 'node:url'
+
+window.importMetaPath = fileURLToPath(import.meta.url)


### PR DESCRIPTION
Backport of #40993.

See that PR for details.

Notes: Fixes an issue where `import.meta.url` did not work in the renderer process with `contextIsolation` enabled.