### PR TITLE
ci: trigger website docs update on release published

### DIFF
--- a/.github/workflows/update-website-docs.yml
+++ b/.github/workflows/update-website-docs.yml
@@ -1,0 +1,39 @@
+name: Update Website Docs
+
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  update-website-docs:
+    name: Update Website Docs
+    runs-on: ubuntu-latest
+    environment: website-docs-updater
+    permissions:
+      contents: read
+      id-token: write # needed for secret-service-action
+    steps:
+      - name: Get GitHub App token
+        id: secret-service
+        uses: electron/secret-service-action@3476425e8b30555aac15b1b7096938e254b0e155 # v1.0.0
+      - name: Check if this release is the latest
+        id: check-if-latest-release
+        env:
+          GH_REPO: electron/electron
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST_RELEASE_TAG="$(gh release view --json tagName --jq '.tagName')"
+          if [ "$LATEST_RELEASE_TAG" = "${GITHUB_REF#refs/tags/}" ]; then
+            echo "isLatestRelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "isLatestRelease=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Trigger website docs update
+        if: ${{ steps.check-if-latest-release.outputs.isLatestRelease }}
+        env:
+          GH_REPO: electron/website
+          GH_TOKEN: ${{ fromJSON(steps.secret-service.outputs.secrets).WEBSITE_DOCS_UPDATER_APP_TOKEN }}
+        run: |
+          gh workflow run update-docs.yml -f sha=$GITHUB_SHA


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

This is intended to effectively retire [`electron/electron-website-updater`](https://github.com/electron/electron-website-updater), which has served us well, but feels overly complex for what we really want these days.

Some of the additional complexity in `electron/electron-website-updater` comes from filtering `push` events on `e/e` to only look at active release branches. The rest of the complexity comes from watching `push` events and publishing any changes to `docs/` on a release branch to the website immediately after merge. This is actually not really desirable behavior, as it means the website docs will be showing unreleased features, and the next release may not be for a week or two.

That discrepancy has potential to confuse developers, and the only real benefits we get are docs fixes and updates to other parts of our docs like `docs/tutorials` go live immediately, instead of being delayed until the next release is put out.

IMO, given the trade off of having unreleased features shown on the docs website for a week or two, and having docs fixes delayed by a week or two, I think the latter is the lesser evil.

If we're happy with making that change, the additional complexity goes away and the flow for updating the website docs collapses down to this simple workflow, and lets us retire `electron/electron-website-updater`. We just need to trigger a website doc update on each published release which is the latest release.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
