### PR TITLE
chore: wordsmith non-maintainer dependency change bot message

### DIFF
--- a/.github/workflows/non-maintainer-dependency-change.yml
+++ b/.github/workflows/non-maintainer-dependency-change.yml
@@ -46,4 +46,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          printf "<!-- disallowed-non-maintainer-change -->\n\nHello @${{ github.event.pull_request.user.login }}! It looks like this pull request touches one of our dependency or CI files, and per [our contribution policy](https://github.com/electron/electron/blob/main/CONTRIBUTING.md#dependencies-upgrades-policy) we do not accept these types of changes in PRs." | gh pr review $PR_URL -r --body-file=-
+          cat <<'REVIEW_EOF' | sed "s/%AUTHOR%/${{ github.event.pull_request.user.login }}/g" | gh pr review $PR_URL -r --body-file=-
+          <!-- disallowed-non-maintainer-change -->
+
+          Hello @%AUTHOR%! It looks like this pull request touches one of our dependency or CI files, and per [our contribution policy](https://github.com/electron/electron/blob/main/CONTRIBUTING.md#dependencies-upgrades-policy) we do not accept these types of changes in PRs.
+
+          To move this PR forward, please:
+
+          1. Revert the dependency/CI file changes from your branch. (e.g. `yarn.lock`, `.yarn/`, `.yarnrc.yml`, `.github/workflows/`, `.github/actions/`)
+          2. Ensure your branch [allows maintainer commits](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) so a maintainer can push the necessary dependency changes on your behalf.
+          3. Leave a comment letting reviewers know the dependency change is still needed.
+
+          <details>
+          <summary>For maintainers</summary>
+
+          To land this PR, push a verified commit to the contributor's branch with the required dependency/CI changes, then dismiss this review.
+
+          </details>
+          REVIEW_EOF


### PR DESCRIPTION
#### Description of Change

Add some guidance to the bot message when a non-maintainer contributes a PR that changes a disallowed file (dependency lockfiles, CI configs).

**New message**:

> Hello @%AUTHOR%! It looks like this pull request touches one of our dependency or CI files, and per [our contribution policy](https://github.com/electron/electron/blob/main/CONTRIBUTING.md#dependencies-upgrades-policy) we do not accept these types of changes in PRs.
>
> To move this PR forward, please:
>
> 1. Revert the dependency/CI file changes from your branch. (e.g. `yarn.lock`, `.yarn/`, `.yarnrc.yml`, `.github/workflows/`, `.github/actions/`)
> 2. Ensure your branch [allows maintainer commits](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) so a maintainer can push the necessary dependency changes on your behalf.
> 3. Leave a comment letting reviewers know the dependency change is still needed.
>
> <details>
> <summary>For maintainers</summary>
>
> To land this PR, push a verified commit to the contributor's branch with the required dependency/CI changes, then dismiss this review.
>
> </details>

#### Checklist

- [x] PR description included

#### Release Notes

Notes: none
