### PR TITLE
refactor: make TrackableObject::weak_map_id() constexpr

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -1154,10 +1154,6 @@ void BaseWindow::SetTitleBarOverlay(const gin_helper::Dictionary& options,
 }
 #endif
 
-int32_t BaseWindow::GetID() const {
-  return weak_map_id();
-}
-
 void BaseWindow::RemoveFromParentChildWindows() {
   if (parent_window_.IsEmpty())
     return;

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -261,7 +261,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void SetTitleBarOverlay(const gin_helper::Dictionary& options,
                           gin_helper::Arguments* args);
 #endif
-  int32_t GetID() const;
+  [[nodiscard]] constexpr int32_t GetID() const { return weak_map_id(); }
 
  private:
   // Helpers.

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -406,7 +406,7 @@ class NativeWindow : public base::SupportsUserData,
   NativeWindow* parent() const { return parent_; }
   bool is_modal() const { return is_modal_; }
 
-  int32_t window_id() const { return window_id_; }
+  [[nodiscard]] constexpr int32_t window_id() const { return window_id_; }
 
   void add_child_window(NativeWindow* child) {
     child_windows_.push_back(child);

--- a/shell/common/gin_helper/trackable_object.h
+++ b/shell/common/gin_helper/trackable_object.h
@@ -28,7 +28,7 @@ class TrackableObjectBase : public CleanedUpAtExit {
   TrackableObjectBase& operator=(const TrackableObjectBase&) = delete;
 
   // The ID in weak map.
-  int32_t weak_map_id() const { return weak_map_id_; }
+  [[nodiscard]] constexpr int32_t weak_map_id() const { return weak_map_id_; }
 
   // Wrap TrackableObject into a class that SupportsUserData.
   void AttachAsUserData(base::SupportsUserData* wrapped);


### PR DESCRIPTION
#### Description of Change

Does what it says on the tin: make `TrackableObject::weak_map_id()` and `BaseWindow::GetID()` inline and constexpr.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.