### PR TITLE
test: correct typo in node-spec.ts comment

### DIFF
--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -28,7 +28,7 @@ describe('node feature', () => {
         expect(msg).to.equal('message');
       });
 
-      it('Has its module searth paths restricted', async () => {
+      it('Has its module search paths restricted', async () => {
         const child = childProcess.fork(path.join(fixtures, 'module', 'module-paths.js'));
         const [msg] = await once(child, 'message');
         expect(msg.length).to.equal(2);


### PR DESCRIPTION
This PR fixes a minor typo in the comment within `spec/node-spec.ts`.  

- Corrected the sentence from:
'Has its module searth paths restricted'

- to:
'Has its module search paths restricted'

Notes: none