### PR TITLE
fix: fix launch crash when null device is disabled on Windows

### DIFF
--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -177,6 +177,11 @@ Disables the Chromium [sandbox](https://www.chromium.org/developers/design-docum
 Forces renderer process and Chromium helper processes to run un-sandboxed.
 Should only be used for testing.
 
+### --no-stdio-init
+
+Disable stdio initialization during node initialization.
+Used to avoid node initialization crash when the nul device is disabled on Windows platform.
+
 ### --proxy-bypass-list=`hosts`
 
 Instructs Electron to bypass the proxy server for the given semi-colon-separated

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -32,6 +32,8 @@
 #include "shell/common/node_bindings.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/node_util.h"
+#include "shell/common/options_switches.h"
+#include "shell/common/platform_util.h"
 
 #if BUILDFLAG(IS_WIN)
 #include "chrome/child/v8_crashpad_support_win.h"
@@ -180,14 +182,33 @@ int NodeMain() {
     NodeBindings::RegisterBuiltinBindings();
 
     // Parse Node.js cli flags and strip out disallowed options.
-    const std::vector<std::string> args = ElectronCommandLine::AsUtf8();
+    std::vector<std::string> args = ElectronCommandLine::AsUtf8();
     ExitIfContainsDisallowedFlags(args);
+
+    uint64_t process_flags =
+        node::ProcessInitializationFlags::kNoInitializeV8 |
+        node::ProcessInitializationFlags::kNoInitializeNodeV8Platform;
+
+    base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+    if (command_line->HasSwitch(switches::kNoStdioInit)) {
+      process_flags |= node::ProcessInitializationFlags::kNoStdioInitialization;
+      // remove the option to avoid node error "bad option: --no-stdio-init"
+      std::string option = std::string("--") + switches::kNoStdioInit;
+      std::erase(args, option);
+    } else {
+#if BUILDFLAG(IS_WIN)
+      if (!platform_util::IsNulDeviceEnabled()) {
+        LOG(FATAL) << "Fail to open nul device and node initialization may "
+                      "crash! Try using --"
+                   << switches::kNoStdioInit;
+      }
+#endif
+    }
 
     std::shared_ptr<node::InitializationResult> result =
         node::InitializeOncePerProcess(
-            args,
-            {node::ProcessInitializationFlags::kNoInitializeV8,
-             node::ProcessInitializationFlags::kNoInitializeNodeV8Platform});
+            args, static_cast<node::ProcessInitializationFlags::Flags>(
+                      process_flags));
 
     for (const std::string& error : result->errors())
       fprintf(stderr, "%s: %s\n", args[0].c_str(), error.c_str());

--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -127,6 +127,7 @@ UtilityProcessWrapper::UtilityProcessWrapper(
                       OPEN_EXISTING, 0, nullptr);
       if (handle == INVALID_HANDLE_VALUE) {
         PLOG(ERROR) << "Failed to create null handle";
+        Emit("error", "Failed to create null handle for ignoring stdio");
         return;
       }
       if (io_handle == IOHandle::STDOUT) {

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -38,6 +38,8 @@
 #include "shell/common/mac/main_application_bundle.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/node_util.h"
+#include "shell/common/options_switches.h"
+#include "shell/common/platform_util.h"
 #include "shell/common/process_util.h"
 #include "shell/common/world_ids.h"
 #include "third_party/blink/public/web/web_local_frame.h"
@@ -567,6 +569,19 @@ void NodeBindings::Initialize(v8::Local<v8::Context> context) {
 
   if (!fuses::IsNodeOptionsEnabled())
     process_flags |= node::ProcessInitializationFlags::kDisableNodeOptionsEnv;
+
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  if (command_line->HasSwitch(switches::kNoStdioInit)) {
+    process_flags |= node::ProcessInitializationFlags::kNoStdioInitialization;
+  } else {
+#if BUILDFLAG(IS_WIN)
+    if (!platform_util::IsNulDeviceEnabled()) {
+      LOG(FATAL) << "Fail to open nul device and node initialization may "
+                    "crash! Try using --"
+                 << switches::kNoStdioInit;
+    }
+#endif
+  }
 
   std::shared_ptr<node::InitializationResult> result =
       node::InitializeOncePerProcess(

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -288,6 +288,10 @@ inline constexpr base::cstring_view kEnableAuthNegotiatePort =
 // If set, NTLM v2 is disabled for POSIX platforms.
 inline constexpr base::cstring_view kDisableNTLMv2 = "disable-ntlm-v2";
 
+// If set, flag node::ProcessInitializationFlags::kNoStdioInitialization would
+// be set for node initialization.
+inline constexpr base::cstring_view kNoStdioInit = "no-stdio-init";
+
 }  // namespace switches
 
 }  // namespace electron

--- a/shell/common/platform_util.h
+++ b/shell/common/platform_util.h
@@ -46,6 +46,9 @@ void Beep();
 #if BUILDFLAG(IS_WIN)
 // SHGetFolderPath calls not covered by Chromium
 bool GetFolderPath(int key, base::FilePath* result);
+
+// Check if nul device can be used.
+bool IsNulDeviceEnabled();
 #endif
 
 #if BUILDFLAG(IS_MAC)

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -12,6 +12,8 @@
 #include <comdef.h>
 #include <commdlg.h>
 #include <dwmapi.h>
+#include <fcntl.h>
+#include <io.h>
 #include <objbase.h>
 #include <shellapi.h>
 #include <shlobj.h>
@@ -448,6 +450,18 @@ bool GetFolderPath(int key, base::FilePath* result) {
 
 void Beep() {
   MessageBeep(MB_OK);
+}
+
+bool IsNulDeviceEnabled() {
+  bool ret = true;
+  int fd = _open("nul", _O_RDWR);
+  if (fd < 0) {
+    ret = false;
+  } else {
+    ret = true;
+    _close(fd);
+  }
+  return ret;
 }
 
 }  // namespace platform_util


### PR DESCRIPTION
add node flag node::ProcessInitializationFlags::kNoStdioInitialization

Fixes #44881

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
