### PR TITLE
fix: `BrowserWindow.isFocused()` on Windows

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -550,7 +550,12 @@ void NativeWindowViews::Focus(bool focus) {
 }
 
 bool NativeWindowViews::IsFocused() const {
-  return widget()->IsActive();
+  bool active = widget()->IsActive();
+#if BUILDFLAG(IS_WIN)
+  return active && ::GetForegroundWindow() == GetAcceleratedWidget();
+#else
+  return active;
+#endif
 }
 
 void NativeWindowViews::Show() {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/47749

Fixes an issue where `BrowserWindow.isFocused` incorrectly returned `true` even if the window was not in the foreground. To fix this, we should check `GetForegroundWindow()` on Windows as well as whether or not the widget is active.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `BrowserWindow.isFocused` incorrectly returned `true` even if the window was not in the foreground.