### PR TITLE
fix: resizing border on Linux WCO caption buttons

### DIFF
--- a/shell/browser/ui/views/opaque_frame_view.cc
+++ b/shell/browser/ui/views/opaque_frame_view.cc
@@ -135,6 +135,11 @@ gfx::Rect OpaqueFrameView::GetWindowBoundsForClientBounds(
 
 int OpaqueFrameView::NonClientHitTest(const gfx::Point& point) {
   if (window()->IsWindowControlsOverlayEnabled()) {
+    // Ensure support for resizing frameless window with border drag.
+    int frame_component = ResizingBorderHitTest(point);
+    if (frame_component != HTNOWHERE)
+      return frame_component;
+
     if (HitTestCaptionButton(close_button_, point))
       return HTCLOSE;
     if (HitTestCaptionButton(restore_button_, point))


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/43714.

Fixes an issue where the resizing border was not being handled correctly on Linux WCO caption buttons. This is now taken into account as a part of the NonClientHitTest.

cc @bpasero 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue when dragging to resize when using Window Controls Overlay on Linux.
