### PR TITLE
ci: add Datadog metrics to clean-src-cache job

### DIFF
--- a/.github/workflows/clean-src-cache.yml
+++ b/.github/workflows/clean-src-cache.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: electron-arc-centralus-linux-amd64-32core
     permissions:
       contents: read
+    env:
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
     container:
       image: ghcr.io/electron/build:bc2f48b2415a670de18d13605b1cf0eb5fdbaae1
       options: --user root
@@ -61,7 +63,6 @@ jobs:
       if: ${{ env.DD_API_KEY != '' }}
       shell: bash
       env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
         CROSS_FREE_BEFORE: ${{ steps.disk-before.outputs.cross_free_kb }}
         CROSS_FREE_AFTER: ${{ steps.disk-after.outputs.cross_free_kb }}
         CROSS_TOTAL: ${{ steps.disk-before.outputs.cross_total_kb }}


### PR DESCRIPTION
#### Description of Change

Enhanced the `clean-src-cache` workflow to capture and report disk space metrics to Datadog. The workflow now:

1. Captures disk space metrics before cleanup (free space and total capacity for both cache volumes)
2. Performs the existing cleanup of files older than 15 days
3. Captures disk space metrics after cleanup
4. Sends all metrics to Datadog via the API, including:
   - Free space before/after cleanup
   - Space freed during cleanup
   - Total capacity
   - Tagged by volume (cross-instance-cache, win-cache) for easy filtering

This enables monitoring of cache cleanup effectiveness and disk usage trends over time.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [ ] `npm test` passes (N/A - workflow configuration change)
- [ ] tests are changed or added (N/A - workflow configuration change)
- [ ] relevant API documentation is updated (N/A - workflow configuration change)

#### Release Notes

Notes: none

https://claude.ai/code/session_013bpDsZLrFDpWMiARNFH4z9