### PR TITLE
fix: correct linux zygote process titles

### DIFF
--- a/shell/app/electron_library_main.mm
+++ b/shell/app/electron_library_main.mm
@@ -7,10 +7,10 @@
 #include "shell/app/electron_library_main.h"
 
 #include "base/apple/bundle_locations.h"
-#include "base/compiler_specific.h"
 #include "base/apple/scoped_nsautorelease_pool.h"
 #include "base/at_exit.h"
 #include "base/command_line.h"
+#include "base/compiler_specific.h"
 #include "base/i18n/icu_util.h"
 #include "base/notreached.h"
 #include "content/public/app/content_main.h"

--- a/shell/app/electron_main_linux.cc
+++ b/shell/app/electron_main_linux.cc
@@ -5,8 +5,8 @@
 #include <cstdlib>
 
 #include "base/at_exit.h"
-#include "base/compiler_specific.h"
 #include "base/command_line.h"
+#include "base/compiler_specific.h"
 #include "base/i18n/icu_util.h"
 #include "base/strings/cstring_view.h"
 #include "content/public/app/content_main.h"


### PR DESCRIPTION
#### Description of Change

On Linux, Electron child processes all showed up as generic zygotes in `ps aux`:

```
mitch    1759609  2.0  0.3 1460051028 214440 ?   S<l  19:47   0:00 /home/mitch/.config/Electron Fiddle/electron-bin/current/electron /tmp/electron-fiddle-1279287-sMVygh0fH1jo --inspect --ozone-platform=wayland /home/mitch/.cache/fiddle-core/fiddles/b35b66f75612912880e4d66dd317c9b5/main.js
mitch    1759612  0.0  0.1 50920708 66004 ?      S<   19:47   0:00 /home/mitch/.config/Electron Fiddle/electron-bin/current/electron --type=zygote --no-zygote-sandbox
mitch    1759613  0.0  0.1 50920696 65672 ?      S<   19:47   0:00 /home/mitch/.config/Electron Fiddle/electron-bin/current/electron --type=zygote
mitch    1759615  0.0  0.0 50920724 14840 ?      S<   19:47   0:00 /home/mitch/.config/Electron Fiddle/electron-bin/current/electron --type=zygote
mitch    1759655  4.3  0.2 56064660 179472 ?     S<l  19:47   0:00 /home/mitch/.config/Electron Fiddle/electron-bin/current/electron --type=zygote --no-zygote-sandbox
mitch    1759661  0.1  0.1 1459874424 105480 ?   S<l  19:47   0:00 /home/mitch/.config/Electron Fiddle/electron-bin/current/electron --type=zygote

```

Now they show their proper types (gpu, renderer) and arguments including flags, like Chromium:

```
mitch    1762160  5.4  0.4 1460197916 282588 ?   S<l  19:49   0:00 /home/mitch/data/Projects/electron/src/out/Testing/electron --inspect --ozone-platform=wayland /tmp/electron-fiddle-1279287-nrTwr784BgJm /home/mitch/.cache/fiddle-core/fiddles/fffa3b930a77d2140805f58b927ab25a/main.js
mitch    1762163  0.1  0.1 51061676 74196 ?      S<   19:49   0:00 /home/mitch/data/Projects/electron/src/out/Testing/electron --type=zygote --no-zygote-sandbox
mitch    1762164  0.1  0.1 51061660 73664 ?      S<   19:49   0:00 /home/mitch/data/Projects/electron/src/out/Testing/electron --type=zygote
mitch    1762166  0.0  0.0 51061688 17084 ?      S<   19:49   0:00 /home/mitch/data/Projects/electron/src/out/Testing/electron --type=zygote
mitch    1762218  7.5  0.3 56222176 211964 ?     S<l  19:49   0:00 /home/mitch/data/Projects/electron/src/out/Testing/electron --type=gpu-process --ozone-platform=wayland --render-node-override=/dev/dri/renderD128 --enable-crash-reporter=a22a5bff-8f3b-4af2-880f-453ac5aa42e2,no_channel --user-data-dir=/home/mitch/.config/truthful-owner-accuse-p9k3a --gpu-preferences=UAAAAAAAAAAgAQAEAAAAAAAAAAAAAGAAAQAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAYAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAgAAAAAAAAA --shared-files --field-trial-handle=3,i,14101308013274626288,521187619438631028,262144 --enable-features=PdfUseShowSaveFilePicker --disable-features=DropInputEventsWhilePaintHolding,LocalNetworkAccessChecks,ScreenAIOCREnabled,SpareRendererForSitePerProcess,TraceSiteInstanceGetProcessCreation --variations-seed-version --pseudonymization-salt-handle=7,i,506182766847727171,559410832760408655,4 --trace-process-track-uuid=3209054329606749827
mitch    1762220  0.3  0.1 50881940 116376 ?     Sl   19:49   0:00 /home/mitch/data/Projects/electron/src/out/Testing/electron --type=utility --utility-sub-type=network.mojom.NetworkService --lang=en-GB --service-sandbox-type=none --render-node-override=/dev/dri/renderD128 --enable-crash-reporter=a22a5bff-8f3b-4af2-880f-453ac5aa42e2,no_channel --user-data-dir=/home/mitch/.config/truthful-owner-accuse-p9k3a --shared-files=v8_context_snapshot_data:100 --field-trial-handle=3,i,14101308013274626288,521187619438631028,262144 --enable-features=PdfUseShowSaveFilePicker --disable-features=DropInputEventsWhilePaintHolding,LocalNetworkAccessChecks,ScreenAIOCREnabled,SpareRendererForSitePerProcess,TraceSiteInstanceGetProcessCreation --variations-seed-version --pseudonymization-salt-handle=7,i,506182766847727171,559410832760408655,4 --trace-process-track-uuid=3998329054067842808
mitch    1762232  1.2  0.2 1460023584 179472 ?   S<l  19:49   0:00 /home/mitch/data/Projects/electron/src/out/Testing/electron --type=renderer --enable-crash-reporter=a22a5bff-8f3b-4af2-880f-453ac5aa42e2,no_channel --user-data-dir=/home/mitch/.config/truthful-owner-accuse-p9k3a --app-path=/tmp/electron-fiddle-1279287-nrTwr784BgJm --enable-sandbox --ozone-platform=wayland --lang=en-GB --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=4 --time-ticks-at-unix-epoch=-1774386820747858 --launch-time-ticks=95740213746 --shared-files=v8_context_snapshot_data:100 --field-trial-handle=3,i,14101308013274626288,521187619438631028,262144 --enable-features=PdfUseShowSaveFilePicker --disable-features=DropInputEventsWhilePaintHolding,LocalNetworkAccessChecks,ScreenAIOCREnabled,SpareRendererForSitePerProcess,TraceSiteInstanceGetProcessCreation --variations-seed-version --pseudonymization-salt-handle=7,i,506182766847727171,559410832760408655,4 --trace-process-track-uuid=4787603778528935789

```

The fix is to pass the original `argv` pointer through to Chromium, since libuv copies it to a different buffer and that breaks Chromium's integrity check when setting the process information.

Refs https://github.com/electron/electron/issues/50462.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

NOTE: PRS submitted without this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] I have built and tested this PR
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed Electron child process titles on Linux so they show their types (render, gpu, etc.) and complete command-line arguments and flags in `ps aux`.
