### PR TITLE
fix: use ShowItemInFolder for devtools showItemInFolder embedder message

### DIFF
--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -25,6 +25,7 @@
 #include "base/values.h"
 #include "build/util/chromium_git_revision.h"
 #include "chrome/browser/devtools/devtools_contents_resizing_strategy.h"
+#include "chrome/common/pref_names.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/scoped_user_pref_update.h"
@@ -152,10 +153,6 @@ GURL GetDevToolsURL(bool can_dock) {
   auto url_string = absl::StrFormat(
       kChromeUIDevToolsURL, GetRemoteBaseURL().spec(), can_dock ? "true" : "");
   return GURL(url_string);
-}
-
-void OnOpenItemComplete(const base::FilePath& path, const std::string& result) {
-  platform_util::ShowItemInFolder(path);
 }
 
 constexpr base::TimeDelta kInitialBackoffDelay = base::Milliseconds(250);
@@ -749,8 +746,22 @@ void InspectableWebContents::ShowItemInFolder(
     return;
 
   base::FilePath path = base::FilePath::FromUTF8Unsafe(file_system_path);
-  platform_util::OpenPath(path.DirName(),
-                          base::BindOnce(&OnOpenItemComplete, path));
+
+  // Only reveal paths that fall under a DevTools workspace folder the user has
+  // explicitly added. The DevTools frontend is renderer-hosted and may be
+  // attacker-controlled, so it must not be able to point this at arbitrary
+  // filesystem locations.
+  const base::DictValue& added_paths =
+      pref_service_->GetDict(prefs::kDevToolsFileSystemPaths);
+  const bool under_registered_root =
+      std::ranges::any_of(added_paths, [&path](const auto& entry) {
+        const base::FilePath root = base::FilePath::FromUTF8Unsafe(entry.first);
+        return root == path || root.IsParent(path);
+      });
+  if (!under_registered_root)
+    return;
+
+  platform_util::ShowItemInFolder(path);
 }
 
 void InspectableWebContents::SaveToFile(const std::string& url,

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -1264,6 +1264,68 @@ describe('webContents module', () => {
     });
   });
 
+  describe('DevTools showItemInFolder embedder message', () => {
+    afterEach(closeAllWindows);
+
+    async function openDevTools (w: BrowserWindow) {
+      await w.loadURL('about:blank');
+      const devtoolsOpened = once(w.webContents, 'devtools-opened');
+      w.webContents.openDevTools({ mode: 'detach', activate: false });
+      await devtoolsOpened;
+      await waitUntil(
+        () => w.webContents.devToolsWebContents!.executeJavaScript(
+          'typeof DevToolsAPI !== "undefined"'
+        )
+      );
+    }
+
+    async function sendShowItemInFolder (w: BrowserWindow, target: string) {
+      await w.webContents.devToolsWebContents!.executeJavaScript(
+        `DevToolsAPI.sendMessageToEmbedder('showItemInFolder', [${JSON.stringify(target)}], null)`
+      );
+    }
+
+    it('does not open or execute paths outside registered workspace folders', async () => {
+      const w = new BrowserWindow({ show: false });
+      await openDevTools(w);
+
+      const candidates = process.platform === 'win32'
+        ? ['C:\\Windows\\win.ini\\x', 'C:\\Windows\\System32\\drivers\\etc\\hosts']
+        : ['/bin/ls/x', '/usr/bin/env'];
+
+      for (const target of candidates) {
+        await sendShowItemInFolder(w, target);
+      }
+
+      // The embedder handler must early-return for non-workspace paths and
+      // must never call platform_util::OpenPath. Reaching this point without
+      // the test runner being killed by a spawned process is the assertion;
+      // additionally verify the renderer is still responsive.
+      const alive = await w.webContents.executeJavaScript('true');
+      expect(alive).to.be.true();
+    });
+
+    // On Linux without a DBus FileManager1 session, ShowItemInFolder falls
+    // back to OpenFolder() which does a blocking DirectoryExists() on the UI
+    // thread (pre-existing behavior). Workspace-gating is covered by the test
+    // above.
+    ifit(process.platform !== 'linux')('reveals paths under a registered workspace folder without executing them', async () => {
+      const w = new BrowserWindow({ show: false });
+      await openDevTools(w);
+
+      const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'devtools-workspace-'));
+      const target = path.join(workspace, 'file.txt');
+      fs.writeFileSync(target, 'hello');
+      defer(() => fs.rmSync(workspace, { recursive: true, force: true }));
+
+      w.webContents.addWorkSpace(workspace);
+      await sendShowItemInFolder(w, target);
+
+      const alive = await w.webContents.executeJavaScript('true');
+      expect(alive).to.be.true();
+    });
+  });
+
   describe('before-mouse-event event', () => {
     afterEach(closeAllWindows);
     it('can prevent document mouse events', async () => {


### PR DESCRIPTION
Use `platform_util::ShowItemInFolder` (reveal-only) instead of `platform_util::OpenPath` for the DevTools `showItemInFolder` embedder message, and gate on registered workspace filesystem paths to match the `IsDevToolsFileSystemAdded` pattern used elsewhere.

Notes: none