### PR TITLE
build: Add ASan Linux build to Actions build/test

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -23,6 +23,9 @@ inputs:
   upload-to-storage:
     description: 'Upload to storage'
     required: true
+  is-asan:
+    description: 'The ASan Linux build'
+    required: false
 runs:
   using: "composite"
   steps:
@@ -56,7 +59,7 @@ runs:
       run: |
         cd src
         e build electron:electron_dist_zip -j $NUMBER_OF_NINJA_PROCESSES
-        if [ "${{ env.CHECK_DIST_MANIFEST }}" = "true" ]; then
+        if [ "${{ inputs.is-asan }}" != "true" ]; then
           target_os=${{ inputs.target-platform == 'linux' && 'linux' || 'mac'}}
           if [ "${{ inputs.artifact-platform }}" = "mas" ]; then
             target_os="${target_os}_mas"

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -184,6 +184,15 @@ runs:
           echo 'Uploading Electron release distribution to GitHub releases'
           script/release/uploaders/upload.py --verbose
         fi
+    - name: Generate Artifact Key
+      shell: bash
+      run: |
+        if [ "${{ inputs.is-asan }}" = "true" ]; then 
+          ARTIFACT_KEY=${{ matrix.build-type }}_${{ inputs.target-arch }}_${{ inputs.is-asan }}
+        else
+          ARTIFACT_KEY=${{ matrix.build-type }}_${{ inputs.target-arch }}
+        fi
+        echo "ARTIFACT_KEY=$ARTIFACT_KEY" >> $GITHUB_ENV
     # The current generated_artifacts_<< artifact.key >> name was taken from CircleCI
     # to ensure we don't break anything, but we may be able to improve that.
     - name: Move all Generated Artifacts to Upload Folder ${{ inputs.step-suffix }}
@@ -192,8 +201,8 @@ runs:
     - name: Upload Generated Artifacts ${{ inputs.step-suffix }}
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
       with:
-        name: generated_artifacts_${{ inputs.artifact-platform }}_${{ env.TARGET_ARCH }}
-        path: ./generated_artifacts_${{ inputs.artifact-platform }}_${{ env.TARGET_ARCH }}
+        name: generated_artifacts_${{ env.$ARTIFACT_KEY }}
+        path: ./generated_artifacts_${{ env.$ARTIFACT_KEY }}
     - name: Upload Src Artifacts ${{ inputs.step-suffix }}
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
       with:

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -188,9 +188,9 @@ runs:
       shell: bash
       run: |
         if [ "${{ inputs.is-asan }}" = "true" ]; then 
-          ARTIFACT_KEY=${{ matrix.build-type }}_${{ inputs.target-arch }}_${{ inputs.is-asan }}
+          ARTIFACT_KEY=${{ inputs.artifact-platform }}_${{ env.TARGET_ARCH }}_${{ inputs.is-asan }}
         else
-          ARTIFACT_KEY=${{ matrix.build-type }}_${{ inputs.target-arch }}
+          ARTIFACT_KEY=${{ inputs.artifact-platform }}_${{ env.TARGET_ARCH }}
         fi
         echo "ARTIFACT_KEY=$ARTIFACT_KEY" >> $GITHUB_ENV
     # The current generated_artifacts_<< artifact.key >> name was taken from CircleCI
@@ -201,10 +201,10 @@ runs:
     - name: Upload Generated Artifacts ${{ inputs.step-suffix }}
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
       with:
-        name: generated_artifacts_${{ env.$ARTIFACT_KEY }}
-        path: ./generated_artifacts_${{ env.$ARTIFACT_KEY }}
+        name: generated_artifacts_${{ env.ARTIFACT_KEY }}
+        path: ./generated_artifacts_${{ env.ARTIFACT_KEY }}
     - name: Upload Src Artifacts ${{ inputs.step-suffix }}
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
       with:
