### PR TITLE
chore: Respect HTTP(S) proxy env variable for Yarn

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,4 +9,8 @@ npmMinimalAgeGate: 10080
 npmPreapprovedPackages:
   - "@electron/*"
 
+httpProxy: "${HTTP_PROXY:-}"
+
+httpsProxy: "${HTTPS_PROXY:-}"
+
 yarnPath: .yarn/releases/yarn-4.12.0.cjs


### PR DESCRIPTION
#### Description of Change
- This is a copy of @panther7's PR #49361 submitted by a maintainer since it touches a dependency or CI files, and per [our contribution policy](https://github.com/electron/electron/blob/main/CONTRIBUTING.md#dependencies-upgrades-policy) we do not accept these types of changes in PRs from non-maintainers.  The work in this PR is @panther7's work.

- Resolves #49171.  Yarn installs that require a proxy can do so by setting the environment variables:
  * `HTTP_PROXY` - Proxy to use when making an HTTP request.
  * `HTTPS_PROXY` - Proxy to use when making an HTTPS request.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->Added support for using a proxy during yarn install
