### PR TITLE
fix: delete UvTaskRunner's timers only after they're closed

### DIFF
--- a/shell/app/uv_task_runner.cc
+++ b/shell/app/uv_task_runner.cc
@@ -2,21 +2,29 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <algorithm>
 #include <utility>
 
 #include "base/location.h"
 #include "base/time/time.h"
 #include "shell/app/uv_task_runner.h"
 
+namespace {
+
+template <typename T>
+void CloseHeapHandle(T* handle) {
+  uv_close(reinterpret_cast<uv_handle_t*>(handle),
+           [](uv_handle_t* closed) { delete reinterpret_cast<T*>(closed); });
+}
+
+}  // namespace
+
 namespace electron {
 
 UvTaskRunner::UvTaskRunner(uv_loop_t* loop) : loop_(loop) {}
 
 UvTaskRunner::~UvTaskRunner() {
-  for (auto& iter : tasks_) {
-    uv_unref(reinterpret_cast<uv_handle_t*>(iter.first));
-    delete iter.first;
-  }
+  std::ranges::for_each(tasks_, [](auto& it) { CloseHeapHandle(it.first); });
 }
 
 bool UvTaskRunner::PostDelayedTask(const base::Location& from_here,
@@ -26,7 +34,7 @@ bool UvTaskRunner::PostDelayedTask(const base::Location& from_here,
   timer->data = this;
   uv_timer_init(loop_, timer);
   uv_timer_start(timer, UvTaskRunner::OnTimeout, delay.InMilliseconds(), 0);
-  tasks_[timer] = std::move(task);
+  tasks_.insert_or_assign(timer, std::move(task));
   return true;
 }
 
@@ -43,19 +51,10 @@ bool UvTaskRunner::PostNonNestableDelayedTask(const base::Location& from_here,
 // static
 void UvTaskRunner::OnTimeout(uv_timer_t* timer) {
   auto& tasks = static_cast<UvTaskRunner*>(timer->data)->tasks_;
-  const auto iter = tasks.find(timer);
-  if (iter == std::end(tasks))
-    return;
-
-  std::move(iter->second).Run();
-  tasks.erase(iter);
-  uv_timer_stop(timer);
-  uv_close(reinterpret_cast<uv_handle_t*>(timer), UvTaskRunner::OnClose);
-}
-
-// static
-void UvTaskRunner::OnClose(uv_handle_t* handle) {
-  delete reinterpret_cast<uv_timer_t*>(handle);
+  if (auto item = tasks.extract(timer)) {
+    std::move(item.mapped()).Run();
+    CloseHeapHandle(timer);
+  }
 }
 
 }  // namespace electron

--- a/shell/app/uv_task_runner.cc
+++ b/shell/app/uv_task_runner.cc
@@ -2,39 +2,33 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include <algorithm>
+#include "shell/app/uv_task_runner.h"
+
 #include <utility>
 
 #include "base/location.h"
 #include "base/time/time.h"
-#include "shell/app/uv_task_runner.h"
-
-namespace {
-
-template <typename T>
-void CloseHeapHandle(T* handle) {
-  uv_close(reinterpret_cast<uv_handle_t*>(handle),
-           [](uv_handle_t* closed) { delete reinterpret_cast<T*>(closed); });
-}
-
-}  // namespace
 
 namespace electron {
 
-UvTaskRunner::UvTaskRunner(uv_loop_t* loop) : loop_(loop) {}
+UvTaskRunner::UvTaskRunner(uv_loop_t* loop) : loop_{loop} {}
 
-UvTaskRunner::~UvTaskRunner() {
-  std::ranges::for_each(tasks_, [](auto& it) { CloseHeapHandle(it.first); });
-}
+UvTaskRunner::~UvTaskRunner() = default;
 
 bool UvTaskRunner::PostDelayedTask(const base::Location& from_here,
                                    base::OnceClosure task,
                                    base::TimeDelta delay) {
-  auto* timer = new uv_timer_t;
+  auto on_timeout = [](uv_timer_t* timer) {
+    auto& tasks = static_cast<UvTaskRunner*>(timer->data)->tasks_;
+    if (auto iter = tasks.find(timer); iter != tasks.end())
+      std::move(tasks.extract(iter).mapped()).Run();
+  };
+
+  auto timer = UvHandle<uv_timer_t>{};
   timer->data = this;
-  uv_timer_init(loop_, timer);
-  uv_timer_start(timer, UvTaskRunner::OnTimeout, delay.InMilliseconds(), 0);
-  tasks_.insert_or_assign(timer, std::move(task));
+  uv_timer_init(loop_, timer.get());
+  uv_timer_start(timer.get(), on_timeout, delay.InMilliseconds(), 0);
+  tasks_.insert_or_assign(std::move(timer), std::move(task));
   return true;
 }
 
@@ -46,15 +40,6 @@ bool UvTaskRunner::PostNonNestableDelayedTask(const base::Location& from_here,
                                               base::OnceClosure task,
                                               base::TimeDelta delay) {
   return PostDelayedTask(from_here, std::move(task), delay);
-}
-
-// static
-void UvTaskRunner::OnTimeout(uv_timer_t* timer) {
-  auto& tasks = static_cast<UvTaskRunner*>(timer->data)->tasks_;
-  if (auto item = tasks.extract(timer)) {
-    std::move(item.mapped()).Run();
-    CloseHeapHandle(timer);
-  }
 }
 
 }  // namespace electron

--- a/shell/app/uv_task_runner.h
+++ b/shell/app/uv_task_runner.h
@@ -39,7 +39,6 @@ class UvTaskRunner : public base::SingleThreadTaskRunner {
  private:
   ~UvTaskRunner() override;
   static void OnTimeout(uv_timer_t* timer);
-  static void OnClose(uv_handle_t* handle);
 
   raw_ptr<uv_loop_t> loop_;
 

--- a/shell/app/uv_task_runner.h
+++ b/shell/app/uv_task_runner.h
@@ -9,7 +9,7 @@
 
 #include "base/memory/raw_ptr.h"
 #include "base/task/single_thread_task_runner.h"
-#include "uv.h"  // NOLINT(build/include_directory)
+#include "shell/common/node_bindings.h"
 
 namespace base {
 class Location;
@@ -38,11 +38,10 @@ class UvTaskRunner : public base::SingleThreadTaskRunner {
 
  private:
   ~UvTaskRunner() override;
-  static void OnTimeout(uv_timer_t* timer);
 
   raw_ptr<uv_loop_t> loop_;
 
-  std::map<uv_timer_t*, base::OnceClosure> tasks_;
+  std::map<UvHandle<uv_timer_t>, base::OnceClosure, UvHandleCompare> tasks_;
 };
 
 }  // namespace electron

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -15,6 +15,7 @@
 #include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ptr_exclusion.h"
 #include "base/memory/weak_ptr.h"
+#include "base/types/to_address.h"
 #include "gin/public/context_holder.h"
 #include "gin/public/gin_embedders.h"
 #include "uv.h"  // NOLINT(build/include_directory)
@@ -58,10 +59,24 @@ template <typename T,
               std::is_same<T, uv_udp_t>::value>::type* = nullptr>
 class UvHandle {
  public:
-  UvHandle() : t_(new T) {}
+  UvHandle() : t_{new T} {}
   ~UvHandle() { reset(); }
+
+  UvHandle(UvHandle&&) = default;
+  UvHandle& operator=(UvHandle&&) = default;
+
+  UvHandle(const UvHandle&) = delete;
+  UvHandle& operator=(const UvHandle&) = delete;
+
   T* get() { return t_; }
+  T* operator->() { return t_; }
+  const T* get() const { return t_; }
+  const T* operator->() const { return t_; }
+
   uv_handle_t* handle() { return reinterpret_cast<uv_handle_t*>(t_); }
+
+  // compare by handle pointer address
+  auto operator<=>(const UvHandle& that) const = default;
 
   void reset() {
     auto* h = handle();
@@ -78,6 +93,16 @@ class UvHandle {
   }
 
   RAW_PTR_EXCLUSION T* t_ = {};
+};
+
+// Helper for comparing UvHandles and raw uv pointers, e.g. as map keys
+struct UvHandleCompare {
+  using is_transparent = void;
+
+  template <typename U, typename V>
+  bool operator()(U const& u, V const& v) const {
+    return base::to_address(u) < base::to_address(v);
+  }
 };
 
 class NodeBindings {


### PR DESCRIPTION
#### Description of Change

Fixes our UvTaskRunner to release uv handles correctly. The [libuv docs say](https://docs.libuv.org/en/v1.x/handle.html#c.uv_close):

> [uv_close()] MUST be called on each handle before memory is released. Moreover, the memory can only be released in close_cb or after it has returned.

Previously, our UvTaskRunner destructor cleaned up any remaining handles by unreffing them and then immediately deleting them. This PR changes that to use the `UvHandle` wrapper class from `node_bindings.h`. since [that class exists to follow libuv's close-then-free lifecycle correctly](https://github.com/electron/electron/pull/25332).

This PR also adds some new work to `UvHandle` to allow it to be used as a map key (follow the [rule of five](https://en.cppreference.com/w/cpp/language/rule_of_three), add a [default spaceship operator](https://en.cppreference.com/w/cpp/language/default_comparisons), add a UvHandleCompare helper class for [heterogeneous lookup](https://abseil.io/tips/144)).

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.