### PR TITLE
perf: use v8::String::NewFromUtf8Literal() when possible

### DIFF
--- a/shell/browser/api/electron_api_auto_updater.cc
+++ b/shell/browser/api/electron_api_auto_updater.cc
@@ -39,7 +39,7 @@ void AutoUpdater::OnError(const std::string& message) {
   if (GetWrapper(isolate).ToLocal(&wrapper)) {
     auto error = v8::Exception::Error(gin::StringToV8(isolate, message));
     std::vector<v8::Local<v8::Value>> args = {
-        gin::StringToV8(isolate, "error"),
+        v8::String::NewFromUtf8Literal(isolate, "error"),
         gin::ConvertToV8(
             isolate,
             error->ToObject(isolate->GetCurrentContext()).ToLocalChecked()),
@@ -70,11 +70,11 @@ void AutoUpdater::OnError(const std::string& message,
 
     // add two new params for better error handling
     errorObject
-        ->Set(context, gin::StringToV8(isolate, "code"),
+        ->Set(context, v8::String::NewFromUtf8Literal(isolate, "code"),
               v8::Integer::New(isolate, code))
         .Check();
     errorObject
-        ->Set(context, gin::StringToV8(isolate, "domain"),
+        ->Set(context, v8::String::NewFromUtf8Literal(isolate, "domain"),
               gin::StringToV8(isolate, domain))
         .Check();
 

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -722,8 +722,8 @@ void BaseWindow::SetMenu(v8::Isolate* isolate, v8::Local<v8::Value> value) {
   } else if (value->IsNull()) {
     RemoveMenu();
   } else {
-    isolate->ThrowException(
-        v8::Exception::TypeError(gin::StringToV8(isolate, "Invalid Menu")));
+    isolate->ThrowException(v8::Exception::TypeError(
+        v8::String::NewFromUtf8Literal(isolate, "Invalid Menu")));
   }
 }
 
@@ -1144,7 +1144,8 @@ gin_helper::WrappableBase* BaseWindow::New(gin_helper::Arguments* args) {
 // static
 void BaseWindow::BuildPrototype(v8::Isolate* isolate,
                                 v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(gin::StringToV8(isolate, "BaseWindow"));
+  prototype->SetClassName(
+      v8::String::NewFromUtf8Literal(isolate, "BaseWindow"));
   gin_helper::Destroyable::MakeDestroyable(isolate, prototype);
   gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("setContentView", &BaseWindow::SetContentView)

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -346,7 +346,8 @@ gin_helper::WrappableBase* BrowserWindow::New(gin_helper::ErrorThrower thrower,
 // static
 void BrowserWindow::BuildPrototype(v8::Isolate* isolate,
                                    v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(gin::StringToV8(isolate, "BrowserWindow"));
+  prototype->SetClassName(
+      v8::String::NewFromUtf8Literal(isolate, "BrowserWindow"));
   gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("focusOnWebView", &BrowserWindow::FocusOnWebView)
       .SetMethod("blurWebView", &BrowserWindow::BlurWebView)

--- a/shell/browser/api/electron_api_cookies.cc
+++ b/shell/browser/api/electron_api_cookies.cc
@@ -79,17 +79,17 @@ struct Converter<net::CookieChangeCause> {
     switch (val) {
       case net::CookieChangeCause::INSERTED:
       case net::CookieChangeCause::EXPLICIT:
-        return gin::StringToV8(isolate, "explicit");
+        return v8::String::NewFromUtf8Literal(isolate, "explicit");
       case net::CookieChangeCause::OVERWRITE:
-        return gin::StringToV8(isolate, "overwrite");
+        return v8::String::NewFromUtf8Literal(isolate, "overwrite");
       case net::CookieChangeCause::EXPIRED:
-        return gin::StringToV8(isolate, "expired");
+        return v8::String::NewFromUtf8Literal(isolate, "expired");
       case net::CookieChangeCause::EVICTED:
-        return gin::StringToV8(isolate, "evicted");
+        return v8::String::NewFromUtf8Literal(isolate, "evicted");
       case net::CookieChangeCause::EXPIRED_OVERWRITE:
-        return gin::StringToV8(isolate, "expired-overwrite");
+        return v8::String::NewFromUtf8Literal(isolate, "expired-overwrite");
       default:
-        return gin::StringToV8(isolate, "unknown");
+        return v8::String::NewFromUtf8Literal(isolate, "unknown");
     }
   }
 };

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -338,10 +338,10 @@ class ClearDataTask {
       // Create a rich error object with extra detail about what data types
       // failed
       auto error = v8::Exception::Error(
-          gin::StringToV8(isolate, "Failed to clear data"));
+          v8::String::NewFromUtf8Literal(isolate, "Failed to clear data"));
       error.As<v8::Object>()
           ->Set(promise_.GetContext(),
-                gin::StringToV8(isolate, "failedDataTypes"),
+                v8::String::NewFromUtf8Literal(isolate, "failedDataTypes"),
                 failed_data_types_array)
           .Check();
 
@@ -1046,13 +1046,15 @@ void Session::CreateInterruptedDownload(const gin_helper::Dictionary& options) {
   options.Get("eTag", &etag);
   options.Get("startTime", &start_time);
   if (path.empty() || url_chain.empty() || length == 0) {
-    isolate_->ThrowException(v8::Exception::Error(gin::StringToV8(
-        isolate_, "Must pass non-empty path, urlChain and length.")));
+    isolate_->ThrowException(
+        v8::Exception::Error(v8::String::NewFromUtf8Literal(
+            isolate_, "Must pass non-empty path, urlChain and length.")));
     return;
   }
   if (offset >= length) {
-    isolate_->ThrowException(v8::Exception::Error(gin::StringToV8(
-        isolate_, "Must pass an offset value less than length.")));
+    isolate_->ThrowException(
+        v8::Exception::Error(v8::String::NewFromUtf8Literal(
+            isolate_, "Must pass an offset value less than length.")));
     return;
   }
   auto* download_manager = browser_context()->GetDownloadManager();

--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -208,7 +208,7 @@ int SystemPreferences::DoSubscribeNotification(
   if (!(maybe_name->IsNull() ||
         gin::ConvertFromV8(isolate, maybe_name, &name_str))) {
     isolate->ThrowException(v8::Exception::Error(
-        gin::StringToV8(isolate, "Must pass null or a string")));
+        v8::String::NewFromUtf8Literal(isolate, "Must pass null or a string")));
     return -1;
   }
 

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -420,7 +420,7 @@ gin::Handle<View> View::Create(v8::Isolate* isolate) {
 // static
 void View::BuildPrototype(v8::Isolate* isolate,
                           v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(gin::StringToV8(isolate, "View"));
+  prototype->SetClassName(v8::String::NewFromUtf8Literal(isolate, "View"));
   gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("addChildView", &View::AddChildViewAt)
       .SetMethod("removeChildView", &View::RemoveChildView)

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3384,8 +3384,8 @@ void WebContents::SendInputEvent(v8::Isolate* isolate,
     }
   }
 
-  isolate->ThrowException(
-      v8::Exception::Error(gin::StringToV8(isolate, "Invalid event object")));
+  isolate->ThrowException(v8::Exception::Error(
+      v8::String::NewFromUtf8Literal(isolate, "Invalid event object")));
 }
 
 void WebContents::BeginFrameSubscription(gin::Arguments* args) {

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -226,7 +226,8 @@ gin_helper::WrappableBase* WebContentsView::New(gin_helper::Arguments* args) {
 void WebContentsView::BuildPrototype(
     v8::Isolate* isolate,
     v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(gin::StringToV8(isolate, "WebContentsView"));
+  prototype->SetClassName(
+      v8::String::NewFromUtf8Literal(isolate, "WebContentsView"));
   gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("setBackgroundColor", &WebContentsView::SetBackgroundColor)
       .SetMethod("setBorderRadius", &WebContentsView::SetBorderRadius)

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -187,8 +187,8 @@ void WebFrameMain::Send(v8::Isolate* isolate,
                         v8::Local<v8::Value> args) {
   blink::CloneableMessage message;
   if (!gin::ConvertFromV8(isolate, args, &message)) {
-    isolate->ThrowException(v8::Exception::Error(
-        gin::StringToV8(isolate, "Failed to serialize arguments")));
+    isolate->ThrowException(v8::Exception::Error(v8::String::NewFromUtf8Literal(
+        isolate, "Failed to serialize arguments")));
     return;
   }
 
@@ -251,8 +251,9 @@ void WebFrameMain::PostMessage(v8::Isolate* isolate,
   std::vector<gin::Handle<MessagePort>> wrapped_ports;
   if (transfer && !transfer.value()->IsUndefined()) {
     if (!gin::ConvertFromV8(isolate, *transfer, &wrapped_ports)) {
-      isolate->ThrowException(v8::Exception::Error(
-          gin::StringToV8(isolate, "Invalid value for transfer")));
+      isolate->ThrowException(
+          v8::Exception::Error(v8::String::NewFromUtf8Literal(
+              isolate, "Invalid value for transfer")));
       return;
     }
   }

--- a/shell/browser/api/views/electron_api_image_view.cc
+++ b/shell/browser/api/views/electron_api_image_view.cc
@@ -34,7 +34,7 @@ gin_helper::WrappableBase* ImageView::New(gin_helper::Arguments* args) {
 // static
 void ImageView::BuildPrototype(v8::Isolate* isolate,
                                v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(gin::StringToV8(isolate, "ImageView"));
+  prototype->SetClassName(v8::String::NewFromUtf8Literal(isolate, "ImageView"));
   gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("setImage", &ImageView::SetImage);
 }

--- a/shell/browser/ui/cocoa/electron_bundle_mover.mm
+++ b/shell/browser/ui/cocoa/electron_bundle_mover.mm
@@ -26,11 +26,11 @@ struct Converter<electron::BundlerMoverConflictType> {
                                    electron::BundlerMoverConflictType value) {
     switch (value) {
       case electron::BundlerMoverConflictType::kExists:
-        return gin::StringToV8(isolate, "exists");
+        return v8::String::NewFromUtf8Literal(isolate, "exists");
       case electron::BundlerMoverConflictType::kExistsAndRunning:
-        return gin::StringToV8(isolate, "existsAndRunning");
+        return v8::String::NewFromUtf8Literal(isolate, "existsAndRunning");
       default:
-        return gin::StringToV8(isolate, "");
+        return v8::String::NewFromUtf8Literal(isolate, "");
     }
   }
 };

--- a/shell/common/gin_helper/callback.cc
+++ b/shell/common/gin_helper/callback.cc
@@ -143,7 +143,7 @@ v8::Local<v8::Value> BindFunctionWith(v8::Isolate* isolate,
                                       v8::Local<v8::Value> arg1,
                                       v8::Local<v8::Value> arg2) {
   v8::MaybeLocal<v8::Value> bind =
-      func->Get(context, gin::StringToV8(isolate, "bind"));
+      func->Get(context, v8::String::NewFromUtf8Literal(isolate, "bind"));
   CHECK(!bind.IsEmpty());
   v8::Local<v8::Function> bind_func = bind.ToLocalChecked().As<v8::Function>();
   v8::Local<v8::Value> converted[] = {func, arg1, arg2};

--- a/shell/common/v8_value_serializer.cc
+++ b/shell/common/v8_value_serializer.cc
@@ -43,8 +43,9 @@ class V8Serializer : public v8::ValueSerializer::Delegate {
     bool wrote_value;
     if (!serializer_.WriteValue(isolate_->GetCurrentContext(), value)
              .To(&wrote_value)) {
-      isolate_->ThrowException(v8::Exception::Error(
-          gin::StringToV8(isolate_, "An object could not be cloned.")));
+      isolate_->ThrowException(
+          v8::Exception::Error(v8::String::NewFromUtf8Literal(
+              isolate_, "An object could not be cloned.")));
       return false;
     }
     DCHECK(wrote_value);

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -539,7 +539,9 @@ class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
                              const std::string& language,
                              v8::Local<v8::Object> provider) {
     auto context = isolate->GetCurrentContext();
-    if (!provider->Has(context, gin::StringToV8(isolate, "spellCheck"))
+    if (!provider
+             ->Has(context,
+                   v8::String::NewFromUtf8Literal(isolate, "spellCheck"))
              .ToChecked()) {
       thrower.ThrowError("\"spellCheck\" has to be defined");
       return;


### PR DESCRIPTION
#### Description of Change

Use `v8::String::NewFromUtf8Literal()` where possible because it's a little faster than `v8::String::NewFromUtf8()`. We have a lot of places with string literals, e.g. in dictionary getter/setter calls.

From the v8 docs:

> Allocates a new string from a UTF-8 literal. This is equivalent to calling
> String::NewFromUtf(isolate, "...").ToLocalChecked(), but without the check
> overhead.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.