### PR TITLE
fix: restore previous Windows screenshotting

### DIFF
--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -126,6 +126,16 @@ bool ElectronDesktopWindowTreeHostWin::HandleMouseEvent(ui::MouseEvent* event) {
   return views::DesktopWindowTreeHostWin::HandleMouseEvent(event);
 }
 
+void ElectronDesktopWindowTreeHostWin::HandleVisibilityChanged(bool visible) {
+  if (native_window_view_->widget())
+    native_window_view_->widget()->OnNativeWidgetVisibilityChanged(visible);
+}
+
+void ElectronDesktopWindowTreeHostWin::SetAllowScreenshots(bool allow) {
+  ::SetWindowDisplayAffinity(GetAcceleratedWidget(),
+                             allow ? WDA_NONE : WDA_EXCLUDEFROMCAPTURE);
+}
+
 void ElectronDesktopWindowTreeHostWin::OnNativeThemeUpdated(
     ui::NativeTheme* observed_theme) {
   HWND hWnd = GetAcceleratedWidget();

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
@@ -41,6 +41,8 @@ class ElectronDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin,
                            int frame_thickness) const override;
   bool HandleMouseEventForCaption(UINT message) const override;
   bool HandleMouseEvent(ui::MouseEvent* event) override;
+  void HandleVisibilityChanged(bool visible) override;
+  void SetAllowScreenshots(bool allow) override;
 
   // ui::NativeThemeObserver:
   void OnNativeThemeUpdated(ui::NativeTheme* observed_theme) override;


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/45990

We previously made a change in https://github.com/electron/electron/pull/45868 to fix content protection being lost on hide and re-show. However, this cause a breaking change where protected windows were made opaque black instead of being hidden as before. This overrides relevant methods in ElectronDesktopWindowTreeHostWin to restore the previous behavior. without regressing the original issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Restored previous window-hiding behavior of `win.setContentProtected()` on Windows.
