### PR TITLE
build: handle out of disk space on source cache

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -57,12 +57,25 @@ runs:
       cache_path=/mnt/cross-instance-cache/$DEPSHASH.tar
       echo "Using cache key: $DEPSHASH"
       echo "Checking for cache in: $cache_path"
-      if [ ! -f "$cache_path" ]; then
+      if [ ! -f "$cache_path" ] || [ `du $cache_path | cut -f1` = "0" ]; then
         echo "cache_exists=false" >> $GITHUB_OUTPUT
         echo "Cache Does Not Exist for $DEPSHASH"
       else
         echo "cache_exists=true" >> $GITHUB_OUTPUT
         echo "Cache Already Exists for $DEPSHASH, Skipping.."
+      fi
+  - name: Check cross instance cache disk space
+    if: steps.check-cache.outputs.cache_exists == 'false'
+    shell: bash
+    run: |    
+      # if there is less than 20 GB free space then creating the cache might fail so exit early
+      freespace=`df -m /mnt/cross-instance-cache | grep -w /mnt/cross-instance-cache | awk '{print $4}'`
+      freespace_human=`df -h /mnt/cross-instance-cache | grep -w /mnt/cross-instance-cache | awk '{print $4}'`
+      if [ $freespace -le 20000 ]; then
+        echo "The cross mount cache has $freespace_human free space which is not enough - exiting"
+        exit 1
+      else
+        echo "The cross mount cache has $freespace_human free space - continuing"
       fi
   - name: Gclient Sync
     if: steps.check-cache.outputs.cache_exists == 'false'

--- a/.github/actions/restore-cache-aks/action.yml
+++ b/.github/actions/restore-cache-aks/action.yml
@@ -17,6 +17,11 @@ runs:
       fi
 
       echo "Persisted cache is $(du -sh $cache_path | cut -f1)"
+      if [ `du  $cache_path | cut -f1` = "0" ]; then
+        echo "Cache is empty - exiting"
+        exit 1
+      fi
+
       mkdir temp-cache
       tar -xf $cache_path -C temp-cache
       echo "Unzipped cache is $(du -sh temp-cache/src | cut -f1)"

--- a/.github/actions/restore-cache-azcopy/action.yml
+++ b/.github/actions/restore-cache-azcopy/action.yml
@@ -44,6 +44,11 @@ runs:
     shell: bash
     run: |
       echo "Downloaded cache is $(du -sh $DEPSHASH.tar | cut -f1)"
+      if [ `du $DEPSHASH.tar | cut -f1` = "0" ]; then
+        echo "Cache is empty - exiting"
+        exit 1
+      fi
+      
       mkdir temp-cache
       tar -xf $DEPSHASH.tar -C temp-cache
       echo "Unzipped cache is $(du -sh temp-cache/src | cut -f1)"

--- a/.github/workflows/clean-src-cache.yml
+++ b/.github/workflows/clean-src-cache.yml
@@ -1,0 +1,21 @@
+name: Clean Source Cache
+
+on:
+  schedule:
+    - cron: "0 0 * * SUN"  # Run at midnight every Sunday
+
+jobs:
+  clean-src-cache:
+    runs-on: electron-arc-linux-amd64-32core
+    container:
+      image: ghcr.io/electron/build:bc2f48b2415a670de18d13605b1cf0eb5fdbaae1
+      options: --user root
+      volumes:
+        - /mnt/cross-instance-cache:/mnt/cross-instance-cache
+    steps:
+    - name: Cleanup Source Cache
+      shell: bash
+      run: |
+        df -h /mnt/cross-instance-cache
+        find /mnt/cross-instance-cache -type f -mtime +30 -delete
+        df -h /mnt/cross-instance-cache


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
We occasionally run into issues when our source cache runs out of disk space.  This PR does a couple of things to help alleviate this issue:
1. Check for enough free disk space before attempting to create a new source cache.  If there isn't enough space, exit the checkout job early so that we don't create incomplete caches.
2. Logic has been added to detect empty source cache files if they somehow exist. If there is an empty source cache, the checkout job will act as if the cache doesn't exist and will attempt to create a new source cache.  Jobs that use the cache will now exit early if the source cache is empty.
3. Adds a cron job to cleanup the source cache every week on Sunday at midnight.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none