### PR TITLE
feat: add deferral capability to `protocol.handle` callback

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -119,13 +119,13 @@ expect streaming responses.
 
 * `scheme` string - scheme to handle, for example `https` or `my-app`. This is
   the bit before the `:` in a URL.
-* `handler` Function\<[GlobalResponse](https://nodejs.org/api/globals.html#response) | Promise\<GlobalResponse\>\>
+* `handler` Function\<[GlobalResponse](https://nodejs.org/api/globals.html#response) | null | Promise\<GlobalResponse\> | null\>
   * `request` [GlobalRequest](https://nodejs.org/api/globals.html#request)
 
 Register a protocol handler for `scheme`. Requests made to URLs with this
 scheme will delegate to this handler to determine what response should be sent.
 
-Either a `Response` or a `Promise<Response>` can be returned.
+Either a `Response` or `null` can be returned (either optionally wrapped in a `Promise`). If `null` is returned, the original request is deferred back to the built-in handler.
 
 Example:
 

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -75,8 +75,8 @@ _This class is not exported from the `'electron'` module. It is only available a
 
 ### `new DeferredResponse()`
 
-Creates a sentinel response value that tells `protocol.handle` to defer to the
-built-in handler for the original request.
+Creates a sentinel response value that tells `protocol.handle` to defer
+the original request back to the built-in handler.
 
 ## Methods
 
@@ -149,7 +149,7 @@ scheme will delegate to this handler to determine what response should be sent.
 
 Either a `Response` or `new protocol.DeferredResponse()` can be returned (either
 optionally wrapped in a `Promise`). Returning
-`new protocol.DeferredResponse()` defers the request back to the built-in
+`new protocol.DeferredResponse()` defers the original request back to the built-in
 handler.
 
 Example:

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -56,6 +56,28 @@ app.whenReady().then(() => {
 })
 ```
 
+## Properties
+
+The `protocol` module has the following properties:
+
+### `protocol.DeferredResponse`
+
+A [`typeof DeferredResponse`](#class-deferredresponse) reference to the
+`DeferredResponse` constructor.
+
+## Class: DeferredResponse
+
+> A sentinel response value that defers handling to the built-in protocol
+> handler.
+
+Process: [Main](../glossary.md#main-process)<br />
+_This class is not exported from the `'electron'` module. It is only available as a property of the `protocol` module._
+
+### `new DeferredResponse()`
+
+Creates a sentinel response value that tells `protocol.handle` to defer to the
+built-in handler for the original request.
+
 ## Methods
 
 The `protocol` module has the following methods:
@@ -119,13 +141,16 @@ expect streaming responses.
 
 * `scheme` string - scheme to handle, for example `https` or `my-app`. This is
   the bit before the `:` in a URL.
-* `handler` Function\<[GlobalResponse](https://nodejs.org/api/globals.html#response) | null | Promise\<GlobalResponse\> | null\>
+* `handler` Function\<[GlobalResponse](https://nodejs.org/api/globals.html#response) | [DeferredResponse](#class-deferredresponse) | Promise\<[GlobalResponse](https://nodejs.org/api/globals.html#response) | [DeferredResponse](#class-deferredresponse)\>\>
   * `request` [GlobalRequest](https://nodejs.org/api/globals.html#request)
 
 Register a protocol handler for `scheme`. Requests made to URLs with this
 scheme will delegate to this handler to determine what response should be sent.
 
-Either a `Response` or `null` can be returned (either optionally wrapped in a `Promise`). If `null` is returned, the original request is deferred back to the built-in handler.
+Either a `Response` or `new protocol.DeferredResponse()` can be returned (either
+optionally wrapped in a `Promise`). Returning
+`new protocol.DeferredResponse()` defers the request back to the built-in
+handler.
 
 Example:
 

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -73,7 +73,7 @@ A [`typeof DeferredResponse`](#class-deferredresponse) reference to the
 Process: [Main](../glossary.md#main-process)<br />
 _This class is not exported from the `'electron'` module. It is only available as a property of the `protocol` module._
 
-### `new DeferredResponse()`
+### `new protocol.DeferredResponse()`
 
 Creates a sentinel response value that tells `protocol.handle` to defer
 the original request back to the built-in handler.

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -115,9 +115,9 @@ function validateResponse (res: Response) {
   return true;
 }
 
-Protocol.prototype.handle = function (this: Electron.Protocol, scheme: string, handler: (req: Request) => Response | Promise<Response>) {
+Protocol.prototype.handle = function (this: Electron.Protocol, scheme: string, handler: (req: Request) => (Response | null) | Promise<Response | null>) {
   const register = isBuiltInScheme(scheme) ? this.interceptProtocol : this.registerProtocol;
-  const success = register.call(this, scheme, async (preq: ProtocolRequest, cb: (pres: ProtocolResponse) => void) => {
+  const success = register.call(this, scheme, async (preq: ProtocolRequest, cb: (pres: ProtocolResponse | null) => void) => {
     try {
       const body = convertToRequestBody(preq.uploadData);
       const headers = new Headers(preq.headers);
@@ -132,7 +132,9 @@ Protocol.prototype.handle = function (this: Electron.Protocol, scheme: string, h
         duplex: body instanceof ReadableStream ? 'half' : undefined
       } as any);
       const res = await handler(req);
-      if (!validateResponse(res)) {
+      if (res === null) {
+        return cb(null);
+      } else if (!validateResponse(res)) {
         return cb({ error: ERR_UNEXPECTED });
       } else if (res.type === 'error') {
         cb({ error: ERR_FAILED });

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -138,10 +138,9 @@ Protocol.prototype.handle = function (this: Electron.Protocol, scheme: string, h
         cb({ error: ERR_FAILED });
       } else {
         cb({
-          data: res.body ? Readable.fromWeb(res.body as ReadableStream<ArrayBufferView>) : null,
+          data: res.body ? Readable.fromWeb(res.body as ReadableStream<ArrayBufferView>) : undefined,
           headers: res.headers ? Object.fromEntries(res.headers) : {},
           statusCode: res.status,
-          statusText: res.statusText,
           mimeType: (res as any).__original_resp?._responseHead?.mimeType
         });
       }

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -1,4 +1,4 @@
-import { ProtocolRequest, session } from 'electron/main';
+import { ProtocolRequest, ProtocolResponse, session } from 'electron/main';
 
 import { createReadStream } from 'fs';
 import { Readable } from 'stream';
@@ -117,7 +117,7 @@ function validateResponse (res: Response) {
 
 Protocol.prototype.handle = function (this: Electron.Protocol, scheme: string, handler: (req: Request) => Response | Promise<Response>) {
   const register = isBuiltInScheme(scheme) ? this.interceptProtocol : this.registerProtocol;
-  const success = register.call(this, scheme, async (preq: ProtocolRequest, cb: any) => {
+  const success = register.call(this, scheme, async (preq: ProtocolRequest, cb: (pres: ProtocolResponse) => void) => {
     try {
       const body = convertToRequestBody(preq.uploadData);
       const headers = new Headers(preq.headers);

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -7,7 +7,12 @@ import { ReadableStream } from 'stream/web';
 import type { ReadableStreamDefaultReader } from 'stream/web';
 
 // Global protocol APIs.
-const { registerSchemesAsPrivileged, getStandardSchemes, Protocol } = process._linkedBinding('electron_browser_protocol');
+const {
+  registerSchemesAsPrivileged,
+  getStandardSchemes,
+  Protocol,
+  DeferredResponse
+} = process._linkedBinding('electron_browser_protocol');
 
 const ERR_FAILED = -2;
 const ERR_UNEXPECTED = -9;
@@ -115,9 +120,21 @@ function validateResponse (res: Response) {
   return true;
 }
 
-Protocol.prototype.handle = function (this: Electron.Protocol, scheme: string, handler: (req: Request) => (Response | null) | Promise<Response | null>) {
+// We need to brand it to avoid having unrelated types like `Response` be assignable to it.
+declare const kDeferredBrand: unique symbol;
+type DeferredResponseBranded = Electron.DeferredResponse & { [kDeferredBrand]: true };
+
+// We have to extract this check out to allow for better type inference in the handler function.
+function isDeferredResponse (res: unknown): res is DeferredResponseBranded {
+  return res instanceof DeferredResponse;
+}
+
+Protocol.prototype.handle = function (
+  this: Electron.Protocol,
+  scheme: string, handler: (req: Request) => (Response | DeferredResponseBranded) | Promise<Response | DeferredResponseBranded>
+) {
   const register = isBuiltInScheme(scheme) ? this.interceptProtocol : this.registerProtocol;
-  const success = register.call(this, scheme, async (preq: ProtocolRequest, cb: (pres: ProtocolResponse | null) => void) => {
+  const success = register.call(this, scheme, async (preq: ProtocolRequest, cb: (pres: ProtocolResponse | DeferredResponseBranded) => void) => {
     try {
       const body = convertToRequestBody(preq.uploadData);
       const headers = new Headers(preq.headers);
@@ -132,8 +149,8 @@ Protocol.prototype.handle = function (this: Electron.Protocol, scheme: string, h
         duplex: body instanceof ReadableStream ? 'half' : undefined
       } as any);
       const res = await handler(req);
-      if (res === null) {
-        return cb(null);
+      if (isDeferredResponse(res)) {
+        return cb(res);
       } else if (!validateResponse(res)) {
         return cb({ error: ERR_UNEXPECTED });
       } else if (res.type === 'error') {
@@ -167,6 +184,7 @@ Protocol.prototype.isProtocolHandled = function (this: Electron.Protocol, scheme
 const protocol = {
   registerSchemesAsPrivileged,
   getStandardSchemes,
+  DeferredResponse,
   registerStringProtocol: (...args) => session.defaultSession.protocol.registerStringProtocol(...args),
   registerBufferProtocol: (...args) => session.defaultSession.protocol.registerBufferProtocol(...args),
   registerStreamProtocol: (...args) => session.defaultSession.protocol.registerStreamProtocol(...args),

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -79,6 +79,9 @@ struct Converter<CustomScheme> {
 
 namespace electron::api {
 
+gin::DeprecatedWrapperInfo DeferredResponse::kWrapperInfo = {
+    gin::kEmbedderNativeGin};
+
 gin::DeprecatedWrapperInfo Protocol::kWrapperInfo = {gin::kEmbedderNativeGin};
 
 std::vector<std::string>& GetStandardSchemes() {
@@ -272,6 +275,27 @@ v8::Local<v8::Promise> Protocol::IsProtocolHandled(v8::Isolate* const isolate,
                    std::ranges::contains(kBuiltinSchemes, scheme));
 }
 
+DeferredResponse::DeferredResponse() = default;
+
+DeferredResponse::~DeferredResponse() = default;
+
+// static
+gin_helper::Handle<DeferredResponse> DeferredResponse::New(
+    gin_helper::ErrorThrower thrower) {
+  return gin_helper::CreateHandle(thrower.isolate(), new DeferredResponse{});
+}
+
+// static
+v8::Local<v8::ObjectTemplate> DeferredResponse::FillObjectTemplate(
+    v8::Isolate* isolate,
+    v8::Local<v8::ObjectTemplate> tmpl) {
+  return gin::ObjectTemplateBuilder(isolate, GetClassName(), tmpl).Build();
+}
+
+const char* DeferredResponse::GetTypeName() {
+  return GetClassName();
+}
+
 void Protocol::HandleOptionalCallback(gin::Arguments* args, Error error) {
   base::RepeatingCallback<void(v8::Local<v8::Value>)> callback;
   if (args->GetNext(&callback)) {
@@ -363,6 +387,8 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   v8::Isolate* const isolate = electron::JavascriptEnvironment::GetIsolate();
   gin_helper::Dictionary dict{isolate, exports};
+  dict.Set("DeferredResponse",
+           electron::api::DeferredResponse::GetConstructor(isolate, context));
   dict.Set("Protocol",
            electron::api::Protocol::GetConstructor(isolate, context));
   dict.SetMethod("registerSchemesAsPrivileged", &RegisterSchemesAsPrivileged);

--- a/shell/browser/api/electron_api_protocol.h
+++ b/shell/browser/api/electron_api_protocol.h
@@ -37,6 +37,22 @@ void AddServiceWorkerScheme(const std::string& scheme);
 void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
                                  v8::Local<v8::Value> val);
 
+class DeferredResponse final
+    : public gin_helper::DeprecatedWrappable<DeferredResponse>,
+      public gin_helper::Constructible<DeferredResponse> {
+ public:
+  static gin_helper::Handle<DeferredResponse> New(gin_helper::ErrorThrower);
+  static v8::Local<v8::ObjectTemplate> FillObjectTemplate(
+      v8::Isolate* isolate,
+      v8::Local<v8::ObjectTemplate> tmpl);
+  static const char* GetClassName() { return "DeferredResponse"; }
+
+  static gin::DeprecatedWrapperInfo kWrapperInfo;
+  const char* GetTypeName() override;
+  DeferredResponse();
+  ~DeferredResponse() override;
+};
+
 // Protocol implementation based on network services.
 class Protocol final : public gin_helper::DeprecatedWrappable<Protocol>,
                        public gin_helper::Constructible<Protocol> {

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -12,6 +12,7 @@
 #include "base/functional/callback_helpers.h"
 #include "base/strings/string_split.h"
 #include "content/public/browser/browser_context.h"
+#include "gin/converter.h"
 #include "gin/arguments.h"
 #include "extensions/browser/extension_navigation_ui_data.h"
 #include "net/base/completion_repeating_callback.h"
@@ -23,6 +24,7 @@
 #include "services/network/public/cpp/features.h"
 #include "services/network/public/mojom/early_hints.mojom.h"
 #include "services/network/public/mojom/url_response_head.mojom.h"
+#include "shell/browser/api/electron_api_protocol.h"
 #include "shell/browser/net/asar/asar_url_loader.h"
 #include "shell/common/options_switches.h"
 #include "third_party/abseil-cpp/absl/strings/str_format.h"
@@ -43,7 +45,9 @@ void StartLoadingOrDefer(
     ProtocolType type,
     gin::Arguments* args) {
   v8::Local<v8::Value> handler_return_value = args->PeekNext();
-  if (!handler_return_value.IsEmpty() && handler_return_value->IsNull()) {
+  electron::api::DeferredResponse* deferred_response = nullptr;
+  if (gin::ConvertFromV8(args->isolate(), handler_return_value,
+                         &deferred_response) && deferred_response) {
     mojo::Remote<network::mojom::URLLoaderFactory> proxy_factory(
         std::move(proxy_factory_remote));
     proxy_factory->CreateLoaderAndStart(

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -51,7 +51,6 @@ void StartLoadingOrDefer(
         request, std::move(client), traffic_annotation);
     return;
   }
-
   ElectronURLLoaderFactory::StartLoading(
       std::move(loader), request_id, options, request, std::move(client),
       traffic_annotation, std::move(proxy_factory_remote), type, args);

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -1613,6 +1613,45 @@ describe('protocol module', () => {
       expect(await contents.executeJavaScript('document.documentElement.textContent')).to.equal('hello');
     });
 
+    // For more context on the difference between the above test and the below test, see:
+    // https://github.com/electron/electron/pull/49671
+
+    it('can defer to the built-in handler and receive redirects', async () => {
+      protocol.handle('http', () => null);
+      defer(() => { protocol.unhandle('http'); });
+
+      const headersReceived: Array<{ url: string, statusCode: number }> = [];
+      session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+        if (details.webContentsId === contents.id && details.resourceType === 'mainFrame') {
+          headersReceived.push({ url: details.url, statusCode: details.statusCode });
+        }
+        callback({ cancel: false, responseHeaders: details.responseHeaders });
+      });
+      defer(() => { session.defaultSession.webRequest.onHeadersReceived(null); });
+
+      let redirectURL = '';
+      contents.once('did-redirect-navigation', (_event, redirectedURL) => {
+        redirectURL = redirectedURL;
+      });
+
+      const server = http.createServer((req, res) => {
+        if (req.url === '/final') {
+          res.end('hello');
+          server.close();
+        } else {
+          res.writeHead(302, { Location: '/final' });
+          res.end();
+        }
+      });
+      const { url } = await listen(server);
+      await contents.loadURL(url);
+
+      expect(redirectURL).to.equal(`${url}/final`);
+      expect(headersReceived[0]).to.deep.equal({ url: `${url}/`, statusCode: 302 });
+      expect(headersReceived[1]).to.deep.equal({ url: `${url}/final`, statusCode: 200 });
+      expect(await contents.executeJavaScript('document.documentElement.textContent')).to.equal('hello');
+    });
+
     it('supports sniffing mime type', async () => {
       protocol.handle('http', async (req) => {
         return net.fetch(req, { bypassCustomProtocolHandlers: true });


### PR DESCRIPTION
#### Description of Change

##### Introduction

This is my attempt to resolve #15434. It's a bit limited from a "dream feature" scenario, but it works well enough in many cases. In short: now, if a developer returns `null` from their `protocol.handle` handler, the original request is deferred back to the built-in handler.

##### FAQ

**Why not `next()` (or `continue()`)?**

Passing in a function for the developer to call makes the code flow a lot more complex. What happens if they write code after calling `next()`? What if they call it twice? Making the sentinel a return value eliminates this issue.

**What if the developer modifies the request before returning `null`?**

As mentioned above (and in the added docs):

> the **original** [emphasis added] request is deferred back to the built-in handler.

There is no link between the request object in JS-land and the request object in C++-land, and this PR doesn't add one. To eliminate complexity, this implementation doesn't worry about a link between these worlds and just continues to use the original request when `null` is returned. Those wanting to decorate requests pre-flight can (preferably) do so from the renderer. If they want to do so with data accessible only from the main process, they can pass that info with IPC.

**What if the developer wants to inspect the response from the built-in handler?**

Again, to eliminate complexity, this is not possible from within the original handler. I also think that most of what people would want to do with this is possible from the renderer (again, with IPC if necessary).

##### Related Issues

Auto-linking more issues here that I find would be resolved by this PR:

resolves #49358
resolves #39709

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added the ability to defer to built-in logic in handlers registered with `protocol.handle`.
 