### PR TITLE
chore: add missing timers-shim.ts to filenames.auto.gni

### DIFF
--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -179,6 +179,7 @@ auto_filenames = {
     "lib/common/define-properties.ts",
     "lib/common/deprecate.ts",
     "lib/common/ipc-messages.ts",
+    "lib/common/timers-shim.ts",
     "lib/common/web-view-methods.ts",
     "lib/common/webpack-globals-provider.ts",
     "lib/renderer/api/context-bridge.ts",


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Follow-up to #50203. This gets automatically added if `script/gen-filenames.ts` gets run, but since it was missed in the previous this is going to try to sneak into another PR the next time that script gets run.

As a follow-up task here, we should really be detecting this issue in CI. Currently the only time `script/gen-filenames.ts` gets run is as a precommit hook, which can get missed for various reasons. We should add a step in CI that runs this script and its siblings (`script/gen-hunspell-filenames.js` and `script/gen-libc++-filenames.js`) and fail if there's local changes after running them.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
