### PR TITLE
fix: toggle devtools menu item for `BaseWindow`

### DIFF
--- a/lib/browser/api/menu-item-roles.ts
+++ b/lib/browser/api/menu-item-roles.ts
@@ -213,9 +213,9 @@ export const roleList: Record<RoleId, Role> = {
     label: 'Toggle Developer Tools',
     accelerator: isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I',
     nonNativeMacOSRole: true,
-    webContentsMethod: (wc) => {
-      const bw = wc.getOwnerBrowserWindow();
-      if (bw) bw.webContents.toggleDevTools();
+    webContentsMethod: () => {
+      const focusedWebContent = webContents.getFocusedWebContents();
+      focusedWebContent?.toggleDevTools();
     }
   },
   togglefullscreen: {

--- a/lib/browser/api/menu-item-roles.ts
+++ b/lib/browser/api/menu-item-roles.ts
@@ -213,8 +213,8 @@ export const roleList: Record<RoleId, Role> = {
     label: 'Toggle Developer Tools',
     accelerator: isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I',
     nonNativeMacOSRole: true,
-    webContentsMethod: wc => {
-      const target = isDevTools(wc) ? getParentWebContents(wc) : wc ; 
+    webContentsMethod: (wc) => {
+      const target = isDevTools(wc) ? getParentWebContents(wc) : wc;
       target?.toggleDevTools();
     }
   },
@@ -358,19 +358,17 @@ export const roleList: Record<RoleId, Role> = {
 };
 
 const isDevTools = (wc: WebContents): boolean => {
-  return wc.getType() === 'remote' 
-          || wc.getURL().startsWith('devtools://')
-          || wc.hostWebContents != null; 
-}
+  return wc.getType() === 'remote' || wc.getURL().startsWith('devtools://') || wc.hostWebContents != null;
+};
 
 const getParentWebContents = (devToolsWebContents: WebContents): WebContents | undefined => {
-  for( const wc of webContents.getAllWebContents()) {
-    if(wc.devToolsWebContents === devToolsWebContents) {
+  for (const wc of webContents.getAllWebContents()) {
+    if (wc.devToolsWebContents === devToolsWebContents) {
       return wc;
     }
   }
-  return undefined; 
-}
+  return undefined;
+};
 
 const hasRole = (role: keyof typeof roleList) => {
   return Object.hasOwn(roleList, role);

--- a/lib/browser/api/menu-item-roles.ts
+++ b/lib/browser/api/menu-item-roles.ts
@@ -213,9 +213,10 @@ export const roleList: Record<RoleId, Role> = {
     label: 'Toggle Developer Tools',
     accelerator: isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I',
     nonNativeMacOSRole: true,
-    webContentsMethod: () => {
-      const focusedWebContent = webContents.getFocusedWebContents();
-      focusedWebContent?.toggleDevTools();
+    webContentsMethod: wc => {
+      if (wc && !wc.isDestroyed()) {
+        wc.toggleDevTools();
+      }
     }
   },
   togglefullscreen: {

--- a/lib/browser/api/menu-item-roles.ts
+++ b/lib/browser/api/menu-item-roles.ts
@@ -214,9 +214,8 @@ export const roleList: Record<RoleId, Role> = {
     accelerator: isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I',
     nonNativeMacOSRole: true,
     webContentsMethod: wc => {
-      if (wc && !wc.isDestroyed()) {
-        wc.toggleDevTools();
-      }
+      const target = isDevTools(wc) ? getParentWebContents(wc) : wc ; 
+      target?.toggleDevTools();
     }
   },
   togglefullscreen: {
@@ -357,6 +356,21 @@ export const roleList: Record<RoleId, Role> = {
     submenu: []
   }
 };
+
+const isDevTools = (wc: WebContents): boolean => {
+  return wc.getType() === 'remote' 
+          || wc.getURL().startsWith('devtools://')
+          || wc.hostWebContents != null; 
+}
+
+const getParentWebContents = (devToolsWebContents: WebContents): WebContents | undefined => {
+  for( const wc of webContents.getAllWebContents()) {
+    if(wc.devToolsWebContents === devToolsWebContents) {
+      return wc;
+    }
+  }
+  return undefined; 
+}
 
 const hasRole = (role: keyof typeof roleList) => {
   return Object.hasOwn(roleList, role);

--- a/lib/browser/api/menu-item-roles.ts
+++ b/lib/browser/api/menu-item-roles.ts
@@ -214,8 +214,10 @@ export const roleList: Record<RoleId, Role> = {
     accelerator: isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I',
     nonNativeMacOSRole: true,
     webContentsMethod: (wc) => {
-      const target = isDevTools(wc) ? getParentWebContents(wc) : wc;
-      target?.toggleDevTools();
+      const parentForDevToolsWebContents = webContents
+        .getAllWebContents()
+        .find(({ devToolsWebContents }) => devToolsWebContents === wc);
+      (parentForDevToolsWebContents || wc).toggleDevTools();
     }
   },
   togglefullscreen: {
@@ -355,19 +357,6 @@ export const roleList: Record<RoleId, Role> = {
     label: 'Share',
     submenu: []
   }
-};
-
-const isDevTools = (wc: WebContents): boolean => {
-  return wc.getType() === 'remote' || wc.getURL().startsWith('devtools://') || wc.hostWebContents != null;
-};
-
-const getParentWebContents = (devToolsWebContents: WebContents): WebContents | undefined => {
-  for (const wc of webContents.getAllWebContents()) {
-    if (wc.devToolsWebContents === devToolsWebContents) {
-      return wc;
-    }
-  }
-  return undefined;
 };
 
 const hasRole = (role: keyof typeof roleList) => {

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3194,6 +3194,17 @@ void WebContents::DisableDeviceEmulation() {
 }
 
 void WebContents::ToggleDevTools() {
+  if (type_ == Type::kRemote) {
+    // DevTools are webContents of Type::kRemote
+    for (auto contents : GetWebContentsList()) {
+      if (contents->GetDevToolsWebContents() == web_contents()) {
+        contents->ToggleDevTools();
+        return;
+      }
+    }
+    return;
+  }
+
   if (IsDevToolsOpened())
     CloseDevTools();
   else

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3194,17 +3194,6 @@ void WebContents::DisableDeviceEmulation() {
 }
 
 void WebContents::ToggleDevTools() {
-  if (type_ == Type::kRemote) {
-    // DevTools are webContents of Type::kRemote
-    for (auto contents : GetWebContentsList()) {
-      if (contents->GetDevToolsWebContents() == web_contents()) {
-        contents->ToggleDevTools();
-        return;
-      }
-    }
-    return;
-  }
-
   if (IsDevToolsOpened())
     CloseDevTools();
   else

--- a/spec/api-menu-item-spec.ts
+++ b/spec/api-menu-item-spec.ts
@@ -1,6 +1,8 @@
-import { BrowserWindow, app, Menu, MenuItem, MenuItemConstructorOptions } from 'electron/main';
+import { BaseWindow, BrowserWindow, WebContentsView, app, Menu, MenuItem, MenuItemConstructorOptions } from 'electron/main';
 
 import { expect } from 'chai';
+
+import { once } from 'node:events';
 
 import { roleList, execute } from '../lib/browser/api/menu-item-roles';
 import { ifit, ifdescribe } from './lib/spec-helpers';
@@ -503,6 +505,46 @@ describe('MenuItems', () => {
       });
       expect(item.label).to.equal('View');
       expect(item.submenu!.items[0].role).to.equal('close');
+    });
+  });
+
+  describe('MenuItem toggleDevTools role', () => {
+    afterEach(closeAllWindows);
+
+    it('toggles devtools on the focused webContents', async () => {
+      const w = new BaseWindow({ show: false });
+      const wcv = new WebContentsView();
+      w.setContentView(wcv);
+      await wcv.webContents.loadURL('about:blank');
+
+      const opened = once(wcv.webContents, 'devtools-opened');
+      expect(execute('toggledevtools', w, wcv.webContents)).to.be.true();
+      await opened;
+      expect(wcv.webContents.isDevToolsOpened()).to.be.true();
+
+      const closed = once(wcv.webContents, 'devtools-closed');
+      execute('toggledevtools', w, wcv.webContents);
+      await closed;
+      expect(wcv.webContents.isDevToolsOpened()).to.be.false();
+    });
+
+    it('toggles parent devtools when invoked with the devtools webContents', async () => {
+      const w = new BaseWindow({ show: true });
+      const wcv = new WebContentsView();
+      w.setContentView(wcv);
+      await wcv.webContents.loadURL('about:blank');
+
+      const opened = once(wcv.webContents, 'devtools-opened');
+      wcv.webContents.openDevTools({ mode: 'detach' });
+      await opened;
+
+      const devToolsWc = wcv.webContents.devToolsWebContents!;
+      expect(devToolsWc).to.not.be.null();
+
+      const closed = once(wcv.webContents, 'devtools-closed');
+      expect(execute('toggledevtools', w, devToolsWc)).to.be.true();
+      await closed;
+      expect(wcv.webContents.isDevToolsOpened()).to.be.false();
     });
   });
 

--- a/spec/api-menu-item-spec.ts
+++ b/spec/api-menu-item-spec.ts
@@ -1,4 +1,12 @@
-import { BaseWindow, BrowserWindow, WebContentsView, app, Menu, MenuItem, MenuItemConstructorOptions } from 'electron/main';
+import {
+  BaseWindow,
+  BrowserWindow,
+  WebContentsView,
+  app,
+  Menu,
+  MenuItem,
+  MenuItemConstructorOptions
+} from 'electron/main';
 
 import { expect } from 'chai';
 

--- a/spec/api-menu-item-spec.ts
+++ b/spec/api-menu-item-spec.ts
@@ -14,7 +14,7 @@ import { once } from 'node:events';
 
 import { roleList, execute } from '../lib/browser/api/menu-item-roles';
 import { ifit, ifdescribe } from './lib/spec-helpers';
-import { closeAllWindows } from './lib/window-helpers';
+import { closeAllWindows, cleanupWebContents } from './lib/window-helpers';
 
 function keys<Key extends string, Value>(record: Record<Key, Value>) {
   return Object.keys(record) as Key[];
@@ -518,6 +518,7 @@ describe('MenuItems', () => {
 
   describe('MenuItem toggleDevTools role', () => {
     afterEach(closeAllWindows);
+    afterEach(cleanupWebContents);
 
     it('toggles devtools on the focused webContents', async () => {
       const w = new BaseWindow({ show: false });
@@ -537,13 +538,13 @@ describe('MenuItems', () => {
     });
 
     it('toggles parent devtools when invoked with the devtools webContents', async () => {
-      const w = new BaseWindow();
+      const w = new BaseWindow({ show: false });
       const wcv = new WebContentsView();
       w.setContentView(wcv);
       await wcv.webContents.loadURL('about:blank');
 
       const opened = once(wcv.webContents, 'devtools-opened');
-      wcv.webContents.openDevTools({ mode: 'detach' });
+      wcv.webContents.openDevTools({ mode: 'bottom' });
       await opened;
       expect(wcv.webContents.isDevToolsOpened()).to.be.true();
 

--- a/spec/api-menu-item-spec.ts
+++ b/spec/api-menu-item-spec.ts
@@ -537,7 +537,7 @@ describe('MenuItems', () => {
     });
 
     it('toggles parent devtools when invoked with the devtools webContents', async () => {
-      const w = new BaseWindow({ show: true });
+      const w = new BaseWindow();
       const wcv = new WebContentsView();
       w.setContentView(wcv);
       await wcv.webContents.loadURL('about:blank');
@@ -545,6 +545,7 @@ describe('MenuItems', () => {
       const opened = once(wcv.webContents, 'devtools-opened');
       wcv.webContents.openDevTools({ mode: 'detach' });
       await opened;
+      expect(wcv.webContents.isDevToolsOpened()).to.be.true();
 
       const devToolsWc = wcv.webContents.devToolsWebContents!;
       expect(devToolsWc).to.not.be.null();


### PR DESCRIPTION
#### Description of Change
Fixes:  #45821, #45386

This PR fixes a "JavaScript error in main process" that occurs when a developer attempts to trigger the `toggleDevTools` when running `BaseWindow`. Unlike `BrowserWindow`, `BaseWindow` have multiple `WebContents` which cause it to fail. This changes the logic to target the currently focused `WebContents` regardless of the window.

##### Root Cause
The pervious implementation of the `toggledevtools` menu role used `getOwnerBrowserWindow()` which returns `{}` when window is hosted within a`BaseWindow` and later when function call `toggleDevTools` was made it causes JS error . 

#### Checklist

- [x] PR description included
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the "Toggle Developer Tools" menu item failed to function correctly with BaseWindow.
