### PR TITLE
fix: update `BrowserView#lastWindowSize` after window resize

### DIFF
--- a/lib/browser/api/browser-view.ts
+++ b/lib/browser/api/browser-view.ts
@@ -145,6 +145,12 @@ export default class BrowserView {
     if (this.#autoHorizontalProportion || this.#autoVerticalProportion) {
       this.#webContentsView.setBounds(newViewBounds);
     }
+
+    // Update #lastWindowSize value after browser windows resize
+    this.#lastWindowSize = {
+      width: newBounds.width,
+      height: newBounds.height
+    };
   }
 
   get webContentsView () {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/43462

During BrowserView auto-resize, the new size is calculated using BrowserView#lastWindowSize, but lastWindowSize is never updated and remains the value from the initial window size. This results in BrowserView being resized incorrectly.
To fix this issue, we should update lastWindowSize to the current window size after it has been used.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed BrowserView auto resize issue.
