### PR TITLE
fix: modernize-use-using clang-tidy warnings (32-x-y backport)

### DIFF
--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -55,7 +55,7 @@ struct Converter<blink::mojom::PageVisibilityState> {
 
 namespace electron::api {
 
-typedef std::unordered_map<int, WebFrameMain*> WebFrameMainIdMap;
+using WebFrameMainIdMap = std::unordered_map<int, WebFrameMain*>;
 
 WebFrameMainIdMap& GetWebFrameMainMap() {
   static base::NoDestructor<WebFrameMainIdMap> instance;

--- a/shell/browser/linux/unity_service.cc
+++ b/shell/browser/linux/unity_service.cc
@@ -13,24 +13,22 @@
 #include "base/nix/xdg_util.h"
 
 // Unity data typedefs.
-typedef struct _UnityInspector UnityInspector;
-typedef UnityInspector* (*unity_inspector_get_default_func)();
-typedef gboolean (*unity_inspector_get_unity_running_func)(
-    UnityInspector* self);
+using UnityInspector = struct _UnityInspector;
+using unity_inspector_get_default_func = UnityInspector* (*)();
+using unity_inspector_get_unity_running_func =
+    gboolean (*)(UnityInspector* self);
 
-typedef struct _UnityLauncherEntry UnityLauncherEntry;
-typedef UnityLauncherEntry* (*unity_launcher_entry_get_for_desktop_id_func)(
-    const gchar* desktop_id);
-typedef void (*unity_launcher_entry_set_count_func)(UnityLauncherEntry* self,
-                                                    gint64 value);
-typedef void (*unity_launcher_entry_set_count_visible_func)(
-    UnityLauncherEntry* self,
-    gboolean value);
-typedef void (*unity_launcher_entry_set_progress_func)(UnityLauncherEntry* self,
-                                                       gdouble value);
-typedef void (*unity_launcher_entry_set_progress_visible_func)(
-    UnityLauncherEntry* self,
-    gboolean value);
+using UnityLauncherEntry = struct _UnityLauncherEntry;
+using unity_launcher_entry_get_for_desktop_id_func =
+    UnityLauncherEntry* (*)(const gchar* desktop_id);
+using unity_launcher_entry_set_count_func = void (*)(UnityLauncherEntry* self,
+                                                     gint64 value);
+using unity_launcher_entry_set_count_visible_func =
+    void (*)(UnityLauncherEntry* self, gboolean value);
+using unity_launcher_entry_set_progress_func =
+    void (*)(UnityLauncherEntry* self, gdouble value);
+using unity_launcher_entry_set_progress_visible_func =
+    void (*)(UnityLauncherEntry* self, gboolean value);
 
 namespace {
 

--- a/shell/browser/ui/views/global_menu_bar_x11.cc
+++ b/shell/browser/ui/views/global_menu_bar_x11.cc
@@ -25,36 +25,35 @@
 #include "ui/gfx/x/xproto.h"
 
 // libdbusmenu-glib types
-typedef struct _DbusmenuMenuitem DbusmenuMenuitem;
-typedef DbusmenuMenuitem* (*dbusmenu_menuitem_new_func)();
-typedef DbusmenuMenuitem* (*dbusmenu_menuitem_new_with_id_func)(int id);
+using DbusmenuMenuitem = struct _DbusmenuMenuitem;
+using dbusmenu_menuitem_new_func = DbusmenuMenuitem* (*)();
+using dbusmenu_menuitem_new_with_id_func = DbusmenuMenuitem* (*)(int id);
 
-typedef int (*dbusmenu_menuitem_get_id_func)(DbusmenuMenuitem* item);
-typedef GList* (*dbusmenu_menuitem_get_children_func)(DbusmenuMenuitem* item);
-typedef DbusmenuMenuitem* (*dbusmenu_menuitem_child_append_func)(
-    DbusmenuMenuitem* parent,
-    DbusmenuMenuitem* child);
-typedef DbusmenuMenuitem* (*dbusmenu_menuitem_property_set_func)(
-    DbusmenuMenuitem* item,
-    const char* property,
-    const char* value);
-typedef DbusmenuMenuitem* (*dbusmenu_menuitem_property_set_variant_func)(
-    DbusmenuMenuitem* item,
-    const char* property,
-    GVariant* value);
-typedef DbusmenuMenuitem* (*dbusmenu_menuitem_property_set_bool_func)(
-    DbusmenuMenuitem* item,
-    const char* property,
-    bool value);
-typedef DbusmenuMenuitem* (*dbusmenu_menuitem_property_set_int_func)(
-    DbusmenuMenuitem* item,
-    const char* property,
-    int value);
+using dbusmenu_menuitem_get_id_func = int (*)(DbusmenuMenuitem* item);
+using dbusmenu_menuitem_get_children_func = GList* (*)(DbusmenuMenuitem* item);
+using dbusmenu_menuitem_child_append_func =
+    DbusmenuMenuitem* (*)(DbusmenuMenuitem* parent, DbusmenuMenuitem* child);
+using dbusmenu_menuitem_property_set_func =
+    DbusmenuMenuitem* (*)(DbusmenuMenuitem* item,
+                          const char* property,
+                          const char* value);
+using dbusmenu_menuitem_property_set_variant_func =
+    DbusmenuMenuitem* (*)(DbusmenuMenuitem* item,
+                          const char* property,
+                          GVariant* value);
+using dbusmenu_menuitem_property_set_bool_func =
+    DbusmenuMenuitem* (*)(DbusmenuMenuitem* item,
+                          const char* property,
+                          bool value);
+using dbusmenu_menuitem_property_set_int_func =
+    DbusmenuMenuitem* (*)(DbusmenuMenuitem* item,
+                          const char* property,
+                          int value);
 
-typedef struct _DbusmenuServer DbusmenuServer;
-typedef DbusmenuServer* (*dbusmenu_server_new_func)(const char* object);
-typedef void (*dbusmenu_server_set_root_func)(DbusmenuServer* self,
-                                              DbusmenuMenuitem* root);
+using DbusmenuServer = struct _DbusmenuServer;
+using dbusmenu_server_new_func = DbusmenuServer* (*)(const char* object);
+using dbusmenu_server_set_root_func = void (*)(DbusmenuServer* self,
+                                               DbusmenuMenuitem* root);
 
 namespace electron {
 

--- a/shell/common/asar/asar_util.cc
+++ b/shell/common/asar/asar_util.cc
@@ -26,7 +26,7 @@ namespace asar {
 
 namespace {
 
-typedef std::map<base::FilePath, std::shared_ptr<Archive>> ArchiveMap;
+using ArchiveMap = std::map<base::FilePath, std::shared_ptr<Archive>>;
 
 const base::FilePath::CharType kAsarExtension[] = FILE_PATH_LITERAL(".asar");
 


### PR DESCRIPTION
Manually backport #44806 to 32-x-y. See that PR for details.

Trop got confused by the `electron_api_web_frame_main.cc` diff due changes in that file from 30fbeec036f8481ba9eba9cb01af0236ed0d28ff

Notes: none.