### PR TITLE
perf: prefer `absl::flat_hash_set` over `std::set` when sorted order is not needed

### DIFF
--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -9,7 +9,6 @@
 #include <memory>
 #include <optional>
 #include <queue>
-#include <set>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -23,6 +22,7 @@
 #include "content/public/browser/web_contents_user_data.h"
 #include "extensions/browser/app_window/size_constraints.h"
 #include "shell/browser/native_window_observer.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
 #include "ui/views/widget/widget_delegate.h"
 
 class SkRegion;
@@ -515,7 +515,8 @@ class NativeWindow : public base::SupportsUserData,
   // Observers of this window.
   base::ObserverList<NativeWindowObserver> observers_;
 
-  std::set<BackgroundThrottlingSource*> background_throttling_sources_;
+  absl::flat_hash_set<BackgroundThrottlingSource*>
+      background_throttling_sources_;
 
   // Accessible title.
   std::u16string accessible_title_;

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -9,11 +9,11 @@
 
 #include <memory>
 #include <optional>
-#include <set>
 #include <string>
 
 #include "base/memory/raw_ptr.h"
 #include "shell/browser/ui/views/root_view.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
 #include "ui/base/ozone_buildflags.h"
 #include "ui/views/controls/webview/unhandled_keyboard_event_handler.h"
 #include "ui/views/widget/widget_observer.h"
@@ -283,7 +283,7 @@ class NativeWindowViews : public NativeWindow,
   base::win::ScopedGDIObject<HICON> app_icon_;
 
   // The set of windows currently forwarding mouse messages.
-  static std::set<NativeWindowViews*> forwarding_windows_;
+  static inline absl::flat_hash_set<NativeWindowViews*> forwarding_windows_;
   static HHOOK mouse_hook_;
   bool forwarding_mouse_messages_ = false;
   HWND legacy_window_ = nullptr;

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -224,7 +224,6 @@ bool IsScreenReaderActive() {
 
 }  // namespace
 
-std::set<NativeWindowViews*> NativeWindowViews::forwarding_windows_;
 HHOOK NativeWindowViews::mouse_hook_ = nullptr;
 
 bool NativeWindowViews::ExecuteWindowsCommand(int command_id) {

--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -6,7 +6,6 @@
 #define ELECTRON_SHELL_BROWSER_OSR_OSR_RENDER_WIDGET_HOST_VIEW_H_
 
 #include <memory>
-#include <set>
 #include <string>
 #include <vector>
 
@@ -28,6 +27,7 @@
 #include "shell/browser/osr/osr_host_display_client.h"
 #include "shell/browser/osr/osr_video_consumer.h"
 #include "shell/browser/osr/osr_view_proxy.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
 #include "third_party/blink/public/mojom/widget/record_content_to_visible_time_request.mojom-forward.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/base/ime/text_input_client.h"
@@ -277,8 +277,8 @@ class OffScreenRenderWidgetHostView
   raw_ptr<OffScreenRenderWidgetHostView> parent_host_view_ = nullptr;
   raw_ptr<OffScreenRenderWidgetHostView> popup_host_view_ = nullptr;
   raw_ptr<OffScreenRenderWidgetHostView> child_host_view_ = nullptr;
-  std::set<OffScreenRenderWidgetHostView*> guest_host_views_;
-  std::set<OffscreenViewProxy*> proxy_views_;
+  absl::flat_hash_set<OffScreenRenderWidgetHostView*> guest_host_views_;
+  absl::flat_hash_set<OffscreenViewProxy*> proxy_views_;
 
   const bool transparent_;
   const bool offscreen_use_shared_texture_;

--- a/shell/browser/ui/views/global_menu_bar_registrar_x11.h
+++ b/shell/browser/ui/views/global_menu_bar_registrar_x11.h
@@ -7,10 +7,9 @@
 
 #include <gio/gio.h>
 
-#include <set>
-
 #include "base/memory/raw_ptr.h"
 #include "base/memory/singleton.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
 #include "ui/base/glib/scoped_gsignal.h"
 #include "ui/gfx/x/xproto.h"
 
@@ -52,7 +51,7 @@ class GlobalMenuBarRegistrarX11 {
 
   // x11::Window which want to be registered, but haven't yet been because
   // we're waiting for the proxy to become available.
-  std::set<x11::Window> live_windows_;
+  absl::flat_hash_set<x11::Window> live_windows_;
   ScopedGSignal signal_;
 };
 

--- a/shell/browser/usb/usb_chooser_context.h
+++ b/shell/browser/usb/usb_chooser_context.h
@@ -6,7 +6,6 @@
 #define ELECTRON_SHELL_BROWSER_USB_USB_CHOOSER_CONTEXT_H_
 
 #include <map>
-#include <set>
 #include <string>
 #include <vector>
 
@@ -20,6 +19,7 @@
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/device/public/mojom/usb_manager.mojom.h"
 #include "services/device/public/mojom/usb_manager_client.mojom.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
 #include "url/origin.h"
 
 namespace mojo {
@@ -108,7 +108,7 @@ class UsbChooserContext : public KeyedService,
   base::queue<device::mojom::UsbDeviceManager::GetDevicesCallback>
       pending_get_devices_requests_;
 
-  std::map<url::Origin, std::set<std::string>> ephemeral_devices_;
+  std::map<url::Origin, absl::flat_hash_set<std::string>> ephemeral_devices_;
   std::map<std::string, device::mojom::UsbDeviceInfoPtr> devices_;
 
   // Connection to |device_manager_instance_|.

--- a/shell/renderer/electron_sandboxed_renderer_client.h
+++ b/shell/renderer/electron_sandboxed_renderer_client.h
@@ -5,9 +5,9 @@
 #define ELECTRON_SHELL_RENDERER_ELECTRON_SANDBOXED_RENDERER_CLIENT_H_
 
 #include <memory>
-#include <set>
 
 #include "shell/renderer/renderer_client_base.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
 
 namespace base {
 class ProcessMetrics;
@@ -64,7 +64,7 @@ class ElectronSandboxedRendererClient : public RendererClientBase {
   // Getting main script context from web frame would lazily initializes
   // its script context. Doing so in a web page without scripts would trigger
   // assertion, so we have to keep a book of injected web frames.
-  std::set<content::RenderFrame*> injected_frames_;
+  absl::flat_hash_set<content::RenderFrame*> injected_frames_;
 };
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

Part 3 of a small series to find places where we should migrate code to `absl::flat_hash_set` and `absl::flat_hash_map` to follow [upstream container recommendations](https://source.chromium.org/chromium/chromium/src/+/main:base/containers/README.md). Previously: #46202, #46348

This PR takes instances where we are using `std::set` but don't care about sorted order -- e.g. when we're holding a set of pointers -- and migrates them to `absl::flat_hash_set`.

All reviews welcomed. CC @codebytere and @clavin who reviewed 46202 and 46348.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.