### PR TITLE
refactor: add `NativeWindow::FromWidget()` helper (36-x-y)

### DIFF
--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -99,12 +99,11 @@ void WebContentsView::WebContentsDestroyed() {
 
 void WebContentsView::OnViewAddedToWidget(views::View* observed_view) {
   DCHECK_EQ(observed_view, view());
-  views::Widget* widget = view()->GetWidget();
-  auto* native_window =
-      static_cast<NativeWindow*>(widget->GetNativeWindowProperty(
-          electron::kElectronNativeWindowKey.c_str()));
+
+  NativeWindow* native_window = NativeWindow::FromWidget(view()->GetWidget());
   if (!native_window)
     return;
+
   // We don't need to call SetOwnerWindow(nullptr) in OnViewRemovedFromWidget
   // because that's handled in the WebContents dtor called prior.
   api_web_contents_->SetOwnerWindow(native_window);
@@ -114,11 +113,11 @@ void WebContentsView::OnViewAddedToWidget(views::View* observed_view) {
 
 void WebContentsView::OnViewRemovedFromWidget(views::View* observed_view) {
   DCHECK_EQ(observed_view, view());
-  views::Widget* widget = view()->GetWidget();
-  auto* native_window = static_cast<NativeWindow*>(
-      widget->GetNativeWindowProperty(kElectronNativeWindowKey.c_str()));
+
+  NativeWindow* native_window = NativeWindow::FromWidget(view()->GetWidget());
   if (!native_window)
     return;
+
   native_window->RemoveDraggableRegionProvider(this);
 }
 

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -284,6 +284,13 @@ bool NativeWindow::IsClosed() const {
   return is_closed_;
 }
 
+// static
+NativeWindow* NativeWindow::FromWidget(const views::Widget* widget) {
+  DCHECK(widget);
+  return static_cast<NativeWindow*>(
+      widget->GetNativeWindowProperty(kNativeWindowKey.c_str()));
+}
+
 void NativeWindow::SetSize(const gfx::Size& size, bool animate) {
   SetBounds(gfx::Rect(GetPosition(), size), animate);
 }

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -47,9 +47,6 @@ class PersistentDictionary;
 
 namespace electron {
 
-inline constexpr base::cstring_view kElectronNativeWindowKey =
-    "__ELECTRON_NATIVE_WINDOW__";
-
 class ElectronMenuModel;
 class BackgroundThrottlingSource;
 
@@ -77,6 +74,8 @@ class NativeWindow : public base::SupportsUserData,
   static std::unique_ptr<NativeWindow> Create(
       const gin_helper::Dictionary& options,
       NativeWindow* parent = nullptr);
+
+  [[nodiscard]] static NativeWindow* FromWidget(const views::Widget* widget);
 
   void InitFromOptions(const gin_helper::Dictionary& options);
 
@@ -443,6 +442,9 @@ class NativeWindow : public base::SupportsUserData,
   std::u16string GetAccessibleWindowTitle() const override;
 
   void set_content_view(views::View* view) { content_view_ = view; }
+
+  static inline constexpr base::cstring_view kNativeWindowKey =
+      "__ELECTRON_NATIVE_WINDOW__";
 
   // The boolean parsing of the "titleBarOverlay" option
   bool titlebar_overlay_ = false;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -204,7 +204,7 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   params.native_widget =
       new ElectronNativeWidgetMac(this, windowType, styleMask, widget());
   widget()->Init(std::move(params));
-  widget()->SetNativeWindowProperty(kElectronNativeWindowKey.c_str(), this);
+  widget()->SetNativeWindowProperty(kNativeWindowKey.c_str(), this);
   SetCanResize(resizable);
   window_ = static_cast<ElectronNSWindow*>(
       widget()->GetNativeWindow().GetNativeNSWindow());

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -312,7 +312,7 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
 #endif
 
   widget()->Init(std::move(params));
-  widget()->SetNativeWindowProperty(kElectronNativeWindowKey.c_str(), this);
+  widget()->SetNativeWindowProperty(kNativeWindowKey.c_str(), this);
   SetCanResize(resizable_);
 
   bool fullscreen = false;


### PR DESCRIPTION
Manually backport  #46917 to 36-x-y. See that PR for details.

Note: none.