### PR TITLE
fix: shell command built from environment values

### DIFF
--- a/script/release/release.ts
+++ b/script/release/release.ts
@@ -7,7 +7,7 @@ import got from 'got';
 import { gte } from 'semver';
 import { track as trackTemp } from 'temp';
 
-import { execSync, ExecSyncOptions } from 'node:child_process';
+import { execFileSync, ExecSyncOptions } from 'node:child_process';
 import { statSync, createReadStream, writeFileSync, close } from 'node:fs';
 import { join } from 'node:path';
 
@@ -233,16 +233,15 @@ function azRemoteFilesForVersion (version: string) {
   }));
 }
 
-function runScript (scriptName: string, scriptArgs: string[], cwd?: string) {
-  const scriptCommand = `${scriptName} ${scriptArgs.join(' ')}`;
+function runScript (scriptPath: string, scriptArgs: string[], cwd?: string) {
   const scriptOptions: ExecSyncOptions = {
     encoding: 'utf-8'
   };
   if (cwd) scriptOptions.cwd = cwd;
   try {
-    return execSync(scriptCommand, scriptOptions);
+    return execFileSync(scriptPath, scriptArgs, scriptOptions);
   } catch (err) {
-    console.error(`${fail} Error running ${scriptName}`, err);
+    console.error(`${fail} Error running ${scriptPath}`, err);
     process.exit(1);
   }
 }


### PR DESCRIPTION

fix the problem, we should avoid constructing a shell command string and passing it to `execSync`. Instead, use `execFileSync` (or `execFile` for async) and pass the script path and arguments as separate parameters. This prevents the shell from interpreting spaces or special characters in the path or arguments. Specifically, in `runScript`, replace the use of `execSync` with `execFileSync`, and update the construction of the command so that the script path and arguments are passed separately. Also, import `execFileSync` from `node:child_process`. Only the file `script/release/release.ts` needs to be changed, specifically the `runScript` function and its usage.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
