### PR TITLE
feat: add support for --no-experimental-global-navigator

### DIFF
--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -327,6 +327,10 @@ Set the directory to which all Node.js diagnostic output files are written. Defa
 
 Affects the default output directory of [v8.setHeapSnapshotNearHeapLimit](https://nodejs.org/docs/latest/api/v8.html#v8setheapsnapshotnearheaplimitlimit).
 
+### `--no-experimental-global-navigator`
+
+Disable exposition of [Navigator API][] on the global scope from Node.js.
+
 [app]: app.md
 [append-switch]: command-line.md#commandlineappendswitchswitch-value
 [debugging-main-process]: ../tutorial/debugging-main-process.md
@@ -335,3 +339,4 @@ Affects the default output directory of [v8.setHeapSnapshotNearHeapLimit](https:
 [play-silent-audio]: https://github.com/atom/atom/pull/9485/files
 [ready]: app.md#event-ready
 [severities]: https://source.chromium.org/chromium/chromium/src/+/main:base/logging.h?q=logging::LogSeverity&ss=chromium
+[Navigator API]: https://github.com/nodejs/node/blob/main/doc/api/globals.md#navigator

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -374,6 +374,7 @@ bool IsAllowedOption(const std::string_view option) {
       "--throw-deprecation",
       "--trace-deprecation",
       "--trace-warnings",
+      "--no-experimental-global-navigator",
   });
 
   if (debug_options.contains(option))

--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -780,5 +780,33 @@ describe('utilityProcess module', () => {
       expect(stat.size).to.be.greaterThan(0);
       await fs.rm(tmpDir, { recursive: true });
     });
+
+    it('supports --no-experimental-global-navigator flag', async () => {
+      {
+        const child = utilityProcess.fork(path.join(fixturesPath, 'navigator.js'), [], {
+          stdio: 'ignore'
+        });
+        await once(child, 'spawn');
+        const [data] = await once(child, 'message');
+        expect(data).to.be.true();
+        const exit = once(child, 'exit');
+        expect(child.kill()).to.be.true();
+        await exit;
+      }
+      {
+        const child = utilityProcess.fork(path.join(fixturesPath, 'navigator.js'), [], {
+          stdio: 'ignore',
+          execArgv: [
+            '--no-experimental-global-navigator'
+          ]
+        });
+        await once(child, 'spawn');
+        const [data] = await once(child, 'message');
+        expect(data).to.be.false();
+        const exit = once(child, 'exit');
+        expect(child.kill()).to.be.true();
+        await exit;
+      }
+    });
   });
 });

--- a/spec/fixtures/api/utility-process/navigator.js
+++ b/spec/fixtures/api/utility-process/navigator.js
@@ -1,0 +1,1 @@
+process.parentPort.postMessage(typeof navigator === 'object');


### PR DESCRIPTION
#### Description of Change

With Node.js v21 starting to support global navigator object, applications that load 3-rd party plugins need to provide a migration timeline for these plugins that relied on the presence of navigator object to detect web environments which would not be the case anymore.

https://github.com/nodejs/node/commit/309c71ae38e0f29fd3d563bfc2766f4aa94eb0ad

#### Release Notes

Notes: add support for `--no-experimental-global-navigator` flag