### PR TITLE
ci: ignore canceled jobs in audit

### DIFF
--- a/.github/workflows/audit-branch-ci.yml
+++ b/.github/workflows/audit-branch-ci.yml
@@ -88,6 +88,7 @@ jobs:
                       !message.startsWith("Dependabot encountered an error performing the update") &&
                       !message.startsWith("The action 'Run Electron Tests' has timed out") &&
                       !message.startsWith("The operation was canceled") &&
+                      !message.startsWith("Canceling since") &&
                       !/Unable to make request/.test(message) &&
                       !/The requested URL returned error/.test(message),
                   )

--- a/.github/workflows/audit-branch-ci.yml
+++ b/.github/workflows/audit-branch-ci.yml
@@ -87,6 +87,7 @@ jobs:
                       !message.startsWith("The hosted runner lost communication with the server") &&
                       !message.startsWith("Dependabot encountered an error performing the update") &&
                       !message.startsWith("The action 'Run Electron Tests' has timed out") &&
+                      !message.startsWith("The operation was canceled") &&
                       !/Unable to make request/.test(message) &&
                       !/The requested URL returned error/.test(message),
                   )


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

NOTE: PRS submitted without this template will be automatically closed.
-->

Jobs can be canceled if multiple PRs are merged in quick succession since we have concurrency limits on these CI jobs on the release branches. Ignore these so they don't trip the audit and ping us.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
