### PR TITLE
fix: `backgroundMaterial` on initial activate

### DIFF
--- a/patches/chromium/fix_activate_background_material_on_windows.patch
+++ b/patches/chromium/fix_activate_background_material_on_windows.patch
@@ -14,7 +14,7 @@ This patch likely can't be upstreamed as-is, as Chromium doesn't have
 this use case in mind currently.
 
 diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
-index 29829e282edfa8821bd366a9e9a3755d7f3f8643..c2f46c5960ef914a21e6df6e56298b3cc8bc36e9 100644
+index 29829e282edfa8821bd366a9e9a3755d7f3f8643..661864ab6aad78a721ac921ae778c40085cdc23e 100644
 --- a/ui/views/win/hwnd_message_handler.cc
 +++ b/ui/views/win/hwnd_message_handler.cc
 @@ -952,13 +952,13 @@ void HWNDMessageHandler::FrameTypeChanged() {
@@ -38,7 +38,7 @@ index 29829e282edfa8821bd366a9e9a3755d7f3f8643..c2f46c5960ef914a21e6df6e56298b3c
        thread_id != GetCurrentThreadId()) {
      // Update the native frame if it is rendering the non-client area.
 -    if (HasSystemFrame()) {
-+    if (HasSystemFrame() || is_translucent_) {
++    if (is_translucent_ || HasSystemFrame()) {
        DefWindowProcWithRedrawLock(WM_NCACTIVATE, FALSE, 0);
      }
    }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/38466

Extends https://github.com/electron/electron/issues/39708 to fix an issue where the `backgroundMaterial` feature did not work in a frameless window on initial window creation. A repaint needed to be triggered first, by a resize or other similar action.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the `backgroundMaterial` feature did not work in a frameless window on initial window creation.