### PR TITLE
chore: cherry-pick 3 changes from 2-M129

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -145,3 +145,5 @@ cherry-pick-38e4483e47f9.patch
 cherry-pick-1b9040817119.patch
 cherry-pick-99cafbf4b4b9.patch
 cherry-pick-d9f7652c867c.patch
+cherry-pick-56be91796b85.patch
+cherry-pick-c333ed995449.patch

--- a/patches/chromium/cherry-pick-56be91796b85.patch
+++ b/patches/chromium/cherry-pick-56be91796b85.patch
@@ -1,0 +1,78 @@
+From 56be91796b858a088f67add4e074b9b016f25757 Mon Sep 17 00:00:00 2001
+From: Kent Tamura <tkent@chromium.org>
+Date: Thu, 19 Sep 2024 03:15:18 +0000
+Subject: [PATCH] RubyLB: Fix a crash with a parent with a non-default text-align
+
+Update the LineInfo::GetTextAlign() logic so that it align with
+ApplyRubyAlign() behavior.
+
+This CL also removes stale comments.
+
+Bug: 367764861
+Change-Id: Idfe0f3c2f77c7a33ff9317c2b0f36ffa397405d1
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5874482
+Commit-Queue: Koji Ishii <kojii@chromium.org>
+Reviewed-by: Koji Ishii <kojii@chromium.org>
+Auto-Submit: Kent Tamura <tkent@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1357460}
+---
+
+diff --git a/third_party/blink/renderer/core/layout/inline/line_info.cc b/third_party/blink/renderer/core/layout/inline/line_info.cc
+index 402e48a..ec44514 100644
+--- a/third_party/blink/renderer/core/layout/inline/line_info.cc
++++ b/third_party/blink/renderer/core/layout/inline/line_info.cc
+@@ -114,14 +114,25 @@
+ }
+ 
+ ETextAlign LineInfo::GetTextAlign(bool is_last_line) const {
+-  // See LayoutRubyBase::TextAlignmentForLine().
+   if (is_ruby_base_)
+     return ETextAlign::kJustify;
+ 
+-  // See LayoutRubyText::TextAlignmentForLine().
+-  if (is_ruby_text_ && LineStyle().GetTextAlign() ==
+-                           ComputedStyleInitialValues::InitialTextAlign())
+-    return ETextAlign::kJustify;
++  if (is_ruby_text_) {
++    ETextAlign text_align = LineStyle().GetTextAlign();
++    if (!RuntimeEnabledFeatures::RubyLineBreakableEnabled()) {
++      if (text_align == ComputedStyleInitialValues::InitialTextAlign()) {
++        return ETextAlign::kJustify;
++      }
++    } else {
++      ERubyAlign ruby_align = LineStyle().RubyAlign();
++      if ((ruby_align == ERubyAlign::kSpaceAround &&
++           (text_align == ComputedStyleInitialValues::InitialTextAlign() ||
++            text_align == ETextAlign::kJustify)) ||
++          ruby_align == ERubyAlign::kSpaceBetween) {
++        return ETextAlign::kJustify;
++      }
++    }
++  }
+ 
+   return LineStyle().GetTextAlign(is_last_line);
+ }
+diff --git a/third_party/blink/web_tests/fast/ruby/ruby-align-in-text-align-crash.html b/third_party/blink/web_tests/fast/ruby/ruby-align-in-text-align-crash.html
+new file mode 100644
+index 0000000..b456709
+--- /dev/null
++++ b/third_party/blink/web_tests/fast/ruby/ruby-align-in-text-align-crash.html
+@@ -0,0 +1,18 @@
++<!DOCTYPE html>
++<head>
++<script src="../../resources/testharness.js"></script>
++<script src="../../resources/testharnessreport.js"></script>
++<style>
++span {
++  display: ruby-text;
++  ruby-align: space-between;
++}
++</style>
++</head>
++<body>
++<center><span><table></table></span></center>
++<script>
++test(() => {
++}, 'crbug.com/367764861: No crash by a ruby-text with ruby-align:space-between in a <center>');
++</script>
++</body>

