### PR TITLE
chore: use v8::Local<>, not v8::Handle<>

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -50,7 +50,7 @@ namespace gin {
 template <>
 struct Converter<electron::TaskbarHost::ThumbarButton> {
   static bool FromV8(v8::Isolate* isolate,
-                     v8::Handle<v8::Value> val,
+                     v8::Local<v8::Value> val,
                      electron::TaskbarHost::ThumbarButton* out) {
     gin::Dictionary dict(isolate);
     if (!gin::ConvertFromV8(isolate, val, &dict))

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -47,7 +47,7 @@ namespace gin {
 template <>
 struct Converter<electron::NativeWindow::TitleBarStyle> {
   static bool FromV8(v8::Isolate* isolate,
-                     v8::Handle<v8::Value> val,
+                     v8::Local<v8::Value> val,
                      electron::NativeWindow::TitleBarStyle* out) {
     using TitleBarStyle = electron::NativeWindow::TitleBarStyle;
     std::string title_bar_style;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -93,7 +93,7 @@ namespace gin {
 template <>
 struct Converter<electron::NativeWindowMac::VisualEffectState> {
   static bool FromV8(v8::Isolate* isolate,
-                     v8::Handle<v8::Value> val,
+                     v8::Local<v8::Value> val,
                      electron::NativeWindowMac::VisualEffectState* out) {
     using VisualEffectState = electron::NativeWindowMac::VisualEffectState;
     std::string visual_effect_state;

--- a/shell/common/api/electron_api_shell.cc
+++ b/shell/common/api/electron_api_shell.cc
@@ -24,7 +24,7 @@ namespace gin {
 template <>
 struct Converter<base::win::ShortcutOperation> {
   static bool FromV8(v8::Isolate* isolate,
-                     v8::Handle<v8::Value> val,
+                     v8::Local<v8::Value> val,
                      base::win::ShortcutOperation* out) {
     std::string operation;
     if (!ConvertFromV8(isolate, val, &operation))

--- a/shell/common/gin_converters/blink_converter.cc
+++ b/shell/common/gin_converters/blink_converter.cc
@@ -51,7 +51,7 @@ namespace gin {
 template <>
 struct Converter<char16_t> {
   static bool FromV8(v8::Isolate* isolate,
-                     v8::Handle<v8::Value> val,
+                     v8::Local<v8::Value> val,
                      char16_t* out) {
     std::u16string code = base::UTF8ToUTF16(gin::V8ToString(isolate, val));
     if (code.length() != 1)
@@ -108,7 +108,7 @@ struct Converter<char16_t> {
 
 bool Converter<blink::WebInputEvent::Type>::FromV8(
     v8::Isolate* isolate,
-    v8::Handle<v8::Value> val,
+    v8::Local<v8::Value> val,
     blink::WebInputEvent::Type* out) {
   std::string type = gin::V8ToString(isolate, val);
 #define CASE_TYPE(event_type, js_name)                   \
@@ -134,7 +134,7 @@ v8::Local<v8::Value> Converter<blink::WebInputEvent::Type>::ToV8(
 template <>
 struct Converter<blink::WebMouseEvent::Button> {
   static bool FromV8(v8::Isolate* isolate,
-                     v8::Handle<v8::Value> val,
+                     v8::Local<v8::Value> val,
                      blink::WebMouseEvent::Button* out) {
     using Val = blink::WebMouseEvent::Button;
     static constexpr auto Lookup =
@@ -193,7 +193,7 @@ static constexpr auto ReferrerPolicies =
 template <>
 struct Converter<blink::WebInputEvent::Modifiers> {
   static bool FromV8(v8::Isolate* isolate,
-                     v8::Handle<v8::Value> val,
+                     v8::Local<v8::Value> val,
                      blink::WebInputEvent::Modifiers* out) {
     return FromV8WithLowerLookup(isolate, val, Modifiers, out) ||
            FromV8WithLowerLookup(isolate, val, ModifierAliases, out);
@@ -661,7 +661,7 @@ v8::Local<v8::Value> Converter<network::mojom::ReferrerPolicy>::ToV8(
 // static
 bool Converter<network::mojom::ReferrerPolicy>::FromV8(
     v8::Isolate* isolate,
-    v8::Handle<v8::Value> val,
+    v8::Local<v8::Value> val,
     network::mojom::ReferrerPolicy* out) {
   return FromV8WithLowerLookup(isolate, val, ReferrerPolicies, out);
 }
@@ -700,7 +700,7 @@ v8::Local<v8::Value> Converter<blink::CloneableMessage>::ToV8(
 }
 
 bool Converter<blink::CloneableMessage>::FromV8(v8::Isolate* isolate,
-                                                v8::Handle<v8::Value> val,
+                                                v8::Local<v8::Value> val,
                                                 blink::CloneableMessage* out) {
   return electron::SerializeV8Value(isolate, val, out);
 }

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -577,7 +577,7 @@ void NodeBindings::Initialize(v8::Local<v8::Context> context) {
 }
 
 std::shared_ptr<node::Environment> NodeBindings::CreateEnvironment(
-    v8::Handle<v8::Context> context,
+    v8::Local<v8::Context> context,
     node::MultiIsolatePlatform* platform,
     std::vector<std::string> args,
     std::vector<std::string> exec_args,
@@ -779,7 +779,7 @@ std::shared_ptr<node::Environment> NodeBindings::CreateEnvironment(
 }
 
 std::shared_ptr<node::Environment> NodeBindings::CreateEnvironment(
-    v8::Handle<v8::Context> context,
+    v8::Local<v8::Context> context,
     node::MultiIsolatePlatform* platform,
     std::optional<base::RepeatingCallback<void()>> on_app_code_ready) {
 #if BUILDFLAG(IS_WIN)

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -93,7 +93,7 @@ class NodeBindings {
 
   // Create the environment and load node.js.
   std::shared_ptr<node::Environment> CreateEnvironment(
-      v8::Handle<v8::Context> context,
+      v8::Local<v8::Context> context,
       node::MultiIsolatePlatform* platform,
       std::vector<std::string> args,
       std::vector<std::string> exec_args,
@@ -101,7 +101,7 @@ class NodeBindings {
           std::nullopt);
 
   std::shared_ptr<node::Environment> CreateEnvironment(
-      v8::Handle<v8::Context> context,
+      v8::Local<v8::Context> context,
       node::MultiIsolatePlatform* platform,
       std::optional<base::RepeatingCallback<void()>> on_app_code_ready =
           std::nullopt);

--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -78,7 +78,7 @@ void ElectronRenderFrameObserver::DidClearWindowObject() {
       !web_frame->IsOnInitialEmptyDocument()) {
     v8::Isolate* isolate = web_frame->GetAgentGroupScheduler()->Isolate();
     v8::HandleScope handle_scope{isolate};
-    v8::Handle<v8::Context> context = web_frame->MainWorldScriptContext();
+    v8::Local<v8::Context> context = web_frame->MainWorldScriptContext();
     v8::MicrotasksScope microtasks_scope(
         isolate, context->GetMicrotaskQueue(),
         v8::MicrotasksScope::kDoNotRunMicrotasks);
@@ -91,7 +91,7 @@ void ElectronRenderFrameObserver::DidClearWindowObject() {
 }
 
 void ElectronRenderFrameObserver::DidInstallConditionalFeatures(
-    v8::Handle<v8::Context> context,
+    v8::Local<v8::Context> context,
     int world_id) {
   // When a child window is created with window.open, its WebPreferences will
   // be copied from its parent, and Chromium will initialize JS context in it

--- a/shell/renderer/electron_render_frame_observer.h
+++ b/shell/renderer/electron_render_frame_observer.h
@@ -29,7 +29,7 @@ class ElectronRenderFrameObserver : private content::RenderFrameObserver {
  private:
   // content::RenderFrameObserver:
   void DidClearWindowObject() override;
-  void DidInstallConditionalFeatures(v8::Handle<v8::Context> context,
+  void DidInstallConditionalFeatures(v8::Local<v8::Context> context,
                                      int world_id) override;
   void WillReleaseScriptContext(v8::Local<v8::Context> context,
                                 int world_id) override;

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -71,7 +71,7 @@ void ElectronRendererClient::UndeferLoad(content::RenderFrame* render_frame) {
 }
 
 void ElectronRendererClient::DidCreateScriptContext(
-    v8::Handle<v8::Context> renderer_context,
+    v8::Local<v8::Context> renderer_context,
     content::RenderFrame* render_frame) {
   // TODO(zcbenz): Do not create Node environment if node integration is not
   // enabled.
@@ -157,7 +157,7 @@ void ElectronRendererClient::DidCreateScriptContext(
 }
 
 void ElectronRendererClient::WillReleaseScriptContext(
-    v8::Handle<v8::Context> context,
+    v8::Local<v8::Context> context,
     content::RenderFrame* render_frame) {
   if (injected_frames_.erase(render_frame) == 0)
     return;

--- a/shell/renderer/electron_renderer_client.h
+++ b/shell/renderer/electron_renderer_client.h
@@ -29,9 +29,9 @@ class ElectronRendererClient : public RendererClientBase {
   ElectronRendererClient& operator=(const ElectronRendererClient&) = delete;
 
   // electron::RendererClientBase:
-  void DidCreateScriptContext(v8::Handle<v8::Context> context,
+  void DidCreateScriptContext(v8::Local<v8::Context> context,
                               content::RenderFrame* render_frame) override;
-  void WillReleaseScriptContext(v8::Handle<v8::Context> context,
+  void WillReleaseScriptContext(v8::Local<v8::Context> context,
                                 content::RenderFrame* render_frame) override;
 
  private:

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -95,7 +95,7 @@ double Uptime() {
       .InSecondsF();
 }
 
-void InvokeEmitProcessEvent(v8::Handle<v8::Context> context,
+void InvokeEmitProcessEvent(v8::Local<v8::Context> context,
                             const std::string& event_name) {
   auto* isolate = context->GetIsolate();
   // set by sandboxed_renderer/init.js
@@ -167,7 +167,7 @@ void ElectronSandboxedRendererClient::RunScriptsAtDocumentEnd(
 }
 
 void ElectronSandboxedRendererClient::DidCreateScriptContext(
-    v8::Handle<v8::Context> context,
+    v8::Local<v8::Context> context,
     content::RenderFrame* render_frame) {
   // Only allow preload for the main frame or
   // For devtools we still want to run the preload_bundle script
@@ -198,7 +198,7 @@ void ElectronSandboxedRendererClient::DidCreateScriptContext(
 }
 
 void ElectronSandboxedRendererClient::WillReleaseScriptContext(
-    v8::Handle<v8::Context> context,
+    v8::Local<v8::Context> context,
     content::RenderFrame* render_frame) {
   if (injected_frames_.erase(render_frame) == 0)
     return;

--- a/shell/renderer/electron_sandboxed_renderer_client.h
+++ b/shell/renderer/electron_sandboxed_renderer_client.h
@@ -34,9 +34,9 @@ class ElectronSandboxedRendererClient : public RendererClientBase {
                           v8::Local<v8::Context> context,
                           content::RenderFrame* render_frame);
   // electron::RendererClientBase:
-  void DidCreateScriptContext(v8::Handle<v8::Context> context,
+  void DidCreateScriptContext(v8::Local<v8::Context> context,
                               content::RenderFrame* render_frame) override;
-  void WillReleaseScriptContext(v8::Handle<v8::Context> context,
+  void WillReleaseScriptContext(v8::Local<v8::Context> context,
                                 content::RenderFrame* render_frame) override;
   // content::ContentRendererClient:
   void RenderFrameCreated(content::RenderFrame*) override;

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -214,7 +214,7 @@ void RendererClientBase::BindProcess(v8::Isolate* isolate,
 }
 
 bool RendererClientBase::ShouldLoadPreload(
-    v8::Handle<v8::Context> context,
+    v8::Local<v8::Context> context,
     content::RenderFrame* render_frame) const {
   auto prefs = render_frame->GetBlinkPreferences();
   bool is_main_frame = render_frame->IsMainFrame();
@@ -580,7 +580,7 @@ extensions::ExtensionsClient* RendererClientBase::CreateExtensionsClient() {
 #endif
 
 bool RendererClientBase::IsWebViewFrame(
-    v8::Handle<v8::Context> context,
+    v8::Local<v8::Context> context,
     content::RenderFrame* render_frame) const {
   auto* isolate = context->GetIsolate();
 
@@ -601,7 +601,7 @@ bool RendererClientBase::IsWebViewFrame(
 }
 
 void RendererClientBase::SetupMainWorldOverrides(
-    v8::Handle<v8::Context> context,
+    v8::Local<v8::Context> context,
     content::RenderFrame* render_frame) {
   auto prefs = render_frame->GetBlinkPreferences();
   // We only need to run the isolated bundle if webview is enabled

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -64,12 +64,12 @@ class RendererClientBase : public content::ContentRendererClient
                     mojo::ScopedMessagePipeHandle interface_pipe) override;
 #endif
 
-  virtual void DidCreateScriptContext(v8::Handle<v8::Context> context,
+  virtual void DidCreateScriptContext(v8::Local<v8::Context> context,
                                       content::RenderFrame* render_frame) = 0;
-  virtual void WillReleaseScriptContext(v8::Handle<v8::Context> context,
+  virtual void WillReleaseScriptContext(v8::Local<v8::Context> context,
                                         content::RenderFrame* render_frame) = 0;
   virtual void DidClearWindowObject(content::RenderFrame* render_frame);
-  virtual void SetupMainWorldOverrides(v8::Handle<v8::Context> context,
+  virtual void SetupMainWorldOverrides(v8::Local<v8::Context> context,
                                        content::RenderFrame* render_frame);
 
   std::unique_ptr<blink::WebPrescientNetworking> CreatePrescientNetworking(
@@ -84,7 +84,7 @@ class RendererClientBase : public content::ContentRendererClient
       v8::Local<v8::Object> context,
       v8::Local<v8::Function> register_cb);
 
-  bool IsWebViewFrame(v8::Handle<v8::Context> context,
+  bool IsWebViewFrame(v8::Local<v8::Context> context,
                       content::RenderFrame* render_frame) const;
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
@@ -96,7 +96,7 @@ class RendererClientBase : public content::ContentRendererClient
                    gin_helper::Dictionary* process,
                    content::RenderFrame* render_frame);
 
-  bool ShouldLoadPreload(v8::Handle<v8::Context> context,
+  bool ShouldLoadPreload(v8::Local<v8::Context> context,
                          content::RenderFrame* render_frame) const;
 
   // content::ContentRendererClient:


### PR DESCRIPTION
#### Description of Change

We should be using `v8::Local` rather than `v8::Handle`. They mean the same thing and the latter is kept around "for historical reasons." It's disabled when `V8_IMMINENT_DEPRECATION_WARNING` is defined (i.e. `V8_DEPRECATE_SOON`).

It's been in this  "imminent deprecation" state for years so it's probably not breaking tomorrow, but that's no reason to keep using the outdated naming...

https://source.chromium.org/chromium/chromium/src/+/main:v8/include/v8-local-handle.h;l=603;drc=c0265133106c7647e90f9aaa4377d28190b1a6a9

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.