### PR TITLE
feat: accept-encoding zstd

### DIFF
--- a/shell/browser/net/system_network_context_manager.cc
+++ b/shell/browser/net/system_network_context_manager.cc
@@ -195,7 +195,8 @@ SystemNetworkContextManager::CreateDefaultNetworkContextParams() {
 void SystemNetworkContextManager::ConfigureDefaultNetworkContextParams(
     network::mojom::NetworkContextParams* network_context_params) {
   network_context_params->enable_brotli = true;
-  network_context_params->enable_zstd = true;
+  network_context_params->enable_zstd = 
+      base::FeatureList::IsEnabled(net::features::kZstdContentEncoding);
 
   network_context_params->enable_referrers = true;
 

--- a/shell/browser/net/system_network_context_manager.cc
+++ b/shell/browser/net/system_network_context_manager.cc
@@ -195,7 +195,7 @@ SystemNetworkContextManager::CreateDefaultNetworkContextParams() {
 void SystemNetworkContextManager::ConfigureDefaultNetworkContextParams(
     network::mojom::NetworkContextParams* network_context_params) {
   network_context_params->enable_brotli = true;
-  network_context_params->enable_zstd = 
+  network_context_params->enable_zstd =
       base::FeatureList::IsEnabled(net::features::kZstdContentEncoding);
 
   network_context_params->enable_referrers = true;

--- a/shell/browser/net/system_network_context_manager.cc
+++ b/shell/browser/net/system_network_context_manager.cc
@@ -195,6 +195,7 @@ SystemNetworkContextManager::CreateDefaultNetworkContextParams() {
 void SystemNetworkContextManager::ConfigureDefaultNetworkContextParams(
     network::mojom::NetworkContextParams* network_context_params) {
   network_context_params->enable_brotli = true;
+  network_context_params->enable_zstd = true;
 
   network_context_params->enable_referrers = true;
 


### PR DESCRIPTION
#### Description of Change

Set the default network context params' `enable_zstd` flag to `true` to enable zstd encoding. As per 43124, this is true for requests made in Chromium but was not true in Electron.

Closes #43124.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Enabled zstd compression in net http requests.