### PR TITLE
docs: link unlinked type references in API documentation

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -123,7 +123,7 @@ Appends the `menuItem` to the menu.
 
 - `id` string
 
-Returns `MenuItem | null` the item with the specified `id`
+Returns [`MenuItem | null`](menu-item.md) - the item with the specified `id`
 
 #### `menu.insert(pos, menuItem)`
 

--- a/docs/api/shared-texture.md
+++ b/docs/api/shared-texture.md
@@ -21,7 +21,7 @@ Imports the shared texture from the given options.
 > [!NOTE]
 > This method is only available in the main process.
 
-Returns `SharedTextureImported` - The imported shared texture.
+Returns [`SharedTextureImported`](structures/shared-texture-imported.md) - The imported shared texture.
 
 ### `sharedTexture.sendSharedTexture(options, ...args)` _Experimental_
 


### PR DESCRIPTION
#### Description of Change

Adds missing markdown links for custom type references in API documentation.

**Changes:**
- `docs/api/menu.md`: Link `MenuItem` return type in `getMenuItemById()` method
- `docs/api/shared-texture.md`: Link `SharedTextureImported` return type in `importSharedTexture()` method

These return types were rendered as plain code blocks while identical types elsewhere in the same files were properly linked, causing inconsistency in documentation navigation.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none