### PR TITLE
chore: clean up `NativeWindowMac::UpdateVibrancyRadii`

### DIFF
--- a/build/rules.gni
+++ b/build/rules.gni
@@ -67,10 +67,6 @@ template("mac_xib_bundle_data") {
     ibtool_flags = [
       "--minimum-deployment-target",
       mac_deployment_target,
-
-      # TODO(rsesek): Enable this once all the bots are on Xcode 7+.
-      # "--target-device",
-      # "mac",
     ]
   }
 


### PR DESCRIPTION
#### Description of Change

This can be cleaned up after CL:6593912

Other small changes include removing `[[NSColor blackColor] set]` since `fill` uses black by default for masks.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
