### PR TITLE
docs: Document ideal iconPath size

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1357,7 +1357,7 @@ Show the app's about panel options. These options can be overridden with `app.se
   * `credits` string (optional) _macOS_ _Windows_ - Credit information.
   * `authors` string[] (optional) _Linux_ - List of app authors.
   * `website` string (optional) _Linux_ - The app's website.
-  * `iconPath` string (optional) _Linux_ _Windows_ - Path to the app's icon in a JPEG or PNG file format. On Linux, will be shown as 64x64 pixels while retaining aspect ratio.
+  * `iconPath` string (optional) _Linux_ _Windows_ - Path to the app's icon in a JPEG or PNG file format. On Linux, will be shown as 64x64 pixels while retaining aspect ratio. On Windows, a 48x48 PNG will result in the best visual quality.
 
 Set the about panel options. This will override the values defined in the app's `.plist` file on macOS. See the [Apple docs][about-panel-options] for more details. On Linux, values must be set in order to be shown; there are no defaults.
 


### PR DESCRIPTION
#### Description of Change

If you use a regular PNG, the Windows about panel will look pretty awful. I tested a bunch of sizes and settled on 48x48. Real fix would obviously be to not resize without any kind of resizing algorithm, but this makes things easier without changing code.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: no-notes
