### PR TITLE
refactor: use gin::Arguments in api::Clipboard

### DIFF
--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -22,15 +22,18 @@
 #include "ui/gfx/codec/png_codec.h"
 #include "ui/gfx/image/image.h"
 
-namespace electron::api {
+namespace {
 
-ui::ClipboardBuffer Clipboard::GetClipboardBuffer(gin_helper::Arguments* args) {
+[[nodiscard]] ui::ClipboardBuffer GetClipboardBuffer(gin::Arguments* args) {
   std::string type;
-  if (args->GetNext(&type) && type == "selection")
-    return ui::ClipboardBuffer::kSelection;
-  else
-    return ui::ClipboardBuffer::kCopyPaste;
+  return args->GetNext(&type) && type == "selection"
+             ? ui::ClipboardBuffer::kSelection
+             : ui::ClipboardBuffer::kCopyPaste;
 }
+
+}  // namespace
+
+namespace electron::api {
 
 std::vector<std::u16string> Clipboard::AvailableFormats(
     gin_helper::Arguments* args) {

--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -97,10 +97,10 @@ std::string Clipboard::Read(const std::string& format_string) {
   return data;
 }
 
-v8::Local<v8::Value> Clipboard::ReadBuffer(const std::string& format_string,
-                                           gin_helper::Arguments* args) {
+v8::Local<v8::Value> Clipboard::ReadBuffer(v8::Isolate* const isolate,
+                                           const std::string& format_string) {
   std::string data = Read(format_string);
-  return electron::Buffer::Copy(args->isolate(), data).ToLocalChecked();
+  return electron::Buffer::Copy(isolate, data).ToLocalChecked();
 }
 
 void Clipboard::WriteBuffer(const std::string& format,

--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -206,10 +206,10 @@ void Clipboard::WriteHTML(const std::u16string& html,
   writer.WriteHTML(html, std::string());
 }
 
-v8::Local<v8::Value> Clipboard::ReadBookmark(gin_helper::Arguments* args) {
+v8::Local<v8::Value> Clipboard::ReadBookmark(v8::Isolate* const isolate) {
   std::u16string title;
   std::string url;
-  auto dict = gin_helper::Dictionary::CreateEmpty(args->isolate());
+  auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
   clipboard->ReadBookmark(/* data_dst = */ nullptr, &title, &url);
   dict.Set("title", title);

--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -36,7 +36,7 @@ namespace {
 namespace electron::api {
 
 std::vector<std::u16string> Clipboard::AvailableFormats(
-    gin_helper::Arguments* args) {
+    gin::Arguments* const args) {
   std::vector<std::u16string> format_types;
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
   clipboard->ReadAvailableTypes(GetClipboardBuffer(args),
@@ -45,7 +45,7 @@ std::vector<std::u16string> Clipboard::AvailableFormats(
 }
 
 bool Clipboard::Has(const std::string& format_string,
-                    gin_helper::Arguments* args) {
+                    gin::Arguments* const args) {
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
   ui::ClipboardFormatType format =
       ui::ClipboardFormatType::CustomPlatformType(format_string);
@@ -108,9 +108,9 @@ v8::Local<v8::Value> Clipboard::ReadBuffer(v8::Isolate* const isolate,
 
 void Clipboard::WriteBuffer(const std::string& format,
                             const v8::Local<v8::Value> buffer,
-                            gin_helper::Arguments* args) {
+                            gin::Arguments* const args) {
   if (!node::Buffer::HasInstance(buffer)) {
-    args->ThrowError("buffer must be a node Buffer");
+    args->ThrowTypeError("buffer must be a node Buffer");
     return;
   }
 
@@ -127,7 +127,7 @@ void Clipboard::WriteBuffer(const std::string& format,
 }
 
 void Clipboard::Write(const gin_helper::Dictionary& data,
-                      gin_helper::Arguments* args) {
+                      gin::Arguments* const args) {
   ui::ScopedClipboardWriter writer(GetClipboardBuffer(args));
   std::u16string text, html, bookmark;
   gfx::Image image;
@@ -151,7 +151,7 @@ void Clipboard::Write(const gin_helper::Dictionary& data,
     writer.WriteImage(image.AsBitmap());
 }
 
-std::u16string Clipboard::ReadText(gin_helper::Arguments* args) {
+std::u16string Clipboard::ReadText(gin::Arguments* const args) {
   std::u16string data;
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
   auto type = GetClipboardBuffer(args);
@@ -173,24 +173,24 @@ std::u16string Clipboard::ReadText(gin_helper::Arguments* args) {
 }
 
 void Clipboard::WriteText(const std::u16string& text,
-                          gin_helper::Arguments* args) {
+                          gin::Arguments* const args) {
   ui::ScopedClipboardWriter writer(GetClipboardBuffer(args));
   writer.WriteText(text);
 }
 
-std::u16string Clipboard::ReadRTF(gin_helper::Arguments* args) {
+std::u16string Clipboard::ReadRTF(gin::Arguments* const args) {
   std::string data;
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
   clipboard->ReadRTF(GetClipboardBuffer(args), /* data_dst = */ nullptr, &data);
   return base::UTF8ToUTF16(data);
 }
 
-void Clipboard::WriteRTF(const std::string& text, gin_helper::Arguments* args) {
+void Clipboard::WriteRTF(const std::string& text, gin::Arguments* const args) {
   ui::ScopedClipboardWriter writer(GetClipboardBuffer(args));
   writer.WriteRTF(text);
 }
 
-std::u16string Clipboard::ReadHTML(gin_helper::Arguments* args) {
+std::u16string Clipboard::ReadHTML(gin::Arguments* const args) {
   std::u16string data;
   std::u16string html;
   std::string url;
@@ -204,7 +204,7 @@ std::u16string Clipboard::ReadHTML(gin_helper::Arguments* args) {
 }
 
 void Clipboard::WriteHTML(const std::u16string& html,
-                          gin_helper::Arguments* args) {
+                          gin::Arguments* const args) {
   ui::ScopedClipboardWriter writer(GetClipboardBuffer(args));
   writer.WriteHTML(html, std::string());
 }
@@ -222,15 +222,15 @@ v8::Local<v8::Value> Clipboard::ReadBookmark(v8::Isolate* const isolate) {
 
 void Clipboard::WriteBookmark(const std::u16string& title,
                               const std::string& url,
-                              gin_helper::Arguments* args) {
+                              gin::Arguments* const args) {
   ui::ScopedClipboardWriter writer(GetClipboardBuffer(args));
   writer.WriteBookmark(title, url);
 }
 
-gfx::Image Clipboard::ReadImage(gin_helper::Arguments* args) {
+gfx::Image Clipboard::ReadImage(gin::Arguments* const args) {
   // The ReadPng uses thread pool which requires app ready.
   if (IsBrowserProcess() && !Browser::Get()->is_ready()) {
-    args->ThrowError(
+    gin_helper::ErrorThrower{args->isolate()}.ThrowError(
         "clipboard.readImage is available only after app ready in the main "
         "process");
     return {};
@@ -259,7 +259,7 @@ gfx::Image Clipboard::ReadImage(gin_helper::Arguments* args) {
 }
 
 void Clipboard::WriteImage(const gfx::Image& image,
-                           gin_helper::Arguments* args) {
+                           gin::Arguments* const args) {
   ui::ScopedClipboardWriter writer(GetClipboardBuffer(args));
   SkBitmap orig = image.AsBitmap();
   SkBitmap bmp;
@@ -277,7 +277,7 @@ std::u16string Clipboard::ReadFindText() {
 }
 #endif
 
-void Clipboard::Clear(gin_helper::Arguments* args) {
+void Clipboard::Clear(gin::Arguments* const args) {
   ui::Clipboard::GetForCurrentThread()->Clear(GetClipboardBuffer(args));
 }
 

--- a/shell/common/api/electron_api_clipboard.h
+++ b/shell/common/api/electron_api_clipboard.h
@@ -50,7 +50,7 @@ class Clipboard {
   static void WriteHTML(const std::u16string& html,
                         gin_helper::Arguments* args);
 
-  static v8::Local<v8::Value> ReadBookmark(gin_helper::Arguments* args);
+  static v8::Local<v8::Value> ReadBookmark(v8::Isolate* isolate);
   static void WriteBookmark(const std::u16string& title,
                             const std::string& url,
                             gin_helper::Arguments* args);

--- a/shell/common/api/electron_api_clipboard.h
+++ b/shell/common/api/electron_api_clipboard.h
@@ -61,8 +61,8 @@ class Clipboard {
   static std::u16string ReadFindText();
   static void WriteFindText(const std::u16string& text);
 
-  static v8::Local<v8::Value> ReadBuffer(const std::string& format_string,
-                                         gin_helper::Arguments* args);
+  static v8::Local<v8::Value> ReadBuffer(v8::Isolate* isolate,
+                                         const std::string& format_string);
   static void WriteBuffer(const std::string& format_string,
                           const v8::Local<v8::Value> buffer,
                           gin_helper::Arguments* args);

--- a/shell/common/api/electron_api_clipboard.h
+++ b/shell/common/api/electron_api_clipboard.h
@@ -16,8 +16,11 @@ namespace gfx {
 class Image;
 }  // namespace gfx
 
-namespace gin_helper {
+namespace gin {
 class Arguments;
+}  // namespace gin
+
+namespace gin_helper {
 class Dictionary;
 }  // namespace gin_helper
 
@@ -29,34 +32,29 @@ class Clipboard {
   Clipboard(const Clipboard&) = delete;
   Clipboard& operator=(const Clipboard&) = delete;
 
-  static std::vector<std::u16string> AvailableFormats(
-      gin_helper::Arguments* args);
-  static bool Has(const std::string& format_string,
-                  gin_helper::Arguments* args);
-  static void Clear(gin_helper::Arguments* args);
+  static std::vector<std::u16string> AvailableFormats(gin::Arguments* args);
+  static bool Has(const std::string& format_string, gin::Arguments* args);
+  static void Clear(gin::Arguments* args);
 
   static std::string Read(const std::string& format_string);
-  static void Write(const gin_helper::Dictionary& data,
-                    gin_helper::Arguments* args);
+  static void Write(const gin_helper::Dictionary& data, gin::Arguments* args);
 
-  static std::u16string ReadText(gin_helper::Arguments* args);
-  static void WriteText(const std::u16string& text,
-                        gin_helper::Arguments* args);
+  static std::u16string ReadText(gin::Arguments* args);
+  static void WriteText(const std::u16string& text, gin::Arguments* args);
 
-  static std::u16string ReadRTF(gin_helper::Arguments* args);
-  static void WriteRTF(const std::string& text, gin_helper::Arguments* args);
+  static std::u16string ReadRTF(gin::Arguments* args);
+  static void WriteRTF(const std::string& text, gin::Arguments* args);
 
-  static std::u16string ReadHTML(gin_helper::Arguments* args);
-  static void WriteHTML(const std::u16string& html,
-                        gin_helper::Arguments* args);
+  static std::u16string ReadHTML(gin::Arguments* args);
+  static void WriteHTML(const std::u16string& html, gin::Arguments* args);
 
   static v8::Local<v8::Value> ReadBookmark(v8::Isolate* isolate);
   static void WriteBookmark(const std::u16string& title,
                             const std::string& url,
-                            gin_helper::Arguments* args);
+                            gin::Arguments* args);
 
-  static gfx::Image ReadImage(gin_helper::Arguments* args);
-  static void WriteImage(const gfx::Image& image, gin_helper::Arguments* args);
+  static gfx::Image ReadImage(gin::Arguments* args);
+  static void WriteImage(const gfx::Image& image, gin::Arguments* args);
 
   static std::u16string ReadFindText();
   static void WriteFindText(const std::u16string& text);
@@ -65,7 +63,7 @@ class Clipboard {
                                          const std::string& format_string);
   static void WriteBuffer(const std::string& format_string,
                           const v8::Local<v8::Value> buffer,
-                          gin_helper::Arguments* args);
+                          gin::Arguments* args);
 
   static void WriteFilesForTesting(const std::vector<base::FilePath>& files);
 };

--- a/shell/common/api/electron_api_clipboard.h
+++ b/shell/common/api/electron_api_clipboard.h
@@ -68,9 +68,6 @@ class Clipboard {
                           gin_helper::Arguments* args);
 
   static void WriteFilesForTesting(const std::vector<base::FilePath>& files);
-
- private:
-  static ui::ClipboardBuffer GetClipboardBuffer(gin_helper::Arguments* args);
 };
 
 }  // namespace electron::api

--- a/shell/common/api/electron_api_clipboard.h
+++ b/shell/common/api/electron_api_clipboard.h
@@ -29,7 +29,6 @@ class Clipboard {
   Clipboard(const Clipboard&) = delete;
   Clipboard& operator=(const Clipboard&) = delete;
 
-  static ui::ClipboardBuffer GetClipboardBuffer(gin_helper::Arguments* args);
   static std::vector<std::u16string> AvailableFormats(
       gin_helper::Arguments* args);
   static bool Has(const std::string& format_string,
@@ -69,6 +68,9 @@ class Clipboard {
                           gin_helper::Arguments* args);
 
   static void WriteFilesForTesting(const std::vector<base::FilePath>& files);
+
+ private:
+  static ui::ClipboardBuffer GetClipboardBuffer(gin_helper::Arguments* args);
 };
 
 }  // namespace electron::api


### PR DESCRIPTION
#### Description of Change

Small refactor to reduce our use of bespoke gin code.

This PR uses `gin::Arguments*` instead of `gin_helper::Arguments*` in `api::Clipboard`. Clipboard doesn't use any of the extra features in `gin_helper::Arguments`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none