### PR TITLE
refactor: remove unused system header includes

### DIFF
--- a/shell/app/electron_content_client.cc
+++ b/shell/app/electron_content_client.cc
@@ -6,7 +6,6 @@
 
 #include <string>
 #include <string_view>
-#include <utility>
 #include <vector>
 
 #include "base/command_line.h"

--- a/shell/app/electron_main_linux.cc
+++ b/shell/app/electron_main_linux.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include <cstdlib>
-#include <utility>
 
 #include "base/at_exit.h"
 #include "base/command_line.h"

--- a/shell/app/electron_main_win.cc
+++ b/shell/app/electron_main_win.cc
@@ -14,7 +14,6 @@
 #include <memory>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "base/at_exit.h"
 #include "base/debug/alias.h"

--- a/shell/browser/api/electron_api_service_worker_main.cc
+++ b/shell/browser/api/electron_api_service_worker_main.cc
@@ -7,7 +7,6 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
-#include <vector>
 
 #include "base/logging.h"
 #include "base/no_destructor.h"

--- a/shell/browser/api/electron_api_service_worker_main.h
+++ b/shell/browser/api/electron_api_service_worker_main.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_BROWSER_API_ELECTRON_API_SERVICE_WORKER_MAIN_H_
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_SERVICE_WORKER_MAIN_H_
 
-#include <optional>
 #include <string>
 #include <vector>
 

--- a/shell/browser/api/electron_api_service_worker_main.h
+++ b/shell/browser/api/electron_api_service_worker_main.h
@@ -6,7 +6,6 @@
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_SERVICE_WORKER_MAIN_H_
 
 #include <string>
-#include <vector>
 
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -9,7 +9,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <string_view>
 #include <utility>
 #include <vector>
 

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -9,7 +9,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "base/functional/callback_forward.h"

--- a/shell/browser/api/gpu_info_enumerator.h
+++ b/shell/browser/api/gpu_info_enumerator.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_BROWSER_API_GPU_INFO_ENUMERATOR_H_
 #define ELECTRON_SHELL_BROWSER_API_GPU_INFO_ENUMERATOR_H_
 
-#include <memory>
 #include <stack>
 #include <string>
 

--- a/shell/browser/electron_download_manager_delegate.cc
+++ b/shell/browser/electron_download_manager_delegate.cc
@@ -6,7 +6,6 @@
 
 #include <string>
 #include <string_view>
-#include <tuple>
 #include <utility>
 
 #include "base/files/file_util.h"

--- a/shell/browser/electron_web_contents_utility_handler_impl.h
+++ b/shell/browser/electron_web_contents_utility_handler_impl.h
@@ -5,8 +5,6 @@
 #ifndef ELECTRON_SHELL_BROWSER_ELECTRON_WEB_CONTENTS_UTILITY_HANDLER_IMPL_H_
 #define ELECTRON_SHELL_BROWSER_ELECTRON_WEB_CONTENTS_UTILITY_HANDLER_IMPL_H_
 
-#include <vector>
-
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/global_routing_id.h"
 #include "content/public/browser/web_contents_observer.h"

--- a/shell/browser/extensions/api/extension_action/extension_action_api.cc
+++ b/shell/browser/extensions/api/extension_action/extension_action_api.cc
@@ -6,7 +6,6 @@
 
 #include <stddef.h>
 
-#include <memory>
 #include <utility>
 
 #include "base/no_destructor.h"

--- a/shell/browser/extensions/api/extension_action/extension_action_api.h
+++ b/shell/browser/extensions/api/extension_action/extension_action_api.h
@@ -5,8 +5,6 @@
 #ifndef SHELL_BROWSER_EXTENSIONS_API_EXTENSION_ACTION_EXTENSION_ACTION_API_H_
 #define SHELL_BROWSER_EXTENSIONS_API_EXTENSION_ACTION_EXTENSION_ACTION_API_H_
 
-#include <string>
-
 #include "base/memory/raw_ptr.h"
 #include "extensions/browser/browser_context_keyed_api_factory.h"
 #include "extensions/browser/extension_action.h"

--- a/shell/browser/extensions/api/scripting/scripting_api.h
+++ b/shell/browser/extensions/api/scripting/scripting_api.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 

--- a/shell/browser/extensions/api/scripting/scripting_api.h
+++ b/shell/browser/extensions/api/scripting/scripting_api.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "chrome/common/extensions/api/scripting.h"

--- a/shell/browser/file_system_access/file_system_access_permission_context.h
+++ b/shell/browser/file_system_access/file_system_access_permission_context.h
@@ -7,6 +7,7 @@
 
 #include "shell/browser/file_system_access/file_system_access_permission_context.h"
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -6,7 +6,6 @@
 
 #include <memory>
 #include <string>
