### PR TITLE
chore: remove unused method asar::ClearArchives()

### DIFF
--- a/shell/common/asar/asar_util.cc
+++ b/shell/common/asar/asar_util.cc
@@ -77,13 +77,6 @@ std::shared_ptr<Archive> GetOrCreateAsarArchive(const base::FilePath& path) {
   return nullptr;
 }
 
-void ClearArchives() {
-  base::AutoLock auto_lock(GetArchiveCacheLock());
-  ArchiveMap& map = GetArchiveCache();
-
-  map.clear();
-}
-
 bool GetAsarArchivePath(const base::FilePath& full_path,
                         base::FilePath* asar_path,
                         base::FilePath* relative_path,

--- a/shell/common/asar/asar_util.h
+++ b/shell/common/asar/asar_util.h
@@ -20,9 +20,6 @@ struct IntegrityPayload;
 // Gets or creates and caches a new Archive from the path.
 std::shared_ptr<Archive> GetOrCreateAsarArchive(const base::FilePath& path);
 
-// Destroy cached Archive objects.
-void ClearArchives();
-
 // Separates the path to Archive out.
 bool GetAsarArchivePath(const base::FilePath& full_path,
                         base::FilePath* asar_path,


### PR DESCRIPTION
#### Description of Change

Remove the function `asar::ClearArchive()`, whose last use was removed in Jun 2021 (b1d1ac65, #29293)

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.