### PR TITLE
fix: use correct signal variable in nan-spec-runner install check

### DIFF
--- a/script/nan-spec-runner.js
+++ b/script/nan-spec-runner.js
@@ -112,16 +112,16 @@ async function main () {
     return process.exit(buildStatus !== 0 ? buildStatus : signal);
   }
 
-  const { status: installStatus } = cp.spawnSync(NPX_CMD, [`yarn@${YARN_VERSION}`, 'install'], {
+  const { status: installStatus, signal: installSignal } = cp.spawnSync(NPX_CMD, [`yarn@${YARN_VERSION}`, 'install'], {
     env,
     cwd: NAN_DIR,
     stdio: 'inherit',
     shell: process.platform === 'win32'
   });
 
-  if (installStatus !== 0 || signal != null) {
+  if (installStatus !== 0 || installSignal != null) {
     console.error('Failed to install nan node_modules');
-    return process.exit(installStatus !== 0 ? installStatus : signal);
+    return process.exit(installStatus !== 0 ? installStatus : installSignal);
   }
 
   const onlyTests = args.only?.split(',');


### PR DESCRIPTION
The install process spawn was not capturing its own signal variable, causing the error check to incorrectly reference the build signal instead. This could lead to:
- Install termination by signal going undetected
- False positive errors when build was killed but install succeeded

This commit ensures the install signal is properly captured and checked, matching the pattern used for the build process.

#### Description of Change
In `script/nan-spec-runner.js`, the yarn install spawn (line 115) only destructured `status` but the error check (line 122) referenced `signal` from the build process instead of the install process signal. This fix captures the install signal and uses it correctly in the error check.


FIxes #48636 


**Before:**

```
const { status: installStatus } = cp.spawnSync(...)
if (installStatus !== 0 || signal != null) { // 'signal' is from build ,not install
```
**After:**
```
const { status: installStatus, signal: installSignal } = cp.spawnSync(...)
if (installStatus !== 0 || installSignal != null) {
```
<!--

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).


#### Release Notes

Notes: Fixed incorrect signal variable reference in nan-spec-runner that could cause install failures to go undetected.
