### PR TITLE
fix: tooltips in WCO caption buttons

### DIFF
--- a/shell/browser/ui/views/win_caption_button_container.cc
+++ b/shell/browser/ui/views/win_caption_button_container.cc
@@ -19,6 +19,7 @@
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/compositor/layer.h"
 #include "ui/strings/grit/ui_strings.h"
+#include "ui/views/accessibility/view_accessibility.h"
 #include "ui/views/background.h"
 #include "ui/views/layout/flex_layout.h"
 #include "ui/views/view_class_properties.h"
@@ -83,6 +84,7 @@ WinCaptionButtonContainer::WinCaptionButtonContainer(WinFrameView* frame_view)
                                    views::MaximumFlexSizeRule::kPreferred,
                                    /* adjust_width_for_height */ false,
                                    views::MinimumFlexSizeRule::kScaleToZero));
+  UpdateButtonToolTipsForWindowControlsOverlay();
 }
 
 WinCaptionButtonContainer::~WinCaptionButtonContainer() {}
@@ -105,18 +107,6 @@ int WinCaptionButtonContainer::NonClientHitTest(const gfx::Point& point) const {
   return HTCAPTION;
 }
 
-gfx::Size WinCaptionButtonContainer::GetButtonSize() const {
-  // Close button size is set the same as all the buttons
-  return close_button_->GetSize();
-}
-
-void WinCaptionButtonContainer::SetButtonSize(gfx::Size size) {
-  minimize_button_->SetSize(size);
-  maximize_button_->SetSize(size);
-  restore_button_->SetSize(size);
-  close_button_->SetSize(size);
-}
-
 void WinCaptionButtonContainer::ResetWindowControls() {
   minimize_button_->SetState(views::Button::STATE_NORMAL);
   maximize_button_->SetState(views::Button::STATE_NORMAL);
@@ -132,10 +122,7 @@ void WinCaptionButtonContainer::AddedToWidget() {
   widget_observation_.Observe(widget);
 
   UpdateButtons();
-
-  if (frame_view_->window()->IsWindowControlsOverlayEnabled()) {
-    UpdateBackground();
-  }
+  UpdateBackground();
 }
 
 void WinCaptionButtonContainer::RemovedFromWidget() {
@@ -181,6 +168,24 @@ void WinCaptionButtonContainer::UpdateButtons() {
   close_button_->SetEnabled(closable);
 
   InvalidateLayout();
+}
+
+void WinCaptionButtonContainer::UpdateButtonToolTipsForWindowControlsOverlay() {
+  minimize_button_->SetTooltipText(
+      minimize_button_->GetViewAccessibility().GetCachedName());
+  maximize_button_->SetTooltipText(
+      maximize_button_->GetViewAccessibility().GetCachedName());
+  restore_button_->SetTooltipText(
+      restore_button_->GetViewAccessibility().GetCachedName());
+  close_button_->SetTooltipText(
+      close_button_->GetViewAccessibility().GetCachedName());
+}
+
+void WinCaptionButtonContainer::SetButtonSize(gfx::Size size) {
+  minimize_button_->SetSize(size);
+  maximize_button_->SetSize(size);
+  restore_button_->SetSize(size);
+  close_button_->SetSize(size);
 }
 
 BEGIN_METADATA(WinCaptionButtonContainer)

--- a/shell/browser/ui/views/win_caption_button_container.h
+++ b/shell/browser/ui/views/win_caption_button_container.h
@@ -42,8 +42,10 @@ class WinCaptionButtonContainer : public views::View,
   // See also ClientView::NonClientHitTest.
   int NonClientHitTest(const gfx::Point& point) const;
 
-  gfx::Size GetButtonSize() const;
   void SetButtonSize(gfx::Size size);
+
+  // Add tooltip text to caption buttons.
+  void UpdateButtonToolTipsForWindowControlsOverlay();
 
   // Sets caption button container background color.
   void UpdateBackground();


### PR DESCRIPTION
#### Description of Change

This PR adds missing tooltip captions to WCO buttons when WCO is enabled. This matches upstream behavior and expectations for the WCO api.

<details><summary>With Tooltips</summary>
<p>

<img width="194" alt="Screenshot 2024-11-19 at 10 47 06 AM" src="https://github.com/user-attachments/assets/8f1cc19b-d812-4000-ac02-c241345d6058">

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where buttons shown under the Window Controls Overlay API were missing tooltips.
