### PR TITLE
docs: cleanup docs/tutorial/custom-window-styles.md

### DIFF
--- a/docs/tutorial/custom-window-styles.md
+++ b/docs/tutorial/custom-window-styles.md
@@ -37,7 +37,6 @@ the illusion of a circular window.
   open on the user's system).
 * The window will not be transparent when DevTools is opened.
 * On _Windows_:
-  * Transparent windows will not work when DWM is disabled.
   * Transparent windows can not be maximized using the Windows system menu or by double
   clicking the title bar. The reasoning behind this can be seen on
   PR [#28207](https://github.com/electron/electron/pull/28207).


### PR DESCRIPTION
#### Description of Change
> Transparent windows will not work when DWM is disabled.

This no longer applies since Electron 23, which only supports Windows 10+, where DWM composition can no longer be disabled.
Follow-up to #45563

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)

#### Release Notes
Notes: none
