### PR TITLE
fix: WCO not working with some window configurations

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -701,6 +701,15 @@ void NativeWindowViews::Minimize() {
 }
 
 void NativeWindowViews::Restore() {
+#if BUILDFLAG(IS_WIN)
+  if (IsMaximized() && transparent()) {
+    SetBounds(restore_bounds_, false);
+    NotifyWindowRestore();
+    UpdateThickFrame();
+    return;
+  }
+#endif
+
   widget()->Restore();
 
 #if BUILDFLAG(IS_WIN)

--- a/shell/browser/ui/views/win_caption_button_container.cc
+++ b/shell/browser/ui/views/win_caption_button_container.cc
@@ -48,27 +48,26 @@ bool HitTestCaptionButton(WinCaptionButton* button, const gfx::Point& point) {
 WinCaptionButtonContainer::WinCaptionButtonContainer(WinFrameView* frame_view)
     : frame_view_(frame_view),
       minimize_button_(AddChildView(CreateCaptionButton(
-          base::BindRepeating(&views::Widget::Minimize,
-                              base::Unretained(frame_view_->frame())),
+          base::BindRepeating(&NativeWindow::Minimize,
+                              base::Unretained(frame_view_->window())),
           frame_view_,
           VIEW_ID_MINIMIZE_BUTTON,
           IDS_APP_ACCNAME_MINIMIZE))),
       maximize_button_(AddChildView(CreateCaptionButton(
-          base::BindRepeating(&views::Widget::Maximize,
-                              base::Unretained(frame_view_->frame())),
+          base::BindRepeating(&NativeWindow::Maximize,
+                              base::Unretained(frame_view_->window())),
           frame_view_,
           VIEW_ID_MAXIMIZE_BUTTON,
           IDS_APP_ACCNAME_MAXIMIZE))),
       restore_button_(AddChildView(CreateCaptionButton(
-          base::BindRepeating(&views::Widget::Restore,
-                              base::Unretained(frame_view_->frame())),
+          base::BindRepeating(&NativeWindow::Restore,
+                              base::Unretained(frame_view_->window())),
           frame_view_,
           VIEW_ID_RESTORE_BUTTON,
           IDS_APP_ACCNAME_RESTORE))),
       close_button_(AddChildView(CreateCaptionButton(
-          base::BindRepeating(&views::Widget::CloseWithReason,
-                              base::Unretained(frame_view_->frame()),
-                              views::Widget::ClosedReason::kCloseButtonClicked),
+          base::BindRepeating(&NativeWindow::Close,
+                              base::Unretained(frame_view_->window())),
           frame_view_,
           VIEW_ID_CLOSE_BUTTON,
           IDS_APP_ACCNAME_CLOSE))) {
@@ -152,7 +151,7 @@ void WinCaptionButtonContainer::UpdateButtons() {
   minimize_button_->SetEnabled(minimizable);
   minimize_button_->SetVisible(minimizable);
 
-  const bool is_maximized = frame_view_->frame()->IsMaximized();
+  const bool is_maximized = frame_view_->window()->IsMaximized();
   const bool maximizable = frame_view_->window()->IsMaximizable();
   restore_button_->SetVisible(is_maximized && maximizable);
   maximize_button_->SetVisible(!is_maximized && maximizable);


### PR DESCRIPTION
#### Description of Change

Fixes an issue where Windows Control Overlay didn't work with some window configurations, specifically transparent windows on Windows. For example, the maximize button didn't work on transparent windows at all. This was happening because WCO buttons always called the related methods on `views::Widget`, but our more complex window configurations have extra handling in `NativeWindow`. This PR updates the WCO buttons to call the correct methods on `NativeWindow` instead of `views::Widget`.

This is a prerequisite to some other Mica-related fixes I'll have up soon, which are partially broken because they now incorporate transparency.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where Windows Control Overlay didn't work with some window configurations.