### PR TITLE
refactor: move ExtensionRegistrar up to ElectronExtensionSystem

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -763,6 +763,8 @@ filenames = {
     "shell/browser/extensions/electron_extension_host_delegate.h",
     "shell/browser/extensions/electron_extension_loader.cc",
     "shell/browser/extensions/electron_extension_loader.h",
+    "shell/browser/extensions/electron_extension_registrar_delegate.cc",
+    "shell/browser/extensions/electron_extension_registrar_delegate.h",
     "shell/browser/extensions/electron_extension_system_factory.cc",
     "shell/browser/extensions/electron_extension_system_factory.h",
     "shell/browser/extensions/electron_extension_system.cc",

--- a/shell/browser/extensions/electron_extension_loader.h
+++ b/shell/browser/extensions/electron_extension_loader.h
@@ -11,7 +11,6 @@
 #include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
-#include "extensions/browser/extension_registrar.h"
 #include "extensions/common/extension_id.h"
 
 namespace base {
@@ -25,12 +24,14 @@ class BrowserContext;
 namespace extensions {
 
 class Extension;
+class ElectronExtensionSystem;
 
-// Handles extension loading and reloading using ExtensionRegistrar.
-class ElectronExtensionLoader : public ExtensionRegistrar::Delegate {
+// Handles extension loading.
+class ElectronExtensionLoader {
  public:
-  explicit ElectronExtensionLoader(content::BrowserContext* browser_context);
-  ~ElectronExtensionLoader() override;
+  explicit ElectronExtensionLoader(content::BrowserContext* browser_context,
+                                   ElectronExtensionSystem* extension_system);
+  ~ElectronExtensionLoader();
 
   // disable copy
   ElectronExtensionLoader(const ElectronExtensionLoader&) = delete;
@@ -43,64 +44,13 @@ class ElectronExtensionLoader : public ExtensionRegistrar::Delegate {
                      base::OnceCallback<void(const Extension* extension,
                                              const std::string&)> cb);
 
-  // Starts reloading the extension. A keep-alive is maintained until the
-  // reload succeeds/fails. If the extension is an app, it will be launched upon
-  // reloading.
-  // This may invalidate references to the old Extension object, so it takes the
-  // ID by value.
-  void ReloadExtension(const ExtensionId& extension_id);
-
-  void UnloadExtension(const ExtensionId& extension_id,
-                       extensions::UnloadedExtensionReason reason);
-
-  ExtensionRegistrar* registrar() { return &extension_registrar_; }
-
  private:
-  // If the extension loaded successfully, enables it. If it's an app, launches
-  // it. If the load failed, updates ShellKeepAliveRequester.
-  void FinishExtensionReload(
-      const ExtensionId& old_extension_id,
-      std::pair<scoped_refptr<const Extension>, std::string> result);
-
   void FinishExtensionLoad(
       base::OnceCallback<void(const Extension*, const std::string&)> cb,
       std::pair<scoped_refptr<const Extension>, std::string> result);
 
-  // ExtensionRegistrar::Delegate:
-  void PreAddExtension(const Extension* extension,
-                       const Extension* old_extension) override;
-  void PostActivateExtension(scoped_refptr<const Extension> extension) override;
-  void PostDeactivateExtension(
-      scoped_refptr<const Extension> extension) override;
-  void PreUninstallExtension(scoped_refptr<const Extension> extension) override;
-  void PostUninstallExtension(scoped_refptr<const Extension> extension,
-                              base::OnceClosure done_callback) override;
-  void PostNotifyUninstallExtension(
-      scoped_refptr<const Extension> extension) override;
-  void LoadExtensionForReload(
-      const ExtensionId& extension_id,
-      const base::FilePath& path,
-      ExtensionRegistrar::LoadErrorBehavior load_error_behavior) override;
-  void ShowExtensionDisabledError(const Extension* extension,
-                                  bool is_remote_install) override;
-  void FinishDelayedInstallationsIfAny() override;
-  bool CanAddExtension(const Extension* extension) override;
-  bool CanEnableExtension(const Extension* extension) override;
-  bool CanDisableExtension(const Extension* extension) override;
-  bool ShouldBlockExtension(const Extension* extension) override;
-
-  raw_ptr<content::BrowserContext> browser_context_;  // Not owned.
-
-  // Registers and unregisters extensions.
-  ExtensionRegistrar extension_registrar_;
-
-  // Holds keep-alives for relaunching apps.
-  //   ShellKeepAliveRequester keep_alive_requester_;
-
-  // Indicates that we posted the (asynchronous) task to start reloading.
-  // Used by ReloadExtension() to check whether ExtensionRegistrar calls
-  // LoadExtensionForReload().
-  bool did_schedule_reload_ = false;
+  raw_ptr<content::BrowserContext> browser_context_;   // Not owned.
+  raw_ptr<ElectronExtensionSystem> extension_system_;  // Not owned.
 
   base::WeakPtrFactory<ElectronExtensionLoader> weak_factory_{this};
 };

--- a/shell/browser/extensions/electron_extension_registrar_delegate.cc
+++ b/shell/browser/extensions/electron_extension_registrar_delegate.cc
@@ -1,0 +1,127 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/extensions/electron_extension_registrar_delegate.h"
+
+#include <utility>
+
+#include "base/auto_reset.h"
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/functional/bind.h"
+#include "base/logging.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/threading/thread_restrictions.h"
+#include "base/time/time.h"
+#include "extensions/browser/extension_file_task_runner.h"
+#include "extensions/browser/extension_prefs.h"
+#include "extensions/browser/extension_registry.h"
+#include "extensions/browser/pref_names.h"
+#include "extensions/common/error_utils.h"
+#include "extensions/common/file_util.h"
+#include "extensions/common/manifest_constants.h"
+#include "shell/browser/extensions/electron_extension_system.h"
+
+namespace extensions {
+
+using LoadErrorBehavior = ExtensionRegistrar::LoadErrorBehavior;
+
+ElectronExtensionRegistrarDelegate::ElectronExtensionRegistrarDelegate(
+    content::BrowserContext* browser_context,
+    ElectronExtensionSystem* extension_system)
+    : browser_context_(browser_context), extension_system_(extension_system) {}
+
+ElectronExtensionRegistrarDelegate::~ElectronExtensionRegistrarDelegate() =
+    default;
+
+void ElectronExtensionRegistrarDelegate::PreAddExtension(
+    const Extension* extension,
+    const Extension* old_extension) {
+  if (old_extension)
+    return;
+
+  // The extension might be disabled if a previous reload attempt failed. In
+  // that case, we want to remove that disable reason.
+  ExtensionPrefs* extension_prefs = ExtensionPrefs::Get(browser_context_);
+  if (extension_prefs->IsExtensionDisabled(extension->id()) &&
+      extension_prefs->HasDisableReason(extension->id(),
+                                        disable_reason::DISABLE_RELOAD)) {
+    extension_prefs->RemoveDisableReason(extension->id(),
+                                         disable_reason::DISABLE_RELOAD);
+    // Only re-enable the extension if there are no other disable reasons.
+    if (extension_prefs->GetDisableReasons(extension->id()) ==
+        disable_reason::DISABLE_NONE) {
+      extension_prefs->SetExtensionEnabled(extension->id());
+    }
+  }
+}
+
+void ElectronExtensionRegistrarDelegate::PostActivateExtension(
+    scoped_refptr<const Extension> extension) {}
+
+void ElectronExtensionRegistrarDelegate::PostDeactivateExtension(
+    scoped_refptr<const Extension> extension) {}
+
+void ElectronExtensionRegistrarDelegate::PreUninstallExtension(
+    scoped_refptr<const Extension> extension) {}
+
+void ElectronExtensionRegistrarDelegate::PostUninstallExtension(
+    scoped_refptr<const Extension> extension,
+    base::OnceClosure done_callback) {}
+
+void ElectronExtensionRegistrarDelegate::PostNotifyUninstallExtension(
+    scoped_refptr<const Extension> extension) {}
+
+void ElectronExtensionRegistrarDelegate::LoadExtensionForReload(
+    const ExtensionId& extension_id,
+    const base::FilePath& path,
+    LoadErrorBehavior load_error_behavior) {
+  CHECK(!path.empty());
+
+  // TODO(nornagon): we should save whether file access was granted
+  // when loading this extension and retain it here. As is, reloading an
+  // extension will cause the file access permission to be dropped.
+  int load_flags = Extension::FOLLOW_SYMLINKS_ANYWHERE;
+  extension_system_->LoadExtension(
+      path, load_flags,
+      base::BindOnce(&ElectronExtensionRegistrarDelegate::FinishExtensionReload,
+                     weak_factory_.GetWeakPtr()));
+}
+
+void ElectronExtensionRegistrarDelegate::FinishExtensionReload(
+    const Extension* extension,
+    const ExtensionId& extension_id) {
+  if (extension) {
+    extension_system_->AddExtension(extension);
+  }
+}
+
+void ElectronExtensionRegistrarDelegate::ShowExtensionDisabledError(
+    const Extension* extension,
+    bool is_remote_install) {}
+
+void ElectronExtensionRegistrarDelegate::FinishDelayedInstallationsIfAny() {}
+
+bool ElectronExtensionRegistrarDelegate::CanAddExtension(
+    const Extension* extension) {
+  return true;
+}
+
+bool ElectronExtensionRegistrarDelegate::CanEnableExtension(
+    const Extension* extension) {
+  return true;
+}
+
+bool ElectronExtensionRegistrarDelegate::CanDisableExtension(
+    const Extension* extension) {
+  return true;
+}
+
+bool ElectronExtensionRegistrarDelegate::ShouldBlockExtension(
+    const Extension* extension) {
+  return false;
+}
+
+}  // namespace extensions

--- a/shell/browser/extensions/electron_extension_registrar_delegate.h
+++ b/shell/browser/extensions/electron_extension_registrar_delegate.h
@@ -1,0 +1,86 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_BROWSER_EXTENSIONS_ELECTRON_EXTENSION_REGISTRAR_DELEGATE_H_
+#define ELECTRON_SHELL_BROWSER_EXTENSIONS_ELECTRON_EXTENSION_REGISTRAR_DELEGATE_H_
+
+#include <string>
+#include <utility>
+
+#include "base/functional/callback.h"
+#include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
+#include "extensions/browser/extension_registrar.h"
+#include "extensions/common/extension_id.h"
+
+namespace base {
+class FilePath;
+}
+
+namespace content {
+class BrowserContext;
+}
+
+namespace extensions {
+
+class Extension;
+class ElectronExtensionSystem;
+
+// Handles extension loading and reloading using ExtensionRegistrar.
+class ElectronExtensionRegistrarDelegate : public ExtensionRegistrar::Delegate {
+ public:
+  explicit ElectronExtensionRegistrarDelegate(
+      content::BrowserContext* browser_context,
+      ElectronExtensionSystem* extension_system);
+  ~ElectronExtensionRegistrarDelegate() override;
+
+  // disable copy
+  ElectronExtensionRegistrarDelegate(
+      const ElectronExtensionRegistrarDelegate&) = delete;
+  ElectronExtensionRegistrarDelegate& operator=(
+      const ElectronExtensionRegistrarDelegate&) = delete;
+
+  void set_extension_registrar(ExtensionRegistrar* registrar) {
+    extension_registrar_ = registrar;
+  }
+
+ private:
+  // ExtensionRegistrar::Delegate:
+  void PreAddExtension(const Extension* extension,
+                       const Extension* old_extension) override;
+  void PostActivateExtension(scoped_refptr<const Extension> extension) override;
+  void PostDeactivateExtension(
+      scoped_refptr<const Extension> extension) override;
+  void PreUninstallExtension(scoped_refptr<const Extension> extension) override;
+  void PostUninstallExtension(scoped_refptr<const Extension> extension,
+                              base::OnceClosure done_callback) override;
+  void PostNotifyUninstallExtension(
+      scoped_refptr<const Extension> extension) override;
+  void LoadExtensionForReload(
+      const ExtensionId& extension_id,
+      const base::FilePath& path,
+      ExtensionRegistrar::LoadErrorBehavior load_error_behavior) override;
+  void ShowExtensionDisabledError(const Extension* extension,
+                                  bool is_remote_install) override;
+  void FinishDelayedInstallationsIfAny() override;
+  bool CanAddExtension(const Extension* extension) override;
+  bool CanEnableExtension(const Extension* extension) override;
+  bool CanDisableExtension(const Extension* extension) override;
+  bool ShouldBlockExtension(const Extension* extension) override;
+
+  // If the extension loaded successfully, enables it. If it's an app, launches
+  // it. If the load failed, updates ShellKeepAliveRequester.
+  void FinishExtensionReload(const Extension* extension,
+                             const ExtensionId& extension_id);
+
+  raw_ptr<content::BrowserContext> browser_context_;   // Not owned.
+  raw_ptr<ElectronExtensionSystem> extension_system_;  // Not owned.
+  raw_ptr<ExtensionRegistrar> extension_registrar_ = nullptr;
+
+  base::WeakPtrFactory<ElectronExtensionRegistrarDelegate> weak_factory_{this};
+};
+
+}  // namespace extensions
+
+#endif  // ELECTRON_SHELL_BROWSER_EXTENSIONS_ELECTRON_EXTENSION_REGISTRAR_DELEGATE_H_

--- a/shell/browser/extensions/electron_extension_system.h
+++ b/shell/browser/extensions/electron_extension_system.h
@@ -13,6 +13,7 @@
 #include "base/one_shot_event.h"
 #include "components/value_store/value_store_factory.h"
 #include "components/value_store/value_store_factory_impl.h"
+#include "extensions/browser/extension_registrar.h"
 #include "extensions/browser/extension_system.h"
 
 namespace base {
@@ -26,6 +27,7 @@ class BrowserContext;
 namespace extensions {
 
 class ElectronExtensionLoader;
+class ElectronExtensionRegistrarDelegate;
 class ValueStoreFactory;
 
 // A simplified version of ExtensionSystem for app_shell. Allows
@@ -39,6 +41,10 @@ class ElectronExtensionSystem : public ExtensionSystem {
   // disable copy
   ElectronExtensionSystem(const ElectronExtensionSystem&) = delete;
   ElectronExtensionSystem& operator=(const ElectronExtensionSystem&) = delete;
+
+  // Adds |extension| to this ExtensionService and notifies observers that the
+  // extension has been loaded.
+  void AddExtension(const Extension* extension);
 
   // Loads an unpacked extension from a directory. Returns the extension on
   // success, or nullptr otherwise.
@@ -86,6 +92,10 @@ class ElectronExtensionSystem : public ExtensionSystem {
       const std::string& extension_id,
       const base::Value::Dict& attributes) override;
 
+  base::WeakPtr<ElectronExtensionSystem> GetWeakPtr() {
+    return weak_factory_.GetWeakPtr();
+  }
+
  private:
   void OnExtensionRegisteredWithRequestContexts(
       scoped_refptr<Extension> extension);
@@ -98,6 +108,12 @@ class ElectronExtensionSystem : public ExtensionSystem {
   std::unique_ptr<UserScriptManager> user_script_manager_;
   std::unique_ptr<AppSorting> app_sorting_;
   std::unique_ptr<ManagementPolicy> management_policy_;
+
+  std::unique_ptr<ElectronExtensionRegistrarDelegate>
+      extension_registrar_delegate_;
+
+  // Helper to register and unregister extensions.
+  std::unique_ptr<ExtensionRegistrar> extension_registrar_;
 
   std::unique_ptr<ElectronExtensionLoader> extension_loader_;
 


### PR DESCRIPTION
#### Description of Change

I'm working on adding support for enabling/disabling extensions to help address https://github.com/electron/electron/issues/41613

This refactor moves ownership of `extensions::ExtensionRegistrar` up to `extensions::ElectronExtensionSystem` to allow easier access and align closer to Chrome. Additionally, this splits our `extensions::ExtensionRegistrar::Delegate` out of `extensions::ElectronExtensionLoader` and into its own delegate similar to Chrome. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
