### PR TITLE
fix: cyclical #include dependency between autofill_popup.h and autofill_popup_view.h

### DIFF
--- a/shell/browser/ui/autofill_popup.cc
+++ b/shell/browser/ui/autofill_popup.cc
@@ -15,6 +15,7 @@
 #include "shell/browser/osr/osr_render_widget_host_view.h"
 #include "shell/browser/osr/osr_view_proxy.h"
 #include "shell/browser/ui/autofill_popup.h"
+#include "shell/browser/ui/views/autofill_popup_view.h"
 #include "shell/common/api/api.mojom.h"
 #include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
 #include "ui/color/color_id.h"
@@ -160,11 +161,7 @@ gfx::Rect CalculatePopupBounds(const gfx::Size& desired_size,
 
 }  // namespace
 
-AutofillPopup::AutofillPopup() {
-  bold_font_list_ = gfx::FontList().DeriveWithWeight(gfx::Font::Weight::BOLD);
-  smaller_font_list_ =
-      gfx::FontList().DeriveWithSizeDelta(kSmallerFontSizeDelta);
-}
+AutofillPopup::AutofillPopup() = default;
 
 AutofillPopup::~AutofillPopup() {
   Hide();

--- a/shell/browser/ui/autofill_popup.h
+++ b/shell/browser/ui/autofill_popup.h
@@ -8,14 +8,17 @@
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
-#include "shell/browser/ui/views/autofill_popup_view.h"
 #include "ui/gfx/font_list.h"
-#include "ui/views/view.h"
-#include "ui/views/widget/widget.h"
+#include "ui/gfx/geometry/rect.h"
+#include "ui/views/view_observer.h"
 
 namespace content {
 class RenderFrameHost;
 }  // namespace content
+
+namespace gfx {
+class RectF;
+}  // namespace gfx
 
 namespace ui {
 using ColorId = int;
@@ -68,6 +71,10 @@ class AutofillPopup : private views::ViewObserver {
   const std::u16string& label_at(int i) const { return labels_.at(i); }
   int LineFromY(int y) const;
 
+  static constexpr int kNamePadding = 15;
+  static constexpr int kRowHeight = 24;
+  static constexpr int kSmallerFontSizeDelta = -1;
+
   int selected_index_;
 
   // Popup location
@@ -81,8 +88,10 @@ class AutofillPopup : private views::ViewObserver {
   std::vector<std::u16string> labels_;
 
   // Font lists for the suggestions
-  gfx::FontList smaller_font_list_;
-  gfx::FontList bold_font_list_;
+  const gfx::FontList smaller_font_list_ =
+      gfx::FontList{}.DeriveWithSizeDelta(kSmallerFontSizeDelta);
+  const gfx::FontList bold_font_list_ =
+      gfx::FontList{}.DeriveWithWeight(gfx::Font::Weight::BOLD);
 
   // For sending the accepted suggestion to the render frame that
   // asked to open the popup

--- a/shell/browser/ui/views/autofill_popup_view.cc
+++ b/shell/browser/ui/views/autofill_popup_view.cc
@@ -12,6 +12,7 @@
 #include "cc/paint/skia_paint_canvas.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_view_host.h"
+#include "shell/browser/ui/autofill_popup.h"
 #include "ui/accessibility/ax_enums.mojom.h"
 #include "ui/base/dragdrop/drag_drop_types.h"
 #include "ui/color/color_provider.h"

--- a/shell/browser/ui/views/autofill_popup_view.h
+++ b/shell/browser/ui/views/autofill_popup_view.h
@@ -8,8 +8,6 @@
 #include <memory>
 #include <optional>
 
-#include "shell/browser/ui/autofill_popup.h"
-
 #include "base/memory/raw_ptr.h"
 #include "content/public/browser/render_widget_host.h"
 #include "electron/buildflags/buildflags.h"
@@ -31,11 +29,8 @@ struct AXNodeData;
 
 namespace electron {
 
-const int kPopupBorderThickness = 1;
-const int kSmallerFontSizeDelta = -1;
-const int kEndPadding = 8;
-const int kNamePadding = 15;
-const int kRowHeight = 24;
+constexpr int kPopupBorderThickness = 1;
+constexpr int kEndPadding = 8;
 
 class AutofillPopup;
 


### PR DESCRIPTION
#### Description of Change

Clean up dependency conflict between AutofillPopup and AutofillPopupView:

- fix cyclical #include header dependency
- fix clang-tidy warning in AutofillPopup warning: use '= default' to define a trivial default constructor [modernize-use-equals-default]
- reduce #include scope in autofill_popup.h and autofill_popup_view.h
- move some numeric constants out of public namespace into private AutofillPopup, since it is their only consumer

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.