### PR TITLE
refactor: prefer std::ranges over begin() and end()

### DIFF
--- a/shell/app/electron_main_win.cc
+++ b/shell/app/electron_main_win.cc
@@ -165,7 +165,7 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
     base::AtExitManager atexit_manager;
     base::i18n::InitializeICU();
     auto ret = electron::NodeMain(argv.size(), argv.data());
-    std::for_each(argv.begin(), argv.end(), free);
+    std::ranges::for_each(argv, free);
     return ret;
   }
 

--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -34,11 +34,9 @@ bool RegisteringMediaKeyForUntrustedClient(const ui::Accelerator& accelerator) {
 
 bool MapHasMediaKeys(
     const std::map<ui::Accelerator, base::RepeatingClosure>& accelerator_map) {
-  auto media_key = std::find_if(
-      accelerator_map.begin(), accelerator_map.end(),
-      [](const auto& ac) { return Command::IsMediaKey(ac.first); });
-
-  return media_key != accelerator_map.end();
+  return std::ranges::any_of(accelerator_map, [](const auto& ac) {
+    return Command::IsMediaKey(ac.first);
+  });
 }
 #endif
 

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -455,8 +455,7 @@ struct Converter<network::mojom::SSLConfigPtr> {
         !options.Get("disabledCipherSuites", &(*out)->disabled_cipher_suites)) {
       return false;
     }
-    std::sort((*out)->disabled_cipher_suites.begin(),
-              (*out)->disabled_cipher_suites.end());
+    std::ranges::sort((*out)->disabled_cipher_suites);
 
     // TODO(nornagon): also support other SSLConfig properties?
     return true;

--- a/shell/browser/hid/hid_chooser_controller.cc
+++ b/shell/browser/hid/hid_chooser_controller.cc
@@ -49,11 +49,11 @@ bool FilterMatch(const blink::mojom::HidDeviceFilterPtr& filter,
   if (filter->usage) {
     if (filter->usage->is_page()) {
       const uint16_t usage_page = filter->usage->get_page();
-      auto find_it =
-          std::find_if(device.collections.begin(), device.collections.end(),
-                       [=](const device::mojom::HidCollectionInfoPtr& c) {
-                         return usage_page == c->usage->usage_page;
-                       });
+      auto find_it = std::ranges::find_if(
+          device.collections,
+          [=](const device::mojom::HidCollectionInfoPtr& c) {
+            return usage_page == c->usage->usage_page;
+          });
       if (find_it == device.collections.end())
         return false;
     } else if (filter->usage->is_usage_and_page()) {

--- a/shell/browser/notifications/notification_presenter.cc
+++ b/shell/browser/notifications/notification_presenter.cc
@@ -38,10 +38,10 @@ void NotificationPresenter::RemoveNotification(Notification* notification) {
 
 void NotificationPresenter::CloseNotificationWithId(
     const std::string& notification_id) {
-  auto it = std::find_if(notifications_.begin(), notifications_.end(),
-                         [&notification_id](const Notification* n) {
-                           return n->notification_id() == notification_id;
-                         });
+  auto it = std::ranges::find_if(
+      notifications_, [&notification_id](const Notification* n) {
+        return n->notification_id() == notification_id;
+      });
   if (it != notifications_.end()) {
     Notification* notification = (*it);
     notification->Dismiss();

--- a/shell/browser/serial/serial_chooser_controller.cc
+++ b/shell/browser/serial/serial_chooser_controller.cc
@@ -177,10 +177,9 @@ void SerialChooserController::OnDeviceChosen(const std::string& port_id) {
   if (port_id.empty()) {
     RunCallback(/*port=*/nullptr);
   } else {
-    const auto it =
-        std::find_if(ports_.begin(), ports_.end(), [&port_id](const auto& ptr) {
-          return ptr->token.ToString() == port_id;
-        });
+    const auto it = std::ranges::find_if(ports_, [&port_id](const auto& ptr) {
+      return ptr->token.ToString() == port_id;
+    });
     if (it != ports_.end()) {
       auto* rfh = content::RenderFrameHost::FromID(render_frame_host_id_);
       chooser_context_->GrantPortPermission(origin_, *it->get(), rfh);
@@ -194,10 +193,9 @@ void SerialChooserController::OnDeviceChosen(const std::string& port_id) {
 void SerialChooserController::OnGetDevices(
     std::vector<device::mojom::SerialPortInfoPtr> ports) {
   // Sort ports by file paths.
-  std::sort(ports.begin(), ports.end(),
-            [](const auto& port1, const auto& port2) {
-              return port1->path.BaseName() < port2->path.BaseName();
-            });
+  std::ranges::sort(ports, [](const auto& port1, const auto& port2) {
+    return port1->path.BaseName() < port2->path.BaseName();
+  });
 
   for (auto& port : ports) {
     if (DisplayDevice(*port))

--- a/shell/browser/ui/views/client_frame_view_linux.cc
+++ b/shell/browser/ui/views/client_frame_view_linux.cc
@@ -409,15 +409,15 @@ void ClientFrameViewLinux::LayoutButtonsOnSide(
       frame_buttons = trailing_frame_buttons_;
       // We always lay buttons out going from the edge towards the center, but
       // they are given to us as left-to-right, so reverse them.
-      std::reverse(frame_buttons.begin(), frame_buttons.end());
+      std::ranges::reverse(frame_buttons);
       break;
     default:
       NOTREACHED();
   }
 
   for (views::FrameButton frame_button : frame_buttons) {
-    auto* button = std::find_if(
-        nav_buttons_.begin(), nav_buttons_.end(), [&](const NavButton& test) {
+    auto* button =
+        std::ranges::find_if(nav_buttons_, [&](const NavButton& test) {
           return test.type != skip_type && test.frame_button == frame_button;
         });
     CHECK(button != nav_buttons_.end())

--- a/shell/browser/ui/win/notify_icon_host.cc
+++ b/shell/browser/ui/win/notify_icon_host.cc
@@ -211,8 +211,7 @@ NotifyIcon* NotifyIconHost::CreateNotifyIcon(std::optional<UUID> guid) {
 }
 
 void NotifyIconHost::Remove(NotifyIcon* icon) {
-  NotifyIcons::iterator i(
-      std::find(notify_icons_.begin(), notify_icons_.end(), icon));
+  const auto i = std::ranges::find(notify_icons_, icon);
 
   if (i == notify_icons_.end()) {
     NOTREACHED();
@@ -241,11 +240,7 @@ LRESULT CALLBACK NotifyIconHost::WndProc(HWND hwnd,
                                          LPARAM lparam) {
   if (message == taskbar_created_message_) {
     // We need to reset all of our icons because the taskbar went away.
-    for (NotifyIcons::const_iterator i(notify_icons_.begin());
-         i != notify_icons_.end(); ++i) {
-      auto* win_icon = static_cast<NotifyIcon*>(*i);
-      win_icon->ResetIcon();
-    }
+    std::ranges::for_each(notify_icons_, [](auto* icon) { icon->ResetIcon(); });
     return TRUE;
   } else if (message == kNotifyIconMessage) {
     NotifyIcon* win_icon = nullptr;

--- a/shell/browser/window_list.cc
+++ b/shell/browser/window_list.cc
@@ -85,7 +85,7 @@ void WindowList::CloseAllWindows() {
   std::vector<base::WeakPtr<NativeWindow>> weak_windows =
       ConvertToWeakPtrVector(GetInstance()->windows_);
 #if BUILDFLAG(IS_MAC)
-  std::reverse(weak_windows.begin(), weak_windows.end());
+  std::ranges::reverse(weak_windows);
 #endif
   for (const auto& window : weak_windows) {
     if (window && !window->IsClosed())

--- a/shell/common/crash_keys.cc
+++ b/shell/common/crash_keys.cc
@@ -67,7 +67,7 @@ void SetCrashKey(const std::string& key, const std::string& value) {
 
   auto& crash_key_names = GetExtraCrashKeyNames();
 
-  auto iter = std::find(crash_key_names.begin(), crash_key_names.end(), key);
+  auto iter = std::ranges::find(crash_key_names, key);
   if (iter == crash_key_names.end()) {
     crash_key_names.emplace_back(key);
     GetExtraCrashKeys().emplace_back(crash_key_names.back().c_str());
@@ -79,7 +79,7 @@ void SetCrashKey(const std::string& key, const std::string& value) {
 void ClearCrashKey(const std::string& key) {
   const auto& crash_key_names = GetExtraCrashKeyNames();
 
-  auto iter = std::find(crash_key_names.begin(), crash_key_names.end(), key);
+  auto iter = std::ranges::find(crash_key_names, key);
   if (iter != crash_key_names.end()) {
     GetExtraCrashKeys()[iter - crash_key_names.begin()].Clear();
   }

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -800,8 +800,8 @@ std::shared_ptr<node::Environment> NodeBindings::CreateEnvironment(
 #if BUILDFLAG(IS_WIN)
   auto& electron_args = ElectronCommandLine::argv();
   std::vector<std::string> args(electron_args.size());
-  std::transform(electron_args.cbegin(), electron_args.cend(), args.begin(),
-                 [](auto& a) { return base::WideToUTF8(a); });
+  std::ranges::transform(electron_args, args.begin(),
+                         [](auto& a) { return base::WideToUTF8(a); });
 #else
   auto args = ElectronCommandLine::argv();
 #endif


### PR DESCRIPTION
#### Description of Change

`std::ranges` is [allowed now](https://chromium-review.googlesource.com/c/chromium/src/+/5668999), so let's use it. This PR migrates the lowest-hanging fruit, e.g. easy cases like this:

```diff
- std::sort(foo.begin(), foo.end());
+ std::ranges::sort(foo);
```

```diff
- std::reverse(foo.begin(), foo.end());
+ std::ranges::reverse(foo);
```

Previously: #43172

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none