### PR TITLE
fix: preference initialization with `app.setPath('sessionData')`

### DIFF
--- a/shell/browser/browser_process_impl.cc
+++ b/shell/browser/browser_process_impl.cc
@@ -10,6 +10,7 @@
 
 #include "base/command_line.h"
 #include "base/files/file_path.h"
+#include "base/files/file_util.h"
 #include "base/functional/bind.h"
 #include "base/notimplemented.h"
 #include "base/path_service.h"
@@ -20,7 +21,6 @@
 #include "components/os_crypt/sync/os_crypt.h"
 #include "components/prefs/in_memory_pref_store.h"
 #include "components/prefs/json_pref_store.h"
-#include "components/prefs/overlay_user_pref_store.h"
 #include "components/prefs/pref_registry.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
@@ -153,16 +153,19 @@ void BrowserProcessImpl::PostEarlyInitialization() {
   ApplyProxyModeFromCommandLine(in_memory_pref_store());
   prefs_factory.set_command_line_prefs(in_memory_pref_store());
 
-  // Only use a persistent prefs store when cookie encryption is enabled as that
-  // is the only key that needs it
   base::FilePath prefs_path;
   CHECK(base::PathService::Get(electron::DIR_SESSION_DATA, &prefs_path));
+  if (!base::DirectoryExists(prefs_path))
+    base::CreateDirectory(prefs_path);
   prefs_path = prefs_path.Append(FILE_PATH_LITERAL("Local State"));
+
   electron::ScopedAllowBlockingForElectron allow_blocking;
   scoped_refptr<JsonPrefStore> user_pref_store =
       base::MakeRefCounted<JsonPrefStore>(prefs_path);
   user_pref_store->ReadPrefs();
   prefs_factory.set_user_prefs(user_pref_store);
+  DCHECK(user_pref_store->IsInitializationComplete());
+
   local_state_ = prefs_factory.Create(std::move(pref_registry));
 }
 


### PR DESCRIPTION
#### Description of Change

Refs #24280.

With #50892, the test [`app module setPath(name, path) sessionData can be changed`](https://github.com/electron/electron/blob/c0f187f90ddfaba6168dd07a1b689797f0078dc4/spec/api-app-spec.ts#L1279-L1284) would fail.

That test changes the `sessionData` path to a non-existent directory. Preference initialization would [fail](https://source.chromium.org/chromium/chromium/src/+/main:components/prefs/json_pref_store.cc;l=445;drc=98cab975b446ca270e595f3ba4894eb2de0a7881) because the [directory did not exist](https://source.chromium.org/chromium/chromium/src/+/main:components/prefs/json_pref_store.cc;l=119;drc=0a39e93d5a632021d620eca8115ba583b8fc6b49). Thus, Chromium would crash at [this `DCHECK`](https://source.chromium.org/chromium/chromium/src/+/main:components/metrics/clean_exit_beacon.cc;l=225-226;drc=a3374d188bd2bc5208be3d9c8a7f1426702e0510). As a result, the test would fail.

This PR changes the code to create the `sessionData` directory if it does not exist.

Our tests will check against regressions for this once the aforementioned PR is merged (because that PR caused the test failure in the first place).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed crash when `app.setPath('sessionData')` was called with a non-existent directory.
