### PR TITLE
build: stop dependabot doing things

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,7 +52,7 @@ updates:
       interval: daily
     labels:
       - "no-backport"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
     target-branch: 33-x-y
   - package-ecosystem: npm
     directories:
@@ -63,7 +63,7 @@ updates:
       interval: daily
     labels:
       - "no-backport"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     target-branch: main
   - package-ecosystem: npm
     directories:
@@ -74,7 +74,7 @@ updates:
       interval: daily
     labels:
       - "no-backport"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     target-branch: 32-x-y
   - package-ecosystem: npm
     directories:
@@ -85,7 +85,7 @@ updates:
       interval: daily
     labels:
       - "no-backport"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     target-branch: 31-x-y
   - package-ecosystem: npm
     directories:
@@ -96,5 +96,5 @@ updates:
       interval: daily
     labels:
       - "no-backport"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     target-branch: 30-x-y


### PR DESCRIPTION
Per the docs setting the PR limit to 0 keeps security updates but stops the "hey you wanna update this dep for no reason" PRs.

I left the "hey you wanna update this dep" PRs on for `main` with a limit of 2 per day because we should stay up to date with stuff, but like, it's not that important.

Notes: none