### PR TITLE
refactor: remove use of deprecated class base::MemoryPressureListener

### DIFF
--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include "base/containers/span.h"
-#include "base/memory/memory_pressure_listener.h"
+#include "base/memory/memory_pressure_listener_registry.h"
 #include "base/no_destructor.h"
 #include "base/strings/strcat.h"
 #include "base/strings/utf_string_conversions.h"
@@ -810,7 +810,7 @@ class WebFrameRenderer final
 
   void ClearCache(v8::Isolate* isolate) {
     blink::WebCache::Clear();
-    base::MemoryPressureListener::NotifyMemoryPressure(
+    base::MemoryPressureListenerRegistry::NotifyMemoryPressure(
         base::MEMORY_PRESSURE_LEVEL_CRITICAL);
   }
 


### PR DESCRIPTION
#### Description of Change

A pretty straightforward change. `base::MemoryPressureListener` was marked as deprecated in  https://chromium-review.googlesource.com/c/chromium/src/+/7576817, so use non-deprecated API instead:

```diff
- base::MemoryPressureListener::NotifyMemoryPressure(foo);
+ base::MemoryPressureListenerRegistry::NotifyMemoryPressure(foo);
```

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.