### PR TITLE
build: use --keep-non-patch flag with git am

### DIFF
--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -52,7 +52,8 @@ def get_repo_root(path):
 
 def am(repo, patch_data, threeway=False, directory=None, exclude=None,
     committer_name=None, committer_email=None, keep_cr=True):
-  args = []
+  # --keep-non-patch prevents stripping leading bracketed strings on the subject line
+  args = ['--keep-non-patch']
   if threeway:
     args += ['--3way']
   if directory is not None:


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

There's an edge case with our patch system where if we cherry-pick an upstream patch that starts with bracketed text, that text is stripped when the patch is applied and then re-exporting the patches causes shear. We've run into that in #48791.

[More info](https://git-scm.com/docs/git-mailinfo#Documentation/git-mailinfo.txt--b) on the effect of `git am --keep-non-patch` (which is just a pass through for `git mailinfo -b`).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
