### PR TITLE
fix: -Wunsafe-buffer-usage warning in V8Serializer::Serialize()

### DIFF
--- a/shell/common/v8_value_serializer.cc
+++ b/shell/common/v8_value_serializer.cc
@@ -49,10 +49,12 @@ class V8Serializer : public v8::ValueSerializer::Delegate {
     }
     DCHECK(wrote_value);
 
-    std::pair<uint8_t*, size_t> buffer = serializer_.Release();
-    DCHECK_EQ(buffer.first, data_.data());
-    out->encoded_message = base::make_span(buffer.first, buffer.second);
+    const auto [data_bytes, data_len] = serializer_.Release();
+    DCHECK_EQ(std::data(data_), data_bytes);
+    DCHECK_GE(std::size(data_), data_len);
+    data_.resize(data_len);
     out->owned_encoded_message = std::move(data_);
+    out->encoded_message = out->owned_encoded_message;
     out->sender_agent_cluster_id =
         blink::WebMessagePort::GetEmbedderAgentClusterID();
 


### PR DESCRIPTION
#### Description of Change

Part 4 in a [series](https://github.com/electron/electron/pull/43477) to fix `-Wunsafe-buffer-usage` warnings in electron `shell/`.

This PR fixes a warning in `electron::V8Serializer::Serialize()`. It does this by using a correctly-sized `data_` field directly so that we don't need to make a call to `UNSAFE_BUFFER_USAGE base::make_span()`.

The warning fixed by this PR:

```
../../electron/shell/common/v8_value_serializer.cc:54:28: error: function introduces unsafe buffer manipulation [-Werror,-Wunsafe-buffer-usage]
   54 |     out->encoded_message = base::make_span(buffer.first, buffer.second);
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../electron/shell/common/v8_value_serializer.cc:54:28: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.