### PR TITLE
docs: link menu type references

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -44,8 +44,8 @@ See [`Menu`](menu.md) for examples.
     menu items.
   * `registerAccelerator` boolean (optional) _Linux_ _Windows_ - If false, the accelerator won't be registered
     with the system, but it will still be displayed. Defaults to true.
-  * `sharingItem` SharingItem (optional) _macOS_ - The item to share when the `role` is `shareMenu`.
-  * `submenu` (MenuItemConstructorOptions[] | [Menu](menu.md)) (optional) - Should be specified
+  * `sharingItem` [SharingItem](structures/sharing-item.md) (optional) _macOS_ - The item to share when the `role` is `shareMenu`.
+  * `submenu` ([MenuItemConstructorOptions](#new-menuitemoptions)[] | [Menu](menu.md)) (optional) - Should be specified
     for `submenu` type menu items. If `submenu` is specified, the `type: 'submenu'` can be omitted.
     If the value is not a [`Menu`](menu.md) then it will be automatically converted to one using
     `Menu.buildFromTemplate`.
@@ -89,7 +89,7 @@ A `Function` that is fired when the MenuItem receives a click event.
 It can be called with `menuItem.click(event, focusedWindow, focusedWebContents)`.
 
 * `event` [KeyboardEvent](structures/keyboard-event.md)
-* `focusedWindow` [BaseWindow](browser-window.md)
+* `focusedWindow` [BaseWindow](base-window.md)
 * `focusedWebContents` [WebContents](web-contents.md)
 
 #### `menuItem.submenu`
@@ -110,11 +110,11 @@ A `string` (optional) indicating the item's role, if set. Can be `undo`, `redo`,
 
 #### `menuItem.accelerator`
 
-An `Accelerator | null` indicating the item's accelerator, if set.
+An [`Accelerator | null`](../tutorial/keyboard-shortcuts.md#accelerators) indicating the item's accelerator, if set.
 
 #### `menuItem.userAccelerator` _Readonly_ _macOS_
 
-An `Accelerator | null` indicating the item's [user-assigned accelerator](https://developer.apple.com/documentation/appkit/nsmenuitem/1514850-userkeyequivalent?language=objc) for the menu item.
+An [`Accelerator | null`](../tutorial/keyboard-shortcuts.md#accelerators) indicating the item's [user-assigned accelerator](https://developer.apple.com/documentation/appkit/nsmenuitem/1514850-userkeyequivalent?language=objc) for the menu item.
 
 > [!NOTE]
 > This property is only initialized after the `MenuItem` has been added to a `Menu`. Either via `Menu.buildFromTemplate` or via `Menu.append()/insert()`.  Accessing before initialization will just return `null`.
@@ -170,7 +170,7 @@ This property can be dynamically changed.
 
 #### `menuItem.sharingItem` _macOS_
 
-A `SharingItem` indicating the item to share when the `role` is `shareMenu`.
+A [`SharingItem`](structures/sharing-item.md) indicating the item to share when the `role` is `shareMenu`.
 
 This property can be dynamically changed.
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -70,7 +70,7 @@ for more information on macOS' native actions.
 
 #### `Menu.buildFromTemplate(template)`
 
-- `template` (MenuItemConstructorOptions | [MenuItem](menu-item.md))[]
+- `template` ([MenuItemConstructorOptions](menu-item.md#new-menuitemoptions) | [MenuItem](menu-item.md))[]
 
 Returns [`Menu`](menu.md)
 
@@ -162,7 +162,7 @@ Emitted when a popup is closed either manually or with `menu.closePopup()`.
 
 #### `menu.items`
 
-A `MenuItem[]` array containing the menu's items.
+A [`MenuItem[]`](menu-item.md) array containing the menu's items.
 
 Each `Menu` consists of multiple [`MenuItem`](menu-item.md) instances and each `MenuItem`
 can nest a `Menu` into its `submenu` property.


### PR DESCRIPTION
#### Description of Change

- link previously unlinked type references in the `Menu` and `MenuItem` docs
- add links for `MenuItemConstructorOptions`, `SharingItem`, and `Accelerator`
- fix the `focusedWindow` `BaseWindow` link target in `MenuItem`

Closes #48904

#### Checklist

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none