### PR TITLE
chore: remove unused #includes

### DIFF
--- a/shell/app/electron_content_client.cc
+++ b/shell/app/electron_content_client.cc
@@ -13,7 +13,6 @@
 #include "base/files/file_util.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
-#include "base/strings/utf_string_conversions.h"
 #include "content/public/common/content_constants.h"
 #include "content/public/common/content_switches.h"
 #include "electron/buildflags/buildflags.h"

--- a/shell/app/electron_content_client.cc
+++ b/shell/app/electron_content_client.cc
@@ -12,7 +12,6 @@
 #include "base/command_line.h"
 #include "base/files/file_util.h"
 #include "base/strings/string_split.h"
-#include "base/strings/string_util.h"
 #include "content/public/common/content_constants.h"
 #include "content/public/common/content_switches.h"
 #include "electron/buildflags/buildflags.h"

--- a/shell/app/electron_content_client.cc
+++ b/shell/app/electron_content_client.cc
@@ -11,7 +11,6 @@
 
 #include "base/command_line.h"
 #include "base/files/file_util.h"
-#include "base/path_service.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"

--- a/shell/app/electron_crash_reporter_client.cc
+++ b/shell/app/electron_crash_reporter_client.cc
@@ -11,7 +11,6 @@
 #include "base/environment.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
-#include "base/logging.h"
 #include "base/path_service.h"
 #include "base/strings/string_split.h"
 #include "base/strings/utf_string_conversions.h"

--- a/shell/app/electron_crash_reporter_client.cc
+++ b/shell/app/electron_crash_reporter_client.cc
@@ -7,7 +7,6 @@
 #include <map>
 #include <string>
 
-#include "base/command_line.h"
 #include "base/environment.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"

--- a/shell/app/electron_crash_reporter_client.cc
+++ b/shell/app/electron_crash_reporter_client.cc
@@ -11,7 +11,6 @@
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/path_service.h"
-#include "base/strings/string_split.h"
 #include "base/strings/utf_string_conversions.h"
 #include "build/build_config.h"
 #include "chrome/common/chrome_paths.h"

--- a/shell/app/electron_crash_reporter_client.h
+++ b/shell/app/electron_crash_reporter_client.h
@@ -8,7 +8,6 @@
 #include <map>
 #include <string>
 
-#include "base/compiler_specific.h"
 #include "base/no_destructor.h"
 #include "build/build_config.h"
 #include "components/crash/core/app/crash_reporter_client.h"

--- a/shell/app/electron_library_main.h
+++ b/shell/app/electron_library_main.h
@@ -6,7 +6,6 @@
 #define ELECTRON_SHELL_APP_ELECTRON_LIBRARY_MAIN_H_
 
 #include "build/build_config.h"
