### PR TITLE
chore: fix textured window conditional on macOS

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -167,11 +167,6 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   if (!rounded_corner && !has_frame())
     styleMask = NSWindowStyleMaskBorderless;
 
-// TODO: remove NSWindowStyleMaskTexturedBackground.
-// https://github.com/electron/electron/issues/43125
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-
   if (minimizable)
     styleMask |= NSWindowStyleMaskMiniaturizable;
   if (closable)
@@ -179,17 +174,16 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   if (resizable)
     styleMask |= NSWindowStyleMaskResizable;
 
+// TODO: remove NSWindowStyleMaskTexturedBackground.
+// https://github.com/electron/electron/issues/43125
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  if (windowType == "textured" || transparent() || !has_frame()) {
+  if (windowType == "textured" && (transparent() || !has_frame())) {
     util::EmitWarning(
         "The 'textured' window type is deprecated and will be removed",
         "DeprecationWarning");
     styleMask |= NSWindowStyleMaskTexturedBackground;
   }
-#pragma clang diagnostic pop
-
-// -Wdeprecated-declarations
 #pragma clang diagnostic pop
 
   // Create views::Widget and assign window_ with it.


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/44688

Fixes an issue where frameless windows emitted a deprecation warning due to `NSWindowStyleMaskTexturedBackground` being deprecated. It's been functionally a no-op for a while (see https://chromium-review.googlesource.com/c/chromium/src/+/4300751) but should only be emitted when a user explicitly passes `type: textured`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where a deprecation warning was being incorrectly emitted for frameless windows on macOS.
