### PR TITLE
docs: recommend calling renderer process modules from preload script

### DIFF
--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -4,6 +4,12 @@
 
 Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process) (non-sandboxed only)
 
+> [!IMPORTANT]
+> If you want to call this API from a renderer process with context isolation enabled,
+> place the API call in your preload script and
+> [expose](../tutorial/context-isolation.md#after-context-isolation-enabled) it using the
+> [`contextBridge`](context-bridge.md) API.
+
 On Linux, there is also a `selection` clipboard. To manipulate it
 you need to pass `selection` to each method:
 

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -4,6 +4,12 @@
 
 Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process)
 
+> [!IMPORTANT]
+> If you want to call this API from a renderer process with context isolation enabled,
+> place the API call in your preload script and
+> [expose](../tutorial/context-isolation.md#after-context-isolation-enabled) it using the
+> [`contextBridge`](context-bridge.md) API.
+
 The following is an example of setting up Electron to automatically submit
 crash reports to a remote server:
 

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -20,6 +20,12 @@ changes:
 
 Process: [Renderer](../glossary.md#renderer-process)
 
+> [!IMPORTANT]
+> If you want to call this API from a renderer process with context isolation enabled,
+> place the API call in your preload script and
+> [expose](../tutorial/context-isolation.md#after-context-isolation-enabled) it using the
+> [`contextBridge`](context-bridge.md) API.
+
 The `ipcRenderer` module is an  [EventEmitter][event-emitter]. It provides a few
 methods so you can send synchronous and asynchronous messages from the render
 process (web page) to the main process. You can also receive replies from the

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -4,6 +4,12 @@
 
 Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process)
 
+> [!IMPORTANT]
+> If you want to call this API from a renderer process with context isolation enabled,
+> place the API call in your preload script and
+> [expose](../tutorial/context-isolation.md#after-context-isolation-enabled) it using the
+> [`contextBridge`](context-bridge.md) API.
+
 The `nativeImage` module provides a unified interface for manipulating
 system images. These can be handy if you want to provide multiple scaled
 versions of the same icon or take advantage of macOS [template images][template-image].

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -4,6 +4,12 @@
 
 Process: [Renderer](../glossary.md#renderer-process)
 
+> [!IMPORTANT]
+> If you want to call this API from a renderer process with context isolation enabled,
+> place the API call in your preload script and
+> [expose](../tutorial/context-isolation.md#after-context-isolation-enabled) it using the
+> [`contextBridge`](context-bridge.md) API.
+
 `webFrame` export of the Electron module is an instance of the `WebFrame`
 class representing the current frame. Sub-frames can be retrieved by
 certain properties and methods (e.g. `webFrame.firstChild`).

--- a/docs/api/web-utils.md
+++ b/docs/api/web-utils.md
@@ -4,6 +4,12 @@
 
 Process: [Renderer](../glossary.md#renderer-process)
 
+> [!IMPORTANT]
+> If you want to call this API from a renderer process with context isolation enabled,
+> place the API call in your preload script and
+> [expose](../tutorial/context-isolation.md#after-context-isolation-enabled) it using the
+> [`contextBridge`](context-bridge.md) API.
+
 ## Methods
 
 The `webUtils` module has the following methods:


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Refs https://github.com/electron/electron/issues/45666

As discussed [here](https://github.com/electron/electron/pull/45861#discussion_r2393055125). CC @MarshallOfSound.

We've had many confused users in the bug tracker who had context isolation enabled and struggled to call `webUtils.getPathForFile`. This makes it clear that when context isolation is enabled, renderer process modules need to be called from the preload script.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none