### PR TITLE
fix: replace deprecated url.parse() in default app entrypoint

### DIFF
--- a/default_app/main.ts
+++ b/default_app/main.ts
@@ -255,8 +255,12 @@ async function startRepl () {
 // start the default app.
 if (option.file && !option.webdriver) {
   const file = option.file;
-  // eslint-disable-next-line n/no-deprecated-api
-  const protocol = url.parse(file).protocol;
+  let protocol: string | null = null;
+  try {
+    protocol = new URL(file).protocol;
+  } catch {
+    // file is not a valid URL string
+  }
   const extension = path.extname(file);
   if (protocol === 'http:' || protocol === 'https:' || protocol === 'file:' || protocol === 'chrome:') {
     await loadApplicationByURL(file);


### PR DESCRIPTION

```markdown
#### Description of Change

Replaces the deprecated `url.parse()` usage in `default_app/main.ts` with the WHATWG `URL` API when detecting whether the default app argument should be handled as a URL.

For non-URL strings, the new code falls back to `null`, preserving the existing control flow for relative and absolute file paths.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are included
- [x] documentation is changed or does not need to be changed

#### Release Notes Notes

```release-note
Fixed a deprecation warning emitted by the default app when parsing URL arguments.
```
```

## Reviewer Notes

- Target issue: [#49550](https://github.com/electron/electron/issues/49550)
- Modified file: [`default_app/main.ts`](/Users/spacex/Code/demo/electron-fix2/electron-src/default_app/main.ts#L256)
- Validation performed:
  - Compared old and new protocol detection for `https://...`, `file:///...`, `chrome://...`, `./app.js`, `/tmp/app.js`, `C:/tmp/app.js`
  - Observed identical protocol classification across all checked inputs
- Not run:
  - Full Electron test suite
  - End-to-end default app launch test in a built Electron binary
