### PR TITLE
docs: added upstream doc links for node, chromium, and v8 in default_app

### DIFF
--- a/default_app/preload.ts
+++ b/default_app/preload.ts
@@ -34,18 +34,25 @@ async function loadSVG (element: HTMLSpanElement) {
 
 async function initialize () {
   const electronPath = await ipcRenderer.invoke('bootstrap');
-
-  function replaceText (selector: string, text: string) {
+  function replaceText (selector: string, text: string, link?: string) {
     const element = document.querySelector<HTMLElement>(selector);
     if (element) {
-      element.innerText = text;
+      if (link) {
+        const anchor = document.createElement('a');
+        anchor.textContent = text;
+        anchor.href = link;
+        anchor.target = '_blank';
+        element.appendChild(anchor);
+      } else {
+        element.innerText = text;
+      }
     }
   }
 
-  replaceText('.electron-version', `Electron v${process.versions.electron}`);
-  replaceText('.chrome-version', `Chromium v${process.versions.chrome}`);
-  replaceText('.node-version', `Node v${process.versions.node}`);
-  replaceText('.v8-version', `v8 v${process.versions.v8}`);
+  replaceText('.electron-version', `Electron v${process.versions.electron}`, 'https://electronjs.org/docs');
+  replaceText('.chrome-version', `Chromium v${process.versions.chrome}`, 'https://developer.chrome.com/docs/chromium');
+  replaceText('.node-version', `Node v${process.versions.node}`, `https://nodejs.org/docs/v${process.versions.node}/api`);
+  replaceText('.v8-version', `v8 v${process.versions.v8}`, 'https://v8.dev/docs');
   replaceText('.command-example', `${electronPath} path-to-app`);
 
   for (const element of document.querySelectorAll<HTMLSpanElement>('.octicon')) {


### PR DESCRIPTION
#### Description of Change

Added upstream documentation links for Node.js, Chromium, and V8 in the default_app of Electron.

Fixes #14728

This is my first open-source contribution, and I’m excited to get involved with Electron! I would appreciate any feedback on improvements or best practices.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added upstream documentation links for Node.js, Chromium, and V8 in the default_app.
