### PR TITLE
fix: fix cookie encryption provider loading on Windows and Linux

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -597,6 +597,7 @@ source_set("electron_lib") {
     use_libcxx_modules = false
 
     deps += [
+      "//components/os_crypt/async/browser:keychain_key_provider",
       "//components/os_crypt/common:keychain_password_mac",
       "//components/remote_cocoa/app_shim",
       "//components/remote_cocoa/browser",

--- a/shell/browser/browser_process_impl.cc
+++ b/shell/browser/browser_process_impl.cc
@@ -28,6 +28,11 @@
 #include "components/os_crypt/async/browser/freedesktop_secret_key_provider.h"
 #include "components/os_crypt/async/browser/posix_key_provider.h"
 #endif
+
+#if BUILDFLAG(IS_MAC)
+#include "components/os_crypt/async/browser/keychain_key_provider.h"
+#endif
+
 #include "components/prefs/in_memory_pref_store.h"
 #include "components/prefs/json_pref_store.h"
 #include "components/prefs/overlay_user_pref_store.h"
@@ -445,6 +450,14 @@ void BrowserProcessImpl::CreateOSCryptAsync() {
   providers.emplace_back(
       /*precedence=*/5u, std::make_unique<os_crypt_async::PosixKeyProvider>());
 #endif  // BUILDFLAG(IS_LINUX)
+
+#if BUILDFLAG(IS_MAC)
+  // On macOS, use KeychainKeyProvider for cookie encryption.
+  // This is enabled by default in Chrome via features::kUseKeychainKeyProvider.
+  providers.emplace_back(
+      /*precedence=*/10u,
+      std::make_unique<os_crypt_async::KeychainKeyProvider>());
+#endif  // BUILDFLAG(IS_MAC)
 
   os_crypt_async_ =
       std::make_unique<os_crypt_async::OSCryptAsync>(std::move(providers));


### PR DESCRIPTION
#### Description of Change

Fast follow to #49348. 

This PR modifies our existing cookie encryption logic to match an upstream change here: "Port net::CookieCryptoDelegate to os_crypt async" | https://chromium-review.googlesource.com/c/chromium/src/+/6996667 However, the previous PR only fixed the issue properly for MacOS. This PR provides the appropriate platform fixes for both Windows and Linux key providers.

We should try to land this fix before the 40.0.0 stable cut, as missing it breaks applications using cookie encryption.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue on Windows and Linux where no cookie encryption key provider was passed into the network service when cookie encryption was enabled.
