### PR TITLE
test: remove outdated disabled test

### DIFF
--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -2135,12 +2135,6 @@ describe('BrowserWindow module', () => {
             expect(w.fullScreen).to.be.true();
           });
 
-          // FIXME: this test needs to be fixed and re-enabled.
-          it.skip('does not go fullscreen if roundedCorners are enabled', async () => {
-            w = new BrowserWindow({ frame: false, roundedCorners: false, fullscreen: true });
-            expect(w.fullScreen).to.be.false();
-          });
-
           it('can be changed', () => {
             w.fullScreen = false;
             expect(w.fullScreen).to.be.false();


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/49169

The test was originally added in https://github.com/electron/electron/pull/35421.

At some point, certain tests stopped running. When @ckerr fixed that bug in https://github.com/electron/electron/pull/46816, he disabled this test in particular because it was failing.

@codebytere fixed the original issue properly in https://github.com/electron/electron/pull/47664. She added new tests. So this original test can be removed.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
