### PR TITLE
chore: remove unused `commandLineSwitches` flag

### DIFF
--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -135,7 +135,6 @@ void WebContentsPreferences::Clear() {
   default_encoding_ = std::nullopt;
   is_webview_ = false;
   custom_args_.clear();
-  custom_switches_.clear();
   enable_blink_features_ = std::nullopt;
   disable_blink_features_ = std::nullopt;
   disable_popups_ = false;
@@ -204,7 +203,6 @@ void WebContentsPreferences::SetFromDictionary(
   if (web_preferences.Get("defaultEncoding", &encoding))
     default_encoding_ = encoding;
   web_preferences.Get(options::kCustomArgs, &custom_args_);
-  web_preferences.Get("commandLineSwitches", &custom_switches_);
   web_preferences.Get("disablePopups", &disable_popups_);
   web_preferences.Get("disableDialogs", &disable_dialogs_);
   web_preferences.Get("safeDialogs", &safe_dialogs_);
@@ -337,11 +335,6 @@ void WebContentsPreferences::AppendCommandLineSwitches(
   for (const auto& arg : custom_args_)
     if (!arg.empty())
       command_line->AppendArg(arg);
-
-  // Custom command line switches.
-  for (const auto& arg : custom_switches_)
-    if (!arg.empty())
-      command_line->AppendSwitch(arg);
 
   if (enable_blink_features_)
     command_line->AppendSwitchASCII(::switches::kEnableBlinkFeatures,

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -122,7 +122,6 @@ class WebContentsPreferences
   std::optional<std::string> default_encoding_;
   bool is_webview_;
   std::vector<std::string> custom_args_;
-  std::vector<std::string> custom_switches_;
   std::optional<std::string> enable_blink_features_;
   std::optional<std::string> disable_blink_features_;
   bool disable_popups_;


### PR DESCRIPTION
#### Description of Change

As in title. Remove unused `commandLineSwitches` flag 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none