### PR TITLE
build: use the linux aks for macos checkout/cache

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    uses: electron/electron/.github/workflows/macos-pipeline.yml@main
+    uses: electron/electron/.github/workflows/macos-pipeline.yml@macos-use-aks
     with:
       is-release: false
       gn-config: //electron/build/args/testing.gn

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    uses: electron/electron/.github/workflows/macos-pipeline.yml@macos-use-aks
+    uses: electron/electron/.github/workflows/macos-pipeline.yml@main
     with:
       is-release: false
       gn-config: //electron/build/args/testing.gn

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -52,7 +52,7 @@ jobs:
   checkout:
     runs-on: aks-linux-large-16
     container:
-      image: ghcr.io/electron/build:9a43c14f5c19be0359843299f79e736521373adc
+      image: ghcr.io/electron/build:latest
       options: --user root
     steps:
     - name: Checkout Electron

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -50,7 +50,10 @@ env:
 
 jobs:
   checkout:
-    runs-on: LargeLinuxRunner
+    runs-on: aks-linux-large-16
+    container:
+      image: ghcr.io/electron/build:9a43c14f5c19be0359843299f79e736521373adc
+      options: --user root
     steps:
     - name: Checkout Electron
       uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
@@ -60,12 +63,8 @@ jobs:
     - name: Set GIT_CACHE_PATH to make gclient to use the cache
       run: |
         echo "GIT_CACHE_PATH=$(pwd)/git-cache" >> $GITHUB_ENV
-    - name: Setup Node.js/npm
-      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
-      with:
-        node-version: 20.11.x
-        cache: yarn
-        cache-dependency-path: src/electron/yarn.lock
+    - name: Install Azure CLI
+      run: sudo bash ./src/electron/script/azure_cli_deb_install.sh
     - name: Install Dependencies
       run: |
         cd src/electron

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -272,7 +272,7 @@ jobs:
         node src/electron/script/generate-deps-hash.js && cat src/electron/.depshash-target
         DEPSHASH=v1-src-cache-$(shasum src/electron/.depshash | cut -f1 -d' ')
         echo "DEPSHASH=$DEPSHASH" >> $GITHUB_ENV
-        echo "CACHE_PATH=/mnt/cross-instance-cache/$DEPSHASH.tar" >> $GITHUB_ENV
+        echo "CACHE_PATH=$DEPSHASH.tar" >> $GITHUB_ENV
     - name: Download Src Cache from AKS
       # The cache will always exist here as a result of the checkout job
       # Either it was uploaded to Azure in the checkout job for this commit
@@ -285,9 +285,8 @@ jobs:
         command: |
           echo "Pulling mounted data from: ${{ env.CACHE_PATH }}"
           az storage file download \
-            --account-name "$AZURE_AKS_CACHE_STORAGE_ACCOUNT" \
             --connection-string "$AZURE_AKS_CACHE_STORAGE_CONNECTION_STRING" \
-            --share-name "$AZURE_AKS_CACHE_SHARE_NAME" \
+            --share-name $AZURE_AKS_CACHE_SHARE_NAME \
             --path ${{ env.CACHE_PATH }}
     - name: Unzip and Ensure Src Cache
       run: |

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -34,14 +34,16 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # Old Azure Storage Variables
   AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
   AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
   AZURE_STORAGE_CONTAINER_NAME: ${{ secrets.AZURE_STORAGE_CONTAINER_NAME }}
+  ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+  # New Azure Storage Variables
   AZURE_AKS_CACHE_STORAGE_KEY: ${{ secrets.AZURE_AKS_CACHE_STORAGE_KEY }}
   AZURE_AKS_CACHE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_AKS_CACHE_STORAGE_CONNECTION_STRING }}
   AZURE_AKS_CACHE_STORAGE_ACCOUNT: ${{ secrets.AZURE_AKS_CACHE_STORAGE_ACCOUNT }}
   AZURE_AKS_CACHE_SHARE_NAME: ${{ secrets.AZURE_AKS_CACHE_SHARE_NAME }}
-  ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
   ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
   ELECTRON_GITHUB_TOKEN: ${{ secrets.ELECTRON_GITHUB_TOKEN }}
   GN_CONFIG: ${{ inputs.gn-config }}
@@ -192,9 +194,9 @@ jobs:
         mv ./src /var/portal
     - name: Persist Src Cache
       run: |
