### PR TITLE
docs: Update 404 devtools extension documentation link

### DIFF
--- a/docs/tutorial/devtools-extension.md
+++ b/docs/tutorial/devtools-extension.md
@@ -94,7 +94,7 @@ If the extension works on Chrome but not on Electron, file a bug in Electron's
 [issue tracker][issue-tracker] and describe which part
 of the extension is not working as expected.
 
-[devtools-extension]: https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools#creating
+[devtools-extension]: https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools
 [session]: ../api/session.md
 [react-devtools]: https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi
 [load-extension]: ../api/extensions-api.md#extensionsloadextensionpath-options


### PR DESCRIPTION
#### Description of Change

<a href="https://www.electronjs.org/docs/latest/tutorial/devtools-extension" target="_blank">
<img width="740" height="210" alt="CleanShot 2025-11-06 at 19 48 43@2x" src="https://github.com/user-attachments/assets/3d917f52-3d1a-48b4-9d6f-7f40eb10accc" /></a>





Link URL: https://developer.chrome.com/extensions/devtools

↑The current link is not exists.

So update to most relevant developer.chrome.com page.

New URL: https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools#creating

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: docs update 404 devtools extension documentation link
