### PR TITLE
fix: crash on beep() on Linux

### DIFF
--- a/patches/chromium/make_gtk_getlibgtk_public.patch
+++ b/patches/chromium/make_gtk_getlibgtk_public.patch
@@ -1,16 +1,16 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: deepak1556 <hop2deep@gmail.com>
 Date: Thu, 7 Apr 2022 20:30:16 +0900
-Subject: Make gtk::GetLibGdkPixbuf public
+Subject: Make gdk::GetLibGdk3 and gtk::GetLibGdkPixbuf public
 
-Allows embedders to get a handle to the gdk_pixbuf
-library already loaded in the process.
+Allows embedders to get a handle to the gdk3 and gdk_pixbuf
+libraries already loaded in the process.
 
 diff --git a/ui/gtk/gtk_compat.cc b/ui/gtk/gtk_compat.cc
-index e05b4f2eb1b22d5a647cb020bae4e4052a2e735c..c06af1c03487fafe76fde3bfa157a7d265e2f3a0 100644
+index e05b4f2eb1b22d5a647cb020bae4e4052a2e735c..edb0e09e4ceb8b426e2e6a79afb7aced6b1cc6e9 100644
 --- a/ui/gtk/gtk_compat.cc
 +++ b/ui/gtk/gtk_compat.cc
-@@ -78,11 +78,6 @@ void* GetLibGio() {
+@@ -78,16 +78,6 @@ void* GetLibGio() {
    return libgio;
  }
  
@@ -19,10 +19,15 @@ index e05b4f2eb1b22d5a647cb020bae4e4052a2e735c..c06af1c03487fafe76fde3bfa157a7d2
 -  return libgdk_pixbuf;
 -}
 -
- void* GetLibGdk3() {
-   static void* libgdk3 = DlOpen("libgdk-3.so.0");
-   return libgdk3;
-@@ -175,6 +170,11 @@ gfx::Insets InsetsFromGtkBorder(const GtkBorder& border) {
+-void* GetLibGdk3() {
+-  static void* libgdk3 = DlOpen("libgdk-3.so.0");
+-  return libgdk3;
+-}
+-
+ void* GetLibGtk3(bool check = true) {
+   static void* libgtk3 = DlOpen("libgtk-3.so.0", check);
+   return libgtk3;
+@@ -175,6 +165,16 @@ gfx::Insets InsetsFromGtkBorder(const GtkBorder& border) {
  
  }  // namespace
  
@@ -31,19 +36,27 @@ index e05b4f2eb1b22d5a647cb020bae4e4052a2e735c..c06af1c03487fafe76fde3bfa157a7d2
 +  return libgdk_pixbuf;
 +}
 +
++void* GetLibGdk3() {
++  static void* libgdk3 = DlOpen("libgdk-3.so.0");
++  return libgdk3;
++}
++
  bool LoadGtk(ui::LinuxUiBackend backend) {
    static bool loaded = LoadGtkImpl(backend);
    return loaded;
 diff --git a/ui/gtk/gtk_compat.h b/ui/gtk/gtk_compat.h
-index 841e2e8fcdbe2da4aac487badd4d352476e461a2..e458df649546fa3bee10e24f0edac147186cc152 100644
+index 841e2e8fcdbe2da4aac487badd4d352476e461a2..cb9f9d2702c15d8387e72986a6ab58bbd76afbd2 100644
 --- a/ui/gtk/gtk_compat.h
 +++ b/ui/gtk/gtk_compat.h
-@@ -42,6 +42,9 @@ using SkColor = uint32_t;
+@@ -42,6 +42,12 @@ using SkColor = uint32_t;
  
  namespace gtk {
  
 +// Get handle to the currently loaded gdk_pixbuf library in the process.
 +void* GetLibGdkPixbuf();
++
++// Get handle to the currently loaded gdk_pixbuf library in the process.
++void* GetLibGdk3();
 +
  // Loads libgtk and related libraries and returns true on success.
  bool LoadGtk(ui::LinuxUiBackend backend);

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -394,6 +394,10 @@ void ElectronBrowserMainParts::ToolkitInitialized() {
   CHECK(linux_ui);
   linux_ui_getter_ = std::make_unique<LinuxUiGetterImpl>();
 
+  electron::InitializeElectron_gdk(gtk::GetLibGdk3());
+  CHECK(electron::IsElectron_gdkInitialized())
+      << "Failed to initialize libgdk-3.so.0";
+
   electron::InitializeElectron_gdk_pixbuf(gtk::GetLibGdkPixbuf());
   CHECK(electron::IsElectron_gdk_pixbufInitialized())
       << "Failed to initialize libgdk_pixbuf-2.0.so.0";


### PR DESCRIPTION
#### Description of Change

Fix a crash that could occur on Linux when calling `beep()`. Thanks to @nmggithub for tracking this down.

CI suggestions welcomed. I don't know of a good way to test audio in CI, but I have manually tested this and attest that it works.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed crash that could occur on Linux when calling `shell.beep()`.