### PR TITLE
fix: `shell.openPath` should be non-blocking

### DIFF
--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -342,7 +342,7 @@ void ShowItemInFolder(const base::FilePath& full_path) {
 
 void OpenPath(const base::FilePath& full_path, OpenCallback callback) {
   // This is async, so we don't care about the return value.
-  XDGOpen(full_path.DirName(), full_path.value(), true, std::move(callback));
+  XDGOpen(full_path.DirName(), full_path.value(), false, std::move(callback));
 }
 
 void OpenFolder(const base::FilePath& full_path) {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/47668.

Fixes an issue where `shell.openPath` was not non-blocking as expected.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `shell.openPath` was not non-blocking as expected.