### PR TITLE
refactor: add EmitDeprecationWarning helper

### DIFF
--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -666,10 +666,9 @@ void WebRequest::SetListener(Event event,
       }
 
       if (filter_include_patterns.empty()) {
-        util::EmitWarning(
+        util::EmitDeprecationWarning(
             "The urls array in WebRequestFilter is empty, which is deprecated. "
-            "Please use '<all_urls>' to match all URLs.",
-            "DeprecationWarning");
+            "Please use '<all_urls>' to match all URLs.");
         filter_include_patterns.insert("<all_urls>");
       }
 

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -182,9 +182,8 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   if (windowType == "textured" && (transparent() || !has_frame())) {
-    util::EmitWarning(
-        "The 'textured' window type is deprecated and will be removed",
-        "DeprecationWarning");
+    util::EmitDeprecationWarning(
+        "The 'textured' window type is deprecated and will be removed");
     styleMask |= NSWindowStyleMaskTexturedBackground;
   }
 #pragma clang diagnostic pop

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -286,9 +286,8 @@ v8::Local<v8::Value> NativeImage::GetBitmap(gin::Arguments* args) {
 
   if (!deprecated_warning_issued) {
     deprecated_warning_issued = true;
-    util::EmitWarning(isolate_,
-                      "getBitmap() is deprecated, use toBitmap() instead.",
-                      "DeprecationWarning");
+    util::EmitDeprecationWarning(
+        isolate_, "getBitmap() is deprecated, use toBitmap() instead.");
   }
 
   return ToBitmap(args);

--- a/shell/common/node_util.cc
+++ b/shell/common/node_util.cc
@@ -65,8 +65,8 @@ void EmitWarning(const std::string_view warning_msg,
 void EmitWarning(v8::Isolate* isolate,
                  const std::string_view warning_msg,
                  const std::string_view warning_type) {
-  ProcessEmitWarningGeneric(node::Environment::GetCurrent(isolate), warning_msg,
-                            warning_type);
+  node::ProcessEmitWarningGeneric(node::Environment::GetCurrent(isolate),
+                                  warning_msg, warning_type);
 }
 
 void EmitDeprecationWarning(const std::string_view warning_msg,
@@ -78,8 +78,9 @@ void EmitDeprecationWarning(const std::string_view warning_msg,
 void EmitDeprecationWarning(v8::Isolate* isolate,
                             const std::string_view warning_msg,
                             const std::string_view deprecation_code) {
-  ProcessEmitWarningGeneric(node::Environment::GetCurrent(isolate), warning_msg,
-                            "DeprecationWarning", deprecation_code);
+  node::ProcessEmitWarningGeneric(node::Environment::GetCurrent(isolate),
+                                  warning_msg, "DeprecationWarning",
+                                  deprecation_code);
 }
 
 node::Environment* CreateEnvironment(v8::Isolate* isolate,

--- a/shell/common/node_util.cc
+++ b/shell/common/node_util.cc
@@ -12,10 +12,10 @@
 #include "base/strings/string_number_conversions.h"
 #include "base/values.h"
 #include "gin/converter.h"
-#include "gin/dictionary.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/node_includes.h"
+#include "third_party/electron_node/src/node_process-inl.h"
 
 namespace electron::util {
 
@@ -65,14 +65,21 @@ void EmitWarning(const std::string_view warning_msg,
 void EmitWarning(v8::Isolate* isolate,
                  const std::string_view warning_msg,
                  const std::string_view warning_type) {
-  v8::HandleScope scope{isolate};
-  gin::Dictionary process{
-      isolate, node::Environment::GetCurrent(isolate)->process_object()};
-  base::RepeatingCallback<void(std::string_view, std::string_view,
-                               std::string_view)>
-      emit_warning;
-  process.Get("emitWarning", &emit_warning);
-  emit_warning.Run(warning_msg, warning_type, "");
+  ProcessEmitWarningGeneric(node::Environment::GetCurrent(isolate), warning_msg,
+                            warning_type);
+}
+
+void EmitDeprecationWarning(const std::string_view warning_msg,
+                            const std::string_view deprecation_code) {
+  EmitDeprecationWarning(JavascriptEnvironment::GetIsolate(), warning_msg,
+                         deprecation_code);
+}
+
+void EmitDeprecationWarning(v8::Isolate* isolate,
+                            const std::string_view warning_msg,
+                            const std::string_view deprecation_code) {
+  ProcessEmitWarningGeneric(node::Environment::GetCurrent(isolate), warning_msg,
+                            "DeprecationWarning", deprecation_code);
 }
 
 node::Environment* CreateEnvironment(v8::Isolate* isolate,

--- a/shell/common/node_util.h
+++ b/shell/common/node_util.h
@@ -30,8 +30,18 @@ void EmitWarning(v8::Isolate* isolate,
                  std::string_view warning_type);
 
 // Emit a warning via node's process.emitWarning(),
-// using JavscriptEnvironment's isolate
+// using JavascriptEnvironment's isolate
 void EmitWarning(std::string_view warning_msg, std::string_view warning_type);
+
+// Emit a deprecation warning via node's process.emitWarning()
+void EmitDeprecationWarning(v8::Isolate* isolate,
+                            std::string_view warning_msg,
+                            std::string_view deprecation_code = "");
+
+// Emit a deprecation warning via node's process.emitWarning(),
+// using JavascriptEnvironment's isolate
+void EmitDeprecationWarning(std::string_view warning_msg,
+                            std::string_view deprecation_code = "");
 
 // Run a script with JS source bundled inside the binary as if it's wrapped
 // in a function called with a null receiver and arguments specified in C++.


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Also switches `EmitWarning` to using Node's `ProcessEmitWarningGeneric`. Just a small quality of life improvement here.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
