### PR TITLE
fix: ensure visibility state observers are notified when background throttling is disabled

### DIFF
--- a/patches/chromium/allow_disabling_blink_scheduler_throttling_per_renderview.patch
+++ b/patches/chromium/allow_disabling_blink_scheduler_throttling_per_renderview.patch
@@ -130,7 +130,7 @@ index f5bdcb8176a94705a3710ba5dbc536a96b35fed9..657a0e059f954a72d4f8654d1a8938ff
    bool storing_in_bfcache = new_state->is_in_back_forward_cache &&
                              !old_state->is_in_back_forward_cache;
    bool restoring_from_bfcache = !new_state->is_in_back_forward_cache &&
-@@ -4182,10 +4186,23 @@ PageScheduler* WebViewImpl::Scheduler() const {
+@@ -4182,10 +4186,21 @@ PageScheduler* WebViewImpl::Scheduler() const {
    return GetPage()->GetPageScheduler();
  }
  
@@ -145,11 +145,9 @@ index f5bdcb8176a94705a3710ba5dbc536a96b35fed9..657a0e059f954a72d4f8654d1a8938ff
      bool is_initial_state) {
    DCHECK(GetPage());
 +
-+  if (!scheduler_throttling_allowed_) {
-+    GetPage()->SetVisibilityState(mojom::blink::PageVisibilityState::kVisible, is_initial_state);
-+    GetPage()->GetPageScheduler()->SetPageVisible(true);
-+    return;
-+  }
++  // If backgroundThrottling is disabled, the page is always visible.
++  if (!scheduler_throttling_allowed_)
++    visibility_state = mojom::blink::PageVisibilityState::kVisible;
 +
    GetPage()->SetVisibilityState(visibility_state, is_initial_state);
    // Do not throttle if the page should be painting.


### PR DESCRIPTION
This PR fixes a bug where HTML5 videos would "disappear" (the video frame goes blank but audio continues) after unminimizing a window. This happened specifically if setBackgroundThrottling(false) was called while the window was minimized.

The Problem
In our Chromium patch for disabling background throttling, we forced the page's visibility state to "visible" to keep it running in the background. However, the code was exiting (returning) immediately after forcing this state.

By exiting early, we accidentally skipped the step where Chromium notifies its internal components—like the video renderer—that the visibility has changed. Because these components never got the update, they stayed in "hidden" mode and stopped sending video frames to the screen, even after you brought the window back up.

The Fix
I’ve updated the patch to remove that early exit. Now, when background throttling is disabled:

We still force the state to visible.
But instead of stopping there, we let the function continue running normally.
This ensures all internal observers are properly "woken up" and notified, allowing video rendering to resume as expected.