### PR TITLE
build: clean up BoringSSL patch

### DIFF
--- a/patches/node/fix_handle_boringssl_and_openssl_incompatibilities.patch
+++ b/patches/node/fix_handle_boringssl_and_openssl_incompatibilities.patch
@@ -17,20 +17,10 @@ Upstreams:
 - https://github.com/nodejs/node/pull/39136
 
 diff --git a/src/crypto/crypto_cipher.cc b/src/crypto/crypto_cipher.cc
-index 67cd4f2adf15e7d8511f561c54163b1842e971af..7e0e1a62289289b8362870ba4869c97494b9298a 100644
+index 67cd4f2adf15e7d8511f561c54163b1842e971af..88471fd6bc0b8a810bb55464cd2d1933d11a8623 100644
 --- a/src/crypto/crypto_cipher.cc
 +++ b/src/crypto/crypto_cipher.cc
-@@ -28,7 +28,8 @@ using v8::Value;
- namespace crypto {
- namespace {
- bool IsSupportedAuthenticatedMode(const EVP_CIPHER* cipher) {
--  switch (EVP_CIPHER_mode(cipher)) {
-+  const int mode = EVP_CIPHER_mode(cipher);
-+  switch (mode) {
-   case EVP_CIPH_CCM_MODE:
-   case EVP_CIPH_GCM_MODE:
- #ifndef OPENSSL_NO_OCB
-@@ -1088,7 +1089,7 @@ void PublicKeyCipher::Cipher(const FunctionCallbackInfo<Value>& args) {
+@@ -1088,7 +1088,7 @@ void PublicKeyCipher::Cipher(const FunctionCallbackInfo<Value>& args) {
      if (EVP_PKEY_decrypt_init(ctx.get()) <= 0) {
        return ThrowCryptoError(env, ERR_get_error());
      }
@@ -39,7 +29,7 @@ index 67cd4f2adf15e7d8511f561c54163b1842e971af..7e0e1a62289289b8362870ba4869c974
      int rsa_pkcs1_implicit_rejection =
          EVP_PKEY_CTX_ctrl_str(ctx.get(), "rsa_pkcs1_implicit_rejection", "1");
      // From the doc -2 means that the option is not supported.
-@@ -1104,6 +1105,7 @@ void PublicKeyCipher::Cipher(const FunctionCallbackInfo<Value>& args) {
+@@ -1104,6 +1104,7 @@ void PublicKeyCipher::Cipher(const FunctionCallbackInfo<Value>& args) {
            "RSA_PKCS1_PADDING is no longer supported for private decryption,"
            " this can be reverted with --security-revert=CVE-2023-46809");
      }
@@ -48,7 +38,7 @@ index 67cd4f2adf15e7d8511f561c54163b1842e971af..7e0e1a62289289b8362870ba4869c974
  
    const EVP_MD* digest = nullptr;
 diff --git a/src/crypto/crypto_common.cc b/src/crypto/crypto_common.cc
-index ee1c7931a5c83eec00fe05807ddb97572fe70cc9..8e297e57fdbc9fd42beb6e4a33cc91b9dd7316b8 100644
+index ee1c7931a5c83eec00fe05807ddb97572fe70cc9..008fa0c04c3dadfe69f87728840f9326a150c7b3 100644
 --- a/src/crypto/crypto_common.cc
 +++ b/src/crypto/crypto_common.cc
 @@ -158,7 +158,7 @@ const char* GetClientHelloALPN(const SSLPointer& ssl) {
@@ -86,18 +76,7 @@ index ee1c7931a5c83eec00fe05807ddb97572fe70cc9..8e297e57fdbc9fd42beb6e4a33cc91b9
  }
  
  const char* GetServerName(SSL* ssl) {
-@@ -206,7 +210,10 @@ const char* GetServerName(SSL* ssl) {
- }
- 
- bool SetGroups(SecureContext* sc, const char* groups) {
-+#ifndef OPENSSL_IS_BORINGSSL
-   return SSL_CTX_set1_groups_list(sc->ctx().get(), groups) == 1;
-+#endif
-+  return SSL_CTX_set1_curves_list(sc->ctx().get(), groups) == 1;
- }
- 
- // When adding or removing errors below, please also update the list in the API
-@@ -1044,14 +1051,14 @@ MaybeLocal<Array> GetClientHelloCiphers(
+@@ -1044,14 +1048,14 @@ MaybeLocal<Array> GetClientHelloCiphers(
      Environment* env,
      const SSLPointer& ssl) {
    EscapableHandleScope scope(env->isolate());
@@ -143,7 +122,7 @@ index 6e5bbe07d0c337b36f3157c2e6404fdc91849fd1..7ec682833213de9054a8c30751436d12
    DHPointer dh;
    {
 diff --git a/src/crypto/crypto_dh.cc b/src/crypto/crypto_dh.cc
-index b4447102a8478639a5aa774e583834d79808603f..ecf938d51ccdbfcb825d44c5ed4ea1229cb05389 100644
+index b4447102a8478639a5aa774e583834d79808603f..fa507b6d3c04691f44b3302058d2007a966306db 100644
 --- a/src/crypto/crypto_dh.cc
 +++ b/src/crypto/crypto_dh.cc
 @@ -154,13 +154,11 @@ bool DiffieHellman::Init(BignumPointer&& bn_p, int g) {
@@ -197,21 +176,11 @@ index b4447102a8478639a5aa774e583834d79808603f..ecf938d51ccdbfcb825d44c5ed4ea122
    V("modp5", BN_get_rfc3526_prime_1536);
    V("modp14", BN_get_rfc3526_prime_2048);
    V("modp15", BN_get_rfc3526_prime_3072);
-@@ -559,15 +556,21 @@ EVPKeyCtxPointer DhKeyGenTraits::Setup(DhKeyPairGenConfig* params) {
-       return EVPKeyCtxPointer();
-     }
- 
-+#ifndef OPENSSL_IS_BORINGSSL
-     prime_fixed_value->release();
-     bn_g.release();
- 
+@@ -565,9 +562,11 @@ EVPKeyCtxPointer DhKeyGenTraits::Setup(DhKeyPairGenConfig* params) {
      key_params = EVPKeyPointer(EVP_PKEY_new());
      CHECK(key_params);
      CHECK_EQ(EVP_PKEY_assign_DH(key_params.get(), dh.release()), 1);
 -  } else if (int* prime_size = std::get_if<int>(&params->params.prime)) {
-+#else
-+    return EVPKeyCtxPointer();
-+#endif
 +  } else if (std::get_if<int>(&params->params.prime)) {
      EVPKeyCtxPointer param_ctx(EVP_PKEY_CTX_new_id(EVP_PKEY_DH, nullptr));
      EVP_PKEY* raw_params = nullptr;
@@ -220,7 +189,7 @@ index b4447102a8478639a5aa774e583834d79808603f..ecf938d51ccdbfcb825d44c5ed4ea122
      if (!param_ctx ||
          EVP_PKEY_paramgen_init(param_ctx.get()) <= 0 ||
          EVP_PKEY_CTX_set_dh_paramgen_prime_len(
-@@ -581,6 +584,9 @@ EVPKeyCtxPointer DhKeyGenTraits::Setup(DhKeyPairGenConfig* params) {
+@@ -581,6 +580,9 @@ EVPKeyCtxPointer DhKeyGenTraits::Setup(DhKeyPairGenConfig* params) {
      }
  
      key_params = EVPKeyPointer(raw_params);
@@ -392,19 +361,6 @@ index 3b3724d6c7156b87555be31470e75b1cf28b5e3f..910c69b6d1d17ef25201dbb39d3d074f
  #if OPENSSL_VERSION_MAJOR >= 3
    // We declare another alias here to avoid having to include crypto_util.h
    using EVPMDPointer = DeleteFnPtr<EVP_MD, EVP_MD_free>;
-diff --git a/src/node_metadata.cc b/src/node_metadata.cc
-index 844c5ac2c2b948b3be35cb3e447717a510a463a6..72a75ee0bf391ea508441f49413f85c5b735b259 100644
---- a/src/node_metadata.cc
-+++ b/src/node_metadata.cc
-@@ -21,7 +21,7 @@
- #include <zlib.h>
- #endif  // NODE_BUNDLED_ZLIB
- 
--#if HAVE_OPENSSL
-+#if HAVE_OPENSSL && !defined(OPENSSL_IS_BORINGSSL)
- #include <openssl/opensslv.h>
- #if NODE_OPENSSL_HAS_QUIC
- #include <openssl/quic.h>
 diff --git a/src/node_metadata.h b/src/node_metadata.h
 index cf051585e779e2b03bd7b95fe5008b89cc7f8162..9de49c6828468fdf846dcd4ad445390f14446099 100644
 --- a/src/node_metadata.h


### PR DESCRIPTION
#### Description of Change

Refs https://boringssl-review.googlesource.com/c/boringssl/+/54306
Refs https://boringssl-review.googlesource.com/c/boringssl/+/67207

Cleans up and removes unnecessary `OPENSSL_IS_BORINGSSL` checks.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
