### PR TITLE
chore: cherry-pick 03d405099043 from skia

### DIFF
--- a/patches/config.json
+++ b/patches/config.json
@@ -12,6 +12,6 @@
   { "patch_dir": "src/electron/patches/ReactiveObjC", "repo": "src/third_party/squirrel.mac/vendor/ReactiveObjC" },
   { "patch_dir": "src/electron/patches/webrtc", "repo": "src/third_party/webrtc" },
   { "patch_dir": "src/electron/patches/reclient-configs", "repo": "src/third_party/engflow-reclient-configs" },
-  { "patch_dir": "src/electron/patches/skia", "repo": "src/third_party/skia/src" }
+  { "patch_dir": "src/electron/patches/skia", "repo": "src/third_party/skia/src" },
   { "patch_dir": "src/electron/patches/sqlite", "repo": "src/third_party/sqlite/src" }
 ]

--- a/patches/config.json
+++ b/patches/config.json
@@ -12,5 +12,6 @@
   { "patch_dir": "src/electron/patches/ReactiveObjC", "repo": "src/third_party/squirrel.mac/vendor/ReactiveObjC" },
   { "patch_dir": "src/electron/patches/webrtc", "repo": "src/third_party/webrtc" },
   { "patch_dir": "src/electron/patches/reclient-configs", "repo": "src/third_party/engflow-reclient-configs" },
+  { "patch_dir": "src/electron/patches/skia", "repo": "src/third_party/skia/src" }
   { "patch_dir": "src/electron/patches/sqlite", "repo": "src/third_party/sqlite/src" }
 ]

--- a/patches/skia/.patches
+++ b/patches/skia/.patches
@@ -1,0 +1,1 @@
+cherry-pick-03d405099043.patch

