### PR TITLE
refactor: use `WidgetDelegate::SetAccessibleTitle()`

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -783,14 +783,6 @@ const views::Widget* NativeWindow::GetWidget() const {
   return widget();
 }
 
-std::u16string NativeWindow::GetAccessibleWindowTitle() const {
-  if (accessible_title_.empty()) {
-    return views::WidgetDelegate::GetAccessibleWindowTitle();
-  }
-
-  return accessible_title_;
-}
-
 std::string NativeWindow::GetTitle() const {
   return base::UTF16ToUTF8(WidgetDelegate::GetWindowTitle());
 }
@@ -804,11 +796,11 @@ void NativeWindow::SetTitle(const std::string_view title) {
 }
 
 void NativeWindow::SetAccessibleTitle(const std::string& title) {
-  accessible_title_ = base::UTF8ToUTF16(title);
+  WidgetDelegate::SetAccessibleTitle(base::UTF8ToUTF16(title));
 }
 
 std::string NativeWindow::GetAccessibleTitle() {
-  return base::UTF16ToUTF8(accessible_title_);
+  return base::UTF16ToUTF8(GetAccessibleWindowTitle());
 }
 
 void NativeWindow::HandlePendingFullscreenTransitions() {

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -447,7 +447,6 @@ class NativeWindow : public base::SupportsUserData,
   // views::WidgetDelegate:
   views::Widget* GetWidget() override;
   const views::Widget* GetWidget() const override;
-  std::u16string GetAccessibleWindowTitle() const override;
 
   void set_content_view(views::View* view) { content_view_ = view; }
 
@@ -531,9 +530,6 @@ class NativeWindow : public base::SupportsUserData,
 
   absl::flat_hash_set<BackgroundThrottlingSource*>
       background_throttling_sources_;
-
-  // Accessible title.
-  std::u16string accessible_title_;
 
   std::string vibrancy_;
   std::string background_material_;

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -16,6 +16,7 @@ import { setTimeout } from 'node:timers/promises';
 import * as nodeUrl from 'node:url';
 
 import { emittedUntil, emittedNTimes } from './lib/events-helpers';
+import { randomString } from './lib/net-helpers';
 import { HexColors, hasCapturableScreen, ScreenCapture } from './lib/screen-helpers';
 import { ifit, ifdescribe, defer, listen, waitUntil } from './lib/spec-helpers';
 import { closeWindow, closeAllWindows } from './lib/window-helpers';
@@ -229,6 +230,36 @@ describe('BrowserWindow module', () => {
           await destroyed;
         });
       }
+    });
+  });
+
+  describe('window.accessibleTitle', () => {
+    const title = 'Window Title';
+    let w: BrowserWindow;
+    beforeEach(() => {
+      w = new BrowserWindow({ show: false, title, webPreferences: { nodeIntegration: true, contextIsolation: false } });
+    });
+    afterEach(async () => {
+      await closeWindow(w);
+      w = null as unknown as BrowserWindow;
+    });
+
+    it('should default to the window title', async () => {
+      expect(w.accessibleTitle).to.equal(title);
+    });
+
+    it('should be mutable', async () => {
+      const accessibleTitle = randomString(20);
+      w.accessibleTitle = accessibleTitle;
+      expect(w.accessibleTitle).to.equal(accessibleTitle);
+    });
+
+    it('should be clearable', async () => {
+      const accessibleTitle = randomString(20);
+      w.accessibleTitle = accessibleTitle;
+      expect(w.accessibleTitle).to.equal(accessibleTitle);
+      w.accessibleTitle = '';
+      expect(w.accessibleTitle).to.equal(title);
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Use upstream's `WidgetDelegate::SetAccessibleTitle()` instead of implementing it ourselves. We were previously doing it ourselves because our code predated the [May 2020 addition](https://chromium-review.googlesource.com/c/chromium/src/+/2218688)  of `SetAccessibleTitle()`.

(Upstream implementation: [SetAccessibleTitle()](https://chromium.googlesource.com/chromium/src/+/a034dd2e96b502a09f8d6dbd26897858e9beea9a/ui/views/widget/widget_delegate.cc#406), [GetAccessibleWindowTitle()](https://chromium.googlesource.com/chromium/src/+/a034dd2e96b502a09f8d6dbd26897858e9beea9a/ui/views/widget/widget_delegate.cc#127))

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.