### PR TITLE
test: fix nan tests on macOS

### DIFF
--- a/script/nan-spec-runner.js
+++ b/script/nan-spec-runner.js
@@ -46,20 +46,23 @@ async function main () {
   const platformFlags = [];
   if (process.platform === 'darwin') {
     const sdkPath = path.resolve(BASE, 'out', outDir, 'sdk', 'xcode_links');
-    const sdks = (await fs.promises.readdir(sdkPath)).filter(fileName => fileName.endsWith('.sdk'));
-    const sdkToUse = sdks[0];
-    if (!sdkToUse) {
+    const sdks = (await fs.promises.readdir(sdkPath)).filter(f => f.endsWith('.sdk'));
+
+    if (!sdks.length) {
       console.error('Could not find an SDK to use for the NAN tests');
       process.exit(1);
     }
 
-    if (sdks.length) {
-      console.warn(`Multiple SDKs found in the xcode_links directory - using ${sdkToUse}`);
+    const sdkToUse = sdks.sort((a, b) => {
+      const getVer = s => s.match(/(\d+)\.?(\d*)/)?.[0] || '0';
+      return getVer(b).localeCompare(getVer(a), undefined, { numeric: true });
+    })[0];
+
+    if (sdks.length > 1) {
+      console.warn(`Multiple SDKs found - using ${sdkToUse}`);
     }
 
-    platformFlags.push(
-      `-isysroot ${path.resolve(sdkPath, sdkToUse)}`
-    );
+    platformFlags.push(`-isysroot ${path.resolve(sdkPath, sdkToUse)}`);
   }
 
   // TODO(ckerr) this is cribbed from read obj/electron/electron_app.ninja.


### PR DESCRIPTION
#### Description of Change

Fixes running Nan tests on macOS. They would fail before this in the case where multiple SDKs existed in `out/Testing/sdk/xcode_links` because the first SDK would be picked and not the most recent, which is the one we'd need. This fixes that.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none