### PR TITLE
chore: cherry-pick 1 changes from 1-M137

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -4,3 +4,4 @@ enable_--perf-prof_flag_on_macos.patch
 cherry-pick-22ac8acf3508.patch
 debug_fix_crash_when_pausing_in_for-of_loop_header.patch
 parser_set_start_end_on_materialized_scopes.patch
+cherry-pick-7bc0a67ebfbf.patch

--- a/patches/v8/cherry-pick-7bc0a67ebfbf.patch
+++ b/patches/v8/cherry-pick-7bc0a67ebfbf.patch
@@ -1,7 +1,7 @@
-From 7bc0a67ebfbf44e7adab47fc2bbbe308660e27f4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Leszek Swirski <leszeks@chromium.org>
 Date: Tue, 27 May 2025 20:33:19 +0200
-Subject: [PATCH] [turbofan] Weaken alias analysis in store-store elimination
+Subject: Weaken alias analysis in store-store elimination
 
 Bug: 420636529
 Change-Id: I7c5a8f47960708cecbb27d811eedc7f754933deb
@@ -10,13 +10,12 @@ Reviewed-by: Shu-yu Guo <syg@chromium.org>
 Auto-Submit: Leszek Swirski <leszeks@chromium.org>
 Commit-Queue: Leszek Swirski <leszeks@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#100530}
----
 
 diff --git a/src/compiler/turboshaft/store-store-elimination-reducer-inl.h b/src/compiler/turboshaft/store-store-elimination-reducer-inl.h
-index 45654a0..e058a41 100644
+index 45654a022fbaa67634d68d7d6e9dab7a5a50cb28..e058a41f23e29bbe4f5098608b340ccfef50bf98 100644
 --- a/src/compiler/turboshaft/store-store-elimination-reducer-inl.h
 +++ b/src/compiler/turboshaft/store-store-elimination-reducer-inl.h
-@@ -325,10 +325,11 @@
+@@ -325,10 +325,11 @@ class RedundantStoreAnalysis {
            // TODO(nicohartmann@): Use the new effect flags to distinguish heap
            // access once available.
            const bool is_on_heap_store = store.kind.tagged_base;
@@ -31,7 +30,7 @@ index 45654a0..e058a41 100644
              bool is_eliminable_store = false;
              switch (table_.GetObservability(store.base(), store.offset, size)) {
                case StoreObservability::kUnobservable:
-@@ -415,11 +416,16 @@
+@@ -415,11 +416,16 @@ class RedundantStoreAnalysis {
            // TODO(nicohartmann@): Use the new effect flags to distinguish heap
            // access once available.
            const bool is_on_heap_load = load.kind.tagged_base;

--- a/patches/v8/cherry-pick-7bc0a67ebfbf.patch
+++ b/patches/v8/cherry-pick-7bc0a67ebfbf.patch
@@ -1,0 +1,54 @@
+From 7bc0a67ebfbf44e7adab47fc2bbbe308660e27f4 Mon Sep 17 00:00:00 2001
+From: Leszek Swirski <leszeks@chromium.org>
+Date: Tue, 27 May 2025 20:33:19 +0200
+Subject: [PATCH] [turbofan] Weaken alias analysis in store-store elimination
+
+Bug: 420636529
+Change-Id: I7c5a8f47960708cecbb27d811eedc7f754933deb
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6594051
+Reviewed-by: Shu-yu Guo <syg@chromium.org>
+Auto-Submit: Leszek Swirski <leszeks@chromium.org>
+Commit-Queue: Leszek Swirski <leszeks@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#100530}
+---
+
+diff --git a/src/compiler/turboshaft/store-store-elimination-reducer-inl.h b/src/compiler/turboshaft/store-store-elimination-reducer-inl.h
+index 45654a0..e058a41 100644
+--- a/src/compiler/turboshaft/store-store-elimination-reducer-inl.h
++++ b/src/compiler/turboshaft/store-store-elimination-reducer-inl.h
+@@ -325,10 +325,11 @@
+           // TODO(nicohartmann@): Use the new effect flags to distinguish heap
+           // access once available.
+           const bool is_on_heap_store = store.kind.tagged_base;
+-          const bool is_field_store = !store.index().valid();
++          const bool is_fixed_offset_store = !store.index().valid();
+           const uint8_t size = store.stored_rep.SizeInBytes();
+-          // For now we consider only stores of fields of objects on the heap.
+-          if (is_on_heap_store && is_field_store) {
++          // For now we consider only stores of fixed offsets of objects on the
++          // heap.
++          if (is_on_heap_store && is_fixed_offset_store) {
+             bool is_eliminable_store = false;
+             switch (table_.GetObservability(store.base(), store.offset, size)) {
+               case StoreObservability::kUnobservable:
+@@ -415,11 +416,16 @@
+           // TODO(nicohartmann@): Use the new effect flags to distinguish heap
+           // access once available.
+           const bool is_on_heap_load = load.kind.tagged_base;
+-          const bool is_field_load = !load.index().valid();
++          const bool is_fixed_offset_load = !load.index().valid();
+           // For now we consider only loads of fields of objects on the heap.
+-          if (is_on_heap_load && is_field_load) {
+-            table_.MarkPotentiallyAliasingStoresAsObservable(load.base(),
+-                                                             load.offset);
++          if (is_on_heap_load) {
++            if (is_fixed_offset_load) {
++              table_.MarkPotentiallyAliasingStoresAsObservable(load.base(),
++                                                               load.offset);
++            } else {
++              // A dynamically indexed load might alias any fixed offset.
++              table_.MarkAllStoresAsObservable();
++            }
+           }
+           break;
+         }


### PR DESCRIPTION
<details>
<summary>electron/security#675 - 7bc0a67ebfbf from v8</summary>
[turbofan] Weaken alias analysis in store-store elimination

Bug: 420636529
Change-Id: I7c5a8f47960708cecbb27d811eedc7f754933deb
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6594051
Reviewed-by: Shu-yu Guo <syg@chromium.org>
Auto-Submit: Leszek Swirski <leszeks@chromium.org>
Commit-Queue: Leszek Swirski <leszeks@chromium.org>
Cr-Commit-Position: refs/heads/main@{#100530}
</details>

Notes:
* Security: backported fix for CVE-2025-5419.