### PR TITLE
refactor: migrate hashing code to new upstream `crypto::hash` API

### DIFF
--- a/shell/browser/net/asar/asar_file_validator.cc
+++ b/shell/browser/net/asar/asar_file_validator.cc
@@ -14,7 +14,6 @@
 #include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
-#include "crypto/sha2.h"
 
 namespace asar {
 
@@ -34,7 +33,7 @@ void AsarFileValidator::EnsureBlockHashExists() {
   current_hash_byte_count_ = 0U;
   switch (integrity_.algorithm) {
     case HashAlgorithm::kSHA256:
-      current_hash_ = crypto::SecureHash::Create(crypto::SecureHash::SHA256);
+      current_hash_.emplace(crypto::hash::kSha256);
       break;
     case HashAlgorithm::kNone:
       NOTREACHED();
@@ -86,7 +85,7 @@ bool AsarFileValidator::FinishBlock() {
   if (!current_hash_) {
     // This happens when we fail to read the resource. Compute empty content's
     // hash in this case.
-    current_hash_ = crypto::SecureHash::Create(crypto::SecureHash::SHA256);
+    current_hash_.emplace(crypto::hash::kSha256);
   }
 
   // If the file reader is done we need to make sure we've either read up to the
@@ -108,7 +107,7 @@ bool AsarFileValidator::FinishBlock() {
     current_hash_->Update(abandoned_buffer);
   }
 
-  auto actual = std::array<uint8_t, crypto::kSHA256Length>{};
+  auto actual = std::array<uint8_t, crypto::hash::kSha256Size>{};
   current_hash_->Finish(actual);
   current_hash_.reset();
   current_hash_byte_count_ = 0;

--- a/shell/browser/net/asar/asar_file_validator.h
+++ b/shell/browser/net/asar/asar_file_validator.h
@@ -5,9 +5,9 @@
 #ifndef ELECTRON_SHELL_BROWSER_NET_ASAR_ASAR_FILE_VALIDATOR_H_
 #define ELECTRON_SHELL_BROWSER_NET_ASAR_ASAR_FILE_VALIDATOR_H_
 
-#include <memory>
+#include <optional>
 
-#include "crypto/secure_hash.h"
+#include "crypto/hash.h"
 #include "mojo/public/cpp/system/file_data_source.h"
 #include "mojo/public/cpp/system/filtered_data_source.h"
 #include "shell/common/asar/archive.h"
@@ -56,7 +56,7 @@ class AsarFileValidator : public mojo::FilteredDataSource::Filter {
   int max_block_;
   uint64_t current_hash_byte_count_ = 0U;
   uint64_t total_hash_byte_count_ = 0;
-  std::unique_ptr<crypto::SecureHash> current_hash_;
+  std::optional<crypto::hash::Hasher> current_hash_;
 };
 
 }  // namespace asar

--- a/shell/common/asar/asar_util.cc
+++ b/shell/common/asar/asar_util.cc
@@ -16,8 +16,7 @@
 #include "base/strings/string_util.h"
 #include "base/synchronization/lock.h"
 #include "base/threading/thread_local.h"
-#include "crypto/secure_hash.h"
-#include "crypto/sha2.h"
+#include "crypto/hash.h"
 #include "shell/common/asar/archive.h"
 #include "shell/common/thread_restrictions.h"
 
@@ -139,7 +138,7 @@ void ValidateIntegrityOrDie(base::span<const uint8_t> input,
                             const IntegrityPayload& integrity) {
   if (integrity.algorithm == HashAlgorithm::kSHA256) {
     const std::string hex_hash =
-        base::ToLowerASCII(base::HexEncode(crypto::SHA256Hash(input)));
+        base::ToLowerASCII(base::HexEncode(crypto::hash::Sha256(input)));
     if (integrity.hash != hex_hash) {
       LOG(FATAL) << "Integrity check failed for asar archive ("
                  << integrity.hash << " vs " << hex_hash << ")";


### PR DESCRIPTION
#### Description of Change

Xref: https://chromium-review.googlesource.com/c/chromium/src/+/6287609

Similar to [chromium:5287609](https://chromium-review.googlesource.com/c/chromium/src/+/6287609), this PR updates our hashing code to use Chromium's new `crypto::hash` API. This API has more memory safety and requires fewer heap allocations.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.