### PR TITLE
ci: allow alternate PR descriptions for dependabot

### DIFF
--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   check-pr-template:
-    if: ${{ github.event.pull_request.head.repo.fork && !github.event.pull_request.draft && !startsWith(github.head_ref, 'roller/') }}
+    if: ${{ github.event.pull_request.head.repo.fork && !github.event.pull_request.draft && !startsWith(github.head_ref, 'roller/') && github.actor != 'dependabot[bot]' }}
     name: Check PR Template
     runs-on: ubuntu-slim
     permissions:


### PR DESCRIPTION
#### Description of Change
- Followup to #50348.  That PR unfortunately autoclosed dependabot PRs since those use a different PR description.  This PR changes the auto close logic to ignore dependabot PRs.  
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

NOTE: PRS submitted without this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
