### PR TITLE
chore: emphasize documentation style guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.
 - [ ] PR description included and stakeholders cc'd
 - [ ] `npm test` passes
 - [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
-- [ ] relevant documentation, tutorials, templates and examples are changed or added
+- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
 - [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).
 
 #### Release Notes

--- a/docs/development/api-history-migration-guide.md
+++ b/docs/development/api-history-migration-guide.md
@@ -65,7 +65,7 @@ Verify that the Pull Request is correct and make a corresponding entry in the
 API History:
 
 > [!NOTE]
-> Refer to the [API History section of `styleguide.md`](../styleguide.md#api-history)
+> Refer to the [API History section of `style-guide.md`](./style-guide.md#api-history)
 for information on how to create API History blocks.
 
 `````markdown

--- a/docs/development/style-guide.md
+++ b/docs/development/style-guide.md
@@ -195,7 +195,7 @@ required[, optional]
 More detailed information on each of the arguments is noted in an unordered list
 below the method. The type of argument is notated by either JavaScript primitives
 (e.g. `string`, `Promise`, or `Object`), a custom API structure like Electron's
-[`Cookie`](api/structures/cookie.md), or the wildcard `any`.
+[`Cookie`](../api/structures/cookie.md), or the wildcard `any`.
 
 If the argument is of type `Array`, use `[]` shorthand with the type of value
 inside the array (for example,`any[]` or `string[]`).
@@ -290,7 +290,7 @@ The purpose of the API History block is to describe when/where/how/why an API wa
 Each API change listed in the block should include a link to the
 PR where that change was made along with an optional short description of the
 change. If applicable, include the [heading id](https://gist.github.com/asabaylus/3071099)
-for that change from the [breaking changes documentation](./breaking-changes.md).
+for that change from the [breaking changes documentation](../breaking-changes.md).
 
 The [API History linting script][api-history-linting-script] (`lint:api-history`)
 validates API History blocks in the Electron documentation against the schema and


### PR DESCRIPTION
This PR aims to give additional visibility to our documentation style guide by adding it to the PR template and moving it into `/development` to mark that it belongs with other contributor-focused docs.

Notes: none