### PR TITLE
docs: clarify webcontents will-navigate initiator scenarios

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -246,10 +246,11 @@ Returns:
   * `frame` WebFrameMain | null - The frame to be navigated.
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
-    navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name), or null if the navigation was not initiated by a frame. This
-    can also be null if the initiating frame was deleted before the event was
-    emitted.
+    navigation, which can differ from `frame` (for example, a parent frame via
+    `window.open` with a frame's name, or a child frame navigating the main
+    frame with `target=_top`), or null if the navigation was not initiated by a
+    frame. This can also be null if the initiating frame was deleted before the
+    event was emitted.
 * `url` string _Deprecated_
 * `isInPlace` boolean _Deprecated_
 * `isMainFrame` boolean _Deprecated_
@@ -280,10 +281,11 @@ Returns:
   * `frame` WebFrameMain | null - The frame to be navigated.
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
-    navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name), or null if the navigation was not initiated by a frame. This
-    can also be null if the initiating frame was deleted before the event was
-    emitted.
+    navigation, which can differ from `frame` (for example, a parent frame via
+    `window.open` with a frame's name, or a child frame navigating the main
+    frame with `target=_top`), or null if the navigation was not initiated by a
+    frame. This can also be null if the initiating frame was deleted before the
+    event was emitted.
 
 Emitted when a user or the page wants to start navigation in any frame. It can happen when
 the `window.location` object is changed or a user clicks a link in the page.
@@ -312,10 +314,11 @@ Returns:
   * `frame` WebFrameMain | null - The frame to be navigated.
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
-    navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name), or null if the navigation was not initiated by a frame. This
-    can also be null if the initiating frame was deleted before the event was
-    emitted.
+    navigation, which can differ from `frame` (for example, a parent frame via
+    `window.open` with a frame's name, or a child frame navigating the main
+    frame with `target=_top`), or null if the navigation was not initiated by a
+    frame. This can also be null if the initiating frame was deleted before the
+    event was emitted.
 * `url` string _Deprecated_
 * `isInPlace` boolean _Deprecated_
 * `isMainFrame` boolean _Deprecated_
@@ -337,10 +340,11 @@ Returns:
   * `frame` WebFrameMain | null - The frame to be navigated.
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
-    navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name), or null if the navigation was not initiated by a frame. This
-    can also be null if the initiating frame was deleted before the event was
-    emitted.
+    navigation, which can differ from `frame` (for example, a parent frame via
+    `window.open` with a frame's name, or a child frame navigating the main
+    frame with `target=_top`), or null if the navigation was not initiated by a
+    frame. This can also be null if the initiating frame was deleted before the
+    event was emitted.
 * `url` string _Deprecated_
 * `isInPlace` boolean _Deprecated_
 * `isMainFrame` boolean _Deprecated_
@@ -369,10 +373,11 @@ Returns:
   * `frame` WebFrameMain | null - The frame to be navigated.
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
-    navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name), or null if the navigation was not initiated by a frame. This
-    can also be null if the initiating frame was deleted before the event was
-    emitted.
+    navigation, which can differ from `frame` (for example, a parent frame via
+    `window.open` with a frame's name, or a child frame navigating the main
+    frame with `target=_top`), or null if the navigation was not initiated by a
+    frame. This can also be null if the initiating frame was deleted before the
+    event was emitted.
 * `url` string _Deprecated_
 * `isInPlace` boolean _Deprecated_
 * `isMainFrame` boolean _Deprecated_


### PR DESCRIPTION
#### Description of Change

Fixes #48793.

Updates navigation event docs in `web-contents.md` to explicitly note that
`details.initiator` can differ from `details.frame`, including:

- parent-frame initiated navigation (existing `window.open` example)
- child-frame initiated main-frame navigation via `target=_top`

The wording is applied consistently across the navigation events that expose
`details.initiator`.

#### Checklist

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)

#### Release Notes

Notes: none
