### PR TITLE
refactor: run Windows `SelectFileDialog` out of process

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -154,9 +154,13 @@ static_library("chrome") {
       "//chrome/browser/ui/frame/window_frame_util.h",
       "//chrome/browser/win/chrome_process_finder.cc",
       "//chrome/browser/win/chrome_process_finder.h",
+      "//chrome/browser/win/chrome_select_file_dialog_factory.cc",
+      "//chrome/browser/win/chrome_select_file_dialog_factory.h",
       "//chrome/browser/win/titlebar_config.cc",
       "//chrome/browser/win/titlebar_config.h",
       "//chrome/browser/win/titlebar_config.h",
+      "//chrome/browser/win/util_win_service.cc",
+      "//chrome/browser/win/util_win_service.h",
       "//chrome/child/v8_crashpad_support_win.cc",
       "//chrome/child/v8_crashpad_support_win.h",
     ]
@@ -238,7 +242,10 @@ static_library("chrome") {
       "//chrome/services/util_win:lib",
       "//components/webapps/common:mojo_bindings",
     ]
-    deps += [ "//components/segmentation_platform/public/proto" ]
+    deps += [
+      "//chrome/services/util_win/public/mojom",
+      "//components/segmentation_platform/public/proto",
+    ]
   }
 
   if (is_mac) {

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -96,6 +96,7 @@
 #endif
 
 #if BUILDFLAG(IS_WIN)
+#include "chrome/browser/win/chrome_select_file_dialog_factory.h"
 #include "ui/base/l10n/l10n_util_win.h"
 #include "ui/gfx/system_fonts_win.h"
 #include "ui/strings/grit/app_locale_settings.h"
@@ -483,6 +484,11 @@ int ElectronBrowserMainParts::PreMainMessageLoopRun() {
   Browser::Get()->PreMainMessageLoopRun();
 
   fake_browser_process_->PreMainMessageLoopRun();
+
+#if BUILDFLAG(IS_WIN)
+  ui::SelectFileDialog::SetFactory(
+      std::make_unique<ChromeSelectFileDialogFactory>());
+#endif
 
   return GetExitCode();
 }

--- a/shell/utility/electron_content_utility_client.cc
+++ b/shell/utility/electron_content_utility_client.cc
@@ -20,7 +20,9 @@
 
 #if BUILDFLAG(IS_WIN)
 #include "chrome/services/util_win/public/mojom/util_read_icon.mojom.h"
+#include "chrome/services/util_win/public/mojom/util_win.mojom.h"
 #include "chrome/services/util_win/util_read_icon.h"
+#include "chrome/services/util_win/util_win_impl.h"
 #endif  // BUILDFLAG(IS_WIN)
 
 #if BUILDFLAG(ENABLE_PRINTING)
@@ -54,6 +56,9 @@ auto RunPrintingService(
 auto RunWindowsIconReader(
     mojo::PendingReceiver<chrome::mojom::UtilReadIcon> receiver) {
   return std::make_unique<UtilReadIcon>(std::move(receiver));
+}
+auto RunWindowsUtility(mojo::PendingReceiver<chrome::mojom::UtilWin> receiver) {
+  return std::make_unique<UtilWinImpl>(std::move(receiver));
 }
 #endif
 
@@ -109,6 +114,7 @@ void ElectronContentUtilityClient::RegisterMainThreadServices(
     mojo::ServiceFactory& services) {
 #if BUILDFLAG(IS_WIN)
   services.Add(RunWindowsIconReader);
+  services.Add(RunWindowsUtility);
 #endif
 
 #if BUILDFLAG(ENABLE_PRINTING)


### PR DESCRIPTION
Backport of #42758.

See that PR for details.

Notes: Fixed an issue where opening multiple file pickers on Windows via the `input` tag could cause a crash.