### PR TITLE
fix: file dialog filters not working correctly

### DIFF
--- a/shell/browser/ui/file_dialog_linux.cc
+++ b/shell/browser/ui/file_dialog_linux.cc
@@ -44,14 +44,14 @@ ui::SelectFileDialog::FileTypeInfo GetFilterInfo(const Filters& filters) {
   ui::SelectFileDialog::FileTypeInfo file_type_info;
 
   for (const auto& [name, extension_group] : filters) {
-    file_type_info.extension_description_overrides.push_back(
-        base::UTF8ToUTF16(name));
-
     const bool has_all_files_wildcard = std::ranges::any_of(
         extension_group, [](const auto& ext) { return ext == "*"; });
+
     if (has_all_files_wildcard) {
       file_type_info.include_all_files = true;
     } else {
+      file_type_info.extension_description_overrides.push_back(
+          base::UTF8ToUTF16(name));
       file_type_info.extensions.emplace_back(extension_group);
     }
   }


### PR DESCRIPTION
#### Description of Change

Fixed a problem where filter name and the extensions they filter won't match.

If someone sets an `All filter` with `*` at the start of the filters all upcoming filters will be shifted and thus labels won't fit to the extensions they actually filter.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed case where file dialog filters would get mixed up, if a `*` filter was included
