### PR TITLE
refactor: avoid deprecated `v8::Context::GetIsolate()` pt 4

### DIFF
--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -432,9 +432,12 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
     v8::Local<v8::Context> error_context =
         error_target == BridgeErrorTarget::kSource ? source_context
                                                    : destination_context;
-    v8::Context::Scope error_scope(error_context);
+    v8::Context::Scope error_scope{error_context};
     // V8 serializer will throw an error if required
-    if (!gin::ConvertFromV8(error_context->GetIsolate(), value, &ret)) {
+    v8::Isolate* const error_isolate =
+        error_target == BridgeErrorTarget::kSource ? source_isolate
+                                                   : destination_isolate;
+    if (!gin::ConvertFromV8(error_isolate, value, &ret)) {
       return {};
     }
   }


### PR DESCRIPTION
#### Description of Change

Fourth and final  PR in a [series](https://github.com/electron/electron/pull/47760) of PRs to reduce use of `v8::Context::GetIsolate()` since that method has been deprecated upstream.

This PR removes most of the instances used by the context bridge and its callers.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.