### PR TITLE
test: use longer timeout on contentTracing tests on WOA

### DIFF
--- a/spec/api-content-tracing-spec.ts
+++ b/spec/api-content-tracing-spec.ts
@@ -25,7 +25,12 @@ ifdescribe(!(['arm', 'arm64'].includes(process.arch)) || (process.platform !== '
   });
 
   describe('startRecording', function () {
-    this.timeout(5e3);
+    if (process.platform === 'win32' && process.arch === 'arm64') {
+      // WOA needs more time
+      this.timeout(10e3);
+    } else {
+      this.timeout(5e3);
+    }
 
     const getFileSizeInKiloBytes = (filePath: string) => {
       const stats = fs.statSync(filePath);
@@ -84,7 +89,12 @@ ifdescribe(!(['arm', 'arm64'].includes(process.arch)) || (process.platform !== '
   });
 
   describe('stopRecording', function () {
-    this.timeout(5e3);
+    if (process.platform === 'win32' && process.arch === 'arm64') {
+      // WOA needs more time
+      this.timeout(10e3);
+    } else {
+      this.timeout(5e3);
+    }
 
     it('does not crash on empty string', async () => {
       const options = {


### PR DESCRIPTION
#### Description of Change
The contentTracing tests have been timing out in WOA more frequently leading to significant flaky runs.  This PR updates the timeout on those tests to resolve that flakiness.


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
