### PR TITLE
fix: recover network requests after Network Service restart

### DIFF
--- a/shell/browser/api/electron_api_utility_process.h
+++ b/shell/browser/api/electron_api_utility_process.h
@@ -56,8 +56,12 @@ class UtilityProcessWrapper final
   ~UtilityProcessWrapper() override;
   static gin_helper::Handle<UtilityProcessWrapper> Create(gin::Arguments* args);
   static raw_ptr<UtilityProcessWrapper> FromProcessId(base::ProcessId pid);
+  // Called when Network Service restarts to refresh all utility processes
+  static void RefreshAllURLLoaderFactories();
 
   void Shutdown(uint64_t exit_code);
+  // Refresh the URLLoaderFactory after Network Service restart
+  void RefreshURLLoaderFactory();
 
   // gin_helper::Wrappable
   static gin::DeprecatedWrapperInfo kWrapperInfo;

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -74,6 +74,7 @@
 #include "shell/browser/api/electron_api_app.h"
 #include "shell/browser/api/electron_api_crash_reporter.h"
 #include "shell/browser/api/electron_api_protocol.h"
+#include "shell/browser/api/electron_api_utility_process.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/api/electron_api_web_request.h"
 #include "shell/browser/badging/badge_manager.h"
@@ -1034,6 +1035,11 @@ void ElectronBrowserClient::OnNetworkServiceCreated(
 
   g_browser_process->system_network_context_manager()->OnNetworkServiceCreated(
       network_service);
+
+  // Refresh URLLoaderFactory for all utility processes when Network Service
+  // restarts. This ensures that fetch requests in utility processes recover
+  // after a Network Service crash.
+  api::UtilityProcessWrapper::RefreshAllURLLoaderFactories();
 }
 
 std::vector<base::FilePath>

--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -197,4 +197,16 @@ void NodeService::Initialize(
   node_bindings_->StartPolling();
 }
 
+void NodeService::UpdateURLLoaderFactory(
+    mojo::PendingRemote<network::mojom::URLLoaderFactory> url_loader_factory,
+    mojo::PendingRemote<network::mojom::HostResolver> host_resolver) {
+  // Update the URL loader factory in URLLoaderBundle to recover from
+  // Network Service crashes.
+  URLLoaderBundle::GetInstance()->SetURLLoaderFactory(
+      std::move(url_loader_factory),
+      mojo::Remote<network::mojom::HostResolver>(std::move(host_resolver)),
+      URLLoaderBundle::GetInstance()
+          ->ShouldUseNetworkObserverfromURLLoaderFactory());
+}
+
 }  // namespace electron

--- a/shell/services/node/node_service.h
+++ b/shell/services/node/node_service.h
@@ -65,6 +65,9 @@ class NodeService : public node::mojom::NodeService {
   void Initialize(node::mojom::NodeServiceParamsPtr params,
                   mojo::PendingRemote<node::mojom::NodeServiceClient>
                       client_pending_remote) override;
+  void UpdateURLLoaderFactory(
+      mojo::PendingRemote<network::mojom::URLLoaderFactory> url_loader_factory,
+      mojo::PendingRemote<network::mojom::HostResolver> host_resolver) override;
 
  private:
   // This needs to be initialized first so that it can be destroyed last

--- a/shell/services/node/public/mojom/node_service.mojom
+++ b/shell/services/node/public/mojom/node_service.mojom
@@ -28,4 +28,10 @@ interface NodeServiceClient {
 interface NodeService {
   Initialize(NodeServiceParams params,
              pending_remote<NodeServiceClient> client_remote);
+
+  // Called when the Network Service restarts to provide a fresh URLLoaderFactory
+  // and HostResolver. This allows network requests to recover after a crash.
+  UpdateURLLoaderFactory(
+      pending_remote<network.mojom.URLLoaderFactory> url_loader_factory,
+      pending_remote<network.mojom.HostResolver> host_resolver);
 };


### PR DESCRIPTION
## Description

Fixes #49572

When the Network Service process crashes and restarts, fetch requests made in utility processes continue to fail with `net::ERR_FAILED`. This happens because the [URLLoaderFactory](cci:1://file:///Users/sriramvarunkumar/electron/shell/browser/net/system_network_context_manager.cc:157:0-172:1) pipes become disconnected and are never reconnected.

## Solution

Added a mechanism to push fresh [URLLoaderFactory](cci:1://file:///Users/sriramvarunkumar/electron/shell/browser/net/system_network_context_manager.cc:157:0-172:1) instances to utility processes when the Network Service restarts:

1. Added a new mojo method to allow the browser to send updated factories to utility processes
2. Hooked into the Network Service restart callback to automatically refresh all running utility processes
3. Updated the URL loader bundle in utility processes to accept the new factory

## How it works

1. When Network Service crashes and restarts, Chromium triggers a callback
2. We iterate all running utility processes and create a fresh [URLLoaderFactory](cci:1://file:///Users/sriramvarunkumar/electron/shell/browser/net/system_network_context_manager.cc:157:0-172:1) from the new [NetworkContext](cci:1://file:///Users/sriramvarunkumar/electron/shell/browser/electron_browser_client.cc:859:0-864:1)
3. We send this factory to each utility process via mojo
4. The utility process updates its internal factory
5. Subsequent fetch requests use the new factory and succeed

## Testing

To test manually:
1. Run an Electron app that uses fetch in a utility process
2. Use Process Explorer to find and kill the NetworkService subprocess
3. Verify that fetch requests recover after the service restarts