### PR TITLE
chore: e patches all

### DIFF
--- a/patches/chromium/fix_take_snapped_status_into_account_when_showing_a_window.patch
+++ b/patches/chromium/fix_take_snapped_status_into_account_when_showing_a_window.patch
@@ -19,10 +19,10 @@ would be removed from its snapped state when re-shown. This fixes that.
 Upstreamed at https://chromium-review.googlesource.com/c/chromium/src/+/6330848.
 
 diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
-index 22ed43bdf4dbaccc598135807abc8383c52db50e..c5457e3e58b53ca04697b22a885da654c6c0655f 100644
+index 64dd7b6e507b61fab7a044823462fb04eabba698..2cd734db007174834c70365ffe6b46d52673e5cb 100644
 --- a/ui/views/win/hwnd_message_handler.cc
 +++ b/ui/views/win/hwnd_message_handler.cc
-@@ -676,7 +676,8 @@ void HWNDMessageHandler::Show(ui::mojom::WindowShowState show_state,
+@@ -683,7 +683,8 @@ void HWNDMessageHandler::Show(ui::mojom::WindowShowState show_state,
      SetWindowPlacement(hwnd(), &placement);
      native_show_state = SW_SHOWMAXIMIZED;
    } else {
@@ -32,7 +32,7 @@ index 22ed43bdf4dbaccc598135807abc8383c52db50e..c5457e3e58b53ca04697b22a885da654
  
      // Use SW_SHOW/SW_SHOWNA instead of SW_SHOWNORMAL/SW_SHOWNOACTIVATE so that
      // the window is not restored to its original position if it is maximized.
-@@ -686,7 +687,8 @@ void HWNDMessageHandler::Show(ui::mojom::WindowShowState show_state,
+@@ -693,7 +694,8 @@ void HWNDMessageHandler::Show(ui::mojom::WindowShowState show_state,
      // position, some do not. See crbug.com/1296710
      switch (show_state) {
        case ui::mojom::WindowShowState::kInactive:
@@ -42,7 +42,7 @@ index 22ed43bdf4dbaccc598135807abc8383c52db50e..c5457e3e58b53ca04697b22a885da654
          break;
        case ui::mojom::WindowShowState::kMaximized:
          native_show_state = SW_SHOWMAXIMIZED;
-@@ -697,9 +699,11 @@ void HWNDMessageHandler::Show(ui::mojom::WindowShowState show_state,
+@@ -704,9 +706,11 @@ void HWNDMessageHandler::Show(ui::mojom::WindowShowState show_state,
        case ui::mojom::WindowShowState::kNormal:
          if ((GetWindowLong(hwnd(), GWL_EXSTYLE) & WS_EX_TRANSPARENT) ||
              (GetWindowLong(hwnd(), GWL_EXSTYLE) & WS_EX_NOACTIVATE)) {


### PR DESCRIPTION
#### Description of Change

Run `e patches all` to make CI happy: all the other PRs to `main` (and the CI for the latest commits in `main` as well) are failing with:

```
2025-03-15T15:04:32.9696539Z [SUCCESS] Cleaning up...
2025-03-15T15:04:32.9811960Z [main 1544d60477] chore: update patches
2025-03-15T15:04:32.9812419Z  1 file changed, 4 insertions(+), 4 deletions(-)
2025-03-15T15:04:33.9082305Z Failed to push to target branch
2025-03-15T15:04:33.9124000Z 
2025-03-15T15:04:33.9124383Z ======================================================================
2025-03-15T15:04:33.9124885Z There were changes to the patches when applying.
2025-03-15T15:04:33.9125317Z Check the CI artifacts for a patch you can apply to fix it.
2025-03-15T15:04:33.9125703Z ======================================================================
2025-03-15T15:04:33.9125923Z 
2025-03-15T15:04:33.9133519Z From 1544d6047737b9e5bd8ca9001a70f1ea7ccb5d8d Mon Sep 17 00:00:00 2001
2025-03-15T15:04:33.9134176Z From: PatchUp <73610968+patchup[bot]@users.noreply.github.com>
2025-03-15T15:04:33.9134663Z Date: Sat, 15 Mar 2025 15:04:28 +0000
2025-03-15T15:04:33.9135026Z Subject: chore: update patches
```

[Example log](https://productionresultssa2.blob.core.windows.net/actions-results/d2135022-6810-48e8-9939-0c31df7b706b/workflow-job-run-9aa3fd6e-5d93-5d3f-3fb8-85321b27bef8/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-03-15T23%3A52%3A34Z&sig=JS5eCkAFMebXWHXRtBmiH71xDiRelDjdf0ajq%2BocoBs%3D&ske=2025-03-16T09%3A12%3A03Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-03-15T21%3A12%3A03Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-03-15T23%3A42%3A29Z&sv=2025-01-05)

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.