### PR TITLE
docs: explain how to create transparent window using BaseWindow

### DIFF
--- a/docs/api/structures/base-window-options.md
+++ b/docs/api/structures/base-window-options.md
@@ -72,6 +72,9 @@
   some GTK+3 desktop environments. Default is `false`.
 * `transparent` boolean (optional) - Makes the window [transparent](../../tutorial/custom-window-styles.md#transparent-windows).
   Default is `false`. On Windows, does not work unless the window is frameless.
+  When you add a [`View`](../view.md) to a `BaseWindow`, you'll need to call
+  [`view.setBackgroundColor`](../view.md#viewsetbackgroundcolorcolor) with a transparent
+  background color on that view to make its background transparent as well.
 * `type` string (optional) - The type of window, default is normal window. See more about
   this below.
 * `visualEffectState` string (optional) _macOS_ - Specify how the material


### PR DESCRIPTION
#### Description of Change

This PR adds a one liner in [`BaseWindowConstructor` docs](https://www.electronjs.org/docs/latest/tutorial/custom-window-styles) to indicate that you must call `view.setBackgroundColor` on added views when using a transparent `BaseWindow`.

Existing docs do not provide any examples using the `BaseWindow` API, and there are no resources highlighting the need to use `view.setBackgroundColor` when creating transparent windows with `BaseWindow`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes:  none
