### PR TITLE
ci: use Node.js 20 in Bake AppVeyor Image workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@
 DEPS                                    @electron/wg-upgrades
 
 # Releases WG
+/.github/workflows/update_appveyor_image.yml @electron/wg-releases
 /docs/breaking-changes.md               @electron/wg-releases
 /npm/                                   @electron/wg-releases
 /script/release                         @electron/wg-releases

--- a/.github/workflows/update_appveyor_image.yml
+++ b/.github/workflows/update_appveyor_image.yml
@@ -23,6 +23,10 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ steps.generate-token.outputs.token }}
+    - name: Setup Node.js
+      uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+      with:
+        node-version: 20.11.x
     - name: Yarn install
       run: |
         node script/yarn.js install --frozen-lockfile


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

The workflow has been failing as the `ubuntu-latest` image comes with Node.js 18 and we weren't installing a specific version.

Also adds this workflow to CODEOWNERS for Releases WG since it wasn't covered before.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
