### PR TITLE
refactor: prefer `GetCreationContextChecked(v8::Isolate*)` over `GetCreationContextChecked()`

### DIFF
--- a/shell/common/gin_helper/callback.h
+++ b/shell/common/gin_helper/callback.h
@@ -49,7 +49,7 @@ struct V8FunctionInvoker<v8::Local<v8::Value>(ArgTypes...)> {
     if (!function.IsAlive())
       return v8::Null(isolate);
     v8::Local<v8::Function> holder = function.NewHandle(isolate);
-    v8::Local<v8::Context> context = holder->GetCreationContextChecked();
+    v8::Local<v8::Context> context = holder->GetCreationContextChecked(isolate);
     v8::MicrotasksScope microtasks_scope(context,
                                          v8::MicrotasksScope::kRunMicrotasks);
     v8::Context::Scope context_scope(context);
@@ -74,7 +74,7 @@ struct V8FunctionInvoker<void(ArgTypes...)> {
     if (!function.IsAlive())
       return;
     v8::Local<v8::Function> holder = function.NewHandle(isolate);
-    v8::Local<v8::Context> context = holder->GetCreationContextChecked();
+    v8::Local<v8::Context> context = holder->GetCreationContextChecked(isolate);
     v8::MicrotasksScope microtasks_scope(context,
                                          v8::MicrotasksScope::kRunMicrotasks);
     v8::Context::Scope context_scope(context);
@@ -98,7 +98,7 @@ struct V8FunctionInvoker<ReturnType(ArgTypes...)> {
     if (!function.IsAlive())
       return ret;
     v8::Local<v8::Function> holder = function.NewHandle(isolate);
-    v8::Local<v8::Context> context = holder->GetCreationContextChecked();
+    v8::Local<v8::Context> context = holder->GetCreationContextChecked(isolate);
     v8::MicrotasksScope microtasks_scope(context,
                                          v8::MicrotasksScope::kRunMicrotasks);
     v8::Context::Scope context_scope(context);

--- a/shell/common/gin_helper/event_emitter_caller.cc
+++ b/shell/common/gin_helper/event_emitter_caller.cc
@@ -23,7 +23,7 @@ v8::Local<v8::Value> CallMethodWithArgs(
                                      node::async_context{0, 0}};
 
   // Perform microtask checkpoint after running JavaScript.
-  v8::MicrotasksScope microtasks_scope(obj->GetCreationContextChecked(),
+  v8::MicrotasksScope microtasks_scope(obj->GetCreationContextChecked(isolate),
                                        v8::MicrotasksScope::kRunMicrotasks);
 
   // node::MakeCallback will also run pending tasks in Node.js.

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -833,7 +833,8 @@ void OverrideGlobalValueFromIsolatedWorld(
 
   {
     v8::Context::Scope main_context_scope(main_context);
-    v8::Local<v8::Context> source_context = value->GetCreationContextChecked();
+    v8::Local<v8::Context> source_context =
+        value->GetCreationContextChecked(isolate);
     v8::MaybeLocal<v8::Value> maybe_proxy = PassValueToOtherContext(
         source_context, main_context, value, source_context->Global(),
         support_dynamic_properties, BridgeErrorTarget::kSource);

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -845,6 +845,7 @@ void OverrideGlobalValueFromIsolatedWorld(
 }
 
 bool OverrideGlobalPropertyFromIsolatedWorld(
+    v8::Isolate* const isolate,
     const std::vector<std::string>& key_path,
     v8::Local<v8::Object> getter,
     v8::Local<v8::Value> setter,
@@ -871,7 +872,7 @@ bool OverrideGlobalPropertyFromIsolatedWorld(
     v8::Local<v8::Value> setter_proxy;
     if (!getter->IsNullOrUndefined()) {
       v8::Local<v8::Context> source_context =
-          getter->GetCreationContextChecked();
+          getter->GetCreationContextChecked(isolate);
       v8::MaybeLocal<v8::Value> maybe_getter_proxy = PassValueToOtherContext(
           source_context, main_context, getter, source_context->Global(), false,
           BridgeErrorTarget::kSource);
@@ -880,7 +881,7 @@ bool OverrideGlobalPropertyFromIsolatedWorld(
     }
     if (!setter->IsNullOrUndefined() && setter->IsObject()) {
       v8::Local<v8::Context> source_context =
-          getter->GetCreationContextChecked();
+          getter->GetCreationContextChecked(isolate);
       v8::MaybeLocal<v8::Value> maybe_setter_proxy = PassValueToOtherContext(
           source_context, main_context, setter, source_context->Global(), false,
           BridgeErrorTarget::kSource);

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -38,7 +38,8 @@ BASE_FEATURE(kContextBridgeMutability,
 
 namespace electron {
 
-content::RenderFrame* GetRenderFrame(v8::Local<v8::Object> value);
+content::RenderFrame* GetRenderFrame(v8::Isolate* isolate,
+                                     v8::Local<v8::Object> value);
 
 namespace api {
 
@@ -760,7 +761,7 @@ v8::MaybeLocal<v8::Context> GetTargetContext(v8::Isolate* isolate,
   blink::ExecutionContext* execution_context =
       blink::ExecutionContext::From(source_context);
   if (execution_context->IsWindow()) {
-    auto* render_frame = GetRenderFrame(source_context->Global());
+    auto* render_frame = GetRenderFrame(isolate, source_context->Global());
     CHECK(render_frame);
     auto* frame = render_frame->GetWebFrame();
     CHECK(frame);
@@ -812,13 +813,14 @@ gin_helper::Dictionary TraceKeyPath(const gin_helper::Dictionary& start,
 }
 
 void OverrideGlobalValueFromIsolatedWorld(
+    v8::Isolate* isolate,
     const std::vector<std::string>& key_path,
     v8::Local<v8::Object> value,
     bool support_dynamic_properties) {
   if (key_path.empty())
     return;
 
-  auto* render_frame = GetRenderFrame(value);
+  auto* render_frame = GetRenderFrame(isolate, value);
   CHECK(render_frame);
   auto* frame = render_frame->GetWebFrame();
   CHECK(frame);
@@ -850,7 +852,7 @@ bool OverrideGlobalPropertyFromIsolatedWorld(
   if (key_path.empty())
     return false;
 
-  auto* render_frame = GetRenderFrame(getter);
+  auto* render_frame = GetRenderFrame(isolate, getter);
   CHECK(render_frame);
   auto* frame = render_frame->GetWebFrame();
   CHECK(frame);

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -497,7 +497,7 @@ void ProxyFunctionWrapper(const v8::FunctionCallbackInfo<v8::Value>& info) {
 
   v8::Local<v8::Function> func = func_value.As<v8::Function>();
   v8::Local<v8::Context> func_owning_context =
-      func->GetCreationContextChecked();
+      func->GetCreationContextChecked(args.isolate());
 
   {
     v8::Context::Scope func_owning_context_scope(func_owning_context);

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -201,7 +201,7 @@ class ScriptExecutionCallback {
         bool should_clone_value =
             !(value->IsObject() &&
               promise_.GetContext() ==
-                  value.As<v8::Object>()->GetCreationContextChecked()) &&
+                  value.As<v8::Object>()->GetCreationContextChecked(isolate)) &&
             value->IsObject();
         if (should_clone_value) {
           CopyResultToCallingContextAndFinalize(isolate,

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -90,8 +90,9 @@ struct Converter<blink::WebCssOrigin> {
 
 namespace electron {
 
-content::RenderFrame* GetRenderFrame(v8::Local<v8::Object> value) {
-  v8::Local<v8::Context> context = value->GetCreationContextChecked();
+content::RenderFrame* GetRenderFrame(v8::Isolate* const isolate,
+                                     v8::Local<v8::Object> value) {
+  v8::Local<v8::Context> context = value->GetCreationContextChecked(isolate);
   if (context.IsEmpty())
     return nullptr;
   blink::WebLocalFrame* frame = blink::WebLocalFrame::FrameForContext(context);
@@ -839,7 +840,8 @@ class WebFrameRenderer final
     // Get the WebLocalFrame before (possibly) executing any user-space JS while
     // getting the |params|. We track the status of the RenderFrame via an
     // observer in case it is deleted during user code execution.
-    content::RenderFrame* render_frame = GetRenderFrame(content_window);
+    content::RenderFrame* render_frame =
+        GetRenderFrame(isolate, content_window);
     if (!render_frame)
       return v8::Null(isolate);
 
@@ -965,8 +967,9 @@ void Initialize(v8::Local<v8::Object> exports,
 
   v8::Isolate* const isolate = v8::Isolate::GetCurrent();
   gin_helper::Dictionary dict{isolate, exports};
-  dict.Set("mainFrame", WebFrameRenderer::Create(
-                            isolate, electron::GetRenderFrame(exports)));
+  dict.Set("mainFrame",
+           WebFrameRenderer::Create(
+               isolate, electron::GetRenderFrame(isolate, exports)));
 }
 
 }  // namespace

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -146,7 +146,7 @@ class ScriptExecutionCallback {
   ScriptExecutionCallback& operator=(const ScriptExecutionCallback&) = delete;
 
   void CopyResultToCallingContextAndFinalize(
-      v8::Isolate* isolate,
+      v8::Isolate* const isolate,
       const v8::Local<v8::Object>& result) {
     v8::MaybeLocal<v8::Value> maybe_result;
     bool success = true;
@@ -155,7 +155,7 @@ class ScriptExecutionCallback {
     {
       v8::TryCatch try_catch(isolate);
       v8::Local<v8::Context> source_context =
-          result->GetCreationContextChecked();
+          result->GetCreationContextChecked(isolate);
       maybe_result = PassValueToOtherContext(
           source_context, promise_.GetContext(), result,
           source_context->Global(), false, BridgeErrorTarget::kSource);

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -102,7 +102,8 @@
 
 namespace electron {
 
-content::RenderFrame* GetRenderFrame(v8::Local<v8::Object> value);
+content::RenderFrame* GetRenderFrame(v8::Isolate* isolate,
+                                     v8::Local<v8::Object> value);
 
 namespace {
 
@@ -616,7 +617,7 @@ void RendererClientBase::AllowGuestViewElementDefinition(
   v8::Context::Scope context_scope(context->GetCreationContextChecked(isolate));
   blink::WebCustomElement::EmbedderNamesAllowedScope embedder_names_scope;
 
-  content::RenderFrame* render_frame = GetRenderFrame(context);
+  content::RenderFrame* render_frame = GetRenderFrame(isolate, context);
   if (!render_frame)
     return;
 

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -613,7 +613,7 @@ void RendererClientBase::AllowGuestViewElementDefinition(
     v8::Local<v8::Object> context,
     v8::Local<v8::Function> register_cb) {
   v8::HandleScope handle_scope(isolate);
-  v8::Context::Scope context_scope(context->GetCreationContextChecked());
+  v8::Context::Scope context_scope(context->GetCreationContextChecked(isolate));
   blink::WebCustomElement::EmbedderNamesAllowedScope embedder_names_scope;
 
   content::RenderFrame* render_frame = GetRenderFrame(context);
@@ -621,8 +621,8 @@ void RendererClientBase::AllowGuestViewElementDefinition(
     return;
 
   render_frame->GetWebFrame()->RequestExecuteV8Function(
-      context->GetCreationContextChecked(), register_cb, v8::Null(isolate), 0,
-      nullptr, base::NullCallback());
+      context->GetCreationContextChecked(isolate), register_cb,
+      v8::Null(isolate), 0, nullptr, base::NullCallback());
 }
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

The no-argument form of `GetCreationContextChecked()` was marked `DEPRECATE_SOON` in https://chromium-review.googlesource.com/c/v8/v8/+/5906106, so we should use the `GetCrreationContextChecked(v8::Isolate*)` variant instead.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.