### PR TITLE
fix: fix video scrubbing on playback

### DIFF
--- a/patches/chromium/feat_add_streaming-protocol_registry_to_multibuffer_data_source.patch
+++ b/patches/chromium/feat_add_streaming-protocol_registry_to_multibuffer_data_source.patch
@@ -85,3 +85,15 @@ index 8c92f1c0c5028069cdad967b5be2bccf8005ed43..40217c27a4cfc43d3143c7eeb2b1e54d
  // A data source capable of loading URLs and buffering the data using an
  // in-memory sliding window.
  //
+diff --git a/third_party/blink/renderer/platform/media/resource_multi_buffer_data_provider.cc b/third_party/blink/renderer/platform/media/resource_multi_buffer_data_provider.cc
+index e0c0f0f90885f293f11ed7d58b72cb1d23d365a8..20877c949eb85e30cc17e4b571e046b9401ebc89 100644
+--- a/third_party/blink/renderer/platform/media/resource_multi_buffer_data_provider.cc
++++ b/third_party/blink/renderer/platform/media/resource_multi_buffer_data_provider.cc
+@@ -309,6 +309,7 @@ void ResourceMultiBufferDataProvider::DidReceiveResponse(
+       do_fail = true;
+     }
+   } else {
++    destination_url_data->set_range_supported();
+     if (content_length != kPositionNotSpecified) {
+       destination_url_data->set_length(content_length + byte_pos());
+     }


### PR DESCRIPTION
#### Description of Change

Fixes #47661

This PR slightly modifies an existing patch to MultibufferDataSource to correctly set the supported range on scrub.

Note: There is currently upstream work around MultiBufferNeverDefer v2 which changed this code (see this crbug: https://issues.chromium.org/issues/41161335); future upstream CLs may result in the patch needing to change again in the near future.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where video scrubbing would not correctly hold the new position on playback.
