### PR TITLE
chore: add "I have built and tested this PR" box to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,7 @@ Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
 
 - [ ] PR description included
+- [ ] I have built and tested this PR
 - [ ] `npm test` passes
 - [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
 - [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

We've been receiving a lot of low-quality AI-generated PRs lately.

Many of these PRs are entirely untested ([example](https://github.com/electron/electron/pull/48448#issuecomment-3544835899)). Many don't even compile ([example](https://github.com/electron/electron/pull/49400/changes/bede0d85e25b7f110b3fd804a6652ba11d4d79ce#r2692637417)).

Investing a lot of time into reviewing these is not a good use of maintainer time.

This PR adds a checkbox "I have built and tested this PR."

I suggest we then close all PRs that have not been built and tested by the PR authors.

This is in line with the suggested [AI tool policy RFC](https://github.com/electron/rfcs/pull/26).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
