### PR TITLE
fix: prefer browser runtime over node in DevTools HostRuntime detection

### DIFF
--- a/patches/devtools_frontend/.patches
+++ b/patches/devtools_frontend/.patches
@@ -1,1 +1,2 @@
 chore_expose_ui_to_allow_electron_to_set_dock_side.patch
+fix_prefer_browser_runtime_over_node_in_hostruntime_detection.patch

--- a/patches/devtools_frontend/fix_prefer_browser_runtime_over_node_in_hostruntime_detection.patch
+++ b/patches/devtools_frontend/fix_prefer_browser_runtime_over_node_in_hostruntime_detection.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Thu, 12 Mar 2026 17:03:29 +0100
+Subject: fix: prefer browser runtime over node in HostRuntime detection
+
+In Electron, the `process` global is available in renderer processes,
+including the DevTools renderer. This causes the IS_NODE check to pass,
+leading DevTools to attempt importing the Node.js platform runtime
+(which uses `node:worker_threads`). However, DevTools Web Workers
+running under the `devtools://` protocol don't have access to Node.js
+built-in modules, resulting in a failed dynamic import.
+
+Fix by checking IS_BROWSER first, since DevTools always runs in a
+browser-like environment. The Node.js runtime is only needed when
+DevTools runs under pure Node.js (e.g., CLI tooling or testing).
+
+diff --git a/front_end/core/platform/HostRuntime.ts b/front_end/core/platform/HostRuntime.ts
+index 91adba7c966a9c4c0e5315d2cfee07f8f622b731..16822b8d4ea74a4ffd6870e5e95948d75918f5d2 100644
+--- a/front_end/core/platform/HostRuntime.ts
++++ b/front_end/core/platform/HostRuntime.ts
+@@ -14,12 +14,12 @@ export const IS_BROWSER =
+     typeof window !== 'undefined' || (typeof self !== 'undefined' && typeof self.postMessage === 'function');
+ 
+ export const HOST_RUNTIME = await (async(): Promise<Api.HostRuntime.HostRuntime> => {
+-  if (IS_NODE) {
+-    return (await import('./node/node.js')).HostRuntime.HOST_RUNTIME;
+-  }
+   if (IS_BROWSER) {
+     return (await import('./browser/browser.js')).HostRuntime.HOST_RUNTIME;
+   }
++  if (IS_NODE) {
++    return (await import('./node/node.js')).HostRuntime.HOST_RUNTIME;
++  }
+ 
+   throw new Error('Unknown runtime!');
+ })();


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/50220

Upstream DevTools' HostRuntime checks `IS_NODE` before `IS_BROWSER` when selecting the platform runtime. In Electron, `process` is available in renderer processes, so `IS_NODE` evaluates to `true` in the DevTools context. This causes DevTools to dynamically import the Node.js platform runtime, which uses `node:worker_threads`. DevTools Web Workers running under the `devtools://` protocol cannot load Node.js built-in modules, so the import fails and breaks features like the formatter worker.

Fix by swapping the check order to prefer `IS_BROWSER` when both are true. This is safe because in pure Node.js environments (the only case where the node runtime is needed), `window` and `self` are both undefined, so `IS_BROWSER` is always `false` regardless of check order.

Upstreamed at https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/7665878

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix an issue where some DevTools functionality didn't work as expected.