### PR TITLE
fix: deliver Universal Links when NSUserActivity.userInfo is nil

### DIFF
--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -146,10 +146,9 @@ static NSDictionary* UNNotificationResponseToNSDictionary(
   NSDictionary* user_info = userActivity.userInfo ?: @{};
 
   electron::Browser* browser = electron::Browser::Get();
-  return browser->ContinueUserActivity(
-             activity_type,
-             electron::NSDictionaryToValue(user_info),
-             electron::NSDictionaryToValue(details))
+  return browser->ContinueUserActivity(activity_type,
+                                       electron::NSDictionaryToValue(user_info),
+                                       electron::NSDictionaryToValue(details))
              ? YES
              : NO;
 }


### PR DESCRIPTION
Closes #49985

#### Description of Change

Fixes an issue where Universal Links (`NSUserActivityTypeBrowsingWeb`) were not delivered to JavaScript on macOS cold launch when `NSUserActivity.userInfo` was `nil`.

Electron previously returned early in `application:continueUserActivity:restorationHandler:` if `userActivity.userInfo` was `nil`. For Universal Links, the URL payload is provided via `userActivity.webpageURL`, and `userInfo` is optional per Apple’s API:

- `NSUserActivity.userInfo` (optional):  
  https://developer.apple.com/documentation/foundation/nsuseractivity/userinfo
- `NSUserActivity.webpageURL`:  
  https://developer.apple.com/documentation/foundation/nsuseractivity/webpageurl

This change treats a missing `userInfo` as an empty dictionary and forwards the activity to `Browser::ContinueUserActivity`, ensuring `details.webpageURL` is delivered to `app.on('continue-activity')` on cold launch.

Existing behavior is preserved for activities that include `userInfo`.

#### Checklist

- [x] PR description included
- [ ] I have built and tested this PR
- [x] `npm test` passes
- [x] tests are changed or added
- [x] relevant API documentation, tutorials, and examples are updated and follow the documentation style guide
- [x] PR release notes describe the change in a way relevant to app developers, and are capitalized, punctuated, and past tense.

#### Release Notes

Notes: Fixed an issue on macOS where Universal Links were not delivered to `app.on('continue-activity')` on cold launch when `NSUserActivity.userInfo` was nil.