### PR TITLE
feat: add Notification.getHistory() for macOS

### DIFF
--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -76,6 +76,43 @@ app.whenReady().then(() => {
 })
 ```
 
+#### `Notification.getHistory()` _macOS_
+
+Returns `Promise<Notification[]>` - Resolves with an array of `Notification` objects representing all delivered notifications still present in Notification Center.
+
+Each returned `Notification` is a live object connected to the corresponding delivered notification. Interaction events (`click`, `reply`, `action`, `close`) will fire on these objects when the user interacts with the notification in Notification Center. This is useful after an app restart to re-attach event handlers to notifications from a previous session.
+
+The returned notifications have their `id`, `groupId`, `title`, `subtitle`, and `body` properties populated from what macOS provides. Other properties (e.g., `actions`, `silent`, `icon`) are not available from delivered notifications and will have default values.
+
+> [!NOTE]
+> Like all macOS notification APIs, this method requires the application to be
+> code-signed. In unsigned development builds, notifications are not delivered
+> to Notification Center and this method will resolve with an empty array.
+
+> [!NOTE]
+> Unlike notifications created with `new Notification()`, notifications returned
+> by `getHistory()` will remain visible in Notification Center when the object
+> is garbage collected.
+
+```js
+const { Notification, app } = require('electron')
+
+app.whenReady().then(async () => {
+  // Restore notifications from a previous session
+  const notifications = await Notification.getHistory()
+  for (const n of notifications) {
+    console.log(`Found delivered notification: ${n.id} - ${n.title}`)
+    n.on('click', () => {
+      console.log(`User clicked: ${n.id}`)
+    })
+    n.on('reply', (event) => {
+      console.log(`User replied to ${n.id}: ${event.reply}`)
+    })
+  }
+  // Keep references so events continue to fire
+})
+```
+
 ### `new Notification([options])`
 
 * `options` Object (optional)

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -82,7 +82,7 @@ Returns `Promise<Notification[]>` - Resolves with an array of `Notification` obj
 
 Each returned `Notification` is a live object connected to the corresponding delivered notification. Interaction events (`click`, `reply`, `action`, `close`) will fire on these objects when the user interacts with the notification in Notification Center. This is useful after an app restart to re-attach event handlers to notifications from a previous session.
 
-The returned notifications have their `id`, `groupId`, `title`, `subtitle`, and `body` properties populated from what macOS provides. Other properties (e.g., `actions`, `silent`, `icon`) are not available from delivered notifications and will have default values.
+The returned notifications have their `id`, `groupId`, `title`, `subtitle`, and `body` properties populated from information available in the Notification Center. Other properties (e.g., `actions`, `silent`, `icon`) are not available from delivered notifications and will have default values.
 
 > [!NOTE]
 > Like all macOS notification APIs, this method requires the application to be

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -92,7 +92,9 @@ The returned notifications have their `id`, `groupId`, `title`, `subtitle`, and 
 > [!NOTE]
 > Unlike notifications created with `new Notification()`, notifications returned
 > by `getHistory()` will remain visible in Notification Center when the object
-> is garbage collected.
+> is garbage collected. Calling `show()` on a restored notification will remove
+> the original from Notification Center and post a new one with the same
+> properties.
 
 ```js
 const { Notification, app } = require('electron')
@@ -328,6 +330,10 @@ call this method before the OS will display it.
 
 If the notification has been shown before, this method will dismiss the previously
 shown notification and create a new one with identical properties.
