### PR TITLE
fix: unexpected `openExternal` dialog on macOS Tahoe

### DIFF
--- a/shell/common/platform_util_mac.mm
+++ b/shell/common/platform_util_mac.mm
@@ -148,6 +148,12 @@ void OpenExternal(const GURL& url,
     return;
   }
 
+  // Check this to prevent system dialog from popping up on macOS Tahoe.
+  if (![[NSWorkspace sharedWorkspace] URLForApplicationToOpenURL:ns_url]) {
+    std::move(callback).Run("No application found to open URL");
+    return;
+  }
+
   NSWorkspaceOpenConfiguration* configuration =
       [NSWorkspaceOpenConfiguration configuration];
   configuration.activates = options.activate;

--- a/spec/api-shell-spec.ts
+++ b/spec/api-shell-spec.ts
@@ -82,6 +82,11 @@ describe('shell module', () => {
       ]);
     });
 
+    ifit(process.platform === 'darwin')('throws when there is no application registered to open the URL', async () => {
+      const url = `unknownscheme-${Date.now()}://test`;
+      await expect(shell.openExternal(url)).to.eventually.be.rejectedWith(/No application found to open URL/);
+    });
+
     it('opens an external link in the renderer', async () => {
       const { url, requestReceived } = await urlOpened();
       const w = new BrowserWindow({ show: false, webPreferences: { sandbox: false, contextIsolation: false, nodeIntegration: true } });


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/48455.

Fixes an issue where `shell.openExternal` causes an unexpected dialog to open when there is no app suitable to open the url:

<img width="372" height="462" alt="Screenshot 2025-10-09 at 10 04 37 AM" src="https://github.com/user-attachments/assets/8a641d08-71e9-49b3-81af-70e03492a328" />

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `shell.openExternal` caused an unexpected dialog to open when there was no app suitable to open the url.