### PR TITLE
refactor: use `base::flat_set` in `WebContents::DidUpdateFaviconUrl()`

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -16,6 +16,7 @@
 
 #include "base/base64.h"
 #include "base/containers/fixed_flat_map.h"
+#include "base/containers/flat_set.h"
 #include "base/containers/id_map.h"
 #include "base/files/file_util.h"
 #include "base/json/json_reader.h"
@@ -2119,13 +2120,12 @@ void WebContents::TitleWasSet(content::NavigationEntry* entry) {
 void WebContents::DidUpdateFaviconURL(
     content::RenderFrameHost* render_frame_host,
     const std::vector<blink::mojom::FaviconURLPtr>& urls) {
-  std::set<GURL> unique_urls;
+  base::flat_set<GURL> unique_urls;
+  unique_urls.reserve(std::size(urls));
   for (const auto& iter : urls) {
-    if (iter->icon_type != blink::mojom::FaviconIconType::kFavicon)
-      continue;
-    const GURL& url = iter->icon_url;
-    if (url.is_valid())
-      unique_urls.insert(url);
+    if (iter->icon_type == blink::mojom::FaviconIconType::kFavicon &&
+        iter->icon_url.is_valid())
+      unique_urls.insert(iter->icon_url);
   }
   Emit("page-favicon-updated", unique_urls);
 }

--- a/shell/common/gin_converters/base_converter.h
+++ b/shell/common/gin_converters/base_converter.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_COMMON_GIN_CONVERTERS_BASE_CONVERTER_H_
 #define ELECTRON_SHELL_COMMON_GIN_CONVERTERS_BASE_CONVERTER_H_
 
+#include "base/containers/flat_set.h"
 #include "base/process/kill.h"
 #include "gin/converter.h"
 #include "shell/common/gin_converters/std_converter.h"
@@ -38,6 +39,14 @@ struct Converter<base::TerminationStatus> {
         NOTREACHED();
     }
     NOTREACHED();
+  }
+};
+
+template <typename T>
+struct Converter<base::flat_set<T>> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const base::flat_set<T>& set) {
+    return Converter<std::span<T>>::ToV8(isolate, std::span{set});
   }
 };
 

--- a/shell/common/gin_converters/std_converter.h
+++ b/shell/common/gin_converters/std_converter.h
@@ -48,6 +48,14 @@ struct Converter<std::span<T>> {
   }
 };
 
+template <typename T, size_t N>
+struct Converter<std::array<T, N>> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const std::array<T, N>& array) {
+    return Converter<std::span<T>>::ToV8(isolate, std::span{array});
+  }
+};
+
 #if !BUILDFLAG(IS_LINUX)
 template <>
 struct Converter<unsigned long> {  // NOLINT(runtime/int)


### PR DESCRIPTION
#### Description of Change

Use `base::flat_set` in `WebContents::DidUpdateFaviconUrl()`. Add a `ToV8()` gin converter for `base::flat_set<T>` (and, more abstractly, for any `std::span<T>`).

The pre-existing spec  `<webview> tag events page-favicon-updated event emits when favicon urls are received`  tests this code.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.