### PR TITLE
docs: modify the thickFrame doc

### DIFF
--- a/docs/api/structures/base-window-options.md
+++ b/docs/api/structures/base-window-options.md
@@ -102,7 +102,10 @@
   should have rounded corners. Default is `true`. Setting this property
   to `false` will prevent the window from being fullscreenable on macOS.
   On Windows versions older than Windows 11 Build 22000 this property has no effect, and frameless windows will not have rounded corners.
-* `thickFrame` boolean (optional) _Windows_ - Use `WS_THICKFRAME` style for frameless windows on Windows, which adds the standard window frame. Setting it to `false` will remove window shadow and window animations, and disable window resizing via dragging the window edges. Default is `true`.
+* `thickFrame` boolean (optional) _Windows_ - Use `WS_THICKFRAME` style for
+  frameless windows on Windows, which adds the standard window frame. Setting it
+  to `false` will remove window shadow and window animations, and disable window
+  resizing via dragging the window edges. Default is `true`.
 * `vibrancy` string (optional) _macOS_ - Add a type of vibrancy effect to
   the window, only on macOS. Can be `appearance-based`, `titlebar`, `selection`,
   `menu`, `popover`, `sidebar`, `header`, `sheet`, `window`, `hud`, `fullscreen-ui`,


### PR DESCRIPTION
#### Description of Change

Previously, the docs only stated that disabling thickFrame removes window shadows and animations, but did not clearly indicate that resizing via window edges would also be disabled. 

It was previously working in a kind of “coincidental” way.

refer: https://learn.microsoft.com/en-us/windows/win32/winmsg/window-styles

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
