### PR TITLE
chore: update patches after #42126 was merged

### DIFF
--- a/patches/chromium/fix_partially_revert_invalidate_focusring.patch
+++ b/patches/chromium/fix_partially_revert_invalidate_focusring.patch
@@ -10,10 +10,10 @@ distros. This patch can be reverted when the issue is fixed upstream, or
 when the crash is addressed.
 
 diff --git a/ui/views/view.cc b/ui/views/view.cc
-index 94b026cda4738e489f1d7201c996f6db70d018ed..32ec794f4683be5ded78dcf310d3623b8748c236 100644
+index 4116b2a3fad02e1060bb7b137804753cf97dd7ca..46d3b426f54041efe4270bfda453358418fff160 100644
 --- a/ui/views/view.cc
 +++ b/ui/views/view.cc
-@@ -911,16 +911,6 @@ void View::Layout(PassKey) {
+@@ -928,16 +928,6 @@ void View::Layout(PassKey) {
  }
  
  void View::InvalidateLayout() {
@@ -30,7 +30,7 @@ index 94b026cda4738e489f1d7201c996f6db70d018ed..32ec794f4683be5ded78dcf310d3623b
    // We should never need to invalidate during a layout call; this tracks
    // how many times that is happening.
    ++invalidates_during_layout_;
-@@ -928,11 +918,6 @@ void View::InvalidateLayout() {
+@@ -945,11 +935,6 @@ void View::InvalidateLayout() {
    // Always invalidate up. This is needed to handle the case of us already being
    // valid, but not our parent.
    needs_layout_ = true;
@@ -43,10 +43,10 @@ index 94b026cda4738e489f1d7201c996f6db70d018ed..32ec794f4683be5ded78dcf310d3623b
      GetLayoutManager()->InvalidateLayout();
    }
 diff --git a/ui/views/view.h b/ui/views/view.h
-index ea7d5441dbbfb713a6ffb57bcc07fb55fa574016..54b4c0a2871f214a4806fd863f32b8d010c09058 100644
+index 8f377e417231698b9146d5b79dc14730e34260f7..9936899e10505f57d3b465d5613d90df8d18ded3 100644
 --- a/ui/views/view.h
 +++ b/ui/views/view.h
-@@ -2343,9 +2343,6 @@ class VIEWS_EXPORT View : public ui::LayerDelegate,
+@@ -2339,9 +2339,6 @@ class VIEWS_EXPORT View : public ui::LayerDelegate,
    // it is happening.
    int invalidates_during_layout_ = 0;
  


### PR DESCRIPTION
#### Description of Change

Update patches in #42126 conflicting with the base 31-x-y branch.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
