### PR TITLE
refactor: avoid unused inheritance in ServiceWorkerMain

### DIFF
--- a/shell/browser/api/electron_api_service_worker_main.h
+++ b/shell/browser/api/electron_api_service_worker_main.h
@@ -16,7 +16,6 @@
 #include "mojo/public/cpp/bindings/associated_remote.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/remote.h"
-#include "shell/browser/event_emitter_mixin.h"
 #include "shell/common/api/api.mojom.h"
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/pinnable.h"
@@ -80,7 +79,6 @@ struct ServiceWorkerKey {
 // the default StoragePartition for the associated BrowserContext.
 class ServiceWorkerMain final
     : public gin_helper::DeprecatedWrappable<ServiceWorkerMain>,
-      public gin_helper::EventEmitterMixin<ServiceWorkerMain>,
       public gin_helper::Pinnable<ServiceWorkerMain>,
       public gin_helper::Constructible<ServiceWorkerMain> {
  public:


### PR DESCRIPTION
#### Description of Change

`ServiceWorkerMain` doesn't emit anything, so it doesn't need to inherit from `EventEmitterMixin`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.