### PR TITLE
fix: remove resize listener when BrowserWindow closed

### DIFF
--- a/lib/browser/api/browser-view.ts
+++ b/lib/browser/api/browser-view.ts
@@ -68,10 +68,7 @@ export default class BrowserView {
   // a webContents can be closed by the user while the BrowserView
   // remains alive and attached to a BrowserWindow.
   set ownerWindow (w: BrowserWindow | null) {
-    if (this.#ownerWindow && this.#resizeListener) {
-      this.#ownerWindow.off('resize', this.#resizeListener);
-      this.#resizeListener = null;
-    }
+    this.#removeResizeListener();
 
     if (this.webContents && !this.webContents.isDestroyed()) {
       this.webContents._setOwnerWindow(w);
@@ -82,6 +79,7 @@ export default class BrowserView {
       this.#lastWindowSize = w.getBounds();
       w.on('resize', this.#resizeListener = this.#autoResize.bind(this));
       w.on('closed', () => {
+        this.#removeResizeListener();
         this.#ownerWindow = null;
         this.#destroyListener = null;
       });
@@ -92,6 +90,13 @@ export default class BrowserView {
     // Ensure that if #webContentsView's webContents is destroyed,
     // the WebContentsView is removed from the view hierarchy.
     this.#ownerWindow?.contentView.removeChildView(this.webContentsView);
+  }
+
+  #removeResizeListener () {
+    if (this.#ownerWindow && this.#resizeListener) {
+      this.#ownerWindow.off('resize', this.#resizeListener);
+      this.#resizeListener = null;
+    }
   }
 
   #autoHorizontalProportion: {width: number, left: number} | null = null;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/43927.

Fixed an issue where an exception could be thrown on BrowserView after its owner BrowserWindow was closed. We need to ensure the resize listener is removed on closed to fix this. It relies on a race condition so we really can't add a test for it.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where an exception could be thrown on BrowserView after its owner BrowserWindow was closed.