### PR TITLE
feat: add alternate property for menu items on macOS

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -43,6 +43,10 @@ See [`Menu`](menu.md) for examples.
     menu items.
   * `registerAccelerator` boolean (optional) _Linux_ _Windows_ - If false, the accelerator won't be registered
     with the system, but it will still be displayed. Defaults to true.
+  * `alternate` boolean (optional) _macOS_ - If true, the menu item will be marked as an alternate menu item.
+    When marked as alternate, the item is hidden by default and only shown when the option/alt key is held,
+    replacing the previous non-alternate menu item in the same menu. The alternate item must be placed
+    immediately after the item it replaces in the menu structure. Defaults to false.
   * `sharingItem` SharingItem (optional) _macOS_ - The item to share when the `role` is `shareMenu`.
   * `submenu` (MenuItemConstructorOptions[] | [Menu](menu.md)) (optional) - Should be specified
     for `submenu` type menu items. If `submenu` is specified, the `type: 'submenu'` can be omitted.
@@ -157,6 +161,30 @@ A `boolean` indicating if the accelerator should be registered with the
 system or just displayed.
 
 This property can be dynamically changed.
+
+#### `menuItem.alternate` _macOS_
+
+A `boolean` indicating if the menu item is marked as an alternate item. When
+marked as alternate, the item is hidden by default and only shown when the
+option/alt key is held, replacing the previous non-alternate menu item in the
+same menu. The alternate item must be positioned immediately after the item it
+replaces in the menu structure.
+
+**Example:**
+
+```js
+const menu = Menu.buildFromTemplate([
+  {
+    label: 'Close',
+    accelerator: 'CmdOrCtrl+W'
+  },
+  {
+    label: 'Close All',
+    accelerator: 'Alt+CmdOrCtrl+W',
+    alternate: true // This replaces "Close" when Alt/Option is held
+  }
+])
+```
 
 #### `menuItem.sharingItem` _macOS_
 

