### PR TITLE
build: add an option to skip the install-sysroot hooks

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -48,6 +48,9 @@ vars = {
   # It's only needed to parse the native tests configurations.
   'checkout_pyyaml': False,
 
+  # Can be used to disable the sysroot hooks.
+  'install_sysroot': True,
+
   'use_rts': False,
 
   'mac_xcode_version': 'default',
@@ -164,7 +167,7 @@ hooks = [
   {
     'name': 'sysroot_arm',
     'pattern': '.',
-    'condition': 'checkout_linux and checkout_arm',
+    'condition': 'install_sysroot and checkout_linux and checkout_arm',
     'action': ['python3', 'src/build/linux/sysroot_scripts/install-sysroot.py',
                '--sysroots-json-path=' + Var('sysroots_json_path'),
                '--arch=arm'],
@@ -172,7 +175,7 @@ hooks = [
   {
     'name': 'sysroot_arm64',
     'pattern': '.',
-    'condition': 'checkout_linux and checkout_arm64',
+    'condition': 'install_sysroot and checkout_linux and checkout_arm64',
     'action': ['python3', 'src/build/linux/sysroot_scripts/install-sysroot.py',
                '--sysroots-json-path=' + Var('sysroots_json_path'),
                '--arch=arm64'],
@@ -180,7 +183,7 @@ hooks = [
   {
     'name': 'sysroot_x86',
     'pattern': '.',
-    'condition': 'checkout_linux and (checkout_x86 or checkout_x64)',
+    'condition': 'install_sysroot and checkout_linux and (checkout_x86 or checkout_x64)',
     'action': ['python3', 'src/build/linux/sysroot_scripts/install-sysroot.py',
                '--sysroots-json-path=' + Var('sysroots_json_path'),
                '--arch=x86'],
@@ -188,7 +191,7 @@ hooks = [
   {
     'name': 'sysroot_mips',
     'pattern': '.',
-    'condition': 'checkout_linux and checkout_mips',
+    'condition': 'install_sysroot and checkout_linux and checkout_mips',
     'action': ['python3', 'src/build/linux/sysroot_scripts/install-sysroot.py',
                '--sysroots-json-path=' + Var('sysroots_json_path'),
                '--arch=mips'],
@@ -196,7 +199,7 @@ hooks = [
   {
     'name': 'sysroot_mips64',
     'pattern': '.',
-    'condition': 'checkout_linux and checkout_mips64',
+    'condition': 'install_sysroot and checkout_linux and checkout_mips64',
     'action': ['python3', 'src/build/linux/sysroot_scripts/install-sysroot.py',
                '--sysroots-json-path=' + Var('sysroots_json_path'),
                '--arch=mips64el'],
@@ -204,7 +207,7 @@ hooks = [
   {
     'name': 'sysroot_x64',
     'pattern': '.',
-    'condition': 'checkout_linux and checkout_x64',
+    'condition': 'install_sysroot and checkout_linux and checkout_x64',
     'action': ['python3', 'src/build/linux/sysroot_scripts/install-sysroot.py',
                '--sysroots-json-path=' + Var('sysroots_json_path'),
                '--arch=x64'],


### PR DESCRIPTION
#### Description of Change

Add a boolean variable to allow sysroot installation hooks to be skipped.  By default they are not skipped, so this doesn't affect any workflows in `electron/electron`. These sysroot hooks are new in Electron 31, having landed in https://github.com/electron/electron/pull/41868/commits/2d43e1e787a17ab7a949d8a04a79b4675ba6b32f.

To be fair, this is to solve a pretty specific use case in Microsoft's downstream build: we have a prebuilt Electron executable and want to test it with the `spec/` directory of a specific commit we obtain with `gclient sync`. We also have sequence-specific steps in our own DEPS hooks. There are goofier workarounds we could do all-downstream if this PR is rejected, but this is the simplest fix and is relatively unobtrusive to `e/e`.

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.