### PR TITLE
chore: migrate to v8::Object::SetPrototypeV2()

### DIFF
--- a/shell/common/gin_helper/event_emitter_template.cc
+++ b/shell/common/gin_helper/event_emitter_template.cc
@@ -32,7 +32,7 @@ v8::Local<v8::FunctionTemplate> GetEventEmitterTemplate(v8::Isolate* isolate) {
               .ToLocal(&func_prototype));
 
     CHECK(func_prototype.As<v8::Object>()
-              ->SetPrototype(context, eventemitter_prototype)
+              ->SetPrototypeV2(context, eventemitter_prototype)
               .ToChecked());
 
     data->SetFunctionTemplate(&kWrapperInfo, tmpl);


### PR DESCRIPTION
#### Description of Change

Xref: https://chromium-review.googlesource.com/c/v8/v8/+/5600627

[api] Mark v8::Object::GetPrototype() for deprecation

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.