### PR TITLE
chore: remove unused WinFrameView::kInactiveTitlebarFeatureAlpha

### DIFF
--- a/shell/browser/ui/views/win_frame_view.h
+++ b/shell/browser/ui/views/win_frame_view.h
@@ -29,10 +29,6 @@ class WinFrameView : public FramelessView {
   void Init(NativeWindowViews* window, views::Widget* frame) override;
   void InvalidateCaptionButtons() override;
 
-  // Alpha to use for features in the titlebar (the window title and caption
-  // buttons) when the window is inactive. They are opaque when active.
-  static constexpr SkAlpha kInactiveTitlebarFeatureAlpha = 0x66;
-
   SkColor GetReadableFeatureColor(SkColor background_color);
 
   // views::NonClientFrameView:


### PR DESCRIPTION
#### Description of Change

Remove a small piece of unused code: `WinFrameView::kInactiveTitlebarFeatureAlpha` was added in Aug 2021 (41646d11, #29600) but never used.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.