### PR TITLE
docs: add API history (G-I)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,7 @@ gh label list --repo electron/electron --search target/ --json name,color --jq '
 ```bash
 npm run lint              # Run all linters
 npm run lint:clang-format # C++ formatting
+npm run lint:api-history  # Validate API history YAML blocks in docs
 ```
 
 ## Key Files

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,58 @@
+# Electron Documentation Guide
+
+## API History Migration
+
+Guide: `docs/development/api-history-migration-guide.md`
+Style rules: `docs/development/style-guide.md` (see "API History" section)
+Schema: `docs/api-history.schema.json`
+Lint: `npm run lint:api-history`
+
+### Format
+
+Place YAML history block directly after the Markdown header, before parameters:
+
+````md
+### `module.method(args)`
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/XXXXX
+```
+-->
+
+* `arg` type - Description.
+````
+
+### Finding when an API was added
+
+- `git log --all --reverse --oneline -S "methodName" -- docs/api/file.md` — find first commit adding a method name
+- `git log --reverse -L :FunctionName:path/to/source.cc` — trace C++ implementation history
+- `git log --grep="keyword" --oneline` — find merge commits referencing PRs
+- `gh pr view <number> --repo electron/electron --json baseRefName` — verify PR targets main (not a backport)
+- Always use the main-branch PR URL in history blocks, not backport PRs
+
+### Cross-referencing breaking changes
+
+- Search `docs/breaking-changes.md` for the API name to find deprecations/removals
+- Use `git blame` on the breaking-changes entry to find the associated PR
+- Add `breaking-changes-header` field using the heading ID from breaking-changes.md
+
+### Placement rules
+
+- Only add blocks to actual API entries (methods, events, properties with backtick signatures)
+- Do NOT add blocks to section headers like `## Methods`, `### Instance Methods`, `## Events`
+- Module-level blocks go after the `# moduleName` heading, before the module description quote
+- For changes affecting multiple APIs, add a block under each affected top-level heading (see style guide "Change affecting multiple APIs")
+
+### Key details
+
+- `added` and `deprecated` arrays have `maxItems: 1`; `changes` can have multiple items
+- `changes` entries require a `description` field; `added`/`deprecated` do not
+- Wrap descriptions in double quotes to avoid YAML parsing issues with special characters
+- Early Electron APIs (pre-2015) use merge-commit PRs (e.g., `Merge pull request #534`)
+- Very early APIs (2013-2014, e.g., `ipcMain.on`, `ipcRenderer.send`) predate GitHub PRs — skip history blocks for these
+- When multiple APIs were added in the same PR, they all reference the same PR URL
+- Promisification PRs (e.g., #17355) count as `changes` entries with a description
+  - These PRs are breaking changes and should have their notes as "This method now returns a Promise instead of using a callback function."
+- APIs that were deprecated and then removed from docs don't need history blocks (the removal is in `breaking-changes.md`)

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -55,6 +55,13 @@ The `globalShortcut` module has the following methods:
 
 ### `globalShortcut.register(accelerator, callback)`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/534
+```
+-->
+
 * `accelerator` string - An [accelerator](../tutorial/keyboard-shortcuts.md#accelerators) shortcut.
 * `callback` Function
 
@@ -77,6 +84,13 @@ the app has been authorized as a [trusted accessibility client](https://develope
 
 ### `globalShortcut.registerAll(accelerators, callback)`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/15542
+```
+-->
+
 * `accelerators` string[] - An array of [accelerator](../tutorial/keyboard-shortcuts.md#accelerators) shortcuts.
 * `callback` Function
 
@@ -96,6 +110,13 @@ the app has been authorized as a [trusted accessibility client](https://develope
 
 ### `globalShortcut.isRegistered(accelerator)`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/534
+```
+-->
+
 * `accelerator` string - An [accelerator](../tutorial/keyboard-shortcuts.md#accelerators) shortcut.
 
 Returns `boolean` - Whether this application has registered `accelerator`.
@@ -106,10 +127,24 @@ don't want applications to fight for global shortcuts.
 
 ### `globalShortcut.unregister(accelerator)`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/534
+```
+-->
+
 * `accelerator` string - An [accelerator](../tutorial/keyboard-shortcuts.md#accelerators) shortcut.
 
 Unregisters the global shortcut of `accelerator`.
 
 ### `globalShortcut.unregisterAll()`
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/534
+```
+-->
 
 Unregisters all of the global shortcuts.

--- a/docs/api/image-view.md
+++ b/docs/api/image-view.md
@@ -35,6 +35,13 @@ webContentsView.webContents.loadURL('https://electronjs.org')
 
 ## Class: ImageView extends `View`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/46760
+```
+-->
+
 > A View that displays an image.
 
 Process: [Main](../glossary.md#main-process)
@@ -49,6 +56,13 @@ Process: [Main](../glossary.md#main-process)
 
 ### `new ImageView()` _Experimental_
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/46760
+```
+-->
+
 Creates an ImageView.
 
 ### Instance Methods
@@ -57,6 +71,13 @@ The following methods are available on instances of the `ImageView` class, in
 addition to those inherited from [View](view.md):
 
 #### `image.setImage(image)` _Experimental_
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/46760
+```
+-->
 
 * `image` NativeImage
 

--- a/docs/api/in-app-purchase.md
+++ b/docs/api/in-app-purchase.md
@@ -1,5 +1,12 @@
 # inAppPurchase
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/11292
+```
+-->
+
 > In-app purchases on Mac App Store.
 
 Process: [Main](../glossary.md#main-process)
@@ -9,6 +16,13 @@ Process: [Main](../glossary.md#main-process)
 The `inAppPurchase` module emits the following events:
 
 ### Event: 'transactions-updated'
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/11292
+```
+-->
 
 Returns:
 
@@ -23,6 +37,19 @@ The `inAppPurchase` module has the following methods:
 
 ### `inAppPurchase.purchaseProduct(productID[, opts])`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/11292
+changes:
+  - pr-url: https://github.com/electron/electron/pull/17355
+    description: "This method now returns a Promise instead of using a callback function."
+    breaking-changes-header: api-changed-callback-based-versions-of-promisified-apis
+  - pr-url: https://github.com/electron/electron/pull/35902
+    description: "Added `username` option to `opts` parameter."
+```
+-->
+
 * `productID` string
 * `opts` Integer | Object (optional) - If specified as an integer, defines the quantity.
   * `quantity` Integer (optional) - The number of items the user wants to purchase.
@@ -34,6 +61,17 @@ You should listen for the `transactions-updated` event as soon as possible and c
 
 ### `inAppPurchase.getProducts(productIDs)`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/12464
+changes:
+  - pr-url: https://github.com/electron/electron/pull/17355
+    description: "This method now returns a Promise instead of using a callback function."
+    breaking-changes-header: api-changed-callback-based-versions-of-promisified-apis
+```
+-->
+
 * `productIDs` string[] - The identifiers of the products to get.
 
 Returns `Promise<Product[]>` - Resolves with an array of [`Product`](structures/product.md) objects.
@@ -42,9 +80,23 @@ Retrieves the product descriptions.
 
 ### `inAppPurchase.canMakePayments()`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/11292
+```
+-->
+
 Returns `boolean` - whether a user can make a payment.
 
 ### `inAppPurchase.restoreCompletedTransactions()`
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/21461
+```
+-->
 
 Restores finished transactions. This method can be called either to install purchases on additional devices, or to restore purchases for an application that the user deleted and reinstalled.
 
@@ -52,13 +104,34 @@ Restores finished transactions. This method can be called either to install purc
 
 ### `inAppPurchase.getReceiptURL()`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/11292
+```
+-->
+
 Returns `string` - the path to the receipt.
 
 ### `inAppPurchase.finishAllTransactions()`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/12464
+```
+-->
+
 Completes all pending transactions.
 
 ### `inAppPurchase.finishTransactionByDate(date)`
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/12464
+```
+-->
 
 * `date` string - The ISO formatted date of the transaction to finish.
 

--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -46,6 +46,13 @@ Listens to `channel`, when a new message arrives `listener` would be called with
 
 ### `ipcMain.off(channel, listener)`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/44651
+```
+-->
+
 * `channel` string
 * `listener` Function
   * `event` [IpcMainEvent][ipc-main-event]
@@ -89,6 +96,13 @@ Removes all listeners from the specified `channel`. Removes all listeners from a
 
 ### `ipcMain.handle(channel, listener)`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/18449
+```
+-->
+
 * `channel` string
 * `listener` Function\<Promise\<any\> | any\>
   * `event` [IpcMainInvokeEvent][ipc-main-invoke-event]
@@ -126,6 +140,13 @@ provided to the renderer process. Please refer to
 
 ### `ipcMain.handleOnce(channel, listener)`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/18449
+```
+-->
+
 * `channel` string
 * `listener` Function\<Promise\<any\> | any\>
   * `event` [IpcMainInvokeEvent][ipc-main-invoke-event]
@@ -135,6 +156,13 @@ Handles a single `invoke`able IPC message, then removes the listener. See
 `ipcMain.handle(channel, listener)`.
 
 ### `ipcMain.removeHandler(channel)`
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/18449
+```
+-->
 
 * `channel` string
 

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -59,6 +59,13 @@ for more info.
 
 ### `ipcRenderer.off(channel, listener)`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/39816
+```
+-->
+
 * `channel` string
 * `listener` Function
   * `event` [IpcRendererEvent][ipc-renderer-event]
@@ -78,6 +85,13 @@ Adds a one time `listener` function for the event. This `listener` is invoked
 only the next time a message is sent to `channel`, after which it is removed.
 
 ### `ipcRenderer.addListener(channel, listener)`
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/39816
+```
+-->
 
 * `channel` string
 * `listener` Function
@@ -128,6 +142,13 @@ If you need to transfer a [`MessagePort`][] to the main process, use [`ipcRender
 If you want to receive a single response from the main process, like the result of a method call, consider using [`ipcRenderer.invoke`](#ipcrendererinvokechannel-args).
 
 ### `ipcRenderer.invoke(channel, ...args)`
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/18449
+```
+-->
 
 * `channel` string
 * `...args` any[]
@@ -208,6 +229,13 @@ and replies by setting `event.returnValue`.
 > [`invoke()`](./ipc-renderer.md#ipcrendererinvokechannel-args).
 
 ### `ipcRenderer.postMessage(channel, message, [transfer])`
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/22404
+```
+-->
 
 * `channel` string
 * `message` any

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -78,6 +78,7 @@ auto_filenames = {
     "docs/api/web-utils.md",
     "docs/api/webview-tag.md",
     "docs/api/window-open.md",
+    "docs/api/structures/activation-arguments.md",
     "docs/api/structures/base-window-options.md",
     "docs/api/structures/bluetooth-device.md",
     "docs/api/structures/browser-window-options.md",


### PR DESCRIPTION
#### Description of Change

Doing a few of these at a time. This time, I've created a `docs/CLAUDE.md` that structures out how to perform these rote operations.

This PR was AI-generated (as were the previous ones), but info was manually validated on my end by clicking on all individual PRs listed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
