### PR TITLE
feat: WebFrameMain no longer follows cross-origin navigations

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1753,23 +1753,6 @@ void WebContents::RenderFrameHostChanged(content::RenderFrameHost* old_host,
     if (new_host)
       new_host->GetRenderWidgetHost()->AddInputEventObserver(this);
   }
-
-  // During cross-origin navigation, a FrameTreeNode will swap out its RFH.
-  // If an instance of WebFrameMain exists, it will need to have its RFH
-  // swapped as well.
-  //
-  // |old_host| can be a nullptr so we use |new_host| for looking up the
-  // WebFrameMain instance.
-  auto* web_frame = WebFrameMain::FromRenderFrameHost(new_host);
-  if (web_frame) {
-    web_frame->UpdateRenderFrameHost(new_host);
-  }
-}
-
-void WebContents::FrameDeleted(int frame_tree_node_id) {
-  auto* web_frame = WebFrameMain::FromFrameTreeNodeId(frame_tree_node_id);
-  if (web_frame)
-    web_frame->Destroyed();
 }
 
 void WebContents::RenderViewDeleted(content::RenderViewHost* render_view_host) {

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -628,7 +628,6 @@ class WebContents : public ExclusiveAccessContext,
   void RenderFrameDeleted(content::RenderFrameHost* render_frame_host) override;
   void RenderFrameHostChanged(content::RenderFrameHost* old_host,
                               content::RenderFrameHost* new_host) override;
-  void FrameDeleted(int frame_tree_node_id) override;
   void RenderViewDeleted(content::RenderViewHost*) override;
   void PrimaryMainFrameRenderProcessGone(
       base::TerminationStatus status) override;

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -12,6 +12,7 @@
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/process/process.h"
+#include "content/public/browser/global_routing_id.h"
 #include "gin/handle.h"
 #include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/remote.h"
@@ -49,7 +50,6 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
   static gin::Handle<WebFrameMain> FromOrNull(
       v8::Isolate* isolate,
       content::RenderFrameHost* render_frame_host);
-  static WebFrameMain* FromFrameTreeNodeId(int frame_tree_node_id);
   static WebFrameMain* FromRenderFrameHost(
       content::RenderFrameHost* render_frame_host);
 
@@ -125,7 +125,7 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
   mojo::Remote<mojom::ElectronRenderer> renderer_api_;
   mojo::PendingReceiver<mojom::ElectronRenderer> pending_receiver_;
 
-  int frame_tree_node_id_;
+  content::GlobalRenderFrameHostToken rfh_token_;
 
   raw_ptr<content::RenderFrameHost> render_frame_ = nullptr;
 

--- a/spec/fixtures/pages/ipc-after-navigate.html
+++ b/spec/fixtures/pages/ipc-after-navigate.html
@@ -1,0 +1,9 @@
+<script>
+const { ipcRenderer } = require('electron')
+window.onload = () => {
+  setInterval(() => {
+    ipcRenderer.send('test')
+  }, 0);
+  window.location.replace("https://example.com");
+}
+</script>


### PR DESCRIPTION
#### Description of Change

This stops WebFrameMain from following navigations.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: WebFrameMain is now tied to a single RenderFrameHost, and does not follow cross-origin navigations.