### PR TITLE
refactor: don't call deprecated `WidgetDelegate` API in `NativeWindowViews`

### DIFF
--- a/patches/chromium/chore_grandfather_in_electron_views_and_delegates.patch
+++ b/patches/chromium/chore_grandfather_in_electron_views_and_delegates.patch
@@ -49,10 +49,10 @@ index ae7eab37f12ba80ec423d229cf048021e9ba6765..507a75dc7947295db221b01356fa57ba
      // These existing cases are "grandfathered in", but there shouldn't be more.
      // See comments atop class.
 diff --git a/ui/views/widget/widget_delegate.h b/ui/views/widget/widget_delegate.h
-index 7c2463cb91d00de2b0fa4f10221ea960be860d9a..0d5c63e7efbe42d5352abdeb594175904af30c41 100644
+index 7c2463cb91d00de2b0fa4f10221ea960be860d9a..e79beefddbd815e1ba7d9be86256e49d3ee7c619 100644
 --- a/ui/views/widget/widget_delegate.h
 +++ b/ui/views/widget/widget_delegate.h
-@@ -169,6 +169,13 @@ namespace data_controls {
+@@ -169,6 +169,12 @@ namespace data_controls {
  class DesktopDataControlsDialog;
  }
  
@@ -60,13 +60,12 @@ index 7c2463cb91d00de2b0fa4f10221ea960be860d9a..0d5c63e7efbe42d5352abdeb59417590
 +class AutofillPopupView;
 +class DevToolsWindowDelegate;
 +class NativeWindowMac;
-+class NativeWindowViews;
 +}
 +
  namespace enterprise_connectors {
  class ContentAnalysisDialog;
  class ContentAnalysisDialogBehaviorBrowserTest;
-@@ -371,6 +378,7 @@ class VIEWS_EXPORT WidgetDelegate {
+@@ -371,6 +377,7 @@ class VIEWS_EXPORT WidgetDelegate {
  
    class OwnedByWidgetPassKey {
     private:
@@ -74,16 +73,15 @@ index 7c2463cb91d00de2b0fa4f10221ea960be860d9a..0d5c63e7efbe42d5352abdeb59417590
      // DO NOT ADD TO THIS LIST!
      // These existing cases are "grandfathered in", but there shouldn't be more.
      // See comments atop `SetOwnedByWidget()`.
-@@ -468,6 +476,8 @@ class VIEWS_EXPORT WidgetDelegate {
+@@ -468,6 +475,7 @@ class VIEWS_EXPORT WidgetDelegate {
    };
    class RegisterDeleteCallbackPassKey {
     private:
 +    friend class electron::NativeWindowMac;
-+    friend class electron::NativeWindowViews;
      // DO NOT ADD TO THIS LIST!
      // These existing cases are "grandfathered in", but there shouldn't be more.
      // See comments atop `RegisterDeleteDelegateCallback()`.
-@@ -918,6 +928,7 @@ class VIEWS_EXPORT WidgetDelegateView : public WidgetDelegate, public View {
+@@ -918,6 +926,7 @@ class VIEWS_EXPORT WidgetDelegateView : public WidgetDelegate, public View {
    View* GetContentsView() override;
  
   private:


### PR DESCRIPTION
#### Description of Change

Part 2 in a [series](https://github.com/electron/electron/pull/46857) to remove deprecated `views::` API from our C++ code.

This removes the `RegisterDeleteDelegateCallback()` call from `NativeWindowViews` and moves the on-delegate-deleted callback logic to `OnWidgetDestroying()` and `OnWidgetDestroyed()`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none