### PR TITLE
fix: devtools dock state with WCO on linux

### DIFF
--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -550,7 +550,7 @@ void InspectableWebContents::LoadCompleted() {
           prefs.FindString("currentDockState");
       base::RemoveChars(*current_dock_state, "\"", &dock_state_);
     }
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX)
     auto* api_web_contents = api::WebContents::From(GetWebContents());
     if (api_web_contents) {
       auto* win =


### PR DESCRIPTION
#### Description of Change

Enables fix from https://github.com/electron/electron/pull/39734 for linux when WCO is enabled.

Refs https://github.com/microsoft/vscode/issues/226633

#### Release Notes

Notes: fix devtools to allow restoring saved dock state on Linux when WCO is enabled