### PR TITLE
feat: add support for `--experimental-network-inspection`

### DIFF
--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -288,6 +288,10 @@ Specify ways of the inspector web socket url exposure.
 
 By default inspector websocket url is available in stderr and under /json/list endpoint on `http://host:port/json/list`.
 
+### `--experimental-network-inspector`
+
+Enable support for devtools network inspector events, for visibility into requests made by the nodejs `http` and `https` modules.
+
 ### `--no-deprecation`
 
 Silence deprecation warnings.

--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -254,7 +254,7 @@ Electron supports some of the [CLI flags][node-cli] supported by Node.js.
 
 **Note:** Passing unsupported command line switches to Electron when it is not running in `ELECTRON_RUN_AS_NODE` will have no effect.
 
-### `--inspect-brk\[=\[host:]port]`
+### `--inspect-brk[=[host:]port]`
 
 Activate inspector on host:port and break at start of user script. Default host:port is 127.0.0.1:9229.
 
@@ -266,13 +266,13 @@ Activate inspector on `host:port` and break at start of the first internal
 JavaScript script executed when the inspector is available.
 Default `host:port` is `127.0.0.1:9229`.
 
-### `--inspect-port=\[host:]port`
+### `--inspect-port=[host:]port`
 
 Set the `host:port` to be used when the inspector is activated. Useful when activating the inspector by sending the SIGUSR1 signal. Default host is `127.0.0.1`.
 
 Aliased to `--debug-port=[host:]port`.
 
-### `--inspect\[=\[host:]port]`
+### `--inspect[=[host:]port]`
 
 Activate inspector on `host:port`. Default is `127.0.0.1:9229`.
 

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -348,6 +348,7 @@ bool IsAllowedOption(const std::string_view option) {
           "--inspect-brk-node",
           "--inspect-port",
           "--inspect-publish-uid",
+          "--experimental-network-inspection",
       });
 
   // This should be aligned with what's possible to set via the process object.


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Allow `--experimental-network-inspection` to be used in NODE_OPTIONS.

Includes https://github.com/nodejs/node/pull/56805

cc @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added support for node option `--experimental-network-inspection`
