### PR TITLE
test: guard permission handlers in File System API tests

### DIFF
--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -995,6 +995,7 @@ describe('chromium features', () => {
     afterEach(() => {
       ipcMain.removeAllListeners('did-create-file-handle');
       ipcMain.removeAllListeners('did-create-directory-handle');
+      session.defaultSession.setPermissionCheckHandler(null);
       session.defaultSession.setPermissionRequestHandler(null);
       closeAllWindows();
     });
@@ -1136,18 +1137,20 @@ describe('chromium features', () => {
       });
 
       w.webContents.session.setPermissionRequestHandler((wc, permission, callback, details) => {
-        expect(permission).to.equal('fileSystem');
+        if (permission === 'fileSystem') {
+          const { href } = url.pathToFileURL(writablePath);
+          expect(details).to.deep.equal({
+            fileAccessType: 'writable',
+            isDirectory: false,
+            isMainFrame: true,
+            filePath: testFile,
+            requestingUrl: href
+          });
 
-        const { href } = url.pathToFileURL(writablePath);
-        expect(details).to.deep.equal({
-          fileAccessType: 'writable',
-          isDirectory: false,
-          isMainFrame: true,
-          filePath: testFile,
-          requestingUrl: href
-        });
-
-        callback(true);
+          callback(true);
+          return;
+        }
+        callback(false);
       });
 
       ipcMain.once('did-create-file-handle', async () => {
@@ -1188,17 +1191,19 @@ describe('chromium features', () => {
       });
 
       w.webContents.session.setPermissionRequestHandler((wc, permission, callback, details) => {
-        expect(permission).to.equal('fileSystem');
+        if (permission === 'fileSystem') {
+          const { href } = url.pathToFileURL(writablePath);
+          expect(details).to.deep.equal({
+            fileAccessType: 'writable',
+            isDirectory: false,
+            isMainFrame: true,
+            filePath: testFile,
+            requestingUrl: href
+          });
 
-        const { href } = url.pathToFileURL(writablePath);
-        expect(details).to.deep.equal({
-          fileAccessType: 'writable',
-          isDirectory: false,
-          isMainFrame: true,
-          filePath: testFile,
-          requestingUrl: href
-        });
-
+          callback(false);
+          return;
+        }
         callback(false);
       });
 
@@ -1292,12 +1297,13 @@ describe('chromium features', () => {
       });
 
       w.webContents.session.setPermissionCheckHandler((wc, permission, origin, details) => {
-        expect(permission).to.equal('fileSystem');
-
-        const { fileAccessType, isDirectory, filePath } = details;
-        expect(fileAccessType).to.equal('readable');
-        expect(isDirectory).to.be.true();
-        expect(filePath).to.equal(testDir);
+        if (permission === 'fileSystem') {
+          const { fileAccessType, isDirectory, filePath } = details;
+          expect(fileAccessType).to.equal('readable');
+          expect(isDirectory).to.be.true();
+          expect(filePath).to.equal(testDir);
+          return false;
+        }
         return false;
       });
 


### PR DESCRIPTION
#### Description of Change

Port of #50865 to `main`. Porting manually was necessary due to code shear between `main` and `42-x-y`.

Fix flaky tests that were causing CI failures.

1. Chromium can fire unrelated permission checks (e.g. 'background-sync') on the default session. Copy a safeguard `permission === 'fileSystem'` from "calls twice when trying to query a read/write file handle permissions".

2. add afterEach cleanup, reset `setPermissionCheckHandler(null)`.

CC @codebytere and @dsanders11, who reviewed 50865.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none