### PR TITLE
chore: add Claude Code skill for Node.js upgrades

### DIFF
--- a/.claude/skills/electron-node-upgrade/SKILL.md
+++ b/.claude/skills/electron-node-upgrade/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: electron-node-upgrade
+description: Guide for performing Node.js version upgrades in the Electron project. Use when working on the roller/node/main branch to fix patch conflicts during `e sync --3`. Covers the patch application workflow, conflict resolution, analyzing upstream Node.js changes, and proper commit formatting for patch fixes.
+---
+
+# Electron Node.js Upgrade: Phase One
+
+## Summary
+
+Run `e sync --3` repeatedly, fixing patch conflicts as they arise, until it succeeds. Then export patches and commit changes atomically.
+
+## Success Criteria
+
+Phase One is complete when:
+- `e sync --3` exits with code 0 (no patch failures)
+- All changes are committed per the commit guidelines
+
+Do not stop until these criteria are met.
+
+**CRITICAL** Do not delete or skip patches unless 100% certain the patch is no longer needed. For major version upgrades, patches that shim deprecated V8 APIs or backport upstream changes are often deletable because the new Node.js version already incorporates them — but verify before removing. Complicated conflicts or hard to resolve issues should be presented to the user after you have exhausted all other options. Do not delete the patch just because you can't solve it.
+
+**CRITICAL** Never use `git am --skip` and then manually recreate a patch by making a new commit. This destroys the original patch's authorship, commit message, and position in the series. If `git am --continue` reports "No changes", investigate why — the changes were likely absorbed by a prior conflict resolution's 3-way merge. Present this situation to the user rather than skipping and recreating.
+
+## Context
+
+The `roller/node/main` branch is created by automation to update Electron's Node.js dependency version in `DEPS`. No work has been done to handle breaking changes between the old and new versions.
+
+There are two types of Node.js version updates:
+- **Bumps** (patch/minor): Automated by `electron-roller[bot]` with commit title `chore: bump node to v{version}`. Trivial patch index updates are handled automatically by `patchup[bot]`. These often land cleanly, but may require manual patch fixes.
+- **Major upgrades** (e.g., v22 → v24): Manual, large PRs with commit title `chore: upgrade Node.js to v{X}.{Y}.{Z}`. These typically involve deleting obsolete patches, adapting many others, and updating `@types/node` in `package.json`.
+
+**Key directories:**
+- Current directory: Electron repo (always run `e` commands here)
+- `../third_party/electron_node`: Node.js repo (where patches apply)
+- `patches/node/`: Patch files for Node.js
+- `docs/development/patches.md`: Patch system documentation
+
+## Pre-flight Checks
+
+Run these once at the start of each upgrade session:
+
+1. **Clear rerere cache** (if enabled): `git rerere clear` in both the electron and `../third_party/electron_node` repos. Stale recorded resolutions from a prior attempt can silently apply wrong merges.
+2. **Ensure pre-commit hooks are installed**: Check that `.git/hooks/pre-commit` exists. If not, run `yarn husky` to install it. The hook runs `lint-staged` which handles clang-format for C++ files.
+
+## Workflow
+
+1. Run `e sync --3` (the `--3` flag enables 3-way merge, always required)
+2. If succeeds → skip to step 5
+3. If patch fails:
+   - Identify target repo and patch from error output
+   - Analyze failure (see references/patch-analysis.md)
+   - Fix conflict in `../third_party/electron_node` working directory
+   - Run `git am --continue` in `../third_party/electron_node`
+   - Repeat until all patches for that repo apply
+   - IMPORTANT: Once `git am --continue` succeeds you MUST run `e patches node` to export fixes
+   - Return to step 1
+4. When `e sync --3` succeeds, run `e patches all`
+5. **Read `references/phase-one-commit-guidelines.md` NOW**, then commit changes following those instructions exactly.
+
+## Commands Reference
+
+| Command | Purpose |
+|---------|---------|
+| `e sync --3` | Clone deps and apply patches with 3-way merge |
+| `git am --continue` | Continue after resolving conflict (run in node repo) |
+| `e patches node` | Export commits from node repo to patch files |
+| `e patches all` | Export all patches from all targets |
+| `e patches node --commit-updates` | Export patches and auto-commit trivial changes |
+| `e patches --list-targets` | List targets and config paths |
+
+## Patch System Mental Model
+
+```
+patches/node/*.patch  →  [e sync --3]  →  ../third_party/electron_node commits
+                      ←  [e patches]   ←
+```
+
+## When to Edit Patches
+
+| Situation | Action |
+|-----------|--------|
+| During active `git am` conflict | Fix in node repo, then `git am --continue` |
+| Modifying patch outside conflict | Edit `.patch` file directly |
+| Creating new patch (rare, avoid) | Commit in node repo, then `e patches node` |
+
+Fix existing patches 99% of the time rather than creating new ones.
+
+## Patch Fixing Rules
+
+1. **Preserve authorship**: Keep original author in TODO comments (from patch `From:` field)
+2. **Never change TODO assignees**: `TODO(name)` must retain original name
+3. **Update descriptions**: If upstream changed APIs or macros, update patch commit message to reflect current state
+4. **Never skip-and-recreate a patch**: If `git am --continue` says "No changes — did you forget to use 'git add'?", do NOT run `git am --skip` and create a replacement commit. The patch's changes were already absorbed by a prior 3-way merge resolution. This means an earlier conflict resolution pulled in too many changes. Present the situation to the user for guidance — the correct fix may require re-doing an earlier resolution more carefully to keep each patch's changes separate.
+
+# Electron Node.js Upgrade: Phase Two
+
+## Summary
+
+Run `e build -k 999 -- --quiet` repeatedly, fixing build issues as they arise, until it succeeds. Then run `e start --version` to validate Electron launches and commit changes atomically.
+
+Run Phase Two immediately after Phase One is complete.
+
+## Success Criteria
+
+Phase Two is complete when:
+- `e build -k 999 -- --quiet` exits with code 0 (no build failures)
+- `e start --version` has been run to check Electron launches
+- All changes are committed per the commit guidelines
+
+Do not stop until these criteria are met. Do not delete code or features, never comment out code in order to take short cut. Make all existing code, logic and intention work.
+
+## Context
+
+The `roller/node/main` branch is created by automation to update Electron's Node.js dependency version in `DEPS`. No work has been done to handle breaking changes between the old and new versions. Node.js APIs (especially internal V8 integration, OpenSSL/BoringSSL compatibility, and build system files) frequently change between versions. In every case the code in Electron must be updated to account for the change in Node.js, strongly avoid making changes to the code in Node.js to fix Electron's build.
+
+**Key directories:**
+- Current directory: Electron repo (always run `e` commands here)
+- `../third_party/electron_node`: Node.js repo (do not touch this code to fix build issues, just read it to obtain context)
+
+## Workflow
+
+1. Run `e build -k 999 -- --quiet` (the `--quiet` flag suppresses per-target status lines, showing only errors and the final result)
+2. If succeeds → skip to step 6
+3. If build fails:
+    - Identify underlying file in "electron" from the compilation error message
+    - Analyze failure
+    - Fix build issue by adapting Electron's code for the change in Node.js
+    - Run `e build -t {target_that_failed}.o` to build just the failed target we were specifically fixing
+        - You can identify the target_that_failed from the failure line in the build log. E.g. `FAILED: 2e506007-8d5d-4f38-bdd1-b5cd77999a77 "./obj/electron/shell/browser/api/electron_api_utility_process.o" CXX obj/electron/shell/browser/api/electron_api_utility_process.o` the target name is `obj/electron/shell/browser/api/electron_api_utility_process.o`
+    - **Read `references/phase-two-commit-guidelines.md` NOW**, then commit changes following those instructions exactly.
+    - Return to step 1
+4. **CRITICAL**: After ANY commit (especially patch commits), immediately run `git status` in the electron repo
+    - Look for other modified `.patch` files that only have index/hunk header changes
+    - These are dependent patches affected by your fix
+    - Commit them immediately with: `git commit -am "chore: update patches (trivial only)"`
+5. Return to step 1
+6. When `e build` succeeds, run `e start --version`
+7. Check if you have any pending changes in the Node.js repo by running `git status` in `../third_party/electron_node`
+    - If you have changes follow the instructions below in "A. Patch Fixes" to correctly commit those modifications into the appropriate patch file
+
+## Commands Reference
+
+| Command | Purpose |
+|---------|---------|
+| `e build -k 999 -- --quiet` | Build Electron, continue on errors, suppress status lines |
+| `e build -t {target}.o` | Build just one specific target to verify a fix |
+| `e start --version` | Validate Electron launches after successful build |
+
+## Two Types of Build Fixes
+
+### A. Patch Fixes (for files in patched Node.js files)
+
+When the error is in a file that Electron patches (check with `grep -l "filename" patches/node/*.patch`):
+
+1. Edit the file in the Node.js source tree (`../third_party/electron_node/...`)
+2. Create a fixup commit targeting the original patch commit:
+    ```bash
+    cd ../third_party/electron_node
+    git add <modified-file>
+    git commit --fixup=<original-patch-commit-hash>
+    GIT_SEQUENCE_EDITOR=: git rebase --autosquash --autostash -i <commit>^
+    ```
+3. Export the updated patch: `e patches node`
+4. Commit the updated patch file following `references/phase-one-commit-guidelines.md`.
+
+To find the original patch commit to fixup: `git log --oneline | grep -i "keyword from patch name"`
+
+The base commit for rebase is the Node.js commit before patches were applied. Find it by checking the `refs/patches/upstream-head` ref.
+
+### B. Electron Code Fixes (for files in shell/, electron/, etc.)
+
+When the error is in Electron's own source code:
+
+1. Edit files directly in the electron repo
+2. Commit directly (no patch export needed)
+
+# Critical: Read Before Committing
+
+- Before ANY Phase One commits: Read `references/phase-one-commit-guidelines.md`
+- Before ANY Phase Two commits: Read `references/phase-two-commit-guidelines.md`
+
+# High-Churn Patches
+
+These patches consistently require the most work during Node.js upgrades:
+
+- **`fix_handle_boringssl_and_openssl_incompatibilities.patch`** — Electron uses BoringSSL (via Chromium) while Node.js expects OpenSSL. This patch is large and complex, and upstream OpenSSL API changes frequently break it.
+- **`fix_crypto_tests_to_run_with_bssl.patch`** — Companion to the above; adapts Node.js crypto tests for BoringSSL. Can grow significantly during major upgrades.
+- **`support_v8_sandboxed_pointers.patch`** — V8 sandbox pointer support requires careful adaptation when V8 APIs change.
+- **`build_add_gn_build_files.patch`** — The GN build file patch is large and touches many build targets. Upstream build system changes frequently conflict.
+
+# Major Version Upgrades
+
+Major Node.js version transitions (e.g., v22 → v24) are significantly more involved than patch bumps:
+
+1. **Expect patch deletions.** Electron uses Chromium's V8, which is often ahead of the V8 version bundled in Node.js. Many patches exist to bridge this gap — shimming newer V8 APIs that Chromium's V8 has but Node.js' older V8 doesn't. When Node.js bumps to a newer major version, its V8 catches up to Chromium's, and those bridge patches can be deleted. In the v22 → v24 upgrade, 17 patches were deleted for this reason.
+2. **Update `@types/node`** in `package.json` to match the new major version.
+3. **Post-upgrade regressions are expected.** Even after the upgrade lands, follow-up fix PRs for edge cases (ESM path handling, certificate loading, platform-specific issues) are normal.
+
+# Skill Directory Structure
+This skill has additional reference files in `references/`:
+- patch-analysis.md - How to analyze patch failures
+- phase-one-commit-guidelines.md - Commit format for Phase One
+- phase-two-commit-guidelines.md - Commit format for Phase Two
+
+Read these when referenced in the workflow steps.

