### PR TITLE
fix: draggable region position with docked DevTools

### DIFF
--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -83,8 +83,16 @@ void WebContentsView::ApplyBorderRadius() {
 
 int WebContentsView::NonClientHitTest(const gfx::Point& point) {
   if (api_web_contents_) {
+    // Convert the point to the contents view's coordinate space rather than
+    // the InspectableWebContentsView's coordinate space, because the draggable
+    // region is relative to the web content area. When DevTools is docked
+    // (e.g. to the left), the contents view is offset within the parent,
+    // so we need to account for that offset.
+    auto* inspectable_view =
+        api_web_contents_->inspectable_web_contents()->GetView();
+    auto* contents_view = inspectable_view->GetContentsView();
     gfx::Point local_point(point);
-    views::View::ConvertPointFromWidget(view(), &local_point);
+    views::View::ConvertPointFromWidget(contents_view, &local_point);
     SkRegion* region = api_web_contents_->draggable_region();
     if (region && region->contains(local_point.x(), local_point.y()))
       return HTCAPTION;

--- a/shell/browser/ui/inspectable_web_contents_view.h
+++ b/shell/browser/ui/inspectable_web_contents_view.h
@@ -62,9 +62,9 @@ class InspectableWebContentsView : public views::View {
   // views::View:
   void Layout(PassKey) override;
 
- private:
   views::View* GetContentsView() const;
 
+ private:
   // Owns us.
   raw_ptr<InspectableWebContents> inspectable_web_contents_;
 


### PR DESCRIPTION
#### Description of Change

Closes #46256

Fixes draggable regions not updating their position when DevTools is docked to the left (or right) side of a frameless window. The issue was that `WebContentsView::NonClientHitTest()` was converting the hit-test point from widget coordinates to the `InspectableWebContentsView` coordinate space, but the draggable region stored on the `WebContents` is relative to the `contents_web_view_`. When DevTools is docked to the side, `contents_web_view_` is offset within the `InspectableWebContentsView`, causing the coordinate spaces to be misaligned — so hits were being tested against the wrong position.

This converts the point to `contents_web_view_` coordinates instead, which correctly accounts for any offset introduced by docked DevTools.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed draggable regions not updating position when DevTools is docked to the left or right in a frameless window.