### PR TITLE
fix: `backgroundMaterial` on initial activate (35-x-y)

### DIFF
--- a/patches/chromium/chore_modify_chromium_handling_of_mouse_events.patch
+++ b/patches/chromium/chore_modify_chromium_handling_of_mouse_events.patch
@@ -61,7 +61,7 @@ index 932351e288f37fd09ae1a43f44e8b51fb0caa4b8..4a0616bc210d234e51e564daabdd2ebd
    // Overridden from WidgetObserver.
    void OnWidgetThemeChanged(Widget* widget) override;
 diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
-index c4d1d483454591031bd76dffced0c1d821800e13..e3bb491f218b2e5d96c424e40a071a618b345039 100644
+index 193e7c1bd76ce18abe6ac47848fc0fb02f2151dd..e985cd1017a54cf8d93875d642d846efb76b60e0 100644
 --- a/ui/views/win/hwnd_message_handler.cc
 +++ b/ui/views/win/hwnd_message_handler.cc
 @@ -3165,15 +3165,19 @@ LRESULT HWNDMessageHandler::HandleMouseEventInternal(UINT message,

--- a/patches/chromium/fix_activate_background_material_on_windows.patch
+++ b/patches/chromium/fix_activate_background_material_on_windows.patch
@@ -14,7 +14,7 @@ This patch likely can't be upstreamed as-is, as Chromium doesn't have
 this use case in mind currently.
 
 diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
-index 1bbc783c8606f28c93b6e3bf2c60fe8ea4e1fc01..1ed6a143f76c21e0cfd5c7b319171c6f38a5df19 100644
+index 1bbc783c8606f28c93b6e3bf2c60fe8ea4e1fc01..79807442326d2e57b62cf889267507ebd4c484a9 100644
 --- a/ui/views/win/hwnd_message_handler.cc
 +++ b/ui/views/win/hwnd_message_handler.cc
 @@ -932,13 +932,13 @@ void HWNDMessageHandler::FrameTypeChanged() {
@@ -33,6 +33,15 @@ index 1bbc783c8606f28c93b6e3bf2c60fe8ea4e1fc01..1ed6a143f76c21e0cfd5c7b319171c6f
  }
  
  void HWNDMessageHandler::SetWindowIcons(const gfx::ImageSkia& window_icon,
+@@ -1725,7 +1725,7 @@ void HWNDMessageHandler::OnActivateApp(BOOL active, DWORD thread_id) {
+   if (delegate_->HasNonClientView() && !active &&
+       thread_id != GetCurrentThreadId()) {
+     // Update the native frame if it is rendering the non-client area.
+-    if (HasSystemFrame()) {
++    if (is_translucent_ || HasSystemFrame()) {
+       DefWindowProcWithRedrawLock(WM_NCACTIVATE, FALSE, 0);
+     }
+   }
 @@ -2327,17 +2327,18 @@ LRESULT HWNDMessageHandler::OnNCActivate(UINT message,
      delegate_->SchedulePaint();
    }

--- a/patches/chromium/fix_take_snapped_status_into_account_when_showing_a_window.patch
+++ b/patches/chromium/fix_take_snapped_status_into_account_when_showing_a_window.patch
@@ -19,7 +19,7 @@ would be removed from its snapped state when re-shown. This fixes that.
 Upstreamed at https://chromium-review.googlesource.com/c/chromium/src/+/6330848.
 
 diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
-index 1ed6a143f76c21e0cfd5c7b319171c6f38a5df19..c4d1d483454591031bd76dffced0c1d821800e13 100644
+index 79807442326d2e57b62cf889267507ebd4c484a9..193e7c1bd76ce18abe6ac47848fc0fb02f2151dd 100644
 --- a/ui/views/win/hwnd_message_handler.cc
 +++ b/ui/views/win/hwnd_message_handler.cc
 @@ -674,7 +674,8 @@ void HWNDMessageHandler::Show(ui::mojom::WindowShowState show_state,


### PR DESCRIPTION
Manually backport #46657 to 35-x-y. See that PR for details.

Notes: Fixed an issue where the `backgroundMaterial` feature did not work in a frameless window on initial window creation.