### PR TITLE
feat: add pinned WebFrameMain variant

### DIFF
--- a/docs/api/structures/ipc-main-event.md
+++ b/docs/api/structures/ipc-main-event.md
@@ -4,7 +4,7 @@
 * `frameId` Integer - The ID of the renderer frame that sent this message
 * `returnValue` any - Set this to the value to be returned in a synchronous message
 * `sender` [WebContents](../web-contents.md) - Returns the `webContents` that sent the message
-* `senderFrame` [WebFrameMain](../web-frame-main.md) _Readonly_ - The frame that sent this message
+* `senderFrame` [WebFrameMain](../web-frame-main.md) _Readonly_ - The frame that sent this message. If the initiating page had a cross-site navigation, this frame will be disposed and throw upon accessing its properties.
 * `ports` [MessagePortMain](../message-port-main.md)[] - A list of MessagePorts that were transferred with this message
 * `reply` Function - A function that will send an IPC message to the renderer frame that sent the original message that you are currently handling.  You should use this method to "reply" to the sent message in order to guarantee the reply will go to the correct process and frame.
   * `channel` string

--- a/docs/api/structures/ipc-main-invoke-event.md
+++ b/docs/api/structures/ipc-main-invoke-event.md
@@ -3,4 +3,4 @@
 * `processId` Integer - The internal ID of the renderer process that sent this message
 * `frameId` Integer - The ID of the renderer frame that sent this message
 * `sender` [WebContents](../web-contents.md) - Returns the `webContents` that sent the message
-* `senderFrame` [WebFrameMain](../web-frame-main.md) _Readonly_ - The frame that sent this message
+* `senderFrame` [WebFrameMain](../web-frame-main.md) _Readonly_ - The frame that sent this message. If the initiating page had a cross-site navigation, this frame will be disposed and throw upon accessing its properties.

