### PR TITLE
perf: avoid a double-map lookup in `NotificationPresenter::RemoveNotification()`

### DIFF
--- a/shell/browser/notifications/notification_presenter.cc
+++ b/shell/browser/notifications/notification_presenter.cc
@@ -27,13 +27,8 @@ base::WeakPtr<Notification> NotificationPresenter::CreateNotification(
 }
 
 void NotificationPresenter::RemoveNotification(Notification* notification) {
-  auto it = notifications_.find(notification);
-  if (it == notifications_.end()) {
-    return;
-  }
-
-  notifications_.erase(notification);
-  delete notification;
+  if (const auto nh = notifications_.extract(notification))
+    delete nh.value();
 }
 
 void NotificationPresenter::CloseNotificationWithId(


### PR DESCRIPTION
#### Description of Change

Yep another remove-a-redundant-map-lookup PR :smile_cat: This time it's in `NotificationPresenter::RemoveNotification()`

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.