### PR TITLE
refactor: remove unused `electron::api::App::FileIconCallback`

### DIFF
--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -34,10 +34,6 @@ namespace base {
 class FilePath;
 }
 
-namespace gfx {
-class Image;
-}
-
 namespace gin {
 template <typename T>
 class Handle;
@@ -65,9 +61,6 @@ class App final : public ElectronBrowserClient::Delegate,
                   private content::GpuDataManagerObserver,
                   private content::BrowserChildProcessObserver {
  public:
-  using FileIconCallback =
-      base::RepeatingCallback<void(v8::Local<v8::Value>, const gfx::Image&)>;
-
   static gin::Handle<App> Create(v8::Isolate* isolate);
   static App* Get();
 


### PR DESCRIPTION
#### Description of Change

Remove this unused typedef. Its last use was removed in 2018 by 3f15f516

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.