### PR TITLE
refactor: remove ToV8(isolate, const char*)

### DIFF
--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -459,11 +459,14 @@ std::vector<content::RenderFrameHost*> WebFrameMain::FramesInSubtree() const {
   return frame_hosts;
 }
 
-const char* WebFrameMain::LifecycleStateForTesting() const {
+std::string_view WebFrameMain::LifecycleStateForTesting() const {
   if (!HasRenderFrame())
     return {};
-  return content::RenderFrameHostImpl::LifecycleStateImplToString(
-      GetLifecycleState(render_frame_host()));
+  if (const char* str =
+          content::RenderFrameHostImpl::LifecycleStateImplToString(
+              GetLifecycleState(render_frame_host())))
+    return str;
+  return {};
 }
 
 v8::Local<v8::Promise> WebFrameMain::CollectDocumentJSCallStack(

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -136,7 +136,7 @@ class WebFrameMain final : public gin::Wrappable<WebFrameMain>,
   std::vector<content::RenderFrameHost*> Frames() const;
   std::vector<content::RenderFrameHost*> FramesInSubtree() const;
 
-  const char* LifecycleStateForTesting() const;
+  std::string_view LifecycleStateForTesting() const;
 
   v8::Local<v8::Promise> CollectDocumentJSCallStack(gin::Arguments* args);
   void CollectedJavaScriptCallStack(

--- a/shell/common/gin_converters/std_converter.h
+++ b/shell/common/gin_converters/std_converter.h
@@ -62,15 +62,6 @@ struct Converter<char[N]> {
 };
 
 template <>
-struct Converter<const char*> {
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const char* val) {
-    return v8::String::NewFromUtf8(isolate, val ? val : "",
-                                   v8::NewStringType::kNormal)
-        .ToLocalChecked();
-  }
-};
-
-template <>
 struct Converter<v8::Local<v8::Array>> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    v8::Local<v8::Array> val) {


### PR DESCRIPTION
#### Description of Change

Remove `ToV8(isolate, const char*)`.

This was previously removed in #44568 but it snuck back in :slightly_smiling_face: 

Using string literals or `std::string_view` are slightly more efficient since they can avoid `ToLocalChecked()` and `strlen()` calls.

Even though that won't be true _in this specific_ case since the one caller was passing it a `char*` returned by `content::RenderFrameHostImpl::LifecycleStateImplToString()`, it's still valuable to remove this converter to ensure that more code won't accidentally call it in the future.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.