### PR TITLE
fix: allow capturing owned windows in desktopCapturer (Issue #49448)

### DIFF
--- a/patches/webrtc/.patches
+++ b/patches/webrtc/.patches
@@ -1,1 +1,2 @@
 fix_handle_pipewire_capturer_initialization_and_management.patch
+fix_window_capture_utils.patch

--- a/patches/webrtc/fix_window_capture_utils.patch
+++ b/patches/webrtc/fix_window_capture_utils.patch
@@ -1,0 +1,13 @@
+diff --git a/modules/desktop_capture/win/window_capture_utils.cc b/modules/desktop_capture/win/window_capture_utils.cc
+index 4badded..6c3f09a 100644
+--- a/modules/desktop_capture/win/window_capture_utils.cc
++++ b/modules/desktop_capture/win/window_capture_utils.cc
+@@ -52,7 +52,7 @@ BOOL CALLBACK GetWindowListHandler(HWND hwnd, LPARAM param) {
+   // namely owned window if they don't have the app window style set
+   HWND owner = GetWindow(hwnd, GW_OWNER);
+   LONG exstyle = GetWindowLong(hwnd, GWL_EXSTYLE);
+-  if (owner && !(exstyle & WS_EX_APPWINDOW)) {
++  if (owner && !(exstyle & WS_EX_APPWINDOW) && !IsWindowOwnedByCurrentProcess(hwnd)) {
+     return TRUE;
+   }
+ 


### PR DESCRIPTION
Fixes #49448

**Description**
The `desktopCapturer.getSources` API on Windows fails to list windows that have a parent window (created with `parent: win`). This is due to an upstream WebRTC filter in `GetWindowListHandler` which excludes owned windows unless they have the `WS_EX_APPWINDOW` style.

This PR adds a patch to WebRTC (`patches/webrtc/fix_window_capture_utils.patch`) that relaxes this check to allow owned windows **if they belong to the current process**. This ensures Electron's child windows are capturable while preserving the original intent of filtering out other auxiliary windows.

**Test Plan**
This change targets the WebRTC module on Windows. It relies on the `IsWindowOwnedByCurrentProcess` helper to distinguish the application's own child windows from other owned windows (like tooltips or menus) that should remain hidden.
