### PR TITLE
build: update build tools to correct sha

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -11,7 +11,7 @@ runs:
         git config --global core.autocrlf false
         git config --global branch.autosetuprebase always
       fi
-      export BUILD_TOOLS_SHA=bf2a839205d569be99e0b23ede5d8a0d5041a777
+      export BUILD_TOOLS_SHA=8246e57791b0af4ae5975eb96f09855f9269b1cd
       npm i -g @electron/build-tools
       e auto-update disable
       if [ "$(expr substr $(uname -s) 1 10)" == "MSYS_NT-10" ]; then


### PR DESCRIPTION
#### Description of Change

- Followup to #44136.  That PR updated build tools to the SHA for https://github.com/electron/build-tools/pull/685, but it should instead point to the SHA of the merged commit, which is what this PR does.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
