### PR TITLE
build: strip linux release binaries

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -17,6 +17,9 @@ inputs:
   is-release:
     description: 'Is release build'
     required: true
+  strip-binaries:
+    description: 'Strip binaries (Linux only)'
+    required: false
   generate-symbols:
     description: 'Generate symbols'
     required: true
@@ -54,6 +57,19 @@ runs:
         NINJA_SUMMARIZE_BUILD=1 e build -j $NUMBER_OF_NINJA_PROCESSES
         cp out/Default/.ninja_log out/electron_ninja_log
         node electron/script/check-symlinks.js
+    - name: Strip Electron Binaries ${{ inputs.step-suffix }}
+      shell: bash
+      if: ${{ inputs.strip-binaries == 'true' && inputs.target-platform == 'linux' }}
+      run: |
+        if [ x"$TARGET_ARCH" == x ]; then
+          target_cpu=x64
+        else
+          target_cpu="$TARGET_ARCH"
+        fi
+        cd src
+        electron/script/copy-debug-symbols.py --target-cpu="$target_cpu" --out-dir=out/Default/debug --compress
+        electron/script/strip-binaries.py --target-cpu="$target_cpu"
+        electron/script/add-debug-link.py --target-cpu="$target_cpu" --debug-dir=out/Default/debug
     - name: Build Electron dist.zip ${{ inputs.step-suffix }}
       shell: bash
       run: |

--- a/.github/workflows/linux-publish.yml
+++ b/.github/workflows/linux-publish.yml
@@ -49,6 +49,7 @@ jobs:
       is-release: true
       gn-build-type: release
       generate-symbols: true
+      strip-binaries: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
     secrets: inherit
 
@@ -64,6 +65,7 @@ jobs:
       is-release: true
       gn-build-type: release
       generate-symbols: true
+      strip-binaries: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
     secrets: inherit
 
@@ -79,5 +81,6 @@ jobs:
       is-release: true
       gn-build-type: release
       generate-symbols: true
+      strip-binaries: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
     secrets: inherit

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -44,6 +44,11 @@ on:
         required: true
         type: string
         default: '0'
+      strip-binaries: 
+        description: 'Strip the binaries before release (Linux only)'
+        required: false
+        type: boolean
+        default: false
       is-asan: 
         description: 'Building the Address Sanitizer (ASan) Linux build'
         required: false
@@ -186,6 +191,7 @@ jobs:
         artifact-platform: ${{ inputs.target-platform == 'linux' && 'linux' || 'darwin' }}
         is-release: '${{ inputs.is-release }}'
         generate-symbols: '${{ inputs.generate-symbols }}'
+        strip-binaries: '${{ inputs.strip-binaries }}'
         upload-to-storage: '${{ inputs.upload-to-storage }}'
         is-asan: '${{ inputs.is-asan }}'
     - name: Set GN_EXTRA_ARGS for MAS Build


### PR DESCRIPTION
#### Description of Change

This PR strips the Linux binaries on release, so they should stay around ~100 MB.

Before: https://github.com/electron/electron/actions/runs/9683327107
After: https://github.com/electron/electron/actions/runs/9687839988

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
