### PR TITLE
build: save/restore cache on Linux builds

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    uses: electron/electron/.github/workflows/linux-pipeline.yml@gh-actions-publish-linux
+    uses: electron/electron/.github/workflows/linux-pipeline.yml@main
     with:
       is-release: false
       gn-config: //electron/build/args/testing.gn

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    uses: electron/electron/.github/workflows/linux-pipeline.yml@main
+    uses: electron/electron/.github/workflows/linux-pipeline.yml@gh-actions-publish-linux
     with:
       is-release: false
       gn-config: //electron/build/args/testing.gn

--- a/.github/workflows/linux-pipeline.yml
+++ b/.github/workflows/linux-pipeline.yml
@@ -271,16 +271,13 @@ jobs:
 
         echo "Downloaded cache is $(du -sh $DEPSHASH.tar | cut -f1)"
         mkdir temp-cache
-        tar -xf $DEPSHASH.tar -C temp-cache
+        tar -xf $cache_path -C temp-cache
         echo "Unzipped cache is $(du -sh temp-cache/src | cut -f1)"
 
         if [ -d "temp-cache/src" ]; then
           echo "Relocating Cache"
           rm -rf src
           mv temp-cache/src src
-
-          echo "Deleting zip file"
-          rm -rf $DEPSHASH.tar
         fi
 
         if [ ! -d "src/third_party/blink" ]; then

--- a/.github/workflows/linux-pipeline.yml
+++ b/.github/workflows/linux-pipeline.yml
@@ -163,7 +163,6 @@ jobs:
         rm -rf src/third_party/swiftshader/tests/regres/testlists
         rm -rf src/electron
         rm -rf src/third_party/electron_node/deps/openssl
-        rm -rf src/third_party/electron_node/deps/v8
     - name: Compress Src Directory
       if: steps.check-cache.outputs.cache_exists == 'false'
       run: |
@@ -269,7 +268,7 @@ jobs:
           echo "Found Cache for $DEPSHASH at $cache_path"
         fi
 
-        echo "Downloaded cache is $(du -sh $DEPSHASH.tar | cut -f1)"
+        echo "Persisted cache is $(du -sh $cache_path | cut -f1)"
         mkdir temp-cache
         tar -xf $cache_path -C temp-cache
         echo "Unzipped cache is $(du -sh temp-cache/src | cut -f1)"

--- a/.github/workflows/linux-pipeline.yml
+++ b/.github/workflows/linux-pipeline.yml
@@ -54,6 +54,9 @@ jobs:
     container:
       image: ghcr.io/electron/build:latest
       options: --user root
+      volumes:
+        - /mnt/cross-instance-cache:/mnt/cross-instance-cache
+        - /var/run/sas:/var/run/sas
     steps:
     - name: Checkout Electron
       uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
@@ -71,11 +74,9 @@ jobs:
       timeout-minutes: 5
       run: |
         git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
-
         sed -i '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
         cd depot_tools
         git apply --3way ../src/electron/.github/workflows/config/gclient.diff
-
         # Ensure depot_tools does not update.
         test -d depot_tools && cd depot_tools
         touch .disable_auto_update
@@ -88,19 +89,14 @@ jobs:
     - name: Check If Cache Exists
       id: check-cache
       run: |
-        exists_json=$(az storage blob exists \
-          --account-name $AZURE_STORAGE_ACCOUNT \
-          --account-key $AZURE_STORAGE_KEY \
-          --container-name $AZURE_STORAGE_CONTAINER_NAME \
-          --name $DEPSHASH)
-
-        cache_exists=$(echo $exists_json | jq -r '.exists')
-        echo "cache_exists=$cache_exists" >> $GITHUB_OUTPUT
-
-        if (test "$cache_exists" = "true"); then
-          echo "Cache Exists for $DEPSHASH"
-        else
+        cache_key=$DEPSHASH
+        cache_path=/mnt/cross-instance-cache/${cache_key}.tar
+        echo "Using cache key: $cache_key"
+        echo "Checking for cache in: $cache_path"
+        if [ ! -f "$cache_path" ]; then
           echo "Cache Does Not Exist for $DEPSHASH"
