### PR TITLE
perf: prefer GURL string_view getters

### DIFF
--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -10,6 +10,7 @@
 #include "base/command_line.h"
 #include "base/environment.h"
 #include "base/process/launch.h"
+#include "base/strings/strcat.h"
 #include "electron/electron_version.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/browser/native_window.h"
@@ -124,7 +125,7 @@ bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
 std::u16string Browser::GetApplicationNameForProtocol(const GURL& url) {
   const std::vector<std::string> argv = {
       "xdg-mime", "query", "default",
-      std::string("x-scheme-handler/") + url.scheme()};
+      base::StrCat({"x-scheme-handler/", url.scheme_piece()})};
 
   return base::ASCIIToUTF16(GetXdgAppOutput(argv).value_or(std::string()));
 }

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -95,7 +95,7 @@ bool IsValidCustomProtocol(const std::wstring& scheme) {
 // (https://docs.microsoft.com/en-us/windows/win32/api/shlwapi/ne-shlwapi-assocstr)
 // and returns the application name, icon and path that handles the protocol.
 std::wstring GetAppInfoHelperForProtocol(ASSOCSTR assoc_str, const GURL& url) {
-  const std::wstring url_scheme = base::ASCIIToWide(url.scheme());
+  const std::wstring url_scheme = base::ASCIIToWide(url.scheme_piece());
   if (!IsValidCustomProtocol(url_scheme))
     return std::wstring();
 

--- a/shell/browser/electron_web_ui_controller_factory.cc
+++ b/shell/browser/electron_web_ui_controller_factory.cc
@@ -25,8 +25,9 @@ ElectronWebUIControllerFactory::~ElectronWebUIControllerFactory() = default;
 content::WebUI::TypeID ElectronWebUIControllerFactory::GetWebUIType(
     content::BrowserContext* browser_context,
     const GURL& url) {
-  if (url.host() == chrome::kChromeUIDevToolsHost ||
-      url.host() == chrome::kChromeUIAccessibilityHost) {
+  if (const std::string_view host = url.host();
+      host == chrome::kChromeUIDevToolsHost ||
+      host == chrome::kChromeUIAccessibilityHost) {
     return const_cast<ElectronWebUIControllerFactory*>(this);
   }
 

--- a/shell/browser/electron_web_ui_controller_factory.cc
+++ b/shell/browser/electron_web_ui_controller_factory.cc
@@ -25,7 +25,7 @@ ElectronWebUIControllerFactory::~ElectronWebUIControllerFactory() = default;
 content::WebUI::TypeID ElectronWebUIControllerFactory::GetWebUIType(
     content::BrowserContext* browser_context,
     const GURL& url) {
-  if (const std::string_view host = url.host();
+  if (const std::string_view host = url.host_piece();
       host == chrome::kChromeUIDevToolsHost ||
       host == chrome::kChromeUIAccessibilityHost) {
     return const_cast<ElectronWebUIControllerFactory*>(this);
@@ -44,12 +44,15 @@ std::unique_ptr<content::WebUIController>
 ElectronWebUIControllerFactory::CreateWebUIControllerForURL(
     content::WebUI* web_ui,
     const GURL& url) {
-  if (url.host() == chrome::kChromeUIDevToolsHost) {
+  const std::string_view host = url.host_piece();
+
+  if (host == chrome::kChromeUIDevToolsHost) {
     auto* browser_context = web_ui->GetWebContents()->GetBrowserContext();
     return std::make_unique<DevToolsUI>(browser_context, web_ui);
-  } else if (url.host() == chrome::kChromeUIAccessibilityHost) {
-    return std::make_unique<ElectronAccessibilityUI>(web_ui);
   }
+
+  if (host == chrome::kChromeUIAccessibilityHost)
+    return std::make_unique<ElectronAccessibilityUI>(web_ui);
 
   return std::unique_ptr<content::WebUIController>();
 }

--- a/shell/browser/net/electron_url_loader_factory.h
+++ b/shell/browser/net/electron_url_loader_factory.h
@@ -53,8 +53,8 @@ using ProtocolHandler =
                                  StartLoadingCallback)>;
 
 // scheme => (type, handler).
-using HandlersMap =
-    std::map<std::string, std::pair<ProtocolType, ProtocolHandler>>;
+using HandlersMap = std::
+    map<std::string, std::pair<ProtocolType, ProtocolHandler>, std::less<>>;
 
 // Implementation of URLLoaderFactory.
 class ElectronURLLoaderFactory : public network::SelfDeletingURLLoaderFactory {

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -806,7 +806,7 @@ void ProxyingURLLoaderFactory::CreateLoaderAndStart(
   bool bypass_custom_protocol_handlers =
       options & kBypassCustomProtocolHandlers;
   if (!bypass_custom_protocol_handlers) {
-    auto it = intercepted_handlers_->find(request.url.scheme());
+    auto it = intercepted_handlers_->find(request.url.scheme_piece());
     if (it != intercepted_handlers_->end()) {
       mojo::PendingRemote<network::mojom::URLLoaderFactory> loader_remote;
       this->Clone(loader_remote.InitWithNewPipeAndPassReceiver());

--- a/shell/browser/protocol_registry.cc
+++ b/shell/browser/protocol_registry.cc
@@ -91,7 +91,7 @@ bool ProtocolRegistry::UninterceptProtocol(const std::string& scheme) {
 }
 
 const HandlersMap::mapped_type* ProtocolRegistry::FindIntercepted(
-    const std::string& scheme) const {
+    const std::string_view scheme) const {
   const auto& map = intercept_handlers_;
   const auto iter = map.find(scheme);
   return iter != std::end(map) ? &iter->second : nullptr;

--- a/shell/browser/protocol_registry.cc
+++ b/shell/browser/protocol_registry.cc
@@ -74,7 +74,7 @@ bool ProtocolRegistry::UnregisterProtocol(const std::string& scheme) {
 }
 
 const HandlersMap::mapped_type* ProtocolRegistry::FindRegistered(
-    const std::string& scheme) const {
+    const std::string_view scheme) const {
   const auto& map = handlers_;
   const auto iter = map.find(scheme);
   return iter != std::end(map) ? &iter->second : nullptr;

--- a/shell/browser/protocol_registry.h
+++ b/shell/browser/protocol_registry.h
@@ -49,7 +49,7 @@ class ProtocolRegistry {
   bool UninterceptProtocol(const std::string& scheme);
 
   [[nodiscard]] const HandlersMap::mapped_type* FindIntercepted(
-      const std::string& scheme) const;
+      std::string_view scheme) const;
 
  private:
   friend class ElectronBrowserContext;

--- a/shell/browser/protocol_registry.h
+++ b/shell/browser/protocol_registry.h
@@ -6,6 +6,7 @@
 #define ELECTRON_SHELL_BROWSER_PROTOCOL_REGISTRY_H_
 
 #include <string>
+#include <string_view>
 
 #include "content/public/browser/content_browser_client.h"
 #include "shell/browser/net/electron_url_loader_factory.h"
@@ -40,7 +41,7 @@ class ProtocolRegistry {
   bool UnregisterProtocol(const std::string& scheme);
 
   [[nodiscard]] const HandlersMap::mapped_type* FindRegistered(
-      const std::string& scheme) const;
+      std::string_view scheme) const;
 
   bool InterceptProtocol(ProtocolType type,
                          const std::string& scheme,

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -684,7 +684,7 @@ void InspectableWebContents::LoadNetworkResource(DispatchCallback callback,
         std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
             std::move(pending_remote)));
   } else if (const auto* const protocol_handler =
-                 protocol_registry->FindRegistered(gurl.scheme())) {
+                 protocol_registry->FindRegistered(gurl.scheme_piece())) {
     url_loader_factory = network::SharedURLLoaderFactory::Create(
         std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
             ElectronURLLoaderFactory::Create(protocol_handler->first,

--- a/shell/browser/web_contents_zoom_controller.cc
+++ b/shell/browser/web_contents_zoom_controller.cc
@@ -186,15 +186,16 @@ void WebContentsZoomController::SetZoomMode(ZoomMode new_mode) {
 
       if (entry) {
         GURL url = content::HostZoomMap::GetURLFromEntry(entry);
-        std::string host = net::GetHostOrSpecFromURL(url);
+        const std::string host = net::GetHostOrSpecFromURL(url);
+        const std::string scheme = url.scheme();
 
-        if (zoom_map->HasZoomLevel(url.scheme(), host)) {
+        if (zoom_map->HasZoomLevel(scheme, host)) {
           // If there are other tabs with the same origin, then set this tab's
           // zoom level to match theirs. The temporary zoom level will be
           // cleared below, but this call will make sure this tab re-draws at
           // the correct zoom level.
           double origin_zoom_level =
-              zoom_map->GetZoomLevelForHostAndScheme(url.scheme(), host);
+              zoom_map->GetZoomLevelForHostAndScheme(scheme, host);
           event_data_->new_zoom_level = origin_zoom_level;
           zoom_map->SetTemporaryZoomLevel(rfh_id, origin_zoom_level);
         } else {

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -492,7 +492,7 @@ SimpleURLLoaderWrapper::GetURLLoaderFactoryForURL(const GURL& url) {
   // correctly intercept file:// scheme URLs.
   if (const bool bypass = request_options_ & kBypassCustomProtocolHandlers;
       !bypass) {
-    const auto scheme = url.scheme();
+    const std::string_view scheme = url.scheme_piece();
     const auto* const protocol_registry =
         ProtocolRegistry::FromBrowserContext(browser_context_);
 


### PR DESCRIPTION
#### Description of Change

Avoid building some unnecessary temp strings.

A new `std::string` is created every time we call `gurl.host()` or `gurl.scheme()`.

We can use `std::string_view`s instead by replacing those calls with `gurl.host_piece()` and `gurl.scheme_piece()`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.