### PR TITLE
feat: [net] add "priority" option to net.request

### DIFF
--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -60,6 +60,10 @@ following properties:
     `strict-origin-when-cross-origin`.
   * `cache` string (optional) - can be `default`, `no-store`, `reload`,
     `no-cache`, `force-cache` or `only-if-cached`.
+  * `priority` string (optional) - can be `throttled`, `idle`, `lowest`,
+    `low`, `medium`, or `highest`. Defaults to `idle`.
+  * `priorityIncremental` boolean (optional) - the incremental loading flag as part
+    of HTTP extensible priorities (RFC 9218). Default is `true`.
 
 `options` properties such as `protocol`, `host`, `hostname`, `port` and `path`
 strictly follow the Node.js model as described in the

--- a/lib/common/api/net-client-request.ts
+++ b/lib/common/api/net-client-request.ts
@@ -288,8 +288,12 @@ function parseOptions (optionsIn: ClientRequestConstructorOptions | string): Nod
     origin: options.origin,
     referrerPolicy: options.referrerPolicy,
     cache: options.cache,
-    allowNonHttpProtocols: Object.hasOwn(options, kAllowNonHttpProtocols)
+    allowNonHttpProtocols: Object.hasOwn(options, kAllowNonHttpProtocols),
+    priority: options.priority
   };
+  if ('priorityIncremental' in options) {
+    urlLoaderOptions.priorityIncremental = options.priorityIncremental;
+  }
   const headers: Record<string, string | string[]> = options.headers || {};
   for (const [name, value] of Object.entries(headers)) {
     validateHeader(name, value);

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -638,6 +638,24 @@ gin::Handle<SimpleURLLoaderWrapper> SimpleURLLoaderWrapper::Create(
       break;
   }
 
+  if (std::string priority; opts.Get("priority", &priority)) {
+    static constexpr auto Lookup =
+        base::MakeFixedFlatMap<std::string_view, net::RequestPriority>({
+            {"throttled", net::THROTTLED},
+            {"idle", net::IDLE},
+            {"lowest", net::LOWEST},
+            {"low", net::LOW},
+            {"medium", net::MEDIUM},
+            {"highest", net::HIGHEST},
+        });
+    if (auto iter = Lookup.find(priority); iter != Lookup.end())
+      request->priority = iter->second;
+  }
+  if (bool priorityIncremental = request->priority_incremental;
+      opts.Get("priorityIncremental", &priorityIncremental)) {
+    request->priority_incremental = priorityIncremental;
+  }
+
   const bool use_session_cookies =
       opts.ValueOrDefault("useSessionCookies", false);
   int options = network::mojom::kURLLoadOptionSniffMimeType;

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -177,6 +177,8 @@ declare namespace NodeJS {
     mode?: string;
     destination?: string;
     bypassCustomProtocolHandlers?: boolean;
+    priority?: 'throttled' | 'idle' | 'lowest' | 'low' | 'medium' | 'highest';
+    priorityIncremental?: boolean;
   };
   type ResponseHead = {
     statusCode: number;


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Add the priority and priorityIncremental options to customize the Priority header of requests sent by net.request.
Currently all requests sent by net.request have a priority header with value `u=4, i`, this maybe unexpected. We want it fully customizable and match the Chrome exactly if possible.

Close #46680

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added the priority and priorityIncremental options to net.request()
