### PR TITLE
fix: build failure when PDF viewer is disabled

### DIFF
--- a/shell/browser/extensions/electron_extension_system.cc
+++ b/shell/browser/extensions/electron_extension_system.cc
@@ -105,8 +105,8 @@ std::unique_ptr<base::Value::Dict> ParseManifest(
 }  // namespace
 
 void ElectronExtensionSystem::LoadComponentExtensions() {
-  std::string utf8_error;
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
+  std::string utf8_error;
   std::string pdf_manifest_string = pdf_extension_util::GetManifest();
   std::unique_ptr<base::Value::Dict> pdf_manifest =
       ParseManifest(pdf_manifest_string);

--- a/shell/browser/extensions/electron_extension_system.cc
+++ b/shell/browser/extensions/electron_extension_system.cc
@@ -87,6 +87,7 @@ void ElectronExtensionSystem::InitForRegularProfile(bool extensions_enabled) {
   management_policy_ = std::make_unique<ManagementPolicy>();
 }
 
+#if BUILDFLAG(ENABLE_PDF_VIEWER)
 namespace {
 
 std::unique_ptr<base::Value::Dict> ParseManifest(
@@ -103,6 +104,7 @@ std::unique_ptr<base::Value::Dict> ParseManifest(
 }
 
 }  // namespace
+#endif  // if BUILDFLAG(ENABLE_PDF_VIEWER)
 
 void ElectronExtensionSystem::LoadComponentExtensions() {
 #if BUILDFLAG(ENABLE_PDF_VIEWER)


### PR DESCRIPTION
#### Description of Change

Fix a FTBFS when the PDF viewer is enabled.

This was introduced by #44843 but it's kind of a good thing? This function has always been unused when the PDF viewer is disabled; but thanks to 44843, the compiler now has enough information to warn us about it & error out.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed build failure when the PDF viewer is disabled.