### PR TITLE
ci: create PR triage project automation

### DIFF
--- a/.github/workflows/pr-triage-automation.yml
+++ b/.github/workflows/pr-triage-automation.yml
@@ -17,7 +17,7 @@ jobs:
       || (github.event_name == 'issue_comment'
           && github.event.issue.pull_request
           && github.event.comment.user.login == github.event.issue.user.login)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
#### Description of Change
This PR adds the following automation to our PR triage board:

This will change the status to of a PR to `Needs Review` whenever one of the following happens:

- The branch is pushed to
- The PR author comments
- The PR author (re-)requests a review from someone

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
