### PR TITLE
refactor: remove unused `ExtensionActionAPI` methods & fields

### DIFF
--- a/shell/browser/extensions/api/extension_action/extension_action_api.cc
+++ b/shell/browser/extensions/api/extension_action/extension_action_api.cc
@@ -33,8 +33,7 @@ void ExtensionActionAPI::Observer::OnExtensionActionAPIShuttingDown() {}
 // ExtensionActionAPI
 //
 
-ExtensionActionAPI::ExtensionActionAPI(content::BrowserContext* context)
-    : browser_context_(context), extension_prefs_(nullptr) {}
+ExtensionActionAPI::ExtensionActionAPI(content::BrowserContext*) {}
 
 // static
 BrowserContextKeyedAPIFactory<ExtensionActionAPI>*
@@ -47,10 +46,6 @@ ExtensionActionAPI::GetFactoryInstance() {
 // static
 ExtensionActionAPI* ExtensionActionAPI::Get(content::BrowserContext* context) {
   return BrowserContextKeyedAPIFactory<ExtensionActionAPI>::Get(context);
-}
-
-ExtensionPrefs* ExtensionActionAPI::GetExtensionPrefs() {
-  return nullptr;
 }
 
 void ExtensionActionAPI::Shutdown() {}

--- a/shell/browser/extensions/api/extension_action/extension_action_api.h
+++ b/shell/browser/extensions/api/extension_action/extension_action_api.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_EXTENSIONS_API_EXTENSION_ACTION_EXTENSION_ACTION_API_H_
 #define SHELL_BROWSER_EXTENSIONS_API_EXTENSION_ACTION_EXTENSION_ACTION_API_H_
 
-#include "base/memory/raw_ptr.h"
 #include "extensions/browser/browser_context_keyed_api_factory.h"
 #include "extensions/browser/extension_action.h"
 #include "extensions/browser/extension_function.h"
@@ -70,16 +69,10 @@ class ExtensionActionAPI : public BrowserContextKeyedAPI {
  private:
   friend class BrowserContextKeyedAPIFactory<ExtensionActionAPI>;
 
-  ExtensionPrefs* GetExtensionPrefs();
-
   // BrowserContextKeyedAPI implementation.
   void Shutdown() override;
   static const char* service_name() { return "ExtensionActionAPI"; }
   static const bool kServiceRedirectedInIncognito = true;
-
-  raw_ptr<content::BrowserContext> browser_context_;
-
-  raw_ptr<ExtensionPrefs> extension_prefs_;
 };
 
 // Implementation of the browserAction and pageAction APIs.


### PR DESCRIPTION
#### Description of Change

Small cleanup PR to remove some unused methods and fields from `ExtensionActionAPI`, including a browser context pointer. Looks like these were added in 5b105f91 but never used

#48848 got me wondering "where else do we have unnecessary BrowserContext handles?" which led to this PR.

CC @codebytere 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.