### PR TITLE
refactor: bluetooth in serial chooser when exclusively wireless serial ports are expected

### DIFF
--- a/shell/browser/serial/serial_chooser_controller.cc
+++ b/shell/browser/serial/serial_chooser_controller.cc
@@ -164,6 +164,7 @@ void SerialChooserController::GetDevices() {
 
 void SerialChooserController::AdapterPoweredChanged(BluetoothAdapter* adapter,
                                                     bool powered) {
+  // TODO(codebytere): maybe emit an event here?
   if (powered) {
     GetDevices();
   }
@@ -274,7 +275,7 @@ void SerialChooserController::OnGetAdapter(
   std::move(callback).Run();
 }
 
-bool SerialChooserController::IsWirelessSerialPortOnly() {
+bool SerialChooserController::IsWirelessSerialPortOnly() const {
   if (allowed_bluetooth_service_class_ids_.empty()) {
     return false;
   }

--- a/shell/browser/serial/serial_chooser_controller.cc
+++ b/shell/browser/serial/serial_chooser_controller.cc
@@ -10,6 +10,8 @@
 #include "base/containers/contains.h"
 #include "base/functional/bind.h"
 #include "content/public/browser/web_contents.h"
+#include "device/bluetooth/bluetooth_adapter.h"
+#include "device/bluetooth/bluetooth_adapter_factory.h"
 #include "device/bluetooth/public/cpp/bluetooth_uuid.h"
 #include "services/device/public/cpp/bluetooth/bluetooth_utils.h"
 #include "services/device/public/mojom/serial.mojom.h"
@@ -65,6 +67,8 @@ namespace electron {
 
 namespace {
 
+using ::device::BluetoothAdapter;
+using ::device::BluetoothAdapterFactory;
 using ::device::mojom::SerialPortType;
 
 bool FilterMatchesPort(const blink::mojom::SerialPortFilter& filter,
@@ -124,8 +128,11 @@ SerialChooserController::SerialChooserController(
                          web_contents_->GetBrowserContext())
                          ->AsWeakPtr();
   DCHECK(chooser_context_);
-  chooser_context_->GetPortManager()->GetDevices(base::BindOnce(
-      &SerialChooserController::OnGetDevices, weak_factory_.GetWeakPtr()));
+
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE, base::BindOnce(&SerialChooserController::GetDevices,
+                                weak_factory_.GetWeakPtr()));
+
   observation_.Observe(chooser_context_.get());
 }
 
@@ -138,6 +145,28 @@ api::Session* SerialChooserController::GetSession() {
     return nullptr;
   }
   return api::Session::FromBrowserContext(web_contents_->GetBrowserContext());
+}
+
+void SerialChooserController::GetDevices() {
+  if (IsWirelessSerialPortOnly()) {
+    if (!adapter_) {
+      BluetoothAdapterFactory::Get()->GetAdapter(base::BindOnce(
+          &SerialChooserController::OnGetAdapter, weak_factory_.GetWeakPtr(),
+          base::BindOnce(&SerialChooserController::GetDevices,
+                         weak_factory_.GetWeakPtr())));
+      return;
+    }
+  }
+
+  chooser_context_->GetPortManager()->GetDevices(base::BindOnce(
+      &SerialChooserController::OnGetDevices, weak_factory_.GetWeakPtr()));
+}
+
+void SerialChooserController::AdapterPoweredChanged(BluetoothAdapter* adapter,
+                                                    bool powered) {
+  if (powered) {
+    GetDevices();
+  }
 }
 
 void SerialChooserController::OnPortAdded(
@@ -196,6 +225,7 @@ void SerialChooserController::OnGetDevices(
     return port1->path.BaseName() < port2->path.BaseName();
   });
 
+  ports_.clear();
   for (auto& port : ports) {
     if (DisplayDevice(*port))
       ports_.push_back(std::move(port));
@@ -234,6 +264,34 @@ void SerialChooserController::RunCallback(
   if (callback_) {
     std::move(callback_).Run(std::move(port));
   }
+}
+void SerialChooserController::OnGetAdapter(
+    base::OnceClosure callback,
+    scoped_refptr<BluetoothAdapter> adapter) {
+  CHECK(adapter);
+  adapter_ = std::move(adapter);
+  adapter_observation_.Observe(adapter_.get());
+  std::move(callback).Run();
+}
+
+bool SerialChooserController::IsWirelessSerialPortOnly() {
+  if (allowed_bluetooth_service_class_ids_.empty()) {
+    return false;
+  }
+
+  // The system's wired and wireless serial ports can be shown if there is no
+  // filter.
+  if (filters_.empty()) {
+    return false;
+  }
+
+  // Check if all the filters are meant for serial port from Bluetooth device.
+  for (const auto& filter : filters_) {
+    if (!filter->bluetooth_service_class_id) {
+      return false;
+    }
+  }
+  return true;
 }
 
 }  // namespace electron

--- a/shell/browser/serial/serial_chooser_controller.h
+++ b/shell/browser/serial/serial_chooser_controller.h
@@ -33,7 +33,7 @@ class ElectronSerialDelegate;
 // SerialChooserController provides data for the Serial API permission prompt.
 class SerialChooserController final
     : private SerialChooserContext::PortObserver,
-      public device::BluetoothAdapter::Observer {
+      private device::BluetoothAdapter::Observer {
  public:
   SerialChooserController(
       content::RenderFrameHost* render_frame_host,
@@ -71,7 +71,7 @@ class SerialChooserController final
   void OnGetAdapter(base::OnceClosure callback,
                     scoped_refptr<device::BluetoothAdapter> adapter);
   // Whether it will only show ports from bluetooth devices.
-  bool IsWirelessSerialPortOnly();
+  [[nodiscard]] bool IsWirelessSerialPortOnly() const;
 
   base::WeakPtr<content::WebContents> web_contents_;
 


### PR DESCRIPTION
#### Description of Change

Refs CL:5737296

> Enhance Web Serial chooser with Bluetooth status hints when exclusively
wireless serial ports are expected. This enhancement mirrors Web Bluetooth chooser behavior.

This change ensures our serial implementation matches upstream.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none