### PR TITLE
refactor: eliminate duplicate code in spec/api-process-spec.ts

### DIFF
--- a/spec/api-process-spec.ts
+++ b/spec/api-process-spec.ts
@@ -10,24 +10,17 @@ import { defer } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
 
 describe('process module', () => {
-  describe('renderer process', () => {
-    let w: BrowserWindow;
-    before(async () => {
-      w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, contextIsolation: false } });
-      await w.loadURL('about:blank');
-    });
-    after(closeAllWindows);
-
+  function generateSpecs (invoke: <T extends (...args: any[]) => any>(fn: T, ...args: Parameters<T>) => Promise<ReturnType<T>>) {
     describe('process.getCreationTime()', () => {
       it('returns a creation time', async () => {
-        const creationTime = await w.webContents.executeJavaScript('process.getCreationTime()');
+        const creationTime = await invoke(() => process.getCreationTime());
         expect(creationTime).to.be.a('number').and.be.at.least(0);
       });
     });
 
     describe('process.getCPUUsage()', () => {
       it('returns a cpu usage object', async () => {
-        const cpuUsage = await w.webContents.executeJavaScript('process.getCPUUsage()');
+        const cpuUsage = await invoke(() => process.getCPUUsage());
         expect(cpuUsage.percentCPUUsage).to.be.a('number');
         expect(cpuUsage.cumulativeCPUUsage).to.be.a('number');
         expect(cpuUsage.idleWakeupsPerSecond).to.be.a('number');
@@ -36,7 +29,7 @@ describe('process module', () => {
 
     describe('process.getBlinkMemoryInfo()', () => {
       it('returns blink memory information object', async () => {
-        const heapStats = await w.webContents.executeJavaScript('process.getBlinkMemoryInfo()');
+        const heapStats = await invoke(() => process.getBlinkMemoryInfo());
         expect(heapStats.allocated).to.be.a('number');
         expect(heapStats.total).to.be.a('number');
       });
@@ -44,7 +37,7 @@ describe('process module', () => {
 
     describe('process.getProcessMemoryInfo()', () => {
       it('resolves promise successfully with valid data', async () => {
-        const memoryInfo = await w.webContents.executeJavaScript('process.getProcessMemoryInfo()');
+        const memoryInfo = await invoke(() => process.getProcessMemoryInfo());
         expect(memoryInfo).to.be.an('object');
         if (process.platform === 'linux' || process.platform === 'win32') {
           expect(memoryInfo.residentSet).to.be.a('number').greaterThan(0);
@@ -57,7 +50,7 @@ describe('process module', () => {
 
     describe('process.getSystemMemoryInfo()', () => {
       it('returns system memory info object', async () => {
-        const systemMemoryInfo = await w.webContents.executeJavaScript('process.getSystemMemoryInfo()');
+        const systemMemoryInfo = await invoke(() => process.getSystemMemoryInfo());
         expect(systemMemoryInfo.free).to.be.a('number');
         expect(systemMemoryInfo.total).to.be.a('number');
       });
@@ -65,113 +58,14 @@ describe('process module', () => {
 
     describe('process.getSystemVersion()', () => {
       it('returns a string', async () => {
-        const systemVersion = await w.webContents.executeJavaScript('process.getSystemVersion()');
+        const systemVersion = await invoke(() => process.getSystemVersion());
         expect(systemVersion).to.be.a('string');
       });
     });
 
     describe('process.getHeapStatistics()', () => {
       it('returns heap statistics object', async () => {
-        const heapStats = await w.webContents.executeJavaScript('process.getHeapStatistics()');
-        expect(heapStats.totalHeapSize).to.be.a('number');
-        expect(heapStats.totalHeapSizeExecutable).to.be.a('number');
-        expect(heapStats.totalPhysicalSize).to.be.a('number');
-        expect(heapStats.totalAvailableSize).to.be.a('number');
-        expect(heapStats.usedHeapSize).to.be.a('number');
-        expect(heapStats.heapSizeLimit).to.be.a('number');
-        expect(heapStats.mallocedMemory).to.be.a('number');
-        expect(heapStats.peakMallocedMemory).to.be.a('number');
-        expect(heapStats.doesZapGarbage).to.be.a('boolean');
-      });
-    });
-
-    describe('process.takeHeapSnapshot()', () => {
-      it('returns true on success', async () => {
-        const filePath = path.join(app.getPath('temp'), 'test.heapsnapshot');
-        defer(() => {
-          try {
-            fs.unlinkSync(filePath);
-          } catch {
-            // ignore error
-          }
-        });
-
-        const success = await w.webContents.executeJavaScript(`process.takeHeapSnapshot(${JSON.stringify(filePath)})`);
-        expect(success).to.be.true();
-        const stats = fs.statSync(filePath);
-        expect(stats.size).not.to.be.equal(0);
-      });
-
-      it('returns false on failure', async () => {
-        const success = await w.webContents.executeJavaScript('process.takeHeapSnapshot("")');
-        expect(success).to.be.false();
-      });
-    });
-
-    describe('process.contextId', () => {
-      it('is a string', async () => {
-        const contextId = await w.webContents.executeJavaScript('process.contextId');
-        expect(contextId).to.be.a('string');
-      });
-    });
-  });
-
-  describe('main process', () => {
-    describe('process.getCreationTime()', () => {
-      it('returns a creation time', () => {
-        const creationTime = process.getCreationTime();
-        expect(creationTime).to.be.a('number').and.be.at.least(0);
-      });
-    });
-
-    describe('process.getCPUUsage()', () => {
-      it('returns a cpu usage object', () => {
-        const cpuUsage = process.getCPUUsage();
-        expect(cpuUsage.percentCPUUsage).to.be.a('number');
-        expect(cpuUsage.cumulativeCPUUsage).to.be.a('number');
-        expect(cpuUsage.idleWakeupsPerSecond).to.be.a('number');
-      });
-    });
-
-    describe('process.getBlinkMemoryInfo()', () => {
-      it('returns blink memory information object', () => {
-        const heapStats = process.getBlinkMemoryInfo();
-        expect(heapStats.allocated).to.be.a('number');
-        expect(heapStats.total).to.be.a('number');
-      });
-    });
-
-    describe('process.getProcessMemoryInfo()', () => {
-      it('resolves promise successfully with valid data', async () => {
-        const memoryInfo = await process.getProcessMemoryInfo();
-        expect(memoryInfo).to.be.an('object');
-        if (process.platform === 'linux' || process.platform === 'win32') {
-          expect(memoryInfo.residentSet).to.be.a('number').greaterThan(0);
-        }
-        expect(memoryInfo.private).to.be.a('number').greaterThan(0);
-        // Shared bytes can be zero
-        expect(memoryInfo.shared).to.be.a('number').greaterThan(-1);
-      });
-    });
-
-    describe('process.getSystemMemoryInfo()', () => {
-      it('returns system memory info object', () => {
-        const systemMemoryInfo = process.getSystemMemoryInfo();
-        expect(systemMemoryInfo.free).to.be.a('number');
-        expect(systemMemoryInfo.total).to.be.a('number');
-      });
-    });
-
-    describe('process.getSystemVersion()', () => {
-      it('returns a string', () => {
-        const systemVersion = process.getSystemVersion();
-        expect(systemVersion).to.be.a('string');
-      });
-    });
-
-    describe('process.getHeapStatistics()', () => {
-      it('returns heap statistics object', async () => {
-        const heapStats = process.getHeapStatistics();
+        const heapStats = await invoke(() => process.getHeapStatistics());
         expect(heapStats.totalHeapSize).to.be.a('number');
         expect(heapStats.totalHeapSizeExecutable).to.be.a('number');
         expect(heapStats.totalPhysicalSize).to.be.a('number');
@@ -187,7 +81,7 @@ describe('process module', () => {
     describe('process.takeHeapSnapshot()', () => {
       // DISABLED-FIXME(nornagon): this seems to take a really long time when run in the
       // main process, for unknown reasons.
-      it('returns true on success', () => {
+      it('returns true on success', async () => {
         const filePath = path.join(app.getPath('temp'), 'test.heapsnapshot');
         defer(() => {
           try {
@@ -197,16 +91,41 @@ describe('process module', () => {
           }
         });
 
-        const success = process.takeHeapSnapshot(filePath);
+        const success = await invoke((filePath: string) => process.takeHeapSnapshot(filePath), filePath);
         expect(success).to.be.true();
         const stats = fs.statSync(filePath);
         expect(stats.size).not.to.be.equal(0);
       });
 
       it('returns false on failure', async () => {
-        const success = process.takeHeapSnapshot('');
+        const success = await invoke((filePath: string) => process.takeHeapSnapshot(filePath), '');
         expect(success).to.be.false();
       });
     });
+  }
+
+  describe('renderer process', () => {
+    let w: BrowserWindow;
+    before(async () => {
+      w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, contextIsolation: false } });
+      await w.loadURL('about:blank');
+    });
+    after(closeAllWindows);
+
+    generateSpecs((fn, ...args) => {
+      const jsonArgs = args.map(value => JSON.stringify(value)).join(',');
+      return w.webContents.executeJavaScript(`(${fn.toString()})(${jsonArgs})`);
+    });
+
+    describe('process.contextId', () => {
+      it('is a string', async () => {
+        const contextId = await w.webContents.executeJavaScript('process.contextId');
+        expect(contextId).to.be.a('string');
+      });
+    });
+  });
+
+  describe('main process', () => {
+    generateSpecs((fn, ...args) => fn(...args));
   });
 });


### PR DESCRIPTION
#### Description of Change
Using the `invoke` function to execute the process module methods in the `api-process-spec.ts` file eliminates duplicate code and simplifies the codebase.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes
Notes: none