### PR TITLE
docs(menu-item): clarify meaning of menuItem.icon when passed a string

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -34,7 +34,34 @@ See [`Menu`](menu.md) for examples.
   * `sublabel` string (optional) _macOS_ - Available in macOS >= 14.4
   * `toolTip` string (optional) _macOS_ - Hover text for this menu item.
   * `accelerator` string (optional) - An [Accelerator](../tutorial/keyboard-shortcuts.md#accelerators) string.
-  * `icon` ([NativeImage](native-image.md) | string) (optional)
+  * `icon` ([NativeImage](native-image.md) | string) (optional) -  
+    Specifies an icon for the menu item.
+
+    When a `string` is provided, it is interpreted as a **file path** to an image file  
+    (either absolute or relative to your app’s directory). It is **not** treated as a
+    system or named icon (for example, passing `"close"` will not use the OS’s default close icon).
+
+    To use an image from code instead of a file path, create a [`NativeImage`](native-image.md)
+    and pass it to the `icon` option:
+
+    ```js
+    // Using a file path string
+    const menu = new MenuItem({
+      label: 'Open',
+      icon: path.join(__dirname, 'assets', 'open.png')
+    })
+
+    // Using a NativeImage
+    const { nativeImage } = require('electron')
+    const img = nativeImage.createFromPath(path.join(__dirname, 'assets', 'open.png'))
+    const menu2 = new MenuItem({ label: 'Open', icon: img })
+    ```
+
+    > [!NOTE]
+    > Under the hood, Electron converts the image via `ui::ImageModel::FromImage`
+    > (see [`electron/shell/browser/api/electron_api_menu.cc`](https://github.com/electron/electron/blob/main/shell/browser/api/electron_api_menu.cc)),
+    > which confirms the string form represents an image file path.
+
   * `enabled` boolean (optional) - If false, the menu item will be greyed out and
     unclickable.
   * `acceleratorWorksWhenHidden` boolean (optional) _macOS_ - default is `true`, and when `false` will prevent the accelerator from triggering the item if the item is not visible.
@@ -65,6 +92,8 @@ See [`Menu`](menu.md) for examples.
 
 > [!NOTE]
 > `acceleratorWorksWhenHidden` is specified as being macOS-only because accelerators always work when items are hidden on Windows and Linux. The option is exposed to users to give them the option to turn it off, as this is possible in native macOS development.
+
+---
 
 ### Instance Properties
 
@@ -117,8 +146,8 @@ An `Accelerator | null` indicating the item's [user-assigned accelerator](https:
 
 #### `menuItem.icon`
 
-A `NativeImage | string` (optional) indicating the
-item's icon, if set.
+A `NativeImage | string` (optional) indicating the item's icon, if set.  
+When a `string` is provided, it is treated as a **file path** to an image (not a named system icon).
 
 #### `menuItem.sublabel`
 


### PR DESCRIPTION
### Summary
fix:
This PR clarifies the documentation for `menuItem.icon` to explicitly state that when
a string is passed, it is interpreted as a **file path** to an image file — not a named
system icon (e.g., `"close"`). 

It also adds clear usage examples for both string-based and `NativeImage` icons,
and includes a note linking to the underlying C++ implementation in 
[`electron/shell/browser/api/electron_api_menu.cc`](https://github.com/electron/electron/blob/main/shell/browser/api/electron_api_menu.cc), 
which confirms this behavior.

### Why
The existing docs mentioned that `menuItem.icon` could be a string but did not explain
how Electron interprets that string. This caused confusion about whether strings like 
`"close"` or `"open"` could be used as symbolic OS icons. 

This clarification helps developers understand that strings are treated as file paths only.

### Changes
- Expanded documentation for `menuItem.icon` in `menu-item.md`.
- Added code examples for both string file paths and `NativeImage` usage.
- Added note linking to implementation for verification.

### Testing
- Verified Markdown formatting locally.
- Ensured examples render correctly in docs preview.
- No code changes — documentation only.

### Related Issue
Fixes: #48907

### Reviewer Notes
The clarification is based on the implementation at:
[`electron/shell/browser/api/electron_api_menu.cc`](https://github.com/electron/electron/blob/main/shell/browser/api/electron_api_menu.cc),
where `Menu::SetIcon` uses `ui::ImageModel::FromImage`, confirming the string form represents
a file path, not a symbolic system icon.
