### PR TITLE
fix: avoid IPC for renderer `webFrame.getZoom...` APIs

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3693,12 +3693,6 @@ void WebContents::SetTemporaryZoomLevel(double level) {
   zoom_controller_->SetTemporaryZoomLevel(level);
 }
 
-void WebContents::DoGetZoomLevel(
-    electron::mojom::ElectronWebContentsUtility::DoGetZoomLevelCallback
-        callback) {
-  std::move(callback).Run(GetZoomLevel());
-}
-
 std::optional<PreloadScript> WebContents::GetPreloadScript() const {
   if (auto* web_preferences = WebContentsPreferences::From(web_contents())) {
     if (auto preload = web_preferences->GetPreloadPath()) {

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -470,9 +470,6 @@ class WebContents final : public ExclusiveAccessContext,
   // mojom::ElectronWebContentsUtility
   void OnFirstNonEmptyLayout(content::RenderFrameHost* render_frame_host);
   void SetTemporaryZoomLevel(double level);
-  void DoGetZoomLevel(
-      electron::mojom::ElectronWebContentsUtility::DoGetZoomLevelCallback
-          callback);
 
   void SetImageAnimationPolicy(const std::string& new_policy);
 

--- a/shell/browser/electron_web_contents_utility_handler_impl.cc
+++ b/shell/browser/electron_web_contents_utility_handler_impl.cc
@@ -58,14 +58,6 @@ void ElectronWebContentsUtilityHandlerImpl::SetTemporaryZoomLevel(
   }
 }
 
-void ElectronWebContentsUtilityHandlerImpl::DoGetZoomLevel(
-    DoGetZoomLevelCallback callback) {
-  api::WebContents* api_web_contents = api::WebContents::From(web_contents());
-  if (api_web_contents) {
-    api_web_contents->DoGetZoomLevel(std::move(callback));
-  }
-}
-
 void ElectronWebContentsUtilityHandlerImpl::CanAccessClipboardDeprecated(
     mojom::PermissionName name,
     const blink::LocalFrameToken& frame_token,

--- a/shell/browser/electron_web_contents_utility_handler_impl.h
+++ b/shell/browser/electron_web_contents_utility_handler_impl.h
@@ -42,7 +42,6 @@ class ElectronWebContentsUtilityHandlerImpl
   // mojom::ElectronWebContentsUtility:
   void OnFirstNonEmptyLayout() override;
   void SetTemporaryZoomLevel(double level) override;
-  void DoGetZoomLevel(DoGetZoomLevelCallback callback) override;
   void CanAccessClipboardDeprecated(
       mojom::PermissionName name,
       const blink::LocalFrameToken& frame_token,

--- a/shell/common/web_contents_utility.mojom
+++ b/shell/common/web_contents_utility.mojom
@@ -16,9 +16,6 @@ interface ElectronWebContentsUtility {
   SetTemporaryZoomLevel(double zoom_level);
 
   [Sync]
-  DoGetZoomLevel() => (double result);
-
-  [Sync]
   CanAccessClipboardDeprecated(
       PermissionName name,
       blink.mojom.LocalFrameToken frame_token) => (blink.mojom.PermissionStatus status);

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -441,20 +441,33 @@ class WebFrameRenderer final : public gin::Wrappable<WebFrameRenderer>,
     if (!MaybeGetRenderFrame(isolate, "setZoomLevel", &render_frame))
       return;
 
+    // Update the zoom controller.
     mojo::AssociatedRemote<mojom::ElectronWebContentsUtility>
         web_contents_utility_remote;
     render_frame->GetRemoteAssociatedInterfaces()->GetInterface(
         &web_contents_utility_remote);
     web_contents_utility_remote->SetTemporaryZoomLevel(level);
+
+    // Update the local web frame for coherence with synchronous calls to
+    // |GetZoomLevel|.
+    if (blink::WebFrameWidget* web_frame =
+            render_frame->GetWebFrame()->FrameWidget()) {
+      web_frame->SetZoomLevel(level);
+    }
   }
 
   double GetZoomLevel(v8::Isolate* isolate) {
     content::RenderFrame* render_frame;
-    if (!MaybeGetRenderFrame(isolate, "getZoomLevel", &render_frame))
+    if (!MaybeGetRenderFrame(isolate, "getZoomLevel", &render_frame)) {
       return 0.0f;
+    }
 
     blink::WebFrameWidget* web_frame =
         render_frame->GetWebFrame()->FrameWidget();
+    if (!web_frame) {
+      return 0.0f;
+    }
+
     return web_frame->GetZoomLevel();
   }
 

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -449,17 +449,13 @@ class WebFrameRenderer final : public gin::Wrappable<WebFrameRenderer>,
   }
 
   double GetZoomLevel(v8::Isolate* isolate) {
-    double result = 0.0;
     content::RenderFrame* render_frame;
     if (!MaybeGetRenderFrame(isolate, "getZoomLevel", &render_frame))
-      return result;
+      return 0.0f;
 
-    mojo::AssociatedRemote<mojom::ElectronWebContentsUtility>
-        web_contents_utility_remote;
-    render_frame->GetRemoteAssociatedInterfaces()->GetInterface(
-        &web_contents_utility_remote);
-    web_contents_utility_remote->DoGetZoomLevel(&result);
-    return result;
+    blink::WebFrameWidget* web_frame =
+        render_frame->GetWebFrame()->FrameWidget();
+    return web_frame->GetZoomLevel();
   }
 
   void SetZoomFactor(gin_helper::ErrorThrower thrower, double factor) {

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -451,7 +451,7 @@ class WebFrameRenderer final : public gin::Wrappable<WebFrameRenderer>,
     // Update the local web frame for coherence with synchronous calls to
     // |GetZoomLevel|.
     if (blink::WebFrameWidget* web_frame =
-            render_frame->GetWebFrame()->FrameWidget()) {
+            render_frame->GetWebFrame()->LocalRoot()->FrameWidget()) {
       web_frame->SetZoomLevel(level);
     }
   }
@@ -463,7 +463,7 @@ class WebFrameRenderer final : public gin::Wrappable<WebFrameRenderer>,
     }
 
     blink::WebFrameWidget* web_frame =
-        render_frame->GetWebFrame()->FrameWidget();
+        render_frame->GetWebFrame()->LocalRoot()->FrameWidget();
     if (!web_frame) {
       return 0.0f;
     }

--- a/spec/api-web-frame-spec.ts
+++ b/spec/api-web-frame-spec.ts
@@ -176,15 +176,15 @@ describe('webFrame module', () => {
 
     describe('setZoomFactor()', () => {
       it('works', async () => {
-        const equal = await w.executeJavaScript('childFrame.setZoomFactor(2.0); childFrame.getZoomFactor() === 2.0');
-        expect(equal).to.be.true();
+        const zoom = await w.executeJavaScript('childFrame.setZoomFactor(2.0); childFrame.getZoomFactor()');
+        expect(zoom).to.equal(2.0);
       });
     });
 
     describe('setZoomLevel()', () => {
       it('works', async () => {
-        const equal = await w.executeJavaScript('childFrame.setZoomLevel(5); childFrame.getZoomLevel() === 5');
-        expect(equal).to.be.true();
+        const zoom = await w.executeJavaScript('childFrame.setZoomLevel(5); childFrame.getZoomLevel()');
+        expect(zoom).to.equal(5);
       });
     });
 


### PR DESCRIPTION
#### Description of Change

Calling the `getZoomLevel` method (and its related `getZoomFactor` method) of the `webFrame` Renderer module causes an IPC call to the browser process to get the zoom level. However, the renderer already must know the zoom level for rendering. We should use the local information in the renderer process instead of the expensive IPC call to the browser process.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Optimized `webFrame.getZoomLevel` and `webFrame.getZoomFactor` APIs.
