### PR TITLE
chore: cherry-pick 2 changes from 0-M129

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -3,3 +3,5 @@ deps_add_v8_object_setinternalfieldfornodecore.patch
 revert_heap_add_checks_position_info.patch
 revert_api_cleanup_remove_setaccessor_and_setnativedataproperty.patch
 spill_all_loop_inputs_before_entering_loop.patch
+cherry-pick-d224d038eba7.patch
+cherry-pick-50645cf964ba.patch

--- a/patches/v8/cherry-pick-50645cf964ba.patch
+++ b/patches/v8/cherry-pick-50645cf964ba.patch
@@ -1,0 +1,113 @@
+From 50645cf964ba96cf44c75fed9790d981a5dd9010 Mon Sep 17 00:00:00 2001
+From: Thibaud Michaud <thibaudm@chromium.org>
+Date: Fri, 20 Sep 2024 15:17:52 +0200
+Subject: [PATCH] [wasm] Add some regression tests
+
+R=clemensb@chromium.org
+
+Bug: 361123483,361717714,362539773
+Change-Id: Ie212596f88d0dfa46269bfcdfc2ca24e9570fb76
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5876288
+Commit-Queue: Thibaud Michaud <thibaudm@chromium.org>
+Reviewed-by: Clemens Backes <clemensb@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#96227}
+---
+
+diff --git a/test/mjsunit/mjsunit.status b/test/mjsunit/mjsunit.status
+index 1cb75ef..f8ef70d 100644
+--- a/test/mjsunit/mjsunit.status
++++ b/test/mjsunit/mjsunit.status
+@@ -2185,7 +2185,9 @@
+   'regress/wasm/regress-336358915': [SKIP],
+   'regress/wasm/regress-342522151': [SKIP],
+   'regress/wasm/regress-349640002': [SKIP],
+-  'regress/wasm/regress-364667545': [SKIP]
++  'regress/wasm/regress-364667545': [SKIP],
++  'regress/wasm/regress-361123483': [SKIP],
++  'regress/wasm/regress-361717714': [SKIP]
+ }],  # (arch != x64 and arch != arm64 and arch != ia32 and arch != arm and arch != riscv64 and arch != loong64)
+ 
+ ##############################################################################
+diff --git a/test/mjsunit/regress/wasm/regress-361123483.js b/test/mjsunit/regress/wasm/regress-361123483.js
+new file mode 100644
+index 0000000..547405e
+--- /dev/null
++++ b/test/mjsunit/regress/wasm/regress-361123483.js
+@@ -0,0 +1,21 @@
++// Copyright 2024 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// Flags: --experimental-wasm-jspi --turboshaft-wasm
++
++d8.file.execute('test/mjsunit/wasm/wasm-module-builder.js');
++
++let builder = new WasmModuleBuilder();
++let import_index = builder.addImport('m', 'i', kSig_i_v);
++builder.addFunction('main', kSig_v_v).addBody([
++    kExprCallFunction, import_index,
++    kExprDrop,
++    kExprCallFunction, import_index,
++    kExprDrop,
++]).exportFunc();
++let instance = builder.instantiate({m: {
++  i: new WebAssembly.Suspending(() => 0)
++}});
++let async_main = WebAssembly.promising(instance.exports.main);
++async_main();
+diff --git a/test/mjsunit/regress/wasm/regress-361717714.js b/test/mjsunit/regress/wasm/regress-361717714.js
+new file mode 100644
+index 0000000..3cd8fd7
+--- /dev/null
++++ b/test/mjsunit/regress/wasm/regress-361717714.js
+@@ -0,0 +1,26 @@
++// Copyright 2024 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// Flags: --experimental-wasm-jspi
++
++function f0() {
++  d8.file.execute('test/mjsunit/wasm/wasm-module-builder.js');
++  let builder = new WasmModuleBuilder();
++  builder.addFunction("w0", kSig_v_v).addBody([
++      kExprLoop, kWasmVoid,
++      kExprBr, 0,
++      kExprEnd
++  ]).exportFunc();
++  const v6 = builder.instantiate();
++  const v7 = v6.exports;
++  let v9 = WebAssembly.promising(v7.w0);
++  postMessage("start");
++  v9();
++}
++const o13 = {
++    "type": "function",
++};
++let worker = new Worker(f0, o13);
++assertEquals("start", worker.getMessage());
++worker.terminateAndWait();
+diff --git a/test/mjsunit/regress/wasm/regress-362539773.js b/test/mjsunit/regress/wasm/regress-362539773.js
+new file mode 100644
+index 0000000..662d53a
+--- /dev/null
++++ b/test/mjsunit/regress/wasm/regress-362539773.js
+@@ -0,0 +1,18 @@
++// Copyright 2024 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// Flags: --wasm-wrapper-tiering-budget=1
++// Flags: --experimental-wasm-type-reflection
++
++d8.file.execute('test/mjsunit/wasm/wasm-module-builder.js');
++const builder = new WasmModuleBuilder();
++const _type = builder.addType(kSig_v_v);
++const _import = builder.addImport('m', 'foo', _type);
++builder.addExportOfKind(_type, builder, _import);
++builder.addFunction('main', _type).addBody([]).exportFunc();
++const func = new WebAssembly.Function(
++  { parameters: [], results: [] },
++  () => {});
++const instance = builder.instantiate({ 'm': { 'foo': func } });
++instance.exports.main();

