### PR TITLE
fix: fall back to default DPI when GTK returns 0 on Linux

### DIFF
--- a/shell/browser/printing/printing_utils.cc
+++ b/shell/browser/printing/printing_utils.cc
@@ -59,6 +59,8 @@ gfx::Size GetDefaultPrinterDPI(const std::u16string& device_name) {
   GtkPrintSettings* print_settings = gtk_print_settings_new();
   int dpi = gtk_print_settings_get_resolution(print_settings);
   g_object_unref(print_settings);
+  if (dpi <= 0)
+    dpi = printing::kDefaultPdfDpi;
   return {dpi, dpi};
 #endif
 }


### PR DESCRIPTION
#### Description of Change

`GetDefaultPrinterDPI()` creates a blank GtkPrintSettings and reads its resolution, which returns 0 for uninitialized settings. With DPI=0, `SetPrintableAreaIfValid()` computes a zero scale factor, producing empty page dimensions that fail `PrintMsgPrintParamsIsValid()`.

Fall back to kDefaultPdfDpi (72) when GTK returns 0, matching the existing Windows fallback pattern when CreateDC fails.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.