-#include "electron/buildflags/buildflags.h"
 
 #if BUILDFLAG(IS_MAC)
 extern "C" {

--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -18,7 +18,6 @@
 #include "base/files/file_util.h"
 #include "base/logging.h"
 #include "base/path_service.h"
-#include "base/strings/string_split.h"
 #include "chrome/common/chrome_paths.h"
 #include "chrome/common/chrome_switches.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"

--- a/shell/app/electron_main_linux.cc
+++ b/shell/app/electron_main_linux.cc
@@ -10,7 +10,6 @@
 #include "base/command_line.h"
 #include "base/i18n/icu_util.h"
 #include "content/public/app/content_main.h"
-#include "electron/buildflags/buildflags.h"
 #include "electron/fuses.h"
 #include "shell/app/electron_main_delegate.h"  // NOLINT
 #include "shell/app/node_main.h"

--- a/shell/app/electron_main_mac.cc
+++ b/shell/app/electron_main_mac.cc
@@ -5,7 +5,6 @@
 #include <cstdlib>
 #include <memory>
 
-#include "electron/buildflags/buildflags.h"
 #include "electron/fuses.h"
 #include "shell/app/electron_library_main.h"
 #include "shell/app/uv_stdio_fix.h"

--- a/shell/app/electron_main_win.cc
+++ b/shell/app/electron_main_win.cc
@@ -17,7 +17,6 @@
 #include <vector>
 
 #include "base/at_exit.h"
-#include "base/environment.h"
 #include "base/i18n/icu_util.h"
 #include "base/memory/raw_ptr_exclusion.h"
 #include "base/process/launch.h"

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -16,7 +16,6 @@
 #include "base/containers/fixed_flat_set.h"
 #include "base/environment.h"
 #include "base/feature_list.h"
-#include "base/strings/string_util.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/task/thread_pool/thread_pool_instance.h"
 #include "content/public/common/content_switches.h"

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -17,7 +17,6 @@
 #include "base/environment.h"
 #include "base/feature_list.h"
 #include "base/strings/string_util.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/task/thread_pool/thread_pool_instance.h"
 #include "content/public/common/content_switches.h"

--- a/shell/app/uv_task_runner.cc
+++ b/shell/app/uv_task_runner.cc
@@ -5,7 +5,6 @@
 #include <utility>
 
 #include "base/location.h"
-#include "base/stl_util.h"
 #include "base/time/time.h"
 #include "shell/app/uv_task_runner.h"
 

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -70,6 +70,7 @@
 #include "shell/common/gin_converters/file_path_converter.h"
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_converters/image_converter.h"
+#include "shell/common/gin_converters/login_item_settings_converter.h"
 #include "shell/common/gin_converters/net_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"

--- a/shell/browser/api/electron_api_auto_updater.cc
+++ b/shell/browser/api/electron_api_auto_updater.cc
@@ -5,7 +5,6 @@
 #include "shell/browser/api/electron_api_auto_updater.h"
 
 #include "base/time/time.h"
-#include "shell/browser/browser.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/browser/native_window.h"
 #include "shell/browser/window_list.h"

--- a/shell/browser/api/electron_api_crash_reporter.cc
+++ b/shell/browser/api/electron_api_crash_reporter.cc
@@ -10,7 +10,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/command_line.h"
 #include "base/functional/bind.h"
 #include "base/no_destructor.h"
 #include "base/path_service.h"

--- a/shell/browser/api/electron_api_data_pipe_holder.cc
+++ b/shell/browser/api/electron_api_data_pipe_holder.cc
@@ -7,7 +7,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/no_destructor.h"
 #include "base/strings/string_number_conversions.h"

--- a/shell/browser/api/electron_api_debugger.h
+++ b/shell/browser/api/electron_api_debugger.h
@@ -12,7 +12,6 @@
 #include "base/values.h"
 #include "content/public/browser/devtools_agent_host_client.h"
 #include "content/public/browser/web_contents_observer.h"
-#include "gin/arguments.h"
 #include "gin/handle.h"
 #include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
@@ -22,6 +21,10 @@ namespace content {
 class DevToolsAgentHost;
 class WebContents;
 }  // namespace content
+
+namespace gin {
+class Arguments;
+}  // namespace gin
 
 namespace electron::api {
 

--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -8,7 +8,6 @@
 
 #include "base/containers/contains.h"
 #include "base/stl_util.h"
-#include "base/strings/utf_string_conversions.h"
 #include "extensions/common/command.h"
 #include "gin/dictionary.h"
 #include "gin/object_template_builder.h"

--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -7,7 +7,6 @@
 #include <vector>
 
 #include "base/containers/contains.h"
-#include "base/stl_util.h"
 #include "extensions/common/command.h"
 #include "gin/dictionary.h"
 #include "gin/object_template_builder.h"

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -10,12 +10,15 @@
 
 #include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
-#include "gin/arguments.h"
 #include "shell/browser/api/electron_api_base_window.h"
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/browser/ui/electron_menu_model.h"
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/pinnable.h"
+
+namespace gin {
+class Arguments;
+}  // namespace gin
 
 namespace electron::api {
 

--- a/shell/browser/api/electron_api_menu_mac.mm
+++ b/shell/browser/api/electron_api_menu_mac.mm
@@ -12,7 +12,6 @@
 #include "base/task/current_thread.h"
 #include "base/task/sequenced_task_runner.h"
 #include "content/public/browser/browser_task_traits.h"
-#include "content/public/browser/browser_thread.h"
 #include "content/public/browser/web_contents.h"
 #include "shell/browser/native_window.h"
 #include "shell/common/keyboard_util.h"

--- a/shell/browser/api/electron_api_native_theme.cc
+++ b/shell/browser/api/electron_api_native_theme.cc
@@ -13,7 +13,6 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
-#include "ui/gfx/color_utils.h"
 #include "ui/native_theme/native_theme.h"
 
 namespace electron::api {

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/api/electron_api_notification.h"
 
-#include "base/strings/utf_string_conversions.h"
 #include "base/uuid.h"
 #include "gin/handle.h"
 #include "shell/browser/api/electron_api_menu.h"

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
-#include "base/strings/utf_string_conversions.h"
 #include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/browser/notifications/notification.h"

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "base/command_line.h"
-#include "base/stl_util.h"
 #include "content/common/url_schemes.h"
 #include "content/public/browser/child_process_security_policy.h"
 #include "gin/object_template_builder.h"

--- a/shell/browser/api/electron_api_protocol.h
+++ b/shell/browser/api/electron_api_protocol.h
@@ -15,6 +15,10 @@
 #include "shell/browser/net/electron_url_loader_factory.h"
 #include "shell/common/gin_helper/constructible.h"
 
+namespace gin {
+class Arguments;
+}  // namespace gin
+
 namespace electron {
 
 class ElectronBrowserContext;

--- a/shell/browser/api/electron_api_screen.cc
+++ b/shell/browser/api/electron_api_screen.cc
@@ -8,7 +8,6 @@
 #include <string_view>
 
 #include "base/functional/bind.h"
-#include "gin/dictionary.h"
 #include "gin/handle.h"
 #include "shell/browser/browser.h"
 #include "shell/common/gin_converters/callback_converter.h"

--- a/shell/browser/api/electron_api_service_worker_context.cc
+++ b/shell/browser/api/electron_api_service_worker_context.cc
@@ -19,7 +19,6 @@
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
-#include "shell/common/gin_helper/function_template_extensions.h"
 #include "shell/common/node_includes.h"
 
 namespace electron::api {

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -16,7 +16,6 @@
 #include "base/files/file_enumerator.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
-#include "base/memory/raw_ptr.h"
 #include "base/scoped_observation.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -24,7 +24,6 @@
 #include "shell/common/gin_helper/cleaned_up_at_exit.h"
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/error_thrower.h"
-#include "shell/common/gin_helper/function_template_extensions.h"
 #include "shell/common/gin_helper/pinnable.h"
 #include "shell/common/gin_helper/promise.h"
 

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "base/memory/weak_ptr.h"
 #include "base/values.h"
 #include "content/public/browser/download_manager.h"

--- a/shell/browser/api/electron_api_system_preferences.cc
+++ b/shell/browser/api/electron_api_system_preferences.cc
@@ -10,7 +10,6 @@
 #include "shell/common/gin_helper/function_template_extensions.h"
 #include "shell/common/node_includes.h"
 #include "ui/gfx/animation/animation.h"
-#include "ui/gfx/color_utils.h"
 #include "ui/native_theme/native_theme.h"
 
 namespace electron::api {

--- a/shell/browser/api/electron_api_system_preferences.cc
+++ b/shell/browser/api/electron_api_system_preferences.cc
@@ -9,7 +9,6 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
 #include "ui/gfx/animation/animation.h"
-#include "ui/native_theme/native_theme.h"
 
 namespace electron::api {
 

--- a/shell/browser/api/electron_api_system_preferences.cc
+++ b/shell/browser/api/electron_api_system_preferences.cc
@@ -7,7 +7,6 @@
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
-#include "shell/common/gin_helper/function_template_extensions.h"
 #include "shell/common/node_includes.h"
 #include "ui/gfx/animation/animation.h"
 #include "ui/native_theme/native_theme.h"

--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -27,7 +27,6 @@
 #include "shell/common/node_includes.h"
 #include "shell/common/process_util.h"
 #include "skia/ext/skia_utils_mac.h"
-#include "ui/native_theme/native_theme.h"
 
 namespace gin {
 

--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -14,7 +14,6 @@
 
 #include "base/apple/scoped_cftyperef.h"
 #include "base/containers/flat_map.h"
-#include "base/strings/stringprintf.h"
 #include "base/strings/sys_string_conversions.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/values.h"

--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -20,7 +20,6 @@
 #include "shell/common/gin_converters/guid_converter.h"
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
-#include "shell/common/gin_helper/function_template_extensions.h"
 #include "shell/common/node_includes.h"
 #include "ui/gfx/image/image.h"
 

--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -21,7 +21,6 @@
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
-#include "ui/gfx/image/image.h"
 
 namespace gin {
 

--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -19,7 +19,6 @@
 #include "content/public/common/result_codes.h"
 #include "gin/handle.h"
 #include "gin/object_template_builder.h"
-#include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "shell/browser/api/message_port.h"
 #include "shell/browser/javascript_environment.h"

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -22,7 +22,6 @@
 #include "base/no_destructor.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/current_thread.h"
-#include "base/task/thread_pool.h"
 #include "base/threading/scoped_blocking_call.h"
 #include "base/values.h"
 #include "chrome/browser/browser_process.h"

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -52,7 +52,6 @@
 #include "shell/common/gin_helper/pinnable.h"
 #include "ui/base/cursor/cursor.h"
 #include "ui/base/models/image_model.h"
-#include "ui/gfx/image/image.h"
 
 #if BUILDFLAG(ENABLE_PRINTING)
 #include "components/printing/browser/print_to_pdf/pdf_print_result.h"

--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -12,7 +12,6 @@
 #include "base/containers/contains.h"
 #include "base/containers/fixed_flat_map.h"
 #include "base/memory/raw_ptr.h"
-#include "base/stl_util.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/values.h"
 #include "extensions/browser/api/web_request/web_request_resource_type.h"

--- a/shell/browser/api/electron_api_web_request.h
+++ b/shell/browser/api/electron_api_web_request.h
@@ -9,7 +9,6 @@
 #include <set>
 
 #include "base/memory/raw_ptr.h"
-#include "base/values.h"
 #include "extensions/common/url_pattern.h"
 #include "gin/handle.h"
 #include "gin/wrappable.h"

--- a/shell/browser/api/electron_api_web_request.h
+++ b/shell/browser/api/electron_api_web_request.h
@@ -11,13 +11,16 @@
 #include "base/memory/raw_ptr.h"
 #include "base/values.h"
 #include "extensions/common/url_pattern.h"
-#include "gin/arguments.h"
 #include "gin/handle.h"
 #include "gin/wrappable.h"
 #include "shell/browser/net/web_request_api_interface.h"
 
 namespace content {
 class BrowserContext;
+}
+
+namespace gin {
+class Arguments;
 }
 
 namespace electron::api {

--- a/shell/browser/api/gpuinfo_manager.cc
+++ b/shell/browser/api/gpuinfo_manager.cc
@@ -8,7 +8,6 @@
 
 #include "base/memory/singleton.h"
 #include "base/task/single_thread_task_runner.h"
-#include "content/public/browser/browser_thread.h"
 #include "gpu/config/gpu_info_collector.h"
 #include "shell/browser/api/gpu_info_enumerator.h"
 #include "shell/common/gin_converters/value_converter.h"

--- a/shell/browser/badging/badge_manager_factory.cc
+++ b/shell/browser/badging/badge_manager_factory.cc
@@ -6,7 +6,6 @@
 
 #include "base/functional/bind.h"
 #include "base/memory/ptr_util.h"
-#include "base/memory/singleton.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
 #include "shell/browser/badging/badge_manager.h"
 

--- a/shell/browser/bluetooth/electron_bluetooth_delegate.h
+++ b/shell/browser/bluetooth/electron_bluetooth_delegate.h
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "base/memory/weak_ptr.h"
-#include "base/observer_list.h"
 #include "content/public/browser/bluetooth_delegate.h"
 #include "content/public/browser/render_frame_host.h"
 #include "third_party/blink/public/mojom/bluetooth/web_bluetooth.mojom-forward.h"

--- a/shell/browser/bluetooth/electron_bluetooth_delegate.h
+++ b/shell/browser/bluetooth/electron_bluetooth_delegate.h
@@ -12,7 +12,6 @@
 
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
-#include "base/scoped_observation.h"
 #include "content/public/browser/bluetooth_delegate.h"
 #include "content/public/browser/render_frame_host.h"
 #include "third_party/blink/public/mojom/bluetooth/web_bluetooth.mojom-forward.h"

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "base/files/file_util.h"
-#include "base/no_destructor.h"
 #include "base/path_service.h"
 #include "base/run_loop.h"
 #include "base/task/single_thread_task_runner.h"

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -21,6 +21,7 @@
 #include "shell/browser/window_list.h"
 #include "shell/common/application_info.h"
 #include "shell/common/electron_paths.h"
+#include "shell/common/gin_converters/login_item_settings_converter.h"
 #include "shell/common/gin_helper/arguments.h"
 #include "shell/common/thread_restrictions.h"
 

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -15,7 +15,6 @@
 #include "base/values.h"
 #include "shell/browser/browser_observer.h"
 #include "shell/browser/window_list_observer.h"
-#include "shell/common/gin_converters/login_item_settings_converter.h"
 #include "shell/common/gin_helper/promise.h"
 
 #if BUILDFLAG(IS_WIN)

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -10,7 +10,6 @@
 #include <string>
 #include <vector>
 
-#include "base/compiler_specific.h"
 #include "base/observer_list.h"
 #include "base/task/cancelable_task_tracker.h"
 #include "base/values.h"

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -14,7 +14,6 @@
 #include "base/observer_list.h"
 #include "base/task/cancelable_task_tracker.h"
 #include "base/values.h"
-#include "gin/dictionary.h"
 #include "shell/browser/browser_observer.h"
 #include "shell/browser/window_list_observer.h"
 #include "shell/common/gin_converters/login_item_settings_converter.h"

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -30,7 +30,6 @@
 #include "shell/common/application_info.h"
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_converters/login_item_settings_converter.h"
-#include "shell/common/gin_helper/arguments.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/promise.h"

--- a/shell/browser/browser_process_impl.h
+++ b/shell/browser/browser_process_impl.h
@@ -13,7 +13,6 @@
 #include <memory>
 #include <string>
 
-#include "base/command_line.h"
 #include "chrome/browser/browser_process.h"
 #include "components/embedder_support/origin_trials/origin_trials_settings_storage.h"
 #include "components/prefs/pref_service.h"

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -38,7 +38,6 @@
 #include "shell/common/gin_converters/file_path_converter.h"
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_converters/login_item_settings_converter.h"
-#include "shell/common/gin_helper/arguments.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/skia_util.h"
 #include "shell/common/thread_restrictions.h"

--- a/shell/browser/certificate_manager_model.h
+++ b/shell/browser/certificate_manager_model.h
@@ -10,7 +10,6 @@
 
 #include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
-#include "base/memory/ref_counted.h"
 #include "net/cert/nss_cert_database.h"
 
 // CertificateManagerModel provides the data to be displayed in the certificate

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -16,7 +16,6 @@
 #include "base/debug/crash_logging.h"
 #include "base/environment.h"
 #include "base/files/file_util.h"
-#include "base/json/json_reader.h"
 #include "base/no_destructor.h"
 #include "base/path_service.h"
 #include "base/stl_util.h"

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -24,7 +24,6 @@
 #include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
-#include "base/strings/utf_string_conversions.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/common/chrome_paths.h"
 #include "chrome/common/chrome_switches.h"

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -19,7 +19,6 @@
 #include "base/no_destructor.h"
 #include "base/path_service.h"
 #include "base/strings/escape.h"
-#include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "chrome/browser/browser_process.h"

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -18,7 +18,6 @@
 #include "base/files/file_util.h"
 #include "base/no_destructor.h"
 #include "base/path_service.h"
-#include "base/stl_util.h"
 #include "base/strings/escape.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -19,7 +19,6 @@
 #include "base/path_service.h"
 #include "base/run_loop.h"
 #include "base/strings/string_number_conversions.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/task/single_thread_task_runner.h"
 #include "chrome/browser/icon_manager.h"
 #include "chrome/browser/ui/color/chrome_color_mixers.h"

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -11,7 +11,6 @@
 
 #include "base/functional/callback.h"
 #include "base/task/single_thread_task_runner.h"
-#include "base/timer/timer.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_main_parts.h"
 #include "electron/buildflags/buildflags.h"

--- a/shell/browser/electron_browser_main_parts_mac.mm
+++ b/shell/browser/electron_browser_main_parts_mac.mm
@@ -8,7 +8,6 @@
 
 #include "base/apple/bundle_locations.h"
 #include "base/apple/foundation_util.h"
-#include "base/path_service.h"
 #include "services/device/public/cpp/geolocation/geolocation_system_permission_manager.h"
 #include "services/device/public/cpp/geolocation/system_geolocation_source_apple.h"
 #include "shell/browser/browser_process_impl.h"

--- a/shell/browser/electron_browser_main_parts_posix.cc
+++ b/shell/browser/electron_browser_main_parts_posix.cc
@@ -19,7 +19,6 @@
 #include "base/posix/eintr_wrapper.h"
 #include "base/threading/platform_thread.h"
 #include "content/public/browser/browser_task_traits.h"
-#include "content/public/browser/browser_thread.h"
 #include "shell/browser/browser.h"
 
 namespace electron {

--- a/shell/browser/electron_browser_main_parts_posix.cc
+++ b/shell/browser/electron_browser_main_parts_posix.cc
@@ -14,6 +14,7 @@
 #include <sys/resource.h>
 #include <unistd.h>
 
+#include "base/compiler_specific.h"
 #include "base/debug/leak_annotations.h"
 #include "base/posix/eintr_wrapper.h"
 #include "base/threading/platform_thread.h"

--- a/shell/browser/electron_permission_manager.h
+++ b/shell/browser/electron_permission_manager.h
@@ -11,7 +11,6 @@
 #include "base/containers/id_map.h"
 #include "base/functional/callback.h"
 #include "content/public/browser/permission_controller_delegate.h"
-#include "gin/dictionary.h"
 #include "shell/browser/electron_browser_context.h"
 #include "shell/common/gin_helper/dictionary.h"
 

--- a/shell/browser/electron_web_ui_controller_factory.cc
+++ b/shell/browser/electron_web_ui_controller_factory.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/electron_web_ui_controller_factory.h"
 
+#include "base/memory/singleton.h"
 #include "chrome/common/webui_url_constants.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_ui_controller.h"

--- a/shell/browser/electron_web_ui_controller_factory.cc
+++ b/shell/browser/electron_web_ui_controller_factory.cc
@@ -7,7 +7,6 @@
 #include "chrome/common/webui_url_constants.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_ui_controller.h"
-#include "electron/buildflags/buildflags.h"
 #include "shell/browser/ui/devtools_ui.h"
 #include "shell/browser/ui/webui/accessibility_ui.h"
 

--- a/shell/browser/extended_web_contents_observer.h
+++ b/shell/browser/extended_web_contents_observer.h
@@ -6,7 +6,6 @@
 #define ELECTRON_SHELL_BROWSER_EXTENDED_WEB_CONTENTS_OBSERVER_H_
 
 #include <string>
-#include <vector>
 
 #include "base/observer_list.h"
 #include "electron/shell/common/api/api.mojom.h"

--- a/shell/browser/extended_web_contents_observer.h
+++ b/shell/browser/extended_web_contents_observer.h
@@ -8,7 +8,10 @@
 #include <string>
 
 #include "electron/shell/common/api/api.mojom.h"
-#include "ui/gfx/geometry/rect.h"
+
+namespace gfx {
+class Rect;
+}
 
 namespace electron {
 

--- a/shell/browser/extended_web_contents_observer.h
+++ b/shell/browser/extended_web_contents_observer.h
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include "base/observer_list.h"
 #include "electron/shell/common/api/api.mojom.h"
 #include "ui/gfx/geometry/rect.h"
 

--- a/shell/browser/extensions/api/extension_action/extension_action_api.cc
+++ b/shell/browser/extensions/api/extension_action/extension_action_api.cc
@@ -11,7 +11,6 @@
 
 #include "base/functional/bind.h"
 #include "base/no_destructor.h"
-#include "base/observer_list.h"
 #include "extensions/browser/event_router.h"
 #include "extensions/browser/extension_prefs.h"
 #include "extensions/browser/extension_util.h"

--- a/shell/browser/extensions/api/extension_action/extension_action_api.h
+++ b/shell/browser/extensions/api/extension_action/extension_action_api.h
@@ -8,8 +8,6 @@
 #include <string>
 
 #include "base/memory/raw_ptr.h"
-#include "base/observer_list.h"
-#include "base/values.h"
 #include "extensions/browser/browser_context_keyed_api_factory.h"
 #include "extensions/browser/extension_action.h"
 #include "extensions/browser/extension_function.h"

--- a/shell/browser/extensions/api/management/electron_management_api_delegate.cc
+++ b/shell/browser/extensions/api/management/electron_management_api_delegate.cc
@@ -10,7 +10,6 @@
 #include <utility>
 
 #include "base/functional/bind.h"
-#include "base/strings/strcat.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "chrome/common/extensions/extension_metrics.h"

--- a/shell/browser/extensions/api/resources_private/resources_private_api.cc
+++ b/shell/browser/extensions/api/resources_private/resources_private_api.cc
@@ -14,7 +14,6 @@
 #include "components/strings/grit/components_strings.h"
 #include "components/zoom/page_zoom_constants.h"
 #include "electron/buildflags/buildflags.h"
-#include "printing/buildflags/buildflags.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/webui/web_ui_util.h"
 

--- a/shell/browser/extensions/api/scripting/scripting_api.cc
+++ b/shell/browser/extensions/api/scripting/scripting_api.cc
@@ -15,7 +15,6 @@
 #include "base/types/optional_util.h"
 #include "chrome/common/extensions/api/scripting.h"
 #include "content/public/browser/browser_task_traits.h"
-#include "content/public/browser/browser_thread.h"
 #include "content/public/browser/navigation_controller.h"
 #include "content/public/browser/navigation_entry.h"
 #include "extensions/browser/extension_api_frame_id_map.h"

--- a/shell/browser/extensions/electron_component_extension_resource_manager.cc
+++ b/shell/browser/extensions/electron_component_extension_resource_manager.cc
@@ -8,7 +8,6 @@
 #include <utility>
 
 #include "base/containers/contains.h"
-#include "base/logging.h"
 #include "base/path_service.h"
 #include "base/stl_util.h"
 #include "base/values.h"

--- a/shell/browser/extensions/electron_component_extension_resource_manager.cc
+++ b/shell/browser/extensions/electron_component_extension_resource_manager.cc
@@ -9,7 +9,6 @@
 
 #include "base/containers/contains.h"
 #include "base/path_service.h"
-#include "base/stl_util.h"
 #include "base/values.h"
 #include "build/build_config.h"
 #include "chrome/common/chrome_paths.h"

--- a/shell/browser/extensions/electron_extension_loader.h
+++ b/shell/browser/extensions/electron_extension_loader.h
@@ -10,7 +10,6 @@
 
 #include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
-#include "base/memory/ref_counted.h"
 #include "base/memory/weak_ptr.h"
 #include "extensions/browser/extension_registrar.h"
 #include "extensions/common/extension_id.h"

--- a/shell/browser/extensions/electron_extension_system.cc
+++ b/shell/browser/extensions/electron_extension_system.cc
@@ -10,7 +10,6 @@
 #include <utility>
 
 #include "base/files/file_path.h"
-#include "base/files/file_util.h"
 #include "base/functional/bind.h"
 #include "base/json/json_string_value_serializer.h"
 #include "base/path_service.h"
@@ -33,7 +32,6 @@
 #include "extensions/browser/service_worker_manager.h"
 #include "extensions/browser/user_script_manager.h"
 #include "extensions/common/constants.h"
-#include "extensions/common/file_util.h"
 #include "shell/browser/extensions/electron_extension_loader.h"
 
 #if BUILDFLAG(ENABLE_PDF_VIEWER)

--- a/shell/browser/extensions/electron_extension_system.h
+++ b/shell/browser/extensions/electron_extension_system.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <string>
 
-#include "base/compiler_specific.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/ref_counted.h"
 #include "base/memory/weak_ptr.h"

--- a/shell/browser/extensions/electron_extension_system.h
+++ b/shell/browser/extensions/electron_extension_system.h
@@ -9,7 +9,6 @@
 #include <string>
 
 #include "base/memory/raw_ptr.h"
-#include "base/memory/ref_counted.h"
 #include "base/memory/weak_ptr.h"
 #include "base/one_shot_event.h"
 #include "components/value_store/value_store_factory.h"

--- a/shell/browser/extensions/electron_extensions_browser_client.h
+++ b/shell/browser/extensions/electron_extensions_browser_client.h
@@ -9,7 +9,6 @@
 #include <string>
 #include <vector>
 
-#include "base/compiler_specific.h"
 #include "build/build_config.h"
 #include "extensions/browser/extensions_browser_client.h"
 #include "extensions/browser/kiosk/kiosk_delegate.h"

--- a/shell/browser/extensions/electron_messaging_delegate.cc
+++ b/shell/browser/extensions/electron_messaging_delegate.cc
@@ -8,7 +8,6 @@
 #include <utility>
 
 #include "base/functional/callback.h"
-#include "base/logging.h"
 #include "base/values.h"
 #include "build/build_config.h"
 #include "components/prefs/pref_service.h"

--- a/shell/browser/extensions/electron_process_manager_delegate.cc
+++ b/shell/browser/extensions/electron_process_manager_delegate.cc
@@ -6,7 +6,6 @@
 #include "shell/browser/extensions/electron_process_manager_delegate.h"
 
 #include "base/command_line.h"
-#include "base/logging.h"
 #include "base/one_shot_event.h"
 #include "build/build_config.h"
 #include "content/public/browser/notification_service.h"

--- a/shell/browser/extensions/electron_process_manager_delegate.h
+++ b/shell/browser/extensions/electron_process_manager_delegate.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_BROWSER_EXTENSIONS_ELECTRON_PROCESS_MANAGER_DELEGATE_H_
 #define ELECTRON_SHELL_BROWSER_EXTENSIONS_ELECTRON_PROCESS_MANAGER_DELEGATE_H_
 
-#include "base/compiler_specific.h"
 #include "content/public/browser/notification_observer.h"
 #include "content/public/browser/notification_registrar.h"
 #include "extensions/browser/process_manager_delegate.h"

--- a/shell/browser/file_select_helper.cc
+++ b/shell/browser/file_select_helper.cc
@@ -13,7 +13,6 @@
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"
 #include "base/memory/ptr_util.h"
-#include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/thread_pool.h"

--- a/shell/browser/file_select_helper.h
+++ b/shell/browser/file_select_helper.h
@@ -9,7 +9,6 @@
 #include <string>
 #include <vector>
 
-#include "base/compiler_specific.h"
 #include "base/memory/raw_ptr.h"
 #include "base/scoped_observation.h"
 #include "build/build_config.h"

--- a/shell/browser/file_select_helper.h
+++ b/shell/browser/file_select_helper.h
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
-#include "base/scoped_observation.h"
 #include "build/build_config.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/render_widget_host.h"

--- a/shell/browser/file_system_access/file_system_access_permission_context.cc
+++ b/shell/browser/file_system_access/file_system_access_permission_context.cc
@@ -13,7 +13,6 @@
 #include "base/path_service.h"
 #include "base/task/thread_pool.h"
 #include "base/time/time.h"
-#include "base/timer/timer.h"
 #include "base/values.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/file_system_access/chrome_file_system_access_permission_context.h"  // nogncheck

--- a/shell/browser/font_defaults.cc
+++ b/shell/browser/font_defaults.cc
@@ -8,7 +8,6 @@
 #include <string>
 #include <string_view>
 
-#include "base/stl_util.h"
 #include "base/strings/strcat.h"
 #include "base/strings/utf_string_conversions.h"
 #include "chrome/common/pref_names.h"

--- a/shell/browser/hid/electron_hid_delegate.cc
+++ b/shell/browser/hid/electron_hid_delegate.cc
@@ -7,7 +7,6 @@
 #include <string>
 #include <utility>
 
-#include "base/command_line.h"
 #include "base/containers/contains.h"
 #include "base/scoped_observation.h"
 #include "chrome/common/chrome_features.h"

--- a/shell/browser/hid/hid_chooser_context.cc
+++ b/shell/browser/hid/hid_chooser_context.cc
@@ -13,7 +13,6 @@
 #include "base/command_line.h"
 #include "base/containers/contains.h"
 #include "base/containers/map_util.h"
-#include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/values.h"

--- a/shell/browser/hid/hid_chooser_controller.cc
+++ b/shell/browser/hid/hid_chooser_controller.cc
@@ -21,7 +21,6 @@
 #include "shell/common/gin_converters/content_converter.h"
 #include "shell/common/gin_converters/hid_device_info_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
-#include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/process_util.h"
 #include "ui/base/l10n/l10n_util.h"

--- a/shell/browser/linux/unity_service.cc
+++ b/shell/browser/linux/unity_service.cc
@@ -9,7 +9,6 @@
 
 #include <string>
 
-#include "base/environment.h"
 #include "base/nix/xdg_util.h"
 
 // Unity data typedefs.

--- a/shell/browser/login_handler.h
+++ b/shell/browser/login_handler.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_BROWSER_LOGIN_HANDLER_H_
 #define ELECTRON_SHELL_BROWSER_LOGIN_HANDLER_H_
 
-#include "base/values.h"
 #include "content/public/browser/content_browser_client.h"
 #include "content/public/browser/login_delegate.h"
 #include "content/public/browser/web_contents_observer.h"

--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -11,7 +11,6 @@
 #include "base/allocator/partition_allocator/src/partition_alloc/shim/allocator_shim.h"
 #include "base/mac/mac_util.h"
 #include "base/strings/sys_string_conversions.h"
-#include "base/values.h"
 #include "shell/browser/api/electron_api_push_notifications.h"
 #include "shell/browser/browser.h"
 #include "shell/browser/mac/dict_util.h"

--- a/shell/browser/mac/in_app_purchase_observer.mm
+++ b/shell/browser/mac/in_app_purchase_observer.mm
@@ -7,7 +7,6 @@
 #include <vector>
 
 #include "base/functional/bind.h"
-#include "base/strings/sys_string_conversions.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 

--- a/shell/browser/microtasks_runner.cc
+++ b/shell/browser/microtasks_runner.cc
@@ -6,7 +6,6 @@
 #include "shell/browser/microtasks_runner.h"
 
 #include "shell/browser/electron_browser_main_parts.h"
-#include "shell/browser/javascript_environment.h"
 #include "shell/common/node_includes.h"
 #include "v8/include/v8.h"
 

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -44,7 +44,6 @@
 #include "third_party/webrtc/modules/desktop_capture/mac/window_list_utils.h"
 #include "ui/base/hit_test.h"
 #include "ui/display/screen.h"
-#include "ui/gfx/skia_util.h"
 #include "ui/gl/gpu_switching_manager.h"
 #include "ui/views/background.h"
 #include "ui/views/cocoa/native_widget_mac_ns_window_host.h"

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -23,7 +23,6 @@
 #include "base/containers/contains.h"
 #include "base/memory/raw_ref.h"
 #include "base/strings/utf_string_conversions.h"
-#include "content/public/browser/browser_thread.h"
 #include "content/public/browser/desktop_media_id.h"
 #include "content/public/common/color_parser.h"
 #include "shell/browser/api/electron_api_web_contents.h"

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -22,7 +22,6 @@
 
 #include "base/containers/contains.h"
 #include "base/memory/raw_ref.h"
-#include "base/stl_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/desktop_media_id.h"

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -21,7 +21,7 @@
 #include <vector>
 
 #include "base/containers/contains.h"
-#include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "base/stl_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "content/public/browser/browser_thread.h"

--- a/shell/browser/net/asar/asar_url_loader.cc
+++ b/shell/browser/net/asar/asar_url_loader.cc
@@ -10,7 +10,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/strings/stringprintf.h"
 #include "base/task/thread_pool.h"
 #include "content/public/browser/file_url_loader.h"
 #include "electron/fuses.h"

--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -34,6 +34,7 @@
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_converters/net_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
+#include "shell/common/gin_helper/dictionary.h"
 #include "third_party/blink/public/mojom/loader/resource_load_info.mojom-shared.h"
 
 #include "shell/common/node_includes.h"

--- a/shell/browser/net/electron_url_loader_factory.h
+++ b/shell/browser/net/electron_url_loader_factory.h
@@ -21,7 +21,15 @@
 #include "services/network/public/mojom/url_loader.mojom.h"
 #include "services/network/public/mojom/url_loader_factory.mojom.h"
 #include "services/network/public/mojom/url_response_head.mojom.h"
-#include "shell/common/gin_helper/dictionary.h"
+#include "v8/include/v8-array-buffer.h"
+
+namespace gin {
+class Arguments;
+}  // namespace gin
+
+namespace gin_helper {
+class Dictionary;
+}  // namespace gin_helper
 
 namespace electron {
 

--- a/shell/browser/net/network_context_service.h
+++ b/shell/browser/net/network_context_service.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_BROWSER_NET_NETWORK_CONTEXT_SERVICE_H_
 #define ELECTRON_SHELL_BROWSER_NET_NETWORK_CONTEXT_SERVICE_H_
 
-#include "base/files/file_path.h"
 #include "base/memory/raw_ptr.h"
 #include "chrome/browser/net/proxy_config_monitor.h"
 #include "components/keyed_service/core/keyed_service.h"
@@ -13,6 +12,10 @@
 #include "services/cert_verifier/public/mojom/cert_verifier_service_factory.mojom.h"
 #include "services/network/public/mojom/network_context.mojom.h"
 #include "shell/browser/electron_browser_context.h"
+
+namespace base {
+class FilePath;
+}  // namespace base
 
 namespace electron {
 

--- a/shell/browser/net/network_context_service_factory.h
+++ b/shell/browser/net/network_context_service_factory.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_BROWSER_NET_NETWORK_CONTEXT_SERVICE_FACTORY_H_
 #define ELECTRON_SHELL_BROWSER_NET_NETWORK_CONTEXT_SERVICE_FACTORY_H_
 
-#include "base/memory/singleton.h"
 #include "components/keyed_service/content/browser_context_keyed_service_factory.h"
 
 class KeyedService;

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -11,7 +11,6 @@
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "base/strings/string_split.h"
-#include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "content/public/browser/browser_context.h"
 #include "extensions/browser/extension_navigation_ui_data.h"

--- a/shell/browser/net/resolve_host_function.cc
+++ b/shell/browser/net/resolve_host_function.cc
@@ -7,7 +7,6 @@
 #include <utility>
 
 #include "base/functional/bind.h"
-#include "base/values.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/storage_partition.h"

--- a/shell/browser/net/system_network_context_manager.cc
+++ b/shell/browser/net/system_network_context_manager.cc
@@ -12,7 +12,6 @@
 #include "base/command_line.h"
 #include "base/memory/raw_ptr.h"
 #include "base/path_service.h"
-#include "base/strings/string_split.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/net/chrome_mojo_proxy_resolver_factory.h"
 #include "chrome/common/chrome_features.h"

--- a/shell/browser/net/system_network_context_manager.h
+++ b/shell/browser/net/system_network_context_manager.h
@@ -7,7 +7,6 @@
 
 #include <optional>
 
-#include "base/memory/ref_counted.h"
 #include "chrome/browser/net/proxy_config_monitor.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "sandbox/policy/features.h"

--- a/shell/browser/notifications/mac/cocoa_notification.mm
+++ b/shell/browser/notifications/mac/cocoa_notification.mm
@@ -10,7 +10,6 @@
 #include "base/logging.h"
 #include "base/mac/mac_util.h"
 #include "base/strings/sys_string_conversions.h"
-#include "base/strings/utf_string_conversions.h"
 #include "shell/browser/notifications/notification_delegate.h"
 #include "shell/browser/notifications/notification_presenter.h"
 #include "skia/ext/skia_utils_mac.h"

--- a/shell/browser/notifications/platform_notification_service.cc
+++ b/shell/browser/notifications/platform_notification_service.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/notifications/platform_notification_service.h"
 
-#include "base/strings/utf_string_conversions.h"
 #include "content/public/browser/notification_event_dispatcher.h"
 #include "content/public/browser/render_process_host.h"
 #include "shell/browser/electron_browser_client.h"

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -19,7 +19,6 @@
 #include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util_win.h"
-#include "base/strings/utf_string_conversions.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "shell/browser/notifications/notification_delegate.h"

--- a/shell/browser/osr/osr_host_display_client.cc
+++ b/shell/browser/osr/osr_host_display_client.cc
@@ -12,7 +12,6 @@
 #include "third_party/skia/include/core/SkColor.h"
 #include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/src/core/SkDevice.h"
-#include "ui/gfx/skia_util.h"
 
 #if BUILDFLAG(IS_WIN)
 #include "skia/ext/skia_utils_win.h"

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -41,7 +41,6 @@
 #include "ui/display/screen.h"
 #include "ui/events/base_event_utils.h"
 #include "ui/events/event_constants.h"
-#include "ui/gfx/canvas.h"
 #include "ui/gfx/geometry/dip_util.h"
 #include "ui/gfx/geometry/size_conversions.h"
 #include "ui/gfx/image/image_skia.h"

--- a/shell/browser/plugins/plugin_utils.cc
+++ b/shell/browser/plugins/plugin_utils.cc
@@ -7,7 +7,6 @@
 #include <vector>
 
 #include "base/containers/contains.h"
-#include "base/values.h"
 #include "content/public/common/webplugininfo.h"
 #include "electron/buildflags/buildflags.h"
 #include "url/gurl.h"

--- a/shell/browser/printing/print_view_manager_electron.h
+++ b/shell/browser/printing/print_view_manager_electron.h
@@ -8,7 +8,6 @@
 #include <string>
 #include <vector>
 
-#include "base/memory/raw_ptr.h"
 #include "base/memory/ref_counted_memory.h"
 #include "build/build_config.h"
 #include "chrome/browser/printing/print_view_manager_base.h"

--- a/shell/browser/relauncher.cc
+++ b/shell/browser/relauncher.cc
@@ -11,6 +11,7 @@
 #endif
 
 #include "base/files/file_util.h"
+#include "base/files/scoped_file.h"
 #include "base/logging.h"
 #include "base/path_service.h"
 #include "base/process/launch.h"

--- a/shell/browser/relauncher_linux.cc
+++ b/shell/browser/relauncher_linux.cc
@@ -9,9 +9,9 @@
 #include <sys/prctl.h>
 #include <sys/signalfd.h>
 
-#include "base/files/file_util.h"
 #include "base/files/scoped_file.h"
 #include "base/logging.h"
+#include "base/posix/eintr_wrapper.h"
 #include "base/process/launch.h"
 #include "base/synchronization/waitable_event.h"
 

--- a/shell/browser/relauncher_mac.cc
+++ b/shell/browser/relauncher_mac.cc
@@ -14,7 +14,6 @@
 #include "base/logging.h"
 #include "base/posix/eintr_wrapper.h"
 #include "base/process/launch.h"
-#include "base/strings/sys_string_conversions.h"
 
 namespace relauncher::internal {
 

--- a/shell/browser/relauncher_mac.cc
+++ b/shell/browser/relauncher_mac.cc
@@ -11,6 +11,7 @@
 
 #include "base/apple/osstatus_logging.h"
 #include "base/files/file_util.h"
+#include "base/files/scoped_file.h"
 #include "base/logging.h"
 #include "base/posix/eintr_wrapper.h"
 #include "base/process/launch.h"

--- a/shell/browser/relauncher_win.cc
+++ b/shell/browser/relauncher_win.cc
@@ -11,7 +11,6 @@
 #include "base/process/process_handle.h"
 #include "base/strings/strcat_win.h"
 #include "base/strings/string_number_conversions_win.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/win/scoped_handle.h"
 #include "sandbox/win/src/nt_internals.h"
 #include "sandbox/win/src/win_utils.h"

--- a/shell/browser/serial/electron_serial_delegate.h
+++ b/shell/browser/serial/electron_serial_delegate.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "base/memory/weak_ptr.h"
+#include "base/observer_list.h"
 #include "base/scoped_observation.h"
 #include "content/public/browser/serial_delegate.h"
 #include "shell/browser/serial/serial_chooser_context.h"

--- a/shell/browser/serial/serial_chooser_context.cc
+++ b/shell/browser/serial/serial_chooser_context.cc
@@ -9,7 +9,6 @@
 
 #include "base/base64.h"
 #include "base/containers/contains.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/values.h"
 #include "content/public/browser/device_service.h"
 #include "content/public/browser/web_contents.h"

--- a/shell/browser/serial/serial_chooser_controller.cc
+++ b/shell/browser/serial/serial_chooser_controller.cc
@@ -10,7 +10,6 @@
 #include "base/files/file_path.h"
 #include "base/functional/bind.h"
 #include "base/strings/stringprintf.h"
-#include "base/strings/utf_string_conversions.h"
 #include "device/bluetooth/public/cpp/bluetooth_uuid.h"
 #include "services/device/public/cpp/bluetooth/bluetooth_utils.h"
 #include "services/device/public/mojom/serial.mojom.h"

--- a/shell/browser/ui/accelerator_util.cc
+++ b/shell/browser/ui/accelerator_util.cc
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "base/logging.h"
-#include "base/stl_util.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "shell/common/keyboard_util.h"

--- a/shell/browser/ui/accelerator_util_unittests.cc
+++ b/shell/browser/ui/accelerator_util_unittests.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/ui/accelerator_util.h"
 
-#include "base/memory/raw_ref.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace accelerator_util {

--- a/shell/browser/ui/certificate_trust.h
+++ b/shell/browser/ui/certificate_trust.h
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include "base/memory/ref_counted.h"
 #include "net/cert/x509_certificate.h"
 #include "shell/common/gin_helper/promise.h"
 

--- a/shell/browser/ui/certificate_trust.h
+++ b/shell/browser/ui/certificate_trust.h
@@ -9,7 +9,6 @@
 
 #include "base/memory/ref_counted.h"
 #include "net/cert/x509_certificate.h"
-#include "shell/browser/javascript_environment.h"
 #include "shell/common/gin_helper/promise.h"
 
 namespace electron {

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -23,7 +23,6 @@
 #include "ui/base/l10n/l10n_util_mac.h"
 #include "ui/events/cocoa/cocoa_event_utils.h"
 #include "ui/events/keycodes/keyboard_code_conversion_mac.h"
-#include "ui/gfx/image/image.h"
 #include "ui/strings/grit/ui_strings.h"
 
 using content::BrowserThread;

--- a/shell/browser/ui/devtools_manager_delegate.cc
+++ b/shell/browser/ui/devtools_manager_delegate.cc
@@ -12,7 +12,6 @@
 #include "base/functional/bind.h"
 #include "base/path_service.h"
 #include "base/strings/string_number_conversions.h"
-#include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "chrome/common/chrome_paths.h"
 #include "content/public/browser/devtools_agent_host.h"

--- a/shell/browser/ui/devtools_manager_delegate.cc
+++ b/shell/browser/ui/devtools_manager_delegate.cc
@@ -12,7 +12,6 @@
 #include "base/functional/bind.h"
 #include "base/path_service.h"
 #include "base/strings/string_number_conversions.h"
-#include "base/strings/utf_string_conversions.h"
 #include "chrome/common/chrome_paths.h"
 #include "content/public/browser/devtools_agent_host.h"
 #include "content/public/browser/devtools_frontend_host.h"

--- a/shell/browser/ui/devtools_manager_delegate.h
+++ b/shell/browser/ui/devtools_manager_delegate.h
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include "base/compiler_specific.h"
 #include "content/public/browser/devtools_manager_delegate.h"
 
 namespace content {

--- a/shell/browser/ui/devtools_ui.cc
+++ b/shell/browser/ui/devtools_ui.cc
@@ -11,7 +11,6 @@
 #include "base/memory/ref_counted_memory.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
-#include "base/strings/stringprintf.h"
 #include "chrome/common/webui_url_constants.h"
 #include "content/public/browser/devtools_frontend_host.h"
 #include "content/public/browser/url_data_source.h"

--- a/shell/browser/ui/devtools_ui.h
+++ b/shell/browser/ui/devtools_ui.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_DEVTOOLS_UI_H_
 #define ELECTRON_SHELL_BROWSER_UI_DEVTOOLS_UI_H_
 
-#include "base/compiler_specific.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/web_ui_controller.h"
 

--- a/shell/browser/ui/electron_menu_model.cc
+++ b/shell/browser/ui/electron_menu_model.cc
@@ -6,8 +6,6 @@
 
 #include <utility>
 
-#include "base/stl_util.h"
-
 namespace electron {
 
 #if BUILDFLAG(IS_MAC)

--- a/shell/browser/ui/file_dialog_linux.cc
+++ b/shell/browser/ui/file_dialog_linux.cc
@@ -8,8 +8,6 @@
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
-#include "base/memory/raw_ptr.h"
-#include "base/memory/raw_ptr_exclusion.h"
 #include "base/run_loop.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"

--- a/shell/browser/ui/file_dialog_linux.cc
+++ b/shell/browser/ui/file_dialog_linux.cc
@@ -9,7 +9,6 @@
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/run_loop.h"
-#include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/browser/native_window_views.h"

--- a/shell/browser/ui/file_dialog_win.cc
+++ b/shell/browser/ui/file_dialog_win.cc
@@ -16,7 +16,6 @@
 
 #include "base/files/file_util.h"
 #include "base/i18n/case_conversion.h"
-#include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/win/registry.h"

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -27,7 +27,6 @@
 #include "components/prefs/scoped_user_pref_update.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_task_traits.h"
-#include "content/public/browser/browser_thread.h"
 #include "content/public/browser/file_select_listener.h"
 #include "content/public/browser/file_url_loader.h"
 #include "content/public/browser/host_zoom_map.h"

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -10,8 +10,6 @@
 #include <utility>
 
 #include "base/base64.h"
-#include "base/json/json_reader.h"
-#include "base/json/json_writer.h"
 #include "base/memory/raw_ptr.h"
 #include "base/metrics/histogram.h"
 #include "base/ranges/algorithm.h"

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -13,7 +13,6 @@
 #include "base/memory/raw_ptr.h"
 #include "base/metrics/histogram.h"
 #include "base/ranges/algorithm.h"
-#include "base/stl_util.h"
 #include "base/strings/pattern.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -19,6 +19,7 @@
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/timer/timer.h"
 #include "base/uuid.h"
 #include "base/values.h"
 #include "chrome/browser/devtools/devtools_contents_resizing_strategy.h"

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -12,7 +12,6 @@
 #include "base/base64.h"
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
-#include "base/json/string_escape.h"
 #include "base/memory/raw_ptr.h"
 #include "base/metrics/histogram.h"
 #include "base/ranges/algorithm.h"

--- a/shell/browser/ui/inspectable_web_contents_view.cc
+++ b/shell/browser/ui/inspectable_web_contents_view.cc
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "base/memory/raw_ptr.h"
-#include "base/strings/utf_string_conversions.h"
 #include "shell/browser/ui/drag_util.h"
 #include "shell/browser/ui/inspectable_web_contents.h"
 #include "shell/browser/ui/inspectable_web_contents_delegate.h"

--- a/shell/browser/ui/message_box_mac.mm
+++ b/shell/browser/ui/message_box_mac.mm
@@ -4,9 +4,7 @@
 
 #include "shell/browser/ui/message_box.h"
 
-#include <string>
 #include <utility>
-#include <vector>
 
 #import <Cocoa/Cocoa.h>
 

--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -17,7 +17,6 @@
 #include "shell/browser/ui/cocoa/electron_menu_controller.h"
 #include "ui/events/cocoa/cocoa_event_utils.h"
 #include "ui/gfx/mac/coordinate_conversion.h"
-#include "ui/native_theme/native_theme.h"
 
 @interface StatusItemView : NSView {
   raw_ptr<electron::TrayIconCocoa> trayIcon_;  // weak

--- a/shell/browser/ui/views/client_frame_view_linux.cc
+++ b/shell/browser/ui/views/client_frame_view_linux.cc
@@ -21,7 +21,6 @@
 #include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/geometry/skia_conversions.h"
-#include "ui/gfx/skia_util.h"
 #include "ui/gfx/text_constants.h"
 #include "ui/gtk/gtk_compat.h"  // nogncheck
 #include "ui/gtk/gtk_util.h"    // nogncheck

--- a/shell/browser/ui/views/electron_views_delegate.h
+++ b/shell/browser/ui/views/electron_views_delegate.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <string>
 
-#include "base/compiler_specific.h"
 #include "base/containers/flat_map.h"
 #include "ui/views/views_delegate.h"
 

--- a/shell/browser/ui/views/global_menu_bar_registrar_x11.cc
+++ b/shell/browser/ui/views/global_menu_bar_registrar_x11.cc
@@ -8,7 +8,6 @@
 
 #include "base/debug/leak_annotations.h"
 #include "base/functional/bind.h"
-#include "base/logging.h"
 #include "content/public/browser/browser_thread.h"
 #include "shell/browser/ui/views/global_menu_bar_x11.h"
 

--- a/shell/browser/ui/views/global_menu_bar_registrar_x11.cc
+++ b/shell/browser/ui/views/global_menu_bar_registrar_x11.cc
@@ -8,6 +8,7 @@
 
 #include "base/debug/leak_annotations.h"
 #include "base/functional/bind.h"
+#include "base/memory/singleton.h"
 #include "content/public/browser/browser_thread.h"
 #include "shell/browser/ui/views/global_menu_bar_x11.h"
 

--- a/shell/browser/ui/views/global_menu_bar_registrar_x11.h
+++ b/shell/browser/ui/views/global_menu_bar_registrar_x11.h
@@ -10,7 +10,6 @@
 #include <set>
 
 #include "base/memory/raw_ptr.h"
-#include "base/memory/ref_counted.h"
 #include "base/memory/singleton.h"
 #include "ui/base/glib/scoped_gsignal.h"
 #include "ui/gfx/x/xproto.h"

--- a/shell/browser/ui/views/global_menu_bar_x11.h
+++ b/shell/browser/ui/views/global_menu_bar_x11.h
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include "base/compiler_specific.h"
 #include "base/memory/raw_ptr.h"
 #include "shell/browser/ui/electron_menu_model.h"
 #include "ui/base/glib/scoped_gsignal.h"

--- a/shell/browser/ui/views/opaque_frame_view.h
+++ b/shell/browser/ui/views/opaque_frame_view.h
@@ -8,7 +8,6 @@
 #include <memory>
 
 #include "base/memory/raw_ptr.h"
-#include "base/scoped_observation.h"
 #include "chrome/browser/ui/view_ids.h"
 #include "shell/browser/ui/views/frameless_view.h"
 #include "ui/base/metadata/metadata_header_macros.h"

--- a/shell/browser/ui/views/root_view.h
+++ b/shell/browser/ui/views/root_view.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"
 #include "shell/browser/ui/accelerator_util.h"
 #include "ui/gfx/geometry/insets.h"

--- a/shell/browser/ui/views/submenu_button.cc
+++ b/shell/browser/ui/views/submenu_button.cc
@@ -5,7 +5,6 @@
 #include "shell/browser/ui/views/submenu_button.h"
 
 #include "base/strings/string_util.h"
-#include "base/strings/utf_string_conversions.h"
 #include "ui/accessibility/ax_enums.mojom.h"
 #include "ui/gfx/canvas.h"
 #include "ui/gfx/color_utils.h"

--- a/shell/browser/ui/views/win_caption_button.cc
+++ b/shell/browser/ui/views/win_caption_button.cc
@@ -17,6 +17,7 @@
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/base/theme_provider.h"
 #include "ui/gfx/animation/tween.h"
+#include "ui/gfx/canvas.h"
 #include "ui/gfx/color_utils.h"
 #include "ui/gfx/geometry/rect_conversions.h"
 #include "ui/gfx/scoped_canvas.h"

--- a/shell/browser/ui/views/win_caption_button.cc
+++ b/shell/browser/ui/views/win_caption_button.cc
@@ -18,7 +18,6 @@
 #include "ui/base/theme_provider.h"
 #include "ui/gfx/animation/tween.h"
 #include "ui/gfx/canvas.h"
-#include "ui/gfx/color_utils.h"
 #include "ui/gfx/geometry/rect_conversions.h"
 #include "ui/gfx/scoped_canvas.h"
 

--- a/shell/browser/ui/views/win_caption_button.h
+++ b/shell/browser/ui/views/win_caption_button.h
@@ -15,8 +15,11 @@
 #include "shell/browser/ui/views/win_icon_painter.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
-#include "ui/gfx/canvas.h"
 #include "ui/views/controls/button/button.h"
+
+namespace gfx {
+class Canvas;
+}
 
 namespace electron {
 

--- a/shell/browser/ui/views/win_icon_painter.cc
+++ b/shell/browser/ui/views/win_icon_painter.cc
@@ -6,6 +6,7 @@
 
 #include "base/numerics/safe_conversions.h"
 #include "third_party/skia/include/core/SkPath.h"
+#include "ui/gfx/canvas.h"
 #include "ui/gfx/color_utils.h"
 #include "ui/gfx/geometry/rect_conversions.h"
 #include "ui/gfx/geometry/rrect_f.h"

--- a/shell/browser/ui/views/win_icon_painter.cc
+++ b/shell/browser/ui/views/win_icon_painter.cc
@@ -7,7 +7,6 @@
 #include "base/numerics/safe_conversions.h"
 #include "third_party/skia/include/core/SkPath.h"
 #include "ui/gfx/canvas.h"
-#include "ui/gfx/color_utils.h"
 #include "ui/gfx/geometry/rect_conversions.h"
 #include "ui/gfx/geometry/rrect_f.h"
 #include "ui/gfx/geometry/skia_conversions.h"

--- a/shell/browser/ui/views/win_icon_painter.h
+++ b/shell/browser/ui/views/win_icon_painter.h
@@ -5,7 +5,9 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_VIEWS_WIN_ICON_PAINTER_H_
 #define ELECTRON_SHELL_BROWSER_UI_VIEWS_WIN_ICON_PAINTER_H_
 
-#include "ui/gfx/canvas.h"
+namespace gfx {
+class Canvas;
+}  // namespace gfx
 
 namespace electron {
 

--- a/shell/browser/ui/views/win_icon_painter.h
+++ b/shell/browser/ui/views/win_icon_painter.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_VIEWS_WIN_ICON_PAINTER_H_
 #define ELECTRON_SHELL_BROWSER_UI_VIEWS_WIN_ICON_PAINTER_H_
 
-#include "base/memory/raw_ptr.h"
 #include "ui/gfx/canvas.h"
 
 namespace electron {

--- a/shell/browser/ui/webui/accessibility_ui.cc
+++ b/shell/browser/ui/webui/accessibility_ui.cc
@@ -14,7 +14,6 @@
 #include "base/functional/callback_helpers.h"
 #include "base/json/json_writer.h"
 #include "base/strings/escape.h"
-#include "base/strings/pattern.h"
 #include "base/strings/string_split.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/values.h"

--- a/shell/browser/ui/webui/accessibility_ui.cc
+++ b/shell/browser/ui/webui/accessibility_ui.cc
@@ -15,6 +15,7 @@
 #include "base/json/json_writer.h"
 #include "base/strings/escape.h"
 #include "base/strings/pattern.h"
+#include "base/strings/string_split.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/values.h"
 #include "build/build_config.h"

--- a/shell/browser/ui/webui/accessibility_ui.cc
+++ b/shell/browser/ui/webui/accessibility_ui.cc
@@ -10,7 +10,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/command_line.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "base/json/json_writer.h"

--- a/shell/browser/ui/win/notify_icon.h
+++ b/shell/browser/ui/win/notify_icon.h
@@ -12,7 +12,6 @@
 #include <memory>
 #include <string>
 
-#include "base/compiler_specific.h"
 #include "base/memory/weak_ptr.h"
 #include "base/win/scoped_gdi_object.h"
 #include "shell/browser/ui/tray_icon.h"

--- a/shell/browser/ui/win/notify_icon_host.cc
+++ b/shell/browser/ui/win/notify_icon_host.cc
@@ -10,7 +10,6 @@
 #include "base/functional/bind.h"
 #include "base/logging.h"
 #include "base/memory/weak_ptr.h"
-#include "base/stl_util.h"
 #include "base/timer/timer.h"
 #include "base/win/win_util.h"
 #include "base/win/windows_types.h"

--- a/shell/browser/ui/win/taskbar_host.cc
+++ b/shell/browser/ui/win/taskbar_host.cc
@@ -7,7 +7,6 @@
 #include <objbase.h>
 #include <string>
 
-#include "base/stl_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/win/scoped_gdi_object.h"
 #include "shell/browser/native_window.h"

--- a/shell/browser/ui/win/taskbar_host.h
+++ b/shell/browser/ui/win/taskbar_host.h
@@ -14,8 +14,11 @@
 
 #include "base/functional/callback.h"
 #include "shell/browser/native_window.h"
-#include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/image/image.h"
+
+namespace gfx {
+class Rect;
+}  // namespace gfx
 
 namespace electron {
 

--- a/shell/browser/usb/usb_chooser_context.cc
+++ b/shell/browser/usb/usb_chooser_context.cc
@@ -11,7 +11,6 @@
 #include "base/functional/bind.h"
 #include "base/observer_list.h"
 #include "base/strings/string_util.h"
-#include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/values.h"

--- a/shell/browser/usb/usb_chooser_context.cc
+++ b/shell/browser/usb/usb_chooser_context.cc
@@ -11,7 +11,6 @@
 #include "base/functional/bind.h"
 #include "base/observer_list.h"
 #include "base/strings/string_util.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/values.h"
 #include "build/build_config.h"

--- a/shell/browser/usb/usb_chooser_context.cc
+++ b/shell/browser/usb/usb_chooser_context.cc
@@ -9,7 +9,6 @@
 
 #include "base/containers/contains.h"
 #include "base/functional/bind.h"
-#include "base/strings/string_util.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/values.h"
 #include "build/build_config.h"

--- a/shell/browser/usb/usb_chooser_context.cc
+++ b/shell/browser/usb/usb_chooser_context.cc
@@ -9,7 +9,6 @@
 
 #include "base/containers/contains.h"
 #include "base/functional/bind.h"
-#include "base/observer_list.h"
 #include "base/strings/string_util.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/values.h"

--- a/shell/browser/usb/usb_chooser_controller.cc
+++ b/shell/browser/usb/usb_chooser_controller.cc
@@ -9,7 +9,6 @@
 
 #include "base/functional/bind.h"
 #include "base/ranges/algorithm.h"
-#include "base/strings/utf_string_conversions.h"
 #include "build/build_config.h"
 #include "components/strings/grit/components_strings.h"
 #include "content/public/browser/render_frame_host.h"

--- a/shell/browser/usb/usb_chooser_controller.cc
+++ b/shell/browser/usb/usb_chooser_controller.cc
@@ -9,7 +9,6 @@
 
 #include "base/functional/bind.h"
 #include "base/ranges/algorithm.h"
-#include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "build/build_config.h"
 #include "components/strings/grit/components_strings.h"

--- a/shell/browser/usb/usb_chooser_controller.h
+++ b/shell/browser/usb/usb_chooser_controller.h
@@ -7,7 +7,6 @@
 
 #include <vector>
 
-#include "base/memory/raw_ptr.h"
 #include "base/memory/ref_counted.h"
 #include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"

--- a/shell/browser/usb/usb_chooser_controller.h
+++ b/shell/browser/usb/usb_chooser_controller.h
@@ -7,7 +7,6 @@
 
 #include <vector>
 
-#include "base/memory/ref_counted.h"
 #include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"
 #include "content/public/browser/web_contents.h"

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -13,7 +13,6 @@
 #include "base/command_line.h"
 #include "base/containers/fixed_flat_map.h"
 #include "base/memory/ptr_util.h"
-#include "base/strings/utf_string_conversions.h"
 #include "cc/base/switches.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_process_host.h"

--- a/shell/browser/win/dark_mode.h
+++ b/shell/browser/win/dark_mode.h
@@ -13,8 +13,6 @@
 #undef WIN32_LEAN_AND_MEAN
 #endif
 
-#include "ui/native_theme/native_theme.h"
-
 namespace electron::win {
 
 bool IsDarkModeSupported();

--- a/shell/browser/zoom_level_delegate.cc
+++ b/shell/browser/zoom_level_delegate.cc
@@ -16,7 +16,6 @@
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service_factory.h"
 #include "components/prefs/scoped_user_pref_update.h"
-#include "content/public/browser/browser_thread.h"
 #include "third_party/blink/public/common/page/page_zoom.h"
 
 namespace electron {

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -13,7 +13,6 @@
 #include "base/logging.h"
 #include "base/memory/ref_counted_memory.h"
 #include "base/strings/pattern.h"
-#include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "gin/arguments.h"
 #include "gin/object_template_builder.h"

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -17,7 +17,6 @@
 #include "gin/arguments.h"
 #include "gin/object_template_builder.h"
 #include "gin/per_isolate_data.h"
-#include "gin/wrappable.h"
 #include "net/base/data_url.h"
 #include "shell/browser/browser.h"
 #include "shell/common/asar/asar_util.h"

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "base/containers/contains.h"
-#include "base/logging.h"
 #include "base/process/process.h"
 #include "base/process/process_handle.h"
 #include "base/system/sys_info.h"

--- a/shell/common/api/electron_bindings.h
+++ b/shell/common/api/electron_bindings.h
@@ -8,12 +8,15 @@
 #include <list>
 #include <memory>
 
-#include "base/files/file_path.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/process/process_metrics.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/node_bindings.h"
 #include "uv.h"  // NOLINT(build/include_directory)
+
+namespace base {
+class FilePath;
+}
 
 namespace gin_helper {
 class Arguments;

--- a/shell/common/application_info_linux.cc
+++ b/shell/common/application_info_linux.cc
@@ -9,7 +9,6 @@
 
 #include <string>
 
-#include "base/environment.h"
 #include "base/logging.h"
 #include "electron/electron_version.h"
 #include "shell/common/platform_util.h"

--- a/shell/common/application_info_win.cc
+++ b/shell/common/application_info_win.cc
@@ -16,7 +16,6 @@
 #include "base/notreached.h"
 #include "base/strings/string_util.h"
 #include "base/strings/string_util_win.h"
-#include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "shell/browser/win/scoped_hstring.h"
 

--- a/shell/common/asar/archive_mac.mm
+++ b/shell/common/asar/archive_mac.mm
@@ -15,7 +15,6 @@
 #include "base/apple/foundation_util.h"
 #include "base/apple/scoped_cftyperef.h"
 #include "base/files/file_util.h"
-#include "base/logging.h"
 #include "base/strings/sys_string_conversions.h"
 #include "shell/common/asar/asar_util.h"
 

--- a/shell/common/asar/asar_util.cc
+++ b/shell/common/asar/asar_util.cc
@@ -12,7 +12,6 @@
 #include "base/files/file_util.h"
 #include "base/logging.h"
 #include "base/no_destructor.h"
-#include "base/stl_util.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/synchronization/lock.h"

--- a/shell/common/asar/scoped_temporary_file.cc
+++ b/shell/common/asar/scoped_temporary_file.cc
@@ -7,7 +7,6 @@
 #include <vector>
 
 #include "base/files/file_util.h"
-#include "base/logging.h"
 #include "shell/common/asar/asar_util.h"
 #include "shell/common/thread_restrictions.h"
 

--- a/shell/common/color_util.cc
+++ b/shell/common/color_util.cc
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <vector>
 
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"

--- a/shell/common/color_util.cc
+++ b/shell/common/color_util.cc
@@ -10,7 +10,6 @@
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "content/public/common/color_parser.h"
-#include "ui/gfx/color_utils.h"
 
 namespace {
 

--- a/shell/common/crash_keys.cc
+++ b/shell/common/crash_keys.cc
@@ -12,7 +12,6 @@
 #include "base/command_line.h"
 #include "base/environment.h"
 #include "base/no_destructor.h"
-#include "base/strings/string_split.h"
 #include "base/strings/stringprintf.h"
 #include "components/crash/core/common/crash_key.h"
 #include "content/public/common/content_switches.h"

--- a/shell/common/extensions/electron_extensions_api_provider.cc
+++ b/shell/common/extensions/electron_extensions_api_provider.cc
@@ -8,7 +8,6 @@
 #include <string>
 
 #include "base/containers/span.h"
-#include "base/strings/utf_string_conversions.h"
 #include "chrome/common/extensions/chrome_manifest_url_handlers.h"
 #include "chrome/common/extensions/manifest_handlers/minimum_chrome_version_checker.h"
 #include "electron/buildflags/buildflags.h"

--- a/shell/common/extensions/electron_extensions_client.h
+++ b/shell/common/extensions/electron_extensions_client.h
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include "base/compiler_specific.h"
 #include "extensions/common/extensions_client.h"
 #include "url/gurl.h"
 

--- a/shell/common/gin_converters/media_converter.cc
+++ b/shell/common/gin_converters/media_converter.cc
@@ -9,7 +9,6 @@
 #include "gin/data_object_builder.h"
 #include "shell/common/gin_converters/frame_converter.h"
 #include "shell/common/gin_converters/gurl_converter.h"
-#include "shell/common/gin_helper/dictionary.h"
 #include "third_party/blink/public/mojom/mediastream/media_stream.mojom.h"
 
 namespace gin {

--- a/shell/common/gin_helper/callback.h
+++ b/shell/common/gin_helper/callback.h
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "base/functional/bind.h"
-#include "gin/dictionary.h"
 #include "shell/common/gin_converters/std_converter.h"
 #include "shell/common/gin_helper/function_template.h"
 #include "shell/common/gin_helper/locker.h"

--- a/shell/common/gin_helper/constructible.h
+++ b/shell/common/gin_helper/constructible.h
@@ -6,7 +6,6 @@
 #define ELECTRON_SHELL_COMMON_GIN_HELPER_CONSTRUCTIBLE_H_
 
 #include "gin/per_isolate_data.h"
-#include "gin/wrappable.h"
 #include "shell/common/gin_helper/event_emitter_template.h"
 #include "shell/common/gin_helper/function_template_extensions.h"
 

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -7,7 +7,6 @@
 
 #include <string_view>
 #include <utility>
-#include <vector>
 
 #include "electron/shell/common/api/api.mojom.h"
 #include "gin/handle.h"
@@ -26,7 +25,6 @@ template <typename T>
 class EventEmitter : public gin_helper::Wrappable<T> {
  public:
   using Base = gin_helper::Wrappable<T>;
-  using ValueArray = std::vector<v8::Local<v8::Value>>;
 
   // Make the convenient methods visible:
   // https://isocpp.org/wiki/faq/templates#nondependent-name-lookup-members

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include "content/public/browser/browser_thread.h"
 #include "electron/shell/common/api/api.mojom.h"
 #include "gin/handle.h"
 #include "shell/common/gin_helper/event.h"

--- a/shell/common/gin_helper/function_template.cc
+++ b/shell/common/gin_helper/function_template.cc
@@ -4,7 +4,6 @@
 
 #include "shell/common/gin_helper/function_template.h"
 
-#include "base/observer_list.h"
 #include "base/strings/strcat.h"
 
 namespace gin_helper {

--- a/shell/common/mac/main_application_bundle.mm
+++ b/shell/common/mac/main_application_bundle.mm
@@ -9,7 +9,6 @@
 #include "base/apple/foundation_util.h"
 #include "base/files/file_path.h"
 #include "base/path_service.h"
-#include "base/strings/string_util.h"
 #include "content/browser/mac_helpers.h"
 
 namespace electron {

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -21,7 +21,6 @@
 #include "base/task/single_thread_task_runner.h"
 #include "base/trace_event/trace_event.h"
 #include "chrome/common/chrome_version.h"
-#include "content/public/browser/browser_thread.h"
 #include "content/public/common/content_paths.h"
 #include "electron/buildflags/buildflags.h"
 #include "electron/electron_version.h"

--- a/shell/common/node_bindings_linux.h
+++ b/shell/common/node_bindings_linux.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_COMMON_NODE_BINDINGS_LINUX_H_
 #define ELECTRON_SHELL_COMMON_NODE_BINDINGS_LINUX_H_
 
-#include "base/compiler_specific.h"
 #include "shell/common/node_bindings.h"
 
 namespace electron {

--- a/shell/common/node_bindings_mac.h
+++ b/shell/common/node_bindings_mac.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_COMMON_NODE_BINDINGS_MAC_H_
 #define ELECTRON_SHELL_COMMON_NODE_BINDINGS_MAC_H_
 
-#include "base/compiler_specific.h"
 #include "shell/common/node_bindings.h"
 
 namespace electron {

--- a/shell/common/node_bindings_win.h
+++ b/shell/common/node_bindings_win.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_COMMON_NODE_BINDINGS_WIN_H_
 #define ELECTRON_SHELL_COMMON_NODE_BINDINGS_WIN_H_
 
-#include "base/compiler_specific.h"
 #include "shell/common/node_bindings.h"
 
 namespace electron {

--- a/shell/common/platform_util.cc
+++ b/shell/common/platform_util.cc
@@ -9,7 +9,6 @@
 #include "base/functional/bind.h"
 #include "base/task/thread_pool.h"
 #include "content/public/browser/browser_task_traits.h"
-#include "content/public/browser/browser_thread.h"
 #include "shell/common/platform_util_internal.h"
 
 namespace platform_util {

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -15,6 +15,7 @@
 #include "base/containers/contains.h"
 #include "base/environment.h"
 #include "base/files/file_util.h"
+#include "base/files/scoped_file.h"
 #include "base/logging.h"
 #include "base/memory/raw_ptr.h"
 #include "base/nix/xdg_util.h"

--- a/shell/common/platform_util_mac.mm
+++ b/shell/common/platform_util_mac.mm
@@ -19,7 +19,6 @@
 #include "base/functional/callback.h"
 #include "base/logging.h"
 #include "base/mac/scoped_aedesc.h"
-#include "base/strings/stringprintf.h"
 #include "base/strings/sys_string_conversions.h"
 #include "base/task/thread_pool.h"
 #include "content/public/browser/browser_task_traits.h"

--- a/shell/common/platform_util_mac.mm
+++ b/shell/common/platform_util_mac.mm
@@ -22,7 +22,6 @@
 #include "base/strings/sys_string_conversions.h"
 #include "base/task/thread_pool.h"
 #include "content/public/browser/browser_task_traits.h"
-#include "content/public/browser/browser_thread.h"
 #include "net/base/apple/url_conversions.h"
 #include "ui/views/widget/widget.h"
 #include "url/gurl.h"

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -22,7 +22,6 @@
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "base/logging.h"
-#include "base/stl_util.h"
 #include "base/strings/escape.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -23,7 +23,6 @@
 #include "base/functional/callback_helpers.h"
 #include "base/logging.h"
 #include "base/strings/escape.h"
-#include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/thread_pool.h"
 #include "base/threading/scoped_blocking_call.h"

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -13,7 +13,6 @@
 
 #include "base/containers/contains.h"
 #include "base/feature_list.h"
-#include "base/no_destructor.h"
 #include "base/trace_event/trace_event.h"
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_frame_observer.h"

--- a/shell/renderer/api/electron_api_ipc_renderer.cc
+++ b/shell/renderer/api/electron_api_ipc_renderer.cc
@@ -4,7 +4,6 @@
 
 #include <string>
 
-#include "base/values.h"
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_frame_observer.h"
 #include "gin/dictionary.h"

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/command_line.h"
 #include "base/memory/memory_pressure_listener.h"
 #include "base/strings/utf_string_conversions.h"
 #include "components/spellcheck/renderer/spellcheck.h"

--- a/shell/renderer/content_settings_observer.cc
+++ b/shell/renderer/content_settings_observer.cc
@@ -4,7 +4,6 @@
 
 #include "shell/renderer/content_settings_observer.h"
 
-#include "base/command_line.h"
 #include "content/public/renderer/render_frame.h"
 #include "shell/common/options_switches.h"
 #include "third_party/blink/public/common/web_preferences/web_preferences.h"

--- a/shell/renderer/content_settings_observer.h
+++ b/shell/renderer/content_settings_observer.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_RENDERER_CONTENT_SETTINGS_OBSERVER_H_
 #define ELECTRON_SHELL_RENDERER_CONTENT_SETTINGS_OBSERVER_H_
 
-#include "base/compiler_specific.h"
 #include "content/public/renderer/render_frame_observer.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
 

--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/environment.h"
 #include "base/trace_event/trace_event.h"
 #include "gin/data_object_builder.h"
 #include "mojo/public/cpp/system/platform_handle.h"

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -10,7 +10,6 @@
 #include "base/memory/weak_ptr.h"
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_frame_observer.h"
-#include "electron/buildflags/buildflags.h"
 #include "electron/shell/common/api/api.mojom.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/receiver.h"

--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -11,7 +11,6 @@
 #include "base/memory/ref_counted_memory.h"
 #include "base/trace_event/trace_event.h"
 #include "content/public/renderer/render_frame.h"
-#include "electron/buildflags/buildflags.h"
 #include "electron/shell/common/api/api.mojom.h"
 #include "ipc/ipc_message_macros.h"
 #include "net/base/net_module.h"

--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -5,7 +5,6 @@
 #include "shell/renderer/electron_render_frame_observer.h"
 
 #include <utility>
-#include <vector>
 
 #include "base/command_line.h"
 #include "base/memory/ref_counted_memory.h"

--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -6,7 +6,6 @@
 
 #include <utility>
 
-#include "base/command_line.h"
 #include "base/memory/ref_counted_memory.h"
 #include "base/trace_event/trace_event.h"
 #include "content/public/renderer/render_frame.h"

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -8,7 +8,6 @@
 #include "base/containers/contains.h"
 #include "base/debug/stack_trace.h"
 #include "content/public/renderer/render_frame.h"
-#include "electron/buildflags/buildflags.h"
 #include "net/http/http_request_headers.h"
 #include "shell/common/api/electron_bindings.h"
 #include "shell/common/gin_helper/dictionary.h"

--- a/shell/renderer/electron_renderer_pepper_host_factory.cc
+++ b/shell/renderer/electron_renderer_pepper_host_factory.cc
@@ -7,7 +7,6 @@
 #include <memory>
 #include <string>
 
-#include "base/logging.h"
 #include "content/public/renderer/renderer_ppapi_host.h"
 #include "ppapi/host/dispatch_host_message.h"
 #include "ppapi/host/ppapi_host.h"

--- a/shell/renderer/electron_renderer_pepper_host_factory.h
+++ b/shell/renderer/electron_renderer_pepper_host_factory.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "base/compiler_specific.h"
 #include "base/memory/raw_ptr.h"
 #include "ppapi/host/host_factory.h"
 

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -16,7 +16,6 @@
 #include "base/process/process_handle.h"
 #include "base/process/process_metrics.h"
 #include "content/public/renderer/render_frame.h"
-#include "electron/buildflags/buildflags.h"
 #include "shell/common/api/electron_bindings.h"
 #include "shell/common/application_info.h"
 #include "shell/common/gin_helper/dictionary.h"

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -12,7 +12,6 @@
 #include "base/command_line.h"
 #include "base/containers/contains.h"
 #include "base/files/file_path.h"
-#include "base/path_service.h"
 #include "base/process/process_handle.h"
 #include "base/process/process_metrics.h"
 #include "content/public/renderer/render_frame.h"

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -11,7 +11,6 @@
 #include "base/base_paths.h"
 #include "base/command_line.h"
 #include "base/containers/contains.h"
-#include "base/files/file_path.h"
 #include "base/process/process_handle.h"
 #include "base/process/process_metrics.h"
 #include "content/public/renderer/render_frame.h"

--- a/shell/renderer/pepper_helper.h
+++ b/shell/renderer/pepper_helper.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_RENDERER_PEPPER_HELPER_H_
 #define ELECTRON_SHELL_RENDERER_PEPPER_HELPER_H_
 
-#include "base/compiler_specific.h"
 #include "base/component_export.h"
 #include "content/public/renderer/render_frame_observer.h"
 

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -12,7 +12,6 @@
 #include "electron/buildflags/buildflags.h"
 #include "media/base/key_systems_support_registration.h"
 #include "printing/buildflags/buildflags.h"
-#include "shell/common/gin_helper/dictionary.h"
 // In SHARED_INTERMEDIATE_DIR.
 #include "widevine_cdm_version.h"  // NOLINT(build/include_directory)
 
@@ -29,6 +28,10 @@ class SpellCheck;
 
 namespace blink {
 class WebLocalFrame;
+}
+
+namespace gin_helper {
+class Dictionary;
 }
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)

--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -4,7 +4,6 @@
 
 #include "shell/renderer/web_worker_observer.h"
 
-#include <set>
 #include <utility>
 
 #include "base/no_destructor.h"

--- a/shell/utility/electron_content_utility_client.cc
+++ b/shell/utility/electron_content_utility_client.cc
@@ -10,6 +10,7 @@
 #include "base/no_destructor.h"
 #include "content/public/utility/utility_thread.h"
 #include "mojo/public/cpp/bindings/service_factory.h"
+#include "printing/buildflags/buildflags.h"
 #include "sandbox/policy/mojom/sandbox.mojom.h"
 #include "sandbox/policy/sandbox_type.h"
 #include "services/proxy_resolver/proxy_resolver_factory_impl.h"

--- a/shell/utility/electron_content_utility_client.cc
+++ b/shell/utility/electron_content_utility_client.cc
@@ -9,6 +9,7 @@
 #include "base/command_line.h"
 #include "base/no_destructor.h"
 #include "content/public/utility/utility_thread.h"
+#include "mojo/public/cpp/bindings/binder_map.h"
 #include "mojo/public/cpp/bindings/service_factory.h"
 #include "printing/buildflags/buildflags.h"
 #include "sandbox/policy/mojom/sandbox.mojom.h"

--- a/shell/utility/electron_content_utility_client.h
+++ b/shell/utility/electron_content_utility_client.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_UTILITY_ELECTRON_CONTENT_UTILITY_CLIENT_H_
 #define ELECTRON_SHELL_UTILITY_ELECTRON_CONTENT_UTILITY_CLIENT_H_
 
-#include "base/compiler_specific.h"
 #include "content/public/utility/content_utility_client.h"
 #include "mojo/public/cpp/bindings/binder_map.h"
 

--- a/shell/utility/electron_content_utility_client.h
+++ b/shell/utility/electron_content_utility_client.h
@@ -6,11 +6,11 @@
 #define ELECTRON_SHELL_UTILITY_ELECTRON_CONTENT_UTILITY_CLIENT_H_
 
 #include "content/public/utility/content_utility_client.h"
-#include "mojo/public/cpp/bindings/binder_map.h"
 
 namespace mojo {
+class BinderMap;
 class ServiceFactory;
-}
+}  // namespace mojo
 
 namespace electron {
 

--- a/shell/utility/electron_content_utility_client.h
+++ b/shell/utility/electron_content_utility_client.h
@@ -8,7 +8,6 @@
 #include "base/compiler_specific.h"
 #include "content/public/utility/content_utility_client.h"
 #include "mojo/public/cpp/bindings/binder_map.h"
-#include "printing/buildflags/buildflags.h"
 
 namespace mojo {
 class ServiceFactory;


### PR DESCRIPTION
#### Description of Change

Remove some `#include` calls that aren't used by the caller.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.