### PR TITLE
test: cleanup RenderFrame lifespan tests

### DIFF
--- a/spec/api-web-frame-main-spec.ts
+++ b/spec/api-web-frame-main-spec.ts
@@ -374,7 +374,9 @@ describe('webFrameMain module', () => {
       await w.webContents.loadURL(server.crossOriginUrl);
       // senderFrame now points to a disposed RenderFrameHost. It should
       // be null when attempting to access the lazily evaluated property.
-      expect(event.senderFrame).to.be.null();
+      waitUntil(() => {
+        return event.senderFrame === null;
+      });
     });
 
     it('is detached when unload handler sends IPC', async () => {

--- a/spec/api-web-frame-main-spec.ts
+++ b/spec/api-web-frame-main-spec.ts
@@ -313,6 +313,7 @@ describe('webFrameMain module', () => {
     beforeEach(async () => {
       w = new BrowserWindow({ show: false });
     });
+    afterEach(closeAllWindows);
 
     // TODO(jkleinsc) fix this flaky test on linux
     ifit(process.platform !== 'linux')('throws upon accessing properties when disposed', async () => {

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -3106,7 +3106,7 @@ describe('iframe using HTML fullscreen API while window is OS-fullscreened', () 
   });
 });
 
-describe('navigator.serial', () => {
+ifdescribe(process.platform !== 'darwin' || process.arch !== 'arm64')('navigator.serial', () => {
   let w: BrowserWindow;
   before(async () => {
     w = new BrowserWindow({
@@ -3638,7 +3638,7 @@ ifdescribe((process.platform !== 'linux' || app.isUnityRunning()))('navigator.se
   });
 });
 
-describe('navigator.bluetooth', () => {
+ifdescribe(process.platform !== 'darwin' || process.arch !== 'arm64')('navigator.bluetooth', () => {
   let w: BrowserWindow;
   before(async () => {
     w = new BrowserWindow({


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
This PR fixes failing/flaky RenderFrame lifespan tests.  Additionally, it disables some device tests that are hanging on macOS arm64 due to some change made in the GHA macOS runners.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
