### PR TITLE
fix: potential crash in `chrome.tabs.update()`

### DIFF
--- a/shell/browser/extensions/api/tabs/tabs_api.cc
+++ b/shell/browser/extensions/api/tabs/tabs_api.cc
@@ -651,7 +651,16 @@ bool TabsUpdateFunction::UpdateURL(const std::string& url_string,
   // will stay in the omnibox - see https://crbug.com/1085779.
   load_params.transition_type = ui::PAGE_TRANSITION_FROM_API;
 
-  web_contents_->GetController().LoadURLWithParams(load_params);
+  base::WeakPtr<content::NavigationHandle> navigation_handle =
+      web_contents_->GetController().LoadURLWithParams(load_params);
+  // Navigation can fail for any number of reasons at the content layer.
+  // Unfortunately, we can't provide a detailed error message here, because
+  // there are too many possible triggers. At least notify the extension that
+  // the update failed.
+  if (!navigation_handle) {
+    *error = "Navigation rejected.";
+    return false;
+  }
 
   DCHECK_EQ(url,
             web_contents_->GetController().GetPendingEntry()->GetVirtualURL());


### PR DESCRIPTION
#### Description of Change

Refs CL:6042891

From the CL:

> tabs.update() can trigger navigations by providing a new URL. These may
be rejected for any number of reasons. We catch some of these (e.g.,
debug URLs), but do not (and likely will never) have all the same checks
in the extensions layer that we do throughout the navigation stack. This
causes issues, since we expect (and DCHECK) that a navigation
successfully starts, which is causing a crash in the case that it fails.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash in `chrome.tabs.update()`.
