### PR TITLE
fix: always call the original impl in swizzled mousedown impls

### DIFF
--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -87,8 +87,8 @@ MouseDownImpl g_nsnextstepframe_mousedown;
         (electron::NativeWindowMac*)[(id)self.window shell];
     if (shell && !shell->has_frame())
       [self cr_mouseDownOnFrameView:event];
-    g_nsthemeframe_mousedown(self, @selector(mouseDown:), event);
   }
+  g_nsthemeframe_mousedown(self, @selector(mouseDown:), event);
 }
 
 - (void)swiz_nsnextstepframe_mouseDown:(NSEvent*)event {
@@ -98,8 +98,8 @@ MouseDownImpl g_nsnextstepframe_mousedown;
     if (shell && !shell->has_frame()) {
       [self cr_mouseDownOnFrameView:event];
     }
-    g_nsnextstepframe_mousedown(self, @selector(mouseDown:), event);
   }
+  g_nsnextstepframe_mousedown(self, @selector(mouseDown:), event);
 }
 
 - (void)swiz_nsview_swipeWithEvent:(NSEvent*)event {


### PR DESCRIPTION
#### Description of Change

Should resolve #49874. We should always call the original mousedown implementation, regardless of if our window responds to `shell`.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed logic bug that rendered certain window types un-resizable on MAS builds.
