### PR TITLE
fix: enable wasm trap handlers in all Node.js  processes

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -62,6 +62,7 @@
 #include "shell/common/logging.h"
 #include "shell/common/node_bindings.h"
 #include "shell/common/node_includes.h"
+#include "shell/common/v8_util.h"
 #include "ui/base/idle/idle.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/ui_base_switches.h"
@@ -273,6 +274,10 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
 
   // Initialize field trials.
   InitializeFieldTrials();
+
+  if (base::FeatureList::IsEnabled(features::kWebAssemblyTrapHandler)) {
+    electron::SetUpWebAssemblyTrapHandler();
+  }
 
   // Reinitialize logging now that the app has had a chance to set the app name
   // and/or user data directory.

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -13,7 +13,6 @@
 
 #include "base/allocator/partition_allocator/src/partition_alloc/oom.h"
 #include "base/base_paths.h"
-#include "base/base_switches.h"
 #include "base/command_line.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/environment.h"
@@ -24,7 +23,6 @@
 #include "base/task/single_thread_task_runner.h"
 #include "base/trace_event/trace_event.h"
 #include "chrome/common/chrome_version.h"
-#include "content/public/common/content_features.h"
 #include "content/public/common/content_paths.h"
 #include "content/public/renderer/render_frame.h"
 #include "electron/buildflags/buildflags.h"
@@ -52,13 +50,6 @@
 #include "third_party/blink/renderer/bindings/core/v8/v8_initializer.h"  // nogncheck
 #include "third_party/electron_node/src/debug_utils.h"
 #include "third_party/electron_node/src/module_wrap.h"
-
-#if BUILDFLAG(IS_LINUX) && (defined(ARCH_CPU_X86_64) || defined(ARCH_CPU_ARM64))
-#define ENABLE_WEB_ASSEMBLY_TRAP_HANDLER_LINUX
-#include "components/crash/core/app/crashpad.h"  // nogncheck
-#include "content/public/common/content_switches.h"
-#include "v8/include/v8-wasm-trap-handler-posix.h"
-#endif
 
 #if !IS_MAS_BUILD()
 #include "shell/common/crash_keys.h"
@@ -511,51 +502,6 @@ void SetNodeOptions(base::Environment* env) {
   }
 }
 
