### PR TITLE
build: ignore files in .git when running markdownlint-cli2

### DIFF
--- a/script/lint.js
+++ b/script/lint.js
@@ -278,7 +278,7 @@ const LINTERS = [{
 }, {
   key: 'md',
   roots: ['.'],
-  ignoreRoots: ['node_modules', 'spec/node_modules'],
+  ignoreRoots: ['.git', 'node_modules', 'spec/node_modules'],
   test: filename => filename.endsWith('.md'),
   run: async (opts, filenames) => {
     let errors = false;


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Unknown reason why this suddenly became a problem, but the lint script started popping false positives inside the `.git` directory so explicitly ignore it.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
