### PR TITLE
refactor: extract logic to `ElectronExtensionsRendererClient`

### DIFF
--- a/shell/renderer/extensions/electron_extensions_renderer_client.cc
+++ b/shell/renderer/extensions/electron_extensions_renderer_client.cc
@@ -6,15 +6,30 @@
 
 #include <string>
 
+#include "base/lazy_instance.h"
+#include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_thread.h"
 #include "extensions/common/constants.h"
 #include "extensions/common/manifest_handlers/background_info.h"
 #include "extensions/renderer/dispatcher.h"
+#include "extensions/renderer/guest_view/mime_handler_view/mime_handler_view_container_manager.h"
 #include "shell/common/world_ids.h"
+#include "third_party/blink/public/platform/web_url.h"
+#include "third_party/blink/public/web/web_document.h"
+#include "third_party/blink/public/web/web_local_frame.h"
+#include "third_party/blink/public/web/web_plugin_params.h"
 
 namespace electron {
 
 ElectronExtensionsRendererClient::ElectronExtensionsRendererClient() {}
+
+// static
+ElectronExtensionsRendererClient*
+ElectronExtensionsRendererClient::GetInstance() {
+  static base::LazyInstance<ElectronExtensionsRendererClient>::Leaky client =
+      LAZY_INSTANCE_INITIALIZER;
+  return client.Pointer();
+}
 
 ElectronExtensionsRendererClient::~ElectronExtensionsRendererClient() = default;
 
@@ -27,8 +42,37 @@ int ElectronExtensionsRendererClient::GetLowestIsolatedWorldId() const {
   return WorldIDs::ISOLATED_WORLD_ID_EXTENSIONS;
 }
 
+// static
+bool ElectronExtensionsRendererClient::MaybeCreateMimeHandlerView(
+    const blink::WebElement& plugin_element,
+    const GURL& resource_url,
+    const std::string& mime_type,
+    const content::WebPluginInfo& plugin_info) {
+  return extensions::MimeHandlerViewContainerManager::Get(
+             content::RenderFrame::FromWebFrame(
+                 plugin_element.GetDocument().GetFrame()),
+             true /* create_if_does_not_exist */)
+      ->CreateFrameContainer(plugin_element, resource_url, mime_type,
+                             plugin_info);
+}
+
+v8::Local<v8::Object> ElectronExtensionsRendererClient::GetScriptableObject(
+    const blink::WebElement& plugin_element,
+    v8::Isolate* isolate) {
+  // If there is a MimeHandlerView that can provide the scriptable object then
+  // MaybeCreateMimeHandlerView must have been called before and a container
+  // manager should exist.
+  auto* container_manager = extensions::MimeHandlerViewContainerManager::Get(
+      content::RenderFrame::FromWebFrame(
+          plugin_element.GetDocument().GetFrame()),
+      false /* create_if_does_not_exist */);
+  if (container_manager)
+    return container_manager->GetScriptableObject(plugin_element, isolate);
+  return v8::Local<v8::Object>();
+}
+
 bool ElectronExtensionsRendererClient::AllowPopup() {
-  // TODO(samuelmaddock):
+  // TODO(samuelmaddock): what do we want to allow here?
   return false;
 }
 

--- a/shell/renderer/extensions/electron_extensions_renderer_client.h
+++ b/shell/renderer/extensions/electron_extensions_renderer_client.h
@@ -8,14 +8,30 @@
 #include <memory>
 
 #include "extensions/renderer/extensions_renderer_client.h"
+#include "v8/include/v8-local-handle.h"
+
+class GURL;
+
+namespace blink {
+class WebElement;
+class WebFrame;
+class WebURL;
+class WebView;
+}  // namespace blink
 
 namespace content {
 class RenderFrame;
-}
+struct WebPluginInfo;
+}  // namespace content
 
 namespace extensions {
 class Dispatcher;
 }
+
+namespace v8 {
+class Isolate;
+class Object;
+}  // namespace v8
 
 namespace electron {
 
@@ -31,11 +47,23 @@ class ElectronExtensionsRendererClient
   ElectronExtensionsRendererClient& operator=(
       const ElectronExtensionsRendererClient&) = delete;
 
-  // extensions::ExtensionsRendererClient:
+  // Get the LazyInstance for ElectronExtensionsRendererClient.
+  static ElectronExtensionsRendererClient* GetInstance();
+
+  // ExtensionsRendererClient implementation.
   bool IsIncognitoProcess() const override;
   int GetLowestIsolatedWorldId() const override;
 
   bool AllowPopup();
+
+  static bool MaybeCreateMimeHandlerView(
+      const blink::WebElement& plugin_element,
+      const GURL& resource_url,
+      const std::string& mime_type,
+      const content::WebPluginInfo& plugin_info);
+  v8::Local<v8::Object> GetScriptableObject(
+      const blink::WebElement& plugin_element,
+      v8::Isolate* isolate);
 
   void RunScriptsAtDocumentStart(content::RenderFrame* render_frame);
   void RunScriptsAtDocumentEnd(content::RenderFrame* render_frame);

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -101,6 +101,7 @@ class RendererClientBase : public content::ContentRendererClient
                             const blink::WebPluginParams& params,
                             blink::WebPlugin** plugin) override;
   void DidSetUserAgent(const std::string& user_agent) override;
+  bool AllowPopup() override;
   bool IsPluginHandledExternally(content::RenderFrame* render_frame,
                                  const blink::WebElement& plugin_element,
                                  const GURL& original_url,


### PR DESCRIPTION
#### Description of Change

Align our logic better with the approach taken by [upstream](https://source.chromium.org/chromium/chromium/src/+/main:chrome/renderer/chrome_content_renderer_client.cc) for logic delegated to `ElectronExtensionsRendererClient`. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none