-void SetUpWebAssemblyTrapHandler() {
-#if BUILDFLAG(IS_WIN)
-  // On Windows we use the default trap handler provided by V8.
-  v8::V8::EnableWebAssemblyTrapHandler(true);
-#elif BUILDFLAG(IS_MAC)
-  // On macOS, Crashpad uses exception ports to handle signals in a
-  // different process. As we cannot just pass a callback to this other
-  // process, we ask V8 to install its own signal handler to deal with
-  // WebAssembly traps.
-  v8::V8::EnableWebAssemblyTrapHandler(true);
-#elif defined(ENABLE_WEB_ASSEMBLY_TRAP_HANDLER_LINUX)
-  const bool crash_reporter_enabled =
-      crash_reporter::GetHandlerSocket(nullptr, nullptr);
-
-  if (crash_reporter_enabled) {
-    // If either --enable-crash-reporter or --enable-crash-reporter-for-testing
-    // is enabled it should take care of signal handling for us, use the default
-    // implementation which doesn't register an additional handler.
-    v8::V8::EnableWebAssemblyTrapHandler(false);
-    return;
-  }
-
-  const bool use_v8_default_handler =
-      base::CommandLine::ForCurrentProcess()->HasSwitch(
-          ::switches::kDisableInProcessStackTraces);
-
-  if (use_v8_default_handler) {
-    // There is no signal handler yet, but it's okay if v8 registers one.
-    v8::V8::EnableWebAssemblyTrapHandler(/*use_v8_signal_handler=*/true);
-    return;
-  }
-
-  if (base::debug::SetStackDumpFirstChanceCallback(
-          v8::TryHandleWebAssemblyTrapPosix)) {
-    // Crashpad and Breakpad are disabled, but the in-process stack dump
-    // handlers are enabled, so set the callback on the stack dump handlers.
-    v8::V8::EnableWebAssemblyTrapHandler(/*use_v8_signal_handler=*/false);
-    return;
-  }
-
-  // As the registration of the callback failed, we don't enable trap
-  // handlers.
-#endif
-}
-
 }  // namespace
 
 namespace electron {
@@ -576,12 +522,7 @@ base::FilePath GetResourcesPath() {
 
 NodeBindings::NodeBindings(BrowserEnvironment browser_env)
     : browser_env_{browser_env},
-      uv_loop_{InitEventLoop(browser_env, &worker_loop_)} {
-  if (base::FeatureList::IsEnabled(features::kWebAssemblyTrapHandler) &&
-      browser_env_ != BrowserEnvironment::kWorker) {
-    SetUpWebAssemblyTrapHandler();
-  }
-}
+      uv_loop_{InitEventLoop(browser_env, &worker_loop_)} {}
 
 NodeBindings::~NodeBindings() {
   // Quit the embed thread.

--- a/shell/common/v8_util.cc
+++ b/shell/common/v8_util.cc
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/base_switches.h"
 #include "base/memory/raw_ptr.h"
 #include "gin/converter.h"
 #include "shell/common/api/electron_api_native_image.h"
@@ -16,6 +17,14 @@
 #include "third_party/blink/public/common/messaging/web_message_port.h"
 #include "ui/gfx/image/image_skia.h"
 #include "v8/include/v8.h"
+
+#if BUILDFLAG(IS_LINUX) && (defined(ARCH_CPU_X86_64) || defined(ARCH_CPU_ARM64))
+#define ENABLE_WEB_ASSEMBLY_TRAP_HANDLER_LINUX
+#include "base/command_line.h"
+#include "components/crash/core/app/crashpad.h"  // nogncheck
+#include "content/public/common/content_switches.h"
+#include "v8/include/v8-wasm-trap-handler-posix.h"
+#endif
 
 namespace electron {
 
@@ -238,6 +247,51 @@ v8::Local<v8::Value> DeserializeV8Value(v8::Isolate* isolate,
 v8::Local<v8::Value> DeserializeV8Value(v8::Isolate* isolate,
                                         base::span<const uint8_t> data) {
   return V8Deserializer(isolate, data).Deserialize();
+}
+
+void SetUpWebAssemblyTrapHandler() {
+#if BUILDFLAG(IS_WIN)
+  // On Windows we use the default trap handler provided by V8.
+  v8::V8::EnableWebAssemblyTrapHandler(true);
+#elif BUILDFLAG(IS_MAC)
+  // On macOS, Crashpad uses exception ports to handle signals in a
+  // different process. As we cannot just pass a callback to this other
+  // process, we ask V8 to install its own signal handler to deal with
+  // WebAssembly traps.
+  v8::V8::EnableWebAssemblyTrapHandler(true);
+#elif defined(ENABLE_WEB_ASSEMBLY_TRAP_HANDLER_LINUX)
+  const bool crash_reporter_enabled =
+      crash_reporter::GetHandlerSocket(nullptr, nullptr);
+
+  if (crash_reporter_enabled) {
+    // If either --enable-crash-reporter or --enable-crash-reporter-for-testing
+    // is enabled it should take care of signal handling for us, use the default
+    // implementation which doesn't register an additional handler.
+    v8::V8::EnableWebAssemblyTrapHandler(false);
+    return;
+  }
+
+  const bool use_v8_default_handler =
+      base::CommandLine::ForCurrentProcess()->HasSwitch(
+          ::switches::kDisableInProcessStackTraces);
+
+  if (use_v8_default_handler) {
+    // There is no signal handler yet, but it's okay if v8 registers one.
+    v8::V8::EnableWebAssemblyTrapHandler(/*use_v8_signal_handler=*/true);
+    return;
+  }
+
+  if (base::debug::SetStackDumpFirstChanceCallback(
+          v8::TryHandleWebAssemblyTrapPosix)) {
+    // Crashpad and Breakpad are disabled, but the in-process stack dump
+    // handlers are enabled, so set the callback on the stack dump handlers.
+    v8::V8::EnableWebAssemblyTrapHandler(/*use_v8_signal_handler=*/false);
+    return;
+  }
+
+  // As the registration of the callback failed, we don't enable trap
+  // handlers.
+#endif
 }
 
 namespace util {

--- a/shell/common/v8_util.h
+++ b/shell/common/v8_util.h
@@ -30,6 +30,8 @@ v8::Local<v8::Value> DeserializeV8Value(v8::Isolate* isolate,
 v8::Local<v8::Value> DeserializeV8Value(v8::Isolate* isolate,
                                         base::span<const uint8_t> data);
 
+void SetUpWebAssemblyTrapHandler();
+
 namespace util {
 
 [[nodiscard]] base::span<uint8_t> as_byte_span(

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -18,6 +18,7 @@
 #include "shell/common/node_includes.h"
 #include "shell/common/node_util.h"
 #include "shell/common/options_switches.h"
+#include "shell/common/v8_util.h"
 #include "shell/renderer/electron_render_frame_observer.h"
 #include "shell/renderer/web_worker_observer.h"
 #include "third_party/blink/public/common/web_preferences/web_preferences.h"
@@ -240,7 +241,9 @@ void ElectronRendererClient::WillDestroyWorkerContextOnWorkerThread(
 }
 
 void ElectronRendererClient::SetUpWebAssemblyTrapHandler() {
-  // Noop, setup happens in `NodeBindings::NodeBindings`.
+  // content/renderer layer already takes care of the feature flag detection
+  // so no need to check for features::kWebAssemblyTrapHandler here.
+  electron::SetUpWebAssemblyTrapHandler();
 }
 
 node::Environment* ElectronRendererClient::GetEnvironment(

--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -11,6 +11,7 @@
 #include "base/no_destructor.h"
 #include "base/process/process.h"
 #include "base/strings/utf_string_conversions.h"
+#include "content/public/common/content_features.h"
 #include "electron/mas.h"
 #include "net/base/network_change_notifier.h"
 #include "services/network/public/cpp/wrapper_shared_url_loader_factory.h"
@@ -22,6 +23,7 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_bindings.h"
 #include "shell/common/node_includes.h"
+#include "shell/common/v8_util.h"
 #include "shell/services/node/parent_port.h"
 
 #if !IS_MAS_BUILD()
@@ -129,6 +131,11 @@ void NodeService::Initialize(
 
   v8::Isolate* const isolate = js_env_->isolate();
   v8::HandleScope scope{isolate};
+
+  // Initialize after setting up the V8 isolate.
+  if (base::FeatureList::IsEnabled(features::kWebAssemblyTrapHandler)) {
+    electron::SetUpWebAssemblyTrapHandler();
+  }
 
   node_bindings_->Initialize(isolate, isolate->GetCurrentContext());
 


### PR DESCRIPTION
#### Description of Change

Found while investigating https://github.com/microsoft/vscode/issues/273191

Since https://github.com/electron/electron/pull/47186 we had accidentally disabled V8 trap handlers in browser and utility process. This incurs performance cost when executing wasm due to inlined bound checks.

Enable the feature back and align it with upstream based on the feature parameter across all processes [features::kWebAssemblyTrapHandler](https://source.chromium.org/chromium/chromium/src/+/main:content/public/common/content_features.cc;l=1175-1186)

Current matrix of enabled platforms.

```
Linux, Windows, MacOS - x86_64
Linux, MacOS - arm64
```

#### Release Notes

Notes: Reenable V8 trap handlers for wasm in browser and utility process, improves runtime execution of wasm