### PR TITLE
ci: output build cache hit rate as GHA annotation

### DIFF
--- a/script/build-stats.mjs
+++ b/script/build-stats.mjs
@@ -32,7 +32,8 @@ async function main () {
   }));
   const hitRate = stats.CacheHit / (stats.Remote + stats.CacheHit + stats.LocalFallback);
 
-  console.log(`Effective cache hit rate: ${(hitRate * 100).toFixed(2)}%`);
+  const messagePrefix = process.env.GITHUB_ACTIONS ? '::notice title=Build Stats::' : '';
+  console.log(`${messagePrefix}Effective cache hit rate: ${(hitRate * 100).toFixed(2)}%`);
 
   if (uploadStats) {
     if (!process.env.DD_API_KEY) {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

NOTE: PRS submitted without this template will be automatically closed.
-->

Small quality of life improvement here so you can easily see the effective cache hit rate for any given build without needing to open the 20 MB log file and search for this line.

This is what it will look like, as an annotation at the top of every build job:

<img width="330" height="245" alt="Example Screenshot" src="https://github.com/user-attachments/assets/8de3eced-986c-42b0-a9fa-438d2947ce0d" />

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
