### PR TITLE
refactor: simplify `ParseUserScript()`

### DIFF
--- a/shell/browser/extensions/api/scripting/scripting_api.cc
+++ b/shell/browser/extensions/api/scripting/scripting_api.cc
@@ -490,14 +490,8 @@ std::unique_ptr<UserScript> ParseUserScript(
       ConvertRegisteredContentScriptToSerializedUserScript(
           std::move(content_script));
 
-  std::unique_ptr<UserScript> user_script =
-      script_serialization::ParseSerializedUserScript(
-          serialized_script, extension, allowed_in_incognito, error);
-  if (!user_script) {
-    return nullptr;  // Parsing failed.
-  }
-
-  return user_script;
+  return script_serialization::ParseSerializedUserScript(
+      serialized_script, extension, allowed_in_incognito, error);
 }
 
 // Converts a UserScript object to a api::scripting::RegisteredContentScript


### PR DESCRIPTION
#### Description of Change

Simplify ParseUserScript() by removing some boilerplate code that hasn't been necessary since #43205.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.