### PR TITLE
refactor: NodeBindings::Create() returns a unique_ptr

### DIFF
--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -84,7 +84,7 @@ class NodeBindings {
  public:
   enum class BrowserEnvironment { kBrowser, kRenderer, kUtility, kWorker };
 
-  static NodeBindings* Create(BrowserEnvironment browser_env);
+  static std::unique_ptr<NodeBindings> Create(BrowserEnvironment browser_env);
   static void RegisterBuiltinBindings();
   static bool IsInitialized();
 

--- a/shell/common/node_bindings_linux.cc
+++ b/shell/common/node_bindings_linux.cc
@@ -33,8 +33,8 @@ void NodeBindingsLinux::PollEvents() {
 }
 
 // static
-NodeBindings* NodeBindings::Create(BrowserEnvironment browser_env) {
-  return new NodeBindingsLinux(browser_env);
+std::unique_ptr<NodeBindings> NodeBindings::Create(BrowserEnvironment env) {
+  return std::make_unique<NodeBindingsLinux>(env);
 }
 
 }  // namespace electron

--- a/shell/common/node_bindings_mac.cc
+++ b/shell/common/node_bindings_mac.cc
@@ -41,8 +41,8 @@ void NodeBindingsMac::PollEvents() {
 }
 
 // static
-NodeBindings* NodeBindings::Create(BrowserEnvironment browser_env) {
-  return new NodeBindingsMac(browser_env);
+std::unique_ptr<NodeBindings> NodeBindings::Create(BrowserEnvironment env) {
+  return std::make_unique<NodeBindingsMac>(env);
 }
 
 }  // namespace electron

--- a/shell/common/node_bindings_win.cc
+++ b/shell/common/node_bindings_win.cc
@@ -50,8 +50,8 @@ void NodeBindingsWin::PollEvents() {
 }
 
 // static
-NodeBindings* NodeBindings::Create(BrowserEnvironment browser_env) {
-  return new NodeBindingsWin(browser_env);
+std::unique_ptr<NodeBindings> NodeBindings::Create(BrowserEnvironment env) {
+  return std::make_unique<NodeBindingsWin>(env);
 }
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

Cleanup PR to make `NodeBindings::Create()` follow Chromium's  [object ownership calling conventions](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md#object-ownership-and-calling-conventions): ownership of the new object is being handed off to the caller, so return it as a `std::unique_ptr<NodeBindings>`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.