### PR TITLE
refactor: migrate `api::ServiceWorkerContext` to cppgc

### DIFF
--- a/patches/chromium/chore_add_electron_objects_to_wrappablepointertag.patch
+++ b/patches/chromium/chore_add_electron_objects_to_wrappablepointertag.patch
@@ -8,10 +8,10 @@ electron objects that extend gin::Wrappable and gets
 allocated on the cpp heap
 
 diff --git a/gin/public/wrappable_pointer_tags.h b/gin/public/wrappable_pointer_tags.h
-index fee622ebde42211de6f702b754cfa38595df5a1c..9f7e1b1b8d871721891255c1f21de825d0df1e30 100644
+index fee622ebde42211de6f702b754cfa38595df5a1c..7bc00b2941cc4aaf0ae02a0db8722f74a0c228d9 100644
 --- a/gin/public/wrappable_pointer_tags.h
 +++ b/gin/public/wrappable_pointer_tags.h
-@@ -77,7 +77,21 @@ enum WrappablePointerTag : uint16_t {
+@@ -77,7 +77,22 @@ enum WrappablePointerTag : uint16_t {
    kWebAXObjectProxy,             // content::WebAXObjectProxy
    kWrappedExceptionHandler,      // extensions::WrappedExceptionHandler
    kIndigoContext,                // indigo::IndigoContext
@@ -27,6 +27,7 @@ index fee622ebde42211de6f702b754cfa38595df5a1c..9f7e1b1b8d871721891255c1f21de825
 +  kElectronProtocol,                    // electron::api::Protocol
 +  kElectronReplyChannel,                // gin_helper::internal::ReplyChannel
 +  kElectronScreen,                      // electron::api::Screen
++  kElectronServiceWorkerContext,        // electron::api::ServiceWorkerContext
 +  kElectronSession,                     // electron::api::Session
 +  kElectronTray,                        // electron::api::Tray
 +  kElectronWebRequest,                  // electron::api::WebRequest

--- a/shell/browser/api/electron_api_service_worker_context.cc
+++ b/shell/browser/api/electron_api_service_worker_context.cc
@@ -13,6 +13,7 @@
 #include "content/public/browser/storage_partition.h"
 #include "gin/data_object_builder.h"
 #include "gin/object_template_builder.h"
+#include "gin/persistent.h"
 #include "shell/browser/api/electron_api_service_worker_main.h"
 #include "shell/browser/electron_browser_context.h"
 #include "shell/browser/javascript_environment.h"
@@ -23,6 +24,7 @@
 #include "shell/common/gin_helper/handle.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/node_util.h"
+#include "v8/include/cppgc/allocation.h"
 
 using ServiceWorkerStatus =
     content::ServiceWorkerRunningInfo::ServiceWorkerVersionStatus;
@@ -75,8 +77,9 @@ v8::Local<v8::Value> ServiceWorkerRunningInfoToDict(
 
 }  // namespace
 
-gin::DeprecatedWrapperInfo ServiceWorkerContext::kWrapperInfo = {
-    gin::kEmbedderNativeGin};
+const gin::WrapperInfo ServiceWorkerContext::kWrapperInfo = {
+    {gin::kEmbedderNativeGin},
+    gin::kElectronServiceWorkerContext};
 
 ServiceWorkerContext::ServiceWorkerContext(
     v8::Isolate* isolate,
@@ -90,7 +93,8 @@ ServiceWorkerContext::ServiceWorkerContext(
 }
 
 ServiceWorkerContext::~ServiceWorkerContext() {
-  service_worker_context_->RemoveObserver(this);
+  if (service_worker_context_)
+    service_worker_context_->RemoveObserver(this);
 }
 
 void ServiceWorkerContext::OnRunningStatusChanged(
@@ -160,7 +164,8 @@ void ServiceWorkerContext::OnVersionStoppedRunning(int64_t version_id) {
 
 void ServiceWorkerContext::OnDestruct(content::ServiceWorkerContext* context) {
   if (context == service_worker_context_) {
-    delete this;
+    service_worker_context_->RemoveObserver(this);
+    service_worker_context_ = nullptr;
   }
 }
 
@@ -234,9 +239,13 @@ v8::Local<v8::Promise> ServiceWorkerContext::StartWorkerForScope(
   service_worker_context_->StartWorkerForScope(
       scope, storage_key,
       base::BindOnce(&ServiceWorkerContext::DidStartWorkerForScope,
-                     weak_ptr_factory_.GetWeakPtr(), shared_promise),
+                     gin::WrapPersistent(weak_factory_.GetWeakCell(
+                         isolate->GetCppHeap()->GetAllocationHandle())),
+                     shared_promise),
       base::BindOnce(&ServiceWorkerContext::DidFailToStartWorkerForScope,
-                     weak_ptr_factory_.GetWeakPtr(), shared_promise));
+                     gin::WrapPersistent(weak_factory_.GetWeakCell(
+                         isolate->GetCppHeap()->GetAllocationHandle())),
+                     shared_promise));
 
   return handle;
 }
@@ -275,14 +284,13 @@ v8::Local<v8::Promise> ServiceWorkerContext::StopAllWorkers(
 }
 
 // static
-gin_helper::Handle<ServiceWorkerContext> ServiceWorkerContext::Create(
+ServiceWorkerContext* ServiceWorkerContext::Create(
     v8::Isolate* isolate,
     ElectronBrowserContext* browser_context) {
-  return gin_helper::CreateHandle(
-      isolate, new ServiceWorkerContext(isolate, browser_context));
+  return cppgc::MakeGarbageCollected<ServiceWorkerContext>(
+      isolate->GetCppHeap()->GetAllocationHandle(), isolate, browser_context);
 }
 
-// static
 gin::ObjectTemplateBuilder ServiceWorkerContext::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
   return gin_helper::EventEmitterMixin<
@@ -301,8 +309,17 @@ gin::ObjectTemplateBuilder ServiceWorkerContext::GetObjectTemplateBuilder(
       .SetMethod("_stopAllWorkers", &ServiceWorkerContext::StopAllWorkers);
 }
 
-const char* ServiceWorkerContext::GetTypeName() {
-  return "ServiceWorkerContext";
+void ServiceWorkerContext::Trace(cppgc::Visitor* visitor) const {
+  gin::Wrappable<ServiceWorkerContext>::Trace(visitor);
+  visitor->Trace(weak_factory_);
+}
+
+const gin::WrapperInfo* ServiceWorkerContext::wrapper_info() const {
+  return &kWrapperInfo;
+}
+
+const char* ServiceWorkerContext::GetHumanReadableName() const {
+  return "Electron / ServiceWorkerContext";
 }
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_service_worker_context.h
+++ b/shell/browser/api/electron_api_service_worker_context.h
@@ -11,8 +11,9 @@
 #include "content/public/browser/service_worker_context.h"
 #include "content/public/browser/service_worker_context_observer.h"
 #include "content/public/browser/storage_partition_config.h"
+#include "gin/weak_cell.h"
+#include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
-#include "shell/common/gin_helper/wrappable.h"
 #include "third_party/blink/public/common/service_worker/embedded_worker_status.h"
 #include "third_party/blink/public/common/tokens/tokens.h"
 
@@ -32,13 +33,12 @@ namespace api {
 class ServiceWorkerMain;
 
 class ServiceWorkerContext final
-    : public gin_helper::DeprecatedWrappable<ServiceWorkerContext>,
+    : public gin::Wrappable<ServiceWorkerContext>,
       public gin_helper::EventEmitterMixin<ServiceWorkerContext>,
       private content::ServiceWorkerContextObserver {
  public:
-  static gin_helper::Handle<ServiceWorkerContext> Create(
-      v8::Isolate* isolate,
-      ElectronBrowserContext* browser_context);
+  static ServiceWorkerContext* Create(v8::Isolate* isolate,
+                                      ElectronBrowserContext* browser_context);
 
   v8::Local<v8::Value> GetAllRunningWorkerInfo(v8::Isolate* isolate);
   v8::Local<v8::Value> GetInfoFromVersionID(gin_helper::ErrorThrower thrower,
@@ -77,17 +77,19 @@ class ServiceWorkerContext final
   void OnVersionRedundant(int64_t version_id, const GURL& scope) override;
   void OnDestruct(content::ServiceWorkerContext* context) override;
 
-  // gin_helper::Wrappable
-  static gin::DeprecatedWrapperInfo kWrapperInfo;
+  // gin::Wrappable
+  static const gin::WrapperInfo kWrapperInfo;
+  static const char* GetClassName() { return "ServiceWorkerContext"; }
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;
-  const char* GetTypeName() override;
+  void Trace(cppgc::Visitor*) const override;
+  const gin::WrapperInfo* wrapper_info() const override;
+  const char* GetHumanReadableName() const override;
 
   // disable copy
   ServiceWorkerContext(const ServiceWorkerContext&) = delete;
   ServiceWorkerContext& operator=(const ServiceWorkerContext&) = delete;
 
- protected:
   explicit ServiceWorkerContext(v8::Isolate* isolate,
                                 ElectronBrowserContext* browser_context);
   ~ServiceWorkerContext() override;
@@ -106,7 +108,7 @@ class ServiceWorkerContext final
   // Used in ServiceWorkerMain lookups.
   const content::StoragePartitionConfig storage_partition_config_;
 
-  base::WeakPtrFactory<ServiceWorkerContext> weak_ptr_factory_{this};
+  gin::WeakCellFactory<ServiceWorkerContext> weak_factory_{this};
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -1358,13 +1358,12 @@ api::Protocol* Session::Protocol() {
   return protocol_.Get();
 }
 
-v8::Local<v8::Value> Session::ServiceWorkerContext(v8::Isolate* isolate) {
-  if (service_worker_context_.IsEmptyThreadSafe()) {
-    v8::Local<v8::Value> handle;
-    handle = ServiceWorkerContext::Create(isolate, browser_context()).ToV8();
-    service_worker_context_.Reset(isolate, handle);
+api::ServiceWorkerContext* Session::ServiceWorkerContext() {
+  if (!service_worker_context_) {
+    service_worker_context_ = ServiceWorkerContext::Create(
+        JavascriptEnvironment::GetIsolate(), browser_context());
   }
-  return service_worker_context_.Get(isolate);
+  return service_worker_context_.Get();
 }
 
 WebRequest* Session::WebRequest(v8::Isolate* isolate) {

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -59,6 +59,7 @@ namespace api {
 
 class NetLog;
 class Protocol;
+class ServiceWorkerContext;
 class WebRequest;
 
 class Session final : public gin::Wrappable<Session>,
@@ -167,7 +168,7 @@ class Session final : public gin::Wrappable<Session>,
   v8::Local<v8::Value> Cookies(v8::Isolate* isolate);
   v8::Local<v8::Value> Extensions(v8::Isolate* isolate);
   api::Protocol* Protocol();
-  v8::Local<v8::Value> ServiceWorkerContext(v8::Isolate* isolate);
+  api::ServiceWorkerContext* ServiceWorkerContext();
   WebRequest* WebRequest(v8::Isolate* isolate);
   api::NetLog* NetLog(v8::Isolate* isolate);
   void Preconnect(const gin_helper::Dictionary& options, gin::Arguments* args);
@@ -215,7 +216,7 @@ class Session final : public gin::Wrappable<Session>,
   v8::TracedReference<v8::Value> extensions_;
   cppgc::Member<api::Protocol> protocol_;
   cppgc::Member<api::NetLog> net_log_;
-  v8::TracedReference<v8::Value> service_worker_context_;
+  cppgc::Member<api::ServiceWorkerContext> service_worker_context_;
   cppgc::Member<api::WebRequest> web_request_;
 
   raw_ptr<v8::Isolate> isolate_;


### PR DESCRIPTION
#### Description of Change

Migrate `api::ServiceWorkerContext` to cppgc.

Prerequisite of #50829.
Subtask of #47922.

CC @deepak1556 

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.