### PR TITLE
chore: enable no autolink markdownlint rule

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,9 @@
 {
   "extends": "@electron/lint-roller/configs/markdownlint.json",
+  "link-image-style": {
+    "autolink": false,
+    "shortcut": false
+  },
   "no-angle-brackets": true,
   "no-curly-braces": true,
   "no-inline-html": {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Follow-up to #42078 to enable the no autolinks rule which was meant to be part of that PR, but I borked a local rebase and it got dropped.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
