### PR TITLE
refactor: reduce code duplication in `LayoutWindowControlsOverlay()`

### DIFF
--- a/shell/browser/ui/views/frameless_view.cc
+++ b/shell/browser/ui/views/frameless_view.cc
@@ -118,6 +118,26 @@ gfx::Size FramelessView::GetMaximumSize() const {
   return size.IsEmpty() ? gfx::Size(INT_MAX, INT_MAX) : size;
 }
 
+void FramelessView::LayoutWindowControlsOverlay(
+    const gfx::Size caption_button_container_size,
+    const bool is_maximized) {
+  NativeWindowViews* const window = this->window();
+
+  int overlay_height = window->titlebar_overlay_height();
+  if (overlay_height == 0) {
+    // Accounting for the 1 pixel margin at the top of the button container
+    overlay_height = is_maximized ? caption_button_container_size.height()
+                                  : caption_button_container_size.height() + 1;
+  }
+  int overlay_width = caption_button_container_size.width();
+  int bounding_rect_width = width() - overlay_width;
+  auto bounding_rect =
+      GetMirroredRect(gfx::Rect{0, 0, bounding_rect_width, overlay_height});
+
+  window->SetWindowControlsOverlayRect(bounding_rect);
+  window->NotifyLayoutWindowControlsOverlay();
+}
+
 BEGIN_METADATA(FramelessView)
 END_METADATA
 

--- a/shell/browser/ui/views/frameless_view.h
+++ b/shell/browser/ui/views/frameless_view.h
@@ -66,6 +66,9 @@ class FramelessView : public views::NonClientFrameView {
   gfx::Size GetMinimumSize() const override;
   gfx::Size GetMaximumSize() const override;
 
+  void LayoutWindowControlsOverlay(gfx::Size caption_button_container_size,
+                                   bool is_maximized);
+
   // Not owned.
   raw_ptr<NativeWindowViews> window_ = nullptr;
   raw_ptr<views::Widget> frame_ = nullptr;

--- a/shell/browser/ui/views/opaque_frame_view.cc
+++ b/shell/browser/ui/views/opaque_frame_view.cc
@@ -273,21 +273,8 @@ void OpaqueFrameView::LayoutWindowControls() {
 }
 
 void OpaqueFrameView::LayoutWindowControlsOverlay() {
-  int overlay_height = window()->titlebar_overlay_height();
-  if (overlay_height == 0) {
-    // Accounting for the 1 pixel margin at the top of the button container
-    overlay_height =
-        window()->IsMaximized()
-            ? caption_button_placeholder_container_->size().height()
-            : caption_button_placeholder_container_->size().height() + 1;
-  }
-  int overlay_width = caption_button_placeholder_container_->size().width();
-  int bounding_rect_width = width() - overlay_width;
-  auto bounding_rect =
-      GetMirroredRect(gfx::Rect(0, 0, bounding_rect_width, overlay_height));
-
-  window()->SetWindowControlsOverlayRect(bounding_rect);
-  window()->NotifyLayoutWindowControlsOverlay();
+  FramelessView::LayoutWindowControlsOverlay(
+      caption_button_placeholder_container_->size(), window()->IsMaximized());
 }
 
 views::Button* OpaqueFrameView::CreateButton(

--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -265,20 +265,8 @@ void WinFrameView::LayoutCaptionButtons() {
 }
 
 void WinFrameView::LayoutWindowControlsOverlay() {
-  int overlay_height = window()->titlebar_overlay_height();
-  if (overlay_height == 0) {
-    // Accounting for the 1 pixel margin at the top of the button container
-    overlay_height = IsMaximized()
-                         ? caption_button_container_->size().height()
-                         : caption_button_container_->size().height() + 1;
-  }
-  int overlay_width = caption_button_container_->size().width();
-  int bounding_rect_width = width() - overlay_width;
-  auto bounding_rect =
-      GetMirroredRect(gfx::Rect(0, 0, bounding_rect_width, overlay_height));
-
-  window()->SetWindowControlsOverlayRect(bounding_rect);
-  window()->NotifyLayoutWindowControlsOverlay();
+  FramelessView::LayoutWindowControlsOverlay(IsMaximized(),
+                                             caption_button_container_->size());
 }
 
 BEGIN_METADATA(WinFrameView)

--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -265,8 +265,8 @@ void WinFrameView::LayoutCaptionButtons() {
 }
 
 void WinFrameView::LayoutWindowControlsOverlay() {
-  FramelessView::LayoutWindowControlsOverlay(IsMaximized(),
-                                             caption_button_container_->size());
+  FramelessView::LayoutWindowControlsOverlay(caption_button_container_->size(),
+                                             IsMaximized());
 }
 
 BEGIN_METADATA(WinFrameView)


### PR DESCRIPTION
#### Description of Change

Does what it says on the tin: move shared code from `OpaqueFrameView` and `WinFrameView` into their shared parent class.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.