### PR TITLE
fix: re-enable OOP printing on Linux

### DIFF
--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -932,3 +932,19 @@ index 63f170c95050416c595e62f4c460c4cd6b7dbd1c..157e3d046889f9c63fdf0fd5d503890f
    // Does bookkeeping when an error occurs.
    virtual mojom::ResultCode OnError();
  
+diff --git a/printing/printing_context_linux.cc b/printing/printing_context_linux.cc
+index fa55d2a1c5f4207cb8eda9305e8bf2af29352c91..13ca65c2c7c3c24882061d8e224bf93899d9a7ab 100644
+--- a/printing/printing_context_linux.cc
++++ b/printing/printing_context_linux.cc
+@@ -52,9 +52,8 @@ void PrintingContextLinux::AskUserForSettings(int max_pages,
+                                               bool is_scripted,
+                                               PrintSettingsCallback callback) {
+   if (!print_dialog_) {
+-    // Can only get here if the renderer is sending bad messages.
+-    // http://crbug.com/341777
+-    NOTREACHED();
++    print_dialog_ = ui::LinuxUi::instance()->CreatePrintDialog(this);
++    print_dialog_->UseDefaultSettings();
+   }
+ 
+   print_dialog_->ShowDialog(delegate_->GetParentView(), has_selection,

--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -61,14 +61,6 @@ void InitializeFeatureList() {
       std::string(",") + features::kMacWebContentsOcclusion.name;
 #endif
 
-#if BUILDFLAG(IS_LINUX) && BUILDFLAG(ENABLE_PRINTING)
-  disable_features +=
-      // EnableOopPrintDrivers is still a bit half-baked on Linux and
-      // causes crashes when trying to show dialogs.
-      // TODO(codebytere): figure out how to re-enable this with our patches.
-      std::string(",") + printing::features::kEnableOopPrintDrivers.name;
-#endif
-
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
   // Enable window.showSaveFilePicker api for saving pdf files.
   // Refs https://issues.chromium.org/issues/373852607


### PR DESCRIPTION
#### Description of Change

Follow up to https://github.com/electron/electron/pull/46087 - we should be using the new OOP printing standard on Linux. Our initial call to update the print settings triggers an unexpected pathway in Linux OOP print code, which expected that the dialog would be initialized by a call to request default print settings that never occurs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none