### PR TITLE
docs: fix lint command

### DIFF
--- a/docs/development/coding-style.md
+++ b/docs/development/coding-style.md
@@ -41,7 +41,7 @@ etc.
 
 * Write [remark](https://github.com/remarkjs/remark) markdown style.
 
-You can run `npm run lint-docs` to ensure that your documentation changes are
+You can run `npm run lint:docs` to ensure that your documentation changes are
 formatted correctly.
 
 ## JavaScript


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Fixes outdated docs lint command in `coding-style.md`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed incorrect docs linting command in docs.<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
