### PR TITLE
fix: system-context-menu with frameless BrowserWindows

### DIFF
--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -288,6 +288,15 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
 
       return false;
     }
+    case WM_RBUTTONUP: {
+      if (!has_frame()) {
+        bool prevent_default = false;
+        NotifyWindowSystemContextMenu(GET_X_LPARAM(l_param),
+                                      GET_Y_LPARAM(l_param), &prevent_default);
+        return prevent_default;
+      }
+      return false;
+    }
     case WM_GETMINMAXINFO: {
       WINDOWPLACEMENT wp;
       wp.length = sizeof(WINDOWPLACEMENT);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/37614
Closes https://github.com/electron/electron/issues/26726
Closes https://github.com/electron/electron/issues/24893

Fixes an issue where `system-context-menu` was not triggered as expected on Windows when using a frameless BrowserWindow. As noted by @ckerr in the above issue, Electron never sees the `WM_CONTEXTMENU` message because [`hwnd_message_handler.cc`](https://source.chromium.org/chromium/chromium/src/+/main:ui/views/win/hwnd_message_handler.cc?q=hwnd_message_handler.cc&sq=package:chromium&type=cs) uses its [own custom event handling](https://source.chromium.org/chromium/chromium/src/+/master:ui/views/win/hwnd_message_handler.cc;l=3038;drc=db9ae7941adc1d95c943accce9e0151d265fd640) for` WM_RBUTTONUP`. We can fix this by intercepting it in `NativeWindowViews::PreHandleMSG`, as suggested [here](https://github.com/electron/electron/issues/26726#issuecomment-2058524167) by @eXhumer. Confirmed to address the issue with a local build and test.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `system-context-menu` was not triggered as expected on Windows when using a frameless BrowserWindow. 