### PR TITLE
docs: additional update of breaking changes for 36-x-y

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -45,12 +45,12 @@ however, old code that needs to preserve this behavior can emulate it by
 creating a random session with `session.fromPartition(some_random_string)`
 and then using it in `ProtocolResponse.session`.
 
-## Planned Breaking API Changes (36.0)
-
 ### Behavior Changed: `BrowserWindow.IsVisibleOnAllWorkspaces()` on Linux
 
 `BrowserWindow.IsVisibleOnAllWorkspaces()` will now return false on Linux if the
 window is not currently visible.
+
+## Planned Breaking API Changes (36.0)
 
 ### Behavior Changes: `app.commandLine`
 


### PR DESCRIPTION
#### Description of Change
- Followup to #46762
- #45887 did not get backported to 36-x-y and it shouldn't be listed as a breaking change there.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
