### PR TITLE
fix: remove redundant `MediaCaptureDevicesDispatcher::GetInstance()` call

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -344,9 +344,6 @@ int ElectronBrowserMainParts::PreCreateThreads() {
   // Force MediaCaptureDevicesDispatcher to be created on UI thread.
   MediaCaptureDevicesDispatcher::GetInstance();
 
-  // Force MediaCaptureDevicesDispatcher to be created on UI thread.
-  MediaCaptureDevicesDispatcher::GetInstance();
-
 #if BUILDFLAG(IS_MAC)
   ui::InitIdleMonitor();
   Browser::Get()->ApplyForcedRTL();


### PR DESCRIPTION
#### Description of Change

Remove redundant `MediaCaptureDevicesDispatcher::GetInstance()` call.

This appears to be a copy-paste error introduced in 465dee2c335db1cf081d07e84b757a65b984d881

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.