### PR TITLE
refactor: remove unused `v8::Isolate*` arg from `GlobalShortcut` constructor

### DIFF
--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -50,7 +50,7 @@ namespace electron::api {
 
 gin::WrapperInfo GlobalShortcut::kWrapperInfo = {gin::kEmbedderNativeGin};
 
-GlobalShortcut::GlobalShortcut(v8::Isolate* isolate) {}
+GlobalShortcut::GlobalShortcut() {}
 
 GlobalShortcut::~GlobalShortcut() {
   UnregisterAll();
@@ -216,7 +216,7 @@ void GlobalShortcut::UnregisterAll() {
 
 // static
 gin::Handle<GlobalShortcut> GlobalShortcut::Create(v8::Isolate* isolate) {
-  return gin::CreateHandle(isolate, new GlobalShortcut(isolate));
+  return gin::CreateHandle(isolate, new GlobalShortcut());
 }
 
 // static

--- a/shell/browser/api/electron_api_global_shortcut.h
+++ b/shell/browser/api/electron_api_global_shortcut.h
@@ -37,7 +37,7 @@ class GlobalShortcut final : private ui::GlobalAcceleratorListener::Observer,
   GlobalShortcut& operator=(const GlobalShortcut&) = delete;
 
  protected:
-  explicit GlobalShortcut(v8::Isolate* isolate);
+  GlobalShortcut();
   ~GlobalShortcut() override;
 
  private:


### PR DESCRIPTION
#### Description of Change

Just a small cleanup to remove an unused argument. It hasn't been used since f1a0d5e811 (#22755)

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.