-        # cache_key=v2-git-cache-$DEPSHASH
+        # cache_key=v2-src-cache-$DEPSHASH
         cache_key=$DEPSHASH
-        cache_path=/var/portal
+        backup_cache_path=/var/portal
         final_cache_path=/mnt/cross-instance-cache/${cache_key}.tar
         echo "Using cache key: $cache_key"
         echo "Checking path: $final_cache_path"
@@ -203,10 +205,10 @@ jobs:
           tmp_container=/mnt/cross-instance-cache/tmp/${{ github.sha }}
           tmp_cache_path=$tmp_container/${cache_key}.tar
           mkdir -p $tmp_container
-          if [ -f "$cache_path" ]; then
-            tar -cf $tmp_cache_path -C $(dirname $cache_path) ./$(basename $cache_path)
+          if [ -f "$backup_cache_path" ]; then
+            tar -cf $tmp_cache_path -C $(dirname $backup_cache_path) ./$(basename $backup_cache_path)
           else
-            tar -cf $tmp_cache_path -C $cache_path/ ./
+            tar -cf $tmp_cache_path -C $backup_cache_path/ ./
           fi
           mv -vn $tmp_cache_path $final_cache_path
           rm -rf $tmp_container
@@ -282,10 +284,16 @@ jobs:
         max_attempts: 3
         retry_on: error
         command: |
+          # cache-key=v2-src-cache-$DEPSHASH
+          cache-key=$DEPSHASH
+          cache-path=/mnt/cross-instance-cache/${cache-key}.tar
+          echo "Pulling mounted data from: $cache-path"
+
           az storage file download \
             --account-name $AZURE_AKS_CACHE_STORAGE_ACCOUNT \
+            --account-key $AZURE_AKS_CACHE_STORAGE_KEY \
             --share-name $AZURE_AKS_CACHE_SHARE_NAME \
-            --path ".DS_Store"
+            --path $cache-path
     - name: Unzip and Ensure Src Cache
       run: |
         echo "Downloaded cache is $(du -sh $DEPSHASH.tar | cut -f1)"

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -113,7 +113,7 @@ jobs:
     #       echo "Cache Does Not Exist for $DEPSHASH"
     #     fi
     - name: Gclient Sync
-      if: steps.check-cache.outputs.cache_exists == 'false'
+      # if: steps.check-cache.outputs.cache_exists == 'false'
       run: |
         gclient config \
           --name "src/electron" \
@@ -160,12 +160,12 @@ jobs:
     # https://dawn-review.googlesource.com/c/dawn/+/83901
     # TODO: maybe better to always leave out */.git/HEAD file for all targets ?
     - name: Delete .git directories under src to free space
-      if: steps.check-cache.outputs.cache_exists == 'false'
+      # if: steps.check-cache.outputs.cache_exists == 'false'
       run: |
         cd src
         ( find . -type d -name ".git" -not -path "./third_party/angle/*" -not -path "./third_party/dawn/*" -not -path "./electron/*" ) | xargs rm -rf
     - name: Minimize Cache Size for Upload
-      if: steps.check-cache.outputs.cache_exists == 'false'
+      # if: steps.check-cache.outputs.cache_exists == 'false'
       run: |
         rm -rf src/android_webview
         rm -rf src/ios/chrome

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -62,6 +62,7 @@ jobs:
       options: --user root
       volumes:
         - /mnt/cross-instance-cache:/mnt/cross-instance-cache
+        - /var/run/sas:/var/run/sas
     steps:
     - name: Checkout Electron
       uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
@@ -102,22 +103,17 @@ jobs:
     - name: Check If Cache Exists
       id: check-cache
       run: |
-        exists_json=$(az storage file exists \
-          --account-name $AZURE_AKS_CACHE_STORAGE_ACCOUNT \
-          --account-key $AZURE_AKS_CACHE_STORAGE_KEY \
-          --share-name $AZURE_AKS_CACHE_SHARE_NAME \
-          --path $DEPSHASH.tar)
-
-        cache_exists=$(echo $exists_json | jq -r '.exists')
-        echo "cache_exists=$cache_exists" >> $GITHUB_OUTPUT
-
-        if (test "$cache_exists" = "true"); then
-          echo "Cache Exists for $DEPSHASH"
-        else
+        cache_key=$DEPSHASH
+        cache_path=/mnt/cross-instance-cache/${cache_key}.tar
+        echo "Using cache key: $cache_key"
+        echo "Checking for cache in: $cache_path"
+        if [ ! -f "$cache_path" ]; then
           echo "Cache Does Not Exist for $DEPSHASH"
