### PR TITLE
feat: use 1.0f as default for offscreen scale factor.

### DIFF
--- a/docs/api/structures/web-preferences.md
+++ b/docs/api/structures/web-preferences.md
@@ -94,7 +94,7 @@
     The actual output pixel format and color space of the texture should refer to [`OffscreenSharedTexture`](../structures/offscreen-shared-texture.md) object in the `paint` event.
     * `argb` - The requested output texture format is 8-bit unorm RGBA, with SRGB SDR color space.
     * `rgbaf16` - The requested output texture format is 16-bit float RGBA, with scRGB HDR color space.
-  * `deviceScaleFactor` number (optional) _Experimental_ - The device scale factor of the offscreen rendering output. If not set, will use primary display's scale factor as default.
+  * `deviceScaleFactor` number (optional) _Experimental_ - The device scale factor of the offscreen rendering output. If not set, will use `1` as default.
 * `contextIsolation` boolean (optional) - Whether to run Electron APIs and
   the specified `preload` script in a separate JavaScript context. Defaults
   to `true`. The context that the `preload` script runs in will only have

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -820,12 +820,8 @@ class WebContents final : public ExclusiveAccessContext,
   bool offscreen_use_shared_texture_ = false;
   std::string offscreen_shared_texture_pixel_format_ = "argb";
 
-  // TODO(reito): 0.0f means the device scale factor is not set, it's a
-  // migration of the breaking change so that we can read the device scale
-  // factor from physical primary screen's info. In Electron 42, we need to set
-  // this to 1.0f so that the offscreen rendering use 1.0 as default when
-  // `deviceScaleFactor` is not specified in webPreferences.
-  float offscreen_device_scale_factor_ = 0.0f;
+  // Use 1.0f for consistent behavior.
+  float offscreen_device_scale_factor_ = 1.0f;
 
   // Whether window is fullscreened by HTML5 api.
   bool html_fullscreen_ = false;

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -93,15 +93,6 @@ ui::MouseWheelEvent UiMouseWheelEventFromWebMouseEvent(
           base::ClampFloor<int>(event.delta_y)};
 }
 
-// TODO(reito): Remove this function and use default 1.0f when Electron 42.
-float GetDefaultDeviceScaleFactorFromDisplayInfo() {
-  display::Display display =
-      display::Screen::Get()->GetDisplayNearestView(gfx::NativeView());
-
-  const float factor = display.device_scale_factor();
-  return factor > 0 ? factor : 1.0f;
-}
-
 }  // namespace
 
 class ElectronDelegatedFrameHostClient
@@ -192,10 +183,8 @@ OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
   DCHECK(render_widget_host_);
   DCHECK(!render_widget_host_->GetView());
 
-  // TODO(reito): Remove this when Electron 42.
   if (cc::MathUtil::IsWithinEpsilon(offscreen_device_scale_factor_, 0.0f)) {
-    offscreen_device_scale_factor_ =
-        GetDefaultDeviceScaleFactorFromDisplayInfo();
+    offscreen_device_scale_factor_ = 1.0f;
   }
 
   delegated_frame_host_allocator_.GenerateId();

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6722,8 +6722,7 @@ describe('BrowserWindow module', () => {
       expect(data.constructor.name).to.equal('NativeImage');
       expect(data.isEmpty()).to.be.false('data is empty');
       const size = data.getSize();
-      // TODO(reito): Use scale factor 1.0f when Electron 42.
-      const { scaleFactor } = screen.getPrimaryDisplay();
+      const scaleFactor = 1;
       expect(size.width).to.be.closeTo(100 * scaleFactor, 2);
       expect(size.height).to.be.closeTo(100 * scaleFactor, 2);
     });


### PR DESCRIPTION
#### Description of Change

Currently main is 42-x-y so we make this break change according to the plan in #48730

#### Release Notes

Notes: Changed offscreen scale factor use `1.0f` as default.