### PR TITLE
fix: revert moving IsClosed() and IsClosable() into NativeWindow::Close()

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -362,7 +362,8 @@ void BaseWindow::SetContentView(gin::Handle<View> view) {
 }
 
 void BaseWindow::CloseImmediately() {
-  window_->CloseImmediately();
+  if (!window_->IsClosed())
+    window_->CloseImmediately();
 }
 
 void BaseWindow::Close() {

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -279,6 +279,10 @@ NativeWindow* NativeWindow::FromWidget(const views::Widget* widget) {
       widget->GetNativeWindowProperty(kNativeWindowKey.c_str()));
 }
 
+bool NativeWindow::IsClosed() const {
+  return is_closed_;
+}
+
 void NativeWindow::SetSize(const gfx::Size& size, bool animate) {
   SetBounds(gfx::Rect(GetPosition(), size), animate);
 }
@@ -516,23 +520,8 @@ void NativeWindow::NotifyWindowCloseButtonClicked() {
   CloseImmediately();
 }
 
-void NativeWindow::Close() {
-  if (!IsClosable()) {
-    WindowList::WindowCloseCancelled(this);
-    return;
-  }
-
-  if (!is_closed())
-    CloseImpl();
-}
-
-void NativeWindow::CloseImmediately() {
-  if (!is_closed())
-    CloseImmediatelyImpl();
-}
-
 void NativeWindow::NotifyWindowClosed() {
-  if (is_closed())
+  if (is_closed_)
     return;
 
   is_closed_ = true;

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -81,10 +81,9 @@ class NativeWindow : public base::SupportsUserData,
 
   virtual void SetContentView(views::View* view) = 0;
 
-  // wrapper around CloseImpl that checks that window_ can be closed
-  void Close();
-  // wrapper around CloseImmediatelyImpl that checks that window_ can be closed
-  void CloseImmediately();
+  virtual void Close() = 0;
+  virtual void CloseImmediately() = 0;
+  virtual bool IsClosed() const;
   virtual void Focus(bool focus) = 0;
   virtual bool IsFocused() const = 0;
   virtual void Show() = 0;
@@ -433,9 +432,9 @@ class NativeWindow : public base::SupportsUserData,
   void UpdateBackgroundThrottlingState();
 
  protected:
-  constexpr void set_has_frame(const bool val) { has_frame_ = val; }
+  friend class api::BrowserView;
 
-  [[nodiscard]] constexpr bool is_closed() const { return is_closed_; }
+  constexpr void set_has_frame(const bool val) { has_frame_ = val; }
 
   NativeWindow(const gin_helper::Dictionary& options, NativeWindow* parent);
 
@@ -451,9 +450,6 @@ class NativeWindow : public base::SupportsUserData,
   std::u16string GetAccessibleWindowTitle() const override;
 
   void set_content_view(views::View* view) { content_view_ = view; }
-
-  virtual void CloseImpl() = 0;
-  virtual void CloseImmediatelyImpl() = 0;
 
   static inline constexpr base::cstring_view kNativeWindowKey =
       "__ELECTRON_NATIVE_WINDOW__";

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -38,8 +38,8 @@ class NativeWindowMac : public NativeWindow,
 
   // NativeWindow:
   void SetContentView(views::View* view) override;
-  void CloseImpl() override;
-  void CloseImmediatelyImpl() override;
+  void Close() override;
+  void CloseImmediately() override;
   void Focus(bool focus) override;
   bool IsFocused() const override;
   void Show() override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -33,6 +33,7 @@
 #include "shell/browser/ui/cocoa/root_view_mac.h"
 #include "shell/browser/ui/cocoa/window_buttons_proxy.h"
 #include "shell/browser/ui/drag_util.h"
+#include "shell/browser/window_list.h"
 #include "shell/common/gin_converters/gfx_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_util.h"
@@ -340,7 +341,12 @@ void NativeWindowMac::SetContentView(views::View* view) {
   root_view->DeprecatedLayoutImmediately();
 }
 
-void NativeWindowMac::CloseImpl() {
+void NativeWindowMac::Close() {
+  if (!IsClosable()) {
+    WindowList::WindowCloseCancelled(this);
+    return;
+  }
+
   if (is_transitioning_fullscreen()) {
     SetHasDeferredWindowClose(true);
     return;
@@ -376,7 +382,7 @@ void NativeWindowMac::CloseImpl() {
   }
 }
 
-void NativeWindowMac::CloseImmediatelyImpl() {
+void NativeWindowMac::CloseImmediately() {
   // Ensure we're detached from the parent window before closing.
   RemoveChildFromParentWindow();
 
@@ -1693,7 +1699,7 @@ bool NativeWindowMac::IsActive() const {
 }
 
 void NativeWindowMac::Cleanup() {
-  DCHECK(!is_closed());
+  DCHECK(!IsClosed());
   ui::NativeTheme::GetInstanceForNativeUi()->RemoveObserver(this);
   display::Screen::GetScreen()->RemoveObserver(this);
   [window_ cleanup];

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -31,6 +31,7 @@
 #include "shell/browser/ui/views/root_view.h"
 #include "shell/browser/web_contents_preferences.h"
 #include "shell/browser/web_view_manager.h"
+#include "shell/browser/window_list.h"
 #include "shell/common/electron_constants.h"
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
@@ -478,11 +479,16 @@ void NativeWindowViews::SetContentView(views::View* view) {
   root_view_.GetMainView()->DeprecatedLayoutImmediately();
 }
 
-void NativeWindowViews::CloseImpl() {
+void NativeWindowViews::Close() {
+  if (!IsClosable()) {
+    WindowList::WindowCloseCancelled(this);
+    return;
+  }
+
   widget()->Close();
 }
 
-void NativeWindowViews::CloseImmediatelyImpl() {
+void NativeWindowViews::CloseImmediately() {
   widget()->CloseNow();
 }
 

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -48,8 +48,8 @@ class NativeWindowViews : public NativeWindow,
 
   // NativeWindow:
   void SetContentView(views::View* view) override;
-  void CloseImpl() override;
-  void CloseImmediatelyImpl() override;
+  void Close() override;
+  void CloseImmediately() override;
   void Focus(bool focus) override;
   bool IsFocused() const override;
   void Show() override;

--- a/shell/browser/window_list.cc
+++ b/shell/browser/window_list.cc
@@ -84,7 +84,7 @@ void WindowList::CloseAllWindows() {
   std::ranges::reverse(weak_windows);
 #endif
   for (const auto& window : weak_windows) {
-    if (window)
+    if (window && !window->IsClosed())
       window->Close();
   }
 }
@@ -95,7 +95,7 @@ void WindowList::DestroyAllWindows() {
       ConvertToWeakPtrVector(GetInstance()->windows_);
 
   for (const auto& window : weak_windows) {
-    if (window)
+    if (window && !window->IsClosed())
       window->CloseImmediately();
   }
 }


### PR DESCRIPTION
Manual backport of 47482

See that PR for details.

Notes: Fixed an issue on application close on Windows, where not all processes are quit on close.