### PR TITLE
refactor: simplify `NativeWindow::FullScreenTransitionState`

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3961,8 +3961,7 @@ bool WebContents::IsFullscreenForTabOrPending(
   if (!owner_window())
     return is_html_fullscreen();
 
-  bool in_transition = owner_window()->fullscreen_transition_state() !=
-                       NativeWindow::FullScreenTransitionState::kNone;
+  const bool in_transition = owner_window()->is_transitioning_fullscreen();
   bool is_html_transition = owner_window()->fullscreen_transition_type() ==
                             NativeWindow::FullScreenTransitionType::kHTML;
 

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -356,14 +356,12 @@ class NativeWindow : public base::SupportsUserData,
   // Handle fullscreen transitions.
   void HandlePendingFullscreenTransitions();
 
-  enum class FullScreenTransitionState { kEntering, kExiting, kNone };
-
-  void set_fullscreen_transition_state(FullScreenTransitionState state) {
-    fullscreen_transition_state_ = state;
+  constexpr void set_is_transitioning_fullscreen(const bool val) {
+    is_transitioning_fullscreen_ = val;
   }
 
   [[nodiscard]] constexpr bool is_transitioning_fullscreen() const {
-    return fullscreen_transition_state_ != FullScreenTransitionState::kNone;
+    return is_transitioning_fullscreen_;
   }
 
   enum class FullScreenTransitionType { kHTML, kNative, kNone };
@@ -519,8 +517,7 @@ class NativeWindow : public base::SupportsUserData,
   // Is this a modal window.
   bool is_modal_ = false;
 
-  FullScreenTransitionState fullscreen_transition_state_ =
-      FullScreenTransitionState::kNone;
+  bool is_transitioning_fullscreen_ = false;
 
   std::list<DraggableRegionProvider*> draggable_region_providers_;
 

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -361,9 +361,6 @@ class NativeWindow : public base::SupportsUserData,
   void set_fullscreen_transition_state(FullScreenTransitionState state) {
     fullscreen_transition_state_ = state;
   }
-  FullScreenTransitionState fullscreen_transition_state() const {
-    return fullscreen_transition_state_;
-  }
 
   [[nodiscard]] constexpr bool is_transitioning_fullscreen() const {
     return fullscreen_transition_state_ != FullScreenTransitionState::kNone;

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -471,8 +471,6 @@ class NativeWindow : public base::SupportsUserData,
   std::optional<extensions::SizeConstraints> content_size_constraints_;
 
   std::queue<bool> pending_transitions_;
-  FullScreenTransitionState fullscreen_transition_state_ =
-      FullScreenTransitionState::kNone;
   FullScreenTransitionType fullscreen_transition_type_ =
       FullScreenTransitionType::kNone;
 
@@ -519,6 +517,9 @@ class NativeWindow : public base::SupportsUserData,
 
   // Is this a modal window.
   bool is_modal_ = false;
+
+  FullScreenTransitionState fullscreen_transition_state_ =
+      FullScreenTransitionState::kNone;
 
   std::list<DraggableRegionProvider*> draggable_region_providers_;
 

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -365,6 +365,10 @@ class NativeWindow : public base::SupportsUserData,
     return fullscreen_transition_state_;
   }
 
+  [[nodiscard]] constexpr bool is_transitioning_fullscreen() const {
+    return fullscreen_transition_state_ != FullScreenTransitionState::kNone;
+  }
+
   enum class FullScreenTransitionType { kHTML, kNative, kNone };
 
   void set_fullscreen_transition_type(FullScreenTransitionType type) {

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -331,7 +331,7 @@ void NativeWindowMac::SetContentView(views::View* view) {
 }
 
 void NativeWindowMac::CloseImpl() {
-  if (fullscreen_transition_state() != FullScreenTransitionState::kNone) {
+  if (is_transitioning_fullscreen()) {
     SetHasDeferredWindowClose(true);
     return;
   }
@@ -623,7 +623,7 @@ void NativeWindowMac::SetFullScreen(bool fullscreen) {
   // that it's possible to call it while a fullscreen transition is currently
   // in process. This can create weird behavior (incl. phantom windows),
   // so we want to schedule a transition for when the current one has completed.
-  if (fullscreen_transition_state() != FullScreenTransitionState::kNone) {
+  if (is_transitioning_fullscreen()) {
     if (!pending_transitions_.empty()) {
       bool last_pending = pending_transitions_.back();
       // Only push new transitions if they're different than the last transition
@@ -780,8 +780,7 @@ void NativeWindowMac::SetResizable(bool resizable) {
 }
 
 bool NativeWindowMac::IsResizable() const {
-  bool in_fs_transition =
-      fullscreen_transition_state() != FullScreenTransitionState::kNone;
+  const bool in_fs_transition = is_transitioning_fullscreen();
   bool has_rs_mask = HasStyleMask(NSWindowStyleMaskResizable);
   return has_rs_mask && !IsFullscreen() && !in_fs_transition;
 }

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -647,12 +647,10 @@ void NativeWindowMac::SetFullScreen(bool fullscreen) {
   // SetFullScreen is called by a user before windowWillEnterFullScreen
   // or windowWillExitFullScreen are invoked, and so a potential transition
   // could be dropped.
-  set_fullscreen_transition_state(fullscreen
-                                      ? FullScreenTransitionState::kEntering
-                                      : FullScreenTransitionState::kExiting);
+  set_is_transitioning_fullscreen(true);
 
   if (![window_ toggleFullScreenMode:nil])
-    set_fullscreen_transition_state(FullScreenTransitionState::kNone);
+    set_is_transitioning_fullscreen(false);
 }
 
 bool NativeWindowMac::IsFullscreen() const {

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -647,12 +647,12 @@ void NativeWindowMac::SetFullScreen(bool fullscreen) {
   // SetFullScreen is called by a user before windowWillEnterFullScreen
   // or windowWillExitFullScreen are invoked, and so a potential transition
   // could be dropped.
-  fullscreen_transition_state_ = fullscreen
-                                     ? FullScreenTransitionState::kEntering
-                                     : FullScreenTransitionState::kExiting;
+  set_fullscreen_transition_state(fullscreen
+                                      ? FullScreenTransitionState::kEntering
+                                      : FullScreenTransitionState::kExiting);
 
   if (![window_ toggleFullScreenMode:nil])
-    fullscreen_transition_state_ = FullScreenTransitionState::kNone;
+    set_fullscreen_transition_state(FullScreenTransitionState::kNone);
 }
 
 bool NativeWindowMac::IsFullscreen() const {

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -18,8 +18,6 @@
 #include "ui/views/widget/native_widget_mac.h"
 
 using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
-using FullScreenTransitionState =
-    electron::NativeWindow::FullScreenTransitionState;
 
 @implementation ElectronNSWindowDelegate
 
@@ -302,7 +300,7 @@ using FullScreenTransitionState =
   // Store resizable mask so it can be restored after exiting fullscreen.
   is_resizable_ = shell_->HasStyleMask(NSWindowStyleMaskResizable);
 
-  shell_->set_fullscreen_transition_state(FullScreenTransitionState::kEntering);
+  shell_->set_is_transitioning_fullscreen(true);
 
   shell_->NotifyWindowWillEnterFullScreen();
 
@@ -311,7 +309,7 @@ using FullScreenTransitionState =
 }
 
 - (void)windowDidEnterFullScreen:(NSNotification*)notification {
-  shell_->set_fullscreen_transition_state(FullScreenTransitionState::kNone);
+  shell_->set_is_transitioning_fullscreen(false);
 
   shell_->NotifyWindowEnterFullScreen();
 
@@ -322,7 +320,7 @@ using FullScreenTransitionState =
 }
 
 - (void)windowDidFailToEnterFullScreen:(NSWindow*)window {
-  shell_->set_fullscreen_transition_state(FullScreenTransitionState::kNone);
+  shell_->set_is_transitioning_fullscreen(false);
 
   shell_->SetResizable(is_resizable_);
   shell_->NotifyWindowDidFailToEnterFullScreen();
@@ -334,13 +332,13 @@ using FullScreenTransitionState =
 }
 
 - (void)windowWillExitFullScreen:(NSNotification*)notification {
-  shell_->set_fullscreen_transition_state(FullScreenTransitionState::kExiting);
+  shell_->set_is_transitioning_fullscreen(true);
 
   shell_->NotifyWindowWillLeaveFullScreen();
 }
 
 - (void)windowDidExitFullScreen:(NSNotification*)notification {
-  shell_->set_fullscreen_transition_state(FullScreenTransitionState::kNone);
+  shell_->set_is_transitioning_fullscreen(false);
 
   shell_->SetResizable(is_resizable_);
   shell_->NotifyWindowLeaveFullScreen();


### PR DESCRIPTION
#### Description of Change

We only care whether the window is transitioning, not whether the transition is entering or exiting. So let's simplify NativeWindow by replacing the tri-state transition state with an `is_fullscreen_transitioning` bool.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.