### PR TITLE
build: revert removal of CIPD patch from depot tools

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -253,6 +253,25 @@ step-depot-tools-get: &step-depot-tools-get
         sed -i '' '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
       else
         sed -i '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
+        # Remove swift-format dep from cipd on macOS until we send a patch upstream.
+        cd depot_tools
+        cat > gclient.diff \<< 'EOF'
+      diff --git a/gclient.py b/gclient.py
+      index c305c248..e6e0fbdc 100755
+      --- a/gclient.py
+      +++ b/gclient.py
+      @@ -783,7 +783,8 @@ class Dependency(gclient_utils.WorkItem, DependencySettings):
+                               not condition or "non_git_source" not in condition):
+                           continue
+                       cipd_root = self.GetCipdRoot()
+      -                for package in dep_value.get('packages', []):
+      +                packages = dep_value.get('packages', [])
+      +                for package in (x for x in packages if "infra/3pp/tools/swift-format" not in x.get('package')):
+                           deps_to_add.append(
+                               CipdDependency(parent=self,
+                                              name=name,
+      EOF
+        git apply --3way gclient.diff
       fi
       # Ensure depot_tools does not update.
       test -d depot_tools && cd depot_tools

--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -21,7 +21,12 @@ runs:
     shell: bash
     run: |
       git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+
       sed -i '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
+      # Remove swift-format dep from cipd on macOS until we send a patch upstream.
+      cd depot_tools
+      git apply --3way ../src/electron/.github/workflows/config/gclient.diff
+
       # Ensure depot_tools does not update.
       test -d depot_tools && cd depot_tools
       touch .disable_auto_update

--- a/.github/workflows/config/gclient.diff
+++ b/.github/workflows/config/gclient.diff
@@ -1,0 +1,14 @@
+diff --git a/gclient.py b/gclient.py
+index 59e2b4c5197928bdba1ef69bdbe637d7dfe471c1..b4bae5e48c83c84bd867187afaf40eed16e69851 100755
+--- a/gclient.py
++++ b/gclient.py
+@@ -783,7 +783,8 @@ class Dependency(gclient_utils.WorkItem, DependencySettings):
+                         not condition or "non_git_source" not in condition):
+                     continue
+                 cipd_root = self.GetCipdRoot()
+-                for package in dep_value.get('packages', []):
++                packages = dep_value.get('packages', [])
++                for package in (x for x in packages if "infra/3pp/tools/swift-format" not in x.get('package')):
+                     deps_to_add.append(
+                         CipdDependency(parent=self,
+                                        name=name,

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -112,6 +112,9 @@ jobs:
 
         # Ensure depot_tools does not update.
         test -d depot_tools && cd depot_tools
+        if [ "`uname`" = "Linux" ]; then
+          git apply --3way ../src/electron/.github/workflows/config/gclient.diff
+        fi
         touch .disable_auto_update
     - name: Add Depot Tools to PATH
       run: echo "$(pwd)/depot_tools" >> $GITHUB_PATH

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -70,6 +70,9 @@ jobs:
           sed -i '' '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
         else
           sed -i '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
+          # Remove swift-format dep from cipd on macOS until we send a patch upstream.
+          cd depot_tools
+          git apply --3way ../src/electron/.github/workflows/config/gclient.diff
         fi
         # Ensure depot_tools does not update.
         test -d depot_tools && cd depot_tools

--- a/.github/workflows/pipeline-segment-node-nan-test.yml
+++ b/.github/workflows/pipeline-segment-node-nan-test.yml
@@ -63,6 +63,8 @@ jobs:
       run: |
         git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
         sed -i '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
+        cd depot_tools
+        git apply --3way ../src/electron/.github/workflows/config/gclient.diff
         # Ensure depot_tools does not update.
         test -d depot_tools && cd depot_tools
         touch .disable_auto_update
@@ -125,6 +127,8 @@ jobs:
       run: |
         git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
         sed -i '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
+        cd depot_tools
+        git apply --3way ../src/electron/.github/workflows/config/gclient.diff
         # Ensure depot_tools does not update.
         test -d depot_tools && cd depot_tools
         touch .disable_auto_update


### PR DESCRIPTION
#### Description of Change

This PR reverts commit a0a8bd2222176cec3b4131100937ffda2cf4df7c, as it's still need it for publish.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
