### PR TITLE
chore: fix unsupported major comment in issue automation

### DIFF
--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -88,7 +88,7 @@ jobs:
                 }
               }
               if (labels.length === 0) {
-                core.setOutput('No supported versions found', true);
+                core.setOutput('unsupportedMajor', true);
                 labels.push('blocked/need-info ❌');
               }
             }


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Follow-up to #44679 which inadvertently broke adding the comment about unsupported versions. The `core.setOutput` isn't a human visible output, but a step output to be used in the next step. Restoring it to the previous value.

https://github.com/electron/electron/blob/58dc990f7a725537b447c22862956ac6d711291d/.github/workflows/issue-opened.yml#L133

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
