### PR TITLE
refactor: use base's map utills in WebFrameMain

### DIFF
--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/containers/map_util.h"
 #include "base/feature_list.h"
 #include "base/logging.h"
 #include "base/no_destructor.h"
@@ -121,19 +122,13 @@ FrameTokenMap& GetFrameTokenMap() {
 // static
 WebFrameMain* WebFrameMain::FromFrameTreeNodeId(
     content::FrameTreeNodeId frame_tree_node_id) {
-  FrameTreeNodeIdMap& frame_map = GetFrameTreeNodeIdMap();
-  auto iter = frame_map.find(frame_tree_node_id);
-  auto* web_frame = iter == frame_map.end() ? nullptr : iter->second;
-  return web_frame;
+  return base::FindPtrOrNull(GetFrameTreeNodeIdMap(), frame_tree_node_id);
 }
 
 // static
 WebFrameMain* WebFrameMain::FromFrameToken(
     content::GlobalRenderFrameHostToken frame_token) {
-  FrameTokenMap& frame_map = GetFrameTokenMap();
-  auto iter = frame_map.find(frame_token);
-  auto* web_frame = iter == frame_map.end() ? nullptr : iter->second;
-  return web_frame;
+  return base::FindPtrOrNull(GetFrameTokenMap(), frame_token);
 }
 
 // static


### PR DESCRIPTION
#### Description of Change

Use `base::FindPtrOrNull()` in `WebFrameMain::FromFrameTreeNodeId()` and in `WebFrameMain::FromFrameToken()`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.