### PR TITLE
ci: fix publish for macOS < 26.0

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -19,6 +19,10 @@ proprietary_codecs = true
 
 enable_printing = true
 
+# Refs https://chromium-review.googlesource.com/c/chromium/src/+/6986517
+# CI is using MacOS 15.5 which doesn't have the required modulemaps.
+use_clang_modules = false
+
 # Removes DLLs from the build, which are only meant to be used for Chromium development.
 # See https://github.com/electron/electron/pull/17985
 angle_enable_vulkan_validation_layers = false


### PR DESCRIPTION
#### Description of Change

Refs https://chromium-review.googlesource.com/c/chromium/src/+/6986517

CI is using MacOS 15.5 which doesn't have the required modulemaps and blocks publishing on failure.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none