### PR TITLE
fix: add missed enum `SaveRequestTypet` to PdfViewerPrivate function

### DIFF
--- a/shell/common/extensions/api/pdf_viewer_private.idl
+++ b/shell/common/extensions/api/pdf_viewer_private.idl
@@ -6,6 +6,15 @@
 // functionality that the PDF Viewer needs from outside the PDF plugin. This API
 // is exclusively for the PDF Viewer.
 namespace pdfViewerPrivate {
+  // Must match `SaveRequestType` in `pdf/mojom/pdf.mojom` and
+  // `tools/typescript/definitions/pdf_viewer_private.d.ts`.
+  enum SaveRequestType {
+    ANNOTATION,
+    ORIGINAL,
+    EDITED,
+    SEARCHIFIED
+  };
+
   // Nearly identical to mimeHandlerPrivate.StreamInfo, but without a mime type
   // nor a response header field. Those fields are unused by the PDF viewer.
   dictionary StreamInfo {
@@ -51,6 +60,13 @@ namespace pdfViewerPrivate {
     static void isAllowedLocalFileAccess(
         DOMString url,
         IsAllowedLocalFileAccessCallback callback);
+
+    // Sends a request to save the PDF to Google Drive if `saveRequestType` is
+    // set. Otherwise, if `saveRequestType` is not set, the default action is
+    // to cancel the existing upload.
+    static void saveToDrive(
+        optional SaveRequestType saveRequestType,
+        optional VoidCallback callback);
 
     // Sets the current tab title to `title` for a full-page PDF.
     static void setPdfDocumentTitle(


### PR DESCRIPTION
#### Description of Change

Fix https://github.com/electron/electron/issues/48347

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix download button does not work in PDF Viewer
