### PR TITLE
refactor: add `gin_helper::Dictionary::ValueOrDefault()` (35-x-y)

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -153,17 +153,17 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
     Center();
   }
 
-  bool use_content_size = false;
-  options.Get(options::kUseContentSize, &use_content_size);
+  const bool use_content_size =
+      options.ValueOrDefault(options::kUseContentSize, false);
 
   // On Linux and Window we may already have maximum size defined.
   extensions::SizeConstraints size_constraints(
       use_content_size ? GetContentSizeConstraints() : GetSizeConstraints());
 
-  int min_width = size_constraints.GetMinimumSize().width();
-  int min_height = size_constraints.GetMinimumSize().height();
-  options.Get(options::kMinWidth, &min_width);
-  options.Get(options::kMinHeight, &min_height);
+  const int min_width = options.ValueOrDefault(
+      options::kMinWidth, size_constraints.GetMinimumSize().width());
+  const int min_height = options.ValueOrDefault(
+      options::kMinHeight, size_constraints.GetMinimumSize().height());
   size_constraints.set_minimum_size(gfx::Size(min_width, min_height));
 
   gfx::Size max_size = size_constraints.GetMaximumSize();
@@ -263,9 +263,7 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
   SetTitle(title);
 
   // Then show it.
-  bool show = true;
-  options.Get(options::kShow, &show);
-  if (show)
+  if (options.ValueOrDefault(options::kShow, true))
     Show();
 }
 

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -120,42 +120,37 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   ui::NativeTheme::GetInstanceForNativeUi()->AddObserver(this);
   display::Screen::GetScreen()->AddObserver(this);
 
-  int width = 800, height = 600;
-  options.Get(options::kWidth, &width);
-  options.Get(options::kHeight, &height);
+  int width = options.ValueOrDefault(options::kWidth, 800);
+  int height = options.ValueOrDefault(options::kHeight, 600);
 
   NSRect main_screen_rect = [[[NSScreen screens] firstObject] frame];
   gfx::Rect bounds(round((NSWidth(main_screen_rect) - width) / 2),
                    round((NSHeight(main_screen_rect) - height) / 2), width,
                    height);
 
-  bool resizable = true;
-  options.Get(options::kResizable, &resizable);
+  const bool resizable = options.ValueOrDefault(options::kResizable, true);
   options.Get(options::kZoomToPageWidth, &zoom_to_page_width_);
   options.Get(options::kSimpleFullscreen, &always_simple_fullscreen_);
   options.GetOptional(options::kTrafficLightPosition, &traffic_light_position_);
   options.Get(options::kVisualEffectState, &visual_effect_state_);
 
-  bool minimizable = true;
-  options.Get(options::kMinimizable, &minimizable);
+  const bool minimizable = options.ValueOrDefault(options::kMinimizable, true);
 
-  bool maximizable = true;
-  options.Get(options::kMaximizable, &maximizable);
+  const bool maximizable = options.ValueOrDefault(options::kMaximizable, true);
 
-  bool closable = true;
-  options.Get(options::kClosable, &closable);
+  const bool closable = options.ValueOrDefault(options::kClosable, true);
 
-  std::string tabbingIdentifier;
-  options.Get(options::kTabbingIdentifier, &tabbingIdentifier);
+  const std::string tabbingIdentifier =
+      options.ValueOrDefault(options::kTabbingIdentifier, std::string{});
 
-  std::string windowType;
-  options.Get(options::kType, &windowType);
+  const std::string windowType =
+      options.ValueOrDefault(options::kType, std::string{});
 
-  bool hiddenInMissionControl = false;
-  options.Get(options::kHiddenInMissionControl, &hiddenInMissionControl);
+  const bool hiddenInMissionControl =
+      options.ValueOrDefault(options::kHiddenInMissionControl, false);
 
-  bool paint_when_initially_hidden = true;
-  options.Get(options::kPaintWhenInitiallyHidden, &paint_when_initially_hidden);
+  const bool paint_when_initially_hidden =
+      options.ValueOrDefault(options::kPaintWhenInitiallyHidden, true);
 
   // The window without titlebar is treated the same with frameless window.
   if (title_bar_style_ != TitleBarStyle::kNormal)
@@ -165,8 +160,8 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
 
   // The NSWindowStyleMaskFullSizeContentView style removes rounded corners
   // for frameless window.
-  bool rounded_corner = true;
-  options.Get(options::kRoundedCorners, &rounded_corner);
+  const bool rounded_corner =
+      options.ValueOrDefault(options::kRoundedCorners, true);
   if (!rounded_corner && !has_frame())
     styleMask = NSWindowStyleMaskBorderless;
 
@@ -289,8 +284,8 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   }
 
   // Resize to content bounds.