-#include <unordered_set>
 #include <utility>
 
 #include "base/allocator/partition_alloc_features.h"

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <queue>
+#include <set>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/shell/browser/net/asar/asar_file_validator.cc
+++ b/shell/browser/net/asar/asar_file_validator.cc
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <array>
-#include <string>
 #include <utility>
 #include <vector>
 

--- a/shell/browser/net/system_network_context_manager.cc
+++ b/shell/browser/net/system_network_context_manager.cc
@@ -7,7 +7,6 @@
 #include <memory>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "base/command_line.h"
 #include "base/memory/raw_ptr.h"

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -8,7 +8,6 @@
 #include <memory>
 #include <optional>
 #include <utility>
-#include <vector>
 
 #include "base/functional/callback_helpers.h"
 #include "base/location.h"

--- a/shell/browser/relauncher.cc
+++ b/shell/browser/relauncher.cc
@@ -4,8 +4,6 @@
 
 #include "shell/browser/relauncher.h"
 
-#include <utility>
-
 #if BUILDFLAG(IS_WIN)
 #include <windows.h>
 #endif

--- a/shell/browser/ui/devtools_ui_bundle_data_source.cc
+++ b/shell/browser/ui/devtools_ui_bundle_data_source.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/ui/devtools_ui_bundle_data_source.h"
 
-#include <memory>
 #include <string>
 #include <utility>
 

--- a/shell/browser/ui/devtools_ui_theme_data_source.cc
+++ b/shell/browser/ui/devtools_ui_theme_data_source.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/ui/devtools_ui_theme_data_source.h"
 
-#include <memory>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/shell/browser/zoom_level_delegate.cc
+++ b/shell/browser/zoom_level_delegate.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/zoom_level_delegate.h"
 
-#include <functional>
 #include <utility>
 #include <vector>
 

--- a/shell/common/process_util.h
+++ b/shell/common/process_util.h
@@ -6,7 +6,6 @@
 #define ELECTRON_SHELL_COMMON_PROCESS_UTIL_H_
 
 #include <string>
-#include <string_view>
 
 namespace electron {
 

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -7,7 +7,6 @@
 #include <memory>
 #include <set>
 #include <string>
-#include <tuple>
 #include <utility>
 #include <vector>
 

--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -5,7 +5,6 @@
 #include "electron/shell/renderer/electron_api_service_impl.h"
 
 #include <string_view>
-#include <tuple>
 #include <utility>
 #include <vector>
 

--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -4,7 +4,6 @@
 
 #include "electron/shell/renderer/electron_api_service_impl.h"
 
-#include <memory>
 #include <string_view>
 #include <tuple>
 #include <utility>

--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -4,8 +4,6 @@
 
 #include "shell/renderer/electron_render_frame_observer.h"
 
-#include <utility>
-
 #include "base/memory/ref_counted_memory.h"
 #include "base/trace_event/trace_event.h"
 #include "content/public/renderer/render_frame.h"

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -5,7 +5,6 @@
 #include "shell/renderer/electron_sandboxed_renderer_client.h"
 
 #include <iterator>
-#include <tuple>
 #include <vector>
 
 #include "base/base_paths.h"

--- a/shell/renderer/extensions/electron_extensions_renderer_client.cc
+++ b/shell/renderer/extensions/electron_extensions_renderer_client.cc
@@ -4,8 +4,6 @@
 
 #include "shell/renderer/extensions/electron_extensions_renderer_client.h"
 
-#include <string>
-
 #include "content/public/renderer/render_thread.h"
 #include "extensions/common/constants.h"
 #include "extensions/common/manifest_handlers/background_info.h"

--- a/shell/renderer/extensions/electron_extensions_renderer_client.h
+++ b/shell/renderer/extensions/electron_extensions_renderer_client.h
@@ -5,8 +5,6 @@
 #ifndef ELECTRON_SHELL_RENDERER_EXTENSIONS_ELECTRON_EXTENSIONS_RENDERER_CLIENT_H_
 #define ELECTRON_SHELL_RENDERER_EXTENSIONS_ELECTRON_EXTENSIONS_RENDERER_CLIENT_H_
 
-#include <memory>
-
 #include "extensions/renderer/extensions_renderer_client.h"
 
 namespace content {


### PR DESCRIPTION
#### Description of Change

Simple cleanup PR to remove unused #includes: e.g. if a header doesn't use `std::set`, it shouldn't  `#include <set>`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none