### PR TITLE
feat: remove Electron links from default help menu

### DIFF
--- a/lib/browser/default-menu.ts
+++ b/lib/browser/default-menu.ts
@@ -1,5 +1,4 @@
-import { shell } from 'electron/common';
-import { app, Menu } from 'electron/main';
+import { Menu } from 'electron/main';
 
 const isMac = process.platform === 'darwin';
 
@@ -12,47 +11,13 @@ export const setApplicationMenuWasSet = () => {
 export const setDefaultApplicationMenu = () => {
   if (applicationMenuWasSet) return;
 
-  const helpMenu: Electron.MenuItemConstructorOptions = {
-    role: 'help',
-    submenu: app.isPackaged
-      ? []
-      : [
-          {
-            label: 'Learn More',
-            click: async () => {
-              await shell.openExternal('https://electronjs.org');
-            }
-          },
-          {
-            label: 'Documentation',
-            click: async () => {
-              const version = process.versions.electron;
-              await shell.openExternal(`https://github.com/electron/electron/tree/v${version}/docs#readme`);
-            }
-          },
-          {
-            label: 'Community Discussions',
-            click: async () => {
-              await shell.openExternal('https://discord.gg/electronjs');
-            }
-          },
-          {
-            label: 'Search Issues',
-            click: async () => {
-              await shell.openExternal('https://github.com/electron/electron/issues');
-            }
-          }
-        ]
-  };
-
   const macAppMenu: Electron.MenuItemConstructorOptions = { role: 'appMenu' };
   const template: Electron.MenuItemConstructorOptions[] = [
     ...(isMac ? [macAppMenu] : []),
     { role: 'fileMenu' },
     { role: 'editMenu' },
     { role: 'viewMenu' },
-    { role: 'windowMenu' },
-    helpMenu
+    { role: 'windowMenu' }
   ];
 
   const menu = Menu.buildFromTemplate(template);


### PR DESCRIPTION
## Summary

The default help menu included links to Electron-specific resources (documentation, community discussions, and search). These links may not be relevant to end-user applications built with Electron.

## Changes

- Remove the `helpMenu` from the default application menu template  
- Remove unused `shell` import (only used for `openExternal` in help menu)
- Remove unused `app` import (only used for `isPackaged` check in help menu)

## Before / After

Before: Default menu had a "Help" submenu with electronjs.org links  
After: Default menu only contains file/edit/view/window menus (+ appMenu on macOS)

Fixes #50629