### PR TITLE
test: offscreen rendering background colors

### DIFF
--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6469,31 +6469,40 @@ describe('BrowserWindow module', () => {
 
     it('creates offscreen window with opaque background', async () => {
       w.setBackgroundColor(HexColors.RED);
-      const paint = once(w.webContents, 'paint') as Promise<[any, Electron.Rectangle, Electron.NativeImage]>;
-      w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
-      const [, , data] = await paint;
-      await debugPreviewImage(data);
-      expect(getPixelColor(data, { x: 0, y: 0 }, true)).to.equal('#ff0000ff');
+      await waitUntil(async () => {
+        const paint = once(w.webContents, 'paint') as Promise<[any, Electron.Rectangle, Electron.NativeImage]>;
+        w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
+        const [, , data] = await paint;
+        await debugPreviewImage(data);
+        expect(getPixelColor(data, { x: 0, y: 0 }, true)).to.equal('#ff0000ff');
+        return true;
+      });
     });
 
     it('creates offscreen window with transparent background', async () => {
       w.setBackgroundColor(HexColors.TRANSPARENT);
-      const paint = once(w.webContents, 'paint') as Promise<[any, Electron.Rectangle, Electron.NativeImage]>;
-      w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
-      const [, , data] = await paint;
-      await debugPreviewImage(data);
-      expect(getPixelColor(data, { x: 0, y: 0 }, true)).to.equal(HexColors.TRANSPARENT);
+      await waitUntil(async () => {
+        const paint = once(w.webContents, 'paint') as Promise<[any, Electron.Rectangle, Electron.NativeImage]>;
+        w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
+        const [, , data] = await paint;
+        await debugPreviewImage(data);
+        expect(getPixelColor(data, { x: 0, y: 0 }, true)).to.equal(HexColors.TRANSPARENT);
+        return true;
+      });
     });
 
     // Semi-transparent background is not supported
     it.skip('creates offscreen window with semi-transparent background', async () => {
       const bgColor = '#66ffffff'; // ARGB
       w.setBackgroundColor(bgColor);
-      const paint = once(w.webContents, 'paint') as Promise<[any, Electron.Rectangle, Electron.NativeImage]>;
-      w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
-      const [, , data] = await paint;
-      await debugPreviewImage(data);
-      expect(getPixelColor(data, { x: 0, y: 0 }, true)).to.equal(bgColor);
+      await waitUntil(async () => {
+        const paint = once(w.webContents, 'paint') as Promise<[any, Electron.Rectangle, Electron.NativeImage]>;
+        w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
+        const [, , data] = await paint;
+        await debugPreviewImage(data);
+        expect(getPixelColor(data, { x: 0, y: 0 }, true)).to.equal(bgColor);
+        return true;
+      });
     });
 
     it('does not crash after navigation', () => {

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1,4 +1,4 @@
-import { NativeImage, nativeImage } from 'electron';
+import { nativeImage } from 'electron';
 import { app, BrowserWindow, BrowserView, dialog, ipcMain, OnBeforeSendHeadersListenerDetails, net, protocol, screen, webContents, webFrameMain, session, WebContents, WebFrameMain } from 'electron/main';
 
 import { expect } from 'chai';
@@ -16,7 +16,7 @@ import { setTimeout } from 'node:timers/promises';
 import * as nodeUrl from 'node:url';
 
 import { emittedUntil, emittedNTimes } from './lib/events-helpers';
-import { previewNativeImage } from './lib/image-helpers';
+import { debugPreviewImage } from './lib/image-helpers';
 import { HexColors, hasCapturableScreen, ScreenCapture, getPixelColor } from './lib/screen-helpers';
 import { ifit, ifdescribe, defer, listen, waitUntil } from './lib/spec-helpers';
 import { closeWindow, closeAllWindows } from './lib/window-helpers';
@@ -6440,9 +6440,6 @@ describe('BrowserWindow module', () => {
   });
 
   describe('offscreen rendering', () => {
-    // Toggle to display windows previewing OSR NativeImage results
-    const DEBUG_OFFSCREEN = false;
-
     let w: BrowserWindow;
     beforeEach(function () {
       w = new BrowserWindow({
@@ -6457,19 +6454,13 @@ describe('BrowserWindow module', () => {
     });
     afterEach(closeAllWindows);
 
-    const preview = async (image: NativeImage) => {
-      if (DEBUG_OFFSCREEN) {
-        await previewNativeImage(image);
-      }
-    };
-
     it('creates offscreen window with correct size', async () => {
       const paint = once(w.webContents, 'paint') as Promise<[any, Electron.Rectangle, Electron.NativeImage]>;
       w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
       const [, , data] = await paint;
       expect(data.constructor.name).to.equal('NativeImage');
       expect(data.isEmpty()).to.be.false('data is empty');
-      await preview(data);
+      await debugPreviewImage(data);
       const size = data.getSize();
       const { scaleFactor } = screen.getPrimaryDisplay();
       expect(size.width).to.be.closeTo(100 * scaleFactor, 2);
@@ -6481,7 +6472,7 @@ describe('BrowserWindow module', () => {
       const paint = once(w.webContents, 'paint') as Promise<[any, Electron.Rectangle, Electron.NativeImage]>;
       w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
       const [, , data] = await paint;
-      await preview(data);
+      await debugPreviewImage(data);
       expect(getPixelColor(data, { x: 0, y: 0 }, true)).to.equal('#ff0000ff');
     });
 
@@ -6490,7 +6481,7 @@ describe('BrowserWindow module', () => {
       const paint = once(w.webContents, 'paint') as Promise<[any, Electron.Rectangle, Electron.NativeImage]>;
       w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
       const [, , data] = await paint;
-      await preview(data);
+      await debugPreviewImage(data);
       expect(getPixelColor(data, { x: 0, y: 0 }, true)).to.equal(HexColors.TRANSPARENT);
     });
 
@@ -6501,7 +6492,7 @@ describe('BrowserWindow module', () => {
       const paint = once(w.webContents, 'paint') as Promise<[any, Electron.Rectangle, Electron.NativeImage]>;
       w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
       const [, , data] = await paint;
-      await preview(data);
+      await debugPreviewImage(data);
       expect(getPixelColor(data, { x: 0, y: 0 }, true)).to.equal(bgColor);
     });
 

--- a/spec/lib/image-helpers.ts
+++ b/spec/lib/image-helpers.ts
@@ -1,0 +1,20 @@
+import { BaseWindow, NativeImage } from 'electron';
+
+import { once } from 'node:events';
+
+/**
+ * Opens a window to display a native image. Useful for quickly debugging tests
+ * rather than writing a file and opening manually.
+ */
+export async function previewNativeImage (image: NativeImage) {
+  const previewWindow = new BaseWindow({
+    title: 'NativeImage preview',
+    backgroundColor: '#444444'
+  });
+  const ImageView = (require('electron') as any).ImageView;
+  const imgView = new ImageView();
+  imgView.setImage(image);
+  previewWindow.contentView.addChildView(imgView);
+  imgView.setBounds({ x: 0, y: 0, ...image.getSize() });
+  await once(previewWindow, 'close');
+};

--- a/spec/lib/image-helpers.ts
+++ b/spec/lib/image-helpers.ts
@@ -5,8 +5,11 @@ import { once } from 'node:events';
 /**
  * Opens a window to display a native image. Useful for quickly debugging tests
  * rather than writing a file and opening manually.
+ *
+ * Set the `DEBUG_PREVIEW_IMAGE` environment variable to show previews.
  */
-export async function previewNativeImage (image: NativeImage) {
+export async function debugPreviewImage (image: NativeImage) {
+  if (!process.env.DEBUG_PREVIEW_IMAGE) return;
   const previewWindow = new BaseWindow({
     title: 'NativeImage preview',
     backgroundColor: '#444444'

--- a/spec/lib/screen-helpers.ts
+++ b/spec/lib/screen-helpers.ts
@@ -10,6 +10,7 @@ export enum HexColors {
   RED = '#ff0000',
   BLUE = '#0000ff',
   WHITE = '#ffffff',
+  TRANSPARENT = '#00000000'
 }
 
 function hexToRgba (
@@ -35,9 +36,10 @@ function formatHexByte (val: number): string {
 /**
  * Get the hex color at the given pixel coordinate in an image.
  */
-function getPixelColor (
+export function getPixelColor (
   image: Electron.NativeImage,
-  point: Electron.Point
+  point: Electron.Point,
+  includeAlpha: boolean = false
 ): string {
   // image.crop crashes if point is fractional, so round to prevent that crash
   const pixel = image.crop({
@@ -48,8 +50,10 @@ function getPixelColor (
   });
   // TODO(samuelmaddock): NativeImage.toBitmap() should return the raw pixel
   // color, but it sometimes differs. Why is that?
-  const [b, g, r] = pixel.toBitmap();
-  return `#${formatHexByte(r)}${formatHexByte(g)}${formatHexByte(b)}`;
+  const [b, g, r, a] = pixel.toBitmap();
+  let hex = `#${formatHexByte(r)}${formatHexByte(g)}${formatHexByte(b)}`;
+  if (includeAlpha) hex += `${formatHexByte(a)}`;
+  return hex;
 }
 
 /** Calculate euclidean distance between colors. */
@@ -68,7 +72,7 @@ function colorDistance (hexColorA: string, hexColorB: string): number {
  * Determine if colors are similar based on distance. This can be useful when
  * comparing colors which may differ based on lossy compression.
  */
-function areColorsSimilar (
+export function areColorsSimilar (
   hexColorA: string,
   hexColorB: string,
   distanceThreshold = 90


### PR DESCRIPTION
#### Description of Change

Add tests to check correctness of offscreen rendering background colors.

These tests were used to verify correctness of [29d8ae1](https://github.com/electron/electron/pull/45172/commits/29d8ae1c828660155c62e5c02889f18c7778fec5) in https://github.com/electron/electron/pull/45172

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes

Notes: none
