### PR TITLE
fix: icon in Windows toast notification

### DIFF
--- a/shell/browser/notifications/win/notification_presenter_win.cc
+++ b/shell/browser/notifications/win/notification_presenter_win.cc
@@ -30,9 +30,8 @@ namespace {
 bool SaveIconToPath(const SkBitmap& bitmap, const base::FilePath& path) {
   std::optional<std::vector<uint8_t>> png_data =
       gfx::PNGCodec::EncodeBGRASkBitmap(bitmap, false);
-  if (!png_data.has_value())
+  if (!png_data.has_value() || !png_data.value().size())
     return false;
-
   return base::WriteFile(path, png_data.value());
 }
 
@@ -64,8 +63,10 @@ bool NotificationPresenterWin::Init() {
 std::wstring NotificationPresenterWin::SaveIconToFilesystem(
     const SkBitmap& icon,
     const GURL& origin) {
-  std::string filename;
+  if (icon.drawsNothing())
+    return L"";
 
+  std::string filename;
   if (origin.is_valid()) {
     filename = base::MD5String(origin.spec()) + ".png";
   } else {
@@ -75,11 +76,11 @@ std::wstring NotificationPresenterWin::SaveIconToFilesystem(
 
   ScopedAllowBlockingForElectron allow_blocking;
   base::FilePath path = temp_dir_.GetPath().Append(base::UTF8ToWide(filename));
-  if (base::PathExists(path))
-    return path.value();
-  if (SaveIconToPath(icon, path))
-    return path.value();
-  return base::UTF8ToWide(origin.spec());
+
+  if (!SaveIconToPath(icon, path))
+    return L"";
+
+  return path.value();
 }
 
 Notification* NotificationPresenterWin::CreateNotificationObject(

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -353,6 +353,7 @@ std::u16string WindowsToastNotification::GetToastXml(
   // Optional icon as app logo override (small icon).
   if (!icon_path.empty()) {
     xml_writer.StartElement(kImage);
+    xml_writer.AddAttribute(kID, "1");
     xml_writer.AddAttribute(kPlacement, kAppLogoOverride);
     xml_writer.AddAttribute(kHintCrop, kHintCropNone);
     xml_writer.AddAttribute(kSrc, base::WideToUTF8(icon_path));


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/48536.
Refs https://github.com/electron/electron/commit/f28d08ad8690d8b9ded8f33781ee990027fd16d0

The `image` attribute should have an ID. Also cleaned up and added checks for missing icons when saving an icon to the filesystem for use in a toast.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where icons didn't show up as expected on Windows Toast notifications.
