### PR TITLE
refactor: simplify Invoker::IsOK()

### DIFF
--- a/shell/common/gin_helper/function_template.h
+++ b/shell/common/gin_helper/function_template.h
@@ -262,7 +262,9 @@ class Invoker<std::index_sequence<indices...>, ArgTypes...>
       : ArgumentHolder<indices, ArgTypes>(args, invoker_options)...,
         args_(args) {}
 
-  bool IsOK() const { return (... && ArgumentHolder<indices, ArgTypes>::ok); }
+  [[nodiscard]] bool IsOK() const {
+    return (... && ArgumentHolder<indices, ArgTypes>::ok);
+  }
 
   template <typename ReturnType>
   void DispatchToCallback(

--- a/shell/common/gin_helper/function_template.h
+++ b/shell/common/gin_helper/function_template.h
@@ -262,7 +262,7 @@ class Invoker<std::index_sequence<indices...>, ArgTypes...>
       : ArgumentHolder<indices, ArgTypes>(args, invoker_options)...,
         args_(args) {}
 
-  bool IsOK() { return And(ArgumentHolder<indices, ArgTypes>::ok...); }
+  bool IsOK() const { return (... && ArgumentHolder<indices, ArgTypes>::ok); }
 
   template <typename ReturnType>
   void DispatchToCallback(
@@ -285,12 +285,6 @@ class Invoker<std::index_sequence<indices...>, ArgTypes...>
   }
 
  private:
-  static bool And() { return true; }
-  template <typename... T>
-  static bool And(bool arg1, T... args) {
-    return arg1 && And(args...);
-  }
-
   raw_ptr<gin::Arguments> args_;
 };
 


### PR DESCRIPTION
#### Description of Change

A small golfing cleanup in the variadic template code for `Invoker::IsOK()`. We can remove the `And()` helper functions and just use [a fold expression](https://en.cppreference.com/w/cpp/language/fold) instead.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.