### PR TITLE
fix: `webContents.print()` ignoring mediaSize when silent

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3148,16 +3148,18 @@ void OnGetDeviceNameToUse(base::WeakPtr<content::WebContents> web_contents,
         .Set(printing::kSettingMediaSizeIsDefault, true);
   };
 
-  const bool use_default_size =
-      print_settings.FindBool(kUseDefaultPrinterPageSize).value_or(false);
-  std::optional<gfx::Size> paper_size;
-  if (use_default_size)
-    paper_size = GetPrinterDefaultPaperSize(base::UTF16ToUTF8(info.second));
+  if (!print_settings.Find(printing::kSettingMediaSize)) {
+    const bool use_default_size =
+        print_settings.FindBool(kUseDefaultPrinterPageSize).value_or(false);
+    std::optional<gfx::Size> paper_size;
+    if (use_default_size)
+      paper_size = GetPrinterDefaultPaperSize(base::UTF16ToUTF8(info.second));
 
-  print_settings.Set(
-      printing::kSettingMediaSize,
-      paper_size ? make_media_size(paper_size->height(), paper_size->width())
-                 : make_media_size(297000, 210000));
+    print_settings.Set(
+        printing::kSettingMediaSize,
+        paper_size ? make_media_size(paper_size->height(), paper_size->width())
+                   : make_media_size(297000, 210000));
+  }
 
   content::RenderFrameHost* rfh = GetRenderFrameHostToUse(web_contents.get());
   if (!rfh)


### PR DESCRIPTION
#### Description of Change

Fixes: https://github.com/electron/electron/issues/50785
Refs #49523

The above PR moved the default media size fallback into `OnGetDeviceNameToUse`, but the new code unconditionally writes `kSettingMediaSize` — clobbering any mediaSize the caller had already set in `WebContents::Print()` from `options.mediaSize` / `pageSize`. As a result, silent prints with an explicit `pageSize` (e.g. "Letter") fell back to A4 with tiny content.

Only populate the default/printer media size when the caller hasn't already supplied one, preserving the precedence:
  1. user-supplied mediaSize / pageSize
  2. printer default (when usePrinterDefaultPageSize is true)
  3. A4 fallback

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where webContents.print() would ignore pageSize / mediaSize when silent was true.