### PR TITLE
test: reenable disabled GHA windows tests

### DIFF
--- a/spec/api-shell-spec.ts
+++ b/spec/api-shell-spec.ts
@@ -3,7 +3,7 @@ import { BrowserWindow, app } from 'electron/main';
 
 import { expect } from 'chai';
 
-import { exec } from 'node:child_process';
+import { execSync } from 'node:child_process';
 import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as http from 'node:http';
@@ -18,12 +18,12 @@ describe('shell module', () => {
     let envVars: Record<string, string | undefined> = {};
     let server: http.Server;
 
-    after(() => {
+    after(function () {
+      this.timeout(60000);
       if (process.env.CI && process.platform === 'win32') {
         // Edge may cause issues with visibility tests, so make sure it is closed after testing.
         const killEdge = 'Get-Process | Where Name -Like "msedge" | Stop-Process';
-        // Asynchronously call powershell to cleanup Edge so that it doesn't cause a test timeout.
-        exec(killEdge, { shell: 'powershell.exe' });
+        execSync(killEdge, { shell: 'powershell.exe' });
       }
     });
 

--- a/spec/api-shell-spec.ts
+++ b/spec/api-shell-spec.ts
@@ -3,6 +3,7 @@ import { BrowserWindow, app } from 'electron/main';
 
 import { expect } from 'chai';
 
+import { exec } from 'node:child_process';
 import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as http from 'node:http';
@@ -16,6 +17,15 @@ describe('shell module', () => {
   describe('shell.openExternal()', () => {
     let envVars: Record<string, string | undefined> = {};
     let server: http.Server;
+
+    after(() => {
+      if (process.env.CI && process.platform === 'win32') {
+        // Edge may cause issues with visibility tests, so make sure it is closed after testing.
+        const killEdge = 'Get-Process | Where Name -Like "msedge" | Stop-Process';
+        // Asynchronously call powershell to cleanup Edge so that it doesn't cause a test timeout.
+        exec(killEdge, { shell: 'powershell.exe' });
+      }
+    });
 
     beforeEach(function () {
       envVars = {

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -653,9 +653,7 @@ describe('chromium features', () => {
       expect(size).to.be.a('number');
     });
 
-    // TODO: Re-enable for windows on GitHub Actions,
-    // fullscreen tests seem to hang on GHA specifically
-    ifit(process.platform !== 'win32' || process.arch === 'arm64')('should lock the keyboard', async () => {
+    it('should lock the keyboard', async () => {
       const w = new BrowserWindow({ show: true });
       await w.loadFile(path.join(fixturesPath, 'pages', 'modal.html'));
 
@@ -2980,9 +2978,7 @@ describe('iframe using HTML fullscreen API while window is OS-fullscreened', () 
     server.close();
   });
 
-  // TODO: Re-enable for windows on GitHub Actions,
-  // fullscreen tests seem to hang on GHA specifically
-  ifit(process.platform !== 'darwin' && (process.platform !== 'win32' || process.arch === 'arm64'))('can fullscreen from out-of-process iframes (non-macOS)', async () => {
+  ifit(process.platform !== 'darwin')('can fullscreen from out-of-process iframes (non-macOS)', async () => {
     const fullscreenChange = once(ipcMain, 'fullscreenChange');
     const html =
       `<iframe style="width: 0" frameborder=0 src="${crossSiteUrl}" allowfullscreen></iframe>`;
@@ -3037,7 +3033,7 @@ describe('iframe using HTML fullscreen API while window is OS-fullscreened', () 
 
   // TODO: Re-enable for windows on GitHub Actions,
   // fullscreen tests seem to hang on GHA specifically
-  ifit(process.platform !== 'win32' || process.arch === 'arm64')('can fullscreen from in-process iframes', async () => {
+  it('can fullscreen from in-process iframes', async () => {
     if (process.platform === 'darwin') await once(w, 'enter-full-screen');
 
     const fullscreenChange = once(ipcMain, 'fullscreenChange');


### PR DESCRIPTION
#### Description of Change
- Followup to #44136.  In investigating test failures on the 32-x-y backport of #44136 in #45013, I discovered that Edge was taking up the whole screen as seen here: 
![screen-cap-1c3832382655f2d59700709f](https://github.com/user-attachments/assets/211cf1d6-2f4c-42f6-98d0-1e91ddb08b79)
This is due to the shell.openExternal tests opening up Edge, so I added a cleanup step to that spec to close Edge if it is open.  After doing that, all of the disabled tests now work.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
