### PR TITLE
refactor: improve input handling in FilePath gin converter

### DIFF
--- a/shell/common/gin_converters/file_path_converter.h
+++ b/shell/common/gin_converters/file_path_converter.h
@@ -5,6 +5,8 @@
 #ifndef ELECTRON_SHELL_COMMON_GIN_CONVERTERS_FILE_PATH_CONVERTER_H_
 #define ELECTRON_SHELL_COMMON_GIN_CONVERTERS_FILE_PATH_CONVERTER_H_
 
+#include <algorithm>
+
 #include "base/files/file_path.h"
 #include "gin/converter.h"
 #include "shell/common/gin_converters/std_converter.h"
@@ -30,6 +32,11 @@ struct Converter<base::FilePath> {
 
     base::FilePath::StringType path;
     if (Converter<base::FilePath::StringType>::FromV8(isolate, val, &path)) {
+      bool has_control_chars = std::any_of(
+          path.begin(), path.end(),
+          [](base::FilePath::CharType c) { return c >= 0 && c < 0x20; });
+      if (has_control_chars)
+        return false;
       *out = base::FilePath(path);
       return true;
     } else {

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -608,6 +608,9 @@ bool Converter<scoped_refptr<network::ResourceRequestBody>>::FromV8(
       const std::string* file = dict.FindString("filePath");
       if (!file)
         return false;
+      if (std::any_of(file->begin(), file->end(),
+                      [](char c) { return c >= 0 && c < 0x20; }))
+        return false;
       double modification_time =
           dict.FindDouble("modificationTime").value_or(0.0);
       int offset = dict.FindInt("offset").value_or(0);


### PR DESCRIPTION
#### Description of Change

This PR modifies the FilePath gin converter so that paths containing certain characters are properly handled across platforms.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
