### PR TITLE
perf: avoid `std::map` temporaries in `IsDevToolsFileSystemAdded()`

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -675,6 +675,12 @@ PrefService* GetPrefService(content::WebContents* web_contents) {
   return static_cast<electron::ElectronBrowserContext*>(context)->prefs();
 }
 
+// returns a Dict of filesystem_path -> type
+[[nodiscard]] const base::Value::Dict& GetAddedFileSystems(
+    content::WebContents* web_contents) {
+  return GetPrefService(web_contents)->GetDict(prefs::kDevToolsFileSystemPaths);
+}
+
 std::map<std::string, std::string> GetAddedFileSystemPaths(
     content::WebContents* web_contents) {
   auto* pref_service = GetPrefService(web_contents);

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -683,11 +683,8 @@ PrefService* GetPrefService(content::WebContents* web_contents) {
 
 std::map<std::string, std::string> GetAddedFileSystemPaths(
     content::WebContents* web_contents) {
-  auto* pref_service = GetPrefService(web_contents);
-  const base::Value::Dict& file_system_paths =
-      pref_service->GetDict(prefs::kDevToolsFileSystemPaths);
   std::map<std::string, std::string> result;
-  for (auto it : file_system_paths) {
+  for (auto it : GetAddedFileSystems(web_contents)) {
     std::string type =
         it.second.is_string() ? it.second.GetString() : std::string();
     result[it.first] = type;

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -693,8 +693,8 @@ std::map<std::string, std::string> GetAddedFileSystemPaths(
 }
 
 bool IsDevToolsFileSystemAdded(content::WebContents* web_contents,
-                               const std::string& file_system_path) {
-  return GetAddedFileSystemPaths(web_contents).contains(file_system_path);
+                               const std::string_view file_system_path) {
+  return GetAddedFileSystems(web_contents).contains(file_system_path);
 }
 
 content::RenderFrameHost* GetRenderFrameHost(


### PR DESCRIPTION
#### Description of Change

`IsDevToolsFileSystemAdded()` wants to know if a `const base::Value::Dict&` provided by Chromium contains an item.  This PR does that by calling `dict.contains(item)`. Previously, it was done by creating single-use temporary `std::map` and then calling `map.contains(item)`.

`IsDevToolsFileSystemAdded()` is used by:

- `WebContents::DevToolsAddFileSystem()`
- `WebContents::DevToolsIndexPath()`
- `WebContents::DevToolsSearchInPath()`

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.