### PR TITLE
Refactor: simplify imports without asterisk

### DIFF
--- a/.lint-roller.json
+++ b/.lint-roller.json
@@ -1,9 +1,9 @@
 {
   "markdown-ts-check": {
     "defaultImports": [
-      "import * as childProcess from 'node:child_process'",
-      "import * as fs from 'node:fs'",
-      "import * as path from 'node:path'",
+      "import childProcess from 'node:child_process'",
+      "import fs from 'node:fs'",
+      "import path from 'node:path'",
       "import { app, autoUpdater, contextBridge, crashReporter, dialog, BrowserWindow, ipcMain, ipcRenderer, Menu, MessageChannelMain, nativeImage, net, protocol, session, systemPreferences, Tray, utilityProcess, webFrame, webFrameMain } from 'electron'"
     ],
     "typings": [

--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -1,8 +1,8 @@
 import { shell } from 'electron/common';
 import { app, dialog, BrowserWindow, ipcMain } from 'electron/main';
 
-import * as path from 'node:path';
-import * as url from 'node:url';
+import path from 'node:path';
+import url from 'node:url';
 
 let mainWindow: BrowserWindow | null = null;
 

--- a/default_app/main.ts
+++ b/default_app/main.ts
@@ -1,9 +1,9 @@
-import * as electron from 'electron/main';
+import electron from 'electron/main';
 
-import * as fs from 'node:fs';
+import fs from 'node:fs';
 import { Module } from 'node:module';
-import * as path from 'node:path';
-import * as url from 'node:url';
+import path from 'node:path';
+import url from 'node:url';
 
 const { app, dialog } = electron;
 

--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -1,7 +1,7 @@
 import { Menu } from 'electron/main';
 
-import { EventEmitter } from 'events';
-import * as fs from 'fs';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
 
 const bindings = process._linkedBinding('electron_browser_app');
 const commandLine = process._linkedBinding('electron_common_command_line');

--- a/lib/browser/api/auto-updater/auto-updater-win.ts
+++ b/lib/browser/api/auto-updater/auto-updater-win.ts
@@ -2,7 +2,7 @@ import * as squirrelUpdate from '@electron/internal/browser/api/auto-updater/squ
 
 import { app } from 'electron/main';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 class AutoUpdater extends EventEmitter implements Electron.AutoUpdater {
   updateAvailable: boolean = false;

--- a/lib/browser/api/auto-updater/squirrel-update-win.ts
+++ b/lib/browser/api/auto-updater/squirrel-update-win.ts
@@ -1,6 +1,6 @@
-import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
-import * as fs from 'fs';
-import * as path from 'path';
+import { spawn, ChildProcessWithoutNullStreams } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 
 // i.e. my-app/app-0.1.13/
 const appFolder = path.dirname(process.execPath);

--- a/lib/browser/api/base-window.ts
+++ b/lib/browser/api/base-window.ts
@@ -1,7 +1,7 @@
 import { TouchBar } from 'electron/main';
 import type { BaseWindow as TLWT } from 'electron/main';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 const { BaseWindow } = process._linkedBinding('electron_browser_base_window') as { BaseWindow: typeof TLWT };
 

--- a/lib/browser/api/in-app-purchase.ts
+++ b/lib/browser/api/in-app-purchase.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 let _inAppPurchase;
 

--- a/lib/browser/api/message-channel.ts
+++ b/lib/browser/api/message-channel.ts
@@ -1,6 +1,6 @@
 import { MessagePortMain } from '@electron/internal/browser/message-port-main';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 const { createPair } = process._linkedBinding('electron_browser_message_port');
 

--- a/lib/browser/api/power-monitor.ts
+++ b/lib/browser/api/power-monitor.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 const {
   createPowerMonitor,

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -1,6 +1,6 @@
 import { ProtocolRequest, session } from 'electron/main';
 
-import { createReadStream } from 'fs';
+import { createReadStream } from 'node:fs';
 import { Readable } from 'stream';
 import { ReadableStream } from 'stream/web';
 

--- a/lib/browser/api/screen.ts
+++ b/lib/browser/api/screen.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 const { createScreen } = process._linkedBinding('electron_browser_screen');
 

--- a/lib/browser/api/share-menu.ts
+++ b/lib/browser/api/share-menu.ts
@@ -1,6 +1,6 @@
 import { BrowserWindow, Menu, SharingItem, PopupOptions } from 'electron/main';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 class ShareMenu extends EventEmitter implements Electron.ShareMenu {
   private menu: Menu;

--- a/lib/browser/api/shared-texture.ts
+++ b/lib/browser/api/shared-texture.ts
@@ -2,7 +2,7 @@ import ipcMain from '@electron/internal/browser/api/ipc-main';
 import * as ipcMainInternalUtils from '@electron/internal/browser/ipc-main-internal-utils';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 const transferTimeout = 1000;
 const sharedTextureNative = process._linkedBinding('electron_common_shared_texture');

--- a/lib/browser/api/touch-bar.ts
+++ b/lib/browser/api/touch-bar.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 let nextItemID = 1;
 

--- a/lib/browser/api/utility-process.ts
+++ b/lib/browser/api/utility-process.ts
@@ -1,6 +1,6 @@
 import { MessagePortMain } from '@electron/internal/browser/message-port-main';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 import { Socket } from 'net';
 import { Duplex, PassThrough } from 'stream';
 

--- a/lib/browser/api/view.ts
+++ b/lib/browser/api/view.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 const { View } = process._linkedBinding('electron_browser_view');
 

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -8,8 +8,8 @@ import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 import { app, session, webFrameMain, dialog } from 'electron/main';
 import type { BrowserWindowConstructorOptions, MessageBoxOptions, NavigationEntry } from 'electron/main';
 
-import * as path from 'path';
-import * as url from 'url';
+import path from 'node:path';
+import url from 'node:url';
 
 // session is not used here, the purpose is to make sure session is initialized
 // before the webContents module.

--- a/lib/browser/devtools.ts
+++ b/lib/browser/devtools.ts
@@ -4,7 +4,7 @@ import * as ipcMainUtils from '@electron/internal/browser/ipc-main-internal-util
 
 import { dialog, Menu } from 'electron/main';
 
-import * as fs from 'fs';
+import fs from 'node:fs';
 
 const convertToMenuTemplate = function (items: ContextMenuItem[], handler: (id: number) => void) {
   return items.map(function (item) {

--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -1,10 +1,10 @@
 import type * as defaultMenuModule from '@electron/internal/browser/default-menu';
 
-import { EventEmitter } from 'events';
-import * as fs from 'fs';
-import * as path from 'path';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import path from 'node:path';
 
-import type * as url from 'url';
+import type * as url from 'node:url';
 import type * as v8 from 'v8';
 
 const Module = require('module') as NodeJS.ModuleInternal;

--- a/lib/browser/ipc-main-impl.ts
+++ b/lib/browser/ipc-main-impl.ts
@@ -1,6 +1,6 @@
 import { IpcMainInvokeEvent } from 'electron/main';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 export class IpcMainImpl extends EventEmitter implements Electron.IpcMain {
   private _invokeHandlers: Map<string, (e: IpcMainInvokeEvent, ...args: any[]) => void> = new Map();

--- a/lib/browser/message-port-main.ts
+++ b/lib/browser/message-port-main.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 export class MessagePortMain extends EventEmitter implements Electron.MessagePortMain {
   _internalPort: any;

--- a/lib/browser/rpc-server.ts
+++ b/lib/browser/rpc-server.ts
@@ -5,8 +5,8 @@ import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 import { clipboard } from 'electron/common';
 import { webFrameMain } from 'electron/main';
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 // Implements window.close()
 ipcMainInternal.on(IPC_MESSAGES.BROWSER_WINDOW_CLOSE, function (event) {

--- a/lib/common/api/net-client-request.ts
+++ b/lib/common/api/net-client-request.ts
@@ -4,7 +4,7 @@ import type {
 } from 'electron/common';
 
 import { Readable, Writable } from 'stream';
-import * as url from 'url';
+import url from 'node:url';
 
 const {
   isValidHeaderName,

--- a/lib/common/init.ts
+++ b/lib/common/init.ts
@@ -1,5 +1,5 @@
 import timers = require('timers');
-import * as util from 'util';
+import util from 'node:util';
 
 import type * as stream from 'stream';
 

--- a/lib/node/asar-fs-wrapper.ts
+++ b/lib/node/asar-fs-wrapper.ts
@@ -1,10 +1,10 @@
-import { Buffer } from 'buffer';
-import { Dirent, constants } from 'fs';
-import * as path from 'path';
-import * as util from 'util';
+import { Buffer } from 'node:buffer';
+import { Dirent, constants } from 'node:fs';
+import path from 'node:path';
+import util from 'node:util';
 
-import type * as Crypto from 'crypto';
-import type * as os from 'os';
+import type * as Crypto from 'node:crypto';
+import type * as os from 'node:os';
 
 const asar = process._linkedBinding('electron_common_asar');
 

--- a/lib/preload_realm/init.ts
+++ b/lib/preload_realm/init.ts
@@ -3,7 +3,7 @@ import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 import type * as ipcRendererUtilsModule from '@electron/internal/renderer/ipc-renderer-internal-utils';
 import { createPreloadProcessObject, executeSandboxedPreloadScripts } from '@electron/internal/sandboxed_renderer/preload';
 
-import * as events from 'events';
+import events from 'node:events';
 
 declare const binding: {
   get: (name: string) => any;

--- a/lib/renderer/api/ipc-renderer.ts
+++ b/lib/renderer/api/ipc-renderer.ts
@@ -1,6 +1,6 @@
 import { getIPCRenderer } from '@electron/internal/renderer/ipc-renderer-bindings';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 const ipc = getIPCRenderer();
 const internal = false;

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -2,8 +2,8 @@ import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 import type * as ipcRendererInternalModule from '@electron/internal/renderer/ipc-renderer-internal';
 import type * as ipcRendererUtilsModule from '@electron/internal/renderer/ipc-renderer-internal-utils';
 
-import * as path from 'path';
-import { pathToFileURL } from 'url';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const Module = require('module') as NodeJS.ModuleInternal;
 

--- a/lib/renderer/ipc-renderer-internal.ts
+++ b/lib/renderer/ipc-renderer-internal.ts
@@ -1,6 +1,6 @@
 import { getIPCRenderer } from '@electron/internal/renderer/ipc-renderer-bindings';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 const ipc = getIPCRenderer();
 const internal = true;

--- a/lib/sandboxed_renderer/init.ts
+++ b/lib/sandboxed_renderer/init.ts
@@ -3,7 +3,7 @@ import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 import type * as ipcRendererUtilsModule from '@electron/internal/renderer/ipc-renderer-internal-utils';
 import { createPreloadProcessObject, executeSandboxedPreloadScripts } from '@electron/internal/sandboxed_renderer/preload';
 
-import * as events from 'events';
+import events from 'node:events';
 import { setImmediate, clearImmediate } from 'timers';
 
 declare const binding: {

--- a/lib/sandboxed_renderer/pre-init.ts
+++ b/lib/sandboxed_renderer/pre-init.ts
@@ -1,6 +1,6 @@
 // Pre-initialization code for sandboxed renderers.
 
-import * as events from 'events';
+import events from 'node:events';
 
 declare const binding: {
   get: (name: string) => any;

--- a/lib/sandboxed_renderer/preload.ts
+++ b/lib/sandboxed_renderer/preload.ts
@@ -1,7 +1,7 @@
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 interface PreloadContext {
   loadedModules: Map<string, any>;

--- a/lib/utility/init.ts
+++ b/lib/utility/init.ts
@@ -1,7 +1,7 @@
 import { ParentPort } from '@electron/internal/utility/parent-port';
 
-import { EventEmitter } from 'events';
-import { pathToFileURL } from 'url';
+import { EventEmitter } from 'node:events';
+import { pathToFileURL } from 'node:url';
 
 const v8Util = process._linkedBinding('electron_common_v8_util');
 

--- a/lib/utility/parent-port.ts
+++ b/lib/utility/parent-port.ts
@@ -1,6 +1,6 @@
 import { MessagePortMain } from '@electron/internal/browser/message-port-main';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 const { createParentPort } = process._linkedBinding('electron_utility_parent_port');
 

--- a/lib/worker/init.ts
+++ b/lib/worker/init.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import path from 'node:path';
 
 const Module = require('module') as NodeJS.ModuleInternal;
 

--- a/script/build-stats.mjs
+++ b/script/build-stats.mjs
@@ -1,4 +1,4 @@
-import * as fs from 'node:fs/promises';
+import fs from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 

--- a/script/check-patch-diff.ts
+++ b/script/check-patch-diff.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
+import path from 'node:path';
 
 const srcPath = path.resolve(__dirname, '..', '..', '..');
 const patchExportFnPath = path.resolve(__dirname, 'export_all_patches.py');

--- a/script/codesign/gen-trust.ts
+++ b/script/codesign/gen-trust.ts
@@ -1,6 +1,6 @@
-import * as cp from 'node:child_process';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import cp from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const certificatePath = process.argv[2];
 const outPath = process.argv[3];

--- a/script/cp.mjs
+++ b/script/cp.mjs
@@ -1,4 +1,4 @@
-import * as fs from 'node:fs/promises';
+import fs from 'node:fs/promises';
 
 const source = process.argv[2];
 const destination = process.argv[3];

--- a/script/gen-filenames.ts
+++ b/script/gen-filenames.ts
@@ -1,7 +1,7 @@
-import * as cp from 'node:child_process';
-import * as fs from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import cp from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 const rootPath = path.resolve(__dirname, '..');
 const gniPath = path.resolve(__dirname, '../filenames.auto.gni');

--- a/script/patches-stats.mjs
+++ b/script/patches-stats.mjs
@@ -1,5 +1,5 @@
-import * as fs from 'node:fs/promises';
-import * as path from 'node:path';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 

--- a/script/release/bin/publish-to-npm.ts
+++ b/script/release/bin/publish-to-npm.ts
@@ -1,10 +1,10 @@
 import { Octokit } from '@octokit/rest';
-import * as semver from 'semver';
-import * as temp from 'temp';
+import semver from 'semver';
+import temp from 'temp';
 
-import * as childProcess from 'node:child_process';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import childProcess from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import { getElectronVersion } from '../../lib/get-version';
 import { getCurrentBranch, ELECTRON_DIR } from '../../lib/utils';

--- a/script/release/get-url-hash.ts
+++ b/script/release/get-url-hash.ts
@@ -1,6 +1,6 @@
 import got from 'got';
 
-import * as url from 'node:url';
+import url from 'node:url';
 
 const HASHER_FUNCTION_HOST = 'electron-hasher.azurewebsites.net';
 const HASHER_FUNCTION_ROUTE = '/api/hashRemoteAsset';

--- a/script/release/prepare-release.ts
+++ b/script/release/prepare-release.ts
@@ -1,5 +1,5 @@
 import { Octokit } from '@octokit/rest';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 
 import { execSync, spawnSync } from 'node:child_process';
 import { join } from 'node:path';

--- a/script/release/release-artifact-cleanup.ts
+++ b/script/release/release-artifact-cleanup.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { Octokit } from '@octokit/rest';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 
 import { createGitHubTokenStrategy } from './github-token';
 import { ELECTRON_ORG, ELECTRON_REPO, ElectronReleaseRepo, NIGHTLY_REPO } from './types';

--- a/script/release/release.ts
+++ b/script/release/release.ts
@@ -2,7 +2,7 @@
 
 import { BlobServiceClient } from '@azure/storage-blob';
 import { Octokit } from '@octokit/rest';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import got from 'got';
 import { gte } from 'semver';
 import { track as trackTemp } from 'temp';

--- a/script/release/run-release-ci-jobs.ts
+++ b/script/release/run-release-ci-jobs.ts
@@ -1,6 +1,6 @@
 import { Octokit } from '@octokit/rest';
 
-import * as assert from 'node:assert';
+import assert from 'node:assert';
 
 import { createGitHubTokenStrategy } from './github-token';
 import { ELECTRON_ORG, ELECTRON_REPO } from './types';

--- a/script/release/uploaders/upload-to-github.ts
+++ b/script/release/uploaders/upload-to-github.ts
@@ -1,6 +1,6 @@
 import { Octokit } from '@octokit/rest';
 
-import * as fs from 'node:fs';
+import fs from 'node:fs';
 
 import { createGitHubTokenStrategy } from '../github-token';
 import { ELECTRON_ORG, ELECTRON_REPO, ElectronReleaseRepo, NIGHTLY_REPO } from '../types';

--- a/script/release/version-utils.ts
+++ b/script/release/version-utils.ts
@@ -1,4 +1,4 @@
-import * as semver from 'semver';
+import semver from 'semver';
 
 import { spawnSync } from 'node:child_process';
 

--- a/script/run-clang-tidy.ts
+++ b/script/run-clang-tidy.ts
@@ -1,13 +1,13 @@
-import * as minimist from 'minimist';
-import * as streamChain from 'stream-chain';
-import * as streamJson from 'stream-json';
+import minimist from 'minimist';
+import streamChain from 'stream-chain';
+import streamJson from 'stream-json';
 import { ignore as streamJsonIgnore } from 'stream-json/filters/Ignore';
 import { streamArray as streamJsonStreamArray } from 'stream-json/streamers/StreamArray';
 
-import * as childProcess from 'node:child_process';
-import * as fs from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import childProcess from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import { chunkFilenames, findMatchingFiles } from './lib/utils';
 

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -1,16 +1,16 @@
 import { app, BrowserWindow, Menu, session, net as electronNet, WebContents, utilityProcess } from 'electron/main';
 
 import { assert, expect } from 'chai';
-import * as semver from 'semver';
+import semver from 'semver';
 import split = require('split')
 
-import * as cp from 'node:child_process';
+import cp from 'node:child_process';
 import { once } from 'node:events';
-import * as fs from 'node:fs';
-import * as http from 'node:http';
-import * as https from 'node:https';
-import * as net from 'node:net';
-import * as path from 'node:path';
+import fs from 'node:fs';
+import http from 'node:http';
+import https from 'node:https';
+import net from 'node:net';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 import { promisify } from 'node:util';
 

--- a/spec/api-autoupdater-darwin-spec.ts
+++ b/spec/api-autoupdater-darwin-spec.ts
@@ -1,15 +1,15 @@
 import { autoUpdater, systemPreferences } from 'electron';
 
 import { expect } from 'chai';
-import * as express from 'express';
-import * as psList from 'ps-list';
-import * as uuid from 'uuid';
+import express from 'express';
+import psList from 'ps-list';
+import uuid from 'uuid';
 
-import * as cp from 'node:child_process';
-import * as fs from 'node:fs';
-import * as http from 'node:http';
+import cp from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
 import { AddressInfo } from 'node:net';
-import * as path from 'node:path';
+import path from 'node:path';
 
 import { copyMacOSFixtureApp, getCodesignIdentity, shouldRunCodesignTests, signApp, spawn } from './lib/codesign-helpers';
 import { withTempDirectory } from './lib/fs-helpers';

--- a/spec/api-browser-view-spec.ts
+++ b/spec/api-browser-view-spec.ts
@@ -3,7 +3,7 @@ import { BrowserView, BrowserWindow, screen, session, webContents } from 'electr
 import { expect } from 'chai';
 
 import { once } from 'node:events';
-import * as path from 'node:path';
+import path from 'node:path';
 
 import { ScreenCapture, hasCapturableScreen } from './lib/screen-helpers';
 import { defer, ifit, startRemoteControlApp } from './lib/spec-helpers';

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -2,17 +2,17 @@ import { app, BrowserWindow, BrowserView, dialog, ipcMain, OnBeforeSendHeadersLi
 
 import { expect } from 'chai';
 
-import * as childProcess from 'node:child_process';
+import childProcess from 'node:child_process';
 import { once } from 'node:events';
-import * as fs from 'node:fs';
-import * as http from 'node:http';
+import fs from 'node:fs';
+import http from 'node:http';
 import { AddressInfo } from 'node:net';
-import * as os from 'node:os';
-import * as path from 'node:path';
-import * as qs from 'node:querystring';
+import os from 'node:os';
+import path from 'node:path';
+import qs from 'node:querystring';
 import { setTimeout as syncSetTimeout } from 'node:timers';
 import { setTimeout } from 'node:timers/promises';
-import * as nodeUrl from 'node:url';
+import nodeUrl from 'node:url';
 
 import { emittedUntil, emittedNTimes } from './lib/events-helpers';
 import { randomString } from './lib/net-helpers';

--- a/spec/api-clipboard-spec.ts
+++ b/spec/api-clipboard-spec.ts
@@ -3,7 +3,7 @@ import { clipboard, nativeImage } from 'electron/common';
 import { expect } from 'chai';
 
 import { Buffer } from 'node:buffer';
-import * as path from 'node:path';
+import path from 'node:path';
 
 import { ifdescribe, ifit } from './lib/spec-helpers';
 

--- a/spec/api-content-tracing-spec.ts
+++ b/spec/api-content-tracing-spec.ts
@@ -2,8 +2,8 @@ import { app, contentTracing, TraceConfig, TraceCategoriesAndOptions } from 'ele
 
 import { expect } from 'chai';
 
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
 import { ifdescribe } from './lib/spec-helpers';

--- a/spec/api-context-bridge-spec.ts
+++ b/spec/api-context-bridge-spec.ts
@@ -3,12 +3,12 @@ import { contextBridge } from 'electron/renderer';
 
 import { expect } from 'chai';
 
-import * as cp from 'node:child_process';
+import cp from 'node:child_process';
 import { once } from 'node:events';
-import * as fs from 'node:fs';
-import * as http from 'node:http';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
 
 import { listen } from './lib/spec-helpers';
 import { closeWindow } from './lib/window-helpers';

--- a/spec/api-crash-reporter-spec.ts
+++ b/spec/api-crash-reporter-spec.ts
@@ -1,14 +1,14 @@
 import { app } from 'electron/main';
 
-import * as Busboy from 'busboy';
+import Busboy from 'busboy';
 import { expect } from 'chai';
-import * as uuid from 'uuid';
+import uuid from 'uuid';
 
-import * as childProcess from 'node:child_process';
+import childProcess from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import * as fs from 'node:fs';
-import * as http from 'node:http';
-import * as path from 'node:path';
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
 import { ifdescribe, ifit, defer, startRemoteControlApp, repeatedly, listen } from './lib/spec-helpers';

--- a/spec/api-debugger-spec.ts
+++ b/spec/api-debugger-spec.ts
@@ -3,8 +3,8 @@ import { BrowserWindow } from 'electron/main';
 import { expect } from 'chai';
 
 import { once } from 'node:events';
-import * as http from 'node:http';
-import * as path from 'node:path';
+import http from 'node:http';
+import path from 'node:path';
 
 import { emittedUntil } from './lib/events-helpers';
 import { listen } from './lib/spec-helpers';

--- a/spec/api-image-view-spec.ts
+++ b/spec/api-image-view-spec.ts
@@ -3,7 +3,7 @@ import { BaseWindow, BrowserWindow, ImageView } from 'electron/main';
 
 import { expect } from 'chai';
 
-import * as path from 'node:path';
+import path from 'node:path';
 
 import { closeAllWindows } from './lib/window-helpers';
 

--- a/spec/api-ipc-main-spec.ts
+++ b/spec/api-ipc-main-spec.ts
@@ -2,9 +2,9 @@ import { ipcMain, BrowserWindow } from 'electron/main';
 
 import { expect } from 'chai';
 
-import * as cp from 'node:child_process';
+import cp from 'node:child_process';
 import { once } from 'node:events';
-import * as path from 'node:path';
+import path from 'node:path';
 
 import { defer } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';

--- a/spec/api-ipc-spec.ts
+++ b/spec/api-ipc-spec.ts
@@ -3,8 +3,8 @@ import { BrowserWindow, ipcMain, IpcMainInvokeEvent, MessageChannelMain, WebCont
 import { expect } from 'chai';
 
 import { EventEmitter, once } from 'node:events';
-import * as http from 'node:http';
-import * as path from 'node:path';
+import http from 'node:http';
+import path from 'node:path';
 
 import { defer, listen } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';

--- a/spec/api-media-handler-spec.ts
+++ b/spec/api-media-handler-spec.ts
@@ -2,7 +2,7 @@ import { BrowserWindow, session, desktopCapturer } from 'electron/main';
 
 import { expect } from 'chai';
 
-import * as http from 'node:http';
+import http from 'node:http';
 
 import { ifit, listen } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';

--- a/spec/api-menu-spec.ts
+++ b/spec/api-menu-spec.ts
@@ -2,9 +2,9 @@ import { BrowserWindow, Menu, MenuItem } from 'electron/main';
 
 import { assert, expect } from 'chai';
 
-import * as cp from 'node:child_process';
+import cp from 'node:child_process';
 import { once } from 'node:events';
-import * as path from 'node:path';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
 import { singleModifierCombinations } from './lib/accelerator-helpers';

--- a/spec/api-native-image-spec.ts
+++ b/spec/api-native-image-spec.ts
@@ -2,7 +2,7 @@ import { nativeImage } from 'electron/common';
 
 import { expect } from 'chai';
 
-import * as path from 'node:path';
+import path from 'node:path';
 
 import { ifdescribe, ifit, itremote, useRemoteContext } from './lib/spec-helpers';
 import { expectDeprecationMessages } from './lib/warning-helpers';

--- a/spec/api-native-theme-spec.ts
+++ b/spec/api-native-theme-spec.ts
@@ -3,7 +3,7 @@ import { nativeTheme, BrowserWindow, ipcMain } from 'electron/main';
 import { expect } from 'chai';
 
 import { once } from 'node:events';
-import * as path from 'node:path';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
 import { closeAllWindows } from './lib/window-helpers';

--- a/spec/api-net-custom-protocols-spec.ts
+++ b/spec/api-net-custom-protocols-spec.ts
@@ -2,8 +2,8 @@ import { net, protocol } from 'electron/main';
 
 import { expect } from 'chai';
 
-import * as path from 'node:path';
-import * as url from 'node:url';
+import path from 'node:path';
+import url from 'node:url';
 
 import { defer } from './lib/spec-helpers';
 

--- a/spec/api-net-log-spec.ts
+++ b/spec/api-net-log-spec.ts
@@ -2,13 +2,13 @@ import { session, net } from 'electron/main';
 
 import { expect } from 'chai';
 
-import * as ChildProcess from 'node:child_process';
+import ChildProcess from 'node:child_process';
 import { once } from 'node:events';
-import * as fs from 'node:fs';
-import * as http from 'node:http';
+import fs from 'node:fs';
+import http from 'node:http';
 import { Socket } from 'node:net';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import os from 'node:os';
+import path from 'node:path';
 
 import { ifit, listen } from './lib/spec-helpers';
 

--- a/spec/api-net-session-spec.ts
+++ b/spec/api-net-session-spec.ts
@@ -2,7 +2,7 @@ import { net, session, BrowserWindow, ClientRequestConstructorOptions } from 'el
 
 import { expect } from 'chai';
 
-import * as dns from 'node:dns';
+import dns from 'node:dns';
 
 import { collectStreamBody, getResponse, respondNTimes, respondOnce } from './lib/net-helpers';
 

--- a/spec/api-net-spec.ts
+++ b/spec/api-net-spec.ts
@@ -3,10 +3,10 @@ import { net, session, ClientRequest, ClientRequestConstructorOptions, utilityPr
 import { expect } from 'chai';
 
 import { once } from 'node:events';
-import * as fs from 'node:fs';
-import * as http from 'node:http';
-import * as http2 from 'node:http2';
-import * as path from 'node:path';
+import fs from 'node:fs';
+import http from 'node:http';
+import http2 from 'node:http2';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
 import { collectStreamBody, collectStreamBodyBuffer, getResponse, kOneKiloByte, kOneMegaByte, randomBuffer, randomString, respondNTimes, respondOnce } from './lib/net-helpers';

--- a/spec/api-notification-dbus-spec.ts
+++ b/spec/api-notification-dbus-spec.ts
@@ -10,9 +10,9 @@ import { nativeImage } from 'electron/common';
 import { app } from 'electron/main';
 
 import { expect } from 'chai';
-import * as dbus from 'dbus-native';
+import dbus from 'dbus-native';
 
-import * as path from 'node:path';
+import path from 'node:path';
 import { promisify } from 'node:util';
 
 import { ifdescribe } from './lib/spec-helpers';

--- a/spec/api-power-monitor-spec.ts
+++ b/spec/api-power-monitor-spec.ts
@@ -7,7 +7,7 @@
 // See https://pypi.python.org/pypi/python-dbusmock for more information about
 // python-dbusmock.
 import { expect } from 'chai';
-import * as dbus from 'dbus-native';
+import dbus from 'dbus-native';
 
 import { once } from 'node:events';
 import { setTimeout } from 'node:timers/promises';

--- a/spec/api-process-spec.ts
+++ b/spec/api-process-spec.ts
@@ -3,8 +3,8 @@ import { app } from 'electron/main';
 
 import { expect } from 'chai';
 
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import { defer } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -3,17 +3,17 @@ import { protocol, webContents, WebContents, session, BrowserWindow, ipcMain, ne
 import { expect } from 'chai';
 import { v4 } from 'uuid';
 
-import * as ChildProcess from 'node:child_process';
+import ChildProcess from 'node:child_process';
 import { EventEmitter, once } from 'node:events';
-import * as fs from 'node:fs';
-import * as http from 'node:http';
-import * as path from 'node:path';
-import * as qs from 'node:querystring';
-import * as stream from 'node:stream';
-import * as streamConsumers from 'node:stream/consumers';
-import * as webStream from 'node:stream/web';
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+import qs from 'node:querystring';
+import stream from 'node:stream';
+import streamConsumers from 'node:stream/consumers';
+import webStream from 'node:stream/web';
 import { setTimeout } from 'node:timers/promises';
-import * as url from 'node:url';
+import url from 'node:url';
 
 import { collectStreamBody, getResponse } from './lib/net-helpers';
 import { listen, defer, ifit } from './lib/spec-helpers';

--- a/spec/api-safe-storage-spec.ts
+++ b/spec/api-safe-storage-spec.ts
@@ -2,10 +2,10 @@ import { safeStorage } from 'electron/main';
 
 import { expect } from 'chai';
 
-import * as cp from 'node:child_process';
+import cp from 'node:child_process';
 import { once } from 'node:events';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import { ifdescribe } from './lib/spec-helpers';
 

--- a/spec/api-service-worker-main-spec.ts
+++ b/spec/api-service-worker-main-spec.ts
@@ -3,9 +3,9 @@ import { ipcMain, session, webContents as webContentsModule, WebContents } from 
 import { expect } from 'chai';
 
 import { once, on } from 'node:events';
-import * as fs from 'node:fs';
-import * as http from 'node:http';
-import * as path from 'node:path';
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
 
 import { listen, waitUntil } from './lib/spec-helpers';
 

--- a/spec/api-service-workers-spec.ts
+++ b/spec/api-service-workers-spec.ts
@@ -4,9 +4,9 @@ import { expect } from 'chai';
 import { v4 } from 'uuid';
 
 import { on, once } from 'node:events';
-import * as fs from 'node:fs';
-import * as http from 'node:http';
-import * as path from 'node:path';
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
 
 import { listen } from './lib/spec-helpers';
 

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -1,15 +1,15 @@
 import { app, session, BrowserWindow, net, ipcMain, Session, webFrameMain, WebFrameMain } from 'electron/main';
 
-import * as auth from 'basic-auth';
+import auth from 'basic-auth';
 import { expect } from 'chai';
-import * as send from 'send';
+import send from 'send';
 
-import * as ChildProcess from 'node:child_process';
+import ChildProcess from 'node:child_process';
 import { once } from 'node:events';
-import * as fs from 'node:fs';
-import * as http from 'node:http';
-import * as https from 'node:https';
-import * as path from 'node:path';
+import fs from 'node:fs';
+import http from 'node:http';
+import https from 'node:https';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
 import { defer, ifit, listen } from './lib/spec-helpers';

--- a/spec/api-shared-texture-spec.ts
+++ b/spec/api-shared-texture-spec.ts
@@ -3,7 +3,7 @@ import { BaseWindow } from 'electron';
 import { expect } from 'chai';
 
 import { randomUUID } from 'node:crypto';
-import * as path from 'node:path';
+import path from 'node:path';
 
 import { ifdescribe } from './lib/spec-helpers';
 import { closeWindow } from './lib/window-helpers';

--- a/spec/api-shell-spec.ts
+++ b/spec/api-shell-spec.ts
@@ -5,10 +5,10 @@ import { expect } from 'chai';
 
 import { execSync } from 'node:child_process';
 import { once } from 'node:events';
-import * as fs from 'node:fs';
-import * as http from 'node:http';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
 
 import { ifdescribe, ifit, listen } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';

--- a/spec/api-subframe-spec.ts
+++ b/spec/api-subframe-spec.ts
@@ -3,8 +3,8 @@ import { app, BrowserWindow, ipcMain } from 'electron/main';
 import { expect } from 'chai';
 
 import { once } from 'node:events';
-import * as http from 'node:http';
-import * as path from 'node:path';
+import http from 'node:http';
+import path from 'node:path';
 
 import { emittedNTimes } from './lib/events-helpers';
 import { ifdescribe, listen } from './lib/spec-helpers';

--- a/spec/api-touch-bar-spec.ts
+++ b/spec/api-touch-bar-spec.ts
@@ -2,7 +2,7 @@ import { BaseWindow, BrowserWindow, TouchBar } from 'electron/main';
 
 import { expect } from 'chai';
 
-import * as path from 'node:path';
+import path from 'node:path';
 
 import { closeWindow } from './lib/window-helpers';
 

--- a/spec/api-tray-spec.ts
+++ b/spec/api-tray-spec.ts
@@ -3,7 +3,7 @@ import { Menu, Tray } from 'electron/main';
 
 import { expect } from 'chai';
 
-import * as path from 'node:path';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
 import { ifdescribe, ifit } from './lib/spec-helpers';

--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -3,11 +3,11 @@ import { BrowserWindow, MessageChannelMain, utilityProcess, app } from 'electron
 
 import { expect } from 'chai';
 
-import * as childProcess from 'node:child_process';
+import childProcess from 'node:child_process';
 import { once } from 'node:events';
-import * as fs from 'node:fs/promises';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { setImmediate } from 'node:timers/promises';
 import { pathToFileURL } from 'node:url';
 

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2,15 +2,15 @@ import { BrowserWindow, ipcMain, webContents, session, app, BrowserView, WebCont
 
 import { assert, expect } from 'chai';
 
-import * as cp from 'node:child_process';
+import cp from 'node:child_process';
 import { once } from 'node:events';
-import * as fs from 'node:fs';
-import * as http from 'node:http';
+import fs from 'node:fs';
+import http from 'node:http';
 import { AddressInfo } from 'node:net';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import os from 'node:os';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
-import * as url from 'node:url';
+import url from 'node:url';
 
 import { ifdescribe, defer, waitUntil, listen, ifit } from './lib/spec-helpers';
 import { cleanupWebContents, closeAllWindows } from './lib/window-helpers';

--- a/spec/api-web-frame-main-spec.ts
+++ b/spec/api-web-frame-main-spec.ts
@@ -3,10 +3,10 @@ import { BrowserWindow, WebFrameMain, webFrameMain, ipcMain, app, WebContents } 
 import { expect } from 'chai';
 
 import { once } from 'node:events';
-import * as http from 'node:http';
-import * as path from 'node:path';
+import http from 'node:http';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
-import * as url from 'node:url';
+import url from 'node:url';
 
 import { emittedNTimes } from './lib/events-helpers';
 import { defer, ifit, listen, waitUntil } from './lib/spec-helpers';

--- a/spec/api-web-frame-spec.ts
+++ b/spec/api-web-frame-spec.ts
@@ -3,7 +3,7 @@ import { BrowserWindow, ipcMain, WebContents } from 'electron/main';
 import { expect } from 'chai';
 
 import { once } from 'node:events';
-import * as path from 'node:path';
+import path from 'node:path';
 
 import { defer } from './lib/spec-helpers';
 

--- a/spec/api-web-request-spec.ts
+++ b/spec/api-web-request-spec.ts
@@ -1,17 +1,17 @@
 import { ipcMain, net, protocol, session, WebContents, webContents } from 'electron/main';
 
 import { expect } from 'chai';
-import * as WebSocket from 'ws';
+import WebSocket from 'ws';
 
 import { once } from 'node:events';
-import * as fs from 'node:fs';
-import * as http from 'node:http';
-import * as http2 from 'node:http2';
+import fs from 'node:fs';
+import http from 'node:http';
+import http2 from 'node:http2';
 import { Socket } from 'node:net';
-import * as path from 'node:path';
-import * as qs from 'node:querystring';
+import path from 'node:path';
+import qs from 'node:querystring';
 import { ReadableStream } from 'node:stream/web';
-import * as url from 'node:url';
+import url from 'node:url';
 
 import { listen, defer } from './lib/spec-helpers';
 

--- a/spec/api-web-utils-spec.ts
+++ b/spec/api-web-utils-spec.ts
@@ -2,7 +2,7 @@ import { BrowserWindow } from 'electron/main';
 
 import { expect } from 'chai';
 
-import * as path from 'node:path';
+import path from 'node:path';
 
 import { defer } from './lib/spec-helpers';
 

--- a/spec/asar-integrity-spec.ts
+++ b/spec/asar-integrity-spec.ts
@@ -3,13 +3,13 @@ import { flipFuses, FuseV1Config, FuseV1Options, FuseVersion } from '@electron/f
 import { resedit } from '@electron/packager/dist/resedit';
 
 import { expect } from 'chai';
-import * as originalFs from 'node:original-fs';
+import originalFs from 'node:original-fs';
 
-import * as cp from 'node:child_process';
-import * as nodeCrypto from 'node:crypto';
-import * as fs from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import cp from 'node:child_process';
+import nodeCrypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import { copyApp } from './lib/fs-helpers';
 import { ifdescribe } from './lib/spec-helpers';

--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -3,9 +3,9 @@ import { BrowserWindow, ipcMain } from 'electron/main';
 import { expect } from 'chai';
 
 import { once } from 'node:events';
-import * as importedFs from 'node:fs';
-import * as path from 'node:path';
-import * as url from 'node:url';
+import importedFs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
 import { Worker } from 'node:worker_threads';
 
 import { getRemoteContext, ifdescribe, ifit, itremote, useRemoteContext } from './lib/spec-helpers';

--- a/spec/autofill-spec.ts
+++ b/spec/autofill-spec.ts
@@ -2,7 +2,7 @@ import { BrowserWindow } from 'electron';
 
 import { expect } from 'chai';
 
-import * as path from 'node:path';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
 import { closeAllWindows } from './lib/window-helpers';

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -3,17 +3,17 @@ import { clipboard } from 'electron/common';
 import { BrowserWindow, WebContents, webFrameMain, session, ipcMain, app, protocol, webContents, dialog, MessageBoxOptions } from 'electron/main';
 
 import { expect } from 'chai';
-import * as ws from 'ws';
+import ws from 'ws';
 
-import * as ChildProcess from 'node:child_process';
+import ChildProcess from 'node:child_process';
 import { EventEmitter, once } from 'node:events';
-import * as fs from 'node:fs';
-import * as http from 'node:http';
-import * as https from 'node:https';
+import fs from 'node:fs';
+import http from 'node:http';
+import https from 'node:https';
 import { AddressInfo } from 'node:net';
-import * as path from 'node:path';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
-import * as url from 'node:url';
+import url from 'node:url';
 
 import { ifit, ifdescribe, defer, itremote, listen, startRemoteControlApp, waitUntil } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';

--- a/spec/cpp-heap-spec.ts
+++ b/spec/cpp-heap-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import * as path from 'node:path';
+import path from 'node:path';
 
 import { startRemoteControlApp } from './lib/spec-helpers';
 

--- a/spec/crash-spec.ts
+++ b/spec/crash-spec.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 
-import * as cp from 'node:child_process';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import cp from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import { ifit, waitUntil } from './lib/spec-helpers';
 

--- a/spec/deprecate-spec.ts
+++ b/spec/deprecate-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import * as deprecate from '../lib/common/deprecate';
+import deprecate from '../lib/common/deprecate';
 
 describe('deprecate', () => {
   let throwing: boolean;

--- a/spec/esm-spec.ts
+++ b/spec/esm-spec.ts
@@ -2,10 +2,10 @@ import { BrowserWindow } from 'electron';
 
 import { expect } from 'chai';
 
-import * as cp from 'node:child_process';
-import * as fs from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import cp from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { stripVTControlCharacters } from 'node:util';
 

--- a/spec/extensions-spec.ts
+++ b/spec/extensions-spec.ts
@@ -1,12 +1,12 @@
 import { app, session, webFrameMain, BrowserWindow, ipcMain, WebContents, Extension, Session } from 'electron/main';
 
 import { expect } from 'chai';
-import * as WebSocket from 'ws';
+import WebSocket from 'ws';
 
 import { once } from 'node:events';
-import * as fs from 'node:fs/promises';
-import * as http from 'node:http';
-import * as path from 'node:path';
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import path from 'node:path';
 
 import { emittedNTimes, emittedUntil } from './lib/events-helpers';
 import { ifit, listen, waitUntil } from './lib/spec-helpers';

--- a/spec/fixtures/esm/entrypoint.mjs
+++ b/spec/fixtures/esm/entrypoint.mjs
@@ -1,4 +1,4 @@
-import * as electron from 'electron';
+import electron from 'electron';
 
 console.log('ESM Launch, ready:', electron.app.isReady());
 process.exit(0);

--- a/spec/fixtures/esm/package/index.mjs
+++ b/spec/fixtures/esm/package/index.mjs
@@ -1,4 +1,4 @@
-import * as electron from 'electron';
+import electron from 'electron';
 
 console.log('ESM Package Launch, ready:', electron.app.isReady());
 process.exit(0);

--- a/spec/fixtures/esm/pre-app-ready-apis.mjs
+++ b/spec/fixtures/esm/pre-app-ready-apis.mjs
@@ -1,4 +1,4 @@
-import * as electron from 'electron';
+import electron from 'electron';
 
 try {
   electron.app.disableHardwareAcceleration();

--- a/spec/fixtures/esm/top-level-await.mjs
+++ b/spec/fixtures/esm/top-level-await.mjs
@@ -1,4 +1,4 @@
-import * as electron from 'electron';
+import electron from 'electron';
 
 // Cheeky delay
 await new Promise((resolve) => setTimeout(resolve, 500));

--- a/spec/get-files.ts
+++ b/spec/get-files.ts
@@ -1,5 +1,5 @@
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 export async function getFiles (
   dir: string,

--- a/spec/guest-window-manager-spec.ts
+++ b/spec/guest-window-manager-spec.ts
@@ -3,8 +3,8 @@ import { BrowserWindow, screen } from 'electron';
 import { expect, assert } from 'chai';
 
 import { once } from 'node:events';
-import * as http from 'node:http';
-import * as nodePath from 'node:path';
+import http from 'node:http';
+import nodePath from 'node:path';
 
 import { HexColors, ScreenCapture, hasCapturableScreen } from './lib/screen-helpers';
 import { ifit, listen } from './lib/spec-helpers';

--- a/spec/lib/codesign-helpers.ts
+++ b/spec/lib/codesign-helpers.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 
-import * as cp from 'node:child_process';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import cp from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const features = process._linkedBinding('electron_common_features');
 const fixturesPath = path.resolve(__dirname, '..', 'fixtures');

--- a/spec/lib/fs-helpers.ts
+++ b/spec/lib/fs-helpers.ts
@@ -1,8 +1,8 @@
-import * as fs from 'original-fs';
+import fs from 'original-fs';
 
-import * as cp from 'node:child_process';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import cp from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
 
 export async function copyApp (targetDir: string): Promise<string> {
   // On macOS we can just copy the app bundle, easier too because of symlinks

--- a/spec/lib/net-helpers.ts
+++ b/spec/lib/net-helpers.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
-import * as dns from 'node:dns';
-import * as http from 'node:http';
+import dns from 'node:dns';
+import http from 'node:http';
 import { Socket } from 'node:net';
 
 import { defer, listen } from './spec-helpers';

--- a/spec/lib/spec-helpers.ts
+++ b/spec/lib/spec-helpers.ts
@@ -3,15 +3,15 @@ import { BrowserWindow } from 'electron/main';
 import { AssertionError } from 'chai';
 import { SuiteFunction, TestFunction } from 'mocha';
 
-import * as childProcess from 'node:child_process';
-import * as http from 'node:http';
-import * as http2 from 'node:http2';
-import * as https from 'node:https';
-import * as net from 'node:net';
-import * as path from 'node:path';
+import childProcess from 'node:child_process';
+import http from 'node:http';
+import http2 from 'node:http2';
+import https from 'node:https';
+import net from 'node:net';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
-import * as url from 'node:url';
-import * as v8 from 'node:v8';
+import url from 'node:url';
+import v8 from 'node:v8';
 
 const addOnly = <T>(fn: Function): T => {
   const wrapped = (...args: any[]) => {

--- a/spec/logging-spec.ts
+++ b/spec/logging-spec.ts
@@ -1,11 +1,11 @@
 import { app } from 'electron';
 
 import { expect } from 'chai';
-import * as uuid from 'uuid';
+import uuid from 'uuid';
 
 import { once } from 'node:events';
-import * as fs from 'node:fs/promises';
-import * as path from 'node:path';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 
 import { startRemoteControlApp, ifdescribe, ifit } from './lib/spec-helpers';
 

--- a/spec/modules-spec.ts
+++ b/spec/modules-spec.ts
@@ -2,10 +2,10 @@ import { BrowserWindow, utilityProcess } from 'electron/main';
 
 import { expect } from 'chai';
 
-import * as childProcess from 'node:child_process';
+import childProcess from 'node:child_process';
 import { once } from 'node:events';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import { ifdescribe, ifit } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -2,12 +2,12 @@ import { webContents } from 'electron/main';
 
 import { expect } from 'chai';
 
-import * as childProcess from 'node:child_process';
+import childProcess from 'node:child_process';
 import { once } from 'node:events';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { EventEmitter } from 'node:stream';
-import * as util from 'node:util';
+import util from 'node:util';
 
 import { copyMacOSFixtureApp, getCodesignIdentity, shouldRunCodesignTests, signApp, spawn } from './lib/codesign-helpers';
 import { withTempDirectory } from './lib/fs-helpers';

--- a/spec/release-notes-spec.ts
+++ b/spec/release-notes-spec.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
-import * as sinon from 'sinon';
+import sinon from 'sinon';
 
 import { SpawnSyncReturns } from 'node:child_process';
-import * as path from 'node:path';
+import path from 'node:path';
 
-import * as notes from '../script/release/notes/notes';
+import notes from '../script/release/notes/notes';
 
 /* Fake a git spawnSync that only returns the specific
    commits that we want to test */

--- a/spec/security-warnings-spec.ts
+++ b/spec/security-warnings-spec.ts
@@ -2,9 +2,9 @@ import { BrowserWindow, WebPreferences } from 'electron/main';
 
 import { expect } from 'chai';
 
-import * as fs from 'node:fs/promises';
-import * as http from 'node:http';
-import * as path from 'node:path';
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
 import { emittedUntil } from './lib/events-helpers';

--- a/spec/spellchecker-spec.ts
+++ b/spec/spellchecker-spec.ts
@@ -3,9 +3,9 @@ import { BrowserWindow, Session, session } from 'electron/main';
 import { expect } from 'chai';
 
 import { once } from 'node:events';
-import * as fs from 'node:fs/promises';
-import * as http from 'node:http';
-import * as path from 'node:path';
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
 import { ifit, ifdescribe, listen } from './lib/spec-helpers';

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -24,7 +24,7 @@ import {
 } from 'electron/main';
 
 import { clipboard, crashReporter, nativeImage, shell } from 'electron/common';
-import * as path from 'node:path';
+import path from 'node:path';
 
 // Quick start
 // https://github.com/electron/electron/blob/main/docs/tutorial/quick-start.md

--- a/spec/version-bump-spec.ts
+++ b/spec/version-bump-spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import * as sinon from 'sinon';
+import sinon from 'sinon';
 
 import { SpawnSyncReturns } from 'node:child_process';
 

--- a/spec/visibility-state-spec.ts
+++ b/spec/visibility-state-spec.ts
@@ -2,9 +2,9 @@ import { BaseWindow, BrowserWindow, BrowserWindowConstructorOptions, webContents
 
 import { expect } from 'chai';
 
-import * as cp from 'node:child_process';
+import cp from 'node:child_process';
 import { once } from 'node:events';
-import * as path from 'node:path';
+import path from 'node:path';
 
 import { ifdescribe, waitUntil } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';

--- a/spec/webview-spec.ts
+++ b/spec/webview-spec.ts
@@ -1,13 +1,13 @@
 import { BrowserWindow, session, ipcMain, app, WebContents } from 'electron/main';
 
-import * as auth from 'basic-auth';
+import auth from 'basic-auth';
 import { expect } from 'chai';
 
 import { once } from 'node:events';
-import * as http from 'node:http';
-import * as path from 'node:path';
+import http from 'node:http';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
-import * as url from 'node:url';
+import url from 'node:url';
 
 import { emittedUntil } from './lib/events-helpers';
 import { HexColors, ScreenCapture, hasCapturableScreen } from './lib/screen-helpers';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "paths": {
       "@electron/internal/*": ["lib/*"],
       "@node/*": ["../third_party/electron_node/*"]
-    }
+    },
+    "esModuleInterop": true,
   },
   "exclude": [
     "electron.d.ts"


### PR DESCRIPTION
#### Description of Change

- Enable [`esModuleInterop`](https://www.typescriptlang.org/tsconfig/#esModuleInterop) in TypeScript,
- Added missings `node:` prefixes,
- Simplify imports without asterisk
    ```js
    import * as fs from 'node:fs'
    // -->
    import fs from 'node:fs'
    ```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
