### PR TITLE
fix: add missing index arg in `navigationHistory.canGoToOffset`

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -514,9 +514,9 @@ WebContents.prototype.canGoForward = function () {
 };
 
 const canGoToOffsetDeprecated = deprecate.warnOnce('webContents.canGoToOffset', 'webContents.navigationHistory.canGoToOffset');
-WebContents.prototype.canGoToOffset = function () {
+WebContents.prototype.canGoToOffset = function (index: number) {
   canGoToOffsetDeprecated();
-  return this._canGoToOffset();
+  return this._canGoToOffset(index);
 };
 
 const clearHistoryDeprecated = deprecate.warnOnce('webContents.clearHistory', 'webContents.navigationHistory.clear');

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -93,7 +93,7 @@ declare namespace Electron {
     _historyLength(): number;
     _canGoBack(): boolean;
     _canGoForward(): boolean;
-    _canGoToOffset(): boolean;
+    _canGoToOffset(index: number): boolean;
     _goBack(): void;
     _goForward(): void;
     _goToOffset(index: number): void;


### PR DESCRIPTION
#### Description of Change
This PR:
- [x] Adds missing index arg for the deprecated version of `webContents.canGoToOffset`

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed issue with missing index arg for `webContents.canGoToOffset`
