### PR TITLE
fix: potential devtools crash on empty

### DIFF
--- a/lib/renderer/inspector.ts
+++ b/lib/renderer/inspector.ts
@@ -11,12 +11,14 @@ const { contextIsolationEnabled } = internalContextBridge;
 * 1) Use menu API to show context menu.
 */
 window.onload = function () {
-  if (contextIsolationEnabled) {
-    internalContextBridge.overrideGlobalValueFromIsolatedWorld([
-      'InspectorFrontendHost', 'showContextMenuAtPoint'
-    ], createMenu);
-  } else {
-    window.InspectorFrontendHost!.showContextMenuAtPoint = createMenu;
+  if (window.InspectorFrontendHost) {
+    if (contextIsolationEnabled) {
+      internalContextBridge.overrideGlobalValueFromIsolatedWorld([
+        'InspectorFrontendHost', 'showContextMenuAtPoint'
+      ], createMenu);
+    } else {
+      window.InspectorFrontendHost.showContextMenuAtPoint = createMenu;
+    }
   }
 };
 

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -830,7 +830,9 @@ gin_helper::Dictionary TraceKeyPath(const gin_helper::Dictionary& start,
                                     const std::vector<std::string>& key_path) {
   gin_helper::Dictionary current = start;
   for (size_t i = 0; i < key_path.size() - 1; i++) {
-    CHECK(current.Get(key_path[i], &current));
+    CHECK(current.Get(key_path[i], &current))
+        << "Failed to get property '" << key_path[i] << "' at index " << i
+        << " in key path";
   }
   return current;
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/49465.

`InspectorFrontendHost` can be null in some circumstances, so trying to override showContextMenuAtPoint on it from a non-DevTools context was causing a crash in [`TraceKeyPath`](https://github.com/electron/electron/blob/712205fecd1fab293e0b8c6ab8e72290a814e071/shell/renderer/api/electron_api_context_bridge.cc#L829-L838). This adds a guard to check that `InspectorFrontendHost` exists before attempting the override. Also improves the `CHECK` verbosity in the above function for easier debugging.

<details><summary>Details</summary>
<p>

```
[78072:0121/113508.866417:FATAL:electron/shell/renderer/api/electron_api_context_bridge.cc:833] Check failed: current.Get(key_path[i], &current). Failed to get property 'InspectorFrontendHost' at index 0 in key path
0   Electron Framework                  0x0000000123e0fe58 base::debug::CollectStackTrace(base::span<void const*, 18446744073709551615ul, void const**>) + 28
1   Electron Framework                  0x0000000123dffdc0 base::debug::StackTrace::StackTrace(unsigned long) + 224
2   Electron Framework                  0x0000000123d18af0 logging::LogMessage::Flush() + 156
3   Electron Framework                  0x0000000123d189cc logging::LogMessage::~LogMessage() + 36
4   Electron Framework                  0x0000000123d0345c logging::(anonymous namespace)::CheckLogMessage::~CheckLogMessage() + 76
5   Electron Framework                  0x0000000123d03124 logging::CheckNoreturnError::~CheckNoreturnError() + 16
6   Electron Framework                  0x0000000123d03134 logging::CheckNoreturnError::PCheck(char const*, base::Location const&) + 0
7   Electron Framework                  0x000000011ddcca60 bool gin_helper::Dictionary::Get<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>, gin_helper::Dictionary>(std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, gin_helper::Dictionary*) const + 0
8   Electron Framework                  0x000000011ddca1c8 electron::api::(anonymous namespace)::OverrideGlobalValueFromIsolatedWorld(v8::Isolate*, std::__Cr::vector<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>, std::__Cr::allocator<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>>> const&, v8::Local<v8::Object>, bool) + 208
9   Electron Framework                  0x000000011dbd5894 base::RepeatingCallback<void (electron::api::BaseWindow*, v8::Isolate*, v8::Local<v8::Value>, gin::Arguments*)>::Run(electron::api::BaseWindow*, v8::Isolate*, v8::Local<v8::Value>, gin::Arguments*) const & + 164
10  Electron Framework                  0x000000011ddcc610 gin_helper::Invoker<std::__Cr::integer_sequence<unsigned long, 0ul, 1ul, 2ul, 3ul>, v8::Isolate*, std::__Cr::vector<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>, std::__Cr::allocator<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>>> const&, v8::Local<v8::Object>, bool>::DispatchToCallback(base::RepeatingCallback<void (v8::Isolate*, std::__Cr::vector<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>, std::__Cr::allocator<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>>> const&, v8::Local<v8::Object>, bool)>) + 240
11  Electron Framework                  0x000000011ddcc4f4 gin_helper::Dispatcher<void (v8::Isolate*, std::__Cr::vector<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>, std::__Cr::allocator<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>>> const&, v8::Local<v8::Object>, bool)>::DispatchToCallbackImpl(gin::Arguments*) + 148
12  Electron Framework                  0x000000011ddcc3e4 gin_helper::Dispatcher<void (v8::Isolate*, std::__Cr::vector<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>, std::__Cr::allocator<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>>> const&, v8::Local<v8::Object>, bool)>::DispatchToCallback(v8::FunctionCallbackInfo<v8::Value> const&) + 44
13  ???                                 0x00000001779b08d4 0x0 + 6301616340
14  ???                                 0x00000001779addb4 0x0 + 6301605300
15  ???                                 0x00000001779addb4 0x0 + 6301605300
16  ???                                 0x00000001779a747c 0x0 + 6301578364
17  ???                                 0x00000001779a715c 0x0 + 6301577564
18  Electron Framework                  0x000000011f93cc4c v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) + 4904
19  Electron Framework                  0x000000011f93b840 v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::DirectHandle<v8::internal::Object>, v8::internal::DirectHandle<v8::internal::Object>, v8::base::Vector<v8::internal::DirectHandle<v8::internal::Object> const>) + 260
20  Electron Framework                  0x000000011f67d4c8 v8::Function::Call(v8::Isolate*, v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*) + 544
21  Electron Framework                  0x0000000126781394 blink::V8ScriptRunner::CallFunction(v8::Local<v8::Function>, blink::ExecutionContext*, v8::Local<v8::Value>, int, v8::Local<v8::Value>*, v8::Isolate*) + 936
22  Electron Framework                  0x0000000128bdbe9c blink::bindings::CallbackInvokeHelper<blink::CallbackFunctionBase, (blink::bindings::CallbackInvokeHelperMode)0, (blink::bindings::CallbackReturnTypeIsPromise)0>::CallInternal(int, v8::Local<v8::Value>*) + 196
23  Electron Framework                  0x0000000128bdbdc0 blink::bindings::CallbackInvokeHelper<blink::CallbackFunctionBase, (blink::bindings::CallbackInvokeHelperMode)0, (blink::bindings::CallbackReturnTypeIsPromise)0>::Call(int, v8::Local<v8::Value>*) + 20
24  Electron Framework                  0x0000000128be0764 blink::V8EventHandlerNonNull::InvokeWithoutRunnabilityCheck(blink::bindings::V8ValueOrScriptWrappableAdapter, blink::BasicHeapVector<(blink::internal::HeapCollectionType)1, blink::ScriptValue, 0u> const&) + 476
25  Electron Framework                  0x0000000126d5db68 blink::JSEventHandler::InvokeInternal(blink::EventTarget&, blink::Event&, v8::Local<v8::Value>) + 1140
26  Electron Framework                  0x0000000126cf10ec blink::JSBasedEventListener::Invoke(blink::ExecutionContext*, blink::Event*) + 976
27  Electron Framework                  0x0000000126cf69b8 blink::EventTarget::FireEventListeners(blink::Event&, blink::EventTargetData*, blink::BasicHeapVector<(blink::internal::HeapCollectionType)1, cppgc::internal::BasicMember<blink::RegisteredEventListener, cppgc::internal::StrongMemberTag, cppgc::internal::DijkstraWriteBarrierPolicy, cppgc::internal::DisabledCheckingPolicy, cppgc::internal::CompressedPointer>, 1u>) + 3440
28  Electron Framework                  0x0000000126cf5910 blink::EventTarget::FireEventListeners(blink::Event&) + 592
29  Electron Framework                  0x000000012706af34 blink::LocalDOMWindow::DispatchEvent(blink::Event&, blink::EventTarget*) + 232
30  Electron Framework                  0x000000012706a990 blink::LocalDOMWindow::DispatchLoadEvent() + 508
31  Electron Framework                  0x000000012706a5c8 blink::LocalDOMWindow::DispatchWindowLoadEvent() + 424
32  Electron Framework                  0x000000012706a9fc blink::LocalDOMWindow::DocumentWasClosed() + 28
33  Electron Framework                  0x000000012878f3cc blink::Document::ImplicitClose() + 140
34  Electron Framework                  0x000000012878fa68 blink::Document::CheckCompletedInternal() + 344
35  Electron Framework                  0x0000000128776d4c blink::Document::CheckCompleted() + 24
36  Electron Framework                  0x0000000127abeb20 blink::FrameLoader::FinishedParsing() + 812
37  Electron Framework                  0x00000001287abea4 blink::Document::FinishedParsing() + 1448
38  Electron Framework                  0x0000000128890d74 blink::HTMLConstructionSite::FinishedParsing() + 176
39  Electron Framework                  0x000000012893270c blink::HTMLTreeBuilder::Finished() + 164
40  Electron Framework                  0x00000001288c1ef0 blink::HTMLDocumentParser::end() + 176
41  Electron Framework                  0x00000001288b9edc blink::HTMLDocumentParser::AttemptToRunDeferredScriptsAndEnd() + 540
42  Electron Framework                  0x00000001288c4480 blink::HTMLDocumentParser::NotifyScriptLoaded() + 244
43  Electron Framework                  0x000000011db9ff0c base::OnceCallback<void ()>::Run() && + 108
44  Electron Framework                  0x00000001230a84e0 blink::ThreadCheckingCallbackWrapper<base::OnceCallback<void ()>, void ()>::Run() + 48
45  Electron Framework                  0x000000011db9ff0c base::OnceCallback<void ()>::Run() && + 108
46  Electron Framework                  0x0000000123d7afa8 base::TaskAnnotator::RunTaskImpl(base::PendingTask&) + 332
47  Electron Framework                  0x0000000123dad640 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*) + 1716
48  Electron Framework                  0x0000000123dacd58 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() + 96
49  Electron Framework                  0x0000000123d293cc base::MessagePumpDefault::Run(base::MessagePump::Delegate*) + 248
50  Electron Framework                  0x0000000123dae404 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) + 884
51  Electron Framework                  0x0000000123d5c29c base::RunLoop::Run(base::Location const&) + 996
52  Electron Framework                  0x00000001267056e4 content::RendererMain(content::MainFunctionParams) + 1416
53  Electron Framework                  0x000000011e2c2c98 content::RunOtherNamedProcessTypeMain(std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, content::MainFunctionParams, content::ContentMainDelegate*) + 748
54  Electron Framework                  0x000000011e2c4664 content::ContentMainRunnerImpl::Run() + 1076
55  Electron Framework                  0x000000011e2c1df0 content::RunContentProcess(content::ContentMainParams, content::ContentMainRunner*) + 1148
56  Electron Framework                  0x000000011e2c1fb4 content::ContentMain(content::ContentMainParams) + 112
57  Electron Framework                  0x000000011db94eac ElectronMain + 124
58  Electron Helper (Renderer)          0x0000000102bb4a38 main + 224
59  dyld                                0x000000019e4e1d54 start + 7184
Task trace:
0   Electron Framework                  0x00000001288a4a48 blink::HTMLParserScriptRunner::PendingScriptFinished(blink::PendingScript*) + 272
1   Electron Framework                  0x0000000127e0e6f0 blink::ModuleMap::Entry::DispatchFinishedNotificationAsync(blink::SingleModuleClient*, v8::ModuleImportPhase) + 168
2   Electron Framework                  0x00000001273cbb38 blink::ScriptDecoderWithClient::FinishDecode(blink::CrossThreadOnceFunction<void ()>) + 500
3   Electron Framework                  0x00000001273cbc70 blink::ScriptDecoderWithClient::FinishDecode(blink::CrossThreadOnceFunction<void ()>) + 812
4   Electron Framework                  0x00000001273cf43c blink::ResourceScriptStreamer::TryStartStreamingTask() + 2992
Task trace buffer limit hit, update PendingTask::kTaskBacktraceLength to increase.
Crash keys:
  "renderer_foreground" = "true"
  "v8_ro_space_firstpage_address" = "0x3f8f00000000"
  "v8_isolate_address" = "0x10c00780000"
  "num-experiments" = "0"
  "chrome-trace-id" = "6769442670109991643"
  "platform" = "darwin"
  "process_type" = "renderer"
  "osarch" = "arm64"
  "pid" = "78072"
  "ptype" = "renderer"

Received signal 6
0   Electron Framework                  0x0000000123e0fe58 base::debug::CollectStackTrace(base::span<void const*, 18446744073709551615ul, void const**>) + 28
1   Electron Framework                  0x0000000123dffdc0 base::debug::StackTrace::StackTrace(unsigned long) + 224
2   Electron Framework                  0x0000000123e0fdac base::debug::(anonymous namespace)::StackDumpSignalHandler(int, __siginfo*, void*) + 940
3   libsystem_platform.dylib            0x000000019e8b3744 _sigtramp + 56
4   libsystem_pthread.dylib             0x000000019e8a9888 pthread_kill + 296
5   libsystem_c.dylib                   0x000000019e7ae850 abort + 124
6   Electron Framework                  0x0000000123d19630 logging::LogMessage::HandleFatal(unsigned long, std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&) const + 468
7   Electron Framework                  0x0000000123d191b4 logging::LogMessage::Flush() + 1888
8   Electron Framework                  0x0000000123d189cc logging::LogMessage::~LogMessage() + 36
9   Electron Framework                  0x0000000123d0345c logging::(anonymous namespace)::CheckLogMessage::~CheckLogMessage() + 76
10  Electron Framework                  0x0000000123d03124 logging::CheckNoreturnError::~CheckNoreturnError() + 16
11  Electron Framework                  0x0000000123d03134 logging::CheckNoreturnError::PCheck(char const*, base::Location const&) + 0
12  Electron Framework                  0x000000011ddcca60 bool gin_helper::Dictionary::Get<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>, gin_helper::Dictionary>(std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, gin_helper::Dictionary*) const + 0
13  Electron Framework                  0x000000011ddca1c8 electron::api::(anonymous namespace)::OverrideGlobalValueFromIsolatedWorld(v8::Isolate*, std::__Cr::vector<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>, std::__Cr::allocator<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>>> const&, v8::Local<v8::Object>, bool) + 208
14  Electron Framework                  0x000000011dbd5894 base::RepeatingCallback<void (electron::api::BaseWindow*, v8::Isolate*, v8::Local<v8::Value>, gin::Arguments*)>::Run(electron::api::BaseWindow*, v8::Isolate*, v8::Local<v8::Value>, gin::Arguments*) const & + 164
15  Electron Framework                  0x000000011ddcc610 gin_helper::Invoker<std::__Cr::integer_sequence<unsigned long, 0ul, 1ul, 2ul, 3ul>, v8::Isolate*, std::__Cr::vector<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>, std::__Cr::allocator<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>>> const&, v8::Local<v8::Object>, bool>::DispatchToCallback(base::RepeatingCallback<void (v8::Isolate*, std::__Cr::vector<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>, std::__Cr::allocator<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>>> const&, v8::Local<v8::Object>, bool)>) + 240
16  Electron Framework                  0x000000011ddcc4f4 gin_helper::Dispatcher<void (v8::Isolate*, std::__Cr::vector<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>, std::__Cr::allocator<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>>> const&, v8::Local<v8::Object>, bool)>::DispatchToCallbackImpl(gin::Arguments*) + 148
17  Electron Framework                  0x000000011ddcc3e4 gin_helper::Dispatcher<void (v8::Isolate*, std::__Cr::vector<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>, std::__Cr::allocator<std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>>> const&, v8::Local<v8::Object>, bool)>::DispatchToCallback(v8::FunctionCallbackInfo<v8::Value> const&) + 44
18  ???                                 0x00000001779b08d4 0x0 + 6301616340
19  ???                                 0x00000001779addb4 0x0 + 6301605300
20  ???                                 0x00000001779addb4 0x0 + 6301605300
21  ???                                 0x00000001779a747c 0x0 + 6301578364
22  ???                                 0x00000001779a715c 0x0 + 6301577564
23  Electron Framework                  0x000000011f93cc4c v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) + 4904
24  Electron Framework                  0x000000011f93b840 v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::DirectHandle<v8::internal::Object>, v8::internal::DirectHandle<v8::internal::Object>, v8::base::Vector<v8::internal::DirectHandle<v8::internal::Object> const>) + 260
25  Electron Framework                  0x000000011f67d4c8 v8::Function::Call(v8::Isolate*, v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*) + 544
26  Electron Framework                  0x0000000126781394 blink::V8ScriptRunner::CallFunction(v8::Local<v8::Function>, blink::ExecutionContext*, v8::Local<v8::Value>, int, v8::Local<v8::Value>*, v8::Isolate*) + 936
27  Electron Framework                  0x0000000128bdbe9c blink::bindings::CallbackInvokeHelper<blink::CallbackFunctionBase, (blink::bindings::CallbackInvokeHelperMode)0, (blink::bindings::CallbackReturnTypeIsPromise)0>::CallInternal(int, v8::Local<v8::Value>*) + 196
28  Electron Framework                  0x0000000128bdbdc0 blink::bindings::CallbackInvokeHelper<blink::CallbackFunctionBase, (blink::bindings::CallbackInvokeHelperMode)0, (blink::bindings::CallbackReturnTypeIsPromise)0>::Call(int, v8::Local<v8::Value>*) + 20
29  Electron Framework                  0x0000000128be0764 blink::V8EventHandlerNonNull::InvokeWithoutRunnabilityCheck(blink::bindings::V8ValueOrScriptWrappableAdapter, blink::BasicHeapVector<(blink::internal::HeapCollectionType)1, blink::ScriptValue, 0u> const&) + 476
30  Electron Framework                  0x0000000126d5db68 blink::JSEventHandler::InvokeInternal(blink::EventTarget&, blink::Event&, v8::Local<v8::Value>) + 1140
31  Electron Framework                  0x0000000126cf10ec blink::JSBasedEventListener::Invoke(blink::ExecutionContext*, blink::Event*) + 976
32  Electron Framework                  0x0000000126cf69b8 blink::EventTarget::FireEventListeners(blink::Event&, blink::EventTargetData*, blink::BasicHeapVector<(blink::internal::HeapCollectionType)1, cppgc::internal::BasicMember<blink::RegisteredEventListener, cppgc::internal::StrongMemberTag, cppgc::internal::DijkstraWriteBarrierPolicy, cppgc::internal::DisabledCheckingPolicy, cppgc::internal::CompressedPointer>, 1u>) + 3440
33  Electron Framework                  0x0000000126cf5910 blink::EventTarget::FireEventListeners(blink::Event&) + 592
34  Electron Framework                  0x000000012706af34 blink::LocalDOMWindow::DispatchEvent(blink::Event&, blink::EventTarget*) + 232
35  Electron Framework                  0x000000012706a990 blink::LocalDOMWindow::DispatchLoadEvent() + 508
36  Electron Framework                  0x000000012706a5c8 blink::LocalDOMWindow::DispatchWindowLoadEvent() + 424
37  Electron Framework                  0x000000012706a9fc blink::LocalDOMWindow::DocumentWasClosed() + 28
38  Electron Framework                  0x000000012878f3cc blink::Document::ImplicitClose() + 140
39  Electron Framework                  0x000000012878fa68 blink::Document::CheckCompletedInternal() + 344
40  Electron Framework                  0x0000000128776d4c blink::Document::CheckCompleted() + 24
41  Electron Framework                  0x0000000127abeb20 blink::FrameLoader::FinishedParsing() + 812
42  Electron Framework                  0x00000001287abea4 blink::Document::FinishedParsing() + 1448
43  Electron Framework                  0x0000000128890d74 blink::HTMLConstructionSite::FinishedParsing() + 176
44  Electron Framework                  0x000000012893270c blink::HTMLTreeBuilder::Finished() + 164
45  Electron Framework                  0x00000001288c1ef0 blink::HTMLDocumentParser::end() + 176
46  Electron Framework                  0x00000001288b9edc blink::HTMLDocumentParser::AttemptToRunDeferredScriptsAndEnd() + 540
47  Electron Framework                  0x00000001288c4480 blink::HTMLDocumentParser::NotifyScriptLoaded() + 244
48  Electron Framework                  0x000000011db9ff0c base::OnceCallback<void ()>::Run() && + 108
49  Electron Framework                  0x00000001230a84e0 blink::ThreadCheckingCallbackWrapper<base::OnceCallback<void ()>, void ()>::Run() + 48
50  Electron Framework                  0x000000011db9ff0c base::OnceCallback<void ()>::Run() && + 108
51  Electron Framework                  0x0000000123d7afa8 base::TaskAnnotator::RunTaskImpl(base::PendingTask&) + 332
52  Electron Framework                  0x0000000123dad640 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*) + 1716
53  Electron Framework                  0x0000000123dacd58 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() + 96
54  Electron Framework                  0x0000000123d293cc base::MessagePumpDefault::Run(base::MessagePump::Delegate*) + 248
55  Electron Framework                  0x0000000123dae404 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) + 884
56  Electron Framework                  0x0000000123d5c29c base::RunLoop::Run(base::Location const&) + 996
57  Electron Framework                  0x00000001267056e4 content::RendererMain(content::MainFunctionParams) + 1416
58  Electron Framework                  0x000000011e2c2c98 content::RunOtherNamedProcessTypeMain(std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, content::MainFunctionParams, content::ContentMainDelegate*) + 748
59  Electron Framework                  0x000000011e2c4664 content::ContentMainRunnerImpl::Run() + 1076
60  Electron Framework                  0x000000011e2c1df0 content::RunContentProcess(content::ContentMainParams, content::ContentMainRunner*) + 1148
61  Electron Framework                  0x000000011e2c1fb4 content::ContentMain(content::ContentMainParams) + 112
62  Electron Framework                  0x000000011db94eac ElectronMain + 124
63  Electron Helper (Renderer)          0x0000000102bb4a38 main + 224
64  dyld                                0x000000019e4e1d54 start + 7184
[end of stack trace]
Renderer process crashed - see https://www.electronjs.org/docs/tutorial/application-debugging for potential debugging information.
```

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
