### PR TITLE
fix: resizable wrong api call

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -301,7 +301,7 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
 
   widget()->Init(std::move(params));
   widget()->SetNativeWindowProperty(kNativeWindowKey.c_str(), this);
-  SetCanResize(resizable_);
+  SetResizable(resizable_);
 
   const bool fullscreen = options.ValueOrDefault(options::kFullscreen, false);
 
@@ -963,7 +963,6 @@ void NativeWindowViews::SetResizable(bool resizable) {
   }
 
   resizable_ = resizable;
-  SetCanResize(resizable_);
 
 #if BUILDFLAG(IS_WIN)
   UpdateThickFrame();


### PR DESCRIPTION
#### Description of Change

fix: #48352

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: The SetCanResize call here seems unnecessary because we manage the window state internally.
Calling SetCanResize directly would trigger `widget()->OnSizeConstraintsChanged()`, which would then cause `HWNDMessageHandler::SizeConstraintsChanged` to add an incorrect style.
I’m not sure if I’ve missed anything.
