### PR TITLE
ci: add timeout to test step

### DIFF
--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -214,6 +214,7 @@ jobs:
 
     - name: Run Electron Tests
       shell: bash
+      timeout-minutes: 40
       env:
         MOCHA_REPORTER: mocha-multi-reporters
         MOCHA_MULTI_REPORTERS: mocha-junit-reporter, tap
@@ -283,6 +284,19 @@ jobs:
             
           fi
         fi
+    - name: Take screenshot on timeout or cancellation
+      if: ${{ inputs.target-platform != 'linux' && (cancelled() || failure()) }}
+      shell: bash
+      run: |
+        screenshot_dir="src/electron/spec/artifacts"
+        mkdir -p "$screenshot_dir"
+        screenshot_file="$screenshot_dir/screenshot-timeout-$(date +%Y%m%d%H%M%S).png"
+        if [ "${{ inputs.target-platform }}" = "macos" ]; then
+          screencapture -x "$screenshot_file" || true
+        elif [ "${{ inputs.target-platform }}" = "win" ]; then
+          powershell -command "Add-Type -AssemblyName System.Windows.Forms; \$screen = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds; \$bitmap = New-Object System.Drawing.Bitmap(\$screen.Width, \$screen.Height); \$graphics = [System.Drawing.Graphics]::FromImage(\$bitmap); \$graphics.CopyFromScreen(\$screen.Location, [System.Drawing.Point]::Empty, \$screen.Size); \$bitmap.Save('$screenshot_file')" || true
+        fi
+
     - name: Upload Test results to Datadog
       env:
         DD_ENV: ci
@@ -298,7 +312,7 @@ jobs:
         fi
       if: always() && !cancelled()
     - name: Upload Test Artifacts
-      if: always() && !cancelled()
+      if: always()
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
       with:
         name: ${{ inputs.target-platform == 'linux' && format('test_artifacts_{0}_{1}_{2}', env.ARTIFACT_KEY, inputs.display-server, matrix.shard) || format('test_artifacts_{0}_{1}', env.ARTIFACT_KEY, matrix.shard) }}


### PR DESCRIPTION

#### Description of Change

This PR adds a timeout to the test step since it appears to sometimes hang on Windows.  Additionally, take a screenshot on timeout so that we can debug why there is a hang

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
