### PR TITLE
refactor: use default printing path when no user options

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -263,8 +263,17 @@ WebContents.prototype.print = function (options: ElectronInternal.WebContentsPri
     throw new TypeError('webContents.print(): Invalid print settings specified.');
   }
 
-  const pageSize = options.pageSize ?? 'A4';
-  if (typeof pageSize === 'object') {
+  const { pageSize } = options;
+  if (typeof pageSize === 'string' && PDFPageSizes[pageSize]) {
+    const mediaSize = PDFPageSizes[pageSize];
+    options.mediaSize = {
+      ...mediaSize,
+      imageable_area_left_microns: 0,
+      imageable_area_bottom_microns: 0,
+      imageable_area_right_microns: mediaSize.width_microns,
+      imageable_area_top_microns: mediaSize.height_microns
+    };
+  } else if (typeof pageSize === 'object') {
     if (!pageSize.height || !pageSize.width) {
       throw new Error('height and width properties are required for pageSize');
     }
@@ -286,16 +295,7 @@ WebContents.prototype.print = function (options: ElectronInternal.WebContentsPri
       imageable_area_right_microns: width,
       imageable_area_top_microns: height
     };
-  } else if (typeof pageSize === 'string' && PDFPageSizes[pageSize]) {
-    const mediaSize = PDFPageSizes[pageSize];
-    options.mediaSize = {
-      ...mediaSize,
-      imageable_area_left_microns: 0,
-      imageable_area_bottom_microns: 0,
-      imageable_area_right_microns: mediaSize.width_microns,
-      imageable_area_top_microns: mediaSize.height_microns
-    };
-  } else {
+  } else if (pageSize !== undefined) {
     throw new Error(`Unsupported pageSize: ${pageSize}`);
   }
 

--- a/shell/common/gin_helper/dictionary.h
+++ b/shell/common/gin_helper/dictionary.h
@@ -183,6 +183,16 @@ class Dictionary : public gin::Dictionary {
 
   bool IsEmpty() const { return isolate() == nullptr || GetHandle().IsEmpty(); }
 
+  bool IsEmptyObject() const {
+    if (IsEmpty())
+      return true;
+
+    v8::Local<v8::Context> context = isolate()->GetCurrentContext();
+    v8::Local<v8::Array> props =
+        GetHandle()->GetOwnPropertyNames(context).ToLocalChecked();
+    return props->Length() == 0;
+  }
+
   v8::Local<v8::Object> GetHandle() const {
     return gin::ConvertToV8(isolate(),
                             *static_cast<const gin::Dictionary*>(this))


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/31151.

Fixes an issue where printing from the renderer process crashes the main process when no printers are installed in the system or there's not a default printer.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where printing from the renderer process crashes the main process when no printers are installed in the system or there's not a default printer.
