### PR TITLE
ci: zstd-compress the src cache and drop the doubled win_toolchain

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -28,8 +28,9 @@ runs:
     shell: bash
     run: |
       node src/electron/script/generate-deps-hash.js
-      echo "DEPSHASH=$(cat src/electron/.depshash)" >> $GITHUB_ENV
-      echo "CACHE_SHARDS=a b c d" >> $GITHUB_ENV
+      DEPSHASH="v2-src-cache-$(cat src/electron/.depshash)"
+      echo "DEPSHASH=$DEPSHASH" >> $GITHUB_ENV
+      echo "CACHE_FILE=$DEPSHASH.tar" >> $GITHUB_ENV
       if [ "${{ inputs.target-platform }}" = "win" ]; then
         echo "CACHE_DRIVE=/mnt/win-cache" >> $GITHUB_ENV
       else
@@ -39,13 +40,7 @@ runs:
     if: ${{ inputs.generate-sas-token == 'true' }}
     shell: bash
     run: |
-      args='{}'
-      for s in $CACHE_SHARDS; do
-        shard_file="v2-src-cache-shard-${s}-${DEPSHASH}.tar"
-        resp=$(curl --unix-socket /var/run/sas/sas.sock --fail "http://foo/${shard_file}?platform=${{ inputs.target-platform }}&getAccountName=true")
-        args=$(jq --arg s "$s" --argjson r "$resp" '. + {($s): $r}' <<< "$args")
-      done
-      echo "$args" > sas-token
+      curl --unix-socket /var/run/sas/sas.sock --fail "http://foo/$CACHE_FILE?platform=${{ inputs.target-platform }}&getAccountName=true" > sas-token
   - name: Save SAS Key
     if: ${{ inputs.generate-sas-token == 'true' }}
     uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
@@ -61,16 +56,16 @@ runs:
         echo "Not using cache this time..."
         echo "cache_exists=false" >> $GITHUB_OUTPUT
       else
+        cache_path=$CACHE_DRIVE/$CACHE_FILE
         echo "Using cache key: $DEPSHASH"
-        cache_exists=true
-        for s in $CACHE_SHARDS; do
-          cache_path="$CACHE_DRIVE/v2-src-cache-shard-${s}-${DEPSHASH}.tar"
-          if [ ! -f "$cache_path" ] || [ `du $cache_path | cut -f1` = "0" ]; then
-            cache_exists=false
-            echo "Cache shard ${s} missing at $cache_path"
-          fi
-        done
-        echo "cache_exists=$cache_exists" >> $GITHUB_OUTPUT
+        echo "Checking for cache in: $cache_path"
+        if [ ! -f "$cache_path" ] || [ `du $cache_path | cut -f1` = "0" ]; then
+          echo "cache_exists=false" >> $GITHUB_OUTPUT
+          echo "Cache Does Not Exist for $DEPSHASH"
+        else
+          echo "cache_exists=true" >> $GITHUB_OUTPUT
+          echo "Cache Already Exists for $DEPSHASH, Skipping.."
+        fi
       fi
   - name: Check cross instance cache disk space
     if: steps.check-cache.outputs.cache_exists == 'false' && inputs.use-cache  == 'true'
@@ -194,29 +189,22 @@ runs:
       echo "Uncompressed src size: $(du -sh src | cut -f1 -d' ')"
       # Named .tar but zstd-compressed; the sas-sidecar's filename allowlist
       # only permits .tar/.tgz so we keep the extension and decode on restore.
