### PR TITLE
refactor: replace base::StringPrintf() calls with absl::StrFormat()

### DIFF
--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -18,7 +18,6 @@
 #include "base/files/file_util.h"
 #include "base/scoped_observation.h"
 #include "base/strings/string_util.h"
-#include "base/strings/stringprintf.h"
 #include "base/uuid.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/predictors/preconnect_manager.h"
@@ -89,6 +88,7 @@
 #include "shell/common/node_includes.h"
 #include "shell/common/node_util.h"
 #include "shell/common/options_switches.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
 #include "third_party/blink/public/common/storage_key/storage_key.h"
 #include "third_party/blink/public/mojom/mediastream/media_stream.mojom.h"
 #include "ui/base/l10n/l10n_util.h"
@@ -1234,8 +1234,8 @@ void Session::Preconnect(const gin_helper::Dictionary& options,
     if (num_sockets_to_preconnect < kMinSocketsToPreconnect ||
         num_sockets_to_preconnect > kMaxSocketsToPreconnect) {
       args->ThrowTypeError(
-          base::StringPrintf("numSocketsToPreconnect is outside range [%d,%d]",
-                             kMinSocketsToPreconnect, kMaxSocketsToPreconnect));
+          absl::StrFormat("numSocketsToPreconnect is outside range [%d,%d]",
+                          kMinSocketsToPreconnect, kMaxSocketsToPreconnect));
       return;
     }
   }
@@ -1357,8 +1357,8 @@ v8::Local<v8::Value> Session::ClearData(gin_helper::ErrorThrower thrower,
         // Opaque origins cannot be used with this API
         if (origin.opaque()) {
           thrower.ThrowError(
-              base::StringPrintf("Invalid origin: '%s'",
-                                 origin_url.possibly_invalid_spec().c_str()));
+              absl::StrFormat("Invalid origin: '%s'",
+                              origin_url.possibly_invalid_spec().c_str()));
           return v8::Undefined(isolate);
         }
 

--- a/shell/browser/extensions/api/management/electron_management_api_delegate.cc
+++ b/shell/browser/extensions/api/management/electron_management_api_delegate.cc
@@ -9,7 +9,6 @@
 #include <string>
 #include <utility>
 
-#include "base/strings/stringprintf.h"
 #include "chrome/common/extensions/extension_metrics.h"
 #include "chrome/common/extensions/manifest_handlers/app_launch_info.h"
 #include "chrome/common/webui_url_constants.h"
