### PR TITLE
refactor: remove unused internal method `contents.canGoToIndex()`

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -4605,7 +4605,6 @@ void WebContents::FillObjectTemplate(v8::Isolate* isolate,
       .SetMethod("_goForward", &WebContents::GoForward)
       .SetMethod("_canGoToOffset", &WebContents::CanGoToOffset)
       .SetMethod("_goToOffset", &WebContents::GoToOffset)
-      .SetMethod("canGoToIndex", &WebContents::CanGoToIndex)
       .SetMethod("_goToIndex", &WebContents::GoToIndex)
       .SetMethod("_getActiveIndex", &WebContents::GetActiveIndex)
       .SetMethod("_getNavigationEntryAtIndex",

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -213,7 +213,6 @@ class WebContents final : public ExclusiveAccessContext,
   void GoForward();
   bool CanGoToOffset(int offset) const;
   void GoToOffset(int offset);
-  bool CanGoToIndex(int index) const;
   void GoToIndex(int index);
   int GetActiveIndex() const;
   content::NavigationEntry* GetNavigationEntryAtIndex(int index) const;
@@ -784,6 +783,8 @@ class WebContents final : public ExclusiveAccessContext,
       const content::ContextMenuParams& params,
       content::GlobalRenderFrameHostId render_frame_host_id,
       std::vector<std::u16string> types);
+
+  [[nodiscard]] bool CanGoToIndex(int index) const;
 
   cppgc::Persistent<api::Session> session_;
   v8::Global<v8::Value> devtools_web_contents_;

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -118,7 +118,6 @@ declare namespace Electron {
     _getHistory(): Electron.NavigationEntry[];
     _restoreHistory(index: number, entries: Electron.NavigationEntry[]): void
     _clearHistory():void
-    canGoToIndex(index: number): boolean;
     destroy(): void;
     // <webview>
     attachToIframe(embedderWebContents: Electron.WebContents, embedderFrameToken: string): void;


### PR DESCRIPTION
#### Description of Change

Remove unused internal JS method `webContents.canGoToIndex()`. The last reference to this code was removed in 2021 by #28839

The C++ WebContents class still uses this method internally, so keep that but make it private.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none