### PR TITLE
ci: use squash merge for apply patches workflow

### DIFF
--- a/.github/workflows/apply-patches.yml
+++ b/.github/workflows/apply-patches.yml
@@ -56,16 +56,16 @@ jobs:
         path: src/electron
         fetch-depth: 0
         persist-credentials: false
-        ref: ${{ github.event.pull_request.head.sha }}
-    - name: Rebase onto Base Branch
+        ref: ${{ github.event.pull_request.base.ref }}
+    - name: Merge PR HEAD
       working-directory: src/electron
       env:
-        BASE_REF: ${{ github.event.pull_request.base.ref }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
         git config user.email "electron@github.com"
         git config user.name "Electron Bot"
-        git fetch origin ${BASE_REF}
-        git rebase origin/${BASE_REF}
+        git fetch origin refs/pull/${PR_NUMBER}/head
+        git merge --squash FETCH_HEAD
     - name: Checkout & Sync & Save
       uses: ./src/electron/.github/actions/checkout
       with:


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

The initial implementation here did a `git rebase` to rebase the PR onto the base branch before applying patches. In practice this has turned out to be a problem, as some PRs may have a commit history which cannot cleanly rebase onto the base branch, but would be fine if squashed.

This PR refactors to align with how we actually merge PRs in practice, with a squash merge. As such it has changed to check out the base branch, and then squash merge in the PR. It leaves the changes staged rather than committing them since it's just for checking purposes.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
