### PR TITLE
chore: cherry-pick 1 changes from 0-M131

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -138,3 +138,4 @@ cherry-pick-8c4edae5e34d.patch
 oom_add_commit_limit_available_to_oom_exception_arguments.patch
 editcontext_use_empty_control_and_selection_bounds_as_fallbacks.patch
 editcontext_return_physical_pixels_from_firstrectforcharacterrange.patch
+cherry-pick-923797bac925.patch

--- a/patches/chromium/cherry-pick-923797bac925.patch
+++ b/patches/chromium/cherry-pick-923797bac925.patch
@@ -1,0 +1,178 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
+Date: Thu, 7 Nov 2024 10:14:59 +0000
+Subject: [M131] Make GetCacheIdentifier() respect GetSkipServiceWorker().
+
+Since the current GetCacheIdentifier() ignores GetSkipServiceWorker(),
+GetCacheIdentifier() returns ServiceWorkerId even if GetSkipServiceWorker()
+is true if the ServiceWorker has a fetch handler.
+
+To make the isolated world respected as an isolated world, the cache
+identifier should not be shared with a page under a ServiceWorker control.
+
+(cherry picked from commit 75f322ad1f64c0bc56fa77ab877b48d72cdb903c)
+
+Bug: 372512079, 373263969
+Change-Id: Idd2d8900f2f720e0a4dc9837e2eb56474c60b587
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5961018
+Reviewed-by: Justin Lulejian <jlulejian@chromium.org>
+Reviewed-by: Kouhei Ueno <kouhei@chromium.org>
+Commit-Queue: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1376006}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6002191
+Auto-Submit: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
+Commit-Queue: Kouhei Ueno <kouhei@chromium.org>
+Cr-Commit-Position: refs/branch-heads/6778@{#1849}
+Cr-Branched-From: b21671ca172dcfd1566d41a770b2808e7fa7cd88-refs/heads/main@{#1368529}
+
+diff --git a/third_party/blink/renderer/core/html/parser/html_srcset_parser.cc b/third_party/blink/renderer/core/html/parser/html_srcset_parser.cc
+index ced29d21ceea8ff351fba86c6820b3b7235f0e87..6861d724f896a9ef30af8b695c70a2e8023c010d 100644
+--- a/third_party/blink/renderer/core/html/parser/html_srcset_parser.cc
++++ b/third_party/blink/renderer/core/html/parser/html_srcset_parser.cc
+@@ -418,7 +418,9 @@ static unsigned AvoidDownloadIfHigherDensityResourceIsInCache(
+     KURL url = document->CompleteURL(
+         StripLeadingAndTrailingHTMLSpaces(image_candidates[i]->Url()));
+     auto* resource = MemoryCache::Get()->ResourceForURL(
+-        url, document->Fetcher()->GetCacheIdentifier(url));
++        url,
++        document->Fetcher()->GetCacheIdentifier(url,
++                                                /*skip_service_worker=*/false));
+     if ((resource && resource->IsLoaded()) || url.ProtocolIsData()) {
+       return i;
+     }
+diff --git a/third_party/blink/renderer/core/inspector/inspector_network_agent.cc b/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
+index d16ec618d3be5b3c03bf6a60b0dd90dfa86d4b87..d507d14158671df098db5184c96bd995d58670ca 100644
+--- a/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
++++ b/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
+@@ -2440,7 +2440,8 @@ bool InspectorNetworkAgent::FetchResourceContent(Document* document,
+   Resource* cached_resource = document->Fetcher()->CachedResource(url);
+   if (!cached_resource) {
+     cached_resource = MemoryCache::Get()->ResourceForURL(
+-        url, document->Fetcher()->GetCacheIdentifier(url));
++        url, document->Fetcher()->GetCacheIdentifier(
++                 url, /*skip_service_worker=*/false));
+   }
+   if (cached_resource && InspectorPageAgent::CachedResourceContent(
+                              cached_resource, content, base64_encoded)) {
+diff --git a/third_party/blink/renderer/core/inspector/inspector_page_agent.cc b/third_party/blink/renderer/core/inspector/inspector_page_agent.cc
+index 38d4e2e3062dda4c1fcf9dcc4aad1671f3345c83..1a6525d4017e697ca98211e5f1b512f97ca6f90f 100644
+--- a/third_party/blink/renderer/core/inspector/inspector_page_agent.cc
++++ b/third_party/blink/renderer/core/inspector/inspector_page_agent.cc
+@@ -176,7 +176,8 @@ Resource* CachedResource(LocalFrame* frame,
+   Resource* cached_resource = document->Fetcher()->CachedResource(url);
+   if (!cached_resource) {
+     cached_resource = MemoryCache::Get()->ResourceForURL(
+-        url, document->Fetcher()->GetCacheIdentifier(url));
++        url, document->Fetcher()->GetCacheIdentifier(
++                 url, /*skip_service_worker=*/false));
+   }
+   if (!cached_resource)
+     cached_resource = loader->ResourceForURL(url);
+diff --git a/third_party/blink/renderer/core/loader/image_loader.cc b/third_party/blink/renderer/core/loader/image_loader.cc
+index 4b3b611c0049f3d466b4461a081a0985520c65f7..6ba9501daee0990fb6e5b16b37d778efc9db32e4 100644
+--- a/third_party/blink/renderer/core/loader/image_loader.cc
++++ b/third_party/blink/renderer/core/loader/image_loader.cc
+@@ -710,7 +710,8 @@ bool ImageLoader::ShouldLoadImmediately(const KURL& url) const {
+   // content when style recalc is over and DOM mutation is allowed again.
+   if (!url.IsNull()) {
+     Resource* resource = MemoryCache::Get()->ResourceForURL(
+-        url, element_->GetDocument().Fetcher()->GetCacheIdentifier(url));
++        url, element_->GetDocument().Fetcher()->GetCacheIdentifier(
++                 url, /*skip_service_worker=*/false));
+ 
+     if (resource && !resource->ErrorOccurred() &&
+         CanReuseFromListOfAvailableImages(
+diff --git a/third_party/blink/renderer/core/testing/internals.cc b/third_party/blink/renderer/core/testing/internals.cc
+index 70c0f282cdc81c17567494f8ba014c98e89c2ea9..b6932e0df0e156045edd677fbd069375599740c2 100644
+--- a/third_party/blink/renderer/core/testing/internals.cc
++++ b/third_party/blink/renderer/core/testing/internals.cc
+@@ -918,8 +918,8 @@ bool Internals::isLoading(const String& url) {
+   if (!document_)
+     return false;
+   const KURL full_url = document_->CompleteURL(url);
+-  const String cache_identifier =
+-      document_->Fetcher()->GetCacheIdentifier(full_url);
++  const String cache_identifier = document_->Fetcher()->GetCacheIdentifier(
++      full_url, /*skip_service_worker=*/false);
+   Resource* resource =
+       MemoryCache::Get()->ResourceForURL(full_url, cache_identifier);
+   // We check loader() here instead of isLoading(), because a multipart
+@@ -931,8 +931,8 @@ bool Internals::isLoadingFromMemoryCache(const String& url) {
+   if (!document_)
+     return false;
+   const KURL full_url = document_->CompleteURL(url);
+-  const String cache_identifier =
+-      document_->Fetcher()->GetCacheIdentifier(full_url);
++  const String cache_identifier = document_->Fetcher()->GetCacheIdentifier(
++      full_url, /*skip_service_worker=*/false);
+   Resource* resource =
+       MemoryCache::Get()->ResourceForURL(full_url, cache_identifier);
+   return resource && resource->GetStatus() == ResourceStatus::kCached;
+diff --git a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc
+index b60d9290346e4b862619db47ac0c2f5264099c71..d4b72be45ae71e3e3417b2e887766b2431cd2da6 100644
+--- a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc
++++ b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc
+@@ -973,7 +973,8 @@ Resource* ResourceFetcher::CreateResourceForStaticData(
+   if (!archive_ && factory.GetType() == ResourceType::kRaw)
+     return nullptr;
+ 
+-  const String cache_identifier = GetCacheIdentifier(url);
++  const String cache_identifier = GetCacheIdentifier(
++      url, params.GetResourceRequest().GetSkipServiceWorker());
+   // Most off-main-thread resource fetches use Resource::kRaw and don't reach
+   // this point, but off-main-thread module fetches might.
+   if (IsMainThread()) {
+@@ -1414,7 +1415,10 @@ Resource* ResourceFetcher::RequestResource(FetchParameters& params,
+         resource = nullptr;
+       } else {
+         resource = MemoryCache::Get()->ResourceForURL(
+-            params.Url(), GetCacheIdentifier(params.Url()));
++            params.Url(),
++          GetCacheIdentifier(
++              params.Url(),
++              params.GetResourceRequest().GetSkipServiceWorker()));
+       }
+       if (resource) {
+         policy = DetermineRevalidationPolicy(resource_type, params, *resource,
+@@ -1712,7 +1716,8 @@ Resource* ResourceFetcher::CreateResourceForLoading(
+     const FetchParameters& params,
+     const ResourceFactory& factory) {
+   const String cache_identifier =
+-      GetCacheIdentifier(params.GetResourceRequest().Url());
++      GetCacheIdentifier(params.GetResourceRequest().Url(),
++                         params.GetResourceRequest().GetSkipServiceWorker());
+   if (!base::FeatureList::IsEnabled(
+           blink::features::kScopeMemoryCachePerContext)) {
+     DCHECK(!IsMainThread() || params.IsStaleRevalidation() ||
+@@ -2784,9 +2789,11 @@ void ResourceFetcher::UpdateAllImageResourcePriorities() {
+   to_be_removed.clear();
+ }
+ 
+-String ResourceFetcher::GetCacheIdentifier(const KURL& url) const {
+-  if (properties_->GetControllerServiceWorkerMode() !=
+-      mojom::ControllerServiceWorkerMode::kNoController) {
++String ResourceFetcher::GetCacheIdentifier(const KURL& url,
++                                           bool skip_service_worker) const {
++  if (!skip_service_worker &&
++      properties_->GetControllerServiceWorkerMode() !=
++          mojom::ControllerServiceWorkerMode::kNoController) {
+     return String::Number(properties_->ServiceWorkerId());
+   }
+ 
+diff --git a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h
+index 4817fbba18b87e806284fa699ceddcb1da7cec5d..dc707825adf833c13881999946f13e65fc1581d7 100644
+--- a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h
++++ b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h
+@@ -278,7 +278,11 @@ class PLATFORM_EXPORT ResourceFetcher
+                          uint32_t inflight_keepalive_bytes);
+   blink::mojom::ControllerServiceWorkerMode IsControlledByServiceWorker() const;
+ 
+-  String GetCacheIdentifier(const KURL& url) const;
++  // Returns a cache identifier for MemoryCache.
++  // `url` is used for finding a matching WebBundle.
++  // If `skip_service_worker` is true, the identifier won't be a ServiceWorker's
++  // identifier to keep the cache separated.
++  String GetCacheIdentifier(const KURL& url, bool skip_service_worker) const;
+ 
+   // If `url` exists as a resource in a subresource bundle in this frame,
+   // returns its UnguessableToken; otherwise, returns std::nullopt.


### PR DESCRIPTION
<details>
<summary>electron/security#624 - 923797bac925 from chromium</summary>
[M131] Make GetCacheIdentifier() respect GetSkipServiceWorker().

Since the current GetCacheIdentifier() ignores GetSkipServiceWorker(),
GetCacheIdentifier() returns ServiceWorkerId even if GetSkipServiceWorker()
is true if the ServiceWorker has a fetch handler.

To make the isolated world respected as an isolated world, the cache
identifier should not be shared with a page under a ServiceWorker control.

(cherry picked from commit 75f322ad1f64c0bc56fa77ab877b48d72cdb903c)

Bug: 372512079, 373263969
Change-Id: Idd2d8900f2f720e0a4dc9837e2eb56474c60b587
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5961018
Reviewed-by: Justin Lulejian <jlulejian@chromium.org>
Reviewed-by: Kouhei Ueno <kouhei@chromium.org>
Commit-Queue: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1376006}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6002191
Auto-Submit: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
Commit-Queue: Kouhei Ueno <kouhei@chromium.org>
Cr-Commit-Position: refs/branch-heads/6778@{#1849}
Cr-Branched-From: b21671ca172dcfd1566d41a770b2808e7fa7cd88-refs/heads/main@{#1368529}
</details>

Notes:
* Security: backported fix for CVE-2024-11110.