### PR TITLE
fix: crash calling `Fetch.continueResponse` with `WebContentsView`

### DIFF
--- a/shell/browser/api/electron_api_debugger.cc
+++ b/shell/browser/api/electron_api_debugger.cc
@@ -81,7 +81,11 @@ void Debugger::DispatchProtocolMessage(DevToolsAgentHost* agent_host,
 
 void Debugger::RenderFrameHostChanged(content::RenderFrameHost* old_rfh,
                                       content::RenderFrameHost* new_rfh) {
-  if (agent_host_) {
+  // ConnectWebContents uses the primary main frame of the webContents,
+  // so if the new_rfh is not the primary main frame, we don't want to
+  // reconnect otherwise we'll end up trying to reconnect to a RenderFrameHost
+  // that already has a DevToolsAgentHost associated with it.
+  if (agent_host_ && new_rfh->IsInPrimaryMainFrame()) {
     agent_host_->DisconnectWebContents();
     auto* web_contents = content::WebContents::FromRenderFrameHost(new_rfh);
     agent_host_->ConnectWebContents(web_contents);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/46109

Fixes an issue where calling `Fetch.continueResponse` via debugger with `WebContentsView` could cause a crash. Some light investigation showed that `RenderFrameDevToolsAgentHost::{Connect|Disconnect}WebContents()` relied on the primary main frame of the passed `webContents` to attach, but it might be the case that the `RenderFrameHost` at hand is not in its primary main frame. If the new `RenderFrameHost` is not the primary main frame, we don't want to reconnect otherwise we'll end up potentially trying to reconnect to a `RenderFrameHost` that already has a `DevToolsAgentHost` associated with it.

See also this known [bug in Chromium](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/devtools/render_frame_devtools_agent_host.cc;l=303-307;drc=5e74ac5d42bce00b534d992272e7fa09b53b300f;bpv=1;bpt=1).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where calling `Fetch.continueResponse` via debugger with `WebContentsView` could cause a crash.