### PR TITLE
fix: remove url.parse usage from net.request

### DIFF
--- a/lib/common/api/net-client-request.ts
+++ b/lib/common/api/net-client-request.ts
@@ -226,9 +226,26 @@ function validateHeader (name: any, value: any): void {
   }
 }
 
+function parseURLString (urlString: string): ClientRequestConstructorOptions {
+  const hashIndex = urlString.indexOf('#');
+  const requestURL = hashIndex === -1 ? urlString : urlString.slice(0, hashIndex);
+
+  try {
+    const parsed = new URL(urlString);
+    return {
+      protocol: parsed.protocol,
+      host: parsed.host,
+      hostname: parsed.hostname,
+      path: `${parsed.pathname}${parsed.search}`,
+      ...(parsed.port ? { port: parsed.port } : {})
+    };
+  } catch {
+    return { path: requestURL };
+  }
+}
+
 function parseOptions (optionsIn: ClientRequestConstructorOptions | string): NodeJS.CreateURLLoaderOptions & ExtraURLLoaderOptions {
-  // eslint-disable-next-line n/no-deprecated-api
-  const options: any = typeof optionsIn === 'string' ? url.parse(optionsIn) : { ...optionsIn };
+  const options: any = typeof optionsIn === 'string' ? parseURLString(optionsIn) : { ...optionsIn };
 
   let urlStr: string = options.url;
 
@@ -260,11 +277,23 @@ function parseOptions (optionsIn: ClientRequestConstructorOptions | string): Nod
       // an invalid request.
       throw new TypeError('Request path contains unescaped characters');
     }
-    // eslint-disable-next-line n/no-deprecated-api
-    const pathObj = url.parse(options.path || '/');
-    urlObj.pathname = pathObj.pathname;
-    urlObj.search = pathObj.search;
-    urlObj.hash = pathObj.hash;
+    const requestPath = options.path || '/';
+    const hashIndex = requestPath.indexOf('#');
+    const searchIndex = requestPath.indexOf('?');
+    const pathEnd = Math.min(
+      searchIndex === -1 ? requestPath.length : searchIndex,
+      hashIndex === -1 ? requestPath.length : hashIndex
+    );
+
+    if (pathEnd > 0) {
+      urlObj.pathname = requestPath.slice(0, pathEnd);
+    }
+    if (searchIndex !== -1) {
+      urlObj.search = requestPath.slice(searchIndex, hashIndex === -1 ? requestPath.length : hashIndex);
+    }
+    if (hashIndex !== -1) {
+      urlObj.hash = requestPath.slice(hashIndex);
+    }
     urlStr = url.format(urlObj);
   }
 

--- a/spec/api-net-spec.ts
+++ b/spec/api-net-spec.ts
@@ -11,6 +11,7 @@ import { setTimeout } from 'node:timers/promises';
 
 import { collectStreamBody, collectStreamBodyBuffer, getResponse, kOneKiloByte, kOneMegaByte, randomBuffer, randomString, respondNTimes, respondOnce } from './lib/net-helpers';
 import { listen, defer, ifdescribe, isTestingBindingAvailable } from './lib/spec-helpers';
+import { expectDeprecationMessages } from './lib/warning-helpers';
 
 const utilityFixturePath = path.resolve(__dirname, 'fixtures', 'api', 'utility-process', 'api-net-spec.js');
 const fixturesPath = path.resolve(__dirname, 'fixtures');
@@ -1536,6 +1537,28 @@ describe('net module', () => {
         expect(() => {
           net.request({ url: 'file://bar' });
         }).to.throw('ClientRequest only supports http: and https: protocols');
+      });
+    });
+
+    describe('deprecation warnings', () => {
+      test('does not emit a warning for request options', async () => {
+        await expectDeprecationMessages(() => {
+          const request = net.request({
+            method: 'POST',
+            hostname: 'google.com',
+            path: '/',
+            port: NaN,
+            protocol: 'https:'
+          });
+          request.abort();
+        });
+      });
+
+      test('does not emit a warning for string URLs', async () => {
+        await expectDeprecationMessages(() => {
+          const request = net.request('https://google.com/');
+          request.abort();
+        });
       });
     });
 


### PR DESCRIPTION
#### Description of Change

Removes deprecated `url.parse()` usage from `net.request` option parsing in `lib/common/api/net-client-request.ts`.

This updates both string URL input handling and request `path` parsing to avoid `DEP0169` warnings while preserving the existing request URL construction behavior, including cases with query strings and fragments.

Also adds regression coverage to ensure `net.request()` does not emit deprecation warnings for either object options or string URL inputs.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are included
- [x] documentation is changed or does not need to be changed

#### Release Notes Notes

```release-note
Fixed a deprecation warning emitted by `net.request()`.
