### PR TITLE
chore: cherry-pick dba49550b12d from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -1,1 +1,2 @@
 chore_allow_customizing_microtask_policy_per_context.patch
+cherry-pick-dba49550b12d.patch

--- a/patches/v8/cherry-pick-dba49550b12d.patch
+++ b/patches/v8/cherry-pick-dba49550b12d.patch
@@ -1,0 +1,268 @@
+From dba49550b12d2aa83e8f40b17bd79c5f7999b64c Mon Sep 17 00:00:00 2001
+From: Olivier Flückiger <olivf@chromium.org>
+Date: Mon, 12 Jan 2026 15:41:30 +0100
+Subject: [PATCH] Merged: [map] Fix publishing of integrity-level transitions
+
+Integrity level transition target maps should not be published to the
+map tree before they are fully initialized. Otherwise concurrent access
+might pick up not fully updated target maps.
+
+Drive-By: Fix a dcheck in the map-updater to not fire when an indirectly
+reachable non-deprecatable map is deprecated due to the whole subtree
+being deprecated.
+
+Fixed: 473851441
+(cherry picked from commit e7f117bdb2fb4acbe619cf26aae2e011bf7f0e25)
+
+Change-Id: I8530281a55bbeed1dd158a126bad807029bf47ae
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7485546
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: Olivier Flückiger <olivf@chromium.org>
+Cr-Commit-Position: refs/branch-heads/14.4@{#40}
+Cr-Branched-From: 80acc26727d5a34e77dabeebe7c9213ec1bd4768-refs/heads/14.4.258@{#1}
+Cr-Branched-From: ce7e597e90f6df3fa4b6df224bc613b80c635450-refs/heads/main@{#104020}
+---
+
+diff --git a/src/objects/map.cc b/src/objects/map.cc
+index 1428c1c..c316181 100644
+--- a/src/objects/map.cc
++++ b/src/objects/map.cc
+@@ -646,20 +646,25 @@
+ }
+ 
+ void Map::DeprecateTransitionTree(Isolate* isolate) {
++  DCHECK(CanBeDeprecated());
++  return DeprecateTransitionTreeImpl(isolate);
++}
++
++void Map::DeprecateTransitionTreeImpl(Isolate* isolate) {
+   if (is_deprecated()) return;
+   DisallowGarbageCollection no_gc;
+   ReadOnlyRoots roots(isolate);
+   TransitionsAccessor transitions(isolate, *this);
+   transitions.ForEachTransition(
+-      &no_gc, [&](Tagged<Map> map) { map->DeprecateTransitionTree(isolate); },
++      &no_gc,
++      [&](Tagged<Map> map) { map->DeprecateTransitionTreeImpl(isolate); },
+       [&](Tagged<Map> map) {
+         if (v8_flags.move_prototype_transitions_first) {
+-          map->DeprecateTransitionTree(isolate);
++          map->DeprecateTransitionTreeImpl(isolate);
+         }
+       },
+       nullptr);
+   DCHECK(!IsFunctionTemplateInfo(constructor_or_back_pointer()));
+-  DCHECK(CanBeDeprecated());
+   set_is_deprecated(true);
+   if (v8_flags.log_maps) {
+     LOG(isolate, MapEvent("Deprecate", direct_handle(*this, isolate), {}));
+@@ -1574,6 +1579,22 @@
+     DirectHandle<DescriptorArray> descriptors, TransitionFlag flag,
+     MaybeDirectHandle<Name> maybe_name, const char* reason,
+     TransitionKindFlag transition_kind) {
++  // Special transitions need to pass an InitMap function to initialize the map
++  // before inserting it into the transition tree.
++  CHECK_IMPLIES(flag == INSERT_TRANSITION,
++                transition_kind == PROPERTY_TRANSITION ||
++                    transition_kind == SIMPLE_PROPERTY_TRANSITION);
++  return CopyReplaceDescriptors(
++      isolate, map, descriptors, flag, [&](Handle<Map>) {}, maybe_name, reason,
++      transition_kind);
++}
++
++template <typename InitMapCb>
++Handle<Map> Map::CopyReplaceDescriptors(
++    Isolate* isolate, DirectHandle<Map> map,
++    DirectHandle<DescriptorArray> descriptors, TransitionFlag flag,
++    const InitMapCb& InitMap, MaybeDirectHandle<Name> maybe_name,
++    const char* reason, TransitionKindFlag transition_kind) {
+   DCHECK(descriptors->IsSortedNoDuplicates());
+ 
+   Handle<Map> result = CopyDropDescriptors(isolate, map);
+@@ -1585,15 +1606,16 @@
+     result->set_may_have_interesting_properties(true);
+   }
+ 
++  bool insert_transition = false;
+   if (map->is_prototype_map()) {
+     result->InitializeDescriptors(isolate, *descriptors);
+   } else {
+     if (flag == INSERT_TRANSITION &&
+         TransitionsAccessor::CanHaveMoreTransitions(isolate, map)) {
++      insert_transition = true;
+       result->InitializeDescriptors(isolate, *descriptors);
+ 
+       DCHECK(!maybe_name.is_null());
+-      ConnectTransition(isolate, map, result, name, transition_kind);
+       is_connected = true;
+     } else if ((transition_kind == PROTOTYPE_TRANSITION &&
+                 v8_flags.move_prototype_transitions_first) ||
+@@ -1611,6 +1633,10 @@
+       result->InitializeDescriptors(isolate, *descriptors);
+     }
+   }
++  InitMap(result);
++  if (insert_transition) {
++    ConnectTransition(isolate, map, result, name, transition_kind);
++  }
+   if (v8_flags.log_maps && !is_connected) {
+     LOG(isolate,
+         MapEvent("ReplaceDescriptors", map, result, reason,
+@@ -1866,68 +1892,70 @@
+       DescriptorArray::CopyUpToAddAttributes(
+           isolate, direct_handle(map->instance_descriptors(isolate), isolate),
+           num_descriptors, attrs_to_add);
++
++  auto InitMap = [&](Handle<Map> new_map) {
++    new_map->set_is_extensible(false);
++    if (!IsTypedArrayOrRabGsabTypedArrayElementsKind(map->elements_kind())) {
++      ElementsKind new_kind = IsStringWrapperElementsKind(map->elements_kind())
++                                  ? SLOW_STRING_WRAPPER_ELEMENTS
++                                  : DICTIONARY_ELEMENTS;
++      if (!old_map_is_dictionary_elements_kind) {
++        switch (map->elements_kind()) {
++          case PACKED_ELEMENTS:
++            if (attrs_to_add == SEALED) {
++              new_kind = PACKED_SEALED_ELEMENTS;
++            } else if (attrs_to_add == FROZEN) {
++              new_kind = PACKED_FROZEN_ELEMENTS;
++            } else {
++              new_kind = PACKED_NONEXTENSIBLE_ELEMENTS;
++            }
++            break;
++          case PACKED_NONEXTENSIBLE_ELEMENTS:
++            if (attrs_to_add == SEALED) {
++              new_kind = PACKED_SEALED_ELEMENTS;
++            } else if (attrs_to_add == FROZEN) {
++              new_kind = PACKED_FROZEN_ELEMENTS;
++            }
++            break;
++          case PACKED_SEALED_ELEMENTS:
++            if (attrs_to_add == FROZEN) {
++              new_kind = PACKED_FROZEN_ELEMENTS;
++            }
++            break;
++          case HOLEY_ELEMENTS:
++            if (attrs_to_add == SEALED) {
++              new_kind = HOLEY_SEALED_ELEMENTS;
++            } else if (attrs_to_add == FROZEN) {
++              new_kind = HOLEY_FROZEN_ELEMENTS;
++            } else {
++              new_kind = HOLEY_NONEXTENSIBLE_ELEMENTS;
++            }
++            break;
++          case HOLEY_NONEXTENSIBLE_ELEMENTS:
++            if (attrs_to_add == SEALED) {
++              new_kind = HOLEY_SEALED_ELEMENTS;
++            } else if (attrs_to_add == FROZEN) {
++              new_kind = HOLEY_FROZEN_ELEMENTS;
++            }
++            break;
++          case HOLEY_SEALED_ELEMENTS:
++            if (attrs_to_add == FROZEN) {
++              new_kind = HOLEY_FROZEN_ELEMENTS;
++            }
++            break;
++          default:
++            break;
++        }
++      }
++      new_map->set_elements_kind(new_kind);
++    }
++  };
++
+   // Do not track transitions during bootstrapping.
+   TransitionFlag flag =
+       isolate->bootstrapper()->IsActive() ? OMIT_TRANSITION : INSERT_TRANSITION;
+-  Handle<Map> new_map =
+-      CopyReplaceDescriptors(isolate, map, new_desc, flag, transition_marker,
+-                             reason, SPECIAL_TRANSITION);
+-  new_map->set_is_extensible(false);
+-  if (!IsTypedArrayOrRabGsabTypedArrayElementsKind(map->elements_kind())) {
+-    ElementsKind new_kind = IsStringWrapperElementsKind(map->elements_kind())
+-                                ? SLOW_STRING_WRAPPER_ELEMENTS
+-                                : DICTIONARY_ELEMENTS;
+-    if (!old_map_is_dictionary_elements_kind) {
+-      switch (map->elements_kind()) {
+-        case PACKED_ELEMENTS:
+-          if (attrs_to_add == SEALED) {
+-            new_kind = PACKED_SEALED_ELEMENTS;
+-          } else if (attrs_to_add == FROZEN) {
+-            new_kind = PACKED_FROZEN_ELEMENTS;
+-          } else {
+-            new_kind = PACKED_NONEXTENSIBLE_ELEMENTS;
+-          }
+-          break;
+-        case PACKED_NONEXTENSIBLE_ELEMENTS:
+-          if (attrs_to_add == SEALED) {
+-            new_kind = PACKED_SEALED_ELEMENTS;
+-          } else if (attrs_to_add == FROZEN) {
+-            new_kind = PACKED_FROZEN_ELEMENTS;
+-          }
+-          break;
+-        case PACKED_SEALED_ELEMENTS:
+-          if (attrs_to_add == FROZEN) {
+-            new_kind = PACKED_FROZEN_ELEMENTS;
+-          }
+-          break;
+-        case HOLEY_ELEMENTS:
+-          if (attrs_to_add == SEALED) {
+-            new_kind = HOLEY_SEALED_ELEMENTS;
+-          } else if (attrs_to_add == FROZEN) {
+-            new_kind = HOLEY_FROZEN_ELEMENTS;
+-          } else {
+-            new_kind = HOLEY_NONEXTENSIBLE_ELEMENTS;
+-          }
+-          break;
+-        case HOLEY_NONEXTENSIBLE_ELEMENTS:
+-          if (attrs_to_add == SEALED) {
+-            new_kind = HOLEY_SEALED_ELEMENTS;
+-          } else if (attrs_to_add == FROZEN) {
+-            new_kind = HOLEY_FROZEN_ELEMENTS;
+-          }
+-          break;
+-        case HOLEY_SEALED_ELEMENTS:
+-          if (attrs_to_add == FROZEN) {
+-            new_kind = HOLEY_FROZEN_ELEMENTS;
+-          }
+-          break;
+-        default:
+-          break;
+-      }
+-    }
+-    new_map->set_elements_kind(new_kind);
+-  }
+-  return new_map;
++  return CopyReplaceDescriptors(isolate, map, new_desc, flag, InitMap,
++                                transition_marker, reason, SPECIAL_TRANSITION);
+ }
+ 
+ namespace {
+diff --git a/src/objects/map.h b/src/objects/map.h
+index 37ce48e..3b50cc4 100644
+--- a/src/objects/map.h
++++ b/src/objects/map.h
+@@ -1070,6 +1070,14 @@
+   static Handle<Map> CopyAddDescriptor(Isolate* isolate, DirectHandle<Map> map,
+                                        Descriptor* descriptor,
+                                        TransitionFlag flag);
++
++  template <typename InitMapCb>
++  static Handle<Map> CopyReplaceDescriptors(
++      Isolate* isolate, DirectHandle<Map> map,
++      DirectHandle<DescriptorArray> descriptors, TransitionFlag flag,
++      const InitMapCb& InitMap, MaybeDirectHandle<Name> maybe_name,
++      const char* reason, TransitionKindFlag transition_kind);
++
+   static Handle<Map> CopyReplaceDescriptors(
+       Isolate* isolate, DirectHandle<Map> map,
+       DirectHandle<DescriptorArray> descriptors, TransitionFlag flag,
+@@ -1084,6 +1092,7 @@
+                                     PropertyNormalizationMode mode);
+ 
+   void DeprecateTransitionTree(Isolate* isolate);
++  void DeprecateTransitionTreeImpl(Isolate* isolate);
+ 
+   void ReplaceDescriptors(Isolate* isolate,
+                           Tagged<DescriptorArray> new_descriptors);


### PR DESCRIPTION
Merged: [map] Fix publishing of integrity-level transitions

Integrity level transition target maps should not be published to the
map tree before they are fully initialized. Otherwise concurrent access
might pick up not fully updated target maps.

Drive-By: Fix a dcheck in the map-updater to not fire when an indirectly
reachable non-deprecatable map is deprecated due to the whole subtree
being deprecated.

Fixed: 473851441
(cherry picked from commit e7f117bdb2fb4acbe619cf26aae2e011bf7f0e25)

Change-Id: I8530281a55bbeed1dd158a126bad807029bf47ae
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7485546
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Commit-Queue: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Auto-Submit: Olivier Flückiger <olivf@chromium.org>
Cr-Commit-Position: refs/branch-heads/14.4@{#40}
Cr-Branched-From: 80acc26727d5a34e77dabeebe7c9213ec1bd4768-refs/heads/14.4.258@{#1}
Cr-Branched-From: ce7e597e90f6df3fa4b6df224bc613b80c635450-refs/heads/main@{#104020}


Notes: Backported fix for 473851441.