### PR TITLE
refactor: migrate `electron_login_helper` to non-deprecated API

### DIFF
--- a/shell/app/electron_login_helper.mm
+++ b/shell/app/electron_login_helper.mm
@@ -4,12 +4,6 @@
 
 #import <Cocoa/Cocoa.h>
 
-// launchApplication is deprecated; should be migrated to
-// [NSWorkspace openApplicationAtURL:configuration:completionHandler:]
-// UserNotifications.frameworks API
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-
 int main(int argc, char* argv[]) {
   @autoreleasepool {
     NSArray* pathComponents =
@@ -17,11 +11,18 @@ int main(int argc, char* argv[]) {
     pathComponents = [pathComponents
         subarrayWithRange:NSMakeRange(0, [pathComponents count] - 4)];
     NSString* path = [NSString pathWithComponents:pathComponents];
+    NSURL* url = [NSURL fileURLWithPath:path];
 
-    [[NSWorkspace sharedWorkspace] launchApplication:path];
+    [[NSWorkspace sharedWorkspace]
+        openApplicationAtURL:url
+               configuration:NSWorkspaceOpenConfiguration.configuration
+           completionHandler:^(NSRunningApplication* app, NSError* error) {
+             if (error) {
+               NSLog(@"Failed to launch application: %@", error);
+             } else {
+               NSLog(@"Application launched successfully: %@", app);
+             }
+           }];
     return 0;
   }
 }
-
-// -Wdeprecated-declarations
-#pragma clang diagnostic pop


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/43087.

Migrates deprecated API in `electron_login_helper` to use non-deprecated API. Functionality should remain identical.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none