### PR TITLE
ci: enable debugging mode when building electron_dist_zip

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -69,7 +69,7 @@ runs:
       shell: bash
       run: |
         cd src
-        e build --target electron:electron_dist_zip -j $NUMBER_OF_NINJA_PROCESSES
+        e build --target electron:electron_dist_zip -j $NUMBER_OF_NINJA_PROCESSES -d explain
         if [ "${{ inputs.is-asan }}" != "true" ]; then
           target_os=${{ inputs.target-platform == 'macos' && 'mac' || inputs.target-platform }}
           if [ "${{ inputs.artifact-platform }}" = "mas" ]; then


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

We're seeing an intermittent issue where the `electron` binary for Linux arm64 isn't seeming to be stripped properly. I've noticed that in these cases there's output which shows that the `electron` binary is being relinked while building the `electron:electron_dist_zip` target, which is why the stripping that occurred earlier is reverted.

It's not clear why the relinking is occurring (seems that `libinstrumentation_probes` is a commonality), so enable the `-d explain` debugging mode so the next time it happens we have extra output explaining why the relinking is happening.

We see this in nightly releases, so not going to backport it since it's just for debugging purposes.

```
2024-12-11T19:32:20.7318370Z Running "autoninja -j 300 electron:electron_dist_zip" in /__w/electron/electron/src/out/Default
2024-12-11T19:32:20.9405774Z Proxy started successfully.
2024-12-11T19:32:32.2069616Z [1/7] COPY gen/components/resources/about_credits.html LICENSES.chromium.html
2024-12-11T19:32:32.2073165Z [2/7] COPY ../../electron/LICENSE LICENSE
2024-12-11T19:32:32.2206919Z [3/7] ACTION //electron:electron_version_file(//build/toolchain/linux:clang_arm)
2024-12-11T19:32:55.2710588Z [4/7] CXX obj/third_party/blink/renderer/core/probe/instrumentation_probes/core_probes_impl.o
2024-12-11T19:32:55.2742951Z [5/7] AR obj/third_party/blink/renderer/core/probe/libinstrumentation_probes.a
2024-12-11T19:33:49.3401364Z [6/7] LINK ./electron
2024-12-11T19:34:22.3013271Z [7/7] ACTION //electron:electron_dist_zip(//build/toolchain/linux:clang_arm)
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
