### PR TITLE
ci: upload stats about patches to DataDog

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -179,6 +179,13 @@ runs:
       else
         echo "Cache key persisted in $final_cache_path"
       fi
+  # - name: Upload patches stats
+  #   if: ${{ inputs.target-platform == 'linux' && github.ref == 'refs/heads/main' }}
+  #   shell: bash
+  #     env:
+  #       DD_API_KEY: ${{ secrets.DD_API_KEY }}
+  #   run: |
+  #     npx ts-node script/patches-stats.ts --upload-stats || true
   - name: Wait for active SSH sessions
     shell: bash
     if: always() && !cancelled()

--- a/script/patches-stats.ts
+++ b/script/patches-stats.ts
@@ -1,0 +1,86 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { parseArgs } from 'node:util';
+
+async function main (): Promise<void> {
+  const { values: { 'upload-stats': uploadStats } } = parseArgs({
+    options: {
+      'upload-stats': {
+        type: 'boolean',
+        default: false
+      }
+    }
+  });
+
+  const config = JSON.parse(await fs.readFile(path.join(__dirname, '..', 'patches', 'config.json'), 'utf-8'));
+
+  let patchCount = 0;
+  let patchesLineCount = 0;
+
+  const root = path.join(__dirname, '..', '..', '..');
+
+  for (const target of config) {
+    const patchDirPath = path.join(root, target.patch_dir);
+    const patches = await fs.readFile(path.join(patchDirPath, '.patches'), 'utf-8');
+
+    for (const patch of patches.trim().split('\n')) {
+      patchCount++;
+      const contents = await fs.readFile(path.join(patchDirPath, patch), 'utf-8');
+      patchesLineCount += Array.from(contents.matchAll(/\n/g)).length;
+    }
+  }
+
+  console.log(`Total patches: ${patchCount}`);
+  console.log(`Total lines in patches: ${patchesLineCount}`);
+
+  if (uploadStats) {
+    if (!process.env.DD_API_KEY) {
+      throw new Error('DD_API_KEY is not set');
+    }
+
+    const timestamp = Math.round(new Date().getTime() / 1000);
+
+    await fetch('https://api.datadoghq.com/api/v2/series', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'DD-API-KEY': process.env.DD_API_KEY
+      },
+      body: JSON.stringify({
+        series: [
+          {
+            metric: 'patches.count',
+            points: [
+              {
+                timestamp,
+                value: patchCount
+              }
+            ],
+            type: 1 // COUNT
+          },
+          {
+            metric: 'patches.lineCount',
+            points: [
+              {
+                timestamp,
+                value: patchesLineCount
+              }
+            ],
+            type: 1 // COUNT
+          }
+        ]
+      })
+    });
+  }
+}
+
+if (require.main === module) {
+  main()
+    .then(() => {
+      process.exit(0);
+    })
+    .catch((err: unknown) => {
+      console.error(`ERROR: ${(err as Error).message}`);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

It would be neat to track stats about our patches over time, so we can keep an eye on it. This is a quick and dirty attempt at throwing the data into DataDog so we can graph it there.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