-  bool use_content_size = false;
-  options.Get(options::kUseContentSize, &use_content_size);
+  bool use_content_size =
+      options.ValueOrDefault(options::kUseContentSize, false);
   // NOTE(@mlaurencin) Spec requirements can be found here:
   // https://developer.mozilla.org/en-US/docs/Web/API/Window/open#width
   constexpr int kMinSizeReqdBySpec = 100;
@@ -311,13 +306,13 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
     SetContentSize(gfx::Size(width, height));
 
   // Enable the NSView to accept first mouse event.
-  bool acceptsFirstMouse = false;
-  options.Get(options::kAcceptFirstMouse, &acceptsFirstMouse);
+  const bool acceptsFirstMouse =
+      options.ValueOrDefault(options::kAcceptFirstMouse, false);
   [window_ setAcceptsFirstMouse:acceptsFirstMouse];
 
   // Disable auto-hiding cursor.
-  bool disableAutoHideCursor = false;
-  options.Get(options::kDisableAutoHideCursor, &disableAutoHideCursor);
+  const bool disableAutoHideCursor =
+      options.ValueOrDefault(options::kDisableAutoHideCursor, false);
   [window_ setDisableAutoHideCursor:disableAutoHideCursor];
 
   SetHiddenInMissionControl(hiddenInMissionControl);

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -257,11 +257,9 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
     SetContentSizeConstraints(extensions::SizeConstraints(
         gfx::Size(), gfx::Size(INT_MAX / 10, INT_MAX / 10)));
 
-  int width = 800, height = 600;
-  options.Get(options::kWidth, &width);
-  options.Get(options::kHeight, &height);
-  gfx::Rect bounds(0, 0, width, height);
-
+  const int width = options.ValueOrDefault(options::kWidth, 800);
+  const int height = options.ValueOrDefault(options::kHeight, 600);
+  gfx::Rect bounds{0, 0, width, height};
   widget_size_ = bounds.size();
 
   widget()->AddObserver(this);
@@ -311,18 +309,15 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
   widget()->SetNativeWindowProperty(kElectronNativeWindowKey.c_str(), this);
   SetCanResize(resizable_);
 
-  bool fullscreen = false;
-  options.Get(options::kFullscreen, &fullscreen);
+  const bool fullscreen = options.ValueOrDefault(options::kFullscreen, false);
 
   std::string window_type;
   options.Get(options::kType, &window_type);
 
 #if BUILDFLAG(IS_LINUX)
   // Set _GTK_THEME_VARIANT to dark if we have "dark-theme" option set.
-  bool use_dark_theme = false;
-  if (options.Get(options::kDarkTheme, &use_dark_theme) && use_dark_theme) {
-    SetGTKDarkThemeEnabled(use_dark_theme);
-  }
+  if (options.ValueOrDefault(options::kDarkTheme, false))
+    SetGTKDarkThemeEnabled(true);
 
   if (parent)
     SetParentWindow(parent);

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -389,12 +389,9 @@ gin::Handle<NativeImage> NativeImage::Crop(v8::Isolate* isolate,
 }
 
 void NativeImage::AddRepresentation(const gin_helper::Dictionary& options) {
-  int width = 0;
-  int height = 0;
-  float scale_factor = 1.0f;
-  options.Get("width", &width);
-  options.Get("height", &height);
-  options.Get("scaleFactor", &scale_factor);
+  const int width = options.ValueOrDefault("width", 0);
+  const int height = options.ValueOrDefault("height", 0);
+  const float scale_factor = options.ValueOrDefault("scaleFactor", 1.0F);
 
   bool skia_rep_added = false;
   gfx::ImageSkia image_skia = image_.AsImageSkia();
@@ -522,8 +519,7 @@ gin::Handle<NativeImage> NativeImage::CreateFromBitmap(
   bitmap.allocN32Pixels(width, height, false);
   bitmap.writePixels({info, buffer_data.data(), bitmap.rowBytes()});
 
-  float scale_factor = 1.0F;
-  options.Get("scaleFactor", &scale_factor);
+  const float scale_factor = options.ValueOrDefault("scaleFactor", 1.0F);
   gfx::ImageSkia image_skia =
       gfx::ImageSkia::CreateFromBitmap(bitmap, scale_factor);
 

--- a/shell/common/gin_helper/dictionary.h
+++ b/shell/common/gin_helper/dictionary.h
@@ -67,6 +67,15 @@ class Dictionary : public gin::Dictionary {
     return result.FromMaybe(false);
   }
 
+  // Convenience function for using a default value if the
+  // specified key isn't present in the dictionary.
+  template <typename T>
+  T ValueOrDefault(const std::string_view key, T default_value) const {
+    if (auto value = T{}; Get(key, &value))
+      return value;
+    return default_value;
+  }
+
   // Like normal Get but put result in an std::optional.
   template <typename T>
   bool GetOptional(const std::string_view key, std::optional<T>* out) const {


### PR DESCRIPTION
Manually backport #46939 to 35-x-y. See that PR for details.

Notes: none.