### PR TITLE
fix: fix devtools patch type error on release builds

### DIFF
--- a/patches/devtools_frontend/feat_allow_enabling_extension_panels_on_custom_protocols.patch
+++ b/patches/devtools_frontend/feat_allow_enabling_extension_panels_on_custom_protocols.patch
@@ -7,14 +7,14 @@ This allows us to show Chrome extension panels on pages served over
 custom protocols.
 
 diff --git a/front_end/core/root/Runtime.ts b/front_end/core/root/Runtime.ts
-index 4f91e0d7b1d289f5eaaaf7c4e174679881fd9a54..cfdfdfe03edfdf89374763f5b3086f0eb15fa72c 100644
+index 4f91e0d7b1d289f5eaaaf7c4e174679881fd9a54..a26b2852662d10f10824cc45735ef12f19a3df86 100644
 --- a/front_end/core/root/Runtime.ts
 +++ b/front_end/core/root/Runtime.ts
 @@ -645,6 +645,7 @@ export type HostConfig = Platform.TypeScriptUtilities.RecursivePartial<{
     * or guest mode, rather than a "normal" profile.
     */
    isOffTheRecord: boolean,
-+  devToolsExtensionSchemes: string[],
++  devToolsExtensionSchemes: readonly string[],
    devToolsEnableOriginBoundCookies: HostConfigEnableOriginBoundCookies,
    devToolsAnimationStylesInStylesTab: HostConfigAnimationStylesInStylesTab,
    devToolsJpegXlImageFormat: HostConfigJpegXlImageFormat,


### PR DESCRIPTION
#### Description of Change

This PR fixes a type error in the DevTools extension patch that flags on release builds.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] I have built and tested this PR
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