-      SHARD_B_DIRS="src/third_party/dawn src/third_party/electron_node src/third_party/tflite src/third_party/devtools-frontend"
-      tar -cf - src/third_party/blink | zstd -T0 --long=30 -f -o v2-src-cache-shard-a-${DEPSHASH}.tar
-      tar -cf - $SHARD_B_DIRS | zstd -T0 --long=30 -f -o v2-src-cache-shard-b-${DEPSHASH}.tar
-      tar -cf - --exclude=src/third_party/blink $(printf -- '--exclude=%s ' $SHARD_B_DIRS) src/third_party | zstd -T0 --long=30 -f -o v2-src-cache-shard-c-${DEPSHASH}.tar
-      tar -cf - --exclude=src/third_party src | zstd -T0 --long=30 -f -o v2-src-cache-shard-d-${DEPSHASH}.tar
-      for s in $CACHE_SHARDS; do
-        f="v2-src-cache-shard-${s}-${DEPSHASH}.tar"
-        echo "Compressed shard ${s} to $(du -sh $f | cut -f1 -d' ')"
-        cp ./$f $CACHE_DRIVE/
-      done
+      tar -cf - src | zstd -T0 --long=30 -f -o $CACHE_FILE
+      echo "Compressed src to $(du -sh $CACHE_FILE | cut -f1 -d' ')"
+      cp ./$CACHE_FILE $CACHE_DRIVE/
   - name: Persist Src Cache
     if: ${{ steps.check-cache.outputs.cache_exists == 'false' && inputs.use-cache == 'true' }}
     shell: bash
     run: |
+      final_cache_path=$CACHE_DRIVE/$CACHE_FILE
       echo "Using cache key: $DEPSHASH"
-      for s in $CACHE_SHARDS; do
-        final_cache_path="$CACHE_DRIVE/v2-src-cache-shard-${s}-${DEPSHASH}.tar"
-        if [ ! -f "$final_cache_path" ]; then
-          echo "Cache shard ${s} not found at $final_cache_path"
-          exit 1
-        fi
-      done
-      echo "All cache shards persisted"
+      echo "Checking path: $final_cache_path"
+      if [ ! -f "$final_cache_path" ]; then
+        echo "Cache key not found"
+        exit 1
+      else
+        echo "Cache key persisted in $final_cache_path"
+      fi
   - name: Wait for active SSH sessions
     shell: bash
     if: always() && !cancelled()

--- a/.github/actions/restore-cache-aks/action.yml
+++ b/.github/actions/restore-cache-aks/action.yml
@@ -10,28 +10,28 @@ runs:
     shell: bash
     run: |
       if [ "${{ inputs.target-platform }}" = "win" ]; then
-        cache_drive=/mnt/win-cache
+        cache_path=/mnt/win-cache/$DEPSHASH.tar
       else
-        cache_drive=/mnt/cross-instance-cache
+        cache_path=/mnt/cross-instance-cache/$DEPSHASH.tar
       fi
 
       echo "Using cache key: $DEPSHASH"
-      for s in $CACHE_SHARDS; do
-        cache_path="${cache_drive}/v2-src-cache-shard-${s}-${DEPSHASH}.tar"
-        if [ ! -f "$cache_path" ] || [ `du $cache_path | cut -f1` = "0" ]; then
-          echo "Cache shard ${s} missing or empty at $cache_path - exiting"
-          exit 1
-        fi
-        echo "Found shard ${s}: $(du -sh $cache_path | cut -f1)"
-      done
+      echo "Checking for cache in: $cache_path"
+      if [ ! -f "$cache_path" ]; then
+        echo "Cache Does Not Exist for $DEPSHASH - exiting"
+        exit 1
+      else
+        echo "Found Cache for $DEPSHASH at $cache_path"
+      fi
 
-      mkdir -p temp-cache/src/third_party
-      pids=()
-      for s in $CACHE_SHARDS; do
-        zstd -d --long=30 -c "${cache_drive}/v2-src-cache-shard-${s}-${DEPSHASH}.tar" | tar -xf - -C temp-cache &
-        pids+=($!)
-      done
-      for pid in "${pids[@]}"; do wait $pid; done
+      echo "Persisted cache is $(du -sh $cache_path | cut -f1)"
+      if [ `du  $cache_path | cut -f1` = "0" ]; then
+        echo "Cache is empty - exiting"
+        exit 1
+      fi
+
+      mkdir temp-cache
+      zstd -d --long=30 -c $cache_path | tar -xf - -C temp-cache
       echo "Unzipped cache is $(du -sh temp-cache/src | cut -f1)"
 
       if [ -d "temp-cache/src" ]; then

