### PR TITLE
perf: avoid redundant call to virtual methods GetProcess() and GetID()

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1788,19 +1788,18 @@ void WebContents::FrameDeleted(content::FrameTreeNodeId frame_tree_node_id) {
 }
 
 void WebContents::RenderViewDeleted(content::RenderViewHost* render_view_host) {
+  const auto id = render_view_host->GetProcess()->GetID().GetUnsafeValue();
   // This event is necessary for tracking any states with respect to
   // intermediate render view hosts aka speculative render view hosts. Currently
   // used by object-registry.js to ref count remote objects.
-  Emit("render-view-deleted",
-       render_view_host->GetProcess()->GetID().GetUnsafeValue());
+  Emit("render-view-deleted", id);
 
   if (web_contents()->GetRenderViewHost() == render_view_host) {
     // When the RVH that has been deleted is the current RVH it means that the
     // the web contents are being closed. This is communicated by this event.
     // Currently tracked by guest-window-manager.ts to destroy the
     // BrowserWindow.
-    Emit("current-render-view-deleted",
-         render_view_host->GetProcess()->GetID().GetUnsafeValue());
+    Emit("current-render-view-deleted", id);
   }
 }
 


### PR DESCRIPTION
#### Description of Change

Another speed-things-up-a-little-by-not-doing-the-same-thing-twice PR.

This one is similar to #46339: don't call virtual methods `RenderViewHost::GetProcess()` and `RenderProcessHost::GetID()` twice in a row when one time will do. 

All reviews welcome. CC @VerteDinde who reviewed #46339.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none