### PR TITLE
perf: cache whether or not ELECTRON_DEBUG_NOTIFICATIONS env var is set

### DIFF
--- a/shell/browser/notifications/mac/cocoa_notification.mm
+++ b/shell/browser/notifications/mac/cocoa_notification.mm
@@ -44,7 +44,7 @@ void CocoaNotification::Show(const NotificationOptions& options) {
   [notification_ setInformativeText:base::SysUTF16ToNSString(options.msg)];
   [notification_ setIdentifier:identifier];
 
-  if (getenv("ELECTRON_DEBUG_NOTIFICATIONS")) {
+  if (electron::debug_notifications) {
     LOG(INFO) << "Notification created (" << [identifier UTF8String] << ")";
   }
 
@@ -170,7 +170,7 @@ void CocoaNotification::NotificationDismissed() {
 }
 
 void CocoaNotification::LogAction(const char* action) {
-  if (getenv("ELECTRON_DEBUG_NOTIFICATIONS") && notification_) {
+  if (electron::debug_notifications && notification_) {
     NSString* identifier = [notification_ valueForKey:@"identifier"];
     DCHECK(identifier);
     LOG(INFO) << "Notification " << action << " (" << [identifier UTF8String]

--- a/shell/browser/notifications/mac/notification_center_delegate.mm
+++ b/shell/browser/notifications/mac/notification_center_delegate.mm
@@ -39,7 +39,7 @@
        didActivateNotification:(NSUserNotification*)notif {
   auto* notification = presenter_->GetNotification(notif);
 
-  if (getenv("ELECTRON_DEBUG_NOTIFICATIONS")) {
+  if (electron::debug_notifications) {
     LOG(INFO) << "Notification activated (" << [notif.identifier UTF8String]
               << ")";
   }

--- a/shell/browser/notifications/mac/notification_presenter_mac.mm
+++ b/shell/browser/notifications/mac/notification_presenter_mac.mm
@@ -30,7 +30,7 @@ CocoaNotification* NotificationPresenterMac::GetNotification(
       return native_notification;
   }
 
-  if (getenv("ELECTRON_DEBUG_NOTIFICATIONS")) {
+  if (electron::debug_notifications) {
     LOG(INFO) << "Could not find notification for "
               << [ns_notification.identifier UTF8String];
   }

--- a/shell/browser/notifications/notification.cc
+++ b/shell/browser/notifications/notification.cc
@@ -4,10 +4,14 @@
 
 #include "shell/browser/notifications/notification.h"
 
+#include "base/environment.h"
 #include "shell/browser/notifications/notification_delegate.h"
 #include "shell/browser/notifications/notification_presenter.h"
 
 namespace electron {
+
+const bool debug_notifications =
+    base::Environment::Create()->HasVar("ELECTRON_DEBUG_NOTIFICATIONS");
 
 NotificationOptions::NotificationOptions() = default;
 NotificationOptions::~NotificationOptions() = default;

--- a/shell/browser/notifications/notification.h
+++ b/shell/browser/notifications/notification.h
@@ -15,6 +15,8 @@
 
 namespace electron {
 
+extern const bool debug_notifications;
+
 class NotificationDelegate;
 class NotificationPresenter;
 

--- a/shell/browser/notifications/win/notification_presenter_win.cc
+++ b/shell/browser/notifications/win/notification_presenter_win.cc
@@ -10,7 +10,6 @@
 #include <string>
 #include <vector>
 
-#include "base/environment.h"
 #include "base/files/file_util.h"
 #include "base/hash/md5.h"
 #include "base/logging.h"

--- a/shell/browser/notifications/win/notification_presenter_win.cc
+++ b/shell/browser/notifications/win/notification_presenter_win.cc
@@ -27,10 +27,6 @@ namespace electron {
 
 namespace {
 
-bool IsDebuggingNotifications() {
-  return base::Environment::Create()->HasVar("ELECTRON_DEBUG_NOTIFICATIONS");
-}
-
 bool SaveIconToPath(const SkBitmap& bitmap, const base::FilePath& path) {
   std::optional<std::vector<uint8_t>> png_data =
       gfx::PNGCodec::EncodeBGRASkBitmap(bitmap, false);
@@ -50,7 +46,7 @@ std::unique_ptr<NotificationPresenter> NotificationPresenter::Create() {
   if (!presenter->Init())
     return {};
 
-  if (IsDebuggingNotifications())
+  if (electron::debug_notifications)
     LOG(INFO) << "Successfully created Windows notifications presenter";
 
   return presenter;

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -66,7 +66,7 @@ namespace {
 constexpr wchar_t kGroup[] = L"Notifications";
 
 void DebugLog(std::string_view log_msg) {
-  if (base::Environment::Create()->HasVar("ELECTRON_DEBUG_NOTIFICATIONS"))
+  if (electron::debug_notifications)
     LOG(INFO) << log_msg;
 }
 

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -13,7 +13,6 @@
 #include <shlobj.h>
 #include <wrl\wrappers\corewrappers.h>
 
-#include "base/environment.h"
 #include "base/hash/hash.h"
 #include "base/logging.h"
 #include "base/strings/strcat.h"


### PR DESCRIPTION
#### Description of Change

A small refactor to cache whether or not the `ELECTRON_DEBUG_NOTIFICATIONS` environment variable is set, instead of re-querying it every time.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none