### PR TITLE
refactor: use `= default` to define trivial destructors

### DIFF
--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -155,7 +155,7 @@ class JSLayoutManager : public views::LayoutManagerBase {
  public:
   explicit JSLayoutManager(LayoutCallback layout_callback)
       : layout_callback_(std::move(layout_callback)) {}
-  ~JSLayoutManager() override {}
+  ~JSLayoutManager() override = default;
 
   // views::LayoutManagerBase
   views::ProposedLayout CalculateProposedLayout(

--- a/shell/browser/extensions/api/extension_action/extension_action_api.cc
+++ b/shell/browser/extensions/api/extension_action/extension_action_api.cc
@@ -29,16 +29,12 @@ void ExtensionActionAPI::Observer::OnExtensionActionUpdated(
 
 void ExtensionActionAPI::Observer::OnExtensionActionAPIShuttingDown() {}
 
-ExtensionActionAPI::Observer::~Observer() {}
-
 //
 // ExtensionActionAPI
 //
 
 ExtensionActionAPI::ExtensionActionAPI(content::BrowserContext* context)
     : browser_context_(context), extension_prefs_(nullptr) {}
-
-ExtensionActionAPI::~ExtensionActionAPI() {}
 
 // static
 BrowserContextKeyedAPIFactory<ExtensionActionAPI>*
@@ -64,8 +60,6 @@ void ExtensionActionAPI::Shutdown() {}
 //
 
 ExtensionActionFunction::ExtensionActionFunction() {}
-
-ExtensionActionFunction::~ExtensionActionFunction() {}
 
 ExtensionFunction::ResponseAction ExtensionActionFunction::Run() {
   return RunExtensionAction();

--- a/shell/browser/extensions/api/extension_action/extension_action_api.h
+++ b/shell/browser/extensions/api/extension_action/extension_action_api.h
@@ -33,7 +33,7 @@ class ExtensionActionAPI : public BrowserContextKeyedAPI {
     virtual void OnExtensionActionAPIShuttingDown();
 
    protected:
-    virtual ~Observer();
+    virtual ~Observer() = default;
   };
 
   explicit ExtensionActionAPI(content::BrowserContext* context);
@@ -41,7 +41,7 @@ class ExtensionActionAPI : public BrowserContextKeyedAPI {
   ExtensionActionAPI(const ExtensionActionAPI&) = delete;
   ExtensionActionAPI& operator=(const ExtensionActionAPI&) = delete;
 
-  ~ExtensionActionAPI() override;
+  ~ExtensionActionAPI() override = default;
 
   // Convenience method to get the instance for a profile.
   static ExtensionActionAPI* Get(content::BrowserContext* context);
@@ -86,7 +86,7 @@ class ExtensionActionAPI : public BrowserContextKeyedAPI {
 class ExtensionActionFunction : public ExtensionFunction {
  protected:
   ExtensionActionFunction();
-  ~ExtensionActionFunction() override;
+  ~ExtensionActionFunction() override = default;
 
   // ExtensionFunction
   ResponseAction Run() override;

--- a/shell/browser/net/web_request_api_interface.h
+++ b/shell/browser/net/web_request_api_interface.h
@@ -20,7 +20,7 @@ namespace electron {
 // Defines the interface for WebRequest API, implemented by api::WebRequestNS.
 class WebRequestAPI {
  public:
-  virtual ~WebRequestAPI() {}
+  virtual ~WebRequestAPI() = default;
 
   using BeforeSendHeadersCallback =
       base::OnceCallback<void(const std::set<std::string>& removed_headers,


### PR DESCRIPTION
#### Description of Change

A followup to #44935 that did the same thing last year. This PR converts a few more destructors.

Relevant Chromium styleguide: [C++ Dos and Don'ts: Prefer to use `=default`](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++-dos-and-donts.md#prefer-to-use)

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.