### PR TITLE
fix: restore std::deque for dynamic crash key storage

### DIFF
--- a/shell/common/crash_keys.cc
+++ b/shell/common/crash_keys.cc
@@ -5,11 +5,11 @@
 #include "shell/common/crash_keys.h"
 
 #include <cstdint>
+#include <deque>
 #include <map>
 #include <string>
 
 #include "base/command_line.h"
-#include "base/containers/circular_deque.h"
 #include "base/environment.h"
 #include "base/no_destructor.h"
 #include "base/strings/strcat.h"
@@ -28,17 +28,22 @@ namespace electron::crash_keys {
 
 namespace {
 
+// Do NOT replace with base::circular_deque. CrashKeyString wraps a
+// crashpad::Annotation that holds self-referential pointers and registers
+// in a process-global linked list; relocating elements (as circular_deque
+// does on growth) corrupts that list and hangs the crashpad handler.
+// std::deque never relocates existing elements. See #50795.
 auto& GetExtraCrashKeys() {
   constexpr size_t kMaxCrashKeyValueSize = 20320;
   static_assert(kMaxCrashKeyValueSize < crashpad::Annotation::kValueMaxSize,
                 "max crash key value length above what crashpad supports");
   using CrashKeyString = crash_reporter::CrashKeyString<kMaxCrashKeyValueSize>;
-  static base::NoDestructor<base::circular_deque<CrashKeyString>> extra_keys;
+  static base::NoDestructor<std::deque<CrashKeyString>> extra_keys;
   return *extra_keys;
 }
 
 auto& GetExtraCrashKeyNames() {
-  static base::NoDestructor<base::circular_deque<std::string>> crash_key_names;
+  static base::NoDestructor<std::deque<std::string>> crash_key_names;
   return *crash_key_names;
 }
 

--- a/spec/api-crash-reporter-spec.ts
+++ b/spec/api-crash-reporter-spec.ts
@@ -250,6 +250,34 @@ ifdescribe(!isLinuxOnArm && !process.mas && !process.env.DISABLE_CRASH_REPORTER_
         expect(crash.addedThenRemoved).to.be.undefined();
       });
 
+      // Regression: base::circular_deque relocates elements on growth,
+      // corrupting crashpad::Annotation's self-referential pointers and
+      // causing missing crash keys or a hung handler. See crash_keys.cc.
+      it('does not corrupt the crashpad annotation list after deque reallocation', async function () {
+        // Tight timeout so a hanging handler fails fast instead of waiting
+        // for the mocha default of 120s.
+        this.timeout(45000);
+        const { port, waitForCrash } = await startServer();
+        runCrashApp('renderer-dynamic-keys', port);
+        const crash = await Promise.race([
+          waitForCrash(),
+          new Promise<never>((_resolve, reject) => {
+            global.setTimeout(
+              () => reject(new Error('crashpad handler hung walking corrupted annotation list; crash upload did not arrive within 30s')),
+              30000
+            );
+          })
+        ]);
+        expect(crash.process_type).to.equal('renderer');
+        const missing: string[] = [];
+        for (let i = 0; i < 50; i++) {
+          if ((crash as any)[`dyn-key-${i}`] !== `val-${i}`) {
+            missing.push(`dyn-key-${i}`);
+          }
+        }
+        expect(missing, `missing dynamic crash keys: ${missing.join(', ')}`).to.be.empty();
+      });
+
       it('contains v8 crash keys when a v8 crash occurs', async () => {
         const { remotely } = await startRemoteControlApp();
         const { port, waitForCrash } = await startServer();

--- a/spec/fixtures/apps/crash/main.js
+++ b/spec/fixtures/apps/crash/main.js
@@ -51,6 +51,19 @@ app.whenReady().then(() => {
     });
     w.loadURL(`about:blank?set_extra=${setExtraParameters ? 1 : 0}`);
     w.webContents.on('render-process-gone', () => process.exit(0));
+  } else if (crashType === 'renderer-dynamic-keys') {
+    const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, contextIsolation: false } });
+    w.webContents.on('render-process-gone', () => process.exit(0));
+    w.webContents.on('did-finish-load', () => {
+      w.webContents.executeJavaScript(`
+        const { crashReporter } = require('electron');
+        for (let i = 0; i < 50; i++) {
+          crashReporter.addExtraParameter('dyn-key-' + i, 'val-' + i);
+        }
+        process.crash();
+      `);
+    });
+    w.loadURL('about:blank');
   } else if (crashType === 'node') {
     const crashPath = path.join(__dirname, 'node-crash.js');
     const child = childProcess.fork(crashPath, { silent: true });


### PR DESCRIPTION
#### Description of Change

#47171 migrated `std::deque` to `base::circular_deque` in `shell/common/crash_keys.cc`. However, `CrashKeyString` wraps a `crashpad::Annotation` that holds self-referential pointers and registers itself in a process-global linked list. `circular_deque` relocates elements on growth (via `VectorBuffer::MoveConstructRange`), leaving those pointers dangling — causing missing crash keys or a hung crashpad handler (especially on macOS). The `base/containers/README.md` warns: "Since `base::deque` does not have stable iterators and it will move the objects it contains, it may not be appropriate for all uses."

Reverts to `std::deque`, whose block-based layout never relocates existing elements. Adds a regression test that registers 50 dynamic crash keys and verifies that all of them survive a renderer crash.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] tests are [added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed the crash keys being lost and the crash reporter hanging on macOS when many dynamic crash keys were registered.
