### PR TITLE
fix: ensure `/dev/null` fd is closed on failure

### DIFF
--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -78,6 +78,9 @@ UtilityProcessWrapper::UtilityProcessWrapper(
   base::FileHandleMappingVector fds_to_remap;
 #endif
   for (const auto& [io_handle, io_type] : stdio) {
+    if (io_handle == IOHandle::STDIN)
+      continue;
+
     if (io_type == IOType::IO_PIPE) {
 #if BUILDFLAG(IS_WIN)
       HANDLE read = nullptr;
@@ -129,6 +132,7 @@ UtilityProcessWrapper::UtilityProcessWrapper(
                       OPEN_EXISTING, 0, nullptr);
       if (handle == INVALID_HANDLE_VALUE) {
         PLOG(ERROR) << "Failed to create null handle";
+        CloseHandle(handle);
         return;
       }
       if (io_handle == IOHandle::STDOUT) {
@@ -140,6 +144,7 @@ UtilityProcessWrapper::UtilityProcessWrapper(
       int devnull = open("/dev/null", O_WRONLY);
       if (devnull < 0) {
         PLOG(ERROR) << "failed to open /dev/null";
+        close(devnull);
         return;
       }
       if (io_handle == IOHandle::STDOUT) {

--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -132,7 +132,6 @@ UtilityProcessWrapper::UtilityProcessWrapper(
                       OPEN_EXISTING, 0, nullptr);
       if (handle == INVALID_HANDLE_VALUE) {
         PLOG(ERROR) << "Failed to create null handle";
-        CloseHandle(handle);
         return;
       }
       if (io_handle == IOHandle::STDOUT) {
@@ -144,7 +143,6 @@ UtilityProcessWrapper::UtilityProcessWrapper(
       int devnull = open("/dev/null", O_WRONLY);
       if (devnull < 0) {
         PLOG(ERROR) << "failed to open /dev/null";
-        close(devnull);
         return;
       }
       if (io_handle == IOHandle::STDOUT) {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/47515.

Previously we were opening a handle to `/dev/null` and never remapping it, so it would be leaked as we never explicitly closed it. This fixes that.

Upstream in this case just called [`_exit`](https://source.chromium.org/chromium/chromium/src/+/main:base/process/launch_posix.cc;l=612;bpv=0;bpt=1) which terminates the process and closes open file descriptors belonging to the process, which s why they didn't have this issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where utility processes could leak file handles.