### PR TITLE
perf: avoid double map lookup in `WebFrameMain::UpdateRenderFrameHost()`

### DIFF
--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -193,8 +193,8 @@ void WebFrameMain::UpdateRenderFrameHost(content::RenderFrameHost* rfh) {
   // Ensure that RFH being swapped in doesn't already exist as its own
   // WebFrameMain instance.
   frame_token_ = rfh->GetGlobalFrameToken();
-  DCHECK(!GetFrameTokenMap().contains(frame_token_));
-  GetFrameTokenMap().emplace(frame_token_, this);
+  const auto [_, inserted] = GetFrameTokenMap().emplace(frame_token_, this);
+  DCHECK(inserted);
 
   render_frame_disposed_ = false;
   TeardownMojoConnection();


### PR DESCRIPTION
#### Description of Change

Remove another redundant map lookup. This one was in `WebFrameMain::UpdateRenderFrameHost()`.

Fix is similar to #46238

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.