### PR TITLE
ci: use `<sup>` in release notes generator

### DIFF
--- a/script/release/notes/notes.ts
+++ b/script/release/notes/notes.ts
@@ -684,7 +684,7 @@ function renderTrops (commit: Commit, excludeBranch: string) {
     .map(([branch, key]) => renderTrop(branch, key))
     .join(', ');
   return body
-    ? `<span style="font-size:small;">(Also in ${body})</span>`
+    ? `<sup>(Also in ${body})</sup>`
     : body;
 }
 


### PR DESCRIPTION
#### Description of Change

Makes the script compatible with both standard Markdown and MDX (for the website blog).

See: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/sup

cc @electron/wg-releases 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
(https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
