### PR TITLE
ci: set git `core.longpaths` to true

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -11,6 +11,7 @@ runs:
         git config --global core.autocrlf false
         git config --global branch.autosetuprebase always
         git config --global core.fscache true
+        git config --global core.longpaths true
         git config --global core.preloadindex true
       fi
       export BUILD_TOOLS_SHA=0a7f6bef9453ceee45612442660ca16d2c40171b

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -135,6 +135,7 @@ jobs:
         git config --global core.autocrlf false
         git config --global branch.autosetuprebase always
         git config --global core.fscache true
+        git config --global core.longpaths true
         git config --global core.preloadindex true
         git clone --filter=tree:0 https://chromium.googlesource.com/chromium/tools/depot_tools.git
         # Ensure depot_tools does not update.


### PR DESCRIPTION
#### Description of Change

This is causing some intermittent failures in CI - see https://github.com/electron/build-tools/pull/727 as well.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none