--- a/.claude/skills/electron-node-upgrade/references/patch-analysis.md
+++ b/.claude/skills/electron-node-upgrade/references/patch-analysis.md
@@ -1,0 +1,112 @@
+# Analyzing Patch Failures
+
+## Investigation Steps
+
+1. **Read the patch file** at `patches/node/{patch_name}.patch`
+
+2. **Examine current state** of the file in the Node.js repo at mentioned line numbers
+
+3. **Check recent upstream changes:**
+   ```bash
+   cd ../third_party/electron_node
+   git log --oneline -10 -- {file}
+   ```
+
+4. **Find Node.js PR** in commit messages:
+   ```
+   PR-URL: https://github.com/nodejs/node/pull/{PR_NUMBER}
+   ```
+
+## Critical: Resolve by Intent, Not by Mechanical Merge
+
+When resolving a patch conflict, do NOT blindly preserve the patch's old code. Instead:
+
+1. **Understand the upstream commit's full scope** — not just the conflicting hunk.
+   Run `git show <commit> --stat` and read diffs for all affected files.
+   Upstream may have removed structs, members, or methods that the patch
+   references in other hunks or files.
+
+2. **Re-read the patch commit message** to understand its *intent* — what
+   behavior does it need to preserve or add?
+
+3. **Implement the intent against the new upstream code.** If the patch's
+   purpose is "add BoringSSL compatibility", add only the compatibility
+   layer — don't also restore old code that upstream separately removed.
+
+### Lesson: Upstream Removals Break Patch References
+
+- **Trigger:** Patch conflict involves an upstream refactor (not just context drift)
+- **Strategy:** After identifying the upstream commit, check its full diff for
+  removed types, members, and methods. If the patch's old code references
+  something removed, the resolution must use the new upstream mechanism.
+
+### Lesson: Separate Patch Purpose from Patch Implementation
+
+- **Trigger:** Conflict between "upstream simplified code" vs "patch has older code"
+- **Strategy:** Identify the *minimal* change the patch needs. If the patch
+  wraps code in a conditional, only add the conditional — don't restore old
+  code that was inside the conditional but was separately cleaned up upstream.
+
+### Lesson: Finish the Adaptation at Conflict Time
+
+- **Trigger:** A patch conflict involves an upstream API removal or replacement
+- **Strategy:** When resolving the conflict, fully adapt the patch to use the
+  new API in the same commit. Don't remove the old code and leave behind stale
+  references that will "be fixed in Phase Two." Each patch fix commit should be
+  a complete resolution.
+
+## Common Failure Patterns
+
+| Pattern | Cause | Solution |
+|---------|-------|----------|
+| Context lines don't match | Surrounding code changed | Update context in patch |
+| File not found | File renamed/moved | Update patch target path |
+| Function not found | Refactored upstream | Find new function name |
+| OpenSSL → BoringSSL mismatch | Crypto API change | Update to BoringSSL-compatible API |
+| GYP/GN build change | Build system refactor | Adapt build patch to new structure |
+| Deleted code | Feature removed | Verify patch still needed |
+| V8 API bridge patch conflicts | Node.js caught up to Chromium's V8 | Patch may be deletable — verify the API is now in Node.js' V8 natively |
+
+## Using Git Blame
+
+To find the commit that changed specific lines:
+
+```bash
+cd ../third_party/electron_node
+git blame -L {start},{end} -- {file}
+git log -1 {commit_sha}  # Look for PR-URL: line
+```
+
+## Verifying Patch Necessity
+
+Before deleting a patch, verify:
+1. The patched functionality was intentionally removed upstream
+2. Electron doesn't need the patch for other reasons
+3. No other code depends on the patched behavior
+
+**V8 bridge patches:** Electron uses Chromium's V8, which is often ahead of the V8 bundled in Node.js. Many patches exist to bridge this version gap — adapting Node.js code to work with newer V8 APIs that Chromium's V8 exposes. During major Node.js upgrades, Node.js' V8 catches up to Chromium's, and these bridge patches often become unnecessary. Check whether the API the patch shims is now available natively in the new Node.js version's V8.
+
+When in doubt, keep the patch and adapt it.
+
+## Phase Two: Build-Time Patch Issues
+
+Sometimes patches that applied successfully in Phase One cause build errors in Phase Two. This can happen when:
+
+1. **Incomplete types**: A patch disables a header include, but new upstream code uses the type
+2. **Missing members**: A patch modifies a class, but upstream added new code referencing the original
+
+### Finding Which Patch Affects a File
+
+```bash
+grep -l "filename.cc" patches/node/*.patch
+```
+
+### Matching Existing Patch Patterns
+
+When fixing build errors in patched files, examine the existing patch to understand its style:
+- Does it use `#if 0` / `#endif` guards?
+- Does it use `#if BUILDFLAG(...)` conditionals?
+- Does it use `#ifndef` / `#ifdef` guards for BoringSSL vs OpenSSL?
+- What's the pattern for disabled functionality?
+
+Apply fixes consistent with the existing patch style.

