### PR TITLE
feat: WebFrameMain.collectJavaScriptCallStack()

### DIFF
--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -145,8 +145,8 @@ ipcRenderer.on('port', (e, msg) => {
 #### `frame.collectJavaScriptCallStack()` _Experimental_
 
 Returns `Promise<string> | Promise<void>` - A promise that resolves with the currently running JavaScript call
-stack. If no JavaScript runs, the promise will never resolve. If the call stack is unable to be collected, it
-will return `undefined`.
+stack. If no JavaScript runs in the frame, the promise will never resolve. In cases where the call stack is
+otherwise unable to be collected, it will return `undefined`.
 
 This can be useful to determine why the frame is unresponsive in cases where there's long-running JavaScript.
 For more information, see the [proposed Crash Reporting API.](https://wicg.github.io/crash-reporting/)

--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -142,6 +142,28 @@ ipcRenderer.on('port', (e, msg) => {
 })
 ```
 
+#### `frame.collectJavaScriptCallStack()` _Experimental_
+
+Returns `Promise<string>` - A promise that resolves with the JavaScript call
+stack.
+
+This can be useful to determine why the frame is unresponsive in cases where there's long-running JavaScript.
+For more information, see the [proposed Crash Reporting API.](https://wicg.github.io/crash-reporting/)
+
+```js
+const { app } = require('electron')
+
+app.commandLine.appendSwitch('enable-features', 'DocumentPolicyIncludeJSCallStacksInCrashReports')
+
+app.on('web-contents-created', (_, webContents) => {
+  webContents.on('unresponsive', async () => {
+    // Interrupt execution and collect call stack from unresponsive renderer
+    const callStack = await webContents.mainFrame.collectJavaScriptCallStack()
+    console.log('Renderer unresponsive\n', callStack)
+  })
+})
+```
+
 ### Instance Properties
 
 #### `frame.ipc` _Readonly_

--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -241,29 +241,6 @@ A `Boolean` representing whether the frame is detached from the frame tree. If a
 while the corresponding page is running any [unload][] listeners, it may become detached as the
 newly navigated page replaced it in the frame tree.
 
-#### `frame.unresponsiveDocumentJSCallStack` _Readonly_ _Experimental_
-
-A `string` representing the JavaScript call stack of the frame while it's in an unresponsive state.
-
-This can be useful to determine why the frame is unresponsive in cases where there's long-running JavaScript.
-For more information, see the [proposed Crash Reporting API.](https://wicg.github.io/crash-reporting/)
-
-```js
-const { app } = require('electron')
-
-app.commandLine.appendSwitch('enable-features', 'DocumentPolicyIncludeJSCallStacksInCrashReports')
-
-app.on('web-contents-created', (_, webContents) => {
-  webContents.on('unresponsive', () => {
-    // Wait for call stack to be collected from the renderer process
-    setTimeout(() => {
-      const jsCallStack = webContents.mainFrame.unresponsiveDocumentJSCallStack
-      console.log('Renderer unresponsive\n', jsCallStack)
-    }, 10)
-  })
-})
-```
-
 [SCA]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 [`postMessage`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 [`MessagePortMain`]: message-port-main.md

--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -241,6 +241,29 @@ A `Boolean` representing whether the frame is detached from the frame tree. If a
 while the corresponding page is running any [unload][] listeners, it may become detached as the
 newly navigated page replaced it in the frame tree.
 
+#### `frame.unresponsiveDocumentJSCallStack` _Readonly_ _Experimental_
+
+A `string` representing the JavaScript call stack of the frame while it's in an unresponsive state.
+
+This can be useful to determine why the frame is unresponsive in cases where there's long-running JavaScript.
+For more information, see the [proposed Crash Reporting API.](https://wicg.github.io/crash-reporting/)
+
+```js
+const { app } = require('electron')
+
+app.commandLine.appendSwitch('enable-features', 'DocumentPolicyIncludeJSCallStacksInCrashReports')
+
+app.on('web-contents-created', (_, webContents) => {
+  webContents.on('unresponsive', () => {
+    // Wait for call stack to be collected from the renderer process
+    setTimeout(() => {
+      const jsCallStack = webContents.mainFrame.unresponsiveDocumentJSCallStack
+      console.log('Renderer unresponsive\n', jsCallStack)
+    }, 10)
+  })
+})
+```
+
 [SCA]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 [`postMessage`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 [`MessagePortMain`]: message-port-main.md

--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -144,8 +144,9 @@ ipcRenderer.on('port', (e, msg) => {
 
 #### `frame.collectJavaScriptCallStack()` _Experimental_
 
-Returns `Promise<string>` - A promise that resolves with the JavaScript call
-stack.
+Returns `Promise<string> | Promise<void>` - A promise that resolves with the currently running JavaScript call
+stack. If no JavaScript runs, the promise will never resolve. If the call stack is unable to be collected, it
+will return `undefined`.
 
 This can be useful to determine why the frame is unresponsive in cases where there's long-running JavaScript.
 For more information, see the [proposed Crash Reporting API.](https://wicg.github.io/crash-reporting/)

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -9,11 +9,9 @@
 #include <utility>
 #include <vector>
 
-#include "base/feature_list.h"
 #include "base/logging.h"
 #include "base/no_destructor.h"
 #include "content/browser/renderer_host/render_frame_host_impl.h"  // nogncheck
-#include "content/browser/renderer_host/render_process_host_impl.h"  // nogncheck
 #include "content/public/browser/frame_tree_node_id.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/common/isolated_world_ids.h"
@@ -431,31 +429,6 @@ std::vector<content::RenderFrameHost*> WebFrameMain::FramesInSubtree() const {
   return frame_hosts;
 }
 
-std::string WebFrameMain::UnresponsiveDocumentJSCallStack() const {
-  if (!CheckRenderFrame())
-    return "";
-
-  if (!base::FeatureList::IsEnabled(
-          blink::features::kDocumentPolicyIncludeJSCallStacksInCrashReports)) {
-    return "";
-  }
-
-  content::RenderProcessHostImpl* rph =
-      static_cast<content::RenderProcessHostImpl*>(render_frame_->GetProcess());
-  const std::string& unresponsive_document_javascript_call_stack =
-      rph->GetUnresponsiveDocumentJavascriptCallStack();
-  const blink::LocalFrameToken& unresponsive_document_token =
-      rph->GetUnresponsiveDocumentToken();
-
-  if (!unresponsive_document_javascript_call_stack.empty()) {
-    if (unresponsive_document_token == render_frame_->GetFrameToken()) {
-      return unresponsive_document_javascript_call_stack;
-    }
-  }
-
-  return "";
-}
-
 void WebFrameMain::DOMContentLoaded() {
   Emit("dom-ready");
 }
@@ -505,8 +478,6 @@ void WebFrameMain::FillObjectTemplate(v8::Isolate* isolate,
       .SetProperty("parent", &WebFrameMain::Parent)
       .SetProperty("frames", &WebFrameMain::Frames)
       .SetProperty("framesInSubtree", &WebFrameMain::FramesInSubtree)
-      .SetProperty("unresponsiveDocumentJSCallStack",
-                   &WebFrameMain::UnresponsiveDocumentJSCallStack)
       .Build();
 }
 

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -9,9 +9,11 @@
 #include <utility>
 #include <vector>
 
+#include "base/feature_list.h"
 #include "base/logging.h"
 #include "base/no_destructor.h"
 #include "content/browser/renderer_host/render_frame_host_impl.h"  // nogncheck
+#include "content/browser/renderer_host/render_process_host_impl.h"  // nogncheck
 #include "content/public/browser/frame_tree_node_id.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/common/isolated_world_ids.h"
@@ -429,6 +431,31 @@ std::vector<content::RenderFrameHost*> WebFrameMain::FramesInSubtree() const {
   return frame_hosts;
 }
 
+std::string WebFrameMain::UnresponsiveDocumentJSCallStack() const {
+  if (!CheckRenderFrame())
+    return "";
+
+  if (!base::FeatureList::IsEnabled(
+          blink::features::kDocumentPolicyIncludeJSCallStacksInCrashReports)) {
+    return "";
+  }
+
+  content::RenderProcessHostImpl* rph =
+      static_cast<content::RenderProcessHostImpl*>(render_frame_->GetProcess());
+  const std::string& unresponsive_document_javascript_call_stack =
+      rph->GetUnresponsiveDocumentJavascriptCallStack();
+  const blink::LocalFrameToken& unresponsive_document_token =
+      rph->GetUnresponsiveDocumentToken();
+
+  if (!unresponsive_document_javascript_call_stack.empty()) {
+    if (unresponsive_document_token == render_frame_->GetFrameToken()) {
+      return unresponsive_document_javascript_call_stack;
+    }
+  }
+
+  return "";
+}
+
 void WebFrameMain::DOMContentLoaded() {
   Emit("dom-ready");
 }
@@ -478,6 +505,8 @@ void WebFrameMain::FillObjectTemplate(v8::Isolate* isolate,
       .SetProperty("parent", &WebFrameMain::Parent)
       .SetProperty("frames", &WebFrameMain::Frames)
       .SetProperty("framesInSubtree", &WebFrameMain::FramesInSubtree)
+      .SetProperty("unresponsiveDocumentJSCallStack",
+                   &WebFrameMain::UnresponsiveDocumentJSCallStack)
       .Build();
 }
 

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -128,8 +128,6 @@ class WebFrameMain final : public gin::Wrappable<WebFrameMain>,
   std::vector<content::RenderFrameHost*> Frames() const;
   std::vector<content::RenderFrameHost*> FramesInSubtree() const;
 
-  std::string UnresponsiveDocumentJSCallStack() const;
-
   void DOMContentLoaded();
 
   mojo::Remote<mojom::ElectronRenderer> renderer_api_;

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -128,6 +128,8 @@ class WebFrameMain final : public gin::Wrappable<WebFrameMain>,
   std::vector<content::RenderFrameHost*> Frames() const;
   std::vector<content::RenderFrameHost*> FramesInSubtree() const;
 
+  std::string UnresponsiveDocumentJSCallStack() const;
+
   void DOMContentLoaded();
 
   mojo::Remote<mojom::ElectronRenderer> renderer_api_;

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -36,6 +36,11 @@ template <typename T>
 class Handle;
 }  // namespace gin
 
+namespace gin_helper {
+template <typename T>
+class Promise;
+}  // namespace gin_helper
+
 namespace electron::api {
 
 class WebContents;
@@ -129,6 +134,10 @@ class WebFrameMain final : public gin::Wrappable<WebFrameMain>,
   std::vector<content::RenderFrameHost*> FramesInSubtree() const;
 
   v8::Local<v8::Promise> CollectDocumentJSCallStack(gin::Arguments* args);
+  void CollectedJavaScriptCallStack(
+      gin_helper::Promise<base::Value> promise,
+      const std::string& untrusted_javascript_call_stack,
+      const std::optional<blink::LocalFrameToken>& remote_frame_token);
 
   void DOMContentLoaded();
 

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -128,6 +128,8 @@ class WebFrameMain final : public gin::Wrappable<WebFrameMain>,
   std::vector<content::RenderFrameHost*> Frames() const;
   std::vector<content::RenderFrameHost*> FramesInSubtree() const;
 
+  v8::Local<v8::Promise> CollectDocumentJSCallStack(gin::Arguments* args);
+
   void DOMContentLoaded();
 
   mojo::Remote<mojom::ElectronRenderer> renderer_api_;

--- a/spec/index.js
+++ b/spec/index.js
@@ -33,6 +33,12 @@ app.commandLine.appendSwitch('host-resolver-rules', [
   'MAP notfound.localhost2 ~NOTFOUND'
 ].join(', '));
 
+// Enable features required by tests.
+app.commandLine.appendSwitch('enable-features', [
+  // spec/api-web-frame-main-spec.ts
+  'DocumentPolicyIncludeJSCallStacksInCrashReports'
+].join(','));
+
 global.standardScheme = 'app';
 global.zoomScheme = 'zoom';
 global.serviceWorkerScheme = 'sw';


### PR DESCRIPTION
#### Description of Change

Adds `WebFrameMain.collectJavaScriptCallStack()` to allow accessing the JavaScript call stack of unresponsive renderers. This is available in Chromium as part of the [Crash Reporting API.](https://wicg.github.io/crash-reporting/)

With this API, a dialog shown when a renderer becomes unresponsive could have an option to copy the stack trace. This would help application developers figure out why their website might be stuck on long-running JavaScript.

I've marked the API as experimental given that the proposal is still a draft.

-----

Here's an example of the output from a [fiddle gist](https://gist.github.com/dfddc4c3e4459f097ca7f9bb35218d88):
```
Renderer unresponsive
 
    at startInfiniteLoop (<anonymous>:5:5)
    at HTMLHtmlElement.clickHandler (<anonymous>:11:5)
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `WebFrameMain.collectJavaScriptCallStack()` for accessing the JavaScript call stack of unresponsive renderers.
