### PR TITLE
feat: add transparency checking to `nativeTheme`

### DIFF
--- a/docs/api/native-theme.md
+++ b/docs/api/native-theme.md
@@ -72,3 +72,7 @@ or is being instructed to use an inverted color scheme.
 
 A `boolean` indicating whether Chromium is in forced colors mode, controlled by system accessibility settings.
 Currently, Windows high contrast is the only system setting that triggers forced colors mode.
+
+### `nativeTheme.prefersReducedTransparency` _Readonly_
+
+A `boolean` that indicates the whether the user has chosen via system accessibility settings to reduce transparency at the OS level.

--- a/shell/browser/api/electron_api_native_theme.cc
+++ b/shell/browser/api/electron_api_native_theme.cc
@@ -68,6 +68,10 @@ bool NativeTheme::InForcedColorsMode() {
   return ui_theme_->InForcedColorsMode();
 }
 
+bool NativeTheme::GetPrefersReducedTransparency() {
+  return ui_theme_->GetPrefersReducedTransparency();
+}
+
 #if BUILDFLAG(IS_MAC)
 const CFStringRef WhiteOnBlack = CFSTR("whiteOnBlack");
 const CFStringRef UniversalAccessDomain = CFSTR("com.apple.universalaccess");
@@ -108,7 +112,9 @@ gin::ObjectTemplateBuilder NativeTheme::GetObjectTemplateBuilder(
                    &NativeTheme::ShouldUseHighContrastColors)
       .SetProperty("shouldUseInvertedColorScheme",
                    &NativeTheme::ShouldUseInvertedColorScheme)
-      .SetProperty("inForcedColorsMode", &NativeTheme::InForcedColorsMode);
+      .SetProperty("inForcedColorsMode", &NativeTheme::InForcedColorsMode)
+      .SetProperty("prefersReducedTransparency",
+                   &NativeTheme::GetPrefersReducedTransparency);
 }
 
 const char* NativeTheme::GetTypeName() {

--- a/shell/browser/api/electron_api_native_theme.h
+++ b/shell/browser/api/electron_api_native_theme.h
@@ -46,6 +46,7 @@ class NativeTheme : public gin::Wrappable<NativeTheme>,
   bool ShouldUseHighContrastColors();
   bool ShouldUseInvertedColorScheme();
   bool InForcedColorsMode();
+  bool GetPrefersReducedTransparency();
 
   // ui::NativeThemeObserver:
   void OnNativeThemeUpdated(ui::NativeTheme* theme) override;

--- a/spec/api-native-theme-spec.ts
+++ b/spec/api-native-theme-spec.ts
@@ -105,4 +105,10 @@ describe('nativeTheme module', () => {
       expect(nativeTheme.inForcedColorsMode).to.be.a('boolean');
     });
   });
+
+  describe('nativeTheme.prefersReducesTransparency', () => {
+    it('returns a boolean', () => {
+      expect(nativeTheme.prefersReducedTransparency).to.be.a('boolean');
+    });
+  });
 });


### PR DESCRIPTION
Backport of #42862.

See that PR for details.

Notes: Added a new property `prefersReducedTransparency` to `nativeTheme`, which indicates whether the user has chosen to reduce OS-level transparency via system accessibility settings.