### PR TITLE
docs: capitalize POSIX and Windows correctly

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -416,7 +416,7 @@ Returns:
     * `launch-failed` - Process never successfully launched
     * `integrity-failure` - Windows code integrity checks failed
   * `exitCode` number - The exit code for the process
-      (e.g. status from waitpid if on posix, from GetExitCodeProcess on Windows).
+      (e.g. status from waitpid if on POSIX, from GetExitCodeProcess on Windows).
   * `serviceName` string (optional) - The non-localized name of the process.
   * `name` string (optional) - The name of the process.
     Examples for utility: `Audio Service`, `Content Decryption Module Service`, `Network Service`, `Video Capture`, etc.

--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -38,7 +38,7 @@ Without `*` prefix the URL has to match exactly.
 
 ### --disable-ntlm-v2
 
-Disables NTLM v2 for posix platforms, no effect elsewhere.
+Disables NTLM v2 for POSIX platforms, no effect elsewhere.
 
 ### --disable-http-cache
 

--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -36,7 +36,7 @@ Open the given file in the desktop's default manner.
 
 ### `shell.openExternal(url[, options])`
 
-* `url` string - Max 2081 characters on windows.
+* `url` string - Max 2081 characters on Windows.
 * `options` Object (optional)
   * `activate` boolean (optional) _macOS_ - `true` to bring the opened application to the foreground. The default is `true`.
   * `workingDirectory` string (optional) _Windows_ - The working directory.

--- a/docs/api/utility-process.md
+++ b/docs/api/utility-process.md
@@ -147,7 +147,7 @@ child process terminates.
 Returns:
 
 * `code` number - Contains the exit code for
-the process obtained from waitpid on POSIX, or GetExitCodeProcess on windows.
+the process obtained from waitpid on POSIX, or GetExitCodeProcess on Windows.
 
 Emitted after the child process ends.
 

--- a/docs/api/utility-process.md
+++ b/docs/api/utility-process.md
@@ -147,7 +147,7 @@ child process terminates.
 Returns:
 
 * `code` number - Contains the exit code for
-the process obtained from waitpid on posix, or GetExitCodeProcess on windows.
+the process obtained from waitpid on POSIX, or GetExitCodeProcess on windows.
 
 Emitted after the child process ends.
 


### PR DESCRIPTION
#### Description of Change

Just a quick capitalization fix in the docs.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.