### PR TITLE
ci: reduce checkout and build log verbosity

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -75,9 +75,9 @@ runs:
         fi
 
         if [ "${{ inputs.is-release }}" = "true" ]; then
-          NINJA_SUMMARIZE_BUILD=1 e build --target electron:release_build
+          NINJA_SUMMARIZE_BUILD=1 e build --target electron:release_build -- --quiet --batch=false --heartbeat_period=30s
         else
-          NINJA_SUMMARIZE_BUILD=1 e build --target electron:testing_build
+          NINJA_SUMMARIZE_BUILD=1 e build --target electron:testing_build -- --quiet --batch=false --heartbeat_period=30s
         fi
         cp out/Default/.ninja_log out/electron_ninja_log
         node electron/script/check-symlinks.js
@@ -102,10 +102,10 @@ runs:
         cd ..
 
         $env:NINJA_SUMMARIZE_BUILD = 1
-        if ("${{ inputs.is-release }}" -eq "true") {          
-          e build --target electron:release_build
+        if ("${{ inputs.is-release }}" -eq "true") {
+          e build --target electron:release_build -- --quiet --batch=false --heartbeat_period=30s
         } else {
-          e build --target electron:testing_build
+          e build --target electron:testing_build -- --quiet --batch=false --heartbeat_period=30s
         }
         Copy-Item out\Default\.ninja_log out\electron_ninja_log
         node electron\script\check-symlinks.js
@@ -185,7 +185,7 @@ runs:
       shell: bash
       run: |
         cd src
-        e build --target electron:electron_chromedriver_zip
+        e build --target electron:electron_chromedriver_zip -- --quiet --batch=false --heartbeat_period=30s
 
         if [ "${{ inputs.is-asan }}" != "true" ]; then
           target_os=${{ inputs.target-platform == 'macos' && 'mac' || inputs.target-platform }}
@@ -229,7 +229,7 @@ runs:
       run: |
         cd src
         gn gen out/ffmpeg --args="import(\"//electron/build/args/ffmpeg.gn\") use_remoteexec=true use_siso=true $GN_EXTRA_ARGS"
-        e build --target electron:electron_ffmpeg_zip -C ../../out/ffmpeg
+        e build --target electron:electron_ffmpeg_zip -C ../../out/ffmpeg --quiet --batch=false --heartbeat_period=30s
     - name: Remove Clang problem matcher
       shell: bash
       run: echo "::remove-matcher owner=clang::"

--- a/.github/actions/build-git-cache/action.yml
+++ b/.github/actions/build-git-cache/action.yml
@@ -58,7 +58,7 @@ runs:
         echo "target_os=['$TARGET_OS']" >> ./.gclient
       fi
 
-      ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES=1 e d gclient sync --with_branch_heads --with_tags --nohooks -vv 
+      ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES=1 e d gclient sync --with_branch_heads --with_tags --nohooks
   - name: Compress Git Cache Directory
     shell: bash
     run: |

--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -109,7 +109,7 @@ runs:
         echo "target_os=['$TARGET_OS']" >> ./.gclient
       fi
 
-      ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES=1 e d gclient sync --with_branch_heads --with_tags -vv
+      ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES=1 e d gclient sync --with_branch_heads --with_tags
       if [[ "${{ inputs.is-release }}" != "true" ]]; then
         # Re-export all the patches to check if there were changes.
         python3 src/electron/script/export_all_patches.py src/electron/patches/config.json


### PR DESCRIPTION
`gclient sync` was running with `-vv` (double-verbose), which dumps every git operation for every dep. Dropped to default verbosity in both the `checkout` and `build-git-cache` actions.

For the build step, pass `--quiet --batch=false --heartbeat_period=30s` through to siso so the log shows a periodic heartbeat rather than a line per build action. `e build` forwards these via `ninjaArgs` and Go's flag parser accepts the double-dash form (depot_tools' own `siso.py` uses the same strings).

Notes: none