### PR TITLE
ci: only run auto close on PRs targeting main branch

### DIFF
--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -3,6 +3,8 @@ name: PR Template Check
 on:
   pull_request_target:
     types: [opened, edited]
+    branches:
+      - main
 
 permissions: {}
 


### PR DESCRIPTION
#### Description of Change
- Followup to #50348.  That PR unfortunately autoclosed trop initiated backports since those use a simpler PR description.  This PR changes the auto close logic to only target main.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

NOTE: PRS submitted without this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
