### PR TITLE
fix: ensure version of `xdg-dialog-portal` with `defaultPath` support

### DIFF
--- a/patches/chromium/feat_add_support_for_missing_dialog_features_to_shell_dialogs.patch
+++ b/patches/chromium/feat_add_support_for_missing_dialog_features_to_shell_dialogs.patch
@@ -272,9 +272,18 @@ index 796e98cd42a5c6087da6cdf1d7bff4248113aeab..bcf43ab96bcb426fde6362dd0da44217
            &SelectFileDialogLinuxKde::OnSelectSingleFolderDialogResponse, this,
            parent, params));
 diff --git a/ui/shell_dialogs/select_file_dialog_linux_portal.cc b/ui/shell_dialogs/select_file_dialog_linux_portal.cc
-index decba61300c21f7f5d070b24c23ff2e08b06d161..26ba2c573ca83433de82496e6f20f71c194babc0 100644
+index decba61300c21f7f5d070b24c23ff2e08b06d161..9bc449d5ebcb88310058559bee78ece90bd3ef25 100644
 --- a/ui/shell_dialogs/select_file_dialog_linux_portal.cc
 +++ b/ui/shell_dialogs/select_file_dialog_linux_portal.cc
+@@ -38,7 +38,7 @@ constexpr char kMethodStartServiceByName[] = "StartServiceByName";
+ constexpr char kXdgPortalService[] = "org.freedesktop.portal.Desktop";
+ constexpr char kXdgPortalObject[] = "/org/freedesktop/portal/desktop";
+ 
+-constexpr int kXdgPortalRequiredVersion = 3;
++constexpr int kXdgPortalRequiredVersion = 4;
+ 
+ constexpr char kXdgPortalRequestInterfaceName[] =
+     "org.freedesktop.portal.Request";
 @@ -218,6 +218,10 @@ void SelectFileDialogLinuxPortal::SelectFileImpl(
    info_->main_task_runner = base::SequencedTaskRunner::GetCurrentDefault();
    listener_params_ = params;


### PR DESCRIPTION
Backport of #43570.

See that PR for details.

Notes: Fixed an issue where `defaultPath` did not work for all users on Linux when creating an open file dialog.