### PR TITLE
chore: cherry-pick 1 changes from 3-M130

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -141,3 +141,4 @@ m126-lts_reland_fix_stringview_to_crash_when_offset_length.patch
 m126-lts_protect_automation_rate_from_non-deterministic_change.patch
 m126-lts_don_t_perform_pseudo-element_ident_parsing_on_non-ascii.patch
 m130_extensions_serviceworker_skip_worker_for_isolated_world.patch
+cherry-pick-e699ac35ac6c.patch

--- a/patches/chromium/cherry-pick-e699ac35ac6c.patch
+++ b/patches/chromium/cherry-pick-e699ac35ac6c.patch
@@ -1,0 +1,104 @@
+From e699ac35ac6c565f6cc24cb98719b922a319e600 Mon Sep 17 00:00:00 2001
+From: Reilly Grant <reillyg@chromium.org>
+Date: Tue, 29 Oct 2024 22:45:33 +0000
+Subject: [PATCH] [M-130] serial: Cancel mojo::SimpleWatcher when source/sink become garbage
+
+SerialPortUnderlyingSink and SerialPortUnderlyingSource need
+prefinalizers so that when they become garbage the mojo::SimpleWatcher
+is disarmed so that it doesn't invoke its callback on a garbage object.
+
+(cherry picked from commit 8ecbee8becf25733afa6dde28c3fde6a1ee2498e)
+
+Bug: 375065084
+Change-Id: Ifc847d61fa530532783d47d5749db45091fdeb96
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5957129
+Reviewed-by: Alvin Ji <alvinji@chromium.org>
+Auto-Submit: Reilly Grant <reillyg@chromium.org>
+Commit-Queue: Alvin Ji <alvinji@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1373408}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5976472
+Commit-Queue: Reilly Grant <reillyg@chromium.org>
+Cr-Commit-Position: refs/branch-heads/6723@{#1569}
+Cr-Branched-From: 985f2961df230630f9cbd75bd6fe463009855a11-refs/heads/main@{#1356013}
+---
+
+diff --git a/third_party/blink/renderer/modules/serial/serial_port_underlying_sink.cc b/third_party/blink/renderer/modules/serial/serial_port_underlying_sink.cc
+index 6aefbb5..a469a00c 100644
+--- a/third_party/blink/renderer/modules/serial/serial_port_underlying_sink.cc
++++ b/third_party/blink/renderer/modules/serial/serial_port_underlying_sink.cc
+@@ -268,4 +268,10 @@
+   abort_handle_.Clear();
+ }
+ 
++void SerialPortUnderlyingSink::Dispose() {
++  // Ensure that `watcher_` is disarmed so that `OnHandleReady()` is not called
++  // after this object becomes garbage.
++  PipeClosed();
++}
++
+ }  // namespace blink
+diff --git a/third_party/blink/renderer/modules/serial/serial_port_underlying_sink.h b/third_party/blink/renderer/modules/serial/serial_port_underlying_sink.h
+index a32b0421..b4e664a 100644
+--- a/third_party/blink/renderer/modules/serial/serial_port_underlying_sink.h
++++ b/third_party/blink/renderer/modules/serial/serial_port_underlying_sink.h
+@@ -20,6 +20,8 @@
+ class WritableStreamDefaultController;
+ 
+ class SerialPortUnderlyingSink final : public UnderlyingSinkBase {
++  USING_PRE_FINALIZER(SerialPortUnderlyingSink, Dispose);
++
+  public:
+   SerialPortUnderlyingSink(SerialPort*, mojo::ScopedDataPipeProducerHandle);
+ 
+@@ -46,6 +48,7 @@
+   void OnFlushOrDrain();
+   void WriteData();
+   void PipeClosed();
++  void Dispose();
+ 
+   mojo::ScopedDataPipeProducerHandle data_pipe_;
+   mojo::SimpleWatcher watcher_;
+diff --git a/third_party/blink/renderer/modules/serial/serial_port_underlying_source.cc b/third_party/blink/renderer/modules/serial/serial_port_underlying_source.cc
+index 6d2911c..6753be0 100644
+--- a/third_party/blink/renderer/modules/serial/serial_port_underlying_source.cc
++++ b/third_party/blink/renderer/modules/serial/serial_port_underlying_source.cc
+@@ -224,4 +224,10 @@
+   data_pipe_.reset();
+ }
+ 
++void SerialPortUnderlyingSource::Dispose() {
++  // Ensure that `watcher_` is disarmed so that `OnHandleReady()` is not called
++  // after this object becomes garbage.
++  Close();
++}
++
+ }  // namespace blink
+diff --git a/third_party/blink/renderer/modules/serial/serial_port_underlying_source.h b/third_party/blink/renderer/modules/serial/serial_port_underlying_source.h
+index 4066e98..0de89d2d 100644
+--- a/third_party/blink/renderer/modules/serial/serial_port_underlying_source.h
++++ b/third_party/blink/renderer/modules/serial/serial_port_underlying_source.h
+@@ -12,6 +12,7 @@
+ #include "third_party/blink/renderer/bindings/core/v8/script_value.h"
+ #include "third_party/blink/renderer/core/execution_context/execution_context_lifecycle_observer.h"
+ #include "third_party/blink/renderer/core/streams/underlying_byte_source_base.h"
++#include "third_party/blink/renderer/platform/heap/prefinalizer.h"
+ 
+ namespace blink {
+ 
+@@ -20,6 +21,8 @@
+ 
+ class SerialPortUnderlyingSource : public UnderlyingByteSourceBase,
+                                    ExecutionContextLifecycleObserver {
++  USING_PRE_FINALIZER(SerialPortUnderlyingSource, Dispose);
++
+  public:
+   SerialPortUnderlyingSource(ScriptState*,
+                              SerialPort*,
+@@ -47,6 +50,7 @@
+   void OnFlush(ScriptPromiseResolver<IDLUndefined>*);
+   void PipeClosed();
+   void Close();
++  void Dispose();
+ 
+   // TODO(crbug.com/1457493) : Remove when debugging is done.
+   MojoResult invalid_data_pipe_read_result_ = MOJO_RESULT_OK;


### PR DESCRIPTION
<details>
<summary>electron/security#623 - e699ac35ac6c from chromium</summary>
[M-130] serial: Cancel mojo::SimpleWatcher when source/sink become garbage

SerialPortUnderlyingSink and SerialPortUnderlyingSource need
prefinalizers so that when they become garbage the mojo::SimpleWatcher
is disarmed so that it doesn't invoke its callback on a garbage object.

(cherry picked from commit 8ecbee8becf25733afa6dde28c3fde6a1ee2498e)

Bug: 375065084
Change-Id: Ifc847d61fa530532783d47d5749db45091fdeb96
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5957129
Reviewed-by: Alvin Ji <alvinji@chromium.org>
Auto-Submit: Reilly Grant <reillyg@chromium.org>
Commit-Queue: Alvin Ji <alvinji@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1373408}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5976472
Commit-Queue: Reilly Grant <reillyg@chromium.org>
Cr-Commit-Position: refs/branch-heads/6723@{#1569}
Cr-Branched-From: 985f2961df230630f9cbd75bd6fe463009855a11-refs/heads/main@{#1356013}
</details>

Notes:
* Security: backported fix for CVE-2024-10827.