### PR TITLE
refactor: remove unnecessary raw_ptr `SavePageHandler::web_contents_`

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2889,8 +2889,8 @@ v8::Local<v8::Promise> WebContents::SavePage(
     return handle;
   }
 
-  auto* handler = new SavePageHandler(web_contents(), std::move(promise));
-  handler->Handle(full_file_path, save_type);
+  auto* handler = new SavePageHandler{std::move(promise)};
+  handler->Handle(full_file_path, save_type, web_contents());
 
   return handle;
 }

--- a/shell/browser/api/save_page_handler.cc
+++ b/shell/browser/api/save_page_handler.cc
@@ -12,9 +12,8 @@
 
 namespace electron::api {
 
-SavePageHandler::SavePageHandler(content::WebContents* web_contents,
-                                 gin_helper::Promise<void> promise)
-    : web_contents_(web_contents), promise_(std::move(promise)) {}
+SavePageHandler::SavePageHandler(gin_helper::Promise<void> promise)
+    : promise_{std::move(promise)} {}
 
 SavePageHandler::~SavePageHandler() = default;
 
@@ -26,9 +25,10 @@ void SavePageHandler::OnDownloadCreated(content::DownloadManager* manager,
 }
 
 bool SavePageHandler::Handle(const base::FilePath& full_path,
-                             const content::SavePageType& save_type) {
+                             const content::SavePageType& save_type,
+                             content::WebContents* web_contents) {
   auto* download_manager =
-      web_contents_->GetBrowserContext()->GetDownloadManager();
+      web_contents->GetBrowserContext()->GetDownloadManager();
   download_manager->AddObserver(this);
   // Chromium will create a 'foo_files' directory under the directory of saving
   // page 'foo.html' for holding other resource files of 'foo.html'.
@@ -36,7 +36,7 @@ bool SavePageHandler::Handle(const base::FilePath& full_path,
       full_path.RemoveExtension().BaseName().value() +
       FILE_PATH_LITERAL("_files"));
   bool result =
-      web_contents_->SavePage(full_path, saved_main_directory_path, save_type);
+      web_contents->SavePage(full_path, saved_main_directory_path, save_type);
   download_manager->RemoveObserver(this);
   // If initialization fails which means fail to create |DownloadItem|, we need
   // to delete the |SavePageHandler| instance to avoid memory-leak.

--- a/shell/browser/api/save_page_handler.h
+++ b/shell/browser/api/save_page_handler.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_BROWSER_API_SAVE_PAGE_HANDLER_H_
 #define ELECTRON_SHELL_BROWSER_API_SAVE_PAGE_HANDLER_H_
 
-#include "base/memory/raw_ptr.h"
 #include "components/download/public/common/download_item.h"
 #include "content/public/browser/download_manager.h"
 #include "content/public/browser/save_page_type.h"
@@ -26,12 +25,12 @@ namespace electron::api {
 class SavePageHandler : private content::DownloadManager::Observer,
                         private download::DownloadItem::Observer {
  public:
-  SavePageHandler(content::WebContents* web_contents,
-                  gin_helper::Promise<void> promise);
+  explicit SavePageHandler(gin_helper::Promise<void> promise);
   ~SavePageHandler() override;
 
   bool Handle(const base::FilePath& full_path,
-              const content::SavePageType& save_type);
+              const content::SavePageType& save_type,
+              content::WebContents* web_contents);
 
  private:
   void Destroy(download::DownloadItem* item);
@@ -43,7 +42,6 @@ class SavePageHandler : private content::DownloadManager::Observer,
   // download::DownloadItem::Observer:
   void OnDownloadUpdated(download::DownloadItem* item) override;
 
-  raw_ptr<content::WebContents> web_contents_;  // weak
   gin_helper::Promise<void> promise_;
 };
 


### PR DESCRIPTION
#### Description of Change

Small cleanup PR to remove `SavePageHandler::web_contents_`. The only place it's used is in `SavePageHandler::Handle()` , so just pass it in as an argument there.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none