### PR TITLE
feat: add win.preventShutdown method on Windows

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -1425,6 +1425,13 @@ On a Window with Window Controls Overlay already enabled, this method updates th
 
 On Linux, the `symbolColor` is automatically calculated to have minimum accessible contrast to the `color` if not explicitly set.
 
+### `win.preventShutdown(reason)` _Windows_
+
+* `reason` string
+
+Indicates that the system cannot be shut down and sets a reason string to be displayed
+to the user if system shutdown is initiated.
+
 [quick-look]: https://en.wikipedia.org/wiki/Quick_Look
 [vibrancy-docs]: https://developer.apple.com/documentation/appkit/nsvisualeffectview?preferredLanguage=objc
 [window-levels]: https://developer.apple.com/documentation/appkit/nswindow/level

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1663,6 +1663,13 @@ On a window with Window Controls Overlay already enabled, this method updates th
 
 On Linux, the `symbolColor` is automatically calculated to have minimum accessible contrast to the `color` if not explicitly set.
 
+### `win.preventShutdown(reason)` _Windows_
+
+* `reason` string
+
+Indicates that the system cannot be shut down and sets a reason string to be displayed
+to the user if system shutdown is initiated.
+
 [page-visibility-api]: https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
 [quick-look]: https://en.wikipedia.org/wiki/Quick_Look
 [vibrancy-docs]: https://developer.apple.com/documentation/appkit/nsvisualeffectview?preferredLanguage=objc

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -8,6 +8,9 @@
 #include <string>
 #include <utility>
 #include <vector>
+#if BUILDFLAG(IS_WIN)
+#include <winuser.h>
+#endif
 
 #include "base/containers/contains.h"
 #include "base/task/single_thread_task_runner.h"
@@ -1050,6 +1053,24 @@ void BaseWindow::SetAppDetails(const gin_helper::Dictionary& options) {
                                   relaunch_command, relaunch_display_name,
                                   window_->GetAcceleratedWidget());
 }
+
+bool BaseWindow::PreventShutdown(const std::string& reason) {
+  LONG res;
+  if (reason.length() == 0)
+    res = ShutdownBlockReasonDestroy(window_->GetAcceleratedWidget());
+  else {
+    std::wstring wreason = base::UTF8ToWide(reason);
+    res = ShutdownBlockReasonCreate(window_->GetAcceleratedWidget(),
+                                    wreason.c_str());
+  }
+
+  if (res != 0)
+    return true;
+
+  DWORD shutdown_block_error = ::GetLastError();
+  base::debug::Alias(&shutdown_block_error);
+  return false;
+}
 #endif
 
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX)
@@ -1301,6 +1322,7 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setThumbnailClip", &BaseWindow::SetThumbnailClip)
       .SetMethod("setThumbnailToolTip", &BaseWindow::SetThumbnailToolTip)
       .SetMethod("setAppDetails", &BaseWindow::SetAppDetails)
+      .SetMethod("preventShutdown", &BaseWindow::PreventShutdown)
 #endif
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX)
       .SetMethod("setTitleBarOverlay", &BaseWindow::SetTitleBarOverlay)

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -247,6 +247,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   bool SetThumbnailClip(const gfx::Rect& region);
   bool SetThumbnailToolTip(const std::string& tooltip);
   void SetAppDetails(const gin_helper::Dictionary& options);
+  bool PreventShutdown(const std::string& tooltip);
 #endif
 
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX)

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -322,6 +322,10 @@ class Browser : private WindowListObserver {
   void SetSecureKeyboardEntryEnabled(bool enabled);
 #endif
 
+#if BUILDFLAG(IS_WIN)
+  void PreventShutdown(const std::wstring& name);
+#endif
+
   bool is_shutting_down() const { return is_shutdown_; }
   bool is_quitting() const { return is_quitting_; }
   bool is_ready() const { return is_ready_; }


### PR DESCRIPTION
#### Description of Change

This change allows to set and remove a reason why shutdown was temporary prevented. It usually looks like this:
<details><summary>Screenshot</summary>
<p>

![26FNWogM](https://github.com/user-attachments/assets/76029684-4901-409d-af61-6cb1153085a2)

</p>
</details> 

I did this as part of adding `WM_QUERYENDSESSION` and improving `WM_ENDSESSION` events. See #44598.

With this PR you can just call `win.preventShutdown("Saving your work...")` after creating a window. After merging #44598 you will need to prevent default behavior of `query-session-end` event:

```js
win.preventShutdown("Saving your work...")
win.on('query-session-end', (ev, reasons) => {
  ev.preventDefault()
  if (reasons.indexOf("shutdown") > -1) {
    console.log("PC is shutting down!")
  }
})

// Remove it after a while...
win.preventShutdown("")
```

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added win.preventShutdown method on Windows to set shutdown reason.<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
