### PR TITLE
refactor: add `NativeWindowViews::SetTitleBarOverlay()`

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -1093,64 +1093,8 @@ bool BaseWindow::IsSnapped() const {
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX)
 void BaseWindow::SetTitleBarOverlay(const gin_helper::Dictionary& options,
                                     gin_helper::Arguments* args) {
-  // Ensure WCO is already enabled on this window
-  if (!window_->IsWindowControlsOverlayEnabled()) {
-    args->ThrowError("Titlebar overlay is not enabled");
-    return;
-  }
-
-  auto* window = static_cast<NativeWindowViews*>(window_.get());
-  bool updated = false;
-
-  // Check and update the button color
-  std::string btn_color;
-  if (options.Get(options::kOverlayButtonColor, &btn_color)) {
-    // Parse the string as a CSS color
-    SkColor color;
-    if (!content::ParseCssColorString(btn_color, &color)) {
-      args->ThrowError("Could not parse color as CSS color");
-      return;
-    }
-
-    // Update the view
-    window->set_overlay_button_color(color);
-    updated = true;
-  }
-
-  // Check and update the symbol color
-  std::string symbol_color;
-  if (options.Get(options::kOverlaySymbolColor, &symbol_color)) {
-    // Parse the string as a CSS color
-    SkColor color;
-    if (!content::ParseCssColorString(symbol_color, &color)) {
-      args->ThrowError("Could not parse symbol color as CSS color");
-      return;
-    }
-
-    // Update the view
-    window->set_overlay_symbol_color(color);
-    updated = true;
-  }
-
-  // Check and update the height
-  int height = 0;
-  if (options.Get(options::kOverlayHeight, &height)) {
-    window->set_titlebar_overlay_height(height);
-    updated = true;
-  }
-
-  if (!updated)
-    return;
-
-  // If anything was updated, ensure the overlay is repainted.
-#if BUILDFLAG(IS_WIN)
-  auto* frame_view = static_cast<WinFrameView*>(
-      window->widget()->non_client_view()->frame_view());
-#else
-  auto* frame_view = static_cast<OpaqueFrameView*>(
-      window->widget()->non_client_view()->frame_view());
-#endif
-  frame_view->InvalidateCaptionButtons();
+  static_cast<NativeWindowViews*>(window_.get())
+      ->SetTitleBarOverlay(options, args);
 }
 #endif
 

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -393,9 +393,6 @@ class NativeWindow : public base::SupportsUserData,
   }
 
   int titlebar_overlay_height() const { return titlebar_overlay_height_; }
-  void set_titlebar_overlay_height(int height) {
-    titlebar_overlay_height_ = height;
-  }
 
   bool has_frame() const { return has_frame_; }
 
@@ -430,6 +427,10 @@ class NativeWindow : public base::SupportsUserData,
   void UpdateBackgroundThrottlingState();
 
  protected:
+  void set_titlebar_overlay_height(int height) {
+    titlebar_overlay_height_ = height;
+  }
+
   constexpr void set_has_frame(const bool val) { has_frame_ = val; }
 
   [[nodiscard]] constexpr bool is_closed() const { return is_closed_; }

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -506,18 +506,12 @@ void NativeWindowViews::SetTitleBarOverlay(
     updated = true;
   }
 
-  if (!updated)
-    return;
-
   // If anything was updated, ensure the overlay is repainted.
