### PR TITLE
docs: clarify window.open feature-string parsing behavior

### DIFF
--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -33,14 +33,29 @@ because it is invoked in the main process.
 Returns [`Window`](https://developer.mozilla.org/en-US/docs/Web/API/Window) | null
 
 `features` is a comma-separated key-value list, following the standard format of
-the browser. Electron will parse [`BrowserWindowConstructorOptions`](structures/browser-window-options.md) out of this
-list where possible, for convenience. For full control and better ergonomics,
-consider using `webContents.setWindowOpenHandler` to customize the
-BrowserWindow creation.
+the browser. Electron parses this string into
+[`BrowserWindowConstructorOptions`](structures/browser-window-options.md) with a
+few important limitations:
+
+* Only top-level keys are parsed. Nested objects (for example
+  `webPreferences.preload`) are not supported.
+* Boolean conversion follows `window.open()` conventions:
+  * `name`, `name=yes`, `name=true`, and `name=1` are interpreted as `true`.
+  * `name=no`, `name=false`, and `name=0` are interpreted as `false`.
+* The following keys are parsed as numbers: `top`, `left`, `x`, `y`, `width`,
+  `height`, `innerWidth`, `innerHeight`, `minWidth`, `maxWidth`, `minHeight`,
+  `maxHeight`, and `opacity`.
+* `top` and `left` are aliases for `y` and `x`, respectively.
+* `resizable` in the feature string is ignored because Chromium treats windows
+  opened by `window.open()` as resizable.
 
 A subset of [`WebPreferences`](structures/web-preferences.md) can be set directly,
 unnested, from the features string: `zoomFactor`, `nodeIntegration`, `javascript`,
 `contextIsolation`, and `webviewTag`.
+
+For full control and better ergonomics, use
+`webContents.setWindowOpenHandler` from the main process to customize window
+creation.
 
 For example:
 


### PR DESCRIPTION
#### Description of Change

Fixes #49716.

This updates the `window.open()` docs to describe exactly how Electron parses the
`features` string today:

- only top-level keys are parsed (no nested keys like `webPreferences.preload`)
- boolean coercion rules (`yes` / `no`, `1` / `0`, etc.)
- numeric keys that are parsed as numbers
- `top` / `left` aliases for `y` / `x`
- `resizable` being ignored in the renderer-provided feature string

It also keeps the recommendation to use
`webContents.setWindowOpenHandler()` for full control from the main process.

Supersedes #49724.

#### Checklist

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)

#### Release Notes

Notes: none
