### PR TITLE
build: strip linux release binaries

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -17,6 +17,9 @@ inputs:
   is-release:
     description: 'Is release build'
     required: true
+  strip-binaries:
+    description: 'Strip binaries (Linux only)'
+    required: false
   generate-symbols:
     description: 'Generate symbols'
     required: true

--- a/.github/workflows/linux-publish.yml
+++ b/.github/workflows/linux-publish.yml
@@ -49,6 +49,7 @@ jobs:
       is-release: true
       gn-build-type: release
       generate-symbols: true
+      strip-binaries: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
     secrets: inherit
 
@@ -64,6 +65,7 @@ jobs:
       is-release: true
       gn-build-type: release
       generate-symbols: true
+      strip-binaries: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
     secrets: inherit
 
@@ -79,5 +81,6 @@ jobs:
       is-release: true
       gn-build-type: release
       generate-symbols: true
+      strip-binaries: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
     secrets: inherit

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -44,6 +44,11 @@ on:
         required: true
         type: string
         default: '0'
+      strip-binaries: 
+        description: 'Strip the binaries before release (Linux only)'
+        required: false
+        type: boolean
+        default: false
       is-asan: 
         description: 'Building the Address Sanitizer (ASan) Linux build'
         required: false
@@ -186,6 +191,7 @@ jobs:
         artifact-platform: ${{ inputs.target-platform == 'linux' && 'linux' || 'darwin' }}
         is-release: '${{ inputs.is-release }}'
         generate-symbols: '${{ inputs.generate-symbols }}'
+        strip-binaries: '${{ inputs.strip-binaries }}'
         upload-to-storage: '${{ inputs.upload-to-storage }}'
         is-asan: '${{ inputs.is-asan }}'
     - name: Set GN_EXTRA_ARGS for MAS Build


### PR DESCRIPTION
#### Description of Change

This PR makes the Linux binaries in release branches not 2GB - this was partially backported but not applied to the publish.yml file

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
