### PR TITLE
chore: allow dependency changes from non-maintainers with label

### DIFF
--- a/.github/workflows/auto-close-pull-request.yml
+++ b/.github/workflows/auto-close-pull-request.yml
@@ -11,7 +11,13 @@ permissions: {}
 jobs:
   auto-close-dependency-pull-request:
     name: Auto close non-maintainer dependency pull request
-    if: ${{ !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association) && github.event.pull_request.user.type != 'Bot' && !github.event.pull_request.draft }}
+    if: >
+      ${{ 
+        !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association) && 
+        github.event.pull_request.user.type != 'Bot' && 
+        !github.event.pull_request.draft &&
+        github.event.pull_request.labels.*.name != 'allow-dependency-change'
+      }}
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-close-pull-request.yml
+++ b/.github/workflows/auto-close-pull-request.yml
@@ -16,7 +16,7 @@ jobs:
         !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association) && 
         github.event.pull_request.user.type != 'Bot' && 
         !github.event.pull_request.draft &&
-        github.event.pull_request.labels.*.name != 'allow-dependency-change'
+        !contains(github.event.pull_request.labels.*.name, 'allow-dependency-change')
       }}
     permissions:
       pull-requests: write


### PR DESCRIPTION
Sometimes dependency changes might be necessary from non-maintainers. See https://github.com/electron/electron/pull/42001#issuecomment-2212383114

Adds a conditional which skips this check when `allow-dependency-change` is an added label.

#### Release Notes

Notes: none