### PR TITLE
build: fix clang format location helper

### DIFF
--- a/.github/workflows/pipeline-electron-lint.yml
+++ b/.github/workflows/pipeline-electron-lint.yml
@@ -53,10 +53,10 @@ jobs:
       run: |
         chromium_revision="$(grep -A1 chromium_version src/electron/DEPS | tr -d '\n' | cut -d\' -f4)"
 
-        sha1_path='buildtools/linux64/clang-format.sha1'
-        curl -sL "https://chromium.googlesource.com/chromium/src/+/${chromium_revision}/${sha1_path}?format=TEXT" | base64 -d > "src/${sha1_path}"
+        mkdir -p src/buildtools
+        curl -sL "https://chromium.googlesource.com/chromium/src/+/${chromium_revision}/buildtools/DEPS?format=TEXT" | base64 -d > src/buildtools/DEPS
 
-        download_from_google_storage.py --no_resume --no_auth --bucket chromium-clang-format -s "src/${sha1_path}"
+        gclient sync --spec="solutions=[{'name':'src/buildtools','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':True},'managed':False}]"
     - name: Run Lint
       shell: bash
       run: |

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -4,6 +4,7 @@ import contextlib
 import errno
 import json
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -184,14 +185,20 @@ def get_electron_exec():
 
 def get_buildtools_executable(name):
   buildtools = os.path.realpath(os.path.join(ELECTRON_DIR, '..', 'buildtools'))
-  chromium_platform = {
-    'darwin': 'mac',
-    'linux': 'linux64',
-    'linux2': 'linux64',
-    'win32': 'win',
-    'cygwin': 'win',
-  }[sys.platform]
-  path = os.path.join(buildtools, chromium_platform, name)
+
+  if sys.platform == 'darwin':
+    chromium_platform = 'mac_arm64' if platform.machine() == 'arm64' else 'mac'
+  elif sys.platform in ['win32', 'cygwin']:
+    chromium_platform = 'win'
+  elif sys.platform in ['linux', 'linux2']:
+    chromium_platform = 'linux64'
+  else:
+    raise Exception(f"Unsupported platform: {sys.platform}")
+
+  if name == 'clang-format':
+    path = os.path.join(buildtools, chromium_platform, 'format', name)
+  else:
+    path = os.path.join(buildtools, chromium_platform, name)
   if sys.platform == 'win32':
     path += '.exe'
   return path


### PR DESCRIPTION
Manual Backport of https://github.com/electron/electron/pull/42911

This incorporates the changes from https://github.com/electron/electron/pull/42527 and the change to `script/lib/util.py` from https://github.com/electron/electron/pull/42118.

Notes: none