### PR TITLE
perf: cache the return value of `IsX11()`

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -163,10 +163,11 @@ gfx::Size WindowSizeToContentSizeBuggy(HWND hwnd, const gfx::Size& size) {
 
 #endif
 
-[[maybe_unused]] bool IsX11() {
-  return ui::OzonePlatform::GetInstance()
-      ->GetPlatformProperties()
-      .electron_can_call_x11;
+[[nodiscard]] bool IsX11() {
+  static const bool is_x11 = ui::OzonePlatform::GetInstance()
+                                 ->GetPlatformProperties()
+                                 .electron_can_call_x11;
+  return is_x11;
 }
 
 class NativeWindowClientView : public views::ClientView {

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -163,7 +163,7 @@ gfx::Size WindowSizeToContentSizeBuggy(HWND hwnd, const gfx::Size& size) {
 
 #endif
 
-[[nodiscard]] bool IsX11() {
+[[maybe_unused, nodiscard]] bool IsX11() {
   static const bool is_x11 = ui::OzonePlatform::GetInstance()
                                  ->GetPlatformProperties()
                                  .electron_can_call_x11;


### PR DESCRIPTION
#### Description of Change

The return value of `IsX11()` isn't ever going to change during an Electron session, and it's cheap to cache the return value in a `static const bool`, so let's do that instead of re-running the test every time the function is called.

Also, add a `[[nodiscard]]` annotation to indicate that callers should use the return value.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.