### PR TITLE
ci: update nick-fields/retry to v4.0.0

### DIFF
--- a/.github/actions/restore-cache-azcopy/action.yml
+++ b/.github/actions/restore-cache-azcopy/action.yml
@@ -24,7 +24,7 @@ runs:
     # The cache will always exist here as a result of the checkout job
     # Either it was uploaded to Azure in the checkout job for this commit
     # or it was uploaded in the checkout job for a previous commit.
-    uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+    uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
     with:
       timeout_minutes: 30
       max_attempts: 3
@@ -101,7 +101,7 @@ runs:
 
   - name: Move Src Cache (Windows)
     if: ${{ inputs.target-platform == 'win' }}
-    uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+    uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
     with:
       timeout_minutes: 30
       max_attempts: 3


### PR DESCRIPTION
#### Description of Change
- Followup to #50373.  Updates nick-fields/retry to v4.0.0 to get a version of that action that uses node 24.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

NOTE: PRS submitted without this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
