### PR TITLE
build: use smaller instances for gn-check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,7 @@ jobs:
     needs: checkout-macos
     with:
       build-runs-on: macos-14-xlarge
+      check-runs-on: macos-14
       test-runs-on: macos-13
       target-platform: macos
       target-arch: x64
@@ -155,6 +156,7 @@ jobs:
     needs: checkout-macos
     with:
       build-runs-on: macos-14-xlarge
+      check-runs-on: macos-14
       test-runs-on: macos-14
       target-platform: macos
       target-arch: arm64
@@ -173,6 +175,7 @@ jobs:
     needs: checkout-linux
     with:
       build-runs-on: electron-arc-linux-amd64-32core
+      check-runs-on: electron-arc-linux-amd64-8core
       test-runs-on: electron-arc-linux-amd64-4core
       build-container: '{"image":"ghcr.io/electron/build:${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root","volumes":["/mnt/cross-instance-cache:/mnt/cross-instance-cache"]}'
       test-container: '{"image":"ghcr.io/electron/build:${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root --privileged --init"}'
@@ -193,6 +196,7 @@ jobs:
     needs: checkout-linux
     with:
       build-runs-on: electron-arc-linux-amd64-32core
+      check-runs-on: electron-arc-linux-amd64-8core
       test-runs-on: electron-arc-linux-amd64-4core
       build-container: '{"image":"ghcr.io/electron/build:${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root","volumes":["/mnt/cross-instance-cache:/mnt/cross-instance-cache"]}'
       test-container: '{"image":"ghcr.io/electron/build:${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root --privileged --init"}'
@@ -214,6 +218,7 @@ jobs:
     needs: checkout-linux
     with:
       build-runs-on: electron-arc-linux-amd64-32core
+      check-runs-on: electron-arc-linux-amd64-8core
       test-runs-on: electron-arc-linux-arm64-4core
       build-container: '{"image":"ghcr.io/electron/build:${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root","volumes":["/mnt/cross-instance-cache:/mnt/cross-instance-cache"]}'
       test-container: '{"image":"ghcr.io/electron/test:arm32v7-${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root --privileged --init","volumes":["/home/runner/externals:/mnt/runner-externals"]}'
@@ -234,6 +239,7 @@ jobs:
     needs: checkout-linux
     with:
       build-runs-on: electron-arc-linux-amd64-32core
+      check-runs-on: electron-arc-linux-amd64-8core
       test-runs-on: electron-arc-linux-arm64-4core
       build-container: '{"image":"ghcr.io/electron/build:${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root","volumes":["/mnt/cross-instance-cache:/mnt/cross-instance-cache"]}'
       test-container: '{"image":"ghcr.io/electron/test:arm64v8-${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root --privileged --init"}'

--- a/.github/workflows/pipeline-electron-build-and-test-and-nan.yml
+++ b/.github/workflows/pipeline-electron-build-and-test-and-nan.yml
@@ -15,6 +15,10 @@ on:
         type: string
         description: 'What host to run the build'
         required: true
+      check-runs-on:
+        type: string
+        description: 'What host to run the gn-check'
+        required: true
       test-runs-on:
         type: string
         description: 'What host to run the tests on'
@@ -77,7 +81,7 @@ jobs:
     with:
       target-platform: ${{ inputs.target-platform }}
       target-arch: ${{ inputs.target-arch }}
-      check-runs-on: ${{ inputs.build-runs-on }}
+      check-runs-on: ${{ inputs.check-runs-on }}
       check-container: ${{ inputs.build-container }}
       gn-build-type: ${{ inputs.gn-build-type }}
       is-asan: ${{ inputs.is-asan }}

--- a/.github/workflows/pipeline-electron-build-and-test.yml
+++ b/.github/workflows/pipeline-electron-build-and-test.yml
@@ -15,6 +15,10 @@ on:
         type: string
         description: 'What host to run the build'
         required: true
+      check-runs-on:
+        type: string
+        description: 'What host to run the gn-check'
+        required: true
       test-runs-on:
         type: string
         description: 'What host to run the tests on'
@@ -83,7 +87,7 @@ jobs:
     with:
       target-platform: ${{ inputs.target-platform }}
       target-arch: ${{ inputs.target-arch }}
-      check-runs-on: ${{ inputs.build-runs-on }}
+      check-runs-on: ${{ inputs.check-runs-on }}
       check-container: ${{ inputs.build-container }}
       gn-build-type: ${{ inputs.gn-build-type }}
       is-asan: ${{ inputs.is-asan }}


### PR DESCRIPTION
Noticed while looking at GHA insights, we spend a _lot_ of minutes running `gn-check` and there is no need to run them on super-large instances 🤔 Honestly it would be nice to somehow run them on linux boxes but you can't easily run `gn gen` on linux hosts for macOS builds.

Notes: none