### PR TITLE
chore: fixup reclient read only access on forks

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -6,6 +6,6 @@ runs:
   - name: Install Build Tools
     shell: bash
     run: |
-      export BUILD_TOOLS_SHA=33dc5186556bfbf7b0121a00cdd89ed3802e47da
+      export BUILD_TOOLS_SHA=eeb1a11392e4cec08fd926c93b31ab556dc0c23b
       npm i -g @electron/build-tools
       e auto-update disable

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -164,7 +164,7 @@ jobs:
       uses: ./src/electron/.github/actions/install-build-tools
     - name: Init Build Tools
       run: |
-        e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }} --import ${{ inputs.gn-build-type }} --target-cpu ${{ inputs.target-arch }} --only-sdk
+        e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }} --import ${{ inputs.gn-build-type }} --target-cpu ${{ inputs.target-arch }}
     - name: Run Electron Only Hooks
       run: |
         gclient runhooks --spec="solutions=[{'name':'src/electron','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':False},'managed':False}]"
@@ -177,18 +177,9 @@ jobs:
     - name: Fix Sync (macOS)
       if: ${{ inputs.target-platform == 'macos' }}
       uses: ./src/electron/.github/actions/fix-sync-macos
-    - name: Install build-tools & Setup RBE
+    - name: Setup Number of Ninja Processes
       run: |
         echo "NUMBER_OF_NINJA_PROCESSES=${{ inputs.target-platform == 'linux' && '300' || '200' }}" >> $GITHUB_ENV
-        cd ~/.electron_build_tools
-        npx yarn --ignore-engines
-        # Pull down credential helper and print status
-        node -e "require('./src/utils/reclient.js').downloadAndPrepare({})"
-        HELPER=$(node -p "require('./src/utils/reclient.js').helperPath({})")
-        $HELPER login
-        echo 'RBE_service='`node -e "console.log(require('./src/utils/reclient.js').serviceAddress)"` >> $GITHUB_ENV
-        echo 'RBE_credentials_helper='`node -e "console.log(require('./src/utils/reclient.js').helperPath({}))"` >> $GITHUB_ENV
-        echo 'RBE_credentials_helper_args=print' >> $GITHUB_ENV
     - name: Free up space (macOS)
       if: ${{ inputs.target-platform == 'macos' }}
       uses: ./src/electron/.github/actions/free-space-macos

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -75,7 +75,7 @@ jobs:
       uses: ./src/electron/.github/actions/install-build-tools
     - name: Init Build Tools
       run: |
-        e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }} --import ${{ inputs.gn-build-type }} --target-cpu ${{ inputs.target-arch }} --only-sdk
+        e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }} --import ${{ inputs.gn-build-type }} --target-cpu ${{ inputs.target-arch }}
     - name: Get Depot Tools
       timeout-minutes: 5
       run: |

--- a/appveyor-woa.yml
+++ b/appveyor-woa.yml
@@ -128,8 +128,6 @@ for:
           if ($env:ELECTRON_RBE_JWT -eq '') {
             $env:RBE_fail_early_min_action_count = "0"
             $env:RBE_fail_early_min_fallback_ratio = "0"
-            $env:RBE_exec_strategy = "local"
-            $env:RBE_remote_update_cache= "false"
           }
       - cd ..\..
       - ps: $env:CHROMIUM_BUILDTOOLS_PATH="$pwd\src\buildtools"
@@ -158,7 +156,7 @@ for:
       - gn check out/Default //electron:electron_app
       - gn check out/Default //electron/shell/common:mojo
       - gn check out/Default //electron/shell/common:plugin
-      - if DEFINED ELECTRON_RBE_JWT (autoninja -j 300 -C out/Default electron:electron_app) else (autoninja -C out/Default electron:electron_app)
+      - autoninja -j 300 -C out/Default electron:electron_app
       - if "%GN_CONFIG%"=="testing" ( python C:\depot_tools\post_build_ninja_summary.py -C out\Default )
       - gn gen out/ffmpeg "--args=import(\"//electron/build/args/ffmpeg.gn\") use_remoteexec=true %GN_EXTRA_ARGS%"
       - autoninja -C out/ffmpeg electron:electron_ffmpeg_zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -123,8 +123,6 @@ for:
           if ($env:ELECTRON_RBE_JWT -eq '') {
             $env:RBE_fail_early_min_action_count = "0"
             $env:RBE_fail_early_min_fallback_ratio = "0"
-            $env:RBE_exec_strategy = "local"
-            $env:RBE_remote_update_cache= "false"
           }
       - cd ..\..
       - ps: $env:CHROMIUM_BUILDTOOLS_PATH="$pwd\src\buildtools"
@@ -153,7 +151,7 @@ for:
       - gn check out/Default //electron:electron_app
       - gn check out/Default //electron/shell/common:mojo
       - gn check out/Default //electron/shell/common:plugin
-      - if DEFINED ELECTRON_RBE_JWT (autoninja -j 300 -C out/Default electron:electron_app) else (autoninja -C out/Default electron:electron_app)
+      - autoninja -j 300 -C out/Default electron:electron_app
       - if "%GN_CONFIG%"=="testing" ( python C:\depot_tools\post_build_ninja_summary.py -C out\Default )
       - gn gen out/ffmpeg "--args=import(\"//electron/build/args/ffmpeg.gn\") use_remoteexec=true %GN_EXTRA_ARGS%"
       - autoninja -C out/ffmpeg electron:electron_ffmpeg_zip


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Followup to https://github.com/electron/build-tools/pull/658.  This will fix an issue using reclient's read only cache on fork PRs.

Additionally, it turns out for GHA we were installing build tools twice and logging into RBE twice, so I removed the additional calls.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
