### PR TITLE
build: do not double fetch depot tools

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Whether to persist the cache to the shared drive'
     required: false
     default: 'true'
+  fetch-tools:
+    description: 'Whether to depot tools and build tools need to be fetched'
+    required: false
+    default: 'true'
 runs:
   using: "composite"
   steps:
@@ -20,9 +24,8 @@ runs:
     uses: ./src/electron/.github/actions/install-dependencies
   - name: Set Chromium Git Cookie
     uses: ./src/electron/.github/actions/set-chromium-cookie
-  - name: Install Build Tools
-    uses: ./src/electron/.github/actions/install-build-tools
   - name: Get Depot Tools
+    if: ${{ inputs.fetch-tools == 'true' }}
     shell: bash
     run: |
       if [[ ! -d depot_tools ]]; then
@@ -33,8 +36,14 @@ runs:
         touch .disable_auto_update
       fi
   - name: Add Depot Tools to PATH
+    if: ${{ inputs.fetch-tools == 'true' }}
     shell: bash
-    run: echo "$(pwd)/depot_tools" >> $GITHUB_PATH
+    run: |
+      echo "$(pwd)/depot_tools" >> $GITHUB_PATH
+      echo "DEPOT_TOOLS_DIR=$(pwd)/depot_tools" >> $GITHUB_ENV
+  - name: Install Build Tools
+    if: ${{ inputs.fetch-tools == 'true' }}
+    uses: ./src/electron/.github/actions/install-build-tools
   - name: Generate DEPS Hash
     shell: bash
     run: |

--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -17,6 +17,7 @@ runs:
   using: "composite"
   steps:
   - name: Set GIT_CACHE_PATH to make gclient to use the cache
+    if: ${{ inputs.fetch-tools == 'true' }}
     shell: bash
     run: |
       echo "GIT_CACHE_PATH=$(pwd)/git-cache" >> $GITHUB_ENV

--- a/.github/actions/fix-sync-macos/action.yml
+++ b/.github/actions/fix-sync-macos/action.yml
@@ -17,26 +17,27 @@ runs:
       # 8. Fixing angle (wrong remote)
       run : |
         SEDOPTION="-i ''"
+        export ELECTRON_DEPOT_TOOLS_DISABLE_LOG=true
         rm -rf src/third_party/llvm-build
         python3 src/tools/clang/scripts/update.py
 
-        echo 'infra/3pp/tools/esbuild/${platform}' `gclient getdep --deps-file=src/third_party/devtools-frontend/src/DEPS -r 'third_party/esbuild:infra/3pp/tools/esbuild/${platform}'` > esbuild_ensure_file
+        echo 'infra/3pp/tools/esbuild/${platform}' `e d gclient getdep --deps-file=src/third_party/devtools-frontend/src/DEPS -r 'third_party/esbuild:infra/3pp/tools/esbuild/${platform}'` > esbuild_ensure_file
         # Remove extra output from calling gclient getdep which always calls update_depot_tools
         sed -i '' "s/Updating depot_tools... //g" esbuild_ensure_file
-        cipd ensure --root src/third_party/devtools-frontend/src/third_party/esbuild -ensure-file esbuild_ensure_file
+        e d cipd ensure --root src/third_party/devtools-frontend/src/third_party/esbuild -ensure-file esbuild_ensure_file
 
         rm -rf src/third_party/rust-toolchain
         python3 src/tools/rust/update_rust.py
         
         # Prevent calling gclient getdep which always calls update_depot_tools
-        echo 'gn/gn/mac-${arch}' `gclient getdep --deps-file=src/DEPS -r 'src/buildtools/mac:gn/gn/mac-${arch}'` > gn_ensure_file
+        echo 'gn/gn/mac-${arch}' `e d gclient getdep --deps-file=src/DEPS -r 'src/buildtools/mac:gn/gn/mac-${arch}'` > gn_ensure_file
         sed -i '' "s/Updating depot_tools... //g" gn_ensure_file
