### PR TITLE
docs: clarify that sessions use cache by default (33-x-y backport)

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -27,7 +27,8 @@ The `session` module has the following methods:
 
 * `partition` string
 * `options` Object (optional)
-  * `cache` boolean - Whether to enable cache.
+  * `cache` boolean - Whether to enable cache. Default is `true` unless the
+    [`--disable-http-cache` switch](command-line-switches.md#--disable-http-cache) is used.
 
 Returns `Session` - A session instance from `partition` string. When there is an existing
 `Session` with the same `partition`, it will be returned; otherwise a new
@@ -46,7 +47,8 @@ of an existing `Session` object.
 
 * `path` string
 * `options` Object (optional)
-  * `cache` boolean - Whether to enable cache.
+  * `cache` boolean - Whether to enable cache. Default is `true` unless the
+    [`--disable-http-cache` switch](command-line-switches.md#--disable-http-cache) is used.
 
 Returns `Session` - A session instance from the absolute path as specified by the `path`
 string. When there is an existing `Session` with the same absolute path, it


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/44547

See that PR for details.

The purpose of this backport is to make the change show up on [electronjs.org](https://www.electronjs.org/docs/latest/api/session), which is currently built from the `33-x-y` branch.

Notes: none.