### PR TITLE
refactor: reduce code duplication in gin_helper::Promise

### DIFF
--- a/shell/browser/api/electron_api_system_preferences_win.cc
+++ b/shell/browser/api/electron_api_system_preferences_win.cc
@@ -16,6 +16,7 @@
 #include "base/win/windows_types.h"
 #include "base/win/wrapped_window_proc.h"
 #include "shell/common/color_util.h"
+#include "shell/common/process_util.h"
 #include "ui/gfx/color_utils.h"
 #include "ui/gfx/win/hwnd_util.h"
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -125,6 +125,7 @@
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/error_thrower.h"
+#include "shell/common/gin_helper/locker.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/language_util.h"

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -23,6 +23,7 @@
 #include "chrome/browser/ui/exclusive_access/exclusive_access_context.h"  // nogncheck
 #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
 #include "content/common/frame.mojom.h"
+#include "content/public/browser/browser_thread.h"
 #include "content/public/browser/devtools_agent_host.h"
 #include "content/public/browser/javascript_dialog_manager.h"
 #include "content/public/browser/render_widget_host.h"

--- a/shell/browser/electron_crypto_module_delegate_nss.cc
+++ b/shell/browser/electron_crypto_module_delegate_nss.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/electron_crypto_module_delegate_nss.h"
 
+#include "content/public/browser/browser_thread.h"
 #include "crypto/nss_crypto_module_delegate.h"
 #include "shell/browser/api/electron_api_app.h"
 #include "shell/browser/javascript_environment.h"

--- a/shell/browser/serial/serial_chooser_controller.cc
+++ b/shell/browser/serial/serial_chooser_controller.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/containers/contains.h"
 #include "base/functional/bind.h"
 #include "base/strings/stringprintf.h"
 #include "content/public/browser/web_contents.h"

--- a/shell/browser/ui/devtools_manager_delegate.cc
+++ b/shell/browser/ui/devtools_manager_delegate.cc
@@ -12,6 +12,7 @@
 #include "base/functional/bind.h"
 #include "base/path_service.h"
 #include "base/strings/string_number_conversions.h"
+#include "content/public/browser/browser_thread.h"
 #include "content/public/browser/devtools_agent_host.h"
 #include "content/public/browser/devtools_frontend_host.h"
 #include "content/public/browser/devtools_socket_factory.h"

--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -13,6 +13,7 @@
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
+#include "shell/common/process_util.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/base/clipboard/clipboard_format_type.h"
 #include "ui/base/clipboard/file_info.h"

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -20,6 +20,7 @@
 #include "shell/common/application_info.h"
 #include "shell/common/gin_converters/file_path_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/locker.h"
 #include "shell/common/gin_helper/microtasks_scope.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/heap_snapshot.h"

--- a/shell/common/gin_helper/promise.cc
+++ b/shell/common/gin_helper/promise.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <string>
 #include <string_view>
 
 #include "content/public/browser/browser_task_traits.h"
