### PR TITLE
build: correct uploader copy for tar files

### DIFF
--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -51,3 +51,12 @@ def get_zip_name(name, version, suffix=''):
   if suffix:
     zip_name += '-' + suffix
   return zip_name + '.zip'
+
+def get_tar_name(name, version, suffix=''):
+  arch = get_target_arch()
+  if arch == 'arm':
+    arch += 'v7l'
+  zip_name = f'{name}-{version}-{get_platform_key()}-{arch}'
+  if suffix:
+    zip_name += '-' + suffix
+  return zip_name + '.tar.xz'

--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -16,7 +16,7 @@ sys.path.append(
 
 from zipfile import ZipFile
 from lib.config import PLATFORM, get_target_arch, \
-                       get_zip_name, set_verbose_mode, \
+                       get_zip_name, get_tar_name, set_verbose_mode, \
                        is_verbose_mode, get_platform_key, \
                        verbose_mode_print
 from lib.util import get_electron_branding, execute, get_electron_version, \
@@ -33,7 +33,8 @@ OUT_DIR = get_out_dir()
 
 DIST_NAME = get_zip_name(PROJECT_NAME, ELECTRON_VERSION)
 SYMBOLS_NAME = get_zip_name(PROJECT_NAME, ELECTRON_VERSION, 'symbols')
-DSYM_NAME = get_zip_name(PROJECT_NAME, ELECTRON_VERSION, 'dsym')
+# Use tar.xz compression for dsym files due to size
+DSYM_NAME = get_tar_name(PROJECT_NAME, ELECTRON_VERSION, 'dsym')
 DSYM_SNAPSHOT_NAME = get_zip_name(PROJECT_NAME, ELECTRON_VERSION,
                                   'dsym-snapshot')
 PDB_NAME = get_zip_name(PROJECT_NAME, ELECTRON_VERSION, 'pdb')


### PR DESCRIPTION
#### Description of Change

dSYMs for tar.xz are currently being copied by the uploader utilities and being renamed to .zip files. This PR clears up that rename and keeps the proper extension to avoid any unexpected issues on decompression for the end user.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
