### PR TITLE
feat: Add the postQuantum and echEnabled options to  SSLConfig

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -1263,6 +1263,8 @@ Returns `string` - The user agent for this session.
     Ex: To disable TLS_RSA_WITH_RC4_128_MD5, specify 0x0004, while to
     disable TLS_ECDH_ECDSA_WITH_RC4_128_SHA, specify 0xC002.
     Note that TLSv1.3 ciphers cannot be disabled using this mechanism.
+  * `postQuantum` boolean (optional) - controls whether post-quantum key agreement in TLS connections is allowed.
+  * `echEnabled` boolean (optional) - Controls whether ECH is enabled.
 
 Sets the SSL configuration for the session. All subsequent network requests
 will use the new configuration. Existing network connections (such as WebSocket

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -457,6 +457,20 @@ struct Converter<network::mojom::SSLConfigPtr> {
     std::sort((*out)->disabled_cipher_suites.begin(),
               (*out)->disabled_cipher_suites.end());
 
+    if (options.Has("postQuantum")) {
+      bool post_quantum = false;
+      if (!options.Get("postQuantum", &post_quantum)) {
+        (*out)->post_quantum_override =
+            post_quantum ? network::mojom::OptionalBool::kTrue
+                         : network::mojom::OptionalBool::kFalse;
+        return false;
+      }
+    }
+
+    if (options.Has("echEnabled ") &&
+        !options.Get("echEnabled", &(*out)->ech_enabled)) {
+      return false;
+    }
     // TODO(nornagon): also support other SSLConfig properties?
     return true;
   }


### PR DESCRIPTION
#### Description of Change

This commit added switches to enable/disable the post-quantum key agreement and ECH for TLS connections.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added postQuantum and echEnabled options to SSLConfig.

@codebytere @zcbenz 

