### PR TITLE
Fix non standard scheme crash  35 x y

### DIFF
--- a/patches/chromium/fix_crash_loading_non-standard_schemes_in_iframes.patch
+++ b/patches/chromium/fix_crash_loading_non-standard_schemes_in_iframes.patch
@@ -28,7 +28,7 @@ The patch should be removed in favor of either:
 Upstream bug https://bugs.chromium.org/p/chromium/issues/detail?id=1081397.
 
 diff --git a/content/browser/renderer_host/navigation_request.cc b/content/browser/renderer_host/navigation_request.cc
-index 0c67607fd99b2fceba176308a041c8f08643506a..6b38139e1b58db7c7a0c4d553ed2cdaa11a63d2d 100644
+index 84b894ac879b5a0ada509da98294db75eebe7fd7..976b8ee4a6f9529727209a3e3a44524c62d0c798 100644
 --- a/content/browser/renderer_host/navigation_request.cc
 +++ b/content/browser/renderer_host/navigation_request.cc
 @@ -10947,6 +10947,12 @@ NavigationRequest::GetOriginForURLLoaderFactoryUncheckedWithDebugInfo() {

--- a/patches/chromium/fix_crash_loading_non-standard_schemes_in_iframes.patch
+++ b/patches/chromium/fix_crash_loading_non-standard_schemes_in_iframes.patch
@@ -28,17 +28,17 @@ The patch should be removed in favor of either:
 Upstream bug https://bugs.chromium.org/p/chromium/issues/detail?id=1081397.
 
 diff --git a/content/browser/renderer_host/navigation_request.cc b/content/browser/renderer_host/navigation_request.cc
-index 84b894ac879b5a0ada509da98294db75eebe7fd7..fbc0fdf6ee5edf3c284260ac8db2f90c40d32d6d 100644
+index 0c67607fd99b2fceba176308a041c8f08643506a..6b38139e1b58db7c7a0c4d553ed2cdaa11a63d2d 100644
 --- a/content/browser/renderer_host/navigation_request.cc
 +++ b/content/browser/renderer_host/navigation_request.cc
 @@ -10947,6 +10947,12 @@ NavigationRequest::GetOriginForURLLoaderFactoryUncheckedWithDebugInfo() {
          "blob");
    }
  
-+  if (!IsInMainFrame() && !common_params().url.IsStandard()) {
++  if (!common_params().url.IsStandard() && !common_params().url.IsAboutBlank()) {
 +    return std::make_pair(url::Origin::Resolve(common_params().url,
-+                                               url::Origin()),
-+                          "url_non_standard");
++                                url::Origin()),
++          "url_non_standard");
 +  }
 +
    // In cases not covered above, URLLoaderFactory should be associated with the

--- a/patches/chromium/ignore_parse_errors_for_pkey_appusermodel_toastactivatorclsid.patch
+++ b/patches/chromium/ignore_parse_errors_for_pkey_appusermodel_toastactivatorclsid.patch
@@ -11,10 +11,10 @@ Bug: N/A
 Change-Id: I9fc472212b2d3afac2c8e18a2159bc2d50bbdf98
 
 diff --git a/AUTHORS b/AUTHORS
-index 55dc38c1448c1960b802c136018c8be22ed61c18..5cd195df3650331fbfd62b2f964368b5f3217f3c 100644
+index e96a3afdabc731afe355cda83eec4923ea780fec..0b1dc07aad197eab7b79344bc5aee702a2d580ab 100644
 --- a/AUTHORS
 +++ b/AUTHORS
-@@ -337,6 +337,7 @@ David Futcher <david.mike.futcher@gmail.com>
+@@ -340,6 +340,7 @@ David Futcher <david.mike.futcher@gmail.com>
  David Jin <davidjin@amazon.com>
  David Lechner <david@pybricks.com>
  David Leen <davileen@amazon.com>
@@ -23,10 +23,10 @@ index 55dc38c1448c1960b802c136018c8be22ed61c18..5cd195df3650331fbfd62b2f964368b5
  David McAllister <mcdavid@amazon.com>
  David Michael Barr <david.barr@samsung.com>
 diff --git a/base/win/shortcut.cc b/base/win/shortcut.cc
-index e790adb2f1d6529ac0dd77145f5da2796264c7ae..8a7edcfaf9af963468b4b42fe55a771fb31f13a2 100644
+index 967e130e823f41c402411dfadb53b805e8a8c92b..3a9df7f31861ca69168fd24513ee554d0984798d 100644
 --- a/base/win/shortcut.cc
 +++ b/base/win/shortcut.cc
-@@ -342,8 +342,9 @@ bool ResolveShortcutProperties(const FilePath& shortcut_path,
+@@ -356,8 +356,9 @@ bool ResolveShortcutProperties(const FilePath& shortcut_path,
                *(pv_toast_activator_clsid.get().puuid));
            break;
          default:

--- a/patches/node/build_remove_explicit_linker_call_to_libm_on_macos.patch
+++ b/patches/node/build_remove_explicit_linker_call_to_libm_on_macos.patch
@@ -40,10 +40,10 @@ index 5e07e106672a04508a77584c109c97a67926c858..91001fa43ea4807d061f296eaeccb751
      }
      if (is_clang || !is_win) {
 diff --git a/deps/uv/unofficial.gni b/deps/uv/unofficial.gni
-index 7a73f891e3fc3261b77af97af63fca2eade49849..bda1b5dc899558c2b4a22377dde9fb3bcce5488c 100644
+index 348d2f0703e47ca7c5326a4b4c1d6ae31157eeb5..0944d6ddd241b113970ab6aa5804f9534fde882a 100644
 --- a/deps/uv/unofficial.gni
 +++ b/deps/uv/unofficial.gni
-@@ -82,11 +82,11 @@ template("uv_gn_build") {
+@@ -87,11 +87,11 @@ template("uv_gn_build") {
        ]
      }
      if (is_posix) {


### PR DESCRIPTION
Manually backport #45694 to 35-x-y. See that PR for details.

Notes: Fixes an issue where the renderer process crashed when loading about:blank in subframes.