### PR TITLE
test: make sure test window is on top for focus tests

### DIFF
--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -98,14 +98,13 @@ describe('window.postMessage', () => {
   });
 });
 
-// Tests disabled due to regression in Chromium upgrade
-// https://github.com/electron/electron/issues/45322
-ifdescribe(!(process.platform === 'win32' && process.arch === 'ia32'))('focus handling', () => {
+describe('focus handling', () => {
   let webviewContents: WebContents;
   let w: BrowserWindow;
 
   beforeEach(async () => {
     w = new BrowserWindow({
+      alwaysOnTop: true,
       show: true,
       webPreferences: {
         nodeIntegration: true,

--- a/spec/lib/screen-helpers.ts
+++ b/spec/lib/screen-helpers.ts
@@ -122,6 +122,14 @@ export class ScreenCapture {
     return this._expectImpl(findPoint(this.display.size), hexColor, true);
   }
 
+  public async takeScreenshot (filePrefix: string) {
+    const frame = await this.captureFrame();
+    return await createArtifactWithRandomId(
+      (id) => `${filePrefix}-${id}.png`,
+      frame.toPNG()
+    );
+  }
+
   private async captureFrame (): Promise<NativeImage> {
     const sources = await desktopCapturer.getSources({
       types: ['screen'],


### PR DESCRIPTION
#### Description of Change
Fixes #45322.  Using a newly added spec helper `takeScreenshot`, I was able to determine that on the focus tests in Windows, the testing window was behind other windows which interfered with the focus tests.  This PR changes our focus tests to make sure the test window is always on top.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
