### PR TITLE
fix: <webview> loses state on Element.moveBefore

### DIFF
--- a/lib/renderer/web-view/web-view-element.ts
+++ b/lib/renderer/web-view/web-view-element.ts
@@ -62,6 +62,8 @@ const defineWebViewElement = (hooks: WebViewImplHooks) => {
       }
     }
 
+    connectedMoveCallback () {} // Prevents disconnectedCallback() / connectedCallback() to run on DOM move.
+
     attributeChangedCallback (name: string, oldValue: any, newValue: any) {
       const internal = internals.get(this);
       if (internal) {

--- a/spec/fixtures/pages/webview-move.html
+++ b/spec/fixtures/pages/webview-move.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <webview src="./a.html"></webview>
+    <div id="move-target"></div>
+    <script>
+      var {ipcRenderer} = require('electron')
+      var wv = document.querySelector('webview')
+      var moveTarget = document.getElementById('move-target')
+
+      var moveCount = 0
+      moveElement = () => {
+        moveCount++
+        moveTarget.moveBefore(wv, null)
+        wv.removeEventListener('dom-ready', moveElement)
+      }
+      wv.addEventListener('dom-ready', moveElement)
+
+      var reloadCount = 0
+      wv.addEventListener('page-title-updated', () => {
+        reloadCount++
+      })
+
+      setTimeout(() => {
+        ipcRenderer.send('webview-reload-count', [moveCount, reloadCount])
+      }, 1000)
+    </script>
+  </body>
+</html>

--- a/spec/webview-spec.ts
+++ b/spec/webview-spec.ts
@@ -157,6 +157,23 @@ describe('<webview> tag', function () {
 
       expect(type).to.equal('undefined', 'WebView still exists');
     });
+
+    it('does not reload when moved', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          webviewTag: true,
+          nodeIntegration: true,
+          contextIsolation: false
+        }
+      });
+      const webviewReloadCount = once(ipcMain, 'webview-reload-count');
+      w.loadFile(path.join(fixtures, 'pages', 'webview-move.html'));
+
+      const [, [moveCount, reloadCount]] = await webviewReloadCount;
+      expect(moveCount).to.equal(1);
+      expect(reloadCount).to.equal(1);
+    });
   });
 
   // FIXME(deepak1556): Ch69 follow up.


### PR DESCRIPTION
#### Description of Change

Allow the `<webview>` custom element to maintain its state when it is moved around in the DOM via `Element.moveBefore`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: `<webview>` now maintain its state when moved around in the DOM via the `Element.moveBefore()` API.
