### PR TITLE
build: update codespace `on-create-command`

### DIFF
--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -58,13 +58,13 @@ if [ ! -f $buildtools/configs/evm.testing.json ]; then
             },
             \"\$schema\": \"file:///home/builduser/.electron_build_tools/evm-config.schema.json\",
             \"configValidationLevel\": \"strict\",
-            \"reclient\": \"$1\",
-            \"preserveXcode\": 5
+            \"remoteBuild\": \"reclient\",
+            \"preserveSDK\": 5
         }
     " >$buildtools/configs/evm.testing.json
   }
 
-  write_config remote_exec
+  write_config
 
   e use testing 
 else


### PR DESCRIPTION
#### Description of Change

Update codespace config defaults to use `preserveSDK` by default as well as `"remoteBuild": "reclient",`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none