### PR TITLE
docs: correct breaking changes versions

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -12,6 +12,31 @@ This document uses the following convention to categorize breaking changes:
 * **Deprecated:** An API was marked as deprecated. The API will continue to function, but will emit a deprecation warning, and will be removed in a future release.
 * **Removed:** An API or feature was removed, and is no longer supported by Electron.
 
+## Planned Breaking API Changes (35.0)
+
+### Deprecated: `level`, `message`, `line`, and `sourceId` arguments in `console-message` event on `WebContents`
+
+The `console-message` event on `WebContents` has been updated to provide details on the `Event`
+argument.
+
+```js
+// Deprecated
+webContents.on('console-message', (event, level, message, line, sourceId) => {})
+
+// Replace with:
+webContents.on('console-message', ({ level, message, lineNumber, sourceId, frame }) => {})
+```
+
+Additionally, `level` is now a string with possible values of `info`, `warning`, `error`, and `debug`.
+
+## Planned Breaking API Changes (34.0)
+
+### Behavior Changed: menu bar will be hidden during fullscreen on Windows
+
+This brings the behavior to parity with Linux. Prior behavior: Menu bar is still visible during fullscreen on Windows. New behavior: Menu bar is hidden during fullscreen on Windows.
+
+**Correction**: This was previously listed as a breaking change in Electron 33, but was first released in Electron 34.
+
 ## Planned Breaking API Changes (33.0)
 
 ### Behavior Changed: frame properties may retrieve detached WebFrameMain instances or none at all
@@ -68,10 +93,6 @@ protocol.handle(other, (req) => {
 mainWindow.loadURL('data:text/html,<script src="loaded-from-dataurl.js"></script>', { baseURLForDataURL: 'other://' })
 mainWindow.loadURL('other://index.html')
 ```
-
-### Behavior Changed: menu bar will be hidden during fullscreen on Windows
-
-This brings the behavior to parity with Linux. Prior behavior: Menu bar is still visible during fullscreen on Windows. New behavior: Menu bar is hidden during fullscreen on Windows.
 
 ### Behavior Changed: `webContents` property on `login` on `app`
 


### PR DESCRIPTION
Manual backport of #45173

See that PR for details

Notes: Corrected the release version of the "menu bar will be hidden during fullscreen on Windows" breaking change.