### PR TITLE
refactor: use `base::SupportsUserData` in render frame observer

### DIFF
--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -154,10 +154,6 @@ void ElectronRenderFrameObserver::WillReleaseScriptContext(
     renderer_client_->WillReleaseScriptContext(isolate, context, render_frame_);
 }
 
-void ElectronRenderFrameObserver::OnDestruct() {
-  delete this;
-}
-
 void ElectronRenderFrameObserver::DidMeaningfulLayout(
     blink::WebMeaningfulLayout layout_type) {
   if (layout_type == blink::WebMeaningfulLayout::kVisuallyNonEmpty) {

--- a/shell/renderer/electron_render_frame_observer.h
+++ b/shell/renderer/electron_render_frame_observer.h
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "base/supports_user_data.h"
 #include "content/public/renderer/render_frame_observer.h"
 #include "ipc/platform_file_for_transit.h"
 #include "third_party/blink/public/web/web_local_frame.h"
@@ -16,7 +17,8 @@ namespace electron {
 class RendererClientBase;
 
 // Helper class to forward the messages to the client.
-class ElectronRenderFrameObserver : private content::RenderFrameObserver {
+class ElectronRenderFrameObserver : public base::SupportsUserData::Data,
+                                    private content::RenderFrameObserver {
  public:
   ElectronRenderFrameObserver(content::RenderFrame* frame,
                               RendererClientBase* renderer_client);
@@ -34,7 +36,7 @@ class ElectronRenderFrameObserver : private content::RenderFrameObserver {
   void WillReleaseScriptContext(v8::Isolate* const isolate,
                                 v8::Local<v8::Context> context,
                                 int world_id) override;
-  void OnDestruct() override;
+  void OnDestruct() override {}
   void DidMeaningfulLayout(blink::WebMeaningfulLayout layout_type) override;
 
   [[nodiscard]] bool ShouldNotifyClient(int world_id) const;

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -31,6 +31,9 @@ namespace electron {
 
 namespace {
 
+const char kElectronRenderFrameObserverKey[] =
+    "kElectronRenderFrameObserverKey";
+
 // Data which only lives on the service worker's thread
 constinit thread_local ServiceWorkerData* service_worker_data = nullptr;
 
@@ -91,7 +94,10 @@ void ElectronSandboxedRendererClient::InitializeBindings(
 
 void ElectronSandboxedRendererClient::RenderFrameCreated(
     content::RenderFrame* render_frame) {
-  new ElectronRenderFrameObserver(render_frame, this);
+  render_frame->SetUserData(
+      kElectronRenderFrameObserverKey,
+      std::make_unique<ElectronRenderFrameObserver>(render_frame, this));
+
   RendererClientBase::RenderFrameCreated(render_frame);
 }
 


### PR DESCRIPTION
#### Description of Change

This uses upstream's `base:::SupportsUserData` idiom to tie `ElectronRenderFrameObserver`'s lifecycle to the `RenderFrame` that it's observing. This removes a `delete this` wart in our code and makes it more consistent with upstream practices.

All reviews welcomed! CC @codebytere and @deepak1556 who have reviewed other recent code cleanup PRs.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.