### PR TITLE
fix: allow built-in PDF viewer in non-persistent session

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -757,19 +757,21 @@ void ElectronBrowserClient::SiteInstanceGotProcessAndSite(
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   auto* browser_context =
       static_cast<ElectronBrowserContext*>(site_instance->GetBrowserContext());
-  if (!browser_context->IsOffTheRecord()) {
-    extensions::ExtensionRegistry* registry =
-        extensions::ExtensionRegistry::Get(browser_context);
-    const extensions::Extension* extension =
-        registry->enabled_extensions().GetExtensionOrAppByURL(
-            site_instance->GetSiteURL());
-    if (!extension)
-      return;
+  extensions::ExtensionRegistry* registry =
+      extensions::ExtensionRegistry::Get(browser_context);
+  const extensions::Extension* extension =
+      registry->enabled_extensions().GetExtensionOrAppByURL(
+          site_instance->GetSiteURL());
+  if (!extension)
+    return;
 
-    extensions::ProcessMap::Get(browser_context)
-        ->Insert(extension->id(),
-                 site_instance->GetProcess()->GetDeprecatedID());
-  }
+  if (browser_context->IsOffTheRecord() &&
+      extension->id() != extension_misc::kPdfExtensionId)
+    return;
+
+  extensions::ProcessMap::Get(browser_context)
+      ->Insert(extension->id(),
+               site_instance->GetProcess()->GetDeprecatedID());
 #endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 }
 

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -399,12 +399,12 @@ ElectronBrowserContext::ElectronBrowserContext(
   if (!in_memory_) {
     BrowserContextDependencyManager::GetInstance()
         ->CreateBrowserContextServices(this);
-
-    auto* extension_system = static_cast<extensions::ElectronExtensionSystem*>(
-        extensions::ExtensionSystem::Get(this));
-    extension_system->InitForRegularProfile(true /* extensions_enabled */);
-    extension_system->FinishInitialization();
   }
+
+  auto* extension_system = static_cast<extensions::ElectronExtensionSystem*>(
+      extensions::ExtensionSystem::Get(this));
+  extension_system->InitForRegularProfile(true /* extensions_enabled */);
+  extension_system->FinishInitialization();
 #endif
 
   // Subscribe to Network Service process gone notifications to reset the
@@ -903,6 +903,12 @@ ElectronBrowserContext* ElectronBrowserContext::From(
   if (!context) {
     context.reset(new ElectronBrowserContext{std::cref(partition), in_memory,
                                              std::move(options)});
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+    // Non-persistent (in-memory) contexts redirect to the default context for
+    // shared extension services (e.g. built-in PDF extension).
+    if (in_memory && !partition.empty())
+      GetDefaultBrowserContext();
+#endif
   }
   return context.get();
 }

--- a/shell/browser/extensions/electron_extensions_browser_client.cc
+++ b/shell/browser/extensions/electron_extensions_browser_client.cc
@@ -95,7 +95,8 @@ bool ElectronExtensionsBrowserClient::IsValidContext(void* context) {
 
 bool ElectronExtensionsBrowserClient::IsSameContext(BrowserContext* first,
                                                     BrowserContext* second) {
-  return first == second;
+  return first == second ||
+         (GetOriginalContext(first) == GetOriginalContext(second));
 }
 
 bool ElectronExtensionsBrowserClient::HasOffTheRecordContext(


### PR DESCRIPTION
#### Description of Change

This is an attempt to fix #27121.

It makes the built-in ([pdfium](https://pdfium.googlesource.com/pdfium/) based) PDF viewer work as expected inside non-persistent sessions.

The main issue was that requests to built-in resources were blocked inside non-persistent sessions. The blocked requests included:
* `chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/index.css`
* `chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/index.html`
* `chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/main.js`
* `chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/pdf_viewer_wrapper.js`
* `chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/index.html`
where `mhjfbmdgcfjbbpaeojofohoefgiehjai` is the extension id of the built-in PDF viewer.

After allowing these requests, requests to `chrome://resources/**` (for example `chrome://resources/css/text_defaults_md.css`) were still blocked and thus had to also be allowed for non-persistent sessions.

I tested with this reproduction of the issue:
```javascript
const { app, BrowserWindow, session } = require("electron");

app.whenReady().then(() => {
    const win = new BrowserWindow({
        webPreferences: {
            devTools: true,
            // Comment out the line below in order to circumvent the issue.
            session: createNonPersistentSession(),
        }
    });

    win.loadURL("https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf");
});

function createNonPersistentSession() {
    const nonPersistentSession = session.fromPartition(crypto.randomUUID());
    return nonPersistentSession;
}
```
Also in this [gist](https://gist.github.com/FrankenApps/062929512a818c71822b3db7acaa4c05) (e.g. for *electron fiddle*).

##### Before
<img width="1299" height="712" alt="Bildschirmfoto 2026-04-06 um 10 36 32" src="https://github.com/user-attachments/assets/631c3f4b-a833-4862-a8c9-344514eea155" />

##### After
<img width="912" height="712" alt="Bildschirmfoto 2026-04-06 um 10 34 20" src="https://github.com/user-attachments/assets/a878a961-25e5-4fcd-88ce-3811f3d6e18d" />

I have to say that I played around with these (and more / other) changes for quite some time now, but I am not very confident that I am headed into the right direction here.
Especially because it touches some rather critical parts of the browser session handling.
Therefore I would really appreciate some guidance from reviewers on whether they think the overall approach is valid.

Some tests fail on my machine, but did so before these changes, too. Therefore I think the local test failures might be unrelated to these changes.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Enabled built-in PDF viewer in non-persistent sessions.
