### PR TITLE
build: apply additional compression to dsym on upload

### DIFF
--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -84,6 +84,12 @@ def make_zip(zip_file_path, files, dirs):
       zip_file.close()
 
 
+def make_tar_xz(tar_file_path, files, dirs):
+  safe_unlink(tar_file_path)
+  allfiles = files + dirs
+  execute(['tar', '-cJf', tar_file_path] + allfiles)
+
+
 def rm_rf(path):
   try:
     shutil.rmtree(path)

--- a/script/zip-symbols.py
+++ b/script/zip-symbols.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 from lib.config import PLATFORM
-from lib.util import scoped_cwd, get_electron_version, make_zip, \
+from lib.util import scoped_cwd, get_electron_version, make_zip, make_tar_xz, \
                      get_electron_branding, get_out_dir, execute
 
 ELECTRON_VERSION = get_electron_version()
@@ -27,16 +27,15 @@ def main():
     make_zip(zip_file, licenses, dirs)
 
   if PLATFORM == 'darwin':
-    dsym_name = 'dsym.zip'
+    dsym_name = 'dsym.tar.xz'
     with scoped_cwd(args.build_dir):
       dsyms = glob.glob('*.dSYM')
       snapshot_dsyms = ['v8_context_snapshot_generator.dSYM']
       for dsym in snapshot_dsyms:
         if (dsym in dsyms):
           dsyms.remove(dsym)
-      dsym_zip_file = os.path.join(args.build_dir, dsym_name)
-      print('Making dsym zip: ' + dsym_zip_file)
-      make_zip(dsym_zip_file, licenses, dsyms)
+      dsym_tar_file = os.path.join(args.build_dir, dsym_name)
+      make_tar_xz(dsym_tar_file, licenses, dsyms)
       dsym_snapshot_name = 'dsym-snapshot.zip'
       dsym_snapshot_zip_file = os.path.join(args.build_dir, dsym_snapshot_name)
       print('Making dsym snapshot zip: ' + dsym_snapshot_zip_file)


### PR DESCRIPTION
#### Description of Change

This PR attempts to fix an issue where darwin dsym files are exceeding the GitHub 2GB file upload limit. Replaces the deflate compression with xz compression.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none