### PR TITLE
fix: dangling raw_ptr JavascriptEnvironment::isolate_

### DIFF
--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -61,12 +61,12 @@ JavascriptEnvironment::JavascriptEnvironment(uv_loop_t* event_loop,
     : isolate_holder_{CreateIsolateHolder(
           Initialize(event_loop, setup_wasm_streaming),
           &max_young_generation_size_)},
-      isolate_{isolate_holder_->isolate()},
-      locker_{std::make_unique<v8::Locker>(isolate_)} {
-  isolate_->Enter();
+      locker_{std::make_unique<v8::Locker>(isolate())} {
+  v8::Isolate* const isolate = this->isolate();
+  isolate->Enter();
 
-  v8::HandleScope scope(isolate_);
-  auto context = node::NewContext(isolate_);
+  v8::HandleScope scope{isolate};
+  auto context = node::NewContext(isolate);
   CHECK(!context.IsEmpty());
 
   context->Enter();
@@ -74,12 +74,13 @@ JavascriptEnvironment::JavascriptEnvironment(uv_loop_t* event_loop,
 
 JavascriptEnvironment::~JavascriptEnvironment() {
   DCHECK_NE(platform_, nullptr);
+  v8::Isolate* isolate = this->isolate();
 
   {
-    v8::HandleScope scope(isolate_);
-    isolate_->GetCurrentContext()->Exit();
+    v8::HandleScope scope{isolate};
+    isolate->GetCurrentContext()->Exit();
   }
-  isolate_->Exit();
+  isolate->Exit();
   g_isolate = nullptr;
 
   // Deinit gin::IsolateHolder prior to calling NodePlatform::UnregisterIsolate.
@@ -89,7 +90,7 @@ JavascriptEnvironment::~JavascriptEnvironment() {
   DCHECK(!microtasks_runner_);
   isolate_holder_.reset();
 
-  platform_->UnregisterIsolate(isolate_);
+  platform_->UnregisterIsolate(isolate);
 }
 
 v8::Isolate* JavascriptEnvironment::Initialize(uv_loop_t* event_loop,
@@ -156,7 +157,7 @@ void JavascriptEnvironment::DestroyMicrotasksRunner() {
   // parameters.
   isolate_holder_->WillDestroyMicrotasksRunner();
   {
-    v8::HandleScope scope(isolate_);
+    v8::HandleScope scope{isolate()};
     gin_helper::CleanedUpAtExit::DoCleanup();
   }
   base::CurrentThread::Get()->RemoveTaskObserver(microtasks_runner_.get());

--- a/shell/browser/javascript_environment.h
+++ b/shell/browser/javascript_environment.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "base/memory/raw_ptr.h"
 #include "gin/public/isolate_holder.h"
 #include "uv.h"  // NOLINT(build/include_directory)
 #include "v8/include/v8-locker.h"
@@ -35,7 +34,9 @@ class JavascriptEnvironment {
   void DestroyMicrotasksRunner();
 
   node::MultiIsolatePlatform* platform() const { return platform_.get(); }
-  v8::Isolate* isolate() const { return isolate_; }
+  [[nodiscard]] v8::Isolate* isolate() const {
+    return isolate_holder_->isolate();
+  }
   size_t max_young_generation_size_in_bytes() const {
     return max_young_generation_size_;
   }
@@ -49,10 +50,7 @@ class JavascriptEnvironment {
   size_t max_young_generation_size_ = 0;
   std::unique_ptr<gin::IsolateHolder> isolate_holder_;
 
-  // owned-by: isolate_holder_
-  const raw_ptr<v8::Isolate> isolate_;
-
-  // depends-on: isolate_
+  // depends-on: isolate_holder_'s isolate
   std::unique_ptr<v8::Locker> locker_;
 
   std::unique_ptr<MicrotasksRunner> microtasks_runner_;


### PR DESCRIPTION
#### Description of Change


Fix a dangling `raw_ptr<v8::Isolate*> JavascriptEnvironment::isolate_;` observed by running specs on a local build with dangling raw_ptr checks enabled.

The root cause was that we kept this field live even after the isolate holder was destroyed. We also have an inlined accessor method which calls an inlined gin accessor, so there's no real benefit in caching a local copy of the isolate in-class. So this PR fixes the dangling pointer by removing it and using the accessor instead.

```txt
[DanglingPtr](1/3) A raw_ptr/raw_ref is dangling.

[DanglingPtr](2/3) First, the memory was freed at:

Stack trace:
#0 0x61dd5b563332 base::debug::CollectStackTrace() [../../base/debug/stack_trace_posix.cc:1050:7]
#1 0x61dd5b54ab51 base::debug::StackTrace::StackTrace() [../../base/debug/stack_trace.cc:280:20]
#2 0x61dd5b56a956 base::allocator::(anonymous namespace)::DanglingRawPtrDetected() [../../base/allocator/partition_alloc_support.cc:438:11]
#3 0x61dd5b6230b3 partition_alloc::PartitionRoot::FreeInUnknownRoot<>() [../../base/allocator/partition_allocator/src/partition_alloc/in_slot_metadata.h:389:5]
#4 0x61dd5d996efd gin::IsolateHolder::~IsolateHolder() [../../gin/isolate_holder.cc:157:13]
#5 0x61dd5442c1c7 electron::JavascriptEnvironment::~JavascriptEnvironment() [../../third_party/libc++/src/include/__memory/unique_ptr.h:74:5]
#6 0x61dd544002d9 electron::ElectronBrowserMainParts::~ElectronBrowserMainParts() [../../third_party/libc++/src/include/__memory/unique_ptr.h:74:5]
#7 0x61dd544003de electron::ElectronBrowserMainParts::~ElectronBrowserMainParts() [../../electron/shell/browser/electron_browser_main_parts.cc:192:53]
#8 0x61dd592f7f58 content::BrowserMainLoop::~BrowserMainLoop() [../../third_party/libc++/src/include/__memory/unique_ptr.h:74:5]
#9 0x61dd592f819e content::BrowserMainLoop::~BrowserMainLoop() [../../content/browser/browser_main_loop.cc:496:37]
#10 0x61dd592fdfac content::BrowserMainRunnerImpl::Shutdown() [../../third_party/libc++/src/include/__memory/unique_ptr.h:74:5]
#11 0x61dd592f7881 content::BrowserMain() [../../content/browser/browser_main.cc:41:16]
#12 0x61dd54ac54d9 content::RunBrowserProcessMain() [../../content/app/content_main_runner_impl.cc:701:10]
#13 0x61dd54ac8857 content::ContentMainRunnerImpl::RunBrowser() [../../content/app/content_main_runner_impl.cc:1325:10]
#14 0x61dd54ac7b60 content::ContentMainRunnerImpl::Run() [../../content/app/content_main_runner_impl.cc:1155:12]
#15 0x61dd54ac3c36 content::RunContentProcess() [../../content/app/content_main.cc:356:36]
#16 0x61dd54ac3e70 content::ContentMain() [../../content/app/content_main.cc:369:10]
#17 0x61dd542b0555 main [../../electron/shell/app/electron_main_linux.cc:50:10]
#18 0x72a010c2a575 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a574)
#19 0x72a010c2a628 __libc_start_main
#20 0x61dd5429402a _start

[DanglingPtr](3/3) Later, the dangling raw_ptr was released at:

Stack trace:
#0 0x61dd5b563332 base::debug::CollectStackTrace() [../../base/debug/stack_trace_posix.cc:1050:7]
#1 0x61dd5b54ab51 base::debug::StackTrace::StackTrace() [../../base/debug/stack_trace.cc:280:20]
#2 0x61dd5b56aa3d base::allocator::(anonymous namespace)::DanglingRawPtrReleased<>() [../../base/allocator/partition_alloc_support.cc:600:21]
#3 0x61dd5b5a8d39 base::internal::RawPtrBackupRefImpl<>::ReleaseInternal() [../../base/allocator/partition_allocator/src/partition_alloc/in_slot_metadata.h:211:7]
#4 0x61dd5442c276 electron::JavascriptEnvironment::~JavascriptEnvironment() [../../base/allocator/partition_allocator/src/partition_alloc/pointers/raw_ptr_backup_ref_impl.h:194:7]
#5 0x61dd544002d9 electron::ElectronBrowserMainParts::~ElectronBrowserMainParts() [../../third_party/libc++/src/include/__memory/unique_ptr.h:74:5]
#6 0x61dd544003de electron::ElectronBrowserMainParts::~ElectronBrowserMainParts() [../../electron/shell/browser/electron_browser_main_parts.cc:192:53]
#7 0x61dd592f7f58 content::BrowserMainLoop::~BrowserMainLoop() [../../third_party/libc++/src/include/__memory/unique_ptr.h:74:5]
#8 0x61dd592f819e content::BrowserMainLoop::~BrowserMainLoop() [../../content/browser/browser_main_loop.cc:496:37]
#9 0x61dd592fdfac content::BrowserMainRunnerImpl::Shutdown() [../../third_party/libc++/src/include/__memory/unique_ptr.h:74:5]
#10 0x61dd592f7881 content::BrowserMain() [../../content/browser/browser_main.cc:41:16]
#11 0x61dd54ac54d9 content::RunBrowserProcessMain() [../../content/app/content_main_runner_impl.cc:701:10]
#12 0x61dd54ac8857 content::ContentMainRunnerImpl::RunBrowser() [../../content/app/content_main_runner_impl.cc:1325:10]
#13 0x61dd54ac7b60 content::ContentMainRunnerImpl::Run() [../../content/app/content_main_runner_impl.cc:1155:12]
#14 0x61dd54ac3c36 content::RunContentProcess() [../../content/app/content_main.cc:356:36]
#15 0x61dd54ac3e70 content::ContentMain() [../../content/app/content_main.cc:369:10]
#16 0x61dd542b0555 main [../../electron/shell/app/electron_main_linux.cc:50:10]
#17 0x72a010c2a575 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a574)
#18 0x72a010c2a628 __libc_start_main
#19 0x61dd5429402a _start

Please check for more information on:
https://chromium.googlesource.com/chromium/src/+/main/docs/dangling_ptr_guide.md
````

Checks enabled by building with these flags:

```diff
diff --git a/build/args/all.gn b/build/args/all.gn
index 45939f456f..1934854c67 100644
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -53,8 +53,11 @@ use_qt6 = false
 
 # https://chromium.googlesource.com/chromium/src/+/main/docs/dangling_ptr.md
 # TODO(vertedinde): hunt down dangling pointers on Linux
-enable_dangling_raw_ptr_checks = false
-enable_dangling_raw_ptr_feature_flag = false
+is_debug = true
+enable_dangling_raw_ptr_checks = true
+enable_dangling_raw_ptr_feature_flag = true
+enable_backup_ref_ptr_support = true
+enable_backup_ref_ptr_feature_flag = true
```

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.