### PR TITLE
fix: deprecation warning crash when no Node.js environment available

### DIFF
--- a/shell/common/node_util.cc
+++ b/shell/common/node_util.cc
@@ -66,8 +66,13 @@ void EmitWarning(const std::string_view warning_msg,
 void EmitWarning(v8::Isolate* isolate,
                  const std::string_view warning_msg,
                  const std::string_view warning_type) {
-  node::ProcessEmitWarningGeneric(node::Environment::GetCurrent(isolate),
-                                  warning_msg, warning_type);
+  node::Environment* env = node::Environment::GetCurrent(isolate);
+  if (!env) {
+    // No Node.js environment available, fall back to console logging.
+    LOG(WARNING) << "[" << warning_type << "] " << warning_msg;
+    return;
+  }
+  node::ProcessEmitWarningGeneric(env, warning_msg, warning_type);
 }
 
 void EmitDeprecationWarning(const std::string_view warning_msg,
@@ -79,8 +84,14 @@ void EmitDeprecationWarning(const std::string_view warning_msg,
 void EmitDeprecationWarning(v8::Isolate* isolate,
                             const std::string_view warning_msg,
                             const std::string_view deprecation_code) {
-  node::ProcessEmitWarningGeneric(node::Environment::GetCurrent(isolate),
-                                  warning_msg, "DeprecationWarning",
+  node::Environment* env = node::Environment::GetCurrent(isolate);
+  if (!env) {
+    // No Node.js environment available, fall back to console logging.
+    LOG(WARNING) << "[DeprecationWarning] " << warning_msg
+                 << " (code: " << deprecation_code << ")";
+    return;
+  }
+  node::ProcessEmitWarningGeneric(env, warning_msg, "DeprecationWarning",
                                   deprecation_code);
 }
 


### PR DESCRIPTION
#### Description of Change

If `util::EmitDeprecationWarning` is called from the renderer process and Node.js integration is disabled, it will crash as `node::Environment::GetCurrent(isolate)` will be `nullptr`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.