### PR TITLE
feat!: remove support for ProtocolResponse.session null value

### DIFF
--- a/docs/api/structures/protocol-response.md
+++ b/docs/api/structures/protocol-response.md
@@ -25,11 +25,8 @@
   and URL responses.
 * `method` string (optional) - The HTTP `method`. This is only used for file
   and URL responses.
-* `session` Session (optional) - The session used for requesting URL, by default
-  the HTTP request will reuse the current session. Setting `session` to `null`
-  would use a random independent session. This is only used for URL responses.
-  **Deprecated:** Using `null` to create a random independent session is
-  deprecated and will be removed soon.
+* `session` Session (optional) - The session used for requesting URL.
+  The HTTP request will reuse the current session by default.
 * `uploadData` [ProtocolResponseUploadData](protocol-response-upload-data.md) (optional) - The data used as upload data. This is only
   used for URL responses when `method` is `"POST"`.
 

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -14,6 +14,18 @@ This document uses the following convention to categorize breaking changes:
 
 ## Planned Breaking API Changes (37.0)
 
+### Removed: `null` value for `session` property in `ProtocolResponse`
+
+This deprecated feature has been removed.
+
+Previously, setting the `ProtocolResponse.session` property to `null`
+would create a random independent session. This is no longer supported.
+
+Using single-purpose sessions here is discouraged due to overhead costs;
+however, old code that needs to preserve this behavior can emulate it by
+creating a random session with `session.fromPartition(some_random_string)`
+and then using it in `ProtocolResponse.session`.
+
 ### Behavior Changed: `BrowserWindow.IsVisibleOnAllWorkspaces()` on Linux
 
 `BrowserWindow.IsVisibleOnAllWorkspaces()` will now return false on Linux if the


### PR DESCRIPTION
#### Description of Change

BREAKING CHANGE

This feature was deprecated in f7ba0d3b (#46131). This PR removes it for Electron 37.

It's being removed because we should discourage single-use sessions. They allocate resources that stick around forever due to bac2f46.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Removed deprecated feature of creating a new random session by setting `ProtocolResponse.session`'s property to `null`.