### PR TITLE
fix: recentDocuments on macOS not working

### DIFF
--- a/shell/browser/ui/cocoa/electron_menu_controller.h
+++ b/shell/browser/ui/cocoa/electron_menu_controller.h
@@ -26,8 +26,6 @@ class ElectronMenuModel;
  @protected
   base::WeakPtr<electron::ElectronMenuModel> model_;
   NSMenu* __strong menu_;
-  NSMenuItem* __strong recentDocumentsMenuItem_;
-  NSMenu* __strong recentDocumentsMenuSwap_;
   BOOL isMenuOpen_;
   BOOL useDefaultAccelerator_;
   base::OnceClosure closeCallback;

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -31,10 +31,14 @@ using SharingItem = electron::ElectronMenuModel::SharingItem;
 
 namespace {
 
+static NSMenuItem* __strong recentDocumentsMenuItem_;
+static NSMenu* __strong recentDocumentsMenuSwap_;
+
 struct Role {
   SEL selector;
   const char* role;
 };
+
 Role kRolesMap[] = {
     {@selector(orderFrontStandardAboutPanel:), "about"},
     {@selector(hide:), "hide"},


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/41973.

Fixes an issue where `recentDocuments` wasn't populating properly after the ARC migration in https://github.com/electron/electron/commit/bbdd037219f81f8c11f4cd92239f15d5365ee905. This happened because the recent documents member became a member variable instead of a static item as it was previously, meaning it was getting clobbered. This fixes that.

Tested with https://gist.github.com/efaca06ece39c8c47ed9b2dae6c3f42e

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `recentDOcuments` wasn't populating properly on macOS.
