### PR TITLE
refactor: use WHATWG URL instead of `url.parse`

### DIFF
--- a/default_app/main.ts
+++ b/default_app/main.ts
@@ -256,7 +256,7 @@ async function startRepl () {
 if (option.file && !option.webdriver) {
   const file = option.file;
   // eslint-disable-next-line n/no-deprecated-api
-  const protocol = url.parse(file).protocol;
+  const protocol = URL.canParse(file) ? new URL(file).protocol : null;
   const extension = path.extname(file);
   if (protocol === 'http:' || protocol === 'https:' || protocol === 'file:' || protocol === 'chrome:') {
     await loadApplicationByURL(file);

--- a/lib/common/api/net-client-request.ts
+++ b/lib/common/api/net-client-request.ts
@@ -227,10 +227,9 @@ function validateHeader (name: any, value: any): void {
 }
 
 function parseOptions (optionsIn: ClientRequestConstructorOptions | string): NodeJS.CreateURLLoaderOptions & ExtraURLLoaderOptions {
-  // eslint-disable-next-line n/no-deprecated-api
-  const options: any = typeof optionsIn === 'string' ? url.parse(optionsIn) : { ...optionsIn };
+  const options: any = typeof optionsIn === 'string' ? new URL(optionsIn) : { ...optionsIn };
 
-  let urlStr: string = options.url;
+  let urlStr: string = options.url || options.href;
 
   if (!urlStr) {
     const urlObj: url.UrlObject = {};
@@ -260,8 +259,8 @@ function parseOptions (optionsIn: ClientRequestConstructorOptions | string): Nod
       // an invalid request.
       throw new TypeError('Request path contains unescaped characters');
     }
-    // eslint-disable-next-line n/no-deprecated-api
-    const pathObj = url.parse(options.path || '/');
+
+    const pathObj = new URL(options.path || '/', 'http://localhost');
     urlObj.pathname = pathObj.pathname;
     urlObj.search = pathObj.search;
     urlObj.hash = pathObj.hash;

--- a/spec/fixtures/pages/window-opener-targetOrigin.html
+++ b/spec/fixtures/pages/window-opener-targetOrigin.html
@@ -9,7 +9,7 @@
     }
   }
   const parsedURL = new URL(window.location.href);
-  if (parsedURL.searchParams.get('opened') != null) {
+  if (parsedURL.searchParams.has('opened')) {
     // Ensure origins are properly checked by removing a single character from the end
     tryPostMessage('do not deliver substring origin', window.location.origin.substring(0, window.location.origin.length - 1))
     tryPostMessage('do not deliver file://', 'file://')


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/49550
Fixes https://github.com/electron/electron/issues/49840

Node is deprecating `url.parse`:

>(node:34012) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
