### PR TITLE
ci: preserve `blocked/*` labels on collaborator comments

### DIFF
--- a/.github/workflows/issue-commented.yml
+++ b/.github/workflows/issue-commented.yml
@@ -10,7 +10,7 @@ permissions: {}
 jobs:
   issue-commented:
     name: Remove blocked/{need-info,need-repro} on comment
-    if: ${{ (contains(github.event.issue.labels.*.name, 'blocked/need-repro') || contains(github.event.issue.labels.*.name, 'blocked/need-info ❌')) && !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association) && github.event.comment.user.type != 'Bot' }}
+    if: ${{ (contains(github.event.issue.labels.*.name, 'blocked/need-repro') || contains(github.event.issue.labels.*.name, 'blocked/need-info ❌')) && !contains(fromJSON('["MEMBER", "OWNER", "COLLABORATOR"]'), github.event.comment.author_association) && github.event.comment.user.type != 'Bot' }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token


### PR DESCRIPTION
#### Description of Change

We have a CI task that removes the `blocked/need-repro` and `blocked/need-info` labels when a user comments on an issue.

That task is already disabled for members and owners.

This PR updates the task to not run for collaborators either.

(In particular, this will make my own life easier as a collaborator with triage permissions.)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none