### PR TITLE
fix: duplicate fullscreen macOS menu item

### DIFF
--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -56,11 +56,6 @@ static NSDictionary* UNNotificationResponseToNSDictionary(
 }
 
 - (void)applicationWillFinishLaunching:(NSNotification*)notify {
-  // Don't add the "Enter Full Screen" menu item automatically.
-  [[NSUserDefaults standardUserDefaults]
-      setBool:NO
-       forKey:@"NSFullScreenMenuItemEverywhere"];
-
   [[[NSWorkspace sharedWorkspace] notificationCenter]
       addObserver:self
          selector:@selector(willPowerOff:)

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -557,6 +557,14 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
 
 - (void)menuWillOpen:(NSMenu*)menu {
   isMenuOpen_ = YES;
+
+  // macOS automatically injects a duplicate "Toggle Full Screen" menu item
+  // when we set menu.delegate on submenus. Remove hidden duplicates.
+  for (NSMenuItem* item in menu.itemArray) {
+    if (item.isHidden && item.action == @selector(toggleFullScreenMode:))
+      [menu removeItem:item];
+  }
+
   [self refreshMenuTree:menu];
   if (model_)
     model_->MenuWillShow();


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/49048

This fixes an issue introduced in 38be633 whereby a duplicate "Toggle Full Screen" menu item appeared in the View menu on macOS.

When `menu.delegate` is set on an `NSMenu` that contains a full screen menu item, macOS automatically injects a hidden duplicate menu item with the `toggleFullScreenMode:` action. This happens between menu creation and when menuWillOpen: is called. To fix this we now remove any hidden menu items in `menuWillOpen` that have the `toggleFullScreenMode:` action. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue whereby a duplicate "Toggle Full Screen" menu item appeared in the View menu on macOS.
