### PR TITLE
fix: dangling raw_ptr<Session> in UserDataLink 

### DIFF
--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -327,9 +327,10 @@ class DictionaryObserver final : public SpellcheckCustomDictionary::Observer {
 #endif  // BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 
 struct UserDataLink : base::SupportsUserData::Data {
-  explicit UserDataLink(Session* ses) : session(ses) {}
+  explicit UserDataLink(base::WeakPtr<Session> session_in)
+      : session{std::move(session_in)} {}
 
-  raw_ptr<Session> session;
+  base::WeakPtr<Session> session;
 };
 
 const void* kElectronApiSessionKey = &kElectronApiSessionKey;
@@ -349,8 +350,9 @@ Session::Session(v8::Isolate* isolate, ElectronBrowserContext* browser_context)
 
   protocol_.Reset(isolate, Protocol::Create(isolate, browser_context).ToV8());
 
-  browser_context->SetUserData(kElectronApiSessionKey,
-                               std::make_unique<UserDataLink>(this));
+  browser_context->SetUserData(
+      kElectronApiSessionKey,
+      std::make_unique<UserDataLink>(weak_factory_.GetWeakPtr()));
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   SpellcheckService* service =
@@ -1226,7 +1228,7 @@ bool Session::IsSpellCheckerEnabled() const {
 Session* Session::FromBrowserContext(content::BrowserContext* context) {
   auto* data =
       static_cast<UserDataLink*>(context->GetUserData(kElectronApiSessionKey));
-  return data ? data->session : nullptr;
+  return data ? data->session.get() : nullptr;
 }
 
 // static

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
 #include "base/values.h"
 #include "content/public/browser/download_manager.h"
 #include "electron/buildflags/buildflags.h"
@@ -213,7 +214,9 @@ class Session : public gin::Wrappable<Session>,
   // The client id to enable the network throttler.
   base::UnguessableToken network_emulation_token_;
 
-  raw_ptr<ElectronBrowserContext> browser_context_;
+  const raw_ptr<ElectronBrowserContext> browser_context_;
+
+  base::WeakPtrFactory<Session> weak_factory_{this};
 };
 
 }  // namespace api


### PR DESCRIPTION
Manual backport of #42786 to 30-x-y. See that PR for details.

Notes: none.