### PR TITLE
chore: cherry-pick 0cab3e4ee34b from skia

### DIFF
--- a/patches/skia/.patches
+++ b/patches/skia/.patches
@@ -1,2 +1,3 @@
 graphite_add_insertstatus_koutoforderrecording.patch
 cherry-pick-03d405099043.patch
+cherry-pick-0cab3e4ee34b.patch

--- a/patches/skia/cherry-pick-0cab3e4ee34b.patch
+++ b/patches/skia/cherry-pick-0cab3e4ee34b.patch
@@ -1,0 +1,663 @@
+From 0cab3e4ee34b3bca6ba7df676639d73ffe4b2135 Mon Sep 17 00:00:00 2001
+From: Greg Daniel <egdaniel@google.com>
+Date: Tue, 10 Mar 2026 16:22:54 -0400
+Subject: [PATCH] Make sure we are getting the correct atlas for glyph mask format.
+
+Bug: b/491421267
+Change-Id: I4eacd46599eca2df8c10a3fc894b9ce890fae1e2
+Reviewed-on: https://skia-review.googlesource.com/c/skia/+/1184076
+Commit-Queue: Greg Daniel <egdaniel@google.com>
+Reviewed-by: Michael Ludwig <michaelludwig@google.com>
+---
+
+diff --git a/bench/GlyphQuadFillBench.cpp b/bench/GlyphQuadFillBench.cpp
+index c478602..b926c6f 100644
+--- a/bench/GlyphQuadFillBench.cpp
++++ b/bench/GlyphQuadFillBench.cpp
+@@ -73,7 +73,7 @@
+                 sktext::gpu::TextBlobTools::FirstSubRun(fBlob.get());
+         SkASSERT_RELEASE(subRun);
+         if (!subRun->glyphVector().hasBackendData()) {
+-            subRun->glyphVector().initBackendData<GlyphData>(&fCache);
++            subRun->glyphVector().initBackendData<GlyphData>(&fCache, subRun->maskFormat());
+         }
+         const auto& glyphData = subRun->glyphVector().accessBackendData<GlyphData>();
+         fVertices.reset(new char[glyphData.vertexStride(subRun->maskFormat(), drawMatrix) *
+diff --git a/gn/tests.gni b/gn/tests.gni
+index 902f44c..ba21a70 100644
+--- a/gn/tests.gni
++++ b/gn/tests.gni
+@@ -437,6 +437,7 @@
+ ganesh_tests_sources = [
+   "$_tests/AdvancedBlendTest.cpp",
+   "$_tests/ApplyGammaTest.cpp",
++  "$_tests/AtlasOobTest.cpp",
+   "$_tests/BackendAllocationTest.cpp",
+   "$_tests/BackendSurfaceMutableStateTest.cpp",
+   "$_tests/BlendTest.cpp",
+diff --git a/src/gpu/ganesh/ops/AtlasTextOp.cpp b/src/gpu/ganesh/ops/AtlasTextOp.cpp
+index eee7f52..26d10a4 100644
+--- a/src/gpu/ganesh/ops/AtlasTextOp.cpp
++++ b/src/gpu/ganesh/ops/AtlasTextOp.cpp
+@@ -538,7 +538,7 @@
+         const sktext::gpu::AtlasSubRun& subRun = geo->fSubRun;
+ 
+         if (!subRun.glyphVector().hasBackendData()) {
+-            subRun.glyphVector().initBackendData<GlyphData>(target->strikeCache());
++            subRun.glyphVector().initBackendData<GlyphData>(target->strikeCache(), maskFormat);
+         }
+ 
+         auto& glyphData = subRun.glyphVector().accessBackendData<GlyphData>();
+diff --git a/src/gpu/ganesh/text/GlyphData.cpp b/src/gpu/ganesh/text/GlyphData.cpp
+index c1416af..503ac353 100644
+--- a/src/gpu/ganesh/text/GlyphData.cpp
++++ b/src/gpu/ganesh/text/GlyphData.cpp
+@@ -171,7 +171,9 @@
+ 
+ GlyphData::~GlyphData() = default;
+ 
+-Glyph GlyphData::makeGlyphFromID(SkPackedGlyphID id) { return Glyph{fTextStrike->getGlyph(id)}; }
++Glyph GlyphData::makeGlyphFromID(SkPackedGlyphID id, MaskFormat format) {
++    return Glyph{fTextStrike->getGlyph(id, format)};
++}
+ 
+ std::tuple<bool, int> GlyphData::regenerateAtlas(int begin,
+                                                  int end,
+@@ -199,7 +201,7 @@
+         bool success = true;
+         for (int i = begin; i < end; i++) {
+             const Glyph& glyph = glyphSpan[i];
+-
++            SkASSERT(glyph.entry().fGlyphEntryKey.fFormat == maskFormat);
+             if (!atlasManager->hasGlyph(maskFormat, glyph.entry())) {
+                 const SkGlyph& skGlyph = *metricsAndImages.glyph(glyph.packedID());
+                 auto code = atlasManager->addGlyphToAtlas(skGlyph,
+diff --git a/src/gpu/ganesh/text/GlyphData.h b/src/gpu/ganesh/text/GlyphData.h
+index 7715492..7c57d42 100644
+--- a/src/gpu/ganesh/text/GlyphData.h
++++ b/src/gpu/ganesh/text/GlyphData.h
+@@ -34,13 +34,31 @@
+ namespace skgpu::ganesh {
+ class TextStrike;
+ 
++struct GlyphEntryKey {
++    explicit GlyphEntryKey(SkPackedGlyphID id, MaskFormat format) : fPackedID(id), fFormat(format) {}
++
++    const SkPackedGlyphID fPackedID;
++    MaskFormat fFormat;
++
++    bool operator==(const GlyphEntryKey& that) const {
++        return fPackedID == that.fPackedID && fFormat == that.fFormat;
++    }
++    bool operator!=(const GlyphEntryKey& that) const {
++        return !(*this == that);
++    }
++
++    uint32_t hash() const {
++        return fPackedID.hash();
++    }
++};
++
+ /**
+  * Ganesh-specific glyph type with atlas location information.
+  */
+ struct GlyphEntry {
+-    explicit GlyphEntry(SkPackedGlyphID id) : fPackedID(id) {}
++    explicit GlyphEntry(SkPackedGlyphID id, MaskFormat format) : fGlyphEntryKey(id, format) {}
+ 
+-    const SkPackedGlyphID fPackedID;
++    const GlyphEntryKey fGlyphEntryKey;
+     GrAtlasLocator fAtlasLocator;
+ };
+ 
+@@ -56,7 +74,7 @@
+ 
+ public:
+     explicit Glyph(GlyphEntry* entry) : fEntry{entry} { SkASSERT(entry); }
+-    SkPackedGlyphID packedID() const { return fEntry->fPackedID; }
++    SkPackedGlyphID packedID() const { return fEntry->fGlyphEntryKey.fPackedID; }
+     GlyphEntry& entry() const { return *fEntry; }
+ };
+ 
+@@ -74,7 +92,7 @@
+ 
+     ~GlyphData();
+ 
+-    Glyph makeGlyphFromID(SkPackedGlyphID);
++    Glyph makeGlyphFromID(SkPackedGlyphID, MaskFormat);
+ 
+     // Regenerate atlas entries for glyphs in range [begin, end).
+     // Returns {success, glyphs_placed_in_atlas}.
+diff --git a/src/gpu/ganesh/text/GrAtlasManager.cpp b/src/gpu/ganesh/text/GrAtlasManager.cpp
+index f5dc77b..f1a2bd3 100644
+--- a/src/gpu/ganesh/text/GrAtlasManager.cpp
++++ b/src/gpu/ganesh/text/GrAtlasManager.cpp
+@@ -177,8 +177,7 @@
+     }
+     SkASSERT(glyph != nullptr);
+ 
+-    MaskFormat glyphFormat = sktext::gpu::FormatFromSkGlyph(skGlyph.maskFormat());
+-    MaskFormat expectedMaskFormat = this->resolveMaskFormat(glyphFormat);
++    MaskFormat expectedMaskFormat = this->resolveMaskFormat(glyph->fGlyphEntryKey.fFormat);
+     int bytesPerPixel = MaskFormatBytesPerPixel(expectedMaskFormat);
+ 
+     int padding;
+diff --git a/src/gpu/ganesh/text/TextStrike.cpp b/src/gpu/ganesh/text/TextStrike.cpp
+index 8771fca..94b3521 100644
+--- a/src/gpu/ganesh/text/TextStrike.cpp
++++ b/src/gpu/ganesh/text/TextStrike.cpp
+@@ -28,20 +28,21 @@
+     return newStrike;
+ }
+ 
+-GlyphEntry* TextStrike::getGlyph(SkPackedGlyphID packedGlyphID) {
+-    GlyphEntry* glyph = fCache.findOrNull(packedGlyphID);
++GlyphEntry* TextStrike::getGlyph(SkPackedGlyphID packedGlyphID, MaskFormat format) {
++    GlyphEntryKey localKey(packedGlyphID, format);
++    GlyphEntry* glyph = fCache.findOrNull(localKey);
+     if (glyph == nullptr) {
+-        glyph = fAlloc.make<GlyphEntry>(packedGlyphID);
++        glyph = fAlloc.make<GlyphEntry>(packedGlyphID, format);
+         fCache.set(glyph);
+         this->addMemoryUsed(sizeof(GlyphEntry));
+     }
+     return glyph;
+ }
+ 
+-const SkPackedGlyphID& TextStrike::HashTraits::GetKey(const GlyphEntry* glyph) {
+-    return glyph->fPackedID;
++const GlyphEntryKey& TextStrike::HashTraits::GetKey(const GlyphEntry* glyph) {
++    return glyph->fGlyphEntryKey;
+ }
+ 
+-uint32_t TextStrike::HashTraits::Hash(SkPackedGlyphID key) { return key.hash(); }
++uint32_t TextStrike::HashTraits::Hash(GlyphEntryKey key) { return key.hash(); }
+ 
+ }  // namespace skgpu::ganesh
+diff --git a/src/gpu/ganesh/text/TextStrike.h b/src/gpu/ganesh/text/TextStrike.h
+index 8222eff..de4f421 100644
+--- a/src/gpu/ganesh/text/TextStrike.h
++++ b/src/gpu/ganesh/text/TextStrike.h
+@@ -10,6 +10,7 @@
+ 
+ #include "include/core/SkRefCnt.h"
+ #include "src/core/SkTHash.h"
++#include "src/gpu/MaskFormat.h"
+ #include "src/text/gpu/StrikeCache.h"
+ 
+ struct SkPackedGlyphID;
+@@ -18,6 +19,7 @@
+ namespace skgpu::ganesh {
+ 
+ struct GlyphEntry;
++struct GlyphEntryKey;
+ 
+ /**
+  * Ganesh-specific text strike cache entry.
+@@ -34,14 +36,15 @@
+     static sk_sp<TextStrike> GetOrCreate(sktext::gpu::StrikeCache* strikeCache,
+                                          const SkStrikeSpec& strikeSpec);
+ 
+-    GlyphEntry* getGlyph(SkPackedGlyphID packedGlyphID);
++    GlyphEntry* getGlyph(SkPackedGlyphID packedGlyphID, MaskFormat format);
+ 
+ private:
+     struct HashTraits {
+-        static const SkPackedGlyphID& GetKey(const GlyphEntry* glyph);
+-        static uint32_t Hash(SkPackedGlyphID key);
++        static const GlyphEntryKey& GetKey(const GlyphEntry* glyph);
++        static uint32_t Hash(GlyphEntryKey key);
+     };
+-    skia_private::THashTable<GlyphEntry*, SkPackedGlyphID, HashTraits> fCache;
++
++    skia_private::THashTable<GlyphEntry*, GlyphEntryKey, HashTraits> fCache;
+ 
+     friend class sktext::gpu::StrikeCache;
+ };
+diff --git a/src/gpu/graphite/Device.cpp b/src/gpu/graphite/Device.cpp
+index 3026445..97ff6f9 100644
+--- a/src/gpu/graphite/Device.cpp
++++ b/src/gpu/graphite/Device.cpp
+@@ -1432,7 +1432,8 @@
+     const int subRunEnd = subRun->glyphCount();
+ 
+     if (!subRun->glyphVector().hasBackendData()) {
+-        subRun->glyphVector().initBackendData<GlyphData>(this->recorder()->priv().strikeCache());
++        subRun->glyphVector().initBackendData<GlyphData>(this->recorder()->priv().strikeCache(),
++                                                         subRun->maskFormat());
+     }
+ 
+     auto& glyphData = subRun->glyphVector().accessBackendData<GlyphData>();
+diff --git a/src/gpu/graphite/text/GlyphData.cpp b/src/gpu/graphite/text/GlyphData.cpp
+index fe1e34a..b8f8fe6 100644
+--- a/src/gpu/graphite/text/GlyphData.cpp
++++ b/src/gpu/graphite/text/GlyphData.cpp
+@@ -29,7 +29,9 @@
+ 
+ GlyphData::~GlyphData() = default;
+ 
+-Glyph GlyphData::makeGlyphFromID(SkPackedGlyphID id) { return Glyph{fTextStrike->getGlyph(id)}; }
++Glyph GlyphData::makeGlyphFromID(SkPackedGlyphID id, MaskFormat format) {
++    return Glyph{fTextStrike->getGlyph(id, format)};
++}
+ 
+ std::tuple<bool, int> GlyphData::regenerateAtlas(int begin,
+                                                  int end,
+@@ -64,6 +66,7 @@
+         bool success = true;
+         SkSpan<const Glyph> glyphs = glyphVector.accessBackendGlyphs<Glyph>();
+         for (int i = begin; i < end; i++) {
++            SkASSERT(glyphs[i].entry().fGlyphEntryKey.fFormat == maskFormat);
+             if (!atlasManager->hasGlyph(maskFormat, glyphs[i].entry())) {
+                 const SkGlyph& skGlyph = *metricsAndImages.glyph(glyphs[i].packedID());
+                 auto code = atlasManager->addGlyphToAtlas(skGlyph, &glyphs[i].entry(), srcPadding);
+diff --git a/src/gpu/graphite/text/GlyphData.h b/src/gpu/graphite/text/GlyphData.h
+index 0dd828c..abe85e2 100644
+--- a/src/gpu/graphite/text/GlyphData.h
++++ b/src/gpu/graphite/text/GlyphData.h
+@@ -31,13 +31,31 @@
+ class Recorder;
+ class TextStrike;
+ 
++struct GlyphEntryKey {
++    explicit GlyphEntryKey(SkPackedGlyphID id, MaskFormat format) : fPackedID(id), fFormat(format) {}
++
++    const SkPackedGlyphID fPackedID;
++    MaskFormat fFormat;
++
++    bool operator==(const GlyphEntryKey& that) const {
++        return fPackedID == that.fPackedID && fFormat == that.fFormat;
++    }
++    bool operator!=(const GlyphEntryKey& that) const {
++        return !(*this == that);
++    }
++
++    uint32_t hash() const {
++        return fPackedID.hash();
++    }
++};
++
+ /**
+  * Graphite-specific glyph type with atlas location information.
+  */
+-struct GlyphEntry final {
+-    explicit GlyphEntry(SkPackedGlyphID id) : fPackedID(id) {}
++struct GlyphEntry {
++    explicit GlyphEntry(SkPackedGlyphID id, MaskFormat format) : fGlyphEntryKey(id, format) {}
+ 
+-    const SkPackedGlyphID fPackedID;
++    const GlyphEntryKey fGlyphEntryKey;
+     DrawAtlas::AtlasLocator fAtlasLocator;
+ };
+ 
+@@ -53,7 +71,7 @@
+ 
+ public:
+     explicit Glyph(GlyphEntry* entry) : fEntry{entry} { SkASSERT(entry); }
+-    SkPackedGlyphID packedID() const { return fEntry->fPackedID; }
++    SkPackedGlyphID packedID() const { return fEntry->fGlyphEntryKey.fPackedID; }
+     GlyphEntry& entry() const { return *fEntry; }
+ };
+ 
+@@ -71,7 +89,7 @@
+ 
+     ~GlyphData();
+ 
+-    Glyph makeGlyphFromID(SkPackedGlyphID);
++    Glyph makeGlyphFromID(SkPackedGlyphID, MaskFormat);
+ 
+     // Regenerate atlas entries for glyphs in range [begin, end).
+     // Returns {success, glyphs_placed_in_atlas}.
+diff --git a/src/gpu/graphite/text/TextAtlasManager.cpp b/src/gpu/graphite/text/TextAtlasManager.cpp
+index d870b7a..e5dd513 100644
+--- a/src/gpu/graphite/text/TextAtlasManager.cpp
++++ b/src/gpu/graphite/text/TextAtlasManager.cpp
+@@ -261,8 +261,7 @@
+     }
+     SkASSERT(glyph != nullptr);
+ 
+-    MaskFormat glyphFormat = sktext::gpu::FormatFromSkGlyph(skGlyph.maskFormat());
+-    MaskFormat expectedMaskFormat = this->resolveMaskFormat(glyphFormat);
++    MaskFormat expectedMaskFormat = this->resolveMaskFormat(glyph->fGlyphEntryKey.fFormat);
+     int bytesPerPixel = MaskFormatBytesPerPixel(expectedMaskFormat);
+ 
+     int padding;
+diff --git a/src/gpu/graphite/text/TextStrike.cpp b/src/gpu/graphite/text/TextStrike.cpp
+index edc643d..c7a41dc 100644
+--- a/src/gpu/graphite/text/TextStrike.cpp
++++ b/src/gpu/graphite/text/TextStrike.cpp
+@@ -28,20 +28,21 @@
+     return newStrike;
+ }
+ 
+-GlyphEntry* TextStrike::getGlyph(SkPackedGlyphID packedGlyphID) {
+-    GlyphEntry* glyph = fCache.findOrNull(packedGlyphID);
++GlyphEntry* TextStrike::getGlyph(SkPackedGlyphID packedGlyphID, MaskFormat format) {
++    GlyphEntryKey localKey(packedGlyphID, format);
++    GlyphEntry* glyph = fCache.findOrNull(localKey);
+     if (glyph == nullptr) {
+-        glyph = fAlloc.make<GlyphEntry>(packedGlyphID);
++        glyph = fAlloc.make<GlyphEntry>(packedGlyphID, format);
+         fCache.set(glyph);
+-        this->addMemoryUsed(sizeof(Glyph));
++        this->addMemoryUsed(sizeof(GlyphEntry));
+     }
+     return glyph;
+ }
+ 
+-const SkPackedGlyphID& TextStrike::HashTraits::GetKey(const GlyphEntry* glyph) {
+-    return glyph->fPackedID;
++const GlyphEntryKey& TextStrike::HashTraits::GetKey(const GlyphEntry* glyph) {
++    return glyph->fGlyphEntryKey;
+ }
+ 
+-uint32_t TextStrike::HashTraits::Hash(SkPackedGlyphID key) { return key.hash(); }
++uint32_t TextStrike::HashTraits::Hash(GlyphEntryKey key) { return key.hash(); }
+ 
+ }  // namespace skgpu::graphite
+diff --git a/src/gpu/graphite/text/TextStrike.h b/src/gpu/graphite/text/TextStrike.h
+index e7ccacd..e51e3d1 100644
+--- a/src/gpu/graphite/text/TextStrike.h
++++ b/src/gpu/graphite/text/TextStrike.h
+@@ -10,6 +10,7 @@
+ 
+ #include "include/core/SkRefCnt.h"
+ #include "src/core/SkTHash.h"
++#include "src/gpu/MaskFormat.h"
+ #include "src/text/gpu/StrikeCache.h"
+ 
+ struct SkPackedGlyphID;
+@@ -18,6 +19,7 @@
+ namespace skgpu::graphite {
+ 
+ struct GlyphEntry;
++struct GlyphEntryKey;
+ 
+ /**
+  * Graphite-specific text strike cache.
+@@ -32,14 +34,15 @@
+     static sk_sp<TextStrike> GetOrCreate(sktext::gpu::StrikeCache* strikeCache,
+                                          const SkStrikeSpec& strikeSpec);
+ 
+-    GlyphEntry* getGlyph(SkPackedGlyphID packedGlyphID);
++    GlyphEntry* getGlyph(SkPackedGlyphID packedGlyphID, MaskFormat format);
+ 
+ private:
+     struct HashTraits {
+-        static const SkPackedGlyphID& GetKey(const GlyphEntry* glyph);
+-        static uint32_t Hash(SkPackedGlyphID key);
++        static const GlyphEntryKey& GetKey(const GlyphEntry* glyph);
++        static uint32_t Hash(GlyphEntryKey key);
+     };
+-    skia_private::THashTable<GlyphEntry*, SkPackedGlyphID, HashTraits> fCache;
++
++    skia_private::THashTable<GlyphEntry*, GlyphEntryKey, HashTraits> fCache;
+ 
+     friend class sktext::gpu::StrikeCache;
+ };
+diff --git a/src/text/gpu/GlyphVector.h b/src/text/gpu/GlyphVector.h
+index 177c01b..3543212 100644
+--- a/src/text/gpu/GlyphVector.h
++++ b/src/text/gpu/GlyphVector.h
+@@ -11,6 +11,7 @@
+ #include "include/core/SkSpan.h"
+ #include "src/core/SkGlyph.h"
+ #include "src/core/SkStrike.h"  // IWYU pragma: keep
++#include "src/gpu/MaskFormat.h"
+ #include "src/text/gpu/StrikeCache.h"
+ 
+ #include <cstddef>
+@@ -80,7 +81,8 @@
+ concept BackendData = requires(T& t,
+                                StrikeCache* cache,
+                                const SkStrikeSpec& spec,
+-                               SkPackedGlyphID id) {
++                               SkPackedGlyphID id,
++                               skgpu::MaskFormat maskFormat) {
+     requires alignof(T) <= alignof(max_align_t);
+     requires sizeof(T)  <= kMaxBackendDataSize;
+ 
+@@ -89,7 +91,7 @@
+     requires std::derived_from<typename decltype(T::FindStrike(cache, spec))::element_type, TextStrikeBase>;
+ 
+     // Must have a makeGlyphFromID that returns a GlyphType
+-    { t.makeGlyphFromID(id) } -> GlyphType;
++    { t.makeGlyphFromID(id, maskFormat) } -> GlyphType;
+ };
+ }  // namespace GlyphVector_Concepts
+ 
+@@ -110,7 +112,8 @@
+     using Strike = std::invoke_result_t<decltype(B::FindStrike), StrikeCache*, const SkStrikeSpec&>;
+ 
+     template <GlyphVector_Concepts::BackendData B>
+-    using Glyph = decltype(std::declval<B>().makeGlyphFromID(SkPackedGlyphID{}));
++    using Glyph = decltype(std::declval<B>().makeGlyphFromID(SkPackedGlyphID{},
++                                                             skgpu::MaskFormat::kARGB));
+ 
+ public:
+     static size_t Size(int numGlyphs) {
+@@ -166,7 +169,7 @@
+     }
+ 
+     template <GlyphVector_Concepts::BackendData B>
+-    void initBackendData(StrikeCache* cache, auto&&... args)
++    void initBackendData(StrikeCache* cache, skgpu::MaskFormat maskFormat, auto&&... args)
+         requires std::is_constructible_v<B, Strike<B>, decltype(args)...> {
+         SkASSERT(!this->hasBackendData());
+         SkASSERT(cache);
+@@ -184,7 +187,7 @@
+ 
+         for (auto& g : fGlyphs) {
+             auto id = *reinterpret_cast<SkPackedGlyphID*>(g.data());
+-            new (g.data()) G{backendData->makeGlyphFromID(id)};
++            new (g.data()) G{backendData->makeGlyphFromID(id, maskFormat)};
+         }
+ 
+         fBackendDataReleaser = [](std::byte* p) { reinterpret_cast<B*>(p)->~B(); };
+diff --git a/tests/AtlasOobTest.cpp b/tests/AtlasOobTest.cpp
+new file mode 100644
+index 0000000..954056e
+--- /dev/null
++++ b/tests/AtlasOobTest.cpp
+@@ -0,0 +1,201 @@
++/*
++ * Copyright 2026 Google LLC
++ *
++ * Use of this source code is governed by a BSD-style license that can be
++ * found in the LICENSE file.
++ */
++#include "include/core/SkCanvas.h"
++#include "include/core/SkGraphics.h"
++#include "include/core/SkSerialProcs.h"
++#include "include/core/SkSurface.h"
++#include "include/private/chromium/SkChromeRemoteGlyphCache.h"
++#include "include/private/chromium/Slug.h"
++#include "src/core/SkDescriptor.h"
++#include "src/core/SkReadBuffer.h"
++#include "src/core/SkTypeface_remote.h"
++#include "src/core/SkWriteBuffer.h"
++#include "src/gpu/MaskFormat.h"
++#include "tests/CtsEnforcement.h"
++#include "tests/Test.h"
++#include "tools/ToolUtils.h"
++
++#if defined(SK_GANESH)
++#include "include/gpu/ganesh/GrDirectContext.h"
++#include "include/gpu/ganesh/SkSurfaceGanesh.h"
++#endif
++
++#if defined(SK_GRAPHITE)
++#include "include/gpu/graphite/Context.h"
++#include "include/gpu/graphite/Surface.h"
++#include "tools/graphite/GraphiteTestContext.h"
++#endif  // defined(SK_GRAPHITE)
++
++#include <vector>
++#include <cstring>
++
++namespace {
++class FakeDiscardableManager : public SkStrikeClient::DiscardableHandleManager {
++public:
++    bool deleteHandle(SkDiscardableHandleId) override { return false; }
++    void notifyCacheMiss(SkStrikeClient::CacheMissType, int) override {}
++    void notifyReadFailure(const ReadFailureData&) override {}
++    void assertHandleValid(SkDiscardableHandleId) override {}
++};
++
++unsigned char kStrikeData[] = {
++  0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x65, 0x07, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x65,
++  0x00, 0x00, 0x00, 0x65, 0xd8, 0x50, 0xda, 0x99, 0x4c, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
++  0x63, 0x65, 0x72, 0x73, 0x38, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x65, 0x00, 0x00, 0x80, 0x41,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x10, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x61, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x41,
++  0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
++  0x40, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0x62, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x41, 0x00, 0x00, 0x00, 0x00,
++  0x08, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0x63, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x41, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x08, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x64, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x20, 0x41, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x01, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x41,
++  0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
++  0x40, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0x66, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x41, 0x00, 0x00, 0x00, 0x00,
++  0x08, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0x67, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x41, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x08, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x65, 0x00, 0x00, 0x00, 0x66, 0x86, 0x07, 0xc2, 0x42,
++  0x4c, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x63, 0x65, 0x72, 0x73, 0x38, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x65, 0x00, 0x00, 0x80, 0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
++  0x99, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x41, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x04, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00
++};
++
++unsigned char kDrawSlugOp[] = {
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x41, 0x00, 0x00, 0x00, 0x41,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x3f,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x3f,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x3f,
++  0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x41,
++  0x00, 0x00, 0x00, 0x41, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x86, 0x07, 0xc2, 0x42, 0x4c, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x63, 0x65, 0x72, 0x73,
++  0x38, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x65, 0x00, 0x00, 0x80, 0x41, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x10, 0x00, 0x01, 0x00, 0x00, 0x00,
++  0x99, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
++};
++
++} // namespace
++
++// TODO: We expect this test to correctly hit an SkUnreachable and then crash. That does not work
++// with our current testing framework because we have no to "expect" a crash. So for now we will
++// land this test with only the valid loop enabled, but to test this is working locally, you should
++// change the loop to have both iterations.
++static void run_atlas_oob_test(skiatest::Reporter* reporter, SkCanvas* canvas) {
++    auto discardableManager = sk_make_sp<FakeDiscardableManager>();
++    SkStrikeClient client(discardableManager, false);
++
++    // 1. Prepare Strike Data
++    if (!client.readStrikeData(kStrikeData, sizeof(kStrikeData))) {
++        REPORTER_ASSERT(reporter, false, "Failed to read initial strike data");
++    }
++
++    // 2. Prepare and Execute DrawSlug ops
++    SkPaint paint;
++    for (int idx = 0; idx < 1; ++idx) {
++//    for (int idx = 0; idx < 2; ++idx) {
++        if (idx == 0) {
++                kDrawSlugOp[0x48] = (unsigned char)skgpu::MaskFormat::kARGB;
++        } else if (idx == 1) {
++                kDrawSlugOp[0x48] = (unsigned char)skgpu::MaskFormat::kA8;
++        }
++        kDrawSlugOp[0xd8] = SkMask::kARGB32_Format;
++        kDrawSlugOp[0xe0] = 0x99;
++
++        auto slug = client.deserializeSlugForTest(kDrawSlugOp, sizeof(kDrawSlugOp));
++        if (slug) {
++            slug->draw(canvas, paint);
++        }
++    }
++
++}
++
++#if defined(SK_GANESH)
++DEF_GANESH_TEST_FOR_RENDERING_CONTEXTS(Atlas_Oob_ganesh, reporter, ctxInfo, CtsEnforcement::kNextRelease) {
++    auto dContext = ctxInfo.directContext();
++    SkImageInfo info = SkImageInfo::MakeN32Premul(1024, 1024);
++    auto surface = SkSurfaces::RenderTarget(dContext, skgpu::Budgeted::kNo, info);
++    if (!surface) return;
++    auto canvas = surface->getCanvas();
++
++    run_atlas_oob_test(reporter, canvas);
++
++    dContext->flushAndSubmit();
++}
++#endif // defined(SK_GANESH)
++
++#if defined(SK_GRAPHITE)
++DEF_GRAPHITE_TEST_FOR_RENDERING_CONTEXTS(Atlas_Oob_graphite, reporter, context, CtsEnforcement::kNextRelease) {
++    using namespace skgpu::graphite;
++    std::unique_ptr<Recorder> recorder = context->makeRecorder();
++    SkImageInfo info = SkImageInfo::MakeN32Premul(1024, 1024);
++    auto surface = SkSurfaces::RenderTarget(recorder.get(), info);
++    if (!surface) return;
++    auto canvas = surface->getCanvas();
++
++    run_atlas_oob_test(reporter, canvas);
++
++    std::unique_ptr<Recording> recording = recorder->snap();
++    InsertRecordingInfo recordingInfo;
++    recordingInfo.fRecording = recording.get();
++    context->insertRecording(recordingInfo);
++    context->submit();
++}
++#endif // defined(SK_GRAPHITE)


### PR DESCRIPTION
Make sure we are getting the correct atlas for glyph mask format.

Bug: b/491421267
Change-Id: I4eacd46599eca2df8c10a3fc894b9ce890fae1e2
Reviewed-on: https://skia-review.googlesource.com/c/skia/+/1184076
Commit-Queue: Greg Daniel <egdaniel@google.com>
Reviewed-by: Michael Ludwig <michaelludwig@google.com>


Notes: Backported fix for b/491421267.