### PR TITLE
ci: include .obj checksums when calculating object change rate

### DIFF
--- a/script/build-stats.mjs
+++ b/script/build-stats.mjs
@@ -164,9 +164,10 @@ async function main () {
     const currentVersion = getChromiumVersionFromDEPS(depsContent);
 
     // Calculate the SHA256 for each object file under `outDir`
-    const objectFiles = await fs.readdir(outDir, { encoding: 'utf8', recursive: true });
+    const files = await fs.readdir(outDir, { encoding: 'utf8', recursive: true });
+    const objectFiles = files.filter(file => file.endsWith('.o') || file.endsWith('.obj'));
     const checksums = {};
-    for (const file of objectFiles.filter(f => f.endsWith('.o'))) {
+    for (const file of objectFiles) {
       const content = await fs.readFile(resolve(outDir, file));
       checksums[file] = createHash('sha256').update(content).digest('hex');
     }


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

NOTE: PRS submitted without this template will be automatically closed.
-->

Currently getting inaccurate numbers for Windows because `.obj` files weren't being included.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
