### PR TITLE
chore: remove declaration for nonexistent method `WebContents._getPrintersAsync()`

### DIFF
--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -102,7 +102,6 @@ declare namespace Electron {
     _sendInternal(channel: string, ...args: any[]): void;
     _printToPDF(options: any): Promise<Buffer>;
     _print(options: any, callback?: (success: boolean, failureReason: string) => void): void;
-    _getPrintersAsync(): Promise<Electron.PrinterInfo[]>;
     _init(): void;
     _getNavigationEntryAtIndex(index: number): Electron.NavigationEntry | null;
     _getActiveIndex(): number;


### PR DESCRIPTION
#### Description of Change

Simple one-line cleanup to remove a type declaration for nonexistent method `WebContents._getPrintersAsync()`. Seems to have been added by accident in 8f51d3e1.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.