### PR TITLE
test: add response to bluetooth request possibilities

### DIFF
--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -3654,8 +3654,14 @@ describe('navigator.bluetooth', () => {
 
   it('can request bluetooth devices', async () => {
     const bluetooth = await w.webContents.executeJavaScript(`
-    navigator.bluetooth.requestDevice({ acceptAllDevices: true}).then(device => "Found a device!").catch(err => err.message);`, true);
-    expect(bluetooth).to.be.oneOf(['Found a device!', 'Bluetooth adapter not available.', 'User cancelled the requestDevice() chooser.']);
+    navigator.bluetooth.requestDevice({ acceptAllDevices: true }).then(device => "Found a device!").catch(err => err.message);`, true);
+    const requestResponses = [
+      'Found a device!',
+      'Bluetooth adapter not available.',
+      'User cancelled the requestDevice() chooser.',
+      'User denied the browser permission to scan for Bluetooth devices.'
+    ];
+    expect(bluetooth).to.be.oneOf(requestResponses, `Unexpected response: ${bluetooth}`);
   });
 });
 
@@ -3685,6 +3691,7 @@ describe('navigator.hid', () => {
     server.close();
     closeAllWindows();
   });
+
   afterEach(() => {
     session.defaultSession.setPermissionCheckHandler(null);
     session.defaultSession.setDevicePermissionHandler(null);


### PR DESCRIPTION
#### Description of Change

See test failure - we should take this possible outcome into account as it can also occur locally.

<img width="812" height="188" alt="Screenshot 2025-07-11 at 4 02 05 PM" src="https://github.com/user-attachments/assets/09bf07f5-a84e-4b00-9adc-7c53ab034049" />


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none