### PR TITLE
perf: use ArrayBuffer::Data() instead of GetBackingStore()->Data() (32-x-y)

### DIFF
--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -255,9 +255,7 @@ v8::Local<v8::Value> NativeImage::ToBitmap(gin::Arguments* args) {
 
   auto array_buffer =
       v8::ArrayBuffer::New(args->isolate(), info.computeMinByteSize());
-  auto backing_store = array_buffer->GetBackingStore();
-  if (bitmap.readPixels(info, backing_store->Data(), info.minRowBytes(), 0,
-                        0)) {
+  if (bitmap.readPixels(info, array_buffer->Data(), info.minRowBytes(), 0, 0)) {
     return node::Buffer::New(args->isolate(), array_buffer, 0,
                              info.computeMinByteSize())
         .ToLocalChecked();

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -710,8 +710,7 @@ void SimpleURLLoaderWrapper::OnDataReceived(std::string_view string_piece,
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
   auto array_buffer = v8::ArrayBuffer::New(isolate, string_piece.size());
-  auto backing_store = array_buffer->GetBackingStore();
-  memcpy(backing_store->Data(), string_piece.data(), string_piece.size());
+  memcpy(array_buffer->Data(), string_piece.data(), string_piece.size());
   Emit("data", array_buffer,
        base::AdaptCallbackForRepeating(std::move(resume)));
 }


### PR DESCRIPTION
Manually backport #44067 to 32-x-y. See that PR for details.

Simple manual patching needed due to context shear from the `base::StringPiece` -> `std::string_view` migration.

Notes: none.