### PR TITLE
chore: move gin::DeprecatedWrappable to gin_helper

### DIFF
--- a/patches/chromium/feat_add_signals_when_embedder_cleanup_callbacks_run_for.patch
+++ b/patches/chromium/feat_add_signals_when_embedder_cleanup_callbacks_run_for.patch
@@ -10,19 +10,10 @@ shutdown leading to UAF in the second pass.
 
 Details at  https://github.com/microsoft/vscode/issues/192119#issuecomment-2375851531
 
-The signals exposed in this patch does the following 2 things,
-
-1) Fix weak state of the wrapped object when the finializer callbacks
-   have not yet been processed
-2) Avoid calling into the second pass when the embedder has already
-  destroyed the wrapped object via CleanedUpAtExit.
-
 This patch is more of a bandaid fix to improve the lifetime
 management with existing finalizer callbacks. We should be able to
 remove this patch once gin::Wrappable can be managed by V8 Oilpan
-
-Refs https://issues.chromium.org/issues/40210365 which is blocked
-on https://issues.chromium.org/issues/42203693
+via https://github.com/electron/electron/issues/47922
 
 diff --git a/gin/isolate_holder.cc b/gin/isolate_holder.cc
 index 5255c1094c88761c19af1ea294ceccaca63b5ae4..bb1639d73070a99984b72eb61afd001dec5b08ff 100644
@@ -87,78 +78,3 @@ index dc3a5b0678b9c686e241b492e2c3b5ac833611a3..32a7ba4f557e65d9525d2ca07e8597e7
    // This method returns V8IsolateMemoryDumpProvider of this isolate, used for
    // testing.
    V8IsolateMemoryDumpProvider* isolate_memory_dump_provider_for_testing()
