### PR TITLE
fix: replace GetLocaleInfoEx with GetUserDefaultGeoName

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -945,15 +945,10 @@ std::string App::GetSystemLocale(gin_helper::ErrorThrower thrower) const {
 std::string App::GetLocaleCountryCode() {
   std::string region;
 #if BUILDFLAG(IS_WIN)
-  WCHAR locale_name[LOCALE_NAME_MAX_LENGTH] = {0};
-
-  if (GetLocaleInfoEx(LOCALE_NAME_USER_DEFAULT, LOCALE_SISO3166CTRYNAME,
-                      (LPWSTR)&locale_name,
-                      sizeof(locale_name) / sizeof(WCHAR)) ||
-      GetLocaleInfoEx(LOCALE_NAME_SYSTEM_DEFAULT, LOCALE_SISO3166CTRYNAME,
-                      (LPWSTR)&locale_name,
-                      sizeof(locale_name) / sizeof(WCHAR))) {
-    base::WideToUTF8(locale_name, wcslen(locale_name), &region);
+  WCHAR geo_name[LOCALE_NAME_MAX_LENGTH] = {0};
+  int result = GetUserDefaultGeoName(geo_name, sizeof(geo_name) / sizeof(WCHAR));
+  if (result > 0) {
+    base::WideToUTF8(geo_name, wcslen(geo_name), &region);
   }
 #elif BUILDFLAG(IS_MAC)
   CFLocaleRef locale = CFLocaleCopyCurrent();


### PR DESCRIPTION
#### Description of Change

`getLocaleCountryCode()` in Windows behaves differently from macOS, so instead of getting the set region/country from OS settings it is getting the display language country, e.g. I use Windows and my display language is set as `English (United Kingdom)` but my `Country or region` setting is `Brazil`, so the function is returning `GB` instead of `BR`, a similar setting in macOS would return `BR` correctly.

To make it work as expected I needed to replace [GetLocaleInfoEx](https://learn.microsoft.com/en-us/windows/win32/api/winnls/nf-winnls-getlocaleinfoex) with [GetUserDefaultGeoName](https://learn.microsoft.com/en-us/windows/win32/api/winnls/nf-winnls-getuserdefaultgeoname)

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Replaced GetLocaleInfoEx with GetUserDefaultGeoName in GetLocaleCountryCode for Windows