### PR TITLE
docs: clarify interplay between utility process events

### DIFF
--- a/docs/api/utility-process.md
+++ b/docs/api/utility-process.md
@@ -127,6 +127,9 @@ Returns:
 
 Emitted when the child process needs to terminate due to non continuable error from V8.
 
+No matter if you listen to the `error` event, the `exit` event will be emitted after the
+child process terminates.
+
 #### Event: 'exit'
 
 Returns:


### PR DESCRIPTION
#### Description of Change

It's useful to mention in the docs that the `exit` event is emitted no matter if you listen to the `error` event or not.

CC @deepak1556

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none