### PR TITLE
feat: add ffmpeg.dll to delay load configuration

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1246,7 +1246,7 @@ if (is_mac) {
         "//components/crash/core/app:run_as_crashpad_handler",
       ]
 
-      ldflags = []
+      ldflags = [ "/DELAYLOAD:ffmpeg.dll" ]
 
       libs = [
         "comctl32.lib",


### PR DESCRIPTION
#### Description of Change

Added ffmpeg.dll to the /DELAYLOAD linker configuration in BUILD.gn to reduce startup overhead and avoid unnecessary loading when ffmpeg-related functionality is not used.

E.g., the browser process was unnecessarily loading it:
![image](https://github.com/user-attachments/assets/4ed8d69e-dfa7-4e45-9b52-c71555964de2)

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `ffmpeg.dll` to delay load configuration.
