### PR TITLE
build: remove no longer needed arg for siso

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -201,7 +201,7 @@ runs:
       shell: bash
       run: |
         cd src
-        gn gen out/ffmpeg --args="import(\"//electron/build/args/ffmpeg.gn\") use_remoteexec=true $GN_EXTRA_ARGS"
+        gn gen out/ffmpeg --args="import(\"//electron/build/args/ffmpeg.gn\") use_remoteexec=true use_siso=true $GN_EXTRA_ARGS"
         e build --target electron:electron_ffmpeg_zip -C ../../out/ffmpeg
     - name: Generate Hunspell Dictionaries ${{ inputs.step-suffix }}
       shell: bash

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -199,7 +199,6 @@ runs:
         fi
     - name: Generate FFMpeg ${{ inputs.step-suffix }}
       shell: bash
-      if: ${{ inputs.is-release == 'true' }}
       run: |
         cd src
         gn gen out/ffmpeg --args="import(\"//electron/build/args/ffmpeg.gn\") use_remoteexec=true $GN_EXTRA_ARGS"

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -199,6 +199,7 @@ runs:
         fi
     - name: Generate FFMpeg ${{ inputs.step-suffix }}
       shell: bash
+      if: ${{ inputs.is-release == 'true' }}
       run: |
         cd src
         gn gen out/ffmpeg --args="import(\"//electron/build/args/ffmpeg.gn\") use_remoteexec=true use_siso=true $GN_EXTRA_ARGS"

--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -69,7 +69,3 @@ v8_expose_public_symbols = true
 # Disable snapshotting a page when printing for its content to be analyzed for
 # sensitive content by enterprise users.
 enterprise_cloud_content_analysis = false
-
-# Disable siso until we are ready to use it.
-# https://chromium-review.googlesource.com/c/chromium/src/+/6638830
-use_siso = false


### PR DESCRIPTION
#### Description of Change
- Followup to #47534.  We no longer need to disable siso by default.
This also fixes our release builds generation of ffmpeg.zip.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
