### PR TITLE
perf: avoid redundant map lookup in `HidChooserContext::DeviceChanged()`

### DIFF
--- a/shell/browser/hid/hid_chooser_context.cc
+++ b/shell/browser/hid/hid_chooser_context.cc
@@ -274,10 +274,11 @@ void HidChooserContext::DeviceRemoved(device::mojom::HidDeviceInfoPtr device) {
 
 void HidChooserContext::DeviceChanged(device::mojom::HidDeviceInfoPtr device) {
   DCHECK(device);
-  DCHECK(devices_.contains(device->guid));
 
   // Update the device list.
-  devices_[device->guid] = device->Clone();
+  auto& mapped = devices_[device->guid];
+  DCHECK(!mapped.is_null());
+  mapped = device->Clone();
 
   // Notify all observers.
   for (auto& observer : device_observer_list_)


### PR DESCRIPTION
#### Description of Change

Another "don't do the same thing twice in a row" PR.

This one removes a redundant map lookup in `HidChooserContext::DeviceChanged()`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.