### PR TITLE
chore: fix `npm run lint` not working on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,6 +22,7 @@ patches/**/.patches merge=union
 *.md text eol=lf
 *.mm text eol=lf
 *.mojom text eol=lf
+*.patches text eol=lf
 *.proto text eol=lf
 *.py text eol=lf
 *.ps1 text eol=lf

--- a/script/lint.js
+++ b/script/lint.js
@@ -8,7 +8,6 @@ const fs = require('node:fs');
 const minimist = require('minimist');
 const path = require('node:path');
 const { getCodeBlocks } = require('@electron/lint-roller/dist/lib/markdown');
-const os = require('node:os');
 
 const { chunkFilenames, findMatchingFiles } = require('./lib/utils');
 
@@ -222,7 +221,7 @@ const LINTERS = [{
       }
 
       // Read the patch list
-      const patchFileList = fs.readFileSync(dotPatchesPath, 'utf8').trim().split(os.EOL);
+      const patchFileList = fs.readFileSync(dotPatchesPath, 'utf8').trim().split('\n');
       const patchFileSet = new Set(patchFileList);
       patchFileList.reduce((seen, file) => {
         if (seen.has(file)) {

--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -134,6 +134,7 @@ def run_clang_format_diff(args, file_name):
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE,
                               universal_newlines=True,
+                              encoding='utf-8',
                               shell=True) as proc:
             outs = list(proc.stdout.readlines())
             errs = list(proc.stderr.readlines())
@@ -186,10 +187,7 @@ def colorize(diff_lines):
 def print_diff(diff_lines, use_color):
     if use_color:
         diff_lines = colorize(diff_lines)
-    if sys.version_info[0] < 3:
-        sys.stdout.writelines((l.encode('utf-8') for l in diff_lines))
-    else:
-        sys.stdout.writelines(diff_lines)
+    sys.stdout.writelines(diff_lines)
 
 
 def print_trouble(prog, message, use_colors):


### PR DESCRIPTION
#### Description of Change

`npm run lint` is not runnable on Windows currently. Made some minor changes to make it working properly.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: fix: fixed the `npm run lint` not working on Windows.
