### PR TITLE
fix: custom spell-checker stuck in infinite loop

### DIFF
--- a/shell/renderer/api/electron_api_spell_check_client.cc
+++ b/shell/renderer/api/electron_api_spell_check_client.cc
@@ -32,7 +32,9 @@ namespace {
 
 bool HasWordCharacters(const std::u16string& text, size_t index) {
   base_icu::UChar32 code;
-  while (base::ReadUnicodeCharacter(text.c_str(), text.size(), &index, &code)) {
+  while (index < text.size() &&
+         base::ReadUnicodeCharacter(text.c_str(), text.size(), &index, &code)) {
+    ++index;
     UErrorCode error = U_ZERO_ERROR;
     if (uscript_getScript(code, &error) != USCRIPT_COMMON)
       return true;


### PR DESCRIPTION
#### Description of Change

As reported in #44336, commit 478defb15c036eb749617ad65633b4eecd02cc66 now causes electron to freezes when using a custom spell checker.

`ReadUnicodeCharacter` updates index to the last character read, and not after it. We need to manually increment it to move to the next character.

It also doesn't validate that the index is valid, so we need to check that index is within bounds.

Refs: #44336


#### Checklist

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: Fix custom spell checker getting stuck in infinite loop using 100% CPU.