### PR TITLE
fix: remove extra 'suspend'/'resume' handling from `powerMonitor`

### DIFF
--- a/shell/browser/api/electron_api_power_monitor_mac.mm
+++ b/shell/browser/api/electron_api_power_monitor_mac.mm
@@ -34,17 +34,6 @@
                            selector:@selector(onScreenUnlocked:)
                                name:@"com.apple.screenIsUnlocked"
                              object:nil];
-    // A notification that the workspace posts before the machine goes to sleep.
-    [distributed_center addObserver:self
-                           selector:@selector(isSuspending:)
-                               name:NSWorkspaceWillSleepNotification
-                             object:nil];
-    // A notification that the workspace posts when the machine wakes from
-    // sleep.
-    [distributed_center addObserver:self
-                           selector:@selector(isResuming:)
-                               name:NSWorkspaceDidWakeNotification
-                             object:nil];
 
     NSNotificationCenter* shared_center =
         [[NSWorkspace sharedWorkspace] notificationCenter];
@@ -71,18 +60,6 @@
 
 - (void)addEmitter:(electron::api::PowerMonitor*)monitor_ {
   self->emitters.push_back(monitor_);
-}
-
-- (void)isSuspending:(NSNotification*)notify {
-  for (auto* emitter : self->emitters) {
-    emitter->Emit("suspend");
-  }
-}
-
-- (void)isResuming:(NSNotification*)notify {
-  for (auto* emitter : self->emitters) {
-    emitter->Emit("resume");
-  }
 }
 
 - (void)onScreenLocked:(NSNotification*)notification {

--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -88,18 +88,6 @@ LRESULT CALLBACK PowerMonitor::WndProc(HWND hwnd,
                            base::Unretained(this)));
       }
     }
-  } else if (message == WM_POWERBROADCAST) {
-    if (wparam == PBT_APMRESUMEAUTOMATIC) {
-      content::GetUIThreadTaskRunner({})->PostTask(
-          FROM_HERE,
-          base::BindOnce([](PowerMonitor* pm) { pm->Emit("resume"); },
-                         base::Unretained(this)));
-    } else if (wparam == PBT_APMSUSPEND) {
-      content::GetUIThreadTaskRunner({})->PostTask(
-          FROM_HERE,
-          base::BindOnce([](PowerMonitor* pm) { pm->Emit("suspend"); },
-                         base::Unretained(this)));
-    }
   }
   return ::DefWindowProc(hwnd, message, wparam, lparam);
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/44252.

'suspend'/'resume' handling was added initially to `electron_api_power_monitor_{win|mac}` prior to `base::PowerSuspendObserver` being added upstream - these events are now emitted via `OnSuspend` and `OnResume` and the extra handling causes them to be emitted twice. On Windows, for example, resuming after sleeping shows:

```
The system is resuming
The system is resuming
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the 'suspend' and 'resume' events could be emitted in duplicate.