### PR TITLE
fix: don't crash Web Workers on unhandled rejections

### DIFF
--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -85,6 +85,9 @@ void WebWorkerObserver::WorkerScriptReadyForEvaluation(
     }
   }
 
+  // We do not want to crash Web Workers on unhandled rejections.
+  env->options()->unhandled_rejections = "warn-with-error-code";
+
   // Add Electron extended APIs.
   electron_bindings_->BindTo(env->isolate(), env->process_object());
 


### PR DESCRIPTION
#### Description of Change

Fix an issue where Web Workers crashed on unhandled rejections. This happened by default because it's how Node.js behaves, but it something we already disabled in the main process and renderer processes because it's not how the web behaves. Align with Web Worker behavior in browsers and prevent utility processes from crashing on any unhandled rejections.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where Web Workers crashed on unhandled rejections.
