### PR TITLE
fix: `BrowserWindow.center()` should center relative to screen

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1070,6 +1070,11 @@ ui::ZOrderLevel NativeWindowViews::GetZOrderLevel() const {
   return widget()->GetZOrderLevel();
 }
 
+// We previous called widget()->CenterWindow() here, but in
+// Chromium CL 4916277 behavior was changed to center relative to the
+// parent window if there is one. We want to keep the old behavior
+// for now to avoid breaking API contract, but should consider the long
+// term plan for this aligning with upstream.
 void NativeWindowViews::Center() {
 #if BUILDFLAG(IS_LINUX)
   auto display =

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1495,26 +1495,6 @@ describe('BrowserWindow module', () => {
       w = null as unknown as BrowserWindow;
     });
 
-    ifdescribe(process.platform !== 'darwin')('BrowserWindow.center()', () => {
-      it('centers the window', async () => {
-        const shown = once(w, 'show');
-        w.show();
-        await shown;
-        w.center();
-        const { x, y } = w.getBounds();
-        await setTimeout(3000);
-
-        w.setBounds({ x: x - 100, y: y - 100 });
-        expect(w.getBounds().x).to.be.closeTo(x - 100, 1);
-        expect(w.getBounds().y).to.be.closeTo(y - 100, 1);
-
-        w.center();
-        const newBounds = w.getBounds();
-        expect(newBounds.x).to.be.closeTo(x, 1);
-        expect(newBounds.y).to.be.closeTo(y, 1);
-      });
-    });
-
     describe('BrowserWindow.setBounds(bounds[, animate])', () => {
       it('sets the window bounds with full bounds', () => {
         const fullBounds = { x: 440, y: 225, width: 500, height: 400 };

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1495,6 +1495,26 @@ describe('BrowserWindow module', () => {
       w = null as unknown as BrowserWindow;
     });
 
+    ifdescribe(process.platform !== 'darwin')('BrowserWindow.center()', () => {
+      it('centers the window', async () => {
+        const shown = once(w, 'show');
+        w.show();
+        await shown;
+        w.center();
+        const { x, y } = w.getBounds();
+        await setTimeout(3000);
+
+        w.setBounds({ x: x - 100, y: y - 100 });
+        expect(w.getBounds().x).to.be.closeTo(x - 100, 1);
+        expect(w.getBounds().y).to.be.closeTo(y - 100, 1);
+
+        w.center();
+        const newBounds = w.getBounds();
+        expect(newBounds.x).to.be.closeTo(x, 1);
+        expect(newBounds.y).to.be.closeTo(y, 1);
+      });
+    });
+
     describe('BrowserWindow.setBounds(bounds[, animate])', () => {
       it('sets the window bounds with full bounds', () => {
         const fullBounds = { x: 440, y: 225, width: 500, height: 400 };


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/41956.
Refs: https://chromium-review.googlesource.com/c/chromium/src/+/4916277

The above CL changed `window.center()` behavior on Windows/Linux (which use `Widget`) such that the window is now centered relative to the parent window and not the full screen as is the expected behavior and the behavior on macOS. Chromium perceived this a bug, but it's important we maintain our end-user behavior consistency here as it's been this way for the lifetime of the method.

Tested with https://gist.github.com/yangannyx/277e71dc348b289cde39e94b4b59d683

cc @yangannyx

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where calling `window.center()` on Windows and Linux incorrectly centered the window.