### PR TITLE
fix: fetch-dependent interfaces in Web Workers

### DIFF
--- a/lib/worker/init.ts
+++ b/lib/worker/init.ts
@@ -17,6 +17,14 @@ const { makeRequireFunction } = __non_webpack_require__('internal/modules/helper
 global.module = new Module('electron/js2c/worker_init');
 global.require = makeRequireFunction(global.module);
 
+// See WebWorkerObserver::WorkerScriptReadyForEvaluation.
+if ((globalThis as any).blinkfetch) {
+  const keys = ['fetch', 'Response', 'FormData', 'Request', 'Headers'];
+  for (const key of keys) {
+    (globalThis as any)[key] = (globalThis as any)[`blink${key}`];
+  }
+}
+
 // Set the __filename to the path of html file if it is file: protocol.
 // NB. 'self' isn't defined in an AudioWorklet.
 if (typeof self !== 'undefined' && self.location.protocol === 'file:') {

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -1019,10 +1019,33 @@ describe('chromium features', () => {
     });
 
     it('Worker has node integration with nodeIntegrationInWorker', async () => {
-      const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, nodeIntegrationInWorker: true, contextIsolation: false } });
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true,
+          nodeIntegrationInWorker: true,
+          contextIsolation: false
+        }
+      });
+
       w.loadURL(`file://${fixturesPath}/pages/worker.html`);
       const [, data] = await once(ipcMain, 'worker-result');
       expect(data).to.equal('object function object function');
+    });
+
+    it('Worker has access to fetch-dependent interfaces with nodeIntegrationInWorker', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true,
+          nodeIntegrationInWorker: true,
+          contextIsolation: false
+        }
+      });
+
+      w.loadURL(`file://${fixturesPath}/pages/worker-fetch.html`);
+      const [, data] = await once(ipcMain, 'worker-fetch-result');
+      expect(data).to.equal('function function function function function');
     });
 
     describe('SharedWorker', () => {

--- a/spec/fixtures/pages/worker-fetch.html
+++ b/spec/fixtures/pages/worker-fetch.html
@@ -1,0 +1,12 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  const { ipcRenderer } = require('electron')
+  let worker = new Worker(`../workers/worker_node_fetch.js`)
+  worker.onmessage = function (event) {
+    ipcRenderer.send('worker-fetch-result', event.data)
+    worker.terminate()
+  }
+</script>
+</body>
+</html>

--- a/spec/fixtures/workers/worker_node_fetch.js
+++ b/spec/fixtures/workers/worker_node_fetch.js
@@ -1,0 +1,7 @@
+self.postMessage([
+  typeof fetch,
+  typeof Response,
+  typeof Request,
+  typeof Headers,
+  typeof FormData
+].join(' '));

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -159,6 +159,38 @@ describe('node feature', () => {
     });
   });
 
+  describe('fetch', () => {
+    itremote('works correctly when nodeIntegration is enabled in the renderer', async (fixtures: string) => {
+      const file = require('node:path').join(fixtures, 'hello.txt');
+      expect(() => {
+        fetch('file://' + file);
+      }).to.not.throw();
+
+      expect(() => {
+        const formData = new FormData();
+        formData.append('username', 'Groucho');
+      }).not.to.throw();
+
+      expect(() => {
+        const request = new Request('https://example.com', {
+          method: 'POST',
+          body: JSON.stringify({ foo: 'bar' })
+        });
+        expect(request.method).to.equal('POST');
+      }).not.to.throw();
+
+      expect(() => {
+        const response = new Response('Hello, world!');
+        expect(response.status).to.equal(200);
+      }).not.to.throw();
+
+      expect(() => {
+        const headers = new Headers();
+        headers.append('Content-Type', 'text/xml');
+      }).not.to.throw();
+    }, [fixtures]);
+  });
+
   it('does not hang when using the fs module in the renderer process', async () => {
     const appPath = path.join(mainFixturesPath, 'apps', 'libuv-hang', 'main.js');
     const appProcess = childProcess.spawn(process.execPath, [appPath], {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42577.

Addresses missing fetch-dependent interfaces in Web Workers using the same approach as in the renderer when `nodeIntegrationInWorker` is enabled. Also adds tests.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `fetch`-dependent interfaces could be missing in Web Workers with `nodeIntegrationInWorker` enabled.