### PR TITLE
feat: allow macOS tray to maintain position

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -327,6 +327,14 @@ Returns [`Rectangle`](structures/rectangle.md)
 
 The `bounds` of this tray icon as `Object`.
 
+#### `tray.setAutosaveName(name)` _macOS_
+
+* `name` string - A string used to uniquely identify the tray icon and allow it to retain its position between relaunches. Using the same string for a new tray item will create it in the same position as the previous tray item to use the string. Passing an empty string will reset the name to a system-assigned name.
+
+#### `tray.getAutosaveName()` _macOS_
+
+Returns `string | null` - A string used to uniquely identify the tray icon and allow it to retain its position between relaunches, or null if none is set.
+
 #### `tray.isDestroyed()`
 
 Returns `boolean` - Whether the tray icon is destroyed.

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -79,7 +79,15 @@ app.whenReady().then(() => {
 ### `new Tray(image, [guid])`
 
 * `image` ([NativeImage](native-image.md) | string)
-* `guid` string (optional) _Windows_ - Assigns a GUID to the tray icon. If the executable is signed and the signature contains an organization in the subject line then the GUID is permanently associated with that signature. OS level settings like the position of the tray icon in the system tray will persist even if the path to the executable changes. If the executable is not code-signed then the GUID is permanently associated with the path to the executable. Changing the path to the executable will break the creation of the tray icon and a new GUID must be used. However, it is highly recommended to use the GUID parameter only in conjunction with code-signed executable. If an App defines multiple tray icons then each icon must use a separate GUID.
+* `guid` string (optional) _Windows_ _macOS_ - A unique string used to identify the tray icon.
+
+**Windows**
+
+On Windows, if the executable is signed and the signature contains an organization in the subject line then the GUID is permanently associated with that signature. OS level settings like the position of the tray icon in the system tray will persist even if the path to the executable changes. If the executable is not code-signed then the GUID is permanently associated with the path to the executable. Changing the path to the executable will break the creation of the tray icon and a new GUID must be used. However, it is highly recommended to use the GUID parameter only in conjunction with code-signed executable. If an App defines multiple tray icons then each icon must use a separate GUID.
+
+**MacOS**
+
+On macOS, the `guid` is a string used to uniquely identify the tray icon and allow it to retain its position between relaunches. Using the same string for a new tray item will create it in the same position as the previous tray item to use the string.
 
 Creates a new tray icon associated with the `image`.
 
@@ -327,13 +335,9 @@ Returns [`Rectangle`](structures/rectangle.md)
 
 The `bounds` of this tray icon as `Object`.
 
-#### `tray.setAutosaveName(name)` _macOS_
+#### `tray.getGUID()` _macOS_ _Windows_
 
-* `name` string - A string used to uniquely identify the tray icon and allow it to retain its position between relaunches. Using the same string for a new tray item will create it in the same position as the previous tray item to use the string. Passing an empty string will reset the name to a system-assigned name.
-
-#### `tray.getAutosaveName()` _macOS_
-
-Returns `string | null` - A string used to uniquely identify the tray icon and allow it to retain its position between relaunches, or null if none is set.
+Returns `string | null` - The GUID used to uniquely identify the tray icon and allow it to retain its position between relaunches, or null if none is set.
 
 #### `tray.isDestroyed()`
 

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -79,7 +79,7 @@ app.whenReady().then(() => {
 ### `new Tray(image, [guid])`
 
 * `image` ([NativeImage](native-image.md) | string)
-* `guid` string (optional) _Windows_ _macOS_ - A unique string used to identify the tray icon.
+* `guid` string (optional) _Windows_ _macOS_ - A unique string used to identify the tray icon. Must adhere to [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) format.
 
 **Windows**
 

--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -72,12 +72,10 @@ gin_helper::Handle<Tray> Tray::New(gin_helper::ErrorThrower thrower,
     return {};
   }
 
-#if BUILDFLAG(IS_WIN)
   if (!guid.has_value() && args->Length() > 1) {
     thrower.ThrowError("Invalid GUID format - GUID must be a string");
     return {};
   }
-#endif
 
   // Error thrown by us will be dropped when entering V8.
   // Make sure to abort early and propagate the error to JS.

--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -392,6 +392,22 @@ gfx::Rect Tray::GetBounds() {
   return tray_icon_->GetBounds();
 }
 
+void Tray::SetAutoSaveName(const std::string& name) {
+  if (!CheckAlive())
+    return;
+  tray_icon_->SetAutoSaveName(name);
+}
+
+v8::Local<v8::Value> Tray::GetAutoSaveName() {
+  if (!CheckAlive())
+    return {};
+  auto* isolate = JavascriptEnvironment::GetIsolate();
+  const std::string& name = tray_icon_->GetAutoSaveName();
+  if (name.empty())
+    return v8::Null(isolate);
+  return gin::ConvertToV8(isolate, name);
+}
+
 bool Tray::CheckAlive() {
   if (!tray_icon_) {
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
@@ -424,6 +440,8 @@ void Tray::FillObjectTemplate(v8::Isolate* isolate,
       .SetMethod("closeContextMenu", &Tray::CloseContextMenu)
       .SetMethod("setContextMenu", &Tray::SetContextMenu)
       .SetMethod("getBounds", &Tray::GetBounds)
+      .SetMethod("setAutosaveName", &Tray::SetAutoSaveName)
+      .SetMethod("getAutosaveName", &Tray::GetAutoSaveName)
       .Build();
 }
 

--- a/shell/browser/api/electron_api_tray.h
+++ b/shell/browser/api/electron_api_tray.h
@@ -111,6 +111,8 @@ class Tray final : public gin_helper::DeprecatedWrappable<Tray>,
   void SetContextMenu(gin_helper::ErrorThrower thrower,
                       v8::Local<v8::Value> arg);
   gfx::Rect GetBounds();
+  void SetAutoSaveName(const std::string& name);
+  v8::Local<v8::Value> GetAutoSaveName();
 
   bool CheckAlive();
 

--- a/shell/browser/api/electron_api_tray.h
+++ b/shell/browser/api/electron_api_tray.h
@@ -19,6 +19,10 @@
 #include "shell/common/gin_helper/pinnable.h"
 #include "shell/common/gin_helper/wrappable.h"
 
+namespace base {
+class Uuid;
+}  // namespace base
+
 namespace gfx {
 class Image;
 class Image;
@@ -45,7 +49,7 @@ class Tray final : public gin_helper::DeprecatedWrappable<Tray>,
   // gin_helper::Constructible
   static gin_helper::Handle<Tray> New(gin_helper::ErrorThrower thrower,
                                       v8::Local<v8::Value> image,
-                                      std::optional<UUID> guid,
+                                      std::optional<base::Uuid> guid,
                                       gin::Arguments* args);
 
   static void FillObjectTemplate(v8::Isolate*, v8::Local<v8::ObjectTemplate>);
@@ -65,7 +69,7 @@ class Tray final : public gin_helper::DeprecatedWrappable<Tray>,
  private:
   Tray(v8::Isolate* isolate,
        v8::Local<v8::Value> image,
-       std::optional<UUID> guid);
+       std::optional<base::Uuid> guid);
   ~Tray() override;
 
   // TrayIconObserver:
@@ -111,12 +115,12 @@ class Tray final : public gin_helper::DeprecatedWrappable<Tray>,
   void SetContextMenu(gin_helper::ErrorThrower thrower,
                       v8::Local<v8::Value> arg);
   gfx::Rect GetBounds();
-  void SetAutoSaveName(const std::string& name);
-  v8::Local<v8::Value> GetAutoSaveName();
+  v8::Local<v8::Value> GetGUID();
 
   bool CheckAlive();
 
   v8::Global<v8::Value> menu_;
+  std::optional<base::Uuid> guid_;
   std::unique_ptr<TrayIcon> tray_icon_;
 };
 

--- a/shell/browser/api/electron_api_tray.h
+++ b/shell/browser/api/electron_api_tray.h
@@ -19,10 +19,6 @@
 #include "shell/common/gin_helper/pinnable.h"
 #include "shell/common/gin_helper/wrappable.h"
 
-namespace base {
-class Uuid;
-}  // namespace base
-
 namespace gfx {
 class Image;
 class Image;

--- a/shell/browser/ui/tray_icon.cc
+++ b/shell/browser/ui/tray_icon.cc
@@ -18,10 +18,6 @@ gfx::Rect TrayIcon::GetBounds() {
 
 void TrayIcon::SetAutoSaveName(const std::string& name) {}
 
-std::string TrayIcon::GetAutoSaveName() const {
-  return std::string();
-}
-
 void TrayIcon::NotifyClicked(const gfx::Rect& bounds,
                              const gfx::Point& location,
                              int modifiers) {

--- a/shell/browser/ui/tray_icon.cc
+++ b/shell/browser/ui/tray_icon.cc
@@ -16,6 +16,12 @@ gfx::Rect TrayIcon::GetBounds() {
   return {};
 }
 
+void TrayIcon::SetAutoSaveName(const std::string& name) {}
+
+std::string TrayIcon::GetAutoSaveName() const {
+  return std::string();
+}
+
 void TrayIcon::NotifyClicked(const gfx::Rect& bounds,
                              const gfx::Point& location,
                              int modifiers) {

--- a/shell/browser/ui/tray_icon.h
+++ b/shell/browser/ui/tray_icon.h
@@ -99,6 +99,9 @@ class TrayIcon {
   // Returns the bounds of tray icon.
   virtual gfx::Rect GetBounds();
 
+  virtual void SetAutoSaveName(const std::string& name);
+  virtual std::string GetAutoSaveName() const;
+
   void AddObserver(TrayIconObserver* obs) { observers_.AddObserver(obs); }
   void RemoveObserver(TrayIconObserver* obs) { observers_.RemoveObserver(obs); }
 

--- a/shell/browser/ui/tray_icon.h
+++ b/shell/browser/ui/tray_icon.h
@@ -18,7 +18,7 @@ namespace electron {
 
 class TrayIcon {
  public:
-  static TrayIcon* Create(std::optional<UUID> guid);
+  static TrayIcon* Create(std::optional<base::Uuid> guid);
 
 #if BUILDFLAG(IS_WIN)
   using ImageType = HICON;
@@ -100,7 +100,6 @@ class TrayIcon {
   virtual gfx::Rect GetBounds();
 
   virtual void SetAutoSaveName(const std::string& name);
-  virtual std::string GetAutoSaveName() const;
 
   void AddObserver(TrayIconObserver* obs) { observers_.AddObserver(obs); }
   void RemoveObserver(TrayIconObserver* obs) { observers_.RemoveObserver(obs); }

--- a/shell/browser/ui/tray_icon_cocoa.h
+++ b/shell/browser/ui/tray_icon_cocoa.h
@@ -35,6 +35,8 @@ class TrayIconCocoa : public TrayIcon {
   void CloseContextMenu() override;
   void SetContextMenu(raw_ptr<ElectronMenuModel> menu_model) override;
   gfx::Rect GetBounds() override;
+  void SetAutoSaveName(const std::string& name) override;
+  std::string GetAutoSaveName() const override;
 
   base::WeakPtr<TrayIconCocoa> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();
@@ -46,6 +48,8 @@ class TrayIconCocoa : public TrayIcon {
 
   // Status menu shown when right-clicking the system icon.
   ElectronMenuController* __strong menu_;
+
+  std::string auto_save_name_;
 
   base::WeakPtrFactory<TrayIconCocoa> weak_factory_{this};
 };

--- a/shell/browser/ui/tray_icon_cocoa.h
+++ b/shell/browser/ui/tray_icon_cocoa.h
@@ -36,7 +36,6 @@ class TrayIconCocoa : public TrayIcon {
   void SetContextMenu(raw_ptr<ElectronMenuModel> menu_model) override;
   gfx::Rect GetBounds() override;
   void SetAutoSaveName(const std::string& name) override;
-  std::string GetAutoSaveName() const override;
 
   base::WeakPtr<TrayIconCocoa> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();
@@ -48,8 +47,6 @@ class TrayIconCocoa : public TrayIcon {
 
   // Status menu shown when right-clicking the system icon.
   ElectronMenuController* __strong menu_;
-
-  std::string auto_save_name_;
 
   base::WeakPtrFactory<TrayIconCocoa> weak_factory_{this};
 };

--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -68,6 +68,10 @@
   [self setFrame:[statusItem_ button].frame];
 }
 
+- (void)setAutosaveName:(NSString*)name {
+  statusItem_.autosaveName = name;
+}
+
 - (void)updateTrackingAreas {
   // Use NSTrackingArea for listening to mouseEnter, mouseExit, and mouseMove
   // events.
@@ -418,6 +422,15 @@ void TrayIconCocoa::SetContextMenu(raw_ptr<ElectronMenuModel> menu_model) {
 
 gfx::Rect TrayIconCocoa::GetBounds() {
   return gfx::ScreenRectFromNSRect([status_item_view_ window].frame);
+}
+
+void TrayIconCocoa::SetAutoSaveName(const std::string& name) {
+  auto_save_name_ = name;
+  [status_item_view_ setAutosaveName:base::SysUTF8ToNSString(name)];
+}
+
+std::string TrayIconCocoa::GetAutoSaveName() const {
+  return auto_save_name_;
 }
 
 // static

--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -11,6 +11,7 @@
 #include "base/message_loop/message_pump_apple.h"
 #include "base/strings/sys_string_conversions.h"
 #include "base/task/current_thread.h"
+#include "base/uuid.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "shell/browser/ui/cocoa/NSString+ANSI.h"
@@ -425,16 +426,11 @@ gfx::Rect TrayIconCocoa::GetBounds() {
 }
 
 void TrayIconCocoa::SetAutoSaveName(const std::string& name) {
-  auto_save_name_ = name;
   [status_item_view_ setAutosaveName:base::SysUTF8ToNSString(name)];
 }
 
-std::string TrayIconCocoa::GetAutoSaveName() const {
-  return auto_save_name_;
-}
-
 // static
-TrayIcon* TrayIcon::Create(std::optional<UUID> guid) {
+TrayIcon* TrayIcon::Create(std::optional<base::Uuid> guid) {
   return new TrayIconCocoa;
 }
 

--- a/shell/browser/ui/tray_icon_linux.cc
+++ b/shell/browser/ui/tray_icon_linux.cc
@@ -112,7 +112,7 @@ ui::StatusIconLinux* TrayIconLinux::GetStatusIcon() {
 }
 
 // static
-TrayIcon* TrayIcon::Create(std::optional<UUID> guid) {
+TrayIcon* TrayIcon::Create(std::optional<base::Uuid> guid) {
   return new TrayIconLinux;
 }
 

--- a/shell/browser/ui/tray_icon_win.cc
+++ b/shell/browser/ui/tray_icon_win.cc
@@ -8,7 +8,7 @@
 namespace electron {
 
 // static
-TrayIcon* TrayIcon::Create(std::optional<UUID> guid) {
+TrayIcon* TrayIcon::Create(std::optional<base::Uuid> guid) {
   static NotifyIconHost host;
   return host.CreateNotifyIcon(guid);
 }

--- a/shell/browser/ui/win/notify_icon_host.h
+++ b/shell/browser/ui/win/notify_icon_host.h
@@ -27,7 +27,7 @@ class NotifyIconHost {
   NotifyIconHost(const NotifyIconHost&) = delete;
   NotifyIconHost& operator=(const NotifyIconHost&) = delete;
 
-  NotifyIcon* CreateNotifyIcon(std::optional<UUID> guid);
+  NotifyIcon* CreateNotifyIcon(std::optional<base::Uuid> guid);
   void Remove(NotifyIcon* notify_icon);
 
  private:

--- a/shell/common/gin_converters/guid_converter.h
+++ b/shell/common/gin_converters/guid_converter.h
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "base/strings/string_util.h"
 #include "base/uuid.h"
 #include "gin/converter.h"
 
@@ -46,7 +47,11 @@ struct Converter<base::Uuid> {
     if (!gin::ConvertFromV8(isolate, val, &guid))
       return false;
 
-    *out = base::Uuid::ParseLowercase(guid);
+    base::Uuid parsed = base::Uuid::ParseLowercase(base::ToLowerASCII(guid));
+    if (!parsed.is_valid())
+      return false;
+
+    *out = parsed;
     return true;
   }
 

--- a/spec/api-tray-spec.ts
+++ b/spec/api-tray-spec.ts
@@ -30,13 +30,13 @@ describe('tray module', () => {
       }).to.throw(/Failed to load image from path (.+)/);
     });
 
-    ifit(process.platform === 'win32')('throws a descriptive error if an invalid guid is given', () => {
+    ifit(process.platform !== 'linux')('throws a descriptive error if an invalid guid is given', () => {
       expect(() => {
         tray = new Tray(nativeImage.createEmpty(), 'I am not a guid');
       }).to.throw('Invalid GUID format');
     });
 
-    ifit(process.platform === 'win32')('accepts a valid guid', () => {
+    ifit(process.platform !== 'linux')('accepts a valid guid', () => {
       expect(() => {
         tray = new Tray(nativeImage.createEmpty(), '0019A433-3526-48BA-A66C-676742C0FEFB');
       }).to.not.throw();


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/42154.

Fixes an issue where a tray icon on macOS would not maintain position across launches.

macOS allows setting an autosave name on an `NSStatusItem`, which enables the icon to maintain its position across launches. If a user creates and then closes a tray icon and then creates a new one with the same autosave name as the previously closed one, macOS will place it in the same position as the previous one with the same name.

We do this by adding a feature to customize the autosave name.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `tray.{get|set}AutosaveName` to enable macOS tray icons to maintain position across launches.