### PR TITLE
ci: fix pulling previous object checksums

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -51,25 +51,12 @@ runs:
       shell: bash
       if: ${{ (github.event_name == 'push' || github.event_name == 'pull_request') && inputs.is-asan != 'true' }}
       env:
-        GH_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ github.token }}
         ARTIFACT_NAME: object-checksums.${{ inputs.artifact-platform }}_${{ inputs.target-arch }}.json
         SEARCH_BRANCH: ${{ case(github.event_name == 'push', github.ref_name, github.event.pull_request.base.ref) }}
         REPO: ${{ github.repository }}
-      run: |
-        echo "Searching for artifact '${ARTIFACT_NAME}' on branch '${SEARCH_BRANCH}'..."
-
-        RUN_IDS=$(gh run list --repo "${REPO}" --branch "${SEARCH_BRANCH}" --workflow Build --status completed --event push --limit 20 --json databaseId --jq '.[].databaseId')
-        for RUN_ID in $RUN_IDS; do
-          ARTIFACT_ID=$(gh api "/repos/${REPO}/actions/runs/${RUN_ID}/artifacts?name=${ARTIFACT_NAME}" --jq '.artifacts[0].id // empty' 2>/dev/null || true)
-          if [ -n "$ARTIFACT_ID" ]; then
-            echo "Found artifact in run ${RUN_ID} (artifact ID: ${ARTIFACT_ID}), downloading..."
-            gh api "/repos/${REPO}/actions/artifacts/${ARTIFACT_ID}/zip" > src/previous-object-checksums.json
-            echo "Downloaded previous object checksums successfully"
-            exit 0
-          fi
-        done
-
-        echo "No previous object checksums found in last 20 runs, continuing without them"
+        OUTPUT_PATH: src/previous-object-checksums.json
+      run: node src/electron/.github/actions/build-electron/download-previous-object-checksums.mjs
     - name: Build Electron ${{ inputs.step-suffix }}
       if: ${{ inputs.target-platform != 'win' }}
       shell: bash

--- a/.github/actions/build-electron/download-previous-object-checksums.mjs
+++ b/.github/actions/build-electron/download-previous-object-checksums.mjs
@@ -1,0 +1,82 @@
+import { Octokit } from '@octokit/rest';
+
+import { writeFileSync } from 'node:fs';
+
+const token = process.env.GITHUB_TOKEN;
+const repo = process.env.REPO;
+const artifactName = process.env.ARTIFACT_NAME;
+const branch = process.env.SEARCH_BRANCH;
+const outputPath = process.env.OUTPUT_PATH;
+
+const required = { GITHUB_TOKEN: token, REPO: repo, ARTIFACT_NAME: artifactName, SEARCH_BRANCH: branch, OUTPUT_PATH: outputPath };
+const missing = Object.entries(required).filter(([, v]) => !v).map(([k]) => k);
+if (missing.length > 0) {
+  console.error(`Missing required environment variables: ${missing.join(', ')}`);
+  process.exit(1);
+}
+
+const [owner, repoName] = repo.split('/');
+const octokit = new Octokit({ auth: token });
+
+async function main () {
+  console.log(`Searching for artifact '${artifactName}' on branch '${branch}'...`);
+
+  // Resolve the "Build" workflow name to an ID, mirroring how `gh run list --workflow` works
+  // under the hood (it uses /repos/{owner}/{repo}/actions/workflows/{id}/runs).
+  const { data: workflows } = await octokit.actions.listRepoWorkflows({ owner, repo: repoName });
+  const buildWorkflow = workflows.workflows.find((w) => w.name === 'Build');
+  if (!buildWorkflow) {
+    console.log('Could not find "Build" workflow, continuing without previous checksums');
+    return;
+  }
+
+  const { data: runs } = await octokit.actions.listWorkflowRuns({
+    owner,
+    repo: repoName,
+    workflow_id: buildWorkflow.id,
+    branch,
+    status: 'completed',
+    event: 'push',
+    per_page: 20,
+    exclude_pull_requests: true
+  });
+
+  for (const run of runs.workflow_runs) {
+    const { data: artifacts } = await octokit.actions.listWorkflowRunArtifacts({
+      owner,
+      repo: repoName,
+      run_id: run.id,
+      name: artifactName
+    });
+
+    if (artifacts.artifacts.length > 0) {
+      const artifact = artifacts.artifacts[0];
+      console.log(`Found artifact in run ${run.id} (artifact ID: ${artifact.id}), downloading...`);
+
+      // Non-archived artifacts are still downloaded from the /zip endpoint
+      const response = await octokit.actions.downloadArtifact({
+        owner,
+        repo: repoName,
+        artifact_id: artifact.id,
+        archive_format: 'zip'
+      });
+
+      if (response.headers['content-type'] !== 'application/json') {
+        console.error(`Unexpected content type for artifact download: ${response.headers['content-type']}`);
+        console.error('Expected application/json, continuing without previous checksums');
+        return;
+      }
+
+      writeFileSync(outputPath, JSON.stringify(response.data));
+      console.log('Downloaded previous object checksums successfully');
+      return;
+    }
+  }
+
+  console.log(`No previous object checksums found in last ${runs.workflow_runs.length} runs, continuing without them`);
+}
+
+main().catch((err) => {
+  console.error('Failed to download previous object checksums, continuing without them:', err.message);
+  process.exit(0);
+});


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

NOTE: PRS submitted without this template will be automatically closed.
-->

Follow-up to #50390. There are two issues that this is fixing:
* When `archive: false` is used for `actions/upload-artifact`, the name of the artifact ends up being the filename, not the name supplied in the `name` input, so it needs to be looked up using that name.
* The parent commit is not guaranteed to have the artifact we're looking for:
  * Docs only PRs don't trigger a build and won't upload the artifact
  * On release branches we limit concurrency so a given commit may not get a full build run if another PR is merged shortly after it

Removes `dawidd6/action-download-artifact` which in hindsight I shouldn't have added, and it can't handle the non-archived artifacts.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
