### PR TITLE
fix: -Wunsafe-buffer-usage warnings in Clipboard::WriteBuffer()

### DIFF
--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -114,8 +114,10 @@ void Clipboard::WriteBuffer(const std::string& format,
   CHECK(buffer->IsArrayBufferView());
   v8::Local<v8::ArrayBufferView> buffer_view = buffer.As<v8::ArrayBufferView>();
   const size_t n_bytes = buffer_view->ByteLength();
-  mojo_base::BigBuffer big_buffer(n_bytes);
-  buffer_view->CopyContents(big_buffer.data(), n_bytes);
+  mojo_base::BigBuffer big_buffer{n_bytes};
+  [[maybe_unused]] const size_t n_got =
+      buffer_view->CopyContents(big_buffer.data(), n_bytes);
+  DCHECK_EQ(n_got, n_bytes);
 
   ui::ScopedClipboardWriter writer(GetClipboardBuffer(args));
   writer.WriteUnsafeRawData(base::UTF8ToUTF16(format), std::move(big_buffer));

--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -111,12 +111,14 @@ void Clipboard::WriteBuffer(const std::string& format,
     return;
   }
 
+  CHECK(buffer->IsArrayBufferView());
+  v8::Local<v8::ArrayBufferView> buffer_view = buffer.As<v8::ArrayBufferView>();
+  const size_t n_bytes = buffer_view->ByteLength();
+  mojo_base::BigBuffer big_buffer(n_bytes);
+  buffer_view->CopyContents(big_buffer.data(), n_bytes);
+
   ui::ScopedClipboardWriter writer(GetClipboardBuffer(args));
-  base::span<const uint8_t> payload_span(
-      reinterpret_cast<const uint8_t*>(node::Buffer::Data(buffer)),
-      node::Buffer::Length(buffer));
-  writer.WriteUnsafeRawData(base::UTF8ToUTF16(format),
-                            mojo_base::BigBuffer(payload_span));
+  writer.WriteUnsafeRawData(base::UTF8ToUTF16(format), std::move(big_buffer));
 }
 
 void Clipboard::Write(const gin_helper::Dictionary& data,


### PR DESCRIPTION
#### Description of Change

Part 5 in a [series](https://github.com/electron/electron/pull/43477) to fix `-Wunsafe-buffer-usage` warnings in electron `shell/`.

This PR fixes a warning in `electron::api::Clipboard::WriteBuffer()`. The warning happened while copying a `v8::ArrayBufferView` into a `mojo::BigBuffer`. Previously we did this by using an unsafe `base::span constructor` to feed to the big buffer. Like #43564, this PR uses [`v8::ArrayBufferView::CopyContents()`](https://chromium.googlesource.com/v8/v8/+/287f5002404a3d08df6b42de1081f89ace1927ea/include/v8-array-buffer.h#386) as an alternative to unsafe pointer math.

The warning fixed by this PR:

```
../../electron/shell/common/api/electron_api_clipboard.cc:115:29: error: function introduces unsafe buffer manipulation [-Werror,-Wunsafe-buffer-usage]
  115 |   base::span<const uint8_t> payload_span(
      |                             ^~~~~~~~~~~~~
  116 |       reinterpret_cast<const uint8_t*>(node::Buffer::Data(buffer)),
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  117 |       node::Buffer::Length(buffer));
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.