### PR TITLE
fix: auth required websocket crash

### DIFF
--- a/shell/browser/net/proxying_websocket.cc
+++ b/shell/browser/net/proxying_websocket.cc
@@ -401,7 +401,7 @@ void ProxyingWebSocket::OnHeadersReceivedCompleteForAuth(
 
   auto continuation = base::BindRepeating(
       &ProxyingWebSocket::OnAuthRequiredComplete, weak_factory_.GetWeakPtr());
-  auto auth_rv = AuthRequiredResponse::kIoPending;
+  auto auth_rv = AuthRequiredResponse::kCancelAuth;
   PauseIncomingMethodCallProcessing();
 
   OnAuthRequiredComplete(auth_rv);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/48505.

Fixes an issue where authentication via websockets can crash due to `NOTREACHED` being a CHECK since M120.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where authentication via websockets can crash.