### PR TITLE
build: use `BUILD_TYPE` from env

### DIFF
--- a/.github/workflows/pipeline-segment-node-nan-test.yml
+++ b/.github/workflows/pipeline-segment-node-nan-test.yml
@@ -41,6 +41,7 @@ jobs:
     timeout-minutes: 20
     env: 
       TARGET_ARCH: ${{ inputs.target-arch }}
+      BUILD_TYPE: linux
     container: ${{ fromJSON(inputs.test-container) }}
     steps:
     - name: Load Build Tools
@@ -71,8 +72,8 @@ jobs:
     - name: Download Generated Artifacts
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:
-        name: generated_artifacts_linux_${{ env.TARGET_ARCH }}
-        path: ./generated_artifacts_linux_${{ env.TARGET_ARCH }}
+        name: generated_artifacts_${{ env.BUILD_TYPE }}_${{ env.TARGET_ARCH }}
+        path: ./generated_artifacts_${{ env.BUILD_TYPE }}_${{ env.TARGET_ARCH }}
     - name: Download Src Artifacts
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:
@@ -103,6 +104,7 @@ jobs:
     timeout-minutes: 20
     env: 
       TARGET_ARCH: ${{ inputs.target-arch }}
+      BUILD_TYPE: linux
     container: ${{ fromJSON(inputs.test-container) }}
     steps:
     - name: Load Build Tools
@@ -133,8 +135,8 @@ jobs:
     - name: Download Generated Artifacts
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:
-        name: generated_artifacts_linux_${{ env.TARGET_ARCH }}
-        path: ./generated_artifacts_linux_${{ env.TARGET_ARCH }}
+        name: generated_artifacts_${{ env.BUILD_TYPE }}_${{ env.TARGET_ARCH }}
+        path: ./generated_artifacts_${{ env.BUILD_TYPE }}_${{ env.TARGET_ARCH }}
     - name: Download Src Artifacts
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:

--- a/script/actions/restore-artifacts.sh
+++ b/script/actions/restore-artifacts.sh
@@ -1,18 +1,5 @@
 #!/bin/bash
 
-if [ "`uname`" == "Darwin" ]; then
-  if [ -z "$MAS_BUILD" ]; then
-    BUILD_TYPE="darwin"
-  else
-    BUILD_TYPE="mas"
-  fi
-elif [ "`uname`" == "Linux" ]; then
-  BUILD_TYPE="linux"
-else
-  echo "Unsupported platform"
-  exit 1
-fi
-
 GENERATED_ARTIFACTS="generated_artifacts_${BUILD_TYPE}_${TARGET_ARCH}"
 SRC_ARTIFACTS="src_artifacts_${BUILD_TYPE}_${TARGET_ARCH}"
 


### PR DESCRIPTION
#### Description of Change

Use `BUILD_TYPE` from env instead of setting it in `restore-artifacts.sh`. Fixes issue with mas src artifacts being incorrectly  extracted.

https://github.com/electron/electron/actions/runs/9510478302/job/26216072597 shows error fixed

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
