### PR TITLE
fix: enable some tests that were accidentally disabled

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -398,7 +398,7 @@ A `View` property for the content view of the window.
 
 A `string` (optional) property that is equal to the `tabbingIdentifier` passed to the `BrowserWindow` constructor or `undefined` if none was set.
 
-#### `win.autoHideMenuBar`
+#### `win.autoHideMenuBar` _Linux_ _Windows_
 
 A `boolean` property that determines whether the window menu bar should hide itself automatically. Once set, the menu bar will only show when users press the single `Alt` key.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -499,7 +499,7 @@ A `Integer` property representing the unique ID of the window. Each ID is unique
 
 A `string` (optional) property that is equal to the `tabbingIdentifier` passed to the `BrowserWindow` constructor or `undefined` if none was set.
 
-#### `win.autoHideMenuBar`
+#### `win.autoHideMenuBar` _Linux_ _Windows_
 
 A `boolean` property that determines whether the window menu bar should hide itself automatically. Once set, the menu bar will only show when users press the single `Alt` key.
 

--- a/docs/api/structures/base-window-options.md
+++ b/docs/api/structures/base-window-options.md
@@ -58,8 +58,8 @@
   `false` on macOS. This option is not configurable on other platforms.
 * `disableAutoHideCursor` boolean (optional) - Whether to hide cursor when typing.
   Default is `false`.
