### PR TITLE
feat: add `fileBacked` and `purgeable` fields to `process.getSystemMemoryInfo()` for macOS

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -211,6 +211,10 @@ Returns `Object`:
   system.
 * `free` Integer - The total amount of memory not being used by applications or disk
   cache.
+* `fileBacked` Integer _macOS_ - The amount of memory that currently has been paged out to storage.
+  Includes memory for file caches, network buffers, and other system services.
+* `purgeable` Integer _macOS_ - The amount of memory that is marked as "purgeable". The system can reclaim it
+  if memory pressure increases.
 * `swapTotal` Integer _Windows_ _Linux_ - The total amount of swap memory in Kilobytes available to the
   system.
 * `swapFree` Integer _Windows_ _Linux_ - The free amount of swap memory in Kilobytes available to the

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -184,8 +184,11 @@ v8::Local<v8::Value> ElectronBindings::GetSystemMemoryInfo(
 #endif
   dict.Set("free", free);
 
+#if BUILDFLAG(IS_MAC)
+  dict.Set("fileBacked", mem_info.file_backed);
+  dict.Set("purgeable", mem_info.purgeable);
+#else
   // NB: These return bogus values on macOS
-#if !BUILDFLAG(IS_MAC)
   dict.Set("swapTotal", mem_info.swap_total);
   dict.Set("swapFree", mem_info.swap_free);
 #endif


### PR DESCRIPTION
Backport of #47628 

See that PR for details.

Notes: Added `fileBacked` and `purgeable` fields to `process.getSystemMemoryInfo()` for macOS.