--- a/.github/actions/restore-cache-azcopy/action.yml
+++ b/.github/actions/restore-cache-azcopy/action.yml
@@ -31,22 +31,21 @@ runs:
       retry_on: error
       shell: bash
       command: |
-        if [ ! -s sas-token ]; then
+        sas_token=$(cat sas-token)
+        if [ -z "$sas_token" ]; then
           echo "SAS Token not found; exiting src cache download early..."
           exit 1
-        fi
-        if [ "${{ inputs.target-platform }}" = "win" ]; then
-          share_name="${{ env.AZURE_AKS_WIN_CACHE_SHARE_NAME }}"
         else
-          share_name="${{ env.AZURE_AKS_CACHE_SHARE_NAME }}"
+          sas_token=$(jq -r '.sasToken' sas-token)
+          account_name=$(jq -r '.accountName' sas-token)
+          if [ "${{ inputs.target-platform }}" = "win" ]; then
+            azcopy copy --log-level=ERROR \
+            "https://$account_name.file.core.windows.net/${{ env.AZURE_AKS_WIN_CACHE_SHARE_NAME }}/${{ env.CACHE_PATH }}?$sas_token" $DEPSHASH.tar
+          else
+            azcopy copy --log-level=ERROR \
+            "https://$account_name.file.core.windows.net/${{ env.AZURE_AKS_CACHE_SHARE_NAME }}/${{ env.CACHE_PATH }}?$sas_token" $DEPSHASH.tar
+          fi            
         fi
-        for s in $CACHE_SHARDS; do
-          shard_file="v2-src-cache-shard-${s}-${DEPSHASH}.tar"
-          sas_token=$(jq -r ".${s}.sasToken" sas-token)
-          account_name=$(jq -r ".${s}.accountName" sas-token)
-          azcopy copy --log-level=ERROR \
-            "https://${account_name}.file.core.windows.net/${share_name}/${shard_file}?${sas_token}" "${shard_file}"
-        done
     env:
       AZURE_AKS_CACHE_SHARE_NAME: linux-cache
       AZURE_AKS_WIN_CACHE_SHARE_NAME: windows-cache
@@ -54,43 +53,49 @@ runs:
     shell: bash
     run: rm -f sas-token
   - name: Unzip and Ensure Src Cache
-    if: ${{ inputs.target-platform == 'macos' || inputs.target-platform == 'win' }}
-    shell: bash
-    run: |
-      for s in $CACHE_SHARDS; do
-        shard_file="v2-src-cache-shard-${s}-${DEPSHASH}.tar"
-        if [ ! -f "$shard_file" ] || [ `du $shard_file | cut -f1` = "0" ]; then
-          echo "Cache shard ${s} is missing or empty - exiting"
-          exit 1
-        fi
-        echo "Downloaded shard ${s}: $(du -sh $shard_file | cut -f1)"
-      done
-
-      mkdir -p temp-cache/src/third_party
-      pids=()
-      for s in $CACHE_SHARDS; do
-        zstd -d --long=30 -c "v2-src-cache-shard-${s}-${DEPSHASH}.tar" | tar -xf - -C temp-cache &
-        pids+=($!)
-      done
-      for pid in "${pids[@]}"; do wait $pid; done
-      echo "Unzipped cache is $(du -sh temp-cache/src | cut -f1)"
-      rm -f v2-src-cache-shard-*-${DEPSHASH}.tar
-
-  - name: Move Src Cache (macOS)
     if: ${{ inputs.target-platform == 'macos' }}
     shell: bash
     run: |
+      echo "Downloaded cache is $(du -sh $DEPSHASH.tar | cut -f1)"
+      if [ `du $DEPSHASH.tar | cut -f1` = "0" ]; then
+        echo "Cache is empty - exiting"
+        exit 1
+      fi
+
+      mkdir temp-cache
+      zstd -d --long=30 -c $DEPSHASH.tar | tar -xf - -C temp-cache
+      echo "Unzipped cache is $(du -sh temp-cache/src | cut -f1)"
+
       if [ -d "temp-cache/src" ]; then
         echo "Relocating Cache"
         rm -rf src
         mv temp-cache/src src
