### PR TITLE
build: fixup release notes generation

### DIFF
--- a/script/release/notes/notes.ts
+++ b/script/release/notes/notes.ts
@@ -109,7 +109,8 @@ const runGit = async (dir: string, args: string[]) => {
   const response = spawnSync('git', args, {
     cwd: dir,
     encoding: 'utf8',
-    stdio: ['inherit', 'pipe', 'pipe']
+    stdio: ['inherit', 'pipe', 'pipe'],
+    maxBuffer: 100 * 1024 * 1024 // 100MB buffer to handle large git outputs
   });
   if (response.status !== 0) {
     console.error(`Git command failed: git ${args.join(' ')}`);


### PR DESCRIPTION
#### Description of Change
- Follow up to #49194.  That PR accidentally broke release notes generation and we did not catch that because we don't generate release notes for nightlies.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
