### PR TITLE
build: update NMV to 125

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -2,7 +2,7 @@ is_electron_build = true
 root_extra_deps = [ "//electron" ]
 
 # Registry of NMVs --> https://github.com/nodejs/node/blob/main/doc/abi_version_registry.json
-node_module_version = 123
+node_module_version = 125
 
 v8_promise_internal_field_count = 1
 v8_embedder_string = "-electron.0"


### PR DESCRIPTION
#### Description of Change

Bumps Electron's NMV to 125. 125 was reserved during the last release cycle here: https://github.com/nodejs/node/pull/52379 but a bump commit like this was not made before 31-x-y was cut. (See https://github.com/electron/electron/pull/39538 for a previous example of this process).

cc @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none