### PR TITLE
chore: remove unused ConvertableToTraceFormatWrapper (33-x-y)

### DIFF
--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -18,7 +18,6 @@
 #include "base/task/current_thread.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/task/thread_pool/initialization_util.h"
-#include "base/trace_event/trace_event.h"
 #include "gin/array_buffer.h"
 #include "gin/v8_initializer.h"
 #include "shell/browser/microtasks_runner.h"
@@ -30,48 +29,6 @@
 namespace {
 v8::Isolate* g_isolate;
 }
-
-namespace gin {
-
-class ConvertableToTraceFormatWrapper final
-    : public base::trace_event::ConvertableToTraceFormat {
- public:
-  explicit ConvertableToTraceFormatWrapper(
-      std::unique_ptr<v8::ConvertableToTraceFormat> inner)
-      : inner_(std::move(inner)) {}
-  ~ConvertableToTraceFormatWrapper() override = default;
-
-  // disable copy
-  ConvertableToTraceFormatWrapper(const ConvertableToTraceFormatWrapper&) =
-      delete;
-  ConvertableToTraceFormatWrapper& operator=(
-      const ConvertableToTraceFormatWrapper&) = delete;
-
-  void AppendAsTraceFormat(std::string* out) const final {
-    inner_->AppendAsTraceFormat(out);
-  }
-
- private:
-  std::unique_ptr<v8::ConvertableToTraceFormat> inner_;
-};
-
-}  // namespace gin
-
-// Allow std::unique_ptr<v8::ConvertableToTraceFormat> to be a valid
-// initialization value for trace macros.
-template <>
-struct base::trace_event::TraceValue::Helper<
-    std::unique_ptr<v8::ConvertableToTraceFormat>> {
-  static constexpr unsigned char kType = TRACE_VALUE_TYPE_CONVERTABLE;
-  static inline void SetValue(
-      TraceValue* v,
-      std::unique_ptr<v8::ConvertableToTraceFormat> value) {
-    // NOTE: |as_convertable| is an owning pointer, so using new here
-    // is acceptable.
-    v->as_convertable =
-        new gin::ConvertableToTraceFormatWrapper(std::move(value));
-  }
-};
 
 namespace electron {
 


### PR DESCRIPTION
Manual backport of #43356 to 33-x-y. See that PR for details.

Notes: none.