### PR TITLE
fix: crash on reconversion with google IME and editcontext on macOS

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -145,3 +145,4 @@ fix_win32_synchronous_spellcheck.patch
 fix_enable_wrap_iter_in_string_view_and_array.patch
 fix_linter_error.patch
 revert_enable_crel_for_arm32_targets.patch
+mac_fix_check_on_ime_reconversion_due_to_invalid_replacement_range.patch

--- a/patches/chromium/mac_fix_check_on_ime_reconversion_due_to_invalid_replacement_range.patch
+++ b/patches/chromium/mac_fix_check_on_ime_reconversion_due_to_invalid_replacement_range.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Keren Zhu <kerenzhu@chromium.org>
+Date: Fri, 18 Apr 2025 11:02:46 -0700
+Subject: mac: fix CHECK on IME reconversion due to invalid replacement range
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+It appears that Google Japanese IME can call -setMarkedText: with an
+invalid replacement range when doing text reconversion (変換, i.e.,
+conversion between different text with same pronunciation). This range
+is a NSRange and NSRange.location is supposed to be NSNotFound (2^31-1)
+for invalid range, but the IME can pass in 2^32. Subsequently causing
+CHECK error.
+
+This CL fixes the issue by converting such invalid NSRange to
+gfx::InvalidRange using FromPossiblyInvalidNSRange(range).
+
+Fixed: 409864204
+Change-Id: I08ff426a933ef76aa81e33af59aa32e2ac0b674d
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6470915
+Commit-Queue: Keren Zhu <kerenzhu@chromium.org>
+Reviewed-by: Marijn Kruisselbrink <mek@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1448935}
+
+diff --git a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm b/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
+index f2499bc084312a09b2324567d270fc1b899e7617..12ee7e75e437426f28002c7c9f4d5f5b5016ec53 100644
+--- a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
++++ b/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
+@@ -2415,9 +2415,10 @@ - (void)setMarkedText:(id)string
+   if ([self isHandlingKeyDown] && !_isReconversionTriggered) {
+     _setMarkedTextReplacementRange = gfx::Range(replacementRange);
+   } else {
+-    _host->ImeSetComposition(_markedText, _imeTextSpans,
+-                             gfx::Range(replacementRange), newSelRange.location,
+-                             NSMaxRange(newSelRange));
++    _host->ImeSetComposition(
++        _markedText, _imeTextSpans,
++        gfx::Range::FromPossiblyInvalidNSRange(replacementRange),
++        newSelRange.location, NSMaxRange(newSelRange));
+   }
+ 
+   [[self inputContext] invalidateCharacterCoordinates];


### PR DESCRIPTION
#### Description of Change

Backports https://chromium-review.googlesource.com/c/chromium/src/+/6470915
Refs https://github.com/microsoft/vscode/issues/230303

#### Release Notes

Notes: fix crash on reconversion with google IME and editcontext on macOS