### PR TITLE
docs: add Playwright version warning to automated testing guide

### DIFF
--- a/docs/tutorial/automated-testing.md
+++ b/docs/tutorial/automated-testing.md
@@ -172,10 +172,7 @@ using browser-specific remote debugging protocols, similar to the [Puppeteer][] 
 Node.js API but geared towards end-to-end testing. Playwright has experimental Electron
 support via Electron's support for the [Chrome DevTools Protocol][] (CDP).
 
-:::warning Version notice
-This tutorial was originally written using `@playwright/test@1.52.0`.
-If you are using a newer version (for example `1.57.0` or later), some APIs or behaviors may differ.
-:::
+This guide is compatible with Playwright 1.57.0 and newer.
 
 ### Install dependencies
 
@@ -203,7 +200,7 @@ test('launch app', async () => {
 })
 ```
 
-After that, you will access to an instance of Playwright's `ElectronApp` class. This
+After that, you will have access to an instance of Playwright's `ElectronApp` class. This
 is a powerful class that has access to main process modules for example:
 
 ```js {5-10} @ts-nocheck


### PR DESCRIPTION
> [!IMPORTANT]
> Please note that code reviews and merges will be delayed during our [quiet period in December](https://www.electronjs.org/blog/dec-quiet-period-25) and might not happen until January.

#### Description of Change

This PR adds a small version notice to the automated testing guide to clarify
the Playwright version used when the tutorial was written. This helps readers
avoid confusion when using newer Playwright releases.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the documentation style guide
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

none

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
