### PR TITLE
chore: clean up outdated goma references

### DIFF
--- a/.circleci/config/base.yml
+++ b/.circleci/config/base.yml
@@ -749,7 +749,7 @@ step-mksnapshot-build: &step-mksnapshot-build
       fi
       sed $SEDOPTION '/.*builtins-pgo/d' out/Default/mksnapshot_args
       sed $SEDOPTION '/--turbo-profiling-input/d' out/Default/mksnapshot_args
-      sed $SEDOPTION '/The gn arg use_goma=true .*/d' out/Default/mksnapshot_args
+
       if [ "`uname`" != "Darwin" ]; then
         if [ "$TARGET_ARCH" == "arm" ]; then
           electron/script/strip-binaries.py --file $PWD/out/Default/clang_x86_v8_arm/mksnapshot

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -33,8 +33,7 @@ If you are a maintainer [with Reclient access](../docs/development/reclient.md) 
 Authentication Status: Authenticated
 Since:     2024-05-28 10:29:33 +0200 CEST
 Expires:   2024-08-26 10:29:33 +0200 CEST
-Cluster:   rbe.notgoma.com
-Principal: github/codebytere
+...
 Access:    Cache & Execute
 ```
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -25,9 +25,20 @@ Codespaces doesn't lean very well into gclient based checkouts, the directory st
 /workspaces/electron
 ```
 
-## Goma
+## Reclient
 
-If you are a maintainer [with Goma access](../docs/development/goma.md) it should be automatically configured and authenticated when you spin up a new codespaces instance.  You can validate this by checking `e d goma_auth info` or by checking that your build-tools configuration has a goma mode of `cluster`.
+If you are a maintainer [with Reclient access](../docs/development/reclient.md) you'll need to ensure you're authenticated when you spin up a new codespaces instance.  You can validate this by checking `e d rbe info` - your build-tools configuration should have `Access` type `Cache & Execute`:
+
+```console
+Authentication Status: Authenticated
+Since:     2024-05-28 10:29:33 +0200 CEST
+Expires:   2024-08-26 10:29:33 +0200 CEST
+Cluster:   rbe.notgoma.com
+Principal: github/codebytere
+Access:    Cache & Execute
+```
+
+To authenticate if you're not logged in, run `e d rbe login` and follow the link to authenticate.
 
 ## Running Electron
 

--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -59,7 +59,6 @@ if [ ! -f $buildtools/configs/evm.testing.json ]; then
             \"\$schema\": \"file:///home/builduser/.electron_build_tools/evm-config.schema.json\",
             \"configValidationLevel\": \"strict\",
             \"reclient\": \"$1\",
-            \"goma\": \"none\",
             \"preserveXcode\": 5
         }
     " >$buildtools/configs/evm.testing.json

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -90,7 +90,6 @@ runs:
         fi
         sed $SEDOPTION '/.*builtins-pgo/d' out/Default/mksnapshot_args
         sed $SEDOPTION '/--turbo-profiling-input/d' out/Default/mksnapshot_args
-        sed $SEDOPTION '/The gn arg use_goma=true .*/d' out/Default/mksnapshot_args
 
         if [ "`uname`" = "Linux" ]; then
           if [ "${{ inputs.target-arch }}" = "arm" ]; then

--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -149,7 +149,7 @@ for:
       - gn desc out/Default v8:run_mksnapshot_default args > out/Default/default_mksnapshot_args
       # Remove unused args from mksnapshot_args
       - ps: >-
-          Get-Content out/Default/default_mksnapshot_args | Where-Object { -not $_.Contains('--turbo-profiling-input') -And -not $_.Contains('builtins-pgo') -And -not $_.Contains('The gn arg use_goma=true') } | Set-Content out/Default/mksnapshot_args
+          Get-Content out/Default/default_mksnapshot_args | Where-Object { -not $_.Contains('--turbo-profiling-input') -And -not $_.Contains('builtins-pgo') } | Set-Content out/Default/mksnapshot_args
       - autoninja -C out/Default electron:electron_mksnapshot_zip
       - cd out\Default
       - 7z a mksnapshot.zip mksnapshot_args gen\v8\embedded.S

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -147,7 +147,7 @@ for:
       - gn desc out/Default v8:run_mksnapshot_default args > out/Default/default_mksnapshot_args
       # Remove unused args from mksnapshot_args
       - ps: >-
-          Get-Content out/Default/default_mksnapshot_args | Where-Object { -not $_.Contains('--turbo-profiling-input') -And -not $_.Contains('builtins-pgo') -And -not $_.Contains('The gn arg use_goma=true') } | Set-Content out/Default/mksnapshot_args
+          Get-Content out/Default/default_mksnapshot_args | Where-Object { -not $_.Contains('--turbo-profiling-input') -And -not $_.Contains('builtins-pgo') } | Set-Content out/Default/mksnapshot_args
       - autoninja -C out/Default electron:electron_mksnapshot_zip
       - cd out\Default
       - 7z a mksnapshot.zip mksnapshot_args gen\v8\embedded.S

--- a/docs/development/goma.md
+++ b/docs/development/goma.md
@@ -1,6 +1,0 @@
-# Goma
-
-> Goma is a distributed compiler service for open-source projects such as
-> Chromium and Android.
-
-Electron's deployment of Goma is deprecated and we are gradually shifting all usage to the [reclient](reclient.md) system. At some point in 2024 the Goma backend will be shutdown.


### PR DESCRIPTION
#### Description of Change

Remove outdated goma references and replace with Reclient where necessary.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none