### PR TITLE
fix: only call popup closecallback for top-level menu

### DIFF
--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -563,16 +563,22 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
 }
 
 - (void)menuDidClose:(NSMenu*)menu {
-  if (isMenuOpen_) {
-    isMenuOpen_ = NO;
-    if (model_)
-      model_->MenuWillClose();
-    // Post async task so that itemSelected runs before the close callback
-    // deletes the controller from the map which deallocates it
-    if (!closeCallback.is_null()) {
-      content::GetUIThreadTaskRunner({})->PostTask(FROM_HERE,
-                                                   std::move(closeCallback));
-    }
+  // If the menu is already closed, do nothing.
+  if (!isMenuOpen_)
+    return;
+
+  // We should only respond to the top-level menu's close event.
+  if (menu != menu_)
+    return;
+
+  isMenuOpen_ = NO;
+  if (model_)
+    model_->MenuWillClose();
+  // Post async task so that itemSelected runs before the close callback
+  // deletes the controller from the map which deallocates it
+  if (!closeCallback.is_null()) {
+    content::GetUIThreadTaskRunner({})->PostTask(FROM_HERE,
+                                                 std::move(closeCallback));
   }
 }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/49005.

Fixes an issue where the close callback param for `menu.popup` would fire when any arbitrary submenu of the given menu closed, and not the menu itself.

Fix this by ensuring that `menuDidClose` checks for the menu being the correc top-level menu.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the close callback param for `menu.popup` would fire when any arbitrary submenu of the given menu closed, and not the menu itself.
