### PR TITLE
fix: set kNoStdioInitialization to avoid node::PlatformInit crash

### DIFF
--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -183,11 +183,18 @@ int NodeMain() {
     const std::vector<std::string> args = ElectronCommandLine::AsUtf8();
     ExitIfContainsDisallowedFlags(args);
 
+    uint64_t process_flags =
+        node::ProcessInitializationFlags::kNoInitializeV8 |
+        node::ProcessInitializationFlags::kNoInitializeNodeV8Platform;
+
+#if BUILDFLAG(IS_WIN)
+    process_flags |= node::ProcessInitializationFlags::kNoStdioInitialization;
+#endif
+
     std::unique_ptr<node::InitializationResult> result =
         node::InitializeOncePerProcess(
-            args,
-            {node::ProcessInitializationFlags::kNoInitializeV8,
-             node::ProcessInitializationFlags::kNoInitializeNodeV8Platform});
+            args, static_cast<node::ProcessInitializationFlags::Flags>(
+                      process_flags));
 
     for (const std::string& error : result->errors())
       fprintf(stderr, "%s: %s\n", args[0].c_str(), error.c_str());

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -556,6 +556,10 @@ void NodeBindings::Initialize(v8::Local<v8::Context> context) {
       node::ProcessInitializationFlags::kNoInitializeV8 |
       node::ProcessInitializationFlags::kNoInitializeNodeV8Platform;
 
+#if BUILDFLAG(IS_WIN)
+  process_flags |= node::ProcessInitializationFlags::kNoStdioInitialization;
+#endif
+
   // We do not want the child processes spawned from the utility process
   // to inherit the custom stdio handles created for the parent.
   if (browser_env_ != BrowserEnvironment::kUtility)


### PR DESCRIPTION
node::InitializeOncePerProcess opens nul devices to replace stdio by default in Electron GUI applications. Disable this feature to avoid electron apps crash on Windows platforms when nul devices are disabled.

issue: https://github.com/electron/electron/issues/44616

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: add node initializaiton flag kNoStdioInitialization to avoid node::PlatformInit crash during node::InitializeOncePerProcess
