### PR TITLE
feat: respect linux wco button order

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1429,6 +1429,25 @@ if (is_mac) {
       ]
     }
   }
+
+  if (is_linux) {
+    executable("electron_linux_ui_unittests") {
+      testonly = true
+      output_name = "electron_linux_ui_unittests"
+      include_dirs = [ "." ]
+      sources = [
+        "shell/browser/ui/run_all_unittests.cc",
+        "shell/browser/ui/views/linux_window_controls_overlay_utils_unittest.cc",
+      ]
+      deps = [
+        ":electron_lib",
+        "//base/test:test_support",
+        "//ui/gfx:test_support",
+        "//testing/gtest",
+        "//ui/views",
+      ]
+    }
+  }
 }
 
 template("dist_zip") {

--- a/filenames.gni
+++ b/filenames.gni
@@ -46,6 +46,8 @@ filenames = {
     "shell/browser/ui/tray_icon_linux.h",
     "shell/browser/ui/views/opaque_frame_view.cc",
     "shell/browser/ui/views/opaque_frame_view.h",
+    "shell/browser/ui/views/linux_window_controls_overlay_utils.cc",
+    "shell/browser/ui/views/linux_window_controls_overlay_utils.h",
     "shell/browser/ui/views/caption_button_placeholder_container.cc",
     "shell/browser/ui/views/caption_button_placeholder_container.h",
     "shell/browser/ui/views/client_frame_view_linux.cc",

--- a/shell/browser/ui/views/linux_window_controls_overlay_utils.cc
+++ b/shell/browser/ui/views/linux_window_controls_overlay_utils.cc
@@ -1,0 +1,42 @@
+#include "shell/browser/ui/views/linux_window_controls_overlay_utils.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace electron::linux_window_controls_overlay {
+
+ButtonOrder::ButtonOrder() = default;
+
+ButtonOrder::ButtonOrder(std::vector<views::FrameButton> leading_buttons,
+                         std::vector<views::FrameButton> trailing_buttons)
+    : leading_buttons(std::move(leading_buttons)),
+      trailing_buttons(std::move(trailing_buttons)) {}
+
+ButtonOrder::~ButtonOrder() = default;
+
+ButtonOrder ResolveButtonOrder(
+    const std::vector<views::FrameButton>& leading_buttons,
+    const std::vector<views::FrameButton>& trailing_buttons) {
+  if (leading_buttons.empty() && trailing_buttons.empty()) {
+    return ButtonOrder{
+        {},
+        {views::FrameButton::kMinimize, views::FrameButton::kMaximize,
+         views::FrameButton::kClose},
+    };
+  }
+
+  return ButtonOrder{leading_buttons, trailing_buttons};
+}
+
+gfx::Rect GetOverlayBounds(const gfx::Rect& client_bounds,
+                           int leading_reserved_width,
+                           int trailing_reserved_width,
+                           int overlay_height) {
+  return gfx::Rect(
+      leading_reserved_width, 0,
+      std::max(0, client_bounds.width() - leading_reserved_width -
+                      trailing_reserved_width),
+      overlay_height);
+}
+
+}  // namespace electron::linux_window_controls_overlay

--- a/shell/browser/ui/views/linux_window_controls_overlay_utils.h
+++ b/shell/browser/ui/views/linux_window_controls_overlay_utils.h
@@ -1,0 +1,32 @@
+#ifndef ELECTRON_SHELL_BROWSER_UI_VIEWS_LINUX_WINDOW_CONTROLS_OVERLAY_UTILS_H_
+#define ELECTRON_SHELL_BROWSER_UI_VIEWS_LINUX_WINDOW_CONTROLS_OVERLAY_UTILS_H_
+
+#include <vector>
+
+#include "ui/gfx/geometry/rect.h"
+#include "ui/views/window/frame_buttons.h"
+
+namespace electron::linux_window_controls_overlay {
+
+struct ButtonOrder {
+  ButtonOrder();
+  ButtonOrder(std::vector<views::FrameButton> leading_buttons,
+              std::vector<views::FrameButton> trailing_buttons);
+  ~ButtonOrder();
+
+  std::vector<views::FrameButton> leading_buttons;
+  std::vector<views::FrameButton> trailing_buttons;
+};
+
+ButtonOrder ResolveButtonOrder(
+    const std::vector<views::FrameButton>& leading_buttons,
+    const std::vector<views::FrameButton>& trailing_buttons);
+
+gfx::Rect GetOverlayBounds(const gfx::Rect& client_bounds,
+                           int leading_reserved_width,
+                           int trailing_reserved_width,
+                           int overlay_height);
+
+}  // namespace electron::linux_window_controls_overlay
+
+#endif  // ELECTRON_SHELL_BROWSER_UI_VIEWS_LINUX_WINDOW_CONTROLS_OVERLAY_UTILS_H_

--- a/shell/browser/ui/views/linux_window_controls_overlay_utils_unittest.cc
+++ b/shell/browser/ui/views/linux_window_controls_overlay_utils_unittest.cc
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Microsoft GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/ui/views/linux_window_controls_overlay_utils.h"
+
+#include <vector>
+
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace electron::linux_window_controls_overlay {
+
+TEST(LinuxWindowControlsOverlayUtilsTest, PreservesResolvedOrder) {
+  const ButtonOrder order = ResolveButtonOrder(
+      {views::FrameButton::kClose},
+      {views::FrameButton::kMinimize, views::FrameButton::kMaximize});
+
+  EXPECT_EQ(order.leading_buttons,
+            (std::vector<views::FrameButton>{views::FrameButton::kClose}));
+  EXPECT_EQ(order.trailing_buttons,
+            (std::vector<views::FrameButton>{
+                views::FrameButton::kMinimize, views::FrameButton::kMaximize}));
+}
+
+TEST(LinuxWindowControlsOverlayUtilsTest, FallsBackWhenOrderingUnavailable) {
+  const ButtonOrder order = ResolveButtonOrder(
+      std::vector<views::FrameButton>{}, std::vector<views::FrameButton>{});
+
+  EXPECT_TRUE(order.leading_buttons.empty());
+  EXPECT_EQ(order.trailing_buttons,
+            (std::vector<views::FrameButton>{
+                views::FrameButton::kMinimize, views::FrameButton::kMaximize,
+                views::FrameButton::kClose}));
+}
+
+TEST(LinuxWindowControlsOverlayUtilsTest, ResolvesUpdatedOrderOnRelayout) {
+  const ButtonOrder first_order = ResolveButtonOrder(
+      std::vector<views::FrameButton>{}, std::vector<views::FrameButton>{});
+  const ButtonOrder updated_order = ResolveButtonOrder(
+      {views::FrameButton::kClose},
+      {views::FrameButton::kMaximize, views::FrameButton::kMinimize});
+
+  EXPECT_EQ(first_order.trailing_buttons,
+            (std::vector<views::FrameButton>{
+                views::FrameButton::kMinimize, views::FrameButton::kMaximize,
+                views::FrameButton::kClose}));
+  EXPECT_EQ(updated_order.leading_buttons,
+            (std::vector<views::FrameButton>{views::FrameButton::kClose}));
+  EXPECT_EQ(updated_order.trailing_buttons,
+            (std::vector<views::FrameButton>{
+                views::FrameButton::kMaximize, views::FrameButton::kMinimize}));
+}
+
+TEST(LinuxWindowControlsOverlayUtilsTest, PreservesOverlayGeometry) {
+  const gfx::Rect overlay_bounds =
+      GetOverlayBounds(gfx::Rect(12, 24, 400, 50),
+                       /*leading_reserved_width=*/0,
+                       /*trailing_reserved_width=*/90,
+                       /*overlay_height=*/31);
+
+  EXPECT_EQ(overlay_bounds, gfx::Rect(0, 0, 310, 31));
+}
+
+TEST(LinuxWindowControlsOverlayUtilsTest, ReservesBothButtonBanks) {
+  const gfx::Rect overlay_bounds =
+      GetOverlayBounds(gfx::Rect(12, 24, 400, 50),
+                       /*leading_reserved_width=*/50,
+                       /*trailing_reserved_width=*/90,
+                       /*overlay_height=*/31);
+
+  EXPECT_EQ(overlay_bounds, gfx::Rect(50, 0, 260, 31));
+}
+
+}  // namespace electron::linux_window_controls_overlay

--- a/shell/browser/ui/views/opaque_frame_view.cc
+++ b/shell/browser/ui/views/opaque_frame_view.cc
@@ -5,6 +5,7 @@
 #include "shell/browser/ui/views/opaque_frame_view.h"
 
 #include "base/containers/adapters.h"
+#include "shell/browser/ui/views/linux_window_controls_overlay_utils.h"
 #include "chrome/browser/ui/views/frame/browser_frame_view_paint_utils_linux.h"  // nogncheck
 #include "chrome/browser/ui/views/frame/opaque_browser_frame_view_layout.h"  // nogncheck
 #include "chrome/grit/generated_resources.h"
@@ -19,11 +20,13 @@
 #include "ui/gfx/font_list.h"
 #include "ui/gfx/geometry/insets_f.h"
 #include "ui/gfx/geometry/skia_conversions.h"
+#include "ui/linux/linux_ui.h"
 #include "ui/views/accessibility/view_accessibility.h"
 #include "ui/views/background.h"
 #include "ui/views/widget/widget.h"
 #include "ui/views/window/frame_background.h"
 #include "ui/views/window/frame_caption_button.h"
+#include "ui/views/window/window_button_order_provider.h"
 #include "ui/views/window/vector_icons/vector_icons.h"
 
 namespace electron {
@@ -59,7 +62,13 @@ const int OpaqueFrameView::kContentEdgeShadowThickness = 2;
 
 OpaqueFrameView::OpaqueFrameView()
     : frame_background_(std::make_unique<views::FrameBackground>()) {}
-OpaqueFrameView::~OpaqueFrameView() = default;
+OpaqueFrameView::~OpaqueFrameView() {
+  if (window_button_order_observing_) {
+    if (auto* linux_ui = ui::LinuxUi::instance()) {
+      linux_ui->RemoveWindowButtonOrderObserver(this);
+    }
+  }
+}
 
 void OpaqueFrameView::Init(NativeWindowViews* window, views::Widget* frame) {
   FramelessView::Init(window, frame);
@@ -75,7 +84,9 @@ void OpaqueFrameView::Init(NativeWindowViews* window, views::Widget* frame) {
   if (!window->IsWindowControlsOverlayEnabled())
     return;
 
-  caption_button_placeholder_container_ =
+  leading_caption_button_placeholder_container_ =
+      AddChildView(std::make_unique<CaptionButtonPlaceholderContainer>());
+  trailing_caption_button_placeholder_container_ =
       AddChildView(std::make_unique<CaptionButtonPlaceholderContainer>());
 
   minimize_button_ = CreateButton(
@@ -99,6 +110,12 @@ void OpaqueFrameView::Init(NativeWindowViews* window, views::Widget* frame) {
       base::BindRepeating(&views::Widget::CloseWithReason,
                           base::Unretained(frame),
                           views::Widget::ClosedReason::kCloseButtonClicked));
+
+  if (auto* linux_ui = ui::LinuxUi::instance()) {
+    linux_ui->AddWindowButtonOrderObserver(this);
+    window_button_order_observing_ = true;
+  }
+  OnWindowButtonOrderingChange();
 }
 
 int OpaqueFrameView::ResizingBorderHitTest(const gfx::Point& point) {
@@ -145,8 +162,10 @@ int OpaqueFrameView::NonClientHitTest(const gfx::Point& point) {
     if (HitTestCaptionButton(minimize_button_, point))
       return HTMINBUTTON;
 
-    if (caption_button_placeholder_container_->GetMirroredBounds().Contains(
-            point)) {
+    if (leading_caption_button_placeholder_container_->GetMirroredBounds()
+            .Contains(point) ||
+        trailing_caption_button_placeholder_container_->GetMirroredBounds()
+            .Contains(point)) {
       return HTCAPTION;
     }
   }
@@ -183,19 +202,29 @@ void OpaqueFrameView::Layout(PassKey) {
   available_space_leading_x_ = client_bounds.x() + top_area_padding.leading;
   available_space_trailing_x_ =
       client_bounds.right() - top_area_padding.trailing;
-  minimum_size_for_buttons_ =
-      (available_space_leading_x_ - client_bounds.x()) +
-      (client_bounds.right() - available_space_trailing_x_);
+  leading_reserved_width_ = available_space_leading_x_ - client_bounds.x();
+  trailing_reserved_width_ =
+      client_bounds.right() - available_space_trailing_x_;
   placed_leading_button_ = false;
   placed_trailing_button_ = false;
 
   LayoutWindowControls();
 
   int height = NonClientTopHeight(false);
-  int container_x =
-      placed_trailing_button_ ? available_space_trailing_x_ : client_bounds.x();
-  caption_button_placeholder_container_->SetBounds(
-      container_x, client_bounds.y(), minimum_size_for_buttons_, height);
+  leading_reserved_width_ = available_space_leading_x_ - client_bounds.x();
+  trailing_reserved_width_ =
+      client_bounds.right() - available_space_trailing_x_;
+
+  leading_caption_button_placeholder_container_->SetVisible(
+      leading_reserved_width_ > 0);
+  leading_caption_button_placeholder_container_->SetBounds(
+      client_bounds.x(), client_bounds.y(), leading_reserved_width_, height);
+
+  trailing_caption_button_placeholder_container_->SetVisible(
+      trailing_reserved_width_ > 0);
+  trailing_caption_button_placeholder_container_->SetBounds(
+      available_space_trailing_x_, client_bounds.y(), trailing_reserved_width_,
+      height);
   LayoutWindowControlsOverlay();
 }
 
@@ -246,6 +275,16 @@ void OpaqueFrameView::PaintAsActiveChanged() {
   SchedulePaint();
 }
 
+void OpaqueFrameView::OnWindowButtonOrderingChange() {
+  auto* provider = views::WindowButtonOrderProvider::GetInstance();
+  const auto order = linux_window_controls_overlay::ResolveButtonOrder(
+      provider->leading_buttons(), provider->trailing_buttons());
+  leading_buttons_ = order.leading_buttons;
+  trailing_buttons_ = order.trailing_buttons;
+
+  InvalidateLayout();
+}
+
 void OpaqueFrameView::UpdateFrameCaptionButtons() {
   const bool active = ShouldPaintAsActive();
   const SkColor symbol_color = window()->overlay_symbol_color();
@@ -266,11 +305,14 @@ void OpaqueFrameView::UpdateFrameCaptionButtons() {
 }
 
 void OpaqueFrameView::UpdateCaptionButtonPlaceholderContainerBackground() {
-  if (caption_button_placeholder_container_) {
-    const SkColor obc = window()->overlay_button_color();
-    const SkColor bg_color = obc == SkColor() ? GetFrameColor() : obc;
-    caption_button_placeholder_container_->SetBackground(
-        views::CreateSolidBackground(bg_color));
+  const SkColor obc = window()->overlay_button_color();
+  const SkColor bg_color = obc == SkColor() ? GetFrameColor() : obc;
+
+  for (auto container : {leading_caption_button_placeholder_container_,
+                         trailing_caption_button_placeholder_container_}) {
+    if (!container)
+      continue;
+    container->SetBackground(views::CreateSolidBackground(bg_color));
   }
 }
 
@@ -301,17 +343,16 @@ void OpaqueFrameView::LayoutWindowControls() {
 void OpaqueFrameView::LayoutWindowControlsOverlay() {
   int overlay_height = window()->titlebar_overlay_height();
   if (overlay_height == 0) {
-    // Accounting for the 1 pixel margin at the top of the button container
+    // Account for the 1-pixel restored-frame margin above the button banks.
     overlay_height =
-        window()->IsMaximized()
-            ? caption_button_placeholder_container_->size().height()
-            : caption_button_placeholder_container_->size().height() + 1;
+        window()->IsMaximized() ? NonClientTopHeight(false)
+                                : NonClientTopHeight(false) + 1;
   }
-  int overlay_width = caption_button_placeholder_container_->size().width();
   gfx::Rect client_bounds = GetBoundsForClientView();
-  int bounding_rect_width = client_bounds.width() - overlay_width;
-  auto bounding_rect =
-      GetMirroredRect(gfx::Rect(0, 0, bounding_rect_width, overlay_height));
+  auto bounding_rect = GetMirroredRect(
+      linux_window_controls_overlay::GetOverlayBounds(
+          client_bounds, leading_reserved_width_, trailing_reserved_width_,
+          overlay_height));
 
   window()->SetWindowControlsOverlayRect(bounding_rect);
   window()->NotifyLayoutWindowControlsOverlay();
@@ -523,7 +564,6 @@ void OpaqueFrameView::SetBoundsForButton(views::FrameButton button_id,
           GetWindowCaptionSpacing(button_id, true, !placed_leading_button_);
 
       available_space_leading_x_ += button_start_spacing;
-      minimum_size_for_buttons_ += button_start_spacing;
 
       bool top_spacing_clickable = is_frame_condensed;
       bool start_spacing_clickable =
@@ -541,7 +581,6 @@ void OpaqueFrameView::SetBoundsForButton(views::FrameButton button_id,
       int button_end_spacing =
           GetWindowCaptionSpacing(button_id, false, !placed_leading_button_);
       available_space_leading_x_ += button_size.width() + button_end_spacing;
-      minimum_size_for_buttons_ += button_size.width() + button_end_spacing;
       placed_leading_button_ = true;
       break;
     }
@@ -551,7 +590,6 @@ void OpaqueFrameView::SetBoundsForButton(views::FrameButton button_id,
           GetWindowCaptionSpacing(button_id, true, !placed_trailing_button_);
 
       available_space_trailing_x_ -= button_start_spacing;
-      minimum_size_for_buttons_ += button_start_spacing;
 
       bool top_spacing_clickable = is_frame_condensed;
       bool start_spacing_clickable =
@@ -567,7 +605,6 @@ void OpaqueFrameView::SetBoundsForButton(views::FrameButton button_id,
       int button_end_spacing =
           GetWindowCaptionSpacing(button_id, false, !placed_trailing_button_);
       available_space_trailing_x_ -= button_size.width() + button_end_spacing;
-      minimum_size_for_buttons_ += button_size.width() + button_end_spacing;
       placed_trailing_button_ = true;
       break;
     }

--- a/shell/browser/ui/views/opaque_frame_view.h
+++ b/shell/browser/ui/views/opaque_frame_view.h
@@ -28,7 +28,8 @@ namespace electron {
 
 class NativeWindowViews;
 
-class OpaqueFrameView : public FramelessView {
+class OpaqueFrameView : public FramelessView,
+                        private ui::WindowButtonOrderObserver {
   METADATA_HEADER(OpaqueFrameView, FramelessView)
 
  public:
@@ -68,6 +69,7 @@ class OpaqueFrameView : public FramelessView {
   };
 
   void PaintAsActiveChanged();
+  void OnWindowButtonOrderingChange() override;
 
   void UpdateCaptionButtonPlaceholderContainerBackground();
   void UpdateFrameCaptionButtons();
@@ -188,9 +190,9 @@ class OpaqueFrameView : public FramelessView {
   bool placed_leading_button_ = false;
   bool placed_trailing_button_ = false;
 
-  // The size of the window buttons. This does not count labels or other
-  // elements that should be counted in a minimal frame.
-  int minimum_size_for_buttons_ = 0;
+  // Width reserved for the button banks on each side of the titlebar.
+  int leading_reserved_width_ = 0;
+  int trailing_reserved_width_ = 0;
 
   std::vector<views::FrameButton> leading_buttons_;
   std::vector<views::FrameButton> trailing_buttons_{
@@ -198,10 +200,13 @@ class OpaqueFrameView : public FramelessView {
       views::FrameButton::kClose};
 
   base::CallbackListSubscription paint_as_active_changed_subscription_;
+  bool window_button_order_observing_ = false;
 
-  // PlaceholderContainer beneath the controls button for WCO.
+  // Placeholder containers beneath the native control banks for WCO.
   raw_ptr<CaptionButtonPlaceholderContainer>
-      caption_button_placeholder_container_;
+      leading_caption_button_placeholder_container_;
+  raw_ptr<CaptionButtonPlaceholderContainer>
+      trailing_caption_button_placeholder_container_;
 };
 
 }  // namespace electron

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3386,6 +3386,8 @@ describe('BrowserWindow module', () => {
       expect(overlayRect.y).to.equal(0);
       if (process.platform === 'darwin') {
         expect(overlayRect.x).to.be.greaterThan(0);
+      } else if (process.platform === 'linux') {
+        expect(overlayRect.x).to.be.at.least(0);
       } else {
         expect(overlayRect.x).to.equal(0);
       }
@@ -3503,6 +3505,8 @@ describe('BrowserWindow module', () => {
       expect(overlayRectPreMax.y).to.equal(0);
       if (process.platform === 'darwin') {
         expect(overlayRectPreMax.x).to.be.greaterThan(0);
+      } else if (process.platform === 'linux') {
+        expect(overlayRectPreMax.x).to.be.at.least(0);
       } else {
         expect(overlayRectPreMax.x).to.equal(0);
       }


### PR DESCRIPTION
#### Description of Change

Change was assisted by OpenAI codex. I understand what this change brings:
- instead of having one view container for window buttons, we have up to two (one on left and one on right, depending on buttons layout)
- we already have a way to know correct order - just don't use it

Before this change:
<img width="666" height="212" alt="image" src="https://github.com/user-attachments/assets/144d4667-d765-4b3e-b688-94c1a6a6b72c" />

After this change:
<img width="887" height="338" alt="image" src="https://github.com/user-attachments/assets/878eabde-cabf-43bf-9ec4-ea7ab5955c2e" />



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes - yes, but I did not run broad spec (ran only on wayland)
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
WCO respected the title bar order defined in system settings.
