### PR TITLE
docs: clarify code signing requirement for safeStorage on macOS

### DIFF
--- a/docs/api/safe-storage.md
+++ b/docs/api/safe-storage.md
@@ -24,6 +24,16 @@ same userspace.
 security semantics of content protected via the `safeStorage` API vary between window managers and secret stores.
   * Note that not all Linux setups have an available secret store. If no secret store is available, items stored in using the `safeStorage` API will be unprotected as they are encrypted via hardcoded plaintext password. You can detect when this happens when `safeStorage.getSelectedStorageBackend()` returns `basic_text`.
 
+> [!IMPORTANT]
+> On macOS, the `safeStorage` API stores encryption keys in the system Keychain under
+> an entry scoped to your app's bundle ID. If your app is not **code signed**, the
+> Keychain entry is associated with an unsigned identity, which means every time the
+> app is rebuilt or reinstalled, the OS treats it as a different app and the user must
+> re-grant Keychain access. **Notarization is not required** for `safeStorage` to work,
+> but code signing is strongly recommended to avoid this regression on each update.
+> See [Apple's documentation on code signing](https://developer.apple.com/documentation/security/code_signing_services)
+> for details.
+
 Note that on macOS, access to the system Keychain is required and
 these calls can block the current thread to collect user input.
 The same is true for Linux, if a password management tool is available.


### PR DESCRIPTION
#### Description of Change

- adds an IMPORTANT callout to safe-storage.md explaining that on macOS the safeStorage API requires the app to be code signed to prevent users from having to re-grant Keychain access on every update/reinstall
- clarifies that notarization is not required (a common misconception)
- links to Apple code signing documentation

Closes #45802

#### Checklist

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the documentation style guide
- [x] PR release notes describe the change in a way relevant to app developers

#### Release Notes

Notes: no-notes