@@ -77,6 +78,24 @@ v8::Local<v8::Promise> PromiseBase::GetHandle() const {
 
 v8::Local<v8::Promise::Resolver> PromiseBase::GetInner() const {
   return resolver_.Get(isolate());
+}
+
+// static
+void PromiseBase::RejectPromise(PromiseBase&& promise,
+                                std::string_view errmsg) {
+  if (auto task_runner = GetTaskRunner()) {
+    task_runner->PostTask(
+        FROM_HERE, base::BindOnce(
+                       // Note that this callback can not take std::string_view,
+                       // as StringPiece only references string internally and
+                       // will blow when a temporary string is passed.
+                       [](PromiseBase&& promise, std::string str) {
+                         promise.RejectWithErrorMessage(str);
+                       },
+                       std::move(promise), std::string{errmsg}));
+  } else {
+    promise.RejectWithErrorMessage(errmsg);
+  }
 }
 
 // static

--- a/shell/common/gin_helper/promise.cc
+++ b/shell/common/gin_helper/promise.cc
@@ -4,10 +4,23 @@
 
 #include <string_view>
 
+#include "content/public/browser/browser_task_traits.h"
+#include "content/public/browser/browser_thread.h"
+#include "shell/common/gin_helper/microtasks_scope.h"
 #include "shell/common/gin_helper/promise.h"
+#include "shell/common/process_util.h"
 #include "v8/include/v8-context.h"
 
 namespace gin_helper {
+
+PromiseBase::SettleScope::SettleScope(const PromiseBase& base)
+    : handle_scope_{base.isolate()},
+      context_{base.GetContext()},
+      microtasks_scope_{base.isolate(), context_->GetMicrotaskQueue(), false,
+                        v8::MicrotasksScope::kRunMicrotasks},
+      context_scope_{context_} {}
+
+PromiseBase::SettleScope::~SettleScope() = default;
 
 PromiseBase::PromiseBase(v8::Isolate* isolate)
     : PromiseBase(isolate,
@@ -28,40 +41,30 @@ PromiseBase::~PromiseBase() = default;
 
 PromiseBase& PromiseBase::operator=(PromiseBase&&) = default;
 
-v8::Maybe<bool> PromiseBase::Reject() {
-  v8::HandleScope handle_scope(isolate());
-  v8::Local<v8::Context> context = GetContext();
-  gin_helper::MicrotasksScope microtasks_scope{
-      isolate(), context->GetMicrotaskQueue(), false,
-      v8::MicrotasksScope::kRunMicrotasks};
-  v8::Context::Scope context_scope(context);
-
-  return GetInner()->Reject(context, v8::Undefined(isolate()));
+// static
+scoped_refptr<base::TaskRunner> PromiseBase::GetTaskRunner() {
+  if (electron::IsBrowserProcess() &&
+      !content::BrowserThread::CurrentlyOn(content::BrowserThread::UI)) {
+    return content::GetUIThreadTaskRunner({});
+  }
+  return {};
 }
 
 v8::Maybe<bool> PromiseBase::Reject(v8::Local<v8::Value> except) {
-  v8::HandleScope handle_scope(isolate());
-  v8::Local<v8::Context> context = GetContext();
-  gin_helper::MicrotasksScope microtasks_scope{
-      isolate(), context->GetMicrotaskQueue(), false,
-      v8::MicrotasksScope::kRunMicrotasks};
-  v8::Context::Scope context_scope(context);
-
-  return GetInner()->Reject(context, except);
+  SettleScope settle_scope{*this};
+  return GetInner()->Reject(settle_scope.context_, except);
 }
 
-v8::Maybe<bool> PromiseBase::RejectWithErrorMessage(
-    const std::string_view message) {
-  v8::HandleScope handle_scope(isolate());
-  v8::Local<v8::Context> context = GetContext();
-  gin_helper::MicrotasksScope microtasks_scope{
-      isolate(), context->GetMicrotaskQueue(), false,
-      v8::MicrotasksScope::kRunMicrotasks};
-  v8::Context::Scope context_scope(context);
+v8::Maybe<bool> PromiseBase::Reject() {
+  SettleScope settle_scope{*this};
+  return GetInner()->Reject(settle_scope.context_, v8::Undefined(isolate()));
+}
 
-  v8::Local<v8::Value> error =
-      v8::Exception::Error(gin::StringToV8(isolate(), message));
-  return GetInner()->Reject(context, (error));
+v8::Maybe<bool> PromiseBase::RejectWithErrorMessage(std::string_view errmsg) {
+  SettleScope settle_scope{*this};
+  return GetInner()->Reject(
+      settle_scope.context_,
+      v8::Exception::Error(gin::StringToV8(isolate(), errmsg)));
 }
 
 v8::Local<v8::Context> PromiseBase::GetContext() const {
@@ -78,9 +81,8 @@ v8::Local<v8::Promise::Resolver> PromiseBase::GetInner() const {
 
 // static
 void Promise<void>::ResolvePromise(Promise<void> promise) {
-  if (electron::IsBrowserProcess() &&
-      !content::BrowserThread::CurrentlyOn(content::BrowserThread::UI)) {
-    content::GetUIThreadTaskRunner({})->PostTask(
+  if (auto task_runner = GetTaskRunner()) {
+    task_runner->PostTask(
         FROM_HERE,
         base::BindOnce([](Promise<void> promise) { promise.Resolve(); },
                        std::move(promise)));
@@ -97,14 +99,8 @@ v8::Local<v8::Promise> Promise<void>::ResolvedPromise(v8::Isolate* isolate) {
 }
 
 v8::Maybe<bool> Promise<void>::Resolve() {
-  v8::HandleScope handle_scope(isolate());
-  v8::Local<v8::Context> context = GetContext();
-  gin_helper::MicrotasksScope microtasks_scope{
-      isolate(), context->GetMicrotaskQueue(), false,
-      v8::MicrotasksScope::kRunMicrotasks};
-  v8::Context::Scope context_scope(context);
-
-  return GetInner()->Resolve(context, v8::Undefined(isolate()));
+  SettleScope settle_scope{*this};
+  return GetInner()->Resolve(settle_scope.context_, v8::Undefined(isolate()));
 }
 
 }  // namespace gin_helper

--- a/shell/common/gin_helper/promise.h
+++ b/shell/common/gin_helper/promise.h
@@ -44,26 +44,7 @@ class PromiseBase {
   PromiseBase& operator=(PromiseBase&&);
 
   // Helper for rejecting promise with error message.
-  //
-  // Note: The parameter type is PromiseBase&& so it can take the instances of
-  // Promise<T> type.
-  static void RejectPromise(PromiseBase&& promise,
-                            const std::string_view errmsg) {
-    if (auto task_runner = GetTaskRunner()) {
-      task_runner->PostTask(
-          FROM_HERE,
-          base::BindOnce(
-              // Note that this callback can not take std::string_view,
-              // as StringPiece only references string internally and
-              // will blow when a temporary string is passed.
-              [](PromiseBase&& promise, std::string str) {
-                promise.RejectWithErrorMessage(str);
-              },
-              std::move(promise), std::string{errmsg}));
-    } else {
-      promise.RejectWithErrorMessage(errmsg);
-    }
-  }
+  static void RejectPromise(PromiseBase&& promise, std::string_view errmsg);
 
   v8::Maybe<bool> Reject();
   v8::Maybe<bool> Reject(v8::Local<v8::Value> except);

--- a/shell/common/gin_helper/promise.h
+++ b/shell/common/gin_helper/promise.h
@@ -15,7 +15,6 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/task/task_runner.h"
 #include "shell/common/gin_converters/std_converter.h"
-#include "shell/common/gin_helper/locker.h"
 #include "shell/common/gin_helper/microtasks_scope.h"
 #include "v8/include/v8-context.h"
 

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -37,6 +37,7 @@
 #include "shell/common/mac/main_application_bundle.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/node_util.h"
+#include "shell/common/process_util.h"
 #include "shell/common/world_ids.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 #include "third_party/blink/renderer/bindings/core/v8/v8_initializer.h"  // nogncheck


### PR DESCRIPTION
#### Description of Change

Refactor some parts of `node_helper::Promise` to avoid code repetition:

- There were five methods with identical handle/microtask/context scopes setup before doing v8::Promise work. This PR extracts that setup into a new [`SettleScope`](https://github.com/electron/electron/blob/cd850238e8c0f2c4ff138c36bff01b6bf23b6e71/shell/common/gin_helper/promise.cc#L19) struct, borrowing the idea from [`SpellCheckScope`](https://github.com/electron/electron/blob/1c3a5ba5d17c18cbc1fc096d2a05fc24f2b2ddee/shell/renderer/api/electron_api_spell_check_client.h#L56).

- There were three methods with identical logic to decide whether to settle the promise immediately or to post it as a task. This PR extracts that logic into a new protected static method, `PromiseBase::GetTaskRunner()`. This has a happy side-effect of decoupling promise.h from the content module, which is good because about 80 files include `promise.h`.

- Side-cleanup: `PromiseBase::ResolvePromise()` isn't a templated function, so its implementation can be moved from the header into the cc file.

- There are a handful of unrelated .cc and .h files that need new `#include` lines because they are directly using API that used to be indirectly included via promise.h

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.