### PR TITLE
chore: cherry-pick f320600cd1f4 from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -1,3 +1,4 @@
 chore_allow_customizing_microtask_policy_per_context.patch
 deps_add_v8_object_setinternalfieldfornodecore.patch
 merged_wasm_gc_scan_the_code_field_of_the_wasminternalfunction.patch
+cherry-pick-f320600cd1f4.patch

--- a/patches/v8/cherry-pick-f320600cd1f4.patch
+++ b/patches/v8/cherry-pick-f320600cd1f4.patch
@@ -1,0 +1,28 @@
+From f320600cd1f48ba6bb57c0395823fe0c5e5ec52e Mon Sep 17 00:00:00 2001
+From: Shu-yu Guo <syg@chromium.org>
+Date: Thu, 09 May 2024 12:03:28 -0700
+Subject: [PATCH] [wasm-gc] Only normalize JSObject targets in SetOrCopyDataProperties
+
+Bug: 339458194
+Change-Id: I4d6eebdd921971fa28d7c474535d978900ba633f
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5527397
+Reviewed-by: Rezvan Mahdavi Hezaveh <rezvan@chromium.org>
+Commit-Queue: Shu-yu Guo <syg@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#93811}
+---
+
+diff --git a/src/objects/js-objects.cc b/src/objects/js-objects.cc
+index c3f5d31..13b787f 100644
+--- a/src/objects/js-objects.cc
++++ b/src/objects/js-objects.cc
+@@ -434,9 +434,7 @@
+       Nothing<bool>());
+ 
+   if (!from->HasFastProperties() && target->HasFastProperties() &&
+-      !IsJSGlobalProxy(*target)) {
+-    // JSProxy is always in slow-mode.
+-    DCHECK(!IsJSProxy(*target));
++      IsJSObject(*target) && !IsJSGlobalProxy(*target)) {
+     // Convert to slow properties if we're guaranteed to overflow the number of
+     // descriptors.
+     int source_length;

--- a/patches/v8/cherry-pick-f320600cd1f4.patch
+++ b/patches/v8/cherry-pick-f320600cd1f4.patch
@@ -1,7 +1,7 @@
-From f320600cd1f48ba6bb57c0395823fe0c5e5ec52e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shu-yu Guo <syg@chromium.org>
-Date: Thu, 09 May 2024 12:03:28 -0700
-Subject: [PATCH] [wasm-gc] Only normalize JSObject targets in SetOrCopyDataProperties
+Date: Thu, 9 May 2024 12:03:28 -0700
+Subject: Only normalize JSObject targets in SetOrCopyDataProperties
 
 Bug: 339458194
 Change-Id: I4d6eebdd921971fa28d7c474535d978900ba633f
@@ -9,13 +9,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5527397
 Reviewed-by: Rezvan Mahdavi Hezaveh <rezvan@chromium.org>
 Commit-Queue: Shu-yu Guo <syg@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#93811}
----
 
 diff --git a/src/objects/js-objects.cc b/src/objects/js-objects.cc
-index c3f5d31..13b787f 100644
+index 32e1e89fc53217fe188c1f764bd97c03dadf35a2..0381a9f65a9e6cdfb30881077e4a442cd2a10802 100644
 --- a/src/objects/js-objects.cc
 +++ b/src/objects/js-objects.cc
-@@ -434,9 +434,7 @@
+@@ -429,9 +429,7 @@ Maybe<bool> JSReceiver::SetOrCopyDataProperties(
        Nothing<bool>());
  
    if (!from->HasFastProperties() && target->HasFastProperties() &&


### PR DESCRIPTION
[wasm-gc] Only normalize JSObject targets in SetOrCopyDataProperties

Bug: 339458194
Change-Id: I4d6eebdd921971fa28d7c474535d978900ba633f
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5527397
Reviewed-by: Rezvan Mahdavi Hezaveh <rezvan@chromium.org>
Commit-Queue: Shu-yu Guo <syg@chromium.org>
Cr-Commit-Position: refs/heads/main@{#93811}


Notes: Backported fix for 339458194.