### PR TITLE
refactor: put empty virtual function definitions in header

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1328,14 +1328,6 @@ void WebContents::EnterFullscreen(const GURL& url,
                                   ExclusiveAccessBubbleType bubble_type,
                                   const int64_t display_id) {}
 
-void WebContents::ExitFullscreen() {}
-
-void WebContents::UpdateExclusiveAccessBubble(
-    const ExclusiveAccessBubbleParams& params,
-    ExclusiveAccessBubbleHideCallback bubble_first_hide_callback) {}
-
-void WebContents::OnExclusiveAccessUserInput() {}
-
 content::WebContents* WebContents::GetWebContentsForExclusiveAccess() {
   return web_contents();
 }

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -724,11 +724,11 @@ class WebContents : public ExclusiveAccessContext,
   void EnterFullscreen(const GURL& url,
                        ExclusiveAccessBubbleType bubble_type,
                        const int64_t display_id) override;
-  void ExitFullscreen() override;
+  void ExitFullscreen() override {}
   void UpdateExclusiveAccessBubble(
       const ExclusiveAccessBubbleParams& params,
-      ExclusiveAccessBubbleHideCallback bubble_first_hide_callback) override;
-  void OnExclusiveAccessUserInput() override;
+      ExclusiveAccessBubbleHideCallback bubble_first_hide_callback) override {}
+  void OnExclusiveAccessUserInput() override {}
   content::WebContents* GetWebContentsForExclusiveAccess() override;
   bool CanUserExitFullscreen() const override;
   bool IsExclusiveAccessBubbleDisplayed() const override;

--- a/shell/browser/api/frame_subscriber.cc
+++ b/shell/browser/api/frame_subscriber.cc
@@ -144,14 +144,6 @@ void FrameSubscriber::OnFrameCaptured(
   Done(content_rect, bitmap);
 }
 
-void FrameSubscriber::OnNewSubCaptureTargetVersion(uint32_t crop_version) {}
-
-void FrameSubscriber::OnFrameWithEmptyRegionCapture() {}
-
-void FrameSubscriber::OnStopped() {}
-
-void FrameSubscriber::OnLog(const std::string& message) {}
-
 void FrameSubscriber::Done(const gfx::Rect& damage, const SkBitmap& frame) {
   if (frame.drawsNothing())
     return;

--- a/shell/browser/api/frame_subscriber.h
+++ b/shell/browser/api/frame_subscriber.h
@@ -61,10 +61,10 @@ class FrameSubscriber : private content::WebContentsObserver,
       const gfx::Rect& content_rect,
       mojo::PendingRemote<viz::mojom::FrameSinkVideoConsumerFrameCallbacks>
           callbacks) override;
-  void OnNewSubCaptureTargetVersion(uint32_t crop_version) override;
-  void OnFrameWithEmptyRegionCapture() override;
-  void OnStopped() override;
-  void OnLog(const std::string& message) override;
+  void OnNewSubCaptureTargetVersion(uint32_t crop_version) override {}
+  void OnFrameWithEmptyRegionCapture() override {}
+  void OnStopped() override {}
+  void OnLog(const std::string& message) override {}
 
   void Done(const gfx::Rect& damage, const SkBitmap& frame);
 

--- a/shell/browser/auto_updater.cc
+++ b/shell/browser/auto_updater.cc
@@ -22,6 +22,12 @@ std::string AutoUpdater::GetFeedURL() {
   return "";
 }
 
