### PR TITLE
chore: remove use of banned absl::optional

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1668,7 +1668,7 @@ ElectronBrowserClient::CreateURLLoaderThrottles(
     const base::RepeatingCallback<content::WebContents*()>& wc_getter,
     content::NavigationUIData* navigation_ui_data,
     content::FrameTreeNodeId frame_tree_node_id,
-    absl::optional<int64_t> navigation_id) {
+    std::optional<int64_t> navigation_id) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
 
   std::vector<std::unique_ptr<blink::URLLoaderThrottle>> result;


### PR DESCRIPTION
#### Description of Change

Replace our one use of `absl::optional` with `std::optional`, since the former is [banned](https://chromium-review.googlesource.com/c/chromium/src/+/5805666).

Side node: this is an argument to a class method, and we specify `absl::optional` in the .cc file but `std::optional` in the .h file. `ABSL_USES_STD_OPTIONAL`  must be getting defined somewhere; otherwise, this wouldn't be compiling in `main` as-is :slightly_smiling_face: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.