### PR TITLE
refactor: return-braced-init-list pt 2 of 2

### DIFF
--- a/shell/browser/api/electron_api_data_pipe_holder.cc
+++ b/shell/browser/api/electron_api_data_pipe_holder.cc
@@ -188,7 +188,7 @@ gin::Handle<DataPipeHolder> DataPipeHolder::From(v8::Isolate* isolate,
     if (gin::ConvertFromV8(isolate, object.ToLocalChecked(), &handle))
       return handle;
   }
-  return gin::Handle<DataPipeHolder>();
+  return {};
 }
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_download_item.cc
+++ b/shell/browser/api/electron_api_download_item.cc
@@ -209,7 +209,7 @@ const GURL& DownloadItem::GetURL() const {
 
 v8::Local<v8::Value> DownloadItem::GetURLChain() const {
   if (!CheckAlive())
-    return v8::Local<v8::Value>();
+    return {};
   return gin::ConvertToV8(isolate_, download_item_->GetUrlChain());
 }
 

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -81,7 +81,7 @@ gin::Handle<Notification> Notification::New(gin_helper::ErrorThrower thrower,
                                             gin::Arguments* args) {
   if (!Browser::Get()->is_ready()) {
     thrower.ThrowError("Cannot create Notification before app is ready");
-    return gin::Handle<Notification>();
+    return {};
   }
   return gin::CreateHandle(thrower.isolate(), new Notification(args));
 }

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -301,7 +301,7 @@ gin::Handle<Protocol> Protocol::Create(
 // static
 gin::Handle<Protocol> Protocol::New(gin_helper::ErrorThrower thrower) {
   thrower.ThrowError("Protocol cannot be created from JS");
-  return gin::Handle<Protocol>();
+  return {};
 }
 
 // static

--- a/shell/browser/api/electron_api_service_worker_context.cc
+++ b/shell/browser/api/electron_api_service_worker_context.cc
@@ -132,7 +132,7 @@ v8::Local<v8::Value> ServiceWorkerContext::GetWorkerInfoFromID(
   auto iter = info_map.find(version_id);
   if (iter == info_map.end()) {
     thrower.ThrowError("Could not find service worker with that version_id");
-    return v8::Local<v8::Value>();
+    return {};
   }
   return ServiceWorkerRunningInfoToDict(thrower.isolate(),
                                         std::move(iter->second));

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -1583,7 +1583,7 @@ std::optional<gin::Handle<Session>> Session::FromPath(
 gin::Handle<Session> Session::New() {
   gin_helper::ErrorThrower(JavascriptEnvironment::GetIsolate())
       .ThrowError("Session objects cannot be created with 'new'");
-  return gin::Handle<Session>();
+  return {};
 }
 
 void Session::FillObjectTemplate(v8::Isolate* isolate,

--- a/shell/browser/api/electron_api_system_preferences_win.cc
+++ b/shell/browser/api/electron_api_system_preferences_win.cc
@@ -154,7 +154,7 @@ std::string SystemPreferences::GetMediaAccessStatus(
         DeviceAccessStatus::DeviceAccessStatus_Allowed);
   } else {
     thrower.ThrowError("Invalid media type");
-    return std::string();
+    return {};
   }
 }
 

--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -411,7 +411,7 @@ gin::Handle<UtilityProcessWrapper> UtilityProcessWrapper::Create(
   gin_helper::Dictionary dict;
   if (!args->GetNext(&dict)) {
     args->ThrowTypeError("Options must be an object.");
-    return gin::Handle<UtilityProcessWrapper>();
+    return {};
   }
 
   std::u16string display_name;
@@ -425,19 +425,19 @@ gin::Handle<UtilityProcessWrapper> UtilityProcessWrapper::Create(
   dict.Get("modulePath", &params->script);
   if (dict.Has("args") && !dict.Get("args", &params->args)) {
     args->ThrowTypeError("Invalid value for args");
-    return gin::Handle<UtilityProcessWrapper>();
+    return {};
   }
 
   gin_helper::Dictionary opts;
   if (dict.Get("options", &opts)) {
     if (opts.Has("env") && !opts.Get("env", &env_map)) {
       args->ThrowTypeError("Invalid value for env");
-      return gin::Handle<UtilityProcessWrapper>();
+      return {};
     }
 
     if (opts.Has("execArgv") && !opts.Get("execArgv", &params->exec_args)) {
       args->ThrowTypeError("Invalid value for execArgv");
-      return gin::Handle<UtilityProcessWrapper>();
+      return {};
     }
 
     opts.Get("serviceName", &display_name);

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -429,7 +429,7 @@ gin::Handle<View> View::Create(v8::Isolate* isolate) {
     if (gin::ConvertFromV8(isolate, obj, &view))
       return view;
   }
-  return gin::Handle<View>();
+  return {};
 }
 
 // static

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2005,7 +2005,7 @@ gin::Handle<gin_helper::internal::Event> WebContents::MakeEventWithSender(
       ReplyChannel::Create(isolate, std::move(callback))
           ->SendError("WebContents was destroyed");
     }
-    return gin::Handle<gin_helper::internal::Event>();
+    return {};
   }
   gin::Handle<gin_helper::internal::Event> event =
       gin_helper::internal::Event::New(isolate);

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2563,7 +2563,7 @@ std::vector<content::NavigationEntry*> WebContents::GetHistory() const {
   // If the history is empty, it contains only one entry and that is
   // "InitialEntry"
   if (history_length == 1 && controller.GetEntryAtIndex(0)->IsInitialEntry())
-    return std::vector<content::NavigationEntry*>();
+    return {};
 
   std::vector<content::NavigationEntry*> history;
   history.reserve(history_length);

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -66,7 +66,7 @@ gin::Handle<WebContents> WebContentsView::GetWebContents(v8::Isolate* isolate) {
   if (api_web_contents_)
     return gin::CreateHandle(isolate, api_web_contents_.get());
   else
-    return gin::Handle<WebContents>();
+    return {};
 }
 
 void WebContentsView::SetBackgroundColor(std::optional<WrappedSkColor> color) {
@@ -153,7 +153,7 @@ gin::Handle<WebContentsView> WebContentsView::Create(
     if (gin::ConvertFromV8(isolate, web_contents_view_obj, &web_contents_view))
       return web_contents_view;
   }
-  return gin::Handle<WebContentsView>();
+  return {};
 }
 
 // static

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -431,14 +431,14 @@ void WebFrameMain::DOMContentLoaded() {
 
 // static
 gin::Handle<WebFrameMain> WebFrameMain::New(v8::Isolate* isolate) {
-  return gin::Handle<WebFrameMain>();
+  return {};
 }
 
 // static
 gin::Handle<WebFrameMain> WebFrameMain::From(v8::Isolate* isolate,
                                              content::RenderFrameHost* rfh) {
   if (!rfh)
-    return gin::Handle<WebFrameMain>();
+    return {};
 
   auto* web_frame = FromRenderFrameHost(rfh);
   if (web_frame)

--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -723,11 +723,11 @@ gin::Handle<WebRequest> WebRequest::From(
     v8::Isolate* isolate,
     content::BrowserContext* browser_context) {
   if (!browser_context)
-    return gin::Handle<WebRequest>();
+    return {};
   auto* user_data =
       static_cast<UserData*>(browser_context->GetUserData(kUserDataKey));
   if (!user_data)
-    return gin::Handle<WebRequest>();
+    return {};
   return gin::CreateHandle(isolate, user_data->data.get());
 }
 

--- a/shell/browser/api/message_port.cc
+++ b/shell/browser/api/message_port.cc
@@ -225,7 +225,7 @@ std::vector<blink::MessagePortChannel> MessagePort::DisentanglePorts(
     const std::vector<gin::Handle<MessagePort>>& ports,
     bool* threw_exception) {
   if (ports.empty())
-    return std::vector<blink::MessagePortChannel>();
+    return {};
 
   std::unordered_set<MessagePort*> visited;
 
@@ -244,7 +244,7 @@ std::vector<blink::MessagePortChannel> MessagePort::DisentanglePorts(
       gin_helper::ErrorThrower(isolate).ThrowError(
           "Port at index " + base::NumberToString(i) + " is " + type + ".");
       *threw_exception = true;
-      return std::vector<blink::MessagePortChannel>();
+      return {};
     }
     visited.insert(port);
   }

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -97,7 +97,7 @@ bool IsValidCustomProtocol(const std::wstring& scheme) {
 std::wstring GetAppInfoHelperForProtocol(ASSOCSTR assoc_str, const GURL& url) {
   const std::wstring url_scheme = base::ASCIIToWide(url.scheme_piece());
   if (!IsValidCustomProtocol(url_scheme))
-    return std::wstring();
+    return {};
 
   wchar_t out_buffer[1024];
   DWORD buffer_size = std::size(out_buffer);
@@ -106,7 +106,7 @@ std::wstring GetAppInfoHelperForProtocol(ASSOCSTR assoc_str, const GURL& url) {
                        nullptr, out_buffer, &buffer_size);
   if (FAILED(hr)) {
     DLOG(WARNING) << "AssocQueryString failed!";
-    return std::wstring();
+    return {};
   }
   return std::wstring(out_buffer);
 }
@@ -251,7 +251,7 @@ std::unique_ptr<FileVersionInfo> FetchFileVersionInfo() {
     electron::ScopedAllowBlockingForElectron allow_blocking;
     return FileVersionInfo::CreateFileVersionInfo(path);
   }
-  return std::unique_ptr<FileVersionInfo>();
+  return {};
 }
 
 }  // namespace

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -796,7 +796,7 @@ ElectronBrowserClient::CreateClientCertStore(
 #elif BUILDFLAG(IS_MAC)
   return std::make_unique<net::ClientCertStoreMac>();
 #elif defined(USE_OPENSSL)
-  return std::unique_ptr<net::ClientCertStore>();
+  return ();
 #endif
 }
 
@@ -805,7 +805,7 @@ ElectronBrowserClient::OverrideSystemLocationProvider() {
 #if BUILDFLAG(OVERRIDE_LOCATION_PROVIDER)
   return std::make_unique<FakeLocationProvider>();
 #else
-  return nullptr;
+  return {};
 #endif
 }
 

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -484,7 +484,7 @@ ElectronBrowserContext::CreateZoomLevelDelegate(
   if (!IsOffTheRecord()) {
     return std::make_unique<ZoomLevelDelegate>(prefs(), partition_path);
   }
-  return std::unique_ptr<content::ZoomLevelDelegate>();
+  return {};
 }
 
 content::DownloadManagerDelegate*

--- a/shell/browser/electron_web_ui_controller_factory.cc
+++ b/shell/browser/electron_web_ui_controller_factory.cc
@@ -54,7 +54,7 @@ ElectronWebUIControllerFactory::CreateWebUIControllerForURL(
   if (host == chrome::kChromeUIAccessibilityHost)
     return std::make_unique<ElectronAccessibilityUI>(web_ui);
 
-  return std::unique_ptr<content::WebUIController>();
+  return {};
 }
 
 }  // namespace electron

--- a/shell/browser/extensions/electron_extension_system.cc
+++ b/shell/browser/extensions/electron_extension_system.cc
@@ -95,7 +95,7 @@ std::unique_ptr<base::Value::Dict> ParseManifest(
 
   if (!manifest.get() || !manifest->is_dict()) {
     LOG(ERROR) << "Failed to parse extension manifest.";
-    return std::unique_ptr<base::Value::Dict>();
+    return {};
   }
   return std::make_unique<base::Value::Dict>(std::move(*manifest).TakeDict());
 }

--- a/shell/browser/file_select_helper.cc
+++ b/shell/browser/file_select_helper.cc
@@ -531,7 +531,7 @@ bool FileSelectHelper::IsAcceptTypeValid(const std::string& accept_type) {
 base::FilePath FileSelectHelper::GetSanitizedFileName(
     const base::FilePath& suggested_filename) {
   if (suggested_filename.empty())
-    return base::FilePath();
+    return {};
   return net::GenerateFileName(
       GURL(), std::string(), std::string(), suggested_filename.AsUTF8Unsafe(),
       std::string(), l10n_util::GetStringUTF8(IDS_DEFAULT_DOWNLOAD_FILENAME));

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -297,12 +297,12 @@ void OffScreenRenderWidgetHostView::SetBounds(const gfx::Rect& new_bounds) {
 }
 
 gfx::NativeView OffScreenRenderWidgetHostView::GetNativeView() {
-  return gfx::NativeView();
+  return {};
 }
 
 gfx::NativeViewAccessible
 OffScreenRenderWidgetHostView::GetNativeViewAccessible() {
-  return gfx::NativeViewAccessible();
+  return {};
 }
 
 ui::TextInputClient* OffScreenRenderWidgetHostView::GetTextInputClient() {

--- a/shell/browser/osr/osr_web_contents_view.cc
+++ b/shell/browser/osr/osr_web_contents_view.cc
@@ -74,19 +74,19 @@ gfx::Size OffScreenWebContentsView::GetSize() {
 #if !BUILDFLAG(IS_MAC)
 gfx::NativeView OffScreenWebContentsView::GetNativeView() const {
   if (!native_window_)
-    return gfx::NativeView();
+    return {};
   return native_window_->GetNativeView();
 }
 
 gfx::NativeView OffScreenWebContentsView::GetContentNativeView() const {
   if (!native_window_)
-    return gfx::NativeView();
+    return {};
   return native_window_->GetNativeView();
 }
 
 gfx::NativeWindow OffScreenWebContentsView::GetTopLevelNativeWindow() const {
   if (!native_window_)
-    return gfx::NativeWindow();
+    return {};
   return native_window_->GetNativeWindow();
 }
 #endif

--- a/shell/browser/ui/devtools_manager_delegate.cc
+++ b/shell/browser/ui/devtools_manager_delegate.cc
@@ -50,13 +50,13 @@ class TCPServerSocketFactory : public content::DevToolsSocketFactory {
     auto socket =
         std::make_unique<net::TCPServerSocket>(nullptr, net::NetLogSource());
     if (socket->ListenWithAddressAndPort(address_, port_, 10) != net::OK)
-      return std::unique_ptr<net::ServerSocket>();
+      return {};
 
     return socket;
   }
   std::unique_ptr<net::ServerSocket> CreateForTethering(
       std::string* name) override {
-    return std::unique_ptr<net::ServerSocket>();
+    return {};
   }
 
   std::string address_;

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -532,14 +532,14 @@ gin::Handle<SimpleURLLoaderWrapper> SimpleURLLoaderWrapper::Create(
   gin_helper::Dictionary opts;
   if (!args->GetNext(&opts)) {
     args->ThrowTypeError("Expected a dictionary");
-    return gin::Handle<SimpleURLLoaderWrapper>();
+    return {};
   }
   auto request = std::make_unique<network::ResourceRequest>();
   opts.Get("method", &request->method);
   opts.Get("url", &request->url);
   if (!request->url.is_valid()) {
     args->ThrowTypeError("Invalid URL");
-    return gin::Handle<SimpleURLLoaderWrapper>();
+    return {};
   }
   request->site_for_cookies = net::SiteForCookies::FromUrl(request->url);
   opts.Get("referrer", &request->referrer);
@@ -607,7 +607,7 @@ gin::Handle<SimpleURLLoaderWrapper> SimpleURLLoaderWrapper::Create(
       if (!net::HttpUtil::IsValidHeaderName(it.first) ||
           !net::HttpUtil::IsValidHeaderValue(it.second)) {
         args->ThrowTypeError("Invalid header name or value");
-        return gin::Handle<SimpleURLLoaderWrapper>();
+        return {};
       }
       request->headers.SetHeader(it.first, it.second);
     }

--- a/shell/common/api/electron_api_v8_util.cc
+++ b/shell/common/api/electron_api_v8_util.cc
@@ -49,10 +49,10 @@ v8::Local<v8::Value> GetHiddenValue(v8::Isolate* isolate,
   v8::Local<v8::Value> value;
   v8::Maybe<bool> result = object->HasPrivate(context, privateKey);
   if (!(result.IsJust() && result.FromJust()))
-    return v8::Local<v8::Value>();
+    return {};
   if (object->GetPrivate(context, privateKey).ToLocal(&value))
     return value;
-  return v8::Local<v8::Value>();
+  return {};
 }
 
 void SetHiddenValue(v8::Isolate* isolate,

--- a/shell/common/extensions/electron_extensions_api_provider.cc
+++ b/shell/common/extensions/electron_extensions_api_provider.cc
@@ -49,7 +49,7 @@ base::span<const APIPermissionInfo::InitInfo> GetPermissionInfos() {
   return base::make_span(permissions_to_register);
 }
 base::span<const Alias> GetPermissionAliases() {
-  return base::span<const Alias>();
+  return {};
 }
 
 }  // namespace

--- a/shell/common/gin_helper/event_emitter_caller.h
+++ b/shell/common/gin_helper/event_emitter_caller.h
@@ -64,7 +64,7 @@ v8::Local<v8::Value> CallMethod(v8::Isolate* isolate,
     return scope.Escape(CustomEmit(isolate, v8_object, method_name,
                                    std::forward<Args>(args)...));
   else
-    return v8::Local<v8::Value>();
+    return {};
 }
 
 template <typename T, typename... Args>

--- a/shell/common/gin_helper/trackable_object.h
+++ b/shell/common/gin_helper/trackable_object.h
@@ -101,7 +101,7 @@ class TrackableObject : public TrackableObjectBase, public EventEmitter<T> {
     if (weak_map_)
       return weak_map_->Values(isolate);
     else
-      return std::vector<v8::Local<v8::Object>>();
+      return {};
   }
 
   // Removes this instance from the weak map.

--- a/shell/common/mac/codesign_util.cc
+++ b/shell/common/mac/codesign_util.cc
@@ -25,7 +25,7 @@ std::optional<bool> IsUnsignedOrAdHocSigned(SecCodeRef code) {
   }
   if (status != errSecSuccess) {
     OSSTATUS_LOG(ERROR, status) << "SecCodeCopyStaticCode";
-    return std::optional<bool>();
+    return {};
   }
   // Copy the signing info from the SecStaticCodeRef.
   base::apple::ScopedCFTypeRef<CFDictionaryRef> signing_info;
@@ -34,7 +34,7 @@ std::optional<bool> IsUnsignedOrAdHocSigned(SecCodeRef code) {
                                     signing_info.InitializeInto());
   if (status != errSecSuccess) {
     OSSTATUS_LOG(ERROR, status) << "SecCodeCopySigningInformation";
-    return std::optional<bool>();
+    return {};
   }
   // Look up the code signing flags. If the flags are absent treat this as
   // unsigned. This decision is consistent with the StaticCode source:
@@ -51,7 +51,7 @@ std::optional<bool> IsUnsignedOrAdHocSigned(SecCodeRef code) {
   long long flags;
   if (!CFNumberGetValue(signing_info_flags, kCFNumberLongLongType, &flags)) {
     LOG(ERROR) << "CFNumberGetValue";
-    return std::optional<bool>();
+    return {};
   }
   if (static_cast<uint32_t>(flags) & kSecCodeSignatureAdhoc) {
     return true;

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -190,7 +190,7 @@ v8::MaybeLocal<v8::Promise> HostImportModuleDynamically(
     v8::Local<v8::FixedArray> v8_import_assertions) {
   if (node::Environment::GetCurrent(context) == nullptr) {
     if (electron::IsBrowserProcess() || electron::IsUtilityProcess())
-      return v8::MaybeLocal<v8::Promise>();
+      return {};
     return blink::V8Initializer::HostImportModuleDynamically(
         context, v8_host_defined_options, v8_referrer_resource_url,
         v8_specifier, v8_import_assertions);

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -152,7 +152,7 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
                         "Electron contextBridge recursion depth exceeded.  "
                         "Nested objects "
                         "deeper than 1000 are not supported.")));
-    return v8::MaybeLocal<v8::Value>();
+    return {};
   }
 
   // Certain primitives always use the current contexts prototype and we can
@@ -209,7 +209,7 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
 
       if (!v8::Function::New(destination_context, ProxyFunctionWrapper, state)
                .ToLocal(&proxy_func))
-        return v8::MaybeLocal<v8::Value>();
+        return {};
       SetPrivate(destination_context, proxy_func.As<v8::Object>(),
                  context_bridge::kOriginalFunctionPrivateKey, func);
       object_cache->CacheProxiedObject(value, proxy_func);
@@ -372,11 +372,11 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
           arr->Get(source_context, i).ToLocalChecked(), value, object_cache,
           support_dynamic_properties, recursion_depth + 1, error_target);
       if (value_for_array.IsEmpty())
-        return v8::MaybeLocal<v8::Value>();
+        return {};
 
       if (!IsTrue(cloned_arr->Set(destination_context, static_cast<int>(i),
                                   value_for_array.ToLocalChecked()))) {
-        return v8::MaybeLocal<v8::Value>();
+        return {};
       }
     }
     object_cache->CacheProxiedObject(value, cloned_arr);
@@ -408,7 +408,7 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
         object_value, source_context, destination_context, object_cache,
         support_dynamic_properties, recursion_depth + 1, error_target);
     if (passed_value.IsEmpty())
-      return v8::MaybeLocal<v8::Value>();
+      return {};
     return v8::MaybeLocal<v8::Value>(passed_value.ToLocalChecked());
   }
 
@@ -421,7 +421,7 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
     v8::Context::Scope error_scope(error_context);
     // V8 serializer will throw an error if required
     if (!gin::ConvertFromV8(error_context->GetIsolate(), value, &ret)) {
-      return v8::MaybeLocal<v8::Value>();
+      return {};
     }
   }
 
@@ -651,7 +651,7 @@ v8::MaybeLocal<v8::Object> CreateProxyForAPI(
           object_cache, support_dynamic_properties, recursion_depth + 1,
           error_target);
       if (passed_value.IsEmpty())
-        return v8::MaybeLocal<v8::Object>();
+        return {};
       proxy.Set(key, passed_value.ToLocalChecked());
     }
 

--- a/shell/renderer/api/electron_api_ipc_renderer.cc
+++ b/shell/renderer/api/electron_api_ipc_renderer.cc
@@ -107,11 +107,11 @@ class IPCRenderer final : public gin::Wrappable<IPCRenderer>,
                                 v8::Local<v8::Value> arguments) {
     if (!electron_ipc_remote_) {
       thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
-      return v8::Local<v8::Promise>();
+      return {};
     }
     blink::CloneableMessage message;
     if (!electron::SerializeV8Value(isolate, arguments, &message)) {
-      return v8::Local<v8::Promise>();
+      return {};
     }
     gin_helper::Promise<blink::CloneableMessage> p(isolate);
     auto handle = p.GetHandle();
@@ -189,11 +189,11 @@ class IPCRenderer final : public gin::Wrappable<IPCRenderer>,
                                 v8::Local<v8::Value> arguments) {
     if (!electron_ipc_remote_) {
       thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
-      return v8::Local<v8::Value>();
+      return {};
     }
     blink::CloneableMessage message;
     if (!electron::SerializeV8Value(isolate, arguments, &message)) {
-      return v8::Local<v8::Value>();
+      return {};
     }
 
     blink::CloneableMessage result;

--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -45,7 +45,7 @@ v8::Local<v8::Object> GetIpcObject(v8::Local<v8::Context> context) {
       global_object->GetPrivate(context, private_binding_key).ToLocalChecked();
   if (value.IsEmpty() || !value->IsObject()) {
     LOG(ERROR) << "Attempted to get the 'ipcNative' object but it was missing";
-    return v8::Local<v8::Object>();
+    return {};
   }
   return value->ToObject(context).ToLocalChecked();
 }

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -86,7 +86,7 @@ v8::Local<v8::Value> CreatePreloadScript(v8::Isolate* isolate,
   auto maybe_script = v8::Script::Compile(context, source);
   v8::Local<v8::Script> script;
   if (!maybe_script.ToLocal(&script))
-    return v8::Local<v8::Value>();
+    return {};
   return script->Run(context).ToLocalChecked();
 }
 

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -456,7 +456,7 @@ v8::Local<v8::Object> RendererClientBase::GetScriptableObject(
   if (container_manager)
     return container_manager->GetScriptableObject(plugin_element, isolate);
 #endif
-  return v8::Local<v8::Object>();
+  return {};
 }
 
 std::unique_ptr<blink::WebPrescientNetworking>


### PR DESCRIPTION
#### Description of Change

Finish off the return-braced-init-list changes. Pt 1 was in #44838.

These diffs really are just a lot of `return {};` and that's pretty much it :smile_cat: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.