### PR TITLE
docs: `transactions-updated` event type

### DIFF
--- a/docs/api/in-app-purchase.md
+++ b/docs/api/in-app-purchase.md
@@ -10,12 +10,12 @@ The `inAppPurchase` module emits the following events:
 
 ### Event: 'transactions-updated'
 
-Emitted when one or more transactions have been updated.
-
 Returns:
 
 * `event` Event
 * `transactions` Transaction[] - Array of [`Transaction`](structures/transaction.md) objects.
+
+Emitted when one or more transactions have been updated.
 
 ## Methods
 


### PR DESCRIPTION
#### Description of Change

The description of the `transactions-updated` event is not in the order expected by the docs parser, which generates type information. Reordering the description after the type information fixes the generated types.

Fixes #45140

#### Release Notes

Notes: none