### PR TITLE
docs: dialog.md - typo fix s/wndow/window/

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -228,7 +228,7 @@ The `filters` specifies an array of file types that can be displayed, see
 **Note:** On macOS, using the asynchronous version is recommended to avoid issues when
 expanding and collapsing the dialog.
 
-### `dialog.showMessageBoxSync([wndow, ]options)`
+### `dialog.showMessageBoxSync([window, ]options)`
 
 * `window` [BaseWindow](base-window.md) (optional)
 * `options` Object


### PR DESCRIPTION
#### Description of Change

Fix a typo in the `window` parameter for `showSaveDialogSync`:

Replace

 `dialog.showSaveDialogSync([wndow, ]options)`

With

 `dialog.showSaveDialogSync([window, ]options)`

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation, tutorials, templates and examples are changed or added

#### Release Notes

Notes: none