### PR TITLE
fix: add missing HandleScope in contentTracing.getTraceBufferUsage()

### DIFF
--- a/shell/browser/api/electron_api_content_tracing.cc
+++ b/shell/browser/api/electron_api_content_tracing.cc
@@ -151,7 +151,10 @@ void OnTraceBufferUsageAvailable(
     gin_helper::Promise<gin_helper::Dictionary> promise,
     float percent_full,
     size_t approximate_count) {
-  auto dict = gin_helper::Dictionary::CreateEmpty(promise.isolate());
+  v8::Isolate* isolate = promise.isolate();
+  v8::HandleScope handle_scope(isolate);
+
+  auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
   dict.Set("percentage", percent_full);
   dict.Set("value", approximate_count);
 

--- a/spec/api-content-tracing-spec.ts
+++ b/spec/api-content-tracing-spec.ts
@@ -132,6 +132,36 @@ ifdescribe(!(['arm', 'arm64'].includes(process.arch)) || (process.platform !== '
     });
   });
 
+  describe('getTraceBufferUsage', function () {
+    this.timeout(10e3);
+
+    it('does not crash and returns valid usage data', async () => {
+      await app.whenReady();
+      await contentTracing.startRecording({
+        categoryFilter: '*',
+        traceOptions: 'record-until-full'
+      });
+
+      // Yield to the event loop so the JS HandleScope from this tick is gone.
+      // When the Mojo response arrives it fires OnTraceBufferUsageAvailable
+      // as a plain Chromium task — if that callback lacks its own HandleScope
+      // the process will crash with "Cannot create a handle without a HandleScope".
+      const result = await contentTracing.getTraceBufferUsage();
+
+      expect(result).to.have.property('percentage').that.is.a('number');
+      expect(result).to.have.property('value').that.is.a('number');
+
+      await contentTracing.stopRecording();
+    });
+
+    it('returns zero usage when no trace is active', async () => {
+      await app.whenReady();
+      const result = await contentTracing.getTraceBufferUsage();
+      expect(result).to.have.property('percentage').that.is.a('number');
+      expect(result.percentage).to.equal(0);
+    });
+  });
+
   describe('captured events', () => {
     it('include V8 samples from the main process', async function () {
       this.timeout(60000);


### PR DESCRIPTION
#### Description of Change

`contentTracing.getTraceBufferUsage()` crashes with a fatal V8 error when
a trace session is active:

```
Fatal error in V8: v8::HandleScope::CreateHandle() Cannot create a handle without a HandleScope
```

The root cause is in `OnTraceBufferUsageAvailable` — the callback for
`TracingController::GetTraceBufferUsage()`. When a trace session is active,
the Chromium tracing service responds asynchronously via Mojo IPC. The
response fires `OnTraceBufferUsageAvailable` as a plain Chromium task on
the UI thread, with no V8 `HandleScope` on the stack.

The callback creates V8 handles via `Dictionary::CreateEmpty()` and
`dict.Set()` *before* `promise.Resolve()` enters its `SettleScope` (which
provides a `HandleScope`). This triggers V8's `SealHandleScope` guard and
crashes the process.

When no trace session is active, `TracingControllerImpl::GetTraceBufferUsage`
short-circuits and calls the callback synchronously (while the JS-level
`HandleScope` is still on the stack), which is why the crash only manifests
with an active trace.

The fix adds an explicit `v8::HandleScope` at the top of the callback,
matching the pattern used by the other `contentTracing` APIs (`getCategories`
and `startRecording` use `Promise::ResolvePromise`; `stopRecording`'s lambda
only calls `promise.Resolve()`/`promise.RejectWithErrorMessage()` which
create their own `HandleScope` via `SettleScope`).

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash in `contentTracing.getTraceBufferUsage()` caused by a missing V8 HandleScope when the callback fires asynchronously from the tracing service.

Made with [Cursor](https://cursor.com)