### PR TITLE
fix: `webContents.downloadURL()` did not support referer header

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2398,6 +2398,13 @@ void WebContents::DownloadURL(const GURL& url, gin::Arguments* args) {
       content::DownloadRequestUtils::CreateDownloadForWebContentsMainFrame(
           web_contents(), url, MISSING_TRAFFIC_ANNOTATION));
   for (const auto& [name, value] : headers) {
+    if (base::ToLowerASCII(name) ==
+        base::ToLowerASCII(net::HttpRequestHeaders::kReferer)) {
+      // Setting a Referer header with HTTPS scheme while the download URL's
+      // scheme is HTTP might lead to download failure.
+      download_params->set_referrer(GURL(value));
+      continue;
+    }
     download_params->add_request_header(name, value);
   }
 


### PR DESCRIPTION
Description of Change

This PR fixes an issue where the `Referer` HTTP header was not being correctly applied when using the `webContents.downloadURL()` API.

The previous implementation added all headers, including `Referer`, through the generic `add_request_header` method. However, `Referer` is a special header that cannot be set via the generic `add_request_header` method. Instead, the download system requires the referrer to be set specifically via `download_params->set_referrer()`.

This change adds logic to specifically detect the `Referer` header (case-insensitively) from the options and sets it using the correct method, ensuring it is properly handled during the download request. Other headers continue to be processed as before.

Before this PR:

- webContents.downloadURL('https://example.com/file', { headers: { 'Referer': 'https://my-referer.com' } }) => ❌ The Referer header was not sent with the download request.

After this PR:

- webContents.downloadURL('https://example.com/file', { headers: { 'Referer': 'https://my-referer.com' } }) => ✅ The Referer header is correctly sent as https://my-referer.com .
- webContents.downloadURL('https://example.com/file', { headers: { 'referer': 'https://my-referer.com' } }) => ✅ The Referer header is correctly sent (header name is case-insensitive).

Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).


Release Notes

Notes: Fixed a bug where the `Referer` header was not being set correctly when using `webContents.downloadURL()`.