### PR TITLE
docs: remove documentation link to discontinued Touch Bar Simulator

### DIFF
--- a/docs/api/touch-bar.md
+++ b/docs/api/touch-bar.md
@@ -23,11 +23,6 @@ Creates a new touch bar with the specified items. Use
 > The TouchBar API is currently experimental and may change or be
 > removed in future Electron releases.
 
-> [!TIP]
-> If you don't have a MacBook with Touch Bar, you can use
-> [Touch Bar Simulator](https://github.com/sindresorhus/touch-bar-simulator)
-> to test Touch Bar usage in your app.
-
 ### Static Properties
 
 #### `TouchBarButton`


### PR DESCRIPTION
Remove documentation link to discontinued Touch Bar Simulator (https://github.com/sindresorhus/touch-bar-simulator) because it is archived and discontinued:

> Warning: This app is discontinued as it no longer works because of changes in macOS.

Documentation link: https://www.electronjs.org/docs/latest/api/touch-bar

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] I have built and tested this PR
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
