### PR TITLE
perf: don't build unused vectors in HidChooserContext

### DIFF
--- a/shell/browser/hid/hid_chooser_context.cc
+++ b/shell/browser/hid/hid_chooser_context.cc
@@ -333,11 +333,6 @@ void HidChooserContext::OnHidManagerConnectionError() {
   hid_manager_.reset();
   client_receiver_.reset();
   devices_.clear();
-
-  std::vector<url::Origin> revoked_origins;
-  revoked_origins.reserve(ephemeral_devices_.size());
-  for (const auto& map_entry : ephemeral_devices_)
-    revoked_origins.push_back(map_entry.first);
   ephemeral_devices_.clear();
 
   // Notify all device observers.

--- a/shell/browser/hid/hid_chooser_context.cc
+++ b/shell/browser/hid/hid_chooser_context.cc
@@ -273,13 +273,8 @@ void HidChooserContext::DeviceRemoved(device::mojom::HidDeviceInfoPtr device) {
   if (CanStorePersistentEntry(*device))
     return;
 
-  std::vector<url::Origin> revoked_origins;
-  for (auto& map_entry : ephemeral_devices_) {
-    if (map_entry.second.erase(device->guid) > 0)
-      revoked_origins.push_back(map_entry.first);
-  }
-  if (revoked_origins.empty())
-    return;
+  for (auto& map_entry : ephemeral_devices_)
+    map_entry.second.erase(device->guid);
 }
 
 void HidChooserContext::DeviceChanged(device::mojom::HidDeviceInfoPtr device) {

--- a/shell/browser/hid/hid_chooser_context.cc
+++ b/shell/browser/hid/hid_chooser_context.cc
@@ -273,8 +273,8 @@ void HidChooserContext::DeviceRemoved(device::mojom::HidDeviceInfoPtr device) {
   if (CanStorePersistentEntry(*device))
     return;
 
-  for (auto& map_entry : ephemeral_devices_)
-    map_entry.second.erase(device->guid);
+  for (auto& [origin, guids] : ephemeral_devices_)
+    guids.erase(device->guid);
 }
 
 void HidChooserContext::DeviceChanged(device::mojom::HidDeviceInfoPtr device) {


### PR DESCRIPTION
#### Description of Change

HidChooserContext's `OnHidManagerConnectionError()` and `DeviceRemoved()` methods both build temporary `std::vector<url::Origin>` objects that are unused. This PR removes them.

The code seems to have been there since the initial commit (6aece4a8, Sep 2021) , so possibly this code was copied from somewhere else? (ETA: answered by @codebytere in comments)

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.