### PR TITLE
feat: allow for dynamically-updating app menu items when the menu is closed

### DIFF
--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -593,8 +593,10 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
       [menu removeItem:item];
   }
 
-  if (model_)
+  if (model_) {
     model_->MenuWillShow();
+    [self refreshMenuTree:menu_ ? menu_ : menu];
+  }
 }
 
 - (void)menuDidClose:(NSMenu*)menu {


### PR DESCRIPTION
#### Description of Change

Our docs for `MenuItem` mention that labels and such can be dynamically updated, but that is not the case. This is a long-standing issue, going back to at least 2018 with #12633 (and, in 2019, with #21504, our documentation was explicitly called out).

However, #49875 *did* sort of introduce this by refreshing the menu in [`menuNeedsUpdate:`](https://developer.apple.com/documentation/appkit/nsmenudelegate/menuneedsupdate(_:)). That works for `Tray` menus, but not for application menus. This adds a matching refresh where it will work with application menus.

Wether this is a `fix` for a `feat` is up for debate. I'm aligning more with documentation we never removed, but I'm also aligning with documentation we were apparently supposed to remove.

EDIT: I was apparently working off of old info. This might be moot in light of #49678? To discuss.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [ ] `npm test` passes
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: To be written.
