### PR TITLE
fix: showMessageDialog should center dialog to parent

### DIFF
--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -160,6 +160,7 @@ DialogResult ShowTaskDialogWstr(gfx::AcceleratedWidget parent,
 
   if (parent) {
     config.hwndParent = parent;
+    config.dwFlags |= TDF_POSITION_RELATIVE_TO_WINDOW;
   }
 
   if (default_id > 0)


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/23001.

<details><summary>Before</summary>
<p>

<img width="939" height="667" alt="Screenshot 2025-08-27 at 10 50 56 AM" src="https://github.com/user-attachments/assets/cc2e107e-99c7-4d6f-9dee-8e14c9145f38" />

</p>
</details> 

<details><summary>After</summary>
<p>

<img width="807" height="633" alt="Screenshot 2025-08-27 at 10 53 11 AM" src="https://github.com/user-attachments/assets/9a9bc307-51b1-450c-bf71-633318a66ab5" />

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `sialog.showMessageDialog` showed a window incorrectly centered to monitor instead of parent window when passed.
