### PR TITLE
build: skip chromium git cookie on forks

### DIFF
--- a/.github/actions/set-chromium-cookie/action.yml
+++ b/.github/actions/set-chromium-cookie/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
   - name: Set the git cookie from chromium.googlesource.com (Unix)
-    if: ${{ runner.os != 'Windows' }}
+    if: ${{ runner.os != 'Windows' && env.CHROMIUM_GIT_COOKIE }}
     shell: bash
     run: |
       eval 'set +o history' 2>/dev/null || setopt HIST_IGNORE_SPACE 2>/dev/null
@@ -18,7 +18,7 @@ runs:
       __END__
       eval 'set -o history' 2>/dev/null || unsetopt HIST_IGNORE_SPACE 2>/dev/null
   - name: Set the git cookie from chromium.googlesource.com (Windows)
-    if: ${{ runner.os == 'Windows' }}
+    if: ${{ runner.os == 'Windows' && env.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
     shell: cmd
     run: |
       git config --global http.cookiefile "%USERPROFILE%\.gitcookies"


### PR DESCRIPTION
#### Description of Change

relates to https://github.com/electron/electron/pull/45669

Need to skip setting this to fix build failures on Windows due to empty strings in the powershell command.
https://github.com/electron/electron/actions/runs/13386146994/job/37515175922?pr=45669

```
powershell -noprofile -nologo -command Write-Output "" >>"%USERPROFILE%\.gitcookies"
Write-Output : Cannot process command because of one or more missing mandatory parameters: InputObject.
At line:1 char:1
+ Write-Output
+ ~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Write-Output], ParameterBindingException
    + FullyQualifiedErrorId : MissingMandatoryParameter,Microsoft.PowerShell.Commands.WriteOutputCommand
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