-        cipd ensure --root src/buildtools/mac -ensure-file gn_ensure_file
+        e d cipd ensure --root src/buildtools/mac -ensure-file gn_ensure_file
 
         # Prevent calling gclient getdep which always calls update_depot_tools
-        echo 'infra/rbe/client/${platform}' `gclient getdep --deps-file=src/DEPS -r 'src/buildtools/reclient:infra/rbe/client/${platform}'` > gn_ensure_file
+        echo 'infra/rbe/client/${platform}' `e d gclient getdep --deps-file=src/DEPS -r 'src/buildtools/reclient:infra/rbe/client/${platform}'` > gn_ensure_file
         sed -i '' "s/Updating depot_tools... //g" gn_ensure_file
-        cipd ensure --root src/buildtools/reclient -ensure-file gn_ensure_file
+        e d cipd ensure --root src/buildtools/reclient -ensure-file gn_ensure_file
         python3 src/buildtools/reclient_cfgs/configure_reclient_cfgs.py --rbe_instance "projects/rbe-chrome-untrusted/instances/default_instance" --reproxy_cfg_template reproxy.cfg.template --rewrapper_cfg_project "" --skip_remoteexec_cfg_fetch
 
         if  [ "${{ env.TARGET_ARCH }}" == "arm64" ]; then
@@ -46,9 +47,9 @@ runs:
         fi
         python3 src/third_party/depot_tools/download_from_google_storage.py --no_resume --no_auth --bucket chromium-browser-clang -s $DSYM_SHA_FILE -o src/tools/clang/dsymutil/bin/dsymutil
 
-        echo 'infra/3pp/tools/ninja/${platform}' `gclient getdep --deps-file=src/DEPS -r 'src/third_party/ninja:infra/3pp/tools/ninja/${platform}'` > ninja_ensure_file
+        echo 'infra/3pp/tools/ninja/${platform}' `e d gclient getdep --deps-file=src/DEPS -r 'src/third_party/ninja:infra/3pp/tools/ninja/${platform}'` > ninja_ensure_file
         sed $SEDOPTION "s/Updating depot_tools... //g" ninja_ensure_file
-        cipd ensure --root src/third_party/ninja -ensure-file ninja_ensure_file
+        e d cipd ensure --root src/third_party/ninja -ensure-file ninja_ensure_file
 
         echo "$(pwd)/src/third_party/ninja" >> $GITHUB_PATH
 

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -129,33 +129,33 @@ jobs:
         echo "GN_EXTRA_ARGS=$GN_EXTRA_ARGS" >> $GITHUB_ENV
     - name: Set Chromium Git Cookie
       uses: ./src/electron/.github/actions/set-chromium-cookie
-    - name: Get Depot Tools
-      timeout-minutes: 5
-      run: |
-        git clone --filter=tree:0 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+    # - name: Get Depot Tools
+    #   timeout-minutes: 5
+    #   run: |
+    #     git clone --filter=tree:0 https://chromium.googlesource.com/chromium/tools/depot_tools.git
 
-        SEDOPTION="-i"
-        if [ "`uname`" = "Darwin" ]; then
-          SEDOPTION="-i ''"
-        fi
+    #     SEDOPTION="-i"
+    #     if [ "`uname`" = "Darwin" ]; then
+    #       SEDOPTION="-i ''"
+    #     fi
 
-        # remove ninjalog_uploader_wrapper.py from autoninja since we don't use it and it causes problems
-        sed $SEDOPTION '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
+    #     # remove ninjalog_uploader_wrapper.py from autoninja since we don't use it and it causes problems
+    #     sed $SEDOPTION '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
 
