### PR TITLE
refactor: remove redundant CreateExtensionsClient() (#45135)

### DIFF
--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -240,7 +240,7 @@ void RendererClientBase::RenderThreadStarted() {
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   auto* thread = content::RenderThread::Get();
 
-  extensions_client_.reset(CreateExtensionsClient());
+  extensions_client_ = std::make_unique<ElectronExtensionsClient>();
   extensions::ExtensionsClient::Set(extensions_client_.get());
 
   extensions_renderer_client_ =
@@ -572,12 +572,6 @@ v8::Local<v8::Context> RendererClientBase::GetContext(
   else
     return frame->MainWorldScriptContext();
 }
-
-#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-extensions::ExtensionsClient* RendererClientBase::CreateExtensionsClient() {
-  return new ElectronExtensionsClient;
-}
-#endif
 
 bool RendererClientBase::IsWebViewFrame(
     v8::Local<v8::Context> context,

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -141,13 +141,6 @@ class RendererClientBase : public content::ContentRendererClient
                       bool was_created_by_renderer,
                       const url::Origin* outermost_origin) override;
 
- protected:
-#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  // app_shell embedders may need custom extensions client interfaces.
-  // This class takes ownership of the returned object.
-  virtual extensions::ExtensionsClient* CreateExtensionsClient();
-#endif
-
  private:
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   std::unique_ptr<extensions::ExtensionsClient> extensions_client_;


### PR DESCRIPTION
Manually backport #45135 to 32-x-y. See that PR for details.

Notes: none