### PR TITLE
ci: use 32-core Windows ARC runners for builds

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -38,8 +38,8 @@ runs:
     if: ${{ runner.os == 'Windows' }}
     shell: bash
     env:
-      ELECTRON_SISO_URL: https://github.com/electron/siso/releases/download/v1.5.7-electron.1/siso-windows-amd64.exe
-      ELECTRON_SISO_SHA256: 3e5ac643e8a4c91b977c98539838815844494dfcf9412fa6a7f68f0d6927556e
+      ELECTRON_SISO_URL: https://github.com/electron/siso/releases/download/v1.5.7-electron.2/siso-windows-amd64.exe
+      ELECTRON_SISO_SHA256: 0e6b754820be3324d5ea4ca3af3634b4cfcf806d89140d78fec4e2a8ef636c9d
     run: |
       set -eo pipefail
       mkdir -p /c/electron-siso

--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -30,3 +30,19 @@ runs:
         echo "$HOME/.electron_build_tools/third_party/depot_tools" >> $GITHUB_PATH
         echo "$HOME/.electron_build_tools/third_party/depot_tools/python-bin" >> $GITHUB_PATH
       fi
+  - name: Install patched siso (Windows)
+    # Overrides the CIPD siso with a build from electron/siso that carries a
+    # retry for transient ERROR_INVALID_PARAMETER during the subninja scan on
+    # container bind-mounted out/ directories. Remove once the fix has rolled
+    # into Chromium's siso_version.
+    if: ${{ runner.os == 'Windows' }}
+    shell: bash
+    env:
+      ELECTRON_SISO_URL: https://github.com/electron/siso/releases/download/v1.5.7-electron.1/siso-windows-amd64.exe
+      ELECTRON_SISO_SHA256: 3e5ac643e8a4c91b977c98539838815844494dfcf9412fa6a7f68f0d6927556e
+    run: |
+      set -eo pipefail
+      mkdir -p /c/electron-siso
+      curl --fail --retry 3 -sSL "$ELECTRON_SISO_URL" -o /c/electron-siso/siso.exe
+      echo "$ELECTRON_SISO_SHA256  /c/electron-siso/siso.exe" | sha256sum --check --strict -
+      echo "SISO_PATH=C:\\electron-siso\\siso.exe" >> "$GITHUB_ENV"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -387,7 +387,7 @@ jobs:
     needs: checkout-windows
     if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
     with:
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: electron-arc-centralus-windows-amd64-32core
       test-runs-on: windows-latest
       target-platform: win
       target-arch: x64
@@ -406,7 +406,7 @@ jobs:
     needs: checkout-windows
     if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
     with:
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: electron-arc-centralus-windows-amd64-32core
       test-runs-on: windows-latest
       target-platform: win
       target-arch: x86
@@ -425,7 +425,7 @@ jobs:
     needs: checkout-windows
     if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
     with:
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: electron-arc-centralus-windows-amd64-32core
       test-runs-on: windows-11-arm
       target-platform: win
       target-arch: arm64

--- a/.github/workflows/windows-publish.yml
+++ b/.github/workflows/windows-publish.yml
@@ -61,7 +61,7 @@ jobs:
     needs: checkout-windows
     with:
       environment: production-release
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: electron-arc-centralus-windows-amd64-32core
       target-platform: win
       target-arch: x64
       is-release: true
@@ -80,7 +80,7 @@ jobs:
     needs: checkout-windows
     with:
       environment: production-release
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: electron-arc-centralus-windows-amd64-32core
       target-platform: win
       target-arch: arm64
       is-release: true
@@ -99,7 +99,7 @@ jobs:
     needs: checkout-windows
     with:
       environment: production-release
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: electron-arc-centralus-windows-amd64-32core
       target-platform: win
       target-arch: x86
       is-release: true


### PR DESCRIPTION
## Summary
- Switches Windows build jobs in `build.yml` and `windows-publish.yml` from the 16-core ARC runner to the new 32-core class (`electron-arc-centralus-windows-amd64-32core`)
- Runner class provisioned in electron/infra#223

## Test plan
- [ ] Windows x64/x86/arm64 build jobs on this PR schedule onto `electron-arc-centralus-windows-amd64-32core` and complete successfully