-diff --git a/gin/wrappable.cc b/gin/wrappable.cc
-index 81ae860e73cee80e51c4ab3f2f24d44a52d30824..7474c7250c81975f25fea194cd816453a092f1cd 100644
---- a/gin/wrappable.cc
-+++ b/gin/wrappable.cc
-@@ -75,6 +75,8 @@ void WrappableBase::SetWrapper(v8::Isolate* isolate,
- DeprecatedWrappableBase::DeprecatedWrappableBase() = default;
- 
- DeprecatedWrappableBase::~DeprecatedWrappableBase() {
-+  if (!wrapper_.IsEmpty())
-+    wrapper_.ClearWeak();
-   wrapper_.Reset();
- }
- 
-@@ -90,15 +92,22 @@ const char* DeprecatedWrappableBase::GetTypeName() {
- void DeprecatedWrappableBase::FirstWeakCallback(
-     const v8::WeakCallbackInfo<DeprecatedWrappableBase>& data) {
-   DeprecatedWrappableBase* wrappable = data.GetParameter();
--  wrappable->dead_ = true;
--  wrappable->wrapper_.Reset();
--  data.SetSecondPassCallback(SecondWeakCallback);
-+  DeprecatedWrappableBase* wrappable_from_field =
-+      static_cast<DeprecatedWrappableBase*>(data.GetInternalField(1));
-+  if (wrappable && wrappable == wrappable_from_field) {
-+    wrappable->dead_ = true;
-+    wrappable->wrapper_.Reset();
-+    data.SetSecondPassCallback(SecondWeakCallback);
-+  }
- }
- 
- void DeprecatedWrappableBase::SecondWeakCallback(
-     const v8::WeakCallbackInfo<DeprecatedWrappableBase>& data) {
-+  if (IsolateHolder::DestroyedMicrotasksRunner())
-+    return;
-   DeprecatedWrappableBase* wrappable = data.GetParameter();
--  delete wrappable;
-+  if (wrappable)
-+    delete wrappable;
- }
- 
- v8::MaybeLocal<v8::Object> DeprecatedWrappableBase::GetWrapperImpl(
-@@ -135,10 +144,15 @@ v8::MaybeLocal<v8::Object> DeprecatedWrappableBase::GetWrapperImpl(
-   void* values[] = {info, this};
-   wrapper->SetAlignedPointerInInternalFields(2, indices, values);
-   wrapper_.Reset(isolate, wrapper);
--  wrapper_.SetWeak(this, FirstWeakCallback, v8::WeakCallbackType::kParameter);
-+  wrapper_.SetWeak(this, FirstWeakCallback, v8::WeakCallbackType::kInternalFields);
-   return v8::MaybeLocal<v8::Object>(wrapper);
- }
- 
-+void DeprecatedWrappableBase::ClearWeak() {
-+  if (!wrapper_.IsEmpty())
-+    wrapper_.ClearWeak();
-+}
-+
- namespace internal {
- 
- void* FromV8Impl(v8::Isolate* isolate,
-diff --git a/gin/wrappable.h b/gin/wrappable.h
-index 2ed30ffbcded21e25c60b142a3c054fbad1053f4..15aa2afce12eda87e015a7acf05fc588594816c0 100644
---- a/gin/wrappable.h
-+++ b/gin/wrappable.h
-@@ -175,6 +175,13 @@ class GIN_EXPORT DeprecatedWrappableBase {
-       v8::Isolate* isolate,
-       DeprecatedWrapperInfo* wrapper_info);
- 
-+  // Make this wrappable strong again. This is useful when the wrappable is
-+  // destroyed outside the finalizer callbacks and we want to avoid scheduling
-+  // the weak callbacks if they haven't been scheduled yet.
-+  // NOTE!!! this does not prevent finalization callbacks from running if they
-+  // have already been processed.
-+  void ClearWeak();
-+
-  private:
-   static void FirstWeakCallback(
-       const v8::WeakCallbackInfo<DeprecatedWrappableBase>& data);

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -27,6 +27,7 @@
 #include "shell/browser/browser_observer.h"
 #include "shell/browser/electron_browser_client.h"
 #include "shell/browser/event_emitter_mixin.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 #if BUILDFLAG(USE_NSS_CERTS)
 #include "shell/browser/certificate_manager_model.h"
@@ -57,7 +58,7 @@ enum class JumpListResult : int;
 namespace api {
 
 class App final : public ElectronBrowserClient::Delegate,
-                  public gin::DeprecatedWrappable<App>,
+                  public gin_helper::DeprecatedWrappable<App>,
                   public gin_helper::EventEmitterMixin<App>,
                   private BrowserObserver,
                   private content::GpuDataManagerObserver,
@@ -66,7 +67,7 @@ class App final : public ElectronBrowserClient::Delegate,
   static gin::Handle<App> Create(v8::Isolate* isolate);
   static App* Get();
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/electron_api_auto_updater.h
+++ b/shell/browser/api/electron_api_auto_updater.h
@@ -7,10 +7,10 @@
 
 #include <string>
 
-#include "gin/wrappable.h"
 #include "shell/browser/auto_updater.h"
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/browser/window_list_observer.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 namespace gin {
 template <typename T>
@@ -19,14 +19,14 @@ class Handle;
 
 namespace electron::api {
 
-class AutoUpdater final : public gin::DeprecatedWrappable<AutoUpdater>,
+class AutoUpdater final : public gin_helper::DeprecatedWrappable<AutoUpdater>,
                           public gin_helper::EventEmitterMixin<AutoUpdater>,
                           public auto_updater::Delegate,
                           private WindowListObserver {
  public:
   static gin::Handle<AutoUpdater> Create(v8::Isolate* isolate);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/electron_api_cookies.h
+++ b/shell/browser/api/electron_api_cookies.h
@@ -11,6 +11,7 @@
 #include "base/memory/raw_ptr.h"
 #include "base/values.h"
 #include "shell/browser/event_emitter_mixin.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 class GURL;
 
@@ -33,13 +34,13 @@ class ElectronBrowserContext;
 
 namespace api {
 
-class Cookies final : public gin::DeprecatedWrappable<Cookies>,
+class Cookies final : public gin_helper::DeprecatedWrappable<Cookies>,
                       public gin_helper::EventEmitterMixin<Cookies> {
  public:
   static gin::Handle<Cookies> Create(v8::Isolate* isolate,
                                      ElectronBrowserContext* browser_context);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/electron_api_data_pipe_holder.h
+++ b/shell/browser/api/electron_api_data_pipe_holder.h
@@ -7,10 +7,10 @@
 
 #include <string>
 
-#include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/network/public/cpp/data_element.h"
 #include "services/network/public/mojom/data_pipe_getter.mojom.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 namespace gin {
 template <typename T>
@@ -20,9 +20,10 @@ class Handle;
 namespace electron::api {
 
 // Retains reference to the data pipe.
-class DataPipeHolder final : public gin::DeprecatedWrappable<DataPipeHolder> {
+class DataPipeHolder final
+    : public gin_helper::DeprecatedWrappable<DataPipeHolder> {
  public:
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   const char* GetTypeName() override;
 

--- a/shell/browser/api/electron_api_debugger.h
+++ b/shell/browser/api/electron_api_debugger.h
@@ -11,8 +11,8 @@
 #include "base/values.h"
 #include "content/public/browser/devtools_agent_host_client.h"
 #include "content/public/browser/web_contents_observer.h"
-#include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 namespace content {
 class DevToolsAgentHost;
@@ -32,7 +32,7 @@ class Promise;
 
 namespace electron::api {
 
-class Debugger final : public gin::DeprecatedWrappable<Debugger>,
+class Debugger final : public gin_helper::DeprecatedWrappable<Debugger>,
                        public gin_helper::EventEmitterMixin<Debugger>,
                        public content::DevToolsAgentHostClient,
                        private content::WebContentsObserver {
@@ -40,7 +40,7 @@ class Debugger final : public gin::DeprecatedWrappable<Debugger>,
   static gin::Handle<Debugger> Create(v8::Isolate* isolate,
                                       content::WebContents* web_contents);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -522,8 +522,8 @@ bool DesktopCapturer::IsDisplayMediaSystemPickerAvailable() {
 
 gin::ObjectTemplateBuilder DesktopCapturer::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
-  return gin::DeprecatedWrappable<DesktopCapturer>::GetObjectTemplateBuilder(
-             isolate)
+  return gin_helper::DeprecatedWrappable<
+             DesktopCapturer>::GetObjectTemplateBuilder(isolate)
       .SetMethod("startHandling", &DesktopCapturer::StartHandling);
 }
 

--- a/shell/browser/api/electron_api_desktop_capturer.h
+++ b/shell/browser/api/electron_api_desktop_capturer.h
@@ -11,8 +11,8 @@
 
 #include "chrome/browser/media/webrtc/desktop_media_list_observer.h"
 #include "chrome/browser/media/webrtc/native_desktop_media_list.h"
-#include "gin/wrappable.h"
 #include "shell/common/gin_helper/pinnable.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 namespace gin {
 template <typename T>
@@ -21,9 +21,10 @@ class Handle;
 
 namespace electron::api {
 
-class DesktopCapturer final : public gin::DeprecatedWrappable<DesktopCapturer>,
-                              public gin_helper::Pinnable<DesktopCapturer>,
-                              private DesktopMediaListObserver {
+class DesktopCapturer final
+    : public gin_helper::DeprecatedWrappable<DesktopCapturer>,
+      public gin_helper::Pinnable<DesktopCapturer>,
+      private DesktopMediaListObserver {
  public:
   struct Source {
     DesktopMediaList::Source media_list_source;
@@ -43,7 +44,7 @@ class DesktopCapturer final : public gin::DeprecatedWrappable<DesktopCapturer>,
                      const gfx::Size& thumbnail_size,
                      bool fetch_window_icons);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/electron_api_download_item.h
+++ b/shell/browser/api/electron_api_download_item.h
@@ -11,10 +11,10 @@
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "components/download/public/common/download_item.h"
-#include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/browser/ui/file_dialog.h"
 #include "shell/common/gin_helper/pinnable.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 class GURL;
 
@@ -25,7 +25,7 @@ class Handle;
 
 namespace electron::api {
 
-class DownloadItem final : public gin::DeprecatedWrappable<DownloadItem>,
+class DownloadItem final : public gin_helper::DeprecatedWrappable<DownloadItem>,
                            public gin_helper::Pinnable<DownloadItem>,
                            public gin_helper::EventEmitterMixin<DownloadItem>,
                            private download::DownloadItem::Observer {
@@ -35,7 +35,7 @@ class DownloadItem final : public gin::DeprecatedWrappable<DownloadItem>,
 
   static DownloadItem* FromDownloadItem(download::DownloadItem* item);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/electron_api_extensions.h
+++ b/shell/browser/api/electron_api_extensions.h
@@ -8,8 +8,8 @@
 #include "base/memory/raw_ptr.h"
 #include "extensions/browser/extension_registry.h"
 #include "extensions/browser/extension_registry_observer.h"
-#include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 namespace gin {
 template <typename T>
@@ -22,7 +22,7 @@ class ElectronBrowserContext;
 
 namespace api {
 
-class Extensions final : public gin::DeprecatedWrappable<Extensions>,
+class Extensions final : public gin_helper::DeprecatedWrappable<Extensions>,
                          public gin_helper::EventEmitterMixin<Extensions>,
                          private extensions::ExtensionRegistryObserver {
  public:
@@ -30,7 +30,7 @@ class Extensions final : public gin::DeprecatedWrappable<Extensions>,
       v8::Isolate* isolate,
       ElectronBrowserContext* browser_context);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -226,8 +226,8 @@ gin::Handle<GlobalShortcut> GlobalShortcut::Create(v8::Isolate* isolate) {
 // static
 gin::ObjectTemplateBuilder GlobalShortcut::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
-  return gin::DeprecatedWrappable<GlobalShortcut>::GetObjectTemplateBuilder(
-             isolate)
+  return gin_helper::DeprecatedWrappable<
+             GlobalShortcut>::GetObjectTemplateBuilder(isolate)
       .SetMethod("registerAll", &GlobalShortcut::RegisterAll)
       .SetMethod("register", &GlobalShortcut::Register)
       .SetMethod("isRegistered", &GlobalShortcut::IsRegistered)

--- a/shell/browser/api/electron_api_global_shortcut.h
+++ b/shell/browser/api/electron_api_global_shortcut.h
@@ -10,7 +10,7 @@
 
 #include "base/functional/callback_forward.h"
 #include "extensions/common/extension_id.h"
-#include "gin/wrappable.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "ui/base/accelerators/accelerator.h"
 #include "ui/base/accelerators/global_accelerator_listener/global_accelerator_listener.h"
 
@@ -21,12 +21,13 @@ class Handle;
 
 namespace electron::api {
 
-class GlobalShortcut final : private ui::GlobalAcceleratorListener::Observer,
-                             public gin::DeprecatedWrappable<GlobalShortcut> {
+class GlobalShortcut final
+    : private ui::GlobalAcceleratorListener::Observer,
+      public gin_helper::DeprecatedWrappable<GlobalShortcut> {
  public:
   static gin::Handle<GlobalShortcut> Create(v8::Isolate* isolate);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/electron_api_in_app_purchase.h
+++ b/shell/browser/api/electron_api_in_app_purchase.h
@@ -8,11 +8,11 @@
 #include <string>
 #include <vector>
 
-#include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/browser/mac/in_app_purchase.h"
 #include "shell/browser/mac/in_app_purchase_observer.h"
 #include "shell/browser/mac/in_app_purchase_product.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "v8/include/v8-forward.h"
 
 namespace gin {
@@ -22,13 +22,14 @@ class Handle;
 
 namespace electron::api {
 
-class InAppPurchase final : public gin::DeprecatedWrappable<InAppPurchase>,
-                            public gin_helper::EventEmitterMixin<InAppPurchase>,
-                            private in_app_purchase::TransactionObserver {
+class InAppPurchase final
+    : public gin_helper::DeprecatedWrappable<InAppPurchase>,
+      public gin_helper::EventEmitterMixin<InAppPurchase>,
+      private in_app_purchase::TransactionObserver {
  public:
   static gin::Handle<InAppPurchase> Create(v8::Isolate* isolate);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -13,6 +13,7 @@
 #include "shell/browser/ui/electron_menu_model.h"
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/pinnable.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "ui/base/mojom/menu_source_type.mojom-forward.h"
 
 namespace gin {
@@ -24,7 +25,7 @@ namespace electron::api {
 class BaseWindow;
 class WebFrameMain;
 
-class Menu : public gin::DeprecatedWrappable<Menu>,
+class Menu : public gin_helper::DeprecatedWrappable<Menu>,
              public gin_helper::EventEmitterMixin<Menu>,
              public gin_helper::Constructible<Menu>,
              public gin_helper::Pinnable<Menu>,
@@ -36,7 +37,7 @@ class Menu : public gin::DeprecatedWrappable<Menu>,
   static void FillObjectTemplate(v8::Isolate*, v8::Local<v8::ObjectTemplate>);
   static const char* GetClassName() { return "Menu"; }
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   const char* GetTypeName() override;
 

--- a/shell/browser/api/electron_api_native_theme.h
+++ b/shell/browser/api/electron_api_native_theme.h
@@ -6,8 +6,8 @@
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_NATIVE_THEME_H_
 
 #include "base/memory/raw_ptr.h"
-#include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "ui/native_theme/native_theme.h"
 #include "ui/native_theme/native_theme_observer.h"
 
@@ -18,13 +18,13 @@ class handle;
 
 namespace electron::api {
 
-class NativeTheme final : public gin::DeprecatedWrappable<NativeTheme>,
+class NativeTheme final : public gin_helper::DeprecatedWrappable<NativeTheme>,
                           public gin_helper::EventEmitterMixin<NativeTheme>,
                           private ui::NativeThemeObserver {
  public:
   static gin::Handle<NativeTheme> Create(v8::Isolate* isolate);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/electron_api_net_log.cc
+++ b/shell/browser/api/electron_api_net_log.cc
@@ -219,7 +219,8 @@ v8::Local<v8::Promise> NetLog::StopLogging(gin::Arguments* args) {
 
 gin::ObjectTemplateBuilder NetLog::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
-  return gin::DeprecatedWrappable<NetLog>::GetObjectTemplateBuilder(isolate)
+  return gin_helper::DeprecatedWrappable<NetLog>::GetObjectTemplateBuilder(
+             isolate)
       .SetProperty("currentlyLogging", &NetLog::IsCurrentlyLogging)
       .SetMethod("startLogging", &NetLog::StartLogging)
       .SetMethod("stopLogging", &NetLog::StopLogging);

--- a/shell/browser/api/electron_api_net_log.h
+++ b/shell/browser/api/electron_api_net_log.h
@@ -10,11 +10,11 @@
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/values.h"
-#include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "net/log/net_log_capture_mode.h"
 #include "services/network/public/mojom/net_log.mojom.h"
 #include "shell/common/gin_helper/promise.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 namespace base {
 class FilePath;
@@ -35,7 +35,7 @@ class ElectronBrowserContext;
 namespace api {
 
 // The code is referenced from the net_log::NetExportFileWriter class.
-class NetLog final : public gin::DeprecatedWrappable<NetLog> {
+class NetLog final : public gin_helper::DeprecatedWrappable<NetLog> {
  public:
   static gin::Handle<NetLog> Create(v8::Isolate* isolate,
                                     ElectronBrowserContext* browser_context);
@@ -45,7 +45,7 @@ class NetLog final : public gin::DeprecatedWrappable<NetLog> {
   v8::Local<v8::Promise> StopLogging(gin::Arguments* args);
   bool IsCurrentlyLogging() const;
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -9,13 +9,13 @@
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
-#include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/browser/notifications/notification.h"
 #include "shell/browser/notifications/notification_delegate.h"
 #include "shell/browser/notifications/notification_presenter.h"
 #include "shell/common/gin_helper/cleaned_up_at_exit.h"
 #include "shell/common/gin_helper/constructible.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "ui/gfx/image/image.h"
 
 namespace gin {
@@ -30,7 +30,7 @@ class ErrorThrower;
 
 namespace electron::api {
 
-class Notification final : public gin::DeprecatedWrappable<Notification>,
+class Notification final : public gin_helper::DeprecatedWrappable<Notification>,
                            public gin_helper::EventEmitterMixin<Notification>,
                            public gin_helper::Constructible<Notification>,
                            public gin_helper::CleanedUpAtExit,
@@ -53,7 +53,7 @@ class Notification final : public gin::DeprecatedWrappable<Notification>,
   void NotificationClosed() override;
   void NotificationFailed(const std::string& error) override;
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   const char* GetTypeName() override;
 

--- a/shell/browser/api/electron_api_power_monitor.h
+++ b/shell/browser/api/electron_api_power_monitor.h
@@ -6,9 +6,9 @@
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_POWER_MONITOR_H_
 
 #include "base/power_monitor/power_observer.h"
-#include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/common/gin_helper/pinnable.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "ui/base/idle/idle.h"
 
 #if BUILDFLAG(IS_LINUX)
@@ -17,7 +17,7 @@
 
 namespace electron::api {
 
-class PowerMonitor final : public gin::DeprecatedWrappable<PowerMonitor>,
+class PowerMonitor final : public gin_helper::DeprecatedWrappable<PowerMonitor>,
                            public gin_helper::EventEmitterMixin<PowerMonitor>,
                            public gin_helper::Pinnable<PowerMonitor>,
                            private base::PowerStateObserver,
@@ -26,7 +26,7 @@ class PowerMonitor final : public gin::DeprecatedWrappable<PowerMonitor>,
  public:
   static v8::Local<v8::Value> Create(v8::Isolate* isolate);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/electron_api_power_save_blocker.cc
+++ b/shell/browser/api/electron_api_power_save_blocker.cc
@@ -121,8 +121,8 @@ gin::Handle<PowerSaveBlocker> PowerSaveBlocker::Create(v8::Isolate* isolate) {
 
 gin::ObjectTemplateBuilder PowerSaveBlocker::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
-  return gin::DeprecatedWrappable<PowerSaveBlocker>::GetObjectTemplateBuilder(
-             isolate)
+  return gin_helper::DeprecatedWrappable<
+             PowerSaveBlocker>::GetObjectTemplateBuilder(isolate)
       .SetMethod("start", &PowerSaveBlocker::Start)
       .SetMethod("stop", &PowerSaveBlocker::Stop)
       .SetMethod("isStarted", &PowerSaveBlocker::IsStarted);

--- a/shell/browser/api/electron_api_power_save_blocker.h
+++ b/shell/browser/api/electron_api_power_save_blocker.h
@@ -6,9 +6,9 @@
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_POWER_SAVE_BLOCKER_H_
 
 #include "base/containers/flat_map.h"
-#include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/device/public/mojom/wake_lock.mojom.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 namespace gin {
 class ObjectTemplateBuilder;
@@ -20,11 +20,11 @@ class Handle;
 namespace electron::api {
 
 class PowerSaveBlocker final
-    : public gin::DeprecatedWrappable<PowerSaveBlocker> {
+    : public gin_helper::DeprecatedWrappable<PowerSaveBlocker> {
  public:
   static gin::Handle<PowerSaveBlocker> Create(v8::Isolate* isolate);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/electron_api_protocol.h
+++ b/shell/browser/api/electron_api_protocol.h
@@ -10,9 +10,9 @@
 
 #include "base/memory/raw_ptr.h"
 #include "content/public/browser/content_browser_client.h"
-#include "gin/wrappable.h"
 #include "shell/browser/net/electron_url_loader_factory.h"
 #include "shell/common/gin_helper/constructible.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 namespace gin {
 class Arguments;
@@ -35,7 +35,7 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
                                  v8::Local<v8::Value> val);
 
 // Protocol implementation based on network services.
-class Protocol final : public gin::DeprecatedWrappable<Protocol>,
+class Protocol final : public gin_helper::DeprecatedWrappable<Protocol>,
                        public gin_helper::Constructible<Protocol> {
  public:
   static gin::Handle<Protocol> Create(v8::Isolate* isolate,
@@ -48,7 +48,7 @@ class Protocol final : public gin::DeprecatedWrappable<Protocol>,
       v8::Local<v8::ObjectTemplate> tmpl);
   static const char* GetClassName() { return "Protocol"; }
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   const char* GetTypeName() override;
 

--- a/shell/browser/api/electron_api_push_notifications.h
+++ b/shell/browser/api/electron_api_push_notifications.h
@@ -6,13 +6,13 @@
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_PUSH_NOTIFICATIONS_H_
 
 #include <string>
-
 #include <vector>
-#include "gin/wrappable.h"
+
 #include "shell/browser/browser_observer.h"
 #include "shell/browser/electron_browser_client.h"
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/common/gin_helper/promise.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 namespace gin {
 template <typename T>
@@ -23,14 +23,14 @@ namespace electron::api {
 
 class PushNotifications final
     : public ElectronBrowserClient::Delegate,
-      public gin::DeprecatedWrappable<PushNotifications>,
+      public gin_helper::DeprecatedWrappable<PushNotifications>,
       public gin_helper::EventEmitterMixin<PushNotifications>,
       private BrowserObserver {
  public:
   static PushNotifications* Get();
   static gin::Handle<PushNotifications> Create(v8::Isolate* isolate);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/electron_api_screen.h
+++ b/shell/browser/api/electron_api_screen.h
@@ -8,8 +8,8 @@
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
-#include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "ui/display/display_observer.h"
 #include "ui/display/screen.h"
 
@@ -26,7 +26,7 @@ class ErrorThrower;
 
 namespace electron::api {
 
-class Screen final : public gin::DeprecatedWrappable<Screen>,
+class Screen final : public gin_helper::DeprecatedWrappable<Screen>,
                      public gin_helper::EventEmitterMixin<Screen>,
                      private display::DisplayObserver {
  public:

--- a/shell/browser/api/electron_api_service_worker_context.h
+++ b/shell/browser/api/electron_api_service_worker_context.h
@@ -8,8 +8,8 @@
 #include "base/memory/raw_ptr.h"
 #include "content/public/browser/service_worker_context.h"
 #include "content/public/browser/service_worker_context_observer.h"
-#include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "third_party/blink/public/common/service_worker/embedded_worker_status.h"
 
 namespace content {
@@ -35,7 +35,7 @@ namespace api {
 class ServiceWorkerMain;
 
 class ServiceWorkerContext final
-    : public gin::DeprecatedWrappable<ServiceWorkerContext>,
+    : public gin_helper::DeprecatedWrappable<ServiceWorkerContext>,
       public gin_helper::EventEmitterMixin<ServiceWorkerContext>,
       private content::ServiceWorkerContextObserver {
  public:
@@ -79,7 +79,7 @@ class ServiceWorkerContext final
   void OnVersionRedundant(int64_t version_id, const GURL& scope) override;
   void OnDestruct(content::ServiceWorkerContext* context) override;
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/electron_api_service_worker_main.h
+++ b/shell/browser/api/electron_api_service_worker_main.h
@@ -12,7 +12,6 @@
 #include "content/public/browser/global_routing_id.h"
 #include "content/public/browser/service_worker_context.h"
 #include "content/public/browser/service_worker_version_base_info.h"
-#include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/associated_receiver.h"
 #include "mojo/public/cpp/bindings/associated_remote.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
@@ -21,6 +20,7 @@
 #include "shell/common/api/api.mojom.h"
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/pinnable.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "third_party/blink/public/common/service_worker/embedded_worker_status.h"
 
 class GURL;
@@ -79,7 +79,7 @@ struct ServiceWorkerKey {
 // StoragePartition in which they're registered. In Electron, this is always
 // the default StoragePartition for the associated BrowserContext.
 class ServiceWorkerMain final
-    : public gin::DeprecatedWrappable<ServiceWorkerMain>,
+    : public gin_helper::DeprecatedWrappable<ServiceWorkerMain>,
       public gin_helper::EventEmitterMixin<ServiceWorkerMain>,
       public gin_helper::Pinnable<ServiceWorkerMain>,
       public gin_helper::Constructible<ServiceWorkerMain> {
@@ -100,7 +100,7 @@ class ServiceWorkerMain final
   static void FillObjectTemplate(v8::Isolate*, v8::Local<v8::ObjectTemplate>);
   static const char* GetClassName() { return "ServiceWorkerMain"; }
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   const char* GetTypeName() override;
 

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -15,7 +15,6 @@
 #include "base/values.h"
 #include "content/public/browser/download_manager.h"
 #include "electron/buildflags/buildflags.h"
-#include "gin/wrappable.h"
 #include "services/network/public/mojom/host_resolver.mojom-forward.h"
 #include "services/network/public/mojom/ssl_config.mojom-forward.h"
 #include "shell/browser/api/ipc_dispatcher.h"
@@ -24,6 +23,7 @@
 #include "shell/common/gin_helper/cleaned_up_at_exit.h"
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/pinnable.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 #include "chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h"  // nogncheck
@@ -57,7 +57,7 @@ struct PreloadScript;
 
 namespace api {
 
-class Session final : public gin::DeprecatedWrappable<Session>,
+class Session final : public gin_helper::DeprecatedWrappable<Session>,
                       public gin_helper::Pinnable<Session>,
                       public gin_helper::Constructible<Session>,
                       public gin_helper::EventEmitterMixin<Session>,
@@ -91,7 +91,7 @@ class Session final : public gin::DeprecatedWrappable<Session>,
     return &browser_context_.get();
   }
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   static void FillObjectTemplate(v8::Isolate*, v8::Local<v8::ObjectTemplate>);
   static const char* GetClassName() { return "Session"; }

--- a/shell/browser/api/electron_api_system_preferences.h
+++ b/shell/browser/api/electron_api_system_preferences.h
@@ -9,8 +9,8 @@
 #include <string>
 
 #include "base/values.h"
-#include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 #if BUILDFLAG(IS_WIN)
 #include "shell/browser/browser.h"
@@ -38,7 +38,7 @@ enum class NotificationCenterKind {
 #endif
 
 class SystemPreferences final
-    : public gin::DeprecatedWrappable<SystemPreferences>,
+    : public gin_helper::DeprecatedWrappable<SystemPreferences>,
       public gin_helper::EventEmitterMixin<SystemPreferences>
 #if BUILDFLAG(IS_WIN)
     ,
@@ -49,7 +49,7 @@ class SystemPreferences final
  public:
   static gin::Handle<SystemPreferences> Create(v8::Isolate* isolate);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/electron_api_tray.h
+++ b/shell/browser/api/electron_api_tray.h
@@ -10,7 +10,6 @@
 #include <string>
 #include <vector>
 
-#include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/browser/ui/tray_icon.h"
 #include "shell/browser/ui/tray_icon_observer.h"
@@ -18,6 +17,7 @@
 #include "shell/common/gin_helper/cleaned_up_at_exit.h"
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/pinnable.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 namespace gfx {
 class Image;
@@ -38,7 +38,7 @@ namespace electron::api {
 
 class Menu;
 
-class Tray final : public gin::DeprecatedWrappable<Tray>,
+class Tray final : public gin_helper::DeprecatedWrappable<Tray>,
                    public gin_helper::EventEmitterMixin<Tray>,
                    public gin_helper::Constructible<Tray>,
                    public gin_helper::CleanedUpAtExit,
@@ -54,7 +54,7 @@ class Tray final : public gin::DeprecatedWrappable<Tray>,
   static void FillObjectTemplate(v8::Isolate*, v8::Local<v8::ObjectTemplate>);
   static const char* GetClassName() { return "Tray"; }
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   const char* GetTypeName() override;
 

--- a/shell/browser/api/electron_api_utility_process.h
+++ b/shell/browser/api/electron_api_utility_process.h
@@ -14,12 +14,12 @@
 #include "base/memory/weak_ptr.h"
 #include "base/process/process_handle.h"
 #include "content/public/browser/service_process_host.h"
-#include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/message.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/browser/net/url_loader_network_observer.h"
 #include "shell/common/gin_helper/pinnable.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "shell/services/node/public/mojom/node_service.mojom.h"
 #include "v8/include/v8-forward.h"
 
@@ -40,7 +40,7 @@ class Connector;
 namespace electron::api {
 
 class UtilityProcessWrapper final
-    : public gin::DeprecatedWrappable<UtilityProcessWrapper>,
+    : public gin_helper::DeprecatedWrappable<UtilityProcessWrapper>,
       public gin_helper::Pinnable<UtilityProcessWrapper>,
       public gin_helper::EventEmitterMixin<UtilityProcessWrapper>,
       private mojo::MessageReceiver,
@@ -56,7 +56,7 @@ class UtilityProcessWrapper final
 
   void Shutdown(uint64_t exit_code);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -31,7 +31,6 @@
 #include "content/public/common/stop_find_action.h"
 #include "electron/buildflags/buildflags.h"
 #include "gin/handle.h"
-#include "gin/wrappable.h"
 #include "printing/buildflags/buildflags.h"
 #include "shell/browser/api/save_page_handler.h"
 #include "shell/browser/background_throttling_source.h"
@@ -45,6 +44,7 @@
 #include "shell/common/gin_helper/cleaned_up_at_exit.h"
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/pinnable.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "shell/common/web_contents_utility.mojom.h"
 #include "ui/base/models/image_model.h"
 
@@ -110,7 +110,7 @@ class FrameSubscriber;
 
 // Wrapper around the content::WebContents.
 class WebContents final : public ExclusiveAccessContext,
-                          public gin::DeprecatedWrappable<WebContents>,
+                          public gin_helper::DeprecatedWrappable<WebContents>,
                           public gin_helper::EventEmitterMixin<WebContents>,
                           public gin_helper::Constructible<WebContents>,
                           public gin_helper::Pinnable<WebContents>,
@@ -172,7 +172,7 @@ class WebContents final : public ExclusiveAccessContext,
   static void FillObjectTemplate(v8::Isolate*, v8::Local<v8::ObjectTemplate>);
   static const char* GetClassName() { return "WebContents"; }
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   const char* GetTypeName() override;
 

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -14,7 +14,6 @@
 #include "base/values.h"
 #include "content/public/browser/frame_tree_node_id.h"
 #include "content/public/browser/global_routing_id.h"
-#include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "shell/browser/event_emitter_mixin.h"
@@ -22,6 +21,7 @@
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/pinnable.h"
 #include "shell/common/gin_helper/promise.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "third_party/blink/public/mojom/page/page_visibility_state.mojom-forward.h"
 
 class GURL;
@@ -47,7 +47,7 @@ namespace electron::api {
 class WebContents;
 
 // Bindings for accessing frames from the main process.
-class WebFrameMain final : public gin::DeprecatedWrappable<WebFrameMain>,
+class WebFrameMain final : public gin_helper::DeprecatedWrappable<WebFrameMain>,
                            public gin_helper::EventEmitterMixin<WebFrameMain>,
                            public gin_helper::Pinnable<WebFrameMain>,
                            public gin_helper::Constructible<WebFrameMain> {
@@ -69,7 +69,7 @@ class WebFrameMain final : public gin::DeprecatedWrappable<WebFrameMain>,
   static void FillObjectTemplate(v8::Isolate*, v8::Local<v8::ObjectTemplate>);
   static const char* GetClassName() { return "WebFrameMain"; }
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   const char* GetTypeName() override;
 

--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -324,7 +324,8 @@ WebRequest::~WebRequest() {
 
 gin::ObjectTemplateBuilder WebRequest::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
-  return gin::DeprecatedWrappable<WebRequest>::GetObjectTemplateBuilder(isolate)
+  return gin_helper::DeprecatedWrappable<WebRequest>::GetObjectTemplateBuilder(
+             isolate)
       .SetMethod(
           "onBeforeRequest",
           &WebRequest::SetResponseListener<ResponseEvent::kOnBeforeRequest>)

--- a/shell/browser/api/electron_api_web_request.h
+++ b/shell/browser/api/electron_api_web_request.h
@@ -9,8 +9,8 @@
 #include <set>
 
 #include "base/memory/raw_ptr.h"
-#include "gin/wrappable.h"
 #include "shell/browser/net/web_request_api_interface.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 class URLPattern;
 
@@ -31,7 +31,7 @@ class Handle;
 
 namespace electron::api {
 
-class WebRequest final : public gin::DeprecatedWrappable<WebRequest>,
+class WebRequest final : public gin_helper::DeprecatedWrappable<WebRequest>,
                          public WebRequestAPI {
  public:
   // Return the WebRequest object attached to |browser_context|, create if there
@@ -53,7 +53,7 @@ class WebRequest final : public gin::DeprecatedWrappable<WebRequest>,
 
   static const char* GetClassName() { return "WebRequest"; }
 
-  // gin::Wrappable:
+  // gin_helper::Wrappable:
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/browser/api/message_port.cc
+++ b/shell/browser/api/message_port.cc
@@ -280,7 +280,7 @@ bool MessagePort::Accept(mojo::Message* mojo_message) {
 
 gin::ObjectTemplateBuilder MessagePort::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
-  return gin::DeprecatedWrappable<MessagePort>::GetObjectTemplateBuilder(
+  return gin_helper::DeprecatedWrappable<MessagePort>::GetObjectTemplateBuilder(
              isolate)
       .SetMethod("postMessage", &MessagePort::PostMessage)
       .SetMethod("start", &MessagePort::Start)

--- a/shell/browser/api/message_port.h
+++ b/shell/browser/api/message_port.h
@@ -8,9 +8,9 @@
 #include <memory>
 #include <vector>
 
-#include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/message.h"
 #include "shell/common/gin_helper/cleaned_up_at_exit.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "third_party/blink/public/common/messaging/message_port_channel.h"
 #include "third_party/blink/public/common/messaging/message_port_descriptor.h"
 
@@ -27,7 +27,7 @@ class Connector;
 namespace electron {
 
 // A non-blink version of blink::MessagePort.
-class MessagePort final : public gin::DeprecatedWrappable<MessagePort>,
+class MessagePort final : public gin_helper::DeprecatedWrappable<MessagePort>,
                           public gin_helper::CleanedUpAtExit,
                           private mojo::MessageReceiver {
  public:
@@ -55,7 +55,7 @@ class MessagePort final : public gin::DeprecatedWrappable<MessagePort>,
       const std::vector<gin::Handle<MessagePort>>& ports,
       bool* threw_exception);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -12,7 +12,7 @@
 #include "base/containers/span.h"
 #include "base/memory/raw_ptr.h"
 #include "base/values.h"
-#include "gin/wrappable.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "ui/gfx/image/image.h"
 #include "ui/gfx/image/image_skia_rep.h"
 
@@ -46,7 +46,7 @@ class ErrorThrower;
 
 namespace electron::api {
 
-class NativeImage final : public gin::DeprecatedWrappable<NativeImage> {
+class NativeImage final : public gin_helper::DeprecatedWrappable<NativeImage> {
  public:
   NativeImage(v8::Isolate* isolate, const gfx::Image& image);
 #if BUILDFLAG(IS_WIN)
@@ -95,7 +95,7 @@ class NativeImage final : public gin::DeprecatedWrappable<NativeImage> {
       NativeImage** native_image,
       OnConvertError on_error = OnConvertError::kThrow);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -19,7 +19,6 @@
 #include "base/sequence_checker.h"
 #include "gin/handle.h"
 #include "gin/object_template_builder.h"
-#include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "mojo/public/cpp/system/data_pipe_producer.h"
 #include "net/base/auth.h"
@@ -165,7 +164,7 @@ class BufferDataSource : public mojo::DataPipeProducer::DataSource {
 };
 
 class JSChunkedDataPipeGetter final
-    : public gin::DeprecatedWrappable<JSChunkedDataPipeGetter>,
+    : public gin_helper::DeprecatedWrappable<JSChunkedDataPipeGetter>,
       public network::mojom::ChunkedDataPipeGetter {
  public:
   static gin::Handle<JSChunkedDataPipeGetter> Create(
@@ -178,10 +177,10 @@ class JSChunkedDataPipeGetter final
                      isolate, body_func, std::move(chunked_data_pipe_getter)));
   }
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override {
-    return gin::DeprecatedWrappable<
+    return gin_helper::DeprecatedWrappable<
                JSChunkedDataPipeGetter>::GetObjectTemplateBuilder(isolate)
         .SetMethod("write", &JSChunkedDataPipeGetter::WriteChunk)
         .SetMethod("done", &JSChunkedDataPipeGetter::Done);

--- a/shell/common/api/electron_api_url_loader.h
+++ b/shell/common/api/electron_api_url_loader.h
@@ -13,7 +13,6 @@
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/sequence_checker.h"
-#include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/receiver_set.h"
 #include "services/network/public/cpp/simple_url_loader_stream_consumer.h"
 #include "services/network/public/mojom/network_context.mojom.h"
@@ -22,6 +21,7 @@
 #include "services/network/public/mojom/url_response_head.mojom.h"
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/common/gin_helper/cleaned_up_at_exit.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "url/gurl.h"
 #include "v8/include/v8-forward.h"
 
@@ -49,7 +49,7 @@ namespace electron::api {
 
 /** Wraps a SimpleURLLoader to make it usable from JavaScript */
 class SimpleURLLoaderWrapper final
-    : public gin::DeprecatedWrappable<SimpleURLLoaderWrapper>,
+    : public gin_helper::DeprecatedWrappable<SimpleURLLoaderWrapper>,
       public gin_helper::EventEmitterMixin<SimpleURLLoaderWrapper>,
       public gin_helper::CleanedUpAtExit,
       private network::SimpleURLLoaderStreamConsumer,
@@ -60,7 +60,7 @@ class SimpleURLLoaderWrapper final
 
   void Cancel();
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -257,7 +257,7 @@ bool Converter<net::HttpRequestHeaders>::FromV8(v8::Isolate* isolate,
 namespace {
 
 class ChunkedDataPipeReadableStream final
-    : public gin::DeprecatedWrappable<ChunkedDataPipeReadableStream> {
+    : public gin_helper::DeprecatedWrappable<ChunkedDataPipeReadableStream> {
  public:
   static gin::Handle<ChunkedDataPipeReadableStream> Create(
       v8::Isolate* isolate,
@@ -267,10 +267,10 @@ class ChunkedDataPipeReadableStream final
                                           isolate, request, data_element));
   }
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override {
-    return gin::DeprecatedWrappable<
+    return gin_helper::DeprecatedWrappable<
                ChunkedDataPipeReadableStream>::GetObjectTemplateBuilder(isolate)
         .SetMethod("read", &ChunkedDataPipeReadableStream::Read);
   }

--- a/shell/common/gin_helper/cleaned_up_at_exit.h
+++ b/shell/common/gin_helper/cleaned_up_at_exit.h
@@ -8,8 +8,8 @@
 namespace gin_helper {
 
 // Objects of this type will be destroyed immediately prior to disposing the V8
-// Isolate. This should only be used for gin::Wrappable objects, whose lifetime
-// is otherwise managed by V8.
+// Isolate. This should only be used for gin_helper::Wrappable objects, whose
+// lifetime is otherwise managed by V8.
 //
 // NB. This is only needed because v8::Global objects that have SetWeak
 // finalization callbacks do not have their finalization callbacks invoked at

--- a/shell/common/gin_helper/constructible.h
+++ b/shell/common/gin_helper/constructible.h
@@ -17,10 +17,10 @@ class EventEmitterMixin;
 // Helper class for Wrappable objects which should be constructible with 'new'
 // in JavaScript.
 //
-// To use, inherit from gin::Wrappable and gin_helper::Constructible, and
+// To use, inherit from gin_helper::Wrappable and gin_helper::Constructible, and
 // define the static methods New and FillObjectTemplate:
 //
-//   class Example : public gin::DeprecatedWrappable<Example>,
+//   class Example : public gin_helper::DeprecatedWrappable<Example>,
 //                   public gin_helper::Constructible<Example> {
 //    public:
 //     static gin::Handle<Example> New(...usual gin method arguments...);
@@ -29,8 +29,8 @@ class EventEmitterMixin;
 //         v8::Local<v8::ObjectTemplate>);
 //   }
 //
-// Do NOT define the usual gin::Wrappable::GetObjectTemplateBuilder. It will
-// not be called for Constructible classes.
+// Do NOT define the usual gin_helper::Wrappable::GetObjectTemplateBuilder. It
+// will not be called for Constructible classes.
 //
 // To expose the constructor, call GetConstructor:
 //

--- a/shell/common/gin_helper/event.h
+++ b/shell/common/gin_helper/event.h
@@ -5,8 +5,8 @@
 #ifndef ELECTRON_SHELL_COMMON_GIN_HELPER_EVENT_H_
 #define ELECTRON_SHELL_COMMON_GIN_HELPER_EVENT_H_
 
-#include "gin/wrappable.h"
 #include "shell/common/gin_helper/constructible.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 namespace gin {
 template <typename T>
@@ -23,7 +23,7 @@ class ObjectTemplate;
 
 namespace gin_helper::internal {
 
-class Event final : public gin::DeprecatedWrappable<Event>,
+class Event final : public gin_helper::DeprecatedWrappable<Event>,
                     public gin_helper::Constructible<Event> {
  public:
   // gin_helper::Constructible
@@ -33,7 +33,7 @@ class Event final : public gin::DeprecatedWrappable<Event>,
       v8::Local<v8::ObjectTemplate> prototype);
   static const char* GetClassName() { return "Event"; }
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   const char* GetTypeName() override;
 

--- a/shell/common/gin_helper/event_emitter_caller.h
+++ b/shell/common/gin_helper/event_emitter_caller.h
@@ -10,8 +10,8 @@
 
 #include "base/containers/span.h"
 #include "gin/converter.h"
-#include "gin/wrappable.h"
 #include "shell/common/gin_converters/std_converter.h"  // for ConvertToV8(iso, &&)
+#include "shell/common/gin_helper/wrappable.h"
 
 namespace gin_helper {
 
@@ -56,7 +56,7 @@ v8::Local<v8::Value> CustomEmit(v8::Isolate* isolate,
 
 template <typename T, typename... Args>
 v8::Local<v8::Value> CallMethod(v8::Isolate* isolate,
-                                gin::DeprecatedWrappable<T>* object,
+                                gin_helper::DeprecatedWrappable<T>* object,
                                 const char* method_name,
                                 Args&&... args) {
   v8::EscapableHandleScope scope(isolate);
@@ -69,7 +69,7 @@ v8::Local<v8::Value> CallMethod(v8::Isolate* isolate,
 }
 
 template <typename T, typename... Args>
-v8::Local<v8::Value> CallMethod(gin::DeprecatedWrappable<T>* object,
+v8::Local<v8::Value> CallMethod(gin_helper::DeprecatedWrappable<T>* object,
                                 const char* method_name,
                                 Args&&... args) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();

--- a/shell/common/gin_helper/reply_channel.cc
+++ b/shell/common/gin_helper/reply_channel.cc
@@ -22,8 +22,8 @@ gin::Handle<ReplyChannel> ReplyChannel::Create(v8::Isolate* isolate,
 
 gin::ObjectTemplateBuilder ReplyChannel::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
-  return gin::DeprecatedWrappable<ReplyChannel>::GetObjectTemplateBuilder(
-             isolate)
+  return gin_helper::DeprecatedWrappable<
+             ReplyChannel>::GetObjectTemplateBuilder(isolate)
       .SetMethod("sendReply", &ReplyChannel::SendReply);
 }
 

--- a/shell/common/gin_helper/reply_channel.h
+++ b/shell/common/gin_helper/reply_channel.h
@@ -5,8 +5,8 @@
 #ifndef ELECTRON_SHELL_COMMON_GIN_HELPER_REPLY_CHANNEL_H_
 #define ELECTRON_SHELL_COMMON_GIN_HELPER_REPLY_CHANNEL_H_
 
-#include "gin/wrappable.h"
 #include "shell/common/api/api.mojom.h"
+#include "shell/common/gin_helper/wrappable.h"
 
 namespace gin {
 template <typename T>
@@ -26,13 +26,13 @@ namespace gin_helper::internal {
 // This object wraps the InvokeCallback so that if it gets GC'd by V8, we can
 // still call the callback and send an error. Not doing so causes a Mojo DCHECK,
 // since Mojo requires callbacks to be called before they are destroyed.
-class ReplyChannel : public gin::DeprecatedWrappable<ReplyChannel> {
+class ReplyChannel : public gin_helper::DeprecatedWrappable<ReplyChannel> {
  public:
   using InvokeCallback = electron::mojom::ElectronApiIPC::InvokeCallback;
   static gin::Handle<ReplyChannel> Create(v8::Isolate* isolate,
                                           InvokeCallback callback);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/shell/common/gin_helper/wrappable.cc
+++ b/shell/common/gin_helper/wrappable.cc
@@ -4,6 +4,7 @@
 
 #include "shell/common/gin_helper/wrappable.h"
 
+#include "gin/object_template_builder.h"
 #include "gin/public/isolate_holder.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "v8/include/v8-function.h"
@@ -89,6 +90,88 @@ void WrappableBase::SecondWeakCallback(
   delete static_cast<WrappableBase*>(data.GetInternalField(0));
 }
 
+DeprecatedWrappableBase::DeprecatedWrappableBase() = default;
+
+DeprecatedWrappableBase::~DeprecatedWrappableBase() {
+  if (!wrapper_.IsEmpty())
+    wrapper_.ClearWeak();
+  wrapper_.Reset();
+}
+
+gin::ObjectTemplateBuilder DeprecatedWrappableBase::GetObjectTemplateBuilder(
+    v8::Isolate* isolate) {
+  return gin::ObjectTemplateBuilder(isolate, GetTypeName());
+}
+
+const char* DeprecatedWrappableBase::GetTypeName() {
+  return nullptr;
+}
+
+void DeprecatedWrappableBase::FirstWeakCallback(
+    const v8::WeakCallbackInfo<DeprecatedWrappableBase>& data) {
+  DeprecatedWrappableBase* wrappable = data.GetParameter();
+  DeprecatedWrappableBase* wrappable_from_field =
+      static_cast<DeprecatedWrappableBase*>(data.GetInternalField(1));
+  if (wrappable && wrappable == wrappable_from_field) {
+    wrappable->dead_ = true;
+    wrappable->wrapper_.Reset();
+    data.SetSecondPassCallback(SecondWeakCallback);
+  }
+}
+
+void DeprecatedWrappableBase::SecondWeakCallback(
+    const v8::WeakCallbackInfo<DeprecatedWrappableBase>& data) {
+  if (gin::IsolateHolder::DestroyedMicrotasksRunner())
+    return;
+  DeprecatedWrappableBase* wrappable = data.GetParameter();
+  if (wrappable)
+    delete wrappable;
+}
+
+v8::MaybeLocal<v8::Object> DeprecatedWrappableBase::GetWrapperImpl(
+    v8::Isolate* isolate,
+    gin::DeprecatedWrapperInfo* info) {
+  if (!wrapper_.IsEmpty()) {
+    return v8::MaybeLocal<v8::Object>(
+        v8::Local<v8::Object>::New(isolate, wrapper_));
+  }
+
+  if (dead_) {
+    return v8::MaybeLocal<v8::Object>();
+  }
+
+  gin::PerIsolateData* data = gin::PerIsolateData::From(isolate);
+  v8::Local<v8::ObjectTemplate> templ = data->DeprecatedGetObjectTemplate(info);
+  if (templ.IsEmpty()) {
+    templ = GetObjectTemplateBuilder(isolate).Build();
+    CHECK(!templ.IsEmpty());
+    data->DeprecatedSetObjectTemplate(info, templ);
+  }
+  CHECK_EQ(gin::kNumberOfInternalFields, templ->InternalFieldCount());
+  v8::Local<v8::Object> wrapper;
+  // |wrapper| may be empty in some extreme cases, e.g., when
+  // Object.prototype.constructor is overwritten.
+  if (!templ->NewInstance(isolate->GetCurrentContext()).ToLocal(&wrapper)) {
+    // The current wrappable object will be no longer managed by V8. Delete this
+    // now.
+    delete this;
+    return v8::MaybeLocal<v8::Object>(wrapper);
+  }
+
+  int indices[] = {gin::kWrapperInfoIndex, gin::kEncodedValueIndex};
+  void* values[] = {info, this};
+  wrapper->SetAlignedPointerInInternalFields(2, indices, values);
+  wrapper_.Reset(isolate, wrapper);
+  wrapper_.SetWeak(this, FirstWeakCallback,
+                   v8::WeakCallbackType::kInternalFields);
+  return v8::MaybeLocal<v8::Object>(wrapper);
+}
+
+void DeprecatedWrappableBase::ClearWeak() {
+  if (!wrapper_.IsEmpty())
+    wrapper_.ClearWeak();
+}
+
 namespace internal {
 
 void* FromV8Impl(v8::Isolate* isolate, v8::Local<v8::Value> val) {
@@ -98,6 +181,31 @@ void* FromV8Impl(v8::Isolate* isolate, v8::Local<v8::Value> val) {
   if (obj->InternalFieldCount() != 1)
     return nullptr;
   return obj->GetAlignedPointerFromInternalField(0);
+}
+
+void* FromV8Impl(v8::Isolate* isolate,
+                 v8::Local<v8::Value> val,
+                 gin::DeprecatedWrapperInfo* wrapper_info) {
+  if (!val->IsObject()) {
+    return nullptr;
+  }
+  v8::Local<v8::Object> obj = v8::Local<v8::Object>::Cast(val);
+  gin::DeprecatedWrapperInfo* info = gin::DeprecatedWrapperInfo::From(obj);
+
+  // If this fails, the object is not managed by Gin. It is either a normal JS
+  // object that's not wrapping any external C++ object, or it is wrapping some
+  // C++ object, but that object isn't managed by Gin (maybe Blink).
+  if (!info) {
+    return nullptr;
+  }
+
+  // If this fails, the object is managed by Gin, but it's not wrapping an
+  // instance of the C++ class associated with wrapper_info.
+  if (info != wrapper_info) {
+    return nullptr;
+  }
+
+  return obj->GetAlignedPointerFromInternalField(gin::kEncodedValueIndex);
 }
 
 }  // namespace internal

--- a/shell/common/gin_helper/wrappable.h
+++ b/shell/common/gin_helper/wrappable.h
@@ -7,7 +7,9 @@
 
 #include "base/functional/bind.h"
 #include "gin/per_isolate_data.h"
+#include "gin/public/wrapper_info.h"
 #include "shell/common/gin_helper/constructor.h"
+#include "shell/common/gin_helper/wrappable_base.h"
 
 namespace gin_helper {
 
@@ -17,6 +19,9 @@ bool IsValidWrappable(const v8::Local<v8::Value>& obj,
 namespace internal {
 
 void* FromV8Impl(v8::Isolate* isolate, v8::Local<v8::Value> val);
+void* FromV8Impl(v8::Isolate* isolate,
+                 v8::Local<v8::Value> val,
+                 gin::DeprecatedWrapperInfo* info);
 
 }  // namespace internal
 
@@ -72,6 +77,24 @@ class Wrappable : public WrappableBase {
   static gin::DeprecatedWrapperInfo kWrapperInfo;
 };
 
+// Copied from https://chromium-review.googlesource.com/c/chromium/src/+/6799157
+// Will be removed as part of https://github.com/electron/electron/issues/47922
+template <typename T>
+class DeprecatedWrappable : public DeprecatedWrappableBase {
+ public:
+  DeprecatedWrappable(const DeprecatedWrappable&) = delete;
+  DeprecatedWrappable& operator=(const DeprecatedWrappable&) = delete;
+
+  // Retrieve (or create) the v8 wrapper object corresponding to this object.
+  v8::MaybeLocal<v8::Object> GetWrapper(v8::Isolate* isolate) {
+    return GetWrapperImpl(isolate, &T::kWrapperInfo);
+  }
+
+ protected:
+  DeprecatedWrappable() = default;
+  ~DeprecatedWrappable() override = default;
+};
+
 // static
 template <typename T>
 gin::DeprecatedWrapperInfo Wrappable<T>::kWrapperInfo = {
@@ -97,6 +120,28 @@ struct Converter<
     *out = static_cast<T*>(static_cast<gin_helper::WrappableBase*>(
         gin_helper::internal::FromV8Impl(isolate, val)));
     return *out != nullptr;
+  }
+};
+
+// This converter handles any subclass of DeprecatedWrappable.
+template <typename T>
+  requires(std::is_convertible_v<T*, gin_helper::DeprecatedWrappableBase*>)
+struct Converter<T*> {
+  static v8::MaybeLocal<v8::Value> ToV8(v8::Isolate* isolate, T* val) {
+    if (val == nullptr) {
+      return v8::Null(isolate);
+    }
+    v8::Local<v8::Object> wrapper;
+    if (!val->GetWrapper(isolate).ToLocal(&wrapper)) {
+      return v8::MaybeLocal<v8::Value>();
+    }
+    return v8::MaybeLocal<v8::Value>(wrapper);
+  }
+
+  static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val, T** out) {
+    *out = static_cast<T*>(static_cast<gin_helper::DeprecatedWrappableBase*>(
+        gin_helper::internal::FromV8Impl(isolate, val, &T::kWrapperInfo)));
+    return *out != NULL;
   }
 };
 

--- a/shell/common/gin_helper/wrappable_base.h
+++ b/shell/common/gin_helper/wrappable_base.h
@@ -10,7 +10,9 @@
 
 namespace gin {
 class Arguments;
-}
+class ObjectTemplateBuilder;
+struct DeprecatedWrapperInfo;
+}  // namespace gin
 
 namespace gin_helper {
 
@@ -60,6 +62,46 @@ class WrappableBase {
       const v8::WeakCallbackInfo<WrappableBase>& data);
 
   raw_ptr<v8::Isolate> isolate_ = nullptr;
+};
+
+// Copied from https://chromium-review.googlesource.com/c/chromium/src/+/6799157
+// Will be removed as part of https://github.com/electron/electron/issues/47922
+class DeprecatedWrappableBase {
+ public:
+  DeprecatedWrappableBase(const DeprecatedWrappableBase&) = delete;
+  DeprecatedWrappableBase& operator=(const DeprecatedWrappableBase&) = delete;
+
+ protected:
+  DeprecatedWrappableBase();
+  virtual ~DeprecatedWrappableBase();
+
+  // Overrides of this method should be declared final and not overridden again.
+  virtual gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
+      v8::Isolate* isolate);
+
+  // Returns a readable type name that will be used in surfacing errors. The
+  // default implementation returns nullptr, which results in a generic error.
+  virtual const char* GetTypeName();
+
+  v8::MaybeLocal<v8::Object> GetWrapperImpl(
+      v8::Isolate* isolate,
+      gin::DeprecatedWrapperInfo* wrapper_info);
+
+  // Make this wrappable strong again. This is useful when the wrappable is
+  // destroyed outside the finalizer callbacks and we want to avoid scheduling
+  // the weak callbacks if they haven't been scheduled yet.
+  // NOTE!!! this does not prevent finalization callbacks from running if they
+  // have already been processed.
+  void ClearWeak();
+
+ private:
+  static void FirstWeakCallback(
+      const v8::WeakCallbackInfo<DeprecatedWrappableBase>& data);
+  static void SecondWeakCallback(
+      const v8::WeakCallbackInfo<DeprecatedWrappableBase>& data);
+
+  bool dead_ = false;
+  v8::Global<v8::Object> wrapper_;  // Weak
 };
 
 }  // namespace gin_helper

--- a/shell/renderer/api/electron_api_ipc_renderer.cc
+++ b/shell/renderer/api/electron_api_ipc_renderer.cc
@@ -10,7 +10,6 @@
 #include "gin/dictionary.h"
 #include "gin/handle.h"
 #include "gin/object_template_builder.h"
-#include "gin/wrappable.h"
 #include "services/service_manager/public/cpp/interface_provider.h"
 #include "shell/common/api/api.mojom.h"
 #include "shell/common/gin_converters/blink_converter.h"
@@ -19,6 +18,7 @@
 #include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/function_template_extensions.h"
 #include "shell/common/gin_helper/promise.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "shell/common/node_bindings.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/v8_util.h"
@@ -55,7 +55,7 @@ bool IsWorkerThread() {
 }
 
 template <typename T>
-class IPCBase : public gin::DeprecatedWrappable<T> {
+class IPCBase : public gin_helper::DeprecatedWrappable<T> {
  public:
   static gin::DeprecatedWrapperInfo kWrapperInfo;
 
@@ -181,10 +181,10 @@ class IPCBase : public gin::DeprecatedWrappable<T> {
     return electron::DeserializeV8Value(isolate, result);
   }
 
-  // gin::Wrappable:
+  // gin_helper::Wrappable:
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override {
-    return gin::DeprecatedWrappable<T>::GetObjectTemplateBuilder(isolate)
+    return gin_helper::DeprecatedWrappable<T>::GetObjectTemplateBuilder(isolate)
         .SetMethod("send", &T::SendMessage)
         .SetMethod("sendSync", &T::SendSync)
         .SetMethod("sendToHost", &T::SendToHost)

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -19,7 +19,6 @@
 #include "content/public/renderer/render_frame_visitor.h"
 #include "gin/handle.h"
 #include "gin/object_template_builder.h"
-#include "gin/wrappable.h"
 #include "services/service_manager/public/cpp/interface_provider.h"
 #include "shell/common/api/api.mojom.h"
 #include "shell/common/gin_converters/blink_converter.h"
@@ -30,6 +29,7 @@
 #include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/function_template_extensions.h"
 #include "shell/common/gin_helper/promise.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/node_util.h"
 #include "shell/common/options_switches.h"
@@ -331,7 +331,8 @@ class SpellCheckerHolder final : private content::RenderFrameObserver {
 };
 
 class WebFrameRenderer final
-    : public gin::DeprecatedWrappable<WebFrameRenderer>,
+    : public gin_helper::DeprecatedWrappable<WebFrameRenderer>,
+      public gin_helper::Constructible<WebFrameRenderer>,
       private content::RenderFrameObserver {
  public:
   static gin::DeprecatedWrapperInfo kWrapperInfo;

--- a/shell/services/node/parent_port.cc
+++ b/shell/services/node/parent_port.cc
@@ -114,7 +114,8 @@ gin::Handle<ParentPort> ParentPort::Create(v8::Isolate* isolate) {
 // static
 gin::ObjectTemplateBuilder ParentPort::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
-  return gin::DeprecatedWrappable<ParentPort>::GetObjectTemplateBuilder(isolate)
+  return gin_helper::DeprecatedWrappable<ParentPort>::GetObjectTemplateBuilder(
+             isolate)
       .SetMethod("postMessage", &ParentPort::PostMessage)
       .SetMethod("start", &ParentPort::Start)
       .SetMethod("pause", &ParentPort::Pause);

--- a/shell/services/node/parent_port.h
+++ b/shell/services/node/parent_port.h
@@ -7,10 +7,10 @@
 
 #include <memory>
 
-#include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/connector.h"
 #include "mojo/public/cpp/bindings/message.h"
 #include "shell/common/gin_helper/cleaned_up_at_exit.h"
+#include "shell/common/gin_helper/wrappable.h"
 #include "third_party/blink/public/common/messaging/message_port_descriptor.h"
 
 namespace v8 {
@@ -31,7 +31,7 @@ namespace electron {
 // There is only a single instance of this class
 // for the lifetime of a Utility Process which
 // also means that GC lifecycle is ignored by this class.
-class ParentPort final : public gin::DeprecatedWrappable<ParentPort>,
+class ParentPort final : public gin_helper::DeprecatedWrappable<ParentPort>,
                          public gin_helper::CleanedUpAtExit,
                          private mojo::MessageReceiver {
  public:
@@ -45,7 +45,7 @@ class ParentPort final : public gin::DeprecatedWrappable<ParentPort>,
   ~ParentPort() override;
   void Initialize(blink::MessagePortDescriptor port);
 
-  // gin::Wrappable
+  // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;


### PR DESCRIPTION
Backport of #47958.

See that PR for details.

Notes: none