### PR TITLE
feat: allow --experimental-inspector-network-resource node flag

### DIFF
--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -319,6 +319,13 @@ By default inspector websocket url is available in stderr and under /json/list e
 
 Enable support for DevTools network inspector events, for visibility into requests made by the nodejs `http` and `https` modules.
 
+### `--experimental-inspector-network-resource`
+
+Enable support for resolving source maps over the network when using the Node.js inspector.
+
+When enabled, DevTools can retrieve remote source maps for main and utility
+process scripts via the Node.js inspector.
+
 ### `--no-deprecation`
 
 Silence deprecation warnings.

--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -326,6 +326,10 @@ Enable support for resolving source maps over the network when using the Node.js
 When enabled, DevTools can retrieve remote source maps for main and utility
 process scripts via the Node.js inspector.
 
+**Note:** When enabled, the Node.js inspector will make network requests to
+URLs specified in source maps. Be mindful of this in environments where the
+process has access to internal networks.
+
 ### `--no-deprecation`
 
 Silence deprecation warnings.

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -434,6 +434,7 @@ bool IsAllowedOption(const std::string_view option) {
           "--inspect-port",
           "--inspect-publish-uid",
           "--experimental-network-inspection",
+          "--experimental-inspector-network-resource",
           "--experimental-transform-types",
       });
 


### PR DESCRIPTION
Fixes #49500

#### Description of Change

This PR adds `--experimental-inspector-network-resource` to Electron’s
Node.js CLI allowlist so it can be passed through to Node.

This enables remote source map resolution in Chrome DevTools for
main and utility processes when using the Node.js inspector.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [ ] tests are changed or added
- [ ] relevant API documentation, tutorials, and examples are updated
- [x] PR release notes describe the change

#### Release Notes

Notes: Allowed the `--experimental-inspector-network-resource` Node.js flag to be passed through Electron.