### PR TITLE
refactor: use `gin::Wrappable` for `electron::api::Screen`

### DIFF
--- a/patches/chromium/chore_add_electron_objects_to_wrappablepointertag.patch
+++ b/patches/chromium/chore_add_electron_objects_to_wrappablepointertag.patch
@@ -8,10 +8,10 @@ electron objects that extend gin::Wrappable and gets
 allocated on the cpp heap
 
 diff --git a/gin/public/wrappable_pointer_tags.h b/gin/public/wrappable_pointer_tags.h
-index 573bcb2e56068a2ade6d8ab28964b077487874fd..16145e466cd560784b89681aa642e350d5b28f12 100644
+index 573bcb2e56068a2ade6d8ab28964b077487874fd..41759b87e1aec4ec125560b9a52828fb44bc5999 100644
 --- a/gin/public/wrappable_pointer_tags.h
 +++ b/gin/public/wrappable_pointer_tags.h
-@@ -74,7 +74,17 @@ enum WrappablePointerTag : uint16_t {
+@@ -74,7 +74,18 @@ enum WrappablePointerTag : uint16_t {
    kTextInputControllerBindings,  // content::TextInputControllerBindings
    kWebAXObjectProxy,             // content::WebAXObjectProxy
    kWrappedExceptionHandler,      // extensions::WrappedExceptionHandler
@@ -24,6 +24,7 @@ index 573bcb2e56068a2ade6d8ab28964b077487874fd..16145e466cd560784b89681aa642e350
 +  kElectronNetLog,                      // electron::api::NetLog
 +  kElectronPowerSaveBlocker,            // electron::api::PowerSaveBlocker
 +  kElectronReplyChannel,                // gin_helper::internal::ReplyChannel
++  kElectronScreen,                      // electron::api::Screen
 +  kElectronSession,                     // electron::api::Session
 +  kElectronWebRequest,                  // electron::api::WebRequest
 +  kLastPointerTag = kElectronWebRequest,

--- a/shell/browser/api/electron_api_screen.h
+++ b/shell/browser/api/electron_api_screen.h
@@ -8,8 +8,8 @@
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
+#include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
-#include "shell/common/gin_helper/wrappable.h"
 #include "ui/display/display_observer.h"
 #include "ui/display/screen.h"
 
@@ -17,7 +17,6 @@ namespace gfx {
 class Point;
 class PointF;
 class Rect;
-class Screen;
 }  // namespace gfx
 
 namespace gin_helper {
@@ -26,23 +25,25 @@ class ErrorThrower;
 
 namespace electron::api {
 
-class Screen final : public gin_helper::DeprecatedWrappable<Screen>,
+class Screen final : public gin::Wrappable<Screen>,
                      public gin_helper::EventEmitterMixin<Screen>,
                      private display::DisplayObserver {
  public:
-  static v8::Local<v8::Value> Create(gin_helper::ErrorThrower error_thrower);
+  static Screen* Create(gin_helper::ErrorThrower error_thrower);
 
-  static gin::DeprecatedWrapperInfo kWrapperInfo;
+  static const gin::WrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;
-  const char* GetTypeName() override;
+  const gin::WrapperInfo* wrapper_info() const override;
+  const char* GetHumanReadableName() const override;
+  const char* GetClassName() const { return "Screen"; }
 
   // disable copy
   Screen(const Screen&) = delete;
   Screen& operator=(const Screen&) = delete;
 
- protected:
-  Screen(v8::Isolate* isolate, display::Screen* screen);
+  // Make public for cppgc::MakeGarbageCollected.
+  explicit Screen(display::Screen* screen);
   ~Screen() override;
 
   gfx::Point GetCursorScreenPoint(v8::Isolate* isolate);


### PR DESCRIPTION
#### Description of Change

Part of #47922.

This PR migrates `electron::api::Screen` to inherit from `gin::Wrappable` instead of from `gin_helper::DeprecatedWrappable`.

#### Checklist

- [x] PR description included
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.