### PR TITLE
fix: devtools re-attaches on open when previously detached

### DIFF
--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -402,7 +402,7 @@ void InspectableWebContents::SetDockState(const std::string& state) {
     can_dock_ = false;
   } else {
     can_dock_ = true;
-    dock_state_ = IsValidDockState(state) ? state : "right";
+    dock_state_ = (state.empty() || IsValidDockState(state)) ? state : "right";
   }
 }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/50788

PR #50646 added a dock state allowlist in SetDockState() that collapsed any non-matching value to "right". `WebContents::OpenDevTools` passes an empty string when no `mode` option is given, which is the sentinel `LoadCompleted()` uses to restore `currentDockState` from prefs. The allowlist clobbered that sentinel to "right", so previously-undocked devtools would flash detached and then snap back to the right dock.

Preserve the empty string through SetDockState() so the pref-restore path runs; still reject any non-empty invalid value to keep the JS-injection guard from #50646 intact.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where DevTools would re-attach to the window when opened after previously being detached.


