### PR TITLE
fix: use requesting frame origin in permission helper and device choosers

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -870,7 +870,7 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
 #### `ses.setPermissionRequestHandler(handler)`
 
 * `handler` Function | null
-  * `webContents` [WebContents](web-contents.md) - WebContents requesting the permission.  Please note that if the request comes from a subframe you should use `requestingOrigin` to check the request origin.
+  * `webContents` [WebContents](web-contents.md) - WebContents requesting the permission.  Please note that if the request comes from a subframe you should use `requestingUrl` to check the request origin.
   * `permission` string - The type of requested permission.
     * `clipboard-read` - Request access to read from the clipboard.
     * `clipboard-sanitized-write` - Request access to write to the clipboard.
@@ -917,7 +917,7 @@ session.fromPartition('some-partition').setPermissionRequestHandler((webContents
 #### `ses.setPermissionCheckHandler(handler)`
 
 * `handler` Function\<boolean> | null
-  * `webContents` ([WebContents](web-contents.md) | null) - WebContents checking the permission.  Please note that if the request comes from a subframe you should use `requestingOrigin` to check the request origin.  All cross origin sub frames making permission checks will pass a `null` webContents to this handler, while certain other permission checks such as `notifications` checks will always pass `null`.  You should use `embeddingOrigin` and `requestingOrigin` to determine what origin the owning frame and the requesting frame are on respectively.
+  * `webContents` ([WebContents](web-contents.md) | null) - WebContents checking the permission.  Please note that if the request comes from a subframe you should use `requestingUrl` to check the request origin.  All cross origin sub frames making permission checks will pass a `null` webContents to this handler, while certain other permission checks such as `notifications` checks will always pass `null`.  You should use `embeddingOrigin` and `requestingOrigin` to determine what origin the owning frame and the requesting frame are on respectively.
   * `permission` string - Type of permission check.
     * `clipboard-read` - Request access to read from the clipboard.
     * `clipboard-sanitized-write` - Request access to write to the clipboard.
@@ -944,7 +944,7 @@ session.fromPartition('some-partition').setPermissionRequestHandler((webContents
     * `securityOrigin` string (optional) - The security origin of the `media` check.
     * `mediaType` string (optional) - The type of media access being requested, can be `video`,
       `audio` or `unknown`.
-    * `requestingOrigin` string (optional) - The origin of the requesting frame.  This is not provided for cross-origin sub frames making permission checks.
+    * `requestingUrl` string (optional) - The last URL the requesting frame loaded.  This is not provided for cross-origin sub frames making permission checks.
     * `isMainFrame` boolean - Whether the frame making the request is the main frame.
     * `filePath` string (optional) - The path of a `fileSystem` request.
     * `isDirectory` boolean (optional) - Whether a `fileSystem` request is a directory.

--- a/docs/api/structures/permission-request.md
+++ b/docs/api/structures/permission-request.md
@@ -1,4 +1,4 @@
 # PermissionRequest Object
 
-* `requestingOrigin` string - The origin of the requesting frame.
+* `requestingUrl` string - The last URL the requesting frame loaded.
 * `isMainFrame` boolean - Whether the frame making the request is the main frame.

--- a/shell/browser/electron_permission_manager.cc
+++ b/shell/browser/electron_permission_manager.cc
@@ -274,8 +274,7 @@ void ElectronPermissionManager::RequestPermissionsWithDetails(
   int request_id = pending_requests_.Add(std::make_unique<PendingRequest>(
       render_frame_host, std::move(permissions), std::move(response_callback)));
 
-  details.Set("requestingOrigin",
-              render_frame_host->GetLastCommittedOrigin().Serialize());
+  details.Set("requestingUrl", render_frame_host->GetLastCommittedURL().spec());
   details.Set("isMainFrame", render_frame_host->GetParent() == nullptr);
   base::Value dict_value(std::move(details));
 
@@ -386,8 +385,8 @@ bool ElectronPermissionManager::CheckPermissionWithDetails(
           ? content::WebContents::FromRenderFrameHost(render_frame_host)
           : nullptr;
   if (render_frame_host) {
-    details.Set("requestingOrigin",
-                render_frame_host->GetLastCommittedOrigin().Serialize());
+    details.Set("requestingUrl",
+                render_frame_host->GetLastCommittedURL().spec());
   }
   details.Set("isMainFrame",
               render_frame_host && render_frame_host->GetParent() == nullptr);

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -1786,7 +1786,7 @@ describe('session module', () => {
 
   describe('ses.setPermissionCheckHandler(handler)', () => {
     afterEach(closeAllWindows);
-    it('details provides requestingOrigin for mainFrame', async () => {
+    it('details provides requestingURL for mainFrame', async () => {
       const w = new BrowserWindow({
         show: false,
         webPreferences: {
@@ -1794,7 +1794,7 @@ describe('session module', () => {
         }
       });
       const ses = w.webContents.session;
-      const loadUrl = 'https://myfakesite';
+      const loadUrl = 'https://myfakesite/';
       let handlerDetails : Electron.PermissionCheckHandlerHandlerDetails;
 
       ses.protocol.interceptStringProtocol('https', (req, cb) => {
@@ -1819,10 +1819,10 @@ describe('session module', () => {
       await w.loadURL(loadUrl);
       const state = await readClipboardPermission();
       expect(state).to.equal('granted');
-      expect(handlerDetails!.requestingOrigin).to.equal(loadUrl);
+      expect(handlerDetails!.requestingUrl).to.equal(loadUrl);
     });
 
-    it('details provides requestingOrigin for cross origin subFrame', async () => {
+    it('details provides requestingURL for cross origin subFrame', async () => {
       const w = new BrowserWindow({
         show: false,
         webPreferences: {
@@ -1830,14 +1830,14 @@ describe('session module', () => {
         }
       });
       const ses = w.webContents.session;
-      const loadUrl = 'https://myfakesite';
+      const loadUrl = 'https://myfakesite/';
       let handlerDetails : Electron.PermissionCheckHandlerHandlerDetails;
 
       ses.protocol.interceptStringProtocol('https', (req, cb) => {
         cb('<html><script>console.log(\'test\');</script></html>');
       });
 
-      ses.setPermissionCheckHandler((_wc, permission, _requestingOrigin, details) => {
+      ses.setPermissionCheckHandler((wc, permission, requestingOrigin, details) => {
         if (permission === 'clipboard-read') {
           handlerDetails = details;
           return true;
@@ -1863,7 +1863,7 @@ describe('session module', () => {
       const [,, frameProcessId, frameRoutingId] = await once(w.webContents, 'did-frame-finish-load');
       const state = await readClipboardPermission(webFrameMain.fromId(frameProcessId, frameRoutingId));
       expect(state).to.equal('granted');
-      expect(handlerDetails!.requestingOrigin).to.equal(loadUrl);
+      expect(handlerDetails!.requestingUrl).to.equal(loadUrl);
       expect(handlerDetails!.isMainFrame).to.be.false();
       expect(handlerDetails!.embeddingOrigin).to.equal('file:///');
     });

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -1055,12 +1055,13 @@ describe('chromium features', () => {
       w.webContents.session.setPermissionRequestHandler((wc, permission, callback, details) => {
         expect(permission).to.equal('fileSystem');
 
+        const { href } = url.pathToFileURL(writablePath);
         expect(details).to.deep.equal({
           fileAccessType: 'writable',
           isDirectory: false,
           isMainFrame: true,
           filePath: testFile,
-          requestingOrigin: 'file://'
+          requestingUrl: href
         });
 
         callback(true);
@@ -1105,12 +1106,13 @@ describe('chromium features', () => {
       w.webContents.session.setPermissionRequestHandler((wc, permission, callback, details) => {
         expect(permission).to.equal('fileSystem');
 
+        const { href } = url.pathToFileURL(writablePath);
         expect(details).to.deep.equal({
           fileAccessType: 'writable',
           isDirectory: false,
           isMainFrame: true,
           filePath: testFile,
-          requestingOrigin: 'file://'
+          requestingUrl: href
         });
 
         callback(false);
@@ -3865,9 +3867,10 @@ describe('paste execCommand', () => {
         };
       }
     });
-    ses.setPermissionCheckHandler((webContents, permission, requestingOrigin) => {
+    ses.setPermissionCheckHandler((webContents, permission, requestingOrigin, details) => {
       if (requestingOrigin === `${webContents?.opener?.origin}/` &&
-        permission === 'deprecated-sync-clipboard-read') {
+          details.requestingUrl === 'about:blank' &&
+          permission === 'deprecated-sync-clipboard-read') {
         return true;
       }
       return false;


### PR DESCRIPTION
#### Description of Change

`WebContentsPermissionHelper::RequestPermission` was passing `web_contents_->GetLastCommittedURL()` as the requesting origin instead of the actual requesting frame's origin. When a subframe initiates a permission request, this meant the top-level page's URL was forwarded rather than the subframe's. The HID, USB, and Serial device choosers had the same pattern — they keyed grants to the primary main frame's origin instead of the requesting frame's.

This PR switches all of these paths to use `requesting_frame->GetLastCommittedOrigin()` so the origin matches the frame that actually initiated the request.

No API changes — `details.requestingUrl` is unchanged (it was already derived from the requesting RFH in `ElectronPermissionManager`).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where permission and device-chooser handlers received the top-level page origin instead of the requesting subframe's origin.