### PR TITLE
fix: fix cast in ElectronDesktopWindowTreeHostLinux

### DIFF
--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
@@ -87,9 +87,15 @@ void ElectronDesktopWindowTreeHostLinux::OnWindowStateChanged(
 
 void ElectronDesktopWindowTreeHostLinux::OnWindowTiledStateChanged(
     ui::WindowTiledEdges new_tiled_edges) {
-  static_cast<ClientFrameViewLinux*>(
-      native_window_view_->widget()->non_client_view()->frame_view())
-      ->set_tiled_edges(new_tiled_edges);
+  // CreateNonClientFrameView creates `ClientFrameViewLinux` only when both
+  // frame and client_frame booleans are set, otherwise it is a different type
+  // of view.
+  if (native_window_view_->has_frame() &&
+      native_window_view_->has_client_frame()) {
+    static_cast<ClientFrameViewLinux*>(
+        native_window_view_->widget()->non_client_view()->frame_view())
+        ->set_tiled_edges(new_tiled_edges);
+  }
   UpdateFrameHints();
 }
 


### PR DESCRIPTION
#### Description of Change

The frame view of the widget is an `ClientFrameViewLinux` instance only when both `frame` and `client_frame` booleans are set to `true`. Otherwise it is an instance of a different class and thus casting to `ClientFrameViewLinux` is incorrect and leads to crashes.

Fix: #41839

cc @VerteDinde @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix crash on window maximize on X11