### PR TITLE
fix: snapped window restoring to correct position

### DIFF
--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -509,7 +509,7 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
       WINDOWPLACEMENT wp;
       wp.length = sizeof(WINDOWPLACEMENT);
 
-      if (GetWindowPlacement(GetAcceleratedWidget(), &wp)) {
+      if (GetWindowPlacement(GetAcceleratedWidget(), &wp) && !was_snapped_) {
         last_normal_placement_bounds_ = gfx::Rect(wp.rcNormalPosition);
       }
 
@@ -518,11 +518,9 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
       if (w_param == SIZE_MAXIMIZED &&
           last_window_state_ != ui::mojom::WindowShowState::kMaximized) {
         if (last_window_state_ == ui::mojom::WindowShowState::kMinimized) {
-          if (was_snapped_) {
-            SetRoundedCorners(false);
-            was_snapped_ = false;
-          }
           NotifyWindowRestore();
+          if (was_snapped_)
+            was_snapped_ = false;
         }
         last_window_state_ = ui::mojom::WindowShowState::kMaximized;
         NotifyWindowMaximize();
@@ -545,12 +543,10 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
             last_window_state_ = ui::mojom::WindowShowState::kFullscreen;
             NotifyWindowEnterFullScreen();
           } else {
-            if (was_snapped_) {
-              SetRoundedCorners(false);
-              was_snapped_ = false;
-            }
             last_window_state_ = ui::mojom::WindowShowState::kNormal;
             NotifyWindowRestore();
+            if (was_snapped_)
+              was_snapped_ = false;
           }
           break;
         default:


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/48273.

Fixes an issue where snapped windows aren't correctly snapped when minimized and then unminimized. The windows were restored to the correct position via previous band-aid PRs, but they weren't actually arranged per Windows core functionality. This was due to a workaround present in our WndProc handling for scaling and displays, which a properly arranged window shouldn't need.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where snapped windows aren't correctly snapped when minimized and then unminimized.