### PR TITLE
build: always use python3 in `script/lib/get-version.js`

### DIFF
--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -74,6 +74,7 @@ jobs:
         echo "C:\Program Files\Git\cmd" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "C:\Program Files\Git\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "C:\Python311" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        cp "C:\Python311\python.exe" "C:\Python311\python3.exe"
     - name: Setup Node.js/npm
       if: ${{ inputs.target-platform == 'win' }}
       uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a

--- a/script/lib/get-version.js
+++ b/script/lib/get-version.js
@@ -19,10 +19,8 @@ module.exports.getElectronVersion = () => {
     // Error may happen when trying to get version before running gn, which is a
     // valid case and error will be ignored.
   }
-  // Most win32 machines have python.exe but no python3.exe.
-  const python = process.platform === 'win32' ? 'python.exe' : 'python3';
   // Get the version from git tag if it is not defined in gn args.
-  const output = spawnSync(python, [path.join(ELECTRON_DIR, 'script', 'get-git-version.py')]);
+  const output = spawnSync('python3', [path.join(ELECTRON_DIR, 'script', 'get-git-version.py')]);
   if (output.status !== 0) {
     throw new Error(`Failed to get git tag, script quit with ${output.status}: ${output.stdout}`);
   }


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

While the deleted comment is accurate, we use `python3` extensively throughout the rest of the build scripts, and more importantly `depot_tools` only ships with a `python3.bat` these days. The existing code causes building to fail on a fresh Windows machine if Python is not installed - otherwise the Python version bundled with `depot_tools` is used and works fine.

Required one minor tweak to the test pipeline segment for WOA to ensure `python3` can be found - I believe this is because `depot_tools` doesn't have an arm64 recipe for Python on Windows.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
