### PR TITLE
refactor: Add `ElectronBrowserContext::BrowserContexts()`

### DIFF
--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -344,6 +344,12 @@ std::vector<ElectronBrowserContext*> ElectronBrowserContext::BrowserContexts() {
                         [](auto& iter) { return iter.second.get(); });
 }
 
+bool ElectronBrowserContext::IsValidContext(const void* context) {
+  return std::ranges::any_of(ContextMap(), [context](const auto& iter) {
+    return iter.second.get() == context;
+  });
+}
+
 // static
 void ElectronBrowserContext::DestroyAllContexts() {
   auto& map = ContextMap();

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -12,6 +12,7 @@
 #include "base/barrier_closure.h"
 #include "base/base_paths.h"
 #include "base/command_line.h"
+#include "base/containers/to_vector.h"
 #include "base/files/file_path.h"
 #include "base/no_destructor.h"
 #include "base/path_service.h"
@@ -309,6 +310,12 @@ bool DoesDeviceMatch(const base::Value& device,
 }
 
 }  // namespace
+
+// static
+std::vector<ElectronBrowserContext*> ElectronBrowserContext::BrowserContexts() {
+  return base::ToVector(browser_context_map(),
+                        [](auto& iter) { return iter.second.get(); });
+}
 
 // static
 ElectronBrowserContext::BrowserContextMap&

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -63,6 +63,8 @@ class ElectronBrowserContext : public content::BrowserContext {
 
   [[nodiscard]] static std::vector<ElectronBrowserContext*> BrowserContexts();
 
+  [[nodiscard]] static bool IsValidContext(const void* context);
+
   // Get or create the default BrowserContext.
   static ElectronBrowserContext* GetDefaultBrowserContext(
       base::Value::Dict options = {});

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -61,30 +61,7 @@ class ElectronBrowserContext : public content::BrowserContext {
   ElectronBrowserContext(const ElectronBrowserContext&) = delete;
   ElectronBrowserContext& operator=(const ElectronBrowserContext&) = delete;
 
-  // partition_id => browser_context
-  struct PartitionKey {
-    PartitionKey(const std::string_view partition, bool in_memory)
-        : type_{Type::Partition}, location_{partition}, in_memory_{in_memory} {}
-
-    explicit PartitionKey(const base::FilePath& file_path)
-        : type_{Type::Path},
-          location_{file_path.AsUTF8Unsafe()},
-          in_memory_{false} {}
-
-    friend auto operator<=>(const PartitionKey&, const PartitionKey&) = default;
-
-   private:
-    enum class Type { Partition, Path };
-
-    Type type_;
-    std::string location_;
-    bool in_memory_;
-  };
-
   [[nodiscard]] static std::vector<ElectronBrowserContext*> BrowserContexts();
-
-  using BrowserContextMap =
-      std::map<PartitionKey, std::unique_ptr<ElectronBrowserContext>>;
 
   // Get or create the default BrowserContext.
   static ElectronBrowserContext* GetDefaultBrowserContext(
@@ -102,8 +79,6 @@ class ElectronBrowserContext : public content::BrowserContext {
   // existing BrowserContext.
   static ElectronBrowserContext* FromPath(const base::FilePath& path,
                                           base::Value::Dict options = {});
-
-  static BrowserContextMap& browser_context_map();
 
   static void DestroyAllContexts();
 

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -81,6 +81,8 @@ class ElectronBrowserContext : public content::BrowserContext {
     bool in_memory_;
   };
 
+  [[nodiscard]] static std::vector<ElectronBrowserContext*> BrowserContexts();
+
   using BrowserContextMap =
       std::map<PartitionKey, std::unique_ptr<ElectronBrowserContext>>;
 

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -554,11 +554,9 @@ void ElectronBrowserMainParts::PostMainMessageLoopRun() {
 
   // Shutdown the DownloadManager before destroying Node to prevent
   // DownloadItem callbacks from crashing.
-  for (auto& iter : ElectronBrowserContext::browser_context_map()) {
-    auto* download_manager = iter.second.get()->GetDownloadManager();
-    if (download_manager) {
+  for (auto* browser_context : ElectronBrowserContext::BrowserContexts()) {
+    if (auto* download_manager = browser_context->GetDownloadManager())
       download_manager->Shutdown();
-    }
   }
 
   // Shutdown utility process created with Electron API before

--- a/shell/browser/extensions/electron_extensions_browser_client.cc
+++ b/shell/browser/extensions/electron_extensions_browser_client.cc
@@ -336,13 +336,10 @@ void ElectronExtensionsBrowserClient::BroadcastEventToRenderers(
     return;
   }
 
-  for (auto const& [key, browser_context] :
-       ElectronBrowserContext::browser_context_map()) {
-    if (browser_context) {
-      extensions::EventRouter::Get(browser_context.get())
-          ->BroadcastEvent(std::make_unique<extensions::Event>(
-              histogram_value, event_name, args.Clone()));
-    }
+  for (auto* browser_context : ElectronBrowserContext::BrowserContexts()) {
+    extensions::EventRouter::Get(browser_context)
+        ->BroadcastEvent(std::make_unique<extensions::Event>(
+            histogram_value, event_name, args.Clone()));
   }
 }
 

--- a/shell/browser/extensions/electron_extensions_browser_client.cc
+++ b/shell/browser/extensions/electron_extensions_browser_client.cc
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <utility>
 
-#include "base/containers/contains.h"
 #include "base/functional/bind.h"
 #include "base/memory/ptr_util.h"
 #include "base/path_service.h"
@@ -85,7 +84,7 @@ bool ElectronExtensionsBrowserClient::AreExtensionsDisabled(
 }
 
 bool ElectronExtensionsBrowserClient::IsValidContext(void* context) {
-  return base::Contains(ElectronBrowserContext::BrowserContexts(), context);
+  return ElectronBrowserContext::IsValidContext(context);
 }
 
 bool ElectronExtensionsBrowserClient::IsSameContext(BrowserContext* first,

--- a/shell/browser/extensions/electron_extensions_browser_client.cc
+++ b/shell/browser/extensions/electron_extensions_browser_client.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/containers/contains.h"
 #include "base/functional/bind.h"
 #include "base/memory/ptr_util.h"
 #include "base/path_service.h"
@@ -84,12 +85,7 @@ bool ElectronExtensionsBrowserClient::AreExtensionsDisabled(
 }
 
 bool ElectronExtensionsBrowserClient::IsValidContext(void* context) {
-  auto& context_map = ElectronBrowserContext::browser_context_map();
-  for (auto const& entry : context_map) {
-    if (entry.second && entry.second.get() == context)
-      return true;
-  }
-  return false;
+  return base::Contains(ElectronBrowserContext::BrowserContexts(), context);
 }
 
 bool ElectronExtensionsBrowserClient::IsSameContext(BrowserContext* first,


### PR DESCRIPTION
#### Description of Change

1. Add a read-only getter so client code can loop through browser contexts w/o knowing about ElectronBrowserContext's internals
2. Migrate client code to use the new getter
3. Make ElectronBrowserContext implementation details private

This is to tighten down controls on how `ElectronBrowserContext` is accessed and to reduce leaking implementation details. Callers should not have mutable access to the context map. Callers shouldn't even need to know the context map exists :slightly_smiling_face: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.