### PR TITLE
fix: use `temp` directory for singleton test and clean up at end

### DIFF
--- a/spec/fixtures/api/singleton-userdata/main.js
+++ b/spec/fixtures/api/singleton-userdata/main.js
@@ -13,6 +13,7 @@ fs.rmSync(userDataFolder, { recursive: true, force: true });
 app.setPath('userData', userDataFolder);
 const gotTheLock = app.requestSingleInstanceLock();
 
+app.releaseSingleInstanceLock();
 fs.rmSync(userDataFolder, { recursive: true, force: true });
 
 app.exit(gotTheLock ? 0 : 1);


### PR DESCRIPTION
#### Description of Change

This should resolve #49539. Some minor refactoring of the test was done, but can be reverted if desired.

#### Checklist

- [x] PR description included
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.