+        else
+          echo "Cache Already Exists for $DEPSHASH, Skipping.."
         fi
     - name: Gclient Sync
-      # if: steps.check-cache.outputs.cache_exists == 'false'
+      if: steps.check-cache.outputs.cache_exists == 'false'
       run: |
         gclient config \
           --name "src/electron" \
@@ -164,12 +160,12 @@ jobs:
     # https://dawn-review.googlesource.com/c/dawn/+/83901
     # TODO: maybe better to always leave out */.git/HEAD file for all targets ?
     - name: Delete .git directories under src to free space
-      # if: steps.check-cache.outputs.cache_exists == 'false'
+      if: steps.check-cache.outputs.cache_exists == 'false'
       run: |
         cd src
         ( find . -type d -name ".git" -not -path "./third_party/angle/*" -not -path "./third_party/dawn/*" -not -path "./electron/*" ) | xargs rm -rf
     - name: Minimize Cache Size for Upload
-      # if: steps.check-cache.outputs.cache_exists == 'false'
+      if: steps.check-cache.outputs.cache_exists == 'false'
       run: |
         rm -rf src/android_webview
         rm -rf src/ios/chrome
@@ -181,18 +177,20 @@ jobs:
         rm -rf src/third_party/swiftshader/tests/regres/testlists
         rm -rf src/electron
     - name: Compress Src Directory
-      # if: steps.check-cache.outputs.cache_exists == 'false'
+      if: steps.check-cache.outputs.cache_exists == 'false'
       run: |
         echo "Uncompressed src size: $(du -sh src | cut -f1 -d' ')"
         tar -cvf $DEPSHASH.tar src
         echo "Compressed src to $(du -sh $DEPSHASH.tar | cut -f1 -d' ')"
     - name: Move src folder to cross-OS portal
+      if: steps.check-cache.outputs.cache_exists == 'false'
       run: |
         cp ./$DEPSHASH.tar /mnt/cross-instance-cache/
         sudo mkdir -p /var/portal
         sudo chown -R $(id -u):$(id -g) /var/portal
         mv ./src /var/portal
     - name: Persist Src Cache
+      if: steps.check-cache.outputs.cache_exists == 'false'
       run: |
         cache_key=$DEPSHASH
         backup_cache_path=/var/portal
@@ -272,7 +270,9 @@ jobs:
     - name: Generate DEPS Hash
       run: |
         node src/electron/script/generate-deps-hash.js && cat src/electron/.depshash-target
-        echo "DEPSHASH=v1-src-cache-$(shasum src/electron/.depshash | cut -f1 -d' ')" >> $GITHUB_ENV
+        DEPSHASH=v1-src-cache-$(shasum src/electron/.depshash | cut -f1 -d' ')
+        echo "DEPSHASH=$DEPSHASH" >> $GITHUB_ENV
+        echo "CACHE_PATH=/mnt/cross-instance-cache/$DEPSHASH.tar" >> $GITHUB_ENV
     - name: Download Src Cache from AKS
       # The cache will always exist here as a result of the checkout job
       # Either it was uploaded to Azure in the checkout job for this commit
@@ -282,16 +282,13 @@ jobs:
         timeout_minutes: 20
         max_attempts: 3
         retry_on: error
-        run: |
-          cache-key=$DEPSHASH
-          cache-path=/mnt/cross-instance-cache/${cache-key}.tar
-          echo "Pulling mounted data from: $cache-path"
-
+        command: |
+          echo "Pulling mounted data from: ${{ env.CACHE_PATH }}"
           az storage file download \
             --account-name $AZURE_AKS_CACHE_STORAGE_ACCOUNT \
             --account-key $AZURE_AKS_CACHE_STORAGE_KEY \
             --share-name $AZURE_AKS_CACHE_SHARE_NAME \
-            --path $cache-path
+            --path ${{ env.CACHE_PATH }}
     - name: Unzip and Ensure Src Cache
       run: |
         echo "Downloaded cache is $(du -sh $DEPSHASH.tar | cut -f1)"

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -56,6 +56,8 @@ jobs:
     container:
       image: ghcr.io/electron/build:latest
       options: --user root
