### PR TITLE
refactor: make `electron::api::BaseWindow` fields private

### DIFF
--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -42,7 +42,8 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
 
-  NativeWindow* window() const { return window_.get(); }
+  const NativeWindow* window() const { return window_.get(); }
+  NativeWindow* window() { return window_.get(); }
 
  protected:
   // Common constructor.
@@ -262,6 +263,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
 #endif
   int32_t GetID() const;
 
+ private:
   // Helpers.
 
   // Remove this window from parent window's |child_windows_|.
@@ -290,7 +292,6 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   // Reference to JS wrapper to prevent garbage collection.
   v8::Global<v8::Value> self_ref_;
 
- private:
   base::WeakPtrFactory<BaseWindow> weak_factory_{this};
 };
 

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -36,7 +36,7 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
   std::string color;
   if (options.Get(options::kBackgroundColor, &color)) {
     web_preferences.SetHidden(options::kBackgroundColor, color);
-  } else if (window_->IsTranslucent()) {
+  } else if (window()->IsTranslucent()) {
     // If the BrowserWindow is transparent or a vibrancy type has been set,
     // also propagate transparency to the WebContents unless a separate
     // backgroundColor has been set.
@@ -67,7 +67,7 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
   gin::Handle<WebContentsView> web_contents_view =
       WebContentsView::Create(isolate, web_preferences);
   DCHECK(web_contents_view.get());
-  window_->AddDraggableRegionProvider(web_contents_view.get());
+  window()->AddDraggableRegionProvider(web_contents_view.get());
   web_contents_view_.Reset(isolate, web_contents_view.ToV8());
 
   // Save a reference of the WebContents.
@@ -209,7 +209,7 @@ void BrowserWindow::UpdateWindowControlsOverlay(
 void BrowserWindow::CloseImmediately() {
   // Close all child windows before closing current window.
   v8::HandleScope handle_scope(isolate());
-  for (v8::Local<v8::Value> value : child_windows_.Values(isolate())) {
+  for (v8::Local<v8::Value> value : GetChildWindows()) {
     gin::Handle<BrowserWindow> child;
     if (gin::ConvertFromV8(isolate(), value, &child) && !child.IsEmpty())
       child->window()->CloseImmediately();


### PR DESCRIPTION
#### Description of Change

Just a little code cleanup: make private the fields in the C++ class `electron::api::BaseWindow`.

No functional changes.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.