### PR TITLE
build: add gn-check to x64 linux pipeline

### DIFF
--- a/.github/workflows/pipeline-electron-build-and-test-and-nan.yml
+++ b/.github/workflows/pipeline-electron-build-and-test-and-nan.yml
@@ -76,6 +76,15 @@ jobs:
       test-runs-on: ${{ inputs.test-runs-on }}
       test-container: ${{ inputs.test-container }}
     secrets: inherit
+  gn-check:
+    if: ${{ inputs.target-platform == 'macos' || inputs.target-arch != 'arm' }}
+    uses: ./.github/workflows/pipeline-segment-electron-gn-check.yml
+    with:
+      target-platform: ${{ inputs.target-platform }}
+      target-arch: ${{ inputs.target-arch }}
+      check-runs-on: ${{ inputs.build-runs-on }}
+      check-container: ${{ inputs.build-container }}
+      gn-build-type: ${{ inputs.gn-build-type }}
   nn-test:
     uses: ./.github/workflows/pipeline-segment-node-nan-test.yml
     needs: build

--- a/.github/workflows/pipeline-electron-build-and-test-and-nan.yml
+++ b/.github/workflows/pipeline-electron-build-and-test-and-nan.yml
@@ -85,6 +85,7 @@ jobs:
       check-runs-on: ${{ inputs.build-runs-on }}
       check-container: ${{ inputs.build-container }}
       gn-build-type: ${{ inputs.gn-build-type }}
+    secrets: inherit
   nn-test:
     uses: ./.github/workflows/pipeline-segment-node-nan-test.yml
     needs: build

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -42,12 +42,7 @@ jobs:
     # TODO(codebytere): Change this to medium VM
     runs-on: ${{ inputs.check-runs-on }}
     container: ${{ fromJSON(inputs.check-container) }}
-    strategy:
-      fail-fast: false
-      matrix:
-        build-type: ${{ inputs.target-platform == 'macos' && fromJSON('["darwin","mas"]') || fromJSON('["linux"]') }}
     env:
-      BUILD_TYPE: ${{ matrix.build-type }}
       TARGET_ARCH: ${{ inputs.target-arch }}
     steps:
     - name: Load Build Tools

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -31,6 +31,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  AZURE_AKS_CACHE_STORAGE_ACCOUNT: ${{ secrets.AZURE_AKS_CACHE_STORAGE_ACCOUNT }}
+  AZURE_AKS_CACHE_SHARE_NAME: ${{ secrets.AZURE_AKS_CACHE_SHARE_NAME }}
   ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
   GN_BUILDFLAG_ARGS: 'enable_precompiled_headers=false'
   GCLIENT_EXTRA_ARGS: ${{ inputs.target-platform == 'macos' && '--custom-var=checkout_mac=True --custom-var=host_os=mac' || '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True' }}


### PR DESCRIPTION
This mostly just adds the x64 gn check step. It also:
* Removes the build-type matrix from gn check (not needed)
* Adds required `AZURE_AKS_` env vars to gn-check so that macOS works again

Notes: none