### PR TITLE
fix: handle OnDelegatedSourceListDismissed asynchronously

### DIFF
--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -15,6 +15,7 @@
 #include "chrome/browser/media/webrtc/desktop_media_list.h"
 #include "chrome/browser/media/webrtc/thumbnail_capturer_mac.h"
 #include "chrome/browser/media/webrtc/window_icon_util.h"
+#include "content/public/browser/browser_thread.h"
 #include "content/public/browser/desktop_capture.h"
 #include "gin/handle.h"
 #include "gin/object_template_builder.h"
@@ -252,7 +253,8 @@ void DesktopCapturer::DesktopListListener::OnSourceThumbnailChanged(int index) {
 }
 
 void DesktopCapturer::DesktopListListener::OnDelegatedSourceListDismissed() {
-  std::move(failure_callback_).Run();
+  content::GetUIThreadTaskRunner({})->PostTask(FROM_HERE,
+                                               std::move(failure_callback_));
 }
 
 void DesktopCapturer::StartHandling(bool capture_window,


### PR DESCRIPTION
#### Description of Change

Fixes #45198.

https://chromium-review.googlesource.com/c/chromium/src/+/5783826 modified `DesktopMediaListBase::OnDelegatedSourceListDismissed` to read as follows:

```cc
void DesktopMediaListBase::OnDelegatedSourceListDismissed() {
  DCHECK_CURRENTLY_ON(BrowserThread::UI);
  DCHECK(IsSourceListDelegated());
  if (observer_)
    observer_->OnDelegatedSourceListDismissed();

  Refresh(false);
}
```

The extra refresh means that it is no longer safe to call `DesktopCapturer::HandleFailure` (which deallocates the `DesktopMediaList`) synchronously from `OnDelegatedSourceListDismissed`. Notably, on Linux when using the PipeWire capturer, trying to share a source and then cancelling it from the xdg-desktop-portal's share prompt often causes an immediate crash. It's very easy to reproduce:

```javascript
const { app, desktopCapturer } = require('electron');

app.whenReady().then(async () => {
  await desktopCapturer.getSources({ types: ['window', 'screen'] });
}).finally(() => {
  app.quit();
});
```

Fix this issue by dispatching the failure callback asynchronously using `PostTask`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed crash on Linux when PipeWire screenshare source selection is cancelled.
