### PR TITLE
refactor: remove use of deprecated API BuildServiceInstanceFor() (31-x-y)

### DIFF
--- a/shell/browser/badging/badge_manager_factory.cc
+++ b/shell/browser/badging/badge_manager_factory.cc
@@ -32,9 +32,10 @@ BadgeManagerFactory::BadgeManagerFactory()
 
 BadgeManagerFactory::~BadgeManagerFactory() = default;
 
-KeyedService* BadgeManagerFactory::BuildServiceInstanceFor(
+std::unique_ptr<KeyedService>
+BadgeManagerFactory::BuildServiceInstanceForBrowserContext(
     content::BrowserContext* context) const {
-  return new BadgeManager();
+  return std::make_unique<BadgeManager>();
 }
 
 }  // namespace badging

--- a/shell/browser/badging/badge_manager_factory.h
+++ b/shell/browser/badging/badge_manager_factory.h
@@ -36,7 +36,7 @@ class BadgeManagerFactory : public BrowserContextKeyedServiceFactory {
   ~BadgeManagerFactory() override;
 
   // BrowserContextKeyedServiceFactory
-  KeyedService* BuildServiceInstanceFor(
+  std::unique_ptr<KeyedService> BuildServiceInstanceForBrowserContext(
       content::BrowserContext* context) const override;
 };
 

--- a/shell/browser/extensions/electron_extension_system_factory.cc
+++ b/shell/browser/extensions/electron_extension_system_factory.cc
@@ -35,9 +35,10 @@ ElectronExtensionSystemFactory::ElectronExtensionSystemFactory()
 
 ElectronExtensionSystemFactory::~ElectronExtensionSystemFactory() = default;
 
-KeyedService* ElectronExtensionSystemFactory::BuildServiceInstanceFor(
+std::unique_ptr<KeyedService>
+ElectronExtensionSystemFactory::BuildServiceInstanceForBrowserContext(
     BrowserContext* context) const {
-  return new ElectronExtensionSystem(context);
+  return std::make_unique<ElectronExtensionSystem>(context);
 }
 
 BrowserContext* ElectronExtensionSystemFactory::GetBrowserContextToUse(

--- a/shell/browser/extensions/electron_extension_system_factory.h
+++ b/shell/browser/extensions/electron_extension_system_factory.h
@@ -5,6 +5,8 @@
 #ifndef ELECTRON_SHELL_BROWSER_EXTENSIONS_ELECTRON_EXTENSION_SYSTEM_FACTORY_H_
 #define ELECTRON_SHELL_BROWSER_EXTENSIONS_ELECTRON_EXTENSION_SYSTEM_FACTORY_H_
 
+#include <memory>
+
 #include "extensions/browser/extension_system_provider.h"
 
 namespace base {
@@ -36,7 +38,7 @@ class ElectronExtensionSystemFactory : public ExtensionSystemProvider {
   ~ElectronExtensionSystemFactory() override;
 
   // BrowserContextKeyedServiceFactory implementation:
-  KeyedService* BuildServiceInstanceFor(
+  std::unique_ptr<KeyedService> BuildServiceInstanceForBrowserContext(
       content::BrowserContext* context) const override;
   content::BrowserContext* GetBrowserContextToUse(
       content::BrowserContext* context) const override;

--- a/shell/browser/file_system_access/file_system_access_permission_context_factory.cc
+++ b/shell/browser/file_system_access/file_system_access_permission_context_factory.cc
@@ -36,15 +36,9 @@ FileSystemAccessPermissionContextFactory::
 FileSystemAccessPermissionContextFactory::
     ~FileSystemAccessPermissionContextFactory() = default;
 
-// static
-KeyedService* FileSystemAccessPermissionContextFactory::BuildServiceInstanceFor(
-    content::BrowserContext* context) const {
-  return BuildInstanceFor(context).release();
-}
-
 std::unique_ptr<KeyedService>
-FileSystemAccessPermissionContextFactory::BuildInstanceFor(
-    content::BrowserContext* context) {
+FileSystemAccessPermissionContextFactory::BuildServiceInstanceForBrowserContext(
+    content::BrowserContext* context) const {
   return std::make_unique<FileSystemAccessPermissionContext>(context);
 }
 

--- a/shell/browser/file_system_access/file_system_access_permission_context_factory.h
+++ b/shell/browser/file_system_access/file_system_access_permission_context_factory.h
@@ -5,6 +5,8 @@
 #ifndef ELECTRON_SHELL_BROWSER_FILE_SYSTEM_ACCESS_FILE_SYSTEM_ACCESS_PERMISSION_CONTEXT_FACTORY_H_
 #define ELECTRON_SHELL_BROWSER_FILE_SYSTEM_ACCESS_FILE_SYSTEM_ACCESS_PERMISSION_CONTEXT_FACTORY_H_
 
+#include <memory>
+
 #include "base/no_destructor.h"
 #include "components/keyed_service/content/browser_context_keyed_service_factory.h"
 #include "shell/browser/file_system_access/file_system_access_permission_context.h"
@@ -18,9 +20,6 @@ class FileSystemAccessPermissionContextFactory
       content::BrowserContext* context);
   static FileSystemAccessPermissionContextFactory* GetInstance();
 
-  static std::unique_ptr<KeyedService> BuildInstanceFor(
-      content::BrowserContext* context);
-
   FileSystemAccessPermissionContextFactory(
       const FileSystemAccessPermissionContextFactory&) = delete;
   FileSystemAccessPermissionContextFactory& operator=(
@@ -33,7 +32,7 @@ class FileSystemAccessPermissionContextFactory
   ~FileSystemAccessPermissionContextFactory() override;
 
   // BrowserContextKeyedServiceFactory:
-  KeyedService* BuildServiceInstanceFor(
+  std::unique_ptr<KeyedService> BuildServiceInstanceForBrowserContext(
       content::BrowserContext* context) const override;
 };
 

--- a/shell/browser/hid/hid_chooser_context_factory.cc
+++ b/shell/browser/hid/hid_chooser_context_factory.cc
@@ -37,11 +37,11 @@ HidChooserContextFactory::HidChooserContextFactory()
 
 HidChooserContextFactory::~HidChooserContextFactory() = default;
 
-KeyedService* HidChooserContextFactory::BuildServiceInstanceFor(
+std::unique_ptr<KeyedService>
+HidChooserContextFactory::BuildServiceInstanceForBrowserContext(
     content::BrowserContext* context) const {
-  auto* browser_context =
-      static_cast<electron::ElectronBrowserContext*>(context);
-  return new HidChooserContext(browser_context);
+  return std::make_unique<HidChooserContext>(
+      static_cast<electron::ElectronBrowserContext*>(context));
 }
 
 content::BrowserContext* HidChooserContextFactory::GetBrowserContextToUse(

--- a/shell/browser/hid/hid_chooser_context_factory.h
+++ b/shell/browser/hid/hid_chooser_context_factory.h
@@ -5,6 +5,8 @@
 #ifndef ELECTRON_SHELL_BROWSER_HID_HID_CHOOSER_CONTEXT_FACTORY_H_
 #define ELECTRON_SHELL_BROWSER_HID_HID_CHOOSER_CONTEXT_FACTORY_H_
 
+#include <memory>
+
 #include "base/no_destructor.h"
 #include "components/keyed_service/content/browser_context_keyed_service_factory.h"
 
@@ -30,8 +32,8 @@ class HidChooserContextFactory : public BrowserContextKeyedServiceFactory {
   HidChooserContextFactory();
   ~HidChooserContextFactory() override;
 
-  // BrowserContextKeyedBaseFactory:
-  KeyedService* BuildServiceInstanceFor(
+  // BrowserContextKeyedServiceFactory:
+  std::unique_ptr<KeyedService> BuildServiceInstanceForBrowserContext(
       content::BrowserContext* profile) const override;
   content::BrowserContext* GetBrowserContextToUse(
       content::BrowserContext* context) const override;

--- a/shell/browser/net/network_context_service_factory.cc
+++ b/shell/browser/net/network_context_service_factory.cc
@@ -28,9 +28,10 @@ NetworkContextServiceFactory::NetworkContextServiceFactory()
 
 NetworkContextServiceFactory::~NetworkContextServiceFactory() = default;
 
-KeyedService* NetworkContextServiceFactory::BuildServiceInstanceFor(
+std::unique_ptr<KeyedService>
+NetworkContextServiceFactory::BuildServiceInstanceForBrowserContext(
     content::BrowserContext* context) const {
-  return new NetworkContextService(
+  return std::make_unique<NetworkContextService>(
       static_cast<ElectronBrowserContext*>(context));
 }
 

--- a/shell/browser/net/network_context_service_factory.h
+++ b/shell/browser/net/network_context_service_factory.h
@@ -5,7 +5,8 @@
 #ifndef ELECTRON_SHELL_BROWSER_NET_NETWORK_CONTEXT_SERVICE_FACTORY_H_
 #define ELECTRON_SHELL_BROWSER_NET_NETWORK_CONTEXT_SERVICE_FACTORY_H_
 
-#include "base/memory/singleton.h"
+#include <memory>
+
 #include "components/keyed_service/content/browser_context_keyed_service_factory.h"
 
 class KeyedService;
@@ -44,7 +45,7 @@ class NetworkContextServiceFactory : public BrowserContextKeyedServiceFactory {
   ~NetworkContextServiceFactory() override;
 
   // BrowserContextKeyedServiceFactory implementation:
-  KeyedService* BuildServiceInstanceFor(
+  std::unique_ptr<KeyedService> BuildServiceInstanceForBrowserContext(
       content::BrowserContext* context) const override;
   content::BrowserContext* GetBrowserContextToUse(
       content::BrowserContext* context) const override;

--- a/shell/browser/serial/serial_chooser_context_factory.cc
+++ b/shell/browser/serial/serial_chooser_context_factory.cc
@@ -18,11 +18,11 @@ SerialChooserContextFactory::SerialChooserContextFactory()
 
 SerialChooserContextFactory::~SerialChooserContextFactory() = default;
 
-KeyedService* SerialChooserContextFactory::BuildServiceInstanceFor(
+std::unique_ptr<KeyedService>
+SerialChooserContextFactory::BuildServiceInstanceForBrowserContext(
     content::BrowserContext* context) const {
-  auto* browser_context =
-      static_cast<electron::ElectronBrowserContext*>(context);
-  return new SerialChooserContext(browser_context);
+  return std::make_unique<SerialChooserContext>(
+      static_cast<electron::ElectronBrowserContext*>(context));
 }
 
 // static

--- a/shell/browser/serial/serial_chooser_context_factory.h
+++ b/shell/browser/serial/serial_chooser_context_factory.h
@@ -5,6 +5,8 @@
 #ifndef ELECTRON_SHELL_BROWSER_SERIAL_SERIAL_CHOOSER_CONTEXT_FACTORY_H_
 #define ELECTRON_SHELL_BROWSER_SERIAL_SERIAL_CHOOSER_CONTEXT_FACTORY_H_
 
+#include <memory>
+
 #include "components/keyed_service/content/browser_context_keyed_service_factory.h"
 #include "shell/browser/serial/serial_chooser_context.h"
 
@@ -35,7 +37,7 @@ class SerialChooserContextFactory : public BrowserContextKeyedServiceFactory {
       delete;
 
   // BrowserContextKeyedServiceFactory methods:
-  KeyedService* BuildServiceInstanceFor(
+  std::unique_ptr<KeyedService> BuildServiceInstanceForBrowserContext(
       content::BrowserContext* context) const override;
   content::BrowserContext* GetBrowserContextToUse(
       content::BrowserContext* context) const override;

--- a/shell/browser/usb/usb_chooser_context_factory.cc
+++ b/shell/browser/usb/usb_chooser_context_factory.cc
@@ -18,11 +18,11 @@ UsbChooserContextFactory::UsbChooserContextFactory()
 
 UsbChooserContextFactory::~UsbChooserContextFactory() = default;
 
-KeyedService* UsbChooserContextFactory::BuildServiceInstanceFor(
+std::unique_ptr<KeyedService>
+UsbChooserContextFactory::BuildServiceInstanceForBrowserContext(
     content::BrowserContext* context) const {
-  auto* browser_context =
-      static_cast<electron::ElectronBrowserContext*>(context);
-  return new UsbChooserContext(browser_context);
+  return std::make_unique<UsbChooserContext>(
+      static_cast<electron::ElectronBrowserContext*>(context));
 }
 
 // static

--- a/shell/browser/usb/usb_chooser_context_factory.h
+++ b/shell/browser/usb/usb_chooser_context_factory.h
@@ -5,6 +5,8 @@
 #ifndef ELECTRON_SHELL_BROWSER_USB_USB_CHOOSER_CONTEXT_FACTORY_H_
 #define ELECTRON_SHELL_BROWSER_USB_USB_CHOOSER_CONTEXT_FACTORY_H_
 
+#include <memory>
+
 #include "components/keyed_service/content/browser_context_keyed_service_factory.h"
 
 namespace base {
@@ -34,7 +36,7 @@ class UsbChooserContextFactory : public BrowserContextKeyedServiceFactory {
   ~UsbChooserContextFactory() override;
 
   // BrowserContextKeyedServiceFactory methods:
-  KeyedService* BuildServiceInstanceFor(
+  std::unique_ptr<KeyedService> BuildServiceInstanceForBrowserContext(
       content::BrowserContext* profile) const override;
 };
 


### PR DESCRIPTION
Manually backport #43690 to 31-x-y. See that PR for details.

Notes: none.