### PR TITLE
docs: document Wayland frameless window shadow behaviour

### DIFF
--- a/docs/tutorial/custom-window-styles.md
+++ b/docs/tutorial/custom-window-styles.md
@@ -12,6 +12,10 @@ To create a frameless window, set the [`BaseWindowContructorOptions`][] `frame`
 
 ```
 
+On Wayland (Linux), frameless windows have GTK drop shadows and extended
+resize boundaries by default. To create a fully frameless window with no
+decorations, set `hasShadow: false` in the window constructor options.
+
 ## Transparent windows
 
 ![Transparent Window](../images/transparent-window.png)


### PR DESCRIPTION
#### Description of Change

This change documents the new Wayland behavior where frameless windows have GTK drop shadows and extended resize boundaries by default (https://github.com/electron/electron/pull/49295)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] I have built and tested this PR
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
