### PR TITLE
docs: Fix `powerMonitor` docs for type generation of `speed-limit-change`

### DIFF
--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -42,6 +42,8 @@ See https://developer.apple.com/library/archive/documentation/Performance/Concep
 
 ### Event: 'speed-limit-change' _macOS_ _Windows_
 
+Returns:
+
 * `limit` number - The operating system's advertised speed limit for CPUs, in percent.
 
 Notification of a change in the operating system's advertised speed limit for


### PR DESCRIPTION
#### Description of Change

A formatting error in the `powerMonitor` docs caused the `speed-limit-change` type definition to be incorrect. This broke for me when upgrading to Electron 33, as it seems the default listener type was changed from `Function` to `() => void`, so anyone using the `limit` parameter would get a type error.

This PR fixes the documentation formatting so that the types parse correctly.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue with the `powerMonitor` documentation that was affected typings for the `speed-limit-change` event listener.
