### PR TITLE
build: use new 7z command line switch

### DIFF
--- a/.github/actions/restore-cache-azcopy/action.yml
+++ b/.github/actions/restore-cache-azcopy/action.yml
@@ -97,7 +97,7 @@ runs:
 
       $TEMP_DIR=New-Item -ItemType Directory -Path temp-cache
       $TEMP_DIR_PATH = $TEMP_DIR.FullName
-      C:\ProgramData\Chocolatey\bin\7z.exe -y -snld x $src_cache -o"$TEMP_DIR_PATH"
+      C:\ProgramData\Chocolatey\bin\7z.exe -y -snld20 x $src_cache -o"$TEMP_DIR_PATH"
 
   - name: Move Src Cache (Windows)
     if: ${{ inputs.target-platform == 'win' }}


### PR DESCRIPTION
#### Description of Change
Our Github Actions Windows runners were recently updated to https://github.com/actions/runner/releases/tag/v2.328.0.  This ended up pulling in a newer version of 7zip which has changed the flag we use from `-snld` to `-snld20`: https://github.com/ip7z/7zip/releases/tag/25.01
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
