### PR TITLE
chore: cherry-pick 521faebc8a7c from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -142,3 +142,4 @@ feat_separate_content_settings_callback_for_sync_and_async_clipboard.patch
 fix_win32_synchronous_spellcheck.patch
 fix_enable_wrap_iter_in_string_view_and_array.patch
 fix_linter_error.patch
+cherry-pick-521faebc8a7c.patch

--- a/patches/chromium/cherry-pick-521faebc8a7c.patch
+++ b/patches/chromium/cherry-pick-521faebc8a7c.patch
@@ -1,0 +1,33 @@
+From 521faebc8a7cffe23177c6600bfcfb3c0b9ab1dc Mon Sep 17 00:00:00 2001
+From: Geoff Lang <geofflang@chromium.org>
+Date: Thu, 06 Mar 2025 19:39:37 -0800
+Subject: [PATCH] Disable setting primtive restart for WebGL in the cmd decoder.
+
+Until it's blocked in ANGLE for WebGL contexts, disable it in the
+command decoder on the service side.
+
+Bug: 401059730
+Change-Id: Ia9c7d951cbd122454afec2f884968e0a709cee77
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6334632
+Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
+Reviewed-by: Kenneth Russell <kbr@chromium.org>
+Commit-Queue: Kenneth Russell <kbr@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1429307}
+---
+
+diff --git a/gpu/command_buffer/service/gles2_cmd_decoder_passthrough.cc b/gpu/command_buffer/service/gles2_cmd_decoder_passthrough.cc
+index ad23480..733c553 100644
+--- a/gpu/command_buffer/service/gles2_cmd_decoder_passthrough.cc
++++ b/gpu/command_buffer/service/gles2_cmd_decoder_passthrough.cc
+@@ -2170,6 +2170,11 @@
+     case GL_DEBUG_OUTPUT:
+       return true;
+ 
++    case GL_PRIMITIVE_RESTART_FIXED_INDEX:
++      // Disable setting primitive restart at the command decoder level until
++      // it's blocked in ANGLE for WebGL contexts.
++      return feature_info_->IsWebGLContext();
++
+     default:
+       return false;
+   }


### PR DESCRIPTION
Disable setting primtive restart for WebGL in the cmd decoder.

Until it's blocked in ANGLE for WebGL contexts, disable it in the
command decoder on the service side.

Bug: 401059730
Change-Id: Ia9c7d951cbd122454afec2f884968e0a709cee77
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6334632
Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
Reviewed-by: Kenneth Russell <kbr@chromium.org>
Commit-Queue: Kenneth Russell <kbr@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1429307}


Notes: Backported fix for 401059730.