### PR TITLE
build: update build tools to get siso for forks fix

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -44,14 +44,6 @@ runs:
     - name: Add Clang problem matcher
       shell: bash
       run: echo "::add-matcher::src/electron/.github/problem-matchers/clang.json"
-    - name: Setup Siso for fork pull requests
-      if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-      shell: bash
-      run: |
-        # Use Local Execution, Remote Caching (LERC). Checks the remote cache for action
-        # matches and uses existing results if a match is found. If not, execution of the
-        # action is performed locally.
-        echo "RBE_exec_strategy=local" >> $GITHUB_ENV
     - name: Build Electron ${{ inputs.step-suffix }}
       shell: bash
       run: |

--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -15,7 +15,7 @@ runs:
         git config --global core.preloadindex true
         git config --global core.longpaths true
       fi
-      export BUILD_TOOLS_SHA=fb34fbad068586d9a6e2bb4e4950bdcf9aaee862
+      export BUILD_TOOLS_SHA=c13f4bdb50e65da46a4703f8f882079dd21fd99e
       npm i -g @electron/build-tools
       # Update depot_tools to ensure python
       e d update_depot_tools


### PR DESCRIPTION
#### Description of Change
- Followup to https://github.com/electron/electron/pull/48319. Unfortunately that change was not sufficient to fix running siso from fork PRS.  This PR updates build-tools to pull in https://github.com/electron/build-tools/pull/751, which will pass `-re_exec_enable=false` to autoninja when a user doesn't have execute rights on the RBE cluster. 

This change has been verified via https://github.com/electron/electron/actions/runs/17773115669/job/50514256655?pr=48331, which is a copy of of #48293 where there are build issues because fork PRs can't write to the RBE cluster.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
