### PR TITLE
build: remove gclient-extra-args from publish jobs

### DIFF
--- a/.github/workflows/linux-publish.yml
+++ b/.github/workflows/linux-publish.yml
@@ -36,8 +36,6 @@ jobs:
         fetch-depth: 0
     - name: Checkout & Sync & Save
       uses: ./src/electron/.github/actions/checkout
-      with:
-        gclient-extra-args: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
 
   publish-x64:
     uses: ./.github/workflows/pipeline-segment-electron-build.yml

--- a/.github/workflows/macos-publish.yml
+++ b/.github/workflows/macos-publish.yml
@@ -39,7 +39,6 @@ jobs:
       uses: ./src/electron/.github/actions/checkout
       with:
         generate-sas-token: 'true'
-        gclient-extra-args: '--custom-var=checkout_mac=True --custom-var=host_os=mac'
 
   publish-x64:
     uses: ./.github/workflows/pipeline-segment-electron-build.yml


### PR DESCRIPTION
#### Description of Change

This PR passes in the `gclient-extra-args` to the checkout job as an input, and then adds it to the environment so it can be used for the checkout build.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
