### PR TITLE
ci: correct contributing link and add link to ai tool policy

### DIFF
--- a/.github/workflows/pull-request-labeled.yml
+++ b/.github/workflows/pull-request-labeled.yml
@@ -72,7 +72,7 @@ jobs:
 
           Hello @${{ github.event.pull_request.user.login }}. Due to the high amount of AI spam PRs we receive, if a PR is detected to be majority AI-generated without disclosure and untested, we will automatically close the PR.
 
-          We welcome the use of AI tools, as long as the PR meets our quality standards and has clearly been built and tested. If you believe your PR was closed in error, we welcome you to resubmit. However, please read our [CONTRIBUTING.md](https://github.com/electron/electron/blob/main/CONTRIBUTING.md) and [AI Tool Policy(https://github.com/electron/governance/blob/main/policy/ai.md) carefully before reopening. Thanks for your contribution.
+          We welcome the use of AI tools, as long as the PR meets our quality standards and has clearly been built and tested. If you believe your PR was closed in error, we welcome you to resubmit. However, please read our [CONTRIBUTING.md](https://github.com/electron/electron/blob/main/CONTRIBUTING.md) and [AI Tool Policy](https://github.com/electron/governance/blob/main/policy/ai.md) carefully before reopening. Thanks for your contribution.
     - name: Close the pull request
       env:
         GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
#### Description of Change

This PR fixes the link to our contributing guidelines and adds the link to our ai tool policy that came out since the label was created.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
