### PR TITLE
fix: `ElectronBrowserContext` `raw_ptr` bug + remove dead code

### DIFF
--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -365,10 +365,10 @@ ElectronBrowserContext::ElectronBrowserContext(
     BrowserContextDependencyManager::GetInstance()
         ->CreateBrowserContextServices(this);
 
-    extension_system_ = static_cast<extensions::ElectronExtensionSystem*>(
+    auto* extension_system = static_cast<extensions::ElectronExtensionSystem*>(
         extensions::ExtensionSystem::Get(this));
-    extension_system_->InitForRegularProfile(true /* extensions_enabled */);
-    extension_system_->FinishInitialization();
+    extension_system->InitForRegularProfile(true /* extensions_enabled */);
+    extension_system->FinishInitialization();
   }
 #endif
 }
@@ -376,11 +376,6 @@ ElectronBrowserContext::ElectronBrowserContext(
 ElectronBrowserContext::~ElectronBrowserContext() {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
   NotifyWillBeDestroyed();
-
-#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  // the DestroyBrowserContextServices() call below frees this.
-  extension_system_ = nullptr;
-#endif
 
   // Notify any keyed services of browser context destruction.
   BrowserContextDependencyManager::GetInstance()->DestroyBrowserContextServices(

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -13,12 +13,10 @@
 #include <variant>
 #include <vector>
 
-#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/media_stream_request.h"
 #include "content/public/browser/resource_context.h"
-#include "electron/buildflags/buildflags.h"
 #include "electron/shell/browser/media/media_device_id_salt.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/network/public/mojom/ssl_config.mojom.h"
@@ -42,12 +40,6 @@ class PreconnectManager;
 namespace storage {
 class SpecialStoragePolicy;
 }
-
-#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-namespace extensions {
-class ElectronExtensionSystem;
-}
-#endif
 
 namespace electron {
 
@@ -154,15 +146,6 @@ class ElectronBrowserContext : public content::BrowserContext {
     return weak_factory_.GetWeakPtr();
   }
 
-#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  extensions::ElectronExtensionSystem* extension_system() {
-    // Guard usages of extension_system() with !IsOffTheRecord()
-    // There is no extension system for in-memory sessions
-    DCHECK(!IsOffTheRecord());
-    return extension_system_;
-  }
-#endif
-
   ProtocolRegistry* protocol_registry() const {
     return protocol_registry_.get();
   }
@@ -236,11 +219,6 @@ class ElectronBrowserContext : public content::BrowserContext {
   bool in_memory_ = false;
   bool use_cache_ = true;
   int max_cache_size_ = 0;
-
-#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  // Owned by the KeyedService system.
-  raw_ptr<extensions::ElectronExtensionSystem> extension_system_;
-#endif
 
   // Shared URLLoaderFactory.
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;


### PR DESCRIPTION
### Description of Change

- Remove `ElectronBrowserContext::extension_system()`, whose last caller was removed on Jul 21, 2020 by 94e64af9edeb82b5192ff01f166a35771b1bfbab in PR #24575...
- ...which, in turn, lets us remove the `raw_ptr` field `ElectronBrowserContext::extension_system_` ...
- ...which, in turn,  fixes the thing that got me looking at this part of the code: a `raw_ptr` error in the `ElectronBrowserContext` destructor  :raised_hands: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.