### PR TITLE
fix: leaked `gfx::Canvas` in `AutofillPopupView::OnPaint()`

### DIFF
--- a/shell/browser/ui/views/autofill_popup_view.cc
+++ b/shell/browser/ui/views/autofill_popup_view.cc
@@ -242,8 +242,8 @@ void AutofillPopupView::OnPaint(gfx::Canvas* canvas) {
 
   std::unique_ptr<cc::SkiaPaintCanvas> paint_canvas;
   if (view_proxy_.get()) {
-    bitmap.allocN32Pixels(popup_->popup_bounds_in_view().width(),
-                          popup_->popup_bounds_in_view().height(), true);
+    const auto bounds = popup_->popup_bounds_in_view();
+    bitmap.allocN32Pixels(bounds.width(), bounds.height(), true);
     paint_canvas = std::make_unique<cc::SkiaPaintCanvas>(bitmap);
     draw_canvas = new gfx::Canvas(paint_canvas.get(), 1.0);
   }

--- a/shell/browser/ui/views/autofill_popup_view.cc
+++ b/shell/browser/ui/views/autofill_popup_view.cc
@@ -238,7 +238,6 @@ void AutofillPopupView::DoUpdateBoundsAndRedrawPopup() {
 void AutofillPopupView::OnPaint(gfx::Canvas* canvas) {
   if (!popup_ || static_cast<size_t>(popup_->line_count()) != children().size())
     return;
-  gfx::Canvas* draw_canvas = canvas;
   SkBitmap bitmap;
 
   std::optional<cc::SkiaPaintCanvas> offscreen_paint_canvas;
@@ -248,17 +247,17 @@ void AutofillPopupView::OnPaint(gfx::Canvas* canvas) {
     bitmap.allocN32Pixels(bounds.width(), bounds.height(), true);
     offscreen_paint_canvas.emplace(bitmap);
     offscreen_draw_canvas.emplace(&offscreen_paint_canvas.value(), 1.0);
-    draw_canvas = &offscreen_draw_canvas.value();
+    canvas = &offscreen_draw_canvas.value();
   }
 
-  draw_canvas->DrawColor(
+  canvas->DrawColor(
       GetColorProvider()->GetColor(ui::kColorResultsTableNormalBackground));
-  OnPaintBorder(draw_canvas);
+  OnPaintBorder(canvas);
 
   for (int i = 0; i < popup_->line_count(); ++i) {
     gfx::Rect line_rect = popup_->GetRowBounds(i);
 
-    DrawAutofillEntry(draw_canvas, i, line_rect);
+    DrawAutofillEntry(canvas, i, line_rect);
   }
 
   if (view_proxy_) {

--- a/shell/browser/ui/views/autofill_popup_view.cc
+++ b/shell/browser/ui/views/autofill_popup_view.cc
@@ -243,8 +243,7 @@ void AutofillPopupView::OnPaint(gfx::Canvas* canvas) {
 
   std::optional<cc::SkiaPaintCanvas> offscreen_paint_canvas;
   std::optional<gfx::Canvas> offscreen_draw_canvas;
-
-  if (view_proxy_.get()) {
+  if (view_proxy_) {
     const auto bounds = popup_->popup_bounds_in_view();
     bitmap.allocN32Pixels(bounds.width(), bounds.height(), true);
     offscreen_paint_canvas.emplace(bitmap);
@@ -262,7 +261,7 @@ void AutofillPopupView::OnPaint(gfx::Canvas* canvas) {
     DrawAutofillEntry(draw_canvas, i, line_rect);
   }
 
-  if (view_proxy_.get()) {
+  if (view_proxy_) {
     view_proxy_->SetBounds(popup_->popup_bounds_in_view());
     view_proxy_->SetBitmap(bitmap);
   }

--- a/shell/browser/ui/views/autofill_popup_view.cc
+++ b/shell/browser/ui/views/autofill_popup_view.cc
@@ -239,12 +239,14 @@ void AutofillPopupView::OnPaint(gfx::Canvas* canvas) {
   if (!popup_ || static_cast<size_t>(popup_->line_count()) != children().size())
     return;
 
+  gfx::Rect offscreen_bounds;
   SkBitmap offscreen_bitmap;
   std::optional<cc::SkiaPaintCanvas> offscreen_paint_canvas;
   std::optional<gfx::Canvas> offscreen_draw_canvas;
   if (view_proxy_) {
-    const auto bounds = popup_->popup_bounds_in_view();
-    offscreen_bitmap.allocN32Pixels(bounds.width(), bounds.height(), true);
+    offscreen_bounds = popup_->popup_bounds_in_view();
+    offscreen_bitmap.allocN32Pixels(offscreen_bounds.width(),
+                                    offscreen_bounds.height(), true);
     offscreen_paint_canvas.emplace(offscreen_bitmap);
     offscreen_draw_canvas.emplace(&offscreen_paint_canvas.value(), 1.0);
     canvas = &offscreen_draw_canvas.value();
@@ -261,7 +263,7 @@ void AutofillPopupView::OnPaint(gfx::Canvas* canvas) {
   }
 
   if (view_proxy_) {
-    view_proxy_->SetBounds(popup_->popup_bounds_in_view());
+    view_proxy_->SetBounds(offscreen_bounds);
     view_proxy_->SetBitmap(offscreen_bitmap);
   }
 }

--- a/shell/browser/ui/views/autofill_popup_view.cc
+++ b/shell/browser/ui/views/autofill_popup_view.cc
@@ -238,14 +238,14 @@ void AutofillPopupView::DoUpdateBoundsAndRedrawPopup() {
 void AutofillPopupView::OnPaint(gfx::Canvas* canvas) {
   if (!popup_ || static_cast<size_t>(popup_->line_count()) != children().size())
     return;
-  SkBitmap bitmap;
 
+  SkBitmap offscreen_bitmap;
   std::optional<cc::SkiaPaintCanvas> offscreen_paint_canvas;
   std::optional<gfx::Canvas> offscreen_draw_canvas;
   if (view_proxy_) {
     const auto bounds = popup_->popup_bounds_in_view();
-    bitmap.allocN32Pixels(bounds.width(), bounds.height(), true);
-    offscreen_paint_canvas.emplace(bitmap);
+    offscreen_bitmap.allocN32Pixels(bounds.width(), bounds.height(), true);
+    offscreen_paint_canvas.emplace(offscreen_bitmap);
     offscreen_draw_canvas.emplace(&offscreen_paint_canvas.value(), 1.0);
     canvas = &offscreen_draw_canvas.value();
   }
@@ -262,7 +262,7 @@ void AutofillPopupView::OnPaint(gfx::Canvas* canvas) {
 
   if (view_proxy_) {
     view_proxy_->SetBounds(popup_->popup_bounds_in_view());
-    view_proxy_->SetBitmap(bitmap);
+    view_proxy_->SetBitmap(offscreen_bitmap);
   }
 }
 

--- a/shell/browser/ui/views/autofill_popup_view.cc
+++ b/shell/browser/ui/views/autofill_popup_view.cc
@@ -5,6 +5,7 @@
 #include "shell/browser/ui/views/autofill_popup_view.h"
 
 #include <memory>
+#include <optional>
 #include <utility>
 
 #include "base/functional/bind.h"
@@ -240,12 +241,13 @@ void AutofillPopupView::OnPaint(gfx::Canvas* canvas) {
   gfx::Canvas* draw_canvas = canvas;
   SkBitmap bitmap;
 
-  std::unique_ptr<cc::SkiaPaintCanvas> paint_canvas;
+  std::optional<cc::SkiaPaintCanvas> offscreen_paint_canvas;
+
   if (view_proxy_.get()) {
     const auto bounds = popup_->popup_bounds_in_view();
     bitmap.allocN32Pixels(bounds.width(), bounds.height(), true);
-    paint_canvas = std::make_unique<cc::SkiaPaintCanvas>(bitmap);
-    draw_canvas = new gfx::Canvas(paint_canvas.get(), 1.0);
+    offscreen_paint_canvas.emplace(bitmap);
+    draw_canvas = new gfx::Canvas(&offscreen_paint_canvas.value(), 1.0);
   }
 
   draw_canvas->DrawColor(

--- a/shell/browser/ui/views/autofill_popup_view.cc
+++ b/shell/browser/ui/views/autofill_popup_view.cc
@@ -242,12 +242,14 @@ void AutofillPopupView::OnPaint(gfx::Canvas* canvas) {
   SkBitmap bitmap;
 
   std::optional<cc::SkiaPaintCanvas> offscreen_paint_canvas;
+  std::optional<gfx::Canvas> offscreen_draw_canvas;
 
   if (view_proxy_.get()) {
     const auto bounds = popup_->popup_bounds_in_view();
     bitmap.allocN32Pixels(bounds.width(), bounds.height(), true);
     offscreen_paint_canvas.emplace(bitmap);
-    draw_canvas = new gfx::Canvas(&offscreen_paint_canvas.value(), 1.0);
+    offscreen_draw_canvas.emplace(&offscreen_paint_canvas.value(), 1.0);
+    draw_canvas = &offscreen_draw_canvas.value();
   }
 
   draw_canvas->DrawColor(


### PR DESCRIPTION
#### Description of Change

Fix a memory leak in AutofillPopupView.

A `gfx::Canvas` was leaked each time `AutofillPopupView::OnPaint()` was called when the popup view had an `OffscreenViewProxy`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed memory leak in AutofillPopupView.