### PR TITLE
refactor: `NativeWindow::Create()` returns a unique_ptr

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -98,8 +98,8 @@ BaseWindow::BaseWindow(v8::Isolate* isolate,
   }
 
   // Creates NativeWindow.
-  window_.reset(NativeWindow::Create(
-      options, parent.IsEmpty() ? nullptr : parent->window_.get()));
+  window_ = NativeWindow::Create(
+      options, parent.IsEmpty() ? nullptr : parent->window_.get());
   window_->AddObserver(this);
 
   SetContentView(View::Create(isolate));

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -71,8 +71,9 @@ class NativeWindow : public base::SupportsUserData,
 
   // Create window with existing WebContents, the caller is responsible for
   // managing the window's live.
-  static NativeWindow* Create(const gin_helper::Dictionary& options,
-                              NativeWindow* parent = nullptr);
+  static std::unique_ptr<NativeWindow> Create(
+      const gin_helper::Dictionary& options,
+      NativeWindow* parent = nullptr);
 
   void InitFromOptions(const gin_helper::Dictionary& options);
 

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1814,9 +1814,10 @@ std::optional<gfx::Rect> NativeWindowMac::GetWindowControlsOverlayRect() {
 }
 
 // static
-NativeWindow* NativeWindow::Create(const gin_helper::Dictionary& options,
-                                   NativeWindow* parent) {
-  return new NativeWindowMac(options, parent);
+std::unique_ptr<NativeWindow> NativeWindow::Create(
+    const gin_helper::Dictionary& options,
+    NativeWindow* parent) {
+  return std::make_unique<NativeWindowMac>(options, parent);
 }
 
 }  // namespace electron

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1789,9 +1789,10 @@ void NativeWindowViews::MoveBehindTaskBarIfNeeded() {
 }
 
 // static
-NativeWindow* NativeWindow::Create(const gin_helper::Dictionary& options,
-                                   NativeWindow* parent) {
-  return new NativeWindowViews(options, parent);
+std::unique_ptr<NativeWindow> NativeWindow::Create(
+    const gin_helper::Dictionary& options,
+    NativeWindow* parent) {
+  return std::make_unique<NativeWindowViews>(options, parent);
 }
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

Cleanup PR to make `NativeWindow::Create()` follow Chromium's  [object ownership calling conventions](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md#object-ownership-and-calling-conventions): ownership of the new object is being handed off to the caller, so return it as a `std::unique_ptr<NativeWindow>`.

Related: #43361

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.