### PR TITLE
chore: disable 'should lock the keyboard' test on macOS

### DIFF
--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -654,7 +654,7 @@ describe('chromium features', () => {
       expect(size).to.be.a('number');
     });
 
-    it('should lock the keyboard', async () => {
+    ifit(process.platform !== 'darwin')('should lock the keyboard', async () => {
       const w = new BrowserWindow({ show: true });
       await w.loadFile(path.join(fixturesPath, 'pages', 'modal.html'));
 


### PR DESCRIPTION
This has [flaked out on a half-dozen PRs](https://github.com/search?q=repo%3Aelectron%2Felectron+%22should+lock+the+keyboard%22&type=pullrequests
) in the past few weeks. It should be disabled to stop blocking PRs -> investigated ->  fixed + re-enabled.

Tracking issue: #45680

Notes: none.