### PR TITLE
docs: fix win.setContentView() arg type

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -506,7 +506,7 @@ labeled as such.
 
 #### `win.setContentView(view)`
 
-* `view` [`View`](view.md)
+* `view` [View](view.md)
 
 Sets the content view of the window.
 


### PR DESCRIPTION
#### Description of Change

Fixup to #44430.

44430 causes this regression in `electron-api.json`:

```diff
@@ -3491,7 +3491,7 @@
             "description": "",
             "required": true,
             "collection": false,
-            "type": "View"
+            "type": "`View`"
           }
         ],
         "returns": null,
```

This PR reverts that part of 44430.

**NB:** Important to note that 44430 looks correct to me at first read. If it **is** correct and this regression is being caused by a parser bug that we have a quick fix for, then let's fast-track that instead and close this PR.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.