### PR TITLE
fix: menu state in macOS dock menus

### DIFF
--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -114,7 +114,14 @@ static NSDictionary* UNNotificationResponseToNSDictionary(
 }
 
 - (NSMenu*)applicationDockMenu:(NSApplication*)sender {
-  return menu_controller_ ? menu_controller_.menu : nil;
+  if (!menu_controller_)
+    return nil;
+
+  // Manually refresh menu state since menuWillOpen: is not called
+  // by macOS for dock menus for some reason before they are displayed.
+  NSMenu* menu = menu_controller_.menu;
+  [menu_controller_ refreshMenuTree:menu];
+  return menu;
 }
 
 - (BOOL)application:(NSApplication*)sender openFile:(NSString*)filename {

--- a/shell/browser/ui/cocoa/electron_menu_controller.h
+++ b/shell/browser/ui/cocoa/electron_menu_controller.h
@@ -57,6 +57,10 @@ class ElectronMenuModel;
 // Whether the menu is currently open.
 - (BOOL)isMenuOpen;
 
+// Recursively refreshes the menu tree starting from |menu|, applying the
+// model state (enabled, checked, hidden etc) to each menu item.
+- (void)refreshMenuTree:(NSMenu*)menu;
+
 // NSMenuDelegate methods this class implements. Subclasses should call super
 // if extending the behavior.
 - (void)menuWillOpen:(NSMenu*)menu;

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -490,8 +490,6 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
                                              : NSControlStateValueOff;
 }
 
-// Recursively refreshes the menu tree starting from |menu|, applying the
-// model state to each menu item.
 - (void)refreshMenuTree:(NSMenu*)menu {
   for (NSMenuItem* item in menu.itemArray) {
     [self applyStateToMenuItem:item];


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/49573

Fixes dock menu not properly supporting enabled, checked, and icon MenuItem properties. The issue was that `menuWillOpen:` isn't called by macOS for dock menus before they are displayed. The enabled, checked, and hidden states were only being applied in `refreshMenuTree`, which is called from `menuWillOpen:`. Since that delegate method doesn't fire for dock menus, the state was never applied.

This PR explicitly calls `refreshMenuTree` `in applicationDockMenu:` before returning the menu to macOS, ensuring the current model state is applied.

cc @Kilian 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed dock menu items not respecting enabled and checked properties on macOS.
