### PR TITLE
ci: re-check signed commits on every PR synchronize

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -442,34 +442,7 @@ jobs:
       contents: read
     needs: [docs-only, macos-x64, macos-arm64, linux-x64, linux-x64-asan, linux-arm, linux-arm64, windows-x64, windows-x86, windows-arm64]
     if: always() && github.repository == 'electron/electron' && !contains(needs.*.result, 'failure')
-    steps: 
+    steps:
     - name: GitHub Actions Jobs Done
       run: |
         echo "All GitHub Actions Jobs are done"
-
-  check-signed-commits:
-    name: Check signed commits in green PR
-    needs: gha-done
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'needs-signed-commits')}}
-    runs-on: ubuntu-slim
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Check signed commits in PR
-        uses: 1Password/check-signed-commits-action@ed2885f3ed2577a4f5d3c3fe895432a557d23d52 # v1
-        with:
-          comment: |
-            ⚠️ This PR contains unsigned commits. This repository enforces [commit signatures](https://docs.github.com/en/authentication/managing-commit-signature-verification) 
-            for all incoming PRs. To get your PR merged, please sign those commits 
-            (`git rebase --exec 'git commit -S --amend --no-edit -n' @{upstream}`) and force push them to this branch 
-            (`git push --force-with-lease`)
-
-            For more information on signing commits, see GitHub's documentation on [Telling Git about your signing key](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key).
-
-      - name: Remove needs-signed-commits label
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: |
-          gh pr edit $PR_URL --remove-label needs-signed-commits

--- a/.github/workflows/pull-request-opened-synchronized.yml
+++ b/.github/workflows/pull-request-opened-synchronized.yml
@@ -13,7 +13,6 @@ permissions: {}
 jobs:
   check-signed-commits:
     name: Check signed commits in PR
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-signed-commits')}}
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -23,9 +22,9 @@ jobs:
         uses: 1Password/check-signed-commits-action@ed2885f3ed2577a4f5d3c3fe895432a557d23d52 # v1
         with:
           comment: |
-            ⚠️ This PR contains unsigned commits. This repository enforces [commit signatures](https://docs.github.com/en/authentication/managing-commit-signature-verification) 
-            for all incoming PRs. To get your PR merged, please sign those commits 
-            (`git rebase --exec 'git commit -S --amend --no-edit -n' @{upstream}`) and force push them to this branch 
+            ⚠️ This PR contains unsigned commits. This repository enforces [commit signatures](https://docs.github.com/en/authentication/managing-commit-signature-verification)
+            for all incoming PRs. To get your PR merged, please sign those commits
+            (`git rebase --exec 'git commit -S --amend --no-edit -n' @{upstream}`) and force push them to this branch
             (`git push --force-with-lease`)
 
             For more information on signing commits, see GitHub's documentation on [Telling Git about your signing key](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key).
@@ -37,3 +36,11 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           gh pr edit $PR_URL --add-label needs-signed-commits
+
+      - name: Remove needs-signed-commits label
+        if: ${{ success() && contains(github.event.pull_request.labels.*.name, 'needs-signed-commits') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr edit $PR_URL --remove-label needs-signed-commits


### PR DESCRIPTION
#### Description of Change

The needs-signed-commits label was previously added by the lightweight synchronize workflow but only removed by a job in build.yml gated on `gha-done`, which requires every macOS/Linux/Windows build to finish green. That made label removal both slow (waits on the full pipeline) and fragile (any unrelated build failure leaves the label pinned even after commits are properly signed).

Drop the `if` guard on the synchronize job so it re-evaluates signing on every push, and add a removal step that runs on success when the label is present. Force-pushing signed commits now clears the label as soon as the check completes, with no dependency on the build pipeline.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none