### PR TITLE
refactor: remove redundant CreateExtensionsClient()

### DIFF
--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -239,7 +239,7 @@ void RendererClientBase::RenderThreadStarted() {
                                                      true);
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  extensions_client_ = CreateExtensionsClient();
+  extensions_client_ = std::make_unique<ElectronExtensionsClient>();
   extensions::ExtensionsClient::Set(extensions_client_.get());
 
   extensions_renderer_client_ =
@@ -564,13 +564,6 @@ v8::Local<v8::Context> RendererClientBase::GetContext(
   else
     return frame->MainWorldScriptContext();
 }
-
-#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-std::unique_ptr<extensions::ExtensionsClient>
-RendererClientBase::CreateExtensionsClient() {
-  return std::make_unique<ElectronExtensionsClient>();
-}
-#endif
 
 bool RendererClientBase::IsWebViewFrame(
     v8::Local<v8::Context> context,

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -239,7 +239,7 @@ void RendererClientBase::RenderThreadStarted() {
                                                      true);
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  extensions_client_.reset(CreateExtensionsClient());
+  extensions_client_ = CreateExtensionsClient();
   extensions::ExtensionsClient::Set(extensions_client_.get());
 
   extensions_renderer_client_ =
@@ -566,8 +566,9 @@ v8::Local<v8::Context> RendererClientBase::GetContext(
 }
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-extensions::ExtensionsClient* RendererClientBase::CreateExtensionsClient() {
-  return new ElectronExtensionsClient;
+std::unique_ptr<extensions::ExtensionsClient>
+RendererClientBase::CreateExtensionsClient() {
+  return std::make_unique<ElectronExtensionsClient>();
 }
 #endif
 

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -143,7 +143,8 @@ class RendererClientBase : public content::ContentRendererClient
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   // app_shell embedders may need custom extensions client interfaces.
   // This class takes ownership of the returned object.
-  virtual extensions::ExtensionsClient* CreateExtensionsClient();
+  virtual std::unique_ptr<extensions::ExtensionsClient>
+  CreateExtensionsClient();
 #endif
 
  private:

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -139,14 +139,6 @@ class RendererClientBase : public content::ContentRendererClient
                       bool was_created_by_renderer,
                       const url::Origin* outermost_origin) override;
 
- protected:
-#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  // app_shell embedders may need custom extensions client interfaces.
-  // This class takes ownership of the returned object.
-  virtual std::unique_ptr<extensions::ExtensionsClient>
-  CreateExtensionsClient();
-#endif
-
  private:
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   std::unique_ptr<extensions::ExtensionsClient> extensions_client_;


### PR DESCRIPTION
#### Description of Change

A quick small cleanup as I'm dusting off my keyboard from the holiday break :)

Xref: https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md#object-ownership-and-calling-conventions

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none