### PR TITLE
build: exit upload with error code if github upload fails

### DIFF
--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -368,6 +368,9 @@ def upload_io_to_github(release, filename, filepath, version):
       for c in iter(lambda: upload_process.stdout.read(1), b""):
         sys.stdout.buffer.write(c)
         sys.stdout.flush()
+    upload_process.wait()
+    if upload_process.returncode != 0:
+      sys.exit(upload_process.returncode)
 
   if "GITHUB_OUTPUT" in os.environ:
     output_path = os.environ["GITHUB_OUTPUT"]


### PR DESCRIPTION
#### Description of Change
It turns out that we were not properly failing release builds when we fail to upload an asset to GitHub.  This PR updates our release logic to fail the build if any assets fail to upload to GitHub.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
