### PR TITLE
build: add ensure_bootstrap command to depot_tools install

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -15,6 +15,7 @@ runs:
       fi
       export BUILD_TOOLS_SHA=6e8526315ea3b4828882497e532b8340e64e053c
       npm i -g @electron/build-tools
+      e d ensure_bootstrap
       e auto-update disable
       e d auto-update disable
       if [ "$(expr substr $(uname -s) 1 10)" == "MSYS_NT-10" ]; then


### PR DESCRIPTION
#### Description of Change

Following up depot_tools discussion in another branch, testing the ensure_bootstrap command for depot_tools

Note: This is in draft because I think we're going to need a build_tools update ([à la update_depot_tools](https://github.com/electron/build-tools/blob/f2a960b4d82e6b5c9dbbd437378a39489f399c50/src/utils/depot-tools.js#L18)) as well to make this work correctly on Windows; will move to this ready once that's in

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
