### PR TITLE
refactor: use Object.values() instead of Object.keys() in stringifyValues()

### DIFF
--- a/lib/common/api/net-client-request.ts
+++ b/lib/common/api/net-client-request.ts
@@ -427,9 +427,8 @@ export class ClientRequest extends Writable implements Electron.ClientRequest {
     this._started = true;
     const stringifyValues = (obj: Record<string, { name: string, value: string | string[] }>) => {
       const ret: Record<string, string> = {};
-      for (const k of Object.keys(obj)) {
-        const kv = obj[k];
-        ret[kv.name] = kv.value.toString();
+      for (const { name, value } of Object.values(obj)) {
+        ret[name] = value.toString();
       }
       return ret;
     };


### PR DESCRIPTION
#### Description of Change

Small cleanup to `stringifyValues()`: it only calls `Object.keys()` to get each key's corresponding value, so just call `Object.values()` instead.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.