### PR TITLE
docs: fix typos across documentation

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -633,7 +633,7 @@ Returns `string` - The current application directory.
 Returns `string` - A path to a special directory or file associated with `name`. On
 failure, an `Error` is thrown.
 
-If `app.getPath('logs')` is called without called `app.setAppLogsPath()` being called first, a default log directory will be created equivalent to calling `app.setAppLogsPath()` without a `path` parameter.
+If `app.getPath('logs')` is called without calling `app.setAppLogsPath()` being called first, a default log directory will be created equivalent to calling `app.setAppLogsPath()` without a `path` parameter.
 
 ### `app.getFileIcon(path[, options])`
 
@@ -648,7 +648,7 @@ Returns `Promise<NativeImage>` - fulfilled with the app's icon, which is a [Nati
 
 Fetches a path's associated icon.
 
-On _Windows_, there a 2 kinds of icons:
+On _Windows_, there are 2 kinds of icons:
 
 * Icons associated with certain file extensions, like `.mp3`, `.png`, etc.
 * Icons inside the file itself, like `.exe`, `.dll`, `.ico`.
@@ -764,7 +764,7 @@ app.getPreferredSystemLanguages() // ['fr-CA', 'en-US', 'zh-Hans-FI', 'es-419']
 
 Both the available languages and regions and the possible return values differ between the two operating systems.
 
-As can be seen with the example above, on Windows, it is possible that a preferred system language has no country code, and that one of the preferred system languages corresponds with the language used for the regional format. On macOS, the region serves more as a default country code: the user doesn't need to have Finnish as a preferred language to use Finland as the region,and the country code `FI` is used as the country code for preferred system languages that do not have associated countries in the language name.
+As can be seen with the example above, on Windows, it is possible that a preferred system language has no country code, and that one of the preferred system languages corresponds with the language used for the regional format. On macOS, the region serves more as a default country code: the user doesn't need to have Finnish as a preferred language to use Finland as the region, and the country code `FI` is used as the country code for preferred system languages that do not have associated countries in the language name.
 
 ### `app.addRecentDocument(path)` _macOS_ _Windows_
 
@@ -1226,7 +1226,7 @@ Returns `boolean` - whether hardware acceleration is currently enabled.
 ### `app.disableDomainBlockingFor3DAPIs()`
 
 By default, Chromium disables 3D APIs (e.g. WebGL) until restart on a per
-domain basis if the GPU processes crashes too frequently. This function
+domain basis if the GPU process crashes too frequently. This function
 disables that behavior.
 
 This method can only be called before app is ready.

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -1049,7 +1049,7 @@ under this mode apps can choose to optimize their UI for tablets, such as
 enlarging the titlebar and hiding titlebar buttons.
 
 This API returns whether the window is in tablet mode, and the `resize` event
-can be be used to listen to changes to tablet mode.
+can be used to listen to changes to tablet mode.
 
 #### `win.getMediaSourceId()`
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1165,7 +1165,7 @@ under this mode apps can choose to optimize their UI for tablets, such as
 enlarging the titlebar and hiding titlebar buttons.
 
 This API returns whether the window is in tablet mode, and the `resize` event
-can be be used to listen to changes to tablet mode.
+can be used to listen to changes to tablet mode.
 
 #### `win.getMediaSourceId()`
 

--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -264,7 +264,7 @@ will not be allowed. The `finish` event is emitted just after the end operation.
 Cancels an ongoing HTTP transaction. If the request has already emitted the
 `close` event, the abort operation will have no effect. Otherwise an ongoing
 event will emit `abort` and `close` events. Additionally, if there is an ongoing
-response object,it will emit the `aborted` event.
+response object, it will emit the `aborted` event.
 
 #### `request.followRedirect()`
 

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -5,7 +5,7 @@
 Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process) _Deprecated_ (non-sandboxed only)
 
 > [!NOTE]
-> Using the `clipoard` API from the renderer process is deprecated.
+> Using the `clipboard` API from the renderer process is deprecated.
 
 > [!IMPORTANT]
 > If you want to call this API from a renderer process,

