### PR TITLE
refactor: remove `WebContentsPermissionHelper::PermissionTypes::KEYBOARD_LOCK`

### DIFF
--- a/shell/browser/web_contents_permission_helper.h
+++ b/shell/browser/web_contents_permission_helper.h
@@ -31,7 +31,6 @@ class WebContentsPermissionHelper
     SERIAL,
     HID,
     USB,
-    KEYBOARD_LOCK,
     FILE_SYSTEM,
   };
 


### PR DESCRIPTION
#### Description of Change

We added this key in https://github.com/electron/electron/pull/41419. Confusingly, upstream [aso added](https://chromium.googlesource.com/chromium/src/+/fd7005c09f2b24ac4fe9804465107de7fdf5f597) `blink::PermissionTypes::KEYBOARD_LOCK` _after_ this PR was submitted but _before_ it got merged :dizzy: so now we have a redundant key. This PR removes our copy.

All reviews welcomed! CC @codebytere, @deepak1556, and @VerteDinde as stakeholders via the Permissions discussion in #wg-upgrades, and @codebytere again as the original author :smile_cat: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.