### PR TITLE
feat: implement two-finger swipe navigation support for macOS

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -272,6 +272,10 @@ static_library("chrome") {
       "//chrome/browser/permissions/system/media_authorization_wrapper_mac.h",
       "//chrome/browser/platform_util_mac.mm",
       "//chrome/browser/process_singleton_mac.mm",
+      "//chrome/browser/renderer_host/chrome_render_widget_host_view_mac_history_swiper.h",
+      "//chrome/browser/renderer_host/chrome_render_widget_host_view_mac_history_swiper.mm",
+      "//chrome/browser/renderer_host/chrome_render_widget_host_view_mac_delegate.h",
+      "//chrome/browser/renderer_host/chrome_render_widget_host_view_mac_delegate.mm",
       "//chrome/browser/ui/views/eye_dropper/eye_dropper_view_mac.h",
       "//chrome/browser/ui/views/eye_dropper/eye_dropper_view_mac.mm",
     ]

--- a/docs/api/structures/web-preferences.md
+++ b/docs/api/structures/web-preferences.md
@@ -52,6 +52,7 @@
   Default is `false`.
 * `scrollBounce` boolean (optional) _macOS_ - Enables scroll bounce
   (rubber banding) effect on macOS. Default is `false`.
+* `enableTwoFingerSwipe` boolean (optional) _macOS_ - Enables two-finger swipe navigation on macOS. Default is `false`.
 * `enableBlinkFeatures` string (optional) - A list of feature strings separated by `,`, like
   `CSSVariables,KeyboardEventKey` to enable. The full list of supported feature
   strings can be found in the [RuntimeEnabledFeatures.json5][runtime-enabled-features]

