### PR TITLE
refactor: in `StopTracing()`,  use string literals instead of `optional<string>`

### DIFF
--- a/shell/browser/api/electron_api_content_tracing.cc
+++ b/shell/browser/api/electron_api_content_tracing.cc
@@ -5,6 +5,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/files/file_util.h"
@@ -20,6 +21,7 @@
 #include "shell/common/node_includes.h"
 
 using content::TracingController;
+using namespace std::literals;
 
 namespace gin {
 
@@ -69,9 +71,9 @@ void StopTracing(gin_helper::Promise<base::FilePath> promise,
                  std::optional<base::FilePath> file_path) {
   auto resolve_or_reject = base::BindOnce(
       [](gin_helper::Promise<base::FilePath> promise,
-         const base::FilePath& path, std::optional<std::string> error) {
-        if (error) {
-          promise.RejectWithErrorMessage(error.value());
+         const base::FilePath& path, const std::string_view error) {
+        if (!std::empty(error)) {
+          promise.RejectWithErrorMessage(error);
         } else {
           promise.Resolve(path);
         }
@@ -81,21 +83,17 @@ void StopTracing(gin_helper::Promise<base::FilePath> promise,
   auto* instance = TracingController::GetInstance();
   if (!instance->IsTracing()) {
     std::move(resolve_or_reject)
-        .Run(std::make_optional(
-            "Failed to stop tracing - no trace in progress"));
+        .Run("Failed to stop tracing - no trace in progress"sv);
   } else if (file_path) {
     auto split_callback = base::SplitOnceCallback(std::move(resolve_or_reject));
     auto endpoint = TracingController::CreateFileEndpoint(
-        *file_path,
-        base::BindOnce(std::move(split_callback.first), std::nullopt));
+        *file_path, base::BindOnce(std::move(split_callback.first), ""sv));
     if (!instance->StopTracing(endpoint)) {
-      std::move(split_callback.second)
-          .Run(std::make_optional("Failed to stop tracing"));
+      std::move(split_callback.second).Run("Failed to stop tracing"sv);
     }
   } else {
     std::move(resolve_or_reject)
-        .Run(std::make_optional(
-            "Failed to create temporary file for trace data"));
+        .Run("Failed to create temporary file for trace data"sv);
   }
 }
 


### PR DESCRIPTION
#### Description of Change

StopTracing() has compile-time string literals that need to get passed to a method that takes a `std::string_view` argument, so the extra `std::optional<std::string>` scaffolding is just extra work that we don't need to do

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none