### PR TITLE
perf: on Windows, make `Archive::HeaderIntegrity()` faster

### DIFF
--- a/shell/common/asar/archive_win.cc
+++ b/shell/common/asar/archive_win.cc
@@ -17,6 +17,7 @@
 #include "base/strings/string_util_win.h"
 #include "base/strings/utf_string_conversions.h"
 #include "shell/common/asar/asar_util.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 
 namespace asar {
 
@@ -39,7 +40,7 @@ std::optional<base::FilePath> Archive::RelativePath() const {
 
 const auto& LoadIntegrityConfigCache() {
   static base::NoDestructor<
-      std::optional<std::unordered_map<std::string, IntegrityPayload>>>
+      std::optional<absl::flat_hash_map<std::string, IntegrityPayload>>>
       integrity_config_cache;
 
   // Skip loading if cache is already loaded
@@ -48,7 +49,8 @@ const auto& LoadIntegrityConfigCache() {
   }
 
   // Init cache
-  *integrity_config_cache = std::unordered_map<std::string, IntegrityPayload>();
+  *integrity_config_cache =
+      absl::flat_hash_map<std::string, IntegrityPayload>{};
 
   // Load integrity config from exe resource
   HMODULE module_handle = ::GetModuleHandle(NULL);

--- a/shell/common/asar/archive_win.cc
+++ b/shell/common/asar/archive_win.cc
@@ -93,6 +93,7 @@ const auto& LoadIntegrityConfigCache() {
   }
 
   // Parse each individual file integrity config
+  integrity_config_cache->reserve(file_configs->size());
   for (size_t i = 0; i < file_configs->size(); i++) {
     // Skip invalid file configs
     const base::Value::Dict* ele_dict = (*file_configs)[i].GetIfDict();

--- a/shell/common/asar/archive_win.cc
+++ b/shell/common/asar/archive_win.cc
@@ -125,8 +125,8 @@ const auto& LoadIntegrityConfigCache() {
     header_integrity.algorithm = HashAlgorithm::kSHA256;
     header_integrity.hash = base::ToLowerASCII(*value);
 
-    integrity_config_cache->value()[base::ToLowerASCII(*file)] =
-        std::move(header_integrity);
+    integrity_config_cache->insert_or_assign(base::ToLowerASCII(*file),
+                                             std::move(header_integrity));
   }
 
   return *integrity_config_cache;

--- a/shell/common/asar/archive_win.cc
+++ b/shell/common/asar/archive_win.cc
@@ -39,6 +39,8 @@ std::optional<base::FilePath> Archive::RelativePath() const {
   return relative_path;
 }
 
+namespace {
+
 auto LoadIntegrityConfig() {
   absl::flat_hash_map<std::string, IntegrityPayload> cache;
 
@@ -124,6 +126,8 @@ const auto& GetIntegrityConfigCache() {
   static const auto cache = base::NoDestructor(LoadIntegrityConfig());
   return *cache;
 }
+
+}  // namespace
 
 std::optional<IntegrityPayload> Archive::HeaderIntegrity() const {
   const std::optional<base::FilePath> relative_path = RelativePath();

--- a/shell/common/asar/archive_win.cc
+++ b/shell/common/asar/archive_win.cc
@@ -139,7 +139,6 @@ std::optional<IntegrityPayload> Archive::HeaderIntegrity() const {
     return *payload;
 
   LOG(FATAL) << "Failed to find file integrity info for " << key;
-  return {};
 }
 
 }  // namespace asar

--- a/shell/common/asar/archive_win.cc
+++ b/shell/common/asar/archive_win.cc
@@ -37,8 +37,7 @@ std::optional<base::FilePath> Archive::RelativePath() const {
   return relative_path;
 }
 
-std::optional<std::unordered_map<std::string, IntegrityPayload>>
-LoadIntegrityConfigCache() {
+const auto& LoadIntegrityConfigCache() {
   static base::NoDestructor<
       std::optional<std::unordered_map<std::string, IntegrityPayload>>>
       integrity_config_cache;
@@ -135,8 +134,7 @@ std::optional<IntegrityPayload> Archive::HeaderIntegrity() const {
   CHECK(relative_path.has_value());
 
   // Load integrity config from exe resource
-  std::optional<std::unordered_map<std::string, IntegrityPayload>>
-      integrity_config = LoadIntegrityConfigCache();
+  const auto& integrity_config = LoadIntegrityConfigCache();
   if (!integrity_config.has_value()) {
     LOG(WARNING) << "Failed to integrity config from exe resource.";
     return std::nullopt;

--- a/shell/common/asar/archive_win.cc
+++ b/shell/common/asar/archive_win.cc
@@ -56,8 +56,8 @@ auto LoadIntegrityConfig() {
     PLOG(FATAL) << "LoadResource failed.";
   }
 
-  auto* res_data = static_cast<const char*>(::LockResource(rcData));
-  int res_size = SizeofResource(module_handle, resource);
+  const auto* res_data = static_cast<const char*>(::LockResource(rcData));
+  const auto res_size = SizeofResource(module_handle, resource);
 
   if (!res_data) {
     PLOG(FATAL) << "Failed to integrity config from exe resource.";

--- a/shell/common/asar/archive_win.cc
+++ b/shell/common/asar/archive_win.cc
@@ -68,9 +68,8 @@ auto LoadIntegrityConfig() {
   }
 
   // Parse integrity config payload
-  const auto integrity_config_payload = std::string_view{res_data, res_size};
   std::optional<base::Value> root =
-      base::JSONReader::Read(integrity_config_payload);
+      base::JSONReader::Read(std::string_view{res_data, res_size});
 
   if (!root.has_value()) {
     LOG(FATAL) << "Invalid integrity config: NOT a valid JSON.";
@@ -127,13 +126,14 @@ const auto& GetIntegrityConfigCache() {
 }
 
 std::optional<IntegrityPayload> Archive::HeaderIntegrity() const {
-  const auto relative_path = RelativePath();
+  const std::optional<base::FilePath> relative_path = RelativePath();
   CHECK(relative_path);
 
-  const auto key = base::ToLowerASCII(base::WideToUTF8(relative_path->value()));
-
-  if (const auto* payload = base::FindOrNull(GetIntegrityConfigCache(), key))
+  if (const IntegrityPayload* payload = base::FindOrNull(
+          GetIntegrityConfigCache(),
+          base::ToLowerASCII(base::WideToUTF8(relative_path->value())))) {
     return *payload;
+  }
 
   LOG(FATAL) << "Failed to find file integrity info for " << rel_path_utf8;
   return {};

--- a/shell/common/asar/archive_win.cc
+++ b/shell/common/asar/archive_win.cc
@@ -6,7 +6,6 @@
 #include "shell/common/asar/archive.h"
 
 #include <algorithm>
-#include <sstream>
 #include <string_view>
 
 #include "base/base_paths.h"
@@ -132,6 +131,7 @@ std::optional<IntegrityPayload> Archive::HeaderIntegrity() const {
   CHECK(relative_path);
 
   const auto key = base::ToLowerASCII(base::WideToUTF8(relative_path->value()));
+
   if (const auto* payload = base::FindOrNull(GetIntegrityConfigCache(), key))
     return *payload;
 

--- a/shell/common/asar/archive_win.cc
+++ b/shell/common/asar/archive_win.cc
@@ -133,13 +133,12 @@ std::optional<IntegrityPayload> Archive::HeaderIntegrity() const {
   const std::optional<base::FilePath> relative_path = RelativePath();
   CHECK(relative_path);
 
-  if (const IntegrityPayload* payload = base::FindOrNull(
-          GetIntegrityConfigCache(),
-          base::ToLowerASCII(base::WideToUTF8(relative_path->value())))) {
-    return *payload;
-  }
+  const auto key = base::ToLowerASCII(base::WideToUTF8(relative_path->value()));
 
-  LOG(FATAL) << "Failed to find file integrity info for " << rel_path_utf8;
+  if (const auto* payload = base::FindOrNull(GetIntegrityConfigCache(), key))
+    return *payload;
+
+  LOG(FATAL) << "Failed to find file integrity info for " << key;
   return {};
 }
 

--- a/shell/common/asar/archive_win.cc
+++ b/shell/common/asar/archive_win.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <sstream>
+#include <string_view>
 
 #include "base/base_paths.h"
 #include "base/json/json_reader.h"
@@ -78,7 +79,7 @@ const auto& LoadIntegrityConfigCache() {
   }
 
   // Parse integrity config payload
-  std::string integrity_config_payload = std::string(res_data, res_size);
+  const auto integrity_config_payload = std::string_view{res_data, res_size};
   std::optional<base::Value> root =
       base::JSONReader::Read(integrity_config_payload);
 


### PR DESCRIPTION
#### Description of Change

Several small performance improvements to `Archive::HeaderIntegrity()` on Windows:

- Don't make a temporary copy of the payload cache every time
- Keep the payload cache in an `absl::flat_hash_map` instead of a `std::map`
- Preallocate capacity when populating the payload cache
- Use `std::string_view` to avoid creating temporary strings to feed to the JSON parser
- Remove an unnecessary std::optional<> wrapper

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Improved ASAR integrity checks on Windows.