### PR TITLE
fix: don't destroy BrowserView webContents on owner window close

### DIFF
--- a/lib/browser/api/browser-window.ts
+++ b/lib/browser/api/browser-window.ts
@@ -77,10 +77,6 @@ BrowserWindow.prototype._init = function (this: BWT) {
 
   this._browserViews = [];
 
-  this.on('close', () => {
-    this._browserViews.forEach(b => b.webContents?.close({ waitForBeforeUnload: true }));
-  });
-
   // Notify the creation of the window.
   app.emit('browser-window-created', { preventDefault () {} }, this);
 

--- a/spec/api-browser-view-spec.ts
+++ b/spec/api-browser-view-spec.ts
@@ -25,10 +25,12 @@ describe('BrowserView module', () => {
   });
 
   afterEach(async () => {
-    const p = once(w.webContents, 'destroyed');
-    await closeWindow(w);
-    w = null as any;
-    await p;
+    if (!w.isDestroyed()) {
+      const p = once(w.webContents, 'destroyed');
+      await closeWindow(w);
+      w = null as any;
+      await p;
+    }
 
     if (view && view.webContents) {
       const p = once(view.webContents, 'destroyed');
@@ -534,6 +536,29 @@ describe('BrowserView module', () => {
   });
 
   describe('shutdown behavior', () => {
+    it('does not destroy its webcontents if an owner BrowserWindow is closed', async () => {
+      view = new BrowserView();
+      w.setBrowserView(view);
+      await view.webContents.loadURL(`data:text/html,
+        <html>
+          <body>
+            <div id="bv_id">HELLO BROWSERVIEW</div>
+          </body>
+        </html>
+      `);
+
+      const query = 'document.getElementById("bv_id").textContent';
+      const contentBefore = await view.webContents.executeJavaScript(query);
+      expect(contentBefore).to.equal('HELLO BROWSERVIEW');
+
+      const closed = once(w, 'closed');
+      w.close();
+      await closed;
+
+      const contentAfter = await view.webContents.executeJavaScript(query);
+      expect(contentAfter).to.equal('HELLO BROWSERVIEW');
+    });
+
     it('does not crash on exit', async () => {
       const rc = await startRemoteControlApp();
       await rc.remotely(() => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42033.
Refs https://github.com/electron/electron/pull/35658

The above PR made it such that we explicitly destroyed the webContents in all BrowserViews currently attached to a give BrowserWindow when the BrowserWindow closed, which was a breaking change from previous BrowserView behavior. We should preserve the previous behavior.

cc @nornagon in case this was for a specific reason i'm not aware of!

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `BrowserView` `webContents` were destroyed on owner `BrowserWindow` closure.
