### PR TITLE
fix: avoid startup crash when V8 sandbox is disabled

### DIFF
--- a/patches/chromium/fix_harden_blink_scriptstate_maybefrom.patch
+++ b/patches/chromium/fix_harden_blink_scriptstate_maybefrom.patch
@@ -56,7 +56,7 @@ index cecf528475cb832ed1876381878eade582bc83d6..71308b2d963c2d083328aad6be356dc5
  
  enum EmbedderDataTag : uint16_t {
 diff --git a/third_party/blink/renderer/platform/bindings/script_state.cc b/third_party/blink/renderer/platform/bindings/script_state.cc
-index 8b6522c9299bef5ab766795b64a1ba30bc382a12..a714aeb8a62886bedb3820b33b49b1ebdb9c7cc0 100644
+index 8b6522c9299bef5ab766795b64a1ba30bc382a12..4615dc04a3814a096898a36c7bbeb30f960a8b4d 100644
 --- a/third_party/blink/renderer/platform/bindings/script_state.cc
 +++ b/third_party/blink/renderer/platform/bindings/script_state.cc
 @@ -14,6 +14,12 @@ namespace blink {
@@ -95,7 +95,7 @@ index 8b6522c9299bef5ab766795b64a1ba30bc382a12..a714aeb8a62886bedb3820b33b49b1eb
  
    // Cut the reference from ScriptState to V8 context.
 diff --git a/third_party/blink/renderer/platform/bindings/script_state.h b/third_party/blink/renderer/platform/bindings/script_state.h
-index 5ccdf26cead17031d510589b74288cbe79692779..bf3023d5305c05c5d92953b5bf5f655f964e5c28 100644
+index 5ccdf26cead17031d510589b74288cbe79692779..54ede003ebe0a46e624c9d67f7272b8898bbc83e 100644
 --- a/third_party/blink/renderer/platform/bindings/script_state.h
 +++ b/third_party/blink/renderer/platform/bindings/script_state.h
 @@ -6,6 +6,7 @@


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/49199

This fixes startup crash in custom builds where V8 sandbox is disabled.

32-bit builds do not enable the V8 sandbox, so checking ARCH_CPU_32_BIT alongside !V8_ENABLE_SANDBOX is redundant.

For more information refer to:
https://github.com/electron/electron/issues/49199 (Issue where this was solved)
https://github.com/electron/electron/issues/48699 (Same problem but the issue was unresolved)


#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

notes: Fixed startup crash when V8 sandbox is disabled.
