### PR TITLE
build: update NMV to 139

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -2,7 +2,7 @@ is_electron_build = true
 root_extra_deps = [ "//electron" ]
 
 # Registry of NMVs --> https://github.com/nodejs/node/blob/main/doc/abi_version_registry.json
-node_module_version = 136
+node_module_version = 139
 
 v8_promise_internal_field_count = 1
 v8_embedder_string = "-electron.0"


### PR DESCRIPTION
#### Description of Change

Bumps the NMV to [139](https://github.com/nodejs/node/pull/58779) for Electron 38

#### Release Notes

Notes: none
