### PR TITLE
refactor: make session::browser_context_ a const raw_ref

### DIFF
--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -91,7 +91,9 @@ class Session : public gin::Wrappable<Session>,
       const base::FilePath& path,
       base::Value::Dict options = {});
 
-  ElectronBrowserContext* browser_context() const { return browser_context_; }
+  ElectronBrowserContext* browser_context() const {
+    return &browser_context_.get();
+  }
 
   // gin::Wrappable
   static gin::WrapperInfo kWrapperInfo;
@@ -215,7 +217,7 @@ class Session : public gin::Wrappable<Session>,
   // The client id to enable the network throttler.
   base::UnguessableToken network_emulation_token_;
 
-  raw_ptr<ElectronBrowserContext> browser_context_;
+  const raw_ref<ElectronBrowserContext> browser_context_;
 };
 
 }  // namespace api


### PR DESCRIPTION
#### Description of Change

session::browser_context_ can't be `nullptr` and the pointer never changes, so use a [`const raw_ref`](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md#non_owning-pointers-in-class-fields) instead of a `raw_ptr`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none