### PR TITLE
chore: disable flaky content tracing tests on Linux

### DIFF
--- a/spec/api-content-tracing-spec.ts
+++ b/spec/api-content-tracing-spec.ts
@@ -6,7 +6,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
-import { ifdescribe, ifit } from './lib/spec-helpers';
+import { ifdescribe } from './lib/spec-helpers';
 
 // FIXME: The tests are skipped on linux arm/arm64
 ifdescribe(!(['arm', 'arm64'].includes(process.arch)) || (process.platform !== 'linux'))('contentTracing', () => {
@@ -91,7 +91,7 @@ ifdescribe(!(['arm', 'arm64'].includes(process.arch)) || (process.platform !== '
     });
   });
 
-  describe('stopRecording', function () {
+  ifdescribe(process.platform !== 'linux')('stopRecording', function () {
     if (process.platform === 'win32' && process.arch === 'arm64') {
       // WOA needs more time
       this.timeout(10e3);
@@ -112,8 +112,7 @@ ifdescribe(!(['arm', 'arm64'].includes(process.arch)) || (process.platform !== '
       expect(fs.statSync(path).isFile()).to.be.true('output exists');
     });
 
-    // FIXME(ckerr): this test regularly flakes
-    ifit(process.platform !== 'linux')('calls its callback with a result file path', async () => {
+    it('calls its callback with a result file path', async () => {
       const resultFilePath = await record(/* options */ {}, outputFilePath);
       expect(resultFilePath).to.be.a('string').and.be.equal(outputFilePath);
     });


### PR DESCRIPTION
#### Description of Change

Disable flaky test.  Test failures seen [here](https://github.com/electron/electron/pull/45573#issuecomment-2657366546) and in the main Chromium roll.

CC @codebytere

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.