-        name: src_artifacts_${{ inputs.artifact-platform }}_${{ env.TARGET_ARCH }}
-        path: ./src_artifacts_${{ inputs.artifact-platform }}_${{ env.TARGET_ARCH }}
+        name: src_artifacts_${{ env.ARTIFACT_KEY }}
+        path: ./src_artifacts_${{ env.ARTIFACT_KEY }}

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -188,7 +188,7 @@ runs:
       shell: bash
       run: |
         if [ "${{ inputs.is-asan }}" = "true" ]; then 
-          ARTIFACT_KEY=${{ inputs.artifact-platform }}_${{ env.TARGET_ARCH }}_${{ inputs.is-asan }}
+          ARTIFACT_KEY=${{ inputs.artifact-platform }}_${{ env.TARGET_ARCH }}_asan
         else
           ARTIFACT_KEY=${{ inputs.artifact-platform }}_${{ env.TARGET_ARCH }}
         fi
@@ -202,9 +202,9 @@ runs:
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
       with:
         name: generated_artifacts_${{ env.ARTIFACT_KEY }}
-        path: ./generated_artifacts_${{ env.ARTIFACT_KEY }}
+        path: ./generated_artifacts_${{ inputs.artifact-platform }}_${{ env.TARGET_ARCH }}
     - name: Upload Src Artifacts ${{ inputs.step-suffix }}
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
       with:
         name: src_artifacts_${{ env.ARTIFACT_KEY }}
-        path: ./src_artifacts_${{ env.ARTIFACT_KEY }}
+        path: ./src_artifacts_${{ inputs.artifact-platform }}_${{ env.TARGET_ARCH }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,6 +163,23 @@ jobs:
       generate-symbols: false
       upload-to-storage: '0'
     secrets: inherit
+
+  linux-x64-asan:
+    uses: ./.github/workflows/pipeline-electron-build-and-test.yml
+    needs: checkout-linux
+    with:
+      build-runs-on: aks-linux-large
+      test-runs-on: aks-linux-medium
+      build-container: '{"image":"ghcr.io/electron/build:${{ inputs.build-image-sha }}","options":"--user root","volumes":["/mnt/cross-instance-cache:/mnt/cross-instance-cache"]}'
+      test-container: '{"image":"ghcr.io/electron/build:${{ inputs.build-image-sha }}","options":"--user root --privileged --init"}'
+      target-platform: linux
+      target-arch: x64
+      is-release: false
+      gn-build-type: testing
+      generate-symbols: false
+      upload-to-storage: '0'
+      is-asan: true
+    secrets: inherit
   
   linux-arm:
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,6 +165,10 @@ jobs:
     secrets: inherit
 
   linux-x64-asan:
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-test.yml
     needs: checkout-linux
     with:

--- a/.github/workflows/pipeline-electron-build-and-test-and-nan.yml
+++ b/.github/workflows/pipeline-electron-build-and-test-and-nan.yml
@@ -49,6 +49,11 @@ on:
         required: true
         type: string
         default: '0'
+      is-asan: 
+        description: 'Building the Address Sanitizer (ASan) Linux build'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: electron-build-and-test-and-nan-${{ inputs.target-platform }}-${{ inputs.target-arch }}-${{ github.ref }}
@@ -75,6 +80,7 @@ jobs:
       check-runs-on: ${{ inputs.build-runs-on }}
       check-container: ${{ inputs.build-container }}
       gn-build-type: ${{ inputs.gn-build-type }}
+      is-asan: ${{ inputs.is-asan }}
     secrets: inherit
   test:
     uses: ./.github/workflows/pipeline-segment-electron-test.yml

--- a/.github/workflows/pipeline-electron-build-and-test.yml
+++ b/.github/workflows/pipeline-electron-build-and-test.yml
@@ -49,6 +49,11 @@ on:
         required: true
         type: string
         default: '0'
+      is-asan: 
+        description: 'Building the Address Sanitizer (ASan) Linux build'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: electron-build-and-test-${{ inputs.target-platform }}-${{ inputs.target-arch }}-${{ github.ref }}
@@ -71,6 +76,7 @@ jobs:
       gn-build-type: ${{ inputs.gn-build-type }}
       generate-symbols: ${{ inputs.generate-symbols }}
       upload-to-storage: ${{ inputs.upload-to-storage }}
+      is-asan: ${{ inputs.is-asan}}
     secrets: inherit
   gn-check:
     uses: ./.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -89,4 +95,5 @@ jobs:
       target-platform: ${{ inputs.target-platform }}
       test-runs-on: ${{ inputs.test-runs-on }}
       test-container: ${{ inputs.test-container }}
+      is-asan: ${{ inputs.is-asan}}
     secrets: inherit

--- a/.github/workflows/pipeline-electron-build-and-test.yml
+++ b/.github/workflows/pipeline-electron-build-and-test.yml
@@ -86,6 +86,7 @@ jobs:
       check-runs-on: ${{ inputs.build-runs-on }}
       check-container: ${{ inputs.build-container }}
       gn-build-type: ${{ inputs.gn-build-type }}
+      is-asan: ${{ inputs.is-asan }}
     secrets: inherit
   test:
     uses: ./.github/workflows/pipeline-segment-electron-test.yml

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -190,6 +190,7 @@ jobs:
         is-release: '${{ inputs.is-release }}'
         generate-symbols: '${{ inputs.generate-symbols }}'
         upload-to-storage: '${{ inputs.upload-to-storage }}'
+        is-asan: '${{ inputs.is-asan }}'
     - name: Set GN_EXTRA_ARGS for MAS Build
       if: ${{ inputs.target-platform == 'macos' }}
       run: |

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -66,7 +66,6 @@ env:
   CHECK_DIST_MANIFEST: true
   IS_GHA_RELEASE: true
   ELECTRON_OUT_DIR: Default
-  IS_ASAN: ${{ inputs.is-asan }}
 
 jobs:
   build:

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -52,7 +52,7 @@ on:
 
 
 concurrency:
-  group: electron-build-${{ inputs.target-platform }}-${{ inputs.target-arch }}-${{ github.ref }}
+  group: electron-build-${{ inputs.target-platform }}-${{ inputs.target-arch }}-${{ inputs.is-asan }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !endsWith(github.ref, '-x-y') }}
 
 env:

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -44,6 +44,11 @@ on:
         required: true
         type: string
         default: '0'
