### PR TITLE
fix: -Wunsafe-buffer-usage warning in WriteAsciiChunk()

### DIFF
--- a/shell/common/heap_snapshot.cc
+++ b/shell/common/heap_snapshot.cc
@@ -4,6 +4,7 @@
 
 #include "shell/common/heap_snapshot.h"
 
+#include "base/containers/span.h"
 #include "base/files/file.h"
 #include "base/memory/raw_ptr.h"
 #include "v8/include/v8-profiler.h"
@@ -24,8 +25,10 @@ class HeapSnapshotOutputStream : public v8::OutputStream {
   void EndOfStream() override { is_complete_ = true; }
 
   v8::OutputStream::WriteResult WriteAsciiChunk(char* data, int size) override {
-    auto bytes_written = file_->WriteAtCurrentPos(data, size);
-    return bytes_written == size ? kContinue : kAbort;
+    const uint8_t* udata = reinterpret_cast<const uint8_t*>(data);
+    const size_t usize = static_cast<size_t>(std::max(0, size));
+    const auto data_span = UNSAFE_BUFFERS(base::span(udata, usize));
+    return file_->WriteAtCurrentPosAndCheck(data_span) ? kContinue : kAbort;
   }
 
  private:

--- a/shell/common/heap_snapshot.cc
+++ b/shell/common/heap_snapshot.cc
@@ -27,6 +27,9 @@ class HeapSnapshotOutputStream : public v8::OutputStream {
   v8::OutputStream::WriteResult WriteAsciiChunk(char* data, int size) override {
     const uint8_t* udata = reinterpret_cast<const uint8_t*>(data);
     const size_t usize = static_cast<size_t>(std::max(0, size));
+    // SAFETY: since WriteAsciiChunk() only gives us data + size, our
+    // UNSAFE_BUFFERS macro call is unavoidable here. It can be removed
+    // if/when v8 changes WriteAsciiChunk() to pass a v8::MemorySpan.
     const auto data_span = UNSAFE_BUFFERS(base::span(udata, usize));
     return file_->WriteAtCurrentPosAndCheck(data_span) ? kContinue : kAbort;
   }


### PR DESCRIPTION
#### Description of Change

Part 16 in a [series](https://github.com/electron/electron/pull/43477) to fix `-Wunsafe-buffer-usage` warnings in Electron `shell/`. This PR fixes a minor API mismatch between Chromium's [spanification](https://groups.google.com/a/chromium.org/g/chromium-dev/c/iEy69ygz-rs) and `v8::OutputStream::WriteAsciiChunk(char* data, int size)`. 

Fixed by this PR:

```
2024-10-04T05:37:05.4109190Z ../../electron/shell/common/heap_snapshot.cc:27:26: error: function introduces unsafe buffer manipulation [-Werror,-Wunsafe-buffer-usage]
2024-10-04T05:37:05.4110250Z    27 |     auto bytes_written = file_->WriteAtCurrentPos(data, size);
2024-10-04T05:37:05.4110860Z       |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-10-04T05:37:05.4111530Z ../../electron/shell/common/heap_snapshot.cc:27:26: note: See //docs/unsafe_buffers.md for help.
2024-10-04T05:37:05.4112120Z 1 error generated.
```

This workaround can be removed if/when v8 changes `v8::OutputStreamWriteAsciiChunk()` to have a [`v8::MemorySpan`](https://chromium.googlesource.com/v8/v8.git/+/main/include/v8-memory-span.h#52) arg.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.