### PR TITLE
fix: guard permission handlers in File System API tests

### DIFF
--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -993,6 +993,9 @@ describe('chromium features', () => {
     let w: BrowserWindow | null = null;
 
     afterEach(() => {
+      ipcMain.removeAllListeners('did-create-file-handle');
+      ipcMain.removeAllListeners('did-create-directory-handle');
+      session.defaultSession.setPermissionCheckHandler(null);
       session.defaultSession.setPermissionRequestHandler(null);
       closeAllWindows();
     });
@@ -1134,18 +1137,20 @@ describe('chromium features', () => {
       });
 
       w.webContents.session.setPermissionRequestHandler((wc, permission, callback, details) => {
-        expect(permission).to.equal('fileSystem');
+        if (permission === 'fileSystem') {
+          const { href } = url.pathToFileURL(writablePath);
+          expect(details).to.deep.equal({
+            fileAccessType: 'writable',
+            isDirectory: false,
+            isMainFrame: true,
+            filePath: testFile,
+            requestingUrl: href
+          });
 
-        const { href } = url.pathToFileURL(writablePath);
-        expect(details).to.deep.equal({
-          fileAccessType: 'writable',
-          isDirectory: false,
-          isMainFrame: true,
-          filePath: testFile,
-          requestingUrl: href
-        });
-
-        callback(true);
+          callback(true);
+          return;
+        }
+        callback(false);
       });
 
       ipcMain.once('did-create-file-handle', async () => {
@@ -1185,17 +1190,19 @@ describe('chromium features', () => {
       });
 
       w.webContents.session.setPermissionRequestHandler((wc, permission, callback, details) => {
-        expect(permission).to.equal('fileSystem');
+        if (permission === 'fileSystem') {
+          const { href } = url.pathToFileURL(writablePath);
+          expect(details).to.deep.equal({
+            fileAccessType: 'writable',
+            isDirectory: false,
+            isMainFrame: true,
+            filePath: testFile,
+            requestingUrl: href
+          });
 
-        const { href } = url.pathToFileURL(writablePath);
-        expect(details).to.deep.equal({
-          fileAccessType: 'writable',
-          isDirectory: false,
-          isMainFrame: true,
-          filePath: testFile,
-          requestingUrl: href
-        });
-
+          callback(false);
+          return;
+        }
         callback(false);
       });
 
@@ -1287,12 +1294,13 @@ describe('chromium features', () => {
       });
 
       w.webContents.session.setPermissionCheckHandler((wc, permission, origin, details) => {
-        expect(permission).to.equal('fileSystem');
-
-        const { fileAccessType, isDirectory, filePath } = details;
-        expect(fileAccessType).to.equal('readable');
-        expect(isDirectory).to.be.true();
-        expect(filePath).to.equal(testDir);
+        if (permission === 'fileSystem') {
+          const { fileAccessType, isDirectory, filePath } = details;
+          expect(fileAccessType).to.equal('readable');
+          expect(isDirectory).to.be.true();
+          expect(filePath).to.equal(testDir);
+          return false;
+        }
         return false;
       });
 


### PR DESCRIPTION
#### Description of Change

Fix flaky tests that are causing a lot of CI failures in 42-x-y.

I'm PR'ing this branch directly for `42-x-y`  instead of `main` because @deepak1556 already landed part of this cleanup (the remove ipcMain listener part) as a side refactor of 542ff828aba8047e747ec8b9fda5a2d4792cb4ee. I'll make a separate `no-backport` PR for `main` if this one goes green.

1. Chromium can fire unrelated permission checks (e.g. 'background-sync') on the default session. Copy a safeguard `permission === 'fileSystem'` from "calls twice when trying to query a read/write file handle permissions".
2. add afterEach cleanup: reset setPermissionCheckHandler(null) and remove ipcMain listeners for 'did-create-file-handle' and 'did-create-directory-handle'.

The CI failures at issue: `42-x-y`:

```
2026-04-08T22:21:57.7418240Z Failure in test: "chromium features File System API, allows permission when trying to create a writable file handle"
2026-04-08T22:21:57.7428440Z Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts)
2026-04-08T22:21:57.7431540Z     at createTimeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/errors.js:498:15)
2026-04-08T22:21:57.7433930Z     at Test.Runnable._timeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/runnable.js:429:10)
2026-04-08T22:21:57.7435600Z Retrying test (2/3)...
2026-04-08T22:22:27.7665770Z Failure in test: "chromium features File System API, allows permission when trying to create a writable file handle"
2026-04-08T22:22:27.7675610Z Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts)
2026-04-08T22:22:27.7677890Z     at createTimeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/errors.js:498:15)
2026-04-08T22:22:27.7679660Z     at Test.Runnable._timeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/runnable.js:429:10)
2026-04-08T22:22:27.7680880Z Retrying test (3/3)...
2026-04-08T22:22:57.7890910Z not ok 1660 chromium features File System API, allows permission when trying to create a writable file handle
2026-04-08T22:22:57.7893010Z   Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts)
2026-04-08T22:22:57.7895700Z   Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts)
2026-04-08T22:22:57.7897470Z       at listOnTimeout (node:internal/timers:605:17)
2026-04-08T22:22:57.7898140Z       at processTimers (node:internal/timers:541:7)
2026-04-08T22:23:27.8093180Z Failure in test: "chromium features File System API, denies permission when trying to create a writable file handle"
2026-04-08T22:23:27.8100640Z Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts)
2026-04-08T22:23:27.8102880Z     at createTimeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/errors.js:498:15)
2026-04-08T22:23:27.8104620Z     at Test.Runnable._timeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/runnable.js:429:10)
2026-04-08T22:23:27.8105780Z Retrying test (1/3)...
2026-04-08T22:23:57.8708110Z Failure in test: "chromium features File System API, denies permission when trying to create a writable file handle"
2026-04-08T22:23:57.8715790Z Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts)
2026-04-08T22:23:57.8718330Z     at createTimeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/errors.js:498:15)
2026-04-08T22:23:57.8720070Z     at Test.Runnable._timeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/runnable.js:429:10)
2026-04-08T22:23:57.8721240Z Retrying test (2/3)...
2026-04-08T22:24:27.9223190Z Failure in test: "chromium features File System API, denies permission when trying to create a writable file handle"
2026-04-08T22:24:27.9231760Z Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts)
2026-04-08T22:24:27.9234850Z     at createTimeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/errors.js:498:15)
2026-04-08T22:24:27.9238350Z     at Test.Runnable._timeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/runnable.js:429:10)
2026-04-08T22:24:27.9240010Z Retrying test (3/3)...
2026-04-08T22:24:57.9447410Z not ok 1661 chromium features File System API, denies permission when trying to create a writable file handle
2026-04-08T22:24:57.9449910Z   Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts)
2026-04-08T22:24:57.9452690Z   Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts)
2026-04-08T22:24:57.9454450Z       at listOnTimeout (node:internal/timers:605:17)
2026-04-08T22:24:57.9455150Z       at processTimers (node:internal/timers:541:7)
2026-04-08T22:25:27.9656430Z Failure in test: "chromium features File System API, calls twice when trying to query a read/write file handle permissions"
2026-04-08T22:25:27.9661790Z Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts)
2026-04-08T22:25:27.9664030Z     at createTimeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/errors.js:498:15)
2026-04-08T22:25:27.9665770Z     at Test.Runnable._timeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/runnable.js:429:10)
2026-04-08T22:25:27.9666970Z Retrying test (1/3)...
2026-04-08T22:25:57.9852620Z Failure in test: "chromium features File System API, calls twice when trying to query a read/write file handle permissions"
2026-04-08T22:25:57.9857640Z Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts)
2026-04-08T22:25:57.9859910Z     at createTimeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/errors.js:498:15)
2026-04-08T22:25:57.9861770Z     at Test.Runnable._timeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/runnable.js:429:10)
2026-04-08T22:25:57.9862940Z Retrying test (2/3)...
2026-04-08T22:25:58.0372900Z (node:32083) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 did-create-file-handle listeners added to [IpcMainImpl]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit
2026-04-08T22:26:28.0062660Z Failure in test: "chromium features File System API, calls twice when trying to query a read/write file handle permissions"
2026-04-08T22:26:28.0067080Z Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts)
2026-04-08T22:26:28.0070030Z     at createTimeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/errors.js:498:15)
2026-04-08T22:26:28.0071760Z     at Test.Runnable._timeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/runnable.js:429:10)
2026-04-08T22:26:28.0072940Z Retrying test (3/3)...
2026-04-08T22:26:58.0320070Z not ok 1662 chromium features File System API, calls twice when trying to query a read/write file handle permissions
2026-04-08T22:26:58.0323380Z   Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts)
2026-04-08T22:26:58.0327330Z   Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts)
2026-04-08T22:26:58.0330070Z       at listOnTimeout (node:internal/timers:605:17)
2026-04-08T22:26:58.0331850Z       at processTimers (node:internal/timers:541:7)
2026-04-08T22:27:18.3207010Z Unhandled exception in main spec runner: AssertionError: expected 'background-sync' to equal 'fileSystem'
2026-04-08T22:27:18.3208790Z     at Function.<anonymous> (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts:1290:31) {
2026-04-08T22:27:18.3209830Z   showDiff: true,
2026-04-08T22:27:18.3210250Z   actual: 'background-sync',
2026-04-08T22:27:18.3210730Z   expected: 'fileSystem',
2026-04-08T22:27:18.3211180Z   operator: 'strictEqual'
2026-04-08T22:27:18.3211770Z }
2026-04-08T22:27:18.3256150Z Failure in test: "chromium features File System API, correctly denies permissions after creating a readable directory handle"
2026-04-08T22:27:18.3257490Z AssertionError: expected 'background-sync' to equal 'fileSystem'
2026-04-08T22:27:18.3258670Z     at Function.<anonymous> (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts:1290:31)
2026-04-08T22:27:18.3259660Z Retrying test (1/3)...
2026-04-08T22:27:18.3266590Z Unhandled exception in main spec runner: AssertionError: expected 'background-sync' to equal 'fileSystem'
2026-04-08T22:27:18.3268080Z     at Function.<anonymous> (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts:1290:31) {
2026-04-08T22:27:18.3269070Z   showDiff: true,
2026-04-08T22:27:18.3269500Z   actual: 'background-sync',
2026-04-08T22:27:18.3269970Z   expected: 'fileSystem',
2026-04-08T22:27:18.3270430Z   operator: 'strictEqual'
2026-04-08T22:27:18.3270850Z }
2026-04-08T22:27:18.3315150Z not ok 1663 chromium features File System API, correctly denies permissions after creating a readable directory handle
2026-04-08T22:27:18.3318250Z   done() called multiple times in test <chromium features File System API, correctly denies permissions after creating a readable directory handle> of file /Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts; in addition, done() received error: AssertionError: expected 'background-sync' to equal 'fileSystem'
2026-04-08T22:27:18.3321280Z       at Function.<anonymous> (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts:1290:31) {
2026-04-08T22:27:18.3334300Z     showDiff: true,
2026-04-08T22:27:18.3334730Z     actual: 'background-sync',
2026-04-08T22:27:18.3335210Z     expected: 'fileSystem',
2026-04-08T22:27:18.3335690Z     operator: 'strictEqual',
2026-04-08T22:27:18.3336150Z     uncaught: true
2026-04-08T22:27:18.3336530Z   }
2026-04-08T22:27:18.3338890Z   Error: done() called multiple times in test <chromium features File System API, correctly denies permissions after creating a readable directory handle> of file /Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts; in addition, done() received error: AssertionError: expected 'background-sync' to equal 'fileSystem'
2026-04-08T22:27:18.3342740Z       at Function.<anonymous> (/Users/runner/work/electron/electron/src/electron/spec/chromium-spec.ts:1290:31) {
2026-04-08T22:27:18.3343750Z     showDiff: true,
2026-04-08T22:27:18.3344180Z     actual: 'background-sync',
2026-04-08T22:27:18.3344670Z     expected: 'fileSystem',
2026-04-08T22:27:18.3345140Z     operator: 'strictEqual',
2026-04-08T22:27:18.3345590Z     uncaught: true
2026-04-08T22:27:18.3345970Z   }
```

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.