### PR TITLE
fix: -Wunsafe-buffer-usage warnings in GdkPixbufFromSkBitmap()

### DIFF
--- a/shell/browser/ui/gtk_util.cc
+++ b/shell/browser/ui/gtk_util.cc
@@ -71,11 +71,8 @@ GdkPixbuf* GdkPixbufFromSkBitmap(const SkBitmap& bitmap) {
   if (bitmap.isNull())
     return {};
 
-  const auto [width, height] = bitmap.dimensions();
-  if (width < 1 || height < 1)
-    return {};
-
   constexpr int kBytesPerPixel = 4;
+  const auto [width, height] = bitmap.dimensions();
   std::vector<uint8_t> bytes;
   bytes.reserve(width * height * kBytesPerPixel);
   for (int y = 0; y < height; ++y) {


### PR DESCRIPTION
#### Description of Change

OK, now that #43938 has some tests in place for `GdkPixbufFromSkBitmap()`... This is part 8 in a [series](https://github.com/electron/electron/pull/43477) to fix `-Wunsafe-buffer-usage` warnings in electron `shell/`. This one fixes these `GdkPixbufFromSkBitmap()` warnings:

```
../../electron/shell/browser/ui/gtk_util.cc:87:31: error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
   87 |       uint32_t pixel = bitmap.getAddr32(0, y)[x];
      |                        ~~~~~~~^~~~~~~~~~~~~~~
../../electron/shell/browser/ui/gtk_util.cc:87:31: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
../../electron/shell/browser/ui/gtk_util.cc:92:9: error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
   92 |         divided[i + 0] = SkColorGetR(unmultiplied);
      |         ^~~~~~~
../../electron/shell/browser/ui/gtk_util.cc:92:9: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
../../electron/shell/browser/ui/gtk_util.cc:93:9: error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
   93 |         divided[i + 1] = SkColorGetG(unmultiplied);
      |         ^~~~~~~
../../electron/shell/browser/ui/gtk_util.cc:93:9: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
../../electron/shell/browser/ui/gtk_util.cc:94:9: error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
   94 |         divided[i + 2] = SkColorGetB(unmultiplied);
      |         ^~~~~~~
../../electron/shell/browser/ui/gtk_util.cc:94:9: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
../../electron/shell/browser/ui/gtk_util.cc:95:9: error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
   95 |         divided[i + 3] = alpha;
      |         ^~~~~~~
../../electron/shell/browser/ui/gtk_util.cc:95:9: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
../../electron/shell/browser/ui/gtk_util.cc:97:9: error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
   97 |         divided[i + 0] = SkColorGetR(pixel);
      |         ^~~~~~~
../../electron/shell/browser/ui/gtk_util.cc:97:9: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
../../electron/shell/browser/ui/gtk_util.cc:98:9: error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
   98 |         divided[i + 1] = SkColorGetG(pixel);
      |         ^~~~~~~
../../electron/shell/browser/ui/gtk_util.cc:98:9: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
../../electron/shell/browser/ui/gtk_util.cc:99:9: error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
   99 |         divided[i + 2] = SkColorGetB(pixel);
      |         ^~~~~~~
../../electron/shell/browser/ui/gtk_util.cc:99:9: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
../../electron/shell/browser/ui/gtk_util.cc:100:9: error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
  100 |         divided[i + 3] = alpha;
      |         ^~~~~~~
../../electron/shell/browser/ui/gtk_util.cc:100:9: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
```

Implementation note: `SkUnPreMultiply::PMColorToColor()` is no longer needed because we're now calling `SkBItmap.getColor()`, which does alpha handling & unpremultiplication for us

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.