### PR TITLE
fix: `webContents.print()` crash on Linux

### DIFF
--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -27,6 +27,10 @@
 #include "pdf/pdf_features.h"
 #endif
 
+#if BUILDFLAG(IS_LINUX)
+#include "printing/printing_features.h"
+#endif
+
 namespace electron {
 
 void InitializeFeatureList() {
@@ -54,6 +58,14 @@ void InitializeFeatureList() {
       // MacWebContentsOcclusion is causing some odd visibility
       // issues with multiple web contents
       std::string(",") + features::kMacWebContentsOcclusion.name;
+#endif
+
+#if BUILDFLAG(IS_LINUX)
+  disable_features +=
+      // EnableOopPrintDrivers is still a bit half-baked on Linux and
+      // causes crashes when trying to show dialogs.
+      // TODO(codebytere): figure out how to re-enable this with our patches.
+      std::string(",") + printing::features::kEnableOopPrintDrivers.name;
 #endif
 
 #if BUILDFLAG(ENABLE_PDF_VIEWER)


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/45931.

Fixes a crash seen on Linux starting in Electron 35 when calling `webContents.print()`. This was happening due to the `EnableOopPrintDrivers` feature being enabled on Linux, which was causing crashes when trying to show dialogs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash seen on Linux when calling `webContents.print()`.