### PR TITLE
fix: View reordering on re-addition to same parent

### DIFF
--- a/docs/api/view.md
+++ b/docs/api/view.md
@@ -48,6 +48,9 @@ Objects created with `new View` have the following instance methods:
 * `index` Integer (optional) - Index at which to insert the child view.
   Defaults to adding the child at the end of the child list.
 
+If the same View is added to a parent which already contains it, it will be reordered such that
+it becomes the topmost view.
+
 #### `view.removeChildView(view)`
 
 * `view` View - Child view to remove.

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -57,6 +57,8 @@ class View : public gin_helper::EventEmitter<View>, public views::ViewObserver {
   void set_delete_view(bool should) { delete_view_ = should; }
 
  private:
+  void ReorderChildView(gin::Handle<View> child, size_t index);
+
   std::vector<v8::Global<v8::Object>> child_views_;
 
   bool delete_view_ = true;

--- a/spec/api-view-spec.ts
+++ b/spec/api-view-spec.ts
@@ -22,4 +22,36 @@ describe('View', () => {
       w.contentView.addChildView(w.contentView);
     }).to.throw('A view cannot be added as its own child');
   });
+
+  it('does not crash when attempting to add a child multiple times', () => {
+    w = new BaseWindow({ show: false });
+    const cv = new View();
+    w.setContentView(cv);
+
+    const v = new View();
+    w.contentView.addChildView(v);
+    w.contentView.addChildView(v);
+    w.contentView.addChildView(v);
+
+    expect(w.contentView.children).to.have.lengthOf(1);
+  });
+
+  it('correctly reorders children', () => {
+    w = new BaseWindow({ show: false });
+    const cv = new View();
+    w.setContentView(cv);
+
+    const v1 = new View();
+    const v2 = new View();
+    const v3 = new View();
+    w.contentView.addChildView(v1);
+    w.contentView.addChildView(v2);
+    w.contentView.addChildView(v3);
+
+    expect(w.contentView.children).to.deep.equal([v1, v2, v3]);
+
+    w.contentView.addChildView(v1);
+    w.contentView.addChildView(v2);
+    expect(w.contentView.children).to.deep.equal([v3, v1, v2]);
+  });
 });

--- a/spec/api-web-contents-view-spec.ts
+++ b/spec/api-web-contents-view-spec.ts
@@ -36,6 +36,25 @@ describe('WebContentsView', () => {
     v.removeChildView(wcv);
   });
 
+  it('correctly reorders children', () => {
+    const w = new BaseWindow({ show: false });
+    const cv = new View();
+    w.setContentView(cv);
+
+    const wcv1 = new WebContentsView();
+    const wcv2 = new WebContentsView();
+    const wcv3 = new WebContentsView();
+    w.contentView.addChildView(wcv1);
+    w.contentView.addChildView(wcv2);
+    w.contentView.addChildView(wcv3);
+
+    expect(w.contentView.children).to.deep.equal([wcv1, wcv2, wcv3]);
+
+    w.contentView.addChildView(wcv1);
+    w.contentView.addChildView(wcv2);
+    expect(w.contentView.children).to.deep.equal([wcv3, wcv1, wcv2]);
+  });
+
   function triggerGCByAllocation () {
     const arr = [];
     for (let i = 0; i < 1000000; i++) {
@@ -79,7 +98,7 @@ describe('WebContentsView', () => {
       expect(await v.webContents.executeJavaScript('initialVisibility')).to.equal('hidden');
     });
 
-    it('becomes visibile when attached', async () => {
+    it('becomes visible when attached', async () => {
       const v = new WebContentsView();
       await v.webContents.loadURL('about:blank');
       expect(await v.webContents.executeJavaScript('document.visibilityState')).to.equal('hidden');


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42077.
Closes https://github.com/electron/electron/issues/41974.
Closes https://github.com/electron/electron/issues/42061.

When the same view is added multiple times, we should match Chromium's behavior in [`View::AddChildViewAtImpl`](https://source.chromium.org/chromium/chromium/src/+/main:ui/views/view.cc;l=3070;bpv=1;bpt=1?q=View::AddChildViewAtImpl&sq=package:chromium&type=cs) and re-order the view such that the view becomes the topmost view. Also adds tests.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash when the same `WebContentsView` is added via `addChildView` multiple times.