### PR TITLE
fix: crash calling `shell.readShortcutLink`

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -135,3 +135,4 @@ chore_partial_revert_of.patch
 fix_software_compositing_infinite_loop.patch
 refactor_unfilter_unresponsive_events.patch
 build_disable_thin_lto_mac.patch
+support_bstr_pkey_appusermodel_id_in_windows_shortcuts.patch

--- a/patches/chromium/support_bstr_pkey_appusermodel_id_in_windows_shortcuts.patch
+++ b/patches/chromium/support_bstr_pkey_appusermodel_id_in_windows_shortcuts.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Thu, 21 Nov 2024 14:23:17 +0100
+Subject: Support BSTR PKEY_AppUserModel_ID in Windows Shortcuts
+
+It's possible for a shortcut link on Windows to be BSTR format;
+this resulted in a DCHECK previously but as of the NOTREACHED
+fatal migration now will crash a given app. This has created an
+issue for Electron, which allows providing the shortcut information
+to end users. This CL thus allows for supporting VT_BSTR variants
+for PKEY_AppUserModel_ID and mitigates a crash. One such example
+is https://github.com/wez/wezterm, which after this change
+correctly gets an appUserModelId of 'org.wezfurlong.wezterm'.
+
+Bug: N/A
+Change-Id: I5ad114bc345059637465b68a53a2f3f8c42de898
+
+diff --git a/base/win/shortcut.cc b/base/win/shortcut.cc
+index d4a54d1afdc121192f9c0321c6ced584ee066486..02f3e63d16c3324f546f6155d722900f0a81131a 100644
+--- a/base/win/shortcut.cc
++++ b/base/win/shortcut.cc
+@@ -289,14 +289,22 @@ bool ResolveShortcutProperties(const FilePath& shortcut_path,
+         return false;
+       }
+       switch (pv_app_id.get().vt) {
+-        case VT_EMPTY:
++        case VT_EMPTY: {
+           properties->set_app_id(std::wstring());
+           break;
+-        case VT_LPWSTR:
++        }
++        case VT_LPWSTR: {
+           properties->set_app_id(pv_app_id.get().pwszVal);
+           break;
+-        default:
++        }
++        case VT_BSTR: {
++          BSTR bs = pv_app_id.get().bstrVal;
++          properties->set_app_id(std::wstring(bs, ::SysStringLen(bs)));
++          break;
++        }
++        default: {
+           NOTREACHED() << "Unexpected variant type: " << pv_app_id.get().vt;
++        }
+       }
+     }
+ 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/44752.

It's possible for a shortcut link on Windows to be BSTR format; this resulted in a DCHECK previously but as of the `NOTREACHED` fatal migration now will crash a given app. Fix this by allowing for supporting `VT_BSTR` variants
for `PKEY_AppUserModel_ID`.

Upstreamed at CL:6039894

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash that could occur when calling `shell.readShortcutLink` on Windows.