### PR TITLE
build: add `v8_toolchain` to darwin/x64

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -26,6 +26,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set GN_EXTRA_ARGS for MacOS x64 Builds
+      shell: bash
+      if: ${{ inputs.target-arch == 'x64' && inputs.target-platform == 'macos' }}
+      run: |
+        GN_APPENDED_ARGS="$GN_EXTRA_ARGS v8_snapshot_toolchain='//build/toolchain/mac:clang_x64'"
+        echo "GN_EXTRA_ARGS=$GN_APPENDED_ARGS" >> $GITHUB_ENV
     - name: Build Electron ${{ inputs.step-suffix }}
       shell: bash
       run: |


### PR DESCRIPTION
#### Description of Change

The PR adds the needed x64 v8_toolchain to compile mksnapshot to the correct arch

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
