### PR TITLE
build: compile Node.js with C++20 support (32-x-y)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       id: set-output
       run: |
         if [ -z "${{ inputs.build-image-sha }}" ]; then
-          echo "build-image-sha=cf814a4d2501e8e843caea071a6b70a48e78b855" >> "$GITHUB_OUTPUT"
+          echo "build-image-sha=77262e58c37631ab082482f42c33cdf68c6c394b" >> "$GITHUB_OUTPUT"
         else
           echo "build-image-sha=${{ inputs.build-image-sha }}" >> "$GITHUB_OUTPUT"
         fi

--- a/patches/node/.patches
+++ b/patches/node/.patches
@@ -51,3 +51,4 @@ fix_add_property_query_interceptors.patch
 src_account_for_openssl_unexpected_version.patch
 src_use_supported_api_to_get_stalled_tla_messages.patch
 build_don_t_redefine_win32_lean_and_mean.patch
+build_compile_with_c_20_support.patch

--- a/patches/node/build_compile_with_c_20_support.patch
+++ b/patches/node/build_compile_with_c_20_support.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Wed, 4 Sep 2024 16:39:23 +0200
+Subject: build: compile with C++20 support
+
+Refs https://github.com/nodejs/node/pull/45427
+
+V8 requires C++20 support as of https://chromium-review.googlesource.com/c/v8/v8/+/5587859.
+
+This can be removed when Electron upgrades to a version of Node.js containing the required V8 version.
+
+diff --git a/common.gypi b/common.gypi
+index 8736ad12eec294070a5160a64248044cd16347c9..216200c279c599f6dee228120ff5f3943fa52ffd 100644
+--- a/common.gypi
++++ b/common.gypi
+@@ -307,7 +307,7 @@
+       'VCCLCompilerTool': {
+         'AdditionalOptions': [
+           '/Zc:__cplusplus',
+-          '-std:c++17'
++          '-std:c++20'
+         ],
+         'BufferSecurityCheck': 'true',
+         'DebugInformationFormat': 1,          # /Z7 embed info in .obj files
+@@ -489,7 +489,7 @@
+       }],
+       [ 'OS in "linux freebsd openbsd solaris android aix os400 cloudabi"', {
+         'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', ],
+-        'cflags_cc': [ '-fno-rtti', '-fno-exceptions', '-std=gnu++17' ],
++        'cflags_cc': [ '-fno-rtti', '-fno-exceptions', '-std=gnu++20' ],
+         'defines': [ '__STDC_FORMAT_MACROS' ],
+         'ldflags': [ '-rdynamic' ],
+         'target_conditions': [
+@@ -660,7 +660,7 @@
+           ['clang==1', {
+             'xcode_settings': {
+               'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0',
+-              'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++17',  # -std=gnu++17
++              'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++20',  # -std=gnu++20
+               'CLANG_CXX_LIBRARY': 'libc++',
+             },
+           }],

--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -186,13 +186,9 @@ async function runMainProcessElectronTests () {
 }
 
 async function installSpecModules (dir) {
-  // v8 headers use c++17 so override the gyp default of -std=c++14,
-  // but don't clobber any other CXXFLAGS that were passed into spec-runner.js
-  const CXXFLAGS = ['-std=c++17', process.env.CXXFLAGS].filter(x => !!x).join(' ');
-
   const env = {
     ...process.env,
-    CXXFLAGS,
+    CXXFLAGS: process.env.CXXFLAGS,
     npm_config_msvs_version: '2019',
     npm_config_yes: 'true'
   };


### PR DESCRIPTION
Manually backport #43555 to 32-x-y. See that PR for details.

Notes: none