### PR TITLE
build: also lint mjs files

### DIFF
--- a/script/create-api-json.mjs
+++ b/script/create-api-json.mjs
@@ -1,4 +1,5 @@
 import { parseDocs } from '@electron/docs-parser';
+
 import { promises } from 'node:fs';
 import { resolve } from 'node:path';
 

--- a/script/lint.js
+++ b/script/lint.js
@@ -138,7 +138,7 @@ const LINTERS = [{
   key: 'javascript',
   roots: ['build', 'default_app', 'lib', 'npm', 'script', 'spec'],
   ignoreRoots: ['spec/node_modules'],
-  test: filename => filename.endsWith('.js') || filename.endsWith('.ts'),
+  test: filename => filename.endsWith('.js') || filename.endsWith('.ts') || filename.endsWith('.mjs'),
   run: async (opts, filenames) => {
     const eslint = new ESLint({
       // Do not use the lint cache on CI builds

--- a/spec/fixtures/api/pdf-reader.mjs
+++ b/spec/fixtures/api/pdf-reader.mjs
@@ -1,6 +1,6 @@
 import * as pdfjs from 'pdfjs-dist';
 
-async function getPDFDoc() {  
+async function getPDFDoc () {
   try {
     const doc = await pdfjs.getDocument(process.argv[2]).promise;
     const page = await doc.getPage(1);
@@ -11,10 +11,11 @@ async function getPDFDoc() {
       view: page.view,
       textContent: items,
       markInfo
-    }
+    };
     console.log(JSON.stringify(pdfInfo));
     process.exit();
   } catch (ex) {
+    console.error(ex);
     process.exit(1);
   }
 }

--- a/spec/fixtures/esm/import-meta/main.mjs
+++ b/spec/fixtures/esm/import-meta/main.mjs
@@ -1,8 +1,9 @@
-import { app, BrowserWindow } from 'electron'
-import { fileURLToPath } from 'node:url'
-import { dirname, join } from 'node:path';
+import { app, BrowserWindow } from 'electron';
 
-async function createWindow() {
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+async function createWindow () {
   const mainWindow = new BrowserWindow({
     show: false,
     webPreferences: {
@@ -10,9 +11,9 @@ async function createWindow() {
       sandbox: false,
       contextIsolation: false
     }
-  })
+  });
 
-  await mainWindow.loadFile('index.html')
+  await mainWindow.loadFile('index.html');
 
   const importMetaPreload = await mainWindow.webContents.executeJavaScript('window.importMetaPath');
   const expected = join(dirname(fileURLToPath(import.meta.url)), 'preload.mjs');
@@ -21,13 +22,13 @@ async function createWindow() {
 }
 
 app.whenReady().then(() => {
-  createWindow()
+  createWindow();
 
   app.on('activate', function () {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow()
-  })
-})
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
 
 app.on('window-all-closed', function () {
-  if (process.platform !== 'darwin') app.quit()
-})
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/spec/fixtures/esm/import-meta/preload.mjs
+++ b/spec/fixtures/esm/import-meta/preload.mjs
@@ -1,3 +1,3 @@
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath } from 'node:url';
 
-window.importMetaPath = fileURLToPath(import.meta.url)
+window.importMetaPath = fileURLToPath(import.meta.url);


### PR DESCRIPTION
Adds `mjs` as a lintable JS extension and fixes the lint errors that arose as a result.

Notes: none