### PR TITLE
fix: modernize-use-equals-default warnings

### DIFF
--- a/shell/browser/auto_updater.h
+++ b/shell/browser/auto_updater.h
@@ -43,7 +43,7 @@ class Delegate {
                                   const std::string& update_url) {}
 
  protected:
-  virtual ~Delegate() {}
+  virtual ~Delegate() = default;
 };
 
 class AutoUpdater {

--- a/shell/browser/browser_observer.h
+++ b/shell/browser/browser_observer.h
@@ -85,7 +85,7 @@ class BrowserObserver : public base::CheckedObserver {
 #endif
 
  protected:
-  ~BrowserObserver() override {}
+  ~BrowserObserver() override = default;
 };
 
 }  // namespace electron

--- a/shell/browser/extended_web_contents_observer.h
+++ b/shell/browser/extended_web_contents_observer.h
@@ -26,7 +26,7 @@ class ExtendedWebContentsObserver : public base::CheckedObserver {
   virtual void OnDevToolsResized() {}
 
  protected:
-  ~ExtendedWebContentsObserver() override {}
+  ~ExtendedWebContentsObserver() override = default;
 };
 
 }  // namespace electron

--- a/shell/browser/extensions/api/extension_action/extension_action_api.h
+++ b/shell/browser/extensions/api/extension_action/extension_action_api.h
@@ -106,14 +106,14 @@ class ExtensionActionFunction : public ExtensionFunction {
 // show
 class ExtensionActionShowFunction : public ExtensionActionFunction {
  protected:
-  ~ExtensionActionShowFunction() override {}
+  ~ExtensionActionShowFunction() override = default;
   ResponseAction RunExtensionAction() override;
 };
 
 // hide
 class ExtensionActionHideFunction : public ExtensionActionFunction {
  protected:
-  ~ExtensionActionHideFunction() override {}
+  ~ExtensionActionHideFunction() override = default;
   ResponseAction RunExtensionAction() override;
 };
 
@@ -123,28 +123,28 @@ class ExtensionActionSetIconFunction : public ExtensionActionFunction {
   static void SetReportErrorForInvisibleIconForTesting(bool value);
 
  protected:
-  ~ExtensionActionSetIconFunction() override {}
+  ~ExtensionActionSetIconFunction() override = default;
   ResponseAction RunExtensionAction() override;
 };
 
 // setTitle
 class ExtensionActionSetTitleFunction : public ExtensionActionFunction {
  protected:
-  ~ExtensionActionSetTitleFunction() override {}
+  ~ExtensionActionSetTitleFunction() override = default;
   ResponseAction RunExtensionAction() override;
 };
 
 // setPopup
 class ExtensionActionSetPopupFunction : public ExtensionActionFunction {
  protected:
-  ~ExtensionActionSetPopupFunction() override {}
+  ~ExtensionActionSetPopupFunction() override = default;
   ResponseAction RunExtensionAction() override;
 };
 
 // setBadgeText
 class ExtensionActionSetBadgeTextFunction : public ExtensionActionFunction {
  protected:
-  ~ExtensionActionSetBadgeTextFunction() override {}
+  ~ExtensionActionSetBadgeTextFunction() override = default;
   ResponseAction RunExtensionAction() override;
 };
 
@@ -152,35 +152,35 @@ class ExtensionActionSetBadgeTextFunction : public ExtensionActionFunction {
 class ExtensionActionSetBadgeBackgroundColorFunction
     : public ExtensionActionFunction {
  protected:
-  ~ExtensionActionSetBadgeBackgroundColorFunction() override {}
+  ~ExtensionActionSetBadgeBackgroundColorFunction() override = default;
   ResponseAction RunExtensionAction() override;
 };
 
 // getTitle
 class ExtensionActionGetTitleFunction : public ExtensionActionFunction {
  protected:
-  ~ExtensionActionGetTitleFunction() override {}
+  ~ExtensionActionGetTitleFunction() override = default;
   ResponseAction RunExtensionAction() override;
 };
 
 // getPopup
 class ExtensionActionGetPopupFunction : public ExtensionActionFunction {
  protected:
-  ~ExtensionActionGetPopupFunction() override {}
+  ~ExtensionActionGetPopupFunction() override = default;
   ResponseAction RunExtensionAction() override;
 };
 
 // openPopup
 class ExtensionActionOpenPopupFunction : public ExtensionActionFunction {
  protected:
-  ~ExtensionActionOpenPopupFunction() override {}
+  ~ExtensionActionOpenPopupFunction() override = default;
   ResponseAction RunExtensionAction() override;
 };
 
 // getBadgeText
 class ExtensionActionGetBadgeTextFunction : public ExtensionActionFunction {
  protected:
-  ~ExtensionActionGetBadgeTextFunction() override {}
+  ~ExtensionActionGetBadgeTextFunction() override = default;
   ResponseAction RunExtensionAction() override;
 };
 
@@ -188,7 +188,7 @@ class ExtensionActionGetBadgeTextFunction : public ExtensionActionFunction {
 class ExtensionActionGetBadgeBackgroundColorFunction
     : public ExtensionActionFunction {
  protected:
-  ~ExtensionActionGetBadgeBackgroundColorFunction() override {}
+  ~ExtensionActionGetBadgeBackgroundColorFunction() override = default;
   ResponseAction RunExtensionAction() override;
 };
 
@@ -201,7 +201,7 @@ class ActionSetIconFunction : public ExtensionActionSetIconFunction {
   DECLARE_EXTENSION_FUNCTION("action.setIcon", ACTION_SETICON)
 
  protected:
-  ~ActionSetIconFunction() override {}
+  ~ActionSetIconFunction() override = default;
 };
 
 class ActionGetPopupFunction : public ExtensionActionGetPopupFunction {
@@ -209,7 +209,7 @@ class ActionGetPopupFunction : public ExtensionActionGetPopupFunction {
   DECLARE_EXTENSION_FUNCTION("action.getPopup", ACTION_GETPOPUP)
 
  protected:
-  ~ActionGetPopupFunction() override {}
+  ~ActionGetPopupFunction() override = default;
 };
 
 class ActionSetPopupFunction : public ExtensionActionSetPopupFunction {
@@ -217,7 +217,7 @@ class ActionSetPopupFunction : public ExtensionActionSetPopupFunction {
   DECLARE_EXTENSION_FUNCTION("action.setPopup", ACTION_SETPOPUP)
 
  protected:
-  ~ActionSetPopupFunction() override {}
+  ~ActionSetPopupFunction() override = default;
 };
 
 class ActionGetTitleFunction : public ExtensionActionGetTitleFunction {
@@ -225,7 +225,7 @@ class ActionGetTitleFunction : public ExtensionActionGetTitleFunction {
   DECLARE_EXTENSION_FUNCTION("action.getTitle", ACTION_GETTITLE)
 
  protected:
-  ~ActionGetTitleFunction() override {}
+  ~ActionGetTitleFunction() override = default;
 };
 
 class ActionSetTitleFunction : public ExtensionActionSetTitleFunction {
@@ -233,7 +233,7 @@ class ActionSetTitleFunction : public ExtensionActionSetTitleFunction {
   DECLARE_EXTENSION_FUNCTION("action.setTitle", ACTION_SETTITLE)
 
  protected:
-  ~ActionSetTitleFunction() override {}
+  ~ActionSetTitleFunction() override = default;
 };
 
 class ActionGetBadgeTextFunction : public ExtensionActionGetBadgeTextFunction {
@@ -241,7 +241,7 @@ class ActionGetBadgeTextFunction : public ExtensionActionGetBadgeTextFunction {
   DECLARE_EXTENSION_FUNCTION("action.getBadgeText", ACTION_GETBADGETEXT)
 
  protected:
-  ~ActionGetBadgeTextFunction() override {}
+  ~ActionGetBadgeTextFunction() override = default;
 };
 
 class ActionSetBadgeTextFunction : public ExtensionActionSetBadgeTextFunction {
@@ -249,7 +249,7 @@ class ActionSetBadgeTextFunction : public ExtensionActionSetBadgeTextFunction {
   DECLARE_EXTENSION_FUNCTION("action.setBadgeText", ACTION_SETBADGETEXT)
 
  protected:
-  ~ActionSetBadgeTextFunction() override {}
+  ~ActionSetBadgeTextFunction() override = default;
 };
 
 class ActionGetBadgeBackgroundColorFunction
@@ -259,7 +259,7 @@ class ActionGetBadgeBackgroundColorFunction
                              ACTION_GETBADGEBACKGROUNDCOLOR)
 
  protected:
-  ~ActionGetBadgeBackgroundColorFunction() override {}
+  ~ActionGetBadgeBackgroundColorFunction() override = default;
 };
 
 class ActionSetBadgeBackgroundColorFunction
@@ -269,7 +269,7 @@ class ActionSetBadgeBackgroundColorFunction
                              ACTION_SETBADGEBACKGROUNDCOLOR)
 
  protected:
-  ~ActionSetBadgeBackgroundColorFunction() override {}
+  ~ActionSetBadgeBackgroundColorFunction() override = default;
 };
 
 class ActionGetBadgeTextColorFunction : public ExtensionActionFunction {
@@ -297,7 +297,7 @@ class ActionEnableFunction : public ExtensionActionShowFunction {
   DECLARE_EXTENSION_FUNCTION("action.enable", ACTION_ENABLE)
 
  protected:
-  ~ActionEnableFunction() override {}
+  ~ActionEnableFunction() override = default;
 };
 
 class ActionDisableFunction : public ExtensionActionHideFunction {
@@ -305,7 +305,7 @@ class ActionDisableFunction : public ExtensionActionHideFunction {
   DECLARE_EXTENSION_FUNCTION("action.disable", ACTION_DISABLE)
 
  protected:
-  ~ActionDisableFunction() override {}
+  ~ActionDisableFunction() override = default;
 };
 
 class ActionIsEnabledFunction : public ExtensionActionFunction {
@@ -350,7 +350,7 @@ class BrowserActionSetIconFunction : public ExtensionActionSetIconFunction {
   DECLARE_EXTENSION_FUNCTION("browserAction.setIcon", BROWSERACTION_SETICON)
 
  protected:
-  ~BrowserActionSetIconFunction() override {}
+  ~BrowserActionSetIconFunction() override = default;
 };
 
 class BrowserActionSetTitleFunction : public ExtensionActionSetTitleFunction {
@@ -358,7 +358,7 @@ class BrowserActionSetTitleFunction : public ExtensionActionSetTitleFunction {
   DECLARE_EXTENSION_FUNCTION("browserAction.setTitle", BROWSERACTION_SETTITLE)
 
  protected:
-  ~BrowserActionSetTitleFunction() override {}
+  ~BrowserActionSetTitleFunction() override = default;
 };
 
 class BrowserActionSetPopupFunction : public ExtensionActionSetPopupFunction {
@@ -366,7 +366,7 @@ class BrowserActionSetPopupFunction : public ExtensionActionSetPopupFunction {
   DECLARE_EXTENSION_FUNCTION("browserAction.setPopup", BROWSERACTION_SETPOPUP)
 
  protected:
-  ~BrowserActionSetPopupFunction() override {}
+  ~BrowserActionSetPopupFunction() override = default;
 };
 
 class BrowserActionGetTitleFunction : public ExtensionActionGetTitleFunction {
@@ -374,7 +374,7 @@ class BrowserActionGetTitleFunction : public ExtensionActionGetTitleFunction {
   DECLARE_EXTENSION_FUNCTION("browserAction.getTitle", BROWSERACTION_GETTITLE)
 
  protected:
-  ~BrowserActionGetTitleFunction() override {}
+  ~BrowserActionGetTitleFunction() override = default;
 };
 
 class BrowserActionGetPopupFunction : public ExtensionActionGetPopupFunction {
@@ -382,7 +382,7 @@ class BrowserActionGetPopupFunction : public ExtensionActionGetPopupFunction {
   DECLARE_EXTENSION_FUNCTION("browserAction.getPopup", BROWSERACTION_GETPOPUP)
 
  protected:
-  ~BrowserActionGetPopupFunction() override {}
+  ~BrowserActionGetPopupFunction() override = default;
 };
 
 class BrowserActionSetBadgeTextFunction
@@ -392,7 +392,7 @@ class BrowserActionSetBadgeTextFunction
                              BROWSERACTION_SETBADGETEXT)
 
  protected:
-  ~BrowserActionSetBadgeTextFunction() override {}
+  ~BrowserActionSetBadgeTextFunction() override = default;
 };
 
 class BrowserActionSetBadgeBackgroundColorFunction
@@ -402,7 +402,7 @@ class BrowserActionSetBadgeBackgroundColorFunction
                              BROWSERACTION_SETBADGEBACKGROUNDCOLOR)
 
  protected:
-  ~BrowserActionSetBadgeBackgroundColorFunction() override {}
+  ~BrowserActionSetBadgeBackgroundColorFunction() override = default;
 };
 
 class BrowserActionGetBadgeTextFunction
@@ -412,7 +412,7 @@ class BrowserActionGetBadgeTextFunction
                              BROWSERACTION_GETBADGETEXT)
 
  protected:
-  ~BrowserActionGetBadgeTextFunction() override {}
+  ~BrowserActionGetBadgeTextFunction() override = default;
 };
 
 class BrowserActionGetBadgeBackgroundColorFunction
@@ -422,7 +422,7 @@ class BrowserActionGetBadgeBackgroundColorFunction
                              BROWSERACTION_GETBADGEBACKGROUNDCOLOR)
 
  protected:
-  ~BrowserActionGetBadgeBackgroundColorFunction() override {}
+  ~BrowserActionGetBadgeBackgroundColorFunction() override = default;
 };
 
 class BrowserActionEnableFunction : public ExtensionActionShowFunction {
@@ -430,7 +430,7 @@ class BrowserActionEnableFunction : public ExtensionActionShowFunction {
   DECLARE_EXTENSION_FUNCTION("browserAction.enable", BROWSERACTION_ENABLE)
 
  protected:
-  ~BrowserActionEnableFunction() override {}
+  ~BrowserActionEnableFunction() override = default;
 };
 
 class BrowserActionDisableFunction : public ExtensionActionHideFunction {
@@ -438,7 +438,7 @@ class BrowserActionDisableFunction : public ExtensionActionHideFunction {
   DECLARE_EXTENSION_FUNCTION("browserAction.disable", BROWSERACTION_DISABLE)
 
  protected:
-  ~BrowserActionDisableFunction() override {}
+  ~BrowserActionDisableFunction() override = default;
 };
 
 class BrowserActionOpenPopupFunction : public ExtensionActionOpenPopupFunction {
@@ -447,7 +447,7 @@ class BrowserActionOpenPopupFunction : public ExtensionActionOpenPopupFunction {
                              BROWSERACTION_OPEN_POPUP)
 
  protected:
-  ~BrowserActionOpenPopupFunction() override {}
+  ~BrowserActionOpenPopupFunction() override = default;
 };
 
 }  // namespace extensions
@@ -461,7 +461,7 @@ class PageActionShowFunction : public extensions::ExtensionActionShowFunction {
   DECLARE_EXTENSION_FUNCTION("pageAction.show", PAGEACTION_SHOW)
 
  protected:
-  ~PageActionShowFunction() override {}
+  ~PageActionShowFunction() override = default;
 };
 
 class PageActionHideFunction : public extensions::ExtensionActionHideFunction {
@@ -469,7 +469,7 @@ class PageActionHideFunction : public extensions::ExtensionActionHideFunction {
   DECLARE_EXTENSION_FUNCTION("pageAction.hide", PAGEACTION_HIDE)
 
  protected:
-  ~PageActionHideFunction() override {}
+  ~PageActionHideFunction() override = default;
 };
 
 class PageActionSetIconFunction
@@ -478,7 +478,7 @@ class PageActionSetIconFunction
   DECLARE_EXTENSION_FUNCTION("pageAction.setIcon", PAGEACTION_SETICON)
 
  protected:
-  ~PageActionSetIconFunction() override {}
+  ~PageActionSetIconFunction() override = default;
 };
 
 class PageActionSetTitleFunction
@@ -487,7 +487,7 @@ class PageActionSetTitleFunction
   DECLARE_EXTENSION_FUNCTION("pageAction.setTitle", PAGEACTION_SETTITLE)
 
  protected:
-  ~PageActionSetTitleFunction() override {}
+  ~PageActionSetTitleFunction() override = default;
 };
 
 class PageActionSetPopupFunction
@@ -496,7 +496,7 @@ class PageActionSetPopupFunction
   DECLARE_EXTENSION_FUNCTION("pageAction.setPopup", PAGEACTION_SETPOPUP)
 
  protected:
-  ~PageActionSetPopupFunction() override {}
+  ~PageActionSetPopupFunction() override = default;
 };
 
 class PageActionGetTitleFunction
@@ -505,7 +505,7 @@ class PageActionGetTitleFunction
   DECLARE_EXTENSION_FUNCTION("pageAction.getTitle", PAGEACTION_GETTITLE)
 
  protected:
-  ~PageActionGetTitleFunction() override {}
+  ~PageActionGetTitleFunction() override = default;
 };
 
 class PageActionGetPopupFunction
@@ -514,7 +514,7 @@ class PageActionGetPopupFunction
   DECLARE_EXTENSION_FUNCTION("pageAction.getPopup", PAGEACTION_GETPOPUP)
 
  protected:
-  ~PageActionGetPopupFunction() override {}
+  ~PageActionGetPopupFunction() override = default;
 };
 
 #endif  // SHELL_BROWSER_EXTENSIONS_API_EXTENSION_ACTION_EXTENSION_ACTION_API_H_

--- a/shell/browser/extensions/api/tabs/tabs_api.h
+++ b/shell/browser/extensions/api/tabs/tabs_api.h
@@ -43,13 +43,13 @@ class TabsExecuteScriptFunction : public ExecuteCodeInTabFunction {
   bool ShouldRemoveCSS() const override;
 
  private:
-  ~TabsExecuteScriptFunction() override {}
+  ~TabsExecuteScriptFunction() override = default;
 
   DECLARE_EXTENSION_FUNCTION("tabs.executeScript", TABS_EXECUTESCRIPT)
 };
 
 class TabsReloadFunction : public ExtensionFunction {
-  ~TabsReloadFunction() override {}
+  ~TabsReloadFunction() override = default;
 
   ResponseAction Run() override;
 
@@ -57,7 +57,7 @@ class TabsReloadFunction : public ExtensionFunction {
 };
 
 class TabsQueryFunction : public ExtensionFunction {
-  ~TabsQueryFunction() override {}
+  ~TabsQueryFunction() override = default;
 
   ResponseAction Run() override;
 
@@ -65,7 +65,7 @@ class TabsQueryFunction : public ExtensionFunction {
 };
 
 class TabsGetFunction : public ExtensionFunction {
-  ~TabsGetFunction() override {}
+  ~TabsGetFunction() override = default;
 
   ResponseAction Run() override;
 
@@ -74,7 +74,7 @@ class TabsGetFunction : public ExtensionFunction {
 
 class TabsSetZoomFunction : public ExtensionFunction {
  private:
-  ~TabsSetZoomFunction() override {}
+  ~TabsSetZoomFunction() override = default;
 
   ResponseAction Run() override;
 
@@ -83,7 +83,7 @@ class TabsSetZoomFunction : public ExtensionFunction {
 
 class TabsGetZoomFunction : public ExtensionFunction {
  private:
-  ~TabsGetZoomFunction() override {}
+  ~TabsGetZoomFunction() override = default;
 
   ResponseAction Run() override;
 
@@ -92,7 +92,7 @@ class TabsGetZoomFunction : public ExtensionFunction {
 
 class TabsSetZoomSettingsFunction : public ExtensionFunction {
  private:
-  ~TabsSetZoomSettingsFunction() override {}
+  ~TabsSetZoomSettingsFunction() override = default;
 
   ResponseAction Run() override;
 
@@ -101,7 +101,7 @@ class TabsSetZoomSettingsFunction : public ExtensionFunction {
 
 class TabsGetZoomSettingsFunction : public ExtensionFunction {
  private:
-  ~TabsGetZoomSettingsFunction() override {}
+  ~TabsGetZoomSettingsFunction() override = default;
 
   ResponseAction Run() override;
 
@@ -113,7 +113,7 @@ class TabsUpdateFunction : public ExtensionFunction {
   TabsUpdateFunction();
 
  protected:
-  ~TabsUpdateFunction() override {}
+  ~TabsUpdateFunction() override = default;
   bool UpdateURL(const std::string& url, int tab_id, std::string* error);
   ResponseValue GetResult();
 

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -27,7 +27,7 @@ namespace electron {
 
 class NativeWindowObserver : public base::CheckedObserver {
  public:
-  ~NativeWindowObserver() override {}
+  ~NativeWindowObserver() override = default;
 
   // Called when the web page in window wants to create a popup window.
   virtual void WillCreatePopupWindow(const std::u16string& frame_name,

--- a/shell/browser/ui/electron_menu_model.h
+++ b/shell/browser/ui/electron_menu_model.h
@@ -37,7 +37,7 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
 
   class Delegate : public ui::SimpleMenuModel::Delegate {
    public:
-    ~Delegate() override {}
+    ~Delegate() override = default;
 
     virtual bool GetAcceleratorForCommandIdWithParams(
         int command_id,
@@ -63,7 +63,7 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
 
   class Observer : public base::CheckedObserver {
    public:
-    ~Observer() override {}
+    ~Observer() override = default;
 
     // Notifies the menu will open.
     virtual void OnMenuWillShow() {}

--- a/shell/browser/ui/inspectable_web_contents_delegate.h
+++ b/shell/browser/ui/inspectable_web_contents_delegate.h
@@ -16,7 +16,7 @@ namespace electron {
 
 class InspectableWebContentsDelegate {
  public:
-  virtual ~InspectableWebContentsDelegate() {}
+  virtual ~InspectableWebContentsDelegate() = default;
 
   // Requested by WebContents of devtools.
   virtual void DevToolsReloadPage() {}

--- a/shell/browser/ui/inspectable_web_contents_view_delegate.h
+++ b/shell/browser/ui/inspectable_web_contents_view_delegate.h
@@ -14,7 +14,7 @@ namespace electron {
 
 class InspectableWebContentsViewDelegate {
  public:
-  virtual ~InspectableWebContentsViewDelegate() {}
+  virtual ~InspectableWebContentsViewDelegate() = default;
 
   virtual void DevToolsFocused() {}
   virtual void DevToolsOpened() {}

--- a/shell/browser/ui/tray_icon_observer.h
+++ b/shell/browser/ui/tray_icon_observer.h
@@ -41,7 +41,7 @@ class TrayIconObserver : public base::CheckedObserver {
   virtual void OnMouseMoved(const gfx::Point& location, int modifiers) {}
 
  protected:
-  ~TrayIconObserver() override {}
+  ~TrayIconObserver() override = default;
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/autofill_popup_view.h
+++ b/shell/browser/ui/views/autofill_popup_view.h
@@ -50,7 +50,7 @@ class AutofillPopupChildView : public views::View {
   AutofillPopupChildView& operator=(const AutofillPopupChildView&) = delete;
 
  private:
-  ~AutofillPopupChildView() override {}
+  ~AutofillPopupChildView() override = default;
 
   // views::Views implementation
   void GetAccessibleNodeData(ui::AXNodeData* node_data) override;

--- a/shell/browser/window_list_observer.h
+++ b/shell/browser/window_list_observer.h
@@ -20,7 +20,7 @@ class WindowListObserver : public base::CheckedObserver {
   virtual void OnWindowAllClosed() {}
 
  protected:
-  ~WindowListObserver() override {}
+  ~WindowListObserver() override = default;
 };
 
 }  // namespace electron

--- a/shell/common/color_util.h
+++ b/shell/common/color_util.h
@@ -12,7 +12,7 @@
 // SkColor is a typedef for uint32_t, this wrapper is to tag an SkColor for
 // ease of use in gin converters.
 struct WrappedSkColor {
-  WrappedSkColor() {}
+  WrappedSkColor() = default;
   WrappedSkColor(SkColor c) : value(c) {}  // NOLINT(runtime/explicit)
   SkColor value;
   operator SkColor() const { return value; }

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -61,7 +61,7 @@ class EventEmitter : public gin_helper::Wrappable<T> {
   EventEmitter& operator=(const EventEmitter&) = delete;
 
  protected:
-  EventEmitter() {}
+  EventEmitter() = default;
 
  private:
   // this.emit(name, event, args...);


### PR DESCRIPTION
#### Description of Change

Last one before honoring the quiet period, I promise

Fix a handful of [modernize-use-equals-default](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-default.html) warnings. If a class having a trivial ctor/dtor was blocked by this, using `= default` will allow the compiler to make that optimization.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.