+
+        echo "Deleting zip file"
+        rm -rf $DEPSHASH.tar
       fi
+
       if [ ! -d "src/third_party/blink" ]; then
         echo "Cache was not correctly restored - exiting"
         exit 1
       fi
+
       echo "Wiping Electron Directory"
       rm -rf src/electron
+
+  - name: Unzip and Ensure Src Cache (Windows)
+    if: ${{ inputs.target-platform == 'win' }}
+    shell: bash
+    run: |
+      echo "Downloaded cache is $(du -sh $DEPSHASH.tar | cut -f1)"
+      if [ `du $DEPSHASH.tar | cut -f1` = "0" ]; then
+        echo "Cache is empty - exiting"
+        exit 1
+      fi
+
+      mkdir temp-cache
+      zstd -d --long=30 -c $DEPSHASH.tar | tar -xf - -C temp-cache
+      rm -f $DEPSHASH.tar
 
   - name: Move Src Cache (Windows)
     if: ${{ inputs.target-platform == 'win' }}

--- a/.github/workflows/pipeline-electron-docs-only.yml
+++ b/.github/workflows/pipeline-electron-docs-only.yml
@@ -35,8 +35,9 @@ jobs:
     - name: Generate DEPS Hash
       run: |
         node src/electron/script/generate-deps-hash.js
-        echo "DEPSHASH=$(cat src/electron/.depshash)" >> $GITHUB_ENV
-        echo "CACHE_SHARDS=a b c d" >> $GITHUB_ENV
+        DEPSHASH=v2-src-cache-$(cat src/electron/.depshash)
+        echo "DEPSHASH=$DEPSHASH" >> $GITHUB_ENV
+        echo "CACHE_PATH=$DEPSHASH.tar" >> $GITHUB_ENV
     - name: Restore src cache via AKS
       uses: ./src/electron/.github/actions/restore-cache-aks
       with:

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -156,8 +156,9 @@ jobs:
     - name: Generate DEPS Hash
       run: |
         node src/electron/script/generate-deps-hash.js
-        echo "DEPSHASH=$(cat src/electron/.depshash)" >> $GITHUB_ENV
-        echo "CACHE_SHARDS=a b c d" >> $GITHUB_ENV
+        DEPSHASH=v2-src-cache-$(cat src/electron/.depshash)
+        echo "DEPSHASH=$DEPSHASH" >> $GITHUB_ENV
+        echo "CACHE_PATH=$DEPSHASH.tar" >> $GITHUB_ENV
     - name: Restore src cache via AZCopy
       if: ${{ inputs.target-platform != 'linux' }}
       uses: ./src/electron/.github/actions/restore-cache-azcopy

--- a/.github/workflows/pipeline-segment-electron-clang-tidy.yml
+++ b/.github/workflows/pipeline-segment-electron-clang-tidy.yml
@@ -80,8 +80,9 @@ jobs:
     - name: Generate DEPS Hash
       run: |
         node src/electron/script/generate-deps-hash.js
-        echo "DEPSHASH=$(cat src/electron/.depshash)" >> $GITHUB_ENV
-        echo "CACHE_SHARDS=a b c d" >> $GITHUB_ENV
+        DEPSHASH=v2-src-cache-$(cat src/electron/.depshash)
+        echo "DEPSHASH=$DEPSHASH" >> $GITHUB_ENV
+        echo "CACHE_PATH=$DEPSHASH.tar" >> $GITHUB_ENV
     - name: Restore src cache via AZCopy
       if: ${{ inputs.target-platform == 'macos' }}
       uses: ./src/electron/.github/actions/restore-cache-azcopy

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -81,8 +81,9 @@ jobs:
     - name: Generate DEPS Hash
       run: |
         node src/electron/script/generate-deps-hash.js
