### PR TITLE
chore: fix multi-version parsing in issue assignment

### DIFF
--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -81,14 +81,15 @@ jobs:
                     const versions = await ElectronVersions.create(undefined, { ignoreCache: true });
 
                     const validVersions = [...versions.supportedMajors, ...versions.prereleaseMajors];
-                    if (!validVersions.includes(major)) {
-                      core.setOutput('unsupportedMajor', true);
-                      labels.push('blocked/need-info ❌');
+                    if (validVersions.includes(major)) {
+                      labels.push(versionLabel);
                     }
-
-                    labels.push(versionLabel);
                   }
                 }
+              }
+              if (labels.length === 0) {
+                core.setOutput('No supported versions found', true);
+                labels.push('blocked/need-info ❌');
               }
             }
 

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -57,32 +57,37 @@ jobs:
 
             const electronVersion = select('heading:has(> text[value="Electron Version"]) + paragraph > text', tree)?.value.trim();
             if (electronVersion !== undefined) {
-              const major = semver.parse(electronVersion)?.major;
-              if (major) {
-                const versionLabel = `${major}-x-y`;
-                let labelExists = false;
+              // It's possible for multiple versions to be listed -
+              // for now check for comma or space separated version.
+              const versions = electronVersion.split(/, | /);
+              for (const version of versions) {
+                const major = semver.parse(version)?.major;
+                if (major) {
+                  const versionLabel = `${major}-x-y`;
+                  let labelExists = false;
 
-                try {
-                  await github.rest.issues.getLabel({
-                    owner,
-                    repo,
-                    name: versionLabel,
-                  });
-                  labelExists = true;
-                } catch {}
+                  try {
+                    await github.rest.issues.getLabel({
+                      owner,
+                      repo,
+                      name: versionLabel,
+                    });
+                    labelExists = true;
+                  } catch {}
 
-                if (labelExists) {
-                  // Check if it's an unsupported major
-                  const { ElectronVersions } = await import('${{ github.workspace }}/node_modules/@electron/fiddle-core/dist/index.js');
-                  const versions = await ElectronVersions.create(undefined, { ignoreCache: true });
+                  if (labelExists) {
+                    // Check if it's an unsupported major
+                    const { ElectronVersions } = await import('${{ github.workspace }}/node_modules/@electron/fiddle-core/dist/index.js');
+                    const versions = await ElectronVersions.create(undefined, { ignoreCache: true });
 
-                  const validVersions = [...versions.supportedMajors, ...versions.prereleaseMajors];
-                  if (!validVersions.includes(major)) {
-                    core.setOutput('unsupportedMajor', true);
-                    labels.push('blocked/need-info ❌');
+                    const validVersions = [...versions.supportedMajors, ...versions.prereleaseMajors];
+                    if (!validVersions.includes(major)) {
+                      core.setOutput('unsupportedMajor', true);
+                      labels.push('blocked/need-info ❌');
+                    }
+
+                    labels.push(versionLabel);
                   }
-
-                  labels.push(versionLabel);
                 }
               }
             }


### PR DESCRIPTION
#### Description of Change

Fixes an issue where issues opened against Electron would fail to auto-assign versions if more than one was provided. All relevant versions should be assigned to the issue if more than one is provided.

Before:

```js
// Using 34.0.0-alpha.6, 33.0.2, 32.2.2, 31.7.3
const major = semver.parse(electronVersion)?.major; // undefined, no versions
```

After:

```js
// Using 34.0.0-alpha.6, 33.0.2, 32.2.2, 31.7.3
const major = semver.parse(electronVersion)?.major; // 34, 33, 32, 31
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none