### PR TITLE
chore: remove var declarations from DEPS that no longer have any effect

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -74,8 +74,6 @@ vars = {
     False,
   'checkout_android_native_support':
     False,
-  'checkout_google_benchmark':
-    False,
   'checkout_clang_tidy':
     True,
 }

--- a/DEPS
+++ b/DEPS
@@ -62,10 +62,6 @@ vars = {
 
   'checkout_nacl':
     False,
-  'checkout_libaom':
-    True,
-  'checkout_oculus_sdk':
-    False,
   'checkout_openxr':
     False,
   'build_with_chromium':


### PR DESCRIPTION
#### Description of Change
The `checkout_google_benchmark ` var was added to `DEPS` in https://github.com/electron/electron/commit/bf6e4b1247f3a48e8926080b1852ec5d739f0888 as part of a Chromium roll 6 years ago. 

I was curious what he variable did, so I poked around in the Chromium codebase. I found that the variable stopped having any effect in https://chromium-review.googlesource.com/c/chromium/src/+/4322306 and was removed from Chromium entirely in https://chromium-review.googlesource.com/c/chromium/src/+/4339138

It seems that including it in the Electron `DEPS` now has no effect, so this PR removes it to avoid confusion.

After making this change, I decided to double check the other variables in `DEPS`, and found that two others are also no longer declared in Chromium, so presumably setting them in Electron's `DEPS` no longer has any effect.

`checkout_oculus_sdk` was removed in https://chromium-review.googlesource.com/c/chromium/src/+/2435722

`checkout_libaom` was removed in https://chromium-review.googlesource.com/c/chromium/src/+/1341968

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: no-notes
