### PR TITLE
fix: use original-order argv for CheckCommandLineArguments on Windows

### DIFF
--- a/shell/app/electron_main_win.cc
+++ b/shell/app/electron_main_win.cc
@@ -222,7 +222,8 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
   CHECK_EQ(fiber_status, FiberStatus::kSuccess);
 #endif  // defined(ARCH_CPU_32_BITS)
 
-  if (!electron::CheckCommandLineArguments(command_line->argv()))
+  if (!electron::CheckCommandLineArguments(
+          electron::ElectronCommandLine::argv()))
     return -1;
 
   sandbox::SandboxInterfaceInfo sandbox_info = {nullptr};


### PR DESCRIPTION
`CheckCommandLineArguments` is order-sensitive, but `base::CommandLine::argv()` returns a reconstructed `[program, switches..., args...]` vector rather than the original token order. Use `ElectronCommandLine::argv()` (the raw `CommandLineToArgvW` result already captured a few lines earlier) instead.

Notes: none