### PR TITLE
build: (siso) exclude System/Cryptexes from mac SDK filegroups

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -32,12 +32,16 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set main.star for macOS builds
+      shell: bash
+      if: ${{ inputs.target-platform == 'macos' }}
+      run: echo "ELECTRON_BUILD_TOOLS_MAIN_STAR=`pwd`/src/electron/build/siso/main.star" >> $GITHUB_ENV
     - name: Set GN_EXTRA_ARGS for MacOS x64 Builds
       shell: bash
       if: ${{ inputs.target-arch == 'x64' && inputs.target-platform == 'macos' }}
       run: |
         GN_APPENDED_ARGS="$GN_EXTRA_ARGS target_cpu=\"x64\" v8_snapshot_toolchain=\"//build/toolchain/mac:clang_x64\""
-        echo "GN_EXTRA_ARGS=$GN_APPENDED_ARGS" >> $GITHUB_ENV
+        echo "GN_EXTRA_ARGS=$GN_APPENDED_ARGS" >> $GITHUB_ENV        
     - name: Set GN_EXTRA_ARGS for Windows
       shell: bash
       if: ${{inputs.target-arch != 'x64' && inputs.target-platform == 'win' }}

--- a/build/siso/main.star
+++ b/build/siso/main.star
@@ -1,0 +1,79 @@
+load("@builtin//encoding.star", "json")
+load("@builtin//path.star", "path")
+load("@builtin//runtime.star", "runtime")
+load("@builtin//struct.star", "module")
+load("@config//main.star", upstream_init = "init")
+load("@config//win_sdk.star", "win_sdk")
+load("@config//gn_logs.star", "gn_logs")
+
+def init(ctx):
+    mod = upstream_init(ctx)
+    step_config = json.decode(mod.step_config)
+
+    # Buildbarn doesn't support input_root_absolute_path so disable that
+    for rule in step_config["rules"]:    
+      input_root_absolute_path = rule.get("input_root_absolute_path", False)
+      if input_root_absolute_path:
+        rule.pop("input_root_absolute_path", None)
+
+    # Only wrap clang rules with a remote wrapper if not on Linux. These are currently only
+    # needed for X-Compile builds, which run on Windows and Mac.
+    if runtime.os != "linux":
+      for rule in step_config["rules"]:
+        if rule["name"].startswith("clang/") or rule["name"].startswith("clang-cl/"):
+          rule["remote_wrapper"] = "../../buildtools/reclient_cfgs/chromium-browser-clang/clang_remote_wrapper"
+          if "inputs" not in rule:
+            rule["inputs"] = []
+          rule["inputs"].append("buildtools/reclient_cfgs/chromium-browser-clang/clang_remote_wrapper")
+          rule["inputs"].append("third_party/llvm-build/Release+Asserts_linux/bin/clang")
+
+      if "executables" not in step_config:
+        step_config["executables"] = []
+      step_config["executables"].append("buildtools/reclient_cfgs/chromium-browser-clang/clang_remote_wrapper")
+      step_config["executables"].append("third_party/llvm-build/Release+Asserts_linux/bin/clang")
+
+    if runtime.os == "darwin":
+      # Update platforms to match our default siso config instead of reclient configs.
+      step_config["platforms"].update({
+          "clang": step_config["platforms"]["default"],
+          "clang_large": step_config["platforms"]["default"],          
+      })      
+
+    if runtime.os == "windows":
+      # Add additional Windows SDK headers needed by Electron      
+      win_toolchain_dir = win_sdk.toolchain_dir(ctx)
+      if win_toolchain_dir:
+        sdk_version = gn_logs.read(ctx).get("windows_sdk_version")
+        step_config["input_deps"][win_toolchain_dir + ":headers"].extend([
+          # third_party/electron_node/deps/uv/include/uv/win.h includes mswsock.h
+          path.join(win_toolchain_dir, "Windows Kits/10/Include", sdk_version, "um/mswsock.h"),
+          # third_party/electron_node/src/debug_utils.cc includes lm.h
+          path.join(win_toolchain_dir, "Windows Kits/10/Include", sdk_version, "um/Lm.h"),          
+        ])
+      
+      # Update platforms to match our default siso config instead of reclient configs.
+      step_config["platforms"].update({
+          "clang-cl": step_config["platforms"]["default"],
+          "clang-cl_large": step_config["platforms"]["default"],
+          "lld-link": step_config["platforms"]["default"],
+      })
+
+    filegroups = mod.filegroups
+    if runtime.os == "darwin":
+      # Exclude System/Cryptexes from mac SDK filegroups to reduce CAS inputs.
+      # Cryptexes contains iOS Catalyst frameworks that aren't needed and whose
+      # large directory trees cause "Object not found" CAS shard failures.
+      for key in filegroups:
+        if "MacOSX" in key and (key.endswith(":headers") or key.endswith(":link")):
+          fg = dict(filegroups[key])
+          excludes = list(fg.get("excludes", []))
+          excludes.append("System/Cryptexes/**")
+          fg["excludes"] = excludes
+          filegroups[key] = fg
+
+    return module(
+      "config",
+      step_config = json.encode(step_config),
+      filegroups = filegroups,
+      handlers = mod.handlers,
+    )


### PR DESCRIPTION
#### Description of Change
Recent release builds on macOS have been failing with the following error:
"out/x/sdk/xcode_links/MacOSX15.5.sdk/System/Cryptexes/OS": Shard 3: Object not found
eg see https://github.com/electron/electron/actions/runs/24033813468/job/70088689968.

The change adds an excludes for System/Cryptexes/** to any MacOSX SDK filegroup (both :headers and :link) for siso. This prevents siso from uploading the System/Cryptexes/OS directory tree to CAS, which contains iOS Catalyst frameworks (Safari, WebKit, etc.) that Electron doesn't use. The intermittent "Object not found" error was happening when a CAS shard holding part of that large directory tree became unavailable.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

NOTE: PRS submitted without this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