--- a/lib/browser/api/menu-item.ts
+++ b/lib/browser/api/menu-item.ts
@@ -37,6 +37,7 @@ const MenuItem = function (this: any, options: any) {
   this.overrideProperty('checked', false);
   this.overrideProperty('acceleratorWorksWhenHidden', true);
   this.overrideProperty('registerAccelerator', roles.shouldRegisterAccelerator(this.role));
+  this.overrideProperty('alternate', false);
 
   if (!MenuItem.types.includes(this.type)) {
     throw new Error(`Unknown menu item type: ${this.type}`);

--- a/lib/browser/api/menu.ts
+++ b/lib/browser/api/menu.ts
@@ -146,6 +146,7 @@ Menu.prototype.insert = function (pos, item) {
   if (item.type === 'palette' || item.type === 'header') {
     this.setCustomType(pos, item.type);
   }
+  if (item.alternate) this.setAlternate(pos, item.alternate);
 
   // Make menu accessible to items.
   item.overrideReadOnlyProperty('menu', this);

--- a/lib/browser/api/menu.ts
+++ b/lib/browser/api/menu.ts
@@ -146,7 +146,9 @@ Menu.prototype.insert = function (pos, item) {
   if (item.type === 'palette' || item.type === 'header') {
     this.setCustomType(pos, item.type);
   }
-  if (item.alternate) this.setAlternate(pos, item.alternate);
+  if (process.platform === 'darwin' && item.alternate) {
+    this.setAlternate(pos, item.alternate);
+  }
 
   // Make menu accessible to items.
   item.overrideReadOnlyProperty('menu', this);

--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -217,6 +217,10 @@ void Menu::SetCustomType(int index, const std::u16string& customType) {
   model_->SetCustomType(index, customType);
 }
 
+void Menu::SetAlternate(int index, bool alternate) {
+  model_->SetAlternate(index, alternate);
+}
+
 void Menu::Clear() {
   model_->Clear();
 }
@@ -267,6 +271,10 @@ bool Menu::WorksWhenHiddenAt(int index) const {
   return model_->WorksWhenHiddenAt(index);
 }
 
+bool Menu::IsAlternateAt(int index) const {
+  return model_->IsAlternateAt(index);
+}
+
 void Menu::OnMenuWillClose() {
   Unpin();
   Emit("menu-will-close");
@@ -291,6 +299,7 @@ void Menu::FillObjectTemplate(v8::Isolate* isolate,
       .SetMethod("setToolTip", &Menu::SetToolTip)
       .SetMethod("setRole", &Menu::SetRole)
       .SetMethod("setCustomType", &Menu::SetCustomType)
+      .SetMethod("setAlternate", &Menu::SetAlternate)
       .SetMethod("clear", &Menu::Clear)
       .SetMethod("getIndexOfCommandId", &Menu::GetIndexOfCommandId)
       .SetMethod("getItemCount", &Menu::GetItemCount)
@@ -302,6 +311,7 @@ void Menu::FillObjectTemplate(v8::Isolate* isolate,
       .SetMethod("isEnabledAt", &Menu::IsEnabledAt)
       .SetMethod("worksWhenHiddenAt", &Menu::WorksWhenHiddenAt)
       .SetMethod("isVisibleAt", &Menu::IsVisibleAt)
+      .SetMethod("isAlternateAt", &Menu::IsAlternateAt)
       .SetMethod("popupAt", &Menu::PopupAt)
       .SetMethod("closePopupAt", &Menu::ClosePopupAt)
       .SetMethod("_getAcceleratorTextAt", &Menu::GetAcceleratorTextAtForTesting)

--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -217,9 +217,15 @@ void Menu::SetCustomType(int index, const std::u16string& customType) {
   model_->SetCustomType(index, customType);
 }
 
+#if BUILDFLAG(IS_MAC)
 void Menu::SetAlternate(int index, bool alternate) {
   model_->SetAlternate(index, alternate);
 }
+
+bool Menu::IsAlternateAt(int index) const {
+  return model_->IsAlternateAt(index);
+}
+#endif
 
 void Menu::Clear() {
   model_->Clear();
@@ -271,10 +277,6 @@ bool Menu::WorksWhenHiddenAt(int index) const {
   return model_->WorksWhenHiddenAt(index);
 }
 
-bool Menu::IsAlternateAt(int index) const {
-  return model_->IsAlternateAt(index);
-}
-
 void Menu::OnMenuWillClose() {
   Unpin();
   Emit("menu-will-close");
@@ -288,37 +290,42 @@ void Menu::OnMenuWillShow() {
 // static
 void Menu::FillObjectTemplate(v8::Isolate* isolate,
                               v8::Local<v8::ObjectTemplate> templ) {
-  gin::ObjectTemplateBuilder(isolate, "Menu", templ)
-      .SetMethod("insertItem", &Menu::InsertItemAt)
-      .SetMethod("insertCheckItem", &Menu::InsertCheckItemAt)
-      .SetMethod("insertRadioItem", &Menu::InsertRadioItemAt)
-      .SetMethod("insertSeparator", &Menu::InsertSeparatorAt)
-      .SetMethod("insertSubMenu", &Menu::InsertSubMenuAt)
-      .SetMethod("setIcon", &Menu::SetIcon)
-      .SetMethod("setSublabel", &Menu::SetSublabel)
-      .SetMethod("setToolTip", &Menu::SetToolTip)
-      .SetMethod("setRole", &Menu::SetRole)
-      .SetMethod("setCustomType", &Menu::SetCustomType)
-      .SetMethod("setAlternate", &Menu::SetAlternate)
-      .SetMethod("clear", &Menu::Clear)
-      .SetMethod("getIndexOfCommandId", &Menu::GetIndexOfCommandId)
-      .SetMethod("getItemCount", &Menu::GetItemCount)
-      .SetMethod("getCommandIdAt", &Menu::GetCommandIdAt)
-      .SetMethod("getLabelAt", &Menu::GetLabelAt)
-      .SetMethod("getSublabelAt", &Menu::GetSublabelAt)
-      .SetMethod("getToolTipAt", &Menu::GetToolTipAt)
-      .SetMethod("isItemCheckedAt", &Menu::IsItemCheckedAt)
-      .SetMethod("isEnabledAt", &Menu::IsEnabledAt)
-      .SetMethod("worksWhenHiddenAt", &Menu::WorksWhenHiddenAt)
-      .SetMethod("isVisibleAt", &Menu::IsVisibleAt)
-      .SetMethod("isAlternateAt", &Menu::IsAlternateAt)
-      .SetMethod("popupAt", &Menu::PopupAt)
-      .SetMethod("closePopupAt", &Menu::ClosePopupAt)
-      .SetMethod("_getAcceleratorTextAt", &Menu::GetAcceleratorTextAtForTesting)
+  auto builder =
+      gin::ObjectTemplateBuilder(isolate, "Menu", templ)
+          .SetMethod("insertItem", &Menu::InsertItemAt)
+          .SetMethod("insertCheckItem", &Menu::InsertCheckItemAt)
+          .SetMethod("insertRadioItem", &Menu::InsertRadioItemAt)
+          .SetMethod("insertSeparator", &Menu::InsertSeparatorAt)
+          .SetMethod("insertSubMenu", &Menu::InsertSubMenuAt)
+          .SetMethod("setIcon", &Menu::SetIcon)
+          .SetMethod("setSublabel", &Menu::SetSublabel)
+          .SetMethod("setToolTip", &Menu::SetToolTip)
+          .SetMethod("setRole", &Menu::SetRole)
+          .SetMethod("setCustomType", &Menu::SetCustomType)
 #if BUILDFLAG(IS_MAC)
-      .SetMethod("_getUserAcceleratorAt", &Menu::GetUserAcceleratorAt)
+          .SetMethod("setAlternate", &Menu::SetAlternate)
+          .SetMethod("isAlternateAt", &Menu::IsAlternateAt)
 #endif
-      .Build();
+          .SetMethod("clear", &Menu::Clear)
+          .SetMethod("getIndexOfCommandId", &Menu::GetIndexOfCommandId)
+          .SetMethod("getItemCount", &Menu::GetItemCount)
+          .SetMethod("getCommandIdAt", &Menu::GetCommandIdAt)
+          .SetMethod("getLabelAt", &Menu::GetLabelAt)
+          .SetMethod("getSublabelAt", &Menu::GetSublabelAt)
+          .SetMethod("getToolTipAt", &Menu::GetToolTipAt)
+          .SetMethod("isItemCheckedAt", &Menu::IsItemCheckedAt)
+          .SetMethod("isEnabledAt", &Menu::IsEnabledAt)
+          .SetMethod("worksWhenHiddenAt", &Menu::WorksWhenHiddenAt)
+          .SetMethod("isVisibleAt", &Menu::IsVisibleAt)
+          .SetMethod("popupAt", &Menu::PopupAt)
+          .SetMethod("closePopupAt", &Menu::ClosePopupAt)
+          .SetMethod("_getAcceleratorTextAt",
+                     &Menu::GetAcceleratorTextAtForTesting)
+#if BUILDFLAG(IS_MAC)
+          .SetMethod("_getUserAcceleratorAt", &Menu::GetUserAcceleratorAt)
+#endif
+      ;
+  builder.Build();
 }
 
 const char* Menu::GetTypeName() {

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -118,6 +118,7 @@ class Menu : public gin_helper::DeprecatedWrappable<Menu>,
   void SetToolTip(int index, const std::u16string& toolTip);
   void SetRole(int index, const std::u16string& role);
   void SetCustomType(int index, const std::u16string& customType);
+  void SetAlternate(int index, bool alternate);
   void Clear();
   int GetIndexOfCommandId(int command_id) const;
   int GetItemCount() const;
@@ -129,6 +130,7 @@ class Menu : public gin_helper::DeprecatedWrappable<Menu>,
   bool IsEnabledAt(int index) const;
   bool IsVisibleAt(int index) const;
   bool WorksWhenHiddenAt(int index) const;
+  bool IsAlternateAt(int index) const;
 };
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -118,7 +118,10 @@ class Menu : public gin_helper::DeprecatedWrappable<Menu>,
   void SetToolTip(int index, const std::u16string& toolTip);
   void SetRole(int index, const std::u16string& role);
   void SetCustomType(int index, const std::u16string& customType);
+#if BUILDFLAG(IS_MAC)
   void SetAlternate(int index, bool alternate);
+  bool IsAlternateAt(int index) const;
+#endif
   void Clear();
   int GetIndexOfCommandId(int command_id) const;
   int GetItemCount() const;
@@ -130,7 +133,6 @@ class Menu : public gin_helper::DeprecatedWrappable<Menu>,
   bool IsEnabledAt(int index) const;
   bool IsVisibleAt(int index) const;
   bool WorksWhenHiddenAt(int index) const;
-  bool IsAlternateAt(int index) const;
 };
 
 }  // namespace electron::api

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -441,6 +441,9 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
     [(id)item
         setAllowsKeyEquivalentWhenHidden:(model->WorksWhenHiddenAt(index))];
 
+    if (model->IsAlternateAt(index))
+      [item setAlternate:YES];
+
     // Set menu item's role.
     [item setTarget:self];
     if (!role.empty()) {

--- a/shell/browser/ui/electron_menu_model.cc
+++ b/shell/browser/ui/electron_menu_model.cc
@@ -72,17 +72,6 @@ std::u16string ElectronMenuModel::GetSecondaryLabelAt(size_t index) const {
   return iter == std::end(sublabels_) ? std::u16string() : iter->second;
 }
 
-void ElectronMenuModel::SetAlternate(size_t index, bool alternate) {
-  int command_id = GetCommandIdAt(index);
-  alternates_[command_id] = alternate;
-}
-
-bool ElectronMenuModel::IsAlternateAt(size_t index) const {
-  int command_id = GetCommandIdAt(index);
-  const auto iter = alternates_.find(command_id);
-  return iter != std::end(alternates_) && iter->second;
-}
-
 bool ElectronMenuModel::GetAcceleratorAtWithParams(
     size_t index,
     bool use_default_accelerator,
@@ -110,6 +99,17 @@ bool ElectronMenuModel::WorksWhenHiddenAt(size_t index) const {
 }
 
 #if BUILDFLAG(IS_MAC)
+void ElectronMenuModel::SetAlternate(size_t index, bool alternate) {
+  int command_id = GetCommandIdAt(index);
+  alternates_[command_id] = alternate;
+}
+
+bool ElectronMenuModel::IsAlternateAt(size_t index) const {
+  int command_id = GetCommandIdAt(index);
+  const auto iter = alternates_.find(command_id);
+  return iter != std::end(alternates_) && iter->second;
+}
+
 bool ElectronMenuModel::GetSharingItemAt(size_t index,
                                          SharingItem* item) const {
   if (delegate_)

--- a/shell/browser/ui/electron_menu_model.cc
+++ b/shell/browser/ui/electron_menu_model.cc
@@ -72,6 +72,17 @@ std::u16string ElectronMenuModel::GetSecondaryLabelAt(size_t index) const {
   return iter == std::end(sublabels_) ? std::u16string() : iter->second;
 }
 
+void ElectronMenuModel::SetAlternate(size_t index, bool alternate) {
+  int command_id = GetCommandIdAt(index);
+  alternates_[command_id] = alternate;
+}
+
+bool ElectronMenuModel::IsAlternateAt(size_t index) const {
+  int command_id = GetCommandIdAt(index);
+  const auto iter = alternates_.find(command_id);
+  return iter != std::end(alternates_) && iter->second;
+}
+
 bool ElectronMenuModel::GetAcceleratorAtWithParams(
     size_t index,
     bool use_default_accelerator,

--- a/shell/browser/ui/electron_menu_model.h
+++ b/shell/browser/ui/electron_menu_model.h
@@ -90,14 +90,14 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
   std::u16string GetRoleAt(size_t index);
   void SetSecondaryLabel(size_t index, const std::u16string& sublabel);
   std::u16string GetSecondaryLabelAt(size_t index) const override;
-  void SetAlternate(size_t index, bool alternate);
-  bool IsAlternateAt(size_t index) const;
   bool GetAcceleratorAtWithParams(size_t index,
                                   bool use_default_accelerator,
                                   ui::Accelerator* accelerator) const;
   bool ShouldRegisterAcceleratorAt(size_t index) const;
   bool WorksWhenHiddenAt(size_t index) const;
 #if BUILDFLAG(IS_MAC)
+  void SetAlternate(size_t index, bool alternate);
+  bool IsAlternateAt(size_t index) const;
   // Return the SharingItem of menu item.
   bool GetSharingItemAt(size_t index, SharingItem* item) const;
   // Set/Get the SharingItem of this menu.
@@ -124,14 +124,14 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
 
 #if BUILDFLAG(IS_MAC)
   std::optional<SharingItem> sharing_item_;
+  base::flat_map<int, bool> alternates_;  // command id -> alternate
 #endif
 
   base::flat_map<int, std::u16string> toolTips_;   // command id -> tooltip
   base::flat_map<int, std::u16string> roles_;      // command id -> role
   base::flat_map<int, std::u16string> sublabels_;  // command id -> sublabel
   base::flat_map<int, std::u16string>
-      customTypes_;                       // command id -> custom type
-  base::flat_map<int, bool> alternates_;  // command id -> alternate
+      customTypes_;  // command id -> custom type
   base::ObserverList<Observer> observers_;
 
   base::WeakPtrFactory<ElectronMenuModel> weak_factory_{this};

--- a/shell/browser/ui/electron_menu_model.h
+++ b/shell/browser/ui/electron_menu_model.h
@@ -90,6 +90,8 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
   std::u16string GetRoleAt(size_t index);
   void SetSecondaryLabel(size_t index, const std::u16string& sublabel);
   std::u16string GetSecondaryLabelAt(size_t index) const override;
+  void SetAlternate(size_t index, bool alternate);
+  bool IsAlternateAt(size_t index) const;
   bool GetAcceleratorAtWithParams(size_t index,
                                   bool use_default_accelerator,
                                   ui::Accelerator* accelerator) const;
@@ -128,7 +130,8 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
   base::flat_map<int, std::u16string> roles_;      // command id -> role
   base::flat_map<int, std::u16string> sublabels_;  // command id -> sublabel
   base::flat_map<int, std::u16string>
-      customTypes_;  // command id -> custom type
+      customTypes_;                       // command id -> custom type
+  base::flat_map<int, bool> alternates_;  // command id -> alternate
   base::ObserverList<Observer> observers_;
 
   base::WeakPtrFactory<ElectronMenuModel> weak_factory_{this};

--- a/spec/api-menu-item-spec.ts
+++ b/spec/api-menu-item-spec.ts
@@ -43,6 +43,40 @@ describe('MenuItems', () => {
       expect(item).to.have.property('role').that.is.a('string');
       expect(item).to.have.property('icon');
     });
+
+    ifdescribe(process.platform === 'darwin')('should have macOS-specific properties', () => {
+      it('should have alternate property', () => {
+        const item = new MenuItem({
+          label: 'Close',
+          alternate: true
+        });
+
+        expect(item).to.have.property('alternate').that.is.a('boolean').and.is.true('item is alternate');
+      });
+
+      it('should default alternate to false', () => {
+        const item = new MenuItem({
+          label: 'Close'
+        });
+
+        expect(item).to.have.property('alternate').that.is.a('boolean').and.is.false('item is not alternate');
+      });
+
+      it('should apply alternate property to menu', () => {
+        const menu = Menu.buildFromTemplate([{
+          label: 'Close',
+          accelerator: 'CmdOrControl+W',
+          alternate: false
+        }, {
+          label: 'Close All',
+          accelerator: 'Alt+CmdOrControl+W',
+          alternate: true
+        }]);
+
+        expect(menu.items[0]).to.have.property('alternate').that.is.false('first item is not alternate');
+        expect(menu.items[1]).to.have.property('alternate').that.is.true('second item is alternate');
+      });
+    });
   });
 
   describe('MenuItem.click', () => {

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -173,6 +173,7 @@ declare namespace Electron {
     setIcon(index: number, image: string | NativeImage): void;
     setRole(index: number, role: string): void;
     setCustomType(index: number, customType: string): void;
+    setAlternate(index: number, alternate: boolean): void;
     insertItem(index: number, commandId: number, label: string): void;
     insertCheckItem(index: number, commandId: number, label: string): void;
     insertRadioItem(index: number, commandId: number, label: string, groupId: number): void;


### PR DESCRIPTION
#### Description of Change

Making sure I don't get rusty: This PR adds support for the macOS `alternate` menu option.

Closes https://github.com/electron/electron/issues/47960. 

![alternate](https://github.com/user-attachments/assets/b3c72546-a6c5-4e8e-950e-ea63bd98f296)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added support for alternate menu items on macOS.