### PR TITLE
docs: add instructions on using node_modules with Yarn

### DIFF
--- a/docs/tutorial/tutorial-2-first-app.md
+++ b/docs/tutorial/tutorial-2-first-app.md
@@ -55,6 +55,16 @@ There are a few rules to follow for the purposes of this tutorial:
 - _author_, _license_, and _description_ can be any value, but will be necessary for
   [packaging][packaging] later on.
 
+:::caution When using Yarn, use `node_modules` instead of PnP
+
+Modern versions of Yarn uses [Plug'n'Play (PnP)](https://yarnpkg.com/features/pnp) to manage project dependencies, whereas older versions of Yarn used a `node_modules` directory for the same task. Electron is not compatible with the modern PnP. Therefore one must configure modern Yarn to use a `node_modules` directory by creating a `.yarnrc.yml` configuration file at the root of the project directory and set the attribute `nodeLinker` to `node-modules`. Read more in [Yarn's reference](https://yarnpkg.com/configuration/yarnrc#nodeLinker).
+
+```yml
+nodeLinker: node-modules
+```
+
+:::
+
 Then, install Electron into your app's **devDependencies**, which is the list of external
 development-only package dependencies not required in production.
 


### PR DESCRIPTION
#### Description of Change

This PR adds instructions for Yarn users that are following the tutorial in the documentation that one must configure modern versions of Yarn to use the classic `node_modules` directory for managing dependencies instead of [PnP](https://yarnpkg.com/features/pnp). 

As of writing, when using the latest Yarn with the default configuration, that is with PnP, issues appeared that took a long time to identify. I believe this incompatibility with Yarn PnP might affect many new Electron developers like myself and that this addition in the documentation would have been valuable early on. 😊

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none
