### PR TITLE
test: fix flaky macOS dock tests

### DIFF
--- a/shell/browser/ui/autofill_popup.cc
+++ b/shell/browser/ui/autofill_popup.cc
@@ -182,14 +182,10 @@ void AutofillPopup::CreateView(content::RenderFrameHost* frame_host,
   views::View::ConvertPointToScreen(parent, &menu_position);
   popup_bounds_ = gfx::Rect(menu_position, element_bounds_.size());
 
-  auto* widget = parent->GetWidget();
-  if (!widget)
-    return;
-
   parent_ = parent;
   parent_->AddObserver(this);
 
-  view_ = new AutofillPopupView(this, widget);
+  view_ = new AutofillPopupView(this, parent->GetWidget());
 
   if (offscreen) {
     auto* rwhv = embedder_frame_host ? embedder_frame_host->GetView()

--- a/shell/browser/ui/views/autofill_popup_view.cc
+++ b/shell/browser/ui/views/autofill_popup_view.cc
@@ -67,7 +67,7 @@ AutofillPopupView::~AutofillPopupView() {
 }
 
 void AutofillPopupView::Show() {
-  if (!parent_widget_ || !popup_)
+  if (!popup_)
     return;
   bool visible = parent_widget_->IsVisible();
   visible = visible || view_proxy_;


### PR DESCRIPTION
#### Description of Change

This PR addresses some instability with the `macos-arm 64 (darwin, 2)` test suite in main, which seems to be commonly flaking on two dock tests:

  1. app module dock APIs dock.bounce should return a positive number for informational type (api-app-spec.ts)
  2. app module dock APIs dock.bounce should return a positive number for critical type (api-app-spec.ts)

This PR attempts to fix the dock tests by using `app.isActive()` instead of `BrowserWindow.getFocusedWindow()`. I think I may have uncovered an actual bug in the current autofill test while trying to deflake it, and included the fix here, but open to splitting that up in to a separate PR - I unfortunately haven't found a consistent fix for deflaking that test yet.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
