### PR TITLE
fix: support custom macOS packages in file dialogs

### DIFF
--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -135,8 +135,19 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
           [content_types_set addObject:utt];
         }
       } else {
-        if (UTType* utt = [UTType typeWithFilenameExtension:@(ext.c_str())])
+        // First try to create a UTType conforming to package type, which is
+        // necessary for custom macOS packages like .rtfd to be recognized
+        // properly in file dialogs. If that fails, fall back to the regular
+        // method.
+        UTType* packageType = [UTType typeWithIdentifier:@"com.apple.package"];
+        UTType* utt = [UTType typeWithFilenameExtension:@(ext.c_str())
+                                       conformingToType:packageType];
+        if (!utt) {
+          utt = [UTType typeWithFilenameExtension:@(ext.c_str())];
+        }
+        if (utt) {
           [content_types_set addObject:utt];
+        }
       }
     }
 


### PR DESCRIPTION
Fixes an issue where custom macOS package types (like .rtfd) were not properly recognized in file dialogs when filtering by extension. The problem occurred because UTType creation didn't specify the package conformance, causing the system to not recognize these files as valid packages.

The fix attempts to create UTTypes with com.apple.package conformance first, then falls back to the regular method if that fails. This ensures that package extensions like .rtfd are properly recognized while maintaining compatibility with non-package file types.

Fixes #48191 👈 explains how to create .rtfd file to test
/cc @codebytere 

#### Description of Change

Adds `typeWithIdentifier:@"com.apple.package"` to extension matching.

#### Release Notes

Restored ability to open macOS "package" bundle files.
