### PR TITLE
fix: frameless modal window does not respect given size on macOS

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -733,7 +733,7 @@ void NativeWindowMac::SetBounds(const gfx::Rect& bounds, bool animate) {
   NSScreen* screen = [[NSScreen screens] firstObject];
   cocoa_bounds.origin.y = NSHeight([screen frame]) - size.height() - bounds.y();
 
-  if (is_modal() && parent()) {
+  if (is_modal() && parent() && !has_frame()) {
     // Modal is shown via `[NSWindow beginSheet:completionHandler:]`, which
     // instead of showing regular window shows sheet, which does not have
     // title bar and AppKit removes the title bar height from the frame,

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -733,6 +733,16 @@ void NativeWindowMac::SetBounds(const gfx::Rect& bounds, bool animate) {
   NSScreen* screen = [[NSScreen screens] firstObject];
   cocoa_bounds.origin.y = NSHeight([screen frame]) - size.height() - bounds.y();
 
+  if (is_modal() && parent()) {
+    // Modal is shown via `[NSWindow beginSheet:completionHandler:]`, which
+    // instead of showing regular window shows sheet, which does not have
+    // title bar and AppKit removes the title bar height from the frame,
+    // if we want to preserve window frame size then treat given dimensions
+    // as content dimensions and add frame dimensions to it which
+    // will be removed by AppKit when showing the modal sheet.
+    cocoa_bounds = [window_ frameRectForContentRect:cocoa_bounds];
+  }
+
   [window_ setFrame:cocoa_bounds display:YES animate:animate];
   user_set_bounds_maximized_ = IsMaximized() ? true : false;
   UpdateWindowOriginalFrame();

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5576,6 +5576,25 @@ describe('BrowserWindow module', () => {
         await createTwo();
       });
 
+      it('frameless option respects used size', () => {
+        const parentWindow = new BrowserWindow();
+        const initialWidth = 600;
+        const initialHeight = 400;
+        const modalWindow = new BrowserWindow({
+          width: initialWidth,
+          height: initialHeight,
+          parent: parentWindow,
+          modal: true,
+          show: true,
+          frame: false
+        });
+        expectBoundsEqual(modalWindow.getSize(), [initialWidth, initialHeight]);
+        const newWidth = 700;
+        const newHeight = 500;
+        modalWindow.setSize(newWidth, newHeight);
+        expectBoundsEqual(modalWindow.getSize(), [newWidth, newHeight]);
+      });
+
       ifdescribe(process.platform !== 'darwin' && !isWayland)('disabling parent windows', () => {
         it('can disable and enable a window', () => {
           const w = new BrowserWindow({ show: false });


### PR DESCRIPTION
`[NSWindow beginSheet:completionHandler:]` is used for displaying modal window on macOS. AppKit for windows displayed this way uses smaller frame by the top frame hight than the window had originaly set, however if we create frameless window on purpose there is no frame to remove and we get unexpected result.

In order to prevent getting smaller window enlarge passed frameless modal window dimensions with `[NSWindow frameRectForContentRect:]` which will add frame dimensions and compensate frame removal done by the `[NSWindow beginSheet:completionHandler:]`.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed frameless modal window size on macOS.