### PR TITLE
docs: clarify navigationhistory offsets

### DIFF
--- a/docs/api/navigation-history.md
+++ b/docs/api/navigation-history.md
@@ -30,7 +30,7 @@ Returns `boolean` - Whether the browser can go forward to next web page.
 
 * `offset` Integer
 
-Returns `boolean` - Whether the web page can go to the specified `offset` from the current entry.
+Returns `boolean` - Whether the web page can go to the specified relative `offset` from the current entry.
 
 #### `navigationHistory.clear()`
 
@@ -66,7 +66,7 @@ Navigates browser to the specified absolute web page index.
 
 * `offset` Integer
 
-Navigates to the specified offset from the current entry.
+Navigates to the specified relative offset from the current entry.
 
 #### `navigationHistory.length()`
 

--- a/docs/api/navigation-history.md
+++ b/docs/api/navigation-history.md
@@ -5,7 +5,16 @@
 Process: [Main](../glossary.md#main-process)<br />
 _This class is not exported from the `'electron'` module. It is only available as a return value of other methods in the Electron API._
 
-Each navigation entry corresponds to a specific page. The indexing system follows a sequential order, where the first available navigation entry is at index 0, representing the earliest visited page, and the latest navigation entry is at index N, representing the most recent page. Maintaining this ordered list of navigation entries enables seamless navigation both backward and forward through the user's browsing history.
+Each [NavigationEntry](./structures/navigation-entry.md) corresponds to a specific visited page.
+The indexing system follows a sequential order, where the entry for the earliest visited
+page is at index 0 and the entry for the most recent visited page is at index N.
+
+Some APIs in this class also accept an _offset_, which is an integer representing the relative
+position of an index from the current entry according to the above indexing system (i.e. an offset
+value of `1` would represent going forward in history by one page).
+
+Maintaining this ordered list of navigation entries enables seamless navigation both backward and
+forward through the user's browsing history.
 
 ### Instance Methods
 


### PR DESCRIPTION
#### Description of Change

In an API WG meeting this month, we were reviewing https://github.com/electron/electron/pull/45433 and had a bit of confusion regarding `offset` vs `index`.

This PR aims to explain the two concepts a bit more explicitly.

cc @alicelovescake @felixrieseberg 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
