### PR TITLE
build: fix datetime module for Linux Publish

### DIFF
--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -48,7 +48,7 @@ def main():
   if args.verbose:
     enable_verbose_mode()
   if args.upload_to_storage:
-    utcnow = datetime.datetime.now(datetime.UTC)
+    utcnow = datetime.datetime.utcnow()
     args.upload_timestamp = utcnow.strftime('%Y%m%d')
 
   build_version = get_electron_build_version()


### PR DESCRIPTION
#### Description of Change

Unblocked publish linux; moves us back to the deprecated datetime.datetime.utcnow() method. We can update this once we move the Linux AKS runners to Python 3.11 or higher.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
