### PR TITLE
docs: document WebDriver command line arguments

### DIFF
--- a/docs/tutorial/automated-testing.md
+++ b/docs/tutorial/automated-testing.md
@@ -14,6 +14,10 @@ From [ChromeDriver - WebDriver for Chrome][chrome-driver]:
 > implements WebDriver's wire protocol for Chromium. It is being developed by
 > members of the Chromium and WebDriver teams.
 
+:::caution
+Creating a WebDriver session will confuse argument parsers like `yargs` running in strict mode, as ChromeDriver adds additional arguments (e.g. `--test-type=webdriver`) to the Electron process at launch. You may need to configure your parser to ignore these arguments.
+:::
+
 There are a few ways that you can set up testing using WebDriver.
 
 ### With WebdriverIO


### PR DESCRIPTION
This PR adds a caution to the automated testing tutorial about WebDriver injecting arguments (like --test-type=webdriver) that can cause strict argument parsers to fail. Addresses issue #31769.

#### Checklist

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added documentation about WebDriver injecting command line arguments.