### PR TITLE
refactor: move impl functions into private namespace

### DIFF
--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -102,10 +102,6 @@ void SetCrashKeyStub(const std::string& key, const std::string& value) {}
 void ClearCrashKeyStub(const std::string& key) {}
 #endif
 
-}  // namespace
-
-namespace electron {
-
 v8::Local<v8::Value> GetParameters(v8::Isolate* isolate) {
   std::map<std::string, std::string> keys;
 #if !IS_MAS_BUILD()
@@ -113,6 +109,10 @@ v8::Local<v8::Value> GetParameters(v8::Isolate* isolate) {
 #endif
   return gin::ConvertToV8(isolate, keys);
 }
+
+}  // namespace
+
+namespace electron {
 
 int NodeMain(int argc, char* argv[]) {
   bool initialized = base::CommandLine::Init(argc, argv);

--- a/shell/browser/api/electron_api_crash_reporter.cc
+++ b/shell/browser/api/electron_api_crash_reporter.cc
@@ -81,6 +81,8 @@ const std::map<std::string, std::string>& GetGlobalCrashKeys() {
   return GetGlobalCrashKeysMutable();
 }
 
+namespace {
+
 bool GetClientIdPath(base::FilePath* path) {
   if (base::PathService::Get(electron::DIR_CRASH_DUMPS, path)) {
     *path = path->Append("client_id");
@@ -108,6 +110,8 @@ void WriteClientId(const std::string& client_id) {
   if (GetClientIdPath(&client_id_path))
     base::WriteFile(client_id_path, client_id);
 }
+
+}  // namespace
 
 std::string GetClientId() {
   static base::NoDestructor<std::string> client_id;

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -46,6 +46,7 @@
 #include "ui/base/cocoa/permissions_utils.h"
 #endif
 
+namespace {
 #if BUILDFLAG(IS_LINUX)
 // Private function in ui/base/x/x11_display_util.cc
 base::flat_map<x11::RandR::Output, int> GetMonitors(
@@ -141,8 +142,6 @@ base::flat_map<int32_t, uint32_t> MonitorAtomIdToDisplayId() {
   return monitor_atom_to_display;
 }
 #endif
-
-namespace {
 
 std::unique_ptr<ThumbnailCapturer> MakeWindowCapturer() {
 #if BUILDFLAG(IS_MAC)

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -874,6 +874,8 @@ void ElectronBrowserClient::RenderProcessExited(
   }
 }
 
+namespace {
+
 void OnOpenExternal(const GURL& escaped_url, bool allowed) {
   if (allowed) {
     platform_util::OpenExternal(
@@ -909,6 +911,8 @@ void HandleExternalProtocolInUI(
   permission_helper->RequestOpenExternalPermission(rfh, std::move(callback),
                                                    has_user_gesture, url);
 }
+
+}  // namespace
 
 bool ElectronBrowserClient::HandleExternalProtocol(
     const GURL& url,

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1543,6 +1543,7 @@ void ElectronBrowserClient::BindHostReceiverForRenderer(
 }
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+namespace {
 void BindMimeHandlerService(
     content::RenderFrameHost* frame_host,
     mojo::PendingReceiver<extensions::mime_handler::MimeHandlerService>
@@ -1571,6 +1572,7 @@ void BindBeforeUnloadControl(
     return;
   guest_view->FuseBeforeUnloadControl(std::move(receiver));
 }
+}  // namespace
 #endif
 
 void ElectronBrowserClient::ExposeInterfacesToRenderer(
@@ -1710,6 +1712,8 @@ content::UsbDelegate* ElectronBrowserClient::GetUsbDelegate() {
   return usb_delegate_.get();
 }
 
+namespace {
+
 void BindBadgeServiceForServiceWorker(
     const content::ServiceWorkerVersionBaseInfo& info,
     mojo::PendingReceiver<blink::mojom::BadgeService> receiver) {
@@ -1723,6 +1727,8 @@ void BindBadgeServiceForServiceWorker(
   badging::BadgeManager::BindServiceWorkerReceiver(
       render_process_host, info.scope, std::move(receiver));
 }
+
+}  // namespace
 
 void ElectronBrowserClient::RegisterBrowserInterfaceBindersForServiceWorker(
     content::BrowserContext* browser_context,

--- a/shell/browser/extensions/api/tabs/tabs_api.cc
+++ b/shell/browser/extensions/api/tabs/tabs_api.cc
@@ -468,6 +468,8 @@ ExtensionFunction::ResponseAction TabsSetZoomSettingsFunction::Run() {
   return RespondNow(NoArguments());
 }
 
+namespace {
+
 bool IsKillURL(const GURL& url) {
 #if DCHECK_IS_ON()
   // Caller should ensure that |url| is already "fixed up" by
@@ -586,6 +588,8 @@ base::expected<GURL, std::string> PrepareURLForNavigation(
 
   return url;
 }
+
+}  // namespace
 
 TabsUpdateFunction::TabsUpdateFunction() : web_contents_(nullptr) {}
 

--- a/shell/browser/serial/serial_chooser_context.cc
+++ b/shell/browser/serial/serial_chooser_context.cc
@@ -37,6 +37,8 @@ constexpr char kUsbDriverKey[] = "usb_driver";
 #endif  // BUILDFLAG(IS_MAC)
 #endif  // BUILDFLAG(IS_WIN)
 
+namespace {
+
 std::string EncodeToken(const base::UnguessableToken& token) {
   const uint64_t data[2] = {token.GetHighForSerialization(),
                             token.GetLowForSerialization()};
@@ -80,6 +82,8 @@ base::Value PortInfoToValue(const device::mojom::SerialPortInfo& port) {
   }
   return base::Value(std::move(value));
 }
+
+}  // namespace
 
 SerialChooserContext::SerialChooserContext(ElectronBrowserContext* context)
     : browser_context_(context) {}

--- a/shell/common/asar/asar_util.cc
+++ b/shell/common/asar/asar_util.cc
@@ -45,8 +45,6 @@ bool IsDirectoryCached(const base::FilePath& path) {
   return is_directory_cache[path] = base::DirectoryExists(path);
 }
 
-}  // namespace
-
 ArchiveMap& GetArchiveCache() {
   static base::NoDestructor<ArchiveMap> s_archive_map;
   return *s_archive_map;
@@ -56,6 +54,8 @@ base::Lock& GetArchiveCacheLock() {
   static base::NoDestructor<base::Lock> lock;
   return *lock;
 }
+
+}  // namespace
 
 std::shared_ptr<Archive> GetOrCreateAsarArchive(const base::FilePath& path) {
   base::AutoLock auto_lock(GetArchiveCacheLock());

--- a/shell/common/extensions/electron_extensions_api_provider.cc
+++ b/shell/common/extensions/electron_extensions_api_provider.cc
@@ -27,6 +27,7 @@
 #include "shell/common/extensions/api/permission_features.h"
 
 namespace extensions {
+namespace {
 
 constexpr APIPermissionInfo::InitInfo permissions_to_register[] = {
     {mojom::APIPermissionID::kDevtools, "devtools",
@@ -51,6 +52,7 @@ base::span<const Alias> GetPermissionAliases() {
   return base::span<const Alias>();
 }
 
+}  // namespace
 }  // namespace extensions
 
 namespace electron {

--- a/shell/common/gin_helper/cleaned_up_at_exit.cc
+++ b/shell/common/gin_helper/cleaned_up_at_exit.cc
@@ -11,10 +11,15 @@
 
 namespace gin_helper {
 
+namespace {
+
 std::vector<CleanedUpAtExit*>& GetDoomed() {
   static base::NoDestructor<std::vector<CleanedUpAtExit*>> doomed;
   return *doomed;
 }
+
+}  // namespace
+
 CleanedUpAtExit::CleanedUpAtExit() {
   GetDoomed().emplace_back(this);
 }

--- a/shell/common/logging.cc
+++ b/shell/common/logging.cc
@@ -41,6 +41,8 @@ base::FilePath GetLogFileName(const base::CommandLine& command_line) {
   }
 }
 
+namespace {
+
 bool HasExplicitLogFile(const base::CommandLine& command_line) {
   std::string filename = command_line.GetSwitchValueASCII(switches::kLogFile);
   if (filename.empty())
@@ -94,6 +96,8 @@ LoggingDestination DetermineLoggingDestination(
     return LOG_TO_FILE | (also_log_to_stderr ? LOG_TO_STDERR : 0);
   return LOG_TO_SYSTEM_DEBUG_LOG | LOG_TO_STDERR;
 }
+
+}  // namespace
 
 void InitElectronLogging(const base::CommandLine& command_line,
                          bool is_preinit) {


### PR DESCRIPTION
#### Description of Change

We have about two dozen impl / helper functions that were accidentally visible in public namespaces. This PR makes them private.

No behavior changes; just making impl details private. Should be good as long as it builds.

- AllowFileAccess()
- BindBadgeServiceForServiceWorker()
- BindBeforeUnloadControl()
- BindMimeHandlerService()
- DetermineLoggingDestination()
- EncodeToken()
- GetArchiveCache()
- GetArchiveCacheLock()
- GetClientIdPath()
- GetDoomed()
- GetEDIDProperty()
- GetMonitors()
- GetParameters()
- GetPermissionAliases()
- GetPermissionInfos()
- HandleExternalProtocolInUI()
- HasExplicitLogFile()
- IsKillURL()
- MonitorAtomIdToDisplayId()
- OnOpenExternal()
- PortInfoToValue()
- PrepareURLForNavigation()
- ReadClientId()
- ResolvePossiblyRelativeURL()
- WriteClientId()

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.