-        # Ensure depot_tools does not update.
-        test -d depot_tools && cd depot_tools
-        touch .disable_auto_update
-    - name: Add Depot Tools to PATH
-      if: ${{ inputs.target-platform != 'win' }}
-      run: |
-        echo "$(pwd)/depot_tools" >> $GITHUB_PATH
-        echo "DEPOT_TOOLS_DIR=$(pwd)/depot_tools" >> $GITHUB_ENV
-    - name: Add Depot Tools to PATH (Windows)
-      shell: powershell
-      if: ${{ inputs.target-platform == 'win' }}      
-      run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "DEPOT_TOOLS_DIR=$(pwd)\depot_tools"
-          Add-Content -Path $env:GITHUB_PATH -Value "$(pwd)\depot_tools"
+    #     # Ensure depot_tools does not update.
+    #     test -d depot_tools && cd depot_tools
+    #     touch .disable_auto_update
+    # - name: Add Depot Tools to PATH
+    #   if: ${{ inputs.target-platform != 'win' }}
+    #   run: |
+    #     echo "$(pwd)/depot_tools" >> $GITHUB_PATH
+    #     echo "DEPOT_TOOLS_DIR=$(pwd)/depot_tools" >> $GITHUB_ENV
+    # - name: Add Depot Tools to PATH (Windows)
+    #   shell: powershell
+    #   if: ${{ inputs.target-platform == 'win' }}      
+    #   run: |
+    #       Add-Content -Path $env:GITHUB_ENV -Value "DEPOT_TOOLS_DIR=$(pwd)\depot_tools"
+    #       Add-Content -Path $env:GITHUB_PATH -Value "$(pwd)\depot_tools"
     - name: Install Build Tools
       uses: ./src/electron/.github/actions/install-build-tools        
     - name: Generate DEPS Hash

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -146,7 +146,11 @@ jobs:
         test -d depot_tools && cd depot_tools
         touch .disable_auto_update
     - name: Add Depot Tools to PATH
-      run: echo "$(pwd)/depot_tools" >> $GITHUB_PATH
+      run: |
+        echo "$(pwd)/depot_tools" >> $GITHUB_PATH
+        echo "DEPOT_TOOLS_DIR=$(pwd)/depot_tools" >> $GITHUB_ENV
+    - name: Install Build Tools
+      uses: ./src/electron/.github/actions/install-build-tools        
     - name: Generate DEPS Hash
       run: |
         node src/electron/script/generate-deps-hash.js
@@ -164,14 +168,13 @@ jobs:
       uses: ./src/electron/.github/actions/checkout
       with:
         use-cache: 'false'
+        fetch-tools: 'false'
     - name: Checkout Electron
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
-    - name: Install Build Tools
-      uses: ./src/electron/.github/actions/install-build-tools
     - name: Init Build Tools
       run: |
         e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }} --import ${{ inputs.gn-build-type }} --target-cpu ${{ inputs.target-arch }}

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -146,9 +146,16 @@ jobs:
         test -d depot_tools && cd depot_tools
         touch .disable_auto_update
     - name: Add Depot Tools to PATH
+      if: ${{ inputs.target-platform != 'win' }}
       run: |
         echo "$(pwd)/depot_tools" >> $GITHUB_PATH
         echo "DEPOT_TOOLS_DIR=$(pwd)/depot_tools" >> $GITHUB_ENV
+    - name: Add Depot Tools to PATH (Windows)
+      shell: powershell
+      if: ${{ inputs.target-platform == 'win' }}      
+      run: |
+          Add-Content -Path $env:GITHUB_ENV -Value "DEPOT_TOOLS_DIR=$(pwd)\depot_tools"
+          Add-Content -Path $env:GITHUB_PATH -Value "$(pwd)\depot_tools"
     - name: Install Build Tools
       uses: ./src/electron/.github/actions/install-build-tools        
     - name: Generate DEPS Hash

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -163,6 +163,12 @@ jobs:
     - name: Restore src cache via AKS
       if: ${{ inputs.target-platform == 'linux' }}
       uses: ./src/electron/.github/actions/restore-cache-aks
