### PR TITLE
docs: add jsign instructions for Azure Trusted Signing on Linux/macOS

### DIFF
--- a/docs/tutorial/code-signing.md
+++ b/docs/tutorial/code-signing.md
@@ -240,7 +240,7 @@ later point, it could make sense to check if the eligibility criteria have chang
 
 #### Using `jsign` for Azure Trusted Signing
 
-For developers on Linux or macOS, `jsign` can be used to sign Windows apps via Azure Trusted Signing. Example usage:
+For developers on Linux or macOS, [`jsign`](https://ebourg.github.io/jsign/) can be used to sign Windows apps via Azure Trusted Signing. Example usage:
 
 ```bash
 jsign --storetype TRUSTEDSIGNING \


### PR DESCRIPTION
#### Description of Change
This PR adds documentation describing how to use `jsign` to sign Windows applications via Azure Trusted Signing from Linux or macOS.

This is a documentation-only change and is helpful for developers who build Windows apps on non-Windows platforms and want an officially supported way to perform code signing using Azure Trusted Signing.


#### Checklist

- [x] PR description included
- [ ] `npm test` passes
- [ ] tests are changed or added
- [x] relevant API documentation, tutorials, and examples are updated and follow the documentation style guide
- [ ] PR release notes describe the change

####  Release Notes
Notes: None

Fixes #49333

