### PR TITLE
refactor: remove unused field `ServiceWorkerMain::weak_factory_`

### DIFF
--- a/shell/browser/api/electron_api_service_worker_main.h
+++ b/shell/browser/api/electron_api_service_worker_main.h
@@ -8,7 +8,6 @@
 #include <string>
 
 #include "base/memory/raw_ptr.h"
-#include "base/memory/weak_ptr.h"
 #include "base/process/process.h"
 #include "content/public/browser/global_routing_id.h"
 #include "content/public/browser/service_worker_context.h"
@@ -168,8 +167,6 @@ class ServiceWorkerMain final
   mojo::AssociatedRemote<mojom::ElectronRenderer> remote_;
 
   std::unique_ptr<gin_helper::Promise<void>> start_worker_promise_;
-
-  base::WeakPtrFactory<ServiceWorkerMain> weak_factory_{this};
 };
 
 }  // namespace electron::api


### PR DESCRIPTION
#### Description of Change

Remove unused field `ServiceWorkerMain::weak_factory_`. Added in a467d06, appears to have never been used. Maybe I'm misunderstanding? Or maybe it's a leftover from an earlier draft? 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.