### PR TITLE
ci: upload build cache hit rate on Windows as well

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -66,7 +66,11 @@ runs:
 
         # Upload build stats to Datadog
         if ! [ -z $DD_API_KEY ]; then
-          npx node electron/script/build-stats.mjs out/Default/siso.INFO --upload-stats || true
+          if [ "$TARGET_PLATFORM" = "win" ]; then
+            npx node electron/script/build-stats.mjs out/Default/siso.exe.INFO --upload-stats || true
+          else
+            npx node electron/script/build-stats.mjs out/Default/siso.INFO --upload-stats || true
+          fi
         else
           echo "Skipping build-stats.mjs upload because DD_API_KEY is not set"
         fi


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Turns out the stats file we need is called `siso.exe.INFO` on Windows. 🤷

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
