### PR TITLE
refactor: avoid `memset()`

### DIFF
--- a/shell/browser/electron_browser_main_parts_posix.cc
+++ b/shell/browser/electron_browser_main_parts_posix.cc
@@ -53,8 +53,7 @@ int g_shutdown_pipe_read_fd = -1;
 // Common code between SIG{HUP, INT, TERM}Handler.
 void GracefulShutdownHandler(int signal) {
   // Reinstall the default handler.  We had one shot at graceful shutdown.
-  struct sigaction action;
-  memset(&action, 0, sizeof(action));
+  struct sigaction action = {};
   action.sa_handler = SIG_DFL;
   RAW_CHECK(sigaction(signal, &action, nullptr) == 0);
 
@@ -174,8 +173,7 @@ void ShutdownDetector::ThreadMain() {
 void ElectronBrowserMainParts::HandleSIGCHLD() {
   // We need to accept SIGCHLD, even though our handler is a no-op because
   // otherwise we cannot wait on children. (According to POSIX 2001.)
-  struct sigaction action;
-  memset(&action, 0, sizeof(action));
+  struct sigaction action = {};
   action.sa_handler = SIGCHLDHandler;
   CHECK_EQ(sigaction(SIGCHLD, &action, nullptr), 0);
 }
@@ -217,8 +215,7 @@ void ElectronBrowserMainParts::InstallShutdownSignalHandlers(
 
   // We need to handle SIGTERM, because that is how many POSIX-based distros
   // ask processes to quit gracefully at shutdown time.
-  struct sigaction action;
-  memset(&action, 0, sizeof(action));
+  struct sigaction action = {};
   action.sa_handler = SIGTERMHandler;
   CHECK_EQ(sigaction(SIGTERM, &action, nullptr), 0);
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1081,8 +1081,7 @@ void NativeWindowViews::SetClosable(bool closable) {
 bool NativeWindowViews::IsClosable() const {
 #if BUILDFLAG(IS_WIN)
   HMENU menu = GetSystemMenu(GetAcceleratedWidget(), false);
-  MENUITEMINFO info;
-  memset(&info, 0, sizeof(info));
+  MENUITEMINFO info = {};
   info.cbSize = sizeof(info);
   info.fMask = MIIM_STATE;
   if (!GetMenuItemInfo(menu, SC_CLOSE, false, &info)) {

--- a/shell/browser/relauncher_linux.cc
+++ b/shell/browser/relauncher_linux.cc
@@ -31,8 +31,7 @@ void RelauncherSynchronizeWithParent() {
   }
 
   // set up a signum handler
-  struct sigaction action;
-  memset(&action, 0, sizeof(action));
+  struct sigaction action = {};
   action.sa_handler = [](int /*signum*/) { parentWaiter.Signal(); };
   if (sigaction(signum, &action, nullptr) != 0) {
     PLOG(ERROR) << "sigaction";

--- a/shell/browser/ui/win/notify_icon.cc
+++ b/shell/browser/ui/win/notify_icon.cc
@@ -242,8 +242,7 @@ void NotifyIcon::SetContextMenu(raw_ptr<ElectronMenuModel> menu_model) {
 }
 
 gfx::Rect NotifyIcon::GetBounds() {
-  NOTIFYICONIDENTIFIER icon_id;
-  memset(&icon_id, 0, sizeof(NOTIFYICONIDENTIFIER));
+  NOTIFYICONIDENTIFIER icon_id = {};
   icon_id.uID = icon_id_;
   icon_id.hWnd = window_;
   icon_id.cbSize = sizeof(NOTIFYICONIDENTIFIER);

--- a/shell/browser/ui/win/notify_icon.h
+++ b/shell/browser/ui/win/notify_icon.h
@@ -76,7 +76,7 @@ class NotifyIcon : public TrayIcon {
   base::WeakPtr<NotifyIcon> GetWeakPtr() { return weak_factory_.GetWeakPtr(); }
 
  private:
-  void InitIconData(NOTIFYICONDATA* icon_data);
+  NOTIFYICONDATA InitIconData() const;
 
   // The tray that owns us.  Weak.
   raw_ptr<NotifyIconHost> host_;


### PR DESCRIPTION
#### Description of Change

Upstream is adding `UNSAFE_TODO()` suppressions for calls to `memset()`, e.g. [here](https://chromium-review.googlesource.com/c/chromium/src/+/6378183). This appears to be related to the ongoing `-Wunsafe-buffer-usage` work.

The few places we use `memset()` are easily replaced with Value Initialization, so that PR fixes it instead of flagging anything as `UNSAFE_TODO()`.

TODO(ckerr): I haven't found explicit discussion of unsafe libc calls + `-Wunsafe-buffer-usage` upstream yet. Are they already getting warnings on these calls? If so, why aren't we seeing them in our code -- is there something we need to opt into?

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.