### PR TITLE
fix: -Wunsafe-buffer-usage warnings in ElectronAccessibilityUI ctor

### DIFF
--- a/shell/browser/ui/webui/accessibility_ui.cc
+++ b/shell/browser/ui/webui/accessibility_ui.cc
@@ -359,8 +359,7 @@ ElectronAccessibilityUI::ElectronAccessibilityUI(content::WebUI* web_ui)
 
   // Add required resources.
   html_source->UseStringsJs();
-  html_source->AddResourcePaths(
-      base::make_span(kAccessibilityResources, kAccessibilityResourcesSize));
+  html_source->AddResourcePaths(kAccessibilityResources);
   html_source->SetDefaultResource(IDR_ACCESSIBILITY_ACCESSIBILITY_HTML);
   html_source->SetRequestFilter(
       base::BindRepeating(&ShouldHandleAccessibilityRequestCallback),


### PR DESCRIPTION
#### Description of Change

Part 12 in a [series](https://github.com/electron/electron/pull/43477) to fix `-Wunsafe-buffer-usage` warnings in `shell/`.

Both part 11 and 12 today are pretty easy.  This one's similar to https://github.com/electron/electron/pull/44024: upstream declares the length of some kConstantArray, which means that array is Spannable. We can pass it directly to functions taking a span argument and don't need to use the unsafe version of `make_span()`.

For example,`gen/chrome/grit/accessibility_resources_map.h` has these declarations:

```c++
extern const webui::ResourcePath AccessibilityResources[3];
extern const size_t kAccessibilityResourcesSize;
```

So we can change our code:

```diff
- FunctionThatTakesASpanArg(std::make_span(kAccessibilityResources, kAccessibilityResourcesSize));
+ FunctionThatTakesASpanArg(kAccessibilityResources);
```

Fixed by this PR:

```
../../electron/shell/browser/ui/webui/accessibility_ui.cc:363:7: error: function introduces unsafe buffer manipulation [-Werror,-Wunsafe-buffer-usage]
  363 |       base::make_span(kAccessibilityResources, kAccessibilityResourcesSize));
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../electron/shell/browser/ui/webui/accessibility_ui.cc:363:7: note: See //docs/unsafe_buffers.md for help.
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.