### PR TITLE
refactor: migrate `api::Extensions` to cppgc

### DIFF
--- a/patches/chromium/chore_add_electron_objects_to_wrappablepointertag.patch
+++ b/patches/chromium/chore_add_electron_objects_to_wrappablepointertag.patch
@@ -8,10 +8,10 @@ electron objects that extend gin::Wrappable and gets
 allocated on the cpp heap
 
 diff --git a/gin/public/wrappable_pointer_tags.h b/gin/public/wrappable_pointer_tags.h
-index fee622ebde42211de6f702b754cfa38595df5a1c..7bc00b2941cc4aaf0ae02a0db8722f74a0c228d9 100644
+index fee622ebde42211de6f702b754cfa38595df5a1c..0f649fa562cef261b127dca7769dd5687a916342 100644
 --- a/gin/public/wrappable_pointer_tags.h
 +++ b/gin/public/wrappable_pointer_tags.h
-@@ -77,7 +77,22 @@ enum WrappablePointerTag : uint16_t {
+@@ -77,7 +77,23 @@ enum WrappablePointerTag : uint16_t {
    kWebAXObjectProxy,             // content::WebAXObjectProxy
    kWrappedExceptionHandler,      // extensions::WrappedExceptionHandler
    kIndigoContext,                // indigo::IndigoContext
@@ -19,8 +19,8 @@ index fee622ebde42211de6f702b754cfa38595df5a1c..7bc00b2941cc4aaf0ae02a0db8722f74
 +  kElectronApp,                         // electron::api::App
 +  kElectronDataPipeHolder,              // electron::api::DataPipeHolder
 +  kElectronDebugger,                    // electron::api::Debugger
-+  kElectronExtensions,                  // electron::api::Extensions
 +  kElectronEvent,                       // gin_helper::internal::Event
++  kElectronExtensions,                  // electron::api::Extensions
 +  kElectronMenu,                        // electron::api::Menu
 +  kElectronNetLog,                      // electron::api::NetLog
 +  kElectronPowerMonitor,                // electron::api::PowerMonitor

--- a/patches/chromium/chore_add_electron_objects_to_wrappablepointertag.patch
+++ b/patches/chromium/chore_add_electron_objects_to_wrappablepointertag.patch
@@ -19,6 +19,7 @@ index fee622ebde42211de6f702b754cfa38595df5a1c..7bc00b2941cc4aaf0ae02a0db8722f74
 +  kElectronApp,                         // electron::api::App
 +  kElectronDataPipeHolder,              // electron::api::DataPipeHolder
 +  kElectronDebugger,                    // electron::api::Debugger
++  kElectronExtensions,                  // electron::api::Extensions
 +  kElectronEvent,                       // gin_helper::internal::Event
 +  kElectronMenu,                        // electron::api::Menu
 +  kElectronNetLog,                      // electron::api::NetLog

--- a/shell/browser/api/electron_api_extensions.cc
+++ b/shell/browser/api/electron_api_extensions.cc
@@ -8,7 +8,6 @@
 #include "extensions/browser/extension_registry.h"
 #include "gin/data_object_builder.h"
 #include "gin/object_template_builder.h"
-#include "shell/browser/api/electron_api_extensions.h"
 #include "shell/browser/electron_browser_context.h"
 #include "shell/browser/extensions/electron_extension_system.h"
 #include "shell/browser/javascript_environment.h"
@@ -17,17 +16,17 @@
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
-#include "shell/common/gin_helper/handle.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/node_util.h"
+#include "v8/include/cppgc/allocation.h"
 
 namespace electron::api {
 
-gin::DeprecatedWrapperInfo Extensions::kWrapperInfo = {gin::kEmbedderNativeGin};
+const gin::WrapperInfo Extensions::kWrapperInfo = {{gin::kEmbedderNativeGin},
+                                                   gin::kElectronExtensions};
 
-Extensions::Extensions(v8::Isolate* isolate,
-                       ElectronBrowserContext* browser_context)
-    : browser_context_(browser_context) {
+Extensions::Extensions(ElectronBrowserContext* browser_context)
+    : browser_context_{browser_context} {
   extensions::ExtensionRegistry::Get(browser_context)->AddObserver(this);
 }
 
@@ -36,11 +35,10 @@ Extensions::~Extensions() {
 }
 
 // static
-gin_helper::Handle<Extensions> Extensions::Create(
-    v8::Isolate* isolate,
-    ElectronBrowserContext* browser_context) {
-  return gin_helper::CreateHandle(isolate,
-                                  new Extensions(isolate, browser_context));
+Extensions* Extensions::Create(v8::Isolate* isolate,
+                               ElectronBrowserContext* browser_context) {
+  return cppgc::MakeGarbageCollected<Extensions>(
+      isolate->GetCppHeap()->GetAllocationHandle(), browser_context);
 }
 
 v8::Local<v8::Promise> Extensions::LoadExtension(
@@ -152,8 +150,12 @@ gin::ObjectTemplateBuilder Extensions::GetObjectTemplateBuilder(
       .SetMethod("getAllExtensions", &Extensions::GetAllExtensions);
 }
 
-const char* Extensions::GetTypeName() {
-  return "Extensions";
+const gin::WrapperInfo* Extensions::wrapper_info() const {
+  return &kWrapperInfo;
+}
+
+const char* Extensions::GetHumanReadableName() const {
+  return "Electron / Extensions";
 }
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_extensions.h
+++ b/shell/browser/api/electron_api_extensions.h
@@ -6,15 +6,9 @@
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_EXTENSIONS_H_
 
 #include "base/memory/raw_ptr.h"
-#include "extensions/browser/extension_registry.h"
 #include "extensions/browser/extension_registry_observer.h"
+#include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
-#include "shell/common/gin_helper/wrappable.h"
-
-namespace gin_helper {
-template <typename T>
-class Handle;
-}  // namespace gin_helper
 
 namespace electron {
 
@@ -22,19 +16,24 @@ class ElectronBrowserContext;
 
 namespace api {
 
-class Extensions final : public gin_helper::DeprecatedWrappable<Extensions>,
+class Extensions final : public gin::Wrappable<Extensions>,
                          public gin_helper::EventEmitterMixin<Extensions>,
                          private extensions::ExtensionRegistryObserver {
  public:
-  static gin_helper::Handle<Extensions> Create(
-      v8::Isolate* isolate,
-      ElectronBrowserContext* browser_context);
+  static Extensions* Create(v8::Isolate* isolate,
+                            ElectronBrowserContext* browser_context);
 
-  // gin_helper::Wrappable
-  static gin::DeprecatedWrapperInfo kWrapperInfo;
+  // gin::Wrappable
+  static const gin::WrapperInfo kWrapperInfo;
+  const gin::WrapperInfo* wrapper_info() const override;
+  const char* GetHumanReadableName() const override;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;
-  const char* GetTypeName() override;
+  const char* GetClassName() const { return "Extensions"; }
+
+  // Make public for cppgc::MakeGarbageCollected.
+  explicit Extensions(ElectronBrowserContext* browser_context);
+  ~Extensions() override;
 
   v8::Local<v8::Promise> LoadExtension(v8::Isolate* isolate,
                                        const base::FilePath& extension_path,
@@ -57,17 +56,12 @@ class Extensions final : public gin_helper::DeprecatedWrappable<Extensions>,
   Extensions(const Extensions&) = delete;
   Extensions& operator=(const Extensions&) = delete;
 
- protected:
-  explicit Extensions(v8::Isolate* isolate,
-                      ElectronBrowserContext* browser_context);
-  ~Extensions() override;
-
  private:
   content::BrowserContext* browser_context() const {
     return browser_context_.get();
   }
 
-  raw_ptr<content::BrowserContext> browser_context_;
+  const raw_ptr<content::BrowserContext> browser_context_;
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -1343,15 +1343,12 @@ v8::Local<v8::Value> Session::Cookies(v8::Isolate* isolate) {
   return cookies_.Get(isolate);
 }
 
-v8::Local<v8::Value> Session::Extensions(v8::Isolate* isolate) {
+api::Extensions* Session::Extensions(v8::Isolate* isolate) {
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  if (extensions_.IsEmptyThreadSafe()) {
-    v8::Local<v8::Value> handle;
-    handle = Extensions::Create(isolate, browser_context()).ToV8();
-    extensions_.Reset(isolate, handle);
-  }
+  if (!extensions_)
+    extensions_ = Extensions::Create(isolate, browser_context());
 #endif
-  return extensions_.Get(isolate);
+  return extensions_.Get();
 }
 
 api::Protocol* Session::Protocol() {

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -57,6 +57,7 @@ struct PreloadScript;
 
 namespace api {
 
+class Extensions;
 class NetLog;
 class Protocol;
 class ServiceWorkerContext;
@@ -166,7 +167,7 @@ class Session final : public gin::Wrappable<Session>,
   v8::Local<v8::Promise> ClearSharedDictionaryCacheForIsolationKey(
       const gin_helper::Dictionary& options);
   v8::Local<v8::Value> Cookies(v8::Isolate* isolate);
-  v8::Local<v8::Value> Extensions(v8::Isolate* isolate);
+  api::Extensions* Extensions(v8::Isolate* isolate);
   api::Protocol* Protocol();
   api::ServiceWorkerContext* ServiceWorkerContext();
   WebRequest* WebRequest(v8::Isolate* isolate);
@@ -213,7 +214,7 @@ class Session final : public gin::Wrappable<Session>,
 
   // Cached gin_helper::Wrappable objects.
   v8::TracedReference<v8::Value> cookies_;
-  v8::TracedReference<v8::Value> extensions_;
+  cppgc::Member<api::Extensions> extensions_;
   cppgc::Member<api::Protocol> protocol_;
   cppgc::Member<api::NetLog> net_log_;
   cppgc::Member<api::ServiceWorkerContext> service_worker_context_;


### PR DESCRIPTION
#### Description of Change

Migrate `api::Extensions` to cppgc.

Subtask of #47922.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.