### PR TITLE
feat: extend navigationHistory API

### DIFF
--- a/docs/api/navigation-history.md
+++ b/docs/api/navigation-history.md
@@ -74,12 +74,3 @@ Returns `boolean` - Whether the navigation entry was removed from the webContent
 #### `navigationHistory.getAllEntries()`
 
 Returns [`NavigationEntry[]`](structures/navigation-entry.md) - WebContents complete history.
-
-#### `navigationHistory.replace(newHistory, index)`
-
-* `newHistory` [`NavigationEntry[]`](structures/navigation-entry.md)
-* `index` Integer
-
-Replaces current history with `newHistory` and sets the active index to `index`. Can't replace history item at the "current active index".
-
-Returns `boolean` - Whether the history was replaced.

--- a/docs/api/navigation-history.md
+++ b/docs/api/navigation-history.md
@@ -63,11 +63,11 @@ Navigates to the specified offset from the current entry.
 
 Returns `Integer` - History length.
 
-#### `navigationHistory.deleteEntryAtIndex(index)`
+#### `navigationHistory.removeEntryAtIndex(index)`
 
 * `index` Integer
 
-Deletes the navigation entry at the given index. Can't delete entry at the "current active index".
+Removes the navigation entry at the given index. Can't remove entry at the "current active index".
 
 Returns `boolean` - Whether the navigation entry was removed from the webContents history.
 

--- a/docs/api/navigation-history.md
+++ b/docs/api/navigation-history.md
@@ -71,11 +71,11 @@ Deletes the navigation entry at the given index. Can't delete entry at the "curr
 
 Returns `boolean` - Whether the navigation entry was removed from the webContents history.
 
-#### `navigationHistory.getHistory()`
+#### `navigationHistory.getAllEntries()`
 
 Returns [`NavigationEntry[]`](structures/navigation-entry.md) - WebContents complete history.
 
-#### `navigationHistory.replaceHistory(newHistory, index)`
+#### `navigationHistory.replace(newHistory, index)`
 
 * `newHistory` [`NavigationEntry[]`](structures/navigation-entry.md)
 * `index` Integer

--- a/docs/api/navigation-history.md
+++ b/docs/api/navigation-history.md
@@ -35,10 +35,7 @@ Returns `Integer` - The index of the current page, from which we would go back/f
 
 * `index` Integer
 
-Returns `Object`:
-
-* `url` string - The URL of the navigation entry at the given index.
-* `title` string - The page title of the navigation entry at the given index.
+Returns [`NavigationEntry`](structures/navigation-entry.md) - Navigation entry at the given index.
 
 If index is out of bounds (greater than history length or less than 0), null will be returned.
 
@@ -65,3 +62,24 @@ Navigates to the specified offset from the current entry.
 #### `navigationHistory.length()`
 
 Returns `Integer` - History length.
+
+#### `navigationHistory.deleteEntryAtIndex(index)`
+
+* `index` Integer
+
+Deletes the navigation entry at the given index. Can't delete entry at the "current active index".
+
+Returns `boolean` - Whether the navigation entry was removed from the webContents history.
+
+#### `navigationHistory.getHistory()`
+
+Returns [`NavigationEntry[]`](structures/navigation-entry.md) - WebContents complete history.
+
+#### `navigationHistory.replaceHistory(newHistory, index)`
+
+* `newHistory` [`NavigationEntry[]`](structures/navigation-entry.md)
+* `index` Integer
+
+Replaces current history with `newHistory` and sets the active index to `index`. Can't replace history item at the "current active index".
+
+Returns `boolean` - Whether the history was replaced.

