### PR TITLE
refactor: use upstream content protection logic on macOS

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -26,6 +26,7 @@
 #include "shell/common/options_switches.h"
 #include "ui/base/hit_test.h"
 #include "ui/compositor/compositor.h"
+#include "ui/views/widget/native_widget_private.h"
 #include "ui/views/widget/widget.h"
 
 #if !BUILDFLAG(IS_MAC)
@@ -820,6 +821,20 @@ void NativeWindow::HandlePendingFullscreenTransitions() {
   bool next_transition = pending_transitions_.front();
   pending_transitions_.pop();
   SetFullScreen(next_transition);
+}
+
+void NativeWindow::SetContentProtection(bool enable) {
+#if !BUILDFLAG(IS_LINUX)
+  widget()->native_widget_private()->SetAllowScreenshots(!enable);
+#endif
+}
+
+bool NativeWindow::IsContentProtected() const {
+#if !BUILDFLAG(IS_LINUX)
+  return !widget()->native_widget_private()->AreScreenshotsAllowed();
+#else  // Not implemented on Linux
+  return false;
+#endif
 }
 
 bool NativeWindow::IsTranslucent() const {

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -186,8 +186,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetDocumentEdited(bool edited) {}
   virtual bool IsDocumentEdited() const;
   virtual void SetIgnoreMouseEvents(bool ignore, bool forward) = 0;
-  virtual void SetContentProtection(bool enable);
-  virtual bool IsContentProtected() const;
+  void SetContentProtection(bool enable);
+  bool IsContentProtected() const;
   virtual void SetFocusable(bool focusable) {}
   virtual bool IsFocusable() const;
   virtual void SetMenu(ElectronMenuModel* menu) {}

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -186,8 +186,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetDocumentEdited(bool edited) {}
   virtual bool IsDocumentEdited() const;
   virtual void SetIgnoreMouseEvents(bool ignore, bool forward) = 0;
-  virtual void SetContentProtection(bool enable) = 0;
-  virtual bool IsContentProtected() const = 0;
+  virtual void SetContentProtection(bool enable);
+  virtual bool IsContentProtected() const;
   virtual void SetFocusable(bool focusable) {}
   virtual bool IsFocusable() const;
   virtual void SetMenu(ElectronMenuModel* menu) {}

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -109,8 +109,6 @@ class NativeWindowMac : public NativeWindow,
   void SetIgnoreMouseEvents(bool ignore, bool forward) override;
   bool IsHiddenInMissionControl() const override;
   void SetHiddenInMissionControl(bool hidden) override;
-  void SetContentProtection(bool enable) override;
-  bool IsContentProtected() const override;
   void SetFocusable(bool focusable) override;
   bool IsFocusable() const override;
   void SetParentWindow(NativeWindow* parent) override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1172,15 +1172,6 @@ void NativeWindowMac::SetIgnoreMouseEvents(bool ignore, bool forward) {
   }
 }
 
-void NativeWindowMac::SetContentProtection(bool enable) {
-  [window_
-      setSharingType:enable ? NSWindowSharingNone : NSWindowSharingReadOnly];
-}
-
-bool NativeWindowMac::IsContentProtected() const {
-  return [window_ sharingType] == NSWindowSharingNone;
-}
-
 void NativeWindowMac::SetFocusable(bool focusable) {
   // No known way to unfocus the window if it had the focus. Here we do not
   // want to call Focus(false) because it moves the window to the back, i.e.

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -44,7 +44,6 @@
 #include "ui/ozone/public/ozone_platform.h"
 #include "ui/views/background.h"
 #include "ui/views/controls/webview/webview.h"
-#include "ui/views/widget/native_widget_private.h"
 #include "ui/views/widget/widget.h"
 #include "ui/views/window/client_view.h"
 #include "ui/wm/core/shadow_types.h"
@@ -1311,20 +1310,6 @@ void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
       });
     }
   }
-#endif
-}
-
-void NativeWindowViews::SetContentProtection(bool enable) {
-#if BUILDFLAG(IS_WIN)
-  widget()->native_widget_private()->SetAllowScreenshots(!enable);
-#endif
-}
-
-bool NativeWindowViews::IsContentProtected() const {
-#if BUILDFLAG(IS_WIN)
-  return !widget()->native_widget_private()->AreScreenshotsAllowed();
-#else  // Not implemented on Linux
-  return false;
 #endif
 }
 

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -115,8 +115,6 @@ class NativeWindowViews : public NativeWindow,
   void SetOpacity(const double opacity) override;
   double GetOpacity() const override;
   void SetIgnoreMouseEvents(bool ignore, bool forward) override;
-  void SetContentProtection(bool enable) override;
-  bool IsContentProtected() const override;
   void SetFocusable(bool focusable) override;
   bool IsFocusable() const override;
   void SetMenu(ElectronMenuModel* menu_model) override;


### PR DESCRIPTION
#### Description of Change
 
Unify some logic within NativeWindow - this is implemented upstream everywhere except Linux.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
