### PR TITLE
docs: unify [!NOTE] structure

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -41,9 +41,10 @@ that was used to open the application, if it was launched from Notification Cent
 You can also call `app.isReady()` to check if this event has already fired and `app.whenReady()`
 to get a Promise that is fulfilled when Electron is initialized.
 
-**Note**: The `ready` event is only fired after the main process has finished running the first
-tick of the event loop. If an Electron API needs to be called before the `ready` event, ensure
-that it is called synchronously in the top-level context of the main process.
+> [!NOTE]
+> The `ready` event is only fired after the main process has finished running the first
+> tick of the event loop. If an Electron API needs to be called before the `ready` event, ensure
+> that it is called synchronously in the top-level context of the main process.
 
 ### Event: 'window-all-closed'
 
@@ -66,12 +67,14 @@ Emitted before the application starts closing its windows.
 Calling `event.preventDefault()` will prevent the default behavior, which is
 terminating the application.
 
-**Note:** If application quit was initiated by `autoUpdater.quitAndInstall()`,
-then `before-quit` is emitted _after_ emitting `close` event on all windows and
-closing them.
+> [!NOTE]
+> If application quit was initiated by `autoUpdater.quitAndInstall()`,
+> then `before-quit` is emitted _after_ emitting `close` event on all windows and
+> closing them.
 
-**Note:** On Windows, this event will not be emitted if the app is closed due
-to a shutdown/restart of the system or a user logout.
+> [!NOTE]
+> On Windows, this event will not be emitted if the app is closed due
+> to a shutdown/restart of the system or a user logout.
 
 ### Event: 'will-quit'
 
@@ -86,8 +89,9 @@ terminating the application.
 See the description of the `window-all-closed` event for the differences between
 the `will-quit` and `window-all-closed` events.
 
-**Note:** On Windows, this event will not be emitted if the app is closed due
-to a shutdown/restart of the system or a user logout.
+> [!NOTE]
+> On Windows, this event will not be emitted if the app is closed due
+> to a shutdown/restart of the system or a user logout.
 
 ### Event: 'quit'
 
@@ -98,8 +102,9 @@ Returns:
 
 Emitted when the application is quitting.
 
-**Note:** On Windows, this event will not be emitted if the app is closed due
-to a shutdown/restart of the system or a user logout.
+> [!NOTE]
+> On Windows, this event will not be emitted if the app is closed due
+> to a shutdown/restart of the system or a user logout.
 
 ### Event: 'open-file' _macOS_
 
@@ -470,24 +475,28 @@ and `workingDirectory` is its current working directory. Usually
 applications respond to this by making their primary window focused and
 non-minimized.
 
-**Note:** `argv` will not be exactly the same list of arguments as those passed
-to the second instance. The order might change and additional arguments might be appended.
-If you need to maintain the exact same arguments, it's advised to use `additionalData` instead.
+> [!NOTE]
+> `argv` will not be exactly the same list of arguments as those passed
+> to the second instance. The order might change and additional arguments might be appended.
+> If you need to maintain the exact same arguments, it's advised to use `additionalData` instead.
 
-**Note:** If the second instance is started by a different user than the first, the `argv` array will not include the arguments.
+> [!NOTE]
+> If the second instance is started by a different user than the first, the `argv` array will not include the arguments.
 
 This event is guaranteed to be emitted after the `ready` event of `app`
 gets emitted.
 
-**Note:** Extra command line arguments might be added by Chromium,
-such as `--original-process-start-time`.
+> [!NOTE]
+> Extra command line arguments might be added by Chromium,
+> such as `--original-process-start-time`.
 
 ## Methods
 
 The `app` object has the following methods:
 
-**Note:** Some methods are only available on specific operating systems and are
-labeled as such.
+> [!NOTE]
+> Some methods are only available on specific operating systems and are
+> labeled as such.
 
 ### `app.quit()`
 
@@ -679,7 +688,8 @@ preferred over `name` by Electron.
 
 Overrides the current application's name.
 
-**Note:** This function overrides the name used internally by Electron; it does not affect the name that the OS uses.
+> [!NOTE]
+> This function overrides the name used internally by Electron; it does not affect the name that the OS uses.
 
 ### `app.getLocale()`
 
