### PR TITLE
build: update devcontainer sha

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   buildtools:
-    image: ghcr.io/electron/devcontainer:9a43c14f5c19be0359843299f79e736521373adc
+    image: ghcr.io/electron/devcontainer:77262e58c37631ab082482f42c33cdf68c6c394b
 
     volumes:
       - ..:/workspaces/gclient/src/electron:cached


### PR DESCRIPTION
#### Description of Change

Fixes broken Codespaces resultant of docs-parser requiring Node.js > v20.11.0. Our Codespaces sha was outdated - this pulls in a newer one with compatible Node.js version.
#### Release Notes

Notes: none
