### PR TITLE
fix: EyeDropper working in devtools

### DIFF
--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -784,6 +784,7 @@ void InspectableWebContents::SetEyeDropperActive(bool active) {
   if (delegate_)
     delegate_->DevToolsSetEyeDropperActive(active);
 }
+
 void InspectableWebContents::ZoomIn() {
   double new_level = GetNextZoomLevel(GetDevToolsZoomLevel(), false);
   SetZoomLevelForWebContents(GetDevToolsWebContents(), new_level);
@@ -963,6 +964,13 @@ bool InspectableWebContents::HandleKeyboardEvent(
 void InspectableWebContents::CloseContents(content::WebContents* source) {
   // This is where the devtools closes itself (by clicking the x button).
   CloseDevTools();
+}
+
+std::unique_ptr<content::EyeDropper> InspectableWebContents::OpenEyeDropper(
+    content::RenderFrameHost* frame,
+    content::EyeDropperListener* listener) {
+  auto* delegate = web_contents_->GetDelegate();
+  return delegate ? delegate->OpenEyeDropper(frame, listener) : nullptr;
 }
 
 void InspectableWebContents::RunFileChooser(

--- a/shell/browser/ui/inspectable_web_contents.h
+++ b/shell/browser/ui/inspectable_web_contents.h
@@ -208,6 +208,9 @@ class InspectableWebContents
   bool HandleKeyboardEvent(content::WebContents*,
                            const input::NativeWebKeyboardEvent&) override;
   void CloseContents(content::WebContents* source) override;
+  std::unique_ptr<content::EyeDropper> OpenEyeDropper(
+      content::RenderFrameHost* frame,
+      content::EyeDropperListener* listener) override;
   void RunFileChooser(content::RenderFrameHost* render_frame_host,
                       scoped_refptr<content::FileSelectListener> listener,
                       const blink::mojom::FileChooserParams& params) override;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/36203.

Fixes an issue where clicking the eyedropper icon did nothing instead of opening an eyedropper for color selection as expected. To fix this, we needed to implement `OpenEyeDropper` in `InspectableWebContents`

<details><summary>After Fix</summary>
<p>

![picker_working](https://github.com/user-attachments/assets/d8835c3b-be42-4e9d-a872-6353d2697691)

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where clicking the eyedropper icon did nothing instead of opening an eyedropper for color selection as expected. 
