### PR TITLE
build: add new status to verify if all the required gha jobs have run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,3 +250,13 @@ jobs:
       generate-symbols: false
       upload-to-storage: '0'
     secrets: inherit
+
+  gha-done:
+    name: GitHub Actions Completed
+    runs-on: ubuntu-latest
+    needs: [docs-only, macos-x64, macos-arm64, linux-x64, linux-x64-asan, linux-arm, linux-arm64]
+    if: always() && !contains(needs.*.result, 'failure')
+    steps: 
+    - name: GitHub Actions Jobs Done
+      run: |
+        echo "All GitHub Actions Jobs are done"


### PR DESCRIPTION
#### Description of Change
This PR adds a new status, **_GitHub Actions Completed_**, which verifies that all required GitHub Actions jobs have successfully run.  Once this PR is merged, we can require this status to make sure that PRs don't get merged with failing GitHub Actions jobs.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: none
