### PR TITLE
docs: Make ipcRenderer and ipcMain listener API docs consistent

### DIFF
--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -41,7 +41,8 @@ The `ipcMain` module has the following methods to listen for events:
   * `event` [IpcMainEvent][ipc-main-event]
   * `...args` any[]
 
-Alias for [`ipcMain.addListener`](#ipcmainaddlistenerchannel-listener).
+Listens to `channel`, when a new message arrives `listener` would be called with
+`listener(event, args...)`.
 
 ### `ipcMain.off(channel, listener)`
 
@@ -50,7 +51,8 @@ Alias for [`ipcMain.addListener`](#ipcmainaddlistenerchannel-listener).
   * `event` [IpcMainEvent][ipc-main-event]
   * `...args` any[]
 
-Alias for [`ipcMain.removeListener`](#ipcmainremovelistenerchannel-listener).
+Removes the specified `listener` from the listener array for the specified
+`channel`.
 
 ### `ipcMain.once(channel, listener)`
 
@@ -69,8 +71,7 @@ only the next time a message is sent to `channel`, after which it is removed.
   * `event` [IpcMainEvent][ipc-main-event]
   * `...args` any[]
 
-Listens to `channel`, when a new message arrives `listener` would be called with
-`listener(event, args...)`.
+Alias for [`ipcMain.on`](#ipcmainonchannel-listener).
 
 ### `ipcMain.removeListener(channel, listener)`
 
@@ -78,8 +79,7 @@ Listens to `channel`, when a new message arrives `listener` would be called with
 * `listener` Function
   * `...args` any[]
 
-Removes the specified `listener` from the listener array for the specified
-`channel`.
+Alias for [`ipcMain.off`](#ipcmainoffchannel-listener).
 
 ### `ipcMain.removeAllListeners([channel])`
 

--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -32,7 +32,7 @@ process, see [webContents.send][web-contents-send] for more information.
 
 ## Methods
 
-The `ipcMain` module has the following method to listen for events:
+The `ipcMain` module has the following methods to listen for events:
 
 ### `ipcMain.on(channel, listener)`
 
@@ -41,8 +41,16 @@ The `ipcMain` module has the following method to listen for events:
   * `event` [IpcMainEvent][ipc-main-event]
   * `...args` any[]
 
-Listens to `channel`, when a new message arrives `listener` would be called with
-`listener(event, args...)`.
+Alias for [`ipcMain.addListener`](#ipcmainaddlistenerchannel-listener).
+
+### `ipcMain.off(channel, listener)`
+
+* `channel` string
+* `listener` Function
+  * `event` [IpcMainEvent][ipc-main-event]
+  * `...args` any[]
+
+Alias for [`ipcMain.removeListener`](#ipcmainremovelistenerchannel-listener).
 
 ### `ipcMain.once(channel, listener)`
 
@@ -53,6 +61,16 @@ Listens to `channel`, when a new message arrives `listener` would be called with
 
 Adds a one time `listener` function for the event. This `listener` is invoked
 only the next time a message is sent to `channel`, after which it is removed.
+
+### `ipcMain.addListener(channel, listener)`
+
+* `channel` string
+* `listener` Function
+  * `event` [IpcMainEvent][ipc-main-event]
+  * `...args` any[]
+
+Listens to `channel`, when a new message arrives `listener` would be called with
+`listener(event, args...)`.
 
 ### `ipcMain.removeListener(channel, listener)`
 
@@ -67,7 +85,7 @@ Removes the specified `listener` from the listener array for the specified
 
 * `channel` string (optional)
 
-Removes listeners of the specified `channel`.
+Removes all listeners from the specified `channel`. Removes all listeners from all channels if no channel is specified.
 
 ### `ipcMain.handle(channel, listener)`
 

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -38,8 +38,7 @@ The `ipcRenderer` module has the following method to listen for events and send 
   * `event` [IpcRendererEvent][ipc-renderer-event]
   * `...args` any[]
 
-Listens to `channel`, when a new message arrives `listener` would be called with
-`listener(event, args...)`.
+Alias for [`ipcRenderer.addListener`](#ipcrendereraddlistenerchannel-listener).
 
 ### `ipcRenderer.off(channel, listener)`
 
@@ -67,7 +66,8 @@ only the next time a message is sent to `channel`, after which it is removed.
   * `event` [IpcRendererEvent][ipc-renderer-event]
   * `...args` any[]
 
-Alias for [`ipcRenderer.on`](#ipcrendereronchannel-listener).
+Listens to `channel`, when a new message arrives `listener` would be called with
+`listener(event, args...)`.
 
 ### `ipcRenderer.removeListener(channel, listener)`
 
@@ -79,11 +79,11 @@ Alias for [`ipcRenderer.on`](#ipcrendereronchannel-listener).
 Removes the specified `listener` from the listener array for the specified
 `channel`.
 
-### `ipcRenderer.removeAllListeners(channel)`
+### `ipcRenderer.removeAllListeners([channel])`
 
-* `channel` string
+* `channel` string (optional)
 
-Removes all listeners, or those of the specified `channel`.
+Removes all listeners from the specified `channel`. Removes all listeners from all channels if no channel is specified.
 
 ### `ipcRenderer.send(channel, ...args)`
 

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -38,7 +38,8 @@ The `ipcRenderer` module has the following method to listen for events and send 
   * `event` [IpcRendererEvent][ipc-renderer-event]
   * `...args` any[]
 
-Alias for [`ipcRenderer.addListener`](#ipcrendereraddlistenerchannel-listener).
+Listens to `channel`, when a new message arrives `listener` would be called with
+`listener(event, args...)`.
 
 ### `ipcRenderer.off(channel, listener)`
 
@@ -47,7 +48,8 @@ Alias for [`ipcRenderer.addListener`](#ipcrendereraddlistenerchannel-listener).
   * `event` [IpcRendererEvent][ipc-renderer-event]
   * `...args` any[]
 
-Alias for [`ipcRenderer.removeListener`](#ipcrendererremovelistenerchannel-listener).
+Removes the specified `listener` from the listener array for the specified
+`channel`.
 
 ### `ipcRenderer.once(channel, listener)`
 
@@ -66,8 +68,7 @@ only the next time a message is sent to `channel`, after which it is removed.
   * `event` [IpcRendererEvent][ipc-renderer-event]
   * `...args` any[]
 
-Listens to `channel`, when a new message arrives `listener` would be called with
-`listener(event, args...)`.
+Alias for [`ipcRenderer.on`](#ipcrendereronchannel-listener).
 
 ### `ipcRenderer.removeListener(channel, listener)`
 
@@ -76,8 +77,7 @@ Listens to `channel`, when a new message arrives `listener` would be called with
   * `event` [IpcRendererEvent][ipc-renderer-event]
   * `...args` any[]
 
-Removes the specified `listener` from the listener array for the specified
-`channel`.
+Alias for [`ipcRenderer.off`](#ipcrendereroffchannel-listener).
 
 ### `ipcRenderer.removeAllListeners([channel])`
 

--- a/spec/api-ipc-main-spec.ts
+++ b/spec/api-ipc-main-spec.ts
@@ -94,6 +94,9 @@ describe('ipc main module', () => {
   });
 
   describe('ipcMain.removeAllListeners', () => {
+    beforeEach(() => { ipcMain.removeAllListeners(); });
+    beforeEach(() => { ipcMain.removeAllListeners(); });
+
     it('removes only the given channel', () => {
       ipcMain.on('channel1', () => {});
       ipcMain.on('channel2', () => {});

--- a/spec/api-ipc-main-spec.ts
+++ b/spec/api-ipc-main-spec.ts
@@ -92,4 +92,24 @@ describe('ipc main module', () => {
       expect(v).to.equal('hello');
     });
   });
+
+  describe('ipcMain.removeAllListeners', () => {
+    it('removes only the given channel', () => {
+      ipcMain.on('channel1', () => {});
+      ipcMain.on('channel2', () => {});
+
+      ipcMain.removeAllListeners('channel1');
+
+      expect(ipcMain.eventNames()).to.deep.equal(['channel2']);
+    });
+
+    it('removes all channels if no channel is specified', () => {
+      ipcMain.on('channel1', () => {});
+      ipcMain.on('channel2', () => {});
+
+      ipcMain.removeAllListeners();
+
+      expect(ipcMain.eventNames()).to.deep.equal([]);
+    });
+  });
 });


### PR DESCRIPTION
#### Description of Change

The documentation for the `on`/`off` and `addListener`/`removeListener` docs for `ipcMain` and `ipcRenderer` are somewhat inconsistent. Thanks to @Kilian for pointing this out.

1. `ipcMain` is missing documentation for the `off` and `addListener` functions. I've added them
2. `off` and `addListener` are documented as aliases for `removeListener` and `on` respectively. This is a little confusing, so I've made `on` and `off` the "primary" APIs and documented `addListener`/`removeListener` as aliases.
3. `ipcRenderer.removeAllListeners` didn't document that the `channel` param was optional, even though it should be. I've updated the docs to mark it as optional, and I've updated both the `ipcRenderer` and `ipcMain` docs to better describe what happens if you don't pass a `channel` value.

I also noticed that we didn't have any tests for the `removeAllListeners` behavior, so I added some. I realize that the implementation *mostly* comes from Node, but it seemed useful to have a regression test, especially for the behavior when no `channel` value is provided.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
