### PR TITLE
build: ignore node version mismatch for electron 30 tests

### DIFF
--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -218,7 +218,7 @@ async function installSpecModules (dir) {
   if (fs.existsSync(path.resolve(dir, 'node_modules'))) {
     await fs.remove(path.resolve(dir, 'node_modules'));
   }
-  const { status } = childProcess.spawnSync(NPX_CMD, [`yarn@${YARN_VERSION}`, 'install', '--frozen-lockfile'], {
+  const { status } = childProcess.spawnSync(NPX_CMD, [`yarn@${YARN_VERSION}`, 'install', '--frozen-lockfile', '--ignore-engines'], {
     env,
     cwd: dir,
     stdio: 'inherit',


### PR DESCRIPTION
Electron 30 CI runs on an older version of node that packager doesn't like, this just bypasses the engine check as it does actually work

Notes: none