### PR TITLE
refactor: move WebFrameRenderer into an anonymous namespace

### DIFF
--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -327,8 +327,6 @@ class SpellCheckerHolder final : private content::RenderFrameObserver {
   std::unique_ptr<SpellCheckClient> spell_check_client_;
 };
 
-}  // namespace
-
 class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
                          private content::RenderFrameObserver {
  public:
@@ -902,6 +900,7 @@ class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
     return render_frame->GetRoutingID();
   }
 };
+}  // namespace
 
 gin::WrapperInfo WebFrameRenderer::kWrapperInfo = {gin::kEmbedderNativeGin};
 


### PR DESCRIPTION
#### Description of Change

Cleanup PR that moves the `WebFrameRenderer` into an anonymous namespace. It doesn't need to be public since it's only used by `shell/renderer/api/electron_api_web_frame.cc`, and making it private shrinks the object file.

Before:

```sh
$ du --bytes out/Testing/obj/electron/electron_lib/electron_api_web_frame.o
958224	out/Testing/obj/electron/electron_lib/electron_api_web_frame.o
$ nm out/Testing/obj/electron/electron_lib/electron_api_web_frame.o | c++filt | rg WebFrameRenderer | wc --lines
294
```

After:

```sh
$ du --bytes out/Testing/obj/electron/electron_lib/electron_api_web_frame.o
870784	out/Testing/obj/electron/electron_lib/electron_api_web_frame.o
$ nm out/Testing/obj/electron/electron_lib/electron_api_web_frame.o | c++filt | rg WebFrameRenderer | wc --lines
179
````

All reviews welcomed; no stakeholders in particular.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.