### PR TITLE
fix: vibrant view is inserted into Views API hierarchy

### DIFF
--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "electron/shell/common/api/api.mojom.h"
 #include "shell/browser/native_window.h"
 #include "third_party/skia/include/core/SkRegion.h"
@@ -299,6 +300,9 @@ class NativeWindowMac : public NativeWindow,
   NSRect default_frame_for_zoom_;
 
   std::string vibrancy_type_;
+
+  // A views::NativeViewHost wrapping the vibrant view. Owned by the root view.
+  raw_ptr<views::NativeViewHost> vibrant_native_view_host_ = nullptr;
 
   // The presentation options before entering simple fullscreen mode.
   NSApplicationPresentationOptions simple_fullscreen_options_;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1392,13 +1392,19 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
   NativeWindow::SetVibrancy(type);
 
   NSVisualEffectView* vibrantView = [window_ vibrantView];
+  views::View* rootView = GetContentsView();
 
   if (type.empty()) {
-    if (vibrantView == nil)
-      return;
+    if (vibrant_native_view_host_ != nullptr) {
+      // Transfers ownership back to caller in the form of a unique_ptr which is
+      // subsequently deleted.
+      rootView->RemoveChildViewT(vibrant_native_view_host_);
+      vibrant_native_view_host_ = nullptr;
+    }
 
-    [vibrantView removeFromSuperview];
-    [window_ setVibrantView:nil];
+    if (vibrantView != nil) {
+      [window_ setVibrantView:nil];
+    }
 
     return;
   }
@@ -1454,9 +1460,13 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
         [vibrantView setState:NSVisualEffectStateFollowsWindowActiveState];
       }
 
-      [[window_ contentView] addSubview:vibrantView
-                             positioned:NSWindowBelow
-                             relativeTo:nil];
+      // Vibrant view is inserted into the root view hierarchy underneath all
+      // other views.
+      vibrant_native_view_host_ = new views::NativeViewHost();
+      rootView->AddChildViewAt(vibrant_native_view_host_, 0);
+      vibrant_native_view_host_->Attach(vibrantView);
+
+      rootView->DeprecatedLayoutImmediately();
 
       UpdateVibrancyRadii(IsFullscreen());
     }

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1462,8 +1462,8 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
 
       // Vibrant view is inserted into the root view hierarchy underneath all
       // other views.
-      vibrant_native_view_host_ = new views::NativeViewHost();
-      rootView->AddChildViewAt(vibrant_native_view_host_, 0);
+      vibrant_native_view_host_ = rootView->AddChildViewAt(
+          std::make_unique<views::NativeViewHost>(), 0);
       vibrant_native_view_host_->Attach(vibrantView);
 
       rootView->DeprecatedLayoutImmediately();


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42336
Closes https://github.com/electron/electron/issues/42335
Refs https://github.com/electron/electron/pull/43033.

Now that the above PR has been reverted we can apply this fix to all release branches.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed issues with the vibrancy view on macOS.
