### PR TITLE
ci: capture fatal errors in clang problem matcher

### DIFF
--- a/.github/problem-matchers/clang.json
+++ b/.github/problem-matchers/clang.json
@@ -5,7 +5,7 @@
       "fromPath": "src/out/Default/args.gn",
       "pattern": [
         {
-          "regexp": "^(.+)[(:](\\d+)[:,](\\d+)\\)?:\\s+(warning|error):\\s+(.*)$",
+          "regexp": "^(.+)[(:](\\d+)[:,](\\d+)\\)?:\\s+(warning|fatal error|error):\\s+(.*)$",
           "file": 1,
           "line": 2,
           "column": 3,


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

NOTE: PRS submitted without this template will be automatically closed.
-->

Certain errors (e.g. not finding a header) are flagged as "fatal error" rather than just "error" so they weren't being properly captured by this regex.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
