### PR TITLE
ci: allow manual backports to pass template check

### DIFF
--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -39,7 +39,7 @@ jobs:
             }
             const body = context.payload.pull_request.body || '';
             // Allow through if body contains a valid backport line
-            const backportRegex = /Backport of (?:#\d+|https:\/\/github.com\/electron\/electron\/pull\/\d+)/i;
+            const backportRegex = /Backport of (?:#|https:\/\/github.com\/electron\/electron\/pull\/)\d+/i;
             if (backportRegex.test(body)) {
               console.log('Backport PR detected, skipping required section check.');
               return;

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -38,6 +38,12 @@ jobs:
               return;
             }
             const body = context.payload.pull_request.body || '';
+            // Allow through if body contains a valid backport line
+            const backportRegex = /Backport of (?:#\d+|https:\/\/github.com\/electron\/electron\/pull\/\d+)/i;
+            if (backportRegex.test(body)) {
+              console.log('Backport PR detected, skipping required section check.');
+              return;
+            }
             const missingSections = requiredSections.filter(
               (section) => !body.includes(section),
             );


### PR DESCRIPTION
#### Description of Change

This PR will allow manual backports that follow the pr body specifications in [our documentation](https://github.com/electron/trop/blob/main/docs/manual-backports.md#manual-backports) to pass the template pr check.

Example of current failure: https://github.com/electron/electron/pull/50912#issuecomment-4226281578

#### Checklist

- [x] PR description included
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
