### PR TITLE
docs: add Wayland note to `win.getPosition()` and `win.getBounds()`

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -756,6 +756,9 @@ Returns [`Rectangle`](structures/rectangle.md) - The `bounds` of the window as `
 > [!NOTE]
 > On macOS, the y-coordinate value returned will be at minimum the [Tray](tray.md) height. For example, calling `win.setBounds({ x: 25, y: 20, width: 800, height: 600 })` with a tray height of 38 means that `win.getBounds()` will return `{ x: 25, y: 38, width: 800, height: 600 }`.
 
+> [!NOTE]
+> On Wayland, this method will return `{ x: 0, y: 0, ... }` as introspecting or programmatically changing the global window coordinates is prohibited.
+
 #### `win.getBackgroundColor()`
 
 Returns `string` - Gets the background color of the window in Hex (`#RRGGBB`) format.
@@ -968,6 +971,9 @@ Moves window to `x` and `y`.
 #### `win.getPosition()`
 
 Returns `Integer[]` - Contains the window's current position.
+
+> [!NOTE]
+> On Wayland, this method will return `[0, 0]` as introspecting or programmatically changing the global window coordinates is prohibited.
 
 #### `win.setTitle(title)`
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -862,6 +862,9 @@ Returns [`Rectangle`](structures/rectangle.md) - The `bounds` of the window as `
 > [!NOTE]
 > On macOS, the y-coordinate value returned will be at minimum the [Tray](tray.md) height. For example, calling `win.setBounds({ x: 25, y: 20, width: 800, height: 600 })` with a tray height of 38 means that `win.getBounds()` will return `{ x: 25, y: 38, width: 800, height: 600 }`.
 
+> [!NOTE]
+> On Wayland, this method will return `{ x: 0, y: 0, ... }` as introspecting or programmatically changing the global window coordinates is prohibited.
+
 #### `win.getBackgroundColor()`
 
 Returns `string` - Gets the background color of the window in Hex (`#RRGGBB`) format.
@@ -1086,6 +1089,9 @@ Not supported on Wayland (Linux).
 #### `win.getPosition()`
 
 Returns `Integer[]` - Contains the window's current position.
+
+> [!NOTE]
+> On Wayland, this method will return `[0, 0]` as introspecting or programmatically changing the global window coordinates is prohibited.
 
 #### `win.setTitle(title)`
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/40886.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none