### PR TITLE
refactor: use kKeyModifiers in IsAltModifier()

### DIFF
--- a/shell/browser/ui/views/root_view.cc
+++ b/shell/browser/ui/views/root_view.cc
@@ -20,13 +20,8 @@ bool IsAltKey(const input::NativeWebKeyboardEvent& event) {
 }
 
 bool IsAltModifier(const input::NativeWebKeyboardEvent& event) {
-  using Modifiers = input::NativeWebKeyboardEvent::Modifiers;
-  int modifiers = event.GetModifiers();
-  modifiers &= ~Modifiers::kNumLockOn;
-  modifiers &= ~Modifiers::kCapsLockOn;
-  return (modifiers == Modifiers::kAltKey) ||
-         (modifiers == (Modifiers::kAltKey | Modifiers::kIsLeft)) ||
-         (modifiers == (Modifiers::kAltKey | Modifiers::kIsRight));
+  using Mods = input::NativeWebKeyboardEvent::Modifiers;
+  return (event.GetModifiers() & Mods::kKeyModifiers) == Mods::kAltKey;
 }
 
 }  // namespace


### PR DESCRIPTION
#### Description of Change

Use the [`WebInputEvent::kKeyModifiers` mask](https://chromium.googlesource.com/chromium/src/+blame/c00c5a0ea70368a64d703c638e6b539afd869ed8/third_party/blink/public/common/input/web_input_event.h#159) to determine whether an event is using only the alt modifier.

We probably didn't use this in `IsAltModifier()` because that function was written two years before the KeyModifiers mask was added upstream in 98ec378a. :smile_cat: 

In the same way that we previously added code to handle `kCapsLockOn` and `kNumLockOn` (81283db2da6c95a316d9345ae20fc0c1ac88d69c), this change also fixes an unreported edge case of not honoring menuitem accelerators when the scroll lock is on.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.