### PR TITLE
chore: allow multiple OS selection on bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,8 @@ body:
     required: true
 - type: dropdown
   attributes:
-    label: What operating system are you using?
+    label: What operating system(s) are you using?
+    multiple: true
     options:
       - Windows
       - macOS


### PR DESCRIPTION
#### Description of Change

It would be nice to allow bug reports to flag multiple platforms, rather than having to specify in "Additional information".

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