--- a/patches/chromium/cherry-pick-56be91796b85.patch
+++ b/patches/chromium/cherry-pick-56be91796b85.patch
@@ -1,7 +1,7 @@
-From 56be91796b858a088f67add4e074b9b016f25757 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kent Tamura <tkent@chromium.org>
 Date: Thu, 19 Sep 2024 03:15:18 +0000
-Subject: [PATCH] RubyLB: Fix a crash with a parent with a non-default text-align
+Subject: RubyLB: Fix a crash with a parent with a non-default text-align
 
 Update the LineInfo::GetTextAlign() logic so that it align with
 ApplyRubyAlign() behavior.
@@ -15,13 +15,12 @@ Commit-Queue: Koji Ishii <kojii@chromium.org>
 Reviewed-by: Koji Ishii <kojii@chromium.org>
 Auto-Submit: Kent Tamura <tkent@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#1357460}
----
 
 diff --git a/third_party/blink/renderer/core/layout/inline/line_info.cc b/third_party/blink/renderer/core/layout/inline/line_info.cc
-index 402e48a..ec44514 100644
+index fc28f58c4d8c8e510e7ed13f978694a16f6dd1f8..b5e11b9d269d8942f1e4478251d67f5a9919ebce 100644
 --- a/third_party/blink/renderer/core/layout/inline/line_info.cc
 +++ b/third_party/blink/renderer/core/layout/inline/line_info.cc
-@@ -114,14 +114,25 @@
+@@ -88,14 +88,25 @@ void LineInfo::SetLineStyle(const InlineNode& node,
  }
  
  ETextAlign LineInfo::GetTextAlign(bool is_last_line) const {
@@ -54,7 +53,7 @@ index 402e48a..ec44514 100644
  }
 diff --git a/third_party/blink/web_tests/fast/ruby/ruby-align-in-text-align-crash.html b/third_party/blink/web_tests/fast/ruby/ruby-align-in-text-align-crash.html
 new file mode 100644
-index 0000000..b456709
+index 0000000000000000000000000000000000000000..b4567097d39ede1f66bb84f0b00519896fd03a18
 --- /dev/null
 +++ b/third_party/blink/web_tests/fast/ruby/ruby-align-in-text-align-crash.html
 @@ -0,0 +1,18 @@

