### PR TITLE
fix: `createWindow` shouldn't load URL for `webContents`

### DIFF
--- a/lib/browser/guest-window-manager.ts
+++ b/lib/browser/guest-window-manager.ts
@@ -71,14 +71,6 @@ export function openGuestWindow ({ embedder, guest, referrer, disposition, postD
         throw new Error('Invalid webContents. Created window should be connected to webContents passed with options object.');
       }
 
-      webContents.loadURL(url, {
-        httpReferrer: referrer,
-        ...(postData && {
-          postData,
-          extraHeaders: formatPostDataHeaders(postData as Electron.UploadRawData[])
-        })
-      });
-
       handleWindowLifecycleEvents({ embedder, frameName, guest, outlivesOpener });
     }
 

--- a/spec/guest-window-manager-spec.ts
+++ b/spec/guest-window-manager-spec.ts
@@ -234,6 +234,10 @@ describe('webContents.setWindowOpenHandler', () => {
             response.statusCode = 200;
             response.end('<title>Child page</title>');
             break;
+          case '/test':
+            response.statusCode = 200;
+            response.end('<title>Test page</title>');
+            break;
           default:
             throw new Error(`Unsupported endpoint: ${request.url}`);
         }
@@ -306,7 +310,33 @@ describe('webContents.setWindowOpenHandler', () => {
       expect(childWindow.title).to.equal(browserWindowTitle);
     });
 
-    it('spawns browser window with overriden options', async () => {
+    it('should be able to access the child window document when createWindow is provided', async () => {
+      browserWindow.webContents.setWindowOpenHandler(() => {
+        return {
+          action: 'allow',
+          createWindow: (options) => {
+            const child = new BrowserWindow(options);
+            return child.webContents;
+          }
+        };
+      });
+
+      const aboutBlankTitle = await browserWindow.webContents.executeJavaScript(`
+        const win1 = window.open('about:blank', '', 'show=no');
+        win1.document.title = 'about-blank-title';
+        win1.document.title;
+      `);
+      expect(aboutBlankTitle).to.equal('about-blank-title');
+
+      const serverPageTitle = await browserWindow.webContents.executeJavaScript(`
+        const win2 = window.open('${url}/child', '', 'show=no');
+        win2.document.title = 'server-page-title';
+        win2.document.title;
+      `);
+      expect(serverPageTitle).to.equal('server-page-title');
+    });
+
+    it('spawns browser window with overridden options', async () => {
       const childWindow = await new Promise<Electron.BrowserWindow>(resolve => {
         browserWindow.webContents.setWindowOpenHandler(() => {
           return {


### PR DESCRIPTION
Backport of #43775.

See that PR for details.

Notes: Fixed a potential issue accessing a child window document when overriding browserWindow creation via `setWindowOpenHandler`.