### PR TITLE
build: add import/order eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,40 @@
     "prefer-const": ["error", {
       "destructuring": "all"
     }],
-    "n/no-callback-literal": "off"
+    "n/no-callback-literal": "off",
+    "import/newline-after-import": "error",
+    "import/order": ["error", {
+      "alphabetize": {
+        "order": "asc"
+      },
+      "newlines-between": "always",
+      "pathGroups": [
+        {
+          "pattern": "@electron/internal/**",
+          "group": "external",
+          "position": "before"
+        },
+        {
+          "pattern": "@electron/**",
+          "group": "external",
+          "position": "before"
+        },
+        {
+          "pattern": "{electron,electron/**}",
+          "group": "external",
+          "position": "before"
+        }
+      ],
+      "pathGroupsExcludedImportTypes": [],
+      "distinctGroup": true,
+      "groups": [
+        "external",
+        "builtin",
+        ["sibling", "parent"],
+        "index",
+        "type"
+      ]
+    }]
   },
   "parserOptions": {
     "ecmaVersion": 6,

--- a/build/webpack/webpack.config.base.js
+++ b/build/webpack/webpack.config.base.js
@@ -1,8 +1,9 @@
+const TerserPlugin = require('terser-webpack-plugin');
+const webpack = require('webpack');
+const WrapperPlugin = require('wrapper-webpack-plugin');
+
 const fs = require('node:fs');
 const path = require('node:path');
-const webpack = require('webpack');
-const TerserPlugin = require('terser-webpack-plugin');
-const WrapperPlugin = require('wrapper-webpack-plugin');
 
 const electronRoot = path.resolve(__dirname, '../..');
 

--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -1,5 +1,6 @@
 import { shell } from 'electron/common';
 import { app, dialog, BrowserWindow, ipcMain } from 'electron/main';
+
 import * as path from 'node:path';
 import * as url from 'node:url';
 

--- a/default_app/main.ts
+++ b/default_app/main.ts
@@ -4,6 +4,7 @@ import * as fs from 'node:fs';
 import { Module } from 'node:module';
 import * as path from 'node:path';
 import * as url from 'node:url';
+
 const { app, dialog } = electron;
 
 type DefaultAppOptions = {

--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
-
 import { Menu } from 'electron/main';
+
+import * as fs from 'fs';
 
 const bindings = process._linkedBinding('electron_browser_app');
 const commandLine = process._linkedBinding('electron_common_command_line');

--- a/lib/browser/api/auto-updater/auto-updater-win.ts
+++ b/lib/browser/api/auto-updater/auto-updater-win.ts
@@ -1,6 +1,8 @@
-import { app } from 'electron/main';
-import { EventEmitter } from 'events';
 import * as squirrelUpdate from '@electron/internal/browser/api/auto-updater/squirrel-update-win';
+
+import { app } from 'electron/main';
+
+import { EventEmitter } from 'events';
 
 class AutoUpdater extends EventEmitter implements Electron.AutoUpdater {
   updateAvailable: boolean = false;

--- a/lib/browser/api/auto-updater/squirrel-update-win.ts
+++ b/lib/browser/api/auto-updater/squirrel-update-win.ts
@@ -1,6 +1,6 @@
+import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
 
 // i.e. my-app/app-0.1.13/
 const appFolder = path.dirname(process.execPath);

--- a/lib/browser/api/base-window.ts
+++ b/lib/browser/api/base-window.ts
@@ -1,6 +1,7 @@
-import { EventEmitter } from 'events';
-import type { BaseWindow as TLWT } from 'electron/main';
 import { TouchBar } from 'electron/main';
+import type { BaseWindow as TLWT } from 'electron/main';
+
+import { EventEmitter } from 'events';
 
 const { BaseWindow } = process._linkedBinding('electron_browser_base_window') as { BaseWindow: typeof TLWT };
 

--- a/lib/browser/api/browser-window.ts
+++ b/lib/browser/api/browser-window.ts
@@ -1,5 +1,6 @@
 import { BaseWindow, WebContents, BrowserView } from 'electron/main';
 import type { BrowserWindow as BWT } from 'electron/main';
+
 const { BrowserWindow } = process._linkedBinding('electron_browser_window') as { BrowserWindow: typeof BWT };
 
 Object.setPrototypeOf(BrowserWindow.prototype, BaseWindow.prototype);

--- a/lib/browser/api/crash-reporter.ts
+++ b/lib/browser/api/crash-reporter.ts
@@ -1,5 +1,6 @@
-import { app } from 'electron/main';
 import * as deprecate from '@electron/internal/common/deprecate';
+
+import { app } from 'electron/main';
 
 const binding = process._linkedBinding('electron_browser_crash_reporter');
 

--- a/lib/browser/api/desktop-capturer.ts
+++ b/lib/browser/api/desktop-capturer.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow } from 'electron/main';
+
 const { createDesktopCapturer, isDisplayMediaSystemPickerAvailable } = process._linkedBinding('electron_browser_desktop_capturer');
 
 const deepEqual = (a: ElectronInternal.GetSourcesOptions, b: ElectronInternal.GetSourcesOptions) => JSON.stringify(a) === JSON.stringify(b);

--- a/lib/browser/api/dialog.ts
+++ b/lib/browser/api/dialog.ts
@@ -1,5 +1,6 @@
 import { app, BaseWindow } from 'electron/main';
 import type { OpenDialogOptions, OpenDialogReturnValue, MessageBoxOptions, SaveDialogOptions, SaveDialogReturnValue, MessageBoxReturnValue, CertificateTrustDialogOptions } from 'electron/main';
+
 const dialogBinding = process._linkedBinding('electron_browser_dialog');
 
 enum SaveFileDialogProperties {

--- a/lib/browser/api/exports/electron.ts
+++ b/lib/browser/api/exports/electron.ts
@@ -1,6 +1,6 @@
-import { defineProperties } from '@electron/internal/common/define-properties';
-import { commonModuleList } from '@electron/internal/common/api/module-list';
 import { browserModuleList } from '@electron/internal/browser/api/module-list';
+import { commonModuleList } from '@electron/internal/common/api/module-list';
+import { defineProperties } from '@electron/internal/common/define-properties';
 
 module.exports = {};
 

--- a/lib/browser/api/menu-item.ts
+++ b/lib/browser/api/menu-item.ts
@@ -1,4 +1,5 @@
 import * as roles from '@electron/internal/browser/api/menu-item-roles';
+
 import { Menu, BaseWindow, WebContents, KeyboardEvent } from 'electron/main';
 
 let nextCommandId = 0;

--- a/lib/browser/api/menu.ts
+++ b/lib/browser/api/menu.ts
@@ -1,6 +1,7 @@
-import { BaseWindow, MenuItem, webContents, Menu as MenuType, MenuItemConstructorOptions } from 'electron/main';
 import { sortMenuItems } from '@electron/internal/browser/api/menu-utils';
 import { setApplicationMenuWasSet } from '@electron/internal/browser/default-menu';
+
+import { BaseWindow, MenuItem, webContents, Menu as MenuType, MenuItemConstructorOptions } from 'electron/main';
 
 const bindings = process._linkedBinding('electron_browser_menu');
 

--- a/lib/browser/api/message-channel.ts
+++ b/lib/browser/api/message-channel.ts
@@ -1,5 +1,7 @@
 import { MessagePortMain } from '@electron/internal/browser/message-port-main';
+
 import { EventEmitter } from 'events';
+
 const { createPair } = process._linkedBinding('electron_browser_message_port');
 
 export default class MessageChannelMain extends EventEmitter implements Electron.MessageChannelMain {

--- a/lib/browser/api/net-fetch.ts
+++ b/lib/browser/api/net-fetch.ts
@@ -1,6 +1,8 @@
-import { ClientRequestConstructorOptions, ClientRequest, IncomingMessage, Session as SessionT } from 'electron/main';
-import { Readable, Writable, isReadable } from 'stream';
 import { allowAnyProtocol } from '@electron/internal/common/api/net-client-request';
+
+import { ClientRequestConstructorOptions, ClientRequest, IncomingMessage, Session as SessionT } from 'electron/main';
+
+import { Readable, Writable, isReadable } from 'stream';
 
 function createDeferredPromise<T, E extends Error = Error> (): { promise: Promise<T>; resolve: (x: T) => void; reject: (e: E) => void; } {
   let res: (x: T) => void;

--- a/lib/browser/api/net.ts
+++ b/lib/browser/api/net.ts
@@ -1,6 +1,7 @@
+import { ClientRequest } from '@electron/internal/common/api/net-client-request';
+
 import { app, IncomingMessage, session } from 'electron/main';
 import type { ClientRequestConstructorOptions } from 'electron/main';
-import { ClientRequest } from '@electron/internal/common/api/net-client-request';
 
 const { isOnline } = process._linkedBinding('electron_common_net');
 

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -1,4 +1,5 @@
 import { ProtocolRequest, session } from 'electron/main';
+
 import { createReadStream } from 'fs';
 import { Readable } from 'stream';
 import { ReadableStream } from 'stream/web';

--- a/lib/browser/api/session.ts
+++ b/lib/browser/api/session.ts
@@ -1,5 +1,7 @@
 import { fetchWithSession } from '@electron/internal/browser/api/net-fetch';
+
 import { net } from 'electron/main';
+
 const { fromPartition, fromPath, Session } = process._linkedBinding('electron_browser_session');
 const { isDisplayMediaSystemPickerAvailable } = process._linkedBinding('electron_browser_desktop_capturer');
 

--- a/lib/browser/api/share-menu.ts
+++ b/lib/browser/api/share-menu.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow, Menu, SharingItem, PopupOptions } from 'electron/main';
+
 import { EventEmitter } from 'events';
 
 class ShareMenu extends EventEmitter implements Electron.ShareMenu {

--- a/lib/browser/api/system-preferences.ts
+++ b/lib/browser/api/system-preferences.ts
@@ -1,4 +1,5 @@
 import * as deprecate from '@electron/internal/common/deprecate';
+
 const { systemPreferences } = process._linkedBinding('electron_browser_system_preferences');
 
 if ('getEffectiveAppearance' in systemPreferences) {

--- a/lib/browser/api/utility-process.ts
+++ b/lib/browser/api/utility-process.ts
@@ -1,7 +1,9 @@
-import { EventEmitter } from 'events';
-import { Duplex, PassThrough } from 'stream';
-import { Socket } from 'net';
 import { MessagePortMain } from '@electron/internal/browser/message-port-main';
+
+import { EventEmitter } from 'events';
+import { Socket } from 'net';
+import { Duplex, PassThrough } from 'stream';
+
 const { _fork } = process._linkedBinding('electron_browser_utility_process');
 
 class ForkUtilityProcess extends EventEmitter implements Electron.UtilityProcess {

--- a/lib/browser/api/view.ts
+++ b/lib/browser/api/view.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+
 const { View } = process._linkedBinding('electron_browser_view');
 
 Object.setPrototypeOf((View as any).prototype, EventEmitter.prototype);

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -1,16 +1,17 @@
-import { app, ipcMain, session, webFrameMain, dialog } from 'electron/main';
-import type { BrowserWindowConstructorOptions, MessageBoxOptions } from 'electron/main';
-
-import * as url from 'url';
-import * as path from 'path';
 import { openGuestWindow, makeWebPreferences, parseContentTypeFormat } from '@electron/internal/browser/guest-window-manager';
-import { parseFeatures } from '@electron/internal/browser/parse-features-string';
+import { IpcMainImpl } from '@electron/internal/browser/ipc-main-impl';
 import { ipcMainInternal } from '@electron/internal/browser/ipc-main-internal';
 import * as ipcMainUtils from '@electron/internal/browser/ipc-main-internal-utils';
 import { MessagePortMain } from '@electron/internal/browser/message-port-main';
-import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
-import { IpcMainImpl } from '@electron/internal/browser/ipc-main-impl';
+import { parseFeatures } from '@electron/internal/browser/parse-features-string';
 import * as deprecate from '@electron/internal/common/deprecate';
+import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
+
+import { app, ipcMain, session, webFrameMain, dialog } from 'electron/main';
+import type { BrowserWindowConstructorOptions, MessageBoxOptions } from 'electron/main';
+
+import * as path from 'path';
+import * as url from 'url';
 
 // session is not used here, the purpose is to make sure session is initialized
 // before the webContents module.

--- a/lib/browser/api/web-frame-main.ts
+++ b/lib/browser/api/web-frame-main.ts
@@ -1,5 +1,5 @@
-import { MessagePortMain } from '@electron/internal/browser/message-port-main';
 import { IpcMainImpl } from '@electron/internal/browser/ipc-main-impl';
+import { MessagePortMain } from '@electron/internal/browser/message-port-main';
 
 const { WebFrameMain, fromId } = process._linkedBinding('electron_browser_web_frame_main');
 

--- a/lib/browser/default-menu.ts
+++ b/lib/browser/default-menu.ts
@@ -1,5 +1,5 @@
-import { app, Menu } from 'electron/main';
 import { shell } from 'electron/common';
+import { app, Menu } from 'electron/main';
 
 const isMac = process.platform === 'darwin';
 

--- a/lib/browser/devtools.ts
+++ b/lib/browser/devtools.ts
@@ -1,9 +1,10 @@
-import { dialog, Menu } from 'electron/main';
-import * as fs from 'fs';
-
+import { IPC_MESSAGES } from '@electron/internal//common/ipc-messages';
 import { ipcMainInternal } from '@electron/internal/browser/ipc-main-internal';
 import * as ipcMainUtils from '@electron/internal/browser/ipc-main-internal-utils';
-import { IPC_MESSAGES } from '@electron/internal//common/ipc-messages';
+
+import { dialog, Menu } from 'electron/main';
+
+import * as fs from 'fs';
 
 const convertToMenuTemplate = function (items: ContextMenuItem[], handler: (id: number) => void) {
   return items.map(function (item) {

--- a/lib/browser/guest-view-manager.ts
+++ b/lib/browser/guest-view-manager.ts
@@ -1,10 +1,11 @@
-import { webContents } from 'electron/main';
 import { ipcMainInternal } from '@electron/internal/browser/ipc-main-internal';
 import * as ipcMainUtils from '@electron/internal/browser/ipc-main-internal-utils';
 import { parseWebViewWebPreferences } from '@electron/internal/browser/parse-features-string';
-import { syncMethods, asyncMethods, properties, navigationHistorySyncMethods } from '@electron/internal/common/web-view-methods';
 import { webViewEvents } from '@electron/internal/browser/web-view-events';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
+import { syncMethods, asyncMethods, properties, navigationHistorySyncMethods } from '@electron/internal/common/web-view-methods';
+
+import { webContents } from 'electron/main';
 
 interface GuestInstance {
   elementInstanceId: number;

--- a/lib/browser/guest-window-manager.ts
+++ b/lib/browser/guest-window-manager.ts
@@ -5,9 +5,10 @@
  * out-of-process (cross-origin) are created here. "Embedder" roughly means
  * "parent."
  */
+import { parseFeatures } from '@electron/internal/browser/parse-features-string';
+
 import { BrowserWindow } from 'electron/main';
 import type { BrowserWindowConstructorOptions, Referrer, WebContents, LoadURLOptions } from 'electron/main';
-import { parseFeatures } from '@electron/internal/browser/parse-features-string';
 
 type PostData = LoadURLOptions['postData']
 export type WindowOpenArgs = {

--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -1,8 +1,9 @@
+import type * as defaultMenuModule from '@electron/internal/browser/default-menu';
+
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import * as path from 'path';
 
-import type * as defaultMenuModule from '@electron/internal/browser/default-menu';
 import type * as url from 'url';
 import type * as v8 from 'v8';
 

--- a/lib/browser/ipc-main-impl.ts
+++ b/lib/browser/ipc-main-impl.ts
@@ -1,5 +1,6 @@
-import { EventEmitter } from 'events';
 import { IpcMainInvokeEvent } from 'electron/main';
+
+import { EventEmitter } from 'events';
 
 export class IpcMainImpl extends EventEmitter implements Electron.IpcMain {
   private _invokeHandlers: Map<string, (e: IpcMainInvokeEvent, ...args: any[]) => void> = new Map();

--- a/lib/browser/rpc-server.ts
+++ b/lib/browser/rpc-server.ts
@@ -1,8 +1,10 @@
-import { clipboard } from 'electron/common';
-import * as fs from 'fs';
 import { ipcMainInternal } from '@electron/internal/browser/ipc-main-internal';
 import * as ipcMainUtils from '@electron/internal/browser/ipc-main-internal-utils';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
+
+import { clipboard } from 'electron/common';
+
+import * as fs from 'fs';
 
 // Implements window.close()
 ipcMainInternal.on(IPC_MESSAGES.BROWSER_WINDOW_CLOSE, function (event) {

--- a/lib/common/api/net-client-request.ts
+++ b/lib/common/api/net-client-request.ts
@@ -1,9 +1,10 @@
-import * as url from 'url';
-import { Readable, Writable } from 'stream';
 import type {
   ClientRequestConstructorOptions,
   UploadProgress
 } from 'electron/common';
+
+import { Readable, Writable } from 'stream';
+import * as url from 'url';
 
 const {
   isValidHeaderName,

--- a/lib/common/init.ts
+++ b/lib/common/init.ts
@@ -1,7 +1,7 @@
-import * as util from 'util';
-import type * as stream from 'stream';
-
 import timers = require('timers');
+import * as util from 'util';
+
+import type * as stream from 'stream';
 
 type AnyFn = (...args: any[]) => any
 

--- a/lib/node/init.ts
+++ b/lib/node/init.ts
@@ -1,3 +1,5 @@
+/* eslint-disable import/newline-after-import */
+/* eslint-disable import/order */
 // Initialize ASAR support in fs module.
 import { wrapFsWithAsar } from './asar-fs-wrapper';
 wrapFsWithAsar(require('fs'));

--- a/lib/renderer/api/exports/electron.ts
+++ b/lib/renderer/api/exports/electron.ts
@@ -1,5 +1,5 @@
-import { defineProperties } from '@electron/internal/common/define-properties';
 import { commonModuleList } from '@electron/internal/common/api/module-list';
+import { defineProperties } from '@electron/internal/common/define-properties';
 import { rendererModuleList } from '@electron/internal/renderer/api/module-list';
 
 module.exports = {};

--- a/lib/renderer/common-init.ts
+++ b/lib/renderer/common-init.ts
@@ -1,10 +1,10 @@
-import { ipcRenderer } from 'electron/renderer';
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
-
+import type * as securityWarningsModule from '@electron/internal/renderer/security-warnings';
+import type * as webFrameInitModule from '@electron/internal/renderer/web-frame-init';
 import type * as webViewInitModule from '@electron/internal/renderer/web-view/web-view-init';
 import type * as windowSetupModule from '@electron/internal/renderer/window-setup';
-import type * as webFrameInitModule from '@electron/internal/renderer/web-frame-init';
-import type * as securityWarningsModule from '@electron/internal/renderer/security-warnings';
+
+import { ipcRenderer } from 'electron/renderer';
 
 const { mainFrame } = process._linkedBinding('electron_renderer_web_frame');
 const v8Util = process._linkedBinding('electron_common_v8_util');
@@ -49,6 +49,7 @@ if (process.isMainFrame) {
 }
 
 const { webFrameInit } = require('@electron/internal/renderer/web-frame-init') as typeof webFrameInitModule;
+
 webFrameInit();
 
 // Warn about security issues

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -1,9 +1,9 @@
-import * as path from 'path';
-import { pathToFileURL } from 'url';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
-
 import type * as ipcRendererInternalModule from '@electron/internal/renderer/ipc-renderer-internal';
 import type * as ipcRendererUtilsModule from '@electron/internal/renderer/ipc-renderer-internal-utils';
+
+import * as path from 'path';
+import { pathToFileURL } from 'url';
 
 const Module = require('module') as NodeJS.ModuleInternal;
 

--- a/lib/renderer/inspector.ts
+++ b/lib/renderer/inspector.ts
@@ -1,8 +1,9 @@
+import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 import { internalContextBridge } from '@electron/internal/renderer/api/context-bridge';
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 import * as ipcRendererUtils from '@electron/internal/renderer/ipc-renderer-internal-utils';
+
 import { webFrame } from 'electron/renderer';
-import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
 const { contextIsolationEnabled } = internalContextBridge;
 

--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -1,5 +1,5 @@
-import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
+import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 
 const { mainFrame: webFrame } = process._linkedBinding('electron_renderer_web_frame');
 

--- a/lib/renderer/web-frame-init.ts
+++ b/lib/renderer/web-frame-init.ts
@@ -1,6 +1,7 @@
-import { webFrame, WebFrame } from 'electron/renderer';
-import * as ipcRendererUtils from '@electron/internal/renderer/ipc-renderer-internal-utils';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
+import * as ipcRendererUtils from '@electron/internal/renderer/ipc-renderer-internal-utils';
+
+import { webFrame, WebFrame } from 'electron/renderer';
 
 // All keys of WebFrame that extend Function
 type WebFrameMethod = {

--- a/lib/renderer/web-view/guest-view-internal.ts
+++ b/lib/renderer/web-view/guest-view-internal.ts
@@ -1,6 +1,6 @@
+import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 import * as ipcRendererUtils from '@electron/internal/renderer/ipc-renderer-internal-utils';
-import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
 const { mainFrame: webFrame } = process._linkedBinding('electron_renderer_web_frame');
 

--- a/lib/renderer/web-view/web-view-attributes.ts
+++ b/lib/renderer/web-view/web-view-attributes.ts
@@ -1,5 +1,5 @@
-import type { WebViewImpl } from '@electron/internal/renderer/web-view/web-view-impl';
 import { WEB_VIEW_ATTRIBUTES, WEB_VIEW_ERROR_MESSAGES } from '@electron/internal/renderer/web-view/web-view-constants';
+import type { WebViewImpl } from '@electron/internal/renderer/web-view/web-view-impl';
 
 const resolveURL = function (url?: string | null) {
   return url ? new URL(url, location.href).href : '';

--- a/lib/renderer/web-view/web-view-element.ts
+++ b/lib/renderer/web-view/web-view-element.ts
@@ -8,9 +8,9 @@
 // which runs in browserify environment instead of Node environment, all native
 // modules must be passed from outside, all included files must be plain JS.
 
+import type { SrcAttribute } from '@electron/internal/renderer/web-view/web-view-attributes';
 import { WEB_VIEW_ATTRIBUTES, WEB_VIEW_ERROR_MESSAGES } from '@electron/internal/renderer/web-view/web-view-constants';
 import { WebViewImpl, WebViewImplHooks, setupMethods } from '@electron/internal/renderer/web-view/web-view-impl';
-import type { SrcAttribute } from '@electron/internal/renderer/web-view/web-view-attributes';
 
 const internals = new WeakMap<HTMLElement, WebViewImpl>();
 

--- a/lib/renderer/web-view/web-view-impl.ts
+++ b/lib/renderer/web-view/web-view-impl.ts
@@ -1,8 +1,8 @@
-import type * as guestViewInternalModule from '@electron/internal/renderer/web-view/guest-view-internal';
-import { WEB_VIEW_ATTRIBUTES } from '@electron/internal/renderer/web-view/web-view-constants';
 import { syncMethods, asyncMethods, properties } from '@electron/internal/common/web-view-methods';
+import type * as guestViewInternalModule from '@electron/internal/renderer/web-view/guest-view-internal';
 import type { WebViewAttribute, PartitionAttribute } from '@electron/internal/renderer/web-view/web-view-attributes';
 import { setupWebViewAttributes } from '@electron/internal/renderer/web-view/web-view-attributes';
+import { WEB_VIEW_ATTRIBUTES } from '@electron/internal/renderer/web-view/web-view-constants';
 
 // ID generator.
 let nextId = 0;

--- a/lib/renderer/web-view/web-view-init.ts
+++ b/lib/renderer/web-view/web-view-init.ts
@@ -1,8 +1,7 @@
-import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
-
-import type * as webViewElementModule from '@electron/internal/renderer/web-view/web-view-element';
+import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 import type * as guestViewInternalModule from '@electron/internal/renderer/web-view/guest-view-internal';
+import type * as webViewElementModule from '@electron/internal/renderer/web-view/web-view-element';
 
 const v8Util = process._linkedBinding('electron_common_v8_util');
 const { mainFrame: webFrame } = process._linkedBinding('electron_renderer_web_frame');

--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -1,6 +1,6 @@
-import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
-import { internalContextBridge } from '@electron/internal/renderer/api/context-bridge';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
+import { internalContextBridge } from '@electron/internal/renderer/api/context-bridge';
+import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 
 const { contextIsolationEnabled } = internalContextBridge;
 

--- a/lib/sandboxed_renderer/init.ts
+++ b/lib/sandboxed_renderer/init.ts
@@ -1,9 +1,9 @@
+import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
+import type * as ipcRendererInternalModule from '@electron/internal/renderer/ipc-renderer-internal';
+import type * as ipcRendererUtilsModule from '@electron/internal/renderer/ipc-renderer-internal-utils';
+
 import * as events from 'events';
 import { setImmediate, clearImmediate } from 'timers';
-import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
-
-import type * as ipcRendererUtilsModule from '@electron/internal/renderer/ipc-renderer-internal-utils';
-import type * as ipcRendererInternalModule from '@electron/internal/renderer/ipc-renderer-internal';
 
 declare const binding: {
   get: (name: string) => any;

--- a/lib/utility/api/net.ts
+++ b/lib/utility/api/net.ts
@@ -1,7 +1,8 @@
+import { fetchWithSession } from '@electron/internal/browser/api/net-fetch';
+import { ClientRequest } from '@electron/internal/common/api/net-client-request';
+
 import { IncomingMessage } from 'electron/utility';
 import type { ClientRequestConstructorOptions } from 'electron/utility';
-import { ClientRequest } from '@electron/internal/common/api/net-client-request';
-import { fetchWithSession } from '@electron/internal/browser/api/net-fetch';
 
 const { isOnline, resolveHost } = process._linkedBinding('electron_common_net');
 

--- a/lib/utility/init.ts
+++ b/lib/utility/init.ts
@@ -1,7 +1,7 @@
+import { ParentPort } from '@electron/internal/utility/parent-port';
+
 import { EventEmitter } from 'events';
 import { pathToFileURL } from 'url';
-
-import { ParentPort } from '@electron/internal/utility/parent-port';
 
 const v8Util = process._linkedBinding('electron_common_v8_util');
 

--- a/lib/utility/parent-port.ts
+++ b/lib/utility/parent-port.ts
@@ -1,5 +1,7 @@
-import { EventEmitter } from 'events';
 import { MessagePortMain } from '@electron/internal/browser/message-port-main';
+
+import { EventEmitter } from 'events';
+
 const { createParentPort } = process._linkedBinding('electron_utility_parent_port');
 
 export class ParentPort extends EventEmitter implements Electron.ParentPort {

--- a/npm/cli.js
+++ b/npm/cli.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const electron = require('./');
-
 const proc = require('child_process');
+
+const electron = require('./');
 
 const child = proc.spawn(electron, process.argv.slice(2), { stdio: 'inherit', windowsHide: false });
 child.on('close', function (code, signal) {

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 
-const { version } = require('./package');
+const { downloadArtifact } = require('@electron/get');
+
+const extract = require('extract-zip');
 
 const childProcess = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const extract = require('extract-zip');
-const { downloadArtifact } = require('@electron/get');
+
+const { version } = require('./package');
 
 if (process.env.ELECTRON_SKIP_BINARY_DOWNLOAD) {
   process.exit(0);

--- a/script/create-api-json.js
+++ b/script/create-api-json.js
@@ -1,4 +1,5 @@
 const { parseDocs } = require('@electron/docs-parser');
+
 const fs = require('node:fs');
 const path = require('node:path');
 

--- a/script/doc-only-change.js
+++ b/script/doc-only-change.js
@@ -1,5 +1,8 @@
-const args = require('minimist')(process.argv.slice(2));
 const { Octokit } = require('@octokit/rest');
+const minimist = require('minimist');
+
+const args = minimist(process.argv.slice(2));
+
 const octokit = new Octokit();
 
 async function checkIfDocOnlyChange () {

--- a/script/generate-version-json.js
+++ b/script/generate-version-json.js
@@ -1,5 +1,6 @@
-const fs = require('node:fs');
 const semver = require('semver');
+
+const fs = require('node:fs');
 
 const outputPath = process.argv[2];
 const currentVersion = process.argv[3];

--- a/script/gn-asar-hash.js
+++ b/script/gn-asar-hash.js
@@ -1,4 +1,5 @@
 const asar = require('@electron/asar');
+
 const crypto = require('node:crypto');
 const fs = require('node:fs');
 

--- a/script/gn-asar.js
+++ b/script/gn-asar.js
@@ -1,4 +1,5 @@
 const asar = require('@electron/asar');
+
 const assert = require('node:assert');
 const fs = require('node:fs');
 const os = require('node:os');

--- a/script/gn-check.js
+++ b/script/gn-check.js
@@ -4,9 +4,12 @@ Usage:
 $ node ./script/gn-check.js [--outDir=dirName]
 */
 
+const minimist = require('minimist');
+
 const cp = require('node:child_process');
 const path = require('node:path');
-const args = require('minimist')(process.argv.slice(2), { string: ['outDir'] });
+
+const args = minimist(process.argv.slice(2), { string: ['outDir'] });
 
 const { getOutDir } = require('./lib/utils');
 

--- a/script/lib/azput.js
+++ b/script/lib/azput.js
@@ -1,5 +1,8 @@
 /* eslint-disable camelcase */
+
 const { BlobServiceClient } = require('@azure/storage-blob');
+const minimist = require('minimist');
+
 const path = require('node:path');
 
 const { ELECTRON_ARTIFACTS_BLOB_STORAGE } = process.env;
@@ -10,7 +13,7 @@ if (!ELECTRON_ARTIFACTS_BLOB_STORAGE) {
 
 const blobServiceClient = BlobServiceClient.fromConnectionString(ELECTRON_ARTIFACTS_BLOB_STORAGE);
 
-const args = require('minimist')(process.argv.slice(2));
+const args = minimist(process.argv.slice(2));
 
 let { prefix = '/', key_prefix = '', _: files } = args;
 if (prefix && !prefix.endsWith(path.sep)) prefix = path.resolve(prefix) + path.sep;

--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -1,5 +1,6 @@
 const chalk = require('chalk');
 const { GitProcess } = require('dugite');
+
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');

--- a/script/lint.js
+++ b/script/lint.js
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 
-const crypto = require('node:crypto');
-const { GitProcess } = require('dugite');
-const childProcess = require('node:child_process');
-const { ESLint } = require('eslint');
-const fs = require('node:fs');
-const minimist = require('minimist');
-const path = require('node:path');
 const { getCodeBlocks } = require('@electron/lint-roller/dist/lib/markdown');
+
+const { GitProcess } = require('dugite');
+const { ESLint } = require('eslint');
+const minimist = require('minimist');
+
+const childProcess = require('node:child_process');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const { chunkFilenames, findMatchingFiles } = require('./lib/utils');
 

--- a/script/nan-spec-runner.js
+++ b/script/nan-spec-runner.js
@@ -1,3 +1,5 @@
+const minimist = require('minimist');
+
 const cp = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -13,7 +15,7 @@ if (!require.main) {
   throw new Error('Must call the nan spec runner directly');
 }
 
-const args = require('minimist')(process.argv.slice(2), {
+const args = minimist(process.argv.slice(2), {
   string: ['only']
 });
 

--- a/script/node-spec-runner.js
+++ b/script/node-spec-runner.js
@@ -1,19 +1,22 @@
+const minimist = require('minimist');
+
 const cp = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const args = require('minimist')(process.argv.slice(2), {
+const utils = require('./lib/utils');
+const DISABLED_TESTS = require('./node-disabled-tests.json');
+
+const args = minimist(process.argv.slice(2), {
   boolean: ['default', 'validateDisabled'],
   string: ['jUnitDir']
 });
 
 const BASE = path.resolve(__dirname, '../..');
-const DISABLED_TESTS = require('./node-disabled-tests.json');
+
 const NODE_DIR = path.resolve(BASE, 'third_party', 'electron_node');
 const JUNIT_DIR = args.jUnitDir ? path.resolve(args.jUnitDir) : null;
 const TAP_FILE_NAME = 'test.tap';
-
-const utils = require('./lib/utils');
 
 if (!require.main) {
   throw new Error('Must call the node spec runner directly');

--- a/script/prepare-appveyor.js
+++ b/script/prepare-appveyor.js
@@ -1,9 +1,12 @@
+const { Octokit } = require('@octokit/rest');
+const got = require('got');
+
 const assert = require('node:assert');
 const fs = require('node:fs');
-const got = require('got');
 const path = require('node:path');
+
 const { handleGitCall, ELECTRON_DIR } = require('./lib/utils.js');
-const { Octokit } = require('@octokit/rest');
+
 const octokit = new Octokit();
 
 const APPVEYOR_IMAGES_URL = 'https://ci.appveyor.com/api/build-clouds';

--- a/script/push-patch.js
+++ b/script/push-patch.js
@@ -1,4 +1,5 @@
 const { appCredentialsFromString, getTokenForRepo } = require('@electron/github-app-auth');
+
 const cp = require('node:child_process');
 
 async function main () {

--- a/script/release/bin/cleanup-release.ts
+++ b/script/release/bin/cleanup-release.ts
@@ -1,4 +1,5 @@
 import { parseArgs } from 'node:util';
+
 import { cleanReleaseArtifacts } from '../release-artifact-cleanup';
 
 const { values: { tag: _tag, releaseID } } = parseArgs({

--- a/script/release/bin/publish-to-npm.ts
+++ b/script/release/bin/publish-to-npm.ts
@@ -1,13 +1,13 @@
 import { Octokit } from '@octokit/rest';
-import * as childProcess from 'node:child_process';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 import * as semver from 'semver';
 import * as temp from 'temp';
 
-import { getCurrentBranch, ELECTRON_DIR } from '../../lib/utils';
-import { getElectronVersion } from '../../lib/get-version';
+import * as childProcess from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
+import { getElectronVersion } from '../../lib/get-version';
+import { getCurrentBranch, ELECTRON_DIR } from '../../lib/utils';
 import { getAssetContents } from '../get-asset';
 import { createGitHubTokenStrategy } from '../github-token';
 import { ELECTRON_ORG, ELECTRON_REPO, ElectronReleaseRepo, NIGHTLY_REPO } from '../types';

--- a/script/release/find-github-release.ts
+++ b/script/release/find-github-release.ts
@@ -1,4 +1,5 @@
 import { Octokit } from '@octokit/rest';
+
 import { createGitHubTokenStrategy } from './github-token';
 import { ELECTRON_ORG, ELECTRON_REPO, ElectronReleaseRepo, NIGHTLY_REPO } from './types';
 

--- a/script/release/get-asset.ts
+++ b/script/release/get-asset.ts
@@ -1,5 +1,6 @@
 import { Octokit } from '@octokit/rest';
 import got from 'got';
+
 import { createGitHubTokenStrategy } from './github-token';
 import { ELECTRON_ORG, ElectronReleaseRepo } from './types';
 

--- a/script/release/get-url-hash.ts
+++ b/script/release/get-url-hash.ts
@@ -1,4 +1,5 @@
 import got from 'got';
+
 import * as url from 'node:url';
 
 const HASHER_FUNCTION_HOST = 'electron-artifact-hasher.azurewebsites.net';

--- a/script/release/notes/index.ts
+++ b/script/release/notes/index.ts
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 
+import { Octokit } from '@octokit/rest';
 import { GitProcess } from 'dugite';
-import { basename } from 'node:path';
 import { valid, compare, gte, lte } from 'semver';
 
-import { ELECTRON_DIR } from '../../lib/utils';
-import { get, render } from './notes';
-
-import { Octokit } from '@octokit/rest';
-import { createGitHubTokenStrategy } from '../github-token';
+import { basename } from 'node:path';
 import { parseArgs } from 'node:util';
+
+import { get, render } from './notes';
+import { ELECTRON_DIR } from '../../lib/utils';
+import { createGitHubTokenStrategy } from '../github-token';
 import { ELECTRON_ORG, ELECTRON_REPO } from '../types';
 
 const octokit = new Octokit({

--- a/script/release/notes/notes.ts
+++ b/script/release/notes/notes.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { resolve as _resolve } from 'node:path';
-
 import { Octokit } from '@octokit/rest';
 import { GitProcess } from 'dugite';
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { resolve as _resolve } from 'node:path';
 
 import { ELECTRON_DIR } from '../../lib/utils';
 import { createGitHubTokenStrategy } from '../github-token';

--- a/script/release/prepare-release.ts
+++ b/script/release/prepare-release.ts
@@ -1,14 +1,15 @@
 import { Octokit } from '@octokit/rest';
 import * as chalk from 'chalk';
 import { GitProcess } from 'dugite';
+
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 
-import { runReleaseCIJobs } from './run-release-ci-jobs';
-import releaseNotesGenerator from './notes';
-import { getCurrentBranch, ELECTRON_DIR } from '../lib/utils.js';
 import { createGitHubTokenStrategy } from './github-token';
+import releaseNotesGenerator from './notes';
+import { runReleaseCIJobs } from './run-release-ci-jobs';
 import { ELECTRON_ORG, ElectronReleaseRepo, VersionBumpType } from './types';
+import { getCurrentBranch, ELECTRON_DIR } from '../lib/utils.js';
 
 const pass = chalk.green('✓');
 const fail = chalk.red('✗');

--- a/script/release/release.ts
+++ b/script/release/release.ts
@@ -4,17 +4,18 @@ import { BlobServiceClient } from '@azure/storage-blob';
 import { Octokit } from '@octokit/rest';
 import * as chalk from 'chalk';
 import got from 'got';
-import { execSync, ExecSyncOptions } from 'node:child_process';
-import { statSync, createReadStream, writeFileSync, close } from 'node:fs';
-import { join } from 'node:path';
 import { gte } from 'semver';
 import { track as trackTemp } from 'temp';
 
-import { ELECTRON_DIR } from '../lib/utils';
-import { getElectronVersion } from '../lib/get-version';
+import { execSync, ExecSyncOptions } from 'node:child_process';
+import { statSync, createReadStream, writeFileSync, close } from 'node:fs';
+import { join } from 'node:path';
+
 import { getUrlHash } from './get-url-hash';
 import { createGitHubTokenStrategy } from './github-token';
 import { ELECTRON_ORG, ELECTRON_REPO, ElectronReleaseRepo, NIGHTLY_REPO } from './types';
+import { getElectronVersion } from '../lib/get-version';
+import { ELECTRON_DIR } from '../lib/utils';
 
 const temp = trackTemp();
 

--- a/script/release/run-release-ci-jobs.ts
+++ b/script/release/run-release-ci-jobs.ts
@@ -1,5 +1,6 @@
 import { Octokit } from '@octokit/rest';
 import got, { OptionsOfTextResponseBody } from 'got';
+
 import * as assert from 'node:assert';
 
 import { createGitHubTokenStrategy } from './github-token';

--- a/script/release/uploaders/upload-to-github.ts
+++ b/script/release/uploaders/upload-to-github.ts
@@ -1,5 +1,7 @@
 import { Octokit } from '@octokit/rest';
+
 import * as fs from 'node:fs';
+
 import { createGitHubTokenStrategy } from '../github-token';
 import { ELECTRON_ORG, ELECTRON_REPO, ElectronReleaseRepo, NIGHTLY_REPO } from '../types';
 

--- a/script/release/version-bumper.ts
+++ b/script/release/version-bumper.ts
@@ -2,7 +2,9 @@
 
 import { valid, coerce, inc } from 'semver';
 
-import { getElectronVersion } from '../lib/get-version';
+import { parseArgs } from 'node:util';
+
+import { VersionBumpType } from './types';
 import {
   isNightly,
   isAlpha,
@@ -12,8 +14,7 @@ import {
   nextBeta,
   isStable
 } from './version-utils';
-import { VersionBumpType } from './types';
-import { parseArgs } from 'node:util';
+import { getElectronVersion } from '../lib/get-version';
 
 // run the script
 async function main () {

--- a/script/release/version-utils.ts
+++ b/script/release/version-utils.ts
@@ -1,5 +1,5 @@
-import * as semver from 'semver';
 import { GitProcess } from 'dugite';
+import * as semver from 'semver';
 
 import { ELECTRON_DIR } from '../lib/utils';
 

--- a/script/run-clang-tidy.ts
+++ b/script/run-clang-tidy.ts
@@ -1,12 +1,13 @@
-import * as childProcess from 'node:child_process';
-import * as fs from 'node:fs';
 import * as minimist from 'minimist';
-import * as os from 'node:os';
-import * as path from 'node:path';
 import * as streamChain from 'stream-chain';
 import * as streamJson from 'stream-json';
 import { ignore as streamJsonIgnore } from 'stream-json/filters/Ignore';
 import { streamArray as streamJsonStreamArray } from 'stream-json/streamers/StreamArray';
+
+import * as childProcess from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 import { chunkFilenames, findMatchingFiles } from './lib/utils';
 

--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -1,19 +1,23 @@
 #!/usr/bin/env node
 
 const { ElectronVersions, Installer } = require('@electron/fiddle-core');
+
 const chalk = require('chalk');
+const { hashElement } = require('folder-hash');
+const minimist = require('minimist');
+
 const childProcess = require('node:child_process');
 const crypto = require('node:crypto');
 const fs = require('node:fs');
-const { hashElement } = require('folder-hash');
 const os = require('node:os');
 const path = require('node:path');
+
 const unknownFlags = [];
 
 const pass = chalk.green('✓');
 const fail = chalk.red('✗');
 
-const args = require('minimist')(process.argv, {
+const args = minimist(process.argv, {
   string: ['runners', 'target', 'electronVersion'],
   unknown: arg => unknownFlags.push(arg)
 });

--- a/script/split-tests.js
+++ b/script/split-tests.js
@@ -1,5 +1,6 @@
-const fs = require('node:fs');
 const glob = require('glob');
+
+const fs = require('node:fs');
 
 const currentShard = parseInt(process.argv[2], 10);
 const shardCount = parseInt(process.argv[3], 10);

--- a/script/start.js
+++ b/script/start.js
@@ -1,5 +1,7 @@
 const cp = require('node:child_process');
+
 const utils = require('./lib/utils');
+
 const electronPath = utils.getAbsoluteElectronExec();
 
 const child = cp.spawn(electronPath, process.argv.slice(2), { stdio: 'inherit' });

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -1,18 +1,21 @@
+import { app, BrowserWindow, Menu, session, net as electronNet, WebContents, utilityProcess } from 'electron/main';
+
 import { assert, expect } from 'chai';
+import * as semver from 'semver';
+import split = require('split')
+
 import * as cp from 'node:child_process';
-import * as https from 'node:https';
-import * as http from 'node:http';
-import * as net from 'node:net';
+import { once } from 'node:events';
 import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as https from 'node:https';
+import * as net from 'node:net';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
-import { app, BrowserWindow, Menu, session, net as electronNet, WebContents, utilityProcess } from 'electron/main';
-import { closeWindow, closeAllWindows } from './lib/window-helpers';
-import { ifdescribe, ifit, listen, waitUntil } from './lib/spec-helpers';
+
 import { collectStreamBody, getResponse } from './lib/net-helpers';
-import { once } from 'node:events';
-import split = require('split')
-import * as semver from 'semver';
+import { ifdescribe, ifit, listen, waitUntil } from './lib/spec-helpers';
+import { closeWindow, closeAllWindows } from './lib/window-helpers';
 
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 

--- a/spec/api-auto-updater-spec.ts
+++ b/spec/api-auto-updater-spec.ts
@@ -1,7 +1,10 @@
 import { autoUpdater } from 'electron/main';
+
 import { expect } from 'chai';
-import { ifit, ifdescribe } from './lib/spec-helpers';
+
 import { once } from 'node:events';
+
+import { ifit, ifdescribe } from './lib/spec-helpers';
 
 ifdescribe(!process.mas)('autoUpdater module', function () {
   describe('checkForUpdates', function () {

--- a/spec/api-autoupdater-darwin-spec.ts
+++ b/spec/api-autoupdater-darwin-spec.ts
@@ -1,16 +1,19 @@
-import { expect } from 'chai';
-import * as cp from 'node:child_process';
-import * as http from 'node:http';
-import * as express from 'express';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import * as psList from 'ps-list';
-import { AddressInfo } from 'node:net';
-import { ifdescribe, ifit } from './lib/spec-helpers';
-import { copyMacOSFixtureApp, getCodesignIdentity, shouldRunCodesignTests, signApp, spawn } from './lib/codesign-helpers';
-import * as uuid from 'uuid';
 import { autoUpdater, systemPreferences } from 'electron';
+
+import { expect } from 'chai';
+import * as express from 'express';
+import * as psList from 'ps-list';
+import * as uuid from 'uuid';
+
+import * as cp from 'node:child_process';
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import { AddressInfo } from 'node:net';
+import * as path from 'node:path';
+
+import { copyMacOSFixtureApp, getCodesignIdentity, shouldRunCodesignTests, signApp, spawn } from './lib/codesign-helpers';
 import { withTempDirectory } from './lib/fs-helpers';
+import { ifdescribe, ifit } from './lib/spec-helpers';
 
 // We can only test the auto updater on darwin non-component builds
 ifdescribe(shouldRunCodesignTests)('autoUpdater behavior', function () {

--- a/spec/api-browser-view-spec.ts
+++ b/spec/api-browser-view-spec.ts
@@ -1,10 +1,13 @@
-import { expect } from 'chai';
-import * as path from 'node:path';
 import { BrowserView, BrowserWindow, screen, webContents } from 'electron/main';
-import { closeWindow } from './lib/window-helpers';
-import { defer, ifit, startRemoteControlApp } from './lib/spec-helpers';
-import { ScreenCapture, hasCapturableScreen } from './lib/screen-helpers';
+
+import { expect } from 'chai';
+
 import { once } from 'node:events';
+import * as path from 'node:path';
+
+import { ScreenCapture, hasCapturableScreen } from './lib/screen-helpers';
+import { defer, ifit, startRemoteControlApp } from './lib/spec-helpers';
+import { closeWindow } from './lib/window-helpers';
 
 describe('BrowserView module', () => {
   const fixtures = path.resolve(__dirname, 'fixtures');

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1,22 +1,24 @@
-import { expect } from 'chai';
-import * as childProcess from 'node:child_process';
-import * as path from 'node:path';
-import * as fs from 'node:fs';
-import * as qs from 'node:querystring';
-import * as http from 'node:http';
-import * as nodeUrl from 'node:url';
-import * as os from 'node:os';
-import { AddressInfo } from 'node:net';
+import { nativeImage } from 'electron';
 import { app, BrowserWindow, BrowserView, dialog, ipcMain, OnBeforeSendHeadersListenerDetails, net, protocol, screen, webContents, webFrameMain, session, WebContents, WebFrameMain } from 'electron/main';
 
+import { expect } from 'chai';
+
+import * as childProcess from 'node:child_process';
+import { once } from 'node:events';
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import { AddressInfo } from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as qs from 'node:querystring';
+import { setTimeout as syncSetTimeout } from 'node:timers';
+import { setTimeout } from 'node:timers/promises';
+import * as nodeUrl from 'node:url';
+
 import { emittedUntil, emittedNTimes } from './lib/events-helpers';
+import { HexColors, hasCapturableScreen, ScreenCapture } from './lib/screen-helpers';
 import { ifit, ifdescribe, defer, listen } from './lib/spec-helpers';
 import { closeWindow, closeAllWindows } from './lib/window-helpers';
-import { HexColors, hasCapturableScreen, ScreenCapture } from './lib/screen-helpers';
-import { once } from 'node:events';
-import { setTimeout } from 'node:timers/promises';
-import { setTimeout as syncSetTimeout } from 'node:timers';
-import { nativeImage } from 'electron';
 
 const fixtures = path.resolve(__dirname, 'fixtures');
 const mainFixtures = path.resolve(__dirname, 'fixtures');

--- a/spec/api-clipboard-spec.ts
+++ b/spec/api-clipboard-spec.ts
@@ -1,8 +1,11 @@
-import { expect } from 'chai';
-import * as path from 'node:path';
-import { Buffer } from 'node:buffer';
-import { ifdescribe, ifit } from './lib/spec-helpers';
 import { clipboard, nativeImage } from 'electron/common';
+
+import { expect } from 'chai';
+
+import { Buffer } from 'node:buffer';
+import * as path from 'node:path';
+
+import { ifdescribe, ifit } from './lib/spec-helpers';
 
 // FIXME(zcbenz): Clipboard tests are failing on WOA.
 ifdescribe(process.platform !== 'win32' || process.arch !== 'arm64')('clipboard module', () => {

--- a/spec/api-content-tracing-spec.ts
+++ b/spec/api-content-tracing-spec.ts
@@ -1,8 +1,11 @@
-import { expect } from 'chai';
 import { app, contentTracing, TraceConfig, TraceCategoriesAndOptions } from 'electron/main';
+
+import { expect } from 'chai';
+
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
+
 import { ifdescribe } from './lib/spec-helpers';
 
 // FIXME: The tests are skipped on linux arm/arm64

--- a/spec/api-context-bridge-spec.ts
+++ b/spec/api-context-bridge-spec.ts
@@ -1,15 +1,17 @@
 import { BrowserWindow, ipcMain } from 'electron/main';
 import { contextBridge } from 'electron/renderer';
+
 import { expect } from 'chai';
+
+import * as cp from 'node:child_process';
+import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import * as cp from 'node:child_process';
 
-import { closeWindow } from './lib/window-helpers';
 import { listen } from './lib/spec-helpers';
-import { once } from 'node:events';
+import { closeWindow } from './lib/window-helpers';
 
 const fixturesPath = path.resolve(__dirname, 'fixtures', 'api', 'context-bridge');
 

--- a/spec/api-crash-reporter-spec.ts
+++ b/spec/api-crash-reporter-spec.ts
@@ -1,14 +1,17 @@
-import { expect } from 'chai';
-import * as childProcess from 'node:child_process';
-import * as http from 'node:http';
-import * as Busboy from 'busboy';
-import * as path from 'node:path';
-import { ifdescribe, ifit, defer, startRemoteControlApp, repeatedly, listen } from './lib/spec-helpers';
 import { app } from 'electron/main';
+
+import * as Busboy from 'busboy';
+import { expect } from 'chai';
+import * as uuid from 'uuid';
+
+import * as childProcess from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import * as fs from 'node:fs';
-import * as uuid from 'uuid';
+import * as http from 'node:http';
+import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
+
+import { ifdescribe, ifit, defer, startRemoteControlApp, repeatedly, listen } from './lib/spec-helpers';
 
 const isWindowsOnArm = process.platform === 'win32' && process.arch === 'arm64';
 const isLinuxOnArm = process.platform === 'linux' && process.arch.includes('arm');

--- a/spec/api-debugger-spec.ts
+++ b/spec/api-debugger-spec.ts
@@ -1,11 +1,14 @@
+import { BrowserWindow } from 'electron/main';
+
 import { expect } from 'chai';
+
+import { once } from 'node:events';
 import * as http from 'node:http';
 import * as path from 'node:path';
-import { BrowserWindow } from 'electron/main';
-import { closeAllWindows } from './lib/window-helpers';
+
 import { emittedUntil } from './lib/events-helpers';
 import { listen } from './lib/spec-helpers';
-import { once } from 'node:events';
+import { closeAllWindows } from './lib/window-helpers';
 
 describe('debugger module', () => {
   const fixtures = path.resolve(__dirname, 'fixtures');

--- a/spec/api-desktop-capturer-spec.ts
+++ b/spec/api-desktop-capturer-spec.ts
@@ -1,9 +1,11 @@
-import { expect } from 'chai';
 import { screen, desktopCapturer, BrowserWindow } from 'electron/main';
+
+import { expect } from 'chai';
+
 import { once } from 'node:events';
 import { setTimeout } from 'node:timers/promises';
-import { ifdescribe, ifit } from './lib/spec-helpers';
 
+import { ifdescribe, ifit } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
 
 ifdescribe(!process.arch.includes('arm') && process.platform !== 'win32')('desktopCapturer', () => {

--- a/spec/api-dialog-spec.ts
+++ b/spec/api-dialog-spec.ts
@@ -1,8 +1,11 @@
-import { expect } from 'chai';
 import { dialog, BaseWindow, BrowserWindow } from 'electron/main';
-import { closeAllWindows } from './lib/window-helpers';
-import { ifit } from './lib/spec-helpers';
+
+import { expect } from 'chai';
+
 import { setTimeout } from 'node:timers/promises';
+
+import { ifit } from './lib/spec-helpers';
+import { closeAllWindows } from './lib/window-helpers';
 
 describe('dialog module', () => {
   describe('showOpenDialog', () => {

--- a/spec/api-global-shortcut-spec.ts
+++ b/spec/api-global-shortcut-spec.ts
@@ -1,5 +1,7 @@
-import { expect } from 'chai';
 import { globalShortcut } from 'electron/main';
+
+import { expect } from 'chai';
+
 import { ifdescribe } from './lib/spec-helpers';
 
 ifdescribe(process.platform !== 'win32')('globalShortcut module', () => {

--- a/spec/api-in-app-purchase-spec.ts
+++ b/spec/api-in-app-purchase-spec.ts
@@ -1,5 +1,7 @@
-import { expect } from 'chai';
 import { inAppPurchase } from 'electron/main';
+
+import { expect } from 'chai';
+
 import { ifdescribe } from './lib/spec-helpers';
 
 describe('inAppPurchase module', function () {

--- a/spec/api-ipc-main-spec.ts
+++ b/spec/api-ipc-main-spec.ts
@@ -1,10 +1,13 @@
-import { expect } from 'chai';
-import * as path from 'node:path';
-import * as cp from 'node:child_process';
-import { closeAllWindows } from './lib/window-helpers';
-import { defer } from './lib/spec-helpers';
 import { ipcMain, BrowserWindow } from 'electron/main';
+
+import { expect } from 'chai';
+
+import * as cp from 'node:child_process';
 import { once } from 'node:events';
+import * as path from 'node:path';
+
+import { defer } from './lib/spec-helpers';
+import { closeAllWindows } from './lib/window-helpers';
 
 describe('ipc main module', () => {
   const fixtures = path.join(__dirname, 'fixtures');

--- a/spec/api-ipc-renderer-spec.ts
+++ b/spec/api-ipc-renderer-spec.ts
@@ -1,7 +1,10 @@
-import { expect } from 'chai';
 import { ipcMain, BrowserWindow } from 'electron/main';
-import { closeWindow } from './lib/window-helpers';
+
+import { expect } from 'chai';
+
 import { once } from 'node:events';
+
+import { closeWindow } from './lib/window-helpers';
 
 describe('ipcRenderer module', () => {
   let w: BrowserWindow;

--- a/spec/api-ipc-spec.ts
+++ b/spec/api-ipc-spec.ts
@@ -1,10 +1,13 @@
-import { EventEmitter, once } from 'node:events';
-import { expect } from 'chai';
 import { BrowserWindow, ipcMain, IpcMainInvokeEvent, MessageChannelMain, WebContents } from 'electron/main';
-import { closeAllWindows } from './lib/window-helpers';
-import { defer, listen } from './lib/spec-helpers';
-import * as path from 'node:path';
+
+import { expect } from 'chai';
+
+import { EventEmitter, once } from 'node:events';
 import * as http from 'node:http';
+import * as path from 'node:path';
+
+import { defer, listen } from './lib/spec-helpers';
+import { closeAllWindows } from './lib/window-helpers';
 
 const v8Util = process._linkedBinding('electron_common_v8_util');
 const fixturesPath = path.resolve(__dirname, 'fixtures');

--- a/spec/api-media-handler-spec.ts
+++ b/spec/api-media-handler-spec.ts
@@ -1,8 +1,11 @@
-import { expect } from 'chai';
 import { BrowserWindow, session, desktopCapturer } from 'electron/main';
-import { closeAllWindows } from './lib/window-helpers';
+
+import { expect } from 'chai';
+
 import * as http from 'node:http';
+
 import { ifit, listen } from './lib/spec-helpers';
+import { closeAllWindows } from './lib/window-helpers';
 
 describe('setDisplayMediaRequestHandler', () => {
   afterEach(closeAllWindows);

--- a/spec/api-menu-item-spec.ts
+++ b/spec/api-menu-item-spec.ts
@@ -1,5 +1,7 @@
 import { BrowserWindow, app, Menu, MenuItem, MenuItemConstructorOptions } from 'electron/main';
+
 import { expect } from 'chai';
+
 import { ifdescribe } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
 import { roleList, execute } from '../lib/browser/api/menu-item-roles';

--- a/spec/api-menu-spec.ts
+++ b/spec/api-menu-spec.ts
@@ -1,12 +1,15 @@
-import * as cp from 'node:child_process';
-import * as path from 'node:path';
-import { assert, expect } from 'chai';
 import { BrowserWindow, Menu, MenuItem } from 'electron/main';
-import { sortMenuItems } from '../lib/browser/api/menu-utils';
+
+import { assert, expect } from 'chai';
+
+import * as cp from 'node:child_process';
+import { once } from 'node:events';
+import * as path from 'node:path';
+import { setTimeout } from 'node:timers/promises';
+
 import { ifit } from './lib/spec-helpers';
 import { closeWindow } from './lib/window-helpers';
-import { once } from 'node:events';
-import { setTimeout } from 'node:timers/promises';
+import { sortMenuItems } from '../lib/browser/api/menu-utils';
 
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 

--- a/spec/api-native-image-spec.ts
+++ b/spec/api-native-image-spec.ts
@@ -1,7 +1,10 @@
-import { expect } from 'chai';
 import { nativeImage } from 'electron/common';
-import { ifdescribe, ifit, itremote, useRemoteContext } from './lib/spec-helpers';
+
+import { expect } from 'chai';
+
 import * as path from 'node:path';
+
+import { ifdescribe, ifit, itremote, useRemoteContext } from './lib/spec-helpers';
 
 describe('nativeImage module', () => {
   const fixturesPath = path.join(__dirname, 'fixtures');

--- a/spec/api-native-theme-spec.ts
+++ b/spec/api-native-theme-spec.ts
@@ -1,5 +1,7 @@
-import { expect } from 'chai';
 import { nativeTheme, BrowserWindow, ipcMain } from 'electron/main';
+
+import { expect } from 'chai';
+
 import { once } from 'node:events';
 import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';

--- a/spec/api-net-custom-protocols-spec.ts
+++ b/spec/api-net-custom-protocols-spec.ts
@@ -1,7 +1,10 @@
-import { expect } from 'chai';
 import { net, protocol } from 'electron/main';
-import * as url from 'node:url';
+
+import { expect } from 'chai';
+
 import * as path from 'node:path';
+import * as url from 'node:url';
+
 import { defer } from './lib/spec-helpers';
 
 describe('net module custom protocols', () => {

--- a/spec/api-net-log-spec.ts
+++ b/spec/api-net-log-spec.ts
@@ -1,13 +1,16 @@
+import { session, net } from 'electron/main';
+
 import { expect } from 'chai';
-import * as http from 'node:http';
+
+import * as ChildProcess from 'node:child_process';
+import { once } from 'node:events';
 import * as fs from 'node:fs';
+import * as http from 'node:http';
+import { Socket } from 'node:net';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import * as ChildProcess from 'node:child_process';
-import { session, net } from 'electron/main';
-import { Socket } from 'node:net';
+
 import { ifit, listen } from './lib/spec-helpers';
-import { once } from 'node:events';
 
 const appPath = path.join(__dirname, 'fixtures', 'api', 'net-log');
 const dumpFile = path.join(os.tmpdir(), 'net_log.json');

--- a/spec/api-net-session-spec.ts
+++ b/spec/api-net-session-spec.ts
@@ -1,6 +1,9 @@
-import { expect } from 'chai';
-import * as dns from 'node:dns';
 import { net, session, BrowserWindow, ClientRequestConstructorOptions } from 'electron/main';
+
+import { expect } from 'chai';
+
+import * as dns from 'node:dns';
+
 import { collectStreamBody, getResponse, respondNTimes, respondOnce } from './lib/net-helpers';
 
 // See https://github.com/nodejs/node/issues/40702.

--- a/spec/api-net-spec.ts
+++ b/spec/api-net-spec.ts
@@ -1,9 +1,12 @@
-import { expect } from 'chai';
 import { net, ClientRequest, ClientRequestConstructorOptions, utilityProcess } from 'electron/main';
+
+import { expect } from 'chai';
+
+import { once } from 'node:events';
 import * as http from 'node:http';
 import * as path from 'node:path';
-import { once } from 'node:events';
 import { setTimeout } from 'node:timers/promises';
+
 import { collectStreamBody, collectStreamBodyBuffer, getResponse, kOneKiloByte, kOneMegaByte, randomBuffer, randomString, respondNTimes, respondOnce } from './lib/net-helpers';
 
 const utilityFixturePath = path.resolve(__dirname, 'fixtures', 'api', 'utility-process', 'api-net-spec.js');

--- a/spec/api-notification-dbus-spec.ts
+++ b/spec/api-notification-dbus-spec.ts
@@ -6,13 +6,16 @@
 //
 // See https://pypi.python.org/pypi/python-dbusmock to read about dbusmock.
 
+import { nativeImage } from 'electron/common';
+import { app } from 'electron/main';
+
 import { expect } from 'chai';
 import * as dbus from 'dbus-native';
-import { app } from 'electron/main';
-import { nativeImage } from 'electron/common';
-import { ifdescribe } from './lib/spec-helpers';
-import { promisify } from 'node:util';
+
 import * as path from 'node:path';
+import { promisify } from 'node:util';
+
+import { ifdescribe } from './lib/spec-helpers';
 
 const fixturesPath = path.join(__dirname, 'fixtures');
 

--- a/spec/api-notification-spec.ts
+++ b/spec/api-notification-spec.ts
@@ -1,6 +1,9 @@
-import { expect } from 'chai';
 import { Notification } from 'electron/main';
+
+import { expect } from 'chai';
+
 import { once } from 'node:events';
+
 import { ifit } from './lib/spec-helpers';
 
 describe('Notification module', () => {

--- a/spec/api-power-monitor-spec.ts
+++ b/spec/api-power-monitor-spec.ts
@@ -8,10 +8,12 @@
 // python-dbusmock.
 import { expect } from 'chai';
 import * as dbus from 'dbus-native';
-import { ifdescribe, startRemoteControlApp } from './lib/spec-helpers';
-import { promisify } from 'node:util';
-import { setTimeout } from 'node:timers/promises';
+
 import { once } from 'node:events';
+import { setTimeout } from 'node:timers/promises';
+import { promisify } from 'node:util';
+
+import { ifdescribe, startRemoteControlApp } from './lib/spec-helpers';
 
 describe('powerMonitor', () => {
   let logindMock: any, dbusMockPowerMonitor: any, getCalls: any, emitSignal: any, reset: any;

--- a/spec/api-power-save-blocker-spec.ts
+++ b/spec/api-power-save-blocker-spec.ts
@@ -1,5 +1,6 @@
-import { expect } from 'chai';
 import { powerSaveBlocker } from 'electron/main';
+
+import { expect } from 'chai';
 
 describe('powerSaveBlocker module', () => {
   it('can be started and stopped', () => {

--- a/spec/api-process-spec.ts
+++ b/spec/api-process-spec.ts
@@ -1,9 +1,12 @@
+import { BrowserWindow } from 'electron';
+import { app } from 'electron/main';
+
+import { expect } from 'chai';
+
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { expect } from 'chai';
-import { BrowserWindow } from 'electron';
+
 import { defer } from './lib/spec-helpers';
-import { app } from 'electron/main';
 import { closeAllWindows } from './lib/window-helpers';
 
 describe('process module', () => {

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -1,20 +1,23 @@
+import { protocol, webContents, WebContents, session, BrowserWindow, ipcMain, net } from 'electron/main';
+
 import { expect } from 'chai';
 import { v4 } from 'uuid';
-import { protocol, webContents, WebContents, session, BrowserWindow, ipcMain, net } from 'electron/main';
+
 import * as ChildProcess from 'node:child_process';
-import * as path from 'node:path';
-import * as url from 'node:url';
-import * as http from 'node:http';
+import { EventEmitter, once } from 'node:events';
 import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as path from 'node:path';
 import * as qs from 'node:querystring';
 import * as stream from 'node:stream';
 import * as streamConsumers from 'node:stream/consumers';
 import * as webStream from 'node:stream/web';
-import { EventEmitter, once } from 'node:events';
-import { closeAllWindows, closeWindow } from './lib/window-helpers';
-import { WebmGenerator } from './lib/video-helpers';
-import { listen, defer, ifit } from './lib/spec-helpers';
 import { setTimeout } from 'node:timers/promises';
+import * as url from 'node:url';
+
+import { listen, defer, ifit } from './lib/spec-helpers';
+import { WebmGenerator } from './lib/video-helpers';
+import { closeAllWindows, closeWindow } from './lib/window-helpers';
 
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 

--- a/spec/api-safe-storage-spec.ts
+++ b/spec/api-safe-storage-spec.ts
@@ -1,10 +1,13 @@
-import * as cp from 'node:child_process';
-import * as path from 'node:path';
 import { safeStorage } from 'electron/main';
+
 import { expect } from 'chai';
-import { ifdescribe } from './lib/spec-helpers';
-import * as fs from 'node:fs';
+
+import * as cp from 'node:child_process';
 import { once } from 'node:events';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { ifdescribe } from './lib/spec-helpers';
 
 describe('safeStorage module', () => {
   it('safeStorage before and after app is ready', async () => {

--- a/spec/api-screen-spec.ts
+++ b/spec/api-screen-spec.ts
@@ -1,5 +1,6 @@
-import { expect } from 'chai';
 import { Display, screen, desktopCapturer } from 'electron/main';
+
+import { expect } from 'chai';
 
 describe('screen module', () => {
   describe('methods reassignment', () => {

--- a/spec/api-service-workers-spec.ts
+++ b/spec/api-service-workers-spec.ts
@@ -1,11 +1,14 @@
+import { session, webContents, WebContents } from 'electron/main';
+
+import { expect } from 'chai';
+import { v4 } from 'uuid';
+
+import { on, once } from 'node:events';
 import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as path from 'node:path';
-import { session, webContents, WebContents } from 'electron/main';
-import { expect } from 'chai';
-import { v4 } from 'uuid';
+
 import { listen } from './lib/spec-helpers';
-import { on, once } from 'node:events';
 
 const partition = 'service-workers-spec';
 

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -1,17 +1,20 @@
+import { app, session, BrowserWindow, net, ipcMain, Session, webFrameMain, WebFrameMain } from 'electron/main';
+
+import * as auth from 'basic-auth';
 import { expect } from 'chai';
+import * as send from 'send';
+
+import * as ChildProcess from 'node:child_process';
 import * as crypto from 'node:crypto';
+import { once } from 'node:events';
+import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as https from 'node:https';
 import * as path from 'node:path';
-import * as fs from 'node:fs';
-import * as ChildProcess from 'node:child_process';
-import { app, session, BrowserWindow, net, ipcMain, Session, webFrameMain, WebFrameMain } from 'electron/main';
-import * as send from 'send';
-import * as auth from 'basic-auth';
-import { closeAllWindows } from './lib/window-helpers';
-import { defer, listen } from './lib/spec-helpers';
-import { once } from 'node:events';
 import { setTimeout } from 'node:timers/promises';
+
+import { defer, listen } from './lib/spec-helpers';
+import { closeAllWindows } from './lib/window-helpers';
 
 describe('session module', () => {
   const fixtures = path.resolve(__dirname, 'fixtures');

--- a/spec/api-shell-spec.ts
+++ b/spec/api-shell-spec.ts
@@ -1,13 +1,16 @@
-import { BrowserWindow, app } from 'electron/main';
 import { shell } from 'electron/common';
-import { closeAllWindows } from './lib/window-helpers';
-import { ifdescribe, ifit, listen } from './lib/spec-helpers';
-import * as http from 'node:http';
+import { BrowserWindow, app } from 'electron/main';
+
+import { expect } from 'chai';
+
+import { once } from 'node:events';
 import * as fs from 'node:fs';
+import * as http from 'node:http';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { expect } from 'chai';
-import { once } from 'node:events';
+
+import { ifdescribe, ifit, listen } from './lib/spec-helpers';
+import { closeAllWindows } from './lib/window-helpers';
 
 describe('shell module', () => {
   describe('shell.openExternal()', () => {

--- a/spec/api-subframe-spec.ts
+++ b/spec/api-subframe-spec.ts
@@ -1,11 +1,14 @@
-import { expect } from 'chai';
-import * as path from 'node:path';
-import * as http from 'node:http';
-import { emittedNTimes } from './lib/events-helpers';
-import { closeWindow } from './lib/window-helpers';
 import { app, BrowserWindow, ipcMain } from 'electron/main';
-import { ifdescribe, listen } from './lib/spec-helpers';
+
+import { expect } from 'chai';
+
 import { once } from 'node:events';
+import * as http from 'node:http';
+import * as path from 'node:path';
+
+import { emittedNTimes } from './lib/events-helpers';
+import { ifdescribe, listen } from './lib/spec-helpers';
+import { closeWindow } from './lib/window-helpers';
 
 describe('renderer nodeIntegrationInSubFrames', () => {
   const generateTests = (description: string, webPreferences: any) => {

--- a/spec/api-system-preferences-spec.ts
+++ b/spec/api-system-preferences-spec.ts
@@ -1,5 +1,7 @@
-import { expect } from 'chai';
 import { systemPreferences } from 'electron/main';
+
+import { expect } from 'chai';
+
 import { ifdescribe } from './lib/spec-helpers';
 
 describe('systemPreferences module', () => {

--- a/spec/api-touch-bar-spec.ts
+++ b/spec/api-touch-bar-spec.ts
@@ -1,7 +1,10 @@
-import * as path from 'node:path';
 import { BaseWindow, BrowserWindow, TouchBar } from 'electron/main';
-import { closeWindow } from './lib/window-helpers';
+
 import { expect } from 'chai';
+
+import * as path from 'node:path';
+
+import { closeWindow } from './lib/window-helpers';
 
 const { TouchBarButton, TouchBarColorPicker, TouchBarGroup, TouchBarLabel, TouchBarOtherItemsProxy, TouchBarPopover, TouchBarScrubber, TouchBarSegmentedControl, TouchBarSlider, TouchBarSpacer } = TouchBar;
 

--- a/spec/api-tray-spec.ts
+++ b/spec/api-tray-spec.ts
@@ -1,9 +1,12 @@
-import { expect } from 'chai';
-import { Menu, Tray } from 'electron/main';
 import { nativeImage } from 'electron/common';
-import { ifdescribe, ifit } from './lib/spec-helpers';
+import { Menu, Tray } from 'electron/main';
+
+import { expect } from 'chai';
+
 import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
+
+import { ifdescribe, ifit } from './lib/spec-helpers';
 
 describe('tray module', () => {
   let tray: Tray;

--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -1,14 +1,17 @@
-import { expect } from 'chai';
-import * as childProcess from 'node:child_process';
-import * as path from 'node:path';
+import { systemPreferences } from 'electron';
 import { BrowserWindow, MessageChannelMain, utilityProcess, app } from 'electron/main';
+
+import { expect } from 'chai';
+
+import * as childProcess from 'node:child_process';
+import { once } from 'node:events';
+import * as path from 'node:path';
+import { setImmediate } from 'node:timers/promises';
+import { pathToFileURL } from 'node:url';
+
+import { respondOnce, randomString, kOneKiloByte } from './lib/net-helpers';
 import { ifit, startRemoteControlApp } from './lib/spec-helpers';
 import { closeWindow } from './lib/window-helpers';
-import { respondOnce, randomString, kOneKiloByte } from './lib/net-helpers';
-import { once } from 'node:events';
-import { pathToFileURL } from 'node:url';
-import { setImmediate } from 'node:timers/promises';
-import { systemPreferences } from 'electron';
 
 const fixturesPath = path.resolve(__dirname, 'fixtures', 'api', 'utility-process');
 const isWindowsOnArm = process.platform === 'win32' && process.arch === 'arm64';

--- a/spec/api-view-spec.ts
+++ b/spec/api-view-spec.ts
@@ -1,6 +1,8 @@
-import { expect } from 'chai';
-import { closeWindow } from './lib/window-helpers';
 import { BaseWindow, View } from 'electron/main';
+
+import { expect } from 'chai';
+
+import { closeWindow } from './lib/window-helpers';
 
 describe('View', () => {
   let w: BaseWindow;

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -1,16 +1,19 @@
+import { BrowserWindow, ipcMain, webContents, session, app, BrowserView, WebContents } from 'electron/main';
+
 import { expect } from 'chai';
-import { AddressInfo } from 'node:net';
+
 import * as cp from 'node:child_process';
-import * as path from 'node:path';
+import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as http from 'node:http';
+import { AddressInfo } from 'node:net';
 import * as os from 'node:os';
-import * as url from 'node:url';
-import { BrowserWindow, ipcMain, webContents, session, app, BrowserView, WebContents } from 'electron/main';
-import { closeAllWindows } from './lib/window-helpers';
-import { ifdescribe, defer, waitUntil, listen, ifit } from './lib/spec-helpers';
-import { once } from 'node:events';
+import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
+import * as url from 'node:url';
+
+import { ifdescribe, defer, waitUntil, listen, ifit } from './lib/spec-helpers';
+import { closeAllWindows } from './lib/window-helpers';
 
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 const features = process._linkedBinding('electron_common_features');

--- a/spec/api-web-contents-view-spec.ts
+++ b/spec/api-web-contents-view-spec.ts
@@ -1,10 +1,12 @@
-import { expect } from 'chai';
 import { BaseWindow, BrowserWindow, View, WebContentsView, webContents, screen } from 'electron/main';
+
+import { expect } from 'chai';
+
 import { once } from 'node:events';
 
-import { closeAllWindows } from './lib/window-helpers';
-import { defer, ifdescribe, waitUntil } from './lib/spec-helpers';
 import { HexColors, ScreenCapture, hasCapturableScreen, nextFrameTime } from './lib/screen-helpers';
+import { defer, ifdescribe, waitUntil } from './lib/spec-helpers';
+import { closeAllWindows } from './lib/window-helpers';
 
 describe('WebContentsView', () => {
   afterEach(closeAllWindows);

--- a/spec/api-web-frame-main-spec.ts
+++ b/spec/api-web-frame-main-spec.ts
@@ -1,13 +1,16 @@
+import { BrowserWindow, WebFrameMain, webFrameMain, ipcMain, app, WebContents } from 'electron/main';
+
 import { expect } from 'chai';
+
+import { once } from 'node:events';
 import * as http from 'node:http';
 import * as path from 'node:path';
+import { setTimeout } from 'node:timers/promises';
 import * as url from 'node:url';
-import { BrowserWindow, WebFrameMain, webFrameMain, ipcMain, app, WebContents } from 'electron/main';
-import { closeAllWindows } from './lib/window-helpers';
+
 import { emittedNTimes } from './lib/events-helpers';
 import { defer, ifit, listen, waitUntil } from './lib/spec-helpers';
-import { once } from 'node:events';
-import { setTimeout } from 'node:timers/promises';
+import { closeAllWindows } from './lib/window-helpers';
 
 describe('webFrameMain module', () => {
   const fixtures = path.resolve(__dirname, 'fixtures');

--- a/spec/api-web-frame-spec.ts
+++ b/spec/api-web-frame-spec.ts
@@ -1,8 +1,11 @@
-import { expect } from 'chai';
-import * as path from 'node:path';
 import { BrowserWindow, ipcMain, WebContents } from 'electron/main';
-import { defer } from './lib/spec-helpers';
+
+import { expect } from 'chai';
+
 import { once } from 'node:events';
+import * as path from 'node:path';
+
+import { defer } from './lib/spec-helpers';
 
 describe('webFrame module', () => {
   const fixtures = path.resolve(__dirname, 'fixtures');

--- a/spec/api-web-request-spec.ts
+++ b/spec/api-web-request-spec.ts
@@ -1,16 +1,19 @@
+import { ipcMain, protocol, session, WebContents, webContents } from 'electron/main';
+
 import { expect } from 'chai';
+import * as WebSocket from 'ws';
+
+import { once } from 'node:events';
+import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as http2 from 'node:http2';
-import * as qs from 'node:querystring';
-import * as path from 'node:path';
-import * as fs from 'node:fs';
-import * as url from 'node:url';
-import * as WebSocket from 'ws';
-import { ipcMain, protocol, session, WebContents, webContents } from 'electron/main';
 import { Socket } from 'node:net';
-import { listen, defer } from './lib/spec-helpers';
-import { once } from 'node:events';
+import * as path from 'node:path';
+import * as qs from 'node:querystring';
 import { ReadableStream } from 'node:stream/web';
+import * as url from 'node:url';
+
+import { listen, defer } from './lib/spec-helpers';
 
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 

--- a/spec/api-web-utils-spec.ts
+++ b/spec/api-web-utils-spec.ts
@@ -1,7 +1,11 @@
-import { expect } from 'chai';
-import * as path from 'node:path';
 import { BrowserWindow } from 'electron/main';
+
+import { expect } from 'chai';
+
+import * as path from 'node:path';
+
 import { defer } from './lib/spec-helpers';
+
 // import { once } from 'node:events';
 
 describe('webUtils module', () => {

--- a/spec/asar-integrity-spec.ts
+++ b/spec/asar-integrity-spec.ts
@@ -1,16 +1,18 @@
+import { getRawHeader } from '@electron/asar';
+import { flipFuses, FuseV1Config, FuseV1Options, FuseVersion } from '@electron/fuses';
+import { resedit } from '@electron/packager/dist/resedit';
+
 import { expect } from 'chai';
+import * as originalFs from 'node:original-fs';
+
 import * as cp from 'node:child_process';
 import * as nodeCrypto from 'node:crypto';
-import * as originalFs from 'node:original-fs';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { ifdescribe } from './lib/spec-helpers';
 
-import { getRawHeader } from '@electron/asar';
-import { resedit } from '@electron/packager/dist/resedit';
-import { flipFuses, FuseV1Config, FuseV1Options, FuseVersion } from '@electron/fuses';
 import { copyApp } from './lib/fs-helpers';
+import { ifdescribe } from './lib/spec-helpers';
 
 const bufferReplace = (haystack: Buffer, needle: string, replacement: string, throwOnMissing = true): Buffer => {
   const needleBuffer = Buffer.from(needle);

--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -1,12 +1,15 @@
+import { BrowserWindow, ipcMain } from 'electron/main';
+
 import { expect } from 'chai';
+
+import { once } from 'node:events';
+import * as importedFs from 'node:fs';
 import * as path from 'node:path';
 import * as url from 'node:url';
 import { Worker } from 'node:worker_threads';
-import { BrowserWindow, ipcMain } from 'electron/main';
-import { closeAllWindows } from './lib/window-helpers';
+
 import { getRemoteContext, ifdescribe, ifit, itremote, useRemoteContext } from './lib/spec-helpers';
-import * as importedFs from 'node:fs';
-import { once } from 'node:events';
+import { closeAllWindows } from './lib/window-helpers';
 
 describe('asar package', () => {
   const fixtures = path.join(__dirname, 'fixtures');

--- a/spec/autofill-spec.ts
+++ b/spec/autofill-spec.ts
@@ -1,8 +1,11 @@
 import { BrowserWindow } from 'electron';
-import * as path from 'node:path';
+
 import { expect } from 'chai';
-import { closeAllWindows } from './lib/window-helpers';
+
+import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
+
+import { closeAllWindows } from './lib/window-helpers';
 
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -1,20 +1,23 @@
-import { expect } from 'chai';
-import { BrowserWindow, WebContents, webFrameMain, session, ipcMain, app, protocol, webContents, dialog, MessageBoxOptions } from 'electron/main';
+import { MediaAccessPermissionRequest } from 'electron';
 import { clipboard } from 'electron/common';
-import { closeAllWindows } from './lib/window-helpers';
-import * as https from 'node:https';
-import * as http from 'node:http';
-import * as path from 'node:path';
-import * as fs from 'node:fs';
-import * as url from 'node:url';
+import { BrowserWindow, WebContents, webFrameMain, session, ipcMain, app, protocol, webContents, dialog, MessageBoxOptions } from 'electron/main';
+
+import { expect } from 'chai';
+import * as ws from 'ws';
+
 import * as ChildProcess from 'node:child_process';
 import { EventEmitter, once } from 'node:events';
-import { ifit, ifdescribe, defer, itremote, listen } from './lib/spec-helpers';
-import { PipeTransport } from './pipe-transport';
-import * as ws from 'ws';
-import { setTimeout } from 'node:timers/promises';
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as https from 'node:https';
 import { AddressInfo } from 'node:net';
-import { MediaAccessPermissionRequest } from 'electron';
+import * as path from 'node:path';
+import { setTimeout } from 'node:timers/promises';
+import * as url from 'node:url';
+
+import { ifit, ifdescribe, defer, itremote, listen } from './lib/spec-helpers';
+import { closeAllWindows } from './lib/window-helpers';
+import { PipeTransport } from './pipe-transport';
 
 const features = process._linkedBinding('electron_common_features');
 

--- a/spec/crash-spec.ts
+++ b/spec/crash-spec.ts
@@ -1,7 +1,9 @@
 import { expect } from 'chai';
+
 import * as cp from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+
 import { ifit } from './lib/spec-helpers';
 
 const fixturePath = path.resolve(__dirname, 'fixtures', 'crash-cases');

--- a/spec/deprecate-spec.ts
+++ b/spec/deprecate-spec.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+
 import * as deprecate from '../lib/common/deprecate';
 
 describe('deprecate', () => {

--- a/spec/esm-spec.ts
+++ b/spec/esm-spec.ts
@@ -1,6 +1,8 @@
-import { expect } from 'chai';
-import * as cp from 'node:child_process';
 import { BrowserWindow } from 'electron';
+
+import { expect } from 'chai';
+
+import * as cp from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/spec/extensions-spec.ts
+++ b/spec/extensions-spec.ts
@@ -1,13 +1,16 @@
-import { expect } from 'chai';
 import { app, session, BrowserWindow, ipcMain, WebContents, Extension, Session } from 'electron/main';
-import { closeAllWindows, closeWindow } from './lib/window-helpers';
+
+import { expect } from 'chai';
+import * as WebSocket from 'ws';
+
+import { once } from 'node:events';
+import * as fs from 'node:fs/promises';
 import * as http from 'node:http';
 import * as path from 'node:path';
-import * as fs from 'node:fs/promises';
-import * as WebSocket from 'ws';
+
 import { emittedNTimes, emittedUntil } from './lib/events-helpers';
 import { ifit, listen, waitUntil } from './lib/spec-helpers';
-import { once } from 'node:events';
+import { closeAllWindows, closeWindow } from './lib/window-helpers';
 
 const uuid = require('uuid');
 

--- a/spec/fixtures/api/context-bridge/context-bridge-mutability/main.js
+++ b/spec/fixtures/api/context-bridge/context-bridge-mutability/main.js
@@ -1,4 +1,5 @@
 const { app, BrowserWindow } = require('electron');
+
 const path = require('node:path');
 
 let win;

--- a/spec/fixtures/api/mixed-sandbox-app/main.js
+++ b/spec/fixtures/api/mixed-sandbox-app/main.js
@@ -1,4 +1,5 @@
 const { app, BrowserWindow, ipcMain } = require('electron');
+
 const net = require('node:net');
 const path = require('node:path');
 

--- a/spec/fixtures/api/relaunch/main.js
+++ b/spec/fixtures/api/relaunch/main.js
@@ -1,4 +1,5 @@
 const { app } = require('electron');
+
 const net = require('node:net');
 
 const socketPath = process.platform === 'win32' ? '\\\\.\\pipe\\electron-app-relaunch' : '/tmp/electron-app-relaunch';

--- a/spec/fixtures/api/safe-storage/decrypt-app/main.js
+++ b/spec/fixtures/api/safe-storage/decrypt-app/main.js
@@ -1,4 +1,5 @@
 const { app, safeStorage } = require('electron');
+
 const { promises: fs } = require('node:fs');
 const path = require('node:path');
 

--- a/spec/fixtures/api/safe-storage/encrypt-app/main.js
+++ b/spec/fixtures/api/safe-storage/encrypt-app/main.js
@@ -1,4 +1,5 @@
 const { app, safeStorage } = require('electron');
+
 const { promises: fs } = require('node:fs');
 const path = require('node:path');
 

--- a/spec/fixtures/api/singleton-userdata/main.js
+++ b/spec/fixtures/api/singleton-userdata/main.js
@@ -1,4 +1,5 @@
 const { app } = require('electron');
+
 const fs = require('node:fs');
 const path = require('node:path');
 

--- a/spec/fixtures/api/utility-process/api-net-spec.js
+++ b/spec/fixtures/api/utility-process/api-net-spec.js
@@ -2,14 +2,17 @@
 /* eslint-disable camelcase */
 require('ts-node/register');
 
-const chai_1 = require('chai');
 const main_1 = require('electron/main');
-const http = require('node:http');
-const url = require('node:url');
+
+const chai_1 = require('chai');
+
 const node_events_1 = require('node:events');
+const http = require('node:http');
 const promises_1 = require('node:timers/promises');
-const net_helpers_1 = require('../../../lib/net-helpers');
+const url = require('node:url');
 const v8 = require('node:v8');
+
+const net_helpers_1 = require('../../../lib/net-helpers');
 
 v8.setFlagsFromString('--expose_gc');
 chai_1.use(require('chai-as-promised'));

--- a/spec/fixtures/api/utility-process/dns-result-order.js
+++ b/spec/fixtures/api/utility-process/dns-result-order.js
@@ -1,3 +1,4 @@
 const dns = require('node:dns');
+
 console.log(dns.getDefaultResultOrder());
 process.exit(0);

--- a/spec/fixtures/api/utility-process/env-app/main.js
+++ b/spec/fixtures/api/utility-process/env-app/main.js
@@ -1,4 +1,5 @@
 const { app, utilityProcess } = require('electron');
+
 const path = require('node:path');
 
 app.whenReady().then(() => {

--- a/spec/fixtures/api/utility-process/inherit-stderr/main.js
+++ b/spec/fixtures/api/utility-process/inherit-stderr/main.js
@@ -1,4 +1,5 @@
 const { app, utilityProcess } = require('electron');
+
 const path = require('node:path');
 
 app.whenReady().then(() => {

--- a/spec/fixtures/api/utility-process/inherit-stdout/main.js
+++ b/spec/fixtures/api/utility-process/inherit-stdout/main.js
@@ -1,4 +1,5 @@
 const { app, utilityProcess } = require('electron');
+
 const path = require('node:path');
 
 app.whenReady().then(() => {

--- a/spec/fixtures/api/utility-process/net.js
+++ b/spec/fixtures/api/utility-process/net.js
@@ -1,4 +1,5 @@
 const { net } = require('electron');
+
 const serverUrl = process.argv[2].split('=')[1];
 let configurableArg = null;
 if (process.argv[3]) {

--- a/spec/fixtures/api/utility-process/suid.js
+++ b/spec/fixtures/api/utility-process/suid.js
@@ -1,2 +1,3 @@
 const result = require('node:child_process').execSync('sudo --help');
+
 process.parentPort.postMessage(result);

--- a/spec/fixtures/apps/crash/fork.js
+++ b/spec/fixtures/apps/crash/fork.js
@@ -1,5 +1,5 @@
-const path = require('node:path');
 const childProcess = require('node:child_process');
+const path = require('node:path');
 
 const crashPath = path.join(__dirname, 'node-crash.js');
 const child = childProcess.fork(crashPath, { silent: true });

--- a/spec/fixtures/apps/crash/main.js
+++ b/spec/fixtures/apps/crash/main.js
@@ -1,6 +1,7 @@
 const { app, BrowserWindow, crashReporter } = require('electron');
-const path = require('node:path');
+
 const childProcess = require('node:child_process');
+const path = require('node:path');
 
 app.setVersion('0.1.0');
 

--- a/spec/fixtures/apps/libuv-hang/main.js
+++ b/spec/fixtures/apps/libuv-hang/main.js
@@ -1,4 +1,5 @@
 const { app, BrowserWindow, ipcMain } = require('electron');
+
 const path = require('node:path');
 
 async function createWindow () {

--- a/spec/fixtures/apps/open-new-window-from-link/main.js
+++ b/spec/fixtures/apps/open-new-window-from-link/main.js
@@ -1,4 +1,5 @@
 const { app, BrowserWindow } = require('electron');
+
 const path = require('node:path');
 
 async function createWindow () {

--- a/spec/fixtures/apps/refresh-page/main.js
+++ b/spec/fixtures/apps/refresh-page/main.js
@@ -1,7 +1,8 @@
-const path = require('node:path');
-const { once } = require('node:events');
-const { pathToFileURL } = require('node:url');
 const { BrowserWindow, app, protocol, net, session } = require('electron');
+
+const { once } = require('node:events');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
 
 if (process.argv.length < 4) {
   console.error('Must pass allow_code_cache code_cache_dir');

--- a/spec/fixtures/apps/remote-control/main.js
+++ b/spec/fixtures/apps/remote-control/main.js
@@ -1,11 +1,12 @@
 // eslint-disable-next-line camelcase
 const electron_1 = require('electron');
+
 // eslint-disable-next-line camelcase
 const { app } = electron_1;
 const http = require('node:http');
-const v8 = require('node:v8');
 // eslint-disable-next-line camelcase,@typescript-eslint/no-unused-vars
 const promises_1 = require('node:timers/promises');
+const v8 = require('node:v8');
 
 if (app.commandLine.hasSwitch('boot-eval')) {
   // eslint-disable-next-line no-eval

--- a/spec/fixtures/apps/set-path/main.js
+++ b/spec/fixtures/apps/set-path/main.js
@@ -1,5 +1,6 @@
-const http = require('node:http');
 const { app, ipcMain, BrowserWindow } = require('electron');
+
+const http = require('node:http');
 
 if (process.argv.length > 3) {
   app.setPath(process.argv[2], process.argv[3]);

--- a/spec/fixtures/apps/xwindow-icon/main.js
+++ b/spec/fixtures/apps/xwindow-icon/main.js
@@ -1,4 +1,5 @@
 const { app, BrowserWindow } = require('electron');
+
 const path = require('node:path');
 
 app.whenReady().then(() => {

--- a/spec/fixtures/auto-update/update-json/index.js
+++ b/spec/fixtures/auto-update/update-json/index.js
@@ -1,3 +1,5 @@
+const { app, autoUpdater } = require('electron');
+
 const fs = require('node:fs');
 const path = require('node:path');
 
@@ -5,8 +7,6 @@ process.on('uncaughtException', (err) => {
   console.error(err);
   process.exit(1);
 });
-
-const { app, autoUpdater } = require('electron');
 
 autoUpdater.on('error', (err) => {
   console.error(err);

--- a/spec/fixtures/auto-update/update-stack/index.js
+++ b/spec/fixtures/auto-update/update-stack/index.js
@@ -1,3 +1,5 @@
+const { app, autoUpdater } = require('electron');
+
 const fs = require('node:fs');
 const path = require('node:path');
 
@@ -5,8 +7,6 @@ process.on('uncaughtException', (err) => {
   console.error(err);
   process.exit(1);
 });
-
-const { app, autoUpdater } = require('electron');
 
 autoUpdater.on('error', (err) => {
   console.error(err);

--- a/spec/fixtures/auto-update/update/index.js
+++ b/spec/fixtures/auto-update/update/index.js
@@ -1,3 +1,5 @@
+const { app, autoUpdater } = require('electron');
+
 const fs = require('node:fs');
 const path = require('node:path');
 
@@ -5,8 +7,6 @@ process.on('uncaughtException', (err) => {
   console.error(err);
   process.exit(1);
 });
-
-const { app, autoUpdater } = require('electron');
 
 autoUpdater.on('error', (err) => {
   console.error(err);

--- a/spec/fixtures/crash-cases/api-browser-destroy/index.js
+++ b/spec/fixtures/crash-cases/api-browser-destroy/index.js
@@ -1,4 +1,5 @@
 const { app, BrowserWindow, BrowserView } = require('electron');
+
 const { expect } = require('chai');
 
 function createWindow () {

--- a/spec/fixtures/crash-cases/fs-promises-renderer-crash/index.js
+++ b/spec/fixtures/crash-cases/fs-promises-renderer-crash/index.js
@@ -1,4 +1,5 @@
 const { app, BrowserWindow } = require('electron');
+
 const path = require('node:path');
 
 app.whenReady().then(() => {

--- a/spec/fixtures/crash-cases/js-execute-iframe/index.js
+++ b/spec/fixtures/crash-cases/js-execute-iframe/index.js
@@ -1,4 +1,5 @@
 const { app, BrowserWindow } = require('electron');
+
 const net = require('node:net');
 const path = require('node:path');
 

--- a/spec/fixtures/crash-cases/native-window-open-exit/index.js
+++ b/spec/fixtures/crash-cases/native-window-open-exit/index.js
@@ -1,6 +1,7 @@
 const { app, ipcMain, BrowserWindow } = require('electron');
-const path = require('node:path');
+
 const http = require('node:http');
+const path = require('node:path');
 
 function createWindow () {
   const mainWindow = new BrowserWindow({

--- a/spec/fixtures/crash-cases/safe-storage/index.js
+++ b/spec/fixtures/crash-cases/safe-storage/index.js
@@ -1,4 +1,5 @@
 const { app, safeStorage } = require('electron');
+
 const { expect } = require('chai');
 
 (async () => {

--- a/spec/fixtures/crash-cases/setimmediate-renderer-crash/index.js
+++ b/spec/fixtures/crash-cases/setimmediate-renderer-crash/index.js
@@ -1,4 +1,5 @@
 const { app, BrowserWindow } = require('electron');
+
 const path = require('node:path');
 
 app.whenReady().then(() => {

--- a/spec/fixtures/crash-cases/webcontents-create-leak-exit/index.js
+++ b/spec/fixtures/crash-cases/webcontents-create-leak-exit/index.js
@@ -1,4 +1,5 @@
 const { app, webContents } = require('electron');
+
 app.whenReady().then(function () {
   webContents.create();
 

--- a/spec/fixtures/crash-cases/webcontentsview-create-leak-exit/index.js
+++ b/spec/fixtures/crash-cases/webcontentsview-create-leak-exit/index.js
@@ -1,4 +1,5 @@
 const { WebContentsView, app } = require('electron');
+
 app.whenReady().then(function () {
   // eslint-disable-next-line no-new
   new WebContentsView();

--- a/spec/fixtures/module/asar.js
+++ b/spec/fixtures/module/asar.js
@@ -1,4 +1,5 @@
 const fs = require('node:fs');
+
 process.on('message', function (file) {
   process.send(fs.readFileSync(file).toString());
 });

--- a/spec/fixtures/module/check-arguments.js
+++ b/spec/fixtures/module/check-arguments.js
@@ -1,4 +1,5 @@
 const { ipcRenderer } = require('electron');
+
 window.onload = function () {
   ipcRenderer.send('answer', process.argv);
 };

--- a/spec/fixtures/module/create_socket.js
+++ b/spec/fixtures/module/create_socket.js
@@ -1,4 +1,5 @@
 const net = require('node:net');
+
 const server = net.createServer(function () {});
 server.listen(process.argv[2]);
 process.exit(0);

--- a/spec/fixtures/module/echo.js
+++ b/spec/fixtures/module/echo.js
@@ -3,4 +3,5 @@ process.on('uncaughtException', function (err) {
 });
 
 const echo = require('@electron-ci/echo');
+
 process.send(echo('ok'));

--- a/spec/fixtures/module/fork_ping.js
+++ b/spec/fixtures/module/fork_ping.js
@@ -1,10 +1,12 @@
+const childProcess = require('node:child_process');
 const path = require('node:path');
 
 process.on('uncaughtException', function (error) {
   process.send(error.stack);
 });
 
-const child = require('node:child_process').fork(path.join(__dirname, '/ping.js'));
+const child = childProcess.fork(path.join(__dirname, '/ping.js'));
+
 process.on('message', function (msg) {
   child.send(msg);
 });

--- a/spec/fixtures/module/isolated-ping.js
+++ b/spec/fixtures/module/isolated-ping.js
@@ -1,2 +1,3 @@
 const { ipcRenderer } = require('electron');
+
 ipcRenderer.send('pong');

--- a/spec/fixtures/module/module-paths.js
+++ b/spec/fixtures/module/module-paths.js
@@ -1,2 +1,3 @@
 const Module = require('node:module');
+
 process.send(Module._nodeModulePaths(process.resourcesPath + '/test.js'));

--- a/spec/fixtures/module/preload-ipc.js
+++ b/spec/fixtures/module/preload-ipc.js
@@ -1,4 +1,5 @@
 const { ipcRenderer } = require('electron');
+
 ipcRenderer.on('ping', function (event, message) {
   ipcRenderer.sendToHost('pong', message);
 });

--- a/spec/fixtures/module/send-later.js
+++ b/spec/fixtures/module/send-later.js
@@ -1,4 +1,5 @@
 const { ipcRenderer } = require('electron');
+
 window.onload = function () {
   ipcRenderer.send('answer', typeof window.process, typeof window.Buffer);
 };

--- a/spec/fixtures/native-addon/external-ab/lib/test-array-buffer.js
+++ b/spec/fixtures/native-addon/external-ab/lib/test-array-buffer.js
@@ -1,4 +1,5 @@
 'use strict';
 
 const binding = require('../build/Release/external_ab.node');
+
 binding.createBuffer();

--- a/spec/fixtures/native-addon/uv-dlopen/index.js
+++ b/spec/fixtures/native-addon/uv-dlopen/index.js
@@ -1,4 +1,5 @@
 const path = require('node:path');
+
 const testLoadLibrary = require('./build/Release/test_module');
 
 const lib = (() => {

--- a/spec/fixtures/no-proprietary-codecs.js
+++ b/spec/fixtures/no-proprietary-codecs.js
@@ -5,6 +5,7 @@
 // that does include proprietary codecs.
 
 const { app, BrowserWindow, ipcMain } = require('electron');
+
 const path = require('node:path');
 
 const MEDIA_ERR_SRC_NOT_SUPPORTED = 4;

--- a/spec/fixtures/test.asar/repack.js
+++ b/spec/fixtures/test.asar/repack.js
@@ -2,6 +2,7 @@
 // using a new version of the asar package
 
 const asar = require('@electron/asar');
+
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');

--- a/spec/fuses-spec.ts
+++ b/spec/fuses-spec.ts
@@ -1,9 +1,12 @@
-import { expect } from 'chai';
-import { startRemoteControlApp } from './lib/spec-helpers';
-import { once } from 'node:events';
-import { spawn, spawnSync } from 'node:child_process';
 import { BrowserWindow } from 'electron';
+
+import { expect } from 'chai';
+
+import { spawn, spawnSync } from 'node:child_process';
+import { once } from 'node:events';
 import path = require('node:path');
+
+import { startRemoteControlApp } from './lib/spec-helpers';
 
 describe('fuses', () => {
   it('can be enabled by command-line argument during testing', async () => {

--- a/spec/guest-window-manager-spec.ts
+++ b/spec/guest-window-manager-spec.ts
@@ -1,10 +1,13 @@
 import { BrowserWindow, screen } from 'electron';
+
 import { expect, assert } from 'chai';
+
+import { once } from 'node:events';
+import * as http from 'node:http';
+
 import { HexColors, ScreenCapture, hasCapturableScreen } from './lib/screen-helpers';
 import { ifit, listen } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
-import { once } from 'node:events';
-import * as http from 'node:http';
 
 describe('webContents.setWindowOpenHandler', () => {
   describe('native window', () => {

--- a/spec/index.js
+++ b/spec/index.js
@@ -1,3 +1,5 @@
+const { app, protocol } = require('electron');
+
 const fs = require('node:fs');
 const path = require('node:path');
 const v8 = require('node:v8');
@@ -11,8 +13,6 @@ process.on('uncaughtException', (err) => {
 // Tell ts-node which tsconfig to use
 process.env.TS_NODE_PROJECT = path.resolve(__dirname, '../tsconfig.spec.json');
 process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = 'true';
-
-const { app, protocol } = require('electron');
 
 // Some Linux machines have broken hardware acceleration support.
 if (process.env.ELECTRON_TEST_DISABLE_HARDWARE_ACCELERATION) {

--- a/spec/lib/artifacts.ts
+++ b/spec/lib/artifacts.ts
@@ -1,6 +1,6 @@
-import path = require('node:path');
-import fs = require('node:fs/promises');
 import { randomBytes } from 'node:crypto';
+import fs = require('node:fs/promises');
+import path = require('node:path');
 
 const IS_CI = !!process.env.CI;
 const ARTIFACT_DIR = path.join(__dirname, '..', 'artifacts');

--- a/spec/lib/codesign-helpers.ts
+++ b/spec/lib/codesign-helpers.ts
@@ -1,7 +1,8 @@
+import { expect } from 'chai';
+
 import * as cp from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { expect } from 'chai';
 
 const features = process._linkedBinding('electron_common_features');
 const fixturesPath = path.resolve(__dirname, '..', 'fixtures');

--- a/spec/lib/fs-helpers.ts
+++ b/spec/lib/fs-helpers.ts
@@ -1,5 +1,6 @@
-import * as cp from 'node:child_process';
 import * as fs from 'original-fs';
+
+import * as cp from 'node:child_process';
 import * as os from 'node:os';
 import * as path from 'node:path';
 

--- a/spec/lib/net-helpers.ts
+++ b/spec/lib/net-helpers.ts
@@ -1,7 +1,9 @@
 import { expect } from 'chai';
+
 import * as dns from 'node:dns';
 import * as http from 'node:http';
 import { Socket } from 'node:net';
+
 import { defer, listen } from './spec-helpers';
 
 // See https://github.com/nodejs/node/issues/40702.

--- a/spec/lib/screen-helpers.ts
+++ b/spec/lib/screen-helpers.ts
@@ -1,6 +1,8 @@
 import { screen, desktopCapturer, NativeImage } from 'electron';
-import { createArtifactWithRandomId } from './artifacts';
+
 import { AssertionError } from 'chai';
+
+import { createArtifactWithRandomId } from './artifacts';
 
 export enum HexColors {
   GREEN = '#00b140',

--- a/spec/lib/spec-helpers.ts
+++ b/spec/lib/spec-helpers.ts
@@ -1,15 +1,17 @@
-import * as childProcess from 'node:child_process';
-import * as path from 'node:path';
-import * as http from 'node:http';
-import * as https from 'node:https';
-import * as http2 from 'node:http2';
-import * as net from 'node:net';
-import * as v8 from 'node:v8';
-import * as url from 'node:url';
-import { SuiteFunction, TestFunction } from 'mocha';
 import { BrowserWindow } from 'electron/main';
+
 import { AssertionError } from 'chai';
+import { SuiteFunction, TestFunction } from 'mocha';
+
+import * as childProcess from 'node:child_process';
+import * as http from 'node:http';
+import * as http2 from 'node:http2';
+import * as https from 'node:https';
+import * as net from 'node:net';
+import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
+import * as url from 'node:url';
+import * as v8 from 'node:v8';
 
 const addOnly = <T>(fn: Function): T => {
   const wrapped = (...args: any[]) => {

--- a/spec/lib/window-helpers.ts
+++ b/spec/lib/window-helpers.ts
@@ -1,5 +1,7 @@
-import { expect } from 'chai';
 import { BaseWindow, BrowserWindow } from 'electron/main';
+
+import { expect } from 'chai';
+
 import { once } from 'node:events';
 
 async function ensureWindowIsClosed (window: BaseWindow | null) {

--- a/spec/logging-spec.ts
+++ b/spec/logging-spec.ts
@@ -1,11 +1,13 @@
 import { app } from 'electron';
-import { expect } from 'chai';
-import { startRemoteControlApp, ifdescribe } from './lib/spec-helpers';
 
+import { expect } from 'chai';
+import * as uuid from 'uuid';
+
+import { once } from 'node:events';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import * as uuid from 'uuid';
-import { once } from 'node:events';
+
+import { startRemoteControlApp, ifdescribe } from './lib/spec-helpers';
 
 function isTestingBindingAvailable () {
   try {

--- a/spec/modules-spec.ts
+++ b/spec/modules-spec.ts
@@ -1,11 +1,14 @@
-import { expect } from 'chai';
-import * as path from 'node:path';
-import * as fs from 'node:fs';
 import { BrowserWindow } from 'electron/main';
-import { ifdescribe, ifit } from './lib/spec-helpers';
-import { closeAllWindows } from './lib/window-helpers';
+
+import { expect } from 'chai';
+
 import * as childProcess from 'node:child_process';
 import { once } from 'node:events';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { ifdescribe, ifit } from './lib/spec-helpers';
+import { closeAllWindows } from './lib/window-helpers';
 
 const Module = require('node:module') as NodeJS.ModuleInternal;
 

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -1,14 +1,17 @@
+import { webContents } from 'electron/main';
+
 import { expect } from 'chai';
+
 import * as childProcess from 'node:child_process';
+import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as util from 'node:util';
-import { getRemoteContext, ifdescribe, ifit, itremote, useRemoteContext } from './lib/spec-helpers';
-import { copyMacOSFixtureApp, getCodesignIdentity, shouldRunCodesignTests, signApp, spawn } from './lib/codesign-helpers';
-import { webContents } from 'electron/main';
 import { EventEmitter } from 'node:stream';
-import { once } from 'node:events';
+import * as util from 'node:util';
+
+import { copyMacOSFixtureApp, getCodesignIdentity, shouldRunCodesignTests, signApp, spawn } from './lib/codesign-helpers';
 import { withTempDirectory } from './lib/fs-helpers';
+import { getRemoteContext, ifdescribe, ifit, itremote, useRemoteContext } from './lib/spec-helpers';
 
 const mainFixturesPath = path.resolve(__dirname, 'fixtures');
 

--- a/spec/parse-features-string-spec.ts
+++ b/spec/parse-features-string-spec.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+
 import { parseCommaSeparatedKeyValue } from '../lib/browser/parse-features-string';
 
 describe('feature-string parsing', () => {

--- a/spec/process-binding-spec.ts
+++ b/spec/process-binding-spec.ts
@@ -1,5 +1,7 @@
-import { expect } from 'chai';
 import { BrowserWindow } from 'electron/main';
+
+import { expect } from 'chai';
+
 import { closeAllWindows } from './lib/window-helpers';
 
 describe('process._linkedBinding', () => {

--- a/spec/release-notes-spec.ts
+++ b/spec/release-notes-spec.ts
@@ -1,8 +1,10 @@
-import { GitProcess, IGitExecutionOptions, IGitResult } from 'dugite';
 import { expect } from 'chai';
-import * as notes from '../script/release/notes/notes';
-import * as path from 'node:path';
+import { GitProcess, IGitExecutionOptions, IGitResult } from 'dugite';
 import * as sinon from 'sinon';
+
+import * as path from 'node:path';
+
+import * as notes from '../script/release/notes/notes';
 
 /* Fake a Dugite GitProcess that only returns the specific
    commits that we want to test */

--- a/spec/security-warnings-spec.ts
+++ b/spec/security-warnings-spec.ts
@@ -1,14 +1,15 @@
-import { expect } from 'chai';
-import * as http from 'node:http';
-import * as fs from 'node:fs/promises';
-import * as path from 'node:path';
-
 import { BrowserWindow, WebPreferences } from 'electron/main';
 
-import { closeWindow } from './lib/window-helpers';
+import { expect } from 'chai';
+
+import * as fs from 'node:fs/promises';
+import * as http from 'node:http';
+import * as path from 'node:path';
+import { setTimeout } from 'node:timers/promises';
+
 import { emittedUntil } from './lib/events-helpers';
 import { listen } from './lib/spec-helpers';
-import { setTimeout } from 'node:timers/promises';
+import { closeWindow } from './lib/window-helpers';
 
 const messageContainsSecurityWarning = (event: Event, level: number, message: string) => {
   return message.includes('Electron Security Warning');

--- a/spec/spellchecker-spec.ts
+++ b/spec/spellchecker-spec.ts
@@ -1,13 +1,15 @@
 import { BrowserWindow, Session, session } from 'electron/main';
 
 import { expect } from 'chai';
-import * as path from 'node:path';
+
+import { once } from 'node:events';
 import * as fs from 'node:fs/promises';
 import * as http from 'node:http';
-import { closeWindow } from './lib/window-helpers';
-import { ifit, ifdescribe, listen } from './lib/spec-helpers';
-import { once } from 'node:events';
+import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
+
+import { ifit, ifdescribe, listen } from './lib/spec-helpers';
+import { closeWindow } from './lib/window-helpers';
 
 const features = process._linkedBinding('electron_common_features');
 const v8Util = process._linkedBinding('electron_common_v8_util');

--- a/spec/ts-smoke/runner.js
+++ b/spec/ts-smoke/runner.js
@@ -1,5 +1,5 @@
-const path = require('node:path');
 const childProcess = require('node:child_process');
+const path = require('node:path');
 
 const typeCheck = () => {
   const tscExec = path.resolve(require.resolve('typescript'), '../../bin/tsc');

--- a/spec/version-bump-spec.ts
+++ b/spec/version-bump-spec.ts
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
 import { GitProcess, IGitExecutionOptions, IGitResult } from 'dugite';
-import { nextVersion } from '../script/release/version-bumper';
 import * as sinon from 'sinon';
+
 import { ifdescribe } from './lib/spec-helpers';
+import { nextVersion } from '../script/release/version-bumper';
 
 class GitFake {
   branches: {

--- a/spec/visibility-state-spec.ts
+++ b/spec/visibility-state-spec.ts
@@ -1,12 +1,14 @@
-import { expect } from 'chai';
-import * as cp from 'node:child_process';
 import { BaseWindow, BrowserWindow, BrowserWindowConstructorOptions, ipcMain, WebContents, WebContentsView } from 'electron/main';
-import * as path from 'node:path';
 
-import { closeWindow } from './lib/window-helpers';
-import { ifdescribe } from './lib/spec-helpers';
+import { expect } from 'chai';
+
+import * as cp from 'node:child_process';
 import { once } from 'node:events';
+import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
+
+import { ifdescribe } from './lib/spec-helpers';
+import { closeWindow } from './lib/window-helpers';
 
 // visibilityState specs pass on linux with a real window manager but on CI
 // the environment does not let these specs pass

--- a/spec/webview-spec.ts
+++ b/spec/webview-spec.ts
@@ -1,15 +1,18 @@
-import * as path from 'node:path';
-import * as url from 'node:url';
 import { BrowserWindow, session, ipcMain, app, WebContents } from 'electron/main';
-import { closeAllWindows } from './lib/window-helpers';
-import { emittedUntil } from './lib/events-helpers';
-import { ifit, ifdescribe, defer, itremote, useRemoteContext, listen } from './lib/spec-helpers';
-import { expect } from 'chai';
-import * as http from 'node:http';
+
 import * as auth from 'basic-auth';
+import { expect } from 'chai';
+
 import { once } from 'node:events';
+import * as http from 'node:http';
+import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
+import * as url from 'node:url';
+
+import { emittedUntil } from './lib/events-helpers';
 import { HexColors, ScreenCapture, hasCapturableScreen } from './lib/screen-helpers';
+import { ifit, ifdescribe, defer, itremote, useRemoteContext, listen } from './lib/spec-helpers';
+import { closeAllWindows } from './lib/window-helpers';
 
 declare let WebView: any;
 const features = process._linkedBinding('electron_common_features');


### PR DESCRIPTION
Consistent ordering, splitting up internal, electron, external, builtin (`node:*`) and local (`./`, `../`) modules into sorted separated groups.

cc @dsanders11 

Notes: none