### PR TITLE
ci: fix sending Slack message in CI audit workflow

### DIFF
--- a/.github/workflows/audit-branch-ci.yml
+++ b/.github/workflows/audit-branch-ci.yml
@@ -136,7 +136,7 @@ jobs:
 
             await core.summary.write();
       - name: Send Slack message if errors
-        if: ${{ steps.audit-errors.outputs.errorsFound && github.ref == 'refs/heads/main' }}
+        if: ${{ always() && steps.audit-errors.outputs.errorsFound && github.ref == 'refs/heads/main' }}
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
           payload: |


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Follow-up to #47404 which was a little too zealous in quieting the Slack messages and now they're not sending at all. The `always()` condition is needed for the rest of the conditional to be evaluated when the audit fails.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
