### PR TITLE
chore: remove unused method ElectronDesktopWindowTreeHostLinux::UpdateClientDecorationHints()

### DIFF
--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
@@ -253,8 +253,4 @@ void ElectronDesktopWindowTreeHostLinux::UpdateFrameHints() {
     SizeConstraintsChanged();
   }
 }
-
-void ElectronDesktopWindowTreeHostLinux::UpdateClientDecorationHints(
-    ClientFrameViewLinux* view) {}
-
 }  // namespace electron

--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.h
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.h
@@ -62,7 +62,6 @@ class ElectronDesktopWindowTreeHostLinux
   void UpdateFrameHints() override;
 
  private:
-  void UpdateClientDecorationHints(ClientFrameViewLinux* view);
   void UpdateWindowState(ui::PlatformWindowState new_state);
 
   raw_ptr<NativeWindowViews> native_window_view_;  // weak ref


### PR DESCRIPTION
#### Description of Change

Minor cleanup to remove an unused method `ElectronDesktopWindowTreeHostLinux::UpdateClientDecorationHints()`. This is unused as of Aug 26 in #41868 dff980c9c20da444fb853b6983eb75d48714b486

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.