### PR TITLE
build: remove generate-sas-token

### DIFF
--- a/.github/workflows/windows-publish.yml
+++ b/.github/workflows/windows-publish.yml
@@ -40,8 +40,6 @@ jobs:
         fetch-depth: 0
     - name: Checkout & Sync & Save
       uses: ./src/electron/.github/actions/checkout
-      with:
-        generate-sas-token: 'true'
 
   publish-x64-win:
     uses: ./.github/workflows/pipeline-segment-electron-build.yml


### PR DESCRIPTION
#### Description of Change

We don't need to use the sas-token for Windows checkout (it's Mac only). Remove the requirement

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
