### PR TITLE
fix: accent color should reflect system settings without restart

### DIFF
--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -319,7 +319,7 @@ class NativeWindowViews : public NativeWindow,
   // Whether the window is currently being moved.
   bool is_moving_ = false;
 
-  std::variant<bool, SkColor> accent_color_ = true;
+  std::variant<std::monostate, bool, SkColor> accent_color_;
 
   std::optional<gfx::Rect> pending_bounds_change_;
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/47626.
Refs https://github.com/electron/electron/pull/47285#issuecomment-3012764206.

Fixes an issue where a window's accent color didn't reflect system settings without restart.

After this PR:

* System Accent Disabled and `accentColor: undefined` => ❌  Frame does NOT have accent color
* System Accent Disabled and `accentColor: true` => ✅ Frame has accent color
* System Accent Disabled and `accentColor: #rrggbb` => ✅  Frame has accent color
* System Accent Disabled and `accentColor: false` => ❌  Frame does NOT have accent color
* System Accent Enabled and `accentColor: undefined` => ✅ Frame has accent color
* System Accent Enabled and `accentColor: true` => ✅ Frame has accent color
* System Accent Enabled and `accentColor: #rrggbb` => ✅ Frame has accent color
* System Accent Enabled and `accentColor: false` => ❌ Frame does NOT have accent color

cc @bpasero 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the window required restart in order to recognize system accent color setting change.
