### PR TITLE
chore: remove unused & undocumented function v8Util.deleteHiddenValue()

### DIFF
--- a/shell/common/api/electron_api_v8_util.cc
+++ b/shell/common/api/electron_api_v8_util.cc
@@ -67,17 +67,6 @@ void SetHiddenValue(v8::Isolate* isolate,
   object->SetPrivate(context, privateKey, value);
 }
 
-void DeleteHiddenValue(v8::Isolate* isolate,
-                       v8::Local<v8::Object> object,
-                       v8::Local<v8::String> key) {
-  v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  v8::Local<v8::Private> privateKey = v8::Private::ForApi(isolate, key);
-  // Actually deleting the value would make force the object into
-  // dictionary mode which is unnecessarily slow. Instead, we replace
-  // the hidden value with "undefined".
-  object->SetPrivate(context, privateKey, v8::Undefined(isolate));
-}
-
 int32_t GetObjectHash(v8::Local<v8::Object> object) {
   return object->GetIdentityHash();
 }
@@ -114,7 +103,6 @@ void Initialize(v8::Local<v8::Object> exports,
   gin_helper::Dictionary dict(context->GetIsolate(), exports);
   dict.SetMethod("getHiddenValue", &GetHiddenValue);
   dict.SetMethod("setHiddenValue", &SetHiddenValue);
-  dict.SetMethod("deleteHiddenValue", &DeleteHiddenValue);
   dict.SetMethod("getObjectHash", &GetObjectHash);
   dict.SetMethod("takeHeapSnapshot", &TakeHeapSnapshot);
   dict.SetMethod("requestGarbageCollectionForTesting",

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -32,7 +32,6 @@ declare namespace NodeJS {
   interface V8UtilBinding {
     getHiddenValue<T>(obj: any, key: string): T;
     setHiddenValue<T>(obj: any, key: string, value: T): void;
-    deleteHiddenValue(obj: any, key: string): void;
     requestGarbageCollectionForTesting(): void;
     runUntilIdle(): void;
     triggerFatalErrorForTesting(): void;


### PR DESCRIPTION
#### Description of Change

Remove unused & undocumented function `v8Util.deleteHiddenValue()`. It hasn't been used since Nov 2020 (c8d77cae4a, #26659).

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.