### PR TITLE
fix: return early from platform_util::Beep() on Linux if there is no default GDK display

### DIFF
--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -406,6 +406,8 @@ bool PlatformTrashItem(const base::FilePath& full_path, std::string* error) {
 
 void Beep() {
   auto* display = gdk_display_get_default();
+  if (!display)
+    return;
   gdk_display_beep(display);
 }
 


### PR DESCRIPTION
#### Description of Change

Adds a missing null check for when `gdk_display_get_default()` returns `NULL`.

Should fix #49436.

#### Checklist

- [x] PR description included
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed crash in platform_util::Beep() on Linux
