### PR TITLE
chore: clean up web secure context patch

### DIFF
--- a/patches/chromium/cherry-pick-dd8e2822e507.patch
+++ b/patches/chromium/cherry-pick-dd8e2822e507.patch
@@ -1,7 +1,7 @@
-From dd8e2822e507a24e1dd16306dca768d29333ba02 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Patrick Meenan <pmeenan@chromium.org>
-Date: Thu, 06 Feb 2025 07:41:40 -0800
-Subject: [PATCH] Set is_web_secure_context when initializing Service Worker from disk
+Date: Thu, 6 Feb 2025 07:41:40 -0800
+Subject: Set is_web_secure_context when initializing Service Worker from disk
 
 The value of is_web_secure_context is not serialized to disk when
 storing the service worker registration (only a few select policies
@@ -23,14 +23,13 @@ Reviewed-by: Hiroki Nakagawa <nhiroki@chromium.org>
 Reviewed-by: Dave Tapuska <dtapuska@chromium.org>
 Commit-Queue: Patrick Meenan <pmeenan@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#1416795}
----
 
 diff --git a/content/browser/renderer_host/policy_container_host.cc b/content/browser/renderer_host/policy_container_host.cc
-index 0b6509d..ad174110 100644
+index b17c33c425da7bc98a6669c6595a7e6185a96644..9630f39ee4570d084c877f69658534affef226d2 100644
 --- a/content/browser/renderer_host/policy_container_host.cc
 +++ b/content/browser/renderer_host/policy_container_host.cc
-@@ -143,9 +143,11 @@
-           cross_origin_isolation_enabled_by_dip) {}
+@@ -135,9 +135,11 @@ PolicyContainerPolicies::PolicyContainerPolicies(
+       allow_cross_origin_isolation(allow_cross_origin_isolation) {}
  
  PolicyContainerPolicies::PolicyContainerPolicies(
 -    const blink::mojom::PolicyContainerPolicies& policies)
@@ -43,11 +42,11 @@ index 0b6509d..ad174110 100644
            mojo::Clone(policies.content_security_policies)),
        cross_origin_embedder_policy(policies.cross_origin_embedder_policy),
 diff --git a/content/browser/renderer_host/policy_container_host.h b/content/browser/renderer_host/policy_container_host.h
-index 51d05d8..fc0ae74 100644
+index 394bd53bb5c1dfea5abe24b9047eb190884c2648..7add42348ef28079196b447feda78210815d1551 100644
 --- a/content/browser/renderer_host/policy_container_host.h
 +++ b/content/browser/renderer_host/policy_container_host.h
-@@ -50,7 +50,8 @@
-       bool cross_origin_isolation_enabled_by_dip);
+@@ -49,7 +49,8 @@ struct CONTENT_EXPORT PolicyContainerPolicies {
+       bool allow_cross_origin_isolation);
  
    explicit PolicyContainerPolicies(
 -      const blink::mojom::PolicyContainerPolicies& policies);
@@ -57,10 +56,10 @@ index 51d05d8..fc0ae74 100644
    // Used when loading workers from network schemes.
    // WARNING: This does not populate referrer policy.
 diff --git a/content/browser/service_worker/service_worker_registry.cc b/content/browser/service_worker/service_worker_registry.cc
-index aa1e8fb5..68b5c2b 100644
+index 8ce6875c21522032e8eb448338558c2a28f78613..efa037a599a38af655fd593767f35a601badd3a1 100644
 --- a/content/browser/service_worker/service_worker_registry.cc
 +++ b/content/browser/service_worker/service_worker_registry.cc
-@@ -1084,7 +1084,8 @@
+@@ -1076,7 +1076,8 @@ ServiceWorkerRegistry::GetOrCreateRegistration(
      if (data.policy_container_policies) {
        version->set_policy_container_host(
            base::MakeRefCounted<PolicyContainerHost>(
@@ -68,5 +67,5 @@ index aa1e8fb5..68b5c2b 100644
 +              PolicyContainerPolicies(*data.policy_container_policies,
 +                                      /*is_web_secure_context=*/true)));
      }
-     if (data.router_rules) {
+     if (data.router_rules && version->IsStaticRouterEnabled()) {
        auto error = version->SetupRouterEvaluator(*data.router_rules);


### PR DESCRIPTION
#### Description of Change

Small quality of life PR, cleans up the patch shas for cherry-pick-dd8e2822e507.patch

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none