-#if BUILDFLAG(IS_WIN)
-  auto* frame_view =
-      static_cast<WinFrameView*>(widget()->non_client_view()->frame_view());
-#else
-  auto* frame_view =
-      static_cast<OpaqueFrameView*>(widget()->non_client_view()->frame_view());
-#endif
-  frame_view->InvalidateCaptionButtons();
+  if (updated) {
+    auto* frame_view =
+        static_cast<FramelessView*>(widget()->non_client_view()->frame_view());
+    frame_view->InvalidateCaptionButtons();
+  }
 }
 
 void NativeWindowViews::SetGTKDarkThemeEnabled(bool use_dark_theme) {

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -33,6 +33,7 @@
 #include "shell/browser/web_view_manager.h"
 #include "shell/common/electron_constants.h"
 #include "shell/common/gin_converters/image_converter.h"
+#include "shell/common/gin_helper/arguments.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/options_switches.h"
 #include "ui/aura/window_tree_host.h"
@@ -455,6 +456,68 @@ NativeWindowViews::~NativeWindowViews() {
   aura::Window* window = GetNativeWindow();
   if (window)
     window->RemovePreTargetHandler(this);
+}
+
+void NativeWindowViews::SetTitleBarOverlay(
+    const gin_helper::Dictionary& options,
+    gin_helper::Arguments* args) {
+  // Ensure WCO is already enabled on this window
+  if (!IsWindowControlsOverlayEnabled()) {
+    args->ThrowError("Titlebar overlay is not enabled");
+    return;
+  }
+
+  bool updated = false;
+
+  // Check and update the button color
+  std::string btn_color;
+  if (options.Get(options::kOverlayButtonColor, &btn_color)) {
+    // Parse the string as a CSS color
+    SkColor color;
+    if (!content::ParseCssColorString(btn_color, &color)) {
+      args->ThrowError("Could not parse color as CSS color");
+      return;
+    }
+
+    // Update the view
+    set_overlay_button_color(color);
+    updated = true;
+  }
+
+  // Check and update the symbol color
+  std::string symbol_color;
+  if (options.Get(options::kOverlaySymbolColor, &symbol_color)) {
+    // Parse the string as a CSS color
+    SkColor color;
+    if (!content::ParseCssColorString(symbol_color, &color)) {
+      args->ThrowError("Could not parse symbol color as CSS color");
+      return;
+    }
+
+    // Update the view
+    set_overlay_symbol_color(color);
+    updated = true;
+  }
+
+  // Check and update the height
+  int height = 0;
+  if (options.Get(options::kOverlayHeight, &height)) {
+    set_titlebar_overlay_height(height);
+    updated = true;
+  }
+
+  if (!updated)
+    return;
+
+  // If anything was updated, ensure the overlay is repainted.
+#if BUILDFLAG(IS_WIN)
+  auto* frame_view =
+      static_cast<WinFrameView*>(widget()->non_client_view()->frame_view());
+#else
+  auto* frame_view =
+      static_cast<OpaqueFrameView*>(widget()->non_client_view()->frame_view());
+#endif
+  frame_view->InvalidateCaptionButtons();
 }
 
 void NativeWindowViews::SetGTKDarkThemeEnabled(bool use_dark_theme) {

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -24,6 +24,10 @@
 #include "shell/browser/ui/win/taskbar_host.h"
 #endif
 
+namespace gin_helper {
+class Arguments;
+}  // namespace gin_helper
+
 namespace electron {
 
 #if BUILDFLAG(IS_LINUX)
@@ -149,6 +153,9 @@ class NativeWindowViews : public NativeWindow,
 
   void IncrementChildModals();
   void DecrementChildModals();
+
+  void SetTitleBarOverlay(const gin_helper::Dictionary& options,
+                          gin_helper::Arguments* args);
 
 #if BUILDFLAG(IS_WIN)
   // Catch-all message handling and filtering. Called before

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -179,15 +179,16 @@ class NativeWindowViews : public NativeWindow,
 #endif
 
   SkColor overlay_button_color() const { return overlay_button_color_; }
+  SkColor overlay_symbol_color() const { return overlay_symbol_color_; }
+
+ private:
   void set_overlay_button_color(SkColor color) {
     overlay_button_color_ = color;
   }
-  SkColor overlay_symbol_color() const { return overlay_symbol_color_; }
   void set_overlay_symbol_color(SkColor color) {
     overlay_symbol_color_ = color;
   }
 
- private:
   // views::WidgetObserver:
   void OnWidgetActivationChanged(views::Widget* widget, bool active) override;
   void OnWidgetBoundsChanged(views::Widget* widget,


### PR DESCRIPTION
#### Description of Change

This is part of a series to update the lifecycle of `NativeWindow::widget_` to use non-deprecated views API, e.g. using `views::Widget::MakeCloseSynchronous()`.

There's a lot of work to do first though. For example, we have a lot of code that calls `window->widget()->foo()` and it's nontrivial to figure out which code paths are reachable when `widget()` is `nullptr`. It's less error-prone to just remove the footguns, e.g. by reducing public use of `NativeWindow::widget()`.

---

This PR moves the implementation of `api::BaseWindow::SetTitleBarOverlay()` into a new method `NativeWindowViews::SetTitleBarOverlay()`. The main motivation to reduce public use of `NativeWindow::widget()`; but since code being moved fits better in `NativeWindowViews`, it improves data hiding in several ways:

- `api::BaseWindow` no longer needs to call `NativeWindow::widget()`
- `NativeWindowViews::set_overlay_button_color()` can be made private
- `NativeWindowVeiws::set_overlay_symbol_color()` can be made private
- `NativeWindow::set_titlebar_overlay_height()` can be made protected
- Improved demeter. `BaseWindow` no longer needs to know about Widget internals, e.g. it no longer calls  `NativeWindow::widget()->non_client_view()->frame_view()` and no longer needs to know what derived type it should use when downcasting that `NonClientFrameView*`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.