### PR TITLE
ci: roll `BUILD_TOOLS_SHA` for macOS 15.5 SDK

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -14,7 +14,7 @@ runs:
         git config --global core.longpaths true
         git config --global core.preloadindex true
       fi
-      export BUILD_TOOLS_SHA=0a7f6bef9453ceee45612442660ca16d2c40171b
+      export BUILD_TOOLS_SHA=274cba0474f0d1e4e6adbb66c1da48556cb0add5
       npm i -g @electron/build-tools
       # Update depot_tools to ensure python
       e d update_depot_tools


### PR DESCRIPTION
#### Description of Change

As in title.

See [diff](https://github.com/electron/build-tools/compare/274cba0474f0d1e4e6adbb66c1da48556cb0add5..e5e0b7a7470a398cb3fe92eceaf0f8837dcc4d1b).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none