### PR TITLE
build: Run gh workflows only on e/e

### DIFF
--- a/.github/workflows/audit-branch-ci.yml
+++ b/.github/workflows/audit-branch-ci.yml
@@ -11,6 +11,7 @@ permissions: {}
 jobs:
   audit_branch_ci:
     name: Audit CI on Branches
+    if: github.repository == 'electron/electron'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/branch-created.yml
+++ b/.github/workflows/branch-created.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   release-branch-created:
     name: Release Branch Created
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.ref_type == 'branch' && endsWith(github.event.ref, '-x-y') && !startsWith(github.event.ref, 'roller')) }}
+    if: ${{ github.repository == 'electron/electron' && (github.event_name == 'workflow_dispatch' || (github.event.ref_type == 'branch' && endsWith(github.event.ref, '-x-y') && !startsWith(github.event.ref, 'roller'))) }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/build-git-cache.yml
+++ b/.github/workflows/build-git-cache.yml
@@ -10,6 +10,7 @@ permissions: {}
 
 jobs:
   build-git-cache-linux:
+    if: github.repository == 'electron/electron'
     runs-on: electron-arc-centralus-linux-amd64-32core
     permissions:
       contents: read
@@ -33,6 +34,7 @@ jobs:
         target-platform: linux
 
   build-git-cache-windows:
+    if: github.repository == 'electron/electron'
     runs-on: electron-arc-centralus-linux-amd64-32core
     permissions:
       contents: read
@@ -57,6 +59,7 @@ jobs:
         target-platform: win
 
   build-git-cache-macos:
+    if: github.repository == 'electron/electron'
     runs-on: electron-arc-centralus-linux-amd64-32core
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ permissions: {}
 
 jobs:
   setup:
+    if: github.repository == 'electron/electron'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -426,7 +427,7 @@ jobs:
     permissions:
       contents: read
     needs: [docs-only, macos-x64, macos-arm64, linux-x64, linux-x64-asan, linux-arm, linux-arm64, windows-x64, windows-x86, windows-arm64]
-    if: always() && !contains(needs.*.result, 'failure')
+    if: always() && github.repository == 'electron/electron' && !contains(needs.*.result, 'failure')
     steps: 
     - name: GitHub Actions Jobs Done
       run: |

--- a/.github/workflows/clean-src-cache.yml
+++ b/.github/workflows/clean-src-cache.yml
@@ -12,6 +12,7 @@ permissions: {}
 
 jobs:
   clean-src-cache:
+    if: github.repository == 'electron/electron'
     runs-on: electron-arc-centralus-linux-amd64-32core
     permissions:
       contents: read

--- a/.github/workflows/linux-publish.yml
+++ b/.github/workflows/linux-publish.yml
@@ -21,6 +21,7 @@ permissions: {}
 
 jobs:
   checkout-linux:
+    if: github.repository == 'electron/electron'
     runs-on: electron-arc-centralus-linux-amd64-32core
     permissions:
       contents: read

--- a/.github/workflows/macos-disk-cleanup.yml
+++ b/.github/workflows/macos-disk-cleanup.yml
@@ -13,6 +13,7 @@ permissions: {}
 
 jobs:
   macos-disk-cleanup:
+    if: github.repository == 'electron/electron'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/macos-publish.yml
+++ b/.github/workflows/macos-publish.yml
@@ -22,6 +22,7 @@ permissions: {}
 
 jobs:
   checkout-macos:
+    if: github.repository == 'electron/electron'
     runs-on: electron-arc-centralus-linux-amd64-32core
     permissions:
       contents: read

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -13,6 +13,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecards analysis
+    if: github.repository == 'electron/electron'
     runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.

--- a/.github/workflows/stable-prep-items.yml
+++ b/.github/workflows/stable-prep-items.yml
@@ -10,6 +10,7 @@ permissions: {}
 jobs:
   check-stable-prep-items:
     name: Check Stable Prep Items
+    if: github.repository == 'electron/electron'
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,7 @@ permissions: {}
 
 jobs:
   stale:
+    if: github.repository == 'electron/electron'
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -33,7 +34,7 @@ jobs:
   pending-repro:
     runs-on: ubuntu-latest
     permissions: {}
-    if: ${{ always() }}
+    if: ${{ always() && github.repository == 'electron/electron' }}
     needs: stale
     steps:
       - name: Generate GitHub App token

--- a/.github/workflows/windows-publish.yml
+++ b/.github/workflows/windows-publish.yml
@@ -22,6 +22,7 @@ permissions: {}
 
 jobs:
   checkout-windows:
+    if: github.repository == 'electron/electron'
     runs-on: electron-arc-centralus-linux-amd64-32core
     permissions:
       contents: read


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/49238, where @nikwen correctly pointed out that forks shouldn't try to run our workflows. Forks can always change that, of course.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: no-notes