### PR TITLE
chore: use relative links from docs/ to files outside of docs/

### DIFF
--- a/docs/api/shared-texture.md
+++ b/docs/api/shared-texture.md
@@ -1,6 +1,6 @@
 # sharedTexture
 
-> Import shared textures into Electron and converts platform specific handles into [`VideoFrame`](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrame). Supports all Web rendering systems, and can be transferred across Electron processes. Read [here](https://github.com/electron/electron/blob/main/shell/common/api/shared_texture/README.md) for more information.
+> Import shared textures into Electron and converts platform specific handles into [`VideoFrame`](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrame). Supports all Web rendering systems, and can be transferred across Electron processes. Read [here](../../shell/common/api/shared_texture/README.md) for more information.
 
 Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process)
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -933,7 +933,7 @@ copying data between CPU and GPU memory, with Chromium's hardware acceleration s
 Only a limited number of textures can exist at the same time, so it's important that you call `texture.release()` as soon as you're done with the texture.
 By managing the texture lifecycle by yourself, you can safely pass the `texture.textureInfo` to other processes through IPC.
 
-More details can be found in the [offscreen rendering tutorial](../tutorial/offscreen-rendering.md). To learn about how to handle the texture in native code, refer to [offscreen rendering's code documentation.](https://github.com/electron/electron/blob/main/shell/browser/osr/README.md).
+More details can be found in the [offscreen rendering tutorial](../tutorial/offscreen-rendering.md). To learn about how to handle the texture in native code, refer to [offscreen rendering's code documentation.](../../shell/browser/osr/README.md).
 
 ```js
 const { BrowserWindow } = require('electron')

--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -41,7 +41,7 @@ e init --root=~/electron --bootstrap testing
 ```
 
 The `--bootstrap` flag also runs `e sync` (synchronizes source code branches from
-[`DEPS`](https://github.com/electron/electron/blob/main/DEPS) using
+[`DEPS`](../../DEPS) using
 [`gclient`](https://chromium.googlesource.com/chromium/tools/depot_tools.git/+/HEAD/README.gclient.md))
 and `e build` (compiles the Electron binary into the `${root}/src/out` folder).
 
@@ -63,7 +63,7 @@ Some quick tips on building once your checkout is set up:
 * **Updating your checkout:** Run git commands such as `git checkout <branch>` and `git pull` from `${root}/src/electron`.
   Whenever you update your commit `HEAD`, make sure to `e sync` before `e build` to sync dependencies
   such as Chromium and Node.js. This is especially relevant because the Chromium version in
-  [`DEPS`](https://github.com/electron/electron/blob/main/DEPS) changes frequently.
+  [`DEPS`](../../DEPS) changes frequently.
 * **Rebuilding:** When making changes to code in `${root}/src/electron/` in a local branch, you only need to re-run `e build`.
 * **Adding patches:** When contributing changes in `${root}/src/` outside of `${root}/src/electron/`, you need to do so
   via Electron's [patch system](./patches.md). The `e patches` command can export all relevant patches to
@@ -98,7 +98,7 @@ Project configurations can be found in the `.gn` and `.gni` files in the `electr
 
 The following `gn` files contain the main rules for building Electron:
 
-* [`BUILD.gn`](https://github.com/electron/electron/blob/main/BUILD.gn) defines how Electron itself
+* [`BUILD.gn`](../../BUILD.gn) defines how Electron itself
   is built and includes the default configurations for linking with Chromium.
 * [`build/args/{testing,release,all}.gn`](https://github.com/electron/electron/tree/main/build/args)
   contain the default build arguments for building Electron.

--- a/docs/development/creating-api.md
+++ b/docs/development/creating-api.md
@@ -6,7 +6,7 @@ This is not a comprehensive end-all guide to creating an Electron Browser API, r
 
 ## Add your files to Electron's project configuration
 
-Electron uses [GN](https://gn.googlesource.com/gn) as a meta build system to generate files for its compiler, [Ninja](https://ninja-build.org/). This means that in order to tell Electron to compile your code, we have to add your API's code and header file names into [`filenames.gni`](https://github.com/electron/electron/blob/main/filenames.gni).
+Electron uses [GN](https://gn.googlesource.com/gn) as a meta build system to generate files for its compiler, [Ninja](https://ninja-build.org/). This means that in order to tell Electron to compile your code, we have to add your API's code and header file names into [`filenames.gni`](../../filenames.gni).
 
 You will need to append your API file names alphabetically into the appropriate files like so:
 
@@ -127,7 +127,7 @@ void Initialize(v8::Local<v8::Object> exports,
 
 ## Link your Electron API with Node
 
-In the [`typings/internal-ambient.d.ts`](https://github.com/electron/electron/blob/main/typings/internal-ambient.d.ts) file, we need to append a new property onto the `Process` interface like so:
+In the [`typings/internal-ambient.d.ts`](../../typings/internal-ambient.d.ts) file, we need to append a new property onto the `Process` interface like so:
 
 ```ts title='typings/internal-ambient.d.ts' @ts-nocheck
 interface Process {
@@ -141,7 +141,7 @@ At the very bottom of your `api_name.cc` file:
 NODE_LINKED_BINDING_CONTEXT_AWARE(electron_browser_{api_name},Initialize)
 ```
 
-In your [`shell/common/node_bindings.cc`](https://github.com/electron/electron/blob/main/shell/common/node_bindings.cc) file, add your node binding name to Electron's built-in modules.
+In your [`shell/common/node_bindings.cc`](../../shell/common/node_bindings.cc) file, add your node binding name to Electron's built-in modules.
 
 ```cpp title='shell/common/node_bindings.cc'
 #define ELECTRON_BROWSER_MODULES(V)      \
@@ -159,7 +159,7 @@ We will need to create a new TypeScript file in the path that follows:
 
 `"lib/browser/api/{electron_browser_{api_name}}.ts"`
 
-An example of the contents of this file can be found [here](https://github.com/electron/electron/blob/main/lib/browser/api/native-theme.ts).
+An example of the contents of this file can be found [here](../../lib/browser/api/native-theme.ts).
 
 ### Expose your module to TypeScript
 

--- a/docs/development/pull-requests.md
+++ b/docs/development/pull-requests.md
@@ -185,7 +185,7 @@ $ git push origin my-branch
 ### Step 9: Opening the Pull Request
 
 From within GitHub, opening a new pull request will present you with a template
-that should be filled out. It can be found [here](https://github.com/electron/electron/blob/main/.github/PULL_REQUEST_TEMPLATE.md).
+that should be filled out. It can be found [here](../../.github/PULL_REQUEST_TEMPLATE.md).
 
 If you do not adequately complete this template, your PR may be delayed in being merged as maintainers
 seek more information or clarify ambiguities.
@@ -218,8 +218,7 @@ seem unfamiliar, refer to this
 
 #### Approval and Request Changes Workflow
 
-All pull requests require approval from a
-[Code Owner](https://github.com/electron/electron/blob/main/.github/CODEOWNERS)
+All pull requests require approval from a [Code Owner](../../.github/CODEOWNERS)
 of the area you modified in order to land. Whenever a maintainer reviews a pull
 request they may request changes. These may be small, such as fixing a typo, or
 may involve substantive changes. Such requests are intended to be helpful, but

--- a/docs/development/source-code-directory-structure.md
+++ b/docs/development/source-code-directory-structure.md
@@ -10,7 +10,7 @@ to understand the source code better.
 ## Project structure
 
 Electron is a complex project containing multiple upstream dependencies, which are tracked in source
-control via the [`DEPS`](https://github.com/electron/electron/blob/main/DEPS) file. When
+control via the [`DEPS`](../../DEPS) file. When
 [initializing a local Electron checkout](./build-instructions-gn.md), Electron's source code is just one
 of many nested folders within the project root.
 

--- a/docs/tutorial/fuses.md
+++ b/docs/tutorial/fuses.md
@@ -197,4 +197,4 @@ Somewhere in the Electron binary, there will be a sequence of bytes that look li
 
 To flip a fuse, you find its position in the fuse wire and change it to "0" or "1" depending on the state you'd like.
 
-You can view the current schema [here](https://github.com/electron/electron/blob/main/build/fuses/fuses.json5).
+You can view the current schema [here](../../build/fuses/fuses.json5).

--- a/docs/tutorial/offscreen-rendering.md
+++ b/docs/tutorial/offscreen-rendering.md
@@ -37,7 +37,7 @@ setting.
     The frames are directly copied in GPU textures, thus this mode is very fast because
     there's no CPU-GPU memory copies overhead, and you can directly import the shared
     texture to your own rendering program. You can read more details
-    [here](https://github.com/electron/electron/blob/main/shell/browser/osr/README.md).
+    [here](../../shell/common/api/shared_texture/README.md).
 
 2. Use CPU shared memory bitmap
 

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -9,7 +9,7 @@ toc_max_heading_level: 3
 
 :::info Reporting security issues
 For information on how to properly disclose an Electron vulnerability,
-see [SECURITY.md](https://github.com/electron/electron/blob/main/SECURITY.md).
+see [SECURITY.md](../../SECURITY.md).
 
 For upstream Chromium vulnerabilities: Electron keeps up to date with alternating
 Chromium releases. For more information, see the

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -2,4 +2,4 @@
 
 * For information on supported releases, see the [Electron Releases](./electron-timelines.md) doc.
 * For community support on Electron, see the [Community page](https://www.electronjs.org/community).
-* For platform support info, see the [README](https://github.com/electron/electron/blob/main/README.md).
+* For platform support info, see the [README](../../README.md).

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "lint:gn": "node ./script/lint.js --gn",
     "lint:docs": "remark docs -qf && npm run lint:js-in-markdown && npm run create-typescript-definitions && npm run lint:ts-check-js-in-markdown && npm run lint:docs-fiddles && npm run lint:docs-relative-links && npm run lint:markdown && npm run lint:api-history",
     "lint:docs-fiddles": "standard \"docs/fiddles/**/*.js\"",
-    "lint:docs-relative-links": "lint-roller-markdown-links --root docs \"**/*.md\"",
+    "lint:docs-relative-links": "lint-roller-markdown-links --resource-root . --root docs \"**/*.md\"",
     "lint:markdown": "node ./script/lint.js --md",
     "lint:ts-check-js-in-markdown": "lint-roller-markdown-ts-check --root docs \"**/*.md\" --ignore \"breaking-changes.md\"",
     "lint:js-in-markdown": "lint-roller-markdown-standard --root docs \"**/*.md\"",


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Changes links to `https://github.com/electron/electron/blob/...` to be relative links outside of `docs/`. This will ensure our relative link linter catches if any of these break. As part of this PR it did detect an existing broken link. 👍 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
