### PR TITLE
fix: RenderFrameHost nullptr dereference

### DIFF
--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -183,7 +183,7 @@ void WebFrameMain::UpdateRenderFrameHost(content::RenderFrameHost* rfh) {
 }
 
 bool WebFrameMain::CheckRenderFrame() const {
-  if (render_frame_disposed_ || render_frame_ == nullptr) {
+  if (!HasRenderFrame()) {
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
     v8::HandleScope scope(isolate);
     gin_helper::ErrorThrower(isolate).ThrowError(
@@ -435,7 +435,7 @@ v8::Local<v8::Promise> WebFrameMain::CollectDocumentJSCallStack(
   gin_helper::Promise<base::Value> promise(args->isolate());
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
-  if (render_frame_disposed_ || render_frame_ == nullptr) {
+  if (!HasRenderFrame()) {
     promise.RejectWithErrorMessage(
         "Render frame was disposed before WebFrameMain could be accessed");
     return handle;
@@ -463,7 +463,7 @@ void WebFrameMain::CollectedJavaScriptCallStack(
     gin_helper::Promise<base::Value> promise,
     const std::string& untrusted_javascript_call_stack,
     const std::optional<blink::LocalFrameToken>& remote_frame_token) {
-  if (render_frame_disposed_ || render_frame_ == nullptr) {
+  if (!HasRenderFrame()) {
     promise.RejectWithErrorMessage(
         "Render frame was disposed before call stack was received");
     return;

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -183,7 +183,7 @@ void WebFrameMain::UpdateRenderFrameHost(content::RenderFrameHost* rfh) {
 }
 
 bool WebFrameMain::CheckRenderFrame() const {
-  if (render_frame_disposed_) {
+  if (render_frame_disposed_ || render_frame_ == nullptr) {
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
     v8::HandleScope scope(isolate);
     gin_helper::ErrorThrower(isolate).ThrowError(
@@ -435,7 +435,7 @@ v8::Local<v8::Promise> WebFrameMain::CollectDocumentJSCallStack(
   gin_helper::Promise<base::Value> promise(args->isolate());
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
-  if (render_frame_disposed_) {
+  if (render_frame_disposed_ || render_frame_ == nullptr) {
     promise.RejectWithErrorMessage(
         "Render frame was disposed before WebFrameMain could be accessed");
     return handle;
@@ -463,7 +463,7 @@ void WebFrameMain::CollectedJavaScriptCallStack(
     gin_helper::Promise<base::Value> promise,
     const std::string& untrusted_javascript_call_stack,
     const std::optional<blink::LocalFrameToken>& remote_frame_token) {
-  if (render_frame_disposed_) {
+  if (render_frame_disposed_ || render_frame_ == nullptr) {
     promise.RejectWithErrorMessage(
         "Render frame was disposed before call stack was received");
     return;

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -101,8 +101,14 @@ class WebFrameMain final : public gin::Wrappable<WebFrameMain>,
   void TeardownMojoConnection();
   void OnRendererConnectionError();
 
-  // WebFrameMain can outlive its RenderFrameHost pointer so we need to check
-  // whether its been disposed of prior to accessing it.
+  [[nodiscard]] constexpr bool HasRenderFrame() const {
+    return !render_frame_disposed_ && render_frame_ != nullptr;
+  }
+
+  // Throws a JS error if HasRenderFrame() is false.
+  // WebFrameMain can outlive its RenderFrameHost pointer,
+  // so we need to check whether its been disposed of
+  // prior to accessing it.
   bool CheckRenderFrame() const;
 
   v8::Local<v8::Promise> ExecuteJavaScript(gin::Arguments* args,


### PR DESCRIPTION
#### Description of Change

Fixes #45142. This PR uses the solution suggested there by @alexi in that issue and also applies it to a couple of other potentially risky places.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed crash when accessing WebFrameMain frames and name attributes on destroyed frames.