### PR TITLE
test: run visibility-state-spec.ts first

### DIFF
--- a/script/split-tests.js
+++ b/script/split-tests.js
@@ -3,8 +3,6 @@ const glob = require('glob');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const VISIBILITY_SPEC = 'spec\\visibility-state-spec.ts';
-
 const currentShard = parseInt(process.argv[2], 10);
 const shardCount = parseInt(process.argv[3], 10);
 
@@ -33,11 +31,4 @@ for (const specFile of specFiles) {
   if (shard === shardCount) shard = 0;
 }
 
-const visiblitySpecIdx = buckets[currentShard - 1];
-if (visiblitySpecIdx > -1) {
-  // If visibility-state-spec is in the list, move it to the first position
-  // so that it gets executed first to avoid other specs interferring with it.
-  buckets[currentShard - 1].splice(visiblitySpecIdx, 1);
-  buckets[currentShard - 1].unshift(VISIBILITY_SPEC);
-}
 console.log(buckets[currentShard - 1].join(' '));

--- a/spec/index.js
+++ b/spec/index.js
@@ -149,7 +149,17 @@ app.whenReady().then(async () => {
 
   const { getFiles } = require('./get-files');
   const testFiles = await getFiles(__dirname, filter);
-  for (const file of testFiles.sort()) {
+  const VISIBILITY_SPEC = ('visibility-state-spec.ts');
+  const sortedFiles = testFiles.sort((a, b) => {
+    // If visibility-state-spec is in the list, move it to the first position
+    // so that it gets executed first to avoid other specs interferring with it.
+    if (a.indexOf(VISIBILITY_SPEC) > -1) {
+      return -1;
+    } else {
+      return a.localeCompare(b);
+    }
+  });
+  for (const file of sortedFiles) {
     mocha.addFile(file);
   }
 


### PR DESCRIPTION
#### Description of Change
I realized looking at the backports of #44037 that it did not actually run the visibility tests first.  The backports have been corrected before merging, but this fix is needed for main.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
