### PR TITLE
fix: crash on empty dialog extensions array on Windows

### DIFF
--- a/shell/browser/ui/file_dialog_win.cc
+++ b/shell/browser/ui/file_dialog_win.cc
@@ -44,8 +44,7 @@ void ConvertFilters(const Filters& filters,
                     std::vector<std::wstring>* buffer,
                     std::vector<COMDLG_FILTERSPEC>* filterspec) {
   if (filters.empty()) {
-    COMDLG_FILTERSPEC spec = {L"All Files (*.*)", L"*.*"};
-    filterspec->push_back(spec);
+    filterspec->push_back({L"All Files (*.*)", L"*.*"});
     return;
   }
 
@@ -55,11 +54,16 @@ void ConvertFilters(const Filters& filters,
     buffer->push_back(base::UTF8ToWide(filter.first));
     spec.pszName = buffer->back().c_str();
 
-    std::vector<std::string> extensions(filter.second);
-    for (std::string& extension : extensions)
-      extension.insert(0, "*.");
-    buffer->push_back(base::UTF8ToWide(base::JoinString(extensions, ";")));
-    spec.pszSpec = buffer->back().c_str();
+    if (filter.second.empty()) {
+      buffer->push_back(L"*.*");
+      spec.pszSpec = buffer->back().c_str();
+    } else {
+      std::vector<std::string> extensions(filter.second);
+      for (std::string& extension : extensions)
+        extension.insert(0, "*.");
+      buffer->push_back(base::UTF8ToWide(base::JoinString(extensions, ";")));
+      spec.pszSpec = buffer->back().c_str();
+    }
 
     filterspec->push_back(spec);
   }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/48611

Fixes a crash caused by the following:

```
out_of_range was thrown in -fno-exceptions mode with message "basic_string"
```

Due to a stricter `-fno-exceptions` introduced in Chromium via https://github.com/electron/electron/compare/v33.2.0...v33.2.1.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash in `dialog.showOpenDialog` on Windows with an empty extension filter array.