### PR TITLE
fix: use treeless clone instead of shallow clone of depot_tools

### DIFF
--- a/.github/workflows/pipeline-electron-lint.yml
+++ b/.github/workflows/pipeline-electron-lint.yml
@@ -32,7 +32,7 @@ jobs:
       shell: bash
       run: |
         # "depot_tools" has to be checkout into "//third_party/depot_tools" so pylint.py can a "pylintrc" file.
-        git clone --filter=tree:0 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+        git clone --filter=tree:0 https://chromium.googlesource.com/chromium/tools/depot_tools.git src/third_party/depot_tools
         echo "$(pwd)/src/third_party/depot_tools" >> $GITHUB_PATH
     - name: Download GN Binary
       shell: bash

--- a/.github/workflows/pipeline-electron-lint.yml
+++ b/.github/workflows/pipeline-electron-lint.yml
@@ -32,7 +32,7 @@ jobs:
       shell: bash
       run: |
         # "depot_tools" has to be checkout into "//third_party/depot_tools" so pylint.py can a "pylintrc" file.
-        git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git src/third_party/depot_tools
+        git clone --filter=tree:0 https://chromium.googlesource.com/chromium/tools/depot_tools.git
         echo "$(pwd)/src/third_party/depot_tools" >> $GITHUB_PATH
     - name: Download GN Binary
       shell: bash

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -114,7 +114,7 @@ jobs:
     - name: Get Depot Tools
       timeout-minutes: 5
       run: |
-        git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+        git clone --filter=tree:0 https://chromium.googlesource.com/chromium/tools/depot_tools.git
 
         SEDOPTION="-i"
         if [ "`uname`" = "Darwin" ]; then

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Get Depot Tools
       timeout-minutes: 5
       run: |
-        git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+        git clone --filter=tree:0 https://chromium.googlesource.com/chromium/tools/depot_tools.git
 
         SEDOPTION="-i"
         if [ "`uname`" = "Darwin" ]; then

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -104,17 +104,16 @@ jobs:
       timeout-minutes: 5
       run: |
         git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
-        if [ "`uname`" = "Darwin" ]; then
-          # remove ninjalog_uploader_wrapper.py from autoninja since we don't use it and it causes problems
-          sed -i '' '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
-        else
-          sed -i '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
-          # Remove swift-format dep from cipd on macOS until we send a patch upstream.
-          cd depot_tools
-          git apply --3way ../src/electron/.github/workflows/config/gclient.diff
-        fi
         # Ensure depot_tools does not update.
         test -d depot_tools && cd depot_tools
+        if [ "`uname`" = "Darwin" ]; then
+          # remove ninjalog_uploader_wrapper.py from autoninja since we don't use it and it causes problems
+          sed -i '' '/ninjalog_uploader_wrapper.py/d' ./autoninja
+        else
+          sed -i '/ninjalog_uploader_wrapper.py/d' ./autoninja
+          # Remove swift-format dep from cipd on macOS until we send a patch upstream.
+          git apply --3way ../src/electron/.github/workflows/config/gclient.diff
+        fi
         touch .disable_auto_update
     - name: Add Depot Tools to PATH
       run: echo "$(pwd)/depot_tools" >> $GITHUB_PATH

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Get Depot Tools
       timeout-minutes: 5
       run: |
-        git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+        git clone --filter=tree:0 https://chromium.googlesource.com/chromium/tools/depot_tools.git
         # Ensure depot_tools does not update.
         test -d depot_tools && cd depot_tools
         if [ "`uname`" = "Darwin" ]; then

--- a/.github/workflows/pipeline-segment-node-nan-test.yml
+++ b/.github/workflows/pipeline-segment-node-nan-test.yml
@@ -63,10 +63,9 @@ jobs:
       run: |
         git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
         sed -i '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
-        cd depot_tools
-        git apply --3way ../src/electron/.github/workflows/config/gclient.diff
         # Ensure depot_tools does not update.
         test -d depot_tools && cd depot_tools
+        git apply --3way ../src/electron/.github/workflows/config/gclient.diff
         touch .disable_auto_update
     - name: Add Depot Tools to PATH
       run: echo "$(pwd)/depot_tools" >> $GITHUB_PATH
