### PR TITLE
feat: import shared texture supports p010le

### DIFF
--- a/docs/api/structures/shared-texture-import-texture-info.md
+++ b/docs/api/structures/shared-texture-import-texture-info.md
@@ -5,6 +5,7 @@
   * `rgba` - 32bpp RGBA (byte-order), 1 plane.
   * `rgbaf16` - Half float RGBA, 1 plane.
   * `nv12` - 12bpp with Y plane followed by a 2x2 interleaved UV plane.
+  * `p010le` - 4:2:0 10-bit YUV (little-endian), Y plane followed by a 2x2 interleaved UV plane.
 * `colorSpace` [ColorSpace](color-space.md) (optional) - The color space of the texture.
 * `codedSize` [Size](size.md) - The full dimensions of the shared texture.
 * `visibleRect` [Rectangle](rectangle.md) (optional) - A subsection of [0, 0, codedSize.width, codedSize.height]. In common cases, it is the full section area.

--- a/shell/common/api/electron_api_shared_texture.cc
+++ b/shell/common/api/electron_api_shared_texture.cc
@@ -127,6 +127,8 @@ std::string TransferVideoPixelFormatToString(media::VideoPixelFormat format) {
       return "rgbaf16";
     case media::PIXEL_FORMAT_NV12:
       return "nv12";
+    case media::PIXEL_FORMAT_P010LE:
+      return "p010le";
     default:
       NOTREACHED();
   }
@@ -569,6 +571,8 @@ struct Converter<ImportSharedTextureInfo> {
         out->pixel_format = media::PIXEL_FORMAT_RGBAF16;
       else if (pixel_format_str == "nv12")
         out->pixel_format = media::PIXEL_FORMAT_NV12;
+      else if (pixel_format_str == "p010le")
+        out->pixel_format = media::PIXEL_FORMAT_P010LE;
       else
         return false;
     }


### PR DESCRIPTION
#### Description of Change

This PR adds support for the p010le pixel format to SharedTextureImportTextureInfo.
p010le is a 4:2:0 10-bit YUV format commonly used by video decoders and GPU pipelines.

cc: @reitowo

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added support for importing shared textures using the p010le 10-bit YUV pixel format.
