### PR TITLE
feat: add B-series ISO paper sizes

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1709,7 +1709,8 @@ Returns `Promise<PrinterInfo[]>` - Resolves with a [`PrinterInfo[]`](structures/
   * `header` string (optional) - string to be printed as page header.
   * `footer` string (optional) - string to be printed as page footer.
   * `pageSize` string | Size (optional) - Specify page size of the printed document. Can be `A0`, `A1`, `A2`, `A3`,
-  `A4`, `A5`, `A6`, `Legal`, `Letter`, `Tabloid` or an Object containing `height` and `width`.
+  `A4`, `A5`, `A6`, `B0`, `B1`, `B2`, `B3`, `B4`, `B5`, `B6`, `Legal`, `Letter`, `Tabloid` or an Object containing `height` and `width`.
+
 * `callback` Function (optional)
   * `success` boolean - Indicates success of the print call.
   * `failureReason` string - Error description called back if the print fails.
@@ -1746,7 +1747,7 @@ win.webContents.print(options, (success, errorType) => {
   * `printBackground` boolean (optional) - Whether to print background graphics. Defaults to false.
   * `scale` number(optional)  - Scale of the webpage rendering. Defaults to 1.
   * `pageSize` string | Size (optional) - Specify page size of the generated PDF. Can be `A0`, `A1`, `A2`, `A3`,
-  `A4`, `A5`, `A6`, `Legal`, `Letter`, `Tabloid`, `Ledger`, or an Object containing `height` and `width` in inches. Defaults to `Letter`.
+  `A4`, `A5`, `A6`, `B0`, `B1`, `B2`, `B3`, `B4`, `B5`, `B6`, `Legal`, `Letter`, `Tabloid`, `Ledger`, or an Object containing `height` and `width` in inches. Defaults to `Letter`.
   * `margins` Object (optional)
     * `top` number (optional) - Top margin in inches. Defaults to 1cm (~0.4 inches).
     * `bottom` number (optional) - Bottom margin in inches. Defaults to 1cm (~0.4 inches).

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -583,8 +583,8 @@ Stops any `findInPage` request for the `webview` with the provided `action`.
     * `vertical` number (optional) - The vertical dpi.
   * `header` string (optional) - string to be printed as page header.
   * `footer` string (optional) - string to be printed as page footer.
-  * `pageSize` string | Size (optional) - Specify page size of the printed document. Can be `A3`,
-  `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height` in microns.
+  * `pageSize` string | Size (optional) - Specify page size of the printed document. Can be `A0`, `A1`, `A2`, `A3`,
+  `A4`, `A5`, `A6`, `B0`, `B1`, `B2`, `B3`, `B4`, `B5`, `B6`, `Legal`, `Letter`, `Tabloid` or an Object containing `height` in microns.
 
 Returns `Promise<void>`
 
@@ -598,7 +598,8 @@ Prints `webview`'s web page. Same as `webContents.print([options])`.
   * `printBackground` boolean (optional) - Whether to print background graphics. Defaults to false.
   * `scale` number(optional)  - Scale of the webpage rendering. Defaults to 1.
   * `pageSize` string | Size (optional) - Specify page size of the generated PDF. Can be `A0`, `A1`, `A2`, `A3`,
-  `A4`, `A5`, `A6`, `Legal`, `Letter`, `Tabloid`, `Ledger`, or an Object containing `height` and `width` in inches. Defaults to `Letter`.
+  `A4`, `A5`, `A6`, `B0`, `B1`, `B2`, `B3`, `B4`, `B5`, `B6`, `Legal`, `Letter`, `Tabloid`, `Ledger`, or an Object containing `height` and `width` in inches. Defaults to `Letter`.
+
   * `margins` Object (optional)
     * `top` number (optional) - Top margin in inches. Defaults to 1cm (~0.4 inches).
     * `bottom` number (optional) - Bottom margin in inches. Defaults to 1cm (~0.4 inches).

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -83,6 +83,48 @@ const PDFPageSizes: Record<string, ElectronInternal.MediaSize> = {
     height_microns: 148000,
     name: 'ISO_A6',
     width_microns: 105000
+  },
+  B0: {
+    custom_display_name: 'B0',
+    height_microns: 1414000,
+    name: 'ISO_B0',
+    width_microns: 1000000
+  },
+  B1: {
+    custom_display_name: 'B1',
+    height_microns: 1000000,
+    name: 'ISO_B1',
+    width_microns: 707000
+  },
+  B2: {
+    custom_display_name: 'B2',
+    height_microns: 707000,
+    name: 'ISO_B2',
+    width_microns: 500000
+  },
+  B3: {
+    custom_display_name: 'B3',
+    height_microns: 500000,
+    name: 'ISO_B3',
+    width_microns: 353000
+  },
+  B4: {
+    custom_display_name: 'B4',
+    height_microns: 353000,
+    name: 'ISO_B4',
+    width_microns: 250000
+  },
+  B5: {
+    custom_display_name: 'B5',
+    height_microns: 250000,
+    name: 'ISO_B5',
+    width_microns: 176000
+  },
+  B6: {
+    custom_display_name: 'B6',
+    height_microns: 176000,
+    name: 'ISO_B6',
+    width_microns: 125000
   }
 } as const;
 
@@ -97,7 +139,14 @@ const paperFormats: Record<string, ElectronInternal.PageSize> = {
   a3: { width: 11.7, height: 16.54 },
   a4: { width: 8.27, height: 11.7 },
   a5: { width: 5.83, height: 8.27 },
-  a6: { width: 4.13, height: 5.83 }
+  a6: { width: 4.13, height: 5.83 },
+  b0: { width: 39.37, height: 55.67 },
+  b1: { width: 27.83, height: 39.37 },
+  b2: { width: 19.69, height: 27.83 },
+  b3: { width: 13.9, height: 19.69 },
+  b4: { width: 9.84, height: 13.9 },
+  b5: { width: 6.93, height: 9.84 },
+  b6: { width: 4.92, height: 6.93 }
 } as const;
 
 // The minimum micron size Chromium accepts is that where:

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2573,7 +2573,14 @@ describe('webContents module', () => {
         A3: { width: 11.7, height: 16.54 },
         A4: { width: 8.27, height: 11.7 },
         A5: { width: 5.83, height: 8.27 },
-        A6: { width: 4.13, height: 5.83 }
+        A6: { width: 4.13, height: 5.83 },
+        B0: { width: 39.37, height: 55.67 },
+        B1: { width: 27.83, height: 39.37 },
+        B2: { width: 19.69, height: 27.83 },
+        B3: { width: 13.9, height: 19.69 },
+        B4: { width: 9.84, height: 13.9 },
+        B5: { width: 6.93, height: 9.84 },
+        B6: { width: 4.92, height: 6.93 }
       };
 
       await w.loadFile(path.join(__dirname, 'fixtures', 'api', 'print-to-pdf-small.html'));


### PR DESCRIPTION
#### Description of Change

I recently wanted to print to a B5 sheet, but only found A-series presets. Adding the B-series sizes from https://en.wikipedia.org/wiki/Paper_size#Overview_of_ISO_paper_sizes

I don't have the disk space to build this project locally (tens of gigabytes, what?) so I am hoping to iterate on the CI build to get to a full build/test cycle. Alternatively, if a maintainer wishes to help with this, that would be appreciated. This is my first time opening a PR against Electron, so I don't know which stakeholders to CC.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd (don't know who to CC)
- [ ] `npm test` passes (don't have the disk space to build locally)
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Allow using B-series ISO paper sizes with `webContents.print()`.