### PR TITLE
fix: clang-tidy `performance-inefficient-vector-operation` warnings

### DIFF
--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -7,6 +7,7 @@
 #include <map>
 
 #include "base/containers/contains.h"
+#include "base/containers/to_vector.h"
 #include "base/run_loop.h"
 #include "base/strings/utf_string_conversions.h"
 #include "shell/browser/browser.h"
@@ -280,11 +281,8 @@ void Clipboard::Clear(gin_helper::Arguments* args) {
 
 // This exists for testing purposes ONLY.
 void Clipboard::WriteFilesForTesting(const std::vector<base::FilePath>& files) {
-  std::vector<ui::FileInfo> file_infos;
-  for (const auto& file : files) {
-    file_infos.emplace_back(ui::FileInfo(ui::FileInfo(file, file.BaseName())));
-  }
-
+  auto to_info = [](const auto& p) { return ui::FileInfo{p, p.BaseName()}; };
+  auto file_infos = base::ToVector(files, to_info);
   ui::ScopedClipboardWriter writer(ui::ClipboardBuffer::kCopyPaste);
   writer.WriteFilenames(ui::FileInfosToURIList(file_infos));
 }


### PR DESCRIPTION
#### Description of Change

Another minor refactor to fix `performance-*` warnings generated by clang-tidy.

tldr, these two warnings were "call vector.reserve() before populating the vector":

```
../../electron/shell/browser/api/electron_api_crash_reporter.cc:228:5: warning: 'push_back' is called inside a loop; consider pre-allocating the container capacity before the loop [performance-inefficient-vector-operation]
  227 |   for (auto* const upload : uploads) {
  228 |     result.push_back(gin::DataObjectBuilder(isolate)
      |     ^
../../electron/shell/common/api/electron_api_clipboard.cc:285:5: warning: 'emplace_back' is called inside a loop; consider pre-allocating the container capacity before the loop [performance-inefficient-vector-operation]
  284 |   for (const auto& file : files) {
  285 |     file_infos.emplace_back(ui::FileInfo(ui::FileInfo(file, file.BaseName())));
      |     ^
```

Fixing them also fixed these other two warnings for free:

```
../../electron/shell/browser/api/electron_api_crash_reporter.cc:227:8: warning: 'auto *const upload' can be declared as 'const auto *const upload' [readability-qualified-auto]
  227 |   for (auto* const upload : uploads) {
      |        ^
      |        const 
../../electron/shell/common/api/electron_api_clipboard.cc:285:29: warning: unnecessary temporary object created while calling emplace_back [modernize-use-emplace]
  285 |     file_infos.emplace_back(ui::FileInfo(ui::FileInfo(file, file.BaseName())));
      |                             ^~~~~~~~~~~~~                                   ~

```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.