### PR TITLE
fix: delete temporary blink* globals after restoring Blink implementations

### DIFF
--- a/lib/node/init.ts
+++ b/lib/node/init.ts
@@ -9,6 +9,7 @@ if ((globalThis as any).blinkfetch) {
   const keys = ['fetch', 'Response', 'FormData', 'Request', 'Headers', 'EventSource'];
   for (const key of keys) {
     (globalThis as any)[key] = (globalThis as any)[`blink${key}`];
+    delete (globalThis as any)[`blink${key}`];
   }
 }
 

--- a/lib/worker/init.ts
+++ b/lib/worker/init.ts
@@ -22,6 +22,7 @@ if ((globalThis as any).blinkfetch) {
   const keys = ['fetch', 'Response', 'FormData', 'Request', 'Headers', 'EventSource'];
   for (const key of keys) {
     (globalThis as any)[key] = (globalThis as any)[`blink${key}`];
+    delete (globalThis as any)[`blink${key}`];
   }
 }
 


### PR DESCRIPTION
`ElectronRendererClient::DidCreateScriptContext` (and `WebWorkerObserver::WorkerScriptReadyForEvaluation`) save Blink's `fetch`/`Response`/`FormData`/`Request`/`Headers`/`EventSource` as temporary `globalThis.blink*` properties before Node initialization (which deletes some of these when its fetch implementation is disabled). `node/init.ts` and `worker/init.ts` restore the originals from these temporaries but previously never deleted the `blink*` globals.

They persisted as non-standard global pollution visible to page content when `contextIsolation: false` — a minor Electron fingerprinting signal, and a bypass for any preload that wraps `window.fetch` (page can call `blinkfetch()` instead).

Notes: no-notes