### PR TITLE
build: clean up src artifacts when green

### DIFF
--- a/.github/workflows/pipeline-electron-build-and-test-and-nan.yml
+++ b/.github/workflows/pipeline-electron-build-and-test-and-nan.yml
@@ -95,3 +95,11 @@ jobs:
       test-container: ${{ inputs.test-container }}
       gn-build-type: ${{ inputs.gn-build-type }}
     secrets: inherit
+  clean:
+    uses: ./.github/workflows/pipeline-segment-electron-clean.yml
+    needs:
+      - test
+      - nn-test
+    with:
+      target-arch: ${{ inputs.target-arch }}
+      target-platform: ${{ inputs.target-platform }}

--- a/.github/workflows/pipeline-electron-build-and-test.yml
+++ b/.github/workflows/pipeline-electron-build-and-test.yml
@@ -90,3 +90,9 @@ jobs:
       test-runs-on: ${{ inputs.test-runs-on }}
       test-container: ${{ inputs.test-container }}
     secrets: inherit
+  clean:
+    uses: ./.github/workflows/pipeline-segment-electron-clean.yml
+    needs: test
+    with:
+      target-arch: ${{ inputs.target-arch }}
+      target-platform: ${{ inputs.target-platform }}

--- a/.github/workflows/pipeline-segment-electron-clean.yml
+++ b/.github/workflows/pipeline-segment-electron-clean.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !endsWith(github.ref, '-x-y') }}
 
 jobs:
-  test:
+  clean:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/pipeline-segment-electron-clean.yml
+++ b/.github/workflows/pipeline-segment-electron-clean.yml
@@ -1,0 +1,30 @@
+name: Pipeline Segment - Electron Clean
+
+on:
+  workflow_call:
+    inputs:
+      target-platform:
+        type: string
+        description: 'Platform to run on, can be macos or linux'
+        required: true
+      target-arch:
+        type: string
+        description: 'Arch to build for, can be x64, arm64 or arm'
+        required: true
+
+concurrency:
+  group: electron-clean-${{ inputs.target-platform }}-${{ inputs.target-arch }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !endsWith(github.ref, '-x-y') }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: ${{ inputs.target-platform == 'macos' && fromJSON('["darwin","mas"]') || fromJSON('["linux"]') }}
+    steps:
+    - uses: geekyeggo/delete-artifact@v5
+      with:
+        name: src_artifacts_${{ matrix.build-type }}_${{ inputs.target-arch }}
+        failOnError: false


### PR DESCRIPTION
This is an interesting trick where we can delete the `src_articacts` cache after we're done with it (all tests have passed). Should save some space + $$$ + make the build output page easier to read. Need to pin the action before landing

Notes: none