-        echo "DEPSHASH=$(cat src/electron/.depshash)" >> $GITHUB_ENV
-        echo "CACHE_SHARDS=a b c d" >> $GITHUB_ENV
+        DEPSHASH=v2-src-cache-$(cat src/electron/.depshash)
+        echo "DEPSHASH=$DEPSHASH" >> $GITHUB_ENV
+        echo "CACHE_PATH=$DEPSHASH.tar" >> $GITHUB_ENV
     - name: Restore src cache via AZCopy
       if: ${{ inputs.target-platform == 'macos' }}
       uses: ./src/electron/.github/actions/restore-cache-azcopy

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -165,8 +165,9 @@ jobs:
       - name: Generate DEPS Hash
         run: |
           node src/electron/script/generate-deps-hash.js
-          echo "DEPSHASH=$(cat src/electron/.depshash)" >> $GITHUB_ENV
-          echo "CACHE_SHARDS=a b c d" >> $GITHUB_ENV
+          DEPSHASH=v2-src-cache-$(cat src/electron/.depshash)
+          echo "DEPSHASH=$DEPSHASH" >> $GITHUB_ENV
+          echo "CACHE_PATH=$DEPSHASH.tar" >> $GITHUB_ENV
       - name: Restore src cache via AZCopy
         if: ${{ inputs.target-platform != 'linux' }}
         uses: ./src/electron/.github/actions/restore-cache-azcopy


### PR DESCRIPTION
Src-cache restore (download + extract), x64 build jobs, main vs this PR:

| Platform | main | this PR | |
|---|---|---|---|
| linux-x64 | 4m 10s | 1m 01s | 4.1× |
| macos-x64 | 11m 49s | 3m 10s | 3.7× |
| windows-x64 | 26m 24s | 11m 01s | 2.4× |

### zstd compression

The tarball was uncompressed (~21GB linux, ~37GB windows). Now `tar -cf - src | zstd -T0 --long=30 -f -o $CACHE_FILE`, extracted via `zstd -d --long=30 -c | tar -xf -` on all platforms. The file is still named `$DEPSHASH.tar` because the SAS-token sidecar only allows `.tar`/`.tgz`; `zstd` doesn't care about the extension.

### Windows extraction: 7z → piped tar

7z was taking ~20 min to extract ~1.1M entries regardless of size — roughly 1ms per entry of header parsing and path normalization, single-threaded, well under what the D16lds_v5 ephemeral disk can do. Switched to the same `zstd -d -c | tar -xf -` pipe under `shell: bash` (Git Bash tar is on PATH via `git.install /GitAndUnixToolsOnPath`). The `-snld20` flag was working around 7z's own "dangerous symlink" refusal; tar extracts them as-is.

This also fixes the original bug where the downloaded tarball was never deleted on Windows — `$src_cache` was defined in the "Unzip" step but referenced in the separate "Move" step where it was undefined, so `Remove-Item` threw, the retry wrapper re-ran, and the second pass skipped the `if` block.

### Skip win_toolchain download during checkout

The Windows cache contained `depot_tools/win_toolchain` twice — the `vs_files.ciopfs` backing store plus the live ciopfs mount at `vs_files/`, both captured by `tar` (~14.6GB). Every Windows consumer already re-fetches this via `vs_toolchain.py update --force`, so the cached copy was overwritten on arrival. Setting `ELECTRON_DEPOT_TOOLS_WIN_TOOLCHAIN=0` / `DEPOT_TOOLS_WIN_TOOLCHAIN=0` on the `gclient sync` makes the hook a no-op so it's never downloaded in the first place.

### Misc

- Cache key bumped to `v2-src-cache-*` (depshash also changes automatically since `checkout/action.yml` is a hash input).
- Dropped `-vv` from `gclient sync` in the checkout action.

### Things tried and backed out

- Stripping `blink/web_tests`, `jetstream`, `llvm-build`, etc. from the cache — caused siso/RBE cache misses since even `data`-only deps participate in action input hashes.
- 4-way sharded tarballs for parallel Windows extraction — only got 11 → ~9 min because NTFS's `$LogFile` journal serializes metadata writes regardless of how many processes are creating files. Not worth the complexity; see electron/infra#219 for the ReFS-workspace approach instead.

Notes: none