### PR TITLE
fix: crash loading `about:blank` in subframes

### DIFF
--- a/patches/chromium/fix_crash_loading_non-standard_schemes_in_iframes.patch
+++ b/patches/chromium/fix_crash_loading_non-standard_schemes_in_iframes.patch
@@ -28,17 +28,17 @@ The patch should be removed in favor of either:
 Upstream bug https://bugs.chromium.org/p/chromium/issues/detail?id=1081397.
 
 diff --git a/content/browser/renderer_host/navigation_request.cc b/content/browser/renderer_host/navigation_request.cc
-index 0c67607fd99b2fceba176308a041c8f08643506a..82c4a7e1d441f1444d6ca32a56e8b0381209ec2f 100644
+index 0c67607fd99b2fceba176308a041c8f08643506a..6b38139e1b58db7c7a0c4d553ed2cdaa11a63d2d 100644
 --- a/content/browser/renderer_host/navigation_request.cc
 +++ b/content/browser/renderer_host/navigation_request.cc
 @@ -10980,6 +10980,12 @@ NavigationRequest::GetOriginForURLLoaderFactoryUncheckedWithDebugInfo() {
          "blob");
    }
  
-+  if (!IsInMainFrame() && !common_params().url.IsStandard()) {
++  if (!common_params().url.IsStandard() && !common_params().url.IsAboutBlank()) {
 +    return std::make_pair(url::Origin::Resolve(common_params().url,
-+                                               url::Origin()),
-+                          "url_non_standard");
++                                url::Origin()),
++          "url_non_standard");
 +  }
 +
    // In cases not covered above, URLLoaderFactory should be associated with the


### PR DESCRIPTION
#### Description of Change

Refs https://chromium-review.googlesource.com/c/chromium/src/+/5873739
Refs https://github.com/electron/electron/pull/44986

Closes https://github.com/electron/electron/issues/45653.
Closes https://github.com/electron/electron/issues/45610

Fixes an issue where the renderer process crashes when loading `about:blank` in subframes. This happened resultant of the above CLs - we shouldn't be attempting to return a null origin for non-standard `about:blank` schemes.

Also removes a conditional for this occurring on subframes only - it's possible for this to affect e.g. the pdf viewer as well which is a main frame cc @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where the renderer process crashed when loading `about:blank` in subframes.