### PR TITLE
fix: crash on `getUserMedia` with invalid `chromeMediaSourceId`

### DIFF
--- a/spec/api-media-handler-spec.ts
+++ b/spec/api-media-handler-spec.ts
@@ -400,6 +400,23 @@ describe('setDisplayMediaRequestHandler', () => {
     expect(ok).to.be.true(message);
   });
 
+  it('throws an error when calling legacy getUserMedia with invalid chromeMediaSourceId', async () => {
+    const w = new BrowserWindow({ show: false });
+    await w.loadURL(serverUrl);
+    const { ok, message } = await w.webContents.executeJavaScript(`
+      new Promise((resolve, reject) => navigator.getUserMedia({
+         video: {
+          mandatory: {
+            chromeMediaSource: 'desktop',
+            chromeMediaSourceId: undefined,
+          },
+        },
+      }, x => resolve({ok: x instanceof MediaStream}), e => resolve({ ok: false, message: e.message })))
+    `);
+    expect(ok).to.be.false();
+    expect(message).to.equal('Invalid state');
+  });
+
   it('can remove a displayMediaRequestHandler', async () => {
     const ses = session.fromPartition('' + Math.random());
 


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/45713.

When a an id from `chromeMediaSourceId` can't be parsed via `content::DesktopMediaID::Parse`, a `null` `DesktopMediaID` is returned with `Type::NONE`. Calling `ToString` on a null `DesktopMediaID` results in a `NOTREACHED` crash. This also fails in upstream - so we should error on this as well.

<details><summary>Upstream</summary>
<p>

<img width="335" alt="Screenshot 2025-02-20 at 12 30 17 PM" src="https://github.com/user-attachments/assets/6ebf5067-8501-4b2c-a73d-e3eae80686e0" />

</p>
</details> 

<details><summary>After Fix</summary>
<p>

<img width="565" alt="Screenshot 2025-02-20 at 7 58 51 PM" src="https://github.com/user-attachments/assets/f3fcc089-5768-47d1-9890-79ce860a10f8" />

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash when calling legacy `getUserMedia` with an invalid  `chromeMediaSourceId`.