+      is-asan: 
+        description: 'Building the Address Sanitizer (ASan) Linux build'
+        required: false
+        type: boolean
+        default: false
 
 
 concurrency:
@@ -61,6 +66,7 @@ env:
   CHECK_DIST_MANIFEST: true
   IS_GHA_RELEASE: true
   ELECTRON_OUT_DIR: Default
+  IS_ASAN: ${{ inputs.is-asan }}
 
 jobs:
   build:
@@ -102,6 +108,8 @@ jobs:
           fi
         elif [ "${{ inputs.target-arch }}" = "arm64" ]; then
           GN_EXTRA_ARGS='target_cpu="arm64" fatal_linker_warnings=false enable_linux_installer=false'
+        elif [ "${{ inputs.is-asan }}" = true ]; then
+          GN_EXTRA_ARGS='is_asan=true'
         fi
         echo "GN_EXTRA_ARGS=$GN_EXTRA_ARGS" >> $GITHUB_ENV
     - name: Get Depot Tools

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -25,9 +25,14 @@ on:
         required: true
         type: string
         default: testing
+      is-asan: 
+        description: 'Building the Address Sanitizer (ASan) Linux build'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
-  group: electron-gn-check-${{ inputs.target-platform }}-${{ inputs.target-arch }}-${{ github.ref }}
+  group: electron-gn-check-${{ inputs.target-platform }}-${{ inputs.target-arch }}-${{ inputs.is-asan }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -20,6 +20,11 @@ on:
         description: 'JSON container information for aks runs-on'
         required: false
         default: '{"image":null}'
+      is-asan: 
+        description: 'Building the Address Sanitizer (ASan) Linux build'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: electron-test-${{ inputs.target-platform }}-${{ inputs.target-arch }}-${{ github.ref }}
@@ -34,6 +39,7 @@ env:
   ELECTRON_OUT_DIR: Default
   ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
   ELECTRON_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  IS_ASAN: ${{ inputs.is-asan }}
 
 jobs:
   test:
@@ -159,7 +165,21 @@ jobs:
           chown -R :builduser . && chmod -R g+w .
           chmod 4755 ../out/Default/chrome-sandbox
           runuser -u builduser -- git config --global --add safe.directory $(pwd)
-          runuser -u builduser -- xvfb-run script/actions/run-tests.sh script/yarn test --runners=main --trace-uncaught --enable-logging --files $tests_files
+          if [ "$IS_ASAN" == "true" ]; then
+            cd ..
+            ASAN_SYMBOLIZE="$PWD/tools/valgrind/asan/asan_symbolize.py --executable-path=$PWD/out/Default/electron"
+            export ASAN_OPTIONS="symbolize=0 handle_abort=1"
+            export G_SLICE=always-malloc
+            export NSS_DISABLE_ARENA_FREE_LIST=1
+            export NSS_DISABLE_UNLOAD=1
+            export LLVM_SYMBOLIZER_PATH=$PWD/third_party/llvm-build/Release+Asserts/bin/llvm-symbolizer
+            export MOCHA_TIMEOUT=180000
+            echo "Piping output to ASAN_SYMBOLIZE ($ASAN_SYMBOLIZE)"
+            cd electron
+            runuser -u builduser -- xvfb-run script/actions/run-tests.sh script/yarn test --runners=main --trace-uncaught --enable-logging --files $tests_files | $ASAN_SYMBOLIZE
+          else
+            runuser -u builduser -- xvfb-run script/actions/run-tests.sh script/yarn test --runners=main --trace-uncaught --enable-logging --files $tests_files
+          fi
         fi
     - name: Wait for active SSH sessions
       if: always() && !cancelled()

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -181,6 +181,24 @@ jobs:
             runuser -u builduser -- xvfb-run script/actions/run-tests.sh script/yarn test --runners=main --trace-uncaught --enable-logging --files $tests_files
           fi
         fi
+    - name: Verify mksnapshot
+      shell: bash
+      run: |
+        if [ "$IS_ASAN" != "true" ]; then
+          cd src
+          if [ "`uname`" != "Darwin" ] && ([ "$TARGET_ARCH" == "arm" ] || [ "$TARGET_ARCH" == "arm64" ]); then
+            python3 electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default --snapshot-files-dir $PWD/cross-arch-snapshots
+          else
+            python3 electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default
+          fi
+        fi
+    - name: Verify ChromeDriver
+      shell: bash
+      run: |
+        if [ "$IS_ASAN" != "true" ]; then
+          cd src
+          python3 electron/script/verify-chromedriver.py --source-root "$PWD" --build-dir out/Default
+        fi
     - name: Wait for active SSH sessions
       if: always() && !cancelled()
       run: |

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -131,8 +131,8 @@ jobs:
     - name: Download Src Artifacts
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:
-        name: src_artifacts_${{ matrix.build-type }}_${{ env.TARGET_ARCH }}
-        path: ./src_artifacts_${{ matrix.build-type }}_${{ env.TARGET_ARCH }}
+        name: src_artifacts_${{ env.ARTIFACT_KEY }}
+        path: ./src_artifacts_${{ env.ARTIFACT_KEY }}
     - name: Restore Generated Artifacts
       run: ./src/electron/script/actions/restore-artifacts.sh
     - name: Unzip Dist, Mksnapshot & Chromedriver

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -27,7 +27,7 @@ on:
         default: false
 
 concurrency:
-  group: electron-test-${{ inputs.target-platform }}-${{ inputs.target-arch }}-${{ github.ref }}
+  group: electron-test-${{ inputs.target-platform }}-${{ inputs.target-arch }}-${{ inputs.is-asan }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !endsWith(github.ref, '-x-y') }}
 
 permissions:

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -52,6 +52,7 @@ jobs:
     env:
       BUILD_TYPE: ${{ matrix.build-type }}
       TARGET_ARCH: ${{ inputs.target-arch }}
