### PR TITLE
feat: add `menuItem.badge` support on macOS

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -64,7 +64,7 @@ See [`Menu`](menu.md) for examples.
   * `afterGroupContaining` string[] (optional) - Provides a means for a single context menu to declare
     the placement of their containing group after the containing group of the item
     with the specified id.
-  * `badge` Object (optional) _macOS_
+  * `badge` Object (optional) _macOS_ - Only available on macOS 14 and up.
     * `type` string (optional) - Can be one of `alerts`, `updates`, `new-items` or `none`. Default is `none`.
     * `count` number (optional) - The number of items the badge displays. Cannot be used with `type: 'none'`.
     * `content` string (optional) - A custom string to display in the badge. Only usable with `type: 'none'`.
@@ -200,4 +200,4 @@ A [`Menu`](menu.md) that the item is a part of.
 
 An [`MenuItemBadge`](structures/menu-item-badge.md) indicating the badge for the menu item.
 
-This property can be dynamically changed.
+This property can be dynamically changed. Only available on macOS 14 and up.

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -65,7 +65,7 @@ See [`Menu`](menu.md) for examples.
     the placement of their containing group after the containing group of the item
     with the specified id.
   * `badge` Object (optional) _macOS_ - Only available on macOS 14 and up.
-    * `type` string (optional) - Can be `alerts`, `updates`, `new-items` or `none`. Default is `none`.
+    * `type` string (optional) - Can be `alerts`, `updates`, `new-items` or `none`. Default is `none`.  See https://developer.apple.com/documentation/appkit/nsmenuitembadge#Creating-badges-of-a-specific-type for further explanation of these types.
     * `count` number (optional) - The number of items the badge displays. Cannot be used with `type: 'none'`.
     * `content` string (optional) - A custom string to display in the badge. Only usable with `type: 'none'`.
 

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -198,6 +198,6 @@ A [`Menu`](menu.md) that the item is a part of.
 
 #### `menuItem.badge` _macOS_
 
-An [`MenuItemBadge`](structures/menu-item-badge.md) indicating the badge for the menu item.
+An [`MenuItemBadge`](structures/menu-item-badge.md) (optional) indicating the badge for the menu item.
 
 This property can be dynamically changed. Only available on macOS 14 and up.

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -64,16 +64,12 @@ See [`Menu`](menu.md) for examples.
   * `afterGroupContaining` string[] (optional) - Provides a means for a single context menu to declare
     the placement of their containing group after the containing group of the item
     with the specified id.
-  * `badge` Object (optional) _macOS_ - Only available on macOS 14 and up.
-    * `type` string (optional) - Can be `alerts`, `updates`, `new-items` or `none`. Default is `none`.  See https://developer.apple.com/documentation/appkit/nsmenuitembadge#Creating-badges-of-a-specific-type for further explanation of these types.
-    * `count` number (optional) - The number of items the badge displays. Cannot be used with `type: 'none'`.
-    * `content` string (optional) - A custom string to display in the badge. Only usable with `type: 'none'`.
+  * `badge` [MenuItemBadge](structures/menu-item-badge.md) (optional) _macOS_ - A badge shown alongside
+    the label, either a system-styled count (`alerts`, `updates`, `new-items`) or a custom string.
+    Only available on macOS 14 and up.
 
 > [!NOTE]
 > `acceleratorWorksWhenHidden` is specified as being macOS-only because accelerators always work when items are hidden on Windows and Linux. The option is exposed to users to give them the option to turn it off, as this is possible in native macOS development.
-
-> [!NOTE]
-> If you use one of the predefined badge types on macOS (not 'none'), the system localizes and pluralizes the string for you. If you create your own custom badge string, you need to localize and pluralize that string yourself.
 
 ### Instance Properties
 
@@ -198,6 +194,7 @@ A [`Menu`](menu.md) that the item is a part of.
 
 #### `menuItem.badge` _macOS_
 
-An [`MenuItemBadge`](structures/menu-item-badge.md) (optional) indicating the badge for the menu item.
+A [`MenuItemBadge`](structures/menu-item-badge.md) (optional) indicating the badge for the menu item.
 
-This property can be dynamically changed. Only available on macOS 14 and up.
+This property can be dynamically changed; setting it to `undefined` removes the badge. Only available on
+macOS 14 and up.

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -65,7 +65,7 @@ See [`Menu`](menu.md) for examples.
     the placement of their containing group after the containing group of the item
     with the specified id.
   * `badge` Object (optional) _macOS_ - Only available on macOS 14 and up.
-    * `type` string (optional) - Can be one of `alerts`, `updates`, `new-items` or `none`. Default is `none`.
+    * `type` string (optional) - Can be `alerts`, `updates`, `new-items` or `none`. Default is `none`.
     * `count` number (optional) - The number of items the badge displays. Cannot be used with `type: 'none'`.
     * `content` string (optional) - A custom string to display in the badge. Only usable with `type: 'none'`.
 

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -64,9 +64,16 @@ See [`Menu`](menu.md) for examples.
   * `afterGroupContaining` string[] (optional) - Provides a means for a single context menu to declare
     the placement of their containing group after the containing group of the item
     with the specified id.
