### PR TITLE
refactor: use upstream `Widget::IsVisibleOnAllWorkspaces()`

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -12,6 +12,13 @@ This document uses the following convention to categorize breaking changes:
 * **Deprecated:** An API was marked as deprecated. The API will continue to function, but will emit a deprecation warning, and will be removed in a future release.
 * **Removed:** An API or feature was removed, and is no longer supported by Electron.
 
+## Planned Breaking API Changes (37.0)
+
+### Behavior Changed: `BrowserWindow.IsVisibleOnAllWorkspaces()` on Linux
+
+`BrowserWindow.IsVisibleOnAllWorkspaces()` will now return false on Linux if the
+window is not currently visible.
+
 ## Planned Breaking API Changes (36.0)
 
 ### Removed:`isDefault` and `status` properties on `PrinterInfo`

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1527,20 +1527,8 @@ void NativeWindowViews::SetVisibleOnAllWorkspaces(
 }
 
 bool NativeWindowViews::IsVisibleOnAllWorkspaces() const {
-#if BUILDFLAG(IS_LINUX)
-  if (IsX11()) {
-    // Use the presence/absence of _NET_WM_STATE_STICKY in _NET_WM_STATE to
-    // determine whether the current window is visible on all workspaces.
-    x11::Atom sticky_atom = x11::GetAtom("_NET_WM_STATE_STICKY");
-    std::vector<x11::Atom> wm_states;
-    auto* connection = x11::Connection::Get();
-    connection->GetArrayProperty(
-        static_cast<x11::Window>(GetAcceleratedWidget()),
-        x11::GetAtom("_NET_WM_STATE"), &wm_states);
-    return base::Contains(wm_states, sticky_atom);
-  }
-#endif
-  return false;
+  // On Windows this always returns false.
+  return widget()->IsVisibleOnAllWorkspaces();
 }
 
 content::DesktopMediaID NativeWindowViews::GetDesktopMediaID() const {


### PR DESCRIPTION
#### Description of Change

We can remove some custom Linux logic here - upstream [sets this](https://source.chromium.org/chromium/chromium/src/+/main:ui/ozone/platform/x11/x11_window.cc;l=1179-1193;drc=e71cafaddfaa5850b906bf4c78b5289a2fa2d81a;bpv=1;bpt=1) on X11 and also has other logic for Wayland we should be leveraging.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none