### PR TITLE
chore: remove unused `view.setLayout()`

### DIFF
--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -5,16 +5,13 @@
 #include "shell/browser/api/electron_api_view.h"
 
 #include <algorithm>
-#include <limits>
 #include <memory>
 #include <string>
 #include <utility>
 
 #include "ash/style/rounded_rect_cutout_path_builder.h"
-#include "gin/data_object_builder.h"
 #include "gin/wrappable.h"
 #include "shell/browser/javascript_environment.h"
-#include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/gfx_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/handle.h"
@@ -23,129 +20,12 @@
 #include "ui/compositor/layer.h"
 #include "ui/views/animation/animation_builder.h"
 #include "ui/views/background.h"
-#include "ui/views/layout/flex_layout.h"
-#include "ui/views/layout/layout_manager_base.h"
 
 #if BUILDFLAG(IS_MAC)
 #include "shell/browser/animation_util.h"
 #endif
 
 namespace gin {
-
-template <>
-struct Converter<views::ChildLayout> {
-  static bool FromV8(v8::Isolate* isolate,
-                     v8::Local<v8::Value> val,
-                     views::ChildLayout* out) {
-    gin_helper::Dictionary dict;
-    if (!gin::ConvertFromV8(isolate, val, &dict))
-      return false;
-    gin_helper::Handle<electron::api::View> view;
-    if (!dict.Get("view", &view))
-      return false;
-    out->child_view = view->view();
-    if (dict.Has("bounds"))
-      dict.Get("bounds", &out->bounds);
-    out->visible = true;
-    if (dict.Has("visible"))
-      dict.Get("visible", &out->visible);
-    return true;
-  }
-};
-
-template <>
-struct Converter<views::ProposedLayout> {
-  static bool FromV8(v8::Isolate* isolate,
-                     v8::Local<v8::Value> val,
-                     views::ProposedLayout* out) {
-    gin_helper::Dictionary dict;
-    if (!gin::ConvertFromV8(isolate, val, &dict))
-      return false;
-    if (!dict.Get("size", &out->host_size))
-      return false;
-    if (!dict.Get("layouts", &out->child_layouts))
-      return false;
-    return true;
-  }
-};
-
-template <>
-struct Converter<views::LayoutOrientation> {
-  static bool FromV8(v8::Isolate* isolate,
-                     v8::Local<v8::Value> val,
-                     views::LayoutOrientation* out) {
-    std::string orientation = base::ToLowerASCII(gin::V8ToString(isolate, val));
-    if (orientation == "horizontal") {
-      *out = views::LayoutOrientation::kHorizontal;
-    } else if (orientation == "vertical") {
-      *out = views::LayoutOrientation::kVertical;
-    } else {
-      return false;
-    }
-    return true;
-  }
-};
-
-template <>
-struct Converter<views::LayoutAlignment> {
-  static bool FromV8(v8::Isolate* isolate,
-                     v8::Local<v8::Value> val,
-                     views::LayoutAlignment* out) {
-    std::string orientation = base::ToLowerASCII(gin::V8ToString(isolate, val));
-    if (orientation == "start") {
-      *out = views::LayoutAlignment::kStart;
-    } else if (orientation == "center") {
-      *out = views::LayoutAlignment::kCenter;
-    } else if (orientation == "end") {
-      *out = views::LayoutAlignment::kEnd;
-    } else if (orientation == "stretch") {
-      *out = views::LayoutAlignment::kStretch;
-    } else if (orientation == "baseline") {
-      *out = views::LayoutAlignment::kBaseline;
-    } else {
-      return false;
-    }
-    return true;
-  }
-};
-
-template <>
-struct Converter<views::FlexAllocationOrder> {
-  static bool FromV8(v8::Isolate* isolate,
-                     v8::Local<v8::Value> val,
-                     views::FlexAllocationOrder* out) {
-    std::string orientation = base::ToLowerASCII(gin::V8ToString(isolate, val));
-    if (orientation == "normal") {
-      *out = views::FlexAllocationOrder::kNormal;
-    } else if (orientation == "reverse") {
-      *out = views::FlexAllocationOrder::kReverse;
-    } else {
-      return false;
-    }
-    return true;
-  }
-};
-
-template <>
-struct Converter<views::SizeBound> {
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   const views::SizeBound& in) {
-    if (in.is_bounded())
-      return v8::Integer::New(isolate, in.value());
-    return v8::Number::New(isolate, std::numeric_limits<double>::infinity());
-  }
-};
-
-template <>
-struct Converter<views::SizeBounds> {
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   const views::SizeBounds& in) {
-    return gin::DataObjectBuilder(isolate)
-        .Set("width", in.width())
-        .Set("height", in.height())
-        .Build();
-  }
-};
 
 template <>
 struct Converter<gfx::Tween::Type> {
@@ -170,27 +50,6 @@ struct Converter<gfx::Tween::Type> {
 }  // namespace gin
 
 namespace electron::api {
-
-using LayoutCallback = base::RepeatingCallback<views::ProposedLayout(
-    const views::SizeBounds& size_bounds)>;
-
-class JSLayoutManager : public views::LayoutManagerBase {
- public:
-  explicit JSLayoutManager(LayoutCallback layout_callback)
-      : layout_callback_(std::move(layout_callback)) {}
-  ~JSLayoutManager() override = default;
-
-  // views::LayoutManagerBase
-  views::ProposedLayout CalculateProposedLayout(
-      const views::SizeBounds& size_bounds) const override {
-    v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-    v8::HandleScope handle_scope(isolate);
-    return layout_callback_.Run(size_bounds);
-  }
-
- private:
-  LayoutCallback layout_callback_;
-};
 
 View::View(views::View* view) : view_(view) {
   view_->set_owned_by_client(views::View::OwnedByClientPassKey{});
@@ -421,51 +280,6 @@ gfx::Rect View::GetBounds() const {
   return view_->bounds();
 }
 
-void View::SetLayout(v8::Isolate* isolate, v8::Local<v8::Object> value) {
-  if (!view_)
-    return;
-  gin_helper::Dictionary dict(isolate, value);
-  LayoutCallback calculate_proposed_layout;
-  if (dict.Get("calculateProposedLayout", &calculate_proposed_layout)) {
-    view_->SetLayoutManager(std::make_unique<JSLayoutManager>(
-        std::move(calculate_proposed_layout)));
-  } else {
-    auto* layout =
-        view_->SetLayoutManager(std::make_unique<views::FlexLayout>());
-    views::LayoutOrientation orientation;
-    if (dict.Get("orientation", &orientation))
-      layout->SetOrientation(orientation);
-    views::LayoutAlignment main_axis_alignment;
-    if (dict.Get("mainAxisAlignment", &main_axis_alignment))
-      layout->SetMainAxisAlignment(main_axis_alignment);
-    views::LayoutAlignment cross_axis_alignment;
-    if (dict.Get("crossAxisAlignment", &cross_axis_alignment))
-      layout->SetCrossAxisAlignment(cross_axis_alignment);
-    gfx::Insets interior_margin;
-    if (dict.Get("interiorMargin", &interior_margin))
-      layout->SetInteriorMargin(interior_margin);
-    int minimum_cross_axis_size;
-    if (dict.Get("minimumCrossAxisSize", &minimum_cross_axis_size))
-      layout->SetMinimumCrossAxisSize(minimum_cross_axis_size);
-    bool collapse_margins;
-    if (dict.Has("collapseMargins") &&
-        dict.Get("collapseMargins", &collapse_margins))
-      layout->SetCollapseMargins(collapse_margins);
-    bool include_host_insets_in_layout;
-    if (dict.Has("includeHostInsetsInLayout") &&
-        dict.Get("includeHostInsetsInLayout", &include_host_insets_in_layout))
-      layout->SetIncludeHostInsetsInLayout(include_host_insets_in_layout);
-    bool ignore_default_main_axis_margins;
-    if (dict.Has("ignoreDefaultMainAxisMargins") &&
-        dict.Get("ignoreDefaultMainAxisMargins",
-                 &ignore_default_main_axis_margins))
-      layout->SetIgnoreDefaultMainAxisMargins(ignore_default_main_axis_margins);
-    views::FlexAllocationOrder flex_allocation_order;
-    if (dict.Get("flexAllocationOrder", &flex_allocation_order))
-      layout->SetFlexAllocationOrder(flex_allocation_order);
-  }
-}
-
 std::vector<v8::Local<v8::Value>> View::GetChildren() {
   std::vector<v8::Local<v8::Value>> ret;
   ret.reserve(child_views_.size());
@@ -584,7 +398,6 @@ void View::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getBounds", &View::GetBounds)
       .SetMethod("setBackgroundColor", &View::SetBackgroundColor)
       .SetMethod("setBorderRadius", &View::SetBorderRadius)
-      .SetMethod("setLayout", &View::SetLayout)
       .SetMethod("setVisible", &View::SetVisible)
       .SetMethod("getVisible", &View::GetVisible);
 }

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -39,7 +39,6 @@ class View : public gin_helper::EventEmitter<View>,
 
   void SetBounds(const gfx::Rect& bounds, gin::Arguments* args);
   gfx::Rect GetBounds() const;
-  void SetLayout(v8::Isolate* isolate, v8::Local<v8::Object> value);
   std::vector<v8::Local<v8::Value>> GetChildren();
   void SetBackgroundColor(std::optional<WrappedSkColor> color);
   void SetBorderRadius(int radius);


### PR DESCRIPTION
#### Description of Change

Another PR in the "remove dead code" series. This one removes `view.setLayout()`.

IMO this feature should be removed since it's ~200 LOC that have been unsupported + undocumented for three years. But -- unlike other PRs in this series -- there's backstory here and the decision isn't as obvious. So I'd particularly appreciate feedback from 43069 / 44876 participants @codebytere @nikwen @itsananderson 

- 2023-12: feature lands, undocumented, in 15c60143241c7d0335f3bc8c722054ce6b8a9481 (#35658).

- 2024-07: I opened https://github.com/electron/electron/pull/43069 (equivalent to this PR) to remove it.  There was discussion that this feature could be useful, it just needed a champion to document it, so I closed the PR.

- 2024-11 https://github.com/electron/electron/issues/44876 was opened to see if anyone wanted to step up and document it. So far, nobody has.

This feature has been in the codebase since 2023 and nobody's stepped up to champion it or document it. It doesn't appear to be important to anyone. Let's remove it.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.