### PR TITLE
fix: delete temporary blink* globals after restoring Blink implementations

### DIFF
--- a/lib/node/init.ts
+++ b/lib/node/init.ts
@@ -9,6 +9,7 @@ if ((globalThis as any).blinkfetch) {
   const keys = ['fetch', 'Response', 'FormData', 'Request', 'Headers', 'EventSource'];
   for (const key of keys) {
     (globalThis as any)[key] = (globalThis as any)[`blink${key}`];
+    delete (globalThis as any)[`blink${key}`];
   }
 }
 

--- a/lib/worker/init.ts
+++ b/lib/worker/init.ts
@@ -22,6 +22,7 @@ if ((globalThis as any).blinkfetch) {
   const keys = ['fetch', 'Response', 'FormData', 'Request', 'Headers', 'EventSource'];
   for (const key of keys) {
     (globalThis as any)[key] = (globalThis as any)[`blink${key}`];
+    delete (globalThis as any)[`blink${key}`];
   }
 }
 


### PR DESCRIPTION
Backport of #49991.

See that PR for details.

Notes: no-notes