### PR TITLE
refactor: remove field `unused weak_factory_`

### DIFF
--- a/shell/browser/api/electron_api_extensions.h
+++ b/shell/browser/api/electron_api_extensions.h
@@ -68,8 +68,6 @@ class Extensions final : public gin::Wrappable<Extensions>,
   }
 
   raw_ptr<content::BrowserContext> browser_context_;
-
-  base::WeakPtrFactory<Extensions> weak_ptr_factory_{this};
 };
 
 }  // namespace api


### PR DESCRIPTION
#### Description of Change

Appears to have been added in e3f61b46 but never used.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.