### PR TITLE
fix: stop menu minimization if set false

### DIFF
--- a/lib/browser/api/menu-item-roles.ts
+++ b/lib/browser/api/menu-item-roles.ts
@@ -78,7 +78,9 @@ export const roleList: Record<RoleId, Role> = {
   minimize: {
     label: 'Minimize',
     accelerator: 'CommandOrControl+M',
-    windowMethod: w => w.minimize()
+    windowMethod: w => {
+      if (w.minimizable) w.minimize();
+    }
   },
   paste: {
     label: 'Paste',

--- a/spec/api-menu-item-spec.ts
+++ b/spec/api-menu-item-spec.ts
@@ -2,7 +2,7 @@ import { BrowserWindow, app, Menu, MenuItem, MenuItemConstructorOptions } from '
 
 import { expect } from 'chai';
 
-import { ifdescribe } from './lib/spec-helpers';
+import { ifit, ifdescribe } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
 import { roleList, execute } from '../lib/browser/api/menu-item-roles';
 
@@ -204,6 +204,22 @@ describe('MenuItems', () => {
 
       const canExecute = execute(item.role as any, win, win.webContents);
       expect(canExecute).to.be.true('can execute');
+    });
+
+    ifit(process.platform === 'win32')('does not execute minimize role when minimizable false', () => {
+      const win = new BrowserWindow({ minimizable: false });
+      const menu = Menu.buildFromTemplate([{
+        label: 'text',
+        role: 'minimize'
+      }]);
+
+      Menu.setApplicationMenu(menu);
+      menu._executeCommand({}, menu.items[0].commandId);
+      expect(win.isMinimized()).to.equal(false);
+
+      win.setMinimizable(true);
+      menu._executeCommand({}, menu.items[0].commandId);
+      expect(win.isMinimized()).to.equal(true);
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Closes #46676

Previously the "Minimize" menu button would still allow the user to minimize the window on Windows, even if the window was created with `minimizable: false`. Now the window will not be able to be minimized via that button.

A follow-up PR is necessary to disable the button such that it is grayed out as well on both macOS and Windows.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: fix Minimize menu button to follow set window minimizability on Windows