### PR TITLE
docs: add cold-start deep link handling example

### DIFF
--- a/docs/tutorial/launch-app-from-url-in-another-app.md
+++ b/docs/tutorial/launch-app-from-url-in-another-app.md
@@ -87,6 +87,13 @@ if (!gotTheLock) {
   // Create mainWindow, load the rest of the app, etc...
   app.whenReady().then(() => {
     createWindow()
+    // Check for deep link on cold start
+    if (process.argv.length >= 2) {
+      const lastArg = process.argv[process.argv.length - 1]
+      if (lastArg.startsWith('electron-fiddle://')) {
+        dialog.showErrorBox('Welcome Back', `You arrived from: ${lastArg}`)
+      }
+    }
   })
 }
 ```


### PR DESCRIPTION
## Description
This PR adds an example of how to handle deep links during a cold start (when the app is not already running) on Windows and Linux.

## Motivation
The current documentation covers handling deep links via the `second-instance` event, but does not explicitly show how to check `process.argv` during the initial app launch. This is a common stumbling block for developers implementing deep linking.

## Changes
- Added a code snippet to `docs/tutorial/launch-app-from-url-in-another-app.md` demonstrating how to check `process.argv` for the custom protocol URI inside `app.whenReady()`.

notes: none
