### PR TITLE
fix: utilityProcess running user script after process.exit is called

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -27,6 +27,16 @@ process.on('unhandledRejection', () => {
 })
 ```
 
+### Behavior Changed: `process.exit()` kills utility process synchronously
+
+Calling `process.exit()` in a utility process will now kill the utility process synchronously.
+This brings the behavior of `process.exit()` in line with Node.js behavior.
+
+Please refer to the
+[Node.js docs](https://nodejs.org/docs/latest-v22.x/api/process.html#processexitcode) and
+[PR #45690](https://github.com/electron/electron/pull/45690) to understand the potential
+implications of that, e.g., when calling `console.log()` before `process.exit()`.
+
 ### Behavior Changed: WebUSB and WebSerial Blocklist Support
 
 [WebUSB](https://developer.mozilla.org/en-US/docs/Web/API/WebUSB_API) and [Web Serial](https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API) now support the [WebUSB Blocklist](https://wicg.github.io/webusb/#blocklist) and [Web Serial Blocklist](https://wicg.github.io/serial/#blocklist) used by Chromium and outlined in their respective specifications.

--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -100,9 +100,7 @@ NodeService::~NodeService() {
     ParentPort::GetInstance()->Close();
     js_env_->DestroyMicrotasksRunner();
     node::Stop(node_env_.get(), node::StopFlags::kDoNotTerminateIsolate);
-    if (g_client_remote.is_bound()) {
-      g_client_remote.reset();
-    }
+    g_client_remote.reset();
   }
 }
 
@@ -151,9 +149,7 @@ void NodeService::Initialize(
         node_env_stopped_ = true;
         ParentPort::GetInstance()->Close();
         js_env_->DestroyMicrotasksRunner();
-        if (g_client_remote.is_bound()) {
-          g_client_remote.reset();
-        }
+        g_client_remote.reset();
         receiver_.ResetWithReason(exit_code, "process_exit_termination");
         node::DefaultProcessExitHandler(env, exit_code);
       });

--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -9,6 +9,7 @@
 
 #include "base/command_line.h"
 #include "base/no_destructor.h"
+#include "base/process/process.h"
 #include "base/strings/utf_string_conversions.h"
 #include "electron/mas.h"
 #include "services/network/public/cpp/wrapper_shared_url_loader_factory.h"
@@ -99,9 +100,9 @@ NodeService::~NodeService() {
     ParentPort::GetInstance()->Close();
     js_env_->DestroyMicrotasksRunner();
     node::Stop(node_env_.get(), node::StopFlags::kDoNotTerminateIsolate);
-  }
-  if (g_client_remote.is_bound()) {
-    g_client_remote.reset();
+    if (g_client_remote.is_bound()) {
+      g_client_remote.reset();
+    }
   }
 }
 
@@ -147,12 +148,14 @@ void NodeService::Initialize(
   node::SetProcessExitHandler(
       node_env_.get(), [this](node::Environment* env, int exit_code) {
         // Destroy node platform.
-        env->set_trace_sync_io(false);
+        node_env_stopped_ = true;
         ParentPort::GetInstance()->Close();
         js_env_->DestroyMicrotasksRunner();
-        node::Stop(env, node::StopFlags::kDoNotTerminateIsolate);
-        node_env_stopped_ = true;
+        if (g_client_remote.is_bound()) {
+          g_client_remote.reset();
+        }
         receiver_.ResetWithReason(exit_code, "process_exit_termination");
+        node::DefaultProcessExitHandler(env, exit_code);
       });
 
   node_env_->set_trace_sync_io(node_env_->options()->trace_sync_io);

--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -129,6 +129,20 @@ describe('utilityProcess module', () => {
       expect(code).to.equal(exitCode);
     });
 
+    it('does not run JS after process.exit is called', async () => {
+      const child = utilityProcess.fork(path.join(fixturesPath, 'no-js-after-exit.js'), [], {
+        stdio: 'pipe'
+      });
+      expect(child.stdout).to.not.be.null();
+      let log = '';
+      child.stdout!.on('data', (chunk) => {
+        log += chunk.toString('utf8');
+      });
+      const [code] = await once(child, 'exit');
+      expect(code).to.equal(1);
+      expect(log).to.be.empty();
+    });
+
     // 32-bit system will not have V8 Sandbox enabled.
     // WoA testing does not have VS toolchain configured to build native addons.
     ifit(process.arch !== 'ia32' && process.arch !== 'arm' && !isWindowsOnArm)('emits \'error\' when fatal error is triggered from V8', async () => {

--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -135,14 +135,18 @@ describe('utilityProcess module', () => {
       const [code] = await once(child, 'exit');
       expect(code).to.equal(1);
       let handle = null;
+      const lines = [];
       try {
         handle = await fs.open(file);
         for await (const line of handle.readLines()) {
-          expect(line).to.not.contain('after exit');
+          lines.push(line);
         }
       } finally {
         await handle?.close();
+        await fs.rm(file, { force: true });
       }
+      expect(lines.length).to.equal(1);
+      expect(lines[0]).to.equal('before exit');
     });
 
     // 32-bit system will not have V8 Sandbox enabled.

--- a/spec/fixtures/api/utility-process/no-js-after-exit.js
+++ b/spec/fixtures/api/utility-process/no-js-after-exit.js
@@ -1,2 +1,7 @@
+const { writeFileSync } = require('node:fs');
+
+const arg = process.argv[2];
+const file = arg.split('=')[1];
+writeFileSync(file, 'before exit');
 process.exit(1);
-process.stdout.write('Unexpected');
+writeFileSync(file, 'after exit');

--- a/spec/fixtures/api/utility-process/no-js-after-exit.js
+++ b/spec/fixtures/api/utility-process/no-js-after-exit.js
@@ -1,0 +1,2 @@
+process.exit(1);
+process.stdout.write('Unexpected');


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/44174

Relies on the `node::DefaultProcessExitHandler` to ensure termination of the process after performing our own cleanup related to the utility process.

#### Release Notes

Notes: fix utilityProcess running user script after process.exit is called