### PR TITLE
perf: avoid redundant map lookup in `AddComponentResourceEntries()`

### DIFF
--- a/shell/browser/extensions/electron_component_extension_resource_manager.cc
+++ b/shell/browser/extensions/electron_component_extension_resource_manager.cc
@@ -89,7 +89,8 @@ void ElectronComponentExtensionResourceManager::AddComponentResourceEntries(
     resource_path = resource_path.NormalizePathSeparators();
 
     if (!gen_folder_path.IsParent(resource_path)) {
-      auto [_, inserted] = path_to_resource_id_.try_emplace(resource_path, id);
+      const auto [_, inserted] =
+          path_to_resource_id_.try_emplace(std::move(resource_path), id);
       DCHECK(inserted);
     } else {
       // If the resource is a generated file, strip the generated folder's path,
@@ -98,7 +99,8 @@ void ElectronComponentExtensionResourceManager::AddComponentResourceEntries(
       base::FilePath effective_path =
           base::FilePath().AppendASCII(resource_path.AsUTF8Unsafe().substr(
               gen_folder_path.value().length()));
-      auto [_, inserted] = path_to_resource_id_.try_emplace(effective_path, id);
+      const auto [_, inserted] =
+          path_to_resource_id_.try_emplace(std::move(effective_path), id);
       DCHECK(inserted);
     }
   }


### PR DESCRIPTION
#### Description of Change

Another remove-redundant-map-lookups PR. This one fixes a double-lookup in `ElectronComponentExtensionResourceManager::AddComponentResourceEntries()`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.