### PR TITLE
ci: fix release branch name in build stats script

### DIFF
--- a/script/build-stats.mjs
+++ b/script/build-stats.mjs
@@ -45,7 +45,13 @@ async function main () {
 
     if (process.env.TARGET_ARCH) tags.push(`target-arch:${process.env.TARGET_ARCH}`);
     if (process.env.TARGET_PLATFORM) tags.push(`target-platform:${process.env.TARGET_PLATFORM}`);
-    if (process.env.GITHUB_HEAD_REF) tags.push(`branch:${process.env.GITHUB_HEAD_REF}`);
+    if (process.env.GITHUB_HEAD_REF) {
+      // Will be set in pull requests
+      tags.push(`branch:${process.env.GITHUB_HEAD_REF}`);
+    } else if (process.env.GITHUB_REF_NAME) {
+      // Will be set for release branches
+      tags.push(`branch:${process.env.GITHUB_REF_NAME}`);
+    }
 
     const series = [
       {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Fast follow-up to #48509, as branch names aren't being populated for release branches. Unfortunately there's not one single environment variable which gives us the name we want (the short ref name) for both PRs and release branches. So first check the one that's good for PRs (and blank on release branches) and then fall back to the other.

| | PR | Release Branch |
|---|:---:|:---:|
| `GITHUB_HEAD_REF` | `<branch_name>` |  |
| `GITHUB_REF_NAME` | `<pr_number>/merge` | `main` |

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
