### PR TITLE
docs: reference security guide in `ipcRenderer.on` docs

### DIFF
--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -41,6 +41,16 @@ The `ipcRenderer` module has the following method to listen for events and send 
 Listens to `channel`, when a new message arrives `listener` would be called with
 `listener(event, args...)`.
 
+:::warning
+Do not expose the `event` argument to the renderer for security reasons! Wrap any
+callback that you receive from the renderer in another function like this:
+`ipcRenderer.on('my-channel', (event, ...args) => callback(...args))`.
+Not wrapping the callback in such a function would expose dangerous Electron APIs
+to the renderer process. See the
+[security guide](../tutorial/security.md#20-do-not-expose-electron-apis-to-untrusted-web-content)
+for more info.
+:::
+
 ### `ipcRenderer.off(channel, listener)`
 
 * `channel` string


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Refs #45228

Add security warning directly to `ipcRenderer.on` documentation.

This is a follow-up to #45241. Some of the proposed changes didn't make it into the version that was merged.

CC @felixrieseberg

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none