### PR TITLE
fix: run `visibleOnAllWorkspaces` tests on the right platforms

### DIFF
--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5407,6 +5407,26 @@ describe('BrowserWindow module', () => {
         expect(w.webContents.isLoadingMainFrame()).to.be.true('isLoadingMainFrame');
       });
     });
+
+    ifdescribe(['darwin', 'linux'].includes(process.platform))('visibleOnAllWorkspaces state', () => {
+      it('with properties', () => {
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false });
+          expect(w.visibleOnAllWorkspaces).to.be.false();
+          w.visibleOnAllWorkspaces = true;
+          expect(w.visibleOnAllWorkspaces).to.be.true();
+        });
+      });
+
+      it('with functions', () => {
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false });
+          expect(w.isVisibleOnAllWorkspaces()).to.be.false();
+          w.setVisibleOnAllWorkspaces(true);
+          expect(w.isVisibleOnAllWorkspaces()).to.be.true();
+        });
+      });
+    });
   });
 
   ifdescribe(process.platform !== 'linux')('window states (excluding Linux)', () => {
@@ -5443,26 +5463,6 @@ describe('BrowserWindow module', () => {
           expect(w.isMovable()).to.be.false('movable');
           w.setMovable(true);
           expect(w.isMovable()).to.be.true('movable');
-        });
-      });
-    });
-
-    ifdescribe(['darwin', 'linux'].includes(process.platform))('visibleOnAllWorkspaces state', () => {
-      it('with properties', () => {
-        it('can be changed', () => {
-          const w = new BrowserWindow({ show: false });
-          expect(w.visibleOnAllWorkspaces).to.be.false();
-          w.visibleOnAllWorkspaces = true;
-          expect(w.visibleOnAllWorkspaces).to.be.true();
-        });
-      });
-
-      it('with functions', () => {
-        it('can be changed', () => {
-          const w = new BrowserWindow({ show: false });
-          expect(w.isVisibleOnAllWorkspaces()).to.be.false();
-          w.setVisibleOnAllWorkspaces(true);
-          expect(w.isVisibleOnAllWorkspaces()).to.be.true();
         });
       });
     });

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5408,7 +5408,7 @@ describe('BrowserWindow module', () => {
       });
     });
 
-    ifdescribe(['darwin', 'linux'].includes(process.platform))('visibleOnAllWorkspaces state', () => {
+    ifdescribe(process.platform !== 'win32')('visibleOnAllWorkspaces state', () => {
       describe('with properties', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5447,7 +5447,7 @@ describe('BrowserWindow module', () => {
       });
     });
 
-    describe('visibleOnAllWorkspaces state', () => {
+    ifdescribe(['darwin', 'linux'].includes(process.platform))('visibleOnAllWorkspaces state', () => {
       it('with properties', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5409,7 +5409,7 @@ describe('BrowserWindow module', () => {
     });
 
     ifdescribe(['darwin', 'linux'].includes(process.platform))('visibleOnAllWorkspaces state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });
           expect(w.visibleOnAllWorkspaces).to.be.false();
@@ -5418,7 +5418,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });
           expect(w.isVisibleOnAllWorkspaces()).to.be.false();


### PR DESCRIPTION
#### Description of Change

Part 1 in a series to enable/fix tests that didn't run due to #46807. 

This step fixes three issues with the `visibleOnAllWorkspaces` tests:

- The tests were enabled on Windows, even though Windows doesn't support this feature
- The tests were skipped on Linux, even though Linux supports this feature
- Due to nested `it()` statements, the tests were not run on any platform (which is why they didn't fail on Windows :smile_cat:)

This PR fixes these by running the tests on Linux and macOS.

All reviews welcomed. CC @nikwen who reviewed the original PR.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.