### PR TITLE
chore: bump chromium to 134.0.6991.0

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -2,7 +2,7 @@ gclient_gn_args_from = 'src'
 
 vars = {
   'chromium_version':
-    '134.0.6990.0',
+    '134.0.6991.0',
   'node_version':
     'v22.13.1',
   'nan_version':

--- a/patches/chromium/build_do_not_depend_on_packed_resource_integrity.patch
+++ b/patches/chromium/build_do_not_depend_on_packed_resource_integrity.patch
@@ -33,10 +33,10 @@ index 66ef563af7a9698ef76ac710824234885ecb6125..e11d4f2d11a4a701c3e02719cc71d3d1
          "//base",
          "//build:branding_buildflags",
 diff --git a/chrome/browser/BUILD.gn b/chrome/browser/BUILD.gn
-index 512e796b8dd07f7d06a69d4183f915b72d3e3400..6b7118ad3e507f32d4dccd26e1dddfa06cf04819 100644
+index 50915667e6d64daea4b2ba5486192fdec63a1b93..f6122b26a50157e71418abaab70c6e9ccf83d3e0 100644
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -4531,7 +4531,7 @@ static_library("browser") {
+@@ -4526,7 +4526,7 @@ static_library("browser") {
            [ "//chrome/browser/ui/webui/signin:profile_impl" ]
      }
  
@@ -46,10 +46,10 @@ index 512e796b8dd07f7d06a69d4183f915b72d3e3400..6b7118ad3e507f32d4dccd26e1dddfa0
        # than here in :chrome_dll.
        deps += [ "//chrome:packed_resources_integrity_header" ]
 diff --git a/chrome/test/BUILD.gn b/chrome/test/BUILD.gn
-index b9c2a5301ec9ff352bb7dc22478f6bdcaf73367d..46b9c69bf798fc2628442f3ce726ff4ed5f50fec 100644
+index 98a6352af08189d7ce34ab5b010935afc3fcfa3f..2cc0a5f0909372dcf24adde2186f90a6ce5f1911 100644
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -6997,9 +6997,12 @@ test("unit_tests") {
+@@ -6996,9 +6996,12 @@ test("unit_tests") {
        "//chrome/notification_helper",
      ]
  

--- a/patches/chromium/chore_allow_chromium_to_handle_synthetic_mouse_events_for_touch.patch
+++ b/patches/chromium/chore_allow_chromium_to_handle_synthetic_mouse_events_for_touch.patch
@@ -34,10 +34,10 @@ index 932351e288f37fd09ae1a43f44e8b51fb0caa4b8..4a0616bc210d234e51e564daabdd2ebd
    // Overridden from WidgetObserver.
    void OnWidgetThemeChanged(Widget* widget) override;
 diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
-index eddd85cfcfa0ca85bfee0fab1ae217e1b567b21a..b33728cb13d07ad0805379ff2cf8f734b6cbf7cf 100644
+index 2bd015be3178ab8dea012d6b1f71d13dd0548c14..759f00dd4e674d1dfca690b82e6e1820900ebf0c 100644
 --- a/ui/views/win/hwnd_message_handler.cc
 +++ b/ui/views/win/hwnd_message_handler.cc
-@@ -3142,15 +3142,19 @@ LRESULT HWNDMessageHandler::HandleMouseEventInternal(UINT message,
+@@ -3144,15 +3144,19 @@ LRESULT HWNDMessageHandler::HandleMouseEventInternal(UINT message,
      }
      // We must let Windows handle the caption buttons if it's drawing them, or
      // they won't work.

--- a/patches/chromium/chore_provide_iswebcontentscreationoverridden_with_full_params.patch
+++ b/patches/chromium/chore_provide_iswebcontentscreationoverridden_with_full_params.patch
@@ -80,10 +80,10 @@ index 4fd8dff1089cd6afa6a66dc185734d7671657281..0a1f4268ea771a3d5d4a2668928c6e5d
        content::WebContents* source,
        const content::OpenURLParams& params,
 diff --git a/chrome/browser/ui/browser.cc b/chrome/browser/ui/browser.cc
-index 79dc99f9c0ccb87725dbad44de7f0b6de7c05ca1..cd9d136ea162efb45a69324246debf7c128bf942 100644
+index ec57ae4f06993d3e6d6330d778b0025c4bbfeda7..8a15c0365be5845c1e017f9b6869a6a4bc932147 100644
 --- a/chrome/browser/ui/browser.cc
 +++ b/chrome/browser/ui/browser.cc
-@@ -2203,12 +2203,11 @@ bool Browser::IsWebContentsCreationOverridden(
+@@ -2211,12 +2211,11 @@ bool Browser::IsWebContentsCreationOverridden(
      content::SiteInstance* source_site_instance,
      content::mojom::WindowContainerType window_container_type,
      const GURL& opener_url,

--- a/patches/chromium/enable_reset_aspect_ratio.patch
+++ b/patches/chromium/enable_reset_aspect_ratio.patch
@@ -19,7 +19,7 @@ index 88d8d9985c6b4c7051f00cba9dfa51b3fcfa524b..2d05856687cd9669f72553d33c8033fd
                                     excluded_margin);
  }
 diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
-index f2668811d73c2211d81b753d5fcc117100a95a55..2aa793660fa963b719c2d7ee71ddf4698744d34c 100644
+index b3dc46c34f2aff45b3bd8ea041f2e55ba61d50f9..a802f4b710b6f8fa154d11846c061720a91e15e4 100644
 --- a/ui/views/win/hwnd_message_handler.cc
 +++ b/ui/views/win/hwnd_message_handler.cc
 @@ -988,8 +988,11 @@ void HWNDMessageHandler::SetFullscreen(bool fullscreen,

--- a/patches/chromium/feat_add_set_theme_source_to_allow_apps_to.patch
+++ b/patches/chromium/feat_add_set_theme_source_to_allow_apps_to.patch
@@ -62,7 +62,7 @@ index 4e825d649919c88aad26e4c3b2fd80575ca57db0..de1d8fea0113b55065e5229b07f95d69
    SEQUENCE_CHECKER(sequence_checker_);
  };
 diff --git a/ui/native_theme/native_theme_win.cc b/ui/native_theme/native_theme_win.cc
-index f9680f5f46180313ef98df97e242f72ac3dfd0dc..5571532504b4752faad2ed5712ba1ef813e32a84 100644
+index 2b2a12cd9d1ac17a245f049cf0775b46c0596531..350586d35b29fb8d772ea70615768d0e62dc5474 100644
 --- a/ui/native_theme/native_theme_win.cc
 +++ b/ui/native_theme/native_theme_win.cc
 @@ -688,6 +688,8 @@ bool NativeThemeWin::ShouldUseDarkColors() const {

--- a/patches/chromium/feat_add_signals_when_embedder_cleanup_callbacks_run_for.patch
+++ b/patches/chromium/feat_add_signals_when_embedder_cleanup_callbacks_run_for.patch
@@ -25,10 +25,10 @@ Refs https://issues.chromium.org/issues/40210365 which is blocked
 on https://issues.chromium.org/issues/42203693
 
 diff --git a/gin/isolate_holder.cc b/gin/isolate_holder.cc
-index 2be37976a1305f1deed561b3b829dbb5d7ae85e7..44eb16f17d272125e2b4a590f8962eb8144d9755 100644
+index d1b95149ea0d16af2606900f10898a355026ffe1..fe1d866cba3b1a221092e1d6dced027894b3f3af 100644
 --- a/gin/isolate_holder.cc
 +++ b/gin/isolate_holder.cc
-@@ -34,6 +34,8 @@ v8::ArrayBuffer::Allocator* g_array_buffer_allocator = nullptr;
+@@ -35,6 +35,8 @@ v8::ArrayBuffer::Allocator* g_array_buffer_allocator = nullptr;
  const intptr_t* g_reference_table = nullptr;
  v8::FatalErrorCallback g_fatal_error_callback = nullptr;
  v8::OOMErrorCallback g_oom_error_callback = nullptr;
@@ -37,7 +37,7 @@ index 2be37976a1305f1deed561b3b829dbb5d7ae85e7..44eb16f17d272125e2b4a590f8962eb8
  
  std::unique_ptr<v8::Isolate::CreateParams> getModifiedIsolateParams(
      std::unique_ptr<v8::Isolate::CreateParams> params,
-@@ -198,10 +200,26 @@ IsolateHolder::getDefaultIsolateParams() {
+@@ -205,10 +207,26 @@ IsolateHolder::getDefaultIsolateParams() {
    return params;
  }
  
@@ -65,10 +65,10 @@ index 2be37976a1305f1deed561b3b829dbb5d7ae85e7..44eb16f17d272125e2b4a590f8962eb8
 +
  }  // namespace gin
 diff --git a/gin/public/isolate_holder.h b/gin/public/isolate_holder.h
-index 52b8c1af58678b9fee684ff75340c98fcc73b552..f79407d741a30298d09efd53589f16dc9b26107f 100644
+index dc3a5b0678b9c686e241b492e2c3b5ac833611a3..32a7ba4f557e65d9525d2ca07e8597e7bd070b12 100644
 --- a/gin/public/isolate_holder.h
 +++ b/gin/public/isolate_holder.h
-@@ -131,6 +131,8 @@ class GIN_EXPORT IsolateHolder {
+@@ -132,6 +132,8 @@ class GIN_EXPORT IsolateHolder {
    // Should only be called after v8::IsolateHolder::Initialize() is invoked.
    static std::unique_ptr<v8::Isolate::CreateParams> getDefaultIsolateParams();
  
@@ -77,7 +77,7 @@ index 52b8c1af58678b9fee684ff75340c98fcc73b552..f79407d741a30298d09efd53589f16dc
    v8::Isolate* isolate() { return isolate_; }
  
    // This method returns if v8::Locker is needed to access isolate.
-@@ -144,6 +146,9 @@ class GIN_EXPORT IsolateHolder {
+@@ -145,6 +147,9 @@ class GIN_EXPORT IsolateHolder {
  
    void EnableIdleTasks(std::unique_ptr<V8IdleTaskRunner> idle_task_runner);
  

--- a/patches/chromium/fix_activate_background_material_on_windows.patch
+++ b/patches/chromium/fix_activate_background_material_on_windows.patch
@@ -14,7 +14,7 @@ This patch likely can't be upstreamed as-is, as Chromium doesn't have
 this use case in mind currently.
 
 diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
-index 3d1397ff82803c9ba45bdcee0b2c61ab5c8049a4..1e6a6715691e07c22202d865dce89c94b3e02d76 100644
+index 9888ac709c51cd30228e3bca6915f7d89071cb83..e7b2bc1905958d2ff9c34ed7a22eb53e7ea3b9b8 100644
 --- a/ui/views/win/hwnd_message_handler.cc
 +++ b/ui/views/win/hwnd_message_handler.cc
 @@ -932,13 +932,13 @@ void HWNDMessageHandler::FrameTypeChanged() {

--- a/patches/chromium/fix_aspect_ratio_with_max_size.patch
+++ b/patches/chromium/fix_aspect_ratio_with_max_size.patch
@@ -11,10 +11,10 @@ enlarge window above dimensions set during creation of the
 BrowserWindow.
 
 diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
-index 2aa793660fa963b719c2d7ee71ddf4698744d34c..eddd85cfcfa0ca85bfee0fab1ae217e1b567b21a 100644
+index a802f4b710b6f8fa154d11846c061720a91e15e4..2bd015be3178ab8dea012d6b1f71d13dd0548c14 100644
 --- a/ui/views/win/hwnd_message_handler.cc
 +++ b/ui/views/win/hwnd_message_handler.cc
-@@ -3745,15 +3745,30 @@ void HWNDMessageHandler::SizeWindowToAspectRatio(UINT param,
+@@ -3747,15 +3747,30 @@ void HWNDMessageHandler::SizeWindowToAspectRatio(UINT param,
    delegate_->GetMinMaxSize(&min_window_size, &max_window_size);
    min_window_size = delegate_->DIPToScreenSize(min_window_size);
    max_window_size = delegate_->DIPToScreenSize(max_window_size);

--- a/patches/chromium/fix_remove_caption-removing_style_call.patch
+++ b/patches/chromium/fix_remove_caption-removing_style_call.patch
@@ -18,7 +18,7 @@ or resizing, but Electron does not seem to run into that issue
 for opaque frameless windows even with that block commented out.
 
 diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
-index b33728cb13d07ad0805379ff2cf8f734b6cbf7cf..3d1397ff82803c9ba45bdcee0b2c61ab5c8049a4 100644
+index 759f00dd4e674d1dfca690b82e6e1820900ebf0c..9888ac709c51cd30228e3bca6915f7d89071cb83 100644
 --- a/ui/views/win/hwnd_message_handler.cc
 +++ b/ui/views/win/hwnd_message_handler.cc
 @@ -1786,7 +1786,23 @@ LRESULT HWNDMessageHandler::OnCreate(CREATESTRUCT* create_struct) {

--- a/patches/chromium/gin_enable_disable_v8_platform.patch
+++ b/patches/chromium/gin_enable_disable_v8_platform.patch
@@ -7,10 +7,10 @@ We don't use gin to create the V8 platform, because we need to inject Node
 things.
 
 diff --git a/gin/isolate_holder.cc b/gin/isolate_holder.cc
-index 1ec03c80cfee5fc427fad846a4df41b98698961c..1bed0865ba952b611985d41b742274861926925d 100644
+index b3416c90c9071d8d32d30ecf257b64f133b2ae07..8632f1c18b407bb7832900bcebadacb3707224ac 100644
 --- a/gin/isolate_holder.cc
 +++ b/gin/isolate_holder.cc
-@@ -155,11 +155,13 @@ void IsolateHolder::Initialize(ScriptMode mode,
+@@ -162,11 +162,13 @@ void IsolateHolder::Initialize(ScriptMode mode,
                                 std::string js_command_line_flags,
                                 bool disallow_v8_feature_flag_overrides,
                                 v8::FatalErrorCallback fatal_error_callback,
@@ -27,10 +27,10 @@ index 1ec03c80cfee5fc427fad846a4df41b98698961c..1bed0865ba952b611985d41b74227486
    g_reference_table = reference_table;
    g_fatal_error_callback = fatal_error_callback;
 diff --git a/gin/public/isolate_holder.h b/gin/public/isolate_holder.h
-index cb4517de39b2ca7b32db557c6d3dd0227ba5b4c2..d1d178de28c7d46db1c96ba321070612ef5812e1 100644
+index ff42cfbb6a228e902317c7e3ab035d8437d5dd62..e27f177ce27e177abf6cee84cd466e7a8a829ee7 100644
 --- a/gin/public/isolate_holder.h
 +++ b/gin/public/isolate_holder.h
-@@ -118,7 +118,8 @@ class GIN_EXPORT IsolateHolder {
+@@ -119,7 +119,8 @@ class GIN_EXPORT IsolateHolder {
                           std::string js_command_line_flags = {},
                           bool disallow_v8_feature_flag_overrides = false,
                           v8::FatalErrorCallback fatal_error_callback = nullptr,

--- a/patches/chromium/isolate_holder.patch
+++ b/patches/chromium/isolate_holder.patch
@@ -15,21 +15,21 @@ for us to register the isolate in between Isolate::Allocate and
 Isolate::Initialize.
 
 diff --git a/gin/isolate_holder.cc b/gin/isolate_holder.cc
-index 1bed0865ba952b611985d41b742274861926925d..2be37976a1305f1deed561b3b829dbb5d7ae85e7 100644
+index 8632f1c18b407bb7832900bcebadacb3707224ac..d1b95149ea0d16af2606900f10898a355026ffe1 100644
 --- a/gin/isolate_holder.cc
 +++ b/gin/isolate_holder.cc
-@@ -76,7 +76,8 @@ IsolateHolder::IsolateHolder(
-     v8::CreateHistogramCallback create_histogram_callback,
+@@ -81,7 +81,8 @@ IsolateHolder::IsolateHolder(
      v8::AddHistogramSampleCallback add_histogram_sample_callback,
      scoped_refptr<base::SingleThreadTaskRunner> user_visible_task_runner,
--    scoped_refptr<base::SingleThreadTaskRunner> best_effort_task_runner)
-+    scoped_refptr<base::SingleThreadTaskRunner> best_effort_task_runner,
+     scoped_refptr<base::SingleThreadTaskRunner> best_effort_task_runner,
+-    std::unique_ptr<v8::CppHeap> cpp_heap)
++    std::unique_ptr<v8::CppHeap> cpp_heap,
 +    v8::Isolate* isolate)
      : IsolateHolder(std::move(task_runner),
                      access_mode,
                      isolate_type,
-@@ -86,7 +87,8 @@ IsolateHolder::IsolateHolder(
-                                              add_histogram_sample_callback),
+@@ -92,7 +93,8 @@ IsolateHolder::IsolateHolder(
+                                              std::move(cpp_heap)),
                      isolate_creation_mode,
                      std::move(user_visible_task_runner),
 -                    std::move(best_effort_task_runner)) {}
@@ -38,7 +38,7 @@ index 1bed0865ba952b611985d41b742274861926925d..2be37976a1305f1deed561b3b829dbb5
  
  IsolateHolder::IsolateHolder(
      scoped_refptr<base::SingleThreadTaskRunner> task_runner,
-@@ -95,7 +97,8 @@ IsolateHolder::IsolateHolder(
+@@ -101,7 +103,8 @@ IsolateHolder::IsolateHolder(
      std::unique_ptr<v8::Isolate::CreateParams> params,
      IsolateCreationMode isolate_creation_mode,
      scoped_refptr<base::SingleThreadTaskRunner> user_visible_task_runner,
@@ -48,7 +48,7 @@ index 1bed0865ba952b611985d41b742274861926925d..2be37976a1305f1deed561b3b829dbb5
      : access_mode_(access_mode), isolate_type_(isolate_type) {
    CHECK(Initialized())
        << "You need to invoke gin::IsolateHolder::Initialize first";
-@@ -106,7 +109,7 @@ IsolateHolder::IsolateHolder(
+@@ -112,7 +115,7 @@ IsolateHolder::IsolateHolder(
    v8::ArrayBuffer::Allocator* allocator = params->array_buffer_allocator;
    DCHECK(allocator);
  
@@ -58,20 +58,20 @@ index 1bed0865ba952b611985d41b742274861926925d..2be37976a1305f1deed561b3b829dbb5
        isolate_, allocator, access_mode_, task_runner,
        std::move(user_visible_task_runner), std::move(best_effort_task_runner));
 diff --git a/gin/public/isolate_holder.h b/gin/public/isolate_holder.h
-index d1d178de28c7d46db1c96ba321070612ef5812e1..52b8c1af58678b9fee684ff75340c98fcc73b552 100644
+index e27f177ce27e177abf6cee84cd466e7a8a829ee7..dc3a5b0678b9c686e241b492e2c3b5ac833611a3 100644
 --- a/gin/public/isolate_holder.h
 +++ b/gin/public/isolate_holder.h
-@@ -87,7 +87,8 @@ class GIN_EXPORT IsolateHolder {
-       scoped_refptr<base::SingleThreadTaskRunner> user_visible_task_runner =
+@@ -88,7 +88,8 @@ class GIN_EXPORT IsolateHolder {
            nullptr,
        scoped_refptr<base::SingleThreadTaskRunner> best_effort_task_runner =
--          nullptr);
-+          nullptr,
+           nullptr,
+-      std::unique_ptr<v8::CppHeap> cpp_heap = {});
++      std::unique_ptr<v8::CppHeap> cpp_heap = {},
 +      v8::Isolate* isolate = nullptr);
    IsolateHolder(
        scoped_refptr<base::SingleThreadTaskRunner> task_runner,
        AccessMode access_mode,
-@@ -97,7 +98,8 @@ class GIN_EXPORT IsolateHolder {
+@@ -98,7 +99,8 @@ class GIN_EXPORT IsolateHolder {
        scoped_refptr<base::SingleThreadTaskRunner> user_visible_task_runner =
            nullptr,
        scoped_refptr<base::SingleThreadTaskRunner> best_effort_task_runner =

--- a/patches/chromium/mas_avoid_private_macos_api_usage.patch.patch
+++ b/patches/chromium/mas_avoid_private_macos_api_usage.patch.patch
@@ -35,7 +35,7 @@ system font by checking if it's kCTFontPriorityAttribute is set to
 system priority.
 
 diff --git a/base/BUILD.gn b/base/BUILD.gn
-index a4ae9c4c242551f6850cdcbb42551b676db76c95..22281156bcfdd6999d15d511c508415f8f3f9ac7 100644
+index e73517e22d14caab93f32c7a179107fa623f9ec1..11eeb65778bb5ea5abb10249ff0a1b44a2f3326c 100644
 --- a/base/BUILD.gn
 +++ b/base/BUILD.gn
 @@ -1028,6 +1028,7 @@ component("base") {
@@ -1804,7 +1804,7 @@ index 29ae2da6a8a2c2a612dfb92f7f9c03ca5fa306b1..440c139a32a0c205e77b657d4aab6468
    // Query the display's refresh rate.
    if (@available(macos 12.0, *)) {
 diff --git a/ui/gfx/BUILD.gn b/ui/gfx/BUILD.gn
-index 6cf9f1a38ed76edc8f64500476b4b3014dc7677f..54dcf71bd0bf5a1455b31f3d042305f0fc3e345b 100644
+index 925d4f128b253d8049a3fbe3b5d3e51ff320d02b..0ae14a7ca74761c767d1e19a2f68ab956eb341d8 100644
 --- a/ui/gfx/BUILD.gn
 +++ b/ui/gfx/BUILD.gn
 @@ -331,6 +331,12 @@ component("gfx") {

--- a/patches/chromium/refactor_expose_hostimportmoduledynamically_and.patch
+++ b/patches/chromium/refactor_expose_hostimportmoduledynamically_and.patch
@@ -7,7 +7,7 @@ Subject: refactor: expose HostImportModuleDynamically and
 This is so that Electron can blend Blink's and Node's implementations of these isolate handlers.
 
 diff --git a/third_party/blink/renderer/bindings/core/v8/v8_initializer.cc b/third_party/blink/renderer/bindings/core/v8/v8_initializer.cc
-index d57eea97fcdff4c4008ea0d03259349ac27a49b8..351ea787052200013b7b14a460dc900ffae010c1 100644
+index dd13541721291278984c3d05013ca570d550f0c8..fbbd616b06d1f439ac77ea09f50217a74fa0c314 100644
 --- a/third_party/blink/renderer/bindings/core/v8/v8_initializer.cc
 +++ b/third_party/blink/renderer/bindings/core/v8/v8_initializer.cc
 @@ -634,7 +634,9 @@ bool WasmJSPromiseIntegrationEnabledCallback(v8::Local<v8::Context> context) {


### PR DESCRIPTION
Updating Chromium to 134.0.6991.0.

See [all changes in 134.0.6990.0..134.0.6991.0](https://chromium.googlesource.com/chromium/src/+log/134.0.6990.0..134.0.6991.0?n=10000&pretty=fuller)

Notes: Updated Chromium to 134.0.6991.0.