### PR TITLE
refactor: do not use `AdaptCallbackForRepeating()` in `electron_api_url_loader.cc`

### DIFF
--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -438,7 +438,7 @@ void SimpleURLLoaderWrapper::OnAuthRequired(
             net::AuthCredentials(username_str, password_str));
       },
       std::move(auth_responder));
-  Emit("login", auth_info, base::AdaptCallbackForRepeating(std::move(cb)));
+  Emit("login", auth_info, std::move(cb));
 }
 
 void SimpleURLLoaderWrapper::OnSSLCertificateError(
@@ -716,8 +716,7 @@ void SimpleURLLoaderWrapper::OnDataReceived(std::string_view string_view,
   v8::HandleScope handle_scope(isolate);
   auto array_buffer = v8::ArrayBuffer::New(isolate, string_view.size());
   memcpy(array_buffer->Data(), string_view.data(), string_view.size());
-  Emit("data", array_buffer,
-       base::AdaptCallbackForRepeating(std::move(resume)));
+  Emit("data", array_buffer, std::move(resume));
 }
 
 void SimpleURLLoaderWrapper::OnComplete(bool success) {

--- a/shell/common/gin_helper/event_emitter_caller.h
+++ b/shell/common/gin_helper/event_emitter_caller.h
@@ -11,6 +11,7 @@
 #include "base/containers/span.h"
 #include "gin/converter.h"
 #include "gin/wrappable.h"
+#include "shell/common/gin_converters/std_converter.h"  // for ConvertToV8(iso, &&)
 
 namespace gin_helper {
 


### PR DESCRIPTION
#### Description of Change

Partial fix for #29739

Upstream removed `base::AdaptCallbackForRepeating()` a long time ago. We still use it, so we have a Chromium patch to patch it back in. This PR fixes a couple of instances of this call, moving towards removing that patch.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.