### PR TITLE
ci: auto label bug issues with version label

### DIFF
--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
           org: electron
-      - run: npm install mdast-util-from-markdown@2.0.0 unist-util-select@5.1.0
+      - run: npm install mdast-util-from-markdown@2.0.0 unist-util-select@5.1.0 semver@7.6.0
       - name: Add labels
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
@@ -45,6 +45,7 @@ jobs:
           script: |
             const { fromMarkdown } = await import('${{ github.workspace }}/node_modules/mdast-util-from-markdown/index.js');
             const { select } = await import('${{ github.workspace }}/node_modules/unist-util-select/index.js');
+            const semver = await import('${{ github.workspace }}/node_modules/semver/index.js');
 
             const [ owner, repo ] = '${{ github.repository }}'.split('/');
             const issue_number = ${{ github.event.issue.number }};
@@ -52,6 +53,28 @@ jobs:
             const tree = fromMarkdown(process.env.ISSUE_BODY);
 
             const labels = [];
+
+            const electronVersion = select('heading:has(> text[value="Electron Version"]) + paragraph > text', tree)?.value.trim();
+            if (electronVersion !== undefined) {
+              const major = semver.parse(electronVersion)?.major;
+              if (major) {
+                const versionLabel = `${major}-x-y`;
+                let labelExists = false;
+
+                try {
+                  await github.rest.issues.getLabel({
+                    owner,
+                    repo,
+                    name: versionLabel,
+                  });
+                  labelExists = true;
+                } catch {}
+
+                if (labelExists) {
+                  labels.push(versionLabel);
+                }
+              }
+            }
 
             const gistUrl = select('heading:has(> text[value="Testcase Gist URL"]) + paragraph > text', tree)?.value.trim();
             if (gistUrl !== undefined && gistUrl.startsWith('https://gist.github.com/')) {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

If "Electron Version" can be parsed by `semver` to a valid version on a new bug issue, and `${major}-x-y` exists as a label, add that label automatically. The call to `github.rest.issues.getLabel` is necessary to check if the label already exists because `github.rest.issues.addLabels` will create a label if it doesn't exist, which we don't want.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
