### PR TITLE
refactor: move NativeWindow::child_windows_ to NativeWindowMac

### DIFF
--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_BROWSER_NATIVE_WINDOW_H_
 #define ELECTRON_SHELL_BROWSER_NATIVE_WINDOW_H_
 
-#include <list>
 #include <memory>
 #include <optional>
 #include <queue>
@@ -402,10 +401,6 @@ class NativeWindow : public base::SupportsUserData,
 
   int32_t window_id() const { return next_id_; }
 
-  void add_child_window(NativeWindow* child) {
-    child_windows_.push_back(child);
-  }
-
   int NonClientHitTest(const gfx::Point& point);
   void AddDraggableRegionProvider(DraggableRegionProvider* provider);
   void RemoveDraggableRegionProvider(DraggableRegionProvider* provider);
@@ -457,8 +452,6 @@ class NativeWindow : public base::SupportsUserData,
       FullScreenTransitionState::kNone;
   FullScreenTransitionType fullscreen_transition_type_ =
       FullScreenTransitionType::kNone;
-
-  std::list<NativeWindow*> child_windows_;
 
  private:
   std::unique_ptr<views::Widget> widget_;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -7,6 +7,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+#include <list>
 #include <memory>
 #include <optional>
 #include <string>
@@ -234,6 +235,10 @@ class NativeWindowMac : public NativeWindow,
                                uint32_t changed_metrics) override;
 
  private:
+  void add_child_window(NativeWindow* child) {
+    child_windows_.push_back(child);
+  }
+
   // Add custom layers to the content view.
   void AddContentViewLayers();
 
@@ -307,6 +312,8 @@ class NativeWindowMac : public NativeWindow,
 
   // The presentation options before entering simple fullscreen mode.
   NSApplicationPresentationOptions simple_fullscreen_options_;
+
+  std::list<NativeWindow*> child_windows_;
 };
 
 }  // namespace electron

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1771,10 +1771,10 @@ void NativeWindowMac::InternalSetParentWindow(NativeWindow* new_parent,
   RemoveChildFromParentWindow();
 
   // Set new parent window.
-  if (new_parent) {
-    new_parent->add_child_window(this);
+  if (auto* new_parent_mac = static_cast<NativeWindowMac*>(new_parent)) {
+    new_parent_mac->add_child_window(this);
     if (attach)
-      new_parent->AttachChildren();
+      new_parent_mac->AttachChildren();
   }
 
   NativeWindow::SetParentWindow(new_parent);


### PR DESCRIPTION
#### Description of Change

Only the Mac subclass of NativeWindow uses the child_windows_ field, so move that field to the subclass.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.