### PR TITLE
chore: fix typos in 'patches/' folder.

### DIFF
--- a/patches/chromium/crashpad_pid_check.patch
+++ b/patches/chromium/crashpad_pid_check.patch
@@ -7,9 +7,9 @@ When both browser process and renderer process are connecting to the pipe,
 the API may return the PID of browser process as real_pid, which is different
 from the PID of renderer process.
 
-This is caused by the crashReporter getting started after the sanbox, after
-we redesign crashReporter's API to make it alwasy start before the
-sanbox, we can remove this patch.
+This is caused by the crashReporter getting started after the sandbox, after
+we redesign crashReporter's API to make it always start before the
+sandbox, we can remove this patch.
 
 See following links for more:
 https://github.com/electron/electron/pull/18483#discussion_r292703588

--- a/patches/chromium/dump_syms.patch
+++ b/patches/chromium/dump_syms.patch
@@ -5,7 +5,7 @@ Subject: dump_syms.patch
 
 dylib currently fails to resolve Squirrel.framework on OSX, we need to fix
 this but it is not a blocker for releasing Electron.  This patch removes
-tthe hard fail on dylib resolve failure from dump_syms
+the hard fail on dylib resolve failure from dump_syms
 
 diff --git a/components/crash/content/tools/generate_breakpad_symbols.py b/components/crash/content/tools/generate_breakpad_symbols.py
 index 1e5ebd243c1f1eeb37d087a9d72afcfd947ec6a0..fe43b91f5c52e3f99dcec9cddb3cacfae1eb4646 100755

--- a/patches/chromium/feat_configure_launch_options_for_service_process.patch
+++ b/patches/chromium/feat_configure_launch_options_for_service_process.patch
@@ -9,7 +9,7 @@ Subject: feat: configure launch options for service process
   Allows configuring base::LaunchOptions::handles_to_inherit, base::LaunchOptions::stdout_handle
   and base::LaunchOptions::stderr_handle when launching the child process.
 - All:
-  Allows configuring base::LauncOptions::current_directory, base::LaunchOptions::enviroment
+  Allows configuring base::LauncOptions::current_directory, base::LaunchOptions::environment
   and base::LaunchOptions::clear_environment.
 
 An example use of this option, UtilityProcess API allows reading the output From
@@ -317,7 +317,7 @@ index 9791ae2f761043b9eecd9064a6fd39a6e2339af4..1083f1683a05825f51f5b2d71f8107d9
 +  // If not empty, change to this directory before executing the new process.
 +  base::FilePath current_directory_;
 +
-+  // Inherit enviroment from parent process.
++  // Inherit environment from parent process.
 +  bool inherit_environment_ = true;
 +
    // Indicates whether the process has been successfully launched yet, or if

--- a/patches/chromium/feat_ensure_mas_builds_of_the_same_application_can_use_safestorage.patch
+++ b/patches/chromium/feat_ensure_mas_builds_of_the_same_application_can_use_safestorage.patch
@@ -3,7 +3,7 @@ From: Samuel Attard <sattard@salesforce.com>
 Date: Thu, 29 Sep 2022 16:58:47 -0700
 Subject: feat: ensure mas builds of the same application can use safestorage
 
-This change ensures that MAS builds of applications with an equivilant darwin build that share the same name do not fight over access to the same Safe Storage account.
+This change ensures that MAS builds of applications with an equivalent darwin build that share the same name do not fight over access to the same Safe Storage account.
 
 Specifically this changes the account name for app "My App" from "My App" to "My App AppStore" if the app is using a MAS build of Electron.
 

--- a/patches/chromium/introduce_ozoneplatform_electron_can_call_x11_property.patch
+++ b/patches/chromium/introduce_ozoneplatform_electron_can_call_x11_property.patch
@@ -3,7 +3,7 @@ From: Marek Rusinowski <marekrusinowski@gmail.com>
 Date: Wed, 23 Mar 2022 21:09:37 +0100
 Subject: introduce OzonePlatform::electron_can_call_x11 property
 
-We expose this additonal property in the OzonePlatform to be able to easily
+We expose this additional property in the OzonePlatform to be able to easily
 determine whatever we can call X11 functions without crashing the application
 at rutime. It would be best if eventually all usages of this property were
 replaced with clean ozone native implementations.

--- a/patches/nan/apply_allcan_read_write.patch
+++ b/patches/nan/apply_allcan_read_write.patch
@@ -8,7 +8,7 @@ Should be upstreamed.
 
 Module version checks are made against 119 since that is the current assigned version
 for Electron 28 in https://github.com/nodejs/node/blob/main/doc/abi_version_registry.json.
-The version should be updateed to the one assinged for Electron 29 when it is available.
+The version should be updated to the one assigned for Electron 29 when it is available.
 
 Steps for upstreaming this patch:
 

--- a/patches/node/fix_add_property_query_interceptors.patch
+++ b/patches/node/fix_add_property_query_interceptors.patch
@@ -4,7 +4,7 @@ Date: Mon, 24 Jun 2024 21:48:40 -0700
 Subject: fix: add property query interceptors
 
 This commit cherry-picks an upstream interceptor API change
-from node-v8/canary to accomodate V8's upstream changes to old
+from node-v8/canary to accommodate V8's upstream changes to old
 interceptor APIs.
 
 Node PR: https://github.com/nodejs/node-v8/commit/d1f18b0bf16efbc1e54ba04a54735ce4683cb936

