### PR TITLE
fix: flicker and ghosting in transparent windows on macOS

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -196,7 +196,7 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   params.type = views::Widget::InitParams::TYPE_WINDOW;
   // Allow painting before shown, to be later disabled in ElectronNSWindow.
   params.headless_mode = true;
-  if (transparent()) {
+  if (IsTranslucent()) {
     params.opacity = views::Widget::InitParams::WindowOpacity::kTranslucent;
   }
   params.native_widget =

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -196,6 +196,9 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   params.type = views::Widget::InitParams::TYPE_WINDOW;
   // Allow painting before shown, to be later disabled in ElectronNSWindow.
   params.headless_mode = true;
+  if (transparent()) {
+    params.opacity = views::Widget::InitParams::WindowOpacity::kTranslucent;
+  }
   params.native_widget =
       new ElectronNativeWidgetMac(this, windowType, styleMask, widget());
   widget()->Init(std::move(params));


### PR DESCRIPTION
#### Description of Change

Transparent windows suffer critical visual issues, including flickering and ghost artifacts. This PR makes the `views::Widget` for macOS windows support transparency when the window is initialized as transparent.

Fixes #45932.

#### Release Notes

Notes: Fixed flickering and ghosting artifacts in transparent windows on macOS.
