### PR TITLE
docs: explain ipcRenderer behavior in context-bridge.md

### DIFF
--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -147,6 +147,23 @@ has been included below for completeness:
 
 If the type you care about is not in the above table, it is probably not supported.
 
+### Exposing ipcRenderer
+
+Attempting to send the entire `ipcRenderer` module as an object over the `contextBridge` will result in an empty object on the receiving side of the bridge. Sending over `ipcRenderer` in full can let any code send any message To use ipcRenderer, which is a security footgun. To interact through `ipcRenderer, provide a safe wrapper like below:
+
+```js
+// Preload (Isolated World)
+contextBridge.exposeInMainWorld('electron', {
+  onMyEventName: (callback) => ipcRenderer.on('MyEventName', (e, ...args) => callback(args))
+})
+```
+
+```js
+// Renderer (Main World)
+window.electron.onEvent(data => { ... });
+```
+
+
 ### Exposing Node Global Symbols
 
 The `contextBridge` can be used by the preload script to give your renderer access to Node APIs.

--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -163,7 +163,7 @@ contextBridge.exposeInMainWorld('electron', {
 
 ```js @ts-nocheck
 // Renderer (Main World)
-window.electron.onEvent(data => { /* ... */ })
+window.electron.onMyEventName(data => { /* ... */ })
 ```
 
 ### Exposing Node Global Symbols

--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -158,7 +158,7 @@ contextBridge.exposeInMainWorld('electron', {
 })
 ```
 
-```js
+```js @ts-nocheck
 // Renderer (Main World)
 window.electron.onEvent(data => { /* ... */ })
 ```

--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -160,7 +160,7 @@ contextBridge.exposeInMainWorld('electron', {
 
 ```js
 // Renderer (Main World)
-window.electron.onEvent(data => { ... });
+window.electron.onEvent(data => { /* ... */ });
 ```
 
 

--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -149,7 +149,7 @@ If the type you care about is not in the above table, it is probably not support
 
 ### Exposing ipcRenderer
 
-Attempting to send the entire `ipcRenderer` module as an object over the `contextBridge` will result in an empty object on the receiving side of the bridge. Sending over `ipcRenderer` in full can let any code send any message To use ipcRenderer, which is a security footgun. To interact through `ipcRenderer, provide a safe wrapper like below:
+Attempting to send the entire `ipcRenderer` module as an object over the `contextBridge` will result in an empty object on the receiving side of the bridge. Sending over `ipcRenderer` in full can let any code send any message, which is a security footgun. To interact through `ipcRenderer, provide a safe wrapper like below:
 
 ```js
 // Preload (Isolated World)

--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -149,7 +149,7 @@ If the type you care about is not in the above table, it is probably not support
 
 ### Exposing ipcRenderer
 
-Attempting to send the entire `ipcRenderer` module as an object over the `contextBridge` will result in an empty object on the receiving side of the bridge. Sending over `ipcRenderer` in full can let any code send any message, which is a security footgun. To interact through `ipcRenderer, provide a safe wrapper like below:
+Attempting to send the entire `ipcRenderer` module as an object over the `contextBridge` will result in an empty object on the receiving side of the bridge. Sending over `ipcRenderer` in full can let any code send any message, which is a security footgun. To interact through `ipcRenderer`, provide a safe wrapper like below:
 
 ```js
 // Preload (Isolated World)

--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -163,7 +163,6 @@ contextBridge.exposeInMainWorld('electron', {
 window.electron.onEvent(data => { /* ... */ })
 ```
 
-
 ### Exposing Node Global Symbols
 
 The `contextBridge` can be used by the preload script to give your renderer access to Node APIs.

--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -160,7 +160,7 @@ contextBridge.exposeInMainWorld('electron', {
 
 ```js
 // Renderer (Main World)
-window.electron.onEvent(data => { /* ... */ });
+window.electron.onEvent(data => { /* ... */ })
 ```
 
 

--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -149,7 +149,10 @@ If the type you care about is not in the above table, it is probably not support
 
 ### Exposing ipcRenderer
 
-Attempting to send the entire `ipcRenderer` module as an object over the `contextBridge` will result in an empty object on the receiving side of the bridge. Sending over `ipcRenderer` in full can let any code send any message, which is a security footgun. To interact through `ipcRenderer`, provide a safe wrapper like below:
+Attempting to send the entire `ipcRenderer` module as an object over the `contextBridge` will result in
+an empty object on the receiving side of the bridge. Sending over `ipcRenderer` in full can let any
+code send any message, which is a security footgun. To interact through `ipcRenderer`, provide a safe wrapper
+like below:
 
 ```js
 // Preload (Isolated World)


### PR DESCRIPTION
#### Description of Change

`ipcRenderer` when sent over `contextBridge` will be empty for security reasons. This is mentioned in the breaking changes but it should also be mentioned on the contextBridge page itself.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