@@ -24,6 +23,7 @@
 #include "extensions/common/api/management.h"
 #include "extensions/common/extension.h"
 #include "services/data_decoder/public/cpp/data_decoder.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
 #include "third_party/blink/public/mojom/manifest/display_mode.mojom.h"
 
 namespace {
@@ -202,7 +202,7 @@ GURL ElectronManagementAPIDelegate::GetIconURL(
     int icon_size,
     ExtensionIconSet::Match match,
     bool grayscale) const {
-  GURL icon_url(base::StringPrintf(
+  GURL icon_url(absl::StrFormat(
       "%s%s/%d/%d%s", chrome::kChromeUIExtensionIconURL,
       extension->id().c_str(), icon_size, static_cast<int>(match),
       grayscale ? "?grayscale=true" : ""));

--- a/shell/browser/extensions/api/scripting/scripting_api.cc
+++ b/shell/browser/extensions/api/scripting/scripting_api.cc
@@ -10,7 +10,6 @@
 #include "base/containers/contains.h"
 #include "base/json/json_writer.h"
 #include "base/strings/string_util.h"
-#include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/types/optional_util.h"
 #include "chrome/common/extensions/api/scripting.h"
@@ -44,6 +43,7 @@
 #include "extensions/common/utils/content_script_utils.h"
 #include "extensions/common/utils/extension_types_utils.h"
 #include "shell/browser/api/electron_api_web_contents.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
 
 namespace extensions {
 
@@ -335,7 +335,7 @@ bool CollectFramesForInjection(const api::scripting::InjectionTarget& target,
           ExtensionApiFrameIdMap::DocumentIdFromString(id);
 
       if (!document_id) {
-        *error_out = base::StringPrintf("Invalid document id %s", id.c_str());
+        *error_out = absl::StrFormat("Invalid document id %s", id.c_str());
         return false;
       }
 
@@ -346,9 +346,8 @@ bool CollectFramesForInjection(const api::scripting::InjectionTarget& target,
       // If the frame was not found or it matched another tab reject this
       // request.
       if (!frame || content::WebContents::FromRenderFrameHost(frame) != tab) {
-        *error_out =
-            base::StringPrintf("No document with id %s in tab with id %d",
-                               id.c_str(), target.tab_id);
+        *error_out = absl::StrFormat("No document with id %s in tab with id %d",
+                                     id.c_str(), target.tab_id);
         return false;
       }
 
@@ -368,8 +367,8 @@ bool CollectFramesForInjection(const api::scripting::InjectionTarget& target,
       content::RenderFrameHost* frame =
           ExtensionApiFrameIdMap::GetRenderFrameHostById(tab, frame_id);
       if (!frame) {
-        *error_out = base::StringPrintf("No frame with id %d in tab with id %d",
-                                        frame_id, target.tab_id);
+        *error_out = absl::StrFormat("No frame with id %d in tab with id %d",
+                                     frame_id, target.tab_id);
         return false;
       }
       frames.insert(frame);
@@ -392,7 +391,7 @@ bool CanAccessTarget(const PermissionsData& permissions,
                      std::string* error_out) {
   auto* contents = electron::api::WebContents::FromID(target.tab_id);
   if (!contents) {
-    *error_out = base::StringPrintf("No tab with id: %d", target.tab_id);
+    *error_out = absl::StrFormat("No tab with id: %d", target.tab_id);
     return false;
   }
 
@@ -631,7 +630,7 @@ ExtensionFunction::ResponseAction ScriptingExecuteScriptFunction::Run() {
     args_expression = base::JoinString(string_args, ",");
   }
 
-  std::string code_to_execute = base::StringPrintf(
+  std::string code_to_execute = absl::StrFormat(
       "(%s)(%s)", injection_.func->c_str(), args_expression.c_str());
 
   std::vector<mojom::JSSourcePtr> sources;

--- a/shell/browser/hid/hid_chooser_context.cc
+++ b/shell/browser/hid/hid_chooser_context.cc
@@ -10,7 +10,6 @@
 #include "base/command_line.h"
 #include "base/containers/contains.h"
 #include "base/containers/map_util.h"
-#include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/values.h"
 #include "chrome/grit/generated_resources.h"
@@ -29,6 +28,7 @@
 #include "shell/common/gin_converters/hid_device_info_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
 #include "third_party/blink/public/common/permissions/permission_utils.h"
 #include "ui/base/l10n/l10n_util.h"
 
@@ -59,7 +59,7 @@ std::u16string HidChooserContext::DisplayNameFromDeviceInfo(
     const device::mojom::HidDeviceInfo& device) {
   if (device.product_name.empty()) {
     auto device_id_string = base::ASCIIToUTF16(
-        base::StringPrintf("%04X:%04X", device.vendor_id, device.product_id));
+        absl::StrFormat("%04X:%04X", device.vendor_id, device.product_id));
     return l10n_util::GetStringFUTF16(IDS_HID_CHOOSER_ITEM_WITHOUT_NAME,
                                       device_id_string);
   }

--- a/shell/browser/hid/hid_chooser_controller.cc
+++ b/shell/browser/hid/hid_chooser_controller.cc
@@ -25,6 +25,7 @@
 #include "shell/common/gin_converters/hid_device_info_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/node_util.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
 #include "third_party/blink/public/mojom/devtools/console_message.mojom.h"
 #include "third_party/blink/public/mojom/hid/hid.mojom.h"
 #include "ui/base/l10n/l10n_util.h"
@@ -277,7 +278,7 @@ bool HidChooserController::DisplayDevice(
 
     AddMessageToConsole(
         blink::mojom::ConsoleMessageLevel::kInfo,
-        base::StringPrintf(
+        absl::StrFormat(
             "Chooser dialog is not displaying a FIDO HID device: vendorId=%d, "
             "productId=%d, name='%s', serial='%s'",
             device.vendor_id, device.product_id, device.product_name.c_str(),
@@ -288,12 +289,12 @@ bool HidChooserController::DisplayDevice(
   if (device.is_excluded_by_blocklist) {
     AddMessageToConsole(
         blink::mojom::ConsoleMessageLevel::kInfo,
-        base::StringPrintf(
-            "Chooser dialog is not displaying a device excluded by "
-            "the HID blocklist: vendorId=%d, "
-            "productId=%d, name='%s', serial='%s'",
-            device.vendor_id, device.product_id, device.product_name.c_str(),
-            device.serial_number.c_str()));
+        absl::StrFormat("Chooser dialog is not displaying a device excluded by "
+                        "the HID blocklist: vendorId=%d, "
+                        "productId=%d, name='%s', serial='%s'",
+                        device.vendor_id, device.product_id,
+                        device.product_name.c_str(),
+                        device.serial_number.c_str()));
     return false;
   }
 

--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -11,7 +11,6 @@
 
 #include "base/containers/fixed_flat_map.h"
 #include "base/strings/string_number_conversions.h"
-#include "base/strings/stringprintf.h"
 #include "base/uuid.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/storage_partition.h"
@@ -34,6 +33,7 @@
 #include "shell/common/gin_converters/net_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
 #include "third_party/blink/public/mojom/loader/resource_load_info.mojom-shared.h"
 
 #include "shell/common/node_includes.h"
@@ -117,9 +117,9 @@ network::mojom::URLResponseHeadPtr ToResponseHead(
   int status_code = net::HTTP_OK;
   dict.Get("statusCode", &status_code);
   head->headers = base::MakeRefCounted<net::HttpResponseHeaders>(
-      base::StringPrintf("HTTP/1.1 %d %s", status_code,
-                         net::GetHttpReasonPhrase(
-                             static_cast<net::HttpStatusCode>(status_code))));
+      absl::StrFormat("HTTP/1.1 %d %s", status_code,
+                      net::GetHttpReasonPhrase(
+                          static_cast<net::HttpStatusCode>(status_code))));
 
   dict.Get("charset", &head->charset);
   bool has_mime_type = dict.Get("mimeType", &head->mime_type);

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -11,7 +11,6 @@
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "base/strings/string_split.h"
-#include "base/strings/stringprintf.h"
 #include "content/public/browser/browser_context.h"
 #include "extensions/browser/extension_navigation_ui_data.h"
 #include "net/base/completion_repeating_callback.h"
@@ -25,6 +24,7 @@
 #include "services/network/public/mojom/url_response_head.mojom.h"
 #include "shell/browser/net/asar/asar_url_loader.h"
 #include "shell/common/options_switches.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
 #include "url/origin.h"
 
 namespace electron {
@@ -400,7 +400,7 @@ void ProxyingURLLoaderFactory::InProgressRequest::
       net::SiteForCookies::FromUrl(redirect_url_);
 
   auto head = network::mojom::URLResponseHead::New();
-  std::string headers = base::StringPrintf(
+  std::string headers = absl::StrFormat(
       "HTTP/1.1 %i Internal Redirect\n"
       "Location: %s\n"
       "Non-Authoritative-Reason: WebRequest API\n\n",

--- a/shell/browser/net/proxying_websocket.cc
+++ b/shell/browser/net/proxying_websocket.cc
@@ -8,11 +8,11 @@
 
 #include "base/functional/bind.h"
 #include "base/strings/string_util.h"
-#include "base/strings/stringprintf.h"
 #include "content/public/browser/browser_thread.h"
 #include "extensions/browser/extension_navigation_ui_data.h"
 #include "net/base/ip_endpoint.h"
 #include "services/network/public/mojom/url_response_head.mojom.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
 
 namespace electron {
 
@@ -139,7 +139,7 @@ void ProxyingWebSocket::OnConnectionEstablished(
   }
 
   response_->headers =
-      base::MakeRefCounted<net::HttpResponseHeaders>(base::StringPrintf(
+      base::MakeRefCounted<net::HttpResponseHeaders>(absl::StrFormat(
           "HTTP/%d.%d %d %s", handshake_response_->http_version.major_value(),
           handshake_response_->http_version.minor_value(),
           handshake_response_->status_code,

--- a/shell/browser/serial/serial_chooser_controller.cc
+++ b/shell/browser/serial/serial_chooser_controller.cc
@@ -9,7 +9,6 @@
 
 #include "base/containers/contains.h"
 #include "base/functional/bind.h"
-#include "base/strings/stringprintf.h"
 #include "content/public/browser/web_contents.h"
 #include "device/bluetooth/public/cpp/bluetooth_uuid.h"
 #include "services/device/public/cpp/bluetooth/bluetooth_utils.h"
@@ -22,6 +21,7 @@
 #include "shell/common/gin_converters/content_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/promise.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
 #include "ui/base/l10n/l10n_util.h"
 
 namespace gin {
@@ -38,10 +38,10 @@ struct Converter<device::mojom::SerialPortInfoPtr> {
       dict.Set("displayName", *port->display_name);
     }
     if (port->has_vendor_id) {
-      dict.Set("vendorId", base::StringPrintf("%u", port->vendor_id));
+      dict.Set("vendorId", absl::StrFormat("%u", port->vendor_id));
     }
     if (port->has_product_id) {
-      dict.Set("productId", base::StringPrintf("%u", port->product_id));
+      dict.Set("productId", absl::StrFormat("%u", port->product_id));
     }
     if (port->serial_number && !port->serial_number->empty()) {
       dict.Set("serialNumber", *port->serial_number);

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -16,7 +16,6 @@
 #include "base/metrics/histogram.h"
 #include "base/strings/pattern.h"
 #include "base/strings/string_util.h"
-#include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/timer/timer.h"
 #include "base/uuid.h"
@@ -52,6 +51,7 @@
 #include "shell/browser/ui/inspectable_web_contents_view_delegate.h"
 #include "shell/common/application_info.h"
 #include "shell/common/platform_util.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
 #include "third_party/blink/public/common/logging/logging_utils.h"
 #include "third_party/blink/public/common/page/page_zoom.h"
 #include "ui/display/display.h"
@@ -137,16 +137,15 @@ double GetNextZoomLevel(double level, bool out) {
 }
 
 GURL GetRemoteBaseURL() {
-  return GURL(base::StringPrintf("%s%s/%s/",
-                                 kChromeUIDevToolsRemoteFrontendBase,
-                                 kChromeUIDevToolsRemoteFrontendPath,
-                                 content::GetChromiumGitRevision().c_str()));
+  return GURL(absl::StrFormat("%s%s/%s/", kChromeUIDevToolsRemoteFrontendBase,
+                              kChromeUIDevToolsRemoteFrontendPath,
+                              content::GetChromiumGitRevision().c_str()));
 }
 
 GURL GetDevToolsURL(bool can_dock) {
-  auto url_string = base::StringPrintf(kChromeUIDevToolsURL,
-                                       GetRemoteBaseURL().spec().c_str(),
-                                       can_dock ? "true" : "");
+  auto url_string =
+      absl::StrFormat(kChromeUIDevToolsURL, GetRemoteBaseURL().spec().c_str(),
+                      can_dock ? "true" : "");
   return GURL(url_string);
 }
 
@@ -632,7 +631,7 @@ void InspectableWebContents::InspectedURLChanged(const std::string& url) {
   if (managed_devtools_web_contents_) {
     if (devtools_title_.empty()) {
       view_->SetTitle(
-          base::UTF8ToUTF16(base::StringPrintf(kTitleFormat, url.c_str())));
+          base::UTF8ToUTF16(absl::StrFormat(kTitleFormat, url.c_str())));
     }
   }
 }
@@ -1032,7 +1031,7 @@ void InspectableWebContents::DidFinishNavigation(
   // most likely bug in chromium.
   base::ReplaceFirstSubstringAfterOffset(&it->second, 0, "var chrome",
                                          "var chrome = window.chrome ");
-  auto script = base::StringPrintf(
+  auto script = absl::StrFormat(
       "%s(\"%s\")", it->second.c_str(),
       base::Uuid::GenerateRandomV4().AsLowercaseString().c_str());
   // Invoking content::DevToolsFrontendHost::SetupExtensionsAPI(frame, script);

--- a/shell/browser/ui/views/global_menu_bar_x11.cc
+++ b/shell/browser/ui/views/global_menu_bar_x11.cc
@@ -8,11 +8,11 @@
 #include <glib-object.h>
 
 #include "base/functional/bind.h"
-#include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/ui/electron_menu_model.h"
 #include "shell/browser/ui/views/global_menu_bar_registrar_x11.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
 #include "ui/aura/window.h"
 #include "ui/aura/window_tree_host.h"
 #include "ui/base/accelerators/menu_label_accelerator_util_linux.h"
@@ -166,7 +166,7 @@ std::string GetMenuModelStatus(ElectronMenuModel* model) {
     int status = model->GetTypeAt(i) | (model->IsVisibleAt(i) << 3) |
                  (model->IsEnabledAt(i) << 4) |
                  (model->IsItemCheckedAt(i) << 5);
-    ret += base::StringPrintf(
+    ret += absl::StrFormat(
         "%s-%X\n", base::UTF16ToUTF8(model->GetLabelAt(i)).c_str(), status);
   }
   return ret;
@@ -194,8 +194,7 @@ GlobalMenuBarX11::~GlobalMenuBarX11() {
 
 // static
 std::string GlobalMenuBarX11::GetPathForWindow(x11::Window window) {
-  return base::StringPrintf("/com/canonical/menu/%X",
-                            static_cast<uint>(window));
+  return absl::StrFormat("/com/canonical/menu/%X", static_cast<uint>(window));
 }
 
 void GlobalMenuBarX11::SetMenu(ElectronMenuModel* menu_model) {

--- a/shell/common/application_info.cc
+++ b/shell/common/application_info.cc
@@ -6,12 +6,12 @@
 
 #include "base/i18n/rtl.h"
 #include "base/no_destructor.h"
-#include "base/strings/stringprintf.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/common/chrome_version.h"
 #include "content/public/common/user_agent.h"
 #include "electron/electron_version.h"
 #include "shell/browser/browser.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
 
 namespace electron {
 
@@ -42,7 +42,7 @@ std::string GetApplicationUserAgent() {
     user_agent = "Chrome/" CHROME_VERSION_STRING " " ELECTRON_PRODUCT_NAME
                  "/" ELECTRON_VERSION_STRING;
   } else {
-    user_agent = base::StringPrintf(
+    user_agent = absl::StrFormat(
         "%s/%s Chrome/%s " ELECTRON_PRODUCT_NAME "/" ELECTRON_VERSION_STRING,
         name.c_str(), browser->GetVersion().c_str(), CHROME_VERSION_STRING);
   }

--- a/shell/common/color_util.cc
+++ b/shell/common/color_util.cc
@@ -7,8 +7,8 @@
 #include <algorithm>
 #include <cmath>
 
-#include "base/strings/stringprintf.h"
 #include "content/public/common/color_parser.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
 
 namespace {
 
@@ -48,12 +48,12 @@ SkColor ParseCSSColor(const std::string& color_string) {
 }
 
 std::string ToRGBHex(SkColor color) {
-  return base::StringPrintf("#%02X%02X%02X", SkColorGetR(color),
-                            SkColorGetG(color), SkColorGetB(color));
+  return absl::StrFormat("#%02X%02X%02X", SkColorGetR(color),
+                         SkColorGetG(color), SkColorGetB(color));
 }
 
 std::string ToRGBAHex(SkColor color, bool include_hash) {
-  std::string color_str = base::StringPrintf(
+  std::string color_str = absl::StrFormat(
       "%02X%02X%02X%02X", SkColorGetR(color), SkColorGetG(color),
       SkColorGetB(color), SkColorGetA(color));
   if (include_hash) {

--- a/shell/common/gin_converters/serial_port_info_converter.h
+++ b/shell/common/gin_converters/serial_port_info_converter.h
@@ -22,9 +22,9 @@ struct Converter<device::mojom::SerialPortInfoPtr> {
     if (port->display_name && !port->display_name->empty())
       dict.Set("displayName", *port->display_name);
     if (port->has_vendor_id)
-      dict.Set("vendorId", base::StringPrintf("%u", port->vendor_id));
+      dict.Set("vendorId", absl::StrFormat("%u", port->vendor_id));
     if (port->has_product_id)
-      dict.Set("productId", base::StringPrintf("%u", port->product_id));
+      dict.Set("productId", absl::StrFormat("%u", port->product_id));
     if (port->serial_number && !port->serial_number->empty())
       dict.Set("serialNumber", *port->serial_number);
 #if BUILDFLAG(IS_MAC)

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -11,7 +11,6 @@
 
 #include "base/command_line.h"
 #include "base/strings/string_split.h"
-#include "base/strings/stringprintf.h"
 #include "components/network_hints/renderer/web_prescient_networking_impl.h"
 #include "content/common/buildflags.h"
 #include "content/public/common/content_constants.h"
@@ -36,6 +35,7 @@
 #include "shell/renderer/content_settings_observer.h"
 #include "shell/renderer/electron_api_service_impl.h"
 #include "shell/renderer/electron_autofill_agent.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
 #include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
 #include "third_party/blink/public/common/associated_interfaces/associated_interface_registry.h"
 #include "third_party/blink/public/common/web_preferences/web_preferences.h"
@@ -204,8 +204,8 @@ RendererClientBase* RendererClientBase::Get() {
 void RendererClientBase::BindProcess(v8::Isolate* isolate,
                                      gin_helper::Dictionary* process,
                                      content::RenderFrame* render_frame) {
-  auto context_id = base::StringPrintf(
-      "%s-%" PRId64, renderer_client_id_.c_str(), ++next_context_id_);
+  auto context_id = absl::StrFormat("%s-%" PRId64, renderer_client_id_.c_str(),
+                                    ++next_context_id_);
 
   process->SetReadOnly("isMainFrame", render_frame->IsMainFrame());
   process->SetReadOnly("contextIsolated",


### PR DESCRIPTION
#### Description of Change

`base::StringPrintf()` is slated for removal and is currently just a pass-through to `absl::StrFormat()`.

Xref: https://issues.chromium.org/issues/40241565
Xref: https://chromium-review.googlesource.com/c/chromium/src/+/4907781

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.