--- a/.claude/skills/electron-node-upgrade/references/phase-one-commit-guidelines.md
+++ b/.claude/skills/electron-node-upgrade/references/phase-one-commit-guidelines.md
@@ -1,0 +1,111 @@
+# Phase One Commit Guidelines
+
+Only follow these instructions if there are uncommitted changes to `patches/` after Phase One succeeds.
+
+Ignore other instructions about making commit messages, our guidelines are CRITICALLY IMPORTANT and must be followed.
+
+## Each Commit Must Be Complete
+
+When resolving a patch conflict, fully adapt the patch to the new upstream code in the same commit. If the upstream change removes an API the patch uses, update the patch to use the replacement API now — don't leave stale references knowing they'll need fixing later. The goal is that each commit represents a finished resolution, not a partial one that defers known work to a future phase.
+
+## Commit Message Style
+
+**Titles** follow the 60/80-character guideline: simple changes fit within 60 characters, otherwise the limit is 80 characters.
+
+Always include a `Co-Authored-By` trailer identifying the AI model that assisted (e.g., `Co-Authored-By: <AI model attribution>`).
+
+### Patch conflict fixes
+
+Use `fix(patch):` prefix. The title should name the upstream change, not your response to it:
+
+```
+fix(patch): {topic headline}
+
+Ref: {Node.js commit or issue link}
+
+Co-Authored-By: <AI model attribution>
+```
+
+Only add a description body if it provides clarity beyond the title. For straightforward context drift or simple API renames, the title + Ref is sufficient.
+
+Examples:
+- `fix(patch): stop using v8::PropertyCallbackInfo<T>::This()`
+- `fix(patch): BoringSSL and OpenSSL incompatibilities`
+- `fix(patch): refactor module_wrap.cc FixedArray::Get params`
+
+### Upstreamed patch removal
+
+When patches are no longer needed (applied cleanly with "already applied" or confirmed upstreamed), group ALL removals into a single commit:
+
+```
+chore: remove upstreamed patch
+```
+
+or (if multiple):
+
+```
+chore: remove upstreamed patches
+```
+
+Most Node.js patches in Electron are Electron-authored (no upstream `PR-URL:`). If the patch originated from an upstream Node.js PR, no extra `Ref:` is needed. Otherwise, add a `Ref:` pointing to the relevant Node.js issue or commit if one exists.
+
+### Trivial patch updates
+
+After all fix commits, stage remaining trivial changes (index, line numbers, context only):
+
+```bash
+git add patches
+git commit -m "chore: update patches (trivial only)"
+```
+
+**Conflict resolution can produce trivial results.** A `git am` conflict doesn't always mean the patch content changed — context drift alone can cause a conflict. After resolving and exporting, inspect the patch diff: if only index hashes, line numbers, and context lines changed (not the patch's own `+`/`-` lines), it's trivial and belongs here, not in a `fix(patch):` commit.
+
+## Atomic Commits
+
+Each patch conflict fix gets its own commit with its own Ref.
+
+IMPORTANT: Try really hard to find the PR or commit reference per the instructions below. Each change you made should in theory have been in response to a change made in Node.js that you identified or can identify. Try for a while to identify and include the ref in the commit message. Do not give up easily.
+
+## Finding Commit/Issue References
+
+Use `git log` or `git blame` on Node.js source files in `../third_party/electron_node`. Look for:
+
+```
+PR-URL: https://github.com/nodejs/node/pull/XXXXX
+```
+
+or issue references in the patch itself:
+
+```
+Refs: https://github.com/nodejs/node/issues/XXXXX
+```
+
+Note: Most Node.js patches in Electron are Electron-authored and won't have upstream references. In that case, check `git log` in the Node.js repo to find which upstream commit caused the conflict.
+
+If no reference found after searching: `Ref: Unable to locate reference`
+
+## Example Commits
+
+### Patch conflict fix (simple — title is sufficient)
+
+```
+fix(patch): stop using v8::PropertyCallbackInfo<T>::This()
+
+Ref: https://github.com/nodejs/node/issues/60616
+
+Co-Authored-By: <AI model attribution>
+```
+
+### Patch conflict fix (complex — description adds value)
+
+```
+fix(patch): BoringSSL and OpenSSL incompatibilities
+
+Upstream updated OpenSSL APIs that diverge from BoringSSL. Adapted
+the compatibility shims in crypto patches to use the BoringSSL
+equivalents.
+
+Ref: Unable to locate reference
+
+Co-Authored-By: <AI model attribution>
+```

