### PR TITLE
test: exercise fuller `globalShortcut` matrix

### DIFF
--- a/spec/api-global-shortcut-spec.ts
+++ b/spec/api-global-shortcut-spec.ts
@@ -4,24 +4,66 @@ import { expect } from 'chai';
 
 import { ifdescribe } from './lib/spec-helpers';
 
+const modifiers = [
+  'CmdOrCtrl',
+  'Alt',
+  process.platform === 'darwin' ? 'Option' : null,
+  'AltGr',
+  'Shift',
+  'Super',
+  'Meta'
+].filter(Boolean);
+
+const keyCodes = [
+  ...Array.from({ length: 10 }, (_, i) => `${i}`), // 0 to 9
+  ...Array.from({ length: 26 }, (_, i) => String.fromCharCode(65 + i)), // A to Z
+  ...Array.from({ length: 24 }, (_, i) => `F${i + 1}`), // F1 to F24
+  ')', '!', '@', '#', '$', '%', '^', '&', '*', '(', ':', ';', ':', '+', '=',
+  '<', ',', '_', '-', '>', '.', '?', '/', '~', '`', '{', ']', '[', '|', '\\',
+  '}', '"', 'Plus', 'Space', 'Tab', 'Capslock', 'Numlock', 'Scrolllock',
+  'Backspace', 'Delete', 'Insert', 'Return', 'Enter', 'Up', 'Down', 'Left',
+  'Right', 'Home', 'End', 'PageUp', 'PageDown', 'Escape', 'Esc', 'PrintScreen',
+  'num0', 'num1', 'num2', 'num3', 'num4', 'num5', 'num6', 'num7', 'num8', 'num9',
+  'numdec', 'numadd', 'numsub', 'nummult', 'numdiv'
+];
+
 ifdescribe(process.platform !== 'win32')('globalShortcut module', () => {
   beforeEach(() => {
     globalShortcut.unregisterAll();
   });
 
   it('can register and unregister single accelerators', () => {
-    const accelerator = 'CmdOrCtrl+A+B+C';
+    const singleModifierCombinations = modifiers.flatMap(
+      mod => keyCodes.map(key => {
+        return key === '+' ? `${mod}+Plus` : `${mod}+${key}`;
+      })
+    );
 
-    expect(globalShortcut.isRegistered(accelerator)).to.be.false('initially registered');
-    globalShortcut.register(accelerator, () => {});
-    expect(globalShortcut.isRegistered(accelerator)).to.be.true('registration worked');
-    globalShortcut.unregister(accelerator);
-    expect(globalShortcut.isRegistered(accelerator)).to.be.false('unregistration worked');
+    const doubleModifierCombinations = modifiers.flatMap(
+      (mod1, i) => modifiers.slice(i + 1).flatMap(
+        mod2 => keyCodes.map(key => {
+          return key === '+' ? `${mod1}+${mod2}+Plus` : `${mod1}+${mod2}+${key}`;
+        })
+      )
+    );
 
-    globalShortcut.register(accelerator, () => {});
-    expect(globalShortcut.isRegistered(accelerator)).to.be.true('reregistration worked');
-    globalShortcut.unregisterAll();
-    expect(globalShortcut.isRegistered(accelerator)).to.be.false('re-unregistration worked');
+    const combinations = [...singleModifierCombinations, ...doubleModifierCombinations];
+
+    combinations.forEach((accelerator) => {
+      expect(globalShortcut.isRegistered(accelerator)).to.be.false(`Initially registered for ${accelerator}`);
+
+      globalShortcut.register(accelerator, () => { });
+      expect(globalShortcut.isRegistered(accelerator)).to.be.true(`Registration failed for ${accelerator}`);
+
+      globalShortcut.unregister(accelerator);
+      expect(globalShortcut.isRegistered(accelerator)).to.be.false(`Unregistration failed for ${accelerator}`);
+
+      globalShortcut.register(accelerator, () => { });
+      expect(globalShortcut.isRegistered(accelerator)).to.be.true(`Re-registration failed for ${accelerator}`);
+
+      globalShortcut.unregisterAll();
+      expect(globalShortcut.isRegistered(accelerator)).to.be.false(`Re-unregistration failed for ${accelerator}`);
+    });
   });
 
   it('can register and unregister multiple accelerators', () => {


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/44341.

Test fuller matrix of accelerator combinations to prevent regressions like the above.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none