### PR TITLE
refactor: simplify KeyWeakMap impl

### DIFF
--- a/shell/common/key_weak_map.h
+++ b/shell/common/key_weak_map.h
@@ -6,9 +6,9 @@
 #define ELECTRON_SHELL_COMMON_KEY_WEAK_MAP_H_
 
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
+#include "base/containers/to_vector.h"
 #include "base/memory/raw_ptr.h"
 #include "v8/include/v8-forward.h"
 
@@ -18,10 +18,10 @@ namespace electron {
 template <typename K>
 class KeyWeakMap {
  public:
-  KeyWeakMap() {}
+  KeyWeakMap() = default;
   ~KeyWeakMap() {
     for (auto& p : map_)
-      p.second.second.ClearWeak();
+      p.second.value.ClearWeak();
   }
 
   // disable copy
@@ -29,55 +29,47 @@ class KeyWeakMap {
   KeyWeakMap& operator=(const KeyWeakMap&) = delete;
 
   // Sets the object to WeakMap with the given |key|.
-  void Set(v8::Isolate* isolate, const K& key, v8::Local<v8::Object> object) {
-    KeyObject key_object = {key, this};
-    auto& p = map_[key] =
-        std::make_pair(key_object, v8::Global<v8::Object>(isolate, object));
-    p.second.SetWeak(&(p.first), OnObjectGC, v8::WeakCallbackType::kParameter);
+  void Set(v8::Isolate* isolate, const K& key, v8::Local<v8::Object> value) {
+    auto& mapped = map_[key] =
+        Mapped{this, key, v8::Global<v8::Object>(isolate, value)};
+    mapped.value.SetWeak(&mapped, OnObjectGC, v8::WeakCallbackType::kParameter);
   }
 
   // Gets the object from WeakMap by its |key|.
   v8::MaybeLocal<v8::Object> Get(v8::Isolate* isolate, const K& key) {
     if (auto iter = map_.find(key); iter != map_.end())
-      return v8::Local<v8::Object>::New(isolate, iter->second.second);
+      return v8::Local<v8::Object>::New(isolate, iter->second.value);
     return {};
   }
 
   // Returns all objects.
   std::vector<v8::Local<v8::Object>> Values(v8::Isolate* isolate) const {
-    std::vector<v8::Local<v8::Object>> values;
-    values.reserve(map_.size());
-    for (const auto& it : map_)
-      values.emplace_back(
-          v8::Local<v8::Object>::New(isolate, it.second.second));
-    return values;
+    return base::ToVector(map_, [isolate](const auto& iter) {
+      return v8::Local<v8::Object>::New(isolate, iter.second.value);
+    });
   }
 
   // Remove object with |key| in the WeakMap.
   void Remove(const K& key) {
-    auto iter = map_.find(key);
-    if (iter == map_.end())
-      return;
-
-    iter->second.second.ClearWeak();
-    map_.erase(iter);
+    if (auto item = map_.extract(key))
+      item.mapped().value.ClearWeak();
   }
 
  private:
   // Records the key and self, used by SetWeak.
-  struct KeyObject {
-    K key;
+  struct Mapped {
     raw_ptr<KeyWeakMap> self;
+    K key;
+    v8::Global<v8::Object> value;
   };
 
-  static void OnObjectGC(
-      const v8::WeakCallbackInfo<typename KeyWeakMap<K>::KeyObject>& data) {
-    KeyWeakMap<K>::KeyObject* key_object = data.GetParameter();
-    key_object->self->Remove(key_object->key);
+  static void OnObjectGC(const v8::WeakCallbackInfo<Mapped>& data) {
+    auto* mapped = data.GetParameter();
+    mapped->self->Remove(mapped->key);
   }
 
   // Map of stored objects.
-  std::unordered_map<K, std::pair<KeyObject, v8::Global<v8::Object>>> map_;
+  std::unordered_map<K, Mapped> map_;
 };
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

Simplify KeyWeakMap's implementation a little:

- Instead of having a MappedType of `std::pair<std::pair<A, B>, C>`, make a private struct that holds A, B, and C
- Use `base::ToVector()` to implement `KeyWeakMap::Values()`
- Use `std::map<>::extract()` to implement `KeyWeakMap::Remove()`
- Remove extra template syntax from `OnObjectGC()`
- Remove unused `#include <utility>`

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.