### PR TITLE
test: dump Electron process PID to path if environment variable set

### DIFF
--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -164,6 +164,9 @@ async function asyncSpawn (exe, runnerArgs) {
     const child = childProcess.spawn(exe, runnerArgs, {
       cwd: path.resolve(__dirname, '../..')
     });
+    if (process.env.ELECTRON_TEST_PID_DUMP_PATH && child.pid) {
+      fs.writeFileSync(process.env.ELECTRON_TEST_PID_DUMP_PATH, child.pid.toString());
+    }
     child.stdout.pipe(process.stdout);
     child.stderr.pipe(process.stderr);
     if (process.env.ELECTRON_FORCE_TEST_SUITE_EXIT) {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Tiny change in service of making it easier to attach a native debugger to the Electron test process, e.g. `ELECTRON_TEST_PID_DUMP_PATH=/foo/bar e test --wait-for-debugger`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
