### PR TITLE
build: drop @types/webpack-env in favor of webpack/module types

### DIFF
--- a/build/webpack/webpack.config.base.js
+++ b/build/webpack/webpack.config.base.js
@@ -143,7 +143,9 @@ if ((globalThis.process || binding.process).argv.includes("--profile-electron-in
             transpileOnly: onlyPrintingGraph,
             ignoreDiagnostics: [
               // File '{0}' is not under 'rootDir' '{1}'.
-              6059
+              6059,
+              // Private field '{0}' must be declared in an enclosing class.
+              1111
             ]
           }
         }]

--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -204,7 +204,7 @@ delete process.appCodeLoaded;
 if (packagePath) {
   // Finally load app's main.js and transfer control to C++.
   if ((packageJson.type === 'module' && !mainStartupScript.endsWith('.cjs')) || mainStartupScript.endsWith('.mjs')) {
-    const { runEntryPointWithESMLoader } = __non_webpack_require__('internal/modules/run_main');
+    const { runEntryPointWithESMLoader } = __non_webpack_require__('internal/modules/run_main') as typeof import('@node/lib/internal/modules/run_main');
     const main = (require('url') as typeof url).pathToFileURL(path.join(packagePath, mainStartupScript));
     runEntryPointWithESMLoader(async (cascadedLoader: any) => {
       try {

--- a/lib/node/asar-fs-wrapper.ts
+++ b/lib/node/asar-fs-wrapper.ts
@@ -52,20 +52,20 @@ const {
   getValidatedPath,
   getOptions,
   getDirent
-} = __non_webpack_require__('internal/fs/utils');
+} = __non_webpack_require__('internal/fs/utils') as typeof import('@node/lib/internal/fs/utils');
 
 const {
   assignFunctionName
-} = __non_webpack_require__('internal/util');
+} = __non_webpack_require__('internal/util') as typeof import('@node/lib/internal/util');
 
 const {
   validateBoolean,
   validateFunction
-} = __non_webpack_require__('internal/validators');
+} = __non_webpack_require__('internal/validators') as typeof import('@node/lib/internal/validators');
 
 // In the renderer node internals use the node global URL but we do not set that to be
 // the global URL instance.  We need to do instanceof checks against the internal URL impl
-const { URL: NodeURL } = __non_webpack_require__('internal/url');
+const { URL: NodeURL } = __non_webpack_require__('internal/url') as typeof import('@node/lib/internal/url');
 
 // Separate asar package's path from full path.
 const splitPath = (archivePathOrBuffer: string | Buffer | URL) => {
@@ -745,8 +745,8 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       const stat = internalBinding('fs').internalModuleStat(resultPath);
 
       context.readdirResults.push(dirent);
-      if (dirent.isDirectory() || stat === 1) {
-        context.pathsQueue.push(path.join(dirent.path, dirent.name));
+      if (dirent!.isDirectory() || stat === 1) {
+        context.pathsQueue.push(path.join(dirent!.path, dirent!.name));
       }
     }
   }
@@ -857,13 +857,13 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
   const { readdir } = fs;
   fs.readdir = function (pathArgument: string, options: ReaddirOptions, callback: ReaddirCallback) {
     callback = typeof options === 'function' ? options : callback;
-    validateFunction(callback, 'callback');
+    validateFunction(callback, 'callback')!;
 
     options = getOptions(options);
     pathArgument = getValidatedPath(pathArgument);
 
     if (options?.recursive != null) {
-      validateBoolean(options?.recursive, 'options.recursive');
+      validateBoolean(options?.recursive, 'options.recursive')!;
     }
 
     if (options?.recursive) {
@@ -914,7 +914,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     pathArgument = getValidatedPath(pathArgument);
 
     if (options?.recursive != null) {
-      validateBoolean(options?.recursive, 'options.recursive');
+      validateBoolean(options?.recursive, 'options.recursive')!;
     }
 
     if (options?.recursive) {
@@ -957,7 +957,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     pathArgument = getValidatedPath(pathArgument);
 
     if (options?.recursive != null) {
-      validateBoolean(options?.recursive, 'options.recursive');
+      validateBoolean(options?.recursive, 'options.recursive')!;
     }
 
     if (options?.recursive) {

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -65,9 +65,9 @@ require('@electron/internal/renderer/common-init');
 
 if (nodeIntegration) {
   // Export node bindings to global.
-  const { makeRequireFunction } = __non_webpack_require__('internal/modules/helpers');
+  const { makeRequireFunction } = __non_webpack_require__('internal/modules/helpers') as typeof import('@node/lib/internal/modules/helpers');
   global.module = new Module('electron/js2c/renderer_init');
-  global.require = makeRequireFunction(global.module);
+  (global.require as any) = makeRequireFunction(global.module);
 
   // Set the __filename to the path of html file if it is file: protocol.
   if (window.location.protocol === 'file:') {
@@ -150,7 +150,7 @@ if (cjsPreloads.length) {
   }
 }
 if (esmPreloads.length) {
-  const { runEntryPointWithESMLoader } = __non_webpack_require__('internal/modules/run_main');
+  const { runEntryPointWithESMLoader } = __non_webpack_require__('internal/modules/run_main') as typeof import('@node/lib/internal/modules/run_main');
 
   runEntryPointWithESMLoader(async (cascadedLoader: any) => {
     // Load the preload scripts.

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -67,7 +67,7 @@ if (nodeIntegration) {
   // Export node bindings to global.
   const { makeRequireFunction } = __non_webpack_require__('internal/modules/helpers') as typeof import('@node/lib/internal/modules/helpers');
   global.module = new Module('electron/js2c/renderer_init');
-  (global.require as any) = makeRequireFunction(global.module);
+  global.require = makeRequireFunction(global.module) as NodeRequire;
 
   // Set the __filename to the path of html file if it is file: protocol.
   if (window.location.protocol === 'file:') {

--- a/lib/utility/init.ts
+++ b/lib/utility/init.ts
@@ -36,7 +36,7 @@ parentPort.on('removeListener', (name: string) => {
 });
 
 // Finally load entry script.
-const { runEntryPointWithESMLoader } = __non_webpack_require__('internal/modules/run_main');
+const { runEntryPointWithESMLoader } = __non_webpack_require__('internal/modules/run_main') as typeof import('@node/lib/internal/modules/run_main');
 const mainEntry = pathToFileURL(entryScript);
 
 runEntryPointWithESMLoader(async (cascadedLoader: any) => {

--- a/lib/worker/init.ts
+++ b/lib/worker/init.ts
@@ -15,7 +15,7 @@ const { hasSwitch, getSwitchValue } = process._linkedBinding('electron_common_co
 // Export node bindings to global.
 const { makeRequireFunction } = __non_webpack_require__('internal/modules/helpers') as typeof import('@node/lib/internal/modules/helpers');
 global.module = new Module('electron/js2c/worker_init');
-(global.require as any) = makeRequireFunction(global.module);
+global.require = makeRequireFunction(global.module) as NodeRequire;
 
 // See WebWorkerObserver::WorkerScriptReadyForEvaluation.
 if ((globalThis as any).blinkfetch) {

--- a/lib/worker/init.ts
+++ b/lib/worker/init.ts
@@ -13,9 +13,9 @@ require('@electron/internal/common/init');
 const { hasSwitch, getSwitchValue } = process._linkedBinding('electron_common_command_line');
 
 // Export node bindings to global.
-const { makeRequireFunction } = __non_webpack_require__('internal/modules/helpers');
+const { makeRequireFunction } = __non_webpack_require__('internal/modules/helpers') as typeof import('@node/lib/internal/modules/helpers');
 global.module = new Module('electron/js2c/worker_init');
-global.require = makeRequireFunction(global.module);
+(global.require as any) = makeRequireFunction(global.module);
 
 // See WebWorkerObserver::WorkerScriptReadyForEvaluation.
 if ((globalThis as any).blinkfetch) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@types/semver": "^7.5.8",
     "@types/stream-json": "^1.7.7",
     "@types/temp": "^0.9.4",
-    "@types/webpack-env": "^1.18.5",
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "@typescript-eslint/parser": "^8.7.0",
     "buffer": "^6.0.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "outDir": "ts-gen",
     "typeRoots" : ["./node_modules/@types", "./spec/node_modules/@types"],
     "paths": {
-      "@electron/internal/*": ["lib/*"]
+      "@electron/internal/*": ["lib/*"],
+      "@node/*": ["../third_party/electron_node/*"]
     }
   },
   "exclude": [

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="webpack/module" />
+
 declare const BUILDFLAG: (flag: boolean) => boolean;
 
 declare namespace NodeJS {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1068,11 +1068,6 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.2.tgz#6dd61e43ef60b34086287f83683a5c1b2dc53d20"
   integrity sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==
 
-"@types/webpack-env@^1.18.5":
-  version "1.18.5"
-  resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.18.5.tgz#eccda0b04fe024bed505881e2e532f9c119169bf"
-  integrity sha512-wz7kjjRRj8/Lty4B+Kr0LN6Ypc/3SymeCCGSbaXp2leH0ZVg/PriNiOwNj4bD4uphI7A8NXS4b6Gl373sfO5mA==
-
 "@types/yauzl@^2.9.1":
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.10.0.tgz#b3248295276cf8c6f153ebe6a9aba0c988cb2599"


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

This change was prompted by #47621 which is trying to bring in the latest `@types/webpack-env` and causing TS build errors due to conflicting types. [Webpack added `module.d.ts` in v5.62.0](https://github.com/webpack/webpack/releases/tag/v5.62.0), which serves the same purpose as `@types/webpack-env`, so this PR switches to it and drops `@types/webpack-env`.

This PR also adds a path mapping in `tsconfig.json` to map `@node/*` to `../third_party/electron_node` and types the requires of Node.js modules so that we get accurate types for them, which required tweaking our existing types a bit.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
