### PR TITLE
ci: don't build yarn modules for linux arm

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -21,4 +21,11 @@ runs:
       if [ "$TARGET_ARCH" = "x86" ]; then
         export npm_config_arch="ia32"
       fi
-      node script/yarn.js install --immutable
+      # if running on linux arm skip yarn Builds
+      ARCH=$(uname -m)
+      if [ "$ARCH" = "armv7l" ]; then
+        echo "Skipping yarn build on linux arm"
+        node script/yarn.js install --immutable --mode=skip-build
+      else
+        node script/yarn.js install --immutable
+      fi


### PR DESCRIPTION
- Followup to #48243.  After the yarn v4 we occasionally see out of memory errors when testing on linux arm 32 bit.   This should fix those oom errors by building yarn modules for linux arm 32 bit.  We lose some test coverage doing so, but it is better than having to constantly rekick the testing jobs.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
