### PR TITLE
docs: add DocCardList component for index doc

### DIFF
--- a/docs/tutorial/window-customization.md
+++ b/docs/tutorial/window-customization.md
@@ -1,3 +1,5 @@
+import DocCardList from '@theme/DocCardList';
+
 # Window Customization
 
 The [`BrowserWindow`][] module is the foundation of your Electron application, and
@@ -5,13 +7,15 @@ it exposes many APIs that let you customize the look and behavior of your app’
 This section covers how to implement various use cases for window customization on macOS,
 Windows, and Linux.
 
-:::info
-`BrowserWindow` is a subclass of the [`BaseWindow`][] module. Both modules allow
-you to create and manage application windows in Electron, with the main difference
-being that `BrowserWindow` supports a single, full size web view while `BaseWindow`
-supports composing many web views. `BaseWindow` can be used interchangeably with `BrowserWindow`
-in the examples of the documents in this section.
-:::
+> [!NOTE]
+> `BrowserWindow` is a subclass of the [`BaseWindow`][] module. Both modules allow
+> you to create and manage application windows in Electron, with the main difference
+> being that `BrowserWindow` supports a single, full size web view while `BaseWindow`
+> supports composing many web views. `BaseWindow` can be used interchangeably with `BrowserWindow`
+> in the examples of the documents in this section.
+
+ <!-- markdownlint-disable-next-line MD033 -->
+<DocCardList />
 
 [`BaseWindow`]: ../api/base-window.md
 [`BrowserWindow`]: ../api/browser-window.md


### PR DESCRIPTION
#### Description of Change

After #43693 was merged, `window-customization.md` became sort of a section index doc. This PR augments it with a Docusaurus component so that we get nice little auto-generated index cards.

ref https://docusaurus.io/docs/sidebar/items#embedding-generated-index-in-doc-page

<img width="1024" alt="image" src="https://github.com/user-attachments/assets/d0f801b9-00c0-4ae3-898b-5eb250db5c75" />


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
