### PR TITLE
feat: import shared texture supports nv16

### DIFF
--- a/docs/api/structures/shared-texture-import-texture-info.md
+++ b/docs/api/structures/shared-texture-import-texture-info.md
@@ -5,6 +5,7 @@
   * `rgba` - 32bpp RGBA (byte-order), 1 plane.
   * `rgbaf16` - Half float RGBA, 1 plane.
   * `nv12` - 12bpp with Y plane followed by a 2x2 interleaved UV plane.
+  * `nv16` - 16bpp with Y plane followed by a 2x1 interleaved UV plane.
   * `p010le` - 4:2:0 10-bit YUV (little-endian), Y plane followed by a 2x2 interleaved UV plane.
 * `colorSpace` [ColorSpace](color-space.md) (optional) - The color space of the texture.
 * `codedSize` [Size](size.md) - The full dimensions of the shared texture.

--- a/shell/common/api/electron_api_shared_texture.cc
+++ b/shell/common/api/electron_api_shared_texture.cc
@@ -127,6 +127,8 @@ std::string TransferVideoPixelFormatToString(media::VideoPixelFormat format) {
       return "rgbaf16";
     case media::PIXEL_FORMAT_NV12:
       return "nv12";
+    case media::PIXEL_FORMAT_NV16:
+      return "nv16";
     case media::PIXEL_FORMAT_P010LE:
       return "p010le";
     default:
@@ -577,6 +579,8 @@ struct Converter<ImportSharedTextureInfo> {
         out->pixel_format = media::PIXEL_FORMAT_RGBAF16;
       else if (pixel_format_str == "nv12")
         out->pixel_format = media::PIXEL_FORMAT_NV12;
+      else if (pixel_format_str == "nv16")
+        out->pixel_format = media::PIXEL_FORMAT_NV16;
       else if (pixel_format_str == "p010le")
         out->pixel_format = media::PIXEL_FORMAT_P010LE;
       else


### PR DESCRIPTION
#### Description of Change

This PR adds support for the nv16 pixel format to SharedTextureImportTextureInfo.

nv16 is a 4:2:2 8-bit bi-planar YUV format (Y plane + interleaved CbCr plane), similar to NV12 but without chroma subsampling in the vertical direction. It is used in some 4K video pipelines and by certain hardware decoders and GPU paths.

cc: @reitowo

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added support for importing shared textures using the nv16 pixel format.
