### PR TITLE
ci: update test timeout to 60 minutes (39-x-y)

### DIFF
--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -211,7 +211,7 @@ jobs:
 
     - name: Run Electron Tests
       shell: bash
-      timeout-minutes: 40
+      timeout-minutes: 60
       env:
         MOCHA_REPORTER: mocha-multi-reporters
         MOCHA_MULTI_REPORTERS: mocha-junit-reporter, tap


### PR DESCRIPTION
Manual backport of #50305 to give the test shard headroom.

`macos-x64 / test / test (darwin, 1)` started hitting the 40-minute step timeout at high rate from 2026-04-06 onward (e.g. https://github.com/electron/electron/actions/runs/24181403207 — 4 consecutive attempts timed out at 40:13). The shard was already running ~37-43 min successfully; recent test additions and the `MacWebContentsOcclusion` re-enable pushed it over the edge on release branches that didn't get the timeout bump.

main and 42-x-y already have this via #50305 / #50315.

Notes: none