--- a/patches/node/fix_capture_embedder_exceptions_before_entering_v8.patch
+++ b/patches/node/fix_capture_embedder_exceptions_before_entering_v8.patch
@@ -3,7 +3,7 @@ From: deepak1556 <hop2deep@gmail.com>
 Date: Tue, 26 Dec 2023 02:10:42 +0900
 Subject: fix: capture embedder exceptions before entering V8
 
-Upstrem bug: https://github.com/nodejs/node-v8/issues/274
+Upstream bug: https://github.com/nodejs/node-v8/issues/274
 
 The patch only addresses the callsites that triggered failing DCHECKS
 in the nodejs test suite. Need to be followed-up with upstream

--- a/patches/squirrel.mac/build_add_gn_config.patch
+++ b/patches/squirrel.mac/build_add_gn_config.patch
@@ -496,7 +496,7 @@ index 0000000000000000000000000000000000000000..bdfaf95f3eca65b3e0831db1b66f651d
 @@ -0,0 +1,18 @@
 +template("xcrun_action") {
 +  assert(defined(invoker.cmd), "Need cmd name to run")
-+  assert(defined(invoker.args), "Need cmd argumets")
++  assert(defined(invoker.args), "Need cmd arguments")
 +  assert(defined(invoker.inputs), "Need inputs")
 +  assert(defined(invoker.outputs), "Need outputs")
 +

--- a/patches/squirrel.mac/feat_add_ability_to_prevent_version_downgrades.patch
+++ b/patches/squirrel.mac/feat_add_ability_to_prevent_version_downgrades.patch
@@ -3,7 +3,7 @@ From: Samuel Attard <marshallofsound@electronjs.org>
 Date: Tue, 6 Jun 2023 15:20:38 -0700
 Subject: feat: add ability to prevent version downgrades
 
-The ElectronSquirrelPreventDowngrades flag in your Info.plist can enable this feature, it must be set to true.  This feature prevents a class of downgrade / freeze issues but has significant drawbacks in that it may break existing apps that delibrately downgrade users via the updater and requires that version strings are exactly A.B.C in order for the version comparison logic to work.  Because of this this feature can not (and is not) enabled by default.
+The ElectronSquirrelPreventDowngrades flag in your Info.plist can enable this feature, it must be set to true.  This feature prevents a class of downgrade / freeze issues but has significant drawbacks in that it may break existing apps that deliberately downgrade users via the updater and requires that version strings are exactly A.B.C in order for the version comparison logic to work.  Because of this this feature can not (and is not) enabled by default.
 
 diff --git a/Squirrel/SQRLUpdater.h b/Squirrel/SQRLUpdater.h
 index b3526b246b3729a7556ca0ec348fdc08825c89ed..87119399e8548e04134d1ee0cd18f85c2ad672c2 100644

--- a/patches/v8/chore_allow_customizing_microtask_policy_per_context.patch
+++ b/patches/v8/chore_allow_customizing_microtask_policy_per_context.patch
@@ -5,7 +5,7 @@ Subject: chore: allow customizing microtask policy per context
 
 With https://github.com/electron/electron/issues/36813, microtask queue associated with a context
 will be used if available, instead of the default associated with an isolate. We need the
-capability to switch the microtask polciy of these per context microtask queue to support
+capability to switch the microtask policy of these per context microtask queue to support
 Node.js integration in the renderer.
 
 diff --git a/include/v8-microtask-queue.h b/include/v8-microtask-queue.h

--- a/patches/v8/deps_add_v8_object_setinternalfieldfornodecore.patch
+++ b/patches/v8/deps_add_v8_object_setinternalfieldfornodecore.patch
@@ -28,17 +28,17 @@ index 71a6c2c9c149116caa410d25aef4087774b81b44..ad8416ea2500f10aad31f25da96b235f
    }
  
 +  /**
-+   * Warning: These are Node.js-specific extentions used to avoid breaking
++   * Warning: These are Node.js-specific extensions used to avoid breaking
 +   * changes in Node.js v20.x. They do not exist in V8 upstream and will
 +   * not exist in Node.js v21.x. Node.js embedders and addon authors should
 +   * not use them from v20.x.
 +   */
 +#ifndef NODE_WANT_INTERNALS
-+  V8_DEPRECATED("This extention should only be used by Node.js core")
++  V8_DEPRECATED("This extension should only be used by Node.js core")
 +#endif
 +  void SetInternalFieldForNodeCore(int index, Local<Module> value);
 +#ifndef NODE_WANT_INTERNALS
-+  V8_DEPRECATED("This extention should only be used by Node.js core")
++  V8_DEPRECATED("This extension should only be used by Node.js core")
 +#endif
 +  void SetInternalFieldForNodeCore(int index, Local<UnboundScript> value);
 +
@@ -69,7 +69,7 @@ index 5ab671c8c4168ac7ccd9d18ea4b9fda16734e4ad..46d56957a5845745fa07ae3db79dd753
 +}
 +
 +/**
-+ * These are Node.js-specific extentions used to avoid breaking changes in
++ * These are Node.js-specific extensions used to avoid breaking changes in
 + * Node.js v20.x.
 + */
 +void v8::Object::SetInternalFieldForNodeCore(int index,


### PR DESCRIPTION
Fixes typos in the `patches/` folder

@ckerr [suggested](https://github.com/electron/electron/pull/43366#pullrequestreview-2248182635) I split what was originally a single PR with changes into 39 files into many.

Notes: none.