+        else
+          echo "Cache Already Exists for $DEPSHASH, Skipping.."
         fi
     - name: Gclient Sync
       if: steps.check-cache.outputs.cache_exists == 'false'
@@ -112,7 +108,7 @@ jobs:
           "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
 
         ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES=1 gclient sync --with_branch_heads --with_tags -vvvvv
-        if [ "${{ inputs.is-release }}" != "true" ]; then
+        if [ ${{ inputs.is-release != true }}]; then
           # Re-export all the patches to check if there were changes.
           python3 src/electron/script/export_all_patches.py src/electron/patches/config.json
           cd src/electron
@@ -174,15 +170,36 @@ jobs:
         echo "Uncompressed src size: $(du -sh src | cut -f1 -d' ')"
         tar -cvf $DEPSHASH.tar src
         echo "Compressed src to $(du -sh $DEPSHASH.tar | cut -f1 -d' ')"
-    - name: Upload Compressed Src Cache to Azure
+    - name: Move src folder to cross-OS portal
       if: steps.check-cache.outputs.cache_exists == 'false'
       run: |
-        az storage blob upload \
-          --account-name $AZURE_STORAGE_ACCOUNT \
-          --account-key $AZURE_STORAGE_KEY \
-          --container-name $AZURE_STORAGE_CONTAINER_NAME \
-          --file $DEPSHASH.tar \
-          --name $DEPSHASH
+        cp ./$DEPSHASH.tar /mnt/cross-instance-cache/
+        sudo mkdir -p /var/portal
+        sudo chown -R $(id -u):$(id -g) /var/portal
+        mv ./src /var/portal
+    - name: Persist Src Cache
+      if: steps.check-cache.outputs.cache_exists == 'false'
+      run: |
+        cache_key=$DEPSHASH
+        backup_cache_path=/var/portal
+        final_cache_path=/mnt/cross-instance-cache/${cache_key}.tar
+        echo "Using cache key: $cache_key"
+        echo "Checking path: $final_cache_path"
+        if [ ! -f "$final_cache_path" ]; then
+          echo "Cache key not found, storing tarball"
+          tmp_container=/mnt/cross-instance-cache/tmp/${{ github.sha }}
+          tmp_cache_path=$tmp_container/${cache_key}.tar
+          mkdir -p $tmp_container
+          if [ -f "$backup_cache_path" ]; then
+            tar -cf $tmp_cache_path -C $(dirname $backup_cache_path) ./$(basename $backup_cache_path)
+          else
+            tar -cf $tmp_cache_path -C $backup_cache_path/ ./
+          fi
+          mv -vn $tmp_cache_path $final_cache_path
+          rm -rf $tmp_container
+        else
+          echo "Cache key already exists, skipping.."
+        fi
   build:
     strategy:
       fail-fast: false
@@ -194,6 +211,9 @@ jobs:
     container:
       image: ghcr.io/electron/build:latest
       options: --user root
+      volumes:
+        - /mnt/cross-instance-cache:/mnt/cross-instance-cache
+        - /var/run/sas:/var/run/sas
     needs: checkout
     steps:
     - name: Load Build Tools
@@ -237,24 +257,18 @@ jobs:
       run: |
         node src/electron/script/generate-deps-hash.js && cat src/electron/.depshash-target
         echo "DEPSHASH=v1-src-cache-$(shasum src/electron/.depshash | cut -f1 -d' ')" >> $GITHUB_ENV
-    - name: Download Src Cache
-      # The cache will always exist here as a result of the checkout job
-      # Either it was uploaded to Azure in the checkout job for this commit
-      # or it was uploaded in the checkout job for a previous commit.
-      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
-      with:
-        timeout_minutes: 20
-        max_attempts: 3
-        retry_on: error
-        command: |
-          az storage blob download \
-            --account-name $AZURE_STORAGE_ACCOUNT \
-            --account-key $AZURE_STORAGE_KEY \
-            --container-name $AZURE_STORAGE_CONTAINER_NAME \
-            --name $DEPSHASH \
-            --file $DEPSHASH.tar
-    - name: Unzip and Ensure Src Cache
+    - name: Restore and Ensure Src Cache
       run: |
