### PR TITLE
build: fixup chromedriver and mksnapshot

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -79,7 +79,7 @@ runs:
       shell: bash
       run: |
         cd src
-        e build --target electron:electron_mksnapshot
+        e build --target electron:electron_mksnapshot_zip
         ELECTRON_DEPOT_TOOLS_DISABLE_LOG=1 e d gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
         # Remove unused args from mksnapshot_args
         SEDOPTION="-i"
@@ -89,7 +89,6 @@ runs:
         sed $SEDOPTION '/.*builtins-pgo/d' out/Default/mksnapshot_args
         sed $SEDOPTION '/--turbo-profiling-input/d' out/Default/mksnapshot_args
 
-        e build --target electron:electron_mksnapshot_zip
         if [ "${{ inputs.target-platform }}" = "win" ]; then
           cd out/Default
           powershell Compress-Archive -update mksnapshot_args mksnapshot.zip
@@ -123,7 +122,6 @@ runs:
       shell: bash
       run: |
         cd src
-        e build --target electron:electron_chromedriver
         e build --target electron:electron_chromedriver_zip
 
         if [ "${{ inputs.is-asan }}" != "true" ]; then

--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -15,7 +15,7 @@ runs:
         git config --global core.preloadindex true
         git config --global core.longpaths true
       fi
-      export BUILD_TOOLS_SHA=c13f4bdb50e65da46a4703f8f882079dd21fd99e
+      export BUILD_TOOLS_SHA=706147b2376f55078f718576b28129a0457f1795
       npm i -g @electron/build-tools
       # Update depot_tools to ensure python
       e d update_depot_tools

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -177,22 +177,18 @@ jobs:
         path: ./src_artifacts_${{ matrix.build-type }}_${{ inputs.target-arch }}
     - name: Restore Generated Artifacts
       run: ./src/electron/script/actions/restore-artifacts.sh
-    - name: Unzip Dist, Mksnapshot & Chromedriver (win)
+    - name: Unzip Dist (win)
       if: ${{ inputs.target-platform == 'win' }}
       shell: powershell
       run: |
         Set-ExecutionPolicy Bypass -Scope Process -Force
         cd src/out/Default
         Expand-Archive -Force dist.zip -DestinationPath ./
-        Expand-Archive -Force chromedriver.zip -DestinationPath ./
-        Expand-Archive -Force mksnapshot.zip -DestinationPath ./
-    - name: Unzip Dist, Mksnapshot & Chromedriver (unix)
+    - name: Unzip Dist (unix)
       if: ${{ inputs.target-platform != 'win' }}
       run: |
         cd src/out/Default
         unzip -:o dist.zip
-        unzip -:o chromedriver.zip
-        unzip -:o mksnapshot.zip
     #- name: Import & Trust Self-Signed Codesigning Cert on MacOS
     #  if: ${{ inputs.target-platform == 'macos' && inputs.target-arch == 'x64' }}
     #  run: |


### PR DESCRIPTION
#### Description of Change
- After the migration to siso via #47534, on occasion on Windows mksnapshot or chromedriver fails to build which then causes errors while testing, eg https://github.com/electron/electron/actions/runs/18198927807/job/51842938994?pr=48439.  

- It turns out there are several issues at hand here: 
1. Build failures are silently failing/not marking the build as failing.  This issue is addressed via https://github.com/electron/build-tools/pull/759
2. The build failure seems to be happening because we run 2 targets back to back which seems to cause file contention on siso builds on Windows sometimes.  In both cases instead of calling e build with the build target and then calling e build with the zip target, we can directly call `e build` with the zip target which should fix this contention issue.
3. chromedriver and mksnapshot are not used in our tests, so we are currently unnecessarily unzipping these zip files in our tests, so this PR removes unzipping those files.  
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
