### PR TITLE
feat: Use DIR_ASSETS path to locate resource bundles

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -602,6 +602,7 @@ Returns `string` - The current application directory.
     * `%APPDATA%` on Windows
     * `$XDG_CONFIG_HOME` or `~/.config` on Linux
     * `~/Library/Application Support` on macOS
+  * `assets` The directory where app assets such as `resources.pak` are stored. By default this is the same as the folder containing the `exe` path.
   * `userData` The directory for storing your app's configuration files, which
     by default is the `appData` directory appended with your app's name. By
     convention files storing user data should be written to this directory, and
@@ -616,7 +617,7 @@ Returns `string` - The current application directory.
     directory.
   * `temp` Temporary directory.
   * `exe` The current executable file.
-  * `module` The `libchromiumcontent` library.
+  * `module` The location of the Chromium module. By default this is synonymous with `exe`.
   * `desktop` The current user's Desktop directory.
   * `documents` Directory for a user's "My Documents".
   * `downloads` Directory for a user's downloads.

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -602,7 +602,7 @@ Returns `string` - The current application directory.
     * `%APPDATA%` on Windows
     * `$XDG_CONFIG_HOME` or `~/.config` on Linux
     * `~/Library/Application Support` on macOS
-  * `assets` The directory where app assets such as `resources.pak` are stored. By default this is the same as the folder containing the `exe` path.
+  * `assets` The directory where app assets such as `resources.pak` are stored. By default this is the same as the folder containing the `exe` path. Available on Windows and Linux only.
   * `userData` The directory for storing your app's configuration files, which
     by default is the `appData` directory appended with your app's name. By
     convention files storing user data should be written to this directory, and

