### PR TITLE
build: use node 20.17 on Windows

### DIFF
--- a/appveyor-bake.yml
+++ b/appveyor-bake.yml
@@ -68,7 +68,7 @@ build_script:
   - ps: $env:PATH="$pwd\depot_tools;$env:PATH"
   - update_depot_tools.bat
   # Uncomment the following line if windows deps change
-  # - src\electron\script\setup-win-for-dev.bat
+  - src\electron\script\setup-win-for-dev.bat
   - >-
       gclient config
       --name "src\electron"

--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -29,7 +29,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: e-131.0.6734.0-node-20.17-1
+image: e-131.0.6734.0-node-20.17-0
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: e-131.0.6734.0-node-20.17-1
+image: e-131.0.6734.0-node-20.17-0
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default

--- a/script/nan-spec-runner.js
+++ b/script/nan-spec-runner.js
@@ -31,7 +31,7 @@ async function main () {
   const env = {
     ...process.env,
     npm_config_nodedir: nodeDir,
-    npm_config_msvs_version: '2019',
+    npm_config_msvs_version: '2022',
     npm_config_arch: process.env.NPM_CONFIG_ARCH,
     npm_config_yes: 'true'
   };

--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -189,7 +189,7 @@ async function installSpecModules (dir) {
   const env = {
     ...process.env,
     CXXFLAGS: process.env.CXXFLAGS,
-    npm_config_msvs_version: '2019',
+    npm_config_msvs_version: '2022',
     npm_config_yes: 'true'
   };
   if (args.electronVersion) {


### PR DESCRIPTION
#### Description of Change

This PR bumps our base images to Node 20.17

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
