### PR TITLE
[Feature Request]: protocol.handle for Websocket  for #43522

### DIFF
--- a/shell/browser/api/electron_api_protocol.h
+++ b/shell/browser/api/electron_api_protocol.h
@@ -30,6 +30,7 @@ class ProtocolRegistry;
 namespace api {
 
 std::vector<std::string>& GetStandardSchemes();
+std::vector<std::string>& GetWebSocketSchemes();
 std::vector<std::string>& GetCodeCacheSchemes();
 
 void AddServiceWorkerScheme(const std::string& scheme);

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1325,7 +1325,7 @@ void ElectronBrowserClient::CreateWebSocket(
       web_request, std::move(factory), url, site_for_cookies, user_agent,
       std::move(handshake_client), true, frame->GetProcess()->GetDeprecatedID(),
       frame->GetRoutingID(), frame->GetLastCommittedOrigin(), browser_context,
-      &next_id_);
+      ProtocolRegistry::FromBrowserContext(browser_context), &next_id_);
 }
 
 void ElectronBrowserClient::WillCreateURLLoaderFactory(

--- a/shell/browser/net/proxying_websocket.h
+++ b/shell/browser/net/proxying_websocket.h
@@ -27,6 +27,8 @@
 
 namespace electron {
 
+class ProtocolRegistry;
+
 // A ProxyingWebSocket proxies a WebSocket connection and dispatches
 // WebRequest API events.
 //
@@ -48,6 +50,7 @@ class ProxyingWebSocket : public network::mojom::WebSocketHandshakeClient,
       int process_id,
       int render_frame_id,
       content::BrowserContext* browser_context,
+      ProtocolRegistry* protocol_registry,
       uint64_t* request_id_generator);
   ~ProxyingWebSocket() override;
 
@@ -97,6 +100,7 @@ class ProxyingWebSocket : public network::mojom::WebSocketHandshakeClient,
       int render_frame_id,
       const url::Origin& origin,
       content::BrowserContext* browser_context,
+      ProtocolRegistry* protocol_registry,
       uint64_t* request_id_generator);
 
  private:
@@ -159,6 +163,11 @@ class ProxyingWebSocket : public network::mojom::WebSocketHandshakeClient,
   mojo::ScopedDataPipeProducerHandle writable_;
 
   extensions::WebRequestInfo info_;
+
+  const raw_ptr<ProtocolRegistry> protocol_registry_;
+  bool protocol_handler_checked_ = false;
+
+  void OnProtocolResponse(gin::Arguments* args);
 
   base::WeakPtrFactory<ProxyingWebSocket> weak_factory_{this};
 };

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -265,6 +265,9 @@ inline constexpr base::cstring_view kStreamingSchemes = "streaming-schemes";
 // Register schemes as supporting V8 code cache.
 inline constexpr base::cstring_view kCodeCacheSchemes = "code-cache-schemes";
 
