### PR TITLE
build: apply additional compression on upload

### DIFF
--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -70,17 +70,17 @@ def make_zip(zip_file_path, files, dirs):
   safe_unlink(zip_file_path)
   if sys.platform == 'darwin':
     allfiles = files + dirs
-    execute(['zip', '-r', '-y', zip_file_path] + allfiles)
+    execute(['zip', '-r', '-y', '-9', zip_file_path] + allfiles)
   else:
     with zipfile.ZipFile(zip_file_path, "w",
                          zipfile.ZIP_DEFLATED,
                          allowZip64=True) as zip_file:
       for filename in files:
-        zip_file.write(filename, filename)
+        zip_file.write(filename, filename, compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)
       for dirname in dirs:
         for root, _, filenames in os.walk(dirname):
           for f in filenames:
-            zip_file.write(os.path.join(root, f))
+            zip_file.write(os.path.join(root, f), compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)
       zip_file.close()
 
 


### PR DESCRIPTION
#### Description of Change

Attempts to fix an issue where dsym files are exceeding the GitHub 2GB file upload limit. This PR adds basic deflate compression to the uploaded files.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
