### PR TITLE
fix: delay JS environment release to prevent V8 global double free on exit

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -184,7 +184,13 @@ ElectronBrowserMainParts::ElectronBrowserMainParts()
   self_ = this;
 }
 
-ElectronBrowserMainParts::~ElectronBrowserMainParts() = default;
+ElectronBrowserMainParts::~ElectronBrowserMainParts() {
+  content::GetUIThreadTaskRunner({})->PostTask(
+      FROM_HERE,
+      base::BindOnce(
+          [](std::unique_ptr<JavascriptEnvironment> js_env) { js_env.reset(); },
+          std::move(js_env_)));
+}
 
 // static
 ElectronBrowserMainParts* ElectronBrowserMainParts::Get() {


### PR DESCRIPTION
#### Description of Change

fixes: https://github.com/electron/electron/issues/47999
maybe fixes: https://github.com/electron/electron/issues/33041

This PR introduces a delayed release of the js_env to prevent double free issues with V8 global instances when Electron exits. 

Currently, when closing an Electron window while certain asynchronous operations (such as `process.getProcessMemoryInfo()`) are active, a double free can occur in V8. The root cause is that `JavascriptEnvironment` is released before pending `PromiseBase` objects, which hold V8 global references, are properly disposed.

This change ensures that the JS environment is released only after all asynchronous references have completed, preventing crashes related to premature disposal of V8 globals.

---

##### Motivation and Context

- Electron's shutdown sequence currently destroys the `JavascriptEnvironment` before all `PromiseBase` objects are freed.
- This leads to a crash with a reproducible stack trace in `v8::internal::GlobalHandles::NodeSpace<NodeType>::Free()`.
- Delaying the release of `JavascriptEnvironment` ensures proper order of destruction, maintaining stability.

**Crash Reproduction:**

In `main.js`, the following code reliably triggers the double free on exit:

```js
setInterval(() => {
  process.getProcessMemoryInfo().then((r) => {
    console.log(r)
  });
}, 4);
```


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: fix: delay JS environment release to prevent V8 global double free on exit
