### PR TITLE
build: move release script to new hasher function

### DIFF
--- a/script/release/get-url-hash.ts
+++ b/script/release/get-url-hash.ts
@@ -2,12 +2,12 @@ import got from 'got';
 
 import * as url from 'node:url';
 
-const HASHER_FUNCTION_HOST = 'electron-artifact-hasher.azurewebsites.net';
-const HASHER_FUNCTION_ROUTE = '/api/HashArtifact';
+const HASHER_FUNCTION_HOST = 'electron-hasher.azurewebsites.net';
+const HASHER_FUNCTION_ROUTE = '/api/hashRemoteAsset';
 
 export async function getUrlHash (targetUrl: string, algorithm = 'sha256', attempts = 3) {
   const options = {
-    code: process.env.ELECTRON_ARTIFACT_HASHER_FUNCTION_KEY!,
+    code: process.env.ELECTRON_HASHER_FUNCTION_KEY!,
     targetUrl,
     algorithm
   };


### PR DESCRIPTION
#### Description of Change

Conversation here: https://electronhq.slack.com/archives/CC80G2R6H/p1745119875976869?thread_ts=1745000386.480629&cid=CC80G2R6H. Following some modernizations to the electron/hasher repo, this PR moves us to use the new Azure function for the artifact hasher during releases.

The corresponding env variable has also been updated in Sudowoodo.

_NOTE:_ This is targeting all active release branches, but we should merge into main and ensure the new function works with nightly before actually merging the backports. Because we're using a new variable for the new function and haven't removed the variable for the old key/function, upload will still work for other release branches in the meantime.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
