### PR TITLE
test: ensure `sender-pid` hint is set in Linux notifications

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -75,6 +75,7 @@ if (is_linux) {
       "notify_notification_set_timeout",
       "notify_notification_set_urgency",
       "notify_notification_set_hint_string",
+      "notify_notification_set_hint",
       "notify_notification_show",
       "notify_notification_close",
     ]

--- a/shell/browser/notifications/linux/libnotify_notification.cc
+++ b/shell/browser/notifications/linux/libnotify_notification.cc
@@ -10,6 +10,7 @@
 #include "base/files/file_enumerator.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
+#include "base/process/process_handle.h"
 #include "base/strings/utf_string_conversions.h"
 #include "shell/browser/notifications/notification_delegate.h"
 #include "shell/browser/ui/gtk_util.h"
@@ -144,6 +145,10 @@ void LibnotifyNotification::Show(const NotificationOptions& options) {
     libnotify_loader_.notify_notification_set_hint_string(
         notification_, "desktop-entry", desktop_id.c_str());
   }
+
+  libnotify_loader_.notify_notification_set_hint(
+      notification_, "sender-pid",
+      g_variant_new_int64(base::GetCurrentProcId()));
 
   GError* error = nullptr;
   libnotify_loader_.notify_notification_show(notification_, &error);

--- a/spec/api-notification-dbus-spec.ts
+++ b/spec/api-notification-dbus-spec.ts
@@ -118,6 +118,7 @@ ifdescribe(!skip)('Notification module (dbus)', () => {
         hints: {
           append: 'true',
           'desktop-entry': appName,
+          'sender-pid': process.pid,
           urgency: 1
         }
       });


### PR DESCRIPTION
#### Description of Change

This PR ensures that the `sender-pid` hint is set for new notifications. It also updates the spec to confirm that DBus receives the hint and that it has the correct value.

This fixes a spec failure when running libnotify >= 0.7.12 (2022-05-05). Starting with that version, libnotify [started injecting `sender-pid` if not provided by the client](https://github.com/GNOME/libnotify/commit/1fba04bc032ad65bedf43e74c2d53121440613f4#diff-e8f7068b3a06ea7f520fc8773e06c46d3ad2f97ff78a7c16a6394030e587d115R824). So our tests received a slightly different DBus payload depending on the libnotify version, causing our deep-equals tests to fail.

By always providing and testing the `sender-pid` hint, both our behavior and our tests should be consistent across distros.

Sample test failure:

```
not ok 1 Notification module (dbus) Notification module using org.freedesktop.Notifications should call org.freedesktop.Notifications to show notifications
  expected { app_name: 'api-notification-dbus-spec', replaces_id: +0, app_icon: '', title: 'title', body: 'body', actions: [], hints: { 'desktop-entry': 'api-notification-dbus-spec', append: 'true', urgency: 1, 'sender-pid': 1057127 } } to deeply equal { app_name: 'api-notification-dbus-spec', replaces_id: +0, app_icon: '', title: 'title', body: 'body', actions: [], hints: { append: 'true', 'desktop-entry': 'api-notification-dbus-spec', urgency: 1 } }
  AssertionError: expected { app_name: 'api-notification-dbus-spec', replaces_id: +0, app_icon: '', title: 'title', body: 'body', actions: [], hints: { 'desktop-entry': 'api-notification-dbus-spec', append: 'true', urgency: 1, 'sender-pid': 1057127 } } to deeply equal { app_name: 'api-notification-dbus-spec', replaces_id: +0, app_icon: '', title: 'title', body: 'body', actions: [], hints: { append: 'true', 'desktop-entry': 'api-notification-dbus-spec', urgency: 1 } }
      at Context.<anonymous> (electron/spec/api-notification-dbus-spec.ts:111:28)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Ensured that the `sender-id` hint is set when creating desktop notifications on DBus.