### PR TITLE
fix: ensure dragging works again after emitting contextmenu event

### DIFF
--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -324,11 +324,6 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
 
       return false;
     }
-    case WM_RBUTTONUP: {
-      if (!has_frame())
-        electron::api::WebContents::SetDisableDraggableRegions(false);
-      return false;
-    }
     case WM_GETMINMAXINFO: {
       WINDOWPLACEMENT wp;
       wp.length = sizeof(WINDOWPLACEMENT);

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -142,6 +142,7 @@ bool ElectronDesktopWindowTreeHostWin::HandleMouseEvent(ui::MouseEvent* event) {
     if (prevent_default) {
       electron::api::WebContents::SetDisableDraggableRegions(true);
       views::DesktopWindowTreeHostWin::HandleMouseEvent(event);
+      electron::api::WebContents::SetDisableDraggableRegions(false);
     }
     return prevent_default;
   }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/48179.

Fixes an issue where dragging sometimes didn't work after the `contextmenu` event was emitted. This happened because `WM_RBUTTONUP` can be racy with the mousehandler, so the call to `electron::api::WebContents::SetDisableDraggableRegions(false)` didn't always happen as expected. Fix this by consolidating logic into `ElectronDesktopWindowTreeHostWin::HandleMouseEvent`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where dragging sometimes didn't work after the `contextmenu` event was emitted.