### PR TITLE
refactor: use `base::ObserverList::Notify()`

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1299,8 +1299,7 @@ void WebContents::BeforeUnloadFired(content::WebContents* tab,
 void WebContents::SetContentsBounds(content::WebContents* source,
                                     const gfx::Rect& rect) {
   if (!Emit("content-bounds-updated", rect))
-    for (ExtendedWebContentsObserver& observer : observers_)
-      observer.OnSetContentBounds(rect);
+    observers_.Notify(&ExtendedWebContentsObserver::OnSetContentBounds, rect);
 }
 
 void WebContents::CloseContents(content::WebContents* source) {
@@ -1316,8 +1315,7 @@ void WebContents::CloseContents(content::WebContents* source) {
 }
 
 void WebContents::ActivateContents(content::WebContents* source) {
-  for (ExtendedWebContentsObserver& observer : observers_)
-    observer.OnActivateContents();
+  observers_.Notify(&ExtendedWebContentsObserver::OnActivateContents);
 }
 
 void WebContents::UpdateTargetURL(content::WebContents* source,
@@ -2112,8 +2110,8 @@ void WebContents::TitleWasSet(content::NavigationEntry* entry) {
   } else {
     final_title = web_contents()->GetTitle();
   }
-  for (ExtendedWebContentsObserver& observer : observers_)
-    observer.OnPageTitleUpdated(final_title, explicit_set);
+  observers_.Notify(&ExtendedWebContentsObserver::OnPageTitleUpdated,
+                    final_title, explicit_set);
   Emit("page-title-updated", final_title, explicit_set);
 }
 
@@ -2169,8 +2167,7 @@ void WebContents::DevToolsClosed() {
 }
 
 void WebContents::DevToolsResized() {
-  for (ExtendedWebContentsObserver& observer : observers_)
-    observer.OnDevToolsResized();
+  observers_.Notify(&ExtendedWebContentsObserver::OnDevToolsResized);
 }
 
 void WebContents::SetOwnerWindow(NativeWindow* owner_window) {

--- a/shell/browser/hid/electron_hid_delegate.cc
+++ b/shell/browser/hid/electron_hid_delegate.cc
@@ -56,25 +56,25 @@ class ElectronHidDelegate::ContextObservation
 
   // HidChooserContext::DeviceObserver:
   void OnDeviceAdded(const device::mojom::HidDeviceInfo& device_info) override {
-    for (auto& observer : observer_list_)
-      observer.OnDeviceAdded(device_info);
+    observer_list_.Notify(&content::HidDelegate::Observer::OnDeviceAdded,
+                          device_info);
   }
 
   void OnDeviceRemoved(
       const device::mojom::HidDeviceInfo& device_info) override {
-    for (auto& observer : observer_list_)
-      observer.OnDeviceRemoved(device_info);
+    observer_list_.Notify(&content::HidDelegate::Observer::OnDeviceRemoved,
+                          device_info);
   }
 
   void OnDeviceChanged(
       const device::mojom::HidDeviceInfo& device_info) override {
-    for (auto& observer : observer_list_)
-      observer.OnDeviceChanged(device_info);
+    observer_list_.Notify(&content::HidDelegate::Observer::OnDeviceChanged,
+                          device_info);
   }
 
   void OnHidManagerConnectionError() override {
-    for (auto& observer : observer_list_)
-      observer.OnHidManagerConnectionError();
+    observer_list_.Notify(
+        &content::HidDelegate::Observer::OnHidManagerConnectionError);
   }
 
   void OnHidChooserContextShutdown() override {

--- a/shell/browser/hid/hid_chooser_context.cc
+++ b/shell/browser/hid/hid_chooser_context.cc
@@ -244,8 +244,7 @@ void HidChooserContext::DeviceAdded(device::mojom::HidDeviceInfoPtr device) {
     devices_.insert({device->guid, device->Clone()});
 
   // Notify all observers.
-  for (auto& observer : device_observer_list_)
-    observer.OnDeviceAdded(*device);
+  device_observer_list_.Notify(&DeviceObserver::OnDeviceAdded, *device);
 }
 
 void HidChooserContext::DeviceRemoved(device::mojom::HidDeviceInfoPtr device) {
@@ -256,8 +255,7 @@ void HidChooserContext::DeviceRemoved(device::mojom::HidDeviceInfoPtr device) {
   DCHECK_EQ(n_erased, 1U);
 
   // Notify all device observers.
-  for (auto& observer : device_observer_list_)
-    observer.OnDeviceRemoved(*device);
+  device_observer_list_.Notify(&DeviceObserver::OnDeviceRemoved, *device);
 
   // Next we'll notify observers for revoked permissions. If the device does not
   // support persistent permissions then device permissions are revoked on
@@ -278,8 +276,7 @@ void HidChooserContext::DeviceChanged(device::mojom::HidDeviceInfoPtr device) {
   mapped = device->Clone();
 
   // Notify all observers.
-  for (auto& observer : device_observer_list_)
-    observer.OnDeviceChanged(*device);
+  device_observer_list_.Notify(&DeviceObserver::OnDeviceChanged, *device);
 }
 
 void HidChooserContext::EnsureHidManagerConnection() {
@@ -329,8 +326,7 @@ void HidChooserContext::OnHidManagerConnectionError() {
   ephemeral_devices_.clear();
 
   // Notify all device observers.
-  for (auto& observer : device_observer_list_)
-    observer.OnHidManagerConnectionError();
+  device_observer_list_.Notify(&DeviceObserver::OnHidManagerConnectionError);
 }
 
 }  // namespace electron

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -505,23 +505,21 @@ void NativeWindow::SetWindowControlsOverlayRect(const gfx::Rect& overlay_rect) {
 }
 
 void NativeWindow::NotifyWindowRequestPreferredWidth(int* width) {
-  for (NativeWindowObserver& observer : observers_)
-    observer.RequestPreferredWidth(width);
+  observers_.Notify(&NativeWindowObserver::RequestPreferredWidth, width);
 }
 
 void NativeWindow::NotifyWindowCloseButtonClicked() {
   // First ask the observers whether we want to close.
   bool prevent_default = false;
-  for (NativeWindowObserver& observer : observers_)
-    observer.WillCloseWindow(&prevent_default);
+  observers_.Notify(&NativeWindowObserver::WillCloseWindow, &prevent_default);
   if (prevent_default) {
     WindowList::WindowCloseCancelled(this);
     return;
   }
 
   // Then ask the observers how should we close the window.
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnCloseButtonClicked(&prevent_default);
+  observers_.Notify(&NativeWindowObserver::OnCloseButtonClicked,
+                    &prevent_default);
   if (prevent_default)
     return;
 
@@ -533,8 +531,7 @@ void NativeWindow::NotifyWindowClosed() {
     return;
 
   is_closed_ = true;
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowClosed();
+  observers_.Notify(&NativeWindowObserver::OnWindowClosed);
 
   WindowList::RemoveWindow(this);
 }
@@ -542,180 +539,153 @@ void NativeWindow::NotifyWindowClosed() {
 void NativeWindow::NotifyWindowQueryEndSession(
     const std::vector<std::string>& reasons,
     bool* prevent_default) {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowQueryEndSession(reasons, prevent_default);
+  observers_.Notify(&NativeWindowObserver::OnWindowQueryEndSession, reasons,
+                    prevent_default);
 }
 
 void NativeWindow::NotifyWindowEndSession(
     const std::vector<std::string>& reasons) {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowEndSession(reasons);
+  observers_.Notify(&NativeWindowObserver::OnWindowEndSession, reasons);
 }
 
 void NativeWindow::NotifyWindowBlur() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowBlur();
+  observers_.Notify(&NativeWindowObserver::OnWindowBlur);
 }
 
 void NativeWindow::NotifyWindowFocus() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowFocus();
+  observers_.Notify(&NativeWindowObserver::OnWindowFocus);
 }
 
 void NativeWindow::NotifyWindowIsKeyChanged(bool is_key) {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowIsKeyChanged(is_key);
+  observers_.Notify(&NativeWindowObserver::OnWindowIsKeyChanged, is_key);
 }
 
 void NativeWindow::NotifyWindowShow() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowShow();
+  observers_.Notify(&NativeWindowObserver::OnWindowShow);
 }
 
 void NativeWindow::NotifyWindowHide() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowHide();
+  observers_.Notify(&NativeWindowObserver::OnWindowHide);
 }
 
 void NativeWindow::NotifyWindowMaximize() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowMaximize();
+  observers_.Notify(&NativeWindowObserver::OnWindowMaximize);
 }
 
 void NativeWindow::NotifyWindowUnmaximize() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowUnmaximize();
+  observers_.Notify(&NativeWindowObserver::OnWindowUnmaximize);
 }
 
 void NativeWindow::NotifyWindowMinimize() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowMinimize();
+  observers_.Notify(&NativeWindowObserver::OnWindowMinimize);
 }
 
 void NativeWindow::NotifyWindowRestore() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowRestore();
+  observers_.Notify(&NativeWindowObserver::OnWindowRestore);
 }
 
 void NativeWindow::NotifyWindowWillResize(const gfx::Rect& new_bounds,
                                           const gfx::ResizeEdge& edge,
                                           bool* prevent_default) {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowWillResize(new_bounds, edge, prevent_default);
+  observers_.Notify(&NativeWindowObserver::OnWindowWillResize, new_bounds, edge,
+                    prevent_default);
 }
 
 void NativeWindow::NotifyWindowWillMove(const gfx::Rect& new_bounds,
                                         bool* prevent_default) {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowWillMove(new_bounds, prevent_default);
+  observers_.Notify(&NativeWindowObserver::OnWindowWillMove, new_bounds,
+                    prevent_default);
 }
 
 void NativeWindow::NotifyWindowResize() {
   NotifyLayoutWindowControlsOverlay();
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowResize();
+  observers_.Notify(&NativeWindowObserver::OnWindowResize);
 }
 
 void NativeWindow::NotifyWindowResized() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowResized();
