### PR TITLE
fix: revoke Read access after removing file via FileSystemAccess API

### DIFF
--- a/shell/browser/file_system_access/file_system_access_permission_context.h
+++ b/shell/browser/file_system_access/file_system_access_permission_context.h
@@ -140,6 +140,11 @@ class FileSystemAccessPermissionContext
 
   void PermissionGrantDestroyed(PermissionGrantImpl* grant);
 
+  // Restores the read permission for `path` if it was previously downgraded,
+  // e.g. by a `remove()` call.
+  void MaybeRestoreReadPermission(const url::Origin& origin,
+                                  const base::FilePath& path);
+
   void CheckShouldBlockAccessToPathAndReply(
       base::FilePath path,
       HandleType handle_type,


### PR DESCRIPTION
#### Description of Change

Refs CL:6677249

Revoke read access when files are removed via the File System Access API.

When `fileHandle.remove()` or `dirHandle.removeEntry()` is called, read permission for the removed path is now revoked and the path is added to a downgraded list for that origin. Whether subsequent permission queries succeed depends on whether the parent directory still has read access. This is gated behind a new `FileSystemAccessRevokeReadOnRemove` flag.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none