### PR TITLE
docs: correct type for `process.noDeprecation`

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -71,7 +71,7 @@ will disable the support for `asar` archives in Node's built-in modules.
 
 ### `process.noDeprecation`
 
-A `boolean | undefined` that controls whether or not deprecation warnings are printed to `stderr`.
+A `boolean` (optional) that controls whether or not deprecation warnings are printed to `stderr`.
 Setting this to `true` will silence deprecation warnings. This property is used
 instead of the `--no-deprecation` command line flag.
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/49213.

Fixes a type error where `process.noDeprecation` was typed only `boolean` but should have been `boolean | undefined`. In Node.js (whence this property originates) unless `--no-deprecation` is passed it's `undefined` by default.

```
electron on git:fix-proc-no-deprecation ❯ e node                     11:50AM
Running "/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/MacOS/Electron"
Welcome to Node.js v24.13.0.
Type ".help" for more information.
> process.noDeprecation
undefined
```

```
electron on git:fix-proc-no-deprecation ❯ e node --no-deprecation       11:52AM
Running "/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/MacOS/Electron --no-deprecation"
Welcome to Node.js v24.13.0.
Type ".help" for more information.
> process.noDeprecation
true
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
