### PR TITLE
build: derive patches upstream-head ref from script path

### DIFF
--- a/docs/development/patches.md
+++ b/docs/development/patches.md
@@ -79,7 +79,7 @@ $ ../../electron/script/git-import-patches ../../electron/patches/node
 $ ../../electron/script/git-export-patches -o ../../electron/patches/node
 ```
 
-Note that `git-import-patches` will mark the commit that was `HEAD` when it was run as `refs/patches/upstream-head`. This lets you keep track of which commits are from Electron patches (those that come after `refs/patches/upstream-head`) and which commits are in upstream (those before `refs/patches/upstream-head`).
+Note that `git-import-patches` will mark the commit that was `HEAD` when it was run as `refs/patches/upstream-head` (and a checkout-specific `refs/patches/upstream-head-<hash>` so that gclient worktrees sharing a `.git/refs` directory don't clobber each other). This lets you keep track of which commits are from Electron patches (those that come after `refs/patches/upstream-head`) and which commits are in upstream (those before `refs/patches/upstream-head`).
 
 #### Resolving conflicts
 

--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -126,6 +126,8 @@ def import_patches(repo, ref=UPSTREAM_HEAD, **kwargs):
   """same as am(), but we save the upstream HEAD so we can refer to it when we
   later export patches"""
   update_ref(repo=repo, ref=ref, newvalue='HEAD')
+  if ref != _LEGACY_UPSTREAM_HEAD:
+    update_ref(repo=repo, ref=_LEGACY_UPSTREAM_HEAD, newvalue='HEAD')
   # Upgrade to index v4 before applying so every intermediate index write
   # during am benefits from path-prefix compression (roughly halves index
   # size in large repos).


### PR DESCRIPTION
`gclient-new-workdir.py` (used by `e worktree add`) symlinks each repo's `.git/refs` directory back to the source checkout. That means `refs/patches/upstream-head` — written by `apply_all_patches.py` during `e sync` and read by `git-export-patches` / `check-patch-diff` — is shared across the source and every worktree.

When you `e sync` a worktree on a different release branch, it overwrites the source checkout's `upstream-head` with that branch's chromium revision. Subsequent `e patches` runs in the source (or another worktree) then export thousands of bogus commits as patches.

This change suffixes the ref with `md5(SCRIPT_DIR)[:8]` so each worktree writes a distinct ref into the shared `refs/` directory. `guess_base_commit` falls back to the legacy unsuffixed ref so existing checkouts keep working until their next sync writes the new ref.

Notes: none