### PR TITLE
build: pin diff.renames for deterministic patch export

### DIFF
--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -128,6 +128,11 @@ def format_patch(repo, since):
         os.path.dirname(os.path.realpath(__file__)),
         'electron.gitattributes',
     ),
+    # Pin rename/copy detection to git's default so that patch output is
+    # deterministic regardless of local or system-level diff.renames config
+    # (e.g. 'copies', which would encode similar new files as copies).
+    '-c',
+    'diff.renames=true',
     # Ensure it is not possible to match anything
     # Disabled for now as we have consistent chunk headers
     # '-c',


### PR DESCRIPTION
`git format-patch` honors `diff.renames`, which defaults to `true` (rename detection only). If a user has `diff.renames=copies` configured at the system or global level, exported patches may encode new files as copies of similar existing files, causing spurious diffs when `e patches` is run against patches exported on other machines.

This pins `diff.renames=true` in the export script to match git's default and ensure consistent output regardless of local git configuration.

Notes: none