### PR TITLE
chore: remove unused method Erase()

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -145,11 +145,6 @@ class LinuxUiGetterImpl : public ui::LinuxUiGetter {
 };
 #endif
 
-template <typename T>
-void Erase(T* container, typename T::iterator iter) {
-  container->erase(iter);
-}
-
 #if BUILDFLAG(IS_WIN)
 int GetMinimumFontSize() {
   int min_font_size;


### PR DESCRIPTION
Manual backport of #43348. See that PR for details.

Notes: none.