### PR TITLE
Upgrade macOS runners to macos-15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,7 +184,7 @@ jobs:
     with:
       target-platform: macos
       target-archs: x64 arm64
-      check-runs-on: macos-14
+      check-runs-on: macos-15
       gn-build-type: testing
     secrets: inherit
 
@@ -219,8 +219,8 @@ jobs:
     uses: ./.github/workflows/pipeline-electron-build-and-test.yml
     needs: checkout-macos
     with:
-      build-runs-on: macos-14-xlarge
-      test-runs-on: macos-13
+      build-runs-on: macos-15-xlarge
+      test-runs-on: macos-14
       target-platform: macos
       target-arch: x64
       is-release: false
@@ -237,7 +237,7 @@ jobs:
     uses: ./.github/workflows/pipeline-electron-build-and-test.yml
     needs: checkout-macos
     with:
-      build-runs-on: macos-14-xlarge
+      build-runs-on: macos-15-xlarge
       test-runs-on: macos-14
       target-platform: macos
       target-arch: arm64

--- a/.github/workflows/macos-publish.yml
+++ b/.github/workflows/macos-publish.yml
@@ -47,7 +47,7 @@ jobs:
     needs: checkout-macos
     with:
       environment: production-release
-      build-runs-on: macos-14-xlarge
+      build-runs-on: macos-15-xlarge
       target-platform: macos
       target-arch: x64
       target-variant: darwin
@@ -62,7 +62,7 @@ jobs:
     needs: checkout-macos
     with:
       environment: production-release
-      build-runs-on: macos-14-xlarge
+      build-runs-on: macos-15-xlarge
       target-platform: macos
       target-arch: x64
       target-variant: mas
@@ -77,7 +77,7 @@ jobs:
     needs: checkout-macos
     with:
       environment: production-release
-      build-runs-on: macos-14-xlarge
+      build-runs-on: macos-15-xlarge
       target-platform: macos
       target-arch: arm64
       target-variant: darwin
@@ -92,7 +92,7 @@ jobs:
     needs: checkout-macos
     with:
       environment: production-release
-      build-runs-on: macos-14-xlarge
+      build-runs-on: macos-15-xlarge
       target-platform: macos
       target-arch: arm64
       target-variant: mas


### PR DESCRIPTION
Upgrade macOS runners from macos-14 to macos-15 and update build and test jobs to support both x64 and arm64 architectures with improved runner specs for better performance and compatibility.

Checklist
	•	PR description included and stakeholders cc’d
	•	npm test passes
	•	tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
	•	relevant API documentation, tutorials, and examples are updated and follow the documentation style guide
	•	PR release notes describe the change in a way relevant to app developers

Release Notes

Notes: Upgrade CI macOS runners to macos-15 for improved build performance and arch support
