### PR TITLE
chore: add CODEOWNERS for .claude folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@ DEPS                                    @electron/wg-upgrades
 /lib/renderer/security-warnings.ts      @electron/wg-security
 
 # Infra WG
+/.claude/                               @electron/wg-infra
 /.github/actions/                       @electron/wg-infra
 /.github/workflows/*-publish.yml        @electron/wg-infra
 /.github/workflows/build.yml            @electron/wg-infra


### PR DESCRIPTION
#### Description of Change

Add wg-infra as code owners for the .claude folder to protect Claude Code configuration files from unauthorized modifications.

_This PR was made by Claude_

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] I have built and tested this PR
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
