### PR TITLE
fix: use setter's creation context when proxying setter in OverrideGlobalPropertyFromIsolatedWorld

### DIFF
--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -905,7 +905,7 @@ bool OverrideGlobalPropertyFromIsolatedWorld(
     }
     if (!setter->IsNullOrUndefined() && setter->IsObject()) {
       v8::Local<v8::Context> source_context =
-          getter->GetCreationContextChecked(isolate);
+          setter.As<v8::Object>()->GetCreationContextChecked(isolate);
       v8::MaybeLocal<v8::Value> maybe_setter_proxy = PassValueToOtherContext(
           isolate, source_context, isolate, main_context, setter,
           source_context->Global(), false, BridgeErrorTarget::kSource);


### PR DESCRIPTION
Copy-paste typo — the setter branch was deriving `source_context` from `getter->GetCreationContextChecked(isolate)` instead of `setter->`.

Currently latent since the only call site (`lib/renderer/api/context-bridge.ts`) always passes both getter and setter from the same preload context, so they resolve to the same creation context. If a future call site ever passed a setter without a getter (or from a different context), this would crash on `GetCreationContextChecked` or use the wrong source context.

Notes: no-notes