### PR TITLE
chore: remove unused isolate argument from Cookies constructor

### DIFF
--- a/shell/browser/api/electron_api_cookies.cc
+++ b/shell/browser/api/electron_api_cookies.cc
@@ -292,8 +292,8 @@ std::string StringToCookieSameSite(const std::string* str_ptr,
 
 gin::WrapperInfo Cookies::kWrapperInfo = {gin::kEmbedderNativeGin};
 
-Cookies::Cookies(v8::Isolate* isolate, ElectronBrowserContext* browser_context)
-    : browser_context_(browser_context) {
+Cookies::Cookies(ElectronBrowserContext* browser_context)
+    : browser_context_{browser_context} {
   cookie_change_subscription_ =
       browser_context_->cookie_change_notifier()->RegisterCookieChangeCallback(
           base::BindRepeating(&Cookies::OnCookieChanged,
@@ -458,7 +458,7 @@ void Cookies::OnCookieChanged(const net::CookieChangeInfo& change) {
 // static
 gin::Handle<Cookies> Cookies::Create(v8::Isolate* isolate,
                                      ElectronBrowserContext* browser_context) {
-  return gin::CreateHandle(isolate, new Cookies(isolate, browser_context));
+  return gin::CreateHandle(isolate, new Cookies{browser_context});
 }
 
 gin::ObjectTemplateBuilder Cookies::GetObjectTemplateBuilder(

--- a/shell/browser/api/electron_api_cookies.h
+++ b/shell/browser/api/electron_api_cookies.h
@@ -50,7 +50,7 @@ class Cookies final : public gin::Wrappable<Cookies>,
   Cookies& operator=(const Cookies&) = delete;
 
  protected:
-  Cookies(v8::Isolate* isolate, ElectronBrowserContext* browser_context);
+  Cookies(ElectronBrowserContext* browser_context);
   ~Cookies() override;
 
   v8::Local<v8::Promise> Get(v8::Isolate*,

--- a/shell/browser/api/electron_api_cookies.h
+++ b/shell/browser/api/electron_api_cookies.h
@@ -50,7 +50,7 @@ class Cookies final : public gin::Wrappable<Cookies>,
   Cookies& operator=(const Cookies&) = delete;
 
  protected:
-  Cookies(ElectronBrowserContext* browser_context);
+  explicit Cookies(ElectronBrowserContext* browser_context);
   ~Cookies() override;
 
   v8::Local<v8::Promise> Get(v8::Isolate*,


### PR DESCRIPTION
#### Description of Change

Remove the unused isolate argument from the Cookies constructor.

It hasn't been needed since the ginify cookies refactor in Mar 2020, commit 22202255

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.