### PR TITLE
feat: Add WebContents::Clone method

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -2275,6 +2275,20 @@ Returns `Integer` - The Chromium internal `pid` of the associated renderer. Can
 be compared to the `frameProcessId` passed by frame specific navigation events
 (e.g. `did-frame-navigate`)
 
+#### `contents.clone()`
+
+Returns `WebContents` - A cloned WebContents instance. This method creates a copy
+of the WebContents with the following attributes:
+
+* **WebPreferences** - All preferences from the original WebContents are copied
+* **SiteInstance** - Uses the same SiteInstance as the original. This means the cloned WebContents will reuse the same render process as the original when loading same-origin pages, and only spawn a new render process for cross-origin navigations. This process allocation behavior is consistent with window.open and tab duplication in Chromium. For more details, see [Chromium's Site Isolation](https://www.chromium.org/developers/design-documents/site-isolation/) design document.
+* **Opener relationship** - Inherits the opener (window.opener) relationship
+* **Navigation state** - Copies the navigation history and controller state
+
+The cloned WebContents is an independent instance with its own lifecycle that can be destroyed separately and will not contain any open web pages.
+
+This API is useful for use cases where you want to create a new WebContents that shares the same render process with the original for same-origin content, while maintaining full lifecycle independence. Additionally, reusing the existing render process can help optimize memory usage and page load speed to a certain extent, as it eliminates the overhead of spawning and initializing a new render process from scratch.
+
 #### `contents.takeHeapSnapshot(filePath)`
 
 * `filePath` string - Path to the output file.

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2461,6 +2461,33 @@ base::ProcessId WebContents::GetOSProcessID() const {
   return process.IsValid() ? process.Pid() : base::kNullProcessId;
 }
 
+v8::Local<v8::Value> WebContents::Clone(v8::Isolate* isolate) {
+  auto new_contents = web_contents()->Clone();
+  DCHECK(new_contents);
+
+  // Copy WebContentsPreferences from the original WebContents to the cloned one
+  v8::Local<v8::Value> current_prefs = GetLastWebPreferences(isolate);
+  gin_helper::Dictionary pref_dict;
+  gin::ConvertFromV8(isolate, gin::ConvertToV8(isolate, current_prefs),
+                     &pref_dict);
+  new WebContentsPreferences(new_contents.get(), pref_dict);
+
+  // Use CreateAndTake to properly take ownership of the cloned WebContents
+  // and create a new wrapper with the appropriate type
+  auto wrapper = CreateAndTake(isolate, std::move(new_contents), type_);
+
+  // We call HandleNewRenderFrame here as at this point the empty "about:blank"
+  // render frame has already been created. This ensures that preferences like
+  // background color, scheduler throttling, and Mojo connection are properly
+  // set up for the cloned WebContents.
+  auto* frame = wrapper->MainFrame();
+  if (frame) {
+    wrapper->HandleNewRenderFrame(frame);
+  }
+
+  return gin::ConvertToV8(isolate, wrapper);
+}
+
 GURL WebContents::GetURL() const {
   return web_contents()->GetLastCommittedURL();
 }
@@ -4587,6 +4614,7 @@ void WebContents::FillObjectTemplate(v8::Isolate* isolate,
                  &WebContents::SetBackgroundThrottling)
       .SetMethod("getProcessId", &WebContents::GetProcessID)
       .SetMethod("getOSProcessId", &WebContents::GetOSProcessID)
+      .SetMethod("clone", &WebContents::Clone)
       .SetMethod("_loadURL", &WebContents::LoadURL)
       .SetMethod("reload", &WebContents::Reload)
       .SetMethod("reloadIgnoringCache", &WebContents::ReloadIgnoringCache)

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -197,6 +197,7 @@ class WebContents final : public ExclusiveAccessContext,
   int32_t GetProcessID() const;
   base::ProcessId GetOSProcessID() const;
   [[nodiscard]] Type type() const { return type_; }
+  v8::Local<v8::Value> Clone(v8::Isolate* isolate);
   void LoadURL(const GURL& url, const gin_helper::Dictionary& options);
   void Reload();
   void ReloadIgnoringCache();

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -1717,6 +1717,155 @@ describe('webContents module', () => {
     });
   });
 