-* `autoHideMenuBar` boolean (optional) - Auto hide the menu bar unless the `Alt`
-  key is pressed. Default is `false`.
+* `autoHideMenuBar` boolean (optional) _Linux_ _Windows_ - Auto hide the menu bar
+  unless the `Alt` key is pressed. Default is `false`.
 * `enableLargerThanScreen` boolean (optional) _macOS_ - Enable the window to
   be resized larger than screen. Only relevant for macOS, as other OSes
   allow larger-than-screen windows by default. Default is `false`.

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -84,7 +84,7 @@ describe('app module', () => {
   });
 
   describe('app name APIs', () => {
-    it('with properties', () => {
+    describe('with properties', () => {
       it('returns the name field of package.json', () => {
         expect(app.name).to.equal('Electron Test Main');
       });
@@ -98,7 +98,7 @@ describe('app module', () => {
       });
     });
 
-    it('with functions', () => {
+    describe('with functions', () => {
       it('returns the name field of package.json', () => {
         expect(app.getName()).to.equal('Electron Test Main');
       });
@@ -988,7 +988,7 @@ describe('app module', () => {
       });
     });
 
-    it('with functions', () => {
+    describe('with functions', () => {
       it('can set accessibility support enabled', () => {
         expect(app.isAccessibilitySupportEnabled()).to.eql(false);
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -2108,6 +2108,7 @@ describe('BrowserWindow module', () => {
             expect(w.fullScreen).to.be.true();
           });
 
+          // FIXME: this test needs to be fixed and re-enabled.
           it.skip('does not go fullscreen if roundedCorners are enabled', async () => {
             w = new BrowserWindow({ frame: false, roundedCorners: false, fullscreen: true });
             expect(w.fullScreen).to.be.false();

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -2102,13 +2102,13 @@ describe('BrowserWindow module', () => {
       });
 
       ifdescribe(process.platform === 'win32')('Fullscreen state', () => {
-        it('with properties', () => {
+        describe('with properties', () => {
           it('can be set with the fullscreen constructor option', () => {
             w = new BrowserWindow({ fullscreen: true });
             expect(w.fullScreen).to.be.true();
           });
 
-          it('does not go fullscreen if roundedCorners are enabled', async () => {
+          it.skip('does not go fullscreen if roundedCorners are enabled', async () => {
             w = new BrowserWindow({ frame: false, roundedCorners: false, fullscreen: true });
             expect(w.fullScreen).to.be.false();
           });
@@ -2186,7 +2186,7 @@ describe('BrowserWindow module', () => {
           });
         });
 
-        it('with functions', () => {
+        describe('with functions', () => {
           it('can be set with the fullscreen constructor option', () => {
             w = new BrowserWindow({ fullscreen: true });
             expect(w.isFullScreen()).to.be.true();
@@ -5434,7 +5434,7 @@ describe('BrowserWindow module', () => {
     afterEach(closeAllWindows);
 
     describe('movable state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be set with movable constructor option', () => {
           const w = new BrowserWindow({ show: false, movable: false });
           expect(w.movable).to.be.false('movable');
@@ -5450,7 +5450,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be set with movable constructor option', () => {
           const w = new BrowserWindow({ show: false, movable: false });
           expect(w.isMovable()).to.be.false('movable');
@@ -5468,7 +5468,7 @@ describe('BrowserWindow module', () => {
     });
 
     ifdescribe(process.platform === 'darwin')('documentEdited state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });
           expect(w.documentEdited).to.be.false();
@@ -5477,7 +5477,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });
           expect(w.isDocumentEdited()).to.be.false();
@@ -5508,7 +5508,7 @@ describe('BrowserWindow module', () => {
     });
 
     describe('native window title', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be set with title constructor option', () => {
           const w = new BrowserWindow({ show: false, title: 'mYtItLe' });
           expect(w.title).to.eql('mYtItLe');
@@ -5522,7 +5522,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be set with minimizable constructor option', () => {
           const w = new BrowserWindow({ show: false, title: 'mYtItLe' });
           expect(w.getTitle()).to.eql('mYtItLe');
@@ -5538,7 +5538,7 @@ describe('BrowserWindow module', () => {
     });
 
     describe('minimizable state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be set with minimizable constructor option', () => {
           const w = new BrowserWindow({ show: false, minimizable: false });
           expect(w.minimizable).to.be.false('minimizable');
@@ -5554,7 +5554,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be set with minimizable constructor option', () => {
           const w = new BrowserWindow({ show: false, minimizable: false });
           expect(w.isMinimizable()).to.be.false('movable');
@@ -5640,7 +5640,7 @@ describe('BrowserWindow module', () => {
     });
 
     ifdescribe(process.platform === 'win32')('maximizable state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('is reset to its former state', () => {
           const w = new BrowserWindow({ show: false });
           w.maximizable = false;
@@ -5654,7 +5654,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('is reset to its former state', () => {
           const w = new BrowserWindow({ show: false });
           w.setMaximizable(false);
@@ -5767,7 +5767,7 @@ describe('BrowserWindow module', () => {
     });
 
     ifdescribe(process.platform === 'darwin')('fullscreenable state', () => {
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be set with fullscreenable constructor option', () => {
           const w = new BrowserWindow({ show: false, fullscreenable: false });
           expect(w.isFullScreenable()).to.be.false('isFullScreenable');
@@ -5834,7 +5834,7 @@ describe('BrowserWindow module', () => {
     });
 
     ifdescribe(process.platform === 'darwin')('isHiddenInMissionControl state', () => {
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be set with ignoreMissionControl constructor option', () => {
           const w = new BrowserWindow({ show: false, hiddenInMissionControl: true });
           expect(w.isHiddenInMissionControl()).to.be.true('isHiddenInMissionControl');
@@ -5854,7 +5854,7 @@ describe('BrowserWindow module', () => {
     // fullscreen events are dispatched eagerly and twiddling things too fast can confuse poor Electron
 
     ifdescribe(process.platform === 'darwin')('kiosk state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be set with a constructor property', () => {
           const w = new BrowserWindow({ kiosk: true });
           expect(w.kiosk).to.be.true();
@@ -5875,7 +5875,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be set with a constructor property', () => {
           const w = new BrowserWindow({ kiosk: true });
           expect(w.isKiosk()).to.be.true();
@@ -6174,7 +6174,7 @@ describe('BrowserWindow module', () => {
     });
 
     describe('closable state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be set with closable constructor option', () => {
           const w = new BrowserWindow({ show: false, closable: false });
           expect(w.closable).to.be.false('closable');
@@ -6190,7 +6190,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be set with closable constructor option', () => {
           const w = new BrowserWindow({ show: false, closable: false });
           expect(w.isClosable()).to.be.false('isClosable');
@@ -6208,7 +6208,7 @@ describe('BrowserWindow module', () => {
     });
 
     describe('hasShadow state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('returns a boolean on all platforms', () => {
           const w = new BrowserWindow({ show: false });
           expect(w.shadow).to.be.a('boolean');

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -2362,10 +2362,10 @@ describe('BrowserWindow module', () => {
     });
   });
 
-  describe('autoHideMenuBar state', () => {
+  ifdescribe(process.platform !== 'darwin')('autoHideMenuBar state', () => {
     afterEach(closeAllWindows);
 
-    it('for properties', () => {
+    describe('for properties', () => {
       it('can be set with autoHideMenuBar constructor option', () => {
         const w = new BrowserWindow({ show: false, autoHideMenuBar: true });
         expect(w.autoHideMenuBar).to.be.true('autoHideMenuBar');
@@ -2381,7 +2381,7 @@ describe('BrowserWindow module', () => {
       });
     });
 
-    it('for functions', () => {
+    describe('for functions', () => {
       it('can be set with autoHideMenuBar constructor option', () => {
         const w = new BrowserWindow({ show: false, autoHideMenuBar: true });
         expect(w.isMenuBarAutoHide()).to.be.true('autoHideMenuBar');

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5407,6 +5407,26 @@ describe('BrowserWindow module', () => {
         expect(w.webContents.isLoadingMainFrame()).to.be.true('isLoadingMainFrame');
       });
     });
+
+    ifdescribe(['darwin', 'linux'].includes(process.platform))('visibleOnAllWorkspaces state', () => {
+      it('with properties', () => {
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false });
+          expect(w.visibleOnAllWorkspaces).to.be.false();
+          w.visibleOnAllWorkspaces = true;
+          expect(w.visibleOnAllWorkspaces).to.be.true();
+        });
+      });
+
+      it('with functions', () => {
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false });
+          expect(w.isVisibleOnAllWorkspaces()).to.be.false();
+          w.setVisibleOnAllWorkspaces(true);
+          expect(w.isVisibleOnAllWorkspaces()).to.be.true();
+        });
+      });
+    });
   });
 
   ifdescribe(process.platform !== 'linux')('window states (excluding Linux)', () => {
@@ -5443,26 +5463,6 @@ describe('BrowserWindow module', () => {
           expect(w.isMovable()).to.be.false('movable');
           w.setMovable(true);
           expect(w.isMovable()).to.be.true('movable');
-        });
-      });
-    });
-
-    ifdescribe(['darwin', 'linux'].includes(process.platform))('visibleOnAllWorkspaces state', () => {
-      it('with properties', () => {
-        it('can be changed', () => {
-          const w = new BrowserWindow({ show: false });
-          expect(w.visibleOnAllWorkspaces).to.be.false();
-          w.visibleOnAllWorkspaces = true;
-          expect(w.visibleOnAllWorkspaces).to.be.true();
-        });
-      });
-
-      it('with functions', () => {
-        it('can be changed', () => {
-          const w = new BrowserWindow({ show: false });
-          expect(w.isVisibleOnAllWorkspaces()).to.be.false();
-          w.setVisibleOnAllWorkspaces(true);
-          expect(w.isVisibleOnAllWorkspaces()).to.be.true();
         });
       });
     });

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5408,7 +5408,7 @@ describe('BrowserWindow module', () => {
       });
     });
 
-    ifdescribe(['darwin', 'linux'].includes(process.platform))('visibleOnAllWorkspaces state', () => {
+    ifdescribe(process.platform !== 'win32')('visibleOnAllWorkspaces state', () => {
       describe('with properties', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5447,7 +5447,7 @@ describe('BrowserWindow module', () => {
       });
     });
 
-    describe('visibleOnAllWorkspaces state', () => {
+    ifdescribe(['darwin', 'linux'].includes(process.platform))('visibleOnAllWorkspaces state', () => {
       it('with properties', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5409,7 +5409,7 @@ describe('BrowserWindow module', () => {
     });
 
     ifdescribe(['darwin', 'linux'].includes(process.platform))('visibleOnAllWorkspaces state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });
           expect(w.visibleOnAllWorkspaces).to.be.false();
@@ -5418,7 +5418,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('with functions', () => {
+      describe('with functions', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });
           expect(w.isVisibleOnAllWorkspaces()).to.be.false();


### PR DESCRIPTION
#### Description of Change

Part 2 in a series to enable/fix tests that didn't run due to #46807. This step fixes some `mocha/no-nested-tests` errors that prevented several tests from being run.

All reviews welcomed. CC @nikwen who reviewed the original PR.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.