### PR TITLE
refactor: replace std::to_string() with base::NumberToString()

### DIFF
--- a/shell/browser/api/electron_api_msix_updater.cc
+++ b/shell/browser/api/electron_api_msix_updater.cc
@@ -9,6 +9,7 @@
 #include "base/environment.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
+#include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/single_thread_task_runner.h"
 #include "content/public/browser/browser_task_traits.h"
@@ -279,7 +280,8 @@ void OnDeploymentCompleted(std::unique_ptr<DeploymentCallbackData> data,
         HRESULT error_code;
         hr = async_info->get_ErrorCode(&error_code);
         if (SUCCEEDED(hr)) {
-          error += " (" + std::to_string(static_cast<int>(error_code)) + ")";
+          error +=
+              " (" + base::NumberToString(static_cast<int>(error_code)) + ")";
         }
       }
     }
@@ -798,10 +800,10 @@ v8::Local<v8::Value> GetPackageInfo() {
         ABI::Windows::ApplicationModel::PackageVersion pkg_version;
         hr = package_id->get_Version(&pkg_version);
         if (SUCCEEDED(hr)) {
-          std::string version = std::to_string(pkg_version.Major) + "." +
-                                std::to_string(pkg_version.Minor) + "." +
-                                std::to_string(pkg_version.Build) + "." +
-                                std::to_string(pkg_version.Revision);
+          std::string version = base::NumberToString(pkg_version.Major) + "." +
+                                base::NumberToString(pkg_version.Minor) + "." +
+                                base::NumberToString(pkg_version.Build) + "." +
+                                base::NumberToString(pkg_version.Revision);
           result.Set("version", version);
         }
       }

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -23,6 +23,7 @@
 #include "base/json/json_reader.h"
 #include "base/no_destructor.h"
 #include "base/strings/strcat.h"
+#include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/current_thread.h"
 #include "base/threading/scoped_blocking_call.h"
@@ -2659,7 +2660,7 @@ void WebContents::RestoreHistory(
       thrower.ThrowError(
           "Failed to restore navigation history: Invalid navigation entry at "
           "index " +
-          std::to_string(index) + ".");
+          base::NumberToString(index) + ".");
       return;
     }
 

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -18,6 +18,7 @@
 #include "base/environment.h"
 #include "base/path_service.h"
 #include "base/run_loop.h"
+#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/single_thread_task_runner.h"
@@ -192,7 +193,7 @@ void V8OOMErrorCallback(const char* location, const v8::OOMDetails& details) {
 
 #if !IS_MAS_BUILD()
   electron::crash_keys::SetCrashKey("electron.v8-oom.is_heap_oom",
-                                    std::to_string(details.is_heap_oom));
+                                    base::NumberToString(details.is_heap_oom));
   if (location) {
     electron::crash_keys::SetCrashKey("electron.v8-oom.location", location);
   }


### PR DESCRIPTION
#### Description of Change

Follow upstream practice of using `base::NumberToString()` instead of `std::to_string()`.

https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++-features.md#std_sto_i_l_ul_ll_ull_f_d_ld_to_string_banned

Inspired by https://github.com/electron/electron/pull/49947

(aside: [{fmt}](https://github.com/fmtlib/fmt) is _really_ nice + performant and we should consider using it. [Upstream ticket](https://issues.chromium.org/issues/367401485))

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.