### PR TITLE
perf: avoid redundant virtual method call in `NativeWindowViews::SetEnabledInternal()`

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -623,11 +623,8 @@ bool NativeWindowViews::ShouldBeEnabled() const {
 }
 
 void NativeWindowViews::SetEnabledInternal(bool enable) {
-  if (enable && IsEnabled()) {
+  if (enable == IsEnabled())
     return;
-  } else if (!enable && !IsEnabled()) {
-    return;
-  }
 
 #if BUILDFLAG(IS_WIN)
   ::EnableWindow(GetAcceleratedWidget(), enable);


### PR DESCRIPTION
#### Description of Change

Don't call `IsEnabled()` twice in a row. Yes, it's a cheap call. But it's also a virtual method that makes a syscall on Windows.

Why waste time make lot call when few call do trick?

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.