### PR TITLE
fix: Linux crash after `webContents.print()` with no parent window

### DIFF
--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -926,3 +926,23 @@ index 1e15568ad872c01c7c588ced81897f8dc229247a..ca528863a2dab2f437bbe95b343ccd33
  namespace sandbox::policy {
  
  base::FilePath GetCanonicalPath(const base::FilePath& path) {
+diff --git a/ui/gtk/gtk_util.cc b/ui/gtk/gtk_util.cc
+index d86fbcf969f2fa0d176ead903703ab612e5464c2..6b963ea8401d20e655d068a69105586814bab320 100644
+--- a/ui/gtk/gtk_util.cc
++++ b/ui/gtk/gtk_util.cc
+@@ -227,9 +227,13 @@ aura::Window* GetAuraTransientParent(GtkWidget* dialog) {
+ }
+ 
+ void ClearAuraTransientParent(GtkWidget* dialog, aura::Window* parent) {
++  if (!parent || !parent->GetHost()) {
++    return;
++  }
++
+   g_object_set_data(G_OBJECT(dialog), kAuraTransientParent, nullptr);
+-  GtkUi::GetPlatform()->ClearTransientFor(
+-      parent->GetHost()->GetAcceleratedWidget());
++  gfx::AcceleratedWidget parent_id = parent->GetHost()->GetAcceleratedWidget();
++  GtkUi::GetPlatform()->ClearTransientFor(parent_id);
+ }
+ 
+ base::OnceClosure DisableHostInputHandling(GtkWidget* dialog,


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/44096.

Fixes an issue where closing a window after printing on Linux triggered a crash. This happened as a result of `gtk::ClearAuraTransientParent()` assuming the `aura:Window` has a root window when in some cases it might not. I've upstreamed this at CL:5933946.

<details><summary>Details</summary>
<p>

```
Received signal 11 SEGV_MAPERR 000000000000
#0 0x649ce6dd0922
base::debug::CollectStackTrace() [../../base/debug/stack_trace_posix.cc:1044:7]
#1 0x649ce6db966a
base::debug::StackTrace::StackTrace() [../../base/debug/stack_trace.cc:245:20]
#2 0x649ce6dd0331
base::debug::(anonymous namespace)::StackDumpSignalHandler() [../../base/debug/stack_trace_posix.cc:463:3]
#3 0x7895a7e45320 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4531f)
#4 0x649cecbfdb45
gtk::ClearAuraTransientParent() [../../ui/gtk/gtk_util.cc:232:15]
#5 0x649cecc08b9c
PrintDialogGtk::OnWindowDestroying() [../../ui/gtk/printing/print_dialog_gtk.cc:665:3]
#6 0x649ce91db7f3
aura::Window::~Window() [../../ui/aura/window.cc:202:14]
#7 0x649ce91dc5ae
aura::Window::~Window() [../../ui/aura/window.cc:191:19]
#8 0x649ce584ad23
content::WebContentsViewAura::~WebContentsViewAura() [../../third_party/libc++/src/include/__memory/unique_ptr.h:68:5]
#9 0x649ce584af3e
content::WebContentsViewAura::~WebContentsViewAura() [../../content/browser/web_contents/web_contents_view_aura.cc:677:45]
#10 0x649ce5801944
content::WebContentsImpl::~WebContentsImpl()
[../../third_party/libc++/src/include/__memory/unique_ptr.h:68:5]
#11 0x649ce580250e
content::WebContentsImpl::~WebContentsImpl()
[../../content/browser/web_contents/web_contents_impl.cc:1246:37]
#12 0x649ce100483f
electron::InspectableWebContents::~InspectableWebContents()
[../../third_party/libc++/src/include/__memory/unique_ptr.h:68:5]
#13 0x649ce10049de electron::InspectableWebContents::~InspectableWebContents()
[../../electron/shell/browser/ui/inspectable_web_contents.cc:346:51]
#14 0x649ce0f228e8 electron::api::WebContents::~WebContents()
[../../third_party/libc++/src/include/__memory/unique_ptr.h:68:5]
#15 0x649ce0f231a0
electron::api::WebContents::DeleteThisIfAlive()
[../../electron/shell/browser/api/electron_api_web_contents.cc:1042:3]
#16 0x649ce0e8f16b base::internal::Invoker<>::Run()
[../../base/functional/bind_internal.h:738:12]
#17 0x649ce0e56120 base::OnceCallback<>::Run()
[../../base/functional/callback.h:156:12]
#18 0x649ce6d2ca1d
base::TaskAnnotator::RunTaskImpl() [../../base/task/common/task_annotator.cc:203:34]
#19 0x649ce6d63de1
base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl()
[../../base/task/common/task_annotator.h:90:5]
#20 0x649ce6d632b4
base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() [../../base/task/sequence_manager/thread_controller_with_message_pump_impl.cc:346:40]
#21 0x649ce6d647d5
base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()
#22 0x649ce6deb849
base::MessagePumpGlib::Run() [../../base/message_loop/message_pump_glib.cc:694:48]
#23 0x649ce6d6511f
base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run() [../../base/task/sequence_manager/thread_controller_with_message_pump_impl.cc:654:12]
#24 0x649ce6d08d72
base::RunLoop::Run() [../../base/run_loop.cc:134:14]
#25 0x649ce4f18377
content::BrowserMainLoop::RunMainMessageLoop()
[../../content/browser/browser_main_loop.cc:1100:18]
#26 0x649ce4f1a895
content::BrowserMainRunnerImpl::Run() [../../content/browser/browser_main_runner_impl.cc:156:15]
#27 0x649ce4f141b8
content::BrowserMain() [../../content/browser/browser_main.cc:34:28]
#28 0x649ce12ab928
content::RunBrowserProcessMain()
[../../content/app/content_main_runner_impl.cc:735:10]
#29 0x649ce12ae5b2
content::ContentMainRunnerImpl::RunBrowser() [../../content/app/content_main_runner_impl.cc:1309:10]
#30 0x649ce12adc27
content::ContentMainRunnerImpl::Run()
[../../content/app/content_main_runner_impl.cc:1161:12]
#31 0x649ce12aa282
content::RunContentProcess()
[../../content/app/content_main.cc:329:36]
#32 0x649ce12aa5b0
content::ContentMain()
[../../content/app/content_main.cc:342:10]
#33 0x649ce0e4e629 main
[../../electron/shell/app/electron_main_linux.cc:43:10]
#34 0x7895a7e2a1ca
(/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9)
#35 0x7895a7e2a28b __libc_start_main
#36 0x649ce0e3402a
_start
  r8: 0000000000000000  r9: 00000000000003aa r10: 0000000000000000 r11: 0000000000000293
 r12: 00007ffde2c890a0 r13: 00007ffde2c89208 r14: 0000346c007fba80 r15: 00007ffde2c89090
  di: 0000346c015e0bc0  si: 0000000000000002  bp: 00007ffde2c89080  bx: 0000346c015e0bc0
  dx: 000000000000000a  ax: 0000000000000000  cx: 9a2cd7949d7d1d00  sp: 00007ffde2c89070
  ip: 0000649cecbfdb45 efl: 0000000000010246 cgf: 002b000000000033 erf: 0000000000000004
 trp: 000000000000000e msk: 0000000000000000 cr2: 0000000000000000
[end of stack trace]
```

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where closing a window after printing on Linux triggered a crash.
