### PR TITLE
docs: `app.getGPUInfo()` may reject

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1285,6 +1285,8 @@ For `infoType` equal to `basic`:
 
 Using `basic` should be preferred if only basic information like `vendorId` or `deviceId` is needed.
 
+Promise is rejected if the GPU is completely disabled, i.e. no hardware and software implementations are available.
+
 ### `app.setBadgeCount([count])` _Linux_ _macOS_
 
 * `count` Integer (optional) - If a value is provided, set the badge to the provided value otherwise, on macOS, display a plain white dot (e.g. unknown number of notifications). On Linux, if a value is not provided the badge will not display.


### PR DESCRIPTION
#### Description of Change

Adds a note to the docs for `app.getGPUInfo()` describing when its returned promise will reject. No behavior change, just documenting existing behavior.

See: https://github.com/electron/electron/issues/49530

#### Checklist

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)

#### Release Notes

Notes: none
