### PR TITLE
#40173 issue: Update main.js

### DIFF
--- a/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/main.js
+++ b/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/main.js
@@ -1,65 +1,91 @@
 // Modules to control application life and create native browser window
-const { app, BrowserWindow, ipcMain, shell, dialog } = require('electron/main')
-const path = require('node:path')
+const { app, BrowserWindow, ipcMain, shell, dialog } = require("electron/main");
+const path = require("node:path");
 
-let mainWindow
+let mainWindow;
 
 if (process.defaultApp) {
   if (process.argv.length >= 2) {
-    app.setAsDefaultProtocolClient('electron-fiddle', process.execPath, [path.resolve(process.argv[1])])
+    app.setAsDefaultProtocolClient("electron-fiddle", process.execPath, [
+      path.resolve(process.argv[1]),
+    ]);
   }
 } else {
-  app.setAsDefaultProtocolClient('electron-fiddle')
+  app.setAsDefaultProtocolClient("electron-fiddle");
 }
 
-const gotTheLock = app.requestSingleInstanceLock()
+const gotTheLock = app.requestSingleInstanceLock();
 
 if (!gotTheLock) {
-  app.quit()
+  app.quit();
 } else {
-  app.on('second-instance', (event, commandLine, workingDirectory) => {
+  app.on("second-instance", (event, commandLine, workingDirectory) => {
     // Someone tried to run a second instance, we should focus our window.
     if (mainWindow) {
-      if (mainWindow.isMinimized()) mainWindow.restore()
-      mainWindow.focus()
+      if (mainWindow.isMinimized()) mainWindow.restore();
+      mainWindow.focus();
     }
 
-    dialog.showErrorBox('Welcome Back', `You arrived from: ${commandLine.pop().slice(0, -1)}`)
-  })
+    // Check if a deep link was provided
+    const url = commandLine.find((arg) => arg.startsWith("electron-fiddle://"));
+    if (url) {
+      handleDeepLink(url);
+    }
+  });
 
   // Create mainWindow, load the rest of the app, etc...
   app.whenReady().then(() => {
-    createWindow()
-  })
+    createWindow();
 
-  app.on('open-url', (event, url) => {
-    dialog.showErrorBox('Welcome Back', `You arrived from: ${url}`)
-  })
+    // Check if a deep link was provided at launch
+    if (process.argv.length > 1) {
+      const url = process.argv.find((arg) =>
+        arg.startsWith("electron-fiddle://")
+      );
+      if (url) {
+        handleDeepLink(url);
+      }
+    }
+  });
+
+  app.on("open-url", (event, url) => {
+    event.preventDefault();
+    handleDeepLink(url);
+  });
 }
 
-function createWindow () {
+function createWindow() {
   // Create the browser window.
   mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js')
-    }
-  })
+      preload: path.join(__dirname, "preload.js"),
+    },
+  });
 
-  mainWindow.loadFile('index.html')
+  mainWindow.loadFile("index.html");
+}
+
+// Function to handle deep links
+function handleDeepLink(url) {
+  if (mainWindow) {
+    if (mainWindow.isMinimized()) mainWindow.restore();
+    mainWindow.focus();
+    dialog.showErrorBox("Welcome", `You arrived from: ${url}`);
+  }
 }
 
 // Quit when all windows are closed, except on macOS. There, it's common
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
-app.on('window-all-closed', function () {
-  if (process.platform !== 'darwin') app.quit()
-})
+app.on("window-all-closed", function () {
+  if (process.platform !== "darwin") app.quit();
+});
 
 // Handle window controls via IPC
-ipcMain.on('shell:open', () => {
-  const pageDirectory = __dirname.replace('app.asar', 'app.asar.unpacked')
-  const pagePath = path.join('file://', pageDirectory, 'index.html')
-  shell.openExternal(pagePath)
-})
+ipcMain.on("shell:open", () => {
+  const pageDirectory = __dirname.replace("app.asar", "app.asar.unpacked");
+  const pagePath = path.join("file://", pageDirectory, "index.html");
+  shell.openExternal(pagePath);
+});


### PR DESCRIPTION
#### Description of Change

This PR implements deep link handling for the Electron app using the custom protocol electron-fiddle://. It ensures deep links are processed correctly whether the app is running or not.

Changes
=>macOS:
Handle open-url event to process deep links.
=>Windows/Linux:
Handle second-instance event for deep links when the app is already running.
Check process.argv for deep links on initial launch.
->Single Instance:
Ensure only one instance of the app runs using app.requestSingleInstanceLock().
Focus the existing window if a second instance is attempted.
->Refactor:
Consolidate deep link handling into handleDeepLink(url) function.
->User Feedback:
Use dialog.showErrorBox to show deep link URLs.
->Requirements
 Handle deep links on macOS via open-url.
 Handle deep links on Windows/Linux via second-instance and process.argv.
 Implement single instance lock.
 Refactor deep link handling logic.
 Provide user feedback for deep links.
->Testing
macOS: Test deep links with the app running and closed.
Windows/Linux: Test deep links with the app running and closed. Verify process.argv on initial launch.

#### one-line description
Implement deep link handling for the electron-fiddle:// protocol to ensure proper URL processing on macOS, Windows, and Linux.
