### PR TITLE
build: fix python warnings "SyntaxWarning: invalid escape sequence '\w'"

### DIFF
--- a/build/generate_node_defines.py
+++ b/build/generate_node_defines.py
@@ -2,7 +2,7 @@ import os
 import re
 import sys
 
-DEFINE_EXTRACT_REGEX = re.compile('^ *# *define (\w*)', re.MULTILINE)
+DEFINE_EXTRACT_REGEX = re.compile(r'^ *# *define (\w*)', re.MULTILINE)
 
 def main(out_dir, headers):
   defines = []

--- a/script/generate-config-gypi.py
+++ b/script/generate-config-gypi.py
@@ -6,7 +6,6 @@ import pprint
 import re
 import subprocess
 import sys
-from lib.config import get_target_arch
 
 ELECTRON_DIR = os.path.abspath(os.path.join(__file__, '..', '..'))
 NODE_DIR = os.path.join(ELECTRON_DIR, '..', 'third_party', 'electron_node')

--- a/script/generate-config-gypi.py
+++ b/script/generate-config-gypi.py
@@ -40,7 +40,7 @@ def read_electron_args():
     for line in file_in:
       if line.startswith('#'):
         continue
-      m = re.match('(\w+) = (.+)', line)
+      m = re.match(r'(\w+) = (.+)', line)
       if m == None:
         continue
       args[m.group(1)] = m.group(2)

--- a/script/generate-config-gypi.py
+++ b/script/generate-config-gypi.py
@@ -40,7 +40,7 @@ def read_electron_args():
       if line.startswith('#'):
         continue
       m = re.match(r'(\w+) = (.+)', line)
-      if m == None:
+      if m is None:
         continue
       args[m.group(1)] = m.group(2)
   return args

--- a/script/zip-symbols.py
+++ b/script/zip-symbols.py
@@ -5,7 +5,7 @@ import glob
 import os
 import sys
 
-from lib.config import PLATFORM, get_target_arch
+from lib.config import PLATFORM
 from lib.util import scoped_cwd, get_electron_version, make_zip, \
                      get_electron_branding, get_out_dir, execute
 


### PR DESCRIPTION
#### Description of Change

Fixes these warnings:

```
[3469/51023] ACTION //electron:electron_generate_node_defines(//build/toolchain/linux:clang_x64)
/home/charles/src/devdiv/src/out/Testing/../../electron/build/generate_node_defines.py:5: SyntaxWarning: invalid escape sequence '\w'
  DEFINE_EXTRACT_REGEX = re.compile('^ *# *define (\w*)', re.MULTILINE)
[4627/51023] ACTION //electron:generate_config_gypi(//build/toolchain/linux:clang_x64)
/home/charles/src/devdiv/src/out/Testing/../../electron/script/generate-config-gypi.py:43: SyntaxWarning: invalid escape sequence '\w'
  m = re.match('(\w+) = (.+)', line)
```

Also fixes three other minor warnings that were nearby: a pair of unused imports and a [pep 8 E711 warning](https://peps.python.org/pep-0008/#programming-recommendations) to use `foo is None` instead of `foo == None`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.