### PR TITLE
fix: resolve inverted theme detection on Linux/Wayland at runtimeFixe…

### DIFF
--- a/shell/browser/api/electron_api_native_theme.h
+++ b/shell/browser/api/electron_api_native_theme.h
@@ -13,6 +13,8 @@
 
 #if BUILDFLAG(IS_WIN)
 #include "base/win/registry.h"
+#elif BUILDFLAG(IS_LINUX)
+#include "ui/linux/linux_ui.h"
 #endif
 
 namespace gin_helper {
@@ -64,6 +66,10 @@ class NativeTheme final : public gin_helper::DeprecatedWrappable<NativeTheme>,
  private:
 #if BUILDFLAG(IS_WIN)
   base::win::RegKey hkcu_themes_regkey_;
+#elif BUILDFLAG(IS_LINUX)
+  // Cache the Linux dark mode state to work around Chromium 142+
+  // issues where preferred_color_scheme() returns inverted values at runtime
+  std::optional<bool> should_use_dark_colors_linux_ = std::nullopt;
 #endif
   std::optional<bool> should_use_dark_colors_for_system_integrated_ui_ =
       std::nullopt;


### PR DESCRIPTION
================================================================================
              ELECTRON BUG #48736 - COMPLETE FIX DOCUMENTATION
================================================================================

DATE: December 27, 2025
ISSUE URL: https://github.com/electron/electron/issues/48736

================================================================================
                           ORIGINAL ISSUE
================================================================================

TITLE: Regression: v39 incorrectly resolves the system theme (light/dark) 
       at runtime and also calculates nativeTheme.shouldUseDarkColors 
       incorrectly at runtime

ELECTRON VERSION: 39.0.0
LAST WORKING VERSION: 38.5.0, 39.0.0-alpha.5
BROKEN IN: 39.0.0-alpha.6 (Chromium 142 upgrade)

AFFECTED PLATFORMS:
- Linux (Archlinux, Ubuntu, etc.)
- Wayland display server
- KDE Plasma 6.x

NOT AFFECTED:
- Windows
- macOS
- Electron v38.x

SYMPTOMS:
1. At startup: Theme detection is CORRECT
2. At runtime (when user changes system theme): Theme is INVERTED
   - Dark mode reported as Light mode
   - Light mode reported as Dark mode

AFFECTED APIs:
- nativeTheme.shouldUseDarkColors → Returns wrong (inverted) value
- window.matchMedia('(prefers-color-scheme: dark)') → Returns wrong result

ROOT CAUSE:
After Chromium v142 upgrade, ui_theme_->preferred_color_scheme() returns
inverted values at runtime on Linux/Wayland when the system theme changes.

================================================================================
                              FIX APPLIED
================================================================================

SOLUTION OVERVIEW:
Instead of relying on Chromium's broken preferred_color_scheme(), the fix
directly queries LinuxUiTheme::PreferDarkTheme() to get the correct system
theme value. This is the same pattern used for Windows (registry query).

================================================================================
                    FILE 1: electron_api_native_theme.h
================================================================================

PATH: shell/browser/api/electron_api_native_theme.h
FULL PATH: c:\Users\Kanika Katare\Desktop\electron\electron\shell\browser\api\electron_api_native_theme.h

--------------------------------------------------------------------------------
                        ORIGINAL CODE (BEFORE FIX)
--------------------------------------------------------------------------------

// Lines 14-16 (includes section):
#if BUILDFLAG(IS_WIN)
#include "base/win/registry.h"
#endif

// Lines 65-69 (private members section):
 private:
#if BUILDFLAG(IS_WIN)
  base::win::RegKey hkcu_themes_regkey_;
#endif
  std::optional<bool> should_use_dark_colors_for_system_integrated_ui_ =

--------------------------------------------------------------------------------
                        CORRECTED CODE (AFTER FIX)
--------------------------------------------------------------------------------

// Lines 14-18 (includes section):
#if BUILDFLAG(IS_WIN)
#include "base/win/registry.h"
#elif BUILDFLAG(IS_LINUX)
#include "ui/linux/linux_ui.h"
#endif

// Lines 66-75 (private members section):
 private:
#if BUILDFLAG(IS_WIN)
  base::win::RegKey hkcu_themes_regkey_;
#elif BUILDFLAG(IS_LINUX)
  // Cache the Linux dark mode state to work around Chromium 142+
  // issues where preferred_color_scheme() returns inverted values at runtime
  std::optional<bool> should_use_dark_colors_linux_ = std::nullopt;
#endif
  std::optional<bool> should_use_dark_colors_for_system_integrated_ui_ =

--------------------------------------------------------------------------------
                              CHANGES SUMMARY
--------------------------------------------------------------------------------

1. Added Linux include for ui/linux/linux_ui.h (lines 16-17)
2. Added member variable should_use_dark_colors_linux_ (lines 69-72)

================================================================================
                    FILE 2: electron_api_native_theme.cc
================================================================================

PATH: shell/browser/api/electron_api_native_theme.cc
FULL PATH: c:\Users\Kanika Katare\Desktop\electron\electron\shell\browser\api\electron_api_native_theme.cc

--------------------------------------------------------------------------------
                        ORIGINAL CODE (BEFORE FIX)
--------------------------------------------------------------------------------

// Lines 12-16 (includes section):
#include "shell/common/gin_helper/handle.h"
#include "shell/common/gin_helper/object_template_builder.h"
#include "shell/common/node_includes.h"
#include "ui/native_theme/native_theme.h"

// Lines 40-52 (OnNativeThemeUpdatedOnUI function):
void NativeTheme::OnNativeThemeUpdatedOnUI() {
#if BUILDFLAG(IS_WIN)
  if (hkcu_themes_regkey_.Valid()) {
    DWORD system_uses_light_theme = 1;
    hkcu_themes_regkey_.ReadValueDW(L"SystemUsesLightTheme",
                                    &system_uses_light_theme);
    bool system_dark_mode_enabled = (system_uses_light_theme == 0);
    should_use_dark_colors_for_system_integrated_ui_ =
        std::make_optional<bool>(system_dark_mode_enabled);
  }
#endif
  Emit("updated");
}

// Lines 75-83 (ShouldUseDarkColors function):
bool NativeTheme::ShouldUseDarkColors() {
  auto theme_source = GetThemeSource();
  if (theme_source == ui::NativeTheme::ThemeSource::kForcedLight)
    return false;
  if (theme_source == ui::NativeTheme::ThemeSource::kForcedDark)
    return true;
  return ui_theme_->preferred_color_scheme() ==
         ui::NativeTheme::PreferredColorScheme::kDark;
}

--------------------------------------------------------------------------------
                        CORRECTED CODE (AFTER FIX)
--------------------------------------------------------------------------------

// Lines 12-20 (includes section):
#include "shell/common/gin_helper/handle.h"
#include "shell/common/gin_helper/object_template_builder.h"
#include "shell/common/node_includes.h"
#include "ui/native_theme/native_theme.h"

#if BUILDFLAG(IS_LINUX)
#include "ui/linux/linux_ui.h"
#endif

// Lines 44-64 (OnNativeThemeUpdatedOnUI function):
void NativeTheme::OnNativeThemeUpdatedOnUI() {
#if BUILDFLAG(IS_WIN)
  if (hkcu_themes_regkey_.Valid()) {
    DWORD system_uses_light_theme = 1;
    hkcu_themes_regkey_.ReadValueDW(L"SystemUsesLightTheme",
                                    &system_uses_light_theme);
    bool system_dark_mode_enabled = (system_uses_light_theme == 0);
    should_use_dark_colors_for_system_integrated_ui_ =
        std::make_optional<bool>(system_dark_mode_enabled);
  }
#elif BUILDFLAG(IS_LINUX)
  // Query the dark mode preference directly from LinuxUiTheme
  // This works around Chromium 142+ issue where preferred_color_scheme()
  // returns inverted values at runtime on Linux/Wayland (issue #48736)
  if (const auto* linux_ui_theme = ui::LinuxUiTheme::GetForProfile(nullptr)) {
    should_use_dark_colors_linux_ =
        std::make_optional<bool>(linux_ui_theme->PreferDarkTheme());
  }
#endif
  Emit("updated");
}

// Lines 87-103 (ShouldUseDarkColors function):
bool NativeTheme::ShouldUseDarkColors() {
  auto theme_source = GetThemeSource();
  if (theme_source == ui::NativeTheme::ThemeSource::kForcedLight)
    return false;
  if (theme_source == ui::NativeTheme::ThemeSource::kForcedDark)
    return true;
#if BUILDFLAG(IS_LINUX)
  // Use the cached Linux theme value queried from LinuxUiTheme
  // This works around Chromium 142+ issue where preferred_color_scheme()
  // returns inverted values at runtime on Linux/Wayland (issue #48736)
  if (should_use_dark_colors_linux_.has_value()) {
    return should_use_dark_colors_linux_.value();
  }
#endif
  return ui_theme_->preferred_color_scheme() ==
         ui::NativeTheme::PreferredColorScheme::kDark;
}

--------------------------------------------------------------------------------
                              CHANGES SUMMARY
--------------------------------------------------------------------------------

1. Added Linux include for ui/linux/linux_ui.h (lines 18-20)

2. Modified OnNativeThemeUpdatedOnUI() to query Linux theme directly:
   - Added #elif BUILDFLAG(IS_LINUX) block (lines 54-61)
   - Queries LinuxUiTheme::PreferDarkTheme() on theme update
   - Caches result in should_use_dark_colors_linux_

3. Modified ShouldUseDarkColors() to use cached Linux value:
   - Added #if BUILDFLAG(IS_LINUX) block (lines 93-99)
   - Returns cached value if available
   - Falls back to preferred_color_scheme() if not


                           HOW THE FIX WORKS


BEFORE FIX (Broken Flow):
1. User changes system theme on Linux/Wayland
2. Chromium's DarkModeManagerLinux detects change
3. Sets preferred_color_scheme_ (but with INVERTED value after Chromium 142)
4. NativeTheme::OnNativeThemeUpdated() is called
5. Electron emits "updated" event
6. App queries shouldUseDarkColors
7. Returns ui_theme_->preferred_color_scheme() which is WRONG

AFTER FIX (Correct Flow):
1. User changes system theme on Linux/Wayland
2. Chromium's DarkModeManagerLinux detects change
3. NativeTheme::OnNativeThemeUpdatedOnUI() is called
4. NEW: Queries LinuxUiTheme::PreferDarkTheme() for CORRECT value
5. NEW: Caches result in should_use_dark_colors_linux_
6. Electron emits "updated" event
7. App queries shouldUseDarkColors
8. NEW: Returns cached should_use_dark_colors_linux_ which is CORRECT


                           VERIFICATION STEPS


To verify the fix works on Linux/Wayland:

1. Build Electron from source with these changes
2. Run an Electron app
3. Note the initial nativeTheme.shouldUseDarkColors value
4. Change system theme (Settings → Appearance → Dark/Light)
5. Check shouldUseDarkColors again

EXPECTED RESULTS:
- Before fix: shouldUseDarkColors is INVERTED (wrong)
- After fix: shouldUseDarkColors matches system theme (correct)

                              FILES SUMMARY


MODIFIED FILES:
1. shell/browser/api/electron_api_native_theme.h
   - Added Linux include
   - Added should_use_dark_colors_linux_ member variable

2. shell/browser/api/electron_api_native_theme.cc
   - Added Linux include
   - Modified OnNativeThemeUpdatedOnUI() 
   - Modified ShouldUseDarkColors()

DOCUMENTATION CREATED:
1. BUG_FIX_SUMMARY.txt (this file)
   Location: c:\Users\Kanika Katare\Desktop\electron\BUG_FIX_SUMMARY.txt

2. FINAL_FIX_DOCUMENTATION.txt (detailed before/after)
   Location: c:\Users\Kanika Katare\Desktop\electron\FINAL_FIX_DOCUMENTATION.txt

