### PR TITLE
refactor: use `absl::InlinedVector` in `ToV8(ElectronPermissionManager)`

### DIFF
--- a/shell/common/gin_converters/usb_protected_classes_converter.h
+++ b/shell/common/gin_converters/usb_protected_classes_converter.h
@@ -13,6 +13,8 @@
 #include "gin/converter.h"
 #include "services/device/public/mojom/usb_device.mojom-forward.h"
 #include "shell/browser/electron_permission_manager.h"
+#include "shell/common/gin_converters/std_converter.h"
+#include "third_party/abseil-cpp/absl/container/inlined_vector.h"
 
 namespace gin {
 
@@ -31,15 +33,14 @@ struct Converter<electron::ElectronPermissionManager::USBProtectedClasses> {
   static v8::Local<v8::Value> ToV8(
       v8::Isolate* isolate,
       const electron::ElectronPermissionManager::USBProtectedClasses& classes) {
-    std::vector<std::string> class_strings;
-    class_strings.reserve(std::size(classes));
+    absl::InlinedVector<std::string_view, ClassMapping.size()> class_strings;
     for (const auto& itr : classes) {
       for (const auto& [usb_class, name] : ClassMapping) {
         if (usb_class == itr)
           class_strings.emplace_back(name);
       }
     }
-    return gin::ConvertToV8(isolate, class_strings);
+    return gin::ConvertToV8(isolate, std::span(class_strings));
   }
 
   static bool FromV8(


### PR DESCRIPTION
#### Description of Change

- Add a gin converter that can convert `std::span<const T>` to V8. Its code is nearly identical to the `std::vector<T>` gin converter, but this lets us pass in non-vector spans, e.g. std::array or [absl::InlinedVector](https://github.com/abseil/abseil-cpp/blob/master/absl/container/inlined_vector.h).

- Add a simple example in the `USBProtectedClasses` gin converter: it now uses a stack-allocated `absl::InlinedVector<std::string_view>` instead of a `std::vector<std::string>`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none