### PR TITLE
fix: modernize-use-nodiscard clang-tidy warnings

### DIFF
--- a/shell/browser/electron_permission_manager.cc
+++ b/shell/browser/electron_permission_manager.cc
@@ -86,7 +86,7 @@ class ElectronPermissionManager::PendingRequest {
     return content::RenderFrameHost::FromID(render_frame_host_id_);
   }
 
-  bool IsComplete() const { return remaining_results_ == 0; }
+  [[nodiscard]] bool IsComplete() const { return remaining_results_ == 0; }
 
   void RunCallback() {
     if (!callback_.is_null()) {

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -135,15 +135,15 @@ class ElectronDelegatedFrameHostClient
       const ElectronDelegatedFrameHostClient&) = delete;
 
   // content::DelegatedFrameHostClient
-  ui::Layer* DelegatedFrameHostGetLayer() const override {
+  [[nodiscard]] ui::Layer* DelegatedFrameHostGetLayer() const override {
     return view_->root_layer();
   }
 
-  bool DelegatedFrameHostIsVisible() const override {
+  [[nodiscard]] bool DelegatedFrameHostIsVisible() const override {
     return view_->IsShowing();
   }
 
-  SkColor DelegatedFrameHostGetGutterColor() const override {
+  [[nodiscard]] SkColor DelegatedFrameHostGetGutterColor() const override {
     if (view_->render_widget_host()->delegate() &&
         view_->render_widget_host()->delegate()->IsFullscreen()) {
       return SK_ColorWHITE;
@@ -156,7 +156,7 @@ class ElectronDelegatedFrameHostClient
     view_->render_widget_host()->DidProcessFrame(frame_token, activation_time);
   }
 
-  float GetDeviceScaleFactor() const override {
+  [[nodiscard]] float GetDeviceScaleFactor() const override {
     return view_->GetDeviceScaleFactor();
   }
 

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -149,7 +149,7 @@ class BufferDataSource : public mojo::DataPipeProducer::DataSource {
 
  private:
   // mojo::DataPipeProducer::DataSource:
-  uint64_t GetLength() const override { return buffer_.size(); }
+  [[nodiscard]] uint64_t GetLength() const override { return buffer_.size(); }
   ReadResult Read(uint64_t offset, base::span<char> buffer) override {
     ReadResult result;
     if (offset <= buffer_.size()) {

--- a/shell/common/extensions/electron_extensions_client.cc
+++ b/shell/common/extensions/electron_extensions_client.cc
@@ -38,12 +38,12 @@ class ElectronPermissionMessageProvider
       const ElectronPermissionMessageProvider&) = delete;
 
   // PermissionMessageProvider implementation.
-  extensions::PermissionMessages GetPermissionMessages(
+  [[nodiscard]] extensions::PermissionMessages GetPermissionMessages(
       const extensions::PermissionIDSet& permissions) const override {
     return extensions::PermissionMessages();
   }
 
-  bool IsPrivilegeIncrease(
+  [[nodiscard]] bool IsPrivilegeIncrease(
       const extensions::PermissionSet& granted_permissions,
       const extensions::PermissionSet& requested_permissions,
       extensions::Manifest::Type extension_type) const override {
@@ -52,7 +52,7 @@ class ElectronPermissionMessageProvider
     return false;
   }
 
-  extensions::PermissionIDSet GetAllPermissionIDs(
+  [[nodiscard]] extensions::PermissionIDSet GetAllPermissionIDs(
       const extensions::PermissionSet& permissions,
       extensions::Manifest::Type extension_type) const override {
     return extensions::PermissionIDSet();

--- a/shell/common/gin_converters/osr_converter.cc
+++ b/shell/common/gin_converters/osr_converter.cc
@@ -54,7 +54,7 @@ struct OffscreenReleaseHolderMonitor {
     holder_ = nullptr;
   }
 
-  bool IsTextureReleased() const { return holder_ == nullptr; }
+  [[nodiscard]] bool IsTextureReleased() const { return holder_ == nullptr; }
 
   v8::Persistent<v8::Value>* CreatePersistent(v8::Isolate* isolate,
                                               v8::Local<v8::Value> value) {

--- a/shell/common/gin_helper/callback.cc
+++ b/shell/common/gin_helper/callback.cc
@@ -88,7 +88,7 @@ class RefCountedGlobal
   RefCountedGlobal(v8::Isolate* isolate, v8::Local<v8::Value> value)
       : handle_(isolate, value.As<T>()) {}
 
-  bool IsAlive() const { return !handle_.IsEmpty(); }
+  [[nodiscard]] bool IsAlive() const { return !handle_.IsEmpty(); }
 
   v8::Local<T> NewHandle(v8::Isolate* isolate) const {
     return v8::Local<T>::New(isolate, handle_);

--- a/shell/common/heap_snapshot.cc
+++ b/shell/common/heap_snapshot.cc
@@ -18,7 +18,7 @@ class HeapSnapshotOutputStream : public v8::OutputStream {
     DCHECK(file_);
   }
 
-  bool IsComplete() const { return is_complete_; }
+  [[nodiscard]] bool IsComplete() const { return is_complete_; }
 
   // v8::OutputStream
   int GetChunkSize() override { return 65536; }

--- a/shell/renderer/api/electron_api_spell_check_client.cc
+++ b/shell/renderer/api/electron_api_spell_check_client.cc
@@ -58,7 +58,7 @@ class SpellCheckClient::SpellcheckRequest {
   SpellcheckRequest& operator=(const SpellcheckRequest&) = delete;
   ~SpellcheckRequest() = default;
 
-  const std::u16string& text() const { return text_; }
+  [[nodiscard]] const std::u16string& text() const { return text_; }
   blink::WebTextCheckingCompletion* completion() { return completion_.get(); }
   std::vector<Word>& wordlist() { return word_list_; }
 

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -132,7 +132,7 @@ class ChromePdfInternalPluginDelegate final
   ~ChromePdfInternalPluginDelegate() override = default;
 
   // `pdf::PdfInternalPluginDelegate`:
-  bool IsAllowedOrigin(const url::Origin& origin) const override {
+  [[nodiscard]] bool IsAllowedOrigin(const url::Origin& origin) const override {
     return origin.scheme() == extensions::kExtensionScheme &&
            origin.host() == extension_misc::kPdfExtensionId;
   }


### PR DESCRIPTION
#### Description of Change

Annotate functions as `[[nodiscard]]` as suggested by clang-tidy's `modernize-use-nodiscard` warning

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none