### PR TITLE
build: increase fetch-deps

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -220,7 +220,7 @@ jobs:
         cache: yarn
         cache-dependency-path: src/electron/yarn.lock
     - name: Enable SSH Debugging
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@b3db6e16e597d92037c8647e54acc5d2b1b48dee
       with:
         detached: true
         limit-access-to-actor: true

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -210,6 +210,7 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+        fetch-tags: true
     - name: Install Azure CLI
       run: |
         brew update && brew install azure-cli
@@ -293,6 +294,8 @@ jobs:
       uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       with:
         path: src/electron
+        fetch-depth: 0
+        fetch-tags: true
     - name: Run Electron Only Hooks
       run: |
         echo "Running Electron Only Hooks"

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -221,7 +221,6 @@ jobs:
         cache: yarn
         cache-dependency-path: src/electron/yarn.lock
     - name: Enable SSH Debugging
-      if: runner.debug == 1
       uses: mxschmitt/action-tmate@v3
       with:
         detached: true

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -219,11 +219,6 @@ jobs:
         node-version: 20.11.x
         cache: yarn
         cache-dependency-path: src/electron/yarn.lock
-    - name: Enable SSH Debugging
-      uses: mxschmitt/action-tmate@b3db6e16e597d92037c8647e54acc5d2b1b48dee
-      with:
-        detached: true
-        limit-access-to-actor: true
     - name: Install Dependencies
       run: |
         cd src/electron

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -220,6 +220,12 @@ jobs:
         node-version: 20.11.x
         cache: yarn
         cache-dependency-path: src/electron/yarn.lock
+    - name: Enable SSH Debugging
+      if: runner.debug == 1
+      uses: mxschmitt/action-tmate@v3
+      with:
+        detached: true
+        limit-access-to-actor: true
     - name: Install Dependencies
       run: |
         cd src/electron

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -210,7 +210,6 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
-        fetch-tags: true
     - name: Install Azure CLI
       run: |
         brew update && brew install azure-cli
@@ -300,7 +299,6 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
-        fetch-tags: true
     - name: Run Electron Only Hooks
       run: |
         echo "Running Electron Only Hooks"


### PR DESCRIPTION
#### Description of Change

This PR increases the fetch-depth in checkout, and fetches tags as well as commit history.
~It also re-enables SSH debugging with tmate, so it's easier for us to SSH into the Actions runner while debugging.~ Removed this functionality in this PR

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
