### PR TITLE
refactor: remove `allow_unsafe_buffers` pragma from `FD_ZERO`

### DIFF
--- a/shell/common/node_bindings_mac.cc
+++ b/shell/common/node_bindings_mac.cc
@@ -2,16 +2,10 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#ifdef UNSAFE_BUFFERS_BUILD
-// TODO(crbug.com/351564777): Remove FD_ZERO and convert code to safer
-// constructs.
-#pragma allow_unsafe_buffers
-#endif
-
 #include "shell/common/node_bindings_mac.h"
 
 #include <errno.h>
-#include <sys/select.h>
+#include <poll.h>
 #include <sys/sysctl.h>
 #include <sys/time.h>
 #include <sys/types.h>
@@ -23,24 +17,18 @@ NodeBindingsMac::NodeBindingsMac(BrowserEnvironment browser_env)
 
 void NodeBindingsMac::PollEvents() {
   auto* const event_loop = uv_loop();
+  // uv_backend_timeout returns milliseconds or -1 for infinite wait.
+  const int backend_fd = uv_backend_fd(event_loop);
+  const int timeout_ms = uv_backend_timeout(event_loop);  // -1 => infinite
 
-  struct timeval tv;
-  int timeout = uv_backend_timeout(event_loop);
-  if (timeout != -1) {
-    tv.tv_sec = timeout / 1000;
-    tv.tv_usec = (timeout % 1000) * 1000;
-  }
+  struct pollfd pfd;
+  pfd.fd = backend_fd;
+  pfd.events = POLLIN;
+  pfd.revents = 0;
 
-  fd_set readset;
-  int fd = uv_backend_fd(event_loop);
-  FD_ZERO(&readset);
-  FD_SET(fd, &readset);
-
-  // Wait for new libuv events.
   int r;
   do {
-    r = select(fd + 1, &readset, nullptr, nullptr,
-               timeout == -1 ? nullptr : &tv);
+    r = poll(&pfd, 1, timeout_ms);
   } while (r == -1 && errno == EINTR);
 }
 


### PR DESCRIPTION
#### Description of Change

Remove `allow_unsafe_buffers` in `node_binding_mac` to address an outstanding TODO from https://github.com/electron/electron/issues/46482

Refactors `NodeBindingsMac::PollEvents()` to use `poll()` instead of `select()`/`fd_set`, removing reliance on `FD_ZERO`/`FD_SET` and eliminating the need for unsafe buffer allowances. Behavior (blocking until libuv backend fd is readable or timeout expires, with EINTR retry and infinite wait support) should remain the same.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
