### PR TITLE
build: update typescript-definitions to 8.15.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@electron/fiddle-core": "^1.0.4",
     "@electron/github-app-auth": "^2.0.0",
     "@electron/lint-roller": "^1.12.1",
-    "@electron/typescript-definitions": "^8.15.2",
+    "@electron/typescript-definitions": "^8.15.6",
     "@octokit/rest": "^19.0.7",
     "@primer/octicons": "^10.0.0",
     "@types/basic-auth": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,10 +219,10 @@
     vscode-languageserver-textdocument "^1.0.8"
     vscode-uri "^3.0.7"
 
-"@electron/typescript-definitions@^8.15.2":
-  version "8.15.2"
-  resolved "https://registry.yarnpkg.com/@electron/typescript-definitions/-/typescript-definitions-8.15.2.tgz#1152e3d3731d236b50a3dee5a108176ce43fd703"
-  integrity sha512-6vlWnnNfZrg9QFOGgoLaQZ/nTCg+Y1laz02pUsRRmCJIpJZOY3HnWnIuav7e8g5IIwHMVc8JSohR+YRgiRk/eA==
+"@electron/typescript-definitions@^8.15.6":
+  version "8.15.6"
+  resolved "https://registry.yarnpkg.com/@electron/typescript-definitions/-/typescript-definitions-8.15.6.tgz#a578ee3de6e6dcfdb5765da58f303900a34b2d06"
+  integrity sha512-9YR2jG7AdRLvZMhQLgTljZzkoaKNP1wbQq+/qjBCCCCCbUpECvMRk1/UeuZErZEmddhSYanQZgXiftF1T072uQ==
   dependencies:
     "@types/node" "^11.13.7"
     chalk "^2.4.2"


### PR DESCRIPTION
#### Description of Change

Updating typescript-definitions to 8.15.6.

This includes the following changes:

- https://github.com/electron/typescript-definitions/pull/254
- https://github.com/electron/typescript-definitions/pull/258
- https://github.com/electron/typescript-definitions/pull/259
- https://github.com/electron/typescript-definitions/pull/264

That also fixes https://github.com/electron/electron/issues/40942.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
