### PR TITLE
fix: initialize keychain names early to ensure safeStorage uses correct app name

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -277,16 +277,6 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
 
   // Initialize after user script environment creation.
   fake_browser_process_->PostEarlyInitialization();
-
-#if BUILDFLAG(IS_MAC)
-  // Initialize keychain names early to ensure safeStorage uses the correct
-  // app name even when called before the app is ready (e.g., in preload
-  // scripts). This must happen after the JS environment is initialized so
-  // GetName() works.
-  std::string app_name = electron::Browser::Get()->GetName();
-  KeychainPassword::GetServiceName() = app_name + " Safe Storage";
-  KeychainPassword::GetAccountName() = app_name;
-#endif
 }
 
 int ElectronBrowserMainParts::PreCreateThreads() {

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -277,6 +277,16 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
 
   // Initialize after user script environment creation.
   fake_browser_process_->PostEarlyInitialization();
+
+#if BUILDFLAG(IS_MAC)
+  // Initialize keychain names early to ensure safeStorage uses the correct
+  // app name even when called before the app is ready (e.g., in preload
+  // scripts). This must happen after the JS environment is initialized so
+  // GetName() works.
+  std::string app_name = electron::Browser::Get()->GetName();
+  KeychainPassword::GetServiceName() = app_name + " Safe Storage";
+  KeychainPassword::GetAccountName() = app_name;
+#endif
 }
 
 int ElectronBrowserMainParts::PreCreateThreads() {
@@ -493,10 +503,8 @@ void ElectronBrowserMainParts::WillRunMainMessageLoop(
 }
 
 void ElectronBrowserMainParts::PostCreateMainMessageLoop() {
-#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC)
-  std::string app_name = electron::Browser::Get()->GetName();
-#endif
 #if BUILDFLAG(IS_LINUX)
+  std::string app_name = electron::Browser::Get()->GetName();
   auto shutdown_cb =
       base::BindOnce([] { LOG(FATAL) << "Failed to shutdown."; });
   ui::OzonePlatform::GetInstance()->PostCreateMainMessageLoop(
@@ -533,10 +541,6 @@ void ElectronBrowserMainParts::PostCreateMainMessageLoop() {
       os_crypt::SelectBackend(config->store, use_backend, desktop_env);
   fake_browser_process_->SetLinuxStorageBackend(selected_backend);
   OSCrypt::SetConfig(std::move(config));
-#endif
-#if BUILDFLAG(IS_MAC)
-  KeychainPassword::GetServiceName() = app_name + " Safe Storage";
-  KeychainPassword::GetAccountName() = app_name;
 #endif
 #if BUILDFLAG(IS_POSIX)
   // Exit in response to SIGINT, SIGTERM, etc.


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/45328

Once I actually understood what's going on, fixing the bug wasn't too hard: We simply have set the `KeychainPassword`'s variables before actually calling underlying APIs. I first tried to just mess with the timing phase, but since @MarshallOfSound called out an (in hindsight) very obvious issue with that approach, we're just making sure the app name is initialized for `KeychainPassword` before APIs are executed.

<details>
<summary>An earlier attempt where I just changed the timing</summary>
Once I actually understood what's going on, fixing the bug wasn't too hard: We simply have set the `KeychainPassword`'s variables earlier. Without this PR, calling `isEncryptionAvailable()` early might set the wrong name because:

1. `PostCreateMainMessageLoop` is where the KeychainPassword service name and account name are set to use the actual app name
2. But if `safeStorage.isEncryptionAvailable()` is called before the app is ready, it accesses KeychainPassword's static variables which get initialized with the defaults ("Chromium Safe Storage" and "Chromium")
3. Once the static variables are initialized, they cannot be changed even when `PostCreateMainMessageLoop` later tries to set them to the correct app name
</details>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: fix: Ensure that `safeStorage` APIs set correct names on macOS even if called early in the app's startup process
