### PR TITLE
docs: fix powerMonitor event types (34-x-y)

### DIFF
--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -26,7 +26,10 @@ Emitted when system changes to battery power.
 
 ### Event: 'thermal-state-change' _macOS_
 
-* `state` string - The system's new thermal state. Can be `unknown`, `nominal`, `fair`, `serious`, `critical`.
+Returns:
+
+* `details` Event\<\>
+  * `state` string - The system's new thermal state. Can be `unknown`, `nominal`, `fair`, `serious`, `critical`.
 
 Emitted when the thermal state of the system changes. Notification of a change
 in the thermal status of the system, such as entering a critical temperature
@@ -42,7 +45,8 @@ See https://developer.apple.com/library/archive/documentation/Performance/Concep
 
 ### Event: 'speed-limit-change' _macOS_ _Windows_
 
-* `limit` number - The operating system's advertised speed limit for CPUs, in percent.
+* `details` Event\<\>
+  * `limit` number - The operating system's advertised speed limit for CPUs, in percent.
 
 Notification of a change in the operating system's advertised speed limit for
 CPUs, in percent. Values below 100 indicate that the system is impairing


### PR DESCRIPTION
Manually backport #45518 to 34-x-y. See that PR for details.

Notes: none