### PR TITLE
ci: split macos-x64 tests into 3 shards (40-x-y)

### DIFF
--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         build-type: ${{ inputs.target-platform == 'macos' && fromJSON('["darwin","mas"]') || (inputs.target-platform == 'win' && fromJSON('["win"]') || fromJSON('["linux"]')) }}
-        shard: ${{ inputs.target-platform == 'linux' && fromJSON('[1, 2, 3]') || fromJSON('[1, 2]') }}
+        shard: ${{ case(inputs.target-platform == 'linux', fromJSON('[1, 2, 3]'), inputs.target-platform == 'macos' && inputs.target-arch == 'x64', fromJSON('[1, 2, 3]'), fromJSON('[1, 2]')) }}
     env:
       BUILD_TYPE: ${{ matrix.build-type }}
       TARGET_ARCH: ${{ inputs.target-arch }}
@@ -222,7 +222,7 @@ jobs:
         cd src/electron
         export ELECTRON_TEST_RESULTS_DIR=`pwd`/junit
         # Get which tests are on this shard
-        tests_files=$(node script/split-tests ${{ matrix.shard }} ${{ inputs.target-platform == 'linux' && 3 || 2 }})
+        tests_files=$(node script/split-tests ${{ matrix.shard }} ${{ case(inputs.target-platform == 'linux', 3, inputs.target-platform == 'macos' && inputs.target-arch == 'x64', 3, 2) }})
 
         # Run tests
         if [ "${{ inputs.target-platform }}" != "linux" ]; then


### PR DESCRIPTION
Manual backport of #50968.

The `macos-x64 / test / test (darwin, 1)` shard has been hitting the 40-minute step timeout at high rate since 2026-04-06 — see e.g. https://github.com/electron/electron/actions/runs/24181403207 (4 consecutive timeouts on 41-x-y). Successful runs already take ~37-43 min and recent test additions plus the `MacWebContentsOcclusion` re-enable pushed it past the limit.

This splits macos-x64 (darwin and mas) from 2 shards to 3, matching what linux already does. `script/split-tests` redistributes 77 spec files from 39+38 → 26+26+25.

Net effect: macos-x64 goes from 4 → 6 test jobs (`{darwin,mas} × {1,2,3}`). macos-arm64 and Windows stay at 2 shards.

Notes: none