### PR TITLE
feat: improve Windows Toast actions support

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1122,6 +1122,19 @@ Updates the current activity if its type matches `type`, merging the entries fro
 
 Changes the [Application User Model ID][app-user-model-id] to `id`.
 
+### `app.setToastActivatorCLSID(id)` _Windows_
+
+* `id` string
+
+Changes the [Toast Activator CLSID][toast-activator-clsid] to `id`. If one is not set via this method, it will be randomly generated for the app.
+
+* The value must be a valid GUID/CLSID in one of the following forms:
+  * Canonical brace-wrapped: `{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}` (preferred)
+  * Canonical without braces: `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX` (braces will be added automatically)
+* Hex digits are case-insensitive.
+
+This method should be called early (before showing notifications) so the value is baked into the registration/shortcut. Supplying an empty string or an unparsable value throws and leaves the existing (or generated) CLSID unchanged. If this method is never called, a random CLSID is generated once per run and exposed via `app.toastActivatorCLSID`.
+
 ### `app.setActivationPolicy(policy)` _macOS_
 
 * `policy` string - Can be 'regular', 'accessory', or 'prohibited'.
@@ -1704,8 +1717,13 @@ platforms) that allows you to perform actions on your app icon in the user's doc
 
 A `boolean` property that returns  `true` if the app is packaged, `false` otherwise. For many apps, this property can be used to distinguish development and production environments.
 
+### `app.toastActivatorCLSID` _Windows_ _Readonly_
+
+A `string` property that returns the app's [Toast Activator CLSID][toast-activator-clsid].
+
 [tasks]:https://learn.microsoft.com/en-us/windows/win32/shell/taskbar-extensions#tasks
 [app-user-model-id]: https://learn.microsoft.com/en-us/windows/win32/shell/appids
+[toast-activator-clsid]: https://learn.microsoft.com/en-us/windows/win32/properties/props-system-appusermodel-toastactivatorclsid
 [electron-forge]: https://www.electronforge.io/
 [electron-packager]: https://github.com/electron/packager
 [CFBundleURLTypes]: https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-102207-TPXREF115

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -67,6 +67,22 @@ Emitted when the notification is shown to the user. Note that this event can be 
 multiple times as a notification can be shown multiple times through the
 `show()` method.
 
+```js
+const { Notification, app } = require('electron')
+
+app.whenReady().then(() => {
+  const n = new Notification({
+    title: 'Title!',
+    subtitle: 'Subtitle!',
+    body: 'Body!'
+  })
+
+  n.on('show', () => console.log('Notification shown!'))
+
+  n.show()
+})
+```
+
 #### Event: 'click'
 
 Returns:
@@ -74,6 +90,22 @@ Returns:
 * `event` Event
 
 Emitted when the notification is clicked by the user.
+
+```js
+const { Notification, app } = require('electron')
+
+app.whenReady().then(() => {
+  const n = new Notification({
+    title: 'Title!',
+    subtitle: 'Subtitle!',
+    body: 'Body!'
+  })
+
+  n.on('click', () => console.log('Notification clicked!'))
+
+  n.show()
+})
+```
 
 #### Event: 'close'
 
@@ -88,21 +120,85 @@ is closed.
 
 On Windows, the `close` event can be emitted in one of three ways: programmatic dismissal with `notification.close()`, by the user closing the notification, or via system timeout. If a notification is in the Action Center after the initial `close` event is emitted, a call to `notification.close()` will remove the notification from the action center but the `close` event will not be emitted again.
 
-#### Event: 'reply' _macOS_
+```js
+const { Notification, app } = require('electron')
+
+app.whenReady().then(() => {
+  const n = new Notification({
+    title: 'Title!',
+    subtitle: 'Subtitle!',
+    body: 'Body!'
+  })
+
+  n.on('close', () => console.log('Notification closed!'))
+
+  n.show()
+})
+```
+
+#### Event: 'reply' _macOS_ _Windows_
 
 Returns:
 
-* `event` Event
-* `reply` string - The string the user entered into the inline reply field.
+* `details` Event\<\>
+  * `reply` string - The string the user entered into the inline reply field.
+* `reply` string _Deprecated_
 
 Emitted when the user clicks the "Reply" button on a notification with `hasReply: true`.
 
-#### Event: 'action' _macOS_
+```js
+const { Notification, app } = require('electron')
+
+app.whenReady().then(() => {
+  const n = new Notification({
+    title: 'Send a Message',
+    body: 'Body Text',
+    hasReply: true,
+    replyPlaceholder: 'Message text...'
+  })
+
+  n.on('reply', (e, reply) => console.log(`User replied: ${reply}`))
+  n.on('click', () => console.log('Notification clicked'))
+
+  n.show()
+})
+```
+
+#### Event: 'action' _macOS_ _Windows_
 
 Returns:
 
