### PR TITLE
fix: devtools crashing on Linux in detach mode

### DIFF
--- a/shell/browser/ui/views/electron_views_delegate.cc
+++ b/shell/browser/ui/views/electron_views_delegate.cc
@@ -8,6 +8,7 @@
 
 #include "ui/views/widget/desktop_aura/desktop_native_widget_aura.h"
 #include "ui/views/widget/native_widget_aura.h"
+#include "ui/views/window/default_frame_view.h"
 
 #if BUILDFLAG(IS_LINUX)
 #include "base/environment.h"
@@ -62,7 +63,7 @@ gfx::ImageSkia* ViewsDelegate::GetDefaultWindowIcon() const {
 
 std::unique_ptr<views::NonClientFrameView>
 ViewsDelegate::CreateDefaultNonClientFrameView(views::Widget* widget) {
-  return nullptr;
+  return std::make_unique<views::DefaultFrameView>(widget);
 }
 
 void ViewsDelegate::OnBeforeWidgetInit(


### PR DESCRIPTION
Backport of #48600

See that PR for details.


Notes: Fixed an issue where calling `webContents.openDevTools({ mode: 'detach' })` would cause a crash on Wayland.
