### PR TITLE
fix: prevent crash when calling contentTracing APIs before app is ready

### DIFF
--- a/shell/browser/api/electron_api_content_tracing.cc
+++ b/shell/browser/api/electron_api_content_tracing.cc
@@ -13,6 +13,7 @@
 #include "base/threading/thread_restrictions.h"
 #include "base/trace_event/trace_config.h"
 #include "content/public/browser/tracing_controller.h"
+#include "shell/browser/browser.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/file_path_converter.h"
@@ -102,6 +103,12 @@ v8::Local<v8::Promise> StopRecording(gin::Arguments* const args) {
   gin_helper::Promise<base::FilePath> promise{args->isolate()};
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
+  if (!electron::Browser::Get()->is_ready()) {
+    promise.RejectWithErrorMessage(
+        "contentTracing cannot be used before app is ready");
+    return handle;
+  }
+
   base::FilePath path;
   if (args->GetNext(&path) && !path.empty()) {
     StopTracing(std::move(promise), std::make_optional(path));
@@ -120,6 +127,12 @@ v8::Local<v8::Promise> GetCategories(v8::Isolate* isolate) {
   gin_helper::Promise<const std::set<std::string>&> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
+  if (!electron::Browser::Get()->is_ready()) {
+    promise.RejectWithErrorMessage(
+        "contentTracing cannot be used before app is ready");
+    return handle;
+  }
+
   // Note: This method always succeeds.
   TracingController::GetInstance()->GetCategories(base::BindOnce(
       gin_helper::Promise<const std::set<std::string>&>::ResolvePromise,
@@ -133,6 +146,12 @@ v8::Local<v8::Promise> StartTracing(
     const base::trace_event::TraceConfig& trace_config) {
   gin_helper::Promise<void> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
+
+  if (!electron::Browser::Get()->is_ready()) {
+    promise.RejectWithErrorMessage(
+        "contentTracing cannot be used before app is ready");
+    return handle;
+  }
 
   if (!TracingController::GetInstance()->StartTracing(
           trace_config,
@@ -164,6 +183,12 @@ void OnTraceBufferUsageAvailable(
 v8::Local<v8::Promise> GetTraceBufferUsage(v8::Isolate* isolate) {
   gin_helper::Promise<gin_helper::Dictionary> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
+
+  if (!electron::Browser::Get()->is_ready()) {
+    promise.RejectWithErrorMessage(
+        "contentTracing cannot be used before app is ready");
+    return handle;
+  }
 
   // Note: This method always succeeds.
   TracingController::GetInstance()->GetTraceBufferUsage(

--- a/spec/fixtures/crash-cases/content-tracing-before-ready/index.js
+++ b/spec/fixtures/crash-cases/content-tracing-before-ready/index.js
@@ -1,0 +1,36 @@
+const { app, contentTracing } = require('electron');
+
+const { expect } = require('chai');
+
+(async () => {
+    // Before app is ready, all contentTracing methods should reject
+    // instead of crashing.
+    if (!app.isReady()) {
+        await expect(
+            contentTracing.startRecording({ included_categories: ['*'] })
+        ).to.be.rejectedWith(/before app is ready/);
+
+        await expect(
+            contentTracing.stopRecording()
+        ).to.be.rejectedWith(/before app is ready/);
+
+        await expect(
+            contentTracing.getCategories()
+        ).to.be.rejectedWith(/before app is ready/);
+
+        await expect(
+            contentTracing.getTraceBufferUsage()
+        ).to.be.rejectedWith(/before app is ready/);
+    }
+
+    await app.whenReady();
+
+    // After app is ready, startRecording should work normally.
+    await contentTracing.startRecording({ included_categories: ['*'] });
+    await contentTracing.stopRecording();
+})()
+    .then(app.quit)
+    .catch((err) => {
+        console.error(err);
+        app.exit(1);
+    });


### PR DESCRIPTION
### 🐛 Problem

Calling `contentTracing` APIs (`startRecording`, `stopRecording`, `getCategories`, `getTraceBufferUsage`) before `app.whenReady()` resolves causes a segmentation fault / hard crash. This is because it invokes Chromium's underlying tracing subsystem before it is properly initialized. 

### ✅ Fix

* Added native `Browser::Get()->is_ready()` guards to the C++ event bindings in [electron_api_content_tracing.cc](cci:7://file:///media/slapi/storage/Github@Open-Source/electron/shell/browser/api/electron_api_content_tracing.cc:0:0-0:0). 
* The functions now gracefully reject their returned promises with a relevant error message instead of failing on the native layer.
* This brings `contentTracing` matching the established conventions of existing Electron APIs (like `safeStorage`).

### 🧪 Tests

* Added a dedicated integration test in the `crash-cases` fixture suite testing that all four APIs correctly reject when called before `app.isReady()`.

### 📌 Notes

* Minimal diff footprint and cleanly aligns with native safeguards found elsewhere to prevent unsafe native code access.

Fixes: https://github.com/electron/electron/issues/50896