### PR TITLE
refactor: don't call deprecated `WidgetDelegate` API in `NativeWindowMac`

### DIFF
--- a/patches/chromium/chore_grandfather_in_electron_views_and_delegates.patch
+++ b/patches/chromium/chore_grandfather_in_electron_views_and_delegates.patch
@@ -49,24 +49,23 @@ index ae7eab37f12ba80ec423d229cf048021e9ba6765..507a75dc7947295db221b01356fa57ba
      // These existing cases are "grandfathered in", but there shouldn't be more.
      // See comments atop class.
 diff --git a/ui/views/widget/widget_delegate.h b/ui/views/widget/widget_delegate.h
-index 7c2463cb91d00de2b0fa4f10221ea960be860d9a..0d5c63e7efbe42d5352abdeb594175904af30c41 100644
+index 7c2463cb91d00de2b0fa4f10221ea960be860d9a..78b3dc6fa4702e9021a10b60a5e3808114c71364 100644
 --- a/ui/views/widget/widget_delegate.h
 +++ b/ui/views/widget/widget_delegate.h
-@@ -169,6 +169,13 @@ namespace data_controls {
+@@ -169,6 +169,12 @@ namespace data_controls {
  class DesktopDataControlsDialog;
  }
  
 +namespace electron {
 +class AutofillPopupView;
 +class DevToolsWindowDelegate;
-+class NativeWindowMac;
 +class NativeWindowViews;
 +}
 +
  namespace enterprise_connectors {
  class ContentAnalysisDialog;
  class ContentAnalysisDialogBehaviorBrowserTest;
-@@ -371,6 +378,7 @@ class VIEWS_EXPORT WidgetDelegate {
+@@ -371,6 +377,7 @@ class VIEWS_EXPORT WidgetDelegate {
  
    class OwnedByWidgetPassKey {
     private:
@@ -74,16 +73,15 @@ index 7c2463cb91d00de2b0fa4f10221ea960be860d9a..0d5c63e7efbe42d5352abdeb59417590
      // DO NOT ADD TO THIS LIST!
      // These existing cases are "grandfathered in", but there shouldn't be more.
      // See comments atop `SetOwnedByWidget()`.
-@@ -468,6 +476,8 @@ class VIEWS_EXPORT WidgetDelegate {
+@@ -468,6 +475,7 @@ class VIEWS_EXPORT WidgetDelegate {
    };
    class RegisterDeleteCallbackPassKey {
     private:
-+    friend class electron::NativeWindowMac;
 +    friend class electron::NativeWindowViews;
      // DO NOT ADD TO THIS LIST!
      // These existing cases are "grandfathered in", but there shouldn't be more.
      // See comments atop `RegisterDeleteDelegateCallback()`.
-@@ -918,6 +928,7 @@ class VIEWS_EXPORT WidgetDelegateView : public WidgetDelegate, public View {
+@@ -918,6 +926,7 @@ class VIEWS_EXPORT WidgetDelegateView : public WidgetDelegate, public View {
    View* GetContentsView() override;
  
   private:

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -223,6 +223,7 @@ class NativeWindowMac : public NativeWindow,
   std::unique_ptr<views::NonClientFrameView> CreateNonClientFrameView(
       views::Widget* widget) override;
   void OnWidgetInitialized() override;
+  void OnWidgetDestroying(views::Widget* widget) override;
 
   // ui::NativeThemeObserver:
   void OnNativeThemeUpdated(ui::NativeTheme* observed_theme) override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -209,16 +209,6 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   window_ = static_cast<ElectronNSWindow*>(
       widget()->GetNativeWindow().GetNativeNSWindow());
 
-  RegisterDeleteDelegateCallback(RegisterDeleteCallbackPassKey(),
-                                 base::BindOnce(
-                                     [](NativeWindowMac* window) {
-                                       if (window->window_)
-                                         window->window_ = nil;
-                                       if (window->buttons_proxy_)
-                                         window->buttons_proxy_ = nil;
-                                     },
-                                     this));
-
   [window_ setEnableLargerThanScreen:enable_larger_than_screen()];
 
   window_delegate_ = [[ElectronNSWindowDelegate alloc] initWithShell:this];
@@ -1869,6 +1859,11 @@ void NativeWindowMac::OnWidgetInitialized() {
       [window setOpaque:YES];
     }
   }
+}
+
+void NativeWindowMac::OnWidgetDestroying(views::Widget* widget) {
+  window_ = nil;
+  buttons_proxy_ = nil;
 }
 
 // static


### PR DESCRIPTION
#### Description of Change

Part 1 in a series to remove deprecated Views API from our code.

We had to add several Electron classes to the "allowed to call deprecated views API" list in the `137.0.7128.1` Chromium [roll](https://github.com/electron/electron/pull/46482). Fixing all of those classes will be a major effort; but happily, `NativeWindowMac` is pretty easy. So let's start there :smile_cat: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.