### PR TITLE
chore: remove unused field `ElectronBrowserClient::browser_main_parts_`

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -829,13 +829,7 @@ ElectronBrowserClient::GetSystemNetworkContext() {
 
 std::unique_ptr<content::BrowserMainParts>
 ElectronBrowserClient::CreateBrowserMainParts(bool /* is_integration_test */) {
-  auto browser_main_parts = std::make_unique<ElectronBrowserMainParts>();
-
-#if BUILDFLAG(IS_MAC)
-  browser_main_parts_ = browser_main_parts.get();
-#endif
-
-  return browser_main_parts;
+  return std::make_unique<ElectronBrowserMainParts>();
 }
 
 void ElectronBrowserClient::WebNotificationAllowed(

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -340,10 +340,6 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
   std::unique_ptr<ElectronHidDelegate> hid_delegate_;
   std::unique_ptr<ElectronWebAuthenticationDelegate>
       web_authentication_delegate_;
-
-#if BUILDFLAG(IS_MAC)
-  raw_ptr<ElectronBrowserMainParts> browser_main_parts_ = nullptr;
-#endif
 };
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

Remove unused field `ElectronBrowserClient::browser_main_parts_`. The code that used it was removed a few months ago in 48d0b09ad932aabc91ef072c862f3489202e40fd (#37587).

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.