### PR TITLE
fix: bugprone-narrowing-conversions warnings in NativeImage

### DIFF
--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -492,9 +492,8 @@ gin::Handle<NativeImage> NativeImage::CreateFromBitmap(
     return gin::Handle<NativeImage>();
   }
 
-  unsigned int width = 0;
-  unsigned int height = 0;
-  double scale_factor = 1.;
+  int width = 0;
+  int height = 0;
 
   if (!options.Get("width", &width)) {
     thrower.ThrowError("width is required");
@@ -506,6 +505,9 @@ gin::Handle<NativeImage> NativeImage::CreateFromBitmap(
     return gin::Handle<NativeImage>();
   }
 
+  if (width <= 0 || height <= 0)
+    return CreateEmpty(thrower.isolate());
+
   auto info = SkImageInfo::MakeN32(width, height, kPremul_SkAlphaType);
   auto size_bytes = info.computeMinByteSize();
 
@@ -515,16 +517,12 @@ gin::Handle<NativeImage> NativeImage::CreateFromBitmap(
     return gin::Handle<NativeImage>();
   }
 
-  options.Get("scaleFactor", &scale_factor);
-
-  if (width == 0 || height == 0) {
-    return CreateEmpty(thrower.isolate());
-  }
-
   SkBitmap bitmap;
   bitmap.allocN32Pixels(width, height, false);
   bitmap.writePixels({info, buffer_data.data(), bitmap.rowBytes()});
 
+  float scale_factor = 1.0F;
+  options.Get("scaleFactor", &scale_factor);
   gfx::ImageSkia image_skia =
       gfx::ImageSkia::CreateFromBitmap(bitmap, scale_factor);
 

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -12,6 +12,7 @@
 #include "base/files/file_util.h"
 #include "base/logging.h"
 #include "base/memory/ref_counted_memory.h"
+#include "base/numerics/safe_conversions.h"
 #include "base/strings/pattern.h"
 #include "base/strings/utf_string_conversions.h"
 #include "gin/arguments.h"
@@ -147,13 +148,13 @@ NativeImage::~NativeImage() {
 }
 
 void NativeImage::UpdateExternalAllocatedMemoryUsage() {
-  int32_t new_memory_usage = 0;
+  int64_t new_memory_usage = 0;
 
   if (image_.HasRepresentation(gfx::Image::kImageRepSkia)) {
     auto* const image_skia = image_.ToImageSkia();
-    if (!image_skia->isNull()) {
-      new_memory_usage = image_skia->bitmap()->computeByteSize();
-    }
+    if (!image_skia->isNull())
+      new_memory_usage =
+          base::as_signed(image_skia->bitmap()->computeByteSize());
   }
 
   isolate_->AdjustAmountOfExternalAllocatedMemory(new_memory_usage -

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -140,7 +140,7 @@ class NativeImage final : public gin::Wrappable<NativeImage> {
   gfx::Image image_;
 
   raw_ptr<v8::Isolate> isolate_;
-  int32_t memory_usage_ = 0;
+  int64_t memory_usage_ = 0;
 };
 
 }  // namespace electron::api


### PR DESCRIPTION
#### Description of Change

I'm experimenting with running Electron's shell code through clang-tidy and thought I'd pick up some low-hanging-fruit fixes while I experiment.

This PR fixes a handful of [narrowing conversions](https://clang.llvm.org/extra//clang-tidy/checks/cppcoreguidelines/narrowing-conversions.html) warnings:

```
    ../../electron/shell/common/api/electron_api_native_image.cc:155:26: warning: narrowing conversion from 'size_t' (aka 'unsigned long') to signed type 'int32_t' (aka 'int') is implementation-defined [bugprone-narrowing-conversions]
      155 |       new_memory_usage = image_skia->bitmap()->computeByteSize();

    ../../electron/shell/common/api/electron_api_native_image.cc:508:36: warning: narrowing conversion from 'unsigned int' to signed type 'int' is implementation-defined [bugprone-narrowing-conversions]
      508 |   auto info = SkImageInfo::MakeN32(width, height, kPremul_SkAlphaType);
          |                                    ^
    ../../electron/shell/common/api/electron_api_native_image.cc:508:43: warning: narrowing conversion from 'unsigned int' to signed type 'int' is implementation-defined [bugprone-narrowing-conversions]
      508 |   auto info = SkImageInfo::MakeN32(width, height, kPremul_SkAlphaType);
          |                                           ^
    ../../electron/shell/common/api/electron_api_native_image.cc:524:25: warning: narrowing conversion from 'unsigned int' to signed type 'int' is implementation-defined [bugprone-narrowing-conversions]
      524 |   bitmap.allocN32Pixels(width, height, false);
          |                         ^
    ../../electron/shell/common/api/electron_api_native_image.cc:524:32: warning: narrowing conversion from 'unsigned int' to signed type 'int' is implementation-defined [bugprone-narrowing-conversions]
      524 |   bitmap.allocN32Pixels(width, height, false);
          |                                ^
    ../../electron/shell/common/api/electron_api_native_image.cc:528:48: warning: narrowing conversion from 'double' to 'float' [bugprone-narrowing-conversions]
      528 |       gfx::ImageSkia::CreateFromBitmap(bitmap, scale_factor);

```

See the commit messages for information on the specific changes.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.