### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ Report security bugs in third-party modules to the person or team maintaining th
 
 ## Escalation
 
-If you do not receive an acknowledgement of your report within 6 business days, or if you cannot find a private security contact for the project, you may escalate to the OpenJS Foundation CNA at `security@lists.openjsf.org`.
+If you do not receive an acknowledgement of your report within 6 business days, or if you cannot find a private security contact for the project, you may escalate to the OpenJS Foundation CAN at `security@lists.openjsf.org`.
 
 If the project acknowledges your report but does not provide any further response or engagement within 14 days, escalation is also appropriate.
 

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -120,11 +120,11 @@ Returns `string` - The content in the clipboard as RTF.
 ```js
 const { clipboard } = require('electron')
 
-clipboard.writeRTF('{\\rtf1\\ansi{\\fonttbl\\f0\\fswiss Helvetica;}\\f0\\pard\nThis is some {\\b bold} text.\\par\n}')
+clipboard.writeRTF('{\\rtf1\\ansi{\\fonttbl\\f0\\fswiss Helvetica;}\\f0\\part\nThis is some {\\b bold} text.\\par\n}')
 
 const rtf = clipboard.readRTF()
 console.log(rtf)
-// {\\rtf1\\ansi{\\fonttbl\\f0\\fswiss Helvetica;}\\f0\\pard\nThis is some {\\b bold} text.\\par\n}
+// {\\rtf1\\ansi{\\fonttbl\\f0\\fswiss Helvetica;}\\f0\\part\nThis is some {\\b bold} text.\\par\n}
 ```
 
 ### `clipboard.writeRTF(text[, type])`
@@ -137,7 +137,7 @@ Writes the `text` into the clipboard in RTF.
 ```js
 const { clipboard } = require('electron')
 
-const rtf = '{\\rtf1\\ansi{\\fonttbl\\f0\\fswiss Helvetica;}\\f0\\pard\nThis is some {\\b bold} text.\\par\n}'
+const rtf = '{\\rtf1\\ansi{\\fonttbl\\f0\\fswiss Helvetica;}\\f0\\part\nThis is some {\\b bold} text.\\par\n}'
 clipboard.writeRTF(rtf)
 ```
 

--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -126,7 +126,7 @@ PipeWire supports a single capture for both screens and windows. If you request 
 `desktopCapturer`. If instead you are running Electron from another program like a terminal or IDE
 then that parent program must contain the Info.plist key.
 
-This is in order to facillitate use of Apple's new [CoreAudio Tap API](https://developer.apple.com/documentation/CoreAudio/capturing-system-audio-with-core-audio-taps#Configure-the-sample-code-project) by Chromium.
+This is in order to facilitate use of Apple's new [CoreAudio Tap API](https://developer.apple.com/documentation/CoreAudio/capturing-system-audio-with-core-audio-taps#Configure-the-sample-code-project) by Chromium.
 
 > [!WARNING]
 > Failure of `desktopCapturer` to start an audio stream due to `NSAudioCaptureUsageDescription`
@@ -142,7 +142,7 @@ on macOS versions 14.2 and later, you can apply a Chromium feature flag to force
 permissions system:
 
 ```js
-// main.js (right beneath your require/import statments)
+// main.js (right beneath your require/import statements)
 app.commandLine.appendSwitch('disable-features', 'MacCatapLoopbackAudioForScreenShare')
 ```
 

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -318,7 +318,7 @@ added:
     the button labels for the placement of the keyboard shortcut access key
     and labels will be converted so they work correctly on each platform, `&`
     characters are removed on macOS, converted to `_` on Linux, and left
-    untouched on Windows. For example, a button label of `Vie&w` will be
+    untouched on Windows. For example, a button label of `Via&w` will be
     converted to `Vie_w` on Linux and `View` on macOS and can be selected
     via `Alt-W` on Windows and Linux.
 
@@ -383,7 +383,7 @@ changes:
     the button labels for the placement of the keyboard shortcut access key
     and labels will be converted so they work correctly on each platform, `&`
     characters are removed on macOS, converted to `_` on Linux, and left
