### PR TITLE
docs: mention webdriver-added cli switches in selenium tests

### DIFF
--- a/docs/tutorial/automated-testing.md
+++ b/docs/tutorial/automated-testing.md
@@ -165,6 +165,13 @@ driver.wait(() => {
 driver.quit()
 ```
 
+> [!NOTE]
+> ChromeDriver and WebDriver may add additional command-line switches when
+> launching your Electron app (for example, `--remote-debugging-port`).
+> If your app parses `process.argv` in strict mode (e.g. with `yargs.strict()`),
+> allow unknown options or filter out WebDriver-added switches before
+> validating arguments.
+
 ## Using Playwright
 
 [Microsoft Playwright](https://playwright.dev) is an end-to-end testing framework built


### PR DESCRIPTION
#### Description of Change

Fixes #31769.

Adds a note to the Selenium/WebDriver guide that ChromeDriver/WebDriver can
append command-line switches when launching Electron.

This clarifies why strict argv validation (for example `yargs.strict()`) may
fail in test runs, and points users to allow/filter unknown switches.

#### Checklist

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)

#### Release Notes

Notes: none
