### PR TITLE
fix: big endian bug in V8 serialization

### DIFF
--- a/shell/common/v8_util.cc
+++ b/shell/common/v8_util.cc
@@ -4,6 +4,7 @@
 
 #include "shell/common/v8_util.h"
 
+#include <cstdint>
 #include <utility>
 #include <vector>
 
@@ -20,11 +21,11 @@
 namespace electron {
 
 namespace {
-enum SerializationTag {
-  kNativeImageTag = 'i',
-  kTrailerOffsetTag = 0xFE,
-  kVersionTag = 0xFF
-};
+
+constexpr uint8_t kNativeImageTag = 'i';
+constexpr uint8_t kTrailerOffsetTag = 0xFE;
+constexpr uint8_t kVersionTag = 0xFF;
+
 }  // namespace
 
 class V8Serializer : public v8::ValueSerializer::Delegate {
@@ -104,7 +105,7 @@ class V8Serializer : public v8::ValueSerializer::Delegate {
   }
 
  private:
-  void WriteTag(SerializationTag tag) { serializer_.WriteRawBytes(&tag, 1); }
+  void WriteTag(const uint8_t tag) { serializer_.WriteRawBytes(&tag, 1U); }
 
   void WriteBlinkEnvelope(uint32_t blink_version) {
     // Write a dummy blink version envelope for compatibility with


### PR DESCRIPTION
#### Description of Change

Fix a sneaky bug that breaks our serialization on big endian systems.

I don't know of anyone running Electron running on IBM System/360, 370, and 390, so this probably less a production issue and more a code correctness issue :smile_cat: 

We have a set of 1-byte tags that we serialize in a single byte, but the tags are instantiated as 4-byte integers because of an untyped enum declaration. So when we call `V8Serializer::WriteRawBytes(void*, size_t )` with `WriteRawBytes(&tag, 1)`  the result is architecture-dependent: it writes the tag's little-endian byte on little-endian machines and works fine, but writes the tag's big-endian byte (a `'\0'`) on big-endian machines.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none