### PR TITLE
chore: stop exposing unused menu methods to JS

### DIFF
--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -264,10 +264,6 @@ int Menu::GetItemCount() const {
   return model_->GetItemCount();
 }
 
-std::u16string Menu::GetSublabelAt(int index) const {
-  return model_->GetSecondaryLabelAt(index);
-}
-
 std::u16string Menu::GetAcceleratorTextAtForTesting(int index) const {
   ui::Accelerator accelerator;
   model_->GetAcceleratorAtWithParams(index, true, &accelerator);
@@ -310,7 +306,6 @@ void Menu::FillObjectTemplate(v8::Isolate* isolate,
       .SetMethod("setCustomType", &Menu::SetCustomType)
       .SetMethod("clear", &Menu::Clear)
       .SetMethod("getItemCount", &Menu::GetItemCount)
-      .SetMethod("getSublabelAt", &Menu::GetSublabelAt)
       .SetMethod("isItemCheckedAt", &Menu::IsItemCheckedAt)
       .SetMethod("isEnabledAt", &Menu::IsEnabledAt)
       .SetMethod("isVisibleAt", &Menu::IsVisibleAt)

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -131,7 +131,6 @@ class Menu : public gin::Wrappable<Menu>,
   void Clear();
   int GetIndexOfCommandId(int command_id) const;
   int GetItemCount() const;
-  std::u16string GetSublabelAt(int index) const;
   bool IsItemCheckedAt(int index) const;
   bool IsEnabledAt(int index) const;
   bool IsVisibleAt(int index) const;


### PR DESCRIPTION
#### Description of Change

Another dead code removal PR. This one removes code that is exposed to JS but is not used, not documented, and not typed in either `electron.d.ts` or `internal-electron.d.ts`.

-  `menu.getSubLabelAt()`
- `menu.getToolTipAt()`
- `menu.getLabelAt()`
- `menu.getIndexOfCommandId()`
- `menu.getCommandIdAt()`
- `menu.worksWhenHiddenAt()`

None of these are used now. As far as I can tell, most of them have never been used. I suspect they were added speculatively.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.