### PR TITLE
fix: revert destroy url loader wrapper when JS env exits

### DIFF
--- a/shell/common/api/electron_api_url_loader.h
+++ b/shell/common/api/electron_api_url_loader.h
@@ -21,7 +21,6 @@
 #include "services/network/public/mojom/url_loader_network_service_observer.mojom.h"
 #include "services/network/public/mojom/url_response_head.mojom.h"
 #include "shell/browser/event_emitter_mixin.h"
-#include "shell/common/gin_helper/cleaned_up_at_exit.h"
 #include "url/gurl.h"
 #include "v8/include/v8-forward.h"
 
@@ -51,7 +50,6 @@ namespace electron::api {
 class SimpleURLLoaderWrapper final
     : public gin::Wrappable<SimpleURLLoaderWrapper>,
       public gin_helper::EventEmitterMixin<SimpleURLLoaderWrapper>,
-      public gin_helper::CleanedUpAtExit,
       private network::SimpleURLLoaderStreamConsumer,
       private network::mojom::URLLoaderNetworkServiceObserver {
  public:


### PR DESCRIPTION
#### Description of Change

We're seeing an increase in `gin::WrappableBase::SecondWeakCallback` exceptions, emanating from `env->RunCleanup()` across all platforms, beginning in Electron 33.2.1. This PR attempts to address those exceptions by reverting #44574

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where `env->RunCleanup()` was throwing an exception on app close
