### PR TITLE
refactor: use process.emitWarning for deprecation warnings in JS

### DIFF
--- a/spec/lib/warning-helpers.ts
+++ b/spec/lib/warning-helpers.ts
@@ -8,11 +8,6 @@ async function expectWarnings (
 ) {
   const messages: { name: string, message: string }[] = [];
 
-  const originalWarn = console.warn;
-  console.warn = (message) => {
-    messages.push({ name: 'Warning', message });
-  };
-
   const warningListener = (error: Error) => {
     messages.push({ name: error.name, message: error.message });
   };
@@ -24,7 +19,6 @@ async function expectWarnings (
   } finally {
     // process.emitWarning seems to need us to wait a tick
     await new Promise(process.nextTick);
-    console.warn = originalWarn;
     process.off('warning' as any, warningListener);
     expect(messages).to.have.lengthOf(expected.length);
     for (const [idx, { name, message }] of messages.entries()) {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Aligns our deprecation warnings in JS with our warnings from C++ such that both use `process.emitWarning`, ensuring users setting a handler for the `warning` event on `process` will capture all deprecation warnings.

Expands the test coverage in `spec/deprecate-spec.ts` and fixes some tests that were passing but actually hitting an error.

Keeps a fallback to `console.warn` if `process.emitWarning` is not available (e.g. renderer without `nodeIntegration: true`).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
