### PR TITLE
build: fixup build attestation

### DIFF
--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -376,7 +376,7 @@ def upload_io_to_github(release, filename, filepath, version):
         github_output.write(",")
       else:
         github_output.write('UPLOADED_PATHS=')
-      github_output.write(filename)
+      github_output.write(os.path.join(filepath, filename))
 
 def upload_sha256_checksum(version, file_path, key_prefix=None):
   checksum_path = f'{file_path}.sha256sum'


### PR DESCRIPTION
#### Description of Change
- Followup to #48239.  After that PR was merged nightly releases started failing with the following error:
```
Error: Could not find subject at path electron-v42.0.0-nightly.20260209-linux-x64.zip,electron-v42.0.0-nightly.20260209-linux-x64-symbols.zip,electron-v42.0.0-nightly.20260209-linux-x64-debug.zip,libcxx-objects-v42.0.0-nightly.20260209-linux-x64.zip,libcxx_headers.zip,libcxxabi_headers.zip,ffmpeg-v42.0.0-nightly.20260209-linux-x64.zip,chromedriver-v42.0.0-nightly.20260209-linux-x64.zip,mksnapshot-v42.0.0-nightly.20260209-linux-x64.zip,hunspell_dictionaries.zip
```

This PR fixes that error by passing full paths to `actions/attest-build-provenance`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
