### PR TITLE
build: use spawn instead of spawnSync for build

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -15,7 +15,7 @@ runs:
         git config --global core.preloadindex true
         git config --global core.longpaths true
       fi
-      export BUILD_TOOLS_SHA=4430e4a505e0f4fa2a41b707a10a36f780bbdd26
+      export BUILD_TOOLS_SHA=a0cc95a1884a631559bcca0c948465b725d9295a
       npm i -g @electron/build-tools
       # Update depot_tools to ensure python
       e d update_depot_tools


### PR DESCRIPTION
#### Description of Change
- Applies https://github.com/electron/build-tools/pull/808 to fix Windows build errors like:
```
3.91s Error: failed to load build.ninja: open obj\components\optimization_guide\core\features.ninja: The parameter is incorrect.
```
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
