### PR TITLE
docs: use optional chaining for `app.dock`

### DIFF
--- a/docs/api/dock.md
+++ b/docs/api/dock.md
@@ -9,7 +9,7 @@ The following example shows how to bounce your icon on the dock.
 
 ```js
 const { app } = require('electron')
-app.dock.bounce()
+app.dock?.bounce()
 ```
 
 ### Instance Methods

--- a/docs/fiddles/features/macos-dock-menu/main.js
+++ b/docs/fiddles/features/macos-dock-menu/main.js
@@ -24,9 +24,7 @@ const dockMenu = Menu.buildFromTemplate([
 ])
 
 app.whenReady().then(() => {
-  if (process.platform === 'darwin') {
-    app.dock.setMenu(dockMenu)
-  }
+  app.dock?.setMenu(dockMenu)
 }).then(createWindow)
 
 app.on('window-all-closed', () => {

--- a/docs/tutorial/macos-dock.md
+++ b/docs/tutorial/macos-dock.md
@@ -50,9 +50,7 @@ const dockMenu = Menu.buildFromTemplate([
 ])
 
 app.whenReady().then(() => {
-  if (process.platform === 'darwin') {
-    app.dock.setMenu(dockMenu)
-  }
+  app.dock?.setMenu(dockMenu)
 }).then(createWindow)
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/46073
Refs https://github.com/electron/electron/pull/46110

Adjusted code in the Electron docs to work nicely with the new types for `app.dock`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes -> I haven't had a chance to run tests locally as I'm still setting up a build environment. Can we run them in CI?
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none