### PR TITLE
fix: allowed dialog file types with one filter

### DIFF
--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -131,10 +131,6 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
     [file_types_list addObject:content_types_set];
   }
 
-  // Don't add file format picker.
-  if ([file_types_list count] <= 1)
-    return;
-
   NSArray* content_types = [file_types_list objectAtIndex:0];
 
   __block BOOL allowAllFiles = NO;
@@ -147,6 +143,10 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
       }];
 
   [dialog setAllowedContentTypes:allowAllFiles ? @[] : content_types];
+
+  // Don't add file format picker.
+  if ([file_types_list count] <= 1)
+    return;
 
   // Add file format picker.
   ElectronAccessoryView* accessoryView = [[ElectronAccessoryView alloc]


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/46883.
Refs https://github.com/electron/electron/issues/46623

Fixes an issue where filters wouldn't apply in the specific case only one was passed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where filters wouldn't apply in the specific case only one was passed.