### PR TITLE
fix: extension web workers net request failing

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1074,6 +1074,12 @@ void ElectronBrowserClient::
   // reason for it, and we could consider supporting it in future.
   protocol_registry->RegisterURLLoaderFactories(factories,
                                                 false /* allow_file_access */);
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+  factories->emplace(
+      extensions::kExtensionScheme,
+      extensions::CreateExtensionWorkerMainResourceURLLoaderFactory(
+          browser_context));
+#endif
 }
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)


### PR DESCRIPTION
#### Description of Change

Fixes an issue with chrome extensions in which calling `new Worker('chrome-extension://...')` would fail with `ERR_UNKNOWN_URL_SCHEME`. Below is a net log snippet of the problem.

```
42: URL_REQUEST
chrome-extension://likgccmbimhjbgkjambclfkhldnlhbnn/js/dictionary/dictionary-database-worker-main.js
Start Time: 2025-02-18 19:52:14.572

t=298 [st=0] +CORS_REQUEST  [dt=0]
              --> cors_preflight_policy = "consider_preflight"
              --> headers = "Accept: */*\r\n\r\n"
              --> is_revalidating = false
              --> method = "GET"
              --> url = "chrome-extension://likgccmbimhjbgkjambclfkhldnlhbnn/js/dictionary/dictionary-database-worker-main.js"
t=298 [st=0]    CHECK_CORS_PREFLIGHT_REQUIRED
                --> preflight_required = false
t=298 [st=0]   +REQUEST_ALIVE  [dt=0]
                --> priority = "IDLE"
                --> traffic_annotation = 72087791
                --> url = "chrome-extension://likgccmbimhjbgkjambclfkhldnlhbnn/js/dictionary/dictionary-database-worker-main.js"
t=298 [st=0]      NETWORK_DELEGATE_BEFORE_URL_REQUEST  [dt=0]
t=298 [st=0]     +URL_REQUEST_START_JOB  [dt=0]
                  --> initiator = "chrome-extension://likgccmbimhjbgkjambclfkhldnlhbnn"
                  --> load_flags = 131072 (CAN_USE_SHARED_DICTIONARY)
                  --> method = "GET"
                  --> network_isolation_key = "chrome-extension://likgccmbimhjbgkjambclfkhldnlhbnn chrome-extension://likgccmbimhjbgkjambclfkhldnlhbnn"
                  --> request_type = "other"
                  --> site_for_cookies = "SiteForCookies: {site=chrome-extension://likgccmbimhjbgkjambclfkhldnlhbnn; schemefully_same=true}"
                  --> url = "chrome-extension://likgccmbimhjbgkjambclfkhldnlhbnn/js/dictionary/dictionary-database-worker-main.js"
t=298 [st=0]     -URL_REQUEST_START_JOB
                  --> net_error = -302 (ERR_UNKNOWN_URL_SCHEME)
t=298 [st=0]      URL_REQUEST_DELEGATE_RESPONSE_STARTED  [dt=0]
t=298 [st=0] -CORS_REQUEST
t=298 [st=0] -URL_REQUEST_DELEGATE_RESPONSE_STARTED
t=298 [st=0] -REQUEST_ALIVE
              --> net_error = -302 (ERR_UNKNOWN_URL_SCHEME)
```

Here's the same code where it's added in Chrome: https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/chrome_content_browser_client.cc;l=6210-6218;drc=798b98d70313e6a55bcf9cc85bc7ca7d42ca6d23

relates to https://github.com/samuelmaddock/electron-browser-shell/issues/106

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes web worker scripts failing to load for chrome extensions.
