### PR TITLE
feat: Tolerate multiple calls to `registerSchemesAsPrivileged`

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -62,7 +62,7 @@ The `protocol` module has the following methods:
 * `customSchemes` [CustomScheme[]](structures/custom-scheme.md)
 
 **Note:** This method can only be used before the `ready` event of the `app`
-module gets emitted and can be called only once.
+module gets emitted.
 
 Registers the `scheme` as standard, secure, bypasses content security policy for
 resources, allows registering ServiceWorker, supports fetch API, streaming

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -168,8 +168,12 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
       return;
     // Add the schemes to command line switches, so child processes can also
     // register them.
+    auto existing = base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(switch_name)
+    auto combined = base::SplitString(existing, ",",  base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+    std::copy(std::begin(schemes), std::end(schemes), std::back_inserter(combined));
+    
     base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
-        switch_name, base::JoinString(schemes, ","));
+        switch_name, base::JoinString(combined, ","));
   };
 
   AppendSchemesToCmdLine(electron::switches::kSecureSchemes, secure_schemes);

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -168,7 +168,7 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
       return;
     // Add the schemes to command line switches, so child processes can also
     // register them.
-    auto existing = base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(switch_name)
+    auto existing = base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(switch_name);
     auto combined = base::SplitString(existing, ",",  base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
     std::copy(std::begin(schemes), std::end(schemes), std::back_inserter(combined));
     

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -168,10 +168,13 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
       return;
     // Add the schemes to command line switches, so child processes can also
     // register them.
-    auto existing = base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(switch_name);
-    auto combined = base::SplitString(existing, ",",  base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
-    std::copy(std::begin(schemes), std::end(schemes), std::back_inserter(combined));
-    
+    auto existing = base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(
+        switch_name);
+    auto combined = base::SplitString(existing, ",", base::TRIM_WHITESPACE,
+                                      base::SPLIT_WANT_NONEMPTY);
+    std::copy(std::begin(schemes), std::end(schemes),
+              std::back_inserter(combined));
+
     base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
         switch_name, base::JoinString(combined, ","));
   };

--- a/spec/index.js
+++ b/spec/index.js
@@ -46,7 +46,9 @@ protocol.registerSchemesAsPrivileged([
   { scheme: 'no-cors', privileges: { supportFetchAPI: true } },
   { scheme: 'no-fetch', privileges: { corsEnabled: true } },
   { scheme: 'stream', privileges: { standard: true, stream: true } },
-  { scheme: 'foo', privileges: { standard: true } },
+  { scheme: 'foo', privileges: { standard: true } }
+]);
+protocol.registerSchemesAsPrivileged([
   { scheme: 'bar', privileges: { standard: true } }
 ]);
 


### PR DESCRIPTION
#### Description of Change

Previously, calls to `registerSchemesAsPrivileged` would add a new command line flag for newly added schemes. One call might add `--fetch-schemes=aaa,bbb` and the next call replaces it with `--fetch-schemes=ccc,ddd`. After this PR, these will be coalesced into `--fetch-schemas=aaa,bbb,ccc,ddd`. 

Fixes #40362 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: `protocol.registerSchemesAsPrivileged` changed to be cumulative instead of last-call-wins.