### PR TITLE
perf: avoid unnecessary vector copy in `GetMimeTypeToExtensionIdMap()`

### DIFF
--- a/shell/browser/plugins/plugin_utils.cc
+++ b/shell/browser/plugins/plugin_utils.cc
@@ -55,8 +55,10 @@ PluginUtils::GetMimeTypeToExtensionIdMap(
 
     if (MimeTypesHandler* handler = MimeTypesHandler::GetHandler(extension)) {
       for (const auto& supported_mime_type : handler->mime_type_set()) {
-        DCHECK(!mime_type_to_extension_id_map.contains(supported_mime_type));
-        mime_type_to_extension_id_map[supported_mime_type] = extension_id;
+        const auto [_, inserted] =
+            mime_type_to_extension_id_map.insert_or_assign(supported_mime_type,
+                                                           extension_id);
+        DCHECK(inserted);
       }
     }
   }

--- a/shell/browser/plugins/plugin_utils.cc
+++ b/shell/browser/plugins/plugin_utils.cc
@@ -35,15 +35,18 @@ PluginUtils::GetMimeTypeToExtensionIdMap(
     content::BrowserContext* browser_context) {
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   const auto& allowed_extension_ids = MimeTypesHandler::GetMIMETypeAllowlist();
+  if (allowed_extension_ids.empty())
+    return {};
+
+  const auto& enabled_extensions =
+      extensions::ExtensionRegistry::Get(browser_context)->enabled_extensions();
 
   base::flat_map<std::string, std::string> mime_type_to_extension_id_map;
   // Go through the white-listed extensions and try to use them to intercept
   // the URL request.
   for (const std::string& extension_id : allowed_extension_ids) {
     const extensions::Extension* extension =
-        extensions::ExtensionRegistry::Get(browser_context)
-            ->enabled_extensions()
-            .GetByID(extension_id);
+        enabled_extensions.GetByID(extension_id);
     // The white-listed extension may not be installed, so we have to nullptr
     // check |extension|.
     if (!extension) {

--- a/shell/browser/plugins/plugin_utils.cc
+++ b/shell/browser/plugins/plugin_utils.cc
@@ -33,10 +33,10 @@ std::string PluginUtils::GetExtensionIdForMimeType(
 base::flat_map<std::string, std::string>
 PluginUtils::GetMimeTypeToExtensionIdMap(
     content::BrowserContext* browser_context) {
-  base::flat_map<std::string, std::string> mime_type_to_extension_id_map;
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  std::vector<std::string> allowed_extension_ids =
-      MimeTypesHandler::GetMIMETypeAllowlist();
+  const auto& allowed_extension_ids = MimeTypesHandler::GetMIMETypeAllowlist();
+
+  base::flat_map<std::string, std::string> mime_type_to_extension_id_map;
   // Go through the white-listed extensions and try to use them to intercept
   // the URL request.
   for (const std::string& extension_id : allowed_extension_ids) {
@@ -58,5 +58,6 @@ PluginUtils::GetMimeTypeToExtensionIdMap(
     }
   }
 #endif
+
   return mime_type_to_extension_id_map;
 }

--- a/shell/browser/plugins/plugin_utils.cc
+++ b/shell/browser/plugins/plugin_utils.cc
@@ -53,7 +53,8 @@ PluginUtils::GetMimeTypeToExtensionIdMap(
       continue;
     }
 
-    if (MimeTypesHandler* handler = MimeTypesHandler::GetHandler(extension)) {
+    if (const MimeTypesHandler* handler =
+            MimeTypesHandler::GetHandler(extension)) {
       for (const auto& supported_mime_type : handler->mime_type_set()) {
         const auto [_, inserted] =
             mime_type_to_extension_id_map.insert_or_assign(supported_mime_type,

--- a/shell/browser/plugins/plugin_utils.cc
+++ b/shell/browser/plugins/plugin_utils.cc
@@ -38,27 +38,23 @@ PluginUtils::GetMimeTypeToExtensionIdMap(
   if (allowed_extension_ids.empty())
     return {};
 
-  const auto& enabled_extensions =
+  const extensions::ExtensionSet& enabled_extensions =
       extensions::ExtensionRegistry::Get(browser_context)->enabled_extensions();
 
   base::flat_map<std::string, std::string> mime_type_to_extension_id_map;
+
   // Go through the white-listed extensions and try to use them to intercept
   // the URL request.
-  for (const std::string& extension_id : allowed_extension_ids) {
-    const extensions::Extension* extension =
-        enabled_extensions.GetByID(extension_id);
-    // The white-listed extension may not be installed, so we have to nullptr
-    // check |extension|.
-    if (!extension) {
+  for (const std::string& id : allowed_extension_ids) {
+    const extensions::Extension* extension = enabled_extensions.GetByID(id);
+    if (!extension)  // extension might not be installed, so check for nullptr
       continue;
-    }
 
     if (const MimeTypesHandler* handler =
             MimeTypesHandler::GetHandler(extension)) {
-      for (const auto& supported_mime_type : handler->mime_type_set()) {
+      for (const std::string& mime_type : handler->mime_type_set()) {
         const auto [_, inserted] =
-            mime_type_to_extension_id_map.insert_or_assign(supported_mime_type,
-                                                           extension_id);
+            mime_type_to_extension_id_map.insert_or_assign(mime_type, id);
         DCHECK(inserted);
       }
     }


### PR DESCRIPTION
#### Description of Change

Refactor `GetMimeTypeToExtensionIdMap()` to avoid some unnecessary work:

- `GetMIMETypeAllowlist()` returns a `const&`, so keep a reference instead of cloning it
- Move the `ExtensionRegistry::Get(browser_context)` call outside of the loop
- Remove redundant map lookups

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.