### PR TITLE
ci: add `kTCCServiceAppleEvents` perm override to fix AppleScript errors

### DIFF
--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -103,6 +103,7 @@ jobs:
             "'kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159"
             "'kTCCServiceCamera','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159"
             "'kTCCServiceBluetoothAlways','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159"
+            "'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159"
         )
         for values in "${userValuesArray[@]}"; do
           # Sonoma and higher have a few extra values


### PR DESCRIPTION
#### Description of Change

See https://github.com/electron/electron/actions/runs/16201576369/job/45745877787?pr=47712:

<img width="855" height="323" alt="Screenshot 2025-07-11 at 4 05 50 PM" src="https://github.com/user-attachments/assets/49ef7f12-b127-4639-861f-2b67c6280b79" />

Adjust TCC perms to allow this permission. See [tcc db ref](https://www.rainforestqa.com/blog/macos-tcc-db-deep-dive) for context.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none