--- a/patches/chromium/cherry-pick-c333ed995449.patch
+++ b/patches/chromium/cherry-pick-c333ed995449.patch
@@ -1,0 +1,182 @@
+From c333ed99544992f66e6e03621fa938d75ad01f70 Mon Sep 17 00:00:00 2001
+From: Ken Rockot <rockot@google.com>
+Date: Mon, 23 Sep 2024 19:26:24 +0000
+Subject: [PATCH] ipcz: Validate link state fragment before adoption
+
+Fixed: 368208152
+Change-Id: I0e2ece4b0857b225d229134b2e55abc3e08348ee
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5876623
+Commit-Queue: Ken Rockot <rockot@google.com>
+Reviewed-by: Daniel Cheng <dcheng@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1358968}
+---
+
+diff --git a/third_party/ipcz/src/ipcz/node_link.cc b/third_party/ipcz/src/ipcz/node_link.cc
+index e862cf40..dde90c9 100644
+--- a/third_party/ipcz/src/ipcz/node_link.cc
++++ b/third_party/ipcz/src/ipcz/node_link.cc
+@@ -36,21 +36,6 @@
+ 
+ namespace ipcz {
+ 
+-namespace {
+-
+-template <typename T>
+-FragmentRef<T> MaybeAdoptFragmentRef(NodeLinkMemory& memory,
+-                                     const FragmentDescriptor& descriptor) {
+-  if (descriptor.is_null() || descriptor.size() < sizeof(T) ||
+-      descriptor.offset() % 8 != 0) {
+-    return {};
+-  }
+-
+-  return memory.AdoptFragmentRef<T>(memory.GetFragment(descriptor));
+-}
+-
+-}  // namespace
+-
+ // static
+ Ref<NodeLink> NodeLink::CreateActive(Ref<Node> node,
+                                      LinkSide link_side,
+@@ -714,8 +699,8 @@
+     return true;
+   }
+ 
+-  auto link_state = MaybeAdoptFragmentRef<RouterLinkState>(
+-      memory(), accept.v0()->new_link_state_fragment);
++  auto link_state = memory().AdoptFragmentRefIfValid<RouterLinkState>(
++      accept.v0()->new_link_state_fragment);
+   if (link_state.is_null()) {
+     // Bypass links must always come with a valid fragment for their
+     // RouterLinkState. If one has not been provided, that's a validation
+@@ -753,8 +738,8 @@
+     return true;
+   }
+ 
+-  auto link_state = MaybeAdoptFragmentRef<RouterLinkState>(
+-      memory(), bypass.v0()->new_link_state_fragment);
++  auto link_state = memory().AdoptFragmentRefIfValid<RouterLinkState>(
++      bypass.v0()->new_link_state_fragment);
+   if (link_state.is_null()) {
+     return false;
+   }
+diff --git a/third_party/ipcz/src/ipcz/node_link_memory.h b/third_party/ipcz/src/ipcz/node_link_memory.h
+index c5e3d64..f457757 100644
+--- a/third_party/ipcz/src/ipcz/node_link_memory.h
++++ b/third_party/ipcz/src/ipcz/node_link_memory.h
+@@ -98,14 +98,29 @@
+   // with the same BufferId and dimensions as `descriptor`.
+   Fragment GetFragment(const FragmentDescriptor& descriptor);
+ 
+-  // Adopts an existing reference to a RefCountedFragment within `fragment`.
+-  // This does NOT increment the ref count of the RefCountedFragment.
++  // Adopts an existing reference to a RefCountedFragment within `fragment`,
++  // which must be a valid, properly aligned, and sufficiently sized fragment to
++  // hold a T. This does NOT increment the ref count of the RefCountedFragment.
+   template <typename T>
+   FragmentRef<T> AdoptFragmentRef(const Fragment& fragment) {
+     ABSL_ASSERT(sizeof(T) <= fragment.size());
+     return FragmentRef<T>(kAdoptExistingRef, WrapRefCounted(this), fragment);
+   }
+ 
++  // Attempts to adopt an existing reference to a RefCountedFragment located at
++  // `fragment`. Returns null if the fragment descriptor is null, misaligned,
++  // or of insufficient size. This does NOT increment the ref count of the
++  // RefCountedFragment.
++  template <typename T>
++  FragmentRef<T> AdoptFragmentRefIfValid(const FragmentDescriptor& descriptor) {
++    if (descriptor.is_null() || descriptor.size() < sizeof(T) ||
++        descriptor.offset() % 8 != 0) {
++      return {};
++    }
++
++    return AdoptFragmentRef<T>(GetFragment(descriptor));
++  }
++
+   // Adds a new buffer to the underlying BufferPool to use as additional
+   // allocation capacity for blocks of size `block_size`. Note that the
+   // contents of the mapped region must already be initialized as a
+diff --git a/third_party/ipcz/src/ipcz/node_link_memory_test.cc b/third_party/ipcz/src/ipcz/node_link_memory_test.cc
+index bcdd45e..fd51b78 100644
+--- a/third_party/ipcz/src/ipcz/node_link_memory_test.cc
++++ b/third_party/ipcz/src/ipcz/node_link_memory_test.cc
+@@ -306,5 +306,54 @@
+   node_c->Close();
+ }
+ 
++struct TestObject : public RefCountedFragment {
++ public:
++  int x;
++  int y;
++};
++
++TEST_F(NodeLinkMemoryTest, AdoptFragmentRefIfValid) {
++  auto object = memory_a().AdoptFragmentRef<TestObject>(
++      memory_a().AllocateFragment(sizeof(TestObject)));
++  object->x = 5;
++  object->y = 42;
++
++  const FragmentDescriptor valid_descriptor(object.fragment().buffer_id(),
++                                            object.fragment().offset(),
++                                            sizeof(TestObject));
++
++  const FragmentDescriptor null_descriptor(
++      kInvalidBufferId, valid_descriptor.offset(), valid_descriptor.size());
++  EXPECT_TRUE(memory_a()
++                  .AdoptFragmentRefIfValid<TestObject>(null_descriptor)
++                  .is_null());
++
++  const FragmentDescriptor empty_descriptor(
++      valid_descriptor.buffer_id(), valid_descriptor.offset(), /*size=*/0);
++  EXPECT_TRUE(memory_a()
++                  .AdoptFragmentRefIfValid<TestObject>(empty_descriptor)
++                  .is_null());
++
++  const FragmentDescriptor short_descriptor(valid_descriptor.buffer_id(),
++                                            valid_descriptor.offset(),
++                                            sizeof(TestObject) - 4);
++  EXPECT_TRUE(memory_a()
++                  .AdoptFragmentRefIfValid<TestObject>(short_descriptor)
++                  .is_null());
++
++  const FragmentDescriptor unaligned_descriptor(valid_descriptor.buffer_id(),
++                                                valid_descriptor.offset() + 2,
++                                                valid_descriptor.size() - 2);
++  EXPECT_TRUE(memory_a()
++                  .AdoptFragmentRefIfValid<TestObject>(unaligned_descriptor)
++                  .is_null());
++
++  const auto adopted_object =
++      memory_a().AdoptFragmentRefIfValid<TestObject>(valid_descriptor);
++  ASSERT_TRUE(adopted_object.is_addressable());
++  EXPECT_EQ(5, adopted_object->x);
++  EXPECT_EQ(42, adopted_object->y);
++}
++
+ }  // namespace
+ }  // namespace ipcz
+diff --git a/third_party/ipcz/src/ipcz/router.cc b/third_party/ipcz/src/ipcz/router.cc
+index 820fafe..a2c65331 100644
+--- a/third_party/ipcz/src/ipcz/router.cc
++++ b/third_party/ipcz/src/ipcz/router.cc
+@@ -745,12 +745,16 @@
+               ? descriptor.decaying_incoming_sequence_length
+               : descriptor.next_incoming_sequence_number);
+ 
++      auto link_state =
++          from_node_link.memory().AdoptFragmentRefIfValid<RouterLinkState>(
++              descriptor.new_link_state_fragment);
++      if (link_state.is_null()) {
++        // Central links require a valid link state fragment.
++        return nullptr;
++      }
+       new_outward_link = from_node_link.AddRemoteRouterLink(
+-          descriptor.new_sublink,
+-          from_node_link.memory().AdoptFragmentRef<RouterLinkState>(
+-              from_node_link.memory().GetFragment(
+-                  descriptor.new_link_state_fragment)),
+-          LinkType::kCentral, LinkSide::kB, router);
++          descriptor.new_sublink, std::move(link_state), LinkType::kCentral,
++          LinkSide::kB, router);
+       if (!new_outward_link) {
+         return nullptr;
+       }

