### PR TITLE
refactor: remove unnecessary template type in EmitEvent()

### DIFF
--- a/shell/common/gin_helper/event_emitter_caller.h
+++ b/shell/common/gin_helper/event_emitter_caller.h
@@ -25,10 +25,10 @@ v8::Local<v8::Value> CallMethodWithArgs(v8::Isolate* isolate,
 
 // obj.emit(name, args...);
 // The caller is responsible of allocating a HandleScope.
-template <typename StringType, typename... Args>
+template <typename... Args>
 v8::Local<v8::Value> EmitEvent(v8::Isolate* isolate,
                                v8::Local<v8::Object> obj,
-                               const StringType& name,
+                               const std::string_view name,
                                Args&&... args) {
   v8::EscapableHandleScope scope{isolate};
   std::array<v8::Local<v8::Value>, 1U + sizeof...(args)> converted_args = {


### PR DESCRIPTION
#### Description of Change

Does what it says on the tin. `std::string_view` works everywhere, so just use that.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.