### PR TITLE
build: roll build-tools SHA to `4430e4a`

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -15,7 +15,7 @@ runs:
         git config --global core.preloadindex true
         git config --global core.longpaths true
       fi
-      export BUILD_TOOLS_SHA=a5d9f9052dcc36ee88bef5c8b13acbefd87b7d8d
+      export BUILD_TOOLS_SHA=4430e4a505e0f4fa2a41b707a10a36f780bbdd26
       npm i -g @electron/build-tools
       # Update depot_tools to ensure python
       e d update_depot_tools


### PR DESCRIPTION
Fixes

```
npm error HEAD is now at a5d9f90 fix: macOS SDK regex on line breaks (#760)
npm error Failed to install build-tools:  Error: ENOENT: no such file or directory, scandir '/github/home/.electron_build_tools/.yarn/releases'
npm error     at readdirSync (node:fs:1583:26)
npm error     at install (file:///usr/lib/node_modules/@electron/build-tools/preinstall.js:57:23)
npm error     at file:///usr/lib/node_modules/@electron/build-tools/preinstall.js:81:1
npm error     at ModuleJob.run (node:internal/modules/esm/module_job:329:25)
npm error     at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:644:26)
npm error     at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5) {
npm error   errno: -2,
npm error   code: 'ENOENT',
npm error   syscall: 'scandir',
npm error   path: '/github/home/.electron_build_tools/.yarn/releases'
npm error }
```

build-tools was pinned to a SHA prior to yarn@4 migration.

---

Notes: none