### PR TITLE
Update notification-spec broken link in the notification.md file

### DIFF
--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -162,7 +162,7 @@ desktop environment that follows [Desktop Notifications
 Specification][notification-spec], including Cinnamon, Enlightenment, Unity,
 GNOME, and KDE.
 
-[notification-spec]: https://developer-old.gnome.org/notification-spec/
+[notification-spec]: [https://developer-old.gnome.org/notification-spec/](https://web.archive.org/web/20240303155839/https://developer-old.gnome.org/notification-spec/)
 [app-user-model-id]: https://learn.microsoft.com/en-us/windows/win32/shell/appids
 [set-app-user-model-id]: ../api/app.md#appsetappusermodelidid-windows
 [squirrel-events]: https://github.com/electron/windows-installer/blob/main/README.md#handling-squirrel-events


### PR DESCRIPTION
#### Description of Change

Fix notification-spec link to link to the waybak machine instead of to a broken page

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix notification-spec link in the example docs. Fixes https://github.com/electron/electron/issues/42240