+  * `badge` Object (optional) _macOS_
+    * `type` string (optional) - Can be one of `alerts`, `updates`, `new-items` or `none`. Default is `none`.
+    * `count` number (optional) - The number of items the badge displays. Cannot be used with `type: 'none'`.
+    * `content` string (optional) - A custom string to display in the badge. Only usable with `type: 'none'`.
 
 > [!NOTE]
 > `acceleratorWorksWhenHidden` is specified as being macOS-only because accelerators always work when items are hidden on Windows and Linux. The option is exposed to users to give them the option to turn it off, as this is possible in native macOS development.
+
+> [!NOTE]
+> If you use one of the predefined badge types on macOS (not 'none'), the system localizes and pluralizes the string for you. If you create your own custom badge string, you need to localize and pluralize that string yourself.
 
 ### Instance Properties
 
@@ -188,3 +195,9 @@ A `number` indicating an item's sequential unique id.
 #### `menuItem.menu`
 
 A [`Menu`](menu.md) that the item is a part of.
+
+#### `menuItem.badge` _macOS_
+
+An [`MenuItemBadge`](structures/menu-item-badge.md) indicating the badge for the menu item.
+
+This property can be dynamically changed.

--- a/docs/api/structures/menu-item-badge.md
+++ b/docs/api/structures/menu-item-badge.md
@@ -1,5 +1,5 @@
 # MenuItemBadge Object
 
-* `type` string (optional) - Can be one of `alerts`, `updates`, `new-items` or `none`. Default is `none`.
+* `type` string (optional) - Can be `alerts`, `updates`, `new-items` or `none`. Default is `none`.
 * `count` number (optional) - The number of items the badge displays. Cannot be used with `type: 'none'`.
 * `content` string (optional) - A custom string to display in the badge. Only usable with `type: 'none'`.

--- a/docs/api/structures/menu-item-badge.md
+++ b/docs/api/structures/menu-item-badge.md
@@ -1,5 +1,5 @@
 # MenuItemBadge Object
 
-* `type` string (optional) - Can be `alerts`, `updates`, `new-items` or `none`. Default is `none`.
+* `type` string (optional) - Can be `alerts`, `updates`, `new-items` or `none`. Default is `none`.  See https://developer.apple.com/documentation/appkit/nsmenuitembadge#Creating-badges-of-a-specific-type for further explanation of these types.
 * `count` number (optional) - The number of items the badge displays. Cannot be used with `type: 'none'`.
 * `content` string (optional) - A custom string to display in the badge. Only usable with `type: 'none'`.

--- a/docs/api/structures/menu-item-badge.md
+++ b/docs/api/structures/menu-item-badge.md
@@ -1,0 +1,5 @@
+# MenuItemBadge Object
+
+* `type` string (optional) - Can be one of `alerts`, `updates`, `new-items` or `none`. Default is `none`.
+* `count` number (optional) - The number of items the badge displays. Cannot be used with `type: 'none'`.
+* `content` string (optional) - A custom string to display in the badge. Only usable with `type: 'none'`.

--- a/docs/api/structures/menu-item-badge.md
+++ b/docs/api/structures/menu-item-badge.md
@@ -1,5 +1,8 @@
 # MenuItemBadge Object
 
