### PR TITLE
ci: add workflow to remove 'needs-signed-commits' label

### DIFF
--- a/.github/workflows/issue-commented.yml
+++ b/.github/workflows/issue-commented.yml
@@ -33,7 +33,31 @@ jobs:
           ISSUE_URL: ${{ github.event.issue.html_url }}
         run: |
           gh issue edit $ISSUE_URL --remove-label 'blocked/need-repro','blocked/need-info ❌'
-
+  
+  pr-needs-signed-commits-commented:
+    name: Remove needs-signed-commits on comment
+    if: ${{ github.event.issue.pull_request && (contains(github.event.issue.labels.*.name, 'needs-signed-commits')) && (github.event.comment.user.login == github.event.issue.user.login) }}
+    runs-on: ubuntu-slim
+    steps:
+      - name: Get author association
+        id: get-author-association
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: *get-author-association
+      - name: Generate GitHub App token
+        uses: electron/github-app-auth-action@e14e47722ed120360649d0789e25b9baece12725 # v2.0.0
+        if: ${{ !contains(fromJSON('["MEMBER", "OWNER", "COLLABORATOR"]'), steps.get-author-association.outputs.author_association) }}
+        id: generate-token
+        with:
+          creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
+      - name: Remove label
+        if: ${{ !contains(fromJSON('["MEMBER", "OWNER", "COLLABORATOR"]'), steps.get-author-association.outputs.author_association) }}
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: |
+          gh issue edit $ISSUE_URL --remove-label 'needs-signed-commits'
+  
   pr-reviewer-requested:
     name: Maintainer requested reviewer on PR
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/request-review') && github.event.comment.user.type != 'Bot' }}


### PR DESCRIPTION
#### Description of Change

This PR adds the ability for the label `needs-signed-commits` to be automatically removed when the author of the PR comments that they have signed their commits. This is a temporary functionality while a programmatic solution is explored for checking the status of the commits themselves.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] I have built and tested this PR
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
