### PR TITLE
docs: fix some module headings

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -1,3 +1,5 @@
+# MenuItem
+
 ## Class: MenuItem
 
 > Add items to native application menus and context menus.

--- a/docs/api/service-worker-main.md
+++ b/docs/api/service-worker-main.md
@@ -1,10 +1,6 @@
-# ServiceWorkerMain
+## Class: ServiceWorkerMain
 
 > An instance of a Service Worker representing a version of a script for a given scope.
-
-Process: [Main](../glossary.md#main-process)
-
-## Class: ServiceWorkerMain
 
 Process: [Main](../glossary.md#main-process)<br />
 _This class is not exported from the `'electron'` module. It is only available as a return value of other methods in the Electron API._


### PR DESCRIPTION
#### Description of Change

* `MenuItem` is an exported module and should have a `#` heading.
* `ServiceWorkerMain` is an unexported class and should not have a `#` heading.

cc @dsanders11

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
