### PR TITLE
fix: `assert.ok` in the renderer process

### DIFF
--- a/patches/node/feat_add_oom_error_callback_in_node_isolatesettings.patch
+++ b/patches/node/feat_add_oom_error_callback_in_node_isolatesettings.patch
@@ -13,7 +13,7 @@ To fix this issue, provide the interface oom_error_callback to enable a
 custom oom error callback set from Electron.
 
 diff --git a/src/api/environment.cc b/src/api/environment.cc
-index 32fc075e97eebca6c47e796ac5308915746ffa2a..e72bee385865c7d34e9eea6b90c6d911d592f8af 100644
+index fc9b056d2f7e25109100fbde5f3ab0aebc8c619a..9b155213ce301df7e396a4a113992499fc7e9910 100644
 --- a/src/api/environment.cc
 +++ b/src/api/environment.cc
 @@ -241,7 +241,10 @@ void SetIsolateErrorHandlers(v8::Isolate* isolate, const IsolateSettings& s) {

--- a/patches/node/fix_assert_module_in_the_renderer_process.patch
+++ b/patches/node/fix_assert_module_in_the_renderer_process.patch
@@ -43,20 +43,6 @@ index 59b5a16f1309a5e4055bccfdb7a529045ad30402..bfdaf6211466a01b64b7942f7b16c480
  
    let filename = call.getFileName();
    const line = call.getLineNumber() - 1;
-diff --git a/src/api/environment.cc b/src/api/environment.cc
-index fc9b056d2f7e25109100fbde5f3ab0aebc8c619a..32fc075e97eebca6c47e796ac5308915746ffa2a 100644
---- a/src/api/environment.cc
-+++ b/src/api/environment.cc
-@@ -247,6 +247,9 @@ void SetIsolateErrorHandlers(v8::Isolate* isolate, const IsolateSettings& s) {
-     auto* prepare_stack_trace_cb = s.prepare_stack_trace_callback ?
-         s.prepare_stack_trace_callback : PrepareStackTraceCallback;
-     isolate->SetPrepareStackTraceCallback(prepare_stack_trace_cb);
-+  } else {
-+    auto env = Environment::GetCurrent(isolate);
-+    env->set_prepare_stack_trace_callback(Local<Function>());
-   }
- }
- 
 diff --git a/src/node_options.cc b/src/node_options.cc
 index 3608ab2b4aeb09e985ca98e23f2dff23567ade71..620776c06d835eb1bfeed060751c570e8d435b29 100644
 --- a/src/node_options.cc

--- a/patches/node/refactor_attach_cppgc_heap_on_v8_isolate_creation.patch
+++ b/patches/node/refactor_attach_cppgc_heap_on_v8_isolate_creation.patch
@@ -18,10 +18,10 @@ This can be removed when Node.js upgrades to a version of V8 containing CLs
 from the above issue.
 
 diff --git a/src/api/environment.cc b/src/api/environment.cc
-index e72bee385865c7d34e9eea6b90c6d911d592f8af..d3d1040b7a1a6b9c4a1fa2399e9235ec3b0b2990 100644
+index 9b155213ce301df7e396a4a113992499fc7e9910..8fe560014216f1fcea7f6e804816765999cebaa2 100644
 --- a/src/api/environment.cc
 +++ b/src/api/environment.cc
-@@ -315,6 +315,10 @@ Isolate* NewIsolate(Isolate::CreateParams* params,
+@@ -312,6 +312,10 @@ Isolate* NewIsolate(Isolate::CreateParams* params,
                      MultiIsolatePlatform* platform,
                      const SnapshotData* snapshot_data,
                      const IsolateSettings& settings) {
@@ -32,7 +32,7 @@ index e72bee385865c7d34e9eea6b90c6d911d592f8af..d3d1040b7a1a6b9c4a1fa2399e9235ec
    Isolate* isolate = Isolate::Allocate();
    if (isolate == nullptr) return nullptr;
  
-@@ -358,9 +362,12 @@ Isolate* NewIsolate(ArrayBufferAllocator* allocator,
+@@ -355,9 +359,12 @@ Isolate* NewIsolate(ArrayBufferAllocator* allocator,
                      uv_loop_t* event_loop,
                      MultiIsolatePlatform* platform,
                      const EmbedderSnapshotData* snapshot_data,

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -983,6 +983,17 @@ describe('node feature', () => {
     });
   });
 
+  itremote('handles assert module assertions as expected', () => {
+    const assert = require('node:assert');
+    try {
+      assert.ok(false);
+      expect.fail('assert.ok(false) should throw');
+    } catch (err) {
+      console.log(err);
+      expect(err).to.be.instanceOf(assert.AssertionError);
+    }
+  });
+
   it('Can find a module using a package.json main field', () => {
     const result = childProcess.spawnSync(process.execPath, [path.resolve(fixtures, 'api', 'electron-main-module', 'app.asar')], { stdio: 'inherit' });
     expect(result.status).to.equal(0);


### PR DESCRIPTION
#### Description of Change

Fixes the `assert.ok` in the renderer process - the removed lines meant that the condition in `getErrMessage` to modify `Error.prepareStackTrace` temporarily would never be called and thus the following error would show:

> `TypeError: call.getFileName is not a function`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue with the `assert` Node.js module in the renderer process.