### PR TITLE
refactor: remove some `NativeWindow` public API (37-x-y)

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -818,17 +818,14 @@ bool NativeWindow::IsTranslucent() const {
 
 #if BUILDFLAG(IS_MAC)
   // Windows with vibrancy set are translucent
-  if (!vibrancy().empty()) {
+  if (!vibrancy_.empty())
     return true;
-  }
 #endif
 
 #if BUILDFLAG(IS_WIN)
   // Windows with certain background materials may be translucent
-  const std::string& bg_material = background_material();
-  if (!bg_material.empty() && bg_material != "none") {
+  if (!background_material_.empty() && background_material_ != "none")
     return true;
-  }
 #endif
 
   return false;

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -230,12 +230,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetAutoHideCursor(bool auto_hide) {}
 
   // Vibrancy API
-  const std::string& vibrancy() const { return vibrancy_; }
   virtual void SetVibrancy(const std::string& type, int duration);
 
-  const std::string& background_material() const {
-    return background_material_;
-  }
   virtual void SetBackgroundMaterial(const std::string& type);
 
   // Traffic Light API
@@ -290,12 +286,6 @@ class NativeWindow : public base::SupportsUserData,
   virtual void CloseFilePreview() {}
 
   virtual void SetGTKDarkThemeEnabled(bool use_dark_theme) {}
-
-  // Converts between content bounds and window bounds.
-  virtual gfx::Rect ContentBoundsToWindowBounds(
-      const gfx::Rect& bounds) const = 0;
-  virtual gfx::Rect WindowBoundsToContentBounds(
-      const gfx::Rect& bounds) const = 0;
 
   base::WeakPtr<NativeWindow> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();
@@ -407,7 +397,6 @@ class NativeWindow : public base::SupportsUserData,
   }
 
   bool has_frame() const { return has_frame_; }
-  void set_has_frame(bool has_frame) { has_frame_ = has_frame; }
 
   bool has_client_frame() const { return has_client_frame_; }
   bool transparent() const { return transparent_; }
@@ -440,11 +429,17 @@ class NativeWindow : public base::SupportsUserData,
   void UpdateBackgroundThrottlingState();
 
  protected:
-  friend class api::BrowserView;
+  constexpr void set_has_frame(const bool val) { has_frame_ = val; }
 
   [[nodiscard]] constexpr bool is_closed() const { return is_closed_; }
 
   NativeWindow(const gin_helper::Dictionary& options, NativeWindow* parent);
+
+  // Converts between content bounds and window bounds.
+  virtual gfx::Rect ContentBoundsToWindowBounds(
+      const gfx::Rect& bounds) const = 0;
+  virtual gfx::Rect WindowBoundsToContentBounds(
+      const gfx::Rect& bounds) const = 0;
 
   // views::WidgetDelegate:
   views::Widget* GetWidget() override;
@@ -461,10 +456,6 @@ class NativeWindow : public base::SupportsUserData,
 
   // The boolean parsing of the "titleBarOverlay" option
   bool titlebar_overlay_ = false;
-
-  // The custom height parsed from the "height" option in a Object
-  // "titleBarOverlay"
-  int titlebar_overlay_height_ = 0;
 
   // The "titleBarStyle" option.
   TitleBarStyle title_bar_style_ = TitleBarStyle::kNormal;
@@ -490,6 +481,10 @@ class NativeWindow : public base::SupportsUserData,
 
   // The content view, weak ref.
   raw_ptr<views::View> content_view_ = nullptr;
+
+  // The custom height parsed from the "height" option in a Object
+  // "titleBarOverlay"
+  int titlebar_overlay_height_ = 0;
 
   // Whether window has standard frame.
   bool has_frame_ = true;


### PR DESCRIPTION
Manually backport #46919 to 37-x-y. See that PR for details.

Notes: none.