### PR TITLE
build: split darwin/mas macOS publish jobs

### DIFF
--- a/.github/workflows/macos-publish.yml
+++ b/.github/workflows/macos-publish.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         generate-sas-token: 'true'
 
-  publish-x64:
+  publish-x64-darwin:
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
     needs: checkout-macos
     with:
@@ -48,13 +48,29 @@ jobs:
       build-runs-on: macos-14-xlarge
       target-platform: macos
       target-arch: x64
+      target-variant: darwin
       is-release: true
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
     secrets: inherit
 
-  publish-arm64:
+  publish-x64-mas:
+    uses: ./.github/workflows/pipeline-segment-electron-build.yml
+    needs: checkout-macos
+    with:
+      environment: production-release
+      build-runs-on: macos-14-xlarge
+      target-platform: macos
+      target-arch: x64
+      target-variant: mas
+      is-release: true
+      gn-build-type: release
+      generate-symbols: true
+      upload-to-storage: ${{ inputs.upload-to-storage }}
+    secrets: inherit
+
+  publish-arm64-darwin:
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
     needs: checkout-macos
     with:
@@ -62,6 +78,22 @@ jobs:
       build-runs-on: macos-14-xlarge
       target-platform: macos
       target-arch: arm64
+      target-variant: darwin
+      is-release: true
+      gn-build-type: release
+      generate-symbols: true
+      upload-to-storage: ${{ inputs.upload-to-storage }}
+    secrets: inherit
+
+  publish-arm64-mas:
+    uses: ./.github/workflows/pipeline-segment-electron-build.yml
+    needs: checkout-macos
+    with:
+      environment: production-release
+      build-runs-on: macos-14-xlarge
+      target-platform: macos
+      target-arch: arm64
+      target-variant: mas
       is-release: true
       gn-build-type: release
       generate-symbols: true

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -15,6 +15,10 @@ on:
         type: string
         description: 'Arch to build for, can be x64, arm64 or arm'
         required: true
+      target-variant:
+        type: string
+        description: 'Variant to build for, no effect on non-macOS target platforms. Can be darwin, mas or all.'
+        default: all
       build-runs-on:
         type: string
         description: 'What host to run the build'
@@ -188,6 +192,7 @@ jobs:
       if: ${{ inputs.target-platform == 'macos' }}
       uses: ./src/electron/.github/actions/free-space-macos
     - name: Build Electron
+      if: ${{ inputs.target-platform != 'macos' || (inputs.target-variant == 'all' || inputs.target-variant == 'darwin') }}
       uses: ./src/electron/.github/actions/build-electron
       with:
         target-arch: ${{ inputs.target-arch }}
@@ -199,13 +204,13 @@ jobs:
         upload-to-storage: '${{ inputs.upload-to-storage }}'
         is-asan: '${{ inputs.is-asan }}'
     - name: Set GN_EXTRA_ARGS for MAS Build
-      if: ${{ inputs.target-platform == 'macos' }}
+      if: ${{ inputs.target-platform == 'macos' && (inputs.target-variant == 'all' || inputs.target-variant == 'mas') }}
       run: |
         echo "MAS_BUILD=true" >> $GITHUB_ENV
         GN_EXTRA_ARGS='is_mas_build=true'
         echo "GN_EXTRA_ARGS=$GN_EXTRA_ARGS" >> $GITHUB_ENV
     - name: Build Electron (MAS)
-      if: ${{ inputs.target-platform == 'macos' }}
+      if: ${{ inputs.target-platform == 'macos' && (inputs.target-variant == 'all' || inputs.target-variant == 'mas') }}
       uses: ./src/electron/.github/actions/build-electron
       with:
         target-arch: ${{ inputs.target-arch }}


### PR DESCRIPTION
In CI doing MAS after darwin is incredibly quick, for release builds it rebuilds basically everything (unclear why). This does the quick and dirty thing of splitting MAS and Darwin out into two jobs during publish to make them way quicker.

Notes: none