+      volumes:
+        - /mnt/cross-instance-cache:/mnt/cross-instance-cache
     steps:
     - name: Checkout Electron
       uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -178,16 +178,22 @@ jobs:
         echo "Uncompressed src size: $(du -sh src | cut -f1 -d' ')"
         tar -cvf $DEPSHASH.tar src
         echo "Compressed src to $(du -sh $DEPSHASH.tar | cut -f1 -d' ')"
-    - name: Upload Compressed Src Cache to Azure
-      if: steps.check-cache.outputs.cache_exists == 'false'
+    - name: Persist Src Cache
       run: |
-        az storage blob upload \
-          --account-name $AZURE_STORAGE_ACCOUNT \
-          --account-key $AZURE_STORAGE_KEY \
-          --container-name $AZURE_STORAGE_CONTAINER_NAME \
-          --file $DEPSHASH.tar \
-          --name $DEPSHASH \
-          --debug
+        cache_key=v2-git-cache-$DEPSHASH
+        final_cache_path=/mnt/cross-instance-cache/${cache_key}.tar
+        echo "Using cache key: $cache_key"
+        echo "Checking path: $final_cache_path"
+        if [ ! -f "$final_cache_path" ]; then
+          echo "Cache key not founding, storing tarball"
+          tmp_container=/mnt/cross-instance-cache/tmp/$CIRCLE_WORKFLOW_JOB_ID
+          tmp_cache_path=$tmp_container/${cache_key}.tar
+          mkdir -p $tmp_container
+          mv -vn $tmp_cache_path $final_cache_path
+          rm -rf $tmp_container
+        else
+          echo "Cache key already exists, skipping.."
+        fi
   build:
     strategy:
       fail-fast: false
@@ -247,7 +253,7 @@ jobs:
       run: |
         node src/electron/script/generate-deps-hash.js && cat src/electron/.depshash-target
         echo "DEPSHASH=v1-src-cache-$(shasum src/electron/.depshash | cut -f1 -d' ')" >> $GITHUB_ENV
-    - name: Download Src Cache
+    - name: Download Src Cache from AKS
       # The cache will always exist here as a result of the checkout job
       # Either it was uploaded to Azure in the checkout job for this commit
       # or it was uploaded in the checkout job for a previous commit.
@@ -257,12 +263,10 @@ jobs:
         max_attempts: 3
         retry_on: error
         command: |
-          az storage blob download \
-            --account-name $AZURE_STORAGE_ACCOUNT \
-            --account-key $AZURE_STORAGE_KEY \
-            --container-name $AZURE_STORAGE_CONTAINER_NAME \
-            --name $DEPSHASH \
-            --file $DEPSHASH.tar \
+          az storage file download \
+            --share-name $AZURE_AKS_CACHE_SHARE_NAME \
+            --account-name $AZURE_AKS_CACHE_STORAGE_ACCOUNT \"
+            --path ".DS_Store"
     - name: Unzip and Ensure Src Cache
       run: |
         echo "Downloaded cache is $(du -sh $DEPSHASH.tar | cut -f1)"

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -286,7 +286,7 @@ jobs:
           echo "Pulling mounted data from: ${{ env.CACHE_PATH }}"
           az storage file download \
             --account-name "$AZURE_AKS_CACHE_STORAGE_ACCOUNT" \
-            --account-key "$AZURE_AKS_CACHE_STORAGE_KEY" \
+            --connection-string "$AZURE_AKS_CACHE_STORAGE_CONNECTION_STRING" \
             --share-name "$AZURE_AKS_CACHE_SHARE_NAME" \
             --path ${{ env.CACHE_PATH }}
     - name: Unzip and Ensure Src Cache

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -172,23 +172,34 @@ jobs:
         rm -rf src/third_party/swift-toolchain
         rm -rf src/third_party/swiftshader/tests/regres/testlists
         rm -rf src/electron
-    - name: Compress Src Directory
-      if: steps.check-cache.outputs.cache_exists == 'false'
+    # - name: Compress Src Directory
+    #   if: steps.check-cache.outputs.cache_exists == 'false'
+    #   run: |
+    #     echo "Uncompressed src size: $(du -sh src | cut -f1 -d' ')"
+    #     tar -cvf $DEPSHASH.tar src
+    #     echo "Compressed src to $(du -sh $DEPSHASH.tar | cut -f1 -d' ')"
+    - name: Move src folder to cross-OS portal
       run: |
