### PR TITLE
fix: crash when iterating all windows

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -121,6 +121,11 @@ BaseWindow::BaseWindow(gin_helper::Arguments* args,
 BaseWindow::~BaseWindow() {
   CloseImmediately();
 
+  // Destroy the native window in next tick because the native code might be
+  // iterating all windows.
+  base::SingleThreadTaskRunner::GetCurrentDefault()->DeleteSoon(
+      FROM_HERE, window_.release());
+
   // Remove global reference so the JS object can be garbage collected.
   self_ref_.Reset();
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42975.
Refs https://github.com/electron/electron/pull/41326.

It's still possible that native code might be iterating all windows when the BaseWindow destructor is called, leading to a crash. We still need to have this `window_.release()` call delayed to the next tick to handle this.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash when calling `BrowserWindow.destroy()`