### PR TITLE
test: add `view.getBounds|setBounds` tests

### DIFF
--- a/spec/api-view-spec.ts
+++ b/spec/api-view-spec.ts
@@ -92,4 +92,46 @@ describe('View', () => {
       expect(v.getVisible()).to.be.false();
     });
   });
+
+  describe('view.getBounds|setBounds', () => {
+    it('defaults to 0,0,0,0', () => {
+      const v = new View();
+      expect(v.getBounds()).to.deep.equal({ x: 0, y: 0, width: 0, height: 0 });
+    });
+
+    it('can be set and retrieved', () => {
+      const v = new View();
+      v.setBounds({ x: 10, y: 20, width: 300, height: 400 });
+      expect(v.getBounds()).to.deep.equal({ x: 10, y: 20, width: 300, height: 400 });
+    });
+
+    it('emits bounds-changed when bounds mutate', () => {
+      const v = new View();
+      let called = 0;
+      v.once('bounds-changed', () => { called++; });
+      v.setBounds({ x: 5, y: 6, width: 7, height: 8 });
+      expect(called).to.equal(1);
+    });
+
+    it('allows zero-size bounds', () => {
+      const v = new View();
+      v.setBounds({ x: 1, y: 2, width: 0, height: 0 });
+      expect(v.getBounds()).to.deep.equal({ x: 1, y: 2, width: 0, height: 0 });
+    });
+
+    it('allows negative coordinates', () => {
+      const v = new View();
+      v.setBounds({ x: -10, y: -20, width: 100, height: 50 });
+      expect(v.getBounds()).to.deep.equal({ x: -10, y: -20, width: 100, height: 50 });
+    });
+
+    it('child bounds remain relative after parent moves', () => {
+      const parent = new View();
+      const child = new View();
+      parent.addChildView(child);
+      child.setBounds({ x: 10, y: 15, width: 25, height: 30 });
+      parent.setBounds({ x: 50, y: 60, width: 500, height: 600 });
+      expect(child.getBounds()).to.deep.equal({ x: 10, y: 15, width: 25, height: 30 });
+    });
+  });
 });


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/48812#issuecomment-3496332942

Adds some specs for `view.getBounds|setBounds`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none