### PR TITLE
docs: document deletion of `databases` directory

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -216,6 +216,14 @@ win.webContents.navigationHistory.canGoToOffset()
 win.webContents.navigationHistory.goToOffset(index)
 ```
 
+### Behavior changed: Directory `databases` in `userData` will be deleted
+
+If you have a directory called `databases` in the directory returned by
+`app.getPath('userData')`, it will be deleted when Electron 32 is first run.
+The `databases` directory was used by WebSQL, which was removed in Electron 31.
+Chromium now performs a cleanup that deletes this directory. See
+[issue #45396](https://github.com/electron/electron/issues/45396).
+
 ## Planned Breaking API Changes (31.0)
 
 ### Removed: `WebSQL` support


### PR DESCRIPTION
#### Description of Change

Refs #45396

Documents a breaking change in Electron 32.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
