### PR TITLE
fix: prevent crash when GPU context unavailable in sharedTexture

### DIFF
--- a/shell/common/api/electron_api_shared_texture.cc
+++ b/shell/common/api/electron_api_shared_texture.cc
@@ -368,12 +368,9 @@ void ImportedSharedTexture::UpdateReleaseSyncToken(
 void ImportedSharedTexture::SetupReleaseSyncTokenCallback() {
   base::AutoLock locker(release_sync_token_lock_);
 
-  auto* sii = GetSharedImageInterface();
-  if (!sii)
-    return;
-
   if (!release_sync_token.HasData()) {
-    release_sync_token = sii->GenUnverifiedSyncToken();
+    if (auto* sii = GetSharedImageInterface())
+      release_sync_token = sii->GenUnverifiedSyncToken();
   }
 
   client_shared_image->UpdateDestructionSyncToken(release_sync_token);

--- a/shell/common/api/electron_api_shared_texture.cc
+++ b/shell/common/api/electron_api_shared_texture.cc
@@ -52,32 +52,85 @@ bool IsBrowserProcess() {
 gpu::ContextSupport* GetContextSupport() {
   if (IsBrowserProcess()) {
     auto* factory = content::ImageTransportFactory::GetInstance();
-    return factory->GetContextFactory()
-        ->SharedMainThreadRasterContextProvider()
-        ->ContextSupport();
+    if (!factory) {
+      LOG(ERROR) << "ImageTransportFactory is null";
+      return nullptr;
+    }
+
+    auto* context_factory = factory->GetContextFactory();
+    if (!context_factory) {
+      LOG(ERROR) << "ContextFactory is null";
+      return nullptr;
+    }
+
+    scoped_refptr<viz::RasterContextProvider> provider =
+        context_factory->SharedMainThreadRasterContextProvider();
+    if (!provider) {
+      LOG(ERROR) << "RasterContextProvider is null";
+      return nullptr;
+    }
+
+    return provider->ContextSupport();
   } else {
-    return blink::SharedGpuContext::ContextProviderWrapper()
-        ->ContextProvider()
-        .ContextSupport();
+    base::WeakPtr<blink::WebGraphicsContext3DProviderWrapper> wrapper =
+        blink::SharedGpuContext::ContextProviderWrapper();
+    if (!wrapper) {
+      LOG(ERROR) << "ContextProviderWrapper is null, GPU context unavailable";
+      return nullptr;
+    }
+
+    auto& context_provider = wrapper->ContextProvider();
+    if (context_provider.IsContextLost()) {
+      LOG(ERROR) << "ContextProvider context is lost";
+      return nullptr;
+    }
+
+    return context_provider.ContextSupport();
   }
 }
 
 gpu::SharedImageInterface* GetSharedImageInterface() {
   if (IsBrowserProcess()) {
     auto* factory = content::ImageTransportFactory::GetInstance();
-    return factory->GetContextFactory()
-        ->SharedMainThreadRasterContextProvider()
-        ->SharedImageInterface();
+    if (!factory) {
+      LOG(ERROR) << "ImageTransportFactory is null";
+      return nullptr;
+    }
+
+    auto* context_factory = factory->GetContextFactory();
+    if (!context_factory) {
+      LOG(ERROR) << "ContextFactory is null";
+      return nullptr;
+    }
+
+    scoped_refptr<viz::RasterContextProvider> provider =
+        context_factory->SharedMainThreadRasterContextProvider();
+    if (!provider) {
+      LOG(ERROR) << "RasterContextProvider is null";
+      return nullptr;
+    }
+
+    return provider->SharedImageInterface();
   } else {
-    return blink::SharedGpuContext::SharedImageInterfaceProvider()
-        ->SharedImageInterface();
+    auto* provider = blink::SharedGpuContext::SharedImageInterfaceProvider();
+    if (!provider) {
+      LOG(ERROR)
+          << "SharedImageInterfaceProvider is null, GPU context unavailable";
+      return nullptr;
+    }
+
+    return provider->SharedImageInterface();
   }
 }
 
 std::string GetBase64StringFromSyncToken(gpu::SyncToken& sync_token) {
   if (!sync_token.verified_flush()) {
     auto* sii = GetSharedImageInterface();
-    sii->VerifySyncToken(sync_token);
+    if (sii) {
+      sii->VerifySyncToken(sync_token);
+    } else {
+      LOG(ERROR) << "Failed to verify sync token, SharedImageInterface is null";
+    }
   }
 
   auto sync_token_data = base::Base64Encode(UNSAFE_BUFFERS(
@@ -156,7 +209,7 @@ struct ImportedSharedTexture
 
   // Texture id for printing warnings like GC check.
   std::string id;
-
+  
   void UpdateReleaseSyncToken(const gpu::SyncToken& token);
   void SetupReleaseSyncTokenCallback();
 
@@ -315,6 +368,12 @@ void ImportedSharedTexture::UpdateReleaseSyncToken(
   base::AutoLock locker(release_sync_token_lock_);
 
   auto* sii = GetSharedImageInterface();
+  if (!sii) {
+    LOG(WARNING)
+        << "Cannot update release sync token, SharedImageInterface is null";
+    return;
+  }
+
   if (release_sync_token.HasData()) {
     // If we already have a release sync token, we need to wait for it
     // to be signaled before we can set the new one.
@@ -329,6 +388,12 @@ void ImportedSharedTexture::SetupReleaseSyncTokenCallback() {
   base::AutoLock locker(release_sync_token_lock_);
 
   auto* sii = GetSharedImageInterface();
+  if (!sii) {
+    LOG(WARNING)
+        << "Cannot setup release sync token, SharedImageInterface is null";
+    return;
+  }
+
   if (!release_sync_token.HasData()) {
     release_sync_token = sii->GenUnverifiedSyncToken();
   }
@@ -336,8 +401,14 @@ void ImportedSharedTexture::SetupReleaseSyncTokenCallback() {
   client_shared_image->UpdateDestructionSyncToken(release_sync_token);
 
   if (release_callback) {
-    GetContextSupport()->SignalSyncToken(release_sync_token,
-                                         std::move(release_callback));
+    auto* context_support = GetContextSupport();
+    if (context_support) {
+      context_support->SignalSyncToken(release_sync_token,
+                                       std::move(release_callback));
+    } else {
+      LOG(WARNING)
+          << "ContextSupport is null, release callback will not be executed";
+    }
   }
 }
 
@@ -731,6 +802,12 @@ v8::Local<v8::Value> ImportSharedTexture(v8::Isolate* isolate,
   }
 
   auto* sii = GetSharedImageInterface();
+  if (!sii) {
+    gin_helper::ErrorThrower(isolate).ThrowError(
+        "Failed to get SharedImageInterface, GPU context unavailable");
+    return v8::Null(isolate);
+  }
+
   gpu::SharedImageUsageSet shared_image_usage =
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_APPLE)
       gpu::SHARED_IMAGE_USAGE_GLES2_READ | gpu::SHARED_IMAGE_USAGE_GLES2_WRITE |
@@ -798,6 +875,12 @@ v8::Local<v8::Value> FinishTransferSharedTexture(v8::Isolate* isolate,
                                                                     &message);
 
   auto* sii = GetSharedImageInterface();
+  if (!sii) {
+    gin_helper::ErrorThrower(isolate).ThrowError(
+        "Failed to get SharedImageInterface, GPU context unavailable");
+    return v8::Null(isolate);
+  }
+
   auto si = sii->ImportSharedImage(std::move(exported));
 
   auto source_st = GetSyncTokenFromBase64String(sync_token_data);

--- a/shell/common/api/electron_api_shared_texture.cc
+++ b/shell/common/api/electron_api_shared_texture.cc
@@ -376,8 +376,7 @@ void ImportedSharedTexture::SetupReleaseSyncTokenCallback() {
   client_shared_image->UpdateDestructionSyncToken(release_sync_token);
 
   if (release_callback) {
-    auto* context_support = GetContextSupport();
-    if (context_support) {
+    if (auto* context_support = GetContextSupport()) {
       context_support->SignalSyncToken(release_sync_token,
                                        std::move(release_callback));
     }

--- a/shell/common/api/electron_api_shared_texture.cc
+++ b/shell/common/api/electron_api_shared_texture.cc
@@ -373,7 +373,8 @@ void ImportedSharedTexture::SetupReleaseSyncTokenCallback() {
       release_sync_token = sii->GenUnverifiedSyncToken();
   }
 
-  client_shared_image->UpdateDestructionSyncToken(release_sync_token);
+  if (release_sync_token.HasData())
+    client_shared_image->UpdateDestructionSyncToken(release_sync_token);
 
   if (release_callback) {
     if (auto* context_support = GetContextSupport()) {

--- a/shell/common/api/electron_api_shared_texture.cc
+++ b/shell/common/api/electron_api_shared_texture.cc
@@ -67,16 +67,12 @@ gpu::ContextSupport* GetContextSupport() {
   } else {
     base::WeakPtr<blink::WebGraphicsContext3DProviderWrapper> wrapper =
         blink::SharedGpuContext::ContextProviderWrapper();
-    if (!wrapper) {
-      LOG(ERROR) << "ContextProviderWrapper is null, GPU context unavailable";
+    if (!wrapper)
       return nullptr;
-    }
 
     auto& context_provider = wrapper->ContextProvider();
-    if (context_provider.IsContextLost()) {
-      LOG(ERROR) << "ContextProvider context is lost";
+    if (context_provider.IsContextLost())
       return nullptr;
-    }
 
     return context_provider.ContextSupport();
   }

--- a/shell/common/api/electron_api_shared_texture.cc
+++ b/shell/common/api/electron_api_shared_texture.cc
@@ -52,23 +52,16 @@ bool IsBrowserProcess() {
 gpu::ContextSupport* GetContextSupport() {
   if (IsBrowserProcess()) {
     auto* factory = content::ImageTransportFactory::GetInstance();
-    if (!factory) {
-      LOG(ERROR) << "ImageTransportFactory is null";
+    if (!auto* factory = content::ImageTransportFactory::GetInstance())
       return nullptr;
-    }
-
-    auto* context_factory = factory->GetContextFactory();
-    if (!context_factory) {
-      LOG(ERROR) << "ContextFactory is null";
+ 
+    if (!auto* context_factory = factory->GetContextFactory())
       return nullptr;
-    }
 
     scoped_refptr<viz::RasterContextProvider> provider =
         context_factory->SharedMainThreadRasterContextProvider();
-    if (!provider) {
-      LOG(ERROR) << "RasterContextProvider is null";
+    if (!provider)
       return nullptr;
-    }
 
     return provider->ContextSupport();
   } else {

--- a/shell/common/api/electron_api_shared_texture.cc
+++ b/shell/common/api/electron_api_shared_texture.cc
@@ -104,10 +104,10 @@ gpu::SharedImageInterface* GetSharedImageInterface() {
   }
 }
 
-std::string GetBase64StringFromSyncToken(gpu::SharedImageInterface* sii,
-                                         gpu::SyncToken& sync_token) {
+std::string GetBase64StringFromSyncToken(gpu::SyncToken& sync_token) {
   if (!sync_token.verified_flush()) {
-    sii->VerifySyncToken(sync_token);
+    if (auto* sii = GetSharedImageInterface())
+      sii->VerifySyncToken(sync_token);
   }
 
   auto sync_token_data = base::Base64Encode(UNSAFE_BUFFERS(
@@ -191,18 +191,14 @@ struct ImportedSharedTexture
   void SetupReleaseSyncTokenCallback();
 
   // Transfer to other Chromium processes.
-  v8::Local<v8::Value> StartTransferSharedTexture(
-      gpu::SharedImageInterface* sii,
-      v8::Isolate* isolate);
+  v8::Local<v8::Value> StartTransferSharedTexture(v8::Isolate* isolate);
 
   // Get the creation sync token for the shared image. This is called
   // after |finishTransferSharedTexture| and users need to pass the
   // sync token back to the source object, and call |setReleaseSyncToken|
   // to prevent the resource being released before actual acquisition
   // happens for the target object.
-  v8::Local<v8::Value> GetFrameCreationSyncToken(
-      gpu::SharedImageInterface* sii,
-      v8::Isolate* isolate);
+  v8::Local<v8::Value> GetFrameCreationSyncToken(v8::Isolate* isolate);
 
   // Set a release sync token for this shared texture. This is set
   // when |finishTransferSharedTexture| is called and prevent the source
@@ -287,7 +283,6 @@ v8::Local<v8::Value> ImportedSharedTextureWrapper::CreateVideoFrame(
 }
 
 v8::Local<v8::Value> ImportedSharedTexture::StartTransferSharedTexture(
-    gpu::SharedImageInterface* sii,
     v8::Isolate* isolate) {
   auto exported = client_shared_image->Export();
 
@@ -306,8 +301,7 @@ v8::Local<v8::Value> ImportedSharedTexture::StartTransferSharedTexture(
   gin_helper::Dictionary root(isolate, v8::Object::New(isolate));
   root.SetReadOnly("transfer", encoded);
 
-  auto sync_token =
-      GetBase64StringFromSyncToken(sii, frame_creation_sync_token);
+  auto sync_token = GetBase64StringFromSyncToken(frame_creation_sync_token);
   root.SetReadOnly("syncToken", sync_token);
 
   root.SetReadOnly("pixelFormat",
@@ -320,12 +314,10 @@ v8::Local<v8::Value> ImportedSharedTexture::StartTransferSharedTexture(
 }
 
 v8::Local<v8::Value> ImportedSharedTexture::GetFrameCreationSyncToken(
-    gpu::SharedImageInterface* sii,
     v8::Isolate* isolate) {
   gin::Dictionary root(isolate, v8::Object::New(isolate));
 
-  auto sync_token =
-      GetBase64StringFromSyncToken(sii, frame_creation_sync_token);
+  auto sync_token = GetBase64StringFromSyncToken(frame_creation_sync_token);
   root.Set("syncToken", sync_token);
 
   return gin::ConvertToV8(isolate, root);
@@ -440,14 +432,13 @@ void ImportedTextureStartTransferSharedTexture(
     return;
   }
 
-  auto* sii = GetSharedImageInterface();
-  if (!sii) {
+  if (!GetSharedImageInterface()) {
     gin_helper::ErrorThrower(isolate).ThrowError(
         "Failed to start shared texture transfer: GPU is not available");
     return;
   }
 
-  auto ret = wrapper->ist->StartTransferSharedTexture(sii, isolate);
+  auto ret = wrapper->ist->StartTransferSharedTexture(isolate);
   info.GetReturnValue().Set(ret);
 }
 
@@ -482,14 +473,13 @@ void ImportedTextureGetFrameCreationSyncToken(
     return;
   }
 
-  auto* sii = GetSharedImageInterface();
-  if (!sii) {
+  if (!GetSharedImageInterface()) {
     gin_helper::ErrorThrower(isolate).ThrowError(
         "Failed to get frame creation sync token: GPU is not available");
     return;
   }
 
-  auto ret = wrapper->ist->GetFrameCreationSyncToken(sii, isolate);
+  auto ret = wrapper->ist->GetFrameCreationSyncToken(isolate);
   info.GetReturnValue().Set(ret);
 }
 
@@ -512,8 +502,7 @@ void ImportedTextureSetReleaseSyncToken(
     return;
   }
 
-  auto* sii = GetSharedImageInterface();
-  if (!sii) {
+  if (!GetSharedImageInterface()) {
     gin_helper::ErrorThrower(isolate).ThrowError(
         "Failed to set release sync token: GPU is not available");
     return;

--- a/shell/common/api/electron_api_shared_texture.cc
+++ b/shell/common/api/electron_api_shared_texture.cc
@@ -353,6 +353,8 @@ void ImportedSharedTexture::SetupReleaseSyncTokenCallback() {
     if (auto* context_support = GetContextSupport()) {
       context_support->SignalSyncToken(release_sync_token,
                                        std::move(release_callback));
+    } else {
+      std::move(release_callback).Run();
     }
   }
 }

--- a/shell/common/api/electron_api_shared_texture.cc
+++ b/shell/common/api/electron_api_shared_texture.cc
@@ -187,8 +187,7 @@ struct ImportedSharedTexture
   // Texture id for printing warnings like GC check.
   std::string id;
 
-  void UpdateReleaseSyncToken(gpu::SharedImageInterface* sii,
-                              const gpu::SyncToken& token);
+  void UpdateReleaseSyncToken(const gpu::SyncToken& token);
   void SetupReleaseSyncTokenCallback();
 
   // Transfer to other Chromium processes.
@@ -214,8 +213,7 @@ struct ImportedSharedTexture
   // object is safe to do the further release. If set, users can call
   // `release()` on the source object without worrying the target object
   // didn't finish acquiring the resource at gpu process.
-  void SetReleaseSyncToken(gpu::SharedImageInterface* sii,
-                           v8::Isolate* isolate,
+  void SetReleaseSyncToken(v8::Isolate* isolate,
                            v8::Local<v8::Value> options);
 
   // The cleanup happens at destructor.
@@ -262,10 +260,7 @@ void ImportedSharedTextureWrapper::ReleaseReference() {
 void OnVideoFrameMailboxReleased(
     const scoped_refptr<ImportedSharedTexture>& ist,
     const gpu::SyncToken& sync_token) {
-  auto* sii = GetSharedImageInterface();
-  if (!sii)
-    return;
-  ist->UpdateReleaseSyncToken(sii, sync_token);
+  ist->UpdateReleaseSyncToken(sync_token);
 }
 
 v8::Local<v8::Value> ImportedSharedTextureWrapper::CreateVideoFrame(
@@ -337,7 +332,6 @@ v8::Local<v8::Value> ImportedSharedTexture::GetFrameCreationSyncToken(
 }
 
 void ImportedSharedTexture::SetReleaseSyncToken(
-    gpu::SharedImageInterface* sii,
     v8::Isolate* isolate,
     v8::Local<v8::Value> options) {
   std::string sync_token_data;
@@ -345,7 +339,7 @@ void ImportedSharedTexture::SetReleaseSyncToken(
   dict.Get("syncToken", &sync_token_data);
 
   auto sync_token = GetSyncTokenFromBase64String(sync_token_data);
-  UpdateReleaseSyncToken(sii, sync_token);
+  UpdateReleaseSyncToken(sync_token);
 }
 
 ImportedSharedTexture::~ImportedSharedTexture() {
@@ -357,11 +351,11 @@ ImportedSharedTexture::~ImportedSharedTexture() {
 }
 
 void ImportedSharedTexture::UpdateReleaseSyncToken(
-    gpu::SharedImageInterface* sii,
     const gpu::SyncToken& token) {
   base::AutoLock locker(release_sync_token_lock_);
 
-  if (release_sync_token.HasData()) {
+  auto* sii = GetSharedImageInterface();
+  if (sii && release_sync_token.HasData()) {
     // If we already have a release sync token, we need to wait for it
     // to be signaled before we can set the new one.
     sii->WaitSyncToken(release_sync_token);
@@ -471,22 +465,6 @@ void ImportedTextureRelease(const v8::FunctionCallbackInfo<v8::Value>& info) {
     gin::ConvertFromV8(isolate, cb, &wrapper->ist->release_callback);
   }
 
-  auto* sii = GetSharedImageInterface();
-  if (!sii) {
-    auto* isolate = info.GetIsolate();
-    gin_helper::ErrorThrower(isolate).ThrowError(
-        "Failed to release shared texture: GPU is not available");
-    return;
-  }
-
-  auto* context_support = GetContextSupport();
-  if (!context_support) {
-    auto* isolate = info.GetIsolate();
-    gin_helper::ErrorThrower(isolate).ThrowError(
-        "Failed to release shared texture: GPU is not available");
-    return;
-  }
-
   // Release the shared texture, so that future frames can be generated.
   wrapper->ReleaseReference();
 
@@ -544,7 +522,7 @@ void ImportedTextureSetReleaseSyncToken(
     return;
   }
 
-  wrapper->ist->SetReleaseSyncToken(sii, isolate, info[0].As<v8::Object>());
+  wrapper->ist->SetReleaseSyncToken(isolate, info[0].As<v8::Object>());
 }
 
 v8::Local<v8::Value> CreateImportedSharedTextureFromSharedImage(

--- a/shell/common/api/electron_api_shared_texture.cc
+++ b/shell/common/api/electron_api_shared_texture.cc
@@ -55,16 +55,9 @@ gpu::ContextSupport* GetContextSupport() {
     if (!factory)
       return nullptr;
 
-    auto* context_factory = factory->GetContextFactory();
-    if (!context_factory)
-      return nullptr;
-
     scoped_refptr<viz::RasterContextProvider> provider =
-        context_factory->SharedMainThreadRasterContextProvider();
-    if (!provider)
-      return nullptr;
-
-    return provider->ContextSupport();
+        factory->GetContextFactory()->SharedMainThreadRasterContextProvider();
+    return provider ? provider->ContextSupport() : nullptr;
   } else {
     base::WeakPtr<blink::WebGraphicsContext3DProviderWrapper> wrapper =
         blink::SharedGpuContext::ContextProviderWrapper();
@@ -85,22 +78,12 @@ gpu::SharedImageInterface* GetSharedImageInterface() {
     if (!factory)
       return nullptr;
 
-    auto* context_factory = factory->GetContextFactory();
-    if (!context_factory)
-      return nullptr;
-
     scoped_refptr<viz::RasterContextProvider> provider =
-        context_factory->SharedMainThreadRasterContextProvider();
-    if (!provider)
-      return nullptr;
-
-    return provider->SharedImageInterface();
+        factory->GetContextFactory()->SharedMainThreadRasterContextProvider();
+    return provider ? provider->SharedImageInterface() : nullptr;
   } else {
     auto* provider = blink::SharedGpuContext::SharedImageInterfaceProvider();
-    if (!provider)
-      return nullptr;
-
-    return provider->SharedImageInterface();
+    return provider ? provider->SharedImageInterface() : nullptr;
   }
 }
 
@@ -209,8 +192,7 @@ struct ImportedSharedTexture
   // object is safe to do the further release. If set, users can call
   // `release()` on the source object without worrying the target object
   // didn't finish acquiring the resource at gpu process.
-  void SetReleaseSyncToken(v8::Isolate* isolate,
-                           v8::Local<v8::Value> options);
+  void SetReleaseSyncToken(v8::Isolate* isolate, v8::Local<v8::Value> options);
 
   // The cleanup happens at destructor.
  private:
@@ -323,9 +305,8 @@ v8::Local<v8::Value> ImportedSharedTexture::GetFrameCreationSyncToken(
   return gin::ConvertToV8(isolate, root);
 }
 
-void ImportedSharedTexture::SetReleaseSyncToken(
-    v8::Isolate* isolate,
-    v8::Local<v8::Value> options) {
+void ImportedSharedTexture::SetReleaseSyncToken(v8::Isolate* isolate,
+                                                v8::Local<v8::Value> options) {
   std::string sync_token_data;
   gin::Dictionary dict(isolate, options.As<v8::Object>());
   dict.Get("syncToken", &sync_token_data);

--- a/shell/common/api/electron_api_shared_texture.cc
+++ b/shell/common/api/electron_api_shared_texture.cc
@@ -452,7 +452,7 @@ void ImportedTextureStartTransferSharedTexture(
   auto* sii = GetSharedImageInterface();
   if (!sii) {
     gin_helper::ErrorThrower(isolate).ThrowError(
-        "Failed to get SharedImageInterface, GPU context unavailable");
+        "Failed to start shared texture transfer: GPU is not available");
     return;
   }
 
@@ -475,7 +475,7 @@ void ImportedTextureRelease(const v8::FunctionCallbackInfo<v8::Value>& info) {
   if (!sii) {
     auto* isolate = info.GetIsolate();
     gin_helper::ErrorThrower(isolate).ThrowError(
-        "Failed to get SharedImageInterface, GPU context unavailable");
+        "Failed to release shared texture: GPU is not available");
     return;
   }
 
@@ -483,7 +483,7 @@ void ImportedTextureRelease(const v8::FunctionCallbackInfo<v8::Value>& info) {
   if (!context_support) {
     auto* isolate = info.GetIsolate();
     gin_helper::ErrorThrower(isolate).ThrowError(
-        "Failed to get ContextSupport, GPU context unavailable");
+        "Failed to release shared texture: GPU is not available");
     return;
   }
 
@@ -510,7 +510,7 @@ void ImportedTextureGetFrameCreationSyncToken(
   auto* sii = GetSharedImageInterface();
   if (!sii) {
     gin_helper::ErrorThrower(isolate).ThrowError(
-        "Failed to get SharedImageInterface, GPU context unavailable");
+        "Failed to get frame creation sync token: GPU is not available");
     return;
   }
 
@@ -540,7 +540,7 @@ void ImportedTextureSetReleaseSyncToken(
   auto* sii = GetSharedImageInterface();
   if (!sii) {
     gin_helper::ErrorThrower(isolate).ThrowError(
-        "Failed to get SharedImageInterface, GPU context unavailable");
+        "Failed to set release sync token: GPU is not available");
     return;
   }
 
@@ -822,7 +822,7 @@ v8::Local<v8::Value> ImportSharedTexture(v8::Isolate* isolate,
   auto* sii = GetSharedImageInterface();
   if (!sii) {
     gin_helper::ErrorThrower(isolate).ThrowError(
-        "Failed to get SharedImageInterface, GPU context unavailable");
+        "Failed to import shared texture: GPU is not available");
     return v8::Null(isolate);
   }
 
@@ -895,7 +895,7 @@ v8::Local<v8::Value> FinishTransferSharedTexture(v8::Isolate* isolate,
   auto* sii = GetSharedImageInterface();
   if (!sii) {
     gin_helper::ErrorThrower(isolate).ThrowError(
-        "Failed to get SharedImageInterface, GPU context unavailable");
+        "Failed to finish shared texture transfer: GPU is not available");
     return v8::Null(isolate);
   }
 

--- a/shell/common/api/electron_api_shared_texture.cc
+++ b/shell/common/api/electron_api_shared_texture.cc
@@ -52,10 +52,11 @@ bool IsBrowserProcess() {
 gpu::ContextSupport* GetContextSupport() {
   if (IsBrowserProcess()) {
     auto* factory = content::ImageTransportFactory::GetInstance();
-    if (!auto* factory = content::ImageTransportFactory::GetInstance())
+    if (!factory)
       return nullptr;
- 
-    if (!auto* context_factory = factory->GetContextFactory())
+
+    auto* context_factory = factory->GetContextFactory();
+    if (!context_factory)
       return nullptr;
 
     scoped_refptr<viz::RasterContextProvider> provider =
@@ -81,45 +82,32 @@ gpu::ContextSupport* GetContextSupport() {
 gpu::SharedImageInterface* GetSharedImageInterface() {
   if (IsBrowserProcess()) {
     auto* factory = content::ImageTransportFactory::GetInstance();
-    if (!factory) {
-      LOG(ERROR) << "ImageTransportFactory is null";
+    if (!factory)
       return nullptr;
-    }
 
     auto* context_factory = factory->GetContextFactory();
-    if (!context_factory) {
-      LOG(ERROR) << "ContextFactory is null";
+    if (!context_factory)
       return nullptr;
-    }
 
     scoped_refptr<viz::RasterContextProvider> provider =
         context_factory->SharedMainThreadRasterContextProvider();
-    if (!provider) {
-      LOG(ERROR) << "RasterContextProvider is null";
+    if (!provider)
       return nullptr;
-    }
 
     return provider->SharedImageInterface();
   } else {
     auto* provider = blink::SharedGpuContext::SharedImageInterfaceProvider();
-    if (!provider) {
-      LOG(ERROR)
-          << "SharedImageInterfaceProvider is null, GPU context unavailable";
+    if (!provider)
       return nullptr;
-    }
 
     return provider->SharedImageInterface();
   }
 }
 
-std::string GetBase64StringFromSyncToken(gpu::SyncToken& sync_token) {
+std::string GetBase64StringFromSyncToken(gpu::SharedImageInterface* sii,
+                                         gpu::SyncToken& sync_token) {
   if (!sync_token.verified_flush()) {
-    auto* sii = GetSharedImageInterface();
-    if (sii) {
-      sii->VerifySyncToken(sync_token);
-    } else {
-      LOG(ERROR) << "Failed to verify sync token, SharedImageInterface is null";
-    }
+    sii->VerifySyncToken(sync_token);
   }
 
   auto sync_token_data = base::Base64Encode(UNSAFE_BUFFERS(
@@ -198,19 +186,24 @@ struct ImportedSharedTexture
 
   // Texture id for printing warnings like GC check.
   std::string id;
-  
-  void UpdateReleaseSyncToken(const gpu::SyncToken& token);
+
+  void UpdateReleaseSyncToken(gpu::SharedImageInterface* sii,
+                              const gpu::SyncToken& token);
   void SetupReleaseSyncTokenCallback();
 
   // Transfer to other Chromium processes.
-  v8::Local<v8::Value> StartTransferSharedTexture(v8::Isolate* isolate);
+  v8::Local<v8::Value> StartTransferSharedTexture(
+      gpu::SharedImageInterface* sii,
+      v8::Isolate* isolate);
 
   // Get the creation sync token for the shared image. This is called
   // after |finishTransferSharedTexture| and users need to pass the
   // sync token back to the source object, and call |setReleaseSyncToken|
   // to prevent the resource being released before actual acquisition
   // happens for the target object.
-  v8::Local<v8::Value> GetFrameCreationSyncToken(v8::Isolate* isolate);
+  v8::Local<v8::Value> GetFrameCreationSyncToken(
+      gpu::SharedImageInterface* sii,
+      v8::Isolate* isolate);
 
   // Set a release sync token for this shared texture. This is set
   // when |finishTransferSharedTexture| is called and prevent the source
@@ -221,7 +214,9 @@ struct ImportedSharedTexture
   // object is safe to do the further release. If set, users can call
   // `release()` on the source object without worrying the target object
   // didn't finish acquiring the resource at gpu process.
-  void SetReleaseSyncToken(v8::Isolate* isolate, v8::Local<v8::Value> options);
+  void SetReleaseSyncToken(gpu::SharedImageInterface* sii,
+                           v8::Isolate* isolate,
+                           v8::Local<v8::Value> options);
 
   // The cleanup happens at destructor.
  private:
@@ -267,7 +262,10 @@ void ImportedSharedTextureWrapper::ReleaseReference() {
 void OnVideoFrameMailboxReleased(
     const scoped_refptr<ImportedSharedTexture>& ist,
     const gpu::SyncToken& sync_token) {
-  ist->UpdateReleaseSyncToken(sync_token);
+  auto* sii = GetSharedImageInterface();
+  if (!sii)
+    return;
+  ist->UpdateReleaseSyncToken(sii, sync_token);
 }
 
 v8::Local<v8::Value> ImportedSharedTextureWrapper::CreateVideoFrame(
@@ -294,6 +292,7 @@ v8::Local<v8::Value> ImportedSharedTextureWrapper::CreateVideoFrame(
 }
 
 v8::Local<v8::Value> ImportedSharedTexture::StartTransferSharedTexture(
+    gpu::SharedImageInterface* sii,
     v8::Isolate* isolate) {
   auto exported = client_shared_image->Export();
 
@@ -312,7 +311,8 @@ v8::Local<v8::Value> ImportedSharedTexture::StartTransferSharedTexture(
   gin_helper::Dictionary root(isolate, v8::Object::New(isolate));
   root.SetReadOnly("transfer", encoded);
 
-  auto sync_token = GetBase64StringFromSyncToken(frame_creation_sync_token);
+  auto sync_token =
+      GetBase64StringFromSyncToken(sii, frame_creation_sync_token);
   root.SetReadOnly("syncToken", sync_token);
 
   root.SetReadOnly("pixelFormat",
@@ -325,23 +325,27 @@ v8::Local<v8::Value> ImportedSharedTexture::StartTransferSharedTexture(
 }
 
 v8::Local<v8::Value> ImportedSharedTexture::GetFrameCreationSyncToken(
+    gpu::SharedImageInterface* sii,
     v8::Isolate* isolate) {
   gin::Dictionary root(isolate, v8::Object::New(isolate));
 
-  auto sync_token = GetBase64StringFromSyncToken(frame_creation_sync_token);
+  auto sync_token =
+      GetBase64StringFromSyncToken(sii, frame_creation_sync_token);
   root.Set("syncToken", sync_token);
 
   return gin::ConvertToV8(isolate, root);
 }
 
-void ImportedSharedTexture::SetReleaseSyncToken(v8::Isolate* isolate,
-                                                v8::Local<v8::Value> options) {
+void ImportedSharedTexture::SetReleaseSyncToken(
+    gpu::SharedImageInterface* sii,
+    v8::Isolate* isolate,
+    v8::Local<v8::Value> options) {
   std::string sync_token_data;
   gin::Dictionary dict(isolate, options.As<v8::Object>());
   dict.Get("syncToken", &sync_token_data);
 
   auto sync_token = GetSyncTokenFromBase64String(sync_token_data);
-  UpdateReleaseSyncToken(sync_token);
+  UpdateReleaseSyncToken(sii, sync_token);
 }
 
 ImportedSharedTexture::~ImportedSharedTexture() {
@@ -353,15 +357,9 @@ ImportedSharedTexture::~ImportedSharedTexture() {
 }
 
 void ImportedSharedTexture::UpdateReleaseSyncToken(
+    gpu::SharedImageInterface* sii,
     const gpu::SyncToken& token) {
   base::AutoLock locker(release_sync_token_lock_);
-
-  auto* sii = GetSharedImageInterface();
-  if (!sii) {
-    LOG(WARNING)
-        << "Cannot update release sync token, SharedImageInterface is null";
-    return;
-  }
 
   if (release_sync_token.HasData()) {
     // If we already have a release sync token, we need to wait for it
@@ -377,11 +375,8 @@ void ImportedSharedTexture::SetupReleaseSyncTokenCallback() {
   base::AutoLock locker(release_sync_token_lock_);
 
   auto* sii = GetSharedImageInterface();
-  if (!sii) {
-    LOG(WARNING)
-        << "Cannot setup release sync token, SharedImageInterface is null";
+  if (!sii)
     return;
-  }
 
   if (!release_sync_token.HasData()) {
     release_sync_token = sii->GenUnverifiedSyncToken();
@@ -394,9 +389,6 @@ void ImportedSharedTexture::SetupReleaseSyncTokenCallback() {
     if (context_support) {
       context_support->SignalSyncToken(release_sync_token,
                                        std::move(release_callback));
-    } else {
-      LOG(WARNING)
-          << "ContextSupport is null, release callback will not be executed";
     }
   }
 }
@@ -457,7 +449,14 @@ void ImportedTextureStartTransferSharedTexture(
     return;
   }
 
-  auto ret = wrapper->ist->StartTransferSharedTexture(isolate);
+  auto* sii = GetSharedImageInterface();
+  if (!sii) {
+    gin_helper::ErrorThrower(isolate).ThrowError(
+        "Failed to get SharedImageInterface, GPU context unavailable");
+    return;
+  }
+
+  auto ret = wrapper->ist->StartTransferSharedTexture(sii, isolate);
   info.GetReturnValue().Set(ret);
 }
 
@@ -470,6 +469,22 @@ void ImportedTextureRelease(const v8::FunctionCallbackInfo<v8::Value>& info) {
   if (cb->IsFunction()) {
     auto* isolate = info.GetIsolate();
     gin::ConvertFromV8(isolate, cb, &wrapper->ist->release_callback);
+  }
+
+  auto* sii = GetSharedImageInterface();
+  if (!sii) {
+    auto* isolate = info.GetIsolate();
+    gin_helper::ErrorThrower(isolate).ThrowError(
+        "Failed to get SharedImageInterface, GPU context unavailable");
+    return;
+  }
+
+  auto* context_support = GetContextSupport();
+  if (!context_support) {
+    auto* isolate = info.GetIsolate();
+    gin_helper::ErrorThrower(isolate).ThrowError(
+        "Failed to get ContextSupport, GPU context unavailable");
+    return;
   }
 
   // Release the shared texture, so that future frames can be generated.
@@ -492,7 +507,14 @@ void ImportedTextureGetFrameCreationSyncToken(
     return;
   }
 
-  auto ret = wrapper->ist->GetFrameCreationSyncToken(isolate);
+  auto* sii = GetSharedImageInterface();
+  if (!sii) {
+    gin_helper::ErrorThrower(isolate).ThrowError(
+        "Failed to get SharedImageInterface, GPU context unavailable");
+    return;
+  }
+
+  auto ret = wrapper->ist->GetFrameCreationSyncToken(sii, isolate);
   info.GetReturnValue().Set(ret);
 }
 
@@ -515,7 +537,14 @@ void ImportedTextureSetReleaseSyncToken(
     return;
   }
 
-  wrapper->ist->SetReleaseSyncToken(isolate, info[0].As<v8::Object>());
+  auto* sii = GetSharedImageInterface();
+  if (!sii) {
+    gin_helper::ErrorThrower(isolate).ThrowError(
+        "Failed to get SharedImageInterface, GPU context unavailable");
+    return;
+  }
+
+  wrapper->ist->SetReleaseSyncToken(sii, isolate, info[0].As<v8::Object>());
 }
 
 v8::Local<v8::Value> CreateImportedSharedTextureFromSharedImage(


### PR DESCRIPTION
#### Description of Change

This PR fixes a critical crash in the `sharedTexture` (introduced in [#47317](https://github.com/electron/electron/pull/47317)) module related to improper lifecycle management of the graphics context provider.

The crash happens in the `ImportedSharedTexture` destructor when it calls `SetupReleaseSyncTokenCallback()`, which in turn calls `GetContextSupport()`. In renderer processes, `GetContextSupport()` attempts to dereference a `WeakPtr<blink::WebGraphicsContext3DProviderWrapper>` without first checking if the pointer is valid. When the GPU context is unavailable (e.g., during shutdown or GPU device loss), this `WeakPtr` is null, causing a CHECK failure.

The fix introduces a safety check in `GetContextSupport()` to verify the availability of the context provider before usage. Additionally, the destruction sequence has been updated to handle context loss gracefully, preventing the `EXCEPTION_BREAKPOINT` triggered by `base::WeakPtr`'s internal checks.

Stack Trace Included:
1
```
#0 main.dll!base::ImmediateCrash()
#1 main.dll!logging::CheckFailure()
#2 main.dll!base::WeakPtr<...>::operator->()
#3 main.dll!(anonymous namespace)::GetContextSupport()
#4 main.dll!(anonymous namespace)::ImportedSharedTexture::SetupReleaseSyncTokenCallback()
#5 main.dll!(anonymous namespace)::ImportedSharedTexture::~ImportedSharedTexture()
```
2
```
#0 main.dll!media::mp2t::Mp2tStreamParser::GetDecryptConfig()
#1 main.dll!(anonymous namespace)::GetSharedImageInterface()
#2 main.dll!electron::api::shared_texture::ImportSharedTexture()
```

#### Checklist

- [x] PR description included
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed crash in sharedTexture module when GPU context becomes unavailable.