--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -219,7 +219,7 @@ std::string LoadResourceBundle(const std::string& locale) {
   pak_dir =
       base::apple::FrameworkBundlePath().Append(FILE_PATH_LITERAL("Resources"));
 #else
-  base::PathService::Get(base::DIR_MODULE, &pak_dir);
+  base::PathService::Get(base::DIR_ASSETS, &pak_dir);
 #endif
 
   std::string loaded_locale = ui::ResourceBundle::InitSharedInstanceWithLocale(

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -383,6 +383,7 @@ int GetPathConstant(std::string_view name) {
   // clang-format off
   constexpr auto Lookup = base::MakeFixedFlatMap<std::string_view, int>({
       {"appData", DIR_APP_DATA},
+      {"assets", base::DIR_ASSETS},
 #if BUILDFLAG(IS_POSIX)
       {"cache", base::DIR_CACHE},
 #else

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -383,7 +383,9 @@ int GetPathConstant(std::string_view name) {
   // clang-format off
   constexpr auto Lookup = base::MakeFixedFlatMap<std::string_view, int>({
       {"appData", DIR_APP_DATA},
+#if !BUILDFLAG(IS_MAC)
       {"assets", base::DIR_ASSETS},
+#endif
 #if BUILDFLAG(IS_POSIX)
       {"cache", base::DIR_CACHE},
 #else

--- a/shell/common/asar/archive_win.cc
+++ b/shell/common/asar/archive_win.cc
@@ -26,13 +26,13 @@ const wchar_t kIntegrityCheckResourceType[] = L"Integrity";
 const wchar_t kIntegrityCheckResourceItem[] = L"ElectronAsar";
 
 std::optional<base::FilePath> Archive::RelativePath() const {
-  base::FilePath exe_path;
-  if (!base::PathService::Get(base::FILE_EXE, &exe_path)) {
-    LOG(FATAL) << "Couldn't get exe file path";
+  base::FilePath assets_dir;
+  if (!base::PathService::Get(base::DIR_ASSETS, &assets_dir)) {
+    LOG(FATAL) << "Couldn't get assets directory path";
   }
 
   base::FilePath relative_path;
-  if (!exe_path.DirName().AppendRelativePath(path_, &relative_path)) {
+  if (!assets_dir.AppendRelativePath(path_, &relative_path)) {
     return std::nullopt;
   }
 

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -456,11 +456,10 @@ base::FilePath GetResourcesPath() {
 #if BUILDFLAG(IS_MAC)
   return MainApplicationBundlePath().Append("Contents").Append("Resources");
 #else
-  auto* command_line = base::CommandLine::ForCurrentProcess();
-  base::FilePath exec_path(command_line->GetProgram());
-  base::PathService::Get(base::FILE_EXE, &exec_path);
+  base::FilePath assets_path;
+  base::PathService::Get(base::DIR_ASSETS, &assets_path);
 
-  return exec_path.DirName().Append(FILE_PATH_LITERAL("resources"));
+  return assets_path.Append(FILE_PATH_LITERAL("resources"));
 #endif
 }
 }  // namespace

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -1109,6 +1109,12 @@ describe('app module', () => {
       expect(paths).to.deep.equal([true, true, true]);
     });
 
+    it('returns an assets path that is identical to the exe parent directory', () => {
+      const assetsPath = app.getPath('assets');
+      expect(fs.existsSync(assetsPath)).to.be.true();
+      expect(assetsPath).to.equal(path.dirname(app.getPath('exe')));
+    });
+
     it('throws an error when the name is invalid', () => {
       expect(() => {
         app.getPath('does-not-exist' as any);

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -1109,11 +1109,19 @@ describe('app module', () => {
       expect(paths).to.deep.equal([true, true, true]);
     });
 
-    it('returns an assets path that is identical to the exe parent directory', () => {
-      const assetsPath = app.getPath('assets');
-      expect(fs.existsSync(assetsPath)).to.be.true();
-      expect(assetsPath).to.equal(path.dirname(app.getPath('exe')));
-    });
+    if (process.platform === 'darwin') {
+      it('returns an assets path that is identical to the resources path', () => {
+        const assetsPath = app.getPath('assets');
+        expect(fs.existsSync(assetsPath)).to.be.true();
+        expect(assetsPath).to.equal(process.resourcesPath);
+      });
+    } else {
+      it('returns an assets path that is identical to the module path', () => {
+        const assetsPath = app.getPath('assets');
+        expect(fs.existsSync(assetsPath)).to.be.true();
+        expect(assetsPath).to.equal(path.dirname(app.getPath('module')));
+      });
+    }
 
     it('throws an error when the name is invalid', () => {
       expect(() => {

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -1110,10 +1110,10 @@ describe('app module', () => {
     });
 
     if (process.platform === 'darwin') {
-      it('returns an assets path that is identical to the resources path', () => {
-        const assetsPath = app.getPath('assets');
-        expect(fs.existsSync(assetsPath)).to.be.true();
-        expect(assetsPath).to.equal(process.resourcesPath);
+      it('throws an error when trying to get the assets path on macOS', () => {
+        expect(() => {
+          app.getPath('assets' as any);
+        }).to.throw(/Failed to get 'assets' path/);
       });
     } else {
       it('returns an assets path that is identical to the module path', () => {


### PR DESCRIPTION
#### Description of Change

Electron currently uses the `DIR_MODULE` constants `DIR_EXE` when querying the `PathService` to calculate resource paths, but the [Chromium source](https://source.chromium.org/chromium/chromium/src/+/febc3ace14c2c7863c308ea1f27b5dd891245bd6:base/base_paths.h;l=35-38) and https://issues.chromium.org/issues/40203062 both discourage using these constants to  locate assets, and instead recommend using `DIR_ASSETS`.

By default `DIR_ASSETS` is an [alias](https://source.chromium.org/chromium/chromium/src/+/febc3ace14c2c7863c308ea1f27b5dd891245bd6:base/base_paths.cc;l=74-75) for `DIR_MODULE`, but by updating Electron to use `DIR_ASSETS`, we align better with Chromium recommendations, and make it possible for apps with custom layouts to only need to override `DIR_ASSETS`.

In addition to changing the constants used internally for loading `resources.pak` and for the `process.resourcesPath`, this PR adds "assets" as a key that can be queried via `app.getPath`.

Because `DIR_ASSETS` is treated as an alias for `DIR_MODULE` by default, these changes should be a no-op for any existing apps.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Internally switched to using `DIR_ASSETS` instead of `DIR_MODULE`/`DIR_EXE` to locate assets and resources, and added "assets" as a key that can be queried via `app.getPath`.
