### PR TITLE
refactor: pass views::Widget* into constructors of our TreeHosts and NativeWidgets

### DIFF
--- a/shell/browser/api/electron_api_menu_views.cc
+++ b/shell/browser/api/electron_api_menu_views.cc
@@ -27,7 +27,7 @@ void MenuViews::PopupAt(BaseWindow* window,
                         int positioning_item,
                         ui::mojom::MenuSourceType source_type,
                         base::OnceClosure callback) {
-  auto* native_window = static_cast<NativeWindowViews*>(window->window());
+  const NativeWindow* native_window = window->window();
   if (!native_window)
     return;
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -304,7 +304,7 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
   auto* native_widget = new views::DesktopNativeWidgetAura(widget());
   params.native_widget = native_widget;
   params.desktop_window_tree_host =
-      new ElectronDesktopWindowTreeHostLinux(this, native_widget);
+      new ElectronDesktopWindowTreeHostLinux{this, widget(), native_widget};
 #endif
 
   widget()->Init(std::move(params));

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -290,7 +290,7 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
   if (parent)
     params.parent = parent->GetNativeWindow();
 
-  params.native_widget = new ElectronDesktopNativeWidgetAura(this);
+  params.native_widget = new ElectronDesktopNativeWidgetAura{this, widget()};
 #elif BUILDFLAG(IS_LINUX)
   std::string name = Browser::Get()->GetName();
   // Set WM_WINDOW_ROLE.

--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
@@ -33,10 +33,10 @@ namespace electron {
 
 ElectronDesktopWindowTreeHostLinux::ElectronDesktopWindowTreeHostLinux(
     NativeWindowViews* native_window_view,
+    views::Widget* widget,
     views::DesktopNativeWidgetAura* desktop_native_widget_aura)
-    : views::DesktopWindowTreeHostLinux(native_window_view->widget(),
-                                        desktop_native_widget_aura),
-      native_window_view_(native_window_view) {}
+    : views::DesktopWindowTreeHostLinux{widget, desktop_native_widget_aura},
+      native_window_view_{native_window_view} {}
 
 ElectronDesktopWindowTreeHostLinux::~ElectronDesktopWindowTreeHostLinux() =
     default;

--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.h
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.h
@@ -29,6 +29,7 @@ class ElectronDesktopWindowTreeHostLinux
  public:
   ElectronDesktopWindowTreeHostLinux(
       NativeWindowViews* native_window_view,
+      views::Widget* widget,
       views::DesktopNativeWidgetAura* desktop_native_widget_aura);
   ~ElectronDesktopWindowTreeHostLinux() override;
 

--- a/shell/browser/ui/win/electron_desktop_native_widget_aura.cc
+++ b/shell/browser/ui/win/electron_desktop_native_widget_aura.cc
@@ -19,7 +19,7 @@ ElectronDesktopNativeWidgetAura::ElectronDesktopNativeWidgetAura(
     : views::DesktopNativeWidgetAura{widget},
       native_window_view_{native_window_view},
       desktop_window_tree_host_{new ElectronDesktopWindowTreeHostWin{
-          native_winodw_view_, widget, this}} {
+          native_window_view, widget, this}} {
   GetNativeWindow()->SetName("ElectronDesktopNativeWidgetAura");
   // This is to enable the override of OnWindowActivated
   wm::SetActivationChangeObserver(GetNativeWindow(), this);

--- a/shell/browser/ui/win/electron_desktop_native_widget_aura.cc
+++ b/shell/browser/ui/win/electron_desktop_native_widget_aura.cc
@@ -26,7 +26,7 @@ ElectronDesktopNativeWidgetAura::ElectronDesktopNativeWidgetAura(
 void ElectronDesktopNativeWidgetAura::InitNativeWidget(
     views::Widget::InitParams params) {
   desktop_window_tree_host_ = new ElectronDesktopWindowTreeHostWin(
-      native_window_view_,
+      native_window_view_, native_window_view_.widget(),
       static_cast<views::DesktopNativeWidgetAura*>(params.native_widget));
   params.desktop_window_tree_host = desktop_window_tree_host_;
   views::DesktopNativeWidgetAura::InitNativeWidget(std::move(params));

--- a/shell/browser/ui/win/electron_desktop_native_widget_aura.cc
+++ b/shell/browser/ui/win/electron_desktop_native_widget_aura.cc
@@ -17,7 +17,9 @@ ElectronDesktopNativeWidgetAura::ElectronDesktopNativeWidgetAura(
     NativeWindowViews* native_window_view,
     views::Widget* widget)
     : views::DesktopNativeWidgetAura{widget},
-      native_window_view_{native_window_view} {
+      native_window_view_{native_window_view},
+      desktop_window_tree_host_{new ElectronDesktopWindowTreeHostWin{
+          native_winodw_view_, widget, this}} {
   GetNativeWindow()->SetName("ElectronDesktopNativeWidgetAura");
   // This is to enable the override of OnWindowActivated
   wm::SetActivationChangeObserver(GetNativeWindow(), this);
@@ -25,9 +27,7 @@ ElectronDesktopNativeWidgetAura::ElectronDesktopNativeWidgetAura(
 
 void ElectronDesktopNativeWidgetAura::InitNativeWidget(
     views::Widget::InitParams params) {
-  desktop_window_tree_host_ = new ElectronDesktopWindowTreeHostWin(
-      native_window_view_, native_window_view_.widget(),
-      static_cast<views::DesktopNativeWidgetAura*>(params.native_widget));
+  CHECK_EQ(params.native_widget, this);
   params.desktop_window_tree_host = desktop_window_tree_host_;
   views::DesktopNativeWidgetAura::InitNativeWidget(std::move(params));
 }

--- a/shell/browser/ui/win/electron_desktop_native_widget_aura.cc
+++ b/shell/browser/ui/win/electron_desktop_native_widget_aura.cc
@@ -14,9 +14,10 @@
 namespace electron {
 
 ElectronDesktopNativeWidgetAura::ElectronDesktopNativeWidgetAura(
-    NativeWindowViews* native_window_view)
-    : views::DesktopNativeWidgetAura(native_window_view->widget()),
-      native_window_view_(native_window_view) {
+    NativeWindowViews* native_window_view,
+    views::Widget* widget)
+    : views::DesktopNativeWidgetAura{widget},
+      native_window_view_{native_window_view} {
   GetNativeWindow()->SetName("ElectronDesktopNativeWidgetAura");
   // This is to enable the override of OnWindowActivated
   wm::SetActivationChangeObserver(GetNativeWindow(), this);

--- a/shell/browser/ui/win/electron_desktop_native_widget_aura.h
+++ b/shell/browser/ui/win/electron_desktop_native_widget_aura.h
@@ -18,7 +18,8 @@ class NativeWindowViews;
 class ElectronDesktopNativeWidgetAura : public views::DesktopNativeWidgetAura {
  public:
   explicit ElectronDesktopNativeWidgetAura(
-      NativeWindowViews* native_window_view);
+      NativeWindowViews* native_window_view,
+      views::Widget* widget);
 
   // disable copy
   ElectronDesktopNativeWidgetAura(const ElectronDesktopNativeWidgetAura&) =

--- a/shell/browser/ui/win/electron_desktop_native_widget_aura.h
+++ b/shell/browser/ui/win/electron_desktop_native_widget_aura.h
@@ -41,10 +41,10 @@ class ElectronDesktopNativeWidgetAura : public views::DesktopNativeWidgetAura {
                          aura::Window* gained_active,
                          aura::Window* lost_active) override;
 
-  raw_ptr<NativeWindowViews> native_window_view_;
+  const raw_ptr<NativeWindowViews> native_window_view_;
 
   // Owned by DesktopNativeWidgetAura.
-  raw_ptr<views::DesktopWindowTreeHost> desktop_window_tree_host_;
+  const raw_ptr<views::DesktopWindowTreeHost> desktop_window_tree_host_;
 };
 
 }  // namespace electron

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -16,10 +16,10 @@ namespace electron {
 
 ElectronDesktopWindowTreeHostWin::ElectronDesktopWindowTreeHostWin(
     NativeWindowViews* native_window_view,
+    views::Widget* widget,
     views::DesktopNativeWidgetAura* desktop_native_widget_aura)
-    : views::DesktopWindowTreeHostWin(native_window_view->widget(),
-                                      desktop_native_widget_aura),
-      native_window_view_(native_window_view) {}
+    : views::DesktopWindowTreeHostWin{widget, desktop_native_widget_aura},
+      native_window_view_{native_window_view} {}
 
 ElectronDesktopWindowTreeHostWin::~ElectronDesktopWindowTreeHostWin() = default;
 

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
@@ -20,6 +20,7 @@ class ElectronDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin,
  public:
   ElectronDesktopWindowTreeHostWin(
       NativeWindowViews* native_window_view,
+      views::Widget* widget,
       views::DesktopNativeWidgetAura* desktop_native_widget_aura);
   ~ElectronDesktopWindowTreeHostWin() override;
 


### PR DESCRIPTION
#### Description of Change

Part 5 in a short series of PRs to reduce public use of `NativeWindow::widget()` so that it can be made into a protected method. See [Part 1](https://github.com/electron/electron/pull/47126) for discussion of why I want to do that.

---

In this PR, we pass the `views::Widget*` into the constructor methods of our bespoke TreeHosts and NativeWidgets instead of calling `NativeWindow::widget()` in those methods.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.