### PR TITLE
fix: WeakPtr crash in `WebContents::DevToolsOpened()`

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2155,8 +2155,10 @@ void WebContents::DevToolsOpened() {
   // Inherit owner window in devtools when it doesn't have one.
   auto* devtools = inspectable_web_contents_->GetDevToolsWebContents();
   bool has_window = devtools->GetUserData(NativeWindowRelay::UserDataKey());
-  if (owner_window() && !has_window)
-    handle->SetOwnerWindow(devtools, owner_window());
+  if (!has_window) {
+    if (const auto* window = owner_window())
+      handle->SetOwnerWindow(devtools, window);
+  }
 
   Emit("devtools-opened");
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/34042.

Fairly sure what's happening here is that the owner window is getting destroyed but the WeakPtr hasn't been cleared yet, so `owner_window()` is returning a dangling pointer, leading to a crash when `SetOwnerWindow()` tries to use it.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none