### PR TITLE
fix: `loginService` -> `loginItemService`

### DIFF
--- a/shell/common/platform_util_mac.mm
+++ b/shell/common/platform_util_mac.mm
@@ -128,7 +128,7 @@ SMAppService* GetServiceForType(const std::string& type,
     return [SMAppService agentServiceWithPlistName:service_name];
   } else if (type == "daemonService") {
     return [SMAppService daemonServiceWithPlistName:service_name];
-  } else if (type == "loginService") {
+  } else if (type == "loginItemService") {
     return [SMAppService loginItemServiceWithIdentifier:service_name];
   } else {
     LOG(ERROR) << "Unrecognized login item type";


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42376.

Corrects check from `loginService` -> `loginItemService`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `app.setLoginItemSettings` incorrectly checked against `loginItemService`
