### PR TITLE
fix: do not defer construction by one microtick in stream

### DIFF
--- a/patches/node/.patches
+++ b/patches/node/.patches
@@ -47,3 +47,4 @@ fix_revert_src_lb_reducing_c_calls_of_esm_legacy_main_resolve.patch
 src_preload_function_for_environment.patch
 deprecate_vector_v8_local_in_v8.patch
 fs_fix_wtf-8_decoding_issue.patch
+stream_do_not_defer_construction_by_one_microtick.patch

--- a/patches/node/stream_do_not_defer_construction_by_one_microtick.patch
+++ b/patches/node/stream_do_not_defer_construction_by_one_microtick.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matteo Collina <hello@matteocollina.com>
+Date: Thu, 7 Mar 2024 17:28:25 +0100
+Subject: stream: do not defer construction by one microtick
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes: https://github.com/nodejs/node/issues/51993
+PR-URL: https://github.com/nodejs/node/pull/52005
+Reviewed-By: Robert Nagy <ronagy@icloud.com>
+Reviewed-By: Michaël Zasso <targos@protonmail.com>
+
+diff --git a/lib/internal/streams/destroy.js b/lib/internal/streams/destroy.js
+index 28802cae5eff32b17d869be5f79b28be84bc09d5..96e61491f08cfc32e1ba780b8136ec02fc38e7b9 100644
+--- a/lib/internal/streams/destroy.js
++++ b/lib/internal/streams/destroy.js
+@@ -291,7 +291,7 @@ function constructNT(stream) {
+     } else if (err) {
+       errorOrDestroy(stream, err, true);
+     } else {
+-      process.nextTick(emitConstructNT, stream);
++      stream.emit(kConstruct);
+     }
+   }
+ 
+@@ -304,10 +304,6 @@ function constructNT(stream) {
+   }
+ }
+ 
+-function emitConstructNT(stream) {
+-  stream.emit(kConstruct);
+-}
+-
+ function isRequest(stream) {
+   return stream?.setHeader && typeof stream.abort === 'function';
+ }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42041

Backports https://github.com/nodejs/node/pull/52005 to fix an issue where `fs.createWriteStream` could write out of order.
 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `fs.createWriteStream` could write out of order.