### PR TITLE
perf: avoid redundant map lookup in UsbChooserContext::OnDeviceRemoved()

### DIFF
--- a/shell/browser/usb/usb_chooser_context.cc
+++ b/shell/browser/usb/usb_chooser_context.cc
@@ -302,8 +302,8 @@ void UsbChooserContext::OnDeviceRemoved(
   }
 
   // Update the device list.
-  DCHECK(devices_.contains(device_info->guid));
-  devices_.erase(device_info->guid);
+  const size_t n_erased = devices_.erase(device_info->guid);
+  DCHECK_EQ(n_erased, 1U);
 
   // Notify all device observers.
   for (auto& observer : device_observer_list_)


### PR DESCRIPTION
#### Description of Change

Avoid a redundant map lookup in `UsbChooserContext::OnDeviceRemoved()`.

All reviews welcomed. CC @codebytere who reviewed [this PR's sibling](https://github.com/electron/electron/pull/46343) :smile_cat: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.