### PR TITLE
perf: prefer `base::SplitStringPiece()` over `base::SplitString()`

### DIFF
--- a/shell/browser/ui/accelerator_util.cc
+++ b/shell/browser/ui/accelerator_util.cc
@@ -7,6 +7,7 @@
 #include <stdio.h>
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/logging.h"
@@ -16,7 +17,7 @@
 
 namespace accelerator_util {
 
-bool StringToAccelerator(const std::string& shortcut,
+bool StringToAccelerator(const std::string_view shortcut,
                          ui::Accelerator* accelerator) {
   if (!base::IsStringASCII(shortcut)) {
     LOG(ERROR) << "The accelerator string can only contain ASCII characters, "

--- a/shell/browser/ui/accelerator_util.cc
+++ b/shell/browser/ui/accelerator_util.cc
@@ -26,14 +26,14 @@ bool StringToAccelerator(const std::string& shortcut,
     return false;
   }
 
-  std::vector<std::string> tokens = base::SplitString(
+  const std::vector<std::string_view> tokens = base::SplitStringPiece(
       shortcut, "+", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
 
   // Now, parse it into an accelerator.
   int modifiers = ui::EF_NONE;
   ui::KeyboardCode key = ui::VKEY_UNKNOWN;
   std::optional<char16_t> shifted_char;
-  for (const auto& token : tokens) {
+  for (const std::string_view token : tokens) {
     ui::KeyboardCode code = electron::KeyboardCodeFromStr(token, &shifted_char);
     if (shifted_char)
       modifiers |= ui::EF_SHIFT_DOWN;

--- a/shell/browser/ui/accelerator_util.h
+++ b/shell/browser/ui/accelerator_util.h
@@ -6,7 +6,7 @@
 #define ELECTRON_SHELL_BROWSER_UI_ACCELERATOR_UTIL_H_
 
 #include <map>
-#include <string>
+#include <string_view>
 
 #include "base/memory/raw_ptr.h"
 #include "shell/browser/ui/electron_menu_model.h"
@@ -21,7 +21,7 @@ typedef struct {
 typedef std::map<ui::Accelerator, MenuItem> AcceleratorTable;
 
 // Parse a string as an accelerator.
-bool StringToAccelerator(const std::string& shortcut,
+bool StringToAccelerator(std::string_view shortcut,
                          ui::Accelerator* accelerator);
 
 // Generate a table that contains menu model's accelerators and command ids.

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -395,14 +395,14 @@ void SetNodeOptions(base::Environment* env) {
     if (electron::fuses::IsNodeOptionsEnabled()) {
       std::string options;
       env->GetVar("NODE_OPTIONS", &options);
-      std::vector<std::string> parts = base::SplitString(
+      const std::vector<std::string_view> parts = base::SplitStringPiece(
           options, " ", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
 
       bool is_packaged_app = electron::api::App::IsPackaged();
 
-      for (const auto& part : parts) {
+      for (const std::string_view part : parts) {
         // Strip off values passed to individual NODE_OPTIONs
-        std::string option = part.substr(0, part.find('='));
+        const std::string_view option = part.substr(0, part.find('='));
 
         if (is_packaged_app && !pkg_opts.contains(option)) {
           // Explicitly disallow majority of NODE_OPTIONS in packaged apps


### PR DESCRIPTION
#### Description of Change

A very small cleanup that I did while waiting on Azure and GHA to run :slightly_smiling_face: 

We have a couple of calls to `base::SplitString()` that don't actually need a new `std::string` constructed for each token;  we can use a view into the original string instead. So change those calls to use `base::SplitStringPiece()` instead:

```
  // Like SplitString above except it returns a vector of StringPieces which
  // reference the original buffer without copying. Although you have to be
  // careful to keep the original string unmodified, this provides an efficient
  // way to iterate through tokens in a string.
````

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.