### PR TITLE
fix: crash on source capture with empty thumbnail size

### DIFF
--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -236,7 +236,8 @@ DesktopCapturer::DesktopListListener::~DesktopListListener() = default;
 
 void DesktopCapturer::DesktopListListener::OnDelegatedSourceListSelection() {
   if (have_thumbnail_) {
-    std::move(update_callback_).Run();
+    content::GetUIThreadTaskRunner({})->PostTask(FROM_HERE,
+                                                 std::move(update_callback_));
   } else {
     have_selection_ = true;
   }
@@ -249,7 +250,8 @@ void DesktopCapturer::DesktopListListener::OnSourceThumbnailChanged(int index) {
     have_selection_ = false;
 
     // PipeWire returns a single source, so index is not relevant.
-    std::move(update_callback_).Run();
+    content::GetUIThreadTaskRunner({})->PostTask(FROM_HERE,
+                                                 std::move(update_callback_));
   } else {
     have_thumbnail_ = true;
   }


### PR DESCRIPTION
#### Description of Change

Refs CL:5783826
Closes https://github.com/electron/electron/issues/47591

Fixes a crash when calling `desktopCapturer.getSources` with an empty thumbnail size.

`DesktopMediaListBase` now calls `Refresh(false)` after dispatching `DesktopMediaListObserver::OnDelegatedSourceListSelection`, so it's important not to call `DesktopCapturer::HandleSuccess` (which deallocates the `DesktopMediaList`) synchronously from `OnDelegatedSourceListSelection`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash when calling `desktopCapturer.getSources` with an empty thumbnail size.
