### PR TITLE
ci: handle PRs with no checks in rerun apply patches

### DIFF
--- a/.github/workflows/rerun-apply-patches.yml
+++ b/.github/workflows/rerun-apply-patches.yml
@@ -35,20 +35,20 @@ jobs:
             echo "Processing PR #${PR_NUMBER}"
 
             # Find the Apply Patches workflow check for this PR
-            CHECK=$(gh pr checks "$PR_NUMBER" --json link,name,state,workflow --jq '[.[] | select(.workflow == "Apply Patches" and .name == "apply-patches")] | first')
+            CHECK=$(gh pr view "$PR_NUMBER" --json statusCheckRollup --jq '[.statusCheckRollup[] | select(.workflowName == "Apply Patches" and .name == "apply-patches")] | first')
 
             if [ -z "$CHECK" ] || [ "$CHECK" = "null" ]; then
               echo "  No Apply Patches workflow found for PR #${PR_NUMBER}"
               continue
             fi
 
-            STATE=$(echo "$CHECK" | jq -r '.state')
-            if [ "$STATE" = "SKIPPED" ]; then
+            CONCLUSION=$(echo "$CHECK" | jq -r '.conclusion')
+            if [ "$CONCLUSION" = "SKIPPED" ]; then
               echo "  apply-patches job was skipped for PR #${PR_NUMBER} (no patches)"
               continue
             fi
 
-            LINK=$(echo "$CHECK" | jq -r '.link')
+            LINK=$(echo "$CHECK" | jq -r '.detailsUrl')
 
             # Extract the run ID from the link (format: .../runs/RUN_ID/job/JOB_ID)
             RUN_ID=$(echo "$LINK" | grep -oE 'runs/[0-9]+' | cut -d'/' -f2)


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

There's an edge case that I wasn't aware of before, where `gh pr checks` exits with a non-zero exit code if there are "no checks reported" for a PR. This seems to be the case for some old PRs that are in merge conflict state.

This PR refactors the workflow to use `gh pr view` instead, which has all the same information we need, in slightly different named fields. Since `gh pr view` is just for viewing a PR, it won't fail on this edge case, `statusCheckRollup` will just be an empty array.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
