### PR TITLE
refactor: prefer `base::circular_deque` over `std::deque`

### DIFF
--- a/shell/browser/net/resolve_proxy_helper.h
+++ b/shell/browser/net/resolve_proxy_helper.h
@@ -5,10 +5,10 @@
 #ifndef ELECTRON_SHELL_BROWSER_NET_RESOLVE_PROXY_HELPER_H_
 #define ELECTRON_SHELL_BROWSER_NET_RESOLVE_PROXY_HELPER_H_
 
-#include <deque>
 #include <optional>
 #include <string>
 
+#include "base/containers/circular_deque.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/ref_counted.h"
 #include "mojo/public/cpp/bindings/receiver.h"
@@ -66,7 +66,7 @@ class ResolveProxyHelper
   // Self-reference. Owned as long as there's an outstanding proxy lookup.
   scoped_refptr<ResolveProxyHelper> owned_self_;
 
-  std::deque<PendingRequest> pending_requests_;
+  base::circular_deque<PendingRequest> pending_requests_;
   // Receiver for the currently in-progress request, if any.
   mojo::Receiver<network::mojom::ProxyLookupClient> receiver_{this};
 

--- a/shell/common/crash_keys.cc
+++ b/shell/common/crash_keys.cc
@@ -5,11 +5,11 @@
 #include "shell/common/crash_keys.h"
 
 #include <cstdint>
-#include <deque>
 #include <map>
 #include <string>
 
 #include "base/command_line.h"
+#include "base/containers/circular_deque.h"
 #include "base/environment.h"
 #include "base/no_destructor.h"
 #include "base/strings/strcat.h"
@@ -28,19 +28,17 @@ namespace electron::crash_keys {
 
 namespace {
 
-constexpr size_t kMaxCrashKeyValueSize = 20320;
-static_assert(kMaxCrashKeyValueSize < crashpad::Annotation::kValueMaxSize,
-              "max crash key value length above what crashpad supports");
-
-using ExtraCrashKeys =
-    std::deque<crash_reporter::CrashKeyString<kMaxCrashKeyValueSize>>;
-ExtraCrashKeys& GetExtraCrashKeys() {
-  static base::NoDestructor<ExtraCrashKeys> extra_keys;
+auto& GetExtraCrashKeys() {
+  constexpr size_t kMaxCrashKeyValueSize = 20320;
+  static_assert(kMaxCrashKeyValueSize < crashpad::Annotation::kValueMaxSize,
+                "max crash key value length above what crashpad supports");
+  using CrashKeyString = crash_reporter::CrashKeyString<kMaxCrashKeyValueSize>;
+  static base::NoDestructor<base::circular_deque<CrashKeyString>> extra_keys;
   return *extra_keys;
 }
 
-std::deque<std::string>& GetExtraCrashKeyNames() {
-  static base::NoDestructor<std::deque<std::string>> crash_key_names;
+auto& GetExtraCrashKeyNames() {
+  static base::NoDestructor<base::circular_deque<std::string>> crash_key_names;
   return *crash_key_names;
 }
 


### PR DESCRIPTION
#### Description of Change

A companion PR to https://github.com/electron/electron/pull/47157 to follow [Chromium's usage advice](https://chromium.googlesource.com/chromium/src/+/main/base/containers/README.md#deque-usage-advice).

That PR migrated `std::queue` use; this one migrates `std::deque`:

> Chromium code should always use `base::circular_deque` or `base::queue` in preference to `std::deque` or `std::queue` due to memory usage and platform variation.
>
> The `base::circular_deque` implementation (and the `base::queue` which uses it) provide performance consistent across platforms that better matches most programmer‘s expectations on performance (it doesn’t waste as much space as libc++ and doesn't do as many heap allocations as MSVC). It also generates less code than std::queue: using it across the code base saves several hundred kilobytes.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.