### PR TITLE
feat: add menu item role `palette` and `header`

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -14,10 +14,10 @@ See [`Menu`](menu.md) for examples.
     * `menuItem` MenuItem
     * `window` [BaseWindow](base-window.md) | undefined - This will not be defined if no window is open.
     * `event` [KeyboardEvent](structures/keyboard-event.md)
-  * `role` string (optional) - Can be `undo`, `redo`, `cut`, `copy`, `paste`, `pasteAndMatchStyle`, `delete`, `selectAll`, `reload`, `forceReload`, `toggleDevTools`, `resetZoom`, `zoomIn`, `zoomOut`, `toggleSpellChecker`, `togglefullscreen`, `window`, `minimize`, `close`, `help`, `about`, `services`, `hide`, `hideOthers`, `unhide`, `quit`, `showSubstitutions`, `toggleSmartQuotes`, `toggleSmartDashes`, `toggleTextReplacement`, `startSpeaking`, `stopSpeaking`, `zoom`, `front`, `appMenu`, `fileMenu`, `editMenu`, `viewMenu`, `shareMenu`, `recentDocuments`, `toggleTabBar`, `selectNextTab`, `selectPreviousTab`, `showAllTabs`, `mergeAllWindows`, `clearRecentDocuments`, `moveTabToNewWindow`, `windowMenu`, `palette` or `header` - Define the action of the menu item, when specified the
+  * `role` string (optional) - Can be `undo`, `redo`, `cut`, `copy`, `paste`, `pasteAndMatchStyle`, `delete`, `selectAll`, `reload`, `forceReload`, `toggleDevTools`, `resetZoom`, `zoomIn`, `zoomOut`, `toggleSpellChecker`, `togglefullscreen`, `window`, `minimize`, `close`, `help`, `about`, `services`, `hide`, `hideOthers`, `unhide`, `quit`, `showSubstitutions`, `toggleSmartQuotes`, `toggleSmartDashes`, `toggleTextReplacement`, `startSpeaking`, `stopSpeaking`, `zoom`, `front`, `appMenu`, `fileMenu`, `editMenu`, `viewMenu`, `shareMenu`, `recentDocuments`, `toggleTabBar`, `selectNextTab`, `selectPreviousTab`, `showAllTabs`, `mergeAllWindows`, `clearRecentDocuments`, `moveTabToNewWindow` or `windowMenu` - Define the action of the menu item, when specified the
     `click` property will be ignored. See [roles](#roles).
-  * `type` string (optional) - Can be `normal`, `separator`, `submenu`, `checkbox` or
-    `radio`.
+  * `type` string (optional) - Can be `normal`, `separator`, `submenu`, `checkbox`,
+    `radio`, `header` or `palette`.
   * `label` string (optional)
   * `sublabel` string (optional) _macOS_ - Available in macOS >= 14.4
   * `toolTip` string (optional) _macOS_ - Hover text for this menu item.
@@ -121,8 +121,6 @@ The following additional roles are available on _macOS_:
 * `recentDocuments` - The submenu is an "Open Recent" menu.
 * `clearRecentDocuments` - Map to the `clearRecentDocuments` action.
 * `shareMenu` - The submenu is [share menu][ShareMenu]. The `sharingItem` property must also be set to indicate the item to share.
-* `palette` - The submenu has the [palette](https://developer.apple.com/documentation/appkit/nsmenu/presentationstyle-swift.enum/palette) presentation style where items to display align horizontally.
-* `header` - A section header for a logical grouping of menu commands.
 
 When specifying a `role` on macOS, `label` and `accelerator` are the only
 options that will affect the menu item. All other options will be ignored.
@@ -160,7 +158,7 @@ item's submenu, if present.
 
 #### `menuItem.type`
 
-A `string` indicating the type of the item. Can be `normal`, `separator`, `submenu`, `checkbox` or `radio`.
+A `string` indicating the type of the item. Can be `normal`, `separator`, `submenu`, `checkbox`, `radio`, `header` or `palette`.
 
 #### `menuItem.role`
 

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -16,8 +16,14 @@ See [`Menu`](menu.md) for examples.
     * `event` [KeyboardEvent](structures/keyboard-event.md)
   * `role` string (optional) - Can be `undo`, `redo`, `cut`, `copy`, `paste`, `pasteAndMatchStyle`, `delete`, `selectAll`, `reload`, `forceReload`, `toggleDevTools`, `resetZoom`, `zoomIn`, `zoomOut`, `toggleSpellChecker`, `togglefullscreen`, `window`, `minimize`, `close`, `help`, `about`, `services`, `hide`, `hideOthers`, `unhide`, `quit`, `showSubstitutions`, `toggleSmartQuotes`, `toggleSmartDashes`, `toggleTextReplacement`, `startSpeaking`, `stopSpeaking`, `zoom`, `front`, `appMenu`, `fileMenu`, `editMenu`, `viewMenu`, `shareMenu`, `recentDocuments`, `toggleTabBar`, `selectNextTab`, `selectPreviousTab`, `showAllTabs`, `mergeAllWindows`, `clearRecentDocuments`, `moveTabToNewWindow` or `windowMenu` - Define the action of the menu item, when specified the
     `click` property will be ignored. See [roles](#roles).
-  * `type` string (optional) - Can be `normal`, `separator`, `submenu`, `checkbox`,
-    `radio`, `header` or `palette`.
+  * `type` string (optional)
+    * `normal`
+    * `separator`
+    * `submenu`
+    * `checkbox`
+    * `radio`
+    * `header` - Only available on macOS 14 and up.
+    * `palette` - Only available on macOS 14 and up.
   * `label` string (optional)
   * `sublabel` string (optional) _macOS_ - Available in macOS >= 14.4
   * `toolTip` string (optional) _macOS_ - Hover text for this menu item.
@@ -159,6 +165,9 @@ item's submenu, if present.
 #### `menuItem.type`
 
 A `string` indicating the type of the item. Can be `normal`, `separator`, `submenu`, `checkbox`, `radio`, `header` or `palette`.
+
+> [!NOTE]
+> `header` and `palette` are only available on macOS 14 and up.
 
 #### `menuItem.role`
 

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -14,7 +14,7 @@ See [`Menu`](menu.md) for examples.
     * `menuItem` MenuItem
     * `window` [BaseWindow](base-window.md) | undefined - This will not be defined if no window is open.
     * `event` [KeyboardEvent](structures/keyboard-event.md)
-  * `role` string (optional) - Can be `undo`, `redo`, `cut`, `copy`, `paste`, `pasteAndMatchStyle`, `delete`, `selectAll`, `reload`, `forceReload`, `toggleDevTools`, `resetZoom`, `zoomIn`, `zoomOut`, `toggleSpellChecker`, `togglefullscreen`, `window`, `minimize`, `close`, `help`, `about`, `services`, `hide`, `hideOthers`, `unhide`, `quit`, `showSubstitutions`, `toggleSmartQuotes`, `toggleSmartDashes`, `toggleTextReplacement`, `startSpeaking`, `stopSpeaking`, `zoom`, `front`, `appMenu`, `fileMenu`, `editMenu`, `viewMenu`, `shareMenu`, `recentDocuments`, `toggleTabBar`, `selectNextTab`, `selectPreviousTab`, `showAllTabs`, `mergeAllWindows`, `clearRecentDocuments`, `moveTabToNewWindow` or `windowMenu` - Define the action of the menu item, when specified the
+  * `role` string (optional) - Can be `undo`, `redo`, `cut`, `copy`, `paste`, `pasteAndMatchStyle`, `delete`, `selectAll`, `reload`, `forceReload`, `toggleDevTools`, `resetZoom`, `zoomIn`, `zoomOut`, `toggleSpellChecker`, `togglefullscreen`, `window`, `minimize`, `close`, `help`, `about`, `services`, `hide`, `hideOthers`, `unhide`, `quit`, `showSubstitutions`, `toggleSmartQuotes`, `toggleSmartDashes`, `toggleTextReplacement`, `startSpeaking`, `stopSpeaking`, `zoom`, `front`, `appMenu`, `fileMenu`, `editMenu`, `viewMenu`, `shareMenu`, `recentDocuments`, `toggleTabBar`, `selectNextTab`, `selectPreviousTab`, `showAllTabs`, `mergeAllWindows`, `clearRecentDocuments`, `moveTabToNewWindow`, `windowMenu`, `palette` or `header` - Define the action of the menu item, when specified the
     `click` property will be ignored. See [roles](#roles).
   * `type` string (optional) - Can be `normal`, `separator`, `submenu`, `checkbox` or
     `radio`.
@@ -121,6 +121,8 @@ The following additional roles are available on _macOS_:
 * `recentDocuments` - The submenu is an "Open Recent" menu.
 * `clearRecentDocuments` - Map to the `clearRecentDocuments` action.
 * `shareMenu` - The submenu is [share menu][ShareMenu]. The `sharingItem` property must also be set to indicate the item to share.
+* `palette` - The submenu has the [palette](https://developer.apple.com/documentation/appkit/nsmenu/presentationstyle-swift.enum/palette) presentation style where items to display align horizontally.
+* `header` - A section header for a logical grouping of menu commands.
 
 When specifying a `role` on macOS, `label` and `accelerator` are the only
 options that will affect the menu item. All other options will be ignored.

--- a/lib/browser/api/menu-item-roles.ts
+++ b/lib/browser/api/menu-item-roles.ts
@@ -8,7 +8,7 @@ type RoleId = 'about' | 'close' | 'copy' | 'cut' | 'delete' | 'forcereload' | 'f
   'paste' | 'pasteandmatchstyle' | 'quit' | 'redo' | 'reload' | 'resetzoom' | 'selectall' | 'services' | 'recentdocuments' | 'clearrecentdocuments' |
   'showsubstitutions' | 'togglesmartquotes' | 'togglesmartdashes' | 'toggletextreplacement' | 'startspeaking' | 'stopspeaking' |
   'toggledevtools' | 'togglefullscreen' | 'undo' | 'unhide' | 'window' | 'zoom' | 'zoomin' | 'zoomout' | 'togglespellchecker' |
-  'appmenu' | 'filemenu' | 'editmenu' | 'viewmenu' | 'windowmenu' | 'sharemenu'
+  'appmenu' | 'filemenu' | 'editmenu' | 'viewmenu' | 'windowmenu' | 'sharemenu' | 'palette' | 'header'
 interface Role {
   label: string;
   accelerator?: string;
@@ -319,6 +319,13 @@ export const roleList: Record<RoleId, Role> = {
   sharemenu: {
     label: 'Share',
     submenu: []
+  },
+  palette: {
+    label: 'Palette',
+    submenu: []
+  },
+  header: {
+    label: 'Section Header'
   }
 };
 

--- a/lib/browser/api/menu-item-roles.ts
+++ b/lib/browser/api/menu-item-roles.ts
@@ -8,7 +8,7 @@ type RoleId = 'about' | 'close' | 'copy' | 'cut' | 'delete' | 'forcereload' | 'f
   'paste' | 'pasteandmatchstyle' | 'quit' | 'redo' | 'reload' | 'resetzoom' | 'selectall' | 'services' | 'recentdocuments' | 'clearrecentdocuments' |
   'showsubstitutions' | 'togglesmartquotes' | 'togglesmartdashes' | 'toggletextreplacement' | 'startspeaking' | 'stopspeaking' |
   'toggledevtools' | 'togglefullscreen' | 'undo' | 'unhide' | 'window' | 'zoom' | 'zoomin' | 'zoomout' | 'togglespellchecker' |
-  'appmenu' | 'filemenu' | 'editmenu' | 'viewmenu' | 'windowmenu' | 'sharemenu' | 'palette' | 'header'
+  'appmenu' | 'filemenu' | 'editmenu' | 'viewmenu' | 'windowmenu' | 'sharemenu'
 interface Role {
   label: string;
   accelerator?: string;
@@ -319,13 +319,6 @@ export const roleList: Record<RoleId, Role> = {
   sharemenu: {
     label: 'Share',
     submenu: []
-  },
-  palette: {
-    label: 'Palette',
-    submenu: []
-  },
-  header: {
-    label: 'Section Header'
   }
 };
 

--- a/lib/browser/api/menu-item.ts
+++ b/lib/browser/api/menu-item.ts
@@ -71,7 +71,7 @@ const MenuItem = function (this: any, options: any) {
   };
 };
 
-MenuItem.types = ['normal', 'separator', 'submenu', 'checkbox', 'radio'];
+MenuItem.types = ['normal', 'separator', 'submenu', 'checkbox', 'radio', 'header', 'palette'];
 
 MenuItem.prototype.getDefaultRoleAccelerator = function () {
   return roles.getDefaultAccelerator(this.role);

--- a/lib/browser/api/menu.ts
+++ b/lib/browser/api/menu.ts
@@ -143,6 +143,9 @@ Menu.prototype.insert = function (pos, item) {
   if (item.toolTip) this.setToolTip(pos, item.toolTip);
   if (item.icon) this.setIcon(pos, item.icon);
   if (item.role) this.setRole(pos, item.role);
+  if (item.type === 'palette' || item.type === 'header') {
+    this.setCustomType(pos, item.type);
+  }
 
   // Make menu accessible to items.
   item.overrideReadOnlyProperty('menu', this);
@@ -264,9 +267,11 @@ function removeExtraSeparators (items: (MenuItemConstructorOptions | MenuItem)[]
 function insertItemByType (this: MenuType, item: MenuItem, pos: number) {
   const types = {
     normal: () => this.insertItem(pos, item.commandId, item.label),
+    header: () => this.insertItem(pos, item.commandId, item.label),
     checkbox: () => this.insertCheckItem(pos, item.commandId, item.label),
     separator: () => this.insertSeparator(pos),
     submenu: () => this.insertSubMenu(pos, item.commandId, item.label, item.submenu),
+    palette: () => this.insertSubMenu(pos, item.commandId, item.label, item.submenu),
     radio: () => {
       // Grouping radio menu items
       item.overrideReadOnlyProperty('groupId', generateGroupId(this.items, pos));

--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -213,6 +213,10 @@ void Menu::SetRole(int index, const std::u16string& role) {
   model_->SetRole(index, role);
 }
 
+void Menu::SetCustomType(int index, const std::u16string& customType) {
+  model_->SetCustomType(index, customType);
+}
+
 void Menu::Clear() {
   model_->Clear();
 }
@@ -286,6 +290,7 @@ void Menu::FillObjectTemplate(v8::Isolate* isolate,
       .SetMethod("setSublabel", &Menu::SetSublabel)
       .SetMethod("setToolTip", &Menu::SetToolTip)
       .SetMethod("setRole", &Menu::SetRole)
+      .SetMethod("setCustomType", &Menu::SetCustomType)
       .SetMethod("clear", &Menu::Clear)
       .SetMethod("getIndexOfCommandId", &Menu::GetIndexOfCommandId)
       .SetMethod("getItemCount", &Menu::GetItemCount)

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -116,6 +116,7 @@ class Menu : public gin::Wrappable<Menu>,
   void SetSublabel(int index, const std::u16string& sublabel);
   void SetToolTip(int index, const std::u16string& toolTip);
   void SetRole(int index, const std::u16string& role);
+  void SetCustomType(int index, const std::u16string& customType);
   void Clear();
   int GetIndexOfCommandId(int command_id) const;
   int GetItemCount() const;

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -333,6 +333,7 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
   std::u16string role = model->GetRoleAt(index);
   electron::ElectronMenuModel::ItemType type = model->GetTypeAt(index);
 
+  // The sectionHeaderWithTitle menu item is only available in macOS 14.0+.
   if (@available(macOS 14, *)) {
     if (role == u"header") {
       item = [NSMenuItem sectionHeaderWithTitle:label];
@@ -379,6 +380,7 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
                           ? [self menuFromModel:submenuModel]
                           : MakeEmptySubmenu();
 
+    // NSMenuPresentationStylePalette is only available in macOS 14.0+.
     if (@available(macOS 14, *)) {
       if (role == u"palette") {
         submenu.presentationStyle = NSMenuPresentationStylePalette;

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -332,10 +332,11 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
 
   std::u16string role = model->GetRoleAt(index);
   electron::ElectronMenuModel::ItemType type = model->GetTypeAt(index);
+  std::u16string customType = model->GetCustomTypeAt(index);
 
   // The sectionHeaderWithTitle menu item is only available in macOS 14.0+.
   if (@available(macOS 14, *)) {
-    if (role == u"header") {
+    if (customType == u"header") {
       item = [NSMenuItem sectionHeaderWithTitle:label];
     }
   }
@@ -382,7 +383,7 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
 
     // NSMenuPresentationStylePalette is only available in macOS 14.0+.
     if (@available(macOS 14, *)) {
-      if (role == u"palette") {
+      if (customType == u"palette") {
         submenu.presentationStyle = NSMenuPresentationStylePalette;
       }
     }

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -330,6 +330,15 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
     }
   }
 
+  std::u16string role = model->GetRoleAt(index);
+  electron::ElectronMenuModel::ItemType type = model->GetTypeAt(index);
+
+  if (@available(macOS 14, *)) {
+    if (role == u"header") {
+      item = [NSMenuItem sectionHeaderWithTitle:label];
+    }
+  }
+
   // If the menu item has an icon, set it.
   ui::ImageModel icon = model->GetIconAt(index);
   if (icon.IsImage())
@@ -337,9 +346,6 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
 
   std::u16string toolTip = model->GetToolTipAt(index);
   [item setToolTip:base::SysUTF16ToNSString(toolTip)];
-
-  std::u16string role = model->GetRoleAt(index);
-  electron::ElectronMenuModel::ItemType type = model->GetTypeAt(index);
 
   if (role == u"services") {
     std::u16string title = u"Services";
@@ -372,6 +378,13 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
     NSMenu* submenu = MenuHasVisibleItems(submenuModel)
                           ? [self menuFromModel:submenuModel]
                           : MakeEmptySubmenu();
+
+    if (@available(macOS 14, *)) {
+      if (role == u"palette") {
+        submenu.presentationStyle = NSMenuPresentationStylePalette;
+      }
+    }
+
     [submenu setTitle:[item title]];
     [item setSubmenu:submenu];
 

--- a/shell/browser/ui/electron_menu_model.cc
+++ b/shell/browser/ui/electron_menu_model.cc
@@ -37,6 +37,18 @@ std::u16string ElectronMenuModel::GetToolTipAt(size_t index) {
   return iter == std::end(toolTips_) ? std::u16string() : iter->second;
 }
 
+void ElectronMenuModel::SetCustomType(size_t index,
+                                      const std::u16string& customType) {
+  int command_id = GetCommandIdAt(index);
+  customTypes_[command_id] = customType;
+}
+
+std::u16string ElectronMenuModel::GetCustomTypeAt(size_t index) {
+  const int command_id = GetCommandIdAt(index);
+  const auto iter = customTypes_.find(command_id);
+  return iter == std::end(customTypes_) ? std::u16string() : iter->second;
+}
+
 void ElectronMenuModel::SetRole(size_t index, const std::u16string& role) {
   int command_id = GetCommandIdAt(index);
   roles_[command_id] = role;

--- a/shell/browser/ui/electron_menu_model.h
+++ b/shell/browser/ui/electron_menu_model.h
@@ -84,6 +84,8 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
 
   void SetToolTip(size_t index, const std::u16string& toolTip);
   std::u16string GetToolTipAt(size_t index);
+  void SetCustomType(size_t index, const std::u16string& customType);
+  std::u16string GetCustomTypeAt(size_t index);
   void SetRole(size_t index, const std::u16string& role);
   std::u16string GetRoleAt(size_t index);
   void SetSecondaryLabel(size_t index, const std::u16string& sublabel);
@@ -122,9 +124,10 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
   std::optional<SharingItem> sharing_item_;
 #endif
 
-  base::flat_map<int, std::u16string> toolTips_;   // command id -> tooltip
-  base::flat_map<int, std::u16string> roles_;      // command id -> role
-  base::flat_map<int, std::u16string> sublabels_;  // command id -> sublabel
+  base::flat_map<int, std::u16string> toolTips_;     // command id -> tooltip
+  base::flat_map<int, std::u16string> roles_;        // command id -> role
+  base::flat_map<int, std::u16string> sublabels_;    // command id -> sublabel
+  base::flat_map<int, std::u16string> customTypes_;  // command id -> tooltip
   base::ObserverList<Observer> observers_;
 
   base::WeakPtrFactory<ElectronMenuModel> weak_factory_{this};

--- a/shell/browser/ui/electron_menu_model.h
+++ b/shell/browser/ui/electron_menu_model.h
@@ -124,10 +124,11 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
   std::optional<SharingItem> sharing_item_;
 #endif
 
-  base::flat_map<int, std::u16string> toolTips_;     // command id -> tooltip
-  base::flat_map<int, std::u16string> roles_;        // command id -> role
-  base::flat_map<int, std::u16string> sublabels_;    // command id -> sublabel
-  base::flat_map<int, std::u16string> customTypes_;  // command id -> tooltip
+  base::flat_map<int, std::u16string> toolTips_;   // command id -> tooltip
+  base::flat_map<int, std::u16string> roles_;      // command id -> role
+  base::flat_map<int, std::u16string> sublabels_;  // command id -> sublabel
+  base::flat_map<int, std::u16string>
+      customTypes_;  // command id -> custom type
   base::ObserverList<Observer> observers_;
 
   base::WeakPtrFactory<ElectronMenuModel> weak_factory_{this};

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -277,7 +277,7 @@ declare module NodeJS {
 interface ContextMenuItem {
   id: number;
   label: string;
-  type: 'normal' | 'separator' | 'subMenu' | 'checkbox';
+  type: 'normal' | 'separator' | 'subMenu' | 'checkbox' | 'header' | 'palette';
   checked: boolean;
   enabled: boolean;
   subItems: ContextMenuItem[];

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -172,6 +172,7 @@ declare namespace Electron {
     setToolTip(index: number, tooltip: string): void;
     setIcon(index: number, image: string | NativeImage): void;
     setRole(index: number, role: string): void;
+    setCustomType(index: number, customType: string): void;
     insertItem(index: number, commandId: number, label: string): void;
     insertCheckItem(index: number, commandId: number, label: string): void;
     insertRadioItem(index: number, commandId: number, label: string, groupId: number): void;


### PR DESCRIPTION
#### Description of Change

Closes #42960

This PR adds two new macOS specific menu item roles:
* [`palette`](https://developer.apple.com/documentation/appkit/nsmenu/presentationstyle-swift.enum/palette): A menu presentation style where items to display align horizontally.
* [`header`](https://developer.apple.com/documentation/appkit/nsmenuitem/sectionheaderwithtitle:): A menu item representing a section header for a logical grouping of menu commands.

``` js
const reactions = []

  for (let i = 1; i <= 4; ++i) {
    reactions.push({
      label: '',
      icon: nativeImage.createFromPath(path.resolve(__dirname, '..', `reaction-${i}@2x.png`)),
      click: () => console.log('Clicked reaction!')
    })
  }

  const paletteMenu = Menu.buildFromTemplate(reactions)

  const contextMenu = Menu.buildFromTemplate([
    {
      label: 'Reactions',
      role: 'header',
    },
    {
      type: 'submenu',
      label: 'Reactions',
      role: 'palette',
      submenu: paletteMenu,
    },
    {
      type: 'submenu',
      label: 'Reactions',
      submenu: paletteMenu,
    },
    { label: 'Tapback...' },
    { label: 'Reply...' },
    { label: 'Add Sticker...' },
  ])
```

<img width="193" alt="image" src="https://github.com/user-attachments/assets/ed06821b-5e09-4535-b0bc-eb8ccbc61b10" />

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Add support for menu item role `palette` and `header` on macOS.
