### PR TITLE
refactor: remove url.parse deprecation warning in default app

### DIFF
--- a/default_app/main.ts
+++ b/default_app/main.ts
@@ -252,8 +252,12 @@ async function startRepl () {
 // start the default app.
 if (option.file && !option.webdriver) {
   const file = option.file;
-  // eslint-disable-next-line n/no-deprecated-api
-  const protocol = url.parse(file).protocol;
+  let protocol: string | null = null;
+  try {
+    protocol = new URL(file).protocol;
+  } catch {
+    // file is not a valid URL string
+  }
   const extension = path.extname(file);
   if (protocol === 'http:' || protocol === 'https:' || protocol === 'file:' || protocol === 'chrome:') {
     await loadApplicationByURL(file);


### PR DESCRIPTION
Fixes #49550. Replaces deprecated url.parse() with the WHATWG URL API to eliminate deprecation warnings in the default app.