+        cache_path=/mnt/cross-instance-cache/$DEPSHASH.tar
+        echo "Using cache key: $DEPSHASH"
+        echo "Checking for cache in: $cache_path"
+        if [ ! -f "$cache_path" ]; then
+          echo "Cache Does Not Exist for $DEPSHASH - exiting"
+          exit 1
+        else
+          echo "Found Cache for $DEPSHASH at $cache_path"
+        fi
+
         echo "Downloaded cache is $(du -sh $DEPSHASH.tar | cut -f1)"
         mkdir temp-cache
         tar -xf $DEPSHASH.tar -C temp-cache

--- a/.github/workflows/linux-pipeline.yml
+++ b/.github/workflows/linux-pipeline.yml
@@ -92,8 +92,10 @@ jobs:
         echo "Using cache key: $cache_key"
         echo "Checking for cache in: $cache_path"
         if [ ! -f "$cache_path" ]; then
+          echo "cache_exists=false" >> $GITHUB_OUTPUT
           echo "Cache Does Not Exist for $DEPSHASH"
         else
+          echo "cache_exists=true" >> $GITHUB_OUTPUT
           echo "Cache Already Exists for $DEPSHASH, Skipping.."
         fi
     - name: Gclient Sync

--- a/.github/workflows/linux-pipeline.yml
+++ b/.github/workflows/linux-pipeline.yml
@@ -160,7 +160,6 @@ jobs:
         rm -rf src/third_party/swift-toolchain
         rm -rf src/third_party/swiftshader/tests/regres/testlists
         rm -rf src/electron
-        rm -rf src/third_party/electron_node/deps/openssl
     - name: Compress Src Directory
       if: steps.check-cache.outputs.cache_exists == 'false'
       run: |

--- a/.github/workflows/linux-pipeline.yml
+++ b/.github/workflows/linux-pipeline.yml
@@ -54,7 +54,6 @@ jobs:
       options: --user root
       volumes:
         - /mnt/cross-instance-cache:/mnt/cross-instance-cache
-        - /var/run/sas:/var/run/sas
     steps:
     - name: Checkout Electron
       uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
@@ -166,36 +165,20 @@ jobs:
       if: steps.check-cache.outputs.cache_exists == 'false'
       run: |
         echo "Uncompressed src size: $(du -sh src | cut -f1 -d' ')"
-        tar -cvf $DEPSHASH.tar src
+        tar -cf $DEPSHASH.tar src
         echo "Compressed src to $(du -sh $DEPSHASH.tar | cut -f1 -d' ')"
-    - name: Move src folder to cross-OS portal
-      if: steps.check-cache.outputs.cache_exists == 'false'
-      run: |
         cp ./$DEPSHASH.tar /mnt/cross-instance-cache/
-        sudo mkdir -p /var/portal
-        sudo chown -R $(id -u):$(id -g) /var/portal
-        mv ./src /var/portal
     - name: Persist Src Cache
       if: steps.check-cache.outputs.cache_exists == 'false'
       run: |
-        backup_cache_path=/var/portal
         final_cache_path=/mnt/cross-instance-cache/$DEPSHASH.tar
         echo "Using cache key: $DEPSHASH"
         echo "Checking path: $final_cache_path"
         if [ ! -f "$final_cache_path" ]; then
-          echo "Cache key not found, storing tarball"
-          tmp_container=/mnt/cross-instance-cache/tmp/${{ github.sha }}
-          tmp_cache_path=$tmp_container/$DEPSHASH.tar
-          mkdir -p $tmp_container
-          if [ -f "$backup_cache_path" ]; then
-            tar -cf $tmp_cache_path -C $(dirname $backup_cache_path) ./$(basename $backup_cache_path)
-          else
-            tar -cf $tmp_cache_path -C $backup_cache_path/ ./
-          fi
-          mv -vn $tmp_cache_path $final_cache_path
-          rm -rf $tmp_container
+          echo "Cache key not found"
+          exit 1
         else
