### PR TITLE
fix: the issue where rounded corners disappear momentarily when closing on Windows 11

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -381,8 +381,7 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
 
     bool rounded_corner = true;
     options.Get(options::kRoundedCorners, &rounded_corner);
-    if (!rounded_corner)
-      SetRoundedCorners(false);
+    SetRoundedCorners(rounded_corner);
   }
 
   LONG ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);


### PR DESCRIPTION
#### Description of Change
fix #45643

Explicitly set rounded corners in borderless mode.


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->

https://github.com/user-attachments/assets/181b80cd-fb4b-4d4d-b7c3-2fd54a93f783

