### PR TITLE
fix: `defaultPath` should apply on all dialog types in Linux Portal

### DIFF
--- a/patches/chromium/feat_add_support_for_missing_dialog_features_to_shell_dialogs.patch
+++ b/patches/chromium/feat_add_support_for_missing_dialog_features_to_shell_dialogs.patch
@@ -8,6 +8,9 @@ This CL adds support for the following features to //shell_dialogs:
 * showHiddenFiles - Show hidden files in dialog.
 * showOverwriteConfirmation - Whether the user will be presented a confirmation dialog if the user types a file name that already exists.
 
+It also:
+* Changes XDG Portal implementation behavior to set default path regardless of dialog type.
+
 This may be partially upstreamed to Chromium in the future.
 
 diff --git a/ui/gtk/select_file_dialog_linux_gtk.cc b/ui/gtk/select_file_dialog_linux_gtk.cc
@@ -269,7 +272,7 @@ index c79fb47bfba9233da7d2c1438d1e26600684fc78..d7cc7cd70653aaa5b628ef456dcb48a2
            &SelectFileDialogLinuxKde::OnSelectSingleFolderDialogResponse, this,
            parent, params));
 diff --git a/ui/shell_dialogs/select_file_dialog_linux_portal.cc b/ui/shell_dialogs/select_file_dialog_linux_portal.cc
-index 65727489ddecb755eeabbd194ce843ca9eaa59c9..b15bace56639d2f914f8f76edfa1b28e33165b48 100644
+index 65727489ddecb755eeabbd194ce843ca9eaa59c9..38134183309f89b76e7d2a8cda0a11f530b79d44 100644
 --- a/ui/shell_dialogs/select_file_dialog_linux_portal.cc
 +++ b/ui/shell_dialogs/select_file_dialog_linux_portal.cc
 @@ -219,6 +219,10 @@ void SelectFileDialogLinuxPortal::SelectFileImpl(
@@ -360,7 +363,7 @@ index 65727489ddecb755eeabbd194ce843ca9eaa59c9..b15bace56639d2f914f8f76edfa1b28e
                             IDS_SELECT_UPLOAD_FOLDER_DIALOG_UPLOAD_BUTTON));
    }
  
-@@ -563,6 +572,7 @@ void SelectFileDialogLinuxPortal::DialogInfo::AppendOptions(
+@@ -563,12 +572,12 @@ void SelectFileDialogLinuxPortal::DialogInfo::AppendOptions(
        type == SelectFileDialog::Type::SELECT_UPLOAD_FOLDER ||
        type == SelectFileDialog::Type::SELECT_EXISTING_FOLDER) {
      AppendBoolOption(&options_writer, kFileChooserOptionDirectory, true);
@@ -368,6 +371,13 @@ index 65727489ddecb755eeabbd194ce843ca9eaa59c9..b15bace56639d2f914f8f76edfa1b28e
    } else if (type == SelectFileDialog::Type::SELECT_OPEN_MULTI_FILE) {
      AppendBoolOption(&options_writer, kFileChooserOptionMultiple, true);
    }
+ 
+-  if (type == SelectFileDialog::Type::SELECT_SAVEAS_FILE &&
+-      !default_path.empty()) {
++  if (!default_path.empty()) {
+     if (default_path_exists) {
+       // If this is an existing directory, navigate to that directory, with no
+       // filename.
 diff --git a/ui/shell_dialogs/select_file_dialog_linux_portal.h b/ui/shell_dialogs/select_file_dialog_linux_portal.h
 index c487f7da19e2d05696a8eb72f2fa3e12972149f3..02a40c571570974dcc61e1b1f7ed95fbfc2bedf2 100644
 --- a/ui/shell_dialogs/select_file_dialog_linux_portal.h


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/microsoft/vscode/issues/213780.

Fixes an issue where the user-specified default path did not take the expected effect when using XDG Portal unless the user was using a save dialog.

This was happening because Chromium's XDG Portal dialog implementation only set the default path in a save dialog context. Fix this by taking it into account for all dialog types.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where the user-specified default path did not work in some circumstances when using Linux dialogs.