### PR TITLE
fix: prevent modification of invalid Content-Disposition header to avoid potential parsing errors.

### DIFF
--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -107,12 +107,14 @@ v8::Local<v8::Value> HttpResponseHeadersToV8(
       if (base::EqualsCaseInsensitiveASCII("Content-Disposition", key) &&
           !value.empty()) {
         net::HttpContentDisposition header(value, std::string());
-        std::string decodedFilename =
-            header.is_attachment() ? " attachment" : " inline";
-        // The filename must be encased in double quotes for serialization
-        // to happen correctly.
-        std::string filename = "\"" + header.filename() + "\"";
-        value = decodedFilename + "; filename=" + filename;
+        if (!header.filename().empty()) {
+          std::string decodedFilename =
+              header.is_attachment() ? " attachment" : " inline";
+          // The filename must be encased in double quotes for serialization
+          // to happen correctly.
+          std::string filename = "\"" + header.filename() + "\"";
+          value = decodedFilename + "; filename=" + filename;
+        }
       }
       response_headers.EnsureList(key)->Append(value);
     }

--- a/spec/api-web-request-spec.ts
+++ b/spec/api-web-request-spec.ts
@@ -28,6 +28,13 @@ describe('webRequest module', () => {
       ]);
       const content = req.url;
       res.end(content);
+    } else if (req.url === '/contentDisposition-invalid') {
+      res.writeHead(200, [
+        'content-disposition',
+        Buffer.from('attachment; filename*=UTF-8"test.json"').toString('binary')
+      ]);
+      const content = req.url;
+      res.end(content);
     } else {
       res.setHeader('Custom', ['Header']);
       let content = req.url;
@@ -481,6 +488,17 @@ describe('webRequest module', () => {
       const disposition = Buffer.from('attachment; filename=aa中aa.txt').toString('binary');
       expect(headers).to.to.have.property('content-disposition', disposition);
       expect(data).to.equal('/contentDisposition');
+    });
+
+    it('does not change content-disposition header when it is invalid', async () => {
+      ses.webRequest.onHeadersReceived((details, callback) => {
+        expect(details.responseHeaders!['content-disposition']).to.deep.equal([' attachment; filename*=UTF-8"test.json"']);
+        callback({});
+      });
+      const { data, headers } = await ajax(defaultURL + 'contentDisposition-invalid');
+      const disposition = Buffer.from('attachment; filename*=UTF-8"test.json"').toString('binary');
+      expect(headers).to.to.have.property('content-disposition', disposition);
+      expect(data).to.equal('/contentDisposition-invalid');
     });
 
     it('follows server redirect', async () => {


### PR DESCRIPTION
#### Description of Change

 Introduce validation for the Content-Disposition header to ensure it's parsed correctly before using the extracted filename. This will improve code robustness and prevent potential issues.

#### Checklist

- [X] PR description included and stakeholders cc'd
- [] `npm test` passes - unable to run it - 
- [X] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes
Notes: Prevent modification of invalid Content-Disposition header to avoid potential parsing errors.

#### Additional info

I was unable to run the tests:
Triggering runners: main
OUT_DIR is: Release
yarn install v1.15.2
warning package.json: No license field
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
warning electron-test-main@0.1.0: No license field
[1/4] Resolving packages...
warning Resolution field "xml2js@0.5.0" is incompatible with requested version "xml2js@^0.4.17"
warning Resolution field "minimist@1.2.7" is incompatible with requested version "minimist@~0.0.1"
[2/4] Fetching packages...
error https://registry.yarnpkg.com/@nut-tree/libnut-win32/-/libnut-win32-2.5.2.tgz: Request failed "404 Not Found"
error https://registry.yarnpkg.com/@nut-tree/libnut/-/libnut-2.5.2.tgz: Request failed "404 Not Found"
error https://registry.yarnpkg.com/@nut-tree/nut-js/-/nut-js-3.1.2.tgz: Request failed "404 Not Found"
error https://registry.yarnpkg.com/@nut-tree/libnut-darwin/-/libnut-darwin-2.5.2.tgz: Request failed "404 Not Found"
error https://registry.yarnpkg.com/@nut-tree/libnut-linux/-/libnut-linux-2.5.2.tgz: Request failed "404 Not Found"
error https://registry.yarnpkg.com/@nut-tree/node-mac-permissions/-/node-mac-permissions-2.2.1.tgz: Request failed "404 Not Found"
info abstract-socket@2.1.1: The platform "win32" is incompatible with this module.
info "abstract-socket@2.1.1" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@2.3.2: The platform "win32" is incompatible with this module.
info "fsevents@2.3.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
error An unexpected error occurred: "ENOENT: no such file or directory, open 'C:\\Users\\user\\AppData\\Local\\Yarn\\Cache\\v4\\npm-@nut-tree-libnut-2.5.2-0e410c108bee31c57ca5923e409762ff223d70de\\node_modules\\@nut-tree\\libnut\\.yarn-metadata.json'".
info If you think this is a bug, please open a bug report with the information provided in "C:\\src\\electron\\spec\\yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
