### PR TITLE
refactor: simplify `NativeWindow::FullScreenTransitionState` (36-x-y)

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3973,8 +3973,7 @@ bool WebContents::IsFullscreenForTabOrPending(
   if (!owner_window())
     return is_html_fullscreen();
 
-  bool in_transition = owner_window()->fullscreen_transition_state() !=
-                       NativeWindow::FullScreenTransitionState::kNone;
+  const bool in_transition = owner_window()->is_transitioning_fullscreen();
   bool is_html_transition = owner_window()->fullscreen_transition_type() ==
                             NativeWindow::FullScreenTransitionType::kHTML;
 

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -354,13 +354,12 @@ class NativeWindow : public base::SupportsUserData,
   // Handle fullscreen transitions.
   void HandlePendingFullscreenTransitions();
 
-  enum class FullScreenTransitionState { kEntering, kExiting, kNone };
-
-  void set_fullscreen_transition_state(FullScreenTransitionState state) {
-    fullscreen_transition_state_ = state;
+  constexpr void set_is_transitioning_fullscreen(const bool val) {
+    is_transitioning_fullscreen_ = val;
   }
-  FullScreenTransitionState fullscreen_transition_state() const {
-    return fullscreen_transition_state_;
+
+  [[nodiscard]] constexpr bool is_transitioning_fullscreen() const {
+    return is_transitioning_fullscreen_;
   }
 
   enum class FullScreenTransitionType { kHTML, kNative, kNone };
@@ -462,8 +461,6 @@ class NativeWindow : public base::SupportsUserData,
   std::optional<extensions::SizeConstraints> content_size_constraints_;
 
   std::queue<bool> pending_transitions_;
-  FullScreenTransitionState fullscreen_transition_state_ =
-      FullScreenTransitionState::kNone;
   FullScreenTransitionType fullscreen_transition_type_ =
       FullScreenTransitionType::kNone;
 
@@ -510,6 +507,8 @@ class NativeWindow : public base::SupportsUserData,
 
   // Is this a modal window.
   bool is_modal_ = false;
+
+  bool is_transitioning_fullscreen_ = false;
 
   std::list<DraggableRegionProvider*> draggable_region_providers_;
 

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -18,8 +18,6 @@
 #include "ui/views/widget/native_widget_mac.h"
 
 using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
-using FullScreenTransitionState =
-    electron::NativeWindow::FullScreenTransitionState;
 
 @implementation ElectronNSWindowDelegate
 
@@ -302,7 +300,7 @@ using FullScreenTransitionState =
   // Store resizable mask so it can be restored after exiting fullscreen.
   is_resizable_ = shell_->HasStyleMask(NSWindowStyleMaskResizable);
 
-  shell_->set_fullscreen_transition_state(FullScreenTransitionState::kEntering);
+  shell_->set_is_transitioning_fullscreen(true);
 
   shell_->NotifyWindowWillEnterFullScreen();
 
@@ -311,7 +309,7 @@ using FullScreenTransitionState =
 }
 
 - (void)windowDidEnterFullScreen:(NSNotification*)notification {
-  shell_->set_fullscreen_transition_state(FullScreenTransitionState::kNone);
+  shell_->set_is_transitioning_fullscreen(false);
 
   shell_->NotifyWindowEnterFullScreen();
 
@@ -322,7 +320,7 @@ using FullScreenTransitionState =
 }
 
 - (void)windowDidFailToEnterFullScreen:(NSWindow*)window {
-  shell_->set_fullscreen_transition_state(FullScreenTransitionState::kNone);
+  shell_->set_is_transitioning_fullscreen(false);
 
   shell_->SetResizable(is_resizable_);
   shell_->NotifyWindowDidFailToEnterFullScreen();
@@ -334,13 +332,13 @@ using FullScreenTransitionState =
 }
 
 - (void)windowWillExitFullScreen:(NSNotification*)notification {
-  shell_->set_fullscreen_transition_state(FullScreenTransitionState::kExiting);
+  shell_->set_is_transitioning_fullscreen(true);
 
   shell_->NotifyWindowWillLeaveFullScreen();
 }
 
 - (void)windowDidExitFullScreen:(NSNotification*)notification {
-  shell_->set_fullscreen_transition_state(FullScreenTransitionState::kNone);
+  shell_->set_is_transitioning_fullscreen(false);
 
   shell_->SetResizable(is_resizable_);
   shell_->NotifyWindowLeaveFullScreen();


### PR DESCRIPTION
Manually backport #46918 to 36-x-y. See that PR for details.

Notes: none.