### PR TITLE
chore: cherry-pick ec6c18478382 from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -1,1 +1,2 @@
 chore_allow_customizing_microtask_policy_per_context.patch
+cherry-pick-ec6c18478382.patch

--- a/patches/v8/cherry-pick-ec6c18478382.patch
+++ b/patches/v8/cherry-pick-ec6c18478382.patch
@@ -1,0 +1,46 @@
+From ec6c184783824fa8f974013aae28a45c36c0112f Mon Sep 17 00:00:00 2001
+From: Darius Mercadier <dmercadier@chromium.org>
+Date: Tue, 16 Sep 2025 16:40:24 +0200
+Subject: [PATCH] [compiler] Don't assume that upper 32-bit of Int32MulOvfCheck are 0
+
+Because Arm64 doesn't have a flag-setting 32-bit multiplication,
+which means that instead with use a 64-bit multiplication, and compare
+result.X() and result.W() to check if an overflow happened. But this
+leads to the upper 32-bit not being zeroed.
+
+Fixed: 445380761
+Change-Id: I31287faf37dc615695047021324e9d1d802cbec2
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6954290
+Auto-Submit: Darius Mercadier <dmercadier@chromium.org>
+Commit-Queue: Leszek Swirski <leszeks@chromium.org>
+Reviewed-by: Leszek Swirski <leszeks@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#102530}
+---
+
+diff --git a/src/compiler/backend/arm64/instruction-selector-arm64.cc b/src/compiler/backend/arm64/instruction-selector-arm64.cc
+index 2b6d584..0aad1ef 100644
+--- a/src/compiler/backend/arm64/instruction-selector-arm64.cc
++++ b/src/compiler/backend/arm64/instruction-selector-arm64.cc
+@@ -2973,9 +2973,19 @@
+       return op.Cast<ShiftOp>().rep == WordRepresentation::Word32();
+     case Opcode::kComparison:
+       return op.Cast<ComparisonOp>().rep == RegisterRepresentation::Word32();
+-    case Opcode::kOverflowCheckedBinop:
+-      return op.Cast<OverflowCheckedBinopOp>().rep ==
+-             WordRepresentation::Word32();
++    case Opcode::kOverflowCheckedBinop: {
++      const OverflowCheckedBinopOp& binop = op.Cast<OverflowCheckedBinopOp>();
++      if (binop.rep != WordRepresentation::Word32()) return false;
++      switch (binop.kind) {
++        case OverflowCheckedBinopOp::Kind::kSignedAdd:
++        case OverflowCheckedBinopOp::Kind::kSignedSub:
++          return true;
++        case OverflowCheckedBinopOp::Kind::kSignedMul:
++          // EmitInt32MulWithOverflow doesn't zero-extend because Arm64 doesn't
++          // have a flag-setting int32 multiplication.
++          return false;
++      }
++    }
+     case Opcode::kProjection:
+       return ZeroExtendsWord32ToWord64NoPhis(op.Cast<ProjectionOp>().input());
+     case Opcode::kLoad: {

--- a/patches/v8/cherry-pick-ec6c18478382.patch
+++ b/patches/v8/cherry-pick-ec6c18478382.patch
@@ -1,7 +1,7 @@
-From ec6c184783824fa8f974013aae28a45c36c0112f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Darius Mercadier <dmercadier@chromium.org>
 Date: Tue, 16 Sep 2025 16:40:24 +0200
-Subject: [PATCH] [compiler] Don't assume that upper 32-bit of Int32MulOvfCheck are 0
+Subject: Don't assume that upper 32-bit of Int32MulOvfCheck are 0
 
 Because Arm64 doesn't have a flag-setting 32-bit multiplication,
 which means that instead with use a 64-bit multiplication, and compare
@@ -15,13 +15,12 @@ Auto-Submit: Darius Mercadier <dmercadier@chromium.org>
 Commit-Queue: Leszek Swirski <leszeks@chromium.org>
 Reviewed-by: Leszek Swirski <leszeks@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#102530}
----
 
 diff --git a/src/compiler/backend/arm64/instruction-selector-arm64.cc b/src/compiler/backend/arm64/instruction-selector-arm64.cc
-index 2b6d584..0aad1ef 100644
+index 60ff1ee97931edfcca28b6f5f7c4918d015af974..0212f4570750599bc266a1cd8c9efa19ea26e85c 100644
 --- a/src/compiler/backend/arm64/instruction-selector-arm64.cc
 +++ b/src/compiler/backend/arm64/instruction-selector-arm64.cc
-@@ -2973,9 +2973,19 @@
+@@ -2958,9 +2958,19 @@ bool InstructionSelector::ZeroExtendsWord32ToWord64NoPhis(OpIndex node) {
        return op.Cast<ShiftOp>().rep == WordRepresentation::Word32();
      case Opcode::kComparison:
        return op.Cast<ComparisonOp>().rep == RegisterRepresentation::Word32();


### PR DESCRIPTION
[compiler] Don't assume that upper 32-bit of Int32MulOvfCheck are 0

Because Arm64 doesn't have a flag-setting 32-bit multiplication,
which means that instead with use a 64-bit multiplication, and compare
result.X() and result.W() to check if an overflow happened. But this
leads to the upper 32-bit not being zeroed.

Fixed: 445380761
Change-Id: I31287faf37dc615695047021324e9d1d802cbec2
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6954290
Auto-Submit: Darius Mercadier <dmercadier@chromium.org>
Commit-Queue: Leszek Swirski <leszeks@chromium.org>
Reviewed-by: Leszek Swirski <leszeks@chromium.org>
Cr-Commit-Position: refs/heads/main@{#102530}


Notes: Backported fix for 445380761.