### PR TITLE
fix: accentColor set distinguishes the frame

### DIFF
--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -595,7 +595,8 @@ void NativeWindowViews::UpdateWindowAccentColor(bool active) {
   }
 
   COLORREF final_color = border_color.value_or(DWMWA_COLOR_DEFAULT);
-  SetWindowBorderAndCaptionColor(GetAcceleratedWidget(), final_color, has_frame());
+  SetWindowBorderAndCaptionColor(GetAcceleratedWidget(), final_color,
+                                 has_frame());
 }
 
 void NativeWindowViews::SetAccentColor(


### PR DESCRIPTION
#### Description of Change

fix: #48192

<img width="854" height="534"  alt="image" src="https://github.com/user-attachments/assets/34c32771-f507-4ac2-9b92-22dc2084ec23" />


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: accentColor set distinguishes the frame
