### PR TITLE
docs: fixing typos in doc

### DIFF
--- a/docs/tutorial/tutorial-2-first-app.md
+++ b/docs/tutorial/tutorial-2-first-app.md
@@ -225,8 +225,8 @@ with CommonJS module syntax:
 <details>
 <summary>Module capitalization conventions</summary>
 
-You might have noticed the capitalization difference between the **a**pp
-and **B**rowser**W**indow modules. Electron follows typical JavaScript conventions here,
+You might have noticed the capitalization difference between the **app**
+and **BrowserWindow** modules. Electron follows typical JavaScript conventions here,
 where PascalCase modules are instantiable class constructors (e.g. BrowserWindow, Tray,
 Notification) whereas camelCase modules are not instantiable (e.g. app, ipcRenderer, webContents).
 


### PR DESCRIPTION
#### Description of Change
There were typos when referencing app and BrowserWindow modules.

cc @electron/docs


#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes

Notes: none
