### PR TITLE
perf: avoid copying a vector when calling ConvertToWeakPtrVector()

### DIFF
--- a/shell/browser/window_list.cc
+++ b/shell/browser/window_list.cc
@@ -6,20 +6,18 @@
 
 #include <algorithm>
 
+#include "base/containers/to_vector.h"
 #include "base/no_destructor.h"
 #include "shell/browser/native_window.h"
 #include "shell/browser/window_list_observer.h"
 
 namespace {
+
 template <typename T>
-std::vector<base::WeakPtr<T>> ConvertToWeakPtrVector(std::vector<T*> raw_ptrs) {
-  std::vector<base::WeakPtr<T>> converted_to_weak;
-  converted_to_weak.reserve(raw_ptrs.size());
-  for (auto* raw_ptr : raw_ptrs) {
-    converted_to_weak.push_back(raw_ptr->GetWeakPtr());
-  }
-  return converted_to_weak;
+auto ConvertToWeakPtrVector(const std::vector<T*>& raw_ptrs) {
+  return base::ToVector(raw_ptrs, [](T* t) { return t->GetWeakPtr(); });
 }
+
 }  // namespace
 
 namespace electron {


### PR DESCRIPTION
#### Description of Change

Have `ConvertToWeakPtrVector()` take a `const vector&` instead of a `vector` to avoid an unnecessary vector copy.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.