--- a/docs/api/structures/navigation-entry.md
+++ b/docs/api/structures/navigation-entry.md
@@ -1,0 +1,4 @@
+# NavigationEntry Object
+
+* `url` string
+* `title` string

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -105,6 +105,7 @@ auto_filenames = {
     "docs/api/structures/mime-typed-buffer.md",
     "docs/api/structures/mouse-input-event.md",
     "docs/api/structures/mouse-wheel-input-event.md",
+    "docs/api/structures/navigation-entry.md",
     "docs/api/structures/notification-action.md",
     "docs/api/structures/notification-response.md",
     "docs/api/structures/open-external-permission-request.md",

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -597,8 +597,7 @@ WebContents.prototype._init = function () {
       length: this._historyLength.bind(this),
       getEntryAtIndex: this._getNavigationEntryAtIndex.bind(this),
       removeEntryAtIndex: this._removeNavigationEntryAtIndex.bind(this),
-      getAllEntries: this._getHistory.bind(this),
-      replace: this._replaceHistory.bind(this)
+      getAllEntries: this._getHistory.bind(this)
     },
     writable: false,
     enumerable: true

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -595,7 +595,10 @@ WebContents.prototype._init = function () {
       goToOffset: this._goToOffset.bind(this),
       getActiveIndex: this._getActiveIndex.bind(this),
       length: this._historyLength.bind(this),
-      getEntryAtIndex: this._getNavigationEntryAtIndex.bind(this)
+      getEntryAtIndex: this._getNavigationEntryAtIndex.bind(this),
+      deleteEntryAtIndex: this._deleteNavigationEntryAtIndex.bind(this),
+      getHistory: this._getHistory.bind(this),
+      replaceHistory: this._replaceHistory.bind(this)
     },
     writable: false,
     enumerable: true

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -596,7 +596,7 @@ WebContents.prototype._init = function () {
       getActiveIndex: this._getActiveIndex.bind(this),
       length: this._historyLength.bind(this),
       getEntryAtIndex: this._getNavigationEntryAtIndex.bind(this),
-      deleteEntryAtIndex: this._deleteNavigationEntryAtIndex.bind(this),
+      removeEntryAtIndex: this._removeNavigationEntryAtIndex.bind(this),
       getAllEntries: this._getHistory.bind(this),
       replace: this._replaceHistory.bind(this)
     },

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -597,8 +597,8 @@ WebContents.prototype._init = function () {
       length: this._historyLength.bind(this),
       getEntryAtIndex: this._getNavigationEntryAtIndex.bind(this),
       deleteEntryAtIndex: this._deleteNavigationEntryAtIndex.bind(this),
-      getHistory: this._getHistory.bind(this),
-      replaceHistory: this._replaceHistory.bind(this)
+      getAllEntries: this._getHistory.bind(this),
+      replace: this._replaceHistory.bind(this)
     },
     writable: false,
     enumerable: true

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2497,7 +2497,7 @@ content::NavigationEntry* WebContents::GetNavigationEntryAtIndex(
 }
 
 bool WebContents::DeleteNavigationEntryAtIndex(int index) {
-  if (index < 0 || index >= GetHistoryLength())
+  if (!CanGoToIndex(index))
     return false;
 
   return web_contents()->GetController().RemoveEntryAtIndex(index);

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2496,7 +2496,7 @@ content::NavigationEntry* WebContents::GetNavigationEntryAtIndex(
   return web_contents()->GetController().GetEntryAtIndex(index);
 }
 
-bool WebContents::DeleteNavigationEntryAtIndex(int index) {
+bool WebContents::RemoveNavigationEntryAtIndex(int index) {
   if (!CanGoToIndex(index))
     return false;
 
@@ -4347,8 +4347,8 @@ void WebContents::FillObjectTemplate(v8::Isolate* isolate,
       .SetMethod("_getNavigationEntryAtIndex",
                  &WebContents::GetNavigationEntryAtIndex)
       .SetMethod("_historyLength", &WebContents::GetHistoryLength)
-      .SetMethod("_deleteNavigationEntryAtIndex",
-                 &WebContents::DeleteNavigationEntryAtIndex)
+      .SetMethod("_removeNavigationEntryAtIndex",
+                 &WebContents::RemoveNavigationEntryAtIndex)
       .SetMethod("_getHistory", &WebContents::GetHistory)
       .SetMethod("_replaceHistory", &WebContents::ReplaceHistory)
       .SetMethod("_clearHistory", &WebContents::ClearHistory)

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2521,33 +2521,6 @@ std::vector<content::NavigationEntry*> WebContents::GetHistory() const {
   return history;
 }
 
-bool WebContents::ReplaceHistory(
-    const std::vector<gin_helper::Dictionary>& new_history,
-    int index) {
-  std::vector<std::unique_ptr<content::NavigationEntry>> history;
-  history.reserve(new_history.size());
-
-  for (const gin_helper::Dictionary& history_item : new_history) {
-    auto entry = content::NavigationEntry::Create();
-    entry->SetIsOverridingUserAgent(true);
-    std::u16string url, title;
-    if (history_item.Get("url", &url))
-      entry->SetURL(GURL(url));
-    if (history_item.Get("title", &title))
-      entry->SetTitle(title);
-
-    history.push_back(std::move(entry));
-  }
-
-  auto& controller = web_contents()->GetController();
-  if (!controller.CanPruneAllButLastCommitted())
-    return false;
-
-  controller.PruneAllButLastCommitted();
-  controller.Restore(index, content::RestoreType::kRestored, &history);
-  return true;
-}
-
 void WebContents::ClearHistory() {
   // In some rare cases (normally while there is no real history) we are in a
   // state where we can't prune navigation entries
@@ -4350,7 +4323,6 @@ void WebContents::FillObjectTemplate(v8::Isolate* isolate,
       .SetMethod("_removeNavigationEntryAtIndex",
                  &WebContents::RemoveNavigationEntryAtIndex)
       .SetMethod("_getHistory", &WebContents::GetHistory)
-      .SetMethod("_replaceHistory", &WebContents::ReplaceHistory)
       .SetMethod("_clearHistory", &WebContents::ClearHistory)
       .SetMethod("isCrashed", &WebContents::IsCrashed)
       .SetMethod("forcefullyCrashRenderer",

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -204,6 +204,10 @@ class WebContents : public ExclusiveAccessContext,
   void GoToIndex(int index);
   int GetActiveIndex() const;
   content::NavigationEntry* GetNavigationEntryAtIndex(int index) const;
+  bool DeleteNavigationEntryAtIndex(int index);
+  std::vector<content::NavigationEntry*> GetHistory() const;
+  bool ReplaceHistory(const std::vector<gin_helper::Dictionary>& new_history,
+                      int index);
   void ClearHistory();
   int GetHistoryLength() const;
   const std::string GetWebRTCIPHandlingPolicy() const;

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -204,7 +204,7 @@ class WebContents : public ExclusiveAccessContext,
   void GoToIndex(int index);
   int GetActiveIndex() const;
   content::NavigationEntry* GetNavigationEntryAtIndex(int index) const;
-  bool DeleteNavigationEntryAtIndex(int index);
+  bool RemoveNavigationEntryAtIndex(int index);
   std::vector<content::NavigationEntry*> GetHistory() const;
   bool ReplaceHistory(const std::vector<gin_helper::Dictionary>& new_history,
                       int index);

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -206,8 +206,6 @@ class WebContents : public ExclusiveAccessContext,
   content::NavigationEntry* GetNavigationEntryAtIndex(int index) const;
   bool RemoveNavigationEntryAtIndex(int index);
   std::vector<content::NavigationEntry*> GetHistory() const;
-  bool ReplaceHistory(const std::vector<gin_helper::Dictionary>& new_history,
-                      int index);
   void ClearHistory();
   int GetHistoryLength() const;
   const std::string GetWebRTCIPHandlingPolicy() const;

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -99,7 +99,6 @@ declare namespace Electron {
     _goToIndex(index: number): void;
     _removeNavigationEntryAtIndex(index: number): boolean;
     _getHistory(): Electron.NavigationEntry[];
-    _replaceHistory(newHistory: Electron.NavigationEntry[], index: number): boolean;
     _clearHistory():void
     canGoToIndex(index: number): boolean;
     destroy(): void;

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -97,7 +97,7 @@ declare namespace Electron {
     _goForward(): void;
     _goToOffset(index: number): void;
     _goToIndex(index: number): void;
-    _deleteNavigationEntryAtIndex(index: number): boolean;
+    _removeNavigationEntryAtIndex(index: number): boolean;
     _getHistory(): Electron.NavigationEntry[];
     _replaceHistory(newHistory: Electron.NavigationEntry[], index: number): boolean;
     _clearHistory():void

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -87,7 +87,7 @@ declare namespace Electron {
     _print(options: any, callback?: (success: boolean, failureReason: string) => void): void;
     _getPrintersAsync(): Promise<Electron.PrinterInfo[]>;
     _init(): void;
-    _getNavigationEntryAtIndex(index: number): Electron.EntryAtIndex | null;
+    _getNavigationEntryAtIndex(index: number): Electron.NavigationEntry | null;
     _getActiveIndex(): number;
     _historyLength(): number;
     _canGoBack(): boolean;
@@ -97,6 +97,9 @@ declare namespace Electron {
     _goForward(): void;
     _goToOffset(index: number): void;
     _goToIndex(index: number): void;
+    _deleteNavigationEntryAtIndex(index: number): boolean;
+    _getHistory(): Electron.NavigationEntry[];
+    _replaceHistory(newHistory: Electron.NavigationEntry[], index: number): boolean;
     _clearHistory():void
     canGoToIndex(index: number): boolean;
     destroy(): void;


### PR DESCRIPTION
#### Description of Change

This PR builds on #41577 and adds 2 more functions to `webContents.navigationHistory`.
The motivation is to provide an API for developers of browser-type applications.

New API:
- `navigationHistory.removeEntryAtIndex(index)` - Removes the navigation entry at the given index.
- `navigationHistory.getAllEntries()` - Returns webContents complete history.

This enables browser-type applications to save (`getAllEntries`) browsing sessions.
Also partially resolves these feature requests: #33899 #41250



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Extended `navigationHistory` API with 2 new functions for better history management.