### PR TITLE
fix: strictly validate sender for internal IPC reply channels

### DIFF
--- a/lib/browser/ipc-main-internal-utils.ts
+++ b/lib/browser/ipc-main-internal-utils.ts
@@ -19,8 +19,8 @@ export function invokeInWebContents<T> (sender: Electron.WebContents, command: s
     const requestId = ++nextId;
     const channel = `${command}_RESPONSE_${requestId}`;
     ipcMainInternal.on(channel, function handler (event, error: Error, result: any) {
-      if (event.type === 'frame' && event.sender !== sender) {
-        console.error(`Reply to ${command} sent by unexpected WebContents (${event.sender.id})`);
+      if (event.type !== 'frame' || event.sender !== sender) {
+        console.error(`Reply to ${command} sent by unexpected sender`);
         return;
       }
 


### PR DESCRIPTION
Manual backport of #50118

See that PR for details

Notes: none