### PR TITLE
fix: webContent.fromId should be number instead of string

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -882,7 +882,7 @@ export function create (options = {}): Electron.WebContents {
   return new (WebContents as any)(options);
 }
 
-export function fromId (id: string) {
+export function fromId (id: number) {
   return binding.fromId(id);
 }
 


### PR DESCRIPTION
#### Description of Change

The fromId defined in the file accepts a string arg, while the api docs are number, the native binding also wants a int32.

#### Release Notes

Notes: none