### PR TITLE
fix: rgbaf16 shared texture remove keyed mutex.

### DIFF
--- a/docs/api/structures/shared-texture-handle.md
+++ b/docs/api/structures/shared-texture-handle.md
@@ -1,6 +1,6 @@
 # SharedTextureHandle Object
 
-* `ntHandle` Buffer (optional) _Windows_ - NT HANDLE holds the shared texture. Note that this NT HANDLE is local to current process.
+* `ntHandle` Buffer (optional) _Windows_ - NT HANDLE holds the shared texture. Note that this NT HANDLE is local to current process. `NV12` format have keyed mutex on texture handle, while other formats do not.
 * `ioSurface` Buffer (optional) _macOS_ - IOSurfaceRef holds the shared texture. Note that this IOSurface is local to current process (not global).
 * `nativePixmap` Object (optional) _Linux_ - Structure contains planes of shared texture.
   * `planes` Object[] _Linux_ - Each plane's info of the shared texture.

--- a/docs/api/structures/shared-texture-handle.md
+++ b/docs/api/structures/shared-texture-handle.md
@@ -1,6 +1,6 @@
 # SharedTextureHandle Object
 
-* `ntHandle` Buffer (optional) _Windows_ - NT HANDLE holds the shared texture. Note that this NT HANDLE is local to current process. `NV12` format have keyed mutex on texture handle, while other formats do not.
+* `ntHandle` Buffer (optional) _Windows_ - NT HANDLE holds the shared texture. Note that this NT HANDLE is local to current process. Output texture of `rgba`, `bgra`, `rgbaf16` formats don't have keyed mutex on texture handle, but `nv12` format texture handles have.
 * `ioSurface` Buffer (optional) _macOS_ - IOSurfaceRef holds the shared texture. Note that this IOSurface is local to current process (not global).
 * `nativePixmap` Object (optional) _Linux_ - Structure contains planes of shared texture.
   * `planes` Object[] _Linux_ - Each plane's info of the shared texture.

--- a/docs/api/structures/shared-texture-handle.md
+++ b/docs/api/structures/shared-texture-handle.md
@@ -1,6 +1,6 @@
 # SharedTextureHandle Object
 
-* `ntHandle` Buffer (optional) _Windows_ - NT HANDLE holds the shared texture. Note that this NT HANDLE is local to current process. Output texture of `rgba`, `bgra`, `rgbaf16` formats don't have keyed mutex on texture handle, but `nv12` format texture handles have.
+* `ntHandle` Buffer (optional) _Windows_ - NT HANDLE holds the shared texture. Note that this NT HANDLE is local to current process.  Output textures of `rgba`, `bgra`, `rgbaf16` formats don't have a keyed mutex on the texture handle, but `nv12` format texture handles do have a keyed mutex.
 * `ioSurface` Buffer (optional) _macOS_ - IOSurfaceRef holds the shared texture. Note that this IOSurface is local to current process (not global).
 * `nativePixmap` Object (optional) _Linux_ - Structure contains planes of shared texture.
   * `planes` Object[] _Linux_ - Each plane's info of the shared texture.

--- a/patches/chromium/osr_shared_texture_remove_keyed_mutex_on_win_dxgi.patch
+++ b/patches/chromium/osr_shared_texture_remove_keyed_mutex_on_win_dxgi.patch
@@ -36,10 +36,10 @@ index 4f1db7db3da9f792ed2a0352abf6940b0f03f4ff..c35b5a44474b6a0c38f177342263e49a
    Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11_texture;
  
 diff --git a/media/video/renderable_mappable_shared_image_video_frame_pool.cc b/media/video/renderable_mappable_shared_image_video_frame_pool.cc
-index 36ed797edc58a6cf094a0b720bf949b3f6379890..950b839a67fc190f9c0d73bcc102b547178216bb 100644
+index 36ed797edc58a6cf094a0b720bf949b3f6379890..36a4a080da38cddad645d42e5c53c840e211105e 100644
 --- a/media/video/renderable_mappable_shared_image_video_frame_pool.cc
 +++ b/media/video/renderable_mappable_shared_image_video_frame_pool.cc
-@@ -211,6 +211,23 @@ bool FrameResources::Initialize(VideoPixelFormat format,
+@@ -211,6 +211,24 @@ bool FrameResources::Initialize(VideoPixelFormat format,
    const gfx::Size coded_size =
        GetCodedSizeForVideoPixelFormat(format, visible_size_);
  
@@ -49,7 +49,8 @@ index 36ed797edc58a6cf094a0b720bf949b3f6379890..950b839a67fc190f9c0d73bcc102b547
 +  // once the GMB is returned from CopyRequest. So there will be no race
 +  // condition on that texture. We can request a GMB without a keyed mutex to
 +  // accelerate and probably prevent some driver deadlock.
-+  if (format == PIXEL_FORMAT_ARGB || format == PIXEL_FORMAT_ABGR) {
++  if (format == PIXEL_FORMAT_ARGB || format == PIXEL_FORMAT_ABGR ||
++      format == PIXEL_FORMAT_RGBAF16) {
 +    // This value is 'borrowed', SCANOUT_VEA_CPU_READ is probably invalid
 +    // cause there's no real SCANOUT on Windows. We simply use this enum as a
 +    // flag to disable mutex in the GMBFactoryDXGI because this enum is also


### PR DESCRIPTION
#### Description of Change

Fixed an issue that caused the RGBAF16 shared texture format to have a keyed mutex on Windows.

Closes #49752

#### Release Notes

Notes: Fixed an issue that caused the RGBAF16 shared texture format to have a keyed mutex on Windows.