### PR TITLE
build: roll build-images to 933c7d6

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   buildtools:
-    image: ghcr.io/electron/devcontainer:424eedbf277ad9749ffa9219068aa72ed4a5e373
+    image: ghcr.io/electron/devcontainer:933c7d6ff6802706875270bec2e3c891cf8add3f
 
     volumes:
       - ..:/workspaces/gclient/src/electron:cached

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       build-image-sha:
         type: string
         description: 'SHA for electron/build image'
-        default: '424eedbf277ad9749ffa9219068aa72ed4a5e373'
+        default: '933c7d6ff6802706875270bec2e3c891cf8add3f'
         required: true
       skip-macos:
         type: boolean
@@ -64,7 +64,7 @@ jobs:
       id: set-output
       run: |
         if [ -z "${{ inputs.build-image-sha }}" ]; then
-          echo "build-image-sha=424eedbf277ad9749ffa9219068aa72ed4a5e373" >> "$GITHUB_OUTPUT"
+          echo "build-image-sha=933c7d6ff6802706875270bec2e3c891cf8add3f" >> "$GITHUB_OUTPUT"
         else
           echo "build-image-sha=${{ inputs.build-image-sha }}" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/workflows/linux-publish.yml
+++ b/.github/workflows/linux-publish.yml
@@ -6,7 +6,7 @@ on:
       build-image-sha:
         type: string
         description: 'SHA for electron/build image'
-        default: '424eedbf277ad9749ffa9219068aa72ed4a5e373'
+        default: '933c7d6ff6802706875270bec2e3c891cf8add3f'
       upload-to-storage:
         description: 'Uploads to Azure storage'
         required: false

--- a/.github/workflows/macos-publish.yml
+++ b/.github/workflows/macos-publish.yml
@@ -6,7 +6,7 @@ on:
       build-image-sha:
         type: string
         description: 'SHA for electron/build image'
-        default: '424eedbf277ad9749ffa9219068aa72ed4a5e373'
+        default: '933c7d6ff6802706875270bec2e3c891cf8add3f'
         required: true
       upload-to-storage:
         description: 'Uploads to Azure storage'

--- a/.github/workflows/windows-publish.yml
+++ b/.github/workflows/windows-publish.yml
@@ -6,7 +6,7 @@ on:
       build-image-sha:
         type: string
         description: 'SHA for electron/build image'
-        default: '424eedbf277ad9749ffa9219068aa72ed4a5e373'
+        default: '933c7d6ff6802706875270bec2e3c891cf8add3f'
         required: true
       upload-to-storage:
         description: 'Uploads to Azure storage'


### PR DESCRIPTION
#### Description of Change

Roll build-images to pick up https://github.com/electron/build-images/pull/49

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none