### PR TITLE
chore: speed up azcopy on src cache

### DIFF
--- a/.github/actions/restore-cache-azcopy/action.yml
+++ b/.github/actions/restore-cache-azcopy/action.yml
@@ -23,7 +23,7 @@ runs:
     # or it was uploaded in the checkout job for a previous commit.
     uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
     with:
-      timeout_minutes: 20
+      timeout_minutes: 30
       max_attempts: 3
       retry_on: error
       command: |
@@ -32,7 +32,7 @@ runs:
           echo "SAS Token not found; exiting src cache download early..."
           exit 1
         fi
-        azcopy copy \
+        azcopy copy --log-level=ERROR \
           "https://${{ env.AZURE_AKS_CACHE_STORAGE_ACCOUNT }}.file.core.windows.net/${{ env.AZURE_AKS_CACHE_SHARE_NAME }}/${{ env.CACHE_PATH }}?$sas_token" $DEPSHASH.tar
   - name: Clean SAS Key
     shell: bash


### PR DESCRIPTION
#### Description of Change

Occasionally a GHA macOS build will timeout copying the source cache from Azure.  This PR tweaks AzCopy to hopefully be a little faster.  Additionally, I've bumped up the timeout to 30 minutes to give more time for times when AzCopy is slower (eg lots of PRs running at the same time). 

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
