### PR TITLE
fix: multiple move() calls on the same unique_ptr

### DIFF
--- a/shell/browser/extensions/electron_extensions_browser_client.cc
+++ b/shell/browser/extensions/electron_extensions_browser_client.cc
@@ -343,13 +343,12 @@ void ElectronExtensionsBrowserClient::BroadcastEventToRenderers(
     return;
   }
 
-  auto event = std::make_unique<extensions::Event>(histogram_value, event_name,
-                                                   args.Clone());
   for (auto const& [key, browser_context] :
        ElectronBrowserContext::browser_context_map()) {
     if (browser_context) {
       extensions::EventRouter::Get(browser_context.get())
-          ->BroadcastEvent(std::move(event));
+          ->BroadcastEvent(std::make_unique<extensions::Event>(
+              histogram_value, event_name, args.Clone()));
     }
   }
 }


### PR DESCRIPTION
#### Description of Change

Small fix I found while researching something else.

`BroadcastEvent()` takes and consumes a `std::unique_ptr<Event>` argument.  `ElectronExtensionsBrowserClient::BroadcastEventToRenderers()` has a bug in that it passes the same unique ptr to as many event routers as it can find.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.