### PR TITLE
docs: fixing typo in dark mode fiddle and doc

### DIFF
--- a/docs/fiddles/features/dark-mode/index.html
+++ b/docs/fiddles/features/dark-mode/index.html
@@ -14,6 +14,5 @@
     <button id="reset-to-system">Reset to System Theme</button>
 
     <script src="renderer.js"></script>
-  </body>
 </body>
 </html>

--- a/docs/tutorial/dark-mode.md
+++ b/docs/tutorial/dark-mode.md
@@ -75,7 +75,6 @@ Starting with the `index.html` file:
     <button id="reset-to-system">Reset to System Theme</button>
 
     <script src="renderer.js"></script>
-  </body>
 </body>
 </html>
 ```


### PR DESCRIPTION
#### Description of Change

The dark mode example had an extra `</body>` at end of the `index.html` file. The extra tag has been removed from the fiddle code as well as the documentation.

cc @electron/docs

#### Checklist

- [x]  PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes

Notes: None
