### PR TITLE
test: fix flaky `BrowserView` test

### DIFF
--- a/spec/api-browser-view-spec.ts
+++ b/spec/api-browser-view-spec.ts
@@ -90,7 +90,7 @@ describe('BrowserView module', () => {
       w.show();
       w.setBounds(display.bounds);
       w.setBackgroundColor(WINDOW_BACKGROUND_COLOR);
-      await w.loadURL('data:text/html,<style>body{background:transparent;}</style>');
+      await w.loadURL('data:text/html,<html></html>');
 
       view = new BrowserView();
       view.setBounds(display.bounds);
@@ -109,7 +109,7 @@ describe('BrowserView module', () => {
       w.show();
       w.setBounds(display.bounds);
       w.setBackgroundColor(WINDOW_BACKGROUND_COLOR);
-      await w.loadURL('data:text/html,<style>body{background:transparent;}</style>');
+      await w.loadURL('data:text/html,<html></html>');
 
       view = new BrowserView();
       view.setBounds(display.bounds);


### PR DESCRIPTION
#### Description of Change

Chromium applies a `#121212` background color in Dark mode, while in Light mode the background is transparent or white when loading `about:blank`.

As a result, the test fails when the desktop theme is set to Dark.


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
