### PR TITLE
refactor: simplify some `BaseWindow` JS getters

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -588,12 +588,9 @@ void BaseWindow::SetPosition(int x, int y, gin_helper::Arguments* args) {
   window_->SetPosition(gfx::Point(x, y), animate);
 }
 
-std::vector<int> BaseWindow::GetPosition() const {
-  std::vector<int> result(2);
-  gfx::Point pos = window_->GetPosition();
-  result[0] = pos.x();
-  result[1] = pos.y();
-  return result;
+std::array<int, 2U> BaseWindow::GetPosition() const {
+  const gfx::Point pos = window_->GetPosition();
+  return {pos.x(), pos.y()};
 }
 void BaseWindow::MoveAbove(const std::string& sourceId,
                            gin_helper::Arguments* args) {

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -507,12 +507,9 @@ void BaseWindow::SetMaximumSize(int width, int height) {
   window_->SetMaximumSize(gfx::Size(width, height));
 }
 
-std::vector<int> BaseWindow::GetMaximumSize() const {
-  std::vector<int> result(2);
-  gfx::Size size = window_->GetMaximumSize();
-  result[0] = size.width();
-  result[1] = size.height();
-  return result;
+std::array<int, 2U> BaseWindow::GetMaximumSize() const {
+  const gfx::Size size = window_->GetMaximumSize();
+  return {size.width(), size.height()};
 }
 
 void BaseWindow::SetSheetOffset(double offsetY, gin_helper::Arguments* args) {

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -495,12 +495,9 @@ void BaseWindow::SetMinimumSize(int width, int height) {
   window_->SetMinimumSize(gfx::Size(width, height));
 }
 
-std::vector<int> BaseWindow::GetMinimumSize() const {
-  std::vector<int> result(2);
-  gfx::Size size = window_->GetMinimumSize();
-  result[0] = size.width();
-  result[1] = size.height();
-  return result;
+std::array<int, 2U> BaseWindow::GetMinimumSize() const {
+  const gfx::Size size = window_->GetMinimumSize();
+  return {size.width(), size.height()};
 }
 
 void BaseWindow::SetMaximumSize(int width, int height) {

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -467,12 +467,9 @@ void BaseWindow::SetSize(int width, int height, gin_helper::Arguments* args) {
   window_->SetSize(size, animate);
 }
 
-std::vector<int> BaseWindow::GetSize() const {
-  std::vector<int> result(2);
-  gfx::Size size = window_->GetSize();
-  result[0] = size.width();
-  result[1] = size.height();
-  return result;
+std::array<int, 2U> BaseWindow::GetSize() const {
+  const gfx::Size size = window_->GetSize();
+  return {size.width(), size.height()};
 }
 
 void BaseWindow::SetContentSize(int width,

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -79,6 +79,14 @@ v8::Local<v8::Value> ToBuffer(v8::Isolate* isolate, void* val, int size) {
     return buffer.ToLocalChecked();
 }
 
+[[nodiscard]] constexpr std::array<int, 2U> ToArray(const gfx::Size size) {
+  return {size.width(), size.height()};
+}
+
+[[nodiscard]] constexpr std::array<int, 2U> ToArray(const gfx::Point point) {
+  return {point.x(), point.y()};
+}
+
 }  // namespace
 
 BaseWindow::BaseWindow(v8::Isolate* isolate,
@@ -468,8 +476,7 @@ void BaseWindow::SetSize(int width, int height, gin_helper::Arguments* args) {
 }
 
 std::array<int, 2U> BaseWindow::GetSize() const {
-  const gfx::Size size = window_->GetSize();
-  return {size.width(), size.height()};
+  return ToArray(window_->GetSize());
 }
 
 void BaseWindow::SetContentSize(int width,
@@ -481,8 +488,7 @@ void BaseWindow::SetContentSize(int width,
 }
 
 std::array<int, 2U> BaseWindow::GetContentSize() const {
-  const gfx::Size size = window_->GetContentSize();
-  return {size.width(), size.height()};
+  return ToArray(window_->GetContentSize());
 }
 
 void BaseWindow::SetMinimumSize(int width, int height) {
@@ -490,8 +496,7 @@ void BaseWindow::SetMinimumSize(int width, int height) {
 }
 
 std::array<int, 2U> BaseWindow::GetMinimumSize() const {
-  const gfx::Size size = window_->GetMinimumSize();
-  return {size.width(), size.height()};
+  return ToArray(window_->GetMinimumSize());
 }
 
 void BaseWindow::SetMaximumSize(int width, int height) {
@@ -499,8 +504,7 @@ void BaseWindow::SetMaximumSize(int width, int height) {
 }
 
 std::array<int, 2U> BaseWindow::GetMaximumSize() const {
-  const gfx::Size size = window_->GetMaximumSize();
-  return {size.width(), size.height()};
+  return ToArray(window_->GetMaximumSize());
 }
 
 void BaseWindow::SetSheetOffset(double offsetY, gin_helper::Arguments* args) {
@@ -583,8 +587,7 @@ void BaseWindow::SetPosition(int x, int y, gin_helper::Arguments* args) {
 }
 
 std::array<int, 2U> BaseWindow::GetPosition() const {
-  const gfx::Point pos = window_->GetPosition();
-  return {pos.x(), pos.y()};
+  return ToArray(window_->GetPosition());
 }
 void BaseWindow::MoveAbove(const std::string& sourceId,
                            gin_helper::Arguments* args) {

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -480,12 +480,9 @@ void BaseWindow::SetContentSize(int width,
   window_->SetContentSize(gfx::Size(width, height), animate);
 }
 
-std::vector<int> BaseWindow::GetContentSize() const {
-  std::vector<int> result(2);
-  gfx::Size size = window_->GetContentSize();
-  result[0] = size.width();
-  result[1] = size.height();
-  return result;
+std::array<int, 2U> BaseWindow::GetContentSize() const {
+  const gfx::Size size = window_->GetContentSize();
+  return {size.width(), size.height()};
 }
 
 void BaseWindow::SetMinimumSize(int width, int height) {

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -149,7 +149,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   bool IsAlwaysOnTop() const;
   void Center();
   void SetPosition(int x, int y, gin_helper::Arguments* args);
-  std::vector<int> GetPosition() const;
+  std::array<int, 2U> GetPosition() const;
   void SetTitle(const std::string& title);
   std::string GetTitle() const;
   void SetAccessibleTitle(const std::string& title);

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -129,7 +129,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void SetMinimumSize(int width, int height);
   std::vector<int> GetMinimumSize() const;
   void SetMaximumSize(int width, int height);
-  std::vector<int> GetMaximumSize() const;
+  std::array<int, 2U> GetMaximumSize() const;
   void SetSheetOffset(double offsetY, gin_helper::Arguments* args);
   void SetResizable(bool resizable);
   bool IsResizable() const;

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -127,7 +127,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   bool IsNormal() const;
   gfx::Rect GetNormalBounds() const;
   void SetMinimumSize(int width, int height);
-  std::vector<int> GetMinimumSize() const;
+  std::array<int, 2U> GetMinimumSize() const;
   void SetMaximumSize(int width, int height);
   std::array<int, 2U> GetMaximumSize() const;
   void SetSheetOffset(double offsetY, gin_helper::Arguments* args);

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -119,7 +119,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void SetBounds(const gfx::Rect& bounds, gin_helper::Arguments* args);
   gfx::Rect GetBounds() const;
   void SetSize(int width, int height, gin_helper::Arguments* args);
-  std::vector<int> GetSize() const;
+  std::array<int, 2U> GetSize() const;
   void SetContentSize(int width, int height, gin_helper::Arguments* args);
   std::vector<int> GetContentSize() const;
   void SetContentBounds(const gfx::Rect& bounds, gin_helper::Arguments* args);

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -121,7 +121,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void SetSize(int width, int height, gin_helper::Arguments* args);
   std::array<int, 2U> GetSize() const;
   void SetContentSize(int width, int height, gin_helper::Arguments* args);
-  std::vector<int> GetContentSize() const;
+  std::array<int, 2U> GetContentSize() const;
   void SetContentBounds(const gfx::Rect& bounds, gin_helper::Arguments* args);
   gfx::Rect GetContentBounds() const;
   bool IsNormal() const;

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_API_ELECTRON_API_BASE_WINDOW_H_
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_BASE_WINDOW_H_
 
+#include <array>
 #include <map>
 #include <memory>
 #include <optional>

--- a/shell/common/gin_converters/std_converter.h
+++ b/shell/common/gin_converters/std_converter.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_COMMON_GIN_CONVERTERS_STD_CONVERTER_H_
 #define ELECTRON_SHELL_COMMON_GIN_CONVERTERS_STD_CONVERTER_H_
 
+#include <array>
 #include <cstddef>
 #include <functional>
 #include <map>


### PR DESCRIPTION
#### Description of Change

A new change in 41d8f90d lets us convert spans to V8. This means we can avoid `std::vector` heap allocations when we're dealing with a fixed-size span (we can use `std::array`) or a span with a known maximum size (we can use `absl::inlined_vector`).

This PR applies this idea to some low-hanging fruit, `BaseWindow`'s size and point getters.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.