### PR TITLE
fix: pdf download functionality

### DIFF
--- a/shell/browser/extensions/api/pdf_viewer_private/pdf_viewer_private_api.cc
+++ b/shell/browser/extensions/api/pdf_viewer_private/pdf_viewer_private_api.cc
@@ -25,6 +25,8 @@ namespace {
 namespace IsAllowedLocalFileAccess =
     api::pdf_viewer_private::IsAllowedLocalFileAccess;
 
+namespace SaveToDrive = api::pdf_viewer_private::SaveToDrive;
+
 namespace SetPdfPluginAttributes =
     api::pdf_viewer_private::SetPdfPluginAttributes;
 
@@ -105,6 +107,24 @@ PdfViewerPrivateIsAllowedLocalFileAccessFunction::Run() {
 
   return RespondNow(WithArguments(
       IsUrlAllowedToEmbedLocalFiles(GURL(params->url), base::Value::List())));
+}
+
+PdfViewerPrivateSaveToDriveFunction::PdfViewerPrivateSaveToDriveFunction() =
+    default;
+
+PdfViewerPrivateSaveToDriveFunction::~PdfViewerPrivateSaveToDriveFunction() =
+    default;
+
+ExtensionFunction::ResponseAction PdfViewerPrivateSaveToDriveFunction::Run() {
+#if BUILDFLAG(ENABLE_PDF_SAVE_TO_DRIVE)
+  std::optional<SaveToDrive::Params> params =
+      SaveToDrive::Params::Create(args());
+  EXTENSION_FUNCTION_VALIDATE(params);
+  // TODO(crbug.com/424208776): Start the save to drive flow.
+  return RespondNow(NoArguments());
+#else
+  return RespondNow(Error("Not supported"));
+#endif  // BUILDFLAG(ENABLE_PDF_SAVE_TO_DRIVE)
 }
 
 PdfViewerPrivateSetPdfDocumentTitleFunction::

--- a/shell/browser/extensions/api/pdf_viewer_private/pdf_viewer_private_api.h
+++ b/shell/browser/extensions/api/pdf_viewer_private/pdf_viewer_private_api.h
@@ -46,6 +46,24 @@ class PdfViewerPrivateIsAllowedLocalFileAccessFunction
   ResponseAction Run() override;
 };
 
+class PdfViewerPrivateSaveToDriveFunction : public ExtensionFunction {
+ public:
+  DECLARE_EXTENSION_FUNCTION("pdfViewerPrivate.saveToDrive",
+                             PDFVIEWERPRIVATE_SAVETODRIVE)
+
+  PdfViewerPrivateSaveToDriveFunction();
+  PdfViewerPrivateSaveToDriveFunction(
+      const PdfViewerPrivateSaveToDriveFunction&) = delete;
+  PdfViewerPrivateSaveToDriveFunction& operator=(
+      const PdfViewerPrivateSaveToDriveFunction&) = delete;
+
+ protected:
+  ~PdfViewerPrivateSaveToDriveFunction() override;
+
+  // Override from ExtensionFunction:
+  ResponseAction Run() override;
+};
+
 class PdfViewerPrivateSetPdfDocumentTitleFunction : public ExtensionFunction {
  public:
   DECLARE_EXTENSION_FUNCTION("pdfViewerPrivate.setPdfDocumentTitle",

--- a/shell/common/extensions/api/pdf_viewer_private.idl
+++ b/shell/common/extensions/api/pdf_viewer_private.idl
@@ -6,6 +6,14 @@
 // functionality that the PDF Viewer needs from outside the PDF plugin. This API
 // is exclusively for the PDF Viewer.
 namespace pdfViewerPrivate {
+  // Must match `SaveRequestType` in `pdf/pdf_view_web_plugin.h` and
+  // `tools/typescript/definitions/pdf_viewer_private.d.ts`.
+  enum SaveRequestType {
+    ANNOTATION,
+    ORIGINAL,
+    EDITED,
+    SEARCHIFIED
+  };
   // Nearly identical to mimeHandlerPrivate.StreamInfo, but without a mime type
   // nor a response header field. Those fields are unused by the PDF viewer.
   dictionary StreamInfo {
@@ -51,6 +59,11 @@ namespace pdfViewerPrivate {
     static void isAllowedLocalFileAccess(
         DOMString url,
         IsAllowedLocalFileAccessCallback callback);
+
+    // Sends a request to save the PDF to Google Drive.
+    static void saveToDrive(
+        SaveRequestType saveRequestType,
+        optional VoidCallback callback);
 
     // Sets the current tab title to `title` for a full-page PDF.
     static void setPdfDocumentTitle(


### PR DESCRIPTION
#### Description of Change

Refs https://chromium-review.googlesource.com/c/chromium/src/+/6682424

Closes https://github.com/electron/electron/issues/48347.

Fixes the above by updating our pdf private functionality for the new method and type.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the PDF viewer toolbar download button did nothing.
