### PR TITLE
fix: account for extraSize in aspect ratio min/max size clamping on macOS

### DIFF
--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -163,13 +163,16 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
         shell_->has_frame() ? NSMakeSize(0, titleBarHeight) : NSZeroSize;
     if (!NSEqualSizes(minSize, zeroSize)) {
       double minWidthForAspectRatio =
-          (minSize.height - titleBarHeight) * aspectRatio;
+          (minSize.height - extraHeightPlusFrame) * aspectRatio +
+          extraWidthPlusFrame;
       bool atMinHeight =
           minSize.height > zeroSize.height && newSize.height <= minSize.height;
       newSize.width = atMinHeight ? minWidthForAspectRatio
                                   : std::max(newSize.width, minSize.width);
 
-      double minHeightForAspectRatio = minSize.width / aspectRatio;
+      double minHeightForAspectRatio =
+          (minSize.width - extraWidthPlusFrame) / aspectRatio +
+          extraHeightPlusFrame;
       bool atMinWidth =
           minSize.width > zeroSize.width && newSize.width <= minSize.width;
       newSize.height = atMinWidth ? minHeightForAspectRatio
@@ -179,13 +182,17 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
     // Clamp to maximum width/height while ensuring aspect ratio remains.
     NSSize maxSize = [window maxSize];
     if (!NSEqualSizes(maxSize, NSMakeSize(FLT_MAX, FLT_MAX))) {
-      double maxWidthForAspectRatio = maxSize.height * aspectRatio;
+      double maxWidthForAspectRatio =
+          (maxSize.height - extraHeightPlusFrame) * aspectRatio +
+          extraWidthPlusFrame;
       bool atMaxHeight =
           maxSize.height < FLT_MAX && newSize.height >= maxSize.height;
       newSize.width = atMaxHeight ? maxWidthForAspectRatio
                                   : std::min(newSize.width, maxSize.width);
 
-      double maxHeightForAspectRatio = maxSize.width / aspectRatio;
+      double maxHeightForAspectRatio =
+          (maxSize.width - extraWidthPlusFrame) / aspectRatio +
+          extraHeightPlusFrame;
       bool atMaxWidth =
           maxSize.width < FLT_MAX && newSize.width >= maxSize.width;
       newSize.height = atMaxWidth ? maxHeightForAspectRatio


### PR DESCRIPTION
#### Description of Change

The min/max clamping paths in `windowWillResize:toSize:` use different formulas than the normal resize path when computing dimensions from the aspect ratio:

| Calculation | Normal resize | Min clamping (before) | Max clamping (before) |
|---|---|---|---|
| Width from height | `(h - extraH) * ratio + extraW` | `(h - titleBar) * ratio` | `h * ratio` |
| Height from width | `(w - extraW) / ratio + extraH` | `w / ratio` | `w / ratio` |

The normal path correctly incorporates `extraWidthPlusFrame` and `extraHeightPlusFrame`, but the min clamping used only `titleBarHeight` (ignoring `extraSize`) and the max clamping used neither. This causes incorrect aspect-ratio-constrained sizes when a window with `extraSize` hits its min or max bounds.

This PR unifies all four clamping formulas to match the normal resize path. When `extraSize` is `{0, 0}` (default), the formulas degenerate to the previous behavior — no existing windows are affected.

Related: #37306 introduced the min/max clamping logic without `extraSize` support.

**Verification matrix:**

| Boundary hit | `extraSize` | Expected |
|---|---|---|
| `minHeight` | `{ w:0, h:36 }` | Width = `(minH - extraH) * ratio + extraW` |
| `minWidth` | `{ w:100, h:0 }` | Height = `(minW - extraW) / ratio + extraH` |
| `maxHeight` | `{ w:0, h:36 }` | Width = `(maxH - extraH) * ratio + extraW` |
| `maxWidth` | `{ w:100, h:0 }` | Height = `(maxW - extraW) / ratio + extraH` |
| `minHeight` | none | Unchanged |
| `maxHeight` | none | Unchanged |

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed aspect ratio min/max size clamping to correctly account for `extraSize` on macOS.