### PR TITLE
perf: avoid triple map lookup in `ElectronHidDelegate::GetContextObserver()`

### DIFF
--- a/shell/browser/hid/electron_hid_delegate.cc
+++ b/shell/browser/hid/electron_hid_delegate.cc
@@ -221,11 +221,10 @@ bool ElectronHidDelegate::IsServiceWorkerAllowedForOrigin(
 ElectronHidDelegate::ContextObservation*
 ElectronHidDelegate::GetContextObserver(
     content::BrowserContext* browser_context) {
-  if (!observations_.contains(browser_context)) {
-    observations_.emplace(browser_context, std::make_unique<ContextObservation>(
-                                               this, browser_context));
-  }
-  return observations_[browser_context].get();
+  auto& observation = observations_[browser_context];
+  if (!observation)
+    observation = std::make_unique<ContextObservation>(this, browser_context);
+  return observation.get();
 }
 
 HidChooserController* ElectronHidDelegate::ControllerForFrame(


### PR DESCRIPTION
#### Description of Change

Refactor `ElectronHidDelegate::GetContextObserver()` s.t. it doesn't perform the same map lookup 3x in a row.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.