### PR TITLE
fix: fix and enable `accessibilitySupportEnabled` tests

### DIFF
--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -978,7 +978,7 @@ describe('app module', () => {
     });
   });
 
-  describe('accessibilitySupportEnabled property', () => {
+  ifdescribe(process.platform !== 'linux')('accessibilitySupportEnabled property', () => {
     it('is mutable', () => {
       const values = [false, true, false];
       const setters: Array<(arg: boolean) => void> = [

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -980,7 +980,7 @@ describe('app module', () => {
 
   describe('accessibilitySupportEnabled property', () => {
     it('is mutable', () => {
-      const values = [false, true, false, true];
+      const values = [false, true, false];
       const setters: Array<(arg: boolean) => void> = [
         (value) => { app.accessibilitySupportEnabled = value; },
         (value) => app.setAccessibilitySupportEnabled(value)

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -978,23 +978,23 @@ describe('app module', () => {
     });
   });
 
-  ifdescribe(process.platform !== 'linux')('accessibilitySupportEnabled property', () => {
-    it('with properties', () => {
-      it('can set accessibility support enabled', () => {
-        expect(app.accessibilitySupportEnabled).to.eql(false);
-
-        app.accessibilitySupportEnabled = true;
-        expect(app.accessibilitySupportEnabled).to.eql(true);
-      });
-    });
-
-    describe('with functions', () => {
-      it('can set accessibility support enabled', () => {
-        expect(app.isAccessibilitySupportEnabled()).to.eql(false);
-
-        app.setAccessibilitySupportEnabled(true);
-        expect(app.isAccessibilitySupportEnabled()).to.eql(true);
-      });
+  describe('accessibilitySupportEnabled property', () => {
+    it('is mutable', () => {
+      const values = [false, true, false, true];
+      const setters: Array<(arg: boolean) => void> = [
+        (value) => { app.accessibilitySupportEnabled = value; },
+        (value) => app.setAccessibilitySupportEnabled(value)
+      ];
+      const getters: Array<() => boolean> = [
+        () => app.accessibilitySupportEnabled,
+        () => app.isAccessibilitySupportEnabled()
+      ];
+      for (const value of values) {
+        for (const set of setters) {
+          set(value);
+          for (const get of getters) expect(get()).to.eql(value);
+        }
+      }
     });
   });
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5410,7 +5410,7 @@ describe('BrowserWindow module', () => {
     });
 
     ifdescribe(process.platform !== 'win32')('visibleOnAllWorkspaces state', () => {
-      describe('with properties', () => {
+      it('with properties', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });
           expect(w.visibleOnAllWorkspaces).to.be.false();

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5410,7 +5410,7 @@ describe('BrowserWindow module', () => {
     });
 
     ifdescribe(process.platform !== 'win32')('visibleOnAllWorkspaces state', () => {
-      it('with properties', () => {
+      describe('with properties', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });
           expect(w.visibleOnAllWorkspaces).to.be.false();


### PR DESCRIPTION
#### Description of Change

Part 4 in a series to enable/fix tests that didn't run due to #46807. This one fixes the `accessibilitySupportEnabled` tests:

- Fix nested-it bug in the spec that prevented the tests from running.
- Fix tests that failed because they assumed the default initial state.
- Test every getter after calling each setter.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.