+  observers_.Notify(&NativeWindowObserver::OnWindowResized);
 }
 
 void NativeWindow::NotifyWindowMove() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowMove();
+  observers_.Notify(&NativeWindowObserver::OnWindowMove);
 }
 
 void NativeWindow::NotifyWindowMoved() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowMoved();
+  observers_.Notify(&NativeWindowObserver::OnWindowMoved);
 }
 
 void NativeWindow::NotifyWindowEnterFullScreen() {
   NotifyLayoutWindowControlsOverlay();
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowEnterFullScreen();
+  observers_.Notify(&NativeWindowObserver::OnWindowEnterFullScreen);
 }
 
 void NativeWindow::NotifyWindowSwipe(const std::string& direction) {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowSwipe(direction);
+  observers_.Notify(&NativeWindowObserver::OnWindowSwipe, direction);
 }
 
 void NativeWindow::NotifyWindowRotateGesture(float rotation) {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowRotateGesture(rotation);
+  observers_.Notify(&NativeWindowObserver::OnWindowRotateGesture, rotation);
 }
 
 void NativeWindow::NotifyWindowSheetBegin() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowSheetBegin();
+  observers_.Notify(&NativeWindowObserver::OnWindowSheetBegin);
 }
 
 void NativeWindow::NotifyWindowSheetEnd() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowSheetEnd();
