### PR TITLE
build: add production-release environment to publish jobs

### DIFF
--- a/.github/workflows/linux-publish.yml
+++ b/.github/workflows/linux-publish.yml
@@ -41,6 +41,7 @@ jobs:
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
     needs: checkout-linux
     with:
+      environment: production-release
       build-runs-on: aks-linux-large
       build-container: '{"image":"ghcr.io/electron/build:${{ inputs.build-image-sha }}","options":"--user root","volumes":["/mnt/cross-instance-cache:/mnt/cross-instance-cache"]}'
       target-platform: linux
@@ -55,6 +56,7 @@ jobs:
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
     needs: checkout-linux
     with:
+      environment: production-release
       build-runs-on: aks-linux-large
       build-container: '{"image":"ghcr.io/electron/build:${{ inputs.build-image-sha }}","options":"--user root","volumes":["/mnt/cross-instance-cache:/mnt/cross-instance-cache"]}'
       target-platform: linux
@@ -69,6 +71,7 @@ jobs:
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
     needs: checkout-linux
     with:
+      environment: production-release
       build-runs-on: aks-linux-large
       build-container: '{"image":"ghcr.io/electron/build:${{ inputs.build-image-sha }}","options":"--user root","volumes":["/mnt/cross-instance-cache:/mnt/cross-instance-cache"]}'
       target-platform: linux

--- a/.github/workflows/macos-publish.yml
+++ b/.github/workflows/macos-publish.yml
@@ -44,6 +44,7 @@ jobs:
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
     needs: checkout-macos
     with:
+      environment: production-release
       build-runs-on: macos-14-xlarge
       target-platform: macos
       target-arch: x64
@@ -57,6 +58,7 @@ jobs:
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
     needs: checkout-macos
     with:
+      environment: production-release
       build-runs-on: macos-14-xlarge
       target-platform: macos
       target-arch: arm64

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -97,9 +97,9 @@ jobs:
       if: ${{ inputs.target-platform == 'linux' }}
       run: |
         if [ "${{ inputs.target-arch  }}" = "arm" ]; then
-          GN_EXTRA_ARGS='build_tflite_with_xnnpack=false'
+          GN_EXTRA_ARGS='target_cpu="arm" build_tflite_with_xnnpack=false'
         elif [ "${{ inputs.target-arch }}" = "arm64" ]; then
-          GN_EXTRA_ARGS='fatal_linker_warnings=false enable_linux_installer=false'
+          GN_EXTRA_ARGS='target_cpu="arm64" fatal_linker_warnings=false enable_linux_installer=false'
         fi
         echo "GN_EXTRA_ARGS=$GN_EXTRA_ARGS" >> $GITHUB_ENV
     - name: Get Depot Tools

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -3,6 +3,10 @@ name: Pipeline Segment - Electron Build
 on:
   workflow_call:
     inputs:
+      environment:
+        description: using the production or testing environment
+        required: false
+        type: string
       target-platform:
         type: string
         description: 'Platform to run on, can be macos or linux'
@@ -64,6 +68,7 @@ jobs:
   build:
     runs-on: ${{ inputs.build-runs-on }}
     container: ${{ fromJSON(inputs.build-container) }}
+    environment: ${{ inputs.environment }}
     env:
       TARGET_ARCH: ${{ inputs.target-arch }}
     steps:


### PR DESCRIPTION
#### Description of Change

Moves Mac Publish & Linux Publish to use the `production-release` environment for secrets.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
