### PR TITLE
build: skip archiving patch conflict fix artifact

### DIFF
--- a/.github/workflows/apply-patches.yml
+++ b/.github/workflows/apply-patches.yml
@@ -78,3 +78,4 @@ jobs:
         name: update-patches
         path: patches/update-patches.patch
         if-no-files-found: ignore
+        archive: false


### PR DESCRIPTION
#### Description of Change

Follow-up to #50235 — addresses [review feedback](https://github.com/electron/electron/pull/50235#discussion_r2928986421) from @dsanders11.

The `update-patches` artifact is a single `.patch` file, so zipping it adds unnecessary overhead. With `archive: false`, `gh run download` fetches the raw file directly without requiring a decompression step.

#### Checklist

- [x] PR description included
- [ ] `npm test` passes — N/A, workflow config only
- [ ] tests are changed or added — N/A
- [ ] relevant documentation is changed or added — N/A

#### Release Notes

Notes: none