### PR TITLE
Windows: Make setFocusable only deactivate a window if focusable is false. Do not deactivate a window when setting focusable to true.

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1336,7 +1336,8 @@ void NativeWindowViews::SetFocusable(bool focusable) {
     ex_style |= WS_EX_NOACTIVATE;
   ::SetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE, ex_style);
   SetSkipTaskbar(!focusable);
-  Focus(false);
+  if (!focusable)
+    Focus(false);
 #endif
 }
 


### PR DESCRIPTION

#### Description of Change

On Windows, calling `NativeWindowViews::SetFocusable(bool focusable)` currently always calls `Focus(false)` at the end of the function regardless of if we're setting focusable to true or false. While it does make sense to lose focus when calling `SetFocusable(false)`, it doesn't make sense to drop focus when calling `SetFocusable(true)`. Setting to `true` should also not forcibly focus. So I propose to drop focus only when `!focusable`, and do not call `Focus()` at all when `focusable`.

#### Release Notes

Notes: Windows: Calling window.setFocusable(true) will no longer cause a window to lose focus