### PR TITLE
refactor: instantiate `navigation_entries` local variable on the stack

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2540,8 +2540,7 @@ void WebContents::RestoreHistory(
 
     nav_entry->SetIsOverridingUserAgent(
         !ua_override.ua_string_override.empty());
-    navigation_entries.push_back(
-        std::unique_ptr<content::NavigationEntry>(nav_entry));
+    navigation_entries.emplace_back(nav_entry);
   }
 
   if (!navigation_entries.empty()) {

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2520,6 +2520,7 @@ void WebContents::RestoreHistory(
 
   auto navigation_entries =
       std::vector<std::unique_ptr<content::NavigationEntry>>{};
+  navigation_entries.reserve(entries.size());
 
   blink::UserAgentOverride ua_override;
   ua_override.ua_string_override = GetUserAgent();

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2518,8 +2518,8 @@ void WebContents::RestoreHistory(
     return;
   }
 
-  auto navigation_entries = std::make_unique<
-      std::vector<std::unique_ptr<content::NavigationEntry>>>();
+  auto navigation_entries =
+      std::vector<std::unique_ptr<content::NavigationEntry>>{};
 
   blink::UserAgentOverride ua_override;
   ua_override.ua_string_override = GetUserAgent();
@@ -2539,14 +2539,14 @@ void WebContents::RestoreHistory(
 
     nav_entry->SetIsOverridingUserAgent(
         !ua_override.ua_string_override.empty());
-    navigation_entries->push_back(
+    navigation_entries.push_back(
         std::unique_ptr<content::NavigationEntry>(nav_entry));
   }
 
-  if (!navigation_entries->empty()) {
+  if (!navigation_entries.empty()) {
     web_contents()->SetUserAgentOverride(ua_override, false);
     web_contents()->GetController().Restore(
-        index, content::RestoreType::kRestored, navigation_entries.get());
+        index, content::RestoreType::kRestored, &navigation_entries);
     web_contents()->GetController().LoadIfNecessary();
   }
 }


### PR DESCRIPTION
#### Description of Change

Small cleanup in `WebContents::RestoreHistory()`:

- Instantiate `navigation_entries` on the stack instead of the heap
- Call `navigation_entries.reserve()` to preallocate capacity for all the entries.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.