### PR TITLE
fix: gin_helper::MicrotasksScope instantiation

### DIFF
--- a/shell/browser/api/electron_api_auto_updater.cc
+++ b/shell/browser/api/electron_api_auto_updater.cc
@@ -46,9 +46,9 @@ void AutoUpdater::OnError(const std::string& message) {
         gin::StringToV8(isolate, message),
     };
 
-    gin_helper::MicrotasksScope microtasks_scope(
+    gin_helper::MicrotasksScope microtasks_scope{
         isolate, wrapper->GetCreationContextChecked()->GetMicrotaskQueue(),
-        true);
+        true, v8::MicrotasksScope::kRunMicrotasks};
 
     node::MakeCallback(isolate, wrapper, "emit", args.size(), args.data(),
                        {0, 0});

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -237,8 +237,9 @@ void ElectronBindings::DidReceiveMemoryDump(
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Context> local_context =
       v8::Local<v8::Context>::New(isolate, context);
-  gin_helper::MicrotasksScope microtasks_scope(
-      isolate, local_context->GetMicrotaskQueue(), true);
+  gin_helper::MicrotasksScope microtasks_scope{
+      isolate, local_context->GetMicrotaskQueue(), true,
+      v8::MicrotasksScope::kRunMicrotasks};
   v8::Context::Scope context_scope(local_context);
 
   if (!success) {

--- a/shell/common/gin_helper/callback.h
+++ b/shell/common/gin_helper/callback.h
@@ -50,8 +50,9 @@ struct V8FunctionInvoker<v8::Local<v8::Value>(ArgTypes...)> {
       return v8::Null(isolate);
     v8::Local<v8::Function> holder = function.NewHandle(isolate);
     v8::Local<v8::Context> context = holder->GetCreationContextChecked();
-    gin_helper::MicrotasksScope microtasks_scope(
-        isolate, context->GetMicrotaskQueue(), true);
+    gin_helper::MicrotasksScope microtasks_scope{
+        isolate, context->GetMicrotaskQueue(), true,
+        v8::MicrotasksScope::kRunMicrotasks};
     v8::Context::Scope context_scope(context);
     std::vector<v8::Local<v8::Value>> args{
         gin::ConvertToV8(isolate, std::forward<ArgTypes>(raw))...};
@@ -75,8 +76,9 @@ struct V8FunctionInvoker<void(ArgTypes...)> {
       return;
     v8::Local<v8::Function> holder = function.NewHandle(isolate);
     v8::Local<v8::Context> context = holder->GetCreationContextChecked();
-    gin_helper::MicrotasksScope microtasks_scope(
-        isolate, context->GetMicrotaskQueue(), true);
+    gin_helper::MicrotasksScope microtasks_scope{
+        isolate, context->GetMicrotaskQueue(), true,
+        v8::MicrotasksScope::kRunMicrotasks};
     v8::Context::Scope context_scope(context);
     std::vector<v8::Local<v8::Value>> args{
         gin::ConvertToV8(isolate, std::forward<ArgTypes>(raw))...};
@@ -99,8 +101,9 @@ struct V8FunctionInvoker<ReturnType(ArgTypes...)> {
       return ret;
     v8::Local<v8::Function> holder = function.NewHandle(isolate);
     v8::Local<v8::Context> context = holder->GetCreationContextChecked();
-    gin_helper::MicrotasksScope microtasks_scope(
-        isolate, context->GetMicrotaskQueue(), true);
+    gin_helper::MicrotasksScope microtasks_scope{
+        isolate, context->GetMicrotaskQueue(), true,
+        v8::MicrotasksScope::kRunMicrotasks};
     v8::Context::Scope context_scope(context);
     std::vector<v8::Local<v8::Value>> args{
         gin::ConvertToV8(isolate, std::forward<ArgTypes>(raw))...};

--- a/shell/common/gin_helper/event_emitter_caller.cc
+++ b/shell/common/gin_helper/event_emitter_caller.cc
@@ -24,8 +24,9 @@ v8::Local<v8::Value> CallMethodWithArgs(v8::Isolate* isolate,
   }
 
   // Perform microtask checkpoint after running JavaScript.
-  gin_helper::MicrotasksScope microtasks_scope(
-      isolate, obj->GetCreationContextChecked()->GetMicrotaskQueue(), true);
+  gin_helper::MicrotasksScope microtasks_scope{
+      isolate, obj->GetCreationContextChecked()->GetMicrotaskQueue(), true,
+      v8::MicrotasksScope::kRunMicrotasks};
 
   // node::MakeCallback will also run pending tasks in Node.js.
   v8::MaybeLocal<v8::Value> ret = node::MakeCallback(

--- a/shell/common/gin_helper/function_template.h
+++ b/shell/common/gin_helper/function_template.h
@@ -267,9 +267,10 @@ class Invoker<std::index_sequence<indices...>, ArgTypes...>
   template <typename ReturnType>
   void DispatchToCallback(
       base::RepeatingCallback<ReturnType(ArgTypes...)> callback) {
-    gin_helper::MicrotasksScope microtasks_scope(
+    gin_helper::MicrotasksScope microtasks_scope{
         args_->isolate(),
-        args_->GetHolderCreationContext()->GetMicrotaskQueue(), true);
+        args_->GetHolderCreationContext()->GetMicrotaskQueue(), true,
+        v8::MicrotasksScope::kRunMicrotasks};
     args_->Return(
         callback.Run(std::move(ArgumentHolder<indices, ArgTypes>::value)...));
   }
@@ -278,9 +279,10 @@ class Invoker<std::index_sequence<indices...>, ArgTypes...>
   // expression to foo. As a result, we must specialize the case of Callbacks
   // that have the void return type.
   void DispatchToCallback(base::RepeatingCallback<void(ArgTypes...)> callback) {
-    gin_helper::MicrotasksScope microtasks_scope(
+    gin_helper::MicrotasksScope microtasks_scope{
         args_->isolate(),
-        args_->GetHolderCreationContext()->GetMicrotaskQueue(), true);
+        args_->GetHolderCreationContext()->GetMicrotaskQueue(), true,
+        v8::MicrotasksScope::kRunMicrotasks};
     callback.Run(std::move(ArgumentHolder<indices, ArgTypes>::value)...);
   }
 

--- a/shell/common/gin_helper/microtasks_scope.h
+++ b/shell/common/gin_helper/microtasks_scope.h
@@ -16,11 +16,10 @@ namespace gin_helper {
 // In the render process creates a v8::MicrotasksScope.
 class MicrotasksScope {
  public:
-  explicit MicrotasksScope(v8::Isolate* isolate,
-                           v8::MicrotaskQueue* microtask_queue,
-                           bool ignore_browser_checkpoint = false,
-                           v8::MicrotasksScope::Type scope_type =
-                               v8::MicrotasksScope::kRunMicrotasks);
+  MicrotasksScope(v8::Isolate* isolate,
+                  v8::MicrotaskQueue* microtask_queue,
+                  bool ignore_browser_checkpoint,
+                  v8::MicrotasksScope::Type scope_type);
   ~MicrotasksScope();
 
   // disable copy

--- a/shell/common/gin_helper/promise.cc
+++ b/shell/common/gin_helper/promise.cc
@@ -30,8 +30,9 @@ PromiseBase& PromiseBase::operator=(PromiseBase&&) = default;
 
 v8::Maybe<bool> PromiseBase::Reject() {
   v8::HandleScope handle_scope(isolate());
-  gin_helper::MicrotasksScope microtasks_scope(
-      isolate(), GetContext()->GetMicrotaskQueue());
+  gin_helper::MicrotasksScope microtasks_scope{
+      isolate(), GetContext()->GetMicrotaskQueue(), false,
+      v8::MicrotasksScope::kRunMicrotasks};
   v8::Context::Scope context_scope(GetContext());
 
   return GetInner()->Reject(GetContext(), v8::Undefined(isolate()));
@@ -39,8 +40,9 @@ v8::Maybe<bool> PromiseBase::Reject() {
 
 v8::Maybe<bool> PromiseBase::Reject(v8::Local<v8::Value> except) {
   v8::HandleScope handle_scope(isolate());
-  gin_helper::MicrotasksScope microtasks_scope(
-      isolate(), GetContext()->GetMicrotaskQueue());
+  gin_helper::MicrotasksScope microtasks_scope{
+      isolate(), GetContext()->GetMicrotaskQueue(), false,
+      v8::MicrotasksScope::kRunMicrotasks};
   v8::Context::Scope context_scope(GetContext());
 
   return GetInner()->Reject(GetContext(), except);
@@ -49,8 +51,9 @@ v8::Maybe<bool> PromiseBase::Reject(v8::Local<v8::Value> except) {
 v8::Maybe<bool> PromiseBase::RejectWithErrorMessage(
     const std::string_view message) {
   v8::HandleScope handle_scope(isolate());
-  gin_helper::MicrotasksScope microtasks_scope(
-      isolate(), GetContext()->GetMicrotaskQueue());
+  gin_helper::MicrotasksScope microtasks_scope{
+      isolate(), GetContext()->GetMicrotaskQueue(), false,
+      v8::MicrotasksScope::kRunMicrotasks};
   v8::Context::Scope context_scope(GetContext());
 
   v8::Local<v8::Value> error =
@@ -92,8 +95,9 @@ v8::Local<v8::Promise> Promise<void>::ResolvedPromise(v8::Isolate* isolate) {
 
 v8::Maybe<bool> Promise<void>::Resolve() {
   v8::HandleScope handle_scope(isolate());
-  gin_helper::MicrotasksScope microtasks_scope(
-      isolate(), GetContext()->GetMicrotaskQueue());
+  gin_helper::MicrotasksScope microtasks_scope{
+      isolate(), GetContext()->GetMicrotaskQueue(), false,
+      v8::MicrotasksScope::kRunMicrotasks};
   v8::Context::Scope context_scope(GetContext());
 
   return GetInner()->Resolve(GetContext(), v8::Undefined(isolate()));

--- a/shell/common/gin_helper/promise.h
+++ b/shell/common/gin_helper/promise.h
@@ -123,8 +123,9 @@ class Promise : public PromiseBase {
   v8::Maybe<bool> Resolve(const RT& value) {
     gin_helper::Locker locker(isolate());
     v8::HandleScope handle_scope(isolate());
-    gin_helper::MicrotasksScope microtasks_scope(
-        isolate(), GetContext()->GetMicrotaskQueue());
+    gin_helper::MicrotasksScope microtasks_scope{
+        isolate(), GetContext()->GetMicrotaskQueue(), false,
+        v8::MicrotasksScope::kRunMicrotasks};
     v8::Context::Scope context_scope(GetContext());
 
     return GetInner()->Resolve(GetContext(),

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -285,7 +285,7 @@ void ErrorMessageListener(v8::Local<v8::Message> message,
   node::Environment* env = node::Environment::GetCurrent(isolate);
   if (env) {
     gin_helper::MicrotasksScope microtasks_scope(
-        isolate, env->context()->GetMicrotaskQueue(),
+        isolate, env->context()->GetMicrotaskQueue(), false,
         v8::MicrotasksScope::kDoNotRunMicrotasks);
     // Emit the after() hooks now that the exception has been handled.
     // Analogous to node/lib/internal/process/execution.js#L176-L180

--- a/shell/common/v8_value_serializer.cc
+++ b/shell/common/v8_value_serializer.cc
@@ -34,9 +34,9 @@ class V8Serializer : public v8::ValueSerializer::Delegate {
   ~V8Serializer() override = default;
 
   bool Serialize(v8::Local<v8::Value> value, blink::CloneableMessage* out) {
-    gin_helper::MicrotasksScope microtasks_scope(
-        isolate_, isolate_->GetCurrentContext()->GetMicrotaskQueue(),
-        v8::MicrotasksScope::kDoNotRunMicrotasks);
+    gin_helper::MicrotasksScope microtasks_scope{
+        isolate_, isolate_->GetCurrentContext()->GetMicrotaskQueue(), false,
+        v8::MicrotasksScope::kDoNotRunMicrotasks};
     WriteBlinkEnvelope(19);
 
     serializer_.WriteHeader();

--- a/shell/renderer/api/electron_api_spell_check_client.cc
+++ b/shell/renderer/api/electron_api_spell_check_client.cc
@@ -221,9 +221,9 @@ void SpellCheckClient::SpellCheckWords(const SpellCheckScope& scope,
   DCHECK(!scope.spell_check_.IsEmpty());
 
   auto context = isolate_->GetCurrentContext();
-  gin_helper::MicrotasksScope microtasks_scope(
-      isolate_, context->GetMicrotaskQueue(),
-      v8::MicrotasksScope::kDoNotRunMicrotasks);
+  gin_helper::MicrotasksScope microtasks_scope{
+      isolate_, context->GetMicrotaskQueue(), false,
+      v8::MicrotasksScope::kDoNotRunMicrotasks};
 
   v8::Local<v8::FunctionTemplate> templ = gin_helper::CreateFunctionTemplate(
       isolate_, base::BindRepeating(&SpellCheckClient::OnSpellCheckDone,

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -204,9 +204,9 @@ void ElectronSandboxedRendererClient::WillReleaseScriptContext(
     return;
 
   auto* isolate = context->GetIsolate();
-  gin_helper::MicrotasksScope microtasks_scope(
-      isolate, context->GetMicrotaskQueue(),
-      v8::MicrotasksScope::kDoNotRunMicrotasks);
+  gin_helper::MicrotasksScope microtasks_scope{
+      isolate, context->GetMicrotaskQueue(), false,
+      v8::MicrotasksScope::kDoNotRunMicrotasks};
   v8::HandleScope handle_scope(isolate);
   v8::Context::Scope context_scope(context);
   InvokeEmitProcessEvent(context, "exit");
@@ -223,9 +223,9 @@ void ElectronSandboxedRendererClient::EmitProcessEvent(
   v8::HandleScope handle_scope{isolate};
 
   v8::Local<v8::Context> context = GetContext(frame, isolate);
-  gin_helper::MicrotasksScope microtasks_scope(
-      isolate, context->GetMicrotaskQueue(),
-      v8::MicrotasksScope::kDoNotRunMicrotasks);
+  gin_helper::MicrotasksScope microtasks_scope{
+      isolate, context->GetMicrotaskQueue(), false,
+      v8::MicrotasksScope::kDoNotRunMicrotasks};
   v8::Context::Scope context_scope(context);
 
   InvokeEmitProcessEvent(context, event_name);


### PR DESCRIPTION
#### Description of Change

Closes #43085.

Require code that instantiates `gin_helper::MicrotasksScope`s to provide all four constructor arguments.

CC @deepak1556 who has the most context on this, but who also (I think?) is on holiday so reviews welcomed from anyone :smile_cat: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.