### PR TITLE
fix: `systemPreferences.getAccentColor` inverted color

### DIFF
--- a/shell/browser/api/electron_api_system_preferences_win.cc
+++ b/shell/browser/api/electron_api_system_preferences_win.cc
@@ -16,6 +16,7 @@
 #include "base/win/wrapped_window_proc.h"
 #include "shell/common/color_util.h"
 #include "shell/common/process_util.h"
+#include "skia/ext/skia_utils_win.h"
 #include "ui/gfx/win/hwnd_util.h"
 #include "ui/gfx/win/singleton_hwnd.h"
 
@@ -88,7 +89,7 @@ std::string SystemPreferences::GetAccentColor() {
   if (!color.has_value())
     return "";
 
-  return hexColorDWORDToRGBA(color.value());
+  return ToRGBAHex(skia::COLORREFToSkColor(color.value()), false);
 }
 
 std::string SystemPreferences::GetColor(gin_helper::ErrorThrower thrower,

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, BrowserView, dialog, ipcMain, OnBeforeSendHeadersListenerDetails, net, protocol, screen, webContents, webFrameMain, session, WebContents, WebFrameMain } from 'electron/main';
+import { app, BrowserWindow, BrowserView, dialog, ipcMain, OnBeforeSendHeadersListenerDetails, net, protocol, screen, webContents, webFrameMain, session, systemPreferences, WebContents, WebFrameMain } from 'electron/main';
 
 import { expect } from 'chai';
 
@@ -2588,6 +2588,14 @@ describe('BrowserWindow module', () => {
       const accentColor = w.getAccentColor();
       expect(accentColor).to.be.a('string');
       expect(accentColor).to.match(/^#[0-9A-F]{6}$/i);
+    });
+
+    it('matches the systemPreferences system color when true', () => {
+      const w = new BrowserWindow({ show: false });
+      w.setAccentColor(true);
+      const accentColor = w.getAccentColor() as string;
+      const systemColor = systemPreferences.getAccentColor().slice(0, 6);
+      expect(accentColor).to.equal(`#${systemColor}`);
     });
 
     it('returns the correct accent color after multiple changes', () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/48506.

Fixes an issue where `systemPreferences.getAccentColor` inverted the color.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `systemPreferences.getAccentColor` inverted the color.
