### PR TITLE
refactor: make `NativeWindow::transparent_` const

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -97,7 +97,7 @@ gfx::Size GetExpandedWindowSize(const NativeWindow* window, gfx::Size size) {
 
 NativeWindow::NativeWindow(const gin_helper::Dictionary& options,
                            NativeWindow* parent)
-    : widget_(std::make_unique<views::Widget>()), parent_(parent) {
+    : parent_(parent) {
   options.Get(options::kFrame, &has_frame_);
   options.Get(options::kTransparent, &transparent_);
   options.Get(options::kEnableLargerThanScreen, &enable_larger_than_screen_);

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -97,10 +97,11 @@ gfx::Size GetExpandedWindowSize(const NativeWindow* window, gfx::Size size) {
 
 NativeWindow::NativeWindow(const gin_helper::Dictionary& options,
                            NativeWindow* parent)
-    : parent_(parent) {
+    : transparent_{options.ValueOrDefault(options::kTransparent, false)},
+      enable_larger_than_screen_{
+          options.ValueOrDefault(options::kEnableLargerThanScreen, false)},
+      parent_{parent} {
   options.Get(options::kFrame, &has_frame_);
-  options.Get(options::kTransparent, &transparent_);
-  options.Get(options::kEnableLargerThanScreen, &enable_larger_than_screen_);
   options.Get(options::kTitleBarStyle, &title_bar_style_);
 #if BUILDFLAG(IS_WIN)
   options.Get(options::kBackgroundMaterial, &background_material_);

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -397,7 +397,6 @@ class NativeWindow : public base::SupportsUserData,
 
   bool has_frame() const { return has_frame_; }
 
-
   [[nodiscard]] bool has_client_frame() const { return has_client_frame_; }
 
   [[nodiscard]] bool transparent() const { return transparent_; }

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -482,7 +482,7 @@ class NativeWindow : public base::SupportsUserData,
  private:
   static bool PlatformHasClientFrame();
 
-  std::unique_ptr<views::Widget> widget_;
+  std::unique_ptr<views::Widget> widget_ = std::make_unique<views::Widget>();
 
   static inline int32_t next_id_ = 0;
   const int32_t window_id_ = ++next_id_;

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -397,10 +397,14 @@ class NativeWindow : public base::SupportsUserData,
 
   bool has_frame() const { return has_frame_; }
 
+
   [[nodiscard]] bool has_client_frame() const { return has_client_frame_; }
 
-  bool transparent() const { return transparent_; }
-  bool enable_larger_than_screen() const { return enable_larger_than_screen_; }
+  [[nodiscard]] bool transparent() const { return transparent_; }
+
+  [[nodiscard]] bool enable_larger_than_screen() const {
+    return enable_larger_than_screen_;
+  }
 
   NativeWindow* parent() const { return parent_; }
   bool is_modal() const { return is_modal_; }
@@ -487,6 +491,12 @@ class NativeWindow : public base::SupportsUserData,
   static inline int32_t next_id_ = 0;
   const int32_t window_id_ = ++next_id_;
 
+  // Whether window is transparent.
+  const bool transparent_;
+
+  // Whether window can be resized larger than screen.
+  const bool enable_larger_than_screen_;
+
   // The content view, weak ref.
   raw_ptr<views::View> content_view_ = nullptr;
 
@@ -501,12 +511,6 @@ class NativeWindow : public base::SupportsUserData,
   // application) instead of the OS. Currently only has meaning on Linux for
   // Wayland hosts.
   const bool has_client_frame_ = PlatformHasClientFrame();
-
-  // Whether window is transparent.
-  bool transparent_ = false;
-
-  // Whether window can be resized larger than screen.
-  bool enable_larger_than_screen_ = false;
 
   // The windows has been closed.
   bool is_closed_ = false;


### PR DESCRIPTION
#### Description of Change

Companion refactor to https://github.com/electron/electron/pull/47156 that makes more fields const. This PR:

- Makes `NativeWindow::enable_larger_than_screen_` const
- Makes `NativeWindow::transparent_` const
- Annotates `NativeWindow::enable_larger_than_screen()` as `[[nodiscard]]`
- Annotates `NativeWindow::transparent()` as `[[nodiscard]]`
- Uses in-class member initialization for `NativeWindow::widget_`

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.