### PR TITLE
refactor: use raw_ref in RootView

### DIFF
--- a/shell/browser/ui/views/root_view.cc
+++ b/shell/browser/ui/views/root_view.cc
@@ -33,14 +33,15 @@ bool IsAltModifier(const content::NativeWebKeyboardEvent& event) {
 
 RootView::RootView(NativeWindow* window)
     : window_{raw_ref<NativeWindow>::from_ptr(window)},
+      main_view_{raw_ref<views::View>::from_ptr(
+          AddChildView(std::make_unique<views::View>()))},
       last_focused_view_tracker_(std::make_unique<views::ViewTracker>()) {
   set_owned_by_client();
   views::BoxLayout* layout =
       SetLayoutManager(std::make_unique<views::BoxLayout>(
           views::BoxLayout::Orientation::kVertical));
-  main_view_ = AddChildView(std::make_unique<views::View>());
   main_view_->SetUseDefaultFillLayout(true);
-  layout->SetFlexForView(main_view_, 1);
+  layout->SetFlexForView(&main_view_.get(), 1);
 }
 
 RootView::~RootView() = default;

--- a/shell/browser/ui/views/root_view.cc
+++ b/shell/browser/ui/views/root_view.cc
@@ -32,7 +32,7 @@ bool IsAltModifier(const content::NativeWebKeyboardEvent& event) {
 }  // namespace
 
 RootView::RootView(NativeWindow* window)
-    : window_(window),
+    : window_{raw_ref<NativeWindow>::from_ptr(window)},
       last_focused_view_tracker_(std::make_unique<views::ViewTracker>()) {
   set_owned_by_client();
   views::BoxLayout* layout =
@@ -62,7 +62,7 @@ void RootView::SetMenu(ElectronMenuModel* menu_model) {
     return;
 
   if (!menu_bar_) {
-    menu_bar_ = std::make_unique<MenuBar>(window_, this);
+    menu_bar_ = std::make_unique<MenuBar>(&window_.get(), this);
     menu_bar_->set_owned_by_client();
     if (!menu_bar_autohide_)
       SetMenuBarVisibility(true);

--- a/shell/browser/ui/views/root_view.cc
+++ b/shell/browser/ui/views/root_view.cc
@@ -34,8 +34,7 @@ bool IsAltModifier(const content::NativeWebKeyboardEvent& event) {
 RootView::RootView(NativeWindow* window)
     : window_{raw_ref<NativeWindow>::from_ptr(window)},
       main_view_{raw_ref<views::View>::from_ptr(
-          AddChildView(std::make_unique<views::View>()))},
-      last_focused_view_tracker_(std::make_unique<views::ViewTracker>()) {
+          AddChildView(std::make_unique<views::View>()))} {
   set_owned_by_client();
   views::BoxLayout* layout =
       SetLayoutManager(std::make_unique<views::BoxLayout>(
@@ -117,7 +116,7 @@ void RootView::HandleKeyEvent(const content::NativeWebKeyboardEvent& event) {
       SetMenuBarVisibility(true);
 
       View* focused_view = GetFocusManager()->GetFocusedView();
-      last_focused_view_tracker_->SetView(focused_view);
+      last_focused_view_tracker_.SetView(focused_view);
       menu_bar_->RequestFocus();
     }
 
@@ -138,7 +137,7 @@ void RootView::HandleKeyEvent(const content::NativeWebKeyboardEvent& event) {
       SetMenuBarVisibility(!menu_bar_visible_);
 
     View* focused_view = GetFocusManager()->GetFocusedView();
-    last_focused_view_tracker_->SetView(focused_view);
+    last_focused_view_tracker_.SetView(focused_view);
     if (menu_bar_visible_) {
       menu_bar_->RequestFocus();
       // Show accelerators when menu bar is focused
@@ -151,7 +150,7 @@ void RootView::HandleKeyEvent(const content::NativeWebKeyboardEvent& event) {
 }
 
 void RootView::RestoreFocus() {
-  View* last_focused_view = last_focused_view_tracker_->view();
+  View* last_focused_view = last_focused_view_tracker_.view();
   if (last_focused_view) {
     GetFocusManager()->SetFocusedViewWithReason(
         last_focused_view,

--- a/shell/browser/ui/views/root_view.h
+++ b/shell/browser/ui/views/root_view.h
@@ -70,7 +70,7 @@ class RootView : public views::View {
   // Map from accelerator to menu item's command id.
   accelerator_util::AcceleratorTable accelerator_table_;
 
-  std::unique_ptr<views::ViewTracker> last_focused_view_tracker_;
+  views::ViewTracker last_focused_view_tracker_;
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/root_view.h
+++ b/shell/browser/ui/views/root_view.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "shell/browser/ui/accelerator_util.h"
 #include "ui/gfx/geometry/insets.h"
 #include "ui/views/view.h"
@@ -55,7 +56,7 @@ class RootView : public views::View {
 
  private:
   // Parent window, weak ref.
-  raw_ptr<NativeWindow> window_;
+  const raw_ref<NativeWindow> window_;
 
   // Menu bar.
   std::unique_ptr<MenuBar> menu_bar_;

--- a/shell/browser/ui/views/root_view.h
+++ b/shell/browser/ui/views/root_view.h
@@ -47,7 +47,7 @@ class RootView : public views::View {
   void RegisterAcceleratorsWithFocusManager(ElectronMenuModel* menu_model);
   void UnregisterAcceleratorsWithFocusManager();
 
-  views::View* GetMainView() { return main_view_; }
+  views::View* GetMainView() { return &main_view_.get(); }
 
   // views::View:
   gfx::Size GetMinimumSize() const override;
@@ -65,7 +65,7 @@ class RootView : public views::View {
   bool menu_bar_alt_pressed_ = false;
 
   // Main view area.
-  raw_ptr<views::View> main_view_;
+  const raw_ref<views::View> main_view_;
 
   // Map from accelerator to menu item's command id.
   accelerator_util::AcceleratorTable accelerator_table_;


### PR DESCRIPTION
#### Description of Change

Make the ownership / nullability contract for `RootView` fields a little stricter:

- [Use `raw_ref<T>` instead of `raw_ptr<T>`](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md#non_owning-pointers-in-class-fields) for class fields that can never be `nullptr`
- Aggregate the `ViewTracker` directly since RootView already owns it, and its lifecycle is identical to the RootView, and the RootView header was already including the ViewTracker header

All reviews welcomed. CC @nornagon as most recent committer and @miniak for general C++ tidying :smile_cat: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.