### PR TITLE
docs: clarify optional args in webFrame.executeJavaScript()

### DIFF
--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -139,7 +139,7 @@ by its key, which is returned from `webFrame.insertCSS(css)`.
 
 Inserts `text` to the focused element.
 
-### `webFrame.executeJavaScript(code[, userGesture, callback])`
+### `webFrame.executeJavaScript(code[, userGesture][, callback])`
 
 * `code` string
 * `userGesture` boolean (optional) - Default is `false`.
@@ -160,7 +160,7 @@ In the browser window some HTML APIs like `requestFullScreen` can only be
 invoked by a gesture from the user. Setting `userGesture` to `true` will remove
 this limitation.
 
-### `webFrame.executeJavaScriptInIsolatedWorld(worldId, scripts[, userGesture, callback])`
+### `webFrame.executeJavaScriptInIsolatedWorld(worldId, scripts[, userGesture][, callback])`
 
 * `worldId` Integer - The ID of the world to run the javascript
             in, `0` is the default main world (where content runs), `999` is the


### PR DESCRIPTION
#### Description of Change

Fix a small documentation bug for the optional arguments in `webFrame.executeJavaScript()` and `webFrame.executeJavaScriptInIsolatedWorld()`: the `hasUserGesture` argument can be omitted, even when a callback is provided:

```diff
-### `webFrame.executeJavaScript(code[, userGesture, callback])`
+### `webFrame.executeJavaScript(code[, userGesture][, callback])`
```

This PR brings the docs in line with the pre-existing, tested behavior. Our tests do this in several places: [1](https://github.com/electron/electron/blob/main/spec/api-web-frame-spec.ts#L208), [2](https://github.com/electron/electron/blob/main/spec/api-web-frame-spec.ts#L223), [3](https://github.com/electron/electron/blob/main/spec/api-web-frame-spec.ts#L238), [4](https://github.com/electron/electron/blob/main/spec/api-web-frame-spec.ts#L253).

All reviews welcomed! CC @deepak1556, who reviewed a similar recent PR #48361

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.