### PR TITLE
ci: update test timeout to 60 minutes

### DIFF
--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -214,7 +214,7 @@ jobs:
 
     - name: Run Electron Tests
       shell: bash
-      timeout-minutes: 40
+      timeout-minutes: 60
       env:
         MOCHA_REPORTER: mocha-multi-reporters
         MOCHA_MULTI_REPORTERS: mocha-junit-reporter, tap


### PR DESCRIPTION
#### Description of Change
The autoupdater tests on mac x64 run slowly (a couple of the tests need multiple re-runs to pass), so we should update the test timeout to accommodate that.  

The autoupdater tests should probably be improved but this will unblock failing CI for now.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
