### PR TITLE
build: fix ffmpeg generation on Windows non-x64

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -38,6 +38,12 @@ runs:
       run: |
         GN_APPENDED_ARGS="$GN_EXTRA_ARGS target_cpu=\"x64\" v8_snapshot_toolchain=\"//build/toolchain/mac:clang_x64\""
         echo "GN_EXTRA_ARGS=$GN_APPENDED_ARGS" >> $GITHUB_ENV
+    - name: Set GN_EXTRA_ARGS for Windows
+      shell: bash
+      if: ${{inputs.target-arch != 'x64' && inputs.target-platform == 'win' }}
+      run: |
+        GN_APPENDED_ARGS="$GN_EXTRA_ARGS target_cpu=\"${{ inputs.target-arch }}\""
+        echo "GN_EXTRA_ARGS=$GN_APPENDED_ARGS" >> $GITHUB_ENV
     - name: Add Clang problem matcher
       shell: bash
       run: echo "::add-matcher::src/electron/.github/problem-matchers/clang.json"

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -190,8 +190,8 @@ runs:
           electron/script/zip-symbols.py -b $BUILD_PATH
         fi
     - name: Generate FFMpeg ${{ inputs.step-suffix }}
-      shell: bash
       if: ${{ inputs.is-release == 'true' }}
+      shell: bash
       run: |
         cd src
         gn gen out/ffmpeg --args="import(\"//electron/build/args/ffmpeg.gn\") use_remoteexec=true $GN_EXTRA_ARGS"


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/47766
Refs https://github.com/electron/electron/pull/45466

Fixes an issue where ffmpeg builds didn't get built correctly on Windows arm64 or ia32

```
src on git:7a73d3ec5a6e8 ❯ file ~/Downloads/x64ffmpeg.dll                    10:25AM
/Users/codebytere/Downloads/ffmpeg.dll: PE32+ executable (DLL) (console) x86-64, for MS Windows

src on git:7a73d3ec5a6e8 ❯ file ~/Downloads/arm64ffmpeg.dll                    10:25AM
/Users/codebytere/Downloads/ffmpeg.dll: PE32+ executable (DLL) (console) x86-64, for MS Windows

src on git:7a73d3ec5a6e8 ❯ file ~/Downloads/ia32ffmpeg.dll                    10:25AM
/Users/codebytere/Downloads/ffmpeg.dll: PE32+ executable (DLL) (console) x86-64, for MS Windows
```

It seems we didn't properly set `GN_EXTRA_ARGS` for those platforms - i went back and checked our old appveyor configs and it's there:

<img width="688" height="525" alt="Screenshot 2025-07-16 at 10 40 00 AM" src="https://github.com/user-attachments/assets/e4b8f16f-1aac-460b-a711-9d4c323b656c" />

so we need to add that back here.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.
