### PR TITLE
fix: addChildView() crashes when adding a closed WebContentsView

### DIFF
--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -216,6 +216,12 @@ void View::AddChildViewAt(gin::Handle<View> child,
   if (!view_)
     return;
 
+  if (!child->view()) {
+    gin_helper::ErrorThrower(isolate()).ThrowError(
+        "Can't add a destroyed child view to a parent view");
+    return;
+  }
+
   // This will CHECK and crash in View::AddChildViewAtImpl if not handled here.
   if (view_ == child->view()) {
     gin_helper::ErrorThrower(isolate()).ThrowError(

--- a/spec/api-web-contents-view-spec.ts
+++ b/spec/api-web-contents-view-spec.ts
@@ -55,6 +55,20 @@ describe('WebContentsView', () => {
     })).to.throw('options.webContents is already attached to a window');
   });
 
+  it('should throw an error when adding a destroyed child view to the parent view', async () => {
+    const browserWindow = new BrowserWindow();
+
+    const webContentsView = new WebContentsView();
+    webContentsView.webContents.loadURL('about:blank');
+    webContentsView.webContents.destroy();
+
+    const destroyed = once(webContentsView.webContents, 'destroyed');
+    await destroyed;
+    expect(() => browserWindow.contentView.addChildView(webContentsView)).to.throw(
+      'Can\'t add a destroyed child view to a parent view'
+    );
+  });
+
   it('should throw error when created with already attached webContents to other WebContentsView', () => {
     const browserWindow = new BrowserWindow();
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/47074

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `addChildView()` crashes when adding a closed WebContentsView

