### PR TITLE
fix: always terminate active Node Streams

### DIFF
--- a/shell/browser/net/node_stream_loader.h
+++ b/shell/browser/net/node_stream_loader.h
@@ -47,6 +47,8 @@ class NodeStreamLoader : public network::mojom::URLLoader {
   using EventCallback = base::RepeatingCallback<void()>;
 
   void Start(network::mojom::URLResponseHeadPtr head);
+  void NotifyEnd();
+  void NotifyError();
   void NotifyReadable();
   void NotifyComplete(int result);
   void ReadMore();
@@ -86,8 +88,12 @@ class NodeStreamLoader : public network::mojom::URLLoader {
 
   // When NotifyComplete is called while writing, we will save the result and
   // quit with it after the write is done.
-  bool ended_ = false;
+  bool pending_result_ = false;
   int result_ = net::OK;
+
+  // Set to `true` when we get either `end` or `error` event on the stream.
+  // If `false` - we call `stream.destroy()` to finalize the stream.
+  bool destroyed_ = false;
 
   // When the stream emits the readable event, we only want to start reading
   // data if the stream was not readable before, so we store the state in a


### PR DESCRIPTION
#### Description of Change

`.destroy()` is an important method in the lifecycle of a Node.js Readable stream. It is typically called to reclaim the resources (e.g., close file descriptor). The only situations where calling it manually isn't necessary are when the following events are emitted first:

- `end`: natural end of a stream
- `error`: stream terminated due to a failure

Prior to this commit the ended state was incorrectly tracked together with a pending internal error. It led to situations where the request could get aborted during a read and then get marked as ended (having pending error).

With this change we disentangle pending "error" and "destroyed" cases to always properly terminate an active Node.js Readable stream.

cc @MarshallOfSound @VerteDinde 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed the resource leak when using Node.js readable streams as the response body for a custom protocol handler.