### PR TITLE
fix: alt-space should route through 'system-context-menu'

### DIFF
--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -150,6 +150,31 @@ bool ElectronDesktopWindowTreeHostWin::HandleMouseEvent(ui::MouseEvent* event) {
   return views::DesktopWindowTreeHostWin::HandleMouseEvent(event);
 }
 
+bool ElectronDesktopWindowTreeHostWin::HandleIMEMessage(UINT message,
+                                                        WPARAM w_param,
+                                                        LPARAM l_param,
+                                                        LRESULT* result) {
+  if ((message == WM_SYSCHAR) && (w_param == VK_SPACE)) {
+    if (native_window_view_->widget() &&
+        native_window_view_->widget()->non_client_view()) {
+      const auto* frame =
+          native_window_view_->widget()->non_client_view()->frame_view();
+      auto location = frame->GetSystemMenuScreenPixelLocation();
+
+      bool prevent_default = false;
+      native_window_view_->NotifyWindowSystemContextMenu(
+          location.x(), location.y(), &prevent_default);
+
+      return prevent_default ||
+             views::DesktopWindowTreeHostWin::HandleIMEMessage(message, w_param,
+                                                               l_param, result);
+    }
+  }
+
+  return views::DesktopWindowTreeHostWin::HandleIMEMessage(message, w_param,
+                                                           l_param, result);
+}
+
 void ElectronDesktopWindowTreeHostWin::HandleVisibilityChanged(bool visible) {
   if (native_window_view_->widget())
     native_window_view_->widget()->OnNativeWidgetVisibilityChanged(visible);

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
@@ -44,6 +44,10 @@ class ElectronDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin,
                            int frame_thickness) const override;
   bool HandleMouseEventForCaption(UINT message) const override;
   bool HandleMouseEvent(ui::MouseEvent* event) override;
+  bool HandleIMEMessage(UINT message,
+                        WPARAM w_param,
+                        LPARAM l_param,
+                        LRESULT* result) override;
   void HandleVisibilityChanged(bool visible) override;
   void SetAllowScreenshots(bool allow) override;
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/49507
Closes https://github.com/electron/electron/issues/19429

Routes alt-space through 'system-context-menu', allowing a user to prevent default behavior of showing the system context menu.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where alt+space triggered th system context menu even if an accelerator was registered for the hotkey combination.