### PR TITLE
fix: revert "build: roll Mantle and remove patch"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ vars = {
   'reactiveobjc_version':
     '74ab5baccc6f7202c8ac69a8d1e152c29dc1ea76',
   'mantle_version':
-    '2a8e2123a3931038179ee06105c9e6ec336b12ea',
+    '78d3966b3c331292ea29ec38661b25df0a245948',
   'engflow_reclient_configs_version':
     '955335c30a752e9ef7bff375baab5e0819b6c00d',
 

--- a/patches/Mantle/.patches
+++ b/patches/Mantle/.patches
@@ -1,0 +1,1 @@
+remove_mtlmanagedobjectadapter_h.patch

--- a/patches/Mantle/remove_mtlmanagedobjectadapter_h.patch
+++ b/patches/Mantle/remove_mtlmanagedobjectadapter_h.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Mon, 7 Dec 2020 17:34:08 -0800
+Subject: Remove MTLManagedObjectAdapter.h
+
+We are using an outdated version of Mantle which leverages NSConfinementConcurrencyType,
+an enum which has been deprecated with no replacement as of macOS 10.11.
+The actual solution to this problem is to upgrade Mantle, but for now
+we just stop building the offending adapter.
+
+diff --git a/Mantle/Mantle.h b/Mantle/Mantle.h
+index ebd74e7e435ef008ef29e94d406246c1f7b07a12..81abff872bd597ce6d21bb43be4d19ddc7253088 100644
+--- a/Mantle/Mantle.h
++++ b/Mantle/Mantle.h
+@@ -15,7 +15,6 @@ FOUNDATION_EXPORT double MantleVersionNumber;
+ FOUNDATION_EXPORT const unsigned char MantleVersionString[];
+ 
+ #import <Mantle/MTLJSONAdapter.h>
+-#import <Mantle/MTLManagedObjectAdapter.h>
+ #import <Mantle/MTLModel.h>
+ #import <Mantle/MTLModel+NSCoding.h>
+ #import <Mantle/MTLValueTransformer.h>

--- a/patches/config.json
+++ b/patches/config.json
@@ -8,6 +8,7 @@
   { "patch_dir": "src/electron/patches/nan", "repo": "src/third_party/nan" },
   { "patch_dir": "src/electron/patches/perfetto", "repo": "src/third_party/perfetto" },
   { "patch_dir": "src/electron/patches/squirrel.mac", "repo": "src/third_party/squirrel.mac" },
+  { "patch_dir": "src/electron/patches/Mantle", "repo": "src/third_party/squirrel.mac/vendor/Mantle" },
   { "patch_dir": "src/electron/patches/ReactiveObjC", "repo": "src/third_party/squirrel.mac/vendor/ReactiveObjC" },
   { "patch_dir": "src/electron/patches/webrtc", "repo": "src/third_party/webrtc" },
   { "patch_dir": "src/electron/patches/reclient-configs", "repo": "src/third_party/engflow-reclient-configs" },

--- a/patches/squirrel.mac/build_add_gn_config.patch
+++ b/patches/squirrel.mac/build_add_gn_config.patch
@@ -23,10 +23,10 @@ index 89c499e451ecb48655cfd42b01ffa1da56998c2e..98f80aad43a87ed75ca1660ad6a178db
 +vendor
 diff --git a/BUILD.gn b/BUILD.gn
 new file mode 100644
-index 0000000000000000000000000000000000000000..a02e5f54d923513fd0676e91a99b8913bad6a57e
+index 0000000000000000000000000000000000000000..68beb3d10580cdb747a78407c7f5bbb205825c4b
 --- /dev/null
 +++ b/BUILD.gn
-@@ -0,0 +1,250 @@
+@@ -0,0 +1,242 @@
 +assert(is_mac)
 +
 +import("//build/config/mac/rules.gni")
@@ -48,16 +48,12 @@ index 0000000000000000000000000000000000000000..a02e5f54d923513fd0676e91a99b8913
 +    "Resources",
 +  ]
 +  info_plist = "vendor/Mantle/Mantle/Info.plist"
