### PR TITLE
docs: mention C++20 requirement in breaking changes document

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -145,6 +145,17 @@ macOS 10.15 (Catalina) is no longer supported by [Chromium](https://chromium-rev
 Older versions of Electron will continue to run on Catalina, but macOS 11 (Big Sur)
 or later will be required to run Electron v33.0.0 and higher.
 
+### Behavior Changed: Native modules now require C++20
+
+Due to changes made upstream, both
+[V8](https://chromium-review.googlesource.com/c/v8/v8/+/5587859) and
+[Node.js](https://github.com/nodejs/node/pull/45427) now require C++20 as a
+minimum version. Developers using native node modules should build their
+modules with `--std=c++20` rather than `--std=c++17`. Images using gcc9 or
+lower may need to update to gcc10 in order to compile. See
+[#43555](https://github.com/electron/electron/pull/43555) for more details.
+
+
 ### Deprecated: `systemPreferences.accessibilityDisplayShouldReduceTransparency`
 
 The `systemPreferences.accessibilityDisplayShouldReduceTransparency` property is now deprecated in favor of the new `nativeTheme.prefersReducedTransparency`, which provides identical information and works cross-platform.

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -155,7 +155,6 @@ modules with `--std=c++20` rather than `--std=c++17`. Images using gcc9 or
 lower may need to update to gcc10 in order to compile. See
 [#43555](https://github.com/electron/electron/pull/43555) for more details.
 
-
 ### Deprecated: `systemPreferences.accessibilityDisplayShouldReduceTransparency`
 
 The `systemPreferences.accessibilityDisplayShouldReduceTransparency` property is now deprecated in favor of the new `nativeTheme.prefersReducedTransparency`, which provides identical information and works cross-platform.


### PR DESCRIPTION
#### Description of Change

Since Electron v33, C++20 has been required for building native modules. This was mentioned in the [blog post](https://www.electronjs.org/blog/electron-33-0#behavior-changed-native-modules-now-require-c20) but not in the breaking changes document. This PR changes that. The wording was copied from the blog post.

CC @VerteDinde

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
