### PR TITLE
fix: BrowserView autoresizing conversion error

### DIFF
--- a/lib/browser/api/browser-view.ts
+++ b/lib/browser/api/browser-view.ts
@@ -34,13 +34,17 @@ export default class BrowserView {
   }
 
   setAutoResize (options: AutoResizeOptions) {
-    if (options == null || typeof options !== 'object') { throw new Error('Invalid auto resize options'); }
+    if (options == null || typeof options !== 'object') {
+      throw new Error('Invalid auto resize options');
+    }
+
     this.#autoResizeFlags = {
       width: !!options.width,
       height: !!options.height,
       horizontal: !!options.horizontal,
       vertical: !!options.vertical
     };
+
     this.#autoHorizontalProportion = null;
     this.#autoVerticalProportion = null;
   }
@@ -71,7 +75,10 @@ export default class BrowserView {
   #autoHorizontalProportion: {width: number, left: number} | null = null;
   #autoVerticalProportion: {height: number, top: number} | null = null;
   #autoResize () {
-    if (!this.ownerWindow) throw new Error('Electron bug: #autoResize called without owner window');
+    if (!this.ownerWindow) {
+      throw new Error('Electron bug: #autoResize called without owner window');
+    };
+
     if (this.#autoResizeFlags.horizontal && this.#autoHorizontalProportion == null) {
       const viewBounds = this.#webContentsView.getBounds();
       this.#autoHorizontalProportion = {
@@ -79,6 +86,7 @@ export default class BrowserView {
         left: this.#lastWindowSize.width / viewBounds.x
       };
     }
+
     if (this.#autoResizeFlags.vertical && this.#autoVerticalProportion == null) {
       const viewBounds = this.#webContentsView.getBounds();
       this.#autoVerticalProportion = {
@@ -86,6 +94,7 @@ export default class BrowserView {
         top: this.#lastWindowSize.height / viewBounds.y
       };
     }
+
     const newBounds = this.ownerWindow.getBounds();
     let widthDelta = newBounds.width - this.#lastWindowSize.width;
     let heightDelta = newBounds.height - this.#lastWindowSize.height;
@@ -105,10 +114,12 @@ export default class BrowserView {
       newViewBounds.width = newBounds.width / this.#autoHorizontalProportion.width;
       newViewBounds.x = newBounds.width / this.#autoHorizontalProportion.left;
     }
+
     if (this.#autoVerticalProportion) {
       newViewBounds.height = newBounds.height / this.#autoVerticalProportion.height;
       newViewBounds.y = newBounds.y / this.#autoVerticalProportion.top;
     }
+
     if (this.#autoHorizontalProportion || this.#autoVerticalProportion) {
       this.#webContentsView.setBounds(newViewBounds);
     }

--- a/shell/common/gin_converters/gfx_converter.cc
+++ b/shell/common/gin_converters/gfx_converter.cc
@@ -14,7 +14,7 @@
 #include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/point.h"
 #include "ui/gfx/geometry/point_f.h"
-#include "ui/gfx/geometry/rect.h"
+#include "ui/gfx/geometry/rect_conversions.h"
 #include "ui/gfx/geometry/resize_utils.h"
 #include "ui/gfx/geometry/size.h"
 
@@ -100,11 +100,12 @@ bool Converter<gfx::Rect>::FromV8(v8::Isolate* isolate,
   gin::Dictionary dict(isolate);
   if (!gin::ConvertFromV8(isolate, val, &dict))
     return false;
-  int x, y, width, height;
+  float x, y, width, height;
   if (!dict.Get("x", &x) || !dict.Get("y", &y) || !dict.Get("width", &width) ||
       !dict.Get("height", &height))
     return false;
-  *out = gfx::Rect(x, y, width, height);
+
+  *out = ToRoundedRect(gfx::RectF(x, y, width, height));
   return true;
 }
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1503,6 +1503,13 @@ describe('BrowserWindow module', () => {
         expectBoundsEqual(w.getBounds(), fullBounds);
       });
 
+      it('rounds non-integer bounds', () => {
+        w.setBounds({ x: 440.5, y: 225.1, width: 500.4, height: 400.9 });
+
+        const bounds = w.getBounds();
+        expect(bounds).to.deep.equal({ x: 441, y: 225, width: 500, height: 401 });
+      });
+
       it('sets the window bounds with partial bounds', () => {
         const fullBounds = { x: 440, y: 225, width: 500, height: 400 };
         w.setBounds(fullBounds);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42003.

Fixes the following issue when setting autoResize on a `BrowserView`:

<img width="822" alt="Screenshot 2024-05-06 at 9 16 39 PM" src="https://github.com/electron/electron/assets/2036040/243a54e8-3a8d-4d2b-8898-66cc503e7e86">

This was happening because `setBounds` accepts a `gfx::Rect` and we were trying to pass double values to the width and height when resizing.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an error when calling `setAutoResize` on a `BrowserView`.
