### PR TITLE
build: gate brew commands in free-space-macos action

### DIFF
--- a/.github/actions/free-space-macos/action.yml
+++ b/.github/actions/free-space-macos/action.yml
@@ -80,8 +80,10 @@ runs:
         sudo rm -rf /Users/runner/.rustup
 
         # remove homebrew packages we don't need
-        brew uninstall -f --zap aws-sam-cli session-manager-plugin gcc gcc@13 gcc@14 llvm@18 gradle maven ant azure-cli
-        brew autoremove
+        if command -v brew &> /dev/null; then
+          brew uninstall -f --zap aws-sam-cli session-manager-plugin gcc gcc@13 gcc@14 llvm@18 gradle maven ant azure-cli
+          brew autoremove
+        fi
 
         # lipo off some huge binaries arm64 versions to save space
         strip_universal_deep $(xcode-select -p)/../SharedFrameworks


### PR DESCRIPTION
The brew uninstall and autoremove commands now only run if brew is available on the machine. This prevents failures on runners where Homebrew is not installed (such as the intel mac runner which we don't use but do track free space on for science)

_Written by Claude and reviewed by @MarshallOfSound before opening PR_

Notes: none