### PR TITLE
docs: add more api history (C-D)

### DIFF
--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -1,5 +1,14 @@
 # clipboard
 
+<!--
+```YAML history
+deprecated:
+  - pr-url: https://github.com/electron/electron/pull/48877
+    description: "Using the `clipboard` API directly in the renderer process is deprecated."
+    breaking-changes-header: deprecated-clipboard-api-access-from-renderer-processes
+```
+-->
+
 > Perform copy and paste operations on the system clipboard.
 
 Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process) _Deprecated_ (non-sandboxed only)

--- a/docs/api/content-tracing.md
+++ b/docs/api/content-tracing.md
@@ -33,6 +33,15 @@ The `contentTracing` module has the following methods:
 
 ### `contentTracing.getCategories()`
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/16583
+    description: "This method now returns a Promise instead of using a callback function."
+    breaking-changes-header: api-changed-callback-based-versions-of-promisified-apis
+```
+-->
+
 Returns `Promise<string[]>` - resolves with an array of category groups once all child processes have acknowledged the `getCategories` request
 
 Get a set of category groups. The category groups can change as new code paths
@@ -43,6 +52,17 @@ are reached. See also the
 > This category can be used to capture Electron-specific tracing events.
 
 ### `contentTracing.startRecording(options)`
+
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/13914
+    description: "The `options` parameter now accepts `TraceConfig` in addition to `TraceCategoriesAndOptions`."
+  - pr-url: https://github.com/electron/electron/pull/16584
+    description: "This function now returns a callback`Promise<void>`."
+    breaking-changes-header: api-changed-callback-based-versions-of-promisified-apis
+```
+-->
 
 * `options` ([TraceConfig](structures/trace-config.md) | [TraceCategoriesAndOptions](structures/trace-categories-and-options.md))
 
@@ -57,6 +77,17 @@ If a recording is already running, the promise will be immediately resolved, as
 only one trace operation can be in progress at a time.
 
 ### `contentTracing.stopRecording([resultFilePath])`
+
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/16584
+    description: "This method now returns a Promise instead of using a callback function."
+    breaking-changes-header: api-changed-callback-based-versions-of-promisified-apis
+  - pr-url: https://github.com/electron/electron/pull/18411
+    description: "The `resultFilePath` parameter is now optional."
+```
+-->
 
 * `resultFilePath` string (optional)
 
@@ -75,6 +106,15 @@ or not provided, trace data will be written to a temporary file, and the path
 will be returned in the promise.
 
 ### `contentTracing.getTraceBufferUsage()`
+
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/16600
+    description: "This method now returns a Promise instead of using a callback function."
+    breaking-changes-header: api-changed-callback-based-versions-of-promisified-apis
+```
+-->
 
 Returns `Promise<Object>` - Resolves with an object containing the `value` and `percentage` of trace buffer maximum usage
 

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -50,6 +50,22 @@ The `crashReporter` module has the following methods:
 
 ### `crashReporter.start(options)`
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/23062
+    description: "Added `rateLimit` and `compress` options."
+  - pr-url: https://github.com/electron/electron/pull/23265
+    description: "Deprecated calling this method in the renderer process."
+    breaking-changes-header: deprecated-crashreporter-methods-in-the-renderer-process
+  - pr-url: https://github.com/electron/electron/pull/25288
+    description: "Default value of `compress` option changed from `false` to `true`."
+    breaking-changes-header: default-changed-crashreporterstart-compress-true-
+  - pr-url: https://github.com/electron/electron/pull/28105
+    description: "The `submitURL` parameter is now optional when `uploadToServer` is `false`."
+```
+-->
+
 * `options` Object
   * `submitURL` string (optional) - URL that crash reports will be sent to as
     POST. Required unless `uploadToServer` is `false`.
@@ -111,6 +127,15 @@ by the crash reporter.
 
 ### `crashReporter.getLastCrashReport()`
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/23265
+    description: "Deprecated calling this method in the renderer process."
+    breaking-changes-header: deprecated-crashreporter-methods-in-the-renderer-process
+```
+-->
+
 Returns [`CrashReport | null`](structures/crash-report.md) - The date and ID of the
 last crash report. Only crash reports that have been uploaded will be returned;
 even if a crash report is present on disk it will not be returned until it is
@@ -120,6 +145,15 @@ uploaded. In the case that there are no uploaded reports, `null` is returned.
 > This method is only available in the main process.
 
 ### `crashReporter.getUploadedReports()`
