### PR TITLE
refactor: minor electron browser context cleanup

### DIFF
--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -463,7 +463,7 @@ bool ElectronBrowserContext::IsOffTheRecord() {
 }
 
 std::string ElectronBrowserContext::GetMediaDeviceIDSalt() {
-  if (!media_device_id_salt_.get())
+  if (!media_device_id_salt_)
     media_device_id_salt_ = std::make_unique<MediaDeviceIDSalt>(prefs_.get());
   return media_device_id_salt_->GetSalt();
 }
@@ -479,10 +479,9 @@ ElectronBrowserContext::CreateZoomLevelDelegate(
 
 content::DownloadManagerDelegate*
 ElectronBrowserContext::GetDownloadManagerDelegate() {
-  if (!download_manager_delegate_.get()) {
-    auto* download_manager = this->GetDownloadManager();
+  if (!download_manager_delegate_) {
     download_manager_delegate_ =
-        std::make_unique<ElectronDownloadManagerDelegate>(download_manager);
+        std::make_unique<ElectronDownloadManagerDelegate>(GetDownloadManager());
   }
   return download_manager_delegate_.get();
 }
@@ -500,7 +499,7 @@ ElectronBrowserContext::GetPlatformNotificationService() {
 
 content::PermissionControllerDelegate*
 ElectronBrowserContext::GetPermissionControllerDelegate() {
-  if (!permission_manager_.get())
+  if (!permission_manager_)
     permission_manager_ = std::make_unique<ElectronPermissionManager>();
   return permission_manager_.get();
 }
@@ -515,7 +514,7 @@ std::string ElectronBrowserContext::GetUserAgent() const {
 }
 
 predictors::PreconnectManager* ElectronBrowserContext::GetPreconnectManager() {
-  if (!preconnect_manager_.get()) {
+  if (!preconnect_manager_) {
     preconnect_manager_ =
         std::make_unique<predictors::PreconnectManager>(nullptr, this);
   }

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -53,10 +53,6 @@ class Value;
 
 namespace electron {
 
-using DevicePermissionMap =
-    std::map<blink::PermissionType,
-             std::map<url::Origin, std::vector<std::unique_ptr<base::Value>>>>;
-
 class ElectronDownloadManagerDelegate;
 class ElectronPermissionManager;
 class CookieChangeNotifier;
@@ -69,10 +65,6 @@ using DisplayMediaResponseCallbackJs =
 using DisplayMediaRequestHandler =
     base::RepeatingCallback<void(const content::MediaStreamRequest&,
                                  DisplayMediaResponseCallbackJs)>;
-using PartitionOrPath =
-    std::variant<std::reference_wrapper<const std::string>,
-                 std::reference_wrapper<const base::FilePath>>;
-
 class ElectronBrowserContext : public content::BrowserContext {
  public:
   // disable copy
@@ -207,6 +199,14 @@ class ElectronBrowserContext : public content::BrowserContext {
                              blink::PermissionType permissionType);
 
  private:
+  using DevicePermissionMap = std::map<
+      blink::PermissionType,
+      std::map<url::Origin, std::vector<std::unique_ptr<base::Value>>>>;
+
+  using PartitionOrPath =
+      std::variant<std::reference_wrapper<const std::string>,
+                   std::reference_wrapper<const base::FilePath>>;
+
   ElectronBrowserContext(const PartitionOrPath partition_location,
                          bool in_memory,
                          base::Value::Dict options);

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -44,13 +44,6 @@ class ElectronExtensionSystem;
 }
 #endif
 
-namespace v8 {
-template <typename T>
-class Local;
-class Isolate;
-class Value;
-}  // namespace v8
-
 namespace electron {
 
 class ElectronDownloadManagerDelegate;

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -21,7 +21,6 @@
 #include "content/public/browser/resource_context.h"
 #include "electron/buildflags/buildflags.h"
 #include "electron/shell/browser/media/media_device_id_salt.h"
-#include "gin/arguments.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/network/public/mojom/network_context.mojom.h"
 #include "services/network/public/mojom/url_loader_factory.mojom.h"
@@ -29,6 +28,10 @@
 
 class PrefService;
 class ValueMapPrefStore;
+
+namespace gin {
+class Arguments;
+}
 
 namespace network {
 class SharedURLLoaderFactory;


### PR DESCRIPTION
#### Description of Change

Minor side-cleanup to `electron::ElectronBrowserContext` that I did while working on a couple of browser context bugfixes

- move DevicePermissionMap, PartionOrPath, out of public namespace into private class
- remove forward declaration of unused v8 classes
- prefer `unique_ptr<T>` operator bool over checking `.get()` for `nullptr`

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none