### PR TITLE
chore: remove unused nogncheck includes

### DIFF
--- a/shell/app/electron_content_client.cc
+++ b/shell/app/electron_content_client.cc
@@ -35,7 +35,6 @@
 
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
 #include "components/pdf/common/constants.h"  // nogncheck
-#include "pdf/pdf.h"                          // nogncheck
 #include "shell/common/electron_constants.h"
 #endif  // BUILDFLAG(ENABLE_PDF_VIEWER)
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -185,10 +185,6 @@
 #endif
 #endif  // BUILDFLAG(ENABLE_PRINTING)
 
-#if BUILDFLAG(ENABLE_PDF_VIEWER)
-#include "components/pdf/browser/pdf_document_helper.h"  // nogncheck
-#endif
-
 #if BUILDFLAG(ENABLE_PLUGINS)
 #include "content/public/browser/plugin_service.h"
 #endif

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -7,6 +7,10 @@
 #include <fcntl.h>
 #include <stdlib.h>
 
+#if BUILDFLAG(IS_LINUX)
+#include <gtk/gtk.h>
+#endif
+
 #include "base/command_line.h"
 #include "base/environment.h"
 #include "base/process/launch.h"
@@ -21,7 +25,6 @@
 
 #if BUILDFLAG(IS_LINUX)
 #include "shell/browser/linux/unity_service.h"
-#include "ui/gtk/gtk_util.h"  // nogncheck
 #endif
 
 namespace electron {

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -31,7 +31,6 @@
 #include "components/net_log/chrome_net_log.h"
 #include "components/network_hints/common/network_hints.mojom.h"
 #include "content/browser/keyboard_lock/keyboard_lock_service_impl.h"  // nogncheck
-#include "content/browser/site_instance_impl.h"  // nogncheck
 #include "content/public/browser/browser_main_runner.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/client_certificate_delegate.h"

--- a/shell/browser/extensions/electron_extensions_api_client.cc
+++ b/shell/browser/extensions/electron_extensions_api_client.cc
@@ -22,10 +22,6 @@
 #include "shell/browser/printing/print_view_manager_electron.h"
 #endif
 
-#if BUILDFLAG(ENABLE_PDF_VIEWER)
-#include "components/pdf/browser/pdf_document_helper.h"  // nogncheck
-#endif
-
 namespace extensions {
 
 class ElectronGuestViewManagerDelegate

--- a/shell/browser/notifications/linux/libnotify_notification.cc
+++ b/shell/browser/notifications/linux/libnotify_notification.cc
@@ -17,7 +17,6 @@
 #include "shell/common/application_info.h"
 #include "shell/common/platform_util.h"
 #include "third_party/skia/include/core/SkBitmap.h"
-#include "ui/gtk/gtk_util.h"  // nogncheck
 
 namespace electron {
 

--- a/shell/browser/ui/file_dialog_linux.cc
+++ b/shell/browser/ui/file_dialog_linux.cc
@@ -17,8 +17,8 @@
 #include "shell/common/gin_converters/file_path_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/promise.h"
-#include "ui/gtk/select_file_dialog_linux_gtk.h"  // nogncheck
 #include "ui/shell_dialogs/select_file_dialog.h"
+#include "ui/shell_dialogs/select_file_policy.h"
 #include "ui/shell_dialogs/selected_file_info.h"
 
 namespace file_dialog {

--- a/shell/common/application_info_linux.cc
+++ b/shell/common/application_info_linux.cc
@@ -12,7 +12,6 @@
 #include "base/logging.h"
 #include "electron/electron_version.h"
 #include "shell/common/platform_util.h"
-#include "ui/gtk/gtk_util.h"  // nogncheck
 
 namespace {
 

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -33,7 +33,6 @@
 #include "dbus/message.h"
 #include "dbus/object_proxy.h"
 #include "shell/common/platform_util_internal.h"
-#include "ui/gtk/gtk_util.h"  // nogncheck
 #include "url/gurl.h"
 
 #define ELECTRON_TRASH "ELECTRON_TRASH"


### PR DESCRIPTION
#### Description of Change

Remove a handful of `#include "foo" // nogncheck` calls that weren't actually being used. Inspired by https://github.com/electron/electron/pull/43960.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.