### PR TITLE
build: add platform-specific conditions to the source_set in chromium_src

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -144,8 +144,6 @@ static_library("chrome") {
     "//chrome/browser/ui/views/overlay/toggle_camera_button.h",
     "//chrome/browser/ui/views/overlay/toggle_microphone_button.cc",
     "//chrome/browser/ui/views/overlay/toggle_microphone_button.h",
-    "//chrome/browser/ui/views/overlay/video_overlay_window_native_widget_mac.h",
-    "//chrome/browser/ui/views/overlay/video_overlay_window_native_widget_mac.mm",
     "//chrome/browser/ui/views/overlay/video_overlay_window_views.cc",
     "//chrome/browser/ui/views/overlay/video_overlay_window_views.h",
     "//chrome/browser/ui/views/picture_in_picture/picture_in_picture_bounds_change_animation.cc",
@@ -282,6 +280,8 @@ static_library("chrome") {
       "//chrome/browser/process_singleton_mac.mm",
       "//chrome/browser/ui/views/eye_dropper/eye_dropper_view_mac.h",
       "//chrome/browser/ui/views/eye_dropper/eye_dropper_view_mac.mm",
+      "//chrome/browser/ui/views/overlay/video_overlay_window_native_widget_mac.h",
+      "//chrome/browser/ui/views/overlay/video_overlay_window_native_widget_mac.mm",
     ]
     deps += [ ":system_media_capture_permissions_mac_conflict" ]
   }

--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -504,15 +504,17 @@ source_set("chrome_spellchecker") {
   ]
 }
 
-# These sources create an object file conflict with one in |:chrome|, so they
-# must live in a separate target.
-# Conflicting sources:
-#   //chrome/browser/media/webrtc/system_media_capture_permissions_stats_mac.mm
-#   //chrome/browser/permissions/system/system_media_capture_permissions_mac.mm
-source_set("system_media_capture_permissions_mac_conflict") {
-  sources = [
-    "//chrome/browser/permissions/system/system_media_capture_permissions_mac.h",
-    "//chrome/browser/permissions/system/system_media_capture_permissions_mac.mm",
-  ]
-  deps = [ "//chrome/common" ]
+if (is_mac) {
+  # These sources create an object file conflict with one in |:chrome|, so they
+  # must live in a separate target.
+  # Conflicting sources:
+  #   //chrome/browser/media/webrtc/system_media_capture_permissions_stats_mac.mm
+  #   //chrome/browser/permissions/system/system_media_capture_permissions_mac.mm
+  source_set("system_media_capture_permissions_mac_conflict") {
+    sources = [
+      "//chrome/browser/permissions/system/system_media_capture_permissions_mac.h",
+      "//chrome/browser/permissions/system/system_media_capture_permissions_mac.mm",
+    ]
+    deps = [ "//chrome/common" ]
+  }
 }


### PR DESCRIPTION
#### Description of Change

The configuration in chromium_src's BUILD.gn causes Visual Studio's Solution Explorer to display projects and code irrelevant to the current platform.

This occurs because source sets originally intended for Mac-only were incorrectly included.
<img width="654" alt="image" src="https://github.com/user-attachments/assets/432696ed-781f-47ab-a972-ba69c9e1bd47" />


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Add platform-specific conditions to the source_set in chromium_src
