### PR TITLE
fix: remove use of deprecated API base::Hash()

### DIFF
--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -70,8 +70,8 @@ void DebugLog(std::string_view log_msg) {
     LOG(INFO) << log_msg;
 }
 
-std::wstring GetTag(const std::string& notification_id) {
-  return base::NumberToWString(base::Hash(notification_id));
+std::wstring GetTag(const std::string_view notification_id) {
+  return base::NumberToWString(base::FastHash(notification_id));
 }
 
 }  // namespace


### PR DESCRIPTION
#### Description of Change

Replace a call of deprecated API `base::Hash()` with `base::FastHash()` instead.

From `base/hash/hash.h`:

```c++
  // Deprecated: Computes a hash of a memory buffer, use FastHash() instead.
  // If you need to persist a change on disk or between computers, use
  // PersistentHash().
  // TODO(crbug.com/40107835): Migrate client code to new hash function.
  BASE_EXPORT uint32_t Hash(const std::string& str);
```

#### Checklist

- [X] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [X] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.