### PR TITLE
fix: restore original BrowserWindow.show() behavior

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -457,11 +457,7 @@ void NativeWindowMac::Show() {
 
   // Panels receive key focus when shown but should not activate the app.
   if (!IsPanel()) {
-    if (@available(macOS 14.0, *)) {
-      [[NSApplication sharedApplication] activate];
-    } else {
-      [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
-    }
+    [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
   }
   [window_ makeKeyAndOrderFront:nil];
 }


### PR DESCRIPTION
The new activate API on macOS is pretty bad, we should just keep using the old API. Similar to #42180. Restores non-panel behavior to pre-panel support.

Notes: BrowserWindow.show() now correctly restores focus to inactive apps on macOS