### PR TITLE
fix: run webRequest handlers for URLs handled by ElectronURLLoaderFactory

### DIFF
--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -570,6 +570,26 @@ ElectronBrowserContext::GetURLLoaderFactory() {
   return url_loader_factory_;
 }
 
+scoped_refptr<network::SharedURLLoaderFactory>
+ElectronBrowserContext::InterceptURLLoaderFactory(
+    scoped_refptr<network::SharedURLLoaderFactory> terminal) {
+  network::URLLoaderFactoryBuilder factory_builder;
+
+  // Consult the embedder.
+  mojo::PendingRemote<network::mojom::TrustedURLLoaderHeaderClient>
+      header_client;
+
+  static_cast<content::ContentBrowserClient*>(ElectronBrowserClient::Get())
+      ->WillCreateURLLoaderFactory(
+          this, nullptr, -1,
+          content::ContentBrowserClient::URLLoaderFactoryType::kNavigation,
+          url::Origin(), net::IsolationInfo(), std::nullopt,
+          ukm::kInvalidSourceIdObj, factory_builder, &header_client, nullptr,
+          nullptr, nullptr, nullptr);
+
+  return std::move(factory_builder).Finish(terminal);
+}
+
 content::PushMessagingService*
 ElectronBrowserContext::GetPushMessagingService() {
   return nullptr;

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -114,6 +114,8 @@ class ElectronBrowserContext : public content::BrowserContext {
   ResolveProxyHelper* GetResolveProxyHelper();
   predictors::PreconnectManager* GetPreconnectManager();
   scoped_refptr<network::SharedURLLoaderFactory> GetURLLoaderFactory();
+  scoped_refptr<network::SharedURLLoaderFactory> InterceptURLLoaderFactory(
+      scoped_refptr<network::SharedURLLoaderFactory> terminal);
 
   std::string GetMediaDeviceIDSalt();
 

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -61,6 +61,7 @@ class ProxyingURLLoaderFactory
     // For usual requests
     InProgressRequest(
         ProxyingURLLoaderFactory* factory,
+        mojo::PendingRemote<network::mojom::URLLoaderFactory> target_factory,
         uint64_t web_request_id,
         int32_t frame_routing_id,
         int32_t network_service_request_id,
@@ -136,6 +137,7 @@ class ProxyingURLLoaderFactory
     void HandleBeforeRequestRedirect();
 
     raw_ptr<ProxyingURLLoaderFactory> const factory_;
+    mojo::Remote<network::mojom::URLLoaderFactory> target_factory_;
     network::ResourceRequest request_;
     const std::optional<url::Origin> original_initiator_;
     const uint64_t request_id_ = 0;

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -504,25 +504,28 @@ SimpleURLLoaderWrapper::GetURLLoaderFactoryForURL(const GURL& url) {
 
     if (const auto* const protocol_handler =
             protocol_registry->FindIntercepted(scheme)) {
-      return network::SharedURLLoaderFactory::Create(
-          std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
-              ElectronURLLoaderFactory::Create(protocol_handler->first,
-                                               protocol_handler->second)));
+      return browser_context_->InterceptURLLoaderFactory(
+          network::SharedURLLoaderFactory::Create(
+              std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
+                  ElectronURLLoaderFactory::Create(protocol_handler->first,
+                                                   protocol_handler->second))));
     }
 
     if (const auto* const protocol_handler =
             protocol_registry->FindRegistered(scheme)) {
-      return network::SharedURLLoaderFactory::Create(
-          std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
-              ElectronURLLoaderFactory::Create(protocol_handler->first,
-                                               protocol_handler->second)));
+      return browser_context_->InterceptURLLoaderFactory(
+          network::SharedURLLoaderFactory::Create(
+              std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
+                  ElectronURLLoaderFactory::Create(protocol_handler->first,
+                                                   protocol_handler->second))));
     }
   }
 
   if (url.SchemeIsFile()) {
-    return network::SharedURLLoaderFactory::Create(
-        std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
-            AsarURLLoaderFactory::Create()));
+    return browser_context_->InterceptURLLoaderFactory(
+        network::SharedURLLoaderFactory::Create(
+            std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
+                AsarURLLoaderFactory::Create())));
   }
 
   return browser_context_->GetURLLoaderFactory();

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -493,23 +493,11 @@ SimpleURLLoaderWrapper::GetURLLoaderFactoryForURL(const GURL& url) {
     return URLLoaderBundle::GetInstance()->GetSharedURLLoaderFactory();
 
   CHECK(browser_context_);
-  // Explicitly handle intercepted protocols here, even though
-  // ProxyingURLLoaderFactory would handle them later on, so that we can
-  // correctly intercept file:// scheme URLs.
   if (const bool bypass = request_options_ & kBypassCustomProtocolHandlers;
       !bypass) {
     const std::string_view scheme = url.scheme_piece();
     const auto* const protocol_registry =
         ProtocolRegistry::FromBrowserContext(browser_context_);
-
-    if (const auto* const protocol_handler =
-            protocol_registry->FindIntercepted(scheme)) {
-      return browser_context_->InterceptURLLoaderFactory(
-          network::SharedURLLoaderFactory::Create(
-              std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
-                  ElectronURLLoaderFactory::Create(protocol_handler->first,
-                                                   protocol_handler->second))));
-    }
 
     if (const auto* const protocol_handler =
             protocol_registry->FindRegistered(scheme)) {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Fixes instances where `ElectronURLLoaderFactory` is used without an intercepting `ProxyingURLLoaderFactory`, leading to `webRequest` handlers not being called. This occurs in `SimpleURLLoaderWrapper::GetURLLoaderFactoryForURL` where the special URL loaders are not built with `ElectronBrowserClient::WillCreateURLLoaderFactory`, and in `ProxyingURLLoaderFactory::CreateLoaderAndStart` where intercepted URLs cause the `ProxyingURLLoaderFactory` to be left early.

Resolves #45865 and #45903.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Call webRequest handlers for intercepted protocols