### PR TITLE
fix(utilityProcess): normalize Windows exit codes to uint32

### DIFF
--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -263,6 +263,13 @@ void UtilityProcessWrapper::HandleTermination(uint64_t exit_code) {
     return;
   terminated_ = true;
 
+#if BUILDFLAG(IS_WIN)
+  // Utility process exit codes are DWORDs, but they can be delivered as signed
+  // integers. Normalize to the 32-bit unsigned value to avoid sign-extension
+  // when widened to 64-bit for JS consumers.
+  exit_code = static_cast<uint32_t>(exit_code);
+ #endif
+
   if (pid_ != base::kNullProcessId)
     GetAllUtilityProcessWrappers().Remove(pid_);
 


### PR DESCRIPTION
Fixes #49455

### Summary
This PR fixes incorrect exit codes reported by `utilityProcess` on Windows when the process exits with a value that exceeds the signed 32-bit integer range.

### Problem
On Windows, process exit codes are 32-bit unsigned integers (DWORD).  
Currently, the exit code received from Chromium is treated as a signed integer, then widened to 64-bit and eventually exposed to JavaScript, which causes negative values to be sign-extended and reinterpreted as very large unsigned numbers.

This results in incorrect values such as:
`18446744072635812000` instead of the expected `3221228192`.

### Root Cause
The issue occurs due to:
- signed to unsigned widening
- sign extension when converting from `int` to `int64`
- loss of precision once converted to a JavaScript number

### Fix
The exit code is normalized to `uint32` at the Chromium → Electron boundary, ensuring:
- correct interpretation of Windows exit codes
- consistent behavior regardless of how the process exits
- no precision loss before reaching JavaScript

### Reproduction
The issue can be reproduced using the following gist:
https://gist.github.com/rf-/bbe5ecede1f2b10ac2bed4c46ac66509

### Platform
- Windows 11
- Electron 40.x

### Notes
This change only affects Windows and aligns Electron’s behavior with how Windows defines process exit codes.