### PR TITLE
perf: improve temporaries in `WebWorkerObserver::WorkerScriptReadyForEvaluation()`

### DIFF
--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -4,9 +4,11 @@
 
 #include "shell/renderer/web_worker_observer.h"
 
+#include <string_view>
 #include <utility>
 
 #include "base/no_destructor.h"
+#include "base/strings/strcat.h"
 #include "base/threading/thread_local.h"
 #include "shell/common/api/electron_bindings.h"
 #include "shell/common/gin_helper/event_emitter_caller.h"
@@ -71,15 +73,14 @@ void WebWorkerObserver::WorkerScriptReadyForEvaluation(
   // is loaded. See corresponding change in node/init.ts.
   v8::Local<v8::Object> global = worker_context->Global();
 
-  std::vector<std::string> keys = {"fetch",   "Response", "FormData",
-                                   "Request", "Headers",  "EventSource"};
-  for (const auto& key : keys) {
+  for (const std::string_view key :
+       {"fetch", "Response", "FormData", "Request", "Headers", "EventSource"}) {
     v8::MaybeLocal<v8::Value> value =
-        global->Get(worker_context, gin::StringToV8(isolate, key.c_str()));
+        global->Get(worker_context, gin::StringToV8(isolate, key));
     if (!value.IsEmpty()) {
-      std::string blink_key = "blink" + key;
+      std::string blink_key = base::StrCat({"blink", key});
       global
-          ->Set(worker_context, gin::StringToV8(isolate, blink_key.c_str()),
+          ->Set(worker_context, gin::StringToV8(isolate, blink_key),
                 value.ToLocalChecked())
           .Check();
     }


### PR DESCRIPTION
#### Description of Change

A couple of small cleanups to `WebWorkerObserver::WorkerScriptReadyForEvaluation()`:

- replace a runtime `std::vector<std::string>` local with compile-time `std::string_view`s
- remove `.c_str()` pessimizations when building v8 strings. When we give gin a `string_view` instead of a `char*`,  then it doesn't have to recalculate the string length.

I came across this change while looking for something else :slightly_smiling_face:. It's a small change but worthwhile to move these strings to compile-time.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.