### PR TITLE
fix: crash in clipboard.readImage() on malformed image data

### DIFF
--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -378,7 +378,11 @@ gfx::Image Clipboard::ReadImage(gin::Arguments* const args) {
           [](std::optional<gfx::Image>* image, base::RepeatingClosure cb,
              const std::vector<uint8_t>& result) {
             SkBitmap bitmap = gfx::PNGCodec::Decode(result);
-            image->emplace(gfx::Image::CreateFrom1xBitmap(bitmap));
+            if (bitmap.isNull()) {
+              image->emplace();
+            } else {
+              image->emplace(gfx::Image::CreateFrom1xBitmap(bitmap));
+            }
             std::move(cb).Run();
           },
           &image, std::move(callback)));


### PR DESCRIPTION
`gfx::PNGCodec::Decode()` returns a null `SkBitmap` when it cannot decode the clipboard contents as a PNG. Passing that null bitmap to `gfx::Image::CreateFrom1xBitmap()` triggers a crash.

This PR adds a null check and returns an empty `gfx::Image` instead, matching the existing pattern in `shell/common/skia_util.cc`.

Notes: Fixed a crash in `clipboard.readImage()` when the clipboard contains malformed image data.