### PR TITLE
docs: fix wording in auto-updater.md

### DIFF
--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -68,7 +68,7 @@ Emitted when there is an error while updating.
 
 ### Event: 'checking-for-update'
 
-Emitted when checking if an update has started.
+Emitted when checking if an update is available has started.
 
 ### Event: 'update-available'
 

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -68,7 +68,7 @@ Emitted when there is an error while updating.
 
 ### Event: 'checking-for-update'
 
-Emitted when checking if an update is available has started.
+Emitted when checking for an available update has started.
 
 ### Event: 'update-available'
 


### PR DESCRIPTION
#### Description of Change

Simple wording fix in autoUpdater docs

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none