### PR TITLE
chore: skip flaky contentTracing test

### DIFF
--- a/spec/api-content-tracing-spec.ts
+++ b/spec/api-content-tracing-spec.ts
@@ -99,7 +99,8 @@ ifdescribe(!(['arm', 'arm64'].includes(process.arch)) || (process.platform !== '
       this.timeout(5e3);
     }
 
-    it('does not crash on empty string', async () => {
+    // FIXME(samuelmaddock): this test regularly flakes
+    it.skip('does not crash on empty string', async () => {
       const options = {
         categoryFilter: '*',
         traceOptions: 'record-until-full,enable-sampling'


### PR DESCRIPTION
#### Description of Change

I've been regularly seeing this test flake
https://github.com/electron/electron/actions/runs/12832950754/job/35787759402?pr=45232#step:19:120
```
not ok 24 contentTracing stopRecording does not crash on empty string
  Failed to stop tracing
  Error: Failed to stop tracing
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes

Notes: none
