### PR TITLE
build: discourage issue filing by end users in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,6 +14,8 @@ body:
         required: true
       - label: I have searched the [issue tracker](https://www.github.com/electron/electron/issues) for a bug report that matches the one I want to file, without success.
         required: true
+      - label: I am an app developer, not an end user. (End users, please report issues to the app developer.)
+        required: true
 - type: input
   attributes:
     label: Electron Version


### PR DESCRIPTION
#### Description of Change

As suggested by @MarshallOfSound during wg-releases meeting.

Should reduce the amount of issues filed by end users.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
