### PR TITLE
fix: potential null dereference in normalizeSpawnArguments() patch

### DIFF
--- a/patches/node/enable_crashpad_linux_node_processes.patch
+++ b/patches/node/enable_crashpad_linux_node_processes.patch
@@ -8,7 +8,7 @@ to child processes spawned with `ELECTRON_RUN_AS_NODE` which is used
 by the crashpad client to connect with the handler process.
 
 diff --git a/lib/child_process.js b/lib/child_process.js
-index c09fca512584ce2c674ae1d05136ff4cd8ea8471..3947e231f4e641b97d12c9639a736fab8836787b 100644
+index c09fca512584ce2c674ae1d05136ff4cd8ea8471..d4edaa71a7bf6660bad209fbfbc43014bb4bf741 100644
 --- a/lib/child_process.js
 +++ b/lib/child_process.js
 @@ -61,6 +61,7 @@ let debug = require('internal/util/debuglog').debuglog(
@@ -27,25 +27,34 @@ index c09fca512584ce2c674ae1d05136ff4cd8ea8471..3947e231f4e641b97d12c9639a736fab
    args = [...execArgv, modulePath, ...args];
  
    if (typeof options.stdio === 'string') {
-@@ -617,6 +617,21 @@ function normalizeSpawnArguments(file, args, options) {
+@@ -617,6 +617,22 @@ function normalizeSpawnArguments(file, args, options) {
                      'options.windowsVerbatimArguments');
    }
  
-+  if (process.platform === 'linux') {
-+    if (ObjectPrototypeHasOwnProperty(options.env || process.env, 'ELECTRON_RUN_AS_NODE') &&
-+        (file === process.execPath)) {
-+      // On Linux, pass the file descriptor which crashpad handler process
-+      // uses to monitor the child process and PID of the handler process.
-+      // https://source.chromium.org/chromium/chromium/src/+/110.0.5415.0:components/crash/core/app/crashpad_linux.cc;l=199-206
-+      const fd = getCrashdumpSignalFD();
-+      const pid = getCrashpadHandlerPID();
-+      if (fd !== -1 && pid !== -1) {
-+        options.env.CRASHDUMP_SIGNAL_FD = fd;
-+        options.env.CRASHPAD_HANDLER_PID = pid;
-+      }
++  const env = options.env || process.env;
++
++  if ((process.platform === 'linux') &&
++      ObjectPrototypeHasOwnProperty(env, 'ELECTRON_RUN_AS_NODE') &&
++      (file === process.execPath)) {
++    // On Linux, pass the file descriptor which crashpad handler process
++    // uses to monitor the child process and PID of the handler process.
++    // https://source.chromium.org/chromium/chromium/src/+/110.0.5415.0:components/crash/core/app/crashpad_linux.cc;l=199-206
++    const fd = getCrashdumpSignalFD();
++    const pid = getCrashpadHandlerPID();
++    if (fd !== -1 && pid !== -1) {
++      env.CRASHDUMP_SIGNAL_FD = fd;
++      env.CRASHPAD_HANDLER_PID = pid;
 +    }
 +  }
 +
    if (options.shell) {
      validateArgumentNullCheck(options.shell, 'options.shell');
      const command = ArrayPrototypeJoin([file, ...args], ' ');
+@@ -650,7 +666,6 @@ function normalizeSpawnArguments(file, args, options) {
+     ArrayPrototypeUnshift(args, file);
+   }
+ 
+-  const env = options.env || process.env;
+   const envPairs = [];
+ 
+   // process.env.NODE_V8_COVERAGE always propagates, making it possible to


### PR DESCRIPTION
#### Description of Change

The old version of this patch has code that can call `options.env.foo = bar` even if  `options.env` is null.  This PR moves the pre-existing upstream Node line `const env = options.env || process.env` to be declared earlier in the function so that we can use `env` safely here.

CC @deepak1556, @mlaurencin since this upstreams a minor cleanup from the Microsoft build's patchset
CC @VerteDinde -- Keeley, I can't tell if you wrote the patch but your name is in the `From:` header so you're a stakeholder :smile_cat: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none