### PR TITLE
refactor: make `NativeWindow::pending_transitions_` a `base::queue`

### DIFF
--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -8,11 +8,11 @@
 #include <list>
 #include <memory>
 #include <optional>
-#include <queue>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#include "base/containers/queue.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
@@ -471,7 +471,8 @@ class NativeWindow : public base::SupportsUserData,
   // on HiDPI displays on some environments.
   std::optional<extensions::SizeConstraints> content_size_constraints_;
 
-  std::queue<bool> pending_transitions_;
+  base::queue<bool> pending_transitions_;
+
   FullScreenTransitionType fullscreen_transition_type_ =
       FullScreenTransitionType::kNone;
 


### PR DESCRIPTION
#### Description of Change

Follow the base/containers/README.md advice that "Chromium code should always use `base::circular_deque` or `base::queue` in preference to `std::deque` or `std::queue` due to memory usage and platform variation."

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.