### PR TITLE
fix: `desktopCapturer` and `screen` source ids should match screen ids

### DIFF
--- a/spec/api-screen-spec.ts
+++ b/spec/api-screen-spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { Display, screen } from 'electron/main';
+import { Display, screen, desktopCapturer } from 'electron/main';
+import { ifit } from './lib/spec-helpers';
 
 describe('screen module', () => {
   describe('methods reassignment', () => {
@@ -11,6 +12,26 @@ describe('screen module', () => {
       } finally {
         screen.getPrimaryDisplay = originalFunction;
       }
+    });
+  });
+
+  describe('screen.getAllDisplays', () => {
+    it('returns an array of displays', () => {
+      const displays = screen.getAllDisplays();
+      expect(displays).to.be.an('array').with.lengthOf.at.least(1);
+      for (const display of displays) {
+        expect(display).to.be.an('object');
+      }
+    });
+
+    // desktopCapturer.getSources does not work as expected in Windows CI.
+    ifit(process.platform !== 'win32')('returns displays with IDs matching desktopCapturer source display IDs', async () => {
+      const displayIds = screen.getAllDisplays().map(d => `${d.id}`);
+
+      const sources = await desktopCapturer.getSources({ types: ['screen'] });
+      const sourceIds = sources.map(s => s.display_id);
+
+      expect(displayIds).to.have.members(sourceIds);
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42747.

Fixes an issue where sources returned by the `desktopCapturer` API and by `screen.getAllDisplays()` no longer match on Windows. This happened initially as a result of https://chromium-review.googlesource.com/c/chromium/src/+/5362362, which removed the static helper we were previously using and required that the id be derived from `HMONITOREX`. The ids are specifically intended and expected to match, so this created a problem for developers needing this information to be kept consistent. To fix this, we need to do a bit more work unfortunately and get that `HMONITOREX` information ourselves in order to derive the correct id.

Confirmed to produce expected results via https://gist.github.com/bukharin/7e4c4d61c9569e57de2183076d2808f9

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where sources returned by the `desktopCapturer` API and `screen.getAllDisplays()` no longer matched on Windows.