### PR TITLE
doc: Update process-model.md examples to use ES modules instead of CommonJS

### DIFF
--- a/docs/tutorial/process-model.md
+++ b/docs/tutorial/process-model.md
@@ -55,7 +55,7 @@ a web page in a separate renderer process. You can interact with this web conten
 from the main process using the window's [`webContents`][web-contents] object.
 
 ```js title='main.js'
-const { BrowserWindow } = require('electron')
+import { BrowserWindow } from 'electron'
 
 const win = new BrowserWindow({ width: 800, height: 1500 })
 win.loadURL('https://github.com')
@@ -158,7 +158,7 @@ A preload script can be attached to the main process in the `BrowserWindow` cons
 `webPreferences` option.
 
 ```js title='main.js'
-const { BrowserWindow } = require('electron')
+import { BrowserWindow } from 'electron'
 // ...
 const win = new BrowserWindow({
   webPreferences: {
@@ -194,7 +194,7 @@ Instead, use the [`contextBridge`][context-bridge] module to accomplish this
 securely:
 
 ```js title='preload.js'
-const { contextBridge } = require('electron')
+import { contextBridge } from 'electron'
 
 contextBridge.exposeInMainWorld('myAPI', {
   desktop: true
@@ -242,8 +242,8 @@ These aliases have no impact on runtime, but can be used for typechecking
 and autocomplete.
 
 ```js title="Usage example"
-const { shell } = require('electron/common')
-const { app } = require('electron/main')
+import { shell } from 'electron/common'
+import { app } from 'electron/main'
 ```
 
 [window-mdn]: https://developer.mozilla.org/en-US/docs/Web/API/Window


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Update process-model.md examples to use ES modules instead of CommonJS

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
