### PR TITLE
chore: cherry-pick 3 changes from 1-M130

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -134,3 +134,4 @@ fix_potential_draggable_region_crash_when_no_mainframeimpl.patch
 feat_allow_usage_of_sccontentsharingpicker_on_supported_platforms.patch
 feat_allow_-4_as_a_macos_screen_share_id.patch
 fix_software_compositing_infinite_loop.patch
+cherry-pick-8c4edae5e34d.patch

--- a/patches/chromium/cherry-pick-8c4edae5e34d.patch
+++ b/patches/chromium/cherry-pick-8c4edae5e34d.patch
@@ -1,0 +1,57 @@
+From 8c4edae5e34dbe82ebaaf9596710800ac524258a Mon Sep 17 00:00:00 2001
+From: Justin Lulejian <jlulejian@chromium.org>
+Date: Fri, 18 Oct 2024 21:34:12 +0000
+Subject: [PATCH] [M130][Extensions][ServiceWorker] Skip worker for isolated world module fetch
+
+Before this change, an isolated world (e.g. extension content script,
+but also others) could dynamically import a script from an accessible
+resource (for extensions this is possible with web accessible
+resources and a matching site). When this occurs a web service worker
+could intercept that request and respond with arbitrary content.
+
+After this change, isolated world module requests skip triggering the
+worker fetch handler. This includes extension content scripts, but also
+includes any other scripts that execute in the isolated world context.
+
+(cherry picked from commit 2c501634c1191be1e509720103f06d51b94e6311)
+
+Bug: 371011220
+Change-Id: I37eda47324b6933a93d2a44792a06ff91399981f
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5917013
+Auto-Submit: Justin Lulejian <jlulejian@chromium.org>
+Reviewed-by: Hiroshige Hayashizaki <hiroshige@chromium.org>
+Commit-Queue: Justin Lulejian <jlulejian@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1365918}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5940150
+Owners-Override: Daniel Yip <danielyip@google.com>
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/6723@{#1432}
+Cr-Branched-From: 985f2961df230630f9cbd75bd6fe463009855a11-refs/heads/main@{#1356013}
+---
+
+diff --git a/third_party/blink/renderer/core/loader/modulescript/module_script_loader.cc b/third_party/blink/renderer/core/loader/modulescript/module_script_loader.cc
+index 9fad30c7..b83416e 100644
+--- a/third_party/blink/renderer/core/loader/modulescript/module_script_loader.cc
++++ b/third_party/blink/renderer/core/loader/modulescript/module_script_loader.cc
+@@ -153,12 +153,20 @@
+   url_ = module_request.Url();
+ #endif
+ 
++  DOMWrapperWorld& request_world = modulator_->GetScriptState()->World();
++
++  // Prevents web service workers from intercepting isolated world dynamic
++  // script imports requests and responding with different contents.
++  // TODO(crbug.com/1296102): Link to documentation that describes the criteria
++  // where module imports are handled by service worker fetch handler.
++  resource_request.SetSkipServiceWorker(request_world.IsIsolatedWorld());
++
+   // <spec step="9">Set request 's destination to the result of running the
+   // fetch destination from module type steps given destination and
+   // moduleType.</spec>
+   SetFetchDestinationFromModuleType(resource_request, module_request);
+ 
+-  ResourceLoaderOptions options(&modulator_->GetScriptState()->World());
++  ResourceLoaderOptions options(&request_world);
+ 
+   // <spec step="11">Set request's initiator type to "script".</spec>
+   options.initiator_info.name = fetch_initiator_type_names::kScript;

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -4,3 +4,5 @@ cherry-pick-81155a8f3b20.patch
 merged_maglev_fix_non-materialized_receiver_closure.patch
 merged_don_t_assume_all_turbofan_frames_are_javascript.patch
 merged_wasm_do_not_inline_wrappers_with_ref_extern_parameter.patch
+cherry-pick-153d4e84e5d1.patch
+cherry-pick-d9893f4856af.patch

--- a/patches/v8/cherry-pick-153d4e84e5d1.patch
+++ b/patches/v8/cherry-pick-153d4e84e5d1.patch
@@ -1,0 +1,71 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andreas Haas <ahaas@chromium.org>
+Date: Thu, 10 Oct 2024 13:56:42 +0200
+Subject: [13.0][wasm] Don't tier up wrapper if signature depends on other
+ instance
+
+The wasm-to-js wrapper tierup currently does not handle signatures with
+indexed types correctly if the WebAssembly instance from which the
+JavaScript function is called is different than the WebAssembly instance
+that imported the JavaScript function initially. With this CL the
+wrapper tierup gets disabled in that case until tierup gets fixed
+eventually.
+
+R=clemensb@chromium.org
+
+Bug: 371565065
+
+(cherry picked from commit 5fcbf3954eb9f7f8221f068b5324e5b6f04b5839)
+
+Change-Id: I43d8eff2d4ce4e3ec775b7346938ea26109f7045
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5937800
+Commit-Queue: Andreas Haas <ahaas@chromium.org>
+Reviewed-by: Clemens Backes <clemensb@chromium.org>
+Cr-Commit-Position: refs/branch-heads/13.0@{#33}
+Cr-Branched-From: 4be854bd71ea878a25b236a27afcecffa2e29360-refs/heads/13.0.245@{#1}
+Cr-Branched-From: 1f5183f7ad6cca21029fd60653d075730c644432-refs/heads/main@{#96103}
+
+diff --git a/src/runtime/runtime-wasm.cc b/src/runtime/runtime-wasm.cc
+index 71e7f3504afdef8fb8a909980709af37e42c7286..b127275bd7502e4fa718296b2e87f62320d58cfa 100644
+--- a/src/runtime/runtime-wasm.cc
++++ b/src/runtime/runtime-wasm.cc
+@@ -626,9 +626,23 @@ RUNTIME_FUNCTION(Runtime_TierUpWasmToJSWrapper) {
+   Handle<WasmTrustedInstanceData> trusted_data(ref->instance_data(), isolate);
+   if (IsTuple2(*origin)) {
+     auto tuple = Cast<Tuple2>(origin);
+-    trusted_data =
+-        handle(Cast<WasmInstanceObject>(tuple->value1())->trusted_data(isolate),
+-               isolate);
++    Handle<WasmTrustedInstanceData> call_origin_trusted_data(
++        Cast<WasmInstanceObject>(tuple->value1())->trusted_data(isolate),
++        isolate);
++    // TODO(371565065): We do not tier up the wrapper if the JS function wasn't
++    // imported in the current instance but the signature is specific to the
++    // importing instance. Remove this bailout again.
++    if (trusted_data->module() != call_origin_trusted_data->module()) {
++      for (wasm::ValueType type : sig.all()) {
++        if (type.has_index()) {
++          // Reset the tiering budget, so that we don't have to deal with the
++          // underflow.
++          ref->set_wrapper_budget(Smi::kMaxValue);
++          return ReadOnlyRoots(isolate).undefined_value();
++        }
++      }
++    }
++    trusted_data = call_origin_trusted_data;
+     origin = direct_handle(tuple->value2(), isolate);
+   }
+   const wasm::WasmModule* module = trusted_data->module();
+diff --git a/test/mjsunit/mjsunit.status b/test/mjsunit/mjsunit.status
+index 1fb2786de576bdcb0f4b6e4145203764dd06b5f0..2fa90fc9399f18411eef2a8a5eb9b40357492c8c 100644
+--- a/test/mjsunit/mjsunit.status
++++ b/test/mjsunit/mjsunit.status
+@@ -41,8 +41,6 @@
+   'compiler/fast-api-helpers': [SKIP],
+   'typedarray-helpers': [SKIP],
+ 
+-  # TODO(ahaas): Fix generic wasm-to-js wrapper tierup test.
+-  'wasm/wasm-to-js-tierup': [SKIP],
+   # All tests in the bug directory are expected to fail.
+   'bugs/*': [FAIL],
+ 

--- a/patches/v8/cherry-pick-d9893f4856af.patch
+++ b/patches/v8/cherry-pick-d9893f4856af.patch
@@ -1,0 +1,40 @@
+From d9893f4856af26e78ba5021063ee2b1c61a3023b Mon Sep 17 00:00:00 2001
+From: Thibaud Michaud <thibaudm@chromium.org>
+Date: Thu, 10 Oct 2024 18:54:04 +0200
+Subject: [PATCH] Merged: [wasm] Fix default externref/exnref reference
+
+- The default nullexternref should be null instead of undefined
+- The default exnref/nullexnref should be null instead of wasm_null
+
+(cherry picked from commit e7ccf0af1bdddd20dc58e1790a94739dba0209a3)
+
+Change-Id: I5b32e80f2eb59b29113232f9e2f59a8803915cb3
+Fixed: 372285204,372269618
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5937812
+Reviewed-by: Thibaud Michaud <thibaudm@chromium.org>
+Auto-Submit: Matthias Liedtke <mliedtke@chromium.org>
+Commit-Queue: Thibaud Michaud <thibaudm@chromium.org>
+Cr-Commit-Position: refs/branch-heads/13.0@{#35}
+Cr-Branched-From: 4be854bd71ea878a25b236a27afcecffa2e29360-refs/heads/13.0.245@{#1}
+Cr-Branched-From: 1f5183f7ad6cca21029fd60653d075730c644432-refs/heads/main@{#96103}
+---
+
+diff --git a/src/wasm/wasm-js.cc b/src/wasm/wasm-js.cc
+index f8549cb..7c07f1e 100644
+--- a/src/wasm/wasm-js.cc
++++ b/src/wasm/wasm-js.cc
+@@ -1322,9 +1322,12 @@
+   DCHECK(type.is_object_reference());
+   // Use undefined for JS type (externref) but null for wasm types as wasm does
+   // not know undefined.
+-  if (type.heap_representation() == i::wasm::HeapType::kExtern ||
+-      type.heap_representation() == i::wasm::HeapType::kNoExtern) {
++  if (type.heap_representation() == i::wasm::HeapType::kExtern) {
+     return isolate->factory()->undefined_value();
++  } else if (type.heap_representation() == i::wasm::HeapType::kNoExtern ||
++             type.heap_representation() == i::wasm::HeapType::kExn ||
++             type.heap_representation() == i::wasm::HeapType::kNoExn) {
++    return isolate->factory()->null_value();
+   }
+   return isolate->factory()->wasm_null();
+ }


### PR DESCRIPTION
<details>
<summary>electron/security#619 - 153d4e84e5d1 from v8</summary>
[13.0][wasm] Don't tier up wrapper if signature depends on other instance

The wasm-to-js wrapper tierup currently does not handle signatures with
indexed types correctly if the WebAssembly instance from which the
JavaScript function is called is different than the WebAssembly instance
that imported the JavaScript function initially. With this CL the
wrapper tierup gets disabled in that case until tierup gets fixed
eventually.

R=clemensb@chromium.org

Bug: 371565065

(cherry picked from commit 5fcbf3954eb9f7f8221f068b5324e5b6f04b5839)

Change-Id: I43d8eff2d4ce4e3ec775b7346938ea26109f7045
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5937800
Commit-Queue: Andreas Haas <ahaas@chromium.org>
Reviewed-by: Clemens Backes <clemensb@chromium.org>
Cr-Commit-Position: refs/branch-heads/13.0@{#33}
Cr-Branched-From: 4be854bd71ea878a25b236a27afcecffa2e29360-refs/heads/13.0.245@{#1}
Cr-Branched-From: 1f5183f7ad6cca21029fd60653d075730c644432-refs/heads/main@{#96103}
</details>

<details>
<summary>electron/security#618 - d9893f4856af from v8</summary>
Merged: [wasm] Fix default externref/exnref reference

- The default nullexternref should be null instead of undefined
- The default exnref/nullexnref should be null instead of wasm_null

(cherry picked from commit e7ccf0af1bdddd20dc58e1790a94739dba0209a3)

Change-Id: I5b32e80f2eb59b29113232f9e2f59a8803915cb3
Fixed: 372285204,372269618
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5937812
Reviewed-by: Thibaud Michaud <thibaudm@chromium.org>
Auto-Submit: Matthias Liedtke <mliedtke@chromium.org>
Commit-Queue: Thibaud Michaud <thibaudm@chromium.org>
Cr-Commit-Position: refs/branch-heads/13.0@{#35}
Cr-Branched-From: 4be854bd71ea878a25b236a27afcecffa2e29360-refs/heads/13.0.245@{#1}
Cr-Branched-From: 1f5183f7ad6cca21029fd60653d075730c644432-refs/heads/main@{#96103}
</details>

<details>
<summary>electron/security#620 - 8c4edae5e34d from chromium</summary>
[M130][Extensions][ServiceWorker] Skip worker for isolated world module fetch

Before this change, an isolated world (e.g. extension content script,
but also others) could dynamically import a script from an accessible
resource (for extensions this is possible with web accessible
resources and a matching site). When this occurs a web service worker
could intercept that request and respond with arbitrary content.

After this change, isolated world module requests skip triggering the
worker fetch handler. This includes extension content scripts, but also
includes any other scripts that execute in the isolated world context.

(cherry picked from commit 2c501634c1191be1e509720103f06d51b94e6311)

Bug: 371011220
Change-Id: I37eda47324b6933a93d2a44792a06ff91399981f
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5917013
Auto-Submit: Justin Lulejian <jlulejian@chromium.org>
Reviewed-by: Hiroshige Hayashizaki <hiroshige@chromium.org>
Commit-Queue: Justin Lulejian <jlulejian@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1365918}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5940150
Owners-Override: Daniel Yip <danielyip@google.com>
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Cr-Commit-Position: refs/branch-heads/6723@{#1432}
Cr-Branched-From: 985f2961df230630f9cbd75bd6fe463009855a11-refs/heads/main@{#1356013}
</details>

Notes:
* Security: backported fix for CVE-2024-10230.
* Security: backported fix for CVE-2024-10231.
* Security: backported fix for CVE-2024-10229.