### PR TITLE
build: fix `slack-github-action` for backports

### DIFF
--- a/.github/workflows/pull-request-labeled.yml
+++ b/.github/workflows/pull-request-labeled.yml
@@ -15,12 +15,12 @@ jobs:
       - name: Trigger Slack workflow
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
+          webhook: ${{ secrets.BACKPORT_REQUESTED_SLACK_WEBHOOK_URL }} 
+          webhook-type: webhook-trigger
           payload: |
             {
               "url": "${{ github.event.pull_request.html_url }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.BACKPORT_REQUESTED_SLACK_WEBHOOK_URL }}
   pull-request-labeled-deprecation-review-complete:
     name: deprecation-review/complete label added
     if: github.event.label.name == 'deprecation-review/complete ✅'


### PR DESCRIPTION
#### Description of Change

Looks like [this commit](https://github.com/slackapi/slack-github-action/commit/e9b3a6beef047e819b8fb417da538f97a93a2ec8) in the action changed some of the logic around to require that a `webhook-type` be passed explicitly as an input.

This will fix backport requests not being sent to the expected Slack channel.

See sample error: https://github.com/electron/electron/actions/runs/12941904035/job/36406556780

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
