### PR TITLE
fix: potential `std::stoi` crash in Windows Toasts

### DIFF
--- a/shell/browser/notifications/win/windows_toast_activator.cc
+++ b/shell/browser/notifications/win/windows_toast_activator.cc
@@ -371,7 +371,7 @@ void HandleToastActivation(const std::wstring& invoked_args,
 
   int action_index = -1;
   if (!action_index_str.empty()) {
-    action_index = std::stoi(action_index_str);
+    base::StringToInt(base::WideToUTF8(action_index_str), &action_index);
   }
 
   std::string reply_text;


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/48132

Fixes a bug that could occur if `action_index_str` contains a non-numeric value. In this case `std::stoi` throws `std::invalid_argument` or `std::out_of_range`, which without exception support crashes the process:

```
Received fatal exception 0xe06d7363
KERNELBASE!LoadLibraryExW [0x7ffe63023c28+1ea398]

Electron exited with code 3221226505.
```

Can be reproduced with:

```js
const { Notification, app } = require('electron')

app.whenReady().then(() => {
  const n = new Notification({
    toastXml: `
      <toast launch="type=action&amp;action=NOTANUMBER&amp;tag=12345">
        <visual>
          <binding template="ToastGeneric">
            <text>Crash Test</text>
            <text>Click me to trigger std::stoi crash</text>
          </binding>
        </visual>
        <actions>
          <action content="Bad Button" arguments="type=action&amp;action=NOTANUMBER&amp;tag=12345" activationType="foreground"/>
        </actions>
      </toast>`
  })
  n.show()
})
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where malformed custom `toastXml` could cause a Notification crash.