### PR TITLE
fix: explicitly call GetNativeNSView() on macOS

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -125,6 +125,7 @@ filenames = {
     "shell/browser/animation_util.h",
     "shell/browser/animation_util_mac.mm",
     "shell/browser/api/electron_api_app_mac.mm",
+    "shell/browser/api/electron_api_base_window_mac.mm",
     "shell/browser/api/electron_api_menu_mac.h",
     "shell/browser/api/electron_api_menu_mac.mm",
     "shell/browser/api/electron_api_native_theme_mac.mm",

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -70,6 +70,7 @@ namespace electron::api {
 
 namespace {
 
+#if !BUILDFLAG(IS_MAC)
 // Converts binary data to Buffer.
 v8::Local<v8::Value> ToBuffer(v8::Isolate* isolate, void* val, int size) {
   auto buffer = node::Buffer::Copy(isolate, static_cast<char*>(val), size);
@@ -78,6 +79,7 @@ v8::Local<v8::Value> ToBuffer(v8::Isolate* isolate, void* val, int size) {
   else
     return buffer.ToLocalChecked();
 }
+#endif
 
 [[nodiscard]] constexpr std::array<int, 2U> ToArray(const gfx::Size size) {
   return {size.width(), size.height()};
@@ -778,17 +780,15 @@ std::string BaseWindow::GetMediaSourceId() const {
   return window_->GetDesktopMediaID().ToString();
 }
 
+#if !BUILDFLAG(IS_MAC)
 v8::Local<v8::Value> BaseWindow::GetNativeWindowHandle() {
   // TODO(MarshallOfSound): Replace once
   // https://chromium-review.googlesource.com/c/chromium/src/+/1253094/ has
   // landed
-#if BUILDFLAG(IS_MAC)
-  auto* handle = window_->GetNativeWindowHandle().GetNativeNSView();
-#else
   NativeWindowHandle handle = window_->GetNativeWindowHandle();
-#endif
   return ToBuffer(isolate(), &handle, sizeof(handle));
 }
+#endif
 
 void BaseWindow::SetProgressBar(double progress, gin_helper::Arguments* args) {
   gin_helper::Dictionary options;

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -782,7 +782,11 @@ v8::Local<v8::Value> BaseWindow::GetNativeWindowHandle() {
   // TODO(MarshallOfSound): Replace once
   // https://chromium-review.googlesource.com/c/chromium/src/+/1253094/ has
   // landed
+#if BUILDFLAG(IS_MAC)
+  auto* handle = window_->GetNativeWindowHandle().GetNativeNSView();
+#else
   NativeWindowHandle handle = window_->GetNativeWindowHandle();
+#endif
   return ToBuffer(isolate(), &handle, sizeof(handle));
 }
 

--- a/shell/browser/api/electron_api_base_window_mac.mm
+++ b/shell/browser/api/electron_api_base_window_mac.mm
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 Microsoft, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/api/electron_api_base_window.h"
+
+#include "electron/buildflags/buildflags.h"
+#include "shell/browser/api/electron_api_view.h"
+#include "shell/browser/native_window.h"
+#include "shell/common/node_includes.h"
+
+namespace {
+
+// Converts binary data to Buffer.
+v8::Local<v8::Value> ToBuffer(v8::Isolate* isolate, void* val, int size) {
+  auto buffer = node::Buffer::Copy(isolate, static_cast<char*>(val), size);
+  if (buffer.IsEmpty())
+    return v8::Null(isolate);
+  else
+    return buffer.ToLocalChecked();
+}
+
+}  // namespace
+
+namespace electron::api {
+
+v8::Local<v8::Value> BaseWindow::GetNativeWindowHandle() {
+  NSView* handle = window_->GetNativeWindowHandle().GetNativeNSView();
+  return ToBuffer(isolate(), &handle, sizeof(handle));
+}
+
+}  // namespace electron::api

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3743,12 +3743,9 @@ void WebContents::SetDevToolsWebContents(const WebContents* devtools) {
     inspectable_web_contents_->SetDevToolsWebContents(devtools->web_contents());
 }
 
+#if !BUILDFLAG(IS_MAC)
 v8::Local<v8::Value> WebContents::GetNativeView(v8::Isolate* isolate) const {
-#if BUILDFLAG(IS_MAC)
-  auto* ptr = web_contents()->GetNativeView().GetNativeNSView();
-#else
   gfx::NativeView ptr = web_contents()->GetNativeView();
-#endif
   auto buffer =
       node::Buffer::Copy(isolate, reinterpret_cast<char*>(&ptr), sizeof(ptr));
   if (buffer.IsEmpty())
@@ -3756,6 +3753,7 @@ v8::Local<v8::Value> WebContents::GetNativeView(v8::Isolate* isolate) const {
   else
     return buffer.ToLocalChecked();
 }
+#endif
 
 v8::Local<v8::Value> WebContents::DevToolsWebContents(v8::Isolate* isolate) {
   if (devtools_web_contents_.IsEmpty())

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3744,9 +3744,13 @@ void WebContents::SetDevToolsWebContents(const WebContents* devtools) {
 }
 
 v8::Local<v8::Value> WebContents::GetNativeView(v8::Isolate* isolate) const {
+#if BUILDFLAG(IS_MAC)
+  auto* ptr = web_contents()->GetNativeView().GetNativeNSView();
+#else
   gfx::NativeView ptr = web_contents()->GetNativeView();
-  auto buffer = node::Buffer::Copy(isolate, reinterpret_cast<char*>(&ptr),
-                                   sizeof(gfx::NativeView));
+#endif
+  auto buffer =
+      node::Buffer::Copy(isolate, reinterpret_cast<char*>(&ptr), sizeof(ptr));
   if (buffer.IsEmpty())
     return v8::Null(isolate);
   else

--- a/shell/browser/api/electron_api_web_contents_mac.mm
+++ b/shell/browser/api/electron_api_web_contents_mac.mm
@@ -6,6 +6,7 @@
 #include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/ui/cocoa/event_dispatching_window.h"
 #include "shell/browser/web_contents_preferences.h"
+#include "shell/common/node_includes.h"
 #include "ui/base/cocoa/command_dispatcher.h"
 #include "ui/base/cocoa/nsmenu_additions.h"
 #include "ui/base/cocoa/nsmenuitem_additions.h"
@@ -90,6 +91,24 @@ bool WebContents::PlatformHandleKeyboardEvent(
   }
 
   return false;
+}
+
+namespace {
+
+// Converts binary data to Buffer.
+v8::Local<v8::Value> ToBuffer(v8::Isolate* isolate, void* val, int size) {
+  auto buffer = node::Buffer::Copy(isolate, static_cast<char*>(val), size);
+  if (buffer.IsEmpty())
+    return v8::Null(isolate);
+  else
+    return buffer.ToLocalChecked();
+}
+
+}  // namespace
+
+v8::Local<v8::Value> WebContents::GetNativeView(v8::Isolate* isolate) const {
+  NSView* handle = web_contents()->GetNativeView().GetNativeNSView();
+  return ToBuffer(isolate, &handle, sizeof(handle));
 }
 
 }  // namespace electron::api

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -58,9 +58,9 @@ class BrowserView;
 }
 
 #if BUILDFLAG(IS_MAC)
-typedef gfx::NativeView NativeWindowHandle;
+using NativeWindowHandle = gfx::NativeView;
 #else
-typedef gfx::AcceleratedWidget NativeWindowHandle;
+using NativeWindowHandle = gfx::AcceleratedWidget;
 #endif
 
 class NativeWindow : public base::SupportsUserData,


### PR DESCRIPTION
#### Description of Change

Fixes #46732.

This fixes a recent regression on macOS that caused `getNativeWindowHandle()` to return the wrong pointer.

Tracking this down was a fun ride. Full description [here](https://github.com/electron/electron/issues/46732#issue-3012257426).

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `getNativeWindowHandle()` crash that affected 36 betas on macOS.
