### PR TITLE
refactor: migrate `electron::api::Protocol` to cppgc

### DIFF
--- a/patches/chromium/chore_add_electron_objects_to_wrappablepointertag.patch
+++ b/patches/chromium/chore_add_electron_objects_to_wrappablepointertag.patch
@@ -8,10 +8,10 @@ electron objects that extend gin::Wrappable and gets
 allocated on the cpp heap
 
 diff --git a/gin/public/wrappable_pointer_tags.h b/gin/public/wrappable_pointer_tags.h
-index fee622ebde42211de6f702b754cfa38595df5a1c..6b524632ebb405e473cf4fe8e253bd13bf7b67e5 100644
+index fee622ebde42211de6f702b754cfa38595df5a1c..9f7e1b1b8d871721891255c1f21de825d0df1e30 100644
 --- a/gin/public/wrappable_pointer_tags.h
 +++ b/gin/public/wrappable_pointer_tags.h
-@@ -77,7 +77,20 @@ enum WrappablePointerTag : uint16_t {
+@@ -77,7 +77,21 @@ enum WrappablePointerTag : uint16_t {
    kWebAXObjectProxy,             // content::WebAXObjectProxy
    kWrappedExceptionHandler,      // extensions::WrappedExceptionHandler
    kIndigoContext,                // indigo::IndigoContext
@@ -24,6 +24,7 @@ index fee622ebde42211de6f702b754cfa38595df5a1c..6b524632ebb405e473cf4fe8e253bd13
 +  kElectronNetLog,                      // electron::api::NetLog
 +  kElectronPowerMonitor,                // electron::api::PowerMonitor
 +  kElectronPowerSaveBlocker,            // electron::api::PowerSaveBlocker
++  kElectronProtocol,                    // electron::api::Protocol
 +  kElectronReplyChannel,                // gin_helper::internal::ReplyChannel
 +  kElectronScreen,                      // electron::api::Screen
 +  kElectronSession,                     // electron::api::Session

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -12,6 +12,7 @@
 #include "base/no_destructor.h"
 #include "content/common/url_schemes.h"
 #include "content/public/browser/child_process_security_policy.h"
+#include "gin/converter.h"
 #include "gin/object_template_builder.h"
 #include "shell/browser/browser.h"
 #include "shell/browser/javascript_environment.h"
@@ -19,13 +20,13 @@
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/net_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
-#include "shell/common/gin_helper/handle.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/node_util.h"
 #include "shell/common/options_switches.h"
 #include "url/url_util.h"
+#include "v8/include/cppgc/allocation.h"
 
 namespace {
 
@@ -81,7 +82,8 @@ struct Converter<CustomScheme> {
 
 namespace electron::api {
 
-gin::DeprecatedWrapperInfo Protocol::kWrapperInfo = {gin::kEmbedderNativeGin};
+const gin::WrapperInfo Protocol::kWrapperInfo = {{gin::kEmbedderNativeGin},
+                                                 gin::kElectronProtocol};
 
 std::vector<std::string>& GetStandardSchemes() {
   static base::NoDestructor<std::vector<std::string>> g_standard_schemes;
@@ -296,23 +298,22 @@ void Protocol::HandleOptionalCallback(gin::Arguments* args, Error error) {
 }
 
 // static
-gin_helper::Handle<Protocol> Protocol::Create(
-    v8::Isolate* isolate,
-    ProtocolRegistry* protocol_registry) {
-  return gin_helper::CreateHandle(isolate, new Protocol{protocol_registry});
+Protocol* Protocol::Create(v8::Isolate* isolate,
+                           ProtocolRegistry* protocol_registry) {
+  return cppgc::MakeGarbageCollected<Protocol>(
+      isolate->GetCppHeap()->GetAllocationHandle(), protocol_registry);
 }
 
 // static
-gin_helper::Handle<Protocol> Protocol::New(gin_helper::ErrorThrower thrower) {
+Protocol* Protocol::New(gin_helper::ErrorThrower thrower) {
   thrower.ThrowError("Protocol cannot be created from JS");
   return {};
 }
 
 // static
-v8::Local<v8::ObjectTemplate> Protocol::FillObjectTemplate(
-    v8::Isolate* isolate,
-    v8::Local<v8::ObjectTemplate> tmpl) {
-  return gin::ObjectTemplateBuilder(isolate, GetClassName(), tmpl)
+void Protocol::FillObjectTemplate(v8::Isolate* isolate,
+                                  v8::Local<v8::ObjectTemplate> tmpl) {
+  gin::ObjectTemplateBuilder(isolate, GetClassName(), tmpl)
       .SetMethod("registerStringProtocol",
                  &Protocol::RegisterProtocolFor<ProtocolType::kString>)
       .SetMethod("registerBufferProtocol",
@@ -345,8 +346,12 @@ v8::Local<v8::ObjectTemplate> Protocol::FillObjectTemplate(
       .Build();
 }
 
-const char* Protocol::GetTypeName() {
-  return GetClassName();
+const gin::WrapperInfo* Protocol::wrapper_info() const {
+  return &kWrapperInfo;
+}
+
+const char* Protocol::GetHumanReadableName() const {
+  return "Electron / Protocol";
 }
 
 }  // namespace electron::api
@@ -372,7 +377,8 @@ void Initialize(v8::Local<v8::Object> exports,
   v8::Isolate* const isolate = electron::JavascriptEnvironment::GetIsolate();
   gin_helper::Dictionary dict{isolate, exports};
   dict.Set("Protocol",
-           electron::api::Protocol::GetConstructor(isolate, context));
+           electron::api::Protocol::GetConstructor(
+               isolate, context, &electron::api::Protocol::kWrapperInfo));
   dict.SetMethod("registerSchemesAsPrivileged", &RegisterSchemesAsPrivileged);
   dict.SetMethod("getStandardSchemes", &electron::api::GetStandardSchemes);
 }

--- a/shell/browser/api/electron_api_protocol.h
+++ b/shell/browser/api/electron_api_protocol.h
@@ -9,19 +9,13 @@
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
-#include "content/public/browser/content_browser_client.h"
+#include "gin/wrappable.h"
 #include "shell/browser/net/electron_url_loader_factory.h"
 #include "shell/common/gin_helper/constructible.h"
-#include "shell/common/gin_helper/wrappable.h"
 
 namespace gin {
 class Arguments;
 }  // namespace gin
-
-namespace gin_helper {
-template <typename T>
-class Handle;
-}  // namespace gin_helper
 
 namespace electron {
 
@@ -38,23 +32,25 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
                                  v8::Local<v8::Value> val);
 
 // Protocol implementation based on network services.
-class Protocol final : public gin_helper::DeprecatedWrappable<Protocol>,
+class Protocol final : public gin::Wrappable<Protocol>,
                        public gin_helper::Constructible<Protocol> {
  public:
-  static gin_helper::Handle<Protocol> Create(
-      v8::Isolate* isolate,
-      ProtocolRegistry* protocol_registry);
+  static Protocol* Create(v8::Isolate* isolate,
+                          ProtocolRegistry* protocol_registry);
 
   // gin_helper::Constructible
-  static gin_helper::Handle<Protocol> New(gin_helper::ErrorThrower thrower);
-  static v8::Local<v8::ObjectTemplate> FillObjectTemplate(
-      v8::Isolate* isolate,
-      v8::Local<v8::ObjectTemplate> tmpl);
+  static Protocol* New(gin_helper::ErrorThrower thrower);
+  static void FillObjectTemplate(v8::Isolate* isolate,
+                                 v8::Local<v8::ObjectTemplate> tmpl);
   static const char* GetClassName() { return "Protocol"; }
 
-  // gin_helper::Wrappable
-  static gin::DeprecatedWrapperInfo kWrapperInfo;
-  const char* GetTypeName() override;
+  // gin::Wrappable
+  static const gin::WrapperInfo kWrapperInfo;
+  const gin::WrapperInfo* wrapper_info() const override;
+  const char* GetHumanReadableName() const override;
+
+  explicit Protocol(ProtocolRegistry* protocol_registry);
+  ~Protocol() override;
 
  private:
   // Possible errors.
@@ -69,9 +65,6 @@ class Protocol final : public gin_helper::DeprecatedWrappable<Protocol>,
   // Callback types.
   using CompletionCallback =
       base::RepeatingCallback<void(v8::Local<v8::Value>)>;
-
-  explicit Protocol(ProtocolRegistry* protocol_registry);
-  ~Protocol() override;
 
   [[nodiscard]] static std::string_view ErrorCodeToString(Error error);
 

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -17,6 +17,7 @@
 #include "base/files/file_enumerator.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
+#include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"
 #include "base/strings/string_util.h"
 #include "base/types/pass_key.h"
@@ -76,6 +77,7 @@
 #include "shell/browser/media/media_device_id_salt.h"
 #include "shell/browser/net/cert_verifier_client.h"
 #include "shell/browser/net/resolve_host_function.h"
+#include "shell/browser/net/resolve_proxy_helper.h"
 #include "shell/browser/session_preferences.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/content_converter.h"
@@ -558,9 +560,7 @@ Session::Session(v8::Isolate* isolate, ElectronBrowserContext* browser_context)
 
   SessionPreferences::CreateForBrowserContext(browser_context);
 
-  protocol_.Reset(
-      isolate,
-      Protocol::Create(isolate, browser_context->protocol_registry()).ToV8());
+  protocol_ = Protocol::Create(isolate, browser_context->protocol_registry());
 
   browser_context->SetUserData(
       kElectronApiSessionKey,
@@ -1354,8 +1354,8 @@ v8::Local<v8::Value> Session::Extensions(v8::Isolate* isolate) {
   return extensions_.Get(isolate);
 }
 
-v8::Local<v8::Value> Session::Protocol(v8::Isolate* isolate) {
-  return protocol_.Get(isolate);
+api::Protocol* Session::Protocol() {
+  return protocol_.Get();
 }
 
 v8::Local<v8::Value> Session::ServiceWorkerContext(v8::Isolate* isolate) {

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
-#include "base/memory/weak_ptr.h"
 #include "base/values.h"
 #include "content/public/browser/download_manager.h"
 #include "electron/buildflags/buildflags.h"
@@ -20,7 +19,6 @@
 #include "services/network/public/mojom/ssl_config.mojom-forward.h"
 #include "shell/browser/api/ipc_dispatcher.h"
 #include "shell/browser/event_emitter_mixin.h"
-#include "shell/browser/net/resolve_proxy_helper.h"
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/self_keep_alive.h"
 
@@ -60,6 +58,7 @@ struct PreloadScript;
 namespace api {
 
 class NetLog;
+class Protocol;
 class WebRequest;
 
 class Session final : public gin::Wrappable<Session>,
@@ -167,7 +166,7 @@ class Session final : public gin::Wrappable<Session>,
       const gin_helper::Dictionary& options);
   v8::Local<v8::Value> Cookies(v8::Isolate* isolate);
   v8::Local<v8::Value> Extensions(v8::Isolate* isolate);
-  v8::Local<v8::Value> Protocol(v8::Isolate* isolate);
+  api::Protocol* Protocol();
   v8::Local<v8::Value> ServiceWorkerContext(v8::Isolate* isolate);
   WebRequest* WebRequest(v8::Isolate* isolate);
   api::NetLog* NetLog(v8::Isolate* isolate);
@@ -214,7 +213,7 @@ class Session final : public gin::Wrappable<Session>,
   // Cached gin_helper::Wrappable objects.
   v8::TracedReference<v8::Value> cookies_;
   v8::TracedReference<v8::Value> extensions_;
-  v8::TracedReference<v8::Value> protocol_;
+  cppgc::Member<api::Protocol> protocol_;
   cppgc::Member<api::NetLog> net_log_;
   v8::TracedReference<v8::Value> service_worker_context_;
   cppgc::Member<api::WebRequest> web_request_;

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "base/command_line.h"
+#include "base/functional/callback_helpers.h"
 #include "base/strings/string_split.h"
 #include "components/network_hints/renderer/web_prescient_networking_impl.h"
 #include "content/common/buildflags.h"


### PR DESCRIPTION
#### Description of Change

Migrate `electron::api::Protocol` to cppgc.

Prerequisite for https://github.com/electron/electron/pull/50829.
Subtask of https://github.com/electron/electron/issues/47922.

CC @deepak1556 

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.