### PR TITLE
fix(windows): reduce blurriness on mixed-DPI displays by enabling Per…

### DIFF
--- a/shell/browser/resources/win/dpi_aware.manifest
+++ b/shell/browser/resources/win/dpi_aware.manifest
@@ -1,9 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <!-- Back-compat for older Windows versions (Vista/7/8/8.1): Per-Monitor v1 awareness -->
     <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-      <!-- See: https://docs.microsoft.com/en-us/windows/desktop/sbscs/application-manifests#dpiAware -->
+      <!-- See: https://learn.microsoft.com/windows/win32/sbscs/application-manifests#dpiaware -->
       <dpiAware>true/pm</dpiAware>
+    </asmv3:windowsSettings>
+
+    <!-- Modern DPI awareness for Windows 10 (Anniversary Update) and newer: Per-Monitor V2 -->
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+      <!-- See: https://learn.microsoft.com/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows -->
+      <dpiAwareness>PerMonitorV2</dpiAwareness>
+      <!-- Enable GDI scaling for better text rendering in legacy controls, ignored where unsupported -->
+      <gdiScaling>true</gdiScaling>
     </asmv3:windowsSettings>
   </asmv3:application>
 </assembly>


### PR DESCRIPTION
Summary Improves DPI handling on Windows by declaring Per‑Monitor V2 awareness and enabling GDI scaling in the application manifest. This reduces blurriness when moving windows between monitors with different scale factors and sharpens legacy GDI-rendered UI where supported.Motivation and Context • Prior behavior relied on Per‑Monitor v1 (<dpiAware>true/pm</dpiAware>), which can still yield blurry content on mixed‑DPI setups (e.g., 100% ↔ 150%). • Microsoft guidance recommends PerMonitorV2 for robust DPI handling of non‑client areas and transitions.•https://learn.microsoft.com/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows•https://learn.microsoft.com/windows/win32/sbscs/application-manifests#dpiawareWhat Changed • shell/browser/resources/win/dpi_aware.manifest•Kept legacy Per‑Monitor v1: <dpiAware>true/pm</dpiAware> (2005 WindowsSettings) for older Windows.•Added modern block (2016 WindowsSettings): <dpiAwareness>PerMonitorV2</dpiAwareness> and <gdiScaling>true</gdiScaling>. • Build wiring unchanged; BUILD.gn already bundles this manifest via windows_manifest("electron_app_manifest").Breaking Change • No. Older Windows versions ignore the 2016 block and continue using the legacy entry.Risks and Mitigations • Runtime calls to SetProcessDpiAwarenessContext remain compatible; redundant requests to PMv2 are benign. • Non‑Windows platforms are unaffected. • GDI scaling is ignored where unsupported; on supported versions it improves clarity of GDI‑based controls.How Has This Been Tested? • Manual verification on Windows 10/11 mixed‑DPI setups: content remains crisp when moving windows across monitors; titlebar/non‑client transitions are smoother. • Confirmed manifest inclusion via BUILD.gn windows_manifest target. • CI will run the existing test suite; no new tests are required for a manifest-only change.Release Notes Notes: Improved Windows DPI rendering by enabling Per‑Monitor V2 awareness and GDI scaling, reducing blurriness on mixed‑DPI displays.