### PR TITLE
refactor: remove redundant map lookups in `browser/api/menu.ts`

### DIFF
--- a/lib/browser/api/menu.ts
+++ b/lib/browser/api/menu.ts
@@ -28,10 +28,10 @@ Menu.prototype._isCommandIdEnabled = function (id) {
   return this.commandsMap[id] ? this.commandsMap[id].enabled : false;
 };
 Menu.prototype._shouldCommandIdWorkWhenHidden = function (id) {
-  return this.commandsMap[id] ? !!this.commandsMap[id].acceleratorWorksWhenHidden : false;
+  return this.commandsMap[id]?.acceleratorWorksWhenHidden ?? false;
 };
 Menu.prototype._isCommandIdVisible = function (id) {
-  return this.commandsMap[id] ? this.commandsMap[id].visible : false;
+  return this.commandsMap[id]?.visible ?? false;
 };
 
 Menu.prototype._getAcceleratorForCommandId = function (id, useDefaultAccelerator) {
@@ -42,12 +42,12 @@ Menu.prototype._getAcceleratorForCommandId = function (id, useDefaultAccelerator
 };
 
 Menu.prototype._shouldRegisterAcceleratorForCommandId = function (id) {
-  return this.commandsMap[id] ? this.commandsMap[id].registerAccelerator : false;
+  return this.commandsMap[id]?.registerAccelerator ?? false;
 };
 
 if (process.platform === 'darwin') {
   Menu.prototype._getSharingItemForCommandId = function (id) {
-    return this.commandsMap[id] ? this.commandsMap[id].sharingItem : null;
+    return this.commandsMap[id]?.sharingItem ?? null;
   };
 }
 


### PR DESCRIPTION
#### Description of Change

Remove a handful of redundant map lookups in `lib/browser/api/menu.ts`:

- Menu.prototype._shouldCommandIdWorkWhenHidden
- Menu.prototype._isCommandIdVisible
- Menu.prototype._shouldRegisterAcceleratorForCommandId
- Menu.prototype._getSharingItemForCommandId

All reviewers welcomed! CC @codebytere who's recently been fixing bugs in this file

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.