### PR TITLE
fix: vibrant view is inserted into Views API hierarchy

### DIFF
--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "electron/shell/common/api/api.mojom.h"
 #include "shell/browser/native_window.h"
 #include "ui/display/display_observer.h"
@@ -298,6 +299,9 @@ class NativeWindowMac : public NativeWindow,
   NSRect default_frame_for_zoom_;
 
   std::string vibrancy_type_;
+
+  // A views::NativeViewHost wrapping the vibrant view. Owned by the root view.
+  raw_ptr<views::NativeViewHost> vibrant_native_view_host_ = nullptr;
 
   // The presentation options before entering simple fullscreen mode.
   NSApplicationPresentationOptions simple_fullscreen_options_;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1397,13 +1397,19 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
   NativeWindow::SetVibrancy(type);
 
   NSVisualEffectView* vibrantView = [window_ vibrantView];
+  views::View* rootView = GetContentsView();
 
   if (type.empty()) {
-    if (vibrantView == nil)
-      return;
+    if (vibrant_native_view_host_ != nullptr) {
+      // Transfers ownership back to caller in the form of a unique_ptr which is
+      // subsequently deleted.
+      rootView->RemoveChildViewT(vibrant_native_view_host_);
+      vibrant_native_view_host_ = nullptr;
+    }
 
-    [vibrantView removeFromSuperview];
-    [window_ setVibrantView:nil];
+    if (vibrantView != nil) {
+      [window_ setVibrantView:nil];
+    }
 
     return;
   }
@@ -1459,9 +1465,13 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
         [vibrantView setState:NSVisualEffectStateFollowsWindowActiveState];
       }
 
-      [[window_ contentView] addSubview:vibrantView
-                             positioned:NSWindowBelow
-                             relativeTo:nil];
+      // Vibrant view is inserted into the root view hierarchy underneath all
+      // other views.
+      vibrant_native_view_host_ = new views::NativeViewHost();
+      rootView->AddChildViewAt(vibrant_native_view_host_, 0);
+      vibrant_native_view_host_->Attach(vibrantView);
+
+      rootView->DeprecatedLayoutImmediately();
 
       UpdateVibrancyRadii(IsFullscreen());
     }


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/41979 in Electron 30.

##### Summary

In Electron 30 setting a BrowserWindow's vibrancy on macOS will often cause the entire contents of the screen to have the vibrancy effect, wiping all actual window contents. This traces back to https://github.com/electron/electron/pull/35658 which replaced BrowserViews with WebContentsViews that use Chromium's Views API. We can fix this by inserting the vibrant view into Chromium's Views hierarchy by wrapping the vibrant view in a NativeViewHost.

##### Before Electron 30

The vibrancy setting creates a native macOS NSVisualEffectView that is inserted as a direct child of the window's contentView [here](https://github.com/electron/electron/blob/85df2a86dda7b99af99310566601ee04b72e55c8/shell/browser/native_window_mac.mm#L1459-L1461). Prior to the BrowserView -> WebContentsView switch, BrowserViews were backed by native macOS NSViews which were also inserted as direct children of the window's contentView [here](https://github.com/electron/electron/commit/15c60143241c7d0335f3bc8c722054ce6b8a9481#diff-148ef9a1a6f049d9fef8c6272a4871d89315f8fc6cd80dc2d41a28b21b29184cL1299-L1302), and the order of BrowserViews and the vibrancy view was maintained using the macOS NSView ordering APIs.

##### Electron 30 Breakage

After BrowserView was replaced with WebContentsView, WebContentsViews are no longer ordered using the macOS view ordering APIs. Instead WebContentsViews use Chromium's Views API (i.e. AddChildViewAt, RemoveChildView, etc). The problem is that the vibrancy view is attempting to use the macOS view ordering API whereas all WebContentsViews now use Chromium's Views API.

I think that the exact bug we're seeing in Electron 30 where the vibrancy view is moved to the top and blocks all other contents is because deep inside Chromium the Views API calls macOS's sortSubviewsUsingFunction [here](https://source.chromium.org/chromium/chromium/src/+/main:components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm;l=1259;drc=c0265133106c7647e90f9aaa4377d28190b1a6a9?q=sortsubviews&ss=chromium%2Fchromium%2Fsrc&start=11), using a [function](https://source.chromium.org/chromium/chromium/src/+/main:components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm;l=220;drc=c0265133106c7647e90f9aaa4377d28190b1a6a9?q=sortsubviews&ss=chromium%2Fchromium%2Fsrc&start=11) that moves all unregistered views (aka the vibrancy view) to the very top.

This can be solved by adding the vibrancy view into the Chromium views hierarchy so that Chromium knows how to order it appropriately. We can wrap the vibrancy view in a NativeViewHost and insert it as the first child of the root ContentsView so that it is behind both the BrowserWindow's webContents and all of the WebContentsViews.

#### Notes

This is a PR against `30-x-y` since this fix is specific to Electron 30. In Electron 31+ there are different issues with a potentially similar solution for vibrancy (see https://github.com/electron/electron/issues/41979#issuecomment-2140732448 for more details). One proposed fix would be to revert https://github.com/electron/electron/pull/41326 and then apply this PR which fixes the vibrancy bugs I am seeing in 31+, but for now this PR fixes the 30 branch.

Let me know if there is a better way to get this fix in, since it's technically not a backport to the 30 branch so CI is currently failing.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed BrowserWindow vibrancy on macOS
