### PR TITLE
refactor: remove unused method `ElectronBrowserContext::GetWeakPtr()`

### DIFF
--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -50,6 +50,7 @@
 #include "shell/browser/electron_download_manager_delegate.h"
 #include "shell/browser/electron_permission_manager.h"
 #include "shell/browser/file_system_access/file_system_access_permission_context_factory.h"
+#include "shell/browser/media/media_device_id_salt.h"
 #include "shell/browser/net/resolve_proxy_helper.h"
 #include "shell/browser/protocol_registry.h"
 #include "shell/browser/serial/serial_chooser_context.h"

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -16,7 +16,6 @@
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/media_stream_request.h"
-#include "content/public/browser/resource_context.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/network/public/mojom/ssl_config.mojom.h"
 #include "third_party/blink/public/common/permissions/permission_utils.h"

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -17,7 +17,6 @@
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/media_stream_request.h"
 #include "content/public/browser/resource_context.h"
-#include "electron/shell/browser/media/media_device_id_salt.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/network/public/mojom/ssl_config.mojom.h"
 #include "third_party/blink/public/common/permissions/permission_utils.h"
@@ -43,12 +42,13 @@ class SpecialStoragePolicy;
 
 namespace electron {
 
+class CookieChangeNotifier;
 class ElectronDownloadManagerDelegate;
 class ElectronPermissionManager;
-class CookieChangeNotifier;
+class MediaDeviceIDSalt;
+class ProtocolRegistry;
 class ResolveProxyHelper;
 class WebViewManager;
-class ProtocolRegistry;
 
 using DisplayMediaResponseCallbackJs =
     base::OnceCallback<void(gin::Arguments* args)>;

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -13,7 +13,6 @@
 #include <variant>
 #include <vector>
 
-#include "base/memory/weak_ptr.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/media_stream_request.h"
 #include "mojo/public/cpp/bindings/remote.h"
@@ -126,9 +125,6 @@ class ElectronBrowserContext : public content::BrowserContext {
   ValueMapPrefStore* in_memory_pref_store() const {
     return in_memory_pref_store_.get();
   }
-  base::WeakPtr<ElectronBrowserContext> GetWeakPtr() {
-    return weak_factory_.GetWeakPtr();
-  }
 
   ProtocolRegistry* protocol_registry() const {
     return protocol_registry_.get();
@@ -214,8 +210,6 @@ class ElectronBrowserContext : public content::BrowserContext {
 
   // In-memory cache that holds objects that have been granted permissions.
   DevicePermissionMap granted_devices_;
-
-  base::WeakPtrFactory<ElectronBrowserContext> weak_factory_{this};
 };
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

- remove unused method `ElectronBrowserContext::GetWeakPtr()`. Last use removed in Aug 2020 by bac2f46.
- remove unused field `ElectronBrowserContext::weak_factory_`.
- remove unused `#include`s from `electron_browser_context.h`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.