### PR TITLE
docs: Document removed macOS 10.15 support

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -14,6 +14,13 @@ This document uses the following convention to categorize breaking changes:
 
 ## Planned Breaking API Changes (33.0)
 
+### Removed: macOS 10.15 support
+
+macOS 10.15 (Catalina) is no longer supported by [Chromium](https://chromium.googlesource.com/chromium/src/+/165142f8df90e3a06b6e4780f0f69f58c9af7495).
+
+Older versions of Electron will continue to run on these operating systems, but macOS 11 (Big Sur)
+or later will be required to run Electron v33.0.0 and higher.
+
 ### Behavior Changed: frame properties may retrieve detached WebFrameMain instances or none at all
 
 APIs which provide access to a `WebFrameMain` instance may return an instance


### PR DESCRIPTION
#### Description of Change

This slipped through: Chrome 129 dropped support for macOS 10.15!

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Document dropped support for macOS 10.15.
