### PR TITLE
fix: display PageUp and PageDown as plain text on macOS menu

### DIFF
--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -429,23 +429,14 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
       if (accelerator.IsCmdDown())
         modifier_mask |= NSEventModifierFlagCommand;
       unichar character;
-      NSString* keyEquivalent = nil;
-      
-      // Handle special keys that should display as plain text on macOS
-      // instead of using Unicode symbols which can be ambiguous
-      switch (accelerator.key_code()) {
-        case ui::VKEY_PRIOR:  // Page Up
-          keyEquivalent = @"Page Up";
-          break;
-        case ui::VKEY_NEXT:   // Page Down
-          keyEquivalent = @"Page Down";
-          break;
-        default:
-          break;
-      }
-      
-      if (keyEquivalent) {
-        item.keyEquivalent = keyEquivalent;
+
+      if (accelerator.key_code() == ui::VKEY_PRIOR) {
+        character = NSPageUpFunctionKey;
+        item.keyEquivalent = [NSString stringWithFormat:@"%C", character];
+        item.keyEquivalentModifierMask = modifier_mask;
+      } else if (accelerator.key_code() == ui::VKEY_NEXT) {
+        character = NSPageDownFunctionKey;
+        item.keyEquivalent = [NSString stringWithFormat:@"%C", character];
         item.keyEquivalentModifierMask = modifier_mask;
       } else if (accelerator.shifted_char) {
         // When a shifted char is explicitly specified, for example Ctrl+Plus,


### PR DESCRIPTION
## Fixes #49151

### Description
On macOS, PageUp and PageDown accelerator keys were rendered with incorrect plain arrows. This PR renders them using the native macOS Page Up/Page Down function-key glyphs, matching system apps and resolving the reversed/ambiguous arrows.

### Changes
- Modified `shell/browser/ui/cocoa/electron_menu_controller.mm`
- Map `ui::VKEY_PRIOR` to the native `NSPageUpFunctionKey` glyph
- Map `ui::VKEY_NEXT` to the native `NSPageDownFunctionKey` glyph
- Preserve all modifier combinations (Cmd, Ctrl, Alt, Shift)
- Fall back to original behavior for all other keys

### Testing
The fix can be tested by creating menu items with PageUp/PageDown accelerators:
```javascript
const { Menu } = require('electron');

const menu = Menu.buildFromTemplate([
  {
    label: 'File',
    submenu: [
      { label: 'Scroll Up', accelerator: 'PageUp' },
      { label: 'Scroll Down', accelerator: 'PageDown' },
      { label: 'With Modifier', accelerator: 'Cmd+PageUp' }
    ]
  }
]);
```

### Impact
- Improves menu clarity and accessibility on macOS
- No breaking changes
- Backward compatible
- Platform-specific (.mm file only)


### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] Tests are changed or added (not applicable - UI text display fix)
- [ ] Relevant API documentation, tutorials, and examples are updated (not applicable - no API changes)
- [x] PR release notes describe the change

**Additional verification:**
- [x] PR description includes the issue reference
- [x] Changes are isolated to the specific problem
- [x] Code follows existing style conventions
- [x] Tested with various modifier combinations
- [x] No breaking changes or API modifications

### Release Notes

**Notes:** Fixed PageUp and PageDown accelerators on macOS menus to use the native Page Up/Page Down glyphs, matching other macOS apps and avoiding reversed arrow rendering.
