### PR TITLE
fix: dialog file filters and macOS app bundles

### DIFF
--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -122,6 +122,18 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
       if (ext == "*") {
         [content_types_set addObject:[UTType typeWithFilenameExtension:@"*"]];
         break;
+      } else if (ext == "app") {
+        // This handles a bug on macOS where the "app" extension by default
+        // maps to "com.apple.application-file", which is for an Application
+        // file (older single-file carbon based apps), and not modern
+        // Application Bundles (multi file packages as you'd see for all modern
+        // applications).
+        UTType* superType =
+            [UTType typeWithIdentifier:@"com.apple.application-bundle"];
+        if (UTType* utt = [UTType typeWithFilenameExtension:@"app"
+                                           conformingToType:superType]) {
+          [content_types_set addObject:utt];
+        }
       } else {
         if (UTType* utt = [UTType typeWithFilenameExtension:@(ext.c_str())])
           [content_types_set addObject:utt];


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/46623
Closes https://github.com/electron/electron/issues/47815

Fixed a bug where `app` extensions filters didn't allow for selecting app bundles in macOS file dialogs.

This happened as a result of a bug on macOS with UTTypes where the "app" extension by default
maps to "com.apple.application-file", which is for an Application  file (older single-file carbon based apps), and not modern Application Bundles (multi file packages as you'd see for all modern applications).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a bug where `app` extensions filters didn't allow for selecting app bundles in macOS file dialogs.