### PR TITLE
ci: write test logging to console on Windows

### DIFF
--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -328,4 +328,3 @@ for:
     on_finish:
       # Uncomment these lines to enable RDP
       # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-      - if exist electron\electron.log ( appveyor-retry appveyor PushArtifact electron\electron.log )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -308,7 +308,7 @@ for:
           if ($env:TARGET_ARCH -eq 'ia32') {
             $env:npm_config_arch = "ia32"
           }
-      - echo Running main test suite & node script/yarn test -- --trace-uncaught --runners=main --enable-logging=file --log-file=%cd%\electron.log
+      - echo Running main test suite & node script/yarn test -- --trace-uncaught --runners=main --enable-logging
       - cd ..
       - echo Verifying non proprietary ffmpeg & python electron\script\verify-ffmpeg.py --build-dir out\Default --source-root %cd% --ffmpeg-path out\ffmpeg
       - echo "About to verify mksnapshot"
@@ -320,4 +320,3 @@ for:
     on_finish:
       # Uncomment these lines to enable RDP
       # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-      - if exist electron\electron.log ( appveyor-retry appveyor PushArtifact electron\electron.log )


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Windows testing (on x64 and ia32) on AppVeyor was throwing the following error during testing:
```ERROR:logging.cc(148)] Failed to init logging: Access is denied. (0x5)```
I investigated this error and it appears that it is simply a contention issue writing to an error log. (https://ci.appveyor.com/project/electron-bot/electron-ia32-testing/builds/50689680/job/hw1k8991ug0jkkve contains some additional debugging to try to track down this issue). In looking at the rest of our CI configurations, we do not write to an error log file but instead log errors to the console.  This PR moves our Windows testing on AppVeyor to write logging to the console to be consistent with the rest of CI.
 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
