### PR TITLE
feat: add query-session-end and improve session-end events on Windows

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -158,6 +158,11 @@ respect user's choice. You can use it if user is risking to lose data.
 
 #### Event: 'session-end' _Windows_
 
+Returns:
+
+* `event` Event
+* `reasons` string[]
+
 Emitted when system is in the process of shutting after successfully
 handling 'query-session-end' event.
 

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -148,8 +148,8 @@ remove the reference to the window and avoid using it any more.
 
 Returns:
 
-* `event` Event
-* `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
+* `event` Event<>
+  * `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
 
 Emitted when a session is about to end due to a shutdown, machine restart, or user log-off.
 Calling `event.preventDefault(`) can delay the system shutdown, though it’s generally best
@@ -164,8 +164,8 @@ refer to the [MSDN documentation](https://learn.microsoft.com/en-us/windows/win3
 
 Returns:
 
-* `event` Event
-* `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
+* `event` Event<>
+  * `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
 
 Emitted when system is in the process of shutting down after successfully handling 'query-session-end' event.
 

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -156,7 +156,9 @@ Calling `event.preventDefault(`) can delay the system shutdown, though it’s ge
 to respect the user’s choice to end the session. However, you may choose to use it if
 ending the session puts the user at risk of losing data.
 
-More about `WM_QUERYENDSESSION` message and reasons on [MSDN](https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-queryendsession).
+Unfortunately, Windows does not offer a way to differentiate between a shutdown and a reboot, meaning the 'shutdown'
+reason is triggered in both scenarios. For more details on the `WM_QUERYENDSESSION` message and its associated reasons,
+refer to the [MSDN documentation](https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-queryendsession).
 
 #### Event: 'session-end' _Windows_
 
@@ -167,7 +169,9 @@ Returns:
 
 Emitted when system is in the process of shutting down after successfully handling 'query-session-end' event.
 
-More about `WM_ENDSESSION` message and reasons on [MSDN](https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-endsession).
+Unfortunately, Windows does not offer a way to differentiate between a shutdown and a reboot, meaning the 'shutdown'
+reason is triggered in both scenarios. For more details on the `WM_ENDSESSION` message and its associated reasons,
+refer to the [MSDN documentation](https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-endsession).
 
 #### Event: 'blur'
 

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -144,35 +144,6 @@ _**Note**: There is a subtle difference between the behaviors of `window.onbefor
 Emitted when the window is closed. After you have received this event you should
 remove the reference to the window and avoid using it any more.
 
-#### Event: 'query-session-end' _Windows_
-
-Returns:
-
-* `event` Event\<\>
-  * `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
-
-Emitted when a session is about to end due to a shutdown, machine restart, or user log-off.
-Calling `event.preventDefault(`) can delay the system shutdown, though it’s generally best
-to respect the user’s choice to end the session. However, you may choose to use it if
-ending the session puts the user at risk of losing data.
-
-Unfortunately, Windows does not offer a way to differentiate between a shutdown and a reboot, meaning the 'shutdown'
-reason is triggered in both scenarios. For more details on the `WM_QUERYENDSESSION` message and its associated reasons,
-refer to the [MSDN documentation](https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-queryendsession).
-
-#### Event: 'session-end' _Windows_
-
-Returns:
-
-* `event` Event\<\>
-  * `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
-
-Emitted when system is in the process of shutting down after successfully handling 'query-session-end' event.
-
-Unfortunately, Windows does not offer a way to differentiate between a shutdown and a reboot, meaning the 'shutdown'
-reason is triggered in both scenarios. For more details on the `WM_ENDSESSION` message and its associated reasons,
-refer to the [MSDN documentation](https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-endsession).
-
 #### Event: 'blur'
 
 Returns:

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -161,7 +161,7 @@ Returns:
 
 * `event` [WindowSessionEndEvent][window-session-end-event]
 
-Emitted when system is in the process of shutting down after successfully handling 'query-session-end' event.
+Emitted when a session is about to end due to a shutdown, machine restart, or user log-off. Once this event fires, there is no way to prevent the session from ending.
 
 #### Event: 'blur'
 

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -148,7 +148,7 @@ remove the reference to the window and avoid using it any more.
 
 Returns:
 
-* `event` Event<>
+* `event` Event\<\>
   * `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
 
 Emitted when a session is about to end due to a shutdown, machine restart, or user log-off.
@@ -164,7 +164,7 @@ refer to the [MSDN documentation](https://learn.microsoft.com/en-us/windows/win3
 
 Returns:
 
-* `event` Event<>
+* `event` Event\<\>
   * `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
 
 Emitted when system is in the process of shutting down after successfully handling 'query-session-end' event.

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -149,7 +149,7 @@ remove the reference to the window and avoid using it any more.
 Returns:
 
 * `event` Event
-* `reasons` string[] - Can contain a combination of those reasons 'shutdown', 'close-app', 'critical' and 'logoff'.
+* `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
 
 Emitted when a session is about to end due to a shutdown, machine restart, or user log-off.
 Calling `event.preventDefault(`) can delay the system shutdown, though it’s generally best
