### PR TITLE
fix: APNS token ids are lowercase ASCII

### DIFF
--- a/docs/api/push-notifications.md
+++ b/docs/api/push-notifications.md
@@ -46,4 +46,7 @@ See: https://developer.apple.com/documentation/appkit/nsapplication/1428476-regi
 ### `pushNotifications.unregisterForAPNSNotifications()` _macOS_
 
 Unregisters the app from notifications received from APNS.
+
+Apps unregistered through this method can always reregister.
+
 See: https://developer.apple.com/documentation/appkit/nsapplication/1428747-unregisterforremotenotifications?language=objc

--- a/shell/browser/api/electron_api_push_notifications_mac.mm
+++ b/shell/browser/api/electron_api_push_notifications_mac.mm
@@ -19,10 +19,7 @@ v8::Local<v8::Promise> PushNotifications::RegisterForAPNSNotifications(
   gin_helper::Promise<std::string> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
-  [[AtomApplication sharedApplication]
-      registerForRemoteNotificationTypes:NSRemoteNotificationTypeBadge |
-                                         NSRemoteNotificationTypeAlert |
-                                         NSRemoteNotificationTypeSound];
+  [[AtomApplication sharedApplication] registerForRemoteNotifications];
 
   PushNotifications::apns_promise_set_.emplace_back(std::move(promise));
   return handle;
@@ -30,8 +27,7 @@ v8::Local<v8::Promise> PushNotifications::RegisterForAPNSNotifications(
 
 void PushNotifications::ResolveAPNSPromiseSetWithToken(
     const std::string& token_string) {
-  std::vector<gin_helper::Promise<std::string>> promises =
-      std::move(PushNotifications::apns_promise_set_);
+  auto promises = std::move(PushNotifications::apns_promise_set_);
   for (auto& promise : promises) {
     promise.Resolve(token_string);
   }
@@ -39,8 +35,7 @@ void PushNotifications::ResolveAPNSPromiseSetWithToken(
 
 void PushNotifications::RejectAPNSPromiseSetWithError(
     const std::string& error_message) {
-  std::vector<gin_helper::Promise<std::string>> promises =
-      std::move(PushNotifications::apns_promise_set_);
+  auto promises = std::move(PushNotifications::apns_promise_set_);
   for (auto& promise : promises) {
     promise.RejectWithErrorMessage(error_message);
   }

--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -180,8 +180,10 @@ static NSDictionary* UNNotificationResponseToNSDictionary(
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken {
   // Resolve outstanding APNS promises created during registration attempts
   if (auto* push_notifications = electron::api::PushNotifications::Get()) {
+    std::string encoded =
+        base::HexEncode(electron::util::as_byte_span(deviceToken));
     push_notifications->ResolveAPNSPromiseSetWithToken(
-        base::HexEncode(electron::util::as_byte_span(deviceToken)));
+        base::ToLowerASCII(encoded));
   }
 }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/46081.

Refactors `pushNotifications.registerForAPNSNotifications()` as well as fixes a token formatting issue where the token ASCII values were incorrectly uppercased (See references [1](https://nshipster.com/apns-device-tokens/), [2](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html), [3](https://www.kodeco.com/11395893-push-notifications-tutorial-getting-started?page=2#toc-anchor-007))

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue with token formatting for tokens received after calling `pushNotifications.registerForAPNSNotifications()`.
