### PR TITLE
refactor: skip span decls that don't add new info

### DIFF
--- a/shell/browser/net/asar/asar_url_loader.cc
+++ b/shell/browser/net/asar/asar_url_loader.cc
@@ -171,8 +171,8 @@ class AsarURLLoader : public network::mojom::URLLoader {
 
     std::vector<char> initial_read_buffer(
         std::min(static_cast<uint32_t>(net::kMaxBytesToSniff), info.size));
-    auto read_result = readable_data_source.get()->Read(
-        info.offset, base::span<char>(initial_read_buffer));
+    auto read_result =
+        readable_data_source.get()->Read(info.offset, initial_read_buffer);
     if (read_result.result != MOJO_RESULT_OK) {
       OnClientComplete(ConvertMojoResultToNetError(read_result.result));
       return;
@@ -244,9 +244,8 @@ class AsarURLLoader : public network::mojom::URLLoader {
       uint64_t bytes_to_drop = block_size - net::kMaxBytesToSniff;
       total_bytes_dropped_from_head += bytes_to_drop;
       std::vector<char> abandoned_buffer(bytes_to_drop);
-      auto abandon_read_result =
-          readable_data_source.get()->Read(info.offset + net::kMaxBytesToSniff,
-                                           base::span<char>(abandoned_buffer));
+      auto abandon_read_result = readable_data_source.get()->Read(
+          info.offset + net::kMaxBytesToSniff, abandoned_buffer);
       if (abandon_read_result.result != MOJO_RESULT_OK) {
         OnClientComplete(
             ConvertMojoResultToNetError(abandon_read_result.result));
@@ -307,7 +306,7 @@ class AsarURLLoader : public network::mojom::URLLoader {
         total_bytes_dropped_from_head += bytes_to_drop;
         std::vector<char> abandoned_buffer(bytes_to_drop);
         auto abandon_read_result = readable_data_source.get()->Read(
-            dropped_bytes_offset, base::span<char>(abandoned_buffer));
+            dropped_bytes_offset, abandoned_buffer);
         if (abandon_read_result.result != MOJO_RESULT_OK) {
           OnClientComplete(
               ConvertMojoResultToNetError(abandon_read_result.result));

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -153,8 +153,7 @@ class BufferDataSource : public mojo::DataPipeProducer::DataSource {
   [[nodiscard]] uint64_t GetLength() const override { return buffer_.size(); }
   ReadResult Read(uint64_t offset, base::span<char> tgt) override {
     CHECK_LE(offset, buffer_.size());
-    const auto src =
-        base::span<const char>{buffer_}.subspan(static_cast<size_t>(offset));
+    const auto src = base::span<const char>{buffer_}.first(offset);
     const auto n_copied = std::min(src.size(), tgt.size());
     tgt.first(n_copied).copy_from(src.first(n_copied));
     return ReadResult{.bytes_read = n_copied};

--- a/shell/common/extensions/electron_extensions_api_provider.cc
+++ b/shell/common/extensions/electron_extensions_api_provider.cc
@@ -46,7 +46,7 @@ constexpr APIPermissionInfo::InitInfo permissions_to_register[] = {
      APIPermissionInfo::kFlagRequiresManagementUIWarning},
 };
 base::span<const APIPermissionInfo::InitInfo> GetPermissionInfos() {
-  return base::span(permissions_to_register);
+  return permissions_to_register;
 }
 base::span<const Alias> GetPermissionAliases() {
   return {};

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -739,7 +739,7 @@ class WebFrameRenderer final
                                              std::move(completion_callback));
 
     render_frame->GetWebFrame()->RequestExecuteScript(
-        world_id, base::span(sources),
+        world_id, sources,
         has_user_gesture ? blink::mojom::UserActivationOption::kActivate
                          : blink::mojom::UserActivationOption::kDoNotActivate,
         script_execution_type, load_blocking_option, base::NullCallback(),


### PR DESCRIPTION
#### Description of Change

These are useful when adding semantic info e.g. when making `const` explicit; otherwise, arrays and vectors are implicitly convertible to base::span and explicit declarations don't add anything.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none