### PR TITLE
build: use @electron-ci/dev-root for package.json default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "electron",
+  "name": "@electron-ci/dev-root",
   "version": "0.0.0-development",
   "repository": "https://github.com/electron/electron",
   "description": "Build cross platform desktop apps with JavaScript, HTML, and CSS",

--- a/script/release/bin/publish-to-npm.ts
+++ b/script/release/bin/publish-to-npm.ts
@@ -13,6 +13,7 @@ import { createGitHubTokenStrategy } from '../github-token';
 import { ELECTRON_ORG, ELECTRON_REPO, ElectronReleaseRepo, NIGHTLY_REPO } from '../types';
 
 const rootPackageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../../package.json'), 'utf-8'));
+rootPackageJson.name = 'electron';
 
 if (!process.env.ELECTRON_NPM_OTP) {
   console.error('Please set ELECTRON_NPM_OTP');

--- a/yarn.lock
+++ b/yarn.lock
@@ -582,6 +582,73 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@electron-ci/dev-root@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@electron-ci/dev-root@workspace:."
+  dependencies:
+    "@azure/storage-blob": "npm:^12.28.0"
+    "@datadog/datadog-ci": "npm:^4.1.2"
+    "@electron/asar": "npm:^4.0.1"
+    "@electron/docs-parser": "npm:^2.0.0"
+    "@electron/fiddle-core": "npm:^1.3.4"
+    "@electron/github-app-auth": "npm:^3.2.0"
+    "@electron/lint-roller": "npm:^3.1.2"
+    "@electron/typescript-definitions": "npm:^9.1.5"
+    "@octokit/rest": "npm:^20.1.2"
+    "@primer/octicons": "npm:^10.0.0"
+    "@types/minimist": "npm:^1.2.5"
+    "@types/node": "npm:^24.9.0"
+    "@types/semver": "npm:^7.5.8"
+    "@types/stream-json": "npm:^1.7.8"
+    "@types/temp": "npm:^0.9.4"
+    "@typescript-eslint/eslint-plugin": "npm:^8.32.1"
+    "@typescript-eslint/parser": "npm:^8.7.0"
+    "@xmldom/xmldom": "npm:^0.8.11"
+    buffer: "npm:^6.0.3"
+    chalk: "npm:^4.1.0"
+    check-for-leaks: "npm:^1.2.1"
+    dugite: "npm:^2.7.1"
+    eslint: "npm:^8.57.1"
+    eslint-config-standard: "npm:^17.1.0"
+    eslint-plugin-import: "npm:^2.32.0"
+    eslint-plugin-markdown: "npm:^5.1.0"
+    eslint-plugin-mocha: "npm:^10.5.0"
+    eslint-plugin-n: "npm:^16.6.2"
+    eslint-plugin-node: "npm:^11.1.0"
+    eslint-plugin-promise: "npm:^6.6.0"
+    events: "npm:^3.2.0"
+    folder-hash: "npm:^4.1.1"
+    got: "npm:^11.8.5"
+    husky: "npm:^9.1.7"
+    lint-staged: "npm:^16.1.0"
+    markdownlint-cli2: "npm:^0.18.0"
+    minimist: "npm:^1.2.8"
+    node-gyp: "npm:^11.4.2"
+    null-loader: "npm:^4.0.1"
+    pre-flight: "npm:^2.0.0"
+    process: "npm:^0.11.10"
+    remark-cli: "npm:^12.0.1"
+    remark-preset-lint-markdown-style-guide: "npm:^6.0.1"
+    semver: "npm:^7.6.3"
+    stream-json: "npm:^1.9.1"
+    tap-xunit: "npm:^2.4.1"
+    temp: "npm:^0.9.4"
+    timers-browserify: "npm:1.4.2"
+    ts-loader: "npm:^8.0.2"
+    ts-node: "npm:6.2.0"
+    typescript: "npm:^5.8.3"
+    url: "npm:^0.11.4"
+    webpack: "npm:^5.95.0"
+    webpack-cli: "npm:^6.0.1"
+    wrapper-webpack-plugin: "npm:^2.2.0"
+  dependenciesMeta:
+    abstract-socket:
+      built: true
+    dugite:
+      built: true
+  languageName: unknown
+  linkType: soft
+
 "@electron-ci/echo@npm:*, @electron-ci/echo@workspace:spec/fixtures/native-addon/echo":
   version: 0.0.0-use.local
   resolution: "@electron-ci/echo@workspace:spec/fixtures/native-addon/echo"
@@ -4916,73 +4983,6 @@ __metadata:
   checksum: 10c0/2c553c4e7618e887398af0fb7ddd8055beb69d37a810ad73fcea0f3e9027f1fc879ef280151fb6bae8e5b961f5597452eafc1ae5a0adca5bd49211545a34afe7
   languageName: node
   linkType: hard
-
-"electron@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "electron@workspace:."
-  dependencies:
-    "@azure/storage-blob": "npm:^12.28.0"
-    "@datadog/datadog-ci": "npm:^4.1.2"
-    "@electron/asar": "npm:^4.0.1"
-    "@electron/docs-parser": "npm:^2.0.0"
-    "@electron/fiddle-core": "npm:^1.3.4"
-    "@electron/github-app-auth": "npm:^3.2.0"
-    "@electron/lint-roller": "npm:^3.1.2"
-    "@electron/typescript-definitions": "npm:^9.1.5"
-    "@octokit/rest": "npm:^20.1.2"
-    "@primer/octicons": "npm:^10.0.0"
-    "@types/minimist": "npm:^1.2.5"
-    "@types/node": "npm:^24.9.0"
-    "@types/semver": "npm:^7.5.8"
-    "@types/stream-json": "npm:^1.7.8"
-    "@types/temp": "npm:^0.9.4"
-    "@typescript-eslint/eslint-plugin": "npm:^8.32.1"
-    "@typescript-eslint/parser": "npm:^8.7.0"
-    "@xmldom/xmldom": "npm:^0.8.11"
-    buffer: "npm:^6.0.3"
-    chalk: "npm:^4.1.0"
-    check-for-leaks: "npm:^1.2.1"
-    dugite: "npm:^2.7.1"
-    eslint: "npm:^8.57.1"
-    eslint-config-standard: "npm:^17.1.0"
-    eslint-plugin-import: "npm:^2.32.0"
-    eslint-plugin-markdown: "npm:^5.1.0"
-    eslint-plugin-mocha: "npm:^10.5.0"
-    eslint-plugin-n: "npm:^16.6.2"
-    eslint-plugin-node: "npm:^11.1.0"
-    eslint-plugin-promise: "npm:^6.6.0"
-    events: "npm:^3.2.0"
-    folder-hash: "npm:^4.1.1"
-    got: "npm:^11.8.5"
-    husky: "npm:^9.1.7"
-    lint-staged: "npm:^16.1.0"
-    markdownlint-cli2: "npm:^0.18.0"
-    minimist: "npm:^1.2.8"
-    node-gyp: "npm:^11.4.2"
-    null-loader: "npm:^4.0.1"
-    pre-flight: "npm:^2.0.0"
-    process: "npm:^0.11.10"
-    remark-cli: "npm:^12.0.1"
-    remark-preset-lint-markdown-style-guide: "npm:^6.0.1"
-    semver: "npm:^7.6.3"
-    stream-json: "npm:^1.9.1"
-    tap-xunit: "npm:^2.4.1"
-    temp: "npm:^0.9.4"
-    timers-browserify: "npm:1.4.2"
-    ts-loader: "npm:^8.0.2"
-    ts-node: "npm:6.2.0"
-    typescript: "npm:^5.8.3"
-    url: "npm:^0.11.4"
-    webpack: "npm:^5.95.0"
-    webpack-cli: "npm:^6.0.1"
-    wrapper-webpack-plugin: "npm:^2.2.0"
-  dependenciesMeta:
-    abstract-socket:
-      built: true
-    dugite:
-      built: true
-  languageName: unknown
-  linkType: soft
 
 "emoji-regex@npm:^10.2.1, emoji-regex@npm:^10.3.0":
   version: 10.4.0


### PR DESCRIPTION
> [!IMPORTANT]
> Please note that code reviews and merges will be delayed during our [quiet period in December](https://www.electronjs.org/blog/dec-quiet-period-25) and might not happen until January.

#### Description of Change
This PR changes the `name` field in package.json from `electron` to `@electron-ci/dev-root` and adds logic to our npm publish script to continue to publish as `electron`.  The reason for this change is that some security scans on systems building Electron improperly flag that there is a vulnerable version of Electron because `0.0.0-development` < any published version of Electron that might have vulnerabilities (eg even https://nvd.nist.gov/vuln/detail/CVE-2016-1202 gets reported against electron 0.0.0-development).
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none