+
+On macOS, calling `show()` on a notification returned by `Notification.getHistory()` will
+remove the original notification from Notification Center and post a new one with the same
+properties.
 
 ```js
 const { Notification, app } = require('electron')

--- a/lib/browser/api/notification.ts
+++ b/lib/browser/api/notification.ts
@@ -2,6 +2,7 @@ const binding = process._linkedBinding('electron_browser_notification');
 
 const ElectronNotification = binding.Notification;
 ElectronNotification.isSupported = binding.isSupported;
+ElectronNotification.getHistory = binding.getHistory;
 
 if (process.platform === 'win32' && binding.handleActivation) {
   ElectronNotification.handleActivation = binding.handleActivation;

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -96,14 +96,30 @@ Notification::Notification(gin::Arguments* args) {
     opts.Get("toastXml", &toast_xml_);
   }
 
-    if (id_.empty())
-      id_ = base::Uuid::GenerateRandomV4().AsLowercaseString();
-  }
+  if (id_.empty())
+    id_ = base::Uuid::GenerateRandomV4().AsLowercaseString();
 }
 
+Notification::Notification(const NotificationInfo& info)
+    : id_(info.id),
+      group_id_(info.group_id),
+      title_(base::UTF8ToUTF16(info.title)),
+      subtitle_(base::UTF8ToUTF16(info.subtitle)),
+      body_(base::UTF8ToUTF16(info.body)),
+      is_restored_(true),
+      presenter_(nullptr) {}
+
 Notification::~Notification() {
-  if (notification_)
+  if (notification_) {
     notification_->set_delegate(nullptr);
+    // For restored notifications, destroy the platform notification to remove
+    // it from the presenter's set. The platform-level is_restored_ flag ensures
+    // this won't remove the notification from Notification Center.
+    // For normal notifications, Close() is called before destruction which
+    // already cleans up, so notification_ will be null here.
+    if (is_restored_)
+      notification_->Destroy();
+  }
 }
 
 // static
@@ -270,6 +286,11 @@ void Notification::Close() {
 
 // Showing notifications
 void Notification::Show() {
+  // Restored notifications are read-only snapshots from Notification Center.
+  // Re-showing them would remove the original and create a duplicate.
+  if (is_restored_)
+    return;
+
   Close();
   if (presenter_) {
     notification_ = presenter_->CreateNotification(this, id_);
@@ -393,31 +414,37 @@ v8::Local<v8::Promise> Notification::GetHistory(v8::Isolate* isolate) {
         v8::Isolate* isolate = promise.isolate();
         v8::HandleScope handle_scope(isolate);
 
-        auto* presenter =
-            static_cast<ElectronBrowserClient*>(ElectronBrowserClient::Get())
-                ->GetNotificationPresenter();
+        // The browser client may have been torn down by the time this
+        // callback fires — null-check to avoid a use-after-free.
+        auto* browser_client = ElectronBrowserClient::Get();
+        if (!browser_client) {
+          promise.Resolve(v8::Array::New(isolate).As<v8::Value>());
+          return;
+        }
+
+        auto* presenter = static_cast<ElectronBrowserClient*>(browser_client)
+                              ->GetNotificationPresenter();
+        if (!presenter) {
+          promise.Resolve(v8::Array::New(isolate).As<v8::Value>());
+          return;
+        }
 
         v8::Local<v8::Array> result =
             v8::Array::New(isolate, notifications.size());
         for (size_t i = 0; i < notifications.size(); i++) {
           const auto& info = notifications[i];
 
-          // Create a live Notification object for each delivered notification.
-          auto* notif = new Notification(/*args=*/nullptr);
-          notif->id_ = info.id;
-          notif->group_id_ = info.group_id;
-          notif->title_ = base::UTF8ToUTF16(info.title);
-          notif->subtitle_ = base::UTF8ToUTF16(info.subtitle);
-          notif->body_ = base::UTF8ToUTF16(info.body);
-          notif->is_restored_ = true;
-
-          // Register with the presenter so click/reply events route here.
-          if (presenter) {
-            notif->notification_ =
-                presenter->CreateNotification(notif, notif->id_);
-            if (notif->notification_)
-              notif->notification_->Restore();
-          }
+          // Create a restored Notification object for each delivered
+          // notification. The API object is owned by V8 GC (via
+          // CreateHandle), while CreateNotification creates a separate
+          // platform notification owned by the presenter. They are connected
+          // by a WeakPtr (API -> platform) and a raw delegate pointer
+          // (platform -> API, cleared in ~Notification).
+          auto* notif = new Notification(info);
+          notif->notification_ =
+              presenter->CreateNotification(notif, notif->id_);
+          if (notif->notification_)
+            notif->notification_->Restore();
 
           auto handle = gin_helper::CreateHandle(isolate, notif);
           result
@@ -469,7 +496,6 @@ const char* Notification::GetTypeName() {
 void Notification::WillBeDestroyed() {
   ClearWeak();
 }
-
 }  // namespace electron::api
 
 namespace {

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -5,6 +5,7 @@
 #include "shell/browser/api/electron_api_notification.h"
 
 #include "base/functional/bind.h"
+#include "base/strings/utf_string_conversions.h"
 #include "base/uuid.h"
 #include "build/build_config.h"
 #include "content/public/browser/browser_task_traits.h"
@@ -13,10 +14,12 @@
 #include "shell/browser/browser.h"
 #include "shell/browser/electron_browser_client.h"
 #include "shell/common/gin_converters/image_converter.h"
+#include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/handle.h"
 #include "shell/common/gin_helper/object_template_builder.h"
+#include "shell/common/gin_helper/promise.h"
 #include "shell/common/node_includes.h"
 #include "url/gurl.h"
 
@@ -93,8 +96,9 @@ Notification::Notification(gin::Arguments* args) {
     opts.Get("toastXml", &toast_xml_);
   }
 
-  if (id_.empty())
-    id_ = base::Uuid::GenerateRandomV4().AsLowercaseString();
+    if (id_.empty())
+      id_ = base::Uuid::GenerateRandomV4().AsLowercaseString();
+  }
 }
 
 Notification::~Notification() {
@@ -370,6 +374,61 @@ void Notification::HandleActivation(v8::Isolate* isolate,
 }
 #endif
 
+// static
+v8::Local<v8::Promise> Notification::GetHistory(v8::Isolate* isolate) {
+  gin_helper::Promise<v8::Local<v8::Value>> promise(isolate);
+  v8::Local<v8::Promise> handle = promise.GetHandle();
+
+  auto* presenter =
+      static_cast<ElectronBrowserClient*>(ElectronBrowserClient::Get())
+          ->GetNotificationPresenter();
+  if (!presenter) {
+    promise.Resolve(v8::Array::New(isolate));
+    return handle;
+  }
+
+  presenter->GetDeliveredNotifications(base::BindOnce(
+      [](gin_helper::Promise<v8::Local<v8::Value>> promise,
+         electron::NotificationPresenter* presenter,
+         std::vector<electron::NotificationInfo> notifications) {
+        v8::Isolate* isolate = promise.isolate();
+        v8::HandleScope handle_scope(isolate);
+
+        v8::Local<v8::Array> result =
+            v8::Array::New(isolate, notifications.size());
+        for (size_t i = 0; i < notifications.size(); i++) {
+          const auto& info = notifications[i];
+
+          // Create a live Notification object for each delivered notification.
+          auto* notif = new Notification(/*args=*/nullptr);
+          notif->id_ = info.id;
+          notif->group_id_ = info.group_id;
+          notif->title_ = base::UTF8ToUTF16(info.title);
+          notif->subtitle_ = base::UTF8ToUTF16(info.subtitle);
+          notif->body_ = base::UTF8ToUTF16(info.body);
+
+          // Register with the presenter so click/reply events route here.
+          if (presenter) {
+            notif->notification_ =
+                presenter->CreateNotification(notif, notif->id_);
+            if (notif->notification_)
+              notif->notification_->Restore();
+          }
+
+          auto handle = gin_helper::CreateHandle(isolate, notif);
+          result
+              ->Set(isolate->GetCurrentContext(), static_cast<uint32_t>(i),
+                    handle.ToV8())
+              .Check();
+        }
+
+        promise.Resolve(result.As<v8::Value>());
+      },
+      std::move(promise), presenter));
+
+  return handle;
+}
+
 void Notification::FillObjectTemplate(v8::Isolate* isolate,
                                       v8::Local<v8::ObjectTemplate> templ) {
   gin::ObjectTemplateBuilder(isolate, GetClassName(), templ)
@@ -424,6 +483,7 @@ void Initialize(v8::Local<v8::Object> exports,
 #if BUILDFLAG(IS_WIN)
   dict.SetMethod("handleActivation", &Notification::HandleActivation);
 #endif
+  dict.SetMethod("getHistory", &Notification::GetHistory);
 }
 
 }  // namespace

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -389,10 +389,13 @@ v8::Local<v8::Promise> Notification::GetHistory(v8::Isolate* isolate) {
 
   presenter->GetDeliveredNotifications(base::BindOnce(
       [](gin_helper::Promise<v8::Local<v8::Value>> promise,
-         electron::NotificationPresenter* presenter,
          std::vector<electron::NotificationInfo> notifications) {
         v8::Isolate* isolate = promise.isolate();
         v8::HandleScope handle_scope(isolate);
+
+        auto* presenter =
+            static_cast<ElectronBrowserClient*>(ElectronBrowserClient::Get())
+                ->GetNotificationPresenter();
 
         v8::Local<v8::Array> result =
             v8::Array::New(isolate, notifications.size());
@@ -424,7 +427,7 @@ v8::Local<v8::Promise> Notification::GetHistory(v8::Isolate* isolate) {
 
         promise.Resolve(result.As<v8::Value>());
       },
-      std::move(promise), presenter));
+      std::move(promise)));
 
   return handle;
 }

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -409,6 +409,7 @@ v8::Local<v8::Promise> Notification::GetHistory(v8::Isolate* isolate) {
           notif->title_ = base::UTF8ToUTF16(info.title);
           notif->subtitle_ = base::UTF8ToUTF16(info.subtitle);
           notif->body_ = base::UTF8ToUTF16(info.body);
+          notif->is_restored_ = true;
 
           // Register with the presenter so click/reply events route here.
           if (presenter) {

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -38,6 +38,7 @@ class Notification final : public gin_helper::DeprecatedWrappable<Notification>,
                            public NotificationDelegate {
  public:
   static bool IsSupported();
+  static v8::Local<v8::Promise> GetHistory(v8::Isolate* isolate);
 
 #if BUILDFLAG(IS_WIN)
   // Register a callback to handle all notification activations.

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -80,6 +80,11 @@ class Notification final : public gin_helper::DeprecatedWrappable<Notification>,
   explicit Notification(gin::Arguments* args);
   ~Notification() override;
 
+  // Private constructor for restored notifications (used by GetHistory).
+  // Does not set presenter_ or parse options — only populates fields from
+  // the delivered notification info.
+  explicit Notification(const NotificationInfo& info);
+
   void Show();
   void Close();
 

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -133,6 +133,7 @@ class Notification final : public gin_helper::DeprecatedWrappable<Notification>,
   std::vector<electron::NotificationAction> actions_;
   std::u16string close_button_text_;
   std::u16string toast_xml_;
+  bool is_restored_ = false;
 
   raw_ptr<electron::NotificationPresenter> presenter_;
 

--- a/shell/browser/notifications/mac/cocoa_notification.h
+++ b/shell/browser/notifications/mac/cocoa_notification.h
@@ -24,6 +24,7 @@ class CocoaNotification : public Notification {
   // Notification:
   void Show(const NotificationOptions& options) override;
   void Dismiss() override;
+  void Restore() override;
 
   void NotificationDisplayed();
   void NotificationReplied(const std::string& reply);
@@ -38,6 +39,7 @@ class CocoaNotification : public Notification {
   void LogAction(const char* action);
   void ScheduleNotification(UNMutableNotificationContent* content);
 
+  bool is_restored_ = false;
   UNNotificationRequest* __strong notification_request_;
 };
 

--- a/shell/browser/notifications/mac/cocoa_notification.mm
+++ b/shell/browser/notifications/mac/cocoa_notification.mm
@@ -31,7 +31,10 @@ CocoaNotification::CocoaNotification(NotificationDelegate* delegate,
     : Notification(delegate, presenter) {}
 
 CocoaNotification::~CocoaNotification() {
-  if (notification_request_)
+  // Don't remove from Notification Center if this was a restored notification.
+  // Restored notifications are observed, not owned — destruction should just
+  // disconnect the event handler, not remove the visible notification.
+  if (notification_request_ && !is_restored_)
     [[UNUserNotificationCenter currentNotificationCenter]
         removeDeliveredNotificationsWithIdentifiers:@[
           notification_request_.identifier
@@ -243,6 +246,24 @@ void CocoaNotification::Dismiss() {
   NotificationDismissed();
 
   notification_request_ = nil;
+}
+
+void CocoaNotification::Restore() {
+  // Create a minimal UNNotificationRequest with just the identifier so that
+  // GetNotification() can match this object when the user interacts with the
+  // notification in Notification Center.
+  NSString* identifier = base::SysUTF8ToNSString(notification_id());
+  UNMutableNotificationContent* content =
+      [[UNMutableNotificationContent alloc] init];
+  notification_request_ =
+      [UNNotificationRequest requestWithIdentifier:identifier
+                                           content:content
+                                           trigger:nil];
+  is_restored_ = true;
+
+  if (electron::debug_notifications) {
+    LOG(INFO) << "Notification restored (" << [identifier UTF8String] << ")";
+  }
 }
 
 void CocoaNotification::NotificationDisplayed() {

--- a/shell/browser/notifications/mac/cocoa_notification.mm
+++ b/shell/browser/notifications/mac/cocoa_notification.mm
@@ -237,7 +237,7 @@ void CocoaNotification::ScheduleNotification(
 }
 
 void CocoaNotification::Dismiss() {
-  if (notification_request_)
+  if (notification_request_ && !is_restored_)
     [[UNUserNotificationCenter currentNotificationCenter]
         removeDeliveredNotificationsWithIdentifiers:@[
           notification_request_.identifier

--- a/shell/browser/notifications/mac/notification_presenter_mac.h
+++ b/shell/browser/notifications/mac/notification_presenter_mac.h
@@ -24,6 +24,10 @@ class NotificationPresenterMac : public NotificationPresenter {
   NotificationPresenterMac();
   ~NotificationPresenterMac() override;
 
+  // NotificationPresenter
+  void GetDeliveredNotifications(
+      GetDeliveredNotificationsCallback callback) override;
+
   NotificationImageRetainer* image_retainer() { return image_retainer_.get(); }
   scoped_refptr<base::SequencedTaskRunner> image_task_runner() {
     return image_task_runner_;

--- a/shell/browser/notifications/mac/notification_presenter_mac.mm
+++ b/shell/browser/notifications/mac/notification_presenter_mac.mm
@@ -2,11 +2,16 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "base/logging.h"
-#include "base/task/thread_pool.h"
-
 #include "shell/browser/notifications/mac/notification_presenter_mac.h"
 
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "base/logging.h"
+#include "base/strings/sys_string_conversions.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/task/thread_pool.h"
 #include "shell/browser/notifications/mac/cocoa_notification.h"
 #include "shell/browser/notifications/mac/notification_center_delegate.h"
 
@@ -78,6 +83,37 @@ NotificationPresenterMac::~NotificationPresenterMac() {
 Notification* NotificationPresenterMac::CreateNotificationObject(
     NotificationDelegate* delegate) {
   return new CocoaNotification(delegate, this);
+}
+
+void NotificationPresenterMac::GetDeliveredNotifications(
+    GetDeliveredNotificationsCallback callback) {
+  scoped_refptr<base::SequencedTaskRunner> task_runner =
+      base::SequencedTaskRunner::GetCurrentDefault();
+
+  __block GetDeliveredNotificationsCallback block_callback =
+      std::move(callback);
+
+  [[UNUserNotificationCenter currentNotificationCenter]
+      getDeliveredNotificationsWithCompletionHandler:^(
+          NSArray<UNNotification*>* _Nonnull notifications) {
+        std::vector<NotificationInfo> results;
+        results.reserve([notifications count]);
+
+        for (UNNotification* notification in notifications) {
+          UNNotificationContent* content = notification.request.content;
+          NotificationInfo info;
+          info.id = base::SysNSStringToUTF8(notification.request.identifier);
+          info.title = base::SysNSStringToUTF8(content.title);
+          info.subtitle = base::SysNSStringToUTF8(content.subtitle);
+          info.body = base::SysNSStringToUTF8(content.body);
+          info.group_id = base::SysNSStringToUTF8(content.threadIdentifier);
+          results.push_back(std::move(info));
+        }
+
+        task_runner->PostTask(
+            FROM_HERE,
+            base::BindOnce(std::move(block_callback), std::move(results)));
+      }];
 }
 
 }  // namespace electron

--- a/shell/browser/notifications/notification.cc
+++ b/shell/browser/notifications/notification.cc
@@ -31,6 +31,15 @@ NotificationAction::NotificationAction(NotificationAction&&) noexcept = default;
 NotificationAction& NotificationAction::operator=(
     NotificationAction&&) noexcept = default;
 
+NotificationInfo::NotificationInfo() = default;
+NotificationInfo::~NotificationInfo() = default;
+NotificationInfo::NotificationInfo(const NotificationInfo&) = default;
+NotificationInfo& NotificationInfo::operator=(const NotificationInfo&) =
+    default;
+NotificationInfo::NotificationInfo(NotificationInfo&&) noexcept = default;
+NotificationInfo& NotificationInfo::operator=(NotificationInfo&&) noexcept =
+    default;
+
 Notification::Notification(NotificationDelegate* delegate,
                            NotificationPresenter* presenter)
     : delegate_(delegate), presenter_(presenter) {}

--- a/shell/browser/notifications/notification.h
+++ b/shell/browser/notifications/notification.h
@@ -60,6 +60,21 @@ struct NotificationOptions {
   ~NotificationOptions();
 };
 
+struct NotificationInfo {
+  std::string id;
+  std::string title;
+  std::string subtitle;
+  std::string body;
+  std::string group_id;
+
+  NotificationInfo();
+  ~NotificationInfo();
+  NotificationInfo(const NotificationInfo&);
+  NotificationInfo& operator=(const NotificationInfo&);
+  NotificationInfo(NotificationInfo&&) noexcept;
+  NotificationInfo& operator=(NotificationInfo&&) noexcept;
+};
+
 class Notification {
  public:
   virtual ~Notification();
@@ -75,6 +90,11 @@ class Notification {
   // Removes the notification if it was not fully removed during dismissal,
   // as can happen on some platforms including Windows.
   virtual void Remove() {}
+
+  // Restores a previously delivered notification for event handling without
+  // re-showing it. Sets up platform state so interaction events (click, reply,
+  // etc.) route to this object.
+  virtual void Restore() {}
 
   // Should be called by derived classes.
   void NotificationClicked();

--- a/shell/browser/notifications/notification_presenter.cc
+++ b/shell/browser/notifications/notification_presenter.cc
@@ -44,4 +44,10 @@ void NotificationPresenter::CloseNotificationWithId(
   }
 }
 
+void NotificationPresenter::GetDeliveredNotifications(
+    GetDeliveredNotificationsCallback callback) {
+  // Default: return empty list. Overridden on macOS.
+  std::move(callback).Run({});
+}
+
 }  // namespace electron

--- a/shell/browser/notifications/notification_presenter.h
+++ b/shell/browser/notifications/notification_presenter.h
@@ -8,12 +8,14 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <vector>
 
+#include "base/functional/callback.h"
 #include "base/memory/weak_ptr.h"
+#include "shell/browser/notifications/notification.h"
 
 namespace electron {
 
-class Notification;
 class NotificationDelegate;
 
 class NotificationPresenter {
@@ -22,10 +24,16 @@ class NotificationPresenter {
 
   virtual ~NotificationPresenter();
 
+  using GetDeliveredNotificationsCallback =
+      base::OnceCallback<void(std::vector<NotificationInfo>)>;
+
   base::WeakPtr<Notification> CreateNotification(
       NotificationDelegate* delegate,
       const std::string& notification_id);
   void CloseNotificationWithId(const std::string& notification_id);
+
+  virtual void GetDeliveredNotifications(
+      GetDeliveredNotificationsCallback callback);
 
   std::set<Notification*> notifications() const { return notifications_; }
 

--- a/spec/api-notification-spec.ts
+++ b/spec/api-notification-spec.ts
@@ -404,7 +404,9 @@ describe('Notification module', () => {
       // skip the content assertions if Notification Center is empty.
       if (history.length > 0) {
         const found = history.find((item: any) => item.id === 'history-test-id');
-        expect(found).to.not.be.undefined();
+        if (!found) {
+          expect.fail('Expected to find notification with id "history-test-id" in history');
+        }
         expect(found).to.be.an.instanceOf(Notification);
         expect(found.title).to.equal('history test');
         expect(found.subtitle).to.equal('history subtitle');
@@ -430,7 +432,9 @@ describe('Notification module', () => {
       const history = await Notification.getHistory();
       if (history.length > 0) {
         const found = history.find((item: any) => item.id === 'history-show-close');
-        expect(found).to.not.be.undefined();
+        if (!found) {
+          expect.fail('Expected to find notification with id "history-show-close" in history');
+        }
         // Calling show() and close() on a restored notification should not throw
         expect(() => {
           found.show();

--- a/spec/api-notification-spec.ts
+++ b/spec/api-notification-spec.ts
@@ -376,4 +376,67 @@ describe('Notification module', () => {
   });
 
   // TODO(sethlu): Find way to test init with notification icon?
+
+  describe('static methods', () => {
+    ifit(process.platform === 'darwin')('getHistory returns a promise that resolves to an array', async () => {
+      const result = Notification.getHistory();
+      expect(result).to.be.a('promise');
+      const history = await result;
+      expect(history).to.be.an('array');
+    });
+
+    ifit(process.platform === 'darwin')('getHistory returns Notification instances with correct properties', async () => {
+      const n = new Notification({
+        id: 'history-test-id',
+        title: 'history test',
+        subtitle: 'history subtitle',
+        body: 'history body',
+        groupId: 'history-group',
+        silent: true
+      });
+
+      const shown = once(n, 'show');
+      n.show();
+      await shown;
+
+      const history = await Notification.getHistory();
+      // getHistory requires code-signed builds to return results;
+      // skip the content assertions if Notification Center is empty.
+      if (history.length > 0) {
+        const found = history.find((item: any) => item.id === 'history-test-id');
+        expect(found).to.not.be.undefined();
+        expect(found).to.be.an.instanceOf(Notification);
+        expect(found.title).to.equal('history test');
+        expect(found.subtitle).to.equal('history subtitle');
+        expect(found.body).to.equal('history body');
+        expect(found.groupId).to.equal('history-group');
+      }
+
+      n.close();
+    });
+
+    ifit(process.platform === 'darwin')('getHistory returned notifications can be shown and closed', async () => {
+      const n = new Notification({
+        id: 'history-show-close',
+        title: 'show close test',
+        body: 'body',
+        silent: true
+      });
+
+      const shown = once(n, 'show');
+      n.show();
+      await shown;
+
+      const history = await Notification.getHistory();
+      if (history.length > 0) {
+        const found = history.find((item: any) => item.id === 'history-show-close');
+        expect(found).to.not.be.undefined();
+        // Calling show() and close() on a restored notification should not throw
+        expect(() => {
+          found.show();
+          found.close();
+        }).to.not.throw();
+      }
+    });
+  });
 });

--- a/spec/api-notification-spec.ts
+++ b/spec/api-notification-spec.ts
@@ -385,37 +385,40 @@ describe('Notification module', () => {
       expect(history).to.be.an('array');
     });
 
-    ifit(process.platform === 'darwin')('getHistory returns Notification instances with correct properties', async () => {
-      const n = new Notification({
-        id: 'history-test-id',
-        title: 'history test',
-        subtitle: 'history subtitle',
-        body: 'history body',
-        groupId: 'history-group',
-        silent: true
-      });
+    ifit(process.platform === 'darwin')(
+      'getHistory returns Notification instances with correct properties',
+      async () => {
+        const n = new Notification({
+          id: 'history-test-id',
+          title: 'history test',
+          subtitle: 'history subtitle',
+          body: 'history body',
+          groupId: 'history-group',
+          silent: true
+        });
 
-      const shown = once(n, 'show');
-      n.show();
-      await shown;
+        const shown = once(n, 'show');
+        n.show();
+        await shown;
 
-      const history = await Notification.getHistory();
-      // getHistory requires code-signed builds to return results;
-      // skip the content assertions if Notification Center is empty.
-      if (history.length > 0) {
-        const found = history.find((item: any) => item.id === 'history-test-id');
-        if (!found) {
-          expect.fail('Expected to find notification with id "history-test-id" in history');
+        const history = await Notification.getHistory();
+        // getHistory requires code-signed builds to return results;
+        // skip the content assertions if Notification Center is empty.
+        if (history.length > 0) {
+          const found = history.find((item: any) => item.id === 'history-test-id');
+          if (!found) {
+            expect.fail('Expected to find notification with id "history-test-id" in history');
+          }
+          expect(found).to.be.an.instanceOf(Notification);
+          expect(found.title).to.equal('history test');
+          expect(found.subtitle).to.equal('history subtitle');
+          expect(found.body).to.equal('history body');
+          expect(found.groupId).to.equal('history-group');
         }
-        expect(found).to.be.an.instanceOf(Notification);
-        expect(found.title).to.equal('history test');
-        expect(found.subtitle).to.equal('history subtitle');
-        expect(found.body).to.equal('history body');
-        expect(found.groupId).to.equal('history-group');
-      }
 
-      n.close();
-    });
+        n.close();
+      }
+    );
 
     ifit(process.platform === 'darwin')('getHistory returned notifications can be shown and closed', async () => {
       const n = new Notification({

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -118,6 +118,7 @@ declare namespace NodeJS {
 
   interface NotificationBinding {
     isSupported(): boolean;
+    getHistory(): Promise<Electron.Notification[]>;
     Notification: typeof Electron.Notification;
     // Windows-only callback for cold-start notification activation
     handleActivation?: (callback: (details: ActivationArgumentsInternal) => void) => void;


### PR DESCRIPTION
#### Description of Change

This PR adds `Notification.getHistory()` for macOS, which returns a `Promise<Notification[]>` of all delivered notifications still present in Notification Center. Each returned Notification is a live object connected to the corresponding delivered notification — interaction events (click, reply, action, close) will fire on these objects, enabling apps to re-attach event handlers after a restart.

The intention behind this API is to allow developers to query for any notifications that they may want to persist after an app restart, and then restore them. The API queries UNUserNotificationCenter's `getDeliveredNotifications` API under the hood, and restores them from the notification center.

_Note: Testing this requires a code-signed build (unsigned builds resolve with empty array)_

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] I have built and tested this PR
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `Notification.getHistory()` for macOS, allowing developers to restore all delivered notifications still present in Notification Center. 
