### PR TITLE
fix: extract 1 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/archaeologist-dig.yml
+++ b/.github/workflows/archaeologist-dig.yml
@@ -23,17 +23,19 @@ jobs:
       - name: Setting Up Dig Site
         run: |
           echo "remote: ${{ github.event.pull_request.head.repo.clone_url }}"
-          echo "sha ${{ github.event.pull_request.head.sha }}"
+          echo "sha ${PR_HEAD_SHA}"
           echo "base ref ${{ github.event.pull_request.base.ref }}"
           git clone https://github.com/electron/electron.git electron          
           cd electron
           mkdir -p artifacts
           git remote add fork ${{ github.event.pull_request.head.repo.clone_url }} && git fetch fork
-          git checkout  ${{ github.event.pull_request.head.sha }}
+          git checkout  ${PR_HEAD_SHA}
           git merge-base origin/${{ github.event.pull_request.base.ref }} HEAD > .dig-old
-          echo  ${{ github.event.pull_request.head.sha }} > .dig-new
+          echo  ${PR_HEAD_SHA} > .dig-new
           cp .dig-old artifacts
 
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       - name: Generating Types for SHA in .dig-new
         uses: ./.github/actions/generate-types
         with:


### PR DESCRIPTION
## Fix: CI/CD Security Vulnerabilities in GitHub Actions

Hi! [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), an open-source
CI/CD security scanner by [Vigilant Cyber Security](https://www.vigilantdefense.com),
identified security vulnerabilities in this repository's GitHub Actions workflows.

This PR applies automated fixes where possible and reports additional findings
for your review.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-002 | high | `.github/workflows/archaeologist-dig.yml` | Extracted 1 unsafe expression(s) to env vars |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-012 | high | `.github/workflows/branch-created.yml` | Secret Exfiltration via Outbound HTTP Request |
| RGS-012 | high | `.github/workflows/macos-disk-cleanup.yml` | Secret Exfiltration via Outbound HTTP Request |
| RGS-004 | high | `.github/workflows/pr-triage-automation.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/pr-triage-automation.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-005 | medium | `.github/workflows/non-maintainer-dependency-change.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/pr-template-check.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/pull-request-opened-synchronized.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.