### PR TITLE
ci: exclude top-level docs files from full CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,10 @@ jobs:
         filters: |
           docs:
             - 'docs/**'
+            - README.md
+            - SECURITY.md
+            - CONTRIBUTING.md
+            - CODE_OF_CONDUCT.md
           src:
             - '!docs/**'
     - name: Set Outputs for Build Image SHA & Docs Only


### PR DESCRIPTION
#### Description of Change

See https://github.com/electron/electron/pull/48871 - changes to this and similar files shouldn't trigger full CI.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none