### PR TITLE
chore: cherry-pick b3c01ac1e60a from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -2,3 +2,4 @@ chore_allow_customizing_microtask_policy_per_context.patch
 deps_add_v8_object_setinternalfieldfornodecore.patch
 merged_wasm_gc_scan_the_code_field_of_the_wasminternalfunction.patch
 cherry-pick-f320600cd1f4.patch
+cherry-pick-b3c01ac1e60a.patch

--- a/patches/v8/cherry-pick-b3c01ac1e60a.patch
+++ b/patches/v8/cherry-pick-b3c01ac1e60a.patch
@@ -1,0 +1,77 @@
+From b3c01ac1e60afc9addad9942f7a9a6c5e8a4a6da Mon Sep 17 00:00:00 2001
+From: Shu-yu Guo <syg@chromium.org>
+Date: Mon, 13 May 2024 11:23:20 -0700
+Subject: [PATCH] [compiler] Don't build AccessInfo for storing to module exports
+
+Bug: 340221135
+Change-Id: I5af35be6ebf6a69db1c4687107503575b23973c4
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5534518
+Reviewed-by: Adam Klein <adamk@chromium.org>
+Commit-Queue: Shu-yu Guo <syg@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#93872}
+---
+
+diff --git a/src/compiler/access-info.cc b/src/compiler/access-info.cc
+index 2e81109..a81a8e8 100644
+--- a/src/compiler/access-info.cc
++++ b/src/compiler/access-info.cc
+@@ -527,6 +527,14 @@
+         Cell::cast(module_namespace->module()->exports()->Lookup(
+             isolate, name.object(),
+             Smi::ToInt(Object::GetHash(*name.object())))));
++    if (IsAnyStore(access_mode)) {
++      // ES#sec-module-namespace-exotic-objects-set-p-v-receiver
++      // ES#sec-module-namespace-exotic-objects-defineownproperty-p-desc
++      //
++      // Storing to a module namespace object is always an error or a no-op in
++      // JS.
++      return PropertyAccessInfo::Invalid(zone);
++    }
+     if (IsTheHole(cell->value(kRelaxedLoad), isolate)) {
+       // This module has not been fully initialized yet.
+       return PropertyAccessInfo::Invalid(zone);
+diff --git a/src/maglev/maglev-graph-builder.cc b/src/maglev/maglev-graph-builder.cc
+index 4d9c6dd..753eb4b 100644
+--- a/src/maglev/maglev-graph-builder.cc
++++ b/src/maglev/maglev-graph-builder.cc
+@@ -4169,19 +4169,28 @@
+         access_info.holder().value());
+   }
+ 
+-  if (access_info.IsFastAccessorConstant()) {
+-    return TryBuildPropertySetterCall(access_info, receiver,
+-                                      GetAccumulatorTagged());
+-  } else {
+-    DCHECK(access_info.IsDataField() || access_info.IsFastDataConstant());
+-    ReduceResult res = TryBuildStoreField(access_info, receiver, access_mode);
+-    if (res.IsDone()) {
+-      RecordKnownProperty(receiver, name,
+-                          current_interpreter_frame_.accumulator(),
+-                          AccessInfoGuaranteedConst(access_info), access_mode);
+-      return res;
++  switch (access_info.kind()) {
++    case compiler::PropertyAccessInfo::kFastAccessorConstant:
++      return TryBuildPropertySetterCall(access_info, receiver,
++                                        GetAccumulatorTagged());
++    case compiler::PropertyAccessInfo::kDataField:
++    case compiler::PropertyAccessInfo::kFastDataConstant: {
++      ReduceResult res = TryBuildStoreField(access_info, receiver, access_mode);
++      if (res.IsDone()) {
++        RecordKnownProperty(
++            receiver, name, current_interpreter_frame_.accumulator(),
++            AccessInfoGuaranteedConst(access_info), access_mode);
++        return res;
++      }
++      return ReduceResult::Fail();
+     }
+-    return ReduceResult::Fail();
++    case compiler::PropertyAccessInfo::kInvalid:
++    case compiler::PropertyAccessInfo::kNotFound:
++    case compiler::PropertyAccessInfo::kDictionaryProtoDataConstant:
++    case compiler::PropertyAccessInfo::kDictionaryProtoAccessorConstant:
++    case compiler::PropertyAccessInfo::kModuleExport:
++    case compiler::PropertyAccessInfo::kStringLength:
++      UNREACHABLE();
+   }
+ }
+ 

--- a/patches/v8/cherry-pick-b3c01ac1e60a.patch
+++ b/patches/v8/cherry-pick-b3c01ac1e60a.patch
@@ -1,7 +1,7 @@
-From b3c01ac1e60afc9addad9942f7a9a6c5e8a4a6da Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shu-yu Guo <syg@chromium.org>
 Date: Mon, 13 May 2024 11:23:20 -0700
-Subject: [PATCH] [compiler] Don't build AccessInfo for storing to module exports
+Subject: Don't build AccessInfo for storing to module exports
 
 Bug: 340221135
 Change-Id: I5af35be6ebf6a69db1c4687107503575b23973c4
@@ -9,13 +9,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5534518
 Reviewed-by: Adam Klein <adamk@chromium.org>
 Commit-Queue: Shu-yu Guo <syg@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#93872}
----
 
 diff --git a/src/compiler/access-info.cc b/src/compiler/access-info.cc
-index 2e81109..a81a8e8 100644
+index 7cff878839c85cd9c6571ee48f1a0fce081f4471..9d022ba402d7bfdd5ca745a4193ee0de0e3d755e 100644
 --- a/src/compiler/access-info.cc
 +++ b/src/compiler/access-info.cc
-@@ -527,6 +527,14 @@
+@@ -526,6 +526,14 @@ PropertyAccessInfo AccessorAccessInfoHelper(
          Cell::cast(module_namespace->module()->exports()->Lookup(
              isolate, name.object(),
              Smi::ToInt(Object::GetHash(*name.object())))));
@@ -31,10 +30,10 @@ index 2e81109..a81a8e8 100644
        // This module has not been fully initialized yet.
        return PropertyAccessInfo::Invalid(zone);
 diff --git a/src/maglev/maglev-graph-builder.cc b/src/maglev/maglev-graph-builder.cc
-index 4d9c6dd..753eb4b 100644
+index 8a5b4483d148192d3106e75874f042ccc6b36e56..728105c0aaccbaeb018eb9b9a660b5acba4650d8 100644
 --- a/src/maglev/maglev-graph-builder.cc
 +++ b/src/maglev/maglev-graph-builder.cc
-@@ -4169,19 +4169,28 @@
+@@ -3914,19 +3914,28 @@ ReduceResult MaglevGraphBuilder::TryBuildPropertyStore(
          access_info.holder().value());
    }
  


### PR DESCRIPTION
[compiler] Don't build AccessInfo for storing to module exports

Bug: 340221135
Change-Id: I5af35be6ebf6a69db1c4687107503575b23973c4
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5534518
Reviewed-by: Adam Klein <adamk@chromium.org>
Commit-Queue: Shu-yu Guo <syg@chromium.org>
Cr-Commit-Position: refs/heads/main@{#93872}


Notes: Backported fix for 340221135.