### PR TITLE
build: fix telemetry error when using autoninja

### DIFF
--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -95,6 +95,8 @@ for:
       - git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
       - ps: New-Item -Name depot_tools\.disable_auto_update -ItemType File
       - depot_tools\bootstrap\win_tools.bat
+      - ps: |
+          Set-Content -Path $pwd\depot_tools\build_telemetry.cfg -Value '{"user": "info@electronjs.org", "status": "opt-out", "countdown": 10, "version": 1}'
       - ps: $env:PATH="$pwd\depot_tools;$env:PATH"
       - ps: >-
           if (Test-Path -Path "$pwd\src\electron") {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -93,6 +93,8 @@ for:
       - git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
       - ps: New-Item -Name depot_tools\.disable_auto_update -ItemType File
       - depot_tools\bootstrap\win_tools.bat
+      - ps: |
+          Set-Content -Path $pwd\depot_tools\build_telemetry.cfg -Value '{"user": "info@electronjs.org", "status": "opt-out", "countdown": 10, "version": 1}'
       - ps: $env:PATH="$pwd\depot_tools;$env:PATH"
       - ps: >-
           if (Test-Path -Path "$pwd\src\electron") {


### PR DESCRIPTION
#### Description of Change
autoninja has been throwing an error in Windows builds:
```
 ERROR:root:Expecting value: line 1 column 1 (char 0)
```
eg see https://ci.appveyor.com/project/electron-bot/electron-x64-release/builds/50534902/job/m4hntgux7tc9xdva#L59117

It turns out that https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/5669094 caused this error and we can work around it by creating a file called `build_telemetry.cfg` in the depot_tools directory.

This change is not needed for GHA as the error doesn't surface there, probably due to the fact that builds there run through `e build` instead of calling autoninja directly.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
