### PR TITLE
refactor: use `dbus_thread_linux::GetSharedSessionBus()`

### DIFF
--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -76,14 +76,8 @@ class ShowItemHelper {
   ShowItemHelper& operator=(const ShowItemHelper&) = delete;
 
   void ShowItemInFolder(const base::FilePath& full_path) {
-    if (!bus_) {
-      // Sets up the D-Bus connection.
-      dbus::Bus::Options bus_options;
-      bus_options.bus_type = dbus::Bus::SESSION;
-      bus_options.connection_type = dbus::Bus::PRIVATE;
-      bus_options.dbus_task_runner = dbus_thread_linux::GetTaskRunner();
-      bus_ = base::MakeRefCounted<dbus::Bus>(bus_options);
-    }
+    if (!bus_)
+      bus_ = dbus_thread_linux::GetSharedSessionBus();
 
     if (!dbus_proxy_) {
       dbus_proxy_ = bus_->GetObjectProxy(DBUS_SERVICE_DBUS,


### PR DESCRIPTION
#### Description of Change

Refs CL:6180523

From CL:
> Share Linux DBus session and system connections

> This cuts down on file descriptor usage and bus initialization time by
sharing DBus connections where possible. This is similar to how ChromeOS
has DBusThreadManager to use one D-Bus thread and Bus object for
everything.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none