### PR TITLE
build: fix python util verbose mode logic

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -63,7 +63,7 @@ runs:
       run: |
         cd src
         electron/script/copy-debug-symbols.py --target-cpu="${{ inputs.target-arch }}" --out-dir=out/Default/debug --compress
-        electron/script/strip-binaries.py --target-cpu="${{ inputs.target-arch }}"
+        electron/script/strip-binaries.py --target-cpu="${{ inputs.target-arch }}" --verbose
         electron/script/add-debug-link.py --target-cpu="${{ inputs.target-arch }}" --debug-dir=out/Default/debug
     - name: Build Electron dist.zip ${{ inputs.step-suffix }}
       shell: bash

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -28,16 +28,17 @@ def get_target_arch():
     return 'x64'
   return arch
 
-
-def enable_verbose_mode():
+def set_verbose_mode(mode):
   print('Running in verbose mode')
   global verbose_mode
-  verbose_mode = True
-
+  verbose_mode = mode
 
 def is_verbose_mode():
   return verbose_mode
 
+def verbose_mode_print(output):
+  if verbose_mode:
+    print(output)
 
 def get_zip_name(name, version, suffix=''):
   arch = get_target_arch()

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -11,9 +11,7 @@ import sys
 from urllib.request import urlopen
 import zipfile
 
