### PR TITLE
refactor: remove unused web contents preferences methods

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3619,9 +3619,8 @@ std::vector<base::FilePath> WebContents::GetPreloadPaths() const {
   auto result = SessionPreferences::GetValidPreloads(GetBrowserContext());
 
   if (auto* web_preferences = WebContentsPreferences::From(web_contents())) {
-    base::FilePath preload;
-    if (web_preferences->GetPreloadPath(&preload)) {
-      result.emplace_back(preload);
+    if (auto preload = web_preferences->GetPreloadPath()) {
+      result.emplace_back(*preload);
     }
   }
 

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -275,15 +275,6 @@ bool WebContentsPreferences::SetImageAnimationPolicy(std::string policy) {
   return false;
 }
 
-bool WebContentsPreferences::GetPreloadPath(base::FilePath* path) const {
-  DCHECK(path);
-  if (preload_path_) {
-    *path = *preload_path_;
-    return true;
-  }
-  return false;
-}
-
 bool WebContentsPreferences::IsSandboxed() const {
   if (sandbox_)
     return *sandbox_;

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -258,14 +258,6 @@ void WebContentsPreferences::SetFromDictionary(
   SaveLastPreferences();
 }
 
-bool WebContentsPreferences::GetSafeDialogsMessage(std::string* message) const {
-  if (safe_dialogs_message_) {
-    *message = *safe_dialogs_message_;
-    return true;
-  }
-  return false;
-}
-
 bool WebContentsPreferences::SetImageAnimationPolicy(std::string policy) {
   if (policy == "animate") {
     image_animation_policy_ =

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -77,7 +77,7 @@ class WebContentsPreferences
   }
   bool ShouldDisablePopups() const { return disable_popups_; }
   bool IsWebSecurityEnabled() const { return web_security_; }
-  bool GetPreloadPath(base::FilePath* path) const;
+  std::optional<base::FilePath> GetPreloadPath() const { return preload_path_; }
   bool IsSandboxed() const;
 
  private:

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -52,7 +52,7 @@ class WebContentsPreferences
   void OverrideWebkitPrefs(blink::web_pref::WebPreferences* prefs,
                            blink::RendererPreferences* renderer_prefs);
 
-  base::Value* last_preference() { return &last_web_preferences_; }
+  const base::Value* last_preference() const { return &last_web_preferences_; }
 
   bool IsOffscreen() const { return offscreen_; }
   std::optional<SkColor> GetBackgroundColor() const {

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -75,7 +75,6 @@ class WebContentsPreferences
   bool AllowsNodeIntegrationInSubFrames() const {
     return node_integration_in_sub_frames_;
   }
-  bool ShouldDisableDialogs() const { return disable_dialogs_; }
   bool ShouldUseSafeDialogs() const { return safe_dialogs_; }
   bool GetSafeDialogsMessage(std::string* message) const;
   bool ShouldDisablePopups() const { return disable_popups_; }

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -75,7 +75,6 @@ class WebContentsPreferences
   bool AllowsNodeIntegrationInSubFrames() const {
     return node_integration_in_sub_frames_;
   }
-  bool ShouldUseSafeDialogs() const { return safe_dialogs_; }
   bool GetSafeDialogsMessage(std::string* message) const;
   bool ShouldDisablePopups() const { return disable_popups_; }
   bool IsWebSecurityEnabled() const { return web_security_; }

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -75,7 +75,6 @@ class WebContentsPreferences
   bool AllowsNodeIntegrationInSubFrames() const {
     return node_integration_in_sub_frames_;
   }
-  bool GetSafeDialogsMessage(std::string* message) const;
   bool ShouldDisablePopups() const { return disable_popups_; }
   bool IsWebSecurityEnabled() const { return web_security_; }
   bool GetPreloadPath(base::FilePath* path) const;


### PR DESCRIPTION
#### Description of Change

Minor cleanup of WebContentsPreferences:

- remove unused methods (callers removed in #40598)
- make const methods const
- update `WebContentsPreferences::GetPreloadPath()` to use `std::optional`

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.