### PR TITLE
fix: `desktopCapturer` and `screen` display ids should match

### DIFF
--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -420,8 +420,7 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
           continue;
         }
 
-        std::wstring wide_device_name(monitorInfo.szDevice);
-        device_name_to_id[base::WideToUTF8(wide_device_name)] =
+        device_name_to_id[base::WideToUTF8(monitorInfo.szDevice)] =
             display::win::internal::DisplayInfo::DisplayIdFromMonitorInfo(
                 monitorInfo);
       }

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -32,7 +32,6 @@
 #include "third_party/webrtc/modules/desktop_capture/win/dxgi_duplicator_controller.h"
 #include "third_party/webrtc/modules/desktop_capture/win/screen_capturer_win_directx.h"
 #include "ui/display/win/display_info.h"
-#include "ui/display/win/screen_win.h"
 #elif BUILDFLAG(IS_OZONE_X11)
 #include "base/logging.h"
 #include "ui/base/x/x11_display_util.h"

--- a/spec/api-screen-spec.ts
+++ b/spec/api-screen-spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { Display, screen, desktopCapturer } from 'electron/main';
-import { ifit } from './lib/spec-helpers';
 
 describe('screen module', () => {
   describe('methods reassignment', () => {
@@ -24,14 +23,14 @@ describe('screen module', () => {
       }
     });
 
-    // desktopCapturer.getSources does not work as expected in Windows CI.
-    ifit(process.platform !== 'win32')('returns displays with IDs matching desktopCapturer source display IDs', async () => {
+    it('returns displays with IDs matching desktopCapturer source display IDs', async () => {
       const displayIds = screen.getAllDisplays().map(d => `${d.id}`);
 
       const sources = await desktopCapturer.getSources({ types: ['screen'] });
       const sourceIds = sources.map(s => s.display_id);
 
-      expect(displayIds).to.have.members(sourceIds);
+      expect(displayIds).to.have.length(sources.length);
+      expect(displayIds).to.have.same.members(sourceIds);
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Follow-up to #42781:

> Closes https://github.com/electron/electron/issues/42747.
>
> Fixes an issue where sources returned by the `desktopCapturer` API and by `screen.getAllDisplays()` no longer match on Windows. This happened initially as a result of https://chromium-review.googlesource.com/c/chromium/src/+/5362362, which removed the static helper we were previously using and required that the id be derived from `HMONITOREX`. The ids are specifically intended and expected to match, so this created a problem for developers needing this information to be kept consistent. To fix this, we need to do a bit more work unfortunately and get that `HMONITOREX` information ourselves in order to derive the correct id.
>
> Confirmed to produce expected results via https://gist.github.com/bukharin/7e4c4d61c9569e57de2183076d2808f9

This PR completes the work in #42781 by setting the `source.display_id` to the derived ID value.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where sources returned by the `desktopCapturer` API and `screen.getAllDisplays()` no longer matched on Windows.
