### PR TITLE
fix: replace deprecated `url.parse()` with WHATWG URL API in default_app

### DIFF
--- a/default_app/main.ts
+++ b/default_app/main.ts
@@ -252,8 +252,7 @@ async function startRepl () {
 // start the default app.
 if (option.file && !option.webdriver) {
   const file = option.file;
-  // eslint-disable-next-line n/no-deprecated-api
-  const protocol = url.parse(file).protocol;
+  const protocol = URL.canParse(file) ? new URL(file).protocol : null;
   const extension = path.extname(file);
   if (protocol === 'http:' || protocol === 'https:' || protocol === 'file:' || protocol === 'chrome:') {
     await loadApplicationByURL(file);


### PR DESCRIPTION
#### Description of Change

Closed: https://github.com/electron/electron/issues/49550

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: None