### PR TITLE
chore: avoid crash while notification removal

### DIFF
--- a/shell/browser/notifications/notification.cc
+++ b/shell/browser/notifications/notification.cc
@@ -46,7 +46,9 @@ void Notification::NotificationFailed(const std::string& error) {
 void Notification::Remove() {}
 
 void Notification::Destroy() {
-  presenter()->RemoveNotification(this);
+  if (presenter()) {
+    presenter()->RemoveNotification(this);
+  }
 }
 
 }  // namespace electron

--- a/shell/browser/notifications/notification_presenter.cc
+++ b/shell/browser/notifications/notification_presenter.cc
@@ -27,6 +27,11 @@ base::WeakPtr<Notification> NotificationPresenter::CreateNotification(
 }
 
 void NotificationPresenter::RemoveNotification(Notification* notification) {
+  auto it = notifications_.find(notification);
+  if (it == notifications_.end()) {
+    return;
+  }
+
   notifications_.erase(notification);
   delete notification;
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/43055

Recently, it was discovered that a crash occurs when erasing a notification point object in the ```electron::NotificationPresenter::RemoveNotification```.

Here, it should be checked and additional protection should be added to avoid it.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes:  Fixes a potential crash when removing notifications on Windows