### PR TITLE
docs: fix ipc highlight lines

### DIFF
--- a/docs/tutorial/ipc.md
+++ b/docs/tutorial/ipc.md
@@ -50,7 +50,7 @@ sections.
 
 In the main process, set an IPC listener on the `set-title` channel with the `ipcMain.on` API:
 
-```js {6-10,22} title='main.js (Main Process)'
+```js {7-11,23} title='main.js (Main Process)'
 const { app, BrowserWindow, ipcMain } = require('electron')
 
 const path = require('node:path')


### PR DESCRIPTION
#### Description of Change

ref https://github.com/electron/website/pull/1028

Fixes the highlight blocks in Docusaurus. cc @electron/docs

#### Checklist

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none