### PR TITLE
fix: flaky utility and BrowserView tests

### DIFF
--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -144,10 +144,10 @@ describe('utilityProcess module', () => {
   });
 
   describe('app \'child-process-gone\' event', () => {
-    const waitForCrash = (serviceName: string) => {
+    const waitForCrash = (name: string) => {
       return new Promise<Electron.Details>((resolve) => {
         app.on('child-process-gone', function onCrash (_event, details) {
-          if (details.serviceName === serviceName) {
+          if (details.name === name) {
             app.off('child-process-gone', onCrash);
             resolve(details);
           }
@@ -156,24 +156,24 @@ describe('utilityProcess module', () => {
     };
 
     ifit(!isWindows32Bit)('with default serviceName', async () => {
-      const serviceName = 'Node Utility Process';
-      const crashPromise = waitForCrash(serviceName);
+      const name = 'Node Utility Process';
+      const crashPromise = waitForCrash(name);
       utilityProcess.fork(path.join(fixturesPath, 'crash.js'));
       const details = await crashPromise;
       expect(details.type).to.equal('Utility');
       expect(details.serviceName).to.equal('node.mojom.NodeService');
-      expect(details.name).to.equal(serviceName);
+      expect(details.name).to.equal(name);
       expect(details.reason).to.be.oneOf(['crashed', 'abnormal-exit']);
     });
 
     ifit(!isWindows32Bit)('with custom serviceName', async () => {
-      const serviceName = crypto.randomUUID();
-      const crashPromise = waitForCrash(serviceName);
-      utilityProcess.fork(path.join(fixturesPath, 'crash.js'), [], { serviceName });
+      const name = crypto.randomUUID();
+      const crashPromise = waitForCrash(name);
+      utilityProcess.fork(path.join(fixturesPath, 'crash.js'), [], { serviceName: name });
       const details = await crashPromise;
       expect(details.type).to.equal('Utility');
       expect(details.serviceName).to.equal('node.mojom.NodeService');
-      expect(details.name).to.equal(serviceName);
+      expect(details.name).to.equal(name);
       expect(details.reason).to.be.oneOf(['crashed', 'abnormal-exit']);
     });
   });

--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -157,8 +157,9 @@ describe('utilityProcess module', () => {
 
     ifit(!isWindows32Bit)('with default serviceName', async () => {
       const serviceName = 'Node Utility Process';
+      const crashPromise = waitForCrash(serviceName);
       utilityProcess.fork(path.join(fixturesPath, 'crash.js'));
-      const details = await waitForCrash(serviceName);
+      const details = await crashPromise;
       expect(details.type).to.equal('Utility');
       expect(details.serviceName).to.equal('node.mojom.NodeService');
       expect(details.name).to.equal(serviceName);
@@ -167,8 +168,9 @@ describe('utilityProcess module', () => {
 
     ifit(!isWindows32Bit)('with custom serviceName', async () => {
       const serviceName = crypto.randomUUID();
+      const crashPromise = waitForCrash(serviceName);
       utilityProcess.fork(path.join(fixturesPath, 'crash.js'), [], { serviceName });
-      const details = await waitForCrash(serviceName);
+      const details = await crashPromise;
       expect(details.type).to.equal('Utility');
       expect(details.serviceName).to.equal('node.mojom.NodeService');
       expect(details.name).to.equal(serviceName);


### PR DESCRIPTION
#### Description of Change

fixes a few reoccurring flaky tests I noticed in #44411

- Utility process checks for unique process name in crash details. Concurrent crashes can overlap causing problems. https://ci.appveyor.com/project/electron-bot/electron-woa-testing/builds/50882274/job/f4pqgi79du1fq2om/tests
- BrowserView tests ensure no WebContents exist before and after each test. Concurrently running non-BrowserView tests might be throwing this off.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
