### PR TITLE
refactor: do not subclass ElectronSpeechRecognitionManagerDelegate from SpeechRecognitionEventListener

### DIFF
--- a/shell/browser/electron_speech_recognition_manager_delegate.cc
+++ b/shell/browser/electron_speech_recognition_manager_delegate.cc
@@ -16,33 +16,6 @@ ElectronSpeechRecognitionManagerDelegate::
 ElectronSpeechRecognitionManagerDelegate::
     ~ElectronSpeechRecognitionManagerDelegate() = default;
 
-void ElectronSpeechRecognitionManagerDelegate::OnRecognitionStart(
-    int session_id) {}
-
-void ElectronSpeechRecognitionManagerDelegate::OnAudioStart(int session_id) {}
-
-void ElectronSpeechRecognitionManagerDelegate::OnSoundStart(int session_id) {}
-
-void ElectronSpeechRecognitionManagerDelegate::OnSoundEnd(int session_id) {}
-
-void ElectronSpeechRecognitionManagerDelegate::OnAudioEnd(int session_id) {}
-
-void ElectronSpeechRecognitionManagerDelegate::OnRecognitionEnd(
-    int session_id) {}
-
-void ElectronSpeechRecognitionManagerDelegate::OnRecognitionResults(
-    int session_id,
-    const std::vector<media::mojom::WebSpeechRecognitionResultPtr>& results) {}
-
-void ElectronSpeechRecognitionManagerDelegate::OnRecognitionError(
-    int session_id,
-    const media::mojom::SpeechRecognitionError& error) {}
-
-void ElectronSpeechRecognitionManagerDelegate::OnAudioLevelsChange(
-    int session_id,
-    float volume,
-    float noise_volume) {}
-
 void ElectronSpeechRecognitionManagerDelegate::CheckRecognitionIsAllowed(
     int session_id,
     base::OnceCallback<void(bool ask_user, bool is_allowed)> callback) {
@@ -51,7 +24,7 @@ void ElectronSpeechRecognitionManagerDelegate::CheckRecognitionIsAllowed(
 
 content::SpeechRecognitionEventListener*
 ElectronSpeechRecognitionManagerDelegate::GetEventListener() {
-  return this;
+  return nullptr;
 }
 
 void ElectronSpeechRecognitionManagerDelegate::BindSpeechRecognitionContext(

--- a/shell/browser/electron_speech_recognition_manager_delegate.h
+++ b/shell/browser/electron_speech_recognition_manager_delegate.h
@@ -5,16 +5,13 @@
 #ifndef ELECTRON_SHELL_BROWSER_ELECTRON_SPEECH_RECOGNITION_MANAGER_DELEGATE_H_
 #define ELECTRON_SHELL_BROWSER_ELECTRON_SPEECH_RECOGNITION_MANAGER_DELEGATE_H_
 
-#include <vector>
-
 #include "content/public/browser/speech_recognition_event_listener.h"
 #include "content/public/browser/speech_recognition_manager_delegate.h"
 
 namespace electron {
 
 class ElectronSpeechRecognitionManagerDelegate
-    : public content::SpeechRecognitionManagerDelegate,
-      public content::SpeechRecognitionEventListener {
+    : public content::SpeechRecognitionManagerDelegate {
  public:
   ElectronSpeechRecognitionManagerDelegate();
   ~ElectronSpeechRecognitionManagerDelegate() override;
@@ -24,23 +21,6 @@ class ElectronSpeechRecognitionManagerDelegate
       const ElectronSpeechRecognitionManagerDelegate&) = delete;
   ElectronSpeechRecognitionManagerDelegate& operator=(
       const ElectronSpeechRecognitionManagerDelegate&) = delete;
-
-  // content::SpeechRecognitionEventListener:
-  void OnRecognitionStart(int session_id) override;
-  void OnAudioStart(int session_id) override;
-  void OnSoundStart(int session_id) override;
-  void OnSoundEnd(int session_id) override;
-  void OnAudioEnd(int session_id) override;
-  void OnRecognitionEnd(int session_id) override;
-  void OnRecognitionResults(
-      int session_id,
-      const std::vector<media::mojom::WebSpeechRecognitionResultPtr>&) override;
-  void OnRecognitionError(
-      int session_id,
-      const media::mojom::SpeechRecognitionError& error) override;
-  void OnAudioLevelsChange(int session_id,
-                           float volume,
-                           float noise_volume) override;
 
   // content::SpeechRecognitionManagerDelegate:
   void CheckRecognitionIsAllowed(


### PR DESCRIPTION
#### Description of Change

All the listener functions are empty stubs (and have been since d4e3c39) so it doesn't seem like we need a listener?

SpeechRecognitionManagerDelegate [declares](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/content/public/browser/speech_recognition_manager_delegate.h#35) this method:

> // Checks whether the delegate is interested (returning a non nullptr
> // ptr) or not (returning nullptr) in receiving a copy of all sessions
> // events. This is called on the IO thread.
> virtual SpeechRecognitionEventListener* GetEventListener() = 0;

This PR has ElectronSpeechRecognitionManagerDelegate stop subclassing from the Listener and changes GetEventListener() to return nullptr.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none