### PR TITLE
feat: allow SF Symbols to be customised

### DIFF
--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -194,10 +194,17 @@ Returns `NativeImage`
 
 Creates a new `NativeImage` instance from `dataUrl`, a base 64 encoded [Data URL][data-url] string.
 
-### `nativeImage.createFromNamedImage(imageName[, hslShift])` _macOS_
+### `nativeImage.createFromNamedImage(imageName[, hslShift, options])` _macOS_
 
 * `imageName` string
 * `hslShift` number[] (optional)
+* `options` Object (optional)
+  * `pointSize` Number (optional) - Defaults to `13.0`.
+  * `weight` String (optional) - Defaults to `semibold`. Can be one of the
+    following values: `ultralight`, `thin`, `light`, `regular`, `medium`,
+    `semibold`, `bold`, `heavy`, `black`.
+  * `scale` String (optional) - Defaults to `small`. Can be one of the following values:
+    `small`, `medium`, `large`.
 
 Returns `NativeImage`
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -194,11 +194,11 @@ Returns `NativeImage`
 
 Creates a new `NativeImage` instance from `dataUrl`, a base 64 encoded [Data URL][data-url] string.
 
-### `nativeImage.createFromNamedImage(imageName[, hslShift, options])` _macOS_
+### `nativeImage.createFromNamedImage(imageName[, options])` _macOS_
 
 * `imageName` string
