### PR TITLE
docs: add guide for debugging preload scripts in VS Code

### DIFF
--- a/docs/tutorial/debugging-vscode.md
+++ b/docs/tutorial/debugging-vscode.md
@@ -29,7 +29,7 @@ $ code my-app
       "windows": {
         "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
       },
-      "args" : ["."],
+      "args": ["."],
       "outputCapture": "std"
     }
   ]
@@ -41,6 +41,67 @@ $ code my-app
 Set some breakpoints in `main.js`, and start debugging in the
 [Debug View](https://code.visualstudio.com/docs/editor/debugging). You should
 be able to hit the breakpoints.
+
+### Preload scripts
+
+Debugging preload scripts requires a slightly different configuration as they run in the renderer process but are initialized before the web page.
+
+#### 1. Configure `webPreferences`
+
+Ensure your `BrowserWindow` configuration allows for debugging. Sometimes `sandbox: false` is required to allow the debugger to attach reliably to the preload script, although this affects the security model of your application.
+
+```js
+const win = new BrowserWindow({
+  webPreferences: {
+    preload: path.join(__dirname, "preload.js"),
+    sandbox: false, // May be required for debugging preload scripts
+  },
+});
+```
+
+#### 2. Update `.vscode/launch.json`
+
+Add a configuration to attach to the renderer process. Note the `runtimeArgs` adding the remote debugging port.
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Main Process",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
+      },
+      "args": ["--remote-debugging-port=9223", "."],
+      "outputCapture": "std"
+    },
+    {
+      "name": "Debug Preload/Renderer",
+      "type": "chrome",
+      "request": "attach",
+      "port": 9223,
+      "webRoot": "${workspaceFolder}",
+      "timeout": 30000
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Debug All",
+      "configurations": ["Debug Main Process", "Debug Preload/Renderer"]
+    }
+  ]
+}
+```
+
+#### 3. Debugging
+
+1. Select "Debug All" from the debug dropdown.
+2. Set breakpoints in your `preload.js`.
+3. Start debugging. The debugger should attach to both the main process and the renderer (where the preload script runs), allowing you to hit breakpoints in the preload script.
 
 ## Debugging the Electron codebase
 
@@ -76,35 +137,35 @@ $ code my-app
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}",
       "environment": [
-          {"name": "ELECTRON_ENABLE_LOGGING", "value": "true"},
-          {"name": "ELECTRON_ENABLE_STACK_DUMPING", "value": "true"},
-          {"name": "ELECTRON_RUN_AS_NODE", "value": ""},
+        { "name": "ELECTRON_ENABLE_LOGGING", "value": "true" },
+        { "name": "ELECTRON_ENABLE_STACK_DUMPING", "value": "true" },
+        { "name": "ELECTRON_RUN_AS_NODE", "value": "" }
       ],
       "externalConsole": false,
       "sourceFileMap": {
-          "o:\\": "${workspaceFolder}",
-      },
-    },
+        "o:\\": "${workspaceFolder}"
+      }
+    }
   ]
 }
 ```
 
 **Configuration Notes**
 
-* `cppvsdbg` requires the
-[built-in C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
-be enabled.
-* `${workspaceFolder}` is the full path to Chromium's `src` directory.
-* `your-executable-location` will be one of the following depending on a few items:
-  * `Testing`: If you are using the default settings of
-  [Electron's Build-Tools](https://github.com/electron/build-tools) or the default
-  instructions when [building from source](../development/build-instructions-gn.md#building).
-  * `Release`: If you built a Release build rather than a Testing build.
-  * `your-directory-name`: If you modified this during your build process from
-  the default, this will be whatever you specified.
-* The `args` array string `"your-electron-project-path"` should be the absolute
-path to either the directory or `main.js` file of the Electron project you are
-using for testing. In this example, it should be your path to `my-app`.
+- `cppvsdbg` requires the
+  [built-in C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
+  be enabled.
+- `${workspaceFolder}` is the full path to Chromium's `src` directory.
+- `your-executable-location` will be one of the following depending on a few items:
+  - `Testing`: If you are using the default settings of
+    [Electron's Build-Tools](https://github.com/electron/build-tools) or the default
+    instructions when [building from source](../development/build-instructions-gn.md#building).
+  - `Release`: If you built a Release build rather than a Testing build.
+  - `your-directory-name`: If you modified this during your build process from
+    the default, this will be whatever you specified.
+- The `args` array string `"your-electron-project-path"` should be the absolute
+  path to either the directory or `main.js` file of the Electron project you are
+  using for testing. In this example, it should be your path to `my-app`.
 
 #### 3. Debugging
 


### PR DESCRIPTION
#### Description of Change

This PR adds documentation for debugging preload scripts in VS Code, addressing issue #30470. It documents the requirement for sandbox: false and provides a launch.json configuration for attaching to the renderer process.

#### Checklist

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added documentation for debugging preload scripts in VS Code.