### PR TITLE
chore: cherry-pick 19a4eebd05a7 from devtools-frontend

### DIFF
--- a/patches/devtools-frontend/.patches
+++ b/patches/devtools-frontend/.patches
@@ -1,1 +1,2 @@
 cherry-pick-8a3bfd4b7403.patch
+cherry-pick-19a4eebd05a7.patch

--- a/patches/devtools-frontend/cherry-pick-19a4eebd05a7.patch
+++ b/patches/devtools-frontend/cherry-pick-19a4eebd05a7.patch
@@ -1,0 +1,98 @@
+From 19a4eebd05a725daad9c254a342717f2ed203015 Mon Sep 17 00:00:00 2001
+From: Andrey Kosyakov <caseq@chromium.org>
+Date: Tue, 12 Mar 2024 19:58:44 -0700
+Subject: [PATCH] Fix support for worklet targets
+
+Bug: 327027138
+Change-Id: I051565c591645f0a4ccc297825d299c0764501ca
+Reviewed-on: https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/5367245
+Reviewed-by: Danil Somsikov <dsv@chromium.org>
+Commit-Queue: Andrey Kosyakov <caseq@chromium.org>
+---
+
+diff --git a/front_end/core/sdk/ChildTargetManager.ts b/front_end/core/sdk/ChildTargetManager.ts
+index f2b6e42..895bdc7 100644
+--- a/front_end/core/sdk/ChildTargetManager.ts
++++ b/front_end/core/sdk/ChildTargetManager.ts
+@@ -172,6 +172,8 @@
+       type = Type.Frame;
+     } else if (targetInfo.type === 'worker') {
+       type = Type.Worker;
++    } else if (targetInfo.type === 'worklet') {
++      type = Type.Worklet;
+     } else if (targetInfo.type === 'shared_worker') {
+       type = Type.SharedWorker;
+     } else if (targetInfo.type === 'shared_storage_worklet') {
+diff --git a/test/e2e/BUILD.gn b/test/e2e/BUILD.gn
+index cac27fe..1e70e50 100644
+--- a/test/e2e/BUILD.gn
++++ b/test/e2e/BUILD.gn
+@@ -45,6 +45,7 @@
+     "settings",
+     "snippets",
+     "sources",
++    "targets",
+     "webaudio",
+   ]
+ }
+diff --git a/test/e2e/targets/BUILD.gn b/test/e2e/targets/BUILD.gn
+new file mode 100644
+index 0000000..d7e979b
+--- /dev/null
++++ b/test/e2e/targets/BUILD.gn
+@@ -0,0 +1,14 @@
++# Copyright 2020 The Chromium Authors. All rights reserved.
++# Use of this source code is governed by a BSD-style license that can be
++# found in the LICENSE file.
++
++import("../../../third_party/typescript/typescript.gni")
++
++node_ts_library("targets") {
++  sources = [ "worklet_test.ts" ]
++
++  deps = [
++    "../../shared",
++    "../helpers",
++  ]
++}
+diff --git a/test/e2e/targets/worklet_test.ts b/test/e2e/targets/worklet_test.ts
+new file mode 100644
+index 0000000..9b8bfad
+--- /dev/null
++++ b/test/e2e/targets/worklet_test.ts
+@@ -0,0 +1,35 @@
++// Copyright 2024 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++import {assert} from 'chai';
++
++import {
++  getBrowserAndPages,
++  goToResource,
++  waitForFunction,
++} from '../../shared/helper.js';
++import {describe, it} from '../../shared/mocha-extensions.js';
++import {
++  getStructuredConsoleMessages,
++  navigateToConsoleTab,
++} from '../helpers/console-helpers.js';
++
++describe('Audio worklet support', () => {
++  it('Receiving log messages from Audio worklets', async () => {
++    const {target} = getBrowserAndPages();
++    await goToResource('empty.html');
++    await navigateToConsoleTab();
++    await target.evaluate(() => {
++      const blob = new Blob(['console.log(\'hello from worklet\')'], {type: 'application/javascript'});
++      const url = URL.createObjectURL(blob);
++      const audioContext = new AudioContext();
++      return audioContext.audioWorklet.addModule(url);
++    });
++    const message = await waitForFunction(async () => {
++      const messages = await getStructuredConsoleMessages();
++      return messages[0];
++    });
++    assert.strictEqual(message.message, 'hello from worklet');
++  });
++});


### PR DESCRIPTION
Fix support for worklet targets

Bug: 327027138
Change-Id: I051565c591645f0a4ccc297825d299c0764501ca
Reviewed-on: https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/5367245
Reviewed-by: Danil Somsikov <dsv@chromium.org>
Commit-Queue: Andrey Kosyakov <caseq@chromium.org>


Notes: Backported fix for 327027138.