### PR TITLE
fix: package import existence verification

### DIFF
--- a/patches/node/fix_allow_passing_fileexists_fn_to_legacymainresolve.patch
+++ b/patches/node/fix_allow_passing_fileexists_fn_to_legacymainresolve.patch
@@ -53,7 +53,7 @@ index 2879e5cf541fb4d226cfd7cc0fe367ca448fb926..03082f0ec4f91382933eec48e77331cd
    const maybeMain = resolvedOption <= legacyMainResolveExtensionsIndexes.kResolvedByMainIndexNode ?
      packageConfig.main || './' : '';
 diff --git a/src/node_file.cc b/src/node_file.cc
-index 1d22e19f16d5ad82466b0724971b2e4a685682f7..9619d10710ffbbdc73fa7d59d1b797c8d0b3a956 100644
+index 1d22e19f16d5ad82466b0724971b2e4a685682f7..3d7e303741a73134e140152bed637fe5ae8bc1db 100644
 --- a/src/node_file.cc
 +++ b/src/node_file.cc
 @@ -3220,13 +3220,25 @@ static void CpSyncCheckPaths(const FunctionCallbackInfo<Value>& args) {
@@ -73,7 +73,7 @@ index 1d22e19f16d5ad82466b0724971b2e4a685682f7..9619d10710ffbbdc73fa7d59d1b797c8
 +        env->isolate(), file_path.c_str(), v8::NewStringType::kNormal)
 +                                       .ToLocalChecked()};
 +    MaybeLocal<Value> maybe_is_file = is_file_function->Call(env->context(), v8::Undefined(env->isolate()), 1, argv);
-+    if (maybe_is_file.IsEmpty()) {
++    if (!maybe_is_file.IsEmpty()) {
 +      bool is_file = maybe_is_file.ToLocalChecked()->BooleanValue(env->isolate());
 +      return is_file ? BindingData::FilePathIsFileReturnType::kIsFile
 +                    : BindingData::FilePathIsFileReturnType::kIsNotFile;

--- a/patches/node/src_stop_using_deprecated_fields_of_fastapicallbackoptions.patch
+++ b/patches/node/src_stop_using_deprecated_fields_of_fastapicallbackoptions.patch
@@ -40,7 +40,7 @@ index 0f0cde7be431dcb80c5314b1a9da49886c436d1c..f6d2bd439cad8b9f91c9d9a6cdb302e6
    }
    HistogramBase* histogram;
 diff --git a/src/node_file.cc b/src/node_file.cc
-index 9619d10710ffbbdc73fa7d59d1b797c8d0b3a956..f2a5c0939b60c582dbbecc07add1e903a9183b95 100644
+index 3d7e303741a73134e140152bed637fe5ae8bc1db..5e744bc34b9dc364e8f20adfd37ee41d76451170 100644
 --- a/src/node_file.cc
 +++ b/src/node_file.cc
 @@ -1061,13 +1061,8 @@ static int32_t FastInternalModuleStat(


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/45896.

Small but critical error not caught as we don't test for this. Adding a test will be a bit complex and I'll follow this up with that but it's blocking enough that we should perhaps not pend on it.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where packages could be mistakenly not found in asar.
