### PR TITLE
chore: bump chromium to 134.0.6992.0

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -2,7 +2,7 @@ gclient_gn_args_from = 'src'
 
 vars = {
   'chromium_version':
-    '134.0.6990.0',
+    '134.0.6992.0',
   'node_version':
     'v22.13.1',
   'nan_version':

--- a/shell/browser/browser_process_impl.h
+++ b/shell/browser/browser_process_impl.h
@@ -70,6 +70,7 @@ class BrowserProcessImpl : public BrowserProcess {
   // BrowserProcess
   BuildState* GetBuildState() override;
   GlobalFeatures* GetFeatures() override;
+  void CreateGlobalFeaturesForTesting() override {}
   void EndSession() override {}
   void FlushLocalStateAndReply(base::OnceClosure reply) override {}
   bool IsShuttingDown() override;


### PR DESCRIPTION
Updating Chromium to 134.0.6992.0.

See [all changes in 134.0.6990.0..134.0.6992.0](https://chromium.googlesource.com/chromium/src/+log/134.0.6990.0..134.0.6992.0?n=10000&pretty=fuller)

Notes: Updated Chromium to 134.0.6992.0.