### PR TITLE
docs: deprecate clipboard API access from renderer processes

### DIFF
--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -2,10 +2,13 @@
 
 > Perform copy and paste operations on the system clipboard.
 
-Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process) (non-sandboxed only)
+Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process) _Deprecated_ (non-sandboxed only)
+
+> [!NOTE]
+> Using the `clipoard` API from the renderer process is deprecated.
 
 > [!IMPORTANT]
-> If you want to call this API from a renderer process with context isolation enabled,
+> If you want to call this API from a renderer process,
 > place the API call in your preload script and
 > [expose](../tutorial/context-isolation.md#after-context-isolation-enabled) it using the
 > [`contextBridge`](context-bridge.md) API.

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -12,6 +12,14 @@ This document uses the following convention to categorize breaking changes:
 * **Deprecated:** An API was marked as deprecated. The API will continue to function, but will emit a deprecation warning, and will be removed in a future release.
 * **Removed:** An API or feature was removed, and is no longer supported by Electron.
 
+## Planned Breaking API Changes (40.0)
+
+### Deprecated: `clipboard` API access from renderer processes
+
+Using the `clipboard` API directly in the renderer process is deprecated.
+If you want to call this API from a renderer process, place the API call in
+your preload script and expose it using the [contextBridge](https://www.electronjs.org/docs/latest/api/context-bridge) API.
+
 ## Planned Breaking API Changes (39.0)
 
 ### Deprecated: `--host-rules` command line switch

--- a/lib/renderer/api/clipboard.ts
+++ b/lib/renderer/api/clipboard.ts
@@ -1,21 +1,45 @@
+import * as deprecate from '@electron/internal/common/deprecate';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 import * as ipcRendererUtils from '@electron/internal/renderer/ipc-renderer-internal-utils';
 
-const clipboard = process._linkedBinding('electron_common_clipboard');
+const clipboard = {} as Electron.Clipboard;
+const originalClipboard = process._linkedBinding('electron_common_clipboard');
+
+const warnDeprecatedAccess = function (method: keyof Electron.Clipboard) {
+  return deprecate.warnOnceMessage(`Accessing 'clipboard.${method}' from the renderer process is
+     deprecated and will be removed. Please use the 'contextBridge' API to access
+     the clipboard API from the renderer.`);
+};
+
+const makeDeprecatedMethod = function (method: keyof Electron.Clipboard): any {
+  const warnDeprecated = warnDeprecatedAccess(method);
+  return (...args: any[]) => {
+    warnDeprecated();
+    return (originalClipboard[method] as any)(...args);
+  };
+};
 
 const makeRemoteMethod = function (method: keyof Electron.Clipboard): any {
-  return (...args: any[]) => ipcRendererUtils.invokeSync(IPC_MESSAGES.BROWSER_CLIPBOARD_SYNC, method, ...args);
+  const warnDeprecated = warnDeprecatedAccess(method);
+  return (...args: any[]) => {
+    warnDeprecated();
+    return ipcRendererUtils.invokeSync(IPC_MESSAGES.BROWSER_CLIPBOARD_SYNC, method, ...args);
+  };
 };
 
 if (process.platform === 'linux') {
   // On Linux we could not access clipboard in renderer process.
-  for (const method of Object.keys(clipboard) as (keyof Electron.Clipboard)[]) {
+  for (const method of Object.keys(originalClipboard) as (keyof Electron.Clipboard)[]) {
     clipboard[method] = makeRemoteMethod(method);
   }
-} else if (process.platform === 'darwin') {
-  // Read/write to find pasteboard over IPC since only main process is notified of changes
-  clipboard.readFindText = makeRemoteMethod('readFindText');
-  clipboard.writeFindText = makeRemoteMethod('writeFindText');
+} else {
+  for (const method of Object.keys(originalClipboard) as (keyof Electron.Clipboard)[]) {
+    if (process.platform === 'darwin' && (method === 'readFindText' || method === 'writeFindText')) {
+      clipboard[method] = makeRemoteMethod(method);
+    } else {
+      clipboard[method] = makeDeprecatedMethod(method);
+    }
+  }
 }
 
 export default clipboard;


### PR DESCRIPTION
#### Description of Change
As documented in the [Clipboard Module Rearchitecture RFC](https://github.com/electron/rfcs/blob/clipboard-rearch/text/0019-clipboard-rearchitecture.md#removing-the-clipboard-api-from-the-renderer), direct access to the clipboard API from the renderer will be removed.  This PR adds a deprecation message in preparation for the changes coming as part of the Clipboard Module Rearchitecture.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->Deprecated clipboard API access from renderer processes
