### PR TITLE
refactor: only pass `v8::Context` to `gin_helper::MicrotasksScope` constructor

### DIFF
--- a/shell/browser/api/electron_api_auto_updater.cc
+++ b/shell/browser/api/electron_api_auto_updater.cc
@@ -47,8 +47,8 @@ void AutoUpdater::OnError(const std::string& message) {
     };
 
     gin_helper::MicrotasksScope microtasks_scope{
-        isolate, wrapper->GetCreationContextChecked()->GetMicrotaskQueue(),
-        true, v8::MicrotasksScope::kRunMicrotasks};
+        wrapper->GetCreationContextChecked(), true,
+        v8::MicrotasksScope::kRunMicrotasks};
 
     node::MakeCallback(isolate, wrapper, "emit", args.size(), args.data(),
                        {0, 0});

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -240,8 +240,7 @@ void ElectronBindings::DidReceiveMemoryDump(
   v8::Local<v8::Context> local_context =
       v8::Local<v8::Context>::New(isolate, context);
   gin_helper::MicrotasksScope microtasks_scope{
-      isolate, local_context->GetMicrotaskQueue(), true,
-      v8::MicrotasksScope::kRunMicrotasks};
+      local_context, true, v8::MicrotasksScope::kRunMicrotasks};
   v8::Context::Scope context_scope(local_context);
 
   if (!success) {

--- a/shell/common/gin_helper/callback.h
+++ b/shell/common/gin_helper/callback.h
@@ -51,8 +51,7 @@ struct V8FunctionInvoker<v8::Local<v8::Value>(ArgTypes...)> {
     v8::Local<v8::Function> holder = function.NewHandle(isolate);
     v8::Local<v8::Context> context = holder->GetCreationContextChecked();
     gin_helper::MicrotasksScope microtasks_scope{
-        isolate, context->GetMicrotaskQueue(), true,
-        v8::MicrotasksScope::kRunMicrotasks};
+        context, true, v8::MicrotasksScope::kRunMicrotasks};
     v8::Context::Scope context_scope(context);
     std::array<v8::Local<v8::Value>, sizeof...(raw)> args{
         gin::ConvertToV8(isolate, std::forward<ArgTypes>(raw))...};
@@ -77,8 +76,7 @@ struct V8FunctionInvoker<void(ArgTypes...)> {
     v8::Local<v8::Function> holder = function.NewHandle(isolate);
     v8::Local<v8::Context> context = holder->GetCreationContextChecked();
     gin_helper::MicrotasksScope microtasks_scope{
-        isolate, context->GetMicrotaskQueue(), true,
-        v8::MicrotasksScope::kRunMicrotasks};
+        context, true, v8::MicrotasksScope::kRunMicrotasks};
     v8::Context::Scope context_scope(context);
     std::array<v8::Local<v8::Value>, sizeof...(raw)> args{
         gin::ConvertToV8(isolate, std::forward<ArgTypes>(raw))...};
@@ -102,8 +100,7 @@ struct V8FunctionInvoker<ReturnType(ArgTypes...)> {
     v8::Local<v8::Function> holder = function.NewHandle(isolate);
     v8::Local<v8::Context> context = holder->GetCreationContextChecked();
     gin_helper::MicrotasksScope microtasks_scope{
-        isolate, context->GetMicrotaskQueue(), true,
-        v8::MicrotasksScope::kRunMicrotasks};
+        context, true, v8::MicrotasksScope::kRunMicrotasks};
     v8::Context::Scope context_scope(context);
     std::array<v8::Local<v8::Value>, sizeof...(raw)> args{
         gin::ConvertToV8(isolate, std::forward<ArgTypes>(raw))...};

--- a/shell/common/gin_helper/event_emitter_caller.cc
+++ b/shell/common/gin_helper/event_emitter_caller.cc
@@ -25,7 +25,7 @@ v8::Local<v8::Value> CallMethodWithArgs(
 
   // Perform microtask checkpoint after running JavaScript.
   gin_helper::MicrotasksScope microtasks_scope{
-      isolate, obj->GetCreationContextChecked()->GetMicrotaskQueue(), true,
+      obj->GetCreationContextChecked(), true,
       v8::MicrotasksScope::kRunMicrotasks};
 
   // node::MakeCallback will also run pending tasks in Node.js.

--- a/shell/common/gin_helper/function_template.h
+++ b/shell/common/gin_helper/function_template.h
@@ -268,8 +268,7 @@ class Invoker<std::index_sequence<indices...>, ArgTypes...>
   void DispatchToCallback(
       base::RepeatingCallback<ReturnType(ArgTypes...)> callback) {
     gin_helper::MicrotasksScope microtasks_scope{
-        args_->isolate(),
-        args_->GetHolderCreationContext()->GetMicrotaskQueue(), true,
+        args_->GetHolderCreationContext(), true,
         v8::MicrotasksScope::kRunMicrotasks};
     args_->Return(
         callback.Run(std::move(ArgumentHolder<indices, ArgTypes>::value)...));
@@ -280,8 +279,7 @@ class Invoker<std::index_sequence<indices...>, ArgTypes...>
   // that have the void return type.
   void DispatchToCallback(base::RepeatingCallback<void(ArgTypes...)> callback) {
     gin_helper::MicrotasksScope microtasks_scope{
-        args_->isolate(),
-        args_->GetHolderCreationContext()->GetMicrotaskQueue(), true,
+        args_->GetHolderCreationContext(), true,
         v8::MicrotasksScope::kRunMicrotasks};
     callback.Run(std::move(ArgumentHolder<indices, ArgTypes>::value)...);
   }

--- a/shell/common/gin_helper/microtasks_scope.cc
+++ b/shell/common/gin_helper/microtasks_scope.cc
@@ -5,13 +5,15 @@
 #include "shell/common/gin_helper/microtasks_scope.h"
 
 #include "shell/common/process_util.h"
+#include "v8/include/v8-context.h"
 
 namespace gin_helper {
 
-MicrotasksScope::MicrotasksScope(v8::Isolate* isolate,
-                                 v8::MicrotaskQueue* microtask_queue,
+MicrotasksScope::MicrotasksScope(v8::Local<v8::Context> context,
                                  bool ignore_browser_checkpoint,
                                  v8::MicrotasksScope::Type scope_type) {
+  auto* isolate = context->GetIsolate();
+  auto* microtask_queue = context->GetMicrotaskQueue();
   if (electron::IsBrowserProcess()) {
     if (!ignore_browser_checkpoint)
       v8::MicrotasksScope::PerformCheckpoint(isolate);

--- a/shell/common/gin_helper/microtasks_scope.h
+++ b/shell/common/gin_helper/microtasks_scope.h
@@ -16,8 +16,7 @@ namespace gin_helper {
 // In the render process creates a v8::MicrotasksScope.
 class MicrotasksScope {
  public:
-  MicrotasksScope(v8::Isolate* isolate,
-                  v8::MicrotaskQueue* microtask_queue,
+  MicrotasksScope(v8::Local<v8::Context> context,
                   bool ignore_browser_checkpoint,
                   v8::MicrotasksScope::Type scope_type);
   ~MicrotasksScope();

--- a/shell/common/gin_helper/promise.cc
+++ b/shell/common/gin_helper/promise.cc
@@ -17,8 +17,7 @@ namespace gin_helper {
 PromiseBase::SettleScope::SettleScope(const PromiseBase& base)
     : handle_scope_{base.isolate()},
       context_{base.GetContext()},
-      microtasks_scope_{base.isolate(), context_->GetMicrotaskQueue(), false,
-                        v8::MicrotasksScope::kRunMicrotasks},
+      microtasks_scope_{context_, false, v8::MicrotasksScope::kRunMicrotasks},
       context_scope_{context_} {}
 
 PromiseBase::SettleScope::~SettleScope() = default;

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -288,8 +288,7 @@ void ErrorMessageListener(v8::Local<v8::Message> message,
   node::Environment* env = node::Environment::GetCurrent(isolate);
   if (env) {
     gin_helper::MicrotasksScope microtasks_scope(
-        isolate, env->context()->GetMicrotaskQueue(), false,
-        v8::MicrotasksScope::kDoNotRunMicrotasks);
+        env->context(), false, v8::MicrotasksScope::kDoNotRunMicrotasks);
     // Emit the after() hooks now that the exception has been handled.
     // Analogous to node/lib/internal/process/execution.js#L176-L180
     if (env->async_hooks()->fields()[node::AsyncHooks::kAfter]) {

--- a/shell/common/v8_util.cc
+++ b/shell/common/v8_util.cc
@@ -36,7 +36,7 @@ class V8Serializer : public v8::ValueSerializer::Delegate {
 
   bool Serialize(v8::Local<v8::Value> value, blink::CloneableMessage* out) {
     gin_helper::MicrotasksScope microtasks_scope{
-        isolate_, isolate_->GetCurrentContext()->GetMicrotaskQueue(), false,
+        isolate_->GetCurrentContext(), false,
         v8::MicrotasksScope::kDoNotRunMicrotasks};
     WriteBlinkEnvelope(19);
 

--- a/shell/renderer/api/electron_api_spell_check_client.cc
+++ b/shell/renderer/api/electron_api_spell_check_client.cc
@@ -217,8 +217,7 @@ void SpellCheckClient::SpellCheckWords(const SpellCheckScope& scope,
 
   auto context = isolate_->GetCurrentContext();
   gin_helper::MicrotasksScope microtasks_scope{
-      isolate_, context->GetMicrotaskQueue(), false,
-      v8::MicrotasksScope::kDoNotRunMicrotasks};
+      context, false, v8::MicrotasksScope::kDoNotRunMicrotasks};
 
   v8::Local<v8::FunctionTemplate> templ = gin_helper::CreateFunctionTemplate(
       isolate_, base::BindRepeating(&SpellCheckClient::OnSpellCheckDone,

--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -81,8 +81,7 @@ void ElectronRenderFrameObserver::DidClearWindowObject() {
     v8::HandleScope handle_scope{isolate};
     v8::Local<v8::Context> context = web_frame->MainWorldScriptContext();
     v8::MicrotasksScope microtasks_scope(
-        isolate, context->GetMicrotaskQueue(),
-        v8::MicrotasksScope::kDoNotRunMicrotasks);
+        context, v8::MicrotasksScope::kDoNotRunMicrotasks);
     v8::Context::Scope context_scope(context);
     // DidClearWindowObject only emits for the main world.
     DidInstallConditionalFeatures(context, MAIN_WORLD_ID);
@@ -123,10 +122,8 @@ void ElectronRenderFrameObserver::DidInstallConditionalFeatures(
   }
   has_delayed_node_initialization_ = false;
 
-  auto* isolate = context->GetIsolate();
   v8::MicrotasksScope microtasks_scope(
-      isolate, context->GetMicrotaskQueue(),
-      v8::MicrotasksScope::kDoNotRunMicrotasks);
+      context, v8::MicrotasksScope::kDoNotRunMicrotasks);
 
   if (ShouldNotifyClient(world_id))
     renderer_client_->DidCreateScriptContext(context, render_frame_);

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -149,8 +149,7 @@ void ElectronSandboxedRendererClient::WillReleaseScriptContext(
 
   auto* isolate = context->GetIsolate();
   gin_helper::MicrotasksScope microtasks_scope{
-      isolate, context->GetMicrotaskQueue(), false,
-      v8::MicrotasksScope::kDoNotRunMicrotasks};
+      context, false, v8::MicrotasksScope::kDoNotRunMicrotasks};
   v8::HandleScope handle_scope(isolate);
   v8::Context::Scope context_scope(context);
   InvokeEmitProcessEvent(context, "exit");
@@ -168,8 +167,7 @@ void ElectronSandboxedRendererClient::EmitProcessEvent(
 
   v8::Local<v8::Context> context = GetContext(frame, isolate);
   gin_helper::MicrotasksScope microtasks_scope{
-      isolate, context->GetMicrotaskQueue(), false,
-      v8::MicrotasksScope::kDoNotRunMicrotasks};
+      context, false, v8::MicrotasksScope::kDoNotRunMicrotasks};
   v8::Context::Scope context_scope(context);
 
   InvokeEmitProcessEvent(context, event_name);

--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -49,8 +49,7 @@ void WebWorkerObserver::WorkerScriptReadyForEvaluation(
   v8::Context::Scope context_scope(worker_context);
   auto* isolate = worker_context->GetIsolate();
   v8::MicrotasksScope microtasks_scope(
-      isolate, worker_context->GetMicrotaskQueue(),
-      v8::MicrotasksScope::kDoNotRunMicrotasks);
+      worker_context, v8::MicrotasksScope::kDoNotRunMicrotasks);
 
   // Start the embed thread.
   node_bindings_->PrepareEmbedThread();


### PR DESCRIPTION
#### Description of Change
There is no need to pass both `v8::Isolate` and `v8::MicrotaskQueue` as we can get both from the `v8::Context`

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: none
