### PR TITLE
fix: account for extraSize in aspect ratio min/max clamping on macOS

### DIFF
--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -158,45 +158,43 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
         windowSize.width() - contentSize.width() + extraSize.width();
     double extraHeightPlusFrame = titleBarHeight + extraSize.height();
 
-    newSize.width =
-        roundf((frameSize.height - extraHeightPlusFrame) * aspectRatio +
-               extraWidthPlusFrame);
-    newSize.height =
-        roundf((newSize.width - extraWidthPlusFrame) / aspectRatio +
-               extraHeightPlusFrame);
+    auto widthForHeight = [&](double h) {
+      return (h - extraHeightPlusFrame) * aspectRatio + extraWidthPlusFrame;
+    };
+    auto heightForWidth = [&](double w) {
+      return (w - extraWidthPlusFrame) / aspectRatio + extraHeightPlusFrame;
+    };
+
+    newSize.width = roundf(widthForHeight(frameSize.height));
+    newSize.height = roundf(heightForWidth(newSize.width));
 
     // Clamp to minimum width/height while ensuring aspect ratio remains.
     NSSize minSize = [window minSize];
     NSSize zeroSize =
         shell_->has_frame() ? NSMakeSize(0, titleBarHeight) : NSZeroSize;
     if (!NSEqualSizes(minSize, zeroSize)) {
-      double minWidthForAspectRatio =
-          (minSize.height - titleBarHeight) * aspectRatio;
       bool atMinHeight =
           minSize.height > zeroSize.height && newSize.height <= minSize.height;
-      newSize.width = atMinHeight ? minWidthForAspectRatio
+      newSize.width = atMinHeight ? widthForHeight(minSize.height)
                                   : std::max(newSize.width, minSize.width);
 
-      double minHeightForAspectRatio = minSize.width / aspectRatio;
       bool atMinWidth =
           minSize.width > zeroSize.width && newSize.width <= minSize.width;
-      newSize.height = atMinWidth ? minHeightForAspectRatio
+      newSize.height = atMinWidth ? heightForWidth(minSize.width)
                                   : std::max(newSize.height, minSize.height);
     }
 
     // Clamp to maximum width/height while ensuring aspect ratio remains.
     NSSize maxSize = [window maxSize];
     if (!NSEqualSizes(maxSize, NSMakeSize(FLT_MAX, FLT_MAX))) {
-      double maxWidthForAspectRatio = maxSize.height * aspectRatio;
       bool atMaxHeight =
           maxSize.height < FLT_MAX && newSize.height >= maxSize.height;
-      newSize.width = atMaxHeight ? maxWidthForAspectRatio
+      newSize.width = atMaxHeight ? widthForHeight(maxSize.height)
                                   : std::min(newSize.width, maxSize.width);
 
-      double maxHeightForAspectRatio = maxSize.width / aspectRatio;
       bool atMaxWidth =
           maxSize.width < FLT_MAX && newSize.width >= maxSize.width;
-      newSize.height = atMaxWidth ? maxHeightForAspectRatio
+      newSize.height = atMaxWidth ? heightForWidth(maxSize.width)
                                   : std::min(newSize.height, maxSize.height);
     }
   }


### PR DESCRIPTION
#### Description of Change

The min/max size clamping paths in `windowWillResize:toSize:` used different formulas than the unconstrained resize path, ignoring `extraSize` set via `win.setAspectRatio(ratio, extraSize)`. Specifically, min clamping only used `titleBarHeight` and max clamping used neither `extraSize` nor `titleBarHeight`, causing incorrect aspect-ratio-constrained sizes when hitting size bounds.

I factored the two aspect ratio conversion formulas out to `widthForHeight` and `heightForWidth` lambdas so the calculation is consistent across paths.

Fixes #50367

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [ ] tests are changed or added
  - Would be nice, but we don't have infrastructure for this kind of testing.

#### Release Notes

Notes: Fixed aspect ratio min/max size clamping to correctly account for extraSize on macOS.