### PR TITLE
fix: ensure graceful quit after autoUpdater.quitAndInstall on macOS

### DIFF
--- a/shell/browser/auto_updater_mac.mm
+++ b/shell/browser/auto_updater_mac.mm
@@ -157,7 +157,11 @@ void AutoUpdater::CheckForUpdates() {
 void AutoUpdater::QuitAndInstall() {
   Delegate* delegate = AutoUpdater::GetDelegate();
   if (g_update_available) {
-    [[g_updater relaunchToInstallUpdate] subscribeError:^(NSError* error) {
+    [[g_updater relaunchToInstallUpdate] subscribeCompleted:^{
+      dispatch_async(dispatch_get_main_queue(), ^{
+        electron::Browser::Get()->Quit();
+      });
+    } error:^(NSError* error) {
       if (delegate)
         delegate->OnError(base::SysNSStringToUTF8(error.localizedDescription),
                           error.code, base::SysNSStringToUTF8(error.domain));


### PR DESCRIPTION
Previously, quitAndInstall would request a relaunch but not explicitly quit the app, leading to a SIGKILL by the update mechanism. This change adds an explicit Browser::Quit() call after the relaunch is successfully queued.

> [!IMPORTANT]
> Please note that code reviews and merges will be delayed during our [quiet period in December](https://www.electronjs.org/blog/dec-quiet-period-25) and might not happen until January.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
