### PR TITLE
fix: handle empty event scenario in ipc callbacks

### DIFF
--- a/shell/browser/electron_api_ipc_handler_impl.cc
+++ b/shell/browser/electron_api_ipc_handler_impl.cc
@@ -49,6 +49,8 @@ void ElectronApiIPCHandlerImpl::Message(bool internal,
     v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
     v8::HandleScope handle_scope(isolate);
     auto* event = MakeIPCEvent(isolate, session->Get(), internal);
+    if (!event)
+      return;
     v8::Local<v8::Object> event_object =
         event->GetWrapper(isolate).ToLocalChecked();
     session->Get()->Message(event_object, channel, std::move(arguments));
@@ -64,6 +66,8 @@ void ElectronApiIPCHandlerImpl::Invoke(bool internal,
     v8::HandleScope handle_scope(isolate);
     auto* event =
         MakeIPCEvent(isolate, session->Get(), internal, std::move(callback));
+    if (!event)
+      return;
     v8::Local<v8::Object> event_object =
         event->GetWrapper(isolate).ToLocalChecked();
     session->Get()->Invoke(event_object, channel, std::move(arguments));
@@ -78,6 +82,8 @@ void ElectronApiIPCHandlerImpl::ReceivePostMessage(
     v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
     v8::HandleScope handle_scope(isolate);
     auto* event = MakeIPCEvent(isolate, session->Get(), false);
+    if (!event)
+      return;
     v8::Local<v8::Object> event_object =
         event->GetWrapper(isolate).ToLocalChecked();
     session->Get()->ReceivePostMessage(event_object, channel,
@@ -95,6 +101,8 @@ void ElectronApiIPCHandlerImpl::MessageSync(bool internal,
     v8::HandleScope handle_scope(isolate);
     auto* event =
         MakeIPCEvent(isolate, session->Get(), internal, std::move(callback));
+    if (!event)
+      return;
     v8::Local<v8::Object> event_object =
         event->GetWrapper(isolate).ToLocalChecked();
     session->Get()->MessageSync(event_object, channel, std::move(arguments));
@@ -108,6 +116,8 @@ void ElectronApiIPCHandlerImpl::MessageHost(const std::string& channel,
     v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
     v8::HandleScope handle_scope(isolate);
     auto* event = MakeIPCEvent(isolate, session->Get(), false);
+    if (!event)
+      return;
     v8::Local<v8::Object> event_object =
         event->GetWrapper(isolate).ToLocalChecked();
     session->Get()->MessageHost(event_object, channel, std::move(arguments));

--- a/shell/browser/electron_api_sw_ipc_handler_impl.cc
+++ b/shell/browser/electron_api_sw_ipc_handler_impl.cc
@@ -76,6 +76,8 @@ void ElectronApiSWIPCHandlerImpl::Message(bool internal,
     v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
     v8::HandleScope handle_scope(isolate);
     auto* event = MakeIPCEvent(isolate, session->Get(), internal);
+    if (!event)
+      return;
     v8::Local<v8::Object> event_object =
         event->GetWrapper(isolate).ToLocalChecked();
     session->Get()->Message(event_object, channel, std::move(arguments));
@@ -92,6 +94,8 @@ void ElectronApiSWIPCHandlerImpl::Invoke(bool internal,
     v8::HandleScope handle_scope(isolate);
     auto* event =
         MakeIPCEvent(isolate, session->Get(), internal, std::move(callback));
+    if (!event)
+      return;
     v8::Local<v8::Object> event_object =
         event->GetWrapper(isolate).ToLocalChecked();
     session->Get()->Invoke(event_object, channel, std::move(arguments));
@@ -106,6 +110,8 @@ void ElectronApiSWIPCHandlerImpl::ReceivePostMessage(
     v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
     v8::HandleScope handle_scope(isolate);
     auto* event = MakeIPCEvent(isolate, session->Get(), false);
+    if (!event)
+      return;
     v8::Local<v8::Object> event_object =
         event->GetWrapper(isolate).ToLocalChecked();
     session->Get()->ReceivePostMessage(event_object, channel,
@@ -123,6 +129,8 @@ void ElectronApiSWIPCHandlerImpl::MessageSync(bool internal,
     v8::HandleScope handle_scope(isolate);
     auto* event =
         MakeIPCEvent(isolate, session->Get(), internal, std::move(callback));
+    if (!event)
+      return;
     v8::Local<v8::Object> event_object =
         event->GetWrapper(isolate).ToLocalChecked();
     session->Get()->MessageSync(event_object, channel, std::move(arguments));


### PR DESCRIPTION
#### Description of Change

Regression from https://github.com/electron/electron/pull/48161

Don't have a reliable repro, but possible fix for the following crash

```
Crashed Thread:        0  CrBrowserMain  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x0000000000000008
Exception Codes:       0x0000000000000001, 0x0000000000000008

Termination Reason:    Namespace SIGNAL, Code 11 Segmentation fault: 11
Terminating Process:   exc handler [86287]

Thread 0 Crashed:: CrBrowserMain Dispatch queue: com.apple.main-thread
0   Electron Framework            	       0x10da818f8 gin::WrappableBase::GetWrapper(v8::Isolate*)
1   Electron Framework            	       0x10f200a94 electron::ElectronApiIPCHandlerImpl::MessageSync(bool, std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, blink::CloneableMessage, base::OnceCallback<void (blink::CloneableMessage)>)
2   Electron Framework            	       0x111450368 electron::mojom::ElectronApiIPCStubDispatch::AcceptWithResponder(electron::mojom::ElectronApiIPC*, mojo::Message*, std::__Cr::unique_ptr<mojo::MessageReceiverWithStatus, std::__Cr::default_delete<mojo::MessageReceiverWithStatus>>)
3   Electron Framework            	       0x10f200e38 electron::mojom::ElectronApiIPCStub<mojo::RawPtrImplRefTraits<electron::mojom::ElectronApiIPC>>::AcceptWithResponder(mojo::Message*, std::__Cr::unique_ptr<mojo::MessageReceiverWithStatus, std::__Cr::default_delete<mojo::MessageReceiverWithStatus>>)
4   Electron Framework            	       0x10d1f1590 mojo::InterfaceEndpointClient::HandleIncomingMessageThunk::Accept(mojo::Message*)
5   Electron Framework            	       0x10c9c84c8 mojo::MessageDispatcher::Accept(mojo::Message*)
6   Electron Framework            	       0x10c9c83b0 mojo::InterfaceEndpointClient::HandleIncomingMessage(mojo::Message*)
7   Electron Framework            	       0x10e3b8be0 IPC::ChannelAssociatedGroupController::AcceptSyncMessage(unsigned int, unsigned int, IPC::(anonymous namespace)::ScopedUrgentMessageNotification)
8   Electron Framework            	       0x10e3b8a80 base::internal::Invoker<base::internal::FunctorTraits<void (IPC::ChannelAssociatedGroupController::*&&)(unsigned int, unsigned int, IPC::(anonymous namespace)::ScopedUrgentMessageNotification), IPC::ChannelAssociatedGroupController*&&, unsigned int&&, unsigned int&&, IPC::(anonymous namespace)::ScopedUrgentMessageNotification&&>, base::internal::BindState<true, true, false, void (IPC::ChannelAssociatedGroupController::*)(unsigned int, unsigned int, IPC::(anonymous namespace)::ScopedUrgentMessageNotification), scoped_refptr<IPC::ChannelAssociatedGroupController>, unsigned int, unsigned int, IPC::(anonymous namespace)::ScopedUrgentMessageNotification>, void ()>::RunOnce(base::internal::BindStateBase*)
9   Electron Framework            	       0x10c981668 base::TaskAnnotator::RunTaskImpl(base::PendingTask&)
10  Electron Framework            	       0x10c980af0 non-virtual thunk to base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()
11  Electron Framework            	       0x10d1d7dd8 invocation function for block in base::MessagePumpCFRunLoopBase::RunWorkSource(void*)
12  Electron Framework            	       0x10cb88244 base::apple::CallWithEHFrame(void () block_pointer)
13  Electron Framework            	       0x10efc239c base::MessagePumpCFRunLoopBase::RunWorkSource(void*)
14  CoreFoundation                	       0x19b986a64 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
15  CoreFoundation                	       0x19b9869f8 __CFRunLoopDoSource0
16  CoreFoundation                	       0x19b986764 __CFRunLoopDoSources0
17  CoreFoundation                	       0x19b9853b8 __CFRunLoopRun
18  CoreFoundation                	       0x19b9849e8 CFRunLoopRunSpecific
19  HIToolbox                     	       0x1a742327c RunCurrentEventLoopInMode
20  HIToolbox                     	       0x1a74264e8 ReceiveNextEventCommon
21  HIToolbox                     	       0x1a75b1484 _BlockUntilNextEventMatchingListInModeWithFilter
22  AppKit                        	       0x19f8a4a34 _DPSNextEvent
23  AppKit                        	       0x1a0243940 -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]
24  AppKit                        	       0x19f897be4 -[NSApplication run]
25  Electron Framework            	       0x10e56d33c base::MessagePumpNSApplication::DoRun(base::MessagePump::Delegate*)
26  Electron Framework            	       0x10e56d154 base::MessagePumpCFRunLoopBase::Run(base::MessagePump::Delegate*)
27  Electron Framework            	       0x10deef06c base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta)
28  Electron Framework            	       0x10e010a28 base::RunLoop::Run(base::Location const&)
29  Electron Framework            	       0x10e76656c content::BrowserMainLoop::RunMainMessageLoop()
30  Electron Framework            	       0x10e7664bc content::BrowserMainRunnerImpl::Run()
31  Electron Framework            	       0x10e7c7ff4 content::BrowserMain(content::MainFunctionParams)
32  Electron Framework            	       0x10e7c7efc content::RunBrowserProcessMain(content::MainFunctionParams, content::ContentMainDelegate*)
33  Electron Framework            	       0x10e3deec4 content::ContentMainRunnerImpl::RunBrowser(content::MainFunctionParams, bool)
34  Electron Framework            	       0x10e3db848 content::ContentMainRunnerImpl::Run()
35  Electron Framework            	       0x10e662054 content::RunContentProcess(content::ContentMainParams, content::ContentMainRunner*)
36  Electron Framework            	       0x10e661a14 content::ContentMain(content::ContentMainParams)
37  Electron Framework            	       0x10f124260 ElectronMain
38  dyld                          	       0x19b4fab98 start
```

#### Release Notes

Notes: fix crash when creating event object for ipc events
