### PR TITLE
refactor: add `NativeWindow::FromWidget()` helper

### DIFF
--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -99,12 +99,11 @@ void WebContentsView::WebContentsDestroyed() {
 
 void WebContentsView::OnViewAddedToWidget(views::View* observed_view) {
   DCHECK_EQ(observed_view, view());
-  views::Widget* widget = view()->GetWidget();
-  auto* native_window =
-      static_cast<NativeWindow*>(widget->GetNativeWindowProperty(
-          electron::kElectronNativeWindowKey.c_str()));
+
+  NativeWindow* native_window = NativeWindow::FromWidget(view()->GetWidget());
   if (!native_window)
     return;
+
   // We don't need to call SetOwnerWindow(nullptr) in OnViewRemovedFromWidget
   // because that's handled in the WebContents dtor called prior.
   api_web_contents_->SetOwnerWindow(native_window);
@@ -114,11 +113,11 @@ void WebContentsView::OnViewAddedToWidget(views::View* observed_view) {
 
 void WebContentsView::OnViewRemovedFromWidget(views::View* observed_view) {
   DCHECK_EQ(observed_view, view());
-  views::Widget* widget = view()->GetWidget();
-  auto* native_window = static_cast<NativeWindow*>(
-      widget->GetNativeWindowProperty(kElectronNativeWindowKey.c_str()));
+
+  NativeWindow* native_window = NativeWindow::FromWidget(view()->GetWidget());
   if (!native_window)
     return;
+
   native_window->RemoveDraggableRegionProvider(this);
 }
 

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -284,6 +284,13 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
     Show();
 }
 
+// static
+NativeWindow* NativeWindow::FromWidget(const views::Widget* widget) {
+  DCHECK(widget);
+  return static_cast<NativeWindow*>(
+      widget->GetNativeWindowProperty(kNativeWindowKey.c_str()));
+}
+
 void NativeWindow::SetSize(const gfx::Size& size, bool animate) {
   SetBounds(gfx::Rect(GetPosition(), size), animate);
 }

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -47,9 +47,6 @@ class PersistentDictionary;
 
 namespace electron {
 
-inline constexpr base::cstring_view kElectronNativeWindowKey =
-    "__ELECTRON_NATIVE_WINDOW__";
-
 class ElectronMenuModel;
 class BackgroundThrottlingSource;
 
@@ -77,6 +74,8 @@ class NativeWindow : public base::SupportsUserData,
   static std::unique_ptr<NativeWindow> Create(
       const gin_helper::Dictionary& options,
       NativeWindow* parent = nullptr);
+
+  [[nodiscard]] static NativeWindow* FromWidget(const views::Widget* widget);
 
   void InitFromOptions(const gin_helper::Dictionary& options);
 
@@ -452,6 +451,9 @@ class NativeWindow : public base::SupportsUserData,
 
   virtual void CloseImpl() = 0;
   virtual void CloseImmediatelyImpl() = 0;
+
+  static inline constexpr base::cstring_view kNativeWindowKey =
+      "__ELECTRON_NATIVE_WINDOW__";
 
   // The boolean parsing of the "titleBarOverlay" option
   bool titlebar_overlay_ = false;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -203,7 +203,7 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   params.native_widget =
       new ElectronNativeWidgetMac(this, windowType, styleMask, widget());
   widget()->Init(std::move(params));
-  widget()->SetNativeWindowProperty(kElectronNativeWindowKey.c_str(), this);
+  widget()->SetNativeWindowProperty(kNativeWindowKey.c_str(), this);
   SetCanResize(resizable);
   window_ = static_cast<ElectronNSWindow*>(
       widget()->GetNativeWindow().GetNativeNSWindow());

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -307,7 +307,7 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
 #endif
 
   widget()->Init(std::move(params));
-  widget()->SetNativeWindowProperty(kElectronNativeWindowKey.c_str(), this);
+  widget()->SetNativeWindowProperty(kNativeWindowKey.c_str(), this);
   SetCanResize(resizable_);
 
   bool fullscreen = false;


### PR DESCRIPTION
#### Description of Change

Add a helper method `static NativeWindow* NativeWindow::FromWidget(const views::Widget*)` to simplify client code: instead of knowing about the native window property values and `kElectronNativeWindowKey`, it just calls a getter instead.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.