### PR TITLE
chore: remove unused base/ includes

### DIFF
--- a/build/fuses/build.py
+++ b/build/fuses/build.py
@@ -36,7 +36,6 @@ TEMPLATE_CC = """
 
 #if DCHECK_IS_ON()
 #include "base/command_line.h"
-#include "base/strings/string_util.h"
 #include <string>
 #endif
 

--- a/shell/app/electron_main_linux.cc
+++ b/shell/app/electron_main_linux.cc
@@ -6,7 +6,6 @@
 #include <utility>
 
 #include "base/at_exit.h"
-#include "base/base_switches.h"
 #include "base/command_line.h"
 #include "base/i18n/icu_util.h"
 #include "content/public/app/content_main.h"

--- a/shell/browser/api/electron_api_crash_reporter.cc
+++ b/shell/browser/api/electron_api_crash_reporter.cc
@@ -10,7 +10,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/functional/bind.h"
 #include "base/no_destructor.h"
 #include "base/path_service.h"
 #include "base/strings/utf_string_conversions.h"

--- a/shell/browser/api/electron_api_crash_reporter.cc
+++ b/shell/browser/api/electron_api_crash_reporter.cc
@@ -38,7 +38,6 @@
 #endif
 
 #if BUILDFLAG(IS_LINUX)
-#include "base/containers/span.h"
 #include "base/files/file_util.h"
 #include "base/uuid.h"
 #include "components/crash/core/common/crash_keys.h"

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "base/containers/flat_map.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/threading/thread_restrictions.h"
 #include "chrome/browser/media/webrtc/desktop_capturer_wrapper.h"
@@ -43,6 +42,7 @@
 #endif
 
 #if BUILDFLAG(IS_MAC)
+#include "base/strings/string_number_conversions.h"
 #include "ui/base/cocoa/permissions_utils.h"
 #endif
 

--- a/shell/browser/api/electron_api_service_worker_context.cc
+++ b/shell/browser/api/electron_api_service_worker_context.cc
@@ -7,7 +7,6 @@
 #include <string_view>
 #include <utility>
 
-#include "base/strings/string_number_conversions.h"
 #include "chrome/browser/browser_process.h"
 #include "content/public/browser/console_message.h"
 #include "content/public/browser/storage_partition.h"

--- a/shell/browser/api/message_port.cc
+++ b/shell/browser/api/message_port.cc
@@ -10,7 +10,6 @@
 
 #include "base/containers/contains.h"
 #include "base/containers/to_vector.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/task/single_thread_task_runner.h"
 #include "gin/arguments.h"
 #include "gin/data_object_builder.h"

--- a/shell/browser/badging/badge_manager_factory.cc
+++ b/shell/browser/badging/badge_manager_factory.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/badging/badge_manager_factory.h"
 
-#include "base/functional/bind.h"
 #include "base/memory/ptr_util.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
 #include "shell/browser/badging/badge_manager.h"

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -10,7 +10,6 @@
 
 #include "base/files/file_util.h"
 #include "base/path_service.h"
-#include "base/run_loop.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/threading/thread_restrictions.h"
 #include "chrome/common/chrome_paths.h"

--- a/shell/browser/electron_autofill_driver_factory.cc
+++ b/shell/browser/electron_autofill_driver_factory.cc
@@ -7,7 +7,6 @@
 #include <memory>
 #include <utility>
 
-#include "base/functional/bind.h"
 #include "content/public/browser/navigation_handle.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -22,7 +22,6 @@
 #include "base/path_service.h"
 #include "base/process/process_metrics.h"
 #include "base/strings/escape.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/common/chrome_paths.h"

--- a/shell/browser/extensions/api/extension_action/extension_action_api.cc
+++ b/shell/browser/extensions/api/extension_action/extension_action_api.cc
@@ -9,7 +9,6 @@
 #include <memory>
 #include <utility>
 
-#include "base/functional/bind.h"
 #include "base/no_destructor.h"
 #include "extensions/browser/event_router.h"
 #include "extensions/browser/extension_prefs.h"

--- a/shell/browser/extensions/api/management/electron_management_api_delegate.cc
+++ b/shell/browser/extensions/api/management/electron_management_api_delegate.cc
@@ -10,7 +10,6 @@
 #include <utility>
 
 #include "base/strings/stringprintf.h"
-#include "base/strings/utf_string_conversions.h"
 #include "chrome/common/extensions/extension_metrics.h"
 #include "chrome/common/extensions/manifest_handlers/app_launch_info.h"
 #include "chrome/common/webui_url_constants.h"

--- a/shell/browser/extensions/api/management/electron_management_api_delegate.cc
+++ b/shell/browser/extensions/api/management/electron_management_api_delegate.cc
@@ -9,7 +9,6 @@
 #include <string>
 #include <utility>
 
-#include "base/functional/bind.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "chrome/common/extensions/extension_metrics.h"

--- a/shell/browser/extensions/electron_extension_host_delegate.cc
+++ b/shell/browser/extensions/electron_extension_host_delegate.cc
@@ -8,7 +8,6 @@
 #include <string>
 #include <utility>
 
-#include "base/logging.h"
 #include "extensions/browser/media_capture_util.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/extensions/electron_extension_web_contents_observer.h"

--- a/shell/browser/extensions/electron_extension_loader.cc
+++ b/shell/browser/extensions/electron_extension_loader.cc
@@ -11,7 +11,6 @@
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/threading/thread_restrictions.h"

--- a/shell/browser/extensions/electron_extension_system.cc
+++ b/shell/browser/extensions/electron_extension_system.cc
@@ -10,7 +10,6 @@
 #include <utility>
 
 #include "base/files/file_path.h"
-#include "base/functional/bind.h"
 #include "base/json/json_string_value_serializer.h"
 #include "base/path_service.h"
 #include "base/values.h"

--- a/shell/browser/extensions/electron_process_manager_delegate.cc
+++ b/shell/browser/extensions/electron_process_manager_delegate.cc
@@ -5,7 +5,6 @@
 
 #include "shell/browser/extensions/electron_process_manager_delegate.h"
 
-#include "base/command_line.h"
 #include "base/one_shot_event.h"
 #include "extensions/browser/extension_system.h"
 #include "extensions/browser/process_manager.h"

--- a/shell/browser/fake_location_provider.cc
+++ b/shell/browser/fake_location_provider.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/fake_location_provider.h"
 
-#include "base/time/time.h"
 #include "services/device/public/mojom/geoposition.mojom-shared.h"
 #include "services/device/public/mojom/geoposition.mojom.h"
 

--- a/shell/browser/file_system_access/file_system_access_permission_context_factory.cc
+++ b/shell/browser/file_system_access/file_system_access_permission_context_factory.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/file_system_access/file_system_access_permission_context_factory.h"
 
-#include "base/functional/bind.h"
 #include "base/memory/ptr_util.h"
 #include "base/no_destructor.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"

--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -14,7 +14,6 @@
 #include "base/bits.h"
 #include "base/command_line.h"
 #include "base/feature_list.h"
-#include "base/no_destructor.h"
 #include "base/task/current_thread.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/task/thread_pool/initialization_util.h"

--- a/shell/browser/net/asar/asar_file_validator.cc
+++ b/shell/browser/net/asar/asar_file_validator.cc
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "base/logging.h"
-#include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "crypto/sha2.h"

--- a/shell/browser/notifications/win/notification_presenter_win.cc
+++ b/shell/browser/notifications/win/notification_presenter_win.cc
@@ -14,7 +14,6 @@
 #include "base/files/file_util.h"
 #include "base/hash/md5.h"
 #include "base/logging.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
 #include "shell/browser/notifications/win/windows_toast_notification.h"

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -17,7 +17,6 @@
 #include "base/hash/hash.h"
 #include "base/logging.h"
 #include "base/strings/strcat.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util_win.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"

--- a/shell/browser/serial/serial_chooser_controller.cc
+++ b/shell/browser/serial/serial_chooser_controller.cc
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <utility>
 
-#include "base/files/file_path.h"
 #include "base/functional/bind.h"
 #include "base/strings/stringprintf.h"
 #include "content/public/browser/web_contents.h"

--- a/shell/browser/special_storage_policy.cc
+++ b/shell/browser/special_storage_policy.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/special_storage_policy.h"
 
-#include "base/functional/bind.h"
 #include "services/network/public/cpp/session_cookie_delete_predicate.h"
 
 namespace electron {

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -10,7 +10,6 @@
 
 #include "base/apple/foundation_util.h"
 #include "base/functional/callback.h"
-#include "base/logging.h"
 #include "base/strings/sys_string_conversions.h"
 #include "base/strings/utf_string_conversions.h"
 #include "content/public/browser/browser_task_traits.h"

--- a/shell/browser/ui/cocoa/window_buttons_proxy.mm
+++ b/shell/browser/ui/cocoa/window_buttons_proxy.mm
@@ -5,7 +5,6 @@
 #include "shell/browser/ui/cocoa/window_buttons_proxy.h"
 
 #include "base/i18n/rtl.h"
-#include "base/notreached.h"
 
 @implementation ButtonsAreaHoverView : NSView
 

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -14,7 +14,6 @@
 #include "base/memory/raw_ptr.h"
 #include "base/metrics/histogram.h"
 #include "base/strings/pattern.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"

--- a/shell/browser/ui/views/global_menu_bar_x11.cc
+++ b/shell/browser/ui/views/global_menu_bar_x11.cc
@@ -8,7 +8,6 @@
 #include <glib-object.h>
 
 #include "base/functional/bind.h"
-#include "base/logging.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "shell/browser/native_window_views.h"

--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -8,7 +8,6 @@
 #include <utility>
 
 #include "base/memory/raw_ptr.h"
-#include "base/strings/utf_string_conversions.h"
 #include "shell/browser/ui/drag_util.h"
 #include "shell/browser/ui/inspectable_web_contents.h"
 #include "shell/browser/ui/inspectable_web_contents_delegate.h"

--- a/shell/browser/window_list.cc
+++ b/shell/browser/window_list.cc
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 
-#include "base/logging.h"
 #include "base/no_destructor.h"
 #include "shell/browser/native_window.h"
 #include "shell/browser/window_list_observer.h"

--- a/shell/browser/zoom_level_delegate.cc
+++ b/shell/browser/zoom_level_delegate.cc
@@ -10,7 +10,6 @@
 
 #include "base/files/file_path.h"
 #include "base/functional/bind.h"
-#include "base/strings/string_number_conversions.h"
 #include "components/prefs/json_pref_store.h"
 #include "components/prefs/pref_filter.h"
 #include "components/prefs/pref_registry_simple.h"

--- a/shell/common/api/electron_api_command_line.cc
+++ b/shell/common/api/electron_api_command_line.cc
@@ -4,7 +4,6 @@
 
 #include "base/command_line.h"
 #include "base/files/file_path.h"
-#include "base/strings/string_util.h"
 #include "services/network/public/cpp/network_switches.h"
 #include "shell/common/gin_converters/base_converter.h"
 #include "shell/common/gin_converters/file_path_converter.h"

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -14,7 +14,6 @@
 #include "base/check_op.h"
 #include "base/containers/fixed_flat_map.h"
 #include "base/memory/raw_ptr.h"
-#include "base/no_destructor.h"
 #include "base/notreached.h"
 #include "base/sequence_checker.h"
 #include "base/strings/string_number_conversions.h"

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -16,7 +16,6 @@
 #include "base/memory/raw_ptr.h"
 #include "base/notreached.h"
 #include "base/sequence_checker.h"
-#include "base/strings/string_number_conversions.h"
 #include "gin/handle.h"
 #include "gin/object_template_builder.h"
 #include "gin/wrappable.h"

--- a/shell/common/application_info_win.cc
+++ b/shell/common/application_info_win.cc
@@ -13,7 +13,6 @@
 #include <memory>
 
 #include "base/file_version_info.h"
-#include "base/notreached.h"
 #include "base/strings/string_util.h"
 #include "base/strings/string_util_win.h"
 #include "base/strings/utf_string_conversions.h"

--- a/shell/common/color_util.cc
+++ b/shell/common/color_util.cc
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <cmath>
 
-#include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "content/public/common/color_parser.h"
 

--- a/shell/common/extensions/electron_extensions_client.cc
+++ b/shell/common/extensions/electron_extensions_client.cc
@@ -7,7 +7,6 @@
 #include <memory>
 #include <string>
 
-#include "base/logging.h"
 #include "base/no_destructor.h"
 #include "components/version_info/version_info.h"
 #include "content/public/common/user_agent.h"

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -11,7 +11,6 @@
 
 #include "base/containers/span.h"
 #include "base/memory/raw_ptr.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/values.h"
 #include "gin/converter.h"

--- a/shell/common/gin_helper/trackable_object.h
+++ b/shell/common/gin_helper/trackable_object.h
@@ -7,7 +7,6 @@
 
 #include <vector>
 
-#include "base/functional/bind.h"
 #include "base/memory/weak_ptr.h"
 #include "shell/common/gin_helper/cleaned_up_at_exit.h"
 #include "shell/common/gin_helper/event_emitter.h"

--- a/shell/common/gin_helper/wrappable.cc
+++ b/shell/common/gin_helper/wrappable.cc
@@ -4,7 +4,6 @@
 
 #include "shell/common/gin_helper/wrappable.h"
 
-#include "base/logging.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "v8/include/v8-function.h"
 

--- a/shell/common/node_bindings_win.cc
+++ b/shell/common/node_bindings_win.cc
@@ -6,7 +6,6 @@
 
 #include <windows.h>
 
-#include "base/logging.h"
 #include "base/system/sys_info.h"
 
 namespace electron {

--- a/shell/renderer/api/electron_api_crash_reporter_renderer.cc
+++ b/shell/renderer/api/electron_api_crash_reporter_renderer.cc
@@ -2,7 +2,6 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "base/functional/bind.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
 

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -56,10 +56,6 @@
 #include "components/pdf/renderer/internal_plugin_renderer_helpers.h"
 #endif  // BUILDFLAG(ENABLE_PDF_VIEWER)
 
-#if BUILDFLAG(IS_MAC)
-#include "base/strings/sys_string_conversions.h"
-#endif
-
 #if BUILDFLAG(IS_WIN)
 #include <shlobj.h>
 #endif

--- a/shell/utility/electron_content_utility_client.cc
+++ b/shell/utility/electron_content_utility_client.cc
@@ -7,7 +7,6 @@
 #include <utility>
 
 #include "base/command_line.h"
-#include "base/no_destructor.h"
 #include "content/public/utility/utility_thread.h"
 #include "mojo/public/cpp/bindings/binder_map.h"
 #include "mojo/public/cpp/bindings/service_factory.h"


### PR DESCRIPTION
#### Description of Change

Does what it says on the tin: remove `#include "base/..."` statements that we don't use.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.