### PR TITLE
fix: remove File.path from types

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@electron/fiddle-core": "^1.3.4",
     "@electron/github-app-auth": "^2.2.1",
     "@electron/lint-roller": "^2.4.0",
-    "@electron/typescript-definitions": "^9.0.0",
+    "@electron/typescript-definitions": "^9.1.1",
     "@octokit/rest": "^20.0.2",
     "@primer/octicons": "^10.0.0",
     "@types/minimist": "^1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -285,10 +285,10 @@
     vscode-uri "^3.0.7"
     yaml "^2.4.5"
 
-"@electron/typescript-definitions@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@electron/typescript-definitions/-/typescript-definitions-9.0.0.tgz#1a8d9f36711ad93643af0662eef917189725c354"
-  integrity sha512-sK/e5ewiHZnpy0jzFW2NmH8KATkprwG962JzxJYw/GphxG/V55mP7UPJirmYUPeOA87TWhL910sjp5gdZ1SQmg==
+"@electron/typescript-definitions@^9.1.1":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@electron/typescript-definitions/-/typescript-definitions-9.1.2.tgz#a9b7bfaed60a528cf1f0ce4a30f01360a27839f2"
+  integrity sha512-BLxuLnvGqKUdesLXh9jB6Ll5Q4Vnb0NqJxuNY+GBz5Q8icxpW2EcHO7gIBpgX+t6sHdfRn9r6Wpwh/CKXoaJng==
   dependencies:
     "@types/node" "^20.11.25"
     chalk "^5.3.0"


### PR DESCRIPTION
Upgrade `@electron/typescript-definitions` to a version that includes https://github.com/electron/typescript-definitions/pull/281

#### Description of Change

Closes #45999

Upgrade `@electron/typescript-definitions` to a version that includes https://github.com/electron/typescript-definitions/pull/281, removing the `path` extension to the `File` type.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes

#### Release Notes

Remove the `path` extension to the `File` type (type-only change)