### PR TITLE
perf: avoid redundant method calls in EventEmitter

### DIFF
--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -31,12 +31,10 @@ class EventEmitter : public gin_helper::Wrappable<T> {
     v8::Local<v8::Object> wrapper = this->GetWrapper();
     if (wrapper.IsEmpty())
       return false;
-    gin::Handle<gin_helper::internal::Event> event =
-        internal::Event::New(isolate);
+    gin::Handle<internal::Event> event = internal::Event::New(isolate);
     // It's possible that |this| will be deleted by EmitEvent, so save anything
     // we need from |this| before calling EmitEvent.
-    gin_helper::EmitEvent(isolate, wrapper, name, event,
-                          std::forward<Args>(args)...);
+    EmitEvent(isolate, wrapper, name, event, std::forward<Args>(args)...);
     return event->GetDefaultPrevented();
   }
 
@@ -48,7 +46,7 @@ class EventEmitter : public gin_helper::Wrappable<T> {
     v8::Local<v8::Object> wrapper = this->GetWrapper();
     if (wrapper.IsEmpty())
       return;
-    gin_helper::EmitEvent(isolate, wrapper, name, std::forward<Args>(args)...);
+    EmitEvent(isolate, wrapper, name, std::forward<Args>(args)...);
   }
 
   // disable copy

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -36,15 +36,15 @@ class EventEmitter : public gin_helper::Wrappable<T> {
   // this.emit(name, new Event(), args...);
   template <typename... Args>
   bool Emit(const std::string_view name, Args&&... args) {
-    v8::HandleScope handle_scope(isolate());
+    v8::Isolate* const isolate = this->isolate();
+    v8::HandleScope handle_scope{isolate};
     v8::Local<v8::Object> wrapper = GetWrapper();
     if (wrapper.IsEmpty())
       return false;
     gin::Handle<gin_helper::internal::Event> event =
-        internal::Event::New(isolate());
+        internal::Event::New(isolate);
     // It's possible that |this| will be deleted by EmitEvent, so save anything
     // we need from |this| before calling EmitEvent.
-    auto* isolate = this->isolate();
     gin_helper::EmitEvent(isolate, GetWrapper(), name, event,
                           std::forward<Args>(args)...);
     return event->GetDefaultPrevented();

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -45,7 +45,7 @@ class EventEmitter : public gin_helper::Wrappable<T> {
         internal::Event::New(isolate);
     // It's possible that |this| will be deleted by EmitEvent, so save anything
     // we need from |this| before calling EmitEvent.
-    gin_helper::EmitEvent(isolate, GetWrapper(), name, event,
+    gin_helper::EmitEvent(isolate, wrapper, name, event,
                           std::forward<Args>(args)...);
     return event->GetDefaultPrevented();
   }

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -23,19 +23,12 @@ namespace gin_helper {
 template <typename T>
 class EventEmitter : public gin_helper::Wrappable<T> {
  public:
-  using Base = gin_helper::Wrappable<T>;
-
-  // Make the convenient methods visible:
-  // https://isocpp.org/wiki/faq/templates#nondependent-name-lookup-members
-  // v8::Isolate* isolate() const { return Base::isolate(); }
-  v8::Local<v8::Object> GetWrapper() const { return Base::GetWrapper(); }
-
   // this.emit(name, new Event(), args...);
   template <typename... Args>
   bool Emit(const std::string_view name, Args&&... args) {
     v8::Isolate* const isolate = Base::isolate();
     v8::HandleScope handle_scope{isolate};
-    v8::Local<v8::Object> wrapper = GetWrapper();
+    v8::Local<v8::Object> wrapper = Base::GetWrapper();
     if (wrapper.IsEmpty())
       return false;
     gin::Handle<gin_helper::internal::Event> event =
@@ -52,7 +45,7 @@ class EventEmitter : public gin_helper::Wrappable<T> {
   void EmitWithoutEvent(const std::string_view name, Args&&... args) {
     v8::Isolate* const isolate = Base::isolate();
     v8::HandleScope handle_scope{isolate};
-    v8::Local<v8::Object> wrapper = GetWrapper();
+    v8::Local<v8::Object> wrapper = Base::GetWrapper();
     if (wrapper.IsEmpty())
       return;
     gin_helper::EmitEvent(isolate, wrapper, name, std::forward<Args>(args)...);
@@ -64,6 +57,9 @@ class EventEmitter : public gin_helper::Wrappable<T> {
 
  protected:
   EventEmitter() = default;
+
+ private:
+  using Base = gin_helper::Wrappable<T>;
 };
 
 }  // namespace gin_helper

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -29,9 +29,6 @@ class EventEmitter : public gin_helper::Wrappable<T> {
   // https://isocpp.org/wiki/faq/templates#nondependent-name-lookup-members
   // v8::Isolate* isolate() const { return Base::isolate(); }
   v8::Local<v8::Object> GetWrapper() const { return Base::GetWrapper(); }
-  v8::MaybeLocal<v8::Object> GetWrapper(v8::Isolate* isolate) const {
-    return Base::GetWrapper(isolate);
-  }
 
   // this.emit(name, new Event(), args...);
   template <typename... Args>

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -27,7 +27,7 @@ class EventEmitter : public gin_helper::Wrappable<T> {
 
   // Make the convenient methods visible:
   // https://isocpp.org/wiki/faq/templates#nondependent-name-lookup-members
-  v8::Isolate* isolate() const { return Base::isolate(); }
+  // v8::Isolate* isolate() const { return Base::isolate(); }
   v8::Local<v8::Object> GetWrapper() const { return Base::GetWrapper(); }
   v8::MaybeLocal<v8::Object> GetWrapper(v8::Isolate* isolate) const {
     return Base::GetWrapper(isolate);
@@ -36,7 +36,7 @@ class EventEmitter : public gin_helper::Wrappable<T> {
   // this.emit(name, new Event(), args...);
   template <typename... Args>
   bool Emit(const std::string_view name, Args&&... args) {
-    v8::Isolate* const isolate = this->isolate();
+    v8::Isolate* const isolate = Base::isolate();
     v8::HandleScope handle_scope{isolate};
     v8::Local<v8::Object> wrapper = GetWrapper();
     if (wrapper.IsEmpty())
@@ -53,7 +53,7 @@ class EventEmitter : public gin_helper::Wrappable<T> {
   // this.emit(name, args...);
   template <typename... Args>
   void EmitWithoutEvent(const std::string_view name, Args&&... args) {
-    v8::Isolate* const isolate = this->isolate();
+    v8::Isolate* const isolate = Base::isolate();
     v8::HandleScope handle_scope{isolate};
     v8::Local<v8::Object> wrapper = GetWrapper();
     if (wrapper.IsEmpty())

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -53,11 +53,12 @@ class EventEmitter : public gin_helper::Wrappable<T> {
   // this.emit(name, args...);
   template <typename... Args>
   void EmitWithoutEvent(const std::string_view name, Args&&... args) {
-    v8::HandleScope handle_scope(isolate());
+    v8::Isolate* const isolate = this->isolate();
+    v8::HandleScope handle_scope(isolate);
     v8::Local<v8::Object> wrapper = GetWrapper();
     if (wrapper.IsEmpty())
       return;
-    gin_helper::EmitEvent(isolate(), GetWrapper(), name,
+    gin_helper::EmitEvent(isolate, GetWrapper(), name,
                           std::forward<Args>(args)...);
   }
 

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -54,12 +54,11 @@ class EventEmitter : public gin_helper::Wrappable<T> {
   template <typename... Args>
   void EmitWithoutEvent(const std::string_view name, Args&&... args) {
     v8::Isolate* const isolate = this->isolate();
-    v8::HandleScope handle_scope(isolate);
+    v8::HandleScope handle_scope{isolate};
     v8::Local<v8::Object> wrapper = GetWrapper();
     if (wrapper.IsEmpty())
       return;
-    gin_helper::EmitEvent(isolate, GetWrapper(), name,
-                          std::forward<Args>(args)...);
+    gin_helper::EmitEvent(isolate, wrapper, name, std::forward<Args>(args)...);
   }
 
   // disable copy

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -26,9 +26,9 @@ class EventEmitter : public gin_helper::Wrappable<T> {
   // this.emit(name, new Event(), args...);
   template <typename... Args>
   bool Emit(const std::string_view name, Args&&... args) {
-    v8::Isolate* const isolate = Base::isolate();
+    v8::Isolate* const isolate = this->isolate();
     v8::HandleScope handle_scope{isolate};
-    v8::Local<v8::Object> wrapper = Base::GetWrapper();
+    v8::Local<v8::Object> wrapper = this->GetWrapper();
     if (wrapper.IsEmpty())
       return false;
     gin::Handle<gin_helper::internal::Event> event =
@@ -43,9 +43,9 @@ class EventEmitter : public gin_helper::Wrappable<T> {
   // this.emit(name, args...);
   template <typename... Args>
   void EmitWithoutEvent(const std::string_view name, Args&&... args) {
-    v8::Isolate* const isolate = Base::isolate();
+    v8::Isolate* const isolate = this->isolate();
     v8::HandleScope handle_scope{isolate};
-    v8::Local<v8::Object> wrapper = Base::GetWrapper();
+    v8::Local<v8::Object> wrapper = this->GetWrapper();
     if (wrapper.IsEmpty())
       return;
     gin_helper::EmitEvent(isolate, wrapper, name, std::forward<Args>(args)...);
@@ -57,9 +57,6 @@ class EventEmitter : public gin_helper::Wrappable<T> {
 
  protected:
   EventEmitter() = default;
-
- private:
-  using Base = gin_helper::Wrappable<T>;
 };
 
 }  // namespace gin_helper


### PR DESCRIPTION
#### Description of Change

Some cleanup to `gin_helper::EventEmitter`:

- avoid redundant calls to `gin_helper::Wrappable<T>::GetWrapper()`
- remove unused method `EventEmitter<T>::isolate()`
- remove unused method `EventEmitter<T>::GetWrapper()`
- remove unused method `EventEmitter<T>::GetWrapper(v8::Isolate*)`
- remove unused typedef `EventEmitter::Base`

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none