### PR TITLE
fix: better prompt not supported message in window-setup.ts

### DIFF
--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -15,7 +15,7 @@ export const windowSetup = (isWebView: boolean, isHiddenPage: boolean) => {
 
   // But we do not support prompt().
   window.prompt = function () {
-    throw new Error('prompt() is and will not be supported.');
+    throw new Error('prompt() is not supported.');
   };
   if (contextIsolationEnabled) internalContextBridge.overrideGlobalValueFromIsolatedWorld(['prompt'], window.prompt);
 


### PR DESCRIPTION
The message should simply read "is not supported" or, alternatively, "is not, and will not, be supported", but not "is and will not be supported".

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
