### PR TITLE
fix: update openUrl to openURL:configuration:completionHandler to correctly focus on external window

### DIFF
--- a/spec/api-shell-spec.ts
+++ b/spec/api-shell-spec.ts
@@ -76,6 +76,25 @@ describe('shell module', () => {
         requestReceived
       ]);
     });
+
+    it('should focus the external app when opening the URL on macOS', async () => {
+      const testUrl = 'http://127.0.0.1';
+      const mainWindow = new BrowserWindow({ show: true, webPreferences: { nodeIntegration: true, contextIsolation: false } });
+      await mainWindow.loadURL('about:blank');
+
+      mainWindow.webContents.on('will-navigate', (event, rawTarget) => {
+        event.preventDefault();
+        shell.openExternal(rawTarget);
+      });
+
+      if (process.platform === 'darwin') {
+        const blurPromise = once(mainWindow, 'blur');
+        expect(mainWindow.isFocused()).to.be.true();
+        await mainWindow.webContents.executeJavaScript(`window.location.href = '${testUrl}'`);
+        await blurPromise;
+        expect(mainWindow.isFocused()).to.be.false();
+      }
+    });
   });
 
   describe('shell.trashItem()', () => {


### PR DESCRIPTION
#### Description of Change
This PR fixes bug identified in Slack where Electron 33 doesn't focus the browser window when opening links when using shell.openExternal

https://electronhq.slack.com/archives/CB6CG54DB/p1729185377925139
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix external window focus when using shell.openExternal