### PR TITLE
docs(autoUpdater): signing is only a pre-req on macOS

### DIFF
--- a/docs/tutorial/tutorial-6-publishing-updating.md
+++ b/docs/tutorial/tutorial-6-publishing-updating.md
@@ -32,7 +32,7 @@ at [https://update.electronjs.org](https://update.electronjs.org). Its requireme
 - Your app runs on macOS or Windows
 - Your app has a public GitHub repository
 - Builds are published to [GitHub releases][]
-- Builds are [code signed][code-signed]
+- Builds are [code signed][code-signed] **(macOS only)**
 
 At this point, we'll assume that you have already pushed all your
 code to a public GitHub repository.

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -19,7 +19,7 @@ for Electron apps that meet the following criteria:
 - App runs on macOS or Windows
 - App has a public GitHub repository
 - Builds are published to [GitHub Releases][gh-releases]
-- Builds are [code-signed](./code-signing.md)
+- Builds are [code-signed](./code-signing.md) **(macOS only)**
 
 The easiest way to use this service is by installing [update-electron-app][],
 a Node.js module preconfigured for use with update.electronjs.org.


### PR DESCRIPTION
ref https://github.com/electron-forge/electron-forge-docs/issues/183#issuecomment-2192571984

cc @electron/docs

notes: none