### PR TITLE
refactor: use InvalidateLayout() not DeprecatedLayoutImmediately()

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -100,7 +100,7 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
   // Note that |GetContentsView|, confusingly, does not refer to the same thing
   // as |BaseWindow::GetContentView|.
   window()->GetContentsView()->AddChildViewAt(web_contents_view->view(), 0);
-  window()->GetContentsView()->DeprecatedLayoutImmediately();
+  window()->GetContentsView()->InvalidateLayout();
 
   // Init window after everything has been setup.
   window()->InitFromOptions(options);

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -365,7 +365,7 @@ void NativeWindowMac::SetContentView(views::View* view) {
   set_content_view(view);
   root_view->AddChildView(content_view());
 
-  root_view->DeprecatedLayoutImmediately();
+  root_view->InvalidateLayout();
 }
 
 void NativeWindowMac::Close() {

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -474,7 +474,7 @@ void NativeWindowViews::SetContentView(views::View* view) {
   set_content_view(view);
   focused_view_ = view;
   root_view_.GetMainView()->AddChildView(content_view());
-  root_view_.GetMainView()->DeprecatedLayoutImmediately();
+  root_view_.GetMainView()->InvalidateLayout();
 }
 
 void NativeWindowViews::Close() {

--- a/shell/browser/ui/inspectable_web_contents_view.cc
+++ b/shell/browser/ui/inspectable_web_contents_view.cc
@@ -123,7 +123,7 @@ void InspectableWebContentsView::ShowDevTools(bool activate) {
     devtools_web_view_->SetWebContents(
         inspectable_web_contents_->GetDevToolsWebContents());
     devtools_web_view_->RequestFocus();
-    DeprecatedLayoutImmediately();
+    InvalidateLayout();
   }
 }
 
@@ -144,7 +144,7 @@ void InspectableWebContentsView::CloseDevTools() {
   } else {
     devtools_web_view_->SetVisible(false);
     devtools_web_view_->SetWebContents(nullptr);
-    DeprecatedLayoutImmediately();
+    InvalidateLayout();
   }
 }
 
@@ -193,7 +193,7 @@ void InspectableWebContentsView::SetIsDocked(bool docked, bool activate) {
 void InspectableWebContentsView::SetContentsResizingStrategy(
     const DevToolsContentsResizingStrategy& strategy) {
   strategy_.CopyFrom(strategy);
-  DeprecatedLayoutImmediately();
+  InvalidateLayout();
 }
 
 void InspectableWebContentsView::SetTitle(const std::u16string& title) {


### PR DESCRIPTION
#### Description of Change

Replace our calls to the deprecated API `DeprecatedLayoutImmediately()` with `InvalidateLayout()` instead.

It looks like all of the occurrences were just to trigger a new draw & didn't necessarily rely on it happening immediately, so `InvalidateLayout()` is the call preferred by upstream.

Xref: https://crbug.com/1121681

Xref: https://chromium-review.googlesource.com/c/chromium/src/+/5242027

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none