### PR TITLE
ci: auto close PRs that do not fill out the required template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,8 @@ Thank you for your Pull Request. Please provide a description above and review
 the requirements below.
 
 Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
+
+NOTE: PRS submitted without this template will be automatically closed.
 -->
 
 #### Checklist

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,0 +1,53 @@
+name: PR Template Check
+
+on:
+  pull_request_target:
+    types: [opened, edited]
+
+permissions: {}
+
+jobs:
+  check-pr-template:
+    name: Check PR Template
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          sparse-checkout: .github/PULL_REQUEST_TEMPLATE.md
+          sparse-checkout-cone-mode: false
+      - name: Check for required sections
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const template = fs.readFileSync('.github/PULL_REQUEST_TEMPLATE.md', 'utf8');
+            const requiredSections = [...template.matchAll(/^(#{1,4} .+)$/gm)].map(
+              (m) => m[1],
+            );
+            if (requiredSections.length === 0) {
+              console.log('No heading sections found in PR template');
+              return;
+            }
+            const body = context.payload.pull_request.body || '';
+            const missingSections = requiredSections.filter(
+              (section) => !body.includes(section),
+            );
+            if (missingSections.length > 0) {
+              const list = missingSections.map((s) => `- \`${s}\``).join('\n');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: `This PR was automatically closed because the PR template was not properly filled out. The following required sections are missing:\n\n${list}\n\nPlease update your PR description to include all required sections and reopen the PR.`,
+              });
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                state: 'closed',
+              });
+            }


### PR DESCRIPTION
#### Description of Change
This PR adds a check to validate that the PR template has been filled out.  If the template has not been filled out, the PR will be automatically closed with a note asking the author to update the description with the template

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
