### PR TITLE
docs: add example for webContents.print

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1801,6 +1801,25 @@ win.webContents.print(options, (success, errorType) => {
   if (!success) console.log(errorType)
 })
 ```
+Example:
+```js
+const { app, BrowserWindow } = require('electron');
+
+app.whenReady().then(() => {
+  const win = new BrowserWindow();
+
+  win.loadURL('https://example.com');
+
+  win.webContents.on('did-finish-load', () => {
+    win.webContents.print({}, (success, errorType) => {
+      if (!success) {
+        console.log('Print failed:', errorType);
+      } else {
+        console.log('Print successful');
+      }
+    });
+  });
+});
 
 #### `contents.printToPDF(options)`
 


### PR DESCRIPTION
## Description

Added a complete example for `webContents.print` in the documentation.

The existing snippet was minimal and did not demonstrate full usage with `app.whenReady()` and `BrowserWindow`. This update improves clarity and helps beginners understand how to use the API in a real-world scenario.