### PR TITLE
ci: fetch clang-tidy package in fix-sync

### DIFF
--- a/.github/actions/fix-sync/action.yml
+++ b/.github/actions/fix-sync/action.yml
@@ -27,6 +27,7 @@ runs:
         python3 src/tools/clang/scripts/update.py
         # Refs https://chromium-review.googlesource.com/c/chromium/src/+/6667681
         python3 src/tools/clang/scripts/update.py --package objdump
+        python3 src/tools/clang/scripts/update.py --package clang-tidy
     - name: Fix esbuild
       if: ${{ inputs.target-platform != 'linux' }}
       uses: ./src/electron/.github/actions/cipd-install


### PR DESCRIPTION
`fix-sync` re-downloads `llvm-build` on macOS/Windows with the base `clang` and `objdump` packages, but not `clang-tidy`. A local `gclient sync` does pull `clang-tidy` (Electron's DEPS sets `checkout_clang_tidy: True`), so CI's `llvm-build` tree ends up missing a file that a local checkout has.

siso uploads the whole toolchain directory as action input, so the hash computed on CI (without `clang-tidy`) doesn't match the hash computed locally (with it). Cache-only local runs against the CI-populated RBE cache miss because the input is absent.

Linux is unaffected — it uses the cached `llvm-build` from the Linux-hosted `gclient sync`, which already includes `clang-tidy`.

Notes: none