### PR TITLE
refactor: remove unnecessary `const_cast`

### DIFF
--- a/shell/browser/electron_web_ui_controller_factory.cc
+++ b/shell/browser/electron_web_ui_controller_factory.cc
@@ -28,7 +28,7 @@ content::WebUI::TypeID ElectronWebUIControllerFactory::GetWebUIType(
   if (const std::string_view host = url.host_piece();
       host == chrome::kChromeUIDevToolsHost ||
       host == chrome::kChromeUIAccessibilityHost) {
-    return const_cast<ElectronWebUIControllerFactory*>(this);
+    return this;
   }
 
   return content::WebUI::kNoWebUI;


### PR DESCRIPTION
#### Description of Change

I'm doing spring cleaning on some small cleanup branches that I've had hanging around on my computer for awhile --

Teeny cleanup 1 of 3: `const_cast` is not needed in `ElectronWebUIControllerFactory::GetWebUIType()`  because as of July 2019 in 50b9c70 it is no longer a const method.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.