### PR TITLE
chore: improve error message on failed SMApp register/unregister

### DIFF
--- a/shell/common/platform_util_mac.mm
+++ b/shell/common/platform_util_mac.mm
@@ -111,7 +111,7 @@ std::string GetLaunchStringForError(NSError* error) {
         return "The specified path doesn't exist or the helper tool at the "
                "specified path isn't valid";
       default:
-        return "Failed to register the login item";
+        return base::SysNSStringToUTF8([error localizedDescription]);
     }
   }
 


### PR DESCRIPTION
#### Description of Change

Seeing some failures in SMApp service setting in macOS tests - improve error output by logging the error's text even if it's not a recognized service management error. Before it basically logged a redundancy:

```
"Unable to set login item: Failed to register the login item"
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none