### PR TITLE
fix: crash on macOS dialog after `window-all-closed`

### DIFF
--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -218,7 +218,7 @@ void SwizzleSwipeWithEvent(NSView* view, SEL swiz_selector) {
 }
 
 - (NSRect)contentRectForFrameRect:(NSRect)frameRect {
-  if (shell_->has_frame())
+  if (shell_ && shell_->has_frame())
     return [super contentRectForFrameRect:frameRect];
   else
     return frameRect;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/46916.
Refs https://github.com/electron/electron/pull/45238

Fixes a crash that occurred with the following stacktrace:

<details><summary>Stack Trace</summary>
<p>

```
Received signal 11 SEGV_ACCERR 0000000002c8
0   Electron Framework                  0x000000012211083c base::debug::CollectStackTrace(base::span<void const*, 18446744073709551615ul, void const**>) + 28
1   Electron Framework                  0x0000000122100cbc base::debug::StackTrace::StackTrace(unsigned long) + 224
2   Electron Framework                  0x0000000122110790 base::debug::(anonymous namespace)::StackDumpSignalHandler(int, __siginfo*, void*) + 940
3   libsystem_platform.dylib            0x000000018ca10624 _sigtramp + 56
4   Electron Framework                  0x00000001237497dc ui::EventLocationFromNative(base::apple::OwnedNSEvent const&) + 124
5   Electron Framework                  0x00000001237497dc ui::EventLocationFromNative(base::apple::OwnedNSEvent const&) + 124
6   Electron Framework                  0x0000000123742bcc ui::MouseEvent::MouseEvent(base::apple::OwnedNSEvent const&) + 152
7   Electron Framework                  0x0000000123748664 ui::EventFromNative(base::apple::OwnedNSEvent const&) + 64
8   Electron Framework                  0x0000000120cb0fc4 -[WebContentsViewCocoa mouseEvent:] + 180
9   Electron Framework                  0x00000001237165a8 -[BaseView mouseExited:] + 104
10  CoreFoundation                      0x000000018caa2474 __invoking___ + 148
11  CoreFoundation                      0x000000018caa2304 -[NSInvocation invoke] + 424
12  CoreFoundation                      0x000000018cad6618 -[NSInvocation invokeWithTarget:] + 64
13  Electron Framework                  0x000000012371cda8 -[CrTrackingAreaOwnerProxy forwardInvocation:] + 72
14  CoreFoundation                      0x000000018caa0b5c ___forwarding___ + 956
15  CoreFoundation                      0x000000018caa06e0 _CF_forwarding_prep_0 + 96
16  AppKit                              0x0000000190b7d56c -[NSTrackingArea _dispatchMouseExited:] + 56
17  AppKit                              0x000000019127c9e0 -[_NSTrackingAreaAKManager _routeEnterExitEvent:] + 352
18  AppKit                              0x000000019127cd0c -[_NSTrackingAreaAKManager routeEnterExitEvent:] + 28
19  AppKit                              0x0000000190b0db70 -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:] + 152
20  AppKit                              0x0000000190b0d910 -[NSWindow(NSEventRouting) sendEvent:] + 288
21  Electron Framework                  0x0000000123f05674 -[NativeWidgetMacNSWindow sendEvent:] + 604
22  Electron Framework                  0x000000011c515030 -[ElectronNSWindow sendEvent:] + 188
23  AppKit                              0x00000001912749f0 +[_NSTrackingAreaAKManager routeEnterExitEvent:] + 80
24  AppKit                              0x0000000191234edc +[_NSTrackingAreaManager routeEnterExitEvent:] + 244
25  AppKit                              0x0000000191384ec0 -[NSApplication(NSEventRouting) sendEvent:] + 368
26  Electron Framework                  0x000000011c4fba08 -[AtomApplication sendEvent:] + 128
27  AppKit                              0x0000000190c13c64 -[NSApplication _doModalLoop:peek:] + 280
28  AppKit                              0x0000000190c127c4 __35-[NSApplication runModalForWindow:]_block_invoke_2 + 56
29  AppKit                              0x0000000190c12770 __35-[NSApplication runModalForWindow:]_block_invoke + 108
30  AppKit                              0x0000000190c1203c _NSTryRunModal + 100
31  AppKit                              0x0000000190c11ef4 -[NSApplication runModalForWindow:] + 292
32  AppKit                              0x0000000190f70278 __19-[NSAlert runModal]_block_invoke_2 + 120
33  AppKit                              0x0000000190f701e4 __19-[NSAlert runModal]_block_invoke + 108
34  AppKit                              0x0000000190c1203c _NSTryRunModal + 100
35  AppKit                              0x0000000190c809e0 -[NSAlert runModal] + 140
36  Electron Framework                  0x000000011c52a940 electron::ShowMessageBox(electron::MessageBoxSettings const&, base::OnceCallback<void (int, bool)>) + 280
37  Electron Framework                  0x000000011c2f1f14 (anonymous namespace)::ShowMessageBox(electron::MessageBoxSettings const&, gin::Arguments*) + 104
38  Electron Framework                  0x000000011c2b8ae4 base::RepeatingCallback<bool (std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, gin::Arguments*)>::Run(std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, gin::Arguments*) const & + 148
39  Electron Framework                  0x000000011c2f32bc void gin_helper::Invoker<std::__Cr::integer_sequence<unsigned long, 0ul, 1ul>, electron::MessageBoxSettings const&, gin::Arguments*>::DispatchToCallback<v8::Local<v8::Promise>>(base::RepeatingCallback<v8::Local<v8::Promise> (electron::MessageBoxSettings const&, gin::Arguments*)>) + 368
40  Electron Framework                  0x000000011c2f30a0 gin_helper::Dispatcher<v8::Local<v8::Promise> (electron::MessageBoxSettings const&, gin::Arguments*)>::DispatchToCallbackImpl(gin::Arguments*) + 172
41  Electron Framework                  0x000000011c2f2f7c gin_helper::Dispatcher<v8::Local<v8::Promise> (electron::MessageBoxSettings const&, gin::Arguments*)>::DispatchToCallback(v8::FunctionCallbackInfo<v8::Value> const&) + 44
42  ???                                 0x0000000157be2598 0x0 + 5767046552
43  ???                                 0x0000000157bdfad8 0x0 + 5767035608
44  ???                                 0x0000000157bdfad8 0x0 + 5767035608
45  ???                                 0x0000000157bdfad8 0x0 + 5767035608
46  ???                                 0x000000015002e400 0x0 + 5637334016
47  ???                                 0x0000000157bda980 0x0 + 5767014784
48  ???                                 0x0000000157bda5b4 0x0 + 5767013812
49  Electron Framework                  0x000000011e12c264 v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) + 5512
50  Electron Framework                  0x000000011e12aba4 v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::DirectHandle<v8::internal::Object>, v8::internal::DirectHandle<v8::internal::Object>, v8::base::Vector<v8::internal::DirectHandle<v8::internal::Object> const>) + 276
51  Electron Framework                  0x000000011de005a8 v8::Function::Call(v8::Isolate*, v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*) + 1156
52  Electron Framework                  0x000000011c55daa0 node::InternalMakeCallback(node::Environment*, v8::Local<v8::Object>, v8::Local<v8::Object>, v8::Local<v8::Function>, int, v8::Local<v8::Value>*, node::async_context, v8::Local<v8::Value>) + 520
53  Electron Framework                  0x000000011c55de70 node::InternalMakeCallback(v8::Isolate*, v8::Local<v8::Object>, v8::Local<v8::Function>, int, v8::Local<v8::Value>*, node::async_context, v8::Local<v8::Value>) + 304
54  Electron Framework                  0x000000011c4aa86c gin_helper::internal::CallMethodWithArgs(v8::Isolate*, v8::Local<v8::Object>, char const*, base::span<v8::Local<v8::Value>, 18446744073709551615ul, v8::Local<v8::Value>*>) + 196
55  Electron Framework                  0x000000011c2a4ca8 bool gin_helper::EventEmitterMixin<electron::api::App>::Emit<>(std::__Cr::basic_string_view<char, std::__Cr::char_traits<char>>) + 188
56  Electron Framework                  0x000000011c3795f4 void base::ObserverList<electron::ExtendedWebContentsObserver, false, true, base::internal::CheckedObserverAdapter>::Notify<void (electron::ExtendedWebContentsObserver::*)()>(T) + 488
57  Electron Framework                  0x000000011c3795f4 void base::ObserverList<electron::ExtendedWebContentsObserver, false, true, base::internal::CheckedObserverAdapter>::Notify<void (electron::ExtendedWebContentsObserver::*)()>(T) + 488
58  Electron Framework                  0x000000011c51aeb4 -[ElectronNSWindowDelegate windowWillClose:] + 356
59  CoreFoundation                      0x000000018cab65cc __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 148
60  CoreFoundation                      0x000000018cb45c88 ___CFXRegistrationPost_block_invoke + 92
61  CoreFoundation                      0x000000018cb45bcc _CFXRegistrationPost + 436
62  CoreFoundation                      0x000000018ca85a18 _CFXNotificationPost + 740
63  Foundation                          0x000000018e03e680 -[NSNotificationCenter postNotificationName:object:userInfo:] + 88
64  AppKit                              0x0000000191522754 -[NSWindow _finishClosingWindow] + 304
65  AppKit                              0x0000000190c68d10 -[NSWindow _close] + 380
66  Electron Framework                  0x0000000123f060ec -[NativeWidgetMacNSWindow close] + 60
67  Electron Framework                  0x000000011c2c681c electron::api::BaseWindow::~BaseWindow() + 72
68  Electron Framework                  0x000000011c2dc40c non-virtual thunk to electron::api::BrowserWindow::~BrowserWindow() + 16
69  Electron Framework                  0x000000011c4a9ba8 gin_helper::(anonymous namespace)::DestroyFunc(v8::FunctionCallbackInfo<v8::Value> const&) + 228
70  ???                                 0x0000000157be2598 0x0 + 5767046552
71  ???                                 0x0000000157bdfad8 0x0 + 5767035608
72  ???                                 0x0000000157bdfad8 0x0 + 5767035608
73  ???                                 0x0000000157bdfad8 0x0 + 5767035608
74  ???                                 0x0000000157bda980 0x0 + 5767014784
75  ???                                 0x0000000157bda5b4 0x0 + 5767013812
76  Electron Framework                  0x000000011e12c264 v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) + 5512
77  Electron Framework                  0x000000011e12aba4 v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::DirectHandle<v8::internal::Object>, v8::internal::DirectHandle<v8::internal::Object>, v8::base::Vector<v8::internal::DirectHandle<v8::internal::Object> const>) + 276
78  Electron Framework                  0x000000011de005a8 v8::Function::Call(v8::Isolate*, v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*) + 1156
79  Electron Framework                  0x000000011c5bc9a4 node::Environment::RunTimers(uv_timer_s*) + 368
80  Electron Framework                  0x000000011c2874bc uv__run_timers + 112
81  Electron Framework                  0x000000011c28a728 uv_run + 584
82  Electron Framework                  0x000000011c4b228c electron::NodeBindings::UvRunOnce() + 232
83  Electron Framework                  0x000000011c2a3e44 base::OnceCallback<void ()>::Run() && + 108
84  Electron Framework                  0x0000000122081028 base::TaskAnnotator::RunTaskImpl(base::PendingTask&) + 280
85  Electron Framework                  0x00000001220b13bc base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*) + 1732
86  Electron Framework                  0x00000001220b0ac4 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() + 96
87  Electron Framework                  0x000000012211e630 base::MessagePumpCFRunLoopBase::RunWork() + 336
88  Electron Framework                  0x000000012211d170 base::apple::CallWithEHFrame(void () block_pointer) + 16
89  Electron Framework                  0x000000012211da1c base::MessagePumpCFRunLoopBase::RunWorkSource(void*) + 68
90  CoreFoundation                      0x000000018cac1c74 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 28
91  CoreFoundation                      0x000000018cac1c08 __CFRunLoopDoSource0 + 172
92  CoreFoundation                      0x000000018cac1974 __CFRunLoopDoSources0 + 232
93  CoreFoundation                      0x000000018cac05c8 __CFRunLoopRun + 840
94  CoreFoundation                      0x000000018cabfbf8 CFRunLoopRunSpecific + 572
95  HIToolbox                           0x000000019854127c RunCurrentEventLoopInMode + 324
96  HIToolbox                           0x00000001985444e8 ReceiveNextEventCommon + 676
97  HIToolbox                           0x00000001986cf484 _BlockUntilNextEventMatchingListInModeWithFilter + 76
98  AppKit                              0x00000001909e7ab4 _DPSNextEvent + 684
99  AppKit                              0x00000001913865b0 -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 688
100 AppKit                              0x00000001909dac64 -[NSApplication run] + 480
101 Electron Framework                  0x000000012211f16c base::MessagePumpNSApplication::DoRun(base::MessagePump::Delegate*) + 408
102 Electron Framework                  0x000000012211d1f0 base::MessagePumpCFRunLoopBase::Run(base::MessagePump::Delegate*) + 112
103 Electron Framework                  0x00000001220b2180 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) + 892
104 Electron Framework                  0x000000012205f7d8 base::RunLoop::Run(base::Location const&) + 996
105 Electron Framework                  0x000000012034af64 content::BrowserMainLoop::RunMainMessageLoop() + 232
106 Electron Framework                  0x000000012034ce08 content::BrowserMainRunnerImpl::Run() + 144
107 Electron Framework                  0x0000000120347a3c content::BrowserMain(content::MainFunctionParams) + 144
108 Electron Framework                  0x000000011c94bbc8 content::RunBrowserProcessMain(content::MainFunctionParams, content::ContentMainDelegate*) + 188
109 Electron Framework                  0x000000011c94e0f8 content::ContentMainRunnerImpl::RunBrowser(content::MainFunctionParams, bool) + 1852
110 Electron Framework                  0x000000011c94d960 content::ContentMainRunnerImpl::Run() + 1180
111 Electron Framework                  0x000000011c94b248 content::RunContentProcess(content::ContentMainParams, content::ContentMainRunner*) + 1344
112 Electron Framework                  0x000000011c94b368 content::ContentMain(content::ContentMainParams) + 112
113 Electron Framework                  0x000000011c29c724 ElectronMain + 124
114 Electron                            0x0000000102d80628 main + 96
115 dyld                                0x000000018c636b98 start + 6076
[end of stack trace]

Electron exited with signal SIGSEGV.
```

</p>
</details> 

This occurred because [`ui::EventLocationFromNative`](https://source.chromium.org/chromium/chromium/src/+/main:ui/events/cocoa/events_mac.mm;l=97-106;drc=1379ddb0f0535ff846ce0fbad8ee49af303140c4;bpv=1;bpt=1) called into [`ElectronNSWindow:contentRectForFrameRect`](https://github.com/electron/electron/blob/0819363f73c02ac2562c34422aa0fc6360da1270/shell/browser/ui/cocoa/electron_ns_window.mm#L221-L226) and tried to check `shell_->has_frame()` after `shell_` was already gone.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash that could occur when opening some dialogs as windows are closing on macOS.