### PR TITLE
feat: view.getVisible()

### DIFF
--- a/docs/api/view.md
+++ b/docs/api/view.md
@@ -106,6 +106,10 @@ Examples of valid `color` values:
 
 * `visible` boolean - If false, the view will be hidden from display.
 
+#### `view.getVisible()`
+
+Returns `boolean` - Whether the view is displayed.
+
 ### Instance Properties
 
 Objects created with `new View` have the following properties:

--- a/docs/api/view.md
+++ b/docs/api/view.md
@@ -108,7 +108,9 @@ Examples of valid `color` values:
 
 #### `view.getVisible()`
 
-Returns `boolean` - Whether the view is displayed.
+Returns `boolean` - Whether the view should be drawn. Note that this is
+different from whether the view is visible on screen—it may still be obscured
+or out of view.
 
 ### Instance Properties
 

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -387,6 +387,10 @@ void View::SetVisible(bool visible) {
   view_->SetVisible(visible);
 }
 
+bool View::GetVisible() const {
+  return view_ ? view_->GetVisible() : false;
+}
+
 void View::OnViewBoundsChanged(views::View* observed_view) {
   ApplyBorderRadius();
   Emit("bounds-changed");
@@ -445,7 +449,8 @@ void View::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setBackgroundColor", &View::SetBackgroundColor)
       .SetMethod("setBorderRadius", &View::SetBorderRadius)
       .SetMethod("setLayout", &View::SetLayout)
-      .SetMethod("setVisible", &View::SetVisible);
+      .SetMethod("setVisible", &View::SetVisible)
+      .SetMethod("getVisible", &View::GetVisible);
 }
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -45,6 +45,7 @@ class View : public gin_helper::EventEmitter<View>,
   void SetBackgroundColor(std::optional<WrappedSkColor> color);
   void SetBorderRadius(int radius);
   void SetVisible(bool visible);
+  bool GetVisible() const;
 
   // views::ViewObserver
   void OnViewBoundsChanged(views::View* observed_view) override;

--- a/spec/api-view-spec.ts
+++ b/spec/api-view-spec.ts
@@ -79,4 +79,17 @@ describe('View', () => {
     v.setBorderRadius(9999999);
     v.setBorderRadius(-9999999);
   });
+
+  describe('view.getVisible|setVisible', () => {
+    it('is visible by default', () => {
+      const v = new View();
+      expect(v.getVisible()).to.be.true();
+    });
+
+    it('can be set to not visible', () => {
+      const v = new View();
+      v.setVisible(false);
+      expect(v.getVisible()).to.be.false();
+    });
+  });
 });


### PR DESCRIPTION
#### Description of Change

resolves https://github.com/electron/electron/issues/44961

Adds method to get visibility state of Views.

##### Todo

- [x] Update description to be more clear that this property determines whether the view should be rendered and not that is visible on screen.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `view.getVisible()`
