### PR TITLE
ci: don't set needs review status on PR that isn't open

### DIFF
--- a/.github/workflows/pr-triage-automation.yml
+++ b/.github/workflows/pr-triage-automation.yml
@@ -17,11 +17,13 @@ jobs:
     name: Set status to Needs Review
     if: >-
       (github.event_name == 'pull_request_target'
+        && github.event.pull_request.state == 'open'
         && github.event.pull_request.draft != true
         && !contains(github.event.pull_request.labels.*.name, 'wip ⚒')
         && (github.event.action == 'synchronize' || github.event.action == 'review_requested'))
       || (github.event_name == 'issue_comment'
           && github.event.issue.pull_request
+          && github.event.issue.state == 'open'
           && !contains(github.event.issue.labels.*.name, 'wip ⚒')
           && github.event.comment.user.login == github.event.issue.user.login)
     runs-on: ubuntu-slim


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

NOTE: PRS submitted without this template will be automatically closed.
-->

The PR triage board archives items when a PR is merged/closed, and attempting to set the status field on an archived item results in an error: https://github.com/electron/electron/actions/runs/24054308032/job/70156989680

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
