### PR TITLE
chore: cherry-pick 3 changes from 1-M132

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -14,3 +14,6 @@ merged_turboshaft_wasm_wasmgctypeanalyzer_fix_phi_input_for.patch
 merged_turboshaft_wasm_wasmgctypeanalyzer_fix_single-block_loops.patch
 merged_interpreter_fix_hole_elision_scope_for_switch_jump_tables.patch
 merged_reland_lower_the_maximum_js_parameter_count.patch
+cherry-pick-9209292e7898.patch
+cherry-pick-97e828af5cbc.patch
+cherry-pick-ca504d096c39.patch

--- a/patches/v8/cherry-pick-9209292e7898.patch
+++ b/patches/v8/cherry-pick-9209292e7898.patch
@@ -1,0 +1,74 @@
+From 9209292e7898a05a98d271c3c597a09d66819292 Mon Sep 17 00:00:00 2001
+From: Darius Mercadier <dmercadier@chromium.org>
+Date: Wed, 08 Jan 2025 14:37:24 +0100
+Subject: [PATCH] Merged: [turbofan] Fix CallWithSpread bug when array prototype has changed
+
+Bug: chromium:385386138
+(cherry picked from commit 1be46f0e2e71159a74d8614f9ac108d334797729)
+
+Change-Id: I8b0c95c4072652e6b9ccab792b6685e0e0dcfbb9
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6172284
+Auto-Submit: Darius Mercadier <dmercadier@chromium.org>
+Commit-Queue: Darius Mercadier <dmercadier@chromium.org>
+Reviewed-by: Nico Hartmann <nicohartmann@chromium.org>
+Cr-Commit-Position: refs/branch-heads/13.2@{#58}
+Cr-Branched-From: 24068c59cedad9ee976ddc05431f5f497b1ebd71-refs/heads/13.2.152@{#1}
+Cr-Branched-From: 6054ba94db0969220be4f94dc1677fc4696bdc4f-refs/heads/main@{#97085}
+---
+
+diff --git a/src/compiler/js-call-reducer.cc b/src/compiler/js-call-reducer.cc
+index a29bd4a..08fd278 100644
+--- a/src/compiler/js-call-reducer.cc
++++ b/src/compiler/js-call-reducer.cc
+@@ -5226,6 +5226,18 @@
+   DCHECK_EQ(static_cast<Node*>(arguments_list)->opcode(),
+             IrOpcode::kJSCreateEmptyLiteralArray);
+ 
++  // Check that arguments_list's prototype is still an array prototype.
++  TNode<Map> map = LoadMap(TNode<HeapObject>::UncheckedCast(arguments_list));
++  TNode<HeapObject> proto = TNode<HeapObject>::UncheckedCast(
++      LoadField(AccessBuilder::ForMapPrototype(), map));
++  TNode<HeapObject> initial_array_prototype =
++      HeapConstant(broker()
++                       ->target_native_context()
++                       .initial_array_prototype(broker())
++                       .object());
++  TNode<Boolean> check = ReferenceEqual(proto, initial_array_prototype);
++  CheckIf(check, DeoptimizeReason::kWrongMap, p.feedback());
++
+   // Turn the JSCallWithArrayLike or JSCallWithSpread roughly into:
+   //
+   //      "arguments_list array is still empty?"
+diff --git a/test/mjsunit/compiler/regress-385386138.js b/test/mjsunit/compiler/regress-385386138.js
+new file mode 100644
+index 0000000..72dadea
+--- /dev/null
++++ b/test/mjsunit/compiler/regress-385386138.js
+@@ -0,0 +1,27 @@
++// Copyright 2024 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// Flags: --allow-natives-syntax --turbofan --no-always-turbofan
++
++function foo() {
++  let val = [];
++  val.__proto__ = RegExp();
++  return Math.max(...val);
++}
++
++%PrepareFunctionForOptimization(foo);
++assertThrows(() => foo(), TypeError,
++             "Spread syntax requires ...iterable[Symbol.iterator] to be a function");
++
++%OptimizeFunctionOnNextCall(foo);
++assertThrows(() => foo(), TypeError,
++             "Spread syntax requires ...iterable[Symbol.iterator] to be a function");
++assertUnoptimized(foo);
++
++
++%OptimizeFunctionOnNextCall(foo);
++assertThrows(() => foo(), TypeError,
++             "Spread syntax requires ...iterable[Symbol.iterator] to be a function");
++// TF should not have speculatively optimized CallWithSpread.
++assertOptimized(foo);

--- a/patches/v8/cherry-pick-97e828af5cbc.patch
+++ b/patches/v8/cherry-pick-97e828af5cbc.patch
@@ -1,0 +1,94 @@
+From 97e828af5cbcf50c3ff0064a4a5c22e18c18b4b5 Mon Sep 17 00:00:00 2001
+From: Olivier Flückiger <olivf@chromium.org>
+Date: Wed, 08 Jan 2025 16:06:43 +0100
+Subject: [PATCH] Merged: [maglev] regalloc: handle non-loop resumable_loops
+
+Resumable loops which are not loops can be either:
+
+1. An unreachable loop with only a back-edge
+2. A fall-through to a resumable loop with a dead back-edge
+
+Only (1) starts with an empty register state.
+
+Fixed: 386143468
+(cherry picked from commit b44bd24761f1a2eae131bd90be15b5a68cc70f83)
+
+Change-Id: I9ebb028fe17c6f1de00825837acec6f8169dbf67
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6172463
+Auto-Submit: Olivier Flückiger <olivf@chromium.org>
+Reviewed-by: Toon Verwaest <verwaest@chromium.org>
+Commit-Queue: Toon Verwaest <verwaest@chromium.org>
+Cr-Commit-Position: refs/branch-heads/13.2@{#60}
+Cr-Branched-From: 24068c59cedad9ee976ddc05431f5f497b1ebd71-refs/heads/13.2.152@{#1}
+Cr-Branched-From: 6054ba94db0969220be4f94dc1677fc4696bdc4f-refs/heads/main@{#97085}
+---
+
+diff --git a/src/maglev/maglev-interpreter-frame-state.cc b/src/maglev/maglev-interpreter-frame-state.cc
+index 7d904bb..dce7517 100644
+--- a/src/maglev/maglev-interpreter-frame-state.cc
++++ b/src/maglev/maglev-interpreter-frame-state.cc
+@@ -1370,6 +1370,23 @@
+   }
+ }
+ 
++bool MergePointInterpreterFrameState::IsUnreachable() const {
++  DCHECK_EQ(predecessors_so_far_, predecessor_count_);
++  if (predecessor_count_ > 1) {
++    return false;
++  }
++  // This should actually only support predecessor_count == 1, but we
++  // currently don't eliminate resumable loop headers (and subsequent code
++  // until the next resume) that end up being unreachable from JumpLoop.
++  if (predecessor_count_ == 0) {
++    DCHECK(is_resumable_loop());
++    return true;
++  }
++  DCHECK_EQ(predecessor_count_, 1);
++  DCHECK_IMPLIES(is_loop(), predecessor_at(0)->control_node()->Is<JumpLoop>());
++  return is_loop();
++}
++
+ }  // namespace maglev
+ }  // namespace internal
+ }  // namespace v8
+diff --git a/src/maglev/maglev-interpreter-frame-state.h b/src/maglev/maglev-interpreter-frame-state.h
+index d8e618f..3d04b93 100644
+--- a/src/maglev/maglev-interpreter-frame-state.h
++++ b/src/maglev/maglev-interpreter-frame-state.h
+@@ -948,6 +948,8 @@
+            predecessors_so_far_ == 0;
+   }
+ 
++  bool IsUnreachable() const;
++
+   BasicBlockType basic_block_type() const {
+     return kBasicBlockTypeBits::decode(bitfield_);
+   }
+diff --git a/src/maglev/maglev-regalloc.cc b/src/maglev/maglev-regalloc.cc
+index 00456fa..a1d24ed 100644
+--- a/src/maglev/maglev-regalloc.cc
++++ b/src/maglev/maglev-regalloc.cc
+@@ -157,7 +157,7 @@
+   }
+ 
+   // Drop all values on resumable loop headers.
+-  if (target->has_state() && target->state()->is_resumable_loop()) return false;
++  if (target->is_loop() && target->state()->is_resumable_loop()) return false;
+ 
+   // TODO(verwaest): This should be true but isn't because we don't yet
+   // eliminate dead code.
+@@ -409,13 +409,9 @@
+       if (block->state()->is_exception_handler()) {
+         // Exceptions start from a blank state of register values.
+         ClearRegisterValues();
+-      } else if (block->state()->is_resumable_loop() &&
+-                 block->state()->predecessor_count() <= 1) {
++      } else if (block->state()->IsUnreachable()) {
+         // Loops that are only reachable through JumpLoop start from a blank
+         // state of register values.
+-        // This should actually only support predecessor_count == 1, but we
+-        // currently don't eliminate resumable loop headers (and subsequent code
+-        // until the next resume) that end up being unreachable from JumpLoop.
+         ClearRegisterValues();
+       } else {
+         InitializeRegisterValues(block->state()->register_state());

--- a/patches/v8/cherry-pick-ca504d096c39.patch
+++ b/patches/v8/cherry-pick-ca504d096c39.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Toon Verwaest <verwaest@chromium.org>
+Date: Tue, 7 Jan 2025 13:35:04 +0100
+Subject: Merged: [compiler] Check max-args when calling bound functions
+
+Bug: 385155406
+(cherry picked from commit d35770876597b8c25de3c483b9368686f3a9fda8)
+
+Change-Id: I98c7166588f4099c5665ff94dc65da5c25be7535
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6175036
+Reviewed-by: Leszek Swirski <leszeks@chromium.org>
+Commit-Queue: Leszek Swirski <leszeks@chromium.org>
+Auto-Submit: Toon Verwaest <verwaest@chromium.org>
+Cr-Commit-Position: refs/branch-heads/13.2@{#62}
+Cr-Branched-From: 24068c59cedad9ee976ddc05431f5f497b1ebd71-refs/heads/13.2.152@{#1}
+Cr-Branched-From: 6054ba94db0969220be4f94dc1677fc4696bdc4f-refs/heads/main@{#97085}
+
+diff --git a/src/compiler/js-call-reducer.cc b/src/compiler/js-call-reducer.cc
+index d38e1c2eff3e583a2da0c1e7b7c32e67bdf6f702..59373c70aad6e0e583b38990371c853d75b9d21e 100644
+--- a/src/compiler/js-call-reducer.cc
++++ b/src/compiler/js-call-reducer.cc
+@@ -4662,6 +4662,9 @@ Reduction JSCallReducer::ReduceJSCall(Node* node) {
+       // succeed.
+       FixedArrayRef bound_arguments = function.bound_arguments(broker());
+       const int bound_arguments_length = bound_arguments.length();
++      if (arity + bound_arguments_length > Code::kMaxArguments) {
++        return NoChange();
++      }
+       static constexpr int kInlineSize = 16;  // Arbitrary.
+       base::SmallVector<Node*, kInlineSize> args;
+       for (int i = 0; i < bound_arguments_length; ++i) {
+diff --git a/src/compiler/js-inlining.cc b/src/compiler/js-inlining.cc
+index f6575134e4cbfd321b26769dd72a59ac2a4e88c6..dfa5c0a01ebc496282ec4c0220e4ba6441f2148d 100644
+--- a/src/compiler/js-inlining.cc
++++ b/src/compiler/js-inlining.cc
+@@ -248,6 +248,7 @@ FrameState JSInliner::CreateArtificialFrameState(
+     Node* context, Node* callee) {
+   const int parameter_count_with_receiver =
+       parameter_count + JSCallOrConstructNode::kReceiverOrNewTargetInputCount;
++  CHECK_LE(parameter_count_with_receiver, kMaxUInt16);
+   const FrameStateFunctionInfo* state_info =
+       common()->CreateFrameStateFunctionInfo(frame_state_type,
+                                              parameter_count_with_receiver, 0,


### PR DESCRIPTION
<details>
<summary>electron/security#647 - 9209292e7898 from v8</summary>
Merged: [turbofan] Fix CallWithSpread bug when array prototype has changed

Bug: chromium:385386138
(cherry picked from commit 1be46f0e2e71159a74d8614f9ac108d334797729)

Change-Id: I8b0c95c4072652e6b9ccab792b6685e0e0dcfbb9
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6172284
Auto-Submit: Darius Mercadier <dmercadier@chromium.org>
Commit-Queue: Darius Mercadier <dmercadier@chromium.org>
Reviewed-by: Nico Hartmann <nicohartmann@chromium.org>
Cr-Commit-Position: refs/branch-heads/13.2@{#58}
Cr-Branched-From: 24068c59cedad9ee976ddc05431f5f497b1ebd71-refs/heads/13.2.152@{#1}
Cr-Branched-From: 6054ba94db0969220be4f94dc1677fc4696bdc4f-refs/heads/main@{#97085}
</details>

<details>
<summary>electron/security#646 - 97e828af5cbc from v8</summary>
Merged: [maglev] regalloc: handle non-loop resumable_loops

Resumable loops which are not loops can be either:

1. An unreachable loop with only a back-edge
2. A fall-through to a resumable loop with a dead back-edge

Only (1) starts with an empty register state.

Fixed: 386143468
(cherry picked from commit b44bd24761f1a2eae131bd90be15b5a68cc70f83)

Change-Id: I9ebb028fe17c6f1de00825837acec6f8169dbf67
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6172463
Auto-Submit: Olivier Flückiger <olivf@chromium.org>
Reviewed-by: Toon Verwaest <verwaest@chromium.org>
Commit-Queue: Toon Verwaest <verwaest@chromium.org>
Cr-Commit-Position: refs/branch-heads/13.2@{#60}
Cr-Branched-From: 24068c59cedad9ee976ddc05431f5f497b1ebd71-refs/heads/13.2.152@{#1}
Cr-Branched-From: 6054ba94db0969220be4f94dc1677fc4696bdc4f-refs/heads/main@{#97085}
</details>

<details>
<summary>electron/security#648 - ca504d096c39 from v8</summary>
Merged: [compiler] Check max-args when calling bound functions

Bug: 385155406
(cherry picked from commit d35770876597b8c25de3c483b9368686f3a9fda8)

Change-Id: I98c7166588f4099c5665ff94dc65da5c25be7535
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6175036
Reviewed-by: Leszek Swirski <leszeks@chromium.org>
Commit-Queue: Leszek Swirski <leszeks@chromium.org>
Auto-Submit: Toon Verwaest <verwaest@chromium.org>
Cr-Commit-Position: refs/branch-heads/13.2@{#62}
Cr-Branched-From: 24068c59cedad9ee976ddc05431f5f497b1ebd71-refs/heads/13.2.152@{#1}
Cr-Branched-From: 6054ba94db0969220be4f94dc1677fc4696bdc4f-refs/heads/main@{#97085}
</details>

Notes:
* Security: backported fix for 385386138.
* Security: backported fix for CVE-2025-0611.
* Security: backported fix for CVE-2025-0612.