### PR TITLE
docs: fix Ubuntu version used to build Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Each Electron release provides binaries for macOS, Windows, and Linux.
 
 * macOS (Big Sur and up): Electron provides 64-bit Intel and Apple Silicon / ARM binaries for macOS.
 * Windows (Windows 10 and up): Electron provides `ia32` (`x86`), `x64` (`amd64`), and `arm64` binaries for Windows. Windows on ARM support was added in Electron 5.0.8. Support for Windows 7, 8 and 8.1 was [removed in Electron 23, in line with Chromium's Windows deprecation policy](https://www.electronjs.org/blog/windows-7-to-8-1-deprecation-notice).
-* Linux: The prebuilt binaries of Electron are built on Ubuntu 20.04. They have also been verified to work on:
+* Linux: The prebuilt binaries of Electron are built on Ubuntu 22.04. They have also been verified to work on:
   * Ubuntu 18.04 and newer
   * Fedora 32 and newer
   * Debian 10 and newer


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Looking at our build images, it seems like we build on Ubuntu 22.04 nowadays.

See https://github.com/electron/build-images/pkgs/container/build/468560753?tag=933c7d6ff6802706875270bec2e3c891cf8add3f.

It would be great if someone who knows more about our builds than me could verify that.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
