### PR TITLE
refactor: use std::optional in MicrotasksScope

### DIFF
--- a/shell/common/gin_helper/microtasks_scope.cc
+++ b/shell/common/gin_helper/microtasks_scope.cc
@@ -16,8 +16,7 @@ MicrotasksScope::MicrotasksScope(v8::Isolate* isolate,
     if (!ignore_browser_checkpoint)
       v8::MicrotasksScope::PerformCheckpoint(isolate);
   } else {
-    v8_microtasks_scope_ = std::make_unique<v8::MicrotasksScope>(
-        isolate, microtask_queue, scope_type);
+    v8_microtasks_scope_.emplace(isolate, microtask_queue, scope_type);
   }
 }
 

--- a/shell/common/gin_helper/microtasks_scope.h
+++ b/shell/common/gin_helper/microtasks_scope.h
@@ -5,7 +5,7 @@
 #ifndef ELECTRON_SHELL_COMMON_GIN_HELPER_MICROTASKS_SCOPE_H_
 #define ELECTRON_SHELL_COMMON_GIN_HELPER_MICROTASKS_SCOPE_H_
 
-#include <memory>
+#include <optional>
 
 #include "v8/include/v8-forward.h"
 #include "v8/include/v8-microtask-queue.h"
@@ -27,7 +27,7 @@ class MicrotasksScope {
   MicrotasksScope& operator=(const MicrotasksScope&) = delete;
 
  private:
-  std::unique_ptr<v8::MicrotasksScope> v8_microtasks_scope_;
+  std::optional<v8::MicrotasksScope> v8_microtasks_scope_;
 };
 
 }  // namespace gin_helper


### PR DESCRIPTION
#### Description of Change

A small refactor to avoid an extra heap allocation/free when instantiating `gin_helper::MicrotasksScope` objects.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.