### PR TITLE
build: run on macOS 15

### DIFF
--- a/.github/workflows/macos-publish.yml
+++ b/.github/workflows/macos-publish.yml
@@ -47,7 +47,7 @@ jobs:
     needs: checkout-macos
     with:
       environment: production-release
-      build-runs-on: macos-14-xlarge
+      build-runs-on: macos-15-xlarge
       target-platform: macos
       target-arch: x64
       target-variant: darwin
@@ -62,7 +62,7 @@ jobs:
     needs: checkout-macos
     with:
       environment: production-release
-      build-runs-on: macos-14-xlarge
+      build-runs-on: macos-15-xlarge
       target-platform: macos
       target-arch: x64
       target-variant: mas
@@ -77,7 +77,7 @@ jobs:
     needs: checkout-macos
     with:
       environment: production-release
-      build-runs-on: macos-14-xlarge
+      build-runs-on: macos-15-xlarge
       target-platform: macos
       target-arch: arm64
       target-variant: darwin
@@ -92,7 +92,7 @@ jobs:
     needs: checkout-macos
     with:
       environment: production-release
-      build-runs-on: macos-14-xlarge
+      build-runs-on: macos-15-xlarge
       target-platform: macos
       target-arch: arm64
       target-variant: mas


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/48362 - https://github.com/electron/electron/pull/48362#pullrequestreview-3324816663

We need to bump the runner version to fix [find_sdk.py](https://source.chromium.org/chromium/chromium/src/+/main:build/mac/find_sdk.py;l=84-86;drc=ef42bc9af8f31c0c726c720edcd609318def20b7) failing to find a system SDK with a minimum of v15.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none