### PR TITLE
fix: `performance-no-automatic-move` clang-tidy warnings

### DIFF
--- a/shell/browser/extensions/electron_extensions_browser_client.cc
+++ b/shell/browser/extensions/electron_extensions_browser_client.cc
@@ -174,7 +174,7 @@ base::FilePath ElectronExtensionsBrowserClient::GetBundleResourcePath(
   if (!chrome_resources_path.IsParent(extension_resources_path))
     return base::FilePath();
 
-  const base::FilePath request_relative_path =
+  base::FilePath request_relative_path =
       extensions::file_util::ExtensionURLToRelativeFilePath(request.url);
   if (!ExtensionsBrowserClient::Get()
            ->GetComponentExtensionResourceManager()

--- a/shell/common/logging.cc
+++ b/shell/common/logging.cc
@@ -29,16 +29,13 @@ base::FilePath GetLogFileName(const base::CommandLine& command_line) {
   if (!filename.empty())
     return base::FilePath::FromUTF8Unsafe(filename);
 
-  const base::FilePath log_filename(FILE_PATH_LITERAL("electron_debug.log"));
-  base::FilePath log_path;
+  auto log_filename = base::FilePath{FILE_PATH_LITERAL("electron_debug.log")};
 
-  if (base::PathService::Get(chrome::DIR_LOGS, &log_path)) {
-    log_path = log_path.Append(log_filename);
-    return log_path;
-  } else {
-    // error with path service, just use some default file somewhere
-    return log_filename;
-  }
+  if (base::FilePath path; base::PathService::Get(chrome::DIR_LOGS, &path))
+    return path.Append(log_filename);
+
+  // error with path service, just use some default file somewhere
+  return log_filename;
 }
 
 namespace {


### PR DESCRIPTION
#### Description of Change

Fix two [performance-no-automatic-move](https://clang.llvm.org/extra/clang-tidy/checks/performance/no-automatic-move.html) warnings.

Fixed by this PR:

> ../../electron/shell/common/logging.cc:40:12: warning: constness of 'log_filename' prevents automatic move [performance-no-automatic-move]
>
> ../../electron/shell/browser/extensions/electron_extensions_browser_client.cc:187:10: warning: constness of 'request_relative_path' prevents automatic move [performance-no-automatic-move]

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none