### PR TITLE
docs: fix broken sentence in crashReporter.start() documentation

### DIFF
--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -63,7 +63,7 @@ The `crashReporter` module has the following methods:
   * `extra` Record\<string, string\> (optional) - Extra string key/value
     annotations that will be sent along with crash reports that are generated
     in the main process. Only string values are supported. Crashes generated in
-    child processes will not contain these extra
+    child processes will not include these extra parameters. To add extra
     parameters to crash reports generated from child processes, call
     [`addExtraParameter`](#crashreporteraddextraparameterkey-value) from the
     child process.


### PR DESCRIPTION
#### Description of Change

Fixes a broken sentence in the crashReporter.start() documentation that was confusing and grammatically incorrect. The sentence about extra parameters in child processes has been rewritten for clarity.

**Before:**
> Crashes generated in child processes will not contain these extra parameters to crash reports generated from child processes, call addExtraParameter from the child process.

**After:**
> Crashes generated in child processes will not include these extra parameters. To add extra parameters to crash reports generated from child processes, call addExtraParameter from the child process.

Fixes #47415

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none