### PR TITLE
fix: mocha/no-nested-tests

### DIFF
--- a/spec/.eslintrc.json
+++ b/spec/.eslintrc.json
@@ -16,6 +16,7 @@
   ],
   "rules": {
     "mocha/no-exclusive-tests": "error",
+    "mocha/no-nested-tests": "error",
     "unicorn/prefer-node-protocol": "error"
   }
 }

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -84,7 +84,7 @@ describe('app module', () => {
   });
 
   describe('app name APIs', () => {
-    it('with properties', () => {
+    describe('with properties', () => {
       it('returns the name field of package.json', () => {
         expect(app.name).to.equal('Electron Test Main');
       });
@@ -98,7 +98,7 @@ describe('app module', () => {
       });
     });
 
-    it('with functions', () => {
+    describe('with functions', () => {
       it('returns the name field of package.json', () => {
         expect(app.getName()).to.equal('Electron Test Main');
       });
@@ -979,7 +979,7 @@ describe('app module', () => {
   });
 
   ifdescribe(process.platform !== 'linux')('accessibilitySupportEnabled property', () => {
-    it('with properties', () => {
+    describe('with properties', () => {
       it('can set accessibility support enabled', () => {
         expect(app.accessibilitySupportEnabled).to.eql(false);
 
@@ -988,7 +988,7 @@ describe('app module', () => {
       });
     });
 
-    it('with functions', () => {
+    describe('with functions', () => {
       it('can set accessibility support enabled', () => {
         expect(app.isAccessibilitySupportEnabled()).to.eql(false);
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -2102,7 +2102,7 @@ describe('BrowserWindow module', () => {
       });
 
       ifdescribe(process.platform === 'win32')('Fullscreen state', () => {
-        it('with properties', () => {
+        describe('with properties', () => {
           it('can be set with the fullscreen constructor option', () => {
             w = new BrowserWindow({ fullscreen: true });
             expect(w.fullScreen).to.be.true();
@@ -2186,7 +2186,7 @@ describe('BrowserWindow module', () => {
           });
         });
 
-        it('with functions', () => {
+        describe('with functions', () => {
           it('can be set with the fullscreen constructor option', () => {
             w = new BrowserWindow({ fullscreen: true });
             expect(w.isFullScreen()).to.be.true();
@@ -2364,7 +2364,7 @@ describe('BrowserWindow module', () => {
   describe('autoHideMenuBar state', () => {
     afterEach(closeAllWindows);
 
-    it('for properties', () => {
+    describe('for properties', () => {
       it('can be set with autoHideMenuBar constructor option', () => {
         const w = new BrowserWindow({ show: false, autoHideMenuBar: true });
         expect(w.autoHideMenuBar).to.be.true('autoHideMenuBar');
@@ -2380,7 +2380,7 @@ describe('BrowserWindow module', () => {
       });
     });
 
-    it('for functions', () => {
+    describe('for functions', () => {
       it('can be set with autoHideMenuBar constructor option', () => {
         const w = new BrowserWindow({ show: false, autoHideMenuBar: true });
         expect(w.isMenuBarAutoHide()).to.be.true('autoHideMenuBar');
@@ -5219,7 +5219,7 @@ describe('BrowserWindow module', () => {
     });
 
     describe('resizable state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be set with resizable constructor option', () => {
           const w = new BrowserWindow({ show: false, resizable: false });
           expect(w.resizable).to.be.false('resizable');
@@ -5239,7 +5239,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be set with resizable constructor option', () => {
           const w = new BrowserWindow({ show: false, resizable: false });
           expect(w.isResizable()).to.be.false('resizable');
@@ -5414,7 +5414,7 @@ describe('BrowserWindow module', () => {
     afterEach(closeAllWindows);
 
     describe('movable state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be set with movable constructor option', () => {
           const w = new BrowserWindow({ show: false, movable: false });
           expect(w.movable).to.be.false('movable');
@@ -5430,7 +5430,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be set with movable constructor option', () => {
           const w = new BrowserWindow({ show: false, movable: false });
           expect(w.isMovable()).to.be.false('movable');
@@ -5448,7 +5448,7 @@ describe('BrowserWindow module', () => {
     });
 
     describe('visibleOnAllWorkspaces state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });
           expect(w.visibleOnAllWorkspaces).to.be.false();
@@ -5457,7 +5457,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });
           expect(w.isVisibleOnAllWorkspaces()).to.be.false();
@@ -5468,7 +5468,7 @@ describe('BrowserWindow module', () => {
     });
 
     ifdescribe(process.platform === 'darwin')('documentEdited state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });
           expect(w.documentEdited).to.be.false();
@@ -5477,7 +5477,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });
           expect(w.isDocumentEdited()).to.be.false();
@@ -5488,7 +5488,7 @@ describe('BrowserWindow module', () => {
     });
 
     ifdescribe(process.platform === 'darwin')('representedFilename', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });
           expect(w.representedFilename).to.eql('');
@@ -5497,7 +5497,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });
           expect(w.getRepresentedFilename()).to.eql('');
@@ -5508,7 +5508,7 @@ describe('BrowserWindow module', () => {
     });
 
     describe('native window title', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be set with title constructor option', () => {
           const w = new BrowserWindow({ show: false, title: 'mYtItLe' });
           expect(w.title).to.eql('mYtItLe');
@@ -5522,7 +5522,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be set with minimizable constructor option', () => {
           const w = new BrowserWindow({ show: false, title: 'mYtItLe' });
           expect(w.getTitle()).to.eql('mYtItLe');
@@ -5538,7 +5538,7 @@ describe('BrowserWindow module', () => {
     });
 
     describe('minimizable state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be set with minimizable constructor option', () => {
           const w = new BrowserWindow({ show: false, minimizable: false });
           expect(w.minimizable).to.be.false('minimizable');
@@ -5554,7 +5554,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be set with minimizable constructor option', () => {
           const w = new BrowserWindow({ show: false, minimizable: false });
           expect(w.isMinimizable()).to.be.false('movable');
@@ -5572,7 +5572,7 @@ describe('BrowserWindow module', () => {
     });
 
     describe('maximizable state (property)', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be set with maximizable constructor option', () => {
           const w = new BrowserWindow({ show: false, maximizable: false });
           expect(w.maximizable).to.be.false('maximizable');
@@ -5605,7 +5605,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be set with maximizable constructor option', () => {
           const w = new BrowserWindow({ show: false, maximizable: false });
           expect(w.isMaximizable()).to.be.false('isMaximizable');
@@ -5640,7 +5640,7 @@ describe('BrowserWindow module', () => {
     });
 
     ifdescribe(process.platform === 'win32')('maximizable state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('is reset to its former state', () => {
           const w = new BrowserWindow({ show: false });
           w.maximizable = false;
@@ -5654,7 +5654,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('is reset to its former state', () => {
           const w = new BrowserWindow({ show: false });
           w.setMaximizable(false);
@@ -5767,7 +5767,7 @@ describe('BrowserWindow module', () => {
     });
 
     ifdescribe(process.platform === 'darwin')('fullscreenable state', () => {
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be set with fullscreenable constructor option', () => {
           const w = new BrowserWindow({ show: false, fullscreenable: false });
           expect(w.isFullScreenable()).to.be.false('isFullScreenable');
@@ -5834,7 +5834,7 @@ describe('BrowserWindow module', () => {
     });
 
     ifdescribe(process.platform === 'darwin')('isHiddenInMissionControl state', () => {
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be set with ignoreMissionControl constructor option', () => {
           const w = new BrowserWindow({ show: false, hiddenInMissionControl: true });
           expect(w.isHiddenInMissionControl()).to.be.true('isHiddenInMissionControl');
@@ -5854,7 +5854,7 @@ describe('BrowserWindow module', () => {
     // fullscreen events are dispatched eagerly and twiddling things too fast can confuse poor Electron
 
     ifdescribe(process.platform === 'darwin')('kiosk state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be set with a constructor property', () => {
           const w = new BrowserWindow({ kiosk: true });
           expect(w.kiosk).to.be.true();
@@ -5875,7 +5875,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be set with a constructor property', () => {
           const w = new BrowserWindow({ kiosk: true });
           expect(w.isKiosk()).to.be.true();
@@ -6174,7 +6174,7 @@ describe('BrowserWindow module', () => {
     });
 
     describe('closable state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be set with closable constructor option', () => {
           const w = new BrowserWindow({ show: false, closable: false });
           expect(w.closable).to.be.false('closable');
@@ -6190,7 +6190,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be set with closable constructor option', () => {
           const w = new BrowserWindow({ show: false, closable: false });
           expect(w.isClosable()).to.be.false('isClosable');
@@ -6208,7 +6208,7 @@ describe('BrowserWindow module', () => {
     });
 
     describe('hasShadow state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('returns a boolean on all platforms', () => {
           const w = new BrowserWindow({ show: false });
           expect(w.shadow).to.be.a('boolean');

--- a/spec/api-desktop-capturer-spec.ts
+++ b/spec/api-desktop-capturer-spec.ts
@@ -119,6 +119,7 @@ ifdescribe(!process.arch.includes('arm') && process.platform !== 'win32')('deskt
     // bots while it is not on my workstation, as expected, with and without
     // the --ci parameter.
     if (process.platform === 'linux' && sources.length === 0) {
+      // eslint-disable-next-line mocha/no-nested-tests
       it.skip('desktopCapturer.getSources returned an empty source list');
       return;
     }
@@ -155,6 +156,7 @@ ifdescribe(!process.arch.includes('arm') && process.platform !== 'win32')('deskt
     // bots while it is not on my workstation, as expected, with and without
     // the --ci parameter.
     if (process.platform === 'linux' && sources.length === 0) {
+      // eslint-disable-next-line mocha/no-nested-tests
       it.skip('desktopCapturer.getSources returned an empty source list');
       return;
     }
@@ -225,6 +227,7 @@ ifdescribe(!process.arch.includes('arm') && process.platform !== 'win32')('deskt
       // the --ci parameter.
       if (process.platform === 'linux' && sources.length === 0) {
         destroyWindows();
+        // eslint-disable-next-line mocha/no-nested-tests
         it.skip('desktopCapturer.getSources returned an empty source list');
         return;
       }


### PR DESCRIPTION
#### Description of Change

Enable the `mocha/no-nested-tests` warning and fix the pre-existing instances. This fixes a problem that caused 57 tests to not be run.

Fixes #46806.

Notes: none.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.