--- a/.claude/skills/electron-node-upgrade/references/phase-two-commit-guidelines.md
+++ b/.claude/skills/electron-node-upgrade/references/phase-two-commit-guidelines.md
@@ -1,0 +1,96 @@
+# Phase Two Commit Guidelines
+
+Only follow these instructions if there are uncommitted changes in the Electron repo after any fixes are made during Phase Two that result a target that was failing, successfully building.
+
+Ignore other instructions about making commit messages, our guidelines are CRITICALLY IMPORTANT and must be followed.
+
+## Commit Message Style
+
+**Titles** follow the 60/80-character guideline: simple changes fit within 60 characters, otherwise the limit is 80 characters. Exception: upstream Node.js PR titles are used verbatim even if longer.
+
+Always include a `Co-Authored-By` trailer identifying the AI model that assisted (e.g., `Co-Authored-By: <AI model attribution>`).
+
+## Two Commit Types
+
+### For Electron Source Changes (shell/, electron/, etc.)
+
+When the upstream Node.js commit has a `PR-URL:`:
+
+```
+node#{PR-Number}: {upstream PR's original title}
+
+Ref: {Node.js PR link}
+
+Co-Authored-By: <AI model attribution>
+```
+
+When there is no `PR-URL:` but there is an issue reference or commit:
+
+```
+fix: {description of the adaptation}
+
+Ref: {Node.js issue or commit link}
+
+Co-Authored-By: <AI model attribution>
+```
+
+Use the **upstream commit's original title** when available — do not paraphrase or rewrite it. To find it: check the commit message in `../third_party/electron_node` for `PR-URL:` or `Refs:` lines.
+
+Only add a description body if it provides clarity beyond what the title already says (e.g., when Electron's adaptation is non-obvious). For simple renames, method additions, or straightforward API updates, the title + Ref link is sufficient.
+
+Each change should have its own commit and its own Ref. Logically group into commits that make sense rather than one giant commit. You may include multiple "Ref" links if required.
+
+IMPORTANT: Try really hard to find a reference. Each change you made should in theory have been in response to a change in Node.js. Check `git log` and `git blame` in the Node.js repo. Do not give up easily.
+
+### For Patch Updates (patches/node/*.patch)
+
+Use the same fixup workflow as Phase One and follow `references/phase-one-commit-guidelines.md` for the commit message format (`fix(patch):` prefix, topic style).
+
+## Dependent Patch Header Updates
+
+After any patch modification, check for other affected patches:
+
+```bash
+git status
+# If other .patch files show as modified with only index, line number, and context changes:
+git add patches/
+git commit -m "chore: update patches (trivial only)"
+```
+
+## Finding References
+
+Use `git log` or `git blame` on Node.js source files in `../third_party/electron_node`. Look for:
+
+```
+PR-URL: https://github.com/nodejs/node/pull/XXXXX
+Refs: https://github.com/nodejs/node/issues/XXXXX
+```
+
+Note: Many Node.js patches in Electron are Electron-authored and won't have upstream `PR-URL:` lines. Check the patch's own commit message for `Refs:` lines, or use `git log` in the Node.js repo to find which upstream commit caused the build break.
+
+If no reference found after searching: `Ref: Unable to locate reference`
+
+## Example Commits
+
+### Electron Source Fix (with upstream PR)
+
+```
+node#61898: src: stop using v8::PropertyCallbackInfo<T>::This()
+
+Ref: https://github.com/nodejs/node/pull/61898
+
+Co-Authored-By: <AI model attribution>
+```
+
+### Electron Source Fix (with issue reference, no PR)
+
+```
+fix: adapt to v8::PropertyCallbackInfo<T>::This() removal
+
+Updated NodeBindings to use HolderV2() after upstream Node.js
+stopped using the deprecated This() API.
+
+Ref: https://github.com/nodejs/node/issues/60616
+
+Co-Authored-By: <AI model attribution>
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,10 @@ e test                    # Run full test suite
 
 When working on the `roller/chromium/main` branch to upgrade Chromium activate the "Electron Chromium Upgrade" skill.
 
+## Node.js Upgrade Workflow
+
+When working on the `roller/node/main` branch to upgrade Node.js activate the "Electron Node.js Upgrade" skill.
+
 ## Pull Requests
 
 PR bodies must always include a `Notes:` section as the **last line** of the body. This is a consumer-facing release note for Electron app developers — describe the user-visible fix or change, not internal implementation details. Use `Notes: none` if there is no user-facing change.


### PR DESCRIPTION
#### Description of Change

Adds a new skill mirroring the Chromium upgrade skill, adapted for Node.js rolls. Covers patch conflict resolution, build fix workflow, commit guidelines, and documents high-churn patches and major version upgrade patterns (V8 bridge patch deletions, BoringSSL complexity).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none