### PR TITLE
build: drop dugite as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "buffer": "^6.0.3",
     "chalk": "^4.1.0",
     "check-for-leaks": "^1.2.1",
-    "dugite": "^2.7.1",
     "eslint": "^8.57.1",
     "eslint-config-standard": "^17.1.0",
     "eslint-plugin-import": "^2.32.0",
@@ -148,9 +147,6 @@
   ],
   "dependenciesMeta": {
     "abstract-socket": {
-      "built": true
-    },
-    "dugite": {
       "built": true
     }
   }

--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -1,6 +1,6 @@
 const chalk = require('chalk');
-const { GitProcess } = require('dugite');
 
+const childProcess = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -61,13 +61,16 @@ function getAbsoluteElectronExec () {
   return path.resolve(SRC_DIR, getElectronExec());
 }
 
-async function handleGitCall (args, gitDir) {
-  const details = await GitProcess.exec(args, gitDir);
-  if (details.exitCode === 0) {
-    return details.stdout.replace(/^\*|\s+|\s+$/, '');
+function handleGitCall (args, gitDir) {
+  const result = childProcess.spawnSync('git', args, {
+    cwd: gitDir,
+    encoding: 'utf8',
+    stdio: ['inherit', 'pipe', 'pipe']
+  });
+  if (result.status === 0) {
+    return result.stdout.replace(/^\*|\s+|\s+$/, '');
   } else {
-    const error = GitProcess.parseError(details.stderr);
-    console.log(`${fail} couldn't parse git process call: `, error);
+    console.log(`${fail} couldn't parse git process call: `, result.stderr);
     process.exit(1);
   }
 }

--- a/script/lint.js
+++ b/script/lint.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-const { GitProcess } = require('dugite');
 const { ESLint } = require('eslint');
 const minimist = require('minimist');
 
@@ -431,9 +430,13 @@ function populateLinterWithArgs (linter, opts) {
 }
 
 async function findChangedFiles (top) {
-  const result = await GitProcess.exec(['diff', '--name-only', '--cached'], top);
-  if (result.exitCode !== 0) {
-    console.log('Failed to find changed files', GitProcess.parseError(result.stderr));
+  const result = childProcess.spawnSync('git', ['diff', '--name-only', '--cached'], {
+    cwd: top,
+    encoding: 'utf8',
+    stdio: ['inherit', 'pipe', 'pipe']
+  });
+  if (result.status !== 0) {
+    console.log('Failed to find changed files', result.stderr);
     process.exit(1);
   }
   const relativePaths = result.stdout.split(/\r\n|\r|\n/g);

--- a/script/release/notes/index.ts
+++ b/script/release/notes/index.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 import { Octokit } from '@octokit/rest';
-import { GitProcess } from 'dugite';
 import { valid, compare, gte, lte } from 'semver';
 
+import { spawnSync } from 'node:child_process';
 import { basename } from 'node:path';
 import { parseArgs } from 'node:util';
 
@@ -20,8 +20,12 @@ const semverify = (version: string) => version.replace(/^origin\//, '').replace(
 
 const runGit = async (args: string[]) => {
   console.info(`Running: git ${args.join(' ')}`);
-  const response = await GitProcess.exec(args, ELECTRON_DIR);
-  if (response.exitCode !== 0) {
+  const response = spawnSync('git', args, {
+    cwd: ELECTRON_DIR,
+    encoding: 'utf8',
+    stdio: ['inherit', 'pipe', 'pipe']
+  });
+  if (response.status !== 0) {
     throw new Error(response.stderr.trim());
   }
   return response.stdout.trim();

--- a/script/release/notes/notes.ts
+++ b/script/release/notes/notes.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import { Octokit } from '@octokit/rest';
-import { GitProcess } from 'dugite';
 
+import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve as _resolve } from 'node:path';
 
@@ -105,8 +105,12 @@ class Pool {
  **/
 
 const runGit = async (dir: string, args: string[]) => {
-  const response = await GitProcess.exec(args, dir);
-  if (response.exitCode !== 0) {
+  const response = spawnSync('git', args, {
+    cwd: dir,
+    encoding: 'utf8',
+    stdio: ['inherit', 'pipe', 'pipe']
+  });
+  if (response.status !== 0) {
     throw new Error(response.stderr.trim());
   }
   return response.stdout.trim();

--- a/script/release/prepare-release.ts
+++ b/script/release/prepare-release.ts
@@ -1,8 +1,7 @@
 import { Octokit } from '@octokit/rest';
 import * as chalk from 'chalk';
-import { GitProcess } from 'dugite';
 
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 
 import { createGitHubTokenStrategy } from './github-token';
@@ -166,11 +165,12 @@ async function createRelease (
 }
 
 async function pushRelease (branch: string) {
-  const pushDetails = await GitProcess.exec(
-    ['push', 'origin', `HEAD:${branch}`, '--follow-tags'],
-    ELECTRON_DIR
-  );
-  if (pushDetails.exitCode === 0) {
+  const pushDetails = spawnSync('git', ['push', 'origin', `HEAD:${branch}`, '--follow-tags'], {
+    cwd: ELECTRON_DIR,
+    encoding: 'utf8',
+    stdio: ['inherit', 'pipe', 'pipe']
+  });
+  if (pushDetails.status === 0) {
     console.log(
       `${pass} Successfully pushed the release.  Wait for ` +
         'release builds to finish before running "npm run release".'
@@ -191,11 +191,12 @@ async function runReleaseBuilds (branch: string, newVersion: string) {
 
 async function tagRelease (version: string) {
   console.log(`Tagging release ${version}.`);
-  const checkoutDetails = await GitProcess.exec(
-    ['tag', '-a', '-m', version, version],
-    ELECTRON_DIR
-  );
-  if (checkoutDetails.exitCode === 0) {
+  const checkoutDetails = spawnSync('git', ['tag', '-a', '-m', version, version], {
+    cwd: ELECTRON_DIR,
+    encoding: 'utf8',
+    stdio: ['inherit', 'pipe', 'pipe']
+  });
+  if (checkoutDetails.status === 0) {
     console.log(`${pass} Successfully tagged ${version}.`);
   } else {
     console.log(

--- a/yarn.lock
+++ b/yarn.lock
@@ -607,7 +607,6 @@ __metadata:
     buffer: "npm:^6.0.3"
     chalk: "npm:^4.1.0"
     check-for-leaks: "npm:^1.2.1"
-    dugite: "npm:^2.7.1"
     eslint: "npm:^8.57.1"
     eslint-config-standard: "npm:^17.1.0"
     eslint-plugin-import: "npm:^2.32.0"
@@ -643,8 +642,6 @@ __metadata:
     wrapper-webpack-plugin: "npm:^2.2.0"
   dependenciesMeta:
     abstract-socket:
-      built: true
-    dugite:
       built: true
   languageName: unknown
   linkType: soft
@@ -4864,16 +4861,6 @@ __metadata:
   bin:
     dogapi: bin/dogapi
   checksum: 10c0/26ad811c8fffb214d175dc0853fb3b61cfb2ac5ad6d6bdfa5e9858c36aad08f7c300fe7258b2302ff106bc8de756ce1b615218a1ba4dfd38bb823d9400b6b842
-  languageName: node
-  linkType: hard
-
-"dugite@npm:^2.7.1":
-  version: 2.7.1
-  resolution: "dugite@npm:2.7.1"
-  dependencies:
-    progress: "npm:^2.0.3"
-    tar: "npm:^6.1.11"
-  checksum: 10c0/8b7992b91abc2473e43a4900c5b100f5a4b98785b9955275c72b1a621152b5df9ff794cda50daced5ee452f4dc95b313ce9c30af5dc9e302241ef9f661a593df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> [!IMPORTANT]
> Please note that code reviews and merges will be delayed during our [quiet period in December](https://www.electronjs.org/blog/dec-quiet-period-25) and might not happen until January.
Dugite frequently fails on install/downloading, etc https://github.com/electron/electron/actions/runs/20136412651/job/57793888145?pr=49193#step:11:391.

This PR removes dugite as a dependency and replaces it with direct calls to git which should be installed on CI already.
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
