### PR TITLE
refactor: make `NativeWindow::has_client_frame_` const

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -127,17 +127,6 @@ NativeWindow::NativeWindow(const gin_helper::Dictionary& options,
   if (parent)
     options.Get("modal", &is_modal_);
 
-#if defined(USE_OZONE)
-  // Ozone X11 likes to prefer custom frames, but we don't need them unless
-  // on Wayland.
-  if (base::FeatureList::IsEnabled(features::kWaylandWindowDecorations) &&
-      !ui::OzonePlatform::GetInstance()
-           ->GetPlatformRuntimeProperties()
-           .supports_server_side_window_decorations) {
-    has_client_frame_ = true;
-  }
-#endif
-
   WindowList::AddWindow(this);
 }
 
@@ -835,6 +824,22 @@ bool NativeWindow::IsTranslucent() const {
 #endif
 
   return false;
+}
+
+// static
+bool NativeWindow::PlatformHasClientFrame() {
+#if defined(USE_OZONE)
+  // Ozone X11 likes to prefer custom frames,
+  // but we don't need them unless on Wayland.
+  static const bool has_client_frame =
+      base::FeatureList::IsEnabled(features::kWaylandWindowDecorations) &&
+      !ui::OzonePlatform::GetInstance()
+           ->GetPlatformRuntimeProperties()
+           .supports_server_side_window_decorations;
+  return has_client_frame;
+#else
+  return false;
+#endif
 }
 
 // static

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -397,7 +397,9 @@ class NativeWindow : public base::SupportsUserData,
 
   bool has_frame() const { return has_frame_; }
 
-  bool has_client_frame() const { return has_client_frame_; }
+  [[nodiscard]] constexpr bool has_client_frame() const {
+    return has_client_frame_;
+  }
   bool transparent() const { return transparent_; }
   bool enable_larger_than_screen() const { return enable_larger_than_screen_; }
 
@@ -478,6 +480,8 @@ class NativeWindow : public base::SupportsUserData,
   std::list<NativeWindow*> child_windows_;
 
  private:
+  static bool PlatformHasClientFrame();
+
   std::unique_ptr<views::Widget> widget_;
 
   static inline int32_t next_id_ = 0;
@@ -496,7 +500,7 @@ class NativeWindow : public base::SupportsUserData,
   // Whether window has standard frame, but it's drawn by Electron (the client
   // application) instead of the OS. Currently only has meaning on Linux for
   // Wayland hosts.
-  bool has_client_frame_ = false;
+  const bool has_client_frame_ = PlatformHasClientFrame();
 
   // Whether window is transparent.
   bool transparent_ = false;


### PR DESCRIPTION
#### Description of Change

Part of a general refactoring of `NativeWindow` to lock down its API, e.g. changing members from public to non-public and/or making them const.

This PR makes `NativeWindow::has_client_frame_` a `const` field since it never changes.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.