### PR TITLE
chore: cherry-pick dd8e2822e507 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -140,3 +140,4 @@ cherry-pick-3dc17c461b12.patch
 ignore_parse_errors_for_pkey_appusermodel_toastactivatorclsid.patch
 feat_add_signals_when_embedder_cleanup_callbacks_run_for.patch
 feat_separate_content_settings_callback_for_sync_and_async_clipboard.patch
+cherry-pick-dd8e2822e507.patch

--- a/patches/chromium/cherry-pick-dd8e2822e507.patch
+++ b/patches/chromium/cherry-pick-dd8e2822e507.patch
@@ -1,0 +1,72 @@
+From dd8e2822e507a24e1dd16306dca768d29333ba02 Mon Sep 17 00:00:00 2001
+From: Patrick Meenan <pmeenan@chromium.org>
+Date: Thu, 06 Feb 2025 07:41:40 -0800
+Subject: [PATCH] Set is_web_secure_context when initializing Service Worker from disk
+
+The value of is_web_secure_context is not serialized to disk when
+storing the service worker registration (only a few select policies
+are).
+
+When instantiating the policy container for an already-registered
+worker, it uses the default value (false) which is wrong.
+
+Since Service Workers are guaranteed to ALWAYS be a web secure
+context, this change explicitly sets it to true when restoring a
+serialized policy.
+
+See: https://w3c.github.io/webappsec-secure-contexts/#examples-service-workers
+
+Bug: 387258077,383070811
+Change-Id: I75efe895662ab4e6d68cacace6d05e004c5dfd33
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6236205
+Reviewed-by: Hiroki Nakagawa <nhiroki@chromium.org>
+Reviewed-by: Dave Tapuska <dtapuska@chromium.org>
+Commit-Queue: Patrick Meenan <pmeenan@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1416795}
+---
+
+diff --git a/content/browser/renderer_host/policy_container_host.cc b/content/browser/renderer_host/policy_container_host.cc
+index 0b6509d..ad174110 100644
+--- a/content/browser/renderer_host/policy_container_host.cc
++++ b/content/browser/renderer_host/policy_container_host.cc
+@@ -143,9 +143,11 @@
+           cross_origin_isolation_enabled_by_dip) {}
+ 
+ PolicyContainerPolicies::PolicyContainerPolicies(
+-    const blink::mojom::PolicyContainerPolicies& policies)
++    const blink::mojom::PolicyContainerPolicies& policies,
++    bool is_web_secure_context)
+     : referrer_policy(policies.referrer_policy),
+       ip_address_space(policies.ip_address_space),
++      is_web_secure_context(is_web_secure_context),
+       content_security_policies(
+           mojo::Clone(policies.content_security_policies)),
+       cross_origin_embedder_policy(policies.cross_origin_embedder_policy),
+diff --git a/content/browser/renderer_host/policy_container_host.h b/content/browser/renderer_host/policy_container_host.h
+index 51d05d8..fc0ae74 100644
+--- a/content/browser/renderer_host/policy_container_host.h
++++ b/content/browser/renderer_host/policy_container_host.h
+@@ -50,7 +50,8 @@
+       bool cross_origin_isolation_enabled_by_dip);
+ 
+   explicit PolicyContainerPolicies(
+-      const blink::mojom::PolicyContainerPolicies& policies);
++      const blink::mojom::PolicyContainerPolicies& policies,
++      bool is_web_secure_context);
+ 
+   // Used when loading workers from network schemes.
+   // WARNING: This does not populate referrer policy.
+diff --git a/content/browser/service_worker/service_worker_registry.cc b/content/browser/service_worker/service_worker_registry.cc
+index aa1e8fb5..68b5c2b 100644
+--- a/content/browser/service_worker/service_worker_registry.cc
++++ b/content/browser/service_worker/service_worker_registry.cc
+@@ -1084,7 +1084,8 @@
+     if (data.policy_container_policies) {
+       version->set_policy_container_host(
+           base::MakeRefCounted<PolicyContainerHost>(
+-              PolicyContainerPolicies(*data.policy_container_policies)));
++              PolicyContainerPolicies(*data.policy_container_policies,
++                                      /*is_web_secure_context=*/true)));
+     }
+     if (data.router_rules) {
+       auto error = version->SetupRouterEvaluator(*data.router_rules);


### PR DESCRIPTION
Set is_web_secure_context when initializing Service Worker from disk

The value of is_web_secure_context is not serialized to disk when
storing the service worker registration (only a few select policies
are).

When instantiating the policy container for an already-registered
worker, it uses the default value (false) which is wrong.

Since Service Workers are guaranteed to ALWAYS be a web secure
context, this change explicitly sets it to true when restoring a
serialized policy.

See: https://w3c.github.io/webappsec-secure-contexts/#examples-service-workers

Bug: 387258077,383070811
Change-Id: I75efe895662ab4e6d68cacace6d05e004c5dfd33
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6236205
Reviewed-by: Hiroki Nakagawa <nhiroki@chromium.org>
Reviewed-by: Dave Tapuska <dtapuska@chromium.org>
Commit-Queue: Patrick Meenan <pmeenan@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1416795}


Notes: Backported fix for 387258077,383070811.