### PR TITLE
perf: use ArrayBuffer::Data() instead of GetBackingStore()->Data()

### DIFF
--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -255,9 +255,7 @@ v8::Local<v8::Value> NativeImage::ToBitmap(gin::Arguments* args) {
 
   auto array_buffer =
       v8::ArrayBuffer::New(args->isolate(), info.computeMinByteSize());
-  auto backing_store = array_buffer->GetBackingStore();
-  if (bitmap.readPixels(info, backing_store->Data(), info.minRowBytes(), 0,
-                        0)) {
+  if (bitmap.readPixels(info, array_buffer->Data(), info.minRowBytes(), 0, 0)) {
     return node::Buffer::New(args->isolate(), array_buffer, 0,
                              info.computeMinByteSize())
         .ToLocalChecked();

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -713,8 +713,7 @@ void SimpleURLLoaderWrapper::OnDataReceived(std::string_view string_view,
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
   auto array_buffer = v8::ArrayBuffer::New(isolate, string_view.size());
-  auto backing_store = array_buffer->GetBackingStore();
-  memcpy(backing_store->Data(), string_view.data(), string_view.size());
+  memcpy(array_buffer->Data(), string_view.data(), string_view.size());
   Emit("data", array_buffer,
        base::AdaptCallbackForRepeating(std::move(resume)));
 }


### PR DESCRIPTION
#### Description of Change

A small little cleanup. This PR replaces our two `v8::ArrayBuffer.GetBackingStore()->Data()` calls with `v8::ArrayBuffer.Data()`. The V8 docs say the latter is a "more efficient shortcut" of the former:

> More efficient shortcut for GetBackingStore()->Data(). The
> returned pointer is valid as long as the ArrayBuffer is alive.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.