### PR TITLE
refactor: reduce use of `NativeWidgetPrivate`

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1291,15 +1291,15 @@ void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
 #endif
 }
 
-void NativeWindowViews::SetContentProtection(bool enable) {
+void NativeWindowViews::SetContentProtection(const bool enable) {
 #if BUILDFLAG(IS_WIN)
-  widget()->native_widget_private()->SetAllowScreenshots(!enable);
+  widget()->SetAllowScreenshots(!enable);
 #endif
 }
 
 bool NativeWindowViews::IsContentProtected() const {
 #if BUILDFLAG(IS_WIN)
-  return !widget()->native_widget_private()->AreScreenshotsAllowed();
+  return !widget()->AreScreenshotsAllowed();
 #else  // Not implemented on Linux
   return false;
 #endif

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -492,8 +492,7 @@ bool NativeWindowViews::IsFocused() const {
 }
 
 void NativeWindowViews::Show() {
-  if (is_modal() && NativeWindow::parent() &&
-      !widget()->native_widget_private()->IsVisible())
+  if (is_modal() && NativeWindow::parent() && !widget()->IsVisible())
     static_cast<NativeWindowViews*>(parent())->IncrementChildModals();
 
   widget()->native_widget_private()->Show(GetRestoredState(), gfx::Rect());

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -19,7 +19,6 @@
 #include "ui/display/display.h"
 #include "ui/display/screen.h"
 #include "ui/gfx/geometry/resize_utils.h"
-#include "ui/views/widget/native_widget_private.h"
 
 // Must be included after other Windows headers.
 #include <UIAutomationClient.h>


### PR DESCRIPTION
#### Description of Change

Prefer to use stable `views::Widget` API instead of using its `native_widget_private()` getter directly. There are a handful of places where `views::Widget` has simple wrapper functions around `native_widget_private()`.

Example:

`views::Widget::AreScreenshotsAllowed()` [is implemented as a simple wrapper](https://chromium.googlesource.com/chromium/src/+/main/ui/views/widget/widget.cc#2429) around `NativePrivateWidget`:

```c++
bool Widget::AreScreenshotsAllowed() {
  return native_widget_ ? native_widget_->AreScreenshotsAllowed() : true;
}
```

So we don't have to call `native_widget_private()`:

```diff
-  widget()->native_widget_private()->AreScreenshotsAllowed()
+  widget()->AreScreenshotsAllowed()
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.