### PR TITLE
fix: set `userAgent` on `navigationHistory.restore()`

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2515,6 +2515,9 @@ void WebContents::RestoreHistory(
   auto navigation_entries = std::make_unique<
       std::vector<std::unique_ptr<content::NavigationEntry>>>();
 
+  blink::UserAgentOverride ua_override;
+  ua_override.ua_string_override = GetUserAgent();
+
   for (const auto& entry : entries) {
     content::NavigationEntry* nav_entry = nullptr;
     if (!gin::Converter<content::NavigationEntry*>::FromV8(isolate, entry,
@@ -2527,11 +2530,15 @@ void WebContents::RestoreHistory(
           std::to_string(index) + ".");
       return;
     }
+
+    nav_entry->SetIsOverridingUserAgent(
+        !ua_override.ua_string_override.empty());
     navigation_entries->push_back(
         std::unique_ptr<content::NavigationEntry>(nav_entry));
   }
 
   if (!navigation_entries->empty()) {
+    web_contents()->SetUserAgentOverride(ua_override, false);
     web_contents()->GetController().Restore(
         index, content::RestoreType::kRestored, navigation_entries.get());
     web_contents()->GetController().LoadIfNecessary();

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -887,6 +887,31 @@ describe('webContents module', () => {
         });
       });
     });
+
+    it('should restore an overridden user agent', async () => {
+      const partition = 'persist:wcvtest';
+      const testUA = 'MyCustomUA';
+
+      const ses = session.fromPartition(partition);
+      ses.setUserAgent(testUA);
+
+      const wcv = new WebContentsView({
+        webPreferences: { partition }
+      });
+
+      wcv.webContents.navigationHistory.restore({
+        entries: [{
+          url: urlPage1,
+          title: 'url1'
+        }],
+        index: 0
+      });
+
+      const ua = wcv.webContents.getUserAgent();
+      const wcvua = await wcv.webContents.executeJavaScript('navigator.userAgent');
+
+      expect(ua).to.equal(wcvua);
+    });
   });
 
   describe('getFocusedWebContents() API', () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/46245.

Fixes an issue where `navigationHistory.restore()` failed to restore the `userAgent` if it was overridden.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `navigationHistory.restore()` failed to restore the `userAgent` if it was overridden.