@@ -688,18 +698,22 @@ Possible return values are documented [here](https://source.chromium.org/chromiu
 
 To set the locale, you'll want to use a command line switch at app startup, which may be found [here](command-line-switches.md).
 
-**Note:** When distributing your packaged app, you have to also ship the
-`locales` folder.
+> [!NOTE]
+> When distributing your packaged app, you have to also ship the
+> `locales` folder.
 
-**Note:** This API must be called after the `ready` event is emitted.
+> [!NOTE]
+> This API must be called after the `ready` event is emitted.
 
-**Note:** To see example return values of this API compared to other locale and language APIs, see [`app.getPreferredSystemLanguages()`](#appgetpreferredsystemlanguages).
+> [!NOTE]
+> To see example return values of this API compared to other locale and language APIs, see [`app.getPreferredSystemLanguages()`](#appgetpreferredsystemlanguages).
 
 ### `app.getLocaleCountryCode()`
 
 Returns `string` - User operating system's locale two-letter [ISO 3166](https://www.iso.org/iso-3166-country-codes.html) country code. The value is taken from native OS APIs.
 
-**Note:** When unable to detect locale country code, it returns empty string.
+> [!NOTE]
+> When unable to detect locale country code, it returns empty string.
 
 ### `app.getSystemLocale()`
 
@@ -712,9 +726,11 @@ Different operating systems also use the regional data differently:
 
 Therefore, this API can be used for purposes such as choosing a format for rendering dates and times in a calendar app, especially when the developer wants the format to be consistent with the OS.
 
-**Note:** This API must be called after the `ready` event is emitted.
+> [!NOTE]
+> This API must be called after the `ready` event is emitted.
 
-**Note:** To see example return values of this API compared to other locale and language APIs, see [`app.getPreferredSystemLanguages()`](#appgetpreferredsystemlanguages).
+> [!NOTE]
+> To see example return values of this API compared to other locale and language APIs, see [`app.getPreferredSystemLanguages()`](#appgetpreferredsystemlanguages).
 
 ### `app.getPreferredSystemLanguages()`
 
@@ -777,16 +793,18 @@ Once registered, all links with `your-protocol://` will be opened with the
 current executable. The whole link, including protocol, will be passed to your
 application as a parameter.
 
-**Note:** On macOS, you can only register protocols that have been added to
-your app's `info.plist`, which cannot be modified at runtime. However, you can
-change the file during build time via [Electron Forge][electron-forge],
-[Electron Packager][electron-packager], or by editing `info.plist` with a text
-editor. Please refer to [Apple's documentation][CFBundleURLTypes] for details.
+> [!NOTE]
+> On macOS, you can only register protocols that have been added to
+> your app's `info.plist`, which cannot be modified at runtime. However, you can
+> change the file during build time via [Electron Forge][electron-forge],
+> [Electron Packager][electron-packager], or by editing `info.plist` with a text
+> editor. Please refer to [Apple's documentation][CFBundleURLTypes] for details.
 
-**Note:** In a Windows Store environment (when packaged as an `appx`) this API
-will return `true` for all calls but the registry key it sets won't be accessible
-by other applications.  In order to register your Windows Store application
-as a default protocol handler you must [declare the protocol in your manifest](https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-uap-protocol).
+> [!NOTE]
+> In a Windows Store environment (when packaged as an `appx`) this API
+> will return `true` for all calls but the registry key it sets won't be accessible
+> by other applications.  In order to register your Windows Store application
+> as a default protocol handler you must [declare the protocol in your manifest](https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-uap-protocol).
 
 The API uses the Windows Registry and `LSSetDefaultHandlerForURLScheme` internally.
 
@@ -810,11 +828,12 @@ protocol (aka URI scheme). If so, it will remove the app as the default handler.
 Returns `boolean` - Whether the current executable is the default handler for a
 protocol (aka URI scheme).
 
-**Note:** On macOS, you can use this method to check if the app has been
-registered as the default protocol handler for a protocol. You can also verify
-this by checking `~/Library/Preferences/com.apple.LaunchServices.plist` on the
-macOS machine. Please refer to
-[Apple's documentation][LSCopyDefaultHandlerForURLScheme] for details.
+> [!NOTE]
+> On macOS, you can use this method to check if the app has been
+> registered as the default protocol handler for a protocol. You can also verify
+> this by checking `~/Library/Preferences/com.apple.LaunchServices.plist` on the
+> macOS machine. Please refer to
+> [Apple's documentation][LSCopyDefaultHandlerForURLScheme] for details.
 
 The API uses the Windows Registry and `LSCopyDefaultHandlerForURLScheme` internally.
 
@@ -858,8 +877,9 @@ Adds `tasks` to the [Tasks][tasks] category of the Jump List on Windows.
 
 Returns `boolean` - Whether the call succeeded.
 
-**Note:** If you'd like to customize the Jump List even more use
-`app.setJumpList(categories)` instead.
+> [!NOTE]
+> If you'd like to customize the Jump List even more use
+> `app.setJumpList(categories)` instead.
 
 ### `app.getJumpListSettings()` _Windows_
 
@@ -897,21 +917,24 @@ following strings:
 If `categories` is `null` the previously set custom Jump List (if any) will be
 replaced by the standard Jump List for the app (managed by Windows).
 
-**Note:** If a `JumpListCategory` object has neither the `type` nor the `name`
-property set then its `type` is assumed to be `tasks`. If the `name` property
+> [!NOTE]
+> If a `JumpListCategory` object has neither the `type` nor the `name`
+> property set then its `type` is assumed to be `tasks`. If the `name` property
 is set but the `type` property is omitted then the `type` is assumed to be
 `custom`.
 
-**Note:** Users can remove items from custom categories, and Windows will not
-allow a removed item to be added back into a custom category until **after**
-the next successful call to `app.setJumpList(categories)`. Any attempt to
-re-add a removed item to a custom category earlier than that will result in the
-entire custom category being omitted from the Jump List. The list of removed
-items can be obtained using `app.getJumpListSettings()`.
+> [!NOTE]
+> Users can remove items from custom categories, and Windows will not
+> allow a removed item to be added back into a custom category until **after**
+> the next successful call to `app.setJumpList(categories)`. Any attempt to
+> re-add a removed item to a custom category earlier than that will result in the
+> entire custom category being omitted from the Jump List. The list of removed
+> items can be obtained using `app.getJumpListSettings()`.
 
-**Note:** The maximum length of a Jump List item's `description` property is
-260 characters. Beyond this limit, the item will not be added to the Jump
-List, nor will it be displayed.
+> [!NOTE]
+> The maximum length of a Jump List item's `description` property is
+> 260 characters. Beyond this limit, the item will not be added to the Jump
+> List, nor will it be displayed.
 
 Here's a very simple example of creating a custom Jump List:
 
@@ -1188,7 +1211,8 @@ Returns [`ProcessMetric[]`](structures/process-metric.md): Array of `ProcessMetr
 
 Returns [`GPUFeatureStatus`](structures/gpu-feature-status.md) - The Graphics Feature Status from `chrome://gpu/`.
 
-**Note:** This information is only usable after the `gpu-info-update` event is emitted.
+> [!NOTE]
+> This information is only usable after the `gpu-info-update` event is emitted.
 
 ### `app.getGPUInfo(infoType)`
 
@@ -1242,11 +1266,13 @@ badge.
 
 On macOS, it shows on the dock icon. On Linux, it only works for Unity launcher.
 
-**Note:** Unity launcher requires a `.desktop` file to work. For more information,
-please read the [Unity integration documentation][unity-requirement].
+> [!NOTE]
+> Unity launcher requires a `.desktop` file to work. For more information,
+> please read the [Unity integration documentation][unity-requirement].
 
-**Note:** On macOS, you need to ensure that your application has the permission
-to display notifications for this method to work.
+> [!NOTE]
+> On macOS, you need to ensure that your application has the permission
+> to display notifications for this method to work.
 
 ### `app.getBadgeCount()` _Linux_ _macOS_
 
@@ -1348,7 +1374,8 @@ details. Disabled by default.
 
 This API must be called after the `ready` event is emitted.
 
-**Note:** Rendering accessibility tree can significantly affect the performance of your app. It should not be enabled by default.
+> [!NOTE]
+> Rendering accessibility tree can significantly affect the performance of your app. It should not be enabled by default.
 
 ### `app.showAboutPanel()`
 
@@ -1476,7 +1503,8 @@ By using this API, important information such as password and other sensitive in
 See [Apple's documentation](https://developer.apple.com/library/archive/technotes/tn2150/_index.html) for more
 details.
 
-**Note:** Enable `Secure Keyboard Entry` only when it is needed and disable it when it is no longer needed.
+> [!NOTE]
+> Enable `Secure Keyboard Entry` only when it is needed and disable it when it is no longer needed.
 
 ### `app.setProxy(config)`
 
@@ -1538,7 +1566,8 @@ See [Chromium's accessibility docs](https://www.chromium.org/developers/design-d
 
 This API must be called after the `ready` event is emitted.
 
-**Note:** Rendering accessibility tree can significantly affect the performance of your app. It should not be enabled by default.
+> [!NOTE]
+> Rendering accessibility tree can significantly affect the performance of your app. It should not be enabled by default.
 
 ### `app.applicationMenu`
 
@@ -1551,11 +1580,13 @@ An `Integer` property that returns the badge count for current app. Setting the 
 
 On macOS, setting this with any nonzero integer shows on the dock icon. On Linux, this property only works for Unity launcher.
 
-**Note:** Unity launcher requires a `.desktop` file to work. For more information,
-please read the [Unity integration documentation][unity-requirement].
+> [!NOTE]
+> Unity launcher requires a `.desktop` file to work. For more information,
+> please read the [Unity integration documentation][unity-requirement].
 
-**Note:** On macOS, you need to ensure that your application has the permission
-to display notifications for this property to take effect.
+> [!NOTE]
+> On macOS, you need to ensure that your application has the permission
+> to display notifications for this property to take effect.
 
 ### `app.commandLine` _Readonly_
 

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -26,8 +26,9 @@ requirements, you can read [Server Support][server-support]. Note that
 update process. Apps that need to disable ATS can add the
 `NSAllowsArbitraryLoads` key to their app's plist.
 
-**Note:** Your application must be signed for automatic updates on macOS.
-This is a requirement of `Squirrel.Mac`.
+> [!IMPORTANT]
+> Your application must be signed for automatic updates on macOS.
+> This is a requirement of `Squirrel.Mac`.
 
 ### Windows
 
@@ -93,8 +94,9 @@ Emitted when an update has been downloaded.
 
 On Windows only `releaseName` is available.
 
-**Note:** It is not strictly necessary to handle this event. A successfully
-downloaded update will still be applied the next time the application starts.
+> [!NOTE]
+> It is not strictly necessary to handle this event. A successfully
+> downloaded update will still be applied the next time the application starts.
 
 ### Event: 'before-quit-for-update'
 
@@ -125,8 +127,9 @@ Returns `string` - The current update feed URL.
 Asks the server whether there is an update. You must call `setFeedURL` before
 using this API.
 
-**Note:** If an update is available it will be downloaded automatically.
-Calling `autoUpdater.checkForUpdates()` twice will download the update two times.
+> [!NOTE]
+> If an update is available it will be downloaded automatically.
+> Calling `autoUpdater.checkForUpdates()` twice will download the update two times.
 
 ### `autoUpdater.quitAndInstall()`
 
@@ -137,9 +140,10 @@ Under the hood calling `autoUpdater.quitAndInstall()` will close all application
 windows first, and automatically call `app.quit()` after all windows have been
 closed.
 
-**Note:** It is not strictly necessary to call this function to apply an update,
-as a successfully downloaded update will always be applied the next time the
-application starts.
+> [!NOTE]
+> It is not strictly necessary to call this function to apply an update,
+> as a successfully downloaded update will always be applied the next time the
+> application starts.
 
 [squirrel-mac]: https://github.com/Squirrel/Squirrel.Mac
 [server-support]: https://github.com/Squirrel/Squirrel.Mac#server-support

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -4,7 +4,7 @@
 
 Process: [Main](../glossary.md#main-process)
 
-> **Note**
+> [!NOTE]
 > `BaseWindow` provides a flexible way to compose multiple web views in a
 > single window. For windows with only a single, full-size web view, the
 > [`BrowserWindow`](browser-window.md) class may be a simpler option.
@@ -107,8 +107,9 @@ It creates a new `BaseWindow` with native properties as set by the `options`.
 
 Objects created with `new BaseWindow` emit the following events:
 
-**Note:** Some events are only available on specific operating systems and are
-labeled as such.
+> [!NOTE]
+> Some events are only available on specific operating systems and are
+> labeled as such.
 
 #### Event: 'close'
 
@@ -137,7 +138,11 @@ window.onbeforeunload = (e) => {
 }
 ```
 
-_**Note**: There is a subtle difference between the behaviors of `window.onbeforeunload = handler` and `window.addEventListener('beforeunload', handler)`. It is recommended to always set the `event.returnValue` explicitly, instead of only returning a value, as the former works more consistently within Electron._
+> [!NOTE]
+> There is a subtle difference between the behaviors of `window.onbeforeunload = handler` and
+> `window.addEventListener('beforeunload', handler)`. It is recommended to always set the
+> `event.returnValue` explicitly, instead of only returning a value, as the former works more
+> consistently within Electron.
 
 #### Event: 'closed'
 
@@ -252,7 +257,8 @@ Emitted when the window is being moved to a new position.
 
 Emitted once when the window is moved to a new position.
 
-**Note**: On macOS this event is an alias of `move`.
+> [!NOTE]
+> On macOS, this event is an alias of `move`.
 
 #### Event: 'enter-full-screen'
 
@@ -421,7 +427,8 @@ A `boolean` property that determines whether the window is focusable.
 
 A `boolean` property that determines whether the window is visible on all workspaces.
 
-**Note:** Always returns false on Windows.
+> [!NOTE]
+> Always returns false on Windows.
 
 #### `win.shadow`
 
@@ -431,7 +438,8 @@ A `boolean` property that determines whether the window has a shadow.
 
 A `boolean` property that determines whether the menu bar should be visible.
 
-**Note:** If the menu bar is auto-hide, users can still bring up the menu bar by pressing the single `Alt` key.
+> [!NOTE]
+> If the menu bar is auto-hide, users can still bring up the menu bar by pressing the single `Alt` key.
 
 #### `win.kiosk`
 
@@ -452,7 +460,8 @@ and the icon of the file will show in window's title bar.
 
 A `string` property that determines the title of the native window.
 
-**Note:** The title of the web page can be different from the title of the native window.
+> [!NOTE]
+> The title of the web page can be different from the title of the native window.
 
 #### `win.minimizable` _macOS_ _Windows_
 
@@ -521,8 +530,9 @@ A `boolean` property that indicates whether the window is arranged via [Snap.](h
 
 Objects created with `new BaseWindow` have the following instance methods:
 
-**Note:** Some methods are only available on specific operating systems and are
-labeled as such.
+> [!NOTE]
+> Some methods are only available on specific operating systems and are
+> labeled as such.
 
 #### `win.setContentView(view)`
 
@@ -614,7 +624,8 @@ Returns `boolean` - Whether the window is minimized.
 
 Sets whether the window should be in fullscreen mode.
 
-**Note:** On macOS, fullscreen transitions take place asynchronously. If further actions depend on the fullscreen state, use the ['enter-full-screen'](base-window.md#event-enter-full-screen) or ['leave-full-screen'](base-window.md#event-leave-full-screen) events.
+> [!NOTE]
+> On macOS, fullscreen transitions take place asynchronously. If further actions depend on the fullscreen state, use the ['enter-full-screen'](base-window.md#event-enter-full-screen) or > ['leave-full-screen'](base-window.md#event-leave-full-screen) events.
 
 #### `win.isFullScreen()`
 
@@ -728,13 +739,15 @@ win.setBounds({ width: 100 })
 console.log(win.getBounds())
 ```
 
-**Note:** On macOS, the y-coordinate value cannot be smaller than the [Tray](tray.md) height. The tray height has changed over time and depends on the operating system, but is between 20-40px. Passing a value lower than the tray height will result in a window that is flush to the tray.
+> [!NOTE]
+> On macOS, the y-coordinate value cannot be smaller than the [Tray](tray.md) height. The tray height has changed over time and depends on the operating system, but is between 20-40px. Passing a value lower than the tray height will result in a window that is flush to the tray.
 
 #### `win.getBounds()`
 
 Returns [`Rectangle`](structures/rectangle.md) - The `bounds` of the window as `Object`.
 
-**Note:** On macOS, the y-coordinate value returned will be at minimum the [Tray](tray.md) height. For example, calling `win.setBounds({ x: 25, y: 20, width: 800, height: 600 })` with a tray height of 38 means that `win.getBounds()` will return `{ x: 25, y: 38, width: 800, height: 600 }`.
+> [!NOTE]
+> On macOS, the y-coordinate value returned will be at minimum the [Tray](tray.md) height. For example, calling `win.setBounds({ x: 25, y: 20, width: 800, height: 600 })` with a tray height of 38 means that `win.getBounds()` will return `{ x: 25, y: 38, width: 800, height: 600 }`.
 
 #### `win.getBackgroundColor()`
 
@@ -742,7 +755,8 @@ Returns `string` - Gets the background color of the window in Hex (`#RRGGBB`) fo
 
 See [Setting `backgroundColor`](browser-window.md#setting-the-backgroundcolor-property).
 
-**Note:** The alpha value is _not_ returned alongside the red, green, and blue values.
+> [!NOTE]
+> The alpha value is _not_ returned alongside the red, green, and blue values.
 
 #### `win.setContentBounds(bounds[, animate])`
 
@@ -760,7 +774,8 @@ Returns [`Rectangle`](structures/rectangle.md) - The `bounds` of the window's cl
 
 Returns [`Rectangle`](structures/rectangle.md) - Contains the window bounds of the normal state
 
-**Note:** whatever the current state of the window : maximized, minimized or in fullscreen, this function always returns the position and size of the window in normal state. In normal state, getBounds and getNormalBounds returns the same [`Rectangle`](structures/rectangle.md).
+> [!NOTE]
+> Whatever the current state of the window : maximized, minimized or in fullscreen, this function always returns the position and size of the window in normal state. In normal state, getBounds and getNormalBounds returns the same [`Rectangle`](structures/rectangle.md).
 
 #### `win.setEnabled(enable)`
 
@@ -957,8 +972,9 @@ Changes the title of native window to `title`.
 
 Returns `string` - The title of the native window.
 
-**Note:** The title of the web page can be different from the title of the native
-window.
+> [!NOTE]
+> The title of the web page can be different from the title of the native
+> window.
 
 #### `win.setSheetOffset(offsetY[, offsetX])` _macOS_
 
@@ -1232,8 +1248,9 @@ in the taskbar.
 
 Sets the properties for the window's taskbar button.
 
-**Note:** `relaunchCommand` and `relaunchDisplayName` must always be set
-together. If one of those properties is not set, then neither will be used.
+> [!NOTE]
+> `relaunchCommand` and `relaunchDisplayName` must always be set
+> together. If one of those properties is not set, then neither will be used.
 
 #### `win.setIcon(icon)` _Windows_ _Linux_
 
@@ -1293,13 +1310,15 @@ maximize button, or by dragging it to the edges of the screen.
 
 Sets whether the window should be visible on all workspaces.
 
-**Note:** This API does nothing on Windows.
+> [!NOTE]
+> This API does nothing on Windows.
 
 #### `win.isVisibleOnAllWorkspaces()` _macOS_ _Linux_
 
 Returns `boolean` - Whether the window is visible on all workspaces.
 
-**Note:** This API always returns false on Windows.
+> [!NOTE]
+> This API always returns false on Windows.
 
 #### `win.setIgnoreMouseEvents(ignore[, options])`
 
@@ -1416,7 +1435,8 @@ This method sets the browser window's system-drawn background material, includin
 
 See the [Windows documentation](https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwm_systembackdrop_type) for more details.
 
-**Note:** This method is only supported on Windows 11 22H2 and up.
+> [!NOTE]
+> This method is only supported on Windows 11 22H2 and up.
 
 #### `win.setWindowButtonPosition(position)` _macOS_
 
@@ -1438,8 +1458,9 @@ Sets the touchBar layout for the current window. Specifying `null` or
 `undefined` clears the touch bar. This method only has an effect if the
 machine has a touch bar.
 
-**Note:** The TouchBar API is currently experimental and may change or be
-removed in future Electron releases.
+> [!NOTE]
+> The TouchBar API is currently experimental and may change or be
+> removed in future Electron releases.
 
 #### `win.setTitleBarOverlay(options)` _Windows_ _Linux_
 

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -8,7 +8,7 @@ deprecated:
 ```
 -->
 
-> **Note**
+> [!NOTE]
 > The `BrowserView` class is deprecated, and replaced by the new
 > [`WebContentsView`](web-contents-view.md) class.
 
@@ -29,7 +29,7 @@ deprecated:
 
 > Create and control views.
 
-> **Note**
+> [!NOTE]
 > The `BrowserView` class is deprecated, and replaced by the new
 > [`WebContentsView`](web-contents-view.md) class.
 
@@ -176,4 +176,5 @@ Examples of valid `color` values:
   * Similar to CSS Color Module Level 3 keywords, but case-sensitive.
     * e.g. `blueviolet` or `red`
 
-**Note:** Hex format with alpha takes `AARRGGBB` or `ARGB`, _not_ `RRGGBBAA` or `RGB`.
+> [!NOTE]
+> Hex format with alpha takes `AARRGGBB` or `ARGB`, _not_ `RRGGBBAA` or `RGB`.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -158,7 +158,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
 
 Objects created with `new BrowserWindow` emit the following events:
 
-**Note:** Some events are only available on specific operating systems and are
+> [!NOTE]
+> Some events are only available on specific operating systems and are
 labeled as such.
 
 #### Event: 'page-title-updated'
@@ -200,7 +201,11 @@ window.onbeforeunload = (e) => {
 }
 ```
 
-_**Note**: There is a subtle difference between the behaviors of `window.onbeforeunload = handler` and `window.addEventListener('beforeunload', handler)`. It is recommended to always set the `event.returnValue` explicitly, instead of only returning a value, as the former works more consistently within Electron._
+> [!NOTE]
+> There is a subtle difference between the behaviors of `window.onbeforeunload = handler` and
+> `window.addEventListener('beforeunload', handler)`. It is recommended to always set the
+> `event.returnValue` explicitly, instead of only returning a value, as the former works more
+> consistently within Electron.
 
 #### Event: 'closed'
 
@@ -323,7 +328,8 @@ Emitted when the window is being moved to a new position.
 
 Emitted once when the window is moved to a new position.
 
-**Note**: On macOS this event is an alias of `move`.
+> [!NOTE]
+> On macOS, this event is an alias of `move`.
 
 #### Event: 'enter-full-screen'
 
@@ -460,7 +466,7 @@ or `null` if the contents are not owned by a window.
 
 * `browserView` [BrowserView](browser-view.md)
 
-> **Note**
+> [!NOTE]
 > The `BrowserView` class is deprecated, and replaced by the new
 > [`WebContentsView`](web-contents-view.md) class.
 
@@ -522,7 +528,8 @@ A `boolean` property that determines whether the window is focusable.
 
 A `boolean` property that determines whether the window is visible on all workspaces.
 
-**Note:** Always returns false on Windows.
+> [!NOTE]
+> Always returns false on Windows.
 
 #### `win.shadow`
 
@@ -532,7 +539,8 @@ A `boolean` property that determines whether the window has a shadow.
 
 A `boolean` property that determines whether the menu bar should be visible.
 
-**Note:** If the menu bar is auto-hide, users can still bring up the menu bar by pressing the single `Alt` key.
+> [!NOTE]
+> If the menu bar is auto-hide, users can still bring up the menu bar by pressing the single `Alt` key.
 
 #### `win.kiosk`
 
@@ -553,7 +561,8 @@ and the icon of the file will show in window's title bar.
 
 A `string` property that determines the title of the native window.
 
-**Note:** The title of the web page can be different from the title of the native window.
+> [!NOTE]
+> The title of the web page can be different from the title of the native window.
 
 #### `win.minimizable` _macOS_ _Windows_
 
@@ -621,8 +630,9 @@ A `boolean` property that indicates whether the window is arranged via [Snap.](h
 
 Objects created with `new BrowserWindow` have the following instance methods:
 
-**Note:** Some methods are only available on specific operating systems and are
-labeled as such.
+> [!NOTE]
+> Some methods are only available on specific operating systems and are
+> labeled as such.
 
 #### `win.destroy()`
 
@@ -704,13 +714,15 @@ Returns `boolean` - Whether the window is minimized.
 
 Sets whether the window should be in fullscreen mode.
 
-**Note:** On macOS, fullscreen transitions take place asynchronously. If further actions depend on the fullscreen state, use the ['enter-full-screen'](browser-window.md#event-enter-full-screen) or ['leave-full-screen'](browser-window.md#event-leave-full-screen) events.
+> [!NOTE]
+> On macOS, fullscreen transitions take place asynchronously. If further actions depend on the fullscreen state, use the ['enter-full-screen'](browser-window.md#event-enter-full-screen) or ['leave-full-screen'](browser-window.md#event-leave-full-screen) events.
 
 #### `win.isFullScreen()`
 
 Returns `boolean` - Whether the window is in fullscreen mode.
 
-**Note:** On macOS, fullscreen transitions take place asynchronously. When querying for a BrowserWindow's fullscreen status, you should ensure that either the ['enter-full-screen'](browser-window.md#event-enter-full-screen) or ['leave-full-screen'](browser-window.md#event-leave-full-screen) events have been emitted.
+> [!NOTE]
+> On macOS, fullscreen transitions take place asynchronously. When querying for a BrowserWindow's fullscreen status, you should ensure that either the ['enter-full-screen'](browser-window.md#event-enter-full-screen) or ['leave-full-screen'](browser-window.md#event-leave-full-screen) events have been emitted.
 
 #### `win.setSimpleFullScreen(flag)` _macOS_
 
@@ -820,13 +832,15 @@ win.setBounds({ width: 100 })
 console.log(win.getBounds())
 ```
 
-**Note:** On macOS, the y-coordinate value cannot be smaller than the [Tray](tray.md) height. The tray height has changed over time and depends on the operating system, but is between 20-40px. Passing a value lower than the tray height will result in a window that is flush to the tray.
+> [!NOTE]
+> On macOS, the y-coordinate value cannot be smaller than the [Tray](tray.md) height. The tray height has changed over time and depends on the operating system, but is between 20-40px. Passing a value lower than the tray height will result in a window that is flush to the tray.
 
 #### `win.getBounds()`
 
 Returns [`Rectangle`](structures/rectangle.md) - The `bounds` of the window as `Object`.
 
-**Note:** On macOS, the y-coordinate value returned will be at minimum the [Tray](tray.md) height. For example, calling `win.setBounds({ x: 25, y: 20, width: 800, height: 600 })` with a tray height of 38 means that `win.getBounds()` will return `{ x: 25, y: 38, width: 800, height: 600 }`.
+> [!NOTE]
+> On macOS, the y-coordinate value returned will be at minimum the [Tray](tray.md) height. For example, calling `win.setBounds({ x: 25, y: 20, width: 800, height: 600 })` with a tray height of 38 means that `win.getBounds()` will return `{ x: 25, y: 38, width: 800, height: 600 }`.
 
 #### `win.getBackgroundColor()`
 
@@ -834,7 +848,8 @@ Returns `string` - Gets the background color of the window in Hex (`#RRGGBB`) fo
 
 See [Setting `backgroundColor`](#setting-the-backgroundcolor-property).
 
-**Note:** The alpha value is _not_ returned alongside the red, green, and blue values.
+> [!NOTE]
+> The alpha value is _not_ returned alongside the red, green, and blue values.
 
 #### `win.setContentBounds(bounds[, animate])`
 
@@ -852,7 +867,8 @@ Returns [`Rectangle`](structures/rectangle.md) - The `bounds` of the window's cl
 
 Returns [`Rectangle`](structures/rectangle.md) - Contains the window bounds of the normal state
 
-**Note:** whatever the current state of the window : maximized, minimized or in fullscreen, this function always returns the position and size of the window in normal state. In normal state, getBounds and getNormalBounds returns the same [`Rectangle`](structures/rectangle.md).
+> [!NOTE]
+> Whatever the current state of the window : maximized, minimized or in fullscreen, this function always returns the position and size of the window in normal state. In normal state, getBounds and getNormalBounds returns the same [`Rectangle`](structures/rectangle.md).
 
 #### `win.setEnabled(enable)`
 
@@ -1049,8 +1065,9 @@ Changes the title of native window to `title`.
 
 Returns `string` - The title of the native window.
 
-**Note:** The title of the web page can be different from the title of the native
-window.
+> [!NOTE]
+> The title of the web page can be different from the title of the native
+> window.
 
 #### `win.setSheetOffset(offsetY[, offsetX])` _macOS_
 
@@ -1409,8 +1426,9 @@ in the taskbar.
 
 Sets the properties for the window's taskbar button.
 
-**Note:** `relaunchCommand` and `relaunchDisplayName` must always be set
-together. If one of those properties is not set, then neither will be used.
+> [!NOTE]
+> `relaunchCommand` and `relaunchDisplayName` must always be set
+> together. If one of those properties is not set, then neither will be used.
 
 #### `win.showDefinitionForSelection()` _macOS_
 
@@ -1474,13 +1492,15 @@ maximize button, or by dragging it to the edges of the screen.
 
 Sets whether the window should be visible on all workspaces.
 
-**Note:** This API does nothing on Windows.
+> [!NOTE]
+> This API does nothing on Windows.
 
 #### `win.isVisibleOnAllWorkspaces()` _macOS_ _Linux_
 
 Returns `boolean` - Whether the window is visible on all workspaces.
 
-**Note:** This API always returns false on Windows.
+> [!NOTE]
+> This API always returns false on Windows.
 
 #### `win.setIgnoreMouseEvents(ignore[, options])`
 
@@ -1601,7 +1621,8 @@ This method sets the browser window's system-drawn background material, includin
 
 See the [Windows documentation](https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwm_systembackdrop_type) for more details.
 
-**Note:** This method is only supported on Windows 11 22H2 and up.
+> [!NOTE]
+> This method is only supported on Windows 11 22H2 and up.
 
 #### `win.setWindowButtonPosition(position)` _macOS_
 
@@ -1623,8 +1644,9 @@ Sets the touchBar layout for the current window. Specifying `null` or
 `undefined` clears the touch bar. This method only has an effect if the
 machine has a touch bar.
 
-**Note:** The TouchBar API is currently experimental and may change or be
-removed in future Electron releases.
+> [!NOTE]
+> The TouchBar API is currently experimental and may change or be
+> removed in future Electron releases.
 
 #### `win.setBrowserView(browserView)` _Experimental_ _Deprecated_
 
@@ -1632,7 +1654,7 @@ removed in future Electron releases.
 If there are other `BrowserView`s attached, they will be removed from
 this window.
 
-> **Note**
+> [!WARNING]
 > The `BrowserView` class is deprecated, and replaced by the new
 > [`WebContentsView`](web-contents-view.md) class.
 
@@ -1641,7 +1663,7 @@ this window.
 Returns `BrowserView | null` - The `BrowserView` attached to `win`. Returns `null`
 if one is not attached. Throws an error if multiple `BrowserView`s are attached.
 
-> **Note**
+> [!WARNING]
 > The `BrowserView` class is deprecated, and replaced by the new
 > [`WebContentsView`](web-contents-view.md) class.
 
@@ -1651,7 +1673,7 @@ if one is not attached. Throws an error if multiple `BrowserView`s are attached.
 
 Replacement API for setBrowserView supporting work with multi browser views.
 
-> **Note**
+> [!WARNING]
 > The `BrowserView` class is deprecated, and replaced by the new
 > [`WebContentsView`](web-contents-view.md) class.
 
@@ -1659,7 +1681,7 @@ Replacement API for setBrowserView supporting work with multi browser views.
 
 * `browserView` [BrowserView](browser-view.md)
 
-> **Note**
+> [!WARNING]
 > The `BrowserView` class is deprecated, and replaced by the new
 > [`WebContentsView`](web-contents-view.md) class.
 
@@ -1670,7 +1692,7 @@ Replacement API for setBrowserView supporting work with multi browser views.
 Raises `browserView` above other `BrowserView`s attached to `win`.
 Throws an error if `browserView` is not attached to `win`.
 
-> **Note**
+> [!WARNING]
 > The `BrowserView` class is deprecated, and replaced by the new
 > [`WebContentsView`](web-contents-view.md) class.
 
@@ -1679,7 +1701,7 @@ Throws an error if `browserView` is not attached to `win`.
 Returns `BrowserView[]` - a sorted by z-index array of all BrowserViews that have been attached
 with `addBrowserView` or `setBrowserView`. The top-most BrowserView is the last element of the array.
 
-> **Note**
+> [!WARNING]
 > The `BrowserView` class is deprecated, and replaced by the new
 > [`WebContentsView`](web-contents-view.md) class.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -868,7 +868,7 @@ Returns [`Rectangle`](structures/rectangle.md) - The `bounds` of the window's cl
 Returns [`Rectangle`](structures/rectangle.md) - Contains the window bounds of the normal state
 
 > [!NOTE]
-> Whatever the current state of the window : maximized, minimized or in fullscreen, this function always returns the position and size of the window in normal state. In normal state, getBounds and getNormalBounds returns the same [`Rectangle`](structures/rectangle.md).
+> Whatever the current state of the window (maximized, minimized or in fullscreen), this function always returns the position and size of the window in normal state. In normal state, `getBounds` and `getNormalBounds` return the same [`Rectangle`](structures/rectangle.md).
 
 #### `win.setEnabled(enable)`
 

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -18,7 +18,8 @@ console.log(clipboard.readText('selection'))
 
 The `clipboard` module has the following methods:
 
-**Note:** Experimental APIs are marked as such and could be removed in future.
+> [!NOTE]
+> Experimental APIs are marked as such and could be removed in future.
 
 ### `clipboard.readText([type])`
 
@@ -141,9 +142,10 @@ bookmark is unavailable.  The `title` value will always be empty on Windows.
 
 Writes the `title` (macOS only) and `url` into the clipboard as a bookmark.
 
-**Note:** Most apps on Windows don't support pasting bookmarks into them so
-you can use `clipboard.write` to write both a bookmark and fallback text to the
-clipboard.
+> [!NOTE]
+> Most apps on Windows don't support pasting bookmarks into them so
+> you can use `clipboard.write` to write both a bookmark and fallback text to the
+> clipboard.
 
 ```js
 const { clipboard } = require('electron')

--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -73,7 +73,8 @@ Passing `--enable-logging=file` will result in logs being saved to the file
 specified by `--log-file=...`, or to `electron_debug.log` in the user-data
 directory if `--log-file` is not specified.
 
-> **Note:** On Windows, logs from child processes cannot be sent to stderr.
+> [!NOTE]
+> On Windows, logs from child processes cannot be sent to stderr.
 > Logging to a file is the most reliable way to collect logs on Windows.
 
 See also `--log-file`, `--log-level`, `--v`, and `--vmodule`.
@@ -252,7 +253,8 @@ the required version is unavailable. Current default is set to `3`.
 
 Electron supports some of the [CLI flags][node-cli] supported by Node.js.
 
-**Note:** Passing unsupported command line switches to Electron when it is not running in `ELECTRON_RUN_AS_NODE` will have no effect.
+> [!NOTE]
+> Passing unsupported command line switches to Electron when it is not running in `ELECTRON_RUN_AS_NODE` will have no effect.
 
 ### `--inspect-brk\[=\[host:]port]`
 

--- a/docs/api/command-line.md
+++ b/docs/api/command-line.md
@@ -25,7 +25,8 @@ document.
 
 Append a switch (with optional `value`) to Chromium's command line.
 
-**Note:** This will not affect `process.argv`. The intended usage of this function is to
+> [!NOTE]
+> This will not affect `process.argv`. The intended usage of this function is to
 control Chromium's behavior.
 
 ```js
@@ -49,8 +50,9 @@ const { app } = require('electron')
 app.commandLine.appendArgument('--enable-experimental-web-platform-features')
 ```
 
-**Note:** This will not affect `process.argv`. The intended usage of this function is to
-control Chromium's behavior.
+> [!NOTE]
+> This will not affect `process.argv`. The intended usage of this function is to
+> control Chromium's behavior.
 
 #### `commandLine.hasSwitch(switch)`
 
@@ -84,7 +86,8 @@ const portValue = app.commandLine.getSwitchValue('remote-debugging-port')
 console.log(portValue) // '8315'
 ```
 
-**Note:** When the switch is not present or has no value, it returns empty string.
+> [!NOTE]
+> When the switch is not present or has no value, it returns empty string.
 
 #### `commandLine.removeSwitch(switch)`
 
@@ -102,5 +105,6 @@ app.commandLine.removeSwitch('remote-debugging-port')
 console.log(app.commandLine.hasSwitch('remote-debugging-port')) // false
 ```
 
-**Note:** This will not affect `process.argv`. The intended usage of this function is to
-control Chromium's behavior.
+> [!NOTE]
+> This will not affect `process.argv`. The intended usage of this function is to
+> control Chromium's behavior.

--- a/docs/api/command-line.md
+++ b/docs/api/command-line.md
@@ -27,7 +27,7 @@ Append a switch (with optional `value`) to Chromium's command line.
 
 > [!NOTE]
 > This will not affect `process.argv`. The intended usage of this function is to
-control Chromium's behavior.
+> control Chromium's behavior.
 
 ```js
 const { app } = require('electron')

--- a/docs/api/content-tracing.md
+++ b/docs/api/content-tracing.md
@@ -7,8 +7,9 @@ Process: [Main](../glossary.md#main-process)
 This module does not include a web interface. To view recorded traces, use
 [trace viewer][], available at `chrome://tracing` in Chrome.
 
-**Note:** You should not use this module until the `ready` event of the app
-module is emitted.
+> [!NOTE]
+> You should not use this module until the `ready` event of the app
+> module is emitted.
 
 ```js
 const { app, contentTracing } = require('electron')

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -19,7 +19,8 @@ following projects:
 * [socorro](https://github.com/mozilla-services/socorro)
 * [mini-breakpad-server](https://github.com/electron/mini-breakpad-server)
 
-> **Note:** Electron uses Crashpad, not Breakpad, to collect and upload
+> [!NOTE]
+> Electron uses Crashpad, not Breakpad, to collect and upload
 > crashes, but for the time being, the [upload protocol is the same](https://chromium.googlesource.com/crashpad/crashpad/+/HEAD/doc/overview_design.md#Upload-to-collection-server).
 
 Or use a 3rd party hosted solution:
@@ -84,19 +85,23 @@ before `app.on('ready')`. If the crash reporter is not initialized at the time
 a renderer process is created, then that renderer process will not be monitored
 by the crash reporter.
 
-**Note:** You can test out the crash reporter by generating a crash using
-`process.crash()`.
+> [!NOTE]
+> You can test out the crash reporter by generating a crash using
+> `process.crash()`.
 
-**Note:** If you need to send additional/updated `extra` parameters after your
-first call `start` you can call `addExtraParameter`.
+> [!NOTE]
+> If you need to send additional/updated `extra` parameters after your
+> first call `start` you can call `addExtraParameter`.
 
-**Note:** Parameters passed in `extra`, `globalExtra` or set with
-`addExtraParameter` have limits on the length of the keys and values. Key names
-must be at most 39 bytes long, and values must be no longer than 127 bytes.
-Keys with names longer than the maximum will be silently ignored. Key values
-longer than the maximum length will be truncated.
+> [!NOTE]
+> Parameters passed in `extra`, `globalExtra` or set with
+> `addExtraParameter` have limits on the length of the keys and values. Key names
+> must be at most 39 bytes long, and values must be no longer than 127 bytes.
+> Keys with names longer than the maximum will be silently ignored. Key values
+> longer than the maximum length will be truncated.
 
-**Note:** This method is only available in the main process.
+> [!NOTE]
+> This method is only available in the main process.
 
 ### `crashReporter.getLastCrashReport()`
 
@@ -105,7 +110,8 @@ last crash report. Only crash reports that have been uploaded will be returned;
 even if a crash report is present on disk it will not be returned until it is
 uploaded. In the case that there are no uploaded reports, `null` is returned.
 
-**Note:** This method is only available in the main process.
+> [!NOTE]
+> This method is only available in the main process.
 
 ### `crashReporter.getUploadedReports()`
 
@@ -114,14 +120,16 @@ Returns [`CrashReport[]`](structures/crash-report.md):
 Returns all uploaded crash reports. Each report contains the date and uploaded
 ID.
 
-**Note:** This method is only available in the main process.
+> [!NOTE]
+> This method is only available in the main process.
 
 ### `crashReporter.getUploadToServer()`
 
 Returns `boolean` - Whether reports should be submitted to the server. Set through
 the `start` method or `setUploadToServer`.
 
-**Note:** This method is only available in the main process.
+> [!NOTE]
+> This method is only available in the main process.
 
 ### `crashReporter.setUploadToServer(uploadToServer)`
 
@@ -130,7 +138,8 @@ the `start` method or `setUploadToServer`.
 This would normally be controlled by user preferences. This has no effect if
 called before `start` is called.
 
-**Note:** This method is only available in the main process.
+> [!NOTE]
+> This method is only available in the main process.
 
 ### `crashReporter.addExtraParameter(key, value)`
 
@@ -148,10 +157,11 @@ with crashes from renderer or other child processes. Similarly, adding extra
 parameters in a renderer process will not result in those parameters being sent
 with crashes that occur in other renderer processes or in the main process.
 
-**Note:** Parameters have limits on the length of the keys and values. Key
-names must be no longer than 39 bytes, and values must be no longer than 20320
-bytes. Keys with names longer than the maximum will be silently ignored. Key
-values longer than the maximum length will be truncated.
+> [!NOTE]
+> Parameters have limits on the length of the keys and values. Key
+> names must be no longer than 39 bytes, and values must be no longer than 20320
+> bytes. Keys with names longer than the maximum will be silently ignored. Key
+> values longer than the maximum length will be truncated.
 
 ### `crashReporter.removeExtraParameter(key)`
 

--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -70,8 +70,9 @@ stopButton.addEventListener('click', () => {
 
 See [`navigator.mediaDevices.getDisplayMedia`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia) for more information.
 
-**Note:** `navigator.mediaDevices.getDisplayMedia` does not permit the use of `deviceId` for
-selection of a source - see [specification](https://w3c.github.io/mediacapture-screen-share/#constraints).
+> [!NOTE]
+> `navigator.mediaDevices.getDisplayMedia` does not permit the use of `deviceId` for
+> selection of a source - see [specification](https://w3c.github.io/mediacapture-screen-share/#constraints).
 
 ## Methods
 
@@ -92,8 +93,9 @@ The `desktopCapturer` module has the following methods:
 
 Returns `Promise<DesktopCapturerSource[]>` - Resolves with an array of [`DesktopCapturerSource`](structures/desktop-capturer-source.md) objects, each `DesktopCapturerSource` represents a screen or an individual window that can be captured.
 
-**Note** Capturing the screen contents requires user consent on macOS 10.15 Catalina or higher,
-which can detected by [`systemPreferences.getMediaAccessStatus`][].
+> [!NOTE]
+> Capturing the screen contents requires user consent on macOS 10.15 Catalina or higher,
+> which can detected by [`systemPreferences.getMediaAccessStatus`][].
 
 [`navigator.mediaDevices.getUserMedia`]: https://developer.mozilla.org/en/docs/Web/API/MediaDevices/getUserMedia
 [`systemPreferences.getMediaAccessStatus`]: system-preferences.md#systempreferencesgetmediaaccessstatusmediatype-windows-macos

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -67,10 +67,11 @@ The `extensions` array should contain extensions without wildcards or dots (e.g.
 `'png'` is good but `'.png'` and `'*.png'` are bad). To show all files, use the
 `'*'` wildcard (no other wildcard is supported).
 
-**Note:** On Windows and Linux an open dialog can not be both a file selector
-and a directory selector, so if you set `properties` to
-`['openFile', 'openDirectory']` on these platforms, a directory selector will be
-shown.
+> [!NOTE]
+> On Windows and Linux an open dialog can not be both a file selector
+> and a directory selector, so if you set `properties` to
+> `['openFile', 'openDirectory']` on these platforms, a directory selector will be
+> shown.
 
 ```js @ts-type={mainWindow:Electron.BaseWindow}
 dialog.showOpenDialogSync(mainWindow, {
@@ -78,10 +79,11 @@ dialog.showOpenDialogSync(mainWindow, {
 })
 ```
 
-**Note:** On Linux `defaultPath` is not supported when using portal file chooser
-dialogs unless the portal backend is version 4 or higher. You can use `--xdg-portal-required-version`
-[command-line switch](./command-line-switches.md#--xdg-portal-required-versionversion)
-to force gtk or kde dialogs.
+> [!NOTE]
+> On Linux `defaultPath` is not supported when using portal file chooser
+> dialogs unless the portal backend is version 4 or higher. You can use `--xdg-portal-required-version`
+> [command-line switch](./command-line-switches.md#--xdg-portal-required-versionversion)
+> to force gtk or kde dialogs.
 
 ### `dialog.showOpenDialog([window, ]options)`
 
@@ -139,10 +141,11 @@ The `extensions` array should contain extensions without wildcards or dots (e.g.
 `'png'` is good but `'.png'` and `'*.png'` are bad). To show all files, use the
 `'*'` wildcard (no other wildcard is supported).
 
-**Note:** On Windows and Linux an open dialog can not be both a file selector
-and a directory selector, so if you set `properties` to
-`['openFile', 'openDirectory']` on these platforms, a directory selector will be
-shown.
+> [!NOTE]
+> On Windows and Linux an open dialog can not be both a file selector
+> and a directory selector, so if you set `properties` to
+> `['openFile', 'openDirectory']` on these platforms, a directory selector will be
+> shown.
 
 ```js @ts-type={mainWindow:Electron.BaseWindow}
 dialog.showOpenDialog(mainWindow, {
@@ -155,10 +158,11 @@ dialog.showOpenDialog(mainWindow, {
 })
 ```
 
-**Note:** On Linux `defaultPath` is not supported when using portal file chooser
-dialogs unless the portal backend is version 4 or higher. You can use `--xdg-portal-required-version`
-[command-line switch](./command-line-switches.md#--xdg-portal-required-versionversion)
-to force gtk or kde dialogs.
+> [!NOTE]
+> On Linux `defaultPath` is not supported when using portal file chooser
+> dialogs unless the portal backend is version 4 or higher. You can use `--xdg-portal-required-version`
+> [command-line switch](./command-line-switches.md#--xdg-portal-required-versionversion)
+> to force gtk or kde dialogs.
 
 ### `dialog.showSaveDialogSync([window, ]options)`
 
@@ -225,8 +229,9 @@ The `window` argument allows the dialog to attach itself to a parent window, mak
 The `filters` specifies an array of file types that can be displayed, see
 `dialog.showOpenDialog` for an example.
 
-**Note:** On macOS, using the asynchronous version is recommended to avoid issues when
-expanding and collapsing the dialog.
+> [!NOTE]
+> On macOS, using the asynchronous version is recommended to avoid issues when
+> expanding and collapsing the dialog.
 
 ### `dialog.showMessageBoxSync([window, ]options)`
 

--- a/docs/api/dock.md
+++ b/docs/api/dock.md
@@ -28,7 +28,8 @@ When `informational` is passed, the dock icon will bounce for one second.
 However, the request remains active until either the application becomes active
 or the request is canceled.
 
-**Note:** This method can only be used while the app is not focused; when the app is focused it will return -1.
+> [!NOTE]
+> This method can only be used while the app is not focused; when the app is focused it will return -1.
 
 #### `dock.cancelBounce(id)` _macOS_
 

--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -144,8 +144,8 @@ Returns `string` - The file name of the download item.
 
 > [!NOTE]
 > The file name is not always the same as the actual one saved in local
-disk. If user changes the file name in a prompted download saving dialog, the
-actual name of saved file will be different.
+> disk. If user changes the file name in a prompted download saving dialog, the
+> actual name of saved file will be different.
 
 #### `downloadItem.getCurrentBytesPerSecond()`
 

--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -115,7 +115,8 @@ Returns `boolean` - Whether the download is paused.
 
 Resumes the download that has been paused.
 
-**Note:** To enable resumable downloads the server you are downloading from must support range requests and provide both `Last-Modified` and `ETag` header values. Otherwise `resume()` will dismiss previously received bytes and restart the download from the beginning.
+> [!NOTE]
+> To enable resumable downloads the server you are downloading from must support range requests and provide both `Last-Modified` and `ETag` header values. Otherwise `resume()` will dismiss previously received bytes and restart the download from the beginning.
 
 #### `downloadItem.canResume()`
 
@@ -141,7 +142,8 @@ Returns `boolean` - Whether the download has user gesture.
 
 Returns `string` - The file name of the download item.
 
-**Note:** The file name is not always the same as the actual one saved in local
+> [!NOTE]
+> The file name is not always the same as the actual one saved in local
 disk. If user changes the file name in a prompted download saving dialog, the
 actual name of saved file will be different.
 
@@ -172,8 +174,9 @@ header.
 
 Returns `string` - The current state. Can be `progressing`, `completed`, `cancelled` or `interrupted`.
 
-**Note:** The following methods are useful specifically to resume a
-`cancelled` item when session is restarted.
+> [!NOTE]
+> The following methods are useful specifically to resume a
+> `cancelled` item when session is restarted.
 
 #### `downloadItem.getURLChain()`
 

--- a/docs/api/extensions-api.md
+++ b/docs/api/extensions-api.md
@@ -92,11 +92,13 @@ app.whenReady().then(async () => {
 
 This API does not support loading packed (.crx) extensions.
 
-**Note:** This API cannot be called before the `ready` event of the `app` module
-is emitted.
+> [!NOTE]
+> This API cannot be called before the `ready` event of the `app` module
+> is emitted.
 
-**Note:** Loading extensions into in-memory (non-persistent) sessions is not
-supported and will throw an error.
+> [!NOTE]
+> Loading extensions into in-memory (non-persistent) sessions is not
+> supported and will throw an error.
 
 #### `extensions.removeExtension(extensionId)`
 
@@ -104,8 +106,9 @@ supported and will throw an error.
 
 Unloads an extension.
 
-**Note:** This API cannot be called before the `ready` event of the `app` module
-is emitted.
+> [!NOTE]
+> This API cannot be called before the `ready` event of the `app` module
+> is emitted.
 
 #### `extensions.getExtension(extensionId)`
 
@@ -113,12 +116,14 @@ is emitted.
 
 Returns `Extension | null` - The loaded extension with the given ID.
 
-**Note:** This API cannot be called before the `ready` event of the `app` module
-is emitted.
+> [!NOTE]
+> This API cannot be called before the `ready` event of the `app` module
+> is emitted.
 
 #### `extensions.getAllExtensions()`
 
 Returns `Extension[]` - A list of all loaded extensions.
 
-**Note:** This API cannot be called before the `ready` event of the `app` module
-is emitted.
+> [!NOTE]
+> This API cannot be called before the `ready` event of the `app` module
+> is emitted.

--- a/docs/api/extensions.md
+++ b/docs/api/extensions.md
@@ -6,7 +6,8 @@ but it also happens to support some other extension capabilities.
 
 [chrome-extensions-api-index]: https://developer.chrome.com/extensions/api_index
 
-> **Note:** Electron does not support arbitrary Chrome extensions from the
+> [!NOTE]
+> Electron does not support arbitrary Chrome extensions from the
 > store, and it is a **non-goal** of the Electron project to be perfectly
 > compatible with Chrome's implementation of Extensions.
 
@@ -160,7 +161,8 @@ The following methods of `chrome.tabs` are supported:
 - `chrome.tabs.update` (partial support)
   - supported properties: `url`, `muted`.
 
-> **Note:** In Chrome, passing `-1` as a tab ID signifies the "currently active
+> [!NOTE]
+> In Chrome, passing `-1` as a tab ID signifies the "currently active
 > tab". Since Electron has no such concept, passing `-1` as a tab ID is not
 > supported and will raise an error.
 
@@ -170,6 +172,7 @@ See [official documentation](https://developer.chrome.com/docs/extensions/refere
 
 All features of this API are supported.
 
-> **NOTE:** Electron's [`webRequest`](web-request.md) module takes precedence over `chrome.webRequest` if there are conflicting handlers.
+> [!NOTE]
+> Electron's [`webRequest`](web-request.md) module takes precedence over `chrome.webRequest` if there are conflicting handlers.
 
 See [official documentation](https://developer.chrome.com/docs/extensions/reference/webRequest) for more information.

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -11,7 +11,7 @@ shortcuts.
 > [!NOTE]
 > The shortcut is global; it will work even if the app does
 > not have the keyboard focus. This module cannot be used before the `ready`
-> event of the app module is emitted.
+> event of the app module is emitted.  
 > Please also note that it is also possible to use Chromium's
 > `GlobalShortcutsPortal` implementation, which allows apps to bind global
 > shortcuts when running within a Wayland session.

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -8,13 +8,13 @@ The `globalShortcut` module can register/unregister a global keyboard shortcut
 with the operating system so that you can customize the operations for various
 shortcuts.
 
-**Note:** The shortcut is global; it will work even if the app does
-not have the keyboard focus. This module cannot be used before the `ready`
-event of the app module is emitted.
-
-Please also note that it is also possible to use Chromium's
-`GlobalShortcutsPortal` implementation, which allows apps to bind global
-shortcuts when running within a Wayland session.
+> [!NOTE]
+> The shortcut is global; it will work even if the app does
+> not have the keyboard focus. This module cannot be used before the `ready`
+> event of the app module is emitted.
+> Please also note that it is also possible to use Chromium's
+> `GlobalShortcutsPortal` implementation, which allows apps to bind global
+> shortcuts when running within a Wayland session.
 
 ```js
 const { app, globalShortcut } = require('electron')

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -11,7 +11,7 @@ shortcuts.
 > [!NOTE]
 > The shortcut is global; it will work even if the app does
 > not have the keyboard focus. This module cannot be used before the `ready`
-> event of the app module is emitted.  
+> event of the app module is emitted.
 > Please also note that it is also possible to use Chromium's
 > `GlobalShortcutsPortal` implementation, which allows apps to bind global
 > shortcuts when running within a Wayland session.

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -156,7 +156,7 @@ If you need to transfer a [`MessagePort`][] to the main process, use [`ipcRender
 
 If you do not need a response to the message, consider using [`ipcRenderer.send`](#ipcrenderersendchannel-args).
 
-> **Note**
+> [!NOTE]
 > Sending non-standard JavaScript types such as DOM objects or
 > special Electron objects will throw an exception.
 >
@@ -165,7 +165,7 @@ If you do not need a response to the message, consider using [`ipcRenderer.send`
 > Electron's IPC to the main process, as the main process would have no way to decode
 > them. Attempting to send such objects over IPC will result in an error.
 
-> **Note**
+> [!NOTE]
 > If the handler in the main process throws an error,
 > the promise returned by `invoke` will reject.
 > However, the `Error` object in the renderer process
@@ -195,7 +195,8 @@ throw an exception.
 The main process handles it by listening for `channel` with [`ipcMain`](./ipc-main.md) module,
 and replies by setting `event.returnValue`.
 
-> :warning: **WARNING**: Sending a synchronous message will block the whole
+> [!WARNING]
+> Sending a synchronous message will block the whole
 > renderer process until the reply is received, so use this method only as a
 > last resort. It's much better to use the asynchronous version,
 > [`invoke()`](./ipc-renderer.md#ipcrendererinvokechannel-args).

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -51,7 +51,8 @@ See [`Menu`](menu.md) for examples.
     the placement of their containing group after the containing group of the item
     with the specified id.
 
-**Note:** `acceleratorWorksWhenHidden` is specified as being macOS-only because accelerators always work when items are hidden on Windows and Linux. The option is exposed to users to give them the option to turn it off, as this is possible in native macOS development.
+> [!NOTE]
+> `acceleratorWorksWhenHidden` is specified as being macOS-only because accelerators always work when items are hidden on Windows and Linux. The option is exposed to users to give them the option to turn it off, as this is possible in native macOS development.
 
 ### Roles
 
@@ -125,7 +126,8 @@ When specifying a `role` on macOS, `label` and `accelerator` are the only
 options that will affect the menu item. All other options will be ignored.
 Lowercase `role`, e.g. `toggledevtools`, is still supported.
 
-**Note:** The `enabled` and `visibility` properties are not available for top-level menu items in the tray on macOS.
+> [!NOTE]
+> The `enabled` and `visibility` properties are not available for top-level menu items in the tray on macOS.
 
 ### Instance Properties
 
@@ -170,7 +172,8 @@ An `Accelerator` (optional) indicating the item's accelerator, if set.
 
 An `Accelerator | null` indicating the item's [user-assigned accelerator](https://developer.apple.com/documentation/appkit/nsmenuitem/1514850-userkeyequivalent?language=objc) for the menu item.
 
-**Note:** This property is only initialized after the `MenuItem` has been added to a `Menu`. Either via `Menu.buildFromTemplate` or via `Menu.append()/insert()`.  Accessing before initialization will just return `null`.
+> [!NOTE]
+> This property is only initialized after the `MenuItem` has been added to a `Menu`. Either via `Menu.buildFromTemplate` or via `Menu.append()/insert()`.  Accessing before initialization will just return `null`.
 
 #### `menuItem.icon`
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -32,16 +32,18 @@ In order to escape the `&` character in an item name, add a proceeding `&`. For 
 Passing `null` will suppress the default menu. On Windows and Linux,
 this has the additional effect of removing the menu bar from the window.
 
-**Note:** The default menu will be created automatically if the app does not set one.
-It contains standard items such as `File`, `Edit`, `View`, `Window` and `Help`.
+> [!NOTE]
+> The default menu will be created automatically if the app does not set one.
+> It contains standard items such as `File`, `Edit`, `View`, `Window` and `Help`.
 
 #### `Menu.getApplicationMenu()`
 
 Returns `Menu | null` - The application menu, if set, or `null`, if not set.
 
-**Note:** The returned `Menu` instance doesn't support dynamic addition or
-removal of menu items. [Instance properties](#instance-properties) can still
-be dynamically modified.
+> [!NOTE]
+> The returned `Menu` instance doesn't support dynamic addition or
+> removal of menu items. [Instance properties](#instance-properties) can still
+> be dynamically modified.
 
 #### `Menu.sendActionToFirstResponder(action)` _macOS_
 
@@ -119,8 +121,9 @@ Inserts the `menuItem` to the `pos` position of the menu.
 
 Objects created with `new Menu` or returned by `Menu.buildFromTemplate` emit the following events:
 
-**Note:** Some events are only available on specific operating systems and are
-labeled as such.
+> [!NOTE]
+> Some events are only available on specific operating systems and are
+> labeled as such.
 
 #### Event: 'menu-will-show'
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -134,7 +134,8 @@ Creates an empty `NativeImage` instance.
 
 Returns `Promise<NativeImage>` - fulfilled with the file's thumbnail preview image, which is a [NativeImage](native-image.md).
 
-Note: The Windows implementation will ignore `size.height` and scale the height according to `size.width`.
+> [!NOTE]
+> Windows implementation will ignore `size.height` and scale the height according to `size.width`.
 
 ### `nativeImage.createFromPath(path)`
 

--- a/docs/api/net-log.md
+++ b/docs/api/net-log.md
@@ -17,8 +17,9 @@ app.whenReady().then(async () => {
 
 See [`--log-net-log`](command-line-switches.md#--log-net-logpath) to log network events throughout the app's lifecycle.
 
-**Note:** All methods unless specified can only be used after the `ready` event
-of the `app` module gets emitted.
+> [!NOTE]
+> All methods unless specified can only be used after the `ready` event
+> of the `app` module gets emitted.
 
 ## Methods
 

--- a/docs/api/net.md
+++ b/docs/api/net.md
@@ -117,8 +117,9 @@ protocol.handle('https', (req) => {
 })
 ```
 
-Note: in the [utility process](../glossary.md#utility-process) custom protocols
-are not supported.
+> [!NOTE]
+> In the [utility process](../glossary.md#utility-process), custom protocols
+> are not supported.
 
 ### `net.isOnline()`
 

--- a/docs/api/power-save-blocker.md
+++ b/docs/api/power-save-blocker.md
@@ -33,10 +33,11 @@ Returns `Integer` - The blocker ID that is assigned to this power blocker.
 Starts preventing the system from entering lower-power mode. Returns an integer
 identifying the power save blocker.
 
-**Note:** `prevent-display-sleep` has higher precedence over
-`prevent-app-suspension`. Only the highest precedence type takes effect. In
-other words, `prevent-display-sleep` always takes precedence over
-`prevent-app-suspension`.
+> [!NOTE]
+> `prevent-display-sleep` has higher precedence over
+> `prevent-app-suspension`. Only the highest precedence type takes effect. In
+> other words, `prevent-display-sleep` always takes precedence over
+> `prevent-app-suspension`.
 
 For example, an API calling A requests for `prevent-app-suspension`, and
 another calling B requests for `prevent-display-sleep`. `prevent-display-sleep`

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -233,7 +233,8 @@ console.log(version)
 // On Linux -> '4.15.0-45-generic'
 ```
 
-**Note:** It returns the actual operating system version instead of kernel version on macOS unlike `os.release()`.
+> [!NOTE]
+> It returns the actual operating system version instead of kernel version on macOS unlike `os.release()`.
 
 ### `process.takeHeapSnapshot(filePath)`
 

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -20,8 +20,9 @@ app.whenReady().then(() => {
 })
 ```
 
-**Note:** All methods unless specified can only be used after the `ready` event
-of the `app` module gets emitted.
+> [!NOTE]
+> All methods unless specified can only be used after the `ready` event
+> of the `app` module gets emitted.
 
 ## Using `protocol` with a custom `partition` or `session`
 
@@ -61,8 +62,9 @@ The `protocol` module has the following methods:
 
 * `customSchemes` [CustomScheme[]](structures/custom-scheme.md)
 
-**Note:** This method can only be used before the `ready` event of the `app`
-module gets emitted and can be called only once.
+> [!NOTE]
+> This method can only be used before the `ready` event of the `app`
+> module gets emitted and can be called only once.
 
 Registers the `scheme` as standard, secure, bypasses content security policy for
 resources, allows registering ServiceWorker, supports fetch API, streaming

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -9,8 +9,9 @@ module is emitted.
 
 `screen` is an [EventEmitter][event-emitter].
 
-**Note:** In the renderer / DevTools, `window.screen` is a reserved DOM
-property, so writing `let { screen } = require('electron')` will not work.
+> [!NOTE]
+> In the renderer / DevTools, `window.screen` is a reserved DOM
+> property, so writing `let { screen } = require('electron')` will not work.
 
 An example of creating a window that fills the whole screen:
 
@@ -101,7 +102,8 @@ Returns [`Point`](structures/point.md)
 
 The current absolute position of the mouse pointer.
 
-**Note:** The return value is a DIP point, not a screen physical point.
+> [!NOTE]
+> The return value is a DIP point, not a screen physical point.
 
 ### `screen.getPrimaryDisplay()`
 

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -762,7 +762,8 @@ Preconnects the given number of sockets to an origin.
 
 Returns `Promise<void>` - Resolves when all connections are closed.
 
-**Note:** It will terminate / fail all requests currently in flight.
+> [!NOTE]
+> It will terminate / fail all requests currently in flight.
 
 #### `ses.fetch(input[, init])`
 
@@ -1305,8 +1306,9 @@ Initiates a download of the resource at `url`.
 The API will generate a [DownloadItem](download-item.md) that can be accessed
 with the [will-download](#event-will-download) event.
 
-**Note:** This does not perform any security checks that relate to a page's origin,
-unlike [`webContents.downloadURL`](web-contents.md#contentsdownloadurlurl-options).
+> [!NOTE]
+> This does not perform any security checks that relate to a page's origin,
+> unlike [`webContents.downloadURL`](web-contents.md#contentsdownloadurlurl-options).
 
 #### `ses.createInterruptedDownload(options)`
 
@@ -1434,7 +1436,8 @@ The built in spellchecker does not automatically detect what language a user is 
 spell checker to correctly check their words you must call this API with an array of language codes.  You can
 get the list of supported language codes with the `ses.availableSpellCheckerLanguages` property.
 
-**Note:** On macOS the OS spellchecker is used and will detect your language automatically.  This API is a no-op on macOS.
+> [!NOTE]
+> On macOS, the OS spellchecker is used and will detect your language automatically. This API is a no-op on macOS.
 
 #### `ses.getSpellCheckerLanguages()`
 
@@ -1442,7 +1445,8 @@ Returns `string[]` - An array of language codes the spellchecker is enabled for.
 will fallback to using `en-US`.  By default on launch if this setting is an empty list Electron will try to populate this
 setting with the current OS locale.  This setting is persisted across restarts.
 
-**Note:** On macOS the OS spellchecker is used and has its own list of languages. On macOS, this API will return whichever languages have been configured by the OS.
+> [!NOTE]
+> On macOS, the OS spellchecker is used and has its own list of languages. On macOS, this API will return whichever languages have been configured by the OS.
 
 #### `ses.setSpellCheckerDictionaryDownloadURL(url)`
 
@@ -1460,7 +1464,8 @@ If the files present in `hunspell_dictionaries.zip` are available at `https://ex
 then you should call this api with `ses.setSpellCheckerDictionaryDownloadURL('https://example.com/dictionaries/')`.  Please
 note the trailing slash.  The URL to the dictionaries is formed as `${url}${filename}`.
 
-**Note:** On macOS the OS spellchecker is used and therefore we do not download any dictionary files.  This API is a no-op on macOS.
+> [!NOTE]
+> On macOS, the OS spellchecker is used and therefore we do not download any dictionary files. This API is a no-op on macOS.
 
 #### `ses.listWordsInSpellCheckerDictionary()`
 
@@ -1474,7 +1479,8 @@ Resolves when the full dictionary is loaded from disk.
 Returns `boolean` - Whether the word was successfully written to the custom dictionary. This API
 will not work on non-persistent (in-memory) sessions.
 
-**Note:** On macOS and Windows 10 this word will be written to the OS custom dictionary as well
+> [!NOTE]
+> On macOS and Windows, this word will be written to the OS custom dictionary as well.
 
 #### `ses.removeWordFromSpellCheckerDictionary(word)`
 
@@ -1483,7 +1489,8 @@ will not work on non-persistent (in-memory) sessions.
 Returns `boolean` - Whether the word was successfully removed from the custom dictionary. This API
 will not work on non-persistent (in-memory) sessions.
 
-**Note:** On macOS and Windows 10 this word will be removed from the OS custom dictionary as well
+> [!NOTE]
+> On macOS and Windows, this word will be removed from the OS custom dictionary as well.
 
 #### `ses.loadExtension(path[, options])` _Deprecated_
 
@@ -1526,11 +1533,13 @@ app.whenReady().then(async () => {
 
 This API does not support loading packed (.crx) extensions.
 
-**Note:** This API cannot be called before the `ready` event of the `app` module
-is emitted.
+> [!NOTE]
+> This API cannot be called before the `ready` event of the `app` module
+> is emitted.
 
-**Note:** Loading extensions into in-memory (non-persistent) sessions is not
-supported and will throw an error.
+> [!NOTE]
+> Loading extensions into in-memory (non-persistent) sessions is not
+> supported and will throw an error.
 
 **Deprecated:** Use the new `ses.extensions.loadExtension` API.
 
@@ -1540,8 +1549,9 @@ supported and will throw an error.
 
 Unloads an extension.
 
-**Note:** This API cannot be called before the `ready` event of the `app` module
-is emitted.
+> [!NOTE]
+> This API cannot be called before the `ready` event of the `app` module
+> is emitted.
 
 **Deprecated:** Use the new `ses.extensions.removeExtension` API.
 
@@ -1551,8 +1561,9 @@ is emitted.
 
 Returns `Extension | null` - The loaded extension with the given ID.
 
-**Note:** This API cannot be called before the `ready` event of the `app` module
-is emitted.
+> [!NOTE]
+> This API cannot be called before the `ready` event of the `app` module
+> is emitted.
 
 **Deprecated:** Use the new `ses.extensions.getExtension` API.
 
@@ -1560,8 +1571,9 @@ is emitted.
 
 Returns `Extension[]` - A list of all loaded extensions.
 
-**Note:** This API cannot be called before the `ready` event of the `app` module
-is emitted.
+> [!NOTE]
+> This API cannot be called before the `ready` event of the `app` module
+> is emitted.
 
 **Deprecated:** Use the new `ses.extensions.getAllExtensions` API.
 
@@ -1599,9 +1611,11 @@ Clears various different types of data.
 This method clears more types of data and is more thorough than the
 `clearStorageData` method.
 
-**Note:** Cookies are stored at a broader scope than origins. When removing cookies and filtering by `origins` (or `excludeOrigins`), the cookies will be removed at the [registrable domain](https://url.spec.whatwg.org/#host-registrable-domain) level. For example, clearing cookies for the origin `https://really.specific.origin.example.com/` will end up clearing all cookies for `example.com`. Clearing cookies for the origin `https://my.website.example.co.uk/` will end up clearing all cookies for `example.co.uk`.
+> [!NOTE]
+> Cookies are stored at a broader scope than origins. When removing cookies and filtering by `origins` (or `excludeOrigins`), the cookies will be removed at the [registrable domain](https://url.spec.whatwg.org/#host-registrable-domain) level. For example, clearing cookies for the origin `https://really.specific.origin.example.com/` will end up clearing all cookies for `example.com`. Clearing cookies for the origin `https://my.website.example.co.uk/` will end up clearing all cookies for `example.co.uk`.
 
-**Note:** Clearing cache data will also clear the shared dictionary cache. This means that any dictionaries used for compression may be reloaded after clearing the cache. If you wish to clear the shared dictionary cache but leave other cached data intact, you may want to use the `clearSharedDictionaryCache` method.
+> [!NOTE]
+> Clearing cache data will also clear the shared dictionary cache. This means that any dictionaries used for compression may be reloaded after clearing the cache. If you wish to clear the shared dictionary cache but leave other cached data intact, you may want to use the `clearSharedDictionaryCache` method.
 
 For more information, refer to Chromium's [`BrowsingDataRemover` interface][browsing-data-remover].
 

--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -14,7 +14,8 @@ const { shell } = require('electron')
 shell.openExternal('https://github.com')
 ```
 
-**Note:** While the `shell` module can be used in the renderer process, it will not function in a sandboxed renderer.
+> [!WARNING]
+> While the `shell` module can be used in the renderer process, it will not function in a sandboxed renderer.
 
 ## Methods
 

--- a/docs/api/structures/jump-list-category.md
+++ b/docs/api/structures/jump-list-category.md
@@ -15,11 +15,13 @@
 * `items` JumpListItem[] (optional) - Array of [`JumpListItem`](jump-list-item.md) objects if `type` is `tasks` or
   `custom`, otherwise it should be omitted.
 
-**Note:** If a `JumpListCategory` object has neither the `type` nor the `name`
-property set then its `type` is assumed to be `tasks`. If the `name` property
-is set but the `type` property is omitted then the `type` is assumed to be
-`custom`.
+> [!NOTE]
+> If a `JumpListCategory` object has neither the `type` nor the `name`
+> property set then its `type` is assumed to be `tasks`. If the `name` property
+> is set but the `type` property is omitted then the `type` is assumed to be
+> `custom`.
 
-**Note:** The maximum length of a Jump List item's `description` property is
-260 characters. Beyond this limit, the item will not be added to the Jump
-List, nor will it be displayed.
+> [!NOTE]
+> The maximum length of a Jump List item's `description` property is
+> 260 characters. Beyond this limit, the item will not be added to the Jump
+> List, nor will it be displayed.

--- a/docs/api/structures/point.md
+++ b/docs/api/structures/point.md
@@ -3,6 +3,7 @@
 * `x` number
 * `y` number
 
-**Note:** Both `x` and `y` must be whole integers, when providing a point object
-as input to an Electron API we will automatically round your `x` and `y` values
-to the nearest whole integer.
+> [!NOTE]
+> Both `x` and `y` must be whole integers, when providing a point object
+> as input to an Electron API we will automatically round your `x` and `y` values
+> to the nearest whole integer.

--- a/docs/api/touch-bar-other-items-proxy.md
+++ b/docs/api/touch-bar-other-items-proxy.md
@@ -4,8 +4,9 @@
 > from Chromium at the space indicated by the proxy. By default, this proxy is added
 > to each TouchBar at the end of the input. For more information, see the AppKit docs on
 > [NSTouchBarItemIdentifierOtherItemsProxy](https://developer.apple.com/documentation/appkit/nstouchbaritemidentifierotheritemsproxy)
->
-> Note: Only one instance of this class can be added per TouchBar.
+
+> [!NOTE]
+> Only one instance of this class can be added per TouchBar.
 
 Process: [Main](../glossary.md#main-process)<br />
 _This class is not exported from the `'electron'` module. It is only available as a return value of other methods in the Electron API._

--- a/docs/api/touch-bar.md
+++ b/docs/api/touch-bar.md
@@ -15,12 +15,14 @@ Process: [Main](../glossary.md#main-process)
 Creates a new touch bar with the specified items. Use
 `BrowserWindow.setTouchBar` to add the `TouchBar` to a window.
 
-**Note:** The TouchBar API is currently experimental and may change or be
-removed in future Electron releases.
+> [!NOTE]
+> The TouchBar API is currently experimental and may change or be
+> removed in future Electron releases.
 
-**Tip:** If you don't have a MacBook with Touch Bar, you can use
-[Touch Bar Simulator](https://github.com/sindresorhus/touch-bar-simulator)
-to test Touch Bar usage in your app.
+> [!TIP]
+> If you don't have a MacBook with Touch Bar, you can use
+> [Touch Bar Simulator](https://github.com/sindresorhus/touch-bar-simulator)
+> to test Touch Bar usage in your app.
 
 ### Static Properties
 

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -176,7 +176,8 @@ Returns:
 
 Emitted when the mouse is released from clicking the tray icon.
 
-Note: This will not be emitted if you have set a context menu for your Tray using `tray.setContextMenu`, as a result of macOS-level constraints.
+> [!NOTE]
+> This will not be emitted if you have set a context menu for your Tray using `tray.setContextMenu`, as a result of macOS-level constraints.
 
 #### Event: 'mouse-down' _macOS_
 

--- a/docs/api/utility-process.md
+++ b/docs/api/utility-process.md
@@ -44,7 +44,8 @@ Process: [Main](../glossary.md#main-process)<br />
 
 Returns [`UtilityProcess`](utility-process.md#class-utilityprocess)
 
-**Note:** `utilityProcess.fork` can only be called after the `ready` event has been emitted on `App`.
+> [!NOTE]
+> `utilityProcess.fork` can only be called after the `ready` event has been emitted on `App`.
 
 ## Class: UtilityProcess
 
@@ -108,7 +109,8 @@ child.on('exit', () => {
 })
 ```
 
-**Note:** You can use the `pid` to determine if the process is currently running.
+> [!NOTE]
+> You can use the `pid` to determine if the process is currently running.
 
 #### `child.stdout`
 

--- a/docs/api/view.md
+++ b/docs/api/view.md
@@ -94,13 +94,15 @@ Examples of valid `color` values:
   * Similar to CSS Color Module Level 3 keywords, but case-sensitive.
     * e.g. `blueviolet` or `red`
 
-**Note:** Hex format with alpha takes `AARRGGBB` or `ARGB`, _not_ `RRGGBBAA` or `RGB`.
+> [!NOTE]
+> Hex format with alpha takes `AARRGGBB` or `ARGB`, _not_ `RRGGBBAA` or `RGB`.
 
 #### `view.setBorderRadius(radius)`
 
 * `radius` Integer - Border radius size in pixels.
 
-**Note:** The area cutout of the view's border still captures clicks.
+> [!NOTE]
+> The area cutout of the view's border still captures clicks.
 
 #### `view.setVisible(visible)`
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -463,7 +463,8 @@ win.webContents.on('will-prevent-unload', (event) => {
 })
 ```
 
-**Note:** This will be emitted for `BrowserViews` but will _not_ be respected - this is because we have chosen not to tie the `BrowserView` lifecycle to its owning BrowserWindow should one exist per the [specification](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event).
+> [!NOTE]
+> This will be emitted for `BrowserViews` but will _not_ be respected - this is because we have chosen not to tie the `BrowserView` lifecycle to its owning BrowserWindow should one exist per the [specification](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event).
 
 #### Event: 'render-process-gone'
 
@@ -1491,7 +1492,8 @@ increment above or below represents zooming 20% larger or smaller to default
 limits of 300% and 50% of original size, respectively. The formula for this is
 `scale := 1.2 ^ level`.
 
-> **NOTE**: The zoom policy at the Chromium level is same-origin, meaning that the
+> [!NOTE]
+> The zoom policy at the Chromium level is same-origin, meaning that the
 > zoom level for a specific domain propagates across all instances of windows with
 > the same domain. Differentiating the window URLs will make zoom work per-window.
 
@@ -1508,7 +1510,8 @@ Returns `Promise<void>`
 
 Sets the maximum and minimum pinch-to-zoom level.
 
-> **NOTE**: Visual zoom is disabled by default in Electron. To re-enable it, call:
+> [!NOTE]
+> Visual zoom is disabled by default in Electron. To re-enable it, call:
 >
 > ```js
 > const win = new BrowserWindow()
@@ -2076,7 +2079,9 @@ Disable device emulation enabled by `webContents.enableDeviceEmulation`.
 * `inputEvent` [MouseInputEvent](structures/mouse-input-event.md) | [MouseWheelInputEvent](structures/mouse-wheel-input-event.md) | [KeyboardInputEvent](structures/keyboard-input-event.md)
 
 Sends an input `event` to the page.
-**Note:** The [`BrowserWindow`](browser-window.md) containing the contents needs to be focused for
+
+> [!NOTE]
+> The [`BrowserWindow`](browser-window.md) containing the contents needs to be focused for
 `sendInputEvent()` to work.
 
 #### `contents.beginFrameSubscription([onlyDirty ,]callback)`
@@ -2218,7 +2223,9 @@ By default this value is `{ min: 0, max: 0 }` , which would apply no restriction
   * `max` Integer - The maximum UDP port number that WebRTC should use.
 
 Setting the WebRTC UDP Port Range allows you to restrict the udp port range used by WebRTC. By default the port range is unrestricted.
-**Note:** To reset to an unrestricted port range this value should be set to `{ min: 0, max: 0 }`.
+
+> [!NOTE]
+> To reset to an unrestricted port range this value should be set to `{ min: 0, max: 0 }`.
 
 #### `contents.getMediaSourceId(requestWebContents)`
 
@@ -2364,8 +2371,9 @@ A [`WebContents`](web-contents.md) instance that might own this `WebContents`.
 
 A `WebContents | null` property that represents the of DevTools `WebContents` associated with a given `WebContents`.
 
-**Note:** Users should never store this object because it may become `null`
-when the DevTools has been closed.
+> [!NOTE]
+> Users should never store this object because it may become `null`
+> when the DevTools has been closed.
 
 #### `contents.debugger` _Readonly_
 

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -41,7 +41,8 @@ Changes the zoom level to the specified level. The original size is 0 and each
 increment above or below represents zooming 20% larger or smaller to default
 limits of 300% and 50% of original size, respectively.
 
-> **NOTE**: The zoom policy at the Chromium level is same-origin, meaning that the
+> [!NOTE]
+> The zoom policy at the Chromium level is same-origin, meaning that the
 > zoom level for a specific domain propagates across all instances of windows with
 > the same domain. Differentiating the window URLs will make zoom work per-window.
 
@@ -56,13 +57,15 @@ Returns `number` - The current zoom level.
 
 Sets the maximum and minimum pinch-to-zoom level.
 
-> **NOTE**: Visual zoom is disabled by default in Electron. To re-enable it, call:
+> [!NOTE]
+> Visual zoom is disabled by default in Electron. To re-enable it, call:
 >
 > ```js
 > webFrame.setVisualZoomLevelLimits(1, 3)
 > ```
 
-> **NOTE**: Visual zoom only applies to pinch-to-zoom behavior. Cmd+/-/0 zoom shortcuts are
+> [!NOTE]
+> Visual zoom only applies to pinch-to-zoom behavior. Cmd+/-/0 zoom shortcuts are
 > controlled by the 'zoomIn', 'zoomOut', and 'resetZoom' MenuItem roles in the application
 > Menu. To disable shortcuts, manually [define the Menu](./menu.md#examples) and omit zoom roles
 > from the definition.
@@ -189,7 +192,9 @@ dispatch errors of isolated worlds to foreign worlds.
   * `name` string (optional) - Name for isolated world. Useful in devtools.
 
 Set the security origin, content security policy and name of the isolated world.
-Note: If the `csp` is specified, then the `securityOrigin` also has to be specified.
+
+> [!NOTE]
+> If the `csp` is specified, then the `securityOrigin` also has to be specified.
 
 ### `webFrame.getResourceUsage()`
 

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -30,8 +30,10 @@ rendered.
 Unlike an `iframe`, the `webview` runs in a separate process than your
 app. It doesn't have the same permissions as your web page and all interactions
 between your app and embedded content will be asynchronous. This keeps your app
-safe from the embedded content. **Note:** Most methods called on the
-webview from the host page require a synchronous call to the main process.
+safe from the embedded content.
+
+> [!NOTE]
+> Most methods called on the webview from the host page require a synchronous call to the main process.
 
 ## Example
 
@@ -252,7 +254,8 @@ The full list of supported feature strings can be found in the
 
 The `webview` tag has the following methods:
 
-**Note:** The webview element must be loaded before using the methods.
+> [!NOTE]
+> The webview element must be loaded before using the methods.
 
 **Example**
 
@@ -679,7 +682,8 @@ increment above or below represents zooming 20% larger or smaller to default
 limits of 300% and 50% of original size, respectively. The formula for this is
 `scale := 1.2 ^ level`.
 
-> **NOTE**: The zoom policy at the Chromium level is same-origin, meaning that the
+> [!NOTE]
+> The zoom policy at the Chromium level is same-origin, meaning that the
 > zoom level for a specific domain propagates across all instances of windows with
 > the same domain. Differentiating the window URLs will make zoom work per-window.
 

--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -155,7 +155,8 @@ $ gn gen out/Release --args="import(\"//electron/build/args/release.gn\")"
 $ gn gen out/Release --args="import(\`"//electron/build/args/release.gn\`")"
 ```
 
-**Note:** This will generate a `out/Testing` or `out/Release` build directory under `src/` with the testing or release build depending upon the configuration passed above. You can replace `Testing|Release` with another names, but it should be a subdirectory of `out`.
+> [!NOTE]
+> This will generate a `out/Testing` or `out/Release` build directory under `src/` with the testing or release build depending upon the configuration passed above. You can replace `Testing|Release` with another names, but it should be a subdirectory of `out`.
 
 Also you shouldn't have to run `gn gen` again—if you want to change the build arguments, you can run `gn args out/Testing` to bring up an editor. To see the list of available build configuration options, run `gn args out/Testing --list`.
 

--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -39,8 +39,9 @@ Building Electron is done entirely with command-line scripts and cannot be done
 with Visual Studio. You can develop Electron with any editor but support for
 building with Visual Studio will come in the future.
 
-**Note:** Even though Visual Studio is not used for building, it's still
-**required** because we need the build toolchains it provides.
+> [!NOTE]
+> Even though Visual Studio is not used for building, it's still
+> **required** because we need the build toolchains it provides.
 
 ## Exclude source tree from Windows Security
 

--- a/docs/development/creating-api.md
+++ b/docs/development/creating-api.md
@@ -148,7 +148,8 @@ In your [`shell/common/node_bindings.cc`](https://github.com/electron/electron/b
   V(electron_browser_{api_name})
 ```
 
-> Note: More technical details on how Node links with Electron can be found on [our blog](https://www.electronjs.org/blog/electron-internals-using-node-as-a-library#link-node-with-electron).
+> [!NOTE]
+> More technical details on how Node links with Electron can be found on [our blog](https://www.electronjs.org/blog/electron-internals-using-node-as-a-library#link-node-with-electron).
 
 ## Expose your API to TypeScript
 

--- a/docs/development/patches.md
+++ b/docs/development/patches.md
@@ -49,7 +49,8 @@ $ git commit
 $ ../../electron/script/git-export-patches -o ../../electron/patches/node
 ```
 
-> **NOTE**: `git-export-patches` ignores any uncommitted files, so you must create a commit if you want your changes to be exported. The subject line of the commit message will be used to derive the patch file name, and the body of the commit message should include the reason for the patch's existence.
+> [!NOTE]
+> `git-export-patches` ignores any uncommitted files, so you must create a commit if you want your changes to be exported. The subject line of the commit message will be used to derive the patch file name, and the body of the commit message should include the reason for the patch's existence.
 
 Re-exporting patches will sometimes cause shasums in unrelated patches to change. This is generally harmless and can be ignored (but go ahead and add those changes to your PR, it'll stop them from showing up for other people).
 

--- a/docs/tutorial/keyboard-shortcuts.md
+++ b/docs/tutorial/keyboard-shortcuts.md
@@ -133,9 +133,10 @@ function handleKeyPress (event) {
 window.addEventListener('keyup', handleKeyPress, true)
 ```
 
-> Note:  the third parameter `true` indicates that the listener will always receive
-key presses before other listeners so they can't have `stopPropagation()`
-called on them.
+> [!NOTE]
+> The third parameter `true` indicates that the listener will always receive
+> key presses before other listeners so they can't have `stopPropagation()`
+> called on them.
 
 #### Intercepting events in the main process
 

--- a/docs/tutorial/multithreading.md
+++ b/docs/tutorial/multithreading.md
@@ -20,7 +20,8 @@ const win = new BrowserWindow({
 The `nodeIntegrationInWorker` can be used independent of `nodeIntegration`, but
 `sandbox` must not be set to `true`.
 
-**Note:** This option is not available in [`SharedWorker`s](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker) or [`Service Worker`s](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker) owing to incompatibilities in sandboxing policies.
+> [!NOTE]
+> This option is not available in [`SharedWorker`s](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker) or [`Service Worker`s](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker) owing to incompatibilities in sandboxing policies.
 
 ## Available APIs
 

--- a/docs/tutorial/online-offline-events.md
+++ b/docs/tutorial/online-offline-events.md
@@ -83,4 +83,5 @@ After launching the Electron application, you should see the notification:
 
 ![Connection status](../images/connection-status.png)
 
-> Note: If you need to communicate the connection status to the main process, use the [IPC renderer](../api/ipc-renderer.md) API.
+> [!NOTE]
+> If you need to communicate the connection status to the main process, use the [IPC renderer](../api/ipc-renderer.md) API.

--- a/docs/tutorial/process-model.md
+++ b/docs/tutorial/process-model.md
@@ -64,7 +64,8 @@ const contents = win.webContents
 console.log(contents)
 ```
 
-> Note: A renderer process is also created for [web embeds][web-embed] such as the
+> [!NOTE]
+> A renderer process is also created for [web embeds][web-embed] such as the
 > `BrowserView` module. The `webContents` object is also accessible for embedded
 > web content.
 

--- a/docs/tutorial/repl.md
+++ b/docs/tutorial/repl.md
@@ -14,8 +14,9 @@ dependency, you should be able to access the REPL with the following command:
   ./node_modules/.bin/electron --interactive
   ```
 
-**Note:** `electron --interactive` is not available on Windows
-(see [electron/electron#5776](https://github.com/electron/electron/pull/5776) for more details).
+> [!NOTE]
+> `electron --interactive` is not available on Windows
+> (see [electron/electron#5776](https://github.com/electron/electron/pull/5776) for more details).
 
 ## Renderer process
 

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -19,12 +19,12 @@ and only allow the capabilities you want to support.
 
 ### WebViews
 
-> Important Note:
-[we do not recommend you to use WebViews](../api/webview-tag.md#warning),
-as this tag undergoes dramatic architectural changes that may affect stability
-of your application. Consider switching to alternatives, like `iframe` and
-Electron's [`WebContentsView`](../api/web-contents-view.md), or an architecture
-that avoids embedded content by design.
+> [!IMPORTANT]
+> [We do not recommend you to use WebViews](../api/webview-tag.md#warning),
+> as this tag undergoes dramatic architectural changes that may affect stability
+> of your application. Consider switching to alternatives, like `iframe` and
+> Electron's [`WebContentsView`](../api/web-contents-view.md), or an architecture
+> that avoids embedded content by design.
 
 [WebViews](../api/webview-tag.md) are based on Chromium's WebViews and are not
 explicitly supported by Electron. We do not guarantee that the WebView API will


### PR DESCRIPTION
#### Description of Change

> [!NOTE]
> This is GitHub's special callout syntax that's been available for a few years.

As of https://github.com/electron/website/pull/655, this feature is also supported on electronjs.org.

This PR just manually changes out top-level instances of **Note:** and **Warning:** callouts that we just had in plain Markdown to use the nicer syntax.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
(https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none