### PR TITLE
docs: improve desktop-capturer loopback docs

### DIFF
--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -100,23 +100,27 @@ Returns `Promise<DesktopCapturerSource[]>` - Resolves with an array of [`Desktop
 [`navigator.mediaDevices.getUserMedia`]: https://developer.mozilla.org/en/docs/Web/API/MediaDevices/getUserMedia
 [`systemPreferences.getMediaAccessStatus`]: system-preferences.md#systempreferencesgetmediaaccessstatusmediatype-windows-macos
 
-## System Audio Capture (macOS 13+)
+## System Audio Capture (macOS 12.3+)
 
- On macOS 13+, `navigator.mediaDevices.getDisplayMedia` can be used to capture system audio
+ On macOS 12.3+, `navigator.mediaDevices.getDisplayMedia` can be used to capture system audio
  if the [`setDisplayMediaRequestHandler`](./session.md#sessetdisplaymediarequesthandlerhandler-opts) `callback` 
- is passed a stream that has `audio: 'loopback'`. See the [example](./desktop-capturer.md) above.
+ is passed a `streams` object that has `audio: 'loopback'`. See the example above.
 
 > [!NOTE]
 > Due to ongoing changes in Chromium, capturing system audio is experimental on macOS 15+ and requires the 
-> following command line switch to be appended:
+> following [command line switch](./command-line-switches.md) to be appended. Please note that you may experience bugs.
 >
 > ```js
 > // main.js
 > app.commandLine.appendSwitch('enable-features', 'MacSckSystemAudioLoopbackOverride');
 > ```
 
-## System Audio Capture (macOS 12.3 or lower)
+## System Audio Capture (before macOS 12.3)
 
-On macOS 12.3 or lower, system audio capture is not supported due to a fundamental limitation whereby apps that want to access the system's audio require a [signed kernel extension](https://developer.apple.com/library/archive/documentation/Security/Conceptual/System_Integrity_Protection_Guide/KernelExtensions/KernelExtensions.html). Chromium, and by extension Electron, does not provide this.
+On macOS 12.3 or lower, system audio capture is not supported due to a fundamental limitation whereby 
+apps that want to access the system's audio require a [signed kernel extension](https://developer.apple.com/library/archive/documentation/Security/ConceptualSystem_Integrity_Protection_Guide/KernelExtensions/KernelExtensions.html). 
+Chromium, and by extension Electron, does not provide this.
 
-It is possible to circumvent this limitation by capturing system audio with another macOS app like Soundflower and passing it through a virtual audio input device. This virtual device can then be queried with `navigator.mediaDevices.getUserMedia`.
+It is possible to circumvent this limitation by capturing system audio with another macOS app like 
+Soundflower and passing it through a virtual audio input device. This virtual device can then be 
+queried with `navigator.mediaDevices.getUserMedia`.

--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -117,6 +117,6 @@ Returns `Promise<DesktopCapturerSource[]>` - Resolves with an array of [`Desktop
 
 ## System Audio Capture (macOS 12.3 or lower)
 
-On macOS 12.3 or lower, `navigator.mediaDevices.getUserMedia` does not work for system audio capture due to a fundamental limitation whereby apps that want to access the system's audio require a [signed kernel extension](https://developer.apple.com/library/archive/documentation/Security/Conceptual/System_Integrity_Protection_Guide/KernelExtensions/KernelExtensions.html). Chromium, and by extension Electron, does not provide this.
+On macOS 12.3 or lower, system audio capture is not supported due to a fundamental limitation whereby apps that want to access the system's audio require a [signed kernel extension](https://developer.apple.com/library/archive/documentation/Security/Conceptual/System_Integrity_Protection_Guide/KernelExtensions/KernelExtensions.html). Chromium, and by extension Electron, does not provide this.
 
 It is possible to circumvent this limitation by capturing system audio with another macOS app like Soundflower and passing it through a virtual audio input device. This virtual device can then be queried with `navigator.mediaDevices.getUserMedia`.

--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -100,7 +100,9 @@ Returns `Promise<DesktopCapturerSource[]>` - Resolves with an array of [`Desktop
 [`navigator.mediaDevices.getUserMedia`]: https://developer.mozilla.org/en/docs/Web/API/MediaDevices/getUserMedia
 [`systemPreferences.getMediaAccessStatus`]: system-preferences.md#systempreferencesgetmediaaccessstatusmediatype-windows-macos
 
-## System Audio Capture (macOS 12.3+)
+## macOS Caveats
+
+### System Audio Capture (macOS 12.3+)
 
  On macOS 12.3+, `navigator.mediaDevices.getDisplayMedia` can be used to capture system audio
  if the [`setDisplayMediaRequestHandler`](./session.md#sessetdisplaymediarequesthandlerhandler-opts) `callback` 
@@ -115,7 +117,7 @@ Returns `Promise<DesktopCapturerSource[]>` - Resolves with an array of [`Desktop
 > app.commandLine.appendSwitch('enable-features', 'MacSckSystemAudioLoopbackOverride');
 > ```
 
-## System Audio Capture (before macOS 12.3)
+### System Audio Capture (before macOS 12.3)
 
 On macOS 12.3 or lower, system audio capture is not supported due to a fundamental limitation whereby 
 apps that want to access the system's audio require a [signed kernel extension](https://developer.apple.com/library/archive/documentation/Security/ConceptualSystem_Integrity_Protection_Guide/KernelExtensions/KernelExtensions.html). 

--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -5,8 +5,7 @@
 
 Process: [Main](../glossary.md#main-process)
 
-The following example shows how to capture video from a desktop window whose
-title is `Electron`:
+The following example shows how to capture video and system audio (if supported) of the current desktop:
 
 ```js
 // main.js
@@ -99,6 +98,20 @@ Returns `Promise<DesktopCapturerSource[]>` - Resolves with an array of [`Desktop
 
 [`navigator.mediaDevices.getUserMedia`]: https://developer.mozilla.org/en/docs/Web/API/MediaDevices/getUserMedia
 [`systemPreferences.getMediaAccessStatus`]: system-preferences.md#systempreferencesgetmediaaccessstatusmediatype-windows-macos
+
+## Loopback Audio on macOS 13/14/15
+
+On macOS 13 and macOS 14, `navigator.mediaDevices.getDisplayMedia` may be used to capture loopback audio if the [`setDisplayMediaRequestHandler`](./session.md#sessetdisplaymediarequesthandlerhandler-opts) callback is returned with `audio: 'loopback'`.
+
+For macOS 15+, loopback audio is only supported if the following experimental command line switches are appended:
+
+```js
+// main.js
+app.commandLine.appendSwitch('enable-features', 'MacLoopbackAudioForScreenShare,MacSckSystemAudioLoopbackOverride');
+```
+
+> [!NOTE]
+> Loopback audio is not supported on any macOS version in `navigator.mediaDevices.getUserMedia`.
 
 ## Caveats
 


### PR DESCRIPTION
#### Description of Change

- Improves documentation related to `desktopCapturer` audio loopback on macOS
- Resolves https://github.com/electron/electron/issues/47490.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