-# from lib.config import is_verbose_mode
-def is_verbose_mode():
-  return False
+from lib.config import verbose_mode_print
 
 ELECTRON_DIR = os.path.abspath(
   os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
@@ -112,13 +110,11 @@ def safe_mkdir(path):
 def execute(argv, env=None, cwd=None):
   if env is None:
     env = os.environ
-  if is_verbose_mode():
-    print(' '.join(argv))
+  verbose_mode_print(' '.join(argv))
   try:
     output = subprocess.check_output(argv, stderr=subprocess.STDOUT,
                                      env=env, cwd=cwd)
-    if is_verbose_mode():
-      print(output)
+    verbose_mode_print(output.decode('utf-8').strip())
     return output
   except subprocess.CalledProcessError as e:
     print(e.output)

--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -16,8 +16,9 @@ sys.path.append(
 
 from zipfile import ZipFile
 from lib.config import PLATFORM, get_target_arch, \
-                       get_zip_name, enable_verbose_mode, \
-                       is_verbose_mode, get_platform_key
+                       get_zip_name, set_verbose_mode, \
+                       is_verbose_mode, get_platform_key, \
+                       verbose_mode_print
 from lib.util import get_electron_branding, execute, get_electron_version, \
                      store_artifact, get_electron_exec, get_out_dir, \
                      SRC_DIR, ELECTRON_DIR, TS_NODE
@@ -45,8 +46,7 @@ CXX_OBJECTS_NAME = get_zip_name(PROJECT_NAME, ELECTRON_VERSION,
 
 def main():
   args = parse_args()
-  if args.verbose:
-    enable_verbose_mode()
+  set_verbose_mode(args.verbose)
   if args.upload_to_storage:
     utcnow = datetime.datetime.utcnow()
     args.upload_timestamp = utcnow.strftime('%Y%m%d')
@@ -391,9 +391,8 @@ def get_release(version):
   release_env = os.environ.copy()
   release_env['NODE_NO_WARNINGS'] = '1'
   release_info = execute([TS_NODE, script_path, version], release_env)
-  if is_verbose_mode():
-    print(f'Release info for version: {version}:\n')
-    print(release_info)
+  verbose_mode_print(f'Release info for version: {version}:\n')
+  verbose_mode_print(release_info)
   release = json.loads(release_info)
   return release
 

--- a/script/strip-binaries.py
+++ b/script/strip-binaries.py
@@ -4,11 +4,26 @@ import argparse
 import os
 import sys
 
-from lib.config import enable_verbose_mode
+from lib.config import set_verbose_mode, is_verbose_mode, verbose_mode_print
 from lib.util import execute, get_linux_binaries, get_out_dir
 
+def get_size(path):
+  size = os.path.getsize(path)
+  units = ["bytes", "KB", "MB", "GB"]
+  for unit in units:
+    if size < 1024:
+      return f"{size:.2f} {unit}"
+    size /= 1024
+  raise ValueError("File size is too large to be processed")
+
 def strip_binaries(directory, target_cpu):
+  if not os.path.isdir(directory):
+    verbose_mode_print('Directory ' + directory + ' does not exist.')
+    return
+
+  verbose_mode_print('Stripping binaries in ' + directory)
   for binary in get_linux_binaries():
+    verbose_mode_print('\nStripping ' + binary)
     binary_path = os.path.join(directory, binary)
     if os.path.isfile(binary_path):
       strip_binary(binary_path, target_cpu)
@@ -20,14 +35,23 @@ def strip_binary(binary_path, target_cpu):
     strip = 'aarch64-linux-gnu-strip'
   else:
     strip = 'strip'
-  execute([
-    strip, '--discard-all', '--strip-debug', '--preserve-dates',
-    binary_path])
+  
+  strip_args = [strip,
+                '--discard-all',
+                '--strip-debug',
+                '--preserve-dates',
+                binary_path]
+  if (is_verbose_mode()):
+    strip_args.insert(1, '--verbose')
+  verbose_mode_print('Binary size before stripping: ' + 
+                     str(get_size(binary_path)))
+  execute(strip_args)
+  verbose_mode_print('Binary size after stripping: ' +
+                     str(get_size(binary_path)))
 
 def main():
   args = parse_args()
-  if args.verbose:
-    enable_verbose_mode()
+  set_verbose_mode(args.verbose)
   if args.file:
     strip_binary(args.file, args.target_cpu)
   else:
@@ -43,6 +67,7 @@ def parse_args():
                       help='Path to a specific file to strip.',
                       required=False)
   parser.add_argument('-v', '--verbose',
+                      default=False,
                       action='store_true',
                       help='Prints the output of the subprocesses')
   parser.add_argument('--target-cpu',


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/44409

Fixup verbose mode logic - help diagnose a potential issue with Linux x64 stripping, which seemingly works fine locally.

<details><summary>Verbose Strip Output</summary>
<p>

```console
19:59:29 /workspaces/gclient/src/electron on fix-verbosity ❯ script/strip-binaries.py --target-cpu=x64 --verbose
Stripping binaries in /workspaces/gclient/src/out/Testing

Stripping chrome-sandbox

Stripping chrome_crashpad_handler
Binary size before stripping: 3.74 MB
strip --verbose --discard-all --strip-debug --preserve-dates /workspaces/gclient/src/out/Testing/chrome_crashpad_handler
copy from `/workspaces/gclient/src/out/Testing/chrome_crashpad_handler' [elf64-x86-64] to `/workspaces/gclient/src/out/Testing/stSnSITX' [elf64-x86-64]
Binary size after stripping: 3.74 MB

Stripping electron
Binary size before stripping: 292.36 MB
strip --verbose --discard-all --strip-debug --preserve-dates /workspaces/gclient/src/out/Testing/electron
copy from `/workspaces/gclient/src/out/Testing/electron' [elf64-x86-64] to `/workspaces/gclient/src/out/Testing/stzgUh41' [elf64-x86-64]
Binary size after stripping: 292.36 MB

Stripping libEGL.so
Binary size before stripping: 280.08 KB
strip --verbose --discard-all --strip-debug --preserve-dates /workspaces/gclient/src/out/Testing/libEGL.so
copy from `/workspaces/gclient/src/out/Testing/libEGL.so' [elf64-x86-64] to `/workspaces/gclient/src/out/Testing/stJGCUxz' [elf64-x86-64]
Binary size after stripping: 280.08 KB

Stripping libGLESv2.so
Binary size before stripping: 11.04 MB
strip --verbose --discard-all --strip-debug --preserve-dates /workspaces/gclient/src/out/Testing/libGLESv2.so
copy from `/workspaces/gclient/src/out/Testing/libGLESv2.so' [elf64-x86-64] to `/workspaces/gclient/src/out/Testing/stPCptlB' [elf64-x86-64]
Binary size after stripping: 11.04 MB

Stripping libffmpeg.so
Binary size before stripping: 3.25 MB
strip --verbose --discard-all --strip-debug --preserve-dates /workspaces/gclient/src/out/Testing/libffmpeg.so
copy from `/workspaces/gclient/src/out/Testing/libffmpeg.so' [elf64-x86-64] to `/workspaces/gclient/src/out/Testing/sthjkJNN' [elf64-x86-64]
Binary size after stripping: 3.25 MB

Stripping libvk_swiftshader.so
Binary size before stripping: 4.90 MB
strip --verbose --discard-all --strip-debug --preserve-dates /workspaces/gclient/src/out/Testing/libvk_swiftshader.so
copy from `/workspaces/gclient/src/out/Testing/libvk_swiftshader.so' [elf64-x86-64] to `/workspaces/gclient/src/out/Testing/stmg36VZ' [elf64-x86-64]
Binary size after stripping: 4.90 MB
```

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none