### PR TITLE
docs: clarify initiator field can be parent or child frame in navigation events

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -247,9 +247,10 @@ Returns:
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
     navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name), or null if the navigation was not initiated by a frame. This
-    can also be null if the initiating frame was deleted before the event was
-    emitted.
+    frame's name) or a child frame (e.g. an unsandboxed iframe navigating its
+    parent via `<a target="_top">`), or null if the navigation was not initiated
+    by a frame. This can also be null if the initiating frame was deleted before
+    the event was emitted.
 * `url` string _Deprecated_
 * `isInPlace` boolean _Deprecated_
 * `isMainFrame` boolean _Deprecated_
@@ -281,9 +282,10 @@ Returns:
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
     navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name), or null if the navigation was not initiated by a frame. This
-    can also be null if the initiating frame was deleted before the event was
-    emitted.
+    frame's name) or a child frame (e.g. an unsandboxed iframe navigating its
+    parent via `<a target="_top">`), or null if the navigation was not initiated
+    by a frame. This can also be null if the initiating frame was deleted before
+    the event was emitted.
 
 Emitted when a user or the page wants to start navigation in any frame. It can happen when
 the `window.location` object is changed or a user clicks a link in the page.
@@ -313,9 +315,10 @@ Returns:
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
     navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name), or null if the navigation was not initiated by a frame. This
-    can also be null if the initiating frame was deleted before the event was
-    emitted.
+    frame's name) or a child frame (e.g. an unsandboxed iframe navigating its
+    parent via `<a target="_top">`), or null if the navigation was not initiated
+    by a frame. This can also be null if the initiating frame was deleted before
+    the event was emitted.
 * `url` string _Deprecated_
 * `isInPlace` boolean _Deprecated_
 * `isMainFrame` boolean _Deprecated_
@@ -338,9 +341,10 @@ Returns:
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
     navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name), or null if the navigation was not initiated by a frame. This
-    can also be null if the initiating frame was deleted before the event was
-    emitted.
+    frame's name) or a child frame (e.g. an unsandboxed iframe navigating its
+    parent via `<a target="_top">`), or null if the navigation was not initiated
+    by a frame. This can also be null if the initiating frame was deleted before
+    the event was emitted.
 * `url` string _Deprecated_
 * `isInPlace` boolean _Deprecated_
 * `isMainFrame` boolean _Deprecated_
@@ -370,9 +374,10 @@ Returns:
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
     navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name), or null if the navigation was not initiated by a frame. This
-    can also be null if the initiating frame was deleted before the event was
-    emitted.
+    frame's name) or a child frame (e.g. an unsandboxed iframe navigating its
+    parent via `<a target="_top">`), or null if the navigation was not initiated
+    by a frame. This can also be null if the initiating frame was deleted before
+    the event was emitted.
 * `url` string _Deprecated_
 * `isInPlace` boolean _Deprecated_
 * `isMainFrame` boolean _Deprecated_

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -247,7 +247,7 @@ Returns:
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
     navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name) or a child frame (e.g. an unsandboxed iframe navigating its
+    frame's name), a child frame (e.g. an unsandboxed iframe navigating its
     parent via `<a target="_top">`), or null if the navigation was not initiated
     by a frame. This can also be null if the initiating frame was deleted before
     the event was emitted.
@@ -282,7 +282,7 @@ Returns:
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
     navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name) or a child frame (e.g. an unsandboxed iframe navigating its
+    frame's name), a child frame (e.g. an unsandboxed iframe navigating its
     parent via `<a target="_top">`), or null if the navigation was not initiated
     by a frame. This can also be null if the initiating frame was deleted before
     the event was emitted.
@@ -315,7 +315,7 @@ Returns:
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
     navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name) or a child frame (e.g. an unsandboxed iframe navigating its
+    frame's name), a child frame (e.g. an unsandboxed iframe navigating its
     parent via `<a target="_top">`), or null if the navigation was not initiated
     by a frame. This can also be null if the initiating frame was deleted before
     the event was emitted.
@@ -341,7 +341,7 @@ Returns:
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
     navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name) or a child frame (e.g. an unsandboxed iframe navigating its
+    frame's name), a child frame (e.g. an unsandboxed iframe navigating its
     parent via `<a target="_top">`), or null if the navigation was not initiated
     by a frame. This can also be null if the initiating frame was deleted before
     the event was emitted.
@@ -374,7 +374,7 @@ Returns:
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
     navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name) or a child frame (e.g. an unsandboxed iframe navigating its
+    frame's name), a child frame (e.g. an unsandboxed iframe navigating its
     parent via `<a target="_top">`), or null if the navigation was not initiated
     by a frame. This can also be null if the initiating frame was deleted before
     the event was emitted.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -246,7 +246,7 @@ Returns:
   * `frame` WebFrameMain | null - The frame to be navigated.
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
-    navigation, which can be a parent frame (e.g. via `window.open` with a
+    navigation. This can be a parent frame (e.g. via `window.open` with a
     frame's name), a child frame (e.g. an unsandboxed iframe navigating its
     parent via `<a target="_top">`), or null if the navigation was not initiated
     by a frame. This can also be null if the initiating frame was deleted before
@@ -281,7 +281,7 @@ Returns:
   * `frame` WebFrameMain | null - The frame to be navigated.
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
-    navigation, which can be a parent frame (e.g. via `window.open` with a
+    navigation. This can be a parent frame (e.g. via `window.open` with a
     frame's name), a child frame (e.g. an unsandboxed iframe navigating its
     parent via `<a target="_top">`), or null if the navigation was not initiated
     by a frame. This can also be null if the initiating frame was deleted before
@@ -314,7 +314,7 @@ Returns:
   * `frame` WebFrameMain | null - The frame to be navigated.
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
-    navigation, which can be a parent frame (e.g. via `window.open` with a
+    navigation. This can be a parent frame (e.g. via `window.open` with a
     frame's name), a child frame (e.g. an unsandboxed iframe navigating its
     parent via `<a target="_top">`), or null if the navigation was not initiated
     by a frame. This can also be null if the initiating frame was deleted before
@@ -340,7 +340,7 @@ Returns:
   * `frame` WebFrameMain | null - The frame to be navigated.
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
-    navigation, which can be a parent frame (e.g. via `window.open` with a
+    navigation. This can be a parent frame (e.g. via `window.open` with a
     frame's name), a child frame (e.g. an unsandboxed iframe navigating its
     parent via `<a target="_top">`), or null if the navigation was not initiated
     by a frame. This can also be null if the initiating frame was deleted before
@@ -373,7 +373,7 @@ Returns:
   * `frame` WebFrameMain | null - The frame to be navigated.
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
-    navigation, which can be a parent frame (e.g. via `window.open` with a
+    navigation. This can be a parent frame (e.g. via `window.open` with a
     frame's name), a child frame (e.g. an unsandboxed iframe navigating its
     parent via `<a target="_top">`), or null if the navigation was not initiated
     by a frame. This can also be null if the initiating frame was deleted before


### PR DESCRIPTION
#### Description of Change
Refs #48793

This updates the `will-navigate` event documentation to include an additional case where navigation can be triggered by an unsandboxed `<iframe>` in the main frame using a link with `target="_top"`. 

Previously, this behavior was undocumented.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] Relevant API documentation updated and follows the documentation style guide
- [x] Release notes noted as none
- [ ] `npm test` passes
- [ ] Tests changed or added if needed

#### Release Notes
Notes: none
