### PR TITLE
fix: correctly track BaseWindow::IsActive() on MacOS

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -317,6 +317,12 @@ void BaseWindow::OnWindowSheetEnd() {
   Emit("sheet-end");
 }
 
+void BaseWindow::OnWindowIsKeyChanged(bool is_key) {
+#if BUILDFLAG(IS_MAC)
+  window()->SetActive(is_key);
+#endif
+}
+
 void BaseWindow::OnWindowEnterHtmlFullScreen() {
   Emit("enter-html-full-screen");
 }

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -85,6 +85,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void OnWindowRotateGesture(float rotation) override;
   void OnWindowSheetBegin() override;
   void OnWindowSheetEnd() override;
+  void OnWindowIsKeyChanged(bool is_key) override;
   void OnWindowEnterFullScreen() override;
   void OnWindowLeaveFullScreen() override;
   void OnWindowEnterHtmlFullScreen() override;


### PR DESCRIPTION
#### Description of Change

Extend https://github.com/electron/electron/pull/24286 to BaseWindow

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed improper focus tracking in BaseWindow on MacOS