-* `event` Event
-* `index` number - The index of the action that was activated.
+* `details` Event\<\>
+  * `actionIndex` number - The index of the action that was activated.
+  * `selectionIndex` number _Windows_ - The index of the selected item, if one was chosen. -1 if none was chosen.
+* `actionIndex` number _Deprecated_
+* `selectionIndex` number _Windows_ _Deprecated_
+
+```js
+const { Notification, app } = require('electron')
+
+app.whenReady().then(() => {
+  const items = ['One', 'Two', 'Three']
+  const n = new Notification({
+    title: 'Choose an Action!',
+    actions: [
+      { type: 'button', text: 'Action 1' },
+      { type: 'button', text: 'Action 2' },
+      { type: 'selection', text: 'Apply', items }
+    ]
+  })
+
+  n.on('click', () => console.log('Notification clicked'))
+  n.on('action', (e) => {
+    console.log(`User triggered action at index: ${e.actionIndex}`)
+    if (e.selectionIndex > -1) {
+      console.log(`User chose selection item '${items[e.selectionIndex]}'`)
+    }
+  })
+
+  n.show()
+})
+```
 
 #### Event: 'failed' _Windows_
 
@@ -112,6 +208,22 @@ Returns:
 * `error` string - The error encountered during execution of the `show()` method.
 
 Emitted when an error is encountered while creating and showing the native notification.
+
+```js
+const { Notification, app } = require('electron')
+
+app.whenReady().then(() => {
+  const n = new Notification({
+    title: 'Bad Action'
+  })
+
+  n.on('failed', (e, err) => {
+    console.log('Notification failed: ', err)
+  })
+
+  n.show()
+})
+```
 
 ### Instance Methods
 
@@ -126,11 +238,41 @@ call this method before the OS will display it.
 If the notification has been shown before, this method will dismiss the previously
 shown notification and create a new one with identical properties.
 
+```js
+const { Notification, app } = require('electron')
+
+app.whenReady().then(() => {
+  const n = new Notification({
+    title: 'Title!',
+    subtitle: 'Subtitle!',
+    body: 'Body!'
+  })
+
+  n.show()
+})
+```
+
 #### `notification.close()`
 
 Dismisses the notification.
 
 On Windows, calling `notification.close()` while the notification is visible on screen will dismiss the notification and remove it from the Action Center. If `notification.close()` is called after the notification is no longer visible on screen, calling `notification.close()` will try remove it from the Action Center.
+
+```js
+const { Notification, app } = require('electron')
+
+app.whenReady().then(() => {
+  const n = new Notification({
+    title: 'Title!',
+    subtitle: 'Subtitle!',
+    body: 'Body!'
+  })
+
+  n.show()
+
+  setTimeout(() => n.close(), 5000)
+})
+```
 
 ### Instance Properties
 

--- a/docs/api/structures/notification-action.md
+++ b/docs/api/structures/notification-action.md
@@ -1,13 +1,15 @@
 # NotificationAction Object
 
-* `type` string - The type of action, can be `button`.
+* `type` string - The type of action, can be `button` or `selection`. `selection` is only supported on Windows.
 * `text` string (optional) - The label for the given action.
+* `items` string[] (optional) _Windows_ - The list of items for the `selection` action `type`.
 
 ## Platform / Action Support
 
 | Action Type | Platform Support | Usage of `text` | Default `text` | Limitations |
 |-------------|------------------|-----------------|----------------|-------------|
-| `button`    | macOS            | Used as the label for the button | "Show" (or a localized string by system default if first of such `button`, otherwise empty) | Only the first one is used. If multiple are provided, those beyond the first will be listed as additional actions (displayed when mouse active over the action button). Any such action also is incompatible with `hasReply` and will be ignored if `hasReply` is `true`. |
+| `button`    | macOS, Windows   | Used as the label for the button | "Show" on macOS (localized) if first `button`, otherwise empty; Windows uses provided `text` | macOS: Only the first one is used as primary; others shown as additional actions (hover). Incompatible with `hasReply` (beyond first ignored). |
+| `selection` | Windows          | Used as the label for the submit button for the selection menu | "Select" | Requires an `items` array property specifying option labels. Emits the `action` event with `(index, selectedIndex)` where `selectedIndex` is the chosen option (>= 0). Ignored on platforms that do not support selection actions. |
 
 ### Button support on macOS
 
@@ -18,3 +20,34 @@ following criteria.
 * App has its `NSUserNotificationAlertStyle` set to `alert` in the `Info.plist`.
 
 If either of these requirements are not met the button won't appear.
+
+### Selection support on Windows
+
+To add a selection (combo box) style action, include an action with `type: 'selection'`, a `text` label for the submit button, and an `items` array of strings:
+
+```js
+const { Notification, app } = require('electron')
+
+app.whenReady().then(() => {
+  const items = ['One', 'Two', 'Three']
+  const n = new Notification({
+    title: 'Choose an option',
+    actions: [{
+      type: 'selection',
+      text: 'Apply',
+      items
+    }]
+  })
+
+  n.on('action', (e) => {
+    console.log(`User triggered action at index: ${e.actionIndex}`)
+    if (e.selectionIndex > 0) {
+      console.log(`User chose selection item '${items[e.selectionIndex]}'`)
+    }
+  })
+
+  n.show()
+})
+```
+
+When the user activates the selection action, the notification's `action` event will be emitted with two parameters: `actionIndex` (the action's index in the `actions` array) and `selectedIndex` (the zero-based index of the chosen item, or `-1` if unavailable). On non-Windows platforms selection actions are ignored.

