### PR TITLE
perf: avoid redundant calls to GetView()

### DIFF
--- a/shell/browser/api/frame_subscriber.cc
+++ b/shell/browser/api/frame_subscriber.cc
@@ -38,13 +38,14 @@ void FrameSubscriber::AttachToHost(content::RenderWidgetHost* host) {
 
   // The view can be null if the renderer process has crashed.
   // (https://crbug.com/847363)
-  if (!host_->GetView())
+  auto* rwhv = host_->GetView();
+  if (!rwhv)
     return;
 
   // Create and configure the video capturer.
   gfx::Size size = GetRenderViewSize();
   DCHECK(!size.IsEmpty());
-  video_capturer_ = host_->GetView()->CreateVideoCapturer();
+  video_capturer_ = rwhv->CreateVideoCapturer();
   video_capturer_->SetResolutionConstraints(size, size, true);
   video_capturer_->SetAutoThrottlingEnabled(false);
   video_capturer_->SetMinSizeChangePeriod(base::TimeDelta());

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -565,10 +565,8 @@ OffScreenRenderWidgetHostView::CreateViewForWidget(
     content::RenderWidgetHost* render_widget_host,
     content::RenderWidgetHost* embedder_render_widget_host,
     content::WebContentsView* web_contents_view) {
-  if (render_widget_host->GetView()) {
-    return static_cast<content::RenderWidgetHostViewBase*>(
-        render_widget_host->GetView());
-  }
+  if (auto* rwhv = render_widget_host->GetView())
+    return static_cast<content::RenderWidgetHostViewBase*>(rwhv);
 
   OffScreenRenderWidgetHostView* embedder_host_view = nullptr;
   if (embedder_render_widget_host) {

--- a/shell/browser/osr/osr_web_contents_view.cc
+++ b/shell/browser/osr/osr_web_contents_view.cc
@@ -35,8 +35,8 @@ void OffScreenWebContentsView::SetWebContents(
     content::WebContents* web_contents) {
   web_contents_ = web_contents;
 
-  if (GetView())
-    GetView()->InstallTransparency();
+  if (auto* view = GetView())
+    view->InstallTransparency();
 }
 
 void OffScreenWebContentsView::SetNativeWindow(NativeWindow* window) {
@@ -53,8 +53,8 @@ void OffScreenWebContentsView::SetNativeWindow(NativeWindow* window) {
 
 void OffScreenWebContentsView::OnWindowResize() {
   // In offscreen mode call RenderWidgetHostView's SetSize explicitly
-  if (GetView())
-    GetView()->SetSize(GetSize());
+  if (auto* view = GetView())
+    view->SetSize(GetSize());
 }
 
 void OffScreenWebContentsView::OnWindowClosed() {
@@ -107,7 +107,9 @@ content::DropData* OffScreenWebContentsView::GetDropData() const {
 }
 
 gfx::Rect OffScreenWebContentsView::GetViewBounds() const {
-  return GetView() ? GetView()->GetViewBounds() : gfx::Rect();
+  if (auto* view = GetView())
+    return view->GetViewBounds();
+  return {};
 }
 
 void OffScreenWebContentsView::CreateView(gfx::NativeView context) {}
@@ -115,10 +117,8 @@ void OffScreenWebContentsView::CreateView(gfx::NativeView context) {}
 content::RenderWidgetHostViewBase*
 OffScreenWebContentsView::CreateViewForWidget(
     content::RenderWidgetHost* render_widget_host) {
-  if (render_widget_host->GetView()) {
-    return static_cast<content::RenderWidgetHostViewBase*>(
-        render_widget_host->GetView());
-  }
+  if (auto* rwhv = render_widget_host->GetView())
+    return static_cast<content::RenderWidgetHostViewBase*>(rwhv);
 
   return new OffScreenRenderWidgetHostView(
       transparent_, painting_, GetFrameRate(), callback_, render_widget_host,
@@ -144,8 +144,8 @@ OffScreenWebContentsView::CreateViewForChildWidget(
 void OffScreenWebContentsView::SetPageTitle(const std::u16string& title) {}
 
 void OffScreenWebContentsView::RenderViewReady() {
-  if (GetView())
-    GetView()->InstallTransparency();
+  if (auto* view = GetView())
+    view->InstallTransparency();
 }
 
 void OffScreenWebContentsView::RenderViewHostChanged(
@@ -181,11 +181,9 @@ void OffScreenWebContentsView::UpdateDragOperation(
     bool document_is_handling_drag) {}
 
 void OffScreenWebContentsView::SetPainting(bool painting) {
-  auto* view = GetView();
   painting_ = painting;
-  if (view != nullptr) {
+  if (auto* view = GetView())
     view->SetPainting(painting);
-  }
 }
 
 bool OffScreenWebContentsView::IsPainting() const {
@@ -195,11 +193,9 @@ bool OffScreenWebContentsView::IsPainting() const {
 }
 
 void OffScreenWebContentsView::SetFrameRate(int frame_rate) {
-  auto* view = GetView();
   frame_rate_ = frame_rate;
-  if (view != nullptr) {
+  if (auto* view = GetView())
     view->SetFrameRate(frame_rate);
-  }
 }
 
 int OffScreenWebContentsView::GetFrameRate() const {

--- a/shell/browser/ui/autofill_popup.cc
+++ b/shell/browser/ui/autofill_popup.cc
@@ -191,11 +191,8 @@ void AutofillPopup::CreateView(content::RenderFrameHost* frame_host,
   view_ = new AutofillPopupView(this, parent->GetWidget());
 
   if (offscreen) {
-    auto* rwhv = frame_host->GetView();
-    if (embedder_frame_host != nullptr) {
-      rwhv = embedder_frame_host->GetView();
-    }
-
+    auto* rwhv = embedder_frame_host ? embedder_frame_host->GetView()
+                                     : frame_host->GetView();
     auto* osr_rwhv = static_cast<OffScreenRenderWidgetHostView*>(rwhv);
     view_->view_proxy_ = std::make_unique<OffscreenViewProxy>(view_);
     osr_rwhv->AddViewProxy(view_->view_proxy_.get());


### PR DESCRIPTION
#### Description of Change

We have a lot of places where we check for a nullptr view before using it in this way:

```c++
if (GetView())
  GetView()->DoSomething();
```

The assembly code does exactly what you'd expect: two identical sequential calls to `GetView()`. To avoid the redundant calls, this PR stores the view in a narrowly-scoped temporary variable, e.g.:

```c++
if (auto* view = GetView())
 view->DoSomething();
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none