### PR TITLE
fix: `BrowserWindow.focus()` on non-foregrounded windows

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -82,6 +82,7 @@
 #include "shell/browser/ui/win/electron_desktop_native_widget_aura.h"
 #include "shell/common/color_util.h"
 #include "skia/ext/skia_utils_win.h"
+#include "ui/base/win/foreground_helper.h"
 #include "ui/display/win/screen_win.h"
 #include "ui/gfx/color_utils.h"
 #include "ui/gfx/win/hwnd_util.h"
@@ -543,6 +544,10 @@ void NativeWindowViews::Focus(bool focus) {
     return;
 
   if (focus) {
+#if BUILDFLAG(IS_WIN)
+    // On Windows, we need to ensure the window is in the foreground.
+    ui::ForegroundHelper::SetForeground(GetAcceleratedWidget());
+#endif
     widget()->Activate();
   } else {
     widget()->Deactivate();


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/47749
Closes https://github.com/electron/electron/issues/29082
Closes https://github.com/electron/electron/issues/25578
Closes https://github.com/electron/electron/issues/32892

Utilizes a helper class within Chromium to force windows to the foreground when they are focused.

Tested with https://gist.github.com/mads6655/b68074cd8e0326a5edc0b2b80ce0b2e8

cc @bpasero 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `BrowserWindow.focus()` did not always work on non-foregrounded windows.