### PR TITLE
fix: data corruption in `protocol.handle`

### DIFF
--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -12,10 +12,10 @@ const ERR_UNEXPECTED = -9;
 const isBuiltInScheme = (scheme: string) => ['http', 'https', 'file'].includes(scheme);
 
 function makeStreamFromPipe (pipe: any): ReadableStream {
-  const buf = new Uint8Array(1024 * 1024 /* 1 MB */);
   return new ReadableStream({
     async pull (controller) {
       try {
+        const buf = new Uint8Array(1024 * 1024 /* 1 MB */);
         const rv = await pipe.read(buf);
         if (rv > 0) {
           controller.enqueue(buf.subarray(0, rv));

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -12,13 +12,13 @@ const ERR_UNEXPECTED = -9;
 const isBuiltInScheme = (scheme: string) => ['http', 'https', 'file'].includes(scheme);
 
 function makeStreamFromPipe (pipe: any): ReadableStream {
+  const buf = new Uint8Array(1024 * 1024 /* 1 MB */);
   return new ReadableStream({
     async pull (controller) {
       try {
-        const buf = new Uint8Array(1024 * 1024 /* 1 MB */);
         const rv = await pipe.read(buf);
         if (rv > 0) {
-          controller.enqueue(buf.subarray(0, rv));
+          controller.enqueue(buf.slice(0, rv));
         } else {
           controller.close();
         }

--- a/spec/index.js
+++ b/spec/index.js
@@ -40,6 +40,7 @@ protocol.registerSchemesAsPrivileged([
   { scheme: global.standardScheme, privileges: { standard: true, secure: true, stream: false } },
   { scheme: global.zoomScheme, privileges: { standard: true, secure: true } },
   { scheme: global.serviceWorkerScheme, privileges: { allowServiceWorkers: true, standard: true, secure: true } },
+  { scheme: 'http-like', privileges: { standard: true, secure: true, corsEnabled: true, supportFetchAPI: true } },
   { scheme: 'cors-blob', privileges: { corsEnabled: true, supportFetchAPI: true } },
   { scheme: 'cors', privileges: { corsEnabled: true, supportFetchAPI: true } },
   { scheme: 'no-cors', privileges: { supportFetchAPI: true } },


### PR DESCRIPTION
#### Description of Change

This fixes an issue in protocol.handle() when consuming incoming data chunks
asynchronously.

Previously, a view on the incoming buffer was passed to the handler function,
meaning that subsequent incoming packets would overwrite the buffer and cause
unexpected changes in the data. Now a copy of the buffer is made before passing
to the handler function instead.

Fixes #41872.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed data corruption when protocol.handle() processed incoming data asynchronously.
