### PR TITLE
refactor: migrate to `View::AddChildView(std::unique_ptr<ui::View*>)`

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -323,7 +323,7 @@ void NativeWindowMac::SetContentView(views::View* view) {
     root_view->RemoveChildView(content_view());
 
   set_content_view(view);
-  root_view->AddChildView(content_view());
+  root_view->AddChildViewRaw(content_view());
 
   root_view->DeprecatedLayoutImmediately();
 }

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -480,7 +480,7 @@ void NativeWindowViews::SetContentView(views::View* view) {
   }
   set_content_view(view);
   focused_view_ = view;
-  root_view_.GetMainView()->AddChildView(content_view());
+  root_view_.GetMainView()->AddChildViewRaw(content_view());
   root_view_.GetMainView()->DeprecatedLayoutImmediately();
 }
 

--- a/shell/browser/ui/inspectable_web_contents_view.cc
+++ b/shell/browser/ui/inspectable_web_contents_view.cc
@@ -90,8 +90,8 @@ InspectableWebContentsView::InspectableWebContentsView(
   }
 
   devtools_web_view_->SetVisible(false);
-  AddChildView(devtools_web_view_.get());
-  AddChildView(GetContentsView());
+  AddChildViewRaw(devtools_web_view_.get());
+  AddChildViewRaw(GetContentsView());
 }
 
 InspectableWebContentsView::~InspectableWebContentsView() {

--- a/shell/browser/ui/views/autofill_popup_view.cc
+++ b/shell/browser/ui/views/autofill_popup_view.cc
@@ -215,9 +215,10 @@ void AutofillPopupView::CreateChildViews() {
   RemoveAllChildViews();
 
   for (int i = 0; i < popup_->line_count(); ++i) {
-    auto* child_view = new AutofillPopupChildView(popup_->value_at(i));
+    auto child_view =
+        std::make_unique<AutofillPopupChildView>(popup_->value_at(i));
     child_view->set_drag_controller(this);
-    AddChildView(child_view);
+    AddChildView(std::move(child_view));
   }
 }
 

--- a/shell/browser/ui/views/autofill_popup_view.h
+++ b/shell/browser/ui/views/autofill_popup_view.h
@@ -51,7 +51,6 @@ class AutofillPopupChildView : public views::View {
   AutofillPopupChildView(const AutofillPopupChildView&) = delete;
   AutofillPopupChildView& operator=(const AutofillPopupChildView&) = delete;
 
- private:
   ~AutofillPopupChildView() override = default;
 
   std::u16string suggestion_;

--- a/shell/browser/ui/views/client_frame_view_linux.cc
+++ b/shell/browser/ui/views/client_frame_view_linux.cc
@@ -84,11 +84,11 @@ ClientFrameViewLinux::ClientFrameViewLinux()
                               views::FrameButton::kMaximize,
                               views::FrameButton::kClose} {
   for (auto& button : nav_buttons_) {
-    button.button = new views::ImageButton();
-    button.button->SetImageVerticalAlignment(views::ImageButton::ALIGN_MIDDLE);
-    button.button->SetAccessibleName(
+    auto image_button = std::make_unique<views::ImageButton>();
+    image_button->SetImageVerticalAlignment(views::ImageButton::ALIGN_MIDDLE);
+    image_button->SetAccessibleName(
         l10n_util::GetStringUTF16(button.accessibility_id));
-    AddChildView(button.button);
+    button.button = AddChildView(std::move(image_button));
   }
 
   auto title = std::make_unique<views::Label>();

--- a/shell/browser/ui/views/client_frame_view_linux.cc
+++ b/shell/browser/ui/views/client_frame_view_linux.cc
@@ -91,13 +91,13 @@ ClientFrameViewLinux::ClientFrameViewLinux()
     AddChildView(button.button);
   }
 
-  title_ = new views::Label();
-  title_->SetSubpixelRenderingEnabled(false);
-  title_->SetAutoColorReadabilityEnabled(false);
-  title_->SetHorizontalAlignment(gfx::ALIGN_CENTER);
-  title_->SetVerticalAlignment(gfx::ALIGN_MIDDLE);
-  title_->SetTextStyle(views::style::STYLE_TAB_ACTIVE);
-  AddChildView(title_);
+  auto title = std::make_unique<views::Label>();
+  title->SetSubpixelRenderingEnabled(false);
+  title->SetAutoColorReadabilityEnabled(false);
+  title->SetHorizontalAlignment(gfx::ALIGN_CENTER);
+  title->SetVerticalAlignment(gfx::ALIGN_MIDDLE);
+  title->SetTextStyle(views::style::STYLE_TAB_ACTIVE);
+  title_ = AddChildView(std::move(title));
 
   native_theme_observer_.Observe(theme_);
 
@@ -293,8 +293,7 @@ void ClientFrameViewLinux::Layout(PassKey) {
   title_bounds.Inset(theme_values_.title_padding);
 
   title_->SetVisible(true);
-  title_->SetBounds(title_bounds.x(), title_bounds.y(), title_bounds.width(),
-                    title_bounds.height());
+  title_->SetBoundsRect(title_bounds);
 }
 
 void ClientFrameViewLinux::OnPaint(gfx::Canvas* canvas) {

--- a/shell/browser/ui/views/client_frame_view_linux.h
+++ b/shell/browser/ui/views/client_frame_view_linux.h
@@ -95,7 +95,7 @@ class ClientFrameViewLinux : public FramelessView,
     void (views::Widget::*callback)();
     int accessibility_id;
     int hit_test_id;
-    RAW_PTR_EXCLUSION views::ImageButton* button{nullptr};
+    raw_ptr<views::ImageButton> button = {};
   };
 
   struct ThemeValues {

--- a/shell/browser/ui/views/client_frame_view_linux.h
+++ b/shell/browser/ui/views/client_frame_view_linux.h
@@ -132,7 +132,7 @@ class ClientFrameViewLinux : public FramelessView,
   raw_ptr<ui::NativeTheme> theme_;
   ThemeValues theme_values_;
 
-  RAW_PTR_EXCLUSION views::Label* title_;
+  raw_ptr<views::Label> title_;
 
   std::unique_ptr<ui::NavButtonProvider> nav_button_provider_;
   std::array<NavButton, kNavButtonCount> nav_buttons_;

--- a/shell/browser/ui/views/menu_bar.cc
+++ b/shell/browser/ui/views/menu_bar.cc
@@ -229,11 +229,11 @@ void MenuBar::RefreshColorCache(const ui::NativeTheme* theme) {
 void MenuBar::RebuildChildren() {
   RemoveAllChildViews();
   for (size_t i = 0, n = GetItemCount(); i < n; ++i) {
-    auto* button = new SubmenuButton(
+    auto button = std::make_unique<SubmenuButton>(
         base::BindRepeating(&MenuBar::ButtonPressed, base::Unretained(this), i),
         menu_model_->GetLabelAt(i), background_color_);
     button->SetID(i);
-    AddChildView(button);
+    AddChildView(std::move(button));
   }
   UpdateViewColors();
 }

--- a/shell/browser/ui/views/opaque_frame_view.cc
+++ b/shell/browser/ui/views/opaque_frame_view.cc
@@ -297,7 +297,7 @@ views::Button* OpaqueFrameView::CreateButton(
     int ht_component,
     const gfx::VectorIcon& icon_image,
     views::Button::PressedCallback callback) {
-  views::FrameCaptionButton* button = new views::FrameCaptionButton(
+  auto button = std::make_unique<views::FrameCaptionButton>(
       views::Button::PressedCallback(), icon_type, ht_component);
   button->SetImage(button->GetIcon(), views::FrameCaptionButton::Animate::kNo,
                    icon_image);
@@ -306,12 +306,11 @@ views::Button* OpaqueFrameView::CreateButton(
   button->SetCallback(std::move(callback));
   button->SetAccessibleName(l10n_util::GetStringUTF16(accessibility_string_id));
   button->SetID(view_id);
-  AddChildView(button);
 
   button->SetPaintToLayer();
   button->layer()->SetFillsBoundsOpaquely(false);
 
-  return button;
+  return AddChildView(std::move(button));
 }
 
 gfx::Insets OpaqueFrameView::FrameBorderInsets(bool restored) const {

--- a/shell/browser/ui/views/win_caption_button_container.h
+++ b/shell/browser/ui/views/win_caption_button_container.h
@@ -67,11 +67,11 @@ class WinCaptionButtonContainer : public views::View,
   void OnWidgetBoundsChanged(views::Widget* widget,
                              const gfx::Rect& new_bounds) override;
 
-  raw_ptr<WinFrameView> const frame_view_;
-  raw_ptr<WinCaptionButton> const minimize_button_;
-  raw_ptr<WinCaptionButton> const maximize_button_;
-  raw_ptr<WinCaptionButton> const restore_button_;
-  raw_ptr<WinCaptionButton> const close_button_;
+  const raw_ptr<WinFrameView> frame_view_;
+  const raw_ptr<WinCaptionButton> minimize_button_;
+  const raw_ptr<WinCaptionButton> maximize_button_;
+  const raw_ptr<WinCaptionButton> restore_button_;
+  const raw_ptr<WinCaptionButton> close_button_;
 
   base::ScopedObservation<views::Widget, views::WidgetObserver>
       widget_observation_{this};


### PR DESCRIPTION
#### Description of Change

Try to get a bit ahead of https://crbug.com/40485510, which is a long-standing issue but has seen a lot of recent commits.  

1. The _easy_ areas to fix the areas where we're just using raw pointers, but are using the default ownership method of letting the View parent own the child. In these cases, we can furtureproof our code by using  `AddChildView(std::unique_ptr<View>)` instead of `AddChildView(View*)`:

```diff
- child_ = new SomeView();
- child_->SetSomeProperty(false);
- view->AddChildView(child_);
+ auto child = std::make_unique<SomeView>();
+ child->SetSomeProperty(false);
+ view_ = AddChildView(std::move(child));
```

2. There are also _harder_ areas to update because we managing some child views' lifecycles ourselves & can't pass ownership to the parent view. I've flagged these cases by changing them to call [`AddChildViewRaw(T*)`](https://chromium-review.googlesource.com/c/chromium/src/+/6293171) instead of `AddChildView(T*)`. These cases have complicated ownership models which we should consider migrating, especially if upstream is still planning on removing `set_owned_by_clent()`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.