### PR TITLE
refactor: use C++20's contains() method

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/containers/contains.h"
 #include "base/task/single_thread_task_runner.h"
 #include "content/public/common/color_parser.h"
 #include "electron/buildflags/buildflags.h"
@@ -1052,7 +1051,7 @@ void BaseWindow::UnhookWindowMessage(UINT message) {
 }
 
 bool BaseWindow::IsWindowMessageHooked(UINT message) {
-  return base::Contains(messages_callback_map_, message);
+  return messages_callback_map_.contains(message);
 }
 
 void BaseWindow::UnhookAllWindowMessages() {

--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -7,7 +7,6 @@
 #include <string>
 #include <vector>
 
-#include "base/containers/contains.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/uuid.h"
 #include "components/prefs/pref_service.h"
@@ -58,7 +57,7 @@ GlobalShortcut::~GlobalShortcut() {
 }
 
 void GlobalShortcut::OnKeyPressed(const ui::Accelerator& accelerator) {
-  if (!base::Contains(accelerator_callback_map_, accelerator)) {
+  if (!accelerator_callback_map_.contains(accelerator)) {
     // This should never occur, because if it does,
     // ui::GlobalAcceleratorListener notifies us with wrong accelerator.
     NOTREACHED();
@@ -68,7 +67,7 @@ void GlobalShortcut::OnKeyPressed(const ui::Accelerator& accelerator) {
 
 void GlobalShortcut::ExecuteCommand(const extensions::ExtensionId& extension_id,
                                     const std::string& command_id) {
-  if (!base::Contains(command_callback_map_, command_id)) {
+  if (!command_callback_map_.contains(command_id)) {
     // This should never occur, because if it does, GlobalAcceleratorListener
     // notifies us with wrong command.
     NOTREACHED();
@@ -195,12 +194,12 @@ void GlobalShortcut::UnregisterSome(
 }
 
 bool GlobalShortcut::IsRegistered(const ui::Accelerator& accelerator) {
-  if (base::Contains(accelerator_callback_map_, accelerator)) {
+  if (accelerator_callback_map_.contains(accelerator)) {
     return true;
   }
   const std::string command_str =
       extensions::Command::AcceleratorToString(accelerator);
-  return base::Contains(command_callback_map_, command_str);
+  return command_callback_map_.contains(command_str);
 }
 
 void GlobalShortcut::UnregisterAll() {

--- a/shell/browser/api/electron_api_power_save_blocker.cc
+++ b/shell/browser/api/electron_api_power_save_blocker.cc
@@ -6,7 +6,6 @@
 
 #include <string>
 
-#include "base/containers/contains.h"
 #include "base/functional/callback_helpers.h"
 #include "content/public/browser/device_service.h"
 #include "gin/dictionary.h"
@@ -110,7 +109,7 @@ bool PowerSaveBlocker::Stop(int id) {
 }
 
 bool PowerSaveBlocker::IsStarted(int id) const {
-  return base::Contains(wake_lock_types_, id);
+  return wake_lock_types_.contains(id);
 }
 
 // static

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "base/command_line.h"
+#include "base/containers/contains.h"
 #include "content/common/url_schemes.h"
 #include "content/public/browser/child_process_security_policy.h"
 #include "gin/handle.h"

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -1523,7 +1523,7 @@ v8::Local<v8::Promise> Session::ClearCodeCaches(
   if (options.Get("urls", &url_list) && !url_list.empty()) {
     url_matcher = base::BindRepeating(
         [](const std::set<GURL>& url_list, const GURL& url) {
-          return base::Contains(url_list, url);
+          return url_list.contains(url);
         },
         url_list);
   }

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -15,7 +15,6 @@
 #include <vector>
 
 #include "base/base64.h"
-#include "base/containers/contains.h"
 #include "base/containers/fixed_flat_map.h"
 #include "base/containers/id_map.h"
 #include "base/files/file_util.h"
@@ -700,8 +699,7 @@ std::map<std::string, std::string> GetAddedFileSystemPaths(
 
 bool IsDevToolsFileSystemAdded(content::WebContents* web_contents,
                                const std::string& file_system_path) {
-  return base::Contains(GetAddedFileSystemPaths(web_contents),
-                        file_system_path);
+  return GetAddedFileSystemPaths(web_contents).contains(file_system_path);
 }
 
 content::RenderFrameHost* GetRenderFrameHost(

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -4158,7 +4158,7 @@ void WebContents::DevToolsIndexPath(
     OnDevToolsIndexingDone(request_id, file_system_path);
     return;
   }
-  if (devtools_indexing_jobs_.count(request_id) != 0)
+  if (devtools_indexing_jobs_.contains(request_id))
     return;
   std::vector<std::string> excluded_folders;
   std::optional<base::Value> parsed_excluded_folders =

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -160,7 +160,7 @@ WebFrameMain::WebFrameMain(content::RenderFrameHost* rfh)
   if (!render_frame_detached_)
     GetFrameTreeNodeIdMap().emplace(frame_tree_node_id_, this);
 
-  DCHECK(GetFrameTokenMap().find(frame_token_) == GetFrameTokenMap().end());
+  DCHECK(!GetFrameTokenMap().contains(frame_token_));
   GetFrameTokenMap().emplace(frame_token_, this);
 
   // WebFrameMain should only be created for active or unloading frames.
@@ -198,7 +198,7 @@ void WebFrameMain::UpdateRenderFrameHost(content::RenderFrameHost* rfh) {
   // Ensure that RFH being swapped in doesn't already exist as its own
   // WebFrameMain instance.
   frame_token_ = rfh->GetGlobalFrameToken();
-  DCHECK(GetFrameTokenMap().find(frame_token_) == GetFrameTokenMap().end());
+  DCHECK(!GetFrameTokenMap().contains(frame_token_));
   GetFrameTokenMap().emplace(frame_token_, this);
 
   render_frame_disposed_ = false;

--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -9,7 +9,6 @@
 #include <string_view>
 #include <utility>
 
-#include "base/containers/contains.h"
 #include "base/containers/fixed_flat_map.h"
 #include "base/memory/raw_ptr.h"
 #include "base/task/sequenced_task_runner.h"
@@ -251,7 +250,7 @@ bool WebRequest::RequestFilter::MatchesURL(
 
 bool WebRequest::RequestFilter::MatchesType(
     extensions::WebRequestResourceType type) const {
-  return types_.empty() || base::Contains(types_, type);
+  return types_.empty() || types_.contains(type);
 }
 
 bool WebRequest::RequestFilter::MatchesRequest(

--- a/shell/browser/api/message_port.cc
+++ b/shell/browser/api/message_port.cc
@@ -8,7 +8,6 @@
 #include <unordered_set>
 #include <utility>
 
-#include "base/containers/contains.h"
 #include "base/containers/to_vector.h"
 #include "base/task/single_thread_task_runner.h"
 #include "gin/arguments.h"
@@ -233,7 +232,7 @@ std::vector<blink::MessagePortChannel> MessagePort::DisentanglePorts(
   // or cloned ports, throw an error (per section 8.3.3 of the HTML5 spec).
   for (unsigned i = 0; i < ports.size(); ++i) {
     auto* port = ports[i].get();
-    if (!port || port->IsNeutered() || base::Contains(visited, port)) {
+    if (!port || port->IsNeutered() || visited.contains(port)) {
       std::string type;
       if (!port)
         type = "null";

--- a/shell/browser/electron_autofill_driver_factory.cc
+++ b/shell/browser/electron_autofill_driver_factory.cc
@@ -83,7 +83,7 @@ AutofillDriver* AutofillDriverFactory::DriverForFrame(
                 driver.get());
     } else {
       driver_map_.erase(insertion_result.first);
-      DCHECK_EQ(driver_map_.count(render_frame_host), 0u);
+      DCHECK(!driver_map_.contains(render_frame_host));
       return nullptr;
     }
   }

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -379,7 +379,7 @@ content::SiteInstance* ElectronBrowserClient::GetSiteInstanceFromAffinity(
 
 bool ElectronBrowserClient::IsRendererSubFrame(
     content::ChildProcessId process_id) const {
-  return base::Contains(renderer_is_subframe_, process_id);
+  return renderer_is_subframe_.contains(process_id);
 }
 
 void ElectronBrowserClient::RenderProcessWillLaunch(

--- a/shell/browser/extensions/api/scripting/scripting_api.cc
+++ b/shell/browser/extensions/api/scripting/scripting_api.cc
@@ -7,7 +7,6 @@
 #include <algorithm>
 
 #include "base/check.h"
-#include "base/containers/contains.h"
 #include "base/json/json_writer.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
@@ -947,13 +946,13 @@ ScriptingGetRegisteredContentScriptsFunction::Run() {
       continue;
     }
 
-    if (!id_filter.empty() && !base::Contains(id_filter, script->id())) {
+    if (!id_filter.empty() && !id_filter.contains(script->id())) {
       continue;
     }
 
     auto registered_script = CreateRegisteredContentScriptInfo(*script);
     registered_script.persist_across_sessions =
-        base::Contains(persistent_script_ids, script->id());
+        persistent_script_ids.contains(script->id());
 
     // Remove the internally used prefix from the `script`'s ID before
     // returning.
@@ -1123,7 +1122,7 @@ std::unique_ptr<UserScript> ScriptingUpdateContentScriptsFunction::ApplyUpdate(
   // original script is persisted and the flag is not specified.
   if (new_script.persist_across_sessions.value_or(false) ||
       (!new_script.persist_across_sessions &&
-       base::Contains(*script_ids_to_persist, new_script.id))) {
+       script_ids_to_persist->contains(new_script.id))) {
     script_ids_to_persist->insert(new_script.id);
   }
 

--- a/shell/browser/extensions/api/tabs/tabs_api.cc
+++ b/shell/browser/extensions/api/tabs/tabs_api.cc
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "base/command_line.h"
+#include "base/containers/contains.h"
 #include "base/strings/pattern.h"
 #include "base/types/expected_macros.h"
 #include "chrome/common/url_constants.h"

--- a/shell/browser/extensions/electron_component_extension_resource_manager.cc
+++ b/shell/browser/extensions/electron_component_extension_resource_manager.cc
@@ -7,7 +7,6 @@
 #include <string>
 #include <utility>
 
-#include "base/containers/contains.h"
 #include "base/path_service.h"
 #include "base/values.h"
 #include "chrome/common/chrome_paths.h"
@@ -89,7 +88,7 @@ void ElectronComponentExtensionResourceManager::AddComponentResourceEntries(
     resource_path = resource_path.NormalizePathSeparators();
 
     if (!gen_folder_path.IsParent(resource_path)) {
-      DCHECK(!base::Contains(path_to_resource_id_, resource_path));
+      DCHECK(!path_to_resource_id_.contains(resource_path));
       path_to_resource_id_[resource_path] = entry.id;
     } else {
       // If the resource is a generated file, strip the generated folder's path,
@@ -98,7 +97,7 @@ void ElectronComponentExtensionResourceManager::AddComponentResourceEntries(
       base::FilePath effective_path =
           base::FilePath().AppendASCII(resource_path.AsUTF8Unsafe().substr(
               gen_folder_path.value().length()));
-      DCHECK(!base::Contains(path_to_resource_id_, effective_path));
+      DCHECK(!path_to_resource_id_.contains(effective_path));
       path_to_resource_id_[effective_path] = entry.id;
     }
   }

--- a/shell/browser/hid/electron_hid_delegate.cc
+++ b/shell/browser/hid/electron_hid_delegate.cc
@@ -7,7 +7,6 @@
 #include <string>
 #include <utility>
 
-#include "base/containers/contains.h"
 #include "base/scoped_observation.h"
 #include "chrome/common/chrome_features.h"
 #include "content/public/browser/web_contents.h"
@@ -118,7 +117,7 @@ std::unique_ptr<content::HidChooser> ElectronHidDelegate::RunChooser(
 
   // Start observing HidChooserContext for permission and device events.
   GetContextObserver(browser_context);
-  DCHECK(base::Contains(observations_, browser_context));
+  DCHECK(observations_.contains(browser_context));
 
   HidChooserController* controller = ControllerForFrame(render_frame_host);
   if (controller) {
@@ -188,7 +187,7 @@ void ElectronHidDelegate::RemoveObserver(
     content::HidDelegate::Observer* observer) {
   if (!browser_context)
     return;
-  DCHECK(base::Contains(observations_, browser_context));
+  DCHECK(observations_.contains(browser_context));
   GetContextObserver(browser_context)->RemoveObserver(observer);
 }
 
@@ -222,7 +221,7 @@ bool ElectronHidDelegate::IsServiceWorkerAllowedForOrigin(
 ElectronHidDelegate::ContextObservation*
 ElectronHidDelegate::GetContextObserver(
     content::BrowserContext* browser_context) {
-  if (!base::Contains(observations_, browser_context)) {
+  if (!observations_.contains(browser_context)) {
     observations_.emplace(browser_context, std::make_unique<ContextObservation>(
                                                this, browser_context));
   }

--- a/shell/browser/hid/hid_chooser_context.cc
+++ b/shell/browser/hid/hid_chooser_context.cc
@@ -8,7 +8,6 @@
 #include <utility>
 
 #include "base/command_line.h"
-#include "base/containers/contains.h"
 #include "base/containers/map_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/values.h"
@@ -94,7 +93,7 @@ base::Value HidChooserContext::DeviceInfoToValue(
 void HidChooserContext::GrantDevicePermission(
     const url::Origin& origin,
     const device::mojom::HidDeviceInfo& device) {
-  DCHECK(base::Contains(devices_, device.guid));
+  DCHECK(devices_.contains(device.guid));
   if (CanStorePersistentEntry(device)) {
     auto* permission_manager = static_cast<ElectronPermissionManager*>(
         browser_context_->GetPermissionControllerDelegate());
@@ -111,7 +110,7 @@ void HidChooserContext::GrantDevicePermission(
 void HidChooserContext::RevokeDevicePermission(
     const url::Origin& origin,
     const device::mojom::HidDeviceInfo& device) {
-  DCHECK(base::Contains(devices_, device.guid));
+  DCHECK(devices_.contains(device.guid));
   if (CanStorePersistentEntry(device)) {
     RevokePersistentDevicePermission(origin, device);
   } else {
@@ -167,8 +166,7 @@ bool HidChooserContext::HasDevicePermission(
     return false;
 
   auto it = ephemeral_devices_.find(origin);
-  if (it != ephemeral_devices_.end() &&
-      base::Contains(it->second, device.guid)) {
+  if (it != ephemeral_devices_.end() && it->second.contains(device.guid)) {
     return true;
   }
 
@@ -189,7 +187,7 @@ bool HidChooserContext::IsFidoAllowedForOrigin(const url::Origin& origin) {
       });
 
   if (origin.scheme() == extensions::kExtensionScheme &&
-      base::Contains(kPrivilegedExtensionIds, origin.host())) {
+      kPrivilegedExtensionIds.contains(origin.host())) {
     return true;
   }
 #endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
@@ -245,7 +243,7 @@ void HidChooserContext::DeviceAdded(device::mojom::HidDeviceInfoPtr device) {
   DCHECK(device);
 
   // Update the device list.
-  if (!base::Contains(devices_, device->guid))
+  if (!devices_.contains(device->guid))
     devices_.insert({device->guid, device->Clone()});
 
   // Notify all observers.
@@ -255,7 +253,7 @@ void HidChooserContext::DeviceAdded(device::mojom::HidDeviceInfoPtr device) {
 
 void HidChooserContext::DeviceRemoved(device::mojom::HidDeviceInfoPtr device) {
   DCHECK(device);
-  DCHECK(base::Contains(devices_, device->guid));
+  DCHECK(devices_.contains(device->guid));
 
   // Update the device list.
   devices_.erase(device->guid);
@@ -276,7 +274,7 @@ void HidChooserContext::DeviceRemoved(device::mojom::HidDeviceInfoPtr device) {
 
 void HidChooserContext::DeviceChanged(device::mojom::HidDeviceInfoPtr device) {
   DCHECK(device);
-  DCHECK(base::Contains(devices_, device->guid));
+  DCHECK(devices_.contains(device->guid));
 
   // Update the device list.
   devices_[device->guid] = device->Clone();

--- a/shell/browser/plugins/plugin_utils.cc
+++ b/shell/browser/plugins/plugin_utils.cc
@@ -6,7 +6,6 @@
 
 #include <vector>
 
-#include "base/containers/contains.h"
 #include "content/public/common/webplugininfo.h"
 #include "electron/buildflags/buildflags.h"
 #include "url/gurl.h"
@@ -53,8 +52,7 @@ PluginUtils::GetMimeTypeToExtensionIdMap(
 
     if (MimeTypesHandler* handler = MimeTypesHandler::GetHandler(extension)) {
       for (const auto& supported_mime_type : handler->mime_type_set()) {
-        DCHECK(!base::Contains(mime_type_to_extension_id_map,
-                               supported_mime_type));
+        DCHECK(!mime_type_to_extension_id_map.contains(supported_mime_type));
         mime_type_to_extension_id_map[supported_mime_type] = extension_id;
       }
     }

--- a/shell/browser/serial/serial_chooser_context.cc
+++ b/shell/browser/serial/serial_chooser_context.cc
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "base/base64.h"
-#include "base/containers/contains.h"
 #include "base/values.h"
 #include "content/public/browser/device_service.h"
 #include "content/public/browser/web_contents.h"
@@ -109,7 +108,7 @@ bool SerialChooserContext::HasPortPermission(
   auto it = ephemeral_ports_.find(origin);
   if (it != ephemeral_ports_.end()) {
     const std::set<base::UnguessableToken>& ports = it->second;
-    if (base::Contains(ports, port.token))
+    if (ports.contains(port.token))
       return true;
   }
 
@@ -227,7 +226,7 @@ base::WeakPtr<SerialChooserContext> SerialChooserContext::AsWeakPtr() {
 }
 
 void SerialChooserContext::OnPortAdded(device::mojom::SerialPortInfoPtr port) {
-  if (!base::Contains(port_info_, port->token))
+  if (!port_info_.contains(port->token))
     port_info_.insert({port->token, port->Clone()});
 
   for (auto& map_entry : ephemeral_ports_) {

--- a/shell/browser/ui/cocoa/electron_touch_bar.mm
+++ b/shell/browser/ui/cocoa/electron_touch_bar.mm
@@ -334,7 +334,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 }
 
 - (bool)hasItemWithID:(const std::string&)item_id {
-  return settings_.find(item_id) != settings_.end();
+  return settings_.contains(item_id);
 }
 
 - (NSColor*)colorFromHexColorString:(const std::string&)colorString {

--- a/shell/browser/ui/message_box_gtk.cc
+++ b/shell/browser/ui/message_box_gtk.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/ui/message_box.h"
 
-#include "base/containers/contains.h"
 #include "base/containers/flat_map.h"
 #include "base/functional/bind.h"
 #include "base/memory/raw_ptr.h"
@@ -232,7 +231,7 @@ int ShowMessageBoxSync(const MessageBoxSettings& settings) {
 
 void ShowMessageBox(const MessageBoxSettings& settings,
                     MessageBoxCallback callback) {
-  if (settings.id && base::Contains(GetDialogsMap(), *settings.id))
+  if (settings.id && GetDialogsMap().contains(*settings.id))
     CloseMessageBox(*settings.id);
   (new GtkMessageBox(settings))->RunAsynchronous(std::move(callback));
 }

--- a/shell/browser/ui/message_box_mac.mm
+++ b/shell/browser/ui/message_box_mac.mm
@@ -8,7 +8,6 @@
 
 #import <Cocoa/Cocoa.h>
 
-#include "base/containers/contains.h"
 #include "base/containers/flat_map.h"
 #include "base/mac/mac_util.h"
 #include "base/no_destructor.h"
@@ -146,7 +145,7 @@ void ShowMessageBox(const MessageBoxSettings& settings,
         ret, alert.suppressionButton.state == NSControlStateValueOn);
   } else {
     if (settings.id) {
-      if (base::Contains(GetDialogsMap(), *settings.id))
+      if (GetDialogsMap().contains(*settings.id))
         CloseMessageBox(*settings.id);
       GetDialogsMap()[*settings.id] = alert;
     }

--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -10,7 +10,6 @@
 
 #include <vector>
 
-#include "base/containers/contains.h"
 #include "base/containers/flat_map.h"
 #include "base/no_destructor.h"
 #include "base/strings/string_util.h"
@@ -242,7 +241,7 @@ DialogResult ShowTaskDialogWstr(gfx::AcceleratedWidget parent,
   TaskDialogIndirect(&config, &id, nullptr, &verification_flag_checked);
 
   int button_id;
-  if (base::Contains(id_map, id))  // common button.
+  if (id_map.contains(id))  // common button.
     button_id = id_map[id];
   else if (id >= kIDStart)  // custom button.
     button_id = id - kIDStart;
@@ -289,7 +288,7 @@ void ShowMessageBox(const MessageBoxSettings& settings,
   // kHwndReserve in the dialogs map for now.
   HWND* hwnd = nullptr;
   if (settings.id) {
-    if (base::Contains(GetDialogsMap(), *settings.id))
+    if (GetDialogsMap().contains(*settings.id))
       CloseMessageBox(*settings.id);
     auto it = GetDialogsMap().emplace(*settings.id,
                                       std::make_unique<HWND>(kHwndReserve));

--- a/shell/browser/usb/electron_usb_delegate.cc
+++ b/shell/browser/usb/electron_usb_delegate.cc
@@ -7,7 +7,6 @@
 #include <string_view>
 #include <utility>
 
-#include "base/containers/contains.h"
 #include "base/observer_list.h"
 #include "base/scoped_observation.h"
 #include "content/public/browser/render_frame_host.h"
@@ -72,7 +71,7 @@ bool IsDevicePermissionAutoGranted(
   // Note: The `DeviceHasInterfaceWithClass()` call is made after checking the
   // origin, since that method call is expensive.
   if (origin.scheme() == extensions::kExtensionScheme &&
-      base::Contains(kSmartCardPrivilegedExtensionIds, origin.host()) &&
+      kSmartCardPrivilegedExtensionIds.contains(origin.host()) &&
       DeviceHasInterfaceWithClass(device_info,
                                   device::mojom::kUsbSmartCardClass)) {
     return true;
@@ -269,7 +268,7 @@ ElectronUsbDelegate::ContextObservation*
 ElectronUsbDelegate::GetContextObserver(
     content::BrowserContext* browser_context) {
   CHECK(browser_context);
-  if (!base::Contains(observations_, browser_context)) {
+  if (!observations_.contains(browser_context)) {
     observations_.emplace(browser_context, std::make_unique<ContextObservation>(
                                                this, browser_context));
   }

--- a/shell/browser/usb/usb_chooser_context.cc
+++ b/shell/browser/usb/usb_chooser_context.cc
@@ -8,7 +8,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/containers/contains.h"
 #include "base/functional/bind.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/values.h"
@@ -158,7 +157,7 @@ UsbChooserContext::~UsbChooserContext() {
 void UsbChooserContext::RevokeDevicePermissionWebInitiated(
     const url::Origin& origin,
     const device::mojom::UsbDeviceInfo& device) {
-  DCHECK(base::Contains(devices_, device.guid));
+  DCHECK(devices_.contains(device.guid));
   RevokeObjectPermissionInternal(origin, DeviceInfoToValue(device),
                                  /*revoked_by_website=*/true);
 }
@@ -217,8 +216,7 @@ bool UsbChooserContext::HasDevicePermission(
     const url::Origin& origin,
     const device::mojom::UsbDeviceInfo& device_info) {
   auto it = ephemeral_devices_.find(origin);
-  if (it != ephemeral_devices_.end() &&
-      base::Contains(it->second, device_info.guid)) {
+  if (it != ephemeral_devices_.end() && it->second.contains(device_info.guid)) {
     return true;
   }
 
@@ -284,7 +282,7 @@ void UsbChooserContext::OnDeviceAdded(
     device::mojom::UsbDeviceInfoPtr device_info) {
   DCHECK(device_info);
   // Update the device list.
-  DCHECK(!base::Contains(devices_, device_info->guid));
+  DCHECK(!devices_.contains(device_info->guid));
   if (!ShouldExposeDevice(*device_info))
     return;
   devices_.insert(std::make_pair(device_info->guid, device_info->Clone()));
@@ -299,12 +297,12 @@ void UsbChooserContext::OnDeviceRemoved(
   DCHECK(device_info);
 
   if (!ShouldExposeDevice(*device_info)) {
-    DCHECK(!base::Contains(devices_, device_info->guid));
+    DCHECK(!devices_.contains(device_info->guid));
     return;
   }
 
   // Update the device list.
-  DCHECK(base::Contains(devices_, device_info->guid));
+  DCHECK(devices_.contains(device_info->guid));
   devices_.erase(device_info->guid);
 
   // Notify all device observers.

--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -6,7 +6,6 @@
 
 #include <map>
 
-#include "base/containers/contains.h"
 #include "base/containers/to_vector.h"
 #include "base/run_loop.h"
 #include "base/strings/utf_string_conversions.h"
@@ -76,7 +75,7 @@ std::string Clipboard::Read(const std::string& format_string) {
       clipboard->ExtractCustomPlatformNames(ui::ClipboardBuffer::kCopyPaste,
                                             /* data_dst = */ nullptr);
 #if BUILDFLAG(IS_LINUX)
-  if (!base::Contains(custom_format_names, format_string)) {
+  if (!custom_format_names.contains(format_string)) {
     custom_format_names =
         clipboard->ExtractCustomPlatformNames(ui::ClipboardBuffer::kSelection,
                                               /* data_dst = */ nullptr);
@@ -84,7 +83,7 @@ std::string Clipboard::Read(const std::string& format_string) {
 #endif
 
   ui::ClipboardFormatType format;
-  if (base::Contains(custom_format_names, format_string)) {
+  if (custom_format_names.contains(format_string)) {
     format =
         ui::ClipboardFormatType(ui::ClipboardFormatType::CustomPlatformType(
             custom_format_names[format_string]));

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -11,7 +11,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/containers/contains.h"
 #include "base/feature_list.h"
 #include "base/json/json_writer.h"
 #include "base/trace_event/trace_event.h"
@@ -69,7 +68,7 @@ bool DeepFreeze(const v8::Local<v8::Object>& object,
                 const v8::Local<v8::Context>& context,
                 std::set<int> frozen = std::set<int>()) {
   int hash = object->GetIdentityHash();
-  if (base::Contains(frozen, hash))
+  if (frozen.contains(hash))
     return true;
   frozen.insert(hash);
 

--- a/shell/renderer/api/electron_api_spell_check_client.cc
+++ b/shell/renderer/api/electron_api_spell_check_client.cc
@@ -12,7 +12,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/containers/contains.h"
 #include "base/logging.h"
 #include "base/numerics/safe_conversions.h"
 #include "base/strings/utf_string_conversion_utils.h"
@@ -190,13 +189,13 @@ void SpellCheckClient::OnSpellCheckDone(
   auto& word_list = pending_request_param_->wordlist();
 
   for (const auto& word : word_list) {
-    if (base::Contains(misspelled, word.text)) {
+    if (misspelled.contains(word.text)) {
       // If this is a contraction, iterate through parts and accept the word
       // if none of them are misspelled
       if (!word.contraction_words.empty()) {
         auto all_correct = true;
         for (const auto& contraction_word : word.contraction_words) {
-          if (base::Contains(misspelled, contraction_word)) {
+          if (misspelled.contains(contraction_word)) {
             all_correct = false;
             break;
           }

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -238,7 +238,7 @@ void ElectronRendererClient::WillDestroyWorkerContextOnWorkerThread(
 
 node::Environment* ElectronRendererClient::GetEnvironment(
     content::RenderFrame* render_frame) const {
-  if (!base::Contains(injected_frames_, render_frame))
+  if (!injected_frames_.contains(render_frame))
     return nullptr;
   v8::HandleScope handle_scope(v8::Isolate::GetCurrent());
   auto context =

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -10,7 +10,6 @@
 
 #include "base/base_paths.h"
 #include "base/command_line.h"
-#include "base/containers/contains.h"
 #include "base/process/process_metrics.h"
 #include "content/public/renderer/render_frame.h"
 #include "shell/common/api/electron_bindings.h"
@@ -158,7 +157,7 @@ void ElectronSandboxedRendererClient::WillReleaseScriptContext(
 void ElectronSandboxedRendererClient::EmitProcessEvent(
     content::RenderFrame* render_frame,
     const char* event_name) {
-  if (!base::Contains(injected_frames_, render_frame))
+  if (!injected_frames_.contains(render_frame))
     return;
 
   blink::WebLocalFrame* frame = render_frame->GetWebFrame();


### PR DESCRIPTION
#### Description of Change

Now that we're using C++20, replace `base::Contains()` with C++20's `std::map<>::contains()` and `std::set<>::contains()`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.