### PR TITLE
ci: fixup build stats upload on Windows

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -98,7 +98,7 @@ runs:
         # Upload build stats to Datadog
         if ($env:DD_API_KEY) {
           try {
-            npx node electron\script\build-stats.mjs out\Default\siso.exe.INFO --upload-stats
+            npx node electron\script\build-stats.mjs out\Default\siso.exe.INFO --upload-stats ; $LASTEXITCODE = 0
           } catch {
             Write-Host "Build stats upload failed, continuing..."
           }


### PR DESCRIPTION
#### Description of Change
Occasionally Windows builds are failing with the following error:
```
2026-02-18T14:58:23.5809594Z ERROR: Invalid string length
2026-02-18T14:58:23.7429489Z ##[error]Process completed with exit code 1.
```

This appears to be coming from the step to `Upload build stats to Datadog`.  On non Windows platforms we ignore the exit code from this step; this PR does the same for Windows platforms.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
