### PR TITLE
docs: security.md use runnable examples for permissions and csp

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -279,25 +279,33 @@ security-conscious developers might want to assume the very opposite.
 #### How?
 
 ```js title='main.js (Main Process)'
-const { session } = require('electron')
+const { app, session } = require('electron')
 const { URL } = require('url')
 
-session
-  .fromPartition('some-partition')
-  .setPermissionRequestHandler((webContents, permission, callback) => {
-    const parsedUrl = new URL(webContents.getURL())
+app.whenReady().then(() => { 
+  // Your function responsible for creating the BrowserWindow and loading your web application
+  createWindow();
+}).then(() => {
+  session.defaultSession.webRequest
+    .setPermissionRequestHandler((webContents, permission, callback) => {
+      const parsedUrl = new URL(webContents.getURL())
 
-    if (permission === 'notifications') {
-      // Approves the permissions request
-      callback(true)
-    }
+      if (permission === 'notifications') {
+        // Approves the permissions request
+        callback(true)
+        return
+      }
 
-    // Verify URL
-    if (parsedUrl.protocol !== 'https:' || parsedUrl.host !== 'example.com') {
-      // Denies the permissions request
-      return callback(false)
-    }
-  })
+      // Verify URL
+      if (parsedUrl.protocol !== 'https:' || parsedUrl.host !== 'example.com') {
+        // Denies the permissions request
+        callback(false)
+        return
+      }
+
+      // Default is deny
+    })
+})  
 ```
 
 ### 6. Do not disable `webSecurity`
@@ -378,14 +386,21 @@ which can be set using Electron's
 handler:
 
 ```js title='main.js (Main Process)'
-const { session } = require('electron')
+const { app, session } = require('electron')
 
-session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
-  callback({
-    responseHeaders: {
-      ...details.responseHeaders,
-      'Content-Security-Policy': ['default-src \'none\'']
-    }
+app.whenReady().then(() => {
+  // Your function responsible for creating the BrowserWindow and loading your web application
+  createWindow();
+}).then(() => {
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': ["default-src 'none'"]
+        // Multiple policies are provided like this, going from specific to general
+        // 'Content-Security-Policy': ["img-src 'self'; script-src 'self' https://apis.example.com; default-src 'none'"]
+      }
+    })
   })
 })
 ```


### PR DESCRIPTION
#### Description of Change
Hi there,

I had opened an issue under electron/website: https://github.com/electron/website/issues/613

I can re-open the issue here, if that helps.

The short version is: I've had issues trying to implement the security guide - mainly two points (_5. Handle session permission requests from remote content_ and _7. Define a Content Security Policy_) caused my application to segfault on startup.
After some research, I've found a solution that's working for me. I've also verified that the security features work as expected.

I have adjusted the example accordingly, hoping that it will help other users.

I am new to Electron, though and it's important that some one verifies that the changes I propose here are actually correct. All I know for certain is that the old examples didn't work out of the box, at all.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes
'none'