-* `type` string (optional) - Can be `alerts`, `updates`, `new-items` or `none`. Default is `none`.  See https://developer.apple.com/documentation/appkit/nsmenuitembadge#Creating-badges-of-a-specific-type for further explanation of these types.
-* `count` number (optional) - The number of items the badge displays. Cannot be used with `type: 'none'`.
-* `content` string (optional) - A custom string to display in the badge. Only usable with `type: 'none'`.
+* `type` string (optional) - Can be `alerts`, `updates`, `new-items` or `none`. Default is `none`. See [Creating badges of a specific type](https://developer.apple.com/documentation/appkit/nsmenuitembadge#Creating-badges-of-a-specific-type) for further explanation of these types.
+* `count` number (optional) - The number of items the badge displays. Required for the `alerts`, `updates` and `new-items` types; cannot be used with `none`.
+* `content` string (optional) - A custom string to display in the badge. Required for, and only usable with, the `none` type.
+
+If you use one of the predefined badge types (not `none`), the system localizes and pluralizes the badge
+for you. If you create your own custom badge string, you need to localize and pluralize that string yourself.

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -125,6 +125,7 @@ auto_filenames = {
     "docs/api/structures/media-access-permission-request.md",
     "docs/api/structures/memory-info.md",
     "docs/api/structures/memory-usage-details.md",
+    "docs/api/structures/menu-item-badge.md",
     "docs/api/structures/mime-typed-buffer.md",
     "docs/api/structures/mouse-input-event.md",
     "docs/api/structures/mouse-wheel-input-event.md",

--- a/lib/browser/api/menu-item.ts
+++ b/lib/browser/api/menu-item.ts
@@ -39,6 +39,24 @@ const MenuItem = function (this: any, options: any) {
   this.overrideProperty('acceleratorWorksWhenHidden', true);
   this.overrideProperty('registerAccelerator', roles.shouldRegisterAccelerator(this.role));
 
+  if (process.platform === 'darwin') {
+    let badgeValue = options.badge;
+    Object.defineProperty(this, 'badge', {
+      get: () => badgeValue,
+      set: (newValue) => {
+        badgeValue = newValue;
+        // Update native badge if this item is already in a menu
+        if (this.menu) {
+          const index = this.menu.getIndexOfCommandId(this.commandId);
+          if (index !== -1 && badgeValue) {
+            this.menu.setBadge(index, badgeValue);
+          }
+        }
+      },
+      enumerable: true
+    });
+  }
+
   if (!MenuItem.types.includes(this.type)) {
     throw new Error(`Unknown menu item type: ${this.type}`);
   }

--- a/lib/browser/api/menu-item.ts
+++ b/lib/browser/api/menu-item.ts
@@ -4,6 +4,34 @@ import { Menu, BaseWindow, WebContents, KeyboardEvent } from 'electron/main';
 
 let nextCommandId = 0;
 
+const badgeTypes = ['alerts', 'updates', 'new-items', 'none'];
+
+const validateBadge = (badge: any) => {
+  if (badge == null) return;
+  if (typeof badge !== 'object') {
+    throw new TypeError('badge must be a MenuItemBadge object');
+  }
+  const type = badge.type ?? 'none';
+  if (!badgeTypes.includes(type)) {
+    throw new TypeError(`Invalid badge type '${type}': must be one of ${badgeTypes.join(', ')}`);
+  }
+  if (type === 'none') {
+    if (typeof badge.content !== 'string') {
+      throw new TypeError("badge.content must be a string when badge.type is 'none'");
+    }
+    if (badge.count != null) {
+      throw new TypeError("badge.count cannot be used when badge.type is 'none'");
+    }
+  } else {
+    if (!Number.isInteger(badge.count) || badge.count < 0) {
+      throw new TypeError(`badge.count must be a non-negative integer when badge.type is '${type}'`);
+    }
+    if (badge.content != null) {
+      throw new TypeError("badge.content can only be used when badge.type is 'none'");
+    }
+  }
+};
+
 const MenuItem = function (this: any, options: any) {
   // Preserve extra fields specified by user
   for (const key in options) {
@@ -40,17 +68,17 @@ const MenuItem = function (this: any, options: any) {
   this.overrideProperty('registerAccelerator', roles.shouldRegisterAccelerator(this.role));
 
   if (process.platform === 'darwin') {
-    let badgeValue = options.badge;
+    validateBadge(options.badge);
+    let badgeValue = options.badge ?? undefined;
     Object.defineProperty(this, 'badge', {
       get: () => badgeValue,
       set: (newValue) => {
-        badgeValue = newValue;
-        // Update native badge if this item is already in a menu
+        validateBadge(newValue);
+        badgeValue = newValue ?? undefined;
+        // Push the change to the native item if this item is already in a menu.
         if (this.menu) {
           const index = this.menu.getIndexOfCommandId(this.commandId);
-          if (index !== -1 && badgeValue) {
-            this.menu.setBadge(index, badgeValue);
-          }
+          if (index !== -1) this.menu.setBadge(index, badgeValue ?? null);
         }
       },
       enumerable: true

--- a/lib/browser/api/menu.ts
+++ b/lib/browser/api/menu.ts
@@ -180,6 +180,9 @@ Menu.prototype.insert = function (pos, item) {
   if (item.type === 'palette' || item.type === 'header') {
     this.setCustomType(pos, item.type);
   }
+  if (process.platform === 'darwin' && item.badge) {
+    this.setBadge(pos, item.badge);
+  }
 
   // Make menu accessible to items.
   item.overrideReadOnlyProperty('menu', this);

--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -18,7 +18,6 @@
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_converters/optional_converter.h"
-#include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/gin_helper/wrappable_pointer_tags.h"
 #include "shell/common/node_includes.h"
@@ -30,6 +29,7 @@
 namespace gin {
 
 using SharingItem = electron::ElectronMenuModel::SharingItem;
+using Badge = electron::ElectronMenuModel::Badge;
 
 template <>
 struct Converter<SharingItem> {
@@ -42,6 +42,28 @@ struct Converter<SharingItem> {
     dict.GetOptional("texts", &(out->texts));
     dict.GetOptional("filePaths", &(out->file_paths));
     dict.GetOptional("urls", &(out->urls));
+    return true;
+  }
+};
+
+template <>
+struct Converter<Badge> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     Badge* out) {
+    gin_helper::Dictionary dict;
+    if (!ConvertFromV8(isolate, val, &dict))
+      return false;
+
+    std::string type_str;
+    if (dict.Get("type", &type_str)) {
+      out->type = base::UTF8ToUTF16(type_str);
+    } else {
+      out->type = u"none";
+    }
+
+    dict.GetOptional("count", &(out->count));
+    dict.GetOptional("content", &(out->content));
     return true;
   }
 };
@@ -262,6 +284,21 @@ void Menu::SetCustomType(int index, const std::u16string& customType) {
   model_->SetCustomType(index, customType);
 }
 
+#if BUILDFLAG(IS_MAC)
+void Menu::SetBadge(int index, const gin_helper::Dictionary& badge_dict) {
+  ElectronMenuModel::Badge badge;
+  std::string type_str;
+  if (badge_dict.Get("type", &type_str)) {
+    badge.type = base::UTF8ToUTF16(type_str);
+  } else {
+    badge.type = u"none";
+  }
+  badge_dict.GetOptional("count", &badge.count);
+  badge_dict.GetOptional("content", &badge.content);
+  model_->SetBadge(index, std::move(badge));
+}
+#endif
+
 void Menu::Clear() {
   model_->Clear();
 }
@@ -303,8 +340,12 @@ void Menu::FillObjectTemplate(v8::Isolate* isolate,
       .SetMethod("setToolTip", &Menu::SetToolTip)
       .SetMethod("setRole", &Menu::SetRole)
       .SetMethod("setCustomType", &Menu::SetCustomType)
+#if BUILDFLAG(IS_MAC)
+      .SetMethod("setBadge", &Menu::SetBadge)
+#endif
       .SetMethod("clear", &Menu::Clear)
       .SetMethod("getItemCount", &Menu::GetItemCount)
+      .SetMethod("getIndexOfCommandId", &Menu::GetIndexOfCommandId)
       .SetMethod("popupAt", &Menu::PopupAt)
       .SetMethod("closePopupAt", &Menu::ClosePopupAt)
       .SetMethod("_getAcceleratorTextAt", &Menu::GetAcceleratorTextAtForTesting)

--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -18,6 +18,7 @@
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_converters/optional_converter.h"
+#include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/gin_helper/wrappable_pointer_tags.h"
 #include "shell/common/node_includes.h"
@@ -54,14 +55,8 @@ struct Converter<Badge> {
     gin_helper::Dictionary dict;
     if (!ConvertFromV8(isolate, val, &dict))
       return false;
-
-    std::string type_str;
-    if (dict.Get("type", &type_str)) {
-      out->type = base::UTF8ToUTF16(type_str);
-    } else {
-      out->type = u"none";
-    }
-
+    out->type = "none";
+    dict.Get("type", &(out->type));
     dict.GetOptional("count", &(out->count));
     dict.GetOptional("content", &(out->content));
     return true;
@@ -285,16 +280,7 @@ void Menu::SetCustomType(int index, const std::u16string& customType) {
 }
 
 #if BUILDFLAG(IS_MAC)
-void Menu::SetBadge(int index, const gin_helper::Dictionary& badge_dict) {
-  ElectronMenuModel::Badge badge;
-  std::string type_str;
-  if (badge_dict.Get("type", &type_str)) {
-    badge.type = base::UTF8ToUTF16(type_str);
-  } else {
-    badge.type = u"none";
-  }
-  badge_dict.GetOptional("count", &badge.count);
-  badge_dict.GetOptional("content", &badge.content);
+void Menu::SetBadge(int index, std::optional<ElectronMenuModel::Badge> badge) {
   model_->SetBadge(index, std::move(badge));
 }
 #endif

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -6,13 +6,13 @@
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_MENU_H_
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/browser/ui/electron_menu_model.h"
 #include "shell/common/gin_helper/constructible.h"
-#include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/self_keep_alive.h"
 #include "ui/base/mojom/menu_source_type.mojom-forward.h"
 #include "v8/include/cppgc/member.h"
@@ -130,7 +130,7 @@ class Menu : public gin::Wrappable<Menu>,
   void SetRole(int index, const std::u16string& role);
   void SetCustomType(int index, const std::u16string& customType);
 #if BUILDFLAG(IS_MAC)
-  void SetBadge(int index, const gin_helper::Dictionary& badge);
+  void SetBadge(int index, std::optional<ElectronMenuModel::Badge> badge);
 #endif
   void Clear();
   int GetIndexOfCommandId(int command_id) const;

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -12,6 +12,7 @@
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/browser/ui/electron_menu_model.h"
 #include "shell/common/gin_helper/constructible.h"
+#include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/self_keep_alive.h"
 #include "ui/base/mojom/menu_source_type.mojom-forward.h"
 #include "v8/include/cppgc/member.h"
@@ -128,6 +129,9 @@ class Menu : public gin::Wrappable<Menu>,
   void SetToolTip(int index, const std::u16string& toolTip);
   void SetRole(int index, const std::u16string& role);
   void SetCustomType(int index, const std::u16string& customType);
+#if BUILDFLAG(IS_MAC)
+  void SetBadge(int index, const gin_helper::Dictionary& badge);
+#endif
   void Clear();
   int GetIndexOfCommandId(int command_id) const;
   int GetItemCount() const;

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -116,6 +116,30 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
   return result;
 }
 
+// Convert a Badge to an NSMenuItemBadge.
+NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
+    API_AVAILABLE(macos(14.0)) {
+  NSString* badgeType = base::SysUTF16ToNSString(badge.type);
+
+  if ([badgeType isEqualToString:@"alerts"]) {
+    if (badge.count.has_value())
+      return [NSMenuItemBadge alertsWithCount:badge.count.value()];
+  } else if ([badgeType isEqualToString:@"updates"]) {
+    if (badge.count.has_value())
+      return [NSMenuItemBadge updatesWithCount:badge.count.value()];
+  } else if ([badgeType isEqualToString:@"new-items"]) {
+    if (badge.count.has_value())
+      return [NSMenuItemBadge newItemsWithCount:badge.count.value()];
+  } else if ([badgeType isEqualToString:@"none"]) {
+    if (badge.content.has_value()) {
+      NSString* content = base::SysUTF8ToNSString(badge.content.value());
+      return [[NSMenuItemBadge alloc] initWithString:content];
+    }
+  }
+
+  return nil;
+}
+
 }  // namespace
 
 // This class stores a base::WeakPtr<electron::ElectronMenuModel> as an
@@ -354,20 +378,27 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
   electron::ElectronMenuModel::ItemType type = model->GetTypeAt(index);
   std::u16string customType = model->GetCustomTypeAt(index);
 
-  // The sectionHeaderWithTitle menu item is only available in macOS 14.0+.
   if (@available(macOS 14, *)) {
     if (customType == u"header") {
       item = [NSMenuItem sectionHeaderWithTitle:label];
     }
   }
 
-  // If the menu item has an icon, set it.
   ui::ImageModel icon = model->GetIconAt(index);
   if (icon.IsImage())
     item.image = icon.GetImage().ToNSImage();
 
   std::u16string toolTip = model->GetToolTipAt(index);
   item.toolTip = base::SysUTF16ToNSString(toolTip);
+
+  if (@available(macOS 14, *)) {
+    electron::ElectronMenuModel::Badge badge;
+    if (model->GetBadgeAt(index, &badge)) {
+      NSMenuItemBadge* nsBadge = CreateBadge(badge);
+      if (nsBadge)
+        item.badge = nsBadge;
+    }
+  }
 
   if (role == u"services") {
     std::u16string title = u"Services";
@@ -550,6 +581,15 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
           break;
         }
       }
+    }
+  }
+
+  if (@available(macOS 14, *)) {
+    electron::ElectronMenuModel::Badge badge;
+    if (model->GetBadgeAt(index, &badge)) {
+      item.badge = CreateBadge(badge);
+    } else {
+      item.badge = nil;
     }
   }
 }

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -116,27 +116,22 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
   return result;
 }
 
-// Convert a Badge to an NSMenuItemBadge.
+// Convert a Badge to an NSMenuItemBadge, or nil if it has nothing to show.
 NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
     API_AVAILABLE(macos(14.0)) {
-  NSString* badgeType = base::SysUTF16ToNSString(badge.type);
-
-  if ([badgeType isEqualToString:@"alerts"]) {
-    if (badge.count.has_value())
-      return [NSMenuItemBadge alertsWithCount:badge.count.value()];
-  } else if ([badgeType isEqualToString:@"updates"]) {
-    if (badge.count.has_value())
-      return [NSMenuItemBadge updatesWithCount:badge.count.value()];
-  } else if ([badgeType isEqualToString:@"new-items"]) {
-    if (badge.count.has_value())
-      return [NSMenuItemBadge newItemsWithCount:badge.count.value()];
-  } else if ([badgeType isEqualToString:@"none"]) {
-    if (badge.content.has_value()) {
-      NSString* content = base::SysUTF8ToNSString(badge.content.value());
-      return [[NSMenuItemBadge alloc] initWithString:content];
-    }
+  if (badge.type == "none") {
+    if (!badge.content)
+      return nil;
+    return [[NSMenuItemBadge alloc]
+        initWithString:base::SysUTF8ToNSString(*badge.content)];
   }
-
+  const NSInteger count = badge.count.value_or(0);
+  if (badge.type == "alerts")
+    return [NSMenuItemBadge alertsWithCount:count];
+  if (badge.type == "updates")
+    return [NSMenuItemBadge updatesWithCount:count];
+  if (badge.type == "new-items")
+    return [NSMenuItemBadge newItemsWithCount:count];
   return nil;
 }
 
@@ -378,12 +373,14 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
   electron::ElectronMenuModel::ItemType type = model->GetTypeAt(index);
   std::u16string customType = model->GetCustomTypeAt(index);
 
+  // The sectionHeaderWithTitle menu item is only available in macOS 14.0+.
   if (@available(macOS 14, *)) {
     if (customType == u"header") {
       item = [NSMenuItem sectionHeaderWithTitle:label];
     }
   }
 
+  // If the menu item has an icon, set it.
   ui::ImageModel icon = model->GetIconAt(index);
   if (icon.IsImage())
     item.image = icon.GetImage().ToNSImage();
@@ -393,11 +390,8 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
 
   if (@available(macOS 14, *)) {
     electron::ElectronMenuModel::Badge badge;
-    if (model->GetBadgeAt(index, &badge)) {
-      NSMenuItemBadge* nsBadge = CreateBadge(badge);
-      if (nsBadge)
-        item.badge = nsBadge;
-    }
+    if (model->GetBadgeAt(index, &badge))
+      item.badge = CreateBadge(badge);
   }
 
   if (role == u"services") {
@@ -586,11 +580,7 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
 
   if (@available(macOS 14, *)) {
     electron::ElectronMenuModel::Badge badge;
-    if (model->GetBadgeAt(index, &badge)) {
-      item.badge = CreateBadge(badge);
-    } else {
-      item.badge = nil;
-    }
+    item.badge = model->GetBadgeAt(index, &badge) ? CreateBadge(badge) : nil;
   }
 }
 

--- a/shell/browser/ui/electron_menu_model.cc
+++ b/shell/browser/ui/electron_menu_model.cc
@@ -12,6 +12,15 @@ namespace electron {
 ElectronMenuModel::SharingItem::SharingItem() = default;
 ElectronMenuModel::SharingItem::SharingItem(SharingItem&&) = default;
 ElectronMenuModel::SharingItem::~SharingItem() = default;
+
+ElectronMenuModel::Badge::Badge() = default;
+ElectronMenuModel::Badge::Badge(Badge&&) = default;
+ElectronMenuModel::Badge::Badge(const Badge&) = default;
+ElectronMenuModel::Badge& ElectronMenuModel::Badge::operator=(const Badge&) =
+    default;
+ElectronMenuModel::Badge& ElectronMenuModel::Badge::operator=(Badge&&) =
+    default;
+ElectronMenuModel::Badge::~Badge() = default;
 #endif
 
 bool ElectronMenuModel::Delegate::GetAcceleratorForCommandId(
@@ -120,6 +129,21 @@ bool ElectronMenuModel::GetSharingItemAt(size_t index,
 
 void ElectronMenuModel::SetSharingItem(SharingItem item) {
   sharing_item_.emplace(std::move(item));
+}
+
+void ElectronMenuModel::SetBadge(size_t index, Badge badge) {
+  int command_id = GetCommandIdAt(index);
+  badges_[command_id] = std::move(badge);
+}
+
+bool ElectronMenuModel::GetBadgeAt(size_t index, Badge* badge) const {
+  int command_id = GetCommandIdAt(index);
+  const auto iter = badges_.find(command_id);
+  if (iter != badges_.end()) {
+    *badge = iter->second;
+    return true;
+  }
+  return false;
 }
 #endif
 

--- a/shell/browser/ui/electron_menu_model.cc
+++ b/shell/browser/ui/electron_menu_model.cc
@@ -131,9 +131,12 @@ void ElectronMenuModel::SetSharingItem(SharingItem item) {
   sharing_item_.emplace(std::move(item));
 }
 
-void ElectronMenuModel::SetBadge(size_t index, Badge badge) {
-  int command_id = GetCommandIdAt(index);
-  badges_[command_id] = std::move(badge);
+void ElectronMenuModel::SetBadge(size_t index, std::optional<Badge> badge) {
+  const int command_id = GetCommandIdAt(index);
+  if (badge)
+    badges_[command_id] = std::move(*badge);
+  else
+    badges_.erase(command_id);
 }
 
 bool ElectronMenuModel::GetBadgeAt(size_t index, Badge* badge) const {

--- a/shell/browser/ui/electron_menu_model.h
+++ b/shell/browser/ui/electron_menu_model.h
@@ -33,6 +33,19 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
     std::optional<std::vector<GURL>> urls;
     std::optional<std::vector<base::FilePath>> file_paths;
   };
+
+  struct Badge {
+    Badge();
+    Badge(Badge&&);
+    Badge(const Badge&);
+    Badge& operator=(const Badge&);
+    Badge& operator=(Badge&&);
+    ~Badge();
+
+    std::u16string type;  // "alerts", "updates", "new-items", or "none"
+    std::optional<int> count;
+    std::optional<std::string> content;
+  };
 #endif
 
   class Delegate : public ui::SimpleMenuModel::Delegate {
@@ -109,6 +122,9 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
     return sharing_item_;
   }
 
+  // Set/Get the Badge of a menu item.
+  void SetBadge(size_t index, Badge badge);
+  bool GetBadgeAt(size_t index, Badge* badge) const;
 #endif
 
   // ui::SimpleMenuModel:
@@ -127,6 +143,7 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
 
 #if BUILDFLAG(IS_MAC)
   std::optional<SharingItem> sharing_item_;
+  base::flat_map<int, Badge> badges_;  // command id -> badge
 #endif
 
   base::flat_map<int, std::u16string> toolTips_;  // command id -> tooltip

--- a/shell/browser/ui/electron_menu_model.h
+++ b/shell/browser/ui/electron_menu_model.h
@@ -42,7 +42,7 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
     Badge& operator=(Badge&&);
     ~Badge();
 
-    std::u16string type;  // "alerts", "updates", "new-items", or "none"
+    std::string type;  // "alerts", "updates", "new-items" or "none"
     std::optional<int> count;
     std::optional<std::string> content;
   };
@@ -122,8 +122,8 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
     return sharing_item_;
   }
 
-  // Set/Get the Badge of a menu item.
-  void SetBadge(size_t index, Badge badge);
+  // Set/Get the badge of a menu item; std::nullopt removes it.
+  void SetBadge(size_t index, std::optional<Badge> badge);
   bool GetBadgeAt(size_t index, Badge* badge) const;
 #endif
 

--- a/spec/api-menu-item-spec.ts
+++ b/spec/api-menu-item-spec.ts
@@ -806,5 +806,47 @@ describe('MenuItems', () => {
       menu.items[0].badge = { type: 'updates', count: 5 };
       expect(menu.items[0].badge).to.deep.equal({ type: 'updates', count: 5 });
     });
+
+    it('should remove an existing badge', () => {
+      const item = new MenuItem({ label: 'test', badge: { type: 'alerts', count: 3 } });
+      item.badge = undefined;
+      expect(item.badge).to.be.undefined();
+
+      const menu = Menu.buildFromTemplate([{ label: 'test', badge: { type: 'none', content: 'New' } }]);
+      menu.items[0].badge = undefined;
+      expect(menu.items[0].badge).to.be.undefined();
+      menu.items[0].badge = { type: 'new-items', count: 2 };
+      expect(menu.items[0].badge).to.deep.equal({ type: 'new-items', count: 2 });
+    });
+
+    it('should default the badge type to none', () => {
+      const item = new MenuItem({ label: 'test', badge: { content: 'Beta' } });
+      expect(item.badge).to.deep.equal({ content: 'Beta' });
+    });
+
+    it('should throw on an invalid badge', () => {
+      expect(() => new MenuItem({ label: 'test', badge: { type: 'bogus', count: 1 } as any })).to.throw(
+        /Invalid badge type/
+      );
+      expect(() => new MenuItem({ label: 'test', badge: { type: 'alerts' } })).to.throw(
+        /badge.count must be a non-negative integer/
+      );
+      expect(() => new MenuItem({ label: 'test', badge: { type: 'updates', count: -1 } })).to.throw(
+        /badge.count must be a non-negative integer/
+      );
+      expect(() => new MenuItem({ label: 'test', badge: { type: 'alerts', count: 1, content: 'x' } })).to.throw(
+        /badge.content can only be used/
+      );
+      expect(() => new MenuItem({ label: 'test', badge: { type: 'none' } })).to.throw(/badge.content must be a string/);
+      expect(() => new MenuItem({ label: 'test', badge: { type: 'none', content: 'x', count: 1 } })).to.throw(
+        /badge.count cannot be used/
+      );
+
+      const item = new MenuItem({ label: 'test' });
+      expect(() => {
+        item.badge = { type: 'bogus' } as any;
+      }).to.throw(/Invalid badge type/);
+      expect(item.badge).to.be.undefined();
+    });
   });
 });

--- a/spec/api-menu-item-spec.ts
+++ b/spec/api-menu-item-spec.ts
@@ -756,4 +756,59 @@ describe('MenuItems', () => {
       expect(menu._getAcceleratorTextAt(5)).to.equal('Ctrl+?');
     });
   });
+
+  ifdescribe(process.platform === 'darwin')('MenuItem.badge', () => {
+    it('should set badge from constructor options', () => {
+      const item = new MenuItem({
+        label: 'test',
+        badge: { type: 'alerts', count: 3 }
+      });
+
+      expect(item.badge).to.deep.equal({ type: 'alerts', count: 3 });
+    });
+
+    it('should support all badge types', () => {
+      const alerts = new MenuItem({ label: 'a', badge: { type: 'alerts', count: 1 } });
+      const updates = new MenuItem({ label: 'b', badge: { type: 'updates', count: 2 } });
+      const newItems = new MenuItem({ label: 'c', badge: { type: 'new-items', count: 5 } });
+      const custom = new MenuItem({ label: 'd', badge: { type: 'none', content: 'Custom' } });
+
+      expect(alerts.badge).to.deep.equal({ type: 'alerts', count: 1 });
+      expect(updates.badge).to.deep.equal({ type: 'updates', count: 2 });
+      expect(newItems.badge).to.deep.equal({ type: 'new-items', count: 5 });
+      expect(custom.badge).to.deep.equal({ type: 'none', content: 'Custom' });
+    });
+
+    it('should allow dynamic badge updates', () => {
+      const item = new MenuItem({
+        label: 'test',
+        badge: { type: 'alerts', count: 1 }
+      });
+
+      item.badge = { type: 'updates', count: 10 };
+      expect(item.badge).to.deep.equal({ type: 'updates', count: 10 });
+    });
+
+    it('should have undefined badge when not set', () => {
+      const item = new MenuItem({ label: 'test' });
+      expect(item.badge).to.be.undefined();
+    });
+
+    it('should set badge on items added to a menu', () => {
+      const menu = Menu.buildFromTemplate([
+        { label: 'test', badge: { type: 'alerts', count: 3 } }
+      ]);
+
+      expect(menu.items[0].badge).to.deep.equal({ type: 'alerts', count: 3 });
+    });
+
+    it('should update badge after item is added to a menu', () => {
+      const menu = Menu.buildFromTemplate([
+        { label: 'test', badge: { type: 'alerts', count: 1 } }
+      ]);
+
+      menu.items[0].badge = { type: 'updates', count: 5 };
+      expect(menu.items[0].badge).to.deep.equal({ type: 'updates', count: 5 });
+    });
+  });
 });

