### PR TITLE
build: add `NSPrefersDisplaySafeAreaCompatibilityMode` = `false` to Info.plist

### DIFF
--- a/shell/browser/resources/mac/Info.plist
+++ b/shell/browser/resources/mac/Info.plist
@@ -64,5 +64,7 @@
         <string>${DEFAULT_APP_ASAR_HEADER_SHA}</string>
       </dict>
     </dict>
+    <key>NSPrefersDisplaySafeAreaCompatibilityMode</key>
+    <false/>
   </dict>
 </plist>


### PR DESCRIPTION
#### Description of Change
https://support.apple.com/en-us/102125
> Apps can be updated to work better with this area of your screen. If a developer updates their app for compatibility with your Mac, the "Scale to fit below built-in camera" setting no longer appears.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: Added `NSPrefersDisplaySafeAreaCompatibilityMode` = `false` to Info.plist to remove "Scale to fit below built-in camera." from app options.