### PR TITLE
fix: systemMediaPermissionDenied should not check camera perms when the request is asking for screen share

### DIFF
--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -66,12 +66,22 @@ bool SystemMediaPermissionDenied(const content::MediaStreamRequest& request) {
                system_media_permissions::SystemPermission::kDenied;
   }
   if (request.video_type != MediaStreamType::NO_SERVICE) {
-    const auto system_video_permission =
-        system_media_permissions::CheckSystemVideoCapturePermission();
-    return system_video_permission ==
-               system_media_permissions::SystemPermission::kRestricted ||
-           system_video_permission ==
-               system_media_permissions::SystemPermission::kDenied;
+    if (request.video_type == MediaStreamType::GUM_DESKTOP_VIDEO_CAPTURE ||
+        request.video_type == MediaStreamType::GUM_TAB_VIDEO_CAPTURE) {
+          const auto system_screen_permission =
+            system_media_permissions::CheckSystemScreenCapturePermission();
+      return system_screen_permission ==
+                system_media_permissions::SystemPermission::kRestricted ||
+              system_screen_permission ==
+                system_media_permissions::SystemPermission::kDenied;
+    } else {
+        const auto system_video_permission =
+          system_media_permissions::CheckSystemVideoCapturePermission();
+        return system_video_permission ==
+                  system_media_permissions::SystemPermission::kRestricted ||
+              system_video_permission ==
+                  system_media_permissions::SystemPermission::kDenied;
+    }
   }
   return false;
 }

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -57,7 +57,7 @@ namespace {
 
 #if BUILDFLAG(IS_MAC)
 bool SystemMediaPermissionDenied(const content::MediaStreamRequest& request) {
-  if (request.audio_type != MediaStreamType::NO_SERVICE) {
+  if (request.audio_type == MediaStreamType::DEVICE_AUDIO_CAPTURE) {
     const auto system_audio_permission =
         system_media_permissions::CheckSystemAudioCapturePermission();
     return system_audio_permission ==
@@ -65,7 +65,7 @@ bool SystemMediaPermissionDenied(const content::MediaStreamRequest& request) {
            system_audio_permission ==
                system_media_permissions::SystemPermission::kDenied;
   }
-  if (request.video_type != MediaStreamType::NO_SERVICE) {
+  if (request.video_type != MediaStreamType::DEVICE_VIDEO_CAPTURE) {
     const auto system_video_permission =
         system_media_permissions::CheckSystemVideoCapturePermission();
     return system_video_permission ==
@@ -73,7 +73,7 @@ bool SystemMediaPermissionDenied(const content::MediaStreamRequest& request) {
            system_video_permission ==
                system_media_permissions::SystemPermission::kDenied;
   }
-  return false;
+  return true;
 }
 #endif
 

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -66,22 +66,12 @@ bool SystemMediaPermissionDenied(const content::MediaStreamRequest& request) {
                system_media_permissions::SystemPermission::kDenied;
   }
   if (request.video_type != MediaStreamType::NO_SERVICE) {
-    if (request.video_type == MediaStreamType::GUM_DESKTOP_VIDEO_CAPTURE ||
-        request.video_type == MediaStreamType::GUM_TAB_VIDEO_CAPTURE) {
-          const auto system_screen_permission =
-            system_media_permissions::CheckSystemScreenCapturePermission();
-      return system_screen_permission ==
-                system_media_permissions::SystemPermission::kRestricted ||
-              system_screen_permission ==
-                system_media_permissions::SystemPermission::kDenied;
-    } else {
-        const auto system_video_permission =
-          system_media_permissions::CheckSystemVideoCapturePermission();
-        return system_video_permission ==
-                  system_media_permissions::SystemPermission::kRestricted ||
-              system_video_permission ==
-                  system_media_permissions::SystemPermission::kDenied;
-    }
+    const auto system_video_permission =
+        system_media_permissions::CheckSystemVideoCapturePermission();
+    return system_video_permission ==
+               system_media_permissions::SystemPermission::kRestricted ||
+           system_video_permission ==
+               system_media_permissions::SystemPermission::kDenied;
   }
   return false;
 }

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -73,7 +73,8 @@ bool SystemMediaPermissionDenied(const content::MediaStreamRequest& request) {
            system_video_permission ==
                system_media_permissions::SystemPermission::kDenied;
   }
-  return true;
+
+  return false;
 }
 #endif
 

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -65,7 +65,7 @@ bool SystemMediaPermissionDenied(const content::MediaStreamRequest& request) {
            system_audio_permission ==
                system_media_permissions::SystemPermission::kDenied;
   }
-  if (request.video_type != MediaStreamType::DEVICE_VIDEO_CAPTURE) {
+  if (request.video_type == MediaStreamType::DEVICE_VIDEO_CAPTURE) {
     const auto system_video_permission =
         system_media_permissions::CheckSystemVideoCapturePermission();
     return system_video_permission ==


### PR DESCRIPTION
#### Description of Change
We are seeing a bug where `navigator.getUserMedia` is falsely reporting incorrect (`denied`) permissions when attempting to retrieve screen sharing permissions despite screen share TTC permissions being `allowed`. This bug is triggered when `camera` permissions are denied.

This PR changes the if statements so we only do this check when trying to return `getUserMedia` results for camera and microphone.



<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes:  fixed bug where camera permissions affected screen sharing <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
