### PR TITLE
build: free up macos disk space as soon as possible

### DIFF
--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -82,6 +82,12 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+    - name: Free up space (macOS)
+      if: ${{ inputs.target-platform == 'macos' }}
+      uses: ./src/electron/.github/actions/free-space-macos
+    - name: Check disk space after freeing up space
+      if: ${{ inputs.target-platform == 'macos' }}
+      run: df -h
     - name: Setup Node.js/npm
       if: ${{ inputs.target-platform == 'macos' }}
       uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -54,6 +54,23 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+    - name: Cleanup disk space on macOS
+      if: ${{ inputs.target-platform == 'macos' }}
+      shell: bash
+      run: |   
+        sudo mkdir -p $TMPDIR/del-target
+
+        tmpify() {
+          if [ -d "$1" ]; then
+            sudo mv "$1" $TMPDIR/del-target/$(echo $1|shasum -a 256|head -n1|cut -d " " -f1)
+          fi
+        }   
+        tmpify /Library/Developer/CoreSimulator
+        tmpify ~/Library/Developer/CoreSimulator
+        sudo rm -rf $TMPDIR/del-target
+    - name: Check disk space after freeing up space
+      if: ${{ inputs.target-platform == 'macos' }}
+      run: df -h        
     - name: Install Build Tools
       uses: ./src/electron/.github/actions/install-build-tools
     - name: Init Build Tools


### PR DESCRIPTION
#### Description of Change
Something happened to the GitHub Actions `macos-14-xlarge` runners that caused these runners to only have 19GB of free space available on them:
```
Run df -h
Filesystem        Size    Used   Avail Capacity iused ifree %iused  Mounted on
/dev/disk3s1s1   295Gi   9.6Gi    19Gi    35%    404k  194M    0%   /
devfs            195Ki   195Ki     0Bi   100%     674     0  100%   /dev
/dev/disk3s6     295Gi    20Ki    19Gi     1%       0  194M    0%   /System/Volumes/VM
/dev/disk3s2     295Gi   4.9Gi    19Gi    22%     [15](https://github.com/electron/electron/actions/runs/10686391001/job/29621645893#step:2:16)3  194M    0%   /System/Volumes/Preboot
/dev/disk3s4     295Gi   288Ki    19Gi     1%      23  194M    0%   /System/Volumes/Update
/dev/disk1s2     500Mi    20Ki   495Mi     1%       0  5.1M    0%   /System/Volumes/xarts
/dev/disk1s1     500Mi    96Ki   495Mi     1%      20  5.1M    0%   /System/Volumes/iSCPreboot
/dev/disk1s3     500Mi   196Ki   495Mi     1%      [17](https://github.com/electron/electron/actions/runs/10686391001/job/29621645893#step:2:18)  5.1M    0%   /System/Volumes/Hardware
/dev/disk3s5     295Gi   260Gi    19Gi    94%    2.2M  194M    1%   /System/Volumes/Data
map auto_home      0Bi     0Bi     0Bi   100%       0     0     -   /System/Volumes/Data/home
```
eg as seen here:
https://github.com/electron/electron/actions/runs/10686391001/job/29621645893#step:2:1

This PR will work around that issue by running our action to free up macos disk space as soon as possible. With this PR the cleanup action will run twice because it also cleans out the src dir once it has been downloaded and unarchived.
 
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
