### PR TITLE
fix: ftbfs when including simdjson in Node.js

### DIFF
--- a/patches/node/.patches
+++ b/patches/node/.patches
@@ -42,3 +42,4 @@ build_restore_clang_as_default_compiler_on_macos.patch
 fix_-wextra-semi_errors_in_nghttp2_helper_h.patch
 fix_remove_harmony-import-assertions_from_node_cc.patch
 win_almost_fix_race_detecting_esrch_in_uv_kill.patch
+chore_disable_deprecation_ftbfs_in_simdjson_header.patch

--- a/patches/node/chore_disable_deprecation_ftbfs_in_simdjson_header.patch
+++ b/patches/node/chore_disable_deprecation_ftbfs_in_simdjson_header.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Charles Kerr <charles@charleskerr.com>
+Date: Mon, 4 Nov 2024 17:40:17 -0600
+Subject: chore: disable deprecation ftbfs in simdjson header
+
+Without this patch, building with simdjson fails with
+
+> error: identifier '_padded' preceded by whitespace in a literal operator
+> declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
+
+This patch can be removed once this is fixed upstream in simdjson.
+
+diff --git a/deps/simdjson/simdjson.h b/deps/simdjson/simdjson.h
+index ddb6f2e4e0a6edd23d5e16db07bc4bb18974d4aa..533dfea4d5fd3c7f6f7fdf0ea525479b11634fd3 100644
+--- a/deps/simdjson/simdjson.h
++++ b/deps/simdjson/simdjson.h
+@@ -3650,12 +3650,17 @@ inline std::ostream& operator<<(std::ostream& out, simdjson_result<padded_string
+ 
+ } // namespace simdjson
+ 
++#pragma clang diagnostic push
++#pragma clang diagnostic ignored "-Wdeprecated-literal-operator"
++
+ // This is deliberately outside of simdjson so that people get it without having to use the namespace
+ inline simdjson::padded_string operator "" _padded(const char *str, size_t len);
+ #ifdef __cpp_char8_t
+ inline simdjson::padded_string operator "" _padded(const char8_t *str, size_t len);
+ #endif
+ 
++#pragma clang diagnostic pop
++
+ namespace simdjson {
+ namespace internal {
+ 
+@@ -4033,6 +4038,9 @@ inline simdjson_result<padded_string> padded_string::load(std::string_view filen
+ 
+ } // namespace simdjson
+ 
++#pragma clang diagnostic push
++#pragma clang diagnostic ignored "-Wdeprecated-literal-operator"
++
+ inline simdjson::padded_string operator "" _padded(const char *str, size_t len) {
+   return simdjson::padded_string(str, len);
+ }
+@@ -4041,6 +4049,8 @@ inline simdjson::padded_string operator "" _padded(const char8_t *str, size_t le
+   return simdjson::padded_string(reinterpret_cast<const char8_t *>(str), len);
+ }
+ #endif
++#pragma clang diagnostic pop
++
+ #endif // SIMDJSON_PADDED_STRING_INL_H
+ /* end file simdjson/padded_string-inl.h */
+ /* skipped duplicate #include "simdjson/padded_string_view.h" */
+@@ -118280,4 +118290,4 @@ namespace simdjson {
+ /* end file simdjson/ondemand.h */
+ 
+ #endif // SIMDJSON_H
+-/* end file simdjson.h */
++/* end file simdjson.h */
+\ No newline at end of file


### PR DESCRIPTION
#### Description of Change

Fixes new `-Wdeprecated-literal-operator` simdjson.h warning that breaks the build in `main` due to `-Werror`.

Xref: https://github.com/electron/electron/pull/44281
Xref: https://github.com/electron/electron/pull/44360

CC @jkleinsc 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none