### PR TITLE
chore: iwyu commonly-included headers in shell/

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -77,6 +77,7 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/object_template_builder.h"
+#include "shell/common/gin_helper/promise.h"
 #include "shell/common/language_util.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/options_switches.h"

--- a/shell/browser/api/electron_api_app_mac.mm
+++ b/shell/browser/api/electron_api_app_mac.mm
@@ -8,7 +8,6 @@
 
 #include "base/path_service.h"
 #include "shell/common/electron_paths.h"
-#include "shell/common/node_includes.h"
 #include "shell/common/process_util.h"
 #include "shell/common/thread_restrictions.h"
 

--- a/shell/browser/api/electron_api_menu_mac.mm
+++ b/shell/browser/api/electron_api_menu_mac.mm
@@ -19,7 +19,6 @@
 #include "shell/browser/api/electron_api_web_frame_main.h"
 #include "shell/browser/native_window.h"
 #include "shell/common/keyboard_util.h"
-#include "shell/common/node_includes.h"
 #include "ui/base/cocoa/menu_utils.h"
 #include "v8/include/cppgc/allocation.h"
 #include "v8/include/v8-cppgc.h"

--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -26,7 +26,6 @@
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/promise.h"
-#include "shell/common/node_includes.h"
 #include "shell/common/process_util.h"
 #include "skia/ext/skia_utils_mac.h"
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -47,6 +47,7 @@
 #include "content/browser/renderer_host/render_widget_host_impl.h"  // nogncheck
 #include "content/browser/renderer_host/render_widget_host_view_base.h"  // nogncheck
 #include "content/browser/web_contents/web_contents_impl.h"  // nogncheck
+#include "content/public/browser/browser_thread.h"
 #include "content/public/browser/child_process_security_policy.h"
 #include "content/public/browser/context_menu_params.h"
 #include "content/public/browser/desktop_media_id.h"
@@ -90,9 +91,11 @@
 #include "services/service_manager/public/cpp/interface_provider.h"
 #include "shell/browser/api/electron_api_browser_window.h"
 #include "shell/browser/api/electron_api_debugger.h"
+#include "shell/browser/api/electron_api_session.h"
 #include "shell/browser/api/electron_api_web_frame_main.h"
 #include "shell/browser/api/frame_subscriber.h"
 #include "shell/browser/api/message_port.h"
+#include "shell/browser/api/save_page_handler.h"
 #include "shell/browser/browser.h"
 #include "shell/browser/child_web_contents_tracker.h"
 #include "shell/browser/electron_autofill_driver_factory.h"

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -53,6 +53,7 @@
 #include "content/public/browser/desktop_media_id.h"
 #include "content/public/browser/desktop_streams_registry.h"
 #include "content/public/browser/devtools_agent_host.h"
+#include "content/public/browser/download_manager.h"
 #include "content/public/browser/download_request_utils.h"
 #include "content/public/browser/favicon_status.h"
 #include "content/public/browser/file_select_listener.h"

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -22,8 +22,6 @@
 #include "chrome/browser/ui/exclusive_access/exclusive_access_context.h"  // nogncheck
 #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
 #include "content/common/frame.mojom-forward.h"
-#include "content/public/browser/browser_thread.h"
-#include "content/public/browser/devtools_agent_host.h"
 #include "content/public/browser/frame_tree_node_id.h"
 #include "content/public/browser/global_routing_id.h"
 #include "content/public/browser/javascript_dialog_manager.h"
@@ -33,9 +31,6 @@
 #include "content/public/common/stop_find_action.h"
 #include "electron/buildflags/buildflags.h"
 #include "printing/buildflags/buildflags.h"
-#include "shell/browser/api/electron_api_debugger.h"
-#include "shell/browser/api/electron_api_session.h"
-#include "shell/browser/api/save_page_handler.h"
 #include "shell/browser/background_throttling_source.h"
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/browser/extended_web_contents_observer.h"
@@ -43,13 +38,10 @@
 #include "shell/browser/preload_script.h"
 #include "shell/browser/ui/inspectable_web_contents_delegate.h"
 #include "shell/browser/ui/inspectable_web_contents_view_delegate.h"
