### PR TITLE
fix: -Wunsafe-buffer-usage warnings in AddComponentResourceEntries()

### DIFF
--- a/shell/browser/extensions/electron_component_extension_resource_manager.cc
+++ b/shell/browser/extensions/electron_component_extension_resource_manager.cc
@@ -24,10 +24,9 @@ namespace extensions {
 
 ElectronComponentExtensionResourceManager::
     ElectronComponentExtensionResourceManager() {
-  AddComponentResourceEntries(kComponentExtensionResources,
-                              kComponentExtensionResourcesSize);
+  AddComponentResourceEntries(kComponentExtensionResources);
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
-  AddComponentResourceEntries(kPdfResources, kPdfResourcesSize);
+  AddComponentResourceEntries(kPdfResources);
 
   // Register strings for the PDF viewer, so that $i18n{} replacements work.
   base::Value::Dict pdf_strings;
@@ -80,20 +79,18 @@ ElectronComponentExtensionResourceManager::GetTemplateReplacementsForExtension(
 }
 
 void ElectronComponentExtensionResourceManager::AddComponentResourceEntries(
-    const webui::ResourcePath* entries,
-    size_t size) {
+    const base::span<const webui::ResourcePath> entries) {
   base::FilePath gen_folder_path = base::FilePath().AppendASCII(
       "@out_folder@/gen/chrome/browser/resources/");
   gen_folder_path = gen_folder_path.NormalizePathSeparators();
 
-  for (size_t i = 0; i < size; ++i) {
-    base::FilePath resource_path =
-        base::FilePath().AppendASCII(entries[i].path);
+  for (const auto& entry : entries) {
+    base::FilePath resource_path = base::FilePath().AppendASCII(entry.path);
     resource_path = resource_path.NormalizePathSeparators();
 
     if (!gen_folder_path.IsParent(resource_path)) {
       DCHECK(!base::Contains(path_to_resource_id_, resource_path));
-      path_to_resource_id_[resource_path] = entries[i].id;
+      path_to_resource_id_[resource_path] = entry.id;
     } else {
       // If the resource is a generated file, strip the generated folder's path,
       // so that it can be served from a normal URL (as if it were not
@@ -102,7 +99,7 @@ void ElectronComponentExtensionResourceManager::AddComponentResourceEntries(
           base::FilePath().AppendASCII(resource_path.AsUTF8Unsafe().substr(
               gen_folder_path.value().length()));
       DCHECK(!base::Contains(path_to_resource_id_, effective_path));
-      path_to_resource_id_[effective_path] = entries[i].id;
+      path_to_resource_id_[effective_path] = entry.id;
     }
   }
 }

--- a/shell/browser/extensions/electron_component_extension_resource_manager.h
+++ b/shell/browser/extensions/electron_component_extension_resource_manager.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <string>
 
+#include "base/containers/span.h"
 #include "base/files/file_path.h"
 #include "extensions/browser/component_extension_resource_manager.h"
 #include "ui/base/webui/resource_path.h"
@@ -38,8 +39,8 @@ class ElectronComponentExtensionResourceManager
       const std::string& extension_id) const override;
 
  private:
-  void AddComponentResourceEntries(const webui::ResourcePath* entries,
-                                   size_t size);
+  void AddComponentResourceEntries(
+      base::span<const webui::ResourcePath> entries);
 
   // A map from a resource path to the resource ID.  Used by
   // IsComponentExtensionResource.


### PR DESCRIPTION
#### Description of Change

Part 10 in a [series](https://github.com/electron/electron/pull/43477) to fix `-Wunsafe-buffer-usage` warnings in `shell/`.

The change is very simple this time: replace the pointer-and-size-args idiom with a `base::span`:

```diff
- foo(const Item* items, size_t n_items)
+ foo(const base::span<const Item> items)
```

Warnings fixed by this PR:

```
../../electron/shell/browser/extensions/electron_component_extension_resource_manager.cc:91:38: error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
   91 |         base::FilePath().AppendASCII(entries[i].path);
      |                                      ^~~~~~~
../../electron/shell/browser/extensions/electron_component_extension_resource_manager.cc:91:38: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
../../electron/shell/browser/extensions/electron_component_extension_resource_manager.cc:96:45: error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
   96 |       path_to_resource_id_[resource_path] = entries[i].id;
      |                                             ^~~~~~~
../../electron/shell/browser/extensions/electron_component_extension_resource_manager.cc:96:45: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
../../electron/shell/browser/extensions/electron_component_extension_resource_manager.cc:105:46: error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
  105 |       path_to_resource_id_[effective_path] = entries[i].id;
      |                                              ^~~~~~~
../../electron/shell/browser/extensions/electron_component_extension_resource_manager.cc:105:46: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.