### PR TITLE
fix: avoid deprecated login item methods

### DIFF
--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -426,19 +426,18 @@ v8::Local<v8::Value> Browser::GetLoginItemSettings(
 #else
   // If the app was previously set as a LoginItem with the deprecated API,
   // we should report its LoginItemSettings via the old API.
-  LoginItemSettings settings_deprecated = GetLoginItemSettingsDeprecated();
   if (@available(macOS 13, *)) {
     const std::string status =
         platform_util::GetLoginItemEnabled(options.type, options.service_name);
     if (status == "enabled-deprecated") {
-      settings = settings_deprecated;
+      settings = GetLoginItemSettingsDeprecated();
     } else {
       settings.open_at_login = status == "enabled";
       settings.opened_at_login = was_launched_at_login_;
       settings.status = status;
     }
   } else {
-    settings = settings_deprecated;
+    settings = GetLoginItemSettingsDeprecated();
   }
 #endif
   return gin::ConvertToV8(isolate, settings);

--- a/shell/common/platform_util_mac.mm
+++ b/shell/common/platform_util_mac.mm
@@ -220,7 +220,6 @@ void Beep() {
 
 std::string GetLoginItemEnabled(const std::string& type,
                                 const std::string& service_name) {
-  bool enabled = GetLoginItemEnabledDeprecated();
   if (@available(macOS 13, *)) {
     SMAppService* service = GetServiceForType(type, service_name);
     SMAppServiceStatus status = [service status];
@@ -232,10 +231,11 @@ std::string GetLoginItemEnabled(const std::string& type,
       return "requires-approval";
     else if (status == SMAppServiceStatusNotFound) {
       // If the login item was enabled with the old API, return that.
-      return enabled ? "enabled-deprecated" : "not-found";
+      return GetLoginItemEnabledDeprecated() ? "enabled-deprecated"
+                                             : "not-found";
     }
   }
-  return enabled ? "enabled" : "not-registered";
+  return GetLoginItemEnabledDeprecated() ? "enabled" : "not-registered";
 }
 
 bool SetLoginItemEnabled(const std::string& type,


### PR DESCRIPTION
There appears to be a deadlock condition inside `LSSharedFileListCopySnapshot` which is called deep within the deprecated codepath on macOS. This change _should_ ensure that the deprecated codepath is not followed 99% of the time.

Honestly we should probably just remove this deprecated code, but for now this is a backport safe variant that should fix the deadlock.

Notes: Fixed potential deadlock inside `app.getLoginItemSettings` on macOS