### PR TITLE
build: use one build target

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -60,7 +60,11 @@ runs:
           sudo launchctl limit maxfiles 65536 200000
         fi
 
-        NINJA_SUMMARIZE_BUILD=1 e build
+        if [ "${{ inputs.is-release }}" = "true" ]; then
+          NINJA_SUMMARIZE_BUILD=1 e build --target electron:release_build
+        else
+          NINJA_SUMMARIZE_BUILD=1 e build --target electron:testing_build
+        fi
         cp out/Default/.ninja_log out/electron_ninja_log
         node electron/script/check-symlinks.js
 
@@ -74,11 +78,10 @@ runs:
         else
           echo "Skipping build-stats.mjs upload because DD_API_KEY is not set"
         fi
-    - name: Build Electron dist.zip ${{ inputs.step-suffix }}
+    - name: Verify dist.zip ${{ inputs.step-suffix }}
       shell: bash
       run: |
-        cd src
-        e build --target electron:electron_dist_zip
+        cd src        
         if [ "${{ inputs.is-asan }}" != "true" ]; then
           target_os=${{ inputs.target-platform == 'macos' && 'mac' || inputs.target-platform }}
           if [ "${{ inputs.artifact-platform }}" = "mas" ]; then
@@ -86,11 +89,10 @@ runs:
           fi
           electron/script/zip_manifests/check-zip-manifest.py out/Default/dist.zip electron/script/zip_manifests/dist_zip.$target_os.${{ inputs.target-arch }}.manifest
         fi
-    - name: Build Mksnapshot ${{ inputs.step-suffix }}
+    - name: Fixup Mksnapshot ${{ inputs.step-suffix }}
       shell: bash
       run: |
         cd src
-        e build --target electron:electron_mksnapshot_zip
         ELECTRON_DEPOT_TOOLS_DISABLE_LOG=1 e d gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
         # Remove unused args from mksnapshot_args
         SEDOPTION="-i"
@@ -142,11 +144,6 @@ runs:
           fi
           electron/script/zip_manifests/check-zip-manifest.py out/Default/chromedriver.zip electron/script/zip_manifests/chromedriver_zip.$target_os.${{ inputs.target-arch }}.manifest
         fi
-    - name: Build Node.js headers ${{ inputs.step-suffix }}
-      shell: bash
-      run: |
-        cd src
-        e build --target electron:node_headers
     - name: Create installed_software.json ${{ inputs.step-suffix }}
       shell: powershell
       if: ${{ inputs.is-release == 'true' && inputs.target-platform == 'win' }}
@@ -166,17 +163,11 @@ runs:
         # Needed for msdia140.dll on 64-bit windows
         cd src
         export PATH="$PATH:$(pwd)/third_party/llvm-build/Release+Asserts/bin"
-    - name: Generate & Zip Symbols ${{ inputs.step-suffix }}
+    - name: Zip Symbols ${{ inputs.step-suffix }}
       shell: bash
       run: |
-        # Generate breakpad symbols on release builds
-        if [ "${{ inputs.generate-symbols }}" = "true" ]; then
-          e build --target electron:electron_symbols
-        fi
         cd src
         export BUILD_PATH="$(pwd)/out/Default"
-        e build --target electron:licenses
-        e build --target electron:electron_version_file
         if [ "${{ inputs.is-release }}" = "true" ]; then
           DELETE_DSYMS_AFTER_ZIP=1 electron/script/zip-symbols.py -b $BUILD_PATH
         else
@@ -189,18 +180,6 @@ runs:
         cd src
         gn gen out/ffmpeg --args="import(\"//electron/build/args/ffmpeg.gn\") use_remoteexec=true use_siso=true $GN_EXTRA_ARGS"
         e build --target electron:electron_ffmpeg_zip -C ../../out/ffmpeg
-    - name: Generate Hunspell Dictionaries ${{ inputs.step-suffix }}
-      shell: bash
-      if: ${{ inputs.is-release == 'true' && inputs.target-platform == 'linux' }}
-      run: |
-        e build --target electron:hunspell_dictionaries_zip
-    - name: Generate Libcxx ${{ inputs.step-suffix }}
-      shell: bash
-      if: ${{ inputs.is-release == 'true' && inputs.target-platform == 'linux' }}
-      run: |
-        e build --target electron:libcxx_headers_zip
-        e build --target electron:libcxxabi_headers_zip
-        e build --target electron:libcxx_objects_zip
     - name: Remove Clang problem matcher
       shell: bash
       run: echo "::remove-matcher owner=clang::"

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1624,6 +1624,29 @@ group("node_headers") {
   public_deps = [ ":tar_node_headers" ]
 }
 
+group("testing_build") {
+  public_deps = [
+    ":electron_dist_zip",
+    ":electron_mksnapshot_zip",
+    ":node_headers",
+  ]
+}
+
+group("release_build") {
+  public_deps = [ ":testing_build" ]
+  if (is_official_build) {
+    public_deps += [ ":electron_symbols" ]
+  }
+  if (is_linux) {
+    public_deps += [
+      ":hunspell_dictionaries_zip",
+      ":libcxx_headers_zip",
+      ":libcxx_objects_zip",
+      ":libcxxabi_headers_zip",
+    ]
+  }
+}
+
 if (is_linux && is_official_build) {
   strip_binary("strip_electron_binary") {
     binary_input = "$root_out_dir/$electron_project_name"

--- a/script/gn-check.js
+++ b/script/gn-check.js
@@ -33,7 +33,9 @@ const gnCheckDirs = [
   '//electron:electron_lib',
   '//electron:electron_app',
   '//electron/shell/common:mojo',
-  '//electron/shell/common:plugin'
+  '//electron/shell/common:plugin',
+  '//electron:testing_build',
+  '//electron:release_build'
 ];
 
 for (const dir of gnCheckDirs) {


### PR DESCRIPTION
Optimizes our builds for use with siso/avoids file contention on Windows.

Most of our build targets have been rolled up into `testing_build` and `release_build`. The one exception is chromedriver because chromedriver needs `testonly = true` which is incompatible with our other build targets.

This should alleviate Windows build failures like this:
`
 Error: failed to load build.ninja: open obj\components\device_signals\core\common\common.ninja: The parameter is incorrect.
`

Release builds for verification of change:
- **Linux**: https://github.com/electron/electron/actions/runs/18661433765
- **macOS**: https://github.com/electron/electron/actions/runs/18661439159
- **Windows**: https://github.com/electron/electron/actions/runs/18661079467


#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