-        echo "Uncompressed src size: $(du -sh src | cut -f1 -d' ')"
-        tar -cvf $DEPSHASH.tar src
-        echo "Compressed src to $(du -sh $DEPSHASH.tar | cut -f1 -d' ')"
+        sudo mkdir -p /var/portal
+        sudo chown -R $(id -u):$(id -g) /var/portal
+        mv ./src /var/portal
     - name: Persist Src Cache
       run: |
         cache_key=v2-git-cache-$DEPSHASH
+        cache_path=/var/portal
         final_cache_path=/mnt/cross-instance-cache/${cache_key}.tar
         echo "Using cache key: $cache_key"
         echo "Checking path: $final_cache_path"
         if [ ! -f "$final_cache_path" ]; then
           echo "Cache key not founding, storing tarball"
-          tmp_container=/mnt/cross-instance-cache/tmp/$CIRCLE_WORKFLOW_JOB_ID
+          tmp_container=/mnt/cross-instance-cache/tmp/${{ github.sha }}
           tmp_cache_path=$tmp_container/${cache_key}.tar
           mkdir -p $tmp_container
+          if [ -f "$cache_path" ]; then
+            tar -cf $tmp_cache_path -C $(dirname $cache_path) ./$(basename $cache_path)
+          else
+            tar -cf $tmp_cache_path -C $cache_path/ ./
+          fi
           mv -vn $tmp_cache_path $final_cache_path
           rm -rf $tmp_container
         else

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -37,6 +37,8 @@ env:
   AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
   AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
   AZURE_STORAGE_CONTAINER_NAME: ${{ secrets.AZURE_STORAGE_CONTAINER_NAME }}
+  AZURE_AKS_CACHE_STORAGE_ACCOUNT: ${{ secrets.AZURE_AKS_CACHE_STORAGE_ACCOUNT }}
+  AZURE_AKS_CACHE_SHARE_NAME: ${{ secrets.AZURE_AKS_CACHE_SHARE_NAME }}
   ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
   ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
   ELECTRON_GITHUB_TOKEN: ${{ secrets.ELECTRON_GITHUB_TOKEN }}
@@ -275,8 +277,8 @@ jobs:
         retry_on: error
         command: |
           az storage file download \
+            --account-name $AZURE_AKS_CACHE_STORAGE_ACCOUNT \
             --share-name $AZURE_AKS_CACHE_SHARE_NAME \
-            --account-name $AZURE_AKS_CACHE_STORAGE_ACCOUNT \"
             --path ".DS_Store"
     - name: Unzip and Ensure Src Cache
       run: |

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -194,7 +194,6 @@ jobs:
         mv ./src /var/portal
     - name: Persist Src Cache
       run: |
-        # cache_key=v2-src-cache-$DEPSHASH
         cache_key=$DEPSHASH
         backup_cache_path=/var/portal
         final_cache_path=/mnt/cross-instance-cache/${cache_key}.tar
@@ -283,8 +282,7 @@ jobs:
         timeout_minutes: 20
         max_attempts: 3
         retry_on: error
-        command: |
-          # cache-key=v2-src-cache-$DEPSHASH
+        run: |
           cache-key=$DEPSHASH
           cache-path=/mnt/cross-instance-cache/${cache-key}.tar
           echo "Pulling mounted data from: $cache-path"

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -91,23 +91,23 @@ jobs:
       run: |
         node src/electron/script/generate-deps-hash.js && cat src/electron/.depshash-target
         echo "DEPSHASH=v1-src-cache-$(shasum src/electron/.depshash | cut -f1 -d' ')" >> $GITHUB_ENV
-    - name: Check If Cache Exists
-      id: check-cache
-      run: |
-        exists_json=$(az storage blob exists \
-          --account-name $AZURE_STORAGE_ACCOUNT \
-          --account-key $AZURE_STORAGE_KEY \
-          --container-name $AZURE_STORAGE_CONTAINER_NAME \
-          --name $DEPSHASH)
+    # - name: Check If Cache Exists
+    #   id: check-cache
+    #   run: |
+    #     exists_json=$(az storage blob exists \
+    #       --account-name $AZURE_STORAGE_ACCOUNT \
+    #       --account-key $AZURE_STORAGE_KEY \
+    #       --container-name $AZURE_STORAGE_CONTAINER_NAME \
+    #       --name $DEPSHASH)
 
