### PR TITLE
perf: avoid redundant map lookups in global shortcut

### DIFF
--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -69,12 +69,13 @@ void GlobalShortcut::OnKeyPressed(const ui::Accelerator& accelerator) {
 
 void GlobalShortcut::ExecuteCommand(const extensions::ExtensionId& extension_id,
                                     const std::string& command_id) {
-  if (!command_callback_map_.contains(command_id)) {
+  if (auto* cb = base::FindOrNull(command_callback_map_, command_id)) {
+    cb->Run();
+  } else {
     // This should never occur, because if it does, GlobalAcceleratorListener
     // notifies us with wrong command.
     NOTREACHED();
   }
-  command_callback_map_[command_id].Run();
 }
 
 bool GlobalShortcut::RegisterAll(

--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "base/containers/map_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/uuid.h"
 #include "components/prefs/pref_service.h"
@@ -57,12 +58,13 @@ GlobalShortcut::~GlobalShortcut() {
 }
 
 void GlobalShortcut::OnKeyPressed(const ui::Accelerator& accelerator) {
-  if (!accelerator_callback_map_.contains(accelerator)) {
+  if (auto* cb = base::FindOrNull(accelerator_callback_map_, accelerator)) {
+    cb->Run();
+  } else {
     // This should never occur, because if it does,
     // ui::GlobalAcceleratorListener notifies us with wrong accelerator.
     NOTREACHED();
   }
-  accelerator_callback_map_[accelerator].Run();
 }
 
 void GlobalShortcut::ExecuteCommand(const extensions::ExtensionId& extension_id,


### PR DESCRIPTION
#### Description of Change

Avoid redundant map lookups in `GlobalShortcut::OnKeyPressed()` and `GlobalShortcut::ExecuteComand()`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.