+
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/23265
+    description: "Deprecated calling this method in the renderer process."
+    breaking-changes-header: deprecated-crashreporter-methods-in-the-renderer-process
+```
+-->
 
 Returns [`CrashReport[]`](structures/crash-report.md):
 
@@ -131,6 +165,15 @@ ID.
 
 ### `crashReporter.getUploadToServer()`
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/23265
+    description: "Deprecated calling this method in the renderer process."
+    breaking-changes-header: deprecated-crashreporter-methods-in-the-renderer-process
+```
+-->
+
 Returns `boolean` - Whether reports should be submitted to the server. Set through
 the `start` method or `setUploadToServer`.
 
@@ -138,6 +181,15 @@ the `start` method or `setUploadToServer`.
 > This method is only available in the main process.
 
 ### `crashReporter.setUploadToServer(uploadToServer)`
+
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/23265
+    description: "Deprecated calling this method in the renderer process."
+    breaking-changes-header: deprecated-crashreporter-methods-in-the-renderer-process
+```
+-->
 
 * `uploadToServer` boolean - Whether reports should be submitted to the server.
 

--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -80,6 +80,17 @@ The `desktopCapturer` module has the following methods:
 
 ### `desktopCapturer.getSources(options)`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/2963
+changes:
+  - pr-url: https://github.com/electron/electron/pull/16427
+    description: "This method now returns a Promise instead of using a callback function."
+    breaking-changes-header: api-changed-callback-based-versions-of-promisified-apis
+```
+-->
+
 * `options` Object
   * `types` string[] - An array of strings that lists the types of desktop sources
     to be captured, available types can be `screen` and `window`.

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -18,6 +18,13 @@ The `dialog` module has the following methods:
 
 ### `dialog.showOpenDialogSync([window, ]options)`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/16973
+```
+-->
+
 * `window` [BaseWindow](base-window.md) (optional)
 * `options` Object
   * `title` string (optional)
@@ -89,6 +96,15 @@ dialog.showOpenDialogSync(mainWindow, {
 > to force gtk or kde dialogs.
 
 ### `dialog.showOpenDialog([window, ]options)`
+
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/16973
+    description: "This method now returns a Promise instead of using a callback function."
+    breaking-changes-header: api-changed-callback-based-versions-of-promisified-apis
+```
+-->
 
 * `window` [BaseWindow](base-window.md) (optional)
 * `options` Object
@@ -171,6 +187,13 @@ dialog.showOpenDialog(mainWindow, {
 
 ### `dialog.showSaveDialogSync([window, ]options)`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/17054
+```
+-->
+
 * `window` [BaseWindow](base-window.md) (optional)
 * `options` Object
   * `title` string (optional) - The dialog title. Cannot be displayed on some _Linux_ desktop environments.
@@ -201,6 +224,15 @@ The `filters` specifies an array of file types that can be displayed, see
 `dialog.showOpenDialog` for an example.
 
 ### `dialog.showSaveDialog([window, ]options)`
+
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/17054
+    description: "This method now returns a Promise instead of using a callback function."
+    breaking-changes-header: api-changed-callback-based-versions-of-promisified-apis
+```
+-->
 
 * `window` [BaseWindow](base-window.md) (optional)
 * `options` Object
@@ -239,6 +271,13 @@ The `filters` specifies an array of file types that can be displayed, see
 > expanding and collapsing the dialog.
 
 ### `dialog.showMessageBoxSync([window, ]options)`
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/17298
+```
+-->
 
 * `window` [BaseWindow](base-window.md) (optional)
 * `options` Object
@@ -282,6 +321,19 @@ The `window` argument allows the dialog to attach itself to a parent window, mak
 If `window` is not shown dialog will not be attached to it. In such case it will be displayed as an independent window.
 
 ### `dialog.showMessageBox([window, ]options)`
+
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/17298
+    description: "This method now returns a Promise instead of using a callback function."
+    breaking-changes-header: api-changed-callback-based-versions-of-promisified-apis
+  - pr-url: https://github.com/electron/electron/pull/26102
+    description: "Added the `signal` option."
+  - pr-url: https://github.com/electron/electron/pull/30474
+    description: "Added the `textWidth` option."
+```
+-->
 
 * `window` [BaseWindow](base-window.md) (optional)
 * `options` Object
@@ -348,6 +400,17 @@ before the app `ready`event on Linux, the message will be emitted to stderr,
 and no GUI dialog will appear.
 
 ### `dialog.showCertificateTrustDialog([window, ]options)` _macOS_ _Windows_
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/9099
+changes:
+  - pr-url: https://github.com/electron/electron/pull/17181
+    description: "This method now returns a Promise instead of using a callback function."
+    breaking-changes-header: api-changed-callback-based-versions-of-promisified-apis
+```
+-->
 
 * `window` [BaseWindow](base-window.md) (optional)
 * `options` Object


### PR DESCRIPTION
#### Description of Change

* clipboard
* contentTracing
* crashReporter
* desktopCapturer
* dialog

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
