### PR TITLE
fix: explicit support for package types in macOS open dialog filters

### DIFF
--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -137,6 +137,10 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
       } else {
         if (UTType* utt = [UTType typeWithFilenameExtension:@(ext.c_str())])
           [content_types_set addObject:utt];
+        if (UTType* utt = [UTType typeWithFilenameExtension:@(ext.c_str())
+                                           conformingToType:[UTType typeWithIdentifier:@"com.apple.package"]]) {
+          [content_types_set addObject:utt];
+        }
       }
     }
 


### PR DESCRIPTION
## Description of Change
Fixed a regression in `dialog.showOpenDialog` on macOS where files inside packages (like `.rtfd`) were not selectable even when their extension was explicitly allowed in the filters.

Fixes #48191

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/electron/electron/blob/main/CONTRIBUTING.md)
- [x] I followed the [coding style](https://github.com/electron/electron/blob/main/docs/development/coding-style.md)
- [x] I have tested this change manually

## Technical Details
Explicitly checks if a filter extension maps to a package-conforming UTType (`com.apple.package`) and adds it to the `NSOpenPanel` allowed content types.

## Test Plan
1. Created a `.rtfd` package using TextEdit
2. Called `showOpenDialog` with filters: `[{ extensions: ['rtfd'] }]`
3. Confirmed `.rtfd` files are now selectable (previously disabled)

## Release Notes
- Fixed an issue where `dialog.showOpenDialog` on macOS would not allow selecting package files (e.g. `.rtfd`) when filtered by extension. #48191