### PR TITLE
chore: change node test timeout from 20m to 30m

### DIFF
--- a/.github/workflows/pipeline-segment-node-nan-test.yml
+++ b/.github/workflows/pipeline-segment-node-nan-test.yml
@@ -38,7 +38,7 @@ jobs:
   node-tests:
     name: Run Node.js Tests
     runs-on: electron-arc-linux-amd64-8core
-    timeout-minutes: 20
+    timeout-minutes: 30
     env: 
       TARGET_ARCH: ${{ inputs.target-arch }}
       BUILD_TYPE: linux
@@ -101,7 +101,7 @@ jobs:
   nan-tests:
     name: Run Nan Tests
     runs-on: electron-arc-linux-amd64-4core
-    timeout-minutes: 20
+    timeout-minutes: 30
     env: 
       TARGET_ARCH: ${{ inputs.target-arch }}
       BUILD_TYPE: linux


### PR DESCRIPTION
#### Description of Change

Change CI so that node tests timeout after 30 minutes instead of 20 minutes.

I've been hitting this in the Chromium roll and thought it might be new to the roll, but I see it's also happening in other PRs too. [here](https://github.com/electron/electron/actions/runs/13305285935/job/37165067833)

CC @electron/wg-infra 

#### Release Notes

Notes: none.