### PR TITLE
fix: bluetooth crash in `select-bluetooth-device` event

### DIFF
--- a/shell/browser/lib/bluetooth_chooser.h
+++ b/shell/browser/lib/bluetooth_chooser.h
@@ -5,13 +5,14 @@
 #ifndef ELECTRON_SHELL_BROWSER_LIB_BLUETOOTH_CHOOSER_H_
 #define ELECTRON_SHELL_BROWSER_LIB_BLUETOOTH_CHOOSER_H_
 
-#include <map>
 #include <string>
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
 #include "content/public/browser/bluetooth_chooser.h"
 #include "shell/browser/api/electron_api_web_contents.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 
 namespace electron {
 
@@ -39,14 +40,18 @@ class BluetoothChooser : public content::BluetoothChooser {
                          bool is_gatt_connected,
                          bool is_paired,
                          int signal_strength_level) override;
+
+  void OnDeviceChosen(const std::string& device_id);
   std::vector<DeviceInfo> GetDeviceList();
 
  private:
-  std::map<std::string, std::u16string> device_map_;
+  absl::flat_hash_map<std::string, std::u16string> device_id_to_name_map_;
   raw_ptr<api::WebContents> api_web_contents_;
   EventHandler event_handler_;
   bool refreshing_ = false;
   bool rescan_ = false;
+
+  base::WeakPtrFactory<BluetoothChooser> weak_ptr_factory_{this};
 };
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/46707

Fixes a possible crash when using `navigator.bluetooth.requestDevice` and the `select-bluetooth-device` event. This happened in the case where Bluetooth was turned off and `navigator.bluetooth.requestDevice` was called and subsequently cancelled via the `select-bluetooth-device` event. Also a bit of related cleanup.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a possible crash when using `navigator.bluetooth.requestDevice` and the `select-bluetooth-device` event.
