### PR TITLE
docs: fixed broken electron-fiddle links in the "Tutorial - Publishing and Updating" doc

### DIFF
--- a/docs/tutorial/tutorial-6-publishing-updating.md
+++ b/docs/tutorial/tutorial-6-publishing-updating.md
@@ -222,8 +222,8 @@ rest of our docs and happy developing! If you have questions, please stop by our
 [code-signed]: ./code-signing.md
 [discord server]: https://discord.gg/electronjs
 [electron fiddle]: https://www.electronjs.org/fiddle
-[fiddle-build]: https://github.com/electron/fiddle/blob/main/.github/workflows/build.yaml
-[fiddle-forge-config]: https://github.com/electron/fiddle/blob/main/forge.config.js
+[fiddle-build]: https://github.com/electron/fiddle/blob/main/.circleci/config.yml
+[fiddle-forge-config]: https://github.com/electron/fiddle/blob/main/forge.config.ts
 [github actions]: https://github.com/features/actions
 [github publisher]: https://www.electronforge.io/config/publishers/github
 [github releases]: https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository


### PR DESCRIPTION
#### Description of Change

Hello,

I found the electron-fiddle's "Build and Release pipeline" and  "Forge configuration" links are broken due to the change of filename. I replaced the broken links with the up-to-date working ones. Thanks for reviewing this PR!

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
