### PR TITLE
docs: use relative link for `OffscreenSharedTexture`

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -41,7 +41,7 @@ webContents.setWindowOpenHandler((details) => {
 
 When using shared texture offscreen rendering feature, the `paint` event now emits a more structured object.
 It moves the `sharedTextureHandle`, `planes`, `modifier` into a unified `handle` property.
-See [here](https://www.electronjs.org/docs/latest/api/structures/offscreen-shared-texture) for more details.
+See the [OffscreenSharedTexture](./api/structures/offscreen-shared-texture.md) API structure for more details.
 
 ## Planned Breaking API Changes (38.0)
 


### PR DESCRIPTION
#### Description of Change

Fixes the website build and a better description to boot.

cc @dsanders11 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none