### PR TITLE
fix: remove unused id argument from TranslateToStock()

### DIFF
--- a/shell/browser/ui/message_box_gtk.cc
+++ b/shell/browser/ui/message_box_gtk.cc
@@ -101,11 +101,10 @@ class GtkMessageBox : private NativeWindowObserver {
     // Add buttons.
     GtkDialog* dialog = GTK_DIALOG(dialog_);
     if (settings.buttons.size() == 0) {
-      gtk_dialog_add_button(dialog, TranslateToStock(0, "OK"), 0);
+      gtk_dialog_add_button(dialog, TranslateToStock("OK"), 0);
     } else {
       for (size_t i = 0; i < settings.buttons.size(); ++i) {
-        gtk_dialog_add_button(dialog, TranslateToStock(i, settings.buttons[i]),
-                              i);
+        gtk_dialog_add_button(dialog, TranslateToStock(settings.buttons[i]), i);
       }
     }
     gtk_dialog_set_default_response(dialog, settings.default_id);
@@ -146,16 +145,20 @@ class GtkMessageBox : private NativeWindowObserver {
     }
   }
 
-  const char* TranslateToStock(int id, const std::string& text) {
+  static const char* TranslateToStock(const std::string& text) {
     const std::string lower = base::ToLowerASCII(text);
-    if (lower == "cancel")
+    if (lower == "cancel") {
       return gtk_util::GetCancelLabel();
-    if (lower == "no")
+    }
+    if (lower == "no") {
       return gtk_util::GetNoLabel();
-    if (lower == "ok")
+    }
+    if (lower == "ok") {
       return gtk_util::GetOkLabel();
-    if (lower == "yes")
+    }
+    if (lower == "yes") {
       return gtk_util::GetYesLabel();
+    }
     return text.c_str();
   }
 


### PR DESCRIPTION
#### Description of Change

Remove the `id` argument from `TranslateToStock()`. It's been unused since fb537d91fce3f97ac3b902c36fcc4626eef0c959.

Also, fix a small number of warnings in that function: [readability-braces-around-statements](https://clang.llvm.org/extra/clang-tidy/checks/readability/braces-around-statements.html) and [readability-convert-member-functions-to-static](https://clang.llvm.org/extra/clang-tidy/checks/readability/convert-member-functions-to-static.html)

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.