### PR TITLE
refactor: NotificationPresenter::Create() returns a std::unique_ptr<>

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -966,9 +966,8 @@ ElectronBrowserClient::CreateDevToolsManagerDelegate() {
 }
 
 NotificationPresenter* ElectronBrowserClient::GetNotificationPresenter() {
-  if (!notification_presenter_) {
-    notification_presenter_.reset(NotificationPresenter::Create());
-  }
+  if (!notification_presenter_)
+    notification_presenter_ = NotificationPresenter::Create();
   return notification_presenter_.get();
 }
 

--- a/shell/browser/notifications/linux/notification_presenter_linux.cc
+++ b/shell/browser/notifications/linux/notification_presenter_linux.cc
@@ -10,10 +10,10 @@
 namespace electron {
 
 // static
-NotificationPresenter* NotificationPresenter::Create() {
-  if (!LibnotifyNotification::Initialize())
-    return nullptr;
-  return new NotificationPresenterLinux;
+std::unique_ptr<NotificationPresenter> NotificationPresenter::Create() {
+  if (LibnotifyNotification::Initialize())
+    return std::make_unique<NotificationPresenterLinux>();
+  return {};
 }
 
 NotificationPresenterLinux::NotificationPresenterLinux() = default;

--- a/shell/browser/notifications/mac/notification_presenter_mac.mm
+++ b/shell/browser/notifications/mac/notification_presenter_mac.mm
@@ -17,8 +17,8 @@
 namespace electron {
 
 // static
-NotificationPresenter* NotificationPresenter::Create() {
-  return new NotificationPresenterMac;
+std::unique_ptr<NotificationPresenter> NotificationPresenter::Create() {
+  return std::make_unique<NotificationPresenterMac>();
 }
 
 CocoaNotification* NotificationPresenterMac::GetNotification(

--- a/shell/browser/notifications/notification_presenter.h
+++ b/shell/browser/notifications/notification_presenter.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_NOTIFICATIONS_NOTIFICATION_PRESENTER_H_
 #define ELECTRON_SHELL_BROWSER_NOTIFICATIONS_NOTIFICATION_PRESENTER_H_
 
+#include <memory>
 #include <set>
 #include <string>
 
@@ -17,7 +18,7 @@ class NotificationDelegate;
 
 class NotificationPresenter {
  public:
-  static NotificationPresenter* Create();
+  static std::unique_ptr<NotificationPresenter> Create();
 
   virtual ~NotificationPresenter();
 

--- a/shell/browser/notifications/win/notification_presenter_win.cc
+++ b/shell/browser/notifications/win/notification_presenter_win.cc
@@ -42,17 +42,17 @@ bool SaveIconToPath(const SkBitmap& bitmap, const base::FilePath& path) {
 }  // namespace
 
 // static
-NotificationPresenter* NotificationPresenter::Create() {
+std::unique_ptr<NotificationPresenter> NotificationPresenter::Create() {
   if (!WindowsToastNotification::Initialize())
-    return nullptr;
+    return {};
   auto presenter = std::make_unique<NotificationPresenterWin>();
   if (!presenter->Init())
-    return nullptr;
+    return {};
 
   if (IsDebuggingNotifications())
     LOG(INFO) << "Successfully created Windows notifications presenter";
 
-  return presenter.release();
+  return presenter;
 }
 
 NotificationPresenterWin::NotificationPresenterWin() = default;


### PR DESCRIPTION
#### Description of Change

Cleanup PR to make `NotificationPresenter::Create()` follow Chromium's  [object ownership calling conventions](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md#object-ownership-and-calling-conventions): ownership of the new object is being handed off to the caller, so return it as a `std::unique_ptr<NotificationPresenter>`.

Related: #43361

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.