### PR TITLE
feat(clipboard): support read/write files

### DIFF
--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -166,6 +166,38 @@ The cached value is reread from the find pasteboard whenever the application is 
 
 Writes the `text` into the find pasteboard (the pasteboard that holds information about the current state of the active application’s find panel) as plain text. This method uses synchronous IPC when called from the renderer process.
 
+### `clipboard.readFiles([type])`
+
+* `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+
+Returns `string[]` - An array of file paths from the clipboard.
+
+```js
+const { clipboard } = require('electron')
+
+clipboard.writeFiles(['path/to/file1.txt', 'path/to/file2.txt'])
+const files = clipboard.readFiles()
+
+console.log(files)
+// ['path/to/file1.txt', 'path/to/file2.txt']
+```
+
+### `clipboard.writeFiles(files)`
+
+* `files` string[] - An array of file paths to write to the clipboard.
+
+Writes the `files` into the clipboard as file paths.
+
+> [!NOTE]
+> Please make sure your app has permission to access `files`
+> otherwise, it will not be able to copy them to the clipboard. It will not crash, it will just ignore the files without access permission.
+
+```js
+const { clipboard } = require('electron')
+
+clipboard.writeFiles(['path/to/file1.txt', 'path/to/file2.txt'])
+```
+
 ### `clipboard.clear([type])`
 
 * `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
@@ -252,6 +284,7 @@ clipboard.writeBuffer('public/utf8-plain-text', buffer)
   * `image` [NativeImage](native-image.md) (optional)
   * `rtf` string (optional)
   * `bookmark` string (optional) - The title of the URL at `text`.
+  * `files` string[] (optional)
 * `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Writes `data` to the clipboard.
@@ -263,7 +296,8 @@ clipboard.write({
   text: 'test',
   html: '<b>Hi</b>',
   rtf: '{\\rtf1\\utf8 text}',
-  bookmark: 'a title'
+  bookmark: 'a title',
+  files: ['path/to/file1.txt', 'path/to/file2.txt']
 })
 
 console.log(clipboard.readText())
@@ -277,4 +311,7 @@ console.log(clipboard.readRTF())
 
 console.log(clipboard.readBookmark())
 // { title: 'a title', url: 'test' }
+
+console.log(clipboard.readFiles())
+// ['path/to/file1.txt', 'path/to/file2.txt']
 ```

--- a/shell/common/api/electron_api_clipboard.h
+++ b/shell/common/api/electron_api_clipboard.h
@@ -68,7 +68,8 @@ class Clipboard {
                           const v8::Local<v8::Value> buffer,
                           gin_helper::Arguments* args);
 
-  static void WriteFilesForTesting(const std::vector<base::FilePath>& files);
+  static std::vector<std::string> ReadFiles(gin_helper::Arguments* args);
+  static void WriteFiles(const std::vector<base::FilePath>& files);
 };
 
 }  // namespace electron::api

--- a/spec/api-clipboard-spec.ts
+++ b/spec/api-clipboard-spec.ts
@@ -105,7 +105,8 @@ ifdescribe(process.platform !== 'win32' || process.arch !== 'arm64')('clipboard 
         html: '<b>Hi</b>',
         rtf: '{\\rtf1\\utf8 text}',
         bookmark: 'a title',
-        image: i
+        image: i,
+        files: [p]
       });
 
       expect(clipboard.readText()).to.equal(text);
@@ -113,6 +114,7 @@ ifdescribe(process.platform !== 'win32' || process.arch !== 'arm64')('clipboard 
       expect(clipboard.readRTF()).to.equal(rtf);
       const readImage = clipboard.readImage();
       expect(readImage.toDataURL()).to.equal(i.toDataURL());
+      expect(clipboard.readFiles()).to.deep.equal([p]);
 
       if (process.platform !== 'linux') {
         if (process.platform !== 'win32') {
@@ -153,6 +155,22 @@ ifdescribe(process.platform !== 'win32' || process.arch !== 'arm64')('clipboard 
       }
       clipboard.writeBuffer(rawFormat, buffer);
       expect(clipboard.readText()).to.equal(message);
+    });
+  });
+
+  describe('clipboard.readFiles()', () => {
+    it('returns data correctly', () => {
+      const file1 = path.join(fixtures, 'assets', 'logo.png');
+      const file2 = path.join(fixtures, 'assets', 'icon.png');
+      clipboard.writeFiles([file1, file2]);
+      const files = clipboard.readFiles();
+      expect(files).to.have.lengthOf(2);
+      expect(files).to.deep.equal([file1, file2]);
+    });
+
+    it('works for empty files', () => {
+      clipboard.writeText('overwrite');
+      expect(clipboard.readFiles()).to.have.lengthOf(0);
     });
   });
 });

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -1016,8 +1016,7 @@ describe('chromium features', () => {
       w.loadFile(writablePath);
 
       w.webContents.once('did-finish-load', () => {
-        // @ts-expect-error Undocumented testing method.
-        clipboard._writeFilesForTesting([testFile]);
+        clipboard.writeFiles([testFile]);
         w.webContents.paste();
       });
     });


### PR DESCRIPTION
#### Description of Change

Chromium implemented the ability to copy files to the clipboard and read file paths from the clipboard in 2021. See: https://chromium-review.googlesource.com/c/chromium/src/+/2651770.
In #41419, @codebytere has already implemented a partial API (WriteFilesForTesting).
In the current PR, I renamed the previous `WriteFilesForTesting` to `WriteFiles` and added a `ReadFiles` method to match it. Additionally, I improved the Write method, and now `clipboard.write` also supports the `files` parameter.

fix: #9035 #26377

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Supports copying files to the clipboard and reading the file paths from the clipboard.
