### PR TITLE
fix: WCO buttons hidden on Linux in fullscreen

### DIFF
--- a/shell/browser/ui/views/opaque_frame_view.cc
+++ b/shell/browser/ui/views/opaque_frame_view.cc
@@ -255,14 +255,17 @@ void OpaqueFrameView::LayoutWindowControls() {
   buttons_not_shown.push_back(views::FrameButton::kMinimize);
   buttons_not_shown.push_back(views::FrameButton::kClose);
 
-  for (const auto& button : leading_buttons_) {
-    ConfigureButton(button, ALIGN_LEADING);
-    std::erase(buttons_not_shown, button);
-  }
+  // We do not want to show the buttons in fullscreen mode.
+  if (!frame()->IsFullscreen()) {
+    for (const auto& button : leading_buttons_) {
+      ConfigureButton(button, ALIGN_LEADING);
+      std::erase(buttons_not_shown, button);
+    }
 
-  for (const auto& button : base::Reversed(trailing_buttons_)) {
-    ConfigureButton(button, ALIGN_TRAILING);
-    std::erase(buttons_not_shown, button);
+    for (const auto& button : base::Reversed(trailing_buttons_)) {
+      ConfigureButton(button, ALIGN_TRAILING);
+      std::erase(buttons_not_shown, button);
+    }
   }
 
   for (const auto& button_id : buttons_not_shown)
@@ -401,8 +404,7 @@ void OpaqueFrameView::ConfigureButton(views::FrameButton button_id,
                                       ButtonAlignment alignment) {
   switch (button_id) {
     case views::FrameButton::kMinimize: {
-      bool can_minimize = true;  // delegate_->CanMinimize();
-      if (can_minimize) {
+      if (window()->IsMinimizable()) {
         minimize_button_->SetVisible(true);
         SetBoundsForButton(button_id, minimize_button_, alignment);
       } else {
@@ -411,8 +413,7 @@ void OpaqueFrameView::ConfigureButton(views::FrameButton button_id,
       break;
     }
     case views::FrameButton::kMaximize: {
-      bool can_maximize = true;  // delegate_->CanMaximize();
-      if (can_maximize) {
+      if (window()->IsMaximizable()) {
         // When the window is restored, we show a maximized button; otherwise,
         // we show a restore button.
         bool is_restored = !window()->IsMaximized() && !window()->IsMinimized();
@@ -430,8 +431,12 @@ void OpaqueFrameView::ConfigureButton(views::FrameButton button_id,
       break;
     }
     case views::FrameButton::kClose: {
-      close_button_->SetVisible(true);
-      SetBoundsForButton(button_id, close_button_, alignment);
+      if (window()->IsClosable()) {
+        close_button_->SetVisible(true);
+        SetBoundsForButton(button_id, close_button_, alignment);
+      } else {
+        HideButton(button_id);
+      }
       break;
     }
   }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/44569.

Fixes an issue where the WCO buttons were hidden on Linux in  fullscreen mode
but not on Windows or macOS. The Windows behavior is the expected one, so this
commit makes the Linux behavior consistent.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the windows control overlay was unexpectedly visible in fullscreen on Linux.
