### PR TITLE
fix: warning: default arguments on virtual or override methods

### DIFF
--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -106,9 +106,9 @@ class NativeWindow : public base::SupportsUserData,
   void SetPosition(const gfx::Point& position, bool animate = false);
   [[nodiscard]] gfx::Point GetPosition() const;
 
-  virtual void SetContentSize(const gfx::Size& size, bool animate = false);
+  void SetContentSize(const gfx::Size& size, bool animate = false);
   virtual gfx::Size GetContentSize() const;
-  virtual void SetContentBounds(const gfx::Rect& bounds, bool animate = false);
+  void SetContentBounds(const gfx::Rect& bounds, bool animate = false);
   virtual gfx::Rect GetContentBounds() const;
   virtual bool IsNormal() const;
   virtual gfx::Rect GetNormalBounds() const = 0;


### PR DESCRIPTION
#### Description of Change

Fix the last couple of warnings found by #49072 that weren't fixed by #49083. On rereading this code, it was simpler than I expected: we never override these methods, so just make them nonvirtual.

CC @dsanders11 

#### Checklist

- [x] PR description included
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.