--- a/patches/chromium/cherry-pick-c333ed995449.patch
+++ b/patches/chromium/cherry-pick-c333ed995449.patch
@@ -1,7 +1,7 @@
-From c333ed99544992f66e6e03621fa938d75ad01f70 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ken Rockot <rockot@google.com>
 Date: Mon, 23 Sep 2024 19:26:24 +0000
-Subject: [PATCH] ipcz: Validate link state fragment before adoption
+Subject: ipcz: Validate link state fragment before adoption
 
 Fixed: 368208152
 Change-Id: I0e2ece4b0857b225d229134b2e55abc3e08348ee
@@ -9,13 +9,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5876623
 Commit-Queue: Ken Rockot <rockot@google.com>
 Reviewed-by: Daniel Cheng <dcheng@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#1358968}
----
 
 diff --git a/third_party/ipcz/src/ipcz/node_link.cc b/third_party/ipcz/src/ipcz/node_link.cc
-index e862cf40..dde90c9 100644
+index 8c378b1ad4d6b06b4d4e80fc99483edea043dde9..ed8d13fe801baed07d50e7458f55e5c0c2e18ccb 100644
 --- a/third_party/ipcz/src/ipcz/node_link.cc
 +++ b/third_party/ipcz/src/ipcz/node_link.cc
