### PR TITLE
refactor: use `net::CanonicalCookie::IsDomainMatch()`

### DIFF
--- a/shell/browser/api/electron_api_cookies.cc
+++ b/shell/browser/api/electron_api_cookies.cc
@@ -102,27 +102,6 @@ namespace electron::api {
 
 namespace {
 
-// Returns whether |domain| matches |filter|.
-bool MatchesDomain(std::string filter, const std::string& domain) {
-  // Add a leading '.' character to the filter domain if it doesn't exist.
-  if (net::cookie_util::DomainIsHostOnly(filter))
-    filter.insert(0, ".");
-
-  std::string sub_domain(domain);
-  // Strip any leading '.' character from the input cookie domain.
-  if (!net::cookie_util::DomainIsHostOnly(sub_domain))
-    sub_domain = sub_domain.substr(1);
-
-  // Now check whether the domain argument is a subdomain of the filter domain.
-  for (sub_domain.insert(0, "."); sub_domain.length() >= filter.length();) {
-    if (sub_domain == filter)
-      return true;
-    const size_t next_dot = sub_domain.find('.', 1);  // Skip over leading dot.
-    sub_domain.erase(0, next_dot);
-  }
-  return false;
-}
-
 // Returns whether |cookie| matches |filter|.
 bool MatchesCookie(const base::Value::Dict& filter,
                    const net::CanonicalCookie& cookie) {
@@ -131,8 +110,7 @@ bool MatchesCookie(const base::Value::Dict& filter,
     return false;
   if ((str = filter.FindString("path")) && *str != cookie.Path())
     return false;
-  if ((str = filter.FindString("domain")) &&
-      !MatchesDomain(*str, cookie.Domain()))
+  if ((str = filter.FindString("domain")) && !cookie.IsDomainMatch(*str))
     return false;
   std::optional<bool> secure_filter = filter.FindBool("secure");
   if (secure_filter && *secure_filter != cookie.SecureAttribute())


### PR DESCRIPTION
#### Description of Change

- Removed our bespoke domain tester and updated callers to use [net::CanonicalCookie::IsDomainMatch()](https://chromium.googlesource.com/chromium/src/+/main/net/cookies/cookie_base.h#81) instead.
- Added domain-matching tests to `spec/api-session-spec.ts`.

Our bespoke method [first landed](https://github.com/electron/electron/pull/1981) in June 2015; but `IsDomainMatch()` has been public API since 2012 and seems like a perfect match, so I'm not sure why we haven't been using it all along. My guess is that it was an oversight?  Hopefully I'm not missing something subtle here -- CC @VerteDinde in case this is another [DomainIs()](https://github.com/electron/electron/pull/44153) change :slightly_smiling_face:  

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.