### PR TITLE
chore: cherry-pick 1fd9cf824950 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -163,3 +163,4 @@ fix_out-of-bounds_read_in_diff_rulesets.patch
 extensions_return_early_from_urlpattern_isvalidscheme.patch
 feat_allow_enabling_extensions_on_custom_protocols.patch
 cherry-pick-89b42d2d3326.patch
+cherry-pick-1fd9cf824950.patch

--- a/patches/chromium/cherry-pick-1fd9cf824950.patch
+++ b/patches/chromium/cherry-pick-1fd9cf824950.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Tue, 31 Mar 2026 14:10:01 -0700
+Subject: Limit file size for GTK3 file chooser preview images
+
+The GTK3 file chooser preview loads selected files via
+gdk_pixbuf_new_from_file_at_size(), which decodes the entire file into
+memory before scaling. For very large images (e.g. uncompressed TIFFs
+over 1 GB), this causes excessive memory allocation and can crash the
+process.
+
+Add a 100 MB file size limit to OnUpdatePreview() so that oversized
+files are skipped rather than decoded. The limit is applied alongside
+the existing regular-file check using the stat result already available.
+
+Bug: none
+Change-Id: I4cf6f7e03b5d26af82b0f1fd2742108aa8883db3
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7715599
+Reviewed-by: Thomas Anderson <thomasanderson@chromium.org>
+Reviewed-by: Avi Drissman <avi@chromium.org>
+Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1608089}
+
+diff --git a/ui/gtk/select_file_dialog_linux_gtk.cc b/ui/gtk/select_file_dialog_linux_gtk.cc
+index e1c5c8e9241d29668d0c7dae12a46a5ded900fac..49d7c37991ea40ce43f8ac04645f1e29d66d793f 100644
+--- a/ui/gtk/select_file_dialog_linux_gtk.cc
++++ b/ui/gtk/select_file_dialog_linux_gtk.cc
+@@ -16,6 +16,7 @@
+ #include <utility>
+ #include <vector>
+ 
++#include "base/byte_size.h"
+ #include "base/logging.h"
+ #include "base/memory/ptr_util.h"
+ #include "base/no_destructor.h"
+@@ -669,8 +670,12 @@ void SelectFileDialogLinuxGtk::OnUpdatePreview(GtkWidget* chooser) {
+ 
+   // Don't attempt to open anything which isn't a regular file. If a named pipe,
+   // this may hang. See https://crbug.com/534754.
++  // Don't attempt to preview files over 100MB to avoid excessive memory use
++  // and crashes when decoding very large images.
+   struct stat stat_buf;
+-  if (stat(filename, &stat_buf) != 0 || !S_ISREG(stat_buf.st_mode)) {
++  constexpr base::ByteSize kMaxPreviewFileSize = base::MiBU(100);
++  if (stat(filename, &stat_buf) != 0 || !S_ISREG(stat_buf.st_mode) ||
++      static_cast<uint64_t>(stat_buf.st_size) > kMaxPreviewFileSize.InBytes()) {
+     g_free(filename);
+     gtk_file_chooser_set_preview_widget_active(GTK_FILE_CHOOSER(chooser),
+                                                FALSE);


### PR DESCRIPTION
Limit file size for GTK3 file chooser preview images

The GTK3 file chooser preview loads selected files via
gdk_pixbuf_new_from_file_at_size(), which decodes the entire file into
memory before scaling. For very large images (e.g. uncompressed TIFFs
over 1 GB), this causes excessive memory allocation and can crash the
process.

Add a 100 MB file size limit to OnUpdatePreview() so that oversized
files are skipped rather than decoded. The limit is applied alongside
the existing regular-file check using the stat result already available.

Bug: none
Change-Id: I4cf6f7e03b5d26af82b0f1fd2742108aa8883db3
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7715599
Reviewed-by: Thomas Anderson <thomasanderson@chromium.org>
Reviewed-by: Avi Drissman <avi@chromium.org>
Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1608089}


Notes: Backported fix for none.