### PR TITLE
build: reenable graphics effects for macOS tests

### DIFF
--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -118,6 +118,12 @@ jobs:
     - name: Turn off the unexpectedly quit dialog on macOS
       if: ${{ inputs.target-platform == 'macos' }}
       run: defaults write com.apple.CrashReporter DialogType server
+    - name: Reenable graphics effects on macOS
+      if: ${{ inputs.target-platform == 'macos' }}
+      run: |
+        # These options to reduce graphics effects were enabled upstream in https://github.com/actions/runner-images/pull/11877
+        defaults write com.apple.universalaccess reduceMotion -bool false
+        defaults write com.apple.universalaccess reduceTransparency -bool false
     - name: Checkout Electron
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:


### PR DESCRIPTION
#### Description of Change

Should fix our macOS tests which have been [failing](https://github.com/electron/electron/actions/runs/14226269149/job/39868911885?pr=46447).

The failures happened after https://github.com/actions/runner-images/pull/11877 [disabled graphics effects](https://github.com/actions/runner-images/commit/a2547b98201714dad9849c3600dae6554f410cea#diff-b068ae80fe8907d5eabab271f84c4abfff179adbc3a8c0d5d351b050cff3c1f2R20-R21).

The failures can be reproduced locally by setting the same `defaults`.  
The failures stop happening locally when undoing those `defaults` changes.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
