### PR TITLE
refactor: dispatch IPC messages from Session

### DIFF
--- a/lib/browser/api/session.ts
+++ b/lib/browser/api/session.ts
@@ -23,7 +23,7 @@ systemPickerVideoSource.name = '';
 Object.freeze(systemPickerVideoSource);
 
 Session.prototype._init = function () {
-  addIpcDispatchListeners(this, this.serviceWorkers);
+  addIpcDispatchListeners(this);
 };
 
 Session.prototype.fetch = function (input: RequestInfo, init?: RequestInit) {

--- a/lib/browser/guest-view-manager.ts
+++ b/lib/browser/guest-view-manager.ts
@@ -155,7 +155,7 @@ const createGuest = function (embedder: Electron.WebContents, embedderFrameId: n
   }
 
   // Dispatch guest's IPC messages to embedder.
-  guest.on('ipc-message-host' as any, function (event: Electron.IpcMainEvent, channel: string, args: any[]) {
+  guest.on('-ipc-message-host' as any, function (event: Electron.IpcMainEvent, channel: string, args: any[]) {
     sendToEmbedder(IPC_MESSAGES.GUEST_VIEW_INTERNAL_DISPATCH_EVENT, 'ipc-message', {
       frameId: [event.processId, event.frameId],
       channel,

--- a/lib/browser/ipc-dispatch.ts
+++ b/lib/browser/ipc-dispatch.ts
@@ -2,8 +2,17 @@ import { ipcMainInternal } from '@electron/internal/browser/ipc-main-internal';
 import { MessagePortMain } from '@electron/internal/browser/message-port-main';
 
 import type { ServiceWorkerMain } from 'electron/main';
+import { ipcMain } from 'electron/main';
 
 const v8Util = process._linkedBinding('electron_common_v8_util');
+const webFrameMainBinding = process._linkedBinding('electron_browser_web_frame_main');
+
+const addReplyToEvent = (event: Electron.IpcMainEvent) => {
+  const { processId, frameId } = event;
+  event.reply = (channel: string, ...args: any[]) => {
+    event.sender.sendToFrame([processId, frameId], channel, ...args);
+  };
+};
 
 const addReturnValueToEvent = (event: Electron.IpcMainEvent | Electron.IpcMainServiceWorkerEvent) => {
   Object.defineProperty(event, 'returnValue', {
@@ -12,26 +21,52 @@ const addReturnValueToEvent = (event: Electron.IpcMainEvent | Electron.IpcMainSe
   });
 };
 
+const getServiceWorkerFromEvent = (event: Electron.IpcMainServiceWorkerEvent | Electron.IpcMainServiceWorkerInvokeEvent): ServiceWorkerMain | undefined => {
+  return event.session.serviceWorkers._getWorkerFromVersionIDIfExists(event.versionId);
+};
+const addServiceWorkerPropertyToEvent = (event: Electron.IpcMainServiceWorkerEvent | Electron.IpcMainServiceWorkerInvokeEvent) => {
+  Object.defineProperty(event, 'serviceWorker', {
+    get: () => event.session.serviceWorkers.getWorkerFromVersionID(event.versionId)
+  });
+};
+
+/**
+ * Cached IPC emitters sorted by dispatch priority.
+ * Caching is used to avoid frequent array allocations.
+ */
+const cachedIpcEmitters: (ElectronInternal.IpcMainInternal | undefined)[] = [
+  undefined, // WebFrameMain ipc
+  undefined, // WebContents ipc
+  ipcMain
+];
+
+// Get list of relevant IPC emitters for dispatch.
+const getIpcEmittersForFrameEvent = (event: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent): (ElectronInternal.IpcMainInternal | undefined)[] => {
+  // Lookup by FrameTreeNode ID to ensure IPCs received after a frame swap are
+  // always received. This occurs when a RenderFrame sends an IPC while it's
+  // unloading and its internal state is pending deletion.
+  const { frameTreeNodeId } = event;
+  const webFrameByFtn = frameTreeNodeId ? webFrameMainBinding._fromFtnIdIfExists(frameTreeNodeId) : undefined;
+  cachedIpcEmitters[0] = webFrameByFtn?.ipc;
+  cachedIpcEmitters[1] = event.sender.ipc;
+  return cachedIpcEmitters;
+};
+
 /**
  * Listens for IPC dispatch events on `api`.
- *
- * NOTE: Currently this only supports dispatching IPCs for ServiceWorkerMain.
  */
-export function addIpcDispatchListeners (api: NodeJS.EventEmitter, serviceWorkers: Electron.ServiceWorkers) {
-  const getServiceWorkerFromEvent = (event: Electron.IpcMainServiceWorkerEvent | Electron.IpcMainServiceWorkerInvokeEvent): ServiceWorkerMain | undefined => {
-    return serviceWorkers._getWorkerFromVersionIDIfExists(event.versionId);
-  };
-  const addServiceWorkerPropertyToEvent = (event: Electron.IpcMainServiceWorkerEvent | Electron.IpcMainServiceWorkerInvokeEvent) => {
-    Object.defineProperty(event, 'serviceWorker', {
-      get: () => serviceWorkers.getWorkerFromVersionID(event.versionId)
-    });
-  };
-
+export function addIpcDispatchListeners (api: NodeJS.EventEmitter) {
   api.on('-ipc-message' as any, function (event: Electron.IpcMainEvent | Electron.IpcMainServiceWorkerEvent, channel: string, args: any[]) {
     const internal = v8Util.getHiddenValue<boolean>(event, 'internal');
 
     if (internal) {
       ipcMainInternal.emit(channel, event, ...args);
+    } else if (event.type === 'frame') {
+      addReplyToEvent(event);
+      event.sender.emit('ipc-message', event, channel, ...args);
+      for (const ipcEmitter of getIpcEmittersForFrameEvent(event)) {
+        ipcEmitter?.emit(channel, event, ...args);
+      }
     } else if (event.type === 'service-worker') {
       addServiceWorkerPropertyToEvent(event);
       getServiceWorkerFromEvent(event)?.ipc.emit(channel, event, ...args);
@@ -51,6 +86,8 @@ export function addIpcDispatchListeners (api: NodeJS.EventEmitter, serviceWorker
 
     if (internal) {
       targets.push(ipcMainInternal);
+    } else if (event.type === 'frame') {
+      targets.push(...getIpcEmittersForFrameEvent(event));
     } else if (event.type === 'service-worker') {
       addServiceWorkerPropertyToEvent(event);
       const workerIpc = getServiceWorkerFromEvent(event)?.ipc;
@@ -75,6 +112,20 @@ export function addIpcDispatchListeners (api: NodeJS.EventEmitter, serviceWorker
     addReturnValueToEvent(event);
     if (internal) {
       ipcMainInternal.emit(channel, event, ...args);
+    } else if (event.type === 'frame') {
+      addReplyToEvent(event);
+      const webContents = event.sender;
+      const ipcEmitters = getIpcEmittersForFrameEvent(event);
+      if (
+        webContents.listenerCount('ipc-message-sync') === 0 &&
+        ipcEmitters.every(emitter => !emitter || emitter.listenerCount(channel) === 0)
+      ) {
+        console.warn(`WebContents #${webContents.id} called ipcRenderer.sendSync() with '${channel}' channel without listeners.`);
+      }
+      webContents.emit('ipc-message-sync', event, channel, ...args);
+      for (const ipcEmitter of ipcEmitters) {
+        ipcEmitter?.emit(channel, event, ...args);
+      }
     } else if (event.type === 'service-worker') {
       addServiceWorkerPropertyToEvent(event);
       getServiceWorkerFromEvent(event)?.ipc.emit(channel, event, ...args);
@@ -83,7 +134,12 @@ export function addIpcDispatchListeners (api: NodeJS.EventEmitter, serviceWorker
 
   api.on('-ipc-ports' as any, function (event: Electron.IpcMainEvent | Electron.IpcMainServiceWorkerEvent, channel: string, message: any, ports: any[]) {
     event.ports = ports.map(p => new MessagePortMain(p));
-    if (event.type === 'service-worker') {
+    if (event.type === 'frame') {
+      const ipcEmitters = getIpcEmittersForFrameEvent(event);
+      for (const ipcEmitter of ipcEmitters) {
+        ipcEmitter?.emit(channel, event, message);
+      }
+    } if (event.type === 'service-worker') {
       addServiceWorkerPropertyToEvent(event);
       getServiceWorkerFromEvent(event)?.ipc.emit(channel, event, message);
     }

--- a/lib/browser/ipc-dispatch.ts
+++ b/lib/browser/ipc-dispatch.ts
@@ -132,6 +132,10 @@ export function addIpcDispatchListeners (api: NodeJS.EventEmitter) {
     }
   } as any);
 
+  api.on('-ipc-message-host', function (event: Electron.IpcMainEvent, channel: string, args: any[]) {
+    event.sender.emit('-ipc-message-host', event, channel, args);
+  });
+
   api.on('-ipc-ports' as any, function (event: Electron.IpcMainEvent | Electron.IpcMainServiceWorkerEvent, channel: string, message: any, ports: any[]) {
     event.ports = ports.map(p => new MessagePortMain(p));
     if (event.type === 'frame') {

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1999,28 +1999,11 @@ bool WebContents::EmitNavigationEvent(
   return event->GetDefaultPrevented();
 }
 
-void WebContents::Message(bool internal,
-                          const std::string& channel,
-                          blink::CloneableMessage arguments,
-                          content::RenderFrameHost* render_frame_host) {
-  TRACE_EVENT1("electron", "WebContents::Message", "channel", channel);
-  // webContents.emit('-ipc-message', new Event(), internal, channel,
-  // arguments);
-  EmitWithSender("-ipc-message", render_frame_host,
-                 electron::mojom::ElectronApiIPC::InvokeCallback(), internal,
-                 channel, std::move(arguments));
-}
-
-void WebContents::Invoke(
-    bool internal,
-    const std::string& channel,
-    blink::CloneableMessage arguments,
-    electron::mojom::ElectronApiIPC::InvokeCallback callback,
-    content::RenderFrameHost* render_frame_host) {
-  TRACE_EVENT1("electron", "WebContents::Invoke", "channel", channel);
-  // webContents.emit('-ipc-invoke', new Event(), internal, channel, arguments);
-  EmitWithSender("-ipc-invoke", render_frame_host, std::move(callback),
-                 internal, channel, std::move(arguments));
+void WebContents::MessageHost(gin::Handle<gin_helper::internal::Event>& event,
+                              const std::string& channel,
+                              blink::CloneableMessage arguments) {
+  TRACE_EVENT1("electron", "WebContents::MessageHost", "channel", channel);
+  EmitWithoutEvent("-ipc-message-host", event, channel, std::move(arguments));
 }
 
 void WebContents::OnFirstNonEmptyLayout(
@@ -2028,73 +2011,6 @@ void WebContents::OnFirstNonEmptyLayout(
   if (render_frame_host == web_contents()->GetPrimaryMainFrame()) {
     Emit("ready-to-show");
   }
-}
-
-gin::Handle<gin_helper::internal::Event> WebContents::MakeEventWithSender(
-    v8::Isolate* isolate,
-    content::RenderFrameHost* frame,
-    electron::mojom::ElectronApiIPC::InvokeCallback callback) {
-  v8::Local<v8::Object> wrapper;
-  if (!GetWrapper(isolate).ToLocal(&wrapper)) {
-    if (callback) {
-      // We must always invoke the callback if present.
-      gin_helper::internal::ReplyChannel::Create(isolate, std::move(callback))
-          ->SendError("WebContents was destroyed");
-    }
-    return {};
-  }
-  gin::Handle<gin_helper::internal::Event> event =
-      gin_helper::internal::Event::New(isolate);
-  gin_helper::Dictionary dict(isolate, event.ToV8().As<v8::Object>());
-  dict.Set("type", "frame");
-  if (callback)
-    dict.Set("_replyChannel", gin_helper::internal::ReplyChannel::Create(
-                                  isolate, std::move(callback)));
-  if (frame) {
-    dict.SetGetter("senderFrame", frame);
-    dict.Set("frameId", frame->GetRoutingID());
-    dict.Set("processId", frame->GetProcess()->GetID().GetUnsafeValue());
-    dict.Set("frameTreeNodeId", frame->GetFrameTreeNodeId());
-  }
-  return event;
-}
-
-void WebContents::ReceivePostMessage(
-    const std::string& channel,
-    blink::TransferableMessage message,
-    content::RenderFrameHost* render_frame_host) {
-  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-  v8::HandleScope handle_scope(isolate);
-  auto wrapped_ports =
-      MessagePort::EntanglePorts(isolate, std::move(message.ports));
-  v8::Local<v8::Value> message_value =
-      electron::DeserializeV8Value(isolate, message);
-  EmitWithSender("-ipc-ports", render_frame_host,
-                 electron::mojom::ElectronApiIPC::InvokeCallback(), false,
-                 channel, message_value, std::move(wrapped_ports));
-}
-
-void WebContents::MessageSync(
-    bool internal,
-    const std::string& channel,
-    blink::CloneableMessage arguments,
-    electron::mojom::ElectronApiIPC::MessageSyncCallback callback,
-    content::RenderFrameHost* render_frame_host) {
-  TRACE_EVENT1("electron", "WebContents::MessageSync", "channel", channel);
-  // webContents.emit('-ipc-message-sync', new Event(sender, message), internal,
-  // channel, arguments);
-  EmitWithSender("-ipc-message-sync", render_frame_host, std::move(callback),
-                 internal, channel, std::move(arguments));
-}
-
-void WebContents::MessageHost(const std::string& channel,
-                              blink::CloneableMessage arguments,
-                              content::RenderFrameHost* render_frame_host) {
-  TRACE_EVENT1("electron", "WebContents::MessageHost", "channel", channel);
-  // webContents.emit('ipc-message-host', new Event(), channel, args);
-  EmitWithSender("ipc-message-host", render_frame_host,
-                 electron::mojom::ElectronApiIPC::InvokeCallback(), channel,
-                 std::move(arguments));
 }
 
 void WebContents::DraggableRegionsChanged(

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1999,13 +1999,6 @@ bool WebContents::EmitNavigationEvent(
   return event->GetDefaultPrevented();
 }
 
-void WebContents::MessageHost(gin::Handle<gin_helper::internal::Event>& event,
-                              const std::string& channel,
-                              blink::CloneableMessage arguments) {
-  TRACE_EVENT1("electron", "WebContents::MessageHost", "channel", channel);
-  EmitWithoutEvent("-ipc-message-host", event, channel, std::move(arguments));
-}
-
 void WebContents::OnFirstNonEmptyLayout(
     content::RenderFrameHost* render_frame_host) {
   if (render_frame_host == web_contents()->GetPrimaryMainFrame()) {

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -392,9 +392,6 @@ class WebContents final : public ExclusiveAccessContext,
 
   bool EmitNavigationEvent(const std::string& event,
                            content::NavigationHandle* navigation_handle);
-  void MessageHost(gin::Handle<gin_helper::internal::Event>& event,
-                   const std::string& channel,
-                   blink::CloneableMessage arguments);
 
   WebContents* embedder() { return embedder_; }
 

--- a/shell/browser/api/ipc_dispatcher.h
+++ b/shell/browser/api/ipc_dispatcher.h
@@ -35,15 +35,8 @@ class IpcDispatcher {
 
   void Invoke(gin::Handle<gin_helper::internal::Event>& event,
               const std::string& channel,
-              blink::CloneableMessage arguments,
-              electron::mojom::ElectronApiIPC::InvokeCallback callback) {
-    TRACE_EVENT1("electron", "IpcHelper::Invoke", "channel", channel);
-
-    v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
-    gin_helper::Dictionary dict(isolate, event.ToV8().As<v8::Object>());
-    dict.Set("_replyChannel", gin_helper::internal::ReplyChannel::Create(
-                                  isolate, std::move(callback)));
-
+              blink::CloneableMessage arguments) {
+    TRACE_EVENT1("electron", "IpcDispatcher::Invoke", "channel", channel);
     emitter()->EmitWithoutEvent("-ipc-invoke", event, channel,
                                 std::move(arguments));
   }
@@ -51,6 +44,8 @@ class IpcDispatcher {
   void ReceivePostMessage(gin::Handle<gin_helper::internal::Event>& event,
                           const std::string& channel,
                           blink::TransferableMessage message) {
+    TRACE_EVENT1("electron", "IpcDispatcher::ReceivePostMessage", "channel",
+                 channel);
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
     v8::HandleScope handle_scope(isolate);
     auto wrapped_ports =
@@ -61,18 +56,10 @@ class IpcDispatcher {
                                 std::move(wrapped_ports));
   }
 
-  void MessageSync(
-      gin::Handle<gin_helper::internal::Event>& event,
-      const std::string& channel,
-      blink::CloneableMessage arguments,
-      electron::mojom::ElectronApiIPC::MessageSyncCallback callback) {
-    TRACE_EVENT1("electron", "IpcHelper::MessageSync", "channel", channel);
-
-    v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
-    gin_helper::Dictionary dict(isolate, event.ToV8().As<v8::Object>());
-    dict.Set("_replyChannel", gin_helper::internal::ReplyChannel::Create(
-                                  isolate, std::move(callback)));
-
+  void MessageSync(gin::Handle<gin_helper::internal::Event>& event,
+                   const std::string& channel,
+                   blink::CloneableMessage arguments) {
+    TRACE_EVENT1("electron", "IpcDispatcher::MessageSync", "channel", channel);
     emitter()->EmitWithoutEvent("-ipc-message-sync", event, channel,
                                 std::move(arguments));
   }

--- a/shell/browser/api/ipc_dispatcher.h
+++ b/shell/browser/api/ipc_dispatcher.h
@@ -64,6 +64,14 @@ class IpcDispatcher {
                                 std::move(arguments));
   }
 
+  void MessageHost(gin::Handle<gin_helper::internal::Event>& event,
+                   const std::string& channel,
+                   blink::CloneableMessage arguments) {
+    TRACE_EVENT1("electron", "IpcDispatcher::MessageHost", "channel", channel);
+    emitter()->EmitWithoutEvent("-ipc-message-host", event, channel,
+                                std::move(arguments));
+  }
+
  private:
   inline T* emitter() {
     // T must inherit from gin_helper::EventEmitterMixin<T>

--- a/shell/browser/electron_api_ipc_handler_impl.cc
+++ b/shell/browser/electron_api_ipc_handler_impl.cc
@@ -8,7 +8,12 @@
 
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_process_host.h"
+#include "gin/handle.h"
 #include "mojo/public/cpp/bindings/self_owned_receiver.h"
+#include "shell/browser/api/electron_api_session.h"
+#include "shell/common/gin_converters/content_converter.h"
+#include "shell/common/gin_converters/frame_converter.h"
+#include "shell/common/gin_helper/event.h"
 
 namespace electron {
 ElectronApiIPCHandlerImpl::ElectronApiIPCHandlerImpl(
@@ -38,55 +43,127 @@ void ElectronApiIPCHandlerImpl::OnConnectionError() {
 void ElectronApiIPCHandlerImpl::Message(bool internal,
                                         const std::string& channel,
                                         blink::CloneableMessage arguments) {
-  api::WebContents* api_web_contents = api::WebContents::From(web_contents());
-  if (api_web_contents) {
-    api_web_contents->Message(internal, channel, std::move(arguments),
-                              GetRenderFrameHost());
-  }
+  auto* session = GetSession();
+  v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+  auto event = MakeIPCEvent(isolate, session, internal);
+  if (event.IsEmpty())
+    return;
+  session->Message(event, channel, std::move(arguments));
 }
 void ElectronApiIPCHandlerImpl::Invoke(bool internal,
                                        const std::string& channel,
                                        blink::CloneableMessage arguments,
                                        InvokeCallback callback) {
-  api::WebContents* api_web_contents = api::WebContents::From(web_contents());
-  if (api_web_contents) {
-    api_web_contents->Invoke(internal, channel, std::move(arguments),
-                             std::move(callback), GetRenderFrameHost());
-  }
+  auto* session = GetSession();
+  v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+  auto event = MakeIPCEvent(isolate, session, internal, std::move(callback));
+  if (event.IsEmpty())
+    return;
+  session->Invoke(event, channel, std::move(arguments));
 }
 
 void ElectronApiIPCHandlerImpl::ReceivePostMessage(
     const std::string& channel,
     blink::TransferableMessage message) {
-  api::WebContents* api_web_contents = api::WebContents::From(web_contents());
-  if (api_web_contents) {
-    api_web_contents->ReceivePostMessage(channel, std::move(message),
-                                         GetRenderFrameHost());
-  }
+  auto* session = GetSession();
+  v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+  auto event = MakeIPCEvent(isolate, session, false);
+  if (event.IsEmpty())
+    return;
+  session->ReceivePostMessage(event, channel, std::move(message));
 }
 
 void ElectronApiIPCHandlerImpl::MessageSync(bool internal,
                                             const std::string& channel,
                                             blink::CloneableMessage arguments,
                                             MessageSyncCallback callback) {
-  api::WebContents* api_web_contents = api::WebContents::From(web_contents());
-  if (api_web_contents) {
-    api_web_contents->MessageSync(internal, channel, std::move(arguments),
-                                  std::move(callback), GetRenderFrameHost());
-  }
+  auto* session = GetSession();
+  v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+  auto event = MakeIPCEvent(isolate, session, internal, std::move(callback));
+  if (event.IsEmpty())
+    return;
+  session->MessageSync(event, channel, std::move(arguments));
 }
 
 void ElectronApiIPCHandlerImpl::MessageHost(const std::string& channel,
                                             blink::CloneableMessage arguments) {
+  auto* session = GetSession();
+  v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+  auto event = MakeIPCEvent(isolate, session, false);
+  if (event.IsEmpty())
+    return;
   api::WebContents* api_web_contents = api::WebContents::From(web_contents());
-  if (api_web_contents) {
-    api_web_contents->MessageHost(channel, std::move(arguments),
-                                  GetRenderFrameHost());
-  }
+  api_web_contents->MessageHost(event, channel, std::move(arguments));
 }
 
 content::RenderFrameHost* ElectronApiIPCHandlerImpl::GetRenderFrameHost() {
   return content::RenderFrameHost::FromID(render_frame_host_id_);
+}
+
+api::Session* ElectronApiIPCHandlerImpl::GetSession() {
+  auto* rfh = GetRenderFrameHost();
+  return rfh ? api::Session::FromBrowserContext(rfh->GetBrowserContext())
+             : nullptr;
+}
+
+gin::Handle<gin_helper::internal::Event>
+ElectronApiIPCHandlerImpl::MakeIPCEvent(
+    v8::Isolate* isolate,
+    api::Session* session,
+    bool internal,
+    electron::mojom::ElectronApiIPC::InvokeCallback callback) {
+  if (!session) {
+    if (callback) {
+      // We must always invoke the callback if present.
+      gin_helper::internal::ReplyChannel::Create(isolate, std::move(callback))
+          ->SendError("Session does not exist");
+    }
+    return {};
+  }
+
+  api::WebContents* api_web_contents = api::WebContents::From(web_contents());
+  if (!api_web_contents) {
+    if (callback) {
+      // We must always invoke the callback if present.
+      gin_helper::internal::ReplyChannel::Create(isolate, std::move(callback))
+          ->SendError("WebContents does not exist");
+    }
+    return {};
+  }
+
+  v8::Local<v8::Object> wrapper;
+  if (!api_web_contents->GetWrapper(isolate).ToLocal(&wrapper)) {
+    if (callback) {
+      // We must always invoke the callback if present.
+      gin_helper::internal::ReplyChannel::Create(isolate, std::move(callback))
+          ->SendError("WebContents was destroyed");
+    }
+    return {};
+  }
+
+  content::RenderFrameHost* frame = GetRenderFrameHost();
+  gin::Handle<gin_helper::internal::Event> event =
+      gin_helper::internal::Event::New(isolate);
+  gin_helper::Dictionary dict(isolate, event.ToV8().As<v8::Object>());
+  dict.Set("type", "frame");
+  dict.Set("sender", web_contents());
+  if (internal)
+    dict.SetHidden("internal", internal);
+  if (callback)
+    dict.Set("_replyChannel", gin_helper::internal::ReplyChannel::Create(
+                                  isolate, std::move(callback)));
+  if (frame) {
+    dict.SetGetter("senderFrame", frame);
+    dict.Set("frameId", frame->GetRoutingID());
+    dict.Set("processId", frame->GetProcess()->GetID().GetUnsafeValue());
+    dict.Set("frameTreeNodeId", frame->GetFrameTreeNodeId());
+  }
+  return event;
 }
 
 // static

--- a/shell/browser/electron_api_ipc_handler_impl.cc
+++ b/shell/browser/electron_api_ipc_handler_impl.cc
@@ -97,8 +97,7 @@ void ElectronApiIPCHandlerImpl::MessageHost(const std::string& channel,
   auto event = MakeIPCEvent(isolate, session, false);
   if (event.IsEmpty())
     return;
-  api::WebContents* api_web_contents = api::WebContents::From(web_contents());
-  api_web_contents->MessageHost(event, channel, std::move(arguments));
+  session->MessageHost(event, channel, std::move(arguments));
 }
 
 content::RenderFrameHost* ElectronApiIPCHandlerImpl::GetRenderFrameHost() {

--- a/shell/browser/electron_api_ipc_handler_impl.h
+++ b/shell/browser/electron_api_ipc_handler_impl.h
@@ -65,6 +65,14 @@ class ElectronApiIPCHandlerImpl : public mojom::ElectronApiIPC,
   void OnConnectionError();
 
   content::RenderFrameHost* GetRenderFrameHost();
+  api::Session* GetSession();
+
+  gin::Handle<gin_helper::internal::Event> MakeIPCEvent(
+      v8::Isolate* isolate,
+      api::Session* session,
+      bool internal,
+      electron::mojom::ElectronApiIPC::InvokeCallback callback =
+          electron::mojom::ElectronApiIPC::InvokeCallback());
 
   content::GlobalRenderFrameHostId render_frame_host_id_;
 

--- a/shell/browser/electron_api_sw_ipc_handler_impl.h
+++ b/shell/browser/electron_api_sw_ipc_handler_impl.h
@@ -70,8 +70,12 @@ class ElectronApiSWIPCHandlerImpl : public mojom::ElectronApiIPC,
   ElectronBrowserContext* GetBrowserContext();
   api::Session* GetSession();
 
-  gin::Handle<gin_helper::internal::Event> MakeIPCEvent(v8::Isolate* isolate,
-                                                        bool internal);
+  gin::Handle<gin_helper::internal::Event> MakeIPCEvent(
+      v8::Isolate* isolate,
+      api::Session* session,
+      bool internal,
+      electron::mojom::ElectronApiIPC::InvokeCallback callback =
+          electron::mojom::ElectronApiIPC::InvokeCallback());
 
   // content::RenderProcessHostObserver
   void RenderProcessExited(


### PR DESCRIPTION
#### Description of Change

When an IPC is received from a service worker (https://github.com/electron/electron/pull/44411), an event object is created and then dispatched from the associated `Session`. These changes follow the same path for IPC from render frames.

- Internal IPC event listeners now scale with `# of Sessions` instead of `# of WebContents`
- Reduces size of `electron_api_web_contents.cc` and `web-contents.ts` by splitting up IPC code
- Unifies JS dispatch of frame and service worker IPC
- Assigns `event.sender` from native code
- Renames `ipc-message-host` event to `-ipc-message-host`
  - This was undocumented so the `-` is added to indicate its internal usage

##### Before
```mermaid
flowchart TD
  IsolatedWorld[Isolated World / Frame] --> IPCSend;

  IPCSend["ipcRenderer.send(channel,&nbsp;...)"] --> IPCRenderFrame;

  IPCRenderFrame -->|renderer to main| ElectronApiIPCHandlerImpl;
  ElectronApiIPCHandlerImpl --> WebContents;
  WebContents --> WebContentsIPC["webContents.ipc"];
  WebContents --> WebFrameMain["frame.ipc"];
  WebContents --> IPCMain["ipcMain"];
```

##### After
```mermaid
flowchart TD
  IsolatedWorld[Isolated World / Frame] --> IPCSend;

  IPCSend["ipcRenderer.send(channel,&nbsp;...)"] --> IPCRenderFrame;

  IPCRenderFrame -->|renderer to main| ElectronApiIPCHandlerImpl;
  ElectronApiIPCHandlerImpl --> Session;
  Session --> WebContents["webContents.ipc"];
  Session --> WebFrameMain["frame.ipc"];
  Session --> IPCMain["ipcMain"];

  classDef proposed fill:darkgreen;
  class Session proposed;
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: no-notes
