### PR TITLE
fix: revert required portal version for file chooser dialogs

### DIFF
--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -241,6 +241,13 @@ Force using discrete GPU when there are multiple GPUs available.
 
 Force using integrated GPU when there are multiple GPUs available.
 
+### --xdg-portal-required-version=`version`
+
+Sets the minimum required version of XDG portal implementation to `version`
+in order to use the portal backend for file dialogs on linux. File dialogs
+will fallback to using gtk or kde depending on the desktop environment when
+the required version is unavailable. Current default is set to `3`.
+
 ## Node.js Flags
 
 Electron supports some of the [CLI flags][node-cli] supported by Node.js.

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -78,6 +78,11 @@ dialog.showOpenDialogSync(mainWindow, {
 })
 ```
 
+**Note:** On Linux `defaultPath` is not supported when using portal file chooser
+dialogs unless the portal backend is version 4 or higher. You can use `--xdg-portal-required-version`
+[command-line switch](./command-line-switches.md#--xdg-portal-required-versionversion)
+to force gtk or kde dialogs.
+
 ### `dialog.showOpenDialog([window, ]options)`
 
 * `window` [BaseWindow](base-window.md) (optional)
@@ -149,6 +154,11 @@ dialog.showOpenDialog(mainWindow, {
   console.log(err)
 })
 ```
