### PR TITLE
docs: add further disposition description

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -228,6 +228,11 @@ Returns:
   * `disposition` string - Can be `default`, `foreground-tab`,
     `background-tab`, `new-window` or `other`. Corresponds to the manner an associated link was clicked. See Chromium's
     [WindowOpenDisposition](https://source.chromium.org/chromium/chromium/src/+/main:ui/base/window_open_disposition.h).
+      * `default` - In the rare instance Chromium deems in-window navigation valid for a window open call, this would be the classification for the call
+      * `foreground-tab` -  Left Click or Shift + Middle Click
+      * `background-tab` - Middle Click or Ctrl/Cmd + Click
+      * `new-window` - Shift + Left Click
+      * `other` - A catch-all for the remaining Chromium dispositions not handled by Electron
 
 Emitted _after_ successful creation of a window via `window.open` in the renderer.
 Not emitted if the creation of the window is canceled from
@@ -1453,6 +1458,11 @@ Ignore application menu shortcuts while this web contents is focused.
     * `disposition` string - Can be `default`, `foreground-tab`, `background-tab`,
       `new-window` or `other`. Corresponds to the manner an associated link was clicked. See Chromium's
       [WindowOpenDisposition](https://source.chromium.org/chromium/chromium/src/+/main:ui/base/window_open_disposition.h).
+      * `default` - In the rare instance Chromium deems in-window navigation valid for a window open call, this would be the classification for the call
+      * `foreground-tab` -  Left Click or Shift + Middle Click
+      * `background-tab` - Middle Click or Ctrl/Cmd + Click
+      * `new-window` - Shift + Left Click
+      * `other` - A catch-all for the remaining Chromium dispositions not handled by Electron
     * `referrer` [Referrer](structures/referrer.md) - The referrer that will be
       passed to the new window. May or may not result in the `Referer` header being
       sent, depending on the referrer policy.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -226,7 +226,8 @@ Returns:
     Only defined when the window is being created by a form that set
     `target=_blank`.
   * `disposition` string - Can be `default`, `foreground-tab`,
-    `background-tab`, `new-window` or `other`.
+    `background-tab`, `new-window` or `other`. Corresponds to the manner an associated link was clicked. See Chromium's
+    [WindowOpenDisposition](https://source.chromium.org/chromium/chromium/src/+/main:ui/base/window_open_disposition.h).
 
 Emitted _after_ successful creation of a window via `window.open` in the renderer.
 Not emitted if the creation of the window is canceled from
@@ -1450,7 +1451,8 @@ Ignore application menu shortcuts while this web contents is focused.
     * `frameName` string - Name of the window provided in `window.open()`
     * `features` string - Comma separated list of window features provided to `window.open()`.
     * `disposition` string - Can be `default`, `foreground-tab`, `background-tab`,
-      `new-window` or `other`.
+      `new-window` or `other`. Corresponds to the manner an associated link was clicked. See Chromium's
+      [WindowOpenDisposition](https://source.chromium.org/chromium/chromium/src/+/main:ui/base/window_open_disposition.h).
     * `referrer` [Referrer](structures/referrer.md) - The referrer that will be
       passed to the new window. May or may not result in the `Referer` header being
       sent, depending on the referrer policy.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -226,13 +226,16 @@ Returns:
     Only defined when the window is being created by a form that set
     `target=_blank`.
   * `disposition` string - Can be `default`, `foreground-tab`,
-    `background-tab`, `new-window` or `other`. Corresponds to the manner an associated link was clicked. See Chromium's
+    `background-tab`, `new-window` or `other`. Corresponds to the manner
+    an associated link was clicked. See Chromium's
     [WindowOpenDisposition](https://source.chromium.org/chromium/chromium/src/+/main:ui/base/window_open_disposition.h).
-      * `default` - In the rare instance Chromium deems in-window navigation valid for a window open call, this would be the classification for the call
-      * `foreground-tab` -  Left Click or Shift + Middle Click
-      * `background-tab` - Middle Click or Ctrl/Cmd + Click
-      * `new-window` - Shift + Left Click
-      * `other` - A catch-all for the remaining Chromium dispositions not handled by Electron
+    * `default` - Indicates Chromium deems in-window navigation valid
+      for a window open call.
+    * `foreground-tab` - Corresponds to a left click or shift + middle click.
+    * `background-tab` - Corresponds to a middle click or ctrl/cmd + click.
+    * `new-window` - Corresponds to a shift + left click.
+    * `other` - A catch-all for the remaining Chromium dispositions not
+      handled by Electron.
 
 Emitted _after_ successful creation of a window via `window.open` in the renderer.
 Not emitted if the creation of the window is canceled from
@@ -1455,14 +1458,17 @@ Ignore application menu shortcuts while this web contents is focused.
     * `url` string - The _resolved_ version of the URL passed to `window.open()`. e.g. opening a window with `window.open('foo')` will yield something like `https://the-origin/the/current/path/foo`.
     * `frameName` string - Name of the window provided in `window.open()`
     * `features` string - Comma separated list of window features provided to `window.open()`.
-    * `disposition` string - Can be `default`, `foreground-tab`, `background-tab`,
-      `new-window` or `other`. Corresponds to the manner an associated link was clicked. See Chromium's
+    * `disposition` string - Can be `default`, `foreground-tab`,
+      `background-tab`, `new-window` or `other`. Corresponds to the manner
+      an associated link was clicked. See Chromium's
       [WindowOpenDisposition](https://source.chromium.org/chromium/chromium/src/+/main:ui/base/window_open_disposition.h).
-      * `default` - In the rare instance Chromium deems in-window navigation valid for a window open call, this would be the classification for the call
-      * `foreground-tab` -  Left Click or Shift + Middle Click
-      * `background-tab` - Middle Click or Ctrl/Cmd + Click
-      * `new-window` - Shift + Left Click
-      * `other` - A catch-all for the remaining Chromium dispositions not handled by Electron
+      * `default` - Indicates Chromium deems in-window navigation valid
+        for a window open call.
+      * `foreground-tab` - Corresponds to a left click or shift + middle click.
+      * `background-tab` - Corresponds to a middle click or ctrl/cmd + click.
+      * `new-window` - Corresponds to a shift + left click.
+      * `other` - A catch-all for the remaining Chromium dispositions not
+        handled by Electron.
     * `referrer` [Referrer](structures/referrer.md) - The referrer that will be
       passed to the new window. May or may not result in the `Referer` header being
       sent, depending on the referrer policy.


### PR DESCRIPTION
#### Description of Change

This PR adds to the description of the `disposition` window option to make its origins and functionality a bit more clear.

https://github.com/electron/electron/pull/49379 helped to reveal this gap in our documentation

https://gist.github.com/98b622ed47612d49f6ce2e37caf9799f can be used to demonstrate the dispositions triggered by clicks

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [ ] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
