### PR TITLE
feat: add native Liquid Glass support on macOS 26+

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -1501,6 +1501,54 @@ See the [Windows documentation](https://learn.microsoft.com/en-us/windows/win32/
 > [!NOTE]
 > This method is only supported on Windows 11 22H2 and up.
 
+#### `win.setGlassEffect(options)` _macOS_ _Experimental_
+
+* `options` Object | null
+  * `style` string (optional) - The glass style. Can be `regular` or `clear`. Defaults to `regular`.
+  * `cornerRadius` number (optional) - Corner radius of the glass shape. Defaults to `0`.
+  * `tintColor` string (optional) - CSS color used to tint the glass. Defaults to no tint.
+
+Applies a native Liquid Glass effect behind the entire window content area
+using [NSGlassEffectView][glass-docs]. The web contents render above the glass
+surface, so any transparent regions in the page reveal the glass underneath.
+Passing `null` removes the effect.
+
+> [!NOTE]
+> This method requires macOS 26.0 or later and has no effect on earlier
+> releases. Use `win.isGlassEffectSupported()` to check availability.
+
+#### `win.setGlassEffectRegions(regions)` _macOS_ _Experimental_
+
+* `regions` [GlassEffectRegion](structures/glass-effect-region.md)[] | null
+
+Places native Liquid Glass overlays above the web contents at the specified
+rectangles. Each glass view captures the web content behind it as its backdrop
+and renders the refraction and highlight effects on top. Mouse events pass
+through to the web content.
+
+Because each overlay sits above the web contents, any content the page
+renders inside a region's bounds appears underneath the glass and is
+refracted along with the rest of the backdrop. Edge distortion is
+pronounced while the center stays readable with a soft frosted look. For
+crisp, unrefracted content on top of the glass, provide a
+[`contentImage`](structures/glass-effect-region.md) per region.
+
+Call this method with the on-screen bounds of the elements you want to
+glassify, and call it again whenever the layout changes (for example,
+from a `ResizeObserver`). Glass regions stack in array order: the last
+region in the array renders on top.
+
+Passing `null` or an empty array removes all glass regions.
+
+> [!NOTE]
+> This method requires macOS 26.0 or later and has no effect on earlier
+> releases. Use `win.isGlassEffectSupported()` to check availability.
+
+#### `win.isGlassEffectSupported()` _macOS_
+
+Returns `boolean` - Whether the native Liquid Glass effect is available on
+this system (macOS 26.0 or later).
+
 #### `win.setWindowButtonPosition(position)` _macOS_
 
 * `position` [Point](structures/point.md) | null
@@ -1538,6 +1586,7 @@ On Linux, the `symbolColor` is automatically calculated to have minimum accessib
 
 [quick-look]: https://en.wikipedia.org/wiki/Quick_Look
 [vibrancy-docs]: https://developer.apple.com/documentation/appkit/nsvisualeffectview?preferredLanguage=objc
+[glass-docs]: https://developer.apple.com/documentation/appkit/nsglasseffectview?preferredLanguage=objc
 [window-levels]: https://developer.apple.com/documentation/appkit/nswindow/level
 [event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter
 [window-session-end-event]:../api/structures/window-session-end-event.md

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1722,6 +1722,54 @@ See the [Windows documentation](https://learn.microsoft.com/en-us/windows/win32/
 > [!NOTE]
 > This method is only supported on Windows 11 22H2 and up.
 
+#### `win.setGlassEffect(options)` _macOS_ _Experimental_
+
+* `options` Object | null
+  * `style` string (optional) - The glass style. Can be `regular` or `clear`. Defaults to `regular`.
+  * `cornerRadius` number (optional) - Corner radius of the glass shape. Defaults to `0`.
+  * `tintColor` string (optional) - CSS color used to tint the glass. Defaults to no tint.
+
+Applies a native Liquid Glass effect behind the entire window content area
+using [NSGlassEffectView][glass-docs]. The web contents render above the glass
+surface, so any transparent regions in the page reveal the glass underneath.
+Passing `null` removes the effect.
+
+> [!NOTE]
+> This method requires macOS 26.0 or later and has no effect on earlier
+> releases. Use `win.isGlassEffectSupported()` to check availability.
+
+#### `win.setGlassEffectRegions(regions)` _macOS_ _Experimental_
+
+* `regions` [GlassEffectRegion](structures/glass-effect-region.md)[] | null
+
+Places native Liquid Glass overlays above the web contents at the specified
+rectangles. Each glass view captures the web content behind it as its backdrop
+and renders the refraction and highlight effects on top. Mouse events pass
+through to the web content.
+
+Because each overlay sits above the web contents, any content the page
+renders inside a region's bounds appears underneath the glass and is
+refracted along with the rest of the backdrop. Edge distortion is
+pronounced while the center stays readable with a soft frosted look. For
+crisp, unrefracted content on top of the glass, provide a
+[`contentImage`](structures/glass-effect-region.md) per region.
+
+Call this method with the on-screen bounds of the elements you want to
+glassify, and call it again whenever the layout changes (for example,
+from a `ResizeObserver`). Glass regions stack in array order: the last
+region in the array renders on top.
+
+Passing `null` or an empty array removes all glass regions.
+
+> [!NOTE]
+> This method requires macOS 26.0 or later and has no effect on earlier
+> releases. Use `win.isGlassEffectSupported()` to check availability.
+
+#### `win.isGlassEffectSupported()` _macOS_
+
+Returns `boolean` - Whether the native Liquid Glass effect is available on
+this system (macOS 26.0 or later).
+
 #### `win.setWindowButtonPosition(position)` _macOS_
 
 * `position` [Point](structures/point.md) | null
@@ -1817,6 +1865,7 @@ On Linux, the `symbolColor` is automatically calculated to have minimum accessib
 [page-visibility-api]: https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
 [quick-look]: https://en.wikipedia.org/wiki/Quick_Look
 [vibrancy-docs]: https://developer.apple.com/documentation/appkit/nsvisualeffectview?preferredLanguage=objc
+[glass-docs]: https://developer.apple.com/documentation/appkit/nsglasseffectview?preferredLanguage=objc
 [window-levels]: https://developer.apple.com/documentation/appkit/nswindow/level
 [event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter
 [window-session-end-event]:../api/structures/window-session-end-event.md

--- a/docs/api/structures/base-window-options.md
+++ b/docs/api/structures/base-window-options.md
@@ -116,6 +116,13 @@
 * `backgroundMaterial` string (optional) _Windows_ - Set the window's
   system-drawn background material, including behind the non-client area.
   Can be `auto`, `none`, `mica`, `acrylic` or `tabbed`. See [win.setBackgroundMaterial](../browser-window.md#winsetbackgroundmaterialmaterial-windows) for more information.
+* `glassEffect` Object (optional) _macOS_ _Experimental_ - Apply a native
+  Liquid Glass effect behind the window content area. Requires macOS 26.0 or
+  later. See [win.setGlassEffect](../base-window.md#winsetglasseffectoptions-macos-experimental)
+  for more information.
+  * `style` string (optional) - The glass style. Can be `regular` or `clear`. Defaults to `regular`.
+  * `cornerRadius` number (optional) - Corner radius of the glass shape. Defaults to `0`.
+  * `tintColor` string (optional) - CSS color used to tint the glass.
 * `zoomToPageWidth` boolean (optional) _macOS_ - Controls the behavior on
   macOS when option-clicking the green stoplight button on the toolbar or by
   clicking the Window > Zoom menu item. If `true`, the window will grow to

--- a/docs/api/structures/glass-effect-region.md
+++ b/docs/api/structures/glass-effect-region.md
@@ -1,0 +1,10 @@
+# GlassEffectRegion Object
+
+* `x` number - The x coordinate of the region's origin in window content coordinates.
+* `y` number - The y coordinate of the region's origin in window content coordinates.
+* `width` number - The width of the region.
+* `height` number - The height of the region.
+* `style` string (optional) - The glass style. Can be `regular` or `clear`. Defaults to `regular`.
+* `cornerRadius` number (optional) - Corner radius of the glass shape. Defaults to `0`.
+* `tintColor` string (optional) - Color used to tint the glass, as a CSS string. Hex values with alpha follow Electron's `#AARRGGBB` convention (same as `backgroundColor`). Defaults to no tint.
+* `contentImage` [NativeImage](../native-image.md) (optional) - An image to render inside the glass's content view, on top of the glass surface. The image is centered, scaled down proportionally to fit, and receives native vibrancy filtering. Only honoured by `setGlassEffectRegions`.

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -96,6 +96,7 @@ auto_filenames = {
     "docs/api/structures/file-filter.md",
     "docs/api/structures/file-path-with-headers.md",
     "docs/api/structures/filesystem-permission-request.md",
+    "docs/api/structures/glass-effect-region.md",
     "docs/api/structures/gpu-feature-status.md",
     "docs/api/structures/hid-device.md",
     "docs/api/structures/input-event.md",

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -69,6 +69,51 @@ struct Converter<electron::TaskbarHost::ThumbarButton> {
 }  // namespace gin
 #endif
 
+#if BUILDFLAG(IS_MAC)
+namespace gin {
+
+template <>
+struct Converter<electron::GlassEffectStyle> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     electron::GlassEffectStyle* out) {
+    std::string s;
+    if (!ConvertFromV8(isolate, val, &s))
+      return false;
+    if (s == "regular")
+      *out = electron::GlassEffectStyle::kRegular;
+    else if (s == "clear")
+      *out = electron::GlassEffectStyle::kClear;
+    else
+      return false;
+    return true;
+  }
+};
+
+template <>
+struct Converter<electron::GlassEffectRegion> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     electron::GlassEffectRegion* out) {
+    gin_helper::Dictionary dict;
+    if (!ConvertFromV8(isolate, val, &dict))
+      return false;
+    dict.Get("style", &out->style);
+    dict.Get("cornerRadius", &out->corner_radius);
+    WrappedSkColor tint;
+    if (dict.Get("tintColor", &tint))
+      out->tint_color = tint;
+    dict.Get("contentImage", &out->content_image);
+    // Accept either flat x/y/width/height or a nested bounds object.
+    if (!dict.Get("bounds", &out->bounds))
+      ConvertFromV8(isolate, val, &out->bounds);
+    return true;
+  }
+};
+
+}  // namespace gin
+#endif
+
 namespace electron::api {
 
 namespace {
@@ -854,6 +899,20 @@ void BaseWindow::SetBackgroundMaterial(const std::string& material) {
 }
 
 #if BUILDFLAG(IS_MAC)
+void BaseWindow::SetGlassEffect(std::optional<GlassEffectRegion> options) {
+  window_->SetGlassEffect(std::move(options));
+}
+
+void BaseWindow::SetGlassEffectRegions(
+    std::optional<std::vector<GlassEffectRegion>> regions) {
+  window_->SetGlassEffectRegions(regions ? std::move(*regions)
+                                         : std::vector<GlassEffectRegion>{});
+}
+
+bool BaseWindow::IsGlassEffectSupported() const {
+  return window_->IsGlassEffectSupported();
+}
+
 std::string BaseWindow::GetAlwaysOnTopLevel() const {
   return window_->GetAlwaysOnTopLevel();
 }
@@ -1266,6 +1325,9 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setBackgroundMaterial", &BaseWindow::SetBackgroundMaterial)
 
 #if BUILDFLAG(IS_MAC)
+      .SetMethod("setGlassEffect", &BaseWindow::SetGlassEffect)
+      .SetMethod("setGlassEffectRegions", &BaseWindow::SetGlassEffectRegions)
+      .SetMethod("isGlassEffectSupported", &BaseWindow::IsGlassEffectSupported)
       .SetMethod("isHiddenInMissionControl",
                  &BaseWindow::IsHiddenInMissionControl)
       .SetMethod("setHiddenInMissionControl",

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -14,6 +14,7 @@
 
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
+#include "shell/browser/native_window.h"
 #include "shell/browser/native_window_observer.h"
 #include "shell/common/api/electron_api_native_image.h"
 #include "shell/common/gin_helper/trackable_object.h"
@@ -201,6 +202,10 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   virtual void SetBackgroundMaterial(const std::string& material);
 
 #if BUILDFLAG(IS_MAC)
+  void SetGlassEffect(std::optional<GlassEffectRegion> options);
+  void SetGlassEffectRegions(
+      std::optional<std::vector<GlassEffectRegion>> regions);
+  bool IsGlassEffectSupported() const;
   std::string GetAlwaysOnTopLevel() const;
   void SetWindowButtonVisibility(bool visible);
   bool GetWindowButtonVisibility() const;

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -20,6 +20,7 @@
 #include "shell/browser/ui/drag_util.h"
 #include "shell/browser/window_list.h"
 #include "shell/common/color_util.h"
+#include "shell/common/gin_converters/gfx_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/persistent_dictionary.h"
 #include "shell/common/options_switches.h"
@@ -231,6 +232,17 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
 #if BUILDFLAG(IS_MAC)
   if (std::string val; options.Get(options::kVibrancyType, &val))
     SetVibrancy(val, 0);
+
+  if (gin_helper::Dictionary glass;
+      options.Get(options::kGlassEffect, &glass)) {
+    GlassEffectRegion opts;
+    if (std::string s; glass.Get("style", &s) && s == "clear")
+      opts.style = GlassEffectStyle::kClear;
+    glass.Get("cornerRadius", &opts.corner_radius);
+    if (WrappedSkColor c; glass.Get("tintColor", &c))
+      opts.tint_color = c;
+    SetGlassEffect(std::move(opts));
+  }
 #elif BUILDFLAG(IS_WIN)
   if (std::string val; options.Get(options::kBackgroundMaterial, &val))
     SetBackgroundMaterial(val);
@@ -449,6 +461,27 @@ void NativeWindow::SetVibrancy(const std::string& type, int duration) {
 void NativeWindow::SetBackgroundMaterial(const std::string& type) {
   background_material_ = type;
 }
+
+#if BUILDFLAG(IS_MAC)
+GlassEffectRegion::GlassEffectRegion() = default;
+GlassEffectRegion::GlassEffectRegion(const GlassEffectRegion&) = default;
+GlassEffectRegion::GlassEffectRegion(GlassEffectRegion&&) = default;
+GlassEffectRegion& GlassEffectRegion::operator=(const GlassEffectRegion&) =
+    default;
+GlassEffectRegion& GlassEffectRegion::operator=(GlassEffectRegion&&) = default;
+GlassEffectRegion::~GlassEffectRegion() = default;
+
+void NativeWindow::SetGlassEffect(std::optional<GlassEffectRegion> options) {
+  has_glass_effect_ = options.has_value();
+}
+
+void NativeWindow::SetGlassEffectRegions(
+    std::vector<GlassEffectRegion> regions) {}
+
+bool NativeWindow::IsGlassEffectSupported() const {
+  return false;
+}
+#endif
 
 void NativeWindow::SetTouchBar(
     std::vector<gin_helper::PersistentDictionary> items) {}
@@ -784,6 +817,9 @@ bool NativeWindow::IsTranslucent() const {
 #if BUILDFLAG(IS_MAC)
   // Windows with vibrancy set are translucent
   if (!vibrancy_.empty())
+    return true;
+
+  if (has_glass_effect_)
     return true;
 #endif
 

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -22,6 +22,8 @@
 #include "extensions/browser/app_window/size_constraints.h"
 #include "shell/browser/native_window_observer.h"
 #include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
+#include "ui/gfx/geometry/rect.h"
+#include "ui/gfx/image/image.h"
 #include "ui/views/widget/widget_delegate.h"
 
 class SkRegion;
@@ -53,6 +55,26 @@ class BackgroundThrottlingSource;
 using NativeWindowHandle = gfx::NativeView;
 #else
 using NativeWindowHandle = gfx::AcceleratedWidget;
+#endif
+
+#if BUILDFLAG(IS_MAC)
+enum class GlassEffectStyle { kRegular, kClear };
+
+struct GlassEffectRegion {
+  GlassEffectRegion();
+  GlassEffectRegion(const GlassEffectRegion&);
+  GlassEffectRegion(GlassEffectRegion&&);
+  GlassEffectRegion& operator=(const GlassEffectRegion&);
+  GlassEffectRegion& operator=(GlassEffectRegion&&);
+  ~GlassEffectRegion();
+
+  GlassEffectStyle style = GlassEffectStyle::kRegular;
+  float corner_radius = 0.f;
+  std::optional<SkColor> tint_color;
+  // Region-only fields — ignored by SetGlassEffect.
+  gfx::Rect bounds;
+  gfx::Image content_image;
+};
 #endif
 
 class NativeWindow : public views::WidgetDelegate {
@@ -233,6 +255,22 @@ class NativeWindow : public views::WidgetDelegate {
   }
 
   virtual void SetBackgroundMaterial(const std::string& type);
+
+#if BUILDFLAG(IS_MAC)
+  // Liquid Glass API (macOS 26+).
+  //
+  // SetGlassEffect places a single NSGlassEffectView behind the web content,
+  // covering the full content area. Transparent page regions reveal the glass
+  // surface underneath. Pass std::nullopt to remove the effect.
+  //
+  // SetGlassEffectRegions places one NSGlassEffectView per region above the
+  // web content. Each glass view captures the web content behind it as its
+  // backdrop and renders the refraction/highlight effect. Mouse events pass
+  // through to the web content. Pass an empty vector to remove all regions.
+  virtual void SetGlassEffect(std::optional<GlassEffectRegion> options);
+  virtual void SetGlassEffectRegions(std::vector<GlassEffectRegion> regions);
+  virtual bool IsGlassEffectSupported() const;
+#endif
 
   // Traffic Light API
 #if BUILDFLAG(IS_MAC)
@@ -439,6 +477,12 @@ class NativeWindow : public views::WidgetDelegate {
     titlebar_overlay_height_ = height;
   }
 
+#if BUILDFLAG(IS_MAC)
+  void set_has_glass_effect(bool has_glass_effect) {
+    has_glass_effect_ = has_glass_effect;
+  }
+#endif
+
   [[nodiscard]] bool has_client_frame() const { return has_client_frame_; }
 
   [[nodiscard]] bool transparent() const { return transparent_; }
@@ -549,6 +593,10 @@ class NativeWindow : public views::WidgetDelegate {
 
   std::string vibrancy_;
   std::string background_material_;
+
+#if BUILDFLAG(IS_MAC)
+  bool has_glass_effect_ = false;
+#endif
 
   gfx::Rect overlay_rect_;
 

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -129,6 +129,9 @@ class NativeWindowMac : public NativeWindow,
   bool IsVisibleOnAllWorkspaces() const override;
   void SetAutoHideCursor(bool auto_hide) override;
   void SetVibrancy(const std::string& type, int duration) override;
+  void SetGlassEffect(std::optional<GlassEffectRegion> options) override;
+  void SetGlassEffectRegions(std::vector<GlassEffectRegion> regions) override;
+  bool IsGlassEffectSupported() const override;
   void SetWindowButtonVisibility(bool visible) override;
   bool GetWindowButtonVisibility() const override;
   void SetWindowButtonPosition(std::optional<gfx::Point> position) override;
@@ -185,6 +188,8 @@ class NativeWindowMac : public NativeWindow,
   void SetBorderless(bool borderless);
 
   void UpdateVibrancyRadii(bool fullscreen);
+
+  void UpdateGlassEffectFrames();
 
   void UpdateWindowOriginalFrame();
 
@@ -316,6 +321,17 @@ class NativeWindowMac : public NativeWindow,
 
   // A views::NativeViewHost wrapping the vibrant view. Owned by the root view.
   raw_ptr<views::NativeViewHost> vibrant_native_view_host_ = nullptr;
+
+  // Full-window NSGlassEffectView inserted at the bottom of the NSWindow's
+  // content view so its backdrop captures the desktop, not the web content.
+  NSView* __strong glass_effect_view_ = nil;
+
+  // NSGlassEffectContainerView holding overlay glass regions placed above the
+  // web content. Typed as NSView* to avoid availability-annotated member.
+  NSView* __strong glass_region_container_ = nil;
+  std::vector<NSView*> glass_region_views_;
+  // Only bounds are retained; style/tint/image are baked into the NSViews.
+  std::vector<gfx::Rect> glass_region_bounds_;
 
   // The presentation options before entering simple fullscreen mode.
   NSApplicationPresentationOptions simple_fullscreen_options_;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/apple/foundation_util.h"
 #include "base/apple/scoped_cftyperef.h"
 #include "base/mac/mac_util.h"
 #include "base/strings/sys_string_conversions.h"
@@ -86,6 +87,28 @@
   NSRectFill(rect);
 }
 
+@end
+
+// Subclasses that ignore mouse events so clicks fall through to the web
+// content underneath. Used for overlay glass regions.
+API_AVAILABLE(macos(26.0))
+@interface ElectronPassthroughGlassView : NSGlassEffectView
+@end
+
+@implementation ElectronPassthroughGlassView
+- (NSView*)hitTest:(NSPoint)point {
+  return nil;
+}
+@end
+
+API_AVAILABLE(macos(26.0))
+@interface ElectronPassthroughGlassContainerView : NSGlassEffectContainerView
+@end
+
+@implementation ElectronPassthroughGlassContainerView
+- (NSView*)hitTest:(NSPoint)point {
+  return nil;
+}
 @end
 
 namespace gin {
@@ -214,6 +237,11 @@ NativeWindowMac::NativeWindowMac(const int32_t base_window_id,
     styleMask |= NSWindowStyleMaskTexturedBackground;
   }
 #pragma clang diagnostic pop
+
+  // Set before IsTranslucent() is read for widget opacity. SetGlassEffect
+  // re-sets this in InitFromOptions, but that runs after widget init.
+  set_has_glass_effect(options.Has(options::kGlassEffect) &&
+                       IsGlassEffectSupported());
 
   // Create views::Widget and assign window_ with it.
   // TODO(zcbenz): Get rid of the window_ in future.
@@ -1509,6 +1537,152 @@ void NativeWindowMac::SetVibrancy(const std::string& type, int duration) {
     }
 
     [vibrantView setMaterial:vibrancyType];
+  }
+}
+
+namespace {
+
+API_AVAILABLE(macos(26.0))
+void ConfigureGlassEffectView(NSGlassEffectView* view,
+                              const GlassEffectRegion& opts) {
+  view.style = opts.style == GlassEffectStyle::kClear
+                   ? NSGlassEffectViewStyleClear
+                   : NSGlassEffectViewStyleRegular;
+  view.cornerRadius = opts.corner_radius;
+  view.tintColor =
+      opts.tint_color ? skia::SkColorToSRGBNSColor(*opts.tint_color) : nil;
+
+  if (!opts.content_image.IsEmpty()) {
+    NSImageView* imageView =
+        base::apple::ObjCCast<NSImageView>(view.contentView);
+    if (!imageView) {
+      imageView = [[NSImageView alloc] initWithFrame:view.bounds];
+      imageView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+      imageView.imageScaling = NSImageScaleProportionallyDown;
+      imageView.imageAlignment = NSImageAlignCenter;
+      view.contentView = imageView;
+    }
+    imageView.image = opts.content_image.ToNSImage();
+  } else if (view.contentView) {
+    view.contentView = nil;
+  }
+}
+
+}  // namespace
+
+bool NativeWindowMac::IsGlassEffectSupported() const {
+  if (@available(macOS 26.0, *)) {
+    return true;
+  }
+  return false;
+}
+
+void NativeWindowMac::SetGlassEffect(std::optional<GlassEffectRegion> options) {
+  if (@available(macOS 26.0, *)) {
+    NativeWindow::SetGlassEffect(options);
+
+    NSView* contentView = [window_ contentView];
+
+    if (!options) {
+      [glass_effect_view_ removeFromSuperview];
+      glass_effect_view_ = nil;
+      return;
+    }
+
+    if (!glass_effect_view_) {
+      NSGlassEffectView* glass =
+          [[NSGlassEffectView alloc] initWithFrame:[contentView bounds]];
+      [glass setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
+      glass_effect_view_ = glass;
+
+      // Insert directly at the bottom of the NSWindow's content view so the
+      // CABackdropLayer only captures the desktop behind the window, not the
+      // web content. Using NativeViewHost here places the glass above the web
+      // CALayerHost in the actual NSView z-order, which makes the glass
+      // refract the page instead of the desktop.
+      [contentView addSubview:glass positioned:NSWindowBelow relativeTo:nil];
+    }
+
+    ConfigureGlassEffectView(
+        static_cast<NSGlassEffectView*>(glass_effect_view_), *options);
+  }
+}
+
+void NativeWindowMac::SetGlassEffectRegions(
+    std::vector<GlassEffectRegion> regions) {
+  if (@available(macOS 26.0, *)) {
+    NSView* contentView = [window_ contentView];
+
+    if (regions.empty()) {
+      [glass_region_container_ removeFromSuperview];
+      glass_region_container_ = nil;
+      glass_region_views_.clear();
+      glass_region_bounds_.clear();
+      return;
+    }
+
+    NSGlassEffectContainerView* container =
+        static_cast<NSGlassEffectContainerView*>(glass_region_container_);
+    if (!container) {
+      container = [[ElectronPassthroughGlassContainerView alloc]
+          initWithFrame:[contentView bounds]];
+      [container setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
+      NSView* inner = [[NSView alloc] initWithFrame:[contentView bounds]];
+      [inner setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
+      container.contentView = inner;
+      // Add as the topmost subview of the window content view so the glass
+      // layers capture the web content below as their backdrop. The
+      // passthrough subclass ensures mouse events fall through to the web
+      // content.
+      [contentView addSubview:container
+                   positioned:NSWindowAbove
+                   relativeTo:nil];
+      glass_region_container_ = container;
+    }
+
+    NSView* inner = container.contentView;
+
+    while (glass_region_views_.size() > regions.size()) {
+      [glass_region_views_.back() removeFromSuperview];
+      glass_region_views_.pop_back();
+    }
+    while (glass_region_views_.size() < regions.size()) {
+      ElectronPassthroughGlassView* glass =
+          [[ElectronPassthroughGlassView alloc] initWithFrame:NSZeroRect];
+      [inner addSubview:glass];
+      glass_region_views_.push_back(glass);
+    }
+
+    glass_region_bounds_.clear();
+    glass_region_bounds_.reserve(regions.size());
+    for (size_t i = 0; i < regions.size(); ++i) {
+      ConfigureGlassEffectView(
+          static_cast<NSGlassEffectView*>(glass_region_views_[i]), regions[i]);
+      glass_region_bounds_.push_back(regions[i].bounds);
+    }
+
+    UpdateGlassEffectFrames();
+  }
+}
+
+void NativeWindowMac::UpdateGlassEffectFrames() {
+  if (@available(macOS 26.0, *)) {
+    if (!glass_region_container_)
+      return;
+
+    DCHECK_EQ(glass_region_bounds_.size(), glass_region_views_.size());
+
+    NSGlassEffectContainerView* container =
+        static_cast<NSGlassEffectContainerView*>(glass_region_container_);
+    CGFloat containerHeight = container.contentView.bounds.size.height;
+
+    for (size_t i = 0; i < glass_region_bounds_.size(); ++i) {
+      const gfx::Rect& b = glass_region_bounds_[i];
+      // Convert from Electron's top-left origin to Cocoa's bottom-left.
+      [glass_region_views_[i]
+          setFrame:NSMakeRect(b.x(), containerHeight - b.bottom(), b.width(),
+                              b.height())];
+    }
   }
 }
 

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -220,6 +220,7 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
   [super windowDidResize:notification];
   shell_->NotifyWindowResize();
   shell_->RedrawTrafficLights();
+  shell_->UpdateGlassEffectFrames();
   // When reduce motion is enabled windowDidResize is only called once after
   // a resize and windowDidEndLiveResize is not called. So we need to call
   // handleZoomEnd here as well.

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -113,6 +113,9 @@ inline constexpr std::string_view kVibrancyType = "vibrancy";
 // Add a vibrancy effect to the browser window.
 inline constexpr std::string_view kBackgroundMaterial = "backgroundMaterial";
 
+// Add a native Liquid Glass effect to the browser window (macOS 26+).
+inline constexpr std::string_view kGlassEffect = "glassEffect";
+
 // Specify how the material appearance should reflect window activity state on
 // macOS.
 inline constexpr std::string_view kVisualEffectState = "visualEffectState";

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, BrowserView, dialog, ipcMain, OnBeforeSendHeadersListenerDetails, net, protocol, screen, webContents, webFrameMain, session, systemPreferences, WebContents, WebFrameMain } from 'electron/main';
+import { nativeImage } from 'electron/common';
 
 import { expect } from 'chai';
 
@@ -2988,6 +2989,81 @@ describe('BrowserWindow module', () => {
       const w = new BrowserWindow({ show: false });
       expect(() => {
         w.setVibrancy('i-am-not-a-valid-vibrancy-type' as any);
+      }).to.not.throw();
+    });
+  });
+
+  ifdescribe(process.platform === 'darwin')('BrowserWindow glass effect', () => {
+    afterEach(closeAllWindows);
+
+    it('reports whether glass effect is supported', () => {
+      const w = new BrowserWindow({ show: false });
+      expect(w.isGlassEffectSupported()).to.be.a('boolean');
+    });
+
+    it('allows setting, changing, and removing the window glass effect', () => {
+      const w = new BrowserWindow({ show: false });
+      expect(() => {
+        w.setGlassEffect({ style: 'regular', cornerRadius: 16 });
+        w.setGlassEffect({ style: 'clear', tintColor: '#ff00ff80' });
+        w.setGlassEffect(null);
+        w.setGlassEffect({ style: 'regular' });
+        w.setGlassEffect(null);
+      }).to.not.throw();
+    });
+
+    it('allows setting and clearing glass effect regions', () => {
+      const w = new BrowserWindow({ show: false });
+      expect(() => {
+        w.setGlassEffectRegions([
+          { x: 10, y: 10, width: 200, height: 60, cornerRadius: 30, style: 'regular' },
+          { x: 10, y: 80, width: 100, height: 100, cornerRadius: 20, style: 'clear', tintColor: '#00ff00' }
+        ]);
+        w.setGlassEffectRegions([
+          { x: 0, y: 0, width: 50, height: 50, cornerRadius: 25 }
+        ]);
+        w.setGlassEffectRegions([]);
+        w.setGlassEffectRegions(null);
+      }).to.not.throw();
+    });
+
+    it('accepts the glassEffect constructor option', () => {
+      expect(() => {
+        const w = new BrowserWindow({
+          show: false,
+          glassEffect: { style: 'regular', cornerRadius: 12 }
+        });
+        w.close();
+      }).to.not.throw();
+    });
+
+    it('accepts a contentImage on glass effect regions', () => {
+      const w = new BrowserWindow({ show: false });
+      const img = nativeImage.createFromNamedImage('NSFolder');
+      expect(() => {
+        w.setGlassEffectRegions([
+          { x: 0, y: 0, width: 60, height: 60, cornerRadius: 30, contentImage: img }
+        ]);
+        // Re-apply with the image removed to exercise contentView teardown.
+        w.setGlassEffectRegions([
+          { x: 0, y: 0, width: 60, height: 60, cornerRadius: 30 }
+        ]);
+        w.setGlassEffectRegions(null);
+      }).to.not.throw();
+    });
+
+    it('allows window glass and region glass to coexist', () => {
+      const w = new BrowserWindow({ show: false });
+      expect(() => {
+        w.setGlassEffect({ style: 'regular' });
+        w.setGlassEffectRegions([
+          { x: 10, y: 10, width: 50, height: 50, cornerRadius: 10, style: 'clear' }
+        ]);
+        // Toggle each independently.
+        w.setGlassEffect(null);
+        w.setGlassEffect({ style: 'clear' });
+        w.setGlassEffectRegions(null);
+        w.setGlassEffect(null);
       }).to.not.throw();
     });
   });

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1,5 +1,5 @@
-import { app, BrowserWindow, BrowserView, dialog, ipcMain, OnBeforeSendHeadersListenerDetails, net, protocol, screen, webContents, webFrameMain, session, systemPreferences, WebContents, WebFrameMain } from 'electron/main';
 import { nativeImage } from 'electron/common';
+import { app, BrowserWindow, BrowserView, dialog, ipcMain, OnBeforeSendHeadersListenerDetails, net, protocol, screen, webContents, webFrameMain, session, systemPreferences, WebContents, WebFrameMain } from 'electron/main';
 
 import { expect } from 'chai';
 


### PR DESCRIPTION
#### Description of Change

https://github.com/user-attachments/assets/56385f3b-72bb-4493-a809-017f4db732b5

Adds native macOS 26 Liquid Glass (`NSGlassEffectView`) support to `BaseWindow`/`BrowserWindow` with three new macOS-only APIs:

- **`win.setGlassEffect(options)`** and the **`glassEffect`** constructor option — place a single `NSGlassEffectView` behind the web contents covering the full content area, similar to the existing `vibrancy` API. Supports `style` (`regular`/`clear`), `cornerRadius`, and `tintColor`.

- **`win.setGlassEffectRegions(regions)`** — place `NSGlassEffectView` overlays above the web contents at specified rectangles. Each glass view captures the web content behind it as its backdrop and renders the refraction and highlight effects on top. Mouse events pass through. Supports per-region `style`, `cornerRadius`, `tintColor`, and an optional `contentImage` (a `NativeImage` rendered crisp on top of the glass surface).

- **`win.isGlassEffectSupported()`** — returns whether Liquid Glass is available (macOS 26.0+).

All APIs are guarded by `@available(macOS 26.0, *)` and are no-ops on earlier releases.

**Implementation notes:**
- Window glass inserts the `NSGlassEffectView` directly at the bottom of the window content view (`positioned:NSWindowBelow`) so its `CABackdropLayer` only captures the desktop, not the web content.
- Region glass uses an `NSGlassEffectContainerView` at the top of the NSView stack. Both the container and each glass view override `hitTest:` to return `nil` so mouse events fall through.
- Region frames are stored on `NativeWindowMac` and re-laid-out in `windowDidResize:` to keep the top-left → Cocoa bottom-left Y-flip correct across resizes.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `setGlassEffect`, `setGlassEffectRegions`, and `isGlassEffectSupported` to `BrowserWindow` for native Liquid Glass on macOS 26+.