### PR TITLE
fix: gin_helper::Promise in GPUInfoManager must be destroyed before destroying Node/V8

### DIFF
--- a/shell/browser/api/gpuinfo_manager.cc
+++ b/shell/browser/api/gpuinfo_manager.cc
@@ -17,7 +17,9 @@
 namespace electron {
 
 GPUInfoManager* GPUInfoManager::GetInstance() {
-  return base::Singleton<GPUInfoManager>::get();
+  // will be deleted by CleanedUpAtExit::DoCleanup
+  static GPUInfoManager* instance = new GPUInfoManager();
+  return instance;
 }
 
 GPUInfoManager::GPUInfoManager()

--- a/shell/browser/api/gpuinfo_manager.h
+++ b/shell/browser/api/gpuinfo_manager.h
@@ -34,6 +34,8 @@ class GPUInfoManager : private content::GpuDataManagerObserver {
   void FetchCompleteInfo(gin_helper::Promise<base::Value> promise);
   void FetchBasicInfo(gin_helper::Promise<base::Value> promise);
 
+  void Shutdown() { complete_info_promise_set_.clear(); }
+
  private:
   // content::GpuDataManagerObserver
   void OnGpuInfoUpdate() override;

--- a/shell/browser/api/gpuinfo_manager.h
+++ b/shell/browser/api/gpuinfo_manager.h
@@ -11,6 +11,7 @@
 #include "content/browser/gpu/gpu_data_manager_impl.h"  // nogncheck
 #include "content/public/browser/gpu_data_manager.h"
 #include "content/public/browser/gpu_data_manager_observer.h"
+#include "shell/common/gin_helper/cleaned_up_at_exit.h"
 
 namespace gin_helper {
 template <typename T>
@@ -20,7 +21,8 @@ class Promise;
 namespace electron {
 
 // GPUInfoManager is a singleton used to manage and fetch GPUInfo
-class GPUInfoManager : private content::GpuDataManagerObserver {
+class GPUInfoManager : private content::GpuDataManagerObserver,
+                       public gin_helper::CleanedUpAtExit {
  public:
   static GPUInfoManager* GetInstance();
 
@@ -33,8 +35,6 @@ class GPUInfoManager : private content::GpuDataManagerObserver {
 
   void FetchCompleteInfo(gin_helper::Promise<base::Value> promise);
   void FetchBasicInfo(gin_helper::Promise<base::Value> promise);
-
-  void Shutdown() { complete_info_promise_set_.clear(); }
 
  private:
   // content::GpuDataManagerObserver

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -47,6 +47,7 @@
 #include "services/tracing/public/cpp/stack_sampling/tracing_sampler_profiler.h"
 #include "shell/app/electron_main_delegate.h"
 #include "shell/browser/api/electron_api_utility_process.h"
+#include "shell/browser/api/gpuinfo_manager.h"
 #include "shell/browser/browser.h"
 #include "shell/browser/browser_process_impl.h"
 #include "shell/browser/electron_browser_client.h"
@@ -587,6 +588,9 @@ void ElectronBrowserMainParts::PostMainMessageLoopRun() {
         utility_process_wrapper->Shutdown(0 /* exit_code */);
     }
   }
+
+  // Destroy all promises in GPUInfoManager before destroying Node/V8.
+  GPUInfoManager::GetInstance()->Shutdown();
 
   // Destroy node platform after all destructors_ are executed, as they may
   // invoke Node/V8 APIs inside them.

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -47,7 +47,6 @@
 #include "services/tracing/public/cpp/stack_sampling/tracing_sampler_profiler.h"
 #include "shell/app/electron_main_delegate.h"
 #include "shell/browser/api/electron_api_utility_process.h"
-#include "shell/browser/api/gpuinfo_manager.h"
 #include "shell/browser/browser.h"
 #include "shell/browser/browser_process_impl.h"
 #include "shell/browser/electron_browser_client.h"
@@ -588,9 +587,6 @@ void ElectronBrowserMainParts::PostMainMessageLoopRun() {
         utility_process_wrapper->Shutdown(0 /* exit_code */);
     }
   }
-
-  // Destroy all promises in GPUInfoManager before destroying Node/V8.
-  GPUInfoManager::GetInstance()->Shutdown();
 
   // Destroy node platform after all destructors_ are executed, as they may
   // invoke Node/V8 APIs inside them.


### PR DESCRIPTION
#### Description of Change

Fixes #46433

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: fix crash on application exit with pending `app.getGPUInfo` promise
