### PR TITLE
fix: remove extra "

### DIFF
--- a/docs/fiddles/features/web-bluetooth/index.html
+++ b/docs/fiddles/features/web-bluetooth/index.html
@@ -11,7 +11,7 @@
     <button id="clickme">Test Bluetooth</button>
     <button id="cancel">Cancel Bluetooth Request</button>
 
-    <p>Currently selected bluetooth device: <strong id="device-name""></strong></p>
+    <p>Currently selected bluetooth device: <strong id="device-name"></strong></p>
 
     <script src="./renderer.js"></script>
   </body>


### PR DESCRIPTION
#### Description of Change

The extra " was removed.

![image](https://github.com/user-attachments/assets/bb4a1200-e372-4838-8ad4-fa1017b6ce01)

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
