### PR TITLE
docs: fix apostrophe typo "Electrons" -> "Electron's"

### DIFF
--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -182,7 +182,7 @@ dispatch errors of isolated worlds to foreign worlds.
 
 ### `webFrame.setIsolatedWorldInfo(worldId, info)`
 
-* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature. Chrome extensions reserve the range of IDs in `[1 << 20, 1 << 29)`. You can provide any integer here.
+* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electron's `contextIsolation` feature. Chrome extensions reserve the range of IDs in `[1 << 20, 1 << 29)`. You can provide any integer here.
 * `info` Object
   * `securityOrigin` string (optional) - Security origin for the isolated world.
   * `csp` string (optional) - Content Security Policy for the isolated world.

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -1,6 +1,6 @@
 # Experimental APIs
 
-Some of Electrons APIs are tagged with `_Experimental_` in the documentation.
+Some of Electron's APIs are tagged with `_Experimental_` in the documentation.
 This tag indicates that the API may not be considered stable and the API may
 be removed or modified more frequently than other APIs with less warning.
 


### PR DESCRIPTION
#### Description of Change

Let's fast-track this urgent fix.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.