### PR TITLE
fix: win.closeFilePreview recreates panel when called twice

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1596,8 +1596,11 @@ void NativeWindowMac::PreviewFile(const std::string& path,
 }
 
 void NativeWindowMac::CloseFilePreview() {
-  if ([QLPreviewPanel sharedPreviewPanelExists]) {
+  // Need to be careful about checking [QLPreviewPanel sharedPreviewPanel] as
+  // simply accessing it will cause it to reinitialize and reappear.
+  if ([QLPreviewPanel sharedPreviewPanelExists] && preview_item_) {
     [[QLPreviewPanel sharedPreviewPanel] close];
+    preview_item_ = nil;
   }
 }
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6234,12 +6234,17 @@ describe('BrowserWindow module', () => {
 
   ifdescribe(process.platform === 'darwin')('previewFile', () => {
     afterEach(closeAllWindows);
-    it('opens the path in Quick Look on macOS', () => {
+    it('opens the path in Quick Look on macOS', async () => {
       const w = new BrowserWindow({ show: false });
       expect(() => {
         w.previewFile(__filename);
         w.closeFilePreview();
       }).to.not.throw();
+
+      // [QLPreviewPanel sharedPreviewPanel] appears to open late sometimes in
+      // CI. Try to close again after a slight delay.
+      await setTimeout(10);
+      w.closeFilePreview();
     });
 
     it('should not call BrowserWindow show event', async () => {

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6241,10 +6241,12 @@ describe('BrowserWindow module', () => {
         w.closeFilePreview();
       }).to.not.throw();
 
-      // [QLPreviewPanel sharedPreviewPanel] appears to open late sometimes in
-      // CI. Try to close again after a slight delay.
-      await setTimeout(10);
-      w.closeFilePreview();
+      if (process.env.CI) {
+        // [QLPreviewPanel sharedPreviewPanel] appears to open late sometimes in
+        // CI. Try to close again after a slight delay.
+        await setTimeout(500);
+        w.closeFilePreview();
+      }
     });
 
     it('should not call BrowserWindow show event', async () => {

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6256,6 +6256,7 @@ describe('BrowserWindow module', () => {
       w.previewFile(__filename);
       await setTimeout(500);
       expect(showCalled).to.equal(false, 'should not have called show twice');
+      w.closeFilePreview();
     });
   });
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6234,19 +6234,12 @@ describe('BrowserWindow module', () => {
 
   ifdescribe(process.platform === 'darwin')('previewFile', () => {
     afterEach(closeAllWindows);
-    it('opens the path in Quick Look on macOS', async () => {
+    it('opens the path in Quick Look on macOS', () => {
       const w = new BrowserWindow({ show: false });
       expect(() => {
         w.previewFile(__filename);
         w.closeFilePreview();
       }).to.not.throw();
-
-      if (process.env.CI) {
-        // [QLPreviewPanel sharedPreviewPanel] appears to open late sometimes in
-        // CI. Try to close again after a slight delay.
-        await setTimeout(500);
-        w.closeFilePreview();
-      }
     });
 
     it('should not call BrowserWindow show event', async () => {


### PR DESCRIPTION
#### Description of Change

Accessing `[QLPreviewPanel sharedPreviewPanel]` causes the panel to be initialized and reappear according to [QLPreviewPanel.h](https://github.com/phracker/MacOSX-SDKs/blob/041600eda65c6a668f66cb7d56b7d1da3e8bcc93/MacOSX10.6.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/QuickLookUI.framework/Versions/A/Headers/QLPreviewPanel.h#L36-L39).

```
/*!
 * @abstract Returns the QLPreviewPanel instance, creating it if it doesnÕt exist yet.
 */
+ (QLPreviewPanel *)sharedPreviewPanel;
```

Thus when calling `win.closeFilePreview` multiple times, it would recreate the closed window every other call.

To fix this, we can release the `preview_file_` data source and gate based on its existence before accessing `[QLPreviewPanel sharedPreviewPanel]`.

This resolves our flaky visual tests where this panel appears in front of other windows. 

repro gist: https://gist.github.com/86dec76eb1fd0a163ceb30925558d081

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes

Notes: Fixed file preview window reappearing when calling `win.closeFilePreview` twice on macOS.
