### PR TITLE
refactor: use gdk_display_beep() on Linux

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -84,7 +84,10 @@ if (is_linux) {
   # from the gtk library. Function signatures for which stubs are
   # required should be declared in the sig files.
   generate_stubs("electron_gtk_stubs") {
-    sigs = [ "shell/browser/ui/electron_gdk_pixbuf.sigs" ]
+    sigs = [
+      "shell/browser/ui/electron_gdk.sigs",
+      "shell/browser/ui/electron_gdk_pixbuf.sigs",
+    ]
     extra_header = "shell/browser/ui/electron_gtk.fragment"
     output_name = "electron_gtk_stubs"
     public_deps = [ "//ui/gtk:gtk_config" ]

--- a/shell/browser/ui/electron_gdk.sigs
+++ b/shell/browser/ui/electron_gdk.sigs
@@ -1,0 +1,1 @@
+void gdk_display_beep(GdkDisplay* display);

--- a/shell/browser/ui/electron_gtk.sigs
+++ b/shell/browser/ui/electron_gtk.sigs
@@ -1,7 +1,0 @@
-GtkFileChooserNative* gtk_file_chooser_native_new(const gchar* title, GtkWindow* parent, GtkFileChooserAction action, const gchar* accept_label, const gchar* cancel_label);
-void gtk_native_dialog_set_modal(GtkNativeDialog* self, gboolean modal);
-void gtk_native_dialog_show(GtkNativeDialog* self);
-void gtk_native_dialog_hide(GtkNativeDialog* self);
-gint gtk_native_dialog_run(GtkNativeDialog* self);
-void gtk_native_dialog_destroy(GtkNativeDialog* self);
-GType gtk_native_dialog_get_type(void);

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -11,6 +11,8 @@
 #include <string>
 #include <vector>
 
+#include <gtk/gtk.h>
+
 #include "base/cancelable_callback.h"
 #include "base/containers/contains.h"
 #include "base/environment.h"
@@ -408,15 +410,7 @@ bool PlatformTrashItem(const base::FilePath& full_path, std::string* error) {
 }  // namespace internal
 
 void Beep() {
-  // echo '\a' > /dev/console
-  FILE* fp = fopen("/dev/console", "a");
-  if (fp == nullptr) {
-    fp = fopen("/dev/tty", "a");
-  }
-  if (fp != nullptr) {
-    fprintf(fp, "\a");
-    fclose(fp);
-  }
+  gdk_display_beep(gdk_display_get_default());
 }
 
 bool GetDesktopName(std::string* setme) {

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -11,7 +11,7 @@
 #include <string>
 #include <vector>
 
-#include <gtk/gtk.h>
+#include <gdk/gdk.h>
 
 #include "base/cancelable_callback.h"
 #include "base/containers/contains.h"
@@ -34,6 +34,9 @@
 #include "dbus/bus.h"
 #include "dbus/message.h"
 #include "dbus/object_proxy.h"
+#include "electron/electron_gtk_stubs.h"
+#include "ui/gtk/gtk_stubs.h"
+
 #include "shell/common/platform_util_internal.h"
 #include "url/gurl.h"
 
@@ -410,7 +413,8 @@ bool PlatformTrashItem(const base::FilePath& full_path, std::string* error) {
 }  // namespace internal
 
 void Beep() {
-  gdk_display_beep(gdk_display_get_default());
+  auto* display = gdk_display_get_default();
+  gdk_display_beep(display);
 }
 
 bool GetDesktopName(std::string* setme) {

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -34,8 +34,6 @@
 #include "dbus/bus.h"
 #include "dbus/message.h"
 #include "dbus/object_proxy.h"
-#include "electron/electron_gtk_stubs.h"
-#include "ui/gtk/gtk_stubs.h"
 
 #include "shell/common/platform_util_internal.h"
 #include "url/gurl.h"


### PR DESCRIPTION
#### Description of Change

Simplify `platform_util::Beep()` by using [gdk_display_beep()](https://docs.gtk.org/gdk4/method.Display.beep.html) instead of rolling our own implementation.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.