### PR TITLE
perf: avoid double map lookup in HidChooserContext::DeviceRemoved()

### DIFF
--- a/shell/browser/hid/hid_chooser_context.cc
+++ b/shell/browser/hid/hid_chooser_context.cc
@@ -253,10 +253,10 @@ void HidChooserContext::DeviceAdded(device::mojom::HidDeviceInfoPtr device) {
 
 void HidChooserContext::DeviceRemoved(device::mojom::HidDeviceInfoPtr device) {
   DCHECK(device);
-  DCHECK(devices_.contains(device->guid));
 
   // Update the device list.
-  devices_.erase(device->guid);
+  const size_t n_erased = devices_.erase(device->guid);
+  DCHECK_EQ(n_erased, 1U);
 
   // Notify all device observers.
   for (auto& observer : device_observer_list_)


### PR DESCRIPTION
#### Description of Change

Remove a redundant map lookup in `HidChooserContext::DeviceRemoved()`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.