### PR TITLE
fix: runtime JS error that crashes `GetPackageJSON`

### DIFF
--- a/shell/common/api/electron_api_asar.cc
+++ b/shell/common/api/electron_api_asar.cc
@@ -191,13 +191,15 @@ class Archive : public node::ObjectWrap {
 static void SplitPath(const v8::FunctionCallbackInfo<v8::Value>& args) {
   auto* isolate = args.GetIsolate();
 
+  auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
+  args.GetReturnValue().Set(dict.GetHandle());
+
   base::FilePath path;
   if (!gin::ConvertFromV8(isolate, args[0], &path)) {
-    args.GetReturnValue().Set(v8::False(isolate));
+    dict.Set("isAsar", false);
     return;
   }
 
-  auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
   base::FilePath asar_path, file_path;
   if (asar::GetAsarArchivePath(path, &asar_path, &file_path, true)) {
     dict.Set("isAsar", true);
@@ -206,7 +208,6 @@ static void SplitPath(const v8::FunctionCallbackInfo<v8::Value>& args) {
   } else {
     dict.Set("isAsar", false);
   }
-  args.GetReturnValue().Set(dict.GetHandle());
 }
 
 void Initialize(v8::Local<v8::Object> exports,


### PR DESCRIPTION
#### Description of Change

We overriden the `GetPackageJSON` in Node.js to let us read files straight from the ASAR file instead of disk. The override works by providing a JS method with the limitation that it should not throw a runtime error. However, this invariant was accidentally violated by `asar.splitPath` that sometimes contrary to its' TypeScript definition returned `false`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

cc @zcbenz @nikwen 

## Example of crash stack

```
0: libsystem_kernel.dylib +0x[REDACTED]
1: libsystem_c.dylib +0x0000000000078a38
2: node::OnFatalError(char const*, char const*)+0xf8 (node_errors.cc:593)
3: v8::Utils::ReportApiFailure(char const*, char const*)+0x4c (api.cc:272)
4: node::modules::BindingData::GetPackageJSON(node::Realm*, std::__Cr::basic_string_view<char, std::__Cr::char_traits<char>>, node::modules::BindingData::ErrorContext*)+0x15f8 (v8-local-handle.h:770)
5: node::modules::BindingData::TraverseParent(node::Realm*, std::__Cr::__fs::filesystem::path const&)+0x460 (node_modules.cc:396)
6: node::modules::BindingData::GetNearestParentPackageJSON(v8::FunctionCallbackInfo<v8::Value> const&)+0x270 (node_modules.cc:432)
```

#### Release Notes

Notes:  fix: runtime JS error that crashes `GetPackageJSON`