### PR TITLE
fix: utilityProcess exit handler

### DIFF
--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -4,6 +4,7 @@
 
 #include "shell/services/node/node_service.h"
 
+#include <cstdlib>
 #include <sstream>
 #include <utility>
 
@@ -149,10 +150,14 @@ void NodeService::Initialize(
         // Destroy node platform.
         env->set_trace_sync_io(false);
         ParentPort::GetInstance()->Close();
+        if (g_client_remote.is_bound()) {
+          g_client_remote.reset();
+        }
         js_env_->DestroyMicrotasksRunner();
         node::Stop(env, node::StopFlags::kDoNotTerminateIsolate);
         node_env_stopped_ = true;
         receiver_.ResetWithReason(exit_code, "process_exit_termination");
+        std::exit(exit_code);
       });
 
   node_env_->set_trace_sync_io(node_env_->options()->trace_sync_io);


### PR DESCRIPTION
#### Description of Change
This is an attempted fix for the issue [#44174](https://github.com/electron/electron/issues/44174) utilityProcess not exiting immediately after process.exit() call.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
