### PR TITLE
docs: unify documentation example and fiddle for IPC pattern-1

### DIFF
--- a/docs/fiddles/ipc/pattern-1/main.js
+++ b/docs/fiddles/ipc/pattern-1/main.js
@@ -1,6 +1,12 @@
 const { app, BrowserWindow, ipcMain } = require('electron/main')
 const path = require('node:path')
 
+function handleSetTitle (event, title) {
+  const webContents = event.sender
+  const win = BrowserWindow.fromWebContents(webContents)
+  win.setTitle(title)
+}
+
 function createWindow () {
   const mainWindow = new BrowserWindow({
     webPreferences: {
@@ -8,16 +14,11 @@ function createWindow () {
     }
   })
 
-  ipcMain.on('set-title', (event, title) => {
-    const webContents = event.sender
-    const win = BrowserWindow.fromWebContents(webContents)
-    win.setTitle(title)
-  })
-
   mainWindow.loadFile('index.html')
 }
 
 app.whenReady().then(() => {
+  ipcMain.on('set-title', handleSetTitle)
   createWindow()
 
   app.on('activate', function () {

--- a/docs/tutorial/ipc.md
+++ b/docs/tutorial/ipc.md
@@ -74,10 +74,6 @@ function createWindow () {
 app.whenReady().then(() => {
   ipcMain.on('set-title', handleSetTitle)
   createWindow()
-
-  app.on('activate', function () {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow()
-  })
 })
 // ...
 ```

--- a/docs/tutorial/ipc.md
+++ b/docs/tutorial/ipc.md
@@ -74,6 +74,10 @@ function createWindow () {
 app.whenReady().then(() => {
   ipcMain.on('set-title', handleSetTitle)
   createWindow()
+
+  app.on('activate', function () {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+  })
 })
 // ...
 ```


### PR DESCRIPTION
#### Description of Change

Unify the IPC Pattern 1 implementation in documentation with the actual fiddle code by:
 - Adding `handleSetTitle` and removing anonymous callback in `set-title` event in `main.js` file in pattern-1 fiddle to match ipc.md
 - Adding missing event handler for `activate` in `ipc.md` to match `main.js` in pattern-1 fiddle

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: No notes
