### PR TITLE
chore: cherry-pick 4 changes from 4-M131

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -142,3 +142,5 @@ cherry-pick-923797bac925.patch
 cherry-pick-e699ac35ac6c.patch
 ui_add_missing_shortcut_text_for_vkey_command_on_linux.patch
 wayland_support_outgoing_dnd_sessions_with_no_offered_mime_types.patch
+cherry-pick-3a6ff45cc3f4.patch
+cherry-pick-a51e7ebb7663.patch

--- a/patches/chromium/cherry-pick-3a6ff45cc3f4.patch
+++ b/patches/chromium/cherry-pick-3a6ff45cc3f4.patch
@@ -1,0 +1,52 @@
+From 3a6ff45cc3f48a359772f81c512c512b4f2d2643 Mon Sep 17 00:00:00 2001
+From: Stefan Zager <szager@chromium.org>
+Date: Sat, 14 Dec 2024 11:06:00 -0800
+Subject: [PATCH] [M130] Prevent ImageData from being reclaimed while in use
+
+Cherry-picked from:
+  https://chromium-review.googlesource.com/c/chromium/src/+/5990752
+
+Bug: chromium:368222741
+Change-Id: If830b19287fd7c4aa07137044f23a14f8ce6912d
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6093379
+Reviewed-by: Prudhvikumar Bommana <pbommana@google.com>
+Owners-Override: Prudhvikumar Bommana <pbommana@google.com>
+Commit-Queue: Prudhvikumar Bommana <pbommana@google.com>
+Cr-Commit-Position: refs/branch-heads/6723@{#2713}
+Cr-Branched-From: 985f2961df230630f9cbd75bd6fe463009855a11-refs/heads/main@{#1356013}
+---
+
+diff --git a/cc/tiles/gpu_image_decode_cache.cc b/cc/tiles/gpu_image_decode_cache.cc
+index df1d24b..39fa3ff 100644
+--- a/cc/tiles/gpu_image_decode_cache.cc
++++ b/cc/tiles/gpu_image_decode_cache.cc
+@@ -2401,6 +2401,9 @@
+ 
+   image_data->decode.ResetData();
+ 
++  // Prevent image_data from being deleted while lock is not held.
++  scoped_refptr<ImageData> image_data_holder(image_data);
++
+   // Decode the image into `aux_image_data` while the lock is not held.
+   DecodedAuxImageData aux_image_data[kAuxImageCount];
+   {
+@@ -2728,6 +2731,9 @@
+   sk_sp<SkImage> uploaded_v_image =
+       image_data->decode.image(2, AuxImage::kDefault);
+ 
++  // Prevent image_data from being deleted while lock is not held.
++  scoped_refptr<ImageData> image_data_holder(image_data);
++
+   // For kGpu, we upload and color convert (if necessary).
+   if (image_data->mode == DecodedDataMode::kGpu) {
+     DCHECK(!use_transfer_cache_);
+@@ -2815,6 +2821,9 @@
+   DCHECK(!use_transfer_cache_);
+   DCHECK(!image_data->info.yuva.has_value());
+ 
++  // Prevent image_data from being deleted while lock is not held.
++  scoped_refptr<ImageData> image_data_holder(image_data);
++
+   // RGBX decoding is below.
+   // For kGpu, we upload and color convert (if necessary).
+   if (image_data->mode == DecodedDataMode::kGpu) {

--- a/patches/chromium/cherry-pick-a51e7ebb7663.patch
+++ b/patches/chromium/cherry-pick-a51e7ebb7663.patch
@@ -1,0 +1,184 @@
+From a51e7ebb7663b40ed070e91669f69c64fb9179d9 Mon Sep 17 00:00:00 2001
+From: Guido Urdaneta <guidou@chromium.org>
+Date: Wed, 18 Dec 2024 15:21:59 -0800
+Subject: [PATCH] [M126-LTS][VideoCaptureManager] Replace raw pointers with scoped_refptr
+
+VCM used VideoCaptureController raw pointers in a number of places,
+including as a field in VCM::CaptureDeviceStartRequest.
+
+This CL replaces the field and some other usages with a scoped_refptr
+to prevent dangling pointers.
+
+(cherry picked from commit 3524ce528548d1d743a6aa6e339ecb5a186c22bc)
+
+Bug: 382135228
+Change-Id: I1bd5f95bdf57631227034beb8bb076f258606378
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6088073
+Commit-Queue: Guido Urdaneta <guidou@chromium.org>
+Reviewed-by: Dale Curtis <dalecurtis@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1396301}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6099792
+Reviewed-by: Guido Urdaneta <guidou@chromium.org>
+Commit-Queue: Gyuyoung Kim (xWF) <qkim@google.com>
+Cr-Commit-Position: refs/branch-heads/6478@{#2009}
+Cr-Branched-From: e6143acc03189c5e52959545b110d6d17ecd5286-refs/heads/main@{#1300313}
+---
+
+diff --git a/content/browser/renderer_host/media/video_capture_manager.cc b/content/browser/renderer_host/media/video_capture_manager.cc
+index 3db89a04..11b6caf 100644
+--- a/content/browser/renderer_host/media/video_capture_manager.cc
++++ b/content/browser/renderer_host/media/video_capture_manager.cc
+@@ -15,6 +15,7 @@
+ #include "base/location.h"
+ #include "base/logging.h"
+ #include "base/memory/raw_ptr.h"
++#include "base/memory/scoped_refptr.h"
+ #include "base/metrics/histogram_functions.h"
+ #include "base/observer_list.h"
+ #include "base/ranges/algorithm.h"
+@@ -61,12 +62,14 @@
+ class VideoCaptureManager::CaptureDeviceStartRequest {
+  public:
+   CaptureDeviceStartRequest(
+-      VideoCaptureController* controller,
++      scoped_refptr<VideoCaptureController> controller,
+       const media::VideoCaptureSessionId& session_id,
+       const media::VideoCaptureParams& params,
+       mojo::PendingRemote<video_effects::mojom::VideoEffectsProcessor>
+           video_effects_processor);
+-  VideoCaptureController* controller() const { return controller_; }
++  scoped_refptr<VideoCaptureController> controller() const {
++    return controller_;
++  }
+   const base::UnguessableToken& session_id() const { return session_id_; }
+   media::VideoCaptureParams params() const { return params_; }
+ 
+@@ -76,7 +79,7 @@
+   }
+ 
+  private:
+-  const raw_ptr<VideoCaptureController> controller_;
++  const scoped_refptr<VideoCaptureController> controller_;
+   const base::UnguessableToken session_id_;
+   const media::VideoCaptureParams params_;
+   mojo::PendingRemote<video_effects::mojom::VideoEffectsProcessor>
+@@ -84,12 +87,12 @@
+ };
+ 
+ VideoCaptureManager::CaptureDeviceStartRequest::CaptureDeviceStartRequest(
+-    VideoCaptureController* controller,
++    scoped_refptr<VideoCaptureController> controller,
+     const media::VideoCaptureSessionId& session_id,
+     const media::VideoCaptureParams& params,
+     mojo::PendingRemote<video_effects::mojom::VideoEffectsProcessor>
+         video_effects_processor)
+-    : controller_(controller),
++    : controller_(std::move(controller)),
+       session_id_(session_id),
+       params_(params),
+       video_effects_processor_(std::move(video_effects_processor)) {}
+@@ -258,14 +261,15 @@
+ 
+ void VideoCaptureManager::QueueStartDevice(
+     const media::VideoCaptureSessionId& session_id,
+-    VideoCaptureController* controller,
++    scoped_refptr<VideoCaptureController> controller,
+     const media::VideoCaptureParams& params,
+     mojo::PendingRemote<video_effects::mojom::VideoEffectsProcessor>
+         video_effects_processor) {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+   DCHECK(lock_time_.is_null());
+-  device_start_request_queue_.push_back(CaptureDeviceStartRequest(
+-      controller, session_id, params, std::move(video_effects_processor)));
++  device_start_request_queue_.push_back(
++      CaptureDeviceStartRequest(std::move(controller), session_id, params,
++                                std::move(video_effects_processor)));
+   if (device_start_request_queue_.size() == 1)
+     ProcessDeviceStartRequestQueue();
+ }
+@@ -311,7 +315,8 @@
+   if (request == device_start_request_queue_.end())
+     return;
+ 
+-  VideoCaptureController* const controller = request->controller();
++  scoped_refptr<VideoCaptureController> const controller =
++      request->controller();
+ 
+   EmitLogMessage("VideoCaptureManager::ProcessDeviceStartRequestQueue", 3);
+   // The unit test VideoCaptureManagerTest.OpenNotExisting requires us to fail
+@@ -329,7 +334,7 @@
+         GetDeviceInfoById(controller->device_id());
+     if (!device_info) {
+       OnDeviceLaunchFailed(
+-          controller,
++          controller.get(),
+           media::VideoCaptureError::
+               kVideoCaptureManagerProcessDeviceStartQueueDeviceInfoNotFound);
+       return;
+@@ -350,7 +355,7 @@
+       base::BindOnce([](scoped_refptr<VideoCaptureManager>,
+                         scoped_refptr<VideoCaptureController>) {},
+                      scoped_refptr<VideoCaptureManager>(this),
+-                     GetControllerSharedRef(controller)),
++                     std::move(controller)),
+       request->TakeVideoEffectsProcessor());
+ }
+ 
+@@ -434,7 +439,7 @@
+     EmitLogMessage(string_stream.str(), 1);
+   }
+ 
+-  VideoCaptureController* controller =
++  scoped_refptr<VideoCaptureController> controller =
+       GetOrCreateController(session_id, params);
+   if (!controller) {
+     std::move(done_cb).Run(nullptr);
+@@ -908,7 +913,8 @@
+   return nullptr;
+ }
+ 
+-VideoCaptureController* VideoCaptureManager::GetOrCreateController(
++scoped_refptr<VideoCaptureController>
++VideoCaptureManager::GetOrCreateController(
+     const media::VideoCaptureSessionId& capture_session_id,
+     const media::VideoCaptureParams& params) {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+@@ -930,10 +936,12 @@
+     return existing_device;
+   }
+ 
+-  VideoCaptureController* new_controller = new VideoCaptureController(
+-      device_info.id, device_info.type, params,
+-      video_capture_provider_->CreateDeviceLauncher(), emit_log_message_cb_);
+-  controllers_.emplace_back(new_controller);
++  scoped_refptr<VideoCaptureController> new_controller =
++      base::MakeRefCounted<VideoCaptureController>(
++          device_info.id, device_info.type, params,
++          video_capture_provider_->CreateDeviceLauncher(),
++          emit_log_message_cb_);
++  controllers_.push_back(new_controller);
+   return new_controller;
+ }
+ 
+diff --git a/content/browser/renderer_host/media/video_capture_manager.h b/content/browser/renderer_host/media/video_capture_manager.h
+index a93c6bb..b88052a4 100644
+--- a/content/browser/renderer_host/media/video_capture_manager.h
++++ b/content/browser/renderer_host/media/video_capture_manager.h
+@@ -297,7 +297,7 @@
+   // Finds a VideoCaptureController for the indicated |capture_session_id|,
+   // creating a fresh one if necessary. Returns nullptr if said
+   // |capture_session_id| is invalid.
+-  VideoCaptureController* GetOrCreateController(
++  scoped_refptr<VideoCaptureController> GetOrCreateController(
+       const media::VideoCaptureSessionId& capture_session_id,
+       const media::VideoCaptureParams& params);
+ 
+@@ -309,7 +309,7 @@
+   // another request pending start.
+   void QueueStartDevice(
+       const media::VideoCaptureSessionId& session_id,
+-      VideoCaptureController* controller,
++      scoped_refptr<VideoCaptureController> controller,
+       const media::VideoCaptureParams& params,
+       mojo::PendingRemote<video_effects::mojom::VideoEffectsProcessor>
+           video_effects_processor);

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -7,3 +7,5 @@ merged_wasm_do_not_inline_wrappers_with_ref_extern_parameter.patch
 cherry-pick-153d4e84e5d1.patch
 cherry-pick-d9893f4856af.patch
 merged_liftoff_fix_clobbered_scratch_register.patch
+cherry-pick-aad648bd2af9.patch
+cherry-pick-cb0d9e1d7b88.patch

--- a/patches/v8/cherry-pick-aad648bd2af9.patch
+++ b/patches/v8/cherry-pick-aad648bd2af9.patch
@@ -1,0 +1,95 @@
+From aad648bd2af9815d0c48eeb78cbf3d8e6471d094 Mon Sep 17 00:00:00 2001
+From: Darius Mercadier <dmercadier@chromium.org>
+Date: Thu, 05 Dec 2024 16:03:33 +0100
+Subject: [PATCH] Merged: [maglev] Avoid retagging loop phi backedges too early
+
+When we decide that a loop phi should remain tagged, we call
+EnsurePhiInputsTagged to ensures that it only has tagged inputs, which
+calls EnsurePhiTagged, which might cause retagging of any untagged
+phi it has as input.
+
+In order to avoid retagging multiple times the same Phi, we have a
+SnaphotTable (`phi_taggings_`), which records existing tagging in the
+predecessors, and in which EnsurePhiTagged looks to avoid creating
+new retagging nodes. For loop phis, the backedge predecessor won't
+have an entry yet in this SnapshotTable (since we only visit loops
+once, this has to be the first time we visit the header and thus
+we can't have already visited the backedge block), and we should
+thus not call EnsurePhiTagged on the backedge.
+
+Note that the backedge input will anyways be properly tagged when
+FixLoopPhisBackedge is later called from the JumpLoop backedge.
+
+Fixed: chromium:382190919
+(cherry picked from commit e4ecfc909687511aeb20b88ce6ae2a7a1a80afe5)
+
+Change-Id: Ib24f311cb443eabe278f537c00bbc3274bf82415
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6084686
+Auto-Submit: Olivier Flückiger <olivf@chromium.org>
+Commit-Queue: Olivier Flückiger <olivf@chromium.org>
+Commit-Queue: Camillo Bruni <cbruni@chromium.org>
+Reviewed-by: Camillo Bruni <cbruni@chromium.org>
+Cr-Commit-Position: refs/branch-heads/13.0@{#41}
+Cr-Branched-From: 4be854bd71ea878a25b236a27afcecffa2e29360-refs/heads/13.0.245@{#1}
+Cr-Branched-From: 1f5183f7ad6cca21029fd60653d075730c644432-refs/heads/main@{#96103}
+---
+
+diff --git a/src/maglev/maglev-phi-representation-selector.cc b/src/maglev/maglev-phi-representation-selector.cc
+index c03974e..b4d913d 100644
+--- a/src/maglev/maglev-phi-representation-selector.cc
++++ b/src/maglev/maglev-phi-representation-selector.cc
+@@ -334,7 +334,8 @@
+   // should be tagged. We'll thus insert tagging operation on the untagged phi
+   // inputs of {phi}.
+ 
+-  for (int i = 0; i < phi->input_count(); i++) {
++  const int skip_backedge = phi->is_loop_phi() ? 1 : 0;
++  for (int i = 0; i < phi->input_count() - skip_backedge; i++) {
+     ValueNode* input = phi->input(i).node();
+     if (Phi* phi_input = input->TryCast<Phi>()) {
+       phi->change_input(i, EnsurePhiTagged(phi_input, phi->predecessor_at(i),
+diff --git a/test/mjsunit/maglev/regress-382190919.js b/test/mjsunit/maglev/regress-382190919.js
+new file mode 100644
+index 0000000..773f442
+--- /dev/null
++++ b/test/mjsunit/maglev/regress-382190919.js
+@@ -0,0 +1,39 @@
++// Copyright 2024 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// Flags: --allow-natives-syntax --no-maglev-loop-peeling
++
++function g() { }
++%NeverOptimizeFunction(g);
++
++function foo(b) {
++  let phi1 = 0;
++  for (let i = 0; i < 10; i++) {
++    phi1++; // Int32 use so that {phi1} gets untagged.
++  }
++
++  let phi2 = undefined; // Not untaggable.
++  let j = 0;
++
++  if (b) {
++    g(phi1); // Triggering retagging of {phi1}.
++  }
++
++  // Nothing between the `if` and the loop header, so that the loop header ends
++  // up having 2 incoming forward edges.
++
++  for (; j < 5; j++) {
++    phi2 = phi1; // New retagging of {phi1} since previous one is not available
++                 // in all predecessors.
++  }
++
++  return phi2;
++}
++
++%PrepareFunctionForOptimization(foo);
++foo(true);
++foo(false);
++
++%OptimizeMaglevOnNextCall(foo);
++foo(true);

--- a/patches/v8/cherry-pick-cb0d9e1d7b88.patch
+++ b/patches/v8/cherry-pick-cb0d9e1d7b88.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Olivier=20Fl=C3=BCckiger?= <olivf@chromium.org>
+Date: Fri, 13 Dec 2024 13:19:30 +0100
+Subject: Merged: [ic] fix Object.assign clearing object hashes
+
+The Object.assign fastcase should not override the hash of the to
+object.
+
+Bug: 383647255
+(cherry picked from commit 357d0dd4bc7f64eb81cdf49c5cf3699cf151909d)
+
+Change-Id: I2bbf10614d7997a396800cef33144875309010d9
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6097572
+Reviewed-by: Camillo Bruni <cbruni@chromium.org>
+Commit-Queue: Igor Sheludko <ishell@chromium.org>
+Cr-Commit-Position: refs/branch-heads/13.0@{#43}
+Cr-Branched-From: 4be854bd71ea878a25b236a27afcecffa2e29360-refs/heads/13.0.245@{#1}
+Cr-Branched-From: 1f5183f7ad6cca21029fd60653d075730c644432-refs/heads/main@{#96103}
+
+diff --git a/src/builtins/builtins-object-gen.cc b/src/builtins/builtins-object-gen.cc
+index d5f2cd711ab4b5774bfd62a88df874e929561402..4cda7f415fafa03f5a8f3e37ddbabb3029c64097 100644
+--- a/src/builtins/builtins-object-gen.cc
++++ b/src/builtins/builtins-object-gen.cc
+@@ -486,6 +486,13 @@ TF_BUILTIN(ObjectAssign, ObjectBuiltinsAssembler) {
+     GotoIfNot(TaggedEqual(LoadElements(CAST(to)), EmptyFixedArrayConstant()),
+               &slow_path);
+ 
++    // Ensure the properties field is not used to store a hash.
++    TNode<Object> properties = LoadJSReceiverPropertiesOrHash(to);
++    GotoIf(TaggedIsSmi(properties), &slow_path);
++    CSA_DCHECK(this,
++               Word32Or(TaggedEqual(properties, EmptyFixedArrayConstant()),
++                        IsPropertyArray(CAST(properties))));
++
+     // Check if our particular source->target combination is fast clonable.
+     // E.g., this ensures that we only have fast properties and in general that
+     // the binary layout is compatible for `FastCloneJSObject`.


### PR DESCRIPTION
<details>
<summary>electron/security#635 - aad648bd2af9 from v8</summary>
Merged: [maglev] Avoid retagging loop phi backedges too early

When we decide that a loop phi should remain tagged, we call
EnsurePhiInputsTagged to ensures that it only has tagged inputs, which
calls EnsurePhiTagged, which might cause retagging of any untagged
phi it has as input.

In order to avoid retagging multiple times the same Phi, we have a
SnaphotTable (`phi_taggings_`), which records existing tagging in the
predecessors, and in which EnsurePhiTagged looks to avoid creating
new retagging nodes. For loop phis, the backedge predecessor won't
have an entry yet in this SnapshotTable (since we only visit loops
once, this has to be the first time we visit the header and thus
we can't have already visited the backedge block), and we should
thus not call EnsurePhiTagged on the backedge.

Note that the backedge input will anyways be properly tagged when
FixLoopPhisBackedge is later called from the JumpLoop backedge.

Fixed: chromium:382190919
(cherry picked from commit e4ecfc909687511aeb20b88ce6ae2a7a1a80afe5)

Change-Id: Ib24f311cb443eabe278f537c00bbc3274bf82415
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6084686
Auto-Submit: Olivier Flückiger <olivf@chromium.org>
Commit-Queue: Olivier Flückiger <olivf@chromium.org>
Commit-Queue: Camillo Bruni <cbruni@chromium.org>
Reviewed-by: Camillo Bruni <cbruni@chromium.org>
Cr-Commit-Position: refs/branch-heads/13.0@{#41}
Cr-Branched-From: 4be854bd71ea878a25b236a27afcecffa2e29360-refs/heads/13.0.245@{#1}
Cr-Branched-From: 1f5183f7ad6cca21029fd60653d075730c644432-refs/heads/main@{#96103}
</details>

<details>
<summary>electron/security#636 - 3a6ff45cc3f4 from chromium</summary>
[M130] Prevent ImageData from being reclaimed while in use

Cherry-picked from:
  https://chromium-review.googlesource.com/c/chromium/src/+/5990752

Bug: chromium:368222741
Change-Id: If830b19287fd7c4aa07137044f23a14f8ce6912d
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6093379
Reviewed-by: Prudhvikumar Bommana <pbommana@google.com>
Owners-Override: Prudhvikumar Bommana <pbommana@google.com>
Commit-Queue: Prudhvikumar Bommana <pbommana@google.com>
Cr-Commit-Position: refs/branch-heads/6723@{#2713}
Cr-Branched-From: 985f2961df230630f9cbd75bd6fe463009855a11-refs/heads/main@{#1356013}
</details>

<details>
<summary>electron/security#633 - cb0d9e1d7b88 from v8</summary>
Merged: [ic] fix Object.assign clearing object hashes

The Object.assign fastcase should not override the hash of the to
object.

Bug: 383647255
(cherry picked from commit 357d0dd4bc7f64eb81cdf49c5cf3699cf151909d)

Change-Id: I2bbf10614d7997a396800cef33144875309010d9
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6097572
Reviewed-by: Camillo Bruni <cbruni@chromium.org>
Commit-Queue: Igor Sheludko <ishell@chromium.org>
Cr-Commit-Position: refs/branch-heads/13.0@{#43}
Cr-Branched-From: 4be854bd71ea878a25b236a27afcecffa2e29360-refs/heads/13.0.245@{#1}
Cr-Branched-From: 1f5183f7ad6cca21029fd60653d075730c644432-refs/heads/main@{#96103}
</details>

<details>
<summary>electron/security#632 - a51e7ebb7663 from chromium</summary>
[M126-LTS][VideoCaptureManager] Replace raw pointers with scoped_refptr

VCM used VideoCaptureController raw pointers in a number of places,
including as a field in VCM::CaptureDeviceStartRequest.

This CL replaces the field and some other usages with a scoped_refptr
to prevent dangling pointers.

(cherry picked from commit 3524ce528548d1d743a6aa6e339ecb5a186c22bc)

Bug: 382135228
Change-Id: I1bd5f95bdf57631227034beb8bb076f258606378
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6088073
Commit-Queue: Guido Urdaneta <guidou@chromium.org>
Reviewed-by: Dale Curtis <dalecurtis@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1396301}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6099792
Reviewed-by: Guido Urdaneta <guidou@chromium.org>
Commit-Queue: Gyuyoung Kim (xWF) <qkim@google.com>
Cr-Commit-Position: refs/branch-heads/6478@{#2009}
Cr-Branched-From: e6143acc03189c5e52959545b110d6d17ecd5286-refs/heads/main@{#1300313}
</details>

Notes:
* Security: backported fix for CVE-2024-12693.
* Security: backported fix for CVE-2024-12694.
* Security: backported fix for CVE-2024-12695.
* Security: backported fix for 382135228.