-        cache_exists=$(echo $exists_json | jq -r '.exists')
-        echo "cache_exists=$cache_exists" >> $GITHUB_OUTPUT
+    #     cache_exists=$(echo $exists_json | jq -r '.exists')
+    #     echo "cache_exists=$cache_exists" >> $GITHUB_OUTPUT
 
-        if (test "$cache_exists" = "true"); then
-          echo "Cache Exists for $DEPSHASH"
-        else
-          echo "Cache Does Not Exist for $DEPSHASH"
-        fi
+    #     if (test "$cache_exists" = "true"); then
+    #       echo "Cache Exists for $DEPSHASH"
+    #     else
+    #       echo "Cache Does Not Exist for $DEPSHASH"
+    #     fi
     - name: Gclient Sync
       if: steps.check-cache.outputs.cache_exists == 'false'
       run: |

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -44,6 +44,7 @@ env:
   AZURE_AKS_CACHE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_AKS_CACHE_STORAGE_CONNECTION_STRING }}
   AZURE_AKS_CACHE_STORAGE_ACCOUNT: ${{ secrets.AZURE_AKS_CACHE_STORAGE_ACCOUNT }}
   AZURE_AKS_CACHE_SHARE_NAME: ${{ secrets.AZURE_AKS_CACHE_SHARE_NAME }}
+  AZURE_AKS_CACHE_SAS_TOKEN: ${{ secrets.AZURE_AKS_CACHE_SAS_TOKEN }}
   ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
   ELECTRON_GITHUB_TOKEN: ${{ secrets.ELECTRON_GITHUB_TOKEN }}
   GN_CONFIG: ${{ inputs.gn-config }}
@@ -78,6 +79,7 @@ jobs:
       run: |
         cd src/electron
         node script/yarn install
+        brew install azcopy
     - name: Get Depot Tools
       timeout-minutes: 5
       run: |
@@ -283,11 +285,8 @@ jobs:
         max_attempts: 3
         retry_on: error
         command: |
-          echo "Pulling mounted data from: ${{ env.CACHE_PATH }}"
-          az storage file download \
-            --connection-string "$AZURE_AKS_CACHE_STORAGE_CONNECTION_STRING" \
-            --share-name $AZURE_AKS_CACHE_SHARE_NAME \
-            --path ${{ env.CACHE_PATH }}
+          azcopy copy \
+            "https://${AZURE_AKS_CACHE_STORAGE_ACCOUNT}.file.core.windows.net/${AZURE_AKS_CACHE_SHARE_NAME}/${{ env.CACHE_PATH}}?${AZURE_AKS_CACHE_SAS_TOKEN}" $DEPSHASH.tar
     - name: Unzip and Ensure Src Cache
       run: |
         echo "Downloaded cache is $(du -sh $DEPSHASH.tar | cut -f1)"

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -285,9 +285,9 @@ jobs:
         command: |
           echo "Pulling mounted data from: ${{ env.CACHE_PATH }}"
           az storage file download \
-            --account-name $AZURE_AKS_CACHE_STORAGE_ACCOUNT \
-            --account-key $AZURE_AKS_CACHE_STORAGE_KEY \
-            --share-name $AZURE_AKS_CACHE_SHARE_NAME \
+            --account-name "$AZURE_AKS_CACHE_STORAGE_ACCOUNT" \
+            --account-key "$AZURE_AKS_CACHE_STORAGE_KEY" \
+            --share-name "$AZURE_AKS_CACHE_SHARE_NAME" \
             --path ${{ env.CACHE_PATH }}
     - name: Unzip and Ensure Src Cache
       run: |

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -79,7 +79,6 @@ jobs:
       run: |
         cd src/electron
         node script/yarn install
-        brew install azcopy
     - name: Get Depot Tools
       timeout-minutes: 5
       run: |
@@ -246,6 +245,7 @@ jobs:
       run: |
         cd src/electron
         node script/yarn install
+        brew install azcopy
     - name: Load Target Arch & CPU
       run: |
         echo "TARGET_ARCH=${{ matrix.build-arch }}" >> $GITHUB_ENV

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -37,6 +37,8 @@ env:
   AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
   AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
   AZURE_STORAGE_CONTAINER_NAME: ${{ secrets.AZURE_STORAGE_CONTAINER_NAME }}
