### PR TITLE
fix: asar handling of `package.json`

### DIFF
--- a/lib/node/asar-fs-wrapper.ts
+++ b/lib/node/asar-fs-wrapper.ts
@@ -1018,7 +1018,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
   const { getNearestParentPackageJSONType } = moduleBinding;
   internalBinding('modules').getNearestParentPackageJSONType = (checkPath: string) => {
     const pathInfo = splitPath(checkPath);
-    if (!pathInfo.isAsar) return getNearestParentPackageJSON(checkPath);
+    if (!pathInfo.isAsar) return getNearestParentPackageJSONType(checkPath);
     const { asarPath, filePath } = pathInfo;
 
     const archive = getOrCreateArchive(asarPath);


### PR DESCRIPTION
#### Description of Change

Fixes an issue where packaged apps could sometimes fail to find the correct `package.json` in asar directories.

Tested with:

```
npx create-electron-app@6.0.4 my-commonjs-app
cd my-commonjs-app
npm run package
echo "asfjhlasf;asklfas" > package.json
./out/commonjs-app-darwin-arm64/commonjs-app.app/Contents/MacOS/commonjs-app
```

To ensure that it finds the `package.json` in `app.asar` as expected.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where packaged apps could sometimes fail to find the correct `package.json` in asar directories.