+    - name: Debug Windows
+      shell: powershell
+      if: ${{ inputs.target-platform == 'win' }}
+      run: |
+        echo "PATH IS: $env:PATH"
+        echo "DEPOT_TOOLS_DIR: $env:DEPOT_TOOLS_DIR"
     - name: Checkout src via gclient sync
       if: ${{ inputs.target-platform == 'win' }}
       uses: ./src/electron/.github/actions/checkout

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -65,7 +65,9 @@ jobs:
         sudo rm -rf $TMPDIR/del-target
     - name: Check disk space after freeing up space
       if: ${{ inputs.target-platform == 'macos' }}
-      run: df -h        
+      run: df -h
+    - name: Set Chromium Git Cookie
+      uses: ./src/electron/.github/actions/set-chromium-cookie
     - name: Install Build Tools
       uses: ./src/electron/.github/actions/install-build-tools
     - name: Enable windows toolchain

--- a/.github/workflows/pipeline-segment-node-nan-test.yml
+++ b/.github/workflows/pipeline-segment-node-nan-test.yml
@@ -53,13 +53,6 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Set Chromium Git Cookie
       uses: ./src/electron/.github/actions/set-chromium-cookie
-    - name: Install Build Tools
-      uses: ./src/electron/.github/actions/install-build-tools
-    - name: Init Build Tools
-      run: |
-        e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }} --import ${{ inputs.gn-build-type }} --target-cpu ${{ inputs.target-arch }}
-    - name: Install Dependencies
-      uses: ./src/electron/.github/actions/install-dependencies
     - name: Get Depot Tools
       timeout-minutes: 5
       run: |
@@ -68,7 +61,16 @@ jobs:
         test -d depot_tools && cd depot_tools
         touch .disable_auto_update
     - name: Add Depot Tools to PATH
-      run: echo "$(pwd)/depot_tools" >> $GITHUB_PATH
+      run: |
+        echo "$(pwd)/depot_tools" >> $GITHUB_PATH
+        echo "DEPOT_TOOLS_DIR=$(pwd)/depot_tools" >> $GITHUB_ENV
+    - name: Install Build Tools
+      uses: ./src/electron/.github/actions/install-build-tools
+    - name: Init Build Tools
+      run: |
+        e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }} --import ${{ inputs.gn-build-type }} --target-cpu ${{ inputs.target-arch }}
+    - name: Install Dependencies
+      uses: ./src/electron/.github/actions/install-dependencies
     - name: Download Generated Artifacts
       uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806
       with:
@@ -114,13 +116,6 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
-    - name: Install Build Tools
-      uses: ./src/electron/.github/actions/install-build-tools
-    - name: Init Build Tools
-      run: |
-        e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }}
-    - name: Install Dependencies
-      uses: ./src/electron/.github/actions/install-dependencies
     - name: Set Chromium Git Cookie
       uses: ./src/electron/.github/actions/set-chromium-cookie
     - name: Get Depot Tools
@@ -131,7 +126,16 @@ jobs:
         test -d depot_tools && cd depot_tools
         touch .disable_auto_update
     - name: Add Depot Tools to PATH
-      run: echo "$(pwd)/depot_tools" >> $GITHUB_PATH
+      run: |
+        echo "$(pwd)/depot_tools" >> $GITHUB_PATH
+        echo "DEPOT_TOOLS_DIR=$(pwd)/depot_tools" >> $GITHUB_ENV
+    - name: Install Build Tools
+      uses: ./src/electron/.github/actions/install-build-tools
+    - name: Init Build Tools
+      run: |
+        e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }}
+    - name: Install Dependencies
+      uses: ./src/electron/.github/actions/install-dependencies
     - name: Download Generated Artifacts
       uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806
       with:


### PR DESCRIPTION
#### Description of Change
Followup to #46091.  

In many cases we install build tools and git clone depot_tools in the same job.  This means that we effectively clone depot_tools twice.  This PR changes those jobs to clone depot_tools first and then set the `DEPOT_TOOLS_DIR` environment variable _before_ installing build_tools so that [build_tools uses the depot_tools already installed](https://github.com/electron/build-tools/blob/7379782a48976ba64172fe17b931909631adaed3/src/utils/depot-tools.js#L10C37-L10C53) versus git cloning a second copy of depot_tools.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
