### PR TITLE
chore: clean up clang-tidy warnings

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -988,17 +988,15 @@ std::string App::GetLocaleCountryCode() {
   WCHAR locale_name[LOCALE_NAME_MAX_LENGTH] = {0};
 
   if (GetLocaleInfoEx(LOCALE_NAME_USER_DEFAULT, LOCALE_SISO3166CTRYNAME,
-                      (LPWSTR)&locale_name,
-                      sizeof(locale_name) / sizeof(WCHAR)) ||
+                      locale_name, std::size(locale_name)) ||
       GetLocaleInfoEx(LOCALE_NAME_SYSTEM_DEFAULT, LOCALE_SISO3166CTRYNAME,
-                      (LPWSTR)&locale_name,
-                      sizeof(locale_name) / sizeof(WCHAR))) {
+                      locale_name, std::size(locale_name))) {
     base::WideToUTF8(locale_name, wcslen(locale_name), &region);
   }
 #elif BUILDFLAG(IS_MAC)
   CFLocaleRef locale = CFLocaleCopyCurrent();
-  CFStringRef value = CFStringRef(
-      static_cast<CFTypeRef>(CFLocaleGetValue(locale, kCFLocaleCountryCode)));
+  auto value =
+      static_cast<CFStringRef>(CFLocaleGetValue(locale, kCFLocaleCountryCode));
   if (value != nil) {
     char temporaryCString[3];
     const CFIndex kCStringSize = sizeof(temporaryCString);

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -180,7 +180,7 @@ std::vector<std::string> Browser::GetRecentDocuments() {
   std::vector<std::string> documents;
   documents.reserve([recentURLs count]);
   for (NSURL* url in recentURLs)
-    documents.push_back(std::string([url.path UTF8String]));
+    documents.emplace_back([url.path UTF8String]);
   return documents;
 }
 

--- a/shell/browser/mac/electron_application.mm
+++ b/shell/browser/mac/electron_application.mm
@@ -208,7 +208,7 @@ inline void dispatch_sync_main(dispatch_block_t block) {
         forEventClass:kInternetEventClass
            andEventID:kAEGetURL];
 
-  handoffLock_ = [NSCondition new];
+  handoffLock_ = [[NSCondition alloc] init];
 }
 
 - (void)handleURLEvent:(NSAppleEventDescriptor*)event

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -97,7 +97,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetFullScreen(bool fullscreen) = 0;
   virtual bool IsFullscreen() const = 0;
 
-  virtual void SetBounds(const gfx::Rect& bounds, bool animate = false) = 0;
+  virtual void SetBounds(const gfx::Rect& bounds, bool animate) = 0;
   virtual gfx::Rect GetBounds() const = 0;
   void SetShape(const std::vector<gfx::Rect>& rects);
   void SetSize(const gfx::Size& size, bool animate = false);

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -58,7 +58,7 @@ class NativeWindowMac : public NativeWindow,
   bool IsMinimized() const override;
   void SetFullScreen(bool fullscreen) override;
   bool IsFullscreen() const override;
