### PR TITLE
fix: `app.accessibilitySupportEnabled` 

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1159,7 +1159,8 @@ void App::DisableDomainBlockingFor3DAPIs(gin_helper::ErrorThrower thrower) {
 
 bool App::IsAccessibilitySupportEnabled() {
   auto* ax_state = content::BrowserAccessibilityState::GetInstance();
-  return ax_state->GetAccessibilityMode() == ui::kAXModeComplete;
+  auto mode = ax_state->GetAccessibilityMode();
+  return mode.has_mode(ui::kAXModeComplete.flags());
 }
 
 void App::SetAccessibilitySupportEnabled(gin_helper::ErrorThrower thrower,


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/48039.

Fixes an issue where `app.accessibilitySupportEnabled` didn't work as expected. This happened as a result of https://github.com/electron/electron/issues/46118.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `app.accessibilitySupportEnabled` didn't work as expected. 