### PR TITLE
perf: avoid redundant map lookups in `GetStorageMask()`

### DIFF
--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -179,9 +179,8 @@ BrowsingDataRemover::DataType GetDataTypeMask(
     const std::vector<std::string>& data_types) {
   BrowsingDataRemover::DataType mask = 0u;
   for (const auto& type : data_types) {
-    if (kDataTypeLookup.contains(type)) {
-      mask |= kDataTypeLookup.at(type);
-    }
+    if (const auto* val = base::FindOrNull(kDataTypeLookup, type))
+      mask |= *val;
   }
   return mask;
 }

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -13,6 +13,7 @@
 
 #include "base/command_line.h"
 #include "base/containers/fixed_flat_map.h"
+#include "base/containers/map_util.h"
 #include "base/files/file_enumerator.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
@@ -139,9 +140,8 @@ uint32_t GetStorageMask(const std::vector<std::string>& storage_types) {
 
   uint32_t storage_mask = 0;
   for (const auto& it : storage_types) {
-    auto type = base::ToLowerASCII(it);
-    if (Lookup.contains(type))
-      storage_mask |= Lookup.at(type);
+    if (const uint32_t* val = base::FindOrNull(Lookup, base::ToLowerASCII(it)))
+      storage_mask |= *val;
   }
   return storage_mask;
 }


### PR DESCRIPTION
#### Description of Change

I'm getting close to the end of these double-map-lookup PRs, but here are two fixes.

This one removes double lookups in `GetStorageMask()` and `GetDataTypeMask()`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.