--- a/filenames.gni
+++ b/filenames.gni
@@ -79,6 +79,8 @@ filenames = {
     "shell/browser/notifications/win/notification_presenter_win.h",
     "shell/browser/notifications/win/windows_toast_notification.cc",
     "shell/browser/notifications/win/windows_toast_notification.h",
+    "shell/browser/notifications/win/windows_toast_activator.cc",
+    "shell/browser/notifications/win/windows_toast_activator.h",
     "shell/browser/relauncher_win.cc",
     "shell/browser/ui/certificate_trust_win.cc",
     "shell/browser/ui/file_dialog_win.cc",

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -88,6 +88,7 @@
 
 #if BUILDFLAG(IS_WIN)
 #include "base/strings/utf_string_conversions.h"
+#include "shell/browser/notifications/win/windows_toast_activator.h"
 #include "shell/browser/ui/win/jump_list.h"
 #endif
 
@@ -1840,6 +1841,10 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
 #if BUILDFLAG(IS_WIN)
       .SetMethod("setAppUserModelId",
                  base::BindRepeating(&Browser::SetAppUserModelID, browser))
+      .SetMethod("setToastActivatorCLSID",
+                 base::BindRepeating(&App::SetToastActivatorCLSID,
+                                     base::Unretained(this)))
+      .SetProperty("toastActivatorCLSID", &App::GetToastActivatorCLSID)
 #endif
       .SetMethod(
           "isDefaultProtocolClient",
@@ -1966,6 +1971,34 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
       .SetMethod("setProxy", &App::SetProxy)
       .SetMethod("resolveProxy", &App::ResolveProxy);
 }
+
+#if BUILDFLAG(IS_WIN)
+void App::SetToastActivatorCLSID(gin_helper::ErrorThrower thrower,
+                                 const std::string& id) {
+  std::wstring wide = base::UTF8ToWide(id);
+  CLSID parsed;
+  if (FAILED(::CLSIDFromString(wide.c_str(), &parsed))) {
+    if (!wide.empty() && wide.front() != L'{') {
+      std::wstring with_braces = L"{" + wide + L"}";
+      if (FAILED(::CLSIDFromString(with_braces.c_str(), &parsed))) {
+        thrower.ThrowError("Invalid CLSID format");
+        return;
+      }
+      wide = std::move(with_braces);
+    } else {
+      thrower.ThrowError("Invalid CLSID format");
+      return;
+    }
+  }
+
+  SetAppToastActivatorCLSID(wide);
+}
+
+v8::Local<v8::Value> App::GetToastActivatorCLSID(v8::Isolate* isolate) {
+  return gin::ConvertToV8(isolate,
+                          base::WideToUTF8(GetAppToastActivatorCLSID()));
+}
+#endif
 
 const char* App::GetHumanReadableName() const {
   return "Electron / App";

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -265,6 +265,12 @@ class App final : public gin::Wrappable<App>,
 
   // Set or remove a custom Jump List for the application.
   JumpListResult SetJumpList(v8::Isolate* isolate, v8::Local<v8::Value> val);
+
+  // Set the toast activator CLSID.
+  void SetToastActivatorCLSID(gin_helper::ErrorThrower thrower,
+                              const std::string& id);
+  // Get the toast activator CLSID.
+  v8::Local<v8::Value> GetToastActivatorCLSID(v8::Isolate* isolate);
 #endif  // BUILDFLAG(IS_WIN)
 
   std::unique_ptr<ProcessSingleton> process_singleton_;

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -31,6 +31,9 @@ struct Converter<electron::NotificationAction> {
       return false;
     }
     dict.Get("text", &(out->text));
+    std::vector<std::u16string> items;
+    if (dict.Get("items", &items))
+      out->items = std::move(items);
     return true;
   }
 
@@ -39,6 +42,9 @@ struct Converter<electron::NotificationAction> {
     auto dict = gin::Dictionary::CreateEmpty(isolate);
     dict.Set("text", val.text);
     dict.Set("type", val.type);
+    if (!val.items.empty()) {
+      dict.Set("items", val.items);
+    }
     return ConvertToV8(isolate, dict);
   }
 };
@@ -138,8 +144,20 @@ void Notification::SetToastXml(const std::u16string& new_toast_xml) {
   toast_xml_ = new_toast_xml;
 }
 
