### PR TITLE
build: define `NOMINMAX` in `common.gypi`

### DIFF
--- a/patches/node/.patches
+++ b/patches/node/.patches
@@ -53,3 +53,4 @@ cli_remove_deprecated_v8_flag.patch
 build_restore_clang_as_default_compiler_on_macos.patch
 esm_drop_support_for_import_assertions.patch
 build_remove_explicit_linker_call_to_libm_on_macos.patch
+build_define_nominmax_in_common_gypi.patch

--- a/patches/node/build_define_nominmax_in_common_gypi.patch
+++ b/patches/node/build_define_nominmax_in_common_gypi.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Mon, 3 Mar 2025 12:05:55 +0100
+Subject: build: define NOMINMAX in common.gypi
+
+V8 and Node.js had defined NOMINMAX on Windows for a long time. In
+recent changes, V8 added std::numeric_limits::min usages in its
+header files which caused addons without NOMINMAX defines failed
+to compile.
+
+Define NOMINMAX in common.gypi so that addons can be compiled with
+the latest V8 header files.
+
+NAN includes uv.h before node.h, which makes
+these defines effectiveless. Nevertheless, the include order should not be
+significant.
+
+PR-URL: https://github.com/nodejs/node/pull/52794
+
+diff --git a/common.gypi b/common.gypi
+index 9bbf1b277eb17d78ca385643c3177638fd75866a..959ee74af88b44d31f2e6fa65c6f260820bd8c46 100644
+--- a/common.gypi
++++ b/common.gypi
+@@ -480,6 +480,10 @@
+           '_HAS_EXCEPTIONS=0',
+           'BUILDING_V8_SHARED=1',
+           'BUILDING_UV_SHARED=1',
++          # Stop <windows.h> from defining macros that conflict with
++          # std::min() and std::max().  We don't use <windows.h> (much)
++          # but we still inherit it from uv.h.
++          'NOMINMAX',
+         ],
+       }],
+       [ 'OS in "linux freebsd openbsd solaris aix os400"', {
+diff --git a/node.gypi b/node.gypi
+index 46c7c7e353f29b8b3e5937ec80a5924020548980..212750978fb5c24fffe410cbdfe8dbdfe2ea8b42 100644
+--- a/node.gypi
++++ b/node.gypi
+@@ -63,10 +63,6 @@
+         'FD_SETSIZE=1024',
+         # we need to use node's preferred "win32" rather than gyp's preferred "win"
+         'NODE_PLATFORM="win32"',
+-        # Stop <windows.h> from defining macros that conflict with
+-        # std::min() and std::max().  We don't use <windows.h> (much)
+-        # but we still inherit it from uv.h.
+-        'NOMINMAX',
+         '_UNICODE=1',
+       ],
+       'msvs_precompiled_header': 'tools/msvs/pch/node_pch.h',


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/45826.
Refs https://github.com/nodejs/node/pull/52794.

Fixes an issue where native Node.js addons including `uv.h` before `node.h` don't compile as expected.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where native Node.js addons including `uv.h` before `node.h` don't compile as expected.