### PR TITLE
fix: cherry-pick fix thumbnail size patch for macOS

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -137,3 +137,4 @@ cherry-pick-1b1f34234346.patch
 bindings_refactor_domdatastore.patch
 merge_fix_domarraybuffer_isdetached_and_comment_out_a_check.patch
 cherry-pick-98bcf9ef5cdd.patch
+cherry-pick-c1f25647c2fc.patch

--- a/patches/chromium/cherry-pick-c1f25647c2fc.patch
+++ b/patches/chromium/cherry-pick-c1f25647c2fc.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Johannes Kron <kron@chromium.org>
+Date: Tue, 13 Feb 2024 23:22:49 +0000
+Subject: [ThumbnailCapturerMac] Update thumbnail size when sources are
+ selected
+
+(cherry picked from commit c1f25647c2fcbf5e5a2d574feb284bc7284b944d)
+
+Bug: b/40281869
+Change-Id: I2d5a3954886bc6a5742321aeab415362da19c0ce
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5285701
+Commit-Queue: Johannes Kron <kron@chromium.org>
+Reviewed-by: Elad Alon <eladalon@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1260137}
+
+diff --git a/chrome/browser/media/webrtc/thumbnail_capturer_mac.mm b/chrome/browser/media/webrtc/thumbnail_capturer_mac.mm
+index ebe194e9d4a77d74996cb575364a32b61ccfac52..b27f6348d338d8952716b51825586e5d29b75651 100644
+--- a/chrome/browser/media/webrtc/thumbnail_capturer_mac.mm
++++ b/chrome/browser/media/webrtc/thumbnail_capturer_mac.mm
+@@ -365,6 +365,8 @@ void API_AVAILABLE(macos(14.0))
+     gfx::Size thumbnail_size) {
+   DCHECK(task_runner_->RunsTasksInCurrentSequence());
+ 
++  thumbnail_size_ = thumbnail_size;
++
+   // The iteration is in reverse order so that the sources
+   // first in the list are captured first. This way we make sure that the first
+   // thumbnails in the view are captured first.

--- a/patches/chromium/cherry-pick-c1f25647c2fc.patch
+++ b/patches/chromium/cherry-pick-c1f25647c2fc.patch
@@ -1,8 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Johannes Kron <kron@chromium.org>
 Date: Tue, 13 Feb 2024 23:22:49 +0000
-Subject: [ThumbnailCapturerMac] Update thumbnail size when sources are
- selected
+Subject: Update thumbnail size when sources are selected
 
 (cherry picked from commit c1f25647c2fcbf5e5a2d574feb284bc7284b944d)
 


### PR DESCRIPTION
#### Description of Change

Cherry-pick https://source.chromium.org/chromium/chromium/src/+/c1f25647c2fcbf5e5a2d574feb284bc7284b944d to fix a regression caused by #41329 where the thumbnails are not captured at the requested resolution. (The patch was made in Chromium 123, so it's already in v30 and just needs to be backported to v29.)

Fixes #41630.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed blurry thumbnails from desktop capturer on macOS.