### PR TITLE
fix: export zlib symbols for native addon support

### DIFF
--- a/build/electron.def
+++ b/build/electron.def
@@ -94,3 +94,4 @@ EXPORTS
   zlibCompileFlags
   zError
   get_crc_table
+


### PR DESCRIPTION
Fixes #49089

Exports zlib symbols from electron.exe on Windows to enable native addons to link with zlib functions.

Description of Change
Native addons on Windows couldn't link with zlib despite the header being available. This PR exports all zlib symbols in 
build/electron.def
 to fix the issue.

Symbol list matches the official [zlib.def](https://github.com/madler/zlib/blob/master/win32/zlib.def) reference.

Checklist
 PR description included
 npm test passes (requires Windows CI)
 tests added - N/A: linker configuration only
 docs updated - N/A: no API changes
 Release notes included
Release Notes
Notes: Added zlib symbol exports on Windows to support native addons that depend on zlib compression functions.