### PR TITLE
perf: use `v8::Eternal` for our perma-Globals

### DIFF
--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -397,12 +397,12 @@ gin_helper::WrappableBase* View::New(gin::Arguments* args) {
 
 // static
 v8::Local<v8::Function> View::GetConstructor(v8::Isolate* isolate) {
-  static base::NoDestructor<v8::Global<v8::Function>> constructor;
-  if (constructor.get()->IsEmpty()) {
-    constructor->Reset(isolate, gin_helper::CreateConstructor<View>(
-                                    isolate, base::BindRepeating(&View::New)));
+  static v8::Eternal<v8::Function> constructor;
+  if (constructor.IsEmpty()) {
+    constructor.Set(isolate, gin_helper::CreateConstructor<View>(
+                                 isolate, base::BindRepeating(&View::New)));
   }
-  return v8::Local<v8::Function>::New(isolate, *constructor.get());
+  return constructor.Get(isolate);
 }
 
 // static

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/api/electron_api_web_contents_view.h"
 
-#include "base/no_destructor.h"
 #include "gin/data_object_builder.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/browser.h"
@@ -157,13 +156,13 @@ gin::Handle<WebContentsView> WebContentsView::Create(
 
 // static
 v8::Local<v8::Function> WebContentsView::GetConstructor(v8::Isolate* isolate) {
-  static base::NoDestructor<v8::Global<v8::Function>> constructor;
-  if (constructor.get()->IsEmpty()) {
-    constructor->Reset(
-        isolate, gin_helper::CreateConstructor<WebContentsView>(
-                     isolate, base::BindRepeating(&WebContentsView::New)));
+  static v8::Eternal<v8::Function> constructor;
+  if (constructor.IsEmpty()) {
+    constructor.Set(isolate,
+                    gin_helper::CreateConstructor<WebContentsView>(
+                        isolate, base::BindRepeating(&WebContentsView::New)));
   }
-  return v8::Local<v8::Function>::New(isolate, *constructor.get());
+  return constructor.Get(isolate);
 }
 
 // static

--- a/shell/common/gin_helper/destroyable.cc
+++ b/shell/common/gin_helper/destroyable.cc
@@ -4,7 +4,6 @@
 
 #include "shell/common/gin_helper/destroyable.h"
 
-#include "base/no_destructor.h"
 #include "gin/converter.h"
 #include "shell/common/gin_helper/wrappable_base.h"
 #include "v8/include/v8-function.h"
@@ -13,15 +12,9 @@ namespace gin_helper {
 
 namespace {
 
-v8::Global<v8::FunctionTemplate>* GetDestroyFunc() {
-  static base::NoDestructor<v8::Global<v8::FunctionTemplate>> destroy_func;
-  return destroy_func.get();
-}
+v8::Eternal<v8::FunctionTemplate> destroy_func_;
 
-v8::Global<v8::FunctionTemplate>* GetIsDestroyedFunc() {
-  static base::NoDestructor<v8::Global<v8::FunctionTemplate>> is_destroyed_func;
-  return is_destroyed_func.get();
-}
+v8::Eternal<v8::FunctionTemplate> is_destroyed_func_;
 
 void DestroyFunc(const v8::FunctionCallbackInfo<v8::Value>& info) {
   v8::Local<v8::Object> holder = info.This();
@@ -53,22 +46,20 @@ bool Destroyable::IsDestroyed(v8::Local<v8::Object> object) {
 void Destroyable::MakeDestroyable(v8::Isolate* isolate,
                                   v8::Local<v8::FunctionTemplate> prototype) {
   // Cache the FunctionTemplate of "destroy" and "isDestroyed".
-  if (GetDestroyFunc()->IsEmpty()) {
+  if (destroy_func_.IsEmpty()) {
     auto templ = v8::FunctionTemplate::New(isolate, DestroyFunc);
     templ->RemovePrototype();
-    GetDestroyFunc()->Reset(isolate, templ);
+    destroy_func_.Set(isolate, templ);
     templ = v8::FunctionTemplate::New(isolate, IsDestroyedFunc);
     templ->RemovePrototype();
-    GetIsDestroyedFunc()->Reset(isolate, templ);
+    is_destroyed_func_.Set(isolate, templ);
   }
 
   auto proto_templ = prototype->PrototypeTemplate();
-  proto_templ->Set(
-      gin::StringToSymbol(isolate, "destroy"),
-      v8::Local<v8::FunctionTemplate>::New(isolate, *GetDestroyFunc()));
-  proto_templ->Set(
-      gin::StringToSymbol(isolate, "isDestroyed"),
-      v8::Local<v8::FunctionTemplate>::New(isolate, *GetIsDestroyedFunc()));
+  proto_templ->Set(gin::StringToSymbol(isolate, "destroy"),
+                   destroy_func_.Get(isolate));
+  proto_templ->Set(gin::StringToSymbol(isolate, "isDestroyed"),
+                   is_destroyed_func_.Get(isolate));
 }
 
 }  // namespace gin_helper


### PR DESCRIPTION
#### Description of Change

We have a handful of persistent handles that we've been storing as `base::NoDestructor<v8::Global<>>` objects. This PR stores them as `v8::Eternal<>` objects instead, both to improve GC and to simplify the code.

- `v8::Eternal` is described in the embedder's guide as "a persistent handle for JavaScript objects that are expected to never be deleted. It is cheaper to use because it relieves the garbage collector from determining the liveness of that object.

- Since `v8::Eternal` is trivially destructible, we can remove the `base::NoDestructor` wrapper and just use a static instance directly instead. In fact, base::NoDestructor _complains_ if you try to use it. Removing the wrapper simplifies our code a little.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.