### PR TITLE
docs: remove `electron-quick-start` from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,29 +44,17 @@ Each Electron release provides binaries for macOS, Windows, and Linux.
   * Fedora 32 and newer
   * Debian 10 and newer
 
-## Quick start & Electron Fiddle
+## Electron Fiddle
 
 Use [`Electron Fiddle`](https://github.com/electron/fiddle)
 to build, run, and package small Electron experiments, to see code examples for all of Electron's APIs, and
 to try out different versions of Electron. It's designed to make the start of your journey with
 Electron easier.
 
-Alternatively, clone and run the
-[electron/electron-quick-start](https://github.com/electron/electron-quick-start)
-repository to see a minimal Electron app in action:
-
-```sh
-git clone https://github.com/electron/electron-quick-start
-cd electron-quick-start
-npm install
-npm start
-```
-
 ## Resources for learning Electron
 
 * [electronjs.org/docs](https://electronjs.org/docs) - All of Electron's documentation
 * [electron/fiddle](https://github.com/electron/fiddle) - A tool to build, run, and package small Electron experiments
-* [electron/electron-quick-start](https://github.com/electron/electron-quick-start) - A very basic starter Electron app
 * [electronjs.org/community#boilerplates](https://electronjs.org/community#boilerplates) - Sample starter apps created by the community
 
 ## Programmatic usage


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Refs https://github.com/electron/.permissions/pull/293

The repo was renamed to `minimal-repro` and is no longer intended to be used as a way to start new projects (see PR above).

Since we really want bugs in `electron/electron` to be reported with a Fiddle gist instead of a standalone repo (makes reproducing and bisecting sooo much easier and safer!), I removed the repo from the README completely instead of mentioning it as an issue reproduction starting point.

CC @yangannyx

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
