### PR TITLE
fix: remove decorateURL from default_app

### DIFF
--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -11,13 +11,6 @@ app.on('window-all-closed', () => {
   app.quit();
 });
 
-function decorateURL (url: string) {
-  // safely add `?utm_source=default_app
-  const parsedUrl = new URL(url);
-  parsedUrl.searchParams.append('utm_source', 'default_app');
-  return parsedUrl.toString();
-}
-
 // Find the shortest path to the electron binary
 const absoluteElectronPath = process.execPath;
 const relativeElectronPath = path.relative(process.cwd(), absoluteElectronPath);
@@ -69,7 +62,7 @@ async function createWindow (backgroundColor?: string) {
   mainWindow.on('ready-to-show', () => mainWindow!.show());
 
   mainWindow.webContents.setWindowOpenHandler(details => {
-    shell.openExternal(decorateURL(details.url));
+    shell.openExternal(details.url);
     return { action: 'deny' };
   });
 


### PR DESCRIPTION
#### Description of Change

With the most recent change to the default app (https://github.com/electron/electron/pull/45392), the two links below were generated. Due to having `?utm_source=default_app` appended to them, both are not correctly resolved. This PR simply removes the function that adds that parameter. CC’ing the security working group since they were also CC’ed when this function was first introduced with a list of other changes that were noted as security-related. Alternatively, if there is a security reason to keep the function, I could update this PR to allow a way to indicate that the parameter should not be added to a given url.

- https://www.electronjs.org/docs?utm_source=default_app
- https://nodejs.org/docs/v24.14.1/api?utm_source=default_app (e.g.)

cc @electron/wg-security 

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
