### PR TITLE
build: add logging to notes generator

### DIFF
--- a/script/release/notes/notes.ts
+++ b/script/release/notes/notes.ts
@@ -105,12 +105,17 @@ class Pool {
  **/
 
 const runGit = async (dir: string, args: string[]) => {
+  console.log(`Running git ${args.join(' ')} in ${dir}`);
   const response = spawnSync('git', args, {
     cwd: dir,
     encoding: 'utf8',
     stdio: ['inherit', 'pipe', 'pipe']
   });
   if (response.status !== 0) {
+    console.error(`Git command failed: git ${args.join(' ')}`);
+    console.error('STDERR was ' + response.stderr.trim());
+    console.error('STDOUT was ' + response.stdout.trim());
+    console.log('Response status:', response.status);
     throw new Error(response.stderr.trim());
   }
   return response.stdout.trim();


### PR DESCRIPTION
#### Description of Change
Sudowoodo is failing to generate release notes.  This PR adds debugging so that we can track down the issue.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
