### PR TITLE
refactor: fix modernize-return-braced-init-list warnings

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -776,7 +776,7 @@ base::OnceClosure App::SelectClientCertificate(
         std::move((*shared_identities)[0]),
         base::BindRepeating(&GotPrivateKey, shared_delegate, std::move(cert)));
   }
-  return base::OnceClosure();
+  return {};
 }
 
 void App::OnGpuInfoUpdate() {
@@ -944,7 +944,7 @@ std::string App::GetSystemLocale(gin_helper::ErrorThrower thrower) const {
     thrower.ThrowError(
         "app.getSystemLocale() can only be called "
         "after app is ready");
-    return std::string();
+    return {};
   }
   return static_cast<BrowserProcessImpl*>(g_browser_process)->GetSystemLocale();
 }

--- a/shell/browser/api/electron_api_cookies.cc
+++ b/shell/browser/api/electron_api_cookies.cc
@@ -168,7 +168,7 @@ void FilterCookieWithStatuses(
 // Parse dictionary property to CanonicalCookie time correctly.
 base::Time ParseTimeProperty(const std::optional<double>& value) {
   if (!value)  // empty time means ignoring the parameter
-    return base::Time();
+    return {};
   if (*value == 0)  // FromSecondsSinceUnixEpoch would convert 0 to empty Time
     return base::Time::UnixEpoch();
   return base::Time::FromSecondsSinceUnixEpoch(*value);

--- a/shell/browser/api/electron_api_crash_reporter.cc
+++ b/shell/browser/api/electron_api_crash_reporter.cc
@@ -99,7 +99,7 @@ std::string ReadClientId() {
   if (GetClientIdPath(&client_id_path) &&
       (!base::ReadFileToStringWithMaxSize(client_id_path, &client_id, 36) ||
        client_id.size() != 36))
-    return std::string();
+    return {};
   return client_id;
 }
 

--- a/shell/browser/api/electron_api_net_log.cc
+++ b/shell/browser/api/electron_api_net_log.cc
@@ -63,8 +63,7 @@ scoped_refptr<base::SequencedTaskRunner> CreateFileTaskRunner() {
 }
 
 base::File OpenFileForWriting(base::FilePath path) {
-  return base::File(path,
-                    base::File::FLAG_CREATE_ALWAYS | base::File::FLAG_WRITE);
+  return {path, base::File::FLAG_CREATE_ALWAYS | base::File::FLAG_WRITE};
 }
 
 void ResolvePromiseWithNetError(gin_helper::Promise<void> promise,
@@ -93,7 +92,7 @@ v8::Local<v8::Promise> NetLog::StartLogging(base::FilePath log_path,
                                             gin::Arguments* args) {
   if (log_path.empty()) {
     args->ThrowTypeError("The first parameter must be a valid string");
-    return v8::Local<v8::Promise>();
+    return {};
   }
 
   net::NetLogCaptureMode capture_mode = net::NetLogCaptureMode::kDefault;
@@ -106,7 +105,7 @@ v8::Local<v8::Promise> NetLog::StartLogging(base::FilePath log_path,
       if (!gin::ConvertFromV8(args->isolate(), capture_mode_v8,
                               &capture_mode)) {
         args->ThrowTypeError("Invalid value for captureMode");
-        return v8::Local<v8::Promise>();
+        return {};
       }
     }
     v8::Local<v8::Value> max_file_size_v8;
@@ -114,14 +113,14 @@ v8::Local<v8::Promise> NetLog::StartLogging(base::FilePath log_path,
       if (!gin::ConvertFromV8(args->isolate(), max_file_size_v8,
                               &max_file_size)) {
         args->ThrowTypeError("Invalid value for maxFileSize");
-        return v8::Local<v8::Promise>();
+        return {};
       }
     }
   }
 
   if (net_log_exporter_) {
     args->ThrowTypeError("There is already a net log running");
-    return v8::Local<v8::Promise>();
+    return {};
   }
 
   pending_start_promise_ =

--- a/shell/browser/api/electron_api_safe_storage.cc
+++ b/shell/browser/api/electron_api_safe_storage.cc
@@ -53,13 +53,13 @@ v8::Local<v8::Value> EncryptString(v8::Isolate* isolate,
     if (!electron::Browser::Get()->is_ready()) {
       gin_helper::ErrorThrower(isolate).ThrowError(
           "safeStorage cannot be used before app is ready");
-      return v8::Local<v8::Value>();
+      return {};
     }
     gin_helper::ErrorThrower(isolate).ThrowError(
         "Error while encrypting the text provided to "
         "safeStorage.encryptString. "
         "Encryption is not available.");
-    return v8::Local<v8::Value>();
+    return {};
   }
 
   std::string ciphertext;
@@ -69,7 +69,7 @@ v8::Local<v8::Value> EncryptString(v8::Isolate* isolate,
     gin_helper::ErrorThrower(isolate).ThrowError(
         "Error while encrypting the text provided to "
         "safeStorage.encryptString.");
-    return v8::Local<v8::Value>();
+    return {};
   }
 
   return node::Buffer::Copy(isolate, ciphertext.c_str(), ciphertext.size())

--- a/shell/browser/api/electron_api_screen.cc
+++ b/shell/browser/api/electron_api_screen.cc
@@ -82,7 +82,7 @@ gfx::Point Screen::GetCursorScreenPoint(v8::Isolate* isolate) {
     thrower.ThrowError(
         "screen.getCursorScreenPoint() cannot be called before a window has "
         "been created.");
-    return gfx::Point();
+    return {};
   }
 #endif
   return screen_->GetCursorScreenPoint();

--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -67,13 +67,13 @@ gin::Handle<Tray> Tray::New(gin_helper::ErrorThrower thrower,
                             gin::Arguments* args) {
   if (!Browser::Get()->is_ready()) {
     thrower.ThrowError("Cannot create Tray before app is ready");
-    return gin::Handle<Tray>();
+    return {};
   }
 
 #if BUILDFLAG(IS_WIN)
   if (!guid.has_value() && args->Length() > 1) {
     thrower.ThrowError("Invalid GUID format");
-    return gin::Handle<Tray>();
+    return {};
   }
 #endif
 
@@ -85,7 +85,7 @@ gin::Handle<Tray> Tray::New(gin_helper::ErrorThrower thrower,
   if (try_catch.HasCaught()) {
     delete tray;
     try_catch.ReThrow();
-    return gin::Handle<Tray>();
+    return {};
   }
 
   auto handle = gin::CreateHandle(args->isolate(), tray);
@@ -264,7 +264,7 @@ void Tray::SetTitle(const std::string& title,
 
 std::string Tray::GetTitle() {
   if (!CheckAlive())
-    return std::string();
+    return {};
 #if BUILDFLAG(IS_MAC)
   return tray_icon_->GetTitle();
 #else
@@ -388,7 +388,7 @@ void Tray::SetContextMenu(gin_helper::ErrorThrower thrower,
 
 gfx::Rect Tray::GetBounds() {
   if (!CheckAlive())
-    return gfx::Rect();
+    return {};
   return tray_icon_->GetBounds();
 }
 

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -282,7 +282,7 @@ void View::SetBounds(const gfx::Rect& bounds) {
 
 gfx::Rect View::GetBounds() {
   if (!view_)
-    return gfx::Rect();
+    return {};
   return view_->bounds();
 }
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2650,7 +2650,7 @@ std::string WebContents::GetMediaSourceID(
     content::WebContents* request_web_contents) {
   auto* frame_host = web_contents()->GetPrimaryMainFrame();
   if (!frame_host)
-    return std::string();
+    return {};
 
   content::DesktopMediaID media_id(
       content::DesktopMediaID::TYPE_WEB_CONTENTS,
@@ -2660,7 +2660,7 @@ std::string WebContents::GetMediaSourceID(
 
   auto* request_frame_host = request_web_contents->GetPrimaryMainFrame();
   if (!request_frame_host)
-    return std::string();
+    return {};
 
   std::string id =
       content::DesktopStreamsRegistry::GetInstance()->RegisterStream(
@@ -2782,7 +2782,7 @@ bool WebContents::IsDevToolsOpened() {
 
 std::u16string WebContents::GetDevToolsTitle() {
   if (type_ == Type::kRemote)
-    return std::u16string();
+    return {};
 
   DCHECK(inspectable_web_contents_);
   return inspectable_web_contents_->GetDevToolsTitle();
@@ -3662,7 +3662,7 @@ gfx::Size WebContents::GetSizeForNewRenderView(content::WebContents* wc) {
     }
   }
 
-  return gfx::Size();
+  return {};
 }
 
 void WebContents::SetZoomLevel(double level) {

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -344,7 +344,7 @@ content::FrameTreeNodeId WebFrameMain::FrameTreeNodeID() const {
 
 std::string WebFrameMain::Name() const {
   if (!CheckRenderFrame())
-    return std::string();
+    return {};
   return render_frame_->GetFrameName();
 }
 
@@ -376,7 +376,7 @@ GURL WebFrameMain::URL() const {
 
 std::string WebFrameMain::Origin() const {
   if (!CheckRenderFrame())
-    return std::string();
+    return {};
   return render_frame_->GetLastCommittedOrigin().Serialize();
 }
 

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -66,9 +66,9 @@ std::optional<std::string> GetXdgAppOutput(
                                                &success_code);
 
   if (!ran_ok || success_code != EXIT_SUCCESS)
-    return std::optional<std::string>();
+    return {};
 
-  return std::make_optional(reply);
+  return reply;
 }
 
 bool SetDefaultWebClient(const std::string& protocol) {

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -598,7 +598,7 @@ ElectronBrowserClient::GetGeneratedCodeCacheSettings(
   // If we pass 0 for size, disk_cache will pick a default size using the
   // heuristics based on available disk size. These are implemented in
   // disk_cache::PreferredCacheSize in net/disk_cache/cache_util.cc.
-  return content::GeneratedCodeCacheSettings(true, 0, cache_path);
+  return {true, 0, cache_path};
 }
 
 void ElectronBrowserClient::AllowCertificateError(
@@ -631,7 +631,7 @@ base::OnceClosure ElectronBrowserClient::SelectClientCertificate(
         std::move(client_certs), std::move(delegate));
   }
 
-  return base::OnceClosure();
+  return {};
 }
 
 bool ElectronBrowserClient::CanCreateWindow(
@@ -987,7 +987,7 @@ base::FilePath ElectronBrowserClient::GetDefaultDownloadDirectory() {
   base::FilePath download_path;
   if (base::PathService::Get(chrome::DIR_DEFAULT_DOWNLOADS, &download_path))
     return download_path;
-  return base::FilePath();
+  return {};
 }
 
 scoped_refptr<network::SharedURLLoaderFactory>

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -163,7 +163,7 @@ std::u16string MediaStringProvider(media::MessageId id) {
       return u"Communications";
 #endif
     default:
-      return std::u16string();
+      return {};
   }
 }
 

--- a/shell/browser/electron_permission_manager.cc
+++ b/shell/browser/electron_permission_manager.cc
@@ -278,8 +278,7 @@ ElectronPermissionManager::GetPermissionResultForOriginWithoutContext(
     const url::Origin& embedding_origin) {
   blink::mojom::PermissionStatus status = GetPermissionStatus(
       permission, requesting_origin.GetURL(), embedding_origin.GetURL());
-  return content::PermissionResult(
-      status, content::PermissionStatusSource::UNSPECIFIED);
+  return {status, content::PermissionStatusSource::UNSPECIFIED};
 }
 
 void ElectronPermissionManager::CheckBluetoothDevicePair(

--- a/shell/browser/extensions/electron_extensions_browser_client.cc
+++ b/shell/browser/extensions/electron_extensions_browser_client.cc
@@ -165,14 +165,14 @@ base::FilePath ElectronExtensionsBrowserClient::GetBundleResourcePath(
   *resource_id = 0;
   base::FilePath chrome_resources_path;
   if (!base::PathService::Get(chrome::DIR_RESOURCES, &chrome_resources_path))
-    return base::FilePath();
+    return {};
 
   // Since component extension resources are included in
   // component_extension_resources.pak file in |chrome_resources_path|,
   // calculate the extension |request_relative_path| against
   // |chrome_resources_path|.
   if (!chrome_resources_path.IsParent(extension_resources_path))
-    return base::FilePath();
+    return {};
 
   base::FilePath request_relative_path =
       extensions::file_util::ExtensionURLToRelativeFilePath(request.url);
@@ -180,7 +180,7 @@ base::FilePath ElectronExtensionsBrowserClient::GetBundleResourcePath(
            ->GetComponentExtensionResourceManager()
            ->IsComponentExtensionResource(extension_resources_path,
                                           request_relative_path, resource_id)) {
-    return base::FilePath();
+    return {};
   }
   DCHECK_NE(0, *resource_id);
 

--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -40,12 +40,14 @@ gin::IsolateHolder CreateIsolateHolder(v8::Isolate* isolate) {
   // This is necessary for important aspects of Node.js
   // including heap and cpu profilers to function properly.
 
-  return gin::IsolateHolder(base::SingleThreadTaskRunner::GetCurrentDefault(),
-                            gin::IsolateHolder::kSingleThread,
-                            gin::IsolateHolder::IsolateType::kUtility,
-                            std::move(create_params),
-                            gin::IsolateHolder::IsolateCreationMode::kNormal,
-                            nullptr, nullptr, isolate);
+  return {base::SingleThreadTaskRunner::GetCurrentDefault(),
+          gin::IsolateHolder::kSingleThread,
+          gin::IsolateHolder::IsolateType::kUtility,
+          std::move(create_params),
+          gin::IsolateHolder::IsolateCreationMode::kNormal,
+          nullptr,
+          nullptr,
+          isolate};
 }
 
 }  // namespace

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -332,7 +332,7 @@ extensions::SizeConstraints NativeWindow::GetSizeConstraints() const {
   if (size_constraints_)
     return *size_constraints_;
   if (!content_size_constraints_)
-    return extensions::SizeConstraints();
+    return {};
   // Convert content size constraints to window size constraints.
   extensions::SizeConstraints constraints;
   if (content_size_constraints_->HasMaximumSize()) {
@@ -366,7 +366,7 @@ extensions::SizeConstraints NativeWindow::GetContentSizeConstraints() const {
   if (content_size_constraints_)
     return *content_size_constraints_;
   if (!size_constraints_)
-    return extensions::SizeConstraints();
+    return {};
   // Convert window size constraints to content size constraints.
   // Note that we are not caching the results, because Chromium reccalculates
   // window frame size everytime when min/max sizes are passed, and we must

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -14,6 +14,7 @@
 #include "base/location.h"
 #include "base/memory/ptr_util.h"
 #include "base/memory/raw_ptr.h"
+#include "base/numerics/safe_conversions.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/time/time.h"
 #include "components/input/cursor_manager.h"
@@ -115,9 +116,9 @@ ui::MouseEvent UiMouseEventFromWebMouseEvent(blink::WebMouseEvent event) {
 
 ui::MouseWheelEvent UiMouseWheelEventFromWebMouseEvent(
     blink::WebMouseWheelEvent event) {
-  return ui::MouseWheelEvent(UiMouseEventFromWebMouseEvent(event),
-                             std::floor(event.delta_x),
-                             std::floor(event.delta_y));
+  return {UiMouseEventFromWebMouseEvent(event),
+          base::ClampFloor<int>(event.delta_x),
+          base::ClampFloor<int>(event.delta_y)};
 }
 
 }  // namespace

--- a/shell/browser/plugins/plugin_utils.cc
+++ b/shell/browser/plugins/plugin_utils.cc
@@ -28,7 +28,7 @@ std::string PluginUtils::GetExtensionIdForMimeType(
   auto it = map.find(mime_type);
   if (it != map.end())
     return it->second;
-  return std::string();
+  return {};
 }
 
 base::flat_map<std::string, std::string>

--- a/shell/browser/printing/printing_utils.cc
+++ b/shell/browser/printing/printing_utils.cc
@@ -59,7 +59,7 @@ gfx::Size GetDefaultPrinterDPI(const std::u16string& device_name) {
   GtkPrintSettings* print_settings = gtk_print_settings_new();
   int dpi = gtk_print_settings_get_resolution(print_settings);
   g_object_unref(print_settings);
-  return gfx::Size(dpi, dpi);
+  return {dpi, dpi};
 #endif
 }
 

--- a/shell/browser/ui/autofill_popup.cc
+++ b/shell/browser/ui/autofill_popup.cc
@@ -245,7 +245,7 @@ gfx::Rect AutofillPopup::popup_bounds_in_view() {
   gfx::Point origin(popup_bounds_.origin());
   views::View::ConvertPointFromScreen(parent_, &origin);
 
-  return gfx::Rect(origin, popup_bounds_.size());
+  return {origin, popup_bounds_.size()};
 }
 
 void AutofillPopup::OnViewBoundsChanged(views::View* view) {
@@ -280,9 +280,8 @@ int AutofillPopup::GetDesiredPopupWidth() {
 gfx::Rect AutofillPopup::GetRowBounds(int index) {
   int top = kPopupBorderThickness + index * kRowHeight;
 
-  return gfx::Rect(kPopupBorderThickness, top,
-                   popup_bounds_.width() - 2 * kPopupBorderThickness,
-                   kRowHeight);
+  return {kPopupBorderThickness, top,
+          popup_bounds_.width() - 2 * kPopupBorderThickness, kRowHeight};
 }
 
 const gfx::FontList& AutofillPopup::GetValueFontListForRow(int index) const {

--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
@@ -50,12 +50,12 @@ gfx::Insets ElectronDesktopWindowTreeHostLinux::CalculateInsetsInDIP(
     ui::PlatformWindowState window_state) const {
   // If we are not showing frame, the insets should be zero.
   if (native_window_view_->IsFullscreen()) {
-    return gfx::Insets();
+    return {};
   }
 
   if (!native_window_view_->has_frame() ||
       !native_window_view_->has_client_frame()) {
-    return gfx::Insets();
+    return {};
   }
 
   auto* view = static_cast<ClientFrameViewLinux*>(

--- a/shell/browser/ui/tray_icon.cc
+++ b/shell/browser/ui/tray_icon.cc
@@ -13,7 +13,7 @@ TrayIcon::TrayIcon() = default;
 TrayIcon::~TrayIcon() = default;
 
 gfx::Rect TrayIcon::GetBounds() {
-  return gfx::Rect();
+  return {};
 }
 
 void TrayIcon::NotifyClicked(const gfx::Rect& bounds,

--- a/shell/browser/ui/views/client_frame_view_linux.cc
+++ b/shell/browser/ui/views/client_frame_view_linux.cc
@@ -154,8 +154,8 @@ gfx::Insets ClientFrameViewLinux::GetBorderDecorationInsets() const {
 }
 
 gfx::Insets ClientFrameViewLinux::GetInputInsets() const {
-  return gfx::Insets(
-      host_supports_client_frame_shadow_ ? -kResizeOutsideBorderSize : 0);
+  return gfx::Insets{
+      host_supports_client_frame_shadow_ ? -kResizeOutsideBorderSize : 0};
 }
 
 gfx::Rect ClientFrameViewLinux::GetWindowContentBounds() const {
@@ -457,7 +457,7 @@ void ClientFrameViewLinux::LayoutButtonsOnSide(
 
 gfx::Rect ClientFrameViewLinux::GetTitlebarBounds() const {
   if (frame_->IsFullscreen()) {
-    return gfx::Rect();
+    return {};
   }
 
   int font_height = gfx::FontList().GetHeight();

--- a/shell/browser/ui/views/opaque_frame_view.cc
+++ b/shell/browser/ui/views/opaque_frame_view.cc
@@ -338,7 +338,7 @@ bool OpaqueFrameView::IsFrameCondensed() const {
 }
 
 gfx::Insets OpaqueFrameView::RestoredFrameBorderInsets() const {
-  return gfx::Insets();
+  return {};
 }
 
 gfx::Insets OpaqueFrameView::RestoredFrameEdgeInsets() const {

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -53,8 +53,7 @@ namespace {
 
   // If the device id wasn't specified then this is a screen capture request
   // (i.e. chooseDesktopMedia() API wasn't used to generate device id).
-  return content::DesktopMediaID(content::DesktopMediaID::TYPE_SCREEN,
-                                 -1 /* kFullDesktopScreenId */);
+  return {content::DesktopMediaID::TYPE_SCREEN, -1 /* kFullDesktopScreenId */};
 }
 
 #if BUILDFLAG(IS_MAC)

--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -231,7 +231,7 @@ gfx::Image Clipboard::ReadImage(gin_helper::Arguments* args) {
     args->ThrowError(
         "clipboard.readImage is available only after app ready in the main "
         "process");
-    return gfx::Image();
+    return {};
   }
 
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
@@ -271,7 +271,7 @@ void Clipboard::WriteImage(const gfx::Image& image,
 #if !BUILDFLAG(IS_MAC)
 void Clipboard::WriteFindText(const std::u16string& text) {}
 std::u16string Clipboard::ReadFindText() {
-  return std::u16string();
+  return {};
 }
 #endif
 

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -323,7 +323,7 @@ gfx::Size NativeImage::GetSize(const std::optional<float> scale_factor) {
   float sf = scale_factor.value_or(1.0f);
   gfx::ImageSkiaRep image_rep = image_.AsImageSkia().GetRepresentation(sf);
 
-  return gfx::Size(image_rep.GetWidth(), image_rep.GetHeight());
+  return {image_rep.GetWidth(), image_rep.GetHeight()};
 }
 
 std::vector<float> NativeImage::GetScaleFactors() {
@@ -489,7 +489,7 @@ gin::Handle<NativeImage> NativeImage::CreateFromBitmap(
     const gin_helper::Dictionary& options) {
   if (!node::Buffer::HasInstance(buffer)) {
     thrower.ThrowError("buffer must be a node Buffer");
-    return gin::Handle<NativeImage>();
+    return {};
   }
 
   int width = 0;
@@ -497,12 +497,12 @@ gin::Handle<NativeImage> NativeImage::CreateFromBitmap(
 
   if (!options.Get("width", &width)) {
     thrower.ThrowError("width is required");
-    return gin::Handle<NativeImage>();
+    return {};
   }
 
   if (!options.Get("height", &height)) {
     thrower.ThrowError("height is required");
-    return gin::Handle<NativeImage>();
+    return {};
   }
 
   if (width <= 0 || height <= 0)
@@ -514,7 +514,7 @@ gin::Handle<NativeImage> NativeImage::CreateFromBitmap(
   const auto buffer_data = electron::util::as_byte_span(buffer);
   if (size_bytes != buffer_data.size()) {
     thrower.ThrowError("invalid buffer size");
-    return gin::Handle<NativeImage>();
+    return {};
   }
 
   SkBitmap bitmap;
@@ -536,7 +536,7 @@ gin::Handle<NativeImage> NativeImage::CreateFromBuffer(
     gin::Arguments* args) {
   if (!node::Buffer::HasInstance(buffer)) {
     thrower.ThrowError("buffer must be a node Buffer");
-    return gin::Handle<NativeImage>();
+    return {};
   }
 
   int width = 0;

--- a/shell/common/extensions/electron_extensions_client.cc
+++ b/shell/common/extensions/electron_extensions_client.cc
@@ -55,7 +55,7 @@ class ElectronPermissionMessageProvider
   [[nodiscard]] extensions::PermissionIDSet GetAllPermissionIDs(
       const extensions::PermissionSet& permissions,
       extensions::Manifest::Type extension_type) const override {
-    return extensions::PermissionIDSet();
+    return {};
   }
 };
 
@@ -113,7 +113,7 @@ extensions::URLPatternSet
 ElectronExtensionsClient::GetPermittedChromeSchemeHosts(
     const extensions::Extension* extension,
     const extensions::APIPermissionSet& api_permissions) const {
-  return extensions::URLPatternSet();
+  return {};
 }
 
 bool ElectronExtensionsClient::IsScriptableURL(const GURL& url,

--- a/shell/common/gin_helper/wrappable.cc
+++ b/shell/common/gin_helper/wrappable.cc
@@ -25,16 +25,15 @@ v8::Local<v8::Object> WrappableBase::GetWrapper() const {
   if (!wrapper_.IsEmpty())
     return v8::Local<v8::Object>::New(isolate_, wrapper_);
   else
-    return v8::Local<v8::Object>();
+    return {};
 }
 
 v8::MaybeLocal<v8::Object> WrappableBase::GetWrapper(
     v8::Isolate* isolate) const {
   if (!wrapper_.IsEmpty())
-    return v8::MaybeLocal<v8::Object>(
-        v8::Local<v8::Object>::New(isolate, wrapper_));
+    return {v8::Local<v8::Object>::New(isolate, wrapper_)};
   else
-    return v8::MaybeLocal<v8::Object>();
+    return {};
 }
 
 void WrappableBase::InitWithArgs(gin::Arguments* args) {

--- a/shell/common/node_util.cc
+++ b/shell/common/node_util.cc
@@ -27,7 +27,7 @@ v8::MaybeLocal<v8::Value> CompileAndCall(
       context, id, parameters, node::Realm::GetCurrent(context));
 
   if (compiled.IsEmpty())
-    return v8::MaybeLocal<v8::Value>();
+    return {};
 
   v8::Local<v8::Function> fn = compiled.ToLocalChecked().As<v8::Function>();
   v8::MaybeLocal<v8::Value> ret = fn->Call(

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -592,7 +592,7 @@ class WebFrameRenderer final : public gin::Wrappable<WebFrameRenderer>,
 
     content::RenderFrame* render_frame;
     if (!MaybeGetRenderFrame(isolate, "insertCSS", &render_frame))
-      return std::u16string();
+      return {};
 
     blink::WebFrame* web_frame = render_frame->GetWebFrame();
     if (web_frame->IsWebLocalFrame()) {
@@ -602,7 +602,7 @@ class WebFrameRenderer final : public gin::Wrappable<WebFrameRenderer>,
                             css_origin)
           .Utf16();
     }
-    return std::u16string();
+    return {};
   }
 
   void RemoveInsertedCSS(v8::Isolate* isolate, const std::u16string& key) {

--- a/shell/renderer/printing/print_render_frame_helper_delegate.cc
+++ b/shell/renderer/printing/print_render_frame_helper_delegate.cc
@@ -34,7 +34,7 @@ blink::WebElement PrintRenderFrameHelperDelegate::GetPdfElement(
     return plugin_element;
   }
 #endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  return blink::WebElement();
+  return {};
 }
 
 bool PrintRenderFrameHelperDelegate::IsPrintPreviewEnabled() {


### PR DESCRIPTION
#### Description of Change

Fix a handful of [modernize-return-braced-init-list](https://clang.llvm.org/extra/clang-tidy/checks/modernize/return-braced-init-list.html) warnings.  This avoids duplicating the return type in the function definition.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes:  none.