### PR TITLE
fix: `trafficLightPosition` incorrect with `customButtonsOnHover`

### DIFF
--- a/shell/browser/ui/cocoa/window_buttons_proxy.mm
+++ b/shell/browser/ui/cocoa/window_buttons_proxy.mm
@@ -176,6 +176,13 @@
     [button setHidden:hidden];
     [button setNeedsDisplay:YES];
   }
+
+  // On macOS 26, toggling the hidden state of the standard window buttons can
+  // cause AppKit to re-layout the title bar container and reset its frame,
+  // which loses the custom margin adjustments. Re-apply the calculated geometry
+  // after visibility changes to keep the buttons at the specified margin
+  // instead of snapping back to the default until the next manual resize.
+  [self redraw];
 }
 
 // Return the bounds of all 3 buttons.


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/48463.

Fixes an issue where `trafficLightPosition` would not be correctly applied when using `titleBarStyle: 'customButtonsOnHover'`. On macOS 26, toggling the hidden state of the standard window buttons can
cause AppKit to re-layout the title bar container and reset its frame, which loses the custom margin adjustments.

To fix this re-apply the calculated geometry after visibility changes to keep the buttons at the specified margin
instead of snapping back to the default until the next manual resize.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `trafficLightPosition` would not be correctly applied when using `titleBarStyle: 'customButtonsOnHover'` on macOS 26.
