### PR TITLE
ci: allow ai-pr label without comment

### DIFF
--- a/.github/workflows/pull-request-labeled.yml
+++ b/.github/workflows/pull-request-labeled.yml
@@ -50,7 +50,7 @@ jobs:
           field-value: ✅ Reviewed
   pull-request-labeled-ai-pr:
     name: ai-pr label added
-    if: github.event.label.name == 'ai-pr'
+    if: github.event.label.name == 'ai-pr' && github.event.pull_request.state != 'closed'
     runs-on: ubuntu-latest
     permissions: {}
     steps:


### PR DESCRIPTION
#### Description of Change

This PR would allow maintainers to add the `ai-pr` label on PRs that are already closed without having it attempt to comment and close the issue again. This will allow us to label PRs as AI after they are closed, such that the label can provide a more accurate metric of the number of AI PRs we are seeing. For example, [this PR](https://github.com/electron/electron/pull/50768) that was closed by automation for another reason could be labeled after this change.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] I have built and tested this PR
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
