### PR TITLE
ci: use env variable in branch created workflow

### DIFF
--- a/.github/workflows/branch-created.yml
+++ b/.github/workflows/branch-created.yml
@@ -23,11 +23,13 @@ jobs:
     steps:
       - name: Determine Major Version
         id: check-major-version
+        env:
+          BRANCH_NAME: ${{ github.event.inputs.branch-name || github.event.ref }}
         run: |
-          if [[ ${{ github.event.inputs.branch-name || github.event.ref }} =~ ^([0-9]+)-x-y$ ]]; then
+          if [[ "$BRANCH_NAME" =~ ^([0-9]+)-x-y$ ]]; then
             echo "MAJOR=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
           else
-            echo "Not a release branch: ${{ github.event.inputs.branch-name || github.event.ref }}"
+            echo "Not a release branch: $BRANCH_NAME"
           fi
       - name: New Release Branch Tasks
         if: ${{ steps.check-major-version.outputs.MAJOR }}


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Better to put the usage of `${{ ... }}` in an env variable so it's properly stringified if the `workflow_dispatch` input is improperly formed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
