### PR TITLE
docs: update Node.js stable release policy

### DIFF
--- a/docs/tutorial/electron-timelines.md
+++ b/docs/tutorial/electron-timelines.md
@@ -98,19 +98,10 @@ is as follows:
 
 <img src="https://raw.githubusercontent.com/nodejs/Release/main/schedule.svg?sanitize=true" alt="Releases">
 
-As a rule, stable branches of Electron do not receive Node.js upgrades after they have been cut.
 If Electron has recently updated its `main` branch to a new major version of Node.js, the next stable
 branch to be cut will be released with the new version.
 
-Patch upgrades of Node that contain significant security or bug fixes, and are submitted
-more than 2 weeks prior to a stable release date, will be accepted into an Electron alpha
-or beta release branch.
-
-Minor upgrades of Node that contain significant security or bug fixes, and are submitted
-more than 2 weeks prior to a stable release date may be accepted into an Electron alpha or
-beta release branch on a case-by-case basis. These requests will be reviewed and voted on
-by the [Releases Working Group](https://github.com/electron/governance/tree/main/wg-releases),
-to ensure minimal disruption for developers who may be consuming alpha or beta releases.
+Stable release lines of Electron will receive minor and patch bumps of Node.js after they are released. Patch bumps to Node.js will be released in patch releases of Electron, and minor bumps to Node.js will result in a minor release of Electron. Security-only release branches will receive security-related changes from Node.js releases, but not the full release.
 
 ### Breaking API changes
 

--- a/docs/tutorial/electron-timelines.md
+++ b/docs/tutorial/electron-timelines.md
@@ -101,7 +101,9 @@ is as follows:
 If Electron has recently updated its `main` branch to a new major version of Node.js, the next stable
 branch to be cut will be released with the new version.
 
-Stable release lines of Electron will receive minor and patch bumps of Node.js after they are released. Patch bumps to Node.js will be released in patch releases of Electron, and minor bumps to Node.js will result in a minor release of Electron. Security-only release branches will receive security-related changes from Node.js releases, but not the full release.
+Stable release lines of Electron will receive minor and patch bumps of Node.js after they are released.
+Patch bumps to Node.js will be released in patch releases of Electron, and minor bumps to Node.js will result in a minor release of Electron.
+Security-only release branches will receive security-related changes from Node.js releases, but not the full release.
 
 ### Breaking API changes
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/43091

Update external documentation to reflect the new Node.js version release policy decided by the Release WG.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none