### PR TITLE
fix: If the loop is not initialized then there is nothing to clean up for NodeBindings

### DIFF
--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -420,6 +420,10 @@ NodeBindings::NodeBindings(BrowserEnvironment browser_env)
       uv_loop_{InitEventLoop(browser_env, &worker_loop_)} {}
 
 NodeBindings::~NodeBindings() {
+  // If the loop is not initialized then there is nothing to clean up.
+  if (!initialized_)
+    return;
+  
   // Quit the embed thread.
   embed_closed_ = true;
   uv_sem_post(&embed_sem_);


### PR DESCRIPTION
If the node bindings is not initialized, destructor will lead app to crash.

