### PR TITLE
fix: avoid redundant `page-favicon-updated` events on `setBounds`

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2239,7 +2239,7 @@ void WebContents::DidUpdateFaviconURL(
         iter->icon_url.is_valid())
       unique_urls.insert(iter->icon_url);
   }
-  // Deduplicate: only emit if favicon URLs actually changed
+  // Only emit if favicon URLs actually changed
   if (unique_urls == last_favicon_urls_)
     return;
   last_favicon_urls_ = unique_urls;

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "base/containers/flat_set.h"
 #include "base/functional/callback_forward.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ptr_exclusion.h"


### PR DESCRIPTION
#### Description of Change

Closes #49392

Fixes an issue where calling `setBounds` on a `WebContentsView` unintentionally triggers the `page-favicon-updated` event even when the favicon has not actually changed.

Currently, layout-related updates such as resizing or repositioning a `WebContentsView` can cause redundant emissions of `page-favicon-updated`, which is unexpected and leads to duplicate callbacks in user code. This change ensures that the event is only emitted when there is a real change in the favicon data, preventing unnecessary and misleading notifications.

This makes the `page-favicon-updated` event more semantically correct and avoids side effects caused by purely visual or layout updates.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] PR description included
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers and are [capitalized, punctuated, and in past tense](https://github.com/electron/clerk/blob/main/README.md#examples).
---

#### Release Notes

Notes: Fixed an issue where calling `setBounds` on a `WebContentsView` could trigger redundant `page-favicon-updated` events even when the favicon had not changed.