### PR TITLE
refactor: use `std::map::try_emplace()` over `std::map::insert()`

### DIFF
--- a/shell/browser/electron_autofill_driver_factory.cc
+++ b/shell/browser/electron_autofill_driver_factory.cc
@@ -94,8 +94,7 @@ AutofillDriver* AutofillDriverFactory::DriverForFrame(
 void AutofillDriverFactory::AddDriverForFrame(
     content::RenderFrameHost* render_frame_host,
     CreationCallback factory_method) {
-  auto insertion_result =
-      driver_map_.insert(std::make_pair(render_frame_host, nullptr));
+  auto insertion_result = driver_map_.try_emplace(render_frame_host, nullptr);
   // This can be called twice for the key representing the main frame.
   if (insertion_result.second) {
     insertion_result.first->second = std::move(factory_method).Run();

--- a/shell/browser/file_system_access/file_system_access_permission_context.cc
+++ b/shell/browser/file_system_access/file_system_access_permission_context.cc
@@ -746,7 +746,7 @@ void FileSystemAccessPermissionContext::SetLastPickedDirectory(
     base::Value::Dict dict;
     dict.Set(GenerateLastPickedDirectoryKey(id), std::move(entry));
     MaybeEvictEntries(dict);
-    id_pathinfo_map_.insert(std::make_pair(origin, std::move(dict)));
+    id_pathinfo_map_.try_emplace(origin, std::move(dict));
   }
 }
 

--- a/shell/browser/hid/electron_hid_delegate.cc
+++ b/shell/browser/hid/electron_hid_delegate.cc
@@ -241,8 +241,7 @@ HidChooserController* ElectronHidDelegate::AddControllerForFrame(
   auto controller = std::make_unique<HidChooserController>(
       render_frame_host, std::move(filters), std::move(exclusion_filters),
       std::move(callback), web_contents, weak_factory_.GetWeakPtr());
-  controller_map_.insert(
-      std::make_pair(render_frame_host, std::move(controller)));
+  controller_map_.try_emplace(render_frame_host, std::move(controller));
   return ControllerForFrame(render_frame_host);
 }
 

--- a/shell/browser/hid/hid_chooser_context.cc
+++ b/shell/browser/hid/hid_chooser_context.cc
@@ -307,7 +307,7 @@ void HidChooserContext::SetUpHidManagerConnection(
 void HidChooserContext::InitDeviceList(
     std::vector<device::mojom::HidDeviceInfoPtr> devices) {
   for (auto& device : devices)
-    devices_.insert({device->guid, std::move(device)});
+    devices_.try_emplace(device->guid, std::move(device));
 
   is_initialized_ = true;
 

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -883,9 +883,9 @@ void ProxyingURLLoaderFactory::OnLoaderForCorsPreflightCreated(
   // sending request headers is very difficult.
   const uint64_t web_request_id = ++(*request_id_generator_);
 
-  auto result = requests_.insert(std::make_pair(
+  auto result = requests_.try_emplace(
       web_request_id, std::make_unique<InProgressRequest>(
-                          this, web_request_id, frame_routing_id_, request)));
+                          this, web_request_id, frame_routing_id_, request));
 
   result.first->second->OnLoaderCreated(std::move(receiver));
   result.first->second->Restart();

--- a/shell/browser/notifications/mac/cocoa_notification.mm
+++ b/shell/browser/notifications/mac/cocoa_notification.mm
@@ -93,8 +93,8 @@ void CocoaNotification::Show(const NotificationOptions& options) {
             actionWithIdentifier:actionIdentifier
                            title:base::SysUTF16ToNSString(action.text)];
         [additionalActions addObject:notificationAction];
-        additional_action_indices_.insert(
-            std::make_pair(base::SysNSStringToUTF8(actionIdentifier), i));
+        additional_action_indices_.try_emplace(
+            base::SysNSStringToUTF8(actionIdentifier), i);
       }
     }
     i++;

--- a/shell/browser/serial/electron_serial_delegate.cc
+++ b/shell/browser/serial/electron_serial_delegate.cc
@@ -116,8 +116,7 @@ SerialChooserController* ElectronSerialDelegate::AddControllerForFrame(
       render_frame_host, std::move(filters),
       std::move(allowed_bluetooth_service_class_ids), std::move(callback),
       web_contents, weak_factory_.GetWeakPtr());
-  controller_map_.insert(
-      std::make_pair(render_frame_host, std::move(controller)));
+  controller_map_.try_emplace(render_frame_host, std::move(controller));
   return ControllerForFrame(render_frame_host);
 }
 

--- a/shell/browser/serial/serial_chooser_context.cc
+++ b/shell/browser/serial/serial_chooser_context.cc
@@ -87,7 +87,7 @@ void SerialChooserContext::GrantPortPermission(
     const url::Origin& origin,
     const device::mojom::SerialPortInfo& port,
     content::RenderFrameHost* render_frame_host) {
-  port_info_.insert({port.token, port.Clone()});
+  port_info_.try_emplace(port.token, port.Clone());
 
   if (CanStorePersistentEntry(port)) {
     auto* permission_manager = static_cast<ElectronPermissionManager*>(
@@ -275,7 +275,7 @@ void SerialChooserContext::SetUpPortManagerConnection(
 void SerialChooserContext::OnGetDevices(
     std::vector<device::mojom::SerialPortInfoPtr> ports) {
   for (auto& port : ports)
-    port_info_.insert({port->token, std::move(port)});
+    port_info_.try_emplace(port->token, std::move(port));
   is_initialized_ = true;
 }
 

--- a/shell/browser/usb/electron_usb_delegate.cc
+++ b/shell/browser/usb/electron_usb_delegate.cc
@@ -299,8 +299,7 @@ UsbChooserController* ElectronUsbDelegate::AddControllerForFrame(
   auto controller = std::make_unique<UsbChooserController>(
       render_frame_host, std::move(options), std::move(callback), web_contents,
       weak_factory_.GetWeakPtr());
-  controller_map_.insert(
-      std::make_pair(render_frame_host, std::move(controller)));
+  controller_map_.try_emplace(render_frame_host, std::move(controller));
   return ControllerForFrame(render_frame_host);
 }
 

--- a/shell/browser/usb/usb_chooser_context.cc
+++ b/shell/browser/usb/usb_chooser_context.cc
@@ -105,10 +105,8 @@ void UsbChooserContext::InitDeviceList(
     std::vector<device::mojom::UsbDeviceInfoPtr> devices) {
   for (auto& device_info : devices) {
     DCHECK(device_info);
-    if (ShouldExposeDevice(*device_info)) {
-      devices_.insert(
-          std::make_pair(device_info->guid, std::move(device_info)));
-    }
+    if (ShouldExposeDevice(*device_info))
+      devices_.try_emplace(device_info->guid, std::move(device_info));
   }
   is_initialized_ = true;
 
@@ -289,7 +287,7 @@ void UsbChooserContext::OnDeviceAdded(
   DCHECK(!devices_.contains(device_info->guid));
   if (!ShouldExposeDevice(*device_info))
     return;
-  devices_.insert(std::make_pair(device_info->guid, device_info->Clone()));
+  devices_.try_emplace(device_info->guid, device_info->Clone());
 
   // Notify all observers.
   for (auto& observer : device_observer_list_)


### PR DESCRIPTION
#### Description of Change

Small cleanup in our use of maps: `try_emplace()` has more efficient move semantics and its name is clearer about what happens when the same key is already present in the map. All other things being equal, we should use it instead of `insert()`.

All human reviews welcomed! :smile_cat: I'm also requesting a review from Copilot just to see what will happen; I've never used that before.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.