### PR TITLE
chore: cherry-pick 5 changes from 1-M125

### DIFF
--- a/patches/DirectXShaderCompiler/.patches
+++ b/patches/DirectXShaderCompiler/.patches
@@ -2,3 +2,4 @@ cherry-pick-a65e511a14b4.patch
 cherry-pick-bc18aec94c82.patch
 cherry-pick-bd7aa9779873.patch
 cherry-pick-2a434fd0af6b.patch
+cherry-pick-867c1001637e.patch

--- a/patches/DirectXShaderCompiler/cherry-pick-867c1001637e.patch
+++ b/patches/DirectXShaderCompiler/cherry-pick-867c1001637e.patch
@@ -1,0 +1,105 @@
+From 867c1001637e9156f13e852e80ce2038fe5c7ca2 Mon Sep 17 00:00:00 2001
+From: Antonio Maiorano <amaiorano@google.com>
+Date: Thu, 16 May 2024 14:24:27 -0400
+Subject: [PATCH] Fix invalid module bitcode when indexing a swizzled bool vector (#6582)
+
+When indexing a swizzled bool vector, some HLSL-specific code in
+EmitCXXMemberOrOperatorMemberCallExpr kicks in to handle the
+HLSLVecType. In this case, we’re dealing with an ExtVectorElt because of
+the swizzle, so this function creates a GEP, Load, and Store on the
+vector. However, boolean scalars are returned as type i11 while the
+store is storing to a bool, which is an i32, so we need to insert a cast
+before the store.
+
+Bug: chromium:338161969
+Change-Id: I45f8ec383be49210a10f725d8266b66fd30c34be
+Reviewed-on: https://chromium-review.googlesource.com/c/external/github.com/microsoft/DirectXShaderCompiler/+/5545820
+Reviewed-by: James Price <jrprice@google.com>
+Reviewed-by: dan sinclair <dsinclair@google.com>
+---
+
+diff --git a/tools/clang/lib/CodeGen/CGExpr.cpp b/tools/clang/lib/CodeGen/CGExpr.cpp
+index cc46d06..efef059 100644
+--- a/tools/clang/lib/CodeGen/CGExpr.cpp
++++ b/tools/clang/lib/CodeGen/CGExpr.cpp
+@@ -1137,6 +1137,12 @@
+   return MDHelper.createRange(Min, End);
+ }
+ 
++static bool ShouldEmitRangeMD(llvm::Value *Value, QualType Ty) {
++  if (hasBooleanRepresentation(Ty))
++    return cast<llvm::IntegerType>(Value->getType())->getBitWidth() != 1;
++  return true;
++}
++
+ llvm::Value *CodeGenFunction::EmitLoadOfScalar(llvm::Value *Addr, bool Volatile,
+                                                unsigned Alignment, QualType Ty,
+                                                SourceLocation Loc,
+@@ -1236,7 +1242,8 @@
+       EmitCheck(std::make_pair(Check, Kind), "load_invalid_value", StaticArgs,
+                 EmitCheckValue(Load));
+     }
+-  } else if (CGM.getCodeGenOpts().OptimizationLevel > 0)
++  } else if (CGM.getCodeGenOpts().OptimizationLevel > 0 &&
++             ShouldEmitRangeMD(Load, Ty))
+     if (llvm::MDNode *RangeInfo = getRangeForLoadFromType(Ty))
+       Load->setMetadata(llvm::LLVMContext::MD_range, RangeInfo);
+ 
+diff --git a/tools/clang/lib/CodeGen/CGExprCXX.cpp b/tools/clang/lib/CodeGen/CGExprCXX.cpp
+index 2efde7c..924a0f8 100644
+--- a/tools/clang/lib/CodeGen/CGExprCXX.cpp
++++ b/tools/clang/lib/CodeGen/CGExprCXX.cpp
+@@ -235,12 +235,17 @@
+ 
+           llvm::Constant *zero = Builder.getInt32(0);
+           llvm::Value *TmpThis = CreateTempAlloca(Ty);
++          QualType ElTy = hlsl::GetElementTypeOrType(Base->getType());
++          bool IsBool = ElTy->isSpecificBuiltinType(BuiltinType::Bool);
+           for (unsigned i = 0; i < Ty->getVectorNumElements(); i++) {
+             llvm::Value *EltIdx = Elts->getAggregateElement(i);
+             llvm::Value *EltGEP = Builder.CreateGEP(This, {zero, EltIdx});
+             llvm::Value *TmpEltGEP =
+                 Builder.CreateGEP(TmpThis, {zero, Builder.getInt32(i)});
+             llvm::Value *Elt = Builder.CreateLoad(EltGEP);
++            if (IsBool)
++              Elt = Builder.CreateTrunc(
++                  Elt, llvm::Type::getInt1Ty(getLLVMContext()));
+             Builder.CreateStore(Elt, TmpEltGEP);
+           }
+           This = TmpThis;
+diff --git a/tools/clang/test/CodeGenDXIL/operators/swizzle/indexSwizzledBoolVec.hlsl b/tools/clang/test/CodeGenDXIL/operators/swizzle/indexSwizzledBoolVec.hlsl
+new file mode 100644
+index 0000000..a47482d
+--- /dev/null
++++ b/tools/clang/test/CodeGenDXIL/operators/swizzle/indexSwizzledBoolVec.hlsl
+@@ -0,0 +1,30 @@
++// Test indexing a swizzled bool vector
++// RUN: %dxc -fcgl -T cs_6_0 %s | FileCheck %s
++
++// This was asserting in Instructions.cpp with:
++// void llvm::StoreInst::AssertOK(): Assertion `getOperand(0)->getType() == cast<PointerType>(getOperand(1)->getType())->getElementType() && "Ptr must be a pointer to Val type!"' failed.
++
++// Make sure load of i32 gets truncated to i1 when indexing bool vectors
++// CHECK:       [[TMP:%[a-z0-9\.]+]] = alloca <2 x i1>
++// CHECK:       [[VA0:%[a-z0-9\.]+]] = getelementptr <2 x i1>, <2 x i1>* [[TMP]], i32 0, i32 0,
++// CHECK-NEXT:  [[VA1:%[a-z0-9\.]+]] = load i32, i32* getelementptr inbounds (<4 x i32>, <4 x i32>* @"\01?v_bool4@?1??main@@YAXXZ@3V?$vector@_N$03@@B", i32 0, i32 2),
++// CHECK-NEXT:  [[VA2:%[a-z0-9\.]+]] = trunc i32 [[VA1]] to i1,
++// CHECK-NEXT:  store i1 [[VA2]], i1* [[VA0]],
++// CHECK-NEXT:  [[VB0:%[a-z0-9\.]+]] = getelementptr <2 x i1>, <2 x i1>* [[TMP]], i32 0, i32 1,
++// CHECK-NEXT:  [[VB1:%[a-z0-9\.]+]] = load i32, i32* getelementptr inbounds (<4 x i32>, <4 x i32>* @"\01?v_bool4@?1??main@@YAXXZ@3V?$vector@_N$03@@B", i32 0, i32 3),
++// CHECK-NEXT:  [[VB2:%[a-z0-9\.]+]] = trunc i32 [[VB1]] to i1,
++// CHECK-NEXT:  store i1 [[VB2]], i1* [[VB0]],
++
++
++cbuffer cbuffer_tint_symbol_3 : register(b0) {
++    uint4 global_uint4[1];
++};
++
++[numthreads(1, 1, 1)]
++void main() {
++    const bool4 v_bool4 = bool4(true, true, true, true);
++    const uint gx = global_uint4[0].x;
++    if (v_bool4.zw[gx] == 0) {
++        GroupMemoryBarrierWithGroupSync();
++    }
++}

