### PR TITLE
build: enable -Wunsafe-buffer-usage warnings

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -77,3 +77,6 @@ enterprise_cloud_content_analysis = false
 # TODO: remove dependency on legacy ipc
 # https://issues.chromium.org/issues/40943039
 content_enable_legacy_ipc = true
+
+# Electron has its own unsafe-buffers enforcement directories.
+clang_unsafe_buffers_paths = "//electron/electron_unsafe_buffers_paths.txt"

--- a/electron_unsafe_buffers_paths.txt
+++ b/electron_unsafe_buffers_paths.txt
@@ -1,0 +1,33 @@
+# Copyright 2024 The PDFium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# The set of path prefixes that should be checked for unsafe buffer usage (see
+# -Wunsafe-buffer-usage in Clang).
+#
+# ***
+# Paths should be written as relative to the root of the source tree with
+# unix-style path separators. Directory prefixes should end with `/`, such
+# as `base/`.
+# ***
+#
+# Files in this set are known to not use pointer arithmetic/subscripting, and
+# make use of constructs like base::span or containers like std::vector instead.
+#
+# See `docs/unsafe_buffers.md`.
+
+# These directories are excluded because they come from outside Electron and
+# we don't have control over their contents.
+-base/
+-components/
+-device/
+-extensions/
+-google_apis/
+-net/
+-services/
+-skia/
+-third_party/
+-tools/
+-ui/
+-url/
+-v8/

--- a/electron_unsafe_buffers_paths.txt
+++ b/electron_unsafe_buffers_paths.txt
@@ -1,4 +1,4 @@
-# Copyright 2024 The PDFium Authors. All rights reserved.
+# Copyright 2024 The Electron Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/electron_unsafe_buffers_paths.txt
+++ b/electron_unsafe_buffers_paths.txt
@@ -19,6 +19,7 @@
 # These directories are excluded because they come from outside Electron and
 # we don't have control over their contents.
 -base/
+-chrome/
 -components/
 -device/
 -extensions/


### PR DESCRIPTION
#### Description of Change

Part 23 in a [series](https://github.com/electron/electron/pull/43477) to fix `-Wunsafe-buffer-usage` warnings in `shell/`. 

Now that all the warnings are fixed :tada: , this PR enables the compiler warning in our builds to prevent any future regressions. It uses [similar upstream work in pdfium](https://pdfium-review.googlesource.com/c/pdfium/+/117850) as a template for using [the `clang_unsafe_buffers_path` build option](https://chromium-review.googlesource.com/c/chromium/src/+/5369835) to enable unsafe buffer usage warnings in Electron's C++ code.

Notes: Fixed all `-Wunsafe-buffer-usage` Clang warnings and enabled the compiler warning in new builds.