### PR TITLE
fix: prevent log files being written to current directory on Windows

### DIFF
--- a/shell/common/api/electron_api_testing.cc
+++ b/shell/common/api/electron_api_testing.cc
@@ -2,8 +2,10 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include "base/command_line.h"
 #include "base/dcheck_is_on.h"
 #include "base/logging.h"
+#include "content/public/common/content_switches.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
 #include "v8/include/v8.h"
@@ -34,12 +36,18 @@ void Log(int severity, std::string text) {
   }
 }
 
+std::string GetLoggingDestination() {
+  auto* command_line = base::CommandLine::ForCurrentProcess();
+  return command_line->GetSwitchValueASCII(switches::kEnableLogging);
+}
+
 void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context,
                 void* priv) {
   gin_helper::Dictionary dict(context->GetIsolate(), exports);
   dict.SetMethod("log", &Log);
+  dict.SetMethod("getLoggingDestination", &GetLoggingDestination);
 }
 
 }  // namespace

--- a/shell/common/api/electron_api_testing.cc
+++ b/shell/common/api/electron_api_testing.cc
@@ -37,7 +37,7 @@ void Log(int severity, std::string text) {
 }
 
 std::string GetLoggingDestination() {
-  auto* command_line = base::CommandLine::ForCurrentProcess();
+  const auto* command_line = base::CommandLine::ForCurrentProcess();
   return command_line->GetSwitchValueASCII(switches::kEnableLogging);
 }
 

--- a/shell/common/logging.cc
+++ b/shell/common/logging.cc
@@ -20,7 +20,7 @@
 #if BUILDFLAG(IS_WIN)
 #include <windows.h>
 #include "base/win/scoped_handle.h"
-#include "base/win/win_util.h"
+#include "base/win/windows_handle_util.h"
 #include "sandbox/policy/switches.h"
 #endif
 

--- a/shell/common/logging.cc
+++ b/shell/common/logging.cc
@@ -17,10 +17,40 @@
 #include "chrome/common/chrome_paths.h"
 #include "content/public/common/content_switches.h"
 
