### PR TITLE
refactor: use base::as_byte_span() in EncodeToken().

### DIFF
--- a/shell/browser/serial/serial_chooser_context.cc
+++ b/shell/browser/serial/serial_chooser_context.cc
@@ -28,8 +28,7 @@ namespace {
 std::string EncodeToken(const base::UnguessableToken& token) {
   const uint64_t data[2] = {token.GetHighForSerialization(),
                             token.GetLowForSerialization()};
-  return base::Base64Encode(
-      std::string_view(reinterpret_cast<const char*>(&data[0]), sizeof(data)));
+  return base::Base64Encode(base::as_byte_span(data));
 }
 
 base::Value PortInfoToValue(const device::mojom::SerialPortInfo& port) {


### PR DESCRIPTION
#### Description of Change

Small cleanup to use `base::as_byte_span()` in `EncodeToken()` to match [the changes in upstream's serial_chooser_context.cc](https://chromium-review.googlesource.com/c/chromium/src/+/5247305).

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.