### PR TITLE
refactor: remove WindowListObserver::OnWindowAdded()

### DIFF
--- a/shell/browser/window_list.cc
+++ b/shell/browser/window_list.cc
@@ -51,18 +51,12 @@ void WindowList::AddWindow(NativeWindow* window) {
   // Push |window| on the appropriate list instance.
   WindowVector& windows = GetInstance()->windows_;
   windows.push_back(window);
-
-  for (WindowListObserver& observer : GetObservers())
-    observer.OnWindowAdded(window);
 }
 
 // static
 void WindowList::RemoveWindow(NativeWindow* window) {
   WindowVector& windows = GetInstance()->windows_;
   std::erase(windows, window);
-
-  for (WindowListObserver& observer : GetObservers())
-    observer.OnWindowRemoved(window);
 
   if (windows.empty()) {
     for (WindowListObserver& observer : GetObservers())

--- a/shell/browser/window_list_observer.h
+++ b/shell/browser/window_list_observer.h
@@ -13,12 +13,6 @@ class NativeWindow;
 
 class WindowListObserver : public base::CheckedObserver {
  public:
-  // Called immediately after a window is added to the list.
-  virtual void OnWindowAdded(NativeWindow* window) {}
-
-  // Called immediately after a window is removed from the list.
-  virtual void OnWindowRemoved(NativeWindow* window) {}
-
   // Called when a window close is cancelled by beforeunload handler.
   virtual void OnWindowCloseCancelled(NativeWindow* window) {}
 


### PR DESCRIPTION
#### Description of Change

Remove `WindowListObserver::OnWindowAdded()` and `WindowListObserver::OnWindowRemoved()` because they haven't been used in literally a decade. :hourglass: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.