### PR TITLE
refactor: remove unused `weak_factory_` in electron_management_api_delegate.cc

### DIFF
--- a/shell/browser/extensions/api/management/electron_management_api_delegate.cc
+++ b/shell/browser/extensions/api/management/electron_management_api_delegate.cc
@@ -44,10 +44,6 @@ class ManagementSetEnabledFunctionInstallPromptDelegate
       const ManagementSetEnabledFunctionInstallPromptDelegate&) = delete;
   ManagementSetEnabledFunctionInstallPromptDelegate& operator=(
       const ManagementSetEnabledFunctionInstallPromptDelegate&) = delete;
-
- private:
-  base::WeakPtrFactory<ManagementSetEnabledFunctionInstallPromptDelegate>
-      weak_factory_{this};
 };
 
 class ManagementUninstallFunctionUninstallDialogDelegate


### PR DESCRIPTION
#### Description of Change

Remove unused `weak_factory_` field. Appears to have been added in 3745b76da but never used

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.