### PR TITLE
chore: deprecate `textured`  BrowserWindow `type` option on macOS

### DIFF
--- a/docs/api/structures/base-window-options.md
+++ b/docs/api/structures/base-window-options.md
@@ -139,8 +139,7 @@ Possible values are:
     -webkit-app-region: drag. This type is commonly used for splash screens.
   * The `notification` type creates a window that behaves like a system notification.
 * On macOS, possible types are `desktop`, `textured`, `panel`.
-  * The `textured` type adds metal gradient appearance
-    (`NSWindowStyleMaskTexturedBackground`).
+  * The `textured` type adds metal gradient appearance. This option is **deprecated**.
   * The `desktop` type places the window at the desktop background window level
     (`kCGDesktopWindowLevel - 1`). Note that desktop window will not receive
     focus, keyboard or mouse events, but you can use `globalShortcut` to receive

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -14,6 +14,10 @@ This document uses the following convention to categorize breaking changes:
 
 ## Planned Breaking API Changes (33.0)
 
+### Deprecated: `textured` option in `BrowserWindowConstructorOption.type`
+
+The `textured` option of `type` in `BrowserWindowConstructorOptions` has been depecated with no replacement. This option relied on the [`NSWindowStyleMaskTexturedBackground`](https://developer.apple.com/documentation/appkit/nswindowstylemask/nswindowstylemasktexturedbackground) style mask on macOS, which has been deprecated with no alternative.
+
 ### Deprecated: `systemPreferences.accessibilityDisplayShouldReduceTransparency`
 
 The `systemPreferences.accessibilityDisplayShouldReduceTransparency` property is now deprecated in favor of the new `nativeTheme.prefersReducedTransparency`, which provides identical information and works cross-platform.

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -38,6 +38,7 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/options_switches.h"
+#include "shell/common/process_util.h"
 #include "skia/ext/skia_utils_mac.h"
 #include "third_party/webrtc/modules/desktop_capture/mac/window_list_utils.h"
 #include "ui/base/hit_test.h"
@@ -198,14 +199,6 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   bool hiddenInMissionControl = false;
   options.Get(options::kHiddenInMissionControl, &hiddenInMissionControl);
 
-  bool useStandardWindow = true;
-  // eventually deprecate separate "standardWindow" option in favor of
-  // standard / textured window types
-  options.Get(options::kStandardWindow, &useStandardWindow);
-  if (windowType == "textured") {
-    useStandardWindow = false;
-  }
-
   // The window without titlebar is treated the same with frameless window.
   if (title_bar_style_ != TitleBarStyle::kNormal)
     set_has_frame(false);
@@ -225,8 +218,18 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
     styleMask |= NSWindowStyleMaskClosable;
   if (resizable)
     styleMask |= NSWindowStyleMaskResizable;
-  if (!useStandardWindow || transparent() || !has_frame())
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  if (windowType == "textured" || transparent() || !has_frame()) {
+    node::Environment* env =
+        node::Environment::GetCurrent(JavascriptEnvironment::GetIsolate());
+    EmitWarning(env,
+                "The 'textured' window type is deprecated and will be removed",
+                "DeprecationWarning");
     styleMask |= NSWindowStyleMaskTexturedBackground;
+  }
+#pragma clang diagnostic pop
 
   // Create views::Widget and assign window_ with it.
   // TODO(zcbenz): Get rid of the window_ in future.

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -86,9 +86,6 @@ const char kType[] = "type";
 // Disable auto-hiding cursor.
 const char kDisableAutoHideCursor[] = "disableAutoHideCursor";
 
-// Use the macOS' standard window instead of the textured window.
-const char kStandardWindow[] = "standardWindow";
-
 // Default browser window background color.
 const char kBackgroundColor[] = "backgroundColor";
 

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -47,7 +47,6 @@ extern const char kDarkTheme[];
 extern const char kTransparent[];
 extern const char kType[];
 extern const char kDisableAutoHideCursor[];
-extern const char kStandardWindow[];
 extern const char kBackgroundColor[];
 extern const char kHasShadow[];
 extern const char kOpacity[];


### PR DESCRIPTION
#### Description of Change

BREAKING CHANGE

Closes https://github.com/electron/electron/issues/43125.

Removes usage of `textured` as a BrowserWindow `type` option on macOS. It relied on [`NSWindowStyleMaskTexturedBackground`](https://developer.apple.com/documentation/appkit/nswindowstylemask/nswindowstylemasktexturedbackground?changes=_1), which has been removed with no replacement.

Should be merged after https://github.com/electron/electron/pull/43087

`standardWindow` was not documented so we don't need to put it through a formal deprecation cycle.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Deprecated usage of `textured`  BrowserWindow `type` option on macOS.
