### PR TITLE
build: use powershell for Electron build step

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -45,6 +45,7 @@ runs:
       shell: bash
       run: echo "::add-matcher::src/electron/.github/problem-matchers/clang.json"
     - name: Build Electron ${{ inputs.step-suffix }}
+      if: ${{ inputs.target-platform != 'win' }}
       shell: bash
       run: |
         rm -rf "src/out/Default/Electron Framework.framework"
@@ -70,14 +71,37 @@ runs:
 
         # Upload build stats to Datadog
         if ! [ -z $DD_API_KEY ]; then
-          if [ "$TARGET_PLATFORM" = "win" ]; then
-            npx node electron/script/build-stats.mjs out/Default/siso.exe.INFO --upload-stats || true
-          else
-            npx node electron/script/build-stats.mjs out/Default/siso.INFO --upload-stats || true
-          fi
+          npx node electron/script/build-stats.mjs out/Default/siso.INFO --upload-stats || true          
         else
           echo "Skipping build-stats.mjs upload because DD_API_KEY is not set"
         fi
+    - name: Build Electron (Windows) ${{ inputs.step-suffix }}
+      if: ${{ inputs.target-platform == 'win' }}
+      shell: powershell
+      run: |
+        cd src\electron
+        git pack-refs
+        cd ..
+
+        $env:NINJA_SUMMARIZE_BUILD = 1
+        if ("${{ inputs.is-release }}" -eq "true") {          
+          e build --target electron:release_build
+        } else {
+          e build --target electron:testing_build
+        }
+        Copy-Item out\Default\.ninja_log out\electron_ninja_log
+        node electron\script\check-symlinks.js
+
+        # Upload build stats to Datadog
+        if ($env:DD_API_KEY) {
+          try {
+            npx node electron\script\build-stats.mjs out\Default\siso.exe.INFO --upload-stats
+          } catch {
+            Write-Host "Build stats upload failed, continuing..."
+          }
+        } else {
+          Write-Host "Skipping build-stats.mjs upload because DD_API_KEY is not set"
+        }
     - name: Verify dist.zip ${{ inputs.step-suffix }}
       shell: bash
       run: |


### PR DESCRIPTION
> [!IMPORTANT]
> Please note that code reviews and merges will be delayed during our [quiet period in December](https://www.electronjs.org/blog/dec-quiet-period-25) and might not happen until January.

#### Description of Change
This is a speculative fix for Windows builds occasionally failing with a error like the following:
```
Error: failed to load build.ninja: open (.ninja file path):
The parameter is incorrect.
```

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
