### PR TITLE
docs: note macOS fullscreen events in fullscreen query

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -690,6 +690,8 @@ Sets whether the window should be in fullscreen mode.
 
 Returns `boolean` - Whether the window is in fullscreen mode.
 
+**Note:** On macOS, fullscreen transitions take place asynchronously. When querying for a BrowserWindow's fullscreen status, you should ensure that either the ['enter-full-screen'](browser-window.md#event-enter-full-screen) or ['leave-full-screen'](browser-window.md#event-leave-full-screen) events have been emitted.
+
 #### `win.setSimpleFullScreen(flag)` _macOS_
 
 * `flag` boolean


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/35360.

Improves docs to make clearer conditions where `win.isFullScreen()` might return an unexpected value on macOS.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
