### PR TITLE
fix: opening package paths as directory on macOS

### DIFF
--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -318,9 +318,10 @@ void ReadDialogPathsWithBookmarks(NSOpenPanel* dialog,
       BOOL exists =
           [[NSFileManager defaultManager] fileExistsAtPath:path
                                                isDirectory:&is_directory];
-      BOOL is_package =
-          [[NSWorkspace sharedWorkspace] isFilePackageAtPath:path];
-      if (!exists || !is_directory || is_package)
+      BOOL is_package_as_directory =
+          [[NSWorkspace sharedWorkspace] isFilePackageAtPath:path] &&
+          [dialog treatsFilePackagesAsDirectories];
+      if (!exists || !is_directory || !is_package_as_directory)
         continue;
     }
 


### PR DESCRIPTION
#### Description of Change

Follow-up to https://github.com/electron/electron/pull/38557

Unlike chromium we support dialog option to treat packages as directory which should be respected.

#### Release Notes

Notes: fix opening package paths as directory when `treatPackageAsDirectory` is enabled on macOS