### PR TITLE
docs: update security scoped bookmarks info

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -360,7 +360,7 @@ On Windows the options are more limited, due to the Win32 APIs used:
 
 ## Bookmarks array
 
-`showOpenDialog`, `showOpenDialogSync`, `showSaveDialog`, and `showSaveDialogSync` will return a `bookmarks` array.
+`showOpenDialog` and `showSaveDialog` resolve to an object with a `bookmarks` field. This field is an array of Base64 encoded strings that contain the [security scoped bookmark](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) data for the saved file. The `securityScopedBookmarks` option must be enabled for this to be present.
 
 | Build Type | securityScopedBookmarks boolean | Return Type | Return Value                   |
 |------------|---------------------------------|:-----------:|--------------------------------|


### PR DESCRIPTION
#### Description of Change

The docs for [Security Scoped Bookmark](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) states that `showOpenDialog`, `showOpenDialogSync`, `showSaveDialog`, and `showSaveDialogSync` all support returning this data, when it is only the async methods that do.

This PR updates that description to only list the supported methods and provides more information about the data, copied from the parameter/return descriptions above.

Fixes #44889 

#### Release Notes

Notes: None