+      ARTIFACT_KEY: ${{ matrix.build-type }}_${{ inputs.target-arch }}
     steps:
     - name: Fix node20 on arm32 runners
       if: ${{ inputs.target-arch == 'arm' }}
@@ -117,11 +118,16 @@ jobs:
         touch .disable_auto_update
     - name: Add Depot Tools to PATH
       run: echo "$(pwd)/depot_tools" >> $GITHUB_PATH
+    - name: Generate ASan Artifact Key
+      if: ${{ inputs.is-asan == true }}
+      run: |
+        ARTIFACT_KEY=${{ matrix.build-type }}_${{ inputs.target-arch }}_${{ inputs.is-asan }}
+        echo "ARTIFACT_KEY=$ARTIFACT_KEY" >> $GITHUB_ENV
     - name: Download Generated Artifacts
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:
-        name: generated_artifacts_${{ matrix.build-type }}_${{ inputs.target-arch }}
-        path: ./generated_artifacts_${{ matrix.build-type }}_${{ inputs.target-arch }}
+        name: generated_artifacts_${{ env.ARTIFACT_KEY }}
+        path: ./generated_artifacts_${{ env.ARTIFACT_KEY }}
     - name: Download Src Artifacts
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -121,18 +121,18 @@ jobs:
     - name: Generate ASan Artifact Key
       if: ${{ inputs.is-asan == true }}
       run: |
