### PR TITLE
fix: correct utility process exit code on Windows

### DIFF
--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -291,7 +291,7 @@ void UtilityProcessWrapper::OnServiceProcessTerminatedNormally(
       info.GetProcess().Pid() != pid_)
     return;
 
-  HandleTermination(info.exit_code());
+  HandleTermination(static_cast<uint32_t>(info.exit_code()));
 }
 
 void UtilityProcessWrapper::OnServiceProcessCrashed(
@@ -300,7 +300,7 @@ void UtilityProcessWrapper::OnServiceProcessCrashed(
       info.GetProcess().Pid() != pid_)
     return;
 
-  HandleTermination(info.exit_code());
+  HandleTermination(static_cast<uint32_t>(info.exit_code()));
 }
 
 void UtilityProcessWrapper::CloseConnectorPort() {


### PR DESCRIPTION
On Windows, process exit codes are 32-bit unsigned integers (DWORD). When passed from Chromium to Electron as a signed int and then implicitly converted to uint64_t, values with the high bit set (e.g., NTSTATUS codes) undergo sign extension, producing incorrect values.

Cast the exit code to uint32_t before widening to uint64_t to prevent sign extension and preserve the original Windows exit code.

Fixes #49455

#### Description of Change

  On Windows, process exit codes are 32-bit unsigned integers (`DWORD`). The `utilityProcess` `exit` event reports incorrect codes when the value has the
  high bit set (e.g., NTSTATUS codes from process crashes).

  `ServiceProcessInfo::exit_code()` returns a signed `int`. When implicitly converted to `uint64_t` (the parameter type of `HandleTermination`), values with
   the high bit set undergo sign extension. For example, exit code `0xC0000005` (3,221,225,477) gets reported as `18,446,744,072,635,812,000`.

  The fix casts the exit code to `uint32_t` before widening to `uint64_t`, preventing sign extension in both `OnServiceProcessTerminatedNormally` and
  `OnServiceProcessCrashed`.

  #### Checklist

  - [x] PR description included
  - [x] I have built and tested this PR
  - [x] `npm test` passes
  - [x] PR release notes describe the change

  #### Release Notes

  Notes: Fixed `utilityProcess` `exit` event reporting incorrect exit codes on Windows when the code has the high bit set.