### PR TITLE
chore: cherry-pick 1 changes from 0-M131

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -141,3 +141,4 @@ m126-lts_reland_fix_stringview_to_crash_when_offset_length.patch
 m126-lts_protect_automation_rate_from_non-deterministic_change.patch
 m126-lts_don_t_perform_pseudo-element_ident_parsing_on_non-ascii.patch
 m130_extensions_serviceworker_skip_worker_for_isolated_world.patch
+cherry-pick-923797bac925.patch

--- a/patches/chromium/cherry-pick-923797bac925.patch
+++ b/patches/chromium/cherry-pick-923797bac925.patch
@@ -1,0 +1,178 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
+Date: Thu, 7 Nov 2024 10:14:59 +0000
+Subject: [M131] Make GetCacheIdentifier() respect GetSkipServiceWorker().
+
+Since the current GetCacheIdentifier() ignores GetSkipServiceWorker(),
+GetCacheIdentifier() returns ServiceWorkerId even if GetSkipServiceWorker()
+is true if the ServiceWorker has a fetch handler.
+
+To make the isolated world respected as an isolated world, the cache
+identifier should not be shared with a page under a ServiceWorker control.
+
+(cherry picked from commit 75f322ad1f64c0bc56fa77ab877b48d72cdb903c)
+
+Bug: 372512079, 373263969
+Change-Id: Idd2d8900f2f720e0a4dc9837e2eb56474c60b587
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5961018
+Reviewed-by: Justin Lulejian <jlulejian@chromium.org>
+Reviewed-by: Kouhei Ueno <kouhei@chromium.org>
+Commit-Queue: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1376006}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6002191
+Auto-Submit: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
+Commit-Queue: Kouhei Ueno <kouhei@chromium.org>
+Cr-Commit-Position: refs/branch-heads/6778@{#1849}
+Cr-Branched-From: b21671ca172dcfd1566d41a770b2808e7fa7cd88-refs/heads/main@{#1368529}
+
+diff --git a/third_party/blink/renderer/core/html/parser/html_srcset_parser.cc b/third_party/blink/renderer/core/html/parser/html_srcset_parser.cc
+index 05a51f69a45a051f533db57ebf18a49e7295fab5..c7310f2178900b8d78724e44b176f79d1396cc47 100644
+--- a/third_party/blink/renderer/core/html/parser/html_srcset_parser.cc
++++ b/third_party/blink/renderer/core/html/parser/html_srcset_parser.cc
+@@ -413,7 +413,9 @@ static unsigned AvoidDownloadIfHigherDensityResourceIsInCache(
+     KURL url = document->CompleteURL(
+         StripLeadingAndTrailingHTMLSpaces(image_candidates[i]->Url()));
+     auto* resource = MemoryCache::Get()->ResourceForURL(
+-        url, document->Fetcher()->GetCacheIdentifier(url));
++        url,
++        document->Fetcher()->GetCacheIdentifier(url,
++                                                /*skip_service_worker=*/false));
+     if ((resource && resource->IsLoaded()) || url.ProtocolIsData()) {
+       return i;
+     }
+diff --git a/third_party/blink/renderer/core/inspector/inspector_network_agent.cc b/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
+index 8ec24db596ab9b3c93d2f6d691fa0bcd87006307..f5937485e4a02ed190e16077356ccde448e0c9ce 100644
+--- a/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
++++ b/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
+@@ -2406,7 +2406,8 @@ bool InspectorNetworkAgent::FetchResourceContent(Document* document,
+   Resource* cached_resource = document->Fetcher()->CachedResource(url);
+   if (!cached_resource) {
+     cached_resource = MemoryCache::Get()->ResourceForURL(
+-        url, document->Fetcher()->GetCacheIdentifier(url));
++        url, document->Fetcher()->GetCacheIdentifier(
++                 url, /*skip_service_worker=*/false));
+   }
+   if (cached_resource && InspectorPageAgent::CachedResourceContent(
+                              cached_resource, content, base64_encoded)) {
+diff --git a/third_party/blink/renderer/core/inspector/inspector_page_agent.cc b/third_party/blink/renderer/core/inspector/inspector_page_agent.cc
+index 62a5d9b831f11d6d74b1a8a0b51d2a436f0eb8c5..9678233733e1f4be9b4647bc7b0c2b7f173521d1 100644
+--- a/third_party/blink/renderer/core/inspector/inspector_page_agent.cc
++++ b/third_party/blink/renderer/core/inspector/inspector_page_agent.cc
+@@ -171,7 +171,8 @@ Resource* CachedResource(LocalFrame* frame,
+   Resource* cached_resource = document->Fetcher()->CachedResource(url);
+   if (!cached_resource) {
+     cached_resource = MemoryCache::Get()->ResourceForURL(
+-        url, document->Fetcher()->GetCacheIdentifier(url));
++        url, document->Fetcher()->GetCacheIdentifier(
++                 url, /*skip_service_worker=*/false));
+   }
+   if (!cached_resource)
+     cached_resource = loader->ResourceForURL(url);
+diff --git a/third_party/blink/renderer/core/loader/image_loader.cc b/third_party/blink/renderer/core/loader/image_loader.cc
+index 5986a8a358f97515d91bb4bfb6cf8719cac93948..e141443809783ef7140e2a48f30a1079a6913248 100644
+--- a/third_party/blink/renderer/core/loader/image_loader.cc
++++ b/third_party/blink/renderer/core/loader/image_loader.cc
+@@ -743,7 +743,8 @@ bool ImageLoader::ShouldLoadImmediately(const KURL& url) const {
+   // content when style recalc is over and DOM mutation is allowed again.
+   if (!url.IsNull()) {
+     Resource* resource = MemoryCache::Get()->ResourceForURL(
+-        url, element_->GetDocument().Fetcher()->GetCacheIdentifier(url));
++        url, element_->GetDocument().Fetcher()->GetCacheIdentifier(
++                 url, /*skip_service_worker=*/false));
+ 
+     if (resource && !resource->ErrorOccurred() &&
+         CanReuseFromListOfAvailableImages(
+diff --git a/third_party/blink/renderer/core/testing/internals.cc b/third_party/blink/renderer/core/testing/internals.cc
+index 184e1795bc084e4702b4d077a880279a3663a674..f13bb7bdd2c15831e03a49f5a34c9aafb04dedff 100644
+--- a/third_party/blink/renderer/core/testing/internals.cc
++++ b/third_party/blink/renderer/core/testing/internals.cc
+@@ -915,8 +915,8 @@ bool Internals::isLoading(const String& url) {
+   if (!document_)
+     return false;
+   const KURL full_url = document_->CompleteURL(url);
+-  const String cache_identifier =
+-      document_->Fetcher()->GetCacheIdentifier(full_url);
++  const String cache_identifier = document_->Fetcher()->GetCacheIdentifier(
++      full_url, /*skip_service_worker=*/false);
+   Resource* resource =
+       MemoryCache::Get()->ResourceForURL(full_url, cache_identifier);
+   // We check loader() here instead of isLoading(), because a multipart
+@@ -928,8 +928,8 @@ bool Internals::isLoadingFromMemoryCache(const String& url) {
+   if (!document_)
+     return false;
+   const KURL full_url = document_->CompleteURL(url);
+-  const String cache_identifier =
+-      document_->Fetcher()->GetCacheIdentifier(full_url);
++  const String cache_identifier = document_->Fetcher()->GetCacheIdentifier(
++      full_url, /*skip_service_worker=*/false);
+   Resource* resource =
+       MemoryCache::Get()->ResourceForURL(full_url, cache_identifier);
+   return resource && resource->GetStatus() == ResourceStatus::kCached;
+diff --git a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc
+index 6656da73d48a197eb58f1be3811ac558510bb54a..f2c6b3518f8aaa0ddd72acfa7586928e11151b1d 100644
+--- a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc
++++ b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc
+@@ -957,7 +957,8 @@ Resource* ResourceFetcher::CreateResourceForStaticData(
+   if (!archive_ && factory.GetType() == ResourceType::kRaw)
+     return nullptr;
+ 
+-  const String cache_identifier = GetCacheIdentifier(url);
++  const String cache_identifier = GetCacheIdentifier(
++      url, params.GetResourceRequest().GetSkipServiceWorker());
+   // Most off-main-thread resource fetches use Resource::kRaw and don't reach
+   // this point, but off-main-thread module fetches might.
+   if (IsMainThread()) {
+@@ -1320,7 +1321,10 @@ Resource* ResourceFetcher::RequestResource(FetchParameters& params,
+         resource = nullptr;
+       } else {
+         resource = MemoryCache::Get()->ResourceForURL(
+-            params.Url(), GetCacheIdentifier(params.Url()));
++            params.Url(),
++          GetCacheIdentifier(
++              params.Url(),
++              params.GetResourceRequest().GetSkipServiceWorker()));
+       }
+       if (resource) {
+         policy = DetermineRevalidationPolicy(resource_type, params, *resource,
+@@ -1614,7 +1618,8 @@ Resource* ResourceFetcher::CreateResourceForLoading(
+     const FetchParameters& params,
+     const ResourceFactory& factory) {
+   const String cache_identifier =
+-      GetCacheIdentifier(params.GetResourceRequest().Url());
++      GetCacheIdentifier(params.GetResourceRequest().Url(),
++                         params.GetResourceRequest().GetSkipServiceWorker());
+   if (!base::FeatureList::IsEnabled(
+           blink::features::kScopeMemoryCachePerContext)) {
+     DCHECK(!IsMainThread() || params.IsStaleRevalidation() ||
+@@ -2672,9 +2677,11 @@ void ResourceFetcher::UpdateAllImageResourcePriorities() {
+   to_be_removed.clear();
+ }
+ 
+-String ResourceFetcher::GetCacheIdentifier(const KURL& url) const {
+-  if (properties_->GetControllerServiceWorkerMode() !=
+-      mojom::ControllerServiceWorkerMode::kNoController) {
++String ResourceFetcher::GetCacheIdentifier(const KURL& url,
++                                           bool skip_service_worker) const {
++  if (!skip_service_worker &&
++      properties_->GetControllerServiceWorkerMode() !=
++          mojom::ControllerServiceWorkerMode::kNoController) {
+     return String::Number(properties_->ServiceWorkerId());
+   }
+ 
+diff --git a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h
+index 04f985ee491e87a6cbabaa1c1ff6f513a8e14384..14c92ee2411d88c32079c6765a047ed0da655b47 100644
+--- a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h
++++ b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h
+@@ -274,7 +274,11 @@ class PLATFORM_EXPORT ResourceFetcher
+                          uint32_t inflight_keepalive_bytes);
+   blink::mojom::ControllerServiceWorkerMode IsControlledByServiceWorker() const;
+ 
+-  String GetCacheIdentifier(const KURL& url) const;
++  // Returns a cache identifier for MemoryCache.
++  // `url` is used for finding a matching WebBundle.
++  // If `skip_service_worker` is true, the identifier won't be a ServiceWorker's
++  // identifier to keep the cache separated.
++  String GetCacheIdentifier(const KURL& url, bool skip_service_worker) const;
+ 
+   // If `url` exists as a resource in a subresource bundle in this frame,
+   // returns its UnguessableToken; otherwise, returns std::nullopt.


### PR DESCRIPTION
<details>
<summary>electron/security#624 - 923797bac925 from chromium</summary>
[M131] Make GetCacheIdentifier() respect GetSkipServiceWorker().

Since the current GetCacheIdentifier() ignores GetSkipServiceWorker(),
GetCacheIdentifier() returns ServiceWorkerId even if GetSkipServiceWorker()
is true if the ServiceWorker has a fetch handler.

To make the isolated world respected as an isolated world, the cache
identifier should not be shared with a page under a ServiceWorker control.

(cherry picked from commit 75f322ad1f64c0bc56fa77ab877b48d72cdb903c)

Bug: 372512079, 373263969
Change-Id: Idd2d8900f2f720e0a4dc9837e2eb56474c60b587
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5961018
Reviewed-by: Justin Lulejian <jlulejian@chromium.org>
Reviewed-by: Kouhei Ueno <kouhei@chromium.org>
Commit-Queue: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1376006}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6002191
Auto-Submit: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
Commit-Queue: Kouhei Ueno <kouhei@chromium.org>
Cr-Commit-Position: refs/branch-heads/6778@{#1849}
Cr-Branched-From: b21671ca172dcfd1566d41a770b2808e7fa7cd88-refs/heads/main@{#1368529}
</details>

Notes:
* Security: backported fix for CVE-2024-11110.