### PR TITLE
fix: offscreen rendering does not paint after gpu process crashed

### DIFF
--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -59,9 +59,11 @@ typedef base::RepeatingCallback<void(const gfx::Rect&, const SkBitmap&)>
     OnPaintCallback;
 typedef base::RepeatingCallback<void(const gfx::Rect&)> OnPopupPaintCallback;
 
-class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
-                                      public ui::CompositorDelegate,
-                                      public OffscreenViewProxyObserver {
+class OffScreenRenderWidgetHostView
+    : public content::RenderWidgetHostViewBase,
+      public content::RenderFrameMetadataProvider::Observer,
+      public ui::CompositorDelegate,
+      public OffscreenViewProxyObserver {
  public:
   OffScreenRenderWidgetHostView(bool transparent,
                                 bool painting,
@@ -174,6 +176,15 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
       const gfx::PointF& point,
       RenderWidgetHostViewBase* target_view,
       gfx::PointF* transformed_point) override;
+
+  // RenderFrameMetadataProvider::Observer:
+  void OnRenderFrameMetadataChangedBeforeActivation(
+      const cc::RenderFrameMetadata& metadata) override {}
+  void OnRenderFrameMetadataChangedAfterActivation(
+      base::TimeTicks activation_time) override {}
+  void OnRenderFrameSubmission() override {}
+  void OnLocalSurfaceIdChanged(
+      const cc::RenderFrameMetadata& metadata) override;
 
   // ui::CompositorDelegate:
   bool IsOffscreen() const override;


### PR DESCRIPTION
#### Description of Change

Fixes: [#37399](https://github.com/electron/electron/issues/37399)

1. `OffScreenRenderWidgetHostView` inherit from `RenderFrameMetadataProvider::Observer` and implement the `OnLocalSurfaceIdChanged` method. 
2. `GPU Process crashed` will trigger `OnLocalSurfaceIdChanged` and we can call `ResizeRootLayer` if `surface_id` changed


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: electron doesn't paint on offscreen-render mode after gpu process crashed 

