### PR TITLE
refactor: remove unnecessary template type in `EmitEvent()`

### DIFF
--- a/shell/common/gin_helper/event_emitter_caller.cc
+++ b/shell/common/gin_helper/event_emitter_caller.cc
@@ -11,7 +11,7 @@ namespace gin_helper::internal {
 v8::Local<v8::Value> CallMethodWithArgs(
     v8::Isolate* isolate,
     v8::Local<v8::Object> obj,
-    const char* method,
+    const std::string_view method,
     const base::span<v8::Local<v8::Value>> args) {
   v8::EscapableHandleScope handle_scope{isolate};
 
@@ -27,8 +27,9 @@ v8::Local<v8::Value> CallMethodWithArgs(
                                        v8::MicrotasksScope::kRunMicrotasks);
 
   // node::MakeCallback will also run pending tasks in Node.js.
-  v8::MaybeLocal<v8::Value> ret = node::MakeCallback(
-      isolate, obj, method, args.size(), args.data(), {0, 0});
+  v8::MaybeLocal<v8::Value> ret =
+      node::MakeCallback(isolate, obj, gin::StringToV8(isolate, method),
+                         args.size(), args.data(), {0, 0});
 
   // If the JS function throws an exception (doesn't return a value) the result
   // of MakeCallback will be empty and therefore ToLocal will be false, in this

--- a/shell/common/gin_helper/event_emitter_caller.h
+++ b/shell/common/gin_helper/event_emitter_caller.h
@@ -6,6 +6,7 @@
 #define ELECTRON_SHELL_COMMON_GIN_HELPER_EVENT_EMITTER_CALLER_H_
 
 #include <array>
+#include <string_view>
 #include <utility>
 
 #include "base/containers/span.h"
@@ -20,17 +21,17 @@ namespace internal {
 
 v8::Local<v8::Value> CallMethodWithArgs(v8::Isolate* isolate,
                                         v8::Local<v8::Object> obj,
-                                        const char* method,
+                                        std::string_view method,
                                         base::span<v8::Local<v8::Value>> args);
 
 }  // namespace internal
 
 // obj.emit(name, args...);
 // The caller is responsible of allocating a HandleScope.
-template <typename StringType, typename... Args>
+template <typename... Args>
 v8::Local<v8::Value> EmitEvent(v8::Isolate* isolate,
                                v8::Local<v8::Object> obj,
-                               const StringType& name,
+                               const std::string_view name,
                                Args&&... args) {
   v8::EscapableHandleScope scope{isolate};
   std::array<v8::Local<v8::Value>, 1U + sizeof...(args)> converted_args = {
@@ -45,7 +46,7 @@ v8::Local<v8::Value> EmitEvent(v8::Isolate* isolate,
 template <typename... Args>
 v8::Local<v8::Value> CustomEmit(v8::Isolate* isolate,
                                 v8::Local<v8::Object> object,
-                                const char* custom_emit,
+                                const std::string_view custom_emit,
                                 Args&&... args) {
   v8::EscapableHandleScope scope{isolate};
   std::array<v8::Local<v8::Value>, sizeof...(args)> converted_args = {
@@ -58,7 +59,7 @@ v8::Local<v8::Value> CustomEmit(v8::Isolate* isolate,
 template <typename T, typename... Args>
 v8::Local<v8::Value> CallMethod(v8::Isolate* isolate,
                                 gin_helper::DeprecatedWrappable<T>* object,
-                                const char* method_name,
+                                const std::string_view method_name,
                                 Args&&... args) {
   v8::EscapableHandleScope scope(isolate);
   v8::Local<v8::Object> v8_object;
@@ -71,7 +72,7 @@ v8::Local<v8::Value> CallMethod(v8::Isolate* isolate,
 
 template <typename T, typename... Args>
 v8::Local<v8::Value> CallMethod(gin_helper::DeprecatedWrappable<T>* object,
-                                const char* method_name,
+                                const std::string_view method_name,
                                 Args&&... args) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   return CallMethod(isolate, object, method_name, std::forward<Args>(args)...);
@@ -80,7 +81,7 @@ v8::Local<v8::Value> CallMethod(gin_helper::DeprecatedWrappable<T>* object,
 template <typename T, typename... Args>
 v8::Local<v8::Value> CallMethod(v8::Isolate* isolate,
                                 gin::Wrappable<T>* object,
-                                const char* method_name,
+                                const std::string_view method_name,
                                 Args&&... args) {
   v8::EscapableHandleScope scope(isolate);
   v8::Local<v8::Object> v8_object;
@@ -93,7 +94,7 @@ v8::Local<v8::Value> CallMethod(v8::Isolate* isolate,
 
 template <typename T, typename... Args>
 v8::Local<v8::Value> CallMethod(gin::Wrappable<T>* object,
-                                const char* method_name,
+                                const std::string_view method_name,
                                 Args&&... args) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   return CallMethod(isolate, object, method_name, std::forward<Args>(args)...);


### PR DESCRIPTION
#### Description of Change

- Remove an unnecessary StringView template type in `electron::EmitEvent()` -- just use `std::string_view` in all cases
- Refactor `electron::internal::CallMethodWithArgs() to take a `std::string_view` instead of a `const char*`. 

Supersedes https://github.com/electron/electron/pull/44099.

All reviews welcomed. CC @codebytere as previous stakeholder

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.