### PR TITLE
docs: remove postinstall lifecycle warning

### DIFF
--- a/docs/tutorial/tutorial-2-first-app.md
+++ b/docs/tutorial/tutorial-2-first-app.md
@@ -83,17 +83,6 @@ dependency.
 npm install electron --save-dev
 ```
 
-:::warning
-
-If you are installing Electron v41.x or below, you need to ensure that its `postinstall` lifecycle
-script is able to run. This means avoiding the `--ignore-scripts` flag on npm and allowlisting
-`electron` to run build scripts on other package managers.
-
-This has changed with Electron v42. See
-[electron/rfcs#22](https://github.com/electron/rfcs/pull/22) for more details.
-
-:::
-
 Your package.json file should look something like this after initializing your package
 and installing Electron. You should also now have a `node_modules` folder containing
 the Electron executable, as well as a `package-lock.json` lockfile that specifies


### PR DESCRIPTION
#### Description of Change
remove `postinstall` lifecycle warnings because they are redundant as of electron v42
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

NOTE: PRS submitted without this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
