### PR TITLE
feat: Allow `View.setBounds` to animate

### DIFF
--- a/docs/api/view.md
+++ b/docs/api/view.md
@@ -62,7 +62,7 @@ it becomes the topmost view.
 
 If the view passed as a parameter is not a child of this view, this method is a no-op.
 
-#### `view.setBounds(bounds[, animate])`
+#### `view.setBounds(bounds[, options])`
 
 * `bounds` [Rectangle](structures/rectangle.md) - New bounds of the View.
 * `options` Object (optional) - Options for setting the bounds.

--- a/docs/api/view.md
+++ b/docs/api/view.md
@@ -65,9 +65,10 @@ If the view passed as a parameter is not a child of this view, this method is a 
 #### `view.setBounds(bounds[, animate])`
 
 * `bounds` [Rectangle](structures/rectangle.md) - New bounds of the View.
-* `animate` boolean | Object (optional) - If true, the bounds change will be animated. If an object is passed, it can contain the following properties:
-  * `duration` Integer (optional) - Duration of the animation in milliseconds.
-  * `easing` string (optional) - Easing function for the animation. Can be `linear`, `ease-in`, `ease-out`, or `ease-in-out`. Default is `linear`.
+* `options` Object (optional) - Options for setting the bounds.
+  * `animate` boolean | Object (optional) - If true, the bounds change will be animated. If an object is passed, it can contain the following properties:
+    * `duration` Integer (optional) - Duration of the animation in milliseconds.
+    * `easing` string (optional) - Easing function for the animation. Can be `linear`, `ease-in`, `ease-out`, or `ease-in-out`. Default is `linear`.
 
 #### `view.getBounds()`
 

--- a/docs/api/view.md
+++ b/docs/api/view.md
@@ -62,9 +62,13 @@ it becomes the topmost view.
 
 If the view passed as a parameter is not a child of this view, this method is a no-op.
 
-#### `view.setBounds(bounds)`
+#### `view.setBounds(bounds[, options])`
 
 * `bounds` [Rectangle](structures/rectangle.md) - New bounds of the View.
+* `options` Object (optional) - Options for the bounds change.
+  * `animate` boolean (optional) - If true, the bounds change will be animated.
+  * `duration` Integer (optional) - Duration of the animation in milliseconds.
+  * `easing` string (optional) - Easing function for the animation. Can be `linear`, `ease-in`, `ease-out`, or `ease-in-out`. Default is `linear`.
 
 #### `view.getBounds()`
 

--- a/docs/api/view.md
+++ b/docs/api/view.md
@@ -62,11 +62,10 @@ it becomes the topmost view.
 
 If the view passed as a parameter is not a child of this view, this method is a no-op.
 
-#### `view.setBounds(bounds[, options])`
+#### `view.setBounds(bounds[, animate])`
 
 * `bounds` [Rectangle](structures/rectangle.md) - New bounds of the View.
-* `options` Object (optional) - Options for the bounds change.
-  * `animate` boolean (optional) - If true, the bounds change will be animated.
+* `animate` boolean | Object (optional) - If true, the bounds change will be animated. If an object is passed, it can contain the following properties:
   * `duration` Integer (optional) - Duration of the animation in milliseconds.
   * `easing` string (optional) - Easing function for the animation. Can be `linear`, `ease-in`, `ease-out`, or `ease-in-out`. Default is `linear`.
 

--- a/docs/api/view.md
+++ b/docs/api/view.md
@@ -67,8 +67,12 @@ If the view passed as a parameter is not a child of this view, this method is a 
 * `bounds` [Rectangle](structures/rectangle.md) - New bounds of the View.
 * `options` Object (optional) - Options for setting the bounds.
   * `animate` boolean | Object (optional) - If true, the bounds change will be animated. If an object is passed, it can contain the following properties:
