### PR TITLE
feat: support WebSocket authentication handling

### DIFF
--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -115,57 +115,6 @@ TCP connection is made to the server, but before any http data is sent.
 
 The `callback` has to be called with a `response` object.
 
-#### `webRequest.onAuthRequired([filter, ]listener)`
-
-* `filter` [WebRequestFilter](structures/web-request-filter.md) (optional)
-* `listener` Function | null
-  * `details` Object
-    * `id` Integer
-    * `url` string
-    * `method` string
-    * `webContentsId` Integer (optional)
-    * `webContents` WebContents (optional)
-    * `frame` WebFrameMain | null (optional) - Requesting frame.
-      May be `null` if accessed after the frame has either navigated or been destroyed.
-    * `resourceType` string - Can be `mainFrame`, `subFrame`, `stylesheet`, `script`, `image`, `font`, `object`, `xhr`, `ping`, `cspReport`, `media`, `webSocket` or `other`.
-    * `referrer` string
-    * `timestamp` Double
-    * `requestHeaders` Record\<string, string\>
-    * `isProxy` boolean
-    * `scheme` string
-    * `host` string
-    * `port` Integer
-    * `realm` string
-  * `callback` Function
-    * `authRequiredResponse` Object
-      * `cancel` boolean (optional)
-      * `authCredentials` Object
-        * `username` string
-        * `password` string
-
-The `listener` will be called with `listener(details, callback)` when authentication is required.
-
-The `callback` has to be called with an `authRequiredResponse` object.
-
-```js
-const { app, session } = require('electron')
-
-const path = require('node:path')
-
-app.whenReady().then(() => {
-  session.defaultSession.webRequest.onAuthRequired({ urls: ['ws://*/*'] }, (details, callback) => {
-    console.log('Auth required for:', details.url)
-    callback({
-      cancel: false,
-      authCredentials: {
-        username: 'user',
-        password: 'pass'
-      }
-    })
-  })
-})
-```
-
 #### `webRequest.onSendHeaders([filter, ]listener)`
 
 * `filter` [WebRequestFilter](structures/web-request-filter.md) (optional)

--- a/shell/browser/login_handler.cc
+++ b/shell/browser/login_handler.cc
@@ -42,6 +42,23 @@ LoginHandler::LoginHandler(
                      response_headers, first_auth_attempt));
 }
 
+LoginHandler::LoginHandler(
+    const net::AuthChallengeInfo& auth_info,
+    content::WebContents* web_contents,
+    base::ProcessId process_id,
+    const GURL& url,
+    scoped_refptr<net::HttpResponseHeaders> response_headers,
+    content::LoginDelegate::LoginAuthRequiredCallback auth_required_callback)
+    : LoginHandler(auth_info,
+                   web_contents,
+                   /*is_request_for_primary_main_frame=*/false,
+                   /*is_request_for_navigation=*/false,
+                   process_id,
+                   url,
+                   std::move(response_headers),
+                   /*first_auth_attempt=*/false,
+                   std::move(auth_required_callback)) {}
+
 void LoginHandler::EmitEvent(
     net::AuthChallengeInfo auth_info,
     content::WebContents* web_contents,

--- a/shell/browser/login_handler.h
+++ b/shell/browser/login_handler.h
@@ -32,6 +32,13 @@ class LoginHandler : public content::LoginDelegate {
       scoped_refptr<net::HttpResponseHeaders> response_headers,
       bool first_auth_attempt,
       content::LoginDelegate::LoginAuthRequiredCallback auth_required_callback);
+  LoginHandler(
+      const net::AuthChallengeInfo& auth_info,
+      content::WebContents* web_contents,
+      base::ProcessId process_id,
+      const GURL& url,
+      scoped_refptr<net::HttpResponseHeaders> response_headers,
+      content::LoginDelegate::LoginAuthRequiredCallback auth_required_callback);
   ~LoginHandler() override;
 
   // disable copy

--- a/shell/browser/net/proxying_websocket.cc
+++ b/shell/browser/net/proxying_websocket.cc
@@ -373,20 +373,22 @@ void ProxyingWebSocket::OnHeadersReceivedComplete(int error_code) {
 }
 
 void ProxyingWebSocket::OnAuthRequiredComplete(
-    WebRequestAPI::AuthRequiredResponse rv) {
+    api::WebRequest::AuthRequiredResponse rv) {
   CHECK(auth_required_callback_);
   ResumeIncomingMethodCallProcessing();
   switch (rv) {
-    case WebRequestAPI::AuthRequiredResponse::AUTH_REQUIRED_RESPONSE_NO_ACTION:
-    case WebRequestAPI::AuthRequiredResponse::
+    case api::WebRequest::AuthRequiredResponse::
+        AUTH_REQUIRED_RESPONSE_NO_ACTION:
+    case api::WebRequest::AuthRequiredResponse::
         AUTH_REQUIRED_RESPONSE_CANCEL_AUTH:
       std::move(auth_required_callback_).Run(std::nullopt);
       break;
 
-    case WebRequestAPI::AuthRequiredResponse::AUTH_REQUIRED_RESPONSE_SET_AUTH:
+    case api::WebRequest::AuthRequiredResponse::AUTH_REQUIRED_RESPONSE_SET_AUTH:
       std::move(auth_required_callback_).Run(auth_credentials_);
       break;
-    case WebRequestAPI::AuthRequiredResponse::AUTH_REQUIRED_RESPONSE_IO_PENDING:
+    case api::WebRequest::AuthRequiredResponse::
+        AUTH_REQUIRED_RESPONSE_IO_PENDING:
       NOTREACHED();
   }
 }
@@ -403,11 +405,11 @@ void ProxyingWebSocket::OnHeadersReceivedCompleteForAuth(
 
   auto continuation = base::BindRepeating(
       &ProxyingWebSocket::OnAuthRequiredComplete, weak_factory_.GetWeakPtr());
-  auto auth_rv = web_request_api_->OnAuthRequired(
+  auto auth_rv = web_request_->OnAuthRequired(
       &info_, auth_info, std::move(continuation), &auth_credentials_);
   PauseIncomingMethodCallProcessing();
-  if (auth_rv ==
-      WebRequestAPI::AuthRequiredResponse::AUTH_REQUIRED_RESPONSE_IO_PENDING) {
+  if (auth_rv == api::WebRequest::AuthRequiredResponse::
+                     AUTH_REQUIRED_RESPONSE_IO_PENDING) {
     return;
   }
 

--- a/shell/browser/net/proxying_websocket.h
+++ b/shell/browser/net/proxying_websocket.h
@@ -104,7 +104,7 @@ class ProxyingWebSocket : public network::mojom::WebSocketHandshakeClient,
   void ContinueToStartRequest(int error_code);
   void OnHeadersReceivedComplete(int error_code);
   void ContinueToHeadersReceived();
-  void OnAuthRequiredComplete(WebRequestAPI::AuthRequiredResponse rv);
+  void OnAuthRequiredComplete(api::WebRequest::AuthRequiredResponse rv);
   void OnHeadersReceivedCompleteForAuth(const net::AuthChallengeInfo& auth_info,
                                         int rv);
   void ContinueToCompleted();


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/48505.

This PR adds handling for the 'login' event to allow authentication via web sockets.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added support for WebSocket authentication through the `login` event on `webContents`.