### PR TITLE
ci: Use Local Execution, Remote Caching (LERC) for fork PRS

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -44,6 +44,14 @@ runs:
     - name: Add Clang problem matcher
       shell: bash
       run: echo "::add-matcher::src/electron/.github/problem-matchers/clang.json"
+    - name: Setup Siso for fork pull requests
+      if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+      shell: bash
+      run: |
+        # Use Local Execution, Remote Caching (LERC). Checks the remote cache for action
+        # matches and uses existing results if a match is found. If not, execution of the
+        # action is performed locally.
+        echo "RBE_exec_strategy=local" >> $GITHUB_ENV
     - name: Build Electron ${{ inputs.step-suffix }}
       shell: bash
       run: |


### PR DESCRIPTION
#### Description of Change
- Since #47534, fork PRs have been failing trying to use siso with the error: ```PermissionDenied desc = Failed to authorize to Execute() against instance name "projects/electron-rbe/instances/default_instance": Permission denied``` (eg see https://github.com/electron/electron/actions/runs/17621870487/job/50277249344#step:24:33167).

Since fork PRs only have read access to the RBE cache that siso uses, this PR fixes that error by setting the RBE exec strategy to `local` which has the following operation:
> Use Local Execution, Remote Caching (LERC). Checks the remote cache for action matches and uses existing results if a match is found. If not, execution of the action is performed locally.

Successful builds with this strategy can be seen here: https://github.com/electron/electron/actions/runs/17739060216?pr=48320.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
