### PR TITLE
fix: fullscreen fillet / recovery is incorrect

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -386,6 +386,7 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
     }
 
     ::SetWindowLong(GetAcceleratedWidget(), GWL_STYLE, frame_style);
+    SetRoundedCorners(rounded_corner_);
   }
 
   LONG ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -376,13 +376,16 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
       frame_style |= WS_MINIMIZEBOX;
     if (maximizable_)
       frame_style |= WS_MAXIMIZEBOX;
-    // We should not show a frame for transparent window.
-    if (!thick_frame_)
-      frame_style &= ~(WS_THICKFRAME | WS_CAPTION);
-    ::SetWindowLong(GetAcceleratedWidget(), GWL_STYLE, frame_style);
 
-    options.Get(options::kRoundedCorners, &rounded_corner_);
-    SetRoundedCorners(rounded_corner_);
+    // We should not show a frame for transparent window.
+    if (!thick_frame_) {
+      frame_style &= ~(WS_THICKFRAME | WS_CAPTION);
+      rounded_corner_ = false;
+    } else {
+      options.Get(options::kRoundedCorners, &rounded_corner_);
+    }
+
+    ::SetWindowLong(GetAcceleratedWidget(), GWL_STYLE, frame_style);
   }
 
   LONG ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -652,8 +652,9 @@ void NativeWindowViews::SetEnabledInternal(bool enable) {
 void NativeWindowViews::Maximize() {
 #if BUILDFLAG(IS_WIN)
   if (IsTranslucent()) {
-    // If a window is translucent but not transparent on Windows,
-    // that means it must have a backgroundMaterial set.
+    // Semi-transparent windows with backgroundMaterial not set to 'none', and
+    // not fully transparent, require manual handling of rounded corners when
+    // maximized.
     if (rounded_corner_)
       SetRoundedCorners(false);
 

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -289,6 +289,9 @@ class NativeWindowViews : public NativeWindow,
   HWND legacy_window_ = nullptr;
   bool layered_ = false;
 
+  // this value is determined when the window is created.
+  bool rounded_corner_ = true;
+
   // Set to true if the window is always on top and behind the task bar.
   bool behind_task_bar_ = false;
 

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -289,7 +289,7 @@ class NativeWindowViews : public NativeWindow,
   HWND legacy_window_ = nullptr;
   bool layered_ = false;
 
-  // this value is determined when the window is created.
+  // This value is determined when the window is created.
   bool rounded_corner_ = true;
 
   // Set to true if the window is always on top and behind the task bar.


### PR DESCRIPTION
#### Description of Change

fix: #46468

I can't run the test on the company's device. It gives the error "Error: Failed to get git tag, script quit with 9009." I looked at the script file but couldn't understand what's happening...
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed the issue where maximizing and restoring the window does not respect the corner radius settings, and the corner radius is incorrect in fullscreen mode.