-@@ -36,21 +36,6 @@
+@@ -37,21 +37,6 @@
  
  namespace ipcz {
  
@@ -37,33 +36,33 @@ index e862cf40..dde90c9 100644
  // static
  Ref<NodeLink> NodeLink::CreateActive(Ref<Node> node,
                                       LinkSide link_side,
-@@ -714,8 +699,8 @@
+@@ -703,8 +688,8 @@ bool NodeLink::OnAcceptBypassLink(msg::AcceptBypassLink& accept) {
      return true;
    }
  
 -  auto link_state = MaybeAdoptFragmentRef<RouterLinkState>(
--      memory(), accept.v0()->new_link_state_fragment);
+-      memory(), accept.params().new_link_state_fragment);
 +  auto link_state = memory().AdoptFragmentRefIfValid<RouterLinkState>(
-+      accept.v0()->new_link_state_fragment);
++      accept.params().new_link_state_fragment);
    if (link_state.is_null()) {
      // Bypass links must always come with a valid fragment for their
      // RouterLinkState. If one has not been provided, that's a validation
-@@ -753,8 +738,8 @@
+@@ -746,8 +731,8 @@ bool NodeLink::OnBypassPeerWithLink(msg::BypassPeerWithLink& bypass) {
      return true;
    }
  
 -  auto link_state = MaybeAdoptFragmentRef<RouterLinkState>(
--      memory(), bypass.v0()->new_link_state_fragment);
+-      memory(), bypass.params().new_link_state_fragment);
 +  auto link_state = memory().AdoptFragmentRefIfValid<RouterLinkState>(
-+      bypass.v0()->new_link_state_fragment);
++      bypass.params().new_link_state_fragment);
    if (link_state.is_null()) {
      return false;
    }
 diff --git a/third_party/ipcz/src/ipcz/node_link_memory.h b/third_party/ipcz/src/ipcz/node_link_memory.h
-index c5e3d64..f457757 100644
+index df8010b595fdecea8959d2277da22ec734728e43..ba04a7c03da0d7f0bb5424b858a1bea7801ab9b4 100644
 --- a/third_party/ipcz/src/ipcz/node_link_memory.h
 +++ b/third_party/ipcz/src/ipcz/node_link_memory.h
-@@ -98,14 +98,29 @@
+@@ -86,14 +86,29 @@ class NodeLinkMemory : public RefCounted<NodeLinkMemory> {
    // with the same BufferId and dimensions as `descriptor`.
    Fragment GetFragment(const FragmentDescriptor& descriptor);
  
@@ -96,10 +95,10 @@ index c5e3d64..f457757 100644
    // allocation capacity for blocks of size `block_size`. Note that the
    // contents of the mapped region must already be initialized as a
 diff --git a/third_party/ipcz/src/ipcz/node_link_memory_test.cc b/third_party/ipcz/src/ipcz/node_link_memory_test.cc
-index bcdd45e..fd51b78 100644
+index 8a515c1fa5bf2b49067f8538a3e7d08a0d859a4b..2f8cdd38d4f9a3cfbcb9570104748e9887647463 100644
 --- a/third_party/ipcz/src/ipcz/node_link_memory_test.cc
 +++ b/third_party/ipcz/src/ipcz/node_link_memory_test.cc
-@@ -306,5 +306,54 @@
+@@ -303,5 +303,54 @@ TEST_F(NodeLinkMemoryTest, ParcelDataAllocation) {
    node_c->Close();
  }
  
@@ -155,10 +154,10 @@ index bcdd45e..fd51b78 100644
  }  // namespace
  }  // namespace ipcz
 diff --git a/third_party/ipcz/src/ipcz/router.cc b/third_party/ipcz/src/ipcz/router.cc
-index 820fafe..a2c65331 100644
+index 79c443d942c6613ea8a52990b93c1811e2d3d166..b1dc593427ecae67b6758edd82257f88daefcde1 100644
 --- a/third_party/ipcz/src/ipcz/router.cc
 +++ b/third_party/ipcz/src/ipcz/router.cc
