### PR TITLE
docs: correct yarn part of `tutorial-5-packaging`

### DIFF
--- a/docs/tutorial/tutorial-5-packaging.md
+++ b/docs/tutorial/tutorial-5-packaging.md
@@ -44,10 +44,24 @@ have to worry about wiring them all together.
 You can install Electron Forge's CLI in your project's `devDependencies` and import your
 existing project with a handy conversion script.
 
-```sh npm2yarn
+<Tabs>
+  <TabItem value="npm" label="npm">
+
+```sh
 npm install --save-dev @electron-forge/cli
 npx electron-forge import
 ```
+
+  </TabItem>
+  <TabItem value="yarn" label="Yarn">
+
+```sh
+yarn add --dev @electron-forge/cli
+yarn electron-forge import
+```
+
+  </TabItem>
+</Tabs>
 
 Once the conversion script is done, Forge should have added a few scripts
 to your `package.json` file.


### PR DESCRIPTION
#### Description of Change

used Tabs component instead of `npm2yarn` directive, since it was configured to use `yarn dlx` for `npx` which fails for electron forge. docs now point to use local version of electron-forge.
<img width="1037" height="240" alt="Screenshot 2026-01-15 at 00 34 09" src="https://github.com/user-attachments/assets/c3414ae7-35b4-4002-94c0-eead11381b4f" />
<img width="683" height="316" alt="image" src="https://github.com/user-attachments/assets/fc6845ca-0401-41f1-9542-919c2d5e93f6" />

tested on yarn 4.9 and yarn 4.12, for node 22.20.0 and 24.11.1.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: updated `tutorial-5-packaging.md` to no longer crash when using yarn.
