### PR TITLE
refactor: DRY in App::SetAppLogPath()

### DIFF
--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -178,6 +178,8 @@ class App final : public gin::Wrappable<App>,
       const content::ChildProcessTerminationInfo& info) override;
 
  private:
+  [[nodiscard]] static base::FilePath GetDefaultAppLogPath();
+
   void BrowserChildProcessCrashedOrKilled(
       const content::ChildProcessData& data,
       const content::ChildProcessTerminationInfo& info);
@@ -190,8 +192,7 @@ class App final : public gin::Wrappable<App>,
                             const std::string& name = std::string());
   void ChildProcessDisconnected(content::ChildProcessId pid);
 
-  void SetAppLogsPath(gin_helper::ErrorThrower thrower,
-                      std::optional<base::FilePath> custom_path);
+  void SetAppLogsPath(gin::Arguments* args);
 
   // Get/Set the pre-defined path in PathService.
   base::FilePath GetPath(gin_helper::ErrorThrower thrower,

--- a/shell/browser/api/electron_api_app_mac.mm
+++ b/shell/browser/api/electron_api_app_mac.mm
@@ -17,30 +17,14 @@
 
 namespace electron::api {
 
-void App::SetAppLogsPath(gin_helper::ErrorThrower thrower,
-                         std::optional<base::FilePath> custom_path) {
-  if (custom_path.has_value()) {
-    if (!custom_path->IsAbsolute()) {
-      thrower.ThrowError("Path must be absolute");
-      return;
-    }
-    {
-      ScopedAllowBlockingForElectron allow_blocking;
-      base::PathService::Override(DIR_APP_LOGS, custom_path.value());
-    }
-  } else {
-    NSString* bundle_name =
-        [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"];
-    NSString* logs_path =
-        [NSString stringWithFormat:@"Library/Logs/%@", bundle_name];
-    NSString* library_path =
-        [NSHomeDirectory() stringByAppendingPathComponent:logs_path];
-    {
-      ScopedAllowBlockingForElectron allow_blocking;
-      base::PathService::Override(DIR_APP_LOGS,
-                                  base::FilePath([library_path UTF8String]));
-    }
-  }
+base::FilePath App::GetDefaultAppLogPath() {
+  NSString* bundle_name =
+      [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"];
+  NSString* logs_path =
+      [NSString stringWithFormat:@"Library/Logs/%@", bundle_name];
+  NSString* library_path =
+      [NSHomeDirectory() stringByAppendingPathComponent:logs_path];
+  return base::FilePath{[library_path UTF8String]};
 }
 
 void App::SetActivationPolicy(gin_helper::ErrorThrower thrower,


### PR DESCRIPTION
#### Description of Change

This PR has two goals:

1. Reduces duplicated code between the macOS and non-macOS implementations. `App::SetAppLogPath()` is now the same code on all platforms. The only platform-specific code is in a new static private helper function, `App::GetDefaultAppLogPath()`.

1. Indirectly helps the [small series](https://github.com/electron/electron/pull/48354) of PRs to reduce `gin_helper`'s footprint. One step in this series is to phase out marshalling `std::optional<T>` args through `gin_helper`, and this PR does that for `App::SetAppLogPath()`.

All reviews welcome! CC @codebytere as gin_helper stakeholder & as author of the code being refactored here

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.