+  AZURE_AKS_CACHE_STORAGE_KEY: ${{ secrets.AZURE_AKS_CACHE_STORAGE_KEY }}
+  AZURE_AKS_CACHE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_AKS_CACHE_STORAGE_CONNECTION_STRING }}
   AZURE_AKS_CACHE_STORAGE_ACCOUNT: ${{ secrets.AZURE_AKS_CACHE_STORAGE_ACCOUNT }}
   AZURE_AKS_CACHE_SHARE_NAME: ${{ secrets.AZURE_AKS_CACHE_SHARE_NAME }}
   ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
@@ -52,7 +54,7 @@ env:
 
 jobs:
   checkout:
-    runs-on: aks-linux-large-16
+    runs-on: aks-linux-large
     container:
       image: ghcr.io/electron/build:latest
       options: --user root
@@ -95,23 +97,23 @@ jobs:
       run: |
         node src/electron/script/generate-deps-hash.js && cat src/electron/.depshash-target
         echo "DEPSHASH=v1-src-cache-$(shasum src/electron/.depshash | cut -f1 -d' ')" >> $GITHUB_ENV
-    # - name: Check If Cache Exists
-    #   id: check-cache
-    #   run: |
-    #     exists_json=$(az storage blob exists \
-    #       --account-name $AZURE_STORAGE_ACCOUNT \
-    #       --account-key $AZURE_STORAGE_KEY \
-    #       --container-name $AZURE_STORAGE_CONTAINER_NAME \
-    #       --name $DEPSHASH)
+    - name: Check If Cache Exists
+      id: check-cache
+      run: |
+        exists_json=$(az storage file exists \
+          --account-name $AZURE_AKS_CACHE_STORAGE_ACCOUNT \
+          --account-key $AZURE_AKS_CACHE_STORAGE_KEY \
+          --share-name $AZURE_AKS_CACHE_SHARE_NAME \
+          --path $DEPSHASH.tar)
 
-    #     cache_exists=$(echo $exists_json | jq -r '.exists')
-    #     echo "cache_exists=$cache_exists" >> $GITHUB_OUTPUT
+        cache_exists=$(echo $exists_json | jq -r '.exists')
+        echo "cache_exists=$cache_exists" >> $GITHUB_OUTPUT
 
-    #     if (test "$cache_exists" = "true"); then
-    #       echo "Cache Exists for $DEPSHASH"
-    #     else
-    #       echo "Cache Does Not Exist for $DEPSHASH"
-    #     fi
+        if (test "$cache_exists" = "true"); then
+          echo "Cache Exists for $DEPSHASH"
+        else
+          echo "Cache Does Not Exist for $DEPSHASH"
+        fi
     - name: Gclient Sync
       # if: steps.check-cache.outputs.cache_exists == 'false'
       run: |
@@ -176,26 +178,28 @@ jobs:
         rm -rf src/third_party/swift-toolchain
         rm -rf src/third_party/swiftshader/tests/regres/testlists
         rm -rf src/electron
-    # - name: Compress Src Directory
-    #   if: steps.check-cache.outputs.cache_exists == 'false'
-    #   run: |
-    #     echo "Uncompressed src size: $(du -sh src | cut -f1 -d' ')"
-    #     tar -cvf $DEPSHASH.tar src
-    #     echo "Compressed src to $(du -sh $DEPSHASH.tar | cut -f1 -d' ')"
+    - name: Compress Src Directory
+      # if: steps.check-cache.outputs.cache_exists == 'false'
+      run: |
+        echo "Uncompressed src size: $(du -sh src | cut -f1 -d' ')"
+        tar -cvf $DEPSHASH.tar src
+        echo "Compressed src to $(du -sh $DEPSHASH.tar | cut -f1 -d' ')"
     - name: Move src folder to cross-OS portal
       run: |
+        cp ./$DEPSHASH.tar /mnt/cross-instance-cache/
         sudo mkdir -p /var/portal
         sudo chown -R $(id -u):$(id -g) /var/portal
         mv ./src /var/portal
     - name: Persist Src Cache
       run: |
-        cache_key=v2-git-cache-$DEPSHASH
+        # cache_key=v2-git-cache-$DEPSHASH
+        cache_key=$DEPSHASH
         cache_path=/var/portal
         final_cache_path=/mnt/cross-instance-cache/${cache_key}.tar
         echo "Using cache key: $cache_key"
         echo "Checking path: $final_cache_path"
         if [ ! -f "$final_cache_path" ]; then
