### PR TITLE
fix: don't observe WebUSB for in-memory partitions

### DIFF
--- a/shell/browser/hid/electron_hid_delegate.cc
+++ b/shell/browser/hid/electron_hid_delegate.cc
@@ -46,8 +46,8 @@ class ElectronHidDelegate::ContextObservation
   ContextObservation(ElectronHidDelegate* parent,
                      content::BrowserContext* browser_context)
       : parent_(parent), browser_context_(browser_context) {
-    auto* chooser_context = GetChooserContext(browser_context_);
-    device_observation_.Observe(chooser_context);
+    if (auto* chooser_context = GetChooserContext(browser_context_))
+      device_observation_.Observe(chooser_context);
   }
 
   ContextObservation(ContextObservation&) = delete;

--- a/shell/browser/usb/electron_usb_delegate.cc
+++ b/shell/browser/usb/electron_usb_delegate.cc
@@ -94,7 +94,8 @@ class ElectronUsbDelegate::ContextObservation
                      content::BrowserContext* browser_context)
       : parent_(parent), browser_context_(browser_context) {
     auto* chooser_context = GetChooserContext(browser_context_);
-    device_observation_.Observe(chooser_context);
+    if (chooser_context)
+      device_observation_.Observe(chooser_context);
   }
   ContextObservation(ContextObservation&) = delete;
   ContextObservation& operator=(ContextObservation&) = delete;


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/42340.
Follow-up to https://github.com/electron/electron/pull/42347.

We also need to ensure we're not calling `Observe` on the `base::ScopedObservation` when the BrowserContext is in-memory.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `navigator.usb.getDevices()` could crash in some circumstances