### PR TITLE
ci: add problem matcher for clang output

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -38,6 +38,9 @@ runs:
       run: |
         GN_APPENDED_ARGS="$GN_EXTRA_ARGS target_cpu=\"x64\" v8_snapshot_toolchain=\"//build/toolchain/mac:clang_x64\""
         echo "GN_EXTRA_ARGS=$GN_APPENDED_ARGS" >> $GITHUB_ENV
+    - name: Add Clang problem matcher
+      shell: bash
+      run: echo "::add-matcher::src/electron/.github/problem-matchers/clang.json"
     - name: Build Electron ${{ inputs.step-suffix }}
       shell: bash
       run: |
@@ -199,6 +202,9 @@ runs:
         e build --target electron:libcxx_headers_zip -j $NUMBER_OF_NINJA_PROCESSES
         e build --target electron:libcxxabi_headers_zip -j $NUMBER_OF_NINJA_PROCESSES
         e build --target electron:libcxx_objects_zip -j $NUMBER_OF_NINJA_PROCESSES
+    - name: Remove Clang problem matcher
+      shell: bash
+      run: echo "::remove-matcher owner=clang::"
     - name: Generate TypeScript Definitions ${{ inputs.step-suffix }}
       if: ${{ inputs.is-release == 'true' }}
       shell: bash

--- a/.github/problem-matchers/clang.json
+++ b/.github/problem-matchers/clang.json
@@ -1,0 +1,18 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "clang",
+      "fromPath": "src/out/Default/args.gn",
+      "pattern": [
+        {
+          "regexp": "^(.+)[(:](\\d+)[:,](\\d+)\\)?:\\s+(warning|error):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Adds [a GitHub actions problem matcher](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md) to turn warnings/errors in the build output into warning/error annotations on the workflow runs so they're more discoverable.

See https://github.com/electron/electron/actions/runs/15127447507 for an example run with annotations on the summary page (scroll to the bottom, but links won't work since I removed the build error commit), or see the image below. Unfortunately there's no deduplication of annotations (long standing issue) so we get a lot of duplicate ones across our various build configurations. On each individual jobs the annotations are at the top of the page, collapsed by default.

<img width="613" alt="Build Error Annotations" src="https://github.com/user-attachments/assets/99b216e3-c736-44e4-b8d9-478368615ab1" />

~~Blocked by https://github.com/actions/runner/pull/3802 as the relative paths in our build errors are relative to `src/out/Default/` but the problem matcher constructs absolute paths from the workspace directory - there's no way to get `src` into the constructed path as it doesn't occur in either the workspace directory or the relative path in the error.~~

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
