### PR TITLE
docs: add net.isOnline() to online/offline detection tutorial

### DIFF
--- a/docs/tutorial/online-offline-events.md
+++ b/docs/tutorial/online-offline-events.md
@@ -9,8 +9,8 @@ Online and offline event detection can be implemented in both the main and rende
 
 The `navigator.onLine` attribute returns:
 
-* `false` if all network requests are guaranteed to fail (e.g. when disconnected from the network).
-* `true` in all other cases.
+- `false` if all network requests are guaranteed to fail (e.g. when disconnected from the network).
+- `true` in all other cases.
 
 Since many cases return `true`, you should treat with care situations of
 getting false positives, as we cannot always assume that `true` value means


### PR DESCRIPTION
#### Description of Change

Fixes #48561

Updated the online/offline detection tutorial to mention `net.isOnline()` method and `net.online` property available in the main process. Previously, the docs only covered `navigator.onLine` in the renderer process.

Changes:
- Added "Main Process Detection" section with code examples showing `net.isOnline()` and `net.online` usage
- Updated intro to clarify both main and renderer process methods are available
- Updated note about IPC communication to mention `net.isOnline()` as a direct alternative
- Added note about `net` module requiring the `ready` event

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are changed or added
- [x] relevant API documentation, tutorials, and examples are updated and follow the documentation style guide
- [x] PR release notes describe the change in a way relevant to app developers, and are capitalized, punctuated, and past tense.

#### Release Notes

Notes: Updated online/offline detection documentation to include net.isOnline() method and net.online property for main process usage.