### PR TITLE
refactor: remove stray `.c_str()` calls for `absl::StrFormat()`

### DIFF
--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -1499,9 +1499,8 @@ v8::Local<v8::Value> Session::ClearData(gin_helper::ErrorThrower thrower,
 
         // Opaque origins cannot be used with this API
         if (origin.opaque()) {
-          thrower.ThrowError(
-              absl::StrFormat("Invalid origin: '%s'",
-                              origin_url.possibly_invalid_spec().c_str()));
+          thrower.ThrowError(absl::StrFormat(
+              "Invalid origin: '%s'", origin_url.possibly_invalid_spec()));
           return v8::Undefined(isolate);
         }
 

--- a/shell/browser/extensions/api/management/electron_management_api_delegate.cc
+++ b/shell/browser/extensions/api/management/electron_management_api_delegate.cc
@@ -199,9 +199,8 @@ GURL ElectronManagementAPIDelegate::GetIconURL(
     ExtensionIconSet::Match match,
     bool grayscale) const {
   GURL icon_url(absl::StrFormat(
-      "%s%s/%d/%d%s", chrome::kChromeUIExtensionIconURL,
-      extension->id().c_str(), icon_size, static_cast<int>(match),
-      grayscale ? "?grayscale=true" : ""));
+      "%s%s/%d/%d%s", chrome::kChromeUIExtensionIconURL, extension->id(),
+      icon_size, static_cast<int>(match), grayscale ? "?grayscale=true" : ""));
   CHECK(icon_url.is_valid());
   return icon_url;
 }

--- a/shell/browser/extensions/api/scripting/scripting_api.cc
+++ b/shell/browser/extensions/api/scripting/scripting_api.cc
@@ -215,7 +215,7 @@ bool CollectFramesForInjection(const api::scripting::InjectionTarget& target,
           ExtensionApiFrameIdMap::DocumentIdFromString(id);
 
       if (!document_id) {
-        *error_out = absl::StrFormat("Invalid document id %s", id.c_str());
+        *error_out = absl::StrFormat("Invalid document id %s", id);
         return false;
       }
 
@@ -227,7 +227,7 @@ bool CollectFramesForInjection(const api::scripting::InjectionTarget& target,
       // request.
       if (!frame || content::WebContents::FromRenderFrameHost(frame) != tab) {
         *error_out = absl::StrFormat("No document with id %s in tab with id %d",
-                                     id.c_str(), target.tab_id);
+                                     id, target.tab_id);
         return false;
       }
 
@@ -499,8 +499,8 @@ ExtensionFunction::ResponseAction ScriptingExecuteScriptFunction::Run() {
     args_expression = base::JoinString(string_args, ",");
   }
 
-  std::string code_to_execute = absl::StrFormat(
-      "(%s)(%s)", injection_.func->c_str(), args_expression.c_str());
+  std::string code_to_execute =
+      absl::StrFormat("(%s)(%s)", *injection_.func, args_expression);
 
   std::vector<mojom::JSSourcePtr> sources;
   sources.push_back(mojom::JSSource::New(std::move(code_to_execute), GURL()));

--- a/shell/browser/hid/hid_chooser_controller.cc
+++ b/shell/browser/hid/hid_chooser_controller.cc
@@ -280,8 +280,8 @@ bool HidChooserController::DisplayDevice(
         absl::StrFormat(
             "Chooser dialog is not displaying a FIDO HID device: vendorId=%d, "
             "productId=%d, name='%s', serial='%s'",
-            device.vendor_id, device.product_id, device.product_name.c_str(),
-            device.serial_number.c_str()));
+            device.vendor_id, device.product_id, device.product_name,
+            device.serial_number));
     return false;
   }
 
@@ -292,8 +292,7 @@ bool HidChooserController::DisplayDevice(
                         "the HID blocklist: vendorId=%d, "
                         "productId=%d, name='%s', serial='%s'",
                         device.vendor_id, device.product_id,
-                        device.product_name.c_str(),
-                        device.serial_number.c_str()));
+                        device.product_name, device.serial_number));
     return false;
   }
 

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -394,7 +394,7 @@ void ProxyingURLLoaderFactory::InProgressRequest::
       "HTTP/1.1 %i Internal Redirect\n"
       "Location: %s\n"
       "Non-Authoritative-Reason: WebRequest API\n\n",
-      kInternalRedirectStatusCode, redirect_url_.spec().c_str());
+      kInternalRedirectStatusCode, redirect_url_.spec());
 
   // Cross-origin requests need to modify the Origin header to 'null'. Since
   // CorsURLLoader sets |request_initiator| to the Origin request header in

