### PR TITLE
build: apply additional compression to dsym on upload

### DIFF
--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -66,11 +66,15 @@ def download(text, url, path):
   return path
 
 
-def make_zip(zip_file_path, files, dirs):
+def make_zip(zip_file_path, files, dirs, use_xz=False):
   safe_unlink(zip_file_path)
   if sys.platform == 'darwin':
     allfiles = files + dirs
-    execute(['zip', '-r', '-y', '-9', zip_file_path] + allfiles)
+    if use_xz:
+      # Use xz compression for better compression ratio (vs deflate)
+      execute(['zip', '-r', '-y', '-9', '-Z', 'xz', zip_file_path] + allfiles)
+    else:
+      execute(['zip', '-r', '-y', '-9', zip_file_path] + allfiles)
   else:
     with zipfile.ZipFile(zip_file_path, "w",
                          zipfile.ZIP_DEFLATED,

--- a/script/zip-symbols.py
+++ b/script/zip-symbols.py
@@ -36,7 +36,8 @@ def main():
           dsyms.remove(dsym)
       dsym_zip_file = os.path.join(args.build_dir, dsym_name)
       print('Making dsym zip: ' + dsym_zip_file)
-      make_zip(dsym_zip_file, licenses, dsyms)
+      # Use xz compression to reduce file size and stay under GitHub's 2GB limit
+      make_zip(dsym_zip_file, licenses, dsyms, use_xz=True)
       dsym_snapshot_name = 'dsym-snapshot.zip'
       dsym_snapshot_zip_file = os.path.join(args.build_dir, dsym_snapshot_name)
       print('Making dsym snapshot zip: ' + dsym_snapshot_zip_file)


### PR DESCRIPTION
#### Description of Change

This PR attempts to fix an issue where darwin dsym files are exceeding the GitHub 2GB file upload limit. Replaces the deflate compression with xz compression.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
