### PR TITLE
fix: missing `fetch`-dependent interfaces in Node.js

### DIFF
--- a/lib/node/init.ts
+++ b/lib/node/init.ts
@@ -3,8 +3,11 @@ import { wrapFsWithAsar } from './asar-fs-wrapper';
 wrapFsWithAsar(require('fs'));
 
 // See ElectronRendererClient::DidCreateScriptContext.
-if ((globalThis as any).blinkFetch) {
-  globalThis.fetch = (globalThis as any).blinkFetch;
+if ((globalThis as any).blinkfetch) {
+  const keys = ['fetch', 'Response', 'FormData', 'Request', 'Headers'];
+  for (const key of keys) {
+    (globalThis as any)[key] = (globalThis as any)[`blink${key}`];
+  }
 }
 
 // Hook child_process.fork.


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42381.
Refs https://github.com/electron/electron/pull/41710

Fixes an issue where `fetch` dependent interfaces in Node.js were not defined when `nodeIntegration` was enabled in some circumstances. I handled this partially in https://github.com/electron/electron/pull/41710/commits/9e4ae9c040763ff84e356c2bffd3076d9d5ad7b2, but the problem extended slightly further and the same approach needed to be taken for `FormData`, `Request`, etc.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `fetch` dependent interfaces in Node.js were not defined when `nodeIntegration` was enabled in some circumstances.