### PR TITLE
chore: remove unused gin::Converter<char[]>::ToV8(isolate, const char*)

### DIFF
--- a/shell/common/gin_converters/std_converter.h
+++ b/shell/common/gin_converters/std_converter.h
@@ -54,14 +54,6 @@ struct Converter<std::nullptr_t> {
   }
 };
 
-template <>
-struct Converter<char[]> {
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const char* val) {
-    return v8::String::NewFromUtf8(isolate, val, v8::NewStringType::kNormal)
-        .ToLocalChecked();
-  }
-};
-
 template <size_t N>
 struct Converter<char[N]> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const char (&val)[N]) {


### PR DESCRIPTION
#### Description of Change

This converter is no longer needed after #44498 and #44405.

This is not just a nice small code cleanup, but is also an indicator of a nice small performance improvement: the fact that Electron builds without this converter means we're no longer passing raw C strings to V8. The string length is always known, so V8 doesn't need to check with `strlen()` anymore.

That wasn't a big bottleneck, but now it's nothing at all :slightly_smiling_face: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none