### PR TITLE
fix: misc-use-internal-linkage warnings

### DIFF
--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -70,6 +70,8 @@ Menu::~Menu() {
   }
 }
 
+namespace {
+
 bool InvokeBoolMethod(const Menu* menu,
                       const char* method,
                       int command_id,
@@ -83,6 +85,8 @@ bool InvokeBoolMethod(const Menu* menu,
   bool ret = false;
   return gin::ConvertFromV8(isolate, val, &ret) ? ret : default_value;
 }
+
+}  // namespace
 
 bool Menu::IsCommandIdChecked(int command_id) const {
   return InvokeBoolMethod(this, "_isCommandIdChecked", command_id);

--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -44,6 +44,8 @@
 
 namespace electron {
 
+namespace {
+
 base::IDMap<api::UtilityProcessWrapper*, base::ProcessId>&
 GetAllUtilityProcessWrappers() {
   static base::NoDestructor<
@@ -51,6 +53,8 @@ GetAllUtilityProcessWrappers() {
       s_all_utility_process_wrappers;
   return *s_all_utility_process_wrappers;
 }
+
+}  // namespace
 
 namespace api {
 

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -100,6 +100,8 @@ using FrameTreeNodeIdMap = std::unordered_map<content::FrameTreeNodeId,
 using FrameTokenMap =
     std::map<content::GlobalRenderFrameHostToken, WebFrameMain*>;
 
+namespace {
+
 FrameTreeNodeIdMap& GetFrameTreeNodeIdMap() {
   static base::NoDestructor<FrameTreeNodeIdMap> instance;
   return *instance;
@@ -108,6 +110,8 @@ FrameTokenMap& GetFrameTokenMap() {
   static base::NoDestructor<FrameTokenMap> instance;
   return *instance;
 }
+
+}  // namespace
 
 // static
 WebFrameMain* WebFrameMain::FromFrameTreeNodeId(

--- a/shell/browser/extensions/electron_extension_system.cc
+++ b/shell/browser/extensions/electron_extension_system.cc
@@ -87,6 +87,8 @@ void ElectronExtensionSystem::InitForRegularProfile(bool extensions_enabled) {
   management_policy_ = std::make_unique<ManagementPolicy>();
 }
 
+namespace {
+
 std::unique_ptr<base::Value::Dict> ParseManifest(
     const std::string_view manifest_contents) {
   JSONStringValueDeserializer deserializer(manifest_contents);
@@ -99,6 +101,8 @@ std::unique_ptr<base::Value::Dict> ParseManifest(
   }
   return std::make_unique<base::Value::Dict>(std::move(*manifest).TakeDict());
 }
+
+}  // namespace
 
 void ElectronExtensionSystem::LoadComponentExtensions() {
   std::string utf8_error;

--- a/shell/browser/printing/printing_utils.cc
+++ b/shell/browser/printing/printing_utils.cc
@@ -79,6 +79,8 @@ bool IsDeviceNameValid(const std::u16string& device_name) {
 #endif
 }
 
+namespace {
+
 // Duplicated from chrome/browser/printing/print_view_manager_common.cc
 content::RenderFrameHost* GetFullPagePlugin(content::WebContents* contents) {
   content::RenderFrameHost* full_page_plugin = nullptr;
@@ -97,6 +99,8 @@ content::RenderFrameHost* GetFullPagePlugin(content::WebContents* contents) {
 #endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   return full_page_plugin;
 }
+
+}  // namespace
 
 // Pick the right RenderFrameHost based on the WebContents.
 // Modified from chrome/browser/printing/print_view_manager_common.cc

--- a/shell/common/gin_converters/blink_converter.cc
+++ b/shell/common/gin_converters/blink_converter.cc
@@ -201,6 +201,8 @@ struct Converter<blink::WebInputEvent::Modifiers> {
   }
 };
 
+namespace {
+
 std::vector<std::string_view> ModifiersToArray(int modifiers) {
   std::vector<std::string_view> modifier_strings;
 
@@ -210,6 +212,8 @@ std::vector<std::string_view> ModifiersToArray(int modifiers) {
 
   return modifier_strings;
 }
+
+}  // namespace
 
 blink::WebInputEvent::Type GetWebInputEventType(v8::Isolate* isolate,
                                                 v8::Local<v8::Value> val) {
@@ -301,6 +305,8 @@ bool Converter<blink::WebKeyboardEvent>::FromV8(v8::Isolate* isolate,
   return true;
 }
 
+namespace {
+
 int GetKeyLocationCode(const blink::WebInputEvent& key) {
   // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/events/keyboard_event.h;l=46;drc=1ff6437e65b183e673b7b4f25060b74dc2ba5c37
   enum KeyLocationCode {
@@ -318,6 +324,8 @@ int GetKeyLocationCode(const blink::WebInputEvent& key) {
     return kDomKeyLocationRight;
   return kDomKeyLocationStandard;
 }
+
+}  // namespace
 
 v8::Local<v8::Value> Converter<blink::WebKeyboardEvent>::ToV8(
     v8::Isolate* isolate,

--- a/shell/common/platform_util.cc
+++ b/shell/common/platform_util.cc
@@ -13,6 +13,8 @@
 
 namespace platform_util {
 
+namespace {
+
 struct TrashItemResult {
   bool success;
   std::string error;
@@ -23,6 +25,8 @@ TrashItemResult TrashItemOnBlockingThread(const base::FilePath& full_path) {
   bool success = internal::PlatformTrashItem(full_path, &error);
   return {success, error};
 }
+
+}  // namespace
 
 void TrashItem(const base::FilePath& full_path,
                base::OnceCallback<void(bool, const std::string&)> callback) {

--- a/shell/common/skia_util.cc
+++ b/shell/common/skia_util.cc
@@ -29,6 +29,8 @@
 
 namespace electron::util {
 
+namespace {
+
 struct ScaleFactorPair {
   const char* name;
   float scale;
@@ -54,6 +56,22 @@ float GetScaleFactorFromPath(const base::FilePath& path) {
 
   return 1.0f;
 }
+
+bool AddImageSkiaRepFromPath(gfx::ImageSkia* image,
+                             const base::FilePath& path,
+                             double scale_factor) {
+  std::string file_contents;
+  {
+    electron::ScopedAllowBlockingForElectron allow_blocking;
+    if (!asar::ReadFileToString(path, &file_contents))
+      return false;
+  }
+
+  return AddImageSkiaRepFromBuffer(image, base::as_byte_span(file_contents), 0,
+                                   0, scale_factor);
+}
+
+}  // namespace
 
 bool AddImageSkiaRepFromPNG(gfx::ImageSkia* image,
                             const base::span<const uint8_t> data,
@@ -112,20 +130,6 @@ bool AddImageSkiaRepFromBuffer(gfx::ImageSkia* image,
 
   image->AddRepresentation(gfx::ImageSkiaRep(bitmap, scale_factor));
   return true;
-}
-
-bool AddImageSkiaRepFromPath(gfx::ImageSkia* image,
-                             const base::FilePath& path,
-                             double scale_factor) {
-  std::string file_contents;
-  {
-    electron::ScopedAllowBlockingForElectron allow_blocking;
-    if (!asar::ReadFileToString(path, &file_contents))
-      return false;
-  }
-
-  return AddImageSkiaRepFromBuffer(image, base::as_byte_span(file_contents), 0,
-                                   0, scale_factor);
 }
 
 bool PopulateImageSkiaRepsFromPath(gfx::ImageSkia* image,

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -659,6 +659,8 @@ v8::MaybeLocal<v8::Object> CreateProxyForAPI(
   }
 }
 
+namespace {
+
 void ExposeAPIInWorld(v8::Isolate* isolate,
                       const int world_id,
                       const std::string& key,
@@ -818,6 +820,8 @@ bool IsCalledFromMainWorld(v8::Isolate* isolate) {
   v8::Local<v8::Context> main_context = frame->MainWorldScriptContext();
   return isolate->GetCurrentContext() == main_context;
 }
+
+}  // namespace
 
 }  // namespace api
 


### PR DESCRIPTION
#### Description of Change

Move several impl functions, structs, and variables into an anonymous namespace so that they're only visible to that source file. This fixes some [misc-use-internal-linkage](https://clang.llvm.org/extra/clang-tidy/checks/misc/use-internal-linkage.html) warnings.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.