### PR TITLE
docs: document that `shell.trashItem` requires backslashes

### DIFF
--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -58,6 +58,10 @@ Rejects if there was an error while deleting the requested item.
 This moves a path to the OS-specific trash location (Trash on macOS, Recycle
 Bin on Windows, and a desktop-environment-specific location on Linux).
 
+The path must use the default path separator for the platform (backslash on
+Windows). Use `path.resolve()` from the `node:path` module to ensure correct
+handling on all filesystems.
+
 ### `shell.beep()`
 
 Play the beep sound.


### PR DESCRIPTION
In Windows many functions relating to files (e.g. shell.openItem, the Node fs functions, as well as native Win32 APIs) will accept either type of slash / or \ as a folder separator.

shell.trashItem does not work with / as folder separator in Windows. This documentation change explains that.

See also:
https://github.com/electron/electron/issues/28831

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none