+  observers_.Notify(&NativeWindowObserver::OnWindowSheetEnd);
 }
 
 void NativeWindow::NotifyWindowLeaveFullScreen() {
   NotifyLayoutWindowControlsOverlay();
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowLeaveFullScreen();
+  observers_.Notify(&NativeWindowObserver::OnWindowLeaveFullScreen);
 }
 
 void NativeWindow::NotifyWindowEnterHtmlFullScreen() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowEnterHtmlFullScreen();
+  observers_.Notify(&NativeWindowObserver::OnWindowEnterHtmlFullScreen);
 }
 
 void NativeWindow::NotifyWindowLeaveHtmlFullScreen() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowLeaveHtmlFullScreen();
+  observers_.Notify(&NativeWindowObserver::OnWindowLeaveHtmlFullScreen);
 }
 
 void NativeWindow::NotifyWindowAlwaysOnTopChanged() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowAlwaysOnTopChanged();
+  observers_.Notify(&NativeWindowObserver::OnWindowAlwaysOnTopChanged);
 }
 
 void NativeWindow::NotifyWindowExecuteAppCommand(
     const std::string_view command_name) {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnExecuteAppCommand(command_name);
+  observers_.Notify(&NativeWindowObserver::OnExecuteAppCommand, command_name);
 }
 
 void NativeWindow::NotifyTouchBarItemInteraction(const std::string& item_id,
                                                  base::Value::Dict details) {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnTouchBarItemResult(item_id, details);
+  observers_.Notify(&NativeWindowObserver::OnTouchBarItemResult, item_id,
+                    details);
 }
 
 void NativeWindow::NotifyNewWindowForTab() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnNewWindowForTab();