-+  extra_substitutions = [
-+    "CURRENT_PROJECT_VERSION=0.0.0",
-+    "PRODUCT_BUNDLE_IDENTIFIER=com.electron.mantle",
-+  ]
++  extra_substitutions = [ "CURRENT_PROJECT_VERSION=0.0.0" ]
 +
 +  configs -= [
 +    "//build/config/compiler:chromium_code",
 +    "//build/config/gcc:symbol_visibility_hidden",
 +  ]
-+
 +  configs += [ "//build/config/compiler:no_chromium_code" ]
 +  public_deps = [ ":mantle_headers" ]
 +  deps = []
@@ -70,8 +66,6 @@ index 0000000000000000000000000000000000000000..a02e5f54d923513fd0676e91a99b8913
 +  include_dirs = [
 +    "vendor/Mantle/Mantle",
 +    "vendor/Mantle/Mantle/extobjc",
-+    "vendor/Mantle/Mantle/extobjc/include",
-+    "vendor/Mantle/Mantle/include",
 +  ]
 +
 +  cflags_objc = [
@@ -202,7 +196,6 @@ index 0000000000000000000000000000000000000000..a02e5f54d923513fd0676e91a99b8913
 +  cflags_objc = [
 +    "-fobjc-weak",
 +    "-Wno-unknown-warning-option",
-+    "-Wno-deprecated-declarations",
 +    "-Wno-block-capture-autoreleasing",
 +    "-fobjc-arc",
 +  ]
@@ -269,7 +262,6 @@ index 0000000000000000000000000000000000000000..a02e5f54d923513fd0676e91a99b8913
 +  cflags_objc = [
 +    "-fobjc-weak",
 +    "-fobjc-arc",
-+    "-Wno-deprecated-declarations",
 +    "-Wno-block-capture-autoreleasing",
 +  ]
 +
@@ -542,10 +534,10 @@ index 0000000000000000000000000000000000000000..a7aeeb7d3e187bd91ef12ed860d1e37e
 +    sys.exit(e.returncode)
 diff --git a/filenames.gni b/filenames.gni
 new file mode 100644
-index 0000000000000000000000000000000000000000..cee305c80588ffe2234bfadd5c211a9c301fe589
+index 0000000000000000000000000000000000000000..3672153140b74fe948e7102b5e1ffad49341163d
 --- /dev/null
 +++ b/filenames.gni
-@@ -0,0 +1,249 @@
+@@ -0,0 +1,243 @@
 +squirrel_filenames = {
 +  headers = [
 +    "Squirrel/NSBundle+SQRLVersionExtensions.h",
@@ -590,25 +582,22 @@ index 0000000000000000000000000000000000000000..cee305c80588ffe2234bfadd5c211a9c
 +
 +mantle_filenames = {
 +  headers = [
++    "vendor/Mantle/Mantle/MTLJSONAdapter.h",
++    "vendor/Mantle/Mantle/MTLModel+NSCoding.h",
++    "vendor/Mantle/Mantle/MTLModel.h",
 +    "vendor/Mantle/Mantle/MTLReflection.h",
++    "vendor/Mantle/Mantle/MTLValueTransformer.h",
++    "vendor/Mantle/Mantle/Mantle.h",
++    "vendor/Mantle/Mantle/NSArray+MTLManipulationAdditions.h",
++    "vendor/Mantle/Mantle/NSDictionary+MTLManipulationAdditions.h",
 +    "vendor/Mantle/Mantle/NSError+MTLModelException.h",
-+    "vendor/Mantle/Mantle/NSDictionary+MTLJSONKeyPath.h",
-+    "vendor/Mantle/Mantle/include/MTLJSONAdapter.h",
-+    "vendor/Mantle/Mantle/include/MTLModel+NSCoding.h",
-+    "vendor/Mantle/Mantle/include/MTLModel.h",
-+    "vendor/Mantle/Mantle/include/MTLTransformerErrorHandling.h",
-+    "vendor/Mantle/Mantle/include/MTLValueTransformer.h",
-+    "vendor/Mantle/Mantle/include/Mantle.h",
-+    "vendor/Mantle/Mantle/include/NSArray+MTLManipulationAdditions.h",
-+    "vendor/Mantle/Mantle/include/NSDictionary+MTLMappingAdditions.h",
-+    "vendor/Mantle/Mantle/include/NSDictionary+MTLManipulationAdditions.h",
-+    "vendor/Mantle/Mantle/include/NSObject+MTLComparisonAdditions.h",
-+    "vendor/Mantle/Mantle/include/NSValueTransformer+MTLInversionAdditions.h",
-+    "vendor/Mantle/Mantle/include/NSValueTransformer+MTLPredefinedTransformerAdditions.h",
-+    "vendor/Mantle/Mantle/extobjc/include/MTLEXTKeyPathCoding.h",
-+    "vendor/Mantle/Mantle/extobjc/include/MTLEXTRuntimeExtensions.h",
-+    "vendor/Mantle/Mantle/extobjc/include/MTLEXTScope.h",
-+    "vendor/Mantle/Mantle/extobjc/include/MTLMetamacros.h",
++    "vendor/Mantle/Mantle/NSObject+MTLComparisonAdditions.h",
++    "vendor/Mantle/Mantle/NSValueTransformer+MTLInversionAdditions.h",
++    "vendor/Mantle/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.h",
++    "vendor/Mantle/Mantle/extobjc/MTLEXTKeyPathCoding.h",
++    "vendor/Mantle/Mantle/extobjc/MTLEXTRuntimeExtensions.h",
++    "vendor/Mantle/Mantle/extobjc/MTLEXTScope.h",
++    "vendor/Mantle/Mantle/extobjc/metamacros.h",
 +  ]
 +
 +  sources = [
@@ -616,12 +605,9 @@ index 0000000000000000000000000000000000000000..cee305c80588ffe2234bfadd5c211a9c
 +    "vendor/Mantle/Mantle/MTLModel+NSCoding.m",
 +    "vendor/Mantle/Mantle/MTLModel.m",
 +    "vendor/Mantle/Mantle/MTLReflection.m",
-+    "vendor/Mantle/Mantle/MTLTransformerErrorHandling.m",
 +    "vendor/Mantle/Mantle/MTLValueTransformer.m",
 +    "vendor/Mantle/Mantle/NSArray+MTLManipulationAdditions.m",
-+    "vendor/Mantle/Mantle/NSDictionary+MTLJSONKeyPath.m",
 +    "vendor/Mantle/Mantle/NSDictionary+MTLManipulationAdditions.m",
-+    "vendor/Mantle/Mantle/NSDictionary+MTLMappingAdditions.m",
 +    "vendor/Mantle/Mantle/NSError+MTLModelException.m",
 +    "vendor/Mantle/Mantle/NSObject+MTLComparisonAdditions.m",
 +    "vendor/Mantle/Mantle/NSValueTransformer+MTLInversionAdditions.m",

--- a/patches/squirrel.mac/use_uttype_class_instead_of_deprecated_uttypeconformsto.patch
+++ b/patches/squirrel.mac/use_uttype_class_instead_of_deprecated_uttypeconformsto.patch
@@ -6,10 +6,10 @@ Subject: Use UTType class instead of deprecated UTTypeConformsTo
 macOS 12 removed support for the deprecated UTTypeConformsTo function. Its replacement is the dedicated UTType class in the Uniform Type Identifiers framework.
 
 diff --git a/BUILD.gn b/BUILD.gn
-index a02e5f54d923513fd0676e91a99b8913bad6a57e..6f32c4b203a0efa2ccd515e3754494deef5b39f0 100644
+index 68beb3d10580cdb747a78407c7f5bbb205825c4b..b9e871a0292eeda1f0e738329d0b510bdc3e34a0 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -234,6 +234,7 @@ mac_framework_bundle("squirrel_framework") {
+@@ -227,6 +227,7 @@ mac_framework_bundle("squirrel_framework") {
      "IOKit.framework",
      "Security.framework",
      "ServiceManagement.framework",


### PR DESCRIPTION
#### Description of Change

Partially addresses #49977 for the Electron 41 release.

After bumping Mantle, we're seeing several errors in SQRLShipItRequest that are seemingly related to the upstream changes. This PR reverts commit 11d174344a8c833d74d953b552dfee86580356d2 for Electron 41 specifically - we can re-enable code-signing tests and try to keep the Mantle roll forward for Electron 42.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] I have built and tested this PR
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where Squirrel.Mac's auto updater would fail to install new updates if the targetBundleURL was either not set or contained special characters.