### PR TITLE
fix: hard crash on invalid command line switches

### DIFF
--- a/docs/api/command-line.md
+++ b/docs/api/command-line.md
@@ -20,45 +20,87 @@ document.
 
 #### `commandLine.appendSwitch(switch[, value])`
 
-* `switch` string - A command-line switch, without the leading `--`
-* `value` string (optional) - A value for the given switch
+* `switch` string - A command-line switch, without the leading `--`.
+* `value` string (optional) - A value for the given switch.
 
 Append a switch (with optional `value`) to Chromium's command line.
 
 **Note:** This will not affect `process.argv`. The intended usage of this function is to
 control Chromium's behavior.
 
+```js
+const { app } = require('electron')
+
+app.commandLine.appendSwitch('remote-debugging-port', '8315')
+```
+
 #### `commandLine.appendArgument(value)`
 
-* `value` string - The argument to append to the command line
+* `value` string - The argument to append to the command line.
 
 Append an argument to Chromium's command line. The argument will be quoted
 correctly. Switches will precede arguments regardless of appending order.
 
 If you're appending an argument like `--switch=value`, consider using `appendSwitch('switch', 'value')` instead.
 
+```js
+const { app } = require('electron')
+
+app.commandLine.appendArgument('--enable-experimental-web-platform-features')
+```
+
 **Note:** This will not affect `process.argv`. The intended usage of this function is to
 control Chromium's behavior.
 
 #### `commandLine.hasSwitch(switch)`
 
-* `switch` string - A command-line switch
+* `switch` string - A command-line switch.
 
 Returns `boolean` - Whether the command-line switch is present.
 
+```js
+const { app } = require('electron')
+
+app.commandLine.appendSwitch('remote-debugging-port', '8315')
+const hasPort = app.commandLine.hasSwitch('remote-debugging-port')
+console.log(hasPort) // true
+```
+
 #### `commandLine.getSwitchValue(switch)`
 
-* `switch` string - A command-line switch
+* `switch` string - A command-line switch.
 
 Returns `string` - The command-line switch value.
+
+This function is meant to obtain Chromium command line switches. It is not
+meant to be used for application-specific command line arguments. For the
+latter, please use `process.argv`.
+
+```js
+const { app } = require('electron')
+
+app.commandLine.appendSwitch('remote-debugging-port', '8315')
+const portValue = app.commandLine.getSwitchValue('remote-debugging-port')
+console.log(portValue) // '8315'
+```
 
 **Note:** When the switch is not present or has no value, it returns empty string.
 
 #### `commandLine.removeSwitch(switch)`
 
-* `switch` string - A command-line switch
+* `switch` string - A command-line switch.
 
 Removes the specified switch from Chromium's command line.
+
+```js
+const { app } = require('electron')
+
+app.commandLine.appendSwitch('remote-debugging-port', '8315')
+console.log(app.commandLine.hasSwitch('remote-debugging-port')) // true
+
+app.commandLine.removeSwitch('remote-debugging-port')
+console.log(app.commandLine.hasSwitch('remote-debugging-port')) // false
+```
 
 **Note:** This will not affect `process.argv`. The intended usage of this function is to
 control Chromium's behavior.

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -14,6 +14,14 @@ This document uses the following convention to categorize breaking changes:
 
 ## Planned Breaking API Changes (35.0)
 
+### Behavior Changes: `app.commandLine`
+
+`app.commandLine` will convert upper-cases switches and arguments to lowercase.
+
+`app.commandLine` was only meant to handle chromium switches (which aren't case-sensitive) and switches passed via `app.commandLine` will not be passed down to any of the child processes.
+
+If you were using `app.commandLine` to control the behavior of the  main process, you should do this via `process.argv`.
+
 ### Behavior Changed: Dialog API's `defaultPath` option on Linux
 
 On Linux, the required portal version for file dialogs has been reverted

--- a/shell/common/api/electron_api_command_line.cc
+++ b/shell/common/api/electron_api_command_line.cc
@@ -4,50 +4,59 @@
 
 #include "base/command_line.h"
 #include "base/files/file_path.h"
+#include "base/strings/string_util.h"
 #include "services/network/public/cpp/network_switches.h"
 #include "shell/common/gin_converters/base_converter.h"
 #include "shell/common/gin_converters/file_path_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
+#include "third_party/abseil-cpp/absl/strings/ascii.h"
 
 namespace {
+bool HasSwitch(const std::string& switch_string) {
+  auto switch_str = base::ToLowerASCII(switch_string);
 
-bool HasSwitch(const std::string& name) {
-  return base::CommandLine::ForCurrentProcess()->HasSwitch(name);
+  auto* command_line = base::CommandLine::ForCurrentProcess();
+  return command_line->HasSwitch(switch_str);
 }
 
-base::CommandLine::StringType GetSwitchValue(const std::string& name) {
-  return base::CommandLine::ForCurrentProcess()->GetSwitchValueNative(name);
+base::CommandLine::StringType GetSwitchValue(gin_helper::ErrorThrower thrower,
+                                             const std::string& switch_string) {
+  auto switch_str = base::ToLowerASCII(switch_string);
+
+  auto* command_line = base::CommandLine::ForCurrentProcess();
+  return command_line->GetSwitchValueNative(switch_str);
 }
 
 void AppendSwitch(const std::string& switch_string,
                   gin_helper::Arguments* args) {
+  auto switch_str = base::ToLowerASCII(switch_string);
   auto* command_line = base::CommandLine::ForCurrentProcess();
-
   if (base::EndsWith(switch_string, "-path",
                      base::CompareCase::INSENSITIVE_ASCII) ||
       switch_string == network::switches::kLogNetLog) {
     base::FilePath path;
     args->GetNext(&path);
-    command_line->AppendSwitchPath(switch_string, path);
+    command_line->AppendSwitchPath(switch_str, path);
     return;
   }
 
   base::CommandLine::StringType value;
   if (args->GetNext(&value))
-    command_line->AppendSwitchNative(switch_string, value);
+    command_line->AppendSwitchNative(switch_str, value);
   else
-    command_line->AppendSwitch(switch_string);
+    command_line->AppendSwitch(switch_str);
 }
 
 void RemoveSwitch(const std::string& switch_string) {
+  auto switch_str = base::ToLowerASCII(switch_string);
+
   auto* command_line = base::CommandLine::ForCurrentProcess();
-  command_line->RemoveSwitch(switch_string);
+  command_line->RemoveSwitch(switch_str);
 }
 
 void AppendArg(const std::string& arg) {
   auto* command_line = base::CommandLine::ForCurrentProcess();
-
   command_line->AppendArg(arg);
 }
 


### PR DESCRIPTION
Backport of #46004.

See that PR for details.

Notes: Fixed an issue where badly formatted switches could cause crashes in `app.commandLine` functions.