### PR TITLE
fix: system accent color parsing hex order

### DIFF
--- a/shell/common/color_util.cc
+++ b/shell/common/color_util.cc
@@ -12,6 +12,8 @@
 
 #if BUILDFLAG(IS_WIN)
 #include <dwmapi.h>
+
+#include "base/win/registry.h"
 #endif
 
 namespace {
@@ -68,12 +70,18 @@ std::string ToRGBAHex(SkColor color, bool include_hash) {
 
 #if BUILDFLAG(IS_WIN)
 std::optional<DWORD> GetSystemAccentColor() {
-  DWORD color = 0;
-  BOOL opaque = FALSE;
-
-  if (FAILED(DwmGetColorizationColor(&color, &opaque)))
+  base::win::RegKey key;
+  if (key.Open(HKEY_CURRENT_USER, L"SOFTWARE\\Microsoft\\Windows\\DWM",
+               KEY_READ) != ERROR_SUCCESS) {
     return std::nullopt;
-  return color;
+  }
+
+  DWORD accent_color = 0;
+  if (key.ReadValueDW(L"AccentColor", &accent_color) != ERROR_SUCCESS) {
+    return std::nullopt;
+  }
+
+  return accent_color;
 }
 #endif
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/48086
Closes https://github.com/electron/electron/issues
Refs https://github.com/electron/electron/pull/47741.

Fixes an issue where the accent color would be accidentally inverted when set to match the system color. This could be seen if you chose e.g. an orange, whose color opposite is blue; the window would have a blue border in that case. This happened because `DwmGetColorizationColor` returns a color formatted `0xAARRGGBB`,  and the parsing performed [here](https://github.com/electron/electron/blob/5c98e3609f4b62490fd44541f28f1086b604e4e9/shell/browser/native_window_views_win.cc#L585-L589) used `Get{R|G|B}Value` to parse the color into a `COLORREF`. From [documentation](https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/nf-dwmapi-dwmgetcolorizationcolor):

> The value pointed to by pcrColorization is in an 0xAARRGGBB format. Many Microsoft Win32 APIs, such as `COLORREF`, use a `0x00BBGGRR` format. Be careful to assure that the intended colors are used.

Switch to pulling the color from the windows registry, which does not require extra conversion to ensure the color is in the right format.

cc @bpasero

Tested to ensure the color updates correctly with settings change.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where the accent color would be accidentally inverted when set to match the system color.