### PR TITLE
feat: add `app.getRecentDocuments()`

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -759,6 +759,20 @@ bar, and on macOS, you can visit it from dock menu.
 
 Clears the recent documents list.
 
+### `app.getRecentDocuments()`_macOS_ _Windows_
+
+Returns `string[]` - An array containing documents in the most recent documents list.
+
+```js
+const { app } = require('electron')
+
+const file = path.join(app.getPath('desktop'), 'foo.txt')
+app.addRecentDocument(file);
+
+const recents = app.getRecentDocuments();
+console.log(recents) // ['/path/to/desktop/foo.txt'}
+```
+
 ### `app.setAsDefaultProtocolClient(protocol[, path, args])`
 
 * `protocol` string - The name of your protocol, without `://`. For example,

--- a/docs/tutorial/recent-documents.md
+++ b/docs/tutorial/recent-documents.md
@@ -77,6 +77,11 @@ To clear the list of recent documents, use the
 In this guide, the list of documents is cleared once all windows have been
 closed.
 
+#### Accessing the list of recent documents
+
+To access the list of recent documents, use the
+[app.getRecentDocuments][getrecentdocuments] API.
+
 ## Additional information
 
 ### Windows Notes
@@ -138,5 +143,6 @@ of `app` module will be emitted for it.
 [dock-menu-image]: https://cloud.githubusercontent.com/assets/639601/5069610/2aa80758-6e97-11e4-8cfb-c1a414a10774.png
 [addrecentdocument]: ../api/app.md#appaddrecentdocumentpath-macos-windows
 [clearrecentdocuments]: ../api/app.md#appclearrecentdocuments-macos-windows
+[getrecentdocuments]: ../api/app.md#appgetrecentdocuments-macos-windows
 [app-registration]: https://learn.microsoft.com/en-us/windows/win32/shell/app-registration
 [menu-item-image]: https://user-images.githubusercontent.com/3168941/33003655-ea601c3a-cd70-11e7-97fa-7c062149cfb1.png

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1692,6 +1692,8 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
                  base::BindRepeating(&Browser::AddRecentDocument, browser))
       .SetMethod("clearRecentDocuments",
                  base::BindRepeating(&Browser::ClearRecentDocuments, browser))
