### PR TITLE
fix: dangling raw_ptr ElectronBrowserContext::extension_system_

### DIFF
--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -372,6 +372,10 @@ ElectronBrowserContext::ElectronBrowserContext(
 ElectronBrowserContext::~ElectronBrowserContext() {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
   NotifyWillBeDestroyed();
+
+  // the DestroyBrowserContextServices() call below frees this.
+  extension_system_ = nullptr;
+
   // Notify any keyed services of browser context destruction.
   BrowserContextDependencyManager::GetInstance()->DestroyBrowserContextServices(
       this);


### PR DESCRIPTION
#### Description of Change

The extension system is freed by the DestroyBrowserContextServices() call in the ElectronBrowserContext destructor, so we need to zero out the pointer to avoid a dangling raw_ptr error.

The raw_ptr error that this fixes:

```
The memory was freed at:
#0 0x5bb186624502 base::debug::CollectStackTrace() [../../base/debug/stack_trace_posix.cc:1044:7]
#1 0x5bb18660c25c base::debug::StackTrace::StackTrace() [../../base/debug/stack_trace.cc:242:20]
#2 0x5bb18662aaba base::allocator::(anonymous namespace)::DanglingRawPtrDetected() [../../base/allocator/partition_alloc_support.cc:497:11]
#3 0x5bb1866d8fb2 allocator_shim::internal::PartitionFree() [../../base/allocator/partition_allocator/src/partition_alloc/in_slot_metadata.h:396:5]
#4 0x5bb1817f47c5 base::internal::flat_tree<>::erase() [../../third_party/libc++/src/include/__memory/unique_ptr.h:67:5]
#5 0x5bb187f7fe6b KeyedServiceTemplatedFactory<>::Disassociate() [../../components/keyed_service/core/keyed_service_templated_factory.cc:142:14]
#6 0x5bb187f80036 KeyedServiceTemplatedFactory<>::ContextDestroyed() [../../components/keyed_service/core/keyed_service_templated_factory.cc:161:3]
#7 0x5bb187f7de8c DependencyManager::DestroyContextServices() [../../components/keyed_service/core/dependency_manager.cc:207:14]
#8 0x5bb18086b9f1 electron::ElectronBrowserContext::~ElectronBrowserContext() [../../electron/shell/browser/electron_browser_context.cc:376:51]
#9 0x5bb18086bd9e electron::ElectronBrowserContext::~ElectronBrowserContext() [../../electron/shell/browser/electron_browser_context.cc:372:51]
#10 0x5bb180873fcb electron::ElectronBrowserMainParts::PostMainMessageLoopRun() [../../third_party/libc++/src/include/__memory/unique_ptr.h:67:5]
#11 0x5bb184cf4fdd content::BrowserMainLoop::ShutdownThreadsAndCleanUp() [../../content/browser/browser_main_loop.cc:1148:13]
#12 0x5bb184cf740b content::BrowserMainRunnerImpl::Shutdown() [../../content/browser/browser_main_runner_impl.cc:194:17]
#13 0x5bb184cf0d77 content::BrowserMain() [../../content/browser/browser_main.cc:43:16]
#14 0x5bb180b7c628 content::RunBrowserProcessMain() [../../content/app/content_main_runner_impl.cc:739:10]
#15 0x5bb180b7f622 content::ContentMainRunnerImpl::RunBrowser() [../../content/app/content_main_runner_impl.cc:1325:10]
#16 0x5bb180b7ec03 content::ContentMainRunnerImpl::Run() [../../content/app/content_main_runner_impl.cc:1177:12]
#17 0x5bb180b7adfb content::RunContentProcess() [../../content/app/content_main.cc:330:36]
#18 0x5bb180b7b120 content::ContentMain() [../../content/app/content_main.cc:343:10]
#19 0x5bb180733639 main [../../electron/shell/app/electron_main_linux.cc:45:10]
#20 0x7a0ad5e2a1ca (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9)
#21 0x7a0ad5e2a28b __libc_start_main
#22 0x5bb18071902a _start

Task trace:
No active task.
The dangling raw_ptr was released at:
#0 0x5bb186624502 base::debug::CollectStackTrace() [../../base/debug/stack_trace_posix.cc:1044:7]
#1 0x5bb18660c25c base::debug::StackTrace::StackTrace() [../../base/debug/stack_trace.cc:242:20]
#2 0x5bb18662abab base::allocator::(anonymous namespace)::DanglingRawPtrReleased<>() [../../base/allocator/partition_alloc_support.cc:659:21]
#3 0x5bb186670265 base::internal::RawPtrBackupRefImpl<>::ReleaseInternal() [../../base/allocator/partition_allocator/src/partition_alloc/in_slot_metadata.h:224:7]
#4 0x5bb18086bb11 electron::ElectronBrowserContext::~ElectronBrowserContext() [../../base/allocator/partition_allocator/src/partition_alloc/pointers/raw_ptr_backup_ref_impl.h:200:7]
#5 0x5bb18086bd9e electron::ElectronBrowserContext::~ElectronBrowserContext() [../../electron/shell/browser/electron_browser_context.cc:372:51]
#6 0x5bb180873fcb electron::ElectronBrowserMainParts::PostMainMessageLoopRun() [../../third_party/libc++/src/include/__memory/unique_ptr.h:67:5]
#7 0x5bb184cf4fdd content::BrowserMainLoop::ShutdownThreadsAndCleanUp() [../../content/browser/browser_main_loop.cc:1148:13]
#8 0x5bb184cf740b content::BrowserMainRunnerImpl::Shutdown() [../../content/browser/browser_main_runner_impl.cc:194:17]
#9 0x5bb184cf0d77 content::BrowserMain() [../../content/browser/browser_main.cc:43:16]
#10 0x5bb180b7c628 content::RunBrowserProcessMain() [../../content/app/content_main_runner_impl.cc:739:10]
#11 0x5bb180b7f622 content::ContentMainRunnerImpl::RunBrowser() [../../content/app/content_main_runner_impl.cc:1325:10]
#12 0x5bb180b7ec03 content::ContentMainRunnerImpl::Run() [../../content/app/content_main_runner_impl.cc:1177:12]
#13 0x5bb180b7adfb content::RunContentProcess() [../../content/app/content_main.cc:330:36]
#14 0x5bb180b7b120 content::ContentMain() [../../content/app/content_main.cc:343:10]
#15 0x5bb180733639 main [../../electron/shell/app/electron_main_linux.cc:45:10]
#16 0x7a0ad5e2a1ca (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9)
#17 0x7a0ad5e2a28b __libc_start_main
#18 0x5bb18071902a _start
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none