### PR TITLE
fix: -Wunsafe-buffer-usage warning in asar_util's ReadFileToString()

### DIFF
--- a/shell/common/asar/asar_util.cc
+++ b/shell/common/asar/asar_util.cc
@@ -126,11 +126,8 @@ bool ReadFileToString(const base::FilePath& path, std::string* contents) {
     return false;
 
   contents->resize(info.size);
-  if (static_cast<int>(info.size) !=
-      src.Read(info.offset, const_cast<char*>(contents->data()),
-               contents->size())) {
+  if (!src.ReadAndCheck(info.offset, base::as_writable_byte_span(*contents)))
     return false;
-  }
 
   if (info.integrity)
     ValidateIntegrityOrDie(base::as_byte_span(*contents), *info.integrity);


### PR DESCRIPTION
#### Description of Change

Part 7 in a [series](https://github.com/electron/electron/pull/43477) to fix `-Wunsafe-buffer-usage` warnings in electron `shell/`. This fixes an asar `base::File` API call, similar to [an earlier](https://github.com/electron/electron/pull/43624) asar fix in the series.

The warning fixed by this PR:

```
../../electron/shell/common/asar/asar_util.cc:130:7: error: function introduces unsafe buffer manipulation [-Werror,-Wunsafe-buffer-usage]
  130 |       src.Read(info.offset, const_cast<char*>(contents->data()),
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  131 |                contents->size())) {
      |                ~~~~~~~~~~~~~~~~~
../../electron/shell/common/asar/asar_util.cc:130:7: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.