### PR TITLE
refactor: use base::ImmediateCrash()

### DIFF
--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -11,6 +11,7 @@
 
 #include "base/containers/contains.h"
 #include "base/files/file.h"
+#include "base/immediate_crash.h"
 #include "base/process/process.h"
 #include "base/process/process_handle.h"
 #include "base/system/sys_info.h"
@@ -113,8 +114,7 @@ void ElectronBindings::OnCallNextTick(uv_async_t* handle) {
 
 // static
 void ElectronBindings::Crash() {
-  volatile int* zero = nullptr;
-  *zero = 0;
+  base::ImmediateCrash();
 }
 
 // static

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -14,6 +14,7 @@
 #include "base/command_line.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/environment.h"
+#include "base/immediate_crash.h"
 #include "base/path_service.h"
 #include "base/run_loop.h"
 #include "base/strings/string_split.h"
@@ -164,8 +165,7 @@ void V8FatalErrorCallback(const char* location, const char* message) {
   electron::crash_keys::SetCrashKey("electron.v8-fatal.location", location);
 #endif
 
-  volatile int* zero = nullptr;
-  *zero = 0;
+  base::ImmediateCrash();
 }
 
 bool AllowWasmCodeGenerationCallback(v8::Local<v8::Context> context,

--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "base/command_line.h"
+#include "base/immediate_crash.h"
 #include "base/no_destructor.h"
 #include "base/strings/utf_string_conversions.h"
 #include "electron/mas.h"
@@ -44,8 +45,7 @@ void V8FatalErrorCallback(const char* location, const char* message) {
   electron::crash_keys::SetCrashKey("electron.v8-fatal.location", location);
 #endif
 
-  volatile int* zero = nullptr;
-  *zero = 0;
+  base::ImmediateCrash();
 }
 
 URLLoaderBundle::URLLoaderBundle() = default;


### PR DESCRIPTION
#### Description of Change

When we need to crash, call `base::ImmediateCrash()` instead of rolling our own bespoke crashing code.

This fixes a couple of nullptr dereference warnings; but more importantly, calling a function named `base::ImmediateCrash()` makes the intent explicit.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.