### PR TITLE
fix: Linux `visibleOnAllWorkspaces` property

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1525,6 +1525,13 @@ void NativeWindowViews::SetVisibleOnAllWorkspaces(
 }
 
 bool NativeWindowViews::IsVisibleOnAllWorkspaces() const {
+  // NB: Electron >= 37 has a better long-term fix, but it also has an edge
+  // case which is a breaking change. The code here is dirtier (e.g. accessing
+  // a method marked as private) to avoid that edge case. More info @
+  // https://github.com/electron/electron/pull/46834#issuecomment-2836287699
+  if (const auto* view_native_widget = widget()->native_widget_private())
+    return view_native_widget->IsVisibleOnAllWorkspaces();
+
 #if BUILDFLAG(IS_LINUX)
   if (IsX11()) {
     // Use the presence/absence of _NET_WM_STATE_STICKY in _NET_WM_STATE to

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5408,8 +5408,7 @@ describe('BrowserWindow module', () => {
       });
     });
 
-    // FIXME: enable this test on Linux as well.
-    ifdescribe(process.platform === 'darwin')('visibleOnAllWorkspaces state', () => {
+    ifdescribe(process.platform !== 'win32')('visibleOnAllWorkspaces state', () => {
       describe('with properties', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5408,7 +5408,8 @@ describe('BrowserWindow module', () => {
       });
     });
 
-    ifdescribe(process.platform !== 'win32')('visibleOnAllWorkspaces state', () => {
+    // FIXME: enable this test on Linux as well.
+    ifdescribe(process.platform === 'darwin')('visibleOnAllWorkspaces state', () => {
       describe('with properties', () => {
         it('can be changed', () => {
           const w = new BrowserWindow({ show: false });


### PR DESCRIPTION
#### Description of Change

Fix the broken `visibleOnAllWorkspaces` property on Linux and enable the related tests.

#45887 is the right long-term fix and is what we're using in Electron 37; however, it can't be backported because it has an edge case that counts as a breaking change.

This PR isn't as clean or maintainable, but it does fix the same bug in a nonbreaking way. So it's not here to supersede 45887, just to patch the older maintenance branches.

All reviews welcomed. CC @codebytere who wrote 45887.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed the `visibleOnAllWorkspaces` property on Linux.