### PR TITLE
fix: Implement 8 gamepads

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -135,3 +135,4 @@ chore_partial_revert_of.patch
 fix_software_compositing_infinite_loop.patch
 refactor_unfilter_unresponsive_events.patch
 build_disable_thin_lto_mac.patch
+increase_gamepad_limit_to_8.patch

--- a/patches/chromium/increase_gamepad_limit_to_8.patch
+++ b/patches/chromium/increase_gamepad_limit_to_8.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Filip Strelec <filip.strelec@gmail.com>
 Date: Thu, 20 Sep 2018 17:48:38 -0700
-Subject: gtk_visibility.patch
+Subject: increase_gamepad_limit_to_8.patch
 
 Allow up to 8 gamepads
 

--- a/patches/chromium/increase_gamepad_limit_to_8.patch
+++ b/patches/chromium/increase_gamepad_limit_to_8.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Filip Strelec <filip.strelec@gmail.com>
+Date: Thu, 20 Sep 2018 17:48:38 -0700
+Subject: gtk_visibility.patch
+
+Allow up to 8 gamepads
+
+diff --git a/device/gamepad/public/cpp/gamepads.h b/device/gamepad/public/cpp/gamepads.h
+--- a/device/gamepad/public/cpp/gamepads.h
++++ b/device/gamepad/public/cpp/gamepads.h
+@@ -17,7 +17,7 @@ namespace device {
+ // browser.
+ class COMPONENT_EXPORT(GAMEPAD_PUBLIC) Gamepads {
+  public:
+-  static constexpr size_t kItemsLengthCap = 4;
++  static constexpr size_t kItemsLengthCap = 8;
+ 
+   // Gamepad data for N separate gamepad devices.
+   std::array<Gamepad, kItemsLengthCap> items;


### PR DESCRIPTION
#### Description of Change
This pr should fix the problem with the limit of 4 gamepads minimum.

Bare in mind, this has not yet been tested!
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->








#### Release Notes
Removed the 4 gamepads limit for gamepad API
Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->

P.S. If this works, is it possible to merge the fix in "electron": "27.1.0", version ?
