### PR TITLE
feat: support dip <-> screen conversion on Linux

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -670,6 +670,8 @@ source_set("electron_lib") {
     sources += [
       "shell/browser/certificate_manager_model.cc",
       "shell/browser/certificate_manager_model.h",
+      "shell/browser/linux/x11_util.cc",
+      "shell/browser/linux/x11_util.h",
       "shell/browser/ui/gtk_util.cc",
       "shell/browser/ui/gtk_util.h",
     ]

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -356,7 +356,7 @@ as `-webkit-app-region: drag` in a frameless window.
 
 Calling `event.preventDefault()` will prevent the menu from being displayed.
 
-To convert `point` to DIP, use [`screen.screenToDipPoint(point)`](./screen.md#screenscreentodippointpoint-windows).
+To convert `point` to DIP, use [`screen.screenToDipPoint(point)`](./screen.md#screenscreentodippointpoint-windows-linux).
 
 ### Static Methods
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -435,7 +435,7 @@ as `-webkit-app-region: drag` in a frameless window.
 
 Calling `event.preventDefault()` will prevent the menu from being displayed.
 
-To convert `point` to DIP, use [`screen.screenToDipPoint(point)`](./screen.md#screenscreentodippointpoint-windows).
+To convert `point` to DIP, use [`screen.screenToDipPoint(point)`](./screen.md#screenscreentodippointpoint-windows-linux).
 
 ### Static Methods
 

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -124,7 +124,7 @@ Returns [`Display`](structures/display.md) - The display nearest the specified p
 Returns [`Display`](structures/display.md) - The display that most closely
 intersects the provided bounds.
 
-### `screen.screenToDipPoint(point)` _Windows_
+### `screen.screenToDipPoint(point)` _Windows_ _Linux_
 
 * `point` [Point](structures/point.md)
 
@@ -133,7 +133,10 @@ Returns [`Point`](structures/point.md)
 Converts a screen physical point to a screen DIP point.
 The DPI scale is performed relative to the display containing the physical point.
 
-### `screen.dipToScreenPoint(point)` _Windows_
+Not currently supported on Wayland - if used there it will return the point passed
+in with no changes.
+
+### `screen.dipToScreenPoint(point)` _Windows_ _Linux_
 
 * `point` [Point](structures/point.md)
 
@@ -141,6 +144,8 @@ Returns [`Point`](structures/point.md)
 
 Converts a screen DIP point to a screen physical point.
 The DPI scale is performed relative to the display containing the DIP point.
+
+Not currently supported on Wayland.
 
 ### `screen.screenToDipRect(window, rect)` _Windows_
 

--- a/shell/browser/api/electron_api_screen.h
+++ b/shell/browser/api/electron_api_screen.h
@@ -15,6 +15,7 @@
 
 namespace gfx {
 class Point;
+class PointF;
 class Rect;
 class Screen;
 }  // namespace gfx
@@ -57,6 +58,9 @@ class Screen final : public gin::Wrappable<Screen>,
   display::Display GetDisplayMatching(const gfx::Rect& match_rect) const {
     return screen_->GetDisplayMatching(match_rect);
   }
+
+  gfx::PointF ScreenToDIPPoint(const gfx::PointF& point_px);
+  gfx::Point DIPToScreenPoint(const gfx::Point& point_dip);
 
   // display::DisplayObserver:
   void OnDisplayAdded(const display::Display& new_display) override;

--- a/shell/browser/linux/x11_util.cc
+++ b/shell/browser/linux/x11_util.cc
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 Microsoft GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/linux/x11_util.h"
+
+#include "ui/ozone/public/ozone_platform.h"
+
+namespace x11_util {
+
+bool IsX11() {
+  return ui::OzonePlatform::GetInstance()
+      ->GetPlatformProperties()
+      .electron_can_call_x11;
+}
+
+}  // namespace x11_util

--- a/shell/browser/linux/x11_util.h
+++ b/shell/browser/linux/x11_util.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 Microsoft GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_BROWSER_LINUX_X11_UTIL_H_
+#define ELECTRON_SHELL_BROWSER_LINUX_X11_UTIL_H_
+
+namespace x11_util {
+
+bool IsX11();
+
+}  // namespace x11_util
+
+#endif  // ELECTRON_SHELL_BROWSER_LINUX_X11_UTIL_H_

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -55,6 +55,7 @@
 #include "base/strings/string_util.h"
 #include "shell/browser/browser.h"
 #include "shell/browser/linux/unity_service.h"
+#include "shell/browser/linux/x11_util.h"
 #include "shell/browser/ui/electron_desktop_window_tree_host_linux.h"
 #include "shell/browser/ui/views/client_frame_view_linux.h"
 #include "shell/browser/ui/views/native_frame_view.h"
@@ -163,13 +164,6 @@ gfx::Size WindowSizeToContentSizeBuggy(HWND hwnd, const gfx::Size& size) {
 }
 
 #endif
-
-[[maybe_unused, nodiscard]] bool IsX11() {
-  static const bool is_x11 = ui::OzonePlatform::GetInstance()
-                                 ->GetPlatformProperties()
-                                 .electron_can_call_x11;
-  return is_x11;
-}
 
 class NativeWindowClientView : public views::ClientView {
  public:
@@ -333,7 +327,7 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
   if (parent)
     SetParentWindow(parent);
 
-  if (IsX11()) {
+  if (x11_util::IsX11()) {
     // Before the window is mapped the SetWMSpecState can not work, so we have
     // to manually set the _NET_WM_STATE.
     std::vector<x11::Atom> state_atom_list;
@@ -484,7 +478,7 @@ NativeWindowViews::~NativeWindowViews() {
 
 void NativeWindowViews::SetGTKDarkThemeEnabled(bool use_dark_theme) {
 #if BUILDFLAG(IS_LINUX)
-  if (IsX11()) {
+  if (x11_util::IsX11()) {
     const std::string color = use_dark_theme ? "dark" : "light";
     auto* connection = x11::Connection::Get();
     connection->SetStringProperty(
@@ -551,7 +545,7 @@ void NativeWindowViews::Show() {
 
   // On X11, setting Z order before showing the window doesn't take effect,
   // so we have to call it again.
-  if (IsX11())
+  if (x11_util::IsX11())
     widget()->SetZOrderLevel(widget()->GetZOrderLevel());
 #endif
 }
@@ -567,7 +561,7 @@ void NativeWindowViews::ShowInactive() {
 
   // On X11, setting Z order before showing the window doesn't take effect,
   // so we have to call it again.
-  if (IsX11())
+  if (x11_util::IsX11())
     widget()->SetZOrderLevel(widget()->GetZOrderLevel());
 #endif
 }
@@ -612,7 +606,7 @@ bool NativeWindowViews::IsEnabled() const {
 #if BUILDFLAG(IS_WIN)
   return ::IsWindowEnabled(GetAcceleratedWidget());
 #elif BUILDFLAG(IS_LINUX)
-  if (IsX11())
+  if (x11_util::IsX11())
     return !event_disabler_.get();
   NOTIMPLEMENTED();
   return true;
@@ -649,7 +643,7 @@ void NativeWindowViews::SetEnabledInternal(bool enable) {
 #if BUILDFLAG(IS_WIN)
   ::EnableWindow(GetAcceleratedWidget(), enable);
 #else
-  if (IsX11()) {
+  if (x11_util::IsX11()) {
     views::DesktopWindowTreeHostPlatform* tree_host =
         views::DesktopWindowTreeHostLinux::GetHostForWidget(
             GetAcceleratedWidget());
@@ -981,7 +975,7 @@ bool NativeWindowViews::MoveAbove(const std::string& sourceId) {
                  0, 0, 0,
                  SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
 #else
-  if (IsX11()) {
+  if (x11_util::IsX11()) {
     if (!IsWindowValid(static_cast<x11::Window>(id.id)))
       return false;
 
@@ -1003,7 +997,7 @@ void NativeWindowViews::MoveTop() {
                  size.width(), size.height(),
                  SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
 #else
-  if (IsX11())
+  if (x11_util::IsX11())
     electron::MoveWindowToForeground(
         static_cast<x11::Window>(GetAcceleratedWidget()));
 #endif
@@ -1318,7 +1312,7 @@ void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
     SetForwardMouseMessages(forward);
   }
 #else
-  if (IsX11()) {
+  if (x11_util::IsX11()) {
     auto* connection = x11::Connection::Get();
     if (ignore) {
       x11::Rectangle r{0, 0, 1, 1};
@@ -1440,7 +1434,7 @@ void NativeWindowViews::SetParentWindow(NativeWindow* parent) {
   NativeWindow::SetParentWindow(parent);
 
 #if BUILDFLAG(IS_LINUX)
-  if (IsX11()) {
+  if (x11_util::IsX11()) {
     auto* connection = x11::Connection::Get();
     connection->SetProperty(
         static_cast<x11::Window>(GetAcceleratedWidget()),

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1558,7 +1558,7 @@ bool NativeWindowViews::IsVisibleOnAllWorkspaces() const {
     return view_native_widget->IsVisibleOnAllWorkspaces();
 
 #if BUILDFLAG(IS_LINUX)
-  if (IsX11()) {
+  if (x11_util::IsX11()) {
     // Use the presence/absence of _NET_WM_STATE_STICKY in _NET_WM_STATE to
     // determine whether the current window is visible on all workspaces.
     x11::Atom sticky_atom = x11::GetAtom("_NET_WM_STATE_STICKY");


### PR DESCRIPTION
Backport of #46211

See that PR for details.


Notes: Added support for `screen.dipToScreenPoint(point)` and `screen.screenToDipPoint(point)` on Linux X11.
