### PR TITLE
refactor: extract-constant static Windows registry keys in Browser code

### DIFF
--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -55,6 +55,9 @@ namespace electron {
 
 namespace {
 
+constexpr base::wcstring_view Run =
+    LR"(Software\Microsoft\Windows\CurrentVersion\Run)";
+
 constexpr base::wcstring_view StartupApprovedRun =
     LR"(Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run)";
 
@@ -611,8 +614,7 @@ void Browser::UpdateBadgeContents(
 }
 
 void Browser::SetLoginItemSettings(LoginItemSettings settings) {
-  std::wstring key_path = L"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
-  base::win::RegKey key(HKEY_CURRENT_USER, key_path.c_str(), KEY_ALL_ACCESS);
+  base::win::RegKey key(HKEY_CURRENT_USER, Run.data(), KEY_ALL_ACCESS);
 
   base::win::RegKey startup_approved_key(
       HKEY_CURRENT_USER, StartupApprovedRun.data(), KEY_ALL_ACCESS);

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -55,9 +55,11 @@ namespace electron {
 
 namespace {
 
+// specifies what should run at user login
 constexpr base::wcstring_view Run =
     LR"(Software\Microsoft\Windows\CurrentVersion\Run)";
 
+// controls whether each Run entry is enabled or disabled
 constexpr base::wcstring_view StartupApprovedRun =
     LR"(Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run)";
 

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -653,8 +653,7 @@ void Browser::SetLoginItemSettings(LoginItemSettings settings) {
 v8::Local<v8::Value> Browser::GetLoginItemSettings(
     const LoginItemSettings& options) {
   LoginItemSettings settings;
-  std::wstring keyPath = L"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
-  base::win::RegKey key(HKEY_CURRENT_USER, keyPath.c_str(), KEY_ALL_ACCESS);
+  base::win::RegKey key(HKEY_CURRENT_USER, Run.data(), KEY_ALL_ACCESS);
   std::wstring keyVal;
 
   // keep old openAtLogin behaviour
@@ -670,10 +669,9 @@ v8::Local<v8::Value> Browser::GetLoginItemSettings(
   // set executable_will_launch_at_login to 'true'.
   boolean executable_will_launch_at_login = false;
   std::vector<LaunchItem> launch_items;
-  base::win::RegistryValueIterator hkcu_iterator(HKEY_CURRENT_USER,
-                                                 keyPath.c_str());
+  base::win::RegistryValueIterator hkcu_iterator(HKEY_CURRENT_USER, Run.data());
   base::win::RegistryValueIterator hklm_iterator(HKEY_LOCAL_MACHINE,
-                                                 keyPath.c_str());
+                                                 Run.data());
 
   launch_items = GetLoginItemSettingsHelper(
       &hkcu_iterator, &executable_will_launch_at_login, L"user", options);

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -614,11 +614,8 @@ void Browser::SetLoginItemSettings(LoginItemSettings settings) {
   std::wstring key_path = L"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
   base::win::RegKey key(HKEY_CURRENT_USER, key_path.c_str(), KEY_ALL_ACCESS);
 
-  std::wstring startup_approved_key_path =
-      L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved"
-      L"\\Run";
   base::win::RegKey startup_approved_key(
-      HKEY_CURRENT_USER, startup_approved_key_path.c_str(), KEY_ALL_ACCESS);
+      HKEY_CURRENT_USER, StartupApprovedRun.data(), KEY_ALL_ACCESS);
   PCWSTR key_name =
       !settings.name.empty() ? settings.name.c_str() : GetAppUserModelID();
 
@@ -631,9 +628,7 @@ void Browser::SetLoginItemSettings(LoginItemSettings settings) {
         startup_approved_key.DeleteValue(key_name);
       } else {
         HKEY hard_key;
-        LPCTSTR path = TEXT(
-            "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApp"
-            "roved\\Run");
+        constexpr LPCTSTR path = StartupApprovedRun.data();
         LONG res =
             RegOpenKeyEx(HKEY_CURRENT_USER, path, 0, KEY_ALL_ACCESS, &hard_key);
 

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -205,7 +205,7 @@ std::vector<LaunchItem> GetLoginItemSettingsHelper(
         const HKEY scope_key =
             scope == L"user" ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE;
         HKEY hkey;
-        LONG res = RegOpenKeyEx(scope_key, StartupApprovedRun.data(), 0,
+        LONG res = RegOpenKeyEx(scope_key, StartupApprovedRun.c_str(), 0,
                                 KEY_QUERY_VALUE, &hkey);
         if (res == ERROR_SUCCESS) {
           DWORD type, size;
@@ -616,10 +616,10 @@ void Browser::UpdateBadgeContents(
 }
 
 void Browser::SetLoginItemSettings(LoginItemSettings settings) {
-  base::win::RegKey key(HKEY_CURRENT_USER, Run.data(), KEY_ALL_ACCESS);
+  base::win::RegKey key(HKEY_CURRENT_USER, Run.c_str(), KEY_ALL_ACCESS);
 
   base::win::RegKey startup_approved_key(
-      HKEY_CURRENT_USER, StartupApprovedRun.data(), KEY_ALL_ACCESS);
+      HKEY_CURRENT_USER, StartupApprovedRun.c_str(), KEY_ALL_ACCESS);
   PCWSTR key_name =
       !settings.name.empty() ? settings.name.c_str() : GetAppUserModelID();
 
@@ -632,7 +632,7 @@ void Browser::SetLoginItemSettings(LoginItemSettings settings) {
         startup_approved_key.DeleteValue(key_name);
       } else {
         HKEY hard_key;
-        constexpr LPCTSTR path = StartupApprovedRun.data();
+        constexpr LPCTSTR path = StartupApprovedRun.c_str();
         LONG res =
             RegOpenKeyEx(HKEY_CURRENT_USER, path, 0, KEY_ALL_ACCESS, &hard_key);
 
@@ -655,7 +655,7 @@ void Browser::SetLoginItemSettings(LoginItemSettings settings) {
 v8::Local<v8::Value> Browser::GetLoginItemSettings(
     const LoginItemSettings& options) {
   LoginItemSettings settings;
-  base::win::RegKey key(HKEY_CURRENT_USER, Run.data(), KEY_ALL_ACCESS);
+  base::win::RegKey key(HKEY_CURRENT_USER, Run.c_str(), KEY_ALL_ACCESS);
   std::wstring keyVal;
 
   // keep old openAtLogin behaviour
@@ -671,9 +671,10 @@ v8::Local<v8::Value> Browser::GetLoginItemSettings(
   // set executable_will_launch_at_login to 'true'.
   boolean executable_will_launch_at_login = false;
   std::vector<LaunchItem> launch_items;
-  base::win::RegistryValueIterator hkcu_iterator(HKEY_CURRENT_USER, Run.data());
+  base::win::RegistryValueIterator hkcu_iterator(HKEY_CURRENT_USER,
+                                                 Run.c_str());
   base::win::RegistryValueIterator hklm_iterator(HKEY_LOCAL_MACHINE,
-                                                 Run.data());
+                                                 Run.c_str());
 
   launch_items = GetLoginItemSettingsHelper(
       &hkcu_iterator, &executable_will_launch_at_login, L"user", options);


### PR DESCRIPTION
#### Description of Change

`browser_win.cc` has a lot of redundant declarations of Windows registry keys. This PR makes symbolic constants for them and uses those instead. The symbolic constants are declared as constexpr [base::wcstring_view](https://chromium.googlesource.com/chromium/src/base/+/refs/heads/main/strings/cstring_view.h) to avoid the need for `std::wstring` temporaries.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.