### PR TITLE
chore: remove unused WrappableBase::AfterInit()

### DIFF
--- a/shell/common/gin_helper/wrappable.cc
+++ b/shell/common/gin_helper/wrappable.cc
@@ -56,8 +56,6 @@ void WrappableBase::InitWith(v8::Isolate* isolate,
   v8::Local<v8::Function> init;
   if (Dictionary(isolate, wrapper).Get("_init", &init))
     init->Call(isolate->GetCurrentContext(), wrapper, 0, nullptr).IsEmpty();
-
-  AfterInit(isolate);
 }
 
 // static

--- a/shell/common/gin_helper/wrappable_base.h
+++ b/shell/common/gin_helper/wrappable_base.h
@@ -45,9 +45,6 @@ class WrappableBase {
   v8::Isolate* isolate() const { return isolate_; }
 
  protected:
-  // Called after the "_init" method gets called in JavaScript.
-  virtual void AfterInit(v8::Isolate* isolate) {}
-
   // Bind the C++ class to the JS wrapper.
   // This method should only be called by classes using Constructor.
   virtual void InitWith(v8::Isolate* isolate, v8::Local<v8::Object> wrapper);


### PR DESCRIPTION
#### Description of Change

last caller removed in 6159066c (#22916)

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.