### PR TITLE
test: fix timing issue in `utilityProcess` test fixtures

### DIFF
--- a/spec/fixtures/api/utility-process/dns-result-order.js
+++ b/spec/fixtures/api/utility-process/dns-result-order.js
@@ -1,4 +1,6 @@
 const dns = require('node:dns');
 
-console.log(dns.getDefaultResultOrder());
-process.exit(0);
+const write = (writable, chunk) => new Promise((resolve) => writable.write(chunk, resolve));
+
+write(process.stdout, `${dns.getDefaultResultOrder()}\n`)
+  .then(() => process.exit(0));

--- a/spec/fixtures/api/utility-process/esm.mjs
+++ b/spec/fixtures/api/utility-process/esm.mjs
@@ -1,2 +1,4 @@
-console.log(import.meta.url);
-process.exit(0);
+const write = (writable, chunk) => new Promise((resolve) => writable.write(chunk, resolve));
+
+write(process.stdout, `${import.meta.url}\n`)
+  .then(() => process.exit(0));


### PR DESCRIPTION
#### Description of Change

Followup to #45690. The same race condition described there also exists in the `esm.js` and `dns-result-order.js` fixtures. This PR ensures that stdout's buffers are flushed before calling `process.exit()`.

This race condition's worth fixing in `electron/electron`; but FWIW, I'm only seeing this test fail on a downstream build's CI boxes, not in `electron/electron`'s GitHub Actions.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.