### PR TITLE
fix: build failure when printing is disabled

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1988,6 +1988,7 @@ void WebContents::DraggableRegionsChanged(
   draggable_region_ = DraggableRegionsToSkRegion(regions);
 }
 
+#if BUILDFLAG(ENABLE_PRINTING)
 void WebContents::PrintCrossProcessSubframe(
     content::WebContents* web_contents,
     const gfx::Rect& rect,
@@ -1998,6 +1999,7 @@ void WebContents::PrintCrossProcessSubframe(
     client->PrintCrossProcessSubframe(rect, document_cookie, subframe_host);
   }
 }
+#endif
 
 SkRegion* WebContents::draggable_region() {
   return g_disable_draggable_regions ? nullptr : draggable_region_.get();

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -585,11 +585,13 @@ class WebContents final : public ExclusiveAccessContext,
   void DraggableRegionsChanged(
       const std::vector<blink::mojom::DraggableRegionPtr>& regions,
       content::WebContents* contents) override;
+#if BUILDFLAG(ENABLE_PRINTING)
   void PrintCrossProcessSubframe(
       content::WebContents* web_contents,
       const gfx::Rect& rect,
       int document_cookie,
       content::RenderFrameHost* subframe_host) const override;
+#endif
 
   // content::WebContentsObserver:
   void BeforeUnloadFired(bool proceed) override;

--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -16,6 +16,7 @@
 #include "electron/buildflags/buildflags.h"
 #include "media/base/media_switches.h"
 #include "net/base/features.h"
+#include "printing/buildflags/buildflags.h"
 #include "services/network/public/cpp/features.h"
 #include "third_party/blink/public/common/features.h"
 
@@ -60,7 +61,7 @@ void InitializeFeatureList() {
       std::string(",") + features::kMacWebContentsOcclusion.name;
 #endif
 
-#if BUILDFLAG(IS_LINUX)
+#if BUILDFLAG(IS_LINUX) && BUILDFLAG(ENABLE_PRINTING)
   disable_features +=
       // EnableOopPrintDrivers is still a bit half-baked on Linux and
       // causes crashes when trying to show dialogs.


### PR DESCRIPTION
#### Description of Change

Fix 1d6cb34 FTBFS regression when building with printing disabled.

This breaks the Microsoft internal builds of Electron; so if possible, I'd like to get this landed before we kick off the weekly 33 and 34 releases.

CC @codebytere @electron/wg-releases 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed build failure when building with printing disabled.