### PR TITLE
build: use Python311 exe

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -16,5 +16,5 @@ runs:
       e auto-update disable
       if [ "$(expr substr $(uname -s) 1 10)" == "MSYS_NT-10" ]; then
         e d cipd.bat --version
-        cp "C:\Python37\python.exe" "C:\Python37\python3.exe"
+        cp "C:\Python311\python.exe" "C:\Python311\python3.exe"
       fi


### PR DESCRIPTION
#### Description of Change

Fixes our Windows CI to use Python 3.11.9/ the Python311.exe

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none