### PR TITLE
refactor: make `NativeWindow::has_frame_` const

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -100,6 +100,7 @@ NativeWindow::NativeWindow(const gin_helper::Dictionary& options,
     : transparent_{options.ValueOrDefault(options::kTransparent, false)},
       enable_larger_than_screen_{
           options.ValueOrDefault(options::kEnableLargerThanScreen, false)},
+      is_modal_{parent != nullptr && options.ValueOrDefault("modal", false)},
       parent_{parent} {
   options.Get(options::kFrame, &has_frame_);
   options.Get(options::kTitleBarStyle, &title_bar_style_);
@@ -124,9 +125,6 @@ NativeWindow::NativeWindow(const gin_helper::Dictionary& options,
         titlebar_overlay_height_ = height;
     }
   }
-
-  if (parent)
-    options.Get("modal", &is_modal_);
 
   WindowList::AddWindow(this);
 }

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -97,13 +97,14 @@ gfx::Size GetExpandedWindowSize(const NativeWindow* window, gfx::Size size) {
 
 NativeWindow::NativeWindow(const gin_helper::Dictionary& options,
                            NativeWindow* parent)
-    : transparent_{options.ValueOrDefault(options::kTransparent, false)},
+    : title_bar_style_{options.ValueOrDefault(options::kTitleBarStyle,
+                                              TitleBarStyle::kNormal)},
+      transparent_{options.ValueOrDefault(options::kTransparent, false)},
       enable_larger_than_screen_{
           options.ValueOrDefault(options::kEnableLargerThanScreen, false)},
       is_modal_{parent != nullptr && options.ValueOrDefault("modal", false)},
       parent_{parent} {
   options.Get(options::kFrame, &has_frame_);
-  options.Get(options::kTitleBarStyle, &title_bar_style_);
 #if BUILDFLAG(IS_WIN)
   options.Get(options::kBackgroundMaterial, &background_material_);
 #elif BUILDFLAG(IS_MAC)

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -103,8 +103,9 @@ NativeWindow::NativeWindow(const gin_helper::Dictionary& options,
       enable_larger_than_screen_{
           options.ValueOrDefault(options::kEnableLargerThanScreen, false)},
       is_modal_{parent != nullptr && options.ValueOrDefault("modal", false)},
+      has_frame_{options.ValueOrDefault(options::kFrame, true) &&
+                 title_bar_style_ == TitleBarStyle::kNormal},
       parent_{parent} {
-  options.Get(options::kFrame, &has_frame_);
 #if BUILDFLAG(IS_WIN)
   options.Get(options::kBackgroundMaterial, &background_material_);
 #elif BUILDFLAG(IS_MAC)

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -399,10 +399,6 @@ class NativeWindow : public base::SupportsUserData,
 
   bool has_frame() const { return has_frame_; }
 
-  [[nodiscard]] bool has_client_frame() const { return has_client_frame_; }
-
-  [[nodiscard]] bool transparent() const { return transparent_; }
-
   [[nodiscard]] bool enable_larger_than_screen() const {
     return enable_larger_than_screen_;
   }
@@ -441,7 +437,11 @@ class NativeWindow : public base::SupportsUserData,
 
   constexpr void set_has_frame(const bool val) { has_frame_ = val; }
 
-  [[nodiscard]] constexpr bool is_closed() const { return is_closed_; }
+  [[nodiscard]] bool has_client_frame() const { return has_client_frame_; }
+
+  [[nodiscard]] bool transparent() const { return transparent_; }
+
+  [[nodiscard]] bool is_closed() const { return is_closed_; }
 
   NativeWindow(const gin_helper::Dictionary& options, NativeWindow* parent);
 

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -406,7 +406,8 @@ class NativeWindow : public base::SupportsUserData,
   }
 
   NativeWindow* parent() const { return parent_; }
-  bool is_modal() const { return is_modal_; }
+
+  [[nodiscard]] bool is_modal() const { return is_modal_; }
 
   [[nodiscard]] constexpr int32_t window_id() const { return window_id_; }
 
@@ -490,11 +491,19 @@ class NativeWindow : public base::SupportsUserData,
   static inline int32_t next_id_ = 0;
   const int32_t window_id_ = ++next_id_;
 
+  // Whether window has standard frame, but it's drawn by Electron (the client
+  // application) instead of the OS. Currently only has meaning on Linux for
+  // Wayland hosts.
+  const bool has_client_frame_ = PlatformHasClientFrame();
+
   // Whether window is transparent.
   const bool transparent_;
 
   // Whether window can be resized larger than screen.
   const bool enable_larger_than_screen_;
+
+  // Is this a modal window.
+  const bool is_modal_;
 
   // The content view, weak ref.
   raw_ptr<views::View> content_view_ = nullptr;
@@ -505,11 +514,6 @@ class NativeWindow : public base::SupportsUserData,
 
   // Whether window has standard frame.
   bool has_frame_ = true;
-
-  // Whether window has standard frame, but it's drawn by Electron (the client
-  // application) instead of the OS. Currently only has meaning on Linux for
-  // Wayland hosts.
-  const bool has_client_frame_ = PlatformHasClientFrame();
 
   // The windows has been closed.
   bool is_closed_ = false;
@@ -526,9 +530,6 @@ class NativeWindow : public base::SupportsUserData,
 
   // The parent window, it is guaranteed to be valid during this window's life.
   raw_ptr<NativeWindow> parent_ = nullptr;
-
-  // Is this a modal window.
-  bool is_modal_ = false;
 
   bool is_transitioning_fullscreen_ = false;
 

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -374,14 +374,16 @@ class NativeWindow : public base::SupportsUserData,
   views::Widget* widget() const { return widget_.get(); }
   views::View* content_view() const { return content_view_; }
 
-  enum class TitleBarStyle {
+  enum class TitleBarStyle : uint8_t {
     kNormal,
     kHidden,
     kHiddenInset,
     kCustomButtonsOnHover,
   };
 
-  TitleBarStyle title_bar_style() const { return title_bar_style_; }
+  [[nodiscard]] TitleBarStyle title_bar_style() const {
+    return title_bar_style_;
+  }
 
   bool IsWindowControlsOverlayEnabled() const {
     bool valid_titlebar_style = title_bar_style() == TitleBarStyle::kHidden
@@ -466,9 +468,6 @@ class NativeWindow : public base::SupportsUserData,
   // The boolean parsing of the "titleBarOverlay" option
   bool titlebar_overlay_ = false;
 
-  // The "titleBarStyle" option.
-  TitleBarStyle title_bar_style_ = TitleBarStyle::kNormal;
-
   // Minimum and maximum size.
   std::optional<extensions::SizeConstraints> size_constraints_;
   // Same as above but stored as content size, we are storing 2 types of size
@@ -490,6 +489,9 @@ class NativeWindow : public base::SupportsUserData,
 
   static inline int32_t next_id_ = 0;
   const int32_t window_id_ = ++next_id_;
+
+  // The "titleBarStyle" option.
+  const TitleBarStyle title_bar_style_;
 
   // Whether window has standard frame, but it's drawn by Electron (the client
   // application) instead of the OS. Currently only has meaning on Linux for

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -397,7 +397,7 @@ class NativeWindow : public base::SupportsUserData,
 
   int titlebar_overlay_height() const { return titlebar_overlay_height_; }
 
-  bool has_frame() const { return has_frame_; }
+  [[nodiscard]] bool has_frame() const { return has_frame_; }
 
   NativeWindow* parent() const { return parent_; }
 
@@ -427,11 +427,11 @@ class NativeWindow : public base::SupportsUserData,
   void UpdateBackgroundThrottlingState();
 
  protected:
+  NativeWindow(const gin_helper::Dictionary& options, NativeWindow* parent);
+
   void set_titlebar_overlay_height(int height) {
     titlebar_overlay_height_ = height;
   }
-
-  constexpr void set_has_frame(const bool val) { has_frame_ = val; }
 
   [[nodiscard]] bool has_client_frame() const { return has_client_frame_; }
 
@@ -442,8 +442,6 @@ class NativeWindow : public base::SupportsUserData,
   [[nodiscard]] bool enable_larger_than_screen() const {
     return enable_larger_than_screen_;
   }
-
-  NativeWindow(const gin_helper::Dictionary& options, NativeWindow* parent);
 
   virtual void OnTitleChanged() {}
 
@@ -507,15 +505,15 @@ class NativeWindow : public base::SupportsUserData,
   // Is this a modal window.
   const bool is_modal_;
 
+  // Whether window has standard frame.
+  const bool has_frame_;
+
   // The content view, weak ref.
   raw_ptr<views::View> content_view_ = nullptr;
 
   // The custom height parsed from the "height" option in a Object
   // "titleBarOverlay"
   int titlebar_overlay_height_ = 0;
-
-  // Whether window has standard frame.
-  bool has_frame_ = true;
 
   // The windows has been closed.
   bool is_closed_ = false;

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -399,10 +399,6 @@ class NativeWindow : public base::SupportsUserData,
 
   bool has_frame() const { return has_frame_; }
 
-  [[nodiscard]] bool enable_larger_than_screen() const {
-    return enable_larger_than_screen_;
-  }
-
   NativeWindow* parent() const { return parent_; }
 
   [[nodiscard]] bool is_modal() const { return is_modal_; }
@@ -442,6 +438,10 @@ class NativeWindow : public base::SupportsUserData,
   [[nodiscard]] bool transparent() const { return transparent_; }
 
   [[nodiscard]] bool is_closed() const { return is_closed_; }
+
+  [[nodiscard]] bool enable_larger_than_screen() const {
+    return enable_larger_than_screen_;
+  }
 
   NativeWindow(const gin_helper::Dictionary& options, NativeWindow* parent);
 

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -152,7 +152,7 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
       options.ValueOrDefault(options::kPaintWhenInitiallyHidden, true);
 
   // The window without titlebar is treated the same with frameless window.
-  if (title_bar_style_ != TitleBarStyle::kNormal)
+  if (title_bar_style() != TitleBarStyle::kNormal)
     set_has_frame(false);
 
   NSUInteger styleMask = NSWindowStyleMaskTitled;
@@ -252,20 +252,20 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
     // https://github.com/electron/electron/issues/517.
     [window_ setOpaque:NO];
     // Show window buttons if titleBarStyle is not "normal".
-    if (title_bar_style_ == TitleBarStyle::kNormal) {
+    if (title_bar_style() == TitleBarStyle::kNormal) {
       InternalSetWindowButtonVisibility(false);
     } else {
       buttons_proxy_ = [[WindowButtonsProxy alloc] initWithWindow:window_];
       [buttons_proxy_ setHeight:titlebar_overlay_height()];
       if (traffic_light_position_) {
         [buttons_proxy_ setMargin:*traffic_light_position_];
-      } else if (title_bar_style_ == TitleBarStyle::kHiddenInset) {
+      } else if (title_bar_style() == TitleBarStyle::kHiddenInset) {
         // For macOS >= 11, while this value does not match official macOS apps
         // like Safari or Notes, it matches titleBarStyle's old implementation
         // before Electron <= 12.
         [buttons_proxy_ setMargin:gfx::Point(12, 11)];
       }
-      if (title_bar_style_ == TitleBarStyle::kCustomButtonsOnHover) {
+      if (title_bar_style() == TitleBarStyle::kCustomButtonsOnHover) {
         [buttons_proxy_ setShowOnHover:YES];
       } else {
         // customButtonsOnHover does not show buttons initially.
@@ -1053,7 +1053,7 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
       if (has_frame())
         visibility = true;
       else
-        visibility = title_bar_style_ != TitleBarStyle::kNormal;
+        visibility = title_bar_style() != TitleBarStyle::kNormal;
       InternalSetWindowButtonVisibility(visibility);
     }
 
@@ -1481,7 +1481,7 @@ void NativeWindowMac::SetWindowButtonVisibility(bool visible) {
     [buttons_proxy_ setVisible:visible];
   }
 
-  if (title_bar_style_ != TitleBarStyle::kCustomButtonsOnHover)
+  if (title_bar_style() != TitleBarStyle::kCustomButtonsOnHover)
     InternalSetWindowButtonVisibility(visible);
 
   NotifyLayoutWindowControlsOverlay();

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -151,10 +151,6 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   const bool paint_when_initially_hidden =
       options.ValueOrDefault(options::kPaintWhenInitiallyHidden, true);
 
-  // The window without titlebar is treated the same with frameless window.
-  if (title_bar_style() != TitleBarStyle::kNormal)
-    set_has_frame(false);
-
   NSUInteger styleMask = NSWindowStyleMaskTitled;
 
   // The NSWindowStyleMaskFullSizeContentView style removes rounded corners

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -242,7 +242,7 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
   }
 
   // |hidden| is the only non-default titleBarStyle valid on Windows and Linux.
-  if (title_bar_style_ == TitleBarStyle::kHidden)
+  if (title_bar_style() == TitleBarStyle::kHidden)
     set_has_frame(false);
 
 #if BUILDFLAG(IS_WIN)

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -241,10 +241,6 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
     }
   }
 
-  // |hidden| is the only non-default titleBarStyle valid on Windows and Linux.
-  if (title_bar_style() == TitleBarStyle::kHidden)
-    set_has_frame(false);
-
 #if BUILDFLAG(IS_WIN)
   // If the taskbar is re-created after we start up, we have to rebuild all of
   // our buttons.


### PR DESCRIPTION
#### Description of Change

Continuing some low-hanging-fruit refactor work to constify some read-only fields in `NativeWindow`.

I'm constifying these fields to guarantee that the assumptions our code's already making are safe assumptions. For example, `NativeWindow::has_frame_` is used to decide which subclass of `views::NonClientFrameView` to instantiate in `NativeWindowViews::CreateNonClientFrameView()` and then later to safely downcast it in `NativeWindowViews::GetClientFrameViewLinux()`. So we definitely don't want `has_frame_` changing during runtime :boom: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.