### PR TITLE
fix: prevent borders and smearing in transparent frameless/client frame windows on Linux

### DIFF
--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
@@ -239,7 +239,9 @@ void ElectronDesktopWindowTreeHostLinux::UpdateFrameHints() {
     if (ui::OzonePlatform::GetInstance()->IsWindowCompositingSupported()) {
       // Set the opaque region.
       std::vector<gfx::Rect> opaque_region;
-      if (IsShowingFrame(window_state)) {
+      if (native_window_view_->IsTranslucent()) {
+        // Leave opaque_region empty.
+      } else if (IsShowingFrame(window_state)) {
         // The opaque region is a list of rectangles that contain only fully
         // opaque pixels of the window.  We need to convert the clipping
         // rounded-rect into this format.

--- a/shell/browser/ui/views/opaque_frame_view.cc
+++ b/shell/browser/ui/views/opaque_frame_view.cc
@@ -203,6 +203,12 @@ void OpaqueFrameView::OnPaint(gfx::Canvas* canvas) {
   if (frame()->IsFullscreen())
     return;
 
+  if (window()->IsWindowControlsOverlayEnabled())
+    UpdateFrameCaptionButtons();
+
+  if (window()->IsTranslucent())
+    return;
+
   const bool active = ShouldPaintAsActive();
   const gfx::Insets border = RestoredFrameBorderInsets();
   const bool showing_shadow = linux_frame_layout_->IsShowingShadow();
@@ -228,11 +234,6 @@ void OpaqueFrameView::OnPaint(gfx::Canvas* canvas) {
   ::PaintRestoredFrameBorderLinux(*canvas, *this, frame_background_.get(), clip,
                                   showing_shadow, active, border, shadow_values,
                                   linux_frame_layout_->tiled());
-
-  if (!window()->IsWindowControlsOverlayEnabled())
-    return;
-
-  UpdateFrameCaptionButtons();
 }
 
 void OpaqueFrameView::PaintAsActiveChanged() {


### PR DESCRIPTION
#### Description of Change

Electron 41.x added CSD to frameless windows, which introduced a regression where transparent frameless windows would have 1px borders.

Fixing this issue also addressed another problem with transparency on Linux (going back years for client frames) where transparent windows would smear and get corrupted as windows were dragged around. The underlying cause was the same: parts of the window lifecycle, painting, and opacity checks did not account for transparency.

Fixes https://github.com/electron/electron/issues/50536, fixes https://github.com/electron/electron/issues/50535.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

NOTE: PRS submitted without this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] I have built and tested this PR
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples --> Fixed a regression on Linux where transparent frameless windows would have visible borders.  Also fixed a longstanding issue where transparent windows on Linux could show smeared and glitched content as windows moved around.
