### PR TITLE
chore: fix typos in 'shell/' folder.

### DIFF
--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -261,7 +261,7 @@ class ClearDataTask {
   }
 
  private:
-  // An individiual |content::BrowsingDataRemover::Remove...| operation as part
+  // An individual |content::BrowsingDataRemover::Remove...| operation as part
   // of a full |ClearDataTask|. This class manages its own lifetime, cleaning
   // itself up after the operation completes and notifies the task of the
   // result.

--- a/shell/browser/extensions/api/scripting/scripting_api.cc
+++ b/shell/browser/extensions/api/scripting/scripting_api.cc
@@ -519,7 +519,7 @@ api::scripting::RegisteredContentScript CreateRegisteredContentScriptInfo(
         converted.reserve(sources.size());
         for (auto& source : sources) {
           CHECK(source.file)
-              << "Content scripts don't allow arbtirary code strings";
+              << "Content scripts don't allow arbitrary code strings";
           converted.push_back(std::move(*source.file));
         }
         return converted;

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -448,7 +448,7 @@ class NativeWindow : public base::SupportsUserData,
   // Minimum and maximum size.
   std::optional<extensions::SizeConstraints> size_constraints_;
   // Same as above but stored as content size, we are storing 2 types of size
-  // constraints beacause converting between them will cause rounding errors
+  // constraints because converting between them will cause rounding errors
   // on HiDPI displays on some environments.
   std::optional<extensions::SizeConstraints> content_size_constraints_;
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -569,7 +569,7 @@ bool NativeWindowViews::IsVisible() const {
   // current window.
   bool visible =
       ::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE) & WS_VISIBLE;
-  // WS_VISIBLE is true even if a window is miminized - explicitly check that.
+  // WS_VISIBLE is true even if a window is minimized - explicitly check that.
   return visible && !IsMinimized();
 #else
   return widget()->IsVisible();

--- a/shell/browser/net/asar/asar_url_loader_factory.h
+++ b/shell/browser/net/asar/asar_url_loader_factory.h
@@ -9,7 +9,7 @@
 
 namespace mojo {
 template <typename T>
-class PendingReciever;
+class PendingReceiver;
 template <typename T>
 class PendingRemote;
 }  // namespace mojo

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -35,7 +35,7 @@
 
 namespace mojo {
 template <typename T>
-class PendingReciever;
+class PendingReceiver;
 template <typename T>
 class PendingRemote;
 }  // namespace mojo

--- a/shell/browser/usb/electron_usb_delegate.h
+++ b/shell/browser/usb/electron_usb_delegate.h
@@ -27,7 +27,7 @@ class RenderFrameHost;
 
 namespace mojo {
 template <typename T>
-class PendingReciever;
+class PendingReceiver;
 template <typename T>
 class PendingRemote;
 }  // namespace mojo

--- a/shell/browser/usb/usb_chooser_context.h
+++ b/shell/browser/usb/usb_chooser_context.h
@@ -24,7 +24,7 @@
 
 namespace mojo {
 template <typename T>
-class PendingReciever;
+class PendingReceiver;
 template <typename T>
 class PendingRemote;
 }  // namespace mojo

--- a/shell/common/extensions/api/browser_action.json
+++ b/shell/common/extensions/api/browser_action.json
@@ -344,7 +344,7 @@
               "name": "popupView",
               "type": "object",
               "optional": true,
-              "description": "JavaScript 'window' object for the popup window if it was succesfully opened.",
+              "description": "JavaScript 'window' object for the popup window if it was successfully opened.",
               "additionalProperties": {
                 "type": "any"
               }

--- a/shell/common/gin_converters/callback_converter.h
+++ b/shell/common/gin_converters/callback_converter.h
@@ -18,11 +18,11 @@ struct Converter<base::RepeatingCallback<Sig>> {
                                    const base::RepeatingCallback<Sig>& val) {
     // We don't use CreateFunctionTemplate here because it creates a new
     // FunctionTemplate everytime, which is cached by V8 and causes leaks.
-    auto translater =
+    auto translator =
         base::BindRepeating(&gin_helper::NativeFunctionInvoker<Sig>::Go, val);
     // To avoid memory leak, we ensure that the callback can only be called
     // for once.
-    return gin_helper::CreateFunctionFromTranslater(isolate, translater, true);
+    return gin_helper::CreateFunctionFromTranslator(isolate, translator, true);
   }
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,

--- a/shell/common/gin_helper/callback.h
+++ b/shell/common/gin_helper/callback.h
@@ -117,9 +117,9 @@ struct V8FunctionInvoker<ReturnType(ArgTypes...)> {
 };
 
 // Helper to pass a C++ function to JavaScript.
-using Translater = base::RepeatingCallback<void(gin::Arguments* args)>;
-v8::Local<v8::Value> CreateFunctionFromTranslater(v8::Isolate* isolate,
-                                                  const Translater& translater,
+using Translator = base::RepeatingCallback<void(gin::Arguments* args)>;
+v8::Local<v8::Value> CreateFunctionFromTranslator(v8::Isolate* isolate,
+                                                  const Translator& translator,
                                                   bool one_time);
 v8::Local<v8::Value> BindFunctionWith(v8::Isolate* isolate,
                                       v8::Local<v8::Context> context,
@@ -149,9 +149,9 @@ template <typename Sig>
 v8::Local<v8::Value> CallbackToV8Leaked(
     v8::Isolate* isolate,
     const base::RepeatingCallback<Sig>& val) {
-  Translater translater =
+  Translator translator =
       base::BindRepeating(&NativeFunctionInvoker<Sig>::Go, val);
-  return CreateFunctionFromTranslater(isolate, translater, false);
+  return CreateFunctionFromTranslator(isolate, translator, false);
 }
 
 }  // namespace gin_helper


### PR DESCRIPTION
Fixes typos in the `shell/` folder

@ckerr [suggested](https://github.com/electron/electron/pull/43366#pullrequestreview-2248182635) I split what was originally a single PR with changes into 39 files into many.

Notes: none.
