### PR TITLE
feat: remove Electron links from default help menu

### DIFF
--- a/lib/browser/default-menu.ts
+++ b/lib/browser/default-menu.ts
@@ -1,5 +1,4 @@
-import { shell } from 'electron/common';
-import { app, Menu } from 'electron/main';
+import { Menu } from 'electron/main';
 
 const isMac = process.platform === 'darwin';
 
@@ -12,47 +11,13 @@ export const setApplicationMenuWasSet = () => {
 export const setDefaultApplicationMenu = () => {
   if (applicationMenuWasSet) return;
 
-  const helpMenu: Electron.MenuItemConstructorOptions = {
-    role: 'help',
-    submenu: app.isPackaged
-      ? []
-      : [
-          {
-            label: 'Learn More',
-            click: async () => {
-              await shell.openExternal('https://electronjs.org');
-            }
-          },
-          {
-            label: 'Documentation',
-            click: async () => {
-              const version = process.versions.electron;
-              await shell.openExternal(`https://github.com/electron/electron/tree/v${version}/docs#readme`);
-            }
-          },
-          {
-            label: 'Community Discussions',
-            click: async () => {
-              await shell.openExternal('https://discord.gg/electronjs');
-            }
-          },
-          {
-            label: 'Search Issues',
-            click: async () => {
-              await shell.openExternal('https://github.com/electron/electron/issues');
-            }
-          }
-        ]
-  };
-
   const macAppMenu: Electron.MenuItemConstructorOptions = { role: 'appMenu' };
   const template: Electron.MenuItemConstructorOptions[] = [
     ...(isMac ? [macAppMenu] : []),
     { role: 'fileMenu' },
     { role: 'editMenu' },
     { role: 'viewMenu' },
-    { role: 'windowMenu' },
-    helpMenu
+    { role: 'windowMenu' }
   ];
 
   const menu = Menu.buildFromTemplate(template);


### PR DESCRIPTION
The default help menu included links to electronjs.org documentation, community discussions, and search functionality. These links are Electron-specific development resources that may not be relevant to end-user applications built with Electron.

Remove the helpMenu from the default application menu template and remove unused imports (shell, app) that were only needed for the help menu functionality.

Fixes #50629

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

NOTE: PRS submitted without this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] I have built and tested this PR
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
