### PR TITLE
fix: potential invalid dereference in `ScriptingExecuteScriptFunction::Run()`

### DIFF
--- a/shell/browser/extensions/api/scripting/scripting_api.cc
+++ b/shell/browser/extensions/api/scripting/scripting_api.cc
@@ -498,7 +498,7 @@ ExtensionFunction::ResponseAction ScriptingExecuteScriptFunction::Run() {
   }
 
   std::string code_to_execute = absl::StrFormat(
-      "(%s)(%s)", injection_.func->c_str(), args_expression.c_str());
+      "(%s)(%s)", injection_.func.value_or(""), args_expression);
 
   std::vector<mojom::JSSourcePtr> sources;
   sources.push_back(mojom::JSSource::New(std::move(code_to_execute), GURL()));


### PR DESCRIPTION
#### Description of Change

`injection_.func` is a `std::optional<std::string>`.

Our code does a safety check in debug builds two paragraphs up:

```
DCHECK(injection_.func)
```

... but that doesn't help for production. The risky code is"

```
base::StringPrintf("%s", injection_.func->c_str())
```

... which could lead to an invalid dereference if `injection_func` is empty.

I'll also try upstreaming this for `chrome/browser/extensions/api/scripting/scripting_api.cc`

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none