### PR TITLE
fix: dangling raw_ptr<views::View> in api::View

### DIFF
--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -179,7 +179,7 @@ View::~View() {
     return;
   view_->RemoveObserver(this);
   if (delete_view_)
-    delete view_;
+    view_.ClearAndDelete();
 }
 
 void View::ReorderChildView(gin::Handle<View> child, size_t index) {


### PR DESCRIPTION
#### Description of Change

Fix another `raw_ptr` error.

This one is pretty small: the destructor for `electron::api::View` isn't cleared before the View is destroyed.

Clearing it fixes this backtrace:

```
Running: Main process specs
ok 1 app module BrowserWindow events should emit browser-window-created event when window is created
[1223495:0716/123446.652699:ERROR:partition_alloc_support.cc(687)] Detected dangling raw_ptr with id=0x00000bf402e2f7f8:
[DanglingSignature]	base::debug::CollectStackTrace() [../../base/debug/stack_trace_posix.cc:1044:7]	electron::NodeBindings::WakeupMainThread() [../../electron/shell/common/node_bindings.cc:911:26]	electron::api::View::~View() [../../base/allocator/partition_allocator/src/partition_alloc/pointers/raw_ptr_backup_ref_impl.h:200:7]	electron::NodeBindings::WakeupMainThread() [../../electron/shell/common/node_bindings.cc:911:26]

The memory was freed at:
#0 0x57333638f3f2 base::debug::CollectStackTrace() [../../base/debug/stack_trace_posix.cc:1044:7]
#1 0x57333637714c base::debug::StackTrace::StackTrace() [../../base/debug/stack_trace.cc:242:20]
#2 0x5733363959aa base::allocator::(anonymous namespace)::DanglingRawPtrDetected() [../../base/allocator/partition_alloc_support.cc:497:11]
#3 0x5733305d9b81 partition_alloc::PartitionRoot::Free<>() [../../base/allocator/partition_allocator/src/partition_alloc/in_slot_metadata.h:396:5]
#4 0x573330705ce6 CaptionButtonPlaceholderContainer::~CaptionButtonPlaceholderContainer() [../../electron/shell/browser/ui/views/caption_button_placeholder_container.cc:16:71]
#5 0x57333055f5bd electron::api::View::~View() [../../electron/shell/browser/api/electron_api_view.cc:182:5]
#6 0x57333055f6de electron::api::View::~View() [../../electron/shell/browser/api/electron_api_view.cc:177:15]
#7 0x5733326234f9 v8::internal::GlobalHandles::InvokeSecondPassPhantomCallbacks() [../../v8/src/handles/global-handles.cc:866:3]
#8 0x57333c2f2d9e node::PerIsolatePlatformData::RunForegroundTask() [../../third_party/electron_node/src/node_platform.cc:431:11]
#9 0x57333c2f1b1c node::PerIsolatePlatformData::FlushForegroundTasksInternal() [../../third_party/electron_node/src/node_platform.cc:505:5]
#10 0x573330486c0e uv__async_io [../../third_party/electron_node/deps/uv/src/unix/async.c:175:5]
#11 0x573330498650 uv__io_poll [../../third_party/electron_node/deps/uv/src/unix/linux.c:1485:11]
#12 0x5733304870a0 uv_run [../../third_party/electron_node/deps/uv/src/unix/core.c:447:5]
#13 0x5733306bd97e electron::NodeBindings::UvRunOnce() [../../electron/shell/common/node_bindings.cc:895:11]
#14 0x5733304f1f0b base::internal::Invoker<>::RunOnce() [../../base/functional/bind_internal.h:738:12]
#15 0x5733304a3290 base::OnceCallback<>::Run() [../../base/functional/callback.h:156:12]
#16 0x5733362e7d2d base::TaskAnnotator::RunTaskImpl() [../../base/task/common/task_annotator.cc:203:34]
#17 0x57333631e7e8 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl() [../../base/task/common/task_annotator.h:90:5]
#18 0x57333631dcb4 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() [../../base/task/sequence_manager/thread_controller_with_message_pump_impl.cc:346:40]
#19 0x57333631f1e5 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()
#20 0x5733363ad0f9 base::MessagePumpGlib::Run() [../../base/message_loop/message_pump_glib.cc:694:48]
#21 0x57333631fb2f base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run() [../../base/task/sequence_manager/thread_controller_with_message_pump_impl.cc:654:12]
#22 0x5733362c4ad2 base::RunLoop::Run() [../../base/run_loop.cc:134:14]
#23 0x573334a5fd87 content::BrowserMainLoop::RunMainMessageLoop() [../../content/browser/browser_main_loop.cc:1086:18]
#24 0x573334a622d5 content::BrowserMainRunnerImpl::Run() [../../content/browser/browser_main_runner_impl.cc:159:15]
#25 0x573334a5bd28 content::BrowserMain() [../../content/browser/browser_main.cc:34:28]
#26 0x5733308e7468 content::RunBrowserProcessMain() [../../content/app/content_main_runner_impl.cc:739:10]
#27 0x5733308ea462 content::ContentMainRunnerImpl::RunBrowser() [../../content/app/content_main_runner_impl.cc:1325:10]
#28 0x5733308e9a43 content::ContentMainRunnerImpl::Run() [../../content/app/content_main_runner_impl.cc:1177:12]
#29 0x5733308e5c3b content::RunContentProcess() [../../content/app/content_main.cc:330:36]
#30 0x5733308e5f60 content::ContentMain() [../../content/app/content_main.cc:343:10]
#31 0x57333049b639 main [../../electron/shell/app/electron_main_linux.cc:45:10]
#32 0x7ab76a42a1ca (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9)
#33 0x7ab76a42a28b __libc_start_main
#34 0x57333048102a _start

Task trace:
#0 0x5733306bdc42 electron::NodeBindings::WakeupMainThread() [../../electron/shell/common/node_bindings.cc:911:26]

The dangling raw_ptr was released at:
#0 0x57333638f3f2 base::debug::CollectStackTrace() [../../base/debug/stack_trace_posix.cc:1044:7]
#1 0x57333637714c base::debug::StackTrace::StackTrace() [../../base/debug/stack_trace.cc:242:20]
#2 0x573336395a9b base::allocator::(anonymous namespace)::DanglingRawPtrReleased<>() [../../base/allocator/partition_alloc_support.cc:659:21]
#3 0x5733363db155 base::internal::RawPtrBackupRefImpl<>::ReleaseInternal() [../../base/allocator/partition_allocator/src/partition_alloc/in_slot_metadata.h:224:7]
#4 0x57333055f61d electron::api::View::~View() [../../base/allocator/partition_allocator/src/partition_alloc/pointers/raw_ptr_backup_ref_impl.h:200:7]
#5 0x57333055f6de electron::api::View::~View() [../../electron/shell/browser/api/electron_api_view.cc:177:15]
#6 0x5733326234f9 v8::internal::GlobalHandles::InvokeSecondPassPhantomCallbacks() [../../v8/src/handles/global-handles.cc:866:3]
#7 0x57333c2f2d9e node::PerIsolatePlatformData::RunForegroundTask() [../../third_party/electron_node/src/node_platform.cc:431:11]
#8 0x57333c2f1b1c node::PerIsolatePlatformData::FlushForegroundTasksInternal() [../../third_party/electron_node/src/node_platform.cc:505:5]
#9 0x573330486c0e uv__async_io [../../third_party/electron_node/deps/uv/src/unix/async.c:175:5]
#10 0x573330498650 uv__io_poll [../../third_party/electron_node/deps/uv/src/unix/linux.c:1485:11]
#11 0x5733304870a0 uv_run [../../third_party/electron_node/deps/uv/src/unix/core.c:447:5]
#12 0x5733306bd97e electron::NodeBindings::UvRunOnce() [../../electron/shell/common/node_bindings.cc:895:11]
#13 0x5733304f1f0b base::internal::Invoker<>::RunOnce() [../../base/functional/bind_internal.h:738:12]
#14 0x5733304a3290 base::OnceCallback<>::Run() [../../base/functional/callback.h:156:12]
#15 0x5733362e7d2d base::TaskAnnotator::RunTaskImpl() [../../base/task/common/task_annotator.cc:203:34]
#16 0x57333631e7e8 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl() [../../base/task/common/task_annotator.h:90:5]
#17 0x57333631dcb4 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() [../../base/task/sequence_manager/thread_controller_with_message_pump_impl.cc:346:40]
#18 0x57333631f1e5 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()
#19 0x5733363ad0f9 base::MessagePumpGlib::Run() [../../base/message_loop/message_pump_glib.cc:694:48]
#20 0x57333631fb2f base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run() [../../base/task/sequence_manager/thread_controller_with_message_pump_impl.cc:654:12]
#21 0x5733362c4ad2 base::RunLoop::Run() [../../base/run_loop.cc:134:14]
#22 0x573334a5fd87 content::BrowserMainLoop::RunMainMessageLoop() [../../content/browser/browser_main_loop.cc:1086:18]
#23 0x573334a622d5 content::BrowserMainRunnerImpl::Run() [../../content/browser/browser_main_runner_impl.cc:159:15]
#24 0x573334a5bd28 content::BrowserMain() [../../content/browser/browser_main.cc:34:28]
#25 0x5733308e7468 content::RunBrowserProcessMain() [../../content/app/content_main_runner_impl.cc:739:10]
#26 0x5733308ea462 content::ContentMainRunnerImpl::RunBrowser() [../../content/app/content_main_runner_impl.cc:1325:10]
#27 0x5733308e9a43 content::ContentMainRunnerImpl::Run() [../../content/app/content_main_runner_impl.cc:1177:12]
#28 0x5733308e5c3b content::RunContentProcess() [../../content/app/content_main.cc:330:36]
#29 0x5733308e5f60 content::ContentMain() [../../content/app/content_main.cc:343:10]
#30 0x57333049b639 main [../../electron/shell/app/electron_main_linux.cc:45:10]
#31 0x7ab76a42a1ca (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9)
#32 0x7ab76a42a28b __libc_start_main
#33 0x57333048102a _start
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.