### PR TITLE
ci: don't fail branch created workflow if previous board not found

### DIFF
--- a/.github/workflows/branch-created.yml
+++ b/.github/workflows/branch-created.yml
@@ -117,10 +117,11 @@ jobs:
         uses: dsanders11/project-actions/find-project@2134fe7cc71c58b7ae259c82a8e63c6058255678 # v1.7.0
         id: find-prev-release-board
         with:
+          fail-if-project-not-found: false
           title: ${{ steps.generate-project-metadata.outputs.prev-prev-major }}-x-y
           token: ${{ steps.generate-token.outputs.token }}
       - name: Close Previous Release Project Board
-        if: ${{ steps.check-major-version.outputs.MAJOR }}
+        if: ${{ steps.find-prev-release-board.outputs.number }}
         uses: dsanders11/project-actions/close-project@2134fe7cc71c58b7ae259c82a8e63c6058255678 # v1.7.0
         with:
           project-number: ${{ steps.find-prev-release-board.outputs.number }}


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

This ensures we can re-run the workflow to create the release project board if we need to and not have it fail since the previous project board was closed in the initial run. Ran into this the other day when we had to re-run the workflow to fix the variable interpolation failure.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
