### PR TITLE
perf: avoid protocol registry redundant lookup

### DIFF
--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -232,7 +232,7 @@ bool Protocol::UnregisterProtocol(const std::string& scheme,
 }
 
 bool Protocol::IsProtocolRegistered(const std::string& scheme) {
-  return protocol_registry_->IsProtocolRegistered(scheme);
+  return protocol_registry_->RegisteredProtocol(scheme) != nullptr;
 }
 
 ProtocolError Protocol::InterceptProtocol(ProtocolType type,
@@ -251,7 +251,7 @@ bool Protocol::UninterceptProtocol(const std::string& scheme,
 }
 
 bool Protocol::IsProtocolIntercepted(const std::string& scheme) {
-  return protocol_registry_->IsProtocolIntercepted(scheme);
+  return protocol_registry_->InterceptedProtocol(scheme) != nullptr;
 }
 
 v8::Local<v8::Promise> Protocol::IsProtocolHandled(const std::string& scheme,

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -232,7 +232,7 @@ bool Protocol::UnregisterProtocol(const std::string& scheme,
 }
 
 bool Protocol::IsProtocolRegistered(const std::string& scheme) {
-  return protocol_registry_->RegisteredProtocol(scheme) != nullptr;
+  return protocol_registry_->FindRegistered(scheme) != nullptr;
 }
 
 ProtocolError Protocol::InterceptProtocol(ProtocolType type,
@@ -251,7 +251,7 @@ bool Protocol::UninterceptProtocol(const std::string& scheme,
 }
 
 bool Protocol::IsProtocolIntercepted(const std::string& scheme) {
-  return protocol_registry_->InterceptedProtocol(scheme) != nullptr;
+  return protocol_registry_->FindIntercepted(scheme) != nullptr;
 }
 
 v8::Local<v8::Promise> Protocol::IsProtocolHandled(const std::string& scheme,

--- a/shell/browser/protocol_registry.cc
+++ b/shell/browser/protocol_registry.cc
@@ -75,6 +75,13 @@ bool ProtocolRegistry::UnregisterProtocol(const std::string& scheme) {
   return handlers_.erase(scheme) != 0;
 }
 
+const HandlersMap::mapped_type* ProtocolRegistry::RegisteredProtocol(
+    const std::string& scheme) const {
+  const auto& map = handlers_;
+  const auto iter = map.find(scheme);
+  return iter != std::end(map) ? &iter->second : nullptr;
+}
+
 bool ProtocolRegistry::IsProtocolRegistered(const std::string& scheme) {
   return base::Contains(handlers_, scheme);
 }
@@ -87,6 +94,13 @@ bool ProtocolRegistry::InterceptProtocol(ProtocolType type,
 
 bool ProtocolRegistry::UninterceptProtocol(const std::string& scheme) {
   return intercept_handlers_.erase(scheme) != 0;
+}
+
+const HandlersMap::mapped_type* ProtocolRegistry::InterceptedProtocol(
+    const std::string& scheme) const {
+  const auto& map = intercept_handlers_;
+  const auto iter = map.find(scheme);
+  return iter != std::end(map) ? &iter->second : nullptr;
 }
 
 bool ProtocolRegistry::IsProtocolIntercepted(const std::string& scheme) {

--- a/shell/browser/protocol_registry.cc
+++ b/shell/browser/protocol_registry.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/protocol_registry.h"
 
-#include "base/stl_util.h"
 #include "content/public/browser/web_contents.h"
 #include "electron/fuses.h"
 #include "shell/browser/electron_browser_context.h"
@@ -82,10 +81,6 @@ const HandlersMap::mapped_type* ProtocolRegistry::RegisteredProtocol(
   return iter != std::end(map) ? &iter->second : nullptr;
 }
 
-bool ProtocolRegistry::IsProtocolRegistered(const std::string& scheme) {
-  return base::Contains(handlers_, scheme);
-}
-
 bool ProtocolRegistry::InterceptProtocol(ProtocolType type,
                                          const std::string& scheme,
                                          const ProtocolHandler& handler) {
@@ -101,10 +96,6 @@ const HandlersMap::mapped_type* ProtocolRegistry::InterceptedProtocol(
   const auto& map = intercept_handlers_;
   const auto iter = map.find(scheme);
   return iter != std::end(map) ? &iter->second : nullptr;
-}
-
-bool ProtocolRegistry::IsProtocolIntercepted(const std::string& scheme) {
-  return base::Contains(intercept_handlers_, scheme);
 }
 
 }  // namespace electron

--- a/shell/browser/protocol_registry.cc
+++ b/shell/browser/protocol_registry.cc
@@ -74,7 +74,7 @@ bool ProtocolRegistry::UnregisterProtocol(const std::string& scheme) {
   return handlers_.erase(scheme) != 0;
 }
 
-const HandlersMap::mapped_type* ProtocolRegistry::RegisteredProtocol(
+const HandlersMap::mapped_type* ProtocolRegistry::FindRegistered(
     const std::string& scheme) const {
   const auto& map = handlers_;
   const auto iter = map.find(scheme);
@@ -91,7 +91,7 @@ bool ProtocolRegistry::UninterceptProtocol(const std::string& scheme) {
   return intercept_handlers_.erase(scheme) != 0;
 }
 
-const HandlersMap::mapped_type* ProtocolRegistry::InterceptedProtocol(
+const HandlersMap::mapped_type* ProtocolRegistry::FindIntercepted(
     const std::string& scheme) const {
   const auto& map = intercept_handlers_;
   const auto iter = map.find(scheme);

--- a/shell/browser/protocol_registry.h
+++ b/shell/browser/protocol_registry.h
@@ -41,11 +41,17 @@ class ProtocolRegistry {
   bool UnregisterProtocol(const std::string& scheme);
   bool IsProtocolRegistered(const std::string& scheme);
 
+  [[nodiscard]] const HandlersMap::mapped_type* RegisteredProtocol(
+      const std::string& scheme) const;
+
   bool InterceptProtocol(ProtocolType type,
                          const std::string& scheme,
                          const ProtocolHandler& handler);
   bool UninterceptProtocol(const std::string& scheme);
   bool IsProtocolIntercepted(const std::string& scheme);
+
+  [[nodiscard]] const HandlersMap::mapped_type* InterceptedProtocol(
+      const std::string& scheme) const;
 
  private:
   friend class ElectronBrowserContext;

--- a/shell/browser/protocol_registry.h
+++ b/shell/browser/protocol_registry.h
@@ -33,7 +33,6 @@ class ProtocolRegistry {
   CreateNonNetworkNavigationURLLoaderFactory(const std::string& scheme);
 
   const HandlersMap& intercept_handlers() const { return intercept_handlers_; }
-  const HandlersMap& handlers() const { return handlers_; }
 
   bool RegisterProtocol(ProtocolType type,
                         const std::string& scheme,

--- a/shell/browser/protocol_registry.h
+++ b/shell/browser/protocol_registry.h
@@ -39,7 +39,7 @@ class ProtocolRegistry {
                         const ProtocolHandler& handler);
   bool UnregisterProtocol(const std::string& scheme);
 
-  [[nodiscard]] const HandlersMap::mapped_type* RegisteredProtocol(
+  [[nodiscard]] const HandlersMap::mapped_type* FindRegistered(
       const std::string& scheme) const;
 
   bool InterceptProtocol(ProtocolType type,
@@ -47,7 +47,7 @@ class ProtocolRegistry {
                          const ProtocolHandler& handler);
   bool UninterceptProtocol(const std::string& scheme);
 
-  [[nodiscard]] const HandlersMap::mapped_type* InterceptedProtocol(
+  [[nodiscard]] const HandlersMap::mapped_type* FindIntercepted(
       const std::string& scheme) const;
 
  private:

--- a/shell/browser/protocol_registry.h
+++ b/shell/browser/protocol_registry.h
@@ -39,7 +39,6 @@ class ProtocolRegistry {
                         const std::string& scheme,
                         const ProtocolHandler& handler);
   bool UnregisterProtocol(const std::string& scheme);
-  bool IsProtocolRegistered(const std::string& scheme);
 
   [[nodiscard]] const HandlersMap::mapped_type* RegisteredProtocol(
       const std::string& scheme) const;
@@ -48,7 +47,6 @@ class ProtocolRegistry {
                          const std::string& scheme,
                          const ProtocolHandler& handler);
   bool UninterceptProtocol(const std::string& scheme);
-  bool IsProtocolIntercepted(const std::string& scheme);
 
   [[nodiscard]] const HandlersMap::mapped_type* InterceptedProtocol(
       const std::string& scheme) const;

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -684,7 +684,7 @@ void InspectableWebContents::LoadNetworkResource(DispatchCallback callback,
         std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
             std::move(pending_remote)));
   } else if (const auto* const handler =
-                 protocol_registry->RegisteredProtocol(gurl.scheme())) {
+                 protocol_registry->FindRegistered(gurl.scheme())) {
     url_loader_factory = network::SharedURLLoaderFactory::Create(
         std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
             ElectronURLLoaderFactory::Create(handler->first, handler->second)));

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -683,11 +683,12 @@ void InspectableWebContents::LoadNetworkResource(DispatchCallback callback,
     url_loader_factory = network::SharedURLLoaderFactory::Create(
         std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
             std::move(pending_remote)));
-  } else if (const auto* const handler =
+  } else if (const auto* const protocol_handler =
                  protocol_registry->FindRegistered(gurl.scheme())) {
     url_loader_factory = network::SharedURLLoaderFactory::Create(
         std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
-            ElectronURLLoaderFactory::Create(handler->first, handler->second)));
+            ElectronURLLoaderFactory::Create(protocol_handler->first,
+                                             protocol_handler->second)));
   } else {
     auto* partition = GetDevToolsWebContents()
                           ->GetBrowserContext()

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -674,7 +674,7 @@ void InspectableWebContents::LoadNetworkResource(DispatchCallback callback,
   resource_request.site_for_cookies = net::SiteForCookies::FromUrl(gurl);
   resource_request.headers.AddHeadersFromString(headers);
 
-  auto* protocol_registry = ProtocolRegistry::FromBrowserContext(
+  const auto* const protocol_registry = ProtocolRegistry::FromBrowserContext(
       GetDevToolsWebContents()->GetBrowserContext());
   NetworkResourceLoader::URLLoaderFactoryHolder url_loader_factory;
   if (gurl.SchemeIsFile()) {
@@ -683,14 +683,11 @@ void InspectableWebContents::LoadNetworkResource(DispatchCallback callback,
     url_loader_factory = network::SharedURLLoaderFactory::Create(
         std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
             std::move(pending_remote)));
-  } else if (protocol_registry->IsProtocolRegistered(gurl.scheme())) {
-    auto& protocol_handler = protocol_registry->handlers().at(gurl.scheme());
-    mojo::PendingRemote<network::mojom::URLLoaderFactory> pending_remote =
-        ElectronURLLoaderFactory::Create(protocol_handler.first,
-                                         protocol_handler.second);
+  } else if (const auto* const handler =
+                 protocol_registry->RegisteredProtocol(gurl.scheme())) {
     url_loader_factory = network::SharedURLLoaderFactory::Create(
         std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
-            std::move(pending_remote)));
+            ElectronURLLoaderFactory::Create(handler->first, handler->second)));
   } else {
     auto* partition = GetDevToolsWebContents()
                           ->GetBrowserContext()

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -485,15 +485,17 @@ SimpleURLLoaderWrapper::GetURLLoaderFactoryForURL(const GURL& url) {
     const auto scheme = url.scheme();
     const auto* reg = ProtocolRegistry::FromBrowserContext(browser_context_);
 
-    if (const auto* proto = reg->InterceptedProtocol(scheme))
+    if (const auto* handler = reg->FindIntercepted(scheme))
       return network::SharedURLLoaderFactory::Create(
           std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
-              ElectronURLLoaderFactory::Create(proto->first, proto->second)));
+              ElectronURLLoaderFactory::Create(handler->first,
+                                               handler->second)));
 
-    if (const auto* proto = reg->RegisteredProtocol(scheme))
+    if (const auto* handler = reg->FindRegistered(scheme))
       return network::SharedURLLoaderFactory::Create(
           std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
-              ElectronURLLoaderFactory::Create(proto->first, proto->second)));
+              ElectronURLLoaderFactory::Create(handler->first,
+                                               handler->second)));
   }
 
   if (url.SchemeIsFile())


### PR DESCRIPTION
#### Description of Change

Fix a performance wart in `ProtocolRegistry`. The current workflow is to call `ProtocolRegistry::handlers().at(scheme)` after a safeguard check to `ProtocolRegistry::IsRegistered(scheme)`.  This workflow requires a redundant lookup for `scheme` and is also a minor demeter violation.

This PR replaces the methods `ProtocolRegistry::IsRegistered(scheme)` and `ProtocolRegistry::handlers(scheme)` with a new `ProtocolRegistry::FindRegistered(scheme) const` that returns a const pointer to the handler, or `nullptr` if none is found.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none