+  observers_.Notify(&NativeWindowObserver::OnNewWindowForTab);
 }
 
 void NativeWindow::NotifyWindowSystemContextMenu(int x,
                                                  int y,
                                                  bool* prevent_default) {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnSystemContextMenu(x, y, prevent_default);
+  observers_.Notify(&NativeWindowObserver::OnSystemContextMenu, x, y,
+                    prevent_default);
 }
 
 void NativeWindow::NotifyLayoutWindowControlsOverlay() {
-  auto bounding_rect = GetWindowControlsOverlayRect();
-  if (bounding_rect.has_value()) {
-    for (NativeWindowObserver& observer : observers_)
-      observer.UpdateWindowControlsOverlay(bounding_rect.value());
-  }
+  if (const auto bounds = GetWindowControlsOverlayRect())
+    observers_.Notify(&NativeWindowObserver::UpdateWindowControlsOverlay,
+                      *bounds);
 }
 
 #if BUILDFLAG(IS_WIN)
 void NativeWindow::NotifyWindowMessage(UINT message,
                                        WPARAM w_param,
                                        LPARAM l_param) {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowMessage(message, w_param, l_param);
+  observers_.Notify(&NativeWindowObserver::OnWindowMessage, message, w_param,
+                    l_param);
 }
 #endif
 

