### PR TITLE
chore: speed up cache only reclient for fork PRs

### DIFF
--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -115,6 +115,13 @@ for:
           $env:RBE_experimental_credentials_helper = $env:RECLIENT_HELPER
       - ps: >-
           $env:RBE_experimental_credentials_helper_args = "print"
+      - ps: >-
+          if ($env:ELECTRON_RBE_JWT -eq '') {
+            $env:RBE_fail_early_min_action_count = "0"
+            $env:RBE_fail_early_min_fallback_ratio = "0"
+            $env:RBE_exec_strategy = "local"
+            $env:RBE_remote_update_cache= "false"
+          }
       - cd ..\..
       - ps: $env:CHROMIUM_BUILDTOOLS_PATH="$pwd\src\buildtools"
       - ps: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -113,6 +113,13 @@ for:
           $env:RBE_experimental_credentials_helper = $env:RECLIENT_HELPER
       - ps: >-
           $env:RBE_experimental_credentials_helper_args = "print"
+      - ps: >-
+          if ($env:ELECTRON_RBE_JWT -eq '') {
+            $env:RBE_fail_early_min_action_count = "0"
+            $env:RBE_fail_early_min_fallback_ratio = "0"
+            $env:RBE_exec_strategy = "local"
+            $env:RBE_remote_update_cache= "false"
+          }
       - cd ..\..
       - ps: $env:CHROMIUM_BUILDTOOLS_PATH="$pwd\src\buildtools"
       - ps: >-


### PR DESCRIPTION
#### Description of Change
- As discovered in https://github.com/electron/build-tools/issues/630 there are certain environment variables that should be set when using read only reclient.  GHA uses build-tools so the changes in https://github.com/electron/build-tools/pull/631 will address this; however for AppVeyor we need to manually set the applicable environment variables which is what this PR does.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
