### PR TITLE
build: create maintainer task issue template and disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,4 @@
+blank_issues_enabled: false
 contact_links:
   - name: Discord Chat
     url: https://discord.gg/APGC3k5yaH

--- a/.github/ISSUE_TEMPLATE/maintainer_task.yml
+++ b/.github/ISSUE_TEMPLATE/maintainer_task.yml
@@ -1,0 +1,20 @@
+name: Task (Maintainers only)
+description: Only to be created by Electron maintainers (e.g. for upgrade follow-ups)
+type: 'task'
+body:
+- type: checkboxes
+  attributes:
+    label: Preflight Checklist
+    description: Please ensure you've completed all of the following.
+    options:
+      - label: I am a [maintainer](https://github.com/orgs/electron/people) of the Electron project. (If not, please create a [different issue type](https://github.com/electron/electron/issues/new/).)
+        required: true
+      - label: I have read the [Contributing Guidelines](https://github.com/electron/electron/blob/main/CONTRIBUTING.md) for this project.
+        required: true
+      - label: I agree to follow the [Code of Conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project adheres to.
+        required: true
+- type: textarea
+  attributes:
+    label: Task Description
+  validations:
+    required: true


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

The Electron project regularly receives issues where the authors didn't fill out the available issue templates. This leads to lengthy back and forth to obtain the required information.

@dsanders11 told me that blank issues are currently enabled so that maintainers can create issues for tasks, e.g. upgrade follow-ups.

This PR:

- Creates a new issue template for maintainers to cover the aforementioned use case
- Disables blank issues

The new task type should solve maintainers' need to create issues without following any templates. At the same time, it has issue authors confirm that they are maintainers of the Electron project and guides them towards the appropriate templates if they are not. This should hopefully reduce the amount of incomplete bug reports.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none