### PR TITLE
build: build ffmpeg on MAS publish

### DIFF
--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -507,7 +507,7 @@ jobs:
         else
           electron/script/zip-symbols.py -b $BUILD_PATH
         fi
-    - name: Generate FFMpeg
+    - name: Generate FFMpeg (darwin)
       if: ${{ inputs.is-release }}
       run: |
         cd src
@@ -628,6 +628,12 @@ jobs:
         else
           electron/script/zip-symbols.py -b $BUILD_PATH
         fi
+    - name: Generate FFMpeg (mas)
+      if: ${{ inputs.is-release }}
+      run: |
+        cd src
+        gn gen out/ffmpeg --args="import(\"//electron/build/args/ffmpeg.gn\") use_remoteexec=true $GN_EXTRA_ARGS"
+        autoninja -C out/ffmpeg electron:electron_ffmpeg_zip -j $NUMBER_OF_NINJA_PROCESSES
     # TODO(vertedinde): These uploads currently point to a different Azure bucket & GitHub Repo
     - name: Publish Electron Dist
       if: ${{ inputs.is-release }}


### PR DESCRIPTION
#### Description of Change

Adds the ffmpeg generation for the MAS publish job as well as Darwin.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