-#include "shell/common/api/api.mojom.h"
 #include "shell/common/gin_helper/cleaned_up_at_exit.h"
 #include "shell/common/gin_helper/constructible.h"
-#include "shell/common/gin_helper/handle.h"
 #include "shell/common/gin_helper/pinnable.h"
 #include "shell/common/gin_helper/wrappable.h"
-#include "shell/common/web_contents_utility.mojom.h"
 #include "ui/base/models/image_model.h"
 #include "v8/include/cppgc/persistent.h"
 
@@ -66,8 +58,14 @@ struct DeviceEmulationParams;
 // enum class PermissionType;
 }  // namespace blink
 
+namespace base {
+class FilePath;
+class Value;
+}  // namespace base
+
 namespace content {
 enum class KeyboardEventProcessingResult;
+class DevToolsAgentHost;
 class WebContents;
 }  // namespace content
 
@@ -78,6 +76,8 @@ class Arguments;
 namespace gin_helper {
 class Dictionary;
 class ErrorThrower;
+template <typename T>
+class Handle;
 template <typename T>
 class Promise;
 }  // namespace gin_helper
@@ -110,7 +110,9 @@ class OffScreenWebContentsView;
 namespace api {
 
 class BaseWindow;
+class Debugger;
 class FrameSubscriber;
+class Session;
 
 // Wrapper around the content::WebContents.
 class WebContents final : public ExclusiveAccessContext,

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -22,6 +22,7 @@
 #include "shell/browser/window_list.h"
 #include "shell/common/application_info.h"
 #include "shell/common/gin_converters/login_item_settings_converter.h"
+#include "shell/common/gin_helper/promise.h"
 #include "shell/common/thread_restrictions.h"
 
 namespace electron {

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -15,7 +15,6 @@
 #include "base/task/cancelable_task_tracker.h"
 #include "base/values.h"
 #include "shell/browser/window_list_observer.h"
-#include "shell/common/gin_helper/promise.h"
 
 #if BUILDFLAG(IS_WIN)
 #include <windows.h>
@@ -35,7 +34,17 @@ class Arguments;
 
 namespace gin_helper {
 class Arguments;
-}
+template <typename T>
+class Promise;
+}  // namespace gin_helper
+
+namespace v8 {
+template <typename T>
+class Local;
+class Isolate;
+class Promise;
+class Value;
+}  // namespace v8
 
 namespace electron {
 

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -42,6 +42,7 @@
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_converters/login_item_settings_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/promise.h"
 #include "shell/common/skia_util.h"
 #include "shell/common/thread_restrictions.h"
 #include "skia/ext/font_utils.h"

--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -17,12 +17,15 @@
 #include "base/task/single_thread_task_runner.h"
 #include "base/task/thread_pool/initialization_util.h"
 #include "gin/array_buffer.h"
+#include "gin/public/isolate_holder.h"
 #include "gin/v8_initializer.h"
 #include "shell/browser/microtasks_runner.h"
 #include "shell/common/gin_helper/cleaned_up_at_exit.h"
 #include "shell/common/node_includes.h"
 #include "third_party/blink/public/common/switches.h"
 #include "third_party/electron_node/src/node_wasm_web_api.h"
+#include "v8/include/v8-isolate.h"
+#include "v8/include/v8-locker.h"
 
 namespace {
 v8::Isolate* g_isolate;
@@ -135,6 +138,10 @@ v8::Isolate* JavascriptEnvironment::Initialize(uv_loop_t* event_loop,
   g_isolate = isolate;
 
   return isolate;
+}
+
+v8::Isolate* JavascriptEnvironment::isolate() const {
+  return isolate_holder_->isolate();
 }
 
 // static

--- a/shell/browser/javascript_environment.h
+++ b/shell/browser/javascript_environment.h
@@ -7,14 +7,21 @@
 
 #include <memory>
 
-#include "gin/public/isolate_holder.h"
 #include "uv.h"  // NOLINT(build/include_directory)
-#include "v8/include/v8-locker.h"
+
+namespace gin {
+class IsolateHolder;
+}  // namespace gin
 
 namespace node {
 class Environment;
 class MultiIsolatePlatform;
 }  // namespace node
+
+namespace v8 {
+class Isolate;
+class Locker;
+}  // namespace v8
 
 namespace electron {
 
@@ -34,14 +41,13 @@ class JavascriptEnvironment {
   void DestroyMicrotasksRunner();
 
   node::MultiIsolatePlatform* platform() const { return platform_.get(); }
-  [[nodiscard]] v8::Isolate* isolate() const {
-    return isolate_holder_->isolate();
-  }
+
   size_t max_young_generation_size_in_bytes() const {
     return max_young_generation_size_;
   }
 
-  static v8::Isolate* GetIsolate();
+  [[nodiscard]] v8::Isolate* isolate() const;
+  [[nodiscard]] static v8::Isolate* GetIsolate();
 
  private:
   v8::Isolate* Initialize(uv_loop_t* event_loop, bool setup_wasm_streaming);

--- a/shell/browser/login_handler.cc
+++ b/shell/browser/login_handler.cc
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "base/task/sequenced_task_runner.h"
+#include "content/public/browser/browser_thread.h"
 #include "gin/arguments.h"
 #include "gin/dictionary.h"
 #include "shell/browser/api/electron_api_app.h"

--- a/shell/common/application_info.cc
+++ b/shell/common/application_info.cc
@@ -6,6 +6,7 @@
 
 #include "base/i18n/rtl.h"
 #include "base/no_destructor.h"
+#include "base/strings/string_util.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/common/chrome_version.h"
 #include "components/embedder_support/user_agent_utils.h"

--- a/shell/common/gin_helper/callback.h
+++ b/shell/common/gin_helper/callback.h
@@ -13,6 +13,7 @@
 #include "shell/common/gin_helper/function_template.h"
 #include "shell/common/gin_helper/locker.h"
 #include "v8/include/cppgc/persistent.h"
+#include "v8/include/v8-context.h"
 #include "v8/include/v8-function.h"
 #include "v8/include/v8-microtask-queue.h"
 // Implements safe conversions between JS functions and base::RepeatingCallback.

--- a/shell/common/gin_helper/function_template.h
+++ b/shell/common/gin_helper/function_template.h
@@ -16,7 +16,6 @@
 #include "gin/public/gin_embedders.h"
 #include "shell/common/gin_helper/destroyable.h"
 #include "shell/common/gin_helper/error_thrower.h"
-#include "v8/include/v8-context.h"
 #include "v8/include/v8-external.h"
 #include "v8/include/v8-microtask-queue.h"
 #include "v8/include/v8-template.h"

--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -15,7 +15,6 @@
 #include "shell/common/gin_converters/blink_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/heap_snapshot.h"
-#include "shell/common/node_includes.h"
 #include "shell/common/options_switches.h"
 #include "shell/common/thread_restrictions.h"
 #include "shell/common/v8_util.h"
@@ -27,6 +26,7 @@
 #include "third_party/blink/public/web/blink.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 #include "third_party/blink/public/web/web_message_port_converter.h"
+#include "v8/include/v8-context.h"
 
 namespace electron {
 


### PR DESCRIPTION
#### Description of Change

A small cleanup refactor that I did as a tangent for another PR that I'm working on.

This PR removes unnecessary `#include` calls in some of the most commonly-included headers in `shell/` and fixes some transitive includes that surfaced from making this change.

CC @dsanders11 as an iwyu stakeholder :)

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.