### PR TITLE
refactor: prefer std::ranges over base::ranges

### DIFF
--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -4,9 +4,9 @@
 
 #include "shell/browser/electron_browser_context.h"
 
+#include <algorithm>
 #include <memory>
 #include <optional>
-
 #include <utility>
 
 #include "base/barrier_closure.h"
@@ -129,7 +129,7 @@ media::mojom::CaptureHandlePtr CreateCaptureHandle(
 
   const auto& captured_config = captured->GetCaptureHandleConfig();
   if (!captured_config.all_origins_permitted &&
-      base::ranges::none_of(
+      std::ranges::none_of(
           captured_config.permitted_origins,
           [capturer_origin](const url::Origin& permitted_origin) {
             return capturer_origin.IsSameOriginWith(permitted_origin);

--- a/shell/browser/file_system_access/file_system_access_permission_context.cc
+++ b/shell/browser/file_system_access/file_system_access_permission_context.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/file_system_access/file_system_access_permission_context.h"
 
+#include <algorithm>
 #include <string>
 #include <utility>
 
@@ -98,7 +99,7 @@ constexpr base::TimeDelta kPermissionRevocationTimeout = base::Seconds(5);
 #if BUILDFLAG(IS_WIN)
 [[nodiscard]] constexpr bool ContainsInvalidDNSCharacter(
     base::FilePath::StringType hostname) {
-  return !base::ranges::all_of(hostname, [](base::FilePath::CharType c) {
+  return !std::ranges::all_of(hostname, [](base::FilePath::CharType c) {
     return (c >= L'A' && c <= L'Z') || (c >= L'a' && c <= L'z') ||
            (c >= L'0' && c <= L'9') || (c == L'.') || (c == L'-');
   });
@@ -355,7 +356,7 @@ class FileSystemAccessPermissionContext::PermissionGrantImpl
       const base::FilePath& old_path,
       const base::FilePath& new_path) {
     DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
-    auto entry_it = base::ranges::find_if(
+    auto entry_it = std::ranges::find_if(
         grants,
         [&old_path](const auto& entry) { return entry.first == old_path; });
 
@@ -683,7 +684,7 @@ void FileSystemAccessPermissionContext::MaybeEvictEntries(
     return;
   }
 
-  base::ranges::sort(entries);
+  std::ranges::sort(entries);
   size_t entries_to_remove = entries.size() - max_ids_per_origin_;
   for (size_t i = 0; i < entries_to_remove; ++i) {
     bool did_remove_entry = dict.Remove(entries[i].second);
@@ -862,7 +863,7 @@ bool FileSystemAccessPermissionContext::OriginHasReadAccess(
 
   auto it = active_permissions_map_.find(origin);
   if (it != active_permissions_map_.end()) {
-    return base::ranges::any_of(it->second.read_grants, [&](const auto& grant) {
+    return std::ranges::any_of(it->second.read_grants, [&](const auto& grant) {
       return grant.second->GetStatus() == PermissionStatus::GRANTED;
     });
   }
@@ -876,10 +877,9 @@ bool FileSystemAccessPermissionContext::OriginHasWriteAccess(
 
   auto it = active_permissions_map_.find(origin);
   if (it != active_permissions_map_.end()) {
-    return base::ranges::any_of(
-        it->second.write_grants, [&](const auto& grant) {
-          return grant.second->GetStatus() == PermissionStatus::GRANTED;
-        });
+    return std::ranges::any_of(it->second.write_grants, [&](const auto& grant) {
+      return grant.second->GetStatus() == PermissionStatus::GRANTED;
+    });
   }
 
   return false;

--- a/shell/browser/hid/hid_chooser_controller.cc
+++ b/shell/browser/hid/hid_chooser_controller.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/hid/hid_chooser_controller.h"
 
+#include <algorithm>
 #include <utility>
 
 #include "base/command_line.h"
@@ -368,8 +369,8 @@ void HidChooserController::UpdateDeviceInfo(
   auto physical_device_it = device_map_.find(id);
   DCHECK(physical_device_it != device_map_.end());
   auto& device_infos = physical_device_it->second;
-  auto device_it = base::ranges::find(device_infos, device.guid,
-                                      &device::mojom::HidDeviceInfo::guid);
+  auto device_it = std::ranges::find(device_infos, device.guid,
+                                     &device::mojom::HidDeviceInfo::guid);
   DCHECK(device_it != device_infos.end());
   *device_it = device.Clone();
 }

--- a/shell/browser/serial/serial_chooser_controller.cc
+++ b/shell/browser/serial/serial_chooser_controller.cc
@@ -154,8 +154,8 @@ void SerialChooserController::OnPortAdded(
 
 void SerialChooserController::OnPortRemoved(
     const device::mojom::SerialPortInfo& port) {
-  const auto it = base::ranges::find(ports_, port.token,
-                                     &device::mojom::SerialPortInfo::token);
+  const auto it = std::ranges::find(ports_, port.token,
+                                    &device::mojom::SerialPortInfo::token);
   if (it != ports_.end()) {
     api::Session* session = GetSession();
     if (session) {

--- a/shell/browser/ui/file_dialog_linux.cc
+++ b/shell/browser/ui/file_dialog_linux.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <algorithm>
 #include <vector>
 
 #include "base/files/file_util.h"
@@ -45,7 +46,7 @@ ui::SelectFileDialog::FileTypeInfo GetFilterInfo(const Filters& filters) {
     file_type_info.extension_description_overrides.push_back(
         base::UTF8ToUTF16(name));
 
-    const bool has_all_files_wildcard = base::ranges::any_of(
+    const bool has_all_files_wildcard = std::ranges::any_of(
         extension_group, [](const auto& ext) { return ext == "*"; });
     if (has_all_files_wildcard) {
       file_type_info.include_all_files = true;

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -5,6 +5,7 @@
 
 #include "shell/browser/ui/inspectable_web_contents.h"
 
+#include <algorithm>
 #include <memory>
 #include <string_view>
 #include <utility>
@@ -13,7 +14,6 @@
 #include "base/base64.h"
 #include "base/memory/raw_ptr.h"
 #include "base/metrics/histogram.h"
-#include "base/ranges/algorithm.h"
 #include "base/strings/pattern.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
@@ -111,10 +111,10 @@ gfx::Rect DictionaryToRect(const base::Value::Dict& dict) {
 }
 
 bool IsPointInScreen(const gfx::Point& point) {
-  return base::ranges::any_of(display::Screen::GetScreen()->GetAllDisplays(),
-                              [&point](auto const& display) {
-                                return display.bounds().Contains(point);
-                              });
+  return std::ranges::any_of(display::Screen::GetScreen()->GetAllDisplays(),
+                             [&point](auto const& display) {
+                               return display.bounds().Contains(point);
+                             });
 }
 
 void SetZoomLevelForWebContents(content::WebContents* web_contents,

--- a/shell/browser/usb/usb_chooser_controller.cc
+++ b/shell/browser/usb/usb_chooser_controller.cc
@@ -4,11 +4,11 @@
 
 #include "shell/browser/usb/usb_chooser_controller.h"
 
-#include <stddef.h>
+#include <algorithm>
+#include <cstddef>
 #include <utility>
 
 #include "base/functional/bind.h"
-#include "base/ranges/algorithm.h"
 #include "components/strings/grit/components_strings.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"
@@ -146,7 +146,7 @@ bool UsbChooserController::DisplayDevice(
     return false;
   }
 
-  if (base::ranges::any_of(
+  if (std::ranges::any_of(
           options_->exclusion_filters, [&device_info](const auto& filter) {
             return device::UsbDeviceFilterMatches(*filter, device_info);
           })) {

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -4,6 +4,8 @@
 
 #include "shell/renderer/electron_renderer_client.h"
 
+#include <algorithm>
+
 #include "base/command_line.h"
 #include "base/containers/contains.h"
 #include "base/debug/stack_trace.h"
@@ -163,7 +165,7 @@ void ElectronRendererClient::WillReleaseScriptContext(
     return;
 
   node::Environment* env = node::Environment::GetCurrent(context);
-  const auto iter = base::ranges::find_if(
+  const auto iter = std::ranges::find_if(
       environments_, [env](auto& item) { return env == item.get(); });
   if (iter == environments_.end())
     return;


### PR DESCRIPTION
#### Description of Change

`std::ranges` is explicitly allowed now, so this PR migrates our C++20 `base::ranges` calls to `std::ranges`.

Related links:

- https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++-features.md#range-algorithms-allowed
- https://chromium-review.googlesource.com/c/chromium/src/+/5668999
- https://groups.google.com/a/chromium.org/g/cxx/c/ZnIbkfJ0Glw

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.