### PR TITLE
fix: MessagePort closing unexpectedly with non-cloneable objects

### DIFF
--- a/shell/browser/api/message_port.cc
+++ b/shell/browser/api/message_port.cc
@@ -76,8 +76,11 @@ void MessagePort::PostMessage(gin::Arguments* args) {
     return;
   }
 
-  electron::SerializeV8Value(args->isolate(), message_value,
-                             &transferable_message);
+  if (!electron::SerializeV8Value(args->isolate(), message_value,
+                                  &transferable_message)) {
+    // SerializeV8Value sets an exception.
+    return;
+  }
 
   v8::Local<v8::Value> transferables;
   std::vector<gin::Handle<MessagePort>> wrapped_ports;

--- a/shell/services/node/parent_port.cc
+++ b/shell/services/node/parent_port.cc
@@ -44,7 +44,13 @@ void ParentPort::PostMessage(v8::Local<v8::Value> message_value) {
   if (!connector_closed_ && connector_ && connector_->is_valid()) {
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
     blink::TransferableMessage transferable_message;
-    electron::SerializeV8Value(isolate, message_value, &transferable_message);
+
+    if (!electron::SerializeV8Value(isolate, message_value,
+                                    &transferable_message)) {
+      // SerializeV8Value sets an exception.
+      return;
+    }
+
     mojo::Message mojo_message =
         blink::mojom::TransferableMessage::WrapAsMessage(
             std::move(transferable_message));

--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -297,6 +297,17 @@ describe('utilityProcess module', () => {
       expect(child.kill()).to.be.true();
       await exit;
     });
+
+    it('handles the parent port trying to send an non-clonable object', async () => {
+      const child = utilityProcess.fork(path.join(fixturesPath, 'non-cloneable.js'));
+      await once(child, 'spawn');
+      child.postMessage('non-cloneable');
+      const [data] = await once(child, 'message');
+      expect(data).to.equal('caught-non-cloneable');
+      const exit = once(child, 'exit');
+      expect(child.kill()).to.be.true();
+      await exit;
+    });
   });
 
   describe('behavior', () => {

--- a/spec/fixtures/api/utility-process/non-cloneable.js
+++ b/spec/fixtures/api/utility-process/non-cloneable.js
@@ -1,0 +1,11 @@
+const nonClonableObject = () => {};
+
+process.parentPort.on('message', () => {
+  try {
+    process.parentPort.postMessage(nonClonableObject);
+  } catch (error) {
+    if (/An object could not be cloned/.test(error.message)) {
+      process.parentPort.postMessage('caught-non-cloneable');
+    }
+  }
+});


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42373. 

We need to return early if `electron::SerializeV8Value`, as that means an exception has occurred and should be surfaced to the user.

Takes the same approach as similar apis:
- https://github.com/electron/electron/blob/7f3dc7d4ceab7c33656ccb204a9bb7eb06821559/shell/browser/api/electron_api_utility_process.cc#L298-L302
- https://github.com/electron/electron/blob/1bfd3e0631a00a4940d7ce89bebb515ad7e519ca/shell/browser/api/electron_api_web_frame_main.cc#L244-L248

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where MessagePorts could close unexpectedly with non-cloneable objects sent via `postMessage`.