### PR TITLE
refactor: remove ElectronBrowserMainParts::field_trial_list_

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -14,7 +14,6 @@
 #include "base/command_line.h"
 #include "base/feature_list.h"
 #include "base/i18n/rtl.h"
-#include "base/metrics/field_trial.h"
 #include "base/nix/xdg_util.h"
 #include "base/path_service.h"
 #include "base/run_loop.h"
@@ -212,7 +211,6 @@ int ElectronBrowserMainParts::GetExitCode() const {
 }
 
 int ElectronBrowserMainParts::PreEarlyInitialization() {
-  field_trial_list_ = std::make_unique<base::FieldTrialList>();
 #if BUILDFLAG(IS_POSIX)
   HandleSIGCHLD();
 #endif

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -23,10 +23,6 @@
 class BrowserProcessImpl;
 class IconManager;
 
-namespace base {
-class FieldTrialList;
-}
-
 #if defined(USE_AURA)
 namespace wm {
 class WMState;
@@ -170,7 +166,6 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   std::unique_ptr<Browser> browser_;
 
   std::unique_ptr<IconManager> icon_manager_;
-  std::unique_ptr<base::FieldTrialList> field_trial_list_;
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   std::unique_ptr<ElectronExtensionsClient> extensions_client_;


### PR DESCRIPTION
#### Description of Change

Experimental PR to test whether 38c389133740aa7f05d2c557865db48b9c3834ec is still needed by removing the  `FieldTrialList` instance to see if the `DCHECK()` still exists.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.