### PR TITLE
fix: `net.isOnline` always true in utility processes

### DIFF
--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -12,6 +12,7 @@
 #include "base/process/process.h"
 #include "base/strings/utf_string_conversions.h"
 #include "electron/mas.h"
+#include "net/base/network_change_notifier.h"
 #include "services/network/public/cpp/wrapper_shared_url_loader_factory.h"
 #include "services/network/public/mojom/host_resolver.mojom.h"
 #include "services/network/public/mojom/network_context.mojom.h"
@@ -126,6 +127,12 @@ void NodeService::Initialize(
   v8::HandleScope scope{isolate};
 
   node_bindings_->Initialize(isolate, isolate->GetCurrentContext());
+
+  if (!network_change_notifier_) {
+    network_change_notifier_ = net::NetworkChangeNotifier::CreateIfNeeded(
+        net::NetworkChangeNotifier::CONNECTION_UNKNOWN,
+        net::NetworkChangeNotifier::ConnectionSubtype::SUBTYPE_UNKNOWN);
+  }
 
   // Append program path for process.argv0
   auto program = base::CommandLine::ForCurrentProcess()->GetProgram();

--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -128,11 +128,9 @@ void NodeService::Initialize(
 
   node_bindings_->Initialize(isolate, isolate->GetCurrentContext());
 
-  if (!network_change_notifier_) {
-    network_change_notifier_ = net::NetworkChangeNotifier::CreateIfNeeded(
-        net::NetworkChangeNotifier::CONNECTION_UNKNOWN,
-        net::NetworkChangeNotifier::ConnectionSubtype::SUBTYPE_UNKNOWN);
-  }
+  network_change_notifier_ = net::NetworkChangeNotifier::CreateIfNeeded(
+      net::NetworkChangeNotifier::CONNECTION_UNKNOWN,
+      net::NetworkChangeNotifier::ConnectionSubtype::SUBTYPE_UNKNOWN);
 
   // Append program path for process.argv0
   auto program = base::CommandLine::ForCurrentProcess()->GetProgram();

--- a/shell/services/node/node_service.h
+++ b/shell/services/node/node_service.h
@@ -11,6 +11,7 @@
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "mojo/public/cpp/bindings/remote.h"
+#include "net/base/network_change_notifier.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "services/network/public/mojom/host_resolver.mojom.h"
 #include "services/network/public/mojom/url_loader_factory.mojom-forward.h"
@@ -84,6 +85,8 @@ class NodeService : public node::mojom::NodeService {
 
   // depends-on: js_env_'s isolate
   std::shared_ptr<node::Environment> node_env_;
+
+  std::unique_ptr<net::NetworkChangeNotifier> network_change_notifier_;
 };
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

Closes #48100.

Fixes an issue where `net.isOnline()` always returned `true` in utilityProcesses. This happened because utility processes never created a `net::NetworkChangeNotifier`, so `net.isOnline()` always saw a null [global](https://source.chromium.org/chromium/chromium/src/+/main:net/base/network_change_notifier.cc;drc=280cd6cc9ad696c74313035a0bbaab8f4f8c4bf4;bpv=1;bpt=1;l=52) and defaulted to “online”.

Fix this by adding a per‑utility‑process `NetworkChangeNotifier` during `NodeService::Initialize()]`, allowing `net.isOnline()`  to reflect real connectivity. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `net.isOnline()` always returned `true` in utilityProcesses.
