### PR TITLE
chore: remove unused typedef CreateDownloadPathCallback

### DIFF
--- a/shell/browser/electron_download_manager_delegate.h
+++ b/shell/browser/electron_download_manager_delegate.h
@@ -20,9 +20,6 @@ namespace electron {
 class ElectronDownloadManagerDelegate
     : public content::DownloadManagerDelegate {
  public:
-  using CreateDownloadPathCallback =
-      base::RepeatingCallback<void(const base::FilePath&)>;
-
   explicit ElectronDownloadManagerDelegate(content::DownloadManager* manager);
   ~ElectronDownloadManagerDelegate() override;
 


### PR DESCRIPTION
#### Description of Change

Remove the `CreateDownloadPathCallback` typedef because the code using it was removed in  e3c580e9

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.