### PR TITLE
docs: add caveats for Electron PipeWire implementation

### DIFF
--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -102,6 +102,10 @@ Returns `Promise<DesktopCapturerSource[]>` - Resolves with an array of [`Desktop
 
 ## Caveats
 
+`desktopCapturer.getSources(options)` only returns a single source on Linux when using Pipewire.
+
+PipeWire supports a single capture for both screens and windows. If you request the window and screen type, the selected source will be returned as a window capture.
+
 `navigator.mediaDevices.getUserMedia` does not work on macOS for audio capture due to a fundamental limitation whereby apps that want to access the system's audio require a [signed kernel extension](https://developer.apple.com/library/archive/documentation/Security/Conceptual/System_Integrity_Protection_Guide/KernelExtensions/KernelExtensions.html). Chromium, and by extension Electron, does not provide this.
 
 It is possible to circumvent this limitation by capturing system audio with another macOS app like Soundflower and passing it through a virtual audio input device. This virtual device can then be queried with `navigator.mediaDevices.getUserMedia`.


### PR DESCRIPTION
#### Description of Change

The Pipewire Capturer implementation in Electron has some Caveats, but those are only documented in the codebase. 

https://github.com/electron/electron/blob/fed73040e246e3289b1b0f24cfa032bcf899a763/shell/browser/api/electron_api_desktop_capturer.cc#L253

https://github.com/electron/electron/blob/fed73040e246e3289b1b0f24cfa032bcf899a763/shell/browser/api/electron_api_desktop_capturer.cc#L285-L286

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)

Notes: none