-void Notification::NotificationAction(int index) {
-  Emit("action", index);
+void Notification::NotificationAction(int action_index, int selection_index) {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+
+  gin_helper::internal::Event* event =
+      gin_helper::internal::Event::New(isolate);
+  v8::Local<v8::Object> event_object =
+      event->GetWrapper(isolate).ToLocalChecked();
+
+  gin_helper::Dictionary dict(isolate, event_object);
+  dict.Set("selectionIndex", selection_index);
+  dict.Set("actionIndex", action_index);
+
+  EmitWithoutEvent("action", event_object, action_index, selection_index);
 }
 
 void Notification::NotificationClick() {
@@ -147,7 +165,18 @@ void Notification::NotificationClick() {
 }
 
 void Notification::NotificationReplied(const std::string& reply) {
-  Emit("reply", reply);
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+
+  gin_helper::internal::Event* event =
+      gin_helper::internal::Event::New(isolate);
+  v8::Local<v8::Object> event_object =
+      event->GetWrapper(isolate).ToLocalChecked();
+
+  gin_helper::Dictionary dict(isolate, event_object);
+  dict.Set("reply", reply);
+
+  EmitWithoutEvent("reply", event_object, reply);
 }
 
 void Notification::NotificationDisplayed() {

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -45,7 +45,7 @@ class Notification final : public gin_helper::DeprecatedWrappable<Notification>,
   static const char* GetClassName() { return "Notification"; }
 
   // NotificationDelegate:
-  void NotificationAction(int index) override;
+  void NotificationAction(int action_index, int selection_index) override;
   void NotificationClick() override;
   void NotificationReplied(const std::string& reply) override;
   void NotificationDisplayed() override;

--- a/shell/browser/notifications/mac/cocoa_notification.mm
+++ b/shell/browser/notifications/mac/cocoa_notification.mm
@@ -139,7 +139,7 @@ void CocoaNotification::NotificationReplied(const std::string& reply) {
 
 void CocoaNotification::NotificationActivated() {
   if (delegate())
-    delegate()->NotificationAction(action_index_);
+    delegate()->NotificationAction(action_index_, -1);
 
   this->LogAction("button clicked");
 }
@@ -156,7 +156,7 @@ void CocoaNotification::NotificationActivated(
       }
     }
 
-    delegate()->NotificationAction(index);
+    delegate()->NotificationAction(index, -1);
   }
 
   this->LogAction("button clicked");

--- a/shell/browser/notifications/notification.cc
+++ b/shell/browser/notifications/notification.cc
@@ -22,6 +22,15 @@ NotificationOptions& NotificationOptions::operator=(NotificationOptions&&) =
     default;
 NotificationOptions::~NotificationOptions() = default;
 
+NotificationAction::NotificationAction() = default;
+NotificationAction::~NotificationAction() = default;
+NotificationAction::NotificationAction(const NotificationAction&) = default;
+NotificationAction& NotificationAction::operator=(const NotificationAction&) =
+    default;
+NotificationAction::NotificationAction(NotificationAction&&) noexcept = default;
+NotificationAction& NotificationAction::operator=(
+    NotificationAction&&) noexcept = default;
+
 Notification::Notification(NotificationDelegate* delegate,
                            NotificationPresenter* presenter)
     : delegate_(delegate), presenter_(presenter) {}

--- a/shell/browser/notifications/notification.h
+++ b/shell/browser/notifications/notification.h
@@ -23,6 +23,14 @@ class NotificationPresenter;
 struct NotificationAction {
   std::u16string type;
   std::u16string text;
+  std::vector<std::u16string> items;
+
+  NotificationAction();
+  ~NotificationAction();
+  NotificationAction(const NotificationAction&);
+  NotificationAction& operator=(const NotificationAction&);
+  NotificationAction(NotificationAction&&) noexcept;
+  NotificationAction& operator=(NotificationAction&&) noexcept;
 };
 
 struct NotificationOptions {

--- a/shell/browser/notifications/notification_delegate.h
+++ b/shell/browser/notifications/notification_delegate.h
@@ -19,7 +19,9 @@ class NotificationDelegate {
 
   // Notification was replied to
   virtual void NotificationReplied(const std::string& reply) {}
-  virtual void NotificationAction(int index) {}
+  // |selection_index| is >= 0 only for selection actions (Windows), otherwise
+  // -1.
+  virtual void NotificationAction(int action_index, int selection_index = -1) {}
 
   virtual void NotificationClick() {}
   virtual void NotificationClosed() {}

--- a/shell/browser/notifications/win/notification_presenter_win.cc
+++ b/shell/browser/notifications/win/notification_presenter_win.cc
@@ -16,6 +16,7 @@
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
+#include "shell/browser/notifications/win/windows_toast_activator.h"
 #include "shell/browser/notifications/win/windows_toast_notification.h"
 #include "shell/common/thread_restrictions.h"
 #include "third_party/skia/include/core/SkBitmap.h"
@@ -44,6 +45,9 @@ std::unique_ptr<NotificationPresenter> NotificationPresenter::Create() {
   auto presenter = std::make_unique<NotificationPresenterWin>();
   if (!presenter->Init())
     return {};
+
+  // Ensure COM toast activator is registered once the presenter is ready.
+  NotificationActivator::RegisterActivator();
 
   if (electron::debug_notifications)
     LOG(INFO) << "Successfully created Windows notifications presenter";

--- a/shell/browser/notifications/win/windows_toast_activator.cc
+++ b/shell/browser/notifications/win/windows_toast_activator.cc
@@ -1,0 +1,414 @@
+// Copyright (c) 2025 Microsoft, GmbH
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/notifications/win/windows_toast_activator.h"
+
+#include <propkey.h>
+#include <propvarutil.h>
+#include <shlobj.h>
+#include <shobjidl.h>
+#include <wrl/module.h>
+#ifdef StrCat
+// Undefine Windows shlwapi.h StrCat macro to avoid conflict with
+// base/strings/strcat.h which deliberately defines a StrCat macro sentinel.
+#undef StrCat
+#endif
+
+#include <string>
+#include <vector>
+
+#include <algorithm>
+#include <atomic>
+
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/hash/hash.h"
+#include "base/logging.h"
+#include "base/no_destructor.h"
+#include "base/strings/string_number_conversions_win.h"
+#include "base/strings/string_split.h"
+#include "base/strings/string_util.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/win/registry.h"
+#include "base/win/scoped_propvariant.h"
+#include "base/win/win_util.h"
+#include "content/public/browser/browser_task_traits.h"
+#include "content/public/browser/browser_thread.h"
+#include "shell/browser/api/electron_api_notification.h"  // nogncheck - for delegate events
+#include "shell/browser/electron_browser_client.h"
+#include "shell/browser/notifications/notification.h"
+#include "shell/browser/notifications/notification_delegate.h"
+#include "shell/browser/notifications/notification_presenter.h"
+#include "shell/browser/notifications/win/notification_presenter_win.h"
+#include "shell/common/application_info.h"
+
+namespace electron {
+
+namespace {
+
+class NotificationActivatorFactory final : public IClassFactory {
+ public:
+  NotificationActivatorFactory() : ref_count_(1) {}
+  ~NotificationActivatorFactory() = default;
+  IFACEMETHODIMP QueryInterface(REFIID riid, void** ppv) override {
+    if (!ppv)
+      return E_POINTER;
+    if (riid == IID_IUnknown || riid == IID_IClassFactory) {
+      *ppv = static_cast<IClassFactory*>(this);
+    } else {
+      *ppv = nullptr;
+      return E_NOINTERFACE;
+    }
+    AddRef();
+    return S_OK;
+  }
+  IFACEMETHODIMP_(ULONG) AddRef() override { return ++ref_count_; }
+  IFACEMETHODIMP_(ULONG) Release() override {
+    ULONG res = --ref_count_;
+    if (res == 0)
+      delete this;
+    return res;
+  }
+
+  IFACEMETHODIMP CreateInstance(IUnknown* outer,
+                                REFIID riid,
+                                void** ppv) override {
+    if (outer)
+      return CLASS_E_NOAGGREGATION;
+    auto activator = Microsoft::WRL::Make<NotificationActivator>();
+    return activator.CopyTo(riid, ppv);
+  }
+  IFACEMETHODIMP LockServer(BOOL) override { return S_OK; }
+
+ private:
+  std::atomic<ULONG> ref_count_;
+};
+
+NotificationActivatorFactory* g_factory_instance = nullptr;
+bool g_registration_in_progress = false;
+
+std::wstring GetExecutablePath() {
+  wchar_t path[MAX_PATH];
+  DWORD len = ::GetModuleFileNameW(nullptr, path, std::size(path));
+  if (len == 0 || len == std::size(path))
+    return L"";
+  return std::wstring(path, len);
+}
+
+void EnsureCLSIDRegistry() {
+  std::wstring exe = GetExecutablePath();
+  if (exe.empty())
+    return;
+  std::wstring clsid = GetAppToastActivatorCLSID();
+  std::wstring key_path = L"Software\\Classes\\CLSID\\" + clsid;
+  base::win::RegKey key(HKEY_CURRENT_USER, key_path.c_str(), KEY_SET_VALUE);
+  if (!key.Valid())
+    return;
+  key.WriteValue(nullptr, L"Electron Notification Activator");
+  key.WriteValue(L"CustomActivator", 1U);
+
+  std::wstring local_server = key_path + L"\\LocalServer32";
+  base::win::RegKey server_key(HKEY_CURRENT_USER, local_server.c_str(),
+                               KEY_SET_VALUE);
+  if (!server_key.Valid())
+    return;
+  server_key.WriteValue(nullptr, exe.c_str());
+}
+
+bool ExistingShortcutValid(const base::FilePath& lnk_path, PCWSTR aumid) {
+  if (!base::PathExists(lnk_path))
+    return false;
+  Microsoft::WRL::ComPtr<IShellLink> existing;
+  if (FAILED(CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER,
+                              IID_PPV_ARGS(&existing))))
+    return false;
+  Microsoft::WRL::ComPtr<IPersistFile> pf;
+  if (FAILED(existing.As(&pf)) ||
+      FAILED(pf->Load(lnk_path.value().c_str(), STGM_READ))) {
+    return false;
+  }
+  Microsoft::WRL::ComPtr<IPropertyStore> store;
+  if (FAILED(existing.As(&store)))
+    return false;
+  base::win::ScopedPropVariant pv_id;
+  base::win::ScopedPropVariant pv_clsid;
+  if (FAILED(store->GetValue(PKEY_AppUserModel_ID, pv_id.Receive())) ||
+      FAILED(store->GetValue(PKEY_AppUserModel_ToastActivatorCLSID,
+                             pv_clsid.Receive()))) {
+    return false;
+  }
+  if (pv_id.get().vt == VT_LPWSTR && pv_clsid.get().vt == VT_CLSID &&
+      pv_id.get().pwszVal && pv_clsid.get().puuid) {
+    CLSID desired;
+    if (SUCCEEDED(::CLSIDFromString(GetAppToastActivatorCLSID(), &desired))) {
+      return _wcsicmp(pv_id.get().pwszVal, aumid) == 0 &&
+             IsEqualGUID(*pv_clsid.get().puuid, desired);
+    }
+  }
+  return false;
+}
+
+void EnsureShortcut() {
+  PCWSTR aumid = GetRawAppUserModelID();
+  if (!aumid || !*aumid)
+    return;
+
+  std::wstring exe = GetExecutablePath();
+  if (exe.empty())
+    return;
+
+  PWSTR programs_path = nullptr;
+  if (FAILED(
+          SHGetKnownFolderPath(FOLDERID_Programs, 0, nullptr, &programs_path)))
+    return;
+  base::FilePath programs(programs_path);
+  CoTaskMemFree(programs_path);
+
+  std::wstring product_name = base::UTF8ToWide(GetApplicationName());
+  if (product_name.empty())
+    product_name = L"ElectronApp";
+  base::CreateDirectory(programs);
+  base::FilePath lnk_path = programs.Append(product_name + L".lnk");
+  if (base::PathExists(lnk_path)) {
+    Microsoft::WRL::ComPtr<IShellLink> existing;
+    if (SUCCEEDED(CoCreateInstance(CLSID_ShellLink, nullptr,
+                                   CLSCTX_INPROC_SERVER,
+                                   IID_PPV_ARGS(&existing)))) {
+      Microsoft::WRL::ComPtr<IPersistFile> pf;
+      if (SUCCEEDED(existing.As(&pf)) &&
+          SUCCEEDED(pf->Load(lnk_path.value().c_str(), STGM_READ))) {
+        Microsoft::WRL::ComPtr<IPropertyStore> store;
+        if (SUCCEEDED(existing.As(&store))) {
+          base::win::ScopedPropVariant pv_clsid;
+          if (SUCCEEDED(store->GetValue(PKEY_AppUserModel_ToastActivatorCLSID,
+                                        pv_clsid.Receive())) &&
+              pv_clsid.get().vt == VT_CLSID && pv_clsid.get().puuid) {
+            wchar_t buf[64] = {0};
+            if (StringFromGUID2(*pv_clsid.get().puuid, buf, std::size(buf)) >
+                0) {
+              SetAppToastActivatorCLSID(buf);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (ExistingShortcutValid(lnk_path, aumid))
+    return;
+
+  Microsoft::WRL::ComPtr<IShellLink> shell_link;
+  if (FAILED(CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER,
+                              IID_PPV_ARGS(&shell_link))))
+    return;
+  shell_link->SetPath(exe.c_str());
+  shell_link->SetArguments(L"");
+  shell_link->SetDescription(product_name.c_str());
+  shell_link->SetWorkingDirectory(
+      base::FilePath(exe).DirName().value().c_str());
+
+  Microsoft::WRL::ComPtr<IPropertyStore> prop_store;
+  if (SUCCEEDED(shell_link.As(&prop_store))) {
+    PROPVARIANT pv_id;
+    PropVariantInit(&pv_id);
+    if (SUCCEEDED(InitPropVariantFromString(aumid, &pv_id))) {
+      prop_store->SetValue(PKEY_AppUserModel_ID, pv_id);
+      PropVariantClear(&pv_id);
+    }
+    PROPVARIANT pv_clsid;
+    PropVariantInit(&pv_clsid);
+    GUID clsid;
+    if (SUCCEEDED(::CLSIDFromString(GetAppToastActivatorCLSID(), &clsid)) &&
+        SUCCEEDED(InitPropVariantFromCLSID(clsid, &pv_clsid))) {
+      prop_store->SetValue(PKEY_AppUserModel_ToastActivatorCLSID, pv_clsid);
+      PropVariantClear(&pv_clsid);
+    }
+    prop_store->Commit();
+  }
+
+  Microsoft::WRL::ComPtr<IPersistFile> persist_file;
+  if (SUCCEEDED(shell_link.As(&persist_file))) {
+    persist_file->Save(lnk_path.value().c_str(), TRUE);
+  }
+}
+
+}  // namespace
+
+DWORD NotificationActivator::g_cookie_ = 0;
+bool NotificationActivator::g_registered_ = false;
+
+NotificationActivator::NotificationActivator() = default;
+NotificationActivator::~NotificationActivator() = default;
+
+// static
+
+// static
+void NotificationActivator::RegisterActivator() {
+  if (g_registered_ || g_registration_in_progress)
+    return;
+  g_registration_in_progress = true;
+
+  // Perform all blocking filesystem / registry work off the UI thread.
+  base::ThreadPool::PostTask(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::BEST_EFFORT},
+      base::BindOnce([]() {
+        EnsureShortcut();
+        EnsureCLSIDRegistry();
+        content::GetUIThreadTaskRunner({})->PostTask(
+            FROM_HERE, base::BindOnce([]() {
+              g_registration_in_progress = false;
+              if (g_registered_)
+                return;
+              CLSID clsid;
+              if (FAILED(
+                      ::CLSIDFromString(GetAppToastActivatorCLSID(), &clsid))) {
+                LOG(ERROR) << "Invalid toast activator CLSID";
+                return;
+              }
+              if (!g_factory_instance)
+                g_factory_instance =
+                    new (std::nothrow) NotificationActivatorFactory();
+              if (!g_factory_instance)
+                return;
+              DWORD cookie = 0;
+              HRESULT hr = ::CoRegisterClassObject(
+                  clsid, static_cast<IClassFactory*>(g_factory_instance),
+                  CLSCTX_LOCAL_SERVER, REGCLS_MULTIPLEUSE | REGCLS_SUSPENDED,
+                  &cookie);
+              if (FAILED(hr))
+                return;
+              hr = ::CoResumeClassObjects();
+              if (FAILED(hr)) {
+                ::CoRevokeClassObject(cookie);
+                return;
+              }
+              g_cookie_ = cookie;
+              g_registered_ = true;
+            }));
+      }));
+}
+
+// static
+void NotificationActivator::UnregisterActivator() {
+  if (!g_registered_)
+    return;
+  ::CoRevokeClassObject(g_cookie_);
+  g_cookie_ = 0;
+  g_registered_ = false;
+  // Factory instance lifetime intentionally leaked after revoke to avoid
+  // race; could be deleted here if ensured no pending COM calls.
+}
+
+IFACEMETHODIMP NotificationActivator::Activate(
+    LPCWSTR app_user_model_id,
+    LPCWSTR invoked_args,
+    const NOTIFICATION_USER_INPUT_DATA* data,
+    ULONG data_count) {
+  std::wstring args = invoked_args ? invoked_args : L"";
+  std::wstring aumid = app_user_model_id ? app_user_model_id : L"";
+
+  std::vector<ActivationUserInput> copied_inputs;
+  if (data && data_count) {
+    std::vector<NOTIFICATION_USER_INPUT_DATA> temp;
+    temp.resize(static_cast<size_t>(data_count));
+    std::copy_n(data, static_cast<size_t>(data_count), temp.begin());
+    copied_inputs.reserve(temp.size());
+    for (const auto& entry : temp) {
+      ActivationUserInput ui;
+      if (entry.Key)
+        ui.key = entry.Key;
+      if (entry.Value)
+        ui.value = entry.Value;
+      copied_inputs.push_back(std::move(ui));
+    }
+  }
+
+  content::GetUIThreadTaskRunner({})->PostTask(
+      FROM_HERE, base::BindOnce(&HandleToastActivation, std::move(args),
+                                std::move(copied_inputs)));
+  return S_OK;
+}
+
+void HandleToastActivation(const std::wstring& invoked_args,
+                           std::vector<ActivationUserInput> inputs) {
+  // Expected invoked_args format:
+  // type=<click|action|reply>&action=<index>&tag=<hash> Parse simple key=value
+  // pairs separated by '&'.
+  std::wstring args = invoked_args;
+  std::wstring type;
+  std::wstring action_index_str;
+  std::wstring tag_str;
+
+  for (const auto& token : base::SplitString(args, L"&", base::KEEP_WHITESPACE,
+                                             base::SPLIT_WANT_NONEMPTY)) {
+    auto kv = base::SplitString(token, L"=", base::KEEP_WHITESPACE,
+                                base::SPLIT_WANT_NONEMPTY);
+    if (kv.size() != 2)
+      continue;
+    if (kv[0] == L"type")
+      type = kv[1];
+    else if (kv[0] == L"action")
+      action_index_str = kv[1];
+    else if (kv[0] == L"tag")
+      tag_str = kv[1];
+  }
+
+  int action_index = -1;
+  if (!action_index_str.empty()) {
+    action_index = std::stoi(action_index_str);
+  }
+
+  std::string reply_text;
+  for (const auto& entry : inputs) {
+    std::wstring_view key_view(entry.key);
+    if (key_view == L"reply") {
+      reply_text = base::WideToUTF8(entry.value);
+    }
+  }
+
+  auto* browser_client =
+      static_cast<ElectronBrowserClient*>(ElectronBrowserClient::Get());
+  if (!browser_client)
+    return;
+
+  NotificationPresenter* presenter = browser_client->GetNotificationPresenter();
+  if (!presenter)
+    return;
+
+  Notification* target = nullptr;
+  for (auto* n : presenter->notifications()) {
+    std::wstring tag_hash =
+        base::NumberToWString(base::FastHash(n->notification_id()));
+    if (tag_hash == tag_str) {
+      target = n;
+      break;
+    }
+  }
+
+  if (!target)
+    return;
+
+  if (type == L"action" && target->delegate()) {
+    int selection_index = -1;
+    for (const auto& entry : inputs) {
+      std::wstring_view key_view(entry.key);
+      if (base::StartsWith(key_view, L"selection",
+                           base::CompareCase::SENSITIVE)) {
+        int parsed = -1;
+        if (base::StringToInt(entry.value, &parsed) && parsed >= 0)
+          selection_index = parsed;
+        break;
+      }
+    }
+    if (action_index >= 0)
+      target->delegate()->NotificationAction(action_index, selection_index);
+  } else if ((type == L"reply" || (!reply_text.empty() && type.empty())) &&
+             target->delegate()) {
+    target->delegate()->NotificationReplied(reply_text);
+  } else if ((type == L"click" || type.empty()) && target->delegate()) {
+    target->NotificationClicked();
+  }
+}
+
+}  // namespace electron

--- a/shell/browser/notifications/win/windows_toast_activator.h
+++ b/shell/browser/notifications/win/windows_toast_activator.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 Microsoft, GmbH
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_BROWSER_NOTIFICATIONS_WIN_WINDOWS_TOAST_ACTIVATOR_H_
+#define ELECTRON_SHELL_BROWSER_NOTIFICATIONS_WIN_WINDOWS_TOAST_ACTIVATOR_H_
+
+#include <NotificationActivationCallback.h>
+#include <windows.h>
+#include <wrl/implements.h>
+#include <string>
+#include <vector>
+
+namespace electron {
+
+class NotificationPresenterWin;
+
+class NotificationActivator
+    : public Microsoft::WRL::RuntimeClass<
+          Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>,
+          INotificationActivationCallback> {
+ public:
+  NotificationActivator();
+  ~NotificationActivator() override;
+
+  IFACEMETHODIMP Activate(LPCWSTR app_user_model_id,
+                          LPCWSTR invoked_args,
+                          const NOTIFICATION_USER_INPUT_DATA* data,
+                          ULONG data_count) override;
+
+  static void RegisterActivator();
+  static void UnregisterActivator();
+
+ private:
+  static DWORD g_cookie_;
+  static bool g_registered_;
+};
+
+struct ActivationUserInput {
+  std::wstring key;
+  std::wstring value;
+};
+
+void HandleToastActivation(const std::wstring& invoked_args,
+                           std::vector<ActivationUserInput> inputs);
+
+}  // namespace electron
+
+#endif  // ELECTRON_SHELL_BROWSER_NOTIFICATIONS_WIN_WINDOWS_TOAST_ACTIVATOR_H_

--- a/shell/browser/notifications/win/windows_toast_notification.h
+++ b/shell/browser/notifications/win/windows_toast_notification.h
@@ -60,11 +60,16 @@ class WindowsToastNotification : public Notification {
   friend class ToastEventHandler;
 
   HRESULT ShowInternal(const NotificationOptions& options);
-  static std::u16string GetToastXml(const std::u16string& title,
-                                    const std::u16string& msg,
-                                    const std::wstring& icon_path,
-                                    const std::u16string& timeout_type,
-                                    const bool silent);
+  static std::u16string GetToastXml(
+      const std::string& notification_id,
+      const std::u16string& title,
+      const std::u16string& msg,
+      const std::wstring& icon_path,
+      const std::u16string& timeout_type,
+      const bool silent,
+      const std::vector<NotificationAction>& actions,
+      bool has_reply,
+      const std::u16string& reply_placeholder);
   static HRESULT XmlDocumentFromString(
       const wchar_t* xmlString,
       ABI::Windows::Data::Xml::Dom::IXmlDocument** doc);
@@ -77,6 +82,7 @@ class WindowsToastNotification : public Notification {
   static bool CreateToastXmlDocument(
       const NotificationOptions& options,
       NotificationPresenter* presenter,
+      const std::string& notification_id,
       base::WeakPtr<Notification> weak_notification,
       scoped_refptr<base::SingleThreadTaskRunner> ui_task_runner,
       ComPtr<ABI::Windows::Data::Xml::Dom::IXmlDocument>* toast_xml);

--- a/shell/common/application_info.h
+++ b/shell/common/application_info.h
@@ -32,6 +32,8 @@ PCWSTR GetRawAppUserModelID();
 bool GetAppUserModelID(ScopedHString* app_id);
 void SetAppUserModelID(const std::wstring& name);
 bool IsRunningInDesktopBridge();
+PCWSTR GetAppToastActivatorCLSID();
+void SetAppToastActivatorCLSID(const std::wstring& clsid);
 #endif
 
 }  // namespace electron

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -155,6 +155,14 @@ describe('app module', () => {
     });
   });
 
+  ifdescribe(process.platform === 'win32')('app.setToastActivatorCLSID()', () => {
+    it('throws on invalid format', () => {
+      expect(() => {
+        app.setToastActivatorCLSID('1234567890');
+      }).to.throw(/Invalid CLSID format/);
+    });
+  });
+
   describe('app.isPackaged', () => {
     it('should be false during tests', () => {
       expect(app.isPackaged).to.equal(false);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/47722
Closes https://github.com/electron/electron/issues/24524

Extends actions support for Windows Toasts to include buttons, dropdowns, and replies.

TODO:
 - [x] Allow devs to set toast activator CLSID
 - [x] Test selection action functionality
 - [x] Test button action functionality
 - [x] Test reply functionality
 - [x] Update Documentation
 - [x] Localize reply button

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Extended actions support for Windows notifications to include buttons, select dropdowns, and replies.
