### PR TITLE
docs: deprecate setting ProtocolResponse.session to null

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -27,7 +27,7 @@ process.on('unhandledRejection', () => {
 })
 ```
 
-### Removed:`isDefault` and `status` properties on `PrinterInfo`
+### Removed: `isDefault` and `status` properties on `PrinterInfo`
 
 These properties have been removed from the PrinterInfo Object
 because they have been removed from upstream Chromium.
@@ -38,6 +38,16 @@ When calling `Session.clearStorageData(options)`, the `options.quota` type
 `syncable` is no longer supported because it has been
 [removed](https://chromium-review.googlesource.com/c/chromium/src/+/6309405)
 from upstream Chromium.
+
+### Removed: `null` value for `session` property in `ProtocolResponse`
+
+Previously, setting the ProtocolResponse.session property to `null`
+Would create a random independent session. This is no longer supported.
+
+Using single-purpose sessions here is discouraged due to overhead costs;
+however, old code that needs to preserve this behavior can emulate it by
+creating a random session with `session.fromPartition(some_random_string)`
+and then using it in `ProtocolResponse.session`.
 
 ### Deprecated: `quota` property in `Session.clearStorageData(options)`
 


### PR DESCRIPTION
#### Description of Change

Deprecate the special case of setting `ProtocolResponse.session` to `null` to create a new random independent session.

The other uses of `ProtocolResponse.session` are unchanged.

See discussion @ https://electronhq.slack.com/archives/CB6CG54DB/p1742330946259379

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.