### PR TITLE
docs: clarify source:dns is required for DNS-over-HTTPS in resolveHost

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -687,7 +687,11 @@ pooled sockets using previous proxy from being reused by future requests.
       come from DNS, MulticastDNS, HOSTS file, etc
     * `system` - Results will only be retrieved from the system or OS, e.g. via
       the `getaddrinfo()` system call
-    * `dns` - Results will only come from DNS queries
+    * `dns` - Results will only come from DNS queries. Use this value when you
+      have configured DNS-over-HTTPS via
+      [`ses.configureHostResolver()`](#sescconfigurehostresolveroptions) to
+      ensure the query is routed through your DoH servers rather than falling
+      back to the system resolver or another source.
     * `mdns` - Results will only come from Multicast DNS queries
     * `localOnly` - No external sources will be used. Results will only come
       from fast local sources that are available no matter the source setting,


### PR DESCRIPTION
#### Description of Change

- adds a note to the `source: "dns"` option in `ses.resolveHost()` explaining that this value must be used explicitly when DNS-over-HTTPS has been configured via `ses.configureHostResolver()`
- without `source: "dns"`, the default `source: "any"` or `source: "system"` may bypass the DoH servers entirely

Fixes #49055

#### Checklist

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the documentation style guide
- [x] PR release notes describe the change in a way relevant to app developers

#### Release Notes

Notes: no-notes