### PR TITLE
fix: warning in file picker UI

### DIFF
--- a/shell/browser/file_system_access/file_system_access_permission_context.cc
+++ b/shell/browser/file_system_access/file_system_access_permission_context.cc
@@ -825,13 +825,7 @@ std::u16string FileSystemAccessPermissionContext::GetPickerTitle(
               ? IDS_FILE_SYSTEM_ACCESS_CHOOSER_OPEN_WRITABLE_DIRECTORY_TITLE
               : IDS_FILE_SYSTEM_ACCESS_CHOOSER_OPEN_READABLE_DIRECTORY_TITLE);
       break;
-    case blink::mojom::TypeSpecificFilePickerOptionsUnion::Tag::
-        kSaveFilePickerOptions:
-      title = l10n_util::GetStringUTF16(
-          IDS_FILE_SYSTEM_ACCESS_CHOOSER_OPEN_SAVE_FILE_TITLE);
-      break;
-    case blink::mojom::TypeSpecificFilePickerOptionsUnion::Tag::
-        kOpenFilePickerOptions:
+    default:
       break;
   }
   return title;


### PR DESCRIPTION
#### Description of Change

Remove the code in `shell/browser/file_system_access/file_system_access_permission_context.cc` that loads `IDS_FILE_SYSTEM_ACCESS_CHOOSER_OPEN_SAVE_FILE_TITLE` for the title string in `kSaveFilePickerOptions` dialogs. The upstream default of that string is "Warning: this site can see edits you make", which doesn't make sense for Electron?

Removing the string there returns to the pre-30.0.0 behavior, which on my Linux test machine, is the string "All Files".

Fixes #46052.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed incorrect titlebar in file save dialogs.