### PR TITLE
refactor: spanify image utils

### DIFF
--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -410,7 +410,7 @@ void NativeImage::AddRepresentation(const gin_helper::Dictionary& options) {
             &image_skia, data_ptr, data.size(), scale_factor);
       } else if (mime_type == "image/jpeg") {
         skia_rep_added = electron::util::AddImageSkiaRepFromJPEG(
-            &image_skia, data_ptr, data.size(), scale_factor);
+            &image_skia, base::as_bytes(base::span(data)), scale_factor);
       }
     }
   }
@@ -457,7 +457,7 @@ gin::Handle<NativeImage> NativeImage::CreateFromJPEG(v8::Isolate* isolate,
                                                      size_t length) {
   gfx::ImageSkia image_skia;
   electron::util::AddImageSkiaRepFromJPEG(
-      &image_skia, reinterpret_cast<const unsigned char*>(buffer), length, 1.0);
+      &image_skia, base::as_bytes(base::make_span(buffer, length)), 1.0);
   return Create(isolate, gfx::Image(image_skia));
 }
 

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -441,12 +441,11 @@ gin::Handle<NativeImage> NativeImage::Create(v8::Isolate* isolate,
 }
 
 // static
-gin::Handle<NativeImage> NativeImage::CreateFromPNG(v8::Isolate* isolate,
-                                                    const char* buffer,
-                                                    size_t length) {
+gin::Handle<NativeImage> NativeImage::CreateFromPNG(
+    v8::Isolate* isolate,
+    const base::span<const uint8_t> data) {
   gfx::ImageSkia image_skia;
-  electron::util::AddImageSkiaRepFromPNG(
-      &image_skia, base::as_bytes(base::make_span(buffer, length)), 1.0);
+  electron::util::AddImageSkiaRepFromPNG(&image_skia, data, 1.0);
   return Create(isolate, gfx::Image(image_skia));
 }
 
@@ -564,7 +563,7 @@ gin::Handle<NativeImage> NativeImage::CreateFromDataURL(v8::Isolate* isolate,
   std::string mime_type, charset, data;
   if (net::DataURL::Parse(url, &mime_type, &charset, &data)) {
     if (mime_type == "image/png")
-      return CreateFromPNG(isolate, data.c_str(), data.size());
+      return CreateFromPNG(isolate, base::as_bytes(base::span(data)));
     else if (mime_type == "image/jpeg")
       return CreateFromJPEG(isolate, data.c_str(), data.size());
   }

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -404,10 +404,9 @@ void NativeImage::AddRepresentation(const gin_helper::Dictionary& options) {
   } else if (options.Get("dataURL", &url)) {
     std::string mime_type, charset, data;
     if (net::DataURL::Parse(url, &mime_type, &charset, &data)) {
-      auto* data_ptr = reinterpret_cast<const unsigned char*>(data.c_str());
       if (mime_type == "image/png") {
         skia_rep_added = electron::util::AddImageSkiaRepFromPNG(
-            &image_skia, data_ptr, data.size(), scale_factor);
+            &image_skia, base::as_bytes(base::span(data)), scale_factor);
       } else if (mime_type == "image/jpeg") {
         skia_rep_added = electron::util::AddImageSkiaRepFromJPEG(
             &image_skia, base::as_bytes(base::span(data)), scale_factor);
@@ -447,7 +446,7 @@ gin::Handle<NativeImage> NativeImage::CreateFromPNG(v8::Isolate* isolate,
                                                     size_t length) {
   gfx::ImageSkia image_skia;
   electron::util::AddImageSkiaRepFromPNG(
-      &image_skia, reinterpret_cast<const unsigned char*>(buffer), length, 1.0);
+      &image_skia, base::as_bytes(base::make_span(buffer, length)), 1.0);
   return Create(isolate, gfx::Image(image_skia));
 }
 

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -406,10 +406,10 @@ void NativeImage::AddRepresentation(const gin_helper::Dictionary& options) {
     if (net::DataURL::Parse(url, &mime_type, &charset, &data)) {
       if (mime_type == "image/png") {
         skia_rep_added = electron::util::AddImageSkiaRepFromPNG(
-            &image_skia, base::as_bytes(base::span(data)), scale_factor);
+            &image_skia, base::as_byte_span(data), scale_factor);
       } else if (mime_type == "image/jpeg") {
         skia_rep_added = electron::util::AddImageSkiaRepFromJPEG(
-            &image_skia, base::as_bytes(base::span(data)), scale_factor);
+            &image_skia, base::as_byte_span(data), scale_factor);
       }
     }
   }
@@ -562,9 +562,9 @@ gin::Handle<NativeImage> NativeImage::CreateFromDataURL(v8::Isolate* isolate,
   std::string mime_type, charset, data;
   if (net::DataURL::Parse(url, &mime_type, &charset, &data)) {
     if (mime_type == "image/png")
-      return CreateFromPNG(isolate, base::as_bytes(base::span(data)));
+      return CreateFromPNG(isolate, base::as_byte_span(data));
     if (mime_type == "image/jpeg")
-      return CreateFromJPEG(isolate, base::as_bytes(base::span(data)));
+      return CreateFromJPEG(isolate, base::as_byte_span(data));
   }
 
   return CreateEmpty(isolate);

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -450,12 +450,11 @@ gin::Handle<NativeImage> NativeImage::CreateFromPNG(
 }
 
 // static
-gin::Handle<NativeImage> NativeImage::CreateFromJPEG(v8::Isolate* isolate,
-                                                     const char* buffer,
-                                                     size_t length) {
+gin::Handle<NativeImage> NativeImage::CreateFromJPEG(
+    v8::Isolate* isolate,
+    const base::span<const uint8_t> buffer) {
   gfx::ImageSkia image_skia;
-  electron::util::AddImageSkiaRepFromJPEG(
-      &image_skia, base::as_bytes(base::make_span(buffer, length)), 1.0);
+  electron::util::AddImageSkiaRepFromJPEG(&image_skia, buffer, 1.0);
   return Create(isolate, gfx::Image(image_skia));
 }
 
@@ -564,8 +563,8 @@ gin::Handle<NativeImage> NativeImage::CreateFromDataURL(v8::Isolate* isolate,
   if (net::DataURL::Parse(url, &mime_type, &charset, &data)) {
     if (mime_type == "image/png")
       return CreateFromPNG(isolate, base::as_bytes(base::span(data)));
-    else if (mime_type == "image/jpeg")
-      return CreateFromJPEG(isolate, data.c_str(), data.size());
+    if (mime_type == "image/jpeg")
+      return CreateFromJPEG(isolate, base::as_bytes(base::span(data)));
   }
 
   return CreateEmpty(isolate);

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "base/containers/flat_map.h"
+#include "base/containers/span.h"
 #include "base/memory/raw_ptr.h"
 #include "base/values.h"
 #include "gin/wrappable.h"
@@ -61,8 +62,7 @@ class NativeImage final : public gin::Wrappable<NativeImage> {
   static gin::Handle<NativeImage> Create(v8::Isolate* isolate,
                                          const gfx::Image& image);
   static gin::Handle<NativeImage> CreateFromPNG(v8::Isolate* isolate,
-                                                const char* buffer,
-                                                size_t length);
+                                                base::span<const uint8_t> data);
   static gin::Handle<NativeImage> CreateFromJPEG(v8::Isolate* isolate,
                                                  const char* buffer,
                                                  size_t length);

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -63,9 +63,9 @@ class NativeImage final : public gin::Wrappable<NativeImage> {
                                          const gfx::Image& image);
   static gin::Handle<NativeImage> CreateFromPNG(v8::Isolate* isolate,
                                                 base::span<const uint8_t> data);
-  static gin::Handle<NativeImage> CreateFromJPEG(v8::Isolate* isolate,
-                                                 const char* buffer,
-                                                 size_t length);
+  static gin::Handle<NativeImage> CreateFromJPEG(
+      v8::Isolate* isolate,
+      base::span<const uint8_t> data);
   static gin::Handle<NativeImage> CreateFromPath(v8::Isolate* isolate,
                                                  const base::FilePath& path);
   static gin::Handle<NativeImage> CreateFromBitmap(

--- a/shell/common/api/electron_api_native_image_mac.mm
+++ b/shell/common/api/electron_api_native_image_mac.mm
@@ -29,6 +29,10 @@ namespace electron::api {
 namespace {
 
 base::span<const uint8_t> as_byte_span(NSData* data) {
+  // SAFETY: There is no NSData API that passes the UNSAFE_BUFFER_USAGE
+  // test, so let's isolate the unsafe API use into this function. Instead of
+  // calling '[data bytes]' and '[data length]' directly, the rest of our
+  // code should prefer to use spans returned by this function.
   return UNSAFE_BUFFERS(base::span{
       reinterpret_cast<const uint8_t*>([data bytes]), [data length]});
 }

--- a/shell/common/api/electron_api_native_image_mac.mm
+++ b/shell/common/api/electron_api_native_image_mac.mm
@@ -26,6 +26,15 @@
 
 namespace electron::api {
 
+namespace {
+
+base::span<const uint8_t> as_bytes(NSData* data) {
+  return UNSAFE_BUFFERS(base::span{
+      reinterpret_cast<const uint8_t*>([data bytes]), [data length]});
+}
+
+}  // namespace
+
 NSData* bufferFromNSImage(NSImage* image) {
   CGImageRef ref = [image CGImageForProposedRect:nil context:nil hints:nil];
   NSBitmapImageRep* rep = [[NSBitmapImageRep alloc] initWithCGImage:ref];
@@ -139,8 +148,9 @@ gin::Handle<NativeImage> NativeImage::CreateFromNamedImage(gin::Arguments* args,
               .AsNSImage());
     }
 
-    return CreateFromPNG(args->isolate(), (char*)[png_data bytes],
-                         [png_data length]);
+    auto span = UNSAFE_BUFFERS(base::span(reinterpret_
+
+    return CreateFromPNG(args->isolate(), as_bytes(png_data));
   }
 }
 

--- a/shell/common/api/electron_api_native_image_mac.mm
+++ b/shell/common/api/electron_api_native_image_mac.mm
@@ -28,7 +28,7 @@ namespace electron::api {
 
 namespace {
 
-base::span<const uint8_t> as_bytes(NSData* data) {
+base::span<const uint8_t> as_byte_span(NSData* data) {
   return UNSAFE_BUFFERS(base::span{
       reinterpret_cast<const uint8_t*>([data bytes]), [data length]});
 }
@@ -136,9 +136,7 @@ gin::Handle<NativeImage> NativeImage::CreateFromNamedImage(gin::Arguments* args,
     NSData* png_data = bufferFromNSImage(image);
 
     if (args->GetNext(&hsl_shift) && hsl_shift.size() == 3) {
-      gfx::Image gfx_image = gfx::Image::CreateFrom1xPNGBytes(
-          {reinterpret_cast<const uint8_t*>((char*)[png_data bytes]),
-           [png_data length]});
+      auto gfx_image = gfx::Image::CreateFrom1xPNGBytes(as_byte_span(png_data));
       color_utils::HSL shift = {safeShift(hsl_shift[0], -1),
                                 safeShift(hsl_shift[1], 0.5),
                                 safeShift(hsl_shift[2], 0.5)};
@@ -148,7 +146,7 @@ gin::Handle<NativeImage> NativeImage::CreateFromNamedImage(gin::Arguments* args,
               .AsNSImage());
     }
 
-    return CreateFromPNG(args->isolate(), as_bytes(png_data));
+    return CreateFromPNG(args->isolate(), as_byte_span(png_data));
   }
 }
 

--- a/shell/common/api/electron_api_native_image_mac.mm
+++ b/shell/common/api/electron_api_native_image_mac.mm
@@ -148,8 +148,6 @@ gin::Handle<NativeImage> NativeImage::CreateFromNamedImage(gin::Arguments* args,
               .AsNSImage());
     }
 
-    auto span = UNSAFE_BUFFERS(base::span(reinterpret_
-
     return CreateFromPNG(args->isolate(), as_bytes(png_data));
   }
 }

--- a/shell/common/node_util.cc
+++ b/shell/common/node_util.cc
@@ -4,6 +4,7 @@
 
 #include "shell/common/node_util.h"
 
+#include "base/compiler_specific.h"
 #include "base/logging.h"
 #include "gin/converter.h"
 #include "gin/dictionary.h"
@@ -63,6 +64,12 @@ void EmitWarning(v8::Isolate* isolate,
       emit_warning;
   process.Get("emitWarning", &emit_warning);
   emit_warning.Run(warning_msg, warning_type, "");
+}
+
+base::span<uint8_t> as_byte_span(v8::Local<v8::Value> node_buffer) {
+  auto* data = reinterpret_cast<uint8_t*>(node::Buffer::Data(node_buffer));
+  const auto size = node::Buffer::Length(node_buffer);
+  return UNSAFE_BUFFERS(base::span{data, size});
 }
 
 }  // namespace electron::util

--- a/shell/common/node_util.cc
+++ b/shell/common/node_util.cc
@@ -66,6 +66,10 @@ void EmitWarning(v8::Isolate* isolate,
   emit_warning.Run(warning_msg, warning_type, "");
 }
 
+// SAFETY: There is no node::Buffer API that passes the UNSAFE_BUFFER_USAGE
+// test, so let's isolate the unsafe API use into this function. Instead of
+// calling `Buffer::Data()` and `Buffer::Length()` directly, the rest of our
+// code should prefer to use spans returned by this function.
 base::span<uint8_t> as_byte_span(v8::Local<v8::Value> node_buffer) {
   auto* data = reinterpret_cast<uint8_t*>(node::Buffer::Data(node_buffer));
   const auto size = node::Buffer::Length(node_buffer);

--- a/shell/common/node_util.h
+++ b/shell/common/node_util.h
@@ -8,6 +8,7 @@
 #include <string_view>
 #include <vector>
 
+#include "base/containers/span.h"
 #include "v8/include/v8-forward.h"
 
 namespace node {
@@ -35,6 +36,11 @@ v8::MaybeLocal<v8::Value> CompileAndCall(
     const char* id,
     std::vector<v8::Local<v8::String>>* parameters,
     std::vector<v8::Local<v8::Value>>* arguments);
+
+// Convenience function to view a Node buffer's data as a base::span().
+// Analogous to base::as_byte_span()
+[[nodiscard]] base::span<uint8_t> as_byte_span(
+    v8::Local<v8::Value> node_buffer);
 
 }  // namespace electron::util
 

--- a/shell/common/skia_util.cc
+++ b/shell/common/skia_util.cc
@@ -124,8 +124,8 @@ bool AddImageSkiaRepFromPath(gfx::ImageSkia* image,
       return false;
   }
 
-  return AddImageSkiaRepFromBuffer(
-      image, base::as_bytes(base::span(file_contents)), 0, 0, scale_factor);
+  return AddImageSkiaRepFromBuffer(image, base::as_byte_span(file_contents), 0,
+                                   0, scale_factor);
 }
 
 bool PopulateImageSkiaRepsFromPath(gfx::ImageSkia* image,

--- a/shell/common/skia_util.cc
+++ b/shell/common/skia_util.cc
@@ -68,10 +68,9 @@ bool AddImageSkiaRepFromPNG(gfx::ImageSkia* image,
 }
 
 bool AddImageSkiaRepFromJPEG(gfx::ImageSkia* image,
-                             const unsigned char* data,
-                             size_t size,
+                             const base::span<const uint8_t> data,
                              double scale_factor) {
-  auto bitmap = gfx::JPEGCodec::Decode(data, size);
+  auto bitmap = gfx::JPEGCodec::Decode(data.data(), data.size());
   if (!bitmap)
     return false;
 
@@ -99,7 +98,8 @@ bool AddImageSkiaRepFromBuffer(gfx::ImageSkia* image,
     return true;
 
   // Try JPEG second.
-  if (AddImageSkiaRepFromJPEG(image, data, size, scale_factor))
+  if (AddImageSkiaRepFromJPEG(
+          image, base::as_bytes(base::make_span(data, size)), scale_factor))
     return true;
 
   if (width == 0 || height == 0)

--- a/shell/common/skia_util.cc
+++ b/shell/common/skia_util.cc
@@ -56,11 +56,10 @@ float GetScaleFactorFromPath(const base::FilePath& path) {
 }
 
 bool AddImageSkiaRepFromPNG(gfx::ImageSkia* image,
-                            const unsigned char* data,
-                            size_t size,
+                            const base::span<const uint8_t> data,
                             double scale_factor) {
   SkBitmap bitmap;
-  if (!gfx::PNGCodec::Decode(data, size, &bitmap))
+  if (!gfx::PNGCodec::Decode(data.data(), data.size(), &bitmap))
     return false;
 
   image->AddRepresentation(gfx::ImageSkiaRep(bitmap, scale_factor));
@@ -94,7 +93,8 @@ bool AddImageSkiaRepFromBuffer(gfx::ImageSkia* image,
                                int height,
                                double scale_factor) {
   // Try PNG first.
-  if (AddImageSkiaRepFromPNG(image, data, size, scale_factor))
+  if (AddImageSkiaRepFromPNG(image, base::as_bytes(base::make_span(data, size)),
+                             scale_factor))
     return true;
 
   // Try JPEG second.

--- a/shell/common/skia_util.h
+++ b/shell/common/skia_util.h
@@ -5,9 +5,13 @@
 #ifndef ELECTRON_SHELL_COMMON_SKIA_UTIL_H_
 #define ELECTRON_SHELL_COMMON_SKIA_UTIL_H_
 
+#include <cstdint>
+
+#include "base/containers/span.h"
+
 namespace base {
 class FilePath;
-}
+}  // namespace base
 
 namespace gfx {
 class ImageSkia;
@@ -26,8 +30,7 @@ bool AddImageSkiaRepFromBuffer(gfx::ImageSkia* image,
                                double scale_factor);
 
 bool AddImageSkiaRepFromJPEG(gfx::ImageSkia* image,
-                             const unsigned char* data,
-                             size_t size,
+                             base::span<const uint8_t> data,
                              double scale_factor);
 
 bool AddImageSkiaRepFromPNG(gfx::ImageSkia* image,

--- a/shell/common/skia_util.h
+++ b/shell/common/skia_util.h
@@ -23,8 +23,7 @@ bool PopulateImageSkiaRepsFromPath(gfx::ImageSkia* image,
                                    const base::FilePath& path);
 
 bool AddImageSkiaRepFromBuffer(gfx::ImageSkia* image,
-                               const unsigned char* data,
-                               size_t size,
+                               base::span<const uint8_t> data,
                                int width,
                                int height,
                                double scale_factor);

--- a/shell/common/skia_util.h
+++ b/shell/common/skia_util.h
@@ -34,8 +34,7 @@ bool AddImageSkiaRepFromJPEG(gfx::ImageSkia* image,
                              double scale_factor);
 
 bool AddImageSkiaRepFromPNG(gfx::ImageSkia* image,
-                            const unsigned char* data,
-                            size_t size,
+                            base::span<const uint8_t> data,
                             double scale_factor);
 
 #if BUILDFLAG(IS_WIN)


### PR DESCRIPTION
#### Description of Change

This PR makes our C++ image API span-friendly and provides `get_byte_span()` getters for Node.js buffers and for NSData objects. The latter fixes one of our remaining `-Wunsafe-buffer-usage` warnings, making this PR part 14 in the [unsafe buffer PR series](https://github.com/electron/electron/pull/43477).

APIs changed to take a `base::span` instead of `data, len` params:

- `electron::api::NativeImage::CreateFromJPEG()`
- `electron::api::NativeImage::CreateFromPNG()`
- `electron::util::AddImageSkiaRepFromBuffer()`
- `electron::util::AddImageSkiaRepFromJPEG()`
- `electron::util::AddImageSkiaRepFromPNG()`

Warnings fixed by this PR:

```
2024-10-04T05:37:14.0643890Z ../../electron/shell/common/api/electron_api_native_image_mac.mm:131:11: error: function introduces unsafe buffer manipulation [-Werror,-Wunsafe-buffer-usage]
2024-10-04T05:37:14.0644860Z   131 |           {reinterpret_cast<const uint8_t*>((char*)[png_data bytes]),
2024-10-04T05:37:14.0645380Z       |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-10-04T05:37:14.0645860Z   132 |            [png_data length]});
2024-10-04T05:37:14.0646200Z       |            ~~~~~~~~~~~~~~~~~~
2024-10-04T05:37:14.0646960Z ../../electron/shell/common/api/electron_api_native_image_mac.mm:131:11: note: See //docs/unsafe_buffers.md for help.
2024-10-04T05:37:14.0647700Z 1 error generated.
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none