### PR TITLE
build: fix depot tool pathing on Windows

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -15,12 +15,16 @@ runs:
       fi
       export BUILD_TOOLS_SHA=6e8526315ea3b4828882497e532b8340e64e053c
       npm i -g @electron/build-tools
+      # Update depot_tools to ensure python
       e d update_depot_tools
       e auto-update disable
+      # Disable further updates of depot_tools
       e d auto-update disable
       if [ "$(expr substr $(uname -s) 1 10)" == "MSYS_NT-10" ]; then
         e d cipd.bat --version
         cp "C:\Python311\python.exe" "C:\Python311\python3.exe"
+        echo "C:\Users\ContainerAdministrator\.electron_build_tools\third_party\depot_tools" >> $GITHUB_PATH
+      else
+        echo "$HOME/.electron_build_tools/third_party/depot_tools" >> $GITHUB_PATH
+        echo "$HOME/.electron_build_tools/third_party/depot_tools/python-bin" >> $GITHUB_PATH
       fi
-      echo "$HOME/.electron_build_tools/third_party/depot_tools" >> $GITHUB_PATH
-      echo "$HOME/.electron_build_tools/third_party/depot_tools/python-bin" >> $GITHUB_PATH


### PR DESCRIPTION
#### Description of Change
- Followup to #47160.  Unfortunately that PR did not fix the issue as it turns out the issue is caused by depot_tools being preinstalled on the widows runner image.  This PR fixes the underlying issue by properly setting the path to the depot_tools installed as part of the build which will then resolve this error:
```
python3_bin_reldir.txt not found. need to initialize depot_tools by
running gclient, update_depot_tools or ensure_bootstrap.
```

Verified by building ffmpeg for a testing build here: https://github.com/electron/electron/actions/runs/15171656549/job/42663073571?pr=47194#step:23:43892

Once this PR makes it way through all supported branches, we can remove depot_tools from the windows runner image by reapplying https://github.com/electron/infra/pull/120
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
