### PR TITLE
docs: update formatting for mdx3 compatibility

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -600,7 +600,7 @@ Perhaps there are 15 pixels of controls on the left edge, 25 pixels of controls
 on the right edge and 50 pixels of controls below the player. In order to
 maintain a 16:9 aspect ratio (standard aspect ratio for HD @1920x1080) within
 the player itself we would call this function with arguments of 16/9 and
-{ width: 40, height: 50 }. The second argument doesn't care where the extra width and height
+\{ width: 40, height: 50 \}. The second argument doesn't care where the extra width and height
 are within the content view--only that they exist. Sum any extra width and
 height areas you have within the overall content view.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -723,7 +723,7 @@ Perhaps there are 15 pixels of controls on the left edge, 25 pixels of controls
 on the right edge and 50 pixels of controls below the player. In order to
 maintain a 16:9 aspect ratio (standard aspect ratio for HD @1920x1080) within
 the player itself we would call this function with arguments of 16/9 and
-{ width: 40, height: 50 }. The second argument doesn't care where the extra width and height
+\{ width: 40, height: 50 \}. The second argument doesn't care where the extra width and height
 are within the content view--only that they exist. Sum any extra width and
 height areas you have within the overall content view.
 

--- a/docs/api/net.md
+++ b/docs/api/net.md
@@ -66,7 +66,7 @@ requests according to the specified protocol scheme in the `options` object.
 ### `net.fetch(input[, init])`
 
 * `input` string | [GlobalRequest](https://nodejs.org/api/globals.html#request)
-* `init` [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/fetch#options) & { bypassCustomProtocolHandlers?: boolean } (optional)
+* `init` [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/fetch#options) & \{ bypassCustomProtocolHandlers?: boolean \} (optional)
 
 Returns `Promise<GlobalResponse>` - see [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response).
 

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -695,7 +695,7 @@ Returns `Promise<void>` - Resolves when all connections are closed.
 #### `ses.fetch(input[, init])`
 
 * `input` string | [GlobalRequest](https://nodejs.org/api/globals.html#request)
-* `init` [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/fetch#options) & { bypassCustomProtocolHandlers?: boolean } (optional)
+* `init` [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/fetch#options) & \{ bypassCustomProtocolHandlers?: boolean \} (optional)
 
 Returns `Promise<GlobalResponse>` - see [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response).
 

--- a/docs/development/debugging-with-symbol-server.md
+++ b/docs/development/debugging-with-symbol-server.md
@@ -15,7 +15,7 @@ calls, and other compiler optimizations. The only workaround is to build an
 unoptimized local build.
 
 The official symbol server URL for Electron is
-<https://symbols.electronjs.org>.
+[https://symbols.electronjs.org](https://symbols.electronjs.org).
 You cannot visit this URL directly, you must add it to the symbol path of your
 debugging tool. In the examples below, a local cache directory is used to avoid
 repeatedly fetching the PDB from the server. Replace `c:\code\symbols` with an

--- a/docs/tutorial/esm.md
+++ b/docs/tutorial/esm.md
@@ -78,7 +78,8 @@ JavaScript transpilers (e.g. Babel, TypeScript) have historically supported ES M
 syntax before Node.js supported ESM imports by turning these calls to CommonJS
 `require` calls.
 
-<details><summary>Example: @babel/plugin-transform-modules-commonjs</summary>
+<details>
+<summary>Example: @babel/plugin-transform-modules-commonjs</summary>
 
 The `@babel/plugin-transform-modules-commonjs` plugin will transform
 ESM imports down to `require` calls. The exact syntax will depend on the

--- a/docs/tutorial/tutorial-1-prerequisites.md
+++ b/docs/tutorial/tutorial-1-prerequisites.md
@@ -121,7 +121,7 @@ need to install Node.js themselves as a prerequisite to running your app.
 
 To check which version of Node.js is running in your app, you can access the global
 [`process.versions`][] variable in the main process or preload script. You can also reference
-<https://releases.electronjs.org/releases.json>.
+[https://releases.electronjs.org/releases.json](https://releases.electronjs.org/releases.json).
 
 :::
 

--- a/docs/tutorial/tutorial-2-first-app.md
+++ b/docs/tutorial/tutorial-2-first-app.md
@@ -222,7 +222,8 @@ with CommonJS module syntax:
 - [app][app], which controls your application's event lifecycle.
 - [BrowserWindow][browser-window], which creates and manages app windows.
 
-<details><summary>Module capitalization conventions</summary>
+<details>
+<summary>Module capitalization conventions</summary>
 
 You might have noticed the capitalization difference between the **a**pp
 and **B**rowser**W**indow modules. Electron follows typical JavaScript conventions here,
@@ -231,7 +232,8 @@ Notification) whereas camelCase modules are not instantiable (e.g. app, ipcRende
 
 </details>
 
-<details><summary>Typed import aliases</summary>
+<details>
+<summary>Typed import aliases</summary>
 
 For better type checking when writing TypeScript code, you can choose to import
 main process modules from `electron/main`.


### PR DESCRIPTION
#### Description of Change

Ran through the gamut of `npx docusaurus-mdx-checker` for the Docusaurus v3 upgrade and this should clear the remaining issues:

1. `{` and `}` both need to be escaped as MDX >=2 supports curly brace JS expressions (ref: https://mdxjs.com/docs/what-is-mdx/#expressions)
2. MDX >=2 does not support GitHub-flavoured Markdown [autolinks](https://github.github.com/gfm/#autolink) such as `<https://electronjs.org>` (ref: https://docusaurus.io/blog/preparing-your-site-for-docusaurus-v3#bad-usage-of-gfm-autolink)
3. Putting `<details><summary>Summary here</summary>` doesn't work anymore in MDX >=2 for some reason and we need to add a line break now (ref: https://github.com/orgs/mdx-js/discussions/2241)

cc @electron/docs 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none