### PR TITLE
build: allow clearing src & cross mnt cache via dispatch

### DIFF
--- a/.github/workflows/clean-src-cache.yml
+++ b/.github/workflows/clean-src-cache.yml
@@ -7,6 +7,7 @@ name: Clean Source Cache
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
#### Description of Change

As in title.

Once-a-day seems to work fine but we're running into issues on occasion even in light of that and it'd be nice to do it on demand.
#### Release Notes

Notes: none