### PR TITLE
build: fix clang format/lint

### DIFF
--- a/.circleci/config/jobs/lint.yml
+++ b/.circleci/config/jobs/lint.yml
@@ -31,7 +31,7 @@ steps:
         mkdir -p src/buildtools
         curl -sL "https://chromium.googlesource.com/chromium/src/+/${chromium_revision}/buildtools/DEPS?format=TEXT" | base64 -d > src/buildtools/DEPS
 
-        gclient runhooks --spec="solutions=[{'name':'src/buildtools','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':True},'managed':False}]"
+        gclient sync --spec="solutions=[{'name':'src/buildtools','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':True},'managed':False}]"
   - run:
       name: Run Lint
       command: |

--- a/.github/workflows/pipeline-electron-lint.yml
+++ b/.github/workflows/pipeline-electron-lint.yml
@@ -56,7 +56,7 @@ jobs:
         mkdir -p src/buildtools
         curl -sL "https://chromium.googlesource.com/chromium/src/+/${chromium_revision}/buildtools/DEPS?format=TEXT" | base64 -d > src/buildtools/DEPS
 
-        gclient runhooks --spec="solutions=[{'name':'src/buildtools','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':True},'managed':False}]"
+        gclient sync --spec="solutions=[{'name':'src/buildtools','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':True},'managed':False}]"
     - name: Run Lint
       shell: bash
       run: |

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -195,12 +195,18 @@ def get_buildtools_executable(name):
   else:
     raise Exception(f"Unsupported platform: {sys.platform}")
 
-  if name == 'clang-format':
-    path = os.path.join(buildtools, chromium_platform, 'format', name)  
-  else:
-    path = os.path.join(buildtools, chromium_platform, name)
+  path = os.path.join(buildtools, chromium_platform, name)
   if sys.platform == 'win32':
     path += '.exe'
+  return path
+
+def get_depot_tools_executable(name):
+  buildtools = os.path.realpath(
+    os.path.join(ELECTRON_DIR, '..', 'third_party', 'depot_tools'))
+
+  path = os.path.join(buildtools, name)
+  if sys.platform == 'win32':
+    path += '.bat'
   return path
 
 def get_linux_binaries():

--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -23,7 +23,7 @@ import traceback
 import tempfile
 
 from functools import partial
-from lib.util import get_buildtools_executable
+from lib.util import get_depot_tools_executable
 
 DEFAULT_EXTENSIONS = 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx,mm'
 DEFAULT_CLANG_FORMAT_IGNORE = '.clang-format-ignore'
@@ -205,7 +205,7 @@ def main():
         '--clang-format-executable',
         metavar='EXECUTABLE',
         help='path to the clang-format executable',
-        default=get_buildtools_executable('clang-format'))
+        default=get_depot_tools_executable('clang-format'))
     parser.add_argument(
         '--extensions',
         help='comma-separated list of file extensions'

--- a/script/run-gn-format.py
+++ b/script/run-gn-format.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import sys
 
-from lib.util import get_buildtools_executable
+from lib.util import get_depot_tools_executable
 
 SOURCE_ROOT = os.path.dirname(os.path.dirname(__file__))
 
@@ -15,7 +15,7 @@ def main():
     os.path.join(SOURCE_ROOT, '..', 'buildtools')
   )
 
-  gn_path = get_buildtools_executable('gn')
+  gn_path = get_depot_tools_executable('gn')
   for gn_file in sys.argv[1:]:
     subprocess.check_call(
       [gn_path, 'format', gn_file],


### PR DESCRIPTION
#### Description of Change

Fixes the clang-format binary path, h/t to @codebytere and @dsanders11 for the help!

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
