### PR TITLE
fix: Fixed crash due to dangling this after reopening main window f…

### DIFF
--- a/shell/browser/ui/views/menu_bar.cc
+++ b/shell/browser/ui/views/menu_bar.cc
@@ -42,10 +42,15 @@ MenuBar::MenuBar(NativeWindow* window, RootView* root_view)
   SetLayoutManager(std::make_unique<views::BoxLayout>(
       views::BoxLayout::Orientation::kHorizontal));
   window_->AddObserver(this);
+
+  menu_delegate_ = new MenuDelegate(this);
+  menu_delegate_->AddObserver(this);
+
 }
 
 MenuBar::~MenuBar() {
   window_->RemoveObserver(this);
+  menu_delegate_->RemoveObserver(this);
 }
 
 void MenuBar::SetMenu(ElectronMenuModel* model) {
@@ -195,11 +200,9 @@ void MenuBar::ButtonPressed(size_t id, const ui::Event& event) {
   DCHECK(source);
 
   // Deleted in MenuDelegate::OnMenuClosed
-  auto* menu_delegate = new MenuDelegate(this);
-  menu_delegate->RunMenu(
+  menu_delegate_->RunMenu(
       menu_model_->GetSubmenuModelAt(id), source,
       event.IsKeyEvent() ? ui::MENU_SOURCE_KEYBOARD : ui::MENU_SOURCE_MOUSE);
-  menu_delegate->AddObserver(this);
 }
 
 void MenuBar::ViewHierarchyChanged(

--- a/shell/browser/ui/views/menu_bar.h
+++ b/shell/browser/ui/views/menu_bar.h
@@ -92,6 +92,7 @@ class MenuBar : public views::AccessiblePaneView,
   raw_ptr<NativeWindow> window_;
   raw_ptr<RootView> root_view_;
   raw_ptr<ElectronMenuModel> menu_model_ = nullptr;
+  raw_ptr<MenuDelegate> menu_delegate_ = nullptr;
   bool accelerator_installed_ = false;
 };
 

--- a/shell/browser/ui/views/menu_delegate.cc
+++ b/shell/browser/ui/views/menu_delegate.cc
@@ -105,11 +105,6 @@ void MenuDelegate::WillHideMenu(views::MenuItemView* menu) {
 void MenuDelegate::OnMenuClosed(views::MenuItemView* menu) {
   for (Observer& obs : observers_)
     obs.OnMenuClosed();
-
-  // Only switch to new menu when current menu is closed.
-  if (button_to_open_)
-    button_to_open_->Activate(nullptr);
-  delete this;
 }
 
 views::MenuItemView* MenuDelegate::GetSiblingMenu(


### PR DESCRIPTION

#### Description of Change
**Problem**

Closing and subsequently opening a window causes a crash in MenuDelegate. The issue arises because the destructor MenuBar::~MenuBar() is called before OnMenuClosed(), leading to the following sequence:

1.  MenuBar::~MenuBar() is invoked, destroying the observer pointers.
2. In OnMenuClosed(), when iterating through the observer list with for (Observer& obs : observers_), we encounter a crash due to dereferencing already destroyed pointers.

Additionally, the current implementation creates a new MenuDelegate instance each time a button is pressed, which is not optimal for memory usage.

**Proposed Fix**

To address these issues, I propose the following changes:

1.  Single Instance of MenuDelegate: Create only one instance of MenuDelegate to be reused, rather than instantiating a new one on each button press. This will help optimize memory usage.

2. Remove from Observer List in Destructor: Modify the destructor of MenuBar to properly remove the MenuDelegate from the observer list. Since we use the Chromium raw_ptr wrapper, we can safely omit the deletion of the MenuDelegate in OnMenuClosed(); it will be destroyed along with the MenuBar.

Reproduction Steps

To reproduce the crash, you can use the following code snippet:

``` 
const {
  app,
  BrowserWindow,
  Menu,
} = require('electron');

let window1;

let template = [{
  label: 'Test',
  role: 'help',
  submenu: [{
    label: 'Test',
    click: function(menuItem, browserWindow, options) {
      menuManager.handleMenuAction('openNewWindow', {
        type: 'shortcut',
        isGlobal: true
      }, options);
    }
  }]
}]

function openNewWindow() {
  const win = new BrowserWindow({
    width: 800,
    height: 600,
  })
}

const menuManager = {
  handleMenuAction: function(action, meta, options) {

    if (action === 'openNewWindow') {
      window1.destroy();
      openNewWindow();
    }
  },
};

function createWindow() {
  const applicationMenu = Menu.buildFromTemplate(template);

  Menu.setApplicationMenu(applicationMenu);

  window1 = new BrowserWindow({
    width: 800,
    height: 600,
  })
}

app.whenReady().then(() => {
  createWindow()

  app.on('activate', () => {
    if (BrowserWindow.getAllWindows().length === 0) {
      createWindow()
    }
  })
})
```

**Expected Behavior**

The program should handle window closing and reopening without crashing.

**Actual Behavior**

Application crashed.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
