### PR TITLE
fix: crash when resolving proxy due to network service restart

### DIFF
--- a/shell/browser/browser_process_impl.cc
+++ b/shell/browser/browser_process_impl.cc
@@ -329,7 +329,7 @@ const std::string& BrowserProcessImpl::GetSystemLocale() const {
 electron::ResolveProxyHelper* BrowserProcessImpl::GetResolveProxyHelper() {
   if (!resolve_proxy_helper_) {
     resolve_proxy_helper_ = base::MakeRefCounted<electron::ResolveProxyHelper>(
-        system_network_context_manager()->GetContext());
+        nullptr /* browser_context */);
   }
   return resolve_proxy_helper_.get();
 }

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -609,8 +609,7 @@ ElectronBrowserContext::GetFileSystemAccessPermissionContext() {
 
 ResolveProxyHelper* ElectronBrowserContext::GetResolveProxyHelper() {
   if (!resolve_proxy_helper_) {
-    resolve_proxy_helper_ = base::MakeRefCounted<ResolveProxyHelper>(
-        GetDefaultStoragePartition()->GetNetworkContext());
+    resolve_proxy_helper_ = base::MakeRefCounted<ResolveProxyHelper>(this);
   }
   return resolve_proxy_helper_.get();
 }

--- a/shell/browser/net/resolve_proxy_helper.h
+++ b/shell/browser/net/resolve_proxy_helper.h
@@ -12,11 +12,12 @@
 #include "base/memory/raw_ptr.h"
 #include "base/memory/ref_counted.h"
 #include "mojo/public/cpp/bindings/receiver.h"
-#include "services/network/public/mojom/network_context.mojom.h"
 #include "services/network/public/mojom/proxy_lookup_client.mojom.h"
 #include "url/gurl.h"
 
 namespace electron {
+
+class ElectronBrowserContext;
 
 class ResolveProxyHelper
     : public base::RefCountedThreadSafe<ResolveProxyHelper>,
@@ -24,7 +25,7 @@ class ResolveProxyHelper
  public:
   using ResolveProxyCallback = base::OnceCallback<void(std::string)>;
 
-  explicit ResolveProxyHelper(network::mojom::NetworkContext* network_context);
+  explicit ResolveProxyHelper(ElectronBrowserContext* browser_context);
 
   void ResolveProxy(const GURL& url, ResolveProxyCallback callback);
 
@@ -70,7 +71,7 @@ class ResolveProxyHelper
   mojo::Receiver<network::mojom::ProxyLookupClient> receiver_{this};
 
   // Weak Ref
-  raw_ptr<network::mojom::NetworkContext> network_context_ = nullptr;
+  raw_ptr<ElectronBrowserContext> browser_context_;
 };
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/microsoft/vscode/issues/217220

Regressed in https://github.com/electron/electron/commit/26131b23b81a661fb65d37437b9a1f63b4408fae

Avoid capturing `network::mojom::NetworkContext` in the `ResolveProxyHelper` which is a singleton per browser context or per app depending on the caller. Instead use the helpers which will reinitialize the context if the network service was restarted.

#### Release Notes

Notes: fix crash when resolving proxy with `session.resolveProxy` api