### PR TITLE
refactor: make context bridge's private keys hidden, constexpr string_views

### DIFF
--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -44,12 +44,14 @@ namespace api {
 
 namespace context_bridge {
 
-const char kProxyFunctionPrivateKey[] = "electron_contextBridge_proxy_fn";
-const char kProxyFunctionReceiverPrivateKey[] =
+const std::string_view kProxyFunctionPrivateKey =
+    "electron_contextBridge_proxy_fn";
+const std::string_view kProxyFunctionReceiverPrivateKey =
     "electron_contextBridge_proxy_fn_receiver";
-const char kSupportsDynamicPropertiesPrivateKey[] =
+const std::string_view kSupportsDynamicPropertiesPrivateKey =
     "electron_contextBridge_supportsDynamicProperties";
-const char kOriginalFunctionPrivateKey[] = "electron_contextBridge_original_fn";
+const std::string_view kOriginalFunctionPrivateKey =
+    "electron_contextBridge_original_fn";
 
 }  // namespace context_bridge
 

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -115,7 +115,7 @@ bool IsPlainArray(const v8::Local<v8::Value>& arr) {
 
 void SetPrivate(v8::Local<v8::Context> context,
                 v8::Local<v8::Object> target,
-                const std::string& key,
+                const std::string_view key,
                 v8::Local<v8::Value> value) {
   target
       ->SetPrivate(
@@ -128,7 +128,7 @@ void SetPrivate(v8::Local<v8::Context> context,
 
 v8::MaybeLocal<v8::Value> GetPrivate(v8::Local<v8::Context> context,
                                      v8::Local<v8::Object> target,
-                                     const std::string& key) {
+                                     const std::string_view key) {
   return target->GetPrivate(
       context,
       v8::Private::ForApi(context->GetIsolate(),

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -44,13 +44,13 @@ namespace api {
 
 namespace context_bridge {
 
-const std::string_view kProxyFunctionPrivateKey =
+constexpr std::string_view kProxyFunctionPrivateKey =
     "electron_contextBridge_proxy_fn";
-const std::string_view kProxyFunctionReceiverPrivateKey =
+constexpr std::string_view kProxyFunctionReceiverPrivateKey =
     "electron_contextBridge_proxy_fn_receiver";
-const std::string_view kSupportsDynamicPropertiesPrivateKey =
+constexpr std::string_view kSupportsDynamicPropertiesPrivateKey =
     "electron_contextBridge_supportsDynamicProperties";
-const std::string_view kOriginalFunctionPrivateKey =
+constexpr std::string_view kOriginalFunctionPrivateKey =
     "electron_contextBridge_original_fn";
 
 }  // namespace context_bridge


### PR DESCRIPTION
#### Description of Change

A small cleanup/correctness PR for ContextBridge, which accidentally put its private lookup keys in a public namespace. 

This PR moves them into a private namespace and changes their type to `constexpr std::string_view`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.