### PR TITLE
fix: restore `wasOpenedAtLogin` functionality

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1265,7 +1265,7 @@ Returns `Object`:
 
 * `openAtLogin` boolean - `true` if the app is set to open at login.
 * `openAsHidden` boolean _macOS_ _Deprecated_ - `true` if the app is set to open as hidden at login. This does not work on macOS 13 and up.
-* `wasOpenedAtLogin` boolean _macOS_ _Deprecated_ - `true` if the app was opened at login automatically. This setting is not available on [MAS builds][mas-builds] or on macOS 13 and up.
+* `wasOpenedAtLogin` boolean _macOS_ - `true` if the app was opened at login automatically.
 * `wasOpenedAsHidden` boolean _macOS_ _Deprecated_ - `true` if the app was opened as a hidden login item. This indicates that the app should not open any windows at startup. This setting is not available on [MAS builds][mas-builds] or on macOS 13 and up.
 * `restoreState` boolean _macOS_ _Deprecated_ - `true` if the app was opened as a login item that should restore the state from the previous session. This indicates that the app should restore the windows that were open the last time the app was closed. This setting is not available on [MAS builds][mas-builds] or on macOS 13 and up.
 * `status` string _macOS_ - can be one of `not-registered`, `enabled`, `requires-approval`, or `not-found`.

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -236,6 +236,10 @@ class Browser : private WindowListObserver {
   // Set docks' icon.
   void DockSetIcon(v8::Isolate* isolate, v8::Local<v8::Value> icon);
 
+  void SetLaunchedAtLogin(bool launched_at_login) {
+    was_launched_at_login_ = launched_at_login;
+  }
+
 #endif  // BUILDFLAG(IS_MAC)
 
   void ShowAboutPanel();
@@ -370,6 +374,7 @@ class Browser : private WindowListObserver {
 #if BUILDFLAG(IS_MAC)
   std::unique_ptr<ui::ScopedPasswordInputEnabler> password_input_enabler_;
   base::Time last_dock_show_;
+  bool was_launched_at_login_;
 #endif
 
   base::Value::Dict about_panel_options_;

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -392,6 +392,7 @@ v8::Local<v8::Value> Browser::GetLoginItemSettings(
       platform_util::GetLoginItemEnabled(options.type, options.service_name);
   settings.open_at_login =
       status == "enabled" || status == "enabled-deprecated";
+  settings.opened_at_login = was_launched_at_login_;
   if (@available(macOS 13, *))
     settings.status = status;
 #else
@@ -405,6 +406,7 @@ v8::Local<v8::Value> Browser::GetLoginItemSettings(
       settings = settings_deprecated;
     } else {
       settings.open_at_login = status == "enabled";
+      settings.opened_at_login = was_launched_at_login_;
       settings.status = status;
     }
   } else {

--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -84,6 +84,14 @@ static NSDictionary* UNNotificationResponseToNSDictionary(
     }
   }
 
+  NSAppleEventDescriptor* event =
+      NSAppleEventManager.sharedAppleEventManager.currentAppleEvent;
+  BOOL launched_as_login_item =
+      (event.eventID == kAEOpenApplication &&
+       [event paramDescriptorForKeyword:keyAEPropData].enumCodeValue ==
+           keyAELaunchedAsLogInItem);
+  electron::Browser::Get()->SetLaunchedAtLogin(launched_as_login_item);
+
   electron::Browser::Get()->DidFinishLaunching(
       electron::NSDictionaryToValue(notification_info));
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42302.

Re-adds `wasOpenedAtLogin` functionality to check whether or not an app was launched as a login item on macOS. I'd previously thought this wasn't possible when I switched our API base over to SMAppService, but @nikwen brought my attention in the above linked issue to a supported way to determine the information.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Re-adds functionality to check whether or not an app was launched as a login service on macOS.
