### PR TITLE
refactor: replace base::StringPrintf() calls with absl::StrFormat()

### DIFF
--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -1067,9 +1067,9 @@ std::string Session::RegisterPreloadScript(
                          });
 
   if (it != preload_scripts.end()) {
-    thrower.ThrowError(base::StringPrintf(
-        "Cannot register preload script with existing ID '%s'",
-        new_preload_script.id.c_str()));
+    thrower.ThrowError(
+        absl::StrFormat("Cannot register preload script with existing ID '%s'",
+                        new_preload_script.id));
     return "";
   }
 
@@ -1080,8 +1080,8 @@ std::string Session::RegisterPreloadScript(
                  << new_preload_script.file_path;
     } else {
       thrower.ThrowError(
-          base::StringPrintf("Preload script must have absolute path: %s",
-                             new_preload_script.file_path.value().c_str()));
+          absl::StrFormat("Preload script must have absolute path: %s",
+                          new_preload_script.file_path.value()));
       return "";
     }
   }
@@ -1110,9 +1110,8 @@ void Session::UnregisterPreloadScript(gin_helper::ErrorThrower thrower,
   }
 
   // If the script is not found, throw an error
-  thrower.ThrowError(base::StringPrintf(
-      "Cannot unregister preload script with non-existing ID '%s'",
-      script_id.c_str()));
+  thrower.ThrowError(absl::StrFormat(
+      "Cannot unregister preload script with non-existing ID '%s'", script_id));
 }
 
 std::vector<PreloadScript> Session::GetPreloadScripts() const {

--- a/shell/browser/ui/devtools_ui_theme_data_source.cc
+++ b/shell/browser/ui/devtools_ui_theme_data_source.cc
@@ -23,6 +23,7 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_ui.h"
 #include "net/base/url_util.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
 #include "ui/base/webui/web_ui_util.h"
 #include "ui/color/color_provider.h"
 #include "ui/color/color_provider_utils.h"
@@ -158,17 +159,16 @@ void ThemeDataSource::SendColorsCss(
         for (ui::ColorId id = start; id < end; ++id) {
           const SkColor color = color_provider.GetColor(id);
           std::string css_id_to_color_mapping =
-              base::StringPrintf("%s:%s;", color_css_name.Run(id).c_str(),
-                                 ui::ConvertSkColorToCSSColor(color).c_str());
+              absl::StrFormat("%s:%s;", color_css_name.Run(id),
+                              ui::ConvertSkColorToCSSColor(color));
           base::StrAppend(&css_string, {css_id_to_color_mapping});
           if (generate_rgb_vars) {
             // Also generate a r,g,b string for each color so apps can construct
             // colors with their own opacities in css.
             const std::string css_rgb_color_str =
                 color_utils::SkColorToRgbString(color);
-            const std::string css_id_to_rgb_color_mapping =
-                base::StringPrintf("%s-rgb:%s;", color_css_name.Run(id).c_str(),
-                                   css_rgb_color_str.c_str());
+            const std::string css_id_to_rgb_color_mapping = absl::StrFormat(
+                "%s-rgb:%s;", color_css_name.Run(id), css_rgb_color_str);
             base::StrAppend(&css_string, {css_id_to_rgb_color_mapping});
           }
         }

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -25,6 +25,7 @@
 #include "shell/common/node_includes.h"
 #include "shell/common/world_ids.h"
 #include "shell/renderer/preload_realm_context.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
 #include "third_party/blink/public/web/web_blob.h"
 #include "third_party/blink/public/web/web_element.h"
 #include "third_party/blink/public/web/web_local_frame.h"
@@ -945,7 +946,7 @@ v8::Local<v8::Value> ExecuteInWorld(v8::Isolate* isolate,
   if (!maybe_target_context.ToLocal(&target_context)) {
     isolate->ThrowException(v8::Exception::Error(gin::StringToV8(
         isolate,
-        base::StringPrintf("Failed to get context for world %d", world_id))));
+        absl::StrFormat("Failed to get context for world %d", world_id))));
     return v8::Undefined(isolate);
   }
 
@@ -957,8 +958,7 @@ v8::Local<v8::Value> ExecuteInWorld(v8::Isolate* isolate,
     v8::MaybeLocal<v8::Script> maybe_compiled_script;
     {
       v8::TryCatch try_catch(isolate);
-      std::string return_func_code =
-          base::StringPrintf("(%s)", function_str.c_str());
+      std::string return_func_code = absl::StrFormat("(%s)", function_str);
       maybe_compiled_script = v8::Script::Compile(
           target_context, gin::StringToV8(isolate, return_func_code));
       if (try_catch.HasCaught()) {
@@ -1022,7 +1022,7 @@ v8::Local<v8::Value> ExecuteInWorld(v8::Isolate* isolate,
       v8::Local<v8::Value> arg;
       if (!args_array->Get(source_context, i).ToLocal(&arg)) {
         gin_helper::ErrorThrower(isolate).ThrowError(
-            base::StringPrintf("Failed to get argument at index %d", i));
+            absl::StrFormat("Failed to get argument at index %d", i));
         return v8::Undefined(isolate);
       }
 
@@ -1032,7 +1032,7 @@ v8::Local<v8::Value> ExecuteInWorld(v8::Isolate* isolate,
           &object_cache);
       if (proxied_arg.IsEmpty()) {
         gin_helper::ErrorThrower(isolate).ThrowError(
-            base::StringPrintf("Failed to proxy argument at index %d", i));
+            absl::StrFormat("Failed to proxy argument at index %d", i));
         return v8::Undefined(isolate);
       }
       proxied_args.push_back(proxied_arg.ToLocalChecked());


### PR DESCRIPTION
#### Description of Change

replace base::StringPrintf() calls with absl::StrFormat()
    
The former is now a pass-through for the latter and is slated for removal
    
Xref: https://issues.chromium.org/issues/40241565
    
https://chromium-review.googlesource.com/c/chromium/src/+/4907781

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.