### PR TITLE
fix: segfault when moving WebContentsView between BrowserWindows

### DIFF
--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -125,6 +125,15 @@ struct Converter<views::FlexAllocationOrder> {
 };
 
 template <>
+struct Converter<electron::api::View> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     electron::api::View* out) {
+    return gin::ConvertFromV8(isolate, val, &out);
+  }
+};
+
+template <>
 struct Converter<views::SizeBound> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const views::SizeBound& in) {
@@ -386,6 +395,21 @@ void View::OnViewBoundsChanged(views::View* observed_view) {
 void View::OnViewIsDeleting(views::View* observed_view) {
   DCHECK_EQ(observed_view, view_);
   view_ = nullptr;
+}
+
+void View::OnChildViewRemoved(views::View* observed_view, views::View* child) {
+  /* Test without this fix to see if crash case works
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  auto it = std::ranges::find_if(
+      child_views_, [&](const v8::Global<v8::Object>& child_view) {
+        View current_view;
+        gin::ConvertFromV8(isolate, child_view.Get(isolate), &current_view);
+        return current_view.view()->GetID() == child->GetID();
+      });
+  if (it != child_views_.end()) {
+    child_views_.erase(it);
+  }
+  */
 }
 
 // static

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -47,6 +47,8 @@ class View : public gin_helper::EventEmitter<View>,
   // views::ViewObserver
   void OnViewBoundsChanged(views::View* observed_view) override;
   void OnViewIsDeleting(views::View* observed_view) override;
+  void OnChildViewRemoved(views::View* observed_view,
+                          views::View* child) override;
 
   views::View* view() const { return view_; }
   std::optional<int> border_radius() const { return border_radius_; }

--- a/spec/fixtures/crash-cases/webview-move-between-windows/index.js
+++ b/spec/fixtures/crash-cases/webview-move-between-windows/index.js
@@ -1,0 +1,31 @@
+const { app, BrowserWindow, WebContentsView } = require('electron');
+
+function createWindow () {
+  // Create the browser window.
+  const mainWindow = new BrowserWindow();
+  const secondaryWindow = new BrowserWindow();
+
+  const contentsView = new WebContentsView();
+  mainWindow.contentView.addChildView(contentsView);
+  mainWindow.webContents.setDevToolsWebContents(contentsView.webContents);
+  mainWindow.openDevTools();
+
+  contentsView.setBounds({
+    x: 400,
+    y: 0,
+    width: 400,
+    height: 600
+  });
+
+  setTimeout(() => {
+    secondaryWindow.contentView.addChildView(contentsView);
+    setTimeout(() => {
+      mainWindow.contentView.addChildView(contentsView);
+      app.quit();
+    }, 1000);
+  }, 1000);
+}
+
+app.whenReady().then(() => {
+  createWindow();
+});


### PR DESCRIPTION
#### Description of Change
- Fixes #44571
The root of this issue is that View was not properly accounting for children that had been removed by being moved over to another View.  This PR fixes that issue by using `OnChildViewRemoved` from `views::ViewObserver` to handle this use case.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->Fixed segfault when moving WebContentsView between BrowserWindows.
