### PR TITLE
feat: allow showing a window without foregrounding it on macOS

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -586,7 +586,12 @@ Returns `boolean` - Whether the window is destroyed.
 
 Shows and gives focus to the window.
 
-#### `win.showInactive()`
+#### `win.showInactive([options])`
+
+* `options` Object (optional)
+  * `bringToFront` boolean (optional) - Whether to bring the window to the
+    front of the window stack. Default is `true`. Set to `false` to show
+    the window at the back of the stack. _macOS_
 
 Shows the window but doesn't focus on it.
 

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -589,9 +589,9 @@ Shows and gives focus to the window.
 #### `win.showInactive([options])`
 
 * `options` Object (optional)
-  * `bringToFront` boolean (optional) - Whether to bring the window to the
-    front of the window stack. Default is `true`. Set to `false` to show
-    the window at the back of the stack. _macOS_
+  * `bringToFront` boolean (optional) _macOS_ - Whether to bring the window
+    to the front of the window stack. Default is `true`. Set to `false` to
+    show the window at the back of the stack.
 
 Shows the window but doesn't focus on it.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -688,9 +688,9 @@ Shows and gives focus to the window.
 #### `win.showInactive([options])`
 
 * `options` Object (optional)
-  * `bringToFront` boolean (optional) - Whether to bring the window to the
-    front of the window stack. Default is `true`. Set to `false` to show
-    the window at the back of the stack. _macOS_
+  * `bringToFront` boolean (optional) _macOS_ - Whether to bring the window
+    to the front of the window stack. Default is `true`. Set to `false` to
+    show the window at the back of the stack.
 
 Shows the window but doesn't focus on it.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -685,7 +685,12 @@ Returns `boolean` - Whether the window is destroyed.
 
 Shows and gives focus to the window.
 
-#### `win.showInactive()`
+#### `win.showInactive([options])`
+
+* `options` Object (optional)
+  * `bringToFront` boolean (optional) - Whether to bring the window to the
+    front of the window stack. Default is `true`. Set to `false` to show
+    the window at the back of the stack. _macOS_
 
 Shows the window but doesn't focus on it.
 

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -380,11 +380,16 @@ void BaseWindow::Show() {
   window_->Show();
 }
 
