### PR TITLE
fix: apply enableBlinkFeatures to service worker renderers (issue #49…

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -612,8 +612,25 @@ void ElectronBrowserClient::AppendExtraCommandLineSwitches(
       auto* browser_context = render_process_host->GetBrowserContext();
       auto* session_prefs =
           SessionPreferences::FromBrowserContext(browser_context);
-      if (session_prefs->HasServiceWorkerPreloadScript()) {
-        command_line->AppendSwitch(switches::kServiceWorkerPreload);
+      if (session_prefs) {
+        if (session_prefs->HasServiceWorkerPreloadScript()) {
+          command_line->AppendSwitch(switches::kServiceWorkerPreload);
+        }
+
+        if (!web_contents) {
+          const auto& enable_features =
+              session_prefs->GetEnableBlinkFeatures();
+          if (enable_features) {
+            command_line->AppendSwitchASCII(::switches::kEnableBlinkFeatures,
+                                            *enable_features);
+          }
+          const auto& disable_features =
+              session_prefs->GetDisableBlinkFeatures();
+          if (disable_features) {
+            command_line->AppendSwitchASCII(::switches::kDisableBlinkFeatures,
+                                            *disable_features);
+          }
+        }
       }
     }
   }

--- a/shell/browser/session_preferences.cc
+++ b/shell/browser/session_preferences.cc
@@ -39,4 +39,26 @@ bool SessionPreferences::HasServiceWorkerPreloadScript() {
   return it != preloads.end();
 }
 
+void SessionPreferences::SetEnableBlinkFeatures(const std::string& features) {
+  if (!features.empty()) {
+    enable_blink_features_ = features;
+  }
+}
+
+void SessionPreferences::SetDisableBlinkFeatures(const std::string& features) {
+  if (!features.empty()) {
+    disable_blink_features_ = features;
+  }
+}
+
+const std::optional<std::string>& SessionPreferences::GetEnableBlinkFeatures()
+    const {
+  return enable_blink_features_;
+}
+
+const std::optional<std::string>& SessionPreferences::GetDisableBlinkFeatures()
+    const {
+  return disable_blink_features_;
+}
+
 }  // namespace electron

--- a/shell/browser/session_preferences.h
+++ b/shell/browser/session_preferences.h
@@ -30,6 +30,11 @@ class SessionPreferences : public base::SupportsUserData::Data {
 
   bool HasServiceWorkerPreloadScript();
 
+  void SetEnableBlinkFeatures(const std::string& features);
+  void SetDisableBlinkFeatures(const std::string& features);
+  const std::optional<std::string>& GetEnableBlinkFeatures() const;
+  const std::optional<std::string>& GetDisableBlinkFeatures() const;
+
  private:
   SessionPreferences();
 
@@ -37,6 +42,8 @@ class SessionPreferences : public base::SupportsUserData::Data {
   static int kLocatorKey;
 
   std::vector<PreloadScript> preload_scripts_;
+  std::optional<std::string> enable_blink_features_;
+  std::optional<std::string> disable_blink_features_;
 };
 
 }  // namespace electron

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -222,12 +222,22 @@ void WebContentsPreferences::SetFromDictionary(
   web_preferences.Get("ignoreMenuShortcuts", &ignore_menu_shortcuts_);
   std::string enable_blink_features;
   if (web_preferences.Get(options::kEnableBlinkFeatures,
-                          &enable_blink_features))
+                          &enable_blink_features)) {
     enable_blink_features_ = enable_blink_features;
+    if (auto* session_prefs = SessionPreferences::FromBrowserContext(
+            web_contents_->GetBrowserContext())) {
+      session_prefs->SetEnableBlinkFeatures(enable_blink_features);
+    }
+  }
   std::string disable_blink_features;
   if (web_preferences.Get(options::kDisableBlinkFeatures,
-                          &disable_blink_features))
+                          &disable_blink_features)) {
     disable_blink_features_ = disable_blink_features;
+    if (auto* session_prefs = SessionPreferences::FromBrowserContext(
+            web_contents_->GetBrowserContext())) {
+      session_prefs->SetDisableBlinkFeatures(disable_blink_features);
+    }
+  }
 
   base::FilePath::StringType preload_path;
   if (web_preferences.Get(options::kPreloadScript, &preload_path)) {


### PR DESCRIPTION
fix: apply enableBlinkFeatures to service worker renderers (issue #49277)

#### Description of Change

Fixes #49277

**Problem:**
When a page is served by a service worker with Cross-Origin-Embedder-Policy (COEP), the `enableBlinkFeatures` setting from `webPreferences` is ignored. This occurs because service worker renderer processes don't have an associated `WebContents` at the time command line switches are appended during process creation.

**Root Cause:**
In `ElectronBrowserClient::AppendExtraCommandLineSwitches()`, Blink features are only applied when a `WebContents` is found for the renderer process. Service worker processes are created without an associated `WebContents`, causing the lookup to fail and the `--enable-blink-features` switch to never be appended.

**Solution:**
This PR implements a session-level fallback for Blink features:
1. Store `enableBlinkFeatures` and `disableBlinkFeatures` in `SessionPreferences` (session-wide)
2. When a `WebContents` sets Blink features, also store them in the associated session
3. When spawning a renderer process without a `WebContents` (e.g., service workers), fallback to session-level features

This approach follows the existing pattern used for service worker preload scripts.

**Changes:**
- `session_preferences.h/cc`: Added storage and accessors for Blink features
- `web_contents_preferences.cc`: Store Blink features in session when set
- `electron_browser_client.cc`: Apply session-level features when WebContents not found

#### Checklist

- [x] PR description included
- [ ] `npm test` passes - Skipped: Build environment not available, relying on CI
- [ ] tests are changed or added - No new tests added (see explanation below)(https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `enableBlinkFeatures` being ignored when pages are served by service workers with Cross-Origin-Embedder-Policy.