### PR TITLE
fix: -Wunsafe-buffer-usage warnings in WebFrameRenderer::ExecuteJavaScript()

### DIFF
--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/containers/span.h"
 #include "base/memory/memory_pressure_listener.h"
 #include "base/strings/utf_string_conversions.h"
 #include "components/spellcheck/renderer/spellcheck.h"
@@ -653,7 +654,7 @@ class WebFrameRenderer final : public gin::Wrappable<WebFrameRenderer>,
                                              std::move(completion_callback));
 
     render_frame->GetWebFrame()->RequestExecuteScript(
-        blink::DOMWrapperWorld::kMainWorldId, base::make_span(&source, 1u),
+        blink::DOMWrapperWorld::kMainWorldId, base::span_from_ref(source),
         has_user_gesture ? blink::mojom::UserActivationOption::kActivate
                          : blink::mojom::UserActivationOption::kDoNotActivate,
         blink::mojom::EvaluationTiming::kSynchronous,


### PR DESCRIPTION
#### Description of Change

Part 11 in a [series](https://github.com/electron/electron/pull/43477) to fix `-Wunsafe-buffer-usage` warnings in `shell/`.

This one is pretty easy: Use [`base::span_from_ref()`](https://chromium-review.googlesource.com/c/chromium/src/+/5181774) to create a single-element span:

```diff
  Foo foo;
- auto foo_span = base::make_span(&foo, 1u);
+ auto foo_span = base::span_from_ref(foo);
```

Warning fixed by this PR:

```
../../electron/shell/renderer/api/electron_api_web_frame.cc:656:47: error: function introduces unsafe buffer manipulation [-Werror,-Wunsafe-buffer-usage]
  656 |         blink::DOMWrapperWorld::kMainWorldId, base::make_span(&source, 1u),
      |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../electron/shell/renderer/api/electron_api_web_frame.cc:656:47: note: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.