### PR TITLE
build: write abi version to published npm package

### DIFF
--- a/script/release/bin/publish-to-npm.ts
+++ b/script/release/bin/publish-to-npm.ts
@@ -137,6 +137,20 @@ new Promise<string>((resolve, reject) => {
     return release;
   })
   .then(async (release) => {
+    const gnArgs = await fs.promises.readFile(path.resolve(ELECTRON_DIR, 'build/args/all.gn'), 'utf8');
+
+    const abiVersionLine = gnArgs.split('\n').find((line) => line.startsWith('node_module_version = '));
+    const abiVersion = abiVersionLine ? abiVersionLine.split('=')[1].trim() : null;
+    if (!abiVersion) {
+      throw new Error('Could not find node_module_version in GN args');
+    }
+
+    const abiVersionFile = path.join(tempDir, 'abi_version');
+    await fs.promises.writeFile(abiVersionFile, abiVersion);
+
+    return release;
+  })
+  .then(async (release) => {
     const currentBranch = await getCurrentBranch();
 
     if (isNightlyElectronVersion) {


### PR DESCRIPTION
This adds a helper file that makes it easier for tools like `node-abi` to determine the ABI version of an otherwise unknown package. `node-abi` is a pretty massive source of annoyance for folks, even for seasoned Electron App developers it's an annoying thing you need to keep ensuring you update. Package managers don't make it easy, so instead to mitigate this as much as possible I'm proposing we write this file to disk, and then in `node-abi` if we are resolving a version we **don't recognize** we try to find this file on disk for a matching electron version. If it matches, and it exists, we can serve it and app developers don't need to do any package manager shenanigans.

Notes: Added `abi_version` file to the npm package