### PR TITLE
ci: ignore network-related error annotations in audit

### DIFF
--- a/.github/workflows/audit-branch-ci.yml
+++ b/.github/workflows/audit-branch-ci.yml
@@ -64,7 +64,8 @@ jobs:
                       annotation_level === "failure" &&
                       !message.startsWith("Process completed with exit code") &&
                       !message.startsWith("Response status code does not indicate success"),
-                      !message.endsWith("Unable to make request: ECONNRESET"),
+                      !/Unable to make request/.test(message),
+                      !/The requested URL returned error/.test(message),
                   )
                 ) {
                   checkRun.hasErrorAnnotations = true;

--- a/.github/workflows/audit-branch-ci.yml
+++ b/.github/workflows/audit-branch-ci.yml
@@ -57,13 +57,14 @@ jobs:
                   repo: "electron",
                   check_run_id: checkRun.id,
                 })).data ?? [];
-                console.log(checkRun);
-                console.log(annotations);
 
                 if (
                   annotations.find(
                     ({ annotation_level, message }) =>
-                      annotation_level === 'failure' && !message.startsWith("Process completed with exit code")
+                      annotation_level === "failure" &&
+                      !message.startsWith("Process completed with exit code") &&
+                      !message.startsWith("Response status code does not indicate success"),
+                      !message.endsWith("Unable to make request: ECONNRESET"),
                   )
                 ) {
                   checkRun.hasErrorAnnotations = true;


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

We've seen these pop up but we don't want them to trip this audit since they're transient errors. Also removes a couple of debugging lines that were inadvertently left in previously.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
