### PR TITLE
fix: missing SQLite builtin support in Node.js

### DIFF
--- a/patches/node/build_add_gn_build_files.patch
+++ b/patches/node/build_add_gn_build_files.patch
@@ -24,7 +24,7 @@ index 4560bac7b8e3c707ecea5a425f642efb9de9ed36..e9c2a4391f4058a21a259cacaac4fde5
    o['variables']['v8_enable_external_code_space'] = 1 if options.enable_pointer_compression else 0
    o['variables']['v8_enable_31bit_smis_on_64bit_arch'] = 1 if options.enable_pointer_compression else 0
 diff --git a/node.gni b/node.gni
-index 35ccd0487f20cece033d58827ecb7ed016908ee4..b4450e3dd17994d1eaf59eb5cff5912545e89793 100644
+index 35ccd0487f20cece033d58827ecb7ed016908ee4..62cd49c6a87074912a1cb6792576c8d4f239b669 100644
 --- a/node.gni
 +++ b/node.gni
 @@ -5,10 +5,10 @@
@@ -40,7 +40,15 @@ index 35ccd0487f20cece033d58827ecb7ed016908ee4..b4450e3dd17994d1eaf59eb5cff59125
  
    # The location of OpenSSL - use the one from node's deps by default.
    node_openssl_path = "$node_path/deps/openssl"
