### PR TITLE
fix: destroy url loader wrapper when JS env exits

### DIFF
--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -172,7 +172,6 @@ class BufferDataSource : public mojo::DataPipeProducer::DataSource {
 
 class JSChunkedDataPipeGetter final
     : public gin::Wrappable<JSChunkedDataPipeGetter>,
-      public gin_helper::CleanedUpAtExit,
       public network::mojom::ChunkedDataPipeGetter {
  public:
   static gin::Handle<JSChunkedDataPipeGetter> Create(

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -172,6 +172,7 @@ class BufferDataSource : public mojo::DataPipeProducer::DataSource {
 
 class JSChunkedDataPipeGetter final
     : public gin::Wrappable<JSChunkedDataPipeGetter>,
+      public gin_helper::CleanedUpAtExit,
       public network::mojom::ChunkedDataPipeGetter {
  public:
   static gin::Handle<JSChunkedDataPipeGetter> Create(

--- a/shell/common/api/electron_api_url_loader.h
+++ b/shell/common/api/electron_api_url_loader.h
@@ -21,6 +21,7 @@
 #include "services/network/public/mojom/url_loader_network_service_observer.mojom.h"
 #include "services/network/public/mojom/url_response_head.mojom.h"
 #include "shell/browser/event_emitter_mixin.h"
+#include "shell/common/gin_helper/cleaned_up_at_exit.h"
 #include "url/gurl.h"
 #include "v8/include/v8-forward.h"
 
@@ -50,6 +51,7 @@ namespace electron::api {
 class SimpleURLLoaderWrapper final
     : public gin::Wrappable<SimpleURLLoaderWrapper>,
       public gin_helper::EventEmitterMixin<SimpleURLLoaderWrapper>,
+      public gin_helper::CleanedUpAtExit,
       private network::SimpleURLLoaderStreamConsumer,
       private network::mojom::URLLoaderNetworkServiceObserver {
  public:

--- a/shell/common/api/electron_api_url_loader.h
+++ b/shell/common/api/electron_api_url_loader.h
@@ -21,7 +21,6 @@
 #include "services/network/public/mojom/url_loader_network_service_observer.mojom.h"
 #include "services/network/public/mojom/url_response_head.mojom.h"
 #include "shell/browser/event_emitter_mixin.h"
-#include "shell/common/gin_helper/cleaned_up_at_exit.h"
 #include "url/gurl.h"
 #include "v8/include/v8-forward.h"
 
@@ -51,7 +50,6 @@ namespace electron::api {
 class SimpleURLLoaderWrapper final
     : public gin::Wrappable<SimpleURLLoaderWrapper>,
       public gin_helper::EventEmitterMixin<SimpleURLLoaderWrapper>,
-      public gin_helper::CleanedUpAtExit,
       private network::SimpleURLLoaderStreamConsumer,
       private network::mojom::URLLoaderNetworkServiceObserver {
  public:


### PR DESCRIPTION
#### Description of Change

Similar fix to https://github.com/electron/electron/pull/39335
For https://github.com/microsoft/vscode/issues/232564

#### Release Notes

Notes: fix crash in net api when utility process exits.