### PR TITLE
build: don't run symbol generation on PS

### DIFF
--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -174,8 +174,8 @@ for:
           if ($env:GN_CONFIG -eq 'release') {
             # Needed for msdia140.dll on 64-bit windows
             $env:Path += ";$pwd\third_party\llvm-build\Release+Asserts\bin"
-            autoninja -C out/Default electron:electron_symbols
           }
+      - if "%GN_CONFIG%"=="release" ( autoninja -C out/Default electron:electron_symbols )
       - ps: >-
           if ($env:GN_CONFIG -eq 'release') {
             python3 electron\script\zip-symbols.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -171,8 +171,8 @@ for:
           if ($env:GN_CONFIG -eq 'release') {
             # Needed for msdia140.dll on 64-bit windows
             $env:Path += ";$pwd\third_party\llvm-build\Release+Asserts\bin"
-            autoninja -C out/Default electron:electron_symbols
           }
+      - if "%GN_CONFIG%"=="release" ( autoninja -C out/Default electron:electron_symbols )
       - ps: >-
           if ($env:GN_CONFIG -eq 'release') {
             python3 electron\script\zip-symbols.py


### PR DESCRIPTION
#### Description of Change

This PR fixes symbol generation on Windows - currently, autoninja is failing on PowerShell commands with an error which is swallowed when running the command in cmd. This will unblock release builds.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
