### PR TITLE
refactor: make `api::View` methods const, private

### DIFF
--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -280,7 +280,7 @@ void View::SetBounds(const gfx::Rect& bounds) {
   view_->SetBoundsRect(bounds);
 }
 
-gfx::Rect View::GetBounds() {
+gfx::Rect View::GetBounds() const {
   if (!view_)
     return {};
   return view_->bounds();

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -39,7 +39,7 @@ class View : public gin_helper::EventEmitter<View>,
   void RemoveChildView(gin::Handle<View> child);
 
   void SetBounds(const gfx::Rect& bounds);
-  gfx::Rect GetBounds();
+  gfx::Rect GetBounds() const;
   void SetLayout(v8::Isolate* isolate, v8::Local<v8::Object> value);
   std::vector<v8::Local<v8::Value>> GetChildren();
   void SetBackgroundColor(std::optional<WrappedSkColor> color);

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -47,12 +47,6 @@ class View : public gin_helper::EventEmitter<View>,
   void SetVisible(bool visible);
   bool GetVisible() const;
 
-  // views::ViewObserver
-  void OnViewBoundsChanged(views::View* observed_view) override;
-  void OnViewIsDeleting(views::View* observed_view) override;
-  void OnChildViewRemoved(views::View* observed_view,
-                          views::View* child) override;
-
   views::View* view() const { return view_; }
   std::optional<int> border_radius() const { return border_radius_; }
 
@@ -69,6 +63,12 @@ class View : public gin_helper::EventEmitter<View>,
   void set_delete_view(bool should) { delete_view_ = should; }
 
  private:
+  // views::ViewObserver
+  void OnViewBoundsChanged(views::View* observed_view) override;
+  void OnViewIsDeleting(views::View* observed_view) override;
+  void OnChildViewRemoved(views::View* observed_view,
+                          views::View* child) override;
+
   void ApplyBorderRadius();
   void ReorderChildView(gin::Handle<View> child, size_t index);
 

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -21,8 +21,6 @@ class Handle;
 
 namespace electron::api {
 
-using ChildPair = std::pair<raw_ptr<views::View>, v8::Global<v8::Object>>;
-
 class View : public gin_helper::EventEmitter<View>,
              private views::ViewObserver {
  public:
@@ -63,6 +61,8 @@ class View : public gin_helper::EventEmitter<View>,
   void set_delete_view(bool should) { delete_view_ = should; }
 
  private:
+  using ChildPair = std::pair<raw_ptr<views::View>, v8::Global<v8::Object>>;
+
   // views::ViewObserver
   void OnViewBoundsChanged(views::View* observed_view) override;
   void OnViewIsDeleting(views::View* observed_view) override;


### PR DESCRIPTION
#### Description of Change

Teeny cleanup PR 3 of 3: Make some `api::View` methods const or private:

- Make `OnBoundsChanged()` private
- Make `OnViewIsDeleting()` private
- Make `OnChildViewRemoved()` private
- Make `GetBounds()` const
- Make `ChildPair` private

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.