### PR TITLE
refactor: avoid a few unnecessary strings

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -242,7 +242,7 @@ template <>
 struct Converter<WindowOpenDisposition> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    WindowOpenDisposition val) {
-    std::string disposition = "other";
+    std::string_view disposition = "other";
     switch (val) {
       case WindowOpenDisposition::CURRENT_TAB:
         disposition = "default";

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -303,7 +303,7 @@ struct Converter<electron::api::WebContents::Type> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    electron::api::WebContents::Type val) {
     using Type = electron::api::WebContents::Type;
-    std::string type;
+    std::string_view type;
     switch (val) {
       case Type::kBackgroundPage:
         type = "backgroundPage";

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -430,7 +430,7 @@ std::optional<std::string> GetDesktopName() {
 
 std::string GetXdgAppId() {
   if (std::optional<std::string> desktop_file_name = GetDesktopName()) {
-    const std::string kDesktopExtension{".desktop"};
+    constexpr std::string_view kDesktopExtension = ".desktop";
     if (base::EndsWith(*desktop_file_name, kDesktopExtension,
                        base::CompareCase::INSENSITIVE_ASCII)) {
       desktop_file_name->resize(desktop_file_name->size() -


### PR DESCRIPTION
#### Description of Change

Small cleanup that I came across while working on something else.

In a handful of cases, we're instantiating a `std::string` when a cheaper `std::string_view` will do. This PR fixes that.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.