### PR TITLE
fix: don't use deprecate-soon class v8::String::Value

### DIFF
--- a/shell/common/gin_converters/file_path_converter.h
+++ b/shell/common/gin_converters/file_path_converter.h
@@ -23,9 +23,11 @@ struct Converter<base::FilePath> {
     if (val->IsNull())
       return true;
 
-    v8::String::Value str(isolate, val);
-    if (str.length() == 0) {
-      *out = base::FilePath();
+    // if the `val` is an empty string, set `out` to an empty FilePath
+    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+    v8::Local<v8::String> str;
+    if (!val->ToString(context).ToLocal(&str) || str->Length() == 0) {
+      *out = {};
       return true;
     }
 

--- a/shell/common/gin_converters/file_path_converter.h
+++ b/shell/common/gin_converters/file_path_converter.h
@@ -23,10 +23,11 @@ struct Converter<base::FilePath> {
     if (val->IsNull())
       return true;
 
+    if (!val->IsString())
+      return true;
     // if the `val` is an empty string, set `out` to an empty FilePath
-    v8::Local<v8::Context> context = isolate->GetCurrentContext();
-    v8::Local<v8::String> str;
-    if (!val->ToString(context).ToLocal(&str) || str->Length() == 0) {
+    v8::Local<v8::String> str = v8::Local<v8::String>::Cast(val);
+    if (str->Length() == 0) {
       *out = {};
       return true;
     }

--- a/shell/common/gin_converters/file_path_converter.h
+++ b/shell/common/gin_converters/file_path_converter.h
@@ -23,11 +23,7 @@ struct Converter<base::FilePath> {
     if (val->IsNull())
       return true;
 
-    if (!val->IsString())
-      return true;
-    // if the `val` is an empty string, set `out` to an empty FilePath
-    v8::Local<v8::String> str = v8::Local<v8::String>::Cast(val);
-    if (str->Length() == 0) {
+    if (val->IsString() && v8::Local<v8::String>::Cast(val)->Length() == 0) {
       *out = {};
       return true;
     }


### PR DESCRIPTION
#### Description of Change

Upstream marked v8::String::Value as `V8_DEPRECATE_SOON` last month, so let's stop using it.

The replacement code mostly does the same as v8::String::Value()''s implementation; but since our test only cares about the length and not the contents, we also get a nice little perf win of not needing to allocate a char array and not needing to call Local::String::Write().

- [Upstream V8_DEPRECATE_SOON change](https://chromium-review.googlesource.com/c/v8/v8/+/5667299)
- Upstream's [v8::String::Value() impl](https://chromium.googlesource.com/v8/v8/+/20226b740bfa1a1e46dff80363232dfd3da50de8/src/api/api.cc#10883)
- History on why we used it in #19792: [1](https://github.com/electron/electron/pull/19792/commits/80c1a9739d191d2e393e56e2b254fb72bf6859e9), [2](https://github.com/electron/electron/pull/19792/commits/f49ed30f7205d7295ab035c6f1b3702cf7e3217c)

CC @codebytere and @deepak1556 who coded / reviewed 19792

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.