### PR TITLE
chore: update vm module warning

### DIFF
--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -12,7 +12,7 @@ const Module = require('module') as NodeJS.ModuleInternal;
 const originalModuleLoad = Module._load;
 Module._load = function (request: string) {
   if (request === 'vm') {
-    console.warn('The vm module of Node.js is deprecated in the renderer process and will be removed.');
+    console.warn('The vm module of Node.js is unsupported in Electron\'s renderer process due to incompatibilities with the Blink rendering engine. Crashes are likely and avoiding the module is highly recommended.');
   }
   return originalModuleLoad.apply(this, arguments as any);
 };

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -12,7 +12,7 @@ const Module = require('module') as NodeJS.ModuleInternal;
 const originalModuleLoad = Module._load;
 Module._load = function (request: string) {
   if (request === 'vm') {
-    console.warn('The vm module of Node.js is unsupported in Electron\'s renderer process due to incompatibilities with the Blink rendering engine. Crashes are likely and avoiding the module is highly recommended.');
+    console.warn('The vm module of Node.js is unsupported in Electron\'s renderer process due to incompatibilities with the Blink rendering engine. Crashes are likely and avoiding the module is highly recommended. This module may be removed in a future release.');
   }
   return originalModuleLoad.apply(this, arguments as any);
 };


### PR DESCRIPTION
#### Description of Change

closes https://github.com/electron/electron/issues/31724

Update the vm module warning to strongly recommend avoiding its usage rather than a deprecation warning.

The alternative is to disallow the module's usage without some kind of `dangerouslyAllowVMModule` flag. I think a warning is fine though and involves less code for us to maintain and ship.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
