### PR TITLE
fix: window freezes on macOS when failing to enter fullscreen

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -280,6 +280,7 @@ v8::Local<v8::Value> BrowserWindow::GetWebContents(v8::Isolate* isolate) {
 }
 
 void BrowserWindow::OnWindowShow() {
+  web_contents()->WasShown();
   BaseWindow::OnWindowShow();
 }
 


### PR DESCRIPTION
Fixes #49347

#### Description of Change

This fixes a regression from #47151 where windows would freeze on macOS when failing to enter fullscreen (e.g., when swiping between virtual desktops).

The issue: `OnWindowHide()` calls `WasOccluded()` but `OnWindowShow()` wasn't calling `WasShown()`, creating an imbalance. When fullscreen transitions fail, macOS fires these observer callbacks directly, leaving Chromium thinking the page is hidden and stopping all rendering.

The fix: Add `web_contents()->WasShown()` to `OnWindowShow()` to match the `WasOccluded()` in `OnWindowHide()`. Yes, this means `WasShown()` gets called twice when you explicitly call `Show()`, but that's fine since it's idempotent.

#### Checklist

- [x] PR description included
- [ ] `npm test` passes
- [ ] tests are changed or added
- [ ] relevant API documentation, tutorials, and examples are updated and follow the documentation style guide
- [x] PR release notes describe the change in a way relevant to app developers, and are capitalized, punctuated, and past tense.

#### Release Notes

Notes: Fixed window freezing on macOS when failing to enter fullscreen.