### PR TITLE
chore: add .eslintrc.json for `docs/fiddles`

### DIFF
--- a/docs/fiddles/.eslintrc.json
+++ b/docs/fiddles/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "standard",
+  "rules": {
+    "import/order": "off"
+  }
+}


### PR DESCRIPTION
Adds an ESLint config that matches what we lint for in `@electron/lint-roller` for the `docs/fiddles` samples.

cc @dsanders11 

notes: none