### PR TITLE
refactor: use `XmlWriter` for Windows toasts

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -682,6 +682,7 @@ source_set("electron_lib") {
     deps += [
       "//components/app_launch_prefetch",
       "//components/crash/core/app:crash_export_thunks",
+      "//third_party/libxml:xml_writer",
       "//ui/native_theme:native_theme_browser",
       "//ui/wm",
       "//ui/wm/public",

--- a/shell/browser/notifications/win/windows_toast_notification.h
+++ b/shell/browser/notifications/win/windows_toast_notification.h
@@ -58,33 +58,11 @@ class WindowsToastNotification : public Notification {
   friend class ToastEventHandler;
 
   HRESULT ShowInternal(const NotificationOptions& options);
-  HRESULT GetToastXml(
-      ABI::Windows::UI::Notifications::IToastNotificationManagerStatics*
-          toastManager,
-      const std::u16string& title,
-      const std::u16string& msg,
-      const std::wstring& icon_path,
-      const std::u16string& timeout_type,
-      const bool silent,
-      ABI::Windows::Data::Xml::Dom::IXmlDocument** toast_xml);
-  HRESULT SetXmlAudioSilent(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc);
-  HRESULT SetXmlScenarioReminder(
-      ABI::Windows::Data::Xml::Dom::IXmlDocument* doc);
-  HRESULT SetXmlText(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
-                     const std::u16string& text);
-  HRESULT SetXmlText(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
-                     const std::u16string& title,
-                     const std::u16string& body);
-  HRESULT SetXmlImage(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
-                      const std::wstring& icon_path);
-  HRESULT GetTextNodeList(
-      ScopedHString* tag,
-      ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
-      ABI::Windows::Data::Xml::Dom::IXmlNodeList** node_list,
-      uint32_t req_length);
-  HRESULT AppendTextToXml(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
-                          ABI::Windows::Data::Xml::Dom::IXmlNode* node,
-                          const std::u16string& text);
+  std::u16string GetToastXml(const std::u16string& title,
+                             const std::u16string& msg,
+                             const std::wstring& icon_path,
+                             const std::u16string& timeout_type,
+                             const bool silent);
   HRESULT XmlDocumentFromString(
       const wchar_t* xmlString,
       ABI::Windows::Data::Xml::Dom::IXmlDocument** doc);


### PR DESCRIPTION
#### Description of Change

We can clean up our XML building logic by re-using the XmlWriter class available upstream.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none