### PR TITLE
refactor: track downloads by guid

### DIFF
--- a/shell/browser/electron_download_manager_delegate.cc
+++ b/shell/browser/electron_download_manager_delegate.cc
@@ -218,13 +218,13 @@ void ElectronDownloadManagerDelegate::GetItemSaveDialogOptions(
 }
 
 void ElectronDownloadManagerDelegate::OnDownloadPathGenerated(
-    uint32_t download_id,
+    const std::string& download_guid,
     download::DownloadTargetCallback callback,
     const base::FilePath& default_path) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
   ScopedAllowBlockingForElectron allow_blocking;
 
-  auto* item = download_manager_->GetDownload(download_id);
+  auto* item = download_manager_->GetDownloadByGuid(download_guid);
   if (!item)
     return;
 
@@ -269,7 +269,7 @@ void ElectronDownloadManagerDelegate::OnDownloadPathGenerated(
     gin_helper::Promise<gin_helper::Dictionary> dialog_promise(isolate);
     auto dialog_callback = base::BindOnce(
         &ElectronDownloadManagerDelegate::OnDownloadSaveDialogDone,
-        base::Unretained(this), download_id, std::move(callback));
+        base::Unretained(this), download_guid, std::move(callback));
 
     std::ignore = dialog_promise.Then(std::move(dialog_callback));
     file_dialog::ShowSaveDialog(settings, std::move(dialog_promise));
@@ -286,12 +286,12 @@ void ElectronDownloadManagerDelegate::OnDownloadPathGenerated(
 }
 
 void ElectronDownloadManagerDelegate::OnDownloadSaveDialogDone(
-    uint32_t download_id,
+    const std::string& download_guid,
     download::DownloadTargetCallback download_callback,
     gin_helper::Dictionary result) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
-  auto* item = download_manager_->GetDownload(download_id);
+  auto* item = download_manager_->GetDownloadByGuid(download_guid);
   if (!item)
     return;
 
@@ -370,7 +370,7 @@ bool ElectronDownloadManagerDelegate::DetermineDownloadTarget(
                      download->GetSuggestedFilename(), download->GetMimeType(),
                      last_saved_directory_, default_download_path),
       base::BindOnce(&ElectronDownloadManagerDelegate::OnDownloadPathGenerated,
-                     weak_ptr_factory_.GetWeakPtr(), download->GetId(),
+                     weak_ptr_factory_.GetWeakPtr(), download->GetGuid(),
                      std::move(*callback)));
   return true;
 }

--- a/shell/browser/electron_download_manager_delegate.h
+++ b/shell/browser/electron_download_manager_delegate.h
@@ -48,12 +48,12 @@ class ElectronDownloadManagerDelegate
   void GetItemSaveDialogOptions(download::DownloadItem* item,
                                 file_dialog::DialogSettings* options);
 
-  void OnDownloadPathGenerated(uint32_t download_id,
+  void OnDownloadPathGenerated(const std::string& download_guid,
                                download::DownloadTargetCallback callback,
                                const base::FilePath& default_path);
 
   void OnDownloadSaveDialogDone(
-      uint32_t download_id,
+      const std::string& download_guid,
       download::DownloadTargetCallback download_callback,
       gin_helper::Dictionary result);
 


### PR DESCRIPTION
#### Description of Change

Refs http://crbug.com/593020.

Small refactor - `GetDownload` is deprecated.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none