### PR TITLE
fix: upgrade undici to 6.24.0, 7.24.0 (CVE-2026-1526)

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,5 +160,8 @@
     "abstract-socket": {
       "built": true
     }
+  },
+  "dependencies": {
+    "undici": "6.24.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -622,6 +622,7 @@ __metadata:
     ts-loader: "npm:^8.0.2"
     ts-node: "npm:6.2.0"
     typescript: "npm:^5.8.3"
+    undici: "npm:6.24.0"
     url: "npm:^0.11.4"
     webpack: "npm:^5.104.1"
     webpack-cli: "npm:^6.0.1"
@@ -13081,6 +13082,13 @@ __metadata:
   version: 7.16.0
   resolution: "undici-types@npm:7.16.0"
   checksum: 10c0/3033e2f2b5c9f1504bdc5934646cb54e37ecaca0f9249c983f7b1fc2e87c6d18399ebb05dc7fd5419e02b2e915f734d872a65da2e3eeed1813951c427d33cc9a
+  languageName: node
+  linkType: hard
+
+"undici@npm:6.24.0":
+  version: 6.24.0
+  resolution: "undici@npm:6.24.0"
+  checksum: 10c0/a97d7f1214b34c5b2802558d06cbed97ff96a27ab6548972ba9d07c13951c69e2e9f2f01581f71c86b74755d2bf92e64091cf8f2c6eba4184f10c6d583e60388
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Upgrade undici from 5.29.0 to 6.24.0, 7.24.0 to fix CVE-2026-1526.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-1526 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-1526` |
| **File** | `yarn.lock` |

**Description**: undici: undici: Denial of Service via unbounded memory consumption during WebSocket permessage-deflate decompression

## Changes
- `package.json`
- `yarn.lock`

## Verification
- [ ] Build not verified
- [ ] Scanner re-scan not performed
- [ ] LLM code review not performed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