+      .SetMethod("getRecentDocuments",
+                 base::BindRepeating(&Browser::GetRecentDocuments, browser))
 #if BUILDFLAG(IS_WIN)
       .SetMethod("setAppUserModelId",
                  base::BindRepeating(&Browser::SetAppUserModelID, browser))

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -125,6 +125,9 @@ class Browser : private WindowListObserver {
   // Clear the recent documents list.
   void ClearRecentDocuments();
 
+  // Return the recent documents list.
+  std::vector<std::string> GetRecentDocuments();
+
 #if BUILDFLAG(IS_WIN)
   // Set the application user model ID.
   void SetAppUserModelID(const std::wstring& name);

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -94,6 +94,10 @@ bool SetDefaultWebClient(const std::string& protocol) {
 
 void Browser::AddRecentDocument(const base::FilePath& path) {}
 
+std::vector<std::string> Browser::GetRecentDocuments() {
+  return std::vector<std::string>();
+}
+
 void Browser::ClearRecentDocuments() {}
 
 bool Browser::SetAsDefaultProtocolClient(const std::string& protocol,

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -17,6 +17,7 @@
 #include "base/base_paths.h"
 #include "base/command_line.h"
 #include "base/file_version_info.h"
+#include "base/files/file_enumerator.h"
 #include "base/files/file_path.h"
 #include "base/logging.h"
 #include "base/path_service.h"
@@ -314,6 +315,33 @@ void GetApplicationInfoForProtocolUsingAssocQuery(
               app_display_name, std::move(promise));
 }
 
+std::string ResolveShortcut(const base::FilePath& lnk_path) {
+  std::string target_path;
+
+  // Initialize COM
+  CoInitialize(nullptr);
+
+  CComPtr<IShellLink> shell_link;
+  if (SUCCEEDED(CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER,
+                                 IID_PPV_ARGS(&shell_link)))) {
+    CComPtr<IPersistFile> persist_file;
+    if (SUCCEEDED(shell_link->QueryInterface(IID_PPV_ARGS(&persist_file)))) {
+      if (SUCCEEDED(persist_file->Load(lnk_path.value().c_str(), STGM_READ))) {
+        WCHAR resolved_path[MAX_PATH];
+        if (SUCCEEDED(
+                shell_link->GetPath(resolved_path, MAX_PATH, nullptr, 0))) {
+          target_path = base::FilePath(resolved_path).MaybeAsASCII();
+        }
+      }
+    }
+  }
+
+  // Uninitialize COM
+  CoUninitialize();
+
+  return target_path;
+}
+
 void Browser::AddRecentDocument(const base::FilePath& path) {
   CComPtr<IShellItem> item;
   HRESULT hr = SHCreateItemFromParsingName(path.value().c_str(), nullptr,
@@ -322,12 +350,40 @@ void Browser::AddRecentDocument(const base::FilePath& path) {
     SHARDAPPIDINFO info;
     info.psi = item;
     info.pszAppID = GetAppUserModelID();
+    LOG(INFO) << "SHAddToRecentDocs(SHARD_APPIDINFO, &info): " << path.value();
     SHAddToRecentDocs(SHARD_APPIDINFO, &info);
   }
 }
 
 void Browser::ClearRecentDocuments() {
   SHAddToRecentDocs(SHARD_APPIDINFO, nullptr);
+}
+
+std::vector<std::string> Browser::GetRecentDocuments() {
+  ScopedAllowBlockingForElectron allow_blocking;
+  std::vector<std::string> docs;
+
+  PWSTR recent_path_ptr = nullptr;
+  HRESULT hr =
+      SHGetKnownFolderPath(FOLDERID_Recent, 0, nullptr, &recent_path_ptr);
+  if (SUCCEEDED(hr) && recent_path_ptr) {
+    base::FilePath recent_folder(recent_path_ptr);
+    CoTaskMemFree(recent_path_ptr);
+
+    base::FileEnumerator enumerator(recent_folder, /*recursive=*/false,
+                                    base::FileEnumerator::FILES,
+                                    FILE_PATH_LITERAL("*.lnk"));
+
+    for (base::FilePath file = enumerator.Next(); !file.empty();
+         file = enumerator.Next()) {
+      std::string resolved_path = ResolveShortcut(file);
+      if (!resolved_path.empty()) {
+        docs.push_back(resolved_path);
+      }
+    }
+  }
+
+  return docs;
 }
 
 void Browser::SetAppUserModelID(const std::wstring& name) {

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -11,6 +11,7 @@ import * as http from 'node:http';
 import * as https from 'node:https';
 import * as net from 'node:net';
 import * as path from 'node:path';
+import { setTimeout } from 'node:timers/promises';
 import { promisify } from 'node:util';
 
 import { collectStreamBody, getResponse } from './lib/net-helpers';
@@ -356,6 +357,44 @@ describe('app module', () => {
     });
   });
 
+  ifdescribe(process.platform !== 'linux')('app.{add|get|clear}RecentDocument(s)', () => {
+    const tempFiles = [
+      path.join(fixturesPath, 'foo.txt'),
+      path.join(fixturesPath, 'bar.txt'),
+      path.join(fixturesPath, 'baz.txt')
+    ];
+
+    afterEach(() => {
+      app.clearRecentDocuments();
+      for (const file of tempFiles) {
+        fs.unlinkSync(file);
+      }
+    });
+
+    beforeEach(() => {
+      app.clearRecentDocuments();
+      for (const file of tempFiles) {
+        fs.writeFileSync(file, 'Lorem Ipsum');
+      }
+    });
+
+    it('can add a recent document', async () => {
+      app.addRecentDocument(tempFiles[0]);
+      if (process.platform === 'win32') await setTimeout(1000);
+      expect(app.getRecentDocuments()).to.include.members([tempFiles[0]]);
+    });
+
+    it('can clear recent documents', async () => {
+      app.addRecentDocument(tempFiles[1]);
+      app.addRecentDocument(tempFiles[2]);
+      if (process.platform === 'win32') await setTimeout(1000);
+      expect(app.getRecentDocuments()).to.include.members([tempFiles[1], tempFiles[2]]);
+      app.clearRecentDocuments();
+      if (process.platform === 'win32') await setTimeout(1000);
+      expect(app.getRecentDocuments()).to.deep.equal([]);
+    });
+  });
+
   describe('app.relaunch', () => {
     let server: net.Server | null = null;
     const socketPath = process.platform === 'win32' ? '\\\\.\\pipe\\electron-app-relaunch' : '/tmp/electron-app-relaunch';
@@ -553,8 +592,8 @@ describe('app module', () => {
 
   describe('app.badgeCount', () => {
     const platformIsNotSupported =
-        (process.platform === 'win32') ||
-        (process.platform === 'linux' && !app.isUnityRunning());
+      (process.platform === 'win32') ||
+      (process.platform === 'linux' && !app.isUnityRunning());
 
     const expectedBadgeCount = 42;
 


### PR DESCRIPTION
#### Description of Change

As in title - allows getting recent documents. Also allows testing other recent document functionality.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added support for  `app.getRecentDocuments()` on Windows and macOS.