### PR TITLE
fix: -Wunsafe-buffer-usage warnings in GetNextZoomLevel() (#44149)

### DIFF
--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -124,22 +124,20 @@ void SetZoomLevelForWebContents(content::WebContents* web_contents,
   content::HostZoomMap::SetZoomLevel(web_contents, level);
 }
 
-double GetNextZoomLevel(const double level, const bool out) {
+double GetNextZoomLevel(double level, bool out) {
   static constexpr std::array<double, 16U> kPresetFactors{
       0.25, 0.333, 0.5,  0.666, 0.75, 0.9, 1.0, 1.1,
       1.25, 1.5,   1.75, 2.0,   2.5,  3.0, 4.0, 5.0};
-  static constexpr auto kBegin = kPresetFactors.begin();
-  static constexpr auto kEnd = kPresetFactors.end();
+  static constexpr size_t size = std::size(kPresetFactors);
 
   const double factor = blink::PageZoomLevelToZoomFactor(level);
-  auto matches = [=](auto val) {
-    return blink::PageZoomValuesEqual(factor, val);
-  };
-  if (auto iter = std::find_if(kBegin, kEnd, matches); iter != kEnd) {
-    if (out && iter != kBegin)
-      return blink::PageZoomFactorToZoomLevel(*--iter);
-    if (!out && ++iter != kEnd)
-      return blink::PageZoomFactorToZoomLevel(*iter);
+  for (size_t i = 0U; i < size; ++i) {
+    if (!blink::PageZoomValuesEqual(kPresetFactors[i], factor))
+      continue;
+    if (out && i > 0U)
+      return blink::PageZoomFactorToZoomLevel(kPresetFactors[i - 1U]);
+    if (!out && i + 1U < size)
+      return blink::PageZoomFactorToZoomLevel(kPresetFactors[i + 1U]);
   }
   return level;
 }


### PR DESCRIPTION
Manual backport of #44149 to 31-x-y. See that PR for details.

Notes: none