### PR TITLE
fix: calculation of newViewBounds.y for vertical proportion

### DIFF
--- a/lib/browser/api/browser-view.ts
+++ b/lib/browser/api/browser-view.ts
@@ -144,7 +144,7 @@ export default class BrowserView {
 
     if (this.#autoVerticalProportion) {
       newViewBounds.height = newBounds.height / this.#autoVerticalProportion.height;
-      newViewBounds.y = newBounds.y / this.#autoVerticalProportion.top;
+      newViewBounds.y = newBounds.height / this.#autoVerticalProportion.top;
     }
 
     if (this.#autoHorizontalProportion || this.#autoVerticalProportion) {


### PR DESCRIPTION
Small adjustment to the calculation of the `y` coordinate when setting new bounds for a `BrowserView` with auto vertical proportioning. The change updates the logic to use the height of the new bounds instead of the y-coordinate, which should improve the accuracy of the vertical positioning.

* Fixed the calculation of `newViewBounds.y` in `BrowserView` to use `newBounds.height` instead of `newBounds.y` when applying auto vertical proportions.