### PR TITLE
refactor: allocate gin_helper::internal::Event on cpp heap

### DIFF
--- a/patches/chromium/chore_add_electron_objects_to_wrappablepointertag.patch
+++ b/patches/chromium/chore_add_electron_objects_to_wrappablepointertag.patch
@@ -8,17 +8,18 @@ electron objects that extend gin::Wrappable and gets
 allocated on the cpp heap
 
 diff --git a/gin/public/wrappable_pointer_tags.h b/gin/public/wrappable_pointer_tags.h
-index a507d1d837ab3ec2b2d3ae7978d9d410ab2ec2d1..5a69c5c7c5ed0e834e09ff3a2d0f0126ba4ccf99 100644
+index a507d1d837ab3ec2b2d3ae7978d9d410ab2ec2d1..2f4b90949972c3c4641bc9e489bd0c73c2f0a981 100644
 --- a/gin/public/wrappable_pointer_tags.h
 +++ b/gin/public/wrappable_pointer_tags.h
-@@ -72,7 +72,9 @@ enum WrappablePointerTag : uint16_t {
+@@ -72,7 +72,10 @@ enum WrappablePointerTag : uint16_t {
    kTextInputControllerBindings,  // content::TextInputControllerBindings
    kWebAXObjectProxy,             // content::WebAXObjectProxy
    kWrappedExceptionHandler,      // extensions::WrappedExceptionHandler
 -  kLastPointerTag = kWrappedExceptionHandler,
 +  kElectronApp,                  // electron::api::App
 +  kElectronSession,              // electron::api::Session
-+  kLastPointerTag = kElectronSession,
++  kElectronEvent,                // gin_helper::internal::Event
++  kLastPointerTag = kElectronEvent,
  };
  
  static_assert(kLastPointerTag <

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -194,14 +194,15 @@ void BaseWindow::OnWindowQueryEndSession(
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
 
-  gin_helper::Handle<gin_helper::internal::Event> event =
+  gin_helper::internal::Event* event =
       gin_helper::internal::Event::New(isolate);
-  v8::Local<v8::Object> event_object = event.ToV8().As<v8::Object>();
+  v8::Local<v8::Object> event_object =
+      event->GetWrapper(isolate).ToLocalChecked();
 
   gin::Dictionary dict(isolate, event_object);
   dict.Set("reasons", reasons);
 
-  EmitWithoutEvent("query-session-end", event);
+  EmitWithoutEvent("query-session-end", event_object);
   if (event->GetDefaultPrevented()) {
     *prevent_default = true;
   }
@@ -211,14 +212,15 @@ void BaseWindow::OnWindowEndSession(const std::vector<std::string>& reasons) {
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
 
-  gin_helper::Handle<gin_helper::internal::Event> event =
+  gin_helper::internal::Event* event =
       gin_helper::internal::Event::New(isolate);
-  v8::Local<v8::Object> event_object = event.ToV8().As<v8::Object>();
+  v8::Local<v8::Object> event_object =
+      event->GetWrapper(isolate).ToLocalChecked();
 
   gin::Dictionary dict(isolate, event_object);
   dict.Set("reasons", reasons);
 
-  EmitWithoutEvent("session-end", event);
+  EmitWithoutEvent("session-end", event_object);
 }
 
 void BaseWindow::OnWindowBlur() {

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1117,9 +1117,10 @@ void WebContents::OnDidAddMessageToConsole(
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
 
-  gin_helper::Handle<gin_helper::internal::Event> event =
+  gin_helper::internal::Event* event =
       gin_helper::internal::Event::New(isolate);
-  v8::Local<v8::Object> event_object = event.ToV8().As<v8::Object>();
+  v8::Local<v8::Object> event_object =
+      event->GetWrapper(isolate).ToLocalChecked();
 
   gin_helper::Dictionary dict(isolate, event_object);
   dict.SetGetter("frame", source_frame);
@@ -1131,7 +1132,7 @@ void WebContents::OnDidAddMessageToConsole(
   // TODO(samuelmaddock): Delete when deprecated arguments are fully removed.
   dict.Set("_level", static_cast<int32_t>(level));
 
-  EmitWithoutEvent("-console-message", event);
+  EmitWithoutEvent("-console-message", event_object);
 }
 
 void WebContents::OnCreateWindow(
@@ -1515,9 +1516,10 @@ void WebContents::RendererUnresponsive(
     base::RepeatingClosure hang_monitor_restarter) {
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
-  gin_helper::Handle<gin_helper::internal::Event> event =
+  gin_helper::internal::Event* event =
       gin_helper::internal::Event::New(isolate);
-  v8::Local<v8::Object> event_object = event.ToV8().As<v8::Object>();
+  v8::Local<v8::Object> event_object =
+      event->GetWrapper(isolate).ToLocalChecked();
   gin::Dictionary dict(isolate, event_object);
 
   auto* web_contents_impl = static_cast<content::WebContentsImpl*>(source);
@@ -1531,7 +1533,7 @@ void WebContents::RendererUnresponsive(
       static_cast<content::RenderWidgetHostImpl*>(render_widget_host);
   dict.Set("rendererInitialized", rwh_impl->renderer_initialized());
 
-  EmitWithoutEvent("-unresponsive", event);
+  EmitWithoutEvent("-unresponsive", event_object);
 }
 
 void WebContents::RendererResponsive(
@@ -1700,12 +1702,13 @@ content::JavaScriptDialogManager* WebContents::GetJavaScriptDialogManager(
 void WebContents::OnAudioStateChanged(bool audible) {
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
-  gin_helper::Handle<gin_helper::internal::Event> event =
+  gin_helper::internal::Event* event =
       gin_helper::internal::Event::New(isolate);
-  v8::Local<v8::Object> event_object = event.ToV8().As<v8::Object>();
+  v8::Local<v8::Object> event_object =
+      event->GetWrapper(isolate).ToLocalChecked();
   gin::Dictionary dict(isolate, event_object);
   dict.Set("audible", audible);
-  EmitWithoutEvent("audio-state-changed", event);
+  EmitWithoutEvent("audio-state-changed", event_object);
 }
 
 void WebContents::BeforeUnloadFired(bool proceed) {
@@ -1968,9 +1971,10 @@ bool WebContents::EmitNavigationEvent(
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
 
-  gin_helper::Handle<gin_helper::internal::Event> event =
+  gin_helper::internal::Event* event =
       gin_helper::internal::Event::New(isolate);
-  v8::Local<v8::Object> event_object = event.ToV8().As<v8::Object>();
+  v8::Local<v8::Object> event_object =
+      event->GetWrapper(isolate).ToLocalChecked();
 
   gin_helper::Dictionary dict(isolate, event_object);
   dict.Set("url", url);
@@ -1981,8 +1985,8 @@ bool WebContents::EmitNavigationEvent(
   dict.SetGetter("frame", frame_host);
   dict.SetGetter("initiator", initiator_frame_host);
 
-  EmitWithoutEvent(event_name, event, url, is_same_document, is_main_frame,
-                   frame_process_id, frame_routing_id);
+  EmitWithoutEvent(event_name, event_object, url, is_same_document,
+                   is_main_frame, frame_process_id, frame_routing_id);
   return event->GetDefaultPrevented();
 }
 
@@ -3632,16 +3636,17 @@ void WebContents::OnPaint(const gfx::Rect& dirty_rect,
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
 
-  gin_helper::Handle<gin_helper::internal::Event> event =
+  gin_helper::internal::Event* event =
       gin_helper::internal::Event::New(isolate);
-  v8::Local<v8::Object> event_object = event.ToV8().As<v8::Object>();
+  v8::Local<v8::Object> event_object =
+      event->GetWrapper(isolate).ToLocalChecked();
   gin_helper::Dictionary dict(isolate, event_object);
 
   if (offscreen_use_shared_texture_) {
     dict.Set("texture", tex);
   }
 
-  EmitWithoutEvent("paint", event, dirty_rect,
+  EmitWithoutEvent("paint", event_object, dirty_rect,
                    gfx::Image::CreateFrom1xBitmap(bitmap));
 }
 

--- a/shell/browser/api/ipc_dispatcher.h
+++ b/shell/browser/api/ipc_dispatcher.h
@@ -18,6 +18,7 @@
 #include "shell/common/gin_helper/handle.h"
 #include "shell/common/gin_helper/reply_channel.h"
 #include "shell/common/v8_util.h"
+#include "v8/include/cppgc/macros.h"
 
 namespace electron {
 
@@ -25,15 +26,17 @@ namespace electron {
 // See ipc-dispatch.ts for JS listeners.
 template <typename T>
 class IpcDispatcher {
+  CPPGC_DISALLOW_NEW();
+
  public:
-  void Message(gin_helper::Handle<gin_helper::internal::Event>& event,
+  void Message(v8::Local<v8::Object> event,
                const std::string& channel,
                blink::CloneableMessage args) {
     TRACE_EVENT1("electron", "IpcDispatcher::Message", "channel", channel);
     emitter()->EmitWithoutEvent("-ipc-message", event, channel, args);
   }
 
-  void Invoke(gin_helper::Handle<gin_helper::internal::Event>& event,
+  void Invoke(v8::Local<v8::Object> event,
               const std::string& channel,
               blink::CloneableMessage arguments) {
     TRACE_EVENT1("electron", "IpcDispatcher::Invoke", "channel", channel);
@@ -41,10 +44,9 @@ class IpcDispatcher {
                                 std::move(arguments));
   }
 
-  void ReceivePostMessage(
-      gin_helper::Handle<gin_helper::internal::Event>& event,
-      const std::string& channel,
-      blink::TransferableMessage message) {
+  void ReceivePostMessage(v8::Local<v8::Object> event,
+                          const std::string& channel,
+                          blink::TransferableMessage message) {
     TRACE_EVENT1("electron", "IpcDispatcher::ReceivePostMessage", "channel",
                  channel);
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
@@ -57,7 +59,7 @@ class IpcDispatcher {
                                 std::move(wrapped_ports));
   }
 
-  void MessageSync(gin_helper::Handle<gin_helper::internal::Event>& event,
+  void MessageSync(v8::Local<v8::Object> event,
                    const std::string& channel,
                    blink::CloneableMessage arguments) {
     TRACE_EVENT1("electron", "IpcDispatcher::MessageSync", "channel", channel);
@@ -65,7 +67,7 @@ class IpcDispatcher {
                                 std::move(arguments));
   }
 
-  void MessageHost(gin_helper::Handle<gin_helper::internal::Event>& event,
+  void MessageHost(v8::Local<v8::Object> event,
                    const std::string& channel,
                    blink::CloneableMessage arguments) {
     TRACE_EVENT1("electron", "IpcDispatcher::MessageHost", "channel", channel);

--- a/shell/browser/electron_api_ipc_handler_impl.h
+++ b/shell/browser/electron_api_ipc_handler_impl.h
@@ -72,7 +72,7 @@ class ElectronApiIPCHandlerImpl : public mojom::ElectronApiIPC,
   content::RenderFrameHost* GetRenderFrameHost();
   gin::WeakCell<api::Session>* GetSession();
 
-  gin_helper::Handle<gin_helper::internal::Event> MakeIPCEvent(
+  gin_helper::internal::Event* MakeIPCEvent(
       v8::Isolate* isolate,
       api::Session* session,
       bool internal,

--- a/shell/browser/electron_api_sw_ipc_handler_impl.h
+++ b/shell/browser/electron_api_sw_ipc_handler_impl.h
@@ -13,7 +13,6 @@
 #include "electron/shell/common/api/api.mojom.h"
 #include "mojo/public/cpp/bindings/associated_receiver.h"
 #include "shell/common/gin_helper/event.h"
-#include "shell/common/gin_helper/handle.h"
 
 namespace content {
 class RenderProcessHost;
@@ -75,7 +74,7 @@ class ElectronApiSWIPCHandlerImpl : public mojom::ElectronApiIPC,
   ElectronBrowserContext* GetBrowserContext();
   gin::WeakCell<api::Session>* GetSession();
 
-  gin_helper::Handle<gin_helper::internal::Event> MakeIPCEvent(
+  gin_helper::internal::Event* MakeIPCEvent(
       v8::Isolate* isolate,
       api::Session* session,
       bool internal,

--- a/shell/browser/electron_crypto_module_delegate_nss.cc
+++ b/shell/browser/electron_crypto_module_delegate_nss.cc
@@ -48,9 +48,10 @@ void ElectronNSSCryptoModuleDelegate::RequestPasswordOnUIThread(
   v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
 
-  gin_helper::Handle<gin_helper::internal::Event> event =
+  gin_helper::internal::Event* event =
       gin_helper::internal::Event::New(isolate);
-  v8::Local<v8::Object> event_object = event.ToV8().As<v8::Object>();
+  v8::Local<v8::Object> event_object =
+      event->GetWrapper(isolate).ToLocalChecked();
   gin_helper::Dictionary dict(isolate, event_object);
   dict.Set("hostname", server_.host());
   dict.Set("tokenName", token_name);

--- a/shell/browser/event_emitter_mixin.h
+++ b/shell/browser/event_emitter_mixin.h
@@ -32,8 +32,10 @@ class EventEmitterMixin {
     v8::Local<v8::Object> wrapper;
     if (!static_cast<T*>(this)->GetWrapper(isolate).ToLocal(&wrapper))
       return false;
-    gin_helper::Handle<internal::Event> event = internal::Event::New(isolate);
-    gin_helper::EmitEvent(isolate, wrapper, name, event,
+    internal::Event* event = internal::Event::New(isolate);
+    v8::Local<v8::Object> event_object =
+        event->GetWrapper(isolate).ToLocalChecked();
+    gin_helper::EmitEvent(isolate, wrapper, name, event_object,
                           std::forward<Args>(args)...);
     return event->GetDefaultPrevented();
   }

--- a/shell/common/gin_helper/event.cc
+++ b/shell/common/gin_helper/event.cc
@@ -3,21 +3,24 @@
 // found in the LICENSE file.
 
 #include "shell/common/gin_helper/event.h"
-#include "gin/dictionary.h"
+
 #include "gin/object_template_builder.h"
-#include "shell/common/gin_helper/handle.h"
+#include "v8/include/cppgc/allocation.h"
+#include "v8/include/v8-cppgc.h"
 
 namespace gin_helper::internal {
 
 // static
-gin_helper::Handle<Event> Event::New(v8::Isolate* isolate) {
-  return gin_helper::CreateHandle(isolate, new Event());
+Event* Event::New(v8::Isolate* isolate) {
+  auto* event = cppgc::MakeGarbageCollected<Event>(
+      isolate->GetCppHeap()->GetAllocationHandle());
+  return event;
 }
 // static
 v8::Local<v8::ObjectTemplate> Event::FillObjectTemplate(
     v8::Isolate* isolate,
     v8::Local<v8::ObjectTemplate> templ) {
-  return gin::ObjectTemplateBuilder(isolate, "Event", templ)
+  return gin::ObjectTemplateBuilder(isolate, GetClassName(), templ)
       .SetMethod("preventDefault", &Event::PreventDefault)
       .SetProperty("defaultPrevented", &Event::GetDefaultPrevented)
       .Build();
@@ -27,10 +30,15 @@ Event::Event() = default;
 
 Event::~Event() = default;
 
-gin::DeprecatedWrapperInfo Event::kWrapperInfo = {gin::kEmbedderNativeGin};
+gin::WrapperInfo Event::kWrapperInfo = {{gin::kEmbedderNativeGin},
+                                        gin::kElectronEvent};
 
-const char* Event::GetTypeName() {
-  return GetClassName();
+const gin::WrapperInfo* Event::wrapper_info() const {
+  return &kWrapperInfo;
+}
+
+const char* Event::GetHumanReadableName() const {
+  return "Electron / Event";
 }
 
 }  // namespace gin_helper::internal

--- a/shell/common/gin_helper/event.h
+++ b/shell/common/gin_helper/event.h
@@ -5,38 +5,27 @@
 #ifndef ELECTRON_SHELL_COMMON_GIN_HELPER_EVENT_H_
 #define ELECTRON_SHELL_COMMON_GIN_HELPER_EVENT_H_
 
+#include "gin/wrappable.h"
 #include "shell/common/gin_helper/constructible.h"
-#include "shell/common/gin_helper/wrappable.h"
-
-namespace gin_helper {
-template <typename T>
-class Handle;
-}  // namespace gin_helper
-
-namespace v8 {
-class Isolate;
-template <typename T>
-class Local;
-class Object;
-class ObjectTemplate;
-}  // namespace v8
 
 namespace gin_helper::internal {
 
-class Event final : public gin_helper::DeprecatedWrappable<Event>,
+class Event final : public gin::Wrappable<Event>,
                     public gin_helper::Constructible<Event> {
  public:
   // gin_helper::Constructible
-  static gin_helper::Handle<Event> New(v8::Isolate* isolate);
+  static Event* New(v8::Isolate* isolate);
   static v8::Local<v8::ObjectTemplate> FillObjectTemplate(
       v8::Isolate* isolate,
       v8::Local<v8::ObjectTemplate> prototype);
   static const char* GetClassName() { return "Event"; }
 
-  // gin_helper::Wrappable
-  static gin::DeprecatedWrapperInfo kWrapperInfo;
-  const char* GetTypeName() override;
+  // gin::Wrappable
+  static gin::WrapperInfo kWrapperInfo;
+  const gin::WrapperInfo* wrapper_info() const override;
+  const char* GetHumanReadableName() const override;
 
+  Event();
   ~Event() override;
 
   void PreventDefault() { default_prevented_ = true; }
@@ -44,8 +33,6 @@ class Event final : public gin_helper::DeprecatedWrappable<Event>,
   bool GetDefaultPrevented() { return default_prevented_; }
 
  private:
-  Event();
-
   bool default_prevented_ = false;
 };
 

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -31,10 +31,13 @@ class EventEmitter : public gin_helper::Wrappable<T> {
     v8::Local<v8::Object> wrapper = this->GetWrapper();
     if (wrapper.IsEmpty())
       return false;
-    gin_helper::Handle<internal::Event> event = internal::Event::New(isolate);
+    internal::Event* event = internal::Event::New(isolate);
+    v8::Local<v8::Object> event_object =
+        event->GetWrapper(isolate).ToLocalChecked();
     // It's possible that |this| will be deleted by EmitEvent, so save anything
     // we need from |this| before calling EmitEvent.
-    EmitEvent(isolate, wrapper, name, event, std::forward<Args>(args)...);
+    EmitEvent(isolate, wrapper, name, event_object,
+              std::forward<Args>(args)...);
     return event->GetDefaultPrevented();
   }
 

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -644,7 +644,8 @@ void NodeBindings::Initialize(v8::Isolate* const isolate,
     SetErrorMode(GetErrorMode() & ~SEM_NOGPFAULTERRORBOX);
 #endif
 
-  gin_helper::internal::Event::GetConstructor(isolate, context);
+  gin_helper::internal::Event::GetConstructor(
+      isolate, context, &gin_helper::internal::Event::kWrapperInfo);
 
   g_is_initialized = true;
 }


### PR DESCRIPTION
#### Description of Change

Part of https://github.com/electron/electron/issues/47922

`gin_helper::internal::Event` is constructed and maintained only for the lifetime of an event, there are no off-heap references to the object which also simplifies reasoning its lifetime, the cpp heap allocated instance is passed to event emitting callsites as raw pointer, this is fine as V8 can trace pointers on the stack via conservative stack scanning.

#### Release Notes

Notes: `Electron.Event` object backing class is now managed by v8