### PR TITLE
fix: devtools crashing on Linux in detach mode

### DIFF
--- a/shell/browser/ui/views/electron_views_delegate.cc
+++ b/shell/browser/ui/views/electron_views_delegate.cc
@@ -8,6 +8,7 @@
 
 #include "ui/views/widget/desktop_aura/desktop_native_widget_aura.h"
 #include "ui/views/widget/native_widget_aura.h"
+#include "ui/views/window/default_frame_view.h"
 
 #if BUILDFLAG(IS_LINUX)
 #include "base/environment.h"
@@ -62,7 +63,7 @@ gfx::ImageSkia* ViewsDelegate::GetDefaultWindowIcon() const {
 
 std::unique_ptr<views::FrameView> ViewsDelegate::CreateDefaultFrameView(
     views::Widget* widget) {
-  return nullptr;
+  return std::make_unique<views::DefaultFrameView>(widget);
 }
 
 void ViewsDelegate::OnBeforeWidgetInit(


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/48430
Refs CL:6633935

Fixes an issue where calling `webContents.openDevTools({ mode: 'detach' })` would cause a crash on Wayland.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where calling `webContents.openDevTools({ mode: 'detach' })` would cause a crash on Wayland.
