### PR TITLE
ci: detect patch needs update error with problem matcher

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -143,11 +143,12 @@ runs:
           echo "No changes to patches detected"
         fi
       fi
-  - name: Remove patch conflict problem matcher
+  - name: Remove patch conflict problem matchers
     shell: bash
     run: |
       echo "::remove-matcher owner=merge-conflict::"
       echo "::remove-matcher owner=patch-conflict::"
+      echo "::remove-matcher owner=patch-needs-update::"
   - name: Upload patches stats
     if: ${{ inputs.target-platform == 'linux' && github.ref == 'refs/heads/main' }}
     shell: bash

--- a/.github/problem-matchers/patch-conflict.json
+++ b/.github/problem-matchers/patch-conflict.json
@@ -19,6 +19,16 @@
           "line": 3
         }
       ]
+    },
+    {
+      "owner": "patch-needs-update",
+      "pattern": [
+        {
+          "regexp": "^((patches\/.*): needs update)$",
+          "message": 1,
+          "file": 2
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

We had a patch failure on `main` which wasn't caught by our audit, so extending this problem matcher to catch this case.

Example run using that most recent failure: https://github.com/electron/electron/actions/runs/21024844609/job/60446804629?pr=49405

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
