### PR TITLE
fix: set ozone platform for wayland

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -655,6 +655,7 @@ source_set("electron_lib") {
       "//ui/events/devices/x11",
       "//ui/events/platform/x11",
       "//ui/gtk:gtk_config",
+      "//ui/linux:display_server_utils",
       "//ui/linux:linux_ui",
       "//ui/linux:linux_ui_factory",
       "//ui/wm",

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -68,6 +68,7 @@
 #include "ui/base/ui_base_switches.h"
 #include "ui/color/color_provider_manager.h"
 #include "ui/display/screen.h"
+#include "ui/linux/display_server_utils.h"
 #include "ui/views/layout/layout_provider.h"
 #include "url/url_util.h"
 


### PR DESCRIPTION
#### Description of Change

In a recent upgrade roll I made a [breaking change](https://www.electronjs.org/docs/latest/breaking-changes#removed-electron_ozone_platform_hint-environment-variable) to remove the custom `ELECTRON_OZONE_PLATFORM_HINT` env var and directed users to use the `XDG_SESSION_TYPE` env var instead. However, I forgot to ensure that [function](https://source.chromium.org/chromium/chromium/src/+/main:ui/linux/display_server_utils.cc?q=symbol%3A%5Cbui%3A%3ASetOzonePlatformForLinuxIfNeeded%5Cb%20case%3Ayes) to use that env var was called. Thus, this PR calls that function during startup.

The code in this PR mirrors the [corresponding upstream code](https://source.chromium.org/chromium/chromium/src/+/main:chrome/app/chrome_main_delegate.cc;l=810-817;drc=61b367b8b73a1db50dbeca05a5ec0e5f776e6443).

Fixes #48298
Refs #48001

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed Wayland configuration through the `XDG_SESSION_TYPE` environment variable.