### PR TITLE
fix: -Wunsafe-buffer-usage warnings in IsUrlArg()

### DIFF
--- a/shell/app/command_line_args.cc
+++ b/shell/app/command_line_args.cc
@@ -48,7 +48,7 @@ bool CheckCommandLineArguments(const base::CommandLine::StringVector& argv) {
       break;
     if (block_args)
       return false;
-    if (IsUrl(arg))
+    if (IsUrlArg(arg))
       block_args = true;
   }
   return true;

--- a/shell/app/command_line_args.cc
+++ b/shell/app/command_line_args.cc
@@ -43,7 +43,6 @@ namespace electron {
 // More info at https://www.electronjs.org/blog/protocol-handler-fix
 bool CheckCommandLineArguments(const base::CommandLine::StringVector& argv) {
   bool block_args = false;
-
   for (const auto& arg : argv) {
     if (arg == DashDash)
       break;
@@ -52,7 +51,6 @@ bool CheckCommandLineArguments(const base::CommandLine::StringVector& argv) {
     if (IsUrl(arg))
       block_args = true;
   }
-
   return true;
 }
 

--- a/shell/app/command_line_args.h
+++ b/shell/app/command_line_args.h
@@ -9,7 +9,7 @@
 
 namespace electron {
 
-bool CheckCommandLineArguments(int argc, base::CommandLine::CharType** argv);
+bool CheckCommandLineArguments(const base::CommandLine::StringVector& argv);
 bool IsSandboxEnabled(base::CommandLine* command_line);
 
 }  // namespace electron

--- a/shell/app/electron_main_win.cc
+++ b/shell/app/electron_main_win.cc
@@ -224,7 +224,7 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
   CHECK_EQ(fiber_status, FiberStatus::kSuccess);
 #endif  // defined(ARCH_CPU_32_BITS)
 
-  if (!electron::CheckCommandLineArguments(arguments.argc, arguments.argv))
+  if (!electron::CheckCommandLineArguments(command_line->argv()))
     return -1;
 
   sandbox::SandboxInterfaceInfo sandbox_info = {nullptr};


### PR DESCRIPTION
#### Description of Change

Upstream is starting to use `-Wunsafe-buffer-usage` as part of a [larger C buffer hardening project at Google](https://bughunters.google.com/blog/6368559657254912/llvm-s-rfc-c-buffer-hardening-at-google). We should be doing this too.

This is part 1 in a small series to fix `-Wunsafe-buffer-usage` warnings in Electron. My intent is to fix all of them and then add the clang warning to our cflags.

We have 44 such warnings in `shell/`. This PR fixes the first three :smile_cat: 

```sh
46362:../../electron/shell/app/command_line_args.cc:18:20: warning: unsafe pointer arithmetic [-Wunsafe-buffer-usage]
46365:../../electron/shell/app/command_line_args.cc:18:20: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
46366:../../electron/shell/app/command_line_args.cc:18:35: warning: unsafe pointer arithmetic [-Wunsafe-buffer-usage]
46369:../../electron/shell/app/command_line_args.cc:18:35: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
46370:../../electron/shell/app/command_line_args.cc:24:18: warning: unsafe pointer arithmetic [-Wunsafe-buffer-usage]
46373:../../electron/shell/app/command_line_args.cc:24:18: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.