### PR TITLE
refactor: pass `gfx::ResizeEdge` by value

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -254,7 +254,7 @@ void BaseWindow::OnWindowRestore() {
 }
 
 void BaseWindow::OnWindowWillResize(const gfx::Rect& new_bounds,
-                                    const gfx::ResizeEdge& edge,
+                                    const gfx::ResizeEdge edge,
                                     bool* prevent_default) {
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -71,7 +71,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void OnWindowMinimize() override;
   void OnWindowRestore() override;
   void OnWindowWillResize(const gfx::Rect& new_bounds,
-                          const gfx::ResizeEdge& edge,
+                          gfx::ResizeEdge edge,
                           bool* prevent_default) override;
   void OnWindowResize() override;
   void OnWindowResized() override;

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -602,7 +602,7 @@ void NativeWindow::NotifyWindowRestore() {
 }
 
 void NativeWindow::NotifyWindowWillResize(const gfx::Rect& new_bounds,
-                                          const gfx::ResizeEdge& edge,
+                                          const gfx::ResizeEdge edge,
                                           bool* prevent_default) {
   observers_.Notify(&NativeWindowObserver::OnWindowWillResize, new_bounds, edge,
                     prevent_default);

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -319,7 +319,7 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowRestore();
   void NotifyWindowMove();
   void NotifyWindowWillResize(const gfx::Rect& new_bounds,
-                              const gfx::ResizeEdge& edge,
+                              gfx::ResizeEdge edge,
                               bool* prevent_default);
   void NotifyWindowResize();
   void NotifyWindowResized();

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -78,7 +78,7 @@ class NativeWindowObserver : public base::CheckedObserver {
   virtual void OnWindowMinimize() {}
   virtual void OnWindowRestore() {}
   virtual void OnWindowWillResize(const gfx::Rect& new_bounds,
-                                  const gfx::ResizeEdge& edge,
+                                  gfx::ResizeEdge edge,
                                   bool* prevent_default) {}
   virtual void OnWindowResize() {}
   virtual void OnWindowResized() {}

--- a/shell/common/gin_converters/gfx_converter.cc
+++ b/shell/common/gin_converters/gfx_converter.cc
@@ -197,7 +197,7 @@ v8::Local<v8::Value> Converter<display::Display>::ToV8(
 
 v8::Local<v8::Value> Converter<gfx::ResizeEdge>::ToV8(
     v8::Isolate* isolate,
-    const gfx::ResizeEdge& val) {
+    const gfx::ResizeEdge val) {
   switch (val) {
     case gfx::ResizeEdge::kRight:
       return StringToV8(isolate, "right");

--- a/shell/common/gin_converters/gfx_converter.h
+++ b/shell/common/gin_converters/gfx_converter.h
@@ -77,7 +77,7 @@ struct Converter<display::Display> {
 template <>
 struct Converter<gfx::ResizeEdge> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   const gfx::ResizeEdge& val);
+                                   const gfx::ResizeEdge val);
 };
 
 template <>


### PR DESCRIPTION
#### Description of Change

Small cleanup to pass `gfx::ResizeEdge` by value. It's [an enum class](https://chromium.googlesource.com/chromium/src/+/main/ui/gfx/geometry/resize_utils.h#17), so it's simpler to pass it by value than by reference.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.