### PR TITLE
fix: emit `context-menu` event in Windows draggable regions

### DIFF
--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -6,6 +6,7 @@
 
 #include "base/win/windows_version.h"
 #include "electron/buildflags/buildflags.h"
+#include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/ui/views/win_frame_view.h"
 #include "shell/browser/win/dark_mode.h"
@@ -113,6 +114,12 @@ bool ElectronDesktopWindowTreeHostWin::HandleMouseEvent(ui::MouseEvent* event) {
     bool prevent_default = false;
     native_window_view_->NotifyWindowSystemContextMenu(event->x(), event->y(),
                                                        &prevent_default);
+    // If the user prevents default behavior, emit contextmenu event to
+    // allow bringing up the custom menu.
+    if (prevent_default) {
+      electron::api::WebContents::SetDisableDraggableRegions(true);
+      views::DesktopWindowTreeHostWin::HandleMouseEvent(event);
+    }
     return prevent_default;
   }
 

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2942,8 +2942,13 @@ describe('webContents module', () => {
       expect(contextMenuEmitCount).to.equal(1);
     });
 
-    ifit(process.platform !== 'win32')('emits when right-clicked in page in a draggable region', async () => {
+    it('emits when right-clicked in page in a draggable region', async () => {
       const w = new BrowserWindow({ show: false });
+
+      if (process.platform === 'win32') {
+        w.on('system-context-menu', (event) => { event.preventDefault(); });
+      }
+
       await w.loadFile(path.join(fixturesPath, 'pages', 'draggable-page.html'));
 
       const promise = once(w.webContents, 'context-menu') as Promise<[any, Electron.ContextMenuParams]>;


### PR DESCRIPTION
Backport of #45851

See that PR for details.


Notes: Fixed an issue where `context-menu` event weren't emitted as expected on Windows in draggable regions.