### PR TITLE
docs: update 38.0 breaking changes

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -12,23 +12,13 @@ This document uses the following convention to categorize breaking changes:
 * **Deprecated:** An API was marked as deprecated. The API will continue to function, but will emit a deprecation warning, and will be removed in a future release.
 * **Removed:** An API or feature was removed, and is no longer supported by Electron.
 
-## Planned Breaking API Changes (39.0)
-
-### Removed: `ELECTRON_OZONE_PLATFORM_HINT` evironment variable
-
-The default value of the `--ozone-plaftform` flag [changed to `auto`](https://chromium-review.googlesource.com/c/chromium/src/+/6775426) in Electron 38.
-
-You should use the `XDG_SESSION_TYPE=wayland` environment variable instead to use Wayland.
-
 ## Planned Breaking API Changes (38.0)
 
-### Deprecated: `ELECTRON_OZONE_PLATFORM_HINT` environment variable
+### Removed: `ELECTRON_OZONE_PLATFORM_HINT` environment variable
 
 The default value of the `--ozone-plaftform` flag [changed to `auto`](https://chromium-review.googlesource.com/c/chromium/src/+/6775426).
 
 You should use the `XDG_SESSION_TYPE=wayland` environment variable instead to use Wayland.
-
-This environment variable will be [removed soon](https://chromium-review.googlesource.com/c/chromium/src/+/6819616).
 
 ### Removed: macOS 11 support
 


### PR DESCRIPTION
#### Description of Change
- #47983 documented the breaking change  of the `ELECTRON_OZONE_PLATFORM_HINT` environment variable removal as it was removed because of https://chromium-review.googlesource.com/c/chromium/src/+/6819616
- #48075 includes https://chromium-review.googlesource.com/c/chromium/src/+/6824606 which is a chromium backport of https://chromium-review.googlesource.com/c/chromium/src/+/6819616, so the breaking change has moved from 39.0.0 to 38.0.0. 
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
