### PR TITLE
fix: WebUSB should not crash when using in-memory partitions

### DIFF
--- a/shell/browser/usb/electron_usb_delegate.cc
+++ b/shell/browser/usb/electron_usb_delegate.cc
@@ -174,6 +174,9 @@ std::unique_ptr<content::UsbChooser> ElectronUsbDelegate::RunChooser(
 bool ElectronUsbDelegate::CanRequestDevicePermission(
     content::BrowserContext* browser_context,
     const url::Origin& origin) {
+  if (!browser_context)
+    return false;
+
   base::Value::Dict details;
   details.Set("securityOrigin", origin.GetURL().spec());
   auto* permission_manager = static_cast<ElectronPermissionManager*>(
@@ -188,32 +191,46 @@ void ElectronUsbDelegate::RevokeDevicePermissionWebInitiated(
     content::BrowserContext* browser_context,
     const url::Origin& origin,
     const device::mojom::UsbDeviceInfo& device) {
-  GetChooserContext(browser_context)
-      ->RevokeDevicePermissionWebInitiated(origin, device);
+  auto* chooser_context = GetChooserContext(browser_context);
+  if (chooser_context) {
+    chooser_context->RevokeDevicePermissionWebInitiated(origin, device);
+  }
 }
 
 const device::mojom::UsbDeviceInfo* ElectronUsbDelegate::GetDeviceInfo(
     content::BrowserContext* browser_context,
     const std::string& guid) {
-  return GetChooserContext(browser_context)->GetDeviceInfo(guid);
+  auto* chooser_context = GetChooserContext(browser_context);
+  if (!chooser_context)
+    return nullptr;
+  return chooser_context->GetDeviceInfo(guid);
 }
 
 bool ElectronUsbDelegate::HasDevicePermission(
     content::BrowserContext* browser_context,
     content::RenderFrameHost* frame,
     const url::Origin& origin,
-    const device::mojom::UsbDeviceInfo& device) {
-  if (IsDevicePermissionAutoGranted(origin, device))
+    const device::mojom::UsbDeviceInfo& device_info) {
+  if (IsDevicePermissionAutoGranted(origin, device_info))
     return true;
 
+  auto* chooser_context = GetChooserContext(browser_context);
+  if (!chooser_context)
+    return false;
+
   return GetChooserContext(browser_context)
-      ->HasDevicePermission(origin, device);
+      ->HasDevicePermission(origin, device_info);
 }
 
 void ElectronUsbDelegate::GetDevices(
     content::BrowserContext* browser_context,
     blink::mojom::WebUsbService::GetDevicesCallback callback) {
-  GetChooserContext(browser_context)->GetDevices(std::move(callback));
+  auto* chooser_context = GetChooserContext(browser_context);
+  if (!chooser_context) {
+    std::move(callback).Run(std::vector<device::mojom::UsbDeviceInfoPtr>());
+    return;
+  }
+  chooser_context->GetDevices(std::move(callback));
 }
 
 void ElectronUsbDelegate::GetDevice(
@@ -222,25 +239,35 @@ void ElectronUsbDelegate::GetDevice(
     base::span<const uint8_t> blocked_interface_classes,
     mojo::PendingReceiver<device::mojom::UsbDevice> device_receiver,
     mojo::PendingRemote<device::mojom::UsbDeviceClient> device_client) {
-  GetChooserContext(browser_context)
-      ->GetDevice(guid, blocked_interface_classes, std::move(device_receiver),
-                  std::move(device_client));
+  auto* chooser_context = GetChooserContext(browser_context);
+  if (chooser_context) {
+    chooser_context->GetDevice(guid, blocked_interface_classes,
+                               std::move(device_receiver),
+                               std::move(device_client));
+  }
 }
 
 void ElectronUsbDelegate::AddObserver(content::BrowserContext* browser_context,
                                       Observer* observer) {
+  if (!browser_context)
+    return;
+
   GetContextObserver(browser_context)->AddObserver(observer);
 }
 
 void ElectronUsbDelegate::RemoveObserver(
     content::BrowserContext* browser_context,
     Observer* observer) {
+  if (!browser_context)
+    return;
+
   GetContextObserver(browser_context)->RemoveObserver(observer);
 }
 
 ElectronUsbDelegate::ContextObservation*
 ElectronUsbDelegate::GetContextObserver(
     content::BrowserContext* browser_context) {
+  CHECK(browser_context);
   if (!base::Contains(observations_, browser_context)) {
     observations_.emplace(browser_context, std::make_unique<ContextObservation>(
                                                this, browser_context));

--- a/shell/browser/usb/electron_usb_delegate.h
+++ b/shell/browser/usb/electron_usb_delegate.h
@@ -56,10 +56,11 @@ class ElectronUsbDelegate : public content::UsbDelegate {
   const device::mojom::UsbDeviceInfo* GetDeviceInfo(
       content::BrowserContext* browser_context,
       const std::string& guid) override;
-  bool HasDevicePermission(content::BrowserContext* browser_context,
-                           content::RenderFrameHost* frame,
-                           const url::Origin& origin,
-                           const device::mojom::UsbDeviceInfo& device) override;
+  bool HasDevicePermission(
+      content::BrowserContext* browser_context,
+      content::RenderFrameHost* frame,
+      const url::Origin& origin,
+      const device::mojom::UsbDeviceInfo& device_info) override;
   void GetDevices(
       content::BrowserContext* browser_context,
       blink::mojom::WebUsbService::GetDevicesCallback callback) override;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42340.

Fixes an issue where some calls to WebUSB methods could crash. This could happen when the current partition was in-memory, as by default Chromium (and the spec) [do not support this](https://source.chromium.org/chromium/chromium/src/+/main:components/keyed_service/content/browser_context_keyed_service_factory.cc;l=64;drc=ac83a5a2d3c04763d86ce16d92f3904cc9566d3a;bpv=1;bpt=1). This pulls in CL:4506353 to ensure cases with no chooser context are handled appropriately.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where some calls to WebUSB methods could crash.