### PR TITLE
feat: register contextMenus and sidePanel extension permissions

### DIFF
--- a/shell/common/extensions/api/_api_features.json
+++ b/shell/common/extensions/api/_api_features.json
@@ -24,6 +24,14 @@
   "action.setBadgeTextColor": {
     "channel": "stable"
   },
+  "contextMenus": {
+    "dependencies": ["permission:contextMenus"],
+    "contexts": ["privileged_extension"]
+  },
+  "sidePanel": {
+    "dependencies": ["permission:sidePanel"],
+    "contexts": ["privileged_extension"]
+  },
   "extension": {
     "channel": "stable",
     "extension_types": ["extension"],

--- a/shell/common/extensions/electron_extensions_api_provider.cc
+++ b/shell/common/extensions/electron_extensions_api_provider.cc
@@ -40,6 +40,8 @@ constexpr APIPermissionInfo::InitInfo permissions_to_register[] = {
      APIPermissionInfo::kFlagRequiresManagementUIWarning},
     {mojom::APIPermissionID::kScripting, "scripting",
      APIPermissionInfo::kFlagRequiresManagementUIWarning},
+    {mojom::APIPermissionID::kContextMenus, "contextMenus"},
+    {mojom::APIPermissionID::kSidePanel, "sidePanel"},
 };
 base::span<const APIPermissionInfo::InitInfo> GetPermissionInfos() {
   return base::span(permissions_to_register);


### PR DESCRIPTION
Fixes #50331. This PR adds the missing 'contextMenus' and 'sidePanel' permissions to the Electron extension system, resolving the 'unknown permission' warnings and enabling the corresponding APIs.