### PR TITLE
fix: detach native view when its removed from parent on macOS

### DIFF
--- a/shell/browser/ui/cocoa/delayed_native_view_host.mm
+++ b/shell/browser/ui/cocoa/delayed_native_view_host.mm
@@ -15,6 +15,8 @@ DelayedNativeViewHost::~DelayedNativeViewHost() = default;
 
 void DelayedNativeViewHost::ViewHierarchyChanged(
     const views::ViewHierarchyChangedDetails& details) {
+  if (!details.is_add && native_view())
+    Detach();
   NativeViewHost::ViewHierarchyChanged(details);
   if (details.is_add && GetWidget() && !native_view())
     Attach(native_view_);


### PR DESCRIPTION
#### Description of Change
Right now DelayedNativeViewHost attaches its underlying native view when it's being attached to a widget but it doesn't detach it when it's being detached. It may lead to use-after-free and crash.

We (in OpenFin) have different views hierarchy and lack of detaching a native views causes use-after-free during destruction of a window which contains some views. I was not able to get a repo on clean Electron but it seems wrong that we don't detach a native view and it may cause problems in different scenarios also on clean Electron.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed potential use-after-free during view removal on macOS.
