### PR TITLE
docs: note Linux performance for getApplicationNameForProtocol

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -878,6 +878,11 @@ Returns `string` - Name of the application handling the protocol, or an empty
 This method returns the application name of the default handler for the protocol
 (aka URI scheme) of a URL.
 
+> [!NOTE]
+> On Linux, this method can be noticeably slower than on macOS and Windows.
+> If you need to call it repeatedly, cache the result instead of querying it on
+> every use.
+
 ### `app.getApplicationInfoForProtocol(url)` _macOS_ _Windows_
 
 * `url` string - a URL with the protocol name to check. Unlike the other


### PR DESCRIPTION
#### Description of Change

Adds a note to `app.getApplicationNameForProtocol()` documentation explaining that the API can be noticeably slower on Linux than on macOS and Windows.

The note also recommends caching the result when the API is called repeatedly.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are included
- [x] documentation is changed or does not need to be changed

#### Release Notes Notes

```release-note
Updated the `app.getApplicationNameForProtocol()` documentation to note Linux performance characteristics.
