### PR TITLE
fix: correct electron gin embedder indices

### DIFF
--- a/patches/chromium/fix_harden_blink_scriptstate_maybefrom.patch
+++ b/patches/chromium/fix_harden_blink_scriptstate_maybefrom.patch
@@ -43,15 +43,15 @@ diff --git a/gin/public/gin_embedders.h b/gin/public/gin_embedders.h
 index 8d7c5631fd8f1499c67384286f0e3c4037673b32..99b2e2f63be8a46c5546dd53bc9b05e8c54e857c 100644
 --- a/gin/public/gin_embedders.h
 +++ b/gin/public/gin_embedders.h
-@@ -18,6 +18,8 @@ namespace gin {
- enum GinEmbedder : uint16_t {
-   kEmbedderNativeGin,
+@@ -20,6 +20,8 @@ enum GinEmbedder : uint16_t {
    kEmbedderBlink,
-+  kEmbedderElectron,
-+  kEmbedderBlinkTag,
    kEmbedderPDFium,
    kEmbedderFuchsia,
++  kEmbedderElectron,
++  kEmbedderBlinkTag,
  };
+ 
+ }  // namespace gin
 diff --git a/third_party/blink/renderer/platform/bindings/script_state.cc b/third_party/blink/renderer/platform/bindings/script_state.cc
 index e4a27a24c83dd1a478b2ada8b6c8220076790791..c76dc818f38a62fff63852dbecbc85e304ac731d 100644
 --- a/third_party/blink/renderer/platform/bindings/script_state.cc
@@ -112,14 +112,13 @@ index b3cc8d819b06108386aed9465cab4f27a28b675f..a1757901e52360a9c2ec3c573adb20d0
    static constexpr int kV8ContextPerContextDataIndex =
        static_cast<int>(gin::kPerContextDataStartIndex) +
        static_cast<int>(gin::kEmbedderBlink);
-@@ -271,6 +278,11 @@ class PLATFORM_EXPORT ScriptState : public GarbageCollected<ScriptState> {
+@@ -271,6 +278,10 @@ class PLATFORM_EXPORT ScriptState : public GarbageCollected<ScriptState> {
    // internals.idl.
    String last_compiled_script_file_name_;
    bool last_compiled_script_used_code_cache_ = false;
 +
 +  static constexpr int kV8ContextPerContextDataTagIndex =
 +      static_cast<int>(gin::kPerContextDataStartIndex) +
-+      static_cast<int>(gin::kEmbedderBlink) +
 +      static_cast<int>(gin::kEmbedderBlinkTag);
  };
  


### PR DESCRIPTION
#### Description of Change

Move Electron's extra embedders to the end of the enum so they do not interfere with Chromium embedder indices.
Also use `kEmbedderBlinkTag` directly in its index calculation without adding extra indices from other tags.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed invalid memory access in pdf viewer which lead to random crashes.
