### PR TITLE
fix: validate response header names and values before AddHeader

### DIFF
--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -24,6 +24,7 @@
 #include "net/base/filename_util.h"
 #include "net/http/http_request_headers.h"
 #include "net/http/http_status_code.h"
+#include "net/http/http_util.h"
 #include "net/url_request/redirect_util.h"
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
@@ -138,13 +139,17 @@ network::mojom::URLResponseHeadPtr ToResponseHead(
   base::DictValue headers;
   if (dict.Get("headers", &headers)) {
     for (const auto iter : headers) {
+      if (!net::HttpUtil::IsValidHeaderName(iter.first))
+        continue;
       if (iter.second.is_string()) {
         // key, value
-        head->headers->AddHeader(iter.first, iter.second.GetString());
+        if (net::HttpUtil::IsValidHeaderValue(iter.second.GetString()))
+          head->headers->AddHeader(iter.first, iter.second.GetString());
       } else if (iter.second.is_list()) {
         // key: [values...]
         for (const auto& item : iter.second.GetList()) {
-          if (item.is_string())
+          if (item.is_string() &&
+              net::HttpUtil::IsValidHeaderValue(item.GetString()))
             head->headers->AddHeader(iter.first, item.GetString());
         }
       } else {

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -19,6 +19,7 @@
 #include "net/cert/x509_certificate.h"
 #include "net/cert/x509_util.h"
 #include "net/http/http_response_headers.h"
+#include "net/http/http_util.h"
 #include "net/http/http_version.h"
 #include "net/url_request/redirect_info.h"
 #include "services/network/public/cpp/data_element.h"
@@ -198,6 +199,10 @@ bool Converter<net::HttpResponseHeaders*>::FromV8(
     }
     std::string value;
     gin::ConvertFromV8(isolate, localStrVal, &value);
+    if (!net::HttpUtil::IsValidHeaderName(key) ||
+        !net::HttpUtil::IsValidHeaderValue(value)) {
+      return false;
+    }
     out->AddHeader(key, value);
     return true;
   };


### PR DESCRIPTION
Adds `net::HttpUtil::IsValidHeaderName`/`IsValidHeaderValue` checks before calling `HttpResponseHeaders::AddHeader` in:

- `ToResponseHead` (custom protocol handler response headers) — invalid headers are dropped
- `Converter<HttpResponseHeaders*>::FromV8` (`webRequest.onHeadersReceived`) — conversion fails on invalid input

This matches the existing validation already applied to request headers in `electron_api_url_loader.cc`.

Notes: Fixed an issue where invalid characters in custom protocol or webRequest response header values were not rejected.