### PR TITLE
fix: remove unused local variables

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1011,8 +1011,6 @@ bool App::RequestSingleInstanceLock(gin::Arguments* args) {
   if (HasSingleInstanceLock())
     return true;
 
-  std::string program_name = electron::Browser::Get()->GetName();
-
   base::FilePath user_dir;
   base::PathService::Get(chrome::DIR_USER_DATA, &user_dir);
   // The user_dir may not have been created yet.
@@ -1023,6 +1021,7 @@ bool App::RequestSingleInstanceLock(gin::Arguments* args) {
   blink::CloneableMessage additional_data_message;
   args->GetNext(&additional_data_message);
 #if BUILDFLAG(IS_WIN)
+  const std::string program_name = electron::Browser::Get()->GetName();
   bool app_is_sandboxed =
       IsSandboxEnabled(base::CommandLine::ForCurrentProcess());
   process_singleton_ = std::make_unique<ProcessSingleton>(

--- a/shell/browser/relauncher.cc
+++ b/shell/browser/relauncher.cc
@@ -157,7 +157,6 @@ int RelauncherMain(const content::MainFunctionParams& main_parameters) {
   // Figure out what to execute, what arguments to pass it, and whether to
   // start it in the background.
   bool in_relauncher_args = false;
-  StringType relaunch_executable;
   StringVector relauncher_args;
   StringVector launch_argv;
   for (size_t argv_index = 2; argv_index < argv.size(); ++argv_index) {

--- a/shell/browser/ui/views/global_menu_bar_registrar_x11.cc
+++ b/shell/browser/ui/views/global_menu_bar_registrar_x11.cc
@@ -80,7 +80,6 @@ void GlobalMenuBarRegistrarX11::RegisterXWindow(x11::Window window) {
 
 void GlobalMenuBarRegistrarX11::UnregisterXWindow(x11::Window window) {
   DCHECK(registrar_proxy_);
-  std::string path = electron::GlobalMenuBarX11::GetPathForWindow(window);
 
   ANNOTATE_SCOPED_MEMORY_LEAK;  // http://crbug.com/314087
   // TODO(erg): The mozilla implementation goes to a lot of callback trouble


### PR DESCRIPTION
#### Description of Change

Don't declare local variables that we don't use.

This `bugprone-unused-local-non-trivial-variable` off of our clang-tidy bingo card :smile_cat: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.