### PR TITLE
fix: ensure showInactive actually shows

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -473,7 +473,7 @@ void NativeWindowMac::ShowInactive() {
   if (parent())
     InternalSetParentWindow(parent(), true);
 
-  [window_ orderFrontRegardless];
+  [window_ orderFrontKeepWindowKeyState];
 }
 
 void NativeWindowMac::Hide() {


### PR DESCRIPTION
This aligns our API usage with Chromium and ensures that windows shown inactive that were initially hidden actually get painted to.

Notes: Fixed issue where windows made visible with `showInactive` were blank