### PR TITLE
ci: add markdownlint problem matcher

### DIFF
--- a/.github/problem-matchers/markdownlint.json
+++ b/.github/problem-matchers/markdownlint.json
@@ -1,0 +1,16 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "markdownlint",
+      "pattern": [
+        {
+          "regexp": "^(.+):(\\d+):(\\d+)\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/pipeline-electron-lint.yml
+++ b/.github/workflows/pipeline-electron-lint.yml
@@ -65,9 +65,11 @@ jobs:
         curl -sL "https://chromium.googlesource.com/chromium/src/+/${chromium_revision}/buildtools/DEPS?format=TEXT" | base64 -d > src/buildtools/DEPS
 
         gclient sync --spec="solutions=[{'name':'src/buildtools','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':True},'managed':False}]"
-    - name: Add ESLint problem matcher
+    - name: Add problem matchers
       shell: bash
-      run: echo "::add-matcher::src/electron/.github/problem-matchers/eslint-stylish.json"
+      run: |
+        echo "::add-matcher::src/electron/.github/problem-matchers/eslint-stylish.json"
+        echo "::add-matcher::src/electron/.github/problem-matchers/markdownlint.json"
     - name: Run Lint
       shell: bash
       run: |


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Problem matcher to match the error output of `markdownlint-cli2`. [Example CI run](https://github.com/electron/electron/actions/runs/21887979278/job/63187363036).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
