### PR TITLE
refactor: use url::DomainIs() to check cookie domains

### DIFF
--- a/docs/api/cookies.md
+++ b/docs/api/cookies.md
@@ -74,7 +74,7 @@ The following methods are available on instances of `Cookies`:
     `url`. Empty implies retrieving cookies of all URLs.
   * `name` string (optional) - Filters cookies by name.
   * `domain` string (optional) - Retrieves cookies whose domains match or are
-    subdomains of `domains`.
+    subdomains of `domain`.
   * `path` string (optional) - Retrieves cookies whose path matches `path`.
   * `secure` boolean (optional) - Filters cookies by their Secure property.
   * `session` boolean (optional) - Filters out session or persistent cookies.

--- a/shell/browser/api/electron_api_cookies.cc
+++ b/shell/browser/api/electron_api_cookies.cc
@@ -30,6 +30,7 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/gin_helper/promise.h"
+#include "url/url_util.h"
 
 namespace gin {
 
@@ -100,25 +101,12 @@ namespace electron::api {
 
 namespace {
 
-// Returns whether |domain| matches |filter|.
-bool MatchesDomain(std::string filter, const std::string& domain) {
-  // Add a leading '.' character to the filter domain if it doesn't exist.
-  if (net::cookie_util::DomainIsHostOnly(filter))
-    filter.insert(0, ".");
-
-  std::string sub_domain(domain);
+bool DomainIs(std::string_view host, const std::string_view domain) {
   // Strip any leading '.' character from the input cookie domain.
-  if (!net::cookie_util::DomainIsHostOnly(sub_domain))
-    sub_domain = sub_domain.substr(1);
+  if (host.starts_with('.'))
+    host.remove_prefix(1);
 
-  // Now check whether the domain argument is a subdomain of the filter domain.
-  for (sub_domain.insert(0, "."); sub_domain.length() >= filter.length();) {
-    if (sub_domain == filter)
-      return true;
-    const size_t next_dot = sub_domain.find('.', 1);  // Skip over leading dot.
-    sub_domain.erase(0, next_dot);
-  }
-  return false;
+  return url::DomainIs(host, domain);
 }
 
 // Returns whether |cookie| matches |filter|.
@@ -129,8 +117,7 @@ bool MatchesCookie(const base::Value::Dict& filter,
     return false;
   if ((str = filter.FindString("path")) && *str != cookie.Path())
     return false;
-  if ((str = filter.FindString("domain")) &&
-      !MatchesDomain(*str, cookie.Domain()))
+  if ((str = filter.FindString("domain")) && !DomainIs(cookie.Domain(), *str))
     return false;
   std::optional<bool> secure_filter = filter.FindBool("secure");
   if (secure_filter && *secure_filter != cookie.SecureAttribute())

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -126,6 +126,41 @@ describe('session module', () => {
       expect(cs.some(c => c.name === name && c.value === value)).to.equal(true);
     });
 
+    it('gets domain-equal cookies', async () => {
+      const { cookies } = session.defaultSession;
+      const name = '1';
+      const value = '1';
+      const domain = 'github.com';
+
+      await cookies.set({ url: `https://${domain}/foo`, name, value });
+      const cs = await cookies.get({ domain });
+      expect(cs.some(c => c.name === name && c.value === value)).to.equal(true);
+    });
+
+    it('gets domain-inclusive cookies', async () => {
+      const { cookies } = session.defaultSession;
+      const name = '1';
+      const value = '1';
+      const domain = 'github.com';
+      const subdomain = `subdomain.${domain}`;
+
+      await cookies.set({ url: `https://${subdomain}/foo`, name, value });
+      const cs = await cookies.get({ domain });
+      expect(cs.some(c => c.name === name && c.value === value)).to.equal(true);
+    });
+
+    it('omits domain-exclusive cookies', async () => {
+      const { cookies } = session.defaultSession;
+      const name = '1';
+      const value = '1';
+      const domain = 'github.com';
+      const subdomain = `subdomain.${domain}`;
+
+      await cookies.set({ url: `https://${domain}/foo`, name, value });
+      const cs = await cookies.get({ domain: subdomain });
+      expect(cs.some(c => c.name === name && c.value === value)).to.equal(false);
+    });
+
     it('rejects when setting a cookie with missing required fields', async () => {
       const { cookies } = session.defaultSession;
       const name = '1';

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -126,6 +126,16 @@ describe('session module', () => {
       expect(cs.some(c => c.name === name && c.value === value)).to.equal(true);
     });
 
+    it('does not match on empty domain filter strings', async () => {
+      const { cookies } = session.defaultSession;
+      const name = '1';
+      const value = '1';
+
+      await cookies.set({ url: 'https://microsoft.com/', name, value });
+      const cs = await cookies.get({ domain: '' });
+      expect(cs.some(c => c.name === name && c.value === value)).to.equal(false);
+    });
+
     it('gets domain-equal cookies', async () => {
       const { cookies } = session.defaultSession;
       const name = '1';

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import * as crypto from 'node:crypto';
 import * as http from 'node:http';
 import * as https from 'node:https';
 import * as path from 'node:path';
@@ -128,7 +129,7 @@ describe('session module', () => {
 
     it('does not match on empty domain filter strings', async () => {
       const { cookies } = session.defaultSession;
-      const name = '1';
+      const name = crypto.randomBytes(20).toString('hex');
       const value = '1';
       const url = 'https://microsoft.com/';
 
@@ -140,7 +141,7 @@ describe('session module', () => {
 
     it('gets domain-equal cookies', async () => {
       const { cookies } = session.defaultSession;
-      const name = '1';
+      const name = crypto.randomBytes(20).toString('hex');
       const value = '1';
       const url = 'https://microsoft.com/';
 
@@ -152,7 +153,7 @@ describe('session module', () => {
 
     it('gets domain-inclusive cookies', async () => {
       const { cookies } = session.defaultSession;
-      const name = '1';
+      const name = crypto.randomBytes(20).toString('hex');
       const value = '1';
       const url = 'https://subdomain.microsoft.com/';
 
@@ -164,7 +165,7 @@ describe('session module', () => {
 
     it('omits domain-exclusive cookies', async () => {
       const { cookies } = session.defaultSession;
-      const name = '1';
+      const name = crypto.randomBytes(20).toString('hex');
       const value = '1';
       const url = 'https://microsoft.com';
 

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -130,40 +130,48 @@ describe('session module', () => {
       const { cookies } = session.defaultSession;
       const name = '1';
       const value = '1';
+      const url = 'https://microsoft.com/';
 
-      await cookies.set({ url: 'https://microsoft.com/', name, value });
+      await cookies.set({ url, name, value });
       const cs = await cookies.get({ domain: '' });
       expect(cs.some(c => c.name === name && c.value === value)).to.equal(false);
+      cookies.remove(url, name);
     });
 
     it('gets domain-equal cookies', async () => {
       const { cookies } = session.defaultSession;
       const name = '1';
       const value = '1';
+      const url = 'https://microsoft.com/';
 
-      await cookies.set({ url: 'https://microsoft.com/', name, value });
+      await cookies.set({ url, name, value });
       const cs = await cookies.get({ domain: 'microsoft.com' });
       expect(cs.some(c => c.name === name && c.value === value)).to.equal(true);
+      cookies.remove(url, name);
     });
 
     it('gets domain-inclusive cookies', async () => {
       const { cookies } = session.defaultSession;
       const name = '1';
       const value = '1';
+      const url = 'https://subdomain.microsoft.com/';
 
-      await cookies.set({ url: 'https://subdomain.microsoft.com/', name, value });
+      await cookies.set({ url, name, value });
       const cs = await cookies.get({ domain: 'microsoft.com' });
       expect(cs.some(c => c.name === name && c.value === value)).to.equal(true);
+      cookies.remove(url, name);
     });
 
     it('omits domain-exclusive cookies', async () => {
       const { cookies } = session.defaultSession;
       const name = '1';
       const value = '1';
+      const url = 'https://microsoft.com';
 
-      await cookies.set({ url: 'https://microsoft.com/', name, value });
+      await cookies.set({ url, name, value });
       const cs = await cookies.get({ domain: 'subdomain.microsoft.com' });
       expect(cs.some(c => c.name === name && c.value === value)).to.equal(false);
+      cookies.remove(url, name);
     });
 
     it('rejects when setting a cookie with missing required fields', async () => {

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -130,10 +130,9 @@ describe('session module', () => {
       const { cookies } = session.defaultSession;
       const name = '1';
       const value = '1';
-      const domain = 'github.com';
 
-      await cookies.set({ url: `https://${domain}/foo`, name, value });
-      const cs = await cookies.get({ domain });
+      await cookies.set({ url: 'https://microsoft.com/', name, value });
+      const cs = await cookies.get({ domain: 'microsoft.com' });
       expect(cs.some(c => c.name === name && c.value === value)).to.equal(true);
     });
 
@@ -141,11 +140,9 @@ describe('session module', () => {
       const { cookies } = session.defaultSession;
       const name = '1';
       const value = '1';
-      const domain = 'github.com';
-      const subdomain = `subdomain.${domain}`;
 
-      await cookies.set({ url: `https://${subdomain}/foo`, name, value });
-      const cs = await cookies.get({ domain });
+      await cookies.set({ url: 'https://subdomain.microsoft.com/', name, value });
+      const cs = await cookies.get({ domain: 'microsoft.com' });
       expect(cs.some(c => c.name === name && c.value === value)).to.equal(true);
     });
 
@@ -153,11 +150,9 @@ describe('session module', () => {
       const { cookies } = session.defaultSession;
       const name = '1';
       const value = '1';
-      const domain = 'github.com';
-      const subdomain = `subdomain.${domain}`;
 
-      await cookies.set({ url: `https://${domain}/foo`, name, value });
-      const cs = await cookies.get({ domain: subdomain });
+      await cookies.set({ url: 'https://microsoft.com/', name, value });
+      const cs = await cookies.get({ domain: 'subdomain.microsoft.com' });
       expect(cs.some(c => c.name === name && c.value === value)).to.equal(false);
     });
 


### PR DESCRIPTION
#### Description of Change

- Chromium's `url::DomainIs()` does the same thing as our `MatchesDomain()` function, so let's not reinvent the wheel.  This PR removes our bespoke code and uses `url::DomainIs()` instead
- Add domain-matching tests
- Fix a small typo in the docs

Historical note: looks like we have a bespoke impl because `MatchesDomain()` landed in dbbc2f19f4, which precedes https://codereview.chromium.org/2287483002 by a year. So we were _preinventing_ the wheel :smile_cat: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.