### PR TITLE
perf: don't create unused menuitem icons

### DIFF
--- a/shell/browser/ui/gtk/menu_util.cc
+++ b/shell/browser/ui/gtk/menu_util.cc
@@ -61,27 +61,21 @@ GdkModifierType GetGdkModifierForAccelerator(
 
 }  // namespace
 
-GtkWidget* BuildMenuItemWithImage(const std::string& label, GtkWidget* image) {
-// GTK4 removed support for image menu items.
+GtkWidget* BuildMenuItemWithImage(const std::string& label,
+                                  const gfx::Image& icon) {
+// GTK4 removed support for menuitem icons.
 #if GTK_CHECK_VERSION(3, 90, 0)
   return gtk_menu_item_new_with_mnemonic(label.c_str());
 #else
   G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
   GtkWidget* menu_item = gtk_image_menu_item_new_with_mnemonic(label.c_str());
+  GdkPixbuf* pixbuf = gtk_util::GdkPixbufFromSkBitmap(*icon.ToSkBitmap());
+  GtkWidget* image = gtk_image_new_from_pixbuf(pixbuf);
   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(menu_item), image);
+  g_object_unref(pixbuf);
   G_GNUC_END_IGNORE_DEPRECATIONS;
   return menu_item;
 #endif
-}
-
-GtkWidget* BuildMenuItemWithImage(const std::string& label,
-                                  const gfx::Image& icon) {
-  GdkPixbuf* pixbuf = gtk_util::GdkPixbufFromSkBitmap(*icon.ToSkBitmap());
-
-  GtkWidget* menu_item =
-      BuildMenuItemWithImage(label, gtk_image_new_from_pixbuf(pixbuf));
-  g_object_unref(pixbuf);
-  return menu_item;
 }
 
 GtkWidget* BuildMenuItemWithLabel(const std::string& label) {

--- a/shell/browser/ui/gtk/menu_util.h
+++ b/shell/browser/ui/gtk/menu_util.h
@@ -26,8 +26,6 @@ using MenuActivatedCallback = base::RepeatingCallback<void(GtkWidget*)>;
 
 // Builds GtkImageMenuItems.
 GtkWidget* BuildMenuItemWithImage(const std::string& label, GtkWidget* image);
-GtkWidget* BuildMenuItemWithImage(const std::string& label,
-                                  const gfx::Image& icon);
 GtkWidget* BuildMenuItemWithLabel(const std::string& label);
 
 ui::MenuModel* ModelForMenuItem(GtkMenuItem* menu_item);


### PR DESCRIPTION
#### Description of Change

GTK >= 3.90.0 removed support for menuitem icons. When Electron is built with GTK >= 3.90.0, our code builds these icons and then throws them away unused. Instead, let's just not build them.

Our `gtk_util::GdkPixbufFromSkBitmap()` utility uses BGRAToRGBA and is expensive to call.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.