### PR TITLE
ci: make src-cache upload atomic

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -191,19 +191,31 @@ runs:
       # only permits .tar/.tgz so we keep the extension and decode on restore.
       tar -cf - src | zstd -T0 --long=30 -f -o $CACHE_FILE
       echo "Compressed src to $(du -sh $CACHE_FILE | cut -f1 -d' ')"
-      cp ./$CACHE_FILE $CACHE_DRIVE/
   - name: Persist Src Cache
     if: ${{ steps.check-cache.outputs.cache_exists == 'false' && inputs.use-cache == 'true' }}
     shell: bash
     run: |
       final_cache_path=$CACHE_DRIVE/$CACHE_FILE
+      # Upload to a run-unique temp name first so concurrent readers never
+      # observe a partially-written file, and an interrupted copy can't leave
+      # a truncated file at the final path. Orphaned temp files get swept by
+      # the clean-orphaned-cache-uploads workflow.
+      tmp_cache_path=$final_cache_path.upload-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+      echo "Uploading to temp path: $tmp_cache_path"
+      cp ./$CACHE_FILE $tmp_cache_path
+
       echo "Using cache key: $DEPSHASH"
-      echo "Checking path: $final_cache_path"
+      if [ -f "$final_cache_path" ]; then
+        echo "Cache already persisted at $final_cache_path by a concurrent run; discarding ours"
+        rm -f $tmp_cache_path
+      else
+        mv -f $tmp_cache_path $final_cache_path
+        echo "Cache key persisted in $final_cache_path"
+      fi
+
       if [ ! -f "$final_cache_path" ]; then
         echo "Cache key not found"
         exit 1
-      else
-        echo "Cache key persisted in $final_cache_path"
       fi
   - name: Wait for active SSH sessions
     shell: bash

--- a/.github/workflows/clean-orphaned-cache-uploads.yml
+++ b/.github/workflows/clean-orphaned-cache-uploads.yml
@@ -1,0 +1,32 @@
+name: Clean Orphaned Cache Uploads
+
+# Description:
+# Sweeps orphaned in-flight upload temp files left on the src-cache volumes
+# by checkout/action.yml when its cp-to-share step dies before the rename.
+# A successful upload finishes in minutes, so anything older than 4h is dead.
+
+on:
+  schedule:
+    - cron: "0 */4 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  clean-orphaned-uploads:
+    if: github.repository == 'electron/electron'
+    runs-on: electron-arc-centralus-linux-amd64-32core
+    permissions:
+      contents: read
+    container:
+      image: ghcr.io/electron/build:bc2f48b2415a670de18d13605b1cf0eb5fdbaae1
+      options: --user root
+      volumes:
+        - /mnt/cross-instance-cache:/mnt/cross-instance-cache
+        - /mnt/win-cache:/mnt/win-cache
+    steps:
+    - name: Remove Orphaned Upload Temp Files
+      shell: bash
+      run: |
+        find /mnt/cross-instance-cache -maxdepth 1 -type f -name '*.tar.upload-*' -mmin +240 -print -delete
+        find /mnt/win-cache -maxdepth 1 -type f -name '*.tar.upload-*' -mmin +240 -print -delete


### PR DESCRIPTION
The checkout action `cp`s the ~6 GB zstd archive directly to its final path on the cache share. That copy is non-atomic, so:

- a reader that races it sees a partial file and fails with zstd `Read error (39): premature end`,
- if the `cp` is interrupted, the truncated file is left at the final path; the existence check then treats it as a valid cache and no later run ever repairs it, and
- two checkout runs with the same DEPSHASH can both pass the early existence check and `cp` to the same destination concurrently — the second open truncates the file while the first is still writing, leaving a corrupt archive at the final path.

This uploads to a run-unique `*.tar.upload-<run_id>-<attempt>` temp name on the share and `mv`s to the final path (atomic, same filesystem). If the final file already exists by then, a concurrent run won and we discard our temp instead.

A new `clean-orphaned-cache-uploads` workflow runs every 4 hours to remove any `*.tar.upload-*` files older than 4 h (i.e. uploads that died mid-copy).

Notes: none