### PR TITLE
fix: replace deprecated libnotify API calls

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -74,7 +74,6 @@ if (is_linux) {
       "notify_notification_set_image_from_pixbuf",
       "notify_notification_set_timeout",
       "notify_notification_set_urgency",
-      "notify_notification_set_hint_string",
       "notify_notification_set_hint",
       "notify_notification_show",
       "notify_notification_close",

--- a/shell/browser/notifications/linux/libnotify_notification.cc
+++ b/shell/browser/notifications/linux/libnotify_notification.cc
@@ -131,19 +131,20 @@ void LibnotifyNotification::Show(const NotificationOptions& options) {
   // Always try to append notifications.
   // Unique tags can be used to prevent this.
   if (HasCapability("append")) {
-    libnotify_loader_.notify_notification_set_hint_string(notification_,
-                                                          "append", "true");
+    libnotify_loader_.notify_notification_set_hint(
+        notification_, "append", g_variant_new_string("true"));
   } else if (HasCapability("x-canonical-append")) {
-    libnotify_loader_.notify_notification_set_hint_string(
-        notification_, "x-canonical-append", "true");
+    libnotify_loader_.notify_notification_set_hint(
+        notification_, "x-canonical-append", g_variant_new_string("true"));
   }
 
   // Send the desktop name to identify the application
   // The desktop-entry is the part before the .desktop
   std::string desktop_id = platform_util::GetXdgAppId();
   if (!desktop_id.empty()) {
-    libnotify_loader_.notify_notification_set_hint_string(
-        notification_, "desktop-entry", desktop_id.c_str());
+    libnotify_loader_.notify_notification_set_hint(
+        notification_, "desktop-entry",
+        g_variant_new_string(desktop_id.c_str()));
   }
 
   libnotify_loader_.notify_notification_set_hint(


### PR DESCRIPTION
#### Description of Change

notify_notification_set_hint_string() is deprecated, so let's use notify_notification_set_hint() instead.

Xref: https://github.com/GNOME/libnotify/commit/2fe1748295c97cd8251e1711e0f54c4d65633d48

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.