### PR TITLE
docs: clarify resolveHost source behavior with secure dns

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1187,6 +1187,12 @@ This can be configured to either restrict usage of non-encrypted DNS
 (`secureDnsMode: "secure"`), or disable DNS-over-HTTPS (`secureDnsMode:
 "off"`). It is also possible to enable or disable the built-in resolver.
 
+These settings apply to lookups that use Chromium's DNS resolver (for example,
+[`ses.resolveHost()`](session.md#sesresolvehosthost-options) with
+`source: 'dns'` or the default `source: 'any'`). Lookups with
+`source: 'system'` are delegated to the OS resolver and do not use
+`app.configureHostResolver()` Secure DNS settings.
+
 To disable insecure DNS, you can specify a `secureDnsMode` of `"secure"`. If you do
 so, you should make sure to provide a list of DNS-over-HTTPS servers to use, in
 case the user's DNS configuration does not include a provider that supports

--- a/docs/api/net.md
+++ b/docs/api/net.md
@@ -148,12 +148,19 @@ will be successful.
     * `any` (default) - Resolver will pick an appropriate source. Results could
       come from DNS, MulticastDNS, HOSTS file, etc
     * `system` - Results will only be retrieved from the system or OS, e.g. via
-      the `getaddrinfo()` system call
-    * `dns` - Results will only come from DNS queries
+      the `getaddrinfo()` system call. This bypasses
+      [`app.configureHostResolver()`](app.md#appconfigurehostresolveroptions).
+    * `dns` - Results will only come from DNS queries. This follows
+      [`app.configureHostResolver()`](app.md#appconfigurehostresolveroptions)
+      and the `secureDnsPolicy` value for this request.
     * `mdns` - Results will only come from Multicast DNS queries
     * `localOnly` - No external sources will be used. Results will only come
       from fast local sources that are available no matter the source setting,
       e.g. cache, hosts file, IP literal resolution, etc.
+    The `source` option selects the resolver backend. Whether Secure DNS
+    (DNS-over-HTTPS) is used is controlled by
+    [`app.configureHostResolver()`](app.md#appconfigurehostresolveroptions)
+    and `secureDnsPolicy`.
   * `cacheUsage` string (optional) - Indicates what DNS cache entries, if any,
     can be used to provide a response. One of the following values:
     * `allowed` (default) - Results may come from the host cache if non-stale

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -688,12 +688,19 @@ pooled sockets using previous proxy from being reused by future requests.
     * `any` (default) - Resolver will pick an appropriate source. Results could
       come from DNS, MulticastDNS, HOSTS file, etc
     * `system` - Results will only be retrieved from the system or OS, e.g. via
-      the `getaddrinfo()` system call
-    * `dns` - Results will only come from DNS queries
+      the `getaddrinfo()` system call. This bypasses
+      [`app.configureHostResolver()`](app.md#appconfigurehostresolveroptions).
+    * `dns` - Results will only come from DNS queries. This follows
+      [`app.configureHostResolver()`](app.md#appconfigurehostresolveroptions)
+      and the `secureDnsPolicy` value for this request.
     * `mdns` - Results will only come from Multicast DNS queries
     * `localOnly` - No external sources will be used. Results will only come
       from fast local sources that are available no matter the source setting,
       e.g. cache, hosts file, IP literal resolution, etc.
+    The `source` option selects the resolver backend. Whether Secure DNS
+    (DNS-over-HTTPS) is used is controlled by
+    [`app.configureHostResolver()`](app.md#appconfigurehostresolveroptions)
+    and `secureDnsPolicy`.
   * `cacheUsage` string (optional) - Indicates what DNS cache entries, if any,
     can be used to provide a response. One of the following values:
     * `allowed` (default) - Results may come from the host cache if non-stale


### PR DESCRIPTION
#### Description of Change

Fixes #49055.

Clarifies how `source` in `ses.resolveHost()` / `net.resolveHost()` interacts with
`app.configureHostResolver()` and per-request `secureDnsPolicy`:

- `source` selects the resolver backend
- `source: 'dns'` follows Chromium resolver Secure DNS settings
- `source: 'system'` uses OS resolution and bypasses Chromium Secure DNS settings

Also adds matching guidance to `app.configureHostResolver()` docs to make the
relationship explicit.

#### Checklist

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)

#### Release Notes

Notes: none
