### PR TITLE
fix: don't force kFitToPrintableArea scaling when custom margins are set

### DIFF
--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -675,7 +675,7 @@ index ac2f719be566020d9f41364560c12e6d6d0fe3d8..16d758a6936f66148a196761cfb875f6
    PrintingFailed(int32 cookie, PrintFailureReason reason);
  
 diff --git a/components/printing/renderer/print_render_frame_helper.cc b/components/printing/renderer/print_render_frame_helper.cc
-index 60b5e83a8bc1ed07970be4cdfdc19962698bd754..1320f3b10b07b2cee90f39f406604176c7575796 100644
+index 60b5e83a8bc1ed07970be4cdfdc19962698bd754..dd83b6cfb6e3f916e60f50402014cd931a4d8850 100644
 --- a/components/printing/renderer/print_render_frame_helper.cc
 +++ b/components/printing/renderer/print_render_frame_helper.cc
 @@ -54,6 +54,7 @@
@@ -799,7 +799,7 @@ index 60b5e83a8bc1ed07970be4cdfdc19962698bd754..1320f3b10b07b2cee90f39f406604176
      // Check if `this` is still valid.
      if (!self)
        return;
-@@ -2394,29 +2415,43 @@ void PrintRenderFrameHelper::IPCProcessed() {
+@@ -2394,29 +2415,47 @@ void PrintRenderFrameHelper::IPCProcessed() {
  }
  
  bool PrintRenderFrameHelper::InitPrintSettings(blink::WebLocalFrame* frame,
@@ -835,8 +835,12 @@ index 60b5e83a8bc1ed07970be4cdfdc19962698bd754..1320f3b10b07b2cee90f39f406604176
 -                      : mojom::PrintScalingOption::kSourceSize;
 -  RecordDebugEvent(settings.params->printed_doc_type ==
 +  bool silent = new_settings.FindBool("silent").value_or(false);
-+  if (silent) {
-+    settings->params->print_scaling_option = mojom::PrintScalingOption::kFitToPrintableArea;
++  int margins_type = new_settings.FindInt(kSettingMarginsType)
++      .value_or(static_cast<int>(mojom::MarginType::kDefaultMargins));
++  if (silent &&
++      margins_type == static_cast<int>(mojom::MarginType::kDefaultMargins)) {
++    settings->params->print_scaling_option =
++        mojom::PrintScalingOption::kFitToPrintableArea;
 +  } else {
 +    settings->params->print_scaling_option =
 +        center_on_paper ? mojom::PrintScalingOption::kCenterShrinkToFitPaper


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/50481

When silent printing with non-default margins (custom, no margins, or printable area margins), the kFitToPrintableArea scaling option causes double-marginalization: the custom margins define the content area, then the scaling additionally fits content to the printer's printable area.

Only apply kFitToPrintableArea when using default margins in silent mode. For non-default margins, use the same scaling as non-silent prints.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where margins did not look as expected when printing in silent mode.