### PR TITLE
build: enable dependabot on supported branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,91 @@ updates:
     labels:
       - "no-backport"
       - "semver/none"
+    target-branch: main
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - "no-backport"
+      - "semver/none"
+    target-branch: 33-x-y
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - "no-backport"
+      - "semver/none"
+    target-branch: 32-x-y
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - "no-backport"
+      - "semver/none"
+    target-branch: 31-x-y
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - "no-backport"
+      - "semver/none"
+    target-branch: 30-x-y
+  - package-ecosystem: npm
+    directories:
+      - /
+      - /spec
+      - /npm
+    schedule:
+      interval: daily
+    labels:
+      - "no-backport"
+    open-pull-requests-limit: 5
+    target-branch: 33-x-y
+  - package-ecosystem: npm
+    directories:
+      - /
+      - /spec
+      - /npm
+    schedule:
+      interval: daily
+    labels:
+      - "no-backport"
+    open-pull-requests-limit: 5
+    target-branch: main
+  - package-ecosystem: npm
+    directories:
+      - /
+      - /spec
+      - /npm
+    schedule:
+      interval: daily
+    labels:
+      - "no-backport"
+    open-pull-requests-limit: 5
+    target-branch: 32-x-y
+  - package-ecosystem: npm
+    directories:
+      - /
+      - /spec
+      - /npm
+    schedule:
+      interval: daily
+    labels:
+      - "no-backport"
+    open-pull-requests-limit: 5
+    target-branch: 31-x-y
+  - package-ecosystem: npm
+    directories:
+      - /
+      - /spec
+      - /npm
+    schedule:
+      interval: daily
+    labels:
+      - "no-backport"
+    open-pull-requests-limit: 5
+    target-branch: 30-x-y


### PR DESCRIPTION
This enables github actions and npm dependabot on all supported branches instead of just main, it always felt a bit weird that we had this enabled for main but not our release lines. Should reduce drift and remove the need to backport these if dependabot runs on everything.

Will need to keep this file up to date during the release process but doing that manually for now (once every two months) isn't the end of the world.

Notes: none