### PR TITLE
chore: remove unused reference to `api::BrowserView`

### DIFF
--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -50,10 +50,6 @@ namespace electron {
 class ElectronMenuModel;
 class BackgroundThrottlingSource;
 
-namespace api {
-class BrowserView;
-}
-
 #if BUILDFLAG(IS_MAC)
 using NativeWindowHandle = gfx::NativeView;
 #else
@@ -434,8 +430,6 @@ class NativeWindow : public base::SupportsUserData,
   void UpdateBackgroundThrottlingState();
 
  protected:
-  friend class api::BrowserView;
-
   NativeWindow(const gin_helper::Dictionary& options, NativeWindow* parent);
 
   void set_titlebar_overlay_height(int height) {


### PR DESCRIPTION
#### Description of Change

Remove a dangling reference to the `api::BrowserView` class which was removed in #35658 / 15c60143

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

All reviews welcomed; no particular stakeholders IMO? This is a cleanup I found while reading something else.

#### Release Notes

Notes: none.