### PR TITLE
fix: provide explicit cookie encryption provider for cookie encryption

### DIFF
--- a/shell/browser/net/network_context_service.h
+++ b/shell/browser/net/network_context_service.h
@@ -5,11 +5,15 @@
 #ifndef ELECTRON_SHELL_BROWSER_NET_NETWORK_CONTEXT_SERVICE_H_
 #define ELECTRON_SHELL_BROWSER_NET_NETWORK_CONTEXT_SERVICE_H_
 
+#include <memory>
+
 #include "base/memory/raw_ptr.h"
 #include "chrome/browser/net/proxy_config_monitor.h"
 #include "components/keyed_service/core/keyed_service.h"
 #include "services/cert_verifier/public/mojom/cert_verifier_service_factory.mojom-forward.h"
 #include "services/network/public/mojom/network_context.mojom-forward.h"
+
+class CookieEncryptionProviderImpl;
 
 namespace base {
 class FilePath;
@@ -46,6 +50,7 @@ class NetworkContextService : public KeyedService {
 
   raw_ptr<ElectronBrowserContext> browser_context_;
   ProxyConfigMonitor proxy_config_monitor_;
+  std::unique_ptr<CookieEncryptionProviderImpl> cookie_encryption_provider_;
 };
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

This PR modifies our existing cookie encryption logic to match an upstream change here, which now requires a cookie encryption provider for the network service to use if cookie encryption is enabled: Reland "Port net::CookieCryptoDelegate to os_crypt async" | https://chromium-review.googlesource.com/c/chromium/src/+/6996667

This bug is also present in 40-x-y; we should try to land this fix before the 40.0.0 stable cut next week, as missing it could potentially break applications using cookie encryption.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where no cookie encryption provider was passed into the network service when cookie encryption was enabled.
