### PR TITLE
chore: Remove redundant IS_WIN check inside electron_main_win.cc

### DIFF
--- a/shell/app/electron_main_win.cc
+++ b/shell/app/electron_main_win.cc
@@ -214,10 +214,8 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
     return crashpad_status;
   }
 
-#if BUILDFLAG(IS_WIN)
   // access ui native theme here to prevent blocking calls later
   base::win::AllowDarkModeForApp(true);
-#endif
 
 #if defined(ARCH_CPU_32_BITS)
   // Intentionally crash if converting to a fiber failed.


### PR DESCRIPTION
#### Description of Change

This code snipped was moved from `shell/browser/electron_browser_main_parts.cc` to `shell/app/electron_main_win.cc` in #35529

When it lived in `electron_browser_main_parts.cc` the `IS_WIN` check made sense because that file used on all platforms. However, `electron_main_win.cc` is Windows specific, so the compiler directive is unnecessary.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none