### PR TITLE
refactor: replace calls to NotifyAccessibilityEventDeprecated()

### DIFF
--- a/shell/browser/ui/views/autofill_popup_view.cc
+++ b/shell/browser/ui/views/autofill_popup_view.cc
@@ -111,7 +111,7 @@ void AutofillPopupView::Show() {
   auto* host = popup_->frame_host_->GetRenderViewHost()->GetWidget();
   host->AddKeyPressEventCallback(keypress_callback_);
 
-  NotifyAccessibilityEventDeprecated(ax::mojom::Event::kMenuStart, true);
+  GetViewAccessibility().NotifyEvent(ax::mojom::Event::kMenuStart, true);
 }
 
 void AutofillPopupView::Hide() {
@@ -122,7 +122,7 @@ void AutofillPopupView::Hide() {
   }
 
   RemoveObserver();
-  NotifyAccessibilityEventDeprecated(ax::mojom::Event::kMenuEnd, true);
+  GetViewAccessibility().NotifyEvent(ax::mojom::Event::kMenuEnd, true);
 
   if (GetWidget()) {
     GetWidget()->Close();
@@ -165,7 +165,7 @@ void AutofillPopupView::OnSelectedRowChanged(
     int selected = current_row_selection.value_or(-1);
     if (selected == -1 || static_cast<size_t>(selected) >= children().size())
       return;
-    children().at(selected)->NotifyAccessibilityEventDeprecated(
+    children().at(selected)->GetViewAccessibility().NotifyEvent(
         ax::mojom::Event::kSelection, true);
   }
 }


### PR DESCRIPTION
#### Description of Change

Don't call the deprecated API `views::View::NotifyAccessibilityEventDeprecated()`.

This change is pretty straightforward: just call `GetViewAccessibility().NotifyEvent()` instead.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.