### PR TITLE
docs: update new GitHub issue link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ propose changes to this document in a pull request.
 
 ## [Issues](https://electronjs.org/docs/development/issues)
 
-Issues are created [here](https://github.com/electron/electron/issues/new).
+Issues are created [here](https://github.com/electron/electron/issues/new/choose).
 
 * [How to Contribute in Issues](https://electronjs.org/docs/development/issues#how-to-contribute-in-issues)
 * [Asking for General Help](https://electronjs.org/docs/development/issues#asking-for-general-help)


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

This currently dumps the user to the blank issue, which isn't what we want. Seems like there's oddly a behavior difference depending on if there's a trailing slash after `/issues/new` (trailing slash takes you to the chooser), so let's link directly to the issue template chooser.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
