### PR TITLE
refactor: remove redundant NativeImage::GetBitmap()

### DIFF
--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -271,16 +271,12 @@ changes:
 
 Returns `string` - The [Data URL][data-url] of the image.
 
-#### `image.getBitmap([options])`
+#### `image.getBitmap([options])` _Deprecated_
 
 * `options` Object (optional)
   * `scaleFactor` Number (optional) - Defaults to 1.0.
 
-Returns `Buffer` - A [Buffer][buffer] that contains the image's raw bitmap pixel data.
-
-The difference between `getBitmap()` and `toBitmap()` is that `getBitmap()` does not
-copy the bitmap data, so you have to use the returned Buffer immediately in
-current event loop tick; otherwise the data might be changed or destroyed.
+Legacy alias for `image.toBitmap()`.
 
 #### `image.getNativeHandle()` _macOS_
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -887,7 +887,7 @@ const { BrowserWindow } = require('electron')
 
 const win = new BrowserWindow({ webPreferences: { offscreen: true } })
 win.webContents.on('paint', (event, dirty, image) => {
-  // updateBitmap(dirty, image.getBitmap())
+  // updateBitmap(dirty, image.toBitmap())
 })
 win.loadURL('https://github.com')
 ```

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -45,6 +45,19 @@ window is not currently visible.
 
 If you were using `app.commandLine` to control the behavior of the  main process, you should do this via `process.argv`.
 
+### Deprecated: `NativeImage.getBitmap()`
+
+`NativeImage.toBitmap()` returns a newly-allocated copy of the bitmap. `NativeImage.getBitmap()` was originally an alternative function that returned the original instead of a copy. This changed when sandboxing was introduced, so both return a copy and are functionally equivalent.
+
+Client code should call `NativeImage.toBitmap()` instead:
+
+```js
+// Deprecated
+bitmap = image.getBitmap()
+// Use this instead
+bitmap = image.toBitmap()
+```
+
 ## Planned Breaking API Changes (36.0)
 
 ### Utility Process unhandled rejection behavior change

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -286,6 +286,19 @@ std::string NativeImage::ToDataURL(gin::Arguments* args) {
       image_.AsImageSkia().GetRepresentation(scale_factor).GetBitmap());
 }
 
+v8::Local<v8::Value> NativeImage::GetBitmap(gin::Arguments* args) {
+  static bool deprecated_warning_issued = false;
+
+  if (!deprecated_warning_issued) {
+    deprecated_warning_issued = true;
+    util::EmitWarning(isolate_,
+                      "getBitmap() is deprecated, use toBitmap() instead.",
+                      "DeprecationWarning");
+  }
+
+  return ToBitmap(args);
+}
+
 v8::Local<v8::Value> NativeImage::GetNativeHandle(
     gin_helper::ErrorThrower thrower) {
 #if BUILDFLAG(IS_MAC)
@@ -582,7 +595,7 @@ gin::ObjectTemplateBuilder NativeImage::GetObjectTemplateBuilder(
       .SetMethod("toPNG", &NativeImage::ToPNG)
       .SetMethod("toJPEG", &NativeImage::ToJPEG)
       .SetMethod("toBitmap", &NativeImage::ToBitmap)
-      .SetMethod("getBitmap", &NativeImage::ToBitmap)
+      .SetMethod("getBitmap", &NativeImage::GetBitmap)
       .SetMethod("getScaleFactors", &NativeImage::GetScaleFactors)
       .SetMethod("getNativeHandle", &NativeImage::GetNativeHandle)
       .SetMethod("toDataURL", &NativeImage::ToDataURL)

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -286,20 +286,6 @@ std::string NativeImage::ToDataURL(gin::Arguments* args) {
       image_.AsImageSkia().GetRepresentation(scale_factor).GetBitmap());
 }
 
-v8::Local<v8::Value> NativeImage::GetBitmap(gin::Arguments* args) {
-  float scale_factor = GetScaleFactorFromOptions(args);
-
-  const SkBitmap bitmap =
-      image_.AsImageSkia().GetRepresentation(scale_factor).GetBitmap();
-  SkPixelRef* ref = bitmap.pixelRef();
-  if (!ref)
-    return node::Buffer::New(args->isolate(), 0).ToLocalChecked();
-  return node::Buffer::Copy(args->isolate(),
-                            reinterpret_cast<char*>(ref->pixels()),
-                            bitmap.computeByteSize())
-      .ToLocalChecked();
-}
-
 v8::Local<v8::Value> NativeImage::GetNativeHandle(
     gin_helper::ErrorThrower thrower) {
 #if BUILDFLAG(IS_MAC)
@@ -596,7 +582,7 @@ gin::ObjectTemplateBuilder NativeImage::GetObjectTemplateBuilder(
       .SetMethod("toPNG", &NativeImage::ToPNG)
       .SetMethod("toJPEG", &NativeImage::ToJPEG)
       .SetMethod("toBitmap", &NativeImage::ToBitmap)
-      .SetMethod("getBitmap", &NativeImage::GetBitmap)
+      .SetMethod("getBitmap", &NativeImage::ToBitmap)
       .SetMethod("getScaleFactors", &NativeImage::GetScaleFactors)
       .SetMethod("getNativeHandle", &NativeImage::GetNativeHandle)
       .SetMethod("toDataURL", &NativeImage::ToDataURL)

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -112,7 +112,6 @@ class NativeImage final : public gin::Wrappable<NativeImage> {
   v8::Local<v8::Value> ToJPEG(v8::Isolate* isolate, int quality);
   v8::Local<v8::Value> ToBitmap(gin::Arguments* args);
   std::vector<float> GetScaleFactors();
-  v8::Local<v8::Value> GetBitmap(gin::Arguments* args);
   v8::Local<v8::Value> GetNativeHandle(gin_helper::ErrorThrower thrower);
   gin::Handle<NativeImage> Resize(gin::Arguments* args,
                                   base::Value::Dict options);

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -112,6 +112,7 @@ class NativeImage final : public gin::Wrappable<NativeImage> {
   v8::Local<v8::Value> ToJPEG(v8::Isolate* isolate, int quality);
   v8::Local<v8::Value> ToBitmap(gin::Arguments* args);
   std::vector<float> GetScaleFactors();
+  v8::Local<v8::Value> GetBitmap(gin::Arguments* args);
   v8::Local<v8::Value> GetNativeHandle(gin_helper::ErrorThrower thrower);
   gin::Handle<NativeImage> Resize(gin::Arguments* args,
                                   base::Value::Dict options);

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -4599,7 +4599,7 @@ describe('BrowserWindow module', () => {
 
           try {
             const expectedSize = rect.width * rect.height * 4;
-            expect(image.getBitmap()).to.be.an.instanceOf(Buffer).with.lengthOf(expectedSize);
+            expect(image.toBitmap()).to.be.an.instanceOf(Buffer).with.lengthOf(expectedSize);
             done();
           } catch (e) {
             done(e);

--- a/spec/api-native-image-spec.ts
+++ b/spec/api-native-image-spec.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 
 import * as path from 'node:path';
 
+import { expectDeprecationMessages } from './lib/deprecate-helpers';
 import { ifdescribe, ifit, itremote, useRemoteContext } from './lib/spec-helpers';
 
 describe('nativeImage module', () => {
@@ -78,15 +79,20 @@ describe('nativeImage module', () => {
   });
 
   describe('createEmpty()', () => {
-    it('returns an empty image', () => {
+    it('returns an empty image', async () => {
       const empty = nativeImage.createEmpty();
       expect(empty.isEmpty()).to.be.true();
       expect(empty.getAspectRatio()).to.equal(1);
       expect(empty.toDataURL()).to.equal('data:image/png;base64,');
       expect(empty.toDataURL({ scaleFactor: 2.0 })).to.equal('data:image/png;base64,');
       expect(empty.getSize()).to.deep.equal({ width: 0, height: 0 });
-      expect(empty.getBitmap()).to.be.empty();
-      expect(empty.getBitmap({ scaleFactor: 2.0 })).to.be.empty();
+      await expectDeprecationMessages(
+        () => {
+          expect(empty.getBitmap()).to.be.empty();
+          expect(empty.getBitmap({ scaleFactor: 2.0 })).to.be.empty();
+        },
+        'getBitmap() is deprecated, use toBitmap() instead.'
+      );
       expect(empty.toBitmap()).to.be.empty();
       expect(empty.toBitmap({ scaleFactor: 2.0 })).to.be.empty();
       expect(empty.toJPEG(100)).to.be.empty();

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -1291,7 +1291,7 @@ const win4 = new BrowserWindow({
 });
 
 win4.webContents.on('paint', (event, dirty, _image) => {
-  console.log(dirty, _image.getBitmap());
+  console.log(dirty, _image.toBitmap());
 });
 
 win4.webContents.on('devtools-open-url', (event, url) => {


### PR DESCRIPTION
#### Description of Change

Mark `NativeImage.getBitmap()` as deprecated and document it as an alias for `NativeImage.toBitmap()`.

The documentation says:

> The difference between `getBitmap()` and `toBitmap()` is that `getBitmap()` does not
copy the bitmap data, so you have to use the returned Buffer immediately in
current event loop tick; otherwise the data might be changed or destroyed.

...but this hasn't been true since June 2022  https://github.com/electron/electron/pull/34403/commits/f61be5720deb2f21e7d4102b0f71d90258f0b0a4#diff-87426541166a1d650dedb7f3804023ffeb1718899ab7a83814ad538061546d60 because the old behavior of `getBitmap()` wasn't sandbox-compatible. For nearly three years, both functions have returned a newly-allocated copy of the bitmap and are functionally equivalent. :smile_cat: 

So this PR:

1. Removes the redundant C++ class method `NativeImage::GetBitmap()`
2. Maps the JS method `NativeImage.getBitmap()` to C++ `NativeImage::ToBitmap()`
3. Documents `NativeImage.getBitmap()` as an alias to `NativeImage.toBitmap()`
4. Documents `NativeImage.getBitmap()` as deprecated

Items 1-3 are `semver/patch` bugfix. Item 4 is arguably `semver/minor`? Labeling the PR accordingly. If @electron/wg-api wants to keep both methods as non-deprecated for some reason, I'm open to the idea.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Deprecated `NativeImage.getBitmap()` and fixed incorrect documentation.