-    * `duration` Integer (optional) - Duration of the animation in milliseconds.
-    * `easing` string (optional) - Easing function for the animation. Can be `linear`, `ease-in`, `ease-out`, or `ease-in-out`. Default is `linear`.
+    * `duration` Integer (optional) - Duration of the animation in milliseconds. Default is `250`.
+    * `easing` string (optional) - Easing function for the animation. Default is `linear`.
+      * `linear`
+      * `ease-in`
+      * `ease-out`
+      * `ease-in-out`
 
 #### `view.getBounds()`
 

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -378,7 +378,6 @@ void View::SetBounds(const gfx::Rect& bounds, gin::Arguments* const args) {
   if (view_->width() < bounds.width() || view_->height() < bounds.height()) {
     view_->SetBoundsRect(max_size);
 
-    ui::Layer* layer = view_->layer();
     if (layer) {
       layer->SetClipRect(
           gfx::Rect(0, 0, current_bounds.width(), current_bounds.height()));

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -315,7 +315,6 @@ ui::Layer* View::GetLayer() {
   ui::Layer* layer = view_->layer();
 
   layer->SetFillsBoundsOpaquely(false);
-  layer->SetOpacity(1.0f);
 
   return layer;
 }

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -344,6 +344,7 @@ void View::SetBounds(const gfx::Rect& bounds, gin::Arguments* const args) {
       .OnEnded(base::BindOnce(
           [](views::View* view, const gfx::Rect& final_bounds) {
             view->SetBoundsRect(final_bounds);
+            view->DestroyLayer();
           },
           view_, bounds))
       .Once()

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -317,13 +317,10 @@ void View::SetBounds(const gfx::Rect& bounds, gin::Arguments* const args) {
   }
 
   gfx::Rect current_bounds = view_->bounds();
-
-  gfx::Rect current_size =
-      gfx::Rect(0, 0, current_bounds.width(), current_bounds.height());
   gfx::Rect target_size = gfx::Rect(0, 0, bounds.width(), bounds.height());
-
   gfx::Rect max_size =
-      gfx::Rect(0, 0, std::max(current_bounds.width(), bounds.width()),
+      gfx::Rect(current_bounds.x(), current_bounds.y(),
+                std::max(current_bounds.width(), bounds.width()),
                 std::max(current_bounds.height(), bounds.height()));
 
   view_->SetPaintToLayer();
@@ -332,10 +329,11 @@ void View::SetBounds(const gfx::Rect& bounds, gin::Arguments* const args) {
   // view's bounds immediatley to the new size (not position) and set the
   // layer's clip rect to animate from there.
   if (view_->width() < bounds.width() || view_->height() < bounds.height()) {
-    view_->SetBoundsRect(gfx::Rect(current_bounds.origin(), max_size.size()));
+    view_->SetBoundsRect(max_size);
 
     ui::Layer* layer = view_->layer();
-    layer->SetClipRect(current_size);
+    layer->SetClipRect(
+        gfx::Rect(0, 0, current_bounds.width(), current_bounds.height()));
   }
 
   views::AnimationBuilder()
@@ -344,7 +342,6 @@ void View::SetBounds(const gfx::Rect& bounds, gin::Arguments* const args) {
       .OnEnded(base::BindOnce(
           [](views::View* view, const gfx::Rect& final_bounds) {
             view->SetBoundsRect(final_bounds);
-            view->DestroyLayer();
           },
           view_, bounds))
       .Once()

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -324,11 +324,19 @@ void View::SetBounds(const gfx::Rect& bounds, gin::Arguments* const args) {
   int duration = 250;
   gfx::Tween::Type easing = gfx::Tween::LINEAR;
 
-  gin_helper::Dictionary options;
-  if (args->GetNext(&options)) {
-    options.Get("animate", &animate);
-    options.Get("duration", &duration);
-    options.Get("easing", &easing);
+  if (args && args->Length() > 1) {
+    v8::Local<v8::Value> next_arg = args->PeekNext();
+
+    if (next_arg->IsBoolean()) {
+      args->GetNext(&animate);
+    } else if (next_arg->IsObject()) {
+      animate = true;
+
+      gin_helper::Dictionary dict;
+      args->GetNext(&dict);
+      dict.Get("duration", &duration);
+      dict.Get("easing", &easing);
+    }
   }
 
   if (duration < 0)
@@ -339,7 +347,6 @@ void View::SetBounds(const gfx::Rect& bounds, gin::Arguments* const args) {
 
   if (!animate) {
     view_->SetBoundsRect(bounds);
-
     return;
   }
 

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -323,7 +323,7 @@ void View::SetBounds(const gfx::Rect& bounds, gin::Arguments* const args) {
                 std::max(current_bounds.width(), bounds.width()),
                 std::max(current_bounds.height(), bounds.height()));
 
-  view_->SetPaintToLayer();
+  view_->SetPaintToLayer(ui::LAYER_NOT_DRAWN);
 
   // if the view's size is smaller than the target size, we need to set the
   // view's bounds immediatley to the new size (not position) and set the
@@ -332,8 +332,10 @@ void View::SetBounds(const gfx::Rect& bounds, gin::Arguments* const args) {
     view_->SetBoundsRect(max_size);
 
     ui::Layer* layer = view_->layer();
-    layer->SetClipRect(
-        gfx::Rect(0, 0, current_bounds.width(), current_bounds.height()));
+    if (layer) {
+      layer->SetClipRect(
+          gfx::Rect(0, 0, current_bounds.width(), current_bounds.height()));
+    }
   }
 
   views::AnimationBuilder()

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -324,18 +324,22 @@ void View::SetBounds(const gfx::Rect& bounds, gin::Arguments* const args) {
   int duration = 250;
   gfx::Tween::Type easing = gfx::Tween::LINEAR;
 
-  if (args && args->Length() > 1) {
-    v8::Local<v8::Value> next_arg = args->PeekNext();
+  gin_helper::Dictionary dict;
+  if (args->GetNext(&dict)) {
+    v8::Local<v8::Value> animate_value;
 
-    if (next_arg->IsBoolean()) {
-      args->GetNext(&animate);
-    } else if (next_arg->IsObject()) {
-      animate = true;
+    if (dict.Get("animate", &animate_value)) {
+      if (animate_value->IsBoolean()) {
+        animate = animate_value->BooleanValue(isolate());
+      } else {
+        animate = true;
 
-      gin_helper::Dictionary dict;
-      args->GetNext(&dict);
-      dict.Get("duration", &duration);
-      dict.Get("easing", &easing);
+        gin_helper::Dictionary animate_dict;
+        if (gin::ConvertFromV8(isolate(), animate_value, &animate_dict)) {
+          animate_dict.Get("duration", &duration);
+          animate_dict.Get("easing", &easing);
+        }
+      }
     }
   }
 

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -37,7 +37,7 @@ class View : public gin_helper::EventEmitter<View>,
                       std::optional<size_t> index);
   void RemoveChildView(gin_helper::Handle<View> child);
 
-  void SetBounds(const gfx::Rect& bounds);
+  void SetBounds(const gfx::Rect& bounds, gin::Arguments* args);
   gfx::Rect GetBounds() const;
   void SetLayout(v8::Isolate* isolate, v8::Local<v8::Object> value);
   std::vector<v8::Local<v8::Value>> GetChildren();

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -70,7 +70,7 @@ class View : public gin_helper::EventEmitter<View>,
   void OnChildViewRemoved(views::View* observed_view,
                           views::View* child) override;
 
-  void GetLayer();
+  ui::Layer* GetLayer();
   void ApplyBorderRadius();
   void ReorderChildView(gin_helper::Handle<View> child, size_t index);
 

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -70,6 +70,7 @@ class View : public gin_helper::EventEmitter<View>,
   void OnChildViewRemoved(views::View* observed_view,
                           views::View* child) override;
 
+  void GetLayer();
   void ApplyBorderRadius();
   void ReorderChildView(gin_helper::Handle<View> child, size_t index);
 

--- a/spec/api-view-spec.ts
+++ b/spec/api-view-spec.ts
@@ -133,5 +133,18 @@ describe('View', () => {
       parent.setBounds({ x: 50, y: 60, width: 500, height: 600 });
       expect(child.getBounds()).to.deep.equal({ x: 10, y: 15, width: 25, height: 30 });
     });
+
+    it('can set bounds with animation', (done) => {
+      const v = new View();
+      v.setBounds({ x: 0, y: 0, width: 100, height: 100 }, {
+        animate: {
+          duration: 300
+        }
+      });
+      setTimeout(() => {
+        expect(v.getBounds()).to.deep.equal({ x: 0, y: 0, width: 100, height: 100 });
+        done();
+      }, 350);
+    });
   });
 });


### PR DESCRIPTION
#### Description of Change

Add an optional options object to `View.setBounds` which, if specified, allows for the use of Chromium's `AnimationBuilder` to natively animate the bounds change of the view.

https://github.com/user-attachments/assets/01cfd678-9c27-4df5-a066-0833fc0bf1e1

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Add animation functionality to `view.setBounds` and add `view.setBackgroundBlur`