-* `hslShift` number[] (optional)
-* `options` Object (optional)
+* `options` Object | number[] (optional)
+  * `hslShift` number[] (optional)
   * `pointSize` Number (optional) - Defaults to `30.0`.
   * `weight` String (optional) - Defaults to `regular`. Can be one of the
     following values: `ultralight`, `thin`, `light`, `regular`, `medium`,

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -246,6 +246,23 @@ const image = nativeImage.createFromNamedImage('square.and.pencil')
 where `'square.and.pencil'` is the symbol name from the
 [SF Symbols app](https://developer.apple.com/sf-symbols/).
 
+### `nativeImage.createMenuSymbol(imageName)` _macOS_
+
+* `imageName` string
+
+Returns `NativeImage`
+
+Creates a new `NativeImage` instance from an SF Symbol for use in a native [Menu](./menu.md). See [SF Symbols](https://developer.apple.com/sf-symbols/) for a list of possible values.
+
+```js
+const { nativeImage, MenuItem } = require('electron')
+
+const item = new MenuItem({
+  icon: nativeImage.createMenuSymbol('folder.badge.plus'),
+  label: 'Create Folder'
+})
+```
+
 ## Class: NativeImage
 
 > Natively wrap images such as tray, dock, and application icons.

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -200,11 +200,8 @@ Creates a new `NativeImage` instance from `dataUrl`, a base 64 encoded [Data URL
 * `options` Object | number[] (optional)
   * `hslShift` number[] (optional)
   * `pointSize` Number (optional) - Defaults to `30.0`.
-  * `weight` String (optional) - Defaults to `regular`. Can be one of the
-    following values: `ultralight`, `thin`, `light`, `regular`, `medium`,
-    `semibold`, `bold`, `heavy`, `black`.
-  * `scale` String (optional) - Defaults to `medium`. Can be one of the following values:
-    `small`, `medium`, `large`.
+  * `weight` 'ultralight' | 'thin' | 'light' | 'regular' | 'medium' | 'semibold' | 'bold' | 'heavy' | 'black' (optional) - Defaults to `regular`.
+  * `scale` 'small' | 'medium' | 'large' (optional) - Defaults to `medium`.
 
 Returns `NativeImage`
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -199,11 +199,11 @@ Creates a new `NativeImage` instance from `dataUrl`, a base 64 encoded [Data URL
 * `imageName` string
 * `hslShift` number[] (optional)
 * `options` Object (optional)
-  * `pointSize` Number (optional) - Defaults to `13.0`.
-  * `weight` String (optional) - Defaults to `semibold`. Can be one of the
+  * `pointSize` Number (optional) - Defaults to `30.0`.
+  * `weight` String (optional) - Defaults to `regular`. Can be one of the
     following values: `ultralight`, `thin`, `light`, `regular`, `medium`,
     `semibold`, `bold`, `heavy`, `black`.
-  * `scale` String (optional) - Defaults to `small`. Can be one of the following values:
+  * `scale` String (optional) - Defaults to `medium`. Can be one of the following values:
     `small`, `medium`, `large`.
 
 Returns `NativeImage`

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -197,7 +197,8 @@ Creates a new `NativeImage` instance from `dataUrl`, a base 64 encoded [Data URL
 ### `nativeImage.createFromNamedImage(imageName[, options])` _macOS_
 
 * `imageName` string
-* `options` Object | number[] (optional)
+* `options` Object | number[] (optional) - If `options` is a number array  (_Deprecated_), it is interpreted as `hslShift`. If it is an object, the
+following properties can be specified:
   * `hslShift` number[] (optional)
   * `pointSize` Number (optional) - Defaults to `30.0`.
   * `weight` 'ultralight' | 'thin' | 'light' | 'regular' | 'medium' | 'semibold' | 'bold' | 'heavy' | 'black' (optional) - Defaults to `regular`.

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -118,6 +118,19 @@ When calling `Session.clearStorageData(options)`, the `options.quotas` object is
 [removed](https://chromium-review.googlesource.com/c/chromium/src/+/7596126)
 from upstream Chromium.
 
+### Deprecated: Passing only an array `hslShift` to `nativeImage.createFromNamedImage()`
+
+Passing only an array `hslShift` to `nativeImage.createFromNamedImage()` is deprecated. You should now pass an options object with an `hslShift` property instead:
+
+```js
+// Deprecated
+nativeImage.createFromNamedImage(imageName, [0, 1, -1])
+// Replace with
+nativeImage.createFromNamedImage(imageName, {
+  hslShift: [0, 1, -1]
+})
+```
+
 ## Planned Breaking API Changes (41.0)
 
 ### Behavior Changed: PDFs no longer create a separate WebContents

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -569,6 +569,12 @@ gin_helper::Handle<NativeImage> NativeImage::CreateFromNamedImage(
     std::string name) {
   return CreateEmpty(args->isolate());
 }
+
+gin_helper::Handle<NativeImage> NativeImage::CreateMenuSymbol(
+    gin::Arguments* args,
+    std::string name) {
+  return CreateEmpty(args->isolate());
+}
 #endif
 
 // static
@@ -634,6 +640,7 @@ void Initialize(v8::Local<v8::Object> exports,
   native_image.SetMethod("createFromDataURL", &NativeImage::CreateFromDataURL);
   native_image.SetMethod("createFromNamedImage",
                          &NativeImage::CreateFromNamedImage);
+  native_image.SetMethod("createMenuSymbol", &NativeImage::CreateMenuSymbol);
 #if !BUILDFLAG(IS_LINUX)
   native_image.SetMethod("createThumbnailFromPath",
                          &NativeImage::CreateThumbnailFromPath);

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -82,6 +82,8 @@ class NativeImage final : public gin_helper::DeprecatedWrappable<NativeImage> {
   static gin_helper::Handle<NativeImage> CreateFromNamedImage(
       gin::Arguments* args,
       std::string name);
+  static gin_helper::Handle<NativeImage> CreateMenuSymbol(gin::Arguments* args,
+                                                          std::string name);
 #if !BUILDFLAG(IS_LINUX)
   static v8::Local<v8::Promise> CreateThumbnailFromPath(
       v8::Isolate* isolate,

--- a/shell/common/api/electron_api_native_image_mac.mm
+++ b/shell/common/api/electron_api_native_image_mac.mm
@@ -134,14 +134,8 @@ gin_helper::Handle<NativeImage> NativeImage::CreateMenuSymbol(
     float aspect_ratio =
         static_cast<float>(size.width()) / static_cast<float>(size.height());
 
-    int new_width = 14;
-    int new_height = static_cast<int>(14 / aspect_ratio);
-
-    // prevent tall symbols from exceeding menu item height (e.g. chevron.right)
-    if (new_height >= 16) {
-      new_height = 14;
-      new_width = static_cast<int>(14 * aspect_ratio);
-    }
+    int new_height = 14;
+    int new_width = static_cast<int>(14 * aspect_ratio);
 
     gin_helper::Handle<NativeImage> sized = handle->Resize(
         args,

--- a/shell/common/api/electron_api_native_image_mac.mm
+++ b/shell/common/api/electron_api_native_image_mac.mm
@@ -22,6 +22,7 @@
 #include "shell/common/gin_helper/handle.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/mac_util.h"
+#include "shell/common/node_util.h"
 #include "ui/gfx/color_utils.h"
 #include "ui/gfx/geometry/size.h"
 #include "ui/gfx/image/image_skia.h"
@@ -153,6 +154,8 @@ gin_helper::Handle<NativeImage> NativeImage::CreateFromNamedImage(
     gin::Arguments* args,
     std::string name) {
   @autoreleasepool {
+    static bool deprecated_warning_issued = false;
+
     std::vector<double> hsl_shift;
 
     float pointSize = 30.0;
@@ -164,6 +167,14 @@ gin_helper::Handle<NativeImage> NativeImage::CreateFromNamedImage(
       if (opts->IsArray()) {
         // Treat an array as a HSL shift.
         gin::ConvertFromV8(args->isolate(), opts, &hsl_shift);
+
+        if (!deprecated_warning_issued) {
+          deprecated_warning_issued = true;
+          util::EmitDeprecationWarning(
+              isolate_,
+              "createFromNamedImage(name, hslShift) is deprecated, use "
+              "createFromNamedImage(name, { hslShift }) instead.");
+        }
       } else {
         gin_helper::Dictionary options(args->isolate(), opts.As<v8::Object>());
         options.Get("hslShift", &hsl_shift);

--- a/shell/common/api/electron_api_native_image_mac.mm
+++ b/shell/common/api/electron_api_native_image_mac.mm
@@ -130,13 +130,13 @@ gin_helper::Handle<NativeImage> NativeImage::CreateMenuSymbol(
     float aspect_ratio =
         static_cast<float>(size.width()) / static_cast<float>(size.height());
 
-    int new_width = 14;
-    int new_height = static_cast<int>(14 / aspect_ratio);
+    int new_width = 15;
+    int new_height = static_cast<int>(15 / aspect_ratio);
 
     // prevent tall symbols from exceeding menu item height (e.g. chevron.right)
     if (new_height >= 16) {
-      new_height = 14;
-      new_width = static_cast<int>(14 * aspect_ratio);
+      new_height = 15;
+      new_width = static_cast<int>(15 * aspect_ratio);
     }
 
     gin_helper::Handle<NativeImage> sized = handle->Resize(

--- a/shell/common/api/electron_api_native_image_mac.mm
+++ b/shell/common/api/electron_api_native_image_mac.mm
@@ -171,7 +171,6 @@ gin_helper::Handle<NativeImage> NativeImage::CreateFromNamedImage(
         if (!deprecated_warning_issued) {
           deprecated_warning_issued = true;
           util::EmitDeprecationWarning(
-              isolate_,
               "createFromNamedImage(name, hslShift) is deprecated, use "
               "createFromNamedImage(name, { hslShift }) instead.");
         }

--- a/shell/common/api/electron_api_native_image_mac.mm
+++ b/shell/common/api/electron_api_native_image_mac.mm
@@ -114,6 +114,10 @@ gin_helper::Handle<NativeImage> NativeImage::CreateMenuSymbol(
         [NSImage imageWithSystemSymbolName:base::SysUTF8ToNSString(name)
                   accessibilityDescription:nil];
 
+    if (!image || !image.valid) {
+      return CreateEmpty(args->isolate());
+    }
+
     NSImageSymbolConfiguration* symbol_config = [NSImageSymbolConfiguration
         configurationWithPointSize:13.0
                             weight:NSFontWeightSemibold
@@ -122,6 +126,10 @@ gin_helper::Handle<NativeImage> NativeImage::CreateMenuSymbol(
     image = [image imageWithSymbolConfiguration:symbol_config];
 
     NSData* png_data = bufferFromNSImage(image);
+
+    if (!png_data) {
+      return CreateEmpty(args->isolate());
+    }
 
     gin_helper::Handle<NativeImage> handle =
         CreateFromPNG(args->isolate(), electron::util::as_byte_span(png_data));

--- a/shell/common/api/electron_api_native_image_mac.mm
+++ b/shell/common/api/electron_api_native_image_mac.mm
@@ -142,7 +142,7 @@ gin_helper::Handle<NativeImage> NativeImage::CreateMenuSymbol(
 
     gin_helper::Handle<NativeImage> sized = handle->Resize(
         args,
-        base::Value::Dict().Set("width", new_width).Set("height", new_height));
+        base::DictValue().Set("width", new_width).Set("height", new_height));
 
     sized->SetTemplateImage(true);
 

--- a/spec/api-native-image-spec.ts
+++ b/spec/api-native-image-spec.ts
@@ -336,7 +336,7 @@ describe('nativeImage module', () => {
     });
 
     ifit(process.platform === 'darwin')('returns a valid named symbol with options on darwin', function () {
-      const image = nativeImage.createFromNamedImage('atom', undefined, {
+      const image = nativeImage.createFromNamedImage('atom', {
         weight: 'ultralight',
         scale: 'small',
         pointSize: 24

--- a/spec/api-native-image-spec.ts
+++ b/spec/api-native-image-spec.ts
@@ -335,6 +335,15 @@ describe('nativeImage module', () => {
       expect(image.isEmpty()).to.be.false();
     });
 
+    ifit(process.platform === 'darwin')('returns a valid named symbol with options on darwin', function () {
+      const image = nativeImage.createFromNamedImage('atom', undefined, {
+        weight: 'ultralight',
+        scale: 'small',
+        pointSize: 24
+      });
+      expect(image.isEmpty()).to.be.false();
+    });
+
     ifit(process.platform === 'darwin')('returns allows an HSL shift for a valid image on darwin', function () {
       const image = nativeImage.createFromNamedImage('NSActionTemplate', [0.5, 0.2, 0.8]);
       expect(image.isEmpty()).to.be.false();

--- a/spec/api-native-image-spec.ts
+++ b/spec/api-native-image-spec.ts
@@ -350,6 +350,18 @@ describe('nativeImage module', () => {
     });
   });
 
+  describe('createMenuSymbol(name)', () => {
+    it('returns empty for invalid options', () => {
+      const image = nativeImage.createMenuSymbol('totally_not_real');
+      expect(image.isEmpty()).to.be.true();
+    });
+
+    ifit(process.platform === 'darwin')('returns a valid image on darwin', function () {
+      const image = nativeImage.createMenuSymbol('atom');
+      expect(image.isEmpty()).to.be.false();
+    });
+  });
+
   describe('resize(options)', () => {
     it('returns a resized image', () => {
       const image = nativeImage.createFromPath(path.join(fixturesPath, 'assets', 'logo.png'));


### PR DESCRIPTION
#### Description of Change

Allow SF Symbols created with `nativeImage.createFromNamedImage` to be customised in terms of point size, weight, and symbol rendering scale. 
<img width="128" height="276" alt="SCR-20251112-qylh" src="https://github.com/user-attachments/assets/37ecb96d-4c1e-4b2b-b1f1-0794adf39943" />

```ts
const image = nativeImage.createFromNamedImage("atom", undefined, {
	// Default values, match macOS native menu item icons
    pointSize: 30,
    scale: "medium",
    weight: "regular",
});
```

Also adds a new method, `nativeImage.createMenuSymbol` to return in a single call a native-matching symbol for use in a `MenuItem`.
<img width="210" height="86" alt="SCR-20251113-smrl" src="https://github.com/user-attachments/assets/932fa32d-3859-41a5-b208-d425228258a9" />

```ts
const item = new MenuItem({
	icon: nativeImage.createFromNamedImage("atom"),
	label: 'Electron'
})
```

Closes https://github.com/electron/electron/issues/48909

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: feat: SF Symbol customisation