### PR TITLE
build: update on-create-command for siso

### DIFF
--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -48,7 +48,8 @@ if [ ! -f $buildtools/configs/evm.testing.json ]; then
             \"gen\": {
                 \"args\": [
                     \"import(\\\"//electron/build/args/testing.gn\\\")\",
-                    \"use_remoteexec = true\"
+                    \"use_remoteexec = true\",
+                    \"use_siso=true\"
                 ],
                 \"out\": \"Testing\"
             },
@@ -58,7 +59,7 @@ if [ ! -f $buildtools/configs/evm.testing.json ]; then
             },
             \"\$schema\": \"file:///home/builduser/.electron_build_tools/evm-config.schema.json\",
             \"configValidationLevel\": \"strict\",
-            \"remoteBuild\": \"reclient\",
+            \"remoteBuild\": \"siso\",
             \"preserveSDK\": 5
         }
     " >$buildtools/configs/evm.testing.json


### PR DESCRIPTION
As in title. Otherwise:

```
2026-01-12 09:45:27.402Z: Cloning "depot_tools" into /home/builduser/.electron_build_tools/third_party/depot_tools
2026-01-12 09:45:30.860Z: Updating /home/builduser/.electron_build_tools/third_party/depot_tools
2026-01-12 09:45:30.862Z: Running "/home/builduser/.electron_build_tools/third_party/depot_tools/update_depot_tools"
2026-01-12 09:45:47.147Z: WARN We've made these temporary changes to your configuration:
 * migrated remoteBuild from unsupported 'reclient' to 'siso'
 * added gn arg "use_siso = ********" needed by remoteBuild siso
Run "e sanitize-config" to make these changes permanent.
```

Notes: none.