### PR TITLE
build: enable v8_temporal_support

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -10,9 +10,6 @@ v8_embedder_string = "-electron.0"
 # TODO: this breaks mksnapshot
 v8_enable_snapshot_native_code_counters = false
 
-# TODO: remove once https://issues.chromium.org/issues/416540976 is resolved
-v8_enable_temporal_support = false
-
 # we use this api
 v8_enable_javascript_promise_hooks = true
 


### PR DESCRIPTION
#### Description of Change

Follow-up to https://github.com/electron/electron/pull/47481

Was disabled as part of https://github.com/electron/electron/pull/47481/commits/0f4f76ca23c51e6e4a292b9862f977e1c27d4a3e but I couldn't repro it locally on any of the platforms with later commits and CI seems happy now https://github.com/electron/electron/actions/runs/15881234638, aligning the flags with upstream. Can revisit if build failures arise again.

#### Release Notes

Notes: none