### PR TITLE
test: add window dialog spec helper

### DIFF
--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -285,12 +285,24 @@ DialogResult ShowTaskDialogUTF8(const MessageBoxSettings& settings,
 }  // namespace
 
 int ShowMessageBoxSync(const MessageBoxSettings& settings) {
-  gfx::AcceleratedWidget parent_widget =
+  const gfx::AcceleratedWidget parent_widget =
       settings.parent_window
           ? static_cast<electron::NativeWindowViews*>(settings.parent_window)
                 ->GetAcceleratedWidget()
           : nullptr;
-  DialogResult result = ShowTaskDialogUTF8(settings, parent_widget, nullptr);
+  const HWND focused_window = ::GetFocus();
+  const bool restore_focus = parent_widget && focused_window &&
+                             (focused_window == parent_widget ||
+                              ::IsChild(parent_widget, focused_window));
+
+  const DialogResult result =
+      ShowTaskDialogUTF8(settings, parent_widget, nullptr);
+
+  if (restore_focus && ::IsWindow(parent_widget)) {
+    ::SetForegroundWindow(parent_widget);
+    ::SetFocus(::IsWindow(focused_window) ? focused_window : parent_widget);
+  }
+
   return result.button_id;
 }
 

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain, webContents, session, app, BrowserView, WebContents, BaseWindow, WebContentsView } from 'electron/main';
+import { BrowserWindow, ipcMain, webContents, session, app, BrowserView, WebContents, BaseWindow, WebContentsView, dialog } from 'electron/main';
 
 import { assert, expect } from 'chai';
 
