### PR TITLE
ci: fix Nan test failure on Linux

### DIFF
--- a/.github/workflows/pipeline-segment-node-nan-test.yml
+++ b/.github/workflows/pipeline-segment-node-nan-test.yml
@@ -152,7 +152,7 @@ jobs:
         unzip -:o dist.zip
     - name: Setup Linux for Headless Testing
       run: sh -e /etc/init.d/xvfb start
-    - name: Run Node.js Tests
+    - name: Run Nan Tests
       run: |
         cd src
         node electron/script/nan-spec-runner.js

--- a/script/nan-spec-runner.js
+++ b/script/nan-spec-runner.js
@@ -17,6 +17,14 @@ const args = require('minimist')(process.argv.slice(2), {
   string: ['only']
 });
 
+const getNodeGypVersion = () => {
+  const nanPackageJSONPath = path.join(NAN_DIR, 'package.json');
+  const nanPackageJSON = JSON.parse(fs.readFileSync(nanPackageJSONPath, 'utf8'));
+  const { devDependencies } = nanPackageJSON;
+  const nodeGypVersion = devDependencies['node-gyp'];
+  return nodeGypVersion || 'latest';
+};
+
 async function main () {
   const outDir = utils.getOutDir({ shouldLog: true });
   const nodeDir = path.resolve(BASE, 'out', outDir, 'gen', 'node_headers');
@@ -90,7 +98,8 @@ async function main () {
     env.LDFLAGS = ldflags;
   }
 
-  const { status: buildStatus, signal } = cp.spawnSync(NPX_CMD, ['node-gyp', 'rebuild', '--verbose', '--directory', 'test', '-j', 'max'], {
+  const nodeGypVersion = getNodeGypVersion();
+  const { status: buildStatus, signal } = cp.spawnSync(NPX_CMD, [`node-gyp@${nodeGypVersion}`, 'rebuild', '--verbose', '--directory', 'test', '-j', 'max'], {
     env,
     cwd: NAN_DIR,
     stdio: 'inherit',


### PR DESCRIPTION
#### Description of Change

Fixes an issue seen after the release of node-gyp@10.2.0 owing to https://github.com/nodejs/node-gyp/commit/ea99fea83485dc5be04db01df9b2fdbe05319b8e. To fix this, use the same version of node-gyp when building nan tests as the one they directly depend on.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none