### PR TITLE
perf: avoid `std::map` temporaries  in `WebContents::DevToolsRequestFileSystems()`

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -4040,32 +4040,22 @@ void WebContents::DevToolsAppendToFile(const std::string& url,
 }
 
 void WebContents::DevToolsRequestFileSystems() {
-  auto* const dtwc = GetDevToolsWebContents();
-
-  const base::Value::Dict& added_paths = GetAddedFileSystems(dtwc);
-  if (added_paths.empty()) {
-    inspectable_web_contents_->CallClientFunction(
-        "DevToolsAPI", "fileSystemsLoaded", base::Value(base::Value::List()));
-    return;
-  }
-
-  std::vector<FileSystem> file_systems;
   const std::string empty_str;
+  content::WebContents* const dtwc = GetDevToolsWebContents();
+  const base::Value::Dict& added_paths = GetAddedFileSystems(dtwc);
+
+  auto filesystems = base::Value::List::with_capacity(added_paths.size());
   for (const auto path_and_type : added_paths) {
     const auto& [path, type_val] = path_and_type;
     const auto& type = type_val.is_string() ? type_val.GetString() : empty_str;
     const std::string file_system_id =
         RegisterFileSystem(dtwc, base::FilePath::FromUTF8Unsafe(path));
-    file_systems.emplace_back(
-        CreateFileSystemStruct(dtwc, file_system_id, path, type));
+    filesystems.Append(CreateFileSystemValue(
+        CreateFileSystemStruct(dtwc, file_system_id, path, type)));
   }
 
-  base::Value::List file_system_value;
-  for (const auto& file_system : file_systems)
-    file_system_value.Append(CreateFileSystemValue(file_system));
   inspectable_web_contents_->CallClientFunction(
-      "DevToolsAPI", "fileSystemsLoaded",
-      base::Value(std::move(file_system_value)));
+      "DevToolsAPI", "fileSystemsLoaded", base::Value{std::move(filesystems)});
 }
 
 void WebContents::DevToolsAddFileSystem(

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -682,17 +682,6 @@ PrefService* GetPrefService(content::WebContents* web_contents) {
   return GetPrefService(web_contents)->GetDict(prefs::kDevToolsFileSystemPaths);
 }
 
-std::map<std::string, std::string> GetAddedFileSystemPaths(
-    content::WebContents* web_contents) {
-  std::map<std::string, std::string> result;
-  for (auto it : GetAddedFileSystems(web_contents)) {
-    std::string type =
-        it.second.is_string() ? it.second.GetString() : std::string();
-    result[it.first] = type;
-  }
-  return result;
-}
-
 bool IsDevToolsFileSystemAdded(content::WebContents* web_contents,
                                const std::string_view file_system_path) {
   return GetAddedFileSystems(web_contents).contains(file_system_path);

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -4051,7 +4051,9 @@ void WebContents::DevToolsAppendToFile(const std::string& url,
 }
 
 void WebContents::DevToolsRequestFileSystems() {
-  auto file_system_paths = GetAddedFileSystemPaths(GetDevToolsWebContents());
+  auto* const dtwc = GetDevToolsWebContents();
+
+  auto file_system_paths = GetAddedFileSystemPaths(dtwc);
   if (file_system_paths.empty()) {
     inspectable_web_contents_->CallClientFunction(
         "DevToolsAPI", "fileSystemsLoaded", base::Value(base::Value::List()));
@@ -4062,11 +4064,9 @@ void WebContents::DevToolsRequestFileSystems() {
   for (const auto& file_system_path : file_system_paths) {
     base::FilePath path =
         base::FilePath::FromUTF8Unsafe(file_system_path.first);
-    std::string file_system_id =
-        RegisterFileSystem(GetDevToolsWebContents(), path);
-    FileSystem file_system =
-        CreateFileSystemStruct(GetDevToolsWebContents(), file_system_id,
-                               file_system_path.first, file_system_path.second);
+    std::string file_system_id = RegisterFileSystem(dtwc, path);
+    FileSystem file_system = CreateFileSystemStruct(
+        dtwc, file_system_id, file_system_path.first, file_system_path.second);
     file_systems.push_back(file_system);
   }
 


### PR DESCRIPTION
#### Description of Change

Avoid a `std::map` temporary in `WebContents::DevToolsRequestFileSystems()`.

This builds on top of a similar refactor in #46230.

All reviews welcomed. CC @dsanders11 who reviewed 46230.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.