### PR TITLE
docs: cleanup desktop-capturer doc after chromium audio capture additions

### DIFF
--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -94,6 +94,7 @@ The `desktopCapturer` module has the following methods:
 Returns `Promise<DesktopCapturerSource[]>` - Resolves with an array of [`DesktopCapturerSource`](structures/desktop-capturer-source.md) objects, each `DesktopCapturerSource` represents a screen or an individual window that can be captured.
 
 > [!NOTE]
+<!-- markdownlint-disable-next-line MD032 -->
 > * Capturing audio requires `NSAudioCaptureUsageDescription` Info.plist key on macOS 14.2 Sonoma and higher - [read more](#macos-versions-142-or-higher).
 > * Capturing the screen contents requires user consent on macOS 10.15 Catalina or higher, which can detected by [`systemPreferences.getMediaAccessStatus`][].
 


### PR DESCRIPTION
#### Description of Change

This PR is a follow up to https://github.com/electron/electron/pull/49717 to address some of the documentation problems that it had. The first issue was that the `NOTE` section had an extra space resulting in the block not being properly formatted (as seen [here](https://www.electronjs.org/docs/latest/api/desktop-capturer#desktopcapturergetsourcesoptions) on the site currently). The second was the line lengths not being between 80 and 100 characters as per [the style guide](https://www.electronjs.org/docs/latest/development/style-guide#markdown-rules). The lines were updated to be within this range, with exceptions for lines that contain links. (There are other lines within the document that are above 100 characters, but the scope of this PR is to simply correct the last addition as opposed to the document as a whole).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
