### PR TITLE
fix: titlebar showing in content protected window

### DIFF
--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
@@ -52,8 +52,11 @@ class ElectronDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin,
   bool ShouldWindowContentsBeTransparent() const override;
 
  private:
+  void UpdateAllowScreenshots();
+
   raw_ptr<NativeWindowViews> native_window_view_;  // weak ref
   std::optional<bool> force_should_paint_as_active_;
+  bool allow_screenshots_ = true;
   bool widget_init_done_ = false;
 };
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/47152.

Fixes an issue where protected transparent windows will show a titlebar after visibility change. This happened because `SetWindowDisplayAffinity` will attempt to compose the window when hidden and re-shown.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where protected transparent windows inappropriately showed a titlebar after visibility change.
