### PR TITLE
fix: remove menu observer before destroying menu_controller_

### DIFF
--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -68,6 +68,10 @@ Menu::Menu(gin::Arguments* args)
 }
 
 Menu::~Menu() {
+  RemoveModelObserver();
+}
+
+void Menu::RemoveModelObserver() {
   if (model_) {
     model_->RemoveObserver(this);
   }

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -61,6 +61,10 @@ class Menu : public gin::Wrappable<Menu>,
   ElectronMenuModel* model() const { return model_.get(); }
 
  protected:
+  // Remove this instance as an observer from the model. Called by derived
+  // class destructors to ensure observer is removed before platform-specific
+  // cleanup that may trigger model callbacks.
+  void RemoveModelObserver();
   // Returns a new callback which keeps references of the JS wrapper until the
   // passed |callback| is called.
   base::OnceClosure BindSelfToClosure(base::OnceClosure callback);

--- a/shell/browser/api/electron_api_menu_mac.mm
+++ b/shell/browser/api/electron_api_menu_mac.mm
@@ -54,9 +54,7 @@ MenuMac::MenuMac(gin::Arguments* args) : Menu{args} {}
 MenuMac::~MenuMac() {
   // Must remove observer before destroying menu_controller_, which holds
   // a weak reference to model_
-  if (model_) {
-    model_->RemoveObserver(this);
-  }
+  RemoveModelObserver();
 }
 
 void MenuMac::PopupAt(BaseWindow* window,


### PR DESCRIPTION
#### Description of Change

Follow up to https://github.com/electron/electron/pull/48351

A previous refactor uncovered a long-standing bug in `MenuMac::~MenuMac() `'s lifetime cycle: When `MenuMac::~MenuMac()` was being destroyed by GC, during implicit destruction of `menu_controller_`, it could trigger callbacks to the model through observer notifications. `Menu::~Menu()` ran after, removing the observer too late.

This PR moves the observer cleanup from `Menu::~Menu()` to `MenuMac::~MenuMac()`, removing the observer before `menu_controller_` is destroyed and preventing callbacks during the deallocation.  

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an application crash on MacOS where the menu observer was not being properly removed before garbage collection.