### PR TITLE
docs: clarify allowed characters in protocol names

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -56,6 +56,15 @@ app.whenReady().then(() => {
 })
 ```
 
+## Protocol names
+
+[RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) defines what a valid
+protocol name is:
+
+> Scheme names consist of a sequence of characters beginning with a letter and followed
+> by any combination of letters, digits, plus ("+"), period ("."), or hyphen ("-").
+> Although schemes are case-insensitive, the canonical form is lowercase […].
+
 ## Methods
 
 The `protocol` module has the following methods:


### PR DESCRIPTION
#### Description of Change

Had to look this up, so thought we should document it. :)

#### Checklist

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
