### PR TITLE
docs: fix typo in ASAR integrity docs

### DIFF
--- a/docs/tutorial/asar-integrity.md
+++ b/docs/tutorial/asar-integrity.md
@@ -125,7 +125,7 @@ in the form included below:
 ]
 ```
 
-::: info
+:::info
 
 For an implementation example, see [`src/resedit.ts`](https://github.com/electron/packager/blob/main/src/resedit.ts)
 in the Electron Packager code.


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

This PR fixes a small typo that causes a rendering issue on the ASAR integrity page:

![image](https://github.com/electron/electron/assets/9100169/992dcbcb-84d7-4ded-9c86-191172ac5d5c)


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
