### PR TITLE
docs: document setAlwaysOnTop and isAlwaysOnTop Wayland limitations

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -944,9 +944,13 @@ Sets whether the window should show always on top of other windows. After
 setting this, the window is still a normal window, not a toolbox window which
 can not be focused on.
 
+Not supported on Wayland (Linux).
+
 #### `win.isAlwaysOnTop()`
 
 Returns `boolean` - Whether the window is always on top of other windows.
+
+Not supported on Wayland (Linux).
 
 #### `win.moveAbove(mediaSourceId)`
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1056,9 +1056,13 @@ Sets whether the window should show always on top of other windows. After
 setting this, the window is still a normal window, not a toolbox window which
 can not be focused on.
 
+Not supported on Wayland (Linux).
+
 #### `win.isAlwaysOnTop()`
 
 Returns `boolean` - Whether the window is always on top of other windows.
+
+Not supported on Wayland (Linux).
 
 #### `win.moveAbove(mediaSourceId)`
 

--- a/docs/api/structures/base-window-options.md
+++ b/docs/api/structures/base-window-options.md
@@ -29,7 +29,7 @@
   stop interacting with wm, so the window will always stay on top in all
   workspaces.
 * `alwaysOnTop` boolean (optional) - Whether the window should always stay on top of
-  other windows. Default is `false`.
+  other windows. Default is `false`. Not supported on Wayland (Linux).
 * `fullscreen` boolean (optional) - Whether the window should show in fullscreen. When
   explicitly set to `false` the fullscreen button will be hidden or disabled
   on macOS. Default is `false`.

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -25,10 +25,6 @@ fallback frames as well.
 Apps or extensions that relied on Electron skipping those frames should narrow their
 injection target, frame IDs, or match patterns.
 
-### Behavior Changed: `setAlwaysOnTop` and `isAlwaysOnTop` not supported on Wayland
-
-The `BrowserWindow.setAlwaysOnTop()` and `BrowserWindow.isAlwaysOnTop()` APIs are not supported on Wayland (Linux), as the protocol does not provide a way for applications to control window z-order. Users can force XWayland by passing `--ozone-platform=x11`.
-
 ### Behavior Changed: Dialog methods default to Downloads directory
 
 The `defaultPath` option for the following methods now defaults to the user's Downloads folder (or their home directory if Downloads doesn't exist) when not explicitly provided:

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -25,6 +25,10 @@ fallback frames as well.
 Apps or extensions that relied on Electron skipping those frames should narrow their
 injection target, frame IDs, or match patterns.
 
+### Behavior Changed: `setAlwaysOnTop` and `isAlwaysOnTop` not supported on Wayland
+
+The `BrowserWindow.setAlwaysOnTop()` and `BrowserWindow.isAlwaysOnTop()` APIs are not supported on Wayland (Linux), as the protocol does not provide a way for applications to control window z-order. Users can force XWayland by passing `--ozone-platform=x11`.
+
 ### Behavior Changed: Dialog methods default to Downloads directory
 
 The `defaultPath` option for the following methods now defaults to the user's Downloads folder (or their home directory if Downloads doesn't exist) when not explicitly provided:


### PR DESCRIPTION
#### Description of Change

Documents that `setAlwaysOnTop` has no effect on Wayland (Linux) since the Wayland protocol does not allow applications to control their own z-order. Also adds a note to `isAlwaysOnTop` explaining that the returned value may be inaccurate on Wayland, as it reflects the internally stored state rather than the actual window z-order.

Changes made:
- Added "Not supported on Wayland (Linux)" note to `setAlwaysOnTop` in both `base-window.md` and `browser-window.md`
- Added `[!NOTE]` block to `isAlwaysOnTop` in both files explaining the potential inaccuracy on Wayland
- Added "Not supported on Wayland (Linux)" to the `alwaysOnTop` constructor option in `base-window-options.md`

Fixes #50403

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Documented that `setAlwaysOnTop` and `isAlwaysOnTop` are not supported on Wayland (Linux) due to protocol limitations.