### PR TITLE
perf: prefer `absl::flat_hash_set` over `std::unordered_set`

### DIFF
--- a/shell/browser/api/message_port.cc
+++ b/shell/browser/api/message_port.cc
@@ -5,7 +5,6 @@
 #include "shell/browser/api/message_port.h"
 
 #include <string>
-#include <unordered_set>
 #include <utility>
 
 #include "base/containers/to_vector.h"
@@ -20,6 +19,7 @@
 #include "shell/common/gin_helper/event_emitter_caller.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/v8_util.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
 #include "third_party/blink/public/common/messaging/transferable_message.h"
 #include "third_party/blink/public/common/messaging/transferable_message_mojom_traits.h"
 #include "third_party/blink/public/mojom/messaging/transferable_message.mojom.h"
@@ -226,7 +226,8 @@ std::vector<blink::MessagePortChannel> MessagePort::DisentanglePorts(
   if (ports.empty())
     return {};
 
-  std::unordered_set<MessagePort*> visited;
+  absl::flat_hash_set<MessagePort*> visited;
+  visited.reserve(ports.size());
 
   // Walk the incoming array - if there are any duplicate ports, or null ports
   // or cloned ports, throw an error (per section 8.3.3 of the HTML5 spec).

--- a/shell/renderer/api/electron_api_spell_check_client.cc
+++ b/shell/renderer/api/electron_api_spell_check_client.cc
@@ -8,7 +8,6 @@
 #include <memory>
 #include <set>
 #include <string_view>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -20,6 +19,7 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/function_template.h"
 #include "shell/common/gin_helper/microtasks_scope.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
 #include "third_party/blink/public/web/web_text_checking_completion.h"
 #include "third_party/blink/public/web/web_text_checking_result.h"
 #include "third_party/icu/source/common/unicode/uscript.h"
@@ -182,9 +182,9 @@ void SpellCheckClient::SpellCheckText() {
 
 void SpellCheckClient::OnSpellCheckDone(
     const std::vector<std::u16string>& misspelled_words) {
+  const absl::flat_hash_set<std::u16string> misspelled{misspelled_words.begin(),
+                                                       misspelled_words.end()};
   std::vector<blink::WebTextCheckingResult> results;
-  std::unordered_set<std::u16string> misspelled(misspelled_words.begin(),
-                                                misspelled_words.end());
 
   auto& word_list = pending_request_param_->wordlist();
 


### PR DESCRIPTION
#### Description of Change

Replace our two uses of `std::unordered_set` with `absl::flat_hash_set` instead.

This is a followup to #46202 with the same goals as that PR: to better follow  the [upstream container recommendations](https://source.chromium.org/chromium/chromium/src/+/main:base/containers/README.md)

> Note that this advice never suggests the use of `std::unordered_map` and `std::unordered_set`. These containers provides similar features to the Abseil flat hash containers but with worse performance. They should only be used if absolutely required for compatibility with third-party code.

All reviews welcomed. CC @codebytere who reviewed 46202.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.