@@ -165,7 +165,7 @@ refer to the [MSDN documentation](https://learn.microsoft.com/en-us/windows/win3
 Returns:
 
 * `event` Event
-* `reasons` string[] - Can contain a combination of those reasons 'shutdown', 'close-app', 'critical' and 'logoff'.
+* `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
 
 Emitted when system is in the process of shutting down after successfully handling 'query-session-end' event.
 

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -144,10 +144,22 @@ _**Note**: There is a subtle difference between the behaviors of `window.onbefor
 Emitted when the window is closed. After you have received this event you should
 remove the reference to the window and avoid using it any more.
 
+#### Event: 'query-session-end' _Windows_
+
+Returns:
+
+* `event` Event
+* `reasons` string[]
+
+Emitted when window session is going to end due to force shutdown or machine
+restart or session log off. Calling `event.preventDefault()` will delay
+system shutdown, however it's not recommended, because it's a good practice to
+respect user's choice. You can use it if user is risking to lose data.
+
 #### Event: 'session-end' _Windows_
 
-Emitted when window session is going to end due to force shutdown or machine restart
-or session log off.
+Emitted when system is in the process of shutting after successfully
+handling 'query-session-end' event.
 
 #### Event: 'blur'
 

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -149,22 +149,25 @@ remove the reference to the window and avoid using it any more.
 Returns:
 
 * `event` Event
-* `reasons` string[]
+* `reasons` string[] - Can contain a combination of those reasons 'shutdown', 'close-app', 'critical' and 'logoff'.
 
-Emitted when window session is going to end due to shutdown, machine
-restart or session log off. Calling `event.preventDefault()` will delay
-system shutdown, however it's not recommended, because it's a good practice to
-respect user's choice. You can use it if user is risking to lose data.
+Emitted when a session is about to end due to a shutdown, machine restart, or user log-off.
+Calling `event.preventDefault(`) can delay the system shutdown, though it’s generally best
+to respect the user’s choice to end the session. However, you may choose to use it if
+ending the session puts the user at risk of losing data.
+
+More about `WM_QUERYENDSESSION` message and reasons on [MSDN](https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-queryendsession).
 
 #### Event: 'session-end' _Windows_
 
 Returns:
 
 * `event` Event
-* `reasons` string[]
+* `reasons` string[] - Can contain a combination of those reasons 'shutdown', 'close-app', 'critical' and 'logoff'.
 
-Emitted when system is in the process of shutting after successfully
-handling 'query-session-end' event.
+Emitted when system is in the process of shutting down after successfully handling 'query-session-end' event.
+
+More about `WM_ENDSESSION` message and reasons on [MSDN](https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-endsession).
 
 #### Event: 'blur'
 

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -144,6 +144,25 @@ _**Note**: There is a subtle difference between the behaviors of `window.onbefor
 Emitted when the window is closed. After you have received this event you should
 remove the reference to the window and avoid using it any more.
 
+#### Event: 'query-session-end' _Windows_
+
+Returns:
+
+* `event` [WindowSessionEndEvent][window-session-end-event]
+
+Emitted when a session is about to end due to a shutdown, machine restart, or user log-off.
+Calling `event.preventDefault()` can delay the system shutdown, though it’s generally best
+to respect the user’s choice to end the session. However, you may choose to use it if
+ending the session puts the user at risk of losing data.
+
+#### Event: 'session-end' _Windows_
+
+Returns:
+
+* `event` [WindowSessionEndEvent][window-session-end-event]
+
+Emitted when system is in the process of shutting down after successfully handling 'query-session-end' event.
+
 #### Event: 'blur'
 
 Returns:
@@ -1424,3 +1443,4 @@ On Linux, the `symbolColor` is automatically calculated to have minimum accessib
 [vibrancy-docs]: https://developer.apple.com/documentation/appkit/nsvisualeffectview?preferredLanguage=objc
 [window-levels]: https://developer.apple.com/documentation/appkit/nswindow/level
 [event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter
+[window-session-end-event]:../api/structures/window-session-end-event.md

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -151,7 +151,7 @@ Returns:
 * `event` Event
 * `reasons` string[]
 
-Emitted when window session is going to end due to force shutdown or machine
+Emitted when window session is going to end due to shutdown, machine
 restart or session log off. Calling `event.preventDefault()` will delay
 system shutdown, however it's not recommended, because it's a good practice to
 respect user's choice. You can use it if user is risking to lose data.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -212,22 +212,25 @@ remove the reference to the window and avoid using it any more.
 Returns:
 
 * `event` Event
-* `reasons` string[]
+* `reasons` string[] - Can contain a combination of those reasons 'shutdown', 'close-app', 'critical' and 'logoff'.
 
-Emitted when window session is going to end due to shutdown, machine
-restart or session log off. Calling `event.preventDefault()` will delay
-system shutdown, however it's not recommended, because it's a good practice to
-respect user's choice. You can use it if user is risking to lose data.
+Emitted when a session is about to end due to a shutdown, machine restart, or user log-off.
+Calling `event.preventDefault(`) can delay the system shutdown, though it’s generally best
+to respect the user’s choice to end the session. However, you may choose to use it if
+ending the session puts the user at risk of losing data.
+
+More about `WM_QUERYENDSESSION` message and reasons on [MSDN](https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-queryendsession).
 
 #### Event: 'session-end' _Windows_
 
 Returns:
 
 * `event` Event
-* `reasons` string[]
+* `reasons` string[] - Can contain a combination of those reasons 'shutdown', 'close-app', 'critical' and 'logoff'.
 
-Emitted when system is in the process of shutting after successfully
-handling 'query-session-end' event.
+Emitted when system is in the process of shutting down after successfully handling 'query-session-end' event.
+
+More about `WM_ENDSESSION` message and reasons on [MSDN](https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-endsession).
 
 #### Event: 'unresponsive'
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -207,10 +207,27 @@ _**Note**: There is a subtle difference between the behaviors of `window.onbefor
 Emitted when the window is closed. After you have received this event you should
 remove the reference to the window and avoid using it any more.
 
+#### Event: 'query-session-end' _Windows_
+
+Returns:
+
+* `event` Event
+* `reasons` string[]
+
+Emitted when window session is going to end due to force shutdown or machine
+restart or session log off. Calling `event.preventDefault()` will delay
+system shutdown, however it's not recommended, because it's a good practice to
+respect user's choice. You can use it if user is risking to lose data.
+
 #### Event: 'session-end' _Windows_
 
-Emitted when window session is going to end due to force shutdown or machine restart
-or session log off.
+Returns:
+
+* `event` Event
+* `reasons` string[]
+
+Emitted when system is in the process of shutting after successfully
+handling 'query-session-end' event.
 
 #### Event: 'unresponsive'
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -211,8 +211,8 @@ remove the reference to the window and avoid using it any more.
 
 Returns:
 
-* `event` Event
-* `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
+* `event` Event<>
+  * `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
 
 Emitted when a session is about to end due to a shutdown, machine restart, or user log-off.
 Calling `event.preventDefault(`) can delay the system shutdown, though it’s generally best
