### PR TITLE
fix: gc crash

### DIFF
--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -179,11 +179,11 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
 - (void)dealloc {
   [menu_ setDelegate:nil];
 
+  model_ = nullptr;
+
   // Close the menu if it is still open. This could happen if a tab gets closed
   // while its context menu is still open.
   [self cancel];
-
-  model_ = nullptr;
 }
 
 - (void)setPopupCloseCallback:(base::OnceClosure)callback {
@@ -219,7 +219,7 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
   if (isMenuOpen_) {
     [menu_ cancelTracking];
     isMenuOpen_ = NO;
-    if (model_)
+    if (model_ & model->CanEmitEvents())
       model_->MenuWillClose();
     if (!popupCloseCallback.is_null()) {
       content::GetUIThreadTaskRunner({})->PostTask(


### PR DESCRIPTION
#### Description of Change

When a menu is garbage collected (instead of explicitly closed), the destructor path calls `[cancel]` which attempts to emit a `menu-will-close` JS event via `model_->MenuWillClose()`. In Electron 40, V8 14.4 changed context disposal GC from idle tasks to kUserVisible priority ([change](https://github.com/v8/v8/commit/8bc90d739e4fe7a5a8ed6693a1aaec5ce3cf3bce)), causing GC to run more aggressively during context teardown. If a menu's destructor fires while the V8 context is already being destroyed, we crash in GetCreationContextChecked.

switching these two lines means that MenuWillClose will not be called during alloc. This should be safe as if the menu is being GC'd, the JS context is being torn down and can't handle the event anyway


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
