### PR TITLE
fix: use-after-move of bus connection in xdg portal detection

### DIFF
--- a/shell/browser/ui/file_dialog_linux_portal.cc
+++ b/shell/browser/ui/file_dialog_linux_portal.cc
@@ -86,8 +86,9 @@ void CheckPortalAvailabilityOnBusThread() {
                     << (g_portal_available ? "yes" : "no");
             flag->Set();
             bus->ShutdownAndBlock();
+            bus.reset();
           },
-          std::move(bus), flag));
+          bus, flag));
 }
 
 }  // namespace


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/47007

#### Release Notes

Notes: fix crash in xdg portal version detection on startup