### PR TITLE
feat: allow setting `roundedCorners` on Windows

### DIFF
--- a/docs/api/structures/base-window-options.md
+++ b/docs/api/structures/base-window-options.md
@@ -100,7 +100,7 @@
 * `roundedCorners` boolean (optional) _macOS_ _Windows_ - Whether frameless window
   should have rounded corners. Default is `true`. Setting this property
   to `false` will prevent the window from being fullscreenable on macOS.
-  Requires at least Windows 11 Build 22000.
+  On Windows versions older than Windows 11 Build 22000 this property has no effect, and frameless windows will not have rounded corners.
 * `thickFrame` boolean (optional) - Use `WS_THICKFRAME` style for frameless windows on
   Windows, which adds standard window frame. Setting it to `false` will remove
   window shadow and window animations. Default is `true`.

--- a/docs/api/structures/base-window-options.md
+++ b/docs/api/structures/base-window-options.md
@@ -97,9 +97,10 @@
   * `height` Integer (optional) - The height of the title bar and Window Controls Overlay in pixels. Default is system height.
 * `trafficLightPosition` [Point](point.md) (optional) _macOS_ -
   Set a custom position for the traffic light buttons in frameless windows.
-* `roundedCorners` boolean (optional) _macOS_ - Whether frameless window
-  should have rounded corners on macOS. Default is `true`. Setting this property
-  to `false` will prevent the window from being fullscreenable.
+* `roundedCorners` boolean (optional) _macOS_ _Windows_ - Whether frameless window
+  should have rounded corners. Default is `true`. Setting this property
+  to `false` will prevent the window from being fullscreenable on macOS.
+  Requires at least Windows 11 Build 22000.
 * `thickFrame` boolean (optional) - Use `WS_THICKFRAME` style for frameless windows on
   Windows, which adds standard window frame. Setting it to `false` will remove
   window shadow and window animations. Default is `true`.

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -378,6 +378,11 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
     if (!thick_frame_)
       frame_style &= ~(WS_THICKFRAME | WS_CAPTION);
     ::SetWindowLong(GetAcceleratedWidget(), GWL_STYLE, frame_style);
+
+    bool rounded_corner = true;
+    options.Get(options::kRoundedCorners, &rounded_corner);
+    if (!rounded_corner)
+      SetRoundedCorners(false);
   }
 
   LONG ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/45456.

Allows removing rounded corners for frameless windows on Windows. Improved `BrowserWindow` ctor option platform parity just a bit.

<details><summary> roundedCorners enabled </summary>
<p>

<img width="807" alt="Screenshot 2025-02-12 at 9 41 39 AM" src="https://github.com/user-attachments/assets/11573eac-c97b-44e5-9603-b9a2c77047c2" />

</p>
</details> 

<details><summary>roundedCorners disabled</summary>
<p>

<img width="812" alt="Screenshot 2025-02-12 at 9 41 24 AM" src="https://github.com/user-attachments/assets/16b7db3e-5ba8-4db8-b0fb-ea6d85ca335f" />

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added support for `roundedCorners` BrowserWindow constructor option on Windows.
