### PR TITLE
fix: resolve WebContents lifecycle stability and resource management issues

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -210,9 +210,8 @@ function parsePageSize (pageSize: string | ElectronInternal.PageSize) {
   }
 }
 
-// Translate the options of printToPDF.
+const pendingPrintToPDF = new WeakMap<Electron.WebContents, Promise<any>>();
 
-let pendingPromise: Promise<any> | undefined;
 WebContents.prototype.printToPDF = async function (options) {
   const margins = checkType(options.margins ?? {}, 'object', 'margins');
   const pageSize = parsePageSize(options.pageSize ?? 'letter');
@@ -245,12 +244,11 @@ WebContents.prototype.printToPDF = async function (options) {
   };
 
   if (this._printToPDF) {
-    if (pendingPromise) {
-      pendingPromise = pendingPromise.then(() => this._printToPDF(printSettings));
-    } else {
-      pendingPromise = this._printToPDF(printSettings);
-    }
-    return pendingPromise;
+    const lastPromise = pendingPrintToPDF.get(this) || Promise.resolve();
+    // Use .finally style .then/.catch to ensure the chain continues even if a previous print failed.
+    const promise = lastPromise.then(() => this._printToPDF(printSettings), () => this._printToPDF(printSettings));
+    pendingPrintToPDF.set(this, promise);
+    return promise;
   } else {
     throw new Error('Printing feature is disabled');
   }

--- a/lib/browser/ipc-main-internal-utils.ts
+++ b/lib/browser/ipc-main-internal-utils.ts
@@ -1,3 +1,4 @@
+import { webContents } from 'electron/main';
 import { ipcMainInternal } from '@electron/internal/browser/ipc-main-internal';
 
 type IPCHandler = (event: ElectronInternal.IpcMainInternalEvent, ...args: any[]) => any
@@ -18,20 +19,26 @@ export function invokeInWebContents<T> (sender: Electron.WebContents, command: s
   return new Promise<T>((resolve, reject) => {
     const requestId = ++nextId;
     const channel = `${command}_RESPONSE_${requestId}`;
-    ipcMainInternal.on(channel, function handler (event, error: Error, result: any) {
+    const cleanup = () => {
+      (ipcMainInternal as any).removeListener(channel, handler);
+    };
+    function handler (event: any, error: Error, result: any) {
       if (event.type !== 'frame' || event.sender !== sender) {
         console.error(`Reply to ${command} sent by unexpected sender`);
         return;
       }
 
-      ipcMainInternal.removeListener(channel, handler);
+      cleanup();
+      sender.removeListener('destroyed' as any, cleanup);
 
       if (error) {
         reject(error);
       } else {
         resolve(result);
       }
-    });
+    }
+    ipcMainInternal.on(channel, handler);
+    sender.once('destroyed' as any, cleanup);
 
     sender._sendInternal(command, requestId, ...args);
   });
@@ -41,21 +48,33 @@ export function invokeInWebFrameMain<T> (sender: Electron.WebFrameMain, command:
   return new Promise<T>((resolve, reject) => {
     const requestId = ++nextId;
     const channel = `${command}_RESPONSE_${requestId}`;
-    const frameTreeNodeId = sender.frameTreeNodeId;
-    ipcMainInternal.on(channel, function handler (event, error: Error, result: any) {
+    const frameTreeNodeId = (sender as any).frameTreeNodeId;
+    const cleanup = () => {
+      (ipcMainInternal as any).removeListener(channel, handler);
+    };
+    function handler (event: any, error: Error, result: any) {
       if (event.type !== 'frame' || event.frameTreeNodeId !== frameTreeNodeId) {
         console.error(`Reply to ${command} sent by unexpected sender`);
         return;
       }
 
-      ipcMainInternal.removeListener(channel, handler);
+      cleanup();
+      const contents = webContents.fromFrame(sender);
+      if (contents) {
+        contents.removeListener('destroyed' as any, cleanup);
+      }
 
       if (error) {
         reject(error);
       } else {
         resolve(result);
       }
-    });
+    }
+    ipcMainInternal.on(channel, handler);
+    const contents = webContents.fromFrame(sender);
+    if (contents) {
+      contents.once('destroyed' as any, cleanup);
+    }
 
     sender._sendInternal(command, requestId, ...args);
   });

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2203,6 +2203,7 @@ void WebContents::DidFinishNavigation(
     frame_process_id = frame_host->GetProcess()->GetID().GetUnsafeValue();
     frame_routing_id = frame_host->GetRoutingID();
   }
+  auto weak_this = GetWeakPtr();
   if (!navigation_handle->IsErrorPage()) {
     // FIXME: All the Emit() calls below could potentially result in |this|
     // being destroyed (by JS listening for the event and calling
@@ -2212,6 +2213,8 @@ void WebContents::DidFinishNavigation(
     if (is_same_document) {
       Emit("did-navigate-in-page", url, is_main_frame, frame_process_id,
            frame_routing_id);
+      if (!weak_this)
+        return;
     } else {
       const net::HttpResponseHeaders* http_response =
           navigation_handle->GetResponseHeaders();
@@ -2223,8 +2226,12 @@ void WebContents::DidFinishNavigation(
       }
       Emit("did-frame-navigate", url, http_response_code, http_status_text,
            is_main_frame, frame_process_id, frame_routing_id);
+      if (!weak_this)
+        return;
       if (is_main_frame) {
         Emit("did-navigate", url, http_response_code, http_status_text);
+        if (!weak_this)
+          return;
       }
 
       content::NavigationEntry* entry = navigation_handle->GetNavigationEntry();
@@ -2238,7 +2245,7 @@ void WebContents::DidFinishNavigation(
           (entry->GetTransitionType() & ui::PAGE_TRANSITION_FORWARD_BACK))
         WebContents::TitleWasSet(entry);
     }
-    if (is_guest())
+    if (weak_this && is_guest())
       Emit("load-commit", url, is_main_frame);
   } else {
     auto url = navigation_handle->GetURL();
@@ -2247,12 +2254,17 @@ void WebContents::DidFinishNavigation(
     Emit("did-fail-provisional-load", code, description, url, is_main_frame,
          frame_process_id, frame_routing_id);
 
+    if (!weak_this)
+      return;
+
     // Do not emit "did-fail-load" for canceled requests.
     if (code != net::ERR_ABORTED) {
       util::EmitWarning(
           base::StrCat({"Failed to load URL: ", url.possibly_invalid_spec(),
                         " with error: ", description}),
           "electron");
+      if (!weak_this)
+        return;
       Emit("did-fail-load", code, description, url, is_main_frame,
            frame_process_id, frame_routing_id);
     }

--- a/spec/api-web-contents-stability-spec.ts
+++ b/spec/api-web-contents-stability-spec.ts
@@ -1,0 +1,100 @@
+import { BrowserWindow, webContents, ipcMain, WebContents } from 'electron/main';
+import { expect } from 'chai';
+import { once } from 'node:events';
+import * as path from 'node:path';
+import { setTimeout } from 'node:timers/promises';
+import { closeAllWindows } from './lib/window-helpers';
+
+describe('stability fixes', () => {
+  afterEach(closeAllWindows);
+
+  describe('printToPDF deadlock fix', () => {
+    it('does not deadlock after a failed print job', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+
+      // Trigger a guaranteed failure (invalid margins)
+      await expect(w.webContents.printToPDF({
+        margins: { top: 100, bottom: 100, left: 100, right: 100 } // Exceeds page size
+      })).to.eventually.be.rejected();
+
+      // Subsequent call should work without deadlocking
+      const promise = w.webContents.printToPDF({});
+      const result = await Promise.race([
+        promise,
+        setTimeout(5000).then(() => 'timeout')
+      ]);
+
+      expect(result).to.not.equal('timeout');
+      expect(Buffer.isBuffer(result)).to.be.true();
+    });
+
+    it('does not affect other windows after a failure', async () => {
+      const w1 = new BrowserWindow({ show: false });
+      const w2 = new BrowserWindow({ show: false });
+      await Promise.all([w1.loadURL('about:blank'), w2.loadURL('about:blank')]);
+
+      // Fail in window 1
+      await expect(w1.webContents.printToPDF({
+        margins: { top: 100, bottom: 100, left: 100, right: 100 }
+      })).to.eventually.be.rejected();
+
+      // Window 2 should still be able to print
+      const result = await w2.webContents.printToPDF({});
+      expect(Buffer.isBuffer(result)).to.be.true();
+    });
+  });
+
+  describe('C++ DidFinishNavigation re-entrancy fix', () => {
+    it('does not crash when window is destroyed during did-navigate', async () => {
+      const w = new BrowserWindow({ show: false });
+      w.webContents.on('did-navigate', () => {
+        w.destroy();
+      });
+
+      // Navigate to trigger the event and potential C++ UAF
+      await w.loadURL('data:text/html,<h1>Test</h1>');
+      
+      // If we didn't crash, the test passes
+      expect(w.isDestroyed()).to.be.true();
+    });
+
+    it('does not crash when window is destroyed during did-frame-navigate', async () => {
+      const w = new BrowserWindow({ show: false });
+      w.webContents.on('did-frame-navigate', () => {
+        w.destroy();
+      });
+
+      await w.loadURL('data:text/html,<h1>Test</h1>');
+      expect(w.isDestroyed()).to.be.true();
+    });
+  });
+
+  describe('Internal IPC listener leak fix', () => {
+    it('cleans up response listeners when WebContents is destroyed', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+
+      // ipcMainInternal is not exported but we can check it indirectly 
+      // by inspecting listeners on the internal channels if we had access.
+      // Since it's internal, we'll verify that calling executeJavaScript 
+      // doesn't leave dangling references to destroyed windows.
+      
+      const ipcMainInternal = (process as any)._linkedBinding('electron_browser_ipc').ipcMainInternal;
+      const initialListeners = ipcMainInternal.eventNames().length;
+      
+      // Start a request that will stay "pending" for a bit
+      w.webContents.executeJavaScript('new Promise(() => {})'); 
+      
+      // Destroy the window mid-request
+      w.destroy();
+      
+      // Wait a tick for cleanup
+      await setTimeout(100);
+      
+      const finalListeners = ipcMainInternal.eventNames().length;
+      // Should have cleaned up the unique channel listener
+      expect(finalListeners).to.be.lessThanOrEqual(initialListeners);
+    });
+  });
+});


### PR DESCRIPTION
#### Description of Change

This PR resolves three critical stability and resource management issues discovered during a deep-dive analysis of the Electron core:

1. **Fix PDF Printing Deadlock**: ensures the `printToPDF` promise chain is instance-isolated and "healed" upon failure, preventing a global feature lockout.
2. **Mitigate C++ Use-After-Free**: adds `base::WeakPtr` guards to `DidFinishNavigation` to safely handle synchronous object destruction during navigation event emissions.
3. **Prevent Internal IPC Listener Leak**: adds `destroyed` handlers to internal process requests (e.g., `executeJavaScript`) to ensure formal cleanup of orphaned IPC listeners.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers.

#### Release Notes

Notes: Fixed several high-impact stability bugs including printToPDF deadlocks, C++ re-entrancy risks in navigation, and internal IPC listener leaks.