### PR TITLE
build: fix clang-format duplicate message

### DIFF
--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -369,9 +369,6 @@ def main():
           patch_file.close()
           os.unlink(patch_file.name)
         else:
-          print(
-            'To patch these files, run:',
-            f"$ git apply {patch_file.name}", sep='\n')
           filename=patch_file.name
           print(f"\nTo patch these files, run:\n$ git apply {filename}\n")
 


### PR DESCRIPTION
#### Description of Change

Remove duplicate message on clang-format failure exit.

<details><summary>Sample</summary>
<p>

```
electron on git:fix-fsa-crashes ❯ npm run lint                    10:37AM

> electron@0.0.0-development lint
> node ./script/lint.js && npm run lint:docs

--- a/shell/browser/file_system_access/file_system_access_permission_context.cc
+++ b/shell/browser/file_system_access/file_system_access_permission_context.cc
@@ -474,8 +474,8 @@
   bool creating_new_grant = !existing_grant;
   if (creating_new_grant) {
     grant = base::MakeRefCounted<PermissionGrantImpl>(
-        weak_factory_.GetWeakPtr(), origin, path_info, handle_type, GrantType::kRead,
-        user_action);
+        weak_factory_.GetWeakPtr(), origin, path_info, handle_type,
+        GrantType::kRead, user_action);
     existing_grant = grant.get();
   } else {
     grant = existing_grant;
To patch these files, run:
$ git apply /tmp/electron-format-xvbzg1j2

To patch these files, run:
$ git apply /tmp/electron-format-xvbzg1j2
```

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none