### PR TITLE
fix: ensure `context-menu` emitted for draggable regions

### DIFF
--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -169,6 +169,9 @@ class NativeWindowMac : public NativeWindow,
   void NotifyWindowDidFailToEnterFullScreen();
   void NotifyWindowWillLeaveFullScreen();
 
+  // views::WidgetDelegate:
+  views::View* GetContentsView() override;
+
   // Cleanup observers when window is getting closed. Note that the destructor
   // can be called much later after window gets closed, so we should not do
   // cleanup in destructor.
@@ -220,7 +223,6 @@ class NativeWindowMac : public NativeWindow,
 
  protected:
   // views::WidgetDelegate:
-  views::View* GetContentsView() override;
   bool CanMaximize() const override;
   std::unique_ptr<views::NonClientFrameView> CreateNonClientFrameView(
       views::Widget* widget) override;

--- a/shell/browser/ui/cocoa/delayed_native_view_host.h
+++ b/shell/browser/ui/cocoa/delayed_native_view_host.h
@@ -23,7 +23,8 @@ class DelayedNativeViewHost : public views::NativeViewHost {
   // views::View:
   void ViewHierarchyChanged(
       const views::ViewHierarchyChangedDetails& details) override;
-  bool OnMousePressed(const ui::MouseEvent& event) override;
+
+  gfx::NativeView GetNativeView() { return native_view_; }
 
  private:
   gfx::NativeView native_view_;

--- a/shell/browser/ui/cocoa/delayed_native_view_host.mm
+++ b/shell/browser/ui/cocoa/delayed_native_view_host.mm
@@ -3,8 +3,6 @@
 // found in the LICENSE file.
 
 #include "shell/browser/ui/cocoa/delayed_native_view_host.h"
-#include "base/apple/owned_objc.h"
-#include "shell/browser/ui/cocoa/electron_inspectable_web_contents_view.h"
 
 namespace electron {
 
@@ -20,23 +18,6 @@ void DelayedNativeViewHost::ViewHierarchyChanged(
   NativeViewHost::ViewHierarchyChanged(details);
   if (details.is_add && GetWidget() && !native_view())
     Attach(native_view_);
-}
-
-bool DelayedNativeViewHost::OnMousePressed(const ui::MouseEvent& ui_event) {
-  // NativeViewHost::OnMousePressed normally isn't called, but
-  // NativeWidgetMacNSWindow specifically carves out an event here for
-  // right-mouse-button clicks. We want to forward them to the web content, so
-  // handle them here.
-  // See:
-  // https://source.chromium.org/chromium/chromium/src/+/main:components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm;l=415-421;drc=a5af91924bafb85426e091c6035801990a6dc697
-
-  ElectronInspectableWebContentsView* inspectable_web_contents_view =
-      (ElectronInspectableWebContentsView*)native_view_.GetNativeNSView();
-  [inspectable_web_contents_view
-      redispatchContextMenuEvent:base::apple::OwnedNSEvent(
-                                     ui_event.native_event())];
-
-  return true;
 }
 
 }  // namespace electron

--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -7,6 +7,8 @@
 #include "base/strings/sys_string_conversions.h"
 #include "electron/mas.h"
 #include "shell/browser/native_window_mac.h"
+#include "shell/browser/ui/cocoa/delayed_native_view_host.h"
+#include "shell/browser/ui/cocoa/electron_inspectable_web_contents_view.h"
 #include "shell/browser/ui/cocoa/electron_preview_item.h"
 #include "shell/browser/ui/cocoa/electron_touch_bar.h"
 #include "shell/browser/ui/cocoa/root_view_mac.h"
@@ -188,6 +190,38 @@ void SwizzleSwipeWithEvent(NSView* view, SEL swiz_selector) {
 }
 
 // NSWindow overrides.
+
+- (void)sendEvent:(NSEvent*)event {
+  // Draggable regions only respond to left-click dragging, but the system will
+  // still suppress right-clicks in a draggable region. Forwarding right-clicks
+  // and ctrl+left-clicks allows the underlying views to respond to right-click
+  // to potentially bring up a frame context menu. WebContentsView is now a
+  // sibling view of the NSWindow contentView, so we need to intercept the event
+  // here as NativeWidgetMacNSWindow won't forward it to the WebContentsView
+  // anymore.
+  if (event.type == NSEventTypeRightMouseDown ||
+      (event.type == NSEventTypeLeftMouseDown &&
+       ([event modifierFlags] & NSEventModifierFlagControl))) {
+    // The WebContentsView is added a sibling of BaseWindow's contentView at
+    // index 0 before it in the paint order - see
+    // https://github.com/electron/electron/pull/41256.
+    auto* wcv = shell_->GetContentsView()->children().front().get();
+    if (!wcv)
+      return;
+
+    auto ns_view = static_cast<electron::DelayedNativeViewHost*>(wcv)
+                       ->GetNativeView()
+                       .GetNativeNSView();
+    if (!ns_view)
+      return;
+
+    auto* iwcv = (ElectronInspectableWebContentsView*)ns_view;
+    [iwcv redispatchContextMenuEvent:base::apple::OwnedNSEvent(event)];
+    return;
+  }
+
+  [super sendEvent:event];
+}
 
 - (void)rotateWithEvent:(NSEvent*)event {
   shell_->NotifyWindowRotateGesture(event.rotation);

--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -205,7 +205,11 @@ void SwizzleSwipeWithEvent(NSView* view, SEL swiz_selector) {
     // The WebContentsView is added a sibling of BaseWindow's contentView at
     // index 0 before it in the paint order - see
     // https://github.com/electron/electron/pull/41256.
-    auto* wcv = shell_->GetContentsView()->children().front().get();
+    const auto& children = shell_->GetContentsView()->children();
+    if (children.empty())
+      return;
+
+    auto* wcv = children.front().get();
     if (!wcv)
       return;
 
@@ -215,8 +219,8 @@ void SwizzleSwipeWithEvent(NSView* view, SEL swiz_selector) {
     if (!ns_view)
       return;
 
-    auto* iwcv = (ElectronInspectableWebContentsView*)ns_view;
-    [iwcv redispatchContextMenuEvent:base::apple::OwnedNSEvent(event)];
+    [static_cast<ElectronInspectableWebContentsView*>(ns_view)
+        redispatchContextMenuEvent:base::apple::OwnedNSEvent(event)];
     return;
   }
 

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2730,6 +2730,25 @@ describe('webContents module', () => {
       expect(params.x).to.be.a('number');
       expect(params.y).to.be.a('number');
     });
+
+    it('emits when right-clicked in page in a draggable region', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadFile(path.join(fixturesPath, 'pages', 'draggable-page.html'));
+
+      const promise = once(w.webContents, 'context-menu') as Promise<[any, Electron.ContextMenuParams]>;
+
+      // Simulate right-click to create context-menu event.
+      const opts = { x: 0, y: 0, button: 'right' as const };
+      w.webContents.sendInputEvent({ ...opts, type: 'mouseDown' });
+      w.webContents.sendInputEvent({ ...opts, type: 'mouseUp' });
+
+      const [, params] = await promise;
+
+      expect(params.pageURL).to.equal(w.webContents.getURL());
+      expect(params.frame).to.be.an('object');
+      expect(params.x).to.be.a('number');
+      expect(params.y).to.be.a('number');
+    });
   });
 
   describe('close() method', () => {

--- a/spec/fixtures/pages/draggable-page.html
+++ b/spec/fixtures/pages/draggable-page.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>Draggable Page</title>
+  <style>
+    .draggable {
+      -webkit-app-region: drag;
+      height: 100vh;
+      width: 100vw;
+      margin: 0;
+      background-color: #f0f0f0;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="draggable"></div>
+</body>
+
+</html>


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/44386.
Refs https://github.com/electron/electron/pull/41256

Fixes an issue where the webContents `context-menu` event was not emitted when using `-webkit-app-region: drag`. This was happening after the sibling view change above because `sendEvent` in `NativeWidgetMacNSWindow` no longer sent the right-click event to the correct NSView. We can fix this by intercepting the event in `sendEvent` on `ElectronNSWindow`, which inherits from `NativeWidgetMacNSWindow`. This solution avoids patching.

cc @bpasero

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the webContents `context-menu` event was not emitted when using `-webkit-app-region: drag`.