### PR TITLE
fix: handle potential missing close event property

### DIFF
--- a/lib/browser/api/browser-window.ts
+++ b/lib/browser/api/browser-window.ts
@@ -54,7 +54,7 @@ BrowserWindow.prototype._init = function (this: BWT) {
   });
   this.on('close', (event) => {
     queueMicrotask(() => {
-      if (!unresponsiveEvent && !event.defaultPrevented) {
+      if (!unresponsiveEvent && !event?.defaultPrevented) {
         unresponsiveEvent = setTimeout(emitUnresponsiveEvent, 5000);
       }
     });


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/46574.

If an app for some reason emits `close` themselves the `close` event won't have an `event` property necessarily. Ensure an error isn't thrown in that case.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an error when calling `window.emit('close')` after toggling fullscreen mode.