### PR TITLE
fix: cppgc crashes on Linux with 16KiB pages

### DIFF
--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -85,6 +85,10 @@ v8::Isolate* JavascriptEnvironment::Initialize(uv_loop_t* event_loop,
   auto* cmd = base::CommandLine::ForCurrentProcess();
   // --js-flags.
   std::string js_flags = "--no-freeze-flags-after-init ";
+#if defined(OS_LINUX)
+  // See https://issues.chromium.org/issues/378017037 - fixed in M134.
+  js_flags.append("--nodecommit_pooled_pages ");
+#endif
   js_flags.append(cmd->GetSwitchValueASCII(blink::switches::kJavaScriptFlags));
   v8::V8::SetFlagsFromString(js_flags.c_str(), js_flags.size());
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/45560.
Refs https://issues.chromium.org/issues/378017037.

Fixes an issue where Electron may experience crashes on Linux with 16KiB pages. This happened due to hardcoded `kGuardPageSize` in cppgc - see above CRBUG for more. Fixed in M134 and above.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where Electron may experience crashes on Linux with 16KiB pages.
