### PR TITLE
build: extend Chromium options in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
     label: Does the issue also appear in Chromium / Google Chrome?
     description: If it does, please report the issue in the [Chromium issue tracker](https://issues.chromium.org/issues), not against Electron. Electron will inherit the fix once Chromium resolves the issue.
     options:
-      - I did not know how to test
+      - I don't know how to test
       - "Yes"
       - "No"
   validations:


### PR DESCRIPTION
#### Description of Change

As predicted by @dsanders11 and others, we got a bunch of bug reports with clearly incorrect values for "does this issue also happen in Chromium?" because people didn't test or didn't know how to test.

This PR adds an "I don't know how to test" option.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none