### PR TITLE
fix: documentation spelling errors

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -1511,7 +1511,7 @@ Returns `Promise<void>` - resolves when all data has been cleared.
 
 Clears various different types of data.
 
-This method clears more types of data and is more thourough than the
+This method clears more types of data and is more thorough than the
 `clearStorageData` method.
 
 **Note:** Cookies are stored at a broader scope than origins. When removing cookies and filtering by `origins` (or `excludeOrigins`), the cookies will be removed at the [registrable domain](https://url.spec.whatwg.org/#host-registrable-domain) level. For example, clearing cookies for the origin `https://really.specific.origin.example.com/` will end up clearing all cookies for `example.com`. Clearing cookies for the origin `https://my.website.example.co.uk/` will end up clearing all cookies for `example.co.uk`.

--- a/docs/api/touch-bar-scrubber.md
+++ b/docs/api/touch-bar-scrubber.md
@@ -39,7 +39,7 @@ updates the control in the touch bar. Possible values:
 
 #### `touchBarScrubber.overlayStyle`
 
-A `string` representing the style that selected items in the scrubber should have. This style is overlayed on top
+A `string` representing the style that selected items in the scrubber should have. This style is overlaid on top
 of the scrubber item instead of being placed behind it. Updating this value immediately updates the control in the
 touch bar. Possible values:
 

--- a/docs/api/web-utils.md
+++ b/docs/api/web-utils.md
@@ -14,7 +14,7 @@ The `webUtils` module has the following methods:
 
 Returns `string` - The file system path that this `File` object points to. In the case where the object passed in is not a `File` object an exception is thrown. In the case where the File object passed in was constructed in JS and is not backed by a file on disk an empty string is returned.
 
-This method superceded the previous augmentation to the `File` object with the `path` property.  An example is included below.
+This method superseded the previous augmentation to the `File` object with the `path` property.  An example is included below.
 
 ```js
 // Before


### PR DESCRIPTION
#### Description of Change
Fix typos only

#### Checklist

Typos only.

I was unable to run tests, since [Build Tools has Xcode issues](https://github.com/electron/build-tools/issues/514#issuecomment-2298204226)

#### Release Notes

Notes: none