### PR TITLE
refactor: replace base::EndsWith() with std::ends_with()

### DIFF
--- a/shell/app/electron_main_delegate_mac.mm
+++ b/shell/app/electron_main_delegate_mac.mm
@@ -33,14 +33,12 @@ base::FilePath GetHelperAppPath(const base::FilePath& frameworks_path,
   base::PathService::Get(base::FILE_EXE, &path);
 
   std::string helper_name = "Helper";
-  if (base::EndsWith(path.value(), content::kMacHelperSuffix_renderer,
-                     base::CompareCase::SENSITIVE)) {
+  if (const auto& val = path.value();
+      val.ends_with(content::kMacHelperSuffix_renderer)) {
     helper_name += content::kMacHelperSuffix_renderer;
-  } else if (base::EndsWith(path.value(), content::kMacHelperSuffix_gpu,
-                            base::CompareCase::SENSITIVE)) {
+  } else if (val.ends_with(content::kMacHelperSuffix_gpu)) {
     helper_name += content::kMacHelperSuffix_gpu;
-  } else if (base::EndsWith(path.value(), content::kMacHelperSuffix_plugin,
-                            base::CompareCase::SENSITIVE)) {
+  } else if (val.ends_with(content::kMacHelperSuffix_plugin)) {
     helper_name += content::kMacHelperSuffix_plugin;
   }
 

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -1545,8 +1545,7 @@ gin::Handle<Session> Session::FromPartition(v8::Isolate* isolate,
   if (partition.empty()) {
     browser_context =
         ElectronBrowserContext::From("", false, std::move(options));
-  } else if (base::StartsWith(partition, kPersistPrefix,
-                              base::CompareCase::SENSITIVE)) {
+  } else if (partition.starts_with(kPersistPrefix)) {
     std::string name = partition.substr(8);
     browser_context =
         ElectronBrowserContext::From(name, false, std::move(options));

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -106,12 +106,9 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol,
   const std::vector<std::string> argv = {kXdgSettings, "check",
                                          kXdgSettingsDefaultSchemeHandler,
                                          protocol, desktop_name};
-  const auto output = GetXdgAppOutput(argv);
-  if (!output)
-    return false;
-
   // Allow any reply that starts with "yes".
-  return base::StartsWith(output.value(), "yes", base::CompareCase::SENSITIVE);
+  const std::optional<std::string> output = GetXdgAppOutput(argv);
+  return output && output->starts_with("yes");
 }
 
 // Todo implement

--- a/shell/common/mac/main_application_bundle.mm
+++ b/shell/common/mac/main_application_bundle.mm
@@ -31,13 +31,10 @@ base::FilePath MainApplicationBundlePath() {
 
   // Up to Contents.
   if (!HasMainProcessKey() &&
-      (base::EndsWith(path.value(), " Helper", base::CompareCase::SENSITIVE) ||
-       base::EndsWith(path.value(), content::kMacHelperSuffix_plugin,
-                      base::CompareCase::SENSITIVE) ||
-       base::EndsWith(path.value(), content::kMacHelperSuffix_renderer,
-                      base::CompareCase::SENSITIVE) ||
-       base::EndsWith(path.value(), content::kMacHelperSuffix_gpu,
-                      base::CompareCase::SENSITIVE))) {
+      (path.value().ends_with(" Helper") ||
+       path.value().ends_with(content::kMacHelperSuffix_plugin) ||
+       path.value().ends_with(content::kMacHelperSuffix_renderer) ||
+       path.value().ends_with(content::kMacHelperSuffix_gpu))) {
     // The running executable is the helper. Go up five steps:
     // Contents/Frameworks/Helper.app/Contents/MacOS/Helper
     // ^ to here                                     ^ from here


### PR DESCRIPTION
#### Description of Change

Very small C++20 migration PR. Replaces `base::EndsWith(foo, base::CompareCase::SENSITIVE)` with `foo.ends_with()`.

Xref: https://issues.chromium.org/issues/40256235 upstream migration ticket

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none