### PR TITLE
fix: -Wunsafe-buffer-usage warnings in GetNextZoomLevel()

### DIFF
--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -6,6 +6,7 @@
 #include "shell/browser/ui/inspectable_web_contents.h"
 
 #include <algorithm>
+#include <array>
 #include <memory>
 #include <string_view>
 #include <utility>
@@ -69,10 +70,6 @@ namespace electron {
 
 namespace {
 
-const double kPresetZoomFactors[] = {0.25, 0.333, 0.5,  0.666, 0.75, 0.9,
-                                     1.0,  1.1,   1.25, 1.5,   1.75, 2.0,
-                                     2.5,  3.0,   4.0,  5.0};
-
 const char kChromeUIDevToolsURL[] =
     "devtools://devtools/bundled/devtools_app.html?"
     "remoteBase=%s&"
@@ -121,16 +118,20 @@ void SetZoomLevelForWebContents(content::WebContents* web_contents,
   content::HostZoomMap::SetZoomLevel(web_contents, level);
 }
 
-double GetNextZoomLevel(double level, bool out) {
-  double factor = blink::ZoomLevelToZoomFactor(level);
-  size_t size = std::size(kPresetZoomFactors);
-  for (size_t i = 0; i < size; ++i) {
-    if (!blink::ZoomValuesEqual(kPresetZoomFactors[i], factor))
-      continue;
-    if (out && i > 0)
-      return blink::ZoomFactorToZoomLevel(kPresetZoomFactors[i - 1]);
-    if (!out && i != size - 1)
-      return blink::ZoomFactorToZoomLevel(kPresetZoomFactors[i + 1]);
+double GetNextZoomLevel(const double level, const bool out) {
+  static constexpr std::array<double, 16U> kPresetFactors{
+      0.25, 0.333, 0.5,  0.666, 0.75, 0.9, 1.0, 1.1,
+      1.25, 1.5,   1.75, 2.0,   2.5,  3.0, 4.0, 5.0};
+  static constexpr auto kBegin = kPresetFactors.begin();
+  static constexpr auto kEnd = kPresetFactors.end();
+
+  const double factor = blink::ZoomLevelToZoomFactor(level);
+  auto matches = [=](auto val) { return blink::ZoomValuesEqual(factor, val); };
+  if (auto iter = std::find_if(kBegin, kEnd, matches); iter != kEnd) {
+    if (out && iter != kBegin)
+      return blink::ZoomFactorToZoomLevel(*--iter);
+    if (!out && ++iter != kEnd)
+      return blink::ZoomFactorToZoomLevel(*iter);
   }
   return level;
 }


### PR DESCRIPTION
#### Description of Change

Part 6 in a [series](https://github.com/electron/electron/pull/43477) to fix `-Wunsafe-buffer-usage` warnings in electron `shell/`.

This PR fixes three warnings in `GetNextZoomLevel()`. The previous code is reasonable IMO but still kicks a clang warning because of its use of pointer math. :man_shrugging: This PR uses iterators and begin / end / find_if instead.

The warnings fixed by this PR:

```
../../electron/shell/browser/ui/inspectable_web_contents.cc:128:33: error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
  128 |     if (!blink::ZoomValuesEqual(kPresetZoomFactors[i], factor))
      |                                 ^~~~~~~~~~~~~~~~~~
../../electron/shell/browser/ui/inspectable_web_contents.cc:128:33: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
../../electron/shell/browser/ui/inspectable_web_contents.cc:131:43: error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
  131 |       return blink::ZoomFactorToZoomLevel(kPresetZoomFactors[i - 1]);
      |                                           ^~~~~~~~~~~~~~~~~~
../../electron/shell/browser/ui/inspectable_web_contents.cc:131:43: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
../../electron/shell/browser/ui/inspectable_web_contents.cc:133:43: error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
  133 |       return blink::ZoomFactorToZoomLevel(kPresetZoomFactors[i + 1]);
      |                                           ^~~~~~~~~~~~~~~~~~
../../electron/shell/browser/ui/inspectable_web_contents.cc:133:43: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.