### PR TITLE
fix: remove unnecessary permission check in GetStatus method

### DIFF
--- a/shell/browser/file_system_access/file_system_access_permission_context.cc
+++ b/shell/browser/file_system_access/file_system_access_permission_context.cc
@@ -258,23 +258,6 @@ class FileSystemAccessPermissionContext::PermissionGrantImpl
   // FileSystemAccessPermissionGrant:
   PermissionStatus GetStatus() override {
     DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-
-    auto* permission_manager =
-        static_cast<electron::ElectronPermissionManager*>(
-            context_->browser_context()->GetPermissionControllerDelegate());
-    if (permission_manager && permission_manager->HasPermissionCheckHandler()) {
-      base::DictValue details;
-      details.Set("filePath", base::FilePathToValue(path_info_.path));
-      details.Set("isDirectory", handle_type_ == HandleType::kDirectory);
-      details.Set("fileAccessType",
-                  type_ == GrantType::kWrite ? "writable" : "readable");
-
-      bool granted = permission_manager->CheckPermissionWithDetails(
-          blink::PermissionType::FILE_SYSTEM, nullptr, origin_.GetURL(),
-          std::move(details));
-      return granted ? PermissionStatus::GRANTED : PermissionStatus::DENIED;
-    }
-
     return status_;
   }
 


### PR DESCRIPTION
#### Description of Change

Changed GetStatus() to just return the cached [status_](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of re-invoking the handler. Permissions are determined once via the async RequestPermission() flow (which handles queuing properly), then cached and reused. If a permission is revoked at runtime, [SetStatus()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) + [NotifyPermissionStatusChanged()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) ensures Blink is notified and will re-query on the next access.

Closes #50559
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

NOTE: PRS submitted without this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Removed the synchronous call to CheckPermissionWithDetails from GetStatus that was blocking Promise.all on getFIleHandle<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
