### PR TITLE
perf: use v8::String::NewFromUtf8Literal in ToV8() gin converter

### DIFF
--- a/shell/common/gin_converters/std_converter.h
+++ b/shell/common/gin_converters/std_converter.h
@@ -70,12 +70,10 @@ struct Converter<char[]> {
   }
 };
 
-template <size_t n>
-struct Converter<char[n]> {
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const char* val) {
-    return v8::String::NewFromUtf8(isolate, val, v8::NewStringType::kNormal,
-                                   n - 1)
-        .ToLocalChecked();
+template <size_t N>
+struct Converter<char[N]> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const char (&val)[N]) {
+    return v8::String::NewFromUtf8Literal(isolate, val);
   }
 };
 


### PR DESCRIPTION
#### Description of Change

Use `v8::String::NewFromUtf8Literal()` instead of `v8::String::NewFromUtf8()` when the string literal size is known at compile time. This avoids a little bit of overhead of v8 having to call strlen() and ToLocalChecked().

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.