### PR TITLE
docs: document Windows pitfall when updating patches

### DIFF
--- a/docs/development/patches.md
+++ b/docs/development/patches.md
@@ -65,6 +65,8 @@ $ git rebase --autosquash -i [COMMIT_SHA]^
 $ ../electron/script/git-export-patches -o ../electron/patches/v8
 ```
 
+Note that the `^` symbol [can cause trouble on Windows](https://stackoverflow.com/questions/14203952/git-reset-asks-more/14204318#14204318). The workaround is to either quote it `"[COMMIT_SHA]^"` or avoid it `[COMMIT_SHA]~1`.
+
 #### Removing a patch
 
 ```bash


### PR DESCRIPTION
#### Description of Change

Document a potential patching pitfall that surprised @mlaurencin, @jkleinsc, and me :dizzy: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.