### PR TITLE
build: disable GitHub Actions in 32-x-y

### DIFF
--- a/script/release/ci-release-build.js
+++ b/script/release/ci-release-build.js
@@ -385,6 +385,7 @@ function buildCircleCI (targetBranch, options) {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function buildGHActions (targetBranch, options) {
   if (options.job) {
     assert(ghActionsPublishWorkflows.includes(options.job), `Unknown GitHub Actions workflow name: ${options.job}. Valid values are: ${ghActionsPublishWorkflows}.`);
@@ -405,10 +406,10 @@ function runRelease (targetBranch, options) {
         buildCircleCI(targetBranch, options);
         break;
       }
-      case 'GitHubActions': {
-        buildGHActions(targetBranch, options);
-        break;
-      }
+      // case 'GitHubActions': {
+      //   buildGHActions(targetBranch, options);
+      //   break;
+      // }
       case 'AppVeyor': {
         buildAppVeyor(targetBranch, options);
         break;
@@ -421,7 +422,7 @@ function runRelease (targetBranch, options) {
   } else {
     buildCircleCI(targetBranch, options);
     buildAppVeyor(targetBranch, options);
-    buildGHActions(targetBranch, options);
+    // buildGHActions(targetBranch, options);
   }
   console.log(`${jobRequestedCount} jobs were requested.`);
 }


### PR DESCRIPTION
#### Description of Change

The 32-x-y branch point happened during the GitHub Actions migration - some of the work merged into main was included, but there have been several changes made in main that have not yet been backported. This PR disables GitHub Actions in 32-x-y until we have a chance to backport the additional changes.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
