### PR TITLE
feat: ServiceWorkerMain.scriptURL

### DIFF
--- a/docs/api/service-worker-main.md
+++ b/docs/api/service-worker-main.md
@@ -46,6 +46,10 @@ An [`IpcMainServiceWorker`](ipc-main-service-worker.md) instance scoped to the s
 
 A `string` representing the scope URL of the service worker.
 
+#### `serviceWorker.scriptURL` _Readonly_ _Experimental_
+
+A `string` representing the script URL of the service worker.
+
 #### `serviceWorker.versionId` _Readonly_ _Experimental_
 
 A `number` representing the ID of the specific version of the service worker script in its scope.

--- a/shell/browser/api/electron_api_service_worker_main.cc
+++ b/shell/browser/api/electron_api_service_worker_main.cc
@@ -283,6 +283,12 @@ GURL ServiceWorkerMain::ScopeURL() const {
   return version_info()->scope;
 }
 
+GURL ServiceWorkerMain::ScriptURL() const {
+  if (version_destroyed_)
+    return {};
+  return version_info()->script_url;
+}
+
 // static
 gin::Handle<ServiceWorkerMain> ServiceWorkerMain::New(v8::Isolate* isolate) {
   return gin::Handle<ServiceWorkerMain>();
@@ -331,6 +337,7 @@ void ServiceWorkerMain::FillObjectTemplate(
                  &ServiceWorkerMain::CountExternalRequestsForTest)
       .SetProperty("versionId", &ServiceWorkerMain::VersionID)
       .SetProperty("scope", &ServiceWorkerMain::ScopeURL)
+      .SetProperty("scriptURL", &ServiceWorkerMain::ScriptURL)
       .Build();
 }
 

--- a/shell/browser/api/electron_api_service_worker_main.h
+++ b/shell/browser/api/electron_api_service_worker_main.h
@@ -149,6 +149,7 @@ class ServiceWorkerMain final
 
   int64_t VersionID() const;
   GURL ScopeURL() const;
+  GURL ScriptURL() const;
 
   // Version ID unique only to the StoragePartition.
   int64_t version_id_;

--- a/spec/api-service-worker-main-spec.ts
+++ b/spec/api-service-worker-main-spec.ts
@@ -314,6 +314,17 @@ describe('ServiceWorkerMain module', () => {
     });
   });
 
+  describe("'scriptURL' property", () => {
+    it('matches the expected value', async () => {
+      loadWorkerScript();
+      const serviceWorker = await waitForServiceWorker();
+      expect(serviceWorker).to.not.be.undefined();
+      if (!serviceWorker) return;
+      expect(serviceWorker).to.have.property('scriptURL').that.is.a('string');
+      expect(serviceWorker.scriptURL).to.equal(`${baseUrl}/sw.js`);
+    });
+  });
+
   describe('ipc', () => {
     beforeEach(() => {
       registerPreload('preload-tests.js');


### PR DESCRIPTION
#### Description of Change

Adds `scriptURL` property to `ServiceWorkerMain`. This is equivalent to the [`scriptURL`](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker/scriptURL) property available in renderers.

This was omitted initially as it wasn't available on a public interface. I've since landed a CL to move it to the public `ServiceWorkerVersionBaseInfo` struct.
https://chromium-review.googlesource.com/c/chromium/src/+/6243058

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `scriptURL` property to `ServiceWorkerMain`.
