### PR TITLE
docs: clarify session.clearData() can delete more types than listed

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -1509,7 +1509,9 @@ session is persisted on disk.  For in memory sessions this returns `null`.
 #### `ses.clearData([options])`
 
 * `options` Object (optional)
-  * `dataTypes` String[] (optional) - The types of data to clear. By default, this will clear all types of data.
+  * `dataTypes` String[] (optional) - The types of data to clear. By default, this will clear all types of data. This
+    can potentially include data types not explicitly listed here. (See Chromium's
+    [`BrowsingDataRemover`][browsing-data-remover] for the full list.)
     * `backgroundFetch` - Background Fetch
     * `cache` - Cache
     * `cookies` - Cookies
@@ -1535,7 +1537,7 @@ This method clears more types of data and is more thorough than the
 
 **Note:** Cookies are stored at a broader scope than origins. When removing cookies and filtering by `origins` (or `excludeOrigins`), the cookies will be removed at the [registrable domain](https://url.spec.whatwg.org/#host-registrable-domain) level. For example, clearing cookies for the origin `https://really.specific.origin.example.com/` will end up clearing all cookies for `example.com`. Clearing cookies for the origin `https://my.website.example.co.uk/` will end up clearing all cookies for `example.co.uk`.
 
-For more information, refer to Chromium's [`BrowsingDataRemover` interface](https://source.chromium.org/chromium/chromium/src/+/main:content/public/browser/browsing_data_remover.h).
+For more information, refer to Chromium's [`BrowsingDataRemover` interface][browsing-data-remover].
 
 ### Instance Properties
 
@@ -1601,3 +1603,5 @@ app.whenReady().then(async () => {
   console.log('Net-logs written to', path)
 })
 ```
+
+[browsing-data-remover]: https://source.chromium.org/chromium/chromium/src/+/main:content/public/browser/browsing_data_remover.h


### PR DESCRIPTION
#### Description of Change

The `session.clearData()` docs list a number of data types that will get deleted when the function gets called.

However, this list is not kept up to date with the upstream list in Chromium. By default, it will delete everything Chromium will delete. This is more than listed.

Additionally, even if we synced the lists now, they might get out of sync again in the future. So I think it makes sense to add a note that this function might delete more than the user expects it to.

##### Code references

[Here](https://github.com/electron/electron/blob/9f1e23c405847c2773231347b7604731741b0034/shell/browser/api/electron_api_session.cc#L1308) is how Electron deletes data.  
[Here](https://source.chromium.org/chromium/chromium/src/+/main:content/public/browser/browsing_data_remover.h) is the file with all the data types Chromium will delete if no data types are explicitly specified.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Documented that `session.clearData()` might delete more data types than listed in the docs.