+void AutoUpdater::SetFeedURL(gin::Arguments* args) {}
+
+void AutoUpdater::CheckForUpdates() {}
+
+void AutoUpdater::QuitAndInstall() {}
+
 bool AutoUpdater::IsVersionAllowedForUpdate(const std::string& current_version,
                                             const std::string& target_version) {
   return false;

--- a/shell/browser/auto_updater.cc
+++ b/shell/browser/auto_updater.cc
@@ -22,12 +22,6 @@ std::string AutoUpdater::GetFeedURL() {
   return "";
 }
 
-void AutoUpdater::SetFeedURL(gin::Arguments* args) {}
-
-void AutoUpdater::CheckForUpdates() {}
-
-void AutoUpdater::QuitAndInstall() {}
-
 bool AutoUpdater::IsVersionAllowedForUpdate(const std::string& current_version,
                                             const std::string& target_version) {
   return false;

--- a/shell/browser/auto_updater.h
+++ b/shell/browser/auto_updater.h
@@ -64,9 +64,9 @@ class AutoUpdater {
   // FIXME(zcbenz): We should not do V8 in this file, this method should only
   // accept C++ struct as parameter, and atom_api_auto_updater.cc is responsible
   // for parsing the parameter from JavaScript.
-  static void SetFeedURL(gin::Arguments* args) {}
-  static void CheckForUpdates() {}
-  static void QuitAndInstall() {}
+  static void SetFeedURL(gin::Arguments* args);
+  static void CheckForUpdates();
+  static void QuitAndInstall();
 
   static bool IsVersionAllowedForUpdate(const std::string& current_version,
                                         const std::string& target_version);

--- a/shell/browser/auto_updater.h
+++ b/shell/browser/auto_updater.h
@@ -64,9 +64,9 @@ class AutoUpdater {
   // FIXME(zcbenz): We should not do V8 in this file, this method should only
   // accept C++ struct as parameter, and atom_api_auto_updater.cc is responsible
   // for parsing the parameter from JavaScript.
-  static void SetFeedURL(gin::Arguments* args);
-  static void CheckForUpdates();
-  static void QuitAndInstall();
+  static void SetFeedURL(gin::Arguments* args) {}
+  static void CheckForUpdates() {}
+  static void QuitAndInstall() {}
 
   static bool IsVersionAllowedForUpdate(const std::string& current_version,
                                         const std::string& target_version);

--- a/shell/browser/electron_pdf_document_helper_client.cc
+++ b/shell/browser/electron_pdf_document_helper_client.cc
@@ -8,14 +8,3 @@
 
 ElectronPDFDocumentHelperClient::ElectronPDFDocumentHelperClient() = default;
 ElectronPDFDocumentHelperClient::~ElectronPDFDocumentHelperClient() = default;
-
-void ElectronPDFDocumentHelperClient::UpdateContentRestrictions(
-    content::RenderFrameHost* render_frame_host,
-    int content_restrictions) {}
-void ElectronPDFDocumentHelperClient::OnPDFHasUnsupportedFeature(
-    content::WebContents* contents) {}
-void ElectronPDFDocumentHelperClient::OnSaveURL(
-    content::WebContents* contents) {}
-void ElectronPDFDocumentHelperClient::SetPluginCanSave(
-    content::RenderFrameHost* render_frame_host,
-    bool can_save) {}

--- a/shell/browser/electron_pdf_document_helper_client.h
+++ b/shell/browser/electron_pdf_document_helper_client.h
@@ -18,11 +18,11 @@ class ElectronPDFDocumentHelperClient : public pdf::PDFDocumentHelperClient {
  private:
   // pdf::PDFDocumentHelperClient
   void UpdateContentRestrictions(content::RenderFrameHost* render_frame_host,
-                                 int content_restrictions) override;
-  void OnPDFHasUnsupportedFeature(content::WebContents* contents) override;
-  void OnSaveURL(content::WebContents* contents) override;
+                                 int content_restrictions) override {}
+  void OnPDFHasUnsupportedFeature(content::WebContents* contents) override {}
+  void OnSaveURL(content::WebContents* contents) override {}
   void SetPluginCanSave(content::RenderFrameHost* render_frame_host,
-                        bool can_save) override;
+                        bool can_save) override {}
 };
 
 #endif  // ELECTRON_SHELL_BROWSER_ELECTRON_PDF_DOCUMENT_HELPER_CLIENT_H_

--- a/shell/browser/extensions/electron_extension_host_delegate.cc
+++ b/shell/browser/extensions/electron_extension_host_delegate.cc
@@ -28,9 +28,6 @@ void ElectronExtensionHostDelegate::OnExtensionHostCreated(
   electron::api::WebContents::FromOrCreate(isolate, web_contents);
 }
 
-void ElectronExtensionHostDelegate::OnMainFrameCreatedForBackgroundPage(
-    ExtensionHost* host) {}
-
 content::JavaScriptDialogManager*
 ElectronExtensionHostDelegate::GetJavaScriptDialogManager() {
   // TODO(jamescook): Create a JavaScriptDialogManager or reuse the one from

--- a/shell/browser/extensions/electron_extension_host_delegate.h
+++ b/shell/browser/extensions/electron_extension_host_delegate.h
@@ -25,7 +25,7 @@ class ElectronExtensionHostDelegate : public ExtensionHostDelegate {
 
   // ExtensionHostDelegate implementation.
   void OnExtensionHostCreated(content::WebContents* web_contents) override;
-  void OnMainFrameCreatedForBackgroundPage(ExtensionHost* host) override;
+  void OnMainFrameCreatedForBackgroundPage(ExtensionHost* host) override {}
   content::JavaScriptDialogManager* GetJavaScriptDialogManager() override;
   void CreateTab(std::unique_ptr<content::WebContents> web_contents,
                  const std::string& extension_id,

--- a/shell/browser/media/media_capture_devices_dispatcher.cc
+++ b/shell/browser/media/media_capture_devices_dispatcher.cc
@@ -25,28 +25,6 @@ MediaCaptureDevicesDispatcher::MediaCaptureDevicesDispatcher() {
 
 MediaCaptureDevicesDispatcher::~MediaCaptureDevicesDispatcher() = default;
 
-void MediaCaptureDevicesDispatcher::OnAudioCaptureDevicesChanged() {}
-
-void MediaCaptureDevicesDispatcher::OnVideoCaptureDevicesChanged() {}
-
-void MediaCaptureDevicesDispatcher::OnMediaRequestStateChanged(
-    int render_process_id,
-    int render_view_id,
-    int page_request_id,
-    const GURL& security_origin,
-    blink::mojom::MediaStreamType stream_type,
-    content::MediaRequestState state) {}
-
-void MediaCaptureDevicesDispatcher::OnCreatingAudioStream(int render_process_id,
-                                                          int render_view_id) {}
-
-void MediaCaptureDevicesDispatcher::OnSetCapturingLinkSecured(
-    int render_process_id,
-    int render_frame_id,
-    int page_request_id,
-    blink::mojom::MediaStreamType stream_type,
-    bool is_secure) {}
-
 const std::optional<blink::MediaStreamDevice>
 MediaCaptureDevicesDispatcher::GetPreferredAudioDeviceForBrowserContext(
     content::BrowserContext* browser_context,

--- a/shell/browser/media/media_capture_devices_dispatcher.h
+++ b/shell/browser/media/media_capture_devices_dispatcher.h
@@ -21,21 +21,21 @@ class MediaCaptureDevicesDispatcher
   static MediaCaptureDevicesDispatcher* GetInstance();
 
   // Overridden from content::MediaObserver:
-  void OnAudioCaptureDevicesChanged() override;
-  void OnVideoCaptureDevicesChanged() override;
+  void OnAudioCaptureDevicesChanged() override {}
+  void OnVideoCaptureDevicesChanged() override {}
   void OnMediaRequestStateChanged(int render_process_id,
                                   int render_view_id,
                                   int page_request_id,
                                   const GURL& security_origin,
                                   blink::mojom::MediaStreamType stream_type,
-                                  content::MediaRequestState state) override;
+                                  content::MediaRequestState state) override {}
   void OnCreatingAudioStream(int render_process_id,
-                             int render_view_id) override;
+                             int render_view_id) override {}
   void OnSetCapturingLinkSecured(int render_process_id,
                                  int render_frame_id,
                                  int page_request_id,
                                  blink::mojom::MediaStreamType stream_type,
-                                 bool is_secure) override;
+                                 bool is_secure) override {}
   const std::optional<blink::MediaStreamDevice>
   GetPreferredAudioDeviceForBrowserContext(
       content::BrowserContext* browser_context,

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -471,6 +471,9 @@ void NativeWindow::SetBackgroundMaterial(const std::string& type) {
   background_material_ = type;
 }
 
+void NativeWindow::SetTouchBar(
+    std::vector<gin_helper::PersistentDictionary> items) {}
+
 void NativeWindow::SetEscapeTouchBarItem(
     gin_helper::PersistentDictionary item) {}
 

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -439,45 +439,21 @@ bool NativeWindow::IsTabletMode() const {
   return false;
 }
 
-void NativeWindow::SetRepresentedFilename(const std::string& filename) {}
-
 std::string NativeWindow::GetRepresentedFilename() const {
   return "";
 }
-
-void NativeWindow::SetDocumentEdited(bool edited) {}
 
 bool NativeWindow::IsDocumentEdited() const {
   return false;
 }
 
-void NativeWindow::SetFocusable(bool focusable) {}
-
 bool NativeWindow::IsFocusable() const {
   return false;
 }
 
-void NativeWindow::SetMenu(ElectronMenuModel* menu) {}
-
 void NativeWindow::SetParentWindow(NativeWindow* parent) {
   parent_ = parent;
 }
-
-void NativeWindow::InvalidateShadow() {}
-
-void NativeWindow::SetAutoHideCursor(bool auto_hide) {}
-
-void NativeWindow::SelectPreviousTab() {}
-
-void NativeWindow::SelectNextTab() {}
-
-void NativeWindow::ShowAllTabs() {}
-
-void NativeWindow::MergeAllWindows() {}
-
-void NativeWindow::MoveTabToNewWindow() {}
-
-void NativeWindow::ToggleTabBar() {}
 
 bool NativeWindow::AddTabbedWindow(NativeWindow* window) {
   return true;  // for non-Mac platforms
@@ -495,21 +471,12 @@ void NativeWindow::SetBackgroundMaterial(const std::string& type) {
   background_material_ = type;
 }
 
-void NativeWindow::SetTouchBar(
-    std::vector<gin_helper::PersistentDictionary> items) {}
-
-void NativeWindow::RefreshTouchBarItem(const std::string& item_id) {}
-
 void NativeWindow::SetEscapeTouchBarItem(
     gin_helper::PersistentDictionary item) {}
-
-void NativeWindow::SetAutoHideMenuBar(bool auto_hide) {}
 
 bool NativeWindow::IsMenuBarAutoHide() const {
   return false;
 }
-
-void NativeWindow::SetMenuBarVisibility(bool visible) {}
 
 bool NativeWindow::IsMenuBarVisible() const {
   return true;
@@ -520,11 +487,6 @@ void NativeWindow::SetAspectRatio(double aspect_ratio,
   aspect_ratio_ = aspect_ratio;
   aspect_ratio_extraSize_ = extra_size;
 }
-
-void NativeWindow::PreviewFile(const std::string& path,
-                               const std::string& display_name) {}
-
-void NativeWindow::CloseFilePreview() {}
 
 std::optional<gfx::Rect> NativeWindow::GetWindowControlsOverlayRect() {
   return overlay_rect_;

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -171,20 +171,21 @@ class NativeWindow : public base::SupportsUserData,
   virtual bool IsTabletMode() const;
   virtual void SetBackgroundColor(SkColor color) = 0;
   virtual SkColor GetBackgroundColor() const = 0;
-  virtual void InvalidateShadow();
+  virtual void InvalidateShadow() {}
+
   virtual void SetHasShadow(bool has_shadow) = 0;
   virtual bool HasShadow() const = 0;
   virtual void SetOpacity(const double opacity) = 0;
   virtual double GetOpacity() const = 0;
-  virtual void SetRepresentedFilename(const std::string& filename);
+  virtual void SetRepresentedFilename(const std::string& filename) {}
   virtual std::string GetRepresentedFilename() const;
-  virtual void SetDocumentEdited(bool edited);
+  virtual void SetDocumentEdited(bool edited) {}
   virtual bool IsDocumentEdited() const;
   virtual void SetIgnoreMouseEvents(bool ignore, bool forward) = 0;
   virtual void SetContentProtection(bool enable) = 0;
-  virtual void SetFocusable(bool focusable);
+  virtual void SetFocusable(bool focusable) {}
   virtual bool IsFocusable() const;
-  virtual void SetMenu(ElectronMenuModel* menu);
+  virtual void SetMenu(ElectronMenuModel* menu) {}
   virtual void SetParentWindow(NativeWindow* parent);
   virtual content::DesktopMediaID GetDesktopMediaID() const = 0;
   virtual gfx::NativeView GetNativeView() const = 0;
@@ -213,7 +214,7 @@ class NativeWindow : public base::SupportsUserData,
 
   virtual bool IsVisibleOnAllWorkspaces() const = 0;
 
-  virtual void SetAutoHideCursor(bool auto_hide);
+  virtual void SetAutoHideCursor(bool auto_hide) {}
 
   // Vibrancy API
   const std::string& vibrancy() const { return vibrancy_; }
@@ -241,24 +242,25 @@ class NativeWindow : public base::SupportsUserData,
 #endif
 
   // Touchbar API
-  virtual void SetTouchBar(std::vector<gin_helper::PersistentDictionary> items);
-  virtual void RefreshTouchBarItem(const std::string& item_id);
+  virtual void SetTouchBar(
+      std::vector<gin_helper::PersistentDictionary> items) {}
+  virtual void RefreshTouchBarItem(const std::string& item_id) {}
   virtual void SetEscapeTouchBarItem(gin_helper::PersistentDictionary item);
 
   // Native Tab API
-  virtual void SelectPreviousTab();
-  virtual void SelectNextTab();
-  virtual void ShowAllTabs();
-  virtual void MergeAllWindows();
-  virtual void MoveTabToNewWindow();
-  virtual void ToggleTabBar();
+  virtual void SelectPreviousTab() {}
+  virtual void SelectNextTab() {}
+  virtual void ShowAllTabs() {}
+  virtual void MergeAllWindows() {}
+  virtual void MoveTabToNewWindow() {}
+  virtual void ToggleTabBar() {}
   virtual bool AddTabbedWindow(NativeWindow* window);
   virtual std::optional<std::string> GetTabbingIdentifier() const;
 
   // Toggle the menu bar.
-  virtual void SetAutoHideMenuBar(bool auto_hide);
+  virtual void SetAutoHideMenuBar(bool auto_hide) {}
   virtual bool IsMenuBarAutoHide() const;
-  virtual void SetMenuBarVisibility(bool visible);
+  virtual void SetMenuBarVisibility(bool visible) {}
   virtual bool IsMenuBarVisible() const;
 
   // Set the aspect ratio when resizing window.
@@ -270,8 +272,8 @@ class NativeWindow : public base::SupportsUserData,
 
   // File preview APIs.
   virtual void PreviewFile(const std::string& path,
-                           const std::string& display_name);
-  virtual void CloseFilePreview();
+                           const std::string& display_name) {}
+  virtual void CloseFilePreview() {}
 
   virtual void SetGTKDarkThemeEnabled(bool use_dark_theme) {}
 

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -242,8 +242,7 @@ class NativeWindow : public base::SupportsUserData,
 #endif
 
   // Touchbar API
-  virtual void SetTouchBar(
-      std::vector<gin_helper::PersistentDictionary> items) {}
+  virtual void SetTouchBar(std::vector<gin_helper::PersistentDictionary> items);
   virtual void RefreshTouchBarItem(const std::string& item_id) {}
   virtual void SetEscapeTouchBarItem(gin_helper::PersistentDictionary item);
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -993,8 +993,6 @@ bool NativeWindowViews::IsMaximizable() const {
 #endif
 }
 
-void NativeWindowViews::SetExcludedFromShownWindowsMenu(bool excluded) {}
-
 bool NativeWindowViews::IsExcludedFromShownWindowsMenu() const {
   // return false on unsupported platforms
   return false;

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -102,7 +102,7 @@ class NativeWindowViews : public NativeWindow,
   std::string GetTitle() const override;
   void FlashFrame(bool flash) override;
   void SetSkipTaskbar(bool skip) override;
-  void SetExcludedFromShownWindowsMenu(bool excluded) override;
+  void SetExcludedFromShownWindowsMenu(bool excluded) override {}
   bool IsExcludedFromShownWindowsMenu() const override;
   void SetSimpleFullScreen(bool simple_fullscreen) override;
   bool IsSimpleFullScreen() const override;

--- a/shell/browser/net/proxying_websocket.cc
+++ b/shell/browser/net/proxying_websocket.cc
@@ -114,10 +114,6 @@ void ProxyingWebSocket::ContinueToHeadersReceived() {
   OnHeadersReceivedComplete(net::OK);
 }
 
-void ProxyingWebSocket::OnFailure(const std::string& message,
-                                  int32_t net_error,
-                                  int32_t response_code) {}
-
 void ProxyingWebSocket::OnConnectionEstablished(
     mojo::PendingRemote<network::mojom::WebSocket> websocket,
     mojo::PendingReceiver<network::mojom::WebSocketClient> client_receiver,

--- a/shell/browser/net/proxying_websocket.h
+++ b/shell/browser/net/proxying_websocket.h
@@ -75,7 +75,7 @@ class ProxyingWebSocket : public network::mojom::WebSocketHandshakeClient,
       network::mojom::WebSocketHandshakeRequestPtr request) override;
   void OnFailure(const std::string& message,
                  int32_t net_error,
-                 int32_t response_code) override;
+                 int32_t response_code) override {}
   void OnConnectionEstablished(
       mojo::PendingRemote<network::mojom::WebSocket> websocket,
       mojo::PendingReceiver<network::mojom::WebSocketClient> client_receiver,

--- a/shell/browser/notifications/notification.cc
+++ b/shell/browser/notifications/notification.cc
@@ -43,8 +43,6 @@ void Notification::NotificationFailed(const std::string& error) {
   Destroy();
 }
 
-void Notification::Remove() {}
-
 void Notification::Destroy() {
   if (presenter()) {
     presenter()->RemoveNotification(this);

--- a/shell/browser/notifications/notification.h
+++ b/shell/browser/notifications/notification.h
@@ -58,7 +58,7 @@ class Notification {
 
   // Removes the notification if it was not fully removed during dismissal,
   // as can happen on some platforms including Windows.
-  virtual void Remove();
+  virtual void Remove() {}
 
   // Should be called by derived classes.
   void NotificationClicked();

--- a/shell/browser/notifications/platform_notification_service.cc
+++ b/shell/browser/notifications/platform_notification_service.cc
@@ -114,16 +114,6 @@ void PlatformNotificationService::DisplayNotification(
   }
 }
 
-void PlatformNotificationService::DisplayPersistentNotification(
-    const std::string& notification_id,
-    const GURL& service_worker_scope,
-    const GURL& origin,
-    const blink::PlatformNotificationData& notification_data,
-    const blink::NotificationResources& notification_resources) {}
-
-void PlatformNotificationService::ClosePersistentNotification(
-    const std::string& notification_id) {}
-
 void PlatformNotificationService::CloseNotification(
     const std::string& notification_id) {
   auto* presenter = browser_client_->GetNotificationPresenter();

--- a/shell/browser/notifications/platform_notification_service.cc
+++ b/shell/browser/notifications/platform_notification_service.cc
@@ -114,6 +114,16 @@ void PlatformNotificationService::DisplayNotification(
   }
 }
 
+void PlatformNotificationService::DisplayPersistentNotification(
+    const std::string& notification_id,
+    const GURL& service_worker_scope,
+    const GURL& origin,
+    const blink::PlatformNotificationData& notification_data,
+    const blink::NotificationResources& notification_resources) {}
+
+void PlatformNotificationService::ClosePersistentNotification(
+    const std::string& notification_id) {}
+
 void PlatformNotificationService::CloseNotification(
     const std::string& notification_id) {
   auto* presenter = browser_client_->GetNotificationPresenter();
@@ -133,6 +143,11 @@ int64_t PlatformNotificationService::ReadNextPersistentNotificationId() {
   // Electron doesn't support persistent notifications.
   return 0;
 }
+
+void PlatformNotificationService::RecordNotificationUkmEvent(
+    const content::NotificationDatabaseData& data) {}
+
+void PlatformNotificationService::ScheduleTrigger(base::Time timestamp) {}
 
 base::Time PlatformNotificationService::ReadNextTriggerTimestamp() {
   return base::Time::Max();

--- a/shell/browser/notifications/platform_notification_service.cc
+++ b/shell/browser/notifications/platform_notification_service.cc
@@ -114,16 +114,6 @@ void PlatformNotificationService::DisplayNotification(
   }
 }
 
-void PlatformNotificationService::DisplayPersistentNotification(
-    const std::string& notification_id,
-    const GURL& service_worker_scope,
-    const GURL& origin,
-    const blink::PlatformNotificationData& notification_data,
-    const blink::NotificationResources& notification_resources) {}
-
-void PlatformNotificationService::ClosePersistentNotification(
-    const std::string& notification_id) {}
-
 void PlatformNotificationService::CloseNotification(
     const std::string& notification_id) {
   auto* presenter = browser_client_->GetNotificationPresenter();
@@ -143,11 +133,6 @@ int64_t PlatformNotificationService::ReadNextPersistentNotificationId() {
   // Electron doesn't support persistent notifications.
   return 0;
 }
-
-void PlatformNotificationService::RecordNotificationUkmEvent(
-    const content::NotificationDatabaseData& data) {}
-
-void PlatformNotificationService::ScheduleTrigger(base::Time timestamp) {}
 
 base::Time PlatformNotificationService::ReadNextTriggerTimestamp() {
   return base::Time::Max();

--- a/shell/browser/notifications/platform_notification_service.h
+++ b/shell/browser/notifications/platform_notification_service.h
@@ -39,8 +39,9 @@ class PlatformNotificationService
       const GURL& service_worker_scope,
       const GURL& origin,
       const blink::PlatformNotificationData& notification_data,
-      const blink::NotificationResources& notification_resources) override;
-  void ClosePersistentNotification(const std::string& notification_id) override;
+      const blink::NotificationResources& notification_resources) override {}
+  void ClosePersistentNotification(
+      const std::string& notification_id) override {}
   void CloseNotification(const std::string& notification_id) override;
   void GetDisplayedNotifications(
       DisplayedNotificationsCallback callback) override;

--- a/shell/browser/notifications/platform_notification_service.h
+++ b/shell/browser/notifications/platform_notification_service.h
@@ -39,9 +39,8 @@ class PlatformNotificationService
       const GURL& service_worker_scope,
       const GURL& origin,
       const blink::PlatformNotificationData& notification_data,
-      const blink::NotificationResources& notification_resources) override {}
-  void ClosePersistentNotification(
-      const std::string& notification_id) override {}
+      const blink::NotificationResources& notification_resources) override;
+  void ClosePersistentNotification(const std::string& notification_id) override;
   void CloseNotification(const std::string& notification_id) override;
   void GetDisplayedNotifications(
       DisplayedNotificationsCallback callback) override;

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -306,8 +306,6 @@ ui::TextInputClient* OffScreenRenderWidgetHostView::GetTextInputClient() {
   return nullptr;
 }
 
-void OffScreenRenderWidgetHostView::Focus() {}
-
 bool OffScreenRenderWidgetHostView::HasFocus() {
   return false;
 }
@@ -377,13 +375,9 @@ std::optional<SkColor> OffScreenRenderWidgetHostView::GetBackgroundColor() {
   return background_color_;
 }
 
-void OffScreenRenderWidgetHostView::UpdateBackgroundColor() {}
-
 gfx::Size OffScreenRenderWidgetHostView::GetVisibleViewportSize() {
   return size_;
 }
-
-void OffScreenRenderWidgetHostView::SetInsets(const gfx::Insets& insets) {}
 
 blink::mojom::PointerLockResult OffScreenRenderWidgetHostView::LockPointer(
     bool request_unadjusted_movement) {
@@ -395,8 +389,6 @@ OffScreenRenderWidgetHostView::ChangePointerLock(
     bool request_unadjusted_movement) {
   return blink::mojom::PointerLockResult::kUnsupportedOptions;
 }
-
-void OffScreenRenderWidgetHostView::UnlockPointer() {}
 
 void OffScreenRenderWidgetHostView::TakeFallbackContentFrom(
     content::RenderWidgetHostView* view) {
@@ -447,18 +439,9 @@ void OffScreenRenderWidgetHostView::InitAsPopup(
   Show();
 }
 
-void OffScreenRenderWidgetHostView::UpdateCursor(const ui::Cursor&) {}
-
 input::CursorManager* OffScreenRenderWidgetHostView::GetCursorManager() {
   return cursor_manager_.get();
 }
-
-void OffScreenRenderWidgetHostView::SetIsLoading(bool loading) {}
-
-void OffScreenRenderWidgetHostView::TextInputStateChanged(
-    const ui::mojom::TextInputState& params) {}
-
-void OffScreenRenderWidgetHostView::ImeCancelComposition() {}
 
 void OffScreenRenderWidgetHostView::RenderProcessGone() {
   Destroy();
@@ -492,9 +475,6 @@ void OffScreenRenderWidgetHostView::Destroy() {
   delete this;
 }
 
-void OffScreenRenderWidgetHostView::UpdateTooltipUnderCursor(
-    const std::u16string&) {}
-
 uint32_t OffScreenRenderWidgetHostView::GetCaptureSequenceNumber() const {
   return latest_capture_sequence_number_;
 }
@@ -520,9 +500,6 @@ display::ScreenInfo OffScreenRenderWidgetHostView::GetScreenInfo() const {
   return screen_info;
 }
 
-void OffScreenRenderWidgetHostView::TransformPointToRootSurface(
-    gfx::PointF* point) {}
-
 gfx::Rect OffScreenRenderWidgetHostView::GetBoundsInRootWindow() {
   return gfx::Rect(size_);
 }
@@ -531,9 +508,6 @@ std::optional<content::DisplayFeature>
 OffScreenRenderWidgetHostView::GetDisplayFeature() {
   return std::nullopt;
 }
-
-void OffScreenRenderWidgetHostView::SetDisplayFeatureForTesting(
-    const content::DisplayFeature* display_feature) {}
 
 viz::SurfaceId OffScreenRenderWidgetHostView::GetCurrentSurfaceId() const {
   return delegated_frame_host() ? delegated_frame_host()->GetCurrentSurfaceId()
@@ -545,11 +519,6 @@ OffScreenRenderWidgetHostView::CreateSyntheticGestureTarget() {
   NOTIMPLEMENTED();
   return nullptr;
 }
-
-void OffScreenRenderWidgetHostView::ImeCompositionRangeChanged(
-    const gfx::Range&,
-    const std::optional<std::vector<gfx::Rect>>& character_bounds,
-    const std::optional<std::vector<gfx::Rect>>& line_bounds) {}
 
 gfx::Size OffScreenRenderWidgetHostView::GetCompositorViewportPixelSize() {
   return gfx::ScaleToCeiledSize(GetRequestedRendererSize(),
@@ -676,22 +645,6 @@ bool OffScreenRenderWidgetHostView::InstallTransparency() {
 }
 
 #if BUILDFLAG(IS_MAC)
-void OffScreenRenderWidgetHostView::SetActive(bool active) {}
-
-void OffScreenRenderWidgetHostView::ShowDefinitionForSelection() {}
-
-void OffScreenRenderWidgetHostView::SpeakSelection() {}
-
-void OffScreenRenderWidgetHostView::SetWindowFrameInScreen(
-    const gfx::Rect& rect) {}
-
-void OffScreenRenderWidgetHostView::ShowSharePicker(
-    const std::string& title,
-    const std::string& text,
-    const std::string& url,
-    const std::vector<std::string>& file_paths,
-    blink::mojom::ShareService::ShareCallback callback) {}
-
 bool OffScreenRenderWidgetHostView::UpdateNSViewAndDisplay() {
   return false;
 }

--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -90,8 +90,8 @@ class OffScreenRenderWidgetHostView
   gfx::NativeView GetNativeView(void) override;
   gfx::NativeViewAccessible GetNativeViewAccessible(void) override;
   ui::TextInputClient* GetTextInputClient() override;
-  void Focus(void) override;
-  bool HasFocus(void) override;
+  void Focus() override {}
+  bool HasFocus() override;
   uint32_t GetCaptureSequenceNumber() const override;
   bool IsSurfaceAvailableForCopy(void) override;
   void Hide(void) override;
@@ -99,27 +99,27 @@ class OffScreenRenderWidgetHostView
   void EnsureSurfaceSynchronizedForWebTest() override;
   gfx::Rect GetViewBounds(void) override;
   gfx::Size GetVisibleViewportSize() override;
-  void SetInsets(const gfx::Insets&) override;
+  void SetInsets(const gfx::Insets&) override {}
   void SetBackgroundColor(SkColor color) override;
   std::optional<SkColor> GetBackgroundColor() override;
-  void UpdateBackgroundColor() override;
+  void UpdateBackgroundColor() override {}
   blink::mojom::PointerLockResult LockPointer(
       bool request_unadjusted_movement) override;
   blink::mojom::PointerLockResult ChangePointerLock(
       bool request_unadjusted_movement) override;
-  void UnlockPointer(void) override;
+  void UnlockPointer(void) override {}
   void TakeFallbackContentFrom(content::RenderWidgetHostView* view) override;
 #if BUILDFLAG(IS_MAC)
-  void SetActive(bool active) override;
-  void ShowDefinitionForSelection() override;
-  void SpeakSelection() override;
-  void SetWindowFrameInScreen(const gfx::Rect& rect) override;
+  void SetActive(bool active) override {}
+  void ShowDefinitionForSelection() override {}
+  void SpeakSelection() override {}
+  void SetWindowFrameInScreen(const gfx::Rect& rect) override {}
   void ShowSharePicker(
       const std::string& title,
       const std::string& text,
       const std::string& url,
       const std::vector<std::string>& file_paths,
-      blink::mojom::ShareService::ShareCallback callback) override;
+      blink::mojom::ShareService::ShareCallback callback) override {}
   uint64_t GetNSViewId() const override;
   bool UpdateNSViewAndDisplay();
 #endif  // BUILDFLAG(IS_MAC)
@@ -131,25 +131,26 @@ class OffScreenRenderWidgetHostView
   void InitAsPopup(content::RenderWidgetHostView* parent_host_view,
                    const gfx::Rect& bounds,
                    const gfx::Rect& anchor_rect) override;
-  void UpdateCursor(const ui::Cursor&) override;
-  void SetIsLoading(bool is_loading) override;
-  void TextInputStateChanged(const ui::mojom::TextInputState& params) override;
-  void ImeCancelComposition(void) override;
+  void UpdateCursor(const ui::Cursor&) override {}
+  void SetIsLoading(bool is_loading) override {}
+  void TextInputStateChanged(const ui::mojom::TextInputState& params) override {
+  }
+  void ImeCancelComposition(void) override {}
   void RenderProcessGone() override;
   void ShowWithVisibility(content::PageVisibilityState page_visibility) final;
   void Destroy(void) override;
-  void UpdateTooltipUnderCursor(const std::u16string&) override;
+  void UpdateTooltipUnderCursor(const std::u16string&) override {}
   input::CursorManager* GetCursorManager() override;
   void CopyFromSurface(
       const gfx::Rect& src_rect,
       const gfx::Size& output_size,
       base::OnceCallback<void(const SkBitmap&)> callback) override;
   display::ScreenInfo GetScreenInfo() const override;
-  void TransformPointToRootSurface(gfx::PointF* point) override;
+  void TransformPointToRootSurface(gfx::PointF* point) override {}
   gfx::Rect GetBoundsInRootWindow(void) override;
   std::optional<content::DisplayFeature> GetDisplayFeature() override;
   void SetDisplayFeatureForTesting(
-      const content::DisplayFeature* display_feature) override;
+      const content::DisplayFeature* display_feature) override {}
   void NotifyHostAndDelegateOnWasShown(
       blink::mojom::RecordContentToVisibleTimeRequestPtr) final;
   void RequestSuccessfulPresentationTimeFromHostOrDelegate(
@@ -161,7 +162,7 @@ class OffScreenRenderWidgetHostView
   void ImeCompositionRangeChanged(
       const gfx::Range&,
       const std::optional<std::vector<gfx::Rect>>& character_bounds,
-      const std::optional<std::vector<gfx::Rect>>& line_bounds) override;
+      const std::optional<std::vector<gfx::Rect>>& line_bounds) override {}
   gfx::Size GetCompositorViewportPixelSize() override;
   ui::Compositor* GetCompositor() override;
 

--- a/shell/browser/osr/osr_video_consumer.cc
+++ b/shell/browser/osr/osr_video_consumer.cc
@@ -138,15 +138,6 @@ void OffScreenVideoConsumer::OnFrameCaptured(
   callback_.Run(*update_rect, bitmap);
 }
 
-void OffScreenVideoConsumer::OnNewSubCaptureTargetVersion(
-    uint32_t crop_version) {}
-
-void OffScreenVideoConsumer::OnFrameWithEmptyRegionCapture() {}
-
-void OffScreenVideoConsumer::OnStopped() {}
-
-void OffScreenVideoConsumer::OnLog(const std::string& message) {}
-
 bool OffScreenVideoConsumer::CheckContentRect(const gfx::Rect& content_rect) {
   gfx::Size view_size = view_->SizeInPixels();
   gfx::Size content_size = content_rect.size();

--- a/shell/browser/osr/osr_video_consumer.h
+++ b/shell/browser/osr/osr_video_consumer.h
@@ -44,10 +44,10 @@ class OffScreenVideoConsumer : public viz::mojom::FrameSinkVideoConsumer {
       const gfx::Rect& content_rect,
       mojo::PendingRemote<viz::mojom::FrameSinkVideoConsumerFrameCallbacks>
           callbacks) override;
-  void OnNewSubCaptureTargetVersion(uint32_t crop_version) override;
-  void OnFrameWithEmptyRegionCapture() override;
-  void OnStopped() override;
-  void OnLog(const std::string& message) override;
+  void OnNewSubCaptureTargetVersion(uint32_t crop_version) override {}
+  void OnFrameWithEmptyRegionCapture() override {}
+  void OnStopped() override {}
+  void OnLog(const std::string& message) override {}
 
   bool CheckContentRect(const gfx::Rect& content_rect);
 

--- a/shell/browser/osr/osr_web_contents_view.cc
+++ b/shell/browser/osr/osr_web_contents_view.cc
@@ -129,20 +129,10 @@ OffScreenWebContentsView::CreateViewForChildWidget(
                                            render_widget_host, view, GetSize());
 }
 
-void OffScreenWebContentsView::SetPageTitle(const std::u16string& title) {}
-
 void OffScreenWebContentsView::RenderViewReady() {
   if (auto* view = GetView())
     view->InstallTransparency();
 }
-
-void OffScreenWebContentsView::RenderViewHostChanged(
-    content::RenderViewHost* old_host,
-    content::RenderViewHost* new_host) {}
-
-void OffScreenWebContentsView::SetOverscrollControllerEnabled(bool enabled) {}
-
-void OffScreenWebContentsView::OnCapturerCountChanged() {}
 
 #if BUILDFLAG(IS_MAC)
 bool OffScreenWebContentsView::CloseTabAfterEventTrackingIfNeeded() {
@@ -163,10 +153,6 @@ void OffScreenWebContentsView::StartDragging(
     static_cast<content::WebContentsImpl*>(web_contents_)
         ->SystemDragEnded(source_rwh);
 }
-
-void OffScreenWebContentsView::UpdateDragOperation(
-    ui::mojom::DragOperation operation,
-    bool document_is_handling_drag) {}
 
 void OffScreenWebContentsView::SetPainting(bool painting) {
   painting_ = painting;
@@ -199,11 +185,6 @@ OffScreenRenderWidgetHostView* OffScreenWebContentsView::GetView() const {
   }
   return nullptr;
 }
-
-void OffScreenWebContentsView::FullscreenStateChanged(bool is_fullscreen) {}
-
-void OffScreenWebContentsView::UpdateWindowControlsOverlay(
-    const gfx::Rect& bounding_rect) {}
 
 content::BackForwardTransitionAnimationManager*
 OffScreenWebContentsView::GetBackForwardTransitionAnimationManager() {

--- a/shell/browser/osr/osr_web_contents_view.cc
+++ b/shell/browser/osr/osr_web_contents_view.cc
@@ -92,16 +92,6 @@ gfx::Rect OffScreenWebContentsView::GetContainerBounds() const {
   return GetViewBounds();
 }
 
-void OffScreenWebContentsView::Focus() {}
-
-void OffScreenWebContentsView::SetInitialFocus() {}
-
-void OffScreenWebContentsView::StoreFocus() {}
-
-void OffScreenWebContentsView::RestoreFocus() {}
-
-void OffScreenWebContentsView::FocusThroughTabTraversal(bool reverse) {}
-
 content::DropData* OffScreenWebContentsView::GetDropData() const {
   return nullptr;
 }
@@ -111,8 +101,6 @@ gfx::Rect OffScreenWebContentsView::GetViewBounds() const {
     return view->GetViewBounds();
   return {};
 }
-
-void OffScreenWebContentsView::CreateView(gfx::NativeView context) {}
 
 content::RenderWidgetHostViewBase*
 OffScreenWebContentsView::CreateViewForWidget(

--- a/shell/browser/osr/osr_web_contents_view.h
+++ b/shell/browser/osr/osr_web_contents_view.h
@@ -63,14 +63,14 @@ class OffScreenWebContentsView : public content::WebContentsView,
       content::RenderWidgetHost* render_widget_host) override;
   content::RenderWidgetHostViewBase* CreateViewForChildWidget(
       content::RenderWidgetHost* render_widget_host) override;
-  void SetPageTitle(const std::u16string& title) override;
+  void SetPageTitle(const std::u16string& title) override {}
   void RenderViewReady() override;
   void RenderViewHostChanged(content::RenderViewHost* old_host,
-                             content::RenderViewHost* new_host) override;
-  void SetOverscrollControllerEnabled(bool enabled) override;
-  void OnCapturerCountChanged() override;
-  void FullscreenStateChanged(bool is_fullscreen) override;
-  void UpdateWindowControlsOverlay(const gfx::Rect& bounding_rect) override;
+                             content::RenderViewHost* new_host) override {}
+  void SetOverscrollControllerEnabled(bool enabled) override {}
+  void OnCapturerCountChanged() override {}
+  void FullscreenStateChanged(bool is_fullscreen) override {}
+  void UpdateWindowControlsOverlay(const gfx::Rect& bounding_rect) override {}
   content::BackForwardTransitionAnimationManager*
   GetBackForwardTransitionAnimationManager() override;
 
@@ -88,7 +88,7 @@ class OffScreenWebContentsView : public content::WebContentsView,
                      const blink::mojom::DragEventSourceInfo& event_info,
                      content::RenderWidgetHostImpl* source_rwh) override;
   void UpdateDragOperation(ui::mojom::DragOperation operation,
-                           bool document_is_handling_drag) override;
+                           bool document_is_handling_drag) override {}
   void SetPainting(bool painting);
   bool IsPainting() const;
   void SetFrameRate(int frame_rate);

--- a/shell/browser/osr/osr_web_contents_view.h
+++ b/shell/browser/osr/osr_web_contents_view.h
@@ -51,14 +51,14 @@ class OffScreenWebContentsView : public content::WebContentsView,
   gfx::NativeView GetContentNativeView() const override;
   gfx::NativeWindow GetTopLevelNativeWindow() const override;
   gfx::Rect GetContainerBounds() const override;
-  void Focus() override;
-  void SetInitialFocus() override;
-  void StoreFocus() override;
-  void RestoreFocus() override;
-  void FocusThroughTabTraversal(bool reverse) override;
+  void Focus() override {}
+  void SetInitialFocus() override {}
+  void StoreFocus() override {}
+  void RestoreFocus() override {}
+  void FocusThroughTabTraversal(bool reverse) override {}
   content::DropData* GetDropData() const override;
   gfx::Rect GetViewBounds() const override;
-  void CreateView(gfx::NativeView context) override;
+  void CreateView(gfx::NativeView context) override {}
   content::RenderWidgetHostViewBase* CreateViewForWidget(
       content::RenderWidgetHost* render_widget_host) override;
   content::RenderWidgetHostViewBase* CreateViewForChildWidget(

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -628,8 +628,6 @@ void InspectableWebContents::SetInspectedPageBounds(const gfx::Rect& rect) {
     view_->SetContentsResizingStrategy(DevToolsContentsResizingStrategy{rect});
 }
 
-void InspectableWebContents::InspectElementCompleted() {}
-
 void InspectableWebContents::InspectedURLChanged(const std::string& url) {
   if (managed_devtools_web_contents_) {
     if (devtools_title_.empty()) {
@@ -763,9 +761,6 @@ void InspectableWebContents::RemoveFileSystem(
         base::FilePath::FromUTF8Unsafe(file_system_path));
 }
 
-void InspectableWebContents::UpgradeDraggedFileSystemPermissions(
-    const std::string& file_system_url) {}
-
 void InspectableWebContents::IndexPath(int request_id,
                                        const std::string& file_system_path,
                                        const std::string& excluded_folders) {
@@ -786,16 +781,10 @@ void InspectableWebContents::SearchInPath(int request_id,
     delegate_->DevToolsSearchInPath(request_id, file_system_path, query);
 }
 
-void InspectableWebContents::SetWhitelistedShortcuts(
-    const std::string& message) {}
-
 void InspectableWebContents::SetEyeDropperActive(bool active) {
   if (delegate_)
     delegate_->DevToolsSetEyeDropperActive(active);
 }
-void InspectableWebContents::ShowCertificateViewer(
-    const std::string& cert_chain) {}
-
 void InspectableWebContents::ZoomIn() {
   double new_level = GetNextZoomLevel(GetDevToolsZoomLevel(), false);
   SetZoomLevelForWebContents(GetDevToolsWebContents(), new_level);
@@ -812,20 +801,6 @@ void InspectableWebContents::ResetZoom() {
   SetZoomLevelForWebContents(GetDevToolsWebContents(), 0.);
   UpdateDevToolsZoomLevel(0.);
 }
-
-void InspectableWebContents::SetDevicesDiscoveryConfig(
-    bool discover_usb_devices,
-    bool port_forwarding_enabled,
-    const std::string& port_forwarding_config,
-    bool network_discovery_enabled,
-    const std::string& network_discovery_config) {}
-
-void InspectableWebContents::SetDevicesUpdatesEnabled(bool enabled) {}
-
-void InspectableWebContents::OpenRemotePage(const std::string& browser_id,
-                                            const std::string& url) {}
-
-void InspectableWebContents::OpenNodeFrontend() {}
 
 void InspectableWebContents::DispatchProtocolMessageFromDevToolsFrontend(
     const std::string& message) {
@@ -896,8 +871,6 @@ void InspectableWebContents::GetHostConfig(DispatchCallback callback) {
   std::move(callback).Run(&response);
 }
 
-void InspectableWebContents::ConnectionReady() {}
-
 void InspectableWebContents::RegisterExtensionsAPI(const std::string& origin,
                                                    const std::string& script) {
   extensions_api_[origin + "/"] = script;
@@ -954,9 +927,6 @@ void InspectableWebContents::DispatchProtocolMessage(
     }
   }
 }
-
-void InspectableWebContents::AgentHostClosed(
-    content::DevToolsAgentHost* agent_host) {}
 
 void InspectableWebContents::RenderFrameHostChanged(
     content::RenderFrameHost* old_host,

--- a/shell/browser/ui/inspectable_web_contents.h
+++ b/shell/browser/ui/inspectable_web_contents.h
@@ -91,7 +91,7 @@ class InspectableWebContents
   void CloseWindow() override;
   void LoadCompleted() override;
   void SetInspectedPageBounds(const gfx::Rect& rect) override;
-  void InspectElementCompleted() override;
+  void InspectElementCompleted() override {}
   void InspectedURLChanged(const std::string& url) override;
   void LoadNetworkResource(DispatchCallback callback,
                            const std::string& url,
@@ -111,7 +111,7 @@ class InspectableWebContents
   void AddFileSystem(const std::string& type) override;
   void RemoveFileSystem(const std::string& file_system_path) override;
   void UpgradeDraggedFileSystemPermissions(
-      const std::string& file_system_url) override;
+      const std::string& file_system_url) override {}
   void IndexPath(int index_request_id,
                  const std::string& file_system_path,
                  const std::string& excluded_folders) override;
@@ -119,9 +119,9 @@ class InspectableWebContents
   void SearchInPath(int search_request_id,
                     const std::string& file_system_path,
                     const std::string& query) override;
-  void SetWhitelistedShortcuts(const std::string& message) override;
+  void SetWhitelistedShortcuts(const std::string& message) override {}
   void SetEyeDropperActive(bool active) override;
-  void ShowCertificateViewer(const std::string& cert_chain) override;
+  void ShowCertificateViewer(const std::string& cert_chain) override {}
   void ZoomIn() override;
   void ZoomOut() override;
   void ResetZoom() override;
@@ -130,11 +130,11 @@ class InspectableWebContents
       bool port_forwarding_enabled,
       const std::string& port_forwarding_config,
       bool network_discovery_enabled,
-      const std::string& network_discovery_config) override;
-  void SetDevicesUpdatesEnabled(bool enabled) override;
+      const std::string& network_discovery_config) override {}
+  void SetDevicesUpdatesEnabled(bool enabled) override {}
   void OpenRemotePage(const std::string& browser_id,
-                      const std::string& url) override;
-  void OpenNodeFrontend() override;
+                      const std::string& url) override {}
+  void OpenNodeFrontend() override {}
   void DispatchProtocolMessageFromDevToolsFrontend(
       const std::string& message) override;
   void RecordCountHistogram(const std::string& name,
@@ -156,7 +156,7 @@ class InspectableWebContents
   void ClearPreferences() override;
   void GetSyncInformation(DispatchCallback callback) override;
   void GetHostConfig(DispatchCallback callback) override;
-  void ConnectionReady() override;
+  void ConnectionReady() override {}
   void RegisterExtensionsAPI(const std::string& origin,
                              const std::string& script) override;
   void Reattach(DispatchCallback callback) override;
@@ -191,7 +191,7 @@ class InspectableWebContents
   // content::DevToolsAgentHostClient:
   void DispatchProtocolMessage(content::DevToolsAgentHost* agent_host,
                                base::span<const uint8_t> message) override;
-  void AgentHostClosed(content::DevToolsAgentHost* agent_host) override;
+  void AgentHostClosed(content::DevToolsAgentHost* agent_host) override {}
 
   // content::WebContentsObserver:
   void RenderFrameHostChanged(content::RenderFrameHost* old_host,

--- a/shell/browser/ui/tray_icon.cc
+++ b/shell/browser/ui/tray_icon.cc
@@ -12,19 +12,6 @@ TrayIcon::TrayIcon() = default;
 
 TrayIcon::~TrayIcon() = default;
 
-void TrayIcon::SetPressedImage(ImageType image) {}
-
-void TrayIcon::DisplayBalloon(const BalloonOptions& options) {}
-
-void TrayIcon::RemoveBalloon() {}
-
-void TrayIcon::Focus() {}
-
-void TrayIcon::PopUpContextMenu(const gfx::Point& pos,
-                                base::WeakPtr<ElectronMenuModel> menu_model) {}
-
-void TrayIcon::CloseContextMenu() {}
-
 gfx::Rect TrayIcon::GetBounds() {
   return gfx::Rect();
 }

--- a/shell/browser/ui/tray_icon.h
+++ b/shell/browser/ui/tray_icon.h
@@ -36,7 +36,7 @@ class TrayIcon {
   virtual void SetImage(ImageType image) = 0;
 
   // Sets the image associated with this status icon when pressed.
-  virtual void SetPressedImage(ImageType image);
+  virtual void SetPressedImage(ImageType image) {}
 
   // Sets the hover text for this status icon. This is also used as the label
   // for the menu item which is created as a replacement for the status icon
@@ -79,19 +79,19 @@ class TrayIcon {
 
   // Displays a notification balloon with the specified contents.
   // Depending on the platform it might not appear by the icon tray.
-  virtual void DisplayBalloon(const BalloonOptions& options);
+  virtual void DisplayBalloon(const BalloonOptions& options) {}
 
   // Removes the notification balloon.
-  virtual void RemoveBalloon();
+  virtual void RemoveBalloon() {}
 
   // Returns focus to the taskbar notification area.
-  virtual void Focus();
+  virtual void Focus() {}
 
   // Popups the menu.
   virtual void PopUpContextMenu(const gfx::Point& pos,
-                                base::WeakPtr<ElectronMenuModel> menu_model);
+                                base::WeakPtr<ElectronMenuModel> menu_model) {}
 
-  virtual void CloseContextMenu();
+  virtual void CloseContextMenu() {}
 
   // Set the context menu for this icon.
   virtual void SetContextMenu(raw_ptr<ElectronMenuModel> menu_model) = 0;

--- a/shell/browser/ui/views/electron_views_delegate.cc
+++ b/shell/browser/ui/views/electron_views_delegate.cc
@@ -64,10 +64,6 @@ ViewsDelegate::CreateDefaultNonClientFrameView(views::Widget* widget) {
   return nullptr;
 }
 
-void ViewsDelegate::AddRef() {}
-
-void ViewsDelegate::ReleaseRef() {}
-
 void ViewsDelegate::OnBeforeWidgetInit(
     views::Widget::InitParams* params,
     views::internal::NativeWidgetDelegate* delegate) {

--- a/shell/browser/ui/views/electron_views_delegate.h
+++ b/shell/browser/ui/views/electron_views_delegate.h
@@ -48,8 +48,8 @@ class ViewsDelegate : public views::ViewsDelegate {
 #endif
   std::unique_ptr<views::NonClientFrameView> CreateDefaultNonClientFrameView(
       views::Widget* widget) override;
-  void AddRef() override;
-  void ReleaseRef() override;
+  void AddRef() override {}
+  void ReleaseRef() override {}
   void OnBeforeWidgetInit(
       views::Widget::InitParams* params,
       views::internal::NativeWidgetDelegate* delegate) override;

--- a/shell/browser/ui/views/frameless_view.cc
+++ b/shell/browser/ui/views/frameless_view.cc
@@ -87,18 +87,6 @@ int FramelessView::NonClientHitTest(const gfx::Point& point) {
   return HTCLIENT;
 }
 
-void FramelessView::GetWindowMask(const gfx::Size& size, SkPath* window_mask) {}
-
-void FramelessView::ResetWindowControls() {}
-
-void FramelessView::UpdateWindowIcon() {}
-
-void FramelessView::InvalidateCaptionButtons() {}
-
-void FramelessView::UpdateWindowTitle() {}
-
-void FramelessView::SizeConstraintsChanged() {}
-
 views::View* FramelessView::TargetForRect(views::View* root,
                                           const gfx::Rect& rect) {
   CHECK_EQ(root, this);

--- a/shell/browser/ui/views/frameless_view.h
+++ b/shell/browser/ui/views/frameless_view.h
@@ -35,7 +35,7 @@ class FramelessView : public views::NonClientFrameView {
 
   // Tells the NonClientView to invalidate caption buttons
   // and forces a re-layout and re-paint.
-  virtual void InvalidateCaptionButtons();
+  virtual void InvalidateCaptionButtons() {}
 
   NativeWindowViews* window() const { return window_; }
   views::Widget* frame() const { return frame_; }
@@ -51,11 +51,11 @@ class FramelessView : public views::NonClientFrameView {
   gfx::Rect GetWindowBoundsForClientBounds(
       const gfx::Rect& client_bounds) const override;
   int NonClientHitTest(const gfx::Point& point) override;
-  void GetWindowMask(const gfx::Size& size, SkPath* window_mask) override;
-  void ResetWindowControls() override;
-  void UpdateWindowIcon() override;
-  void UpdateWindowTitle() override;
-  void SizeConstraintsChanged() override;
+  void GetWindowMask(const gfx::Size& size, SkPath* window_mask) override {}
+  void ResetWindowControls() override {}
+  void UpdateWindowIcon() override {}
+  void UpdateWindowTitle() override {}
+  void SizeConstraintsChanged() override {}
 
   // views::ViewTargeterDelegate:
   views::View* TargetForRect(views::View* root, const gfx::Rect& rect) override;

--- a/shell/browser/usb/usb_chooser_context.cc
+++ b/shell/browser/usb/usb_chooser_context.cc
@@ -64,14 +64,6 @@ bool ShouldExposeDevice(const device::mojom::UsbDeviceInfo& device_info) {
 
 namespace electron {
 
-void UsbChooserContext::DeviceObserver::OnDeviceAdded(
-    const device::mojom::UsbDeviceInfo& device_info) {}
-
-void UsbChooserContext::DeviceObserver::OnDeviceRemoved(
-    const device::mojom::UsbDeviceInfo& device_info) {}
-
-void UsbChooserContext::DeviceObserver::OnDeviceManagerConnectionError() {}
-
 UsbChooserContext::UsbChooserContext(ElectronBrowserContext* context)
     : browser_context_(context) {}
 

--- a/shell/browser/usb/usb_chooser_context.h
+++ b/shell/browser/usb/usb_chooser_context.h
@@ -47,9 +47,9 @@ class UsbChooserContext : public KeyedService,
   // connected.
   class DeviceObserver : public base::CheckedObserver {
    public:
-    virtual void OnDeviceAdded(const device::mojom::UsbDeviceInfo&);
-    virtual void OnDeviceRemoved(const device::mojom::UsbDeviceInfo&);
-    virtual void OnDeviceManagerConnectionError();
+    virtual void OnDeviceAdded(const device::mojom::UsbDeviceInfo&) {}
+    virtual void OnDeviceRemoved(const device::mojom::UsbDeviceInfo&) {}
+    virtual void OnDeviceManagerConnectionError() {}
 
     // Called when the BrowserContext is shutting down. Observers must remove
     // themselves before returning.

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -719,8 +719,6 @@ void SimpleURLLoaderWrapper::OnComplete(bool success) {
   pinned_chunk_pipe_getter_.Reset();
 }
 
-void SimpleURLLoaderWrapper::OnRetry(base::OnceClosure start_retry) {}
-
 void SimpleURLLoaderWrapper::OnResponseStarted(
     const GURL& final_url,
     const network::mojom::URLResponseHead& response_head) {

--- a/shell/common/api/electron_api_url_loader.h
+++ b/shell/common/api/electron_api_url_loader.h
@@ -73,7 +73,7 @@ class SimpleURLLoaderWrapper
   void OnDataReceived(std::string_view string_view,
                       base::OnceClosure resume) override;
   void OnComplete(bool success) override;
-  void OnRetry(base::OnceClosure start_retry) override;
+  void OnRetry(base::OnceClosure start_retry) override {}
 
   // network::mojom::URLLoaderNetworkServiceObserver:
   void OnAuthRequired(

--- a/shell/renderer/api/electron_api_spell_check_client.cc
+++ b/shell/renderer/api/electron_api_spell_check_client.cc
@@ -118,14 +118,9 @@ bool SpellCheckClient::IsSpellCheckingEnabled() const {
   return true;
 }
 
-void SpellCheckClient::ShowSpellingUI(bool show) {}
-
 bool SpellCheckClient::IsShowingSpellingUI() {
   return false;
 }
-
-void SpellCheckClient::UpdateSpellingUIWithMisspelledWord(
-    const blink::WebString& word) {}
 
 void SpellCheckClient::SpellCheckText() {
   const auto& text = pending_request_param_->text();

--- a/shell/renderer/api/electron_api_spell_check_client.h
+++ b/shell/renderer/api/electron_api_spell_check_client.h
@@ -48,10 +48,10 @@ class SpellCheckClient : public blink::WebSpellCheckPanelHostClient,
   bool IsSpellCheckingEnabled() const override;
 
   // blink::WebSpellCheckPanelHostClient:
-  void ShowSpellingUI(bool show) override;
+  void ShowSpellingUI(bool show) override {}
   bool IsShowingSpellingUI() override;
   void UpdateSpellingUIWithMisspelledWord(
-      const blink::WebString& word) override;
+      const blink::WebString& word) override {}
 
   struct SpellCheckScope {
     v8::HandleScope handle_scope_;


### PR DESCRIPTION
#### Description of Change

Code layout cleanup. No functional changes.

There are a lot of places where we declare a virtual method in a header and define an empty implementation (i.e. `{}`) in the cc file. Upstream puts the `{}` definition straight in the header. This removes the need for some cc boilerplate code. This PR changes our code to do it the way upstream does it.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.