### PR TITLE
refactor: use v8::True(isolate) and v8::False(isolate)

### DIFF
--- a/shell/common/gin_helper/callback.cc
+++ b/shell/common/gin_helper/callback.cc
@@ -54,8 +54,7 @@ void CallTranslator(v8::Local<v8::External> external,
       args->ThrowTypeError("One-time callback was called more than once");
       return;
     } else {
-      state->Set(context, called_symbol, v8::Boolean::New(isolate, true))
-          .ToChecked();
+      state->Set(context, called_symbol, v8::True(isolate)).ToChecked();
     }
   }
 

--- a/shell/common/gin_helper/event_emitter_caller.cc
+++ b/shell/common/gin_helper/event_emitter_caller.cc
@@ -18,7 +18,7 @@ v8::Local<v8::Value> CallMethodWithArgs(
 
   // CallbackScope and MakeCallback both require an active node::Environment
   if (!node::Environment::GetCurrent(isolate))
-    return handle_scope.Escape(v8::Boolean::New(isolate, false));
+    return handle_scope.Escape(v8::False(isolate));
 
   node::CallbackScope callback_scope{isolate, v8::Object::New(isolate),
                                      node::async_context{0, 0}};
@@ -39,7 +39,7 @@ v8::Local<v8::Value> CallMethodWithArgs(
   if (v8::Local<v8::Value> localRet; ret.ToLocal(&localRet))
     return handle_scope.Escape(localRet);
 
-  return handle_scope.Escape(v8::Boolean::New(isolate, false));
+  return handle_scope.Escape(v8::False(isolate));
 }
 
 }  // namespace gin_helper::internal


### PR DESCRIPTION
#### Description of Change

Teeny cleanup 2 of 3: Instead of `v8::Boolean::New(isolate, true-or-false)`, use `v8::True(isolate)` and `v8::False(isolate)`.  They are slightly easier to read and very slightly faster (since `New()` just calls `True()` or `False()`)

```diff
- v8::Boolean::New(isolate, true)
+ v8::True(isolate)
- v8::Boolean::New(isolate, false)
+ v8::False(isolate)
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.