### PR TITLE
chore: remove some unnecessary diffs in `refactor_expose_file_system_access_blocklist.patch`

### DIFF
--- a/patches/chromium/refactor_expose_file_system_access_blocklist.patch
+++ b/patches/chromium/refactor_expose_file_system_access_blocklist.patch
@@ -8,24 +8,10 @@ it in Electron and prevent drift from Chrome's blocklist. We should look for a w
 to upstream this change to Chrome.
 
 diff --git a/chrome/browser/file_system_access/chrome_file_system_access_permission_context.cc b/chrome/browser/file_system_access/chrome_file_system_access_permission_context.cc
-index fc75611edcaffa0501d5ad171e82e42a9d48002b..087d79d3249b7589f7f4cd5f7330edf33b7ec165 100644
+index fc75611edcaffa0501d5ad171e82e42a9d48002b..057ef82bd6c6f9c01a2a82d0ce429efb22487d8b 100644
 --- a/chrome/browser/file_system_access/chrome_file_system_access_permission_context.cc
 +++ b/chrome/browser/file_system_access/chrome_file_system_access_permission_context.cc
-@@ -83,11 +83,13 @@
- #include "chrome/browser/ui/browser_window/public/browser_window_interface_iterator.h"  // nogncheck crbug.com/40147906
- #include "chrome/browser/ui/tabs/public/tab_features.h"
- #include "chrome/browser/ui/views/file_system_access/file_system_access_page_action_controller.h"
-+#if 0
- #include "chrome/browser/web_applications/proto/web_app_install_state.pb.h"
- #include "chrome/browser/web_applications/web_app_install_manager.h"
- #include "chrome/browser/web_applications/web_app_install_manager_observer.h"
- #include "chrome/browser/web_applications/web_app_provider.h"
- #include "chrome/browser/web_applications/web_app_registrar.h"
-+#endif
- #include "components/tabs/public/tab_interface.h"
- #if BUILDFLAG(ENABLE_PLATFORM_APPS)
- #include "extensions/browser/extension_registry.h"  // nogncheck
-@@ -287,214 +289,10 @@ bool MaybeIsLocalUNCPath(const base::FilePath& path) {
+@@ -287,214 +287,10 @@ bool MaybeIsLocalUNCPath(const base::FilePath& path) {
  }
  #endif
  
@@ -244,62 +230,6 @@ index fc75611edcaffa0501d5ad171e82e42a9d48002b..087d79d3249b7589f7f4cd5f7330edf3
  
  // Checks if `path` should be blocked by the `rules`.
  // The BlockType of the nearest ancestor of a path to check is what
-@@ -1474,16 +1272,6 @@ struct ChromeFileSystemAccessPermissionContext::OriginState {
-   std::unique_ptr<base::RetainingOneShotTimer> cleanup_timer;
- };
- 
--ChromeFileSystemAccessPermissionContext::BlockPathRules::BlockPathRules() =
--    default;
--ChromeFileSystemAccessPermissionContext::BlockPathRules::~BlockPathRules() =
--    default;
--ChromeFileSystemAccessPermissionContext::BlockPathRules::BlockPathRules(
--    const BlockPathRules& other) = default;
--ChromeFileSystemAccessPermissionContext::BlockPathRules&
--ChromeFileSystemAccessPermissionContext::BlockPathRules::operator=(
--    const BlockPathRules& other) = default;
--
- ChromeFileSystemAccessPermissionContext::
-     ChromeFileSystemAccessPermissionContext(content::BrowserContext* context,
-                                             const base::Clock* clock)
-@@ -1502,7 +1290,7 @@ ChromeFileSystemAccessPermissionContext::
- #if BUILDFLAG(IS_ANDROID)
-   one_time_permissions_tracker_.Observe(
-       OneTimePermissionsTrackerFactory::GetForBrowserContext(context));
--#else
-+#elif 0
-   auto* provider = web_app::WebAppProvider::GetForWebApps(
-       Profile::FromBrowserContext(profile_));
-   if (provider) {
-@@ -2885,7 +2673,7 @@ void ChromeFileSystemAccessPermissionContext::OnShutdown() {
-   one_time_permissions_tracker_.Reset();
- }
- 
--#if !BUILDFLAG(IS_ANDROID)
-+#if 0
- void ChromeFileSystemAccessPermissionContext::OnWebAppInstalled(
-     const webapps::AppId& app_id) {
-   if (!base::FeatureList::IsEnabled(
-@@ -3243,11 +3031,7 @@ bool ChromeFileSystemAccessPermissionContext::
-         HandleType handle_type,
-         UserAction user_action,
-         GrantType grant_type) {
--#if BUILDFLAG(IS_ANDROID)
--  // TODO(crbug.com/40101963): Enable when android persisted permissions are
--  // implemented.
--  return false;
--#else
-+#elif 0
-   if (!base::FeatureList::IsEnabled(
-           features::kFileSystemAccessPersistentPermissions)) {
-     return false;
-@@ -3298,6 +3082,7 @@ bool ChromeFileSystemAccessPermissionContext::
- 
-   return false;
- #endif  // BUILDFLAG(IS_ANDROID)
-+  return false;
- }
- 
- std::vector<FileRequestData> ChromeFileSystemAccessPermissionContext::
 diff --git a/chrome/browser/file_system_access/chrome_file_system_access_permission_context.h b/chrome/browser/file_system_access/chrome_file_system_access_permission_context.h
 index ae026d5321cd513c188297e53fe65aaaa77d6f34..184fda7f5851a5d22957b3ebd9d47a4f635a1aff 100644
 --- a/chrome/browser/file_system_access/chrome_file_system_access_permission_context.h


### PR DESCRIPTION
#### Description of Change

Remove some unnecessary parts of the patch `refactor_expose_file_system_access_blocklist.patch`. 

Since we don't compile `chrome_file_system_access_permission_context.cc`, we don't need to remove the default constructors / destructors / etc. and we don't need to `#if 0` out part of its `#include` block.

I've kept the part that removes `NormalizeFilePath()` and `GenerateBlockPaths()` to act as a conflict tripwire: if upstream changes their implementation, the patch will fail and so we'll know to update the version we patch into `chrome_file_system_access_permission_context.h`.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.