### PR TITLE
fix: in `Emit()`, don't leak converted Arg `Local<Values>` into caller's scope

### DIFF
--- a/shell/common/gin_helper/event_emitter_caller.h
+++ b/shell/common/gin_helper/event_emitter_caller.h
@@ -44,11 +44,13 @@ v8::Local<v8::Value> EmitEvent(v8::Isolate* isolate,
                                v8::Local<v8::Object> obj,
                                const StringType& name,
                                Args&&... args) {
+  v8::EscapableHandleScope scope{isolate};
   internal::ValueVector converted_args = {
       gin::StringToV8(isolate, name),
       gin::ConvertToV8(isolate, std::forward<Args>(args))...,
   };
-  return internal::CallMethodWithArgs(isolate, obj, "emit", &converted_args);
+  return scope.Escape(
+      internal::CallMethodWithArgs(isolate, obj, "emit", &converted_args));
 }
 
 // obj.custom_emit(args...)
@@ -57,11 +59,12 @@ v8::Local<v8::Value> CustomEmit(v8::Isolate* isolate,
                                 v8::Local<v8::Object> object,
                                 const char* custom_emit,
                                 Args&&... args) {
+  v8::EscapableHandleScope scope{isolate};
   internal::ValueVector converted_args = {
       gin::ConvertToV8(isolate, std::forward<Args>(args))...,
   };
-  return internal::CallMethodWithArgs(isolate, object, custom_emit,
-                                      &converted_args);
+  return scope.Escape(internal::CallMethodWithArgs(isolate, object, custom_emit,
+                                                   &converted_args));
 }
 
 template <typename T, typename... Args>


### PR DESCRIPTION
#### Description of Change

The two `Emit(isolate, obj, name, Args&&... args)` methods convert `args` into an array of `Local<Value>s`  to pass to Node/V8. But they don't use a HandleScope, so these temporary handles are leaked into the caller's scopes.

In most calls this is OK since either `args` is empty or since the caller creates a scope right before emission, but not everywhere. It's more reliable to handle this in the `Emit()` functions, so this PR adds `EscapableHandleScope`s to plug the leaks.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.