### PR TITLE
perf: remove isolate scope from DidProcessTask()

### DIFF
--- a/shell/browser/microtasks_runner.cc
+++ b/shell/browser/microtasks_runner.cc
@@ -17,7 +17,6 @@ void MicrotasksRunner::WillProcessTask(const base::PendingTask& pending_task,
                                        bool was_blocked_or_low_priority) {}
 
 void MicrotasksRunner::DidProcessTask(const base::PendingTask& pending_task) {
-  v8::Isolate::Scope scope(isolate_);
   // In the browser process we follow Node.js microtask policy of kExplicit
   // and let the MicrotaskRunner which is a task observer for chromium UI thread
   // scheduler run the microtask checkpoint. This worked fine because Node.js


### PR DESCRIPTION
#### Description of Change

I was profiling Electron on Ubuntu 24.04 a bit with hotspot, and this section shows up pretty high due to the cost of  `ObtainCurrentThreadStackStart()` when calling `Isolate::Scope::Enter()`.

It's not clear to me that this line is actually needed here in `DidProcessTask()`. The line predates the Node microtasks fixup, going back to 0c711f690e6a50840e7866af87ed1cc1949bac37.

So this is a PR to remove it and see what CI and the other maintainers think of the idea.

CC @deepak1556 and @codebytere who probably have the best context to give a 2nd opinion on whether this Isolate::Scope is actually needed.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Performance improvements when processing microtasks.