### PR TITLE
refactor: move `gin::Converter<PreloadScript>` impl to a .cc file

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -479,6 +479,7 @@ filenames = {
     "shell/browser/osr/osr_web_contents_view.h",
     "shell/browser/plugins/plugin_utils.cc",
     "shell/browser/plugins/plugin_utils.h",
+    "shell/browser/preload_script.cc",
     "shell/browser/preload_script.h",
     "shell/browser/protocol_registry.cc",
     "shell/browser/protocol_registry.h",

--- a/shell/browser/preload_script.cc
+++ b/shell/browser/preload_script.cc
@@ -1,0 +1,82 @@
+// Copyright (c) 2025 Salesforce, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/preload_script.h"
+
+#include "base/containers/fixed_flat_map.h"
+#include "base/files/file_path.h"
+#include "base/uuid.h"
+#include "shell/common/gin_converters/file_path_converter.h"
+#include "shell/common/gin_helper/dictionary.h"
+
+namespace gin {
+
+using electron::PreloadScript;
+
+// static
+v8::Local<v8::Value> Converter<PreloadScript::ScriptType>::ToV8(
+    v8::Isolate* isolate,
+    const PreloadScript::ScriptType& in) {
+  using Val = PreloadScript::ScriptType;
+  static constexpr auto Lookup = base::MakeFixedFlatMap<Val, std::string_view>({
+      {Val::kWebFrame, "frame"},
+      {Val::kServiceWorker, "service-worker"},
+  });
+  return StringToV8(isolate, Lookup.at(in));
+}
+
+// static
+bool Converter<PreloadScript::ScriptType>::FromV8(
+    v8::Isolate* isolate,
+    v8::Local<v8::Value> val,
+    PreloadScript::ScriptType* out) {
+  using Val = PreloadScript::ScriptType;
+  static constexpr auto Lookup = base::MakeFixedFlatMap<std::string_view, Val>({
+      {"frame", Val::kWebFrame},
+      {"service-worker", Val::kServiceWorker},
+  });
+  return FromV8WithLookup(isolate, val, Lookup, out);
+}
+
+// static
+v8::Local<v8::Value> Converter<PreloadScript>::ToV8(
+    v8::Isolate* isolate,
+    const PreloadScript& script) {
+  gin::Dictionary dict(isolate, v8::Object::New(isolate));
+  dict.Set("filePath", script.file_path.AsUTF8Unsafe());
+  dict.Set("id", script.id);
+  dict.Set("type", script.script_type);
+  return ConvertToV8(isolate, dict).As<v8::Object>();
+}
+
+// static
+bool Converter<PreloadScript>::FromV8(v8::Isolate* isolate,
+                                      v8::Local<v8::Value> val,
+                                      PreloadScript* out) {
+  gin_helper::Dictionary options;
+  if (!ConvertFromV8(isolate, val, &options))
+    return false;
+  if (PreloadScript::ScriptType script_type;
+      options.Get("type", &script_type)) {
+    out->script_type = script_type;
+  } else {
+    return false;
+  }
+  if (base::FilePath file_path; options.Get("filePath", &file_path)) {
+    out->file_path = file_path;
+  } else {
+    return false;
+  }
+  if (std::string id; options.Get("id", &id)) {
+    out->id = id;
+  } else {
+    out->id = base::Uuid::GenerateRandomV4().AsLowercaseString();
+  }
+  if (bool deprecated; options.Get("_deprecated", &deprecated)) {
+    out->deprecated = deprecated;
+  }
+  return true;
+}
+
+}  // namespace gin

--- a/shell/browser/preload_script.h
+++ b/shell/browser/preload_script.h
@@ -5,14 +5,11 @@
 #ifndef ELECTRON_SHELL_BROWSER_PRELOAD_SCRIPT_H_
 #define ELECTRON_SHELL_BROWSER_PRELOAD_SCRIPT_H_
 
-#include <string_view>
+#include <string>
 
-#include "base/containers/fixed_flat_map.h"
 #include "base/files/file_path.h"
-#include "base/uuid.h"
 #include "gin/converter.h"
-#include "shell/common/gin_converters/file_path_converter.h"
-#include "shell/common/gin_helper/dictionary.h"
+#include "v8/include/v8-forward.h"
 
 namespace electron {
 
@@ -36,67 +33,19 @@ using electron::PreloadScript;
 template <>
 struct Converter<PreloadScript::ScriptType> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   const PreloadScript::ScriptType& in) {
-    using Val = PreloadScript::ScriptType;
-    static constexpr auto Lookup =
-        base::MakeFixedFlatMap<Val, std::string_view>({
-            {Val::kWebFrame, "frame"},
-            {Val::kServiceWorker, "service-worker"},
-        });
-    return StringToV8(isolate, Lookup.at(in));
-  }
-
+                                   const PreloadScript::ScriptType& in);
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
-                     PreloadScript::ScriptType* out) {
-    using Val = PreloadScript::ScriptType;
-    static constexpr auto Lookup =
-        base::MakeFixedFlatMap<std::string_view, Val>({
-            {"frame", Val::kWebFrame},
-            {"service-worker", Val::kServiceWorker},
-        });
-    return FromV8WithLookup(isolate, val, Lookup, out);
-  }
+                     PreloadScript::ScriptType* out);
 };
 
 template <>
 struct Converter<PreloadScript> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   const PreloadScript& script) {
-    gin::Dictionary dict(isolate, v8::Object::New(isolate));
-    dict.Set("filePath", script.file_path.AsUTF8Unsafe());
-    dict.Set("id", script.id);
-    dict.Set("type", script.script_type);
-    return ConvertToV8(isolate, dict).As<v8::Object>();
-  }
-
+                                   const PreloadScript& script);
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
-                     PreloadScript* out) {
-    gin_helper::Dictionary options;
-    if (!ConvertFromV8(isolate, val, &options))
-      return false;
-    if (PreloadScript::ScriptType script_type;
-        options.Get("type", &script_type)) {
-      out->script_type = script_type;
-    } else {
-      return false;
-    }
-    if (base::FilePath file_path; options.Get("filePath", &file_path)) {
-      out->file_path = file_path;
-    } else {
-      return false;
-    }
-    if (std::string id; options.Get("id", &id)) {
-      out->id = id;
-    } else {
-      out->id = base::Uuid::GenerateRandomV4().AsLowercaseString();
-    }
-    if (bool deprecated; options.Get("_deprecated", &deprecated)) {
-      out->deprecated = deprecated;
-    }
-    return true;
-  }
+                     PreloadScript* out);
 };
 
 }  // namespace gin


### PR DESCRIPTION
#### Description of Change

Small refactor to just move the implementation of `gin::Converter<PreloadScript>` from a header file into a cc file. Since `preload_script.h` is indirectly included by a lot of our source files, this change helps reduce incidental includes.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.