### PR TITLE
fix: calculate a hash for the Tag property of ToastNotification.

### DIFF
--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -146,7 +146,7 @@ void WindowsToastNotification::Remove() {
     return;
 
   ScopedHString group(kGroup);
-  ScopedHString tag(base::as_wcstr(base::UTF8ToUTF16(notification_id())));
+  ScopedHString tag(base::as_wcstr(base::UTF8ToUTF16(std::to_string(std::hash<std::string>{}(notification_id())))));
   notification_history->RemoveGroupedTagWithId(tag, group, app_id);
 }
 
@@ -199,7 +199,7 @@ HRESULT WindowsToastNotification::ShowInternal(
   REPORT_AND_RETURN_IF_FAILED(toast2->put_Group(group),
                               "WinAPI: Setting group failed");
 
-  ScopedHString tag(base::as_wcstr(base::UTF8ToUTF16(notification_id())));
+  ScopedHString tag(base::as_wcstr(base::UTF8ToUTF16(std::to_string(std::hash<std::string>{}(notification_id())))));
   REPORT_AND_RETURN_IF_FAILED(toast2->put_Tag(tag),
                               "WinAPI: Setting tag failed");
 


### PR DESCRIPTION
#### Description of Change

We encountered an issue on Windows, the notification won't popup when use web notification.
After our investigation. We found that when the URL exceeds a certain length, it will not popup the notification.
And it was caused by this change: https://github.com/electron/electron/pull/40242
In fact, the length of notification_id() will be affected by url, NotificationOptions, etc.

My solution is to calculate the hash of the notification_id() value.

Related issue:
https://github.com/electron/electron/issues/42233
https://github.com/electron/electron/issues/40433
