### PR TITLE
fix: use uppercase trace event phases for perfetto compatibility

### DIFF
--- a/patches/node/build_enable_perfetto.patch
+++ b/patches/node/build_enable_perfetto.patch
@@ -63,6 +63,31 @@ index f8b4fd7c4ca5a0907806c7e804de8c951675a36a..209e3bcf8be5a23ac528dcd673bed82c
  }
  
  function ipToInt(ip) {
+diff --git a/lib/internal/trace_events_async_hooks.js b/lib/internal/trace_events_async_hooks.js
+index a9f517ffc9e4eea5bc68997ffadc85d43dde2a52..d3db6bf119a6bb9cea1d069957f89cc7f99512b7 100644
+--- a/lib/internal/trace_events_async_hooks.js
++++ b/lib/internal/trace_events_async_hooks.js
+@@ -11,15 +11,13 @@ const { trace } = internalBinding('trace_events');
+ const async_wrap = internalBinding('async_wrap');
+ const async_hooks = require('async_hooks');
+ const {
+-  CHAR_LOWERCASE_B,
+-  CHAR_LOWERCASE_E,
++  CHAR_UPPERCASE_B,
++  CHAR_UPPERCASE_E,
+ } = require('internal/constants');
+ 
+-// Use small letters such that chrome://tracing groups by the name.
+-// The behavior is not only useful but the same as the events emitted using
+-// the specific C++ macros.
+-const kBeforeEvent = CHAR_LOWERCASE_B;
+-const kEndEvent = CHAR_LOWERCASE_E;
++// See v8/src/builtins/builtins-trace.cc - must be uppercase for perfetto
++const kBeforeEvent = CHAR_UPPERCASE_B;
++const kEndEvent = CHAR_UPPERCASE_E;
+ const kTraceEventCategory = 'node,node.async_hooks';
+ 
+ const kEnabled = Symbol('enabled');
 diff --git a/node.gyp b/node.gyp
 index f5cd416b5fe7a51084bc4af9a4427a8e62599fd8..5eb70ce3820f2b82121bc102c5182ab768cbef36 100644
 --- a/node.gyp

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -567,14 +567,7 @@ describe('command line switches', () => {
     });
 
     it('creates startup trace', async () => {
-      // node.async_hooks relies on %trace builtin to log trace points from JS
-      // https://github.com/nodejs/node/blob/8b199eef3dd4de910a6521adc42ae611a62a19e1/lib/internal/trace_events_async_hooks.js#L48-L53
-      // The phase event arg TRACE_EVENT_PHASE_NESTABLE_ASYNC_(BEGIN | END) is not supported in v8_use_perfetto mode
-      // https://source.chromium.org/chromium/chromium/src/+/main:v8/src/builtins/builtins-trace.cc;l=201-216
-      // and leads to the following error: TypeError: Trace event phase must be a number.
-      // TODO: Identify why the error started appearing with roll https://github.com/electron/electron/pull/47561
-      // given both v8_use_perfetto has been enabled before the roll and builtins-trace macro hasn't changed.
-      const rc = await startRemoteControlApp(['--trace-startup="*,-node.async_hooks"', `--trace-startup-file=${outputFilePath}`, '--trace-startup-duration=1', '--enable-logging']);
+      const rc = await startRemoteControlApp(['--trace-startup=*', `--trace-startup-file=${outputFilePath}`, '--trace-startup-duration=1', '--enable-logging']);
       const stderrComplete = new Promise<string>(resolve => {
         let stderr = '';
         rc.process.stderr!.on('data', (chunk) => {


### PR DESCRIPTION
#### Description of Change

Fixes #50124

Node.js's `trace_events_async_hooks.js` uses lowercase phase characters ('b'/'e' for `NESTABLE_ASYNC_BEGIN/END`) when calling V8's trace builtin. In perfetto mode, V8's `builtins-trace.cc` only handles uppercase phases ('B'/'E'/'I'), causing a "Trace event phase must be a number" TypeError that breaks utility process startup when `contentTracing` is active.

This was already fixed for `lib/internal/http.js` in the existing build_enable_perfetto` patch but `trace_events_async_hooks.js` was missed.

Also fixes the `--trace-startup` spec.

Tested with https://gist.github.com/b0915eb5b25cb26d9c524e12eefede0a

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a bug where contentTracing could break utility process startup.