### PR TITLE
build: account for `subjectAndDescription` null in patch linting

### DIFF
--- a/script/lint.js
+++ b/script/lint.js
@@ -252,8 +252,10 @@ const LINTERS = [{
 
     const allOk = filenames.length > 0 && filenames.map(f => {
       const patchText = fs.readFileSync(f, 'utf8');
-      const subjectAndDescription = /Subject: (.*?)\n\n([\s\S]*?)\s*(?=diff)/ms.exec(patchText);
-      if (!subjectAndDescription[2]) {
+
+      const regex = /Subject: (.*?)\n\n([\s\S]*?)\s*(?=diff)/ms;
+      const subjectAndDescription = regex.exec(patchText);
+      if (!subjectAndDescription?.[2]) {
         console.warn(`Patch file '${f}' has no description. Every patch must contain a justification for why the patch exists and the plan for its removal.`);
         return false;
       }


### PR DESCRIPTION
#### Description of Change

Sample error:

```js
electron on git:roller/chromium/main ❯ node ./script/lint.js --patches
TypeError: Cannot read properties of null (reading '2')
    at /Users/codebytere/Developer/electron-gn/src/electron/script/lint.js:256:33
    at Array.map (<anonymous>)
    at Object.run (/Users/codebytere/Developer/electron-gn/src/electron/script/lint.js:253:53)
    at main (/Users/codebytere/Developer/electron-gn/src/electron/script/lint.js:469:20)
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none