### PR TITLE
chore: cherry-pick 45eb42cd398e from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -1,2 +1,3 @@
 chore_allow_customizing_microtask_policy_per_context.patch
 cherry-pick-7bc0a67ebfbf.patch
+cherry-pick-45eb42cd398e.patch

--- a/patches/v8/cherry-pick-45eb42cd398e.patch
+++ b/patches/v8/cherry-pick-45eb42cd398e.patch
@@ -1,7 +1,7 @@
-From 45eb42cd398ea2a0fd6d145a6c36d57f71498d34 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Igor Sheludko <ishell@chromium.org>
 Date: Tue, 27 May 2025 21:34:45 +0200
-Subject: [PATCH] [turbofan] Convert Smi to Word64 using zero extension
+Subject: Convert Smi to Word64 using zero extension
 
 ... when a known type range contains only positive values.
 
@@ -11,13 +11,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6594731
 Reviewed-by: Nico Hartmann <nicohartmann@chromium.org>
 Commit-Queue: Igor Sheludko <ishell@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#100538}
----
 
 diff --git a/src/compiler/representation-change.cc b/src/compiler/representation-change.cc
-index a05b47e..116dcb6 100644
+index a05b47e602e9707c17ba0ddcc9cfc071b95db168..116dcb6ce9a10e8fd3c681292ceaa2894db55052 100644
 --- a/src/compiler/representation-change.cc
 +++ b/src/compiler/representation-change.cc
-@@ -1394,7 +1394,12 @@
+@@ -1394,7 +1394,12 @@ Node* RepresentationChanger::GetWord64RepresentationFor(
      }
    } else if (output_rep == MachineRepresentation::kTaggedSigned) {
      if (output_type.Is(Type::SignedSmall())) {

--- a/patches/v8/cherry-pick-45eb42cd398e.patch
+++ b/patches/v8/cherry-pick-45eb42cd398e.patch
@@ -1,0 +1,33 @@
+From 45eb42cd398ea2a0fd6d145a6c36d57f71498d34 Mon Sep 17 00:00:00 2001
+From: Igor Sheludko <ishell@chromium.org>
+Date: Tue, 27 May 2025 21:34:45 +0200
+Subject: [PATCH] [turbofan] Convert Smi to Word64 using zero extension
+
+... when a known type range contains only positive values.
+
+Bug: 420637585
+Change-Id: I8d9bb3f2fe2e5268e1659bb4ea7bbf97bfb52288
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6594731
+Reviewed-by: Nico Hartmann <nicohartmann@chromium.org>
+Commit-Queue: Igor Sheludko <ishell@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#100538}
+---
+
+diff --git a/src/compiler/representation-change.cc b/src/compiler/representation-change.cc
+index a05b47e..116dcb6 100644
+--- a/src/compiler/representation-change.cc
++++ b/src/compiler/representation-change.cc
+@@ -1394,7 +1394,12 @@
+     }
+   } else if (output_rep == MachineRepresentation::kTaggedSigned) {
+     if (output_type.Is(Type::SignedSmall())) {
+-      op = simplified()->ChangeTaggedSignedToInt64();
++      if (output_type.IsRange() && output_type.AsRange()->Min() >= 0) {
++        node = InsertChangeTaggedSignedToInt32(node);
++        op = machine()->ChangeUint32ToUint64();
++      } else {
++        op = simplified()->ChangeTaggedSignedToInt64();
++      }
+     } else {
+       return TypeError(node, output_rep, output_type,
+                        MachineRepresentation::kWord64);


### PR DESCRIPTION
[turbofan] Convert Smi to Word64 using zero extension

... when a known type range contains only positive values.

Bug: 420637585
Change-Id: I8d9bb3f2fe2e5268e1659bb4ea7bbf97bfb52288
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6594731
Reviewed-by: Nico Hartmann <nicohartmann@chromium.org>
Commit-Queue: Igor Sheludko <ishell@chromium.org>
Cr-Commit-Position: refs/heads/main@{#100538}


Notes: Backported fix for 420637585.