### PR TITLE
docs: explain how to load SF Symbols with `nativeImage`

### DIFF
--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -236,7 +236,7 @@ For SF Symbols, usage looks as follows:
 const image = nativeImage.createFromNamedImage('square.and.pencil')
 ```
 
-where `"square.and.pencil"` is the symbol name from the
+where `'square.and.pencil'` is the symbol name from the
 [SF Symbols app](https://developer.apple.com/sf-symbols/).
 
 ## Class: NativeImage


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/48203

Explains how to load SF Symbols with `nativeImage.createFromNamedImage()`.

CC @TheCommieAxolotl

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none