### PR TITLE
chore: cherry-pick 2 changes from 1-M124

### DIFF
--- a/patches/DirectXShaderCompiler/.patches
+++ b/patches/DirectXShaderCompiler/.patches
@@ -1,2 +1,3 @@
 fix_hlmatrixlowerpass_leaving_call_to_dangling_functionval.patch
 cherry-pick-a65e511a14b4.patch
+cherry-pick-bc18aec94c82.patch

--- a/patches/DirectXShaderCompiler/cherry-pick-bc18aec94c82.patch
+++ b/patches/DirectXShaderCompiler/cherry-pick-bc18aec94c82.patch
@@ -1,7 +1,7 @@
-From bc18aec94c828f7dc3ba0eb8ad964dfb6453b903 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Antonio Maiorano <amaiorano@google.com>
 Date: Thu, 18 Apr 2024 13:07:04 -0400
-Subject: [PATCH] Replace dynamic_cast with virtual call (#6515)
+Subject: Replace dynamic_cast with virtual call (#6515)
 
 Make TextDiagnosticPrinter::setPrefix a virtual function in base class
 DiagnosticConsumer. This allows us to avoid using dynamic_cast in
@@ -14,13 +14,12 @@ Change-Id: Ida73077f24fdb4b705b5d868b04ac6cfecb30327
 Reviewed-on: https://chromium-review.googlesource.com/c/external/github.com/microsoft/DirectXShaderCompiler/+/5464347
 Reviewed-by: dan sinclair <dsinclair@chromium.org>
 Reviewed-by: David Neto <dneto@google.com>
----
 
 diff --git a/tools/clang/include/clang/Basic/Diagnostic.h b/tools/clang/include/clang/Basic/Diagnostic.h
-index dc9f781..0b98dff 100644
+index dc9f781c093c0bc8f6da773d514ac6d1503f842d..0b98dffb94185e242320409d43b74dae2c2a908d 100644
 --- a/tools/clang/include/clang/Basic/Diagnostic.h
 +++ b/tools/clang/include/clang/Basic/Diagnostic.h
-@@ -1395,6 +1395,8 @@
+@@ -1395,6 +1395,8 @@ public:
    /// warnings and errors.
    virtual void HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
                                  const Diagnostic &Info);
@@ -30,10 +29,10 @@ index dc9f781..0b98dff 100644
  
  /// \brief A diagnostic client that ignores all diagnostics.
 diff --git a/tools/clang/include/clang/Frontend/TextDiagnosticPrinter.h b/tools/clang/include/clang/Frontend/TextDiagnosticPrinter.h
-index 04a5705..936031e 100644
+index 04a570559fe06a0670ef8a7e6e94c40aa37e55a9..936031e09673a09c6e1164c515efce02ac51b910 100644
 --- a/tools/clang/include/clang/Frontend/TextDiagnosticPrinter.h
 +++ b/tools/clang/include/clang/Frontend/TextDiagnosticPrinter.h
-@@ -45,7 +45,8 @@
+@@ -45,7 +45,8 @@ public:
    /// setPrefix - Set the diagnostic printer prefix string, which will be
    /// printed at the start of any diagnostics. If empty, no prefix string is
    /// used.
@@ -44,10 +43,10 @@ index 04a5705..936031e 100644
    void BeginSourceFile(const LangOptions &LO, const Preprocessor *PP) override;
    void EndSourceFile() override;
 diff --git a/tools/clang/lib/CodeGen/CodeGenAction.cpp b/tools/clang/lib/CodeGen/CodeGenAction.cpp
-index 4fa721e..68ebaad 100644
+index 4fa721e812296356e31fc1bf6ea35ce295c2592c..68ebaadf5a8960c8def189248412136fe9543422 100644
 --- a/tools/clang/lib/CodeGen/CodeGenAction.cpp
 +++ b/tools/clang/lib/CodeGen/CodeGenAction.cpp
-@@ -557,7 +557,7 @@
+@@ -557,7 +557,7 @@ BackendConsumer::DxilDiagHandler(const llvm::DiagnosticInfoDxil &D) {
  
    // If no location information is available, add function name
    if (Loc.isInvalid()) {

--- a/patches/DirectXShaderCompiler/cherry-pick-bc18aec94c82.patch
+++ b/patches/DirectXShaderCompiler/cherry-pick-bc18aec94c82.patch
@@ -1,0 +1,58 @@
+From bc18aec94c828f7dc3ba0eb8ad964dfb6453b903 Mon Sep 17 00:00:00 2001
+From: Antonio Maiorano <amaiorano@google.com>
+Date: Thu, 18 Apr 2024 13:07:04 -0400
+Subject: [PATCH] Replace dynamic_cast with virtual call (#6515)
+
+Make TextDiagnosticPrinter::setPrefix a virtual function in base class
+DiagnosticConsumer. This allows us to avoid using dynamic_cast in
+BackendConsumer::DxilDiagHandler, required for codebases that do not
+enable RTTI. This is also the only place in the codebase that uses RTTI
+(AFAICT).
+
+Bug: chromium:333420620
+Change-Id: Ida73077f24fdb4b705b5d868b04ac6cfecb30327
+Reviewed-on: https://chromium-review.googlesource.com/c/external/github.com/microsoft/DirectXShaderCompiler/+/5464347
+Reviewed-by: dan sinclair <dsinclair@chromium.org>
+Reviewed-by: David Neto <dneto@google.com>
+---
+
+diff --git a/tools/clang/include/clang/Basic/Diagnostic.h b/tools/clang/include/clang/Basic/Diagnostic.h
+index dc9f781..0b98dff 100644
+--- a/tools/clang/include/clang/Basic/Diagnostic.h
++++ b/tools/clang/include/clang/Basic/Diagnostic.h
+@@ -1395,6 +1395,8 @@
+   /// warnings and errors.
+   virtual void HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
+                                 const Diagnostic &Info);
++
++  virtual void setPrefix(std::string Value) {} // HLSL Change
+ };
+ 
+ /// \brief A diagnostic client that ignores all diagnostics.
+diff --git a/tools/clang/include/clang/Frontend/TextDiagnosticPrinter.h b/tools/clang/include/clang/Frontend/TextDiagnosticPrinter.h
+index 04a5705..936031e 100644
+--- a/tools/clang/include/clang/Frontend/TextDiagnosticPrinter.h
++++ b/tools/clang/include/clang/Frontend/TextDiagnosticPrinter.h
+@@ -45,7 +45,8 @@
+   /// setPrefix - Set the diagnostic printer prefix string, which will be
+   /// printed at the start of any diagnostics. If empty, no prefix string is
+   /// used.
+-  void setPrefix(std::string Value) { Prefix = Value; }
++  // HLSL Change: add override
++  void setPrefix(std::string Value) override { Prefix = Value; }
+ 
+   void BeginSourceFile(const LangOptions &LO, const Preprocessor *PP) override;
+   void EndSourceFile() override;
+diff --git a/tools/clang/lib/CodeGen/CodeGenAction.cpp b/tools/clang/lib/CodeGen/CodeGenAction.cpp
+index 4fa721e..68ebaad 100644
+--- a/tools/clang/lib/CodeGen/CodeGenAction.cpp
++++ b/tools/clang/lib/CodeGen/CodeGenAction.cpp
+@@ -557,7 +557,7 @@
+ 
+   // If no location information is available, add function name
+   if (Loc.isInvalid()) {
+-    auto *DiagClient = dynamic_cast<TextDiagnosticPrinter*>(Diags.getClient());
++    auto *DiagClient = Diags.getClient();
+     auto *func = D.getFunction();
+     if (DiagClient && func)
+       DiagClient->setPrefix("Function: " + func->getName().str());

--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -1,2 +1,3 @@
 m123_vulkan_fix_access_to_inactive_attributes.patch
 cherry-pick-f6672dbbe223.patch
+cherry-pick-ba3b4e239620.patch

--- a/patches/angle/cherry-pick-ba3b4e239620.patch
+++ b/patches/angle/cherry-pick-ba3b4e239620.patch
@@ -1,0 +1,250 @@
+From ba3b4e239620c95792e7d23c2975be4ab26d153e Mon Sep 17 00:00:00 2001
+From: Shahbaz Youssefi <syoussefi@chromium.org>
+Date: Mon, 08 Apr 2024 10:14:45 -0400
+Subject: [PATCH] M123: SPIR-V: Fix const constructors with single scalar
+
+These constructors may be generated because of
+RemoveArrayLengthTraverser.
+
+Bug: chromium:332546345
+Change-Id: I2b2bf3728ef5bae148abc2a8518f8f3f42850025
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5462388
+(cherry picked from commit 0b776d32f69a932acb61963d9daad9e13f610944)
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5473406
+Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
+Reviewed-by: Geoff Lang <geofflang@chromium.org>
+Reviewed-by: Daniel Gagnon <dgagnon@google.com>
+---
+
+diff --git a/src/compiler/translator/Compiler.cpp b/src/compiler/translator/Compiler.cpp
+index 88f21c4..7702c9a 100644
+--- a/src/compiler/translator/Compiler.cpp
++++ b/src/compiler/translator/Compiler.cpp
+@@ -1061,6 +1061,11 @@
+     {
+         return false;
+     }
++    // Fold the expressions again, because |RemoveArrayLengthMethod| can introduce new constants.
++    if (!FoldExpressions(this, root, &mDiagnostics))
++    {
++        return false;
++    }
+ 
+     if (!RemoveUnreferencedVariables(this, root, &mSymbolTable))
+     {
+diff --git a/src/compiler/translator/spirv/OutputSPIRV.cpp b/src/compiler/translator/spirv/OutputSPIRV.cpp
+index 6eb72d6..1d85aff 100644
+--- a/src/compiler/translator/spirv/OutputSPIRV.cpp
++++ b/src/compiler/translator/spirv/OutputSPIRV.cpp
+@@ -1335,6 +1335,8 @@
+ 
+     if (type.isMatrix() && !type.isArray())
+     {
++        ASSERT(parameters.size() == type.getRows() * type.getCols());
++
+         // Matrices are constructed from their columns.
+         spirv::IdRefList columnIds;
+ 
+diff --git a/src/tests/gl_tests/GLSLTest.cpp b/src/tests/gl_tests/GLSLTest.cpp
+index 2604bd7..2ea6984 100644
+--- a/src/tests/gl_tests/GLSLTest.cpp
++++ b/src/tests/gl_tests/GLSLTest.cpp
+@@ -8486,6 +8486,198 @@
+     EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
+ }
+ 
++// Test that array length inside vector constructor works.
++TEST_P(GLSLTest_ES3, ArrayLengthInVectorConstructor)
++{
++    const char kVS[] = R"(#version 300 es
++precision highp float;
++flat out uvec4 v;
++
++int[1] f0()
++{
++    return int[1](1);
++}
++void main()
++{
++    v = uvec4(vec4(f0().length()));
++
++    gl_Position.x = ((gl_VertexID & 1) == 0 ? -1.0 : 1.0);
++    gl_Position.y = ((gl_VertexID & 2) == 0 ? -1.0 : 1.0);
++    gl_Position.zw = vec2(0, 1);
++})";
++
++    const char kFS[] = R"(#version 300 es
++precision highp float;
++flat in uvec4 v;
++out vec4 color;
++
++bool isEq(uint a, float b) { return abs(float(a) - b) < 0.01; }
++
++void main()
++{
++    if (isEq(v[0], 1.) &&
++        isEq(v[1], 1.) &&
++        isEq(v[2], 1.) &&
++        isEq(v[3], 1.))
++    {
++        color = vec4(0, 1, 0, 1);
++    }
++    else
++    {
++        color = vec4(1, 0, 0, 1);
++    }
++})";
++
++    ANGLE_GL_PROGRAM(program, kVS, kFS);
++    glUseProgram(program);
++    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
++    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
++}
++
++// Test that array length inside vector constructor works in complex expression.
++TEST_P(GLSLTest_ES3, ArrayLengthInVectorConstructorComplex)
++{
++    const char kVS[] = R"(#version 300 es
++precision highp float;
++out vec4 v;
++
++int[1] f0()
++{
++    return int[1](1);
++}
++void main()
++{
++    v = vec4(float(uint(f0().length()) + 1u) / 4.);
++
++    gl_Position.x = ((gl_VertexID & 1) == 0 ? -1.0 : 1.0);
++    gl_Position.y = ((gl_VertexID & 2) == 0 ? -1.0 : 1.0);
++    gl_Position.zw = vec2(0, 1);
++})";
++
++    const char kFS[] = R"(#version 300 es
++precision highp float;
++in vec4 v;
++out vec4 color;
++
++bool isEq(float a, float b) { return abs(float(a) - b) < 0.01; }
++
++void main()
++{
++    if (isEq(v[0], 0.5) &&
++        isEq(v[1], 0.5) &&
++        isEq(v[2], 0.5) &&
++        isEq(v[3], 0.5))
++    {
++        color = vec4(0, 1, 0, 1);
++    }
++    else
++    {
++        color = vec4(1, 0, 0, 1);
++    }
++})";
++
++    ANGLE_GL_PROGRAM(program, kVS, kFS);
++    glUseProgram(program);
++    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
++    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
++}
++
++// Test that array length inside matrix constructor works.
++TEST_P(GLSLTest_ES3, ArrayLengthInMatrixConstructor)
++{
++    const char kVS[] = R"(#version 300 es
++precision highp float;
++out mat2x2 v;
++
++int[1] f0()
++{
++    return int[1](1);
++}
++void main()
++{
++    v = mat2x2(f0().length());
++
++    gl_Position.x = ((gl_VertexID & 1) == 0 ? -1.0 : 1.0);
++    gl_Position.y = ((gl_VertexID & 2) == 0 ? -1.0 : 1.0);
++    gl_Position.zw = vec2(0, 1);
++})";
++
++    const char kFS[] = R"(#version 300 es
++precision highp float;
++in mat2x2 v;
++out vec4 color;
++
++bool isEq(float a, float b) { return abs(a - b) < 0.01; }
++
++void main()
++{
++    if (isEq(v[0][0], 1.) &&
++        isEq(v[0][1], 0.) &&
++        isEq(v[1][0], 0.) &&
++        isEq(v[1][1], 1.))
++    {
++        color = vec4(0, 1, 0, 1);
++    }
++    else
++    {
++        color = vec4(1, 0, 0, 1);
++    }
++})";
++
++    ANGLE_GL_PROGRAM(program, kVS, kFS);
++    glUseProgram(program);
++    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
++    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
++}
++
++// Test that array length inside vector constructor inside matrix constructor works.
++TEST_P(GLSLTest_ES3, ArrayLengthInVectorInMatrixConstructor)
++{
++    const char kVS[] = R"(#version 300 es
++precision highp float;
++out mat2x2 v;
++
++int[1] f0()
++{
++    return int[1](1);
++}
++void main()
++{
++    v = mat2x2(vec2(f0().length()), f0().length(), 0);
++
++    gl_Position.x = ((gl_VertexID & 1) == 0 ? -1.0 : 1.0);
++    gl_Position.y = ((gl_VertexID & 2) == 0 ? -1.0 : 1.0);
++    gl_Position.zw = vec2(0, 1);
++})";
++
++    const char kFS[] = R"(#version 300 es
++precision highp float;
++in mat2x2 v;
++out vec4 color;
++
++bool isEq(float a, float b) { return abs(a - b) < 0.01; }
++
++void main()
++{
++    if (isEq(v[0][0], 1.) &&
++        isEq(v[0][1], 1.) &&
++        isEq(v[1][0], 1.) &&
++        isEq(v[1][1], 0.))
++    {
++        color = vec4(0, 1, 0, 1);
++    }
++    else
++    {
++        color = vec4(1, 0, 0, 1);
++    }
++})";
++
++    ANGLE_GL_PROGRAM(program, kVS, kFS);
++    glUseProgram(program);
++    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
++    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
++}
++
+ // Test that statements inside switch() get translated to correct HLSL.
+ TEST_P(GLSLTest_ES3, DifferentStatementsInsideSwitch)
+ {

--- a/patches/angle/cherry-pick-ba3b4e239620.patch
+++ b/patches/angle/cherry-pick-ba3b4e239620.patch
@@ -1,7 +1,7 @@
-From ba3b4e239620c95792e7d23c2975be4ab26d153e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shahbaz Youssefi <syoussefi@chromium.org>
-Date: Mon, 08 Apr 2024 10:14:45 -0400
-Subject: [PATCH] M123: SPIR-V: Fix const constructors with single scalar
+Date: Mon, 8 Apr 2024 10:14:45 -0400
+Subject: M123: SPIR-V: Fix const constructors with single scalar
 
 These constructors may be generated because of
 RemoveArrayLengthTraverser.
@@ -14,13 +14,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5473406
 Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
 Reviewed-by: Geoff Lang <geofflang@chromium.org>
 Reviewed-by: Daniel Gagnon <dgagnon@google.com>
----
 
 diff --git a/src/compiler/translator/Compiler.cpp b/src/compiler/translator/Compiler.cpp
-index 88f21c4..7702c9a 100644
+index b76923563fd186087dc34be142934b84874da853..9a7e46f644fb8bb01561c5c1a6e332249b31276c 100644
 --- a/src/compiler/translator/Compiler.cpp
 +++ b/src/compiler/translator/Compiler.cpp
-@@ -1061,6 +1061,11 @@
+@@ -1035,6 +1035,11 @@ bool TCompiler::checkAndSimplifyAST(TIntermBlock *root,
      {
          return false;
      }
@@ -33,10 +32,10 @@ index 88f21c4..7702c9a 100644
      if (!RemoveUnreferencedVariables(this, root, &mSymbolTable))
      {
 diff --git a/src/compiler/translator/spirv/OutputSPIRV.cpp b/src/compiler/translator/spirv/OutputSPIRV.cpp
-index 6eb72d6..1d85aff 100644
+index caa8f956716abf53aaeb58a5f654f5a4f04c4d6a..67b1fdd4784660483a408f1ee27ce48b05ffcb0a 100644
 --- a/src/compiler/translator/spirv/OutputSPIRV.cpp
 +++ b/src/compiler/translator/spirv/OutputSPIRV.cpp
-@@ -1335,6 +1335,8 @@
+@@ -1335,6 +1335,8 @@ spirv::IdRef OutputSPIRVTraverser::createComplexConstant(const TType &type,
  
      if (type.isMatrix() && !type.isArray())
      {
@@ -46,10 +45,10 @@ index 6eb72d6..1d85aff 100644
          spirv::IdRefList columnIds;
  
 diff --git a/src/tests/gl_tests/GLSLTest.cpp b/src/tests/gl_tests/GLSLTest.cpp
-index 2604bd7..2ea6984 100644
+index c9d954ed1f7a4bfd4d5b5d5916d3def07aaa2637..8c13f9ef1dafb63d5ed8aa557a152404585608be 100644
 --- a/src/tests/gl_tests/GLSLTest.cpp
 +++ b/src/tests/gl_tests/GLSLTest.cpp
-@@ -8486,6 +8486,198 @@
+@@ -8486,6 +8486,198 @@ void main()
      EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
  }
  


### PR DESCRIPTION
<details>
<summary>electron/security#494 - bc18aec94c82 from DirectXShaderCompiler</summary>
Replace dynamic_cast with virtual call (#6515)

Make TextDiagnosticPrinter::setPrefix a virtual function in base class
DiagnosticConsumer. This allows us to avoid using dynamic_cast in
BackendConsumer::DxilDiagHandler, required for codebases that do not
enable RTTI. This is also the only place in the codebase that uses RTTI
(AFAICT).

Bug: chromium:333420620
Change-Id: Ida73077f24fdb4b705b5d868b04ac6cfecb30327
Reviewed-on: https://chromium-review.googlesource.com/c/external/github.com/microsoft/DirectXShaderCompiler/+/5464347
Reviewed-by: dan sinclair <dsinclair@chromium.org>
Reviewed-by: David Neto <dneto@google.com>
</details>

<details>
<summary>electron/security#493 - ba3b4e239620 from angle</summary>
M123: SPIR-V: Fix const constructors with single scalar

These constructors may be generated because of
RemoveArrayLengthTraverser.

Bug: chromium:332546345
Change-Id: I2b2bf3728ef5bae148abc2a8518f8f3f42850025
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5462388
(cherry picked from commit 0b776d32f69a932acb61963d9daad9e13f610944)
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5473406
Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
Reviewed-by: Geoff Lang <geofflang@chromium.org>
Reviewed-by: Daniel Gagnon <dgagnon@google.com>
</details>

Notes:
* Security: backported fix for CVE-2024-4060.
* Security: backported fix for CVE-2024-4058.