### PR TITLE
build: automatically install git for dugite

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -22,6 +22,3 @@ runs:
         export npm_config_arch="ia32"
       fi
       node script/yarn.js install --immutable
-      if [ "$BUILD_TYPE" = "win" ]; then
-        node node_modules/dugite/script/download-git.js
-      fi

--- a/package.json
+++ b/package.json
@@ -139,5 +139,10 @@
   "workspaces": [
     "spec",
     "spec/fixtures/native-addon/*"
-  ]
+  ],
+  "dependenciesMeta": {
+    "dugite": {
+      "built": true
+    }
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4726,6 +4726,9 @@ __metadata:
     webpack: "npm:^5.95.0"
     webpack-cli: "npm:^6.0.1"
     wrapper-webpack-plugin: "npm:^2.2.0"
+  dependenciesMeta:
+    dugite:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
#### Description of Change
- followup to #48243.  This adds dugite as a module that can run postinstall scripts so that we don't have to manually install git for dugite.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
