### PR TITLE
test: fix extensions console flake

### DIFF
--- a/spec/extensions-spec.ts
+++ b/spec/extensions-spec.ts
@@ -18,7 +18,7 @@ const uuid = require('uuid');
 const fixtures = path.join(__dirname, 'fixtures');
 
 describe('chrome extensions', () => {
-  const emptyPage = '<script>console.log("loaded")</script>';
+  const emptyPage = '<html><body><h1>EMPTY PAGE</h1></body></html>';
 
   // NB. extensions are only allowed on http://, https:// and ftp:// (!) urls by default.
   let server: http.Server;


### PR DESCRIPTION
#### Description of Change

Fixes a race condition flake in extensions tests:

<img width="753" height="360" alt="Screenshot 2025-07-15 at 9 53 40 AM" src="https://github.com/user-attachments/assets/90a8badd-2058-4288-a604-10e9002abd42" />

Many of them depend on parsing console logs, and sometimes the empty page load from the server could interfere with what it was supposed to be parsing.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none