### PR TITLE
fix: `simpleFullScreen` exits when web content calls `requestFullscreen`

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -4502,7 +4502,8 @@ void WebContents::OnDevToolsSearchCompleted(
 
 void WebContents::SetHtmlApiFullscreen(bool enter_fullscreen) {
   // Window is already in fullscreen mode, save the state.
-  if (enter_fullscreen && owner_window()->IsFullscreen()) {
+  if (enter_fullscreen && (owner_window()->IsFullscreen() ||
+                           owner_window()->IsSimpleFullScreen())) {
     native_fullscreen_ = true;
     UpdateHtmlApiFullscreen(true);
     return;

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6598,6 +6598,26 @@ describe('BrowserWindow module', () => {
         w.setFullScreen(!w.isFullScreen());
       });
 
+      ifit(process.platform === 'darwin')('does not exit simpleFullScreen when requestFullscreen is called', async () => {
+        const w = new BrowserWindow();
+        await w.loadFile(path.join(fixtures, 'pages', 'a.html'));
+
+        w.setSimpleFullScreen(true);
+        expect(w.isSimpleFullScreen()).to.be.true('isSimpleFullScreen');
+
+        const enterHtmlFS = once(w.webContents, 'enter-html-full-screen');
+        await w.webContents.executeJavaScript('document.getElementById("div").requestFullscreen()', true);
+        await enterHtmlFS;
+
+        expect(w.isSimpleFullScreen()).to.be.true('isSimpleFullScreen after requestFullscreen');
+
+        const leaveHtmlFS = once(w.webContents, 'leave-html-full-screen');
+        await w.webContents.executeJavaScript('document.exitFullscreen()');
+        await leaveHtmlFS;
+
+        expect(w.isSimpleFullScreen()).to.be.true('isSimpleFullScreen after exitFullscreen');
+      });
+
       it('should not be changed by setKiosk method', async () => {
         const w = new BrowserWindow();
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/50842

`SetHtmlApiFullscreen` only `checked IsFullscreen()` to detect that the window was already fullscreen, missing the simple-fullscreen case on macOS. When web content triggered `requestFullscreen` the code fell through to `SetFullScreen(true)` which toggled simple fullscreen off.

Include `IsSimpleFullScreen()` in the guard so the HTML-API fullscreen state is updated without touching the window's fullscreen mode.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `setSimpleFullScreen` on macOS would exit when web content called `requestFullscreen()`.