### PR TITLE
refactor: spanify image utils (32-x-y)

### DIFF
--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -30,6 +30,7 @@
 #include "shell/common/gin_helper/function_template_extensions.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
+#include "shell/common/node_util.h"
 #include "shell/common/process_util.h"
 #include "shell/common/skia_util.h"
 #include "shell/common/thread_restrictions.h"
@@ -397,20 +398,18 @@ void NativeImage::AddRepresentation(const gin_helper::Dictionary& options) {
   v8::Local<v8::Value> buffer;
   GURL url;
   if (options.Get("buffer", &buffer) && node::Buffer::HasInstance(buffer)) {
-    auto* data = reinterpret_cast<unsigned char*>(node::Buffer::Data(buffer));
-    auto size = node::Buffer::Length(buffer);
     skia_rep_added = electron::util::AddImageSkiaRepFromBuffer(
-        &image_skia, data, size, width, height, scale_factor);
+        &image_skia, electron::util::as_byte_span(buffer), width, height,
+        scale_factor);
   } else if (options.Get("dataURL", &url)) {
     std::string mime_type, charset, data;
     if (net::DataURL::Parse(url, &mime_type, &charset, &data)) {
-      auto* data_ptr = reinterpret_cast<const unsigned char*>(data.c_str());
       if (mime_type == "image/png") {
         skia_rep_added = electron::util::AddImageSkiaRepFromPNG(
-            &image_skia, data_ptr, data.size(), scale_factor);
+            &image_skia, base::as_byte_span(data), scale_factor);
       } else if (mime_type == "image/jpeg") {
         skia_rep_added = electron::util::AddImageSkiaRepFromJPEG(
-            &image_skia, data_ptr, data.size(), scale_factor);
+            &image_skia, base::as_byte_span(data), scale_factor);
       }
     }
   }
@@ -442,22 +441,20 @@ gin::Handle<NativeImage> NativeImage::Create(v8::Isolate* isolate,
 }
 
 // static