--- a/shell/browser/serial/electron_serial_delegate.cc
+++ b/shell/browser/serial/electron_serial_delegate.cc
@@ -128,20 +128,19 @@ void ElectronSerialDelegate::DeleteControllerForFrame(
 // SerialChooserContext::PortObserver:
 void ElectronSerialDelegate::OnPortAdded(
     const device::mojom::SerialPortInfo& port) {
-  for (auto& observer : observer_list_)
-    observer.OnPortAdded(port);
+  observer_list_.Notify(&content::SerialDelegate::Observer::OnPortAdded, port);
 }
 
 void ElectronSerialDelegate::OnPortRemoved(
     const device::mojom::SerialPortInfo& port) {
-  for (auto& observer : observer_list_)
-    observer.OnPortRemoved(port);
+  observer_list_.Notify(&content::SerialDelegate::Observer::OnPortRemoved,
+                        port);
 }
 
 void ElectronSerialDelegate::OnPortManagerConnectionError() {
   port_observation_.Reset();
-  for (auto& observer : observer_list_)
-    observer.OnPortManagerConnectionError();
+  observer_list_.Notify(
+      &content::SerialDelegate::Observer::OnPortManagerConnectionError);
 }
 
 void ElectronSerialDelegate::OnSerialChooserContextShutdown() {

--- a/shell/browser/serial/serial_chooser_context.cc
+++ b/shell/browser/serial/serial_chooser_context.cc
@@ -238,15 +238,12 @@ void SerialChooserContext::OnPortAdded(device::mojom::SerialPortInfoPtr port) {
     ports.erase(port->token);
   }
 
-  for (auto& observer : port_observer_list_)
-    observer.OnPortAdded(*port);
+  port_observer_list_.Notify(&PortObserver::OnPortAdded, *port);
 }
 
 void SerialChooserContext::OnPortRemoved(
     device::mojom::SerialPortInfoPtr port) {
-  for (auto& observer : port_observer_list_)
-    observer.OnPortRemoved(*port);
-
+  port_observer_list_.Notify(&PortObserver::OnPortRemoved, *port);
   port_info_.erase(port->token);
 }
 

--- a/shell/browser/ui/electron_menu_model.cc
+++ b/shell/browser/ui/electron_menu_model.cc
@@ -101,16 +101,12 @@ void ElectronMenuModel::SetSharingItem(SharingItem item) {
 
 void ElectronMenuModel::MenuWillClose() {
   ui::SimpleMenuModel::MenuWillClose();
-  for (Observer& observer : observers_) {
-    observer.OnMenuWillClose();
-  }
+  observers_.Notify(&Observer::OnMenuWillClose);
 }
 
 void ElectronMenuModel::MenuWillShow() {
   ui::SimpleMenuModel::MenuWillShow();
-  for (Observer& observer : observers_) {
-    observer.OnMenuWillShow();
-  }
+  observers_.Notify(&Observer::OnMenuWillShow);
 }
 
 ElectronMenuModel* ElectronMenuModel::GetSubmenuModelAt(size_t index) {

--- a/shell/browser/ui/tray_icon.cc
+++ b/shell/browser/ui/tray_icon.cc
@@ -19,93 +19,75 @@ gfx::Rect TrayIcon::GetBounds() {
 void TrayIcon::NotifyClicked(const gfx::Rect& bounds,
                              const gfx::Point& location,
                              int modifiers) {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnClicked(bounds, location, modifiers);
+  observers_.Notify(&TrayIconObserver::OnClicked, bounds, location, modifiers);
 }
 
 void TrayIcon::NotifyDoubleClicked(const gfx::Rect& bounds, int modifiers) {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnDoubleClicked(bounds, modifiers);
+  observers_.Notify(&TrayIconObserver::OnDoubleClicked, bounds, modifiers);
 }
 
 void TrayIcon::NotifyMiddleClicked(const gfx::Rect& bounds, int modifiers) {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnMiddleClicked(bounds, modifiers);
+  observers_.Notify(&TrayIconObserver::OnMiddleClicked, bounds, modifiers);
 }
 
 void TrayIcon::NotifyBalloonShow() {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnBalloonShow();
+  observers_.Notify(&TrayIconObserver::OnBalloonShow);
 }
 
 void TrayIcon::NotifyBalloonClicked() {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnBalloonClicked();
+  observers_.Notify(&TrayIconObserver::OnBalloonClicked);
 }
 
 void TrayIcon::NotifyBalloonClosed() {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnBalloonClosed();
+  observers_.Notify(&TrayIconObserver::OnBalloonClosed);
 }
 
 void TrayIcon::NotifyRightClicked(const gfx::Rect& bounds, int modifiers) {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnRightClicked(bounds, modifiers);
+  observers_.Notify(&TrayIconObserver::OnRightClicked, bounds, modifiers);
 }
 
 void TrayIcon::NotifyDrop() {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnDrop();
+  observers_.Notify(&TrayIconObserver::OnDrop);
 }
 
 void TrayIcon::NotifyDropFiles(const std::vector<std::string>& files) {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnDropFiles(files);
+  observers_.Notify(&TrayIconObserver::OnDropFiles, files);
 }
 
 void TrayIcon::NotifyDropText(const std::string& text) {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnDropText(text);
+  observers_.Notify(&TrayIconObserver::OnDropText, text);
 }
 
 void TrayIcon::NotifyMouseUp(const gfx::Point& location, int modifiers) {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnMouseUp(location, modifiers);
+  observers_.Notify(&TrayIconObserver::OnMouseUp, location, modifiers);
 }
 
 void TrayIcon::NotifyMouseDown(const gfx::Point& location, int modifiers) {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnMouseDown(location, modifiers);
+  observers_.Notify(&TrayIconObserver::OnMouseDown, location, modifiers);
 }
 
 void TrayIcon::NotifyMouseEntered(const gfx::Point& location, int modifiers) {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnMouseEntered(location, modifiers);
+  observers_.Notify(&TrayIconObserver::OnMouseEntered, location, modifiers);
 }
 
 void TrayIcon::NotifyMouseExited(const gfx::Point& location, int modifiers) {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnMouseExited(location, modifiers);
+  observers_.Notify(&TrayIconObserver::OnMouseExited, location, modifiers);
 }
 
 void TrayIcon::NotifyMouseMoved(const gfx::Point& location, int modifiers) {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnMouseMoved(location, modifiers);
+  observers_.Notify(&TrayIconObserver::OnMouseMoved, location, modifiers);
 }
 
 void TrayIcon::NotifyDragEntered() {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnDragEntered();
+  observers_.Notify(&TrayIconObserver::OnDragEntered);
 }
 
 void TrayIcon::NotifyDragExited() {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnDragExited();
+  observers_.Notify(&TrayIconObserver::OnDragExited);
 }
 
 void TrayIcon::NotifyDragEnded() {
-  for (TrayIconObserver& observer : observers_)
-    observer.OnDragEnded();
+  observers_.Notify(&TrayIconObserver::OnDragEnded);
 }
 
 }  // namespace electron

--- a/shell/browser/ui/views/menu_delegate.cc
+++ b/shell/browser/ui/views/menu_delegate.cc
@@ -51,14 +51,12 @@ void MenuDelegate::RunMenu(ElectronMenuModel* model,
 }
 
 void MenuDelegate::ExecuteCommand(int id) {
-  for (Observer& obs : observers_)
-    obs.OnBeforeExecuteCommand();
+  observers_.Notify(&Observer::OnBeforeExecuteCommand);
   adapter_->ExecuteCommand(id);
 }
 
 void MenuDelegate::ExecuteCommand(int id, int mouse_event_flags) {
-  for (Observer& obs : observers_)
-    obs.OnBeforeExecuteCommand();
+  observers_.Notify(&Observer::OnBeforeExecuteCommand);
   adapter_->ExecuteCommand(id, mouse_event_flags);
 }
 
@@ -104,8 +102,7 @@ void MenuDelegate::WillHideMenu(views::MenuItemView* menu) {
 }
 
 void MenuDelegate::OnMenuClosed(views::MenuItemView* menu) {
-  for (Observer& obs : observers_)
-    obs.OnMenuClosed();
+  observers_.Notify(&Observer::OnMenuClosed);
 
   // Only switch to new menu when current menu is closed.
   if (button_to_open_)

--- a/shell/browser/usb/electron_usb_delegate.cc
+++ b/shell/browser/usb/electron_usb_delegate.cc
@@ -102,19 +102,19 @@ class ElectronUsbDelegate::ContextObservation
 
   // UsbChooserContext::DeviceObserver:
   void OnDeviceAdded(const device::mojom::UsbDeviceInfo& device_info) override {
-    for (auto& observer : observer_list_)
-      observer.OnDeviceAdded(device_info);
+    observer_list_.Notify(&content::UsbDelegate::Observer::OnDeviceAdded,
+                          device_info);
   }
 
   void OnDeviceRemoved(
       const device::mojom::UsbDeviceInfo& device_info) override {
-    for (auto& observer : observer_list_)
-      observer.OnDeviceRemoved(device_info);
+    observer_list_.Notify(&content::UsbDelegate::Observer::OnDeviceRemoved,
+                          device_info);
   }
 
   void OnDeviceManagerConnectionError() override {
-    for (auto& observer : observer_list_)
-      observer.OnDeviceManagerConnectionError();
+    observer_list_.Notify(
+        &content::UsbDelegate::Observer::OnDeviceManagerConnectionError);
   }
 
   void OnBrowserContextShutdown() override {

--- a/shell/browser/usb/usb_chooser_context.cc
+++ b/shell/browser/usb/usb_chooser_context.cc
@@ -290,8 +290,7 @@ void UsbChooserContext::OnDeviceAdded(
   devices_.try_emplace(device_info->guid, device_info->Clone());
 
   // Notify all observers.
-  for (auto& observer : device_observer_list_)
-    observer.OnDeviceAdded(*device_info);
+  device_observer_list_.Notify(&DeviceObserver::OnDeviceAdded, *device_info);
 }
 
 void UsbChooserContext::OnDeviceRemoved(
@@ -308,8 +307,7 @@ void UsbChooserContext::OnDeviceRemoved(
   DCHECK_EQ(n_erased, 1U);
 
   // Notify all device observers.
-  for (auto& observer : device_observer_list_)
-    observer.OnDeviceRemoved(*device_info);
+  device_observer_list_.Notify(&DeviceObserver::OnDeviceRemoved, *device_info);
 
   // If the device was persistent, return. Otherwise, notify all permission
   // observers that its permissions were revoked.
@@ -331,8 +329,7 @@ void UsbChooserContext::OnDeviceManagerConnectionError() {
   ephemeral_devices_.clear();
 
   // Notify all device observers.
-  for (auto& observer : device_observer_list_)
-    observer.OnDeviceManagerConnectionError();
+  device_observer_list_.Notify(&DeviceObserver::OnDeviceManagerConnectionError);
 }
 
 }  // namespace electron

--- a/shell/browser/window_list.cc
+++ b/shell/browser/window_list.cc
@@ -57,16 +57,13 @@ void WindowList::RemoveWindow(NativeWindow* window) {
   WindowVector& windows = GetInstance()->windows_;
   std::erase(windows, window);
 
-  if (windows.empty()) {
-    for (WindowListObserver& observer : GetObservers())
-      observer.OnWindowAllClosed();
-  }
+  if (windows.empty())
+    GetObservers().Notify(&WindowListObserver::OnWindowAllClosed);
 }
 
 // static
 void WindowList::WindowCloseCancelled(NativeWindow* window) {
-  for (WindowListObserver& observer : GetObservers())
-    observer.OnWindowCloseCancelled(window);
+  GetObservers().Notify(&WindowListObserver::OnWindowCloseCancelled, window);
 }
 
 // static


### PR DESCRIPTION
#### Description of Change

Update our code to use `base::ObserverList::Notify()`, a function [added last year](https://chromium-review.googlesource.com/c/chromium/src/+/5868181) to simplify observer notification.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.