### PR TITLE
refactor: have ShowSaveDialogSync() return a std::optional<base::FilePath>

### DIFF
--- a/shell/browser/api/electron_api_dialog.cc
+++ b/shell/browser/api/electron_api_dialog.cc
@@ -71,9 +71,8 @@ v8::Local<v8::Promise> ShowOpenDialog(
 
 void ShowSaveDialogSync(const file_dialog::DialogSettings& settings,
                         gin::Arguments* args) {
-  base::FilePath path;
-  if (file_dialog::ShowSaveDialogSync(settings, &path))
-    args->Return(path);
+  if (const auto path = file_dialog::ShowSaveDialogSync(settings))
+    args->Return(*path);
 }
 
 v8::Local<v8::Promise> ShowSaveDialog(

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -18,6 +18,7 @@
 #include "base/containers/fixed_flat_map.h"
 #include "base/containers/flat_set.h"
 #include "base/containers/id_map.h"
+#include "base/containers/map_util.h"
 #include "base/files/file_util.h"
 #include "base/json/json_reader.h"
 #include "base/no_destructor.h"
@@ -4008,30 +4009,35 @@ void WebContents::DevToolsSaveToFile(const std::string& url,
                                      const std::string& content,
                                      bool save_as,
                                      bool is_base64) {
-  base::FilePath path;
-  auto it = saved_files_.find(url);
-  if (it != saved_files_.end() && !save_as) {
-    path = it->second;
-  } else {
+  const base::FilePath* path = nullptr;
+
+  if (!save_as)
+    base::FindOrNull(saved_files_, url);
+
+  if (path == nullptr) {
     file_dialog::DialogSettings settings;
     settings.parent_window = owner_window();
     settings.force_detached = offscreen_;
     settings.title = url;
     settings.default_path = base::FilePath::FromUTF8Unsafe(url);
-    if (!file_dialog::ShowSaveDialogSync(settings, &path)) {
-      inspectable_web_contents_->CallClientFunction(
-          "DevToolsAPI", "canceledSaveURL", base::Value(url));
-      return;
+    if (auto new_path = file_dialog::ShowSaveDialogSync(settings)) {
+      auto [iter, _] = saved_files_.try_emplace(url, std::move(*new_path));
+      path = &iter->second;
     }
   }
 
-  saved_files_[url] = path;
+  if (path == nullptr) {
+    inspectable_web_contents_->CallClientFunction(
+        "DevToolsAPI", "canceledSaveURL", base::Value{url});
+    return;
+  }
+
   // Notify DevTools.
   inspectable_web_contents_->CallClientFunction(
-      "DevToolsAPI", "savedURL", base::Value(url),
-      base::Value(path.AsUTF8Unsafe()));
+      "DevToolsAPI", "savedURL", base::Value{url},
+      base::Value{path->AsUTF8Unsafe()});
   file_task_runner_->PostTask(
-      FROM_HERE, base::BindOnce(&WriteToFile, path, content, is_base64));
+      FROM_HERE, base::BindOnce(&WriteToFile, *path, content, is_base64));
 }
 
 void WebContents::DevToolsAppendToFile(const std::string& url,

--- a/shell/browser/ui/file_dialog.h
+++ b/shell/browser/ui/file_dialog.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_FILE_DIALOG_H_
 #define ELECTRON_SHELL_BROWSER_UI_FILE_DIALOG_H_
 
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -72,7 +73,8 @@ bool ShowOpenDialogSync(const DialogSettings& settings,
 void ShowOpenDialog(const DialogSettings& settings,
                     gin_helper::Promise<gin_helper::Dictionary> promise);
 
-bool ShowSaveDialogSync(const DialogSettings& settings, base::FilePath* path);
+std::optional<base::FilePath> ShowSaveDialogSync(
+    const DialogSettings& settings);
 
 void ShowSaveDialog(const DialogSettings& settings,
                     gin_helper::Promise<gin_helper::Dictionary> promise);

--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -436,19 +436,18 @@ void ShowOpenDialog(const DialogSettings& settings,
   }
 }
 
-bool ShowSaveDialogSync(const DialogSettings& settings, base::FilePath* path) {
-  DCHECK(path);
+std::optional<base::FilePath> ShowSaveDialogSync(
+    const DialogSettings& settings) {
   NSSavePanel* dialog = [NSSavePanel savePanel];
 
   SetupDialog(dialog, settings);
   SetupSaveDialogForProperties(dialog, settings.properties);
 
-  int chosen = RunModalDialog(dialog, settings);
+  const int chosen = RunModalDialog(dialog, settings);
   if (chosen == NSModalResponseCancel || ![[dialog URL] isFileURL])
-    return false;
+    return {};
 
-  *path = base::FilePath(base::SysNSStringToUTF8([[dialog URL] path]));
-  return true;
+  return base::FilePath{base::SysNSStringToUTF8([[dialog URL] path])};
 }
 
 void SaveDialogCompletion(int chosen,

--- a/shell/browser/ui/file_dialog_win.cc
+++ b/shell/browser/ui/file_dialog_win.cc
@@ -257,11 +257,11 @@ std::optional<base::FilePath> ShowSaveDialogSync(
 void ShowSaveDialog(const DialogSettings& settings,
                     gin_helper::Promise<gin_helper::Dictionary> promise) {
   auto done = [](gin_helper::Promise<gin_helper::Dictionary> promise,
-                 bool success, base::FilePath result) {
+                 std::optional<base::FilePath> result) {
     v8::HandleScope handle_scope(promise.isolate());
     auto dict = gin::Dictionary::CreateEmpty(promise.isolate());
-    dict.Set("canceled", !success);
-    dict.Set("filePath", result);
+    dict.Set("canceled", !result.has_value());
+    dict.Set("filePath", result.value_or(base::FilePath{}));
     promise.Resolve(dict);
   };
   dialog_thread::Run(base::BindOnce(ShowSaveDialogSync, settings),


### PR DESCRIPTION
#### Description of Change

A small side refactor to [prefer return values to output parameters](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f20-for-out-output-values-prefer-return-values-to-output-parameters) in `ShowSaveDialogSync()`.

```diff
-  bool ShowSaveDialogSync(const DialogSettings& settings, base::FilePath* path);
+  std::optional<base::FilePath> ShowSaveDialogSync(const DialogSettings& settings);
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none