### PR TITLE
fix: possible timing issue in utility-process spec

### DIFF
--- a/spec/fixtures/api/utility-process/log.js
+++ b/spec/fixtures/api/utility-process/log.js
@@ -1,3 +1,7 @@
-console.log('hello');
-process.stderr.write('world');
-process.exit(0);
+function write (writable, chunk) {
+  return new Promise((resolve) => writable.write(chunk, resolve));
+}
+
+write(process.stdout, 'hello\n')
+  .then(() => write(process.stderr, 'world'))
+  .then(() => process.exit(0));


### PR DESCRIPTION
#### Description of Change

This fixture has been calling process.exit() immediately after writing to stdout and stderr, which the [Node.js docs say](https://nodejs.org/api/process.html#processexitcode) is risky behavior:

> Calling process.exit() will force the process to exit as quickly as
> possible even if there are still asynchronous operations pending that
> have not yet completed fully, including I/O operations to
> process.stdout and process.stderr.

This fixture's been around for years without problems (AFAIK). The writes are very small (`'hello\n'` and `'world'`) so they finish quickly. But recently I've been testing on a _very_ slow CI machine. There, I see this spec flaking when it expects stderr to be `'world'` but it gets `''`. This PR changes the fixture to wait for stdout & stderr to flush before calling process.exit().

I've read through the specs that touch `log.js` and AFAICT this fix doesn't change the semantics of any of spec, e.g. none of them are looking for an unfinished write().

Yes, I'm changing a three-line .js file. Bikesheds welcome. :smile_cat: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none