--- a/patches/v8/cherry-pick-d224d038eba7.patch
+++ b/patches/v8/cherry-pick-d224d038eba7.patch
@@ -1,0 +1,66 @@
+From d224d038eba7d355009c24bf485141321583307a Mon Sep 17 00:00:00 2001
+From: Thibaud Michaud <thibaudm@chromium.org>
+Date: Tue, 10 Sep 2024 10:52:38 +0200
+Subject: [PATCH] [M126-LTS][wasm][jspi] Fix JSPI + lazy deopt
+
+With JSPI, the stack frame iterator stops at the end of the current
+stack segment. Follow the chain of stacks to find all frames marked for
+deoptimization.
+
+R=mliedtke@chromium.org
+
+Fixed: 365376497
+Change-Id: Iff1112dbd2a86a014c8de6d844f585fd568ad552
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5850428
+Commit-Queue: Thibaud Michaud <thibaudm@chromium.org>
+Reviewed-by: Matthias Liedtke <mliedtke@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#96028}
+(cherry picked from commit 906e41b88fa5b79d2afc699f8c4da87c4eb9c7e5)
+---
+
+diff --git a/src/deoptimizer/deoptimizer.cc b/src/deoptimizer/deoptimizer.cc
+index c09e825..8786ce6 100644
+--- a/src/deoptimizer/deoptimizer.cc
++++ b/src/deoptimizer/deoptimizer.cc
+@@ -336,6 +336,21 @@
+   // for the trampoline to the deoptimizer call respective to each code, and use
+   // it to replace the current pc on the stack.
+   void VisitThread(Isolate* isolate, ThreadLocalTop* top) override {
++#if V8_ENABLE_WEBASSEMBLY
++    // Also visit the ancestors of the active stack for wasm stack switching.
++    // We don't need to visit suspended stacks at the moment, because 1) they
++    // only contain wasm frames and 2) wasm does not do lazy deopt. Revisit this
++    // if one of these assumptions changes.
++    Tagged<WasmContinuationObject> continuation;
++    if (top == isolate->thread_local_top()) {
++      Tagged<Object> maybe_continuation =
++          isolate->root(RootIndex::kActiveContinuation);
++      if (!IsUndefined(maybe_continuation)) {
++        continuation = Cast<WasmContinuationObject>(maybe_continuation);
++      }
++    }
++#endif
++
+     for (StackFrameIterator it(isolate, top); !it.done(); it.Advance()) {
+       if (it.frame()->is_optimized()) {
+         Tagged<GcSafeCode> code = it.frame()->GcSafeLookupCode();
+@@ -369,6 +384,19 @@
+           }
+         }
+       }
++
++#if V8_ENABLE_WEBASSEMBLY
++      // We reached the base of the wasm stack. Follow the chain of
++      // continuations to find the parent stack and reset the iterator.
++      if (it.frame()->type() == StackFrame::STACK_SWITCH) {
++        CHECK_EQ(top, isolate->thread_local_top());
++        DCHECK(!continuation.is_null());
++        continuation = Cast<WasmContinuationObject>(continuation->parent());
++        wasm::StackMemory* parent =
++            reinterpret_cast<wasm::StackMemory*>(continuation->stack());
++        it.Reset(top, parent);
++      }
++#endif
+     }
+   }
+ 


### PR DESCRIPTION
<details>
<summary>electron/security#581 - d224d038eba7 from v8</summary>
[M126-LTS][wasm][jspi] Fix JSPI + lazy deopt

With JSPI, the stack frame iterator stops at the end of the current
stack segment. Follow the chain of stacks to find all frames marked for
deoptimization.

R=mliedtke@chromium.org

Fixed: 365376497
Change-Id: Iff1112dbd2a86a014c8de6d844f585fd568ad552
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5850428
Commit-Queue: Thibaud Michaud <thibaudm@chromium.org>
Reviewed-by: Matthias Liedtke <mliedtke@chromium.org>
Cr-Commit-Position: refs/heads/main@{#96028}
(cherry picked from commit 906e41b88fa5b79d2afc699f8c4da87c4eb9c7e5)
</details>

<details>
<summary>electron/security#582 - 50645cf964ba from v8</summary>
[wasm] Add some regression tests

R=clemensb@chromium.org

Bug: 361123483,361717714,362539773
Change-Id: Ie212596f88d0dfa46269bfcdfc2ca24e9570fb76
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5876288
Commit-Queue: Thibaud Michaud <thibaudm@chromium.org>
Reviewed-by: Clemens Backes <clemensb@chromium.org>
Cr-Commit-Position: refs/heads/main@{#96227}
</details>

Notes:
* Security: backported fix for CVE-2024-8904.
* Security: backported fix for 361123483.