### PR TITLE
fix: remove dangling raw_ptr `api::WebContents::zoom_controller_`

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -972,11 +972,12 @@ WebContents::WebContents(v8::Isolate* isolate,
 
 void WebContents::InitZoomController(content::WebContents* web_contents,
                                      const gin_helper::Dictionary& options) {
-  WebContentsZoomController::CreateForWebContents(web_contents);
-  zoom_controller_ = WebContentsZoomController::FromWebContents(web_contents);
+  WebContentsZoomController* const zoom_controller =
+      WebContentsZoomController::GetOrCreateForWebContents(web_contents);
+
   double zoom_factor;
   if (options.Get(options::kZoomFactor, &zoom_factor))
-    zoom_controller_->SetDefaultZoomFactor(zoom_factor);
+    zoom_controller->SetDefaultZoomFactor(zoom_factor);
 
   // Nothing to do with ZoomController, but this function gets called in all
   // init cases!
@@ -3867,12 +3868,16 @@ gfx::Size WebContents::GetSizeForNewRenderView(content::WebContents* wc) {
   return {};
 }
 
+WebContentsZoomController* WebContents::GetZoomController() const {
+  return WebContentsZoomController::FromWebContents(web_contents());
+}
+
 void WebContents::SetZoomLevel(double level) {
-  zoom_controller_->SetZoomLevel(level);
+  GetZoomController()->SetZoomLevel(level);
 }
 
 double WebContents::GetZoomLevel() const {
-  return zoom_controller_->GetZoomLevel();
+  return GetZoomController()->GetZoomLevel();
 }
 
 void WebContents::SetZoomFactor(gin_helper::ErrorThrower thrower,
@@ -3892,7 +3897,7 @@ double WebContents::GetZoomFactor() const {
 }
 
 void WebContents::SetTemporaryZoomLevel(double level) {
-  zoom_controller_->SetTemporaryZoomLevel(level);
+  GetZoomController()->SetTemporaryZoomLevel(level);
 }
 
 std::optional<PreloadScript> WebContents::GetPreloadScript() const {

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -380,7 +380,7 @@ class WebContents final : public ExclusiveAccessContext,
   content::RenderFrameHost* Opener();
   content::RenderFrameHost* FocusedFrame();
 
-  WebContentsZoomController* GetZoomController() { return zoom_controller_; }
+  [[nodiscard]] WebContentsZoomController* GetZoomController() const;
 
   void AddObserver(ExtendedWebContentsObserver* obs) {
     observers_.AddObserver(obs);
@@ -857,11 +857,6 @@ class WebContents final : public ExclusiveAccessContext,
   // dialog_manager_, so we can make sure inspectable_web_contents_ is
   // destroyed before dialog_manager_, otherwise a crash would happen.
   std::unique_ptr<InspectableWebContents> inspectable_web_contents_;
-
-  // The zoom controller for this webContents.
-  // Note: owned by inspectable_web_contents_, so declare this *after*
-  // that field to ensure the dtor destroys them in the right order.
-  raw_ptr<WebContentsZoomController> zoom_controller_ = nullptr;
 
   std::optional<GURL> pending_unload_url_ = std::nullopt;
 

--- a/shell/browser/extensions/api/tabs/tabs_api.cc
+++ b/shell/browser/extensions/api/tabs/tabs_api.cc
@@ -398,9 +398,7 @@ ExtensionFunction::ResponseAction TabsGetZoomFunction::Run() {
   if (!contents)
     return RespondNow(Error("No such tab"));
 
-  double zoom_level = contents->GetZoomController()->GetZoomLevel();
-  double zoom_factor = blink::ZoomLevelToZoomFactor(zoom_level);
-
+  const double zoom_factor = contents->GetZoomFactor();
   return RespondNow(ArgumentList(tabs::GetZoom::Results::Create(zoom_factor)));
 }
 
@@ -414,9 +412,9 @@ ExtensionFunction::ResponseAction TabsGetZoomSettingsFunction::Run() {
   if (!contents)
     return RespondNow(Error("No such tab"));
 
-  auto* zoom_controller = contents->GetZoomController();
-  WebContentsZoomController::ZoomMode zoom_mode =
-      contents->GetZoomController()->zoom_mode();
+  const auto* zoom_controller = contents->GetZoomController();
+  const WebContentsZoomController::ZoomMode zoom_mode =
+      zoom_controller->zoom_mode();
   tabs::ZoomSettings zoom_settings;
   ZoomModeToZoomSettings(zoom_mode, &zoom_settings);
   zoom_settings.default_zoom_factor =


### PR DESCRIPTION
#### Description of Change

Fix a dangling `raw_ptr<WebContentsZoomController> api::WebContents::zoom_controller_;` observed by running specs on a local build with dangling raw_ptr checks enabled. It's never used in any hotspots -- always triggered by events or users -- so I've fixed this dangling pointer by removing it. We now look it up when needed.  (And lookup is very cheap anyway: a static key into a small `absl::flat_hash_map`)

I've added a couple of minor side cleanups, e.g. adding `[[nodiscard]]` and removing a couple of redundant lookups.

The dangling pointer report:

```
[DanglingPtr](1/3) A raw_ptr/raw_ref is dangling.

[DanglingPtr](2/3) First, the memory was freed at:

Stack trace:
#0 0x575fe1eeb712 base::debug::CollectStackTrace() [../../base/debug/stack_trace_posix.cc:1050:7]
#1 0x575fe1ed2f31 base::debug::StackTrace::StackTrace() [../../base/debug/stack_trace.cc:280:20]
#2 0x575fe1ef2d36 base::allocator::(anonymous namespace)::DanglingRawPtrDetected() [../../base/allocator/partition_alloc_support.cc:438:11]
#3 0x575fe1faf512 allocator_shim::internal::PartitionAllocFunctionsInternal<>::FreeWithSize() [../../base/allocator/partition_allocator/src/partition_alloc/in_slot_metadata.h:389:5]
#4 0x575fdb223c56 absl::container_internal::IterateOverFullSlots() [../../third_party/abseil-cpp/absl/functional/function_ref.h:165:12]
#5 0x575fdad3ec68 absl::container_internal::raw_hash_set<>::destructor_impl() [../../third_party/abseil-cpp/absl/container/internal/raw_hash_set.h:3077:7]
#6 0x575fe1e35b3e base::SupportsUserData::~SupportsUserData() [../../third_party/abseil-cpp/absl/container/internal/raw_hash_set.h:2348:5]
#7 0x575fe068df54 content::WebContentsImpl::~WebContentsImpl() [../../content/public/browser/web_contents.h:444:35]
#8 0x575fe068efbe content::WebContentsImpl::~WebContentsImpl() [../../content/browser/web_contents/web_contents_impl.cc:1382:37]
#9 0x575fdadcf9e9 electron::InspectableWebContents::~InspectableWebContents() [../../third_party/libc++/src/include/__memory/unique_ptr.h:74:5]
#10 0x575fdadcfbbe electron::InspectableWebContents::~InspectableWebContents() [../../electron/shell/browser/ui/inspectable_web_contents.cc:354:51]
#11 0x575fdace3ab2 electron::api::WebContents::~WebContents() [../../third_party/libc++/src/include/__memory/unique_ptr.h:74:5]
#12 0x575fdace439b electron::api::WebContents::DeleteThisIfAlive() [../../electron/shell/browser/api/electron_api_web_contents.cc:1176:3]
#13 0x575fdac437bf electron::api::BrowserWindow::~BrowserWindow() [../../electron/shell/browser/api/electron_api_browser_window.cc:106:24]
#14 0x575fdac438de electron::api::BrowserWindow::~BrowserWindow() [../../electron/shell/browser/api/electron_api_browser_window.cc:101:33]
#15 0x575fdac0e3a1 base::OnceCallback<>::Run() [../../base/functional/callback.h:155:12]
#16 0x575fe1e3aab1 base::TaskAnnotator::RunTaskImpl() [../../base/task/common/task_annotator.cc:229:34]
#17 0x575fe1e70673 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl() [../../base/task/common/task_annotator.h:112:5]
#18 0x575fe1e6fa9b base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() [../../base/task/sequence_manager/thread_controller_with_message_pump_impl.cc:340:40]
#19 0x575fe1f0cdd5 base::MessagePumpGlib::Run() [../../base/message_loop/message_pump_glib.cc:782:48]
#20 0x575fe1e717ca base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run() [../../base/task/sequence_manager/thread_controller_with_message_pump_impl.cc:651:12]
#21 0x575fe1e180e6 base::RunLoop::Run() [../../base/run_loop.cc:135:14]
#22 0x575fdfc84931 content::BrowserMainLoop::RunMainMessageLoop() [../../content/browser/browser_main_loop.cc:1105:18]
#23 0x575fdfc86e81 content::BrowserMainRunnerImpl::Run() [../../content/browser/browser_main_runner_impl.cc:151:15]
#24 0x575fdfc80822 content::BrowserMain() [../../content/browser/browser_main.cc:32:28]
#25 0x575fdb4152c9 content::RunBrowserProcessMain() [../../content/app/content_main_runner_impl.cc:701:10]
#26 0x575fdb418647 content::ContentMainRunnerImpl::RunBrowser() [../../content/app/content_main_runner_impl.cc:1325:10]
#27 0x575fdb417950 content::ContentMainRunnerImpl::Run() [../../content/app/content_main_runner_impl.cc:1155:12]
#28 0x575fdb413a26 content::RunContentProcess() [../../content/app/content_main.cc:356:36]
#29 0x575fdb413c60 content::ContentMain() [../../content/app/content_main.cc:369:10]
#30 0x575fdac02555 main [../../electron/shell/app/electron_main_linux.cc:50:10]
#31 0x7dbcc842a575 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a574)
#32 0x7dbcc842a628 __libc_start_main
#33 0x575fdabe602a _start

Task trace:
#0 0x575fdac2eee4 electron::api::BaseWindow::OnWindowClosed() [../../electron/shell/browser/api/electron_api_base_window.cc:180:7]
#1 0x575fdae514a5 electron::NodeBindings::WakeupMainThread() [../../electron/shell/common/node_bindings.cc:1029:26]

[DanglingPtr](3/3) Later, the dangling raw_ptr was released at:

Stack trace:
#0 0x575fe1eeb712 base::debug::CollectStackTrace() [../../base/debug/stack_trace_posix.cc:1050:7]
#1 0x575fe1ed2f31 base::debug::StackTrace::StackTrace() [../../base/debug/stack_trace.cc:280:20]
#2 0x575fe1ef2e1d base::allocator::(anonymous namespace)::DanglingRawPtrReleased<>() [../../base/allocator/partition_alloc_support.cc:600:21]
#3 0x575fe1f307c9 base::internal::RawPtrBackupRefImpl<>::ReleaseInternal() [../../base/allocator/partition_allocator/src/partition_alloc/in_slot_metadata.h:211:7]
#4 0x575fdace3a96 electron::api::WebContents::~WebContents() [../../base/allocator/partition_allocator/src/partition_alloc/pointers/raw_ptr_backup_ref_impl.h:194:7]
#5 0x575fdace41d5 electron::api::WebContents::~WebContents() [../../electron/shell/browser/api/electron_api_web_contents.cc:1121:29]
#6 0x575fdae470bb gin_helper::CleanedUpAtExit::DoCleanup() [../../electron/shell/common/gin_helper/cleaned_up_at_exit.cc:38:5]
#7 0x575fdad7d59e electron::JavascriptEnvironment::DestroyMicrotasksRunner() [../../electron/shell/browser/javascript_environment.cc:168:5]
#8 0x575fdad52ced electron::ElectronBrowserMainParts::PostMainMessageLoopRun() [../../electron/shell/browser/electron_browser_main_parts.cc:616:12]
#9 0x575fdfc84b97 content::BrowserMainLoop::ShutdownThreadsAndCleanUp() [../../content/browser/browser_main_loop.cc:1164:13]
#10 0x575fdfc86f80 content::BrowserMainRunnerImpl::Shutdown() [../../content/browser/browser_main_runner_impl.cc:175:17]
#11 0x575fdfc80871 content::BrowserMain() [../../content/browser/browser_main.cc:41:16]
#12 0x575fdb4152c9 content::RunBrowserProcessMain() [../../content/app/content_main_runner_impl.cc:701:10]
#13 0x575fdb418647 content::ContentMainRunnerImpl::RunBrowser() [../../content/app/content_main_runner_impl.cc:1325:10]
#14 0x575fdb417950 content::ContentMainRunnerImpl::Run() [../../content/app/content_main_runner_impl.cc:1155:12]
#15 0x575fdb413a26 content::RunContentProcess() [../../content/app/content_main.cc:356:36]
#16 0x575fdb413c60 content::ContentMain() [../../content/app/content_main.cc:369:10]
#17 0x575fdac02555 main [../../electron/shell/app/electron_main_linux.cc:50:10]
#18 0x7dbcc842a575 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a574)
#19 0x7dbcc842a628 __libc_start_main
#20 0x575fdabe602a _start

Please check for more information on:
https://chromium.googlesource.com/chromium/src/+/main/docs/dangling_ptr_guide.md
```

Checks enabled by building with these flags:

```diff
diff --git a/build/args/all.gn b/build/args/all.gn
index 45939f456f..1934854c67 100644
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -53,8 +53,11 @@ use_qt6 = false
 
 # https://chromium.googlesource.com/chromium/src/+/main/docs/dangling_ptr.md
 # TODO(vertedinde): hunt down dangling pointers on Linux
-enable_dangling_raw_ptr_checks = false
-enable_dangling_raw_ptr_feature_flag = false
+is_debug = true
+enable_dangling_raw_ptr_checks = true
+enable_dangling_raw_ptr_feature_flag = true
+enable_backup_ref_ptr_support = true
+enable_backup_ref_ptr_feature_flag = true
```

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.