### PR TITLE
test: strip color output in ESM spec

### DIFF
--- a/spec/esm-spec.ts
+++ b/spec/esm-spec.ts
@@ -7,6 +7,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { stripVTControlCharacters } from 'node:util';
 
 const runFixture = async (appPath: string, args: string[] = []) => {
   const result = cp.spawn(process.execPath, [appPath, ...args], {
@@ -27,8 +28,8 @@ const runFixture = async (appPath: string, args: string[] = []) => {
   return {
     code,
     signal,
-    stdout: Buffer.concat(stdout).toString().trim(),
-    stderr: Buffer.concat(stderr).toString().trim()
+    stdout: stripVTControlCharacters(Buffer.concat(stdout).toString().trim()),
+    stderr: stripVTControlCharacters(Buffer.concat(stderr).toString().trim())
   };
 };
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Ran into this when running these tests under VS Code, `FORCE_COLOR` would be set which caused ANSI escape codes to be present in the output and fail the test.  Node.js provides a nice little util for exactly this situation.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
