### PR TITLE
build: add patch conflict resolution workflow with CI artifacts

### DIFF
--- a/.github/workflows/apply-patches.yml
+++ b/.github/workflows/apply-patches.yml
@@ -71,3 +71,10 @@ jobs:
       uses: ./src/electron/.github/actions/checkout
       with:
         target-platform: linux
+    - name: Upload Patch Conflict Fix
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: update-patches
+        path: patches/update-patches.patch
+        if-no-files-found: ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,22 @@ patches/{target}/*.patch  →  [e sync --3]  →  target repo commits
 2. Create a git commit
 3. Run `e patches <target>` to export
 
+**Fixing patch conflicts on an existing PR:**
+
+If asked to fix a patch conflict on a branch that already has an open PR, check the PR's failed **Apply Patches** CI run for an `update-patches` artifact before running `e sync` locally. CI has already performed the 3-way merge and exported the resolved patch diff — applying it is much faster than a full local sync.
+
+```bash
+# Find the failed Apply Patches run for the PR and download the artifact
+gh run list --repo electron/electron --branch <pr-branch> --workflow "Apply Patches" --limit 1
+gh run download <run-id> --repo electron/electron --name update-patches
+
+# Apply the CI-generated fix, then push
+git am update-patches.patch
+git push
+```
+
+If no artifact exists (e.g. the 3-way merge itself failed), fall back to `e sync --3` and resolve manually.
+
 ## Testing
 
 **Test location:** `spec/` directory


### PR DESCRIPTION
#### Description of Change

This PR adds documentation and CI automation to streamline the patch conflict resolution workflow when fixing conflicts on branches with open PRs.

**Changes:**
1. **CLAUDE.md**: Added a new section documenting how to use CI-generated patch artifacts to resolve conflicts faster than running a full local sync. Includes commands for finding and downloading the artifact from a failed Apply Patches run, and guidance on fallback procedures.

2. **.github/workflows/apply-patches.yml**: Added a new workflow step that uploads a `update-patches.patch` artifact when the Apply Patches job fails. This artifact contains the resolved patch diff from CI's 3-way merge, allowing developers to quickly apply the fix without running `e sync --3` locally.

The workflow improvement reduces friction in the patch management process by leveraging CI's already-computed merge resolution.

#### Checklist

- [x] PR description included
- [x] Documentation updated (CLAUDE.md and workflow comments)
- [ ] `npm test` passes (N/A - documentation and workflow configuration only)
- [ ] tests are changed or added (N/A - no code logic changes)
- [ ] relevant API documentation updated (N/A)

#### Release Notes

Notes: none