### PR TITLE
fix: confirm a `v8::Value` is a `v8::Object` before casting it

### DIFF
--- a/shell/browser/api/message_port.cc
+++ b/shell/browser/api/message_port.cc
@@ -30,11 +30,11 @@ namespace electron {
 
 namespace {
 
-bool IsValidWrappable(const v8::Local<v8::Value>& obj) {
-  v8::Local<v8::Object> port = v8::Local<v8::Object>::Cast(obj);
-
-  if (!port->IsObject())
+bool IsValidWrappable(const v8::Local<v8::Value>& val) {
+  if (!val->IsObject())
     return false;
+
+  v8::Local<v8::Object> port = val.As<v8::Object>();
 
   if (port->InternalFieldCount() != gin::kNumberOfInternalFields)
     return false;


### PR DESCRIPTION
#### Description of Change

Small fix to confirm that a `Local<Value>` is a `Local<Object>` before casting it as one.

Looks like doing the other way around can cause a crash when`Local.As()` calls `Local.Cast()` if `V8_ENABLE_CHECKS` is defined and the Value isn't an Object?

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.