### PR TITLE
chore: cherry-pick 8d9662f73d73 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -153,3 +153,4 @@ add_linux_window_controls_menu.patch
 make_focus_methods_in_webcontentsviewchildframe_notimplemented.patch
 cherry-pick-295a4a1b14b8.patch
 cherry-pick-c3568ceda9d8.patch
+cherry-pick-8d9662f73d73.patch

--- a/patches/chromium/cherry-pick-8d9662f73d73.patch
+++ b/patches/chromium/cherry-pick-8d9662f73d73.patch
@@ -1,0 +1,107 @@
+From 8d9662f73d73c9ef20f99eac066ed0fdd6cf8984 Mon Sep 17 00:00:00 2001
+From: Jayson Adams <shrike@chromium.org>
+Date: Wed, 07 May 2025 11:16:18 -0700
+Subject: [PATCH] Revert "[Mac Text Subs] Ignore out-of-order text substitutions" [M137]
+
+This reverts commit d5bf4ba9cd66ce8bc28939a6807777403f295259.
+
+Reason for revert: breaks text substitution for all web text fields
+
+Bug: 409342979
+Fixed: 415810816
+
+Original change's description:
+> [Mac Text Subs] Ignore out-of-order text substitutions
+>
+> This cl forces the web contents to ignore any incoming text
+> correction that appies to an older version of the web contents's
+> text, avoiding a crash.
+>
+> Bug: 372217922
+> Change-Id: Iaf502a04af58fba395cadc12652ddd6ccaed520c
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6299632
+> Commit-Queue: Jayson Adams <shrike@chromium.org>
+> Reviewed-by: Leonard Grey <lgrey@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1427904}
+
+Bug: 372217922
+Change-Id: I2d7c5ff8a6c5892ff67ddc90e3c69270e9a5a5a5
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6514150
+Reviewed-by: Leonard Grey <lgrey@chromium.org>
+Commit-Queue: Jayson Adams <shrike@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7151@{#517}
+Cr-Branched-From: 8e0d32ed6e49a2415b16e5ed402957cac2349ce2-refs/heads/main@{#1453031}
+---
+
+diff --git a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm b/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
+index a6b6917e..1b458cd 100644
+--- a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
++++ b/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
+@@ -289,7 +289,7 @@
+   // full string in the renderer.
+   std::u16string _availableText;
+   size_t _availableTextOffset;
+-  NSUInteger _availableTextChangeNumber;
++  NSUInteger _availableTextChangeCounter;
+   gfx::Range _textSelectionRange;
+ 
+   // The composition range, cached from the RenderWidgetHostView. This is only
+@@ -479,7 +479,7 @@
+   NSRect textRectInViewCoordinates =
+       [self convertRect:textRectInWindowCoordinates fromView:nil];
+ 
+-  NSUInteger capturedChangeNumber = _availableTextChangeNumber;
++  NSUInteger capturedChangeCounter = _availableTextChangeCounter;
+ 
+   [self.spellChecker
+       showCorrectionIndicatorOfType:NSCorrectionIndicatorTypeDefault
+@@ -490,7 +490,7 @@
+                   completionHandler:^(NSString* acceptedString) {
+                     [self didAcceptReplacementString:acceptedString
+                                forTextCheckingResult:candidateResult
+-                                    withChangeNumber:capturedChangeNumber];
++                                    withChangeNumber:capturedChangeCounter];
+                   }];
+ }
+ 
+@@ -502,11 +502,8 @@
+   // Call it to report whether they initially accepted or rejected the
+   // suggestion, but also if they edit, revert, etc. later.
+ 
+-  // Exit if there's no replacement string, or if the web contents changed
+-  // in between our spell checker request and this response.
+-  if (acceptedString == nil || _availableTextChangeNumber != changeNumber) {
++  if (acceptedString == nil)
+     return;
+-  }
+ 
+   NSRange availableTextRange =
+       NSMakeRange(_availableTextOffset, _availableText.length());
+@@ -530,6 +527,18 @@
+                                                      language:nil])
+       return;
+ 
++    // Gather some info in case -doubleClickAtIndex: throws an exception.
++    // This change will eventually be reverted.
++    NSString* info = [NSString
++        stringWithFormat:@"%lu == %lu %lu %@ %@ %@ %@", changeNumber,
++                         _availableTextChangeCounter, attString.string.length,
++                         NSStringFromRange(availableTextRange),
++                         NSStringFromRange(correction.range),
++                         NSStringFromRange(trailingRange),
++                         NSStringFromRange(trailingRangeInAvailableText)];
++    SCOPED_CRASH_KEY_STRING256("RenderWidgetHostViewCocoa", "didAcceptTR",
++                               base::SysNSStringToUTF8(info));
++
+     if ([attString doubleClickAtIndex:trailingRangeInAvailableText.location]
+             .location < trailingRangeInAvailableText.location)
+       return;
+@@ -650,7 +659,7 @@
+                        range:(gfx::Range)range {
+   _availableText = text;
+   _availableTextOffset = offset;
+-  _availableTextChangeNumber++;
++  _availableTextChangeCounter++;
+   _textSelectionRange = range;
+   _substitutionWasApplied = NO;
+   [NSSpellChecker.sharedSpellChecker dismissCorrectionIndicatorForView:self];


### PR DESCRIPTION
Revert "[Mac Text Subs] Ignore out-of-order text substitutions" [M137]

This reverts commit d5bf4ba9cd66ce8bc28939a6807777403f295259.

Reason for revert: breaks text substitution for all web text fields

Bug: 409342979
Fixed: 415810816

Original change's description:
> [Mac Text Subs] Ignore out-of-order text substitutions
>
> This cl forces the web contents to ignore any incoming text
> correction that appies to an older version of the web contents's
> text, avoiding a crash.
>
> Bug: 372217922
> Change-Id: Iaf502a04af58fba395cadc12652ddd6ccaed520c
> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6299632
> Commit-Queue: Jayson Adams <shrike@chromium.org>
> Reviewed-by: Leonard Grey <lgrey@chromium.org>
> Cr-Commit-Position: refs/heads/main@{#1427904}

Bug: 372217922
Change-Id: I2d7c5ff8a6c5892ff67ddc90e3c69270e9a5a5a5
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6514150
Reviewed-by: Leonard Grey <lgrey@chromium.org>
Commit-Queue: Jayson Adams <shrike@chromium.org>
Cr-Commit-Position: refs/branch-heads/7151@{#517}
Cr-Branched-From: 8e0d32ed6e49a2415b16e5ed402957cac2349ce2-refs/heads/main@{#1453031}


Notes: Backported fix for 409342979.