### PR TITLE
fix: remove unneeded handlescope from JS callbacks

### DIFF
--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -1697,14 +1697,11 @@ Session* Session::CreateFrom(v8::Isolate* isolate,
     return nullptr;
   }
 
-  {
-    v8::HandleScope handle_scope(isolate);
-    v8::Local<v8::Object> wrapper;
-    if (!session->GetWrapper(isolate).ToLocal(&wrapper)) {
-      return nullptr;
-    }
-    App::Get()->EmitWithoutEvent("session-created", wrapper);
+  v8::Local<v8::Object> wrapper;
+  if (!session->GetWrapper(isolate).ToLocal(&wrapper)) {
+    return nullptr;
   }
+  App::Get()->EmitWithoutEvent("session-created", wrapper);
 
   return session;
 }
@@ -1883,7 +1880,6 @@ v8::Local<v8::Value> FromPartition(const std::string& partition,
       Session::FromPartition(args->isolate(), partition, std::move(options));
 
   if (session) {
-    v8::HandleScope handle_scope(args->isolate());
     v8::Local<v8::Object> wrapper;
     if (!session->GetWrapper(args->isolate()).ToLocal(&wrapper)) {
       return v8::Null(args->isolate());
@@ -1905,7 +1901,6 @@ v8::Local<v8::Value> FromPath(const base::FilePath& path,
   Session* session = Session::FromPath(args, path, std::move(options));
 
   if (session) {
-    v8::HandleScope handle_scope(args->isolate());
     v8::Local<v8::Object> wrapper;
     if (!session->GetWrapper(args->isolate()).ToLocal(&wrapper)) {
       return v8::Null(args->isolate());

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3756,7 +3756,6 @@ v8::Local<v8::Value> WebContents::GetOwnerBrowserWindow(
 }
 
 v8::Local<v8::Value> WebContents::Session(v8::Isolate* isolate) {
-  v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Object> wrapper;
   if (!session_->GetWrapper(isolate).ToLocal(&wrapper)) {
     return v8::Null(isolate);
@@ -3806,7 +3805,6 @@ v8::Local<v8::Value> WebContents::Debugger(v8::Isolate* isolate) {
     debugger_ = electron::api::Debugger::Create(isolate, web_contents());
   }
 
-  v8::HandleScope handle_scope{isolate};
   v8::Local<v8::Object> wrapper;
   if (!debugger_->GetWrapper(isolate).ToLocal(&wrapper)) {
     return v8::Null(isolate);


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/48308#discussion_r2348597086

These callsites already get an associated default handle scope when V8 invokes them, these should have been an `EscapableHandleScope` if at all we need to add one.

The crash can be repro when running our test suites under `is_debug=true` build. Thanks to report from openfin cc @marekharanczyk

#### Release Notes

Notes: fix crash when accessing `webContents.session` or `webContents.debugger`