### PR TITLE
docs: add ELECTRON_INSTALL env vars and remove ELECTRON_SKIP_BINARY_D…

### DIFF
--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -203,13 +203,22 @@ the one downloaded by `npm install`. Usage:
 export ELECTRON_OVERRIDE_DIST_PATH=/Users/username/projects/electron/out/Testing
 ```
 
-### `ELECTRON_SKIP_BINARY_DOWNLOAD`
+### `ELECTRON_INSTALL_PLATFORM`
 
-If you want to install your project's dependencies but don't need to use Electron functionality,
-you can set the `ELECTRON_SKIP_BINARY_DOWNLOAD` environment variable to prevent the binary from being
-downloaded. For instance, this feature can be useful in continuous integration environments when
-running unit tests that mock out the `electron` module.
+Manually overrides platform used by `electron` package during an install.
+This can be useful if you are on one platform (e.g macOS) but want to
+download binaries for another platform (e.g Windows or Linux). Usage:
 
 ```sh
-ELECTRON_SKIP_BINARY_DOWNLOAD=1 npm install
+ELECTRON_INSTALL_PLATFORM=darwin npm install
+```
+
+### `ELECTRON_INSTALL_ARCH`
+
+Manually overrides architecture used by `electron` package during an install.
+This can be useful if you are on one arch (e.g `arm64`) but want to download
+binaries meant for another arch. Note that this will not work under Rosetta. Usage:
+
+```sh
+ELECTRON_INSTALL_ARCH=arm64 npm install
 ```


### PR DESCRIPTION
#### Description of Change
adds ELECTRON_INSTALL environment variables to environment-variables.md
also removes ELECTRON_SKIP_BINARY_DOWNLOAD as it was deprecated as of electron v42
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

NOTE: PRS submitted without this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none