### PR TITLE
fix: destroy parent port backend when JS env exits

### DIFF
--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -96,6 +96,7 @@ NodeService::NodeService(
 NodeService::~NodeService() {
   if (!node_env_stopped_) {
     node_env_->set_trace_sync_io(false);
+    ParentPort::GetInstance()->Close();
     js_env_->DestroyMicrotasksRunner();
     node::Stop(node_env_.get(), node::StopFlags::kDoNotTerminateIsolate);
   }
@@ -147,6 +148,7 @@ void NodeService::Initialize(
       node_env_.get(), [this](node::Environment* env, int exit_code) {
         // Destroy node platform.
         env->set_trace_sync_io(false);
+        ParentPort::GetInstance()->Close();
         js_env_->DestroyMicrotasksRunner();
         node::Stop(env, node::StopFlags::kDoNotTerminateIsolate);
         node_env_stopped_ = true;

--- a/shell/services/node/parent_port.cc
+++ b/shell/services/node/parent_port.cc
@@ -23,8 +23,8 @@ namespace electron {
 gin::WrapperInfo ParentPort::kWrapperInfo = {gin::kEmbedderNativeGin};
 
 ParentPort* ParentPort::GetInstance() {
-  static base::NoDestructor<ParentPort> instance;
-  return instance.get();
+  static ParentPort* instance = new ParentPort();
+  return instance;
 }
 
 ParentPort::ParentPort() = default;

--- a/shell/services/node/parent_port.h
+++ b/shell/services/node/parent_port.h
@@ -51,9 +51,10 @@ class ParentPort final : public gin::Wrappable<ParentPort>,
       v8::Isolate* isolate) override;
   const char* GetTypeName() override;
 
+  void Close();
+
  private:
   void PostMessage(v8::Local<v8::Value> message_value);
-  void Close();
   void Start();
   void Pause();
 

--- a/shell/services/node/parent_port.h
+++ b/shell/services/node/parent_port.h
@@ -10,6 +10,7 @@
 #include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/connector.h"
 #include "mojo/public/cpp/bindings/message.h"
+#include "shell/common/gin_helper/cleaned_up_at_exit.h"
 #include "third_party/blink/public/common/messaging/message_port_descriptor.h"
 
 namespace v8 {
@@ -31,6 +32,7 @@ namespace electron {
 // for the lifetime of a Utility Process which
 // also means that GC lifecycle is ignored by this class.
 class ParentPort final : public gin::Wrappable<ParentPort>,
+                         public gin_helper::CleanedUpAtExit,
                          private mojo::MessageReceiver {
  public:
   static ParentPort* GetInstance();


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/microsoft/vscode/issues/243957.
Refs https://github.com/electron/electron/pull/39335.

We previously added this change to `MessagePort` but did not do the same for `ParentPort`, and it seems it is subject to the same potential issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix a potential crash in `parentPort`.
