### PR TITLE
build: fix GHA arm tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
       build-runs-on: aks-linux-large
       test-runs-on: aks-linux-arm-medium
       build-container: '{"image":"ghcr.io/electron/build:${{ inputs.build-image-sha }}","options":"--user root","volumes":["/mnt/cross-instance-cache:/mnt/cross-instance-cache"]}'
-      test-container: '{"image":"ghcr.io/electron/test:arm32v7-${{ inputs.build-image-sha }}","options":"--user root --privileged --init"}'
+      test-container: '{"image":"ghcr.io/electron/test:arm32v7-${{ inputs.build-image-sha }}","options":"--user root --privileged --init","volumes":["/home/runner/externals:/mnt/runner-externals"]}'
       target-platform: linux
       target-arch: arm
       is-release: false

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Lock
       if: ${{ inputs.target-arch == 'arm' }}
       run: |
-        touch /var/.ssh-lock
+        cp $(which node) /mnt/runner-externals/node20/bin/
     - name: Checkout Electron
       uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       with:

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -41,6 +41,10 @@ jobs:
       BUILD_TYPE: ${{ matrix.build-type }}
       TARGET_ARCH: ${{ inputs.target-arch }}
     steps:
+    - name: Lock
+      if: ${{ inputs.target-arch == 'arm' }}
+      run: |
+        touch /var/.ssh-lock
     - name: Checkout Electron
       uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       with:

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -41,7 +41,7 @@ jobs:
       BUILD_TYPE: ${{ matrix.build-type }}
       TARGET_ARCH: ${{ inputs.target-arch }}
     steps:
-    - name: Lock
+    - name: Fix node20 on arm32 runners
       if: ${{ inputs.target-arch == 'arm' }}
       run: |
         cp $(which node) /mnt/runner-externals/node20/bin/


### PR DESCRIPTION
This is kinda a bug in GitHub Actions itself, but it mounts a not-arm version of node20 on arm runners because it mounts based on host not based on container. For now we can just be kind and give actions _our_ node 20 which we know works 😆 This gets the linux CI green across the board

Notes: none