### PR TITLE
refactor: use base::NumberToString()

### DIFF
--- a/shell/browser/serial/serial_chooser_controller.cc
+++ b/shell/browser/serial/serial_chooser_controller.cc
@@ -9,6 +9,7 @@
 
 #include "base/containers/contains.h"
 #include "base/functional/bind.h"
+#include "base/strings/string_number_conversions.h"
 #include "content/public/browser/web_contents.h"
 #include "device/bluetooth/bluetooth_adapter.h"
 #include "device/bluetooth/bluetooth_adapter_factory.h"
@@ -23,7 +24,6 @@
 #include "shell/common/gin_converters/content_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/promise.h"
-#include "third_party/abseil-cpp/absl/strings/str_format.h"
 #include "ui/base/l10n/l10n_util.h"
 
 namespace gin {
@@ -40,10 +40,10 @@ struct Converter<device::mojom::SerialPortInfoPtr> {
       dict.Set("displayName", *port->display_name);
     }
     if (port->has_vendor_id) {
-      dict.Set("vendorId", absl::StrFormat("%u", port->vendor_id));
+      dict.Set("vendorId", base::NumberToString(port->vendor_id));
     }
     if (port->has_product_id) {
-      dict.Set("productId", absl::StrFormat("%u", port->product_id));
+      dict.Set("productId", base::NumberToString(port->product_id));
     }
     if (port->serial_number && !port->serial_number->empty()) {
       dict.Set("serialNumber", *port->serial_number);

--- a/shell/common/gin_converters/serial_port_info_converter.h
+++ b/shell/common/gin_converters/serial_port_info_converter.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_COMMON_GIN_CONVERTERS_SERIAL_PORT_INFO_CONVERTER_H_
 #define ELECTRON_SHELL_COMMON_GIN_CONVERTERS_SERIAL_PORT_INFO_CONVERTER_H_
 
+#include "base/strings/string_number_conversions.h"
 #include "gin/converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "third_party/blink/public/mojom/serial/serial.mojom.h"
@@ -22,9 +23,9 @@ struct Converter<device::mojom::SerialPortInfoPtr> {
     if (port->display_name && !port->display_name->empty())
       dict.Set("displayName", *port->display_name);
     if (port->has_vendor_id)
-      dict.Set("vendorId", absl::StrFormat("%u", port->vendor_id));
+      dict.Set("vendorId", base::NumberToString(port->vendor_id));
     if (port->has_product_id)
-      dict.Set("productId", absl::StrFormat("%u", port->product_id));
+      dict.Set("productId", base::NumberToString(port->product_id));
     if (port->serial_number && !port->serial_number->empty())
       dict.Set("serialNumber", *port->serial_number);
 #if BUILDFLAG(IS_MAC)


### PR DESCRIPTION
#### Description of Change

Teeny little cleanup for how we convert unsigned ints to strings:

```diff
- foo = absl::StrFormat("%u", bar);
+ foo = base::NumberToString(bar);
```

The latter is slightly more efficient, slightly to read, slightly more futureproof if the type of `bar` ever changes.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.