### PR TITLE
fix: don't call `TaskDialogIndirect` with disabled parent windows

### DIFF
--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -158,7 +158,7 @@ DialogResult ShowTaskDialogWstr(gfx::AcceleratedWidget parent,
   config.hInstance = GetModuleHandle(nullptr);
   config.dwFlags = flags;
 
-  if (parent) {
+  if (parent && ::IsWindowEnabled(parent)) {
     config.hwndParent = parent;
     config.dwFlags |= TDF_POSITION_RELATIVE_TO_WINDOW;
   }


### PR DESCRIPTION
#### Description of Change

Should resolve #50068. This is a naïve fix, and I don't have a Windows dev box to easily test this on.

[The documentation for `TaskDialogIndirect`](https://learn.microsoft.com/en-us/windows/win32/api/commctrl/nf-commctrl-taskdialogindirect) includes the following line:
> The parent window should not be hidden or disabled when this function is called.

This ensures we don't violate that remark.

#### Checklist

- [x] PR description included
- [ ] I have built and tested this PR
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed bug where opening a message box immediately upon closing a child window may cause the parent window to freeze on Windows.