### PR TITLE
docs: update allowed `window.open` options

### DIFF
--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -39,8 +39,8 @@ consider using `webContents.setWindowOpenHandler` to customize the
 BrowserWindow creation.
 
 A subset of [`WebPreferences`](structures/web-preferences.md) can be set directly,
-unnested, from the features string: `zoomFactor`, `nodeIntegration`, `preload`,
-`javascript`, `contextIsolation`, and `webviewTag`.
+unnested, from the features string: `zoomFactor`, `nodeIntegration`, `javascript`,
+`contextIsolation`, and `webviewTag`.
 
 For example:
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Fixes https://github.com/electron/electron/issues/48271

The `preload` option was removed in https://github.com/electron/electron/pull/23226.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
