### PR TITLE
build: use Node 20 in Appveyor images

### DIFF
--- a/appveyor-bake.yml
+++ b/appveyor-bake.yml
@@ -68,7 +68,7 @@ build_script:
   - ps: $env:PATH="$pwd\depot_tools;$env:PATH"
   - update_depot_tools.bat
   # Uncomment the following line if windows deps change
-  # - src\electron\script\setup-win-for-dev.bat
+  - src\electron\script\setup-win-for-dev.bat
   - >-
       gclient config
       --name "src\electron"

--- a/appveyor-bake.yml
+++ b/appveyor-bake.yml
@@ -68,7 +68,7 @@ build_script:
   - ps: $env:PATH="$pwd\depot_tools;$env:PATH"
   - update_depot_tools.bat
   # Uncomment the following line if windows deps change
-  - src\electron\script\setup-win-for-dev.bat
+  # - src\electron\script\setup-win-for-dev.bat
   - >-
       gclient config
       --name "src\electron"

--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -29,7 +29,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: e-130.0.6695.0
+image: e-130.0.6695.0-node-20
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: e-130.0.6695.0
+image: e-130.0.6695.0-node-20
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default

--- a/script/setup-win-for-dev.bat
+++ b/script/setup-win-for-dev.bat
@@ -56,11 +56,14 @@ REM Install Windows SDK
 choco install windows-sdk-11-version-22h2-all
 
 REM Install nodejs python git and yarn needed dependencies
-choco install -y --force nodejs --version=18.12.1
+choco install -y --force nodejs --version=20.9.0
 choco install -y python2 git yarn
 choco install python --version 3.7.9
 call C:\ProgramData\chocolatey\bin\RefreshEnv.cmd
 SET PATH=C:\Python27\;C:\Python27\Scripts;C:\Python39\;C:\Python39\Scripts;%PATH%
+if not exist "C:\Users\appveyor\AppData\Roaming\npm" (
+  mkdir "C:\Users\appveyor\AppData\Roaming\npm"
+)
 
 REM Setup Depot Tools
 git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git C:\depot_tools


### PR DESCRIPTION
#### Description of Change

Upgrades our Appveyor base images to use Node 20 instead of Node 18.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
