### PR TITLE
chore: remove deprecated `systemPreferences.isAeroGlassEnabled()`

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -181,16 +181,6 @@ Some popular `key` and `type`s are:
 Removes the `key` in `NSUserDefaults`. This can be used to restore the default
 or global value of a `key` previously set with `setUserDefault`.
 
-### `systemPreferences.isAeroGlassEnabled()` _Windows_ _Deprecated_
-
-Returns `boolean` - `true` if [DWM composition][dwm-composition] (Aero Glass) is
-enabled, and `false` otherwise.
-
-**Deprecated:**
-This function has been always returning `true` since Electron 23, which only supports Windows 10+.
-
-[dwm-composition]: https://learn.microsoft.com/en-us/windows/win32/dwm/composition-ovw
-
 ### `systemPreferences.getAccentColor()` _Windows_ _macOS_
 
 Returns `string` - The users current system wide accent color preference in RGBA

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -12,6 +12,15 @@ This document uses the following convention to categorize breaking changes:
 * **Deprecated:** An API was marked as deprecated. The API will continue to function, but will emit a deprecation warning, and will be removed in a future release.
 * **Removed:** An API or feature was removed, and is no longer supported by Electron.
 
+## Planned Breaking API Changes (36.0)
+
+### Removed: `systemPreferences.isAeroGlassEnabled()`
+
+The `systemPreferences.isAeroGlassEnabled()` function has been removed without replacement.
+It has been always returning `true` since Electron 23, which only supports Windows 10+, where DWM composition can no longer be disabled.
+
+https://learn.microsoft.com/en-us/windows/win32/dwm/composition-ovw#disabling-dwm-composition-windows7-and-earlier
+
 ## Planned Breaking API Changes (35.0)
 
 ### Deprecated: `getFromVersionID` on `session.serviceWorkers`

--- a/lib/browser/api/system-preferences.ts
+++ b/lib/browser/api/system-preferences.ts
@@ -20,12 +20,4 @@ if ('accessibilityDisplayShouldReduceTransparency' in systemPreferences) {
   });
 }
 
-if (process.platform === 'win32') {
-  const isAeroGlassEnabledDeprecated = deprecate.warnOnce('systemPreferences.isAeroGlassEnabled');
-  systemPreferences.isAeroGlassEnabled = () => {
-    isAeroGlassEnabledDeprecated();
-    return true;
-  };
-}
-
 export default systemPreferences;

--- a/spec/api-system-preferences-spec.ts
+++ b/spec/api-system-preferences-spec.ts
@@ -2,7 +2,6 @@ import { systemPreferences } from 'electron/main';
 
 import { expect } from 'chai';
 
-import { expectDeprecationMessages } from './lib/deprecate-helpers';
 import { ifdescribe } from './lib/spec-helpers';
 
 describe('systemPreferences module', () => {
@@ -57,13 +56,6 @@ describe('systemPreferences module', () => {
           systemPreferences.registerDefaults(badDefault as any);
         }).to.throw('Error processing argument at index 0, conversion failure from ');
       }
-    });
-  });
-
-  ifdescribe(process.platform === 'win32')('systemPreferences.isAeroGlassEnabled()', () => {
-    it('always returns true', () => {
-      expect(systemPreferences.isAeroGlassEnabled()).to.equal(true);
-      expectDeprecationMessages(() => systemPreferences.isAeroGlassEnabled(), '\'systemPreferences.isAeroGlassEnabled\' is deprecated and will be removed.');
     });
   });
 

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -370,6 +370,8 @@ if (process.platform === 'win32') {
   // @ts-expect-error Removed API
   systemPreferences.on('high-contrast-color-scheme-changed', (_, highContrast) => console.log(highContrast ? 'high contrast' : 'not high contrast'));
   console.log('Color for menu is', systemPreferences.getColor('menu'));
+  // @ts-expect-error Removed API
+  systemPreferences.isAeroGlassEnabled();
 }
 
 if (process.platform === 'darwin') {


### PR DESCRIPTION
#### Description of Change
Finish deprecation from #45434

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: The deprecated `systemPreferences.isAeroGlassEnabled()` API has been removed.