### PR TITLE
perf: avoid a triple-redundant map lookup in `ViewsDelegate::GetAppbarAutohideEdges()`

### DIFF
--- a/shell/browser/ui/views/electron_views_delegate_win.cc
+++ b/shell/browser/ui/views/electron_views_delegate_win.cc
@@ -119,8 +119,8 @@ int ViewsDelegate::GetAppbarAutohideEdges(HMONITOR monitor,
   // in us thinking there is no auto-hide edges. By returning at least one edge
   // we don't initially go fullscreen until we figure out the real auto-hide
   // edges.
-  if (!appbar_autohide_edge_map_.contains(monitor))
-    appbar_autohide_edge_map_[monitor] = EDGE_BOTTOM;
+  auto [iter, _] = appbar_autohide_edge_map_.try_emplace(monitor, EDGE_BOTTOM);
+  const int edges{iter->second};
 
   // We use the SHAppBarMessage API to get the taskbar autohide state. This API
   // spins a modal loop which could cause callers to be reentered. To avoid
@@ -133,9 +133,9 @@ int ViewsDelegate::GetAppbarAutohideEdges(HMONITOR monitor,
         base::BindOnce(&GetAppbarAutohideEdgesOnWorkerThread, monitor),
         base::BindOnce(&ViewsDelegate::OnGotAppbarAutohideEdges,
                        weak_factory_.GetWeakPtr(), std::move(callback), monitor,
-                       appbar_autohide_edge_map_[monitor]));
+                       edges));
   }
-  return appbar_autohide_edge_map_[monitor];
+  return edges;
 }
 
 void ViewsDelegate::OnGotAppbarAutohideEdges(base::OnceClosure callback,


### PR DESCRIPTION
#### Description of Change

Another "avoid redundant map loookups" PR. This one is kind of novel: it fixes code that did *four* identical lookups in `ViewsDelegate::GetAppbarAutohideEdges()` :slightly_smiling_face: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.