### PR TITLE
fix: remove address-bar-related flag from non-debug `loadURL` calls

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -40,6 +40,7 @@
 #include "components/prefs/scoped_user_pref_update.h"
 #include "components/security_state/content/content_utils.h"
 #include "components/security_state/core/security_state.h"
+#include "content/browser/renderer_host/debug_urls.h"
 #include "content/browser/renderer_host/frame_tree_node.h"  // nogncheck
 #include "content/browser/renderer_host/navigation_controller_impl.h"  // nogncheck
 #include "content/browser/renderer_host/render_frame_host_manager.h"  // nogncheck
@@ -2425,7 +2426,11 @@ void WebContents::LoadURL(const GURL& url,
   // Calling LoadURLWithParams() can trigger JS which destroys |this|.
   auto weak_this = GetWeakPtr();
 
-  params.transition_type = ui::PageTransitionFromInt(ui::PAGE_TRANSITION_TYPED);
+  params.transition_type =
+      content::IsDebugURL(url)
+          ? ui::PageTransitionFromInt(ui::PAGE_TRANSITION_TYPED |
+                                      ui::PAGE_TRANSITION_FROM_ADDRESS_BAR)
+          : ui::PAGE_TRANSITION_TYPED;
   params.override_user_agent = content::NavigationController::UA_OVERRIDE_TRUE;
 
   // It's not safe to start a new navigation or otherwise discard the current


### PR DESCRIPTION
#### Description of Change

Should fix #46469. This may have other effects, but it's my opinion that we shouldn't be telling Chromium our URL's came from the address bar when they didn't.

[Upstream Chromium recently changed how they handled navigation to URL's with fragments via the omnibox / address bar,](https://chromium-review.googlesource.com/c/chromium/src/+/5896034/29/content/browser/renderer_host/navigation_controller_impl.cc) which essentially no-ops navigating to the same URL if a fragment is involved. If no fragment is involved, its treated as a reload. Previously this was the case when fragments were involved, but it seems Chromium is trying to distance themselves from that behavior.

Really, as for the initial issue, I don't think we should have ever expected "navigate to the same URL" to always mean "reload". However, with the removal of our use of the `ui::PAGE_TRANSITION_FROM_ADDRESS_BAR` flag that behavior lives on so this really accomplishes two things:

1. Fixes #46469 as desired by the original issue author,
2. Removes the use of a flag we probably shouldn't have been using in the first place.

EDIT: I had to re-include said flag at least for the cases that motivated its original inclusion: debug URLs.

#### Checklist

- [x] PR description included
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
