### PR TITLE
feat: expose requestingOrigin on permission requests

### DIFF
--- a/docs/api/structures/permission-request.md
+++ b/docs/api/structures/permission-request.md
@@ -1,5 +1,5 @@
 # PermissionRequest Object
 
-* `requestingOrigin` string - The origin you should treat the request as coming from. Note this may be different to `requestingUrl` in the case of child frames, you should use `requestingOrigin` as the "safe" one to check.
+* `requestingOrigin` string - The origin you should treat the request as coming from. Note this may be different to `requestingUrl` in the case of child frames. You should use `requestingOrigin` as the "safe" one to check.
 * `requestingUrl` string - The last URL the requesting frame loaded.
 * `isMainFrame` boolean - Whether the frame making the request is the main frame.

--- a/docs/api/structures/permission-request.md
+++ b/docs/api/structures/permission-request.md
@@ -1,4 +1,5 @@
 # PermissionRequest Object
 
+* `requestingOrigin` string - The origin you should treat the request as coming from. Note this may be different to `requestingUrl` in the case of child frames, you should use `requestingOrigin` as the "safe" one to check.
 * `requestingUrl` string - The last URL the requesting frame loaded.
 * `isMainFrame` boolean - Whether the frame making the request is the main frame.

--- a/shell/browser/electron_permission_manager.cc
+++ b/shell/browser/electron_permission_manager.cc
@@ -210,6 +210,7 @@ void ElectronPermissionManager::RequestPermissionsWithDetails(
   int request_id = pending_requests_.Add(std::make_unique<PendingRequest>(
       render_frame_host, permissions, std::move(response_callback)));
 
+  details.Set("requestingOrigin", request_description.requesting_origin.spec());
   details.Set("requestingUrl", render_frame_host->GetLastCommittedURL().spec());
   details.Set("isMainFrame", render_frame_host->GetParent() == nullptr);
   base::Value dict_value(std::move(details));


### PR DESCRIPTION
This aligns with requestingOrigin that is exposed on permission checks. It allows for about:blank frames owned by a security origin to have a valid and safe origin associated with permission requests.

Notes: added `requestingOrigin` to permission request details