-          echo "Cache key not founding, storing tarball"
+          echo "Cache key not found, storing tarball"
           tmp_container=/mnt/cross-instance-cache/tmp/${{ github.sha }}
           tmp_cache_path=$tmp_container/${cache_key}.tar
           mkdir -p $tmp_container

--- a/script/azure_cli_deb_install.sh
+++ b/script/azure_cli_deb_install.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+#######################################################################################################################
+# This script does three fundamental things:                                                                          #
+#   1. Add Microsoft's GPG Key has a trusted source of apt packages.                                                  #
+#   2. Add Microsoft's repositories as a source for apt packages.                                                     #
+#   3. Installs the Azure CLI from those repositories.                                                                #
+# Given the nature of this script, it must be executed with elevated privileges, i.e. with `sudo`.                    #
+#                                                                                                                     #
+# Copied from https://azurecliprod.blob.core.windows.net/$root/deb_install.sh                                         #
+#######################################################################################################################
+
+set -e
+
+if [[ $# -ge 1 && $1 == "-y" ]]; then
+    global_consent=0
+else
+    global_consent=1
+fi
+
+function assert_consent {
+    if [[ $2 -eq 0 ]]; then
+        return 0
+    fi
+
+    echo -n "$1 [Y/n] "
+    read consent
+    if [[ ! "${consent}" == "y" && ! "${consent}" == "Y" && ! "${consent}" == "" ]]; then
+        echo "'${consent}'"
+        exit 1
+    fi
+}
+
+global_consent=0 # Artificially giving global consent after review-feedback. Remove this line to enable interactive mode
+
+setup() {
+
+    assert_consent "Add packages necessary to modify your apt-package sources?" ${global_consent}
+    set -v
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y apt-transport-https lsb-release gnupg curl
+    set +v
+
+    assert_consent "Add Microsoft as a trusted package signer?" ${global_consent}
+    set -v
+    curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg
+    set +v
+
+    assert_consent "Add the Azure CLI Repository to your apt sources?" ${global_consent}
+    set -v
+    # Use env var DIST_CODE for the package dist name if provided
+    if [[ -z $DIST_CODE ]]; then
+        CLI_REPO=$(lsb_release -cs)
+        shopt -s nocasematch
+        ERROR_MSG="Unable to find a package for your system. Please check if an existing package in https://packages.microsoft.com/repos/azure-cli/dists/ can be used in your system and install with the dist name: 'curl -sL https://aka.ms/InstallAzureCLIDeb | sudo DIST_CODE=<dist_code_name> bash'"
+        if [[ ! $(curl -sL https://packages.microsoft.com/repos/azure-cli/dists/) =~ $CLI_REPO ]]; then
+            DIST=$(lsb_release -is)
+            if [[ $DIST =~ "Ubuntu" ]]; then
+                CLI_REPO="jammy"
+            elif [[ $DIST =~ "Debian" ]]; then
+                CLI_REPO="bookworm"
+            elif [[ $DIST =~ "LinuxMint" ]]; then
+                CLI_REPO=$(cat /etc/os-release | grep -Po 'UBUNTU_CODENAME=\K.*') || true
+                if [[ -z $CLI_REPO ]]; then
+                    echo $ERROR_MSG
+                    exit 1
+                fi
+            else
+                echo $ERROR_MSG
+                exit 1
+            fi
+        fi
+    else
+        CLI_REPO=$DIST_CODE
+        if [[ ! $(curl -sL https://packages.microsoft.com/repos/azure-cli/dists/) =~ $CLI_REPO ]]; then
+            echo "Unable to find an azure-cli package with DIST_CODE=$CLI_REPO in https://packages.microsoft.com/repos/azure-cli/dists/."
+            exit 1
+        fi
+    fi
+    echo "deb [arch=$(dpkg --print-architecture)] https://packages.microsoft.com/repos/azure-cli/ ${CLI_REPO} main" \
+        > /etc/apt/sources.list.d/azure-cli.list
+    apt-get update
+    set +v
+
+    assert_consent "Install the Azure CLI?" ${global_consent}
+    apt-get install -y azure-cli
+
+}
+
+setup  # ensure the whole file is downloaded before executing


### PR DESCRIPTION
#### Description of Change

Modifies the way we're handling the GHA MacOS cache to use the Linux AKS NFS image for caching.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
