### PR TITLE
refactor: prefer member initializers in asar structs

### DIFF
--- a/shell/common/asar/archive.cc
+++ b/shell/common/asar/archive.cc
@@ -156,17 +156,14 @@ bool FillFileInfoWithNode(Archive::FileInfo* info,
 
 }  // namespace
 
-IntegrityPayload::IntegrityPayload()
-    : algorithm(HashAlgorithm::kNone), block_size(0) {}
+IntegrityPayload::IntegrityPayload() = default;
 IntegrityPayload::~IntegrityPayload() = default;
 IntegrityPayload::IntegrityPayload(const IntegrityPayload& other) = default;
 
-Archive::FileInfo::FileInfo()
-    : unpacked(false), executable(false), size(0), offset(0) {}
+Archive::FileInfo::FileInfo() = default;
 Archive::FileInfo::~FileInfo() = default;
 
-Archive::Archive(const base::FilePath& path)
-    : initialized_(false), path_(path), file_(base::File::FILE_OK) {
+Archive::Archive(const base::FilePath& path) : path_{path} {
   electron::ScopedAllowBlockingForElectron allow_blocking;
   file_.Initialize(path_, base::File::FLAG_OPEN | base::File::FLAG_READ);
 #if BUILDFLAG(IS_WIN)

--- a/shell/common/asar/archive.h
+++ b/shell/common/asar/archive.h
@@ -31,9 +31,9 @@ struct IntegrityPayload {
   IntegrityPayload();
   ~IntegrityPayload();
   IntegrityPayload(const IntegrityPayload& other);
-  HashAlgorithm algorithm;
+  HashAlgorithm algorithm = HashAlgorithm::kNone;
   std::string hash;
-  uint32_t block_size;
+  uint32_t block_size = 0U;
   std::vector<std::string> blocks;
 };
 
@@ -44,10 +44,10 @@ class Archive {
   struct FileInfo {
     FileInfo();
     ~FileInfo();
-    bool unpacked;
-    bool executable;
-    uint32_t size;
-    uint64_t offset;
+    bool unpacked = false;
+    bool executable = false;
+    uint32_t size = 0U;
+    uint64_t offset = 0U;
     std::optional<IntegrityPayload> integrity;
   };
 
@@ -100,10 +100,10 @@ class Archive {
   base::FilePath path() const { return path_; }
 
  private:
-  bool initialized_;
+  bool initialized_ = false;
   bool header_validated_ = false;
   const base::FilePath path_;
-  base::File file_;
+  base::File file_{base::File::FILE_OK};
   int fd_ = -1;
   uint32_t header_size_ = 0;
   std::optional<base::Value::Dict> header_;


### PR DESCRIPTION
#### Description of Change

refactor: prefer member initializers in `asar::Archive`, `asar::Archive::FileInfo`, and `asar::IntegrityPayload`

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none