### PR TITLE
chore: cherry-pick 2 changes from 5-M131

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -137,3 +137,4 @@ refactor_unfilter_unresponsive_events.patch
 wayland_support_outgoing_dnd_sessions_with_no_offered_mime_types.patch
 support_bstr_pkey_appusermodel_id_in_windows_shortcuts.patch
 cherry-pick-3dc17c461b12.patch
+cherry-pick-f3300abe2fcd.patch

--- a/patches/chromium/cherry-pick-f3300abe2fcd.patch
+++ b/patches/chromium/cherry-pick-f3300abe2fcd.patch
@@ -1,0 +1,255 @@
+From f3300abe2fcd0164794d7a782cc221d10c17f322 Mon Sep 17 00:00:00 2001
+From: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
+Date: Mon, 06 Jan 2025 05:34:49 -0800
+Subject: [PATCH] [M130] Make AcceptLanguagesWatcher a weak persistent object
+
+DedicatedWorkerOrSharedWorkerFetchContext keeps on having a pointer
+to the AcceptLanguagesWatcher as a raw_ptr.  Even if the implementing
+object gets garbage-collected, the pointer is kept.  Therefore,
+DedicatedWorkerOrSharedWorkerFetchContext may use it after the GC.
+
+This CL revised the raw_ptr to AcceptLanguagesWatcher to use
+WeakPersistent so that the users of the object won't access it
+after it gets GCed.
+
+(cherry picked from commit 9e7b77da977401361ef3bc9ad0f43e7563f49657)
+
+Bug: 379869752
+Change-Id: Ic3997fcf17aa93f45507241e0fc18a486efc1932
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6038980
+Reviewed-by: Michael Lippautz <mlippautz@chromium.org>
+Auto-Submit: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
+Commit-Queue: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1390151}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6148168
+Reviewed-by: Erhu Akpobaro <eakpobaro@google.com>
+Commit-Queue: Daniel Yip <danielyip@google.com>
+Auto-Submit: Daniel Yip <danielyip@google.com>
+Owners-Override: Daniel Yip <danielyip@google.com>
+Cr-Commit-Position: refs/branch-heads/6723@{#2761}
+Cr-Branched-From: 985f2961df230630f9cbd75bd6fe463009855a11-refs/heads/main@{#1356013}
+---
+
+diff --git a/third_party/blink/public/platform/web_worker_fetch_context.h b/third_party/blink/public/platform/web_worker_fetch_context.h
+index 6f2a2e9..cf8bfce4 100644
+--- a/third_party/blink/public/platform/web_worker_fetch_context.h
++++ b/third_party/blink/public/platform/web_worker_fetch_context.h
+@@ -33,19 +33,12 @@
+ 
+ namespace blink {
+ 
++class AcceptLanguagesWatcher;
+ class WebDocumentSubresourceFilter;
+ class URLLoaderFactory;
+ class WebURLRequest;
+ class URLLoaderThrottle;
+ 
+-// Helper class allowing DedicatedOrSharedWorkerFetchContextImpl to notify blink
+-// upon an accept languages update. This class will be extended by
+-// WorkerNavigator.
+-class AcceptLanguagesWatcher {
+- public:
+-  virtual void NotifyUpdate() = 0;
+-};
+-
+ // WebWorkerFetchContext is a per-worker object created on the main thread,
+ // passed to a worker (dedicated, shared and service worker) and initialized on
+ // the worker thread by InitializeOnWorkerThread(). It contains information
+diff --git a/third_party/blink/renderer/core/workers/worker_navigator.cc b/third_party/blink/renderer/core/workers/worker_navigator.cc
+index 344382b..a4159a4 100644
+--- a/third_party/blink/renderer/core/workers/worker_navigator.cc
++++ b/third_party/blink/renderer/core/workers/worker_navigator.cc
+@@ -61,4 +61,9 @@
+       *Event::Create(event_type_names::kLanguagechange));
+ }
+ 
++void WorkerNavigator::Trace(Visitor* visitor) const {
++  NavigatorBase::Trace(visitor);
++  AcceptLanguagesWatcher::Trace(visitor);
++}
++
+ }  // namespace blink
+diff --git a/third_party/blink/renderer/core/workers/worker_navigator.h b/third_party/blink/renderer/core/workers/worker_navigator.h
+index ea07a96..ab622f8e 100644
+--- a/third_party/blink/renderer/core/workers/worker_navigator.h
++++ b/third_party/blink/renderer/core/workers/worker_navigator.h
+@@ -29,6 +29,7 @@
+ #include "third_party/blink/public/platform/web_worker_fetch_context.h"
+ #include "third_party/blink/renderer/core/core_export.h"
+ #include "third_party/blink/renderer/core/execution_context/navigator_base.h"
++#include "third_party/blink/renderer/platform/accept_languages_watcher.h"
+ #include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
+ 
+ namespace blink {
+@@ -46,6 +47,9 @@
+ 
+   // AcceptLanguagesWatcher override
+   void NotifyUpdate() override;
++
++  // Both NavigatorLanguage and AcceptLanguagesWatcher override
++  void Trace(Visitor* visitor) const override;
+ };
+ 
+ }  // namespace blink
+diff --git a/third_party/blink/renderer/modules/service_worker/web_service_worker_fetch_context_impl.cc b/third_party/blink/renderer/modules/service_worker/web_service_worker_fetch_context_impl.cc
+index 0815877..4930962 100644
+--- a/third_party/blink/renderer/modules/service_worker/web_service_worker_fetch_context_impl.cc
++++ b/third_party/blink/renderer/modules/service_worker/web_service_worker_fetch_context_impl.cc
+@@ -18,6 +18,7 @@
+ #include "third_party/blink/public/platform/url_loader_throttle_provider.h"
+ #include "third_party/blink/public/platform/web_url_request_extra_data.h"
+ #include "third_party/blink/public/platform/websocket_handshake_throttle_provider.h"
++#include "third_party/blink/renderer/platform/accept_languages_watcher.h"
+ #include "third_party/blink/renderer/platform/loader/fetch/url_loader/url_loader_factory.h"
+ #include "third_party/blink/renderer/platform/loader/internet_disconnected_url_loader.h"
+ 
+@@ -226,9 +227,12 @@
+ 
+ void WebServiceWorkerFetchContextImpl::NotifyUpdate(
+     const RendererPreferences& new_prefs) {
+-  DCHECK(accept_languages_watcher_);
+-  if (renderer_preferences_.accept_languages != new_prefs.accept_languages)
+-    accept_languages_watcher_->NotifyUpdate();
++  // Reserving `watcher` on the stack ensures it is not GC'd within this scope.
++  auto* watcher = accept_languages_watcher_.Get();
++  if (watcher &&
++      renderer_preferences_.accept_languages != new_prefs.accept_languages) {
++    watcher->NotifyUpdate();
++  }
+   renderer_preferences_ = new_prefs;
+ }
+ 
+diff --git a/third_party/blink/renderer/modules/service_worker/web_service_worker_fetch_context_impl.h b/third_party/blink/renderer/modules/service_worker/web_service_worker_fetch_context_impl.h
+index a7c897de..c2f1c9d 100644
+--- a/third_party/blink/renderer/modules/service_worker/web_service_worker_fetch_context_impl.h
++++ b/third_party/blink/renderer/modules/service_worker/web_service_worker_fetch_context_impl.h
+@@ -6,16 +6,16 @@
+ #define THIRD_PARTY_BLINK_RENDERER_MODULES_SERVICE_WORKER_WEB_SERVICE_WORKER_FETCH_CONTEXT_IMPL_H_
+ 
+ #include "base/memory/raw_ptr.h"
++#include "base/task/single_thread_task_runner.h"
+ #include "mojo/public/cpp/bindings/pending_receiver.h"
+ #include "mojo/public/cpp/bindings/receiver.h"
+ #include "third_party/blink/public/common/renderer_preferences/renderer_preferences.h"
+ #include "third_party/blink/public/mojom/renderer_preference_watcher.mojom-blink.h"
+ #include "third_party/blink/public/mojom/service_worker/service_worker.mojom-forward.h"
+ #include "third_party/blink/public/mojom/worker/subresource_loader_updater.mojom-blink.h"
+-
+-#include "base/task/single_thread_task_runner.h"
+ #include "third_party/blink/public/platform/modules/service_worker/web_service_worker_fetch_context.h"
+ #include "third_party/blink/public/platform/web_common.h"
++#include "third_party/blink/renderer/platform/heap/persistent.h"
+ #include "third_party/blink/renderer/platform/weborigin/kurl.h"
+ #include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
+ #include "third_party/blink/renderer/platform/wtf/vector.h"
+@@ -135,7 +135,7 @@
+   // This is owned by ThreadedMessagingProxyBase on the main thread.
+   raw_ptr<base::WaitableEvent> terminate_sync_load_event_ = nullptr;
+ 
+-  raw_ptr<AcceptLanguagesWatcher> accept_languages_watcher_ = nullptr;
++  WeakPersistent<AcceptLanguagesWatcher> accept_languages_watcher_;
+ 
+   Vector<String> cors_exempt_header_list_;
+   bool is_offline_mode_ = false;
+diff --git a/third_party/blink/renderer/platform/BUILD.gn b/third_party/blink/renderer/platform/BUILD.gn
+index 5b8e391..12da20f 100644
+--- a/third_party/blink/renderer/platform/BUILD.gn
++++ b/third_party/blink/renderer/platform/BUILD.gn
+@@ -341,6 +341,7 @@
+   output_name = "blink_platform"
+ 
+   sources = [
++    "accept_languages_watcher.h",
+     "animation/animation_translation_util.cc",
+     "animation/animation_translation_util.h",
+     "animation/compositor_animation.cc",
+diff --git a/third_party/blink/renderer/platform/accept_languages_watcher.h b/third_party/blink/renderer/platform/accept_languages_watcher.h
+new file mode 100644
+index 0000000..7fd5de07f
+--- /dev/null
++++ b/third_party/blink/renderer/platform/accept_languages_watcher.h
+@@ -0,0 +1,22 @@
++// Copyright 2024 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef THIRD_PARTY_BLINK_RENDERER_PLATFORM_ACCEPT_LANGUAGES_WATCHER_H_
++#define THIRD_PARTY_BLINK_RENDERER_PLATFORM_ACCEPT_LANGUAGES_WATCHER_H_
++
++#include "third_party/blink/renderer/platform/heap/garbage_collected.h"
++
++namespace blink {
++
++// Helper class allowing DedicatedOrSharedWorkerFetchContextImpl to notify blink
++// upon an accept languages update. This class will be extended by
++// WorkerNavigator.
++class AcceptLanguagesWatcher : public GarbageCollectedMixin {
++ public:
++  virtual void NotifyUpdate() = 0;
++};
++
++}  // namespace blink
++
++#endif  // THIRD_PARTY_BLINK_RENDERER_PLATFORM_ACCEPT_LANGUAGES_WATCHER_H_
+diff --git a/third_party/blink/renderer/platform/loader/fetch/url_loader/DEPS b/third_party/blink/renderer/platform/loader/fetch/url_loader/DEPS
+index c8a92c06..7886b02 100644
+--- a/third_party/blink/renderer/platform/loader/fetch/url_loader/DEPS
++++ b/third_party/blink/renderer/platform/loader/fetch/url_loader/DEPS
+@@ -28,4 +28,7 @@
+     "web_url_loader_unittest.cc": [
+         "+net/test/cert_test_util.h"
+     ],
++    "dedicated_or_shared_worker_fetch_context_impl.cc": [
++        "+third_party/blink/renderer/platform/accept_languages_watcher.h",
++    ],
+ }
+diff --git a/third_party/blink/renderer/platform/loader/fetch/url_loader/dedicated_or_shared_worker_fetch_context_impl.cc b/third_party/blink/renderer/platform/loader/fetch/url_loader/dedicated_or_shared_worker_fetch_context_impl.cc
+index cc1954f6..c9f96ff 100644
+--- a/third_party/blink/renderer/platform/loader/fetch/url_loader/dedicated_or_shared_worker_fetch_context_impl.cc
++++ b/third_party/blink/renderer/platform/loader/fetch/url_loader/dedicated_or_shared_worker_fetch_context_impl.cc
+@@ -28,6 +28,7 @@
+ #include "third_party/blink/public/platform/web_security_origin.h"
+ #include "third_party/blink/public/platform/web_url_request_extra_data.h"
+ #include "third_party/blink/public/platform/websocket_handshake_throttle_provider.h"
++#include "third_party/blink/renderer/platform/accept_languages_watcher.h"
+ #include "third_party/blink/renderer/platform/loader/fetch/url_loader/url_loader.h"
+ #include "third_party/blink/renderer/platform/loader/fetch/url_loader/url_loader_factory.h"
+ #include "url/url_constants.h"
+@@ -605,9 +606,13 @@
+ 
+ void DedicatedOrSharedWorkerFetchContextImpl::NotifyUpdate(
+     const RendererPreferences& new_prefs) {
+-  if (accept_languages_watcher_ &&
+-      renderer_preferences_.accept_languages != new_prefs.accept_languages)
+-    accept_languages_watcher_->NotifyUpdate();
++  // Reserving `accept_languages_watcher` on the stack ensures it is not GC'd
++  // within this scope.
++  auto* accept_languages_watcher = accept_languages_watcher_.Get();
++  if (accept_languages_watcher &&
++      renderer_preferences_.accept_languages != new_prefs.accept_languages) {
++    accept_languages_watcher->NotifyUpdate();
++  }
+   renderer_preferences_ = new_prefs;
+   for (auto& watcher : child_preference_watchers_)
+     watcher->NotifyUpdate(new_prefs);
+diff --git a/third_party/blink/renderer/platform/loader/fetch/url_loader/dedicated_or_shared_worker_fetch_context_impl.h b/third_party/blink/renderer/platform/loader/fetch/url_loader/dedicated_or_shared_worker_fetch_context_impl.h
+index b95a25fe..d0387cf 100644
+--- a/third_party/blink/renderer/platform/loader/fetch/url_loader/dedicated_or_shared_worker_fetch_context_impl.h
++++ b/third_party/blink/renderer/platform/loader/fetch/url_loader/dedicated_or_shared_worker_fetch_context_impl.h
+@@ -23,6 +23,7 @@
+ #include "third_party/blink/public/platform/web_common.h"
+ #include "third_party/blink/public/platform/web_dedicated_or_shared_worker_fetch_context.h"
+ #include "third_party/blink/public/platform/web_string.h"
++#include "third_party/blink/renderer/platform/heap/persistent.h"
+ #include "third_party/blink/renderer/platform/wtf/casting.h"
+ #include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
+ #include "third_party/blink/renderer/platform/wtf/vector.h"
+@@ -301,7 +302,7 @@
+   std::unique_ptr<WeakWrapperResourceLoadInfoNotifier>
+       weak_wrapper_resource_load_info_notifier_;
+ 
+-  raw_ptr<AcceptLanguagesWatcher> accept_languages_watcher_ = nullptr;
++  WeakPersistent<AcceptLanguagesWatcher> accept_languages_watcher_;
+ };
+ 
+ template <>

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -2,3 +2,4 @@ chore_allow_customizing_microtask_policy_per_context.patch
 deps_add_v8_object_setinternalfieldfornodecore.patch
 fix_disable_scope_reuse_associated_dchecks.patch
 fix_compiler_failure_on_older_clang.patch