--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -231,6 +231,12 @@ A `string` representing the [visibility state](https://developer.mozilla.org/en-
 
 See also how the [Page Visibility API](browser-window.md#page-visibility) is affected by other Electron APIs.
 
+#### `frame.pinned` _Readonly_
+
+A `Boolean` representing whether the frame is pinned to its internal values. In the case
+of cross-site navigation, this frame will be disposed and throw upon accessing its
+properties.
+
 [SCA]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 [`postMessage`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 [`MessagePortMain`]: message-port-main.md

--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -66,6 +66,13 @@ These methods can be accessed from the `webFrameMain` module:
 Returns `WebFrameMain | undefined` - A frame with the given process and routing IDs,
 or `undefined` if there is no WebFrameMain associated with the given IDs.
 
+### `webFrameMain.fromFrameTreeNodeId(frameTreeNodeId)`
+
+* `frameTreeNodeId` Integer - An `Integer` representing frame tree node ID of the frame. This can be thought of as the ID corresponding to an `<iframe>`.
+
+Returns `WebFrameMain | undefined` - A frame with the frame tree node ID,
+or `undefined` if there is no WebFrameMain associated with the given ID.
+
 ## Class: WebFrameMain
 
 Process: [Main](../glossary.md#main-process)<br />

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -486,10 +486,6 @@ const addReplyToEvent = (event: Electron.IpcMainEvent) => {
 
 const addSenderToEvent = (event: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent, sender: Electron.WebContents) => {
   event.sender = sender;
-  const { processId, frameId } = event;
-  Object.defineProperty(event, 'senderFrame', {
-    get: () => webFrameMain.fromId(processId, frameId)
-  });
 };
 
 const addReturnValueToEvent = (event: Electron.IpcMainEvent) => {

--- a/lib/browser/api/web-frame-main.ts
+++ b/lib/browser/api/web-frame-main.ts
@@ -1,7 +1,7 @@
 import { MessagePortMain } from '@electron/internal/browser/message-port-main';
 import { IpcMainImpl } from '@electron/internal/browser/ipc-main-impl';
 
-const { WebFrameMain, fromId } = process._linkedBinding('electron_browser_web_frame_main');
+const { WebFrameMain, fromId, fromFrameTreeNodeId } = process._linkedBinding('electron_browser_web_frame_main');
 
 Object.defineProperty(WebFrameMain.prototype, 'ipc', {
   get () {
@@ -43,5 +43,6 @@ WebFrameMain.prototype.postMessage = function (...args) {
 };
 
 export default {
-  fromId
+  fromId,
+  fromFrameTreeNodeId
 };

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1599,6 +1599,11 @@ void WebContents::HandleNewRenderFrame(
   auto* web_frame = WebFrameMain::FromRenderFrameHost(render_frame_host);
   if (web_frame)
     web_frame->MaybeSetupMojoConnection();
+
+  auto* pinned_web_frame = WebFrameMain::FromRenderFrameHost(
+      render_frame_host, WebFrameMain::FrameType::Pinned);
+  if (pinned_web_frame)
+    pinned_web_frame->MaybeSetupMojoConnection();
 }
 
 void WebContents::OnBackgroundColorChanged() {
@@ -1654,6 +1659,12 @@ void WebContents::RenderFrameDeleted(
   auto* web_frame = WebFrameMain::FromRenderFrameHost(render_frame_host);
   if (web_frame && web_frame->render_frame_host() == render_frame_host)
     web_frame->MarkRenderFrameDisposed();
+
+  auto* pinned_web_frame = WebFrameMain::FromRenderFrameHost(
+      render_frame_host, WebFrameMain::FrameType::Pinned);
+  if (pinned_web_frame &&
+      pinned_web_frame->render_frame_host() == render_frame_host)
+    pinned_web_frame->MarkRenderFrameDisposed();
 }
 
 void WebContents::RenderFrameHostChanged(content::RenderFrameHost* old_host,

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1682,7 +1682,8 @@ void WebContents::RenderFrameHostChanged(content::RenderFrameHost* old_host,
   //
   // |old_host| can be a nullptr so we use |new_host| for looking up the
   // WebFrameMain instance.
-  auto* web_frame = WebFrameMain::FromRenderFrameHost(new_host);
+  auto* web_frame =
+      WebFrameMain::FromFrameTreeNodeId(new_host->GetFrameTreeNodeId());
   if (web_frame) {
     web_frame->UpdateRenderFrameHost(new_host);
   }
@@ -1975,6 +1976,7 @@ gin::Handle<gin_helper::internal::Event> WebContents::MakeEventWithSender(
   if (frame) {
     dict.Set("frameId", frame->GetRoutingID());
     dict.Set("processId", frame->GetProcess()->GetID());
+    dict.Set("senderFrame", PinnedRenderFrameHostRef::Create(frame));
   }
   return event;
 }

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1772,6 +1772,11 @@ void WebContents::DOMContentLoaded(
   if (web_frame)
     web_frame->DOMContentLoaded();
 
+  auto* pinned_web_frame = WebFrameMain::FromRenderFrameHost(
+      render_frame_host, WebFrameMain::FrameType::Pinned);
+  if (pinned_web_frame)
+    pinned_web_frame->DOMContentLoaded();
+
   if (!render_frame_host->GetParent())
     Emit("dom-ready");
 }

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -332,9 +332,8 @@ void WebFrameMain::PostMessage(v8::Isolate* isolate,
                                        std::move(transferable_message));
 }
 
-gin::Handle<WebFrameMain> WebFrameMain::GetPinnedFrame(
-    gin::Arguments* args) const {
-  return From(args->isolate(), render_frame_, FrameType::Pinned);
+bool WebFrameMain::Pinned() const {
+  return render_frame_pinned_;
 }
 
 int WebFrameMain::FrameTreeNodeID() const {
@@ -475,7 +474,6 @@ void WebFrameMain::FillObjectTemplate(v8::Isolate* isolate,
       .SetMethod("reload", &WebFrameMain::Reload)
       .SetMethod("_send", &WebFrameMain::Send)
       .SetMethod("_postMessage", &WebFrameMain::PostMessage)
-      .SetMethod("getPinnedFrame", &WebFrameMain::GetPinnedFrame)
       .SetProperty("frameTreeNodeId", &WebFrameMain::FrameTreeNodeID)
       .SetProperty("name", &WebFrameMain::Name)
       .SetProperty("osProcessId", &WebFrameMain::OSProcessID)
@@ -488,6 +486,7 @@ void WebFrameMain::FillObjectTemplate(v8::Isolate* isolate,
       .SetProperty("parent", &WebFrameMain::Parent)
       .SetProperty("frames", &WebFrameMain::Frames)
       .SetProperty("framesInSubtree", &WebFrameMain::FramesInSubtree)
+      .SetProperty("pinned", &WebFrameMain::Pinned)
       .Build();
 }
 

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -38,7 +38,7 @@ namespace electron::api {
 
 // Helper struct for serializing RenderFrameHosts to binded as a pinned
 // WebFrameMain. This ensures the RenderFrameHost never gets swapped on
-// cross-site navigation, in  the case of race conditions.
+// cross-site navigation, in the case of race conditions.
 struct PinnedRenderFrameHostRef {
  private:
   explicit PinnedRenderFrameHostRef(
@@ -81,7 +81,8 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
 
   static WebFrameMain* FromFrameTreeNodeId(int frame_tree_node_id);
   static WebFrameMain* FromFrameToken(
-      content::GlobalRenderFrameHostToken frame_token);
+      content::GlobalRenderFrameHostToken frame_token,
+      WebFrameMain::FrameType frame_type);
   static WebFrameMain* FromPinnedFrameToken(
       content::GlobalRenderFrameHostToken frame_token);
   static WebFrameMain* FromRenderFrameHost(

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -73,9 +73,11 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
       v8::Isolate* isolate,
       content::RenderFrameHost* render_frame_host,
       FrameType frame_type = FrameType::Default);
+  // Gets WebFrameMain if it exists, without creating a new handle
   static gin::Handle<WebFrameMain> FromOrNull(
       v8::Isolate* isolate,
-      content::RenderFrameHost* render_frame_host);
+      content::RenderFrameHost* render_frame_host,
+      FrameType frame_type);
 
   static WebFrameMain* FromFrameTreeNodeId(int frame_tree_node_id);
   static WebFrameMain* FromFrameToken(

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -140,6 +140,7 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
                    v8::Local<v8::Value> message_value,
                    std::optional<v8::Local<v8::Value>> transfer);
 
+  bool Pinned() const;
   int FrameTreeNodeID() const;
   std::string Name() const;
   base::ProcessId OSProcessID() const;
@@ -153,8 +154,6 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
   content::RenderFrameHost* Parent() const;
   std::vector<content::RenderFrameHost*> Frames() const;
   std::vector<content::RenderFrameHost*> FramesInSubtree() const;
-
-  gin::Handle<WebFrameMain> GetPinnedFrame(gin::Arguments* args) const;
 
   void DOMContentLoaded();
 

--- a/shell/common/gin_converters/frame_converter.cc
+++ b/shell/common/gin_converters/frame_converter.cc
@@ -101,4 +101,16 @@ bool Converter<gin_helper::AccessorValue<content::RenderFrameHost*>>::FromV8(
   return true;
 }
 
+// static
+v8::Local<v8::Value> Converter<electron::api::PinnedRenderFrameHostRef>::ToV8(
+    v8::Isolate* isolate,
+    electron::api::PinnedRenderFrameHostRef val) {
+  auto* rfh = content::RenderFrameHost::FromFrameToken(val.token);
+  if (!rfh)
+    return v8::Null(isolate);
+  return electron::api::WebFrameMain::From(
+             isolate, rfh, electron::api::WebFrameMain::FrameType::Pinned)
+      .ToV8();
+}
+
 }  // namespace gin

--- a/shell/common/gin_converters/frame_converter.h
+++ b/shell/common/gin_converters/frame_converter.h
@@ -12,6 +12,12 @@ namespace content {
 class RenderFrameHost;
 }
 
+namespace electron {
+namespace api {
+struct PinnedRenderFrameHostRef;
+}
+}  // namespace electron
+
 namespace gin {
 
 template <>
@@ -31,6 +37,12 @@ struct Converter<gin_helper::AccessorValue<content::RenderFrameHost*>> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      gin_helper::AccessorValue<content::RenderFrameHost*>* out);
+};
+
+template <>
+struct Converter<electron::api::PinnedRenderFrameHostRef> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   electron::api::PinnedRenderFrameHostRef val);
 };
 
 }  // namespace gin

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -125,6 +125,7 @@ declare namespace NodeJS {
   interface WebFrameMainBinding {
     WebFrameMain: typeof Electron.WebFrameMain;
     fromId(processId: number, routingId: number): Electron.WebFrameMain;
+    fromFrameTreeNodeId(frameTreeNodeId: number): Electron.WebFrameMain;
     _fromIdOrNull(processId: number, routingId: number, pinned: boolean): Electron.WebFrameMain | null;
   }
 

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -125,7 +125,7 @@ declare namespace NodeJS {
   interface WebFrameMainBinding {
     WebFrameMain: typeof Electron.WebFrameMain;
     fromId(processId: number, routingId: number): Electron.WebFrameMain;
-    fromIdOrNull(processId: number, routingId: number): Electron.WebFrameMain | null;
+    _fromIdOrNull(processId: number, routingId: number, pinned: boolean): Electron.WebFrameMain | null;
   }
 
   interface InternalWebPreferences {


### PR DESCRIPTION
#### Description of Change

> [!NOTE]
> This proposal has been superseded by #43473

In our security recommendations guide, we list [validating senderFrame of IPCs.](https://www.electronjs.org/docs/latest/tutorial/security#17-validate-the-sender-of-all-ipc-messages) In the case of IPCs sent after the [unload event](https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event), it's possible for `senderFrame` to point to a different RenderFrameHost than the sender of the IPC.

The process occurs as followed ([gist to repro](https://gist.github.com/samuelmaddock/146c20a13c8f313e28a2e19db237db28)):
1. WebFrameMain is set to RFH A
2. Cross-origin navigation begins
3. WebFrameMain is swapped to RFH B
4. Window 'unload' listener is emitted in RFH A, now [marked as `kPendingDeletion`](https://source.chromium.org/chromium/chromium/src/+/main:content/public/browser/render_frame_host.h;l=729-737;drc=82dff63dbf9db05e9274e11d9128af7b9f51ceaa)
5. RFH A sends an IPC during the unload listener
6. IPC is received with senderFrame pointing to RFH B

`WebFrameMain` internally indexes a RFH by its FrameTreeNode ID. This is based on the design of WebFrameMain being similar to how `<iframe>` works.

By introducing a "pinned" WebFrameMain, we can ensure the data is immutable and won't update in the case of cross-origin navigation frame swaps.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes:
* Added "pinned" WebFrameMain variant used by IPC's `senderFrame` to ensure immutability of the sender.
* Added `webFrameMain.fromFrameTreeNodeId(frameTreeNodeId)` as a method to get a WebFrameMain instance independent of its process and frame IDs.
* Fixed `webFrameMain.fromId(processId, frameId)` returning a WebFrameMain which doesn't match the given parameters in cases where a cross-origin navigation occurred.
