### PR TITLE
refactor: added prefix for NodeJS modules

### DIFF
--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -1,7 +1,7 @@
 import { Menu } from 'electron/main';
 
-import { EventEmitter } from 'events';
-import * as fs from 'fs';
+import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
 
 const bindings = process._linkedBinding('electron_browser_app');
 const commandLine = process._linkedBinding('electron_common_command_line');

--- a/lib/browser/api/auto-updater/auto-updater-win.ts
+++ b/lib/browser/api/auto-updater/auto-updater-win.ts
@@ -2,7 +2,7 @@ import * as squirrelUpdate from '@electron/internal/browser/api/auto-updater/squ
 
 import { app } from 'electron/main';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 class AutoUpdater extends EventEmitter implements Electron.AutoUpdater {
   updateAvailable: boolean = false;

--- a/lib/browser/api/auto-updater/squirrel-update-win.ts
+++ b/lib/browser/api/auto-updater/squirrel-update-win.ts
@@ -1,6 +1,6 @@
-import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
-import * as fs from 'fs';
-import * as path from 'path';
+import { spawn, ChildProcessWithoutNullStreams } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 // i.e. my-app/app-0.1.13/
 const appFolder = path.dirname(process.execPath);

--- a/lib/browser/api/base-window.ts
+++ b/lib/browser/api/base-window.ts
@@ -1,7 +1,7 @@
 import { TouchBar } from 'electron/main';
 import type { BaseWindow as TLWT } from 'electron/main';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 const { BaseWindow } = process._linkedBinding('electron_browser_base_window') as { BaseWindow: typeof TLWT };
 

--- a/lib/browser/api/in-app-purchase.ts
+++ b/lib/browser/api/in-app-purchase.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 let _inAppPurchase;
 

--- a/lib/browser/api/message-channel.ts
+++ b/lib/browser/api/message-channel.ts
@@ -1,6 +1,6 @@
 import { MessagePortMain } from '@electron/internal/browser/message-port-main';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 const { createPair } = process._linkedBinding('electron_browser_message_port');
 

--- a/lib/browser/api/net-fetch.ts
+++ b/lib/browser/api/net-fetch.ts
@@ -2,7 +2,7 @@ import { allowAnyProtocol } from '@electron/internal/common/api/net-client-reque
 
 import { ClientRequestConstructorOptions, ClientRequest, IncomingMessage, Session as SessionT } from 'electron/main';
 
-import { Readable, Writable, isReadable } from 'stream';
+import { Readable, Writable, isReadable } from 'node:stream';
 
 function createDeferredPromise<T, E extends Error = Error> (): { promise: Promise<T>; resolve: (x: T) => void; reject: (e: E) => void; } {
   let res: (x: T) => void;

--- a/lib/browser/api/power-monitor.ts
+++ b/lib/browser/api/power-monitor.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 const {
   createPowerMonitor,

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -1,10 +1,10 @@
 import { ProtocolRequest, session } from 'electron/main';
 
-import { createReadStream } from 'fs';
-import { Readable } from 'stream';
-import { ReadableStream } from 'stream/web';
+import { createReadStream } from 'node:fs';
+import { Readable } from 'node:stream';
+import { ReadableStream } from 'node:stream/web';
 
-import type { ReadableStreamDefaultReader } from 'stream/web';
+import type { ReadableStreamDefaultReader } from 'node:stream/web';
 
 // Global protocol APIs.
 const { registerSchemesAsPrivileged, getStandardSchemes, Protocol } = process._linkedBinding('electron_browser_protocol');

--- a/lib/browser/api/screen.ts
+++ b/lib/browser/api/screen.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 const { createScreen } = process._linkedBinding('electron_browser_screen');
 

--- a/lib/browser/api/share-menu.ts
+++ b/lib/browser/api/share-menu.ts
@@ -1,6 +1,6 @@
 import { BrowserWindow, Menu, SharingItem, PopupOptions } from 'electron/main';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 class ShareMenu extends EventEmitter implements Electron.ShareMenu {
   private menu: Menu;

--- a/lib/browser/api/shared-texture.ts
+++ b/lib/browser/api/shared-texture.ts
@@ -2,7 +2,7 @@ import ipcMain from '@electron/internal/browser/api/ipc-main';
 import * as ipcMainInternalUtils from '@electron/internal/browser/ipc-main-internal-utils';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 const transferTimeout = 1000;
 const sharedTextureNative = process._linkedBinding('electron_common_shared_texture');

--- a/lib/browser/api/touch-bar.ts
+++ b/lib/browser/api/touch-bar.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 let nextItemID = 1;
 

--- a/lib/browser/api/utility-process.ts
+++ b/lib/browser/api/utility-process.ts
@@ -1,8 +1,8 @@
 import { MessagePortMain } from '@electron/internal/browser/message-port-main';
 
-import { EventEmitter } from 'events';
-import { Socket } from 'net';
-import { Duplex, PassThrough } from 'stream';
+import { EventEmitter } from 'node:events';
+import { Socket } from 'node:net';
+import { Duplex, PassThrough } from 'node:stream';
 
 const { _fork } = process._linkedBinding('electron_browser_utility_process');
 

--- a/lib/browser/api/view.ts
+++ b/lib/browser/api/view.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 const { View } = process._linkedBinding('electron_browser_view');
 

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -8,8 +8,8 @@ import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 import { app, session, webFrameMain, dialog } from 'electron/main';
 import type { BrowserWindowConstructorOptions, MessageBoxOptions, NavigationEntry } from 'electron/main';
 
-import * as path from 'path';
-import * as url from 'url';
+import * as path from 'node:path';
+import * as url from 'node:url';
 
 // session is not used here, the purpose is to make sure session is initialized
 // before the webContents module.

--- a/lib/browser/devtools.ts
+++ b/lib/browser/devtools.ts
@@ -4,7 +4,7 @@ import * as ipcMainUtils from '@electron/internal/browser/ipc-main-internal-util
 
 import { dialog, Menu } from 'electron/main';
 
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 const convertToMenuTemplate = function (items: ContextMenuItem[], handler: (id: number) => void) {
   return items.map(function (item) {

--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -1,11 +1,11 @@
 import type * as defaultMenuModule from '@electron/internal/browser/default-menu';
 
-import { EventEmitter } from 'events';
-import * as fs from 'fs';
-import * as path from 'path';
+import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
-import type * as url from 'url';
-import type * as v8 from 'v8';
+import type * as url from 'node:url';
+import type * as v8 from 'node:v8';
 
 const Module = require('module') as NodeJS.ModuleInternal;
 

--- a/lib/browser/ipc-main-impl.ts
+++ b/lib/browser/ipc-main-impl.ts
@@ -1,6 +1,6 @@
 import { IpcMainInvokeEvent } from 'electron/main';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 export class IpcMainImpl extends EventEmitter implements Electron.IpcMain {
   private _invokeHandlers: Map<string, (e: IpcMainInvokeEvent, ...args: any[]) => void> = new Map();

--- a/lib/browser/message-port-main.ts
+++ b/lib/browser/message-port-main.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 export class MessagePortMain extends EventEmitter implements Electron.MessagePortMain {
   _internalPort: any;

--- a/lib/browser/rpc-server.ts
+++ b/lib/browser/rpc-server.ts
@@ -5,8 +5,8 @@ import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 import { clipboard } from 'electron/common';
 import { webFrameMain } from 'electron/main';
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 // Implements window.close()
 ipcMainInternal.on(IPC_MESSAGES.BROWSER_WINDOW_CLOSE, function (event) {

--- a/lib/common/api/net-client-request.ts
+++ b/lib/common/api/net-client-request.ts
@@ -3,8 +3,8 @@ import type {
   UploadProgress
 } from 'electron/common';
 
-import { Readable, Writable } from 'stream';
-import * as url from 'url';
+import { Readable, Writable } from 'node:stream';
+import * as url from 'node:url';
 
 const {
   isValidHeaderName,

--- a/lib/common/init.ts
+++ b/lib/common/init.ts
@@ -1,7 +1,7 @@
+import * as util from 'node:util';
 import timers = require('timers');
-import * as util from 'util';
 
-import type * as stream from 'stream';
+import type * as stream from 'node:stream';
 
 type AnyFn = (...args: any[]) => any
 

--- a/lib/node/asar-fs-wrapper.ts
+++ b/lib/node/asar-fs-wrapper.ts
@@ -1,10 +1,10 @@
-import { Buffer } from 'buffer';
-import { Dirent, constants } from 'fs';
-import * as path from 'path';
-import * as util from 'util';
+import { Buffer } from 'node:buffer';
+import { Dirent, constants } from 'node:fs';
+import * as path from 'node:path';
+import * as util from 'node:util';
 
-import type * as Crypto from 'crypto';
-import type * as os from 'os';
+import type * as Crypto from 'node:crypto';
+import type * as os from 'node:os';
 
 const asar = process._linkedBinding('electron_common_asar');
 

--- a/lib/preload_realm/init.ts
+++ b/lib/preload_realm/init.ts
@@ -3,7 +3,7 @@ import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 import type * as ipcRendererUtilsModule from '@electron/internal/renderer/ipc-renderer-internal-utils';
 import { createPreloadProcessObject, executeSandboxedPreloadScripts } from '@electron/internal/sandboxed_renderer/preload';
 
-import * as events from 'events';
+import * as events from 'node:events';
 
 declare const binding: {
   get: (name: string) => any;

--- a/lib/renderer/api/ipc-renderer.ts
+++ b/lib/renderer/api/ipc-renderer.ts
@@ -1,6 +1,6 @@
 import { getIPCRenderer } from '@electron/internal/renderer/ipc-renderer-bindings';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 const ipc = getIPCRenderer();
 const internal = false;

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -2,8 +2,8 @@ import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 import type * as ipcRendererInternalModule from '@electron/internal/renderer/ipc-renderer-internal';
 import type * as ipcRendererUtilsModule from '@electron/internal/renderer/ipc-renderer-internal-utils';
 
-import * as path from 'path';
-import { pathToFileURL } from 'url';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const Module = require('module') as NodeJS.ModuleInternal;
 

--- a/lib/renderer/ipc-renderer-internal.ts
+++ b/lib/renderer/ipc-renderer-internal.ts
@@ -1,6 +1,6 @@
 import { getIPCRenderer } from '@electron/internal/renderer/ipc-renderer-bindings';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 const ipc = getIPCRenderer();
 const internal = true;

--- a/lib/sandboxed_renderer/init.ts
+++ b/lib/sandboxed_renderer/init.ts
@@ -3,8 +3,8 @@ import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 import type * as ipcRendererUtilsModule from '@electron/internal/renderer/ipc-renderer-internal-utils';
 import { createPreloadProcessObject, executeSandboxedPreloadScripts } from '@electron/internal/sandboxed_renderer/preload';
 
-import * as events from 'events';
-import { setImmediate, clearImmediate } from 'timers';
+import * as events from 'node:events';
+import { setImmediate, clearImmediate } from 'node:timers';
 
 declare const binding: {
   process: NodeJS.Process;

--- a/lib/sandboxed_renderer/pre-init.ts
+++ b/lib/sandboxed_renderer/pre-init.ts
@@ -1,6 +1,6 @@
 // Pre-initialization code for sandboxed renderers.
 
-import * as events from 'events';
+import * as events from 'node:events';
 
 declare const binding: {
   get: (name: string) => any;

--- a/lib/sandboxed_renderer/preload.ts
+++ b/lib/sandboxed_renderer/preload.ts
@@ -1,7 +1,7 @@
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 interface PreloadContext {
   loadedModules: Map<string, any>;

--- a/lib/utility/init.ts
+++ b/lib/utility/init.ts
@@ -1,7 +1,7 @@
 import { ParentPort } from '@electron/internal/utility/parent-port';
 
-import { EventEmitter } from 'events';
-import { pathToFileURL } from 'url';
+import { EventEmitter } from 'node:events';
+import { pathToFileURL } from 'node:url';
 
 const v8Util = process._linkedBinding('electron_common_v8_util');
 

--- a/lib/utility/parent-port.ts
+++ b/lib/utility/parent-port.ts
@@ -1,6 +1,6 @@
 import { MessagePortMain } from '@electron/internal/browser/message-port-main';
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 const { createParentPort } = process._linkedBinding('electron_utility_parent_port');
 

--- a/lib/worker/init.ts
+++ b/lib/worker/init.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 const Module = require('module') as NodeJS.ModuleInternal;
 


### PR DESCRIPTION
#### Description of Change

Unification. Some modules have `node:` prefix, some not.

Added (missing) prefixies for NodeJS modules.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
