### PR TITLE
perf: avoid a little extra work in `InvokeIpcCallback()`

### DIFF
--- a/shell/renderer/electron_ipc_native.cc
+++ b/shell/renderer/electron_ipc_native.cc
@@ -4,6 +4,8 @@
 
 #include "electron/shell/renderer/electron_ipc_native.h"
 
+#include <optional>
+
 #include "base/trace_event/trace_event.h"
 #include "shell/common/gin_converters/blink_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
@@ -45,10 +47,9 @@ void InvokeIpcCallback(v8::Isolate* const isolate,
 
   // Only set up the node::CallbackScope if there's a node environment.
   // Sandboxed renderers don't have a node environment.
-  std::unique_ptr<node::CallbackScope> callback_scope;
-  if (node::Environment::GetCurrent(context)) {
-    callback_scope = std::make_unique<node::CallbackScope>(
-        isolate, ipcNative, node::async_context{0, 0});
+  std::optional<node::CallbackScope> callback_scope;
+  if (auto* env = node::Environment::GetCurrent(context)) {
+    callback_scope.emplace(env, ipcNative, node::async_context{0, 0});
   }
 
   auto callback_key = gin::ConvertToV8(isolate, callback_name)


### PR DESCRIPTION
#### Description of Change

Avoid a little extra work in `InvokeIpcCallback()`:

1. Allocate the `node::CallbackScope` on the stack instead of the heap by using `std::optional` instead of `std::unique_ptr`.
2. Skip a redundant call to  `node::Environment::GetCurrent()` by passing `env` to the callback scope's constructor

CC @codebytere, @deepak1556 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.