### PR TITLE
ci: don't call datadog test logging on forks

### DIFF
--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -196,7 +196,10 @@ jobs:
         DD_API_KEY: ${{ secrets.DD_API_KEY }}
         DD_CIVISIBILITY_LOGS_ENABLED: true
         DD_TAGS: "os.architecture:${{ inputs.target-arch }},os.family:${{ inputs.target-platform }},os.platform:${{ inputs.target-platform }},asan:${{ inputs.is-asan }}"
-      run: datadog-ci junit upload src/electron/junit/test-results-main.xml
+      run: |
+        if ! [ -z $DD_API_KEY ]; then
+          datadog-ci junit upload src/electron/junit/test-results-main.xml
+        fi          
       if: always() && !cancelled()
     - name: Upload Test Artifacts
       if: always() && !cancelled()

--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -335,7 +335,7 @@ for:
       # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
       - if exist electron\junit\test-results-main.xml ( appveyor-retry appveyor PushArtifact electron\junit\test-results-main.xml )
       - ps: |
-          if ($env:RUN_TESTS -eq 'true') {
+          if ($env:DD_API_KEY) {
             $env:DD_GIT_COMMIT_SHA = $env:APPVEYOR_REPO_COMMIT
             $env:DD_GIT_BRANCH = $env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH
             $env:DD_TAGS = "os.architecture:$env:TARGET_ARCH,os.family:windows,os.platform:win32"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -330,7 +330,7 @@ for:
       # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
       - if exist electron\junit\test-results-main.xml ( appveyor-retry appveyor PushArtifact electron\junit\test-results-main.xml )
       - ps: |
-          if ($env:RUN_TESTS -eq 'true') {
+          if ($env:RUN_TESTS -eq 'true' -And $env:DD_API_KEY) {
             $env:DD_GIT_COMMIT_SHA = $env:APPVEYOR_REPO_COMMIT
             $env:DD_GIT_BRANCH = $env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH
             $env:DD_TAGS = "os.architecture:$env:TARGET_ARCH,os.family:windows,os.platform:win32"


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Fork PRS can't call datadog test logging so disable for foks.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
