### PR TITLE
fix: context-menu emitted twice

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -371,6 +371,9 @@ namespace electron::api {
 
 namespace {
 
+// Global toggle for disabling draggable regions checks.
+bool g_disable_draggable_regions = false;
+
 constexpr std::string_view CursorTypeToString(
     ui::mojom::CursorType cursor_type) {
   switch (cursor_type) {
@@ -2068,6 +2071,10 @@ void WebContents::DraggableRegionsChanged(
   }
 
   draggable_region_ = DraggableRegionsToSkRegion(regions);
+}
+
+SkRegion* WebContents::draggable_region() {
+  return g_disable_draggable_regions ? nullptr : draggable_region_.get();
 }
 
 void WebContents::DidStartNavigation(
@@ -4611,6 +4618,11 @@ std::list<WebContents*> WebContents::GetWebContentsList() {
     list.push_back(iter.GetCurrentValue());
   }
   return list;
+}
+
+// static
+void WebContents::SetDisableDraggableRegions(bool disable) {
+  g_disable_draggable_regions = disable;
 }
 
 // static

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -151,6 +151,10 @@ class WebContents final : public ExclusiveAccessContext,
   static WebContents* FromID(int32_t id);
   static std::list<WebContents*> GetWebContentsList();
 
+  // Whether to disable draggable regions globally. This can be used to allow
+  // events to skip client region hit tests.
+  static void SetDisableDraggableRegions(bool disable);
+
   // Get the V8 wrapper of the |web_contents|, or create one if not existed.
   //
   // The lifetime of |web_contents| is NOT managed by this class, and the type
@@ -485,13 +489,7 @@ class WebContents final : public ExclusiveAccessContext,
 
   void PDFReadyToPrint();
 
-  SkRegion* draggable_region() {
-    return force_non_draggable_ ? nullptr : draggable_region_.get();
-  }
-
-  void SetForceNonDraggable(bool force_non_draggable) {
-    force_non_draggable_ = force_non_draggable;
-  }
+  SkRegion* draggable_region();
 
   // disable copy
   WebContents(const WebContents&) = delete;
@@ -890,8 +888,6 @@ class WebContents final : public ExclusiveAccessContext,
   raw_ptr<content::RenderFrameHost> fullscreen_frame_ = nullptr;
 
   std::unique_ptr<SkRegion> draggable_region_;
-
-  bool force_non_draggable_ = false;
 
   base::WeakPtrFactory<WebContents> weak_factory_{this};
 };

--- a/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.h
+++ b/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.h
@@ -49,8 +49,6 @@ using electron::InspectableWebContentsViewMac;
 - (void)setTitle:(NSString*)title;
 - (NSString*)getTitle;
 
-- (void)setForceNonDraggable:(BOOL)forceNonDraggable;
-
 @end
 
 #endif  // ELECTRON_SHELL_BROWSER_UI_COCOA_ELECTRON_INSPECTABLE_WEB_CONTENTS_VIEW_H_

--- a/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.h
+++ b/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.h
@@ -49,7 +49,7 @@ using electron::InspectableWebContentsViewMac;
 - (void)setTitle:(NSString*)title;
 - (NSString*)getTitle;
 
-- (void)redispatchContextMenuEvent:(base::apple::OwnedNSEvent)theEvent;
+- (void)setForceNonDraggable:(BOOL)forceNonDraggable;
 
 @end
 

--- a/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.mm
+++ b/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.mm
@@ -298,26 +298,13 @@
     [self notifyDevToolsFocused];
 }
 
-- (void)redispatchContextMenuEvent:(base::apple::OwnedNSEvent)event {
-  DCHECK(event.Get().type == NSEventTypeRightMouseDown ||
-         (event.Get().type == NSEventTypeLeftMouseDown &&
-          (event.Get().modifierFlags & NSEventModifierFlagControl)));
+- (void)setForceNonDraggable:(BOOL)forceNonDraggable {
   content::WebContents* contents =
       inspectableWebContentsView_->inspectable_web_contents()->GetWebContents();
   electron::api::WebContents* api_contents =
       electron::api::WebContents::From(contents);
   if (api_contents) {
-    // Temporarily pretend that the WebContents is fully non-draggable while we
-    // re-send the mouse event. This allows the re-dispatched event to "land"
-    // on the WebContents, instead of "falling through" back to the window.
-    auto* rwhv = contents->GetRenderWidgetHostView();
-    if (rwhv) {
-      api_contents->SetForceNonDraggable(true);
-      BaseView* contentsView =
-          (BaseView*)rwhv->GetNativeView().GetNativeNSView();
-      [contentsView mouseEvent:event.Get()];
-      api_contents->SetForceNonDraggable(false);
-    }
+    api_contents->SetForceNonDraggable(forceNonDraggable);
   }
 }
 

--- a/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.mm
+++ b/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.mm
@@ -298,16 +298,6 @@
     [self notifyDevToolsFocused];
 }
 
-- (void)setForceNonDraggable:(BOOL)forceNonDraggable {
-  content::WebContents* contents =
-      inspectableWebContentsView_->inspectable_web_contents()->GetWebContents();
-  electron::api::WebContents* api_contents =
-      electron::api::WebContents::From(contents);
-  if (api_contents) {
-    api_contents->SetForceNonDraggable(forceNonDraggable);
-  }
-}
-
 #pragma mark - NSWindowDelegate
 
 - (void)windowWillClose:(NSNotification*)notification {

--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -6,6 +6,7 @@
 
 #include "base/strings/sys_string_conversions.h"
 #include "electron/mas.h"
+#include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/native_window_mac.h"
 #include "shell/browser/ui/cocoa/delayed_native_view_host.h"
 #include "shell/browser/ui/cocoa/electron_inspectable_web_contents_view.h"
@@ -195,65 +196,21 @@ void SwizzleSwipeWithEvent(NSView* view, SEL swiz_selector) {
   // Draggable regions only respond to left-click dragging, but the system will
   // still suppress right-clicks in a draggable region. Temporarily disabling
   // draggable regions allows the underlying views to respond to right-click
-  // to potentially bring up a frame context menu. WebContentsView is now a
-  // sibling view of the NSWindow contentView, so we need to intercept the event
-  // here as NativeWidgetMacNSWindow won't forward it to the WebContentsView
-  // anymore.
+  // to potentially bring up a frame context menu.
   BOOL shouldDisableDraggable =
       (event.type == NSEventTypeRightMouseDown ||
        (event.type == NSEventTypeLeftMouseDown &&
         ([event modifierFlags] & NSEventModifierFlagControl)));
 
-  // Maybe disable draggable regions.
   if (shouldDisableDraggable) {
-    // We're looking for the NativeViewHost that contains the WebContentsView.
-    // There can be two possible NativeViewHosts - one containing the
-    // WebContentsView (present for BrowserWindows) and the one containing the
-    // VibrantView (present when vibrancy is set). We want the one containing
-    // the WebContentsView if it exists.
-    const auto& children = shell_->GetContentsView()->children();
-    const auto it = std::ranges::find_if(children, [&](views::View* child) {
-      if (std::strcmp(child->GetClassName(), "NativeViewHost") == 0) {
-        auto* nvh = static_cast<views::NativeViewHost*>(child);
-        return nvh->native_view().GetNativeNSView() != [self vibrantView];
-      }
-      return false;
-    });
-
-    if (it != children.end()) {
-      auto ns_view = static_cast<electron::DelayedNativeViewHost*>(*it)
-                         ->native_view()
-                         .GetNativeNSView();
-      if (ns_view) {
-        [static_cast<ElectronInspectableWebContentsView*>(ns_view)
-            setForceNonDraggable:true];
-      }
-    }
+    electron::api::WebContents::SetDisableDraggableRegions(true);
   }
 
   [super sendEvent:event];
 
-  // Maybe re-enable draggable regions.
   // Perform the same logic in case children have changed due to side effects.
   if (shouldDisableDraggable) {
-    const auto& children = shell_->GetContentsView()->children();
-    const auto it = std::ranges::find_if(children, [&](views::View* child) {
-      if (std::strcmp(child->GetClassName(), "NativeViewHost") == 0) {
-        auto* nvh = static_cast<views::NativeViewHost*>(child);
-        return nvh->native_view().GetNativeNSView() != [self vibrantView];
-      }
-      return false;
-    });
-
-    if (it != children.end()) {
-      auto ns_view = static_cast<electron::DelayedNativeViewHost*>(*it)
-                         ->native_view()
-                         .GetNativeNSView();
-      if (ns_view) {
-        [static_cast<ElectronInspectableWebContentsView*>(ns_view)
-            setForceNonDraggable:false];
-      }
-    }
+    electron::api::WebContents::SetDisableDraggableRegions(false);
   }
 }
 

--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -208,7 +208,6 @@ void SwizzleSwipeWithEvent(NSView* view, SEL swiz_selector) {
 
   [super sendEvent:event];
 
-  // Perform the same logic in case children have changed due to side effects.
   if (shouldDisableDraggable) {
     electron::api::WebContents::SetDisableDraggableRegions(false);
   }

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2739,7 +2739,6 @@ describe('webContents module', () => {
       let contextMenuEmitCount = 0;
 
       w.webContents.on('context-menu', () => {
-        console.error('context-menu event' + Date.now());
         contextMenuEmitCount++;
       });
 

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2731,6 +2731,27 @@ describe('webContents module', () => {
       expect(params.y).to.be.a('number');
     });
 
+    // Skipping due to lack of native click support.
+    it.skip('emits the correct number of times when right-clicked in page', async () => {
+      const w = new BrowserWindow({ show: true });
+      await w.loadFile(path.join(fixturesPath, 'pages', 'base-page.html'));
+
+      let contextMenuEmitCount = 0;
+
+      w.webContents.on('context-menu', () => {
+        console.error('context-menu event' + Date.now());
+        contextMenuEmitCount++;
+      });
+
+      // TODO(samuelmaddock): Perform native right-click. We've tried then
+      // dropped robotjs and nutjs so for now this is a manual test.
+
+      await once(w.webContents, 'context-menu');
+      await setTimeout(100);
+
+      expect(contextMenuEmitCount).to.equal(1);
+    });
+
     it('emits when right-clicked in page in a draggable region', async () => {
       const w = new BrowserWindow({ show: false });
       await w.loadFile(path.join(fixturesPath, 'pages', 'draggable-page.html'));


### PR DESCRIPTION
#### Description of Change

closes https://github.com/electron/electron/issues/44976

When a mouse event is signaled on `ElectronNSWindow`, it was being dispatched twice. Once from `redispatchContextMenuEvent` and once from `[super sendEvent:event]`.

https://github.com/electron/electron/blob/3bd5f14cee3ba62a654a37af76b92110e886630f/shell/browser/ui/cocoa/electron_ns_window.mm#L219-L230

`redispatchContextMenuEvent` works by temporarily disabling draggable regions, then dispatching the mouse event again on the specific WebContents. However, when the click won't pass a non-client (draggable region) hit test, it will be dispatched twice.

Instead of redispatching events, this fix proposes to globally disable draggable regions, allow the event to be processed as normally, then re-enable draggable regions. This effectively skips the draggable region check for right-clicks.

Tested using https://gist.github.com/samuelmaddock/8eefd9b741018120624eca9776f826bf

cc @codebytere 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed issue where 'contextmenu' event is emitted twice on macOS.
