### PR TITLE
refactor: reduce scope of temporaries when getting dictionary values

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -136,19 +136,17 @@ NativeWindow::~NativeWindow() {
 
 void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
   // Setup window from options.
-  int x = -1, y = -1;
-  bool center;
-  if (options.Get(options::kX, &x) && options.Get(options::kY, &y)) {
-    SetPosition(gfx::Point(x, y));
+  if (int x, y; options.Get(options::kX, &x) && options.Get(options::kY, &y)) {
+    SetPosition(gfx::Point{x, y});
 
 #if BUILDFLAG(IS_WIN)
     // FIXME(felixrieseberg): Dirty, dirty workaround for
     // https://github.com/electron/electron/issues/10862
     // Somehow, we need to call `SetBounds` twice to get
     // usable results. The root cause is still unknown.
-    SetPosition(gfx::Point(x, y));
+    SetPosition(gfx::Point{x, y});
 #endif
-  } else if (options.Get(options::kCenter, &center) && center) {
+  } else if (bool center; options.Get(options::kCenter, &center) && center) {
     Center();
   }
 
@@ -187,27 +185,21 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
     SetSizeConstraints(size_constraints);
   }
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX)
-  bool closable;
-  if (options.Get(options::kClosable, &closable)) {
-    SetClosable(closable);
-  }
+  if (bool val; options.Get(options::kClosable, &val))
+    SetClosable(val);
 #endif
-  bool movable;
-  if (options.Get(options::kMovable, &movable)) {
-    SetMovable(movable);
-  }
-  bool has_shadow;
-  if (options.Get(options::kHasShadow, &has_shadow)) {
-    SetHasShadow(has_shadow);
-  }
-  double opacity;
-  if (options.Get(options::kOpacity, &opacity)) {
-    SetOpacity(opacity);
-  }
-  bool top;
-  if (options.Get(options::kAlwaysOnTop, &top) && top) {
+
+  if (bool val; options.Get(options::kMovable, &val))
+    SetMovable(val);
+
+  if (bool val; options.Get(options::kHasShadow, &val))
+    SetHasShadow(val);
+
+  if (double val; options.Get(options::kOpacity, &val))
+    SetOpacity(val);
+
+  if (bool val; options.Get(options::kAlwaysOnTop, &val) && val)
     SetAlwaysOnTop(ui::ZOrderLevel::kFloatingWindow);
-  }
 
   bool fullscreenable = true;
   bool fullscreen = false;
@@ -224,29 +216,21 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
   if (fullscreen)
     SetFullScreen(true);
 
-  bool resizable;
-  if (options.Get(options::kResizable, &resizable)) {
-    SetResizable(resizable);
-  }
+  if (bool val; options.Get(options::kResizable, &val))
+    SetResizable(val);
 
-  bool skip;
-  if (options.Get(options::kSkipTaskbar, &skip)) {
-    SetSkipTaskbar(skip);
-  }
-  bool kiosk;
-  if (options.Get(options::kKiosk, &kiosk) && kiosk) {
-    SetKiosk(kiosk);
-  }
+  if (bool val; options.Get(options::kSkipTaskbar, &val))
+    SetSkipTaskbar(val);
+
+  if (bool val; options.Get(options::kKiosk, &val) && val)
+    SetKiosk(val);
+
 #if BUILDFLAG(IS_MAC)
-  std::string type;
-  if (options.Get(options::kVibrancyType, &type)) {
-    SetVibrancy(type, 0);
-  }
+  if (std::string val; options.Get(options::kVibrancyType, &val))
+    SetVibrancy(val, 0);
 #elif BUILDFLAG(IS_WIN)
-  std::string material;
-  if (options.Get(options::kBackgroundMaterial, &material)) {
-    SetBackgroundMaterial(material);
-  }
+  if (std::string val; options.Get(options::kBackgroundMaterial, &val))
+    SetBackgroundMaterial(val);
 #endif
 
   SkColor background_color = SK_ColorWHITE;
