### PR TITLE
refactor: use private inheritance from `mojo::MessageReceiver`

### DIFF
--- a/shell/browser/api/electron_api_utility_process.h
+++ b/shell/browser/api/electron_api_utility_process.h
@@ -43,7 +43,7 @@ class UtilityProcessWrapper final
     : public gin::Wrappable<UtilityProcessWrapper>,
       public gin_helper::Pinnable<UtilityProcessWrapper>,
       public gin_helper::EventEmitterMixin<UtilityProcessWrapper>,
-      public mojo::MessageReceiver,
+      private mojo::MessageReceiver,
       public node::mojom::NodeServiceClient,
       public content::ServiceProcessHost::Observer {
  public:

--- a/shell/browser/api/message_port.h
+++ b/shell/browser/api/message_port.h
@@ -29,7 +29,7 @@ namespace electron {
 // A non-blink version of blink::MessagePort.
 class MessagePort final : public gin::Wrappable<MessagePort>,
                           public gin_helper::CleanedUpAtExit,
-                          public mojo::MessageReceiver {
+                          private mojo::MessageReceiver {
  public:
   ~MessagePort() override;
   static gin::Handle<MessagePort> Create(v8::Isolate* isolate);

--- a/shell/services/node/parent_port.h
+++ b/shell/services/node/parent_port.h
@@ -31,7 +31,7 @@ namespace electron {
 // for the lifetime of a Utility Process which
 // also means that GC lifecycle is ignored by this class.
 class ParentPort final : public gin::Wrappable<ParentPort>,
-                         public mojo::MessageReceiver {
+                         private mojo::MessageReceiver {
  public:
   static ParentPort* GetInstance();
   static gin::Handle<ParentPort> Create(v8::Isolate* isolate);


### PR DESCRIPTION
#### Description of Change

We have a handful of classes that use public inheritance from `mojo::MessageReceiver` but, but didn't intend for that class's API to be public (e.g. the `Accept() override` method is made private). This PR changes that inheritance to private.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.