-          echo "Cache key already exists, skipping.."
+          echo "Cache key persisted in $final_cache_path"
         fi
   build:
     strategy:
@@ -210,7 +193,6 @@ jobs:
       options: --user root
       volumes:
         - /mnt/cross-instance-cache:/mnt/cross-instance-cache
-        - /var/run/sas:/var/run/sas
     needs: checkout
     steps:
     - name: Load Build Tools

--- a/.github/workflows/linux-pipeline.yml
+++ b/.github/workflows/linux-pipeline.yml
@@ -87,9 +87,8 @@ jobs:
     - name: Check If Cache Exists
       id: check-cache
       run: |
-        cache_key=$DEPSHASH
-        cache_path=/mnt/cross-instance-cache/${cache_key}.tar
-        echo "Using cache key: $cache_key"
+        cache_path=/mnt/cross-instance-cache/$DEPSHASH.tar
+        echo "Using cache key: $DEPSHASH"
         echo "Checking for cache in: $cache_path"
         if [ ! -f "$cache_path" ]; then
           echo "cache_exists=false" >> $GITHUB_OUTPUT
@@ -108,7 +107,7 @@ jobs:
           "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
 
         ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES=1 gclient sync --with_branch_heads --with_tags -vvvvv
-        if [ ${{ inputs.is-release != true }}]; then
+        if [ "${{ inputs.is-release }}" != "true" ]; then
           # Re-export all the patches to check if there were changes.
           python3 src/electron/script/export_all_patches.py src/electron/patches/config.json
           cd src/electron
@@ -179,15 +178,14 @@ jobs:
     - name: Persist Src Cache
       if: steps.check-cache.outputs.cache_exists == 'false'
       run: |
-        cache_key=$DEPSHASH
         backup_cache_path=/var/portal
-        final_cache_path=/mnt/cross-instance-cache/${cache_key}.tar
-        echo "Using cache key: $cache_key"
+        final_cache_path=/mnt/cross-instance-cache/$DEPSHASH.tar
+        echo "Using cache key: $DEPSHASH"
         echo "Checking path: $final_cache_path"
         if [ ! -f "$final_cache_path" ]; then
           echo "Cache key not found, storing tarball"
           tmp_container=/mnt/cross-instance-cache/tmp/${{ github.sha }}
-          tmp_cache_path=$tmp_container/${cache_key}.tar
+          tmp_cache_path=$tmp_container/$DEPSHASH.tar
           mkdir -p $tmp_container
           if [ -f "$backup_cache_path" ]; then
             tar -cf $tmp_cache_path -C $(dirname $backup_cache_path) ./$(basename $backup_cache_path)

--- a/.github/workflows/linux-pipeline.yml
+++ b/.github/workflows/linux-pipeline.yml
@@ -34,9 +34,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
-  AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
-  AZURE_STORAGE_CONTAINER_NAME: ${{ secrets.AZURE_STORAGE_CONTAINER_NAME }}
   ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
   ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
   ELECTRON_GITHUB_TOKEN: ${{ secrets.ELECTRON_GITHUB_TOKEN }}
@@ -44,6 +41,7 @@ env:
   # Disable pre-compiled headers to reduce out size - only useful for rebuilds
   GN_BUILDFLAG_ARGS: 'enable_precompiled_headers = false'
   GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
+  # Only disable this in the Asan build
   CHECK_DIST_MANIFEST: true
   IS_GHA_RELEASE: true
   ELECTRON_OUT_DIR: Default

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -181,34 +181,18 @@ jobs:
         echo "Uncompressed src size: $(du -sh src | cut -f1 -d' ')"
         tar -cf $DEPSHASH.tar src
         echo "Compressed src to $(du -sh $DEPSHASH.tar | cut -f1 -d' ')"
