### PR TITLE
build: point Publish MacOS action to main branch SHA

### DIFF
--- a/.github/workflows/macos-publish.yml
+++ b/.github/workflows/macos-publish.yml
@@ -15,8 +15,7 @@ on:
 
 jobs:
   publish:
-  # TODO(vertedinde): Change this to main before merge
-    uses: electron/electron/.github/workflows/macos-build.yml@gh-actions-mac-publish
+    uses: electron/electron/.github/workflows/macos-build.yml@361b37592af3e79606440ca0c229c27df78676cf
     with:
       IS_RELEASE: true
       GN_CONFIG: //electron/build/args/release.gn


### PR DESCRIPTION
#### Description of Change

Follow up to #42236 - points the publish action to a specific SHA, rather than the branch.

We could also point this @ main to automatically pick up main branch changes, but leaving this pinned to a SHA in the short term for slightly better security

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
