### PR TITLE
feat: expose `win.isContentProtected()`

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -1346,6 +1346,10 @@ On Windows it calls SetWindowDisplayAffinity with `WDA_EXCLUDEFROMCAPTURE`.
 For Windows 10 version 2004 and up the window will be removed from capture entirely,
 older Windows versions behave as if `WDA_MONITOR` is applied capturing a black window.
 
+#### `win.isContentProtected()` _macOS_ _Windows_
+
+Returns `boolean` - whether or not content protection is currently enabled.
+
 #### `win.setFocusable(focusable)` _macOS_ _Windows_
 
 * `focusable` boolean

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1528,6 +1528,10 @@ On Windows it calls SetWindowDisplayAffinity with `WDA_EXCLUDEFROMCAPTURE`.
 For Windows 10 version 2004 and up the window will be removed from capture entirely,
 older Windows versions behave as if `WDA_MONITOR` is applied capturing a black window.
 
+#### `win.isContentProtected()` _macOS_ _Windows_
+
+Returns `boolean` - whether or not content protection is currently enabled.
+
 #### `win.setFocusable(focusable)` _macOS_ _Windows_
 
 * `focusable` boolean

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -1204,7 +1204,7 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isDocumentEdited", &BaseWindow::IsDocumentEdited)
       .SetMethod("setIgnoreMouseEvents", &BaseWindow::SetIgnoreMouseEvents)
       .SetMethod("setContentProtection", &BaseWindow::SetContentProtection)
-      .SetMethod("_isContentProtected", &BaseWindow::IsContentProtected)
+      .SetMethod("isContentProtected", &BaseWindow::IsContentProtected)
       .SetMethod("setFocusable", &BaseWindow::SetFocusable)
       .SetMethod("isFocusable", &BaseWindow::IsFocusable)
       .SetMethod("setMenu", &BaseWindow::SetMenu)

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -331,8 +331,7 @@ describe('BrowserWindow module', () => {
     afterEach(closeAllWindows);
     it('can set content protection', async () => {
       const w = new BrowserWindow({ show: false });
-      // @ts-expect-error This is a private API
-      expect(w._isContentProtected()).to.equal(false);
+      expect(w.isContentProtected()).to.equal(false);
 
       const shown = once(w, 'show');
 
@@ -340,8 +339,7 @@ describe('BrowserWindow module', () => {
       await shown;
 
       w.setContentProtection(true);
-      // @ts-expect-error This is a private API
-      expect(w._isContentProtected()).to.equal(true);
+      expect(w.isContentProtected()).to.equal(true);
     });
 
     it('does not remove content protection after the window is hidden and shown', async () => {

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -358,8 +358,7 @@ describe('BrowserWindow module', () => {
       w.show();
       await shown;
 
-      // @ts-expect-error This is a private API
-      expect(w._isContentProtected()).to.equal(true);
+      expect(w.isContentProtected()).to.equal(true);
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Expose a function to allow developers to check current content protection status. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Exposed `win.isContentProtected()` to allow developers to check window protection status.
