### PR TITLE
fix: keep track of native dialog boxes and restore focus when they are closed

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -192,13 +192,23 @@ void BrowserWindow::OnWindowFocus() {
 
 void BrowserWindow::OnNativeDialogWillOpen() {
 #if BUILDFLAG(IS_WIN)
-  if (api_web_contents_ && window()->IsVisible() && window()->IsFocused())
+  ++native_dialog_depth_;
+  if (native_dialog_depth_ == 1 && api_web_contents_ && window()->IsVisible() &&
+      window()->IsFocused()) {
     web_contents()->StoreFocus();
+  }
 #endif
 }
 
 void BrowserWindow::OnNativeDialogClosed() {
 #if BUILDFLAG(IS_WIN)
+  if (native_dialog_depth_ == 0)
+    return;
+  --native_dialog_depth_;
+
+  if (native_dialog_depth_ != 0)
+    return;
+
   // Some native modal dialogs do not trigger a full blur/focus cycle on
   // Windows, so restore the renderer focus explicitly when the dialog closes.
   if (window()->IsVisible() && window()->IsFocused())

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -172,17 +172,38 @@ void BrowserWindow::OnWindowBlur() {
   BaseWindow::OnWindowBlur();
 }
 
+void BrowserWindow::RestoreWebContentsFocus() {
+  if (!api_web_contents_)
+    return;
+
+  web_contents()->RestoreFocus();
+#if !BUILDFLAG(IS_MAC)
+  if (!api_web_contents_->IsDevToolsOpened())
+    web_contents()->Focus();
+#endif
+}
+
 void BrowserWindow::OnWindowFocus() {
   // focus/blur events might be emitted while closing window.
-  if (api_web_contents_) {
-    web_contents()->RestoreFocus();
-#if !BUILDFLAG(IS_MAC)
-    if (!api_web_contents_->IsDevToolsOpened())
-      web_contents()->Focus();
-#endif
-  }
+  RestoreWebContentsFocus();
 
   BaseWindow::OnWindowFocus();
+}
+
+void BrowserWindow::OnNativeDialogWillOpen() {
+#if BUILDFLAG(IS_WIN)
+  if (api_web_contents_ && window()->IsVisible() && window()->IsFocused())
+    web_contents()->StoreFocus();
+#endif
+}
+
+void BrowserWindow::OnNativeDialogClosed() {
+#if BUILDFLAG(IS_WIN)
+  // Some native modal dialogs do not trigger a full blur/focus cycle on
+  // Windows, so restore the renderer focus explicitly when the dialog closes.
+  if (window()->IsVisible() && window()->IsFocused())
+    RestoreWebContentsFocus();
+#endif
 }
 
 void BrowserWindow::OnWindowIsKeyChanged(bool is_key) {

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -53,6 +53,8 @@ class BrowserWindow : public BaseWindow,
   // NativeWindowObserver:
   void RequestPreferredWidth(int* width) override;
   void OnCloseButtonClicked(bool* prevent_default) override;
+  void OnNativeDialogWillOpen() override;
+  void OnNativeDialogClosed() override;
   void OnWindowIsKeyChanged(bool is_key) override;
   void UpdateWindowControlsOverlay(const gfx::Rect& bounding_rect) override;
 
@@ -77,6 +79,7 @@ class BrowserWindow : public BaseWindow,
 
  private:
   // Helpers.
+  void RestoreWebContentsFocus();
 
   v8::Global<v8::Value> web_contents_;
   bool web_contents_shown_ = false;

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "base/cancelable_callback.h"
+#include "build/build_config.h"
 #include "shell/browser/api/electron_api_base_window.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/ui/drag_util.h"
@@ -85,6 +86,9 @@ class BrowserWindow : public BaseWindow,
   bool web_contents_shown_ = false;
   v8::Global<v8::Value> web_contents_view_;
   base::WeakPtr<api::WebContents> api_web_contents_;
+#if BUILDFLAG(IS_WIN)
+  int native_dialog_depth_ = 0;
+#endif
 
   base::WeakPtrFactory<BrowserWindow> weak_factory_{this};
 };

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -542,6 +542,14 @@ void NativeWindow::NotifyWindowFocus() {
   observers_.Notify(&NativeWindowObserver::OnWindowFocus);
 }
 
+void NativeWindow::NotifyNativeDialogWillOpen() {
+  observers_.Notify(&NativeWindowObserver::OnNativeDialogWillOpen);
+}
+
+void NativeWindow::NotifyNativeDialogClosed() {
+  observers_.Notify(&NativeWindowObserver::OnNativeDialogClosed);
+}
+
 void NativeWindow::NotifyWindowIsKeyChanged(bool is_key) {
   observers_.Notify(&NativeWindowObserver::OnWindowIsKeyChanged, is_key);
 }

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -309,6 +309,8 @@ class NativeWindow : public views::WidgetDelegate {
   void NotifyWindowEndSession(const std::vector<std::string>& reasons);
   void NotifyWindowBlur();
   void NotifyWindowFocus();
+  void NotifyNativeDialogWillOpen();
+  void NotifyNativeDialogClosed();
   void NotifyWindowShow();
   void NotifyWindowIsKeyChanged(bool is_key);
   void NotifyWindowHide();

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -63,6 +63,12 @@ class NativeWindowObserver : public base::CheckedObserver {
   // Called when window gains focus.
   virtual void OnWindowFocus() {}
 
+  // Called before a native modal dialog attached to the window is shown.
+  virtual void OnNativeDialogWillOpen() {}
+
+  // Called when a native modal dialog attached to the window has closed.
+  virtual void OnNativeDialogClosed() {}
+
   // Called when window gained or lost key window status.
   virtual void OnWindowIsKeyChanged(bool is_key) {}
 

--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -285,17 +285,23 @@ DialogResult ShowTaskDialogUTF8(const MessageBoxSettings& settings,
 }  // namespace
 
 int ShowMessageBoxSync(const MessageBoxSettings& settings) {
+  if (settings.parent_window)
+    settings.parent_window->NotifyNativeDialogWillOpen();
   gfx::AcceleratedWidget parent_widget =
       settings.parent_window
           ? static_cast<electron::NativeWindowViews*>(settings.parent_window)
                 ->GetAcceleratedWidget()
           : nullptr;
   DialogResult result = ShowTaskDialogUTF8(settings, parent_widget, nullptr);
+  if (settings.parent_window)
+    settings.parent_window->NotifyNativeDialogClosed();
   return result.button_id;
 }
 
 void ShowMessageBox(const MessageBoxSettings& settings,
                     MessageBoxCallback callback) {
+  if (settings.parent_window)
+    settings.parent_window->NotifyNativeDialogWillOpen();
   // The dialog is created in a new thread so we don't know its HWND yet, put
   // kHwndReserve in the dialogs map for now.
   HWND* hwnd = nullptr;
@@ -312,18 +318,20 @@ void ShowMessageBox(const MessageBoxSettings& settings,
           ? static_cast<electron::NativeWindowViews*>(settings.parent_window)
                 ->GetAcceleratedWidget()
           : nullptr;
-  dialog_thread::Run(base::BindOnce(&ShowTaskDialogUTF8, settings,
-                                    parent_widget, base::Unretained(hwnd)),
-                     base::BindOnce(
-                         [](MessageBoxCallback callback, std::optional<int> id,
-                            DialogResult result) {
-                           if (id)
-                             GetDialogsMap().erase(*id);
-                           std::move(callback).Run(
-                               result.button_id,
-                               result.verification_flag_checked);
-                         },
-                         std::move(callback), settings.id));
+  dialog_thread::Run(
+      base::BindOnce(&ShowTaskDialogUTF8, settings, parent_widget,
+                     base::Unretained(hwnd)),
+      base::BindOnce(
+          [](MessageBoxCallback callback, std::optional<int> id,
+             NativeWindow* parent_window, DialogResult result) {
+            if (id)
+              GetDialogsMap().erase(*id);
+            if (parent_window)
+              parent_window->NotifyNativeDialogClosed();
+            std::move(callback).Run(result.button_id,
+                                    result.verification_flag_checked);
+          },
+          std::move(callback), settings.id, settings.parent_window));
 }
 
 void CloseMessageBox(int id) {

--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -285,23 +285,29 @@ DialogResult ShowTaskDialogUTF8(const MessageBoxSettings& settings,
 }  // namespace
 
 int ShowMessageBoxSync(const MessageBoxSettings& settings) {
-  if (settings.parent_window)
-    settings.parent_window->NotifyNativeDialogWillOpen();
+  base::WeakPtr<NativeWindow> parent_window =
+      settings.parent_window ? settings.parent_window->GetWeakPtr()
+                             : base::WeakPtr<NativeWindow>();
+  if (parent_window)
+    parent_window->NotifyNativeDialogWillOpen();
   gfx::AcceleratedWidget parent_widget =
       settings.parent_window
           ? static_cast<electron::NativeWindowViews*>(settings.parent_window)
                 ->GetAcceleratedWidget()
           : nullptr;
   DialogResult result = ShowTaskDialogUTF8(settings, parent_widget, nullptr);
-  if (settings.parent_window)
-    settings.parent_window->NotifyNativeDialogClosed();
+  if (parent_window)
+    parent_window->NotifyNativeDialogClosed();
   return result.button_id;
 }
 
 void ShowMessageBox(const MessageBoxSettings& settings,
                     MessageBoxCallback callback) {
-  if (settings.parent_window)
-    settings.parent_window->NotifyNativeDialogWillOpen();
+  base::WeakPtr<NativeWindow> parent_window =
+      settings.parent_window ? settings.parent_window->GetWeakPtr()
+                             : base::WeakPtr<NativeWindow>();
+  if (parent_window)
+    parent_window->NotifyNativeDialogWillOpen();
   // The dialog is created in a new thread so we don't know its HWND yet, put
   // kHwndReserve in the dialogs map for now.
   HWND* hwnd = nullptr;
@@ -323,7 +329,7 @@ void ShowMessageBox(const MessageBoxSettings& settings,
                      base::Unretained(hwnd)),
       base::BindOnce(
           [](MessageBoxCallback callback, std::optional<int> id,
-             NativeWindow* parent_window, DialogResult result) {
+             base::WeakPtr<NativeWindow> parent_window, DialogResult result) {
             if (id)
               GetDialogsMap().erase(*id);
             if (parent_window)
@@ -331,7 +337,7 @@ void ShowMessageBox(const MessageBoxSettings& settings,
             std::move(callback).Run(result.button_id,
                                     result.verification_flag_checked);
           },
-          std::move(callback), settings.id, settings.parent_window));
+          std::move(callback), settings.id, std::move(parent_window)));
 }
 
 void CloseMessageBox(int id) {


### PR DESCRIPTION
#### Description of Change

A note: this was primarily written with GPT-5.4 (but after a bit of discussion). I'm totally open to it being the wrong approach.

Resolves #50647
Resolves #19977
Resolves #31917
Resolves #41603

Resolves (maybe) #40212

I do not have a Windows box to test this on, so I'm not sure if this works, but the code passes my initial reading.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] I have built and tested this PR
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed bug on Windows where inputs would not be focused upon returning from a dialog box.
