### PR TITLE
refactor: remove unused field ServiceWorkerMain.start_worker_promise_

### DIFF
--- a/shell/browser/api/electron_api_service_worker_main.h
+++ b/shell/browser/api/electron_api_service_worker_main.h
@@ -163,8 +163,6 @@ class ServiceWorkerMain final
 
   raw_ptr<content::ServiceWorkerContext> service_worker_context_;
   mojo::AssociatedRemote<mojom::ElectronRenderer> remote_;
-
-  std::unique_ptr<gin_helper::Promise<void>> start_worker_promise_;
 };
 
 }  // namespace electron::api


### PR DESCRIPTION
#### Description of Change

Straightforward code removal: remove `ServiceWorkerMain::start_worker_promise_`, which was added in a467d068 but has never been used.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.