### PR TITLE
feat: add `become-key` and `resign-key` events on `BrowserWindow` (macOS)

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -188,7 +188,7 @@ Returns:
 
 Emitted when the window gains focus.
 
-#### Event: 'become-key' _macOS_
+#### Event: 'did-become-key' _macOS_
 
 Returns:
 
@@ -199,7 +199,7 @@ Emitted when the window becomes the key window. On macOS, this is distinct from
 useful for floating panels, overlays, or Spotlight-like interfaces using
 `NSPanel`.
 
-#### Event: 'resign-key' _macOS_
+#### Event: 'did-resign-key' _macOS_
 
 Returns:
 

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -188,6 +188,28 @@ Returns:
 
 Emitted when the window gains focus.
 
+#### Event: 'become-key' _macOS_
+
+Returns:
+
+* `event` Event
+
+Emitted when the window becomes the key window. On macOS, this is distinct from
+`focus` because a window can become key without becoming main (focused). This is
+useful for floating panels, overlays, or Spotlight-like interfaces using
+`NSPanel`.
+
+#### Event: 'resign-key' _macOS_
+
+Returns:
+
+* `event` Event
+
+Emitted when the window resigns key window status. On macOS, this is distinct
+from `blur` because a window can lose key status without losing main status.
+This is useful for floating panels, overlays, or Spotlight-like interfaces using
+`NSPanel`.
+
 #### Event: 'show'
 
 Emitted when the window is shown.

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -194,7 +194,9 @@ Returns:
 
 * `event` Event
 
-Emitted when the window becomes the key window. On macOS, this is distinct from
+Emitted when the window becomes the [key window](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/WinPanel/Concepts/ChangingMainKeyWindow.html).
+The key window receives keyboard and other non-touch-related events, and only
+one window at a time may be the key window. On macOS, this is distinct from
 `focus` because a window can become key without becoming main (focused). This is
 useful for floating panels, overlays, or Spotlight-like interfaces using
 `NSPanel`.
@@ -205,10 +207,12 @@ Returns:
 
 * `event` Event
 
-Emitted when the window resigns key window status. On macOS, this is distinct
-from `blur` because a window can lose key status without losing main status.
-This is useful for floating panels, overlays, or Spotlight-like interfaces using
-`NSPanel`.
+Emitted when the window resigns [key window](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/WinPanel/Concepts/ChangingMainKeyWindow.html)
+status. The key window receives keyboard and other non-touch-related events, and
+only one window at a time may be the key window. On macOS, this is distinct from
+`blur` because a window can lose key status without losing main status. This is
+useful for floating panels, overlays,
+or Spotlight-like interfaces using `NSPanel`.
 
 #### Event: 'show'
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -256,14 +256,14 @@ Emitted when the window loses focus.
 
 Emitted when the window gains focus.
 
-#### Event: 'become-key' _macOS_
+#### Event: 'did-become-key' _macOS_
 
 Emitted when the window becomes the key window. On macOS, this is distinct from
 `focus` because a window can become key without becoming main (focused). This is
 useful for floating panels, overlays, or Spotlight-like interfaces using
 `NSPanel`.
 
-#### Event: 'resign-key' _macOS_
+#### Event: 'did-resign-key' _macOS_
 
 Emitted when the window resigns key window status. On macOS, this is distinct
 from `blur` because a window can lose key status without losing main status.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -256,6 +256,20 @@ Emitted when the window loses focus.
 
 Emitted when the window gains focus.
 
+#### Event: 'become-key' _macOS_
+
+Emitted when the window becomes the key window. On macOS, this is distinct from
+`focus` because a window can become key without becoming main (focused). This is
+useful for floating panels, overlays, or Spotlight-like interfaces using
+`NSPanel`.
+
+#### Event: 'resign-key' _macOS_
+
+Emitted when the window resigns key window status. On macOS, this is distinct
+from `blur` because a window can lose key status without losing main status.
+This is useful for floating panels, overlays, or Spotlight-like interfaces using
+`NSPanel`.
+
 #### Event: 'show'
 
 Emitted when the window is shown.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -258,16 +258,20 @@ Emitted when the window gains focus.
 
 #### Event: 'did-become-key' _macOS_
 
-Emitted when the window becomes the key window. On macOS, this is distinct from
+Emitted when the window becomes the [key window](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/WinPanel/Concepts/ChangingMainKeyWindow.html).
+The key window receives keyboard and other non-touch-related events, and only
+one window at a time may be the key window. On macOS, this is distinct from
 `focus` because a window can become key without becoming main (focused). This is
 useful for floating panels, overlays, or Spotlight-like interfaces using
 `NSPanel`.
 
 #### Event: 'did-resign-key' _macOS_
 
-Emitted when the window resigns key window status. On macOS, this is distinct
-from `blur` because a window can lose key status without losing main status.
-This is useful for floating panels, overlays, or Spotlight-like interfaces using
+Emitted when the window resigns [key window](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/WinPanel/Concepts/ChangingMainKeyWindow.html)
+status. The key window receives keyboard and other non-touch-related events, and
+only one window at a time may be the key window. On macOS, this is distinct from
+`blur` because a window can lose key status without losing main status. This is
+useful for floating panels, overlays, or Spotlight-like interfaces using
 `NSPanel`.
 
 #### Event: 'show'

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -226,9 +226,9 @@ void BaseWindow::OnWindowFocus() {
 void BaseWindow::OnWindowIsKeyChanged(bool is_key) {
 #if BUILDFLAG(IS_MAC)
   if (is_key) {
-    Emit("become-key");
+    Emit("did-become-key");
   } else {
-    Emit("resign-key");
+    Emit("did-resign-key");
   }
 #endif
 }

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -223,6 +223,16 @@ void BaseWindow::OnWindowFocus() {
   EmitEventSoon("focus");
 }
 
+void BaseWindow::OnWindowIsKeyChanged(bool is_key) {
+#if BUILDFLAG(IS_MAC)
+  if (is_key) {
+    Emit("become-key");
+  } else {
+    Emit("resign-key");
+  }
+#endif
+}
+
 void BaseWindow::OnWindowShow() {
   Emit("show");
 }

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -65,6 +65,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void OnWindowEndSession(const std::vector<std::string>& reasons) override;
   void OnWindowBlur() override;
   void OnWindowFocus() override;
+  void OnWindowIsKeyChanged(bool is_key) override;
   void OnWindowShow() override;
   void OnWindowHide() override;
   void OnWindowMaximize() override;

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -191,6 +191,7 @@ void BrowserWindow::OnWindowIsKeyChanged(bool is_key) {
   if (rwhv)
     rwhv->SetActive(is_key);
   window()->SetActive(is_key);
+  BaseWindow::OnWindowIsKeyChanged(is_key);
 #endif
 }
 


### PR DESCRIPTION
#### Description of Change

Fixes #49274 which has more details.

- Exposes native macOS `windowDidBecomeKey` and `windowDidResignKey` NSWindow delegate callbacks as public `BrowserWindow`/`BaseWindow` events
- On macOS, the **key window** is the window that receives keyboard and other non-touch-related events. Only one window at a time may be the key window. This is distinct from the main (focused) window — a window can become key without becoming main, which is useful for floating panels, overlays, or Spotlight-like interfaces using `NSPanel` (there is a demo video of what i mean in the linked issue above)
- The code for `OnWindowIsKeyChanged` already existed internally but wasn't mapped to any public-facing listener, so this is a pretty short PR hooking the parts

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `become-key` and `resign-key` events on macOS for detecting key window status changes in floating panels and overlays.