### PR TITLE
fix: hex-encode Windows notification icon temp filenames

### DIFF
--- a/shell/browser/notifications/win/notification_presenter_win.cc
+++ b/shell/browser/notifications/win/notification_presenter_win.cc
@@ -73,7 +73,7 @@ std::wstring NotificationPresenterWin::SaveIconToFilesystem(
   std::string filename;
   if (origin.is_valid()) {
     const auto hash = base::SHA1HashString(origin.spec());
-    filename = base::HexEncode(hash.data(), hash.size()) + ".png";
+    filename = base::HexEncode(hash) + ".png";
   } else {
     const int64_t now_usec = base::Time::Now().since_origin().InMicroseconds();
     filename = base::NumberToString(now_usec) + ".png";


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/48768
Closes https://github.com/electron/electron/issues/50424

`NotificationPresenterWin` was using `SHA1HashString(origin.spec())` directly as the basename for the temporary PNG written for toast icons.

`SHA1HashString` returns raw digest bytes, so the generated filename could contain invalid path characters on Windows. That caused `WriteFile` to fail when saving notification icons, which left toast XML without the expected icon path.

Hex-encode the digest before appending .png so the temporary filename is filesystem-safe while keeping deterministic naming for a given origin.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a bug where Windows notification icons could fail to save because their temporary filenames contained invalid characters.
