### PR TITLE
fix: chrome.i18n unavailable in extension service workers

### DIFF
--- a/shell/common/extensions/api/_api_features.json
+++ b/shell/common/extensions/api/_api_features.json
@@ -24,20 +24,6 @@
   "action.setBadgeTextColor": {
     "channel": "stable"
   },
-  "tabs": {
-    "channel": "stable",
-    "extension_types": ["extension"],
-    "contexts": ["privileged_extension"]
-  },
-  "tabs.executeScript": {
-    "max_manifest_version": 2
-  },
-  "tabs.insertCSS": {
-    "max_manifest_version": 2
-  },
-  "tabs.removeCSS": {
-    "max_manifest_version": 2
-  },
   "extension": {
     "channel": "stable",
     "extension_types": ["extension"],
@@ -58,12 +44,6 @@
       "content_script"
     ],
     "max_manifest_version": 2
-  },
-  "i18n": {
-    "channel": "stable",
-    "extension_types": ["extension"],
-    "contexts": ["privileged_extension", "unprivileged_extension", "content_script"],
-    "disallow_for_service_workers": true
   },
   "mimeHandlerViewGuestInternal": {
     "internal": true,
@@ -93,5 +73,19 @@
     "channel": "trunk",
     "dependencies": ["permission:scripting"],
     "contexts": ["content_script"]
+  },
+  "tabs": {
+    "channel": "stable",
+    "extension_types": ["extension"],
+    "contexts": ["privileged_extension"]
+  },
+  "tabs.executeScript": {
+    "max_manifest_version": 2
+  },
+  "tabs.insertCSS": {
+    "max_manifest_version": 2
+  },
+  "tabs.removeCSS": {
+    "max_manifest_version": 2
   }
 }


### PR DESCRIPTION
#### Description of Change

The `chrome.i18n` API has moved into `//extensions`
https://chromium-review.googlesource.com/c/chromium/src/+/3362491

Our manifest was preventing it from being included in extension service workers. I also sorted the APIs alphabetically as that's how it's organized upstream.

cc @codebytere 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `chrome.i18n` extension API being unavailable in service workers.
