### PR TITLE
chore: adjust PR template to discourage AI PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,7 @@ Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
 
 - [ ] PR description included and stakeholders cc'd
+- [ ] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
 - [ ] `npm test` passes
 - [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
 - [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)


### PR DESCRIPTION
#### Description of Change

We've been flooded with AI PRs recently, and many people on the team are annoyed.

We used to have a problem with people not using our issue templates. When we adjusted our blank issue template and [included a checkbox "I am a maintainer"](https://github.com/electron/electron/pull/45309), we virtually eliminated people using blank issues. People use the correct templates now.

I believe the flood of AI PRs is not due to malice but due to inexperience. Young developers think that Cursor and ChatGPT are how you build software and don't know that AI PRs don't help. (See [Hanlon's razor](https://en.wikipedia.org/wiki/Hanlon%27s_razor): "Never attribute to malice that which is adequately explained by stupidity.")

This PR adds a checkbox to our PR template that asks contributors to confirm that their PRs are not AI-generated.

I think this will kill 50% of AI PRs. Not eliminate them but reduce the burden on the team.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
