### PR TITLE
fix: `dialog.showMessageBox` defaultid on Windows

### DIFF
--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -162,8 +162,18 @@ DialogResult ShowTaskDialogWstr(gfx::AcceleratedWidget parent,
     config.hwndParent = parent;
   }
 
-  if (default_id > 0)
-    config.nDefaultButton = kIDStart + default_id;
+  if (default_id >= 0 && static_cast<size_t>(default_id) < buttons.size()) {
+    if (!no_link) {
+      auto common = GetCommonID(buttons[default_id]);
+      if (common.button != -1) {
+        config.nDefaultButton = common.id;
+      } else {
+        config.nDefaultButton = kIDStart + default_id;
+      }
+    } else {
+      config.nDefaultButton = kIDStart + default_id;
+    }
+  }
 
   // TaskDialogIndirect doesn't allow empty name, if we set empty title it
   // will show "electron.exe" in title.


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/22600.

Fixes Windows message box default button handling.

On Windows, `dialog.showMessageBox` / `showMessageBoxSync` ignored defaultId when it was 0 (first button) and failed whenever the target button text matched a common button (OK/Yes/No/Cancel/etc.), because we always offset with `kIDStart instead of using the native common button ID. This meant the default focus could be wrong. The fix accepts `defaultId >= 0`, bounds‑checks it, and maps to the proper ID (common button ID or custom offset) before calling TaskDialogIndirect.

Using the following code:

```js
dialog.showMessageBoxSync(null, {
    type:'warning',
    buttons: ['Yes', 'No', 'Third'],
    defaultId: 1,
    cancelId: 1,
    title: 'Power Control',
    message: "Warning!"
});
```

<details><summary>Before</summary>
<p>

<img width="366" height="142" alt="Screenshot 2025-08-29 at 9 54 35 AM" src="https://github.com/user-attachments/assets/6df67b59-9986-4d94-aa57-6b21327e2d2c" />

</p>
</details> 

<details><summary>After</summary>
<p>

<img width="365" height="139" alt="Screenshot 2025-08-29 at 9 54 55 AM" src="https://github.com/user-attachments/assets/004cbce1-56cc-416a-9bce-852d25f87620" />

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes Windows `dialog.showMessageBox` default button handling.
