### PR TITLE
docs: correct breaking changes versions

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -12,7 +12,7 @@ This document uses the following convention to categorize breaking changes:
 * **Deprecated:** An API was marked as deprecated. The API will continue to function, but will emit a deprecation warning, and will be removed in a future release.
 * **Removed:** An API or feature was removed, and is no longer supported by Electron.
 
-## Planned Breaking API Changes (34.0)
+## Planned Breaking API Changes (35.0)
 
 ### Deprecated: `level`, `message`, `line`, and `sourceId` arguments in `console-message` event on `WebContents`
 
@@ -28,6 +28,14 @@ webContents.on('console-message', ({ level, message, lineNumber, sourceId, frame
 ```
 
 Additionally, `level` is now a string with possible values of `info`, `warning`, `error`, and `debug`.
+
+## Planned Breaking API Changes (34.0)
+
+### Behavior Changed: menu bar will be hidden during fullscreen on Windows
+
+This brings the behavior to parity with Linux. Prior behavior: Menu bar is still visible during fullscreen on Windows. New behavior: Menu bar is hidden during fullscreen on Windows.
+
+**Correction**: This was previously listed as a breaking change in Electron 33, but was first released in Electron 34.
 
 ## Planned Breaking API Changes (33.0)
 
@@ -85,10 +93,6 @@ protocol.handle(other, (req) => {
 mainWindow.loadURL('data:text/html,<script src="loaded-from-dataurl.js"></script>', { baseURLForDataURL: 'other://' })
 mainWindow.loadURL('other://index.html')
 ```
-
-### Behavior Changed: menu bar will be hidden during fullscreen on Windows
-
-This brings the behavior to parity with Linux. Prior behavior: Menu bar is still visible during fullscreen on Windows. New behavior: Menu bar is hidden during fullscreen on Windows.
 
 ### Behavior Changed: `webContents` property on `login` on `app`
 


### PR DESCRIPTION
Updating the breaking changes doc in preparation for the release of Electron 34. We identified two changes as being in the wrong sections. In both cases the PR merged after the last release, but was opened before it. Thus, their changes to this doc for the "next" version were no longer current.

I added a "correction" note to the section that we sent out in 33 but actually lands in this upcoming 34 release.

Ref: https://github.com/electron/electron/pull/43402, https://github.com/electron/electron/pull/43617

Notes: Corrected the release version of the "menu bar will be hidden during fullscreen on Windows" breaking change.
