### PR TITLE
fix: crash with creating OffScreenWebContentsView

### DIFF
--- a/shell/browser/osr/osr_web_contents_view.h
+++ b/shell/browser/osr/osr_web_contents_view.h
@@ -109,7 +109,7 @@ class OffScreenWebContentsView : public content::WebContentsView,
   raw_ptr<content::WebContents> web_contents_ = nullptr;
 
 #if BUILDFLAG(IS_MAC)
-  RAW_PTR_EXCLUSION OffScreenView* offScreenView_;
+  RAW_PTR_EXCLUSION OffScreenView* offScreenView_ = nullptr;
 #endif
 };
 


### PR DESCRIPTION
#### Description of Change

On the Mac platform, OffScreenWebContentsView uses Automatic Reference Counting (ARC) to handle the lifecycle of offScreenView_. However, this private member variable is not initialized and its value is undefined. In some cases, it is initialized to a garbage value, which may cause ARC to release the value incorrectly, resulting in a crash.

The crash stack is：

> Crashed Thread:        0  CrBrowserMain  Dispatch queue: com.apple.main-thread
> 
> Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
> Exception Codes:       KERN_INVALID_ADDRESS at 0x0000100220010020
> Exception Codes:       0x0000000000000001, 0x0000100220010020
> 
> VM Region Info: 0x100220010020 is not in any region.  Bytes after previous region: 16277389246497  Bytes before following region: 446139662304
>       REGION TYPE                    START - END         [ VSIZE] PRT/MAX SHRMOD  REGION DETAIL
>       Memory Tag 255            13438000000-13440000000  [128.0M] ---/rwx SM=NUL  
> --->  GAP OF 0xf35c0000000 BYTES
>       Memory Tag 255           106a00000000-106a08000000 [128.0M] ---/rwx SM=NUL  
> 
> Thread 0 Crashed:: CrBrowserMain Dispatch queue: com.apple.main-thread
> 0   libobjc.A.dylib               	       0x19e8c86b4 objc_release + 16
> 1   Electron Framework            	       0x109ea89c8 electron::OffScreenWebContentsView::OffScreenWebContentsView(bool, base::RepeatingCallback<void (gfx::Rect const&, SkBitmap const&)> const&) + 96 ([osr_web_contents_view.cc:19](http://osr_web_contents_view.cc:19/)) [inlined]
> 2   Electron Framework            	       0x109ea89c8 electron::OffScreenWebContentsView::OffScreenWebContentsView(bool, base::RepeatingCallback<void (gfx::Rect const&, SkBitmap const&)> const&) + 124 ([osr_web_contents_view.cc:17](http://osr_web_contents_view.cc:17/))

I printed the initial value of offScreenView_ in shell/browser/osr/osr_web_contents_view_mac.mm, and there are indeed garbage values：
```
void OffScreenWebContentsView::PlatformCreate() {
  if (offScreenView_ != nil) {
    // This is new code for logging.
    NSLog(@"OffScreenView: %p", offScreenView_);
   // Output like:
   //2024-07-16 15:54:12.396 Electron[93587:1664657] OffScreenView: 0x13402119e20
  }
  offScreenView_ = [[OffScreenView alloc] init];
}
```

Because the crash has a random probability, it is difficult to construct a scenario percentage reproduction. Therefore, I did not write relevant test samples.
If you want to reproduce the crash, you can execute it multiple times:
`npm run test -- -g BrowserWindow`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash when using off screen rendering.
