### PR TITLE
refactor: avoid minor code repetition in native_image.cc

### DIFF
--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -374,18 +374,15 @@ gin::Handle<NativeImage> NativeImage::Resize(gin::Arguments* args,
   else if (quality && *quality == "better")
     method = skia::ImageOperations::ResizeMethod::RESIZE_BETTER;
 
-  gfx::ImageSkia resized = gfx::ImageSkiaOperations::CreateResizedImage(
-      image_.AsImageSkia(), method, size);
-  return gin::CreateHandle(
-      args->isolate(), new NativeImage(args->isolate(), gfx::Image(resized)));
+  return Create(args->isolate(),
+                gfx::Image{gfx::ImageSkiaOperations::CreateResizedImage(
+                    image_.AsImageSkia(), method, size)});
 }
 
 gin::Handle<NativeImage> NativeImage::Crop(v8::Isolate* isolate,
                                            const gfx::Rect& rect) {
-  gfx::ImageSkia cropped =
-      gfx::ImageSkiaOperations::ExtractSubset(image_.AsImageSkia(), rect);
-  return gin::CreateHandle(isolate,
-                           new NativeImage(isolate, gfx::Image(cropped)));
+  return Create(isolate, gfx::Image{gfx::ImageSkiaOperations::ExtractSubset(
+                             image_.AsImageSkia(), rect)});
 }
 
 void NativeImage::AddRepresentation(const gin_helper::Dictionary& options) {
@@ -437,7 +434,7 @@ bool NativeImage::IsTemplateImage() {
 
 // static
 gin::Handle<NativeImage> NativeImage::CreateEmpty(v8::Isolate* isolate) {
-  return gin::CreateHandle(isolate, new NativeImage(isolate, gfx::Image()));
+  return Create(isolate, gfx::Image{});
 }
 
 // static


### PR DESCRIPTION
#### Description of Change

Small refactor in NativeImage to avoid a little code repetition.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none