### PR TITLE
chore: remove unused ConvertableToTraceFormatWrapper

### DIFF
--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -31,48 +31,6 @@ namespace {
 v8::Isolate* g_isolate;
 }
 
-namespace gin {
-
-class ConvertableToTraceFormatWrapper final
-    : public base::trace_event::ConvertableToTraceFormat {
- public:
-  explicit ConvertableToTraceFormatWrapper(
-      std::unique_ptr<v8::ConvertableToTraceFormat> inner)
-      : inner_(std::move(inner)) {}
-  ~ConvertableToTraceFormatWrapper() override = default;
-
-  // disable copy
-  ConvertableToTraceFormatWrapper(const ConvertableToTraceFormatWrapper&) =
-      delete;
-  ConvertableToTraceFormatWrapper& operator=(
-      const ConvertableToTraceFormatWrapper&) = delete;
-
-  void AppendAsTraceFormat(std::string* out) const final {
-    inner_->AppendAsTraceFormat(out);
-  }
-
- private:
-  std::unique_ptr<v8::ConvertableToTraceFormat> inner_;
-};
-
-}  // namespace gin
-
-// Allow std::unique_ptr<v8::ConvertableToTraceFormat> to be a valid
-// initialization value for trace macros.
-template <>
-struct base::trace_event::TraceValue::Helper<
-    std::unique_ptr<v8::ConvertableToTraceFormat>> {
-  static constexpr unsigned char kType = TRACE_VALUE_TYPE_CONVERTABLE;
-  static inline void SetValue(
-      TraceValue* v,
-      std::unique_ptr<v8::ConvertableToTraceFormat> value) {
-    // NOTE: |as_convertable| is an owning pointer, so using new here
-    // is acceptable.
-    v->as_convertable =
-        new gin::ConvertableToTraceFormatWrapper(std::move(value));
-  }
-};
-
 namespace electron {
 
 namespace {


### PR DESCRIPTION

#### Description of Change

Remove unused helper class `ConvertableToTraceFormatWrapper` and unique_ptr trace helper.

Last use removed in Apr 2024 (39bf441b, #41880)

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.