### PR TITLE
feat: support no-warnings and disable-warning Node.js cli flags

### DIFF
--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -272,6 +272,13 @@ Set the `host:port` to be used when the inspector is activated. Useful when acti
 
 Aliased to `--debug-port=[host:]port`.
 
+### `--disable-warning=code-or-type`
+
+Disable specific process warnings by `code` or `type`.
+
+Warnings emitted from [`process.emitWarning()`](https://nodejs.org/api/process.html#processemitwarningwarning-options)
+may contain a `code` and a `type`. This option will not-emit warnings that have a matching `code` or `type`.
+
 ### `--inspect\[=\[host:]port]`
 
 Activate inspector on `host:port`. Default is `127.0.0.1:9229`.
@@ -291,6 +298,10 @@ By default inspector websocket url is available in stderr and under /json/list e
 ### `--no-deprecation`
 
 Silence deprecation warnings.
+
+### `--no-warnings`
+
+Silence all process warnings (including deprecations).
 
 ### `--throw-deprecation`
 

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -353,8 +353,10 @@ bool IsAllowedOption(const std::string_view option) {
   // This should be aligned with what's possible to set via the process object.
   static constexpr auto options = base::MakeFixedFlatSet<std::string_view>({
       "--diagnostic-dir",
+      "--disable-warning",
       "--dns-result-order",
       "--no-deprecation",
+      "--no-warnings",
       "--throw-deprecation",
       "--trace-deprecation",
       "--trace-warnings",


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

`--no-deprecation` is a rather blunt hammer that has some unintuitive behavior in Node.js, namely that it prevents the `warning` event from being emitted at all for deprecations, while `--no-warnings` only silences the default handler which writes warnings to `stderr`. Node.js also has `ExperimentalWarning` these days so it's nice to have one switch to silence all of them.

`--disable-warning` is a more surgical way to silence warnings (while still emitting the `warning` event), which makes it easy to silence just the experimental warnings and keep deprecation warnings more visible.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Add support for --no-warnings and --disable-warning Node.js cli flags <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