--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -2,3 +2,4 @@ m123_vulkan_fix_access_to_inactive_attributes.patch
 cherry-pick-f6672dbbe223.patch
 cherry-pick-ba3b4e239620.patch
 cherry-pick-c67f290ef0f0.patch
+cherry-pick-bda89e1f7c71.patch

--- a/patches/angle/cherry-pick-bda89e1f7c71.patch
+++ b/patches/angle/cherry-pick-bda89e1f7c71.patch
@@ -1,0 +1,74 @@
+From bda89e1f7c7195a9d03d037039c2dd5057563a59 Mon Sep 17 00:00:00 2001
+From: Shahbaz Youssefi <syoussefi@chromium.org>
+Date: Thu, 02 May 2024 11:17:33 -0400
+Subject: [PATCH] M124: Vulkan: Turn SPIR-V limitations to crash instead of security bug
+
+The input shader can be made complex in a number of different ways,
+resulting in instructions with a length higher than what can fit in
+SPIR-V (i.e. 16 bits).  Ideally, the translator would catch such complex
+usage early on and gracefully fail compilation.  However, as a safety
+net, this change makes sure such a case is detected when the SPIR-V
+instruction is being generated and turned into a crash.  This makes sure
+such bugs are no longer security bugs.
+
+Bug: chromium:335613092
+Change-Id: Iab16b49ed80929fc343b4c7bffce306919de2e96
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5547611
+Reviewed-by: Roman Lavrov <romanl@google.com>
+---
+
+diff --git a/scripts/code_generation_hashes/SPIR-V_helpers.json b/scripts/code_generation_hashes/SPIR-V_helpers.json
+index cb1b596..944cf1a 100644
+--- a/scripts/code_generation_hashes/SPIR-V_helpers.json
++++ b/scripts/code_generation_hashes/SPIR-V_helpers.json
+@@ -1,8 +1,8 @@
+ {
+   "src/common/spirv/gen_spirv_builder_and_parser.py":
+-    "e95670a30a4eda80a146b61c986fb03c",
++    "868a697edbc38c95e36be54cf5c71435",
+   "src/common/spirv/spirv_instruction_builder_autogen.cpp":
+-    "1b5f60a24d459e7a30c29cf7acfa2106",
++    "c149de371bcd571bd31cc8eb1e517910",
+   "src/common/spirv/spirv_instruction_builder_autogen.h":
+     "56b1309d8afabb2b64d7e16f0c4a4898",
+   "src/common/spirv/spirv_instruction_parser_autogen.cpp":
+diff --git a/src/common/spirv/gen_spirv_builder_and_parser.py b/src/common/spirv/gen_spirv_builder_and_parser.py
+index 5e8e9bc..c7e1f40 100755
+--- a/src/common/spirv/gen_spirv_builder_and_parser.py
++++ b/src/common/spirv/gen_spirv_builder_and_parser.py
+@@ -93,6 +93,15 @@
+     ASSERT(length <= 0xFFFFu);
+     ASSERT(op <= 0xFFFFu);
+ 
++    // It's easy for a complex shader to be crafted to hit the length limit,
++    // turn that into a crash instead of a security bug.  Ideally, the compiler
++    // would gracefully fail compilation, so this is more of a safety net.
++    if (ANGLE_UNLIKELY(length > 0xFFFFu))
++    {
++        ERR() << "Complex shader not representible in SPIR-V";
++        ANGLE_CRASH();
++    }
++
+     return static_cast<uint32_t>(length) << 16 | op;
+ }
+ }  // anonymous namespace
+diff --git a/src/common/spirv/spirv_instruction_builder_autogen.cpp b/src/common/spirv/spirv_instruction_builder_autogen.cpp
+index 3c73c58..6e6ad6f 100644
+--- a/src/common/spirv/spirv_instruction_builder_autogen.cpp
++++ b/src/common/spirv/spirv_instruction_builder_autogen.cpp
+@@ -25,6 +25,15 @@
+     ASSERT(length <= 0xFFFFu);
+     ASSERT(op <= 0xFFFFu);
+ 
++    // It's easy for a complex shader to be crafted to hit the length limit,
++    // turn that into a crash instead of a security bug.  Ideally, the compiler
++    // would gracefully fail compilation, so this is more of a safety net.
++    if (ANGLE_UNLIKELY(length > 0xFFFFu))
++    {
++        ERR() << "Complex shader not representible in SPIR-V";
++        ANGLE_CRASH();
++    }
++
+     return static_cast<uint32_t>(length) << 16 | op;
+ }
+ }  // anonymous namespace

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -143,3 +143,5 @@ a11y_avoid_clearing_resetting_focus_on_an_already_focus_event.patch
 cherry-pick-b2cc7b7ac538.patch
 feat_add_support_for_missing_dialog_features_to_shell_dialogs.patch
 cherry-pick-03609e39be8c.patch
