### PR TITLE
build: free additional space on MacOS runners

### DIFF
--- a/.github/actions/free-space-macos/action.yml
+++ b/.github/actions/free-space-macos/action.yml
@@ -78,4 +78,4 @@ runs:
 
         # lipo off some huge binaries arm64 versions to save space
         strip_universal_deep $(xcode-select -p)/../SharedFrameworks
-        strip_arm_deep /System/Volumes/Data/Library/Developer/CommandLineTools/usr
+        strip_universal_deep /System/Volumes/Data/Library/Developer/CommandLineTools/usr

--- a/.github/actions/free-space-macos/action.yml
+++ b/.github/actions/free-space-macos/action.yml
@@ -47,6 +47,8 @@ runs:
         tmpify $(xcode-select -p)/Platforms/WatchSimulator.platform
         tmpify $(xcode-select -p)/Platforms/AppleTVSimulator.platform
         tmpify $(xcode-select -p)/Platforms/iPhoneSimulator.platform
+        tmpify $(xcode-select -p)/Platforms/XROS.platform
+        tmpify $(xcode-select -p)/Platforms/XRSimulator.platform
         tmpify $(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/metal/ios
         tmpify $(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift
         tmpify $(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0
@@ -58,11 +60,13 @@ runs:
 
         sudo rm -rf /Applications/Safari.app
         sudo rm -rf /Applications/Xcode_16.1.app
-        sudo rm -rf /Applications/Xcode_16.3.app
         sudo rm -rf /Applications/Xcode_16.2.app
-        sudo rm -rf /Applications/Google Chrome.app
+        sudo rm -rf /Applications/Xcode_16.3.app
         sudo rm -rf /Applications/Xcode_16.4.app
+        sudo rm -rf /Applications/Google Chrome.app
         sudo rm -rf /Applications/Google Chrome for Testing.app
+        sudo rm -rf /Applications/Microsoft Edge.app
+        sudo rm -rf /Applications/Microsoft Edge Webdriver.app
         sudo rm -rf	/Applications/Firefox.app
         sudo rm -rf ~/project/src/third_party/catapult/tracing/test_data
         sudo rm -rf ~/project/src/third_party/angle/third_party/VK-GL-CTS
@@ -70,7 +74,8 @@ runs:
         sudo rm -rf $JAVA_HOME_11_arm64
         sudo rm -rf $JAVA_HOME_17_arm64
         sudo rm -rf $JAVA_HOME_21_arm64
+        sudo rm -rf /Applications/Xcode_26_beta.app
 
         # lipo off some huge binaries arm64 versions to save space
         strip_universal_deep $(xcode-select -p)/../SharedFrameworks
-        # strip_arm_deep /System/Volumes/Data/Library/Developer/CommandLineTools/usr
+        strip_arm_deep /System/Volumes/Data/Library/Developer/CommandLineTools/usr


### PR DESCRIPTION
#### Description of Change

After merging #47481, our publish nightly jobs are running out of space on our MacOS runners. This PR attempts to free up additional space on the runners

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
