### PR TITLE
Save window state

### DIFF
--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -58,9 +58,9 @@ async function createWindow (backgroundColor?: string) {
       nodeIntegration: false
     },
     // @ts-ignore
-    windowStateRestoreOptions: {
-      stateId: 'first-main-window'
-    },
+    // windowStateRestoreOptions: {
+    //   stateId: 'first-main-window'
+    // },
     useContentSize: true,
     show: false
   };

--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -59,9 +59,7 @@ async function createWindow (backgroundColor?: string) {
     },
     // @ts-ignore
     windowStateRestoreOptions: {
-      stateId: 'first-main-window',
-      bounds: true,
-      displayMode: true
+      stateId: 'first-main-window'
     },
     useContentSize: true,
     show: false

--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -57,6 +57,12 @@ async function createWindow (backgroundColor?: string) {
       sandbox: true,
       nodeIntegration: false
     },
+    // @ts-ignore
+    windowStateRestoreOptions: {
+      stateId: 'first-main-window',
+      bounds: true,
+      displayMode: true
+    },
     useContentSize: true,
     show: false
   };

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -178,7 +178,7 @@ void BaseWindow::OnWindowClosed() {
   // We can not call Destroy here because we need to call Emit first, but we
   // also do not want any method to be used, so just mark as destroyed here.
   MarkDestroyed();
-
+  window_->SaveWindowState();
   Emit("closed");
 
   RemoveFromParentChildWindows();
@@ -271,6 +271,7 @@ void BaseWindow::OnWindowResize() {
 }
 
 void BaseWindow::OnWindowResized() {
+  window_->SaveWindowState();
   Emit("resized");
 }
 
@@ -286,6 +287,7 @@ void BaseWindow::OnWindowMove() {
 }
 
 void BaseWindow::OnWindowMoved() {
+  window_->SaveWindowState();
   Emit("moved");
 }
 

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -492,6 +492,8 @@ void ElectronBrowserContext::InitPrefs() {
   // Unique uuid for global shortcuts.
   registry->RegisterStringPref(electron::kElectronGlobalShortcutsUuid,
                                std::string());
+
+  registry->RegisterDictionaryPref(electron::kWindowStates);
 }
 
 void ElectronBrowserContext::SetUserAgent(const std::string& user_agent) {

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -18,6 +18,7 @@
 #include "base/observer_list.h"
 #include "base/strings/cstring_view.h"
 #include "base/supports_user_data.h"
+#include "components/prefs/pref_service.h"
 #include "content/public/browser/desktop_media_id.h"
 #include "content/public/browser/web_contents_user_data.h"
 #include "extensions/browser/app_window/size_constraints.h"
@@ -426,6 +427,8 @@ class NativeWindow : public base::SupportsUserData,
   // throttling, then throttling in the `ui::Compositor` will be disabled.
   void UpdateBackgroundThrottlingState();
 
+  void SaveWindowState();
+
  protected:
   NativeWindow(const gin_helper::Dictionary& options, NativeWindow* parent);
 
@@ -545,6 +548,9 @@ class NativeWindow : public base::SupportsUserData,
   std::string background_material_;
 
   gfx::Rect overlay_rect_;
+
+  raw_ptr<PrefService> prefs_ = nullptr;
+  std::string window_state_id_;
 
   base::WeakPtrFactory<NativeWindow> weak_factory_{this};
 };

--- a/shell/common/electron_constants.h
+++ b/shell/common/electron_constants.h
@@ -26,12 +26,15 @@ inline constexpr std::string_view kLeft = "left";
 inline constexpr std::string_view kTop = "top";
 inline constexpr std::string_view kRight = "right";
 inline constexpr std::string_view kBottom = "bottom";
+
 inline constexpr std::string_view kMaximized = "maximized";
 inline constexpr std::string_view kFullscreen = "fullscreen";
+
 inline constexpr std::string_view kWorkAreaLeft = "work_area_left";
 inline constexpr std::string_view kWorkAreaTop = "work_area_top";
 inline constexpr std::string_view kWorkAreaRight = "work_area_right";
 inline constexpr std::string_view kWorkAreaBottom = "work_area_bottom";
+
 inline constexpr std::string_view kWindowStates = "electron.window_states";
 
 inline constexpr base::cstring_view kRunAsNode = "ELECTRON_RUN_AS_NODE";

--- a/shell/common/electron_constants.h
+++ b/shell/common/electron_constants.h
@@ -21,6 +21,19 @@ inline constexpr std::string_view kDeviceVendorIdKey = "vendorId";
 inline constexpr std::string_view kDeviceProductIdKey = "productId";
 inline constexpr std::string_view kDeviceSerialNumberKey = "serialNumber";
 
+// Window state preference keys
+inline constexpr std::string_view kLeft = "left";
+inline constexpr std::string_view kTop = "top";
+inline constexpr std::string_view kRight = "right";
+inline constexpr std::string_view kBottom = "bottom";
+inline constexpr std::string_view kMaximized = "maximized";
+inline constexpr std::string_view kFullscreen = "fullscreen";
+inline constexpr std::string_view kWorkAreaLeft = "work_area_left";
+inline constexpr std::string_view kWorkAreaTop = "work_area_top";
+inline constexpr std::string_view kWorkAreaRight = "work_area_right";
+inline constexpr std::string_view kWorkAreaBottom = "work_area_bottom";
+inline constexpr std::string_view kWindowStates = "electron.window_states";
+
 inline constexpr base::cstring_view kRunAsNode = "ELECTRON_RUN_AS_NODE";
 
 // Per-profile UUID to distinguish global shortcut sessions for

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -107,6 +107,19 @@ inline constexpr std::string_view kFocusable = "focusable";
 // The WebPreferences.
 inline constexpr std::string_view kWebPreferences = "webPreferences";
 
+// Window state restore options for BrowserWindow
+inline constexpr std::string_view kWindowStateRestoreOptions =
+    "windowStateRestoreOptions";
+
+// The unique identifier for the window state in preferences
+inline constexpr std::string_view kStateId = "stateId";
+
+// Whether to save the window bounds
+inline constexpr std::string_view kBounds = "bounds";
+
+// Whether to save the window display mode
+inline constexpr std::string_view kDisplayMode = "displayMode";
+
 // Add a vibrancy effect to the browser window
 inline constexpr std::string_view kVibrancyType = "vibrancy";
 


### PR DESCRIPTION
#### Description of Change

Added a constructor option `windowStateRestoreOptions` to `BaseWindowConstructorOptions` with a single param `stateId` (for now). It saves window bounds continuously on resize, move, and close events. Does not restore.

Variables saved internally are the same as https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/views/chrome_views_delegate.cc;drc=1f9f3d7d4227fc2021915926b0e9f934cd610201;l=99