@@ -227,8 +227,8 @@ refer to the [MSDN documentation](https://learn.microsoft.com/en-us/windows/win3
 
 Returns:
 
-* `event` Event
-* `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
+* `event` Event<>
+  * `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
 
 Emitted when system is in the process of shutting down after successfully handling 'query-session-end' event.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -224,7 +224,7 @@ Returns:
 
 * `event` [WindowSessionEndEvent][window-session-end-event]
 
-Emitted when system is in the process of shutting down after successfully handling 'query-session-end' event.
+Emitted when a session is about to end due to a shutdown, machine restart, or user log-off. Once this event fires, there is no way to prevent the session from ending.
 
 #### Event: 'unresponsive'
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -214,7 +214,7 @@ Returns:
 * `event` Event
 * `reasons` string[]
 
-Emitted when window session is going to end due to force shutdown or machine
+Emitted when window session is going to end due to shutdown, machine
 restart or session log off. Calling `event.preventDefault()` will delay
 system shutdown, however it's not recommended, because it's a good practice to
 respect user's choice. You can use it if user is risking to lose data.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -211,30 +211,20 @@ remove the reference to the window and avoid using it any more.
 
 Returns:
 
-* `event` Event\<\>
-  * `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
+* `event` [WindowSessionEndEvent][window-session-end-event]
 
 Emitted when a session is about to end due to a shutdown, machine restart, or user log-off.
 Calling `event.preventDefault()` can delay the system shutdown, though it’s generally best
 to respect the user’s choice to end the session. However, you may choose to use it if
 ending the session puts the user at risk of losing data.
 
-Unfortunately, Windows does not offer a way to differentiate between a shutdown and a reboot, meaning the 'shutdown'
-reason is triggered in both scenarios. For more details on the `WM_QUERYENDSESSION` message and its associated reasons,
-refer to the [MSDN documentation](https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-queryendsession).
-
 #### Event: 'session-end' _Windows_
 
 Returns:
 
-* `event` Event\<\>
-  * `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
+* `event` [WindowSessionEndEvent][window-session-end-event]
 
 Emitted when system is in the process of shutting down after successfully handling 'query-session-end' event.
-
-Unfortunately, Windows does not offer a way to differentiate between a shutdown and a reboot, meaning the 'shutdown'
-reason is triggered in both scenarios. For more details on the `WM_ENDSESSION` message and its associated reasons,
-refer to the [MSDN documentation](https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-endsession).
 
 #### Event: 'unresponsive'
 
@@ -1692,3 +1682,4 @@ On Linux, the `symbolColor` is automatically calculated to have minimum accessib
 [vibrancy-docs]: https://developer.apple.com/documentation/appkit/nsvisualeffectview?preferredLanguage=objc
 [window-levels]: https://developer.apple.com/documentation/appkit/nswindow/level
 [event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter
+[window-session-end-event]:../api/structures/window-session-end-event.md

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -219,7 +219,9 @@ Calling `event.preventDefault(`) can delay the system shutdown, though it’s ge
 to respect the user’s choice to end the session. However, you may choose to use it if
 ending the session puts the user at risk of losing data.
 
-More about `WM_QUERYENDSESSION` message and reasons on [MSDN](https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-queryendsession).
+Unfortunately, Windows does not offer a way to differentiate between a shutdown and a reboot, meaning the 'shutdown'
+reason is triggered in both scenarios. For more details on the `WM_QUERYENDSESSION` message and its associated reasons,
+refer to the [MSDN documentation](https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-queryendsession).
 
 #### Event: 'session-end' _Windows_
 
@@ -230,7 +232,9 @@ Returns:
 
 Emitted when system is in the process of shutting down after successfully handling 'query-session-end' event.
 
-More about `WM_ENDSESSION` message and reasons on [MSDN](https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-endsession).
+Unfortunately, Windows does not offer a way to differentiate between a shutdown and a reboot, meaning the 'shutdown'
+reason is triggered in both scenarios. For more details on the `WM_ENDSESSION` message and its associated reasons,
+refer to the [MSDN documentation](https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-endsession).
 
 #### Event: 'unresponsive'
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -215,7 +215,7 @@ Returns:
   * `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
 
 Emitted when a session is about to end due to a shutdown, machine restart, or user log-off.
-Calling `event.preventDefault(`) can delay the system shutdown, though it’s generally best
+Calling `event.preventDefault()` can delay the system shutdown, though it’s generally best
 to respect the user’s choice to end the session. However, you may choose to use it if
 ending the session puts the user at risk of losing data.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -211,7 +211,7 @@ remove the reference to the window and avoid using it any more.
 
 Returns:
 
-* `event` Event<>
+* `event` Event\<\>
   * `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
 
 Emitted when a session is about to end due to a shutdown, machine restart, or user log-off.
@@ -227,7 +227,7 @@ refer to the [MSDN documentation](https://learn.microsoft.com/en-us/windows/win3
 
 Returns:
 
-* `event` Event<>
+* `event` Event\<\>
   * `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
 
 Emitted when system is in the process of shutting down after successfully handling 'query-session-end' event.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -212,7 +212,7 @@ remove the reference to the window and avoid using it any more.
 Returns:
 
 * `event` Event
-* `reasons` string[] - Can contain a combination of those reasons 'shutdown', 'close-app', 'critical' and 'logoff'.
+* `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
 
 Emitted when a session is about to end due to a shutdown, machine restart, or user log-off.
 Calling `event.preventDefault(`) can delay the system shutdown, though it’s generally best
@@ -228,7 +228,7 @@ refer to the [MSDN documentation](https://learn.microsoft.com/en-us/windows/win3
 Returns:
 
 * `event` Event
-* `reasons` string[] - Can contain a combination of those reasons 'shutdown', 'close-app', 'critical' and 'logoff'.
+* `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
 
 Emitted when system is in the process of shutting down after successfully handling 'query-session-end' event.
 

--- a/docs/api/structures/window-session-end-event.md
+++ b/docs/api/structures/window-session-end-event.md
@@ -1,0 +1,7 @@
+# WindowSessionEndEvent Object extends `Event`
+
+* `reasons` string[] - List of reasons for shutdown. Can be 'shutdown', 'close-app', 'critical', or 'logoff'.
+
+Unfortunately, Windows does not offer a way to differentiate between a shutdown and a reboot, meaning the 'shutdown'
+reason is triggered in both scenarios. For more details on the `WM_ENDSESSION` message and its associated reasons,
+refer to the [MSDN documentation](https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-endsession).

--- a/docs/tutorial/multithreading.md
+++ b/docs/tutorial/multithreading.md
@@ -42,7 +42,7 @@ safe.
 The only way to load a native module safely for now, is to make sure the app
 loads no native modules after the Web Workers get started.
 
-```js @ts-expect-error=[1]
+```js
 process.dlopen = () => {
   throw new Error('Load native module is not safe')
 }

--- a/docs/tutorial/multithreading.md
+++ b/docs/tutorial/multithreading.md
@@ -42,7 +42,7 @@ safe.
 The only way to load a native module safely for now, is to make sure the app
 loads no native modules after the Web Workers get started.
 
-```js
+```js @ts-expect-error=[1]
 process.dlopen = () => {
   throw new Error('Load native module is not safe')
 }

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -151,6 +151,7 @@ auto_filenames = {
     "docs/api/structures/web-request-filter.md",
     "docs/api/structures/web-source.md",
     "docs/api/structures/window-open-handler-response.md",
+    "docs/api/structures/window-session-end-event.md",
   ]
 
   sandbox_bundle_deps = [

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -184,8 +184,8 @@ void BaseWindow::OnWindowQueryEndSession(const std::vector<std::string> reason,
   }
 }
 
-void BaseWindow::OnWindowEndSession() {
-  Emit("session-end");
+void BaseWindow::OnWindowEndSession(const std::vector<std::string> reason) {
+  Emit("session-end", reason);
 }
 
 void BaseWindow::OnWindowBlur() {

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -179,13 +179,33 @@ void BaseWindow::OnWindowClosed() {
 
 void BaseWindow::OnWindowQueryEndSession(const std::vector<std::string>& reasons,
                                          bool* prevent_default) {
-  if (Emit("query-session-end", reasons)) {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+
+  gin::Handle<gin_helper::internal::Event> event =
+      gin_helper::internal::Event::New(isolate);
+  v8::Local<v8::Object> event_object = event.ToV8().As<v8::Object>();
+
+  gin::Dictionary dict(isolate, event_object);
+  dict.Set("reasons", reasons);
+
+  EmitWithoutEvent("query-session-end", event);
+  if (event->GetDefaultPrevented()) {
     *prevent_default = true;
   }
 }
 
 void BaseWindow::OnWindowEndSession(const std::vector<std::string>& reasons) {
-  Emit("session-end", reasons);
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+
+  gin::Handle<gin_helper::internal::Event> event = gin_helper::internal::Event::New(isolate);
+  v8::Local<v8::Object> event_object = event.ToV8().As<v8::Object>();
+
+  gin::Dictionary dict(isolate, event_object);
+  dict.Set("reasons", reasons);
+
+  EmitWithoutEvent("session-end", event);
 }
 
 void BaseWindow::OnWindowBlur() {

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -177,8 +177,9 @@ void BaseWindow::OnWindowClosed() {
       FROM_HERE, GetDestroyClosure());
 }
 
-void BaseWindow::OnWindowQueryEndSession(const std::vector<std::string>& reasons,
-                                         bool* prevent_default) {
+void BaseWindow::OnWindowQueryEndSession(
+    const std::vector<std::string>& reasons,
+    bool* prevent_default) {
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
 
@@ -199,7 +200,8 @@ void BaseWindow::OnWindowEndSession(const std::vector<std::string>& reasons) {
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
 
-  gin::Handle<gin_helper::internal::Event> event = gin_helper::internal::Event::New(isolate);
+  gin::Handle<gin_helper::internal::Event> event =
+      gin_helper::internal::Event::New(isolate);
   v8::Local<v8::Object> event_object = event.ToV8().As<v8::Object>();
 
   gin::Dictionary dict(isolate, event_object);

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -190,7 +190,7 @@ void BaseWindow::OnWindowQueryEndSession(
   gin::Dictionary dict(isolate, event_object);
   dict.Set("reasons", reasons);
 
-  EmitWithEvent("query-session-end", event);
+  EmitWithoutEvent("query-session-end", event);
   if (event->GetDefaultPrevented()) {
     *prevent_default = true;
   }
@@ -207,7 +207,7 @@ void BaseWindow::OnWindowEndSession(const std::vector<std::string>& reasons) {
   gin::Dictionary dict(isolate, event_object);
   dict.Set("reasons", reasons);
 
-  EmitWithEvent("session-end", event);
+  EmitWithoutEvent("session-end", event);
 }
 
 void BaseWindow::OnWindowBlur() {

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -177,6 +177,13 @@ void BaseWindow::OnWindowClosed() {
       FROM_HERE, GetDestroyClosure());
 }
 
+void BaseWindow::OnWindowQueryEndSession(const std::vector<std::string> reason,
+                                         bool* prevent_default) {
+  if (Emit("query-session-end", reason)) {
+    *prevent_default = true;
+  }
+}
+
 void BaseWindow::OnWindowEndSession() {
   Emit("session-end");
 }

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -190,7 +190,7 @@ void BaseWindow::OnWindowQueryEndSession(
   gin::Dictionary dict(isolate, event_object);
   dict.Set("reasons", reasons);
 
-  EmitWithoutEvent("query-session-end", event);
+  EmitWithEvent("query-session-end", event);
   if (event->GetDefaultPrevented()) {
     *prevent_default = true;
   }
@@ -207,7 +207,7 @@ void BaseWindow::OnWindowEndSession(const std::vector<std::string>& reasons) {
   gin::Dictionary dict(isolate, event_object);
   dict.Set("reasons", reasons);
 
-  EmitWithoutEvent("session-end", event);
+  EmitWithEvent("session-end", event);
 }
 
 void BaseWindow::OnWindowBlur() {

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -177,15 +177,15 @@ void BaseWindow::OnWindowClosed() {
       FROM_HERE, GetDestroyClosure());
 }
 
-void BaseWindow::OnWindowQueryEndSession(const std::vector<std::string> reason,
+void BaseWindow::OnWindowQueryEndSession(const std::vector<std::string> reasons,
                                          bool* prevent_default) {
-  if (Emit("query-session-end", reason)) {
+  if (Emit("query-session-end", reasons)) {
     *prevent_default = true;
   }
 }
 
-void BaseWindow::OnWindowEndSession(const std::vector<std::string> reason) {
-  Emit("session-end", reason);
+void BaseWindow::OnWindowEndSession(const std::vector<std::string> reasons) {
+  Emit("session-end", reasons);
 }
 
 void BaseWindow::OnWindowBlur() {

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -177,14 +177,14 @@ void BaseWindow::OnWindowClosed() {
       FROM_HERE, GetDestroyClosure());
 }
 
-void BaseWindow::OnWindowQueryEndSession(const std::vector<std::string> reasons,
+void BaseWindow::OnWindowQueryEndSession(const std::vector<std::string>& reasons,
                                          bool* prevent_default) {
   if (Emit("query-session-end", reasons)) {
     *prevent_default = true;
   }
 }
 
-void BaseWindow::OnWindowEndSession(const std::vector<std::string> reasons) {
+void BaseWindow::OnWindowEndSession(const std::vector<std::string>& reasons) {
   Emit("session-end", reasons);
 }
 

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -57,9 +57,9 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   // NativeWindowObserver:
   void WillCloseWindow(bool* prevent_default) override;
   void OnWindowClosed() override;
-  void OnWindowQueryEndSession(const std::vector<std::string> reason,
+  void OnWindowQueryEndSession(const std::vector<std::string> reasons,
                                bool* prevent_default) override;
-  void OnWindowEndSession(const std::vector<std::string> reason) override;
+  void OnWindowEndSession(const std::vector<std::string> reasons) override;
   void OnWindowBlur() override;
   void OnWindowFocus() override;
   void OnWindowShow() override;

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -59,7 +59,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void OnWindowClosed() override;
   void OnWindowQueryEndSession(const std::vector<std::string> reason,
                                bool* prevent_default) override;
-  void OnWindowEndSession() override;
+  void OnWindowEndSession(const std::vector<std::string> reason) override;
   void OnWindowBlur() override;
   void OnWindowFocus() override;
   void OnWindowShow() override;

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -57,9 +57,9 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   // NativeWindowObserver:
   void WillCloseWindow(bool* prevent_default) override;
   void OnWindowClosed() override;
-  void OnWindowQueryEndSession(const std::vector<std::string> reasons,
+  void OnWindowQueryEndSession(const std::vector<std::string>& reasons,
                                bool* prevent_default) override;
-  void OnWindowEndSession(const std::vector<std::string> reasons) override;
+  void OnWindowEndSession(const std::vector<std::string>& reasons) override;
   void OnWindowBlur() override;
   void OnWindowFocus() override;
   void OnWindowShow() override;

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -57,6 +57,8 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   // NativeWindowObserver:
   void WillCloseWindow(bool* prevent_default) override;
   void OnWindowClosed() override;
+  void OnWindowQueryEndSession(const std::vector<std::string> reason,
+                               bool* prevent_default) override;
   void OnWindowEndSession() override;
   void OnWindowBlur() override;
   void OnWindowFocus() override;

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -532,6 +532,13 @@ void NativeWindow::NotifyWindowClosed() {
   WindowList::RemoveWindow(this);
 }
 
+void NativeWindow::NotifyWindowQueryEndSession(
+    const std::vector<std::string> reason,
+    bool* prevent_default) {
+  for (NativeWindowObserver& observer : observers_)
+    observer.OnWindowQueryEndSession(reason, prevent_default);
+}
+
 void NativeWindow::NotifyWindowEndSession() {
   for (NativeWindowObserver& observer : observers_)
     observer.OnWindowEndSession();

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -533,16 +533,16 @@ void NativeWindow::NotifyWindowClosed() {
 }
 
 void NativeWindow::NotifyWindowQueryEndSession(
-    const std::vector<std::string> reason,
+    const std::vector<std::string> reasons,
     bool* prevent_default) {
   for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowQueryEndSession(reason, prevent_default);
+    observer.OnWindowQueryEndSession(reasons, prevent_default);
 }
 
 void NativeWindow::NotifyWindowEndSession(
-    const std::vector<std::string> reason) {
+    const std::vector<std::string> reasons) {
   for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowEndSession(reason);
+    observer.OnWindowEndSession(reasons);
 }
 
 void NativeWindow::NotifyWindowBlur() {

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -539,9 +539,10 @@ void NativeWindow::NotifyWindowQueryEndSession(
     observer.OnWindowQueryEndSession(reason, prevent_default);
 }
 
-void NativeWindow::NotifyWindowEndSession() {
+void NativeWindow::NotifyWindowEndSession(
+    const std::vector<std::string> reason) {
   for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowEndSession();
+    observer.OnWindowEndSession(reason);
 }
 
 void NativeWindow::NotifyWindowBlur() {

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -533,14 +533,14 @@ void NativeWindow::NotifyWindowClosed() {
 }
 
 void NativeWindow::NotifyWindowQueryEndSession(
-    const std::vector<std::string> reasons,
+    const std::vector<std::string>& reasons,
     bool* prevent_default) {
   for (NativeWindowObserver& observer : observers_)
     observer.OnWindowQueryEndSession(reasons, prevent_default);
 }
 
 void NativeWindow::NotifyWindowEndSession(
-    const std::vector<std::string> reasons) {
+    const std::vector<std::string>& reasons) {
   for (NativeWindowObserver& observer : observers_)
     observer.OnWindowEndSession(reasons);
 }

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -301,6 +301,8 @@ class NativeWindow : public base::SupportsUserData,
   // related notifications.
   void NotifyWindowRequestPreferredWidth(int* width);
   void NotifyWindowCloseButtonClicked();
+  void NotifyWindowQueryEndSession(const std::vector<std::string> reason,
+                                   bool* prevent_default);
   void NotifyWindowClosed();
   void NotifyWindowEndSession();
   void NotifyWindowBlur();

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -301,10 +301,10 @@ class NativeWindow : public base::SupportsUserData,
   // related notifications.
   void NotifyWindowRequestPreferredWidth(int* width);
   void NotifyWindowCloseButtonClicked();
-  void NotifyWindowQueryEndSession(const std::vector<std::string> reasons,
-                                   bool* prevent_default);
   void NotifyWindowClosed();
-  void NotifyWindowEndSession(const std::vector<std::string> reasons);
+  void NotifyWindowQueryEndSession(const std::vector<std::string>& reasons,
+                                   bool* prevent_default);
+  void NotifyWindowEndSession(const std::vector<std::string>& reasons);
   void NotifyWindowBlur();
   void NotifyWindowFocus();
   void NotifyWindowShow();

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -304,7 +304,7 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowQueryEndSession(const std::vector<std::string> reason,
                                    bool* prevent_default);
   void NotifyWindowClosed();
-  void NotifyWindowEndSession();
+  void NotifyWindowEndSession(const std::vector<std::string> reason);
   void NotifyWindowBlur();
   void NotifyWindowFocus();
   void NotifyWindowShow();

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -301,10 +301,10 @@ class NativeWindow : public base::SupportsUserData,
   // related notifications.
   void NotifyWindowRequestPreferredWidth(int* width);
   void NotifyWindowCloseButtonClicked();
-  void NotifyWindowQueryEndSession(const std::vector<std::string> reason,
+  void NotifyWindowQueryEndSession(const std::vector<std::string> reasons,
                                    bool* prevent_default);
   void NotifyWindowClosed();
-  void NotifyWindowEndSession(const std::vector<std::string> reason);
+  void NotifyWindowEndSession(const std::vector<std::string> reasons);
   void NotifyWindowBlur();
   void NotifyWindowFocus();
   void NotifyWindowShow();

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -55,7 +55,7 @@ class NativeWindowObserver : public base::CheckedObserver {
                                        bool* prevent_default) {}
 
   // Called when Windows sends WM_ENDSESSION message
-  virtual void OnWindowEndSession() {}
+  virtual void OnWindowEndSession(const std::vector<std::string> reason) {}
 
   // Called when window loses focus.
   virtual void OnWindowBlur() {}

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -51,11 +51,11 @@ class NativeWindowObserver : public base::CheckedObserver {
   virtual void OnWindowClosed() {}
 
   // Called when Windows sends WM_QUERYENDSESSION message.
-  virtual void OnWindowQueryEndSession(const std::vector<std::string> reason,
+  virtual void OnWindowQueryEndSession(const std::vector<std::string> reasons,
                                        bool* prevent_default) {}
 
   // Called when Windows sends WM_ENDSESSION message
-  virtual void OnWindowEndSession(const std::vector<std::string> reason) {}
+  virtual void OnWindowEndSession(const std::vector<std::string> reasons) {}
 
   // Called when window loses focus.
   virtual void OnWindowBlur() {}

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -50,6 +50,10 @@ class NativeWindowObserver : public base::CheckedObserver {
   // Called when the window is closed.
   virtual void OnWindowClosed() {}
 
+  // Called when Windows sends WM_QUERYENDSESSION message.
+  virtual void OnWindowQueryEndSession(const std::vector<std::string> reason,
+                                       bool* prevent_default) {}
+
   // Called when Windows sends WM_ENDSESSION message
   virtual void OnWindowEndSession() {}
 

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -51,11 +51,11 @@ class NativeWindowObserver : public base::CheckedObserver {
   virtual void OnWindowClosed() {}
 
   // Called when Windows sends WM_QUERYENDSESSION message.
-  virtual void OnWindowQueryEndSession(const std::vector<std::string> reasons,
+  virtual void OnWindowQueryEndSession(const std::vector<std::string>& reasons,
                                        bool* prevent_default) {}
 
   // Called when Windows sends WM_ENDSESSION message
-  virtual void OnWindowEndSession(const std::vector<std::string> reasons) {}
+  virtual void OnWindowEndSession(const std::vector<std::string>& reasons) {}
 
   // Called when window loses focus.
   virtual void OnWindowBlur() {}

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -409,8 +409,8 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
     }
     case WM_QUERYENDSESSION: {
       bool prevent_default = false;
-      std::vector<std::string> reason = EndSessionToStringVec(l_param);
-      NotifyWindowQueryEndSession(reason, &prevent_default);
+      std::vector<std::string> reasons = EndSessionToStringVec(l_param);
+      NotifyWindowQueryEndSession(reasons, &prevent_default);
       // Result should be TRUE by default, otherwise WM_ENDSESSION will not be
       // fired in some cases: More:
       // https://learn.microsoft.com/en-us/windows/win32/rstmgr/guidelines-for-applications
@@ -418,9 +418,9 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       return prevent_default;
     }
     case WM_ENDSESSION: {
-      std::vector<std::string> reason = EndSessionToStringVec(l_param);
+      std::vector<std::string> reasons = EndSessionToStringVec(l_param);
       if (w_param) {
-        NotifyWindowEndSession(reason);
+        NotifyWindowEndSession(reasons);
       }
       return false;
     }

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -409,11 +409,13 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       bool prevent_default = false;
       std::vector<std::string> reason = EndSessionToStringVec(l_param);
       NotifyWindowQueryEndSession(reason, &prevent_default);
+      *result = !prevent_default;
       return prevent_default;
     }
     case WM_ENDSESSION: {
+      std::vector<std::string> reason = EndSessionToStringVec(l_param);
       if (w_param) {
-        NotifyWindowEndSession();
+        NotifyWindowEndSession(reason);
       }
       return false;
     }

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -30,8 +30,10 @@ namespace {
 // Convert Win32 WM_QUERYENDSESSIONS to strings.
 const std::vector<std::string> EndSessionToStringVec(LPARAM end_session_id) {
   std::vector<std::string> params;
-  if (end_session_id == 0)
+  if (end_session_id == 0) {
+    params.push_back("shutdown");
     return params;
+  }
 
   if (end_session_id & ENDSESSION_CLOSEAPP)
     params.push_back("close-app");

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -409,6 +409,9 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       bool prevent_default = false;
       std::vector<std::string> reason = EndSessionToStringVec(l_param);
       NotifyWindowQueryEndSession(reason, &prevent_default);
+      // Result should be TRUE by default, otherwise WM_ENDSESSION will not be
+      // fired in some cases: More:
+      // https://learn.microsoft.com/en-us/windows/win32/rstmgr/guidelines-for-applications
       *result = !prevent_default;
       return prevent_default;
     }

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -409,7 +409,6 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       bool prevent_default = false;
       std::vector<std::string> reason = EndSessionToStringVec(l_param);
       NotifyWindowQueryEndSession(reason, &prevent_default);
-      *result = !prevent_default;
       return prevent_default;
     }
     case WM_ENDSESSION: {

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -45,14 +45,6 @@ class EventEmitter : public gin_helper::Wrappable<T> {
     return EmitWithEvent(name, event, std::forward<Args>(args)...);
   }
 
-  // disable copy
-  EventEmitter(const EventEmitter&) = delete;
-  EventEmitter& operator=(const EventEmitter&) = delete;
-
- protected:
-  EventEmitter() {}
-
- private:
   // this.emit(name, event, args...);
   template <typename... Args>
   bool EmitWithEvent(const std::string_view name,
@@ -65,6 +57,13 @@ class EventEmitter : public gin_helper::Wrappable<T> {
                           std::forward<Args>(args)...);
     return event->GetDefaultPrevented();
   }
+
+  // disable copy
+  EventEmitter(const EventEmitter&) = delete;
+  EventEmitter& operator=(const EventEmitter&) = delete;
+
+ protected:
+  EventEmitter() {}
 };
 
 }  // namespace gin_helper

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -45,6 +45,25 @@ class EventEmitter : public gin_helper::Wrappable<T> {
     return EmitWithEvent(name, event, std::forward<Args>(args)...);
   }
 
+  // this.emit(name, args...);
+  template <typename... Args>
+  void EmitWithoutEvent(const std::string_view name, Args&&... args) {
+    v8::HandleScope handle_scope(isolate());
+    v8::Local<v8::Object> wrapper = GetWrapper();
+    if (wrapper.IsEmpty())
+      return;
+    gin_helper::EmitEvent(isolate(), GetWrapper(), name,
+                          std::forward<Args>(args)...);
+  }
+
+  // disable copy
+  EventEmitter(const EventEmitter&) = delete;
+  EventEmitter& operator=(const EventEmitter&) = delete;
+
+ protected:
+  EventEmitter() {}
+
+ private:
   // this.emit(name, event, args...);
   template <typename... Args>
   bool EmitWithEvent(const std::string_view name,
@@ -57,13 +76,6 @@ class EventEmitter : public gin_helper::Wrappable<T> {
                           std::forward<Args>(args)...);
     return event->GetDefaultPrevented();
   }
-
-  // disable copy
-  EventEmitter(const EventEmitter&) = delete;
-  EventEmitter& operator=(const EventEmitter&) = delete;
-
- protected:
-  EventEmitter() {}
 };
 
 }  // namespace gin_helper


### PR DESCRIPTION
#### Description of Change

Current Electron version allows to handle only `WM_ENDSESSION`, but not `WM_QUERYENDSESSION`. This cause a lot of problems while Electron app is packaged into own MSI and is a menubar/tray app. For example currently we cannot close app using Restart Manager which is used by default since Windows Installer 4.0. We have to use [util:CloseApplication](https://wixtoolset.org/docs/schema/util/closeapplication/) or call `taskkil`.

Quote from [Restart Manager guidelines for Applications](https://learn.microsoft.com/en-us/windows/win32/rstmgr/guidelines-for-applications):

> Applications running on Windows Vista and Windows Server 2008 should adhere to these guidelines to ensure that the Restart Manager can shut down and restart applications if necessary to install updates.

> GUI applications should listen for the WM_QUERYENDSESSION message and return a value of TRUE if the application is prepared to shut down and restart. If no application returns a value of FALSE, the Restart Manager sends a [WM_ENDSESSION](https://learn.microsoft.com/en-us/windows/desktop/Shutdown/wm-endsession) message with the lParam parameter set to ENDSESSION_CLOSEAPP (0x1) and the wparam parameter set to TRUE. [...] If any GUI application responds to a WM_QUERYENDSESSION message by returning a value of FALSE, the shutdown is canceled.

So to properly close GUI app we need to handle `WM_QUERYENDSESSION` properly and return `TRUE`. But for now for any unknown WM message it will cause us to return FALSE (see calling code: https://github.com/chromium/chromium/blob/134896c2d6148c6bd2f7b096b0664b1e4013cb5c/ui/views/win/hwnd_message_handler.cc#L1069).

My implementation will return TRUE by default (in case of `WM_QUERYSESSION`), so it could probably fix longstanding issues like this: https://github.com/electron/electron/issues/15880. `ev.preventDefault()` can still return old behaviour.

Also both `query-session-end` and `session-end` now return a reasons why they receiving this event, it could be `shutdown`, `close-app`, `critical` and `logoff`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `query-session-end` event and improved `session-end` events on Windows<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->