### PR TITLE
fix: don't crash Utility Processes on unhandled rejections

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -14,13 +14,18 @@ This document uses the following convention to categorize breaking changes:
 
 ## Planned Breaking API Changes (36.0)
 
-### Web Workers and Utility Process unhandled rejection behavior change
+### Utility Process unhandled rejection behavior change
 
-Web Workers and Utility Processes will now warn with an error message when an unhandled
-rejection occurs instead of crashing the proces
+Utility Processes will now warn with an error message when an unhandled
+rejection occurs instead of crashing the process.
 
-We are making this change to align with Web Worker behavior in browsers and prevent
-utility processes from crashing on any unhandled rejections.
+To restore the previous behavior, you can use:
+
+```js
+process.on('uncaughtException', () => {
+  process.exit(1)
+})
+```
 
 ### Removed:`isDefault` and `status` properties on `PrinterInfo`
 

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -14,6 +14,14 @@ This document uses the following convention to categorize breaking changes:
 
 ## Planned Breaking API Changes (36.0)
 
+### Web Workers and Utility Process unhandled rejection behavior change
+
+Web Workers and Utility Processes will now warn with an error message when an unhandled
+rejection occurs instead of crashing the proces
+
+We are making this change to align with Web Worker behavior in browsers and prevent
+utility processes from crashing on any unhandled rejections.
+
 ### Removed:`isDefault` and `status` properties on `PrinterInfo`
 
 These properties have been removed from the PrinterInfo Object

--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -85,6 +85,9 @@ void WebWorkerObserver::WorkerScriptReadyForEvaluation(
     }
   }
 
+  // We do not want to crash Web Workers on unhandled rejections.
+  env->options()->unhandled_rejections = "warn-with-error-code";
+
   // Add Electron extended APIs.
   electron_bindings_->BindTo(env->isolate(), env->process_object());
 

--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -85,9 +85,6 @@ void WebWorkerObserver::WorkerScriptReadyForEvaluation(
     }
   }
 
-  // We do not want to crash Web Workers on unhandled rejections.
-  env->options()->unhandled_rejections = "warn-with-error-code";
-
   // Add Electron extended APIs.
   electron_bindings_->BindTo(env->isolate(), env->process_object());
 

--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -155,6 +155,9 @@ void NodeService::Initialize(
 
   node_env_->set_trace_sync_io(node_env_->options()->trace_sync_io);
 
+  // We do not want to crash the utility process on unhandled rejections.
+  node_env_->options()->unhandled_rejections = "warn-with-error-code";
+
   // Add Electron extended APIs.
   electron_bindings_->BindTo(node_env_->isolate(), node_env_->process_object());
 


### PR DESCRIPTION
#### Description of Change

Change default behavior of utility processes crashed on unhandled rejections. This happened by default because it's how Node.js behaves, but it something we already disabled in the main process and renderer processes because it's not how the web behaves. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where utility processes crashed on unhandled rejections.
