### PR TITLE
docs(web-embeds): replace BrowserView ref with WebContentsView

### DIFF
--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -23,8 +23,8 @@ and only allow the capabilities you want to support.
 [we do not recommend you to use WebViews](../api/webview-tag.md#warning),
 as this tag undergoes dramatic architectural changes that may affect stability
 of your application. Consider switching to alternatives, like `iframe` and
-Electron's `BrowserView`, or an architecture that avoids embedded content
-by design.
+Electron's [`WebContentsView`](../api/web-contents-view.md), or an architecture
+that avoids embedded content by design.
 
 [WebViews](../api/webview-tag.md) are based on Chromium's WebViews and are not
 explicitly supported by Electron. We do not guarantee that the WebView API will


### PR DESCRIPTION
#### Description of Change

Replaces a reference to a deprecated API. Also adds an additional link to the new API.

CC: @electron/docs 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm lint:docs` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes

Notes: none