-@@ -745,12 +745,16 @@
+@@ -765,12 +765,16 @@ Ref<Router> Router::Deserialize(const RouterDescriptor& descriptor,
                ? descriptor.decaying_incoming_sequence_length
                : descriptor.next_incoming_sequence_number);
  
@@ -170,12 +169,12 @@ index 820fafe..a2c65331 100644
 +        return nullptr;
 +      }
        new_outward_link = from_node_link.AddRemoteRouterLink(
--          descriptor.new_sublink,
+-          context, descriptor.new_sublink,
 -          from_node_link.memory().AdoptFragmentRef<RouterLinkState>(
 -              from_node_link.memory().GetFragment(
 -                  descriptor.new_link_state_fragment)),
 -          LinkType::kCentral, LinkSide::kB, router);
-+          descriptor.new_sublink, std::move(link_state), LinkType::kCentral,
++          context, descriptor.new_sublink, std::move(link_state), LinkType::kCentral,
 +          LinkSide::kB, router);
        if (!new_outward_link) {
          return nullptr;

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -11,3 +11,4 @@ cherry-pick-bc545b15a0ee.patch
 spill_all_loop_inputs_before_entering_loop.patch
 cherry-pick-9542895cdd3d.patch
 cherry-pick-81155a8f3b20.patch
+cherry-pick-a7766feb0a90.patch

--- a/patches/v8/cherry-pick-a7766feb0a90.patch
+++ b/patches/v8/cherry-pick-a7766feb0a90.patch
@@ -1,0 +1,44 @@
+From a7766feb0a9062a4bb75431fa4dcff4062af1442 Mon Sep 17 00:00:00 2001
+From: Igor Sheludko <ishell@chromium.org>
+Date: Tue, 24 Sep 2024 18:20:18 +0000
+Subject: [PATCH] Revert "[maps] Re-enable side-step transitions"
+
+This reverts commit 62605e134c758be5148d8d7b2541122835006155.
+
+Reason for revert: https://crbug.com/369374536
+
+Original change's description:
+> [maps] Re-enable side-step transitions
+>
+> Bug: 40764103
+> Change-Id: Ie380d54e00a38cf8e8937990af321bc7e498d686
+> Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5667163
+> Auto-Submit: Olivier Flückiger <olivf@chromium.org>
+> Commit-Queue: Olivier Flückiger <olivf@chromium.org>
+> Reviewed-by: Igor Sheludko <ishell@chromium.org>
+> Commit-Queue: Igor Sheludko <ishell@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#94738}
+
+Bug: 40764103
+Fixed: 369374536
+Change-Id: I94ed458ab17c9474b9d684a8b8c4414f4480e728
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5886972
+Commit-Queue: Clemens Backes <clemensb@chromium.org>
+Reviewed-by: Clemens Backes <clemensb@chromium.org>
+Commit-Queue: Igor Sheludko <ishell@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#96265}
+---
+
+diff --git a/src/flags/flag-definitions.h b/src/flags/flag-definitions.h
+index 25c8d41..dfdf5ed 100644
+--- a/src/flags/flag-definitions.h
++++ b/src/flags/flag-definitions.h
+@@ -2514,7 +2514,7 @@
+ DEFINE_INT(max_valid_polymorphic_map_count, 4,
+            "maximum number of valid maps to track in POLYMORPHIC state")
+ DEFINE_BOOL(
+-    clone_object_sidestep_transitions, true,
++    clone_object_sidestep_transitions, false,
+     "support sidestep transitions for dependency tracking object clone maps")
+ DEFINE_WEAK_IMPLICATION(future, clone_object_sidestep_transitions)
+ 

--- a/patches/v8/cherry-pick-a7766feb0a90.patch
+++ b/patches/v8/cherry-pick-a7766feb0a90.patch
@@ -1,7 +1,10 @@
-From a7766feb0a9062a4bb75431fa4dcff4062af1442 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Igor Sheludko <ishell@chromium.org>
 Date: Tue, 24 Sep 2024 18:20:18 +0000
-Subject: [PATCH] Revert "[maps] Re-enable side-step transitions"
+Subject: Revert "[maps] Re-enable side-step transitions"
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 This reverts commit 62605e134c758be5148d8d7b2541122835006155.
 
@@ -27,18 +30,19 @@ Commit-Queue: Clemens Backes <clemensb@chromium.org>
 Reviewed-by: Clemens Backes <clemensb@chromium.org>
 Commit-Queue: Igor Sheludko <ishell@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#96265}
----
 
 diff --git a/src/flags/flag-definitions.h b/src/flags/flag-definitions.h
-index 25c8d41..dfdf5ed 100644
+index 470c596abed95bc3e391c890d2caedd2b1d33036..2e6af9dda620542e369aa89f91b48dbc7af4a986 100644
 --- a/src/flags/flag-definitions.h
 +++ b/src/flags/flag-definitions.h
-@@ -2514,7 +2514,7 @@
+@@ -2285,6 +2285,10 @@ DEFINE_BOOL_READONLY(fast_map_update, false,
+                      "enable fast map update by caching the migration target")
  DEFINE_INT(max_valid_polymorphic_map_count, 4,
             "maximum number of valid maps to track in POLYMORPHIC state")
- DEFINE_BOOL(
--    clone_object_sidestep_transitions, true,
++DEFINE_BOOL(
 +    clone_object_sidestep_transitions, false,
-     "support sidestep transitions for dependency tracking object clone maps")
- DEFINE_WEAK_IMPLICATION(future, clone_object_sidestep_transitions)
++    "support sidestep transitions for dependency tracking object clone maps")
++DEFINE_WEAK_IMPLICATION(future, clone_object_sidestep_transitions)
  
+ // map-inl.h
+ DEFINE_INT(fast_properties_soft_limit, 12,


### PR DESCRIPTION
<details>
<summary>electron/security#589 - 56be91796b85 from chromium</summary>
RubyLB: Fix a crash with a parent with a non-default text-align

Update the LineInfo::GetTextAlign() logic so that it align with
ApplyRubyAlign() behavior.

This CL also removes stale comments.

Bug: 367764861
Change-Id: Idfe0f3c2f77c7a33ff9317c2b0f36ffa397405d1
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5874482
Commit-Queue: Koji Ishii <kojii@chromium.org>
Reviewed-by: Koji Ishii <kojii@chromium.org>
Auto-Submit: Kent Tamura <tkent@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1357460}
</details>

<details>
<summary>electron/security#588 - c333ed995449 from chromium</summary>
ipcz: Validate link state fragment before adoption

Fixed: 368208152
Change-Id: I0e2ece4b0857b225d229134b2e55abc3e08348ee
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5876623
Commit-Queue: Ken Rockot <rockot@google.com>
Reviewed-by: Daniel Cheng <dcheng@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1358968}
</details>