--- a/patches/skia/cherry-pick-03d405099043.patch
+++ b/patches/skia/cherry-pick-03d405099043.patch
@@ -1,0 +1,166 @@
+From 03d405099043409a7925e54d7cfad73a9c5ad8db Mon Sep 17 00:00:00 2001
+From: Michael Ludwig <michaelludwig@google.com>
+Date: Thu, 19 Feb 2026 16:29:16 -0500
+Subject: [PATCH] [ganesh] Guard verb counts in tessellation accumulation against overflow
+
+Rejects adding a path if the total verb count would overflow.
+Rejects merging ops if their total verb counts would overflow.
+Clamps the min allocation size in the GrVertexChunkArray to prevent
+overflow.
+Clamps the preallocation verb count parameter to avoid overflow in their
+intermediate calculations.
+
+Bug: b/484983991
+Change-Id: I32359cf10a996baf46b023a6cb8c608834942e0b
+Reviewed-on: https://skia-review.googlesource.com/c/skia/+/1169977
+Commit-Queue: Michael Ludwig <michaelludwig@google.com>
+Reviewed-by: Thomas Smith <thomsmit@google.com>
+---
+
+diff --git a/src/gpu/ganesh/GrVertexChunkArray.cpp b/src/gpu/ganesh/GrVertexChunkArray.cpp
+index 337e394..3d80581 100644
+--- a/src/gpu/ganesh/GrVertexChunkArray.cpp
++++ b/src/gpu/ganesh/GrVertexChunkArray.cpp
+@@ -10,6 +10,7 @@
+ #include "src/gpu/ganesh/GrMeshDrawTarget.h"
+ 
+ #include <algorithm>
++#include <limits>
+ 
+ GrVertexChunkBuilder::~GrVertexChunkBuilder() {
+     if (!fChunks->empty()) {
+@@ -37,6 +38,12 @@
+         fCurrChunkVertexCapacity = 0;
+         return false;
+     }
+-    fMinVerticesPerChunk *= 2;
++
++    int maxVerticesPerChunk = std::numeric_limits<int>::max() / fStride;
++    if (maxVerticesPerChunk / 2 > fMinVerticesPerChunk) {
++        fMinVerticesPerChunk *= 2;
++    } else {
++        fMinVerticesPerChunk = maxVerticesPerChunk;
++    }
+     return true;
+ }
+diff --git a/src/gpu/ganesh/ops/AtlasRenderTask.cpp b/src/gpu/ganesh/ops/AtlasRenderTask.cpp
+index 5f05079..13b2ff4 100644
+--- a/src/gpu/ganesh/ops/AtlasRenderTask.cpp
++++ b/src/gpu/ganesh/ops/AtlasRenderTask.cpp
+@@ -54,6 +54,17 @@
+     SkASSERT(this->isEmpty());
+     SkASSERT(!fDynamicAtlas->isInstantiated());  // Paths can't be added after instantiate().
+ 
++    // Check for room in the list first and return false if prior draws need to be flushed first.
++    if (GrFillRuleForSkPath(path) == GrFillRule::kNonzero) {
++        if (!fWindingPathList.canAdd(path)) {
++            return false;
++        }
++    } else {
++        if (!fEvenOddPathList.canAdd(path)) {
++            return false;
++        }
++    }
++
+     if (!fDynamicAtlas->addRect(widthInAtlas, heightInAtlas, locationInAtlas)) {
+         return false;
+     }
+diff --git a/src/gpu/ganesh/ops/AtlasRenderTask.h b/src/gpu/ganesh/ops/AtlasRenderTask.h
+index c44b426..de056f1 100644
+--- a/src/gpu/ganesh/ops/AtlasRenderTask.h
++++ b/src/gpu/ganesh/ops/AtlasRenderTask.h
+@@ -22,6 +22,7 @@
+ #include "src/gpu/ganesh/ops/OpsTask.h"
+ #include "src/gpu/ganesh/tessellate/PathTessellator.h"
+ 
++#include <limits>
+ #include <memory>
+ #include <utility>
+ 
+@@ -89,6 +90,7 @@
+     class AtlasPathList : SkNoncopyable {
+     public:
+         void add(PathDrawAllocator* alloc, const SkMatrix& pathMatrix, const SkPath& path) {
++            SkASSERT(this->canAdd(path));
+             fPathDrawList = &alloc->emplace_back(pathMatrix, path, SK_PMColor4fTRANSPARENT,
+                                                  fPathDrawList);
+             if (path.isInverseFillType()) {
+@@ -98,6 +100,12 @@
+             fTotalCombinedPathVerbCnt += path.countVerbs();
+             ++fPathCount;
+         }
++
++        bool canAdd(const SkPath& path) const {
++            // Return true so long as we won't overflow the total verb count
++            return std::numeric_limits<int>::max() - fTotalCombinedPathVerbCnt >= path.countVerbs();
++        }
++
+         const PathDrawList* pathDrawList() const { return fPathDrawList; }
+         int totalCombinedPathVerbCnt() const { return fTotalCombinedPathVerbCnt; }
+         int pathCount() const { return fPathCount; }
+diff --git a/src/gpu/ganesh/ops/PathTessellateOp.cpp b/src/gpu/ganesh/ops/PathTessellateOp.cpp
+index 3bc370f..f879a2e 100644
+--- a/src/gpu/ganesh/ops/PathTessellateOp.cpp
++++ b/src/gpu/ganesh/ops/PathTessellateOp.cpp
+@@ -5,6 +5,7 @@
+  * found in the LICENSE file.
+  */
+ #include "src/gpu/ganesh/ops/PathTessellateOp.h"
++#include <limits>
+ 
+ #include "include/core/SkColor.h"
+ #include "include/gpu/ganesh/GrRecordingContext.h"
+@@ -53,10 +54,13 @@
+                                                               SkArenaAlloc*,
+                                                               const GrCaps&) {
+     auto* op = grOp->cast<PathTessellateOp>();
++    bool verbCountOverflow = std::numeric_limits<int>::max() - fTotalCombinedPathVerbCnt <
++            op->fTotalCombinedPathVerbCnt;
+     bool canMerge = fAAType == op->fAAType &&
+                     fStencil == op->fStencil &&
+                     fProcessors == op->fProcessors &&
+-                    fShaderMatrix == op->fShaderMatrix;
++                    fShaderMatrix == op->fShaderMatrix &&
++                    !verbCountOverflow;
+     if (canMerge) {
+         fTotalCombinedPathVerbCnt += op->fTotalCombinedPathVerbCnt;
+         fPatchAttribs |= op->fPatchAttribs;
+diff --git a/src/gpu/tessellate/FixedCountBufferUtils.h b/src/gpu/tessellate/FixedCountBufferUtils.h
+index f2ab0f4..055f6a0 100644
+--- a/src/gpu/tessellate/FixedCountBufferUtils.h
++++ b/src/gpu/tessellate/FixedCountBufferUtils.h
+@@ -14,6 +14,7 @@
+ #include <algorithm>
+ #include <cstddef>
+ #include <cstdint>
++#include <limits>
+ 
+ namespace skgpu { struct VertexWriter; }
+ 
+@@ -44,6 +45,8 @@
+         // Over-allocate enough curves for 1 in 4 to chop. Every chop introduces 2 new patches:
+         // another curve patch and a triangle patch that glues the two chops together,
+         // i.e. + 2 * ((count + 3) / 4) == (count + 3) / 2
++        constexpr int kMaxVerbCount = std::numeric_limits<int>::max() >> 2;
++        totalCombinedPathVerbCnt = std::min(kMaxVerbCount, totalCombinedPathVerbCnt);
+         return totalCombinedPathVerbCnt + (totalCombinedPathVerbCnt + 3) / 2;
+     }
+ 
+@@ -88,6 +91,8 @@
+ 
+     static constexpr int PreallocCount(int totalCombinedPathVerbCnt)  {
+         // Over-allocate enough wedges for 1 in 4 to chop, i.e., ceil(maxWedges * 5/4)
++        constexpr int kMaxVerbCount = std::numeric_limits<int>::max() >> 3;
++        totalCombinedPathVerbCnt = std::min(kMaxVerbCount, totalCombinedPathVerbCnt);
+         return (totalCombinedPathVerbCnt * 5 + 3) / 4;
+     }
+ 
+@@ -140,6 +145,8 @@
+         // Over-allocate enough patches for each stroke to chop once, and for 8 extra caps. Since
+         // we have to chop at inflections, points of 180 degree rotation, and anywhere a stroke
+         // requires too many parametric segments, many strokes will end up getting choppped.
++        constexpr int kMaxVerbCount = std::numeric_limits<int>::max() >> 2;
++        totalCombinedPathVerbCnt = std::min(kMaxVerbCount, totalCombinedPathVerbCnt);
+         return (totalCombinedPathVerbCnt * 2) + 8/* caps */;
+     }
+ 


### PR DESCRIPTION
[ganesh] Guard verb counts in tessellation accumulation against overflow

Rejects adding a path if the total verb count would overflow.
Rejects merging ops if their total verb counts would overflow.
Clamps the min allocation size in the GrVertexChunkArray to prevent
overflow.
Clamps the preallocation verb count parameter to avoid overflow in their
intermediate calculations.

Bug: b/484983991
Change-Id: I32359cf10a996baf46b023a6cb8c608834942e0b
Reviewed-on: https://skia-review.googlesource.com/c/skia/+/1169977
Commit-Queue: Michael Ludwig <michaelludwig@google.com>
Reviewed-by: Thomas Smith <thomsmit@google.com>


Notes: Backported fix for b/484983991.