### PR TITLE
refactor: reduce & remove no-op MicrotasksScope calls

### DIFF
--- a/shell/browser/api/electron_api_auto_updater.cc
+++ b/shell/browser/api/electron_api_auto_updater.cc
@@ -46,10 +46,6 @@ void AutoUpdater::OnError(const std::string& message) {
         gin::StringToV8(isolate, message),
     };
 
-    gin_helper::MicrotasksScope microtasks_scope{
-        wrapper->GetCreationContextChecked(), true,
-        v8::MicrotasksScope::kRunMicrotasks};
-
     node::MakeCallback(isolate, wrapper, "emit", args.size(), args.data(),
                        {0, 0});
   }

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -235,12 +235,11 @@ void ElectronBindings::DidReceiveMemoryDump(
     base::ProcessId target_pid,
     bool success,
     std::unique_ptr<memory_instrumentation::GlobalMemoryDump> global_dump) {
+  DCHECK(electron::IsBrowserProcess());
   v8::Isolate* isolate = promise.isolate();
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Context> local_context =
       v8::Local<v8::Context>::New(isolate, context);
-  gin_helper::MicrotasksScope microtasks_scope{
-      local_context, true, v8::MicrotasksScope::kRunMicrotasks};
   v8::Context::Scope context_scope(local_context);
 
   if (!success) {

--- a/shell/common/v8_util.cc
+++ b/shell/common/v8_util.cc
@@ -36,7 +36,7 @@ class V8Serializer : public v8::ValueSerializer::Delegate {
 
   bool Serialize(v8::Local<v8::Value> value, blink::CloneableMessage* out) {
     gin_helper::MicrotasksScope microtasks_scope{
-        isolate_->GetCurrentContext(), false,
+        isolate_->GetCurrentContext(), true,
         v8::MicrotasksScope::kDoNotRunMicrotasks};
     WriteBlinkEnvelope(19);
 

--- a/shell/renderer/api/electron_api_spell_check_client.cc
+++ b/shell/renderer/api/electron_api_spell_check_client.cc
@@ -215,8 +215,8 @@ void SpellCheckClient::SpellCheckWords(const SpellCheckScope& scope,
   DCHECK(!scope.spell_check_.IsEmpty());
 
   auto context = isolate_->GetCurrentContext();
-  gin_helper::MicrotasksScope microtasks_scope{
-      context, false, v8::MicrotasksScope::kDoNotRunMicrotasks};
+  v8::MicrotasksScope microtasks_scope(
+      context, v8::MicrotasksScope::kDoNotRunMicrotasks);
 
   v8::Local<v8::FunctionTemplate> templ = gin_helper::CreateFunctionTemplate(
       isolate_, base::BindRepeating(&SpellCheckClient::OnSpellCheckDone,

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -146,8 +146,8 @@ void ElectronSandboxedRendererClient::WillReleaseScriptContext(
     return;
 
   auto* isolate = context->GetIsolate();
-  gin_helper::MicrotasksScope microtasks_scope{
-      context, false, v8::MicrotasksScope::kDoNotRunMicrotasks};
+  v8::MicrotasksScope microtasks_scope(
+      context, v8::MicrotasksScope::kDoNotRunMicrotasks);
   v8::HandleScope handle_scope(isolate);
   v8::Context::Scope context_scope(context);
   InvokeEmitProcessEvent(context, "exit");
@@ -164,8 +164,8 @@ void ElectronSandboxedRendererClient::EmitProcessEvent(
   v8::HandleScope handle_scope{isolate};
 
   v8::Local<v8::Context> context = GetContext(frame, isolate);
-  gin_helper::MicrotasksScope microtasks_scope{
-      context, false, v8::MicrotasksScope::kDoNotRunMicrotasks};
+  v8::MicrotasksScope microtasks_scope(
+      context, v8::MicrotasksScope::kDoNotRunMicrotasks);
   v8::Context::Scope context_scope(context);
 
   InvokeEmitProcessEvent(context, event_name);


### PR DESCRIPTION
#### Description of Change

Each of the 3 commits in this PR targets a specific use or category of uses of `gin_helper::MicrotasksScope` for removal and includes in-depth discussion on why they are removed. In summary:

* 2 browser process no-ops are removed
* 3 uses in `shell/renderer/` are reduced to `v8::MicrotasksScope`

Beyond only looking at the parameters & path name, I also considered the surrounding context and history (via. git blame) of each case, with the goal to avoid removing a call that _should_ be there but was incorrectly configured.

This leaves all remaining uses of `gin_helper::MicrotasksScope` in `shell/common/`.

Refs: #46669

(Branch based off #46668, ignore the `fix: do not run microtasks in V8Serializer in browser process` commit.)

#### Release Notes

Notes: none
