### PR TITLE
docs: fix typo in `code-signing.md`

### DIFF
--- a/docs/tutorial/code-signing.md
+++ b/docs/tutorial/code-signing.md
@@ -12,11 +12,11 @@ security warnings.
 ![macOS Sonoma Gatekeeper warning: The app is damaged](../images/gatekeeper.png)
 
 Both Windows and macOS prevent users from running unsigned applications. It is
-possible to distribute applications without codesigning them - but in order to
+possible to distribute applications without signing them - but in order to
 run them, users need to go through multiple advanced and manual steps.
 
 If you are building an Electron app that you intend to package and distribute,
-it should be code signed. The Electron ecosystem tooling makes codesigning your
+it should be code signed. The Electron ecosystem tooling makes signing your
 apps straightforward - this documentation explains how sign your apps on both
 Windows and macOS.
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Fix typo in `codesigning` page by replace `codesigning` with `singing`

Close #45177
Ref: https://github.com/electron/electron/pull/45184#pullrequestreview-2549567111
cc @nikwen 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none.