### PR TITLE
docs: fix incorrectly rendered URLs in progress bars tutorial

### DIFF
--- a/docs/tutorial/progress-bar.md
+++ b/docs/tutorial/progress-bar.md
@@ -31,8 +31,9 @@ and Linux (Unity) there can be only one progress bar for the application.
 ----
 
 All three cases are covered by the same API - the
-[`setProgressBar()`][setprogressbar] method available on an instance of
-`BrowserWindow`. To indicate your progress, call this method with a number
+[`setProgressBar()`](../api/browser-window.md#winsetprogressbarprogress-options)
+method available on an instance of `BrowserWindow`.
+To indicate your progress, call this method with a number
 between `0` and `1`. For example, if you have a long-running task that is
 currently at 63% towards completion, you would call it as
 `setProgressBar(0.63)`.
@@ -43,7 +44,7 @@ in Windows or clamp to 100% in other operating systems. An indeterminate progres
 remains active but does not show an actual percentage, and is used for situations when
 you do not know how long an operation will take to complete.
 
-See the [API documentation for more options and modes][setprogressbar].
+See the [API documentation for more options and modes](../api/browser-window.md#winsetprogressbarprogress-options).
 
 ## Example
 
@@ -112,5 +113,3 @@ For macOS, the progress bar will also be indicated for your application
 when using [Mission Control](https://support.apple.com/en-us/HT204100):
 
 ![Mission Control Progress Bar](../images/mission-control-progress-bar.png)
-
-[setprogressbar]: ../api/browser-window.md#winsetprogressbarprogress-options


### PR DESCRIPTION
#### Description of Change

This is a minor fix to the Progress Bars Markdown file. 

A twice-repeated URL is listed in the reference-style format. While this Markdown is correct, [the conversion into HTML renders these URLs incorrectly](https://www.electronjs.org/docs/latest/tutorial/progress-bar):

<img width="574" alt="image" src="https://github.com/electron/electron/assets/20751300/ebec15ed-5361-4522-a235-4fa6491ff315">

![image](https://github.com/electron/electron/assets/20751300/e8e62344-8a93-4349-be76-d6761f979ca1)

While the proper long-term fix would be to update the documentation generator to support this Markdown syntax, this PR provides a fix by using the standard Markdown URL syntax.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes

Notes: none