### PR TITLE
feat: Expose zoom mode API for per-webContents zoom control

### DIFF
--- a/docs/api/structures/web-preferences.md
+++ b/docs/api/structures/web-preferences.md
@@ -37,6 +37,9 @@
   the same session. Default is the default session.
 * `zoomFactor` number (optional) - The default zoom factor of the page, `3.0` represents
   `300%`. Default is `1.0`.
+* `zoomMode` string (optional) - The initial zoom mode for the page. See
+  [`contents.setZoomMode`](../web-contents.md#contentssetzoommodemode) for available
+  modes. Default is `'default'`.
 * `javascript` boolean (optional) - Enables JavaScript support. Default is `true`.
 * `webSecurity` boolean (optional) - When `false`, it will disable the
   same-origin policy (usually using testing websites by people), and set

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1565,7 +1565,7 @@ Returns `number` - the current zoom level.
 <!--
 ```YAML history
 added:
-  - pr-url: https://github.com/electron/electron/pull/XXXXX
+  - pr-url: https://github.com/electron/electron/pull/49962
 ```
 -->
 
@@ -1590,7 +1590,7 @@ The `isolated` and `manual` zoom modes persist across navigations.
 <!--
 ```YAML history
 added:
-  - pr-url: https://github.com/electron/electron/pull/XXXXX
+  - pr-url: https://github.com/electron/electron/pull/49962
 ```
 -->
 
@@ -2448,7 +2448,7 @@ The zoom factor is the zoom percent divided by 100, so 300% = 3.0.
 <!--
 ```YAML history
 added:
-  - pr-url: https://github.com/electron/electron/pull/XXXXX
+  - pr-url: https://github.com/electron/electron/pull/49962
 ```
 -->
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1553,7 +1553,7 @@ limits of 300% and 50% of original size, respectively. The formula for this is
 > [!NOTE]
 > The zoom policy at the Chromium level is same-origin by default, meaning that
 > the zoom level for a specific domain propagates across all instances of windows
-> with the same domain. To use per-tab zoom instead, set the zoom mode to
+> with the same domain. To use per-webContents zoom instead, set the zoom mode to
 > `'isolated'` via [`contents.setZoomMode('isolated')`](#contentssetzoommodemode).
 
 #### `contents.getZoomLevel()`
@@ -1574,13 +1574,13 @@ added:
 Sets the zoom mode for this web contents.
 
 * `default` - Zoom changes are handled automatically on a per-origin basis.
-  Other tabs navigated to the same origin will share the same zoom level.
-* `isolated` - Zoom changes are handled automatically but on a per-tab basis.
-  This tab will not be affected by zoom changes in other tabs, and vice versa.
+  Other webContents navigated to the same origin will share the same zoom level.
+* `isolated` - Zoom changes are handled automatically but on a per-webContents basis.
+  This webContents will not be affected by zoom changes in other webContents, and vice versa.
 * `manual` - Automatic zoom handling is disabled. The `zoom-changed` event
   will still be dispatched, but the page will not actually be zoomed.
   The zoom level can be managed manually by the application.
-* `disabled` - All zooming in this tab is disabled. The tab will revert
+* `disabled` - All zooming in this webContents is disabled. The webContents will revert
   to the default zoom level and all zoom changes will be ignored.
 
 The `isolated` and `manual` zoom modes persist across navigations.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1551,13 +1551,51 @@ limits of 300% and 50% of original size, respectively. The formula for this is
 `scale := 1.2 ^ level`.
 
 > [!NOTE]
-> The zoom policy at the Chromium level is same-origin, meaning that the
-> zoom level for a specific domain propagates across all instances of windows with
-> the same domain. Differentiating the window URLs will make zoom work per-window.
+> The zoom policy at the Chromium level is same-origin by default, meaning that
+> the zoom level for a specific domain propagates across all instances of windows
+> with the same domain. To use per-tab zoom instead, set the zoom mode to
+> `'isolated'` via [`contents.setZoomMode('isolated')`](#contentssetzoommodemode).
 
 #### `contents.getZoomLevel()`
 
 Returns `number` - the current zoom level.
+
+#### `contents.setZoomMode(mode)`
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/XXXXX
+```
+-->
+
+* `mode` string - Can be `default`, `isolated`, `manual`, or `disabled`.
+
+Sets the zoom mode for this web contents.
+
+* `default` - Zoom changes are handled automatically on a per-origin basis.
+  Other tabs navigated to the same origin will share the same zoom level.
+* `isolated` - Zoom changes are handled automatically but on a per-tab basis.
+  This tab will not be affected by zoom changes in other tabs, and vice versa.
+* `manual` - Automatic zoom handling is disabled. The `zoom-changed` event
+  will still be dispatched, but the page will not actually be zoomed.
+  The zoom level can be managed manually by the application.
+* `disabled` - All zooming in this tab is disabled. The tab will revert
+  to the default zoom level and all zoom changes will be ignored.
+
+The `isolated` and `manual` zoom modes persist across navigations.
+
+#### `contents.getZoomMode()`
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/XXXXX
+```
+-->
+
+Returns `string` - The current zoom mode. Can be `default`, `isolated`,
+`manual`, or `disabled`.
 
 #### `contents.setVisualZoomLevelLimits(minimumLevel, maximumLevel)`
 
@@ -2404,6 +2442,20 @@ The original size is 0 and each increment above or below represents zooming 20% 
 A `number` property that determines the zoom factor for this web contents.
 
 The zoom factor is the zoom percent divided by 100, so 300% = 3.0.
+
+#### `contents.zoomMode`
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/XXXXX
+```
+-->
+
+A `string` property that determines the zoom mode for this web contents.
+
+See [`contents.setZoomMode`](#contentssetzoommodemode) for a description of the
+available modes.
 
 #### `contents.frameRate`
 

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -968,6 +968,11 @@ WebContents.prototype._init = function () {
     set: (factor) => this.setZoomFactor(factor)
   });
 
+  Object.defineProperty(this, 'zoomMode', {
+    get: () => this.getZoomMode(),
+    set: (mode) => this.setZoomMode(mode)
+  });
+
   Object.defineProperty(this, 'frameRate', {
     get: () => this.getFrameRate(),
     set: (rate) => this.setFrameRate(rate)

--- a/lib/common/web-view-methods.ts
+++ b/lib/common/web-view-methods.ts
@@ -53,12 +53,14 @@ export const syncMethods = new Set([
   'showDefinitionForSelection',
   'getZoomFactor',
   'getZoomLevel',
+  'getZoomMode',
   'setZoomFactor',
   'setZoomLevel',
+  'setZoomMode',
   ...navigationHistorySyncMethods
 ]);
 
-export const properties = new Set(['audioMuted', 'userAgent', 'zoomLevel', 'zoomFactor', 'frameRate']);
+export const properties = new Set(['audioMuted', 'userAgent', 'zoomLevel', 'zoomFactor', 'zoomMode', 'frameRate']);
 
 export const asyncMethods = new Set([
   'capturePage',

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1007,9 +1007,8 @@ void WebContents::InitZoomController(content::WebContents* web_contents,
     // The mode will take full effect once the first navigation commits.
     auto mode = ParseZoomMode(zoom_mode_str);
     if (mode) {
-      bool persist =
-          *mode == WebContentsZoomController::ZOOM_MODE_ISOLATED ||
-          *mode == WebContentsZoomController::ZOOM_MODE_MANUAL;
+      bool persist = *mode == WebContentsZoomController::ZOOM_MODE_ISOLATED ||
+                     *mode == WebContentsZoomController::ZOOM_MODE_MANUAL;
       zoom_controller->SetPersistZoomMode(persist);
       zoom_controller->set_zoom_mode(*mode);
       // When persisting zoom mode AND a custom zoom factor is set, initialize

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -975,14 +975,52 @@ WebContents::WebContents(v8::Isolate* isolate,
                             options);
 }
 
+namespace {
+std::optional<WebContentsZoomController::ZoomMode> ParseZoomMode(
+    const std::string& mode) {
+  if (mode == "default")
+    return WebContentsZoomController::ZOOM_MODE_DEFAULT;
+  if (mode == "isolated")
+    return WebContentsZoomController::ZOOM_MODE_ISOLATED;
+  if (mode == "manual")
+    return WebContentsZoomController::ZOOM_MODE_MANUAL;
+  if (mode == "disabled")
+    return WebContentsZoomController::ZOOM_MODE_DISABLED;
+  return std::nullopt;
+}
+}  // namespace
+
 void WebContents::InitZoomController(content::WebContents* web_contents,
                                      const gin_helper::Dictionary& options) {
   WebContentsZoomController* const zoom_controller =
       WebContentsZoomController::GetOrCreateForWebContents(web_contents);
 
-  double zoom_factor;
+  double zoom_factor = 0;
   if (options.Get(options::kZoomFactor, &zoom_factor))
     zoom_controller->SetDefaultZoomFactor(zoom_factor);
+
+  std::string zoom_mode_str;
+  if (options.Get(options::kZoomMode, &zoom_mode_str)) {
+    // Set mode and persist flag directly on the controller rather than going
+    // through SetZoomMode(), which manipulates HostZoomMap temporary zoom
+    // levels and requires a fully initialized RenderFrameHost.
+    // The mode will take full effect once the first navigation commits.
+    auto mode = ParseZoomMode(zoom_mode_str);
+    if (mode) {
+      bool persist =
+          *mode == WebContentsZoomController::ZOOM_MODE_ISOLATED ||
+          *mode == WebContentsZoomController::ZOOM_MODE_MANUAL;
+      zoom_controller->SetPersistZoomMode(persist);
+      zoom_controller->set_zoom_mode(*mode);
+      // When persisting zoom mode AND a custom zoom factor is set, initialize
+      // the tracked zoom level from the factor. Otherwise the first navigation
+      // would apply zoom_level_=0 (default) instead of the factor, because
+      // SetZoomFactorOnNavigationIfNeeded is skipped in persist mode.
+      if (persist && zoom_factor > 0)
+        zoom_controller->set_zoom_level(
+            blink::ZoomFactorToZoomLevel(zoom_factor));
+    }
+  }
 
   // Nothing to do with ZoomController, but this function gets called in all
   // init cases!
@@ -2266,6 +2304,9 @@ void WebContents::DidFinishNavigation(
       Emit("did-frame-navigate", url, http_response_code, http_status_text,
            is_main_frame, frame_process_id, frame_routing_id);
       if (is_main_frame) {
+        // Ensure zoom is updated before JS handlers see the event.
+        if (auto* zc = GetZoomController())
+          zc->ProcessNavigationZoom(navigation_handle);
         Emit("did-navigate", url, http_response_code, http_status_text);
       }
 
@@ -3972,6 +4013,37 @@ double WebContents::GetZoomFactor() const {
   return blink::ZoomLevelToZoomFactor(level);
 }
 
+void WebContents::SetZoomMode(gin_helper::ErrorThrower thrower,
+                              const std::string& mode) {
+  auto zoom_mode = ParseZoomMode(mode);
+  if (!zoom_mode) {
+    thrower.ThrowError(
+        "'zoomMode' must be 'default', 'isolated', 'manual', or 'disabled'");
+    return;
+  }
+
+  // When set via the Electron JS API, persist isolated/manual modes across
+  // navigations. The extensions API calls SetZoomMode on the controller
+  // directly and won't set this flag, preserving Chromium's default behavior.
+  GetZoomController()->SetPersistZoomMode(
+      *zoom_mode == WebContentsZoomController::ZOOM_MODE_ISOLATED ||
+      *zoom_mode == WebContentsZoomController::ZOOM_MODE_MANUAL);
+  GetZoomController()->SetZoomMode(*zoom_mode);
+}
+
+std::string WebContents::GetZoomMode() const {
+  switch (GetZoomController()->zoom_mode()) {
+    case WebContentsZoomController::ZOOM_MODE_ISOLATED:
+      return "isolated";
+    case WebContentsZoomController::ZOOM_MODE_MANUAL:
+      return "manual";
+    case WebContentsZoomController::ZOOM_MODE_DISABLED:
+      return "disabled";
+    default:
+      return "default";
+  }
+}
+
 void WebContents::SetTemporaryZoomLevel(double level) {
   GetZoomController()->SetTemporaryZoomLevel(level);
 }
@@ -4753,6 +4825,8 @@ void WebContents::FillObjectTemplate(v8::Isolate* isolate,
       .SetMethod("getZoomLevel", &WebContents::GetZoomLevel)
       .SetMethod("setZoomFactor", &WebContents::SetZoomFactor)
       .SetMethod("getZoomFactor", &WebContents::GetZoomFactor)
+      .SetMethod("setZoomMode", &WebContents::SetZoomMode)
+      .SetMethod("getZoomMode", &WebContents::GetZoomMode)
       .SetMethod("getType", &WebContents::type)
       .SetMethod("_getPreloadScript", &WebContents::GetPreloadScript)
       .SetMethod("getLastWebPreferences", &WebContents::GetLastWebPreferences)
@@ -4899,6 +4973,21 @@ gin_helper::Handle<WebContents> WebContents::CreateFromWebPreferences(
           // has already navigated by the time we wrap the webContents.
           zoom_controller->SetZoomLevel(
               blink::ZoomFactorToZoomLevel(zoom_factor));
+        }
+      }
+
+      std::string zoom_mode_str;
+      if (web_preferences.Get(options::kZoomMode, &zoom_mode_str)) {
+        auto mode = ParseZoomMode(zoom_mode_str);
+        if (mode) {
+          auto* zoom_controller = WebContentsZoomController::FromWebContents(
+              web_contents->web_contents());
+          if (zoom_controller) {
+            zoom_controller->SetPersistZoomMode(
+                *mode == WebContentsZoomController::ZOOM_MODE_ISOLATED ||
+                *mode == WebContentsZoomController::ZOOM_MODE_MANUAL);
+            zoom_controller->SetZoomMode(*mode);
+          }
         }
       }
     }

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -336,6 +336,8 @@ class WebContents final : public ExclusiveAccessContext,
   double GetZoomLevel() const;
   void SetZoomFactor(gin_helper::ErrorThrower thrower, double factor);
   double GetZoomFactor() const;
+  void SetZoomMode(gin_helper::ErrorThrower thrower, const std::string& mode);
+  std::string GetZoomMode() const;
 
   // Callback triggered on permission response.
   void OnEnterFullscreenModeForTab(

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -138,6 +138,9 @@ inline constexpr std::string_view kOverlayHeight = "height";
 // The factor of which page should be zoomed.
 inline constexpr std::string_view kZoomFactor = "zoomFactor";
 
+// The zoom mode for the web contents.
+inline constexpr std::string_view kZoomMode = "zoomMode";
+
 // Script that will be loaded by guest WebContents before other scripts.
 inline constexpr std::string_view kPreloadScript = "preload";
 

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2394,6 +2394,510 @@ describe('webContents module', () => {
     });
   });
 
+  describe('zoom mode', () => {
+    afterEach(closeAllWindows);
+
+    it('defaults to "default" zoom mode', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+      expect(w.webContents.getZoomMode()).to.equal('default');
+    });
+
+    it('can get and set zoom mode via functions', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+
+      w.webContents.setZoomMode('isolated');
+      expect(w.webContents.getZoomMode()).to.equal('isolated');
+
+      w.webContents.setZoomMode('manual');
+      expect(w.webContents.getZoomMode()).to.equal('manual');
+
+      w.webContents.setZoomMode('disabled');
+      expect(w.webContents.getZoomMode()).to.equal('disabled');
+
+      w.webContents.setZoomMode('default');
+      expect(w.webContents.getZoomMode()).to.equal('default');
+    });
+
+    it('can get and set zoom mode via property', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+
+      w.webContents.zoomMode = 'isolated';
+      expect(w.webContents.zoomMode).to.equal('isolated');
+
+      w.webContents.zoomMode = 'default';
+      expect(w.webContents.zoomMode).to.equal('default');
+    });
+
+    it('throws on invalid zoom mode', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+
+      expect(() => {
+        w.webContents.setZoomMode('invalid' as any);
+      }).to.throw();
+    });
+
+    it('isolated mode prevents zoom propagation across same-origin tabs', async () => {
+      const w = new BrowserWindow({ show: false });
+      const w2 = new BrowserWindow({ show: false });
+
+      defer(() => {
+        w2.setClosable(true);
+        w2.close();
+      });
+
+      await w.loadURL('about:blank');
+      await w2.loadURL('about:blank');
+
+      w.webContents.setZoomMode('isolated');
+      w.webContents.setZoomLevel(2.0);
+
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+      expect(w2.webContents.getZoomLevel()).to.not.equal(2.0);
+    });
+
+    it('disabled mode prevents zoom level changes', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+
+      w.webContents.setZoomMode('disabled');
+      const beforeLevel = w.webContents.getZoomLevel();
+      w.webContents.setZoomLevel(2.0);
+      expect(w.webContents.getZoomLevel()).to.equal(beforeLevel);
+    });
+
+    it('persists isolated mode across cross-document navigation', async () => {
+      const server = http.createServer((req, res) => {
+        res.end('hello');
+      });
+      const { url: serverUrl } = await listen(server);
+      defer(() => server.close());
+
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL(serverUrl);
+
+      w.webContents.setZoomMode('isolated');
+      w.webContents.setZoomLevel(2.0);
+      expect(w.webContents.getZoomMode()).to.equal('isolated');
+
+      const crossSiteUrl = serverUrl.replace('127.0.0.1', 'localhost');
+      await w.loadURL(crossSiteUrl);
+      expect(w.webContents.getZoomMode()).to.equal('isolated');
+    });
+
+    it('resets isolated mode when switched back to default', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+
+      w.webContents.setZoomMode('isolated');
+      expect(w.webContents.getZoomMode()).to.equal('isolated');
+
+      w.webContents.setZoomMode('default');
+      expect(w.webContents.getZoomMode()).to.equal('default');
+    });
+
+    it('manual mode tracks zoom level without zooming the page', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+
+      w.webContents.setZoomMode('manual');
+      w.webContents.setZoomLevel(2.0);
+
+      // Controller reports the manually tracked level
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+    });
+
+    it('preserves zoom level after navigation in isolated mode', async () => {
+      const server = http.createServer((req, res) => {
+        res.end('hello');
+      });
+      const { url: serverUrl } = await listen(server);
+      defer(() => server.close());
+
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL(serverUrl);
+
+      w.webContents.setZoomMode('isolated');
+      w.webContents.setZoomLevel(2.0);
+
+      const crossSiteUrl = serverUrl.replace('127.0.0.1', 'localhost');
+      await w.loadURL(crossSiteUrl);
+
+      expect(w.webContents.getZoomMode()).to.equal('isolated');
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+    });
+
+    it('transitions from disabled to isolated mode correctly', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+
+      // Start in disabled mode — zoom changes should be ignored
+      w.webContents.setZoomMode('disabled');
+      w.webContents.setZoomLevel(3.0);
+      expect(w.webContents.getZoomLevel()).to.equal(0);
+
+      // Transition to isolated mode (special code path: doesn't call
+      // SetTemporaryZoomLevel, manually fires observer event instead)
+      w.webContents.setZoomMode('isolated');
+      expect(w.webContents.getZoomMode()).to.equal('isolated');
+
+      // Zoom should now work in isolated mode
+      w.webContents.setZoomLevel(2.0);
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+    });
+
+    it('isolated zoom does not leak to same-origin tabs after navigation', async () => {
+      const server = http.createServer((req, res) => {
+        res.end('hello');
+      });
+      const { url: serverUrl } = await listen(server);
+      defer(() => server.close());
+
+      const w = new BrowserWindow({ show: false });
+      const w2 = new BrowserWindow({ show: false });
+      defer(() => {
+        w2.setClosable(true);
+        w2.close();
+      });
+
+      // w2 loads the target origin first — reset any stale per-host zoom
+      await w2.loadURL(serverUrl);
+      w2.webContents.setZoomLevel(0);
+
+      // w starts on a different origin, sets isolated zoom
+      const crossSiteUrl = serverUrl.replace('127.0.0.1', 'localhost');
+      await w.loadURL(crossSiteUrl);
+      w.webContents.setZoomMode('isolated');
+      w.webContents.setZoomLevel(2.0);
+
+      // w navigates to the same origin as w2
+      await w.loadURL(serverUrl);
+
+      // w2 should remain unaffected
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+      expect(w2.webContents.getZoomLevel()).to.equal(0);
+    });
+
+    it('can set zoom mode via webPreferences', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          zoomMode: 'isolated'
+        }
+      });
+      await w.loadURL('about:blank');
+      expect(w.webContents.getZoomMode()).to.equal('isolated');
+    });
+
+    it('webPreferences zoomMode isolated prevents cross-tab zoom', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          zoomMode: 'isolated'
+        }
+      });
+      const w2 = new BrowserWindow({ show: false });
+      defer(() => {
+        w2.setClosable(true);
+        w2.close();
+      });
+
+      await w.loadURL('about:blank');
+      await w2.loadURL('about:blank');
+
+      w.webContents.setZoomLevel(2.0);
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+      expect(w2.webContents.getZoomLevel()).to.not.equal(2.0);
+    });
+
+    it('webPreferences zoomMode disabled prevents zoom changes', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          zoomMode: 'disabled'
+        }
+      });
+      await w.loadURL('about:blank');
+
+      expect(w.webContents.getZoomMode()).to.equal('disabled');
+      w.webContents.setZoomLevel(2.0);
+      expect(w.webContents.getZoomLevel()).to.equal(0);
+    });
+
+    it('default mode shares zoom across same-origin tabs', async () => {
+      const w = new BrowserWindow({ show: false });
+      const w2 = new BrowserWindow({ show: false });
+      defer(() => {
+        w2.setClosable(true);
+        w2.close();
+      });
+
+      await w.loadURL('about:blank');
+      await w2.loadURL('about:blank');
+
+      try {
+        // Both in default mode — zoom should propagate per-domain
+        w.webContents.setZoomLevel(2.0);
+        expect(w2.webContents.getZoomLevel()).to.equal(2.0);
+      } finally {
+        // Reset per-host zoom in HostZoomMap to avoid leaking to other tests
+        w.webContents.setZoomLevel(0);
+      }
+    });
+
+    it('switching from isolated to default re-joins per-domain zoom', async () => {
+      const server = http.createServer((req, res) => {
+        res.end('hello');
+      });
+      const { url: serverUrl } = await listen(server);
+      defer(() => server.close());
+
+      const w = new BrowserWindow({ show: false });
+      const w2 = new BrowserWindow({ show: false });
+      defer(() => {
+        w2.setClosable(true);
+        w2.close();
+      });
+
+      await w.loadURL(serverUrl);
+      await w2.loadURL(serverUrl);
+      // Reset any stale per-host zoom from previous tests
+      w.webContents.setZoomLevel(0);
+
+      try {
+        // Isolated: w's zoom should NOT affect w2
+        w.webContents.setZoomMode('isolated');
+        w.webContents.setZoomLevel(2.0);
+        expect(w2.webContents.getZoomLevel()).to.equal(0);
+
+        // Switch back to default: w's zoom should now affect w2
+        w.webContents.setZoomMode('default');
+        w.webContents.setZoomLevel(3.0);
+        expect(w2.webContents.getZoomLevel()).to.equal(3.0);
+      } finally {
+        // Reset per-host zoom in HostZoomMap to avoid leaking to other tests
+        w.webContents.setZoomLevel(0);
+      }
+    });
+
+    it('webPreferences zoomMode isolated persists across navigation', async () => {
+      const server = http.createServer((req, res) => {
+        res.end('hello');
+      });
+      const { url: serverUrl } = await listen(server);
+      defer(() => server.close());
+
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          zoomMode: 'isolated'
+        }
+      });
+      await w.loadURL(serverUrl);
+      w.webContents.setZoomLevel(2.0);
+
+      const crossSiteUrl = serverUrl.replace('127.0.0.1', 'localhost');
+      await w.loadURL(crossSiteUrl);
+
+      expect(w.webContents.getZoomMode()).to.equal('isolated');
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+    });
+
+    it('preserves zoomMode and zoomLevel after reload', async () => {
+      const server = http.createServer((req, res) => {
+        res.end('hello');
+      });
+      const { url: serverUrl } = await listen(server);
+      defer(() => server.close());
+
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL(serverUrl);
+
+      w.webContents.setZoomMode('isolated');
+      w.webContents.setZoomLevel(2.0);
+
+      // Reload the page
+      const reloadPromise = once(w.webContents, 'did-finish-load');
+      w.webContents.reload();
+      await reloadPromise;
+
+      expect(w.webContents.getZoomMode()).to.equal('isolated');
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+    });
+
+    it('isolated mode with webPreferences.zoomFactor preserves zoom after navigation', async () => {
+      const server = http.createServer((req, res) => {
+        res.end('hello');
+      });
+      const { url: serverUrl } = await listen(server);
+      defer(() => server.close());
+
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          zoomMode: 'isolated',
+          zoomFactor: 1.5
+        }
+      });
+      await w.loadURL(serverUrl);
+      w.webContents.setZoomLevel(2.0);
+
+      // Navigate cross-site — the zoomFactor must NOT override our isolated zoom
+      const crossSiteUrl = serverUrl.replace('127.0.0.1', 'localhost');
+      await w.loadURL(crossSiteUrl);
+
+      expect(w.webContents.getZoomMode()).to.equal('isolated');
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+    });
+
+    it('preserves zoomMode and zoomLevel after same-origin navigation', async () => {
+      const server = http.createServer((req, res) => {
+        res.end('hello');
+      });
+      const { url: serverUrl } = await listen(server);
+      defer(() => server.close());
+
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL(serverUrl);
+
+      w.webContents.setZoomMode('isolated');
+      w.webContents.setZoomLevel(2.0);
+
+      // Navigate to a different path on the same origin
+      await w.loadURL(serverUrl + '/other-page');
+
+      expect(w.webContents.getZoomMode()).to.equal('isolated');
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+    });
+
+    it('webPreferences zoomFactor is applied as initial zoom in isolated mode', async () => {
+      const server = http.createServer((req, res) => {
+        res.end('hello');
+      });
+      const { url: serverUrl } = await listen(server);
+      defer(() => server.close());
+
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          zoomMode: 'isolated',
+          zoomFactor: 1.5
+        }
+      });
+      await w.loadURL(serverUrl);
+
+      // The zoomFactor should be applied as the initial zoom level
+      expect(w.webContents.getZoomMode()).to.equal('isolated');
+      const zoomFactor = w.webContents.getZoomFactor();
+      expect(zoomFactor).to.be.closeTo(1.5, 0.05);
+    });
+
+    it('rapid mode switching does not crash', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+
+      // Rapidly switch between all modes
+      w.webContents.setZoomMode('isolated');
+      w.webContents.setZoomMode('manual');
+      w.webContents.setZoomMode('disabled');
+      w.webContents.setZoomMode('default');
+      w.webContents.setZoomMode('isolated');
+      w.webContents.setZoomMode('default');
+
+      expect(w.webContents.getZoomMode()).to.equal('default');
+    });
+
+    it('mode transitions preserve expected zoom behavior', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+
+      // disabled -> isolated -> manual -> default
+      w.webContents.setZoomMode('disabled');
+      w.webContents.setZoomLevel(3.0);
+      expect(w.webContents.getZoomLevel()).to.equal(0); // disabled ignores zoom
+
+      w.webContents.setZoomMode('isolated');
+      w.webContents.setZoomLevel(2.0);
+      expect(w.webContents.getZoomLevel()).to.equal(2.0); // isolated works
+
+      w.webContents.setZoomMode('manual');
+      w.webContents.setZoomLevel(1.5);
+      expect(w.webContents.getZoomLevel()).to.equal(1.5); // manual tracks level
+
+      w.webContents.setZoomMode('default');
+      // After switching to default, zoom should be at the per-domain level
+      expect(w.webContents.getZoomMode()).to.equal('default');
+      // Reset per-host zoom in HostZoomMap to avoid leaking to other tests
+      w.webContents.setZoomLevel(0);
+    });
+
+    it('isolated mode does not share zoom across different sessions', async () => {
+      const w = new BrowserWindow({ show: false });
+      const w2 = new BrowserWindow({
+        show: false,
+        webPreferences: { partition: 'zoom-test-partition' }
+      });
+      defer(() => {
+        w2.setClosable(true);
+        w2.close();
+      });
+
+      await w.loadURL('about:blank');
+      await w2.loadURL('about:blank');
+
+      w.webContents.setZoomMode('isolated');
+      w.webContents.setZoomLevel(2.0);
+
+      // Different session — should never share zoom regardless of mode
+      expect(w2.webContents.getZoomLevel()).to.equal(0);
+    });
+
+    it('setZoomLevel and setZoomFactor are consistent in isolated mode', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+
+      w.webContents.setZoomMode('isolated');
+
+      // Set via setZoomFactor, read via getZoomLevel
+      w.webContents.setZoomFactor(1.5);
+      const levelFromFactor = w.webContents.getZoomLevel();
+      expect(levelFromFactor).to.not.equal(0);
+
+      // Set via setZoomLevel, read via getZoomFactor
+      w.webContents.setZoomLevel(0);
+      const factorFromLevel = w.webContents.getZoomFactor();
+      expect(factorFromLevel).to.be.closeTo(1.0, 0.05);
+    });
+
+    it('isolated mode works correctly after error page navigation', async () => {
+      const server = http.createServer((req, res) => {
+        res.end('hello');
+      });
+      const { url: serverUrl } = await listen(server);
+      defer(() => server.close());
+
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL(serverUrl);
+
+      w.webContents.setZoomMode('isolated');
+      w.webContents.setZoomLevel(2.0);
+
+      // Navigate to an error page
+      await w.loadURL('http://localhost:1/nonexistent').catch(() => {});
+
+      // Mode should still be isolated
+      expect(w.webContents.getZoomMode()).to.equal('isolated');
+
+      // Navigate back to a valid page
+      await w.loadURL(serverUrl);
+      expect(w.webContents.getZoomMode()).to.equal('isolated');
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+    });
+  });
+
   describe('webrtc ip policy api', () => {
     afterEach(closeAllWindows);
     it('can set and get webrtc ip policies', () => {


### PR DESCRIPTION
Add `contents.setZoomMode(mode)` and `contents.getZoomMode()` APIs to allow controlling zoom behavior on a per-webContents basis. Supported modes: `default`, `isolated`, `manual`, `disabled`.

The `isolated` and `manual` modes persist across navigations when set via the Electron JS API, while preserving Chromium's default reset-on-navigation behavior for the extensions API path.

Allow setting the zoom mode at window creation time via `webPreferences`, similar to the existing `zoomFactor` option.

### Description of Change

Exposes Chromium's per-webContents zoom mode to Electron's JavaScript API via `webContents.setZoomMode(mode)`, `webContents.getZoomMode()`, and the `webContents.zoomMode` property.

**Zoom modes:**

- **`default`** — zoom changes are per-origin (Chromium default behavior)
- **`isolated`** — zoom changes are per-webContents, not shared across same-origin webContents
- **`manual`** — automatic zoom handling is disabled; the app manages zoom via events
- **`disabled`** — all zooming is disabled; the webContents stays at the default zoom level

The `isolated` and `manual` modes persist across navigations automatically.

Zoom mode can also be set at construction time via `webPreferences.zoomMode`.

Additionally fixes an observer ordering issue where `did-navigate` would report stale zoom values by ensuring zoom state is updated before the event is emitted.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] I have built and tested this PR
- [X] `npm test` passes
- [X] tests are added(https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [X] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [X] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `webContents.setZoomMode(mode)` / `webContents.getZoomMode()` and `webContents.zoomMode` property for per-webContents zoom control.