### PR TITLE
refactor: devirtualize `NativeWindow` methods

### DIFF
--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -103,10 +103,13 @@ class NativeWindow : public base::SupportsUserData,
   virtual bool IsFullscreen() const = 0;
   virtual void SetBounds(const gfx::Rect& bounds, bool animate = false) = 0;
   virtual gfx::Rect GetBounds() const = 0;
-  virtual void SetSize(const gfx::Size& size, bool animate = false);
-  virtual gfx::Size GetSize() const;
-  virtual void SetPosition(const gfx::Point& position, bool animate = false);
-  virtual gfx::Point GetPosition() const;
+
+  void SetSize(const gfx::Size& size, bool animate = false);
+  [[nodiscard]] gfx::Size GetSize() const;
+
+  void SetPosition(const gfx::Point& position, bool animate = false);
+  [[nodiscard]] gfx::Point GetPosition() const;
+
   virtual void SetContentSize(const gfx::Size& size, bool animate = false);
   virtual gfx::Size GetContentSize() const;
   virtual void SetContentBounds(const gfx::Rect& bounds, bool animate = false);

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -131,9 +131,11 @@ class NativeWindow : public base::SupportsUserData,
 
   virtual gfx::Size GetContentMinimumSize() const;
   virtual gfx::Size GetContentMaximumSize() const;
-  virtual void SetSheetOffset(const double offsetX, const double offsetY);
-  virtual double GetSheetOffsetX() const;
-  virtual double GetSheetOffsetY() const;
+
+  void SetSheetOffset(const double offsetX, const double offsetY);
+  [[nodiscard]] double GetSheetOffsetX() const;
+  [[nodiscard]] double GetSheetOffsetY() const;
+
   virtual void SetResizable(bool resizable) = 0;
   virtual bool MoveAbove(const std::string& sourceId) = 0;
   virtual void MoveTop() = 0;

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -129,8 +129,8 @@ class NativeWindow : public base::SupportsUserData,
   void SetMaximumSize(const gfx::Size& size);
   [[nodiscard]] gfx::Size GetMaximumSize() const;
 
-  virtual gfx::Size GetContentMinimumSize() const;
-  virtual gfx::Size GetContentMaximumSize() const;
+  [[nodiscard]] gfx::Size GetContentMinimumSize() const;
+  [[nodiscard]] gfx::Size GetContentMaximumSize() const;
 
   void SetSheetOffset(const double offsetX, const double offsetY);
   [[nodiscard]] double GetSheetOffsetX() const;

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -122,10 +122,13 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints);
   virtual extensions::SizeConstraints GetContentSizeConstraints() const;
-  virtual void SetMinimumSize(const gfx::Size& size);
-  virtual gfx::Size GetMinimumSize() const;
-  virtual void SetMaximumSize(const gfx::Size& size);
-  virtual gfx::Size GetMaximumSize() const;
+
+  void SetMinimumSize(const gfx::Size& size);
+  [[nodiscard]] gfx::Size GetMinimumSize() const;
+
+  void SetMaximumSize(const gfx::Size& size);
+  [[nodiscard]] gfx::Size GetMaximumSize() const;
+
   virtual gfx::Size GetContentMinimumSize() const;
   virtual gfx::Size GetContentMaximumSize() const;
   virtual void SetSheetOffset(const double offsetX, const double offsetY);


### PR DESCRIPTION
#### Description of Change

`NativeWindow`  has a handful of virtual methods that are never overridden. Let's devirtualize them to avoid the vtable overhead.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.