### PR TITLE
docs: fix types of `app.dock`

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1559,8 +1559,8 @@ command line arguments that Chromium uses.
 
 ### `app.dock` _macOS_ _Readonly_
 
-A [`Dock`](./dock.md) `| undefined` object that allows you to perform actions on your app icon in the user's
-dock on macOS.
+A `Dock | undefined` property ([`Dock`](./dock.md) on macOS, `undefined` on all other
+platforms) that allows you to perform actions on your app icon in the user's dock.
 
 ### `app.isPackaged` _Readonly_
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/46072
Refs https://github.com/electron/electron/issues/45028

Fixes the types of `app.dock`, which is not defined on Windows and Linux.

After the change, TypeScript will hint developers to handle cases where `app.dock` is not defined. They can do this, for example, using optional chaining: `app.dock?.show()`

##### Caveat

Technically, this docs change isn't 100% correct. It will generate the following types:

```ts
interface App {
  dock: Dock | undefined;
}
```

To be fully correct, it should be:

```ts
interface App {
  dock?: Dock;
}
```

(`"dock" in app` returns `false` on Windows and Linux.)

However, this doesn't currently seem to be supported by the docs parser. From what I can tell, the `(optional)` prefix is only recognized on [nested lists](https://github.com/electron/docs-parser/blob/95500a801ca416f9d776e1e6c9892f4e9c8ea308/src/markdown-helpers.ts#L945), not on property definitions.

This change gets us 90% of the way there from an app developer perspective, so it's already worth making as is.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed TypeScript types for `app.dock`