--- a/spec/api-menu-item-spec.ts
+++ b/spec/api-menu-item-spec.ts
@@ -795,17 +795,13 @@ describe('MenuItems', () => {
     });
 
     it('should set badge on items added to a menu', () => {
-      const menu = Menu.buildFromTemplate([
-        { label: 'test', badge: { type: 'alerts', count: 3 } }
-      ]);
+      const menu = Menu.buildFromTemplate([{ label: 'test', badge: { type: 'alerts', count: 3 } }]);
 
       expect(menu.items[0].badge).to.deep.equal({ type: 'alerts', count: 3 });
     });
 
     it('should update badge after item is added to a menu', () => {
-      const menu = Menu.buildFromTemplate([
-        { label: 'test', badge: { type: 'alerts', count: 1 } }
-      ]);
+      const menu = Menu.buildFromTemplate([{ label: 'test', badge: { type: 'alerts', count: 1 } }]);
 
       menu.items[0].badge = { type: 'updates', count: 5 };
       expect(menu.items[0].badge).to.deep.equal({ type: 'updates', count: 5 });

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -630,6 +630,28 @@ menuItem.click = (passedMenuItem: Electron.MenuItem, browserWindow: Electron.Bro
   console.log('click', passedMenuItem, browserWindow);
 };
 
+const badgedItem = new MenuItem({
+  label: 'Alerts',
+  badge: { type: 'alerts', count: 3 }
+});
+console.log(badgedItem.badge);
+
+const customBadgeItem = new MenuItem({
+  label: 'Custom',
+  badge: { type: 'none', content: 'New' }
+});
+customBadgeItem.badge = { type: 'updates', count: 5 };
+
+const updatesItem = new MenuItem({
+  label: 'Updates',
+  badge: { type: 'updates', count: 10 }
+});
+
+const newItemsBadge = new MenuItem({
+  label: 'New Items',
+  badge: { type: 'new-items', count: 1 }
+});
+
 // menu
 // https://github.com/electron/electron/blob/main/docs/api/menu.md
 

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -193,6 +193,7 @@ declare namespace Electron {
     commandsMap: Record<string, MenuItem>;
     groupsMap: Record<string, MenuItem[]>;
     getItemCount(): number;
+    getIndexOfCommandId(commandId: number): number;
     popupAt(
       window: BaseWindow,
       frame: WebFrameMain | undefined,
@@ -208,6 +209,7 @@ declare namespace Electron {
     setIcon(index: number, image: string | NativeImage): void;
     setRole(index: number, role: string): void;
     setCustomType(index: number, customType: string): void;
+    setBadge(index: number, badge: MenuItemBadge): void;
     insertItem(index: number, commandId: number, label: string): void;
     insertCheckItem(index: number, commandId: number, label: string): void;
     insertRadioItem(index: number, commandId: number, label: string, groupId: number): void;

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -209,7 +209,7 @@ declare namespace Electron {
     setIcon(index: number, image: string | NativeImage): void;
     setRole(index: number, role: string): void;
     setCustomType(index: number, customType: string): void;
-    setBadge(index: number, badge: MenuItemBadge): void;
+    setBadge(index: number, badge: MenuItemBadge | null): void;
     insertItem(index: number, commandId: number, label: string): void;
     insertCheckItem(index: number, commandId: number, label: string): void;
     insertRadioItem(index: number, commandId: number, label: string, groupId: number): void;


### PR DESCRIPTION
#### Description of Change

Adds a `badge` property to `MenuItem` on macOS, backed by AppKit's `NSMenuItemBadge` API (macOS 14+). The property accepts a `MenuItemBadge` object with a `type` (`alerts`, `updates`, `new-items`, or `none`) and an optional `count` or custom `content` string.

The badge can be set at construction time, updated dynamically after the item has been added to a menu, or removed by clearing the property. Invalid combinations (unknown `type`, a count badge without `count`, a `none` badge without `content`) throw a `TypeError`.

<img width="265" height="224" alt="Screenshot 2026-01-29 at 10 42 30 AM" src="https://github.com/user-attachments/assets/3de4c469-2f81-49b1-991a-735b8ebfeff0" />

<details><summary>Example</summary>
<p>

```js
const { app, BrowserWindow, Menu } = require('electron/main')

app.whenReady().then(() => {
  const mainWindow = new BrowserWindow({ height: 600, width: 600 })
  mainWindow.loadFile('index.html')

  const template = [
    {
      label: 'Hello from Electron!',
      submenu: [
        {
          label: 'I have a custom handler',
          click () {
            console.log('👋')
          }
        },
        {
          label: 'Messages',
          badge: { type: 'none', content: 'New' }
        },
        {
          label: 'Notifications',
          badge: { type: 'alerts', count: 1 }
        },
        {
          label: 'Favorites',
          badge: { type: 'none', content: '⭐' }
        }
      ]
    }
  ]

  const menu = Menu.buildFromTemplate(template)
  Menu.setApplicationMenu(menu)
})
```

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added a `badge` property to `MenuItem` on macOS 14+ for showing a count or custom text badge next to a menu item's label.

