### PR TITLE
fix: launch crash when null device is disabled on Windows

### DIFF
--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -193,6 +193,11 @@ Disables the Chromium [sandbox](https://www.chromium.org/developers/design-docum
 Forces renderer process and Chromium helper processes to run un-sandboxed.
 Should only be used for testing.
 
+### --no-stdio-init
+
+Disable stdio initialization during node initialization.
+Used to avoid node initialization crash when the nul device is disabled on Windows platform.
+
 ### --proxy-bypass-list=`hosts`
 
 Instructs Electron to bypass the proxy server for the given semi-colon-separated

--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -132,6 +132,7 @@ UtilityProcessWrapper::UtilityProcessWrapper(
                       OPEN_EXISTING, 0, nullptr);
       if (handle == INVALID_HANDLE_VALUE) {
         PLOG(ERROR) << "Failed to create null handle";
+        Emit("error", "Failed to create null handle for ignoring stdio");
         return;
       }
       if (io_handle == IOHandle::STDOUT) {

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -549,7 +549,7 @@ void ElectronBrowserClient::AppendExtraCommandLineSwitches(
   if (process_type == ::switches::kUtilityProcess ||
       process_type == ::switches::kRendererProcess) {
     // Copy following switches to child process.
-    static constexpr std::array<const char*, 9U> kCommonSwitchNames = {
+    static constexpr std::array<const char*, 10U> kCommonSwitchNames = {
         switches::kStandardSchemes.c_str(),
         switches::kEnableSandbox.c_str(),
         switches::kSecureSchemes.c_str(),
@@ -558,6 +558,7 @@ void ElectronBrowserClient::AppendExtraCommandLineSwitches(
         switches::kFetchSchemes.c_str(),
         switches::kServiceWorkerSchemes.c_str(),
         switches::kStreamingSchemes.c_str(),
+        switches::kNoStdioInit.c_str(),
         switches::kCodeCacheSchemes.c_str()};
     command_line->CopySwitchesFrom(*base::CommandLine::ForCurrentProcess(),
                                    kCommonSwitchNames);

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -40,6 +40,8 @@
 #include "shell/common/mac/main_application_bundle.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/node_util.h"
+#include "shell/common/options_switches.h"
+#include "shell/common/platform_util.h"
 #include "shell/common/process_util.h"
 #include "shell/common/world_ids.h"
 #include "third_party/blink/public/common/web_preferences/web_preferences.h"
@@ -671,6 +673,19 @@ void NodeBindings::Initialize(v8::Isolate* const isolate,
 
   if (!fuses::IsNodeOptionsEnabled())
     process_flags |= node::ProcessInitializationFlags::kDisableNodeOptionsEnv;
+
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  if (command_line->HasSwitch(switches::kNoStdioInit)) {
+    process_flags |= node::ProcessInitializationFlags::kNoStdioInitialization;
+  } else {
+#if BUILDFLAG(IS_WIN)
+    if (!platform_util::IsNulDeviceEnabled()) {
+      LOG(FATAL) << "Unable to open nul device needed for initialization,"
+                    "aborting startup. As a workaround, try starting with --"
+                 << switches::kNoStdioInit;
+    }
+#endif
+  }
 
   std::shared_ptr<node::InitializationResult> result =
       node::InitializeOncePerProcess(

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -309,6 +309,10 @@ inline constexpr base::cstring_view kDisableNTLMv2 = "disable-ntlm-v2";
 inline constexpr base::cstring_view kServiceWorkerPreload =
     "service-worker-preload";
 
+// If set, flag node::ProcessInitializationFlags::kNoStdioInitialization would
+// be set for node initialization.
+inline constexpr base::cstring_view kNoStdioInit = "no-stdio-init";
+
 }  // namespace switches
 
 }  // namespace electron

--- a/shell/common/platform_util.h
+++ b/shell/common/platform_util.h
@@ -47,6 +47,9 @@ void Beep();
 #if BUILDFLAG(IS_WIN)
 // SHGetFolderPath calls not covered by Chromium
 bool GetFolderPath(int key, base::FilePath* result);
+
+// Check if nul device can be used.
+bool IsNulDeviceEnabled();
 #endif
 
 #if BUILDFLAG(IS_MAC)

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -12,6 +12,8 @@
 #include <comdef.h>
 #include <commdlg.h>
 #include <dwmapi.h>
+#include <fcntl.h>
+#include <io.h>
 #include <objbase.h>
 #include <shellapi.h>
 #include <shlobj.h>
@@ -448,6 +450,17 @@ bool GetFolderPath(int key, base::FilePath* result) {
 
 void Beep() {
   MessageBeep(MB_OK);
+}
+
+bool IsNulDeviceEnabled() {
+  bool ret = true;
+  int fd = _open("nul", _O_RDWR);
+  if (fd < 0) {
+    ret = false;
+  } else {
+    _close(fd);
+  }
+  return ret;
 }
 
 }  // namespace platform_util


### PR DESCRIPTION
add node flag node::ProcessInitializationFlags::kNoStdioInitialization


#### Description of Change

This PR continues https://github.com/electron/electron/pull/44882 (originally by @yangllu, my colleague).
I've taken over this task and addressed all 4 review comments:​

​​All 3​​ were updated exactly as suggested (@deepak1556).
​​For parameter passing​​, I didn’t just ​​send​​ it to the Renderer. Since ​​the​​ node ​​module​​ is also used in the Utility process, I ​​added​​ it there ​​as well​​."


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: add support for `--no-stdio-init` to be used when nul device is disabled on windows