### PR TITLE
docs: ensure all links are on a single line

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -125,8 +125,8 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
 https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
 
 [homepage]: https://www.contributor-covenant.org
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ View these docs in other languages on our [Crowdin](https://crowdin.com/project/
 
 The Electron framework lets you write cross-platform desktop applications
 using JavaScript, HTML and CSS. It is based on [Node.js](https://nodejs.org/) and
-[Chromium](https://www.chromium.org) and is used by the [Visual Studio
-Code](https://github.com/Microsoft/vscode/) and many other [apps](https://electronjs.org/apps).
+[Chromium](https://www.chromium.org) and is used by the
+[Visual Studio Code](https://github.com/Microsoft/vscode/) and many other [apps](https://electronjs.org/apps).
 
 Follow [@electronjs](https://twitter.com/electronjs) on Twitter for important
 announcements.

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1282,8 +1282,7 @@ Returns `Object`:
 * `settings` Object
   * `openAtLogin` boolean (optional) - `true` to open the app at login, `false` to remove
     the app as a login item. Defaults to `false`.
-  * `openAsHidden` boolean (optional) _macOS_ _Deprecated_ - `true` to open the app as hidden. Defaults to `false`. The user can edit this setting from the System Preferences so `app.getLoginItemSettings().wasOpenedAsHidden` should be checked when the app is opened to know the current value. This setting is not available on [MAS build
-s][mas-builds] or on macOS 13 and up.
+  * `openAsHidden` boolean (optional) _macOS_ _Deprecated_ - `true` to open the app as hidden. Defaults to `false`. The user can edit this setting from the System Preferences so `app.getLoginItemSettings().wasOpenedAsHidden` should be checked when the app is opened to know the current value. This setting is not available on [MAS builds][mas-builds] or on macOS 13 and up.
   * `type` string (optional) _macOS_ - The type of service to add as a login item. Defaults to `mainAppService`. Only available on macOS 13 and up.
     * `mainAppService` - The primary application.
     * `agentService` - The property list name for a launch agent. The property list name must correspond to a property list in the app’s `Contents/Library/LaunchAgents` directory.

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -20,8 +20,9 @@ In addition, there are some subtle differences on each platform:
 
 On macOS, the `autoUpdater` module is built upon [Squirrel.Mac][squirrel-mac],
 meaning you don't need any special setup to make it work. For server-side
-requirements, you can read [Server Support][server-support]. Note that [App
-Transport Security](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW35) (ATS) applies to all requests made as part of the
+requirements, you can read [Server Support][server-support]. Note that
+[App Transport Security](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW35)
+(ATS) applies to all requests made as part of the
 update process. Apps that need to disable ATS can add the
 `NSAllowsArbitraryLoads` key to their app's plist.
 

--- a/docs/api/content-tracing.md
+++ b/docs/api/content-tracing.md
@@ -35,8 +35,8 @@ The `contentTracing` module has the following methods:
 Returns `Promise<string[]>` - resolves with an array of category groups once all child processes have acknowledged the `getCategories` request
 
 Get a set of category groups. The category groups can change as new code paths
-are reached. See also the [list of built-in tracing
-categories](https://chromium.googlesource.com/chromium/src/+/main/base/trace_event/builtin_categories.h).
+are reached. See also the
+[list of built-in tracing categories](https://chromium.googlesource.com/chromium/src/+/main/base/trace_event/builtin_categories.h).
 
 > **NOTE:** Electron adds a non-default tracing category called `"electron"`.
 > This category can be used to capture Electron-specific tracing events.

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -145,16 +145,16 @@ debugging purposes.
 Prints Chromium's internal logging to the console.
 
 Setting this variable is the same as passing `--enable-logging`
-on the command line. For more info, see `--enable-logging` in [command-line
-switches](./command-line-switches.md#--enable-loggingfile).
+on the command line. For more info, see `--enable-logging` in
+[command-line switches](./command-line-switches.md#--enable-loggingfile).
 
 ### `ELECTRON_LOG_FILE`
 
 Sets the file destination for Chromium's internal logging.
 
 Setting this variable is the same as passing `--log-file`
-on the command line. For more info, see `--log-file` in [command-line
-switches](./command-line-switches.md#--log-filepath).
+on the command line. For more info, see `--log-file` in
+[command-line switches](./command-line-switches.md#--log-filepath).
 
 ### `ELECTRON_DEBUG_NOTIFICATIONS`
 

--- a/docs/api/extensions.md
+++ b/docs/api/extensions.md
@@ -1,9 +1,8 @@
 # Chrome Extension Support
 
-Electron supports a subset of the [Chrome Extensions
-API][chrome-extensions-api-index], primarily to support DevTools extensions and
-Chromium-internal extensions, but it also happens to support some other
-extension capabilities.
+Electron supports a subset of the [Chrome Extensions API][chrome-extensions-api-index],
+primarily to support DevTools extensions and Chromium-internal extensions,
+but it also happens to support some other extension capabilities.
 
 [chrome-extensions-api-index]: https://developer.chrome.com/extensions/api_index
 

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -82,8 +82,8 @@ Removes all listeners, or those of the specified `channel`.
 * `...args` any[]
 
 Send an asynchronous message to the main process via `channel`, along with
-arguments. Arguments will be serialized with the [Structured Clone
-Algorithm][SCA], just like [`window.postMessage`][], so prototype chains will not be
+arguments. Arguments will be serialized with the [Structured Clone Algorithm][SCA],
+just like [`window.postMessage`][], so prototype chains will not be
 included. Sending Functions, Promises, Symbols, WeakMaps, or WeakSets will
 throw an exception.
 
@@ -110,8 +110,8 @@ If you want to receive a single response from the main process, like the result 
 Returns `Promise<any>` - Resolves with the response from the main process.
 
 Send a message to the main process via `channel` and expect a result
-asynchronously. Arguments will be serialized with the [Structured Clone
-Algorithm][SCA], just like [`window.postMessage`][], so prototype chains will not be
+asynchronously. Arguments will be serialized with the [Structured Clone Algorithm][SCA],
+just like [`window.postMessage`][], so prototype chains will not be
 included. Sending Functions, Promises, Symbols, WeakMaps, or WeakSets will
 throw an exception.
 
@@ -160,8 +160,8 @@ If you do not need a response to the message, consider using [`ipcRenderer.send`
 Returns `any` - The value sent back by the [`ipcMain`](./ipc-main.md) handler.
 
 Send a message to the main process via `channel` and expect a result
-synchronously. Arguments will be serialized with the [Structured Clone
-Algorithm][SCA], just like [`window.postMessage`][], so prototype chains will not be
+synchronously. Arguments will be serialized with the [Structured Clone Algorithm][SCA],
+just like [`window.postMessage`][], so prototype chains will not be
 included. Sending Functions, Promises, Symbols, WeakMaps, or WeakSets will
 throw an exception.
 
@@ -208,8 +208,8 @@ ipcMain.on('port', (e, msg) => {
 })
 ```
 
-For more information on using `MessagePort` and `MessageChannel`, see the [MDN
-documentation](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel).
+For more information on using `MessagePort` and `MessageChannel`, see the
+[MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel).
 
 ### `ipcRenderer.sendToHost(channel, ...args)`
 

--- a/docs/api/net.md
+++ b/docs/api/net.md
@@ -86,9 +86,8 @@ async function example () {
 }
 ```
 
-This method will issue requests from the [default
-session](session.md#sessiondefaultsession). To send a `fetch` request from
-another session, use [ses.fetch()](session.md#sesfetchinput-init).
+This method will issue requests from the [default session](session.md#sessiondefaultsession).
+To send a `fetch` request from another session, use [ses.fetch()](session.md#sesfetchinput-init).
 
 See the MDN documentation for
 [`fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/fetch) for more
@@ -101,11 +100,10 @@ Limitations:
 * The `.type` and `.url` values of the returned `Response` object are
   incorrect.
 
-By default, requests made with `net.fetch` can be made to [custom
-protocols](protocol.md) as well as `file:`, and will trigger
-[webRequest](web-request.md) handlers if present. When the non-standard
-`bypassCustomProtocolHandlers` option is set in RequestInit, custom protocol
-handlers will not be called for this request. This allows forwarding an
+By default, requests made with `net.fetch` can be made to [custom protocols](protocol.md)
+as well as `file:`, and will trigger [webRequest](web-request.md) handlers if present.
+When the non-standard `bypassCustomProtocolHandlers` option is set in RequestInit,
+custom protocol handlers will not be called for this request. This allows forwarding an
 intercepted request to the built-in handler. [webRequest](web-request.md)
 handlers will still be triggered when bypassing custom protocols.
 
@@ -167,9 +165,8 @@ will be successful.
 
 Returns [`Promise<ResolvedHost>`](structures/resolved-host.md) - Resolves with the resolved IP addresses for the `host`.
 
-This method will resolve hosts from the [default
-session](session.md#sessiondefaultsession). To resolve a host from
-another session, use [ses.resolveHost()](session.md#sesresolvehosthost-options).
+This method will resolve hosts from the [default session](session.md#sessiondefaultsession).
+To resolve a host from another session, use [ses.resolveHost()](session.md#sesresolvehosthost-options).
 
 ## Properties
 

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -79,9 +79,8 @@ protocol.registerSchemesAsPrivileged([
 ])
 ```
 
-A standard scheme adheres to what RFC 3986 calls [generic URI
-syntax](https://tools.ietf.org/html/rfc3986#section-3). For example `http` and
-`https` are standard schemes, while `file` is not.
+A standard scheme adheres to what RFC 3986 calls [generic URI syntax](https://tools.ietf.org/html/rfc3986#section-3).
+For example `http` and `https` are standard schemes, while `file` is not.
 
 Registering a scheme as standard allows relative and absolute resources to
 be resolved correctly when served. Otherwise the scheme will behave like the

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -729,11 +729,10 @@ Limitations:
 * The `.type` and `.url` values of the returned `Response` object are
   incorrect.
 
-By default, requests made with `net.fetch` can be made to [custom
-protocols](protocol.md) as well as `file:`, and will trigger
-[webRequest](web-request.md) handlers if present. When the non-standard
-`bypassCustomProtocolHandlers` option is set in RequestInit, custom protocol
-handlers will not be called for this request. This allows forwarding an
+By default, requests made with `net.fetch` can be made to [custom protocols](protocol.md)
+as well as `file:`, and will trigger [webRequest](web-request.md) handlers if present.
+When the non-standard `bypassCustomProtocolHandlers` option is set in RequestInit,
+custom protocol handlers will not be called for this request. This allows forwarding an
 intercepted request to the built-in handler. [webRequest](web-request.md)
 handlers will still be triggered when bypassing custom protocols.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -617,8 +617,7 @@ Returns:
 
 Emitted when failed to verify the `certificate` for `url`.
 
-The usage is the same with [the `certificate-error` event of
-`app`](app.md#event-certificate-error).
+The usage is the same with [the `certificate-error` event of `app`](app.md#event-certificate-error).
 
 #### Event: 'select-client-certificate'
 
@@ -632,8 +631,7 @@ Returns:
 
 Emitted when a client certificate is requested.
 
-The usage is the same with [the `select-client-certificate` event of
-`app`](app.md#event-select-client-certificate).
+The usage is the same with [the `select-client-certificate` event of `app`](app.md#event-select-client-certificate).
 
 #### Event: 'login'
 
@@ -1850,8 +1848,8 @@ Opens the developer tools for the service worker context.
 * `...args` any[]
 
 Send an asynchronous message to the renderer process via `channel`, along with
-arguments. Arguments will be serialized with the [Structured Clone
-Algorithm][SCA], just like [`postMessage`][], so prototype chains will not be
+arguments. Arguments will be serialized with the [Structured Clone Algorithm][SCA],
+just like [`postMessage`][], so prototype chains will not be
 included. Sending Functions, Promises, Symbols, WeakMaps, or WeakSets will
 throw an exception.
 

--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -103,10 +103,9 @@ Returns `boolean` - Whether the reload was initiated successfully. Only results 
 * `...args` any[]
 
 Send an asynchronous message to the renderer process via `channel`, along with
-arguments. Arguments will be serialized with the [Structured Clone
-Algorithm][SCA], just like [`postMessage`][], so prototype chains will not be
-included. Sending Functions, Promises, Symbols, WeakMaps, or WeakSets will
-throw an exception.
+arguments. Arguments will be serialized with the [Structured Clone Algorithm][SCA],
+just like [`postMessage`][], so prototype chains will not be included.
+Sending Functions, Promises, Symbols, WeakMaps, or WeakSets will throw an exception.
 
 The renderer process can handle the message by listening to `channel` with the
 [`ipcRenderer`](ipc-renderer.md) module.

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -716,8 +716,8 @@ document.getElementById('webview').addEventListener('new-window', () => {
 ### Deprecated: BrowserWindow `scroll-touch-*` events
 
 The `scroll-touch-begin`, `scroll-touch-end` and `scroll-touch-edge` events on
-BrowserWindow are deprecated. Instead, use the newly available [`input-event`
-event](api/web-contents.md#event-input-event) on WebContents.
+BrowserWindow are deprecated. Instead, use the newly available
+[`input-event` event](api/web-contents.md#event-input-event) on WebContents.
 
 ```js
 // Deprecated
@@ -742,8 +742,8 @@ win.webContents.on('input-event', (_, event) => {
 ### Behavior Changed: V8 Memory Cage enabled
 
 The V8 memory cage has been enabled, which has implications for native modules
-which wrap non-V8 memory with `ArrayBuffer` or `Buffer`. See the [blog post
-about the V8 memory cage](https://www.electronjs.org/blog/v8-memory-cage) for
+which wrap non-V8 memory with `ArrayBuffer` or `Buffer`. See the
+[blog post about the V8 memory cage](https://www.electronjs.org/blog/v8-memory-cage) for
 more details.
 
 ### API Changed: `webContents.printToPDF()`
@@ -1345,8 +1345,7 @@ const w = new BrowserWindow({
 })
 ```
 
-We [recommend moving away from the remote
-module](https://medium.com/@nornagon/electrons-remote-module-considered-harmful-70d69500f31).
+We [recommend moving away from the remote module](https://medium.com/@nornagon/electrons-remote-module-considered-harmful-70d69500f31).
 
 ### `protocol.unregisterProtocol`
 
@@ -1506,12 +1505,11 @@ You can see the original API proposal and reasoning [here](https://github.com/el
 
 ### Behavior Changed: Values sent over IPC are now serialized with Structured Clone Algorithm
 
-The algorithm used to serialize objects sent over IPC (through
-`ipcRenderer.send`, `ipcRenderer.sendSync`, `WebContents.send` and related
-methods) has been switched from a custom algorithm to V8's built-in [Structured
-Clone Algorithm][SCA], the same algorithm used to serialize messages for
-`postMessage`. This brings about a 2x performance improvement for large
-messages, but also brings some breaking changes in behavior.
+The algorithm used to serialize objects sent over IPC (through `ipcRenderer.send`,
+`ipcRenderer.sendSync`, `WebContents.send` and related methods) has been switched from a custom
+algorithm to V8's built-in [Structured Clone Algorithm][SCA], the same algorithm used to serialize
+messages for `postMessage`. This brings about a 2x performance improvement for large messages,
+but also brings some breaking changes in behavior.
 
 * Sending Functions, Promises, WeakMaps, WeakSets, or objects containing any
   such values, over IPC will now throw an exception, instead of silently
@@ -2018,8 +2016,8 @@ app.getGPUInfo('basic')
 When building native modules for windows, the `win_delay_load_hook` variable in
 the module's `binding.gyp` must be true (which is the default). If this hook is
 not present, then the native module will fail to load on Windows, with an error
-message like `Cannot find module`. See the [native module
-guide](./tutorial/using-native-node-modules.md) for more.
+message like `Cannot find module`.
+See the [native module guide](./tutorial/using-native-node-modules.md) for more.
 
 ### Removed: IA32 Linux support
 

--- a/docs/development/coding-style.md
+++ b/docs/development/coding-style.md
@@ -24,8 +24,8 @@ You can run `npm run lint` to show any style issues detected by `cpplint` and
 
 ## C++ and Python
 
-For C++ and Python, we follow Chromium's [Coding
-Style](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/styleguide/styleguide.md).
+For C++ and Python, we follow Chromium's
+[Coding Style](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/styleguide/styleguide.md).
 There is also a script `script/cpplint.py` to check whether all files conform.
 
 The Python version we are using now is Python 3.9.

--- a/docs/development/source-code-directory-structure.md
+++ b/docs/development/source-code-directory-structure.md
@@ -3,8 +3,8 @@
 The source code of Electron is separated into a few parts, mostly
 following Chromium on the separation conventions.
 
-You may need to become familiar with [Chromium's multi-process
-architecture](https://dev.chromium.org/developers/design-documents/multi-process-architecture)
+You may need to become familiar with
+[Chromium's multi-process architecture](https://dev.chromium.org/developers/design-documents/multi-process-architecture)
 to understand the source code better.
 
 ## Structure of Source Code

--- a/docs/tutorial/application-debugging.md
+++ b/docs/tutorial/application-debugging.md
@@ -26,8 +26,8 @@ of the most powerful utilities in any Electron Developer's tool belt.
 ## Main Process
 
 Debugging the main process is a bit trickier, since you cannot open
-developer tools for them. The Chromium Developer Tools can [be used
-to debug Electron's main process][node-inspect] thanks to a closer collaboration
+developer tools for them. The Chromium Developer Tools can
+[be used to debug Electron's main process][node-inspect] thanks to a closer collaboration
 between Google / Chrome and Node.js, but you might encounter oddities like
 `require` not being present in the console.
 

--- a/docs/tutorial/application-distribution.md
+++ b/docs/tutorial/application-distribution.md
@@ -24,8 +24,8 @@ If you prefer the manual approach, there are 2 ways to distribute your applicati
 
 ### With prebuilt binaries
 
-To distribute your app manually, you need to download Electron's [prebuilt
-binaries](https://github.com/electron/electron/releases). Next, the folder
+To distribute your app manually, you need to download Electron's
+[prebuilt binaries](https://github.com/electron/electron/releases). Next, the folder
 containing your app should be named `app` and placed in Electron's resources
 directory as shown in the following examples.
 

--- a/docs/tutorial/asar-archives.md
+++ b/docs/tutorial/asar-archives.md
@@ -6,10 +6,9 @@ hide_title: false
 ---
 
 After creating an [application distribution](application-distribution.md), the
-app's source code are usually bundled into an [ASAR
-archive](https://github.com/electron/asar), which is a simple extensive archive
-format designed for Electron apps. By bundling the app we can mitigate issues
-around long path names on Windows, speed up `require` and conceal your source
+app's source code are usually bundled into an [ASAR archive](https://github.com/electron/asar),
+which is a simple extensive archive format designed for Electron apps. By bundling the app
+we can mitigate issues around long path names on Windows, speed up `require` and conceal your source
 code from cursory inspection.
 
 The bundled app runs in a virtual file system and most APIs would just work

--- a/docs/tutorial/code-signing.md
+++ b/docs/tutorial/code-signing.md
@@ -55,8 +55,8 @@ If you're not using an integrated build pipeline like Forge, you
 are likely using [`@electron/packager`][], which includes [`@electron/osx-sign`][] and
 [`@electron/notarize`][].
 
-If you're using Packager's API, you can pass [in configuration that both signs
-and notarizes your application](https://electron.github.io/packager/main/modules.html).
+If you're using Packager's API, you can pass
+[in configuration that both signs and notarizes your application](https://electron.github.io/packager/main/modules.html).
 If the example below does not meet your needs, please see [`@electron/osx-sign`][] and
 [`@electron/notarize`][] for the many possible configuration options.
 
@@ -129,9 +129,9 @@ be found in the [Electron Forge Code Signing Tutorial](https://www.electronforge
 If you're not using an integrated build pipeline like Forge, you
 are likely using [`@electron/packager`][], which includes [`@electron/windows-sign`][].
 
-If you're using Packager's API, you can pass [in configuration that signs
-your application](https://electron.github.io/packager/main/modules.html). If the
-example below does not meet your needs, please see [`@electron/windows-sign`][]
+If you're using Packager's API, you can pass
+[in configuration that signs your application](https://electron.github.io/packager/main/modules.html).
+If the example below does not meet your needs, please see [`@electron/windows-sign`][]
 for the many possible configuration options.
 
 ```js @ts-nocheck

--- a/docs/tutorial/launch-app-from-url-in-another-app.md
+++ b/docs/tutorial/launch-app-from-url-in-another-app.md
@@ -130,9 +130,8 @@ this for you.
 #### [Electron Forge](https://electronforge.io)
 
 If you're using Electron Forge, adjust `packagerConfig` for macOS support, and the configuration for
-the appropriate Linux makers for Linux support, in your [Forge
-configuration](https://www.electronforge.io/configuration) _(please note the following example only
-shows the bare minimum needed to add the configuration changes)_:
+the appropriate Linux makers for Linux support, in your [Forge configuration](https://www.electronforge.io/configuration)
+_(please note the following example only shows the bare minimum needed to add the configuration changes)_:
 
 ```json
 {

--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -158,9 +158,8 @@ This module allows you to detect ahead of time whether or not the notification w
 ### Linux
 
 Notifications are sent using `libnotify`, which can show notifications on any
-desktop environment that follows [Desktop Notifications
-Specification][notification-spec], including Cinnamon, Enlightenment, Unity,
-GNOME, and KDE.
+desktop environment that follows [Desktop Notifications Specification][notification-spec],
+including Cinnamon, Enlightenment, Unity, GNOME, and KDE.
 
 [notification-spec]: https://developer-old.gnome.org/notification-spec/
 [app-user-model-id]: https://learn.microsoft.com/en-us/windows/win32/shell/appids


### PR DESCRIPTION
#### Description of Change

Due to a bug in Docusaurus 3 (https://github.com/facebook/docusaurus/issues/9048), having links on multiple lines will break relative linking in the website build process.

```markdown
[This link will not
work properly in Docusaurus 3](https://electronjs.org)
```


This PR changes some whitespace around to fix all instances of this case in the Electron docs. These instances were vetted with https://github.com/electron/lint-roller/commit/f68f4691a17876787749d120c0c4185675b9dcae (thanks @dsanders11!), which will be applied to this repository in a separate PR.

cc @electron/docs


#### Release Notes

Notes: none
