### PR TITLE
refactor: remove C-style void arg type for no-arg functions

### DIFF
--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -89,17 +89,17 @@ class OffScreenRenderWidgetHostView
   void InitAsChild(gfx::NativeView) override;
   void SetSize(const gfx::Size&) override;
   void SetBounds(const gfx::Rect&) override;
-  gfx::NativeView GetNativeView(void) override;
-  gfx::NativeViewAccessible GetNativeViewAccessible(void) override;
+  gfx::NativeView GetNativeView() override;
+  gfx::NativeViewAccessible GetNativeViewAccessible() override;
   ui::TextInputClient* GetTextInputClient() override;
   void Focus() override {}
   bool HasFocus() override;
   uint32_t GetCaptureSequenceNumber() const override;
-  bool IsSurfaceAvailableForCopy(void) override;
-  void Hide(void) override;
-  bool IsShowing(void) override;
+  bool IsSurfaceAvailableForCopy() override;
+  void Hide() override;
+  bool IsShowing() override;
   void EnsureSurfaceSynchronizedForWebTest() override;
-  gfx::Rect GetViewBounds(void) override;
+  gfx::Rect GetViewBounds() override;
   gfx::Size GetVisibleViewportSize() override;
   void SetInsets(const gfx::Insets&) override {}
   void SetBackgroundColor(SkColor color) override;
@@ -109,7 +109,7 @@ class OffScreenRenderWidgetHostView
       bool request_unadjusted_movement) override;
   blink::mojom::PointerLockResult ChangePointerLock(
       bool request_unadjusted_movement) override;
-  void UnlockPointer(void) override {}
+  void UnlockPointer() override {}
   void TakeFallbackContentFrom(content::RenderWidgetHostView* view) override;
 #if BUILDFLAG(IS_MAC)
   void SetActive(bool active) override {}
@@ -137,10 +137,10 @@ class OffScreenRenderWidgetHostView
   void SetIsLoading(bool is_loading) override {}
   void TextInputStateChanged(const ui::mojom::TextInputState& params) override {
   }
-  void ImeCancelComposition(void) override {}
+  void ImeCancelComposition() override {}
   void RenderProcessGone() override;
   void ShowWithVisibility(content::PageVisibilityState page_visibility) final;
-  void Destroy(void) override;
+  void Destroy() override;
   void UpdateTooltipUnderCursor(const std::u16string&) override {}
   input::CursorManager* GetCursorManager() override;
   void CopyFromSurface(
@@ -149,7 +149,7 @@ class OffScreenRenderWidgetHostView
       base::OnceCallback<void(const SkBitmap&)> callback) override;
   display::ScreenInfo GetScreenInfo() const override;
   void TransformPointToRootSurface(gfx::PointF* point) override {}
-  gfx::Rect GetBoundsInRootWindow(void) override;
+  gfx::Rect GetBoundsInRootWindow() override;
   std::optional<content::DisplayFeature> GetDisplayFeature() override;
   void SetDisplayFeatureForTesting(
       const content::DisplayFeature* display_feature) override {}

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -47,11 +47,11 @@ class DeleteFileProgressSink : public IFileOperationProgressSink {
 
  private:
   // IFileOperationProgressSink
-  ULONG STDMETHODCALLTYPE AddRef(void) override;
-  ULONG STDMETHODCALLTYPE Release(void) override;
+  ULONG STDMETHODCALLTYPE AddRef() override;
+  ULONG STDMETHODCALLTYPE Release() override;
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid,
                                            LPVOID* ppvObj) override;
-  HRESULT STDMETHODCALLTYPE StartOperations(void) override;
+  HRESULT STDMETHODCALLTYPE StartOperations() override;
   HRESULT STDMETHODCALLTYPE FinishOperations(HRESULT) override;
   HRESULT STDMETHODCALLTYPE PreRenameItem(DWORD, IShellItem*, LPCWSTR) override;
   HRESULT STDMETHODCALLTYPE
@@ -90,9 +90,9 @@ class DeleteFileProgressSink : public IFileOperationProgressSink {
                                         HRESULT,
                                         IShellItem*) override;
   HRESULT STDMETHODCALLTYPE UpdateProgress(UINT, UINT) override;
-  HRESULT STDMETHODCALLTYPE ResetTimer(void) override;
-  HRESULT STDMETHODCALLTYPE PauseTimer(void) override;
-  HRESULT STDMETHODCALLTYPE ResumeTimer(void) override;
+  HRESULT STDMETHODCALLTYPE ResetTimer() override;
+  HRESULT STDMETHODCALLTYPE PauseTimer() override;
+  HRESULT STDMETHODCALLTYPE ResumeTimer() override;
 
   ULONG m_cRef;
 };


### PR DESCRIPTION
#### Description of Change

A small cleanup to remove use of the C-style function declaration idiom.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none