### PR TITLE
fix: don't use deprecated ui::MouseEvent constructor

### DIFF
--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -103,12 +103,12 @@ ui::MouseEvent UiMouseEventFromWebMouseEvent(blink::WebMouseEvent event) {
       break;
   }
 
-  ui::MouseEvent ui_event(type,
-                          gfx::Point(std::floor(event.PositionInWidget().x()),
-                                     std::floor(event.PositionInWidget().y())),
-                          gfx::Point(std::floor(event.PositionInWidget().x()),
-                                     std::floor(event.PositionInWidget().y())),
-                          ui::EventTimeForNow(), button_flags, button_flags);
+  ui::MouseEvent ui_event{type,
+                          event.PositionInWidget(),
+                          event.PositionInWidget(),
+                          ui::EventTimeForNow(),
+                          button_flags,
+                          button_flags};
   ui_event.SetClickCount(event.click_count);
 
   return ui_event;

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -56,31 +56,6 @@ namespace {
 const float kDefaultScaleFactor = 1.0;
 
 ui::MouseEvent UiMouseEventFromWebMouseEvent(blink::WebMouseEvent event) {
-  ui::EventType type = ui::EventType::kUnknown;
-  switch (event.GetType()) {
-    case blink::WebInputEvent::Type::kMouseDown:
-      type = ui::EventType::kMousePressed;
-      break;
-    case blink::WebInputEvent::Type::kMouseUp:
-      type = ui::EventType::kMouseReleased;
-      break;
-    case blink::WebInputEvent::Type::kMouseMove:
-      type = ui::EventType::kMouseMoved;
-      break;
-    case blink::WebInputEvent::Type::kMouseEnter:
-      type = ui::EventType::kMouseEntered;
-      break;
-    case blink::WebInputEvent::Type::kMouseLeave:
-      type = ui::EventType::kMouseExited;
-      break;
-    case blink::WebInputEvent::Type::kMouseWheel:
-      type = ui::EventType::kMousewheel;
-      break;
-    default:
-      type = ui::EventType::kUnknown;
-      break;
-  }
-
   int button_flags = 0;
   switch (event.button) {
     case blink::WebMouseEvent::Button::kBack:
@@ -103,7 +78,7 @@ ui::MouseEvent UiMouseEventFromWebMouseEvent(blink::WebMouseEvent event) {
       break;
   }
 
-  ui::MouseEvent ui_event{type,
+  ui::MouseEvent ui_event{event.GetTypeAsUiEventType(),
                           event.PositionInWidget(),
                           event.PositionInWidget(),
                           ui::EventTimeForNow(),


### PR DESCRIPTION
#### Description of Change

Our `UiMouseEventFromWebMouseEvent()` function was added in 2017 by 218e28b136124bdad6abd7e763ba89b36910aaca and it's mostly been unchanged since then.

This PR makes two changes:

- Use the `gfx::PointF` constructor of `ui::MouseEvent` intead of the deprecated `gfx::Point` variant. This was added upstream in 2019 by https://chromium-review.googlesource.com/c/1444251.
- Use `WebInputEvent::GetTypeAsUiEventType()` instead of rolling our own. This was added upstream in 2020 by https://chromium-review.googlesource.com/c/chromium/src/+/2180291.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.