@@ -127,10 +126,9 @@ jobs:
       run: |
         git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
         sed -i '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
-        cd depot_tools
-        git apply --3way ../src/electron/.github/workflows/config/gclient.diff
         # Ensure depot_tools does not update.
         test -d depot_tools && cd depot_tools
+        git apply --3way ../src/electron/.github/workflows/config/gclient.diff
         touch .disable_auto_update
     - name: Add Depot Tools to PATH
       run: echo "$(pwd)/depot_tools" >> $GITHUB_PATH

--- a/.github/workflows/pipeline-segment-node-nan-test.yml
+++ b/.github/workflows/pipeline-segment-node-nan-test.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Get Depot Tools
       timeout-minutes: 5
       run: |
-        git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+        git clone --filter=tree:0 https://chromium.googlesource.com/chromium/tools/depot_tools.git
         sed -i '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
         # Ensure depot_tools does not update.
         test -d depot_tools && cd depot_tools
@@ -124,7 +124,7 @@ jobs:
     - name: Get Depot Tools
       timeout-minutes: 5
       run: |
-        git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+        git clone --filter=tree:0 https://chromium.googlesource.com/chromium/tools/depot_tools.git
         sed -i '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
         # Ensure depot_tools does not update.
         test -d depot_tools && cd depot_tools


### PR DESCRIPTION
#### Description of Change

Try to fix a "lacks the necessary blob to perform a 3-way merge" error [in the Chromium roll](https://github.com/electron/electron/actions/runs/10023951256/job/27705423005?pr=42779) in #42779:

```
2024-07-20T23:59:10.2695797Z ^[[36;1mgit clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git^[[0m
2024-07-20T23:59:10.2696459Z ^[[36;1m^[[0m
2024-07-20T23:59:10.2696897Z ^[[36;1msed -i '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja^[[0m
2024-07-20T23:59:10.2697683Z ^[[36;1m# Remove swift-format dep from cipd on macOS until we send a patch upstream.^[[0m
2024-07-20T23:59:10.2698289Z ^[[36;1mcd depot_tools^[[0m
2024-07-20T23:59:10.2698800Z ^[[36;1mgit apply --3way ../src/electron/.github/workflows/config/gclient.diff^[[0m
2024-07-20T23:59:10.2699566Z ^[[36;1m^[[0m
2024-07-20T23:59:10.2699897Z ^[[36;1m# Ensure depot_tools does not update.^[[0m
2024-07-20T23:59:10.2700364Z ^[[36;1mtest -d depot_tools && cd depot_tools^[[0m
2024-07-20T23:59:10.2700799Z ^[[36;1mtouch .disable_auto_update^[[0m
2024-07-20T23:59:10.2701305Z shell: bash --noprofile --norc -e -o pipefail {0}
2024-07-20T23:59:10.2701703Z env:
2024-07-20T23:59:10.2702165Z   GCLIENT_EXTRA_ARGS: --custom-var=checkout_arm=True --custom-var=checkout_arm64=True
2024-07-20T23:59:10.2702822Z   GIT_CACHE_PATH: /__w/electron/electron/git-cache
2024-07-20T23:59:10.2703436Z ##[endgroup]
2024-07-20T23:59:10.3103122Z Cloning into 'depot_tools'...
2024-07-20T23:59:10.6905621Z error: repository lacks the necessary blob to perform 3-way merge.
2024-07-20T23:59:10.6906275Z Falling back to direct application...
2024-07-20T23:59:10.7175098Z ##[group]Run echo "$(pwd)/depot_tools" >> $GITHUB_PATH
2024-07-20T23:59:10.7175542Z ^[[36;1mecho "$(pwd)/depot_tools" >> $GITHUB_PATH^[[0m
```

https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/ ; the tldr is that treeless clones are good for use cases like this where you want a short-term lightweight checkout but need the repo's commit history.

CC @electron/wg-infra in general, but @VerteDinde and @codebytere  in particular who look like they'll be up-to-speed with this part of the scripts via #42500, #42484

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.