### PR TITLE
refactor: make `NativeWindow::pending_transitions_` a `base::queue` (35-x-y)

### DIFF
--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -8,11 +8,11 @@
 #include <list>
 #include <memory>
 #include <optional>
-#include <queue>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#include "base/containers/queue.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
@@ -463,9 +463,10 @@ class NativeWindow : public base::SupportsUserData,
   // on HiDPI displays on some environments.
   std::optional<extensions::SizeConstraints> content_size_constraints_;
 
-  std::queue<bool> pending_transitions_;
+  base::queue<bool> pending_transitions_;
   FullScreenTransitionState fullscreen_transition_state_ =
       FullScreenTransitionState::kNone;
+
   FullScreenTransitionType fullscreen_transition_type_ =
       FullScreenTransitionType::kNone;
 


### PR DESCRIPTION
Manually backport #47157 to 35-x-y. See that PR for details.

Notes: none.