### PR TITLE
docs: fix broken anchors

### DIFF
--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -51,7 +51,7 @@ Unsupported options are:
 --http-parser
 ```
 
-If the [`nodeOptions` fuse](../tutorial/fuses.md#L27) is disabled, `NODE_OPTIONS` will be ignored.
+If the [`nodeOptions` fuse](../tutorial/fuses.md#nodeoptions) is disabled, `NODE_OPTIONS` will be ignored.
 
 ### `NODE_EXTRA_CA_CERTS`
 
@@ -61,7 +61,7 @@ See [Node.js cli documentation](https://github.com/nodejs/node/blob/main/doc/api
 export NODE_EXTRA_CA_CERTS=/path/to/cert.pem 
 ```
 
-If the [`nodeOptions` fuse](../tutorial/fuses.md#L27) is disabled, `NODE_EXTRA_CA_CERTS` will be ignored.
+If the [`nodeOptions` fuse](../tutorial/fuses.md#nodeoptions) is disabled, `NODE_EXTRA_CA_CERTS` will be ignored.
 
 ### `GOOGLE_API_KEY`
 


### PR DESCRIPTION
The LOC links don't work on the website and are brittler than just linking to the heading anchor directly.

notes: none