### PR TITLE
macOS: add support helper for Find pasteboard (Use Selection for Find)

### DIFF
--- a/shell/browser/ui/cocoa/find_pasteboard_mac.mm
+++ b/shell/browser/ui/cocoa/find_pasteboard_mac.mm
@@ -1,0 +1,13 @@
+#import <AppKit/AppKit.h>
+
+void WriteTextToFindPasteboard(NSString* text) {
+  if (!text || text.length == 0)
+    return;
+
+  NSPasteboard* findPasteboard =
+      [NSPasteboard pasteboardWithName:NSPasteboardNameFind];
+
+  [findPasteboard clearContents];
+  [findPasteboard setString:text
+                    forType:NSPasteboardTypeString];
+}

--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -321,7 +321,7 @@
 }
 
 - (BOOL)handleDrop:(id<NSDraggingInfo>)sender {
-  NSPasteboardNameFind* pboard = [sender draggingPasteboard];
+  NSPasteboard* pboard = [sender draggingPasteboard];
 
 // TODO(codebytere): update to currently supported NSPasteboardTypeFileURL or
 // kUTTypeFileURL.


### PR DESCRIPTION
#### Description of Change
This change adds a macOS-specific helper for writing text to the Find pasteboard (`NSPasteboardNameFind`).

On macOS, well-behaved applications support the “Use Selection for Find” feature by placing the selected text onto the Find pasteboard. This helper provides the native functionality needed for Electron apps to support that behavior.

This change does not wire the helper to menu actions yet; that integration can be done in a follow-up change.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes] describe the change in a way relevant to app developers,

#### Release Notes

Notes: I am working from Windows and was not able to test this change on macOS directly.