### PR TITLE
fix: silence -Wunsafe-buffer-usage warning in GetPreferredLanguages()

### DIFF
--- a/shell/common/language_util_linux.cc
+++ b/shell/common/language_util_linux.cc
@@ -22,7 +22,10 @@ std::vector<std::string> GetPreferredLanguages() {
   DCHECK(languages);   // A valid pointer is guaranteed.
   DCHECK(*languages);  // At least one entry, "C", is guaranteed.
 
-  for (; *languages; ++languages) {
+  // SAFETY: |g_get_language_names()| returns a glib-owned array
+  // of const C strings, terminated by an empty string.
+  // This loop is the correct way to walk through its return values.
+  for (; *languages; UNSAFE_BUFFERS(++languages)) {
     if (strcmp(*languages, "C") != 0) {
       preferredLanguages.push_back(base::i18n::GetCanonicalLocale(*languages));
     }


### PR DESCRIPTION
#### Description of Change

Part 20 in a [series](https://github.com/electron/electron/pull/43477) to fix `-Wunsafe-buffer-usage` warnings in `shell/`.  

This PR silences a warning caused by a call to `g_get_language_names()`. It's unavoidable due to that function's API, so we silence the warning by wrapping the pointer math in an `UNSAFE_MACROS()` macro add a [`// SAFETY`](https://chromium.googlesource.com/chromium/src/+/main/docs/unsafe_buffers.md#suppressions) comment  explaining what's up.

Warning silenced by this PR:

```
../../electron/shell/common/language_util_linux.cc:25:24: error: unsafe pointer arithmetic [-Werror,-Wunsafe-buffer-usage]
   25 |   for (; *languages; ++languages) {
      |                        ^~~~~~~~~
../../electron/shell/common/language_util_linux.cc:25:24: note: See //docs/unsafe_buffers.md for help.
1 error generated.
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none