### PR TITLE
fix: shutdown crash when unregistering power notification on windows

### DIFF
--- a/shell/browser/api/electron_api_power_monitor.h
+++ b/shell/browser/api/electron_api_power_monitor.h
@@ -89,6 +89,9 @@ class PowerMonitor final : public gin::Wrappable<PowerMonitor>,
 
   // The window used for processing events.
   HWND window_;
+
+  // Handle returned by RegisterSuspendResumeNotification.
+  HPOWERNOTIFY power_notify_handle_ = nullptr;
 #endif
 
 #if BUILDFLAG(IS_LINUX)

--- a/shell/browser/api/electron_api_power_monitor.h
+++ b/shell/browser/api/electron_api_power_monitor.h
@@ -8,7 +8,6 @@
 #include "base/power_monitor/power_observer.h"
 #include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
-#include "shell/common/gin_helper/self_keep_alive.h"
 
 #if BUILDFLAG(IS_LINUX)
 #include "shell/browser/lib/power_observer_linux.h"
@@ -97,8 +96,6 @@ class PowerMonitor final : public gin::Wrappable<PowerMonitor>,
 #if BUILDFLAG(IS_LINUX)
   PowerObserverLinux power_observer_linux_{this};
 #endif
-
-  gin_helper::SelfKeepAlive<PowerMonitor> keep_alive_{this};
 };
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -92,7 +92,7 @@ LRESULT CALLBACK PowerMonitor::WndProc(HWND hwnd,
     }
     if (should_treat_as_current_session) {
       if (wparam == WTS_SESSION_LOCK) {
-        // SelfKeepAlive prevents GC of this object, so Unretained is safe.
+        // JS module reference prevents GC of this object, so Unretained is safe.
         content::GetUIThreadTaskRunner({})->PostTask(
             FROM_HERE,
             base::BindOnce([](PowerMonitor* pm) { pm->Emit("lock-screen"); },

--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -45,14 +45,16 @@ void PowerMonitor::InitPlatformSpecificMonitors() {
 
   // For Windows 8 and later, a new "connected standby" mode has been added and
   // we must explicitly register for its notifications.
-  RegisterSuspendResumeNotification(static_cast<HANDLE>(window_),
-                                    DEVICE_NOTIFY_WINDOW_HANDLE);
+  power_notify_handle_ = RegisterSuspendResumeNotification(
+      static_cast<HANDLE>(window_), DEVICE_NOTIFY_WINDOW_HANDLE);
 }
 
 void PowerMonitor::DestroyPlatformSpecificMonitors() {
   if (window_) {
     WTSUnRegisterSessionNotification(window_);
-    UnregisterSuspendResumeNotification(static_cast<HANDLE>(window_));
+    if (power_notify_handle_) {
+      UnregisterSuspendResumeNotification(power_notify_handle_);
+    }
     gfx::SetWindowUserData(window_, nullptr);
     DestroyWindow(window_);
     window_ = nullptr;

--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -47,6 +47,8 @@ void PowerMonitor::InitPlatformSpecificMonitors() {
   // we must explicitly register for its notifications.
   power_notify_handle_ = RegisterSuspendResumeNotification(
       static_cast<HANDLE>(window_), DEVICE_NOTIFY_WINDOW_HANDLE);
+  PLOG_IF(ERROR, !power_notify_handle_)
+      << "RegisterSuspendResumeNotification failed";
 }
 
 void PowerMonitor::DestroyPlatformSpecificMonitors() {
@@ -54,6 +56,7 @@ void PowerMonitor::DestroyPlatformSpecificMonitors() {
     WTSUnRegisterSessionNotification(window_);
     if (power_notify_handle_) {
       UnregisterSuspendResumeNotification(power_notify_handle_);
+      power_notify_handle_ = nullptr;
     }
     gfx::SetWindowUserData(window_, nullptr);
     DestroyWindow(window_);

--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -92,7 +92,8 @@ LRESULT CALLBACK PowerMonitor::WndProc(HWND hwnd,
     }
     if (should_treat_as_current_session) {
       if (wparam == WTS_SESSION_LOCK) {
-        // JS module reference prevents GC of this object, so Unretained is safe.
+        // JS module reference prevents GC of this object, so Unretained is
+        // safe.
         content::GetUIThreadTaskRunner({})->PostTask(
             FROM_HERE,
             base::BindOnce([](PowerMonitor* pm) { pm->Emit("lock-screen"); },

--- a/spec/cpp-heap-spec.ts
+++ b/spec/cpp-heap-spec.ts
@@ -315,4 +315,44 @@ describe('cpp heap', () => {
       expect(result).to.equal(true);
     });
   });
+
+  describe('powerMonitor module', () => {
+    it('should retain native PowerMonitor via JS module reference', async () => {
+      const rc = await startRemoteControlApp(['--expose-internals', '--js-flags=--expose-gc']);
+      const result = await rc.remotely(async (heap: string) => {
+        const { powerMonitor, app } = require('electron');
+        const { recordState } = require(heap);
+        const v8Util = (process as any)._linkedBinding('electron_common_v8_util');
+
+        // Register a listener to trigger native PowerMonitor creation.
+        const listener = () => {};
+        powerMonitor.on('suspend', listener);
+
+        // Add and remove several listeners to exercise the path,
+        // then GC to ensure no duplicate native objects are created.
+        for (let i = 0; i < 5; i++) {
+          const tmp = () => {};
+          powerMonitor.on('resume', tmp);
+          powerMonitor.removeListener('resume', tmp);
+        }
+
+        v8Util.requestGarbageCollectionForTesting();
+
+        const state = recordState();
+        const nodes = state.snapshot.filter(
+          (node: any) => node.name === 'Electron / PowerMonitor'
+        );
+        const found = nodes.length > 0;
+        const noDuplicates = nodes.length === 1;
+
+        setTimeout(() => app.quit());
+        return { found, noDuplicates };
+      }, path.join(__dirname, '../../third_party/electron_node/test/common/heap'));
+
+      const [code] = await once(rc.process, 'exit');
+      expect(code).to.equal(0);
+      expect(result.found).to.equal(true, 'PowerMonitor should be in snapshot (held by JS module)');
+      expect(result.noDuplicates).to.equal(true, 'should have exactly one PowerMonitor instance');
+    });
+  });
 });


### PR DESCRIPTION
#### Description of Change

Extracted from https://github.com/electron/electron/pull/50465
Followup to https://github.com/electron/electron/pull/50045

Refs https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-unregistersuspendresumenotification
the handle to unregister should be the return value of registeration api not the window handle.

#### Release Notes

Notes: Fixed shutdown crash on windows when power monitor notifications were subscribed.