### PR TITLE
fix: CHECK when adding view as its own child

### DIFF
--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -189,6 +189,14 @@ void View::AddChildViewAt(gin::Handle<View> child,
   // has a View, possibly a wrapper view around the underlying platform View.
   if (!view_)
     return;
+
+  // This will CHECK and crash in View::AddChildViewAtImpl if not handled here.
+  if (view_ == child->view()) {
+    gin_helper::ErrorThrower(isolate()).ThrowError(
+        "A view cannot be added as its own child");
+    return;
+  }
+
   size_t index =
       std::min(child_views_.size(), maybe_index.value_or(child_views_.size()));
   child_views_.emplace(child_views_.begin() + index,     // index

--- a/spec/api-view-spec.ts
+++ b/spec/api-view-spec.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import { closeWindow } from './lib/window-helpers';
 import { BaseWindow, View } from 'electron/main';
 
@@ -10,6 +11,15 @@ describe('View', () => {
 
   it('can be used as content view', () => {
     w = new BaseWindow({ show: false });
-    w.setContentView(new View());
+    const v = new View();
+    w.setContentView(v);
+    expect(w.contentView).to.equal(v);
+  });
+
+  it('will throw when added as a child to itself', () => {
+    w = new BaseWindow({ show: false });
+    expect(() => {
+      w.contentView.addChildView(w.contentView);
+    }).to.throw('A view cannot be added as its own child');
   });
 });


### PR DESCRIPTION
#### Description of Change

Fixes the following CHECK in [`View::AddChildViewAtImpl`](https://source.chromium.org/chromium/chromium/src/+/main:ui/views/view.cc;l=3071;bpv=1;bpt=1?q=AddChildViewAt):

```
[23853:0507/174950.101294:FATAL:view.cc(3081)] Check failed: view != this (0x130006c2000 vs. 0x130006c2000)You cannot add a view as its own child
```

and adds a test. Incidental to investigation of https://github.com/electron/electron/issues/41974

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes a crash in `addChildView` if a view is added as its own child.
