### PR TITLE
build: move set chromium cookie before build tools step

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -18,10 +18,10 @@ runs:
       echo "GIT_CACHE_PATH=$(pwd)/git-cache" >> $GITHUB_ENV
   - name: Install Dependencies
     uses: ./src/electron/.github/actions/install-dependencies
-  - name: Install Build Tools
-    uses: ./src/electron/.github/actions/install-build-tools
   - name: Set Chromium Git Cookie
     uses: ./src/electron/.github/actions/set-chromium-cookie
+  - name: Install Build Tools
+    uses: ./src/electron/.github/actions/install-build-tools
   - name: Get Depot Tools
     shell: bash
     run: |

--- a/.github/workflows/pipeline-segment-node-nan-test.yml
+++ b/.github/workflows/pipeline-segment-node-nan-test.yml
@@ -51,6 +51,8 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+    - name: Set Chromium Git Cookie
+      uses: ./src/electron/.github/actions/set-chromium-cookie
     - name: Install Build Tools
       uses: ./src/electron/.github/actions/install-build-tools
     - name: Init Build Tools
@@ -58,8 +60,6 @@ jobs:
         e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }} --import ${{ inputs.gn-build-type }} --target-cpu ${{ inputs.target-arch }}
     - name: Install Dependencies
       uses: ./src/electron/.github/actions/install-dependencies
-    - name: Set Chromium Git Cookie
-      uses: ./src/electron/.github/actions/set-chromium-cookie
     - name: Get Depot Tools
       timeout-minutes: 5
       run: |


### PR DESCRIPTION
#### Description of Change
Followup to #45581.

This PR:
- [x] Reorders set chromium git cookie step before installing build tools and fetching depot tools.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