+cherry-pick-b922fcb61e3b.patch
+cherry-pick-0d9598145069.patch

--- a/patches/chromium/cherry-pick-0d9598145069.patch
+++ b/patches/chromium/cherry-pick-0d9598145069.patch
@@ -1,0 +1,806 @@
+From 0d9598145069402dfdb8fc2484b47baf51123177 Mon Sep 17 00:00:00 2001
+From: Brendon Tiszka <tiszka@chromium.org>
+Date: Mon, 20 May 2024 18:33:53 +0000
+Subject: [PATCH] Fix bugs in GLES* command handlers
+
+If the command buffer is in an invalid state then we can't trust
+the contents of the get buffer.
+
+(cherry picked from commit 374789ab8f5eeac24e2e335af825d34b8c3fde81)
+
+Bug: 340822365,40947303
+Change-Id: I465d617e5056877fb464dd59df983a9e8d866b85
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5542488
+Commit-Queue: Brendon Tiszka <tiszka@chromium.org>
+Reviewed-by: Geoff Lang <geofflang@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1301529}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5550571
+Reviewed-by: Brendon Tiszka <tiszka@chromium.org>
+Owners-Override: Prudhvikumar Bommana <pbommana@google.com>
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/6367@{#1205}
+Cr-Branched-From: d158c6dc6e3604e6f899041972edf26087a49740-refs/heads/main@{#1274542}
+---
+
+diff --git a/gpu/command_buffer/build_cmd_buffer_lib.py b/gpu/command_buffer/build_cmd_buffer_lib.py
+index b8ca818..4f1aa8e 100644
+--- a/gpu/command_buffer/build_cmd_buffer_lib.py
++++ b/gpu/command_buffer/build_cmd_buffer_lib.py
+@@ -2954,7 +2954,9 @@
+   result->SetNumResults(0);
+   helper_->%(func_name)s(%(arg_string)s,
+       GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(%(last_arg_name)s);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -4456,7 +4458,9 @@
+       f.write(
+           "  helper_->%s(%s, GetResultShmId(), result.offset());\n" %
+               (func.name, arg_string))
+-      f.write("  WaitForCmd();\n")
++      f.write("  if (!WaitForCmd()) {\n")
++      f.write("    return %s; \n" % error_value)
++      f.write("  }\n")
+       f.write("  %s result_value = *result" % func.return_type)
+       if func.return_type == "GLboolean":
+         f.write(" != 0")
+diff --git a/gpu/command_buffer/client/gles2_implementation.cc b/gpu/command_buffer/client/gles2_implementation.cc
+index ff1dad8e5..ba7b7bc 100644
+--- a/gpu/command_buffer/client/gles2_implementation.cc
++++ b/gpu/command_buffer/client/gles2_implementation.cc
+@@ -595,7 +595,9 @@
+   }
+   *result = GL_NO_ERROR;
+   helper_->GetError(GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return GL_NO_ERROR;
++  }
+   GLenum error = *result;
+   if (error == GL_NO_ERROR) {
+     error = GetClientSideGLError();
+@@ -720,7 +722,9 @@
+     }
+     *result = 0;
+     helper_->IsEnabled(cap, GetResultShmId(), result.offset());
+-    WaitForCmd();
++    if (!WaitForCmd()) {
++      return GL_FALSE;
++    }
+     state = (*result) != 0;
+   }
+ 
+@@ -741,7 +745,9 @@
+     auto result = GetResultAs<Result>();
+     *result = 0;
+     helper_->IsEnablediOES(target, index, GetResultShmId(), result.offset());
+-    WaitForCmd();
++    if (!WaitForCmd()) {
++      return GL_FALSE;
++    }
+     state = (*result) != 0;
+   }
+ 
+@@ -1360,7 +1366,9 @@
+   *result = 0;
+   helper_->GetMaxValueInBufferCHROMIUM(buffer_id, count, type, offset,
+                                        GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return 0;
++  }
+   return *result;
+ }
+ 
+@@ -1663,7 +1671,9 @@
+     result->SetNumResults(0);
+     helper_->GetVertexAttribPointerv(index, pname, GetResultShmId(),
+                                      result.offset());
+-    WaitForCmd();
++    if (!WaitForCmd()) {
++      return;
++    }
+     result->CopyResult(ptr);
+     GPU_CLIENT_LOG_CODE_BLOCK(num_results = result->GetNumResults());
+   }
+@@ -1738,7 +1748,9 @@
+   *result = -1;
+   helper_->GetAttribLocation(program, kResultBucketId, GetResultShmId(),
+                              result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return -1;
++  }
+   helper_->SetBucketSize(kResultBucketId, 0);
+   return *result;
+ }
+@@ -1766,7 +1778,9 @@
+   *result = -1;
+   helper_->GetUniformLocation(program, kResultBucketId, GetResultShmId(),
+                               result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return -1;
++  }
+   helper_->SetBucketSize(kResultBucketId, 0);
+   return *result;
+ }
+@@ -1799,7 +1813,9 @@
+   result->SetNumResults(0);
+   helper_->GetUniformIndices(program, kResultBucketId, GetResultShmId(),
+                              result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return false;
++  }
+   if (result->GetNumResults() != count) {
+     return false;
+   }
+@@ -1859,7 +1875,9 @@
+   *result = -1;
+   helper_->GetFragDataIndexEXT(program, kResultBucketId, GetResultShmId(),
+                                result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return -1;
++  }
+   helper_->SetBucketSize(kResultBucketId, 0);
+   return *result;
+ }
+@@ -1888,7 +1906,9 @@
+   *result = -1;
+   helper_->GetFragDataLocation(program, kResultBucketId, GetResultShmId(),
+                                result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return -1;
++  }
+   helper_->SetBucketSize(kResultBucketId, 0);
+   return *result;
+ }
+@@ -1917,7 +1937,9 @@
+   *result = GL_INVALID_INDEX;
+   helper_->GetUniformBlockIndex(program, kResultBucketId, GetResultShmId(),
+                                 result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return GL_INVALID_INDEX;
++  }
+   helper_->SetBucketSize(kResultBucketId, 0);
+   return *result;
+ }
+@@ -1962,7 +1984,9 @@
+   *result = GL_INVALID_INDEX;
+   helper_->GetProgramResourceIndex(program, program_interface, kResultBucketId,
+                                    GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return GL_INVALID_INDEX;
++  }
+   helper_->SetBucketSize(kResultBucketId, 0);
+   return *result;
+ }
+@@ -2007,7 +2031,9 @@
+     helper_->GetProgramResourceName(program, program_interface, index,
+                                     kResultBucketId, GetResultShmId(),
+                                     result.offset());
+-    WaitForCmd();
++    if (!WaitForCmd()) {
++      return false;
++    }
+     success = !!*result;
+   }
+   if (success) {
+@@ -2066,7 +2092,9 @@
+   helper_->GetProgramResourceiv(program, program_interface, index,
+                                 kResultBucketId, GetResultShmId(),
+                                 result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return false;
++  }
+   if (length) {
+     *length = result->GetNumResults();
+   }
+@@ -2138,7 +2166,9 @@
+   helper_->GetProgramResourceLocation(program, program_interface,
+                                       kResultBucketId, GetResultShmId(),
+                                       result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return -1;
++  }
+   helper_->SetBucketSize(kResultBucketId, 0);
+   return *result;
+ }
+@@ -4015,7 +4045,9 @@
+   result->success = false;
+   helper_->GetActiveAttrib(program, index, kResultBucketId, GetResultShmId(),
+                            result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return false;
++  }
+   bool success = !!result->success;
+   if (success) {
+     if (size) {
+@@ -4083,7 +4115,9 @@
+   result->success = false;
+   helper_->GetActiveUniform(program, index, kResultBucketId, GetResultShmId(),
+                             result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return false;
++  }
+   bool success = !!result->success;
+   if (success) {
+     if (size) {
+@@ -4150,7 +4184,9 @@
+   *result = 0;
+   helper_->GetActiveUniformBlockName(program, index, kResultBucketId,
+                                      GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return false;
++  }
+   bool success = !!result;
+   if (success) {
+     // Note: this can invalidate |result|.
+@@ -4197,7 +4233,9 @@
+   result->SetNumResults(0);
+   helper_->GetActiveUniformBlockiv(program, index, pname, GetResultShmId(),
+                                    result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return false;
++  }
+   if (result->GetNumResults() > 0) {
+     if (params) {
+       result->CopyResult(params);
+@@ -4254,7 +4292,9 @@
+   result->SetNumResults(0);
+   helper_->GetActiveUniformsiv(program, kResultBucketId, pname,
+                                GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return false;
++  }
+   bool success = result->GetNumResults() == count;
+   if (success) {
+     if (params) {
+@@ -4330,7 +4370,9 @@
+                               transfer_buffer_->GetOffset(result),
+                               checked_size);
+   int32_t token = helper_->InsertToken();
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   if (count) {
+     *count = result->GetNumResults();
+   }
+@@ -4372,7 +4414,9 @@
+       result->success = false;
+       helper_->GetShaderPrecisionFormat(shadertype, precisiontype,
+                                         GetResultShmId(), result.offset());
+-      WaitForCmd();
++      if (!WaitForCmd()) {
++        return;
++      }
+       if (result->success)
+         static_state_.shader_precisions[key] = *result;
+     }
+@@ -4485,7 +4529,9 @@
+   result->success = false;
+   helper_->GetTransformFeedbackVarying(program, index, kResultBucketId,
+                                        GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return false;
++  }
+   if (result->success) {
+     if (size) {
+       *size = result->size;
+@@ -4553,7 +4599,9 @@
+     }
+     result->SetNumResults(0);
+     helper_->GetUniformfv(program, location, GetResultShmId(), result.offset());
+-    WaitForCmd();
++    if (!WaitForCmd()) {
++      return;
++    }
+     result->CopyResult(params);
+     GPU_CLIENT_LOG_CODE_BLOCK({
+       for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -4581,7 +4629,9 @@
+     }
+     result->SetNumResults(0);
+     helper_->GetUniformiv(program, location, GetResultShmId(), result.offset());
+-    WaitForCmd();
++    if (!WaitForCmd()) {
++      return;
++    }
+     result->CopyResult(params);
+     GPU_CLIENT_LOG_CODE_BLOCK({
+       for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -4610,7 +4660,9 @@
+     result->SetNumResults(0);
+     helper_->GetUniformuiv(program, location, GetResultShmId(),
+                            result.offset());
+-    WaitForCmd();
++    if (!WaitForCmd()) {
++      return;
++    }
+     result->CopyResult(params);
+     GPU_CLIENT_LOG_CODE_BLOCK({
+       for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -4788,7 +4840,9 @@
+       dst_sk_color_type, dst_sk_alpha_type, shm_id, shm_offset,
+       color_space_offset, pixels_offset, mailbox_offset);
+ 
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return GL_FALSE;
++  }
+   if (!*readback_result) {
+     return GL_FALSE;
+   }
+@@ -4937,7 +4991,9 @@
+     helper_->ReadPixels(xoffset, y_index, width, num_rows, format, type,
+                         buffer.shm_id(), buffer.offset(), GetResultShmId(),
+                         result.offset(), false);
+-    WaitForCmd();
++    if (!WaitForCmd()) {
++      break;
++    }
+     // If it was not marked as successful exit.
+     if (!result->success) {
+       break;
+@@ -5646,7 +5702,9 @@
+     }
+     result->SetNumResults(0);
+     helper_->GetVertexAttribfv(index, pname, GetResultShmId(), result.offset());
+-    WaitForCmd();
++    if (!WaitForCmd()) {
++      return;
++    }
+     result->CopyResult(params);
+     GPU_CLIENT_LOG_CODE_BLOCK({
+       for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -5679,7 +5737,9 @@
+     }
+     result->SetNumResults(0);
+     helper_->GetVertexAttribiv(index, pname, GetResultShmId(), result.offset());
+-    WaitForCmd();
++    if (!WaitForCmd()) {
++      return;
++    }
+     result->CopyResult(params);
+     GPU_CLIENT_LOG_CODE_BLOCK({
+       for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -5713,7 +5773,9 @@
+     result->SetNumResults(0);
+     helper_->GetVertexAttribIiv(index, pname, GetResultShmId(),
+                                 result.offset());
+-    WaitForCmd();
++    if (!WaitForCmd()) {
++      return;
++    }
+     result->CopyResult(params);
+     GPU_CLIENT_LOG_CODE_BLOCK({
+       for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -5747,7 +5809,9 @@
+     result->SetNumResults(0);
+     helper_->GetVertexAttribIuiv(index, pname, GetResultShmId(),
+                                  result.offset());
+-    WaitForCmd();
++    if (!WaitForCmd()) {
++      return;
++    }
+     result->CopyResult(params);
+     GPU_CLIENT_LOG_CODE_BLOCK({
+       for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -5782,7 +5846,9 @@
+   *result = 0;
+   helper_->EnableFeatureCHROMIUM(kResultBucketId, GetResultShmId(),
+                                  result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return false;
++  }
+   helper_->SetBucketSize(kResultBucketId, 0);
+   GPU_CLIENT_LOG("   returned " << GLES2Util::GetStringBool(*result));
+   return *result != 0;
+@@ -5937,7 +6003,9 @@
+                             GetResultShmId(), result.offset());
+     // TODO(zmo): For write only mode with MAP_INVALID_*_BIT, we should
+     // consider an early return without WaitForCmd(). crbug.com/465804.
+-    WaitForCmd();
++    if (!WaitForCmd()) {
++      return nullptr;
++    }
+     if (*result) {
+       const GLbitfield kInvalidateBits =
+           GL_MAP_INVALIDATE_BUFFER_BIT | GL_MAP_INVALIDATE_RANGE_BIT;
+@@ -7212,7 +7280,9 @@
+     *result = GL_WAIT_FAILED;
+     helper_->ClientWaitSync(ToGLuint(sync), flags, timeout, GetResultShmId(),
+                             result.offset());
+-    WaitForCmd();
++    if (!WaitForCmd()) {
++      return GL_WAIT_FAILED;
++    }
+     localResult = *result;
+     GPU_CLIENT_LOG("returned " << localResult);
+   }
+@@ -7290,7 +7360,9 @@
+     result->SetNumResults(0);
+     helper_->GetInternalformativ(target, format, pname, GetResultShmId(),
+                                  result.offset());
+-    WaitForCmd();
++    if (!WaitForCmd()) {
++      return;
++    }
+     GPU_CLIENT_LOG_CODE_BLOCK({
+       for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+         GPU_CLIENT_LOG("  " << i << ": " << result->GetData()[i]);
+diff --git a/gpu/command_buffer/client/gles2_implementation_impl_autogen.h b/gpu/command_buffer/client/gles2_implementation_impl_autogen.h
+index 5db0583..9e578e3 100644
+--- a/gpu/command_buffer/client/gles2_implementation_impl_autogen.h
++++ b/gpu/command_buffer/client/gles2_implementation_impl_autogen.h
+@@ -207,7 +207,9 @@
+   }
+   *result = 0;
+   helper_->CheckFramebufferStatus(target, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return GL_FRAMEBUFFER_UNSUPPORTED;
++  }
+   GLenum result_value = *result;
+   GPU_CLIENT_LOG("returned " << result_value);
+   CheckGLError();
+@@ -882,7 +884,9 @@
+   }
+   result->SetNumResults(0);
+   helper_->GetBooleanv(pname, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(params);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -910,7 +914,9 @@
+   }
+   result->SetNumResults(0);
+   helper_->GetBooleani_v(pname, index, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(data);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -939,7 +945,9 @@
+   result->SetNumResults(0);
+   helper_->GetBufferParameteri64v(target, pname, GetResultShmId(),
+                                   result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(params);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -969,7 +977,9 @@
+   result->SetNumResults(0);
+   helper_->GetBufferParameteriv(target, pname, GetResultShmId(),
+                                 result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(params);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -994,7 +1004,9 @@
+   }
+   result->SetNumResults(0);
+   helper_->GetFloatv(pname, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(params);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -1029,7 +1041,9 @@
+   result->SetNumResults(0);
+   helper_->GetFramebufferAttachmentParameteriv(
+       target, attachment, pname, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(params);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -1054,7 +1068,9 @@
+   }
+   result->SetNumResults(0);
+   helper_->GetInteger64v(pname, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(params);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -1082,7 +1098,9 @@
+   }
+   result->SetNumResults(0);
+   helper_->GetIntegeri_v(pname, index, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(data);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -1109,7 +1127,9 @@
+   }
+   result->SetNumResults(0);
+   helper_->GetInteger64i_v(pname, index, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(data);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -1135,7 +1155,9 @@
+   }
+   result->SetNumResults(0);
+   helper_->GetIntegerv(pname, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(params);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -1163,7 +1185,9 @@
+   }
+   result->SetNumResults(0);
+   helper_->GetProgramiv(program, pname, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(params);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -1220,7 +1244,9 @@
+   result->SetNumResults(0);
+   helper_->GetRenderbufferParameteriv(target, pname, GetResultShmId(),
+                                       result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(params);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -1249,7 +1275,9 @@
+   result->SetNumResults(0);
+   helper_->GetSamplerParameterfv(sampler, pname, GetResultShmId(),
+                                  result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(params);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -1279,7 +1307,9 @@
+   result->SetNumResults(0);
+   helper_->GetSamplerParameteriv(sampler, pname, GetResultShmId(),
+                                  result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(params);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -1307,7 +1337,9 @@
+   }
+   result->SetNumResults(0);
+   helper_->GetShaderiv(shader, pname, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(params);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -1396,7 +1428,9 @@
+   }
+   result->SetNumResults(0);
+   helper_->GetSynciv(ToGLuint(sync), pname, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(values);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -1427,7 +1461,9 @@
+   }
+   result->SetNumResults(0);
+   helper_->GetTexParameterfv(target, pname, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(params);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -1456,7 +1492,9 @@
+   }
+   result->SetNumResults(0);
+   helper_->GetTexParameteriv(target, pname, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(params);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -1541,7 +1579,9 @@
+   }
+   *result = 0;
+   helper_->IsBuffer(buffer, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return GL_FALSE;
++  }
+   GLboolean result_value = *result != 0;
+   GPU_CLIENT_LOG("returned " << result_value);
+   CheckGLError();
+@@ -1560,7 +1600,9 @@
+   }
+   *result = 0;
+   helper_->IsFramebuffer(framebuffer, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return GL_FALSE;
++  }
+   GLboolean result_value = *result != 0;
+   GPU_CLIENT_LOG("returned " << result_value);
+   CheckGLError();
+@@ -1578,7 +1620,9 @@
+   }
+   *result = 0;
+   helper_->IsProgram(program, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return GL_FALSE;
++  }
+   GLboolean result_value = *result != 0;
+   GPU_CLIENT_LOG("returned " << result_value);
+   CheckGLError();
+@@ -1597,7 +1641,9 @@
+   }
+   *result = 0;
+   helper_->IsRenderbuffer(renderbuffer, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return GL_FALSE;
++  }
+   GLboolean result_value = *result != 0;
+   GPU_CLIENT_LOG("returned " << result_value);
+   CheckGLError();
+@@ -1615,7 +1661,9 @@
+   }
+   *result = 0;
+   helper_->IsSampler(sampler, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return GL_FALSE;
++  }
+   GLboolean result_value = *result != 0;
+   GPU_CLIENT_LOG("returned " << result_value);
+   CheckGLError();
+@@ -1633,7 +1681,9 @@
+   }
+   *result = 0;
+   helper_->IsShader(shader, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return GL_FALSE;
++  }
+   GLboolean result_value = *result != 0;
+   GPU_CLIENT_LOG("returned " << result_value);
+   CheckGLError();
+@@ -1651,7 +1701,9 @@
+   }
+   *result = 0;
+   helper_->IsSync(ToGLuint(sync), GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return GL_FALSE;
++  }
+   GLboolean result_value = *result != 0;
+   GPU_CLIENT_LOG("returned " << result_value);
+   CheckGLError();
+@@ -1669,7 +1721,9 @@
+   }
+   *result = 0;
+   helper_->IsTexture(texture, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return GL_FALSE;
++  }
+   GLboolean result_value = *result != 0;
+   GPU_CLIENT_LOG("returned " << result_value);
+   CheckGLError();
+@@ -1689,7 +1743,9 @@
+   *result = 0;
+   helper_->IsTransformFeedback(transformfeedback, GetResultShmId(),
+                                result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return GL_FALSE;
++  }
+   GLboolean result_value = *result != 0;
+   GPU_CLIENT_LOG("returned " << result_value);
+   CheckGLError();
+@@ -3093,7 +3149,9 @@
+   }
+   *result = 0;
+   helper_->IsVertexArrayOES(array, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return GL_FALSE;
++  }
+   GLboolean result_value = *result != 0;
+   GPU_CLIENT_LOG("returned " << result_value);
+   CheckGLError();
+@@ -3187,7 +3245,9 @@
+   result->SetNumResults(0);
+   helper_->GetProgramInterfaceiv(program, program_interface, pname,
+                                  GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(params);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -3905,7 +3965,9 @@
+   result->SetNumResults(0);
+   helper_->GetFramebufferPixelLocalStorageParameterfvANGLE(
+       plane, pname, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(params);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {
+@@ -3939,7 +4001,9 @@
+   result->SetNumResults(0);
+   helper_->GetFramebufferPixelLocalStorageParameterivANGLE(
+       plane, pname, GetResultShmId(), result.offset());
+-  WaitForCmd();
++  if (!WaitForCmd()) {
++    return;
++  }
+   result->CopyResult(params);
+   GPU_CLIENT_LOG_CODE_BLOCK({
+     for (int32_t i = 0; i < result->GetNumResults(); ++i) {

--- a/patches/chromium/cherry-pick-b922fcb61e3b.patch
+++ b/patches/chromium/cherry-pick-b922fcb61e3b.patch
@@ -1,0 +1,90 @@
+From b922fcb61e3b12cc53d0151605207e8d5578dfa7 Mon Sep 17 00:00:00 2001
+From: rubberyuzu <yuzus@chromium.org>
+Date: Fri, 17 May 2024 02:53:09 +0000
+Subject: [PATCH] [bfcache] Use WeakPtr for delegate_
+
+This CL starts using a WeakPtr for `delegate_`. This is because
+`ReportFeaturesToDelegate()` is posted and when it's executed,
+`delegate_` might be destroyed.
+
+(cherry picked from commit da7a6845e589dc71da9898f7e181a7c88a62e2e1)
+
+Bug: 336012573
+Change-Id: I9aa5ee7ae7d484d4208e6bdd8ea2853763d69a6b
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5493004
+Reviewed-by: Kentaro Hara <haraken@chromium.org>
+Commit-Queue: Yuzu Saijo <yuzus@chromium.org>
+Reviewed-by: Fergal Daly <fergal@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1297242}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5547038
+Auto-Submit: Yuzu Saijo <yuzus@chromium.org>
+Commit-Queue: Kentaro Hara <haraken@chromium.org>
+Cr-Commit-Position: refs/branch-heads/6367@{#1190}
+Cr-Branched-From: d158c6dc6e3604e6f899041972edf26087a49740-refs/heads/main@{#1274542}
+---
+
+diff --git a/third_party/blink/renderer/platform/scheduler/common/back_forward_cache_disabling_feature_tracker.cc b/third_party/blink/renderer/platform/scheduler/common/back_forward_cache_disabling_feature_tracker.cc
+index 2f57918..4b353b7 100644
+--- a/third_party/blink/renderer/platform/scheduler/common/back_forward_cache_disabling_feature_tracker.cc
++++ b/third_party/blink/renderer/platform/scheduler/common/back_forward_cache_disabling_feature_tracker.cc
+@@ -22,9 +22,13 @@
+ 
+ void BackForwardCacheDisablingFeatureTracker::SetDelegate(
+     FrameOrWorkerScheduler::Delegate* delegate) {
++  // This function is only called when initializing. `delegate_` should be
++  // nullptr at first.
+   DCHECK(!delegate_);
+-  delegate_ = delegate;
+-  // `delegate` might be nullptr on tests.
++  // `delegate` can be nullptr for tests.
++  if (delegate) {
++    delegate_ = (*delegate).AsWeakPtr();
++  }
+ }
+ 
+ void BackForwardCacheDisablingFeatureTracker::Reset() {
+@@ -163,7 +167,13 @@
+   last_reported_sticky_ = sticky_features_and_js_locations_;
+   FrameOrWorkerScheduler::Delegate::BlockingDetails details(
+       non_sticky_features_and_js_locations_, sticky_features_and_js_locations_);
+-  delegate_->UpdateBackForwardCacheDisablingFeatures(details);
++
++  // Check if the delegate still exists. This check is necessary because
++  // `FrameOrWorkerScheduler::Delegate` might be destroyed and thus `delegate_`
++  // might be gone when `ReportFeaturesToDelegate() is executed.
++  if (delegate_) {
++    delegate_->UpdateBackForwardCacheDisablingFeatures(details);
++  }
+ }
+ 
+ }  // namespace scheduler
+diff --git a/third_party/blink/renderer/platform/scheduler/common/back_forward_cache_disabling_feature_tracker.h b/third_party/blink/renderer/platform/scheduler/common/back_forward_cache_disabling_feature_tracker.h
+index c78d791..1ec5cc4 100644
+--- a/third_party/blink/renderer/platform/scheduler/common/back_forward_cache_disabling_feature_tracker.h
++++ b/third_party/blink/renderer/platform/scheduler/common/back_forward_cache_disabling_feature_tracker.h
+@@ -119,8 +119,7 @@
+   BFCacheBlockingFeatureAndLocations non_sticky_features_and_js_locations_;
+   BFCacheBlockingFeatureAndLocations sticky_features_and_js_locations_;
+ 
+-  raw_ptr<FrameOrWorkerScheduler::Delegate, DanglingUntriaged> delegate_ =
+-      nullptr;
++  base::WeakPtr<FrameOrWorkerScheduler::Delegate> delegate_ = nullptr;
+   raw_ptr<ThreadSchedulerBase, DanglingUntriaged> scheduler_;
+ 
+   base::WeakPtrFactory<BackForwardCacheDisablingFeatureTracker> weak_factory_{
+diff --git a/third_party/blink/renderer/platform/scheduler/public/frame_or_worker_scheduler.h b/third_party/blink/renderer/platform/scheduler/public/frame_or_worker_scheduler.h
+index 12b056f..e2bdb43d 100644
+--- a/third_party/blink/renderer/platform/scheduler/public/frame_or_worker_scheduler.h
++++ b/third_party/blink/renderer/platform/scheduler/public/frame_or_worker_scheduler.h
+@@ -150,6 +150,11 @@
+     // changed when a blocking feature and its JS location are registered or
+     // removed.
+     virtual void UpdateBackForwardCacheDisablingFeatures(BlockingDetails) = 0;
++
++    base::WeakPtr<Delegate> AsWeakPtr() {
++      return weak_ptr_factory_.GetWeakPtr();
++    }
++    base::WeakPtrFactory<Delegate> weak_ptr_factory_{this};
+   };
+ 
+   virtual ~FrameOrWorkerScheduler();

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -5,3 +5,4 @@ cherry-pick-f320600cd1f4.patch
 cherry-pick-b3c01ac1e60a.patch
 cherry-pick-6503a987d966.patch
 cherry-pick-3e037e195e50.patch
+cherry-pick-e7b64c6ee185.patch

--- a/patches/v8/cherry-pick-e7b64c6ee185.patch
+++ b/patches/v8/cherry-pick-e7b64c6ee185.patch
@@ -1,0 +1,32 @@
+From e7b64c6ee185693ff1e45f0d7af1850d7f439fb7 Mon Sep 17 00:00:00 2001
+From: Matthias Liedtke <mliedtke@chromium.org>
+Date: Fri, 10 May 2024 10:38:29 +0200
+Subject: [PATCH] Merged: [builtins] HasOnlySimpleElements is false for non-JSObjects
+
+Bug: 338908243
+(cherry picked from commit cc05792346fb017eaa961ee7d35cf1f9bb53bb0a)
+
+Change-Id: I9b5c2333924a54169ea3fa48e67e7db2ec67f6b9
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5545380
+Reviewed-by: Jakob Kummerow <jkummerow@chromium.org>
+Commit-Queue: Matthias Liedtke <mliedtke@chromium.org>
+Auto-Submit: Matthias Liedtke <mliedtke@chromium.org>
+Commit-Queue: Jakob Kummerow <jkummerow@chromium.org>
+Cr-Commit-Position: refs/branch-heads/12.4@{#34}
+Cr-Branched-From: 309640da62fae0485c7e4f64829627c92d53b35d-refs/heads/12.4.254@{#1}
+Cr-Branched-From: 5dc24701432278556a9829d27c532f974643e6df-refs/heads/main@{#92862}
+---
+
+diff --git a/src/builtins/builtins-array.cc b/src/builtins/builtins-array.cc
+index 60dc193..dc82b65 100644
+--- a/src/builtins/builtins-array.cc
++++ b/src/builtins/builtins-array.cc
+@@ -51,7 +51,7 @@
+   DisallowGarbageCollection no_gc;
+   PrototypeIterator iter(isolate, receiver, kStartAtReceiver);
+   for (; !iter.IsAtEnd(); iter.Advance()) {
+-    if (IsJSProxy(iter.GetCurrent())) return false;
++    if (!IsJSObject(iter.GetCurrent())) return false;
+     Tagged<JSObject> current = iter.GetCurrent<JSObject>();
+     if (!HasSimpleElements(current)) return false;
+   }


### PR DESCRIPTION
<details>
<summary>electron/security#515 - e7b64c6ee185 from v8</summary>
Merged: [builtins] HasOnlySimpleElements is false for non-JSObjects

Bug: 338908243
(cherry picked from commit cc05792346fb017eaa961ee7d35cf1f9bb53bb0a)

Change-Id: I9b5c2333924a54169ea3fa48e67e7db2ec67f6b9
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5545380
Reviewed-by: Jakob Kummerow <jkummerow@chromium.org>
Commit-Queue: Matthias Liedtke <mliedtke@chromium.org>
Auto-Submit: Matthias Liedtke <mliedtke@chromium.org>
Commit-Queue: Jakob Kummerow <jkummerow@chromium.org>
Cr-Commit-Position: refs/branch-heads/12.4@{#34}
Cr-Branched-From: 309640da62fae0485c7e4f64829627c92d53b35d-refs/heads/12.4.254@{#1}
Cr-Branched-From: 5dc24701432278556a9829d27c532f974643e6df-refs/heads/main@{#92862}
</details>

<details>
<summary>electron/security#516 - 867c1001637e from DirectXShaderCompiler</summary>
Fix invalid module bitcode when indexing a swizzled bool vector (#6582)

When indexing a swizzled bool vector, some HLSL-specific code in
EmitCXXMemberOrOperatorMemberCallExpr kicks in to handle the
HLSLVecType. In this case, we’re dealing with an ExtVectorElt because of
the swizzle, so this function creates a GEP, Load, and Store on the
vector. However, boolean scalars are returned as type i11 while the
store is storing to a bool, which is an i32, so we need to insert a cast
before the store.

Bug: chromium:338161969
Change-Id: I45f8ec383be49210a10f725d8266b66fd30c34be
Reviewed-on: https://chromium-review.googlesource.com/c/external/github.com/microsoft/DirectXShaderCompiler/+/5545820
Reviewed-by: James Price <jrprice@google.com>
Reviewed-by: dan sinclair <dsinclair@google.com>
</details>

<details>
<summary>electron/security#517 - b922fcb61e3b from chromium</summary>
[bfcache] Use WeakPtr for delegate_

This CL starts using a WeakPtr for `delegate_`. This is because
`ReportFeaturesToDelegate()` is posted and when it's executed,
`delegate_` might be destroyed.

(cherry picked from commit da7a6845e589dc71da9898f7e181a7c88a62e2e1)

Bug: 336012573
Change-Id: I9aa5ee7ae7d484d4208e6bdd8ea2853763d69a6b
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5493004
Reviewed-by: Kentaro Hara <haraken@chromium.org>
Commit-Queue: Yuzu Saijo <yuzus@chromium.org>
Reviewed-by: Fergal Daly <fergal@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1297242}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5547038
Auto-Submit: Yuzu Saijo <yuzus@chromium.org>
Commit-Queue: Kentaro Hara <haraken@chromium.org>
Cr-Commit-Position: refs/branch-heads/6367@{#1190}
Cr-Branched-From: d158c6dc6e3604e6f899041972edf26087a49740-refs/heads/main@{#1274542}
</details>

<details>
<summary>electron/security#518 - bda89e1f7c71 from angle</summary>
M124: Vulkan: Turn SPIR-V limitations to crash instead of security bug

The input shader can be made complex in a number of different ways,
resulting in instructions with a length higher than what can fit in
SPIR-V (i.e. 16 bits).  Ideally, the translator would catch such complex
usage early on and gracefully fail compilation.  However, as a safety
net, this change makes sure such a case is detected when the SPIR-V
instruction is being generated and turned into a crash.  This makes sure
such bugs are no longer security bugs.

Bug: chromium:335613092
Change-Id: Iab16b49ed80929fc343b4c7bffce306919de2e96
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5547611
Reviewed-by: Roman Lavrov <romanl@google.com>
</details>

<details>
<summary>electron/security#513 - 0d9598145069 from chromium</summary>
Fix bugs in GLES* command handlers

If the command buffer is in an invalid state then we can't trust
the contents of the get buffer.

(cherry picked from commit 374789ab8f5eeac24e2e335af825d34b8c3fde81)

Bug: 340822365,40947303
Change-Id: I465d617e5056877fb464dd59df983a9e8d866b85
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5542488
Commit-Queue: Brendon Tiszka <tiszka@chromium.org>
Reviewed-by: Geoff Lang <geofflang@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1301529}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5550571
Reviewed-by: Brendon Tiszka <tiszka@chromium.org>
Owners-Override: Prudhvikumar Bommana <pbommana@google.com>
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Cr-Commit-Position: refs/branch-heads/6367@{#1205}
Cr-Branched-From: d158c6dc6e3604e6f899041972edf26087a49740-refs/heads/main@{#1274542}
</details>

Notes:
* Security: backported fix for CVE-2024-5158.
* Security: backported fix for CVE-2024-5160.
* Security: backported fix for CVE-2024-5157.
* Security: backported fix for CVE-2024-5159.
* Security: backported fix for 340822365.