### PR TITLE
chore: delay load pdfjs-dist for pdf spec

### DIFF
--- a/spec/fixtures/api/pdf-reader.mjs
+++ b/spec/fixtures/api/pdf-reader.mjs
@@ -1,7 +1,8 @@
-import * as pdfjs from 'pdfjs-dist';
+import { app } from 'electron';
 
 async function getPDFDoc () {
   try {
+    const pdfjs = await import('pdfjs-dist');
     const doc = await pdfjs.getDocument(process.argv[2]).promise;
     const page = await doc.getPage(1);
     const { items } = await page.getTextContent();
@@ -20,4 +21,4 @@ async function getPDFDoc () {
   }
 }
 
-getPDFDoc();
+app.whenReady().then(() => getPDFDoc());


### PR DESCRIPTION
#### Description of Change

Found while fixing tests for https://github.com/electron/electron/pull/48837

trap handlers will be initialized once the user script starts but before app#ready. Wasm compilation before that phase will break trap handler registeration due to the check in `v8::internal::wasm::UpdateComputedInformation`. For some reason this issue was only visible in <= 39-x-y when pdf-reader.mjs was being loaded, maybe some module loading logic changed in >= 40-x-y which are based on Node.js v24.x that actually delayed the loading phase. In either case, it is best to align the compilation of wasm module required for the tests in light of changes to how we are registering the trap handlers for the main process.

#### Release Notes

Notes: none