### PR TITLE
docs: Clarify menus use non-native styles

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -2,7 +2,10 @@
 
 ## Class: Menu
 
-> Create native application menus and context menus.
+> Create application menus and context menus.
+>
+> * Menus under Windows and Linux look visually similar to Chromium.
+> * Menus under macOS are native.
 
 Process: [Main](../glossary.md#main-process)
 


### PR DESCRIPTION
#### Description of Change

As confirmed in https://github.com/electron/electron/issues/42262#issuecomment-2544981851, at this time, Electron won't be taking steps to restore native menus since the Chrome Refresh 2023 removed them upstream. Electron's docs still refers to them as "native", however, it would be more accurate to imply they are inherited from Chromium.

More so for Windows/Linux, where Chromium inherits colours for the menu, but not the padding, fonts or spacing. macOS seems to be the only one that's native with menus looking identical to any other macOS application _(as observed in macOS 11)._

This will help provide clarity to Electron applications that they shouldn't assume Electron's API for menus are truly "native" for their users, which allows them to take steps to cover UI and accessibility needs.  For example, VS Code is waiting for "upstream" (Electron) for this one:

* https://github.com/microsoft/vscode/pull/229385#issuecomment-2482284132

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes

N/A
