### PR TITLE
docs: fix v40 stable release date

### DIFF
--- a/docs/tutorial/electron-timelines.md
+++ b/docs/tutorial/electron-timelines.md
@@ -9,7 +9,7 @@ check out our [Electron Versioning](./electron-versioning.md) doc.
 
 | Electron | Alpha | Beta | Stable | EOL | Chrome | Node | Supported |
 | ------- | ----- | ------- | ------ | ------ | ---- | ---- | ---- |
-| 40.0.0 |  2025-Oct-30 | 2025-Dec-03 | - | 2026-Jun-30 | M144 | TBD | ✅ |
+| 40.0.0 |  2025-Oct-30 | 2025-Dec-03 | 2026-Jan-13 | 2026-Jun-30 | M144 | TBD | ✅ |
 | 39.0.0 |  2025-Sep-04 | 2025-Oct-01 | 2025-Oct-28 | 2026-May-05 | M142 | v22.20 | ✅ |
 | 38.0.0 |  2025-Jun-26 | 2025-Aug-06 | 2025-Sep-02 | 2026-Mar-10 | M140 | v22.18 | ✅ |
 | 37.0.0 |  2025-May-01 | 2025-May-28 | 2025-Jun-24 | 2026-Jan-13 | M138 | v22.16 | ✅ |


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/48906

On the Electron Timelines tutorial page (/docs/latest/tutorial/electron-timelines), there is a clear typo in the release schedule for v40.0.0.

The table currently lists the dates as:
* Alpha: 2025-Oct-30
* Beta: 2025-Dec-03
* **Stable: 2025-Oct-28**

This is logically incorrect, as the 'Stable' release date (Oct 28) is listed *before* both the 'Alpha' (Oct 30) and 'Beta' (Dec 03) dates for the same version.

This appears to be a copy-paste error, as the 'Stable' date (2025-Oct-28) is identical to the 'Stable' date for the v39.0.0 release in the preceding row.

This commit updates the 'Stable' date for v40.0.0 to its correct value, ensuring the timeline is accurate and logical.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
