### PR TITLE
fix: param passed to `showSaveDialogSync` on Linux

### DIFF
--- a/shell/browser/ui/file_dialog_linux.cc
+++ b/shell/browser/ui/file_dialog_linux.cc
@@ -208,9 +208,6 @@ class FileChooserDialog : public ui::SelectFileDialog::Listener {
 
 bool ShowOpenDialogSync(const DialogSettings& settings,
                         std::vector<base::FilePath>* paths) {
-  v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
-  gin_helper::Promise<gin_helper::Dictionary> promise(isolate);
-
   base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
   auto cb = base::BindOnce(
       [](base::RepeatingClosure cb, std::vector<base::FilePath>* file_paths,
@@ -222,7 +219,6 @@ bool ShowOpenDialogSync(const DialogSettings& settings,
 
   FileChooserDialog* dialog = new FileChooserDialog();
   dialog->RunOpenDialog(std::move(cb), settings);
-
   run_loop.Run();
   return !paths->empty();
 }
@@ -235,8 +231,6 @@ void ShowOpenDialog(const DialogSettings& settings,
 
 bool ShowSaveDialogSync(const DialogSettings& settings, base::FilePath* path) {
   base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
-  v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
-  gin_helper::Promise<gin_helper::Dictionary> promise(isolate);
   auto cb = base::BindOnce(
       [](base::RepeatingClosure cb, base::FilePath* file_path,
          gin_helper::Dictionary result) {
@@ -246,7 +240,7 @@ bool ShowSaveDialogSync(const DialogSettings& settings, base::FilePath* path) {
       run_loop.QuitClosure(), path);
 
   FileChooserDialog* dialog = new FileChooserDialog();
-  dialog->RunSaveDialog(std::move(promise), settings);
+  dialog->RunSaveDialog(std::move(cb), settings);
   run_loop.Run();
   return !path->empty();
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42621.

Fixes an issue where control could fail to return properly after saving a dialog using showSaveDialogSync on Linux.

Tested with https://gist.github.com/mpolk/2cf36a722696695b6e0107a2250c8ccc

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where control could fail to return properly after saving a dialog using showOpenDialogSync on Linux.