### PR TITLE
build: re-enable `container_overflow` ASAN check

### DIFF
--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -176,7 +176,7 @@ jobs:
           if [ "${{ inputs.is-asan }}" == "true" ]; then
             cd ..
             ASAN_SYMBOLIZE="$PWD/tools/valgrind/asan/asan_symbolize.py --executable-path=$PWD/out/Default/electron"
-            export ASAN_OPTIONS="symbolize=0 handle_abort=1 detect_container_overflow=0"
+            export ASAN_OPTIONS="symbolize=0 handle_abort=1"
             export G_SLICE=always-malloc
             export NSS_DISABLE_ARENA_FREE_LIST=1
             export NSS_DISABLE_UNLOAD=1

--- a/patches/node/.patches
+++ b/patches/node/.patches
@@ -43,3 +43,4 @@ fix_-wextra-semi_errors_in_nghttp2_helper_h.patch
 fix_remove_harmony-import-assertions_from_node_cc.patch
 win_almost_fix_race_detecting_esrch_in_uv_kill.patch
 chore_disable_deprecation_ftbfs_in_simdjson_header.patch
+src_provide_workaround_for_container-overflow.patch

--- a/patches/node/src_provide_workaround_for_container-overflow.patch
+++ b/patches/node/src_provide_workaround_for_container-overflow.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Daniel Lemire <daniel@lemire.me>
+Date: Tue, 29 Oct 2024 12:28:47 -0400
+Subject: src: provide workaround for container-overflow
+
+Address a sanitizer error 'container-overflow', which happens only on systems where the
+standard library has been annotated to warn about reads between the std::string's end
+and the end of the its allocated memory (std::string:capacity). This reads are memory safe
+but they can also be a sign that there is a real bug. In the instance of issue 55584,
+it is not a bug, it is a false positive.
+
+In some instances, it is possible to indicate to the compiler that we want to disallow
+these checks to avoid the false positive, but I could not find documentation on this topic
+In a future release of simdjson, we will provide a more convenient function that
+avoids such ugly workaround.
+
+diff --git a/src/node_modules.cc b/src/node_modules.cc
+index 3bedd2dfecb49c3f69ea59b70d72b8b6fc605132..2b0e4905dd557e73542cf052ba81327b1e1e471f 100644
+--- a/src/node_modules.cc
++++ b/src/node_modules.cc
+@@ -100,11 +100,23 @@ const BindingData::PackageConfig* BindingData::GetPackageJSON(
+   if (ReadFileSync(&package_config.raw_json, path.data()) < 0) {
+     return nullptr;
+   }
++  // In some systems, std::string is annotated to generate an
++  // AddressSanitizer: container-overflow error when reading beyond the end of
++  // the string even when we are still within the capacity of the string.
++  // https://github.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow
++  // https://github.com/nodejs/node/issues/55584
++  // The next lines are a workaround to avoid this false positive.
++  size_t json_length = package_config.raw_json.size();
++  package_config.raw_json.append(simdjson::SIMDJSON_PADDING, ' ');
++  simdjson::padded_string_view json_view(package_config.raw_json.data(),
++                                         json_length,
++                                         package_config.raw_json.size());
++  // End of workaround
+ 
+   simdjson::ondemand::document document;
+   simdjson::ondemand::object main_object;
+   simdjson::error_code error =
+-      binding_data->json_parser.iterate(package_config.raw_json).get(document);
++      binding_data->json_parser.iterate(json_view).get(document);
+ 
+   const auto throw_invalid_package_config = [error_context, path, realm]() {
+     if (error_context == nullptr) {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/44549.

Backports https://github.com/nodejs/node/pull/55591 to re-enable `container_overflow` ASAN checks.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none