### PR TITLE
docs: fix capitalization for `InputEvent.modifiers`

### DIFF
--- a/docs/api/structures/input-event.md
+++ b/docs/api/structures/input-event.md
@@ -12,6 +12,6 @@
   `pointerDown`, `pointerUp`, `pointerMove`, `pointerRawUpdate`,
   `pointerCancel` or `pointerCausedUaAction`.
 * `modifiers` string[] (optional) - An array of modifiers of the event, can
-  be `shift`, `control`, `ctrl`, `alt`, `meta`, `command`, `cmd`, `isKeypad`,
-  `isAutoRepeat`, `leftButtonDown`, `middleButtonDown`, `rightButtonDown`,
-  `capsLock`, `numLock`, `left`, `right`.
+  be `shift`, `control`, `ctrl`, `alt`, `meta`, `command`, `cmd`, `iskeypad`,
+  `isautorepeat`, `leftbuttondown`, `middlebuttondown`, `rightbuttondown`,
+  `capslock`, `numlock`, `left`, `right`.


### PR DESCRIPTION
#### Description of Change

These modifiers are documented as being camelCase, but they're actually lowercase as described in: https://github.com/electron/electron/blob/e4d660af86b95254b8b49de948923d4e1f4769f6/shell/common/gin_converters/blink_converter.cc#L153-L170

Did a quick check with the code below using Fiddle and they seem to be lowercase since Electron 22 (the oldest version I could use this event on), so I assume it's just a documentation issue:

```ts
mainWindow.webContents.on('input-event', (_, inputEvent) => {
  console.log(inputEvent)
})
```

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed capitalization for `InputEvent.modifiers` <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
