### PR TITLE
refactor: migrate to CLIENT_OWNS_WIDGET

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -234,7 +234,7 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   // Create views::Widget and assign window_ with it.
   // TODO(zcbenz): Get rid of the window_ in future.
   views::Widget::InitParams params(
-      views::Widget::InitParams::WIDGET_OWNS_NATIVE_WIDGET,
+      views::Widget::InitParams::CLIENT_OWNS_WIDGET,
       views::Widget::InitParams::TYPE_WINDOW);
   params.bounds = bounds;
   params.delegate = this;

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -274,8 +274,8 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
   widget()->AddObserver(this);
 
   using InitParams = views::Widget::InitParams;
-  auto params = InitParams{InitParams::WIDGET_OWNS_NATIVE_WIDGET,
-                           InitParams::TYPE_WINDOW};
+  auto params =
+      InitParams{InitParams::CLIENT_OWNS_WIDGET, InitParams::TYPE_WINDOW};
   params.bounds = bounds;
   params.delegate = this;
   params.remove_standard_frame = !has_frame() || has_client_frame();

--- a/shell/browser/ui/inspectable_web_contents_view.cc
+++ b/shell/browser/ui/inspectable_web_contents_view.cc
@@ -171,7 +171,7 @@ void InspectableWebContentsView::SetIsDocked(bool docked, bool activate) {
         this, devtools_window_web_view_, devtools_window_.get());
 
     views::Widget::InitParams params{
-        views::Widget::InitParams::WIDGET_OWNS_NATIVE_WIDGET};
+        views::Widget::InitParams::CLIENT_OWNS_WIDGET};
     params.delegate = devtools_window_delegate_;
     params.bounds = inspectable_web_contents()->dev_tools_bounds();
 


### PR DESCRIPTION
#### Description of Change

`WIDGET_OWNS_NATIVE_WIDGET` is deprecated; `CLIENT_OWNS_WIDGET` is its safe replacement.

- https://chromium-review.googlesource.com/c/chromium/src/+/5577858 (deprecation)
- https://chromium-review.googlesource.com/c/chromium/src/+/3976182 (background)
- https://chromium-review.googlesource.com/c/chromium/src/+/3982903 (background)

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.