### PR TITLE
build: move hunspell generation to Linux

### DIFF
--- a/.github/workflows/linux-pipeline.yml
+++ b/.github/workflows/linux-pipeline.yml
@@ -268,6 +268,11 @@ jobs:
         cd src
         gn gen out/ffmpeg --args="import(\"//electron/build/args/ffmpeg.gn\") use_remoteexec=true $GN_EXTRA_ARGS"
         autoninja -C out/ffmpeg electron:electron_ffmpeg_zip -j $NUMBER_OF_NINJA_PROCESSES
+    - name: Generate Hunspell Dictionaries
+      if: ${{ inputs.is-release }}
+      run: |
+        cd src
+        autoninja -C out/Default electron:hunspell_dictionaries_zip -j $NUMBER_OF_NINJA_PROCESSES
     - name: Maybe Generate Libcxx
       if: ${{ inputs.is-release }}
       run: |

--- a/.github/workflows/macos-pipeline.yml
+++ b/.github/workflows/macos-pipeline.yml
@@ -393,11 +393,6 @@ jobs:
         cd src
         gn gen out/ffmpeg --args="import(\"//electron/build/args/ffmpeg.gn\") use_remoteexec=true $GN_EXTRA_ARGS"
         autoninja -C out/ffmpeg electron:electron_ffmpeg_zip -j $NUMBER_OF_NINJA_PROCESSES
-    - name: Generate Hunspell Dictionaries
-      if: ${{ inputs.is-release }}
-      run: |
-        cd src
-        autoninja -C out/Default electron:hunspell_dictionaries_zip -j $NUMBER_OF_NINJA_PROCESSES
     - name: Generate TypeScript Definitions
       if: ${{ inputs.is-release }}
       run: |


### PR DESCRIPTION
#### Description of Change

Does what it says on the tin - moves Hunspell from Mac to Linux, only runs it one time.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
