### PR TITLE
feat: enable secondary label for macOS menu

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -19,7 +19,7 @@ See [`Menu`](menu.md) for examples.
   * `type` string (optional) - Can be `normal`, `separator`, `submenu`, `checkbox` or
     `radio`.
   * `label` string (optional)
-  * `sublabel` string (optional)
+  * `sublabel` string (optional) _macOS_ - Available in macOS >= 14.4
   * `toolTip` string (optional) _macOS_ - Hover text for this menu item.
   * `accelerator` [Accelerator](accelerator.md) (optional)
   * `icon` ([NativeImage](native-image.md) | string) (optional)

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -329,6 +329,27 @@ name, no matter what label you set. To change it, modify your app bundle's
 [About Information Property List Files][AboutInformationPropertyListFiles]
 for more information.
 
+### Menu Sublabels
+
+Menu sublabels, or [subtitles](https://developer.apple.com/documentation/appkit/nsmenuitem/subtitle?language=objc), can be added to menu items using the `sublabel` option. Below is an example based on the renderer example above:
+
+```js @ts-expect-error=[12]
+// main
+ipcMain.on('show-context-menu', (event) => {
+  const template = [
+    {
+      label: 'Menu Item 1',
+      sublabel: 'Subtitle 1',
+      click: () => { event.sender.send('context-menu-command', 'menu-item-1') }
+    },
+    { type: 'separator' },
+    { label: 'Menu Item 2', sublabel: 'Subtitle 2', type: 'checkbox', checked: true }
+  ]
+  const menu = Menu.buildFromTemplate(template)
+  menu.popup({ window: BrowserWindow.fromWebContents(event.sender) })
+})
+```
+
 ## Setting Menu for Specific Browser Window (_Linux_ _Windows_)
 
 The [`setMenu` method][setMenu] of browser windows can set the menu of certain

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -315,11 +315,20 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
 - (NSMenuItem*)makeMenuItemForIndex:(NSInteger)index
                           fromModel:(electron::ElectronMenuModel*)model {
   std::u16string label16 = model->GetLabelAt(index);
+  auto rawSecondaryLabel = model->GetSecondaryLabelAt(index);
   NSString* label = l10n_util::FixUpWindowsStyleLabel(label16);
 
   NSMenuItem* item = [[NSMenuItem alloc] initWithTitle:label
                                                 action:@selector(itemSelected:)
                                          keyEquivalent:@""];
+
+  if (!rawSecondaryLabel.empty()) {
+    NSString* secondary_label =
+        l10n_util::FixUpWindowsStyleLabel(rawSecondaryLabel);
+    if (@available(macOS 14.4, *)) {
+      item.subtitle = secondary_label;
+    }
+  }
 
   // If the menu item has an icon, set it.
   ui::ImageModel icon = model->GetIconAt(index);

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -323,7 +323,7 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
                                          keyEquivalent:@""];
 
   if (!rawSecondaryLabel.empty()) {
-     if (@available(macOS 14.4, *)) {
+    if (@available(macOS 14.4, *)) {
       NSString* secondary_label =
           l10n_util::FixUpWindowsStyleLabel(rawSecondaryLabel);
       item.subtitle = secondary_label;

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -323,9 +323,9 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
                                          keyEquivalent:@""];
 
   if (!rawSecondaryLabel.empty()) {
-    NSString* secondary_label =
-        l10n_util::FixUpWindowsStyleLabel(rawSecondaryLabel);
-    if (@available(macOS 14.4, *)) {
+     if (@available(macOS 14.4, *)) {
+      NSString* secondary_label =
+          l10n_util::FixUpWindowsStyleLabel(rawSecondaryLabel);
       item.subtitle = secondary_label;
     }
   }


### PR DESCRIPTION
#### Description of Change

Closes #34621 

Adds sublabel functionality for macOS >= 14.4.

Tests and docs updates to come

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: added sublabel functionality for menus on macOS >= 14.4

@deepak1556 @VerteDinde 