+  describe('clone()', () => {
+    afterEach(closeAllWindows);
+    afterEach(() => {
+      webContents.getAllWebContents().forEach((wc) => {
+        wc.destroy();
+      });
+    });
+
+    it('web-contents-created event will be emitted for cloned WebContents', async () => {
+      const w = new BrowserWindow({
+        show: false
+      });
+
+      const webContentsCreated = once(app, 'web-contents-created') as Promise<[any, WebContents]>;
+      const clonedContents = w.webContents.clone();
+      const [, createdContents] = await webContentsCreated;
+
+      expect(clonedContents).to.equal(createdContents);
+      expect(createdContents).to.not.equal(w.webContents);
+    });
+
+    it('clones a WebContents instance', async () => {
+      const w = new BrowserWindow({
+        show: false
+      });
+      const clonedContents = w.webContents.clone();
+      expect(clonedContents).to.not.be.undefined();
+      expect(clonedContents).to.not.equal(w.webContents);
+      await clonedContents.loadURL('about:blank');
+      expect(clonedContents.getOSProcessId()).to.be.a('number').and.be.above(0);
+    });
+
+    it('cloned and original WebContents have different process IDs when loading same URL', async () => {
+      const w = new BrowserWindow({
+        show: false
+      });
+      const clonedContents = w.webContents.clone();
+      expect(clonedContents).to.not.be.undefined();
+
+      // Load the same URL in both original and cloned WebContents
+      await w.webContents.loadURL('https://docs.qq.com');
+      await clonedContents.loadURL('https://docs.qq.com');
+
+      // They should have different process IDs since they are separate processes
+      const originalPID = w.webContents.getOSProcessId();
+      const clonedPID = clonedContents.getOSProcessId();
+
+      expect(originalPID).to.be.above(0);
+      expect(clonedPID).to.be.above(0);
+      expect(originalPID).to.equal(clonedPID);
+
+      // Create a new BrowserWindow with same URL
+      const w2 = new BrowserWindow({
+        show: false
+      });
+      await w2.webContents.loadURL('https://docs.qq.com');
+      const newWindowPID = w2.webContents.getOSProcessId();
+
+      // New window should also have a different process ID
+      expect(newWindowPID).to.be.above(0);
+      expect(newWindowPID).to.not.equal(originalPID);
+    });
+
+    it('node integration and ipc message work in both original and cloned WebContents', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          sandbox: false,
+          nodeIntegration: true,
+          contextIsolation: false
+        }
+      });
+
+      // Load a simple page
+      await w.loadFile(path.join(fixturesPath, 'pages', 'base-page.html'));
+
+      // Keep track of messages received
+      let message = '';
+      const onOriginalMessage = (_event: any, msg: string) => {
+        message = msg;
+      };
+      const onClonedMessage = (_event: any, msg: string) => {
+        message = msg;
+      };
+
+      ipcMain.once('test-node-integration-original', onOriginalMessage);
+
+      // Test original WebContents can use require('electron') and send ipc
+      await w.webContents.executeJavaScript(`
+        const { ipcRenderer } = require('electron');
+        ipcRenderer.send('test-node-integration-original', 'message from original');
+      `);
+
+      // Wait for message to be processed
+      await setTimeout(100);
+      expect(message).to.equal('message from original');
+      const clonedContents = w.webContents.clone();
+      expect(clonedContents).to.not.be.undefined();
+
+      await clonedContents.loadFile(path.join(fixturesPath, 'pages', 'base-page.html'));
+
+      ipcMain.once('test-node-integration-cloned', onClonedMessage);
+
+      // Test cloned WebContents can use require('electron') and send ipc
+      await clonedContents.executeJavaScript(`
+        const { ipcRenderer } = require('electron');
+        ipcRenderer.send('test-node-integration-cloned', 'message from cloned');
+      `);
+
+      // Wait for message to be processed
+      await setTimeout(100);
+      expect(message).to.equal('message from cloned');
+    });
+
+    it('cloned WebContents has independent lifecycle from original', async () => {
+      const w = new BrowserWindow({
+        show: false
+      });
+
+      // Load URL to ensure WebContents is initialized
+      await w.loadURL('about:blank');
+
+      // Clone the WebContents
+      const clonedContents = w.webContents.clone();
+      expect(clonedContents).to.not.be.undefined();
+
+      await clonedContents.loadURL('about:blank');
+
+      // Both should not be destroyed initially
+      expect(w.webContents.isDestroyed()).to.be.false();
+      expect(clonedContents.isDestroyed()).to.be.false();
+
+      const origWebContents = w.webContents;
+
+      // Destroy the original WebContents
+      w.webContents.destroy();
+
+      await setTimeout();
+
+      // Original should be destroyed, but cloned should still be alive
+      expect(origWebContents.isDestroyed()).to.be.true();
+      expect(clonedContents.isDestroyed()).to.be.false();
+
+      // Cloned WebContents should still be usable
+      const url = clonedContents.getURL();
+      expect(url).to.equal('about:blank');
+    });
+  });
+
   describe('getMediaSourceId()', () => {
     afterEach(closeAllWindows);
     it('returns a valid stream id', () => {


### PR DESCRIPTION
#### Description of Change

Added a `clone` method to `WebContents`. Our goal is to enable different `WebContents` instances that load pages from the same domain to share the renderer process, similar to the behavior of `window.open`. In `window.open`, the new `WebContents` reuses the opener's `SiteInstance`, allowing renderer process reuse. However, Electron's current `webContents.create` method always creates a new `SiteInstance`, resulting in a new renderer process each time.

I discovered a workaround by introducing a clone method to WebContents that creates a new instance inheriting many properties—including SiteInstance and navigation history—but not the FrameTree. The FrameTree will be loaded based on the latest navigation information when the WebContents becomes visible. This new WebContents closely matches the one created via window.open, and navigating to same-origin sites shares the same renderer process.

Example API usage:
```javascript
const webContents1 = electron.webContents.create({
  type: 'window',
  sandbox: false,
  nodeIntegration: true,
  contextIsolation: false,
});

webContents1.loadURL('https://www.qq.com');

// If you want to reuse the renderer process to open a same-origin website.
const webContents2 = webContents1.clone();
webContents2.loadURL('https://docs.qq.com');

// If you don't want to reuse the renderer process.
const webContents3 = electron.webContents.create({});
webContents3.loadURL('https://www.qq.com');

const wrapWebContentsView = (webContents) => {
  return new electron.WebContentsView({
    webContents: webContents,
    webPreferences: webContents.getLastWebPreferences(),
  });
}
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->Added Clone method to WebContents.
