### PR TITLE
fix: ensure version of `xdg-dialog-portal` with `defaultPath` support

### DIFF
--- a/patches/chromium/feat_add_support_for_missing_dialog_features_to_shell_dialogs.patch
+++ b/patches/chromium/feat_add_support_for_missing_dialog_features_to_shell_dialogs.patch
@@ -199,10 +199,21 @@ index 58985ce62dc569256bad5e94de9c0d125fc470d0..33436784b691c860d58f8b4dfcc6718e
            &SelectFileDialogLinuxKde::OnSelectSingleFolderDialogResponse, this,
            parent));
 diff --git a/ui/shell_dialogs/select_file_dialog_linux_portal.cc b/ui/shell_dialogs/select_file_dialog_linux_portal.cc
-index 61ddcbf7bf57e423099c7d392a19b3ec79b5d03f..8c3f4058ad7e9f6460c8d0516a150db612e8f574 100644
+index 61ddcbf7bf57e423099c7d392a19b3ec79b5d03f..b2d2e11f72dcca5b3791a6dd3e9e5ae930a1f701 100644
 --- a/ui/shell_dialogs/select_file_dialog_linux_portal.cc
 +++ b/ui/shell_dialogs/select_file_dialog_linux_portal.cc
-@@ -221,6 +221,8 @@ void SelectFileDialogLinuxPortal::SelectFileImpl(
+@@ -44,7 +44,9 @@ constexpr char kMethodStartServiceByName[] = "StartServiceByName";
+ constexpr char kXdgPortalService[] = "org.freedesktop.portal.Desktop";
+ constexpr char kXdgPortalObject[] = "/org/freedesktop/portal/desktop";
+ 
+-constexpr int kXdgPortalRequiredVersion = 3;
++// Version 4 includes support for current_folder option to the OpenFile method via
++// https://github.com/flatpak/xdg-desktop-portal/commit/71165a5.
++constexpr int kXdgPortalRequiredVersion = 4;
+ 
+ constexpr char kXdgPortalRequestInterfaceName[] =
+     "org.freedesktop.portal.Request";
+@@ -221,6 +223,8 @@ void SelectFileDialogLinuxPortal::SelectFileImpl(
                       weak_factory_.GetWeakPtr()));
    info_->type = type;
    info_->main_task_runner = base::SequencedTaskRunner::GetCurrentDefault();
@@ -211,7 +222,7 @@ index 61ddcbf7bf57e423099c7d392a19b3ec79b5d03f..8c3f4058ad7e9f6460c8d0516a150db6
  
    if (owning_window) {
      if (auto* root = owning_window->GetRootWindow()) {
-@@ -557,7 +559,9 @@ void SelectFileDialogLinuxPortal::DialogInfo::AppendOptions(
+@@ -557,7 +561,9 @@ void SelectFileDialogLinuxPortal::DialogInfo::AppendOptions(
                       response_handle_token);
  
    if (type == SelectFileDialog::Type::SELECT_UPLOAD_FOLDER) {
@@ -222,7 +233,7 @@ index 61ddcbf7bf57e423099c7d392a19b3ec79b5d03f..8c3f4058ad7e9f6460c8d0516a150db6
                         l10n_util::GetStringUTF8(
                             IDS_SELECT_UPLOAD_FOLDER_DIALOG_UPLOAD_BUTTON));
    }
-@@ -566,6 +570,8 @@ void SelectFileDialogLinuxPortal::DialogInfo::AppendOptions(
+@@ -566,6 +572,8 @@ void SelectFileDialogLinuxPortal::DialogInfo::AppendOptions(
        type == SelectFileDialog::Type::SELECT_UPLOAD_FOLDER ||
        type == SelectFileDialog::Type::SELECT_EXISTING_FOLDER) {
      AppendBoolOption(&options_writer, kFileChooserOptionDirectory, true);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/43310.

The minimum version of `org.freedesktop.portal.FileChooser` containing support for setting a defaultPath via `current_folder` in https://github.com/flatpak/xdg-desktop-portal/commit/71165a52ea6ba164816131ea039ccea253fe103b is 4. Chromium [requires version 3](https://source.chromium.org/chromium/chromium/src/+/main:ui/shell_dialogs/select_file_dialog_linux_portal.cc;l=47?q=kXdgPortalRequiredVersion&sq=package:chromium&type=cs) in order to use the interface, otherwise they fall back to GTK. Our dialog API requires that `defaultPath` work both on open and save dialogs - we can ensure this by bumping the required minimum to 4 before falling back to GTK.

The interface version bump commit is https://github.com/flatpak/xdg-desktop-portal/commit/4bf4d63e495e6ac1ea70340a1c37771e8d33e967, which includes the `current_folder` commit.

cc @bpasero 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `defaultPath` did not work for all users on Linux when creating an open file dialog.
