### PR TITLE
test: service worker contextBridge leak

### DIFF
--- a/spec/api-service-worker-main-spec.ts
+++ b/spec/api-service-worker-main-spec.ts
@@ -388,6 +388,13 @@ describe('ServiceWorkerMain module', () => {
       const result = await runTest(serviceWorker, { name: 'testEvaluate', args: ['evalConstructorName'] });
       expect(result).to.equal('ServiceWorkerGlobalScope');
     });
+
+    it('does not leak prototypes', async () => {
+      loadWorkerScript();
+      const serviceWorker = await waitForServiceWorker('running');
+      const result = await runTest(serviceWorker, { name: 'testPrototypeLeak', args: [] });
+      expect(result).to.be.true();
+    });
   });
 
   describe('extensions', () => {


### PR DESCRIPTION
#### Description of Change

closes https://github.com/electron/electron/issues/45188

Adds a test to ensure values passed between service worker contexts do not leak prototypes. This is a reimplementation of a [test from the contextBridge spec file.](https://github.com/electron/electron/blob/eac270bea7798b5f8b62504e1f1161f89f3a189d/spec/api-context-bridge-spec.ts#L879-L989)

I decided to add a new test rather than refactor the contextBridge tests for a few reasons:
1. `ServiceWorkerMain` has no `executeJavaScript` method yet. This prevents us from running arbitrary JS in the main world of service workers.
2. The service worker preload context is more limited than render frame isolated contexts. The `Blob` global doesn't exist which the contextBridge test depends on.
3. The complexity involved in porting `makeBindingWindow` and `callWithBindings` to work with SWs while keeping the code maintainable didn't seem worth it.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
