### PR TITLE
fix: fallback to old MacOS context menu behavior if no frame is present

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -74,7 +74,7 @@ The `menu` object has the following instance methods:
 * `options` Object (optional)
   * `window` [BaseWindow](base-window.md) (optional) - Default is the focused window.
   * `frame` [WebFrameMain](web-frame-main.md) (optional) - Provide the relevant frame
-    if you want certain OS-level features such as Writing Tools on macOS to function correctly. Typically, this should be `params.frame` from the [`context-menu` event](web-contents.md#event-context-menu) on a WebContents.
+    if you want certain OS-level features such as Writing Tools on macOS to function correctly. Typically, this should be `params.frame` from the [`context-menu` event](web-contents.md#event-context-menu) on a WebContents, or the [`focusedFrame` property](web-contents.md#contentsfocusedframe-readonly) of a WebContents.
   * `x` number (optional) - Default is the current mouse cursor position.
     Must be declared if `y` is declared.
   * `y` number (optional) - Default is the current mouse cursor position.

--- a/shell/browser/api/electron_api_menu_mac.mm
+++ b/shell/browser/api/electron_api_menu_mac.mm
@@ -164,17 +164,23 @@ void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
           static_cast<content::RenderWidgetHostViewMac*>(rfh->GetView());
       RenderWidgetHostViewCocoa* cocoa_view = rwhvm->GetInProcessNSView();
       view = cocoa_view;
+
+      // TODO: ui::ShowContextMenu does not dispatch the event correctly
+      // if no frame is found. Fix this to remove if/else condition.
+      NSEvent* dummy_event =
+          [NSEvent mouseEventWithType:NSEventTypeRightMouseDown
+                             location:position
+                        modifierFlags:0
+                            timestamp:0
+                         windowNumber:nswindow.windowNumber
+                              context:nil
+                          eventNumber:0
+                           clickCount:1
+                             pressure:0];
+      ui::ShowContextMenu(menu, dummy_event, view, true);
     }
-    NSEvent* dummy_event = [NSEvent mouseEventWithType:NSEventTypeRightMouseDown
-                                              location:position
-                                         modifierFlags:0
-                                             timestamp:0
-                                          windowNumber:nswindow.windowNumber
-                                               context:nil
-                                           eventNumber:0
-                                            clickCount:1
-                                              pressure:0];
-    ui::ShowContextMenu(menu, dummy_event, view, true);
+    // If no render frame host was found, return early.
+    return;
   } else {
     // Make sure events can be pumped while the menu is up.
     base::CurrentThread::ScopedAllowApplicationTasksInNativeNestedLoop allow;

--- a/shell/browser/api/electron_api_menu_mac.mm
+++ b/shell/browser/api/electron_api_menu_mac.mm
@@ -165,18 +165,30 @@ void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
       RenderWidgetHostViewCocoa* cocoa_view = rwhvm->GetInProcessNSView();
       view = cocoa_view;
     }
-  }
+    NSEvent* dummy_event = [NSEvent mouseEventWithType:NSEventTypeRightMouseDown
+                                              location:position
+                                         modifierFlags:0
+                                             timestamp:0
+                                          windowNumber:nswindow.windowNumber
+                                               context:nil
+                                           eventNumber:0
+                                            clickCount:1
+                                              pressure:0];
+    ui::ShowContextMenu(menu, dummy_event, view, true);
+  } else {
+    // Make sure events can be pumped while the menu is up.
+    base::CurrentThread::ScopedAllowApplicationTasksInNativeNestedLoop allow;
 
-  NSEvent* dummy_event = [NSEvent mouseEventWithType:NSEventTypeRightMouseDown
-                                            location:position
-                                       modifierFlags:0
-                                           timestamp:0
-                                        windowNumber:nswindow.windowNumber
-                                             context:nil
-                                         eventNumber:0
-                                          clickCount:1
-                                            pressure:0];
-  ui::ShowContextMenu(menu, dummy_event, view, true);
+    // One of the events that could be pumped is |window.close()|.
+    // User-initiated event-tracking loops protect against this by
+    // setting flags in -[CrApplication sendEvent:], but since
+    // web-content menus are initiated by IPC message the setup has to
+    // be done manually.
+    base::mac::ScopedSendingEvent sendingEventScoper;
+
+    // Don't emit unresponsive event when showing menu.
+    [menu popUpMenuPositioningItem:item atLocation:position inView:view];
+  }
 }
 
 void MenuMac::ClosePopupAt(int32_t window_id) {

--- a/shell/browser/api/electron_api_menu_mac.mm
+++ b/shell/browser/api/electron_api_menu_mac.mm
@@ -178,23 +178,22 @@ void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
                            clickCount:1
                              pressure:0];
       ui::ShowContextMenu(menu, dummy_event, view, true);
+      return;
     }
-    // If no render frame host was found, return early.
-    return;
-  } else {
-    // Make sure events can be pumped while the menu is up.
-    base::CurrentThread::ScopedAllowApplicationTasksInNativeNestedLoop allow;
-
-    // One of the events that could be pumped is |window.close()|.
-    // User-initiated event-tracking loops protect against this by
-    // setting flags in -[CrApplication sendEvent:], but since
-    // web-content menus are initiated by IPC message the setup has to
-    // be done manually.
-    base::mac::ScopedSendingEvent sendingEventScoper;
-
-    // Don't emit unresponsive event when showing menu.
-    [menu popUpMenuPositioningItem:item atLocation:position inView:view];
   }
+
+  // Make sure events can be pumped while the menu is up.
+  base::CurrentThread::ScopedAllowApplicationTasksInNativeNestedLoop allow;
+
+  // One of the events that could be pumped is |window.close()|.
+  // User-initiated event-tracking loops protect against this by
+  // setting flags in -[CrApplication sendEvent:], but since
+  // web-content menus are initiated by IPC message the setup has to
+  // be done manually.
+  base::mac::ScopedSendingEvent sendingEventScoper;
+
+  // Don't emit unresponsive event when showing menu.
+  [menu popUpMenuPositioningItem:item atLocation:position inView:view];
 }
 
 void MenuMac::ClosePopupAt(int32_t window_id) {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/46505

Follow up to #45138

This PR re-adds and falls back to the old code path for context menus, should a user not explicitly pass in a frame option into the menus

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where context menu actions such as copy/paste did not correctly fire when a frame was not passed in
