### PR TITLE
fix: `showInactive` window not showing

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -467,7 +467,7 @@ void NativeWindowMac::ShowInactive() {
   if (parent())
     InternalSetParentWindow(parent(), true);
 
-  [window_ orderFrontKeepWindowKeyState];
+  [window_ orderFrontRegardless];
 }
 
 void NativeWindowMac::Hide() {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42962
Refs https://github.com/electron/electron/pull/42226
Refs https://github.com/electron/electron/pull/43033

Fixes `showInactive` window not showing - we don't need to use `orderFrontKeepWindowKeyState` after reverting #43033

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where calling `window.showInactive` on macOS did not actually show the window.