### PR TITLE
refactor: remove some `NativeWindow` public API

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -830,10 +830,8 @@ bool NativeWindow::IsTranslucent() const {
 
 #if BUILDFLAG(IS_WIN)
   // Windows with certain background materials may be translucent
-  const std::string& bg_material = background_material();
-  if (!bg_material.empty() && bg_material != "none") {
+  if (!background_material_.empty() && background_material_ != "none")
     return true;
-  }
 #endif
 
   return false;

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -823,9 +823,8 @@ bool NativeWindow::IsTranslucent() const {
 
 #if BUILDFLAG(IS_MAC)
   // Windows with vibrancy set are translucent
-  if (!vibrancy().empty()) {
+  if (!vibrancy_.empty())
     return true;
-  }
 #endif
 
 #if BUILDFLAG(IS_WIN)

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -224,7 +224,6 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetAutoHideCursor(bool auto_hide) {}
 
   // Vibrancy API
-  const std::string& vibrancy() const { return vibrancy_; }
   virtual void SetVibrancy(const std::string& type, int duration);
 
   virtual void SetBackgroundMaterial(const std::string& type);

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -456,10 +456,6 @@ class NativeWindow : public base::SupportsUserData,
   // The boolean parsing of the "titleBarOverlay" option
   bool titlebar_overlay_ = false;
 
-  // The custom height parsed from the "height" option in a Object
-  // "titleBarOverlay"
-  int titlebar_overlay_height_ = 0;
-
   // The "titleBarStyle" option.
   TitleBarStyle title_bar_style_ = TitleBarStyle::kNormal;
 
@@ -486,6 +482,10 @@ class NativeWindow : public base::SupportsUserData,
 
   // The content view, weak ref.
   raw_ptr<views::View> content_view_ = nullptr;
+
+  // The custom height parsed from the "height" option in a Object
+  // "titleBarOverlay"
+  int titlebar_overlay_height_ = 0;
 
   // Whether window has standard frame.
   bool has_frame_ = true;

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -430,8 +430,6 @@ class NativeWindow : public base::SupportsUserData,
   void UpdateBackgroundThrottlingState();
 
  protected:
-  friend class api::BrowserView;
-
   constexpr void set_has_frame(const bool val) { has_frame_ = val; }
 
   [[nodiscard]] constexpr bool is_closed() const { return is_closed_; }

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -402,7 +402,6 @@ class NativeWindow : public base::SupportsUserData,
   }
 
   bool has_frame() const { return has_frame_; }
-  void set_has_frame(bool has_frame) { has_frame_ = has_frame; }
 
   bool has_client_frame() const { return has_client_frame_; }
   bool transparent() const { return transparent_; }
@@ -436,6 +435,8 @@ class NativeWindow : public base::SupportsUserData,
 
  protected:
   friend class api::BrowserView;
+
+  constexpr void set_has_frame(const bool val) { has_frame_ = val; }
 
   [[nodiscard]] constexpr bool is_closed() const { return is_closed_; }
 

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -281,12 +281,6 @@ class NativeWindow : public base::SupportsUserData,
 
   virtual void SetGTKDarkThemeEnabled(bool use_dark_theme) {}
 
-  // Converts between content bounds and window bounds.
-  virtual gfx::Rect ContentBoundsToWindowBounds(
-      const gfx::Rect& bounds) const = 0;
-  virtual gfx::Rect WindowBoundsToContentBounds(
-      const gfx::Rect& bounds) const = 0;
-
   base::WeakPtr<NativeWindow> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();
   }
@@ -437,6 +431,12 @@ class NativeWindow : public base::SupportsUserData,
   NativeWindow(const gin_helper::Dictionary& options, NativeWindow* parent);
 
   virtual void OnTitleChanged() {}
+
+  // Converts between content bounds and window bounds.
+  virtual gfx::Rect ContentBoundsToWindowBounds(
+      const gfx::Rect& bounds) const = 0;
+  virtual gfx::Rect WindowBoundsToContentBounds(
+      const gfx::Rect& bounds) const = 0;
 
   // views::WidgetDelegate:
   views::Widget* GetWidget() override;

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -227,9 +227,6 @@ class NativeWindow : public base::SupportsUserData,
   const std::string& vibrancy() const { return vibrancy_; }
   virtual void SetVibrancy(const std::string& type, int duration);
 
-  const std::string& background_material() const {
-    return background_material_;
-  }
   virtual void SetBackgroundMaterial(const std::string& type);
 
   // Traffic Light API


### PR DESCRIPTION
#### Description of Change

Small refactor to make some incidentally-public API either protected or private

- Remove `NativeWindow::background_material()`: it was only used in one place and that's in a const `NativeWindow` method, so remove the getter and just reference the field directly instead.
- Remove `NativeWindow::vibrancy()`: same as above.
- Make `NativeWindow::set_has_frame()` protected because it's only needed by subclasses.
- Make `NativeWindow::titlebar_overlay_height_` private. Clients should use the getter & setter.
- Have `NativeWindow` unfriend `api::BrowserView`; this hasn't been needed since 2022
 
#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.