### PR TITLE
fix: preserve macos child window level

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -599,11 +599,13 @@ void NativeWindowMac::AttachChildren() {
     if ([child_nswindow parentWindow] == window_)
       continue;
 
-    // Attaching a window as a child window resets its window level, so
-    // save and restore it afterwards.
+    // Attaching a window as a child window resets window levels, so
+    // save and restore them afterwards.
     NSInteger level = window_.level;
+    NSInteger child_level = [child_nswindow level];
     [window_ addChildWindow:child_nswindow ordered:NSWindowAbove];
     [window_ setLevel:level];
+    [child_nswindow setLevel:child_level];
   }
 }
 


### PR DESCRIPTION
#### Description of Change
There is some code in Chromium that [checks the window level](https://source.chromium.org/chromium/chromium/src/+/main:content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm;l=754;drc=e4fd3f0d808141d13c0b6c821f9b10a04b1469e2) to determine if an unfocused window can receive mousemove events.

When Electron sets a window's parent, the level of both the parent and child are reset to NSWindowNormal. There is already some code to restore the parent's level. So I added some code to restore the child's level as well.

If the current behavior is the intended behavior, then an alternative patch could add a new window property that overrides the level check in Chromium. But this seemed simpler to me.

I couldn't find any tests for this area of the code. Happy to let someone with more Electron knowledge take over from here if much more is needed to get this landed.

Fixes #44150

#### Release Notes

Notes: Fixed MacOS windows losing their alwaysOnTop status when they were assigned a parent window.