### PR TITLE
fix: fix typos in C++ source comments

### DIFF
--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -642,7 +642,7 @@ void NativeWindowViews::ResetWindowControls() {
 // Windows with |backgroundMaterial| expand to the same dimensions and
 // placement as the display to approximate maximization - unless we remove
 // rounded corners there will be a gap between the window and the display
-// at the corners noticable to users.
+// at the corners noticeable to users.
 void NativeWindowViews::SetRoundedCorners(bool rounded) {
   // DWMWA_WINDOW_CORNER_PREFERENCE is supported after Windows 11 Build 22000.
   if (base::win::GetVersion() < base::win::Version::WIN11)

--- a/shell/browser/ui/file_dialog.h
+++ b/shell/browser/ui/file_dialog.h
@@ -86,7 +86,7 @@ void ShowSaveDialog(const DialogSettings& settings,
 #if BUILDFLAG(IS_LINUX)
 // Rewrite of SelectFileDialogLinuxPortal equivalent functions with primary
 // difference being that dbus_thread_linux::GetSharedSessionBus is not used
-// so that version detection can be initiated and compeleted on the dbus thread
+// so that version detection can be initiated and completed on the dbus thread
 // Refs https://github.com/electron/electron/issues/46652
 void StartPortalAvailabilityTestInBackground();
 bool IsPortalAvailable();


### PR DESCRIPTION
Fix minor typos found in comments:\n- 'noticable' → 'noticeable' in shell/browser/native_window_views_win.cc\n- 'compeleted' → 'completed' in shell/browser/ui/file_dialog.h