### PR TITLE
refactor: add NativeWindow::SetShape()

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -684,7 +684,7 @@ double BaseWindow::GetOpacity() const {
 }
 
 void BaseWindow::SetShape(const std::vector<gfx::Rect>& rects) {
-  window_->widget()->SetShape(std::make_unique<std::vector<gfx::Rect>>(rects));
+  window_->SetShape(rects);
 }
 
 void BaseWindow::SetRepresentedFilename(const std::string& filename) {

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -289,6 +289,10 @@ NativeWindow* NativeWindow::FromWidget(const views::Widget* widget) {
       widget->GetNativeWindowProperty(kNativeWindowKey.c_str()));
 }
 
+void NativeWindow::SetShape(const std::vector<gfx::Rect>& rects) {
+  widget()->SetShape(std::make_unique<std::vector<gfx::Rect>>(rects));
+}
+
 void NativeWindow::SetSize(const gfx::Size& size, bool animate) {
   SetBounds(gfx::Rect(GetPosition(), size), animate);
 }

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -101,9 +101,10 @@ class NativeWindow : public base::SupportsUserData,
   virtual bool IsMinimized() const = 0;
   virtual void SetFullScreen(bool fullscreen) = 0;
   virtual bool IsFullscreen() const = 0;
+
   virtual void SetBounds(const gfx::Rect& bounds, bool animate = false) = 0;
   virtual gfx::Rect GetBounds() const = 0;
-
+  void SetShape(const std::vector<gfx::Rect>& rects);
   void SetSize(const gfx::Size& size, bool animate = false);
   [[nodiscard]] gfx::Size GetSize() const;
 


### PR DESCRIPTION
#### Description of Change

Part 3 in a short series of PRs to reduce public use of `NativeWindow::widget()` so that it can be made into a protected method. See [Part 1](https://github.com/electron/electron/pull/47126) for discussion of why I want to do that.

---

This PR is a simple [demeter](https://en.wikipedia.org/wiki/Law_of_Demeter#In_object-oriented_programming) refactor to decouple `api::BaseWindow::SetShape()` from knowledge of `views::Widget`. Instead, it just  lets `NativeWindow` handle it by calling the new method `NativeWindow::SetShape()`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.