### PR TITLE
perf: remove unnecessary `.c_str()` calls

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -462,8 +462,7 @@ void OnClientCertificateSelected(
     return;
 
   auto certs = net::X509Certificate::CreateCertificateListFromBytes(
-      base::as_bytes(base::make_span(data.c_str(), data.size())),
-      net::X509Certificate::FORMAT_AUTO);
+      base::as_bytes(base::make_span(data)), net::X509Certificate::FORMAT_AUTO);
   if (!certs.empty()) {
     scoped_refptr<net::X509Certificate> cert(certs[0].get());
     for (auto& identity : *identities) {

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -399,9 +399,7 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
       int device_name_index = 0;
       for (auto& source : screen_sources) {
         const auto& device_name = device_names[device_name_index++];
-        std::wstring wide_device_name;
-        base::UTF8ToWide(device_name.c_str(), device_name.size(),
-                         &wide_device_name);
+        const std::wstring wide_device_name = base::UTF8ToWide(device_name);
         const int64_t device_id =
             base::PersistentHash(base::WideToUTF8(wide_device_name.c_str()));
         source.display_id = base::NumberToString(device_id);

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -399,9 +399,7 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
       int device_name_index = 0;
       for (auto& source : screen_sources) {
         const auto& device_name = device_names[device_name_index++];
-        const std::wstring wide_device_name = base::UTF8ToWide(device_name);
-        const int64_t device_id =
-            base::PersistentHash(base::WideToUTF8(wide_device_name.c_str()));
+        const int64_t device_id = base::PersistentHash(device_name);
         source.display_id = base::NumberToString(device_id);
       }
     }

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -313,7 +313,7 @@ int ElectronBrowserMainParts::PreCreateThreads() {
     std::string str;
     if (env->GetVar("LC_ALL", &str))
       lc_all.emplace(std::move(str));
-    env->SetVar("LC_ALL", locale.c_str());
+    env->SetVar("LC_ALL", locale);
   }
 #endif
 

--- a/shell/browser/net/asar/asar_url_loader.cc
+++ b/shell/browser/net/asar/asar_url_loader.cc
@@ -267,7 +267,7 @@ class AsarURLLoader : public network::mojom::URLLoader {
     }
     if (head->headers) {
       head->headers->AddHeader(net::HttpRequestHeaders::kContentType,
-                               head->mime_type.c_str());
+                               head->mime_type);
     }
     client_->OnReceiveResponse(std::move(head), std::move(consumer_handle),
                                std::nullopt);

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -540,7 +540,7 @@ HRESULT WindowsToastNotification::SetXmlImage(IXmlDocument* doc,
   ComPtr<IXmlNode> src_attr;
   RETURN_IF_FAILED(attrs->GetNamedItem(src, &src_attr));
 
-  ScopedHString img_path(icon_path.c_str());
+  const ScopedHString img_path{icon_path};
   if (!img_path.success())
     return E_FAIL;
 

--- a/shell/common/api/electron_api_command_line.cc
+++ b/shell/common/api/electron_api_command_line.cc
@@ -14,12 +14,11 @@
 namespace {
 
 bool HasSwitch(const std::string& name) {
-  return base::CommandLine::ForCurrentProcess()->HasSwitch(name.c_str());
+  return base::CommandLine::ForCurrentProcess()->HasSwitch(name);
 }
 
 base::CommandLine::StringType GetSwitchValue(const std::string& name) {
-  return base::CommandLine::ForCurrentProcess()->GetSwitchValueNative(
-      name.c_str());
+  return base::CommandLine::ForCurrentProcess()->GetSwitchValueNative(name);
 }
 
 void AppendSwitch(const std::string& switch_string,

--- a/shell/common/api/electron_api_shell.cc
+++ b/shell/common/api/electron_api_shell.cc
@@ -51,7 +51,7 @@ void OnOpenFinished(gin_helper::Promise<void> promise,
   if (error.empty())
     promise.Resolve();
   else
-    promise.RejectWithErrorMessage(error.c_str());
+    promise.RejectWithErrorMessage(error);
 }
 
 v8::Local<v8::Promise> OpenExternal(const GURL& url, gin::Arguments* args) {


### PR DESCRIPTION
#### Description of Change

Minor perf cleanup for cases where we have a string or wstring `foo` and pass it to a method that takes a `std::string_view` with `foo.c_str()` instead of just `foo`. Passing the string is preferable since its length is already known and won't have to be recomputed from the `const char*`.

All reviews welcome; no specific individual stakeholders.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.