--- a/shell/browser/net/proxying_websocket.cc
+++ b/shell/browser/net/proxying_websocket.cc
@@ -142,8 +142,7 @@ void ProxyingWebSocket::OnConnectionEstablished(
       base::MakeRefCounted<net::HttpResponseHeaders>(absl::StrFormat(
           "HTTP/%d.%d %d %s", handshake_response_->http_version.major_value(),
           handshake_response_->http_version.minor_value(),
-          handshake_response_->status_code,
-          handshake_response_->status_text.c_str()));
+          handshake_response_->status_code, handshake_response_->status_text));
   for (const auto& header : handshake_response_->headers)
     response_->headers->AddHeader(header->name, header->value);
 

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -139,16 +139,14 @@ double GetNextZoomLevel(double level, bool out) {
 }
 
 GURL GetRemoteBaseURL() {
-  return GURL(
-      absl::StrFormat("%s%s/%s/", kChromeUIDevToolsRemoteFrontendBase,
-                      kChromeUIDevToolsRemoteFrontendPath,
-                      embedder_support::GetChromiumGitRevision().c_str()));
+  return GURL(absl::StrFormat("%s%s/%s/", kChromeUIDevToolsRemoteFrontendBase,
+                              kChromeUIDevToolsRemoteFrontendPath,
+                              embedder_support::GetChromiumGitRevision()));
 }
 
 GURL GetDevToolsURL(bool can_dock) {
-  auto url_string =
-      absl::StrFormat(kChromeUIDevToolsURL, GetRemoteBaseURL().spec().c_str(),
-                      can_dock ? "true" : "");
+  auto url_string = absl::StrFormat(
+      kChromeUIDevToolsURL, GetRemoteBaseURL().spec(), can_dock ? "true" : "");
   return GURL(url_string);
 }
 
@@ -630,8 +628,7 @@ void InspectableWebContents::SetInspectedPageBounds(const gfx::Rect& rect) {
 void InspectableWebContents::InspectedURLChanged(const std::string& url) {
   if (managed_devtools_web_contents_) {
     if (devtools_title_.empty()) {
-      view_->SetTitle(
-          base::UTF8ToUTF16(absl::StrFormat(kTitleFormat, url.c_str())));
+      view_->SetTitle(base::UTF8ToUTF16(absl::StrFormat(kTitleFormat, url)));
     }
   }
 }
@@ -1023,9 +1020,9 @@ void InspectableWebContents::DidFinishNavigation(
   // most likely bug in chromium.
   base::ReplaceFirstSubstringAfterOffset(&it->second, 0, "var chrome",
                                          "var chrome = window.chrome ");
-  auto script = absl::StrFormat(
-      "%s(\"%s\")", it->second.c_str(),
-      base::Uuid::GenerateRandomV4().AsLowercaseString().c_str());
+  auto script =
+      absl::StrFormat("%s(\"%s\")", it->second,
+                      base::Uuid::GenerateRandomV4().AsLowercaseString());
   // Invoking content::DevToolsFrontendHost::SetupExtensionsAPI(frame, script);
   // should be enough, but it seems to be a noop currently.
   frame->ExecuteJavaScriptForTests(base::UTF8ToUTF16(script),

--- a/shell/browser/ui/views/global_menu_bar_x11.cc
+++ b/shell/browser/ui/views/global_menu_bar_x11.cc
@@ -164,8 +164,8 @@ std::string GetMenuModelStatus(ElectronMenuModel* model) {
     int status = model->GetTypeAt(i) | (model->IsVisibleAt(i) << 3) |
                  (model->IsEnabledAt(i) << 4) |
                  (model->IsItemCheckedAt(i) << 5);
-    ret += absl::StrFormat(
-        "%s-%X\n", base::UTF16ToUTF8(model->GetLabelAt(i)).c_str(), status);
+    ret += absl::StrFormat("%s-%X\n", base::UTF16ToUTF8(model->GetLabelAt(i)),
+                           status);
   }
   return ret;
 }

--- a/shell/common/application_info.cc
+++ b/shell/common/application_info.cc
@@ -44,7 +44,7 @@ std::string GetApplicationUserAgent() {
   } else {
     user_agent = absl::StrFormat(
         "%s/%s Chrome/%s " ELECTRON_PRODUCT_NAME "/" ELECTRON_VERSION_STRING,
-        name.c_str(), browser->GetVersion().c_str(), CHROME_VERSION_STRING);
+        name, browser->GetVersion(), CHROME_VERSION_STRING);
   }
   return embedder_support::BuildUserAgentFromProduct(user_agent);
 }

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -185,8 +185,8 @@ RendererClientBase* RendererClientBase::Get() {
 void RendererClientBase::BindProcess(v8::Isolate* isolate,
                                      gin_helper::Dictionary* process,
                                      content::RenderFrame* render_frame) {
-  auto context_id = absl::StrFormat("%s-%" PRId64, renderer_client_id_.c_str(),
-                                    ++next_context_id_);
+  auto context_id =
+      absl::StrFormat("%s-%" PRId64, renderer_client_id_, ++next_context_id_);
 
   process->SetReadOnly("isMainFrame", render_frame->IsMainFrame());
   process->SetReadOnly("contextIsolated",


### PR DESCRIPTION
#### Description of Change

Remove unnecessary calls to `c_str()` when calling `absl::StrFormat()`, which understands C++ strings like `std::string` and `std::string_view`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none