### PR TITLE
build: add symbol_level=1 to GN_BUILDFLAG_ARGS on release

### DIFF
--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -56,8 +56,6 @@ env:
   ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
   ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
   ELECTRON_GITHUB_TOKEN: ${{ secrets.ELECTRON_GITHUB_TOKEN }}
-  # Disable pre-compiled headers to reduce out size - only useful for rebuilds
-  GN_BUILDFLAG_ARGS: 'enable_precompiled_headers=false'
   GCLIENT_EXTRA_ARGS: ${{ inputs.target-platform == 'macos' && '--custom-var=checkout_mac=True --custom-var=host_os=mac' || '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True' }}
   # Only disable this in the Asan build
   CHECK_DIST_MANIFEST: true
@@ -97,10 +95,10 @@ jobs:
       if: ${{ inputs.target-platform == 'linux' }}
       run: |
         if [ "${{ inputs.target-arch  }}" = "arm" ]; then
-          GN_EXTRA_ARGS='target_cpu="arm" build_tflite_with_xnnpack=false'
           if [ "${{ inputs.is-release  }}" = true ]; then
-            GN_BUILDFLAG_ARGS='enable_precompiled_headers=false symbol_level=1'
-            echo "GN_BUILDFLAG_ARGS=$GN_BUILDFLAG_ARGS" >> $GITHUB_ENV
+            GN_EXTRA_ARGS='target_cpu="arm" build_tflite_with_xnnpack=false symbol_level=1'
+          else
+            GN_EXTRA_ARGS='target_cpu="arm" build_tflite_with_xnnpack=false'
           fi
         elif [ "${{ inputs.target-arch }}" = "arm64" ]; then
           GN_EXTRA_ARGS='target_cpu="arm64" fatal_linker_warnings=false enable_linux_installer=false'

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -98,6 +98,10 @@ jobs:
       run: |
         if [ "${{ inputs.target-arch  }}" = "arm" ]; then
           GN_EXTRA_ARGS='target_cpu="arm" build_tflite_with_xnnpack=false'
+          if [ "${{ inputs.is-release  }}" = true ]; then
+            GN_BUILDFLAG_ARGS='enable_precompiled_headers=false symbol_level=1'
+            echo "GN_BUILDFLAG_ARGS=$GN_BUILDFLAG_ARGS" >> $GITHUB_ENV
+          fi
         elif [ "${{ inputs.target-arch }}" = "arm64" ]; then
           GN_EXTRA_ARGS='target_cpu="arm64" fatal_linker_warnings=false enable_linux_installer=false'
         fi

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -34,7 +34,6 @@ env:
   AZURE_AKS_CACHE_STORAGE_ACCOUNT: ${{ secrets.AZURE_AKS_CACHE_STORAGE_ACCOUNT }}
   AZURE_AKS_CACHE_SHARE_NAME: ${{ secrets.AZURE_AKS_CACHE_SHARE_NAME }}
   ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
-  GN_BUILDFLAG_ARGS: 'enable_precompiled_headers=false'
   GCLIENT_EXTRA_ARGS: ${{ inputs.target-platform == 'macos' && '--custom-var=checkout_mac=True --custom-var=host_os=mac' || '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True' }}
   ELECTRON_OUT_DIR: Default
   TARGET_ARCH: ${{ inputs.target-arch }}


### PR DESCRIPTION
#### Description of Change

Currently `linux-arm` is failing on publish with `ld.lld: error: output file too large: 5118387152 bytes`. @jkleinsc found this issue where we need to set a symbol level to 1 for 32 bit releases because of https://crbug.com/648948. This PR correctly sets the symbol level for release builds.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
