### PR TITLE
fix: use `BlockedRequest` struct to handle `webRequest` data

### DIFF
--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -185,9 +185,10 @@ void FillDetails(gin_helper::Dictionary* details, Arg arg, Args... args) {
   FillDetails(details, args...);
 }
 
+// Modified from extensions/browser/api/web_request/web_request_api_helpers.cc.
 std::pair<std::set<std::string>, std::set<std::string>>
-CalculateOnBeforeSendHeadersDelta(net::HttpRequestHeaders* old_headers,
-                                  net::HttpRequestHeaders* new_headers) {
+CalculateOnBeforeSendHeadersDelta(const net::HttpRequestHeaders* old_headers,
+                                  const net::HttpRequestHeaders* new_headers) {
   // Newly introduced or overridden request headers.
   std::set<std::string> modified_request_headers;
   // Keys of request headers to be deleted.
@@ -473,8 +474,10 @@ void WebRequest::OnBeforeSendHeadersListenerResult(
     }
   }
 
-  std::pair<std::set<std::string>, std::set<std::string>> updated_headers =
-      CalculateOnBeforeSendHeadersDelta(old_headers, &new_headers);
+  // If the user passes |cancel|, |new_headers| should be nullptr.
+  const auto updated_headers = CalculateOnBeforeSendHeadersDelta(
+      old_headers,
+      result == net::ERR_BLOCKED_BY_CLIENT ? nullptr : &new_headers);
 
   // Leave |request.request_headers| unchanged if the user didn't modify it.
   if (user_modified_headers)

--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -185,22 +185,6 @@ void FillDetails(gin_helper::Dictionary* details, Arg arg, Args... args) {
   FillDetails(details, args...);
 }
 
-void ReadFromResponse(v8::Isolate* isolate,
-                      gin::Dictionary* response,
-                      const std::pair<scoped_refptr<net::HttpResponseHeaders>*,
-                                      const std::string>& headers) {
-  std::string status_line;
-  if (!response->Get("statusLine", &status_line))
-    status_line = headers.second;
-  v8::Local<v8::Value> value;
-  if (response->Get("responseHeaders", &value) && value->IsObject()) {
-    *headers.first = new net::HttpResponseHeaders("");
-    (*headers.first)->ReplaceStatusLine(status_line);
-    gin::Converter<net::HttpResponseHeaders*>::FromV8(isolate, value,
-                                                      (*headers.first).get());
-  }
-}
-
 std::pair<std::set<std::string>, std::set<std::string>>
 CalculateOnBeforeSendHeadersDelta(net::HttpRequestHeaders* old_headers,
                                   net::HttpRequestHeaders* new_headers) {
@@ -279,14 +263,21 @@ bool WebRequest::RequestFilter::MatchesRequest(
   return MatchesURL(info->url) && MatchesType(info->web_request_type);
 }
 
-// Contains info about requests that are blocked waiting for a response from
-// an extension.
 struct WebRequest::BlockedRequest {
   BlockedRequest() = default;
   raw_ptr<const extensions::WebRequestInfo> request = nullptr;
   net::CompletionOnceCallback callback;
+  // Only used for onBeforeSendHeaders.
   BeforeSendHeadersCallback before_send_headers_callback;
+  // Only used for onBeforeSendHeaders.
   raw_ptr<net::HttpRequestHeaders> request_headers = nullptr;
+  // Only used for onHeadersReceived.
+  scoped_refptr<const net::HttpResponseHeaders> original_response_headers;
+  // Only used for onHeadersReceived.
+  raw_ptr<scoped_refptr<net::HttpResponseHeaders>> override_response_headers =
+      nullptr;
+  std::string status_line;
+  // Only used for onBeforeRequest.
   raw_ptr<GURL> new_url = nullptr;
 };
 
@@ -489,8 +480,6 @@ void WebRequest::OnBeforeSendHeadersListenerResult(
   if (user_modified_headers)
     request.request_headers->Swap(&new_headers);
 
-  // The ProxyingURLLoaderFactory expects the callback to be executed
-  // asynchronously, because it used to work on IO thread before NetworkService.
   base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
       FROM_HERE,
       base::BindOnce(std::move(request.before_send_headers_callback),
@@ -505,12 +494,86 @@ int WebRequest::OnHeadersReceived(
     const net::HttpResponseHeaders* original_response_headers,
     scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
     GURL* allowed_unsafe_redirect_url) {
-  const std::string& status_line =
-      original_response_headers ? original_response_headers->GetStatusLine()
-                                : std::string();
-  return HandleResponseEvent(
-      ResponseEvent::kOnHeadersReceived, info, std::move(callback),
-      std::make_pair(override_response_headers, status_line), request);
+  return HandleOnHeadersReceivedResponseEvent(
+      info, request, std::move(callback), original_response_headers,
+      override_response_headers);
+}
+
+int WebRequest::HandleOnHeadersReceivedResponseEvent(
+    extensions::WebRequestInfo* request_info,
+    const network::ResourceRequest& request,
+    net::CompletionOnceCallback callback,
+    const net::HttpResponseHeaders* original_response_headers,
+    scoped_refptr<net::HttpResponseHeaders>* override_response_headers) {
+  const auto iter = response_listeners_.find(ResponseEvent::kOnHeadersReceived);
+  if (iter == std::end(response_listeners_))
+    return net::OK;
+
+  const auto& info = iter->second;
+  if (!info.filter.MatchesRequest(request_info))
+    return net::OK;
+
+  BlockedRequest blocked_request;
+  blocked_request.callback = std::move(callback);
+  blocked_request.override_response_headers = override_response_headers;
+  blocked_request.status_line = original_response_headers
+                                    ? original_response_headers->GetStatusLine()
+                                    : std::string();
+  blocked_requests_[request_info->id] = std::move(blocked_request);
+
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+  gin_helper::Dictionary details(isolate, v8::Object::New(isolate));
+  FillDetails(&details, request_info, request);
+
+  ResponseCallback response =
+      base::BindOnce(&WebRequest::OnHeadersReceivedListenerResult,
+                     base::Unretained(this), request_info->id);
+  info.listener.Run(gin::ConvertToV8(isolate, details), std::move(response));
+  return net::ERR_IO_PENDING;
+}
+
+void WebRequest::OnHeadersReceivedListenerResult(
+    uint64_t id,
+    v8::Local<v8::Value> response) {
+  const auto iter = blocked_requests_.find(id);
+  if (iter == std::end(blocked_requests_))
+    return;
+
+  auto& request = iter->second;
+
+  int result = net::OK;
+  bool user_modified_headers = false;
+  scoped_refptr<net::HttpResponseHeaders> override_headers(
+      new net::HttpResponseHeaders(""));
+  if (response->IsObject()) {
+    v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+    gin::Dictionary dict(isolate, response.As<v8::Object>());
+
+    bool cancel = false;
+    dict.Get("cancel", &cancel);
+    if (cancel) {
+      result = net::ERR_BLOCKED_BY_CLIENT;
+    } else {
+      std::string status_line;
+      if (!dict.Get("statusLine", &status_line))
+        status_line = request.status_line;
+      v8::Local<v8::Value> value;
+      if (dict.Get("responseHeaders", &value) && value->IsObject()) {
+        user_modified_headers = true;
+        override_headers->ReplaceStatusLine(status_line);
+        gin::Converter<net::HttpResponseHeaders*>::FromV8(
+            isolate, value, override_headers.get());
+      }
+    }
+  }
+
+  if (user_modified_headers)
+    request.override_response_headers->swap(override_headers);
+
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE, base::BindOnce(std::move(request.callback), result));
+  blocked_requests_.erase(iter);
 }
 
 void WebRequest::OnSendHeaders(extensions::WebRequestInfo* info,
@@ -640,65 +703,6 @@ void WebRequest::HandleSimpleEvent(SimpleEvent event,
   gin_helper::Dictionary details(isolate, v8::Object::New(isolate));
   FillDetails(&details, request_info, args...);
   info.listener.Run(gin::ConvertToV8(isolate, details));
-}
-
-template <typename Out, typename... Args>
-int WebRequest::HandleResponseEvent(ResponseEvent event,
-                                    extensions::WebRequestInfo* request_info,
-                                    net::CompletionOnceCallback callback,
-                                    Out out,
-                                    Args... args) {
-  const auto iter = response_listeners_.find(event);
-  if (iter == std::end(response_listeners_))
-    return net::OK;
-
-  const auto& info = iter->second;
-  if (!info.filter.MatchesRequest(request_info))
-    return net::OK;
-
-  BlockedRequest request;
-  request.callback = std::move(callback);
-  blocked_requests_[request_info->id] = std::move(request);
-
-  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-  v8::HandleScope handle_scope(isolate);
-  gin_helper::Dictionary details(isolate, v8::Object::New(isolate));
-  FillDetails(&details, request_info, args...);
-
-  ResponseCallback response =
-      base::BindOnce(&WebRequest::OnListenerResult<Out>, base::Unretained(this),
-                     request_info->id, out);
-  info.listener.Run(gin::ConvertToV8(isolate, details), std::move(response));
-  return net::ERR_IO_PENDING;
-}
-
-template <typename T>
-void WebRequest::OnListenerResult(uint64_t id,
-                                  T out,
-                                  v8::Local<v8::Value> response) {
-  const auto iter = blocked_requests_.find(id);
-  if (iter == std::end(blocked_requests_))
-    return;
-
-  int result = net::OK;
-  if (response->IsObject()) {
-    v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-    gin::Dictionary dict(isolate, response.As<v8::Object>());
-
-    bool cancel = false;
-    dict.Get("cancel", &cancel);
-    if (cancel)
-      result = net::ERR_BLOCKED_BY_CLIENT;
-    else
-      ReadFromResponse(isolate, &dict, out);
-  }
-
-  // The ProxyingURLLoaderFactory expects the callback to be executed
-  // asynchronously, because it used to work on IO thread before NetworkService.
-  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
-      FROM_HERE,
-      base::BindOnce(std::move(blocked_requests_[id].callback), result));
-  blocked_requests_.erase(iter);
 }
 
 // static

--- a/shell/browser/api/electron_api_web_request.h
+++ b/shell/browser/api/electron_api_web_request.h
@@ -84,6 +84,8 @@ class WebRequest : public gin::Wrappable<WebRequest>, public WebRequestAPI {
   WebRequest(v8::Isolate* isolate, content::BrowserContext* browser_context);
   ~WebRequest() override;
 
+  // Contains info about requests that are blocked waiting for a response from
+  // the user.
   struct BlockedRequest;
 
   enum class SimpleEvent {
@@ -116,15 +118,6 @@ class WebRequest : public gin::Wrappable<WebRequest>, public WebRequestAPI {
   void HandleSimpleEvent(SimpleEvent event,
                          extensions::WebRequestInfo* info,
                          Args... args);
-  template <typename Out, typename... Args>
-  int HandleResponseEvent(ResponseEvent event,
-                          extensions::WebRequestInfo* info,
-                          net::CompletionOnceCallback callback,
-                          Out out,
-                          Args... args);
-
-  template <typename T>
-  void OnListenerResult(uint64_t id, T out, v8::Local<v8::Value> response);
 
   int HandleOnBeforeRequestResponseEvent(
       extensions::WebRequestInfo* info,
@@ -136,11 +129,19 @@ class WebRequest : public gin::Wrappable<WebRequest>, public WebRequestAPI {
       const network::ResourceRequest& request,
       BeforeSendHeadersCallback callback,
       net::HttpRequestHeaders* headers);
+  int HandleOnHeadersReceivedResponseEvent(
+      extensions::WebRequestInfo* info,
+      const network::ResourceRequest& request,
+      net::CompletionOnceCallback callback,
+      const net::HttpResponseHeaders* original_response_headers,
+      scoped_refptr<net::HttpResponseHeaders>* override_response_headers);
 
   void OnBeforeRequestListenerResult(uint64_t id,
                                      v8::Local<v8::Value> response);
   void OnBeforeSendHeadersListenerResult(uint64_t id,
                                          v8::Local<v8::Value> response);
+  void OnHeadersReceivedListenerResult(uint64_t id,
+                                       v8::Local<v8::Value> response);
 
   class RequestFilter {
    public:

--- a/spec/api-web-request-spec.ts
+++ b/spec/api-web-request-spec.ts
@@ -328,7 +328,7 @@ describe('webRequest module', () => {
         ses.webRequest.onBeforeSendHeaders((details, callback) => {
           const requestHeaders = details.requestHeaders;
           requestHeaders.Accept = '*/*;test/header';
-          callback({ requestHeaders: requestHeaders });
+          callback({ requestHeaders });
         });
         const { data } = await ajax('no-cors://fake-host/redirect');
         expect(data).to.equal('header-received');
@@ -341,7 +341,7 @@ describe('webRequest module', () => {
       ses.webRequest.onBeforeSendHeaders((details, callback) => {
         const requestHeaders = details.requestHeaders;
         requestHeaders.Origin = 'http://new-origin';
-        callback({ requestHeaders: requestHeaders });
+        callback({ requestHeaders });
       });
       const { data } = await ajax(defaultURL);
       expect(data).to.equal('/new/origin');


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42149.

Fixes an issue where Chromium could crash on a dangling unretained pointer in one of several webRequest functions. This was happening as a result of the fact that we had outstanding blocking requests continue to reference state owned by `ProxyingWebsocket` and `ProxyingURLLoaderFactory` after the requests were destroyed.

This had been going on for a few years, and was likely leading to some ongoing memory issues. To fix this, we need to ensure that all state is cleaned up in `OnRequestWillBeDestroyed`. I chose to create a new BlockedRequest struct to do so, which approximates the approach that [upstream takes](https://source.chromium.org/chromium/chromium/src/+/main:extensions/browser/api/web_request/extension_web_request_event_router.cc;l=501?q=blocked_request.override_response_headers&ss=chromium%2Fchromium%2Fsrc). The complexities of doing so also made our templated approach more trouble than it felt worth, so i pried that apart into separate handlers.

h/t @ckerr for talking lots of this through with me 🙇🏻‍♀️ 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where Chromium could crash on a dangling unretained pointer in one of several webRequest functions
