### PR TITLE
Fix git tag version

### DIFF
--- a/script/get-git-version.py
+++ b/script/get-git-version.py
@@ -24,7 +24,8 @@ try:
       cwd=os.path.abspath(os.path.join(os.path.dirname(__file__), '..')),
       stderr=subprocess.PIPE,
       universal_newlines=True)
-  version = output.strip().replace('v', '')
+  # only remove the 'v' prefix from the tag name.
+  version = output.strip().replace('v', '', 1)
   print(version)
 except Exception:
   # When there is error we print a null version string instead of throwing an


### PR DESCRIPTION
#### Description of Change

In the old version of get-version.js, it replaces the leading 'v', i.e. |output.stdout.toString().trim().replace(/^v/g, '')|. However, in the new version of get-git-version.py, it directly replaces all 'v'. Obviously, it does not conform to the original semantics. Although it will not affect the existing electron version calculation, it may affect other developers' customized git-tag-version, such as v0.0.0-dev.xxx, which will lose the 'v' of dev.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: no-notes