### PR TITLE
fix: the parent window remained interactive after the modal window was opened

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -104,7 +104,8 @@ NativeWindow::NativeWindow(const gin_helper::Dictionary& options,
       transparent_{options.ValueOrDefault(options::kTransparent, false)},
       enable_larger_than_screen_{
           options.ValueOrDefault(options::kEnableLargerThanScreen, false)},
-      is_modal_{parent != nullptr && options.ValueOrDefault("modal", false)},
+      is_modal_{parent != nullptr &&
+                options.ValueOrDefault(options::kModal, false)},
       has_frame_{options.ValueOrDefault(options::kFrame, true) &&
                  title_bar_style_ == TitleBarStyle::kNormal},
       parent_{parent} {

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -553,7 +553,7 @@ bool NativeWindowViews::IsFocused() const {
 }
 
 void NativeWindowViews::Show() {
-  if (is_modal() && NativeWindow::parent() && !widget()->IsVisible())
+  if (is_modal() && NativeWindow::parent())
     static_cast<NativeWindowViews*>(parent())->IncrementChildModals();
 
   widget()->native_widget_private()->Show(GetRestoredState(), gfx::Rect());

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -222,6 +222,8 @@ inline constexpr std::string_view kSpellcheck = "spellcheck";
 inline constexpr std::string_view kEnableDeprecatedPaste =
     "enableDeprecatedPaste";
 
+inline constexpr std::string_view kModal = "modal";
+
 }  // namespace options
 
 // Following are actually command line switches, should be moved to other files.


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/48535

If calling `maximize()` before `show()` while open a modal window, `maximize()` would calling `Show()` of `native_widget_private()`.
https://github.com/electron/electron/blob/184586f0b176b57ec3effeadce0a3075ac051aff/shell/browser/native_window_views.cc#L700-L701

When using API to call `show()` to show the modal window, it will cause the conditional result as false,
https://github.com/electron/electron/blob/184586f0b176b57ec3effeadce0a3075ac051aff/shell/browser/native_window_views.cc#L556-L557

So cause the parent window remained interactive after the modal window was opened.

Search commit history, the code introduced in PR: https://github.com/electron/electron/issues/8768, I cannot reproduce the issues(https://github.com/electron/electron/issues/8768 and https://github.com/electron/electron/issues/8677) that PR fixed originally.

While I personally don't recommend resizing the modal window, including minimize and maximize. the API cannot prevent users from maximize before the showing.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed the issue where the parent window remained interactive after the modal window was opened.