### PR TITLE
fix: allow importing from electron/utility at runtime

### DIFF
--- a/lib/common/init.ts
+++ b/lib/common/init.ts
@@ -93,20 +93,23 @@ makeElectronModule('electron');
 makeElectronModule('electron/common');
 if (process.type === 'browser') {
   makeElectronModule('electron/main');
-}
-if (process.type === 'renderer') {
+} else if (process.type === 'renderer') {
   makeElectronModule('electron/renderer');
+} else if (process.type === 'utility') {
+  makeElectronModule('electron/utility');
 }
 
 const originalResolveFilename = Module._resolveFilename;
 
-// 'electron/main', 'electron/renderer' and 'electron/common' are module aliases
+// 'electron/{common,main,renderer,utility}' are module aliases
 // of the 'electron' module for TypeScript purposes, i.e., the types for
 // 'electron/main' consist of only main process modules, etc. It is intentional
 // that these can be `require()`-ed from both the main process as well as the
 // renderer process regardless of the names, they're superficial for TypeScript
 // only.
-const electronModuleNames = new Set(['electron', 'electron/main', 'electron/renderer', 'electron/common']);
+const electronModuleNames = new Set([
+  'electron', 'electron/main', 'electron/renderer', 'electron/common', 'electron/utility'
+]);
 Module._resolveFilename = function (request, parent, isMain, options) {
   if (electronModuleNames.has(request)) {
     return 'electron';

--- a/lib/utility/api/net.ts
+++ b/lib/utility/api/net.ts
@@ -1,8 +1,7 @@
 import { fetchWithSession } from '@electron/internal/browser/api/net-fetch';
 import { ClientRequest } from '@electron/internal/common/api/net-client-request';
 
-import { IncomingMessage } from 'electron/utility';
-import type { ClientRequestConstructorOptions } from 'electron/utility';
+import type { ClientRequestConstructorOptions, IncomingMessage } from 'electron/utility';
 
 const { isOnline, resolveHost } = process._linkedBinding('electron_common_net');
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Fixes importing from `electron/utility` since currently the following will be typed correctly, but throw a `ERR_MODULE_NOT_FOUND` error at runtime:

```js
const { net } = require('electron/utility');

net.request('https://electronjs.org')
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where importing  from `electron/utility` threw a `ERR_MODULE_NOT_FOUND` error at runtime <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
