### PR TITLE
perf: hold `Emit()` arg arrays in a `std::array`

### DIFF
--- a/shell/common/gin_helper/event_emitter_caller.cc
+++ b/shell/common/gin_helper/event_emitter_caller.cc
@@ -9,10 +9,11 @@
 
 namespace gin_helper::internal {
 
-v8::Local<v8::Value> CallMethodWithArgs(v8::Isolate* isolate,
-                                        v8::Local<v8::Object> obj,
-                                        const char* method,
-                                        ValueVector* args) {
+v8::Local<v8::Value> CallMethodWithArgs(
+    v8::Isolate* isolate,
+    v8::Local<v8::Object> obj,
+    const char* method,
+    const base::span<v8::Local<v8::Value>> args) {
   v8::EscapableHandleScope handle_scope{isolate};
 
   // CallbackScope and MakeCallback both require an active node::Environment
@@ -29,7 +30,7 @@ v8::Local<v8::Value> CallMethodWithArgs(v8::Isolate* isolate,
 
   // node::MakeCallback will also run pending tasks in Node.js.
   v8::MaybeLocal<v8::Value> ret = node::MakeCallback(
-      isolate, obj, method, args->size(), args->data(), {0, 0});
+      isolate, obj, method, args.size(), args.data(), {0, 0});
 
   // If the JS function throws an exception (doesn't return a value) the result
   // of MakeCallback will be empty and therefore ToLocal will be false, in this

--- a/shell/common/gin_helper/event_emitter_caller.h
+++ b/shell/common/gin_helper/event_emitter_caller.h
@@ -7,7 +7,6 @@
 
 #include <array>
 #include <utility>
-#include <vector>
 
 #include "base/containers/span.h"
 #include "gin/converter.h"
@@ -23,20 +22,6 @@ v8::Local<v8::Value> CallMethodWithArgs(v8::Isolate* isolate,
                                         base::span<v8::Local<v8::Value>> args);
 
 }  // namespace internal
-
-// obj.emit.apply(obj, name, args...);
-// The caller is responsible of allocating a HandleScope.
-template <typename StringType>
-v8::Local<v8::Value> EmitEvent(v8::Isolate* isolate,
-                               v8::Local<v8::Object> obj,
-                               const StringType& name,
-                               const base::span<v8::Local<v8::Value>> args) {
-  std::vector<v8::Local<v8::Value>> concatenated_args;
-  concatenated_args.reserve(1 + args.size());
-  concatenated_args.emplace_back(gin::StringToV8(isolate, name));
-  concatenated_args.insert(concatenated_args.end(), args.begin(), args.end());
-  return internal::CallMethodWithArgs(isolate, obj, "emit", concatenated_args);
-}
 
 // obj.emit(name, args...);
 // The caller is responsible of allocating a HandleScope.

--- a/shell/common/gin_helper/event_emitter_caller.h
+++ b/shell/common/gin_helper/event_emitter_caller.h
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/containers/span.h"
 #include "gin/converter.h"
 #include "gin/wrappable.h"
 
@@ -20,7 +21,7 @@ using ValueVector = std::vector<v8::Local<v8::Value>>;
 v8::Local<v8::Value> CallMethodWithArgs(v8::Isolate* isolate,
                                         v8::Local<v8::Object> obj,
                                         const char* method,
-                                        ValueVector* args);
+                                        base::span<v8::Local<v8::Value>> args);
 
 }  // namespace internal
 
@@ -30,11 +31,11 @@ template <typename StringType>
 v8::Local<v8::Value> EmitEvent(v8::Isolate* isolate,
                                v8::Local<v8::Object> obj,
                                const StringType& name,
-                               const internal::ValueVector& args) {
+                               const base::span<v8::Local<v8::Value>> args) {
   internal::ValueVector concatenated_args = {gin::StringToV8(isolate, name)};
   concatenated_args.reserve(1 + args.size());
   concatenated_args.insert(concatenated_args.end(), args.begin(), args.end());
-  return internal::CallMethodWithArgs(isolate, obj, "emit", &concatenated_args);
+  return internal::CallMethodWithArgs(isolate, obj, "emit", concatenated_args);
 }
 
 // obj.emit(name, args...);
@@ -50,7 +51,7 @@ v8::Local<v8::Value> EmitEvent(v8::Isolate* isolate,
       gin::ConvertToV8(isolate, std::forward<Args>(args))...,
   };
   return scope.Escape(
-      internal::CallMethodWithArgs(isolate, obj, "emit", &converted_args));
+      internal::CallMethodWithArgs(isolate, obj, "emit", converted_args));
 }
 
 // obj.custom_emit(args...)
@@ -64,7 +65,7 @@ v8::Local<v8::Value> CustomEmit(v8::Isolate* isolate,
       gin::ConvertToV8(isolate, std::forward<Args>(args))...,
   };
   return scope.Escape(internal::CallMethodWithArgs(isolate, object, custom_emit,
-                                                   &converted_args));
+                                                   converted_args));
 }
 
 template <typename T, typename... Args>


### PR DESCRIPTION
#### Description of Change

A followup to #43729. We know the size of the args list at compile time, so we can use a statically-allocated array instead of a heap-allocated vector, e.g.

```diff
- std::vector<Local> items = { (args)... }
+ std::array<Local, sizeof...(args)> items = { (args)... }
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.