### PR TITLE
build: cancel in-progress runs on new commits

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,7 +1,13 @@
 name: Build MacOS
 
+# TODO: change to 'pull_request' and 'push' 
+# when we are ready to enable this for PRs.
 on:
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   GCLIENT_EXTRA_ARGS: '--custom-var=checkout_mac=True --custom-var=host_os=mac --custom-var=host_cpu=arm64'


### PR DESCRIPTION
#### Description of Change

As in title - cancel in-progress runs on new commits. Ensure concurrency group names are unique across workflows to avoid canceling in-progress jobs or runs from other workflows. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none