-        ARTIFACT_KEY=${{ matrix.build-type }}_${{ inputs.target-arch }}_${{ inputs.is-asan }}
+        ARTIFACT_KEY=${{ matrix.build-type }}_${{ inputs.target-arch }}_asan
         echo "ARTIFACT_KEY=$ARTIFACT_KEY" >> $GITHUB_ENV
     - name: Download Generated Artifacts
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:
         name: generated_artifacts_${{ env.ARTIFACT_KEY }}
-        path: ./generated_artifacts_${{ env.ARTIFACT_KEY }}
+        path: ./generated_artifacts_${{ matrix.build-type }}_${{ inputs.target-arch }}
     - name: Download Src Artifacts
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:
         name: src_artifacts_${{ env.ARTIFACT_KEY }}
-        path: ./src_artifacts_${{ env.ARTIFACT_KEY }}
+        path: ./src_artifacts_${{ matrix.build-type }}_${{ inputs.target-arch }}
     - name: Restore Generated Artifacts
       run: ./src/electron/script/actions/restore-artifacts.sh
     - name: Unzip Dist, Mksnapshot & Chromedriver

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -118,11 +118,12 @@ jobs:
         touch .disable_auto_update
     - name: Add Depot Tools to PATH
       run: echo "$(pwd)/depot_tools" >> $GITHUB_PATH
-    - name: Generate ASan Artifact Key
+    - name: Load ASan specific environment variables
       if: ${{ inputs.is-asan == true }}
       run: |
-        ARTIFACT_KEY=${{ matrix.build-type }}_${{ inputs.target-arch }}_asan
-        echo "ARTIFACT_KEY=$ARTIFACT_KEY" >> $GITHUB_ENV
+        echo "ARTIFACT_KEY=${{ matrix.build-type }}_${{ inputs.target-arch }}_asan" >> $GITHUB_ENV
+        echo "DISABLE_CRASH_REPORTER_TESTS=true" >> $GITHUB_ENV
+        echo "IS_ASAN=true" >> $GITHUB_ENV
     - name: Download Generated Artifacts
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -39,7 +39,6 @@ env:
   ELECTRON_OUT_DIR: Default
   ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
   ELECTRON_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  IS_ASAN: ${{ inputs.is-asan }}
 
 jobs:
   test:

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -183,7 +183,7 @@ jobs:
     - name: Verify mksnapshot
       shell: bash
       run: |
