### PR TITLE
fix: prevent GBytes leak in GdkPixbufFromSkBitmap on Linux/GTK

### DIFF
--- a/shell/browser/ui/gtk_util.cc
+++ b/shell/browser/ui/gtk_util.cc
@@ -82,11 +82,13 @@ GdkPixbuf* GdkPixbufFromSkBitmap(const SkBitmap& bitmap) {
   constexpr GdkColorspace kColorspace = GDK_COLORSPACE_RGB;
   constexpr gboolean kHasAlpha = true;
   constexpr int kBitsPerSample = 8;
-  return gdk_pixbuf_new_from_bytes(
-      g_bytes_new(std::data(bytes), std::size(bytes)), kColorspace, kHasAlpha,
-      kBitsPerSample, width, height,
+  GBytes* gbytes = g_bytes_new(std::data(bytes), std::size(bytes));
+  GdkPixbuf* pixbuf = gdk_pixbuf_new_from_bytes(
+      gbytes, kColorspace, kHasAlpha, kBitsPerSample, width, height,
       gdk_pixbuf_calculate_rowstride(kColorspace, kHasAlpha, kBitsPerSample,
                                      width, height));
+  g_bytes_unref(gbytes);
+  return pixbuf;
 }
 
 }  // namespace gtk_util


### PR DESCRIPTION
#### Description of Change

`g_bytes_new()` was called inline as an argument to `gdk_pixbuf_new_from_bytes()`, which per GTK docs does not take ownership of the `GBytes` - it adds its own internal reference. The caller's `GBytes*` was never stored or unreffed, leaking `4 * width * height` bytes of pixel data on every call.

This is most impactful when calling `Tray.setImage()` repeatedly (e.g., for animated tray icons), causing continuously growing process memory that is never reclaimed.

Internally, `gdk_pixbuf_new_from_bytes()` calls `g_object_new()` with the "pixel-bytes" construct property. In `gdk_pixbuf_set_property()`, the `PROP_PIXEL_BYTES` case stores the bytes via `g_value_dup_boxed()`, which calls `g_boxed_copy()` -> `_g_type_boxed_copy()` -> the registered copy function. Since `G_TYPE_BYTES` is registered as `G_DEFINE_BOXED_TYPE(GBytes, g_bytes, g_bytes_ref, g_bytes_unref)`, the copy function is `g_bytes_ref()`, incrementing the `refcount`. 

Simple [app](https://github.com/cinu/electron-linux-gtk-gbytes-leak-test) that sets tray icon (1024x1024) 100 times:
Before fix: `RSS 633.07 MB`
After fix: `RSS 282.91 MB`

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR

#### Release Notes

Notes: Fix memory leak when setting icons on Linux/GTK