### PR TITLE
fix: `NativeWindowViews::GetRestoredState()` can return wrong state when maximized

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1839,7 +1839,7 @@ ui::mojom::WindowShowState NativeWindowViews::GetRestoredState() {
       return ui::mojom::WindowShowState::kMaximized;
     }
 #else
-    return ui::mojom::WindowShowState::kMinimized;
+    return ui::mojom::WindowShowState::kMaximized;
 #endif
   }
 


### PR DESCRIPTION
#### Description of Change

Fix a bug where `NativeWindowViews::GetRestoredState()` could return the wrong state for maximized windows on Linux.

Introduced by the af58931 Chromium 131.0.6744.0 roll, specifically [this change](https://github.com/electron/electron/commit/9840662#diff-f9d7ef71aadb519c42f18e9c0170137f634f267d72036ab62c3c9e4548c266e0L1787-L1788). Since this was part of the 131 roll, it needs to be backported to Electron 34 and higher.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a bug that could cause some maximized windows on Linux to report an incorrect window state.