### PR TITLE
test: disable unexpectedly quit dialog on macOS

### DIFF
--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -113,6 +113,9 @@ jobs:
             configure_sys_tccdb "$values"
           fi
         done
+    - name: Turn off the unexpectedly quit dialog on macOS
+      if: ${{ inputs.target-platform == 'macos' }}
+      run: defaults write com.apple.CrashReporter DialogType server
     - name: Checkout Electron
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -15,7 +15,6 @@ import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 import * as url from 'node:url';
 
-import { ScreenCapture } from './lib/screen-helpers';
 import { ifit, ifdescribe, defer, itremote, listen, startRemoteControlApp, waitUntil } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
 import { PipeTransport } from './pipe-transport';
@@ -656,8 +655,6 @@ describe('chromium features', () => {
     });
 
     it('should lock the keyboard', async () => {
-      const screenCapture = new ScreenCapture();
-      await screenCapture.takeScreenshot('keyboardlock');
       const w = new BrowserWindow({ show: true });
       await w.loadFile(path.join(fixturesPath, 'pages', 'modal.html'));
 

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -15,6 +15,7 @@ import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 import * as url from 'node:url';
 
+import { ScreenCapture } from './lib/screen-helpers';
 import { ifit, ifdescribe, defer, itremote, listen, startRemoteControlApp, waitUntil } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
 import { PipeTransport } from './pipe-transport';
@@ -655,6 +656,8 @@ describe('chromium features', () => {
     });
 
     it('should lock the keyboard', async () => {
+      const screenCapture = new ScreenCapture();
+      await screenCapture.takeScreenshot('keyboardlock');
       const w = new BrowserWindow({ show: true });
       await w.loadFile(path.join(fixturesPath, 'pages', 'modal.html'));
 


### PR DESCRIPTION
#### Description of Change
In researching #45435, I noticed that sometimes on macOS [the keyboard lock test fails ](https://github.com/electron/electron/actions/runs/13229401223/job/36925369357)so I added a screenshot before that test and saw the following unexpectedly quit dialog:
![dialog](https://github.com/user-attachments/assets/d10816e6-ab01-41ec-a633-c84809cc2572)

I'm not 100% sure that this is why the keyboard lock test fails, but either way we should disable this dialog on macOS so that it doesn't interfere with testing on macOS.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
