### PR TITLE
fix: remove use of banned std::to_string()

### DIFF
--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -664,8 +664,8 @@ IFACEMETHODIMP ToastEventHandler::Invoke(
     winui::Notifications::IToastFailedEventArgs* e) {
   HRESULT error;
   e->get_ErrorCode(&error);
-  std::string errorMessage =
-      "Notification failed. HRESULT:" + std::to_string(error);
+  std::string errorMessage = base::StrCat(
+      {"Notification failed. HRESULT:", base::NumberToString(error)});
   content::GetUIThreadTaskRunner({})->PostTask(
       FROM_HERE, base::BindOnce(&Notification::NotificationFailed,
                                 notification_, errorMessage));


### PR DESCRIPTION
#### Description of Change

Use `base::NumberToString()` instead of `std::to_string()` since the latter is [banned](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++-features.md#std_sto_i_l_ul_ll_ull_f_d_ld_to_string_banned).

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.