### PR TITLE
build: make gen-libc++-filenames.js produce the same results on Windows

### DIFF
--- a/script/gen-libc++-filenames.js
+++ b/script/gen-libc++-filenames.js
@@ -7,6 +7,7 @@ const check = process.argv.includes('--check');
 
 function findAllHeaders (basePath) {
   const allFiles = fs.readdirSync(basePath);
+  allFiles.sort();
   const toReturn = [];
   for (const file of allFiles) {
     const absPath = path.resolve(basePath, file);
@@ -48,7 +49,7 @@ for (const folder of ['libc++', 'libc++abi']) {
   const libcxxIncludeDir = path.resolve(__dirname, '..', '..', 'third_party', folder, 'src', 'include');
   const gclientPath = `third_party/${folder}/src/include`;
 
-  const headers = findAllHeaders(libcxxIncludeDir).map(absPath => path.relative(path.resolve(__dirname, '../..', gclientPath), absPath));
+  const headers = findAllHeaders(libcxxIncludeDir).map(absPath => path.relative(path.resolve(__dirname, '../..', gclientPath), absPath).replaceAll('\\', '/'));
 
   const newHeaders = headers.map(f => `//${path.posix.join(gclientPath, f)}`);
   const content = `${prettyName}_headers = [


### PR DESCRIPTION
#### Description of Change

While working on #45535 I noticed that touching the `DEPS` file on Windows causes `filenames.libcxx.gni` and `filenames.libcxxabi.gni` to be regenerated with what appears to be a different list of paths. When I debugged the issue, I found that there are two causes for this:

1. The list of files returned by `fs.readdirSync` is not consistent between Mac and Windows, so when the script traverses the include directories on Windows, it gets back a list of paths that is in a different order.
2. For headers in nested folders, the `path.relative(path.resolve(...))` call still ends up with a backslash in the relative path on Windows.

To address these Windows inconsistencies, this PR updates the `findAllHeaders` function to sort the list of files in a folder before iterating over them, and updates the header parsing logic to replace `\` with `/` when resolving header paths.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: no-notes
