### PR TITLE
build: use env var for build-tools pinning

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -167,7 +167,8 @@ jobs:
     steps:
     - name: Load Build Tools
       run: |
-        yarn add git://github.com/electron/build-tools.git#2bb63e2e7877491b52f972532b52adc979a6ec2f
+        export BUILD_TOOLS_SHA=2bb63e2e7877491b52f972532b52adc979a6ec2f
+        npm i -g @electron/build-tools
         e init --root=$(pwd) --out=Default testing
     - name: Checkout Electron
       uses: actions/checkout@v4


### PR DESCRIPTION
#### Description of Change

Incorporate https://github.com/electron/build-tools-installer/pull/30 for more durable build-tools pinning.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none