+#if BUILDFLAG(IS_WIN)
+#include <windows.h>
+#include "base/win/scoped_handle.h"
+#include "base/win/win_util.h"
+#include "sandbox/policy/switches.h"
+#endif
+
 namespace logging {
 
 constexpr std::string_view kLogFileName{"ELECTRON_LOG_FILE"};
 constexpr std::string_view kElectronEnableLogging{"ELECTRON_ENABLE_LOGGING"};
+
+#if BUILDFLAG(IS_WIN)
+base::win::ScopedHandle GetLogInheritedHandle(
+    const base::CommandLine& command_line) {
+  auto handle_str = command_line.GetSwitchValueNative(::switches::kLogFile);
+  uint32_t handle_value = 0;
+  if (!base::StringToUint(handle_str, &handle_value)) {
+    return base::win::ScopedHandle();
+  }
+  // Duplicate the handle from the command line so that different things can
+  // init logging. This means the handle from the parent is never closed, but
+  // there will only be one of these in the process.
+  HANDLE log_handle = nullptr;
+  if (!::DuplicateHandle(::GetCurrentProcess(),
+                         base::win::Uint32ToHandle(handle_value),
+                         ::GetCurrentProcess(), &log_handle, 0,
+                         /*bInheritHandle=*/FALSE, DUPLICATE_SAME_ACCESS)) {
+    return base::win::ScopedHandle();
+  }
+  // Transfer ownership to the caller.
+  return base::win::ScopedHandle(log_handle);
+}
+#endif
 
 base::FilePath GetLogFileName(const base::CommandLine& command_line) {
   std::string filename = command_line.GetSwitchValueASCII(switches::kLogFile);
@@ -49,7 +79,10 @@ bool HasExplicitLogFile(const base::CommandLine& command_line) {
 
 LoggingDestination DetermineLoggingDestination(
     const base::CommandLine& command_line,
-    bool is_preinit) {
+    bool is_preinit,
+    bool& filename_is_handle) {
+  filename_is_handle = false;
+
   bool enable_logging = false;
   std::string logging_destination;
   if (command_line.HasSwitch(::switches::kEnableLogging)) {
@@ -72,6 +105,17 @@ LoggingDestination DetermineLoggingDestination(
           base::Environment::Create()->GetVar("ELECTRON_ALSO_LOG_TO_STDERR"))
     also_log_to_stderr = !also_log_to_stderr_str->empty();
 #endif
+
+#if BUILDFLAG(IS_WIN)
+  if (logging_destination == "handle" &&
+      command_line.HasSwitch(::switches::kProcessType) &&
+      command_line.HasSwitch(::switches::kLogFile)) {
+    // Child processes can log to a handle duplicated from the parent, and
+    // provided in the log-file switch value.
+    filename_is_handle = true;
+    return LOG_TO_FILE | (also_log_to_stderr ? LOG_TO_STDERR : 0);
+  }
+#endif  // BUILDFLAG(IS_WIN)
 
   // --enable-logging logs to stderr, --enable-logging=file logs to a file.
   // NB. this differs from Chromium, in which --enable-logging logs to a file
@@ -98,10 +142,14 @@ void InitElectronLogging(const base::CommandLine& command_line,
                          bool is_preinit) {
   const std::string process_type =
       command_line.GetSwitchValueASCII(::switches::kProcessType);
+  bool filename_is_handle = false;
   LoggingDestination logging_dest =
-      DetermineLoggingDestination(command_line, is_preinit);
+      DetermineLoggingDestination(command_line, is_preinit, filename_is_handle);
   LogLockingState log_locking_state = LOCK_LOG_FILE;
   base::FilePath log_path;
+#if BUILDFLAG(IS_WIN)
+  base::win::ScopedHandle log_handle;
+#endif
 
   if (command_line.HasSwitch(::switches::kLoggingLevel) &&
       GetMinLogLevel() >= 0) {
@@ -119,7 +167,19 @@ void InitElectronLogging(const base::CommandLine& command_line,
   // Don't resolve the log path unless we need to. Otherwise we leave an open
   // ALPC handle after sandbox lockdown on Windows.
   if ((logging_dest & LOG_TO_FILE) != 0) {
-    log_path = GetLogFileName(command_line);
+    if (filename_is_handle) {
+#if BUILDFLAG(IS_WIN)
+      // Child processes on Windows are provided a file handle if logging is
+      // enabled as sandboxed processes cannot open files.
+      log_handle = GetLogInheritedHandle(command_line);
+      if (!log_handle.is_valid()) {
+        DLOG(ERROR) << "Unable to initialize logging from handle.";
+        return;
+      }
+#endif
+    } else {
+      log_path = GetLogFileName(command_line);
+    }
   } else {
     log_locking_state = DONT_LOCK_LOG_FILE;
   }
@@ -131,6 +191,13 @@ void InitElectronLogging(const base::CommandLine& command_line,
   LoggingSettings settings;
   settings.logging_dest = logging_dest;
   settings.log_file_path = log_path.value().c_str();
+#if BUILDFLAG(IS_WIN)
+  // Avoid initializing with INVALID_HANDLE_VALUE.
+  // This handle is owned by the logging framework and is closed when the
+  // process exits.
+  // TODO(crbug.com/328285906) Use a ScopedHandle in logging settings.
+  settings.log_file = log_handle.is_valid() ? log_handle.release() : nullptr;
+#endif
   settings.lock_log = log_locking_state;
   // If we're logging to an explicit file passed with --log-file, we don't want
   // to delete the log file on our second initialization.

--- a/shell/common/logging.cc
+++ b/shell/common/logging.cc
@@ -113,7 +113,7 @@ LoggingDestination DetermineLoggingDestination(
     // Child processes can log to a handle duplicated from the parent, and
     // provided in the log-file switch value.
     filename_is_handle = true;
-    return LOG_TO_FILE | (also_log_to_stderr ? LOG_TO_STDERR : 0);
+    return LOG_TO_FILE;
   }
 #endif  // BUILDFLAG(IS_WIN)
 

--- a/shell/common/logging.cc
+++ b/shell/common/logging.cc
@@ -173,7 +173,7 @@ void InitElectronLogging(const base::CommandLine& command_line,
       // enabled as sandboxed processes cannot open files.
       log_handle = GetLogInheritedHandle(command_line);
       if (!log_handle.is_valid()) {
-        DLOG(ERROR) << "Unable to initialize logging from handle.";
+        LOG(ERROR) << "Unable to initialize logging from handle.";
         return;
       }
 #endif

--- a/shell/common/logging.cc
+++ b/shell/common/logging.cc
@@ -35,7 +35,7 @@ base::win::ScopedHandle GetLogInheritedHandle(
   auto handle_str = command_line.GetSwitchValueNative(::switches::kLogFile);
   uint32_t handle_value = 0;
   if (!base::StringToUint(handle_str, &handle_value)) {
-    return base::win::ScopedHandle();
+    return {};
   }
   // Duplicate the handle from the command line so that different things can
   // init logging. This means the handle from the parent is never closed, but
@@ -45,7 +45,7 @@ base::win::ScopedHandle GetLogInheritedHandle(
                          base::win::Uint32ToHandle(handle_value),
                          ::GetCurrentProcess(), &log_handle, 0,
                          /*bInheritHandle=*/FALSE, DUPLICATE_SAME_ACCESS)) {
-    return base::win::ScopedHandle();
+    return {};
   }
   // Transfer ownership to the caller.
   return base::win::ScopedHandle(log_handle);
@@ -77,12 +77,9 @@ bool HasExplicitLogFile(const base::CommandLine& command_line) {
   return !filename.empty();
 }
 
-LoggingDestination DetermineLoggingDestination(
-    const base::CommandLine& command_line,
-    bool is_preinit,
-    bool& filename_is_handle) {
-  filename_is_handle = false;
-
+std::pair<LoggingDestination, bool /* filename_is_handle */>
+DetermineLoggingDestination(const base::CommandLine& command_line,
+                            bool is_preinit) {
   bool enable_logging = false;
   std::string logging_destination;
   if (command_line.HasSwitch(::switches::kEnableLogging)) {
@@ -97,7 +94,7 @@ LoggingDestination DetermineLoggingDestination(
     }
   }
   if (!enable_logging)
-    return LOG_NONE;
+    return {LOG_NONE, false};
 
   bool also_log_to_stderr = false;
 #if !defined(NDEBUG)
@@ -112,8 +109,7 @@ LoggingDestination DetermineLoggingDestination(
       command_line.HasSwitch(::switches::kLogFile)) {
     // Child processes can log to a handle duplicated from the parent, and
     // provided in the log-file switch value.
-    filename_is_handle = true;
-    return LOG_TO_FILE;
+    return {LOG_TO_FILE, true};
   }
 #endif  // BUILDFLAG(IS_WIN)
 
@@ -132,8 +128,8 @@ LoggingDestination DetermineLoggingDestination(
   // given.
   if (HasExplicitLogFile(command_line) ||
       (logging_destination == "file" && !is_preinit))
-    return LOG_TO_FILE | (also_log_to_stderr ? LOG_TO_STDERR : 0);
-  return LOG_TO_SYSTEM_DEBUG_LOG | LOG_TO_STDERR;
+    return {LOG_TO_FILE | (also_log_to_stderr ? LOG_TO_STDERR : 0), false};
+  return {LOG_TO_SYSTEM_DEBUG_LOG | LOG_TO_STDERR, false};
 }
 
 }  // namespace
@@ -142,9 +138,8 @@ void InitElectronLogging(const base::CommandLine& command_line,
                          bool is_preinit) {
   const std::string process_type =
       command_line.GetSwitchValueASCII(::switches::kProcessType);
-  bool filename_is_handle = false;
-  LoggingDestination logging_dest =
-      DetermineLoggingDestination(command_line, is_preinit, filename_is_handle);
+  auto [logging_dest, filename_is_handle] =
+      DetermineLoggingDestination(command_line, is_preinit);
   LogLockingState log_locking_state = LOCK_LOG_FILE;
   base::FilePath log_path;
 #if BUILDFLAG(IS_WIN)

--- a/spec/fixtures/log-test.js
+++ b/spec/fixtures/log-test.js
@@ -1,0 +1,3 @@
+const binding = process._linkedBinding('electron_common_testing');
+binding.log(1, 'CHILD_PROCESS_TEST_LOG');
+binding.log(1, `CHILD_PROCESS_DESTINATION_${binding.getLoggingDestination()}`);


### PR DESCRIPTION
#### Description of Change

* regression was introduced in https://github.com/chromium/chromium/commit/9d2b795f72832aa7216d7c84bdbf5d2358346548
* it appears that Electron is involved in the processing of the command line for Chromium child processes but doesn't handle the new "handle" option value
* this fix duplicates the new logic in `logging_chrome.cc` introduced in the patch that caused the regression
  * that file appears to be where Electron's `logging.cc` was originally copied from based on a bunch of similarities in the code of the two files
* verified this does not write log files to the CWD with the fix

Fixes https://github.com/electron/electron/issues/46836
Fixes https://github.com/electron/electron/issues/43508

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: fix log files written to the current working directory on Windows
