### PR TITLE
fix: only bind ElectronAutofillDriver on primary main frames

### DIFF
--- a/shell/browser/electron_autofill_driver.cc
+++ b/shell/browser/electron_autofill_driver.cc
@@ -45,6 +45,9 @@ void AutofillDriver::ShowAutofillPopup(
   if (!owner_window)
     return;
 
+  if (!render_frame_host_->IsInPrimaryMainFrame())
+    return;
+
   // |bounds| is supplied by the renderer in the calling frame's RenderWidget
   // coordinate space. Convert to the root view's space and clamp to the
   // calling frame's visible viewport so a (potentially compromised) subframe

--- a/shell/browser/electron_autofill_driver_factory.cc
+++ b/shell/browser/electron_autofill_driver_factory.cc
@@ -61,6 +61,8 @@ void AutofillDriverFactory::DidFinishNavigation(
 
 AutofillDriver* AutofillDriverFactory::DriverForFrame(
     content::RenderFrameHost* render_frame_host) {
+  if (!render_frame_host->IsInPrimaryMainFrame())
+    return nullptr;
   auto insertion_result = driver_map_.emplace(render_frame_host, nullptr);
   std::unique_ptr<AutofillDriver>& driver = insertion_result.first->second;
   bool insertion_happened = insertion_result.second;

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1541,15 +1541,17 @@ void ElectronBrowserClient::
           },
           &render_frame_host));
 
-  associated_registry.AddInterface<mojom::ElectronAutofillDriver>(
-      base::BindRepeating(
-          [](content::RenderFrameHost* render_frame_host,
-             mojo::PendingAssociatedReceiver<mojom::ElectronAutofillDriver>
-                 receiver) {
-            AutofillDriverFactory::BindAutofillDriver(std::move(receiver),
-                                                      render_frame_host);
-          },
-          &render_frame_host));
+  if (render_frame_host.IsInPrimaryMainFrame()) {
+    associated_registry.AddInterface<mojom::ElectronAutofillDriver>(
+        base::BindRepeating(
+            [](content::RenderFrameHost* render_frame_host,
+               mojo::PendingAssociatedReceiver<mojom::ElectronAutofillDriver>
+                   receiver) {
+              AutofillDriverFactory::BindAutofillDriver(std::move(receiver),
+                                                        render_frame_host);
+            },
+            &render_frame_host));
+  }
 #if BUILDFLAG(ENABLE_PLUGINS)
   associated_registry.AddInterface<mojom::ElectronPluginInfoHost>(
       base::BindRepeating(


### PR DESCRIPTION
#### Description of Change

`mojom::ElectronAutofillDriver` was previously registered for every `RenderFrameHost`, but the native autofill popup is only exercised from `<datalist>` / `<select>` elements on the primary main frame — the existing autofill spec even notes that `webContents.sendInputEvent` cannot route keyboard input to an OOPIF, so subframes have no working path to this UI.

This PR scopes the interface to where it is actually used:

- Gate the associated interface registration in `ElectronBrowserClient::RegisterAssociatedInterfaceBindersForRenderFrameHost` on `IsInPrimaryMainFrame()`, mirroring how `ElectronApiIPC` is already scoped in the same function.
- Return early from `AutofillDriverFactory::DriverForFrame` for any non-primary-main-frame RFH so the factory never stores a driver for an unsupported frame.
- Re-check `IsInPrimaryMainFrame()` inside `AutofillDriver::ShowAutofillPopup` as defence in depth for messages that race with a navigation.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes

#### Release Notes

Notes: Fixed an issue where the autofill driver could be reached from frames other than the primary main frame.