### PR TITLE
build: fix Chromium roll linting merge base determination in CI

### DIFF
--- a/script/lint-roller-chromium-changes.mjs
+++ b/script/lint-roller-chromium-changes.mjs
@@ -124,7 +124,7 @@ async function main () {
   // Get the merge base with the target branch
   let mergeBase;
   try {
-    mergeBase = execSync(`git merge-base ${currentBranch} origin/${targetBranch}`, {
+    mergeBase = execSync(`git merge-base HEAD origin/${targetBranch}`, {
       cwd: ELECTRON_DIR,
       encoding: 'utf8'
     }).trim();


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

In CI git doesn't know the branch name since we check out a SHA rather than the branch by ref name. The `git merge-base` call was unnecessarily using the branch name when it could just use `HEAD`, and as a result failing in CI.

I've validated that this runs as expected in CI by temporarily removing the branch restriction.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
