### PR TITLE
chore: cherry-pick 1 changes from 3-M124

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -1,3 +1,4 @@
 m123_vulkan_fix_access_to_inactive_attributes.patch
 cherry-pick-f6672dbbe223.patch
 cherry-pick-ba3b4e239620.patch
+cherry-pick-c67f290ef0f0.patch

--- a/patches/angle/cherry-pick-c67f290ef0f0.patch
+++ b/patches/angle/cherry-pick-c67f290ef0f0.patch
@@ -1,7 +1,7 @@
-From c67f290ef0f0433acb766c024d28c6f59f48b909 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Geoff Lang <geofflang@chromium.org>
 Date: Mon, 29 Apr 2024 15:27:36 -0400
-Subject: [PATCH] M124: GL: Sync unpack state for glCompressedTexSubImage3D
+Subject: M124: GL: Sync unpack state for glCompressedTexSubImage3D
 
 Unpack state is supposed to be ignored for compressed tex image calls
 but some drivers use it anyways and read incorrect data.
@@ -17,13 +17,12 @@ Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
 Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5518811
 Commit-Queue: Srinivas Sista <srinivassista@chromium.org>
 Reviewed-by: Srinivas Sista <srinivassista@chromium.org>
----
 
 diff --git a/src/libANGLE/renderer/gl/TextureGL.cpp b/src/libANGLE/renderer/gl/TextureGL.cpp
-index 2481c65..71ad147 100644
+index c659aacb9e48d7eab033f0ea59d3514f557a430b..f96eefe53f11a8a57fc88998c2ba22a2dacf1d65 100644
 --- a/src/libANGLE/renderer/gl/TextureGL.cpp
 +++ b/src/libANGLE/renderer/gl/TextureGL.cpp
-@@ -664,6 +664,7 @@
+@@ -664,6 +664,7 @@ angle::Result TextureGL::setCompressedSubImage(const gl::Context *context,
          nativegl::GetCompressedSubTexImageFormat(functions, features, format);
  
      stateManager->bindTexture(getType(), mTextureID);

--- a/patches/angle/cherry-pick-c67f290ef0f0.patch
+++ b/patches/angle/cherry-pick-c67f290ef0f0.patch
@@ -1,0 +1,33 @@
+From c67f290ef0f0433acb766c024d28c6f59f48b909 Mon Sep 17 00:00:00 2001
+From: Geoff Lang <geofflang@chromium.org>
+Date: Mon, 29 Apr 2024 15:27:36 -0400
+Subject: [PATCH] M124: GL: Sync unpack state for glCompressedTexSubImage3D
+
+Unpack state is supposed to be ignored for compressed tex image calls
+but some drivers use it anyways and read incorrect data.
+
+Texture3DTestES3.PixelUnpackStateTexSubImage covers this case.
+
+Bug: chromium:337766133
+Change-Id: Ic11a056113b1850bd5b4d6840527164a12849a22
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5498735
+Commit-Queue: Shahbaz Youssefi <syoussefi@chromium.org>
+Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
+(cherry picked from commit 1bb1ee061fe0bce322fb93b447a72e72c993a1f2)
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5518811
+Commit-Queue: Srinivas Sista <srinivassista@chromium.org>
+Reviewed-by: Srinivas Sista <srinivassista@chromium.org>
+---
+
+diff --git a/src/libANGLE/renderer/gl/TextureGL.cpp b/src/libANGLE/renderer/gl/TextureGL.cpp
+index 2481c65..71ad147 100644
+--- a/src/libANGLE/renderer/gl/TextureGL.cpp
++++ b/src/libANGLE/renderer/gl/TextureGL.cpp
+@@ -664,6 +664,7 @@
+         nativegl::GetCompressedSubTexImageFormat(functions, features, format);
+ 
+     stateManager->bindTexture(getType(), mTextureID);
++    ANGLE_TRY(stateManager->setPixelUnpackState(context, unpack));
+     if (nativegl::UseTexImage2D(getType()))
+     {
+         ASSERT(area.z == 0 && area.depth == 1);


### PR DESCRIPTION
<details>
<summary>electron/security#506 - c67f290ef0f0 from angle</summary>
M124: GL: Sync unpack state for glCompressedTexSubImage3D

Unpack state is supposed to be ignored for compressed tex image calls
but some drivers use it anyways and read incorrect data.

Texture3DTestES3.PixelUnpackStateTexSubImage covers this case.

Bug: chromium:337766133
Change-Id: Ic11a056113b1850bd5b4d6840527164a12849a22
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5498735
Commit-Queue: Shahbaz Youssefi <syoussefi@chromium.org>
Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
(cherry picked from commit 1bb1ee061fe0bce322fb93b447a72e72c993a1f2)
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5518811
Commit-Queue: Srinivas Sista <srinivassista@chromium.org>
Reviewed-by: Srinivas Sista <srinivassista@chromium.org>
</details>

Notes:
* Security: backported fix for CVE-2024-4558.