### PR TITLE
refactor: decouple NativeWindowViews and GlobalMenuBarX11

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1357,7 +1357,8 @@ void NativeWindowViews::SetMenu(ElectronMenuModel* menu_model) {
                                         .supports_global_application_menus;
   if (can_use_global_menus && ShouldUseGlobalMenuBar()) {
     if (!global_menu_bar_)
-      global_menu_bar_ = std::make_unique<GlobalMenuBarX11>(this);
+      global_menu_bar_ =
+          std::make_unique<GlobalMenuBarX11>(GetAcceleratedWidget());
     if (global_menu_bar_->IsServerStarted()) {
       root_view_.RegisterAcceleratorsWithFocusManager(menu_model);
       global_menu_bar_->SetMenu(menu_model);

--- a/shell/browser/ui/views/global_menu_bar_x11.cc
+++ b/shell/browser/ui/views/global_menu_bar_x11.cc
@@ -9,7 +9,6 @@
 
 #include "base/functional/bind.h"
 #include "base/strings/utf_string_conversions.h"
-#include "shell/browser/native_window_views.h"
 #include "shell/browser/ui/electron_menu_model.h"
 #include "shell/browser/ui/views/global_menu_bar_registrar_x11.h"
 #include "third_party/abseil-cpp/absl/strings/str_format.h"
@@ -173,10 +172,8 @@ std::string GetMenuModelStatus(ElectronMenuModel* model) {
 
 }  // namespace
 
-GlobalMenuBarX11::GlobalMenuBarX11(NativeWindowViews* window)
-    : window_(window),
-      xwindow_(static_cast<x11::Window>(
-          window_->GetNativeWindow()->GetHost()->GetAcceleratedWidget())) {
+GlobalMenuBarX11::GlobalMenuBarX11(gfx::AcceleratedWidget accelerated_widget)
+    : xwindow_(static_cast<x11::Window>(accelerated_widget)) {
   EnsureMethodsLoaded();
   if (server_new)
     InitServer(xwindow_);

--- a/shell/browser/ui/views/global_menu_bar_x11.h
+++ b/shell/browser/ui/views/global_menu_bar_x11.h
@@ -22,8 +22,6 @@ class Accelerator;
 
 namespace electron {
 
-class NativeWindowViews;
-
 // Controls the Mac style menu bar on Unity.
 //
 // Unity has an Apple-like menu bar at the top of the screen that changes
@@ -37,7 +35,7 @@ class NativeWindowViews;
 // from menu models instead, and it is also per-window specific.
 class GlobalMenuBarX11 {
  public:
-  explicit GlobalMenuBarX11(NativeWindowViews* window);
+  explicit GlobalMenuBarX11(gfx::AcceleratedWidget accelerated_widget);
   virtual ~GlobalMenuBarX11();
 
   // disable copy
@@ -68,7 +66,6 @@ class GlobalMenuBarX11 {
   void OnItemActivated(DbusmenuMenuitem* item, unsigned int timestamp);
   void OnSubMenuShow(DbusmenuMenuitem* item);
 
-  raw_ptr<NativeWindowViews> window_;
   x11::Window xwindow_;
 
   raw_ptr<DbusmenuServer> server_ = nullptr;


### PR DESCRIPTION
#### Description of Change

Remove a little bit of unnecessary coupling between `NativeWindowViews` and `GlobalMenuBarX11`. The latter doesn't need to know about the former:

- Remove the unused field `GlobalMenuBarX11::window_`.
- The `NativeWindowViews*` passed into the `GlobalMenuBarX11` constructor is only used to get the `gfx::AcceleratedWidget`, so skip the middleman and pass in the accelerated widget instead.
- Remove `#include` and forward declarations of `NativeWindowViews`

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.