### PR TITLE
fix: High Contrast mode not working on Windows

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -424,6 +424,7 @@ void ElectronBrowserClient::OverrideWebkitPrefs(
   renderer_prefs->can_accept_load_drops = false;
 
   ui::NativeTheme* native_theme = ui::NativeTheme::GetInstanceForNativeUi();
+  prefs->in_forced_colors = native_theme->InForcedColorsMode();
   prefs->preferred_color_scheme =
       native_theme->ShouldUseDarkColors()
           ? blink::mojom::PreferredColorScheme::kDark


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42609
Refs https://chromium-review.googlesource.com/c/chromium/src/+/5324688
Refs https://chromium-review.googlesource.com/c/chromium/src/+/5368321

Fixes an issue where High Contrast Mode didn't apply to webContents on Windows. This happened as a result of the above CLs - Chromium moved forced color state logic to a Web Setting in Blink. To fix this, we need to also handle it as a web preference via `ElectronBrowserClient::OverrideWebkitPrefs`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where High Contrast Mode didn't apply to webContents on Windows.