### PR TITLE
docs: specify default value for `respondToAuthRequestsFromMainProcess`

### DIFF
--- a/docs/api/utility-process.md
+++ b/docs/api/utility-process.md
@@ -37,7 +37,10 @@ Process: [Main](../glossary.md#main-process)<br />
     to load unsigned libraries. Unless you specifically need this capability, it is best to leave this disabled.
     Default is `false`.
   * `respondToAuthRequestsFromMainProcess` boolean (optional) - With this flag, all HTTP 401 and 407 network
-    requests created via the [net module](net.md) will allow responding to them via the [`app#login`](app.md#event-login) event in the main process instead of the default [`login`](client-request.md#event-login) event on the [`ClientRequest`](client-request.md) object.
+    requests created via the [net module](net.md) will allow responding to them via the
+    [`app#login`](app.md#event-login) event in the main process instead of the default
+    [`login`](client-request.md#event-login) event on the [`ClientRequest`](client-request.md) object. Default is
+    `false`.
 
 Returns [`UtilityProcess`](utility-process.md#class-utilityprocess)
 


### PR DESCRIPTION
#### Description of Change

Relevant code: https://github.com/electron/electron/blob/9f1e23c405847c2773231347b7604731741b0034/shell/browser/api/electron_api_utility_process.cc#L419

CC @deepak1556

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
