### PR TITLE
fix: exit orphaned zygote on invalid IPC socket instead of spinning

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -145,3 +145,4 @@ expose_gtk_ui_platform_field.patch
 patch_osr_control_screen_info.patch
 refactor_allow_customizing_config_in_freedesktopsecretkeyprovider.patch
 fix_wayland_test_crash_on_teardown.patch
+fix_zygote_spinloop_on_invalid_ipc_socket.patch

--- a/patches/chromium/fix_zygote_spinloop_on_invalid_ipc_socket.patch
+++ b/patches/chromium/fix_zygote_spinloop_on_invalid_ipc_socket.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: krka <krka@users.noreply.github.com>
+Date: Thu, 27 Feb 2026 09:00:00 +0100
+Subject: fix: exit orphaned zygote on invalid IPC socket instead of spinning
+
+When the browser process exits and restarts, orphaned zygote processes
+may be left with IPC file descriptors (fd 3) pointing to regular files
+instead of sockets. The existing error handling logs the ENOTSOCK error
+but returns to the main loop, where ppoll() on a regular file returns
+immediately, creating a tight spinloop at ~4000 iterations/second.
+
+This burns 80%+ of a CPU core indefinitely and spams error logs at
+thousands of lines per second, growing ~/.xsession-errors or the
+systemd journal to multi-GB sizes.
+
+The fix extends the existing EOF/ECONNRESET exit path to also cover
+ENOTSOCK and EBADF, which indicate the IPC socket is fundamentally
+invalid and unrecoverable.
+
+Bug: https://github.com/electron/electron/issues/XXXXX
+Bug: https://github.com/microsoft/vscode/issues/288893
+
+diff --git a/content/zygote/zygote_linux.cc b/content/zygote/zygote_linux.cc
+--- a/content/zygote/zygote_linux.cc
++++ b/content/zygote/zygote_linux.cc
+@@ -240,6 +240,14 @@ bool Zygote::HandleRequestFromBrowser(int fd) {
+   }
+
+   if (len == -1) {
++    // If the IPC socket fd is fundamentally invalid (not a socket, or bad fd),
++    // there is no way to recover. This happens when the zygote is orphaned
++    // after the browser process exits and restarts, leaving file descriptors
++    // pointing to non-socket files. Exit to avoid an infinite spinloop.
++    if (errno == ENOTSOCK || errno == EBADF) {
++      LOG(ERROR) << "Zygote IPC socket is invalid, exiting orphaned zygote";
++      _exit(0);
++    }
+     PLOG(ERROR) << "Error reading message from browser";
+     return false;
+   }


### PR DESCRIPTION
## Summary

Fixes https://github.com/electron/electron/issues/49967
Related: https://github.com/microsoft/vscode/issues/288893

When the browser process exits and restarts on Linux, orphaned zygote processes can survive with broken IPC file descriptors (pointing to regular files instead of sockets). The error path in `content/zygote/zygote_linux.cc:245` logs the `ENOTSOCK` error but returns to the main loop, where `ppoll()` on a regular file returns `POLLIN` immediately — creating an infinite spinloop at ~4000 iterations/second.

This burns 80%+ of a CPU core indefinitely and spams `~/.xsession-errors` or the systemd journal at thousands of lines/second (observed: 15 GB in 40 minutes).

The fix extends the existing EOF/ECONNRESET exit path (line 235-240) to also cover `ENOTSOCK` and `EBADF`, which indicate the IPC socket fd is fundamentally invalid and unrecoverable.

## The change

```diff
   if (len == -1) {
+    if (errno == ENOTSOCK || errno == EBADF) {
+      LOG(ERROR) << "Zygote IPC socket is invalid, exiting orphaned zygote";
+      _exit(0);
+    }
     PLOG(ERROR) << "Error reading message from browser";
     return false;
   }
```

All symbols used (`errno`, `ENOTSOCK`, `EBADF`, `LOG`, `_exit`) are already included and used elsewhere in the same file.

## Test plan

- [x] Verified patch applies cleanly against current `content/zygote/zygote_linux.cc`
- [x] Confirmed all symbols are already available (included headers, used in same file)
- [ ] Build verification (requires full Chromium checkout)


🤖 Generated with [Claude Code](https://claude.com/claude-code)