### PR TITLE
refactor: move impl classes into unnamed namespaces

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1879,6 +1879,8 @@ void WebContents::OnFirstNonEmptyLayout(
   }
 }
 
+namespace {
+
 // This object wraps the InvokeCallback so that if it gets GC'd by V8, we can
 // still call the callback and send an error. Not doing so causes a Mojo DCHECK,
 // since Mojo requires callbacks to be called before they are destroyed.
@@ -1934,6 +1936,8 @@ class ReplyChannel : public gin::Wrappable<ReplyChannel> {
 };
 
 gin::WrapperInfo ReplyChannel::kWrapperInfo = {gin::kEmbedderNativeGin};
+
+}  // namespace
 
 gin::Handle<gin_helper::internal::Event> WebContents::MakeEventWithSender(
     v8::Isolate* isolate,

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -25,6 +25,8 @@
 
 namespace electron {
 
+namespace {
+
 const char kXdgSettings[] = "xdg-settings";
 const char kXdgSettingsDefaultSchemeHandler[] = "default-url-scheme-handler";
 
@@ -83,6 +85,8 @@ bool SetDefaultWebClient(const std::string& protocol) {
   bool ran_ok = LaunchXdgUtility(argv, &exit_code);
   return ran_ok && exit_code == EXIT_SUCCESS;
 }
+
+}  // namespace
 
 void Browser::AddRecentDocument(const base::FilePath& path) {}
 

--- a/shell/browser/electron_browser_main_parts_linux.cc
+++ b/shell/browser/electron_browser_main_parts_linux.cc
@@ -18,6 +18,10 @@
 #include "shell/common/thread_restrictions.h"
 #endif
 
+namespace electron {
+
+namespace {
+
 constexpr std::string_view kElectronOzonePlatformHint{
     "ELECTRON_OZONE_PLATFORM_HINT"};
 
@@ -54,10 +58,6 @@ bool HasWaylandDisplay(base::Environment* env) {
 #if BUILDFLAG(IS_OZONE_X11)
 constexpr char kPlatformX11[] = "x11";
 #endif
-
-namespace electron {
-
-namespace {
 
 // Evaluates the environment and returns the effective platform name for the
 // given |ozone_platform_hint|.

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -250,6 +250,8 @@ bool Converter<net::HttpRequestHeaders>::FromV8(v8::Isolate* isolate,
   return true;
 }
 
+namespace {
+
 class ChunkedDataPipeReadableStream
     : public gin::Wrappable<ChunkedDataPipeReadableStream> {
  public:
@@ -489,8 +491,11 @@ class ChunkedDataPipeReadableStream
   v8::Global<v8::ArrayBufferView> buf_;
   gin_helper::Promise<int> promise_;
 };
+
 gin::WrapperInfo ChunkedDataPipeReadableStream::kWrapperInfo = {
     gin::kEmbedderNativeGin};
+
+}  // namespace
 
 // static
 v8::Local<v8::Value> Converter<network::ResourceRequestBody>::ToV8(


### PR DESCRIPTION
#### Description of Change

Similar to #42369.

This PR takes impl classes that were accidentally made public and puts them in an anonymous namespace. This improves the compiler's ability to optimize the code and make smaller object files.

File | Size (bytes) Before | Size (bytes) After | Diff |
----|---:|---:|---:|
`net_converter.o` | 559,904 | 545,192 | -14,712
`electron_api_web_contents.o` | 3,780,168 | 3,772,112 | -8,056
`browser_linux.o` | 138,496 | 137,416 | -1,080
`electron_browser_main_parts_linux.o` | 46,312 | 45,312  | -1,000

Saving about 25K bytes. Nothing earth-shattering, but free is free -- we get this just by moving a few braces to the right place  :smile_cat: 

All reviews welcomed. CC @samuelmaddock and @codebytere, who both reviewed 42369.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.