### PR TITLE
fix: `backgroundMaterial` on initial activate (36-x-y)

### DIFF
--- a/patches/chromium/fix_activate_background_material_on_windows.patch
+++ b/patches/chromium/fix_activate_background_material_on_windows.patch
@@ -14,7 +14,7 @@ This patch likely can't be upstreamed as-is, as Chromium doesn't have
 this use case in mind currently.
 
 diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
-index ecab7d7f95998a055f01d7b5180a8fb80eddb32c..96cf055f1144887c0b4b4aef83898508016b310f 100644
+index ecab7d7f95998a055f01d7b5180a8fb80eddb32c..5c74a092920cdb3b7e98d218c75874cac2d0542f 100644
 --- a/ui/views/win/hwnd_message_handler.cc
 +++ b/ui/views/win/hwnd_message_handler.cc
 @@ -954,13 +954,13 @@ void HWNDMessageHandler::FrameTypeChanged() {
@@ -33,6 +33,15 @@ index ecab7d7f95998a055f01d7b5180a8fb80eddb32c..96cf055f1144887c0b4b4aef83898508
  }
  
  void HWNDMessageHandler::SetWindowIcons(const gfx::ImageSkia& window_icon,
+@@ -1757,7 +1757,7 @@ void HWNDMessageHandler::OnActivateApp(BOOL active, DWORD thread_id) {
+   if (delegate_->HasNonClientView() && !active &&
+       thread_id != GetCurrentThreadId()) {
+     // Update the native frame if it is rendering the non-client area.
+-    if (HasSystemFrame()) {
++    if (is_translucent_ || HasSystemFrame()) {
+       DefWindowProcWithRedrawLock(WM_NCACTIVATE, FALSE, 0);
+     }
+   }
 @@ -2365,17 +2365,18 @@ LRESULT HWNDMessageHandler::OnNCActivate(UINT message,
      delegate_->SchedulePaint();
    }


### PR DESCRIPTION
Manual backport of #46657 to 36-x-y. See that PR for details.

Notes: Fixed an issue where the backgroundMaterial feature did not work in a frameless window on initial window creation.