### PR TITLE
feat:just port will-frame-navigate to old version

### DIFF
--- a/lib/browser/guest-view-manager.ts
+++ b/lib/browser/guest-view-manager.ts
@@ -104,6 +104,16 @@ const createGuest = function (embedder: Electron.WebContents, params: Record<str
     sendToEmbedder(IPC_MESSAGES.GUEST_VIEW_INTERNAL_IPC_MESSAGE, channel, ...args);
   });
 
+   // Dispatch guest's frame navigation event to embedder.
+   guest.on('will-frame-navigate', function (event: Electron.WebContentsWillFrameNavigateEventParams) {
+     sendToEmbedder(IPC_MESSAGES.GUEST_VIEW_INTERNAL_DISPATCH_EVENT, 'will-frame-navigate', {
+       url: event.url,
+       isMainFrame: event.isMainFrame,
+       frameProcessId: event.frame.processId,
+       frameRoutingId: event.frame.routingId
+     });
+   });
+
   // Notify guest of embedder window visibility when it is ready
   // FIXME Remove once https://github.com/electron/electron/issues/6828 is fixed
   guest.on('dom-ready', function () {

--- a/shell/browser/electron_navigation_throttle.cc
+++ b/shell/browser/electron_navigation_throttle.cc
@@ -37,6 +37,11 @@ ElectronNavigationThrottle::WillStartRequest() {
     return PROCEED;
   }
 
+  if (handle->IsRendererInitiated() &&
+       api_contents->EmitNavigationEvent("will-frame-navigate", handle)) {
+    return CANCEL;
+  }
+
   if (handle->IsRendererInitiated() && handle->IsInMainFrame() &&
       api_contents->EmitNavigationEvent("will-navigate", handle)) {
     return CANCEL;


### PR DESCRIPTION
#### Description of Change

For some reason, can not update electron framework been used, but I need this will-frame-navigate event, so just want to build a electron release, no need to merge

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: port will-frame-navigate event to electron version 12 <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->

Backport of #34418