### PR TITLE
build: add missing header for SetStackDumpFirstChanceCallback

### DIFF
--- a/shell/common/v8_util.cc
+++ b/shell/common/v8_util.cc
@@ -21,6 +21,7 @@
 #if BUILDFLAG(IS_LINUX) && (defined(ARCH_CPU_X86_64) || defined(ARCH_CPU_ARM64))
 #define ENABLE_WEB_ASSEMBLY_TRAP_HANDLER_LINUX
 #include "base/command_line.h"
+#include "base/debug/stack_trace.h"
 #include "components/crash/core/app/crashpad.h"  // nogncheck
 #include "content/public/common/content_switches.h"
 #include "v8/include/v8-wasm-trap-handler-posix.h"

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -8,7 +8,6 @@
 
 #include "base/command_line.h"
 #include "base/containers/contains.h"
-#include "base/debug/stack_trace.h"
 #include "content/public/renderer/render_frame.h"
 #include "net/http/http_request_headers.h"
 #include "shell/common/api/electron_bindings.h"


### PR DESCRIPTION
#### Description of Change

Follow-up to https://github.com/electron/electron/pull/48788
For https://github.com/electron/electron/actions/runs/19169160516/job/54797353084

#### Release Notes

Notes: none