### PR TITLE
refactor: remove unused method ProxyingWebSocket::web_request_api()

### DIFF
--- a/shell/browser/net/proxying_websocket.h
+++ b/shell/browser/net/proxying_websocket.h
@@ -111,8 +111,6 @@ class ProxyingWebSocket : public network::mojom::WebSocketHandshakeClient,
       content::BrowserContext* browser_context,
       uint64_t* request_id_generator);
 
-  WebRequestAPI* web_request_api() { return web_request_api_; }
-
  private:
   void OnBeforeRequestComplete(int error_code);
   void OnBeforeSendHeadersComplete(const std::set<std::string>& removed_headers,


### PR DESCRIPTION
#### Description of Change

Remove unused method. Appears to have been added in c608d6d7 when copied from upstream, but we never used it.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.