### PR TITLE
fix: race condition in utilityProcess tests

### DIFF
--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -228,7 +228,6 @@ describe('utilityProcess module', () => {
       const child = utilityProcess.fork(fixtureFile, [], {
         stdio: 'pipe'
       });
-      await once(child, 'spawn');
       expect(child.stdout).to.not.be.null();
       let log = '';
       child.stdout!.on('data', (chunk) => {
@@ -293,7 +292,6 @@ describe('utilityProcess module', () => {
       const child = utilityProcess.fork(path.join(fixturesPath, 'log.js'), [], {
         stdio: 'pipe'
       });
-      await once(child, 'spawn');
       expect(child.stdout).to.not.be.null();
       let log = '';
       child.stdout!.on('data', (chunk) => {
@@ -326,7 +324,6 @@ describe('utilityProcess module', () => {
       const child = utilityProcess.fork(path.join(fixturesPath, 'log.js'), [], {
         stdio: ['ignore', 'pipe', 'pipe']
       });
-      await once(child, 'spawn');
       expect(child.stderr).to.not.be.null();
       let log = '';
       child.stderr!.on('data', (chunk) => {


### PR DESCRIPTION
#### Description of Change

In three tests that call `utilityProcess.fork()`, remove unnecessary calls to `await once(child, 'spawn');` that caused a race condition. Consider a test like this:

```js {.line-numbers}
100    it('is valid when child process launches with pipe stdio configuration', async () => {
101      const child = utilityProcess.fork(path.join(fixturesPath, 'log.js'), [], {
102        stdio: 'pipe'
103      });
104      await once(child, 'spawn');
105      expect(child.stdout).to.not.be.null();
106      let log = '';
107      child.stdout!.on('data', (chunk) => {
108        log += chunk.toString('utf8');
109      });
110      await once(child, 'exit');
111      expect(log).to.equal('hello\n');
112    });
```

Forking a child process (line 101) and then adding a `'data'` listener (line 107) is usually [safe](https://stackoverflow.com/questions/12887669/is-there-a-race-consuming-stdout-from-child-process-spawn-in-node-js) if called one right after the other. But here, the `await` between them (line 104) means this isn't safe: we'll drop any `'data'` event fired while we're `await`ing .

In this example, we could move line 104 to between lines 109 and 110. Since the three tests being changed in the PR don't  do anything with the `'spawn'` event anyway, I just removed them.

This race condition doesn't show up very often in our GitHub Actions CI, but I'm seeing it flake a lot on Windows x86 runs on a downstream build. :man_shrugging:  I have not tracked down what's causing the difference.

All reviews welcome. CC @mlaurencin who's been hitting this flake too. 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.