-    - name: Move src folder to cross-OS portal
-      if: steps.check-cache.outputs.cache_exists == 'false'
-      run: |
         cp ./$DEPSHASH.tar /mnt/cross-instance-cache/
-        sudo mkdir -p /var/portal
-        sudo chown -R $(id -u):$(id -g) /var/portal
-        mv ./src /var/portal
     - name: Persist Src Cache
       if: steps.check-cache.outputs.cache_exists == 'false'
       run: |
-        backup_cache_path=/var/portal
         final_cache_path=/mnt/cross-instance-cache/$DEPSHASH.tar
         echo "Using cache key: $DEPSHASH"
         echo "Checking path: $final_cache_path"
         if [ ! -f "$final_cache_path" ]; then
-          echo "Cache key not found, storing tarball"
-          tmp_container=/mnt/cross-instance-cache/tmp/${{ github.sha }}
-          tmp_cache_path=$tmp_container/$DEPSHASH.tar
-          mkdir -p $tmp_container
-          if [ -f "$backup_cache_path" ]; then
-            tar -cf $tmp_cache_path -C $(dirname $backup_cache_path) ./$(basename $backup_cache_path)
-          else
-            tar -cf $tmp_cache_path -C $backup_cache_path/ ./
-          fi
-          mv -vn $tmp_cache_path $final_cache_path
-          rm -rf $tmp_container
+          echo "Cache key not found"
+          exit 1
         else
-          echo "Cache key already exists, skipping.."
+          echo "Cache key persisted in $final_cache_path"
         fi
   build:
     strategy:

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -106,8 +106,10 @@ jobs:
         echo "Using cache key: $cache_key"
         echo "Checking for cache in: $cache_path"
         if [ ! -f "$cache_path" ]; then
+          echo "cache_exists=false" >> $GITHUB_OUTPUT
           echo "Cache Does Not Exist for $DEPSHASH"
         else
+          echo "cache_exists=true" >> $GITHUB_OUTPUT
           echo "Cache Already Exists for $DEPSHASH, Skipping.."
         fi
     - name: Gclient Sync

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -101,9 +101,8 @@ jobs:
     - name: Check If Cache Exists
       id: check-cache
       run: |
-        cache_key=$DEPSHASH
-        cache_path=/mnt/cross-instance-cache/${cache_key}.tar
-        echo "Using cache key: $cache_key"
+        cache_path=/mnt/cross-instance-cache/$DEPSHASH.tar
+        echo "Using cache key: $DEPSHASH"
         echo "Checking for cache in: $cache_path"
         if [ ! -f "$cache_path" ]; then
           echo "cache_exists=false" >> $GITHUB_OUTPUT
@@ -192,15 +191,14 @@ jobs:
     - name: Persist Src Cache
       if: steps.check-cache.outputs.cache_exists == 'false'
       run: |
-        cache_key=$DEPSHASH
         backup_cache_path=/var/portal
-        final_cache_path=/mnt/cross-instance-cache/${cache_key}.tar
-        echo "Using cache key: $cache_key"
+        final_cache_path=/mnt/cross-instance-cache/$DEPSHASH.tar
+        echo "Using cache key: $DEPSHASH"
         echo "Checking path: $final_cache_path"
         if [ ! -f "$final_cache_path" ]; then
           echo "Cache key not found, storing tarball"
           tmp_container=/mnt/cross-instance-cache/tmp/${{ github.sha }}
-          tmp_cache_path=$tmp_container/${cache_key}.tar
+          tmp_cache_path=$tmp_container/$DEPSHASH.tar
           mkdir -p $tmp_container
           if [ -f "$backup_cache_path" ]; then
             tar -cf $tmp_cache_path -C $(dirname $backup_cache_path) ./$(basename $backup_cache_path)


### PR DESCRIPTION
#### Description of Change

A follow up to #42447, this PR modifies the Linux Build GHA job to use the AKS disk cache, rather than using blob storage upload and download.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
