### PR TITLE
feat: Restore webContents navigation history and page state

### DIFF
--- a/docs/api/navigation-history.md
+++ b/docs/api/navigation-history.md
@@ -75,17 +75,19 @@ Returns `boolean` - Whether the navigation entry was removed from the webContent
 
 Returns [`NavigationEntry[]`](structures/navigation-entry.md) - WebContents complete history.
 
-#### `navigationHistory.restore(index, entries)`
+#### `navigationHistory.restore(options)`
 
-Restores navigation history. Will make a best effort to restore not just the navigation stack but
-also the state of the individual pages - for instance including HTML form values or the scroll
-position. It's recommended to call this API before any navigation entries are created, so ideally
-before you call `loadURL()` or `loadFile()` on the `webContents` object.
+Restores navigation history and loads the given entry in the in stack. Will make a best effort
+to restore not just the navigation stack but also the state of the individual pages - for instance
+including HTML form values or the scroll position. It's recommended to call this API before any
+navigation entries are created, so ideally before you call `loadURL()` or `loadFile()` on the
+`webContents` object.
 
 This API allows you to create common flows that aim to restore, recreate, or clone other webContents.
 
-* `offset` Integer
-* `entries` [NavigationEntry[]](structures/navigation-entry.md)
+* `options` Object
+  * `entries` [NavigationEntry[]](structures/navigation-entry.md) - Result of a prior `getAllEntries()` call
+  * `index` Integer (optional) - Index of the stack that should be loaded. If you set it to `0`, the webContents will load the first (oldest) entry. If you leave it undefined, Electron will automatically load the last (newest) entry.
 
 Returns `Promise<void>` - the promise will resolve when the page has finished loading the selected navigation entry
 (see [`did-finish-load`](web-contents.md#event-did-finish-load)), and rejects

--- a/docs/api/navigation-history.md
+++ b/docs/api/navigation-history.md
@@ -86,3 +86,8 @@ This API allows you to create common flows that aim to restore, recreate, or clo
 
 * `offset` Integer
 * `entries` [NavigationEntry[]](structures/navigation-entry.md)
+
+Returns `Promise<void>` - the promise will resolve when the page has finished loading the selected navigation entry
+(see [`did-finish-load`](web-contents.md#event-did-finish-load)), and rejects
+if the page fails to load (see
+[`did-fail-load`](web-contents.md#event-did-fail-load)). A noop rejection handler is already attached, which avoids unhandled rejection errors.

--- a/docs/api/navigation-history.md
+++ b/docs/api/navigation-history.md
@@ -74,3 +74,15 @@ Returns `boolean` - Whether the navigation entry was removed from the webContent
 #### `navigationHistory.getAllEntries()`
 
 Returns [`NavigationEntry[]`](structures/navigation-entry.md) - WebContents complete history.
+
+#### `navigationHistory.restore(index, entries)`
+
+Restores navigation history. Will make a best effort to restore not just the navigation stack but
+also the state of the individual pages - for instance including HTML form values or the scroll
+position. It's recommended to call this API before any navigation entries are created, so ideally
+before you call `loadURL()` or `loadFile()` on the `webContents` object.
+
+This API allows you to create common flows that aim to restore, recreate, or clone other webContents.
+
+* `offset` Integer
+* `entries` [NavigationEntry[]](structures/navigation-entry.md)

--- a/docs/api/structures/navigation-entry.md
+++ b/docs/api/structures/navigation-entry.md
@@ -2,3 +2,6 @@
 
 * `url` string
 * `title` string
+* `pageState` string (optional) - A base64 encoded data string containing Chromium page state
+  including information like the current scroll position or form values. It is committed by
+  Chromium before a navigation event and on a regular interval.

--- a/docs/tutorial/navigation-history.md
+++ b/docs/tutorial/navigation-history.md
@@ -69,8 +69,25 @@ if (navigationHistory.canGoToOffset(2)) {
 }
 ```
 
+## Restoring history
+
+A common flow is that you want to restore the history of a webContents - for instance to implement an "undo close tab" feature. To do so, you can call `navigationHistory.restore({ index, entries })`. This will restore the webContent's navigation history and the webContents location in said history, meaning that `goBack()` and `goForward()` navigate you through the stack as expected.
+
+```js @ts-type={navigationHistory:Electron.NavigationHistory}
+
+const firstWindow = new BrowserWindow()
+
+// Later, you want a second window to have the same history and navigation position
+async function restore () {
+  const entries = firstWindow.webContents.navigationHistory.getAllEntries()
+  const index = firstWindow.webContents.navigationHistory.getActiveIndex()
+
+  const secondWindow = new BrowserWindow()
+  await secondWindow.webContents.navigationHistory.restore({ index, entries })
+}
+```
+
 Here's a full example that you can open with Electron Fiddle:
 
 ```fiddle docs/fiddles/features/navigation-history
-
 ```

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -611,7 +611,8 @@ WebContents.prototype._init = function () {
       length: this._historyLength.bind(this),
       getEntryAtIndex: this._getNavigationEntryAtIndex.bind(this),
       removeEntryAtIndex: this._removeNavigationEntryAtIndex.bind(this),
-      getAllEntries: this._getHistory.bind(this)
+      getAllEntries: this._getHistory.bind(this),
+      restore: this._restoreHistory.bind(this)
     },
     writable: false,
     enumerable: true

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -343,7 +343,7 @@ WebContents.prototype.loadFile = function (filePath, options = {}) {
 
 type LoadError = { errorCode: number, errorDescription: string, url: string };
 
-WebContents.prototype._awaitNextLoad = function (navigationUrl: string) {
+function _awaitNextLoad (this: Electron.WebContents, navigationUrl: string) {
   return new Promise<void>((resolve, reject) => {
     const resolveAndCleanup = () => {
       removeListeners();
@@ -429,7 +429,7 @@ WebContents.prototype._awaitNextLoad = function (navigationUrl: string) {
 };
 
 WebContents.prototype.loadURL = function (url, options) {
-  const p = this._awaitNextLoad(url);
+  const p = _awaitNextLoad.call(this, url);
   // Add a no-op rejection handler to silence the unhandled rejection error.
   p.catch(() => {});
   this._loadURL(url, options ?? {});
@@ -621,7 +621,7 @@ WebContents.prototype._init = function () {
           throw new Error('Invalid index. Index must be a positive integer and within the bounds of the entries length.');
         }
 
-        const p = this._awaitNextLoad(entries[index].url);
+        const p = _awaitNextLoad.call(this, entries[index].url);
         p.catch(() => {});
         this._restoreHistory(index, entries);
         return p;

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -627,7 +627,13 @@ WebContents.prototype._init = function () {
 
         const p = _awaitNextLoad.call(this, entries[index].url);
         p.catch(() => {});
-        this._restoreHistory(index, entries);
+
+        try {
+          this._restoreHistory(index, entries);
+        } catch (error) {
+          return Promise.reject(error);
+        }
+
         return p;
       }
     },

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -8,7 +8,7 @@ import * as deprecate from '@electron/internal/common/deprecate';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
 import { app, ipcMain, session, webFrameMain, dialog } from 'electron/main';
-import type { BrowserWindowConstructorOptions, MessageBoxOptions } from 'electron/main';
+import type { BrowserWindowConstructorOptions, MessageBoxOptions, NavigationEntry } from 'electron/main';
 
 import * as path from 'path';
 import * as url from 'url';
@@ -343,8 +343,8 @@ WebContents.prototype.loadFile = function (filePath, options = {}) {
 
 type LoadError = { errorCode: number, errorDescription: string, url: string };
 
-WebContents.prototype.loadURL = function (url, options) {
-  const p = new Promise<void>((resolve, reject) => {
+WebContents.prototype._awaitNextLoad = function (navigationUrl: string) {
+  return new Promise<void>((resolve, reject) => {
     const resolveAndCleanup = () => {
       removeListeners();
       resolve();
@@ -402,7 +402,7 @@ WebContents.prototype.loadURL = function (url, options) {
       // the only one is with a bad scheme, perhaps ERR_INVALID_ARGUMENT
       // would be more appropriate.
       if (!error) {
-        error = { errorCode: -2, errorDescription: 'ERR_FAILED', url };
+        error = { errorCode: -2, errorDescription: 'ERR_FAILED', url: navigationUrl };
       }
       finishListener();
     };
@@ -426,6 +426,10 @@ WebContents.prototype.loadURL = function (url, options) {
     this.on('did-stop-loading', stopLoadingListener);
     this.on('destroyed', stopLoadingListener);
   });
+};
+
+WebContents.prototype.loadURL = function (url, options) {
+  const p = this._awaitNextLoad(url);
   // Add a no-op rejection handler to silence the unhandled rejection error.
   p.catch(() => {});
   this._loadURL(url, options ?? {});
@@ -612,7 +616,16 @@ WebContents.prototype._init = function () {
       getEntryAtIndex: this._getNavigationEntryAtIndex.bind(this),
       removeEntryAtIndex: this._removeNavigationEntryAtIndex.bind(this),
       getAllEntries: this._getHistory.bind(this),
-      restore: this._restoreHistory.bind(this)
+      restore: (index: number, entries: NavigationEntry[]) => {
+        if (index < 0 || !entries[index]) {
+          throw new Error('Invalid index. Index must be a positive integer and within the bounds of the entries length.');
+        }
+
+        const p = this._awaitNextLoad(entries[index].url);
+        p.catch(() => {});
+        this._restoreHistory(index, entries);
+        return p;
+      }
     },
     writable: false,
     enumerable: true

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -616,7 +616,11 @@ WebContents.prototype._init = function () {
       getEntryAtIndex: this._getNavigationEntryAtIndex.bind(this),
       removeEntryAtIndex: this._removeNavigationEntryAtIndex.bind(this),
       getAllEntries: this._getHistory.bind(this),
-      restore: (index: number, entries: NavigationEntry[]) => {
+      restore: ({ index, entries }: { index?: number, entries: NavigationEntry[] }) => {
+        if (index === undefined) {
+          index = entries.length - 1;
+        }
+
         if (index < 0 || !entries[index]) {
           throw new Error('Invalid index. Index must be a positive integer and within the bounds of the entries length.');
         }

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2620,22 +2620,22 @@ std::vector<content::NavigationEntry*> WebContents::GetHistory() const {
 }
 
 void WebContents::RestoreHistory(
+    v8::Isolate* isolate,
+    gin_helper::ErrorThrower thrower,
     int index,
     const std::vector<v8::Local<v8::Value>>& entries) {
   if (!web_contents()
            ->GetController()
            .GetLastCommittedEntry()
            ->IsInitialEntry()) {
-    gin_helper::ErrorThrower(JavascriptEnvironment::GetIsolate())
-        .ThrowError(
-            "Cannot restore history on webContents that have previously loaded "
-            "a page.");
+    thrower.ThrowError(
+        "Cannot restore history on webContents that have previously loaded "
+        "a page.");
     return;
   }
 
   auto navigation_entries = std::make_unique<
       std::vector<std::unique_ptr<content::NavigationEntry>>>();
-  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
 
   for (const auto& entry : entries) {
     content::NavigationEntry* nav_entry = nullptr;

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -363,12 +363,31 @@ struct Converter<scoped_refptr<content::DevToolsAgentHost>> {
 
 template <>
 struct Converter<content::NavigationEntry*> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     content::NavigationEntry** out) {
+    gin_helper::Dictionary dict;
+    if (!gin::ConvertFromV8(isolate, val, &dict))
+      return false;
+
+    std::string url_str;
+    std::string title;
+    if (!dict.Get("url", &url_str) || !dict.Get("title", &title))
+      return false;
+
+    auto entry = content::NavigationEntry::Create();
+    entry->SetURL(GURL(url_str));
+    entry->SetTitle(base::UTF8ToUTF16(title));
+    *out = entry.release();
+    return true;
+  }
+
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    content::NavigationEntry* entry) {
     if (!entry) {
       return v8::Null(isolate);
     }
-    gin_helper::Dictionary dict(isolate, v8::Object::New(isolate));
+    gin_helper::Dictionary dict = gin_helper::Dictionary::CreateEmpty(isolate);
     dict.Set("url", entry->GetURL().spec());
     dict.Set("title", entry->GetTitleForDisplay());
     return dict.GetHandle();
@@ -2572,6 +2591,26 @@ std::vector<content::NavigationEntry*> WebContents::GetHistory() const {
   return history;
 }
 
+void WebContents::RestoreHistory(
+    int index,
+    const std::vector<v8::Local<v8::Value>>& entries) {
+  auto navigation_entries = std::make_unique<
+      std::vector<std::unique_ptr<content::NavigationEntry>>>();
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+
+  for (const auto& entry : entries) {
+    content::NavigationEntry* nav_entry = nullptr;
+    if (gin::Converter<content::NavigationEntry*>::FromV8(isolate, entry,
+                                                          &nav_entry)) {
+      navigation_entries->push_back(
+          std::unique_ptr<content::NavigationEntry>(nav_entry));
+    }
+  }
+
+  web_contents()->GetController().Restore(
+      index, content::RestoreType::kRestored, navigation_entries.get());
+}
+
 void WebContents::ClearHistory() {
   // In some rare cases (normally while there is no real history) we are in a
   // state where we can't prune navigation entries
@@ -4397,6 +4436,7 @@ void WebContents::FillObjectTemplate(v8::Isolate* isolate,
                  &WebContents::RemoveNavigationEntryAtIndex)
       .SetMethod("_getHistory", &WebContents::GetHistory)
       .SetMethod("_clearHistory", &WebContents::ClearHistory)
+      .SetMethod("_restoreHistory", &WebContents::RestoreHistory)
       .SetMethod("isCrashed", &WebContents::IsCrashed)
       .SetMethod("forcefullyCrashRenderer",
                  &WebContents::ForcefullyCrashRenderer)

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -374,15 +374,11 @@ struct Converter<content::NavigationEntry*> {
     std::string url_str;
     std::string title;
     std::string encoded_page_state;
+    GURL url;
 
-    if (!dict.Get("url", &url_str) || !dict.Get("title", &title))
+    if (!dict.Get("url", &url) || !dict.Get("title", &title))
       return false;
 
-    GURL url(url_str);
-    if (!url.is_valid())
-      return false;
-
-    // Create entry with validated URL
     auto entry = content::NavigationEntry::Create();
     entry->SetURL(url);
     entry->SetTitle(base::UTF8ToUTF16(title));
@@ -2626,22 +2622,38 @@ std::vector<content::NavigationEntry*> WebContents::GetHistory() const {
 void WebContents::RestoreHistory(
     int index,
     const std::vector<v8::Local<v8::Value>>& entries) {
+  if (!web_contents()
+           ->GetController()
+           .GetLastCommittedEntry()
+           ->IsInitialEntry()) {
+    gin_helper::ErrorThrower(JavascriptEnvironment::GetIsolate())
+        .ThrowError(
+            "Cannot restore history on webContents that have previously loaded "
+            "a page.");
+    return;
+  }
+
   auto navigation_entries = std::make_unique<
       std::vector<std::unique_ptr<content::NavigationEntry>>>();
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
 
   for (const auto& entry : entries) {
     content::NavigationEntry* nav_entry = nullptr;
-    if (gin::Converter<content::NavigationEntry*>::FromV8(isolate, entry,
-                                                          &nav_entry)) {
-      navigation_entries->push_back(
-          std::unique_ptr<content::NavigationEntry>(nav_entry));
+    if (!gin::Converter<content::NavigationEntry*>::FromV8(isolate, entry,
+                                                           &nav_entry) ||
+        !nav_entry) {
+      // Invalid entry, bail out early
+      return;
     }
+    navigation_entries->push_back(
+        std::unique_ptr<content::NavigationEntry>(nav_entry));
   }
 
-  web_contents()->GetController().Restore(
-      index, content::RestoreType::kRestored, navigation_entries.get());
-  web_contents()->GetController().LoadIfNecessary();
+  if (!navigation_entries->empty()) {
+    web_contents()->GetController().Restore(
+        index, content::RestoreType::kRestored, navigation_entries.get());
+    web_contents()->GetController().LoadIfNecessary();
+  }
 }
 
 void WebContents::ClearHistory() {

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2643,6 +2643,10 @@ void WebContents::RestoreHistory(
                                                            &nav_entry) ||
         !nav_entry) {
       // Invalid entry, bail out early
+      thrower.ThrowError(
+          "Failed to restore navigation history: Invalid navigation entry at "
+          "index " +
+          std::to_string(index) + ".");
       return;
     }
     navigation_entries->push_back(

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -219,6 +219,8 @@ class WebContents final : public ExclusiveAccessContext,
   bool RemoveNavigationEntryAtIndex(int index);
   std::vector<content::NavigationEntry*> GetHistory() const;
   void ClearHistory();
+  void RestoreHistory(int index,
+                      const std::vector<v8::Local<v8::Value>>& entries);
   int GetHistoryLength() const;
   const std::string GetWebRTCIPHandlingPolicy() const;
   void SetWebRTCIPHandlingPolicy(const std::string& webrtc_ip_handling_policy);

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -219,7 +219,9 @@ class WebContents final : public ExclusiveAccessContext,
   bool RemoveNavigationEntryAtIndex(int index);
   std::vector<content::NavigationEntry*> GetHistory() const;
   void ClearHistory();
-  void RestoreHistory(int index,
+  void RestoreHistory(v8::Isolate* isolate,
+                      gin_helper::ErrorThrower thrower,
+                      int index,
                       const std::vector<v8::Local<v8::Value>>& entries);
   int GetHistoryLength() const;
   const std::string GetWebRTCIPHandlingPolicy() const;

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -792,7 +792,7 @@ describe('webContents module', () => {
       });
     });
 
-    describe('navigationHistory.restore(index, entries) API', () => {
+    describe('navigationHistory.restore({ index, entries }) API', () => {
       let server: http.Server;
       let serverUrl: string;
 
@@ -834,7 +834,7 @@ describe('webContents module', () => {
           w.webContents.once('dom-ready', () => resolve(w.webContents.executeJavaScript('document.querySelector("input").value')));
 
           // Restore the navigation history
-          w.webContents.navigationHistory.restore(2, entries);
+          return w.webContents.navigationHistory.restore({ index: 2, entries });
         });
 
         expect(formValue).to.equal('Hi!');
@@ -853,7 +853,7 @@ describe('webContents module', () => {
         // Close the window, make a new one
         w.close();
         w = new BrowserWindow();
-        w.webContents.navigationHistory.restore(2, brokenEntries);
+        await w.webContents.navigationHistory.restore({ index: 2, entries: brokenEntries });
 
         const entries = w.webContents.navigationHistory.getAllEntries();
 

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -115,6 +115,7 @@ declare namespace Electron {
     _goToIndex(index: number): void;
     _removeNavigationEntryAtIndex(index: number): boolean;
     _getHistory(): Electron.NavigationEntry[];
+    _restoreHistory(index: number, entries: Electron.NavigationEntry[]): void
     _clearHistory():void
     canGoToIndex(index: number): boolean;
     destroy(): void;

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -87,6 +87,7 @@ declare namespace Electron {
   }
 
   interface WebContents {
+    _awaitNextLoad(expectedUrl: string): Promise<void>;
     _loadURL(url: string, options: ElectronInternal.LoadURLOptions): void;
     getOwnerBrowserWindow(): Electron.BrowserWindow | null;
     getLastWebPreferences(): Electron.WebPreferences | null;


### PR DESCRIPTION
#### Description of Change

This PR exposes a `navigationHistory.restore(index, entries)` API that allows developers to restore navigation history on a new webContents. Then, it also adds Chromium's own `pageState` to `NavigationEntry`, which allows developers to restore scroll position, form entries, and everything else that's part of Blink's serialized page state. This empowers developers to _really_ rehydrate apps, including "Opening apps at the same scroll position" or "Undo close tab".

The changes are straightforward. The only "decision" I've made is around `pageState`: Chromium itself serializes it to a binary string hex format that doesn't survive JSON serialization/deserialization. To make this easier for devs, I've decided to encode that hex format as base64 on our side. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `webContents.navigationHistory.restore(index, entries)` API that allows restoration of navigation history.
