### PR TITLE
build: roll build-image to `a82b87d`

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   buildtools:
-    image: ghcr.io/electron/devcontainer:933c7d6ff6802706875270bec2e3c891cf8add3f
+    image: ghcr.io/electron/devcontainer:a82b87d7a4f5ff0cab61405f8151ac4cf4942aeb
 
     volumes:
       - ..:/workspaces/gclient/src/electron:cached

--- a/.github/workflows/build-git-cache.yml
+++ b/.github/workflows/build-git-cache.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     container:
-      image: ghcr.io/electron/build:bc2f48b2415a670de18d13605b1cf0eb5fdbaae1
+      image: ghcr.io/electron/build:a82b87d7a4f5ff0cab61405f8151ac4cf4942aeb
       options: --user root
       volumes:
         - /mnt/cross-instance-cache:/mnt/cross-instance-cache
@@ -37,7 +37,7 @@ jobs:
     permissions:
       contents: read
     container:
-      image: ghcr.io/electron/build:bc2f48b2415a670de18d13605b1cf0eb5fdbaae1
+      image: ghcr.io/electron/build:a82b87d7a4f5ff0cab61405f8151ac4cf4942aeb
       options: --user root --device /dev/fuse --cap-add SYS_ADMIN
       volumes:
         - /mnt/win-cache:/mnt/win-cache
@@ -63,7 +63,7 @@ jobs:
     # This job updates the same git cache as linux, so it needs to run after the linux one.
     needs: build-git-cache-linux
     container:
-      image: ghcr.io/electron/build:bc2f48b2415a670de18d13605b1cf0eb5fdbaae1
+      image: ghcr.io/electron/build:a82b87d7a4f5ff0cab61405f8151ac4cf4942aeb
       options: --user root
       volumes:
         - /mnt/cross-instance-cache:/mnt/cross-instance-cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       build-image-sha:
         type: string
         description: 'SHA for electron/build image'
-        default: '933c7d6ff6802706875270bec2e3c891cf8add3f'
+        default: 'a82b87d7a4f5ff0cab61405f8151ac4cf4942aeb'
         required: true
       skip-macos:
         type: boolean
@@ -76,7 +76,7 @@ jobs:
       id: set-output
       run: |
         if [ -z "${{ inputs.build-image-sha }}" ]; then
-          echo "build-image-sha=933c7d6ff6802706875270bec2e3c891cf8add3f" >> "$GITHUB_OUTPUT"
+          echo "build-image-sha=a82b87d7a4f5ff0cab61405f8151ac4cf4942aeb" >> "$GITHUB_OUTPUT"
         else
           echo "build-image-sha=${{ inputs.build-image-sha }}" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/workflows/linux-publish.yml
+++ b/.github/workflows/linux-publish.yml
@@ -6,7 +6,7 @@ on:
       build-image-sha:
         type: string
         description: 'SHA for electron/build image'
-        default: '933c7d6ff6802706875270bec2e3c891cf8add3f'
+        default: 'a82b87d7a4f5ff0cab61405f8151ac4cf4942aeb'
       upload-to-storage:
         description: 'Uploads to Azure storage'
         required: false

--- a/.github/workflows/macos-publish.yml
+++ b/.github/workflows/macos-publish.yml
@@ -6,7 +6,7 @@ on:
       build-image-sha:
         type: string
         description: 'SHA for electron/build image'
-        default: '933c7d6ff6802706875270bec2e3c891cf8add3f'
+        default: 'a82b87d7a4f5ff0cab61405f8151ac4cf4942aeb'
         required: true
       upload-to-storage:
         description: 'Uploads to Azure storage'

--- a/.github/workflows/windows-publish.yml
+++ b/.github/workflows/windows-publish.yml
@@ -6,7 +6,7 @@ on:
       build-image-sha:
         type: string
         description: 'SHA for electron/build image'
-        default: '933c7d6ff6802706875270bec2e3c891cf8add3f'
+        default: 'a82b87d7a4f5ff0cab61405f8151ac4cf4942aeb'
         required: true
       upload-to-storage:
         description: 'Uploads to Azure storage'


### PR DESCRIPTION
Roll build-image to include https://github.com/electron/build-images/commit/a82b87d7a4f5ff0cab61405f8151ac4cf4942aeb

Should also fix broken Codespaces.

Notes: none.