### PR TITLE
fix: fix mksnapshot gen/v8 path

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -109,8 +109,8 @@ runs:
           cd out/Default
           powershell Expand-Archive -Path mksnapshot.zip -Destination mktmp
           powershell Copy-Item mksnapshot_args mktmp
-          powershell mkdir mktmp\gen\v8
-          powershell Copy-Item gen\v8\embedded.S mktmp\gen\v8
+          powershell mkdir mktmp\\gen\\v8
+          powershell Copy-Item gen\\v8\\embedded.S mktmp\\gen\\v8
           powershell Compress-Archive -update -Path mktmp mksnapshot.zip
         else
           (cd out/Default; zip mksnapshot.zip mksnapshot_args gen/v8/embedded.S)

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -111,7 +111,6 @@ runs:
           powershell mkdir mktmp\\gen\\v8
           powershell Copy-Item gen\\v8\\embedded.S mktmp\\gen\\v8
           powershell Compress-Archive -update -Path mktmp\\gen mksnapshot.zip
-          powershell rmdir /s mktmp
         else
           (cd out/Default; zip mksnapshot.zip mksnapshot_args gen/v8/embedded.S)
         fi

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -108,7 +108,7 @@ runs:
         if [ "${{ inputs.target-platform }}" = "win" ]; then
           cd out/Default
           powershell Compress-Archive -update mksnapshot_args mksnapshot.zip
-          powershell Compress-Archive -update gen/v8/embedded.S mksnapshot.zip
+          powershell Compress-Archive -update gen\v8\embedded.S mksnapshot.zip
         else
           (cd out/Default; zip mksnapshot.zip mksnapshot_args gen/v8/embedded.S)
         fi

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -107,11 +107,11 @@ runs:
         e build --target electron:electron_mksnapshot_zip -j $NUMBER_OF_NINJA_PROCESSES
         if [ "${{ inputs.target-platform }}" = "win" ]; then
           cd out/Default
-          powershell Expand-Archive -Path mksnapshot.zip -Destination mktmp
-          powershell Copy-Item mksnapshot_args mktmp
+          powershell Compress-Archive -update mksnapshot_args mksnapshot.zip
           powershell mkdir mktmp\\gen\\v8
           powershell Copy-Item gen\\v8\\embedded.S mktmp\\gen\\v8
-          powershell Compress-Archive -update -Path mktmp mksnapshot.zip
+          powershell Compress-Archive -update -Path mktmp\\gen mksnapshot.zip
+          powershell rmdir /s mktmp
         else
           (cd out/Default; zip mksnapshot.zip mksnapshot_args gen/v8/embedded.S)
         fi

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -107,7 +107,11 @@ runs:
         e build --target electron:electron_mksnapshot_zip -j $NUMBER_OF_NINJA_PROCESSES
         if [ "${{ inputs.target-platform }}" = "win" ]; then
           cd out/Default
-          powershell 7z a mksnapshot.zip mksnapshot_args gen\\v8\\embedded.S
+          powershell Expand-Archive -Path mksnapshot.zip -Destination mktmp
+          powershell Copy-Item mksnapshot_args mktmp
+          powershell mkdir mktmp\gen\v8
+          powershell Copy-Item gen\v8\embedded.S mktmp\gen\v8
+          powershell Compress-Archive -update -Path mktmp mksnapshot.zip
         else
           (cd out/Default; zip mksnapshot.zip mksnapshot_args gen/v8/embedded.S)
         fi

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -107,8 +107,7 @@ runs:
         e build --target electron:electron_mksnapshot_zip -j $NUMBER_OF_NINJA_PROCESSES
         if [ "${{ inputs.target-platform }}" = "win" ]; then
           cd out/Default
-          powershell Compress-Archive -update mksnapshot_args mksnapshot.zip
-          powershell Compress-Archive -update gen\v8\embedded.S mksnapshot.zip
+          powershell 7z a mksnapshot.zip mksnapshot_args gen\\v8\\embedded.S
         else
           (cd out/Default; zip mksnapshot.zip mksnapshot_args gen/v8/embedded.S)
         fi


### PR DESCRIPTION
#### Description of Change

Broken by the migration to GHA on Windows, this PR fixes the path for gen\v8\embedded.S used for mksnapshot

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed the path for a needed library used for mksnapshot
