### PR TITLE
build: update hasher return value

### DIFF
--- a/script/release/get-url-hash.ts
+++ b/script/release/get-url-hash.ts
@@ -28,7 +28,9 @@ export async function getUrlHash (targetUrl: string, algorithm = 'sha256', attem
     }
     if (!resp.body) throw new Error('Successful lambda call but failed to get valid hash');
 
-    return resp.body.trim();
+    // response shape should be { hash: 'xyz', invocationId: "abc"}
+    const { hash } = JSON.parse(resp.body.trim());
+    return hash;
   } catch (err) {
     if (attempts > 1) {
       const { response } = err as any;


### PR DESCRIPTION
#### Description of Change

Follow up to #46989, updates the value returned by `getUrlHash` to handle an object being returned, as opposed to only the hash string value

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
