### PR TITLE
docs: add missing deprecations to `breaking-changes.md`

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -65,7 +65,7 @@ contextBridge.exposeInMainWorld('electron', {
 })
 ```
 
-### Deprecated: `clearHistory`, `canGoBack`, `goBack`, `canGoForward`, `goForward`, `canGoToOffset`, `goToOffset` on `WebContents`
+### Deprecated: `clearHistory`, `canGoBack`, `goBack`, `canGoForward`, `goForward`, `goToIndex`, `canGoToOffset`, `goToOffset` on `WebContents`
 
 The navigation-related APIs are now deprecated.
 
@@ -78,6 +78,7 @@ win.webContents.canGoBack()
 win.webContents.goBack()
 win.webContents.canGoForward()
 win.webContents.goForward()
+win.webContents.goToIndex(index)
 win.webContents.canGoToOffset()
 win.webContents.goToOffset(index)
 

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -136,6 +136,24 @@ The autoresizing behavior is now standardized across all platforms.
 If your app uses `BrowserView.setAutoResize` to do anything more complex than making a BrowserView fill the entire window, it's likely you already had custom logic in place to handle this difference in behavior on macOS.
 If so, that logic will no longer be needed in Electron 30 as autoresizing behavior is consistent.
 
+### Deprecated: `BrowserView`
+
+The [`BrowserView`](./api/browser-view.md) class has been deprecated and
+replaced by the new [`WebContentsView`](./api/web-contents-view.md) class.
+
+`BrowserView` related methods in [`BrowserWindow`](./api/browser-window.md) have
+also been deprecated:
+
+```js
+BrowserWindow.fromBrowserView(browserView)
+win.setBrowserView(browserView)
+win.getBrowserView()
+win.addBrowserView(browserView)
+win.removeBrowserView(browserView)
+win.setTopBrowserView(browserView)
+win.getBrowserViews()
+```
+
 ### Removed: `params.inputFormType` property on `context-menu` on `WebContents`
 
 The `inputFormType` property of the params object in the `context-menu`

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -482,7 +482,7 @@ systemPreferences.getColor('selected-content-background')
 
 ## Planned Breaking API Changes (25.0)
 
-### Deprecated: `protocol.{register,intercept}{Buffer,String,Stream,File,Http}Protocol`
+### Deprecated: `protocol.{un,}{register,intercept}{Buffer,String,Stream,File,Http}Protocol` and `protocol.isProtocol{Registered,Intercepted}`
 
 The `protocol.register*Protocol` and `protocol.intercept*Protocol` methods have
 been replaced with [`protocol.handle`](api/protocol.md#protocolhandlescheme-handler).


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Added some missing deprecations to `breaking-changes.md`.

See commit descriptions for links to relevant PRs.

> [!NOTE]
> If https://github.com/electron/electron/commit/7453729be1b5a75c2b620d9225ea920ebfc89b16 is merged, then modify/revert [`997d1a4` (#42982)](https://github.com/electron/electron/pull/42982/commits/997d1a48af2ee0f7837b1debddd8d1176388327f)

@dsanders11 @erickzhao @VerteDinde 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
