### PR TITLE
chore: align `clipboard blink::web_pref::WebPreferences` with upstream

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -405,9 +405,9 @@ void ElectronBrowserClient::OverrideWebkitPrefs(
   prefs->javascript_enabled = true;
   prefs->web_security_enabled = true;
   prefs->plugins_enabled = true;
-  prefs->dom_paste_enabled = true;
+  prefs->dom_paste_enabled = false;
+  prefs->javascript_can_access_clipboard = false;
   prefs->allow_scripts_to_close_windows = true;
-  prefs->javascript_can_access_clipboard = true;
   prefs->local_storage_enabled = true;
   prefs->databases_enabled = true;
   prefs->allow_universal_access_from_file_urls =


### PR DESCRIPTION
#### Description of Change

This PR brings some of our `blink::web_pref::WebPreferences` into alignment with upstream Chromium.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
