### PR TITLE
docs: fix the Apple HIG link for Dock context menu

### DIFF
--- a/docs/api/dock.md
+++ b/docs/api/dock.md
@@ -80,4 +80,4 @@ Returns `Menu | null` - The application's [dock menu][dock-menu].
 
 Sets the `image` associated with this dock icon.
 
-[dock-menu]: https://developer.apple.com/macos/human-interface-guidelines/menus/dock-menus/
+[dock-menu]: https://developer.apple.com/design/human-interface-guidelines/dock-menus


### PR DESCRIPTION
The link seems to have changed. This is the up to date link.

#### Description of Change

Fix state link.

#### Checklist

- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes

Notes: none