### PR TITLE
fix: register `PrintDialogLinuxFactory` on Linux

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -127,6 +127,10 @@
 #include "shell/common/plugin_info.h"
 #endif  // BUILDFLAG(ENABLE_PLUGINS)
 
+#if BUILDFLAG(ENABLE_PRINTING)
+#include "components/printing/common/print_dialog_linux_factory.h"
+#endif
+
 namespace electron {
 
 namespace {
@@ -414,6 +418,10 @@ void ElectronBrowserMainParts::ToolkitInitialized() {
   dark_mode_manager_ = std::make_unique<ui::DarkModeManagerLinux>();
 
   ui::LinuxUi::SetInstance(linux_ui);
+
+#if BUILDFLAG(ENABLE_PRINTING)
+  print_dialog_factory_ = std::make_unique<printing::PrintDialogLinuxFactory>();
+#endif
 
   // Cursor theme changes are tracked by LinuxUI (via a CursorThemeManager
   // implementation). Start observing them once it's initialized.

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -14,7 +14,12 @@
 #include "content/public/browser/browser_main_parts.h"
 #include "electron/buildflags/buildflags.h"
 #include "mojo/public/cpp/bindings/remote.h"
+#include "printing/buildflags/buildflags.h"
 #include "services/device/public/mojom/geolocation_control.mojom.h"
+
+#if BUILDFLAG(ENABLE_PRINTING)
+#include "printing/printing_context_linux.h"
+#endif
 
 class BrowserProcessImpl;
 class IconManager;
@@ -177,6 +182,11 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
 
 #if BUILDFLAG(IS_MAC)
   std::unique_ptr<display::ScopedNativeScreen> screen_;
+#endif
+
+#if BUILDFLAG(ENABLE_PRINTING)
+  std::unique_ptr<printing::PrintingContextLinux::PrintDialogFactory>
+      print_dialog_factory_;
 #endif
 
   static ElectronBrowserMainParts* self_;


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/50420

Chromium 145 refactored Linux print dialog creation to use a factory pattern instead of directly calling `LinuxUi::CreatePrintDialog()`. Chrome registers this factory in
`ChromeBrowserMainExtraPartsViewsLinux::ToolkitInitialized()`, but Electron did not, causing `PrintingContextLinux::EnsurePrintDialog()` to leave `print_dialog_` null on every call.

Without a dialog, `UseDefaultSettings()` and `UpdatePrinterSettings()` return success but with empty/unprocessed settings, causing `PrintMsgPrintParamsIsValid()` to fail. This broke both `window.print()` and `webContents.print()`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed printing on Linux failing with "Invalid printer settings".