### PR TITLE
ci: ignore Dependabot workflow failures in audit

### DIFF
--- a/.github/workflows/audit-branch-ci.yml
+++ b/.github/workflows/audit-branch-ci.yml
@@ -74,6 +74,7 @@ jobs:
                       !message.startsWith("Process completed with exit code") &&
                       !message.startsWith("Response status code does not indicate success") &&
                       !message.startsWith("The hosted runner lost communication with the server") &&
+                      !message.startsWith("Dependabot encountered an error performing the update") &&
                       !/Unable to make request/.test(message) &&
                       !/The requested URL returned error/.test(message),
                   )


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Dependabot has started having a consistent failure related to one package, and keeps tripping this audit. Ignore it since it's not the signal we're looking for with this audit.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
