### PR TITLE
fix: remove duplicate fullscreen menu item on macOS

### DIFF
--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -56,6 +56,11 @@ static NSDictionary* UNNotificationResponseToNSDictionary(
 }
 
 - (void)applicationWillFinishLaunching:(NSNotification*)notify {
+  // Don't add the "Enter Full Screen" menu item automatically.
+  [[NSUserDefaults standardUserDefaults]
+      setBool:NO
+       forKey:@"NSFullScreenMenuItemEverywhere"];
+
   [[[NSWorkspace sharedWorkspace] notificationCenter]
       addObserver:self
          selector:@selector(willPowerOff:)

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -585,13 +585,6 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
 - (void)menuWillOpen:(NSMenu*)menu {
   isMenuOpen_ = YES;
 
-  // macOS automatically injects a duplicate "Toggle Full Screen" menu item
-  // when we set menu.delegate on submenus. Remove hidden duplicates.
-  for (NSMenuItem* item in menu.itemArray) {
-    if (item.isHidden && item.action == @selector(toggleFullScreenMode:))
-      [menu removeItem:item];
-  }
-
   if (model_)
     model_->MenuWillShow();
 }


### PR DESCRIPTION
#### Description of Change
macOS automatically injects an "Enter Full Screen" menu item using the native `toggleFullScreen:` selector. Since Electron provides its own fullscreen toggle via the custom `toggleFullScreenMode:` selector, both items appeared in the View menu.

The previous fix (#49598) checked for items with `toggleFullScreenMode:` (Electron's selector) and required `isHidden`, but the system-injected item uses `toggleFullScreen:` (the native selector) and is not hidden. This fix checks for the correct native selector regardless of hidden state.

Fixes #50531

#### Checklist
- [x] PR description included
- [x] I have built and tested this PR
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed duplicate "Toggle Full Screen" menu entry appearing in the View menu on macOS.
