### PR TITLE
refactor: don't log error just for unsigned code

### DIFF
--- a/shell/common/mac/codesign_util.cc
+++ b/shell/common/mac/codesign_util.cc
@@ -106,7 +106,10 @@ bool ProcessSignatureIsSameWithCurrentApp(pid_t pid) {
   status = SecCodeCheckValidity(process_code.get(), kSecCSDefaultFlags,
                                 self_requirement.get());
   if (status != errSecSuccess && status != errSecCSReqFailed) {
-    OSSTATUS_LOG(ERROR, status) << "SecCodeCheckValidity";
+    // If the code is unsigned, don't log that (it's not an actual error).
+    if (status != errSecCSUnsigned) {
+      OSSTATUS_LOG(ERROR, status) << "SecCodeCheckValidity";
+    }
     return false;
   }
   return status == errSecSuccess;


### PR DESCRIPTION
#### Description of Change

Should resolve #49652.

We don't really need to log an error when the code we're checking in `ProcessSignatureIsSameWithCurrentApp` is unsigned. It's not a system failure, we can just conclude that the signatures don't match (since we already return early if we ourselves aren't signed, the only way to reach that line of code is if we're signed; and no unsigned process (the thing were checking) has any way of matching the signature of our signed code).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR (it compiles and builds, but I don't have an Intel Mac with which to reproduce the original issue (though the code should be self-explanatory)).
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none