### PR TITLE
chore: cherry-pick a08731cf6d70 from angle

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -1,0 +1,1 @@
+cherry-pick-a08731cf6d70.patch

--- a/patches/angle/cherry-pick-a08731cf6d70.patch
+++ b/patches/angle/cherry-pick-a08731cf6d70.patch
@@ -1,0 +1,240 @@
+From a08731cf6d70c60fd74b1d75f2e8b94c52e18140 Mon Sep 17 00:00:00 2001
+From: Shahbaz Youssefi <syoussefi@chromium.org>
+Date: Thu, 19 Feb 2026 14:42:08 -0500
+Subject: [PATCH] Vulkan: Avoid overflow in texture size calculation
+
+Bug: chromium:485622239
+Change-Id: Idf9847afa0aa2e72b6433ac8348ae2820c1ad8c5
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/7595734
+Reviewed-by: Amirali Abdolrashidi <abdolrashidi@google.com>
+Commit-Queue: Shahbaz Youssefi <syoussefi@chromium.org>
+---
+
+diff --git a/src/libANGLE/renderer/vulkan/TextureVk.cpp b/src/libANGLE/renderer/vulkan/TextureVk.cpp
+index 9e208f9..e2185a4 100644
+--- a/src/libANGLE/renderer/vulkan/TextureVk.cpp
++++ b/src/libANGLE/renderer/vulkan/TextureVk.cpp
+@@ -3164,8 +3164,17 @@
+         // invalidate must be called after wait for finish.
+         ANGLE_TRY(srcBuffer->invalidate(renderer));
+ 
+-        size_t dstBufferSize = sourceBox.width * sourceBox.height * sourceBox.depth *
+-                               dstFormat.pixelBytes * layerCount;
++        // Use size_t calculations to avoid 32-bit overflows.  Note that the dimensions are bound by
++        // the maximums specified in Constants.h, and that gl::Box members are signed 32-bit
++        // integers.
++        static_assert(gl::IMPLEMENTATION_MAX_2D_TEXTURE_SIZE *
++                          gl::IMPLEMENTATION_MAX_2D_TEXTURE_SIZE <
++                      std::numeric_limits<int32_t>::max());
++        size_t dstBufferSize = sourceBox.width * sourceBox.height;
++        static_assert(gl::IMPLEMENTATION_MAX_3D_TEXTURE_SIZE *
++                          gl::IMPLEMENTATION_MAX_2D_ARRAY_TEXTURE_LAYERS * 16 <
++                      std::numeric_limits<int32_t>::max());
++        dstBufferSize *= sourceBox.depth * dstFormat.pixelBytes * layerCount;
+ 
+         // Allocate memory in the destination texture for the copy/conversion.
+         uint8_t *dstData = nullptr;
+diff --git a/src/tests/gl_tests/FramebufferTest.cpp b/src/tests/gl_tests/FramebufferTest.cpp
+index 020a041..f72f1a7 100644
+--- a/src/tests/gl_tests/FramebufferTest.cpp
++++ b/src/tests/gl_tests/FramebufferTest.cpp
+@@ -8894,6 +8894,62 @@
+     ASSERT_GL_NO_ERROR();
+ }
+ 
++// Test that 2D array texture size calculation doesn't overflow internally when rendering to it.  An
++// RGB format is used which is often emualted with RGBA.
++//
++// Practically we cannot run this test.  On most configurations, allocating a 4GB texture fails due
++// to internal driver limitations.  On the few configs that the test actually runs, allocating such
++// large memory leads to instability.
++TEST_P(FramebufferTest_ES3, DISABLED_MaxSize2DArrayNoOverflow)
++{
++    GLint maxTexture2DSize;
++    glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTexture2DSize);
++
++    maxTexture2DSize = std::min(maxTexture2DSize, 16384);
++
++    // Create a 2D array texture with RGB format.  Every layer is going to take 1GB of memory (if
++    // emulated with RGBA), so only create 4 layers of it (for a total of 4GB of memory).  If 32-bit
++    // math is involved when calculating sizes related to this texture, they will overflow.
++    constexpr uint32_t kLayers = 4;
++    GLTexture tex;
++    glBindTexture(GL_TEXTURE_2D_ARRAY, tex);
++    glTexStorage3D(GL_TEXTURE_2D_ARRAY, 1, GL_RGB8, maxTexture2DSize, maxTexture2DSize, kLayers);
++    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
++    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
++
++    // Initialize the texture so its content is considered valid and worth preserving.
++    constexpr int kValidSubsectionWidth  = 16;
++    constexpr int kValidSubsectionHeight = 20;
++    std::vector<GLColorRGB> data(kValidSubsectionWidth * kValidSubsectionHeight,
++                                 GLColorRGB(0, 255, 0));
++    for (uint32_t layer = 0; layer < kLayers; ++layer)
++    {
++        glTexSubImage3D(GL_TEXTURE_2D_ARRAY, 0, 0, 0, layer, kValidSubsectionWidth,
++                        kValidSubsectionHeight, 1, GL_RGB, GL_UNSIGNED_BYTE, data.data());
++    }
++
++    // Draw with the texture, making sure it's initialized and data is flushed.
++    ANGLE_GL_PROGRAM(drawTex2DArray, essl3_shaders::vs::Texture2DArray(),
++                     essl3_shaders::fs::Texture2DArray());
++    drawQuad(drawTex2DArray, essl3_shaders::PositionAttrib(), 0.5f);
++
++    // Bind a framebuffer to the texture and render into it.  In some backends, the texture is
++    // recreated to RGBA to be renderable.
++    GLFramebuffer fbo;
++    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
++    glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, tex, 0, 1);
++
++    ANGLE_GL_PROGRAM(drawRed, essl1_shaders::vs::Simple(), essl1_shaders::fs::Red());
++    glViewport(0, 0, kValidSubsectionWidth / 2, kValidSubsectionHeight);
++    drawQuad(drawRed, essl1_shaders::PositionAttrib(), 0.5f);
++
++    EXPECT_PIXEL_RECT_EQ(0, 0, kValidSubsectionWidth / 2, kValidSubsectionHeight, GLColor::red);
++    EXPECT_PIXEL_RECT_EQ(kValidSubsectionWidth / 2, 0,
++                         kValidSubsectionWidth - kValidSubsectionWidth / 2, kValidSubsectionHeight,
++                         GLColor::green);
++    ASSERT_GL_NO_ERROR();
++}
++
+ ANGLE_INSTANTIATE_TEST_ES2_AND(AddMockTextureNoRenderTargetTest,
+                                ES2_D3D9().enable(Feature::AddMockTextureNoRenderTarget),
+                                ES2_D3D11().enable(Feature::AddMockTextureNoRenderTarget));
+diff --git a/src/tests/gl_tests/VulkanImageTest.cpp b/src/tests/gl_tests/VulkanImageTest.cpp
+index 2f06e2d..87e7482 100644
+--- a/src/tests/gl_tests/VulkanImageTest.cpp
++++ b/src/tests/gl_tests/VulkanImageTest.cpp
+@@ -677,8 +677,8 @@
+                         kTextureHeight, 1, GL_RGBA, GL_UNSIGNED_BYTE, textureColor.data());
+     }
+ 
+-    ANGLE_GL_PROGRAM(drawTex2DArray, essl1_shaders::vs::Texture2DArray(),
+-                     essl1_shaders::fs::Texture2DArray());
++    ANGLE_GL_PROGRAM(drawTex2DArray, essl3_shaders::vs::Texture2DArray(),
++                     essl3_shaders::fs::Texture2DArray());
+     drawQuad(drawTex2DArray, essl1_shaders::PositionAttrib(), 0.5f);
+ 
+     // Fill up the device memory until we start allocating on the system memory.
+diff --git a/util/shader_utils.cpp b/util/shader_utils.cpp
+index 275e261..8994612 100644
+--- a/util/shader_utils.cpp
++++ b/util/shader_utils.cpp
+@@ -580,18 +580,6 @@
+ })";
+ }
+ 
+-const char *Texture2DArray()
+-{
+-    return R"(#version 300 es
+-out vec2 v_texCoord;
+-in vec4 a_position;
+-void main()
+-{
+-    gl_Position = vec4(a_position.xy, 0.0, 1.0);
+-    v_texCoord = (a_position.xy * 0.5) + 0.5;
+-})";
+-}
+-
+ }  // namespace vs
+ 
+ namespace fs
+@@ -689,20 +677,6 @@
+ })";
+ }
+ 
+-const char *Texture2DArray()
+-{
+-    return R"(#version 300 es
+-precision highp float;
+-uniform highp sampler2DArray tex2DArray;
+-uniform int slice;
+-in vec2 v_texCoord;
+-out vec4 fragColor;
+-void main()
+-{
+-    fragColor = texture(tex2DArray, vec3(v_texCoord, float(slice)));
+-})";
+-}
+-
+ }  // namespace fs
+ }  // namespace essl1_shaders
+ 
+@@ -787,6 +761,18 @@
+ })";
+ }
+ 
++const char *Texture2DArray()
++{
++    return R"(#version 300 es
++out vec2 v_texCoord;
++in vec4 a_position;
++void main()
++{
++    gl_Position = vec4(a_position.xy, 0.0, 1.0);
++    v_texCoord = (a_position.xy * 0.5) + 0.5;
++})";
++}
++
+ }  // namespace vs
+ 
+ namespace fs
+@@ -844,6 +830,20 @@
+ })";
+ }
+ 
++const char *Texture2DArray()
++{
++    return R"(#version 300 es
++precision highp float;
++uniform highp sampler2DArray tex2DArray;
++uniform int slice;
++in vec2 v_texCoord;
++out vec4 fragColor;
++void main()
++{
++    fragColor = texture(tex2DArray, vec3(v_texCoord, float(slice)));
++})";
++}
++
+ }  // namespace fs
+ }  // namespace essl3_shaders
+ 
+diff --git a/util/shader_utils.h b/util/shader_utils.h
+index 676341e..cf211cf 100644
+--- a/util/shader_utils.h
++++ b/util/shader_utils.h
+@@ -90,7 +90,6 @@
+ // A shader that simply passes through attribute a_position, setting it to gl_Position and varying
+ // texcoord.
+ ANGLE_UTIL_EXPORT const char *Texture2D();
+-ANGLE_UTIL_EXPORT const char *Texture2DArray();
+ 
+ }  // namespace vs
+ 
+@@ -120,7 +119,6 @@
+ 
+ // A shader that samples the texture
+ ANGLE_UTIL_EXPORT const char *Texture2D();
+-ANGLE_UTIL_EXPORT const char *Texture2DArray();
+ 
+ }  // namespace fs
+ }  // namespace essl1_shaders
+@@ -151,6 +149,7 @@
+ // A shader that simply passes through attribute a_position, setting it to gl_Position and varying
+ // texcoord.
+ ANGLE_UTIL_EXPORT const char *Texture2DLod();
++ANGLE_UTIL_EXPORT const char *Texture2DArray();
+ 
+ }  // namespace vs
+ 
+@@ -169,6 +168,9 @@
+ // A shader that samples the texture at a given lod.
+ ANGLE_UTIL_EXPORT const char *Texture2DLod();
+ 
++// A shader that samples the texture at a given slice.
++ANGLE_UTIL_EXPORT const char *Texture2DArray();
++
+ }  // namespace fs
+ }  // namespace essl3_shaders
+ 


### PR DESCRIPTION
Vulkan: Avoid overflow in texture size calculation

Bug: chromium:485622239
Change-Id: Idf9847afa0aa2e72b6433ac8348ae2820c1ad8c5
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/7595734
Reviewed-by: Amirali Abdolrashidi <abdolrashidi@google.com>
Commit-Queue: Shahbaz Youssefi <syoussefi@chromium.org>


Notes: Backported fix for chromium:485622239.