### PR TITLE
fix: dark mode on Linux default themeing

### DIFF
--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
@@ -26,6 +26,7 @@
 #include "ui/linux/linux_ui.h"
 #include "ui/ozone/public/ozone_platform.h"
 #include "ui/platform_window/platform_window.h"
+#include "ui/platform_window/platform_window_init_properties.h"
 #include "ui/views/widget/desktop_aura/desktop_window_tree_host.h"
 #include "ui/views/widget/desktop_aura/desktop_window_tree_host_linux.h"
 
@@ -291,6 +292,16 @@ void ElectronDesktopWindowTreeHostLinux::DispatchEvent(ui::Event* event) {
   }
 
   views::DesktopWindowTreeHostLinux::DispatchEvent(event);
+}
+
+void ElectronDesktopWindowTreeHostLinux::AddAdditionalInitProperties(
+    const views::Widget::InitParams& params,
+    ui::PlatformWindowInitProperties* properties) {
+  views::DesktopWindowTreeHostLinux::AddAdditionalInitProperties(params,
+                                                                 properties);
+  const auto* linux_ui_theme = ui::LinuxUiTheme::GetForProfile(nullptr);
+  properties->prefer_dark_theme =
+      linux_ui_theme && linux_ui_theme->PreferDarkTheme();
 }
 
 }  // namespace electron

--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.h
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.h
@@ -62,6 +62,9 @@ class ElectronDesktopWindowTreeHostLinux
   // views::DesktopWindowTreeHostLinux:
   void UpdateFrameHints() override;
   void DispatchEvent(ui::Event* event) override;
+  void AddAdditionalInitProperties(
+      const views::Widget::InitParams& params,
+      ui::PlatformWindowInitProperties* properties) override;
 
  private:
   void UpdateWindowState(ui::PlatformWindowState new_state);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/47842
Refs CL:6469606

Fixes an issue where windows used dark theme on Linux all the time without reacting to system theme changes.

We need to take an approach similar to that in [`BrowserDesktopWindowTreeHostLinux`](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/views/frame/browser_desktop_window_tree_host_linux.cc;l=106-115;drc=4eaa7ecc4adc54dc936063562327f3d0c599f403;bpv=1;bpt=0) and override the `prefers_dark_theme` property based on our own `ui::LinuxUiGetter`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where windows used dark theme on Linux all the time without reacting to system theme changes.
