### PR TITLE
refactor: move `NativeWindow::child_windows_` to `NativeWindowMac`

### DIFF
--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -413,10 +413,6 @@ class NativeWindow : public base::SupportsUserData,
 
   int32_t window_id() const { return window_id_; }
 
-  void add_child_window(NativeWindow* child) {
-    child_windows_.push_back(child);
-  }
-
   int NonClientHitTest(const gfx::Point& point);
   void AddDraggableRegionProvider(DraggableRegionProvider* provider);
   void RemoveDraggableRegionProvider(DraggableRegionProvider* provider);
@@ -475,8 +471,6 @@ class NativeWindow : public base::SupportsUserData,
       FullScreenTransitionState::kNone;
   FullScreenTransitionType fullscreen_transition_type_ =
       FullScreenTransitionType::kNone;
-
-  std::list<NativeWindow*> child_windows_;
 
  private:
   std::unique_ptr<views::Widget> widget_;

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -153,8 +153,6 @@ class NativeWindow : public base::SupportsUserData,
   virtual std::string GetAlwaysOnTopLevel() const = 0;
   virtual void SetActive(bool is_key) = 0;
   virtual bool IsActive() const = 0;
-  virtual void RemoveChildFromParentWindow() = 0;
-  virtual void RemoveChildWindow(NativeWindow* child) = 0;
   virtual void AttachChildren() = 0;
   virtual void DetachChildren() = 0;
 #endif

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -158,8 +158,8 @@ class NativeWindowMac : public NativeWindow,
   void SetActive(bool is_key) override;
   bool IsActive() const override;
   // Remove the specified child window without closing it.
-  void RemoveChildWindow(NativeWindow* child) override;
-  void RemoveChildFromParentWindow() override;
+  void RemoveChildWindow(NativeWindowMac* child);
+  void RemoveChildFromParentWindow();
   // Attach child windows, if the window is visible.
   void AttachChildren() override;
   // Detach window from parent without destroying it.

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -254,6 +254,8 @@ class NativeWindowMac : public NativeWindow,
   // The views::View that fills the client area.
   std::unique_ptr<RootViewMac> root_view_;
 
+  std::vector<NativeWindowMac*> child_windows_;
+
   bool fullscreen_before_kiosk_ = false;
   bool is_kiosk_ = false;
   bool zoom_to_page_width_ = false;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -234,6 +234,8 @@ class NativeWindowMac : public NativeWindow,
                                uint32_t changed_metrics) override;
 
  private:
+  void RemoveFromTree();
+
   // Add custom layers to the content view.
   void AddContentViewLayers();
 

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -572,7 +572,7 @@ void NativeWindowMac::RemoveFromTree() {
   RemoveChildFromParentWindow();
 
   auto tmp = child_windows_;
-  for (NativeWindow* child : base::Reversed(tmp))
+  for (NativeWindowMac* child : base::Reversed(tmp))
     child->RemoveChildFromParentWindow();
 }
 
@@ -583,7 +583,7 @@ void NativeWindowMac::RemoveChildFromParentWindow() {
   }
 }
 
-void NativeWindowMac::RemoveChildWindow(NativeWindow* child) {
+void NativeWindowMac::RemoveChildWindow(NativeWindowMac* child) {
   std::erase(child_windows_, child);
 
   [window_ removeChildWindow:child->GetNativeWindow().GetNativeNSWindow()];

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -584,14 +584,14 @@ void NativeWindowMac::RemoveChildFromParentWindow() {
 }
 
 void NativeWindowMac::RemoveChildWindow(NativeWindow* child) {
-  child_windows_.remove_if([&child](NativeWindow* w) { return (w == child); });
+  std::erase(child_windows_, child);
 
   [window_ removeChildWindow:child->GetNativeWindow().GetNativeNSWindow()];
 }
 
 void NativeWindowMac::AttachChildren() {
-  for (auto* child : child_windows_) {
-    if (!static_cast<NativeWindowMac*>(child)->wants_to_be_visible())
+  for (NativeWindowMac* const child : child_windows_) {
+    if (!child->wants_to_be_visible())
       continue;
 
     auto* child_nswindow = child->GetNativeWindow().GetNativeNSWindow();
@@ -1808,7 +1808,7 @@ void NativeWindowMac::InternalSetParentWindow(NativeWindow* new_parent,
 
   // Set new parent window.
   if (new_parent) {
-    new_parent->add_child_window(this);
+    new_parent->child_windows_.emplace_back(this);
     if (attach)
       new_parent->AttachChildren();
   }


### PR DESCRIPTION
#### Description of Change

`NativeWindow::child_windows_` is only used by `NativeWindowMac`, so move the container there.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.