--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -172,7 +172,7 @@ Enables net log events to be saved and writes them to `path`.
 Sets the verbosity of logging when used together with `--enable-logging`.
 `N` should be one of [Chrome's LogSeverities][severities].
 
-Note that two complimentary logging mechanisms in Chromium -- `LOG()`
+Note that two complementary logging mechanisms in Chromium -- `LOG()`
 and `VLOG()` -- are controlled by different switches. `--log-level`
 controls `LOG()` messages, while `--v` and `--vmodule` control `VLOG()`
 messages. So you may want to use a combination of these three switches

--- a/docs/api/corner-smoothing-css.md
+++ b/docs/api/corner-smoothing-css.md
@@ -49,7 +49,7 @@ Use the `system-ui` keyword to match the smoothness to the OS design language.
 | Value: | `60%` | `0%` |
 | Example: | ![A rectangle with round corners whose smoothness matches macOS](../images/corner-smoothing-example-60.svg) | ![A rectangle with round corners whose smoothness matches Windows and Linux](../images/corner-smoothing-example-0.svg) |
 
-### Controlling availibility
+### Controlling availability
 
 This CSS rule can be disabled using the Blink feature flag `ElectronCSSCornerSmoothing`.
 

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -344,7 +344,7 @@ Displays a modal dialog that shows an error message.
 
 This API can be called safely before the `ready` event the `app` module emits,
 it is usually used to report errors in early stage of startup. If called
-before the app `ready`event on Linux, the message will be emitted to stderr,
+before the app `ready` event on Linux, the message will be emitted to stderr,
 and no GUI dialog will appear.
 
 ### `dialog.showCertificateTrustDialog([window, ]options)` _macOS_ _Windows_

--- a/docs/api/incoming-message.md
+++ b/docs/api/incoming-message.md
@@ -34,7 +34,7 @@ Returns:
 * `error` Error - Typically holds an error string identifying failure root cause.
 
 Emitted when an error was encountered while streaming response data events. For
-instance, if the server closes the underlying while the response is still
+instance, if the server closes the underlying connection while the response is still
 streaming, an `error` event will be emitted on the response object and a `close`
 event will subsequently follow on the request object.
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -39,7 +39,7 @@ indicate which letter should get a generated accelerator. For example, using
 opens the associated menu. The indicated character in the button label then gets an
 underline, and the `&` character is not displayed on the button label.
 
-In order to escape the `&` character in an item name, add a proceeding `&`. For example, `&&File` would result in `&File` displayed on the button label.
+In order to escape the `&` character in an item name, add a preceding `&`. For example, `&&File` would result in `&File` displayed on the button label.
 
 Passing `null` will suppress the default menu. On Windows and Linux,
 this has the additional effect of removing the menu bar from the window.

--- a/docs/api/native-theme.md
+++ b/docs/api/native-theme.md
@@ -83,4 +83,4 @@ Currently, Windows high contrast is the only system setting that triggers forced
 
 ### `nativeTheme.prefersReducedTransparency` _Readonly_
 
-A `boolean` that indicates the whether the user has chosen via system accessibility settings to reduce transparency at the OS level.
+A `boolean` that indicates whether the user has chosen via system accessibility settings to reduce transparency at the OS level.

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -99,13 +99,13 @@ property is used instead of the `--throw-deprecation` command line flag.
 
 A `boolean` that controls whether or not deprecations printed to `stderr` include
  their stack trace. Setting this to `true` will print stack traces for deprecations.
- This property is instead of the `--trace-deprecation` command line flag.
+ This property is used instead of the `--trace-deprecation` command line flag.
 
 ### `process.traceProcessWarnings`
 
 A `boolean` that controls whether or not process warnings printed to `stderr` include
  their stack trace. Setting this to `true` will print stack traces for process warnings
- (including deprecations). This property is instead of the `--trace-warnings` command
+ (including deprecations). This property is used instead of the `--trace-warnings` command
  line flag.
 
 ### `process.type` _Readonly_

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -1216,7 +1216,7 @@ function createWindow () {
 
   mainWindow.webContents.session.setBluetoothPairingHandler((details, callback) => {
     bluetoothPinCallback = callback
-    // Send a IPC message to the renderer to prompt the user to confirm the pairing.
+    // Send an IPC message to the renderer to prompt the user to confirm the pairing.
     // Note that this will require logic in the renderer to handle this message and
     // display a prompt to the user.
     mainWindow.webContents.send('bluetooth-pairing-request', details)
@@ -1264,7 +1264,7 @@ session.defaultSession.allowNTLMCredentialsForDomains('*')
 
 Overrides the `userAgent` and `acceptLanguages` for this session.
 
-The `acceptLanguages` must a comma separated ordered list of language codes, for
+The `acceptLanguages` must be a comma separated ordered list of language codes, for
 example `"en-US,fr,de,ko,zh-CN,ja"`.
 
 This doesn't affect existing `WebContents`, and each `WebContents` can use

--- a/docs/api/structures/display.md
+++ b/docs/api/structures/display.md
@@ -7,7 +7,7 @@
 * `depthPerComponent` number - The number of bits per color component.
 * `detected` boolean - `true` if the display is detected by the system.
 * `displayFrequency` number - The display refresh rate.
-* `id` number - Unique identifier associated with the display. A value of of -1 means the display is invalid or the correct `id` is not yet known, and a value of -10 means the display is a virtual display assigned to a unified desktop.
+* `id` number - Unique identifier associated with the display. A value of -1 means the display is invalid or the correct `id` is not yet known, and a value of -10 means the display is a virtual display assigned to a unified desktop.
 * `internal` boolean - `true` for an internal display and `false` for an external display.
 * `label` string - User-friendly label, determined by the platform.
 * `maximumCursorSize` [Size](size.md) - Maximum cursor size in native pixels.

--- a/docs/api/structures/notification-action.md
+++ b/docs/api/structures/notification-action.md
@@ -15,6 +15,6 @@ In order for extra notification buttons to work on macOS your app must meet the
 following criteria.
 
 * App is signed
-* App has it's `NSUserNotificationAlertStyle` set to `alert` in the `Info.plist`.
+* App has its `NSUserNotificationAlertStyle` set to `alert` in the `Info.plist`.
 
 If either of these requirements are not met the button won't appear.

--- a/docs/api/structures/web-preferences.md
+++ b/docs/api/structures/web-preferences.md
@@ -40,7 +40,7 @@
 * `javascript` boolean (optional) - Enables JavaScript support. Default is `true`.
 * `webSecurity` boolean (optional) - When `false`, it will disable the
   same-origin policy (usually using testing websites by people), and set
-  `allowRunningInsecureContent` to `true` if this options has not been set
+  `allowRunningInsecureContent` to `true` if this option has not been set
   by user. Default is `true`.
 * `allowRunningInsecureContent` boolean (optional) - Allow an https page to run
   JavaScript, CSS or plugins from http URLs. Default is `false`.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -383,7 +383,7 @@ Emitted after a server side redirect occurs during navigation.  For example a 30
 redirect.
 
 This event cannot be prevented, if you want to prevent redirects you should
-checkout out the `will-redirect` event above.
+check out the `will-redirect` event above.
 
 #### Event: 'did-navigate'
 
@@ -1465,7 +1465,7 @@ Ignore application menu shortcuts while this web contents is focused.
   without a recognized 'action' value will result in a console error and have
   the same effect as returning `{action: 'deny'}`.
 
-Called before creating a window a new window is requested by the renderer, e.g.
+Called before creating a window when a new window is requested by the renderer, e.g.
 by `window.open()`, a link with `target="_blank"`, shift+clicking on a link, or
 submitting a form with `<form target="_blank">`. See
 [`window.open()`](window-open.md) for more details and how to use this in
@@ -2369,7 +2369,7 @@ instance that might own this `WebContents`.
 
 #### `contents.devToolsWebContents` _Readonly_
 
-A `WebContents | null` property that represents the of DevTools `WebContents` associated with a given `WebContents`.
+A `WebContents | null` property that represents the DevTools `WebContents` associated with a given `WebContents`.
 
 > [!NOTE]
 > Users should never store this object because it may become `null`

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -94,7 +94,7 @@ Users can force XWayland by passing `--ozone-platform=x11`.
 ### Removed: `ORIGINAL_XDG_CURRENT_DESKTOP` environment variable
 
 Previously, Electron changed the value of `XDG_CURRENT_DESKTOP` internally to `Unity`, and stored the original name of the desktop session
-in a separate variable. `XDG_CURRENT_DESKTOP` is no longer overriden and now reflects the actual desktop environment.
+in a separate variable. `XDG_CURRENT_DESKTOP` is no longer overridden and now reflects the actual desktop environment.
 
 ### Removed: macOS 11 support
 
@@ -175,7 +175,7 @@ window is not currently visible.
 
 `app.commandLine` was only meant to handle chromium switches (which aren't case-sensitive) and switches passed via `app.commandLine` will not be passed down to any of the child processes.
 
-If you were using `app.commandLine` to control the behavior of the  main process, you should do this via `process.argv`.
+If you were using `app.commandLine` to control the behavior of the main process, you should do this via `process.argv`.
 
 ### Deprecated: `NativeImage.getBitmap()`
 
@@ -205,7 +205,7 @@ from upstream Chromium.
 ### Deprecated: `null` value for `session` property in `ProtocolResponse`
 
 Previously, setting the ProtocolResponse.session property to `null`
-Would create a random independent session. This is no longer supported.
+would create a random independent session. This is no longer supported.
 
 Using single-purpose sessions here is discouraged due to overhead costs;
 however, old code that needs to preserve this behavior can emulate it by
@@ -216,7 +216,7 @@ and then using it in `ProtocolResponse.session`.
 
 When calling `Session.clearStorageData(options)`, the `options.quota`
 property is deprecated. Since the `syncable` type was removed, there
-is only type left -- `'temporary'` -- so specifying it is unnecessary.
+is only one type left -- `'temporary'` -- so specifying it is unnecessary.
 
 ### Deprecated: Extension methods and events on `session`
 
@@ -545,7 +545,7 @@ more information.
 
 ### Removed: The `--disable-color-correct-rendering` switch
 
-This switch was never formally documented but it's removal is being noted here regardless. Chromium itself now has better support for color spaces so this flag should not be needed.
+This switch was never formally documented but its removal is being noted here regardless. Chromium itself now has better support for color spaces so this flag should not be needed.
 
 ### Behavior Changed: `BrowserView.setAutoResize` behavior on macOS
 
@@ -1236,7 +1236,7 @@ more details.
 
 ### API Changed: `webContents.printToPDF()`
 
-`webContents.printToPDF()` has been modified to conform to [`Page.printToPDF`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF) in the Chrome DevTools Protocol. This has been changes in order to
+`webContents.printToPDF()` has been modified to conform to [`Page.printToPDF`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF) in the Chrome DevTools Protocol. This has been changed in order to
 address changes upstream that made our previous implementation untenable and rife with bugs.
 
 **Arguments Changed**

--- a/docs/development/build-instructions-macos.md
+++ b/docs/development/build-instructions-macos.md
@@ -40,7 +40,7 @@ If you are on arm64 architecture, the build script may be pointing to the wrong 
 
 ### Certificates fail to verify
 
-installing [`certifi`](https://pypi.org/project/certifi/) will fix the following error:
+Installing [`certifi`](https://pypi.org/project/certifi/) will fix the following error:
 
 ```sh
 ________ running 'python3 src/tools/clang/scripts/update.py' in '/Users/<user>/electron'

--- a/docs/development/debugging-on-windows.md
+++ b/docs/development/debugging-on-windows.md
@@ -28,7 +28,7 @@ with breakpoints inside Electron's source code.
   format.
 
 * **ProcMon**: The [free SysInternals tool][sys-internals] allows you to inspect
-  a processes parameters, file handles, and registry operations.
+  a process's parameters, file handles, and registry operations.
 
 ## Attaching to and Debugging Electron
 

--- a/docs/development/source-code-directory-structure.md
+++ b/docs/development/source-code-directory-structure.md
@@ -14,7 +14,7 @@ control via the [`DEPS`](https://github.com/electron/electron/blob/main/DEPS) fi
 [initializing a local Electron checkout](./build-instructions-gn.md), Electron's source code is just one
 of many nested folders within the project root.
 
-The project contains a single `src` folder that corresponds a specific git checkout of
+The project contains a single `src` folder that corresponds to a specific git checkout of
 [Chromium's `src` folder](https://source.chromium.org/chromium/chromium/src). In addition, Electron's
 repository code is contained in `src/electron` (with its own nested git repository), and other
 Electron-specific third-party dependencies (e.g. [nan](https://github.com/nodejs/nan) or

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -17,7 +17,7 @@ style, run `npm run lint`, which will run a variety of linting checks
 against your changes depending on which areas of the code they touch.
 
 Many of these checks are included as precommit hooks, so it's likely
-you error would be caught at commit time.
+your error would be caught at commit time.
 
 ## Unit Tests
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -14,7 +14,7 @@ dependency tree from `node_modules`).
 
 ### ASAR integrity
 
-ASAR integrity is an security feature that validates the contents of your app's
+ASAR integrity is a security feature that validates the contents of your app's
 ASAR archives at runtime. When enabled, your Electron app will verify the
 header hash of its ASAR archive on runtime. If no hash is present or if there is a mismatch in the
 hashes, the app will forcefully terminate.
@@ -137,9 +137,9 @@ See also: [code signing](#code-signing)
 
 ### OSR
 
-OSR (offscreen rendering) can be used for loading heavy page in
+OSR (offscreen rendering) can be used for loading a heavy page in
 background and then displaying it after (it will be much faster).
-It allows you to render page without showing it on screen.
+It allows you to render a page without showing it on screen.
 
 For more information, read the [Offscreen Rendering][] tutorial.
 

--- a/docs/tutorial/code-signing.md
+++ b/docs/tutorial/code-signing.md
@@ -210,7 +210,7 @@ const msiCreator = new MSICreator({
 const supportBinaries = await msiCreator.create()
 
 // 🆕 Step 2a: optionally sign support binaries if you
-// sign you binaries as part of of your packaging script
+// sign your binaries as part of your packaging script
 for (const binary of supportBinaries) {
   // Binaries are the new stub executable and optionally
   // the Squirrel auto updater.

--- a/docs/why-electron.md
+++ b/docs/why-electron.md
@@ -30,7 +30,7 @@ If you want to focus on building a great product without debugging a weird quirk
 
 Whatever provider or customer data you need to interact with, they will have probably thought of an integration path with the web. Depending on your technology choice, embedding a YouTube video either takes 30 seconds or requires you to hire a team devoted to streaming and hardware-accelerated video decoding. In the case of YouTube, using anything other than the provided players is actually against their terms and conditions, so you’ll likely embed a browser frame before you implement your own video streaming decoder.
 
-There will be virtually no platform where your app cannot run if you build it with web technologies. Virtually all devices with a display—be that an ATM, a car infotainment system, a smart TV, a fridge, or a Nintendo Switch—come with means to display web technologies. The web is safe bet if you want to be cross-platform.
+There will be virtually no platform where your app cannot run if you build it with web technologies. Virtually all devices with a display—be that an ATM, a car infotainment system, a smart TV, a fridge, or a Nintendo Switch—come with means to display web technologies. The web is a safe bet if you want to be cross-platform.
 
 ### Ubiquity
 
@@ -59,7 +59,7 @@ What does all of that mean for you, a developer, in practice?
 
 ### Stability, security, performance
 
-Electron delivers the best experience on all target platforms (macOS, Windows, Linux) by bundling the latest version of Chromium, V8, and Node.js directly with the application binary. When it comes to running and rendering web content with upmost stability, security, and performance, we currently believe that stack to be “best in class”.
+Electron delivers the best experience on all target platforms (macOS, Windows, Linux) by bundling the latest version of Chromium, V8, and Node.js directly with the application binary. When it comes to running and rendering web content with utmost stability, security, and performance, we currently believe that stack to be “best in class”.
 
 #### Why bundle anything at all
 


### PR DESCRIPTION
#### Description of Change

Fix 40 typos across 25 documentation files, including:

- **Misspellings**: `clipoard` → `clipboard`, `availibility` → `availability`, `overriden` → `overridden`
- **Wrong words**: `complimentary` → `complementary`, `proceeding` → `preceding`, `upmost` → `utmost`
- **Missing words**: "without called" → "without calling", "there a 2 kinds" → "there are 2 kinds", "property is instead of" → "property is used instead of"
- **Doubled/extra words**: "can be be used" → "can be used", "A value of of" → "A value of", "represents the of DevTools" → "represents the DevTools"
- **Missing spaces**: `language,and` → `language, and`, `object,it` → `object, it`
- **Grammar**: "it's removal" → "its removal", "has it's" → "has its", "this options has" → "this option has"
- **Garbled text**: "Called before creating a window a new window is requested" → "Called before creating a window when a new window is requested"

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR

#### Release Notes

Notes: none