### PR TITLE
fix: accidental handle copying in a range loop

### DIFF
--- a/shell/browser/api/message_port.cc
+++ b/shell/browser/api/message_port.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "base/containers/contains.h"
+#include "base/containers/to_vector.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/task/single_thread_task_runner.h"
 #include "gin/arguments.h"
@@ -250,11 +251,7 @@ std::vector<blink::MessagePortChannel> MessagePort::DisentanglePorts(
   }
 
   // Passed-in ports passed validity checks, so we can disentangle them.
-  std::vector<blink::MessagePortChannel> channels;
-  channels.reserve(ports.size());
-  for (auto port : ports)
-    channels.push_back(port->Disentangle());
-  return channels;
+  return base::ToVector(ports, [](auto& port) { return port->Disentangle(); });
 }
 
 void MessagePort::Pin() {


### PR DESCRIPTION
#### Description of Change

Fix a wart from e929b2140d4a1b8bce621f8826639e38cb3f3c6d which used `auto` instead of `auto&` in a ranged loop, causing us to create & throw away `gin::Handle<MessagePort>`s as we loop. Not a major problem; but since we can avoid it, let's avoid it.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.