### PR TITLE
fix: broken OOP `window.print()` on macOS/Linux

### DIFF
--- a/shell/utility/electron_content_utility_client.cc
+++ b/shell/utility/electron_content_utility_client.cc
@@ -31,6 +31,11 @@
 #include "components/services/print_compositor/public/mojom/print_compositor.mojom.h"  // nogncheck
 #endif  // BUILDFLAG(ENABLE_PRINTING)
 
+#if BUILDFLAG(ENABLE_OOP_PRINTING)
+#include "chrome/services/printing/print_backend_service_impl.h"
+#include "chrome/services/printing/public/mojom/print_backend_service.mojom.h"
+#endif  // BUILDFLAG(ENABLE_OOP_PRINTING)
+
 #if BUILDFLAG(ENABLE_PRINTING) && BUILDFLAG(IS_WIN)
 #include "chrome/services/printing/pdf_to_emf_converter_factory.h"
 #endif
@@ -71,6 +76,21 @@ auto RunPrintCompositor(
       content::UtilityThread::Get()->GetIOTaskRunner());
 }
 #endif
+
+#if BUILDFLAG(ENABLE_OOP_PRINTING)
+auto RunPrintingSandboxedPrintBackendHost(
+    mojo::PendingReceiver<printing::mojom::SandboxedPrintBackendHost>
+        receiver) {
+  return std::make_unique<printing::SandboxedPrintBackendHostImpl>(
+      std::move(receiver));
+}
+auto RunPrintingUnsandboxedPrintBackendHost(
+    mojo::PendingReceiver<printing::mojom::UnsandboxedPrintBackendHost>
+        receiver) {
+  return std::make_unique<printing::UnsandboxedPrintBackendHostImpl>(
+      std::move(receiver));
+}
+#endif  // BUILDFLAG(ENABLE_OOP_PRINTING)
 
 auto RunProxyResolver(
     mojo::PendingReceiver<proxy_resolver::mojom::ProxyResolverFactory>
@@ -120,6 +140,11 @@ void ElectronContentUtilityClient::RegisterMainThreadServices(
 
 #if BUILDFLAG(ENABLE_PRINTING)
   services.Add(RunPrintCompositor);
+#endif
+
+#if BUILDFLAG(ENABLE_OOP_PRINTING)
+  services.Add(RunPrintingSandboxedPrintBackendHost);
+  services.Add(RunPrintingUnsandboxedPrintBackendHost);
 #endif
 
 #if BUILDFLAG(ENABLE_PRINT_PREVIEW) || \


### PR DESCRIPTION
#### Description of Change

Refs CL:6032774 via https://github.com/electron/electron/pull/44748

Fixes broken printing on macOS/Linux with the following error messages:

```
[69931:0116/114046.603990:ERROR:utility_thread_impl.cc(227)] Cannot run unknown service: printing.mojom.UnsandboxedPrintBackendHost
[69913:0116/114048.175058:ERROR:device_event_log_impl.cc(199)] [11:40:48.174] Printer: printer_query_oop.cc:140 Error after getting settings due to client registration failure; service or renderer likely has terminated
```

Fix this by registering the relevant services in `ElectronContentUtilityClient`.

Tested with https://gist.github.com/0f0e776b138452d6815ef4efc16aa0d1

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed broken OOP `window.print()` on macOS/Linux.
