### PR TITLE
ci: don't request review for PRs in draft or WIP

### DIFF
--- a/.github/workflows/pr-triage-automation.yml
+++ b/.github/workflows/pr-triage-automation.yml
@@ -16,10 +16,13 @@ jobs:
   set-needs-review:
     name: Set status to Needs Review
     if: >-
-      (github.event_name == 'pull_request_target' && github.event.action == 'synchronize')
-      || (github.event_name == 'pull_request_target' && github.event.action == 'review_requested')
+      (github.event_name == 'pull_request_target'
+        && github.event.pull_request.draft != true
+        && !contains(github.event.pull_request.labels.*.name, 'wip ⚒')
+        && (github.event.action == 'synchronize' || github.event.action == 'review_requested'))
       || (github.event_name == 'issue_comment'
           && github.event.issue.pull_request
+          && !contains(github.event.issue.labels.*.name, 'wip ⚒')
           && github.event.comment.user.login == github.event.issue.user.login)
     runs-on: ubuntu-slim
     permissions:


### PR DESCRIPTION
#### Description of Change
- Followup to #50248.  The Needs Review status should not be set for draft or WIP prs.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

NOTE: PRS submitted without this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
