### PR TITLE
fix: export zlib symbols for native addon support

### DIFF
--- a/build/electron.def
+++ b/build/electron.def
@@ -4,3 +4,107 @@
 ; which is one of the executable names that node-gyp recognizes.
 ; See https://github.com/nodejs/node-gyp/commit/52ceec3a6d15de3a8f385f43dbe5ecf5456ad07a
 NAME node.exe
+
+; Export zlib symbols for native addon support
+; See https://github.com/electron/electron/issues/49089
+EXPORTS
+  ; Core compression/decompression functions
+  zlibVersion
+  deflate
+  deflateEnd
+  deflateInit_
+  deflateInit2_
+  deflateSetDictionary
+  deflateGetDictionary
+  deflateReset
+  deflateParams
+  deflateBound
+  deflateCopy
+  deflateResetKeep
+  deflatePending
+  deflatePrime
+  deflateTune
+  deflateSetHeader
+  inflate
+  inflateEnd
+  inflateInit_
+  inflateInit2_
+  inflateSetDictionary
+  inflateGetDictionary
+  inflateReset
+  inflateReset2
+  inflateSync
+  inflateCopy
+  inflateResetKeep
+  inflatePrime
+  inflateMark
+  inflateGetHeader
+  inflateBack
+  inflateBackEnd
+  inflateBackInit_
+  inflateValidate
+  inflateCodesUsed
+  inflateSyncPoint
+  inflateUndermine
+  
+  ; Convenience functions
+  compress
+  compress2
+  compressBound
+  uncompress
+  uncompress2
+  
+  ; gzip file access functions
+  gzopen
+  gzdopen
+  gzbuffer
+  gzsetparams
+  gzread
+  gzfread
+  gzwrite
+  gzfwrite
+  gzprintf
+  gzvprintf
+  gzputs
+  gzgets
+  gzputc
+  gzgetc
+  gzungetc
+  gzflush
+  gzseek
+  gzrewind
+  gztell
+  gzoffset
+  gzeof
+  gzdirect
+  gzclose
+  gzclose_r
+  gzclose_w
+  gzerror
+  gzclearerr
+  
+  ; Large file support (64-bit)
+  gzopen64
+  gzseek64
+  gztell64
+  gzoffset64
+  gzgetc_
+  gzopen_w
+  
+  ; Checksum functions
+  adler32
+  adler32_z
+  adler32_combine
+  crc32
+  crc32_z
+  crc32_combine
+  crc32_combine_gen
+  crc32_combine_op
+  adler32_combine64
+  crc32_combine64
+  crc32_combine_gen64
+  
+  ; Utility functions
+  zlibCompileFlags
+  zError
+  get_crc_table


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/49089

Exports zlib symbols from electron.exe on Windows to enable native addons to link with zlib functions.

Description of Change
Native addons on Windows couldn't link with zlib despite the header being available. This PR exports all zlib symbols in
build/electron.def
to fix the issue.

Symbol list matches the official [zlib.def](https://github.com/madler/zlib/blob/master/win32/zlib.def) reference.

Checklist
PR description included
npm test passes (requires Windows CI)
tests added - N/A: linker configuration only
docs updated - N/A: no API changes
Release notes included
Release Notes
Notes: Added zlib symbol exports on Windows to support native addons that depend on zlib compression functions.