### PR TITLE
fix: remove obsoleted `--inspect-brk` logic

### DIFF
--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -218,7 +218,6 @@ if (packagePath) {
   } else {
     // Call appCodeLoaded before just for safety, it doesn't matter here as _load is synchronous
     appCodeLoaded!();
-    process._firstFileName = Module._resolveFilename(path.join(packagePath, mainStartupScript), null, false);
     Module._load(path.join(packagePath, mainStartupScript), Module, true);
   }
 } else {

--- a/patches/node/chore_allow_the_node_entrypoint_to_be_a_builtin_module.patch
+++ b/patches/node/chore_allow_the_node_entrypoint_to_be_a_builtin_module.patch
@@ -7,24 +7,6 @@ This allows embedders to tell Node.js what the first "real" file is  when
 they use themselves as the entry point. We should try to upstream some form
 of this.
 
-diff --git a/lib/internal/modules/cjs/loader.js b/lib/internal/modules/cjs/loader.js
-index 9b5772fe9b8babbb892c7a5ec79258472da55a76..3568fd6ea0816f62d97d46f5d497bb1b23bf4e25 100644
---- a/lib/internal/modules/cjs/loader.js
-+++ b/lib/internal/modules/cjs/loader.js
-@@ -1555,6 +1555,13 @@ Module.prototype._compile = function(content, filename, format) {
-   this[kIsExecuting] = true;
-   if (this[kIsMainSymbol] && getOptionValue('--inspect-brk')) {
-     const { callAndPauseOnStart } = internalBinding('inspector');
-+    // process._firstFileName is used by Embedders to tell node what
-+    // the first "real" file is when they use themselves as the entry
-+    // point
-+    if (process._firstFileName) {
-+      resolvedArgv = process._firstFileName;
-+      delete process._firstFileName;
-+    }
-     result = callAndPauseOnStart(compiledWrapper, thisValue, exports,
-                                  require, module, filename, dirname,
-                                  process, localGlobal, localBuffer);
 diff --git a/lib/internal/process/pre_execution.js b/lib/internal/process/pre_execution.js
 index d1c05d1717cdc825c4e48885c963c9ed65bcf51c..278665921c5160ff10b3178db27d4df319fab6b3 100644
 --- a/lib/internal/process/pre_execution.js

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -255,7 +255,6 @@ declare namespace NodeJS {
     once(event: 'document-end', listener: () => any): this;
 
     // Additional properties
-    _firstFileName?: string;
     _serviceStartupScript: string;
     _getOrCreateArchive?: (path: string) => NodeJS.AsarArchive | null;
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/46491.
Refs https://github.com/nodejs/node/pull/55679

Removes logic made redundant in https://github.com/nodejs/node/pull/55679/files.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue with `--inspect-brk`  failing in packaged apps.