-@@ -44,7 +44,7 @@ declare_args() {
+@@ -39,12 +39,15 @@ declare_args() {
+   # The variable is called "openssl" for parity with node's GYP build.
+   node_use_openssl = true
+ 
++  # Build node with SQLite support.
++  node_use_sqlite = true
++
+   # Use the specified path to system CA (PEM format) in addition to
+   # the BoringSSL supplied CA store or compiled-in Mozilla CA copy.
    node_openssl_system_ca_path = ""
  
    # Initialize v8 platform during node.js startup.
@@ -49,7 +57,7 @@ index 35ccd0487f20cece033d58827ecb7ed016908ee4..b4450e3dd17994d1eaf59eb5cff59125
  
    # Custom build tag.
    node_tag = ""
-@@ -64,10 +64,16 @@ declare_args() {
+@@ -64,10 +67,16 @@ declare_args() {
    # TODO(zcbenz): There are few broken things for now:
    #   1. cross-os compilation is not supported.
    #   2. node_mksnapshot crashes when cross-compiling for x64 from arm64.
@@ -271,10 +279,22 @@ index 856878c33681a73d41016729dabe48b0a6a80589..91a11852d206b65485fe90fd037a0bd1
      if sys.platform == 'win32':
        files = [ x.replace('\\', '/') for x in files ]
 diff --git a/unofficial.gni b/unofficial.gni
-index 44641b92678ab2f28e6f5de75a92878f9f3d322d..e17e4f043af6e4047ab82723ffd83187f3c04c5c 100644
+index 44641b92678ab2f28e6f5de75a92878f9f3d322d..a6cfd45b109c7b38fcf1529468ff64d3c1c8bd1b 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
-@@ -142,32 +142,42 @@ template("node_gn_build") {
+@@ -22,6 +22,11 @@ template("node_gn_build") {
+     } else {
+       defines += [ "HAVE_OPENSSL=0" ]
+     }
++    if (node_use_sqlite) {
++      defines += [ "HAVE_SQLITE=1" ]
++    } else {
++      defines += [ "HAVE_SQLITE=0" ]
++    }
+     if (node_use_amaro) {
+       defines += [ "HAVE_AMARO=1" ]
+     } else {
+@@ -142,32 +147,41 @@ template("node_gn_build") {
      public_configs = [
        ":node_external_config",
        "deps/googletest:googletest_config",
@@ -297,7 +317,7 @@ index 44641b92678ab2f28e6f5de75a92878f9f3d322d..e17e4f043af6e4047ab82723ffd83187
        "deps/nghttp2",
 -      "deps/ngtcp2",
        "deps/postject",
-       "deps/sqlite",
+-      "deps/sqlite",
        "deps/uvwasi",
 -      "deps/zstd",
        "//third_party/zlib",
@@ -320,7 +340,7 @@ index 44641b92678ab2f28e6f5de75a92878f9f3d322d..e17e4f043af6e4047ab82723ffd83187
        "$target_gen_dir/node_javascript.cc",
      ] + gypi_values.node_sources
  
-@@ -190,7 +200,7 @@ template("node_gn_build") {
+@@ -190,9 +204,13 @@ template("node_gn_build") {
      }
      if (node_use_openssl) {
        deps += [ "deps/ncrypto" ]
@@ -328,8 +348,14 @@ index 44641b92678ab2f28e6f5de75a92878f9f3d322d..e17e4f043af6e4047ab82723ffd83187
 +      public_deps += [ "//third_party/boringssl" ]
        sources += gypi_values.node_crypto_sources
      }
++    if (node_use_sqlite) {
++      deps += [ "deps/sqlite" ]
++      sources += gypi_values.node_sqlite_sources
++    }
      if (node_enable_inspector) {
-@@ -214,6 +224,10 @@ template("node_gn_build") {
+       deps += [
+         "src/inspector:crdtp",
+@@ -214,6 +232,10 @@ template("node_gn_build") {
      }
    }
  
@@ -340,7 +366,7 @@ index 44641b92678ab2f28e6f5de75a92878f9f3d322d..e17e4f043af6e4047ab82723ffd83187
    executable(target_name) {
      forward_variables_from(invoker, "*")
  
-@@ -288,6 +302,7 @@ template("node_gn_build") {
+@@ -288,6 +310,7 @@ template("node_gn_build") {
    }
  
    executable("node_js2c") {
@@ -348,7 +374,7 @@ index 44641b92678ab2f28e6f5de75a92878f9f3d322d..e17e4f043af6e4047ab82723ffd83187
      deps = [
        "deps/uv",
        "$node_simdutf_path",
-@@ -298,26 +313,75 @@ template("node_gn_build") {
+@@ -298,26 +321,75 @@ template("node_gn_build") {
        "src/embedded_data.cc",
        "src/embedded_data.h",
      ]
@@ -434,7 +460,7 @@ index 44641b92678ab2f28e6f5de75a92878f9f3d322d..e17e4f043af6e4047ab82723ffd83187
      outputs = [ "$target_gen_dir/node_javascript.cc" ]
  
      # Get the path to node_js2c executable of the host toolchain.
-@@ -331,11 +395,11 @@ template("node_gn_build") {
+@@ -331,11 +403,11 @@ template("node_gn_build") {
          get_label_info(":node_js2c($host_toolchain)", "name") +
          host_executable_suffix
  

--- a/patches/node/build_allow_unbundling_of_node_js_dependencies.patch
+++ b/patches/node/build_allow_unbundling_of_node_js_dependencies.patch
@@ -14,10 +14,10 @@ We don't need to do this for zlib, as the existing gn workflow uses the same
 Upstreamed at https://github.com/nodejs/node/pull/55903
 
 diff --git a/unofficial.gni b/unofficial.gni
-index e17e4f043af6e4047ab82723ffd83187f3c04c5c..d591dfc99fdea4f830008502786ee44d863a31fc 100644
+index a6cfd45b109c7b38fcf1529468ff64d3c1c8bd1b..332c9ee7262108ae9616e9bc8bd950a4940a858c 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
-@@ -155,7 +155,6 @@ template("node_gn_build") {
+@@ -160,7 +160,6 @@ template("node_gn_build") {
        ":run_node_js2c",
        "deps/cares",
        "deps/histogram",
@@ -25,7 +25,7 @@ index e17e4f043af6e4047ab82723ffd83187f3c04c5c..d591dfc99fdea4f830008502786ee44d
        "deps/nbytes",
        "deps/nghttp2",
        "deps/postject",
-@@ -194,7 +193,17 @@ template("node_gn_build") {
+@@ -198,7 +197,17 @@ template("node_gn_build") {
        configs -= [ "//build/config/gcc:symbol_visibility_hidden" ]
        configs += [ "//build/config/gcc:symbol_visibility_default" ]
      }
@@ -44,7 +44,7 @@ index e17e4f043af6e4047ab82723ffd83187f3c04c5c..d591dfc99fdea4f830008502786ee44d
      if (v8_enable_i18n_support) {
        deps += [ "//third_party/icu" ]
      }
-@@ -222,6 +231,19 @@ template("node_gn_build") {
+@@ -230,6 +239,19 @@ template("node_gn_build") {
        sources += node_inspector.node_inspector_sources +
                   node_inspector.node_inspector_generated_sources
      }

--- a/patches/node/build_option_to_use_custom_inspector_protocol_path.patch
+++ b/patches/node/build_option_to_use_custom_inspector_protocol_path.patch
@@ -12,7 +12,7 @@ protocol deps to contain https://chromium-review.googlesource.com/c/v8/v8/+/5996
 Rest of the changes can be upstreamed.
 
 diff --git a/node.gni b/node.gni
-index 203b4abbc44df9e58083c819f61f9025104abdc6..73bf3839866a2652ca660f1117e8f249d33fa46a 100644
+index 165b26a79a7f2b74d2a2252dc2350b2e10c091e6..c64761b730e61edcdc0e46a48699f2fd5bb1c0a6 100644
 --- a/node.gni
 +++ b/node.gni
 @@ -16,6 +16,9 @@ declare_args() {
@@ -39,10 +39,10 @@ index 3d7aa148678b2646b88fa7c32abec91791b02b82..4810d93eb971b253f7dadff7011a632f
    gypi_values = exec_script(
        "../../tools/gypi_to_gn.py",
 diff --git a/unofficial.gni b/unofficial.gni
-index d591dfc99fdea4f830008502786ee44d863a31fc..9e26399482d6a1cdb843efb72c152d5cdd5e08ea 100644
+index 332c9ee7262108ae9616e9bc8bd950a4940a858c..8886f2a79ae77614789d6ae0defd4f18fc756456 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
-@@ -214,13 +214,14 @@ template("node_gn_build") {
+@@ -222,13 +222,14 @@ template("node_gn_build") {
      }
      if (node_enable_inspector) {
        deps += [

--- a/patches/node/fix_handle_boringssl_and_openssl_incompatibilities.patch
+++ b/patches/node/fix_handle_boringssl_and_openssl_incompatibilities.patch
@@ -172,7 +172,7 @@ index e5bf2b529bf23914677e25d7468aad58a4684557..9a3c6029ff3319cce58c79782a7bd5d1
    };
    // Check to see if the given public key is suitable for this DH instance.
 diff --git a/node.gni b/node.gni
-index b4450e3dd17994d1eaf59eb5cff5912545e89793..203b4abbc44df9e58083c819f61f9025104abdc6 100644
+index 62cd49c6a87074912a1cb6792576c8d4f239b669..165b26a79a7f2b74d2a2252dc2350b2e10c091e6 100644
 --- a/node.gni
 +++ b/node.gni
 @@ -11,7 +11,7 @@ declare_args() {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/47671
Refs https://github.com/nodejs/node/pull/58122

Fixes an issue where `require('node:sqlite')` didn't work - this happened in https://github.com/electron/electron/pull/47555 via https://github.com/nodejs/node/pull/58122, which added the option to build without sqlite. That didnt get correctly copied to the GN build config.

See upstream at https://github.com/nodejs/node/pull/59017

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `require('node:sqlite')` didn't work.
