### PR TITLE
fix: revert allow disabling all NSMenuItems, fix menu crash

### DIFF
--- a/lib/browser/api/menu.ts
+++ b/lib/browser/api/menu.ts
@@ -25,30 +25,11 @@ Menu.prototype._isCommandIdChecked = function (id) {
 };
 
 Menu.prototype._isCommandIdEnabled = function (id) {
-  const item = this.commandsMap[id];
-  if (!item) return false;
-
-  const focusedWindow = BaseWindow.getFocusedWindow();
-
-  if (item.role === 'minimize' && focusedWindow) {
-    return focusedWindow.isMinimizable();
-  }
-
-  if (item.role === 'togglefullscreen' && focusedWindow) {
-    return focusedWindow.isFullScreenable();
-  }
-
-  if (item.role === 'close' && focusedWindow) {
-    return focusedWindow.isClosable();
-  }
-
-  return item.enabled;
+  return this.commandsMap[id] ? this.commandsMap[id].enabled : false;
 };
-
 Menu.prototype._shouldCommandIdWorkWhenHidden = function (id) {
   return this.commandsMap[id]?.acceleratorWorksWhenHidden ?? false;
 };
-
 Menu.prototype._isCommandIdVisible = function (id) {
   return this.commandsMap[id]?.visible ?? false;
 };


### PR DESCRIPTION
#### Description of Change

After landing #48598, we noticed a hard crash when trying to access the native MacOS "Window" menu (this is reproducible in a default Fiddle). This PR reverts 0cb4fdd0f2ae28d7bf3cd753cd2b641947e637aa to fix that crash.

Hat tip to @erickzhao and @georgexu99 for spotting this crash and bisecting 🙇‍♀️ 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an application crash when clicking or hovering over the native MacOS "Window" menu. Reverts #48598.
