### PR TITLE
docs: update the example of `webContents.setWindowOpenHandler` to cla…

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1485,6 +1485,11 @@ mainWindow.webContents.setWindowOpenHandler((details) => {
       const browserView = new BrowserView(options)
       mainWindow.addBrowserView(browserView)
       browserView.setBounds({ x: 0, y: 0, width: 640, height: 480 })
+      // For `background-tab` disposition (e.g., when middle-clicking or ctrl/cmd-clicking a link),
+      // `options.webContents` is undefined because its creation can be deferred. So load the URL manually.
+      if (details.disposition === 'background-tab') {
+        browserView.webContents.loadURL(details.url)
+      }
       return browserView.webContents
     }
   }


### PR DESCRIPTION
…rify `background-tab` disposition cases

#### Description of Change

Resolves https://github.com/electron/electron/issues/49307 to some extent.

Current `createWindow` example in `webContents.setWindowOpenHandler` doesn't work well for `background-tab` disposition (Middle-click, or CmdOrCtrl+Left click). It creates a transparent view that nothing paints on it when using `BrowserView`, and causes a main process error for `WebContentsView`.

The root cause is that Chromium would defer the `webContents` of `background-tab` to become ready, so that `options.webContents` is undefined. See https://github.com/chromium/chromium/blob/e7662a747d6215ec7c31cd1b226dd38d97fa8baa/content/public/browser/web_contents_delegate.h#L161-L164 and https://github.com/chromium/chromium/blob/main/content/browser/web_contents/web_contents_impl.cc#L5306-L5307, saying that `OpenURLFromTab` "returns nullptr if the URL wasn't opened immediately", and the new background tab is not shown immediately.

As it's the intended behavior of Chromium, this PR clarifies this point by updating the example, so that the developers can treat this case properly.

A possible concern is that loading the URL by ourselves instead of inheriting the WebContents provided by `options` might result in a null `window.opener`. But after testing on Chrome, Firefox and Safari, all of them don't keep the track of `window.opener` for `background-tab` disposition for something like `<a href="..." target="_blank" rel="opener">...</a>`. So it's okay.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Updated the example of webContents.setWindowOpenHandler to clarify background-tab disposition cases
