### PR TITLE
fix: revert macOS content protection logic refactor

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -26,7 +26,6 @@
 #include "shell/common/options_switches.h"
 #include "ui/base/hit_test.h"
 #include "ui/compositor/compositor.h"
-#include "ui/views/widget/native_widget_private.h"
 #include "ui/views/widget/widget.h"
 
 #if !BUILDFLAG(IS_MAC)
@@ -833,20 +832,6 @@ void NativeWindow::HandlePendingFullscreenTransitions() {
   bool next_transition = pending_transitions_.front();
   pending_transitions_.pop();
   SetFullScreen(next_transition);
-}
-
-void NativeWindow::SetContentProtection(bool enable) {
-#if !BUILDFLAG(IS_LINUX)
-  widget()->native_widget_private()->SetAllowScreenshots(!enable);
-#endif
-}
-
-bool NativeWindow::IsContentProtected() const {
-#if !BUILDFLAG(IS_LINUX)
-  return !widget()->native_widget_private()->AreScreenshotsAllowed();
-#else  // Not implemented on Linux
-  return false;
-#endif
 }
 
 bool NativeWindow::IsTranslucent() const {

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -187,8 +187,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetDocumentEdited(bool edited) {}
   virtual bool IsDocumentEdited() const;
   virtual void SetIgnoreMouseEvents(bool ignore, bool forward) = 0;
-  void SetContentProtection(bool enable);
-  bool IsContentProtected() const;
+  virtual void SetContentProtection(bool enable) = 0;
+  virtual bool IsContentProtected() const = 0;
   virtual void SetFocusable(bool focusable) {}
   virtual bool IsFocusable() const;
   virtual void SetMenu(ElectronMenuModel* menu) {}

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -108,6 +108,8 @@ class NativeWindowMac : public NativeWindow,
   void SetIgnoreMouseEvents(bool ignore, bool forward) override;
   bool IsHiddenInMissionControl() const override;
   void SetHiddenInMissionControl(bool hidden) override;
+  void SetContentProtection(bool enable) override;
+  bool IsContentProtected() const override;
   void SetFocusable(bool focusable) override;
   bool IsFocusable() const override;
   void SetParentWindow(NativeWindow* parent) override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1168,6 +1168,15 @@ void NativeWindowMac::SetIgnoreMouseEvents(bool ignore, bool forward) {
   }
 }
 
+void NativeWindowMac::SetContentProtection(bool enable) {
+  [window_
+      setSharingType:enable ? NSWindowSharingNone : NSWindowSharingReadOnly];
+}
+
+bool NativeWindowMac::IsContentProtected() const {
+  return [window_ sharingType] == NSWindowSharingNone;
+}
+
 void NativeWindowMac::SetFocusable(bool focusable) {
   // No known way to unfocus the window if it had the focus. Here we do not
   // want to call Focus(false) because it moves the window to the back, i.e.

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -44,6 +44,7 @@
 #include "ui/ozone/public/ozone_platform.h"
 #include "ui/views/background.h"
 #include "ui/views/controls/webview/webview.h"
+#include "ui/views/widget/native_widget_private.h"
 #include "ui/views/widget/widget.h"
 #include "ui/views/window/client_view.h"
 #include "ui/wm/core/shadow_types.h"
@@ -1299,6 +1300,20 @@ void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
       });
     }
   }
+#endif
+}
+
+void NativeWindowViews::SetContentProtection(bool enable) {
+#if BUILDFLAG(IS_WIN)
+  widget()->native_widget_private()->SetAllowScreenshots(!enable);
+#endif
+}
+
+bool NativeWindowViews::IsContentProtected() const {
+#if BUILDFLAG(IS_WIN)
+  return !widget()->native_widget_private()->AreScreenshotsAllowed();
+#else  // Not implemented on Linux
+  return false;
 #endif
 }
 

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -113,6 +113,8 @@ class NativeWindowViews : public NativeWindow,
   void SetOpacity(const double opacity) override;
   double GetOpacity() const override;
   void SetIgnoreMouseEvents(bool ignore, bool forward) override;
+  void SetContentProtection(bool enable) override;
+  bool IsContentProtected() const override;
   void SetFocusable(bool focusable) override;
   bool IsFocusable() const override;
   void SetMenu(ElectronMenuModel* menu_model) override;


### PR DESCRIPTION
#### Description of Change

Electron 36 is currently looking at a regression on macOS only, where certain transparent child windows are not rendering their contents correctly and are showing as grey. A bisect tracked this bug back to a refactor of our macOS content protection logic. This PR reverts that refactor, specifically commit 34adb976b632157379de34cc1a71bdf6cc089714.

(Making a minimal repro in Fiddle, bug up shortly)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where transparent child windows on macOS were rendering a grey block as opposed to their correct contents.
