### PR TITLE
chore: make version parsing more tolerant

### DIFF
--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -61,7 +61,7 @@ jobs:
               // for now check for comma or space separated version.
               const versions = electronVersion.split(/, | /);
               for (const version of versions) {
-                const major = semver.coerce(version)?.major;
+                const major = semver.coerce(version, { loose: true })?.major;
                 if (major) {
                   const versionLabel = `${major}-x-y`;
                   let labelExists = false;

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -61,7 +61,7 @@ jobs:
               // for now check for comma or space separated version.
               const versions = electronVersion.split(/, | /);
               for (const version of versions) {
-                const major = semver.parse(version)?.major;
+                const major = semver.coerce(version)?.major;
                 if (major) {
                   const versionLabel = `${major}-x-y`;
                   let labelExists = false;


### PR DESCRIPTION
#### Description of Change

Fixes parsing error surfaced in https://github.com/electron/electron/issues/44917 - `V33.2.1` parsed as `null` instead of `33.2.1`. Fix this by trying to coerce instead of just parse.

CLI check:

```sh
npx semver --parse 'V33.2.1' // null
npx semver --coerce 'V33.2.1' // 33.2.1
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none