### PR TITLE
build: update_depot_tools on initial install

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -15,6 +15,7 @@ runs:
       fi
       export BUILD_TOOLS_SHA=6e8526315ea3b4828882497e532b8340e64e053c
       npm i -g @electron/build-tools
+      e d update_depot_tools
       e auto-update disable
       e d auto-update disable
       if [ "$(expr substr $(uname -s) 1 10)" == "MSYS_NT-10" ]; then


### PR DESCRIPTION
Release builds have been seeing the error:
```
python3_bin_reldir.txt not found. need to initialize depot_tools by
running gclient, update_depot_tools or ensure_bootstrap.
``` 
(eg https://github.com/electron/electron/actions/runs/15114398562/job/42508751795#step:23:44284)

This PR ensures that python is setup for proper use from depot_tools which should eliminate this issue.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
