### PR TITLE
fix: menu items not cleaned up after rebuild

### DIFF
--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -276,6 +276,7 @@ void Menu::OnMenuWillClose() {
 }
 
 void Menu::OnMenuWillShow() {
+  keep_alive_ = this;
   Emit("menu-will-show");
 }
 

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -132,7 +132,7 @@ class Menu : public gin::Wrappable<Menu>,
   int GetIndexOfCommandId(int command_id) const;
   int GetItemCount() const;
 
-  gin_helper::SelfKeepAlive<Menu> keep_alive_{this};
+  gin_helper::SelfKeepAlive<Menu> keep_alive_{nullptr};
 };
 
 }  // namespace electron::api


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/50791
Refs #48351

Menu was holding a `SelfKeepAlive` to itself from construction, so any Menu that was never opened (e.g. an application menu replaced before being shown) stayed pinned in cppgc forever. Repeated calls to `Menu.setApplicationMenu` leaked every prior Menu along with its model and items.

Restore the original `Pin`/`Unpin` lifecycle: start `keep_alive_` empty and only assign `this` in `OnMenuWillShow`. OnMenuWillClose already clears it.

<details><summary>Before</summary>
<p>

<img width="712" height="512" alt="Screenshot 2026-04-08 at 2 54 58 PM" src="https://github.com/user-attachments/assets/b929328c-0b76-424a-936d-03daab88fada" />

</p>
</details> 


<details><summary>After</summary>
<p>

<img width="712" height="512" alt="Screenshot 2026-04-08 at 2 54 26 PM" src="https://github.com/user-attachments/assets/ac52cf0d-c6d1-447e-8464-3cd47ce4acd6" />

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a memory leak where Menu items were not cleaned up after Menu.setApplicationMenu was called repeatedly.

