### PR TITLE
build: fail gha-done check when required job fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -441,8 +441,11 @@ jobs:
     permissions:
       contents: read
     needs: [docs-only, macos-x64, macos-arm64, linux-x64, linux-x64-asan, linux-arm, linux-arm64, windows-x64, windows-x86, windows-arm64]
-    if: always() && github.repository == 'electron/electron' && !contains(needs.*.result, 'failure')
+    if: always() && github.repository == 'electron/electron'
     steps:
+    - name: Fail if any needed job failed or was cancelled
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      run: exit 1
     - name: GitHub Actions Jobs Done
       run: |
         echo "All GitHub Actions Jobs are done"


### PR DESCRIPTION
## Summary

- `gha-done` previously used `if: ... && !contains(needs.*.result, 'failure')`, so when a dep failed the job was *skipped*, not failed — and branch protection treats skipped as non-blocking, letting PRs like electron/electron#50929 become mergeable despite a failed test.
- Move the failure check into a step that `exit 1`s, and also trip on `cancelled`.

## Test plan

- [ ] Verify the `GitHub Actions Completed` check reports failure on a PR with a failing test job.

Notes: none