### PR TITLE
fix: `session.clearData` `avoidClosingConnections` default to false

### DIFF
--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -160,7 +160,8 @@ uint32_t GetQuotaMask(const std::vector<std::string>& quota_types) {
   return quota_mask;
 }
 
-constexpr BrowsingDataRemover::DataType kClearDataTypeAll = ~0ULL;
+constexpr BrowsingDataRemover::DataType kClearDataTypeAll =
+    ~0ULL & ~BrowsingDataRemover::DATA_TYPE_AVOID_CLOSING_CONNECTIONS;
 constexpr BrowsingDataRemover::OriginType kClearOriginTypeAll =
     BrowsingDataRemover::ORIGIN_TYPE_UNPROTECTED_WEB |
     BrowsingDataRemover::ORIGIN_TYPE_PROTECTED_WEB;


### PR DESCRIPTION
#### Description of Change

Fixes #44853.

The `clearData` API uses `kClearDataTypeAll` when the `dataTypes` option is not set. This default value currently includes the `avoidClosingConnections` option, which contradicts that option's default value of `false`. This PR updates the default value (`kClearDataTypeAll`) to respect `avoidClosingConnections`'s default value of `false`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: The `avoidClosingConnections` option for `session.clearData` now properly defaults to `false` when the `dataTypes` option is not set.
