### PR TITLE
fix: remove `File.path` from types

### DIFF
--- a/docs/api/web-utils.md
+++ b/docs/api/web-utils.md
@@ -16,7 +16,7 @@ Returns `string` - The file system path that this `File` object points to. In th
 
 This method superseded the previous augmentation to the `File` object with the `path` property.  An example is included below.
 
-```js
+```js @ts-nocheck
 // Before
 const oldPath = document.querySelector('input').files[0].path
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@electron/fiddle-core": "^1.3.4",
     "@electron/github-app-auth": "^2.2.1",
     "@electron/lint-roller": "^2.4.0",
-    "@electron/typescript-definitions": "^9.0.0",
+    "@electron/typescript-definitions": "^9.1.2",
     "@octokit/rest": "^20.0.2",
     "@primer/octicons": "^10.0.0",
     "@types/minimist": "^1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -285,10 +285,10 @@
     vscode-uri "^3.0.7"
     yaml "^2.4.5"
 
-"@electron/typescript-definitions@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@electron/typescript-definitions/-/typescript-definitions-9.0.0.tgz#1a8d9f36711ad93643af0662eef917189725c354"
-  integrity sha512-sK/e5ewiHZnpy0jzFW2NmH8KATkprwG962JzxJYw/GphxG/V55mP7UPJirmYUPeOA87TWhL910sjp5gdZ1SQmg==
+"@electron/typescript-definitions@^9.1.1":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@electron/typescript-definitions/-/typescript-definitions-9.1.2.tgz#a9b7bfaed60a528cf1f0ce4a30f01360a27839f2"
+  integrity sha512-BLxuLnvGqKUdesLXh9jB6Ll5Q4Vnb0NqJxuNY+GBz5Q8icxpW2EcHO7gIBpgX+t6sHdfRn9r6Wpwh/CKXoaJng==
   dependencies:
     "@types/node" "^20.11.25"
     chalk "^5.3.0"
@@ -7042,14 +7042,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -285,7 +285,7 @@
     vscode-uri "^3.0.7"
     yaml "^2.4.5"
 
-"@electron/typescript-definitions@^9.1.1":
+"@electron/typescript-definitions@^9.1.2":
   version "9.1.2"
   resolved "https://registry.yarnpkg.com/@electron/typescript-definitions/-/typescript-definitions-9.1.2.tgz#a9b7bfaed60a528cf1f0ce4a30f01360a27839f2"
   integrity sha512-BLxuLnvGqKUdesLXh9jB6Ll5Q4Vnb0NqJxuNY+GBz5Q8icxpW2EcHO7gIBpgX+t6sHdfRn9r6Wpwh/CKXoaJng==


### PR DESCRIPTION
#### Description of Change

Supersedes https://github.com/electron/electron/pull/46000.
Closes https://github.com/electron/electron/issues/45999

From original PR:
> Upgrade @electron/typescript-definitions to a version that includes https://github.com/electron/typescript-definitions/pull/281, removing the path extension to the File type.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
