### PR TITLE
fix: NODE_OPTIONS parsing for child processes on macOS

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -90,7 +90,9 @@
 
 #if BUILDFLAG(IS_MAC)
 #include <CoreFoundation/CoreFoundation.h>
+#include "content/browser/mac_helpers.h"
 #include "shell/browser/ui/cocoa/electron_bundle_mover.h"
+#include "shell/common/process_util.h"
 #endif
 
 #if BUILDFLAG(IS_LINUX)
@@ -901,6 +903,20 @@ bool App::IsPackaged() {
 
 #if BUILDFLAG(IS_WIN)
   return base_name != FILE_PATH_LITERAL("electron.exe");
+#elif BUILDFLAG(IS_MAC)
+  static const base::FilePath::StringType default_helper =
+      "electron helper" + base::ToLowerASCII(content::kMacHelperSuffix_default);
+  static const base::FilePath::StringType renderer_helper =
+      "electron helper" +
+      base::ToLowerASCII(content::kMacHelperSuffix_renderer);
+  static const base::FilePath::StringType plugin_helper =
+      "electron helper" + base::ToLowerASCII(content::kMacHelperSuffix_plugin);
+  if (IsRendererProcess()) {
+    return base_name != renderer_helper;
+  } else if (IsUtilityProcess()) {
+    return base_name != default_helper && base_name != plugin_helper;
+  }
+  return base_name != FILE_PATH_LITERAL("electron");
 #else
   return base_name != FILE_PATH_LITERAL("electron");
 #endif

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -90,6 +90,7 @@
 
 #if BUILDFLAG(IS_MAC)
 #include <CoreFoundation/CoreFoundation.h>
+#include "base/no_destructor.h"
 #include "content/browser/mac_helpers.h"
 #include "shell/browser/ui/cocoa/electron_bundle_mover.h"
 #include "shell/common/process_util.h"
@@ -904,12 +905,12 @@ bool App::IsPackaged() {
 #if BUILDFLAG(IS_WIN)
   return base_name != FILE_PATH_LITERAL("electron.exe");
 #elif BUILDFLAG(IS_MAC)
-  static const base::FilePath::StringType default_helper =
+  static const base::NoDestructor<std::string> default_helper =
       "electron helper" + base::ToLowerASCII(content::kMacHelperSuffix_default);
-  static const base::FilePath::StringType renderer_helper =
+  static const base::NoDestructor<std::string> renderer_helper =
       "electron helper" +
       base::ToLowerASCII(content::kMacHelperSuffix_renderer);
-  static const base::FilePath::StringType plugin_helper =
+  static const base::NoDestructor<std::string> plugin_helper =
       "electron helper" + base::ToLowerASCII(content::kMacHelperSuffix_plugin);
   if (IsRendererProcess()) {
     return base_name != renderer_helper;

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -905,17 +905,18 @@ bool App::IsPackaged() {
 #if BUILDFLAG(IS_WIN)
   return base_name != FILE_PATH_LITERAL("electron.exe");
 #elif BUILDFLAG(IS_MAC)
-  static const base::NoDestructor<std::string> default_helper =
-      "electron helper" + base::ToLowerASCII(content::kMacHelperSuffix_default);
-  static const base::NoDestructor<std::string> renderer_helper =
+  static const base::NoDestructor<std::string> default_helper(
       "electron helper" +
-      base::ToLowerASCII(content::kMacHelperSuffix_renderer);
-  static const base::NoDestructor<std::string> plugin_helper =
-      "electron helper" + base::ToLowerASCII(content::kMacHelperSuffix_plugin);
+      base::ToLowerASCII(content::kMacHelperSuffix_default));
+  static const base::NoDestructor<std::string> renderer_helper(
+      "electron helper" +
+      base::ToLowerASCII(content::kMacHelperSuffix_renderer));
+  static const base::NoDestructor<std::string> plugin_helper(
+      "electron helper" + base::ToLowerASCII(content::kMacHelperSuffix_plugin));
   if (IsRendererProcess()) {
-    return base_name != renderer_helper;
+    return base_name != *renderer_helper;
   } else if (IsUtilityProcess()) {
-    return base_name != default_helper && base_name != plugin_helper;
+    return base_name != *default_helper && base_name != *plugin_helper;
   }
   return base_name != FILE_PATH_LITERAL("electron");
 #else

--- a/spec/fixtures/apps/node-options-utility-process/fail.js
+++ b/spec/fixtures/apps/node-options-utility-process/fail.js
@@ -1,0 +1,1 @@
+process.exit(1);

--- a/spec/fixtures/apps/node-options-utility-process/main.js
+++ b/spec/fixtures/apps/node-options-utility-process/main.js
@@ -1,0 +1,15 @@
+const { app, utilityProcess } = require('electron');
+
+const path = require('node:path');
+
+app.whenReady().then(() => {
+  const child = utilityProcess.fork(path.join(__dirname, 'noop.js'), [], {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      NODE_OPTIONS: `--require ${path.join(__dirname, 'fail.js')}`
+    }
+  });
+
+  child.once('exit', (code) => app.exit(code));
+});

--- a/spec/fixtures/apps/node-options-utility-process/noop.js
+++ b/spec/fixtures/apps/node-options-utility-process/noop.js
@@ -1,0 +1,1 @@
+process.exit(0);

--- a/spec/fixtures/apps/node-options-utility-process/package.json
+++ b/spec/fixtures/apps/node-options-utility-process/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "electron-test-node-options-utility-process",
+  "main": "main.js"
+}

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -697,6 +697,27 @@ describe('node feature', () => {
       expect(code).to.equal(1);
     });
 
+    it('does allow --require in utility process of non-packaged apps', async () => {
+      const appPath = path.join(fixtures, 'apps', 'node-options-utility-process');
+      // App should exit with code 1.
+      const child = childProcess.spawn(process.execPath, [appPath]);
+      const [code] = await once(child, 'exit');
+      expect(code).to.equal(1);
+    });
+
+    it('does not allow --require in utility process of packaged apps', async () => {
+      const appPath = path.join(fixtures, 'apps', 'node-options-utility-process');
+      // App should exit with code 1.
+      const child = childProcess.spawn(process.execPath, [appPath], {
+        env: {
+          ...process.env,
+          ELECTRON_FORCE_IS_PACKAGED: 'true'
+        }
+      });
+      const [code] = await once(child, 'exit');
+      expect(code).to.equal(0);
+    });
+
     it('does not allow --require in packaged apps', async () => {
       const appPath = path.join(fixtures, 'module', 'noop.js');
       const env = {

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -705,7 +705,9 @@ describe('node feature', () => {
       expect(code).to.equal(1);
     });
 
-    it('does not allow --require in utility process of packaged apps', async () => {
+    // TODO(deepak1556): will be enabled in follow-up PR
+    // https://github.com/electron/electron/pull/46210
+    it.skip('does not allow --require in utility process of packaged apps', async () => {
       const appPath = path.join(fixtures, 'apps', 'node-options-utility-process');
       // App should exit with code 1.
       const child = childProcess.spawn(process.execPath, [appPath], {


### PR DESCRIPTION
#### Description of Change

Exe basenames for child process on macOS should be validated against the respective helper base names.
#### Release Notes

Notes: fix NODE_OPTIONS parsing for child processes on macOS