### PR TITLE
fix: ensure maximize is emitted when reduce motion is enabled on macOS

### DIFF
--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -118,12 +118,6 @@ jobs:
     - name: Turn off the unexpectedly quit dialog on macOS
       if: ${{ inputs.target-platform == 'macos' }}
       run: defaults write com.apple.CrashReporter DialogType server
-    - name: Reenable graphics effects on macOS
-      if: ${{ inputs.target-platform == 'macos' }}
-      run: |
-        # These options to reduce graphics effects were enabled upstream in https://github.com/actions/runner-images/pull/11877
-        defaults write com.apple.universalaccess reduceMotion -bool false
-        defaults write com.apple.universalaccess reduceTransparency -bool false
     - name: Checkout Electron
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -221,6 +221,12 @@ using FullScreenTransitionState =
   [super windowDidResize:notification];
   shell_->NotifyWindowResize();
   shell_->RedrawTrafficLights();
+  // When reduce motion is enabled windowDidResize is only called once after
+  // a resize and windowDidEndLiveResize is not called. So we need to call
+  // handleZoomEnd here as well.
+  if (NSWorkspace.sharedWorkspace.accessibilityDisplayShouldReduceMotion) {
+    [self handleZoomEnd];
+  }
 }
 
 - (void)windowWillMove:(NSNotification*)notification {
@@ -276,9 +282,7 @@ using FullScreenTransitionState =
   return YES;
 }
 
-- (void)windowDidEndLiveResize:(NSNotification*)notification {
-  resizingHorizontally_.reset();
-  shell_->NotifyWindowResized();
+- (void)handleZoomEnd {
   if (is_zooming_) {
     if (shell_->IsMaximized())
       shell_->NotifyWindowMaximize();
@@ -286,6 +290,12 @@ using FullScreenTransitionState =
       shell_->NotifyWindowUnmaximize();
     is_zooming_ = false;
   }
+}
+
+- (void)windowDidEndLiveResize:(NSNotification*)notification {
+  resizingHorizontally_.reset();
+  shell_->NotifyWindowResized();
+  [self handleZoomEnd];
 }
 
 - (void)windowWillEnterFullScreen:(NSNotification*)notification {


### PR DESCRIPTION
Another quirk of macOS I guess, but a non-animated resize isn't "live" so we handle the single resize event instead specifically when reduce motion is enabled.

This also reverts the graphics change in CI in order to "prove" this fixes it.

Closes #46455

Notes: no-notes