### PR TITLE
fix: remove menu update debug log

### DIFF
--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -478,7 +478,6 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
 
   if (![represented
           isKindOfClass:[WeakPtrToElectronMenuModelAsNSObject class]]) {
-    NSLog(@"representedObject is not a WeakPtrToElectronMenuModelAsNSObject");
     return;
   }
 


### PR DESCRIPTION
#### Description of Change

Removes a diagnostic log:

```
representedObject is not a WeakPtrToElectronMenuModelAsNSObject
```

This log was introduced alongside a guard in macOS menu refresh. The guard is part of the system's expected behavior, preventing us from processing menu items we don't own. In other words, the guard itself is benign. Keep the guard, remove the log.

Fixes #50389

#### Checklist
- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Removed "representedObject is not a WeakPtrToElectronMenuModelAsNSObject" logging when interacting with macOS menus.
