### PR TITLE
chore: do not patch `fake_desktop_media_list.cc`

### DIFF
--- a/patches/chromium/desktop_media_list.patch
+++ b/patches/chromium/desktop_media_list.patch
@@ -53,34 +53,6 @@ index de56c9b94f92e9abf69b1d4894e5d386cad6d3cd..f8955ef7cc43b1854b29841ed65260a1
    int GetSourceCount() const override;
    const Source& GetSource(int index) const override;
    DesktopMediaList::Type GetMediaListType() const override;
-diff --git a/chrome/browser/media/webrtc/fake_desktop_media_list.cc b/chrome/browser/media/webrtc/fake_desktop_media_list.cc
-index cea6af048e682e33b5d93e4a3bfb4072840ca4fe..1c98d2275fa73a9e105bbd8928e05b48a4a05c14 100644
---- a/chrome/browser/media/webrtc/fake_desktop_media_list.cc
-+++ b/chrome/browser/media/webrtc/fake_desktop_media_list.cc
-@@ -79,7 +79,8 @@ void FakeDesktopMediaList::StartUpdating(DesktopMediaListObserver* observer) {
-   thumbnail_ = gfx::ImageSkia::CreateFrom1xBitmap(bitmap);
- }
- 
--void FakeDesktopMediaList::Update(UpdateCallback callback) {
-+void FakeDesktopMediaList::Update(UpdateCallback callback,
-+                                  bool refresh_thumbnails) {
-   std::move(callback).Run();
- }
- 
-diff --git a/chrome/browser/media/webrtc/fake_desktop_media_list.h b/chrome/browser/media/webrtc/fake_desktop_media_list.h
-index 786c526588d81b8b5b1b5dd3760719a53e005995..f66b7d0b4dfcbb8ed3dde5a9ff463ae2c8818d27 100644
---- a/chrome/browser/media/webrtc/fake_desktop_media_list.h
-+++ b/chrome/browser/media/webrtc/fake_desktop_media_list.h
-@@ -40,7 +40,8 @@ class FakeDesktopMediaList : public DesktopMediaList {
-   void SetThumbnailSize(const gfx::Size& thumbnail_size) override;
-   void SetViewDialogWindowId(content::DesktopMediaID dialog_id) override;
-   void StartUpdating(DesktopMediaListObserver* observer) override;
--  void Update(UpdateCallback callback) override;
-+  void Update(UpdateCallback callback,
-+              bool refresh_thumbnails = false) override;
-   int GetSourceCount() const override;
-   const Source& GetSource(int index) const override;
-   DesktopMediaList::Type GetMediaListType() const override;
 diff --git a/chrome/browser/media/webrtc/native_desktop_media_list.cc b/chrome/browser/media/webrtc/native_desktop_media_list.cc
 index 2b745dbb254c714756a953ac0a32c1430af2c91d..9a8ebb4edfb92d9fe28ae4b87463a68547ea1ab3 100644
 --- a/chrome/browser/media/webrtc/native_desktop_media_list.cc


### PR DESCRIPTION
#### Description of Change

Sibling PR to #50909.

Remove unnecessary patch parts from `patches/chromium/desktop_media_list.patch`. We don't build/use fake_desktop_media_list.cc, .h, so don't patch them.

CC @codebytere, who reviewed #50909

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.