### PR TITLE
build: fix clang format location helper (again)

### DIFF
--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -194,6 +194,9 @@ def get_buildtools_executable(name):
     chromium_platform = 'linux64'
   else:
     raise Exception(f"Unsupported platform: {sys.platform}")
+  
+  if name == 'clang-format':
+    chromium_platform += '-format'
 
   path = os.path.join(buildtools, chromium_platform, name)
   if sys.platform == 'win32':

--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -23,7 +23,7 @@ import traceback
 import tempfile
 
 from functools import partial
-from lib.util import get_depot_tools_executable
+from lib.util import get_buildtools_executable
 
 DEFAULT_EXTENSIONS = 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx,mm'
 DEFAULT_CLANG_FORMAT_IGNORE = '.clang-format-ignore'
@@ -203,7 +203,7 @@ def main():
         '--clang-format-executable',
         metavar='EXECUTABLE',
         help='path to the clang-format executable',
-        default=get_depot_tools_executable('clang-format'))
+        default=get_buildtools_executable('clang-format'))
     parser.add_argument(
         '--extensions',
         help='comma-separated list of file extensions'


### PR DESCRIPTION
#### Description of Change

Similar to #42527, Chromium recently:
* [Moved `clang-format` to `buildtools`](https://chromium-review.googlesource.com/c/chromium/src/+/5506857)
  * This seems to be on the most recent M126
* [Then, later changed the path of `clang-format`](https://chromium-review.googlesource.com/c/chromium/src/+/5581721), moving from `{platform}/format` to `{platform}-format` (`/` to `-`).
  * This change has not landed on M126

#### Backport strategy

I'm going to backport this change to `32-x-y` and `31-x-y`. This should cleanly backport to `32-x-y`, but since `31-x-y` only got the first change we will have to subtly adjust the `util.py` change to join `format` as a path segment instead of as part of the platform.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
