### PR TITLE
ci: fix patches changes detected in apply patches workflow

### DIFF
--- a/.github/workflows/apply-patches.yml
+++ b/.github/workflows/apply-patches.yml
@@ -66,6 +66,7 @@ jobs:
         git config user.name "Electron Bot"
         git fetch origin refs/pull/${PR_NUMBER}/head
         git merge --squash FETCH_HEAD
+        git commit -n -m "Squashed commits"
     - name: Checkout & Sync & Save
       uses: ./src/electron/.github/actions/checkout
       with:


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Fast follow-up to #49667, because _"It leaves the changes staged rather than committing them since it's just for checking purposes."_ turned out to be famous last words.

I didn't account for the part of our CI workflow which tries to detect patch changes by re-exporting them after sync, which was flagging the staged changes as a change to a patch and failing out. This was not caught originally when testing #49667 as there was a cache match (expected) so the sync never took place. This PR has been tested with the cache disabled to ensure a more complete E2E test.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