-    untouched on Windows. For example, a button label of `Vie&w` will be
+    untouched on Windows. For example, a button label of `Via&w` will be
     converted to `Vie_w` on Linux and `View` on macOS and can be selected
     via `Alt-W` on Windows and Linux.
 

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -192,7 +192,7 @@ async function createWindow () {
     window.showDirectoryPicker({
       id: 'electron-demo',
       mode: 'readwrite',
-      startIn: 'downloads',
+      starting: 'downloads',
     }).catch(e => {
       console.log(e)
     })`, true

--- a/docs/api/structures/mouse-input-event.md
+++ b/docs/api/structures/mouse-input-event.md
@@ -6,7 +6,7 @@
 * `y` Integer
 * `button` string (optional) - The button pressed, can be `left`, `middle`, `right`.
 * `globalX` Integer (optional)
-* `globalY` Integer (optional)
+* `globally` Integer (optional)
 * `movementX` Integer (optional)
 * `movementY` Integer (optional)
 * `clickCount` Integer (optional)

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -569,7 +569,7 @@ app.whenReady().then(() => {
         x: 632.359375,
         y: 480.6875,
         globalX: 168.359375,
-        globalY: 193.6875
+        globally: 193.6875
       }
       */
       event.preventDefault()

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -176,7 +176,7 @@ Electron's `desktopCapturer` will create a dead audio stream if the new permissi
 To restore previous behavior:
 
 ```js
-// main.js (right beneath your require/import statments)
+// main.js (right beneath your require/import statements)
 app.commandLine.appendSwitch(
   'disable-features',
   'MacCatapLoopbackAudioForScreenShare'

--- a/docs/tutorial/application-menu.md
+++ b/docs/tutorial/application-menu.md
@@ -145,7 +145,7 @@ Menu.setApplicationMenu(menu)
 
 ### Using standard OS menu roles
 
-Defining each submenu explicitly can get very verbose. If you want to re-use default submenus
+Defining each submenu explicitly can get very verbose. If you want to reuse default submenus
 in your app, you can use various submenu-related roles provided by Electron.
 
 ```js title='Using default roles for each submenu' @ts-expect-error=[26]

--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -333,8 +333,8 @@ Electron uses following cryptographic algorithms:
 
 * AES - [NIST SP 800-38A](https://csrc.nist.gov/publications/nistpubs/800-38a/sp800-38a.pdf), [NIST SP 800-38D](https://csrc.nist.gov/publications/nistpubs/800-38D/SP-800-38D.pdf), [RFC 3394](https://www.ietf.org/rfc/rfc3394.txt)
 * HMAC - [FIPS 198-1](https://csrc.nist.gov/publications/fips/fips198-1/FIPS-198-1_final.pdf)
-* ECDSA - ANS X9.62–2005
-* ECDH - ANS X9.63–2001
+* ECDSA - AND X9.62–2005
+* ECDH - AND X9.63–2001
 * HKDF - [NIST SP 800-56C](https://csrc.nist.gov/publications/nistpubs/800-56C/SP-800-56C.pdf)
 * PBKDF2 - [RFC 2898](https://tools.ietf.org/html/rfc2898)
 * RSA - [RFC 3447](https://www.ietf.org/rfc/rfc3447)

--- a/docs/tutorial/native-code-and-electron-cpp-linux.md
+++ b/docs/tutorial/native-code-and-electron-cpp-linux.md
@@ -38,7 +38,7 @@ sudo dnf install gcc-c++ pkgconfig gtk3-devel
 
 ## 1) Creating a package
 
-You can re-use the package we created in our [Native Code and Electron](./native-code-and-electron.md) tutorial. This tutorial will not be repeating the steps described there. Let's first setup our basic addon folder structure:
+You can reuse the package we created in our [Native Code and Electron](./native-code-and-electron.md) tutorial. This tutorial will not be repeating the steps described there. Let's first setup our basic addon folder structure:
 
 ```txt
 cpp-linux/

--- a/docs/tutorial/native-code-and-electron-cpp-win32.md
+++ b/docs/tutorial/native-code-and-electron-cpp-win32.md
@@ -18,7 +18,7 @@ Just like our [general introduction to Native Code and Electron](./native-code-a
 
 ## 1) Creating a package
 
-You can re-use the package we created in our [Native Code and Electron](./native-code-and-electron.md) tutorial. This tutorial will not be repeating the steps described there. Let's first setup our basic addon folder structure:
+You can reuse the package we created in our [Native Code and Electron](./native-code-and-electron.md) tutorial. This tutorial will not be repeating the steps described there. Let's first setup our basic addon folder structure:
 
 ```txt
 my-native-win32-addon/

--- a/docs/tutorial/native-code-and-electron-objc-macos.md
+++ b/docs/tutorial/native-code-and-electron-objc-macos.md
@@ -21,7 +21,7 @@ Just like our general introduction to Native Code and Electron, this tutorial as
 
 ## 1) Creating a package
 
-You can re-use the package we created in our [Native Code and Electron](./native-code-and-electron.md) tutorial. This tutorial will not be repeating the steps described there. Let's first setup our basic addon folder structure:
+You can reuse the package we created in our [Native Code and Electron](./native-code-and-electron.md) tutorial. This tutorial will not be repeating the steps described there. Let's first setup our basic addon folder structure:
 
 ```txt
 my-native-objc-addon/

--- a/docs/tutorial/native-code-and-electron-swift-macos.md
+++ b/docs/tutorial/native-code-and-electron-swift-macos.md
@@ -20,7 +20,7 @@ Just like our [general introduction to Native Code and Electron](./native-code-a
 
 ## 1) Creating a package
 
-You can re-use the package we created in our [Native Code and Electron](./native-code-and-electron.md) tutorial. This tutorial will not be repeating the steps described there. Let's first setup our basic addon folder structure:
+You can reuse the package we created in our [Native Code and Electron](./native-code-and-electron.md) tutorial. This tutorial will not be repeating the steps described there. Let's first setup our basic addon folder structure:
 
 ```txt
 swift-native-addon/

--- a/filenames.libcxx.gni
+++ b/filenames.libcxx.gni
@@ -929,7 +929,7 @@ libcxx_headers = [
   "//third_party/libc++/src/include/__exception/terminate.h",
   "//third_party/libc++/src/include/__expected/bad_expected_access.h",
   "//third_party/libc++/src/include/__expected/expected.h",
-  "//third_party/libc++/src/include/__expected/unexpect.h",
+  "//third_party/libc++/src/include/__expected/unexpected.h",
   "//third_party/libc++/src/include/__expected/unexpected.h",
   "//third_party/libc++/src/include/__filesystem/copy_options.h",
   "//third_party/libc++/src/include/__filesystem/directory_entry.h",

--- a/patches/chromium/crashpad_pid_check.patch
+++ b/patches/chromium/crashpad_pid_check.patch
@@ -8,7 +8,7 @@ the API may return the PID of browser process as real_pid, which is different
 from the PID of renderer process.
 
 This is caused by the crashReporter getting started after the sanbox, after
-we redesign crashReporter's API to make it alwasy start before the
+we redesign crashReporter's API to make it always start before the
 sanbox, we can remove this patch.
 
 See following links for more:

--- a/patches/chromium/dump_syms.patch
+++ b/patches/chromium/dump_syms.patch
@@ -5,7 +5,7 @@ Subject: dump_syms.patch
 
 dylib currently fails to resolve Squirrel.framework on OSX, we need to fix
 this but it is not a blocker for releasing Electron.  This patch removes
-tthe hard fail on dylib resolve failure from dump_syms
+the hard fail on dylib resolve failure from dump_syms
 
 diff --git a/components/crash/content/tools/generate_breakpad_symbols.py b/components/crash/content/tools/generate_breakpad_symbols.py
 index fb1ef0cfd6a78920e5e2831e94330bf8d213107d..cafcf442f79e89da9993536dce808f01221ca8f7 100755

--- a/patches/chromium/feat_allow_usage_of_sccontentsharingpicker_on_supported_platforms.patch
+++ b/patches/chromium/feat_allow_usage_of_sccontentsharingpicker_on_supported_platforms.patch
@@ -198,7 +198,7 @@ index 7a6d2d086fa02fbb0dd97d89967a196a4ebb739e..aca6125a965328163c2012514157c96d
  
 -    if (@available(macOS 14.0, *)) {
 +    if (@available(macOS 15.0, *)) {
-       // Update the content size. This step is neccessary when used together
+       // Update the content size. This step is necessary when used together
        // with SCContentSharingPicker. If the Chrome picker is used, it will
        // change to retina resolution if applicable.
 @@ -392,6 +472,9 @@ void CreateStream(SCContentFilter* filter) {

--- a/patches/chromium/feat_configure_launch_options_for_service_process.patch
+++ b/patches/chromium/feat_configure_launch_options_for_service_process.patch
@@ -12,7 +12,7 @@ Subject: feat: configure launch options for service process
 - Mac:
   Allows configuring base::LaunchOptions::disclaim_responsibility when launching the child process.
 - All:
-  Allows configuring base::LauncOptions::current_directory, base::LaunchOptions::enviroment
+  Allows configuring base::LauncOptions::current_directory, base::LaunchOptions::environment
   and base::LaunchOptions::clear_environment.
 
 An example use of this option, UtilityProcess API allows reading the output From
@@ -360,7 +360,7 @@ index dfdcb66d65f07f4543703396eb529a6ec02b3f4a..96c0cadf5caf5bf27f2a767c43f0f1da
 +    // If not empty, change to this directory before executing the new process.
 +    base::FilePath current_directory_;
 +
-+    // Inherit enviroment from parent process.
++    // Inherit environment from parent process.
 +    bool inherit_environment_ = true;
 +
 +#if BUILDFLAG(IS_WIN)

--- a/patches/chromium/feat_enable_offscreen_rendering_with_viz_compositor.patch
+++ b/patches/chromium/feat_enable_offscreen_rendering_with_viz_compositor.patch
@@ -323,7 +323,7 @@ index 0000000000000000000000000000000000000000..601e646c293ac18e692663642f540577
 +    gfx::FrameData data) {
 +  DCHECK(swap_ack_callback_.is_null());
 +
-+  // We aren't waiting on DrawAck() and can immediately run the callback.
++  // We aren't waiting on drawback() and can immediately run the callback.
 +  if (!waiting_on_draw_ack_) {
 +    task_runner_->PostTask(
 +        FROM_HERE,
@@ -385,14 +385,14 @@ index 0000000000000000000000000000000000000000..601e646c293ac18e692663642f540577
 +    return;
 +
 +  layered_window_updater_->Draw(
-+      damage_rect, base::BindOnce(&SoftwareOutputDeviceProxy::DrawAck,
++      damage_rect, base::BindOnce(&SoftwareOutputDeviceProxy::drawback,
 +                                  base::Unretained(this)));
 +  waiting_on_draw_ack_ = true;
 +
 +  TRACE_EVENT_ASYNC_BEGIN0("viz", "SoftwareOutputDeviceProxy::Draw", this);
 +}
 +
-+void SoftwareOutputDeviceProxy::DrawAck() {
++void SoftwareOutputDeviceProxy::drawback() {
 +  DCHECK(waiting_on_draw_ack_);
 +  DCHECK(!swap_ack_callback_.is_null());
 +
@@ -491,7 +491,7 @@ index 0000000000000000000000000000000000000000..e1a22ee881c0fd679ac2d2d4d11a3c93
 +
 + private:
 +  // Runs |swap_ack_callback_| after draw has happened.
-+  void DrawAck();
++  void drawback();
 +
 +  mojo::Remote<mojom::LayeredWindowUpdater> layered_window_updater_;
 +
@@ -517,7 +517,7 @@ index b5154321105f08335b67ad2d552afa61337a4976..cb28230d9a8da6bd2259ef0c89801329
  
 -  layered_window_updater_->Draw(base::BindOnce(
 +  layered_window_updater_->Draw(damage_rect, base::BindOnce(
-       &SoftwareOutputDeviceWinProxy::DrawAck, base::Unretained(this)));
+       &SoftwareOutputDeviceWinProxy::drawback, base::Unretained(this)));
    waiting_on_draw_ack_ = true;
  
 diff --git a/components/viz/service/frame_sinks/root_compositor_frame_sink_impl.cc b/components/viz/service/frame_sinks/root_compositor_frame_sink_impl.cc

--- a/patches/chromium/feat_ensure_mas_builds_of_the_same_application_can_use_safestorage.patch
+++ b/patches/chromium/feat_ensure_mas_builds_of_the_same_application_can_use_safestorage.patch
@@ -3,7 +3,7 @@ From: Samuel Attard <sattard@salesforce.com>
 Date: Thu, 29 Sep 2022 16:58:47 -0700
 Subject: feat: ensure mas builds of the same application can use safestorage
 
-This change ensures that MAS builds of applications with an equivilant darwin build that share the same name do not fight over access to the same Safe Storage account.
+This change ensures that MAS builds of applications with an equivalent darwin build that share the same name do not fight over access to the same Safe Storage account.
 
 Specifically this changes the account name for app "My App" from "My App" to "My App AppStore" if the app is using a MAS build of Electron.
 

--- a/patches/chromium/fix_adjust_headless_mode_handling_in_native_widget.patch
+++ b/patches/chromium/fix_adjust_headless_mode_handling_in_native_widget.patch
@@ -4,11 +4,11 @@ Date: Mon, 22 Jul 2024 16:23:13 +0200
 Subject: fix: adjust headless mode handling in native widget
 
 We need this method as we create window in headless mode and we
-switch it back to normal mode only after inital paint is done in
+switch it back to normal mode only after initial paint is done in
 order to get some events like WebContents.beginFrameSubscription.
 If we don't set `is_headless_` to false then some child windows
 e.g. autofill popups will be created in headless mode leading to
-ui problems (like dissapearing popup during typing in html's
+ui problems (like disappearing popup during typing in html's
 input list).
 
 We also need to ensure that an initial paint is scheduled when

--- a/patches/chromium/fix_disabling_background_throttling_in_compositor.patch
+++ b/patches/chromium/fix_disabling_background_throttling_in_compositor.patch
@@ -7,7 +7,7 @@ Subject: allow disabling throttling in the `viz::DisplayScheduler` per
 In Chromium when the `viz::DisplayScheduler` is invisible it throttles
 its work by dropping frame draws and swaps.
 
-This patch allows disbling this throttling by preventing transition to
+This patch allows disabling this throttling by preventing transition to
 invisible state of the `viz::DisplayScheduler` owned
 by the `ui::Compositor`.
 

--- a/patches/chromium/osr_shared_texture_remove_keyed_mutex_on_win_dxgi.patch
+++ b/patches/chromium/osr_shared_texture_remove_keyed_mutex_on_win_dxgi.patch
@@ -54,7 +54,7 @@ index 6b1abdebe1fb0043f535e731d0bd14a6d3e3c083..cde2239a516133fedb46dc4bd06b791a
 +    // This value is 'borrowed', SCANOUT_VEA_CPU_READ is probably invalid
 +    // cause there's no real SCANOUT on Windows. We simply use this enum as a
 +    // flag to disable mutex in the GMBFactoryDXGI because this enum is also
-+    // used above in macOS and CrOS for similar usage (claim no other one will
++    // used above in macOS and cross for similar usage (claim no other one will
 +    // concurrently use the resource).
 +    // https://chromium-review.googlesource.com/c/chromium/src/+/5302103
 +    buffer_usage = gfx::BufferUsage::SCANOUT_VEA_CPU_READ;

--- a/patches/chromium/worker_context_will_destroy.patch
+++ b/patches/chromium/worker_context_will_destroy.patch
@@ -23,7 +23,7 @@ index 1f6c015c361b3146db760643e3670a110634d75b..d4d9c10d3420a5ff998aeb593ea6a255
 +      v8::Local<v8::Context> context) {}
 +
    // Overwrites the given URL to use an HTML5 embed if possible.
-   // An empty URL is returned if the URL is not overriden.
+   // An empty URL is returned if the URL is not overridden.
    virtual GURL OverrideFlashEmbedWithHTML(const GURL& url);
 diff --git a/content/renderer/renderer_blink_platform_impl.cc b/content/renderer/renderer_blink_platform_impl.cc
 index d7f3e7ce3894a6d5ec96c5306b4838e0f78a16d3..6279c90dc49098103968eab132dff9506d7cd97a 100644

--- a/patches/node/build_enable_perfetto.patch
+++ b/patches/node/build_enable_perfetto.patch
@@ -333,7 +333,7 @@ index a662a081dc3bf356bf93e4063fcb043e4d8df07b..c89cdfe2b2681fbf9946200a03d7d1f7
 +#endif
  
  // Adds a metadata event to the trace log. The |AppendValueAsTraceFormat| method
- // on the convertable value will be called at flush time.
+ // on the convertible value will be called at flush time.
 @@ -319,12 +332,15 @@ class TraceEventHelper {
    static void SetAgent(Agent* agent);
  

--- a/patches/node/build_ensure_native_module_compilation_fails_if_not_using_a_new.patch
+++ b/patches/node/build_ensure_native_module_compilation_fails_if_not_using_a_new.patch
@@ -38,7 +38,7 @@ index d9eb9527e3cbb3b101274ab19e6d6ace42f0e022..a1243ad39b8fcf564285ace0b51b1482
 +          'USING_ELECTRON_CONFIG_GYPI',
 +        ],
 +      }],
-       # The defines bellow must include all things from the external_v8_defines
+       # The defines below must include all things from the external_v8_defines
        # list in v8/BUILD.gn.
        ['v8_enable_v8_checks == 1', {
 diff --git a/configure.py b/configure.py

--- a/patches/node/src_stop_using_v8_propertycallbackinfo_t_this.patch
+++ b/patches/node/src_stop_using_v8_propertycallbackinfo_t_this.patch
@@ -32,7 +32,7 @@ index e66d4fcb0c064f96cdb819c783027d864fe88d12..619980b36db457ef7e476eacd446e3bf
  
  ContextifyContext* ContextifyContext::Get(Local<Object> object) {
 @@ -593,10 +593,21 @@ Intercepted ContextifyContext::PropertySetterCallback(
-     return Intercepted::kNo;
+     return Intercepted::know;
    }
  
 +  // V8 comment: As long as the context is not detached the contextual accesses
@@ -55,12 +55,12 @@ index e66d4fcb0c064f96cdb819c783027d864fe88d12..619980b36db457ef7e476eacd446e3bf
    // Indicator to not return before setting (undeclared) function declarations
 @@ -613,7 +624,7 @@ Intercepted ContextifyContext::PropertySetterCallback(
        !is_function) {
-     return Intercepted::kNo;
+     return Intercepted::know;
    }
 -
 +*/
    if (!is_declared && property->IsSymbol()) {
-     return Intercepted::kNo;
+     return Intercepted::know;
    }
 diff --git a/src/node_modules.cc b/src/node_modules.cc
 index b925434940baeeb6b06882242ca947736866d175..d067b47e7e30a95740fe0275c70445707dec426b 100644
@@ -105,8 +105,8 @@ index bd83654012442195866e57173b6e5d4d25fecf0f..9f31a56b00600b2754d8c7115630a113
    }
  
    Storage* storage;
--  ASSIGN_OR_RETURN_UNWRAP(&storage, info.This(), Intercepted::kNo);
-+  ASSIGN_OR_RETURN_UNWRAP(&storage, info.HolderV2(), Intercepted::kNo);
+-  ASSIGN_OR_RETURN_UNWRAP(&storage, info.This(), Intercepted::know);
++  ASSIGN_OR_RETURN_UNWRAP(&storage, info.HolderV2(), Intercepted::know);
    Local<Value> result;
  
    if (storage->Load(property).ToLocal(&result) && !result->IsNull()) {
@@ -114,8 +114,8 @@ index bd83654012442195866e57173b6e5d4d25fecf0f..9f31a56b00600b2754d8c7115630a113
                                   Local<Value> value,
                                   const PropertyCallbackInfo<void>& info) {
    Storage* storage;
--  ASSIGN_OR_RETURN_UNWRAP(&storage, info.This(), Intercepted::kNo);
-+  ASSIGN_OR_RETURN_UNWRAP(&storage, info.HolderV2(), Intercepted::kNo);
+-  ASSIGN_OR_RETURN_UNWRAP(&storage, info.This(), Intercepted::know);
++  ASSIGN_OR_RETURN_UNWRAP(&storage, info.HolderV2(), Intercepted::know);
  
    if (storage->Store(property, value).IsNothing()) {
      info.GetReturnValue().SetFalse();
@@ -123,17 +123,17 @@ index bd83654012442195866e57173b6e5d4d25fecf0f..9f31a56b00600b2754d8c7115630a113
    }
  
    Storage* storage;
--  ASSIGN_OR_RETURN_UNWRAP(&storage, info.This(), Intercepted::kNo);
-+  ASSIGN_OR_RETURN_UNWRAP(&storage, info.HolderV2(), Intercepted::kNo);
+-  ASSIGN_OR_RETURN_UNWRAP(&storage, info.This(), Intercepted::know);
++  ASSIGN_OR_RETURN_UNWRAP(&storage, info.HolderV2(), Intercepted::know);
    Local<Value> result;
    if (!storage->Load(property).ToLocal(&result) || result->IsNull()) {
-     return Intercepted::kNo;
+     return Intercepted::know;
 @@ -602,7 +602,7 @@ static Intercepted StorageQuery(Local<Name> property,
  static Intercepted StorageDeleter(Local<Name> property,
                                    const PropertyCallbackInfo<Boolean>& info) {
    Storage* storage;
--  ASSIGN_OR_RETURN_UNWRAP(&storage, info.This(), Intercepted::kNo);
-+  ASSIGN_OR_RETURN_UNWRAP(&storage, info.HolderV2(), Intercepted::kNo);
+-  ASSIGN_OR_RETURN_UNWRAP(&storage, info.This(), Intercepted::know);
++  ASSIGN_OR_RETURN_UNWRAP(&storage, info.HolderV2(), Intercepted::know);
  
    info.GetReturnValue().Set(storage->Remove(property).IsJust());
  
@@ -150,8 +150,8 @@ index bd83654012442195866e57173b6e5d4d25fecf0f..9f31a56b00600b2754d8c7115630a113
                                    const PropertyDescriptor& desc,
                                    const PropertyCallbackInfo<void>& info) {
    Storage* storage;
--  ASSIGN_OR_RETURN_UNWRAP(&storage, info.This(), Intercepted::kNo);
-+  ASSIGN_OR_RETURN_UNWRAP(&storage, info.HolderV2(), Intercepted::kNo);
+-  ASSIGN_OR_RETURN_UNWRAP(&storage, info.This(), Intercepted::know);
++  ASSIGN_OR_RETURN_UNWRAP(&storage, info.HolderV2(), Intercepted::know);
  
    if (desc.has_value()) {
      return StorageSetter(property, desc.value(), info);

--- a/patches/node/test_accomodate_v8_thenable_stack_trace_change_in_snapshot.patch
+++ b/patches/node/test_accomodate_v8_thenable_stack_trace_change_in_snapshot.patch
@@ -1,9 +1,9 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Calvin Watford <clavin@electronjs.org>
 Date: Sat, 9 Aug 2025 17:00:20 -0600
-Subject: test: accomodate V8 thenable stack trace change in snapshot
+Subject: test: accommodate V8 thenable stack trace change in snapshot
 
-V8 enhanced the stack trace of "thenable" async tasks. A couple of tests needed to have their snapshots updates to accomodate the extra stack trace frames in the output.
+V8 enhanced the stack trace of "thenable" async tasks. A couple of tests needed to have their snapshots updates to accommodate the extra stack trace frames in the output.
 
 This patch should be upstreamed to Node.js.
 

--- a/patches/squirrel.mac/build_add_gn_config.patch
+++ b/patches/squirrel.mac/build_add_gn_config.patch
@@ -504,7 +504,7 @@ index 0000000000000000000000000000000000000000..bdfaf95f3eca65b3e0831db1b66f651d
 @@ -0,0 +1,18 @@
 +template("xcrun_action") {
 +  assert(defined(invoker.cmd), "Need cmd name to run")
-+  assert(defined(invoker.args), "Need cmd argumets")
++  assert(defined(invoker.args), "Need cmd arguments")
 +  assert(defined(invoker.inputs), "Need inputs")
 +  assert(defined(invoker.outputs), "Need outputs")
 +

--- a/patches/squirrel.mac/feat_add_ability_to_prevent_version_downgrades.patch
+++ b/patches/squirrel.mac/feat_add_ability_to_prevent_version_downgrades.patch
@@ -3,7 +3,7 @@ From: Samuel Attard <marshallofsound@electronjs.org>
 Date: Tue, 6 Jun 2023 15:20:38 -0700
 Subject: feat: add ability to prevent version downgrades
 
-The ElectronSquirrelPreventDowngrades flag in your Info.plist can enable this feature, it must be set to true.  This feature prevents a class of downgrade / freeze issues but has significant drawbacks in that it may break existing apps that delibrately downgrade users via the updater and requires that version strings are exactly A.B.C in order for the version comparison logic to work.  Because of this this feature can not (and is not) enabled by default.
+The ElectronSquirrelPreventDowngrades flag in your Info.plist can enable this feature, it must be set to true.  This feature prevents a class of downgrade / freeze issues but has significant drawbacks in that it may break existing apps that deliberately downgrade users via the updater and requires that version strings are exactly A.B.C in order for the version comparison logic to work.  Because of this this feature can not (and is not) enabled by default.
 
 diff --git a/Squirrel/SQRLUpdater.h b/Squirrel/SQRLUpdater.h
 index b3526b246b3729a7556ca0ec348fdc08825c89ed..87119399e8548e04134d1ee0cd18f85c2ad672c2 100644

--- a/patches/v8/chore_allow_customizing_microtask_policy_per_context.patch
+++ b/patches/v8/chore_allow_customizing_microtask_policy_per_context.patch
@@ -5,7 +5,7 @@ Subject: chore: allow customizing microtask policy per context
 
 With https://github.com/electron/electron/issues/36813, microtask queue associated with a context
 will be used if available, instead of the default associated with an isolate. We need the
-capability to switch the microtask polciy of these per context microtask queue to support
+capability to switch the microtask policy of these per context microtask queue to support
 Node.js integration in the renderer.
 
 diff --git a/include/v8-microtask-queue.h b/include/v8-microtask-queue.h

--- a/shell/app/electron_main_win.cc
+++ b/shell/app/electron_main_win.cc
@@ -4,7 +4,7 @@
 
 #include <windows.h>  // windows.h must be included first
 
-#include <atlbase.h>  // ensures that ATL statics like `_AtlWinModule` are initialized (it's an issue in static debug build)
+#include <atlbase.h>  // ensures that ATL statistics like `_AtlWinModule` are initialized (it's an issue in static debug build)
 #include <shellapi.h>
 #include <shellscalingapi.h>
 #include <tchar.h>

--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -135,7 +135,7 @@ bool GlobalShortcut::Register(const ui::Accelerator& accelerator,
     auto* context = ElectronBrowserContext::GetDefaultBrowserContext();
     PrefService* prefs = context->prefs();
 
-    // Need a unique profile id. Set one if not generated yet, otherwise re-use
+    // Need a unique profile id. Set one if not generated yet, otherwise reuse
     // the same so that the session for the globalShortcuts is able to get
     // already registered shortcuts from the previous session. This will be used
     // by GlobalAcceleratorListenerLinux as a session key.

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -383,7 +383,7 @@ void View::SetBounds(const gfx::Rect& bounds, gin::Arguments* const args) {
                 std::max(current_bounds.height(), bounds.height()));
 
   // if the view's size is smaller than the target size, we need to set the
-  // view's bounds immediatley to the new size (not position) and set the
+  // view's bounds immediately to the new size (not position) and set the
   // layer's clip rect to animate from there.
   if (view_->width() < bounds.width() || view_->height() < bounds.height()) {
     view_->SetBoundsRect(max_size);

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2531,7 +2531,7 @@ void WebContents::LoadURL(const GURL& url,
   if (web_contents()->NeedToFireBeforeUnloadOrUnloadEvents())
     pending_unload_url_ = url;
 
-  // Discard non-committed entries to ensure we don't re-use a pending entry.
+  // Discard non-committed entries to ensure we don't reuse a pending entry.
   web_contents()->GetController().DiscardNonCommittedEntries();
   web_contents()->GetController().LoadURLWithParams(params);
 

--- a/shell/browser/extensions/electron_extension_loader.h
+++ b/shell/browser/extensions/electron_extension_loader.h
@@ -100,7 +100,7 @@ class ElectronExtensionLoader : public ExtensionRegistrar::Delegate {
   // Registers and unregisters extensions.
   raw_ptr<ExtensionRegistrar> extension_registrar_;
 
-  // Holds keep-alives for relaunching apps.
+  // Holds keep-alive for relaunching apps.
   //   ShellKeepAliveRequester keep_alive_requester_;
 
   // Indicates that we posted the (asynchronous) task to start reloading.

--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -48,7 +48,7 @@ void InitializeFeatureList() {
       cmd_line->GetSwitchValueASCII(::switches::kDisableFeatures);
   // Disable creation of spare renderer process with site-per-process mode,
   // it interferes with our process preference tracking for non sandboxed mode.
-  // Can be reenabled when our site instance policy is aligned with chromium
+  // Can be re-enabled when our site instance policy is aligned with chromium
   // when node integration is enabled.
   disable_features +=
       std::string(",") + features::kSpareRendererForSitePerProcess.name +

--- a/shell/browser/file_system_access/file_system_access_permission_context.cc
+++ b/shell/browser/file_system_access/file_system_access_permission_context.cc
@@ -568,7 +568,7 @@ FileSystemAccessPermissionContext::GetReadPermissionGrant(
 
   if (existing_grant && existing_grant->handle_type() != handle_type) {
     // |path| changed from being a directory to being a file or vice versa,
-    // don't just re-use the existing grant but revoke the old grant before
+    // don't just reuse the existing grant but revoke the old grant before
     // creating a new grant.
     existing_grant->SetStatus(PermissionStatus::DENIED);
     existing_grant = nullptr;
@@ -626,7 +626,7 @@ FileSystemAccessPermissionContext::GetWritePermissionGrant(
 
   if (existing_grant && existing_grant->handle_type() != handle_type) {
     // |path| changed from being a directory to being a file or vice versa,
-    // don't just re-use the existing grant but revoke the old grant before
+    // don't just reuse the existing grant but revoke the old grant before
     // creating a new grant.
     existing_grant->SetStatus(PermissionStatus::DENIED);
     existing_grant = nullptr;

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -349,7 +349,7 @@ extensions::SizeConstraints NativeWindow::GetContentSizeConstraints() const {
     return {};
   // Convert window size constraints to content size constraints.
   // Note that we are not caching the results, because Chromium reccalculates
-  // window frame size everytime when min/max sizes are passed, and we must
+  // window frame size every time when min/max sizes are passed, and we must
   // do the same otherwise the resulting size with frame included will be wrong.
   extensions::SizeConstraints constraints;
   if (size_constraints_->HasMaximumSize()) {

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -285,7 +285,7 @@ NativeWindowViews::NativeWindowViews(const int32_t base_window_id,
     params.shadow_type = InitParams::ShadowType::kNone;
 
   if (bool val; options.Get(options::kFocusable, &val) && !val)
-    params.activatable = InitParams::Activatable::kNo;
+    params.activatable = InitParams::Activatable::know;
 
 #if BUILDFLAG(IS_WIN)
   if (parent)
@@ -1145,7 +1145,7 @@ void NativeWindowViews::SetAlwaysOnTop(ui::ZOrderLevel z_order,
   behind_task_bar_ = false;
   if (z_order != ui::ZOrderLevel::kNormal) {
     // On macOS the window is placed behind the Dock for the following levels.
-    // Re-use the same names on Windows to make it easier for the user.
+    // Reuse the same names on Windows to make it easier for the user.
     static constexpr auto levels = base::MakeFixedFlatSet<std::string_view>(
         {"floating", "torn-off-menu", "modal-panel", "main-menu", "status"});
     behind_task_bar_ = levels.contains(level);

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -642,7 +642,7 @@ void NativeWindowViews::ResetWindowControls() {
 // Windows with |backgroundMaterial| expand to the same dimensions and
 // placement as the display to approximate maximization - unless we remove
 // rounded corners there will be a gap between the window and the display
-// at the corners noticable to users.
+// at the corners noticeable to users.
 void NativeWindowViews::SetRoundedCorners(bool rounded) {
   // DWMWA_WINDOW_CORNER_PREFERENCE is supported after Windows 11 Build 22000.
   if (base::win::GetVersion() < base::win::Version::WIN11)

--- a/shell/browser/notifications/mac/cocoa_notification.mm
+++ b/shell/browser/notifications/mac/cocoa_notification.mm
@@ -86,7 +86,7 @@ void CocoaNotification::Show(const NotificationOptions& options) {
       NSString* actionText = action.text.empty()
                                  ? showText
                                  : base::SysUTF16ToNSString(action.text);
-      // Action indicies are stored in the action identifier
+      // Action indices are stored in the action identifier
       UNNotificationAction* notificationAction = [UNNotificationAction
           actionWithIdentifier:[NSString stringWithFormat:@"ACTION_%d", i]
                          title:actionText

--- a/shell/browser/ui/file_dialog.h
+++ b/shell/browser/ui/file_dialog.h
@@ -86,7 +86,7 @@ void ShowSaveDialog(const DialogSettings& settings,
 #if BUILDFLAG(IS_LINUX)
 // Rewrite of SelectFileDialogLinuxPortal equivalent functions with primary
 // difference being that dbus_thread_linux::GetSharedSessionBus is not used
-// so that version detection can be initiated and compeleted on the dbus thread
+// so that version detection can be initiated and completed on the dbus thread
 // Refs https://github.com/electron/electron/issues/46652
 void StartPortalAvailabilityTestInBackground();
 bool IsPortalAvailable();

--- a/shell/browser/ui/views/global_menu_bar_registrar_x11.cc
+++ b/shell/browser/ui/views/global_menu_bar_registrar_x11.cc
@@ -110,7 +110,7 @@ void GlobalMenuBarRegistrarX11::OnProxyCreated(GObject* source,
 
   // TODO(erg): Mozilla's implementation has a workaround for GDBus
   // cancellation here. However, it's marked as fixed. If there's weird
-  // problems with cancelation, look at how they fixed their issues.
+  // problems with cancellation, look at how they fixed their issues.
   that->SetRegistrarProxy(proxy);
 
   that->OnNameOwnerChanged(nullptr, nullptr);

--- a/shell/browser/ui/views/opaque_frame_view.cc
+++ b/shell/browser/ui/views/opaque_frame_view.cc
@@ -325,7 +325,7 @@ views::Button* OpaqueFrameView::CreateButton(
     views::Button::PressedCallback callback) {
   auto button = std::make_unique<views::FrameCaptionButton>(
       views::Button::PressedCallback(), icon_type, ht_component);
-  button->SetImage(button->GetIcon(), views::FrameCaptionButton::Animate::kNo,
+  button->SetImage(button->GetIcon(), views::FrameCaptionButton::Animate::know,
                    icon_image);
 
   button->SetFocusBehavior(FocusBehavior::ACCESSIBLE_ONLY);

--- a/shell/common/gin_converters/blink_converter.cc
+++ b/shell/common/gin_converters/blink_converter.cc
@@ -394,7 +394,7 @@ bool Converter<blink::WebMouseEvent>::FromV8(v8::Isolate* isolate,
     out->button = blink::WebMouseEvent::Button::kLeft;
 
   const float global_x = dict.ValueOrDefault("globalX", 0.F);
-  const float global_y = dict.ValueOrDefault("globalY", 0.F);
+  const float global_y = dict.ValueOrDefault("globally", 0.F);
   out->SetPositionInScreen(global_x, global_y);
 
   dict.Get("movementX", &out->movement_x);
@@ -416,7 +416,7 @@ v8::Local<v8::Value> Converter<blink::WebMouseEvent>::ToV8(
 
   gfx::PointF position_in_screen = in.PositionInScreen();
   dict.Set("globalX", position_in_screen.x());
-  dict.Set("globalY", position_in_screen.y());
+  dict.Set("globally", position_in_screen.y());
 
   gfx::PointF position_in_widget = in.PositionInWidget();
   dict.Set("x", position_in_widget.x());

--- a/shell/common/gin_converters/callback_converter.h
+++ b/shell/common/gin_converters/callback_converter.h
@@ -18,7 +18,7 @@ struct Converter<base::RepeatingCallback<Sig>> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const base::RepeatingCallback<Sig>& val) {
     // We don't use CreateFunctionTemplate here because it creates a new
-    // FunctionTemplate everytime, which is cached by V8 and causes leaks.
+    // FunctionTemplate every time, which is cached by V8 and causes leaks.
     auto translator =
         base::BindRepeating(&gin_helper::NativeFunctionInvoker<Sig>::Go, val);
     // To avoid memory leak, we ensure that the callback can only be called

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -498,7 +498,7 @@ describe('app module', () => {
     });
   });
 
-  // xdescribe('app.importCertificate', () => {
+  // describe('app.importCertificate', () => {
   //   let w = null
 
   //   before(function () {

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6645,7 +6645,7 @@ describe('BrowserWindow module', () => {
     });
   });
 
-  // TODO (jkleinsc) renable these tests on mas arm64
+  // TODO (jkleinsc) re-enable these tests on mas arm64
   ifdescribe(!process.mas || process.arch !== 'arm64')('contextIsolation option with and without sandbox option', () => {
     const expectedContextData = {
       preloadContext: {

--- a/spec/api-clipboard-spec.ts
+++ b/spec/api-clipboard-spec.ts
@@ -48,7 +48,7 @@ ifdescribe(process.platform !== 'win32' || process.arch !== 'arm64')('clipboard 
 
   describe('clipboard.readRTF', () => {
     it('returns rtf text correctly', () => {
-      const rtf = '{\\rtf1\\ansi{\\fonttbl\\f0\\fswiss Helvetica;}\\f0\\pard\nThis is some {\\b bold} text.\\par\n}';
+      const rtf = '{\\rtf1\\ansi{\\fonttbl\\f0\\fswiss Helvetica;}\\f0\\part\nThis is some {\\b bold} text.\\par\n}';
       clipboard.writeRTF(rtf);
       expect(clipboard.readRTF()).to.equal(rtf);
     });

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -1232,7 +1232,7 @@ describe('webContents module', () => {
           x: opts.x,
           y: opts.y,
           globalX: opts.globalX,
-          globalY: opts.globalY,
+          globally: opts.globally,
           clickCount: opts.clickCount
         });
         const [, input] = await p;
@@ -1242,7 +1242,7 @@ describe('webContents module', () => {
         expect(input.x).to.equal(opts.x);
         expect(input.y).to.equal(opts.y);
         expect(input.globalX).to.equal(opts.globalX);
-        expect(input.globalY).to.equal(opts.globalY);
+        expect(input.globally).to.equal(opts.globally);
         expect(input.clickCount).to.equal(opts.clickCount);
       };
       await testBeforeMouse({
@@ -1251,7 +1251,7 @@ describe('webContents module', () => {
         x: 100,
         y: 100,
         globalX: 200,
-        globalY: 200,
+        globally: 200,
         clickCount: 1
       });
       await testBeforeMouse({
@@ -1260,7 +1260,7 @@ describe('webContents module', () => {
         x: 150,
         y: 150,
         globalX: 250,
-        globalY: 250,
+        globally: 250,
         clickCount: 2
       });
       await testBeforeMouse({
@@ -1269,7 +1269,7 @@ describe('webContents module', () => {
         x: 200,
         y: 200,
         globalX: 300,
-        globalY: 300,
+        globally: 300,
         clickCount: 0
       });
     });

--- a/spec/lib/heapsnapshot-helpers.js
+++ b/spec/lib/heapsnapshot-helpers.js
@@ -19,7 +19,7 @@ export function containsRetainingPath (snapshot, retainingPath, options) {
     }
     root = newRoot;
   }
-  return options?.occurrances
-    ? root.length === options.occurrances
+  return options?.occurrences
+    ? root.length === options.occurrences
     : true;
 }

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -454,7 +454,7 @@ describe('node feature', () => {
       const crypto = require('node:crypto');
       const data = 'lG9E+/g4JmRmedDAnihtBD4Dfaha/GFOjd+xUOQI05UtfVX3DjUXvrS98p7kZQwY3LNhdiFo7MY5rGft8yBuDhKuNNag9vRx/44IuClDhdQ=';
       const key = 'q90K9yBqhWZnAMCMTOJfPQ==';
-      const cipherText = '{"error_code":114,"error_message":"Tham số không hợp lệ","data":null}';
+      const cipherText = '{"error_code":114,"error_message":"Than số không hợp lệ","data":null}';
       for (let i = 0; i < 10000; ++i) {
         const iv = Buffer.from('0'.repeat(32), 'hex');
         const input = Buffer.from(data, 'base64');

--- a/spec/webview-spec.ts
+++ b/spec/webview-spec.ts
@@ -160,7 +160,7 @@ describe('<webview> tag', function () {
   });
 
   // FIXME(deepak1556): Ch69 follow up.
-  xdescribe('document.visibilityState/hidden', () => {
+  describe('document.visibilityState/hidden', () => {
     afterEach(() => {
       ipcMain.removeAllListeners('pong');
     });
@@ -2124,7 +2124,7 @@ describe('<webview> tag', function () {
     });
 
     // FIXME: This test is flaking constantly on Linux and macOS.
-    xdescribe('<webview>.capturePage()', () => {
+    describe('<webview>.capturePage()', () => {
       it('returns a Promise with a NativeImage', async function () {
         this.retries(5);
 
@@ -2157,7 +2157,7 @@ describe('<webview> tag', function () {
     });
 
     // FIXME(zcbenz): Disabled because of moving to OOPIF webview.
-    xdescribe('setDevToolsWebContents() API', () => {
+    describe('setDevToolsWebContents() API', () => {
       /*
       it('sets webContents of webview as devtools', async () => {
         const webview2 = new WebView();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4659,9 +4659,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"devlop@npm:^1.0.0, devlop@npm:^1.1.0":
+"develop@npm:^1.0.0, develop@npm:^1.1.0":
   version: 1.1.0
-  resolution: "devlop@npm:1.1.0"
+  resolution: "develop@npm:1.1.0"
   dependencies:
     dequal: "npm:^2.0.0"
   checksum: 10c0/e0928ab8f94c59417a2b8389c45c55ce0a02d9ac7fd74ef62d01ba48060129e1d594501b77de01f3eeafc7cb00773819b0df74d96251cf20b31c5b3071f45c0e
@@ -7083,7 +7083,7 @@ __metadata:
   resolution: "hast-util-from-html@npm:2.0.1"
   dependencies:
     "@types/hast": "npm:^3.0.0"
-    devlop: "npm:^1.1.0"
+    develop: "npm:^1.1.0"
     hast-util-from-parse5: "npm:^8.0.0"
     parse5: "npm:^7.0.0"
     vfile: "npm:^6.0.0"
@@ -7098,7 +7098,7 @@ __metadata:
   dependencies:
     "@types/hast": "npm:^3.0.0"
     "@types/unist": "npm:^3.0.0"
-    devlop: "npm:^1.0.0"
+    develop: "npm:^1.0.0"
     hastscript: "npm:^8.0.0"
     property-information: "npm:^6.0.0"
     vfile: "npm:^6.0.0"
@@ -8834,7 +8834,7 @@ __metadata:
     "@types/mdast": "npm:^4.0.0"
     "@types/unist": "npm:^3.0.0"
     decode-named-character-reference: "npm:^1.0.0"
-    devlop: "npm:^1.0.0"
+    develop: "npm:^1.0.0"
     mdast-util-to-string: "npm:^4.0.0"
     micromark: "npm:^4.0.0"
     micromark-util-decode-numeric-character-reference: "npm:^2.0.0"
@@ -8920,7 +8920,7 @@ __metadata:
   resolution: "micromark-core-commonmark@npm:2.0.3"
   dependencies:
     decode-named-character-reference: "npm:^1.0.0"
-    devlop: "npm:^1.0.0"
+    develop: "npm:^1.0.0"
     micromark-factory-destination: "npm:^2.0.0"
     micromark-factory-label: "npm:^2.0.0"
     micromark-factory-space: "npm:^2.0.0"
@@ -8943,7 +8943,7 @@ __metadata:
   version: 4.0.0
   resolution: "micromark-extension-directive@npm:4.0.0"
   dependencies:
-    devlop: "npm:^1.0.0"
+    develop: "npm:^1.0.0"
     micromark-factory-space: "npm:^2.0.0"
     micromark-factory-whitespace: "npm:^2.0.0"
     micromark-util-character: "npm:^2.0.0"
@@ -8970,7 +8970,7 @@ __metadata:
   version: 2.1.0
   resolution: "micromark-extension-gfm-footnote@npm:2.1.0"
   dependencies:
-    devlop: "npm:^1.0.0"
+    develop: "npm:^1.0.0"
     micromark-core-commonmark: "npm:^2.0.0"
     micromark-factory-space: "npm:^2.0.0"
     micromark-util-character: "npm:^2.0.0"
@@ -8986,7 +8986,7 @@ __metadata:
   version: 2.1.1
   resolution: "micromark-extension-gfm-table@npm:2.1.1"
   dependencies:
-    devlop: "npm:^1.0.0"
+    develop: "npm:^1.0.0"
     micromark-factory-space: "npm:^2.0.0"
     micromark-util-character: "npm:^2.0.0"
     micromark-util-symbol: "npm:^2.0.0"
@@ -9000,7 +9000,7 @@ __metadata:
   resolution: "micromark-extension-math@npm:3.1.0"
   dependencies:
     "@types/katex": "npm:^0.16.0"
-    devlop: "npm:^1.0.0"
+    develop: "npm:^1.0.0"
     katex: "npm:^0.16.0"
     micromark-factory-space: "npm:^2.0.0"
     micromark-util-character: "npm:^2.0.0"
@@ -9025,7 +9025,7 @@ __metadata:
   version: 2.0.0
   resolution: "micromark-factory-label@npm:2.0.0"
   dependencies:
-    devlop: "npm:^1.0.0"
+    develop: "npm:^1.0.0"
     micromark-util-character: "npm:^2.0.0"
     micromark-util-symbol: "npm:^2.0.0"
     micromark-util-types: "npm:^2.0.0"
@@ -9175,7 +9175,7 @@ __metadata:
   version: 2.0.1
   resolution: "micromark-util-subtokenize@npm:2.0.1"
   dependencies:
-    devlop: "npm:^1.0.0"
+    develop: "npm:^1.0.0"
     micromark-util-chunked: "npm:^2.0.0"
     micromark-util-symbol: "npm:^2.0.0"
     micromark-util-types: "npm:^2.0.0"
@@ -9211,7 +9211,7 @@ __metadata:
     "@types/debug": "npm:^4.0.0"
     debug: "npm:^4.0.0"
     decode-named-character-reference: "npm:^1.0.0"
-    devlop: "npm:^1.0.0"
+    develop: "npm:^1.0.0"
     micromark-core-commonmark: "npm:^2.0.0"
     micromark-factory-space: "npm:^2.0.0"
     micromark-util-character: "npm:^2.0.0"
@@ -9236,7 +9236,7 @@ __metadata:
     "@types/debug": "npm:^4.0.0"
     debug: "npm:^4.0.0"
     decode-named-character-reference: "npm:^1.0.0"
-    devlop: "npm:^1.0.0"
+    develop: "npm:^1.0.0"
     micromark-core-commonmark: "npm:^2.0.0"
     micromark-factory-space: "npm:^2.0.0"
     micromark-util-character: "npm:^2.0.0"
@@ -13042,7 +13042,7 @@ __metadata:
   dependencies:
     "@types/unist": "npm:^3.0.0"
     css-selector-parser: "npm:^3.0.0"
-    devlop: "npm:^1.1.0"
+    develop: "npm:^1.1.0"
     nth-check: "npm:^2.0.0"
     zwitch: "npm:^2.0.0"
   checksum: 10c0/2be09c8c146d92f606d7383faa3df0f905b67c0618ac8128f99f8b02cf980f0ee1035b12c598a79fe5aebfef9e10f1e9eb8eb26d605fc65122946f56332bd257


### PR DESCRIPTION
Fixed typographical errors across documentation markdown files using codespell.