-  void SetBounds(const gfx::Rect& bounds, bool animate = false) override;
+  void SetBounds(const gfx::Rect& bounds, bool animate) override;
   gfx::Rect GetBounds() const override;
   bool IsNormal() const override;
   gfx::Rect GetNormalBounds() const override;

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1268,7 +1268,7 @@ void NativeWindowViews::SetBackgroundColor(SkColor background_color) {
       SetClassLongPtr(GetAcceleratedWidget(), GCLP_HBRBACKGROUND,
                       reinterpret_cast<LONG_PTR>(brush));
   if (previous_brush)
-    DeleteObject((HBRUSH)previous_brush);
+    DeleteObject(reinterpret_cast<HBRUSH>(previous_brush));
   InvalidateRect(GetAcceleratedWidget(), nullptr, 1);
 #endif
   SkColor compositor_color = background_color;
@@ -1467,11 +1467,11 @@ void NativeWindowViews::SetParentWindow(NativeWindow* parent) {
   //  the ::GetWindowLongPtr or ::SetWindowLongPtr functions with "nIndex" set
   //  to "GWLP_HWNDPARENT" which actually means the window owner.
   HWND hwndParent = parent ? parent->GetAcceleratedWidget() : nullptr;
-  if (hwndParent ==
-      (HWND)::GetWindowLongPtr(GetAcceleratedWidget(), GWLP_HWNDPARENT))
+  if (hwndParent == reinterpret_cast<HWND>(::GetWindowLongPtr(
+                        GetAcceleratedWidget(), GWLP_HWNDPARENT)))
     return;
   ::SetWindowLongPtr(GetAcceleratedWidget(), GWLP_HWNDPARENT,
-                     (LONG_PTR)hwndParent);
+                     reinterpret_cast<LONG_PTR>(hwndParent));
   // Ensures the visibility
   if (IsVisible()) {
     WINDOWPLACEMENT wp;

--- a/shell/browser/ui/cocoa/electron_bundle_mover.mm
+++ b/shell/browser/ui/cocoa/electron_bundle_mover.mm
@@ -155,10 +155,9 @@ bool AuthorizedInstall(NSString* srcPath, NSString* dstPath, bool* canceled) {
 
   AuthorizationItem myItems = {kAuthorizationRightExecute, 0, nullptr, 0};
   AuthorizationRights myRights = {1, &myItems};
-  AuthorizationFlags myFlags =
-      (AuthorizationFlags)(kAuthorizationFlagInteractionAllowed |
-                           kAuthorizationFlagExtendRights |
-                           kAuthorizationFlagPreAuthorize);
+  AuthorizationFlags myFlags = kAuthorizationFlagInteractionAllowed |
+                               kAuthorizationFlagExtendRights |
+                               kAuthorizationFlagPreAuthorize;
 
   err = AuthorizationCopyRights(myAuthorizationRef, &myRights, nullptr, myFlags,
                                 nullptr);

--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -49,7 +49,7 @@ static StartGridAnimationIMP g_orig_startGridAnimation = nullptr;
 static void Patched_startGridAnimation(id self,
                                        SEL _cmd,
                                        id animation,
-                                       void (^completionHandler)(void)) {
+                                       void (^completionHandler)()) {
   if (completionHandler)
     completionHandler();
 }
@@ -83,8 +83,7 @@ MouseDownImpl g_nsnextstepframe_mousedown;
 @implementation SwizzledMethodsClass
 - (void)swiz_nsthemeframe_mouseDown:(NSEvent*)event {
   if ([self.window respondsToSelector:@selector(shell)]) {
-    electron::NativeWindowMac* shell =
-        (electron::NativeWindowMac*)[(id)self.window shell];
+    electron::NativeWindowMac* shell = [(id)self.window shell];
     if (shell && !shell->has_frame())
       [self cr_mouseDownOnFrameView:event];
   }
@@ -93,8 +92,7 @@ MouseDownImpl g_nsnextstepframe_mousedown;
 
 - (void)swiz_nsnextstepframe_mouseDown:(NSEvent*)event {
   if ([self.window respondsToSelector:@selector(shell)]) {
-    electron::NativeWindowMac* shell =
-        (electron::NativeWindowMac*)[(id)self.window shell];
+    electron::NativeWindowMac* shell = [(id)self.window shell];
     if (shell && !shell->has_frame()) {
       [self cr_mouseDownOnFrameView:event];
     }
@@ -104,8 +102,7 @@ MouseDownImpl g_nsnextstepframe_mousedown;
 
 - (void)swiz_nsview_swipeWithEvent:(NSEvent*)event {
   if ([self.window respondsToSelector:@selector(shell)]) {
-    electron::NativeWindowMac* shell =
-        (electron::NativeWindowMac*)[(id)self.window shell];
+    electron::NativeWindowMac* shell = [(id)self.window shell];
     if (shell) {
       if (event.deltaY == 1.0) {
         shell->NotifyWindowSwipe("up");

--- a/shell/browser/ui/message_box_mac.mm
+++ b/shell/browser/ui/message_box_mac.mm
@@ -80,7 +80,7 @@ NSAlert* CreateNSAlert(const MessageBoxSettings& settings) {
 
     // TODO(@codebytere): This behavior violates HIG & should be deprecated.
     if (settings.cancel_id == settings.default_id) {
-      [(NSButton*)[ns_buttons objectAtIndex:settings.default_id] highlight:YES];
+      [[ns_buttons objectAtIndex:settings.default_id] highlight:YES];
     }
   }
 

--- a/shell/browser/ui/views/win_caption_button_container.cc
+++ b/shell/browser/ui/views/win_caption_button_container.cc
@@ -87,7 +87,7 @@ WinCaptionButtonContainer::WinCaptionButtonContainer(WinFrameView* frame_view)
   UpdateButtonToolTipsForWindowControlsOverlay();
 }
 
-WinCaptionButtonContainer::~WinCaptionButtonContainer() {}
+WinCaptionButtonContainer::~WinCaptionButtonContainer() = default;
 
 int WinCaptionButtonContainer::NonClientHitTest(const gfx::Point& point) const {
   DCHECK(HitTestPoint(point))

--- a/shell/browser/ui/win/notify_icon_host.cc
+++ b/shell/browser/ui/win/notify_icon_host.cc
@@ -198,12 +198,10 @@ NotifyIcon* NotifyIconHost::CreateNotifyIcon(std::optional<base::Uuid> guid) {
       guid_str = guid_str.substr(1, guid_str.length() - 2);
     }
 
-    unsigned char* uid_cstr = (unsigned char*)guid_str.c_str();
+    auto* uid_cstr = reinterpret_cast<unsigned char*>(guid_str.data());
     RPC_STATUS result = UuidFromStringA(uid_cstr, &uid);
     if (result != RPC_S_INVALID_STRING_UUID) {
-      for (NotifyIcons::const_iterator i(notify_icons_.begin());
-           i != notify_icons_.end(); ++i) {
-        auto* current_win_icon = static_cast<NotifyIcon*>(*i);
+      for (const NotifyIcon* current_win_icon : notify_icons_) {
         if (current_win_icon->guid() == uid) {
           LOG(WARNING)
               << "Guid already in use. Existing tray entry will be replaced.";
@@ -256,9 +254,7 @@ LRESULT CALLBACK NotifyIconHost::WndProc(HWND hwnd,
     NotifyIcon* win_icon = nullptr;
 
     // Find the selected status icon.
-    for (NotifyIcons::const_iterator i(notify_icons_.begin());
-         i != notify_icons_.end(); ++i) {
-      auto* current_win_icon = static_cast<NotifyIcon*>(*i);
+    for (NotifyIcon* current_win_icon : notify_icons_) {
       if (current_win_icon->icon_id() == wparam) {
         win_icon = current_win_icon;
         break;

--- a/shell/common/gin_converters/guid_converter.h
+++ b/shell/common/gin_converters/guid_converter.h
@@ -76,7 +76,7 @@ struct Converter<UUID> {
       if (guid[0] == '{' && guid[guid.length() - 1] == '}') {
         guid = guid.substr(1, guid.length() - 2);
       }
-      unsigned char* uid_cstr = (unsigned char*)guid.c_str();
+      auto* uid_cstr = reinterpret_cast<unsigned char*>(guid.data());
       RPC_STATUS result = UuidFromStringA(uid_cstr, &uid);
       if (result == RPC_S_INVALID_STRING_UUID) {
         return false;

--- a/shell/common/platform_util_mac.mm
+++ b/shell/common/platform_util_mac.mm
@@ -167,13 +167,9 @@ void OpenExternal(const GURL& url,
           configuration:configuration
       completionHandler:^(NSRunningApplication* _Nullable app,
                           NSError* _Nullable error) {
-        if (error) {
-          runner->PostTask(FROM_HERE, base::BindOnce(std::move(copied_callback),
-                                                     "Failed to open URL"));
-        } else {
-          runner->PostTask(FROM_HERE,
-                           base::BindOnce(std::move(copied_callback), ""));
-        }
+        std::string err_msg = error ? "Failed to open URL" : "";
+        runner->PostTask(FROM_HERE, base::BindOnce(std::move(copied_callback),
+                                                   std::move(err_msg)));
       }];
 }
 


### PR DESCRIPTION
Backport of #50862.

See that PR for details.

Notes: none