### PR TITLE
docs: fix a syntax issue in document breaking changes

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -128,14 +128,14 @@ The nonstandard `path` property of the Web `File` object was added in an early v
 ```js
 // Before (renderer)
 
-const file = document.querySelector('input[type=file]')
+const file = document.querySelector('input[type=file]').files[0]
 alert(`Uploaded file path was: ${file.path}`)
 ```
 
 ```js
 // After (renderer)
 
-const file = document.querySelector('input[type=file]')
+const file = document.querySelector('input[type=file]').files[0]
 electron.showFilePath(file)
 
 // (preload)


### PR DESCRIPTION
#### Description of Change

Sample code written in the [Breaking Changes](https://www.electronjs.org/docs/latest/breaking-changes#planned-breaking-api-changes-320) does not work, which was added by @nornagon in [#42053](https://github.com/electron/electron/pull/42053)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes

Notes: none
