### PR TITLE
fix: `requestFullscreen` from `WebContentsView`

### DIFF
--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -89,6 +89,9 @@ void WebContentsView::OnViewAddedToWidget(views::View* observed_view) {
       widget->GetNativeWindowProperty(electron::kElectronNativeWindowKey));
   if (!native_window)
     return;
+  // We don't need to call SetOwnerWindow(nullptr) in OnViewRemovedFromWidget
+  // because that's handled in the WebContents dtor called prior.
+  api_web_contents_->SetOwnerWindow(native_window);
   native_window->AddDraggableRegionProvider(this);
 }
 

--- a/spec/api-web-contents-view-spec.ts
+++ b/spec/api-web-contents-view-spec.ts
@@ -60,6 +60,18 @@ describe('WebContentsView', () => {
     });
   });
 
+  it('can be fullscreened', async () => {
+    const w = new BaseWindow();
+    const v = new WebContentsView();
+    w.setContentView(v);
+    await v.webContents.loadURL('data:text/html,<div id="div">This is a simple div.</div>');
+
+    const enterFullScreen = once(w, 'enter-full-screen');
+    await v.webContents.executeJavaScript('document.getElementById("div").requestFullscreen()', true);
+    await enterFullScreen;
+    expect(w.isFullScreen()).to.be.true('isFullScreen');
+  });
+
   describe('visibilityState', () => {
     it('is initially hidden', async () => {
       const v = new WebContentsView();


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/41941.

Fixes an issue where `document.requestFullscreen` didn't work when calling it from a `webContents` inside `WebContentsView`. This was happening because we weren't setting the owner window to the associated NativeWindow after the `WebContentsView` was added to one, and therefore the fullscreen transition wasn't being triggered.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `document.requestFullscreen` didn't work when calling it from a `webContents` inside `WebContentsView`. 