+
+**Note:** On Linux `defaultPath` is not supported when using portal file chooser
+dialogs unless the portal backend is version 4 or higher. You can use `--xdg-portal-required-version`
+[command-line switch](./command-line-switches.md#--xdg-portal-required-versionversion)
+to force gtk or kde dialogs.
 
 ### `dialog.showSaveDialogSync([window, ]options)`
 

--- a/patches/chromium/feat_add_support_for_missing_dialog_features_to_shell_dialogs.patch
+++ b/patches/chromium/feat_add_support_for_missing_dialog_features_to_shell_dialogs.patch
@@ -226,7 +226,7 @@ index 61ddcbf7bf57e423099c7d392a19b3ec79b5d03f..7e52ce9f2f108f1aee4cfe2a95d5aa05
 -
 +const char kXdgPortalRequiredVersionFlag[] = "xdg-portal-required-version";
  struct FileChooserProperties : dbus::PropertySet {
--  dbus::Property<uint32_t> version;
+   dbus::Property<uint32_t> version;
  
    explicit FileChooserProperties(dbus::ObjectProxy* object_proxy)
        : dbus::PropertySet(object_proxy, kFileChooserInterfaceName, {}) {

--- a/patches/chromium/feat_add_support_for_missing_dialog_features_to_shell_dialogs.patch
+++ b/patches/chromium/feat_add_support_for_missing_dialog_features_to_shell_dialogs.patch
@@ -199,21 +199,68 @@ index 58985ce62dc569256bad5e94de9c0d125fc470d0..33436784b691c860d58f8b4dfcc6718e
            &SelectFileDialogLinuxKde::OnSelectSingleFolderDialogResponse, this,
            parent));
 diff --git a/ui/shell_dialogs/select_file_dialog_linux_portal.cc b/ui/shell_dialogs/select_file_dialog_linux_portal.cc
-index 61ddcbf7bf57e423099c7d392a19b3ec79b5d03f..920d0610943091f850e44e3e0481abd7fe08f881 100644
+index 143f5fe1028e154192767599a1e68b45301a894d..132e670dc3ccd9a0f904a8869e516f4556fbf0af 100644
 --- a/ui/shell_dialogs/select_file_dialog_linux_portal.cc
 +++ b/ui/shell_dialogs/select_file_dialog_linux_portal.cc
-@@ -44,7 +44,9 @@ constexpr char kMethodStartServiceByName[] = "StartServiceByName";
+@@ -11,6 +11,7 @@
+
+ #include <string_view>
+
++#include "base/command_line.h"
+ #include "base/functional/bind.h"
+ #include "base/logging.h"
+ #include "base/no_destructor.h"
+@@ -40,6 +41,8 @@ namespace {
  constexpr char kXdgPortalService[] = "org.freedesktop.portal.Desktop";
  constexpr char kXdgPortalObject[] = "/org/freedesktop/portal/desktop";
  
--constexpr int kXdgPortalRequiredVersion = 3;
 +// Version 4 includes support for current_folder option to the OpenFile method via
 +// https://github.com/flatpak/xdg-desktop-portal/commit/71165a5.
-+constexpr int kXdgPortalRequiredVersion = 4;
+ constexpr int kXdgPortalRequiredVersion = 3;
  
  constexpr char kXdgPortalRequestInterfaceName[] =
-     "org.freedesktop.portal.Request";
-@@ -221,6 +223,8 @@ void SelectFileDialogLinuxPortal::SelectFileImpl(
+@@ -66,6 +69,8 @@ constexpr int kFileChooserFilterKindGlob = 0;
+
+ constexpr char kFileUriPrefix[] = "file://";
+
++const char kXdgPortalRequiredVersionFlag[] = "xdg-portal-required-version";
++
+ struct FileChooserProperties : dbus::PropertySet {
+   dbus::Property<uint32_t> version;
+
+@@ -171,10 +176,18 @@ void SelectFileDialogLinuxPortal::StartAvailabilityTestInBackground() {
+   if (GetAvailabilityTestCompletionFlag()->IsSet())
+     return;
+
++  auto* cmd = base::CommandLine::ForCurrentProcess();
++  unsigned int xdg_portal_required_version;
++  if (!base::StringToUint(cmd->GetSwitchValueASCII(kXdgPortalRequiredVersionFlag),
++                          &xdg_portal_required_version)) {
++    xdg_portal_required_version = kXdgPortalRequiredVersion;
++  }
++
+   dbus_thread_linux::GetTaskRunner()->PostTask(
+       FROM_HERE,
+       base::BindOnce(
+-          &SelectFileDialogLinuxPortal::CheckPortalAvailabilityOnBusThread));
++          &SelectFileDialogLinuxPortal::CheckPortalAvailabilityOnBusThread,
++          xdg_portal_required_version));
+ }
+
+ // static
+@@ -185,6 +198,11 @@ bool SelectFileDialogLinuxPortal::IsPortalAvailable() {
+   return is_portal_available_;
+ }
+
++// static
++int SelectFileDialogLinuxPortal::GetPortalVersion() {
++  return available_portal_version_;
++}
++
+ // static
+ void SelectFileDialogLinuxPortal::DestroyPortalConnection() {
+   dbus_thread_linux::GetTaskRunner()->PostTask(
+@@ -214,6 +232,8 @@ void SelectFileDialogLinuxPortal::SelectFileImpl(
                       weak_factory_.GetWeakPtr()));
    info_->type = type;
    info_->main_task_runner = base::SequencedTaskRunner::GetCurrentDefault();
@@ -222,7 +269,50 @@ index 61ddcbf7bf57e423099c7d392a19b3ec79b5d03f..920d0610943091f850e44e3e0481abd7
  
    if (owning_window) {
      if (auto* root = owning_window->GetRootWindow()) {
-@@ -557,7 +561,9 @@ void SelectFileDialogLinuxPortal::DialogInfo::AppendOptions(
+@@ -260,7 +280,8 @@ bool SelectFileDialogLinuxPortal::HasMultipleFileTypeChoicesImpl() {
+ }
+
+ // static
+-void SelectFileDialogLinuxPortal::CheckPortalAvailabilityOnBusThread() {
++void SelectFileDialogLinuxPortal::CheckPortalAvailabilityOnBusThread(
++    unsigned int xdg_portal_required_version) {
+   DCHECK(dbus_thread_linux::GetTaskRunner()->RunsTasksInCurrentSequence());
+   base::AtomicFlag* availability_test_complete =
+       GetAvailabilityTestCompletionFlag();
+@@ -274,6 +295,7 @@ void SelectFileDialogLinuxPortal::CheckPortalAvailabilityOnBusThread() {
+       base::BindOnce(
+           [](scoped_refptr<dbus::Bus> bus,
+              base::AtomicFlag* availability_test_complete,
++             unsigned int xdg_portal_required_version,
+              std::optional<bool> name_has_owner) {
+             if (name_has_owner.value_or(false)) {
+               // The portal service has an owner, proceed to check the version.
+@@ -285,15 +307,22 @@ void SelectFileDialogLinuxPortal::CheckPortalAvailabilityOnBusThread() {
+               if (!properties.GetAndBlock(&properties.version)) {
+                 LOG(ERROR) << "Failed to read portal version property";
+               } else if (properties.version.value() >=
+-                         kXdgPortalRequiredVersion) {
++                         xdg_portal_required_version) {
+                 is_portal_available_ = true;
++                available_portal_version_ = properties.version.value();
++              } else {
++                VLOG(1) << "File chooser portal available version: "
++                        << properties.version.value();
++                available_portal_version_ = properties.version.value();
+               }
+             }
++            VLOG(1) << "File chooser portal expected version: "
++                    << xdg_portal_required_version;
+             VLOG(1) << "File chooser portal available: "
+                     << (is_portal_available_ ? "yes" : "no");
+             availability_test_complete->Set();
+           },
+-          bus, availability_test_complete));
++          bus, availability_test_complete, xdg_portal_required_version));
+ }
+
+ // static
+@@ -471,7 +500,9 @@ void SelectFileDialogLinuxPortal::DialogInfo::AppendOptions(
                       response_handle_token);
  
    if (type == SelectFileDialog::Type::SELECT_UPLOAD_FOLDER) {
@@ -233,7 +323,7 @@ index 61ddcbf7bf57e423099c7d392a19b3ec79b5d03f..920d0610943091f850e44e3e0481abd7
                         l10n_util::GetStringUTF8(
                             IDS_SELECT_UPLOAD_FOLDER_DIALOG_UPLOAD_BUTTON));
    }
-@@ -566,6 +572,8 @@ void SelectFileDialogLinuxPortal::DialogInfo::AppendOptions(
+@@ -480,6 +486,8 @@ void SelectFileDialogLinuxPortal::DialogInfo::AppendOptions(
        type == SelectFileDialog::Type::SELECT_UPLOAD_FOLDER ||
        type == SelectFileDialog::Type::SELECT_EXISTING_FOLDER) {
      AppendBoolOption(&options_writer, kFileChooserOptionDirectory, true);
@@ -242,11 +332,29 @@ index 61ddcbf7bf57e423099c7d392a19b3ec79b5d03f..920d0610943091f850e44e3e0481abd7
    } else if (type == SelectFileDialog::Type::SELECT_OPEN_MULTI_FILE) {
      AppendBoolOption(&options_writer, kFileChooserOptionMultiple, true);
    }
+@@ -820,6 +853,7 @@ SelectFileDialogLinuxPortal::DialogInfo::DialogInfo(
+ SelectFileDialogLinuxPortal::DialogInfo::~DialogInfo() = default;
+
+ bool SelectFileDialogLinuxPortal::is_portal_available_ = false;
++unsigned int SelectFileDialogLinuxPortal::available_portal_version_ = 0;
+ int SelectFileDialogLinuxPortal::handle_token_counter_ = 0;
+
+ }  // namespace ui
 diff --git a/ui/shell_dialogs/select_file_dialog_linux_portal.h b/ui/shell_dialogs/select_file_dialog_linux_portal.h
-index 47e3b0e658858ba5f3219f04d258bdf6dd7c26ed..ff8eaabb406cdf759f7a62725171aaf9f74ce183 100644
+index d57a52b3ccbd3bd6d390615351ea2ad1e475b157..6a2800add2428ffd91286748f886d6c42510ba31 100644
 --- a/ui/shell_dialogs/select_file_dialog_linux_portal.h
 +++ b/ui/shell_dialogs/select_file_dialog_linux_portal.h
-@@ -117,6 +117,8 @@ class SelectFileDialogLinuxPortal : public SelectFileDialogLinux {
+@@ -47,6 +47,9 @@ class SelectFileDialogLinuxPortal : public SelectFileDialogLinux {
+   // availability test has not yet completed.
+   static bool IsPortalAvailable();
+
++  // Get version of portal if available.
++  static int GetPortalVersion();
++
+   // Destroys the connection to the bus.
+   static void DestroyPortalConnection();
+
+@@ -120,6 +123,8 @@ class SelectFileDialogLinuxPortal : public SelectFileDialogLinux {
      Type type;
      // The task runner the SelectFileImpl method was called on.
      scoped_refptr<base::SequencedTaskRunner> main_task_runner;
@@ -255,3 +363,23 @@ index 47e3b0e658858ba5f3219f04d258bdf6dd7c26ed..ff8eaabb406cdf759f7a62725171aaf9
  
     private:
      friend class base::RefCountedThreadSafe<DialogInfo>;
+@@ -176,7 +181,8 @@ class SelectFileDialogLinuxPortal : public SelectFileDialogLinux {
+   };
+
+   // D-Bus configuration and initialization.
+-  static void CheckPortalAvailabilityOnBusThread();
++  static void CheckPortalAvailabilityOnBusThread(
++      unsigned int xdg_portal_required_version);
+
+   // Returns a flag, written by the D-Bus thread and read by the UI thread,
+   // indicating whether or not the availability test has completed.
+@@ -208,6 +214,9 @@ class SelectFileDialogLinuxPortal : public SelectFileDialogLinux {
+   // Written by the D-Bus thread and read by the UI thread.
+   static bool is_portal_available_;
+
++  // Written by the D-Bus thread and read by the UI thread.
++  static unsigned int available_portal_version_;
++
+   // Used by the D-Bus thread to generate unique handle tokens.
+   static int handle_token_counter_;
+

--- a/patches/chromium/feat_add_support_for_missing_dialog_features_to_shell_dialogs.patch
+++ b/patches/chromium/feat_add_support_for_missing_dialog_features_to_shell_dialogs.patch
@@ -199,18 +199,18 @@ index 58985ce62dc569256bad5e94de9c0d125fc470d0..33436784b691c860d58f8b4dfcc6718e
            &SelectFileDialogLinuxKde::OnSelectSingleFolderDialogResponse, this,
            parent));
 diff --git a/ui/shell_dialogs/select_file_dialog_linux_portal.cc b/ui/shell_dialogs/select_file_dialog_linux_portal.cc
-index 143f5fe1028e154192767599a1e68b45301a894d..132e670dc3ccd9a0f904a8869e516f4556fbf0af 100644
+index 61ddcbf7bf57e423099c7d392a19b3ec79b5d03f..7e52ce9f2f108f1aee4cfe2a95d5aa053d49f993 100644
 --- a/ui/shell_dialogs/select_file_dialog_linux_portal.cc
 +++ b/ui/shell_dialogs/select_file_dialog_linux_portal.cc
-@@ -11,6 +11,7 @@
-
+@@ -12,6 +12,7 @@
  #include <string_view>
-
+ 
+ #include "base/containers/contains.h"
 +#include "base/command_line.h"
  #include "base/functional/bind.h"
  #include "base/logging.h"
  #include "base/no_destructor.h"
-@@ -40,6 +41,8 @@ namespace {
+@@ -44,6 +45,8 @@ constexpr char kMethodStartServiceByName[] = "StartServiceByName";
  constexpr char kXdgPortalService[] = "org.freedesktop.portal.Desktop";
  constexpr char kXdgPortalObject[] = "/org/freedesktop/portal/desktop";
  
@@ -219,19 +219,21 @@ index 143f5fe1028e154192767599a1e68b45301a894d..132e670dc3ccd9a0f904a8869e516f45
  constexpr int kXdgPortalRequiredVersion = 3;
  
  constexpr char kXdgPortalRequestInterfaceName[] =
-@@ -66,6 +69,8 @@ constexpr int kFileChooserFilterKindGlob = 0;
-
- constexpr char kFileUriPrefix[] = "file://";
-
+@@ -72,9 +75,8 @@ constexpr char kFileUriPrefix[] = "file://";
+ 
+ // Time to wait for the notification service to start, in milliseconds.
+ constexpr base::TimeDelta kStartServiceTimeout = base::Seconds(1);
+-
 +const char kXdgPortalRequiredVersionFlag[] = "xdg-portal-required-version";
-+
  struct FileChooserProperties : dbus::PropertySet {
-   dbus::Property<uint32_t> version;
-
-@@ -171,10 +176,18 @@ void SelectFileDialogLinuxPortal::StartAvailabilityTestInBackground() {
+-  dbus::Property<uint32_t> version;
+ 
+   explicit FileChooserProperties(dbus::ObjectProxy* object_proxy)
+       : dbus::PropertySet(object_proxy, kFileChooserInterfaceName, {}) {
+@@ -178,10 +180,18 @@ void SelectFileDialogLinuxPortal::StartAvailabilityTestInBackground() {
    if (GetAvailabilityTestCompletionFlag()->IsSet())
      return;
-
+ 
 +  auto* cmd = base::CommandLine::ForCurrentProcess();
 +  unsigned int xdg_portal_required_version;
 +  if (!base::StringToUint(cmd->GetSwitchValueASCII(kXdgPortalRequiredVersionFlag),
@@ -246,12 +248,12 @@ index 143f5fe1028e154192767599a1e68b45301a894d..132e670dc3ccd9a0f904a8869e516f45
 +          &SelectFileDialogLinuxPortal::CheckPortalAvailabilityOnBusThread,
 +          xdg_portal_required_version));
  }
-
+ 
  // static
-@@ -185,6 +198,11 @@ bool SelectFileDialogLinuxPortal::IsPortalAvailable() {
+@@ -192,6 +202,11 @@ bool SelectFileDialogLinuxPortal::IsPortalAvailable() {
    return is_portal_available_;
  }
-
+ 
 +// static
 +int SelectFileDialogLinuxPortal::GetPortalVersion() {
 +  return available_portal_version_;
@@ -260,7 +262,7 @@ index 143f5fe1028e154192767599a1e68b45301a894d..132e670dc3ccd9a0f904a8869e516f45
  // static
  void SelectFileDialogLinuxPortal::DestroyPortalConnection() {
    dbus_thread_linux::GetTaskRunner()->PostTask(
-@@ -214,6 +232,8 @@ void SelectFileDialogLinuxPortal::SelectFileImpl(
+@@ -221,6 +236,8 @@ void SelectFileDialogLinuxPortal::SelectFileImpl(
                       weak_factory_.GetWeakPtr()));
    info_->type = type;
    info_->main_task_runner = base::SequencedTaskRunner::GetCurrentDefault();
@@ -269,9 +271,9 @@ index 143f5fe1028e154192767599a1e68b45301a894d..132e670dc3ccd9a0f904a8869e516f45
  
    if (owning_window) {
      if (auto* root = owning_window->GetRootWindow()) {
-@@ -260,7 +280,8 @@ bool SelectFileDialogLinuxPortal::HasMultipleFileTypeChoicesImpl() {
+@@ -267,7 +284,8 @@ bool SelectFileDialogLinuxPortal::HasMultipleFileTypeChoicesImpl() {
  }
-
+ 
  // static
 -void SelectFileDialogLinuxPortal::CheckPortalAvailabilityOnBusThread() {
 +void SelectFileDialogLinuxPortal::CheckPortalAvailabilityOnBusThread(
@@ -279,40 +281,28 @@ index 143f5fe1028e154192767599a1e68b45301a894d..132e670dc3ccd9a0f904a8869e516f45
    DCHECK(dbus_thread_linux::GetTaskRunner()->RunsTasksInCurrentSequence());
    base::AtomicFlag* availability_test_complete =
        GetAvailabilityTestCompletionFlag();
-@@ -274,6 +295,7 @@ void SelectFileDialogLinuxPortal::CheckPortalAvailabilityOnBusThread() {
-       base::BindOnce(
-           [](scoped_refptr<dbus::Bus> bus,
-              base::AtomicFlag* availability_test_complete,
-+             unsigned int xdg_portal_required_version,
-              std::optional<bool> name_has_owner) {
-             if (name_has_owner.value_or(false)) {
-               // The portal service has an owner, proceed to check the version.
-@@ -285,15 +307,22 @@ void SelectFileDialogLinuxPortal::CheckPortalAvailabilityOnBusThread() {
-               if (!properties.GetAndBlock(&properties.version)) {
-                 LOG(ERROR) << "Failed to read portal version property";
-               } else if (properties.version.value() >=
--                         kXdgPortalRequiredVersion) {
-+                         xdg_portal_required_version) {
-                 is_portal_available_ = true;
-+                available_portal_version_ = properties.version.value();
-+              } else {
-+                VLOG(1) << "File chooser portal available version: "
-+                        << properties.version.value();
-+                available_portal_version_ = properties.version.value();
-               }
-             }
-+            VLOG(1) << "File chooser portal expected version: "
-+                    << xdg_portal_required_version;
-             VLOG(1) << "File chooser portal available: "
-                     << (is_portal_available_ ? "yes" : "no");
-             availability_test_complete->Set();
-           },
--          bus, availability_test_complete));
-+          bus, availability_test_complete, xdg_portal_required_version));
- }
-
- // static
-@@ -471,7 +500,9 @@ void SelectFileDialogLinuxPortal::DialogInfo::AppendOptions(
+@@ -288,11 +306,18 @@ void SelectFileDialogLinuxPortal::CheckPortalAvailabilityOnBusThread() {
+     FileChooserProperties properties(portal);
+     if (!properties.GetAndBlock(&properties.version)) {
+       LOG(ERROR) << "Failed to read portal version property";
+-    } else if (properties.version.value() >= kXdgPortalRequiredVersion) {
+-      is_portal_available_ = true;
++    } else if (properties.version.value() >= xdg_portal_required_version) {
++          is_portal_available_ = true;
++          available_portal_version_ = properties.version.value();
++    } else {
++      VLOG(1) << "File chooser portal available version: "
++              << properties.version.value();
++      available_portal_version_ = properties.version.value();
+     }
+   }
+ 
++  VLOG(1) << "File chooser portal expected version: "
++          << xdg_portal_required_version;
+   VLOG(1) << "File chooser portal available: "
+           << (is_portal_available_ ? "yes" : "no");
+   availability_test_complete->Set();
+@@ -557,7 +582,9 @@ void SelectFileDialogLinuxPortal::DialogInfo::AppendOptions(
                       response_handle_token);
  
    if (type == SelectFileDialog::Type::SELECT_UPLOAD_FOLDER) {
@@ -323,7 +313,7 @@ index 143f5fe1028e154192767599a1e68b45301a894d..132e670dc3ccd9a0f904a8869e516f45
                         l10n_util::GetStringUTF8(
                             IDS_SELECT_UPLOAD_FOLDER_DIALOG_UPLOAD_BUTTON));
    }
-@@ -480,6 +486,8 @@ void SelectFileDialogLinuxPortal::DialogInfo::AppendOptions(
+@@ -566,6 +593,8 @@ void SelectFileDialogLinuxPortal::DialogInfo::AppendOptions(
        type == SelectFileDialog::Type::SELECT_UPLOAD_FOLDER ||
        type == SelectFileDialog::Type::SELECT_EXISTING_FOLDER) {
      AppendBoolOption(&options_writer, kFileChooserOptionDirectory, true);
@@ -332,29 +322,29 @@ index 143f5fe1028e154192767599a1e68b45301a894d..132e670dc3ccd9a0f904a8869e516f45
    } else if (type == SelectFileDialog::Type::SELECT_OPEN_MULTI_FILE) {
      AppendBoolOption(&options_writer, kFileChooserOptionMultiple, true);
    }
-@@ -820,6 +853,7 @@ SelectFileDialogLinuxPortal::DialogInfo::DialogInfo(
- SelectFileDialogLinuxPortal::DialogInfo::~DialogInfo() = default;
-
+@@ -883,6 +912,7 @@ SelectFileDialogLinuxPortal::DialogInfo::ConvertUrisToPaths(
+ }
+ 
  bool SelectFileDialogLinuxPortal::is_portal_available_ = false;
 +unsigned int SelectFileDialogLinuxPortal::available_portal_version_ = 0;
  int SelectFileDialogLinuxPortal::handle_token_counter_ = 0;
-
+ 
  }  // namespace ui
 diff --git a/ui/shell_dialogs/select_file_dialog_linux_portal.h b/ui/shell_dialogs/select_file_dialog_linux_portal.h
-index d57a52b3ccbd3bd6d390615351ea2ad1e475b157..6a2800add2428ffd91286748f886d6c42510ba31 100644
+index 47e3b0e658858ba5f3219f04d258bdf6dd7c26ed..7124f65d801b086cf39f3640027b3deeca9b6dca 100644
 --- a/ui/shell_dialogs/select_file_dialog_linux_portal.h
 +++ b/ui/shell_dialogs/select_file_dialog_linux_portal.h
-@@ -47,6 +47,9 @@ class SelectFileDialogLinuxPortal : public SelectFileDialogLinux {
-   // availability test has not yet completed.
+@@ -44,6 +44,9 @@ class SelectFileDialogLinuxPortal : public SelectFileDialogLinux {
+   // test from above has not yet completed (which should generally not happen).
    static bool IsPortalAvailable();
-
+ 
 +  // Get version of portal if available.
 +  static int GetPortalVersion();
 +
    // Destroys the connection to the bus.
    static void DestroyPortalConnection();
-
-@@ -120,6 +123,8 @@ class SelectFileDialogLinuxPortal : public SelectFileDialogLinux {
+ 
+@@ -117,6 +120,8 @@ class SelectFileDialogLinuxPortal : public SelectFileDialogLinux {
      Type type;
      // The task runner the SelectFileImpl method was called on.
      scoped_refptr<base::SequencedTaskRunner> main_task_runner;
@@ -363,23 +353,23 @@ index d57a52b3ccbd3bd6d390615351ea2ad1e475b157..6a2800add2428ffd91286748f886d6c4
  
     private:
      friend class base::RefCountedThreadSafe<DialogInfo>;
-@@ -176,7 +181,8 @@ class SelectFileDialogLinuxPortal : public SelectFileDialogLinux {
+@@ -173,7 +178,8 @@ class SelectFileDialogLinuxPortal : public SelectFileDialogLinux {
    };
-
+ 
    // D-Bus configuration and initialization.
 -  static void CheckPortalAvailabilityOnBusThread();
 +  static void CheckPortalAvailabilityOnBusThread(
 +      unsigned int xdg_portal_required_version);
-
-   // Returns a flag, written by the D-Bus thread and read by the UI thread,
-   // indicating whether or not the availability test has completed.
-@@ -208,6 +214,9 @@ class SelectFileDialogLinuxPortal : public SelectFileDialogLinux {
+   static bool IsPortalRunningOnBusThread(dbus::ObjectProxy* dbus_proxy);
+   static bool IsPortalActivatableOnBusThread(dbus::ObjectProxy* dbus_proxy);
+ 
+@@ -207,6 +213,9 @@ class SelectFileDialogLinuxPortal : public SelectFileDialogLinux {
    // Written by the D-Bus thread and read by the UI thread.
    static bool is_portal_available_;
-
+ 
 +  // Written by the D-Bus thread and read by the UI thread.
 +  static unsigned int available_portal_version_;
 +
    // Used by the D-Bus thread to generate unique handle tokens.
    static int handle_token_counter_;
-
+ 


### PR DESCRIPTION
#### Description of Change

Manual backport of #44426

Backport for 33 branch of #44426 - hopefully resolved the conflict correctly, not sure how to correctly test the chromium patches. Hoping there's a pipeline for that.

#### Release Notes

Notes: fix file chooser dialogs for flaptak applications