### PR TITLE
build: make sure there is at least 35GB free for source cache

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -73,10 +73,10 @@ runs:
     if: steps.check-cache.outputs.cache_exists == 'false' && inputs.use-cache  == 'true'
     shell: bash
     run: |    
-      # if there is less than 20 GB free space then creating the cache might fail so exit early
+      # if there is less than 35 GB free space then creating the cache might fail so exit early
       freespace=`df -m /mnt/cross-instance-cache | grep -w /mnt/cross-instance-cache | awk '{print $4}'`
       freespace_human=`df -h /mnt/cross-instance-cache | grep -w /mnt/cross-instance-cache | awk '{print $4}'`
-      if [ $freespace -le 20000 ]; then
+      if [ $freespace -le 35000 ]; then
         echo "The cross mount cache has $freespace_human free space which is not enough - exiting"
         exit 1
       else


### PR DESCRIPTION
#### Description of Change
As seen in https://github.com/electron/electron/actions/runs/13157928831/job/36733003034#step:4, compressed src is now 32G, so we need to update the check for free disk space for source caches.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
