### PR TITLE
docs: Update argument shape of found-in-pagein  web-contents.md

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -664,12 +664,12 @@ The usage is the same with [the `login` event of `app`](app.md#event-login).
 Returns:
 
 * `event` Event
-* `result` Object
-  * `requestId` Integer
-  * `activeMatchOrdinal` Integer - Position of the active match.
-  * `matches` Integer - Number of Matches.
-  * `selectionArea` Rectangle - Coordinates of first match region.
-  * `finalUpdate` boolean
+  * `result` Object
+    * `requestId` Integer
+    * `activeMatchOrdinal` Integer - Position of the active match.
+    * `matches` Integer - Number of Matches.
+    * `selectionArea` Rectangle - Coordinates of first match region.
+    * `finalUpdate` boolean
 
 Emitted when a result is available for
 [`webContents.findInPage`](#contentsfindinpagetext-options) request.
@@ -1646,8 +1646,8 @@ Stops any `findInPage` request for the `webContents` with the provided `action`.
 
 ```js
 const win = new BrowserWindow()
-win.webContents.on('found-in-page', (event, result) => {
-  if (result.finalUpdate) win.webContents.stopFindInPage('clearSelection')
+win.webContents.on('found-in-page', (event) => {
+  if (event.result.finalUpdate) win.webContents.stopFindInPage('clearSelection')
 })
 
 const requestId = win.webContents.findInPage('api')


### PR DESCRIPTION
#### Description of Change

According to the docs, results is a second argument for the `found-in-page` event but this is incorrect, it's a property of `event`. This PR corrects the error in the docs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none