### PR TITLE
fix: dangling raw_ptr MicrotasksRunner::isolate_

### DIFF
--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -86,6 +86,7 @@ JavascriptEnvironment::~JavascriptEnvironment() {
   // Otherwise cppgc::internal::Sweeper::Start will try to request a task runner
   // from the NodePlatform with an already unregistered isolate.
   locker_.reset();
+  DCHECK(!microtasks_runner_);
   isolate_holder_.reset();
 
   platform_->UnregisterIsolate(isolate_);
@@ -159,6 +160,7 @@ void JavascriptEnvironment::DestroyMicrotasksRunner() {
     gin_helper::CleanedUpAtExit::DoCleanup();
   }
   base::CurrentThread::Get()->RemoveTaskObserver(microtasks_runner_.get());
+  microtasks_runner_.reset();
 }
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

Fix a dangling `raw_ptr<v8::Isolate*> MicrotasksRunner::isolate_;` observed by running specs on a local build with dangling raw_ptr checks enabled.

The root cause was that `JavascriptEnvironment::DestroyMicrotasksRunner() ` didn't actually destroy the microtasks runner, which continued to survive after the isolate was freed.

```txt
[DanglingPtr](1/3) A raw_ptr/raw_ref is dangling.

[DanglingPtr](2/3) First, the memory was freed at:

Stack trace:
#0 0x55fcca536432 base::debug::CollectStackTrace() [../../base/debug/stack_trace_posix.cc:1050:7]
#1 0x55fcca51dc51 base::debug::StackTrace::StackTrace() [../../base/debug/stack_trace.cc:280:20]
#2 0x55fcca53da56 base::allocator::(anonymous namespace)::DanglingRawPtrDetected() [../../base/allocator/partition_alloc_support.cc:438:11]
#3 0x55fcca5f61b3 partition_alloc::PartitionRoot::FreeInUnknownRoot<>() [../../base/allocator/partition_allocator/src/partition_alloc/in_slot_metadata.h:389:5]
#4 0x55fccc969fed gin::IsolateHolder::~IsolateHolder() [../../gin/isolate_holder.cc:157:13]
#5 0x55fcc33ff804 electron::JavascriptEnvironment::~JavascriptEnvironment() [../../third_party/libc++/src/include/__memory/unique_ptr.h:74:5]
#6 0x55fcc33d3959 electron::ElectronBrowserMainParts::~ElectronBrowserMainParts() [../../third_party/libc++/src/include/__memory/unique_ptr.h:74:5]
#7 0x55fcc33d3a5e electron::ElectronBrowserMainParts::~ElectronBrowserMainParts() [../../electron/shell/browser/electron_browser_main_parts.cc:192:53]
#8 0x55fcc82caf58 content::BrowserMainLoop::~BrowserMainLoop() [../../third_party/libc++/src/include/__memory/unique_ptr.h:74:5]
#9 0x55fcc82cb19e content::BrowserMainLoop::~BrowserMainLoop() [../../content/browser/browser_main_loop.cc:496:37]
#10 0x55fcc82d0fac content::BrowserMainRunnerImpl::Shutdown() [../../third_party/libc++/src/include/__memory/unique_ptr.h:74:5]
#11 0x55fcc82ca881 content::BrowserMain() [../../content/browser/browser_main.cc:41:16]
#12 0x55fcc3a98ad9 content::RunBrowserProcessMain() [../../content/app/content_main_runner_impl.cc:701:10]
#13 0x55fcc3a9be57 content::ContentMainRunnerImpl::RunBrowser() [../../content/app/content_main_runner_impl.cc:1325:10]
#14 0x55fcc3a9b160 content::ContentMainRunnerImpl::Run() [../../content/app/content_main_runner_impl.cc:1155:12]
#15 0x55fcc3a97236 content::RunContentProcess() [../../content/app/content_main.cc:356:36]
#16 0x55fcc3a97470 content::ContentMain() [../../content/app/content_main.cc:369:10]
#17 0x55fcc3284555 main [../../electron/shell/app/electron_main_linux.cc:50:10]
#18 0x7ea81162a575 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a574)
#19 0x7ea81162a628 __libc_start_main
#20 0x55fcc326802a _start

[DanglingPtr](3/3) Later, the dangling raw_ptr was released at:

Stack trace:
#0 0x55fcca536432 base::debug::CollectStackTrace() [../../base/debug/stack_trace_posix.cc:1050:7]
#1 0x55fcca51dc51 base::debug::StackTrace::StackTrace() [../../base/debug/stack_trace.cc:280:20]
#2 0x55fcca53db3d base::allocator::(anonymous namespace)::DanglingRawPtrReleased<>() [../../base/allocator/partition_alloc_support.cc:600:21]
#3 0x55fcca57be39 base::internal::RawPtrBackupRefImpl<>::ReleaseInternal() [../../base/allocator/partition_allocator/src/partition_alloc/in_slot_metadata.h:211:7]
#4 0x55fcc34046ef electron::MicrotasksRunner::~MicrotasksRunner() [../../base/allocator/partition_allocator/src/partition_alloc/pointers/raw_ptr_backup_ref_impl.h:194:7]
#5 0x55fcc33ff838 electron::JavascriptEnvironment::~JavascriptEnvironment() [../../third_party/libc++/src/include/__memory/unique_ptr.h:74:5]
#6 0x55fcc33d3959 electron::ElectronBrowserMainParts::~ElectronBrowserMainParts() [../../third_party/libc++/src/include/__memory/unique_ptr.h:74:5]
#7 0x55fcc33d3a5e electron::ElectronBrowserMainParts::~ElectronBrowserMainParts() [../../electron/shell/browser/electron_browser_main_parts.cc:192:53]
#8 0x55fcc82caf58 content::BrowserMainLoop::~BrowserMainLoop() [../../third_party/libc++/src/include/__memory/unique_ptr.h:74:5]
#9 0x55fcc82cb19e content::BrowserMainLoop::~BrowserMainLoop() [../../content/browser/browser_main_loop.cc:496:37]
#10 0x55fcc82d0fac content::BrowserMainRunnerImpl::Shutdown() [../../third_party/libc++/src/include/__memory/unique_ptr.h:74:5]
#11 0x55fcc82ca881 content::BrowserMain() [../../content/browser/browser_main.cc:41:16]
#12 0x55fcc3a98ad9 content::RunBrowserProcessMain() [../../content/app/content_main_runner_impl.cc:701:10]
#13 0x55fcc3a9be57 content::ContentMainRunnerImpl::RunBrowser() [../../content/app/content_main_runner_impl.cc:1325:10]
#14 0x55fcc3a9b160 content::ContentMainRunnerImpl::Run() [../../content/app/content_main_runner_impl.cc:1155:12]
#15 0x55fcc3a97236 content::RunContentProcess() [../../content/app/content_main.cc:356:36]
#16 0x55fcc3a97470 content::ContentMain() [../../content/app/content_main.cc:369:10]
#17 0x55fcc3284555 main [../../electron/shell/app/electron_main_linux.cc:50:10]
#18 0x7ea81162a575 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a574)
#19 0x7ea81162a628 __libc_start_main
#20 0x55fcc326802a _start
```

Checks enabled by building with these flags:

```diff
diff --git a/build/args/all.gn b/build/args/all.gn
index 45939f456f..1934854c67 100644
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -53,8 +53,11 @@ use_qt6 = false
 
 # https://chromium.googlesource.com/chromium/src/+/main/docs/dangling_ptr.md
 # TODO(vertedinde): hunt down dangling pointers on Linux
-enable_dangling_raw_ptr_checks = false
-enable_dangling_raw_ptr_feature_flag = false
+is_debug = true
+enable_dangling_raw_ptr_checks = true
+enable_dangling_raw_ptr_feature_flag = true
+enable_backup_ref_ptr_support = true
+enable_backup_ref_ptr_feature_flag = true
```

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.