-gin::Handle<NativeImage> NativeImage::CreateFromPNG(v8::Isolate* isolate,
-                                                    const char* buffer,
-                                                    size_t length) {
+gin::Handle<NativeImage> NativeImage::CreateFromPNG(
+    v8::Isolate* isolate,
+    const base::span<const uint8_t> data) {
   gfx::ImageSkia image_skia;
-  electron::util::AddImageSkiaRepFromPNG(
-      &image_skia, reinterpret_cast<const unsigned char*>(buffer), length, 1.0);
+  electron::util::AddImageSkiaRepFromPNG(&image_skia, data, 1.0);
   return Create(isolate, gfx::Image(image_skia));
 }
 
 // static
-gin::Handle<NativeImage> NativeImage::CreateFromJPEG(v8::Isolate* isolate,
-                                                     const char* buffer,
-                                                     size_t length) {
+gin::Handle<NativeImage> NativeImage::CreateFromJPEG(
+    v8::Isolate* isolate,
+    const base::span<const uint8_t> buffer) {
   gfx::ImageSkia image_skia;
-  electron::util::AddImageSkiaRepFromJPEG(
-      &image_skia, reinterpret_cast<const unsigned char*>(buffer), length, 1.0);
+  electron::util::AddImageSkiaRepFromJPEG(&image_skia, buffer, 1.0);
   return Create(isolate, gfx::Image(image_skia));
 }
 
@@ -509,7 +506,8 @@ gin::Handle<NativeImage> NativeImage::CreateFromBitmap(
   auto info = SkImageInfo::MakeN32(width, height, kPremul_SkAlphaType);
   auto size_bytes = info.computeMinByteSize();
 
-  if (size_bytes != node::Buffer::Length(buffer)) {
+  const auto buffer_data = electron::util::as_byte_span(buffer);
+  if (size_bytes != buffer_data.size()) {
     thrower.ThrowError("invalid buffer size");
     return gin::Handle<NativeImage>();
   }
@@ -522,7 +520,7 @@ gin::Handle<NativeImage> NativeImage::CreateFromBitmap(
 
   SkBitmap bitmap;
   bitmap.allocN32Pixels(width, height, false);
-  bitmap.writePixels({info, node::Buffer::Data(buffer), bitmap.rowBytes()});
+  bitmap.writePixels({info, buffer_data.data(), bitmap.rowBytes()});
 
   gfx::ImageSkia image_skia =
       gfx::ImageSkia::CreateFromBitmap(bitmap, scale_factor);
@@ -553,8 +551,8 @@ gin::Handle<NativeImage> NativeImage::CreateFromBuffer(
 
   gfx::ImageSkia image_skia;
   electron::util::AddImageSkiaRepFromBuffer(
-      &image_skia, reinterpret_cast<unsigned char*>(node::Buffer::Data(buffer)),
-      node::Buffer::Length(buffer), width, height, scale_factor);
+      &image_skia, electron::util::as_byte_span(buffer), width, height,
+      scale_factor);
   return Create(args->isolate(), gfx::Image(image_skia));
 }
 
@@ -564,9 +562,9 @@ gin::Handle<NativeImage> NativeImage::CreateFromDataURL(v8::Isolate* isolate,
   std::string mime_type, charset, data;
   if (net::DataURL::Parse(url, &mime_type, &charset, &data)) {
     if (mime_type == "image/png")
-      return CreateFromPNG(isolate, data.c_str(), data.size());
-    else if (mime_type == "image/jpeg")
-      return CreateFromJPEG(isolate, data.c_str(), data.size());
+      return CreateFromPNG(isolate, base::as_byte_span(data));
+    if (mime_type == "image/jpeg")
+      return CreateFromJPEG(isolate, base::as_byte_span(data));
   }
 
   return CreateEmpty(isolate);

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "base/containers/flat_map.h"
+#include "base/containers/span.h"
 #include "base/memory/raw_ptr.h"
 #include "base/values.h"
 #include "gin/handle.h"
@@ -59,11 +60,10 @@ class NativeImage final : public gin::Wrappable<NativeImage> {
   static gin::Handle<NativeImage> Create(v8::Isolate* isolate,
                                          const gfx::Image& image);
   static gin::Handle<NativeImage> CreateFromPNG(v8::Isolate* isolate,
-                                                const char* buffer,
-                                                size_t length);
-  static gin::Handle<NativeImage> CreateFromJPEG(v8::Isolate* isolate,
-                                                 const char* buffer,
-                                                 size_t length);
+                                                base::span<const uint8_t> data);
+  static gin::Handle<NativeImage> CreateFromJPEG(
+      v8::Isolate* isolate,
+      base::span<const uint8_t> data);
   static gin::Handle<NativeImage> CreateFromPath(v8::Isolate* isolate,
                                                  const base::FilePath& path);
   static gin::Handle<NativeImage> CreateFromBitmap(

--- a/shell/common/node_util.h
+++ b/shell/common/node_util.h
@@ -7,8 +7,8 @@
 
 #include <vector>
 
-#include "build/build_config.h"
-#include "v8/include/v8.h"
+#include "base/containers/span.h"
+#include "v8/include/v8-forward.h"
 
 namespace node {
 class Environment;
@@ -26,6 +26,11 @@ v8::MaybeLocal<v8::Value> CompileAndCall(
     const char* id,
     std::vector<v8::Local<v8::String>>* parameters,
     std::vector<v8::Local<v8::Value>>* arguments);
+
+// Convenience function to view a Node buffer's data as a base::span().
+// Analogous to base::as_byte_span()
+[[nodiscard]] base::span<uint8_t> as_byte_span(
+    v8::Local<v8::Value> node_buffer);
 
 }  // namespace electron::util
 

--- a/shell/common/skia_util.cc
+++ b/shell/common/skia_util.cc
@@ -57,11 +57,10 @@ float GetScaleFactorFromPath(const base::FilePath& path) {
 }
 
 bool AddImageSkiaRepFromPNG(gfx::ImageSkia* image,
-                            const unsigned char* data,
-                            size_t size,
+                            const base::span<const uint8_t> data,
                             double scale_factor) {
   SkBitmap bitmap;
-  if (!gfx::PNGCodec::Decode(data, size, &bitmap))
+  if (!gfx::PNGCodec::Decode(data.data(), data.size(), &bitmap))
     return false;
 
   image->AddRepresentation(gfx::ImageSkiaRep(bitmap, scale_factor));
@@ -69,10 +68,9 @@ bool AddImageSkiaRepFromPNG(gfx::ImageSkia* image,
 }
 
 bool AddImageSkiaRepFromJPEG(gfx::ImageSkia* image,
-                             const unsigned char* data,
-                             size_t size,
+                             const base::span<const uint8_t> data,
                              double scale_factor) {
-  auto bitmap = gfx::JPEGCodec::Decode(data, size);
+  auto bitmap = gfx::JPEGCodec::Decode(data.data(), data.size());
   if (!bitmap)
     return false;
 
@@ -90,29 +88,28 @@ bool AddImageSkiaRepFromJPEG(gfx::ImageSkia* image,
 }
 
 bool AddImageSkiaRepFromBuffer(gfx::ImageSkia* image,
-                               const unsigned char* data,
-                               size_t size,
+                               const base::span<const uint8_t> data,
                                int width,
                                int height,
                                double scale_factor) {
   // Try PNG first.
-  if (AddImageSkiaRepFromPNG(image, data, size, scale_factor))
+  if (AddImageSkiaRepFromPNG(image, data, scale_factor))
     return true;
 
   // Try JPEG second.
-  if (AddImageSkiaRepFromJPEG(image, data, size, scale_factor))
+  if (AddImageSkiaRepFromJPEG(image, data, scale_factor))
     return true;
 
   if (width == 0 || height == 0)
     return false;
 
   auto info = SkImageInfo::MakeN32(width, height, kPremul_SkAlphaType);
-  if (size < info.computeMinByteSize())
+  if (data.size() < info.computeMinByteSize())
     return false;
 
   SkBitmap bitmap;
   bitmap.allocN32Pixels(width, height, false);
-  bitmap.writePixels({info, data, bitmap.rowBytes()});
+  bitmap.writePixels({info, data.data(), bitmap.rowBytes()});
 
   image->AddRepresentation(gfx::ImageSkiaRep(bitmap, scale_factor));
   return true;
@@ -128,11 +125,8 @@ bool AddImageSkiaRepFromPath(gfx::ImageSkia* image,
       return false;
   }
 
-  const auto* data =
-      reinterpret_cast<const unsigned char*>(file_contents.data());
-  size_t size = file_contents.size();
-
-  return AddImageSkiaRepFromBuffer(image, data, size, 0, 0, scale_factor);
+  return AddImageSkiaRepFromBuffer(image, base::as_byte_span(file_contents), 0,
+                                   0, scale_factor);
 }
 
 bool PopulateImageSkiaRepsFromPath(gfx::ImageSkia* image,

--- a/shell/common/skia_util.h
+++ b/shell/common/skia_util.h
@@ -5,9 +5,13 @@
 #ifndef ELECTRON_SHELL_COMMON_SKIA_UTIL_H_
 #define ELECTRON_SHELL_COMMON_SKIA_UTIL_H_
 
+#include <cstdint>
+
+#include "base/containers/span.h"
+
 namespace base {
 class FilePath;
-}
+}  // namespace base
 
 namespace gfx {
 class ImageSkia;
@@ -19,20 +23,17 @@ bool PopulateImageSkiaRepsFromPath(gfx::ImageSkia* image,
                                    const base::FilePath& path);
 
 bool AddImageSkiaRepFromBuffer(gfx::ImageSkia* image,
-                               const unsigned char* data,
-                               size_t size,
+                               base::span<const uint8_t> data,
                                int width,
                                int height,
                                double scale_factor);
 
 bool AddImageSkiaRepFromJPEG(gfx::ImageSkia* image,
-                             const unsigned char* data,
-                             size_t size,
+                             base::span<const uint8_t> data,
                              double scale_factor);
 
 bool AddImageSkiaRepFromPNG(gfx::ImageSkia* image,
-                            const unsigned char* data,
-                            size_t size,
+                            base::span<const uint8_t> data,
                             double scale_factor);
 
 #if BUILDFLAG(IS_WIN)


### PR DESCRIPTION
Manual backport of #44127 to 32-x-y. See that PR for details.

Notes: none