### PR TITLE
docs: add jsign and Azure Trusted Signing support to code signing tut…

### DIFF
--- a/docs/tutorial/code-signing.md
+++ b/docs/tutorial/code-signing.md
@@ -249,6 +249,23 @@ and `WiX MSI` installers. Instructions for Azure Trusted Signing can be found
 The Electron Builder documentation for Azure Trusted Signing can be found
 [here][builder-trusted-signing].
 
+### Signing from macOS/Linux
+
+To sign Windows apps from macOS or Linux, you can use [jsign](https://github.com/ebourg/jsign), a Java-based tool that is platform-independent. `jsign` supports standard PFX certificates as well as cloud-based signing solutions like Azure Trusted Signing.
+
+Most Electron build tools allow you to customize the signing executable. For example, you can configure Electron Forge or Electron Packager to use a script that invokes `jsign` instead of `signtool.exe`.
+
+#### Example: Signing with jsign and Azure Trusted Signing
+
+```bash
+jsign --storetype AZUREKEYVAULT \
+      --keystore-mode ARM \
+      --storepass <access-token> \
+      --alias <certificate-name> \
+      --tsaurl http://timestamp.digicert.com \
+      path/to/app.exe
+```
+
 ### Signing Windows Store applications
 
 See the [Windows Store Guide][].


### PR DESCRIPTION
This pull request adds documentation to help developers sign Windows applications from macOS or Linux environments. It introduces `jsign` as a cross-platform signing tool and provides guidance and examples for using it, especially with Azure Trusted Signing.

Documentation improvements for cross-platform code signing:

* Added a section describing how to sign Windows apps from macOS or Linux using the Java-based `jsign` tool, including support for standard PFX certificates and Azure Trusted Signing.
* Provided an example command for signing with `jsign` and Azure Trusted Signing, and explained how to integrate `jsign` with Electron build tools.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
