### PR TITLE
fix: console.log() in AudioWorkletGlobalScope

### DIFF
--- a/patches/devtools_frontend/.patches
+++ b/patches/devtools_frontend/.patches
@@ -1,1 +1,2 @@
 chore_expose_ui_to_allow_electron_to_set_dock_side.patch
+fix_support_for_worklet_targets.patch

--- a/patches/devtools_frontend/fix_support_for_worklet_targets.patch
+++ b/patches/devtools_frontend/fix_support_for_worklet_targets.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrey Kosyakov <caseq@chromium.org>
+Date: Tue, 12 Mar 2024 19:58:44 -0700
+Subject: Fix support for worklet targets
+
+Fixes an issue where console.log() did not work in AudioWorkletGlobalScope.
+
+Bug: 327027138
+Change-Id: I051565c591645f0a4ccc297825d299c0764501ca
+Reviewed-on: https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/5367245
+Reviewed-by: Danil Somsikov <dsv@chromium.org>
+Commit-Queue: Andrey Kosyakov <caseq@chromium.org>
+
+diff --git a/front_end/core/sdk/ChildTargetManager.ts b/front_end/core/sdk/ChildTargetManager.ts
+index 1d790363b8a45655140353863b422fce35f2ae0e..9305546e8777abf582437e0978c114ad5db514ca 100644
+--- a/front_end/core/sdk/ChildTargetManager.ts
++++ b/front_end/core/sdk/ChildTargetManager.ts
+@@ -173,6 +173,8 @@ export class ChildTargetManager extends SDKModel<EventTypes> implements Protocol
+       type = Type.Frame;
+     } else if (targetInfo.type === 'worker') {
+       type = Type.Worker;
++    } else if (targetInfo.type === 'worklet') {
++      type = Type.Worklet;
+     } else if (targetInfo.type === 'shared_worker') {
+       type = Type.SharedWorker;
+     } else if (targetInfo.type === 'shared_storage_worklet') {


### PR DESCRIPTION
#### Description of Change

Refs https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/5367245.

Closes https://github.com/electron/electron/issues/41263

Fixes an issue where `console.log()` in AudioWorkletGlobalScope produced incorrect output.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where `console.log()` in AudioWorkletGlobalScope produced incorrect output.