### PR TITLE
fix: enable `autoHideMenuBar` tests on Linux and Windows

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -398,7 +398,7 @@ A `View` property for the content view of the window.
 
 A `string` (optional) property that is equal to the `tabbingIdentifier` passed to the `BrowserWindow` constructor or `undefined` if none was set.
 
-#### `win.autoHideMenuBar`
+#### `win.autoHideMenuBar` _Linux_ _Windows_
 
 A `boolean` property that determines whether the window menu bar should hide itself automatically. Once set, the menu bar will only show when users press the single `Alt` key.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -499,7 +499,7 @@ A `Integer` property representing the unique ID of the window. Each ID is unique
 
 A `string` (optional) property that is equal to the `tabbingIdentifier` passed to the `BrowserWindow` constructor or `undefined` if none was set.
 
-#### `win.autoHideMenuBar`
+#### `win.autoHideMenuBar` _Linux_ _Windows_
 
 A `boolean` property that determines whether the window menu bar should hide itself automatically. Once set, the menu bar will only show when users press the single `Alt` key.
 

--- a/docs/api/structures/base-window-options.md
+++ b/docs/api/structures/base-window-options.md
@@ -58,8 +58,8 @@
   `false` on macOS. This option is not configurable on other platforms.
 * `disableAutoHideCursor` boolean (optional) - Whether to hide cursor when typing.
   Default is `false`.
-* `autoHideMenuBar` boolean (optional) - Auto hide the menu bar unless the `Alt`
-  key is pressed. Default is `false`.
+* `autoHideMenuBar` boolean (optional) _Linux_ _Windows_ - Auto hide the menu bar
+  unless the `Alt` key is pressed. Default is `false`.
 * `enableLargerThanScreen` boolean (optional) _macOS_ - Enable the window to
   be resized larger than screen. Only relevant for macOS, as other OSes
   allow larger-than-screen windows by default. Default is `false`.

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -2361,10 +2361,10 @@ describe('BrowserWindow module', () => {
     });
   });
 
-  describe('autoHideMenuBar state', () => {
+  ifdescribe(process.platform !== 'darwin')('autoHideMenuBar state', () => {
     afterEach(closeAllWindows);
 
-    it('for properties', () => {
+    describe('for properties', () => {
       it('can be set with autoHideMenuBar constructor option', () => {
         const w = new BrowserWindow({ show: false, autoHideMenuBar: true });
         expect(w.autoHideMenuBar).to.be.true('autoHideMenuBar');
@@ -2380,7 +2380,7 @@ describe('BrowserWindow module', () => {
       });
     });
 
-    it('for functions', () => {
+    describe('for functions', () => {
       it('can be set with autoHideMenuBar constructor option', () => {
         const w = new BrowserWindow({ show: false, autoHideMenuBar: true });
         expect(w.isMenuBarAutoHide()).to.be.true('autoHideMenuBar');


### PR DESCRIPTION
#### Description of Change

Part 3 in a series to enable/fix tests that didn't run due to #46807. This step fixes the `autoHideMenuBar` tests:

- enable `autoHideMenuBar` tests on Linux, Windows
- mark the `BaseWindow.autoHideMenuBar` property as supported on Linux, Windows

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed documentation to mark `Window.autoHideMenuBar` as supported on Linux and Windows.