### PR TITLE
ci: fixup mac runners

### DIFF
--- a/.github/actions/free-space-macos/action.yml
+++ b/.github/actions/free-space-macos/action.yml
@@ -6,6 +6,8 @@ runs:
     - name: Free Space on MacOS
       shell: bash
       run: |
+        echo "Disk usage before cleanup:"
+        df -h
         sudo mkdir -p $TMPDIR/del-target
 
         tmpify() {
@@ -74,3 +76,4 @@ runs:
         # lipo off some huge binaries arm64 versions to save space
         strip_universal_deep $(xcode-select -p)/../SharedFrameworks
         # strip_arm_deep /System/Volumes/Data/Library/Developer/CommandLineTools/usr
+        sudo mdutil -a -i off

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -104,6 +104,8 @@ jobs:
             "'kTCCServiceCamera','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159"
             "'kTCCServiceBluetoothAlways','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159"
             "'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159"
+            "'kTCCServiceCamera',' /opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159"
+            "'kTCCServiceBluetoothAlways',' /opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159"
         )
         for values in "${userValuesArray[@]}"; do
           # Sonoma and higher have a few extra values

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -3106,7 +3106,7 @@ describe('iframe using HTML fullscreen API while window is OS-fullscreened', () 
   });
 });
 
-ifdescribe(process.platform !== 'darwin' || process.arch !== 'arm64')('navigator.serial', () => {
+describe('navigator.serial', () => {
   let w: BrowserWindow;
   before(async () => {
     w = new BrowserWindow({
@@ -3130,6 +3130,7 @@ ifdescribe(process.platform !== 'darwin' || process.arch !== 'arm64')('navigator
   });
 
   it('does not return a port if select-serial-port event is not defined', async () => {
+    // Take screenshot to verify the test is running
     w.loadFile(path.join(fixturesPath, 'pages', 'blank.html'));
     const port = await getPorts();
     expect(port).to.equal(notFoundError);
@@ -3646,7 +3647,7 @@ ifdescribe((process.platform !== 'linux' || app.isUnityRunning()))('navigator.se
   });
 });
 
-ifdescribe(process.platform !== 'darwin' || process.arch !== 'arm64')('navigator.bluetooth', () => {
+describe('navigator.bluetooth', () => {
   let w: BrowserWindow;
   before(async () => {
     w = new BrowserWindow({


### PR DESCRIPTION
#### Description of Change
- This fixes the hang on device tests on macOS arm64 that was disabled in #47746.
- Additionally, this PR disables macOS's spotlight indexing which will free up some disk space and may help improve build performance.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
