### PR TITLE
ci: remove from issue triage on issue transferred

### DIFF
--- a/.github/workflows/issue-transferred.yml
+++ b/.github/workflows/issue-transferred.yml
@@ -1,0 +1,24 @@
+name: Issue Transferred
+
+on:
+  issues:
+    types: [transferred]
+
+permissions: {}
+
+jobs:
+  issue-transferred:
+    name: Issue Transferred
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        uses: electron/github-app-auth-action@384fd19694fe7b6dcc9a684746c6976ad78228ae # v1.1.1
+        id: generate-token
+        with:
+          creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
+          org: electron
+      - name: Remove from issue triage
+        uses: dsanders11/project-actions/delete-item@438b25e007c2f4efec324497fadc6402e7cc61a6 # v1.4.0
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          project-number: 90


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

If an issue is transferred to another repo, it stays on the issue triage board, so this updates our automation to remove it.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
