### PR TITLE
chore: remove unused, undocumented, untested executionMode arg from `web_frame.executeJavaScriptInIsolatedWorld()`

### DIFF
--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -700,20 +700,6 @@ class WebFrameRenderer final
     bool has_user_gesture = false;
     args->GetNext(&has_user_gesture);
 
-    blink::mojom::EvaluationTiming script_execution_type =
-        blink::mojom::EvaluationTiming::kSynchronous;
-    blink::mojom::LoadEventBlockingOption load_blocking_option =
-        blink::mojom::LoadEventBlockingOption::kDoNotBlock;
-    std::string execution_type;
-    args->GetNext(&execution_type);
-
-    if (execution_type == "asynchronous") {
-      script_execution_type = blink::mojom::EvaluationTiming::kAsynchronous;
-    } else if (execution_type == "asynchronousBlockingOnload") {
-      script_execution_type = blink::mojom::EvaluationTiming::kAsynchronous;
-      load_blocking_option = blink::mojom::LoadEventBlockingOption::kBlock;
-    }
-
     ScriptExecutionCallback::CompletionCallback completion_callback;
     args->GetNext(&completion_callback);
 
@@ -749,7 +735,9 @@ class WebFrameRenderer final
         world_id, base::span(sources),
         has_user_gesture ? blink::mojom::UserActivationOption::kActivate
                          : blink::mojom::UserActivationOption::kDoNotActivate,
-        script_execution_type, load_blocking_option, base::NullCallback(),
+        blink::mojom::EvaluationTiming::kSynchronous,
+        blink::mojom::LoadEventBlockingOption::kDoNotBlock,
+        base::NullCallback(),
         base::BindOnce(&ScriptExecutionCallback::Completed,
                        base::Unretained(self)),
         blink::BackForwardCacheAware::kPossiblyDisallow,


### PR DESCRIPTION
#### Description of Change

Remove code that parses a never-used, never-documented, never-tested `executionType` argument in `web_frame.executeJavaScriptInIsolatedWorld()`. This wart goes all the way back to when the feature originally landed in 2017 in https://github.com/electron/electron/pull/11131 which added the feature.

As [documented](https://github.com/electron/electron/blob/main/docs/api/web-frame.md#webframeexecutejavascriptinisolatedworldworldid-scripts-usergesture-callback), the API is:

```
### `webFrame.executeJavaScriptInIsolatedWorld(worldId, scripts[, userGesture, callback])`

* `worldId` Integer
* `scripts` [WebSource[]](structures/web-source.md)
* `userGesture` Boolean (optional) - Default is `false`.
* `callback` Function (optional) - Called after script has been executed.
  * `result` Any
```

But the implementation works this way:

```
### `webFrame.executeJavaScriptInIsolatedWorld(worldId, scripts[[, executionMode], userGesture, callback])`

* `worldId` Integer
* `scripts` [WebSource[]](structures/web-source.md) 
* `executionMode` string (optional) - Can be `synchronous`, `asynchronous`, or `asynchronousBlockingOnload`. Defaults to `synchronous`.
* `userGesture` Boolean (optional) - Default is `false`.
* `callback` Function (optional) - Called after script has been executed.
  * `result` Any
```

We should either remove this code or document and test the feature. Removal seems like the right choice since [nobody's ever requested this feature](https://github.com/electron/electron/issues?q=is%3Aissue%20executeJavaScriptInIsolatedWorld%20asynchronous).

I'm not sure who to CC as a stakeholder here? @deepak1556 was the last person to touch this code, though only [as part of a Chromium roll](https://github.com/electron/electron/pull/35375/commits/f54582dac60cbc963877b80e7ec8508ddc). Also CC @electron/wg-api in case they want to consider adding documentation + tests for this option instead of removing it?  62b1bc)

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none