### PR TITLE
feat: add clipboard privacy options

### DIFF
--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -46,10 +46,11 @@ console.log(text)
 // hello i am a bit of text!'
 ```
 
-### `clipboard.writeText(text[, type])`
+### `clipboard.writeText(text[, type][, privacy])`
 
 * `text` string
 * `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `privacy` string (optional) - Can be `confidential`, `off-the-record`, or `none`. Default is `none`.
 
 Writes the `text` into the clipboard as plain text.
 
@@ -76,10 +77,11 @@ console.log(html)
 // <meta charset='utf-8'><b>Hi</b>
 ```
 
-### `clipboard.writeHTML(markup[, type])`
+### `clipboard.writeHTML(markup[, type][, privacy])`
 
 * `markup` string
 * `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `privacy` string (optional) - Can be `confidential`, `off-the-record`, or `none`. Default is `none`.
 
 Writes `markup` to the clipboard.
 
@@ -95,10 +97,11 @@ clipboard.writeHTML('<b>Hi</b>')
 
 Returns [`NativeImage`](native-image.md) - The image content in the clipboard.
 
-### `clipboard.writeImage(image[, type])`
+### `clipboard.writeImage(image[, type][, privacy])`
 
 * `image` [NativeImage](native-image.md)
 * `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `privacy` string (optional) - Can be `confidential`, `off-the-record`, or `none`. Default is `none`.
 
 Writes `image` to the clipboard.
 
@@ -118,10 +121,11 @@ console.log(rtf)
 // {\\rtf1\\ansi{\\fonttbl\\f0\\fswiss Helvetica;}\\f0\\pard\nThis is some {\\b bold} text.\\par\n}
 ```
 
-### `clipboard.writeRTF(text[, type])`
+### `clipboard.writeRTF(text[, type][, privacy])`
 
 * `text` string
 * `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `privacy` string (optional) - Can be `confidential`, `off-the-record`, or `none`. Default is `none`.
 
 Writes the `text` into the clipboard in RTF.
 
@@ -143,11 +147,12 @@ Returns an Object containing `title` and `url` keys representing the bookmark in
 the clipboard. The `title` and `url` values will be empty strings when the
 bookmark is unavailable.  The `title` value will always be empty on Windows.
 
-### `clipboard.writeBookmark(title, url[, type])` _macOS_ _Windows_
+### `clipboard.writeBookmark(title, url[, type][, privacy])` _macOS_ _Windows_
 
 * `title` string - Unused on Windows
 * `url` string
 * `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `privacy` string (optional) - Can be `confidential`, `off-the-record`, or `none`. Default is `none`.
 
 Writes the `title` (macOS only) and `url` into the clipboard as a bookmark.
 
@@ -238,11 +243,12 @@ console.log(buffer.equals(ret))
 // true
 ```
 
-### `clipboard.writeBuffer(format, buffer[, type])` _Experimental_
+### `clipboard.writeBuffer(format, buffer[, type][, privacy])` _Experimental_
 
 * `format` string
 * `buffer` Buffer
 * `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `privacy` string (optional) - Can be `confidential`, `off-the-record`, or `none`. Default is `none`.
 
 Writes the `buffer` into the clipboard as `format`.
 
@@ -253,7 +259,7 @@ const buffer = Buffer.from('writeBuffer', 'utf8')
 clipboard.writeBuffer('public/utf8-plain-text', buffer)
 ```
 
-### `clipboard.write(data[, type])`
+### `clipboard.write(data[, type][, privacy])`
 
 * `data` Object
   * `text` string (optional)
@@ -262,6 +268,7 @@ clipboard.writeBuffer('public/utf8-plain-text', buffer)
   * `rtf` string (optional)
   * `bookmark` string (optional) - The title of the URL at `text`.
 * `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `privacy` string (optional) - Can be `confidential`, `off-the-record`, or `none`. Default is `none`.
 
 Writes `data` to the clipboard.
 

--- a/shell/common/api/electron_api_clipboard.h
+++ b/shell/common/api/electron_api_clipboard.h
@@ -32,6 +32,12 @@ class Clipboard {
   Clipboard(const Clipboard&) = delete;
   Clipboard& operator=(const Clipboard&) = delete;
 
+  enum class PrivacyType {
+    kNone = 0,
+    kConfidential = 1,
+    kOffTheRecord = 2,
+  };
+
   static std::vector<std::u16string> AvailableFormats(gin::Arguments* args);
   static bool Has(const std::string& format_string, gin::Arguments* args);
   static void Clear(gin::Arguments* args);


### PR DESCRIPTION
#### Description of Change

This is my attempt to resolve #49466. I don't think it's quite ready, so ~~I'm opening it as a draft PR.~~ I welcome comments and critiques to help refine this.

I've added the ability to define the privacy of a write to the clipboard. While the original issue was requesting for the Apple platform, this PR *should* be cross-platform (to the extend that Chromium upstream actually uses the API's I'm depending on).

#### Upstream API's Used

_(links pinned to Chromium 144.0.7559.60, the version used on the current major: Electron 40.0.0)_

Our clipboard API uses [the `ScopedClipboardWriter` class from upstream](https://source.chromium.org/chromium/chromium/src/+/refs/tags/144.0.7559.60:ui/base/clipboard/scoped_clipboard_writer.h) to manage writing to the clipboard. This class has [a private member variable called `privacy_types_`](https://source.chromium.org/chromium/chromium/src/+/refs/tags/144.0.7559.60:ui/base/clipboard/scoped_clipboard_writer.h;l=128) that holds an enumeration of privacy settings for a write to the clipboard.

Unfortunately, that member variable isn't writable directly, and the only mechanisms for manipulating it are the functions [`MarkAsConfidential()`](https://source.chromium.org/chromium/chromium/src/+/refs/tags/144.0.7559.60:ui/base/clipboard/scoped_clipboard_writer.h;l=97) and [`MarkAsOffTheRecord()`](https://source.chromium.org/chromium/chromium/src/+/refs/tags/144.0.7559.60:ui/base/clipboard/scoped_clipboard_writer.h;l=100). To avoid patching Chromium, I simply take these and expose them as mutually-exclusive values for a `privacy` option in the `clipboard` writing API's in JS-land. I took the "privacy type" name for the name in of the enum in C++-land (even though it's now not really a one-to-one mapping) because I wasn't sure what else to call it.

#### Local Testing

~~Final note: while this does compile and build, I haven't fully tested if the behavior actually works as I expect it to. I plan to do so soon, though.~~

I have tested this briefly between my MacBook and my iPad and it seems to work well enough.

- [x] PR description included
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added clipboard privacy options to `clipboard` writing API's.
