### PR TITLE
docs: add generics for `ContextBridge` APIs

### DIFF
--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -50,16 +50,16 @@ When `contextIsolation` is enabled in your `webPreferences` (this is the default
 
 The `contextBridge` module has the following methods:
 
-### `contextBridge.exposeInMainWorld(apiKey, api)`
+### `contextBridge.exposeInMainWorld<T=any>(apiKey, api)`
 
 * `apiKey` string - The key to inject the API onto `window` with.  The API will be accessible on `window[apiKey]`.
-* `api` any - Your API, more information on what this API can be and how it works is available below.
+* `api` T - Your API, more information on what this API can be and how it works is available below.
 
-### `contextBridge.exposeInIsolatedWorld(worldId, apiKey, api)`
+### `contextBridge.exposeInIsolatedWorld<T=any>(worldId, apiKey, api)`
 
 * `worldId` Integer - The ID of the world to inject the API into. `0` is the default world, `999` is the world used by Electron's `contextIsolation` feature. Using 999 would expose the object for preload context. We recommend using 1000+ while creating isolated world.
 * `apiKey` string - The key to inject the API onto `window` with.  The API will be accessible on `window[apiKey]`.
-* `api` any - Your API, more information on what this API can be and how it works is available below.
+* `api` T - Your API, more information on what this API can be and how it works is available below.
 
 ### `contextBridge.executeInMainWorld(executionScript)` _Experimental_
 
@@ -79,7 +79,8 @@ Returns `any` - A copy of the resulting value from executing the function in the
 
 ### API
 
-The `api` provided to [`exposeInMainWorld`](#contextbridgeexposeinmainworldapikey-api) must be a `Function`, `string`, `number`, `Array`, `boolean`, or an object
+The `api` provided to [`exposeInMainWorld`](#contextbridgeexposeinmainworldtanyapikey-api)
+must be a `Function`, `string`, `number`, `Array`, `boolean`, or an object
 whose keys are strings and values are a `Function`, `string`, `number`, `Array`, `boolean`, or another nested object that meets the same conditions.
 
 `Function` values are proxied to the other context and all other values are **copied** and **frozen**. Any data / primitives sent in


### PR DESCRIPTION
#### Description of Change
Currently, [`ContextBridge::exposeInMainWorld`](https://www.electronjs.org/docs/latest/api/context-bridge#contextbridgeexposeinmainworldapikey-api) and [`ContextBridge::exposeInIsolatedWorld`](https://www.electronjs.org/docs/latest/api/context-bridge#contextbridgeexposeinisolatedworldworldid-apikey-api) API uses `any` for the `api` parameter.  This PR adds TypeScript generics support to these APIs for improved type safety.


The newly auto-generated interface `electron.d.ts` will become:
```ts
interface ContextBridge {
    ...
    exposeInIsolatedWorld<T=any>(worldId: number, apiKey: string, api: T): void;
    exposeInMainWorld<T=any>(apiKey: string, api: T): void;
  }
```

Exposed APIs can now be typed:
```ts
interface IMyApi {
  myFunc: () => number
}

contextBridge.exposeInMainWorld<IMyApi>('myApi', {
  myFunc: () => 42
})

contextBridge.exposeInMainWorld<IMyApi>('myApi', {
  myFuncc: () => 42 // this will throw a TS error
})

// Same type can then be reused for specifying the api in global `Window` interface
declare global {
  interface Window {
    myApi: IMyApi
  }
}
```

Resolves #40856

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples --> Added TypeScript generics support for ContextBridge::exposeInMainWorld and ContextBridge::exposeInIsolatedWorld