### PR TITLE
build: re-enable self-cert codesigning on x64 macOS

### DIFF
--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -130,12 +130,12 @@ jobs:
         unzip -:o dist.zip
         unzip -:o chromedriver.zip
         unzip -:o mksnapshot.zip
-    # - name: Import & Trust Self-Signed Codesigning Cert on MacOS
-    #   if: ${{ inputs.target-platform == 'macos' }}
-    #   run: |
-    #     sudo security authorizationdb write com.apple.trust-settings.admin allow
-    #     cd src/electron
-    #     ./script/codesign/generate-identity.sh
+    - name: Import & Trust Self-Signed Codesigning Cert on MacOS
+      if: ${{ inputs.target-platform == 'macos' && inputs.target-arch == 'x64' }}
+      run: |
+        sudo security authorizationdb write com.apple.trust-settings.admin allow
+        cd src/electron
+        ./script/codesign/generate-identity.sh
     - name: Run Electron Tests
       shell: bash
       env:

--- a/spec/lib/codesign-helpers.ts
+++ b/spec/lib/codesign-helpers.ts
@@ -8,7 +8,7 @@ const fixturesPath = path.resolve(__dirname, '..', 'fixtures');
 
 export const shouldRunCodesignTests =
     process.platform === 'darwin' &&
-    !process.env.CI &&
+    !(process.env.CI && process.arch === 'arm64') &&
     !process.mas &&
     !features.isComponentBuild();
 


### PR DESCRIPTION
#### Description of Change

Re-enables self-certified codesigning on macOS an associated tests. It continues to fail mysteriously on arm64 - but we weren't running this on arm64 in Circle either so let's at least bring it back on x64.

Successful build: https://github.com/electron/electron/actions/runs/9572243925

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
