### PR TITLE
fix: `context-menu` event with `BaseWindows`

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -72,7 +72,7 @@ The `menu` object has the following instance methods:
 #### `menu.popup([options])`
 
 * `options` Object (optional)
-  * `window` [BrowserWindow](browser-window.md) (optional) - Default is the focused window.
+  * `window` [BaseWindow](base-window.md) (optional) - Default is the focused window.
   * `x` number (optional) - Default is the current mouse cursor position.
     Must be declared if `y` is declared.
   * `y` number (optional) - Default is the current mouse cursor position.
@@ -86,13 +86,13 @@ The `menu` object has the following instance methods:
     Can be `none`, `mouse`, `keyboard`, `touch`, `touchMenu`, `longPress`, `longTap`, `touchHandle`, `stylus`, `adjustSelection`, or `adjustSelectionReset`.
   * `callback` Function (optional) - Called when menu is closed.
 
-Pops up this menu as a context menu in the [`BrowserWindow`](browser-window.md).
+Pops up this menu as a context menu in the [`BaseWindow`](base-window.md).
 
-#### `menu.closePopup([browserWindow])`
+#### `menu.closePopup([window])`
 
-* `browserWindow` [BrowserWindow](browser-window.md) (optional) - Default is the focused window.
+* `window` [BaseWindow](base-window.md) (optional) - Default is the focused window.
 
-Closes the context menu in the `browserWindow`.
+Closes the context menu in the `window`.
 
 #### `menu.append(menuItem)`
 

--- a/shell/browser/ui/cocoa/delayed_native_view_host.h
+++ b/shell/browser/ui/cocoa/delayed_native_view_host.h
@@ -24,8 +24,6 @@ class DelayedNativeViewHost : public views::NativeViewHost {
   void ViewHierarchyChanged(
       const views::ViewHierarchyChangedDetails& details) override;
 
-  gfx::NativeView GetNativeView() { return native_view_; }
-
  private:
   gfx::NativeView native_view_;
 };


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/44898.
Closes https://github.com/electron/electron/issues/44896.
Closes https://github.com/electron/electron/issues/44943.

Fixes an possible crash when using draggable regions and BaseWindows to get the `context-menu` event. My previous fix did not take into account that the `WebContentsView` was only added as as a sibling view in a `BrowserWindow` context. On an implementation level `menu.popup([options])` already takes a BaseWindows, so also update documentation to reflect this.

Tested with https://gist.github.com/09dd58e289571d3956cc95ea92b7d73a

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an possible crash when using draggable regions and BaseWindows to get the `context-menu` event.