### PR TITLE
perf: avoid redundant map lookups in `GlobalShortcut` (34-x-y backport)

### DIFF
--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -6,6 +6,7 @@
 
 #include <vector>
 
+#include "base/containers/map_util.h"
 #include "extensions/common/command.h"
 #include "gin/dictionary.h"
 #include "gin/handle.h"
@@ -52,12 +53,13 @@ GlobalShortcut::~GlobalShortcut() {
 }
 
 void GlobalShortcut::OnKeyPressed(const ui::Accelerator& accelerator) {
-  if (!accelerator_callback_map_.contains(accelerator)) {
-    // This should never occur, because if it does, GlobalShortcutListener
-    // notifies us with wrong accelerator.
+  if (auto* cb = base::FindOrNull(accelerator_callback_map_, accelerator)) {
+    cb->Run();
+  } else {
+    // This should never occur, because if it does,
+    // ui::GlobalAcceleratorListener notifies us with wrong accelerator.
     NOTREACHED();
   }
-  accelerator_callback_map_[accelerator].Run();
 }
 
 bool GlobalShortcut::RegisterAll(


### PR DESCRIPTION
Manual backport of #46229. See that PR for details.

Notes: none.
