### PR TITLE
perf: use `absl::flat_hash_map` instead of `std::unordered_map`

### DIFF
--- a/shell/browser/api/electron_api_service_worker_main.cc
+++ b/shell/browser/api/electron_api_service_worker_main.cc
@@ -5,7 +5,6 @@
 #include "shell/browser/api/electron_api_service_worker_main.h"
 
 #include <string>
-#include <unordered_map>
 #include <utility>
 
 #include "base/logging.h"
@@ -28,6 +27,7 @@
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/v8_util.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 
 namespace {
 
@@ -58,10 +58,9 @@ std::optional<content::ServiceWorkerVersionBaseInfo> GetLiveVersionInfo(
 namespace electron::api {
 
 // ServiceWorkerKey -> ServiceWorkerMain*
-typedef std::unordered_map<ServiceWorkerKey,
-                           ServiceWorkerMain*,
-                           ServiceWorkerKey::Hasher>
-    VersionIdMap;
+using VersionIdMap = absl::flat_hash_map<ServiceWorkerKey,
+                                         ServiceWorkerMain*,
+                                         ServiceWorkerKey::Hasher>;
 
 VersionIdMap& GetVersionIdMap() {
   static base::NoDestructor<VersionIdMap> instance;

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -5,7 +5,6 @@
 #include "shell/browser/api/electron_api_web_frame_main.h"
 
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -36,6 +35,7 @@
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/v8_util.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 
 namespace {
 
@@ -99,7 +99,7 @@ namespace electron::api {
 // Using FrameTreeNode allows us to track frame across navigations. This
 // is most similar to how <iframe> works.
 using FrameTreeNodeIdMap =
-    std::unordered_map<content::FrameTreeNodeId, WebFrameMain*>;
+    absl::flat_hash_map<content::FrameTreeNodeId, WebFrameMain*>;
 
 // Token -> WebFrameMain*
 // Maps exact RFH to a WebFrameMain instance.

--- a/shell/browser/electron_autofill_driver_factory.h
+++ b/shell/browser/electron_autofill_driver_factory.h
@@ -6,12 +6,12 @@
 #define ELECTRON_SHELL_BROWSER_ELECTRON_AUTOFILL_DRIVER_FACTORY_H_
 
 #include <memory>
-#include <unordered_map>
 
 #include "base/functional/callback_forward.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "content/public/browser/web_contents_user_data.h"
 #include "shell/common/api/api.mojom.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 
 namespace electron {
 
@@ -49,7 +49,8 @@ class AutofillDriverFactory
   explicit AutofillDriverFactory(content::WebContents* web_contents);
   friend class content::WebContentsUserData<AutofillDriverFactory>;
 
-  std::unordered_map<content::RenderFrameHost*, std::unique_ptr<AutofillDriver>>
+  absl::flat_hash_map<content::RenderFrameHost*,
+                      std::unique_ptr<AutofillDriver>>
       driver_map_;
 };
 

--- a/shell/browser/hid/electron_hid_delegate.h
+++ b/shell/browser/hid/electron_hid_delegate.h
@@ -7,13 +7,13 @@
 
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include "base/containers/flat_map.h"
 #include "content/public/browser/hid_chooser.h"
 #include "content/public/browser/hid_delegate.h"
 #include "services/device/public/mojom/hid.mojom-forward.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 #include "third_party/blink/public/mojom/hid/hid.mojom-forward.h"
 #include "url/origin.h"
 
@@ -87,8 +87,8 @@ class ElectronHidDelegate : public content::HidDelegate {
       std::vector<blink::mojom::HidDeviceFilterPtr> exclusion_filters,
       content::HidChooser::Callback callback);
 
-  std::unordered_map<content::RenderFrameHost*,
-                     std::unique_ptr<HidChooserController>>
+  absl::flat_hash_map<content::RenderFrameHost*,
+                      std::unique_ptr<HidChooserController>>
       controller_map_;
 
   base::WeakPtrFactory<ElectronHidDelegate> weak_factory_{this};

--- a/shell/browser/serial/electron_serial_delegate.h
+++ b/shell/browser/serial/electron_serial_delegate.h
@@ -6,7 +6,6 @@
 #define ELECTRON_SHELL_BROWSER_SERIAL_ELECTRON_SERIAL_DELEGATE_H_
 
 #include <memory>
-#include <unordered_map>
 #include <vector>
 
 #include "base/memory/weak_ptr.h"
@@ -15,6 +14,7 @@
 #include "content/public/browser/serial_delegate.h"
 #include "shell/browser/serial/serial_chooser_context.h"
 #include "shell/browser/serial/serial_chooser_controller.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 
 namespace electron {
 
@@ -77,8 +77,8 @@ class ElectronSerialDelegate : public content::SerialDelegate,
       port_observation_{this};
   base::ObserverList<content::SerialDelegate::Observer> observer_list_;
 
-  std::unordered_map<content::RenderFrameHost*,
-                     std::unique_ptr<SerialChooserController>>
+  absl::flat_hash_map<content::RenderFrameHost*,
+                      std::unique_ptr<SerialChooserController>>
       controller_map_;
 
   base::WeakPtrFactory<ElectronSerialDelegate> weak_factory_{this};

--- a/shell/browser/usb/electron_usb_delegate.h
+++ b/shell/browser/usb/electron_usb_delegate.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include "base/containers/span.h"
@@ -17,6 +16,7 @@
 #include "services/device/public/mojom/usb_device.mojom-forward.h"
 #include "services/device/public/mojom/usb_enumeration_options.mojom-forward.h"
 #include "services/device/public/mojom/usb_manager.mojom-forward.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 #include "third_party/blink/public/mojom/usb/web_usb_service.mojom.h"
 #include "url/origin.h"
 
@@ -111,8 +111,8 @@ class ElectronUsbDelegate : public content::UsbDelegate {
   base::flat_map<content::BrowserContext*, std::unique_ptr<ContextObservation>>
       observations_;
 
-  std::unordered_map<content::RenderFrameHost*,
-                     std::unique_ptr<UsbChooserController>>
+  absl::flat_hash_map<content::RenderFrameHost*,
+                      std::unique_ptr<UsbChooserController>>
       controller_map_;
 
   base::WeakPtrFactory<ElectronUsbDelegate> weak_factory_{this};

--- a/shell/common/asar/archive.h
+++ b/shell/common/asar/archive.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include <uv.h>
@@ -17,6 +16,7 @@
 #include "base/files/file_path.h"
 #include "base/synchronization/lock.h"
 #include "base/values.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 
 namespace asar {
 
@@ -110,8 +110,8 @@ class Archive {
 
   // Cached external temporary files.
   base::Lock external_files_lock_;
-  std::unordered_map<base::FilePath::StringType,
-                     std::unique_ptr<ScopedTemporaryFile>>
+  absl::flat_hash_map<base::FilePath::StringType,
+                      std::unique_ptr<ScopedTemporaryFile>>
       external_files_;
 };
 

--- a/shell/common/key_weak_map.h
+++ b/shell/common/key_weak_map.h
@@ -69,6 +69,7 @@ class KeyWeakMap {
   }
 
   // Map of stored objects.
+  // TODO(ckerr): can absl::flat_hash_map be used safely here?
   std::unordered_map<K, Mapped> map_;
 };
 

--- a/shell/renderer/api/context_bridge/object_cache.h
+++ b/shell/renderer/api/context_bridge/object_cache.h
@@ -5,8 +5,7 @@
 #ifndef ELECTRON_SHELL_RENDERER_API_CONTEXT_BRIDGE_OBJECT_CACHE_H_
 #define ELECTRON_SHELL_RENDERER_API_CONTEXT_BRIDGE_OBJECT_CACHE_H_
 
-#include <unordered_map>
-
+#include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 #include "v8/include/v8-local-handle.h"
 #include "v8/include/v8-object.h"
 
@@ -35,7 +34,7 @@ class ObjectCache final {
   };
 
   // from_object ==> proxy_value
-  std::unordered_map<v8::Local<v8::Object>, v8::Local<v8::Value>, Hash>
+  absl::flat_hash_map<v8::Local<v8::Object>, v8::Local<v8::Value>, Hash>
       proxy_map_;
 };
 


### PR DESCRIPTION
#### Description of Change

One step towards following the [upstream container recommendations](https://source.chromium.org/chromium/chromium/src/+/main:base/containers/README.md)

> If you just need a generic map or set container without any additional properties then prefer to use `absl::flat_hash_map` and `absl::flat_hash_set`. These are versatile containers that have good performance on both large and small sized data.

...

> Note that this advice never suggests the use of `std::unordered_map` and `std::unordered_set`. These containers provides similar features to the Abseil flat hash containers but with worse performance. They should only be used if absolutely required for compatibility with third-party code.

Further background reading in [this (old) chromium-dev thread](https://groups.google.com/a/chromium.org/g/chromium-dev/c/rdxOHKzQmRY?pli=1).

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.