### PR TITLE
test: add -pdf-ready-to-print event to WebContents for testing

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -733,6 +733,7 @@ source_set("electron_lib") {
       "//components/pdf/common:util",
       "//components/pdf/renderer",
       "//pdf",
+      "//pdf:content_restriction",
     ]
     sources += [
       "shell/browser/electron_pdf_document_helper_client.cc",

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3754,6 +3754,10 @@ void WebContents::SetBackgroundColor(std::optional<SkColor> maybe_color) {
   }
 }
 
+void WebContents::PDFReadyToPrint() {
+  Emit("-pdf-ready-to-print");
+}
+
 void WebContents::OnInputEvent(const blink::WebInputEvent& event) {
   Emit("input-event", event);
 }

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -489,6 +489,8 @@ class WebContents : public ExclusiveAccessContext,
 
   void SetBackgroundColor(std::optional<SkColor> color);
 
+  void PDFReadyToPrint();
+
   SkRegion* draggable_region() {
     return force_non_draggable_ ? nullptr : draggable_region_.get();
   }

--- a/shell/browser/electron_pdf_document_helper_client.cc
+++ b/shell/browser/electron_pdf_document_helper_client.cc
@@ -5,6 +5,29 @@
 #include "shell/browser/electron_pdf_document_helper_client.h"
 
 #include "content/public/browser/web_contents.h"
+#include "pdf/content_restriction.h"
+#include "shell/browser/api/electron_api_web_contents.h"
 
 ElectronPDFDocumentHelperClient::ElectronPDFDocumentHelperClient() = default;
 ElectronPDFDocumentHelperClient::~ElectronPDFDocumentHelperClient() = default;
+
+void ElectronPDFDocumentHelperClient::UpdateContentRestrictions(
+    content::RenderFrameHost* render_frame_host,
+    int content_restrictions) {
+  // UpdateContentRestrictions potentially gets called twice from
+  // pdf/pdf_view_web_plugin.cc.  The first time it is potentially called is
+  // when loading starts and it is called with a restriction on printing.  The
+  // second time it is called is when loading is finished and if printing is
+  // allowed there won't be a printing restriction passed, so we can use this
+  // second call to notify that the pdf document is ready to print.
+  if (!(content_restrictions & chrome_pdf::kContentRestrictionPrint)) {
+    content::WebContents* web_contents =
+        content::WebContents::FromRenderFrameHost(render_frame_host);
+    electron::api::WebContents* api_web_contents =
+        electron::api::WebContents::From(
+            web_contents->GetOutermostWebContents());
+    if (api_web_contents) {
+      api_web_contents->PDFReadyToPrint();
+    }
+  }
+}

--- a/shell/browser/electron_pdf_document_helper_client.h
+++ b/shell/browser/electron_pdf_document_helper_client.h
@@ -17,8 +17,9 @@ class ElectronPDFDocumentHelperClient : public pdf::PDFDocumentHelperClient {
 
  private:
   // pdf::PDFDocumentHelperClient
+
   void UpdateContentRestrictions(content::RenderFrameHost* render_frame_host,
-                                 int content_restrictions) override {}
+                                 int content_restrictions) override;
   void OnPDFHasUnsupportedFeature(content::WebContents* contents) override {}
   void OnSaveURL(content::WebContents* contents) override {}
   void SetPluginCanSave(content::RenderFrameHost* render_frame_host,

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2450,13 +2450,9 @@ describe('webContents module', () => {
 
     it('from an existing pdf document', async () => {
       const pdfPath = path.join(fixturesPath, 'cat.pdf');
+      const readyToPrint = once(w.webContents, '-pdf-ready-to-print');
       await w.loadFile(pdfPath);
-
-      // TODO(codebytere): the PDF plugin is not always ready immediately
-      // after the document is loaded, so we need to wait for it to be ready.
-      // We should find a better way to do this.
-      await setTimeout(3000);
-
+      await readyToPrint;
       const data = await w.webContents.printToPDF({});
       const doc = await pdfjs.getDocument(data).promise;
       expect(doc.numPages).to.equal(2);


### PR DESCRIPTION
#### Description of Change
This PR adds a new event to WebContents, `-pdf-ready-to-print` which fires when the PDF viewer is done loading content and is ready to print.  This event is intended for testing purposes only. 

- https://github.com/electron/electron/pull/43309 added a test that used a timeout to wait for the PDF viewer to finish loading.  This PR fixes that test to now wait for this new event instead of using the timeout.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
