### PR TITLE
Fix: handling of minimum and maximum window sizes

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1634,14 +1634,25 @@ void NativeWindowViews::OnWidgetActivationChanged(views::Widget* changed_widget,
   root_view_.ResetAltState();
 }
 
-void NativeWindowViews::OnWidgetBoundsChanged(views::Widget* changed_widget,
-                                              const gfx::Rect& bounds) {
+void NativeWindowViews::OnWidgetBoundsChanged(views::Widget* changed_widget, const gfx::Rect& bounds) {
   if (changed_widget != widget())
     return;
 
   // Note: We intentionally use `GetBounds()` instead of `bounds` to properly
   // handle minimized windows on Windows.
   const auto new_bounds = GetBounds();
+
+  // Enforce minimum and maximum size constraints
+  if (new_bounds.width() < min_width_)
+    new_bounds.set_width(min_width_);
+  if (new_bounds.height() < min_height_)
+    new_bounds.set_height(min_height_);
+  if (new_bounds.width() > max_width_)
+    new_bounds.set_width(max_width_);
+  if (new_bounds.height() > max_height_)
+    new_bounds.set_height(max_height_);
+
+  // Notify and update only if there is a change in size
   if (widget_size_ != new_bounds.size()) {
     NotifyWindowResize();
     widget_size_ = new_bounds.size();


### PR DESCRIPTION
#### Description of Change

This PR addresses issue [#43110](https://github.com/electron/electron/issues/43110) by improving the handling of window resizing in Electron. The changes ensure that the window size cannot be resized below the defined minimum width and height or above the defined maximum width and height. Modifications have been made to enforce these constraints in the NativeWindowViews class, specifically within the OnWidgetBoundsChanged function.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X ] PR description included and stakeholders cc'd
- [ X] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ X] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where windows could be resized below the defined minimum width and height or above the defined maximum width and height.

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
