### PR TITLE
chore: update @electron/lint-roller to 2.2.0

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -19,7 +19,8 @@
         "Tabs",
         "TabItem"
       ]
-    }
+    },
+    "no-newline-in-links": true
   },
   "customRules": [
     "@electron/lint-roller/markdownlint-rules/"

--- a/docs/api/structures/trace-config.md
+++ b/docs/api/structures/trace-config.md
@@ -7,8 +7,8 @@
   recording buffer in events.
 * `enable_argument_filter` boolean (optional) - if true, filter event data
   according to a specific list of events that have been manually vetted to not
-  include any PII. See [the implementation in
-  Chromium][trace_event_args_allowlist.cc] for specifics.
+  include any PII. See [the implementation in Chromium][trace_event_args_allowlist.cc]
+  for specifics.
 * `included_categories` string[] (optional) - a list of tracing categories to
   include. Can include glob-like patterns using `*` at the end of the category
   name. See [tracing categories][] for the list of categories.
@@ -21,8 +21,8 @@
   with the trace.
 * `memory_dump_config` Record\<string, any\> (optional) - if the
   `disabled-by-default-memory-infra` category is enabled, this contains
-  optional additional configuration for data collection. See the [Chromium
-  memory-infra docs][memory-infra docs] for more information.
+  optional additional configuration for data collection. See the
+  [Chromium memory-infra docs][memory-infra docs] for more information.
 
 An example TraceConfig that roughly matches what Chrome DevTools records:
 

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -121,8 +121,8 @@ To automate the detection of misconfigurations and insecure patterns, it is
 possible to use
 [Electronegativity](https://github.com/doyensec/electronegativity). For
 additional details on potential weaknesses and implementation bugs when
-developing applications using Electron, please refer to this [guide for
-developers and auditors](https://doyensec.com/resources/us-17-Carettoni-Electronegativity-A-Study-Of-Electron-Security-wp.pdf).
+developing applications using Electron, please refer to this
+[guide for developers and auditors](https://doyensec.com/resources/us-17-Carettoni-Electronegativity-A-Study-Of-Electron-Security-wp.pdf).
 
 ### 1. Only load secure content
 
@@ -644,8 +644,8 @@ windows at runtime.
 
 #### How?
 
-[`webContents`][web-contents] will delegate to its [window open
-handler][window-open-handler] before creating new windows. The handler will
+[`webContents`][web-contents] will delegate to its
+[window open handler][window-open-handler] before creating new windows. The handler will
 receive, amongst other parameters, the `url` the window was requested to open
 and the options used to create it. We recommend that you register a handler to
 monitor the creation of windows, and deny any unexpected window creation.

--- a/docs/tutorial/using-native-node-modules.md
+++ b/docs/tutorial/using-native-node-modules.md
@@ -40,8 +40,8 @@ npm install --save-dev @electron/rebuild
 .\node_modules\.bin\electron-rebuild.cmd
 ```
 
-For more information on usage and integration with other tools such as [Electron
-Packager][electron-packager], consult the project's README.
+For more information on usage and integration with other tools such as
+[Electron Packager][electron-packager], consult the project's README.
 
 ### Using `npm`
 
@@ -108,8 +108,8 @@ the following things:
 On Windows, by default, `node-gyp` links native modules against `node.dll`.
 However, in Electron 4.x and higher, the symbols needed by native modules are
 exported by `electron.exe`, and there is no `node.dll`. In order to load native
-modules on Windows, `node-gyp` installs a [delay-load
-hook](https://learn.microsoft.com/en-us/cpp/build/reference/error-handling-and-notification?view=msvc-170#notification-hooks) that triggers
+modules on Windows, `node-gyp` installs a
+[delay-load hook](https://learn.microsoft.com/en-us/cpp/build/reference/error-handling-and-notification?view=msvc-170#notification-hooks) that triggers
 when the native module is loaded, and redirects the `node.dll` reference to use
 the loading executable instead of looking for `node.dll` in the library search
 path (which would turn up nothing). As such, on Electron 4.x and higher,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@electron/docs-parser": "^1.2.0",
     "@electron/fiddle-core": "^1.0.4",
     "@electron/github-app-auth": "^2.0.0",
-    "@electron/lint-roller": "^2.1.0",
+    "@electron/lint-roller": "^2.2.0",
     "@electron/typescript-definitions": "^8.15.2",
     "@octokit/rest": "^19.0.7",
     "@primer/octicons": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,10 +199,10 @@
     "@octokit/auth-app" "^4.0.13"
     "@octokit/rest" "^19.0.11"
 
-"@electron/lint-roller@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@electron/lint-roller/-/lint-roller-2.1.0.tgz#984ec017c8d512e77e34749e7f6dc965aec8de06"
-  integrity sha512-Oxt7CHq7FNujOi5g0nYq3hwVvspnDk/DCp7C+52pHi3Ez7P85K8dY3QlGtm9Dpswm3t7SJmk6m1pfFzXWre1dg==
+"@electron/lint-roller@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@electron/lint-roller/-/lint-roller-2.2.0.tgz#3390ea37868b1ac35863cd393ddf776d049a2e3c"
+  integrity sha512-gYOwL7p3vXJjzndzW0ewnYuBz+WcNOGCbqNBJLmoVwimHGdNJ7cdh9/AwAggcjHEPO/zpRMfpfhUM7shNPagCQ==
   dependencies:
     "@dsanders11/vscode-markdown-languageservice" "^0.3.0"
     balanced-match "^2.0.0"
@@ -6609,7 +6609,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6629,6 +6629,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Follow-up to #42235 which enforces no newlines in link text. The rule is more strict (which is why there's a few additional changes for a clean lint).

Not sure what's up with the seemingly unrelated `yarn.lock` change, I'm using Yarn 1.22.22.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
