### PR TITLE
perf: avoid redundant map lookup in `WebFrameMain` constructor

### DIFF
--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -155,8 +155,8 @@ WebFrameMain::WebFrameMain(content::RenderFrameHost* rfh)
   if (!render_frame_detached_)
     GetFrameTreeNodeIdMap().emplace(frame_tree_node_id_, this);
 
-  DCHECK(!GetFrameTokenMap().contains(frame_token_));
-  GetFrameTokenMap().emplace(frame_token_, this);
+  const auto [_, inserted] = GetFrameTokenMap().emplace(frame_token_, this);
+  DCHECK(inserted);
 
   // WebFrameMain should only be created for active or unloading frames.
   DCHECK(GetLifecycleState(rfh) == LifecycleState::kActive ||


### PR DESCRIPTION
#### Description of Change

Another PR to remove another redundant map lookup. :slightly_smiling_face: 

This one was in the `WebFrameMain` constructor.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none