### PR TITLE
fix: drag regions in child windows

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -754,10 +754,8 @@ WebContents::WebContents(v8::Isolate* isolate,
   script_executor_ = std::make_unique<extensions::ScriptExecutor>(web_contents);
 #endif
 
-  // In Chrome, draggable regions are only supported in the main frame.
-  // However, we need to support draggable regions on other local
-  // frames/windows, so extend support beyond the main frame by enabling
-  // it for all WebContents.
+  // TODO: This works for main frames, but does not work for child frames.
+  // See: https://github.com/electron/electron/issues/49256
   web_contents->SetSupportsDraggableRegions(true);
 
   session_ = Session::FromOrCreate(isolate, GetBrowserContext());
@@ -1027,10 +1025,8 @@ void WebContents::InitWithWebContents(
   browser_context_ = browser_context;
   web_contents->SetDelegate(this);
 
-  // In Chrome, draggable regions are only supported in the main frame.
-  // However, we need to support draggable regions on other local
-  // frames/windows, so extend support beyond the main frame by enabling
-  // it for all WebContents.
+  // TODO: This works for main frames, but does not work for child frames.
+  // See: https://github.com/electron/electron/issues/49256
   web_contents->SetSupportsDraggableRegions(true);
 
 #if BUILDFLAG(ENABLE_PRINTING)


### PR DESCRIPTION
#### Description of Change

Fixes #49223

Upstream [moved `SetSupportsDraggableRegions`](https://chromium-review.googlesource.com/c/chromium/src/+/7043264) from the renderer-side `WebViewImpl` to the browser-side `content::WebContents`.

This PR adapts to that change by calling `SetSupportsDraggableRegions` during `WebContents` initialization, matching the previous behavior of `ElectronRenderFrameObserver`. The call is placed in two locations to cover all `WebContents` types: owned `WebContents` (`InitWithWebContents`) and remote `WebContents` (constructor).

In the process, we also discovered https://github.com/electron/electron/issues/49256

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed drag regions in child windows
