### PR TITLE
fix: `win.center()` on Windows

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1085,7 +1085,7 @@ void NativeWindowViews::Center() {
 #else
   HWND hwnd = GetAcceleratedWidget();
   gfx::Size size = display::win::ScreenWin::DIPToScreenSize(hwnd, GetSize());
-  gfx::CenterAndSizeWindow(hwnd, hwnd, size);
+  gfx::CenterAndSizeWindow(nullptr, hwnd, size);
 #endif
 }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42194.
Follow-up to https://github.com/electron/electron/issues/42048. 

Fixes an issue where the window could be incorrectly centered in some circumstances. This was happening because we should be explicitly setting the parent to `nullptr` in `gfx::CenterAndSizeWindow` and were passing the HWND instead.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where the window could be incorrectly centered in some circumstances when calling `BrowserWindow.center()`
