### PR TITLE
ci: reenable graphics effects for macOS tests (34-x-y backport)

### DIFF
--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -115,6 +115,15 @@ jobs:
             configure_sys_tccdb "$values"
           fi
         done
+    - name: Turn off the unexpectedly quit dialog on macOS
+      if: ${{ inputs.target-platform == 'macos' }}
+      run: defaults write com.apple.CrashReporter DialogType server
+    - name: Reenable graphics effects on macOS
+      if: ${{ inputs.target-platform == 'macos' }}
+      run: |
+        # These options to reduce graphics effects were enabled upstream in https://github.com/actions/runner-images/pull/11877
+        defaults write com.apple.universalaccess reduceMotion -bool false
+        defaults write com.apple.universalaccess reduceTransparency -bool false
     - name: Checkout Electron
       uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       with:


### PR DESCRIPTION
Manually backport #46454 to 34-x-y. See that PR for details.

This had to be backported manually due to context shear from 0d3e34d0be6 which was in newer branches but not in 34-x-y. It looks like a worthwhile fix, so I decided to pull that into this branch too. If that's incorrect, feel free to request changes or to push up a change.

CC @nikwen @electron/wg-infra 

Notes: none.