### PR TITLE
fix: clang-tidy `performance-inefficient-vector-operation` warnings (32-x-y backport)

### DIFF
--- a/shell/browser/api/electron_api_crash_reporter.cc
+++ b/shell/browser/api/electron_api_crash_reporter.cc
@@ -10,8 +10,7 @@
 #include <utility>
 #include <vector>
 
-#include "base/command_line.h"
-#include "base/functional/bind.h"
+#include "base/containers/to_vector.h"
 #include "base/no_destructor.h"
 #include "base/path_service.h"
 #include "base/strings/utf_string_conversions.h"
@@ -223,18 +222,17 @@ v8::Local<v8::Value> GetUploadedReports(v8::Isolate* isolate) {
     list->LoadSync();
   }
 
+  auto to_obj = [isolate](const UploadList::UploadInfo* upload) {
+    return gin::DataObjectBuilder{isolate}
+        .Set("date", upload->upload_time)
+        .Set("id", upload->upload_id)
+        .Build();
+  };
+
   constexpr size_t kMaxUploadReportsToList = std::numeric_limits<size_t>::max();
-  const std::vector<const UploadList::UploadInfo*> uploads =
-      list->GetUploads(kMaxUploadReportsToList);
-  std::vector<v8::Local<v8::Object>> result;
-  for (auto* const upload : uploads) {
-    result.push_back(gin::DataObjectBuilder(isolate)
-                         .Set("date", upload->upload_time)
-                         .Set("id", upload->upload_id)
-                         .Build());
-  }
-  v8::Local<v8::Value> v8_result = gin::ConvertToV8(isolate, result);
-  return v8_result;
+  return gin::ConvertToV8(
+      isolate,
+      base::ToVector(list->GetUploads(kMaxUploadReportsToList), to_obj));
 }
 #endif
 

--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -7,6 +7,7 @@
 #include <map>
 
 #include "base/containers/contains.h"
+#include "base/containers/to_vector.h"
 #include "base/run_loop.h"
 #include "base/strings/utf_string_conversions.h"
 #include "shell/browser/browser.h"
@@ -281,11 +282,8 @@ void Clipboard::Clear(gin_helper::Arguments* args) {
 
 // This exists for testing purposes ONLY.
 void Clipboard::WriteFilesForTesting(const std::vector<base::FilePath>& files) {
-  std::vector<ui::FileInfo> file_infos;
-  for (const auto& file : files) {
-    file_infos.emplace_back(ui::FileInfo(ui::FileInfo(file, file.BaseName())));
-  }
-
+  auto to_info = [](const auto& p) { return ui::FileInfo{p, p.BaseName()}; };
+  auto file_infos = base::ToVector(files, to_info);
   ui::ScopedClipboardWriter writer(ui::ClipboardBuffer::kCopyPaste);
   writer.WriteFilenames(ui::FileInfosToURIList(file_infos));
 }


### PR DESCRIPTION
Manually backport #44743 to 32-x-y. See that PR for details.

No significant changes compared to 44743; trop just got confused by some `#include` shear in `electron_api_crash_reporter.cc`

Notes: none.