### PR TITLE
fix: `backgroundMaterial` visibility on first window draw

### DIFF
--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -11,6 +11,7 @@
 #include "base/feature_list.h"
 #include "base/metrics/field_trial.h"
 #include "components/spellcheck/common/spellcheck_features.h"
+#include "components/viz/common/features.h"
 #include "content/common/features.h"
 #include "content/public/common/content_features.h"
 #include "electron/buildflags/buildflags.h"
@@ -52,6 +53,9 @@ void InitializeFeatureList() {
       // Delayed spellcheck initialization is causing the
       // 'custom dictionary word list API' spec to crash.
       std::string(",") + spellcheck::kWinDelaySpellcheckServiceInit.name;
+  enable_features +=
+      // Fixes background material not rendering on first paint.
+      std::string(",") + features::kRemoveRedirectionBitmap.name;
 #endif
 
 #if BUILDFLAG(IS_MAC)


### PR DESCRIPTION
#### Description of Change

enables the [`RemoveRedirectionBitmap` chromium flag](https://chromium.googlesource.com/chromium/src/+/HEAD/components/viz/common/features.cc#141) that forces chromium to use the [`WS_EX_NOREDIRECTIONBITMAP` style](https://stackoverflow.com/questions/38179033/when-should-ws-ex-noredirectionbitmap-be-used) when creating windows

fixes #41072 (info about the `transparent` property value is probably a mistake, as the value of this property has no effect on the issue)

based on https://github.com/tauri-apps/tauri/discussions/4747#discussioncomment-8026588

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples --> Fixed `backgroundMaterial` not being show on first window draw when `titleBarStyle` isn't `hidden`
