### PR TITLE
docs: fix info admonitions in security.md

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -246,7 +246,7 @@ and prevent the use of Node primitives `contextIsolation` **must** also be used.
 :::info
 For more information on what `contextIsolation` is and how to enable it please
 see our dedicated [Context Isolation](context-isolation.md) document.
-:::info
+:::
 
 ### 4. Enable process sandboxing
 
@@ -259,7 +259,7 @@ content in an unsandboxed process, including the main process, is not advised.
 :::info
 For more information on what Process Sandboxing is and how to enable it please
 see our dedicated [Process Sandboxing](sandbox.md) document.
-:::info
+:::
 
 ### 5. Handle session permission requests from remote content
 


### PR DESCRIPTION
#### Description of Change

Fixed faulty :::info admonitions resulting in nested info boxes in security.md:
![image](https://github.com/electron/electron/assets/71205200/2db2a632-be45-4860-85fe-f727e6d1ee32)

Tested locally with electron/website

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
