### PR TITLE
refactor: remove unused C string ToV8() gin converter

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1344,7 +1344,7 @@ content::KeyboardEventProcessingResult WebContents::PreHandleKeyboardEvent(
 }
 
 void WebContents::ContentsZoomChange(bool zoom_in) {
-  Emit("zoom-changed", zoom_in ? "in" : "out");
+  Emit("zoom-changed", std::string_view{zoom_in ? "in" : "out"});
 }
 
 Profile* WebContents::GetProfile() {

--- a/shell/common/gin_converters/std_converter.h
+++ b/shell/common/gin_converters/std_converter.h
@@ -55,14 +55,6 @@ struct Converter<std::nullptr_t> {
 };
 
 template <>
-struct Converter<const char*> {
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const char* val) {
-    return v8::String::NewFromUtf8(isolate, val, v8::NewStringType::kNormal)
-        .ToLocalChecked();
-  }
-};
-
-template <>
 struct Converter<char[]> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const char* val) {
     return v8::String::NewFromUtf8(isolate, val, v8::NewStringType::kNormal)


### PR DESCRIPTION
#### Description of Change

Remove the unused `ToV8(v8::Isolate* isolate, const char* val)` gin converter.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.