### PR TITLE
ci: change patches stats DataDog metric type to gauge

### DIFF
--- a/script/patches-stats.mjs
+++ b/script/patches-stats.mjs
@@ -57,7 +57,7 @@ async function main () {
                 value: patchCount
               }
             ],
-            type: 1 // COUNT
+            type: 3 // GAUGE
           },
           {
             metric: 'electron.patches.lineCount',
@@ -67,7 +67,7 @@ async function main () {
                 value: patchesLineCount
               }
             ],
-            type: 1 // COUNT
+            type: 3 // GAUGE
           }
         ]
       })


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Fixing this as now that they're uploading I can see we need these to be logged as gauge metrics, otherwise showing a monthly view will add up the counts on any given day, which is not what we want. You can manually update the metric type on DataDog's dashboard so I've done that to fix it on that side for now, but we should upload new datapoints as the correct type.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
