### PR TITLE
docs: update breaking-changes.md for 35.0.0

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -14,6 +14,16 @@ This document uses the following convention to categorize breaking changes:
 
 ## Planned Breaking API Changes (35.0)
 
+### Behavior Changed: Dialog API's `defaultPath` option on Linux
+
+On Linux, the required portal version for file dialogs has been reverted
+to 3 from 4. Using the `defaultPath` option of the Dialog API is not
+supported when using portal file chooser dialogs unless the portal
+backend is version 4 or higher. The `--xdg-portal-required-version`
+[command-line switch](/api/command-line-switches.md#--xdg-portal-required-versionversion)
+can be used to force a required version for your application.
+See [#44426](https://github.com/electron/electron/pull/44426) for more details.
+
 ### Deprecated: `setPreloads`, `getPreloads` on `Session`
 
 `registerPreloadScript`, `unregisterPreloadScript`, and `getPreloadScripts` are introduced as a


### PR DESCRIPTION
Manually backport #45822 to 35-x-y.

CC @electron/wg-releases this should land before we tag 35.0.0

Notes: none.