### PR TITLE
docs: remove width and height params

### DIFF
--- a/docs/tutorial/online-offline-events.md
+++ b/docs/tutorial/online-offline-events.md
@@ -57,10 +57,7 @@ Finally, create a `main.js` file for main process that creates the window.
 const { app, BrowserWindow } = require('electron')
 
 const createWindow = () => {
-  const onlineStatusWindow = new BrowserWindow({
-    width: 400,
-    height: 100
-  })
+  const onlineStatusWindow = new BrowserWindow()
 
   onlineStatusWindow.loadFile('index.html')
 }


### PR DESCRIPTION
#### Description of Change

- Removed width and height params because output could not be seen.

![image](https://github.com/user-attachments/assets/530445d2-005f-45ab-89b4-16bcf783b21c)


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
