### PR TITLE
docs: add section on local network access permissions for developers

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -75,6 +75,13 @@ an attacker somehow manages to change said content (either by attacking the
 source directly, or by sitting between your app and the actual destination), they
 will be able to execute native code on the user's machine.
 
+### Local Network Access Permissions
+
+With Chrome 142, a new local network access permissions check is being introduced. Electron developers should be aware of how this may affect applications that communicate with localhost or private networks.  
+- Electron currently allows localhost communication without prompting for permission.
+- Developers should follow future updates to ensure compliance with Chromium’s default local network access behavior.
+For more information, see [Chrome Local Network Access](https://developer.chrome.com/blog/local-network-access).
+
 :::warning
 Under no circumstances should you load and execute remote code with
 Node.js integration enabled. Instead, use only local files (packaged together


### PR DESCRIPTION
#### Description of Change

Added a new section documenting local network access permissions for Electron developers. This helps developers understand how to safely request and handle local network access within Electron apps.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are capitalized, punctuated, and past tense

#### Release Notes

Notes: Documented local network access permissions for Electron developers.
