### PR TITLE
fix: logical bug in install.js env var handling

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -44,7 +44,7 @@ downloadArtifact({
   artifactName: 'electron',
   force: process.env.force_no_cache === 'true',
   cacheRoot: process.env.electron_config_cache,
-  checksums: process.env.electron_use_remote_checksums ?? process.env.npm_config_electron_use_remote_checksums ? undefined : require('./checksums.json'),
+  checksums: (process.env.electron_use_remote_checksums || process.env.npm_config_electron_use_remote_checksums) ? undefined : require('./checksums.json'),
   platform,
   arch
 }).then(extractFile).catch(err => {


### PR DESCRIPTION
#### Description of Change

If either `NPM_CONFIG_ELECTRON_USE_REMOTE_CHECKSUMS` or `ELECTRON_USE_REMOTE_CHECKSUMS` are set as environment variables, then force Electron to verify with remote checksums instead of embedded ones.

Fixes #48594.

Thanks to @KinshukSS2 for reporting this and suggesting a solution.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an error when checking environmental variables when using remote checksums when installing Electron via npm.