### PR TITLE
chore: fix compile issue about ambiguous error of multiple methods named 'highlight'.

### DIFF
--- a/shell/browser/ui/message_box_mac.mm
+++ b/shell/browser/ui/message_box_mac.mm
@@ -81,7 +81,7 @@ NSAlert* CreateNSAlert(const MessageBoxSettings& settings) {
 
     // TODO(@codebytere): This behavior violates HIG & should be deprecated.
     if (settings.cancel_id == settings.default_id) {
-      [[ns_buttons objectAtIndex:settings.default_id] highlight:YES];
+      [(NSButton*)[ns_buttons objectAtIndex:settings.default_id] highlight:YES];
     }
   }
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

There are the error encountering stems from multiple methods named `highlight:` being found in different classes within the macOS AppKit framework. Since different classes (NSScroller, NSButton, NSTextView) have a method named `highlight:`, the compiler is unable to resolve which one should be used.

It happened on macOS 15 and Xcode 16.

To fix this, we need to make sure the compiler knows explicitly which class's method you intend to call.
```
../../electron/shell/browser/ui/message_box_mac.mm:87:7: error: multiple methods named 'highlight:' found with mismatched result, parameter type or attributes
   87 |       [[ns_buttons objectAtIndex:settings.default_id] highlight:YES];
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../../../../Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSScroller.h:127:1: note: one possibility
  127 | - (void)highlight:(BOOL)flag API_DEPRECATED("Has had no effect since 10.7", macos(10.0,10.14));
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../../../../Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSButton.h:157:1: note: also found
  157 | - (void)highlight:(BOOL)flag;
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../../../../Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSTextView.h:565:1: note: also found
  565 | - (IBAction)highlight:(nullable id)sender API_AVAILABLE(macos(15.0));
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none