### PR TITLE
fix: renderer freeze after failed fullscreen during macOS Spaces transition

### DIFF
--- a/notes/fix-macos-fullscreen-freeze.md
+++ b/notes/fix-macos-fullscreen-freeze.md
@@ -1,0 +1,3 @@
+## macOS
+
+- Fixed a regression where `BrowserWindow` contents could freeze after a failed fullscreen transition on macOS.

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -279,10 +279,10 @@ v8::Local<v8::Value> BrowserWindow::GetWebContents(v8::Isolate* isolate) {
   return v8::Local<v8::Value>::New(isolate, web_contents_);
 }
 void BrowserWindow::OnWindowShow() {
-+  if (web_contents() &&
-+      web_contents()->GetVisibility() != content::Visibility::VISIBLE) {
-+    web_contents()->WasShown();
-+  }
+ if (web_contents() &&
+      web_contents()->GetVisibility() != content::Visibility::VISIBLE) {
+    web_contents()->WasShown();
+    }
    BaseWindow::OnWindowShow();
 }
 


### PR DESCRIPTION
## Issue
Regression introduced in #47151 causes the renderer to freeze on macOS
when a fullscreen request fails during a Spaces transition.

## Root Cause
During a failed fullscreen attempt, macOS briefly reports the window as
occluded, triggering BrowserWindow::OnWindowHide. Since #47151,
BrowserWindow::OnWindowShow no longer calls WebContents::WasShown,
leaving Chromium thinking the page is hidden and stopping rendering.

## Fix
Ensure WebContents::WasShown is called when the window becomes visible
again, guarded to avoid duplicate calls already handled by Show().

## Repro
https://gist.github.com/cptpcrd/bf28bf81d7cd4c4f4197367b54c708ba

## Regression
Works in 37.7.0, broken in 37.7.1+
