### PR TITLE
chore: cherry-pick 3e037e195e50 from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -4,3 +4,4 @@ merged_wasm_gc_scan_the_code_field_of_the_wasminternalfunction.patch
 cherry-pick-f320600cd1f4.patch
 cherry-pick-b3c01ac1e60a.patch
 cherry-pick-6503a987d966.patch
+cherry-pick-3e037e195e50.patch

--- a/patches/v8/cherry-pick-3e037e195e50.patch
+++ b/patches/v8/cherry-pick-3e037e195e50.patch
@@ -1,0 +1,42 @@
+From 3e037e195e508dea045f5626862412e8f64fc919 Mon Sep 17 00:00:00 2001
+From: Shu-yu Guo <syg@chromium.org>
+Date: Tue, 21 May 2024 10:06:20 -0700
+Subject: [PATCH] [parser] Using FunctionParsingScope for parsing class static blocks
+
+Class static blocks contain statements, don't inherit the
+ExpressionScope stack.
+
+Bug: 341663589
+Change-Id: Id52a60d77781201a706fcf2290d7d103f39bed83
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5553030
+Commit-Queue: Shu-yu Guo <syg@chromium.org>
+Commit-Queue: Adam Klein <adamk@chromium.org>
+Reviewed-by: Adam Klein <adamk@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#94014}
+---
+
+diff --git a/src/ast/scopes.cc b/src/ast/scopes.cc
+index 660fdd2..de4df35 100644
+--- a/src/ast/scopes.cc
++++ b/src/ast/scopes.cc
+@@ -2447,7 +2447,7 @@
+     var->set_is_used();
+     if (inner_scope_calls_eval_ && !var->is_this()) var->SetMaybeAssigned();
+   }
+-  DCHECK(!var->has_forced_context_allocation() || var->is_used());
++  CHECK(!var->has_forced_context_allocation() || var->is_used());
+   // Global variables do not need to be allocated.
+   return !var->IsGlobalObjectProperty() && var->is_used();
+ }
+diff --git a/src/parsing/parser-base.h b/src/parsing/parser-base.h
+index 40914d3..65c338f 100644
+--- a/src/parsing/parser-base.h
++++ b/src/parsing/parser-base.h
+@@ -2661,6 +2661,7 @@
+   }
+ 
+   FunctionState initializer_state(&function_state_, &scope_, initializer_scope);
++  FunctionParsingScope body_parsing_scope(impl());
+   AcceptINScope accept_in(this, true);
+ 
+   // Each static block has its own var and lexical scope, so make a new var

--- a/patches/v8/cherry-pick-3e037e195e50.patch
+++ b/patches/v8/cherry-pick-3e037e195e50.patch
@@ -1,7 +1,7 @@
-From 3e037e195e508dea045f5626862412e8f64fc919 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shu-yu Guo <syg@chromium.org>
 Date: Tue, 21 May 2024 10:06:20 -0700
-Subject: [PATCH] [parser] Using FunctionParsingScope for parsing class static blocks
+Subject: Using FunctionParsingScope for parsing class static blocks
 
 Class static blocks contain statements, don't inherit the
 ExpressionScope stack.
@@ -13,13 +13,12 @@ Commit-Queue: Shu-yu Guo <syg@chromium.org>
 Commit-Queue: Adam Klein <adamk@chromium.org>
 Reviewed-by: Adam Klein <adamk@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#94014}
----
 
 diff --git a/src/ast/scopes.cc b/src/ast/scopes.cc
-index 660fdd2..de4df35 100644
+index 6dfcd45cf208e58a2fc0cd18ba3b115bae35a0d5..61b8fbf0cfcaa02a92ead411e4bcbc1f36dfdad3 100644
 --- a/src/ast/scopes.cc
 +++ b/src/ast/scopes.cc
-@@ -2447,7 +2447,7 @@
+@@ -2441,7 +2441,7 @@ bool Scope::MustAllocate(Variable* var) {
      var->set_is_used();
      if (inner_scope_calls_eval_ && !var->is_this()) var->SetMaybeAssigned();
    }
@@ -29,10 +28,10 @@ index 660fdd2..de4df35 100644
    return !var->IsGlobalObjectProperty() && var->is_used();
  }
 diff --git a/src/parsing/parser-base.h b/src/parsing/parser-base.h
-index 40914d3..65c338f 100644
+index ac35090ca5d129c58c0e4fb31ee2e2456e202dce..059133f32d30c94e400de96313734b64c5421b09 100644
 --- a/src/parsing/parser-base.h
 +++ b/src/parsing/parser-base.h
-@@ -2661,6 +2661,7 @@
+@@ -2619,6 +2619,7 @@ typename ParserBase<Impl>::BlockT ParserBase<Impl>::ParseClassStaticBlock(
    }
  
    FunctionState initializer_state(&function_state_, &scope_, initializer_scope);


### PR DESCRIPTION
[parser] Using FunctionParsingScope for parsing class static blocks

Class static blocks contain statements, don't inherit the
ExpressionScope stack.

Bug: 341663589
Change-Id: Id52a60d77781201a706fcf2290d7d103f39bed83
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5553030
Commit-Queue: Shu-yu Guo <syg@chromium.org>
Commit-Queue: Adam Klein <adamk@chromium.org>
Reviewed-by: Adam Klein <adamk@chromium.org>
Cr-Commit-Position: refs/heads/main@{#94014}


Notes: Backported fix for 341663589.