### PR TITLE
fix: blank page when printing pdf

### DIFF
--- a/shell/browser/printing/printing_utils.h
+++ b/shell/browser/printing/printing_utils.h
@@ -14,6 +14,11 @@ namespace gfx {
 class Size;
 }
 
+namespace content {
+class RenderFrameHost;
+class WebContents;
+}  // namespace content
+
 namespace electron {
 
 // This function returns the per-platform default printer's DPI.
@@ -23,6 +28,9 @@ gfx::Size GetDefaultPrinterDPI(const std::u16string& device_name);
 // found on the network. We need to check this because Chromium does not do
 // sanity checking of device_name validity and so will crash on invalid names.
 bool IsDeviceNameValid(const std::u16string& device_name);
+
+content::RenderFrameHost* GetRenderFrameHostToUse(
+    content::WebContents* contents);
 
 // This function returns a validated device name.
 // If the user passed one to webContents.print(), we check that it's valid and

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2204,6 +2204,10 @@ describe('webContents module', () => {
   ifdescribe(features.isPrintingEnabled())('printToPDF()', () => {
     let w: BrowserWindow;
 
+    const containsText = (items: any[], text: RegExp) => {
+      return items.some(({ str }: { str: string }) => str.match(text));
+    };
+
     beforeEach(() => {
       w = new BrowserWindow({
         show: false,
@@ -2326,7 +2330,7 @@ describe('webContents module', () => {
     });
 
     it('with custom header and footer', async () => {
-      await w.loadFile(path.join(__dirname, 'fixtures', 'api', 'print-to-pdf-small.html'));
+      await w.loadFile(path.join(fixturesPath, 'api', 'print-to-pdf-small.html'));
 
       const data = await w.webContents.printToPDF({
         displayHeaderFooter: true,
@@ -2339,11 +2343,8 @@ describe('webContents module', () => {
 
       const { items } = await page.getTextContent();
 
-      // Check that generated PDF contains a header.
-      const containsText = (text: RegExp) => items.some(({ str }: { str: string }) => str.match(text));
-
-      expect(containsText(/I'm a PDF header/)).to.be.true();
-      expect(containsText(/I'm a PDF footer/)).to.be.true();
+      expect(containsText(items, /I'm a PDF header/)).to.be.true();
+      expect(containsText(items, /I'm a PDF footer/)).to.be.true();
     });
 
     it('in landscape mode', async () => {
@@ -2394,6 +2395,25 @@ describe('webContents module', () => {
         UserProperties: false,
         Suspects: false
       });
+    });
+
+    it('from an existing pdf document', async () => {
+      const pdfPath = path.join(fixturesPath, 'cat.pdf');
+      await w.loadFile(pdfPath);
+
+      // TODO(codebytere): the PDF plugin is not always ready immediately
+      // after the document is loaded, so we need to wait for it to be ready.
+      // We should find a better way to do this.
+      await setTimeout(3000);
+
+      const data = await w.webContents.printToPDF({});
+      const doc = await pdfjs.getDocument(data).promise;
+      expect(doc.numPages).to.equal(2);
+
+      const page = await doc.getPage(1);
+
+      const { items } = await page.getTextContent();
+      expect(containsText(items, /Cat: The Ideal Pet/)).to.be.true();
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/30947.

Fixes an issue where calling `window.print()`, `webContents.print()` or `printToPDF` from an existing PDF document resulted in a blank page. This was happening because we were using the incorrect `RenderFrameHost` in that case - we need to ensure we're using the one corresponding to the PDF plugin.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where calling `window.print()`, `webContents.print()` or `printToPDF` from an existing PDF document resulted in a blank page. 