--- a/patches/chromium/enable_history_swiper_with_web_preferences.patch
+++ b/patches/chromium/enable_history_swiper_with_web_preferences.patch
@@ -1,0 +1,84 @@
+diff --git a/content/browser/renderer_host/render_widget_host_view_mac.h b/content/browser/renderer_host/render_widget_host_view_mac.h
+index 1111111111111111111111111111111111111111..2222222222222222222222222222222222222222 100644
+--- a/content/browser/renderer_host/render_widget_host_view_mac.h
++++ b/content/browser/renderer_host/render_widget_host_view_mac.h
+@@ -50,6 +50,11 @@ class ScopedPasswordInputEnabler;
+ class WebCursor;
+ }  // namespace content
+ 
++#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
++class HistorySwiper;
++namespace electron { class WebContentsPreferences; }
++#endif
++
+ @class RenderWidgetHostViewCocoa;
+ 
+ namespace content {
+@@ -400,6 +405,12 @@ class CONTENT_EXPORT RenderWidgetHostViewMac
+   void SetActive(bool active) override;
+   void SpeakSelection() override;
+   void SetWindowFrameInScreen(const gfx::Rect& rect) override;
++
++#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
++  // Check if two-finger swipe navigation should be enabled via WebPreferences
++  bool ShouldEnableHistorySwiper() const;
++  std::unique_ptr<HistorySwiper> history_swiper_;
++#endif
+ 
+  private:
+   friend class RenderWidgetHostViewMacTest;
+diff --git a/content/browser/renderer_host/render_widget_host_view_mac.mm b/content/browser/renderer_host/render_widget_host_view_mac.mm
+index 1111111111111111111111111111111111111111..2222222222222222222222222222222222222222 100644
+--- a/content/browser/renderer_host/render_widget_host_view_mac.mm
++++ b/content/browser/renderer_host/render_widget_host_view_mac.mm
+@@ -90,6 +90,11 @@
+ #include "ui/base/cocoa/secure_password_input.h"
+ #include "ui/base/cocoa/text_services_context_menu.h"
+ 
++#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
++#include "chrome/browser/renderer_host/chrome_render_widget_host_view_mac_history_swiper.h"
++#include "shell/browser/web_contents_preferences.h"
++#endif
++
+ using blink::DragOperationsMask;
+ using blink::WebInputEvent;
+ using blink::WebMouseEvent;
+@@ -1234,6 +1239,21 @@ void RenderWidgetHostViewMac::SetActive(bool active) {
+   if (host_->is_hidden())
+     return;
+ 
++#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
++  // Initialize history swiper if enabled via WebPreferences
++  if (ShouldEnableHistorySwiper() && !history_swiper_) {
++    history_swiper_ = std::make_unique<HistorySwiper>(
++        this, cocoa_view_, 
++        base::BindRepeating(&RenderWidgetHostViewMac::NavigateToHistoryOffset,
++                           base::Unretained(this)));
++  } else if (!ShouldEnableHistorySwiper() && history_swiper_) {
++    // Disable history swiper if preference is turned off
++    history_swiper_.reset();
++  }
++#endif
++
+   if (HasFocus())
+     host_->Focus();
+   else
+@@ -1242,6 +1262,19 @@ void RenderWidgetHostViewMac::SetActive(bool active) {
+   host_->SetActive(active);
+ }
+ 
++#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
++bool RenderWidgetHostViewMac::ShouldEnableHistorySwiper() const {
++  if (auto* web_contents = content::WebContents::FromRenderViewHost(
++          host_->render_view_host())) {
++    if (auto* preferences = electron::WebContentsPreferences::From(web_contents)) {
++      return preferences->ShouldEnableTwoFingerSwipe();
++    }
++  }
++  return false;
++}
++#endif
++
+ void RenderWidgetHostViewMac::SpeakSelection() {
+   RenderWidgetHostView::SpeakSelection();
+ }

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -218,6 +218,9 @@ class NativeWindowMac : public NativeWindow,
     default_frame_for_zoom_ = frame;
   }
 
+  // Check if two-finger swipe navigation is enabled via WebPreferences
+  bool ShouldEnableTwoFingerSwipe() const;
+
  protected:
   // views::WidgetDelegate:
   views::View* GetContentsView() override;

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -153,6 +153,7 @@ void WebContentsPreferences::Clear() {
 
 #if BUILDFLAG(IS_MAC)
   scroll_bounce_ = false;
+  enable_two_finger_swipe_ = false;
 #endif
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   spellcheck_ = true;
@@ -254,6 +255,7 @@ void WebContentsPreferences::SetFromDictionary(
 
 #if BUILDFLAG(IS_MAC)
   web_preferences.Get(options::kScrollBounce, &scroll_bounce_);
+  web_preferences.Get(options::kEnableTwoFingerSwipe, &enable_two_finger_swipe_);
 #endif
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -489,4 +489,11 @@ void WebContentsPreferences::OverrideWebkitPrefs(
 
 WEB_CONTENTS_USER_DATA_KEY_IMPL(WebContentsPreferences);
 
+#if BUILDFLAG(IS_MAC)
+bool WebContentsPreferences::ShouldEnableTwoFingerSwipe() const {
+  return enable_two_finger_swipe_;
+}
+#endif
+
+
 }  // namespace electron

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -72,6 +72,9 @@ class WebContentsPreferences
   bool ShouldDisableHtmlFullscreenWindowResize() const {
     return disable_html_fullscreen_window_resize_;
   }
+#if BUILDFLAG(IS_MAC)
+  bool ShouldEnableTwoFingerSwipe() const { return enable_two_finger_swipe_; }
+#endif
   bool AllowsNodeIntegrationInSubFrames() const {
     return node_integration_in_sub_frames_;
   }
@@ -138,6 +141,7 @@ class WebContentsPreferences
 
 #if BUILDFLAG(IS_MAC)
   bool scroll_bounce_;
+  bool enable_two_finger_swipe_;
 #endif
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   bool spellcheck_;

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -220,6 +220,9 @@ inline constexpr std::string_view kEnableDeprecatedPaste =
 // Whether the -electron-corner-smoothing CSS rule is enabled.
 inline constexpr std::string_view kEnableCornerSmoothingCSS =
     "enableCornerSmoothingCSS";
+
+// Whether to enable two-finger swipe navigation.
+inline constexpr std::string_view kEnableTwoFingerSwipe = "enableTwoFingerSwipe";
 }  // namespace options
 
 // Following are actually command line switches, should be moved to other files.


### PR DESCRIPTION
> Be advised, this PR is written by Devin.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

This PR implements support for two-finger swipe navigation in Electron for macOS as an opt-in feature, addressing GitHub issue #2683.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
