### PR TITLE
chore: improvements to script/run-clang-tidy.ts

### DIFF
--- a/script/run-clang-tidy.ts
+++ b/script/run-clang-tidy.ts
@@ -114,12 +114,14 @@ async function runClangTidy (
   outDir: string,
   filenames: string[],
   checks: string = '',
-  jobs: number = 1
+  jobs: number = 1,
+  fix: boolean = false
 ): Promise<boolean> {
   const cmd = path.resolve(LLVM_BIN, 'clang-tidy');
   const args = [`-p=${outDir}`];
 
   if (!process.env.CI) args.push('--use-color');
+  if (fix) args.push('--fix');
   if (checks) args.push(`--checks=${checks}`);
 
   // Remove any files that aren't in the compilation database to prevent
@@ -210,7 +212,7 @@ function parseCommandLine () {
     if (!arg || arg.startsWith('-')) {
       console.log(
         'Usage: script/run-clang-tidy.ts [-h|--help] [--jobs|-j] ' +
-          '[--checks] --out-dir OUTDIR [file1 file2]'
+          '[--fix] [--checks] --out-dir OUTDIR [file1 file2]'
       );
       process.exit(0);
     }
@@ -219,7 +221,7 @@ function parseCommandLine () {
   };
 
   const opts = minimist(process.argv.slice(2), {
-    boolean: ['help'],
+    boolean: ['fix', 'help'],
     string: ['checks', 'out-dir'],
     default: { jobs: 1 },
     alias: { help: 'h', jobs: 'j' },
@@ -287,7 +289,7 @@ async function main (): Promise<boolean> {
     );
   }
 
-  return runClangTidy(outDir, filenames, opts.checks, opts.jobs);
+  return runClangTidy(outDir, filenames, opts.checks, opts.jobs, opts.fix);
 }
 
 if (require.main === module) {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

A few improvements which fell out of #49072 which I'm going to land separately to more widely backport them and make that PR a little smaller to review.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
