### PR TITLE
chore: remove applescript from trash

### DIFF
--- a/shell/browser/ui/cocoa/electron_bundle_mover.mm
+++ b/shell/browser/ui/cocoa/electron_bundle_mover.mm
@@ -270,34 +270,10 @@ void Relaunch(NSString* destinationPath) {
 }
 
 bool Trash(NSString* path) {
-  bool result = false;
-
-  if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_8) {
-    result = [[NSFileManager defaultManager]
-          trashItemAtURL:[NSURL fileURLWithPath:path]
-        resultingItemURL:nil
-                   error:nil];
-  }
-
-  // As a last resort try trashing with AppleScript.
-  // This allows us to trash the app in macOS Sierra even when the app is
-  // running inside an app translocation image.
-  if (!result) {
-    auto* code = R"str(
-set theFile to POSIX file "%@"
-tell application "Finder"
-move theFile to trash
-end tell
-)str";
-    NSAppleScript* appleScript = [[NSAppleScript alloc]
-        initWithSource:[NSString stringWithFormat:@(code), path]];
-    NSDictionary* errorDict = nil;
-    NSAppleEventDescriptor* scriptResult =
-        [appleScript executeAndReturnError:&errorDict];
-    result = (scriptResult != nil);
-  }
-
-  return result;
+  return [[NSFileManager defaultManager]
+        trashItemAtURL:[NSURL fileURLWithPath:path]
+      resultingItemURL:nil
+                 error:nil];
 }
 
 bool DeleteOrTrash(NSString* path) {


### PR DESCRIPTION
#### Description of Change

Previously, when `trashItemAtURL:` failed (e.g. on network shares or under app translocation), the code fell back to constructing an AppleScript that interpolated the bundle path directly into a string literal. This was fragile and unnecessary — `trashItemAtURL:` has been the standard API since 10.8 and covers the relevant cases. The fix simply removes the AppleScript fallback entirely, so `Trash()` now returns the result of `trashItemAtURL:` directly.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none