### PR TITLE
fix: second argument to `shell.writeShortcutLink` is optional

### DIFF
--- a/shell/common/api/electron_api_shell.cc
+++ b/shell/common/api/electron_api_shell.cc
@@ -112,11 +112,20 @@ bool WriteShortcutLink(const base::FilePath& shortcut_path,
                        gin::Arguments* const args) {
   base::win::ShortcutOperation operation =
       base::win::ShortcutOperation::kCreateAlways;
-  args->GetNext(&operation);
-  auto options = gin::Dictionary::CreateEmpty(args->isolate());
-  if (!args->GetNext(&options)) {
-    args->ThrowError();
-    return false;
+  gin::Dictionary options = gin::Dictionary::CreateEmpty(args->isolate());
+
+  v8::Local<v8::Value> peek = args->PeekNext();
+  if (peek->IsObject()) {
+    if (!args->GetNext(&options)) {
+      args->ThrowError();
+      return false;
+    }
+  } else {
+    args->GetNext(&operation);
+    if (!args->GetNext(&options)) {
+      args->ThrowError();
+      return false;
+    }
   }
 
   base::win::ShortcutProperties properties;

--- a/spec/api-shell-spec.ts
+++ b/spec/api-shell-spec.ts
@@ -172,6 +172,16 @@ describe('shell module', () => {
       expect(fs.existsSync(tmpShortcut)).to.be.true();
     });
 
+    it('writes the shortcut with omitted operation (defaults to create)', () => {
+      expect(shell.writeShortcutLink(tmpShortcut, shortcutOptions)).to.be.true();
+      expect(fs.existsSync(tmpShortcut)).to.be.true();
+      expect(shell.readShortcutLink(tmpShortcut)).to.deep.equal(shortcutOptions);
+
+      const newOptions = { ...shortcutOptions, description: 'new description' };
+      expect(shell.writeShortcutLink(tmpShortcut, newOptions)).to.be.true();
+      expect(shell.readShortcutLink(tmpShortcut)).to.deep.equal(newOptions);
+    });
+
     it('correctly sets the fields', () => {
       expect(shell.writeShortcutLink(tmpShortcut, shortcutOptions)).to.be.true();
       expect(shell.readShortcutLink(tmpShortcut)).to.deep.equal(shortcutOptions);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/49469

Fixes an issue where `shell.writeShortcutLink` was throwing `TypeError: Insufficient number of arguments` when called with just `[(path, options)]` and no operation argument, even though the docs say operation should default to "create". Fix the argument parsing to check if the second argument is an object (options) or a string (operation), allowing the operation to be optional as expected.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `shell.writeShortcutLink` was throwing `TypeError: Insufficient number of arguments` when called with just `[(path, options)]`.
