### PR TITLE
chore: cherry-pick 22871e619f from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -138,3 +138,4 @@ bindings_refactor_domdatastore.patch
 merge_fix_domarraybuffer_isdetached_and_comment_out_a_check.patch
 cherry-pick-98bcf9ef5cdd.patch
 cherry-pick-c1f25647c2fc.patch
+a11y_avoid_clearing_resetting_focus_on_an_already_focus_event.patch

--- a/patches/chromium/a11y_avoid_clearing_resetting_focus_on_an_already_focus_event.patch
+++ b/patches/chromium/a11y_avoid_clearing_resetting_focus_on_an_already_focus_event.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benjamin Beaudry <benjamin.beaudry@microsoft.com>
+Date: Fri, 8 Mar 2024 21:16:50 +0000
+Subject: [a11y] Avoid clearing/resetting focus on an already focus event
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When we set the focus via an accessibility API on an element that
+is already focused, we first remove the focus and reset it. This
+leads to blur/focusout/focusin events being fired again.
+
+This behavior is different than the one we get when we set focus
+programmatically, with a mouse, or a keyboard, on an already
+focused element. In order to keep the same experience across all
+input modalities, this CL removes the divergent focus behavior
+for accessibility APIs.
+
+We tried to remove this code two years ago (CL:3547796) but it
+got reverted due to bug:40850837. This time, I made sure to discuss
+this issue with the Chrome Android accessibility owners to make 
+sure it's safe to remove. They landed CL:5345750, and then gave
+us the green light to land this CL.
+
+Fixed: 40830307
+Change-Id: I8ad70ed6813e0ae52238292f1b7e6d038a5238f1
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5356613
+Reviewed-by: Mark Schillaci <mschillaci@google.com>
+Commit-Queue: Benjamin Beaudry <benjamin.beaudry@microsoft.com>
+Auto-Submit: Benjamin Beaudry <benjamin.beaudry@microsoft.com>
+Cr-Commit-Position: refs/heads/main@{#1270380}
+
+diff --git a/third_party/blink/renderer/modules/accessibility/ax_node_object.cc b/third_party/blink/renderer/modules/accessibility/ax_node_object.cc
+index a94e88e79c4fb5ed1336a776eafe3e302f5d50f8..a5c4b06e278f805e81799b2d19f27bffe0701c68 100644
+--- a/third_party/blink/renderer/modules/accessibility/ax_node_object.cc
++++ b/third_party/blink/renderer/modules/accessibility/ax_node_object.cc
+@@ -5095,19 +5095,6 @@ bool AXNodeObject::OnNativeFocusAction() {
+     return true;
+   }
+ 
+-  // If this node is already the currently focused node, then calling
+-  // focus() won't do anything.  That is a problem when focus is removed
+-  // from the webpage to chrome, and then returns.  In these cases, we need
+-  // to do what keyboard and mouse focus do, which is reset focus first.
+-  if (document->FocusedElement() == element) {
+-    document->ClearFocusedElement();
+-
+-    // Calling ClearFocusedElement could result in changes to the document,
+-    // like this AXObject becoming detached.
+-    if (IsDetached())
+-      return false;
+-  }
+-
+   if (base::FeatureList::IsEnabled(blink::features::kSimulateClickOnAXFocus)) {
+     // If the object is not natively focusable but can be focused using an ARIA
+     // active descendant, perform a native click instead. This will enable Web

--- a/patches/chromium/a11y_avoid_clearing_resetting_focus_on_an_already_focus_event.patch
+++ b/patches/chromium/a11y_avoid_clearing_resetting_focus_on_an_already_focus_event.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Benjamin Beaudry <benjamin.beaudry@microsoft.com>
 Date: Fri, 8 Mar 2024 21:16:50 +0000
-Subject: [a11y] Avoid clearing/resetting focus on an already focus event
+Subject: Avoid clearing/resetting focus on an already focus event
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit


### PR DESCRIPTION
#### Description of Change

CL https://chromium-review.googlesource.com/c/chromium/src/+/5356613

Refs https://github.com/microsoft/vscode/issues/210842#issue-2254720002

#### Release Notes

Notes: [a11y] avoid clearing/resetting focus on an already focused element