### PR TITLE
chore: add/fix interface comments for sections of methods

### DIFF
--- a/shell/app/electron_main_delegate.h
+++ b/shell/app/electron_main_delegate.h
@@ -30,10 +30,9 @@ class ElectronMainDelegate : public content::ContentMainDelegate {
   ElectronMainDelegate(const ElectronMainDelegate&) = delete;
   ElectronMainDelegate& operator=(const ElectronMainDelegate&) = delete;
 
-  base::StringPiece GetBrowserV8SnapshotFilename() override;
-
  protected:
   // content::ContentMainDelegate:
+  base::StringPiece GetBrowserV8SnapshotFilename() override;
   std::optional<int> BasicStartupComplete() override;
   void PreSandboxStartup() override;
   void SandboxInitialized(const std::string& process_type) override;

--- a/shell/browser/api/electron_api_auto_updater.h
+++ b/shell/browser/api/electron_api_auto_updater.h
@@ -36,7 +36,7 @@ class AutoUpdater : public gin::Wrappable<AutoUpdater>,
   AutoUpdater();
   ~AutoUpdater() override;
 
-  // Delegate implementations.
+  // auto_updater::Delegate:
   void OnError(const std::string& message) override;
   void OnError(const std::string& message,
                const int code,

--- a/shell/browser/api/electron_api_menu_mac.h
+++ b/shell/browser/api/electron_api_menu_mac.h
@@ -18,6 +18,7 @@ class MenuMac : public Menu {
   explicit MenuMac(gin::Arguments* args);
   ~MenuMac() override;
 
+  // Menu
   void PopupAt(BaseWindow* window,
                int x,
                int y,

--- a/shell/browser/api/electron_api_menu_views.h
+++ b/shell/browser/api/electron_api_menu_views.h
@@ -21,6 +21,7 @@ class MenuViews : public Menu {
   ~MenuViews() override;
 
  protected:
+  // Menu
   void PopupAt(BaseWindow* window,
                int x,
                int y,

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -155,6 +155,7 @@ class JSLayoutManager : public views::LayoutManagerBase {
       : layout_callback_(std::move(layout_callback)) {}
   ~JSLayoutManager() override {}
 
+  // views::LayoutManagerBase
   views::ProposedLayout CalculateProposedLayout(
       const views::SizeBounds& size_bounds) const override {
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -170,7 +170,9 @@ class WebContents : public ExclusiveAccessContext,
   void Close(std::optional<gin_helper::Dictionary> options);
   base::WeakPtr<WebContents> GetWeakPtr() { return weak_factory_.GetWeakPtr(); }
 
+  // BackgroundThrottlingSource
   bool GetBackgroundThrottling() const override;
+
   void SetBackgroundThrottling(bool allowed);
   int GetProcessID() const;
   base::ProcessId GetOSProcessID() const;
@@ -345,6 +347,7 @@ class WebContents : public ExclusiveAccessContext,
                                           const base::FilePath& file_path);
   v8::Local<v8::Promise> GetProcessMemoryInfo(v8::Isolate* isolate);
 
+  // content::WebContentsDelegate:
   bool HandleContextMenu(content::RenderFrameHost& render_frame_host,
                          const content::ContextMenuParams& params) override;
 

--- a/shell/browser/api/frame_subscriber.h
+++ b/shell/browser/api/frame_subscriber.h
@@ -46,11 +46,12 @@ class FrameSubscriber : private content::WebContentsObserver,
   void AttachToHost(content::RenderWidgetHost* host);
   void DetachFromHost();
 
+  // content::WebContentsObserver
   void RenderFrameCreated(content::RenderFrameHost* render_frame_host) override;
   void PrimaryPageChanged(content::Page& page) override;
   void RenderViewDeleted(content::RenderViewHost* host) override;
 
-  // viz::mojom::FrameSinkVideoConsumer implementation.
+  // viz::mojom::FrameSinkVideoConsumer
   void OnFrameCaptured(
       ::media::mojom::VideoBufferHandlePtr data,
       ::media::mojom::VideoFrameInfoPtr info,

--- a/shell/browser/api/gpu_info_enumerator.h
+++ b/shell/browser/api/gpu_info_enumerator.h
@@ -30,6 +30,8 @@ class GPUInfoEnumerator final : public gpu::GPUInfo::Enumerator {
  public:
   GPUInfoEnumerator();
   ~GPUInfoEnumerator() override;
+
+  // gpu::GPUInfo::Enumerator
   void AddInt64(const char* name, int64_t value) override;
   void AddInt(const char* name, int value) override;
   void AddString(const char* name, const std::string& value) override;

--- a/shell/browser/api/gpuinfo_manager.h
+++ b/shell/browser/api/gpuinfo_manager.h
@@ -31,6 +31,7 @@ class GPUInfoManager : private content::GpuDataManagerObserver {
   void FetchBasicInfo(gin_helper::Promise<base::Value> promise);
 
  private:
+  // content::GpuDataManagerObserver
   void OnGpuInfoUpdate() override;
 
   base::Value::Dict EnumerateGPUInfo(gpu::GPUInfo gpu_info) const;

--- a/shell/browser/browser_process_impl.h
+++ b/shell/browser/browser_process_impl.h
@@ -51,7 +51,6 @@ class BrowserProcessImpl : public BrowserProcess {
 
   static void ApplyProxyModeFromCommandLine(ValueMapPrefStore* pref_store);
 
-  BuildState* GetBuildState() override;
   void PostEarlyInitialization();
   void PreCreateThreads();
   void PreMainMessageLoopRun();
@@ -68,6 +67,8 @@ class BrowserProcessImpl : public BrowserProcess {
   }
 #endif
 
+  // BrowserProcess
+  BuildState* GetBuildState() override;
   void EndSession() override {}
   void FlushLocalStateAndReply(base::OnceClosure reply) override {}
   bool IsShuttingDown() override;

--- a/shell/browser/electron_autofill_driver.h
+++ b/shell/browser/electron_autofill_driver.h
@@ -30,6 +30,7 @@ class AutofillDriver : public mojom::ElectronAutofillDriver {
       mojo::PendingAssociatedReceiver<mojom::ElectronAutofillDriver>
           pending_receiver);
 
+  // mojom::ElectronAutofillDriver
   void ShowAutofillPopup(const gfx::RectF& bounds,
                          const std::vector<std::u16string>& values,
                          const std::vector<std::u16string>& labels) override;

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -135,6 +135,8 @@ class LinuxUiGetterImpl : public ui::LinuxUiGetter {
  public:
   LinuxUiGetterImpl() = default;
   ~LinuxUiGetterImpl() override = default;
+
+  // ui::LinuxUiGetter
   ui::LinuxUiTheme* GetForWindow(aura::Window* window) override {
     return GetForProfile(nullptr);
   }

--- a/shell/browser/electron_navigation_throttle.h
+++ b/shell/browser/electron_navigation_throttle.h
@@ -19,8 +19,8 @@ class ElectronNavigationThrottle : public content::NavigationThrottle {
   ElectronNavigationThrottle& operator=(const ElectronNavigationThrottle&) =
       delete;
 
+  // content::NavigationThrottle
   ElectronNavigationThrottle::ThrottleCheckResult WillStartRequest() override;
-
   ElectronNavigationThrottle::ThrottleCheckResult WillRedirectRequest()
       override;
 

--- a/shell/browser/extensions/api/extension_action/extension_action_api.h
+++ b/shell/browser/extensions/api/extension_action/extension_action_api.h
@@ -91,6 +91,8 @@ class ExtensionActionFunction : public ExtensionFunction {
  protected:
   ExtensionActionFunction();
   ~ExtensionActionFunction() override;
+
+  // ExtensionFunction
   ResponseAction Run() override;
 
   virtual ResponseAction RunExtensionAction() = 0;

--- a/shell/browser/extensions/api/management/electron_management_api_delegate.h
+++ b/shell/browser/extensions/api/management/electron_management_api_delegate.h
@@ -17,7 +17,7 @@ class ElectronManagementAPIDelegate : public extensions::ManagementAPIDelegate {
   ElectronManagementAPIDelegate();
   ~ElectronManagementAPIDelegate() override;
 
-  // ManagementAPIDelegate.
+  // extensions::ManagementAPIDelegate
   bool LaunchAppFunctionDelegate(
       const extensions::Extension* extension,
       content::BrowserContext* context) const override;

--- a/shell/browser/extensions/electron_extensions_browser_api_provider.h
+++ b/shell/browser/extensions/electron_extensions_browser_api_provider.h
@@ -21,6 +21,7 @@ class ElectronExtensionsBrowserAPIProvider
   ElectronExtensionsBrowserAPIProvider& operator=(
       const ElectronExtensionsBrowserAPIProvider&) = delete;
 
+  // ExtensionsBrowserAPIProvider
   void RegisterExtensionFunctions(ExtensionFunctionRegistry* registry) override;
 };
 

--- a/shell/browser/extensions/electron_kiosk_delegate.h
+++ b/shell/browser/extensions/electron_kiosk_delegate.h
@@ -17,7 +17,7 @@ class ElectronKioskDelegate : public extensions::KioskDelegate {
   ElectronKioskDelegate();
   ~ElectronKioskDelegate() override;
 
-  // KioskDelegate overrides:
+  // extensions::KioskDelegate
   bool IsAutoLaunchedKioskApp(const extensions::ExtensionId& id) const override;
 };
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -185,6 +185,7 @@ class NativeWindowClientView : public views::ClientView {
   NativeWindowClientView(const NativeWindowClientView&) = delete;
   NativeWindowClientView& operator=(const NativeWindowClientView&) = delete;
 
+  // views::ClientView
   views::CloseRequestResult OnWindowCloseRequested() override {
     window_->NotifyWindowCloseButtonClicked();
     return views::CloseRequestResult::kCannotClose;

--- a/shell/browser/net/asar/asar_file_validator.h
+++ b/shell/browser/net/asar/asar_file_validator.h
@@ -25,6 +25,7 @@ class AsarFileValidator : public mojo::FilteredDataSource::Filter {
   AsarFileValidator(const AsarFileValidator&) = delete;
   AsarFileValidator& operator=(const AsarFileValidator&) = delete;
 
+  // mojo::FilteredDataSource::Filter
   void OnRead(base::span<char> buffer,
               mojo::FileDataSource::ReadResult* result) override;
 

--- a/shell/browser/notifications/linux/notification_presenter_linux.h
+++ b/shell/browser/notifications/linux/notification_presenter_linux.h
@@ -16,6 +16,7 @@ class NotificationPresenterLinux : public NotificationPresenter {
   ~NotificationPresenterLinux() override;
 
  private:
+  // NotificationPresenter
   Notification* CreateNotificationObject(
       NotificationDelegate* delegate) override;
 };

--- a/shell/browser/notifications/mac/notification_presenter_mac.h
+++ b/shell/browser/notifications/mac/notification_presenter_mac.h
@@ -21,6 +21,7 @@ class NotificationPresenterMac : public NotificationPresenter {
   ~NotificationPresenterMac() override;
 
  private:
+  // NotificationPresenter
   Notification* CreateNotificationObject(
       NotificationDelegate* delegate) override;
 

--- a/shell/browser/notifications/platform_notification_service.cc
+++ b/shell/browser/notifications/platform_notification_service.cc
@@ -53,6 +53,7 @@ class NotificationDelegateImpl final : public electron::NotificationDelegate {
   NotificationDelegateImpl(const NotificationDelegateImpl&) = delete;
   NotificationDelegateImpl& operator=(const NotificationDelegateImpl&) = delete;
 
+  // electron::NotificationDelegate
   void NotificationDestroyed() override { delete this; }
 
   void NotificationClick() override {

--- a/shell/browser/notifications/win/notification_presenter_win.h
+++ b/shell/browser/notifications/win/notification_presenter_win.h
@@ -41,6 +41,7 @@ class NotificationPresenterWin : public NotificationPresenter {
   std::wstring SaveIconToFilesystem(const SkBitmap& icon, const GURL& origin);
 
  private:
+  // NotificationPresenter
   Notification* CreateNotificationObject(
       NotificationDelegate* delegate) override;
 

--- a/shell/browser/notifications/win/windows_toast_notification.h
+++ b/shell/browser/notifications/win/windows_toast_notification.h
@@ -120,12 +120,17 @@ class ToastEventHandler : public RuntimeClass<RuntimeClassFlags<ClassicCom>,
   ToastEventHandler(const ToastEventHandler&) = delete;
   ToastEventHandler& operator=(const ToastEventHandler&) = delete;
 
+  // DesktopToastActivatedEventHandler
   IFACEMETHODIMP Invoke(
       ABI::Windows::UI::Notifications::IToastNotification* sender,
       IInspectable* args) override;
+
+  // DesktopToastDismissedEventHandler
   IFACEMETHODIMP Invoke(
       ABI::Windows::UI::Notifications::IToastNotification* sender,
       ABI::Windows::UI::Notifications::IToastDismissedEventArgs* e) override;
+
+  // DesktopToastFailedEventHandler
   IFACEMETHODIMP Invoke(
       ABI::Windows::UI::Notifications::IToastNotification* sender,
       ABI::Windows::UI::Notifications::IToastFailedEventArgs* e) override;

--- a/shell/browser/osr/osr_host_display_client.h
+++ b/shell/browser/osr/osr_host_display_client.h
@@ -63,6 +63,7 @@ class OffScreenHostDisplayClient : public viz::HostDisplayClient {
   void SetActive(bool active);
 
  private:
+  // viz::HostDisplayClient
 #if BUILDFLAG(IS_MAC)
   void OnDisplayReceivedCALayerParams(
       const gfx::CALayerParams& ca_layer_params) override;

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -135,6 +135,7 @@ class ElectronDelegatedFrameHostClient
   ElectronDelegatedFrameHostClient& operator=(
       const ElectronDelegatedFrameHostClient&) = delete;
 
+  // content::DelegatedFrameHostClient
   ui::Layer* DelegatedFrameHostGetLayer() const override {
     return view_->root_layer();
   }

--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -121,7 +121,6 @@ class OffScreenRenderWidgetHostView
 #endif  // BUILDFLAG(IS_MAC)
 
   // content::RenderWidgetHostViewBase:
-
   void UpdateFrameSinkIdRegistration() override;
   void InvalidateLocalSurfaceIdAndAllocationGroup() override;
   void ResetFallbackToFirstNavigationSurface() override;

--- a/shell/browser/serial/electron_serial_delegate.h
+++ b/shell/browser/serial/electron_serial_delegate.h
@@ -29,6 +29,7 @@ class ElectronSerialDelegate : public content::SerialDelegate,
   ElectronSerialDelegate(const ElectronSerialDelegate&) = delete;
   ElectronSerialDelegate& operator=(const ElectronSerialDelegate&) = delete;
 
+  // content::SerialDelegate:
   std::unique_ptr<content::SerialChooser> RunChooser(
       content::RenderFrameHost* frame,
       std::vector<blink::mojom::SerialPortFilterPtr> filters,

--- a/shell/browser/ui/file_dialog_linux.cc
+++ b/shell/browser/ui/file_dialog_linux.cc
@@ -137,6 +137,7 @@ class FileChooserDialog : public ui::SelectFileDialog::Listener {
     RunOpenDialogImpl(settings);
   }
 
+  // ui::SelectFileDialog::Listener
   void FileSelected(const ui::SelectedFileInfo& file,
                     int index,
                     void* params) override {

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -242,6 +242,7 @@ class InspectableWebContents::NetworkResourceLoader
     response_headers_ = response_head.headers;
   }
 
+  // network::SimpleURLLoaderStreamConsumer
   void OnDataReceived(base::StringPiece chunk,
                       base::OnceClosure resume) override {
     bool encoded = !base::IsStringUTF8(chunk);

--- a/shell/browser/ui/message_box_gtk.cc
+++ b/shell/browser/ui/message_box_gtk.cc
@@ -182,6 +182,7 @@ class GtkMessageBox : private NativeWindowObserver {
     Show();
   }
 
+  // NativeWindowObserver
   void OnWindowClosed() override {
     parent_->RemoveObserver(this);
     parent_ = nullptr;

--- a/shell/browser/ui/tray_icon_cocoa.h
+++ b/shell/browser/ui/tray_icon_cocoa.h
@@ -21,6 +21,7 @@ class TrayIconCocoa : public TrayIcon {
   TrayIconCocoa();
   ~TrayIconCocoa() override;
 
+  // TrayIcon
   void SetImage(const gfx::Image& image) override;
   void SetPressedImage(const gfx::Image& image) override;
   void SetToolTip(const std::string& tool_tip) override;

--- a/shell/browser/ui/views/autofill_popup_view.h
+++ b/shell/browser/ui/views/autofill_popup_view.h
@@ -73,6 +73,7 @@ class AutofillPopupView : public views::WidgetDelegateView,
 
   int GetSelectedLine() { return selected_line_.value_or(-1); }
 
+  // views::WidgetDelegateView implementation.
   void WriteDragDataForView(views::View*,
                             const gfx::Point&,
                             ui::OSExchangeData*) override;

--- a/shell/browser/ui/views/menu_model_adapter.h
+++ b/shell/browser/ui/views/menu_model_adapter.h
@@ -21,6 +21,7 @@ class MenuModelAdapter : public views::MenuModelAdapter {
   MenuModelAdapter& operator=(const MenuModelAdapter&) = delete;
 
  protected:
+  // views::MenuModelAdapter
   bool GetAccelerator(int id, ui::Accelerator* accelerator) const override;
 
  private:

--- a/shell/browser/ui/views/submenu_button.h
+++ b/shell/browser/ui/views/submenu_button.h
@@ -34,9 +34,9 @@ class SubmenuButton : public views::MenuButton {
 
   char16_t accelerator() const { return accelerator_; }
 
+  // views::MenuButton:
   void GetAccessibleNodeData(ui::AXNodeData* node_data) override;
 
-  // views::MenuButton:
   void PaintButtonContents(gfx::Canvas* canvas) override;
 
  private:

--- a/shell/browser/ui/views/win_caption_button.h
+++ b/shell/browser/ui/views/win_caption_button.h
@@ -35,7 +35,7 @@ class WinCaptionButton : public views::Button {
   WinCaptionButton(const WinCaptionButton&) = delete;
   WinCaptionButton& operator=(const WinCaptionButton&) = delete;
 
-  // // views::Button:
+  // views::Button:
   gfx::Size CalculatePreferredSize(
       const views::SizeBounds& available_size) const override;
   void OnPaintBackground(gfx::Canvas* canvas) override;

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
@@ -29,6 +29,7 @@ class ElectronDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin,
       const ElectronDesktopWindowTreeHostWin&) = delete;
 
  protected:
+  // views::DesktopWindowTreeHostWin:
   bool PreHandleMSG(UINT message,
                     WPARAM w_param,
                     LPARAM l_param,

--- a/shell/browser/webauthn/electron_authenticator_request_delegate.h
+++ b/shell/browser/webauthn/electron_authenticator_request_delegate.h
@@ -15,6 +15,7 @@ class ElectronWebAuthenticationDelegate
  public:
   ~ElectronWebAuthenticationDelegate() override;
 
+  // content::WebAuthenticationDelegate
   bool SupportsResidentKeys(
       content::RenderFrameHost* render_frame_host) override;
 };

--- a/shell/common/gin_helper/function_template.h
+++ b/shell/common/gin_helper/function_template.h
@@ -75,6 +75,8 @@ class CallbackHolderBase {
     DisposeObserver(gin::PerIsolateData* per_isolate_data,
                     CallbackHolderBase* holder);
     ~DisposeObserver() override;
+
+    // gin::PerIsolateData::DisposeObserver
     void OnBeforeDispose(v8::Isolate* isolate) override;
     void OnDisposed() override;
 

--- a/shell/common/node_bindings_linux.h
+++ b/shell/common/node_bindings_linux.h
@@ -15,6 +15,7 @@ class NodeBindingsLinux : public NodeBindings {
   explicit NodeBindingsLinux(BrowserEnvironment browser_env);
 
  private:
+  // NodeBindings
   void PollEvents() override;
 
   // Epoll to poll for uv's backend fd.

--- a/shell/common/node_bindings_mac.h
+++ b/shell/common/node_bindings_mac.h
@@ -15,6 +15,7 @@ class NodeBindingsMac : public NodeBindings {
   explicit NodeBindingsMac(BrowserEnvironment browser_env);
 
  private:
+  // NodeBindings
   void PollEvents() override;
 };
 

--- a/shell/common/node_bindings_win.h
+++ b/shell/common/node_bindings_win.h
@@ -15,6 +15,7 @@ class NodeBindingsWin : public NodeBindings {
   explicit NodeBindingsWin(BrowserEnvironment browser_env);
 
  private:
+  // NodeBindings
   void PollEvents() override;
 };
 

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -49,6 +49,7 @@ class DeleteFileProgressSink : public IFileOperationProgressSink {
   virtual ~DeleteFileProgressSink() = default;
 
  private:
+  // IFileOperationProgressSink
   ULONG STDMETHODCALLTYPE AddRef(void) override;
   ULONG STDMETHODCALLTYPE Release(void) override;
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid,

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -32,6 +32,7 @@ class ElectronApiServiceImpl : public mojom::ElectronRenderer,
 
   void BindTo(mojo::PendingReceiver<mojom::ElectronRenderer> receiver);
 
+  // mojom::ElectronRenderer
   void Message(bool internal,
                const std::string& channel,
                blink::CloneableMessage arguments) override;
@@ -50,7 +51,7 @@ class ElectronApiServiceImpl : public mojom::ElectronRenderer,
       mojo::ScopedMessagePipeHandle* interface_pipe) override;
 
  private:
-  // RenderFrameObserver implementation.
+  // content::RenderFrameObserver
   void DidCreateDocumentElement() override;
   void OnDestruct() override;
 

--- a/shell/renderer/electron_renderer_pepper_host_factory.h
+++ b/shell/renderer/electron_renderer_pepper_host_factory.h
@@ -25,7 +25,7 @@ class ElectronRendererPepperHostFactory : public ppapi::host::HostFactory {
   ElectronRendererPepperHostFactory& operator=(
       const ElectronRendererPepperHostFactory&) = delete;
 
-  // HostFactory.
+  // ppapi::host::HostFactory
   std::unique_ptr<ppapi::host::ResourceHost> CreateResourceHost(
       ppapi::host::PpapiHost* host,
       PP_Resource resource,

--- a/shell/utility/electron_content_utility_client.h
+++ b/shell/utility/electron_content_utility_client.h
@@ -26,6 +26,7 @@ class ElectronContentUtilityClient : public content::ContentUtilityClient {
   ElectronContentUtilityClient& operator=(const ElectronContentUtilityClient&) =
       delete;
 
+  // content::ContentUtilityClient
   void ExposeInterfacesToBrowser(mojo::BinderMap* binders) override;
   void RegisterMainThreadServices(mojo::ServiceFactory& services) override;
   void RegisterIOThreadServices(mojo::ServiceFactory& services) override;


### PR DESCRIPTION
Use this pattern more consistently
```cpp
  // content::GpuDataManagerObserver
  void OnGpuInfoUpdate() override;
```

Notes: none