-        if [ "${{ inputs.is-asan }}" == "true" ]; then
+        if [ "${{ inputs.is-asan }}" != "true" ]; then
           cd src
           if [ "`uname`" != "Darwin" ] && ([ "$TARGET_ARCH" == "arm" ] || [ "$TARGET_ARCH" == "arm64" ]); then
             python3 electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default --snapshot-files-dir $PWD/cross-arch-snapshots
@@ -194,7 +194,7 @@ jobs:
     - name: Verify ChromeDriver
       shell: bash
       run: |
-        if [ "${{ inputs.is-asan }}" == "true" ]; then
+        if [ "${{ inputs.is-asan }}" != "true" ]; then
           cd src
           python3 electron/script/verify-chromedriver.py --source-root "$PWD" --build-dir out/Default
         fi

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -165,7 +165,7 @@ jobs:
           chown -R :builduser . && chmod -R g+w .
           chmod 4755 ../out/Default/chrome-sandbox
           runuser -u builduser -- git config --global --add safe.directory $(pwd)
-          if [ "$IS_ASAN" == "true" ]; then
+          if [ "${{ inputs.is-asan }}" == "true" ]; then
             cd ..
             ASAN_SYMBOLIZE="$PWD/tools/valgrind/asan/asan_symbolize.py --executable-path=$PWD/out/Default/electron"
             export ASAN_OPTIONS="symbolize=0 handle_abort=1"
@@ -184,7 +184,7 @@ jobs:
     - name: Verify mksnapshot
       shell: bash
       run: |
-        if [ "$IS_ASAN" != "true" ]; then
+        if [ "${{ inputs.is-asan }}" == "true" ]; then
           cd src
           if [ "`uname`" != "Darwin" ] && ([ "$TARGET_ARCH" == "arm" ] || [ "$TARGET_ARCH" == "arm64" ]); then
             python3 electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default --snapshot-files-dir $PWD/cross-arch-snapshots
@@ -195,7 +195,7 @@ jobs:
     - name: Verify ChromeDriver
       shell: bash
       run: |
-        if [ "$IS_ASAN" != "true" ]; then
+        if [ "${{ inputs.is-asan }}" == "true" ]; then
           cd src
           python3 electron/script/verify-chromedriver.py --source-root "$PWD" --build-dir out/Default
         fi

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -180,24 +180,6 @@ jobs:
             runuser -u builduser -- xvfb-run script/actions/run-tests.sh script/yarn test --runners=main --trace-uncaught --enable-logging --files $tests_files
           fi
         fi
-    - name: Verify mksnapshot
-      shell: bash
-      run: |
-        if [ "${{ inputs.is-asan }}" != "true" ]; then
-          cd src
-          if [ "`uname`" != "Darwin" ] && ([ "$TARGET_ARCH" == "arm" ] || [ "$TARGET_ARCH" == "arm64" ]); then
-            python3 electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default --snapshot-files-dir $PWD/cross-arch-snapshots
-          else
-            python3 electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default
-          fi
-        fi
-    - name: Verify ChromeDriver
-      shell: bash
-      run: |
-        if [ "${{ inputs.is-asan }}" != "true" ]; then
-          cd src
-          python3 electron/script/verify-chromedriver.py --source-root "$PWD" --build-dir out/Default
-        fi
     - name: Wait for active SSH sessions
       if: always() && !cancelled()
       run: |


### PR DESCRIPTION
#### Description of Change

This PR adds the Linux Address Sanitized (ASan) build to GitHub Actions. It also adds a verify check for mksnapshot and chromedriver to all builds outside of the ASan build.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
