### PR TITLE
docs: fix PrinterInfo info in breaking-changes.md

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -14,6 +14,11 @@ This document uses the following convention to categorize breaking changes:
 
 ## Planned Breaking API Changes (36.0)
 
+### Removed:`isDefault` and `status` properties on `PrinterInfo`
+
+These properties have been removed from the PrinterInfo Object
+because they have been removed from upstream Chromium.
+
 ### Deprecated: Extension methods and events on `session`
 
 `session.loadExtension`, `session.removeExtension`, `session.getExtension`,
@@ -29,11 +34,6 @@ It has been always returning `true` since Electron 23, which only supports Windo
 https://learn.microsoft.com/en-us/windows/win32/dwm/composition-ovw#disabling-dwm-composition-windows7-and-earlier
 
 ## Planned Breaking API Changes (35.0)
-
-### Removed:`isDefault` and `status` properties on `PrinterInfo`
-
-These properties have been removed from the PrinterInfo Object
-because they have been removed from upstream Chromium.
 
 ### Deprecated: `getFromVersionID` on `session.serviceWorkers`
 


### PR DESCRIPTION
#### Description of Change

> ### Removed:`isDefault` and `status` properties on `PrinterInfo`
> These properties have been removed from the PrinterInfo Object
> because they have been removed from upstream Chromium.

These properties [won't be removed until Electron 36](https://github.com/electron/electron/pull/45500/commits/5b65cc739859c8b377209b5949fb729a6f89892d), but `breaking-changes.md` in `main` lists them as being removed in 35. This PR corrects the error.

Thanks @mlaurencin for catching this!

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.