### PR TITLE
fix: crash when drag-dropping some files

### DIFF
--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -700,7 +700,12 @@ v8::MaybeLocal<v8::Object> CreateProxyForAPI(
             recursion_depth + 1, error_target);
         if (passed_value.IsEmpty())
           return {};
-        proxy.Set(key, passed_value.ToLocalChecked());
+
+        {
+          v8::Context::Scope inner_destination_context_scope(
+              destination_context);
+          proxy.Set(key, passed_value.ToLocalChecked());
+        }
       }
     }
 

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -687,17 +687,21 @@ v8::MaybeLocal<v8::Object> CreateProxyForAPI(
           continue;
         }
       }
-      v8::Local<v8::Value> value;
-      if (!api.Get(key, &value))
-        continue;
 
-      auto passed_value = PassValueToOtherContextInner(
-          source_context, source_execution_context, destination_context, value,
-          api.GetHandle(), object_cache, support_dynamic_properties,
-          recursion_depth + 1, error_target);
-      if (passed_value.IsEmpty())
-        return {};
-      proxy.Set(key, passed_value.ToLocalChecked());
+      {
+        v8::Context::Scope source_context_scope(source_context);
+        v8::Local<v8::Value> value;
+        if (!api.Get(key, &value))
+          continue;
+
+        auto passed_value = PassValueToOtherContextInner(
+            source_context, source_execution_context, destination_context,
+            value, api.GetHandle(), object_cache, support_dynamic_properties,
+            recursion_depth + 1, error_target);
+        if (passed_value.IsEmpty())
+          return {};
+        proxy.Set(key, passed_value.ToLocalChecked());
+      }
     }
 
     return proxy.GetHandle();


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/44460.

Fixes a crash that occurs with the following stacktrace:

<details><summary>Stacktrace</summary>
<p>

