### PR TITLE
refactor: remove unused gin_helper::WrappableBase::GetWrapper(v8::Isolate*)

### DIFF
--- a/shell/common/gin_helper/wrappable.cc
+++ b/shell/common/gin_helper/wrappable.cc
@@ -29,14 +29,6 @@ v8::Local<v8::Object> WrappableBase::GetWrapper() const {
     return {};
 }
 
-v8::MaybeLocal<v8::Object> WrappableBase::GetWrapper(
-    v8::Isolate* isolate) const {
-  if (!wrapper_.IsEmpty())
-    return {v8::Local<v8::Object>::New(isolate, wrapper_)};
-  else
-    return {};
-}
-
 void WrappableBase::InitWithArgs(gin::Arguments* args) {
   v8::Local<v8::Object> holder;
   args->GetHolder(&holder);

--- a/shell/common/gin_helper/wrappable_base.h
+++ b/shell/common/gin_helper/wrappable_base.h
@@ -39,7 +39,6 @@ class WrappableBase {
 
   // Retrieve the v8 wrapper object corresponding to this object.
   v8::Local<v8::Object> GetWrapper() const;
-  v8::MaybeLocal<v8::Object> GetWrapper(v8::Isolate* isolate) const;
 
   // Returns the Isolate this object is created in.
   v8::Isolate* isolate() const { return isolate_; }


### PR DESCRIPTION
#### Description of Change

Does what it says on the tin: removes an unused method, `gin_helper::WrappableBase::GetWrapper(v8::Isolate*)`

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.