### PR TITLE
refactor: Allow PostDelayedTasks() to be called from another thread

### DIFF
--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -289,6 +289,8 @@ int NodeMain(int argc, char* argv[]) {
     // is stopping, or the user hooks process.emit('exit').
     exit_code = node::SpinEventLoop(env).FromMaybe(1);
 
+    uv_task_runner->Shutdown();
+
     node::ResetStdio();
 
     node::Stop(env, node::StopFlags::kDoNotTerminateIsolate);

--- a/shell/app/uv_task_runner.cc
+++ b/shell/app/uv_task_runner.cc
@@ -11,25 +11,54 @@
 
 namespace electron {
 
-UvTaskRunner::UvTaskRunner(uv_loop_t* loop) : loop_{loop} {}
+UvTaskRunner::UvTaskRunner(uv_loop_t* loop) : loop_{loop} {
+  uv_async_init(loop_, post_tasks_.get(), [](uv_async_t* handle) {
+    reinterpret_cast<UvTaskRunner*>(handle->data)->PostTasks();
+  });
+  post_tasks_->data = this;
+  uv_unref(reinterpret_cast<uv_handle_t*>(post_tasks_.get()));
+}
 
 UvTaskRunner::~UvTaskRunner() = default;
 
-bool UvTaskRunner::PostDelayedTask(const base::Location& from_here,
-                                   base::OnceClosure task,
+void UvTaskRunner::Shutdown() {
+  post_tasks_.reset();
+}
+
+bool UvTaskRunner::PostDelayedTask(const base::Location& /*from_here*/,
+                                   base::OnceClosure closure,
                                    base::TimeDelta delay) {
+  if (!post_tasks_.get())
+    return false;
+
+  unposted_tasks_lock_.Acquire();
+  unposted_tasks_.emplace_front(std::move(closure), delay);
+  unposted_tasks_lock_.Release();
+
+  uv_async_send(post_tasks_.get());
+
+  return true;
+}
+
+void UvTaskRunner::PostTasks() {
   auto on_timeout = [](uv_timer_t* timer) {
-    auto& tasks = static_cast<UvTaskRunner*>(timer->data)->tasks_;
+    auto& tasks = static_cast<UvTaskRunner*>(timer->data)->posted_tasks_;
     if (auto iter = tasks.find(timer); iter != tasks.end())
       std::move(tasks.extract(iter).mapped()).Run();
   };
 
-  auto timer = UvHandle<uv_timer_t>{};
-  timer->data = this;
-  uv_timer_init(loop_, timer.get());
-  uv_timer_start(timer.get(), on_timeout, delay.InMilliseconds(), 0);
-  tasks_.insert_or_assign(std::move(timer), std::move(task));
-  return true;
+  unposted_tasks_lock_.Acquire();
+  decltype(unposted_tasks_) tasks;
+  std::swap(tasks, unposted_tasks_);
+  unposted_tasks_lock_.Release();
+
+  for (auto& [closure, delay] : tasks) {
+    UvHandle<uv_timer_t> timer;
+    uv_timer_init(loop_, timer.get());
+    timer->data = this;
+    uv_timer_start(timer.get(), on_timeout, delay.InMilliseconds(), 0);
+    posted_tasks_.try_emplace(std::move(timer), std::move(closure));
+  }
 }
 
 bool UvTaskRunner::RunsTasksInCurrentSequence() const {
@@ -37,9 +66,9 @@ bool UvTaskRunner::RunsTasksInCurrentSequence() const {
 }
 
 bool UvTaskRunner::PostNonNestableDelayedTask(const base::Location& from_here,
-                                              base::OnceClosure task,
+                                              base::OnceClosure closure,
                                               base::TimeDelta delay) {
-  return PostDelayedTask(from_here, std::move(task), delay);
+  return PostDelayedTask(from_here, std::move(closure), delay);
 }
 
 }  // namespace electron


### PR DESCRIPTION
refactor: Add UvTaskRunner::Shutdown()

#### Description of Change

This upstreams a subset of the downstream `feat_add_forceallocationstov8sandbox_for_utilityprocess_api.patch`:

- Calling `UvTaskRunner::PostDelayedTasks()` is now safe to call from anywhere
- UvTaskRunner can now be told to disallow new tasks
- It's also a little self-serving, since it upstreams work to reconcile the downstream patch with #43599

Pushing up a draft PR to see if this clears cross-platform CI.

@deepak1556 does it make sense to upstream this? If so, does this implementation meet what you were doing in that patch? 

Related: https://github.com/electron/electron/pull/37582, 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.