@@ -162,6 +162,48 @@ describe('webContents module', () => {
       const wait = once(w, 'closed');
       w.close();
       await wait;
+    });
+
+    ifit(process.platform === 'win32' && !process.env.ELECTRON_SKIP_NATIVE_MODULE_TESTS)('restores tab focus after a synchronous message box prevents unload', async () => {
+      const dialogHelper = require('@electron-ci/dialog-helper');
+      const w = new BrowserWindow({
+        alwaysOnTop: true,
+        show: true,
+        webPreferences: {
+          contextIsolation: false,
+          nodeIntegration: true
+        }
+      });
+      const dialogTitle = `beforeunload-sync-focus-${process.pid}-${Date.now()}`;
+
+      w.webContents.once('will-prevent-unload', event => {
+        event.preventDefault();
+        dialog.showMessageBoxSync(w, {
+          buttons: ['OK'],
+          message: 'Close prevented',
+          title: dialogTitle
+        });
+      });
+
+      await w.loadFile(path.join(__dirname, 'fixtures', 'api', 'beforeunload-focus-loop.html'));
+      w.focus();
+      await waitUntil(() => w.isFocused());
+
+      expect(dialogHelper.clickMessageBoxButtonAndSendTabLater(
+        w.getNativeWindowHandle(), 0, 250)).to.be.true();
+
+      const focusChange = once(ipcMain, 'focus-changed');
+
+      w.close();
+
+      const [, focusedElementId] = await Promise.race([
+        focusChange,
+        setTimeout(3000).then(() => {
+          throw new Error('Timed out waiting for focus to return to the window after closing the sync message box');
+        })
+      ]);
+
+      expect(focusedElementId).to.equal('BUTTON-element-1');
     });
 
     it('fails loading a subsequent page after beforeunload is not prevented', async () => {

--- a/spec/fixtures/api/beforeunload-focus-loop.html
+++ b/spec/fixtures/api/beforeunload-focus-loop.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script>
+    const { ipcRenderer } = require('electron')
+
+    let unloadPrevented = false
+
+    function handleFocusChange(event) {
+      if (event.target.tagName === 'BUTTON') {
+        ipcRenderer.send('focus-changed', `${event.target.tagName}-${event.target.id}`)
+      }
+    }
+
+    addEventListener('focus', handleFocusChange, true)
+
+    window.onbeforeunload = function () {
+      if (!unloadPrevented) {
+        unloadPrevented = true
+        return false
+      }
+    }
+  </script>
+</head>
+<body>
+  <button id="element-1">Button 1</button>
+  <button id="element-2">Button 2</button>
+</body>
+</html>

--- a/spec/fixtures/native-addon/dialog-helper/binding.gyp
+++ b/spec/fixtures/native-addon/dialog-helper/binding.gyp
@@ -2,10 +2,12 @@
   'targets': [
     {
       'target_name': 'dialog_helper',
+      'sources': [
+        'src/main.cc',
+      ],
       'conditions': [
         ['OS=="mac"', {
-          'sources': [
-            'src/main.cc',
+          'sources+': [
             'src/dialog_helper_mac.mm',
           ],
           'libraries': [
@@ -14,7 +16,13 @@
           'xcode_settings': {
             'OTHER_CFLAGS': ['-fobjc-arc'],
           },
-        }, {
+        }],
+        ['OS=="win"', {
+          'sources+': [
+            'src/dialog_helper_win.cc',
+          ],
+        }],
+        ['OS!="mac" and OS!="win"', {
           'type': 'none',
         }],
       ],

--- a/spec/fixtures/native-addon/dialog-helper/src/dialog_helper.h
+++ b/spec/fixtures/native-addon/dialog-helper/src/dialog_helper.h
@@ -21,9 +21,9 @@ struct DialogInfo {
   bool checkbox_checked = false;
 
   // File dialog properties (open/save panels)
-  std::string prompt;        // Button label (NSSavePanel prompt)
-  std::string panel_message; // Panel message text (NSSavePanel message)
-  std::string directory;     // Current directory URL path
+  std::string prompt;         // Button label (NSSavePanel prompt)
+  std::string panel_message;  // Panel message text (NSSavePanel message)
+  std::string directory;      // Current directory URL path
 
   // NSSavePanel-specific properties
   std::string name_field_label;  // Label for the name field
@@ -42,26 +42,35 @@ struct DialogInfo {
   bool can_create_directories = false;
 };
 
-// Get information about the sheet dialog attached to the window identified
-// by the given native handle buffer (NSView* on macOS).
+// Get information about the dialog attached to the window identified by the
+// given native handle buffer (NSView* on macOS, HWND on Windows).
 DialogInfo GetDialogInfo(char* handle, size_t size);
 
-// Click a button at the given index on an NSAlert sheet attached to the window.
-// Returns true if a message box was found and the button was clicked.
+// Click a button at the given index on a message box dialog attached to the
+// window. Returns true if a message box was found and the button was clicked.
 bool ClickMessageBoxButton(char* handle, size_t size, int button_index);
 
-// Toggle the checkbox (suppression button) on an NSAlert sheet.
+// Toggle the checkbox (suppression button) on a message box dialog.
 // Returns true if a checkbox was found and clicked.
 bool ClickCheckbox(char* handle, size_t size);
 
-// Cancel the file dialog (NSOpenPanel/NSSavePanel) sheet attached to the window.
+// Cancel the file dialog (open/save) attached to the window.
 // Returns true if a file dialog was found and cancelled.
 bool CancelFileDialog(char* handle, size_t size);
 
-// Accept the file dialog sheet attached to the window.
+// Accept the file dialog attached to the window.
 // For save dialogs, |filename| is set in the name field before accepting.
 // Returns true if a file dialog was found and accepted.
 bool AcceptFileDialog(char* handle, size_t size, const std::string& filename);
+
+// Starts a background task that waits for a message box attached to the given
+// window, clicks the button at |button_index|, waits for the dialog to close,
+// and then sends a Tab key to the active window after |post_close_delay_ms|.
+// Returns true if the automation task was started.
+bool ClickMessageBoxButtonAndSendTabLater(char* handle,
+                                          size_t size,
+                                          int button_index,
+                                          int post_close_delay_ms);
 
 }  // namespace dialog_helper
 

--- a/spec/fixtures/native-addon/dialog-helper/src/dialog_helper_mac.mm
+++ b/spec/fixtures/native-addon/dialog-helper/src/dialog_helper_mac.mm
@@ -47,7 +47,8 @@ DialogInfo GetDialogInfo(char* handle, size_t size) {
     info.allows_multiple_selection = [panel allowsMultipleSelection];
     info.shows_hidden_files = [panel showsHiddenFiles];
     info.resolves_aliases = [panel resolvesAliases];
-    info.treats_packages_as_directories = [panel treatsFilePackagesAsDirectories];
+    info.treats_packages_as_directories =
+        [panel treatsFilePackagesAsDirectories];
     info.can_create_directories = [panel canCreateDirectories];
     return info;
   }
@@ -77,8 +78,7 @@ DialogInfo GetDialogInfo(char* handle, size_t size) {
   NSMutableArray<NSButton*>* buttons = [NSMutableArray array];
 
   // Recursively find all NSButton instances in the view hierarchy.
-  NSMutableArray<NSView*>* stack =
-      [NSMutableArray arrayWithObject:contentView];
+  NSMutableArray<NSView*>* stack = [NSMutableArray arrayWithObject:contentView];
   while ([stack count] > 0) {
     NSView* current = [stack lastObject];
     [stack removeLastObject];
@@ -153,8 +153,7 @@ DialogInfo GetDialogInfo(char* handle, size_t size) {
           NSString* title = [btn title];
           if (title && [title length] > 0) {
             info.checkbox_label = [title UTF8String];
-            info.checkbox_checked =
-                ([btn state] == NSControlStateValueOn);
+            info.checkbox_checked = ([btn state] == NSControlStateValueOn);
           }
         }
       }
@@ -180,8 +179,7 @@ bool ClickMessageBoxButton(char* handle, size_t size, int button_index) {
   NSView* contentView = [sheet contentView];
   NSMutableArray<NSButton*>* buttons = [NSMutableArray array];
 
-  NSMutableArray<NSView*>* stack =
-      [NSMutableArray arrayWithObject:contentView];
+  NSMutableArray<NSView*>* stack = [NSMutableArray arrayWithObject:contentView];
   while ([stack count] > 0) {
     NSView* current = [stack lastObject];
     [stack removeLastObject];
@@ -225,8 +223,7 @@ bool ClickCheckbox(char* handle, size_t size) {
   // Find the suppression/checkbox button — it is a non-bordered NSButton,
   // unlike the push buttons which are bordered.
   NSView* contentView = [sheet contentView];
-  NSMutableArray<NSView*>* stack =
-      [NSMutableArray arrayWithObject:contentView];
+  NSMutableArray<NSView*>* stack = [NSMutableArray arrayWithObject:contentView];
   while ([stack count] > 0) {
     NSView* current = [stack lastObject];
     [stack removeLastObject];
@@ -296,8 +293,7 @@ bool AcceptFileDialog(char* handle, size_t size, const std::string& filename) {
   NSView* contentView = [sheet contentView];
 
   // Search for the default button (key equivalent "\r") in the view hierarchy.
-  NSMutableArray<NSView*>* stack =
-      [NSMutableArray arrayWithObject:contentView];
+  NSMutableArray<NSView*>* stack = [NSMutableArray arrayWithObject:contentView];
   while ([stack count] > 0) {
     NSView* current = [stack lastObject];
     [stack removeLastObject];
@@ -315,6 +311,10 @@ bool AcceptFileDialog(char* handle, size_t size, const std::string& filename) {
 
   [NSApp endSheet:sheet returnCode:NSModalResponseOK];
   return true;
+}
+
+bool ClickMessageBoxButtonAndSendTabLater(char*, size_t, int, int) {
+  return false;
 }
 
 }  // namespace dialog_helper

--- a/spec/fixtures/native-addon/dialog-helper/src/dialog_helper_win.cc
+++ b/spec/fixtures/native-addon/dialog-helper/src/dialog_helper_win.cc
@@ -1,0 +1,357 @@
+#include "dialog_helper.h"
+
+#include <windows.h>
+
+#include <algorithm>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace dialog_helper {
+namespace {
+
+constexpr wchar_t kDialogClassName[] = L"#32770";
+constexpr auto kPollInterval = std::chrono::milliseconds(50);
+constexpr auto kDialogTimeout = std::chrono::seconds(5);
+
+HWND GetWindowHandle(char* handle, size_t size) {
+  if (size < sizeof(HWND))
+    return {};
+  return *reinterpret_cast<HWND*>(handle);
+}
+
+std::string WideToUtf8(const std::wstring& input) {
+  if (input.empty())
+    return {};
+
+  const int size = ::WideCharToMultiByte(CP_UTF8, 0, input.c_str(), -1, nullptr,
+                                         0, nullptr, nullptr);
+  if (size <= 1)
+    return {};
+
+  std::string output(size, '\0');
+  const int converted = ::WideCharToMultiByte(
+      CP_UTF8, 0, input.c_str(), -1, output.data(), size, nullptr, nullptr);
+  if (converted <= 1)
+    return {};
+
+  output.resize(converted - 1);
+  return output;
+}
+
+std::wstring GetWindowText(HWND hwnd) {
+  int length = ::GetWindowTextLengthW(hwnd);
+  if (length <= 0)
+    return {};
+
+  std::wstring text(length + 1, L'\0');
+  ::GetWindowTextW(hwnd, text.data(), length + 1);
+  text.resize(length);
+  return text;
+}
+
+bool IsDialogForOwner(HWND hwnd, HWND owner) {
+  if (!::IsWindow(hwnd) || !::IsWindowVisible(hwnd))
+    return false;
+  if (::GetWindow(hwnd, GW_OWNER) != owner)
+    return false;
+
+  wchar_t class_name[32] = {0};
+  if (::GetClassNameW(hwnd, class_name, std::size(class_name)) == 0)
+    return false;
+
+  return wcscmp(class_name, kDialogClassName) == 0;
+}
+
+struct FindDialogState {
+  HWND owner = nullptr;
+  HWND dialog = nullptr;
+};
+
+BOOL CALLBACK FindDialogProc(HWND hwnd, LPARAM lparam) {
+  auto* state = reinterpret_cast<FindDialogState*>(lparam);
+  if (IsDialogForOwner(hwnd, state->owner)) {
+    state->dialog = hwnd;
+    return FALSE;
+  }
+  return TRUE;
+}
+
+HWND FindOwnedDialog(HWND owner) {
+  FindDialogState state{owner, nullptr};
+  ::EnumWindows(&FindDialogProc, reinterpret_cast<LPARAM>(&state));
+  return state.dialog;
+}
+
+bool WaitForOwnedDialog(HWND owner,
+                        std::chrono::milliseconds timeout,
+                        HWND* dialog) {
+  auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (HWND candidate = FindOwnedDialog(owner); candidate != nullptr) {
+      *dialog = candidate;
+      return true;
+    }
+    std::this_thread::sleep_for(kPollInterval);
+  }
+  return false;
+}
+
+bool WaitForWindowToClose(HWND hwnd, std::chrono::milliseconds timeout) {
+  auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (!::IsWindow(hwnd))
+      return true;
+    std::this_thread::sleep_for(kPollInterval);
+  }
+  return !::IsWindow(hwnd);
+}
+
+bool IsButtonControl(HWND hwnd) {
+  wchar_t class_name[16] = {0};
+  if (::GetClassNameW(hwnd, class_name, std::size(class_name)) == 0)
+    return false;
+  return wcscmp(class_name, L"Button") == 0;
+}
+
+bool IsStaticTextControl(HWND hwnd) {
+  wchar_t class_name[16] = {0};
+  if (::GetClassNameW(hwnd, class_name, std::size(class_name)) == 0)
+    return false;
+  return wcscmp(class_name, L"Static") == 0;
+}
+
+bool CompareWindowPositions(HWND left, HWND right) {
+  RECT left_rect;
+  RECT right_rect;
+  ::GetWindowRect(left, &left_rect);
+  ::GetWindowRect(right, &right_rect);
+  if (left_rect.top != right_rect.top)
+    return left_rect.top < right_rect.top;
+  return left_rect.left < right_rect.left;
+}
+
+struct EnumChildWindowsState {
+  std::vector<HWND> buttons;
+};
+
+struct TextControlState {
+  std::vector<HWND> controls;
+};
+
+BOOL CALLBACK CollectButtonsProc(HWND hwnd, LPARAM lparam) {
+  auto* state = reinterpret_cast<EnumChildWindowsState*>(lparam);
+  if (::IsWindowVisible(hwnd) && ::IsWindowEnabled(hwnd) &&
+      IsButtonControl(hwnd)) {
+    LONG style = ::GetWindowLongW(hwnd, GWL_STYLE);
+    if ((style & BS_TYPEMASK) != BS_CHECKBOX &&
+        (style & BS_TYPEMASK) != BS_AUTOCHECKBOX &&
+        (style & BS_TYPEMASK) != BS_3STATE &&
+        (style & BS_TYPEMASK) != BS_AUTO3STATE) {
+      state->buttons.push_back(hwnd);
+    }
+  }
+  return TRUE;
+}
+
+std::vector<HWND> GetMessageBoxButtons(HWND dialog) {
+  EnumChildWindowsState state;
+  ::EnumChildWindows(dialog, &CollectButtonsProc,
+                     reinterpret_cast<LPARAM>(&state));
+
+  std::sort(state.buttons.begin(), state.buttons.end(), CompareWindowPositions);
+
+  return state.buttons;
+}
+
+BOOL CALLBACK CollectStaticTextProc(HWND hwnd, LPARAM lparam) {
+  if (!::IsWindowVisible(hwnd) || !IsStaticTextControl(hwnd))
+    return TRUE;
+
+  std::wstring text = GetWindowText(hwnd);
+  if (text.empty())
+    return TRUE;
+
+  auto* state = reinterpret_cast<TextControlState*>(lparam);
+  state->controls.push_back(hwnd);
+  return TRUE;
+}
+
+std::vector<HWND> GetMessageBoxTextControls(HWND dialog) {
+  TextControlState state;
+  ::EnumChildWindows(dialog, &CollectStaticTextProc,
+                     reinterpret_cast<LPARAM>(&state));
+  std::sort(state.controls.begin(), state.controls.end(),
+            CompareWindowPositions);
+  return state.controls;
+}
+
+void PopulateMessageBoxText(HWND dialog, DialogInfo* info) {
+  std::vector<HWND> text_controls = GetMessageBoxTextControls(dialog);
+  if (text_controls.empty())
+    return;
+
+  info->message = WideToUtf8(GetWindowText(text_controls[0]));
+  if (text_controls.size() > 1)
+    info->detail = WideToUtf8(GetWindowText(text_controls[1]));
+}
+
+// NOTE: This only escapes \\ and ". Control characters (\n, \r, \t, etc.)
+// are passed through unescaped, which is technically invalid JSON.
+// But that's OK here in a test environment where control the label text.
+std::string EscapeJsonString(const std::string& input) {
+  std::string escaped;
+  escaped.reserve(input.size());
+  for (const char ch : input) {
+    if (ch == '\\' || ch == '"')
+      escaped.push_back('\\');
+    escaped.push_back(ch);
+  }
+  return escaped;
+}
+
+std::string ButtonsToJson(const std::vector<HWND>& buttons) {
+  std::string json = "[";
+  for (size_t i = 0; i < buttons.size(); ++i) {
+    if (i > 0)
+      json += ',';
+    json += '"';
+    json += EscapeJsonString(WideToUtf8(GetWindowText(buttons[i])));
+    json += '"';
+  }
+  json += "]";
+  return json;
+}
+
+bool ClickButtonByIndex(HWND dialog, int button_index) {
+  std::vector<HWND> buttons = GetMessageBoxButtons(dialog);
+  if (button_index < 0 || static_cast<size_t>(button_index) >= buttons.size())
+    return false;
+
+  ::SendMessageW(buttons[button_index], BM_CLICK, 0, 0);
+  return true;
+}
+
+bool FocusWindow(HWND hwnd) {
+  if (!::IsWindow(hwnd))
+    return false;
+
+  if (::IsIconic(hwnd))
+    ::ShowWindow(hwnd, SW_RESTORE);
+
+  const HWND foreground_window = ::GetForegroundWindow();
+  const DWORD foreground_thread =
+      foreground_window == nullptr
+          ? 0
+          : ::GetWindowThreadProcessId(foreground_window, nullptr);
+  const DWORD current_thread = ::GetCurrentThreadId();
+  const bool attached =
+      foreground_thread != 0 && foreground_thread != current_thread &&
+      ::AttachThreadInput(current_thread, foreground_thread, TRUE) != FALSE;
+
+  ::BringWindowToTop(hwnd);
+  ::SetActiveWindow(hwnd);
+  ::SetForegroundWindow(hwnd);
+
+  if (attached) {
+    ::AttachThreadInput(current_thread, foreground_thread, FALSE);
+  }
+
+  return ::GetForegroundWindow() == hwnd;
+}
+
+// NOTE: SendInput delivers the keystroke to the foreground window, so make
+// sure the target window is re-activated first.
+bool SendTabKey(HWND hwnd) {
+  if (!FocusWindow(hwnd))
+    return false;
+
+  INPUT inputs[2] = {};
+
+  inputs[0].type = INPUT_KEYBOARD;
+  inputs[0].ki.wVk = VK_TAB;
+
+  inputs[1].type = INPUT_KEYBOARD;
+  inputs[1].ki.wVk = VK_TAB;
+  inputs[1].ki.dwFlags = KEYEVENTF_KEYUP;
+
+  return ::SendInput(2, inputs, sizeof(INPUT)) == 2;
+}
+
+}  // namespace
+
+DialogInfo GetDialogInfo(char* handle, size_t size) {
+  DialogInfo info;
+  info.type = "none";
+
+  const HWND owner = GetWindowHandle(handle, size);
+  if (!::IsWindow(owner))
+    return info;
+
+  const HWND dialog = FindOwnedDialog(owner);
+  if (dialog == nullptr)
+    return info;
+
+  info.type = "message-box";
+  std::vector<HWND> buttons = GetMessageBoxButtons(dialog);
+  info.buttons = ButtonsToJson(buttons);
+  PopulateMessageBoxText(dialog, &info);
+  return info;
+}
+
+bool ClickMessageBoxButton(char* handle, size_t size, int button_index) {
+  HWND owner = GetWindowHandle(handle, size);
+  if (!::IsWindow(owner))
+    return false;
+
+  HWND dialog = FindOwnedDialog(owner);
+  if (dialog == nullptr)
+    return false;
+
+  return ClickButtonByIndex(dialog, button_index);
+}
+
+bool ClickCheckbox(char*, size_t) {
+  return false;
+}
+
+bool CancelFileDialog(char*, size_t) {
+  return false;
+}
+
+bool AcceptFileDialog(char*, size_t, const std::string&) {
+  return false;
+}
+
+bool ClickMessageBoxButtonAndSendTabLater(char* handle,
+                                          size_t size,
+                                          int button_index,
+                                          int post_close_delay_ms) {
+  HWND owner = GetWindowHandle(handle, size);
+  if (!::IsWindow(owner))
+    return false;
+
+  // Fire-and-forget: the thread polls for the dialog, clicks, waits for it
+  // to close, then sends a Tab key. Detached because there is no teardown
+  // requirement — the thread will exit on its own after the dialog closes or
+  // the timeout expires.
+  std::thread([owner, button_index, post_close_delay_ms]() {
+    HWND dialog = nullptr;
+    if (!WaitForOwnedDialog(owner, kDialogTimeout, &dialog))
+      return;
+    if (!ClickButtonByIndex(dialog, button_index))
+      return;
+    if (!WaitForWindowToClose(dialog, kDialogTimeout))
+      return;
+    if (post_close_delay_ms > 0) {
+      std::this_thread::sleep_for(
+          std::chrono::milliseconds(post_close_delay_ms));
+    }
+    SendTabKey(owner);
+  }).detach();
+
+  return true;
+}
+
+}  // namespace dialog_helper

--- a/spec/fixtures/native-addon/dialog-helper/src/main.cc
+++ b/spec/fixtures/native-addon/dialog-helper/src/main.cc
@@ -8,17 +8,27 @@
 namespace {
 
 // Helper: extract (char* data, size_t length) from the first Buffer argument.
-bool GetHandleArg(napi_env env, napi_callback_info info, size_t expected_argc,
-                  napi_value* args, char** data, size_t* length) {
-  size_t argc = expected_argc;
+bool GetHandleArg(napi_env env,
+                  napi_callback_info info,
+                  size_t required_argc,
+                  size_t argc_capacity,
+                  napi_value* args,
+                  char** data,
+                  size_t* length) {
+  size_t argc = argc_capacity;
   napi_status status = napi_get_cb_info(env, info, &argc, args, NULL, NULL);
-  if (status != napi_ok || argc < 1)
+  if (status != napi_ok)
     return false;
+  if (argc < required_argc) {
+    napi_throw_error(env, NULL, "Insufficient number of arguments");
+    return false;
+  }
 
   bool is_buffer;
   status = napi_is_buffer(env, args[0], &is_buffer);
   if (status != napi_ok || !is_buffer) {
-    napi_throw_error(env, NULL, "First argument must be a Buffer (native window handle)");
+    napi_throw_error(env, NULL,
+                     "First argument must be a Buffer (native window handle)");
     return false;
   }
 
@@ -30,7 +40,7 @@ napi_value GetDialogInfo(napi_env env, napi_callback_info info) {
   napi_value args[1];
   char* data;
   size_t length;
-  if (!GetHandleArg(env, info, 1, args, &data, &length))
+  if (!GetHandleArg(env, info, 1, 1, args, &data, &length))
     return NULL;
 
   dialog_helper::DialogInfo di = dialog_helper::GetDialogInfo(data, length);
@@ -44,15 +54,18 @@ napi_value GetDialogInfo(napi_env env, napi_callback_info info) {
   napi_set_named_property(env, result, "type", type_val);
 
   napi_value buttons_val;
-  napi_create_string_utf8(env, di.buttons.c_str(), di.buttons.size(), &buttons_val);
+  napi_create_string_utf8(env, di.buttons.c_str(), di.buttons.size(),
+                          &buttons_val);
   napi_set_named_property(env, result, "buttons", buttons_val);
 
   napi_value message_val;
-  napi_create_string_utf8(env, di.message.c_str(), di.message.size(), &message_val);
+  napi_create_string_utf8(env, di.message.c_str(), di.message.size(),
+                          &message_val);
   napi_set_named_property(env, result, "message", message_val);
 
   napi_value detail_val;
-  napi_create_string_utf8(env, di.detail.c_str(), di.detail.size(), &detail_val);
+  napi_create_string_utf8(env, di.detail.c_str(), di.detail.size(),
+                          &detail_val);
   napi_set_named_property(env, result, "detail", detail_val);
 
   napi_value checkbox_label_val;
@@ -66,7 +79,8 @@ napi_value GetDialogInfo(napi_env env, napi_callback_info info) {
 
   // File dialog properties
   napi_value prompt_val;
-  napi_create_string_utf8(env, di.prompt.c_str(), di.prompt.size(), &prompt_val);
+  napi_create_string_utf8(env, di.prompt.c_str(), di.prompt.size(),
+                          &prompt_val);
   napi_set_named_property(env, result, "prompt", prompt_val);
 
   napi_value panel_message_val;
@@ -119,7 +133,8 @@ napi_value GetDialogInfo(napi_env env, napi_callback_info info) {
   napi_set_named_property(env, result, "resolvesAliases", resolves_aliases_val);
 
   napi_value treats_packages_val;
-  napi_get_boolean(env, di.treats_packages_as_directories, &treats_packages_val);
+  napi_get_boolean(env, di.treats_packages_as_directories,
+                   &treats_packages_val);
   napi_set_named_property(env, result, "treatsPackagesAsDirectories",
                           treats_packages_val);
 
@@ -135,13 +150,14 @@ napi_value ClickMessageBoxButton(napi_env env, napi_callback_info info) {
   napi_value args[2];
   char* data;
   size_t length;
-  if (!GetHandleArg(env, info, 2, args, &data, &length))
+  if (!GetHandleArg(env, info, 2, 2, args, &data, &length))
     return NULL;
 
   int32_t button_index;
   napi_status status = napi_get_value_int32(env, args[1], &button_index);
   if (status != napi_ok) {
-    napi_throw_error(env, NULL, "Second argument must be a number (button index)");
+    napi_throw_error(env, NULL,
+                     "Second argument must be a number (button index)");
     return NULL;
   }
 
@@ -156,7 +172,7 @@ napi_value ClickCheckbox(napi_env env, napi_callback_info info) {
   napi_value args[1];
   char* data;
   size_t length;
-  if (!GetHandleArg(env, info, 1, args, &data, &length))
+  if (!GetHandleArg(env, info, 1, 1, args, &data, &length))
     return NULL;
 
   bool ok = dialog_helper::ClickCheckbox(data, length);
@@ -170,7 +186,7 @@ napi_value CancelFileDialog(napi_env env, napi_callback_info info) {
   napi_value args[1];
   char* data;
   size_t length;
-  if (!GetHandleArg(env, info, 1, args, &data, &length))
+  if (!GetHandleArg(env, info, 1, 1, args, &data, &length))
     return NULL;
 
   bool ok = dialog_helper::CancelFileDialog(data, length);
@@ -184,7 +200,7 @@ napi_value AcceptFileDialog(napi_env env, napi_callback_info info) {
   napi_value args[2];
   char* data;
   size_t length;
-  if (!GetHandleArg(env, info, 2, args, &data, &length))
+  if (!GetHandleArg(env, info, 1, 2, args, &data, &length))
     return NULL;
 
   std::string filename;
@@ -206,23 +222,57 @@ napi_value AcceptFileDialog(napi_env env, napi_callback_info info) {
   return result;
 }
 
+napi_value ClickMessageBoxButtonAndSendTabLater(napi_env env,
+                                                napi_callback_info info) {
+  napi_value args[3];
+  char* data;
+  size_t length;
+  if (!GetHandleArg(env, info, 3, 3, args, &data, &length))
+    return NULL;
+
+  int32_t button_index;
+  napi_status status = napi_get_value_int32(env, args[1], &button_index);
+  if (status != napi_ok) {
+    napi_throw_error(env, NULL,
+                     "Second argument must be a number (button index)");
+    return NULL;
+  }
+
+  int32_t post_close_delay_ms;
+  status = napi_get_value_int32(env, args[2], &post_close_delay_ms);
+  if (status != napi_ok) {
+    napi_throw_error(
+        env, NULL, "Third argument must be a number (post-close delay in ms)");
+    return NULL;
+  }
+
+  bool ok = dialog_helper::ClickMessageBoxButtonAndSendTabLater(
+      data, length, button_index, post_close_delay_ms);
+
+  napi_value result;
+  napi_get_boolean(env, ok, &result);
+  return result;
+}
+
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-      {"getDialogInfo", NULL, GetDialogInfo, NULL, NULL, NULL,
-       napi_enumerable, NULL},
+      {"getDialogInfo", NULL, GetDialogInfo, NULL, NULL, NULL, napi_enumerable,
+       NULL},
       {"clickMessageBoxButton", NULL, ClickMessageBoxButton, NULL, NULL, NULL,
        napi_enumerable, NULL},
-      {"clickCheckbox", NULL, ClickCheckbox, NULL, NULL, NULL,
-       napi_enumerable, NULL},
+      {"clickCheckbox", NULL, ClickCheckbox, NULL, NULL, NULL, napi_enumerable,
+       NULL},
       {"cancelFileDialog", NULL, CancelFileDialog, NULL, NULL, NULL,
        napi_enumerable, NULL},
       {"acceptFileDialog", NULL, AcceptFileDialog, NULL, NULL, NULL,
        napi_enumerable, NULL},
+      {"clickMessageBoxButtonAndSendTabLater", NULL,
+       ClickMessageBoxButtonAndSendTabLater, NULL, NULL, NULL, napi_enumerable,
+       NULL},
   };
 
-  napi_define_properties(env, exports,
-                         sizeof(descriptors) / sizeof(*descriptors),
-                         descriptors);
+  napi_define_properties(
+      env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors);
   return exports;
 }
 


### PR DESCRIPTION
#### Description of Change

- Add a Windows-based dialog helper for specs.
- Add a spec to test for focus after dismissing a sync messagebox. I think this _should_ fail CI right now. This is the same issue described in #50647 -- I want to test the regression test before looking at a fix.

#### Checklist

- [x] PR description included
- [ ] I have built and tested this PR
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none