### PR TITLE
docs: security.md mark 'Enable process sandboxing' as active by defau…

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -250,6 +250,10 @@ see our dedicated [Context Isolation](context-isolation.md) document.
 
 ### 4. Enable process sandboxing
 
+:::info
+This recommendation is the default behavior in Electron since 20.0.0.
+:::
+
 [Sandboxing](https://chromium.googlesource.com/chromium/src/+/HEAD/docs/design/sandbox.md)
 is a Chromium feature that uses the operating system to
 significantly limit what renderer processes have access to. You should enable


### PR DESCRIPTION
…lt since electron 20

#### Description of Change
Hello!

I think the security recommendation _4. Enable process sandboxing_ can be marked as active by default (if I understand this correctly: https://www.electronjs.org/docs/latest/tutorial/sandbox). 

Several other features have a similar marker and it's really helpful when going through the guide and looking for steps that need to be implemented manually.

I had opened this issue, because I thought the docs are managed in the website repo. I can re-open the issue here, if that helps.
https://github.com/electron/website/issues/615

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes

'none'
