### PR TITLE
build: fix upload script defaults

### DIFF
--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -158,7 +158,7 @@ def azput(prefix, key_prefix, files):
   print(output)
 
 def get_out_dir():
-  out_dir = 'Debug'
+  out_dir = 'Default'
   override = os.environ.get('ELECTRON_OUT_DIR')
   if override is not None:
     out_dir = override

--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -48,7 +48,7 @@ def main():
   if args.verbose:
     enable_verbose_mode()
   if args.upload_to_storage:
-    utcnow = datetime.datetime.utcnow()
+    utcnow = datetime.datetime.now(datetime.UTC)
     args.upload_timestamp = utcnow.strftime('%Y%m%d')
 
   build_version = get_electron_build_version()


### PR DESCRIPTION
#### Description of Change

Small tweaks to the upload script to fix several defaults founds during the GHA migration

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
