### PR TITLE
fix: do not run microtasks in V8Serializer in browser process

### DIFF
--- a/shell/common/v8_util.cc
+++ b/shell/common/v8_util.cc
@@ -36,7 +36,7 @@ class V8Serializer : public v8::ValueSerializer::Delegate {
 
   bool Serialize(v8::Local<v8::Value> value, blink::CloneableMessage* out) {
     gin_helper::MicrotasksScope microtasks_scope{
-        isolate_->GetCurrentContext(), false,
+        isolate_->GetCurrentContext(), true,
         v8::MicrotasksScope::kDoNotRunMicrotasks};
     WriteBlinkEnvelope(19);
 


### PR DESCRIPTION
#### Description of Change

Fixes #46654

> The root cause is that webContents.send eventually calls [Serialize](https://github.com/electron/electron/blob/32fea719b393c2757c4737386564c910d49b529e/shell/common/v8_util.cc#L37-L40), which has a `gin_helper::MicrotasksScope` that was changed in https://github.com/electron/electron/pull/43209. That change was one of the few that were unclear what the desired behavior should be and changed.

#### Release Notes

Notes: Microtasks are no longer (incorrectly) run by serializing values, including when sending IPC.
