### PR TITLE
chore: better logging if Node initialization fails

### DIFF
--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -250,8 +250,8 @@ int NodeMain() {
 
       uint64_t env_flags = node::EnvironmentFlags::kDefaultFlags |
                            node::EnvironmentFlags::kHideConsoleWindows;
-      env = node::CreateEnvironment(
-          isolate_data, isolate->GetCurrentContext(), result->args(),
+      env = electron::util::CreateEnvironment(
+          isolate, isolate_data, isolate->GetCurrentContext(), result->args(),
           result->exec_args(),
           static_cast<node::EnvironmentFlags::Flags>(env_flags));
       CHECK_NE(nullptr, env);

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -649,7 +649,6 @@ std::shared_ptr<node::Environment> NodeBindings::CreateEnvironment(
   context->SetAlignedPointerInEmbedderData(kElectronContextEmbedderDataIndex,
                                            static_cast<void*>(isolate_data));
 
-  node::Environment* env;
   uint64_t env_flags = node::EnvironmentFlags::kDefaultFlags |
                        node::EnvironmentFlags::kHideConsoleWindows |
                        node::EnvironmentFlags::kNoGlobalSearchPaths |
@@ -675,24 +674,10 @@ std::shared_ptr<node::Environment> NodeBindings::CreateEnvironment(
     env_flags |= node::EnvironmentFlags::kNoStartDebugSignalHandler;
   }
 
-  {
-    v8::TryCatch try_catch(isolate);
-    env = node::CreateEnvironment(
-        static_cast<node::IsolateData*>(isolate_data), context, args, exec_args,
-        static_cast<node::EnvironmentFlags::Flags>(env_flags));
-
-    if (try_catch.HasCaught()) {
-      std::string err_msg =
-          "Failed to initialize node environment in process: " + process_type;
-      v8::Local<v8::Message> message = try_catch.Message();
-      std::string msg;
-      if (!message.IsEmpty() &&
-          gin::ConvertFromV8(isolate, message->Get(), &msg))
-        err_msg += " , with error: " + msg;
-      LOG(ERROR) << err_msg;
-    }
-  }
-
+  node::Environment* env = electron::util::CreateEnvironment(
+      isolate, static_cast<node::IsolateData*>(isolate_data), context, args,
+      exec_args, static_cast<node::EnvironmentFlags::Flags>(env_flags),
+      process_type);
   DCHECK(env);
 
   node::IsolateSettings is;

--- a/shell/common/node_util.h
+++ b/shell/common/node_util.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_COMMON_NODE_UTIL_H_
 #define ELECTRON_SHELL_COMMON_NODE_UTIL_H_
 
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -13,7 +14,13 @@
 
 namespace node {
 class Environment;
+class IsolateData;
+struct ThreadId;
+
+namespace EnvironmentFlags {
+enum Flags : uint64_t;
 }
+}  // namespace node
 
 namespace electron::util {
 
@@ -36,6 +43,15 @@ v8::MaybeLocal<v8::Value> CompileAndCall(
     const char* id,
     std::vector<v8::Local<v8::String>>* parameters,
     std::vector<v8::Local<v8::Value>>* arguments);
+
+// Wrapper for node::CreateEnvironment that logs failure
+node::Environment* CreateEnvironment(v8::Isolate* isolate,
+                                     node::IsolateData* isolate_data,
+                                     v8::Local<v8::Context> context,
+                                     const std::vector<std::string>& args,
+                                     const std::vector<std::string>& exec_args,
+                                     node::EnvironmentFlags::Flags env_flags,
+                                     std::string_view process_type = "");
 
 // Convenience function to view a Node buffer's data as a base::span().
 // Analogous to base::as_byte_span()


### PR DESCRIPTION
#### Description of Change

If `node::CreateEnvironment()` fails in NodeBindings, log some more helpful  information, e.g. the file and line number where the error occurred.

I've only aimed this at 35-x-y since strictly speaking this is `semver/minor`, but IMO would be safe for older branches too.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added more helpful logging if Node.js fails to initialize.