### PR TITLE
build: update NMV to 136 for Electron 37

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -2,7 +2,7 @@ is_electron_build = true
 root_extra_deps = [ "//electron" ]
 
 # Registry of NMVs --> https://github.com/nodejs/node/blob/main/doc/abi_version_registry.json
-node_module_version = 135
+node_module_version = 136
 
 v8_promise_internal_field_count = 1
 v8_embedder_string = "-electron.0"


### PR DESCRIPTION
In preparation for releasing Electron 36 and cutting the `37-x-y` branch, this PR bumps the NMV to 136 for Electron 37.

(Ignore branch name and commit title, brain had an off-by-one error)

Ref: https://github.com/nodejs/node/pull/57979

Notes: none
