### PR TITLE
ci: don't fail issue triage workflows if issue not found on project

### DIFF
--- a/.github/workflows/branch-created.yml
+++ b/.github/workflows/branch-created.yml
@@ -94,7 +94,7 @@ jobs:
             }))
       - name: Create Release Project Board
         if: ${{ steps.check-major-version.outputs.MAJOR }}
-        uses: dsanders11/project-actions/copy-project@438b25e007c2f4efec324497fadc6402e7cc61a6 # v1.4.0
+        uses: dsanders11/project-actions/copy-project@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
         id: create-release-board
         with:
           drafts: true
@@ -114,14 +114,14 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Find Previous Release Project Board
         if: ${{ steps.check-major-version.outputs.MAJOR }}
-        uses: dsanders11/project-actions/find-project@438b25e007c2f4efec324497fadc6402e7cc61a6 # v1.4.0
+        uses: dsanders11/project-actions/find-project@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
         id: find-prev-release-board
         with:
           title: ${{ steps.generate-project-metadata.outputs.prev-prev-major }}-x-y
           token: ${{ steps.generate-token.outputs.token }}
       - name: Close Previous Release Project Board
         if: ${{ steps.check-major-version.outputs.MAJOR }}
-        uses: dsanders11/project-actions/close-project@438b25e007c2f4efec324497fadc6402e7cc61a6 # v1.4.0
+        uses: dsanders11/project-actions/close-project@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
         with:
           project-number: ${{ steps.find-prev-release-board.outputs.number }}
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -20,12 +20,13 @@ jobs:
           creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
           org: electron
       - name: Set status
-        uses: dsanders11/project-actions/edit-item@438b25e007c2f4efec324497fadc6402e7cc61a6 # v1.4.0
+        uses: dsanders11/project-actions/edit-item@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           project-number: 90
           field: Status
           field-value: ✅ Triaged
+          fail-if-item-not-found: false
   issue-labeled-blocked:
     name: blocked/* label added
     if: startsWith(github.event.label.name, 'blocked/')
@@ -38,12 +39,13 @@ jobs:
           creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
           org: electron
       - name: Set status
-        uses: dsanders11/project-actions/edit-item@438b25e007c2f4efec324497fadc6402e7cc61a6 # v1.4.0
+        uses: dsanders11/project-actions/edit-item@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           project-number: 90
           field: Status
           field-value: 🛑 Blocked
+          fail-if-item-not-found: false
   issue-labeled-blocked-need-repro:
     name: blocked/need-repro label added
     if: github.event.label.name == 'blocked/need-repro'

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -19,7 +19,7 @@ jobs:
           creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
           org: electron
       - name: Add to Issue Triage
-        uses: dsanders11/project-actions/add-item@438b25e007c2f4efec324497fadc6402e7cc61a6 # v1.4.0
+        uses: dsanders11/project-actions/add-item@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
         with:
           field: Reporter
           field-value: ${{ github.event.issue.user.login }}

--- a/.github/workflows/issue-transferred.yml
+++ b/.github/workflows/issue-transferred.yml
@@ -18,7 +18,8 @@ jobs:
           creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
           org: electron
       - name: Remove from issue triage
-        uses: dsanders11/project-actions/delete-item@438b25e007c2f4efec324497fadc6402e7cc61a6 # v1.4.0
+        uses: dsanders11/project-actions/delete-item@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           project-number: 90
+          fail-if-item-not-found: false

--- a/.github/workflows/issue-unlabeled.yml
+++ b/.github/workflows/issue-unlabeled.yml
@@ -30,9 +30,10 @@ jobs:
           org: electron
       - name: Set status
         if: ${{ steps.check-for-blocked-labels.outputs.NOT_BLOCKED }}
-        uses: dsanders11/project-actions/edit-item@438b25e007c2f4efec324497fadc6402e7cc61a6 # v1.4.0
+        uses: dsanders11/project-actions/edit-item@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           project-number: 90
           field: Status
           field-value: 📥 Was Blocked
+          fail-if-item-not-found: false

--- a/.github/workflows/pull-request-labeled.yml
+++ b/.github/workflows/pull-request-labeled.yml
@@ -33,7 +33,7 @@ jobs:
           creds: ${{ secrets.RELEASE_BOARD_GH_APP_CREDS }}
           org: electron
       - name: Set status
-        uses: dsanders11/project-actions/edit-item@438b25e007c2f4efec324497fadc6402e7cc61a6 # v1.4.0
+        uses: dsanders11/project-actions/edit-item@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           project-number: 94

--- a/.github/workflows/stable-prep-items.yml
+++ b/.github/workflows/stable-prep-items.yml
@@ -27,7 +27,7 @@ jobs:
           PROJECT_NUMBER=$(gh project list --owner electron --format json | jq -r '.projects | map(select(.title | test("^[0-9]+-x-y$"))) | max_by(.number) | .number')
           echo "PROJECT_NUMBER=$PROJECT_NUMBER" >> "$GITHUB_OUTPUT"
       - name: Update Completed Stable Prep Items
-        uses: dsanders11/project-actions/completed-by@438b25e007c2f4efec324497fadc6402e7cc61a6 # v1.4.0
+        uses: dsanders11/project-actions/completed-by@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
         with:
           field: Prep Status
           field-value: ✅ Complete


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

We have occasional workflow failures (usually when blocked labels are added to non-bug issues) when the issue is not on a project board - this can also happen with race conditions if a maintainer changes a label and then removes the issue from a project board before the workflow runs, for example.

I've updated `dsanders11/project-actions` to add an input to not fail the workflow in these cases, since it just creates noise for us.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
