### PR TITLE
ci: fix issue workflow failures

### DIFF
--- a/.github/workflows/branch-created.yml
+++ b/.github/workflows/branch-created.yml
@@ -94,7 +94,7 @@ jobs:
             }))
       - name: Create Release Project Board
         if: ${{ steps.check-major-version.outputs.MAJOR }}
-        uses: dsanders11/project-actions/copy-project@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
+        uses: dsanders11/project-actions/copy-project@9c80cd31f58599941c64f74636bea95ba5d46090 # v1.5.1
         id: create-release-board
         with:
           drafts: true
@@ -114,14 +114,14 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Find Previous Release Project Board
         if: ${{ steps.check-major-version.outputs.MAJOR }}
-        uses: dsanders11/project-actions/find-project@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
+        uses: dsanders11/project-actions/find-project@9c80cd31f58599941c64f74636bea95ba5d46090 # v1.5.1
         id: find-prev-release-board
         with:
           title: ${{ steps.generate-project-metadata.outputs.prev-prev-major }}-x-y
           token: ${{ steps.generate-token.outputs.token }}
       - name: Close Previous Release Project Board
         if: ${{ steps.check-major-version.outputs.MAJOR }}
-        uses: dsanders11/project-actions/close-project@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
+        uses: dsanders11/project-actions/close-project@9c80cd31f58599941c64f74636bea95ba5d46090 # v1.5.1
         with:
           project-number: ${{ steps.find-prev-release-board.outputs.number }}
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -20,7 +20,7 @@ jobs:
           creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
           org: electron
       - name: Set status
-        uses: dsanders11/project-actions/edit-item@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
+        uses: dsanders11/project-actions/edit-item@9c80cd31f58599941c64f74636bea95ba5d46090 # v1.5.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
           project-number: 90
@@ -39,7 +39,7 @@ jobs:
           creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
           org: electron
       - name: Set status
-        uses: dsanders11/project-actions/edit-item@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
+        uses: dsanders11/project-actions/edit-item@9c80cd31f58599941c64f74636bea95ba5d46090 # v1.5.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
           project-number: 90

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -19,7 +19,7 @@ jobs:
           creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
           org: electron
       - name: Add to Issue Triage
-        uses: dsanders11/project-actions/add-item@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
+        uses: dsanders11/project-actions/add-item@9c80cd31f58599941c64f74636bea95ba5d46090 # v1.5.1
         with:
           field: Reporter
           field-value: ${{ github.event.issue.user.login }}

--- a/.github/workflows/issue-transferred.yml
+++ b/.github/workflows/issue-transferred.yml
@@ -10,6 +10,7 @@ jobs:
   issue-transferred:
     name: Issue Transferred
     runs-on: ubuntu-latest
+    if: ${{ !github.event.changes.new_repository.private }}
     steps:
       - name: Generate GitHub App token
         uses: electron/github-app-auth-action@384fd19694fe7b6dcc9a684746c6976ad78228ae # v1.1.1
@@ -18,8 +19,9 @@ jobs:
           creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
           org: electron
       - name: Remove from issue triage
-        uses: dsanders11/project-actions/delete-item@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
+        uses: dsanders11/project-actions/delete-item@9c80cd31f58599941c64f74636bea95ba5d46090 # v1.5.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
           project-number: 90
+          item: ${{ github.event.changes.new_issue.html_url }}
           fail-if-item-not-found: false

--- a/.github/workflows/issue-unlabeled.yml
+++ b/.github/workflows/issue-unlabeled.yml
@@ -30,7 +30,7 @@ jobs:
           org: electron
       - name: Set status
         if: ${{ steps.check-for-blocked-labels.outputs.NOT_BLOCKED }}
-        uses: dsanders11/project-actions/edit-item@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
+        uses: dsanders11/project-actions/edit-item@9c80cd31f58599941c64f74636bea95ba5d46090 # v1.5.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
           project-number: 90

--- a/.github/workflows/pull-request-labeled.yml
+++ b/.github/workflows/pull-request-labeled.yml
@@ -33,7 +33,7 @@ jobs:
           creds: ${{ secrets.RELEASE_BOARD_GH_APP_CREDS }}
           org: electron
       - name: Set status
-        uses: dsanders11/project-actions/edit-item@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
+        uses: dsanders11/project-actions/edit-item@9c80cd31f58599941c64f74636bea95ba5d46090 # v1.5.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
           project-number: 94

--- a/.github/workflows/stable-prep-items.yml
+++ b/.github/workflows/stable-prep-items.yml
@@ -27,7 +27,7 @@ jobs:
           PROJECT_NUMBER=$(gh project list --owner electron --format json | jq -r '.projects | map(select(.title | test("^[0-9]+-x-y$"))) | max_by(.number) | .number')
           echo "PROJECT_NUMBER=$PROJECT_NUMBER" >> "$GITHUB_OUTPUT"
       - name: Update Completed Stable Prep Items
-        uses: dsanders11/project-actions/completed-by@8bc0bd421be3a2f9e96e160c4cb703f97cd3be55 # v1.5.0
+        uses: dsanders11/project-actions/completed-by@9c80cd31f58599941c64f74636bea95ba5d46090 # v1.5.1
         with:
           field: Prep Status
           field-value: ✅ Complete


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Bumps `dsanders11/project-actions` again to pick up a fix for redacted items being on a project board. This happened with our issue triage board when an issue on this repo was transferred to a private repo, leaving a dangling redacted item on the board. The current version of `dsanders11/project-actions` doesn't handle redacted items properly so some of the issue workflows can choke when the GraphQL API returns one.

This PR fixes two main things:
* Work as expected even if there's a redacted item on the issue triage board
* Bonus fix for the issue transferred workflow, which needs to use the new URL when removing the item from the board - I've also restricted the workflow to only run if the issue was transferred to a public repo, to prevent it from leaking the new URL (and as such the private repo name)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
