### PR TITLE
refactor: reduce scope of relauncher's internal constants

### DIFF
--- a/shell/browser/relauncher.cc
+++ b/shell/browser/relauncher.cc
@@ -36,6 +36,10 @@ namespace {
 // reporting.
 constexpr CharType kRelauncherArgSeparator[] = FILE_PATH_LITERAL("---");
 
+// The "type" argument identifying a relauncher process ("--type=relauncher").
+constexpr CharType kRelauncherTypeArg[] =
+    FILE_PATH_LITERAL("--type=relauncher");
+
 }  // namespace
 
 namespace internal {
@@ -43,8 +47,6 @@ namespace internal {
 #if BUILDFLAG(IS_POSIX)
 const int kRelauncherSyncFD = STDERR_FILENO + 1;
 #endif
-
-const CharType* kRelauncherTypeArg = FILE_PATH_LITERAL("--type=relauncher");
 
 }  // namespace internal
 
@@ -70,7 +72,7 @@ bool RelaunchAppWithHelper(const base::FilePath& helper,
                            const StringVector& argv) {
   StringVector relaunch_argv;
   relaunch_argv.push_back(helper.value());
-  relaunch_argv.push_back(internal::kRelauncherTypeArg);
+  relaunch_argv.push_back(kRelauncherTypeArg);
   // Relauncher process has its own --type=relauncher which
   // is not recognized by the service_manager, explicitly set
   // the sandbox type to avoid CHECK failure in
@@ -159,7 +161,7 @@ bool RelaunchAppWithHelper(const base::FilePath& helper,
 int RelauncherMain(const content::MainFunctionParams& main_parameters) {
   const StringVector& argv = electron::ElectronCommandLine::argv();
 
-  if (argv.size() < 4 || argv[1] != internal::kRelauncherTypeArg) {
+  if (argv.size() < 4 || argv[1] != kRelauncherTypeArg) {
     LOG(ERROR) << "relauncher process invoked with unexpected arguments";
     return 1;
   }

--- a/shell/browser/relauncher.cc
+++ b/shell/browser/relauncher.cc
@@ -34,10 +34,11 @@ namespace {
 // arguments intended for the relaunched process, to get the correct settings
 // for such things as logging and the user-data-dir in case it affects crash
 // reporting.
-constexpr CharType kRelauncherArgSeparator[] = FILE_PATH_LITERAL("---");
+constexpr base::CommandLine::CharType kRelauncherArgSeparator[] =
+    FILE_PATH_LITERAL("---");
 
 // The "type" argument identifying a relauncher process ("--type=relauncher").
-constexpr CharType kRelauncherTypeArg[] =
+constexpr base::CommandLine::CharType kRelauncherTypeArg[] =
     FILE_PATH_LITERAL("--type=relauncher");
 
 }  // namespace

--- a/shell/browser/relauncher.cc
+++ b/shell/browser/relauncher.cc
@@ -25,6 +25,19 @@
 
 namespace relauncher {
 
+namespace {
+
+// The argument separating arguments intended for the relauncher process from
+// those intended for the relaunched process. "---" is chosen instead of "--"
+// because CommandLine interprets "--" as meaning "end of switches", but
+// for many purposes, the relauncher process' CommandLine ought to interpret
+// arguments intended for the relaunched process, to get the correct settings
+// for such things as logging and the user-data-dir in case it affects crash
+// reporting.
+constexpr CharType kRelauncherArgSeparator[] = FILE_PATH_LITERAL("---");
+
+}  // namespace
+
 namespace internal {
 
 #if BUILDFLAG(IS_POSIX)
@@ -32,7 +45,6 @@ const int kRelauncherSyncFD = STDERR_FILENO + 1;
 #endif
 
 const CharType* kRelauncherTypeArg = FILE_PATH_LITERAL("--type=relauncher");
-const CharType* kRelauncherArgSeparator = FILE_PATH_LITERAL("---");
 
 }  // namespace internal
 
@@ -68,7 +80,7 @@ bool RelaunchAppWithHelper(const base::FilePath& helper,
   relaunch_argv.insert(relaunch_argv.end(), relauncher_args.begin(),
                        relauncher_args.end());
 
-  relaunch_argv.push_back(internal::kRelauncherArgSeparator);
+  relaunch_argv.push_back(kRelauncherArgSeparator);
 
   relaunch_argv.insert(relaunch_argv.end(), argv.begin(), argv.end());
 
@@ -162,7 +174,7 @@ int RelauncherMain(const content::MainFunctionParams& main_parameters) {
   for (size_t argv_index = 2; argv_index < argv.size(); ++argv_index) {
     const StringType& arg(argv[argv_index]);
     if (!in_relauncher_args) {
-      if (arg == internal::kRelauncherArgSeparator) {
+      if (arg == kRelauncherArgSeparator) {
         in_relauncher_args = true;
       } else {
         relauncher_args.push_back(arg);

--- a/shell/browser/relauncher.cc
+++ b/shell/browser/relauncher.cc
@@ -23,8 +23,6 @@
 #include "base/posix/eintr_wrapper.h"
 #endif
 
-namespace relauncher {
-
 namespace {
 
 // The argument separating arguments intended for the relauncher process from
@@ -42,6 +40,8 @@ constexpr base::CommandLine::CharType kRelauncherTypeArg[] =
     FILE_PATH_LITERAL("--type=relauncher");
 
 }  // namespace
+
+namespace relauncher {
 
 namespace internal {
 

--- a/shell/browser/relauncher.h
+++ b/shell/browser/relauncher.h
@@ -86,15 +86,6 @@ extern const int kRelauncherSyncFD;
 // The "type" argument identifying a relauncher process ("--type=relauncher").
 extern const CharType* kRelauncherTypeArg;
 
-// The argument separating arguments intended for the relauncher process from
-// those intended for the relaunched process. "---" is chosen instead of "--"
-// because CommandLine interprets "--" as meaning "end of switches", but
-// for many purposes, the relauncher process' CommandLine ought to interpret
-// arguments intended for the relaunched process, to get the correct settings
-// for such things as logging and the user-data-dir in case it affects crash
-// reporting.
-extern const CharType* kRelauncherArgSeparator;
-
 #if BUILDFLAG(IS_WIN)
 StringType GetWaitEventName(base::ProcessId pid);
 

--- a/shell/browser/relauncher.h
+++ b/shell/browser/relauncher.h
@@ -83,9 +83,6 @@ namespace internal {
 extern const int kRelauncherSyncFD;
 #endif
 
-// The "type" argument identifying a relauncher process ("--type=relauncher").
-extern const CharType* kRelauncherTypeArg;
-
 #if BUILDFLAG(IS_WIN)
 StringType GetWaitEventName(base::ProcessId pid);
 

--- a/shell/browser/relauncher.h
+++ b/shell/browser/relauncher.h
@@ -41,7 +41,6 @@ struct MainFunctionParams;
 
 namespace relauncher {
 
-using CharType = base::CommandLine::CharType;
 using StringType = base::CommandLine::StringType;
 using StringVector = base::CommandLine::StringVector;
 

--- a/shell/browser/relauncher_win.cc
+++ b/shell/browser/relauncher_win.cc
@@ -19,8 +19,6 @@ namespace relauncher::internal {
 
 namespace {
 
-const CharType* kWaitEventName = L"ElectronRelauncherWaitEvent";
-
 struct PROCESS_BASIC_INFORMATION {
   union {
     NTSTATUS ExitStatus;
@@ -98,8 +96,8 @@ StringType AddQuoteForArg(const StringType& arg) {
 }  // namespace
 
 StringType GetWaitEventName(base::ProcessId pid) {
-  return base::StrCat(
-      {kWaitEventName, L"-", base::NumberToWString(static_cast<int>(pid))});
+  return base::StrCat({L"ElectronRelauncherWaitEvent-",
+                       base::NumberToWString(static_cast<int>(pid))});
 }
 
 StringType ArgvToCommandLineString(const StringVector& argv) {


### PR DESCRIPTION
#### Description of Change

`kRelauncherTypeArg` and `kRelauncherArgSeparator` were only used in relauncher.cc, so there's no need to declare them in relauncher.h where other files can see them. Move them into an unnamed namespace in relauncher.cc.

Somewhat related to https://github.com/electron/electron/pull/44843

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.