### PR TITLE
fix: dangling raw_ptr NodeBindings::uv_env_

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -604,6 +604,7 @@ void ElectronBrowserMainParts::PostMainMessageLoopRun() {
   node_env_->set_trace_sync_io(false);
   js_env_->DestroyMicrotasksRunner();
   node::Stop(node_env_.get(), node::StopFlags::kDoNotTerminateIsolate);
+  node_bindings_->set_uv_env(nullptr);
   node_env_.reset();
 
   auto default_context_key = ElectronBrowserContext::PartitionKey("", false);

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -155,10 +155,10 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   // Before then, we just exit() without any intermediate steps.
   std::optional<int> exit_code_;
 
-  std::unique_ptr<NodeBindings> node_bindings_;
+  const std::unique_ptr<NodeBindings> node_bindings_;
 
   // depends-on: node_bindings_
-  std::unique_ptr<ElectronBindings> electron_bindings_;
+  const std::unique_ptr<ElectronBindings> electron_bindings_;
 
   // depends-on: node_bindings_
   std::unique_ptr<JavascriptEnvironment> js_env_;


### PR DESCRIPTION
#### Description of Change

Fix a dangling raw_ptr `NodeBindings::uv_env_` in the node bindings owned by `ElectronBrowserMainParts`.

This is set from the EBMS's `node_env_` field [here](https://github.com/electron/electron/blob/778d3098a0f0bfc00015d54263674318f4adf6b1/shell/browser/electron_browser_main_parts.cc#L261) but wasn't being cleared before `node_env_` is destroyed [here](https://github.com/electron/electron/blob/778d3098a0f0bfc00015d54263674318f4adf6b1/shell/browser/electron_browser_main_parts.cc#L607). This PR adds a `set_uv_env(nullptr)` call to clear it.

This PR fixes this dangling raw_ptr error:

```
[1331881:0716/225832.407199:ERROR:partition_alloc_support.cc(687)] Detected dangling raw_ptr with id=0x00001594001957f8:
[DanglingSignature]	node::FreeEnvironment() [../../third_party/electron_node/src/api/environment.cc:526:3]	No active task	electron::NodeBindings::set_uv_env() [../../base/allocator/partition_allocator/src/partition_alloc/pointers/raw_ptr_backup_ref_impl.h:200:7]	No active task

The memory was freed at:
#0 0x57d16ed063f2 base::debug::CollectStackTrace() [../../base/debug/stack_trace_posix.cc:1044:7]
#1 0x57d16ecee14c base::debug::StackTrace::StackTrace() [../../base/debug/stack_trace.cc:242:20]
#2 0x57d16ed0c9aa base::allocator::(anonymous namespace)::DanglingRawPtrDetected() [../../base/allocator/partition_alloc_support.cc:497:11]
#3 0x57d16edbaea2 allocator_shim::internal::PartitionFree() [../../base/allocator/partition_allocator/src/partition_alloc/in_slot_metadata.h:396:5]
#4 0x57d174b56593 node::FreeEnvironment() [../../third_party/electron_node/src/api/environment.cc:526:3]
#5 0x57d169035b7e std::__Cr::__shared_ptr_pointer<>::__on_zero_shared() [../../electron/shell/common/node_bindings.cc:775:5]
#6 0x57d168f53613 electron::ElectronBrowserMainParts::PostMainMessageLoopRun() [../../third_party/libc++/src/include/__memory/shared_ptr.h:156:7]
#7 0x57d16d3d6fdd content::BrowserMainLoop::ShutdownThreadsAndCleanUp() [../../content/browser/browser_main_loop.cc:1148:13]
#8 0x57d16d3d940b content::BrowserMainRunnerImpl::Shutdown() [../../content/browser/browser_main_runner_impl.cc:194:17]
#9 0x57d16d3d2d77 content::BrowserMain() [../../content/browser/browser_main.cc:43:16]
#10 0x57d16925e4e8 content::RunBrowserProcessMain() [../../content/app/content_main_runner_impl.cc:739:10]
#11 0x57d1692614e2 content::ContentMainRunnerImpl::RunBrowser() [../../content/app/content_main_runner_impl.cc:1325:10]
#12 0x57d169260ac3 content::ContentMainRunnerImpl::Run() [../../content/app/content_main_runner_impl.cc:1177:12]
#13 0x57d16925ccbb content::RunContentProcess() [../../content/app/content_main.cc:330:36]
#14 0x57d16925cfe0 content::ContentMain() [../../content/app/content_main.cc:343:10]
#15 0x57d168e12639 main [../../electron/shell/app/electron_main_linux.cc:45:10]
#16 0x70fa9162a1ca (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9)
#17 0x70fa9162a28b __libc_start_main
#18 0x57d168df802a _start

Task trace:
No active task.
The dangling raw_ptr was released at:
#0 0x57d16ed063f2 base::debug::CollectStackTrace() [../../base/debug/stack_trace_posix.cc:1044:7]
#1 0x57d16ecee14c base::debug::StackTrace::StackTrace() [../../base/debug/stack_trace.cc:242:20]
#2 0x57d16ed0ca9b base::allocator::(anonymous namespace)::DanglingRawPtrReleased<>() [../../base/allocator/partition_alloc_support.cc:659:21]
#3 0x57d16ed52155 base::internal::RawPtrBackupRefImpl<>::ReleaseInternal() [../../base/allocator/partition_allocator/src/partition_alloc/in_slot_metadata.h:224:7]
#4 0x57d168f522e2 electron::NodeBindings::set_uv_env() [../../base/allocator/partition_allocator/src/partition_alloc/pointers/raw_ptr_backup_ref_impl.h:200:7]
#5 0x57d168f51fff electron::ElectronBrowserMainParts::~ElectronBrowserMainParts() [../../electron/shell/browser/electron_browser_main_parts.cc:194:19]
#6 0x57d168f5231e electron::ElectronBrowserMainParts::~ElectronBrowserMainParts() [../../electron/shell/browser/electron_browser_main_parts.cc:193:55]
#7 0x57d16d3d34d5 content::BrowserMainLoop::~BrowserMainLoop() [../../third_party/libc++/src/include/__memory/unique_ptr.h:67:5]
#8 0x57d16d3d372e content::BrowserMainLoop::~BrowserMainLoop() [../../content/browser/browser_main_loop.cc:507:37]
#9 0x57d16d3d9431 content::BrowserMainRunnerImpl::Shutdown() [../../third_party/libc++/src/include/__memory/unique_ptr.h:67:5]
#10 0x57d16d3d2d77 content::BrowserMain() [../../content/browser/browser_main.cc:43:16]
#11 0x57d16925e4e8 content::RunBrowserProcessMain() [../../content/app/content_main_runner_impl.cc:739:10]
#12 0x57d1692614e2 content::ContentMainRunnerImpl::RunBrowser() [../../content/app/content_main_runner_impl.cc:1325:10]
#13 0x57d169260ac3 content::ContentMainRunnerImpl::Run() [../../content/app/content_main_runner_impl.cc:1177:12]
#14 0x57d16925ccbb content::RunContentProcess() [../../content/app/content_main.cc:330:36]
#15 0x57d16925cfe0 content::ContentMain() [../../content/app/content_main.cc:343:10]
#16 0x57d168e12639 main [../../electron/shell/app/electron_main_linux.cc:45:10]
#17 0x70fa9162a1ca (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9)
#18 0x70fa9162a28b __libc_start_main
#19 0x57d168df802a _start

Task trace:
No active task.

Please check for more information on:
https://chromium.googlesource.com/chromium/src/+/main/docs/dangling_ptr_guide.md
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.