### PR TITLE
build: fix clang format location helper

### DIFF
--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -4,6 +4,7 @@ import contextlib
 import errno
 import json
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -184,13 +185,16 @@ def get_electron_exec():
 
 def get_buildtools_executable(name):
   buildtools = os.path.realpath(os.path.join(ELECTRON_DIR, '..', 'buildtools'))
-  chromium_platform = {
-    'darwin': 'mac',
-    'linux': 'linux64',
-    'linux2': 'linux64',
-    'win32': 'win',
-    'cygwin': 'win',
-  }[sys.platform]
+
+  if sys.platform == 'darwin':
+    chromium_platform = 'mac_arm64' if platform.machine() == 'arm64' else 'mac'
+  elif sys.platform in ['win32', 'cygwin']:
+    chromium_platform = 'win'
+  elif sys.platform in ['linux', 'linux2']:
+    chromium_platform = 'linux64'
+  else:
+    raise Exception(f"Unsupported platform: {sys.platform}")
+
   if name == 'clang-format':
     path = os.path.join(buildtools, chromium_platform, 'format', name)  
   else:


### PR DESCRIPTION
#### Description of Change

Fixes the following:

```
✖ python3 script/run-clang-format.py -r -c --fix:
run-clang-format.py: error: clang-format exited with code 127: 'shell/common/platform_util_mac.mm'
/bin/sh: /Users/codebytere/Developer/electron-gn/src/buildtools/mac/format/clang-format: No such file or directory
husky - pre-commit hook exited with code 1 (error)
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