+// Register schemes as WebSocket enabled.
+inline constexpr base::cstring_view kWebSocketSchemes = "websocket-schemes";
+
 // The browser process app model ID
 inline constexpr base::cstring_view kAppUserModelId = "app-user-model-id";
 

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -162,6 +162,11 @@ RendererClientBase::RendererClientBase() {
       ParseSchemesCLISwitch(command_line, switches::kSecureSchemes);
   for (const std::string& scheme : secure_schemes_list)
     url::AddSecureScheme(scheme.data());
+  // Parse --websocket-schemes=scheme1,scheme2
+  std::vector<std::string> websocket_schemes_list =
+      ParseSchemesCLISwitch(command_line, switches::kWebSocketSchemes);
+  for (const std::string& scheme : websocket_schemes_list)
+    url::AddWebSocketScheme(scheme.c_str());
   // We rely on the unique process host id which is notified to the
   // renderer process via command line switch from the content layer,
   // if this switch is removed from the content layer for some reason,

--- a/spec/index.js
+++ b/spec/index.js
@@ -55,7 +55,8 @@ protocol.registerSchemesAsPrivileged([
   { scheme: 'no-fetch', privileges: { corsEnabled: true } },
   { scheme: 'stream', privileges: { standard: true, stream: true } },
   { scheme: 'foo', privileges: { standard: true } },
-  { scheme: 'bar', privileges: { standard: true } }
+  { scheme: 'bar', privileges: { standard: true } },
+  { scheme: 'ws-custom', privileges: { standard: true, secure: true, webSocket: true } }
 ]);
 
 app.whenReady().then(async () => {
@@ -115,7 +116,7 @@ app.whenReady().then(async () => {
   // 2. `defer()`-ed methods run, in reverse order,
   // 3. regular `afterEach` hooks run.
   const { runCleanupFunctions } = require('./lib/spec-helpers');
-  mocha.suite.on('suite', function attach (suite) {
+  mocha.suite.on('suite', function attach(suite) {
     suite.afterEach('cleanup', runCleanupFunctions);
     suite.on('suite', attach);
   });

--- a/spec/websocket-protocol-spec.ts
+++ b/spec/websocket-protocol-spec.ts
@@ -1,0 +1,106 @@
+import { protocol, BrowserWindow } from 'electron/main';
+import { expect } from 'chai';
+import * as WebSocket from 'ws';
+import * as http from 'node:http';
+import { closeWindow } from './lib/window-helpers';
+
+describe('custom protocol WebSocket support', () => {
+    const scheme = 'ws-custom';
+    let server: http.Server;
+    let wss: WebSocket.Server;
+    let port: number;
+
+    before(async () => {
+        server = http.createServer();
+        wss = new WebSocket.Server({ noServer: true });
+        server.on('upgrade', (request, socket, head) => {
+            wss.handleUpgrade(request, socket, head, (ws) => {
+                ws.send('hello');
+            });
+        });
+        await new Promise<void>(resolve => server.listen(0, '127.0.0.1', () => resolve()));
+        port = (server.address() as any).port;
+    });
+
+    after(() => {
+        wss.close();
+        server.close();
+    });
+
+    afterEach(async () => {
+        protocol.unhandle(scheme);
+        if (w) await closeWindow(w);
+    });
+
+    let w: BrowserWindow;
+
+    it('allows a custom scheme to redirect a WebSocket connection', async () => {
+        protocol.handle(scheme, () => {
+            return new Response(null, {
+                status: 302,
+                headers: {
+                    Location: `ws://127.0.0.1:${port}`
+                }
+            });
+        });
+
+        w = new BrowserWindow({
+            show: false,
+            webPreferences: {
+                nodeIntegration: true,
+                contextIsolation: false
+            }
+        });
+
+        const result = await w.webContents.executeJavaScript(`
+      new Promise((resolve, reject) => {
+        try {
+          const ws = new WebSocket('${scheme}://example');
+          ws.onmessage = (event) => {
+            resolve(event.data);
+            ws.close();
+          };
+          ws.onclose = () => {
+            reject(new Error('WebSocket closed early'));
+          };
+          ws.onerror = (err) => {
+            reject(new Error('WebSocket error'));
+          };
+          setTimeout(() => reject(new Error('Timeout')), 5000);
+        } catch (e) {
+          reject(e);
+        }
+      });
+    `);
+
+        expect(result).to.equal('hello');
+    });
+
+    it('allows a custom scheme to return a string URL for redirection', async () => {
+        (protocol as any).registerStringProtocol(scheme, (request: any, callback: any) => {
+            callback({ url: `ws://127.0.0.1:${port}` });
+        });
+
+        w = new BrowserWindow({
+            show: false,
+            webPreferences: {
+                nodeIntegration: true,
+                contextIsolation: false
+            }
+        });
+
+        const result = await w.webContents.executeJavaScript(`
+      new Promise((resolve, reject) => {
+        const ws = new WebSocket('${scheme}://example');
+        ws.onmessage = (event) => {
+          resolve(event.data);
+          ws.close();
+        };
+        ws.onerror = () => reject(new Error('WebSocket error'));
+        setTimeout(() => reject(new Error('Timeout')), 5000);
+      });
+    `);
+
+        expect(result).to.equal('hello');
+    });
+});


### PR DESCRIPTION
#### Description of Change

# Walkthrough: WebSocket Support for Custom Protocols

This change adds first-class support for using custom protocols (registered via `protocol.handle()`) with WebSockets. Developers can now intercept, inspect, and redirect WebSocket connections using the same protocol APIs already available for HTTP requests.

---

## Overview

Electron previously restricted WebSocket URLs to `ws:` and `wss:` schemes at the Chromium level. This prevented custom schemes from being used with WebSockets, even if those schemes were already supported for HTTP via `protocol.handle()` or legacy protocol APIs.

This implementation removes that limitation in a controlled way by introducing an explicit WebSocket privilege for custom schemes and by intercepting the WebSocket handshake so protocol handlers can participate in connection routing.

---

## Changes

### 1. WebSocket Privilege for Custom Schemes

A new `webSocket` privilege was added to `protocol.registerSchemesAsPrivileged`. When enabled, the custom scheme is registered with Chromium as a valid WebSocket scheme, preventing the error:

`URL's scheme must be either 'ws' or 'wss'`

Relevant implementation details:

`shell/common/options_switches.h`  
A new `kWebSocketSchemes` command-line switch was added. This switch is used to pass the list of WebSocket-capable schemes from the browser process to child processes.

`shell/browser/api/electron_api_protocol.cc`  
`SchemeOptions` was extended to include the `webSocket` flag.  
`GetWebSocketSchemes()` was implemented to track all schemes registered with WebSocket support.  
`RegisterSchemesAsPrivileged` was updated to call `url::AddWebSocketScheme` for schemes with the `webSocket` privilege enabled.

`shell/renderer/renderer_client_base.cc`  
Renderer-side initialization was updated to call `url::AddWebSocketScheme` for schemes received through the command-line switch, ensuring consistent behavior across processes.

---

### 2. WebSocket Handshake Interception

The WebSocket creation flow was modified so that handshakes can be intercepted before any network request is sent. This enables protocol handlers to redirect WebSocket connections.

Key changes:

`shell/browser/electron_browser_client.cc`  
`CreateWebSocket` was updated to pass the active `ProtocolRegistry` to the WebSocket proxy layer.

`shell/browser/net/proxying_websocket.cc`  
The scheme validation in `OnBeforeRequestComplete` was relaxed to allow custom schemes that are explicitly marked as WebSocket-capable.  
`ContinueToStartRequest` was extended to check whether a custom protocol handler is registered for the request’s scheme.

Behavioral flow:

If no custom protocol handler is registered, the WebSocket proceeds normally.  
If a handler is found, the proxy pauses the connection and invokes the handler.  
If the handler returns a redirect, either as a string URL or as a response containing a `Location` header, the WebSocket connection is transparently redirected to the new endpoint.

---

### 3. Automated Verification

A new test specification was added to ensure correctness and prevent regressions.

`spec/websocket-protocol-spec.ts`

This test validates that:

`protocol.handle()` can intercept and redirect a WebSocket connection created with a custom scheme.  
Legacy APIs such as `protocol.registerStringProtocol` can also redirect WebSocket connections.  
The `webSocket` privilege correctly allows custom schemes to be treated as valid WebSocket schemes by the browser.

---

## Verification Results

All automated tests pass successfully.

The new test coverage confirms correct behavior for both modern and legacy protocol APIs, as well as proper Chromium-level scheme registration for WebSocket usage.

#### Checklist

- [ ] PR description included
- [ ] `npm test` passes
- [ ] tests are changed or added
- [ ] relevant API documentation, tutorials, and examples are updated and follow the documentation style guide
- [ ] PR release notes describe the change in a way relevant to app developers, and are capitalized, punctuated, and past tense

#### Release Notes

Notes: Added support for using custom protocol schemes with WebSockets, allowing WebSocket connections to be intercepted and redirected via `protocol.handle()` and legacy protocol APIs.
