### PR TITLE
refactor: simplify gin_helper::PromiseBase settle funcs

### DIFF
--- a/shell/common/gin_helper/promise.cc
+++ b/shell/common/gin_helper/promise.cc
@@ -29,14 +29,8 @@ PromiseBase::~PromiseBase() = default;
 PromiseBase& PromiseBase::operator=(PromiseBase&&) = default;
 
 v8::Maybe<bool> PromiseBase::Reject() {
-  v8::HandleScope handle_scope(isolate());
-  v8::Local<v8::Context> context = GetContext();
-  gin_helper::MicrotasksScope microtasks_scope{
-      isolate(), context->GetMicrotaskQueue(), false,
-      v8::MicrotasksScope::kRunMicrotasks};
-  v8::Context::Scope context_scope{context};
-
-  return GetInner()->Reject(context, v8::Undefined(isolate()));
+  v8::HandleScope handle_scope{isolate()};
+  return Reject(v8::Undefined(isolate()));
 }
 
 v8::Maybe<bool> PromiseBase::Reject(v8::Local<v8::Value> except) {
@@ -50,18 +44,9 @@ v8::Maybe<bool> PromiseBase::Reject(v8::Local<v8::Value> except) {
   return GetInner()->Reject(context, except);
 }
 
-v8::Maybe<bool> PromiseBase::RejectWithErrorMessage(
-    const std::string_view message) {
-  v8::HandleScope handle_scope(isolate());
-  v8::Local<v8::Context> context = GetContext();
-  gin_helper::MicrotasksScope microtasks_scope{
-      isolate(), context->GetMicrotaskQueue(), false,
-      v8::MicrotasksScope::kRunMicrotasks};
-  v8::Context::Scope context_scope{context};
-
-  v8::Local<v8::Value> error =
-      v8::Exception::Error(gin::StringToV8(isolate(), message));
-  return GetInner()->Reject(context, (error));
+v8::Maybe<bool> PromiseBase::RejectWithErrorMessage(std::string_view msg) {
+  v8::HandleScope handle_scope{isolate()};
+  return Reject(v8::Exception::Error(gin::StringToV8(isolate(), msg)));
 }
 
 v8::Local<v8::Context> PromiseBase::GetContext() const {

--- a/shell/common/gin_helper/promise.cc
+++ b/shell/common/gin_helper/promise.cc
@@ -30,35 +30,38 @@ PromiseBase& PromiseBase::operator=(PromiseBase&&) = default;
 
 v8::Maybe<bool> PromiseBase::Reject() {
   v8::HandleScope handle_scope(isolate());
+  v8::Local<v8::Context> context = GetContext();
   gin_helper::MicrotasksScope microtasks_scope{
-      isolate(), GetContext()->GetMicrotaskQueue(), false,
+      isolate(), context->GetMicrotaskQueue(), false,
       v8::MicrotasksScope::kRunMicrotasks};
-  v8::Context::Scope context_scope(GetContext());
+  v8::Context::Scope context_scope{context};
 
-  return GetInner()->Reject(GetContext(), v8::Undefined(isolate()));
+  return GetInner()->Reject(context, v8::Undefined(isolate()));
 }
 
 v8::Maybe<bool> PromiseBase::Reject(v8::Local<v8::Value> except) {
   v8::HandleScope handle_scope(isolate());
+  v8::Local<v8::Context> context = GetContext();
   gin_helper::MicrotasksScope microtasks_scope{
-      isolate(), GetContext()->GetMicrotaskQueue(), false,
+      isolate(), context->GetMicrotaskQueue(), false,
       v8::MicrotasksScope::kRunMicrotasks};
-  v8::Context::Scope context_scope(GetContext());
+  v8::Context::Scope context_scope{context};
 
-  return GetInner()->Reject(GetContext(), except);
+  return GetInner()->Reject(context, except);
 }
 
 v8::Maybe<bool> PromiseBase::RejectWithErrorMessage(
     const std::string_view message) {
   v8::HandleScope handle_scope(isolate());
+  v8::Local<v8::Context> context = GetContext();
   gin_helper::MicrotasksScope microtasks_scope{
-      isolate(), GetContext()->GetMicrotaskQueue(), false,
+      isolate(), context->GetMicrotaskQueue(), false,
       v8::MicrotasksScope::kRunMicrotasks};
-  v8::Context::Scope context_scope(GetContext());
+  v8::Context::Scope context_scope{context};
 
   v8::Local<v8::Value> error =
       v8::Exception::Error(gin::StringToV8(isolate(), message));
-  return GetInner()->Reject(GetContext(), (error));
+  return GetInner()->Reject(context, (error));
 }
 
 v8::Local<v8::Context> PromiseBase::GetContext() const {
@@ -95,12 +98,13 @@ v8::Local<v8::Promise> Promise<void>::ResolvedPromise(v8::Isolate* isolate) {
 
 v8::Maybe<bool> Promise<void>::Resolve() {
   v8::HandleScope handle_scope(isolate());
+  v8::Local<v8::Context> context = GetContext();
   gin_helper::MicrotasksScope microtasks_scope{
-      isolate(), GetContext()->GetMicrotaskQueue(), false,
+      isolate(), context->GetMicrotaskQueue(), false,
       v8::MicrotasksScope::kRunMicrotasks};
-  v8::Context::Scope context_scope(GetContext());
+  v8::Context::Scope context_scope{context};
 
-  return GetInner()->Resolve(GetContext(), v8::Undefined(isolate()));
+  return GetInner()->Resolve(context, v8::Undefined(isolate()));
 }
 
 }  // namespace gin_helper


### PR DESCRIPTION
#### Description of Change

Simplify our Promise settling code a little:

- The three Reject methods are almost identical. Refactor `Reject()` and `RejectWithErrorMessage()` to delegate their work to `Reject(Local<Value>)`.

- Cache the return value of `GetContext()` instead of calling it 3x in each reject / resolve function

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.