### PR TITLE
fix: restore window's canHide property on macOS

### DIFF
--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -547,6 +547,9 @@ v8::Local<v8::Promise> Browser::DockShow(v8::Isolate* isolate) {
   gin_helper::Promise<void> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
+  for (auto* const& window : WindowList::GetWindows())
+    [window->GetNativeWindow().GetNativeNSWindow() setCanHide:YES];
+
   BOOL active = [[NSRunningApplication currentApplication] isActive];
   ProcessSerialNumber psn = {0, kCurrentProcess};
   if (active) {


### PR DESCRIPTION
#### Description of Change

If calling `app.dock?.hide()` and hiding the window, even if the window is restored, window can no longer be hided.
It due to API set canHide property while calling  `app.dock?.hide()`
https://github.com/electron/electron/blob/678fb400fdb465fbfccd77681f32728a5f86e9bd/shell/browser/browser_mac.mm#L531-L532

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: restored window's canHide property