@@ -257,9 +241,7 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
   }
   SetBackgroundColor(background_color);
 
-  std::string title(Browser::Get()->GetName());
-  options.Get(options::kTitle, &title);
-  SetTitle(title);
+  SetTitle(options.ValueOrDefault(options::kTitle, Browser::Get()->GetName()));
 
   // Then show it.
   if (options.ValueOrDefault(options::kShow, true))

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -237,8 +237,7 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
     [window_ setLevel:NSFloatingWindowLevel];
   }
 
-  bool focusable;
-  if (options.Get(options::kFocusable, &focusable) && !focusable)
+  if (bool val; options.Get(options::kFocusable, &val) && !val)
     [window_ setDisableKeyOrMainWindow:YES];
 
   if (transparent() || !has_frame()) {
@@ -283,12 +282,10 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   // NOTE(@mlaurencin) Spec requirements can be found here:
   // https://developer.mozilla.org/en-US/docs/Web/API/Window/open#width
   constexpr int kMinSizeReqdBySpec = 100;
-  int inner_width = 0;
-  int inner_height = 0;
+  const int inner_width = options.ValueOrDefault(options::kinnerWidth, 0);
+  const int inner_height = options.ValueOrDefault(options::kinnerHeight, 0);
   bool use_content_size =
       options.ValueOrDefault(options::kUseContentSize, false);
-  options.Get(options::kinnerWidth, &inner_width);
-  options.Get(options::kinnerHeight, &inner_height);
   if (inner_width || inner_height) {
     use_content_size = true;
     if (inner_width)

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -199,9 +199,8 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
   if (std::string val; options.Get(options::kTitle, &val))
     SetTitle(val);
 
-  bool menu_bar_autohide;
-  if (options.Get(options::kAutoHideMenuBar, &menu_bar_autohide))
-    root_view_.SetAutoHideMenuBar(menu_bar_autohide);
+  if (bool val; options.Get(options::kAutoHideMenuBar, &val))
+    root_view_.SetAutoHideMenuBar(val);
 
 #if BUILDFLAG(IS_WIN)
   // On Windows we rely on the CanResize() to indicate whether window can be
@@ -218,35 +217,20 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
   overlay_button_color_ = color_utils::GetSysSkColor(COLOR_BTNFACE);
   overlay_symbol_color_ = color_utils::GetSysSkColor(COLOR_BTNTEXT);
 
-  bool accent_color = true;
-  std::string accent_color_string;
-  if (options.Get(options::kAccentColor, &accent_color_string)) {
-    accent_color_ = ParseCSSColor(accent_color_string);
-  } else if (options.Get(options::kAccentColor, &accent_color)) {
-    accent_color_ = accent_color;
+  if (std::string str; options.Get(options::kAccentColor, &str)) {
+    accent_color_ = ParseCSSColor(str);
+  } else if (bool flag; options.Get(options::kAccentColor, &flag)) {
+    accent_color_ = flag;
   }
 #endif
 
-  v8::Local<v8::Value> titlebar_overlay;
-  if (options.Get(options::ktitleBarOverlay, &titlebar_overlay) &&
-      titlebar_overlay->IsObject()) {
-    auto titlebar_overlay_obj =
-        gin_helper::Dictionary::CreateEmpty(options.isolate());
-    options.Get(options::ktitleBarOverlay, &titlebar_overlay_obj);
-
-    std::string overlay_color_string;
-    if (titlebar_overlay_obj.Get(options::kOverlayButtonColor,
-                                 &overlay_color_string)) {
-      bool success = content::ParseCssColorString(overlay_color_string,
-                                                  &overlay_button_color_);
+  if (gin_helper::Dictionary od; options.Get(options::ktitleBarOverlay, &od)) {
+    if (std::string val; od.Get(options::kOverlayButtonColor, &val)) {
+      bool success = content::ParseCssColorString(val, &overlay_button_color_);
       DCHECK(success);
     }
-
-    std::string overlay_symbol_color_string;
-    if (titlebar_overlay_obj.Get(options::kOverlaySymbolColor,
-                                 &overlay_symbol_color_string)) {
-      bool success = content::ParseCssColorString(overlay_symbol_color_string,
-                                                  &overlay_symbol_color_);
+    if (std::string val; od.Get(options::kOverlaySymbolColor, &val)) {
+      bool success = content::ParseCssColorString(val, &overlay_symbol_color_);
       DCHECK(success);
     }
   }
@@ -288,8 +272,7 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
   if (IsTranslucent() && !has_frame())
     params.shadow_type = InitParams::ShadowType::kNone;
 
-  bool focusable;
-  if (options.Get(options::kFocusable, &focusable) && !focusable)
+  if (bool val; options.Get(options::kFocusable, &val) && !val)
     params.activatable = InitParams::Activatable::kNo;
 
 #if BUILDFLAG(IS_WIN)
@@ -412,11 +395,9 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
 
   // NOTE(@mlaurencin) Spec requirements can be found here:
   // https://developer.mozilla.org/en-US/docs/Web/API/Window/open#width
-  int kMinSizeReqdBySpec = 100;
-  int inner_width = 0;
-  int inner_height = 0;
-  options.Get(options::kinnerWidth, &inner_width);
-  options.Get(options::kinnerHeight, &inner_height);
+  constexpr int kMinSizeReqdBySpec = 100;
+  const int inner_width = options.ValueOrDefault(options::kinnerWidth, 0);
+  const int inner_height = options.ValueOrDefault(options::kinnerHeight, 0);
   if (inner_width || inner_height) {
     use_content_size_ = true;
     if (inner_width)
@@ -478,11 +459,10 @@ void NativeWindowViews::SetTitleBarOverlay(
   bool updated = false;
 
   // Check and update the button color
-  std::string btn_color;
-  if (options.Get(options::kOverlayButtonColor, &btn_color)) {
+  if (std::string val; options.Get(options::kOverlayButtonColor, &val)) {
     // Parse the string as a CSS color
     SkColor color;
-    if (!content::ParseCssColorString(btn_color, &color)) {
+    if (!content::ParseCssColorString(val, &color)) {
       args->ThrowError("Could not parse color as CSS color");
       return;
     }
@@ -493,11 +473,10 @@ void NativeWindowViews::SetTitleBarOverlay(
   }
 
   // Check and update the symbol color
-  std::string symbol_color;
-  if (options.Get(options::kOverlaySymbolColor, &symbol_color)) {
+  if (std::string val; options.Get(options::kOverlaySymbolColor, &val)) {
     // Parse the string as a CSS color
     SkColor color;
-    if (!content::ParseCssColorString(symbol_color, &color)) {
+    if (!content::ParseCssColorString(val, &color)) {
       args->ThrowError("Could not parse symbol color as CSS color");
       return;
     }
@@ -508,9 +487,8 @@ void NativeWindowViews::SetTitleBarOverlay(
   }
 
   // Check and update the height
-  int height = 0;
-  if (options.Get(options::kOverlayHeight, &height)) {
-    set_titlebar_overlay_height(height);
+  if (int val; options.Get(options::kOverlayHeight, &val)) {
+    set_titlebar_overlay_height(val);
     updated = true;
   }
 


### PR DESCRIPTION
#### Description of Change

Reduce the scope of temporaries when getting dictionary values in NativeWindows. This leaves fewer temporaries laying around.

Basically, it's this kind of change again & again:

```diff
-  std::string foo;
-  if (options.Get(options::kSomething, &foo)) {
-    DoSomething(foo);
-  }
+  if (std::string val; options.Get(options::kSomething, &val))
+    DoSomething(val);
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.