### PR TITLE
chore: cherry-pick 2 changes from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -151,3 +151,4 @@ fix_fire_menu_popup_start_for_dynamically_created_aria_menus.patch
 extensions_return_early_from_urlpattern_isvalidscheme.patch
 feat_allow_enabling_extensions_on_custom_protocols.patch
 cherry-pick-1fd9cf824950.patch
+cherry-pick-fc10b0d6304d.patch

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -152,3 +152,4 @@ extensions_return_early_from_urlpattern_isvalidscheme.patch
 feat_allow_enabling_extensions_on_custom_protocols.patch
 cherry-pick-1fd9cf824950.patch
 cherry-pick-fc10b0d6304d.patch
+cherry-pick-41c622eea273.patch

--- a/patches/chromium/cherry-pick-41c622eea273.patch
+++ b/patches/chromium/cherry-pick-41c622eea273.patch
@@ -1,0 +1,106 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Wei Wang <wei4.wang@intel.com>
+Date: Fri, 20 Mar 2026 19:57:55 -0700
+Subject: [WebNN] Prevent Pool2d indirection buffer overflow in TFLite
+
+Add a check to ensure the size of the internal indirection buffer used
+by TFLite's Pool2d implementation does not exceed the maximum value
+of a size_t integer.
+
+Bug: 494158331
+Change-Id: I984556f0f608badf8f73fcbb096da5f41170a958
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7687618
+Reviewed-by: Hu, Ningxin <ningxin.hu@intel.com>
+Reviewed-by: Reilly Grant <reillyg@chromium.org>
+Commit-Queue: Wang, Wei4 <wei4.wang@intel.com>
+Cr-Commit-Position: refs/heads/main@{#1602966}
+
+diff --git a/services/webnn/tflite/graph_builder_tflite.cc b/services/webnn/tflite/graph_builder_tflite.cc
+index 5d7ec3e1aabf3014266c7a0b15198c49b2e93dc7..2754e597c7f6dd580369d348197d1ffa98722d6b 100644
+--- a/services/webnn/tflite/graph_builder_tflite.cc
++++ b/services/webnn/tflite/graph_builder_tflite.cc
+@@ -6765,6 +6765,68 @@ auto GraphBuilderTflite::SerializePool2d(const mojom::Pool2d& pool2d)
+     return base::unexpected("Pool2d in tflite doesn't support dilations.");
+   }
+ 
++  // Check the indirection buffer size to ensure it does not exceed the maximum
++  // value of a size_t integer.
++  const mojom::Operand& output_operand = GetOperand(pool2d.output_operand_id);
++  const auto& output_shape = output_operand.descriptor.shape();
++  const webnn::Size2d<uint32_t> output_size2d = {.height = output_shape[1],
++                                                 .width = output_shape[2]};
++  const webnn::Size2d<uint32_t> filter_size2d = {
++      .height = pool2d.window_dimensions->height,
++      .width = pool2d.window_dimensions->width};
++  base::CheckedNumeric<int32_t> checked_output_height = 0;
++
++  if (pool2d.kind == mojom::Pool2d::Kind::kMaxPool2d) {
++    // https://source.chromium.org/chromium/chromium/src/+/main:third_party/xnnpack/src/src/operators/max-pooling-nhwc.c;l=488;drc=b269899e63e0110d1ccf964a741be2833a9ecd9b
++    checked_output_height = output_size2d.height;
++  } else {
++    // https://source.chromium.org/chromium/chromium/src/+/main:third_party/xnnpack/src/src/operators/average-pooling-nhwc.c;l=442;drc=b269899e63e0110d1ccf964a741be2833a9ecd9b
++    auto checked_top_height =
++        base::CheckedNumeric<int32_t>(pool2d.padding->beginning->height);
++    auto checked_stride_height =
++        base::CheckedNumeric<int32_t>(pool2d.strides->height);
++    checked_top_height += checked_stride_height;
++    checked_top_height -= 1;
++    checked_top_height /= checked_stride_height;
++
++    auto checked_bottom_height =
++        base::CheckedNumeric<int32_t>(pool2d.padding->ending->height);
++    checked_bottom_height += checked_stride_height;
++    checked_bottom_height -= 1;
++    checked_bottom_height /= checked_stride_height;
++
++    checked_output_height = checked_top_height;
++    checked_output_height += checked_bottom_height;
++    checked_output_height += 1;
++  }
++
++  auto checked_filter_height =
++      base::CheckedNumeric<int32_t>(filter_size2d.height);
++  auto checked_filter_width =
++      base::CheckedNumeric<int32_t>(filter_size2d.width);
++  auto checked_pooling_size = checked_filter_height;
++  checked_pooling_size *= checked_filter_width;
++
++  auto checked_output_width =
++      base::CheckedNumeric<int32_t>(output_size2d.width);
++  checked_output_width -= 1;
++  checked_output_width *= base::CheckedNumeric<int32_t>(
++      std::min(pool2d.strides->width, filter_size2d.width));
++  checked_output_width *= checked_filter_height;
++  auto checked_step_height = checked_pooling_size + checked_output_width;
++
++  auto checked_indirection_buffer_size = checked_pooling_size;
++  checked_indirection_buffer_size -= 1;
++  checked_output_height *= checked_step_height;
++  checked_indirection_buffer_size += checked_output_height;
++  checked_indirection_buffer_size *=
++      base::CheckedNumeric<int32_t>(sizeof(void*));
++  if (!checked_indirection_buffer_size.IsValid()) {
++    return base::unexpected(
++        "Pool2d doesn't support configurations requiring an internal "
++        "computation buffer that exceeds the maximum size.");
++  }
++
+   ::tflite::BuiltinOperator operator_code;
+   std::optional<TensorInfo> quantized_output;
+   const mojom::Operand& input_operand = GetOperand(pool2d.input_operand_id);
+@@ -6792,15 +6854,8 @@ auto GraphBuilderTflite::SerializePool2d(const mojom::Pool2d& pool2d)
+ 
+   const auto& input_shape = input_operand.descriptor.shape();
+   CHECK_EQ(input_shape.size(), 4u);
+-  const mojom::Operand& output_operand = GetOperand(pool2d.output_operand_id);
+-  const auto& output_shape = output_operand.descriptor.shape();
+   const webnn::Size2d<uint32_t> input_size2d = {.height = input_shape[1],
+                                                 .width = input_shape[2]};
+-  const webnn::Size2d<uint32_t> output_size2d = {.height = output_shape[1],
+-                                                 .width = output_shape[2]};
+-  webnn::Size2d<uint32_t> filter_size2d = {
+-      .height = pool2d.window_dimensions->height,
+-      .width = pool2d.window_dimensions->width};
+   ASSIGN_OR_RETURN(TfLitePadding padding_mode,
+                    GetPool2dTfLitePaddingMode(
+                        *pool2d.padding, input_size2d, filter_size2d,

--- a/patches/chromium/cherry-pick-fc10b0d6304d.patch
+++ b/patches/chromium/cherry-pick-fc10b0d6304d.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Wei Wang <wei4.wang@intel.com>
+Date: Wed, 18 Mar 2026 20:00:51 -0700
+Subject: [WebNN] Reject fusing per-channel quantized gemm if the quantized
+ dimension of filter is not 0
+
+The FULLY_CONNECTED's underlying kernels expect the per-channel
+quantization axis to be the output channel(axis 0). So reject
+fusing per-channel quantized gemm and fall back to the unfused
+operators path if the quantized dimension of filter is not 0.
+
+Bug: 493319454
+Change-Id: Ib7e1236a535dc6a34d3ff9b9f0124a101bd89dbf
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7673406
+Reviewed-by: Phillis Tang <phillis@chromium.org>
+Commit-Queue: Wang, Wei4 <wei4.wang@intel.com>
+Reviewed-by: Hu, Ningxin <ningxin.hu@intel.com>
+Cr-Commit-Position: refs/heads/main@{#1601718}
+
+diff --git a/services/webnn/tflite/graph_builder_tflite.cc b/services/webnn/tflite/graph_builder_tflite.cc
+index 32cec6672e11af039e6c8b59f0c536b9ccc67849..5d7ec3e1aabf3014266c7a0b15198c49b2e93dc7 100644
+--- a/services/webnn/tflite/graph_builder_tflite.cc
++++ b/services/webnn/tflite/graph_builder_tflite.cc
+@@ -2084,6 +2084,19 @@ GraphBuilderTflite::CanFuseQuantizeAndGetOutput(const mojom::Gemm& gemm) {
+     return std::nullopt;
+   }
+ 
++  // The FULLY_CONNECTED's underlying kernels expect the per-channel
++  // quantization axis to be the output channel dimension (axis 0). This means
++  // the first dimension of the scale can not be equal to 1.
++  // https://source.chromium.org/chromium/chromium/src/+/main:third_party/litert/src/tflite/kernels/internal/reference/integer_ops/fully_connected.h;l=68;drc=9213607704a73d1e877921d0454abb11f761bdcc
++  if (per_channel_quantization) {
++    const auto& scale_shape =
++        GetOperand(b_dequantize.scale_operand_id).descriptor.shape();
++
++    if (scale_shape[0] == 1) {
++      return std::nullopt;
++    }
++  }
++
+   // The a_scale * b_scale should be about the same as c_scale for per-tensor
+   // quantization.
+   // https://source.chromium.org/chromium/chromium/src/+/main:third_party/tflite/src/tensorflow/lite/kernels/kernel_util.cc;l=303;drc=492dc9719f6e1845f4f5c0553cd5c7651115f671


### PR DESCRIPTION
#### Description of Change

Backports two upstream changes to the WebNN TFLite graph builder that tighten input validation on its internal code paths. Both are straightforward adaptations of the upstream commits against 146.0.7680.188; there are no Electron-specific changes to the logic.

These changes have already landed in main and 42-x-y via Chrome rolls.

<details>
<summary>cherry-pick fc10b0d6304d from chromium</summary>

[WebNN] Reject fusing per-channel quantized gemm if the quantized
dimension of filter is not 0

The FULLY_CONNECTED's underlying kernels expect the per-channel
quantization axis to be the output channel(axis 0). So reject
fusing per-channel quantized gemm and fall back to the unfused
operators path if the quantized dimension of filter is not 0.

Bug: 493319454
Change-Id: Ib7e1236a535dc6a34d3ff9b9f0124a101bd89dbf
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7673406
Reviewed-by: Phillis Tang <phillis@chromium.org>
Commit-Queue: Wang, Wei4 <wei4.wang@intel.com>
Reviewed-by: Hu, Ningxin <ningxin.hu@intel.com>
Cr-Commit-Position: refs/heads/main@{#1601718}
</details>

<details>
<summary>cherry-pick 41c622eea273 from chromium</summary>

[WebNN] Prevent Pool2d indirection buffer overflow in TFLite

Add a check to ensure the size of the internal indirection buffer used
by TFLite's Pool2d implementation does not exceed the maximum value
of a size_t integer.

Bug: 494158331
Change-Id: I984556f0f608badf8f73fcbb096da5f41170a958
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7687618
Reviewed-by: Hu, Ningxin <ningxin.hu@intel.com>
Reviewed-by: Reilly Grant <reillyg@chromium.org>
Commit-Queue: Wang, Wei4 <wei4.wang@intel.com>
Cr-Commit-Position: refs/heads/main@{#1602966}
</details>

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] \`yarn test\` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Backported upstream fixes for two edge cases in the WebNN TFLite graph builder.