### PR TITLE
fix: correct electron gin embedder indices (33-x-y)

### DIFF
--- a/patches/chromium/fix_harden_blink_scriptstate_maybefrom.patch
+++ b/patches/chromium/fix_harden_blink_scriptstate_maybefrom.patch
@@ -40,18 +40,18 @@ accessing uninitialized lower indexes can return garbage values that cannot be n
 Refer to v8::EmbedderDataSlot::store_aligned_pointer for context.
 
 diff --git a/gin/public/gin_embedders.h b/gin/public/gin_embedders.h
-index 8d7c5631fd8f1499c67384286f0e3c4037673b32..99b2e2f63be8a46c5546dd53bc9b05e8c54e857c 100644
+index 8d7c5631fd8f1499c67384286f0e3c4037673b32..2b7bdfbac06a42e6bc51eb65e023c3673e6eb885 100644
 --- a/gin/public/gin_embedders.h
 +++ b/gin/public/gin_embedders.h
-@@ -18,6 +18,8 @@ namespace gin {
- enum GinEmbedder : uint16_t {
-   kEmbedderNativeGin,
+@@ -20,6 +20,8 @@ enum GinEmbedder : uint16_t {
    kEmbedderBlink,
-+  kEmbedderElectron,
-+  kEmbedderBlinkTag,
    kEmbedderPDFium,
    kEmbedderFuchsia,
++  kEmbedderElectron,
++  kEmbedderBlinkTag,
  };
+
+ }  // namespace gin
 diff --git a/third_party/blink/renderer/platform/bindings/script_state.cc b/third_party/blink/renderer/platform/bindings/script_state.cc
 index e4a27a24c83dd1a478b2ada8b6c8220076790791..c76dc818f38a62fff63852dbecbc85e304ac731d 100644
 --- a/third_party/blink/renderer/platform/bindings/script_state.cc
@@ -86,7 +86,7 @@ index e4a27a24c83dd1a478b2ada8b6c8220076790791..c76dc818f38a62fff63852dbecbc85e3
  
    // Cut the reference from ScriptState to V8 context.
 diff --git a/third_party/blink/renderer/platform/bindings/script_state.h b/third_party/blink/renderer/platform/bindings/script_state.h
-index e9b16a9c71b9631222d0745428fea06be2e74472..aba4d930a9a45fb43e0aaac26af7df4fa07fc447 100644
+index e9b16a9c71b9631222d0745428fea06be2e74472..a85431a73bae23b5d47bc0338430c120de538864 100644
 --- a/third_party/blink/renderer/platform/bindings/script_state.h
 +++ b/third_party/blink/renderer/platform/bindings/script_state.h
 @@ -184,7 +184,12 @@ class PLATFORM_EXPORT ScriptState : public GarbageCollected<ScriptState> {
@@ -103,7 +103,7 @@ index e9b16a9c71b9631222d0745428fea06be2e74472..aba4d930a9a45fb43e0aaac26af7df4f
        return nullptr;
      }
      ScriptState* script_state =
-@@ -251,9 +256,15 @@ class PLATFORM_EXPORT ScriptState : public GarbageCollected<ScriptState> {
+@@ -251,9 +256,14 @@ class PLATFORM_EXPORT ScriptState : public GarbageCollected<ScriptState> {
    static void SetCreateCallback(CreateCallback);
    friend class ScriptStateImpl;
  
@@ -114,7 +114,6 @@ index e9b16a9c71b9631222d0745428fea06be2e74472..aba4d930a9a45fb43e0aaac26af7df4f
        static_cast<int>(gin::kEmbedderBlink);
 +  static constexpr int kV8ContextPerContextDataTagIndex =
 +      static_cast<int>(gin::kPerContextDataStartIndex) +
-+      static_cast<int>(gin::kEmbedderBlink) +
 +      static_cast<int>(gin::kEmbedderBlinkTag);
  };
  


### PR DESCRIPTION
Manually backport #45389 to 33-x-y. See that PR for details.

Notes: Fixed invalid memory access in pdf viewer which lead to random crashes.