### PR TITLE
fix: powerMonitor event types

### DIFF
--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -26,7 +26,8 @@ Emitted when system changes to battery power.
 
 ### Event: 'thermal-state-change' _macOS_
 
-* `state` string - The system's new thermal state. Can be `unknown`, `nominal`, `fair`, `serious`, `critical`.
+* `details` Event\<\>
+  * `state` string - The system's new thermal state. Can be `unknown`, `nominal`, `fair`, `serious`, `critical`.
 
 Emitted when the thermal state of the system changes. Notification of a change
 in the thermal status of the system, such as entering a critical temperature
@@ -44,7 +45,8 @@ See https://developer.apple.com/library/archive/documentation/Performance/Concep
 
 Returns:
 
-* `limit` number - The operating system's advertised speed limit for CPUs, in percent.
+* `details` Event\<\>
+  * `limit` number - The operating system's advertised speed limit for CPUs, in percent.
 
 Notification of a change in the operating system's advertised speed limit for
 CPUs, in percent. Values below 100 indicate that the system is impairing


### PR DESCRIPTION
#### Description of Change

powerMonitor's "speed-limit-change" and "thermal-state-change" events both return objects. However, our docs type them as parameters.

https://github.com/electron/electron/blob/4512b2b5c474f088d30cf58d798916879fac7e84/shell/browser/api/electron_api_power_monitor.cc#L115-L129

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed types for `powerMonitor`'s "speed-limit-change" and "thermal-state-change" events.
