### PR TITLE
refactor: follow upstream's suggestions on when to use EmptyGURL()

### DIFF
--- a/shell/browser/api/electron_api_service_worker_main.cc
+++ b/shell/browser/api/electron_api_service_worker_main.cc
@@ -192,7 +192,7 @@ bool ServiceWorkerMain::IsDestroyed() const {
 }
 
 const blink::StorageKey ServiceWorkerMain::GetStorageKey() {
-  GURL scope = version_info_ ? version_info()->scope : GURL::EmptyGURL();
+  const GURL& scope = version_info_ ? version_info()->scope : GURL::EmptyGURL();
   return blink::StorageKey::CreateFirstParty(url::Origin::Create(scope));
 }
 
@@ -279,7 +279,7 @@ int64_t ServiceWorkerMain::VersionID() const {
 
 GURL ServiceWorkerMain::ScopeURL() const {
   if (version_destroyed_)
-    return GURL::EmptyGURL();
+    return {};
   return version_info()->scope;
 }
 

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -375,7 +375,7 @@ int WebFrameMain::RoutingID() const {
 
 GURL WebFrameMain::URL() const {
   if (!CheckRenderFrame())
-    return GURL::EmptyGURL();
+    return {};
   return render_frame_->GetLastCommittedURL();
 }
 

--- a/shell/browser/extensions/api/management/electron_management_api_delegate.cc
+++ b/shell/browser/extensions/api/management/electron_management_api_delegate.cc
@@ -214,7 +214,7 @@ GURL ElectronManagementAPIDelegate::GetEffectiveUpdateURL(
     const extensions::Extension& extension,
     content::BrowserContext* context) const {
   // TODO(codebytere): we do not currently support ExtensionManagement.
-  return GURL::EmptyGURL();
+  return {};
 }
 
 void ElectronManagementAPIDelegate::ShowMv2DeprecationReEnableDialog(


### PR DESCRIPTION
#### Description of Change

Small code cleanup to follow upstream's suggestions on when to use `GURL::EmptyGURL()` and when to use `GURL::GURL()`:

```
// Returns a reference to a singleton empty GURL. This object is for
// callers who return references but don't have anything to return in
// some cases. If you just want an empty URL for normal use, prefer
// GURL().
```

So this PR uses `GURL()` when we want a new instance of an empty URL, and uses `GURL::EmptyGURL()` when we need a reference to an empty URL.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.