### PR TITLE
chore: reclaim macOS disk space

### DIFF
--- a/.github/actions/free-space-macos/action.yml
+++ b/.github/actions/free-space-macos/action.yml
@@ -64,15 +64,24 @@ runs:
         sudo rm -rf /Applications/Xcode_16.1.app
         sudo rm -rf /Applications/Xcode_16.2.app
         sudo rm -rf /Applications/Xcode_16.3.app
+        sudo rm -rf /Applications/Xcode_26*
         sudo rm -rf /Applications/Google Chrome.app
         sudo rm -rf /Applications/Google Chrome for Testing.app
-        sudo rm -rf	/Applications/Firefox.app
+        sudo rm -rf /Applications/Firefox.app
+        sudo rm -rf /Applications/Microsoft Edge.app
         sudo rm -rf ~/project/src/third_party/catapult/tracing/test_data
         sudo rm -rf ~/project/src/third_party/angle/third_party/VK-GL-CTS
         sudo rm -rf /Users/runner/Library/Android
         sudo rm -rf $JAVA_HOME_11_arm64
         sudo rm -rf $JAVA_HOME_17_arm64
         sudo rm -rf $JAVA_HOME_21_arm64
+        sudo rm -rf $JAVA_HOME_25_arm64
+        sudo rm -rf /Users/runner/.dotnet/
+        sudo rm -rf /Users/runner/.rustup
+
+        # remove homebrew packages we don't need
+        brew uninstall -f --zap aws-sam-cli session-manager-plugin gcc gcc@13 gcc@14 llvm@18 gradle maven ant azure-cli
+        brew autoremove
 
         # lipo off some huge binaries arm64 versions to save space
         strip_universal_deep $(xcode-select -p)/../SharedFrameworks


### PR DESCRIPTION
#### Description of Change
GitHub actions released a new macOS-15 runner and it doesn't have as much free disk space as the previous image:
https://github.com/actions/runner-images/releases/tag/macos-15%2F2025.1126 and this caused releases to fail with an out of disk space error.  Digging into it, with the old image we were able to make about 157GB free; the new image we only were getting 134GB free.  This PR updates our disk space cleanup to reclaim more disk space so that we once again have +150GB free.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