+cherry-pick-0d3c44362eea.patch

--- a/patches/v8/cherry-pick-0d3c44362eea.patch
+++ b/patches/v8/cherry-pick-0d3c44362eea.patch
@@ -1,0 +1,65 @@
+From 0d3c44362eeaf34833df66ab035e2735247987be Mon Sep 17 00:00:00 2001
+From: Thibaud Michaud <thibaudm@chromium.org>
+Date: Wed, 18 Dec 2024 12:14:14 +0100
+Subject: [PATCH] Merged: [wasm][arm][tail-call] Free scratch register earlier
+
+In Liftoff's PrepareTailCall, we kept the UseScratchRegisterScope open
+for longer than necessary. Close the scope earlier to ensure that we
+don't run out of scratch registers in the last "sub" instruction if it
+needs one.
+
+R=clemensb@chromium.org
+
+Fixed: 384565015
+(cherry picked from commit 7c9e628fd07a457635db098483f7a956ecfa385a)
+
+Change-Id: I0100569d5276aa9188ccbc3c7ee409a9dd49be31
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6148448
+Reviewed-by: Daniel Lehmann <dlehmann@chromium.org>
+Commit-Queue: Thibaud Michaud <thibaudm@chromium.org>
+Cr-Commit-Position: refs/branch-heads/13.0@{#49}
+Cr-Branched-From: 4be854bd71ea878a25b236a27afcecffa2e29360-refs/heads/13.0.245@{#1}
+Cr-Branched-From: 1f5183f7ad6cca21029fd60653d075730c644432-refs/heads/main@{#96103}
+---
+
+diff --git a/src/wasm/baseline/arm/liftoff-assembler-arm-inl.h b/src/wasm/baseline/arm/liftoff-assembler-arm-inl.h
+index 99df0d9..30069c7 100644
+--- a/src/wasm/baseline/arm/liftoff-assembler-arm-inl.h
++++ b/src/wasm/baseline/arm/liftoff-assembler-arm-inl.h
+@@ -498,21 +498,23 @@
+ 
+ void LiftoffAssembler::PrepareTailCall(int num_callee_stack_params,
+                                        int stack_param_delta) {
+-  UseScratchRegisterScope temps(this);
+-  Register scratch = temps.Acquire();
++  {
++    UseScratchRegisterScope temps(this);
++    Register scratch = temps.Acquire();
+ 
+-  // Push the return address and frame pointer to complete the stack frame.
+-  sub(sp, sp, Operand(8));
+-  ldr(scratch, MemOperand(fp, 4));
+-  str(scratch, MemOperand(sp, 4));
+-  ldr(scratch, MemOperand(fp, 0));
+-  str(scratch, MemOperand(sp, 0));
++    // Push the return address and frame pointer to complete the stack frame.
++    sub(sp, sp, Operand(8));
++    ldr(scratch, MemOperand(fp, 4));
++    str(scratch, MemOperand(sp, 4));
++    ldr(scratch, MemOperand(fp, 0));
++    str(scratch, MemOperand(sp, 0));
+ 
+-  // Shift the whole frame upwards.
+-  int slot_count = num_callee_stack_params + 2;
+-  for (int i = slot_count - 1; i >= 0; --i) {
+-    ldr(scratch, MemOperand(sp, i * 4));
+-    str(scratch, MemOperand(fp, (i - stack_param_delta) * 4));
++    // Shift the whole frame upwards.
++    int slot_count = num_callee_stack_params + 2;
++    for (int i = slot_count - 1; i >= 0; --i) {
++      ldr(scratch, MemOperand(sp, i * 4));
++      str(scratch, MemOperand(fp, (i - stack_param_delta) * 4));
++    }
+   }
+ 
+   // Set the new stack and frame pointer.


### PR DESCRIPTION
<details>
<summary>electron/security#637 - 0d3c44362eea from v8</summary>
Merged: [wasm][arm][tail-call] Free scratch register earlier

In Liftoff's PrepareTailCall, we kept the UseScratchRegisterScope open
for longer than necessary. Close the scope earlier to ensure that we
don't run out of scratch registers in the last "sub" instruction if it
needs one.

R=clemensb@chromium.org

Fixed: 384565015
(cherry picked from commit 7c9e628fd07a457635db098483f7a956ecfa385a)

Change-Id: I0100569d5276aa9188ccbc3c7ee409a9dd49be31
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6148448
Reviewed-by: Daniel Lehmann <dlehmann@chromium.org>
Commit-Queue: Thibaud Michaud <thibaudm@chromium.org>
Cr-Commit-Position: refs/branch-heads/13.0@{#49}
Cr-Branched-From: 4be854bd71ea878a25b236a27afcecffa2e29360-refs/heads/13.0.245@{#1}
Cr-Branched-From: 1f5183f7ad6cca21029fd60653d075730c644432-refs/heads/main@{#96103}
</details>

<details>
<summary>electron/security#639 - f3300abe2fcd from chromium</summary>
[M130] Make AcceptLanguagesWatcher a weak persistent object

DedicatedWorkerOrSharedWorkerFetchContext keeps on having a pointer
to the AcceptLanguagesWatcher as a raw_ptr.  Even if the implementing
object gets garbage-collected, the pointer is kept.  Therefore,
DedicatedWorkerOrSharedWorkerFetchContext may use it after the GC.

This CL revised the raw_ptr to AcceptLanguagesWatcher to use
WeakPersistent so that the users of the object won't access it
after it gets GCed.

(cherry picked from commit 9e7b77da977401361ef3bc9ad0f43e7563f49657)

Bug: 379869752
Change-Id: Ic3997fcf17aa93f45507241e0fc18a486efc1932
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6038980
Reviewed-by: Michael Lippautz <mlippautz@chromium.org>
Auto-Submit: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
Commit-Queue: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#1390151}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6148168
Reviewed-by: Erhu Akpobaro <eakpobaro@google.com>
Commit-Queue: Daniel Yip <danielyip@google.com>
Auto-Submit: Daniel Yip <danielyip@google.com>
Owners-Override: Daniel Yip <danielyip@google.com>
Cr-Commit-Position: refs/branch-heads/6723@{#2761}
Cr-Branched-From: 985f2961df230630f9cbd75bd6fe463009855a11-refs/heads/main@{#1356013}
</details>

Notes:
* Security: backported fix for 384565015.
* Security: backported fix for 379869752.