### PR TITLE
docs: deprecate `ELECTRON_OZONE_PLATFORM_HINT` env var

### DIFF
--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -125,13 +125,13 @@ Options:
 * `kioclient5`
 * `kioclient`
 
-### `ELECTRON_OZONE_PLATFORM_HINT` _Linux_
+### `ELECTRON_OZONE_PLATFORM_HINT` _Linux_ _Deprecated_
 
-Selects the preferred platform backend used on Linux. The default one is `x11`. `auto` selects Wayland if possible, X11 otherwise.
+Selects the preferred platform backend used on Linux. `auto` selects Wayland if possible, X11 otherwise.
 
 Options:
 
-* `auto`
+* `auto` (Default)
 * `wayland`
 * `x11`
 

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -14,6 +14,14 @@ This document uses the following convention to categorize breaking changes:
 
 ## Planned Breaking API Changes (38.0)
 
+### Deprecated: `ELECTRON_OZONE_PLATFORM_HINT` environment variable
+
+The default value of the `--ozone-plaftform` flag [changed to `auto`](https://chromium-review.googlesource.com/c/chromium/src/+/6775426).
+
+You should use the `XDG_SESSION_TYPE=wayland` environment variable instead to use Wayland.
+
+This environment variable will be [removed soon](https://chromium-review.googlesource.com/c/chromium/src/+/6819616).
+
 ### Removed: macOS 11 support
 
 macOS 11 (Big Sur) is no longer supported by [Chromium](https://chromium-review.googlesource.com/c/chromium/src/+/6594615).


### PR DESCRIPTION
#### Description of Change

Deprecates the **`ELECTRON_OZONE_PLATFORM_HINT` environment variable** in Electron 38. It is planned to be removed in Electron 39.

See #48001 for more information.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Deprecated the `ELECTRON_OZONE_PLATFORM_HINT` environment variable.