### PR TITLE
perf: hold `V8FunctionInvoker` args in a `std::array`

### DIFF
--- a/shell/common/gin_helper/callback.h
+++ b/shell/common/gin_helper/callback.h
@@ -5,8 +5,8 @@
 #ifndef ELECTRON_SHELL_COMMON_GIN_HELPER_CALLBACK_H_
 #define ELECTRON_SHELL_COMMON_GIN_HELPER_CALLBACK_H_
 
+#include <array>
 #include <utility>
-#include <vector>
 
 #include "base/functional/bind.h"
 #include "shell/common/gin_converters/std_converter.h"
@@ -54,7 +54,7 @@ struct V8FunctionInvoker<v8::Local<v8::Value>(ArgTypes...)> {
         isolate, context->GetMicrotaskQueue(), true,
         v8::MicrotasksScope::kRunMicrotasks};
     v8::Context::Scope context_scope(context);
-    std::vector<v8::Local<v8::Value>> args{
+    std::array<v8::Local<v8::Value>, sizeof...(raw)> args{
         gin::ConvertToV8(isolate, std::forward<ArgTypes>(raw))...};
     v8::MaybeLocal<v8::Value> ret = holder->Call(
         context, holder, args.size(), args.empty() ? nullptr : &args.front());
@@ -80,7 +80,7 @@ struct V8FunctionInvoker<void(ArgTypes...)> {
         isolate, context->GetMicrotaskQueue(), true,
         v8::MicrotasksScope::kRunMicrotasks};
     v8::Context::Scope context_scope(context);
-    std::vector<v8::Local<v8::Value>> args{
+    std::array<v8::Local<v8::Value>, sizeof...(raw)> args{
         gin::ConvertToV8(isolate, std::forward<ArgTypes>(raw))...};
     holder
         ->Call(context, holder, args.size(),
@@ -105,7 +105,7 @@ struct V8FunctionInvoker<ReturnType(ArgTypes...)> {
         isolate, context->GetMicrotaskQueue(), true,
         v8::MicrotasksScope::kRunMicrotasks};
     v8::Context::Scope context_scope(context);
-    std::vector<v8::Local<v8::Value>> args{
+    std::array<v8::Local<v8::Value>, sizeof...(raw)> args{
         gin::ConvertToV8(isolate, std::forward<ArgTypes>(raw))...};
     v8::Local<v8::Value> result;
     auto maybe_result = holder->Call(context, holder, args.size(),


### PR DESCRIPTION
#### Description of Change

Same idea as https://github.com/electron/electron/pull/43750, but for `V8FunctionInvoker`'s args.

Since the number of args is known at compile time, we can avoid a little heap memory management by using a std::array instead of a std::vector, e.g.:

```diff
   template<typename... Args>
   void Foo(Args&&... args) {
      ...
-     std::vector<Local> local_args = { ConvertToV8(args)... };
+     std::array<Local, sizeof...(args)> local_args = { ConvertToV8(args)... };
      ...
   }
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.