### PR TITLE
chore: bump chromium to 129.0.6632.0

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -2,7 +2,7 @@ gclient_gn_args_from = 'src'
 
 vars = {
   'chromium_version':
-    '129.0.6630.0',
+    '129.0.6632.0',
   'node_version':
     'v20.16.0',
   'nan_version':

--- a/patches/chromium/adjust_accessibility_ui_for_electron.patch
+++ b/patches/chromium/adjust_accessibility_ui_for_electron.patch
@@ -10,10 +10,10 @@ usage of BrowserList and Browser as we subclass related methods and use our
 WindowList.
 
 diff --git a/chrome/browser/ui/webui/accessibility/accessibility_ui.cc b/chrome/browser/ui/webui/accessibility/accessibility_ui.cc
-index 8bf96dc519e1479d8986ff81c3c81641e5e7c58b..a2b70a26febcebedc125c4c83b662b3c77cb428b 100644
+index 125316ef23a7d82d778aca9e40c99144a6d29ba1..a2aa6da83f0d77fd0c1cba864578ff7bcb471510 100644
 --- a/chrome/browser/ui/webui/accessibility/accessibility_ui.cc
 +++ b/chrome/browser/ui/webui/accessibility/accessibility_ui.cc
-@@ -43,6 +43,7 @@
+@@ -48,6 +48,7 @@
  #include "content/public/browser/web_contents.h"
  #include "content/public/browser/web_contents_delegate.h"
  #include "content/public/browser/web_ui_data_source.h"
@@ -21,7 +21,7 @@ index 8bf96dc519e1479d8986ff81c3c81641e5e7c58b..a2b70a26febcebedc125c4c83b662b3c
  #include "ui/accessibility/accessibility_features.h"
  #include "ui/accessibility/ax_updates_and_events.h"
  #include "ui/accessibility/platform/ax_platform_node.h"
-@@ -169,7 +170,7 @@ base::Value::Dict BuildTargetDescriptor(content::RenderViewHost* rvh) {
+@@ -174,7 +175,7 @@ base::Value::Dict BuildTargetDescriptor(content::RenderViewHost* rvh) {
                                 accessibility_mode);
  }
  
@@ -30,7 +30,7 @@ index 8bf96dc519e1479d8986ff81c3c81641e5e7c58b..a2b70a26febcebedc125c4c83b662b3c
  base::Value::Dict BuildTargetDescriptor(Browser* browser) {
    base::Value::Dict target_data;
    target_data.Set(kSessionIdField, browser->session_id().id());
-@@ -203,7 +204,7 @@ void HandleAccessibilityRequestCallback(
+@@ -208,7 +209,7 @@ void HandleAccessibilityRequestCallback(
    DCHECK(ShouldHandleAccessibilityRequestCallback(path));
  
    base::Value::Dict data;
@@ -39,7 +39,7 @@ index 8bf96dc519e1479d8986ff81c3c81641e5e7c58b..a2b70a26febcebedc125c4c83b662b3c
    ui::AXMode mode =
        content::BrowserAccessibilityState::GetInstance()->GetAccessibilityMode();
    bool is_native_enabled = content::BrowserAccessibilityState::GetInstance()
-@@ -236,7 +237,7 @@ void HandleAccessibilityRequestCallback(
+@@ -241,7 +242,7 @@ void HandleAccessibilityRequestCallback(
    data.Set(kViewsAccessibility, features::IsAccessibilityTreeForViewsEnabled());
  
    std::string pref_api_type =
@@ -48,7 +48,7 @@ index 8bf96dc519e1479d8986ff81c3c81641e5e7c58b..a2b70a26febcebedc125c4c83b662b3c
    bool pref_api_type_supported = false;
  
    std::vector<ui::AXApiType::Type> supported_api_types =
-@@ -303,11 +304,11 @@ void HandleAccessibilityRequestCallback(
+@@ -308,11 +309,11 @@ void HandleAccessibilityRequestCallback(
    data.Set(kPagesField, std::move(page_list));
  
    base::Value::List browser_list;
@@ -62,7 +62,7 @@ index 8bf96dc519e1479d8986ff81c3c81641e5e7c58b..a2b70a26febcebedc125c4c83b662b3c
    data.Set(kBrowsersField, std::move(browser_list));
  
    base::Value::List widgets_list;
-@@ -647,7 +648,8 @@ void AccessibilityUIMessageHandler::SetGlobalString(
+@@ -652,7 +653,8 @@ void AccessibilityUIMessageHandler::SetGlobalString(
    const std::string value = CheckJSValue(data.FindString(kValueField));
  
    if (string_name == kApiTypeField) {
@@ -72,7 +72,7 @@ index 8bf96dc519e1479d8986ff81c3c81641e5e7c58b..a2b70a26febcebedc125c4c83b662b3c
      pref->SetString(prefs::kShownAccessibilityApiType, value);
    }
  }
-@@ -700,7 +702,8 @@ void AccessibilityUIMessageHandler::RequestWebContentsTree(
+@@ -705,7 +707,8 @@ void AccessibilityUIMessageHandler::RequestWebContentsTree(
                       AXPropertyFilter::ALLOW_EMPTY);
    AddPropertyFilters(property_filters, deny, AXPropertyFilter::DENY);
  
@@ -82,7 +82,7 @@ index 8bf96dc519e1479d8986ff81c3c81641e5e7c58b..a2b70a26febcebedc125c4c83b662b3c
    ui::AXApiType::Type api_type =
        ui::AXApiType::From(pref->GetString(prefs::kShownAccessibilityApiType));
    std::string accessibility_contents =
-@@ -727,6 +730,7 @@ void AccessibilityUIMessageHandler::RequestNativeUITree(
+@@ -732,6 +735,7 @@ void AccessibilityUIMessageHandler::RequestNativeUITree(
                       AXPropertyFilter::ALLOW_EMPTY);
    AddPropertyFilters(property_filters, deny, AXPropertyFilter::DENY);
  
@@ -90,7 +90,7 @@ index 8bf96dc519e1479d8986ff81c3c81641e5e7c58b..a2b70a26febcebedc125c4c83b662b3c
    for (Browser* browser : *BrowserList::GetInstance()) {
      if (browser->session_id().id() == session_id) {
        base::Value::Dict result = BuildTargetDescriptor(browser);
-@@ -739,6 +743,7 @@ void AccessibilityUIMessageHandler::RequestNativeUITree(
+@@ -744,6 +748,7 @@ void AccessibilityUIMessageHandler::RequestNativeUITree(
        return;
      }
    }
@@ -98,7 +98,7 @@ index 8bf96dc519e1479d8986ff81c3c81641e5e7c58b..a2b70a26febcebedc125c4c83b662b3c
  #endif  // !BUILDFLAG(IS_ANDROID)
    // No browser with the specified |session_id| was found.
    base::Value::Dict result;
-@@ -807,11 +812,13 @@ void AccessibilityUIMessageHandler::StopRecording(
+@@ -812,11 +817,13 @@ void AccessibilityUIMessageHandler::StopRecording(
  }
  
  ui::AXApiType::Type AccessibilityUIMessageHandler::GetRecordingApiType() {
@@ -115,7 +115,7 @@ index 8bf96dc519e1479d8986ff81c3c81641e5e7c58b..a2b70a26febcebedc125c4c83b662b3c
    // Check to see if it is in the supported types list.
    if (std::find(supported_types.begin(), supported_types.end(), api_type) ==
        supported_types.end()) {
-@@ -881,8 +888,11 @@ void AccessibilityUIMessageHandler::RequestAccessibilityEvents(
+@@ -886,8 +893,11 @@ void AccessibilityUIMessageHandler::RequestAccessibilityEvents(
  // static
  void AccessibilityUIMessageHandler::RegisterProfilePrefs(
      user_prefs::PrefRegistrySyncable* registry) {

--- a/patches/chromium/build_do_not_depend_on_packed_resource_integrity.patch
+++ b/patches/chromium/build_do_not_depend_on_packed_resource_integrity.patch
@@ -11,10 +11,10 @@ if we ever align our .pak file generation with Chrome we can remove this
 patch.
 
 diff --git a/chrome/BUILD.gn b/chrome/BUILD.gn
-index 7ef8050aa89bb4132680c6d00d5d6ab3ecfdc713..bcf823da79171196447708b12c6bfd15cb15774b 100644
+index 74c16760fbd0ec88d8cd4e92a6fc9a68c0a3ebe3..f4907e0e2f491078a652baba8302181f090a4d84 100644
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -192,11 +192,16 @@ if (!is_android && !is_mac) {
+@@ -196,11 +196,16 @@ if (!is_android && !is_mac) {
            "common/crash_keys.h",
          ]
  
@@ -33,24 +33,24 @@ index 7ef8050aa89bb4132680c6d00d5d6ab3ecfdc713..bcf823da79171196447708b12c6bfd15
            "//base",
            "//build:branding_buildflags",
 diff --git a/chrome/browser/BUILD.gn b/chrome/browser/BUILD.gn
-index 61c43d1fbd0823dd818de119201856c6ead600ba..fbdd0eb1738e46d78083c0814c306fdee046c829 100644
+index 30fdf95e3a255cbbb05f4634c19cc192b4c72643..724354994e2cd38f9f04159c065282499d5e3f48 100644
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -4605,7 +4605,7 @@ static_library("browser") {
+@@ -4567,7 +4567,7 @@ static_library("browser") {
+       ]
+     }
  
-     # On Windows, the hashes are embedded in //chrome:chrome_initial rather
-     # than here in :chrome_dll.
 -    if (!is_win) {
 +    if (!is_win && !is_electron_build) {
+       # On Windows, the hashes are embedded in //chrome:chrome_initial rather
+       # than here in :chrome_dll.
        deps += [ "//chrome:packed_resources_integrity_header" ]
-       sources += [ "certificate_viewer_stub.cc" ]
-     }
 diff --git a/chrome/test/BUILD.gn b/chrome/test/BUILD.gn
-index d462dcaf73b0b35b2de4b5db06cef90e5e242ee6..6291442ad205a1af5d25d03e3ef65e285045f3bf 100644
+index a469562fbb3cee09500652b4c8873c9681bdca2a..7511bb15b9ec3006f963e272c55c4c0f244d808d 100644
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -7147,9 +7147,12 @@ test("unit_tests") {
-       "//chrome/browser/safe_browsing/incident_reporting/verifier_test:verifier_test_dll_2",
+@@ -7155,9 +7155,12 @@ test("unit_tests") {
+       "//chrome/notification_helper",
      ]
  
 +    if (!is_electron_build) {
@@ -63,7 +63,7 @@ index d462dcaf73b0b35b2de4b5db06cef90e5e242ee6..6291442ad205a1af5d25d03e3ef65e28
        "//chrome//services/util_win:unit_tests",
        "//chrome/app:chrome_dll_resources",
        "//chrome/app:win_unit_tests",
-@@ -8176,6 +8179,10 @@ test("unit_tests") {
+@@ -8186,6 +8189,10 @@ test("unit_tests") {
        "../browser/performance_manager/policies/background_tab_loading_policy_unittest.cc",
      ]
  
@@ -74,7 +74,7 @@ index d462dcaf73b0b35b2de4b5db06cef90e5e242ee6..6291442ad205a1af5d25d03e3ef65e28
      sources += [
        # The importer code is not used on Android.
        "../common/importer/firefox_importer_utils_unittest.cc",
-@@ -8248,7 +8255,6 @@ test("unit_tests") {
+@@ -8258,7 +8265,6 @@ test("unit_tests") {
  
      # Non-android deps for "unit_tests" target.
      deps += [

--- a/patches/chromium/build_make_libcxx_abi_unstable_false_for_electron.patch
+++ b/patches/chromium/build_make_libcxx_abi_unstable_false_for_electron.patch
@@ -6,7 +6,7 @@ Subject: build: make libcxx_abi_unstable false for electron
 https://nornagon.medium.com/a-libc-odyssey-973e51649063
 
 diff --git a/buildtools/third_party/libc++/__config_site b/buildtools/third_party/libc++/__config_site
-index 0d8e1cbe3d59a77bbef5eef0c2fa438923df8a52..1ee58aecb0b95536c3fe922125d9891335d16a9c 100644
+index d5222dbaf15ab1ccebe7b65cb59cf55fdb92542f..dba4c1db441c35798bea61057a586a4b93e973d3 100644
 --- a/buildtools/third_party/libc++/__config_site
 +++ b/buildtools/third_party/libc++/__config_site
 @@ -18,7 +18,9 @@

--- a/patches/chromium/chore_provide_iswebcontentscreationoverridden_with_full_params.patch
+++ b/patches/chromium/chore_provide_iswebcontentscreationoverridden_with_full_params.patch
@@ -80,10 +80,10 @@ index 28cd699814f32a7a569d63936b9544567a66d9c4..fd461fa448d983481dc4c0c7d03b1945
    }
  
 diff --git a/chrome/browser/ui/browser.cc b/chrome/browser/ui/browser.cc
-index 92aa9eb2d38485a388cd6da519fa8feaf8ce0178..ad05a3c7fd5ac74d0af44fa55b83899e41c655e6 100644
+index 9477ad58da9934bc28bddd8bbaab9c7d5a5ff438..61dc5122a8ec925adada339f5c03773b49880591 100644
 --- a/chrome/browser/ui/browser.cc
 +++ b/chrome/browser/ui/browser.cc
-@@ -2117,12 +2117,11 @@ bool Browser::IsWebContentsCreationOverridden(
+@@ -2121,12 +2121,11 @@ bool Browser::IsWebContentsCreationOverridden(
      content::SiteInstance* source_site_instance,
      content::mojom::WindowContainerType window_container_type,
      const GURL& opener_url,
@@ -99,10 +99,10 @@ index 92aa9eb2d38485a388cd6da519fa8feaf8ce0178..ad05a3c7fd5ac74d0af44fa55b83899e
  
  WebContents* Browser::CreateCustomWebContents(
 diff --git a/chrome/browser/ui/browser.h b/chrome/browser/ui/browser.h
-index dcd6b10b61f6afde1e8f46c75a83d7982766d8d9..7cf7c88602c9e1c8292cc8ba49150c663032a948 100644
+index 5e5cbb8a9c0916a558261bffa45d684feb0e0439..59b3d7d18cee6372aed19277a48445228d9c336b 100644
 --- a/chrome/browser/ui/browser.h
 +++ b/chrome/browser/ui/browser.h
-@@ -993,8 +993,7 @@ class Browser : public TabStripModelObserver,
+@@ -994,8 +994,7 @@ class Browser : public TabStripModelObserver,
        content::SiteInstance* source_site_instance,
        content::mojom::WindowContainerType window_container_type,
        const GURL& opener_url,

--- a/patches/chromium/desktop_media_list.patch
+++ b/patches/chromium/desktop_media_list.patch
@@ -22,10 +22,10 @@ index 904c3a99c7d9ab7ffccf2de596950438b2225502..7a879b2f5332f98927c5e3858dd31c5d
    virtual int GetSourceCount() const = 0;
    virtual const Source& GetSource(int index) const = 0;
 diff --git a/chrome/browser/media/webrtc/desktop_media_list_base.cc b/chrome/browser/media/webrtc/desktop_media_list_base.cc
-index 21c713b3b0f8efb17d704cd460ded4a5b15c52e4..d9943ec17ccec0220d4601ea8242ec3a9d8ba5be 100644
+index a1f5b5903d41befdd1f898ee276444edd0db8512..a4d9eaa18e9f7506332275c52bff6dad0639e2cf 100644
 --- a/chrome/browser/media/webrtc/desktop_media_list_base.cc
 +++ b/chrome/browser/media/webrtc/desktop_media_list_base.cc
-@@ -69,12 +69,12 @@ void DesktopMediaListBase::StartUpdating(DesktopMediaListObserver* observer) {
+@@ -74,12 +74,12 @@ void DesktopMediaListBase::StartUpdating(DesktopMediaListObserver* observer) {
    Refresh(true);
  }
  
@@ -82,10 +82,10 @@ index afc2cf89299315cca68b50196c2377a7d474883d..52bfd487d501ef895915800b9ee83a5b
    const Source& GetSource(int index) const override;
    DesktopMediaList::Type GetMediaListType() const override;
 diff --git a/chrome/browser/media/webrtc/native_desktop_media_list.cc b/chrome/browser/media/webrtc/native_desktop_media_list.cc
-index 0ac5817b7e7839cae9caf0680fc128eb88ce95df..f03e7962617111d71c5e6f4ee684805f3da945de 100644
+index 49deff5a994658d7d4d0178573a869674aecc053..db2afc3cb111c83c01a44cc5aa0a8119a32a959e 100644
 --- a/chrome/browser/media/webrtc/native_desktop_media_list.cc
 +++ b/chrome/browser/media/webrtc/native_desktop_media_list.cc
-@@ -171,7 +171,7 @@ BOOL CALLBACK AllHwndCollector(HWND hwnd, LPARAM param) {
+@@ -176,7 +176,7 @@ BOOL CALLBACK AllHwndCollector(HWND hwnd, LPARAM param) {
  #if BUILDFLAG(IS_MAC)
  BASE_FEATURE(kWindowCaptureMacV2,
               "WindowCaptureMacV2",
@@ -94,7 +94,7 @@ index 0ac5817b7e7839cae9caf0680fc128eb88ce95df..f03e7962617111d71c5e6f4ee684805f
  #endif
  
  content::DesktopMediaID::Type ConvertToDesktopMediaIDType(
-@@ -356,7 +356,7 @@ class NativeDesktopMediaList::Worker
+@@ -361,7 +361,7 @@ class NativeDesktopMediaList::Worker
    base::WeakPtr<NativeDesktopMediaList> media_list_;
  
    DesktopMediaID::Type source_type_;
@@ -103,7 +103,7 @@ index 0ac5817b7e7839cae9caf0680fc128eb88ce95df..f03e7962617111d71c5e6f4ee684805f
    const ThumbnailCapturer::FrameDeliveryMethod frame_delivery_method_;
    const bool add_current_process_windows_;
  
-@@ -644,6 +644,12 @@ void NativeDesktopMediaList::Worker::RefreshNextThumbnail() {
+@@ -649,6 +649,12 @@ void NativeDesktopMediaList::Worker::RefreshNextThumbnail() {
        FROM_HERE,
        base::BindOnce(&NativeDesktopMediaList::UpdateNativeThumbnailsFinished,
                       media_list_));
@@ -116,7 +116,7 @@ index 0ac5817b7e7839cae9caf0680fc128eb88ce95df..f03e7962617111d71c5e6f4ee684805f
  }
  
  void NativeDesktopMediaList::Worker::OnCaptureResult(
-@@ -1028,6 +1034,11 @@ void NativeDesktopMediaList::RefreshForVizFrameSinkWindows(
+@@ -1033,6 +1039,11 @@ void NativeDesktopMediaList::RefreshForVizFrameSinkWindows(
          FROM_HERE, base::BindOnce(&Worker::RefreshThumbnails,
                                    base::Unretained(worker_.get()),
                                    std::move(native_ids), thumbnail_size_));

--- a/patches/chromium/disable_hidden.patch
+++ b/patches/chromium/disable_hidden.patch
@@ -6,7 +6,7 @@ Subject: disable_hidden.patch
 Electron uses this to disable background throttling for hidden windows.
 
 diff --git a/content/browser/renderer_host/render_widget_host_impl.cc b/content/browser/renderer_host/render_widget_host_impl.cc
-index daa7119d62f77f46b2e539a6eed99d204461dc32..872270420493edb219d724a412242b6a0db114af 100644
+index a3e64928c558f0959ff7aa3451f3898cf0d1fb18..389045f400ed0bc0af19047ad318f693a6006910 100644
 --- a/content/browser/renderer_host/render_widget_host_impl.cc
 +++ b/content/browser/renderer_host/render_widget_host_impl.cc
 @@ -778,6 +778,9 @@ void RenderWidgetHostImpl::WasHidden() {
@@ -20,10 +20,10 @@ index daa7119d62f77f46b2e539a6eed99d204461dc32..872270420493edb219d724a412242b6a
        blink::mojom::PointerLockResult::kWrongDocument);
  
 diff --git a/content/browser/renderer_host/render_widget_host_impl.h b/content/browser/renderer_host/render_widget_host_impl.h
-index 6f4e44aba5c19fcc2865b070708ef310d6a78d18..b7daed50073b61bf9ceab2c001b52e32cff42bf7 100644
+index 42161abd764655cc753fffd8577a507955e72ce4..b222f105dbc13e726bbd70186a596dbb442c1aed 100644
 --- a/content/browser/renderer_host/render_widget_host_impl.h
 +++ b/content/browser/renderer_host/render_widget_host_impl.h
-@@ -1000,6 +1000,9 @@ class CONTENT_EXPORT RenderWidgetHostImpl
+@@ -1001,6 +1001,9 @@ class CONTENT_EXPORT RenderWidgetHostImpl
    // Requests a commit and forced redraw in the renderer compositor.
    void ForceRedrawForTesting();
  

--- a/patches/chromium/feat_add_data_parameter_to_processsingleton.patch
+++ b/patches/chromium/feat_add_data_parameter_to_processsingleton.patch
@@ -63,10 +63,10 @@ index 31f5b160e4cd755cfb56a62b04261ee1bee80277..8dbc5ac458481d2f805f90101069f02a
  #if BUILDFLAG(IS_WIN)
    bool EscapeVirtualization(const base::FilePath& user_data_dir);
 diff --git a/chrome/browser/process_singleton_posix.cc b/chrome/browser/process_singleton_posix.cc
-index 2205fa3ee2bd2611bad0594680a7cdee270f4f5e..b013b39c3278d539e4238fba1b143bac00c778f3 100644
+index f8cf2fb4ab66dae92b80c17cdda8b984fe4807c7..1a5d5323c0b37171b61f1fb2445dc18e1738f4ba 100644
 --- a/chrome/browser/process_singleton_posix.cc
 +++ b/chrome/browser/process_singleton_posix.cc
-@@ -610,6 +610,7 @@ class ProcessSingleton::LinuxWatcher
+@@ -615,6 +615,7 @@ class ProcessSingleton::LinuxWatcher
    // |reader| is for sending back ACK message.
    void HandleMessage(const std::string& current_dir,
                       const std::vector<std::string>& argv,
@@ -74,7 +74,7 @@ index 2205fa3ee2bd2611bad0594680a7cdee270f4f5e..b013b39c3278d539e4238fba1b143bac
                       SocketReader* reader);
  
    // Called when the ProcessSingleton that owns this class is about to be
-@@ -669,13 +670,17 @@ void ProcessSingleton::LinuxWatcher::StartListening(int socket) {
+@@ -674,13 +675,17 @@ void ProcessSingleton::LinuxWatcher::StartListening(int socket) {
  }
  
  void ProcessSingleton::LinuxWatcher::HandleMessage(
@@ -94,7 +94,7 @@ index 2205fa3ee2bd2611bad0594680a7cdee270f4f5e..b013b39c3278d539e4238fba1b143bac
      // Send back "ACK" message to prevent the client process from starting up.
      reader->FinishWithACK(kACKToken, std::size(kACKToken) - 1);
    } else {
-@@ -723,7 +728,8 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
+@@ -728,7 +733,8 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
      }
    }
  
@@ -104,7 +104,7 @@ index 2205fa3ee2bd2611bad0594680a7cdee270f4f5e..b013b39c3278d539e4238fba1b143bac
    const size_t kMinMessageLength = std::size(kStartToken) + 4;
    if (bytes_read_ < kMinMessageLength) {
      buf_[bytes_read_] = 0;
-@@ -753,10 +759,28 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
+@@ -758,10 +764,28 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
    tokens.erase(tokens.begin());
    tokens.erase(tokens.begin());
  
@@ -134,7 +134,7 @@ index 2205fa3ee2bd2611bad0594680a7cdee270f4f5e..b013b39c3278d539e4238fba1b143bac
    fd_watch_controller_.reset();
  
    // LinuxWatcher::HandleMessage() is in charge of destroying this SocketReader
-@@ -785,8 +809,10 @@ void ProcessSingleton::LinuxWatcher::SocketReader::FinishWithACK(
+@@ -790,8 +814,10 @@ void ProcessSingleton::LinuxWatcher::SocketReader::FinishWithACK(
  //
  ProcessSingleton::ProcessSingleton(
      const base::FilePath& user_data_dir,
@@ -145,7 +145,7 @@ index 2205fa3ee2bd2611bad0594680a7cdee270f4f5e..b013b39c3278d539e4238fba1b143bac
        current_pid_(base::GetCurrentProcId()) {
    socket_path_ = user_data_dir.Append(chrome::kSingletonSocketFilename);
    lock_path_ = user_data_dir.Append(chrome::kSingletonLockFilename);
-@@ -907,7 +933,8 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
+@@ -912,7 +938,8 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
               sizeof(socket_timeout));
  
    // Found another process, prepare our command line
@@ -155,7 +155,7 @@ index 2205fa3ee2bd2611bad0594680a7cdee270f4f5e..b013b39c3278d539e4238fba1b143bac
    std::string to_send(kStartToken);
    to_send.push_back(kTokenDelimiter);
  
-@@ -917,11 +944,21 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
+@@ -922,11 +949,21 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
    to_send.append(current_dir.value());
  
    const std::vector<std::string>& argv = cmd_line.argv();

--- a/patches/chromium/feat_enable_offscreen_rendering_with_viz_compositor.patch
+++ b/patches/chromium/feat_enable_offscreen_rendering_with_viz_compositor.patch
@@ -90,10 +90,10 @@ index 8af69cac78b7488d28f1f05ccb174793fe5148cd..9f74e511c263d147b5fbe81fe100d217
   private:
    const HWND hwnd_;
 diff --git a/components/viz/service/BUILD.gn b/components/viz/service/BUILD.gn
-index 002b83ff8b81e485739658c8ae236b06b8d36c4d..256266d6e6c8bcd052fb075e2b9f83530174c057 100644
+index 1c5e059cee6593f61270559a58cee7450b52ab8c..d4ac7f62b59c1948b2ec341109d27422ca8dda04 100644
 --- a/components/viz/service/BUILD.gn
 +++ b/components/viz/service/BUILD.gn
-@@ -173,6 +173,8 @@ viz_component("service") {
+@@ -172,6 +172,8 @@ viz_component("service") {
      "display_embedder/skia_output_surface_impl_on_gpu_debug_capture.h",
      "display_embedder/skia_render_copy_results.cc",
      "display_embedder/skia_render_copy_results.h",

--- a/patches/chromium/fix_add_support_for_skipping_first_2_no-op_refreshes_in_thumb_cap.patch
+++ b/patches/chromium/fix_add_support_for_skipping_first_2_no-op_refreshes_in_thumb_cap.patch
@@ -27,10 +27,10 @@ index 7a879b2f5332f98927c5e3858dd31c5de169e5ce..75191362088d2d875330fb2044a4682b
  
  #endif  // CHROME_BROWSER_MEDIA_WEBRTC_DESKTOP_MEDIA_LIST_H_
 diff --git a/chrome/browser/media/webrtc/desktop_media_list_base.cc b/chrome/browser/media/webrtc/desktop_media_list_base.cc
-index d9943ec17ccec0220d4601ea8242ec3a9d8ba5be..5d9029538c690c3d904bd6b39949387931997fdc 100644
+index a4d9eaa18e9f7506332275c52bff6dad0639e2cf..54492210154e3b02e8640cd63b7ec428e81c85d7 100644
 --- a/chrome/browser/media/webrtc/desktop_media_list_base.cc
 +++ b/chrome/browser/media/webrtc/desktop_media_list_base.cc
-@@ -230,7 +230,11 @@ uint32_t DesktopMediaListBase::GetImageHash(const gfx::Image& image) {
+@@ -235,7 +235,11 @@ uint32_t DesktopMediaListBase::GetImageHash(const gfx::Image& image) {
  void DesktopMediaListBase::OnRefreshComplete() {
    DCHECK_CURRENTLY_ON(BrowserThread::UI);
    DCHECK(refresh_callback_);

--- a/patches/chromium/fix_crash_loading_non-standard_schemes_in_iframes.patch
+++ b/patches/chromium/fix_crash_loading_non-standard_schemes_in_iframes.patch
@@ -23,10 +23,10 @@ Upstream bug https://bugs.chromium.org/p/chromium/issues/detail?id=1081397.
 Upstreamed at https://chromium-review.googlesource.com/c/chromium/src/+/3856266.
 
 diff --git a/content/browser/renderer_host/navigation_request.cc b/content/browser/renderer_host/navigation_request.cc
-index fae6cb2e6eeac865825bfcbc79f0fb96aa66d266..1ebc636d40543183d06f8623ae0698c4331a6609 100644
+index 70baa92dfb7782a9b5850f8fd246b0aa0ca46de6..1f4b8f68e2fc974cd8ceafb91916dd994349c69e 100644
 --- a/content/browser/renderer_host/navigation_request.cc
 +++ b/content/browser/renderer_host/navigation_request.cc
-@@ -10704,6 +10704,12 @@ NavigationRequest::GetOriginForURLLoaderFactoryUncheckedWithDebugInfo() {
+@@ -10729,6 +10729,12 @@ NavigationRequest::GetOriginForURLLoaderFactoryUncheckedWithDebugInfo() {
      }
    }
  

--- a/patches/chromium/fix_restore_original_resize_performance_on_macos.patch
+++ b/patches/chromium/fix_restore_original_resize_performance_on_macos.patch
@@ -11,10 +11,10 @@ This patch should be upstreamed as a conditional revert of the logic in desktop
 vs mobile runtimes.  i.e. restore the old logic only on desktop platforms
 
 diff --git a/content/browser/renderer_host/render_widget_host_impl.cc b/content/browser/renderer_host/render_widget_host_impl.cc
-index ad8d5236fe2b9f55462445b2fc332a27e588a8e0..f392a2d3d4066deef9ea22a2affe098d95f64111 100644
+index a06a04c3e1c40370fa04b7bc34f0a3adc9832169..e3f5da2087616300d4765c23f7b8bc190deca4df 100644
 --- a/content/browser/renderer_host/render_widget_host_impl.cc
 +++ b/content/browser/renderer_host/render_widget_host_impl.cc
-@@ -2021,9 +2021,8 @@ RenderWidgetHostImpl::GetWidgetInputHandler() {
+@@ -2026,9 +2026,8 @@ RenderWidgetHostImpl::GetWidgetInputHandler() {
  void RenderWidgetHostImpl::NotifyScreenInfoChanged() {
    // The resize message (which may not happen immediately) will carry with it
    // the screen info as well as the new size (if the screen has changed scale

--- a/patches/chromium/fix_return_v8_value_from_localframe_requestexecutescript.patch
+++ b/patches/chromium/fix_return_v8_value_from_localframe_requestexecutescript.patch
@@ -216,7 +216,7 @@ index db1cc198dfc40ce359bad4157a4aad396e1be1a0..424fa3415a9f7d44a8422ecf0eb3670b
        mojom::blink::WantResultOption::kWantResult, wait_for_promise);
  }
 diff --git a/third_party/blink/renderer/core/frame/web_local_frame_impl.cc b/third_party/blink/renderer/core/frame/web_local_frame_impl.cc
-index e9b2bddc2bf046baa94273d9785087c9235bd7d1..56d5140360395c1bccb03136334fd95b3a5d6686 100644
+index 2079ffada65df5773909f25cb0c6645a3f6b3aab..e1dea864e10a106993d6d713f9b5db06c174adf0 100644
 --- a/third_party/blink/renderer/core/frame/web_local_frame_impl.cc
 +++ b/third_party/blink/renderer/core/frame/web_local_frame_impl.cc
 @@ -1095,14 +1095,15 @@ void WebLocalFrameImpl::RequestExecuteScript(

--- a/patches/chromium/mas_avoid_private_macos_api_usage.patch.patch
+++ b/patches/chromium/mas_avoid_private_macos_api_usage.patch.patch
@@ -35,7 +35,7 @@ system font by checking if it's kCTFontPriorityAttribute is set to
 system priority.
 
 diff --git a/base/BUILD.gn b/base/BUILD.gn
-index dbaf22d68f67cb227a5fc2c774fd582af7715dcc..406bc05f8f4b368f18c6e8264fa5ad6e70d6fe1e 100644
+index f23f880efa562ed992eb9dc92946437b2151d1f1..848f860907f118a8f6cea188601e0873397265cd 100644
 --- a/base/BUILD.gn
 +++ b/base/BUILD.gn
 @@ -1050,6 +1050,7 @@ component("base") {
@@ -379,10 +379,10 @@ index b3c087eda0561d94d205ef0cbbb341a7e2a34638..035202378209e32e6f7c630140367cda
    // Beware: This view was briefly removed (in favor of a bare CALayer) in
    // https://crrev.com/c/1236675. The ordering of unassociated layers relative
 diff --git a/components/viz/service/BUILD.gn b/components/viz/service/BUILD.gn
-index b5d3072f31aa3a07f5e650c3e0299c4e26e8113a..002b83ff8b81e485739658c8ae236b06b8d36c4d 100644
+index 5162f0de437618af7ce9de59209e090ac56881b9..1c5e059cee6593f61270559a58cee7450b52ab8c 100644
 --- a/components/viz/service/BUILD.gn
 +++ b/components/viz/service/BUILD.gn
-@@ -368,6 +368,7 @@ viz_component("service") {
+@@ -367,6 +367,7 @@ viz_component("service") {
          "frame_sinks/external_begin_frame_source_mac.h",
        ]
      }
@@ -390,7 +390,7 @@ index b5d3072f31aa3a07f5e650c3e0299c4e26e8113a..002b83ff8b81e485739658c8ae236b06
    }
  
    if (is_android || use_ozone) {
-@@ -641,6 +642,7 @@ viz_source_set("unit_tests") {
+@@ -639,6 +640,7 @@ viz_source_set("unit_tests") {
        "display_embedder/software_output_device_mac_unittest.mm",
      ]
      frameworks = [ "IOSurface.framework" ]

--- a/patches/chromium/notification_provenance.patch
+++ b/patches/chromium/notification_provenance.patch
@@ -133,7 +133,7 @@ index 46b071609e56e8602b04d1cd9f5f4ebd7e4f4ae1..6092383e0f8f1c0d829a8ef8af53a786
        const GURL& document_url,
        const WeakDocumentPtr& weak_document_ptr,
 diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content/browser/renderer_host/render_process_host_impl.cc
-index dd2c6144fbc99a572282bdb8e0b5f0d9a169f308..bd77d2cf5018c453a753b2f160a382821c84ab78 100644
+index 7ac8e5e171c277a6452009ffadf09f5a685c584b..46b205e47314627bcc0ffd03a28a29c103e523ab 100644
 --- a/content/browser/renderer_host/render_process_host_impl.cc
 +++ b/content/browser/renderer_host/render_process_host_impl.cc
 @@ -1975,7 +1975,7 @@ void RenderProcessHostImpl::CreateNotificationService(

--- a/patches/chromium/pepper_plugin_support.patch
+++ b/patches/chromium/pepper_plugin_support.patch
@@ -7,10 +7,10 @@ This tweaks Chrome's pepper flash and PDF plugin support to make it
 usable from Electron.
 
 diff --git a/chrome/browser/renderer_host/pepper/pepper_isolated_file_system_message_filter.cc b/chrome/browser/renderer_host/pepper/pepper_isolated_file_system_message_filter.cc
-index 6c0f86dc6f588891f9e4b2ff00f39727fd6e03ef..99b8a4d6fe607ce9b502985c971ce3888aee49b5 100644
+index 46513bf122445f822917a1a80d5d9079f288e1b4..7becf2e72ca677335dbd241fa0fef30768a3fc28 100644
 --- a/chrome/browser/renderer_host/pepper/pepper_isolated_file_system_message_filter.cc
 +++ b/chrome/browser/renderer_host/pepper/pepper_isolated_file_system_message_filter.cc
-@@ -7,17 +7,21 @@
+@@ -12,17 +12,21 @@
  #include <stddef.h>
  
  #include "base/task/sequenced_task_runner.h"
@@ -32,7 +32,7 @@ index 6c0f86dc6f588891f9e4b2ff00f39727fd6e03ef..99b8a4d6fe607ce9b502985c971ce388
  #include "ppapi/c/pp_errors.h"
  #include "ppapi/host/dispatch_host_message.h"
  #include "ppapi/host/host_message_context.h"
-@@ -26,12 +30,11 @@
+@@ -31,12 +35,11 @@
  #include "ppapi/shared_impl/file_system_util.h"
  #include "storage/browser/file_system/isolated_context.h"
  
@@ -46,7 +46,7 @@ index 6c0f86dc6f588891f9e4b2ff00f39727fd6e03ef..99b8a4d6fe607ce9b502985c971ce388
  
  namespace {
  
-@@ -41,6 +44,7 @@ const char* kPredefinedAllowedCrxFsOrigins[] = {
+@@ -46,6 +49,7 @@ const char* kPredefinedAllowedCrxFsOrigins[] = {
  };
  
  }  // namespace
@@ -54,7 +54,7 @@ index 6c0f86dc6f588891f9e4b2ff00f39727fd6e03ef..99b8a4d6fe607ce9b502985c971ce388
  
  // static
  PepperIsolatedFileSystemMessageFilter*
-@@ -64,11 +68,16 @@ PepperIsolatedFileSystemMessageFilter::PepperIsolatedFileSystemMessageFilter(
+@@ -69,11 +73,16 @@ PepperIsolatedFileSystemMessageFilter::PepperIsolatedFileSystemMessageFilter(
      const base::FilePath& profile_directory,
      const GURL& document_url,
      ppapi::host::PpapiHost* ppapi_host)
@@ -71,7 +71,7 @@ index 6c0f86dc6f588891f9e4b2ff00f39727fd6e03ef..99b8a4d6fe607ce9b502985c971ce388
  }
  
  PepperIsolatedFileSystemMessageFilter::
-@@ -93,6 +102,7 @@ int32_t PepperIsolatedFileSystemMessageFilter::OnResourceMessageReceived(
+@@ -98,6 +107,7 @@ int32_t PepperIsolatedFileSystemMessageFilter::OnResourceMessageReceived(
    return PP_ERROR_FAILED;
  }
  
@@ -79,7 +79,7 @@ index 6c0f86dc6f588891f9e4b2ff00f39727fd6e03ef..99b8a4d6fe607ce9b502985c971ce388
  Profile* PepperIsolatedFileSystemMessageFilter::GetProfile() {
    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
    ProfileManager* profile_manager = g_browser_process->profile_manager();
-@@ -117,6 +127,7 @@ PepperIsolatedFileSystemMessageFilter::CreateCrxFileSystem(Profile* profile) {
+@@ -122,6 +132,7 @@ PepperIsolatedFileSystemMessageFilter::CreateCrxFileSystem(Profile* profile) {
    return storage::IsolatedContext::ScopedFSHandle();
  #endif
  }
@@ -87,7 +87,7 @@ index 6c0f86dc6f588891f9e4b2ff00f39727fd6e03ef..99b8a4d6fe607ce9b502985c971ce388
  
  int32_t PepperIsolatedFileSystemMessageFilter::OnOpenFileSystem(
      ppapi::host::HostMessageContext* context,
-@@ -125,7 +136,7 @@ int32_t PepperIsolatedFileSystemMessageFilter::OnOpenFileSystem(
+@@ -130,7 +141,7 @@ int32_t PepperIsolatedFileSystemMessageFilter::OnOpenFileSystem(
      case PP_ISOLATEDFILESYSTEMTYPE_PRIVATE_INVALID:
        break;
      case PP_ISOLATEDFILESYSTEMTYPE_PRIVATE_CRX:
@@ -96,7 +96,7 @@ index 6c0f86dc6f588891f9e4b2ff00f39727fd6e03ef..99b8a4d6fe607ce9b502985c971ce388
    }
    NOTREACHED_IN_MIGRATION();
    context->reply_msg =
-@@ -133,6 +144,7 @@ int32_t PepperIsolatedFileSystemMessageFilter::OnOpenFileSystem(
+@@ -138,6 +149,7 @@ int32_t PepperIsolatedFileSystemMessageFilter::OnOpenFileSystem(
    return PP_ERROR_FAILED;
  }
  
@@ -104,7 +104,7 @@ index 6c0f86dc6f588891f9e4b2ff00f39727fd6e03ef..99b8a4d6fe607ce9b502985c971ce388
  int32_t PepperIsolatedFileSystemMessageFilter::OpenCrxFileSystem(
      ppapi::host::HostMessageContext* context) {
  #if BUILDFLAG(ENABLE_EXTENSIONS)
-@@ -173,3 +185,4 @@ int32_t PepperIsolatedFileSystemMessageFilter::OpenCrxFileSystem(
+@@ -178,3 +190,4 @@ int32_t PepperIsolatedFileSystemMessageFilter::OpenCrxFileSystem(
    return PP_ERROR_NOTSUPPORTED;
  #endif
  }

--- a/patches/chromium/process_singleton.patch
+++ b/patches/chromium/process_singleton.patch
@@ -51,10 +51,10 @@ index 23a8257aa2a0a671cf7af35aff9906891091606d..31f5b160e4cd755cfb56a62b04261ee1
    base::win::MessageWindow window_;  // The message-only window.
    bool is_virtualized_;  // Stuck inside Microsoft Softricity VM environment.
 diff --git a/chrome/browser/process_singleton_posix.cc b/chrome/browser/process_singleton_posix.cc
-index c3cf6e083105159fbb815f3754423d276d416036..2205fa3ee2bd2611bad0594680a7cdee270f4f5e 100644
+index 14b9c99e81e0999d1a2e25557e6a731ec88f6a22..f8cf2fb4ab66dae92b80c17cdda8b984fe4807c7 100644
 --- a/chrome/browser/process_singleton_posix.cc
 +++ b/chrome/browser/process_singleton_posix.cc
-@@ -54,6 +54,7 @@
+@@ -59,6 +59,7 @@
  #include <memory>
  #include <set>
  #include <string>
@@ -62,7 +62,7 @@ index c3cf6e083105159fbb815f3754423d276d416036..2205fa3ee2bd2611bad0594680a7cdee
  #include <type_traits>
  
  #include "base/base_paths.h"
-@@ -81,6 +82,7 @@
+@@ -86,6 +87,7 @@
  #include "base/strings/utf_string_conversions.h"
  #include "base/task/sequenced_task_runner_helpers.h"
  #include "base/task/single_thread_task_runner.h"
@@ -70,7 +70,7 @@ index c3cf6e083105159fbb815f3754423d276d416036..2205fa3ee2bd2611bad0594680a7cdee
  #include "base/threading/platform_thread.h"
  #include "base/time/time.h"
  #include "base/timer/timer.h"
-@@ -97,7 +99,7 @@
+@@ -102,7 +104,7 @@
  #include "ui/base/l10n/l10n_util.h"
  #include "ui/base/resource/scoped_startup_resource_bundle.h"
  
@@ -79,7 +79,7 @@ index c3cf6e083105159fbb815f3754423d276d416036..2205fa3ee2bd2611bad0594680a7cdee
  #include "chrome/browser/ui/process_singleton_dialog_linux.h"
  #endif
  
-@@ -343,6 +345,8 @@ bool SymlinkPath(const base::FilePath& target, const base::FilePath& path) {
+@@ -348,6 +350,8 @@ bool SymlinkPath(const base::FilePath& target, const base::FilePath& path) {
  bool DisplayProfileInUseError(const base::FilePath& lock_path,
                                const std::string& hostname,
                                int pid) {
@@ -88,7 +88,7 @@ index c3cf6e083105159fbb815f3754423d276d416036..2205fa3ee2bd2611bad0594680a7cdee
    // Ensure there is an instance of ResourceBundle that is initialized for
    // localized string resource accesses.
    ui::ScopedStartupResourceBundle ensure_startup_resource_bundle;
-@@ -366,6 +370,7 @@ bool DisplayProfileInUseError(const base::FilePath& lock_path,
+@@ -371,6 +375,7 @@ bool DisplayProfileInUseError(const base::FilePath& lock_path,
  
    NOTREACHED_IN_MIGRATION();
    return false;
@@ -96,7 +96,7 @@ index c3cf6e083105159fbb815f3754423d276d416036..2205fa3ee2bd2611bad0594680a7cdee
  }
  
  bool IsChromeProcess(pid_t pid) {
-@@ -378,6 +383,21 @@ bool IsChromeProcess(pid_t pid) {
+@@ -383,6 +388,21 @@ bool IsChromeProcess(pid_t pid) {
                base::FilePath(chrome::kBrowserProcessExecutableName));
  }
  
@@ -118,7 +118,7 @@ index c3cf6e083105159fbb815f3754423d276d416036..2205fa3ee2bd2611bad0594680a7cdee
  // A helper class to hold onto a socket.
  class ScopedSocket {
   public:
-@@ -781,6 +801,10 @@ ProcessSingleton::~ProcessSingleton() {
+@@ -786,6 +806,10 @@ ProcessSingleton::~ProcessSingleton() {
    if (watcher_) {
      watcher_->OnEminentProcessSingletonDestruction();
    }
@@ -129,7 +129,7 @@ index c3cf6e083105159fbb815f3754423d276d416036..2205fa3ee2bd2611bad0594680a7cdee
  }
  
  ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcess() {
-@@ -1048,11 +1072,32 @@ bool ProcessSingleton::Create() {
+@@ -1053,11 +1077,32 @@ bool ProcessSingleton::Create() {
    // Create the socket file somewhere in /tmp which is usually mounted as a
    // normal filesystem. Some network filesystems (notably AFS) are screwy and
    // do not support Unix domain sockets.

--- a/patches/chromium/refactor_expose_cursor_changes_to_the_webcontentsobserver.patch
+++ b/patches/chromium/refactor_expose_cursor_changes_to_the_webcontentsobserver.patch
@@ -30,10 +30,10 @@ index eaca11c1b16ee0befe8f5bfd3735a582a63cbd81..9f042cd993e46993826634772714c4f2
    // RenderWidgetHost on the primary main frame, and false otherwise.
    virtual bool IsWidgetForPrimaryMainFrame(RenderWidgetHostImpl*);
 diff --git a/content/browser/renderer_host/render_widget_host_impl.cc b/content/browser/renderer_host/render_widget_host_impl.cc
-index 872270420493edb219d724a412242b6a0db114af..ad8d5236fe2b9f55462445b2fc332a27e588a8e0 100644
+index 389045f400ed0bc0af19047ad318f693a6006910..a06a04c3e1c40370fa04b7bc34f0a3adc9832169 100644
 --- a/content/browser/renderer_host/render_widget_host_impl.cc
 +++ b/content/browser/renderer_host/render_widget_host_impl.cc
-@@ -1955,6 +1955,9 @@ void RenderWidgetHostImpl::SetCursor(const ui::Cursor& cursor) {
+@@ -1960,6 +1960,9 @@ void RenderWidgetHostImpl::SetCursor(const ui::Cursor& cursor) {
    if (view_) {
      view_->UpdateCursor(cursor);
    }

--- a/patches/chromium/refactor_expose_hostimportmoduledynamically_and.patch
+++ b/patches/chromium/refactor_expose_hostimportmoduledynamically_and.patch
@@ -7,7 +7,7 @@ Subject: refactor: expose HostImportModuleDynamically and
 This is so that Electron can blend Blink's and Node's implementations of these isolate handlers.
 
 diff --git a/third_party/blink/renderer/bindings/core/v8/v8_initializer.cc b/third_party/blink/renderer/bindings/core/v8/v8_initializer.cc
-index c17479e167de17b4ed02be7934a7c3ac7a020ed1..a1d5426f62f24395a7304dce7b040755e7f7b941 100644
+index c7254525d2940f6f2603d208e26b2f22f75fe6f3..36f6e131ecb135d011b271d2cdbaebf5faeb883b 100644
 --- a/third_party/blink/renderer/bindings/core/v8/v8_initializer.cc
 +++ b/third_party/blink/renderer/bindings/core/v8/v8_initializer.cc
 @@ -609,7 +609,9 @@ bool WasmJSPromiseIntegrationEnabledCallback(v8::Local<v8::Context> context) {

--- a/patches/chromium/resource_file_conflict.patch
+++ b/patches/chromium/resource_file_conflict.patch
@@ -52,10 +52,10 @@ Some alternatives to this patch:
 None of these options seems like a substantial maintainability win over this patch to me (@nornagon).
 
 diff --git a/chrome/BUILD.gn b/chrome/BUILD.gn
-index a8c87a5d595af314ff9592b5795346b6859ff60b..7ef8050aa89bb4132680c6d00d5d6ab3ecfdc713 100644
+index 373076ca15f7bc00f74990716c78a37e902c84b2..74c16760fbd0ec88d8cd4e92a6fc9a68c0a3ebe3 100644
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1567,7 +1567,7 @@ if (is_chrome_branded && !is_android) {
+@@ -1571,7 +1571,7 @@ if (is_chrome_branded && !is_android) {
    }
  }
  
@@ -64,7 +64,7 @@ index a8c87a5d595af314ff9592b5795346b6859ff60b..7ef8050aa89bb4132680c6d00d5d6ab3
    chrome_paks("packed_resources") {
      if (is_mac) {
        output_dir = "$root_gen_dir/repack"
-@@ -1606,6 +1606,12 @@ if (!is_android) {
+@@ -1610,6 +1610,12 @@ if (!is_android) {
    }
  }
  

--- a/patches/chromium/support_mixed_sandbox_with_zygote.patch
+++ b/patches/chromium/support_mixed_sandbox_with_zygote.patch
@@ -22,7 +22,7 @@ However, the patch would need to be reviewed by the security team, as it
 does touch a security-sensitive class.
 
 diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content/browser/renderer_host/render_process_host_impl.cc
-index bd77d2cf5018c453a753b2f160a382821c84ab78..c916c631535cb428c31436bc54bfa2dff7cd8c71 100644
+index 46b205e47314627bcc0ffd03a28a29c103e523ab..0e82358006724f6eb2c12a400a877331fdbb5988 100644
 --- a/content/browser/renderer_host/render_process_host_impl.cc
 +++ b/content/browser/renderer_host/render_process_host_impl.cc
 @@ -1612,9 +1612,15 @@ bool RenderProcessHostImpl::Init() {

--- a/patches/devtools_frontend/chore_expose_ui_to_allow_electron_to_set_dock_side.patch
+++ b/patches/devtools_frontend/chore_expose_ui_to_allow_electron_to_set_dock_side.patch
@@ -10,10 +10,10 @@ to handle this without patching, but this is fairly clean for now and no longer 
 patching legacy devtools code.
 
 diff --git a/front_end/entrypoints/main/MainImpl.ts b/front_end/entrypoints/main/MainImpl.ts
-index fbded4d8e5cbe4b7134a1438799ee46800198113..bf713c9f4f168175e9de9e9c2a68b7df9c3eba06 100644
+index 5f03f3197a5302e76a396ce27dd7f95384a96250..3ae373b68b198d28d92b2227be07956e0673b504 100644
 --- a/front_end/entrypoints/main/MainImpl.ts
 +++ b/front_end/entrypoints/main/MainImpl.ts
-@@ -741,6 +741,8 @@ export class MainImpl {
+@@ -746,6 +746,8 @@ export class MainImpl {
  globalThis.Main = globalThis.Main || {};
  // @ts-ignore Exported for Tests.js
  globalThis.Main.Main = MainImpl;

--- a/patches/v8/fix_disable_scope_reuse_associated_dchecks.patch
+++ b/patches/v8/fix_disable_scope_reuse_associated_dchecks.patch
@@ -42,7 +42,7 @@ index 63595b84b71957a81c50d054b8db573be9d9d981..f23453f86cb0786d59328177be1a9bc6
  #endif
      if (!scope->is_function_scope() ||
 diff --git a/src/flags/flag-definitions.h b/src/flags/flag-definitions.h
-index df04f66444cb4aee60244a19e38775033efe7fe8..b9414b7e830b4b1a102ed2b277a4aa8ab3cbc351 100644
+index 41dfc4f9ed0e17b3e808922c65167551a937d3df..5547c52e34d91fa2dcf122c3e1043829f345658b 100644
 --- a/src/flags/flag-definitions.h
 +++ b/src/flags/flag-definitions.h
 @@ -979,7 +979,12 @@ DEFINE_BOOL(trace_track_allocation_sites, false,


### PR DESCRIPTION
Updating Chromium to 129.0.6632.0.

See [all changes in 129.0.6630.0..129.0.6632.0](https://chromium.googlesource.com/chromium/src/+log/129.0.6630.0..129.0.6632.0?n=10000&pretty=fuller)

<!--
Original-Version: 129.0.6630.0
-->

Notes: Updated Chromium to 129.0.6632.0.