### PR TITLE
build: update NMV to 130 for Electron 33

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -2,7 +2,7 @@ is_electron_build = true
 root_extra_deps = [ "//electron" ]
 
 # Registry of NMVs --> https://github.com/nodejs/node/blob/main/doc/abi_version_registry.json
-node_module_version = 128
+node_module_version = 130
 
 v8_promise_internal_field_count = 1
 v8_embedder_string = "-electron.0"


### PR DESCRIPTION
In preparation for releasing Electron 32, we are reserving a new Node Module Version in advance for Electron 33.

Node.js PR: ✅ https://github.com/nodejs/node/pull/54383 (Merged)

Notes: none