### PR TITLE
fix: fixed white flash on call to BrowserWindow.show

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -386,9 +386,6 @@ void BaseWindow::Show() {
 }
 
 void BaseWindow::ShowInactive() {
-  // This method doesn't make sense for modal window.
-  if (IsModal())
-    return;
   window_->ShowInactive();
 }
 

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -104,8 +104,8 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   virtual void Focus();
   virtual void Blur();
   bool IsFocused() const;
-  void Show();
-  void ShowInactive();
+  virtual void Show();
+  virtual void ShowInactive();
   void Hide();
   bool IsVisible() const;
   bool IsEnabled() const;

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -267,13 +267,25 @@ v8::Local<v8::Value> BrowserWindow::GetWebContents(v8::Isolate* isolate) {
 }
 
 void BrowserWindow::OnWindowShow() {
-  web_contents()->WasShown();
   BaseWindow::OnWindowShow();
 }
 
 void BrowserWindow::OnWindowHide() {
   web_contents()->WasOccluded();
   BaseWindow::OnWindowHide();
+}
+
+void BrowserWindow::Show() {
+  web_contents()->WasShown();
+  BaseWindow::Show();
+}
+
+void BrowserWindow::ShowInactive() {
+  // This method doesn't make sense for modal window.
+  if (IsModal())
+    return;
+  web_contents()->WasShown();
+  BaseWindow::ShowInactive();
 }
 
 // static

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -66,6 +66,8 @@ class BrowserWindow : public BaseWindow,
   void SetBackgroundColor(const std::string& color_name) override;
   void OnWindowShow() override;
   void OnWindowHide() override;
+  void Show() override;
+  void ShowInactive() override;
 
   // BrowserWindow APIs.
   void FocusOnWebView();


### PR DESCRIPTION
#### Description of Change
Fixes https://github.com/electron/electron/issues/47149 by showing native NSView corresponding to window's content view before showing the window on a call to `BrowserWindow.show`/`BrowserWindow.showInactive`.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: fixed white flash on call to BrowserWindow.show
