### PR TITLE
fix: ensure bounds stability in `OnWidgetBoundsChanged`

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -22,6 +22,7 @@
 
 #include "base/containers/contains.h"
 #include "base/memory/raw_ptr.h"
+#include "base/numerics/ranges.h"
 #include "base/stl_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "content/public/browser/browser_thread.h"
@@ -1644,10 +1645,18 @@ void NativeWindowViews::OnWidgetBoundsChanged(views::Widget* changed_widget,
   if (changed_widget != widget())
     return;
 
-  // Note: We intentionally use `GetBounds()` instead of `bounds` to properly
-  // handle minimized windows on Windows.
+  // |GetWindowBoundsInScreen| has a ~1 pixel margin of error, so if we check
+  // existing bounds directly against the new bounds without accounting for that
+  // we'll have constant false positives when the window is moving but the user
+  // hasn't changed its size at all.
+  auto areWithinOnePixel = [](gfx::Size old_size, gfx::Size new_size) -> bool {
+    return base::IsApproximatelyEqual(old_size.width(), new_size.width(), 1) &&
+           base::IsApproximatelyEqual(old_size.height(), new_size.height(), 1);
+  };
+
+  // We use |GetBounds| to account for minimized windows on Windows.
   const auto new_bounds = GetBounds();
-  if (widget_size_ != new_bounds.size()) {
+  if (!areWithinOnePixel(widget_size_, new_bounds.size())) {
     NotifyWindowResize();
     widget_size_ = new_bounds.size();
   }


### PR DESCRIPTION
Backport of #43431.

See that PR for details.

Notes: Fixed an issue with `resize` events being emitted on Windows when the window was moved but not resized.