### PR TITLE
fix: -Wunsafe-buffer-usage warnings in GetNextZoomLevel()

### DIFF
--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -118,20 +118,20 @@ void SetZoomLevelForWebContents(content::WebContents* web_contents,
   content::HostZoomMap::SetZoomLevel(web_contents, level);
 }
 
-double GetNextZoomLevel(const double level, const bool out) {
+double GetNextZoomLevel(double level, bool out) {
   static constexpr std::array<double, 16U> kPresetFactors{
       0.25, 0.333, 0.5,  0.666, 0.75, 0.9, 1.0, 1.1,
       1.25, 1.5,   1.75, 2.0,   2.5,  3.0, 4.0, 5.0};
-  static constexpr auto kBegin = kPresetFactors.begin();
-  static constexpr auto kEnd = kPresetFactors.end();
+  static constexpr size_t size = std::size(kPresetFactors);
 
   const double factor = blink::ZoomLevelToZoomFactor(level);
-  auto matches = [=](auto val) { return blink::ZoomValuesEqual(factor, val); };
-  if (auto iter = std::find_if(kBegin, kEnd, matches); iter != kEnd) {
-    if (out && iter != kBegin)
-      return blink::ZoomFactorToZoomLevel(*--iter);
-    if (!out && ++iter != kEnd)
-      return blink::ZoomFactorToZoomLevel(*iter);
+  for (size_t i = 0U; i < size; ++i) {
+    if (!blink::ZoomValuesEqual(kPresetFactors[i], factor))
+      continue;
+    if (out && i > 0U)
+      return blink::ZoomFactorToZoomLevel(kPresetFactors[i - 1U]);
+    if (!out && i + 1U < size)
+      return blink::ZoomFactorToZoomLevel(kPresetFactors[i + 1U]);
   }
   return level;
 }


### PR DESCRIPTION
#### Description of Change

Fixup to #43803 / e894839709406101c54a067b6e1848ff294f17a5 that actually fixes the warning.

Takeaway lesson: give the compiler enough information to know that the array indices are always in the array's valid range.

Warnings fixed by this PR:

```
2024-10-04T05:18:49.7736915Z ../../electron/shell/browser/ui/inspectable_web_contents.cc:132:46: error: unsafe pointer arithmetic [-Werror,-Wunsafe-buffer-usage]
2024-10-04T05:18:49.7737765Z   132 |       return blink::ZoomFactorToZoomLevel(*--iter);
2024-10-04T05:18:49.7738163Z       |                                              ^~~~
2024-10-04T05:18:49.7738801Z ../../electron/shell/browser/ui/inspectable_web_contents.cc:132:46: note: See //docs/unsafe_buffers.md for help.
2024-10-04T05:18:49.7739875Z ../../electron/shell/browser/ui/inspectable_web_contents.cc:133:19: error: unsafe pointer arithmetic [-Werror,-Wunsafe-buffer-usage]
2024-10-04T05:18:49.7740573Z   133 |     if (!out && ++iter != kEnd)
2024-10-04T05:18:49.7740875Z       |                   ^~~~
2024-10-04T05:18:49.7741546Z ../../electron/shell/browser/ui/inspectable_web_contents.cc:133:19: note: See //docs/unsafe_buffers.md for help.
2024-10-04T05:18:49.7742134Z 2 errors generated.
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none