### PR TITLE
chore: cherry-pick bf6dd974238b from angle

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -1,1 +1,2 @@
 cherry-pick-a08731cf6d70.patch
+cherry-pick-bf6dd974238b.patch

--- a/patches/angle/cherry-pick-bf6dd974238b.patch
+++ b/patches/angle/cherry-pick-bf6dd974238b.patch
@@ -1,0 +1,488 @@
+From bf6dd974238bceec7a0a27987e2e02e177f2b7f8 Mon Sep 17 00:00:00 2001
+From: Geoff Lang <geofflang@chromium.org>
+Date: Wed, 11 Feb 2026 15:51:46 -0500
+Subject: [PATCH] Optionally validate GL_MAX_*_UNIFORM_BLOCKS at compile time.
+
+These were validated at link time but some drivers have compiler crashes
+when compiling shaders with too many uniform blocks.
+
+Bug: chromium:475877320
+Change-Id: I4413ce06307b4fe9e27105d85f66f610c235a301
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/7568089
+Commit-Queue: Geoff Lang <geofflang@chromium.org>
+Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
+---
+
+diff --git a/include/GLSLANG/ShaderLang.h b/include/GLSLANG/ShaderLang.h
+index 6e7768b..ab3d49f 100644
+--- a/include/GLSLANG/ShaderLang.h
++++ b/include/GLSLANG/ShaderLang.h
+@@ -26,7 +26,7 @@
+ 
+ // Version number for shader translation API.
+ // It is incremented every time the API changes.
+-#define ANGLE_SH_VERSION 398
++#define ANGLE_SH_VERSION 399
+ 
+ enum ShShaderSpec
+ {
+@@ -384,7 +384,9 @@
+     // VK_EXT_depth_clip_control is supported, this code is not generated, saving a uniform look up.
+     uint64_t addVulkanDepthCorrection : 1;
+ 
+-    uint64_t unused2 : 1;
++    // Validate that the count of uniform blocks is within the GL_MAX_*_UNIFORM_BLOCKS limits. These
++    // limits must be supplied in the BuiltinResources.
++    uint64_t validatePerStageMaxUniformBlocks : 1;
+ 
+     // Ask compiler to generate Vulkan transform feedback emulation support code.
+     uint64_t addVulkanXfbEmulationSupportCode : 1;
+@@ -586,6 +588,12 @@
+     int MinProgramTexelOffset;
+     int MaxProgramTexelOffset;
+ 
++    // GL_MAX_FRAGMENT_UNIFORM_BLOCKS
++    int MaxFragmentUniformBlocks;
++
++    // GL_MAX_VERTEX_UNIFORM_BLOCKS
++    int MaxVertexUniformBlocks;
++
+     // Extension constants.
+ 
+     // Value of GL_MAX_DUAL_SOURCE_DRAW_BUFFERS_EXT for OpenGL ES output context.
+@@ -703,6 +711,9 @@
+     // maximum point size (higher limit from ALIASED_POINT_SIZE_RANGE)
+     float MaxPointSize;
+ 
++    // GL_MAX_COMPUTE_UNIFORM_BLOCKS
++    int MaxComputeUniformBlocks;
++
+     // EXT_geometry_shader constants
+     int MaxGeometryUniformComponents;
+     int MaxGeometryInputComponents;
+@@ -714,6 +725,7 @@
+     int MaxGeometryAtomicCounters;
+     int MaxGeometryShaderInvocations;
+     int MaxGeometryImageUniforms;
++    int MaxGeometryUniformBlocks;
+ 
+     // EXT_tessellation_shader constants
+     int MaxTessControlInputComponents;
+@@ -724,6 +736,7 @@
+     int MaxTessControlImageUniforms;
+     int MaxTessControlAtomicCounters;
+     int MaxTessControlAtomicCounterBuffers;
++    int MaxTessControlUniformBlocks;
+ 
+     int MaxTessPatchComponents;
+     int MaxPatchVertices;
+@@ -736,6 +749,7 @@
+     int MaxTessEvaluationImageUniforms;
+     int MaxTessEvaluationAtomicCounters;
+     int MaxTessEvaluationAtomicCounterBuffers;
++    int MaxTessEvaluationUniformBlocks;
+ 
+     // APPLE_clip_distance / EXT_clip_cull_distance / ANGLE_clip_cull_distance constants
+     int MaxClipDistances;
+diff --git a/include/platform/autogen/FeaturesGL_autogen.h b/include/platform/autogen/FeaturesGL_autogen.h
+index 09d4aa2..c0c00f1 100644
+--- a/include/platform/autogen/FeaturesGL_autogen.h
++++ b/include/platform/autogen/FeaturesGL_autogen.h
+@@ -662,6 +662,12 @@
+         &members,
+     };
+ 
++    FeatureInfo validateMaxPerStageUniformBlocksAtCompileTime = {
++        "validateMaxPerStageUniformBlocksAtCompileTime",
++        FeatureCategory::OpenGLWorkarounds,
++        &members,
++    };
++
+ };
+ 
+ inline FeaturesGL::FeaturesGL()  = default;
+diff --git a/include/platform/gl_features.json b/include/platform/gl_features.json
+index 94d86bd..a78b0d4 100644
+--- a/include/platform/gl_features.json
++++ b/include/platform/gl_features.json
+@@ -860,6 +860,14 @@
+                 "Use ARB_shader_viewport_layer_array or NV_viewport_array2 to implement multiview"
+             ],
+             "issue": "http://anglebug.com/42260809"
++        },
++        {
++            "name": "validate_max_per_stage_uniform_blocks_at_compile_time",
++            "category": "Workarounds",
++            "description": [
++                "Validate GL_MAX_*_UNIFORM_BLOCKS at compile time instead of link time to work around compiler bugs."
++            ],
++            "issue": "http://crbug.com/475877320"
+         }
+     ]
+ }
+diff --git a/src/compiler/translator/Compiler.cpp b/src/compiler/translator/Compiler.cpp
+index 2af7dbe..318b861 100644
+--- a/src/compiler/translator/Compiler.cpp
++++ b/src/compiler/translator/Compiler.cpp
+@@ -1493,6 +1493,8 @@
+         << ":MaxFragmentInputVectors:" << mResources.MaxFragmentInputVectors
+         << ":MinProgramTexelOffset:" << mResources.MinProgramTexelOffset
+         << ":MaxProgramTexelOffset:" << mResources.MaxProgramTexelOffset
++        << ":MaxFragmentUniformBlocks:" << mResources.MaxFragmentUniformBlocks
++        << ":MaxVertexUniformBlocks:" << mResources.MaxVertexUniformBlocks
+         << ":MaxDualSourceDrawBuffers:" << mResources.MaxDualSourceDrawBuffers
+         << ":MaxViewsOVR:" << mResources.MaxViewsOVR
+         << ":NV_draw_buffers:" << mResources.NV_draw_buffers
+@@ -1542,6 +1544,7 @@
+         << ":MaxFragmentAtomicCounterBuffers:" << mResources.MaxFragmentAtomicCounterBuffers
+         << ":MaxCombinedAtomicCounterBuffers:" << mResources.MaxCombinedAtomicCounterBuffers
+         << ":MaxAtomicCounterBufferSize:" << mResources.MaxAtomicCounterBufferSize
++        << ":MaxComputeUnformBlocks:" << mResources.MaxComputeUniformBlocks
+         << ":MaxGeometryUniformComponents:" << mResources.MaxGeometryUniformComponents
+         << ":MaxGeometryInputComponents:" << mResources.MaxGeometryInputComponents
+         << ":MaxGeometryOutputComponents:" << mResources.MaxGeometryOutputComponents
+@@ -1552,6 +1555,7 @@
+         << ":MaxGeometryAtomicCounters:" << mResources.MaxGeometryAtomicCounters
+         << ":MaxGeometryShaderInvocations:" << mResources.MaxGeometryShaderInvocations
+         << ":MaxGeometryImageUniforms:" << mResources.MaxGeometryImageUniforms
++        << ":MaxGeometryUniformBlocks:" << mResources.MaxGeometryUniformBlocks
+         << ":MaxClipDistances" << mResources.MaxClipDistances
+         << ":MaxCullDistances" << mResources.MaxCullDistances
+         << ":MaxCombinedClipAndCullDistances" << mResources.MaxCombinedClipAndCullDistances
+@@ -1563,6 +1567,7 @@
+         << ":MaxTessControlImageUniforms:" << mResources.MaxTessControlImageUniforms
+         << ":MaxTessControlAtomicCounters:" << mResources.MaxTessControlAtomicCounters
+         << ":MaxTessControlAtomicCounterBuffers:" << mResources.MaxTessControlAtomicCounterBuffers
++        << ":MaxTessControlUniformBlocks:" << mResources.MaxTessControlUniformBlocks
+         << ":MaxTessPatchComponents:" << mResources.MaxTessPatchComponents
+         << ":MaxPatchVertices:" << mResources.MaxPatchVertices
+         << ":MaxTessGenLevel:" << mResources.MaxTessGenLevel
+@@ -1572,7 +1577,9 @@
+         << ":MaxTessEvaluationUniformComponents:" << mResources.MaxTessEvaluationUniformComponents
+         << ":MaxTessEvaluationImageUniforms:" << mResources.MaxTessEvaluationImageUniforms
+         << ":MaxTessEvaluationAtomicCounters:" << mResources.MaxTessEvaluationAtomicCounters
+-        << ":MaxTessEvaluationAtomicCounterBuffers:" << mResources.MaxTessEvaluationAtomicCounterBuffers;
++        << ":MaxTessEvaluationAtomicCounterBuffers:" << mResources.MaxTessEvaluationAtomicCounterBuffers
++        << ":MaxTessControlUniformBlocks:" << mResources.MaxTessControlUniformBlocks
++    ;
+     // clang-format on
+ 
+     mBuiltInResourcesString = strstream.str();
+diff --git a/src/compiler/translator/ParseContext.cpp b/src/compiler/translator/ParseContext.cpp
+index 839c59a..b95cb49 100644
+--- a/src/compiler/translator/ParseContext.cpp
++++ b/src/compiler/translator/ParseContext.cpp
+@@ -429,6 +429,37 @@
+     // overestimated).
+     return isStd140 ? kVec4Size : type->getNominalSize() * sizeof(float);
+ }
++
++unsigned int GetMaxUniformBlocksForShaderType(sh::GLenum shaderType,
++                                              const ShCompileOptions &options,
++                                              const ShBuiltInResources &resources)
++{
++    // If the validatePerStageMaxUniformBlocks workaround is disabled. Set a limit that will not be
++    // hit.
++    if (!options.validatePerStageMaxUniformBlocks)
++    {
++        return std::numeric_limits<unsigned int>::max();
++    }
++
++    switch (shaderType)
++    {
++        case GL_FRAGMENT_SHADER:
++            return resources.MaxFragmentUniformBlocks;
++        case GL_VERTEX_SHADER:
++            return resources.MaxVertexUniformBlocks;
++        case GL_COMPUTE_SHADER:
++            return resources.MaxComputeUniformBlocks;
++        case GL_GEOMETRY_SHADER:
++            return resources.MaxGeometryUniformBlocks;
++        case GL_TESS_CONTROL_SHADER:
++            return resources.MaxTessControlUniformBlocks;
++        case GL_TESS_EVALUATION_SHADER:
++            return resources.MaxTessEvaluationUniformBlocks;
++        default:
++            UNREACHABLE();
++            return 0;
++    }
++}
+ }  // namespace
+ 
+ // This tracks each binding point's current default offset for inheritance of subsequent
+@@ -500,6 +531,8 @@
+       mComputeShaderLocalSizeDeclared(false),
+       mComputeShaderLocalSize(-1),
+       mNumViews(-1),
++      mMaxUniformBlocks(GetMaxUniformBlocksForShaderType(mShaderType, options, resources)),
++      mNumUniformBlocks(0),
+       mDeclaringFunction(false),
+       mDeclaringMain(false),
+       mMainFunction(nullptr),
+@@ -6316,6 +6349,22 @@
+         error(arraySizesLine, "geometry shader input blocks must be an array", "");
+     }
+ 
++    // Validate max uniform block limits
++    if (typeQualifier.qualifier == EvqUniform)
++    {
++        unsigned int blockCount =
++            arraySizes == nullptr || arraySizes->empty() ? 1 : (*arraySizes)[0];
++        if (mNumUniformBlocks + blockCount > mMaxUniformBlocks)
++        {
++            error(arraySizesLine,
++                  "uniform block count greater than per stage maximum uniform blocks", "");
++        }
++        else
++        {
++            mNumUniformBlocks += blockCount;
++        }
++    }
++
+     checkIndexIsNotSpecified(typeQualifier.line, typeQualifier.layoutQualifier.index);
+ 
+     if (mShaderVersion < 310)
+diff --git a/src/compiler/translator/ParseContext.h b/src/compiler/translator/ParseContext.h
+index 828eebb..cc43abe 100644
+--- a/src/compiler/translator/ParseContext.h
++++ b/src/compiler/translator/ParseContext.h
+@@ -884,6 +884,12 @@
+     // Keep track of number of views declared in layout.
+     int mNumViews;
+ 
++    // Maximum number of uniform blocks allowed to be declared in this shader. Taken from the
++    // built-in resources and resolved to this shader type.
++    unsigned int mMaxUniformBlocks;
++    // Current count of declared uniform blocks.
++    unsigned int mNumUniformBlocks;
++
+     // Keeps track of whether any of the built-ins that can be redeclared (see
+     // IsRedeclarableBuiltIn()) has been marked as invariant/precise before the possible
+     // redeclaration.
+diff --git a/src/compiler/translator/ShaderLang.cpp b/src/compiler/translator/ShaderLang.cpp
+index a5bfbbc..7304d2e 100644
+--- a/src/compiler/translator/ShaderLang.cpp
++++ b/src/compiler/translator/ShaderLang.cpp
+@@ -262,6 +262,8 @@
+     resources->MaxFragmentInputVectors = 15;
+     resources->MinProgramTexelOffset   = -8;
+     resources->MaxProgramTexelOffset   = 7;
++    resources->MaxFragmentUniformBlocks = 12;
++    resources->MaxVertexUniformBlocks   = 12;
+ 
+     // Extensions constants.
+     resources->MaxDualSourceDrawBuffers = 0;
+@@ -322,6 +324,8 @@
+     resources->MaxUniformBufferBindings       = 32;
+     resources->MaxShaderStorageBufferBindings = 4;
+ 
++    resources->MaxComputeUniformBlocks = 12;
++
+     resources->MaxGeometryUniformComponents     = 1024;
+     resources->MaxGeometryInputComponents       = 64;
+     resources->MaxGeometryOutputComponents      = 64;
+@@ -332,6 +336,7 @@
+     resources->MaxGeometryAtomicCounters        = 0;
+     resources->MaxGeometryShaderInvocations     = 32;
+     resources->MaxGeometryImageUniforms         = 0;
++    resources->MaxGeometryUniformBlocks         = 12;
+ 
+     resources->MaxTessControlInputComponents       = 64;
+     resources->MaxTessControlOutputComponents      = 64;
+@@ -341,6 +346,7 @@
+     resources->MaxTessControlImageUniforms         = 0;
+     resources->MaxTessControlAtomicCounters        = 0;
+     resources->MaxTessControlAtomicCounterBuffers  = 0;
++    resources->MaxTessControlUniformBlocks         = 12;
+ 
+     resources->MaxTessPatchComponents = 120;
+     resources->MaxPatchVertices       = 32;
+@@ -353,6 +359,7 @@
+     resources->MaxTessEvaluationImageUniforms        = 0;
+     resources->MaxTessEvaluationAtomicCounters       = 0;
+     resources->MaxTessEvaluationAtomicCounterBuffers = 0;
++    resources->MaxTessEvaluationUniformBlocks        = 12;
+ 
+     resources->MaxSamples = 4;
+ }
+diff --git a/src/libANGLE/Compiler.cpp b/src/libANGLE/Compiler.cpp
+index 81a8cef..9c3fc31 100644
+--- a/src/libANGLE/Compiler.cpp
++++ b/src/libANGLE/Compiler.cpp
+@@ -167,6 +167,8 @@
+     mResources.MaxFragmentInputVectors = caps.maxFragmentInputComponents / 4;
+     mResources.MinProgramTexelOffset   = caps.minProgramTexelOffset;
+     mResources.MaxProgramTexelOffset   = caps.maxProgramTexelOffset;
++    mResources.MaxFragmentUniformBlocks = caps.maxShaderUniformBlocks[gl::ShaderType::Fragment];
++    mResources.MaxVertexUniformBlocks   = caps.maxShaderUniformBlocks[gl::ShaderType::Vertex];
+ 
+     // EXT_blend_func_extended
+     mResources.EXT_blend_func_extended  = extensions.blendFuncExtendedEXT;
+@@ -209,6 +211,7 @@
+     mResources.MaxCombinedImageUniforms         = caps.maxCombinedImageUniforms;
+     mResources.MaxCombinedShaderOutputResources = caps.maxCombinedShaderOutputResources;
+     mResources.MaxUniformLocations              = caps.maxUniformLocations;
++    mResources.MaxComputeUniformBlocks = caps.maxShaderUniformBlocks[gl::ShaderType::Compute];
+ 
+     for (size_t index = 0u; index < 3u; ++index)
+     {
+@@ -261,6 +264,7 @@
+     mResources.MaxGeometryAtomicCounters      = caps.maxShaderAtomicCounters[ShaderType::Geometry];
+     mResources.MaxGeometryShaderInvocations   = caps.maxGeometryShaderInvocations;
+     mResources.MaxGeometryImageUniforms       = caps.maxShaderImageUniforms[ShaderType::Geometry];
++    mResources.MaxGeometryUniformBlocks = caps.maxShaderUniformBlocks[gl::ShaderType::Geometry];
+ 
+     // Tessellation Shader constants
+     mResources.EXT_tessellation_shader        = extensions.tessellationShaderEXT;
+@@ -276,6 +280,8 @@
+     mResources.MaxTessControlAtomicCounters = caps.maxShaderAtomicCounters[ShaderType::TessControl];
+     mResources.MaxTessControlAtomicCounterBuffers =
+         caps.maxShaderAtomicCounterBuffers[ShaderType::TessControl];
++    mResources.MaxTessControlUniformBlocks =
++        caps.maxShaderUniformBlocks[gl::ShaderType::TessControl];
+ 
+     mResources.MaxTessPatchComponents = caps.maxTessPatchComponents;
+     mResources.MaxPatchVertices       = caps.maxPatchVertices;
+@@ -293,6 +299,8 @@
+         caps.maxShaderAtomicCounters[ShaderType::TessEvaluation];
+     mResources.MaxTessEvaluationAtomicCounterBuffers =
+         caps.maxShaderAtomicCounterBuffers[ShaderType::TessEvaluation];
++    mResources.MaxTessEvaluationUniformBlocks =
++        caps.maxShaderUniformBlocks[gl::ShaderType::TessEvaluation];
+ }
+ 
+ Compiler::~Compiler() = default;
+diff --git a/src/libANGLE/renderer/gl/ShaderGL.cpp b/src/libANGLE/renderer/gl/ShaderGL.cpp
+index 9004ef8..ffa4fb0 100644
+--- a/src/libANGLE/renderer/gl/ShaderGL.cpp
++++ b/src/libANGLE/renderer/gl/ShaderGL.cpp
+@@ -266,6 +266,11 @@
+         options->pls = contextGL->getNativePixelLocalStorageOptions();
+     }
+ 
++    if (features.validateMaxPerStageUniformBlocksAtCompileTime.enabled)
++    {
++        options->validatePerStageMaxUniformBlocks = true;
++    }
++
+     return std::shared_ptr<ShaderTranslateTask>(
+         new ShaderTranslateTaskGL(functions, mShaderID, contextGL->hasNativeParallelCompile()));
+ }
+diff --git a/src/libANGLE/renderer/gl/renderergl_utils.cpp b/src/libANGLE/renderer/gl/renderergl_utils.cpp
+index 8bdbd1a..29abdf4 100644
+--- a/src/libANGLE/renderer/gl/renderergl_utils.cpp
++++ b/src/libANGLE/renderer/gl/renderergl_utils.cpp
+@@ -2751,6 +2751,10 @@
+     // IMG GL drivers crash in glClearTexImage on various format/type combinations such as packed
+     // types, LUMA and depth stencil.
+     ANGLE_FEATURE_CONDITION(features, disableClearTexImageForRobustInit, IsPowerVR(vendor));
++
++    // IMG GL drivers crash while compiling shaders with more than the limit of uniform blocks.
++    ANGLE_FEATURE_CONDITION(features, validateMaxPerStageUniformBlocksAtCompileTime,
++                            IsPowerVR(vendor));
+ }
+ 
+ void InitializeFrontendFeatures(const FunctionsGL *functions, angle::FrontendFeatures *features)
+diff --git a/src/tests/gl_tests/GLSLValidationTest.cpp b/src/tests/gl_tests/GLSLValidationTest.cpp
+index be02d55..bf80afa 100644
+--- a/src/tests/gl_tests/GLSLValidationTest.cpp
++++ b/src/tests/gl_tests/GLSLValidationTest.cpp
+@@ -7288,6 +7288,61 @@
+     validateSuccess(GL_FRAGMENT_SHADER, kShader);
+ }
+ 
++class GLSLValidationTest_ES3_ValidateUniformBlocks : public GLSLValidationTest_ES3
++{};
++
++// Test the validate_max_per_stage_uniform_blocks_at_compile_time feature which validates the
++// uniform block count at compile time instead of link time.
++TEST_P(GLSLValidationTest_ES3_ValidateUniformBlocks,
++       MaxPerStageUniformBlockLimitsValidatedByCompile)
++{
++    GLint maxVertexUniformBlocks, maxFragmentUniformBlocks;
++    glGetIntegerv(GL_MAX_VERTEX_UNIFORM_BLOCKS, &maxVertexUniformBlocks);
++    glGetIntegerv(GL_MAX_FRAGMENT_UNIFORM_BLOCKS, &maxFragmentUniformBlocks);
++
++    // Test with one large array that is larger than the limit
++    std::ostringstream vsStream;
++    vsStream << R"(#version 300 es
++precision mediump float;
++#define BLOCK_COUNT )"
++             << maxVertexUniformBlocks + 1 << R"(
++layout(std140) uniform MyBlock {
++    float x;
++} blocks[BLOCK_COUNT];
++
++void main() {
++    gl_Position = vec4(blocks[BLOCK_COUNT - 1].x);
++})";
++
++    const std::string vertexShader = vsStream.str();
++    validateError(GL_VERTEX_SHADER, vertexShader.c_str(),
++                  "uniform block count greater than per stage maximum uniform blocks");
++
++    // Test with one array that reaches the limit and a single block which overflows the limit
++    std::ostringstream fsStream;
++    fsStream << R"(#version 300 es
++precision mediump float;
++#define BLOCK_COUNT )"
++             << maxFragmentUniformBlocks + 1 << R"(
++layout(std140) uniform MyBlock0 {
++    float x;
++} blocks0[BLOCK_COUNT - 1];
++
++layout(std140) uniform MyBlock1 {
++    float x;
++} block1;
++
++out vec4 fragColor;
++
++void main() {
++    fragColor = vec4(blocks0[BLOCK_COUNT-2].x, block1.x, 0.0, 1.0);
++})";
++
++    const std::string fragmentShader = fsStream.str();
++    validateError(GL_FRAGMENT_SHADER, fragmentShader.c_str(),
++                  "uniform block count greater than per stage maximum uniform blocks");
++}
++
+ }  // namespace
+ 
+ ANGLE_INSTANTIATE_TEST_ES2_AND_ES3(GLSLValidationTest);
+@@ -7296,6 +7351,12 @@
+ GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(GLSLValidationTest_ES3);
+ ANGLE_INSTANTIATE_TEST_ES3(GLSLValidationTest_ES3);
+ 
++GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(GLSLValidationTest_ES3_ValidateUniformBlocks);
++ANGLE_INSTANTIATE_TEST(
++    GLSLValidationTest_ES3_ValidateUniformBlocks,
++    ES3_OPENGL().enable(Feature::ValidateMaxPerStageUniformBlocksAtCompileTime),
++    ES3_OPENGLES().enable(Feature::ValidateMaxPerStageUniformBlocksAtCompileTime));
++
+ GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(GLSLValidationTest_ES31);
+ ANGLE_INSTANTIATE_TEST_ES31(GLSLValidationTest_ES31);
+ 
+diff --git a/util/autogen/angle_features_autogen.cpp b/util/autogen/angle_features_autogen.cpp
+index d902086..bbb75e7 100644
+--- a/util/autogen/angle_features_autogen.cpp
++++ b/util/autogen/angle_features_autogen.cpp
+@@ -491,6 +491,7 @@
+     {Feature::UseVkEventForBufferBarrier, "useVkEventForBufferBarrier"},
+     {Feature::UseVkEventForImageBarrier, "useVkEventForImageBarrier"},
+     {Feature::UseVmaForImageSuballocation, "useVmaForImageSuballocation"},
++    {Feature::ValidateMaxPerStageUniformBlocksAtCompileTime, "validateMaxPerStageUniformBlocksAtCompileTime"},
+     {Feature::VaryingsRequireMatchingPrecisionInSpirv, "varyingsRequireMatchingPrecisionInSpirv"},
+     {Feature::VerifyPipelineCacheInBlobCache, "verifyPipelineCacheInBlobCache"},
+     {Feature::VertexIDDoesNotIncludeBaseVertex, "vertexIDDoesNotIncludeBaseVertex"},
+diff --git a/util/autogen/angle_features_autogen.h b/util/autogen/angle_features_autogen.h
+index 2277a3c..556c8c0 100644
+--- a/util/autogen/angle_features_autogen.h
++++ b/util/autogen/angle_features_autogen.h
+@@ -491,6 +491,7 @@
+     UseVkEventForBufferBarrier,
+     UseVkEventForImageBarrier,
+     UseVmaForImageSuballocation,
++    ValidateMaxPerStageUniformBlocksAtCompileTime,
+     VaryingsRequireMatchingPrecisionInSpirv,
+     VerifyPipelineCacheInBlobCache,
+     VertexIDDoesNotIncludeBaseVertex,


### PR DESCRIPTION
Optionally validate GL_MAX_*_UNIFORM_BLOCKS at compile time.

These were validated at link time but some drivers have compiler crashes
when compiling shaders with too many uniform blocks.

Bug: chromium:475877320
Change-Id: I4413ce06307b4fe9e27105d85f66f610c235a301
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/7568089
Commit-Queue: Geoff Lang <geofflang@chromium.org>
Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>


Notes: Backported fix for chromium:475877320.