### PR TITLE
perf: improve temporaries in `WebWorkerObserver::WorkerScriptReadyForEvaluation()` (33-x-y)

### DIFF
--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -4,10 +4,12 @@
 
 #include "shell/renderer/web_worker_observer.h"
 
+#include <string_view>
 #include <utility>
 
 #include "base/no_destructor.h"
 #include "base/ranges/algorithm.h"
+#include "base/strings/strcat.h"
 #include "base/threading/thread_local.h"
 #include "shell/common/api/electron_bindings.h"
 #include "shell/common/gin_helper/event_emitter_caller.h"
@@ -70,15 +72,14 @@ void WebWorkerObserver::WorkerScriptReadyForEvaluation(
   // is loaded. See corresponding change in node/init.ts.
   v8::Local<v8::Object> global = worker_context->Global();
 
-  std::vector<std::string> keys = {"fetch",   "Response", "FormData",
-                                   "Request", "Headers",  "EventSource"};
-  for (const auto& key : keys) {
+  for (const std::string_view key :
+       {"fetch", "Response", "FormData", "Request", "Headers", "EventSource"}) {
     v8::MaybeLocal<v8::Value> value =
-        global->Get(worker_context, gin::StringToV8(isolate, key.c_str()));
+        global->Get(worker_context, gin::StringToV8(isolate, key));
     if (!value.IsEmpty()) {
-      std::string blink_key = "blink" + key;
+      std::string blink_key = base::StrCat({"blink", key});
       global
-          ->Set(worker_context, gin::StringToV8(isolate, blink_key.c_str()),
+          ->Set(worker_context, gin::StringToV8(isolate, blink_key),
                 value.ToLocalChecked())
           .Check();
     }


### PR DESCRIPTION
Manually backport #46347 to 33-x-y. See that PR for details.

Notes: none.