### PR TITLE
refactor: move `IsClosed()` and `IsClosable()` tests into `NativeWindow::Close()`

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -362,8 +362,7 @@ void BaseWindow::SetContentView(gin::Handle<View> view) {
 }
 
 void BaseWindow::CloseImmediately() {
-  if (!window_->IsClosed())
-    window_->CloseImmediately();
+  window_->CloseImmediately();
 }
 
 void BaseWindow::Close() {

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -285,10 +285,6 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
     Show();
 }
 
-bool NativeWindow::IsClosed() const {
-  return is_closed_;
-}
-
 void NativeWindow::SetSize(const gfx::Size& size, bool animate) {
   SetBounds(gfx::Rect(GetPosition(), size), animate);
 }
@@ -528,8 +524,23 @@ void NativeWindow::NotifyWindowCloseButtonClicked() {
   CloseImmediately();
 }
 
+void NativeWindow::Close() {
+  if (!IsClosable()) {
+    WindowList::WindowCloseCancelled(this);
+    return;
+  }
+
+  if (!is_closed())
+    CloseImpl();
+}
+
+void NativeWindow::CloseImmediately() {
+  if (!is_closed())
+    CloseImmediatelyImpl();
+}
+
 void NativeWindow::NotifyWindowClosed() {
-  if (is_closed_)
+  if (is_closed())
     return;
 
   is_closed_ = true;

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -82,9 +82,10 @@ class NativeWindow : public base::SupportsUserData,
 
   virtual void SetContentView(views::View* view) = 0;
 
-  virtual void Close() = 0;
-  virtual void CloseImmediately() = 0;
-  virtual bool IsClosed() const;
+  // wrapper around CloseImpl that checks that window_ can be closed
+  void Close();
+  // wrapper around CloseImmediatelyImpl that checks that window_ can be closed
+  void CloseImmediately();
   virtual void Focus(bool focus) = 0;
   virtual bool IsFocused() const = 0;
   virtual void Show() = 0;
@@ -436,6 +437,8 @@ class NativeWindow : public base::SupportsUserData,
  protected:
   friend class api::BrowserView;
 
+  [[nodiscard]] constexpr bool is_closed() const { return is_closed_; }
+
   NativeWindow(const gin_helper::Dictionary& options, NativeWindow* parent);
 
   virtual void OnTitleChanged() {}
@@ -446,6 +449,9 @@ class NativeWindow : public base::SupportsUserData,
   std::u16string GetAccessibleWindowTitle() const override;
 
   void set_content_view(views::View* view) { content_view_ = view; }
+
+  virtual void CloseImpl() = 0;
+  virtual void CloseImmediatelyImpl() = 0;
 
   // The boolean parsing of the "titleBarOverlay" option
   bool titlebar_overlay_ = false;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -39,8 +39,8 @@ class NativeWindowMac : public NativeWindow,
   // NativeWindow:
   void OnTitleChanged() override;
   void SetContentView(views::View* view) override;
-  void Close() override;
-  void CloseImmediately() override;
+  void CloseImpl() override;
+  void CloseImmediatelyImpl() override;
   void Focus(bool focus) override;
   bool IsFocused() const override;
   void Show() override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -33,7 +33,6 @@
 #include "shell/browser/ui/cocoa/root_view_mac.h"
 #include "shell/browser/ui/cocoa/window_buttons_proxy.h"
 #include "shell/browser/ui/drag_util.h"
-#include "shell/browser/window_list.h"
 #include "shell/common/gin_converters/gfx_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_util.h"
@@ -331,12 +330,7 @@ void NativeWindowMac::SetContentView(views::View* view) {
   root_view->DeprecatedLayoutImmediately();
 }
 
-void NativeWindowMac::Close() {
-  if (!IsClosable()) {
-    WindowList::WindowCloseCancelled(this);
-    return;
-  }
-
+void NativeWindowMac::CloseImpl() {
   if (fullscreen_transition_state() != FullScreenTransitionState::kNone) {
     SetHasDeferredWindowClose(true);
     return;
@@ -372,7 +366,7 @@ void NativeWindowMac::Close() {
   }
 }
 
-void NativeWindowMac::CloseImmediately() {
+void NativeWindowMac::CloseImmediatelyImpl() {
   // Ensure we're detached from the parent window before closing.
   RemoveChildFromParentWindow();
 
@@ -1680,7 +1674,7 @@ bool NativeWindowMac::IsActive() const {
 }
 
 void NativeWindowMac::Cleanup() {
-  DCHECK(!IsClosed());
+  DCHECK(!is_closed());
   ui::NativeTheme::GetInstanceForNativeUi()->RemoveObserver(this);
   display::Screen::GetScreen()->RemoveObserver(this);
   [window_ cleanup];

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -31,7 +31,6 @@
 #include "shell/browser/ui/views/root_view.h"
 #include "shell/browser/web_contents_preferences.h"
 #include "shell/browser/web_view_manager.h"
-#include "shell/browser/window_list.h"
 #include "shell/common/electron_constants.h"
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
@@ -473,16 +472,11 @@ void NativeWindowViews::SetContentView(views::View* view) {
   root_view_.GetMainView()->DeprecatedLayoutImmediately();
 }
 
-void NativeWindowViews::Close() {
-  if (!IsClosable()) {
-    WindowList::WindowCloseCancelled(this);
-    return;
-  }
-
+void NativeWindowViews::CloseImpl() {
   widget()->Close();
 }
 
-void NativeWindowViews::CloseImmediately() {
+void NativeWindowViews::CloseImmediatelyImpl() {
   widget()->CloseNow();
 }
 

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -47,8 +47,8 @@ class NativeWindowViews : public NativeWindow,
 
   // NativeWindow:
   void SetContentView(views::View* view) override;
-  void Close() override;
-  void CloseImmediately() override;
+  void CloseImpl() override;
+  void CloseImmediatelyImpl() override;
   void Focus(bool focus) override;
   bool IsFocused() const override;
   void Show() override;

--- a/shell/browser/window_list.cc
+++ b/shell/browser/window_list.cc
@@ -87,7 +87,7 @@ void WindowList::CloseAllWindows() {
   std::ranges::reverse(weak_windows);
 #endif
   for (const auto& window : weak_windows) {
-    if (window && !window->IsClosed())
+    if (window)
       window->Close();
   }
 }
@@ -98,7 +98,7 @@ void WindowList::DestroyAllWindows() {
       ConvertToWeakPtrVector(GetInstance()->windows_);
 
   for (const auto& window : weak_windows) {
-    if (window && !window->IsClosed())
+    if (window)
       window->CloseImmediately();
   }
 }


### PR DESCRIPTION
#### Description of Change

- Split `NativeWindow::Close()` into two methods:
  1. `public void NativeWindow::Close()` which does the common prework needed by each subclass, e.g. checking to see if the window is already closed, and calling WindowList::CloseWindowCancelled() if the window is not closable. After the prework is done, it calls `CloseImpl()`.
  2. `protected virtual void NativeWindow::CloseImpl() = 0`, for subclasses to do platform-specific work.

- Split `NativeWindow::CloseImmediately()` into two methods:
  1. `public void NativeWindow::CloseImmediately()`, which does the prework needed by each subclass, e.g. checking to see if the window is already closed. After the prework is done, it calls `CloseImmediatelyImpl()`. 
  2. `protected virtual void NativeWindow::CloseImmediatelyImpl() = 0`, for subclasses to do platform-specific work.

Rationale:

- Eliminates code duplication from `NativeWindow` the previous `Close()` and `CloseImmediately()` methods
- Ensures that the is-not-closed and is-closable checks are called correctly before calling the impl functions. Previously, each caller had to check `if (!IsClosed()) Close();`
- Decouples `NativeWindowMac` and `NativeWindowViews` from the `WindowList` singleton

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.