### PR TITLE
fix: `webContents.print()` with OOP printing

### DIFF
--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -604,6 +604,19 @@ index 402be34ab888cdf834d0fb65de0832e9a8021ced..82ddc92a35d824926c30279e660cc4e8
  }
  
  #if BUILDFLAG(IS_CHROMEOS)
+diff --git a/chrome/browser/printing/printer_query_oop.cc b/chrome/browser/printing/printer_query_oop.cc
+index e271d17b3261c47f3dbeaf9be0b3c4229ee27181..00b906660580aca7d5aabcde54d68c2161ea71dd 100644
+--- a/chrome/browser/printing/printer_query_oop.cc
++++ b/chrome/browser/printing/printer_query_oop.cc
+@@ -127,7 +127,7 @@ void PrinterQueryOop::OnDidAskUserForSettings(
+     std::unique_ptr<PrintSettings> new_settings,
+     mojom::ResultCode result) {
+   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+-  if (result == mojom::ResultCode::kSuccess) {
++  if (result == mojom::ResultCode::kSuccess && query_with_ui_client_id_.has_value()) {
+     // Want the same PrintBackend service as the query so that we use the same
+     // device context.
+     print_document_client_id_ =
 diff --git a/components/printing/browser/print_manager.cc b/components/printing/browser/print_manager.cc
 index 21c81377d32ae8d4185598a7eba88ed1d2063ef0..0767f4e9369e926b1cea99178c1a1975941f1765 100644
 --- a/components/printing/browser/print_manager.cc

--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -613,7 +613,7 @@ index e271d17b3261c47f3dbeaf9be0b3c4229ee27181..00b906660580aca7d5aabcde54d68c21
      mojom::ResultCode result) {
    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 -  if (result == mojom::ResultCode::kSuccess) {
-+  if (result == mojom::ResultCode::kSuccess && query_with_ui_client_id_.has_value()) {
++  if (result == mojom::ResultCode::kSuccess && query_with_ui_client_id_) {
      // Want the same PrintBackend service as the query so that we use the same
      // device context.
      print_document_client_id_ =


### PR DESCRIPTION
#### Description of Change

Ref CL:6032774

Fixes `webContents.print()` after switch to OOP printing on macOS and Linux. We need to make sure that `query_with_ui_client_id_.has_value()` is true, which isnt a scenario upstream hits since we use the update print settings pathway by default when we pass custom settings via `webContents.print()`.

Tested with https://gist.github.com/codebytere/0f0e776b138452d6815ef4efc16aa0d1

✅ A print job can be sent
✅ Two print jobs can be sent consecutively
✅ A print job can be cancelled and a successful print job sent afterwards

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `webContents.print()` after switch to OOP printing on macOS and Linux. 