<details>
<summary>electron/security#587 - a7766feb0a90 from v8</summary>
Revert "[maps] Re-enable side-step transitions"

This reverts commit 62605e134c758be5148d8d7b2541122835006155.

Reason for revert: https://crbug.com/369374536

Original change's description:
> [maps] Re-enable side-step transitions
>
> Bug: 40764103
> Change-Id: Ie380d54e00a38cf8e8937990af321bc7e498d686
> Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5667163
> Auto-Submit: Olivier Flückiger <olivf@chromium.org>
> Commit-Queue: Olivier Flückiger <olivf@chromium.org>
> Reviewed-by: Igor Sheludko <ishell@chromium.org>
> Commit-Queue: Igor Sheludko <ishell@chromium.org>
> Cr-Commit-Position: refs/heads/main@{#94738}

Bug: 40764103
Fixed: 369374536
Change-Id: I94ed458ab17c9474b9d684a8b8c4414f4480e728
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5886972
Commit-Queue: Clemens Backes <clemensb@chromium.org>
Reviewed-by: Clemens Backes <clemensb@chromium.org>
Commit-Queue: Igor Sheludko <ishell@chromium.org>
Cr-Commit-Position: refs/heads/main@{#96265}
</details>

Notes:
* Security: backported fix for CVE-2024-7025.
* Security: backported fix for CVE-2024-9369.
* Security: backported fix for 369374536.