### PR TITLE
feat: add SF Symbol support to NativeImage::CreateFromNamedImage

### DIFF
--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -196,8 +196,7 @@ Creates a new `NativeImage` instance from `dataUrl`, a base 64 encoded [Data URL
 Returns `NativeImage`
 
 Creates a new `NativeImage` instance from the `NSImage` that maps to the
-given image name. See Apple's [`NSImageName`](https://developer.apple.com/documentation/appkit/nsimagename#2901388)
-documentation for a list of possible values.
+given image name. See Apple's [`NSImageName`](https://developer.apple.com/documentation/appkit/nsimagename#2901388) documentation and [SF Symbols](https://developer.apple.com/sf-symbols/) for a list of possible values.
 
 The `hslShift` is applied to the image with the following rules:
 

--- a/shell/common/api/electron_api_native_image_mac.mm
+++ b/shell/common/api/electron_api_native_image_mac.mm
@@ -120,9 +120,20 @@ gin_helper::Handle<NativeImage> NativeImage::CreateFromNamedImage(
       name.erase(pos, to_remove.length());
     }
 
-    NSImage* image = [NSImage imageNamed:base::SysUTF8ToNSString(name)];
+    NSImage* image = nil;
+    NSString* ns_name = base::SysUTF8ToNSString(name);
 
-    if (!image.valid) {
+    // If the name does not include NS, we can assume it is a sf symbol
+    if ([name.find("NS") == std::string::npos]) {
+      if (@available(macOS 11.0, *)) {
+        image = [NSImage systemSymbolName:ns_name accessibilityDescription:nil];
+      }
+    }
+    if (!image) {
+      image = [NSImage imageNamed:ns_name];
+    }
+
+    if (!image || !image.valid) {
       return CreateEmpty(args->isolate());
     }
 


### PR DESCRIPTION
#### Description of Change

Updated `nativeImage.createFromNamedImage` to support SF Symbol names.

If the image name passed to `createFromNamedImage` includes `'NS'`, we treat it as an `NSImageName` value, however if the name does not (e.g. `'star.fill'`) we treat it as a `systemSymbolName`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Updated `nativeImage.createFromNamedImage` to support SF Symbol names.