### PR TITLE
build: don't kill ssh sessions on checkout failure

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -179,3 +179,11 @@ runs:
       else
         echo "Cache key persisted in $final_cache_path"
       fi
+  - name: Wait for active SSH sessions
+    shell: bash
+    if: always() && !cancelled()
+    run: |
+      while [ -f /var/.ssh-lock ]
+      do
+        sleep 60
+      done


### PR DESCRIPTION
#### Description of Change

Wait for any potential debugging sessions to exit before exiting the action. Without this they'll be killed forcefully during debugging.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
