### PR TITLE
fix: `NativeWindow.window_id()` returns same value for all windows

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -94,8 +94,6 @@ gfx::Size GetExpandedWindowSize(const NativeWindow* window, gfx::Size size) {
 NativeWindow::NativeWindow(const gin_helper::Dictionary& options,
                            NativeWindow* parent)
     : widget_(std::make_unique<views::Widget>()), parent_(parent) {
-  ++next_id_;
-
   options.Get(options::kFrame, &has_frame_);
   options.Get(options::kTransparent, &transparent_);
   options.Get(options::kEnableLargerThanScreen, &enable_larger_than_screen_);
@@ -819,9 +817,6 @@ void NativeWindow::HandlePendingFullscreenTransitions() {
   pending_transitions_.pop();
   SetFullScreen(next_transition);
 }
-
-// static
-int32_t NativeWindow::next_id_ = 0;
 
 bool NativeWindow::IsTranslucent() const {
   // Transparent windows are translucent

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -409,7 +409,7 @@ class NativeWindow : public base::SupportsUserData,
   NativeWindow* parent() const { return parent_; }
   bool is_modal() const { return is_modal_; }
 
-  int32_t window_id() const { return next_id_; }
+  int32_t window_id() const { return window_id_; }
 
   void add_child_window(NativeWindow* child) {
     child_windows_.push_back(child);
@@ -472,7 +472,8 @@ class NativeWindow : public base::SupportsUserData,
  private:
   std::unique_ptr<views::Widget> widget_;
 
-  static int32_t next_id_;
+  static inline int32_t next_id_ = 0;
+  const int32_t window_id_ = ++next_id_;
 
   // The content view, weak ref.
   raw_ptr<views::View> content_view_ = nullptr;


### PR DESCRIPTION
#### Description of Change

`NativeWindow::window_id()` always returned the same value, no matter which `NativeWindow` was being queried. This caused `ElectronAccessibilityUI` to behave unpredictably because `RequestNativeUITree()` could sometimes key in on the wrong native window. Introduced in 3f37ff8.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed ElectronAccessibilityUI bug.