```
[3194:0325/102703.083107:FATAL:third_party/blink/renderer/platform/bindings/dom_data_store.h:247] Check failed: Current(isolate).can_use_inline_storage_.
0   Electron Framework                  0x0000000122e26704 base::debug::CollectStackTrace(base::span<void const*, 18446744073709551615ul, void const**>) + 28
1   Electron Framework                  0x0000000122e16ba4 base::debug::StackTrace::StackTrace(unsigned long) + 224
2   Electron Framework                  0x0000000122d3c128 logging::LogMessage::Flush() + 152
3   Electron Framework                  0x0000000122d3c010 logging::LogMessage::~LogMessage() + 36
4   Electron Framework                  0x0000000122d23160 logging::(anonymous namespace)::DCheckLogMessage::~DCheckLogMessage() + 76
5   Electron Framework                  0x0000000122d22a20 logging::CheckError::~CheckError() + 44
6   Electron Framework                  0x0000000122d22a80 logging::CheckError::~CheckError() + 12
7   Electron Framework                  0x0000000127b6b1f0 blink::DOMDataStore::SetReturnValueFast(v8::ReturnValue<v8::Value>, blink::ScriptWrappable*, v8::Local<v8::Object>, blink::ScriptWrappable const*) + 216
8   Electron Framework                  0x0000000127bde770 blink::V8FileList::IndexedPropertyGetterCallback(unsigned int, v8::PropertyCallbackInfo<v8::Value> const&) + 116
9   Electron Framework                  0x000000011f27d508 v8::internal::PropertyCallbackArguments::CallIndexedGetter(v8::internal::DirectHandle<v8::internal::InterceptorInfo>, unsigned int) + 344
10  Electron Framework                  0x000000011f4fbf08 v8::internal::(anonymous namespace)::GetPropertyAttributesWithInterceptorInternal(v8::internal::LookupIterator*, v8::internal::DirectHandle<v8::internal::InterceptorInfo>) + 632
11  Electron Framework                  0x000000011f4e9070 v8::internal::JSReceiver::HasProperty(v8::internal::LookupIterator*) + 84
12  Electron Framework                  0x000000011ec6cd2c v8::Object::Has(v8::Local<v8::Context>, v8::Local<v8::Value>) + 484
13  Electron Framework                  0x000000011d370b8c bool gin_helper::Dictionary::Get<v8::Local<v8::Value>, v8::Local<v8::Value>>(v8::Local<v8::Value> const&, v8::Local<v8::Value>*) const + 116
14  Electron Framework                  0x000000011d370450 electron::api::CreateProxyForAPI(v8::Local<v8::Object> const&, v8::Local<v8::Context> const&, blink::ExecutionContext const*, v8::Local<v8::Context> const&, electron::api::context_bridge::ObjectCache*, bool, int, electron::api::BridgeErrorTarget) + 1188
15  Electron Framework                  0x000000011d36f21c electron::api::PassValueToOtherContextInner(v8::Local<v8::Context>, blink::ExecutionContext const*, v8::Local<v8::Context>, v8::Local<v8::Value>, v8::Local<v8::Value>, electron::api::context_bridge::ObjectCache*, bool, int, electron::api::BridgeErrorTarget) + 2008
16  Electron Framework                  0x000000011d3706f4 electron::api::PassValueToOtherContext(v8::Local<v8::Context>, v8::Local<v8::Context>, v8::Local<v8::Value>, v8::Local<v8::Value>, bool, electron::api::BridgeErrorTarget, electron::api::context_bridge::ObjectCache*) + 216
17  Electron Framework                  0x000000011d36f6e8 electron::api::ProxyFunctionWrapper(v8::FunctionCallbackInfo<v8::Value> const&) + 756
18  ???                                 0x0000000177be13d8 0x0 + 6303912920
19  ???                                 0x0000000177bde918 0x0 + 6303901976
20  ???                                 0x0000000177bde918 0x0 + 6303901976
21  ???                                 0x00000001700029cc 0x0 + 6174026188
22  ???                                 0x0000000177bda3b8 0x0 + 6303884216
23  ???                                 0x0000000177bd9ff4 0x0 + 6303883252
24  Electron Framework                  0x000000011ef92cf0 v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) + 5260
25  Electron Framework                  0x000000011ef9172c v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::DirectHandle<v8::internal::Object>, v8::internal::DirectHandle<v8::internal::Object>, v8::base::Vector<v8::internal::DirectHandle<v8::internal::Object> const>) + 276
26  Electron Framework                  0x000000011ec73c0c v8::Function::Call(v8::Isolate*, v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*) + 920
27  Electron Framework                  0x000000012563fdd0 blink::V8ScriptRunner::CallFunction(v8::Local<v8::Function>, blink::ExecutionContext*, v8::Local<v8::Value>, int, v8::Local<v8::Value>*, v8::Isolate*) + 892
28  Electron Framework                  0x0000000127b2a3b4 blink::bindings::CallbackInvokeHelper<blink::CallbackInterfaceBase, (blink::bindings::CallbackInvokeHelperMode)0, (blink::bindings::CallbackReturnTypeIsPromise)0>::CallInternal(int, v8::Local<v8::Value>*) + 196
29  Electron Framework                  0x0000000127b2a2d8 blink::bindings::CallbackInvokeHelper<blink::CallbackInterfaceBase, (blink::bindings::CallbackInvokeHelperMode)0, (blink::bindings::CallbackReturnTypeIsPromise)0>::Call(int, v8::Local<v8::Value>*) + 20
30  Electron Framework                  0x0000000127b31be0 blink::V8EventListener::InvokeWithoutRunnabilityCheck(blink::bindings::V8ValueOrScriptWrappableAdapter, blink::Event*) + 268
31  Electron Framework                  0x0000000125b8bad4 blink::JSEventListener::InvokeInternal(blink::EventTarget&, blink::Event&, v8::Local<v8::Value>) + 256
32  Electron Framework                  0x0000000125b8b260 blink::JSBasedEventListener::Invoke(blink::ExecutionContext*, blink::Event*) + 820
33  Electron Framework                  0x0000000125b90de4 blink::EventTarget::FireEventListeners(blink::Event&, blink::EventTargetData*, blink::HeapVector<cppgc::internal::BasicMember<blink::RegisteredEventListener, cppgc::internal::StrongMemberTag, cppgc::internal::DijkstraWriteBarrierPolicy, cppgc::internal::DisabledCheckingPolicy, cppgc::internal::CompressedPointer>, 1u>) + 1728
34  Electron Framework                  0x0000000125b903bc blink::EventTarget::FireEventListeners(blink::Event&) + 656
35  Electron Framework                  0x00000001277af3dc blink::NodeEventContext::HandleLocalEvents(blink::Event&) const + 292
36  Electron Framework                  0x00000001277b08c8 blink::EventDispatcher::DispatchEventAtBubbling() + 208
37  Electron Framework                  0x00000001277b0484 blink::EventDispatcher::Dispatch() + 1608
38  Electron Framework                  0x00000001277af9b0 blink::EventDispatcher::DispatchEvent(blink::Node&, blink::Event&) + 212
39  Electron Framework                  0x0000000125b90074 blink::EventTarget::dispatchEventForBindings(blink::Event*, blink::ExceptionState&) + 136
40  Electron Framework                  0x0000000127bdb6e0 blink::(anonymous namespace)::v8_event_target::DispatchEventOperationCallback(v8::FunctionCallbackInfo<v8::Value> const&) + 352
41  ???                                 0x0000000177be13d8 0x0 + 6303912920
42  ???                                 0x000000017000328c 0x0 + 6174028428
43  ???                                 0x0000000177bde918 0x0 + 6303901976
44  ???                                 0x0000000177bde918 0x0 + 6303901976
45  ???                                 0x0000000177bde918 0x0 + 6303901976
46  ???                                 0x0000000170001ddc 0x0 + 6174023132
47  ???                                 0x000000017000b1ac 0x0 + 6174060972
48  ???                                 0x000000017008d320 0x0 + 6174593824
49  ???                                 0x000000017008d48c 0x0 + 6174594188
50  ???                                 0x0000000170003c40 0x0 + 6174030912
51  ???                                 0x00000001700964d0 0x0 + 6174631120
52  ???                                 0x0000000170090c24 0x0 + 6174608420
53  ???                                 0x000000017009a6b8 0x0 + 6174647992
54  ???                                 0x0000000177bde918 0x0 + 6303901976
55  ???                                 0x0000000177bda3b8 0x0 + 6303884216
56  ???                                 0x0000000177bd9ff4 0x0 + 6303883252
57  Electron Framework                  0x000000011ef92cf0 v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) + 5260
58  Electron Framework                  0x000000011ef9172c v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::DirectHandle<v8::internal::Object>, v8::internal::DirectHandle<v8::internal::Object>, v8::base::Vector<v8::internal::DirectHandle<v8::internal::Object> const>) + 276
59  Electron Framework                  0x000000011ec73c0c v8::Function::Call(v8::Isolate*, v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*) + 920
60  Electron Framework                  0x000000012563fdd0 blink::V8ScriptRunner::CallFunction(v8::Local<v8::Function>, blink::ExecutionContext*, v8::Local<v8::Value>, int, v8::Local<v8::Value>*, v8::Isolate*) + 892
61  Electron Framework                  0x0000000127b2a3b4 blink::bindings::CallbackInvokeHelper<blink::CallbackInterfaceBase, (blink::bindings::CallbackInvokeHelperMode)0, (blink::bindings::CallbackReturnTypeIsPromise)0>::CallInternal(int, v8::Local<v8::Value>*) + 196
62  Electron Framework                  0x0000000127b2a2d8 blink::bindings::CallbackInvokeHelper<blink::CallbackInterfaceBase, (blink::bindings::CallbackInvokeHelperMode)0, (blink::bindings::CallbackReturnTypeIsPromise)0>::Call(int, v8::Local<v8::Value>*) + 20
63  Electron Framework                  0x0000000127b31be0 blink::V8EventListener::InvokeWithoutRunnabilityCheck(blink::bindings::V8ValueOrScriptWrappableAdapter, blink::Event*) + 268
64  Electron Framework                  0x0000000125b8bad4 blink::JSEventListener::InvokeInternal(blink::EventTarget&, blink::Event&, v8::Local<v8::Value>) + 256
65  Electron Framework                  0x0000000125b8b260 blink::JSBasedEventListener::Invoke(blink::ExecutionContext*, blink::Event*) + 820
66  Electron Framework                  0x0000000125b90de4 blink::EventTarget::FireEventListeners(blink::Event&, blink::EventTargetData*, blink::HeapVector<cppgc::internal::BasicMember<blink::RegisteredEventListener, cppgc::internal::StrongMemberTag, cppgc::internal::DijkstraWriteBarrierPolicy, cppgc::internal::DisabledCheckingPolicy, cppgc::internal::CompressedPointer>, 1u>) + 1728
67  Electron Framework                  0x0000000125b903bc blink::EventTarget::FireEventListeners(blink::Event&) + 656
68  Electron Framework                  0x00000001277af3dc blink::NodeEventContext::HandleLocalEvents(blink::Event&) const + 292
69  Electron Framework                  0x00000001277b0948 blink::EventDispatcher::DispatchEventAtBubbling() + 336
70  Electron Framework                  0x00000001277b0484 blink::EventDispatcher::Dispatch() + 1608
71  Electron Framework                  0x00000001277af9b0 blink::EventDispatcher::DispatchEvent(blink::Node&, blink::Event&) + 212
72  Electron Framework                  0x00000001263b6d2c blink::MouseEventManager::DispatchDragEvent(WTF::AtomicString const&, blink::Node*, blink::Node*, blink::WebMouseEvent const&, blink::DataTransfer*) + 956
73  Electron Framework                  0x0000000126385498 blink::EventHandler::PerformDragAndDrop(blink::WebMouseEvent const&, blink::DataTransfer*) + 408
74  Electron Framework                  0x0000000126b642ac blink::DragController::PerformDrag(blink::DragData*, blink::LocalFrame&) + 992
75  Electron Framework                  0x0000000126072fb8 blink::WebFrameWidgetImpl::DragTargetDrop(blink::WebDragData const&, gfx::PointF const&, gfx::PointF const&, unsigned int, base::OnceCallback<void ()>) + 888
76  Electron Framework                  0x0000000121f44bbc blink::mojom::blink::FrameWidgetStubDispatch::AcceptWithResponder(blink::mojom::blink::FrameWidget*, mojo::Message*, std::__Cr::unique_ptr<mojo::MessageReceiverWithStatus, std::__Cr::default_delete<mojo::MessageReceiverWithStatus>>) + 596
77  Electron Framework                  0x000000012608a590 blink::mojom::blink::FrameWidgetStub<mojo::RawPtrImplRefTraits<blink::mojom::blink::FrameWidget>>::AcceptWithResponder(mojo::Message*, std::__Cr::unique_ptr<mojo::MessageReceiverWithStatus, std::__Cr::default_delete<mojo::MessageReceiverWithStatus>>) + 44
78  Electron Framework                  0x00000001231bf724 mojo::InterfaceEndpointClient::HandleValidatedMessage(mojo::Message*) + 1644
79  Electron Framework                  0x00000001231c5d58 mojo::MessageDispatcher::Accept(mojo::Message*) + 292
80  Electron Framework                  0x00000001231c14b0 mojo::InterfaceEndpointClient::HandleIncomingMessage(mojo::Message*) + 148
81  Electron Framework                  0x000000012376ee20 IPC::ChannelAssociatedGroupController::AcceptOnEndpointThread(mojo::Message, IPC::(anonymous namespace)::ScopedUrgentMessageNotification) + 604
82  Electron Framework                  0x000000012376f974 base::internal::Invoker<base::internal::FunctorTraits<void (IPC::ChannelAssociatedGroupController::*&&)(mojo::Message, IPC::(anonymous namespace)::ScopedUrgentMessageNotification), IPC::ChannelAssociatedGroupController*&&, mojo::Message&&, IPC::(anonymous namespace)::ScopedUrgentMessageNotification&&>, base::internal::BindState<true, true, false, void (IPC::ChannelAssociatedGroupController::*)(mojo::Message, IPC::(anonymous namespace)::ScopedUrgentMessageNotification), scoped_refptr<IPC::ChannelAssociatedGroupController>, mojo::Message, IPC::(anonymous namespace)::ScopedUrgentMessageNotification>, void ()>::RunOnce(base::internal::BindStateBase*) + 232
83  Electron Framework                  0x000000011d157884 base::OnceCallback<void ()>::Run() && + 108
84  Electron Framework                  0x0000000122d97f40 base::TaskAnnotator::RunTaskImpl(base::PendingTask&) + 280
85  Electron Framework                  0x0000000122dc85ac base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*) + 1732
86  Electron Framework                  0x0000000122dc7cb4 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() + 96
87  Electron Framework                  0x0000000122d45590 base::MessagePumpDefault::Run(base::MessagePump::Delegate*) + 192
88  Electron Framework                  0x0000000122dc9368 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) + 884
89  Electron Framework                  0x0000000122d76d68 base::RunLoop::Run(base::Location const&) + 996
90  Electron Framework                  0x00000001255befb0 content::RendererMain(content::MainFunctionParams) + 1464
91  Electron Framework                  0x000000011d7ef1c0 content::RunOtherNamedProcessTypeMain(std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, content::MainFunctionParams, content::ContentMainDelegate*) + 660
92  Electron Framework                  0x000000011d7f0b44 content::ContentMainRunnerImpl::Run() + 1060
93  Electron Framework                  0x000000011d7ee548 content::RunContentProcess(content::ContentMainParams, content::ContentMainRunner*) + 1344
94  Electron Framework                  0x000000011d7ee668 content::ContentMain(content::ContentMainParams) + 112
95  Electron Framework                  0x000000011d1506e0 ElectronMain + 124
96  Electron Helper (Renderer)          0x0000000104518a98 main + 224
97  dyld                                0x000000019976eb4c start + 6000
Task trace:
0   Electron Framework                  0x0000000123769048 IPC::ChannelAssociatedGroupController::Accept(mojo::Message*) + 1348
Crash keys:
  "max_idle_tasks" = "0"
  "devtools_present" = "true"
  "renderer_foreground" = "true"
  "v8_ro_space_firstpage_address" = "0x6e900000000"
  "v8_isolate_address" = "0x12800cd0000"
  "num-experiments" = "0"
  "platform" = "darwin"
  "process_type" = "renderer"
  "osarch" = "arm64"
  "pid" = "3194"
  "ptype" = "renderer"

Received signal 6
0   Electron Framework                  0x0000000122e26704 base::debug::CollectStackTrace(base::span<void const*, 18446744073709551615ul, void const**>) + 28
1   Electron Framework                  0x0000000122e16ba4 base::debug::StackTrace::StackTrace(unsigned long) + 224
2   Electron Framework                  0x0000000122e26658 base::debug::(anonymous namespace)::StackDumpSignalHandler(int, __siginfo*, void*) + 940
3   libsystem_platform.dylib            0x0000000199b47624 _sigtramp + 56
4   libsystem_pthread.dylib             0x0000000199b0d88c pthread_kill + 296
5   libsystem_c.dylib                   0x0000000199a16c60 abort + 124
6   Electron Framework                  0x0000000122d3cc20 logging::LogMessage::HandleFatal(unsigned long, std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&) const + 468
7   Electron Framework                  0x0000000122d3c7d0 logging::LogMessage::Flush() + 1856
8   Electron Framework                  0x0000000122d3c010 logging::LogMessage::~LogMessage() + 36
9   Electron Framework                  0x0000000122d23160 logging::(anonymous namespace)::DCheckLogMessage::~DCheckLogMessage() + 76
10  Electron Framework                  0x0000000122d22a20 logging::CheckError::~CheckError() + 44
11  Electron Framework                  0x0000000122d22a80 logging::CheckError::~CheckError() + 12
12  Electron Framework                  0x0000000127b6b1f0 blink::DOMDataStore::SetReturnValueFast(v8::ReturnValue<v8::Value>, blink::ScriptWrappable*, v8::Local<v8::Object>, blink::ScriptWrappable const*) + 216
13  Electron Framework                  0x0000000127bde770 blink::V8FileList::IndexedPropertyGetterCallback(unsigned int, v8::PropertyCallbackInfo<v8::Value> const&) + 116
14  Electron Framework                  0x000000011f27d508 v8::internal::PropertyCallbackArguments::CallIndexedGetter(v8::internal::DirectHandle<v8::internal::InterceptorInfo>, unsigned int) + 344
15  Electron Framework                  0x000000011f4fbf08 v8::internal::(anonymous namespace)::GetPropertyAttributesWithInterceptorInternal(v8::internal::LookupIterator*, v8::internal::DirectHandle<v8::internal::InterceptorInfo>) + 632
16  Electron Framework                  0x000000011f4e9070 v8::internal::JSReceiver::HasProperty(v8::internal::LookupIterator*) + 84
17  Electron Framework                  0x000000011ec6cd2c v8::Object::Has(v8::Local<v8::Context>, v8::Local<v8::Value>) + 484
18  Electron Framework                  0x000000011d370b8c bool gin_helper::Dictionary::Get<v8::Local<v8::Value>, v8::Local<v8::Value>>(v8::Local<v8::Value> const&, v8::Local<v8::Value>*) const + 116
19  Electron Framework                  0x000000011d370450 electron::api::CreateProxyForAPI(v8::Local<v8::Object> const&, v8::Local<v8::Context> const&, blink::ExecutionContext const*, v8::Local<v8::Context> const&, electron::api::context_bridge::ObjectCache*, bool, int, electron::api::BridgeErrorTarget) + 1188
20  Electron Framework                  0x000000011d36f21c electron::api::PassValueToOtherContextInner(v8::Local<v8::Context>, blink::ExecutionContext const*, v8::Local<v8::Context>, v8::Local<v8::Value>, v8::Local<v8::Value>, electron::api::context_bridge::ObjectCache*, bool, int, electron::api::BridgeErrorTarget) + 2008
21  Electron Framework                  0x000000011d3706f4 electron::api::PassValueToOtherContext(v8::Local<v8::Context>, v8::Local<v8::Context>, v8::Local<v8::Value>, v8::Local<v8::Value>, bool, electron::api::BridgeErrorTarget, electron::api::context_bridge::ObjectCache*) + 216
22  Electron Framework                  0x000000011d36f6e8 electron::api::ProxyFunctionWrapper(v8::FunctionCallbackInfo<v8::Value> const&) + 756
23  ???                                 0x0000000177be13d8 0x0 + 6303912920
24  ???                                 0x0000000177bde918 0x0 + 6303901976
25  ???                                 0x0000000177bde918 0x0 + 6303901976
26  ???                                 0x00000001700029cc 0x0 + 6174026188
27  ???                                 0x0000000177bda3b8 0x0 + 6303884216
28  ???                                 0x0000000177bd9ff4 0x0 + 6303883252
29  Electron Framework                  0x000000011ef92cf0 v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) + 5260
30  Electron Framework                  0x000000011ef9172c v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::DirectHandle<v8::internal::Object>, v8::internal::DirectHandle<v8::internal::Object>, v8::base::Vector<v8::internal::DirectHandle<v8::internal::Object> const>) + 276
31  Electron Framework                  0x000000011ec73c0c v8::Function::Call(v8::Isolate*, v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*) + 920
32  Electron Framework                  0x000000012563fdd0 blink::V8ScriptRunner::CallFunction(v8::Local<v8::Function>, blink::ExecutionContext*, v8::Local<v8::Value>, int, v8::Local<v8::Value>*, v8::Isolate*) + 892
33  Electron Framework                  0x0000000127b2a3b4 blink::bindings::CallbackInvokeHelper<blink::CallbackInterfaceBase, (blink::bindings::CallbackInvokeHelperMode)0, (blink::bindings::CallbackReturnTypeIsPromise)0>::CallInternal(int, v8::Local<v8::Value>*) + 196
34  Electron Framework                  0x0000000127b2a2d8 blink::bindings::CallbackInvokeHelper<blink::CallbackInterfaceBase, (blink::bindings::CallbackInvokeHelperMode)0, (blink::bindings::CallbackReturnTypeIsPromise)0>::Call(int, v8::Local<v8::Value>*) + 20
35  Electron Framework                  0x0000000127b31be0 blink::V8EventListener::InvokeWithoutRunnabilityCheck(blink::bindings::V8ValueOrScriptWrappableAdapter, blink::Event*) + 268
36  Electron Framework                  0x0000000125b8bad4 blink::JSEventListener::InvokeInternal(blink::EventTarget&, blink::Event&, v8::Local<v8::Value>) + 256
37  Electron Framework                  0x0000000125b8b260 blink::JSBasedEventListener::Invoke(blink::ExecutionContext*, blink::Event*) + 820
38  Electron Framework                  0x0000000125b90de4 blink::EventTarget::FireEventListeners(blink::Event&, blink::EventTargetData*, blink::HeapVector<cppgc::internal::BasicMember<blink::RegisteredEventListener, cppgc::internal::StrongMemberTag, cppgc::internal::DijkstraWriteBarrierPolicy, cppgc::internal::DisabledCheckingPolicy, cppgc::internal::CompressedPointer>, 1u>) + 1728
39  Electron Framework                  0x0000000125b903bc blink::EventTarget::FireEventListeners(blink::Event&) + 656
40  Electron Framework                  0x00000001277af3dc blink::NodeEventContext::HandleLocalEvents(blink::Event&) const + 292
41  Electron Framework                  0x00000001277b08c8 blink::EventDispatcher::DispatchEventAtBubbling() + 208
42  Electron Framework                  0x00000001277b0484 blink::EventDispatcher::Dispatch() + 1608
43  Electron Framework                  0x00000001277af9b0 blink::EventDispatcher::DispatchEvent(blink::Node&, blink::Event&) + 212
44  Electron Framework                  0x0000000125b90074 blink::EventTarget::dispatchEventForBindings(blink::Event*, blink::ExceptionState&) + 136
45  Electron Framework                  0x0000000127bdb6e0 blink::(anonymous namespace)::v8_event_target::DispatchEventOperationCallback(v8::FunctionCallbackInfo<v8::Value> const&) + 352
46  ???                                 0x0000000177be13d8 0x0 + 6303912920
47  ???                                 0x000000017000328c 0x0 + 6174028428
48  ???                                 0x0000000177bde918 0x0 + 6303901976
49  ???                                 0x0000000177bde918 0x0 + 6303901976
50  ???                                 0x0000000177bde918 0x0 + 6303901976
51  ???                                 0x0000000170001ddc 0x0 + 6174023132
52  ???                                 0x000000017000b1ac 0x0 + 6174060972
53  ???                                 0x000000017008d320 0x0 + 6174593824
54  ???                                 0x000000017008d48c 0x0 + 6174594188
55  ???                                 0x0000000170003c40 0x0 + 6174030912
56  ???                                 0x00000001700964d0 0x0 + 6174631120
57  ???                                 0x0000000170090c24 0x0 + 6174608420
58  ???                                 0x000000017009a6b8 0x0 + 6174647992
59  ???                                 0x0000000177bde918 0x0 + 6303901976
60  ???                                 0x0000000177bda3b8 0x0 + 6303884216
61  ???                                 0x0000000177bd9ff4 0x0 + 6303883252
62  Electron Framework                  0x000000011ef92cf0 v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) + 5260
63  Electron Framework                  0x000000011ef9172c v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::DirectHandle<v8::internal::Object>, v8::internal::DirectHandle<v8::internal::Object>, v8::base::Vector<v8::internal::DirectHandle<v8::internal::Object> const>) + 276
64  Electron Framework                  0x000000011ec73c0c v8::Function::Call(v8::Isolate*, v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*) + 920
65  Electron Framework                  0x000000012563fdd0 blink::V8ScriptRunner::CallFunction(v8::Local<v8::Function>, blink::ExecutionContext*, v8::Local<v8::Value>, int, v8::Local<v8::Value>*, v8::Isolate*) + 892
66  Electron Framework                  0x0000000127b2a3b4 blink::bindings::CallbackInvokeHelper<blink::CallbackInterfaceBase, (blink::bindings::CallbackInvokeHelperMode)0, (blink::bindings::CallbackReturnTypeIsPromise)0>::CallInternal(int, v8::Local<v8::Value>*) + 196
67  Electron Framework                  0x0000000127b2a2d8 blink::bindings::CallbackInvokeHelper<blink::CallbackInterfaceBase, (blink::bindings::CallbackInvokeHelperMode)0, (blink::bindings::CallbackReturnTypeIsPromise)0>::Call(int, v8::Local<v8::Value>*) + 20
68  Electron Framework                  0x0000000127b31be0 blink::V8EventListener::InvokeWithoutRunnabilityCheck(blink::bindings::V8ValueOrScriptWrappableAdapter, blink::Event*) + 268
69  Electron Framework                  0x0000000125b8bad4 blink::JSEventListener::InvokeInternal(blink::EventTarget&, blink::Event&, v8::Local<v8::Value>) + 256
70  Electron Framework                  0x0000000125b8b260 blink::JSBasedEventListener::Invoke(blink::ExecutionContext*, blink::Event*) + 820
71  Electron Framework                  0x0000000125b90de4 blink::EventTarget::FireEventListeners(blink::Event&, blink::EventTargetData*, blink::HeapVector<cppgc::internal::BasicMember<blink::RegisteredEventListener, cppgc::internal::StrongMemberTag, cppgc::internal::DijkstraWriteBarrierPolicy, cppgc::internal::DisabledCheckingPolicy, cppgc::internal::CompressedPointer>, 1u>) + 1728
72  Electron Framework                  0x0000000125b903bc blink::EventTarget::FireEventListeners(blink::Event&) + 656
73  Electron Framework                  0x00000001277af3dc blink::NodeEventContext::HandleLocalEvents(blink::Event&) const + 292
74  Electron Framework                  0x00000001277b0948 blink::EventDispatcher::DispatchEventAtBubbling() + 336
75  Electron Framework                  0x00000001277b0484 blink::EventDispatcher::Dispatch() + 1608
76  Electron Framework                  0x00000001277af9b0 blink::EventDispatcher::DispatchEvent(blink::Node&, blink::Event&) + 212
77  Electron Framework                  0x00000001263b6d2c blink::MouseEventManager::DispatchDragEvent(WTF::AtomicString const&, blink::Node*, blink::Node*, blink::WebMouseEvent const&, blink::DataTransfer*) + 956
78  Electron Framework                  0x0000000126385498 blink::EventHandler::PerformDragAndDrop(blink::WebMouseEvent const&, blink::DataTransfer*) + 408
79  Electron Framework                  0x0000000126b642ac blink::DragController::PerformDrag(blink::DragData*, blink::LocalFrame&) + 992
80  Electron Framework                  0x0000000126072fb8 blink::WebFrameWidgetImpl::DragTargetDrop(blink::WebDragData const&, gfx::PointF const&, gfx::PointF const&, unsigned int, base::OnceCallback<void ()>) + 888
81  Electron Framework                  0x0000000121f44bbc blink::mojom::blink::FrameWidgetStubDispatch::AcceptWithResponder(blink::mojom::blink::FrameWidget*, mojo::Message*, std::__Cr::unique_ptr<mojo::MessageReceiverWithStatus, std::__Cr::default_delete<mojo::MessageReceiverWithStatus>>) + 596
82  Electron Framework                  0x000000012608a590 blink::mojom::blink::FrameWidgetStub<mojo::RawPtrImplRefTraits<blink::mojom::blink::FrameWidget>>::AcceptWithResponder(mojo::Message*, std::__Cr::unique_ptr<mojo::MessageReceiverWithStatus, std::__Cr::default_delete<mojo::MessageReceiverWithStatus>>) + 44
83  Electron Framework                  0x00000001231bf724 mojo::InterfaceEndpointClient::HandleValidatedMessage(mojo::Message*) + 1644
84  Electron Framework                  0x00000001231c5d58 mojo::MessageDispatcher::Accept(mojo::Message*) + 292
85  Electron Framework                  0x00000001231c14b0 mojo::InterfaceEndpointClient::HandleIncomingMessage(mojo::Message*) + 148
86  Electron Framework                  0x000000012376ee20 IPC::ChannelAssociatedGroupController::AcceptOnEndpointThread(mojo::Message, IPC::(anonymous namespace)::ScopedUrgentMessageNotification) + 604
87  Electron Framework                  0x000000012376f974 base::internal::Invoker<base::internal::FunctorTraits<void (IPC::ChannelAssociatedGroupController::*&&)(mojo::Message, IPC::(anonymous namespace)::ScopedUrgentMessageNotification), IPC::ChannelAssociatedGroupController*&&, mojo::Message&&, IPC::(anonymous namespace)::ScopedUrgentMessageNotification&&>, base::internal::BindState<true, true, false, void (IPC::ChannelAssociatedGroupController::*)(mojo::Message, IPC::(anonymous namespace)::ScopedUrgentMessageNotification), scoped_refptr<IPC::ChannelAssociatedGroupController>, mojo::Message, IPC::(anonymous namespace)::ScopedUrgentMessageNotification>, void ()>::RunOnce(base::internal::BindStateBase*) + 232
88  Electron Framework                  0x000000011d157884 base::OnceCallback<void ()>::Run() && + 108
89  Electron Framework                  0x0000000122d97f40 base::TaskAnnotator::RunTaskImpl(base::PendingTask&) + 280
90  Electron Framework                  0x0000000122dc85ac base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*) + 1732
91  Electron Framework                  0x0000000122dc7cb4 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() + 96
92  Electron Framework                  0x0000000122d45590 base::MessagePumpDefault::Run(base::MessagePump::Delegate*) + 192
93  Electron Framework                  0x0000000122dc9368 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) + 884
94  Electron Framework                  0x0000000122d76d68 base::RunLoop::Run(base::Location const&) + 996
95  Electron Framework                  0x00000001255befb0 content::RendererMain(content::MainFunctionParams) + 1464
96  Electron Framework                  0x000000011d7ef1c0 content::RunOtherNamedProcessTypeMain(std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, content::MainFunctionParams, content::ContentMainDelegate*) + 660
97  Electron Framework                  0x000000011d7f0b44 content::ContentMainRunnerImpl::Run() + 1060
98  Electron Framework                  0x000000011d7ee548 content::RunContentProcess(content::ContentMainParams, content::ContentMainRunner*) + 1344
99  Electron Framework                  0x000000011d7ee668 content::ContentMain(content::ContentMainParams) + 112
100 Electron Framework                  0x000000011d1506e0 ElectronMain + 124
101 Electron Helper (Renderer)          0x0000000104518a98 main + 224
102 dyld                                0x000000019976eb4c start + 6000
[end of stack trace]
Renderer process crashed - see https://www.electronjs.org/docs/tutorial/application-debugging for potential debugging information.
```

</p>
</details> 

when dragging and dropping files. This happens as a result of trying to serialize `blink::FileList` object over the context bridge - we need to ensure it's accessed in the correct context.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash that could occur when dragging and dropping files into the browser.
