### PR TITLE
build: update appveyor to node 20.17

### DIFF
--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -29,7 +29,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: e-131.0.6734.0-node-20.17
+image: e-131.0.6734.0-node-20.17-1
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default

--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -29,7 +29,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: e-131.0.6734.0
+image: e-131.0.6734.0-node-20.17
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: e-131.0.6734.0-node-20.17
+image: e-131.0.6734.0-node-20.17-1
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: e-131.0.6734.0
+image: e-131.0.6734.0-node-20.17
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default

--- a/script/setup-win-for-dev.bat
+++ b/script/setup-win-for-dev.bat
@@ -56,7 +56,7 @@ REM Install Windows SDK
 choco install windows-sdk-11-version-22h2-all
 
 REM Install nodejs python git and yarn needed dependencies
-choco install -y --force nodejs --version=20.9.0
+choco install -y --force nodejs --version=20.17.0
 choco install -y python2 git yarn
 choco install python --version 3.7.9
 call C:\ProgramData\chocolatey\bin\RefreshEnv.cmd

--- a/script/setup-win-for-dev.bat
+++ b/script/setup-win-for-dev.bat
@@ -61,6 +61,10 @@ choco install -y python2 git yarn
 choco install python --version 3.7.9
 call C:\ProgramData\chocolatey\bin\RefreshEnv.cmd
 SET PATH=C:\Python27\;C:\Python27\Scripts;C:\Python39\;C:\Python39\Scripts;%PATH%
+if exist "C:\Users\appveyor\AppData\Roaming\npm" (
+  rm -rf "C:\Users\appveyor\AppData\Roaming\npm"
+  mkdir "C:\Users\appveyor\AppData\Roaming\npm"
+)
 if not exist "C:\Users\appveyor\AppData\Roaming\npm" (
   mkdir "C:\Users\appveyor\AppData\Roaming\npm"
 )


### PR DESCRIPTION
#### Description of Change

This PR updates our Appveyor build images from Node 20.9 to Node 20.17

Note for backports: these will need to be manually backported, but adding the labels to ensure the backports happen and is cleanly documented.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
