### PR TITLE
fix: fullscreen for windows without rounded corners

### DIFF
--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -175,6 +175,8 @@ class NativeWindowMac : public NativeWindow,
   // cleanup in destructor.
   void Cleanup();
 
+  void SetBorderless(bool borderless);
+
   void UpdateVibrancyRadii(bool fullscreen);
 
   void UpdateWindowOriginalFrame();

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -154,13 +154,6 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
 
   NSUInteger styleMask = NSWindowStyleMaskTitled;
 
-  // The NSWindowStyleMaskFullSizeContentView style removes rounded corners
-  // for frameless window.
-  const bool rounded_corner =
-      options.ValueOrDefault(options::kRoundedCorners, true);
-  if (!rounded_corner && !has_frame())
-    styleMask = NSWindowStyleMaskBorderless;
-
   if (minimizable)
     styleMask |= NSWindowStyleMaskMiniaturizable;
   if (closable)
@@ -219,6 +212,11 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   if (parent && !is_modal()) {
     SetParentWindow(parent);
   }
+
+  const bool rounded_corner =
+      options.ValueOrDefault(options::kRoundedCorners, true);
+  if (!rounded_corner && !has_frame())
+    SetBorderless(!rounded_corner);
 
   if (transparent()) {
     // Setting the background color to clear will also hide the shadow.
@@ -766,6 +764,11 @@ bool NativeWindowMac::MoveAbove(const std::string& sourceId) {
 
 void NativeWindowMac::MoveTop() {
   [window_ orderWindowByShuffling:NSWindowAbove relativeTo:0];
+}
+
+void NativeWindowMac::SetBorderless(bool borderless) {
+  SetStyleMask(!borderless, NSWindowStyleMaskTitled);
+  SetStyleMask(borderless, NSWindowStyleMaskBorderless);
 }
 
 void NativeWindowMac::SetResizable(bool resizable) {

--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -375,9 +375,6 @@ void SwizzleSwipeWithEvent(NSView* view, SEL swiz_selector) {
 }
 
 - (BOOL)toggleFullScreenMode:(id)sender {
-  if (!shell_->has_frame() && !shell_->HasStyleMask(NSWindowStyleMaskTitled))
-    return NO;
-
   bool is_simple_fs = shell_->IsSimpleFullScreen();
   bool always_simple_fs = shell_->always_simple_fullscreen();
 

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.h
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.h
@@ -24,6 +24,8 @@ class NativeWindowMac;
   int level_;
   bool is_resizable_;
 
+  bool is_borderless_;
+
   // Whether the window is currently minimized. Used to work
   // around a macOS bug with child window minimization.
   bool is_minimized_;

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -299,6 +299,8 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 - (void)windowWillEnterFullScreen:(NSNotification*)notification {
   // Store resizable mask so it can be restored after exiting fullscreen.
   is_resizable_ = shell_->HasStyleMask(NSWindowStyleMaskResizable);
+  // Store borderless mask so it can be restored after exiting fullscreen.
+  is_borderless_ = !shell_->HasStyleMask(NSWindowStyleMaskTitled);
 
   shell_->set_is_transitioning_fullscreen(true);
 
@@ -306,6 +308,8 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 
   // Set resizable to true before entering fullscreen.
   shell_->SetResizable(true);
+  // Set borderless to false before entering fullscreen.
+  shell_->SetBorderless(false);
 }
 
 - (void)windowDidEnterFullScreen:(NSNotification*)notification {
@@ -341,6 +345,7 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
   shell_->set_is_transitioning_fullscreen(false);
 
   shell_->SetResizable(is_resizable_);
+  shell_->SetBorderless(is_borderless_);
   shell_->NotifyWindowLeaveFullScreen();
 
   if (shell_->HandleDeferredClose())

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6030,6 +6030,54 @@ describe('BrowserWindow module', () => {
         await leaveFullScreen;
       });
 
+      it('should not crash if rounded corners are disabled', async () => {
+        const w = new BrowserWindow({
+          frame: false,
+          roundedCorners: false
+        });
+
+        const enterFullScreen = once(w, 'enter-full-screen');
+        w.setFullScreen(true);
+        await enterFullScreen;
+
+        await setTimeout();
+
+        const leaveFullScreen = once(w, 'leave-full-screen');
+        w.setFullScreen(false);
+        await leaveFullScreen;
+      });
+
+      it('should not crash if opening a borderless child window from fullscreen parent', async () => {
+        const parent = new BrowserWindow();
+
+        const parentFS = once(parent, 'enter-full-screen');
+        parent.setFullScreen(true);
+        await parentFS;
+
+        await setTimeout();
+
+        const child = new BrowserWindow({
+          width: 400,
+          height: 300,
+          show: false,
+          parent,
+          frame: false,
+          roundedCorners: false
+        });
+
+        await setTimeout();
+
+        const childFS = once(child, 'enter-full-screen');
+        child.show();
+        await childFS;
+
+        await setTimeout();
+
+        const leaveFullScreen = once(child, 'leave-full-screen');
+        child.setFullScreen(false);
+        await leaveFullScreen;
+      });
+
       it('should be able to load a URL while transitioning to fullscreen', async () => {
         const w = new BrowserWindow({ fullscreen: true });
         w.loadFile(path.join(fixtures, 'pages', 'c.html'));


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/47579.

Fixes an issue where child windows could crash if they were opened while the parent is fullscreened and have `roundedCorners` set to `false`. 

This was happening because Chromium uses a custom `NativeWidgetMacNSWindowBorderlessFrame` when the NSWindow has a `NSWindowStyleMaskBorderless` style mask, which is itself a subclass of `NSNextStepFrame`. `NSNextStepFrame` does not implement any of the public or private methods required for fullscreen, and so it would crash. We initially handled this by preventing windows from going fullscreen in that case, but a better solution is to temporarily remove the `NSWindowStyleMaskBorderless` style mask when going fullscreen and then restore it afterwards.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where child windows could crash if they were opened from a fullscreen parent and have `roundedCorners` set to `false`.