### PR TITLE
fix: apply default accelerator for role-based menu items

### DIFF
--- a/lib/browser/api/menu-item.ts
+++ b/lib/browser/api/menu-item.ts
@@ -25,7 +25,7 @@ const MenuItem = function (this: any, options: any) {
 
   this.overrideReadOnlyProperty('type', roles.getDefaultType(this.role));
   this.overrideReadOnlyProperty('role');
-  this.overrideReadOnlyProperty('accelerator');
+  this.overrideReadOnlyProperty('accelerator', roles.getDefaultAccelerator(this.role));
   this.overrideReadOnlyProperty('icon');
   this.overrideReadOnlyProperty('submenu');
 


### PR DESCRIPTION
Role-based menu items (copy, paste, cut, etc.) were returning null for their accelerator property instead of the expected keyboard shortcuts defined in menu-item-roles.ts.

Fixed by passing roles.getDefaultAccelerator(this.role) as the default value to overrideReadOnlyProperty('accelerator').

#### Description of Change

Role-based menu items (copy, paste, cut, undo, redo, selectall, etc.) were returning `null` for their `accelerator` property instead of the expected keyboard shortcuts defined in `menu-item-roles.ts`.

The issue was in `lib/browser/api/menu-item.ts` line 28, where `overrideReadOnlyProperty('accelerator')` was called without a default value, causing the accelerator to be set to `null` instead of the predefined shortcuts like `CommandOrControl+C`, `CommandOrControl+V`, etc.

This fix passes `roles.getDefaultAccelerator(this.role)` as the default value to `overrideReadOnlyProperty('accelerator')`, making it consistent with how other properties like `label` and `registerAccelerator` are handled.

## Checklist

- [] PR description included and stakeholders cc'd
- [] `npm test` passes  
- [] PR release notes describe the change in a way relevant to app developers, and are capitalized, punctuated, and past tense.

## Release Notes

**Notes:** Fixed role-based menu items returning correct keyboard accelerators instead of null.