### PR TITLE
fix: modernize-avoid-c-arrays (33-x-y backport)

### DIFF
--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -78,7 +78,7 @@ namespace electron {
 
 namespace {
 
-const char kRelauncherProcess[] = "relauncher";
+constexpr std::string_view kRelauncherProcess = "relauncher";
 
 constexpr std::string_view kElectronDisableSandbox{"ELECTRON_DISABLE_SANDBOX"};
 constexpr std::string_view kElectronEnableStackDumping{

--- a/shell/browser/extensions/api/scripting/scripting_api.cc
+++ b/shell/browser/extensions/api/scripting/scripting_api.cc
@@ -49,10 +49,10 @@ namespace extensions {
 
 namespace {
 
-constexpr char kCouldNotLoadFileError[] = "Could not load file: '*'.";
-constexpr char kDuplicateFileSpecifiedError[] =
+constexpr std::string_view kCouldNotLoadFileError = "Could not load file: '*'.";
+constexpr std::string_view kDuplicateFileSpecifiedError =
     "Duplicate file specified: '*'.";
-constexpr char kEmptyMatchesError[] =
+constexpr std::string_view kEmptyMatchesError =
     "Script with ID '*' must specify 'matches'.";
 constexpr char kExactlyOneOfCssAndFilesError[] =
     "Exactly one of 'css' and 'files' must be specified.";

--- a/shell/browser/extensions/api/tabs/tabs_api.cc
+++ b/shell/browser/extensions/api/tabs/tabs_api.cc
@@ -6,6 +6,7 @@
 
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -39,7 +40,7 @@ namespace extensions {
 
 namespace tabs = api::tabs;
 
-const char kFrameNotFoundError[] = "No frame with id * in tab *.";
+constexpr std::string_view kFrameNotFoundError = "No frame with id * in tab *.";
 const char kPerOriginOnlyInAutomaticError[] =
     "Can only set scope to "
     "\"per-origin\" in \"automatic\" mode.";

--- a/shell/browser/file_system_access/file_system_access_permission_context.cc
+++ b/shell/browser/file_system_access/file_system_access_permission_context.cc
@@ -90,9 +90,9 @@ using blink::mojom::PermissionStatus;
 // }
 const char kDefaultLastPickedDirectoryKey[] = "default-id";
 const char kCustomLastPickedDirectoryKey[] = "custom-id";
-const char kPathKey[] = "path";
-const char kPathTypeKey[] = "path-type";
-const char kTimestampKey[] = "timestamp";
+constexpr std::string_view kPathKey = "path";
+constexpr std::string_view kPathTypeKey = "path-type";
+constexpr std::string_view kTimestampKey = "timestamp";
 
 constexpr base::TimeDelta kPermissionRevocationTimeout = base::Seconds(5);
 

--- a/shell/browser/ui/devtools_ui_theme_data_source.cc
+++ b/shell/browser/ui/devtools_ui_theme_data_source.cc
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/memory/ref_counted_memory.h"
@@ -97,7 +98,7 @@ void ThemeDataSource::StartDataRequest(
 
   // kColorsCssPath should stay consistent with COLORS_CSS_SELECTOR in
   // colors_css_updater.js.
-  constexpr char kColorsCssPath[] = "colors.css";
+  constexpr std::string_view kColorsCssPath = "colors.css";
   if (parsed_path == kColorsCssPath) {
     SendColorsCss(url, wc_getter, std::move(callback));
     return;

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -72,25 +72,26 @@ namespace electron {
 
 namespace {
 
-const char kChromeUIDevToolsURL[] =
+constexpr std::string_view kChromeUIDevToolsURL =
     "devtools://devtools/bundled/devtools_app.html?"
     "remoteBase=%s&"
     "can_dock=%s&"
     "toolbarColor=rgba(223,223,223,1)&"
     "textColor=rgba(0,0,0,1)&"
     "experiments=true";
-const char kChromeUIDevToolsRemoteFrontendBase[] =
+constexpr std::string_view kChromeUIDevToolsRemoteFrontendBase =
     "https://chrome-devtools-frontend.appspot.com/";
-const char kChromeUIDevToolsRemoteFrontendPath[] = "serve_file";
+constexpr std::string_view kChromeUIDevToolsRemoteFrontendPath = "serve_file";
 
-const char kDevToolsBoundsPref[] = "electron.devtools.bounds";
-const char kDevToolsZoomPref[] = "electron.devtools.zoom";
-const char kDevToolsPreferences[] = "electron.devtools.preferences";
+constexpr std::string_view kDevToolsBoundsPref = "electron.devtools.bounds";
+constexpr std::string_view kDevToolsZoomPref = "electron.devtools.zoom";
+constexpr std::string_view kDevToolsPreferences =
+    "electron.devtools.preferences";
 
-const char kFrontendHostId[] = "id";
-const char kFrontendHostMethod[] = "method";
-const char kFrontendHostParams[] = "params";
-const char kTitleFormat[] = "Developer Tools - %s";
+constexpr std::string_view kFrontendHostId = "id";
+constexpr std::string_view kFrontendHostMethod = "method";
+constexpr std::string_view kFrontendHostParams = "params";
+constexpr std::string_view kTitleFormat = "Developer Tools - %s";
 
 const size_t kMaxMessageChunkSize = IPC::Channel::kMaximumMessageSize / 4;
 

--- a/shell/browser/ui/webui/accessibility_ui.cc
+++ b/shell/browser/ui/webui/accessibility_ui.cc
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -50,49 +51,49 @@
 
 namespace {
 
-static const char kTargetsDataFile[] = "targets-data.json";
+constexpr std::string_view kTargetsDataFile = "targets-data.json";
 
-static const char kAccessibilityModeField[] = "a11yMode";
-static const char kBrowsersField[] = "browsers";
-static const char kErrorField[] = "error";
-static const char kFaviconUrlField[] = "faviconUrl";
-static const char kNameField[] = "name";
-static const char kPagesField[] = "pages";
-static const char kPidField[] = "pid";
-static const char kProcessIdField[] = "processId";
-static const char kRequestTypeField[] = "requestType";
-static const char kRoutingIdField[] = "routingId";
-static const char kSessionIdField[] = "sessionId";
-static const char kSupportedApiTypesField[] = "supportedApiTypes";
-static const char kTreeField[] = "tree";
-static const char kTypeField[] = "type";
-static const char kUrlField[] = "url";
-static const char kWidgetsField[] = "widgets";
-static const char kApiTypeField[] = "apiType";
+constexpr std::string_view kAccessibilityModeField = "a11yMode";
+constexpr std::string_view kBrowsersField = "browsers";
+constexpr std::string_view kErrorField = "error";
+constexpr std::string_view kFaviconUrlField = "faviconUrl";
+constexpr std::string_view kNameField = "name";
+constexpr std::string_view kPagesField = "pages";
+constexpr std::string_view kPidField = "pid";
+constexpr std::string_view kProcessIdField = "processId";
+constexpr std::string_view kRequestTypeField = "requestType";
+constexpr std::string_view kRoutingIdField = "routingId";
+constexpr std::string_view kSessionIdField = "sessionId";
+constexpr std::string_view kSupportedApiTypesField = "supportedApiTypes";
+constexpr std::string_view kTreeField = "tree";
+constexpr std::string_view kTypeField = "type";
+constexpr std::string_view kUrlField = "url";
+constexpr std::string_view kWidgetsField = "widgets";
+constexpr std::string_view kApiTypeField = "apiType";
 
 #if defined(USE_AURA)
-static const char kWidgetIdField[] = "widgetId";
-static const char kWidget[] = "widget";
+constexpr std::string_view kWidgetIdField = "widgetId";
+constexpr std::string_view kWidget = "widget";
 #endif
 
 // Global flags
-static const char kBrowser[] = "browser";
-static const char kCopyTree[] = "copyTree";
-static const char kHTML[] = "html";
-static const char kLocked[] = "locked";
-static const char kNative[] = "native";
-static const char kPage[] = "page";
-static const char kPDFPrinting[] = "pdfPrinting";
-static const char kScreenReader[] = "screenreader";
-static const char kShowOrRefreshTree[] = "showOrRefreshTree";
-static const char kText[] = "text";
-static const char kViewsAccessibility[] = "viewsAccessibility";
-static const char kWeb[] = "web";
+constexpr std::string_view kBrowser = "browser";
+constexpr std::string_view kCopyTree = "copyTree";
+constexpr std::string_view kHTML = "html";
+constexpr std::string_view kLocked = "locked";
+constexpr std::string_view kNative = "native";
+constexpr std::string_view kPage = "page";
+constexpr std::string_view kPDFPrinting = "pdfPrinting";
+constexpr std::string_view kScreenReader = "screenreader";
+constexpr std::string_view kShowOrRefreshTree = "showOrRefreshTree";
+constexpr std::string_view kText = "text";
+constexpr std::string_view kViewsAccessibility = "viewsAccessibility";
+constexpr std::string_view kWeb = "web";
 
 // Possible global flag values
-static const char kDisabled[] = "disabled";
-static const char kOff[] = "off";
-static const char kOn[] = "on";
+constexpr std::string_view kDisabled = "disabled";
+constexpr std::string_view kOff = "off";
+constexpr std::string_view kOn = "on";
 
 base::Value::Dict BuildTargetDescriptor(
     const GURL& url,

--- a/shell/browser/usb/usb_chooser_context.cc
+++ b/shell/browser/usb/usb_chooser_context.cc
@@ -27,8 +27,8 @@
 
 namespace {
 
-constexpr char kDeviceNameKey[] = "productName";
-constexpr char kDeviceIdKey[] = "deviceId";
+constexpr std::string_view kDeviceNameKey = "productName";
+constexpr std::string_view kDeviceIdKey = "deviceId";
 constexpr int kUsbClassMassStorage = 0x08;
 
 bool CanStorePersistentEntry(const device::mojom::UsbDeviceInfo& device_info) {

--- a/shell/browser/zoom_level_delegate.cc
+++ b/shell/browser/zoom_level_delegate.cc
@@ -23,11 +23,13 @@ namespace electron {
 namespace {
 
 // Double that indicates the default zoom level.
-const char kPartitionDefaultZoomLevel[] = "partition.default_zoom_level";
+constexpr std::string_view kPartitionDefaultZoomLevel =
+    "partition.default_zoom_level";
 
 // Dictionary that maps hostnames to zoom levels.  Hosts not in this pref will
 // be displayed at the default zoom level.
-const char kPartitionPerHostZoomLevels[] = "partition.per_host_zoom_levels";
+constexpr std::string_view kPartitionPerHostZoomLevels =
+    "partition.per_host_zoom_levels";
 
 std::string GetHash(const base::FilePath& partition_path) {
   size_t int_key = std::hash<base::FilePath>()(partition_path);

--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -5,6 +5,7 @@
 #include "electron/shell/renderer/electron_api_service_impl.h"
 
 #include <memory>
+#include <string_view>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -32,7 +33,7 @@ namespace electron {
 
 namespace {
 
-const char kIpcKey[] = "ipcNative";
+constexpr std::string_view kIpcKey = "ipcNative";
 
 // Gets the private object under kIpcKey
 v8::Local<v8::Object> GetIpcObject(v8::Local<v8::Context> context) {

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -33,8 +33,8 @@ namespace electron {
 
 namespace {
 
-const char kEmitProcessEventKey[] = "emit-process-event";
-const char kBindingCacheKey[] = "native-binding-cache";
+constexpr std::string_view kEmitProcessEventKey = "emit-process-event";
+constexpr std::string_view kBindingCacheKey = "native-binding-cache";
 
 v8::Local<v8::Object> GetBindingCache(v8::Isolate* isolate) {
   auto context = isolate->GetCurrentContext();


### PR DESCRIPTION
Manually backport #44813 to 33-x-y. See that  PR for details.

Trop got confused because one of the fields changed in 44813 didn't exist in 33-x-y. Other than that, this patch is identical to 44813.

Notes: none.