### PR TITLE
refactor: mark WrappableBase::GetWrapper(Isolate*) as NOTREACHED

### DIFF
--- a/shell/common/gin_helper/wrappable.cc
+++ b/shell/common/gin_helper/wrappable.cc
@@ -4,6 +4,7 @@
 
 #include "shell/common/gin_helper/wrappable.h"
 
+#include "base/notreached.h"
 #include "gin/public/isolate_holder.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "v8/include/v8-function.h"
@@ -31,10 +32,7 @@ v8::Local<v8::Object> WrappableBase::GetWrapper() const {
 
 v8::MaybeLocal<v8::Object> WrappableBase::GetWrapper(
     v8::Isolate* isolate) const {
-  if (!wrapper_.IsEmpty())
-    return {v8::Local<v8::Object>::New(isolate, wrapper_)};
-  else
-    return {};
+  NOTREACHED();
 }
 
 void WrappableBase::InitWithArgs(gin::Arguments* args) {


### PR DESCRIPTION
#### Description of Change

I think this method is unused. Usually you can figure this out in C++ at compile time, but there's an extra complication here so I'd like a 2nd opinion from CI before removing the method.

This PR marks it as `NOTREACHED()` to to force CI tests to fail if this method is called.

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.