### PR TITLE
fix: `getAsFileSystemHandle` failure when drag-dropping two directories

### DIFF
--- a/shell/browser/file_system_access/file_system_access_permission_context.h
+++ b/shell/browser/file_system_access/file_system_access_permission_context.h
@@ -144,9 +144,11 @@ class FileSystemAccessPermissionContext
                                     content::GlobalRenderFrameHostId frame_id,
                                     bool should_block);
 
-  void RunRestrictedPathCallback(SensitiveEntryResult result);
+  void RunRestrictedPathCallback(const base::FilePath& file_path,
+                                 SensitiveEntryResult result);
 
-  void OnRestrictedPathResult(gin::Arguments* args);
+  void OnRestrictedPathResult(const base::FilePath& file_path,
+                              gin::Arguments* args);
 
   void MaybeEvictEntries(base::Value::Dict& dict);
 
@@ -170,7 +172,8 @@ class FileSystemAccessPermissionContext
 
   std::map<url::Origin, base::Value::Dict> id_pathinfo_map_;
 
-  base::OnceCallback<void(SensitiveEntryResult)> callback_;
+  std::map<base::FilePath, base::OnceCallback<void(SensitiveEntryResult)>>
+      callback_map_;
 
   base::WeakPtrFactory<FileSystemAccessPermissionContext> weak_factory_{this};
 };


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/45051.
Closes https://github.com/electron/electron/issues/45225.
Refs https://chromium-review.googlesource.com/c/chromium/src/+/5807287

Fixes an issue where drag-dropping two directories would cause `getAsFileSystemHandle` to never resolve. This happened because the existing logic only expected one directory and so the callback would be overwritten in this use case, triggered by a feature flag change upstream. We store this callback in order to emit an event on session, which is why this happened in Electron and not upstream as well. Fix this by keeping a map of callbacks corresponding to their file paths.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where drag-dropping two directories would cause `getAsFileSystemHandle` to never resolve.
