### PR TITLE
build: run source cache clean daily

### DIFF
--- a/.github/workflows/clean-src-cache.yml
+++ b/.github/workflows/clean-src-cache.yml
@@ -1,8 +1,12 @@
 name: Clean Source Cache
 
+description: |
+  This workflow cleans up the source cache on the cross-instance cache volume
+  to free up space. It runs daily at midnight and clears files older than 15 days.
+
 on:
   schedule:
-    - cron: "0 0 * * SUN"  # Run at midnight every Sunday
+    - cron: "0 0 * * *"
 
 jobs:
   clean-src-cache:
@@ -17,5 +21,5 @@ jobs:
       shell: bash
       run: |
         df -h /mnt/cross-instance-cache
-        find /mnt/cross-instance-cache -type f -mtime +30 -delete
+        find /mnt/cross-instance-cache -type f -mtime +15 -delete
         df -h /mnt/cross-instance-cache


### PR DESCRIPTION
#### Description of Change

Attempt to address persistent source cache space issues:

See https://github.com/electron/electron/pull/45641

> The cross mount cache has 27G free space which is not enough - exiting

#### Release Notes

Notes: none