### PR TITLE
docs: document Document-Policy requirement for collectJavaScriptCallStack

### DIFF
--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -161,6 +161,17 @@ otherwise unable to be collected, it will return `undefined`.
 This can be useful to determine why the frame is unresponsive in cases where there's long-running JavaScript.
 For more information, see the [proposed Crash Reporting API.](https://wicg.github.io/crash-reporting/)
 
+> [!NOTE]
+> Two conditions must both be met for this API to work:
+>
+> 1. The app must enable the feature flag at startup:
+>    `app.commandLine.appendSwitch('enable-features', 'DocumentPolicyIncludeJSCallStacksInCrashReports')`
+> 2. The page being loaded must opt in by sending the following HTTP response header:
+>    `Document-Policy: include-js-call-stacks-in-crash-reports`
+>
+> If the response header is absent, `collectJavaScriptCallStack()` resolves with the message
+> `"Website owner has not opted in for JS call stacks in crash reports"`.
+
 ```js
 const { app } = require('electron')
 


### PR DESCRIPTION
#### Description of Change

- add a `NOTE` callout to `frame.collectJavaScriptCallStack()` explaining that **two** conditions must be met:
  1. the app-side `enable-features` flag (already shown in the example)
  2. the page must send `Document-Policy: include-js-call-stacks-in-crash-reports` as an HTTP response header
- document the error string returned when the header is absent: `"Website owner has not opted in for JS call stacks in crash reports"`

Fixes #45356

#### Checklist

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: no-notes