### PR TITLE
chore: remove unused internal env.unSetVar()

### DIFF
--- a/shell/common/api/electron_api_environment.cc
+++ b/shell/common/api/electron_api_environment.cc
@@ -25,10 +25,6 @@ bool SetVar(const std::string& name, const std::string& value) {
   return base::Environment::Create()->SetVar(name, value);
 }
 
-bool UnSetVar(const std::string& name) {
-  return base::Environment::Create()->UnSetVar(name);
-}
-
 void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context,
@@ -37,7 +33,6 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("getVar", &GetVar);
   dict.SetMethod("hasVar", &HasVar);
   dict.SetMethod("setVar", &SetVar);
-  dict.SetMethod("unSetVar", &UnSetVar);
 }
 
 }  // namespace

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -52,7 +52,6 @@ declare namespace NodeJS {
     getVar(name: string): string | null;
     hasVar(name: string): boolean;
     setVar(name: string, value: string): boolean;
-    unSetVar(name: string): boolean;
   }
 
   type AsarFileInfo = {


### PR DESCRIPTION
#### Description of Change

Remove `env.unSetVar()`, which was added to internal bindings in Oct 2020 (b33f2260, #25623) but never used.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.