### PR TITLE
fix: incorrect WCO tooltip in RTL

### DIFF
--- a/shell/browser/ui/views/win_caption_button_container.cc
+++ b/shell/browser/ui/views/win_caption_button_container.cc
@@ -39,7 +39,8 @@ std::unique_ptr<WinCaptionButton> CreateCaptionButton(
 }
 
 bool HitTestCaptionButton(WinCaptionButton* button, const gfx::Point& point) {
-  return button && button->GetVisible() && button->bounds().Contains(point);
+  return button && button->GetVisible() &&
+         button->GetMirroredBounds().Contains(point);
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
#### Description of Change

Refs https://chromium-review.googlesource.com/c/chromium/src/+/6098828.

From CL:

> This CL addresses an issue in RTL languages where the window caption
buttons display incorrect tooltips. The issue was caused by using `bounds()` for hit testing, which does not account for RTL layouts. The fix replaces `bounds()` with `GetMirroredBounds()`, ensuring that hit testing works correctly in both LTR and RTL contexts.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where RTL tooltips could be incorrect when using WCO on Windows.
