### PR TITLE
test: fix types in chromium-spec

### DIFF
--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -915,7 +915,7 @@ describe('chromium features', () => {
 
           if (action !== 'none') {
             // Make the PermissionRequestHandler behave according to action variable passed for this test
-            testSession.setPermissionRequestHandler((_wc, permission, callback) => {
+            testSession.setPermissionRequestHandler((_wc: Electron.WebContents, permission: string, callback: (allow: boolean) => void) => {
               if (permission === 'geolocation') {
                 if (action === 'allow') callback(true);
                 else if (action === 'deny') callback(false);


### PR DESCRIPTION
#### Description of Change

See https://github.com/electron/electron/actions/runs/19341206364

```
Error: electron/spec/chromium-spec.ts(918,54): error TS7006: Parameter '_wc' implicitly has an 'any' type.
Error: electron/spec/chromium-spec.ts(918,59): error TS7006: Parameter 'permission' implicitly has an 'any' type.
Error: electron/spec/chromium-spec.ts(918,71): error TS7006: Parameter 'callback' implicitly has an 'any' type.
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
