### PR TITLE
refactor: revert url::DomainIs() for cookie domains

### DIFF
--- a/docs/api/cookies.md
+++ b/docs/api/cookies.md
@@ -74,7 +74,7 @@ The following methods are available on instances of `Cookies`:
     `url`. Empty implies retrieving cookies of all URLs.
   * `name` string (optional) - Filters cookies by name.
   * `domain` string (optional) - Retrieves cookies whose domains match or are
-    subdomains of `domain`.
+    subdomains of `domains`.
   * `path` string (optional) - Retrieves cookies whose path matches `path`.
   * `secure` boolean (optional) - Filters cookies by their Secure property.
   * `session` boolean (optional) - Filters out session or persistent cookies.

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -5,7 +5,6 @@ import { expect } from 'chai';
 import * as send from 'send';
 
 import * as ChildProcess from 'node:child_process';
-import * as crypto from 'node:crypto';
 import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as http from 'node:http';
@@ -128,54 +127,6 @@ describe('session module', () => {
       await cookies.set({ url, name, value, expirationDate: (Date.now()) / 1000 + 120 });
       const cs = await cookies.get({ domain: '127.0.0.1' });
       expect(cs.some(c => c.name === name && c.value === value)).to.equal(true);
-    });
-
-    it('does not match on empty domain filter strings', async () => {
-      const { cookies } = session.defaultSession;
-      const name = crypto.randomBytes(20).toString('hex');
-      const value = '1';
-      const url = 'https://microsoft.com/';
-
-      await cookies.set({ url, name, value });
-      const cs = await cookies.get({ domain: '' });
-      expect(cs.some(c => c.name === name && c.value === value)).to.equal(false);
-      cookies.remove(url, name);
-    });
-
-    it('gets domain-equal cookies', async () => {
-      const { cookies } = session.defaultSession;
-      const name = crypto.randomBytes(20).toString('hex');
-      const value = '1';
-      const url = 'https://microsoft.com/';
-
-      await cookies.set({ url, name, value });
-      const cs = await cookies.get({ domain: 'microsoft.com' });
-      expect(cs.some(c => c.name === name && c.value === value)).to.equal(true);
-      cookies.remove(url, name);
-    });
-
-    it('gets domain-inclusive cookies', async () => {
-      const { cookies } = session.defaultSession;
-      const name = crypto.randomBytes(20).toString('hex');
-      const value = '1';
-      const url = 'https://subdomain.microsoft.com/';
-
-      await cookies.set({ url, name, value });
-      const cs = await cookies.get({ domain: 'microsoft.com' });
-      expect(cs.some(c => c.name === name && c.value === value)).to.equal(true);
-      cookies.remove(url, name);
-    });
-
-    it('omits domain-exclusive cookies', async () => {
-      const { cookies } = session.defaultSession;
-      const name = crypto.randomBytes(20).toString('hex');
-      const value = '1';
-      const url = 'https://microsoft.com';
-
-      await cookies.set({ url, name, value });
-      const cs = await cookies.get({ domain: 'subdomain.microsoft.com' });
-      expect(cs.some(c => c.name === name && c.value === value)).to.equal(false);
-      cookies.remove(url, name);
     });
 
     it('rejects when setting a cookie with missing required fields', async () => {


### PR DESCRIPTION
#### Description of Change

When testing samesite/sameparty cookies, we found a subtle regression after switching to the DomainIs implementation where the cookies were no longer being set. This PR reverts that refactor before Electron 33 stable until we can identify why the DomainIs implementation changes this.

Reverts https://github.com/electron/electron/pull/43262

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
