### PR TITLE
refactor: use `WidgetDelegate::SetInitiallyFocusedView()`

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -480,8 +480,10 @@ void NativeWindowViews::SetContentView(views::View* view) {
   }
   set_content_view(view);
   SetInitiallyFocusedView(view);
-  root_view_.GetMainView()->AddChildViewRaw(content_view());
-  root_view_.GetMainView()->DeprecatedLayoutImmediately();
+
+  views::View* const main_view = root_view_.GetMainView();
+  main_view->AddChildViewRaw(view);
+  main_view->DeprecatedLayoutImmediately();
 }
 
 void NativeWindowViews::Close() {

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -479,7 +479,7 @@ void NativeWindowViews::SetContentView(views::View* view) {
     root_view_.GetMainView()->RemoveChildView(content_view());
   }
   set_content_view(view);
-  focused_view_ = view;
+  SetInitiallyFocusedView(view);
   root_view_.GetMainView()->AddChildViewRaw(content_view());
   root_view_.GetMainView()->DeprecatedLayoutImmediately();
 }
@@ -1732,10 +1732,6 @@ void NativeWindowViews::OnWidgetDestroying(views::Widget* widget) {
 
 void NativeWindowViews::OnWidgetDestroyed(views::Widget* changed_widget) {
   widget_destroyed_ = true;
-}
-
-views::View* NativeWindowViews::GetInitiallyFocusedView() {
-  return focused_view_;
 }
 
 bool NativeWindowViews::CanMaximize() const {

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -190,7 +190,6 @@ class NativeWindowViews : public NativeWindow,
   void OnWidgetDestroyed(views::Widget* widget) override;
 
   // views::WidgetDelegate:
-  views::View* GetInitiallyFocusedView() override;
   bool CanMaximize() const override;
   bool CanMinimize() const override;
   std::u16string GetWindowTitle() const override;
@@ -237,9 +236,6 @@ class NativeWindowViews : public NativeWindow,
   void MoveBehindTaskBarIfNeeded();
 
   RootView root_view_{this};
-
-  // The view should be focused by default.
-  raw_ptr<views::View> focused_view_ = nullptr;
 
   // The "resizable" flag on Linux is implemented by setting size constraints,
   // we need to make sure size constraints are restored when window becomes


### PR DESCRIPTION
#### Description of Change

- Use `WidgetDelegate::SetInitiallyFocusedView()` instead of rolling our own implementation. The old code exists because it wasa written before `SetInitiallyFocusedView()` was added upstream by  https://chromium-review.googlesource.com/c/chromium/src/+/2440285.
- Minor side refactor of only calling `GetMainView()` once instead of twice

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.