### PR TITLE
fix: BrowserWindow add the same BrowserView

### DIFF
--- a/lib/browser/api/browser-window.ts
+++ b/lib/browser/api/browser-window.ts
@@ -199,7 +199,14 @@ BrowserWindow.prototype.setBackgroundThrottling = function (allowed: boolean) {
 };
 
 BrowserWindow.prototype.addBrowserView = function (browserView: BrowserView) {
-  if (browserView.ownerWindow) { browserView.ownerWindow.removeBrowserView(browserView); }
+  // avoid adding the same browserView multiple times
+  if (this._browserViews.includes(browserView)) {
+    return;
+  }
+  const oldOwnerWindow = browserView.ownerWindow;
+  if (oldOwnerWindow && oldOwnerWindow !== this) {
+    oldOwnerWindow.removeBrowserView(browserView);
+  }
   this.contentView.addChildView(browserView.webContentsView);
   browserView.ownerWindow = this;
   browserView.webContents._setOwnerWindow(this);


### PR DESCRIPTION
#### Description of Change

After the BrowserView module was refactored in Electron 30, the behavior of the addBrowserView API changed. When the same browserView is added multiple times to a browserWindow, the browserView will first be removed and then re-added.
Specifically, this causes a jump in the page's visibility inside the browserView, and the visibilitychange event is triggered unexpectedly.

The impl of  'addBrowserView'  in different versions:
electron 29: https://github.com/electron/electron/blob/v29.4.6/shell/browser/api/electron_api_base_window.cc#L762
electron 30: https://github.com/electron/electron/blob/v30.0.0/lib/browser/api/browser-window.ts#L178

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed addBrowserView to prevent unnecessary removal and re-adding of the same BrowserView.
