### PR TITLE
docs: leave shortcuts to another page

### DIFF
--- a/docs/api/accelerator.md
+++ b/docs/api/accelerator.md
@@ -11,9 +11,28 @@ Examples:
 * `CommandOrControl+A`
 * `CommandOrControl+Shift+Z`
 
-Shortcuts are registered with the [`globalShortcut`](global-shortcut.md) module
+```
+{
+  label: "menu text",
+  accelerator: "CommandOrControl+Z",
+}
+```
+
+```
+{
+  role: "undo",
+  accelerator: "CommandOrControl",
+  click: () => { do-something; }
+}
+```
+
+# Global Accelerator
+
+Accelerators [Shortcuts] that are registered with the [`globalShortcut`](global-shortcut.md) module
 using the [`register`](global-shortcut.md#globalshortcutregisteraccelerator-callback)
-method, i.e.
+method, are very powerful.
+
+Global Accelerators capture menu shortcuts from ALL ELECTRON APPS - Not just your Electron App.
 
 ```js
 const { app, globalShortcut } = require('electron')

--- a/docs/api/accelerator.md
+++ b/docs/api/accelerator.md
@@ -11,39 +11,9 @@ Examples:
 * `CommandOrControl+A`
 * `CommandOrControl+Shift+Z`
 
-```
-{
-  label: "menu text",
-  accelerator: "CommandOrControl+Z",
-}
-```
-
-```
-{
-  role: "undo",
-  accelerator: "CommandOrControl",
-  click: () => { do-something; }
-}
-```
-
-# Global Accelerator
-
-Accelerators [Shortcuts] that are registered with the [`globalShortcut`](global-shortcut.md) module
+Shortcuts can be registered with the [`globalShortcut`](global-shortcut.md) module
 using the [`register`](global-shortcut.md#globalshortcutregisteraccelerator-callback)
-method, are very powerful.
-
-Global Accelerators capture menu shortcuts from ALL ELECTRON APPS - Not just your Electron App.
-
-```js
-const { app, globalShortcut } = require('electron')
-
-app.whenReady().then(() => {
-  // Register a 'CommandOrControl+Y' shortcut listener.
-  globalShortcut.register('CommandOrControl+Y', () => {
-    // Do stuff when Y and either Command/Control is pressed.
-  })
-})
-```
+method
 
 ## Platform notice
 

--- a/docs/api/accelerator.md
+++ b/docs/api/accelerator.md
@@ -11,9 +11,7 @@ Examples:
 * `CommandOrControl+A`
 * `CommandOrControl+Shift+Z`
 
-Shortcuts can be registered with the [`globalShortcut`](global-shortcut.md) module
-using the [`register`](global-shortcut.md#globalshortcutregisteraccelerator-callback)
-method
+For responding to keyboard shortcuts, [see this documentation](https://www.electronjs.org/docs/latest/tutorial/keyboard-shortcuts#local-shortcuts)
 
 ## Platform notice
 


### PR DESCRIPTION
#### Description of Change

Replaced shortcut explanations on the Accelerator docs page with linkage to the shortcut documentation

#### Checklist

- [√] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes

Replaced shortcut explanations on the Accelerator docs page with linkage to the shortcut documentation
