### PR TITLE
fix(styles): add missing dot prefix to .hero-icon.loop-3 CSS selector

### DIFF
--- a/default_app/styles.css
+++ b/default_app/styles.css
@@ -41,7 +41,7 @@ h4 {
   transform-origin: 50% 50%;
 }
 
-hero-icon.loop-3 {
+.hero-icon.loop-3 {
   transform: translate(79px, 21px);
   opacity: 1;
 }


### PR DESCRIPTION
#### Description of Change

Fixed a CSS selector bug in the default app styles. The `.hero-icon.loop-3` selector was missing the leading dot prefix, which caused the rule to not apply to any elements. This fix ensures that animated hero icons are properly styled.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed CSS selector syntax in default app styles to properly apply animations to hero icons.