### PR TITLE
feat: remove osr framerate limit when use shared texture

### DIFF
--- a/docs/tutorial/offscreen-rendering.md
+++ b/docs/tutorial/offscreen-rendering.md
@@ -14,7 +14,7 @@ _Notes_:
 * There are two rendering modes that can be used (see the section below) and only
 the dirty area is passed to the `paint` event to be more efficient.
 * You can stop/continue the rendering as well as set the frame rate.
-* The maximum frame rate is 240 because greater values bring only performance
+* When `webPreferences.offscreen.useSharedTexture` is not `true`, the maximum frame rate is 240 because greater values bring only performance
 losses with no benefits.
 * When nothing is happening on a webpage, no frames are generated.
 * An offscreen window is always created as a

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -918,7 +918,7 @@ void OffScreenRenderWidgetHostView::SetFrameRate(int frame_rate) {
   } else {
     if (frame_rate <= 0)
       frame_rate = 1;
-    if (frame_rate > 240)
+    if (!offscreen_use_shared_texture_ && frame_rate > 240)
       frame_rate = 240;
 
     frame_rate_ = frame_rate;


### PR DESCRIPTION
#### Description of Change

Remove 240 FPS limit of OSR when using shared texture, because there's no performance limit.

#### Release Notes

Notes: Remove 240 FPS limit when use shared texture OSR.