### PR TITLE
fix: user resizable transparent windows on win32

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1021,17 +1021,13 @@ void NativeWindowViews::MoveTop() {
 
 bool NativeWindowViews::CanResize() const {
 #if BUILDFLAG(IS_WIN)
-  return resizable_ && thick_frame_;
+  return has_frame() ? resizable_ && thick_frame_ : resizable_;
 #else
   return resizable_;
 #endif
 }
 
 bool NativeWindowViews::IsResizable() const {
-#if BUILDFLAG(IS_WIN)
-  if (has_frame())
-    return ::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE) & WS_THICKFRAME;
-#endif
   return CanResize();
 }
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5516,7 +5516,7 @@ describe('BrowserWindow module', () => {
           thickFrame: true,
           transparent: true
         });
-        expect(w.isResizable()).to.be.false('resizable');
+        expect(w.isResizable()).to.be.true('resizable');
         w.maximize();
         expect(w.isMaximized()).to.be.true('maximized');
         const bounds = w.getBounds();


### PR DESCRIPTION
Closes: #48554

#### Description of Change

Frameless windows use hit-test based resize in chromium.  Version 39 of electron regressed resizable windows that did not have a "frame" on win32.

#### Checklist
- [x] PR description included
- [x] `npm test` passes
   I ran tests but there were 245 fails that seemed to have nothing to do with my change.  I don't know if HEAD is broken or if my windows VM is not setup correctly.
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

notes: Fixed user resizing of transparent windows on win32 platform