### PR TITLE
feat: Add support to callback in protocol interceptor handler without argument to perform as if no interceptors.

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -184,6 +184,65 @@ Removes a protocol handler registered with `protocol.handle`.
 
 Returns `boolean` - Whether `scheme` is already handled.
 
+### `protocol.interceptProtocol(scheme, handler)`
+
+* `scheme` string
+* `handler` Function
+  * `request` [ProtocolRequest](structures/protocol-request.md)
+  * `callback` Function
+    * `response` (string | [ProtocolResponse](structures/protocol-response.md)) (optional)
+
+Returns `boolean` - Whether the protocol was successfully registered
+
+Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
+which you can response with a new http request or file or buffer or stream or
+behave as if there is no interceptions.
+
+Examples:
+
+Response with a new http request.
+
+```js
+const sess = session.fromPartition('persist:example')
+sess.protocol.interceptProtocol('https', (request, callback) => {
+  callback({
+    url: 'https://example.com',
+    referrer: 'https://example.com',
+    method: 'POST',
+    uploadData: { contentType: 'text/plain', data: 'Hello World' },
+    session: sess
+  })
+})
+```
+
+But please notice the code above. if the scheme is http and send a new http request in the handler that will hit the handler again. You must end up not responding with a new http request.
+
+Response with file.
+
+```js
+protocol.interceptProtocol('https', (request, callback) => {
+  callback({
+    path: '/path/to/the/file'
+  })
+})
+```
+
+Response with data.
+
+```js
+protocol.interceptProtocol('https', (request, callback) => {
+  callback({ mimeType: 'text/html', data: Buffer.from('<h5>Response</h5>') })
+})
+```
+
+Response as if it hasn't been intercepted.
+
+```js
+protocol.interceptProtocol('https', (request, callback) => {
+  callback()
+})
+```
+
 ### `protocol.registerFileProtocol(scheme, handler)` _Deprecated_
 
 * `scheme` string

--- a/shell/browser/net/electron_url_loader_factory.h
+++ b/shell/browser/net/electron_url_loader_factory.h
@@ -109,7 +109,7 @@ class ElectronURLLoaderFactory : public network::SelfDeletingURLLoaderFactory {
       const net::MutableNetworkTrafficAnnotationTag& traffic_annotation)
       override;
 
-  static void StartLoading(
+  static void StartLoadingWithResponse(
       mojo::PendingReceiver<network::mojom::URLLoader> loader,
       int32_t request_id,
       uint32_t options,
@@ -118,7 +118,8 @@ class ElectronURLLoaderFactory : public network::SelfDeletingURLLoaderFactory {
       const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
       mojo::PendingRemote<network::mojom::URLLoaderFactory> target_factory,
       ProtocolType type,
-      gin::Arguments* args);
+      v8::Isolate* isolate,
+      v8::Local<v8::Value> response);
 
   // disable copy
   ElectronURLLoaderFactory(const ElectronURLLoaderFactory&) = delete;
@@ -130,6 +131,17 @@ class ElectronURLLoaderFactory : public network::SelfDeletingURLLoaderFactory {
       const ProtocolHandler& handler,
       mojo::PendingReceiver<network::mojom::URLLoaderFactory> factory_receiver);
   ~ElectronURLLoaderFactory() override;
+
+  static void StartLoading(
+      mojo::PendingReceiver<network::mojom::URLLoader> loader,
+      int32_t request_id,
+      uint32_t options,
+      const network::ResourceRequest& request,
+      mojo::PendingRemote<network::mojom::URLLoaderClient> client,
+      const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
+      mojo::PendingRemote<network::mojom::URLLoaderFactory> target_factory,
+      ProtocolType type,
+      gin::Arguments* args);
 
   static void OnComplete(
       mojo::PendingRemote<network::mojom::URLLoaderClient> client,

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -241,6 +241,16 @@ class ProxyingURLLoaderFactory
   bool IsForServiceWorkerScript() const;
 
  private:
+  static void StartLoading(
+      mojo::PendingReceiver<network::mojom::URLLoader> loader,
+      int32_t request_id,
+      uint32_t options,
+      const network::ResourceRequest& request,
+      mojo::PendingRemote<network::mojom::URLLoaderClient> client,
+      const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
+      mojo::PendingRemote<network::mojom::URLLoaderFactory> target_factory,
+      ProtocolType type,
+      gin::Arguments* args);
   void OnTargetFactoryError();
   void OnProxyBindingError();
   void RemoveRequest(int32_t network_service_request_id, uint64_t request_id);


### PR DESCRIPTION
#### Description of Change
To SAVE your life while doing protocol intercept.
These changes were made to allow you writting code blow.
```javascript
protocol.interceptProtocol('https', (req, callback) => {
    // map request to file.
    if (shouldMapToLocal(req)) {
        callback({
            path: getLocalFilePathOf(req)
        })
        return
    }
    // Trigger the default behavior of loading https request
    // You never need to care about the net.fetch and handle the redirect may happen in net.fetch.
    // Just call callback();
    // NOTE that only protocol.intercept(Any)Protocol is allowed to call callback without argument.
    // if you are doing a protocol register you have to give the response data in callback too.
    callback();
})
```
Just DO NOT use the documented way.
```
protocol.handle('app', (req) => {
  if (shouldResponseByOthers(req) {
    return giveReponseByOthers(req)
  }
  // To work as you don't intercept it.
  return net.fetch(req)
})
``` 
The document's code is perfect but in real it has tons of bug.

problems
1. losing blob data of req. If you post a file created by a input tag. you'll lose the most important part of the request🐶.(fixed in https://github.com/electron/electron/pull/41052)
![image](https://github.com/electron/electron/assets/24412720/2c4d870a-a2f4-4d33-85c4-263d3a72d612)
2. exception caused by web stream contains undefined data.
3. You cannot perceive redirection in net.fetch API. If you're loading a page you can't response the data of yyyy.html while rendering xxxx.html. You need to perceive the navigation and response with a object created by Response.redirect("yyyy.html").

cc: @codebytere @nornagon 
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
notes: Add support to callback in protocol interceptor handler without argument to perform as if no interceptors.