-void BaseWindow::ShowInactive() {
+void BaseWindow::ShowInactive(gin::Arguments* args) {
   // This method doesn't make sense for modal window.
   if (IsModal())
     return;
-  window_->ShowInactive();
+  gin_helper::Dictionary options;
+  bool bring_to_front = true;
+  if (args->GetNext(&options)) {
+    options.Get("bringToFront", &bring_to_front);
+  }
+  window_->ShowInactive(bring_to_front);
 }
 
 void BaseWindow::Hide() {

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -106,7 +106,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   virtual void Blur();
   bool IsFocused() const;
   virtual void Show();
-  virtual void ShowInactive();
+  virtual void ShowInactive(gin::Arguments* args);
   void Hide();
   bool IsVisible() const;
   bool IsEnabled() const;

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -289,12 +289,12 @@ void BrowserWindow::Show() {
   BaseWindow::Show();
 }
 
-void BrowserWindow::ShowInactive() {
+void BrowserWindow::ShowInactive(gin::Arguments* args) {
   // This method doesn't make sense for modal window.
   if (IsModal())
     return;
   web_contents()->WasShown();
-  BaseWindow::ShowInactive();
+  BaseWindow::ShowInactive(args);
 }
 
 // static

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -68,7 +68,7 @@ class BrowserWindow : public BaseWindow,
   void OnWindowShow() override;
   void OnWindowHide() override;
   void Show() override;
-  void ShowInactive() override;
+  void ShowInactive(gin::Arguments* args) override;
 
   // BrowserWindow APIs.
   void FocusOnWebView();

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -82,7 +82,7 @@ class NativeWindow : public views::WidgetDelegate {
   virtual void Focus(bool focus) = 0;
   virtual bool IsFocused() const = 0;
   virtual void Show() = 0;
-  virtual void ShowInactive() = 0;
+  virtual void ShowInactive(bool bring_to_front = true) = 0;
   virtual void Hide() = 0;
   virtual bool IsVisible() const = 0;
   virtual bool IsEnabled() const = 0;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -47,7 +47,7 @@ class NativeWindowMac : public NativeWindow,
   void Focus(bool focus) override;
   bool IsFocused() const override;
   void Show() override;
-  void ShowInactive() override;
+  void ShowInactive(bool bring_to_front = true) override;
   void Hide() override;
   bool IsVisible() const override;
   bool IsEnabled() const override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -466,7 +466,7 @@ void NativeWindowMac::Show() {
   [window_ makeKeyAndOrderFront:nil];
 }
 
-void NativeWindowMac::ShowInactive() {
+void NativeWindowMac::ShowInactive(bool bring_to_front) {
   set_wants_to_be_visible(true);
 
   // Reattach the window to the parent to actually show it.
@@ -475,8 +475,15 @@ void NativeWindowMac::ShowInactive() {
 
   // Triggers `NativeWidgetMacNSWindowHost::OnVisibilityChanged`.
   widget()->ShowInactive();
-  // `Widget::ShowInactive` is not sufficient to bring window to front.
-  [window_ orderFrontRegardless];
+
+  if (bring_to_front) {
+    // `Widget::ShowInactive` is not sufficient to bring window to front.
+    [window_ orderFrontRegardless];
+  } else {
+    // Show window at the back of the window stack.
+    [window_ orderBack:nil];
+  }
+
   // Above calls do not trigger `orderWindow: relativeTo:` in which headless
   // mode is being disabled.
   [window_ disableHeadlessMode];

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -589,7 +589,7 @@ void NativeWindowViews::Show() {
 #endif
 }
 
-void NativeWindowViews::ShowInactive() {
+void NativeWindowViews::ShowInactive(bool bring_to_front) {
   widget()->ShowInactive();
 
   NotifyWindowShow();
@@ -603,6 +603,10 @@ void NativeWindowViews::ShowInactive() {
   if (x11_util::IsX11())
     widget()->SetZOrderLevel(widget()->GetZOrderLevel());
 #endif
+
+  // Note: bring_to_front is currently only implemented on macOS.
+  // On Windows/Linux, the window may still be brought to front.
+  std::ignore = bring_to_front;
 }
 
 void NativeWindowViews::Hide() {

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -62,7 +62,7 @@ class NativeWindowViews : public NativeWindow,
   void Focus(bool focus) override;
   bool IsFocused() const override;
   void Show() override;
-  void ShowInactive() override;
+  void ShowInactive(bool bring_to_front = true) override;
   void Hide() override;
   bool IsVisible() const override;
   bool IsEnabled() const override;

--- a/spec/api-desktop-capturer-spec.ts
+++ b/spec/api-desktop-capturer-spec.ts
@@ -254,4 +254,71 @@ ifdescribe(!process.arch.includes('arm') && process.platform !== 'win32')('deskt
       destroyWindows();
     }
   });
+
+  ifit(process.platform === 'darwin')('showInactive with bringToFront should control z-order', async function () {
+    // DesktopCapturer.getSources() is guaranteed to return in the correct
+    // z-order from foreground to background.
+    const w1 = new BrowserWindow({ show: false, width: 100, height: 100 });
+    const w2 = new BrowserWindow({ show: false, width: 100, height: 100 });
+
+    const destroyWindows = () => {
+      w1.destroy();
+      w2.destroy();
+    };
+
+    try {
+      // Show and focus both windows sequentially to establish z-order.
+      // w2 should end up in front of w1.
+      for (const w of [w1, w2]) {
+        const wShown = once(w, 'show');
+        const wFocused = once(w, 'focus');
+        w.show();
+        w.focus();
+        await wShown;
+        await wFocused;
+      }
+
+      const getSources = async () => {
+        const sources = await desktopCapturer.getSources({
+          types: ['window'],
+          thumbnailSize: { width: 0, height: 0 }
+        });
+        return sources;
+      };
+
+      // Verify initial z-order: w2 (front) then w1 (back).
+      let sources = await getSources();
+      const initialW2Index = sources.findIndex(s => s.id === w2.getMediaSourceId());
+      const initialW1Index = sources.findIndex(s => s.id === w1.getMediaSourceId());
+
+      // If the environment doesn't give us reliable z-order, bail out.
+      if (initialW2Index === -1 || initialW1Index === -1 || initialW2Index >= initialW1Index) return;
+
+      // Hide w1, then showInactive with bringToFront: false.
+      // It should appear behind w2.
+      w1.hide();
+      await setTimeout(500);
+      w1.showInactive({ bringToFront: false });
+      await setTimeout(2000);
+
+      sources = await getSources();
+      const backW2Index = sources.findIndex(s => s.id === w2.getMediaSourceId());
+      const backW1Index = sources.findIndex(s => s.id === w1.getMediaSourceId());
+      expect(backW2Index).to.be.lessThan(backW1Index, 'w1 should be behind w2 after showInactive({ bringToFront: false })');
+
+      // Hide w1 again, then showInactive with default (bringToFront: true).
+      // It should appear in front of w2.
+      w1.hide();
+      await setTimeout(500);
+      w1.showInactive();
+      await setTimeout(2000);
+
+      sources = await getSources();
+      const frontW1Index = sources.findIndex(s => s.id === w1.getMediaSourceId());
+      const frontW2Index = sources.findIndex(s => s.id === w2.getMediaSourceId());
+      expect(frontW1Index).to.be.lessThan(frontW2Index, 'w1 should be in front of w2 after showInactive() with default bringToFront');
+    } finally {
+      destroyWindows();
+    }
+  });
 });


### PR DESCRIPTION
#### Description of Change

Closes #49393

Adds a `bringToFront` option to `showInactive()` for macOS. When set to `false`, the window is shown at the back of the window stack using `orderBack:` instead of `orderFrontRegardless`.

This is useful for apps that auto-update in the background and need to recreate windows without interrupting the user.

#### Test plan
- [x] Build Electron from source
- [x] Create a simple app that calls `showInactive`
```javascript
const { app, BrowserWindow } = require('electron');

app.setActivationPolicy('accessory');

app.whenReady().then(async () => {
  const back = new BrowserWindow({ width: 400, height: 300, x: 50, y: 50, show: false, title: 'Back' });
  back.loadURL('data:text/html,<h1>Window</h1>');
  back.showInactive();
});
```

- [x] `win.showInactive` with no options - should show the window at the front of the stack


https://github.com/user-attachments/assets/40d8c822-d3f6-4efe-8aea-c16a947ca830



- [x] `win.showInactive` with `bringToFront: false` - should show the window at the back of the stack

https://github.com/user-attachments/assets/d9e3ad37-626d-43e5-8541-ead3411a04f6


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added a `bringToFront` option to `showInactive()` for macOS. When set to `false`, the window is shown at the back of the window stack.