### PR TITLE
fix: FTBFS when building with `enable_plugins = false`

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -674,10 +674,10 @@ source_set("electron_lib") {
 
   if (enable_plugins) {
     sources += [
-      "shell/common/plugin_info.cc",
-      "shell/common/plugin_info.h",
       "shell/browser/electron_plugin_info_host_impl.cc",
       "shell/browser/electron_plugin_info_host_impl.h",
+      "shell/common/plugin_info.cc",
+      "shell/common/plugin_info.h",
     ]
   }
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -676,6 +676,8 @@ source_set("electron_lib") {
     sources += [
       "shell/common/plugin_info.cc",
       "shell/common/plugin_info.h",
+      "shell/browser/electron_plugin_info_host_impl.cc",
+      "shell/browser/electron_plugin_info_host_impl.h",
     ]
   }
 

--- a/filenames.gni
+++ b/filenames.gni
@@ -379,8 +379,6 @@ filenames = {
     "shell/browser/electron_navigation_throttle.h",
     "shell/browser/electron_permission_manager.cc",
     "shell/browser/electron_permission_manager.h",
-    "shell/browser/electron_plugin_info_host_impl.cc",
-    "shell/browser/electron_plugin_info_host_impl.h",
     "shell/browser/electron_speech_recognition_manager_delegate.cc",
     "shell/browser/electron_speech_recognition_manager_delegate.h",
     "shell/browser/electron_web_contents_utility_handler_impl.cc",

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1458,6 +1458,7 @@ void ElectronBrowserClient::
                                                       render_frame_host);
           },
           &render_frame_host));
+#if BUILDFLAG(ENABLE_PLUGINS)
   associated_registry.AddInterface<mojom::ElectronPluginInfoHost>(
       base::BindRepeating(
           [](content::RenderFrameHost* render_frame_host,
@@ -1468,6 +1469,7 @@ void ElectronBrowserClient::
                 std::move(receiver));
           },
           &render_frame_host));
+#endif
 #if BUILDFLAG(ENABLE_PRINTING)
   associated_registry.AddInterface<printing::mojom::PrintManagerHost>(
       base::BindRepeating(

--- a/shell/browser/printing/printing_utils.cc
+++ b/shell/browser/printing/printing_utils.cc
@@ -15,10 +15,13 @@
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"
 #include "electron/buildflags/buildflags.h"
-#include "pdf/pdf_features.h"
 #include "printing/backend/print_backend.h"  // nogncheck
 #include "printing/units.h"
 #include "shell/common/thread_restrictions.h"
+
+#if BUILDFLAG(ENABLE_PDF_VIEWER)
+#include "pdf/pdf_features.h"
+#endif
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 #include "extensions/browser/guest_view/mime_handler_view/mime_handler_view_guest.h"


### PR DESCRIPTION
#### Description of Change

Fix a FTBFS regression in 33-x-y and main that prevents Electron from building when plugins are disabled.

CC @mlaurencin 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a build failure when the `enable_plugins` build flag is false.