### PR TITLE
Add more supported flags in NODE_OPTIONS

### DIFF
--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -329,6 +329,9 @@ bool IsAllowedOption(const std::string_view option) {
       "--throw-deprecation",
       "--trace-deprecation",
       "--trace-warnings",
+      "--enable-source-maps",
+      "--async-stack-traces",
+      "--experimental-specifier-resolution=node",
   });
 
   if (debug_options.contains(option))
@@ -353,6 +356,9 @@ void SetNodeOptions(base::Environment* env) {
   static constexpr auto pkg_opts = base::MakeFixedFlatSet<std::string_view>({
       "--http-parser",
       "--max-http-header-size",
+      "--enable-source-maps",
+      "--async-stack-traces",
+      "--experimental-specifier-resolution=node",
   });
 
   if (env->HasVar("NODE_EXTRA_CA_CERTS")) {
@@ -368,8 +374,12 @@ void SetNodeOptions(base::Environment* env) {
       env->GetVar("NODE_OPTIONS", &options);
       std::vector<std::string> parts = base::SplitString(
           options, " ", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
-
+      
       bool is_packaged_app = electron::api::App::IsPackaged();
+
+      if (env->HasVar("ELECTRON_LESS_RESTRICTIVE_NODE_OPTIONS_IN_PACKAGED_APP") {
+        is_packaged_app = false;
+      }
 
       for (const auto& part : parts) {
         // Strip off values passed to individual NODE_OPTIONs


### PR DESCRIPTION

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Add three new flags`--experimental-specifier-resolution=node --enable-source-maps --async-stack-traces` to `IsAllowedOption > options` and `SetNodeOptions > pkg_opts` in the file `shell/common/node_bindings.cc`.

Add one environment flag `ELECTRON_LESS_RESTRICTIVE_NODE_OPTIONS_IN_PACKAGED_APP` to allow all flags for Node.js except for those disallowd ones in `SetNodeOptions`.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Related issue

https://github.com/electron/electron/issues/38875
