### PR TITLE
refactor: declare gin::Wrapper subclasses as final

### DIFF
--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -47,12 +47,12 @@ enum class JumpListResult : int;
 
 namespace api {
 
-class App : public ElectronBrowserClient::Delegate,
-            public gin::Wrappable<App>,
-            public gin_helper::EventEmitterMixin<App>,
-            public BrowserObserver,
-            public content::GpuDataManagerObserver,
-            public content::BrowserChildProcessObserver {
+class App final : public ElectronBrowserClient::Delegate,
+                  public gin::Wrappable<App>,
+                  public gin_helper::EventEmitterMixin<App>,
+                  public BrowserObserver,
+                  public content::GpuDataManagerObserver,
+                  public content::BrowserChildProcessObserver {
  public:
   using FileIconCallback =
       base::RepeatingCallback<void(v8::Local<v8::Value>, const gfx::Image&)>;

--- a/shell/browser/api/electron_api_auto_updater.h
+++ b/shell/browser/api/electron_api_auto_updater.h
@@ -15,10 +15,10 @@
 
 namespace electron::api {
 
-class AutoUpdater : public gin::Wrappable<AutoUpdater>,
-                    public gin_helper::EventEmitterMixin<AutoUpdater>,
-                    public auto_updater::Delegate,
-                    public WindowListObserver {
+class AutoUpdater final : public gin::Wrappable<AutoUpdater>,
+                          public gin_helper::EventEmitterMixin<AutoUpdater>,
+                          public auto_updater::Delegate,
+                          public WindowListObserver {
  public:
   static gin::Handle<AutoUpdater> Create(v8::Isolate* isolate);
 

--- a/shell/browser/api/electron_api_cookies.h
+++ b/shell/browser/api/electron_api_cookies.h
@@ -27,8 +27,8 @@ class ElectronBrowserContext;
 
 namespace api {
 
-class Cookies : public gin::Wrappable<Cookies>,
-                public gin_helper::EventEmitterMixin<Cookies> {
+class Cookies final : public gin::Wrappable<Cookies>,
+                      public gin_helper::EventEmitterMixin<Cookies> {
  public:
   static gin::Handle<Cookies> Create(v8::Isolate* isolate,
                                      ElectronBrowserContext* browser_context);

--- a/shell/browser/api/electron_api_data_pipe_holder.h
+++ b/shell/browser/api/electron_api_data_pipe_holder.h
@@ -16,7 +16,7 @@
 namespace electron::api {
 
 // Retains reference to the data pipe.
-class DataPipeHolder : public gin::Wrappable<DataPipeHolder> {
+class DataPipeHolder final : public gin::Wrappable<DataPipeHolder> {
  public:
   // gin::Wrappable
   static gin::WrapperInfo kWrapperInfo;

--- a/shell/browser/api/electron_api_debugger.h
+++ b/shell/browser/api/electron_api_debugger.h
@@ -25,10 +25,10 @@ class WebContents;
 
 namespace electron::api {
 
-class Debugger : public gin::Wrappable<Debugger>,
-                 public gin_helper::EventEmitterMixin<Debugger>,
-                 public content::DevToolsAgentHostClient,
-                 public content::WebContentsObserver {
+class Debugger final : public gin::Wrappable<Debugger>,
+                       public gin_helper::EventEmitterMixin<Debugger>,
+                       public content::DevToolsAgentHostClient,
+                       public content::WebContentsObserver {
  public:
   static gin::Handle<Debugger> Create(v8::Isolate* isolate,
                                       content::WebContents* web_contents);

--- a/shell/browser/api/electron_api_desktop_capturer.h
+++ b/shell/browser/api/electron_api_desktop_capturer.h
@@ -17,9 +17,9 @@
 
 namespace electron::api {
 
-class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
-                        public gin_helper::Pinnable<DesktopCapturer>,
-                        public DesktopMediaListObserver {
+class DesktopCapturer final : public gin::Wrappable<DesktopCapturer>,
+                              public gin_helper::Pinnable<DesktopCapturer>,
+                              public DesktopMediaListObserver {
  public:
   struct Source {
     DesktopMediaList::Source media_list_source;

--- a/shell/browser/api/electron_api_download_item.h
+++ b/shell/browser/api/electron_api_download_item.h
@@ -21,10 +21,10 @@ class GURL;
 
 namespace electron::api {
 
-class DownloadItem : public gin::Wrappable<DownloadItem>,
-                     public gin_helper::Pinnable<DownloadItem>,
-                     public gin_helper::EventEmitterMixin<DownloadItem>,
-                     public download::DownloadItem::Observer {
+class DownloadItem final : public gin::Wrappable<DownloadItem>,
+                           public gin_helper::Pinnable<DownloadItem>,
+                           public gin_helper::EventEmitterMixin<DownloadItem>,
+                           public download::DownloadItem::Observer {
  public:
   static gin::Handle<DownloadItem> FromOrCreate(v8::Isolate* isolate,
                                                 download::DownloadItem* item);

--- a/shell/browser/api/electron_api_global_shortcut.h
+++ b/shell/browser/api/electron_api_global_shortcut.h
@@ -16,8 +16,9 @@
 
 namespace electron::api {
 
-class GlobalShortcut : public extensions::GlobalShortcutListener::Observer,
-                       public gin::Wrappable<GlobalShortcut> {
+class GlobalShortcut final
+    : public extensions::GlobalShortcutListener::Observer,
+      public gin::Wrappable<GlobalShortcut> {
  public:
   static gin::Handle<GlobalShortcut> Create(v8::Isolate* isolate);
 

--- a/shell/browser/api/electron_api_in_app_purchase.h
+++ b/shell/browser/api/electron_api_in_app_purchase.h
@@ -18,9 +18,9 @@
 
 namespace electron::api {
 
-class InAppPurchase : public gin::Wrappable<InAppPurchase>,
-                      public gin_helper::EventEmitterMixin<InAppPurchase>,
-                      public in_app_purchase::TransactionObserver {
+class InAppPurchase final : public gin::Wrappable<InAppPurchase>,
+                            public gin_helper::EventEmitterMixin<InAppPurchase>,
+                            public in_app_purchase::TransactionObserver {
  public:
   static gin::Handle<InAppPurchase> Create(v8::Isolate* isolate);
 

--- a/shell/browser/api/electron_api_native_theme.h
+++ b/shell/browser/api/electron_api_native_theme.h
@@ -14,9 +14,9 @@
 
 namespace electron::api {
 
-class NativeTheme : public gin::Wrappable<NativeTheme>,
-                    public gin_helper::EventEmitterMixin<NativeTheme>,
-                    public ui::NativeThemeObserver {
+class NativeTheme final : public gin::Wrappable<NativeTheme>,
+                          public gin_helper::EventEmitterMixin<NativeTheme>,
+                          public ui::NativeThemeObserver {
  public:
   static gin::Handle<NativeTheme> Create(v8::Isolate* isolate);
 

--- a/shell/browser/api/electron_api_net_log.h
+++ b/shell/browser/api/electron_api_net_log.h
@@ -30,7 +30,7 @@ class ElectronBrowserContext;
 namespace api {
 
 // The code is referenced from the net_log::NetExportFileWriter class.
-class NetLog : public gin::Wrappable<NetLog> {
+class NetLog final : public gin::Wrappable<NetLog> {
  public:
   static gin::Handle<NetLog> Create(v8::Isolate* isolate,
                                     ElectronBrowserContext* browser_context);

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -28,11 +28,11 @@ class Handle;
 
 namespace electron::api {
 
-class Notification : public gin::Wrappable<Notification>,
-                     public gin_helper::EventEmitterMixin<Notification>,
-                     public gin_helper::Constructible<Notification>,
-                     public gin_helper::CleanedUpAtExit,
-                     public NotificationDelegate {
+class Notification final : public gin::Wrappable<Notification>,
+                           public gin_helper::EventEmitterMixin<Notification>,
+                           public gin_helper::Constructible<Notification>,
+                           public gin_helper::CleanedUpAtExit,
+                           public NotificationDelegate {
  public:
   static bool IsSupported();
 

--- a/shell/browser/api/electron_api_power_monitor.h
+++ b/shell/browser/api/electron_api_power_monitor.h
@@ -17,12 +17,12 @@
 
 namespace electron::api {
 
-class PowerMonitor : public gin::Wrappable<PowerMonitor>,
-                     public gin_helper::EventEmitterMixin<PowerMonitor>,
-                     public gin_helper::Pinnable<PowerMonitor>,
-                     public base::PowerStateObserver,
-                     public base::PowerSuspendObserver,
-                     public base::PowerThermalObserver {
+class PowerMonitor final : public gin::Wrappable<PowerMonitor>,
+                           public gin_helper::EventEmitterMixin<PowerMonitor>,
+                           public gin_helper::Pinnable<PowerMonitor>,
+                           public base::PowerStateObserver,
+                           public base::PowerSuspendObserver,
+                           public base::PowerThermalObserver {
  public:
   static v8::Local<v8::Value> Create(v8::Isolate* isolate);
 

--- a/shell/browser/api/electron_api_power_save_blocker.h
+++ b/shell/browser/api/electron_api_power_save_blocker.h
@@ -14,7 +14,7 @@
 
 namespace electron::api {
 
-class PowerSaveBlocker : public gin::Wrappable<PowerSaveBlocker> {
+class PowerSaveBlocker final : public gin::Wrappable<PowerSaveBlocker> {
  public:
   static gin::Handle<PowerSaveBlocker> Create(v8::Isolate* isolate);
 

--- a/shell/browser/api/electron_api_protocol.h
+++ b/shell/browser/api/electron_api_protocol.h
@@ -40,8 +40,8 @@ enum class ProtocolError {
 };
 
 // Protocol implementation based on network services.
-class Protocol : public gin::Wrappable<Protocol>,
-                 public gin_helper::Constructible<Protocol> {
+class Protocol final : public gin::Wrappable<Protocol>,
+                       public gin_helper::Constructible<Protocol> {
  public:
   static gin::Handle<Protocol> Create(v8::Isolate* isolate,
                                       ElectronBrowserContext* browser_context);

--- a/shell/browser/api/electron_api_push_notifications.h
+++ b/shell/browser/api/electron_api_push_notifications.h
@@ -17,7 +17,7 @@
 
 namespace electron::api {
 
-class PushNotifications
+class PushNotifications final
     : public ElectronBrowserClient::Delegate,
       public gin::Wrappable<PushNotifications>,
       public gin_helper::EventEmitterMixin<PushNotifications>,

--- a/shell/browser/api/electron_api_screen.h
+++ b/shell/browser/api/electron_api_screen.h
@@ -22,9 +22,9 @@ class Screen;
 
 namespace electron::api {
 
-class Screen : public gin::Wrappable<Screen>,
-               public gin_helper::EventEmitterMixin<Screen>,
-               public display::DisplayObserver {
+class Screen final : public gin::Wrappable<Screen>,
+                     public gin_helper::EventEmitterMixin<Screen>,
+                     public display::DisplayObserver {
  public:
   static v8::Local<v8::Value> Create(gin_helper::ErrorThrower error_thrower);
 

--- a/shell/browser/api/electron_api_service_worker_context.h
+++ b/shell/browser/api/electron_api_service_worker_context.h
@@ -18,7 +18,7 @@ class ElectronBrowserContext;
 
 namespace api {
 
-class ServiceWorkerContext
+class ServiceWorkerContext final
     : public gin::Wrappable<ServiceWorkerContext>,
       public gin_helper::EventEmitterMixin<ServiceWorkerContext>,
       public content::ServiceWorkerContextObserver {

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -60,18 +60,18 @@ class ElectronBrowserContext;
 
 namespace api {
 
-class Session : public gin::Wrappable<Session>,
-                public gin_helper::Pinnable<Session>,
-                public gin_helper::Constructible<Session>,
-                public gin_helper::EventEmitterMixin<Session>,
-                public gin_helper::CleanedUpAtExit,
+class Session final : public gin::Wrappable<Session>,
+                      public gin_helper::Pinnable<Session>,
+                      public gin_helper::Constructible<Session>,
+                      public gin_helper::EventEmitterMixin<Session>,
+                      public gin_helper::CleanedUpAtExit,
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
-                public SpellcheckHunspellDictionary::Observer,
+                      public SpellcheckHunspellDictionary::Observer,
 #endif
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-                public extensions::ExtensionRegistryObserver,
+                      public extensions::ExtensionRegistryObserver,
 #endif
-                public content::DownloadManager::Observer {
+                      public content::DownloadManager::Observer {
  public:
   // Gets or creates Session from the |browser_context|.
   static gin::Handle<Session> CreateFrom(

--- a/shell/browser/api/electron_api_system_preferences.h
+++ b/shell/browser/api/electron_api_system_preferences.h
@@ -31,7 +31,7 @@ enum class NotificationCenterKind {
 };
 #endif
 
-class SystemPreferences
+class SystemPreferences final
     : public gin::Wrappable<SystemPreferences>,
       public gin_helper::EventEmitterMixin<SystemPreferences>
 #if BUILDFLAG(IS_WIN)

--- a/shell/browser/api/electron_api_tray.h
+++ b/shell/browser/api/electron_api_tray.h
@@ -34,12 +34,12 @@ namespace electron::api {
 
 class Menu;
 
-class Tray : public gin::Wrappable<Tray>,
-             public gin_helper::EventEmitterMixin<Tray>,
-             public gin_helper::Constructible<Tray>,
-             public gin_helper::CleanedUpAtExit,
-             public gin_helper::Pinnable<Tray>,
-             public TrayIconObserver {
+class Tray final : public gin::Wrappable<Tray>,
+                   public gin_helper::EventEmitterMixin<Tray>,
+                   public gin_helper::Constructible<Tray>,
+                   public gin_helper::CleanedUpAtExit,
+                   public gin_helper::Pinnable<Tray>,
+                   public TrayIconObserver {
  public:
   // gin_helper::Constructible
   static gin::Handle<Tray> New(gin_helper::ErrorThrower thrower,

--- a/shell/browser/api/electron_api_utility_process.h
+++ b/shell/browser/api/electron_api_utility_process.h
@@ -36,7 +36,7 @@ class Process;
 
 namespace electron::api {
 
-class UtilityProcessWrapper
+class UtilityProcessWrapper final
     : public gin::Wrappable<UtilityProcessWrapper>,
       public gin_helper::Pinnable<UtilityProcessWrapper>,
       public gin_helper::EventEmitterMixin<UtilityProcessWrapper>,

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1896,7 +1896,7 @@ void WebContents::OnFirstNonEmptyLayout(
 // This object wraps the InvokeCallback so that if it gets GC'd by V8, we can
 // still call the callback and send an error. Not doing so causes a Mojo DCHECK,
 // since Mojo requires callbacks to be called before they are destroyed.
-class ReplyChannel : public gin::Wrappable<ReplyChannel> {
+class ReplyChannel final : public gin::Wrappable<ReplyChannel> {
  public:
   using InvokeCallback = electron::mojom::ElectronApiIPC::InvokeCallback;
   static gin::Handle<ReplyChannel> Create(v8::Isolate* isolate,

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -103,19 +103,19 @@ namespace api {
 class BaseWindow;
 
 // Wrapper around the content::WebContents.
-class WebContents : public ExclusiveAccessContext,
-                    public gin::Wrappable<WebContents>,
-                    public gin_helper::EventEmitterMixin<WebContents>,
-                    public gin_helper::Constructible<WebContents>,
-                    public gin_helper::Pinnable<WebContents>,
-                    public gin_helper::CleanedUpAtExit,
-                    public content::WebContentsObserver,
-                    public content::WebContentsDelegate,
-                    public content::RenderWidgetHost::InputEventObserver,
-                    public content::JavaScriptDialogManager,
-                    public InspectableWebContentsDelegate,
-                    public InspectableWebContentsViewDelegate,
-                    public BackgroundThrottlingSource {
+class WebContents final : public ExclusiveAccessContext,
+                          public gin::Wrappable<WebContents>,
+                          public gin_helper::EventEmitterMixin<WebContents>,
+                          public gin_helper::Constructible<WebContents>,
+                          public gin_helper::Pinnable<WebContents>,
+                          public gin_helper::CleanedUpAtExit,
+                          public content::WebContentsObserver,
+                          public content::WebContentsDelegate,
+                          public content::RenderWidgetHost::InputEventObserver,
+                          public content::JavaScriptDialogManager,
+                          public InspectableWebContentsDelegate,
+                          public InspectableWebContentsViewDelegate,
+                          public BackgroundThrottlingSource {
  public:
   enum class Type {
     kBackgroundPage,  // An extension background page.

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -35,10 +35,10 @@ namespace electron::api {
 class WebContents;
 
 // Bindings for accessing frames from the main process.
-class WebFrameMain : public gin::Wrappable<WebFrameMain>,
-                     public gin_helper::EventEmitterMixin<WebFrameMain>,
-                     public gin_helper::Pinnable<WebFrameMain>,
-                     public gin_helper::Constructible<WebFrameMain> {
+class WebFrameMain final : public gin::Wrappable<WebFrameMain>,
+                           public gin_helper::EventEmitterMixin<WebFrameMain>,
+                           public gin_helper::Pinnable<WebFrameMain>,
+                           public gin_helper::Constructible<WebFrameMain> {
  public:
   // Create a new WebFrameMain and return the V8 wrapper of it.
   static gin::Handle<WebFrameMain> New(v8::Isolate* isolate);

--- a/shell/browser/api/electron_api_web_request.h
+++ b/shell/browser/api/electron_api_web_request.h
@@ -22,7 +22,8 @@ class BrowserContext;
 
 namespace electron::api {
 
-class WebRequest : public gin::Wrappable<WebRequest>, public WebRequestAPI {
+class WebRequest final : public gin::Wrappable<WebRequest>,
+                         public WebRequestAPI {
  public:
   // Return the WebRequest object attached to |browser_context|, create if there
   // is no one.

--- a/shell/browser/api/message_port.h
+++ b/shell/browser/api/message_port.h
@@ -24,9 +24,9 @@ class Handle;
 namespace electron {
 
 // A non-blink version of blink::MessagePort.
-class MessagePort : public gin::Wrappable<MessagePort>,
-                    public gin_helper::CleanedUpAtExit,
-                    public mojo::MessageReceiver {
+class MessagePort final : public gin::Wrappable<MessagePort>,
+                          public gin_helper::CleanedUpAtExit,
+                          public mojo::MessageReceiver {
  public:
   ~MessagePort() override;
   static gin::Handle<MessagePort> Create(v8::Isolate* isolate);

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -43,7 +43,7 @@ class Arguments;
 
 namespace electron::api {
 
-class NativeImage : public gin::Wrappable<NativeImage> {
+class NativeImage final : public gin::Wrappable<NativeImage> {
  public:
   NativeImage(v8::Isolate* isolate, const gfx::Image& image);
 #if BUILDFLAG(IS_WIN)

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -160,8 +160,9 @@ class BufferDataSource : public mojo::DataPipeProducer::DataSource {
   std::vector<char> buffer_;
 };
 
-class JSChunkedDataPipeGetter : public gin::Wrappable<JSChunkedDataPipeGetter>,
-                                public network::mojom::ChunkedDataPipeGetter {
+class JSChunkedDataPipeGetter final
+    : public gin::Wrappable<JSChunkedDataPipeGetter>,
+      public network::mojom::ChunkedDataPipeGetter {
  public:
   static gin::Handle<JSChunkedDataPipeGetter> Create(
       v8::Isolate* isolate,

--- a/shell/common/api/electron_api_url_loader.h
+++ b/shell/common/api/electron_api_url_loader.h
@@ -43,7 +43,7 @@ class ElectronBrowserContext;
 namespace electron::api {
 
 /** Wraps a SimpleURLLoader to make it usable from JavaScript */
-class SimpleURLLoaderWrapper
+class SimpleURLLoaderWrapper final
     : public gin::Wrappable<SimpleURLLoaderWrapper>,
       public gin_helper::EventEmitterMixin<SimpleURLLoaderWrapper>,
       public network::SimpleURLLoaderStreamConsumer,

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -252,7 +252,7 @@ bool Converter<net::HttpRequestHeaders>::FromV8(v8::Isolate* isolate,
   return true;
 }
 
-class ChunkedDataPipeReadableStream
+class ChunkedDataPipeReadableStream final
     : public gin::Wrappable<ChunkedDataPipeReadableStream> {
  public:
   static gin::Handle<ChunkedDataPipeReadableStream> Create(

--- a/shell/common/gin_helper/event.h
+++ b/shell/common/gin_helper/event.h
@@ -19,8 +19,8 @@ class ObjectTemplate;
 
 namespace gin_helper::internal {
 
-class Event : public gin::Wrappable<Event>,
-              public gin_helper::Constructible<Event> {
+class Event final : public gin::Wrappable<Event>,
+                    public gin_helper::Constructible<Event> {
  public:
   // gin_helper::Constructible
   static gin::Handle<Event> New(v8::Isolate* isolate);

--- a/shell/renderer/api/electron_api_ipc_renderer.cc
+++ b/shell/renderer/api/electron_api_ipc_renderer.cc
@@ -41,8 +41,8 @@ RenderFrame* GetCurrentRenderFrame() {
   return RenderFrame::FromWebFrame(frame);
 }
 
-class IPCRenderer : public gin::Wrappable<IPCRenderer>,
-                    public content::RenderFrameObserver {
+class IPCRenderer final : public gin::Wrappable<IPCRenderer>,
+                          public content::RenderFrameObserver {
  public:
   static gin::WrapperInfo kWrapperInfo;
 

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -329,8 +329,8 @@ class SpellCheckerHolder final : public content::RenderFrameObserver {
 
 }  // namespace
 
-class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
-                         public content::RenderFrameObserver {
+class WebFrameRenderer final : public gin::Wrappable<WebFrameRenderer>,
+                               public content::RenderFrameObserver {
  public:
   static gin::WrapperInfo kWrapperInfo;
 

--- a/shell/services/node/parent_port.h
+++ b/shell/services/node/parent_port.h
@@ -30,8 +30,8 @@ namespace electron {
 // There is only a single instance of this class
 // for the lifetime of a Utility Process which
 // also means that GC lifecycle is ignored by this class.
-class ParentPort : public gin::Wrappable<ParentPort>,
-                   public mojo::MessageReceiver {
+class ParentPort final : public gin::Wrappable<ParentPort>,
+                         public mojo::MessageReceiver {
  public:
   static ParentPort* GetInstance();
   static gin::Handle<ParentPort> Create(v8::Isolate* isolate);


### PR DESCRIPTION
Manually backport #43527 to 31-x-y. See that PR for details.

Notes: none.