### PR TITLE
fix: UvHandle move semantics

### DIFF
--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -62,8 +62,17 @@ class UvHandle {
   UvHandle() : t_{new T} {}
   ~UvHandle() { reset(); }
 
-  UvHandle(UvHandle&&) = default;
-  UvHandle& operator=(UvHandle&&) = default;
+  explicit UvHandle(UvHandle&& that) {
+    t_ = that.t_;
+    that.t_ = nullptr;
+  }
+
+  UvHandle& operator=(UvHandle&& that) {
+    reset();
+    t_ = that.t_;
+    that.t_ = nullptr;
+    return *this;
+  }
 
   UvHandle(const UvHandle&) = delete;
   UvHandle& operator=(const UvHandle&) = delete;


### PR DESCRIPTION
#### Description of Change

Fix move semantics for UvHandle. This fixes a potential issue in #43561.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.