### PR TITLE
ci: auto close non-maintainer PRs that touch lockfiles

### DIFF
--- a/.github/workflows/auto-close-pull-request.yml
+++ b/.github/workflows/auto-close-pull-request.yml
@@ -1,0 +1,24 @@
+name: Auto Close Pull Request
+
+on:
+  pull_request_target:
+    paths:
+      - 'yarn.lock'
+      - 'spec/yarn.lock'
+
+permissions: {}
+
+jobs:
+  auto-close-dependency-pull-request:
+    name: Auto close non-maintainer dependency pull request
+    if: ${{ !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association) && github.event.pull_request.user.type != 'Bot' && !github.event.pull_request.draft }}
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr close $PR_URL --comment 'Hello @${{ github.event.pull_request.user.login }}! It looks like this pull request touches one of our dependency files, and per [our contribution policy](https://github.com/electron/electron/blob/main/CONTRIBUTING.md#dependencies-upgrades-policy) we do not accept these types of PRs, so this PR will be closed.'


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Some automation to close non-maintainer PRs that touch lockfiles, per [our contribution policy](https://github.com/electron/electron/blob/main/CONTRIBUTING.md#dependencies-upgrades-policy).

Carves out exclusions for bot PRs (to allow for Dependabot) and draft PRs (which our policy says we allow in certain circumstances).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
