### PR TITLE
refactor: reduce public NativeWindow API

### DIFF
--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -473,11 +473,6 @@ class NativeWindow : public base::SupportsUserData,
   // on HiDPI displays on some environments.
   std::optional<extensions::SizeConstraints> content_size_constraints_;
 
-  base::queue<bool> pending_transitions_;
-
-  FullScreenTransitionType fullscreen_transition_type_ =
-      FullScreenTransitionType::kNone;
-
   std::list<NativeWindow*> child_windows_;
 
  private:
@@ -545,6 +540,11 @@ class NativeWindow : public base::SupportsUserData,
   std::string background_material_;
 
   gfx::Rect overlay_rect_;
+
+  base::queue<bool> pending_transitions_;
+
+  FullScreenTransitionType fullscreen_transition_type_ =
+      FullScreenTransitionType::kNone;
 
   base::WeakPtrFactory<NativeWindow> weak_factory_{this};
 };

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -385,6 +385,8 @@ class NativeWindow : public base::SupportsUserData,
     return title_bar_style_;
   }
 
+  [[nodiscard]] bool has_titlebar_overlay() const { return titlebar_overlay_; }
+
   bool IsWindowControlsOverlayEnabled() const {
     bool valid_titlebar_style = title_bar_style() == TitleBarStyle::kHidden
 #if BUILDFLAG(IS_MAC)
@@ -392,7 +394,7 @@ class NativeWindow : public base::SupportsUserData,
                                 title_bar_style() == TitleBarStyle::kHiddenInset
 #endif
         ;
-    return valid_titlebar_style && titlebar_overlay_;
+    return valid_titlebar_style && has_titlebar_overlay();
   }
 
   int titlebar_overlay_height() const { return titlebar_overlay_height_; }
@@ -463,9 +465,6 @@ class NativeWindow : public base::SupportsUserData,
   static inline constexpr base::cstring_view kNativeWindowKey =
       "__ELECTRON_NATIVE_WINDOW__";
 
-  // The boolean parsing of the "titleBarOverlay" option
-  bool titlebar_overlay_ = false;
-
   // Minimum and maximum size.
   std::optional<extensions::SizeConstraints> size_constraints_;
   // Same as above but stored as content size, we are storing 2 types of size
@@ -512,6 +511,9 @@ class NativeWindow : public base::SupportsUserData,
 
   // The windows has been closed.
   bool is_closed_ = false;
+
+  // The boolean parsing of the "titleBarOverlay" option
+  bool titlebar_overlay_ = false;
 
   // Used to display sheets at the appropriate horizontal and vertical offsets
   // on macOS.

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -502,6 +502,9 @@ class NativeWindow : public base::SupportsUserData,
   // Whether window has standard frame.
   const bool has_frame_;
 
+  // The boolean parsing of the "titleBarOverlay" option
+  const bool titlebar_overlay_ = false;
+
   // The content view, weak ref.
   raw_ptr<views::View> content_view_ = nullptr;
 
@@ -511,9 +514,6 @@ class NativeWindow : public base::SupportsUserData,
 
   // The windows has been closed.
   bool is_closed_ = false;
-
-  // The boolean parsing of the "titleBarOverlay" option
-  bool titlebar_overlay_ = false;
 
   // Used to display sheets at the appropriate horizontal and vertical offsets
   // on macOS.

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1827,7 +1827,7 @@ void NativeWindowMac::SetForwardMouseMessages(bool forward) {
 }
 
 std::optional<gfx::Rect> NativeWindowMac::GetWindowControlsOverlayRect() {
-  if (!titlebar_overlay_)
+  if (!has_titlebar_overlay())
     return std::nullopt;
 
   // On macOS, when in fullscreen mode, window controls (the menu bar, title


### PR DESCRIPTION
#### Description of Change

Make `NativeWindow` fields private and/or const where possible

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.