### PR TITLE
fix: keep gdk_pixbuf a dynamic dependency

### DIFF
--- a/shell/browser/ui/electron_gdk_pixbuf.sigs
+++ b/shell/browser/ui/electron_gdk_pixbuf.sigs
@@ -1,3 +1,4 @@
-GdkPixbuf* gdk_pixbuf_new(GdkColorspace colorspace, gboolean has_alpha, int bits_per_sample, int width, int height)
+GdkPixbuf* gdk_pixbuf_new_from_bytes(GBytes* data, GdkColorspace colorspace, gboolean has_alpha, int bits_per_sample, int width, int height, int rowstride)
 GdkPixbuf* gdk_pixbuf_scale_simple(const GdkPixbuf* src, int dest_width, int dest_height, GdkInterpType interp_type)
-guchar* gdk_pixbuf_get_pixels(const GdkPixbuf* pixbuf)
+GdkPixbuf* gdk_pixbuf_new_from_file_at_size(const char* filename, int width, int height, GError** error);
+gint gdk_pixbuf_calculate_rowstride(GdkColorspace colorspace, gboolean has_alpha, int bits_per_sample, int width, int height)


### PR DESCRIPTION
#### Description of Change

We made gdk_pixbuf a dynamic dependency since https://github.com/electron/electron/pull/34077 to help with downstream packaging due to conflicting names of the source package in various distros. The dependency regressed recently via https://github.com/electron/electron/pull/43956 which missed adding required symbols to the stubs.

A good regression test to catch future breakages would be to run https://source.chromium.org/chromium/chromium/src/+/main:third_party/dpkg-shlibdeps/dpkg-shlibdeps.pl and ensure the dependency doesn't show up. If this sounds good I can port a version of https://github.com/microsoft/vscode/blob/a14300ec9f7d04fbbaa9f896d46626110baa2b90/build/linux/debian/calculate-deps.ts#L21-L97 in a follow-up PR

New stub declarations are taken from https://docs.gtk.org/gdk-pixbuf/

#### Release Notes

Notes: fix regression with dynamic dependency on `libgdk_pixbuf`